### PR TITLE
[VideoPlayer] MSGQ_ABORT is not an error, so don't log it as such.

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -254,7 +254,9 @@ void CVideoPlayerAudio::Process()
 
     if (MSGQ_IS_ERROR(ret))
     {
-      CLog::Log(LOGERROR, "Got MSGQ_ABORT or MSGO_IS_ERROR return true");
+      if (!m_messageQueue.ReceivedAbortRequest())
+        CLog::Log(LOGERROR, "MSGQ_IS_ERROR returned true ({})", ret);
+
       break;
     }
     else if (ret == MSGQ_TIMEOUT)

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudioID3.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudioID3.cpp
@@ -132,7 +132,9 @@ void CVideoPlayerAudioID3::Process()
 
     if (MSGQ_IS_ERROR(ret))
     {
-      CLog::Log(LOGERROR, "Got MSGQ_ABORT or MSGQ_IS_ERROR return true ({})", ret);
+      if (!m_messageQueue.ReceivedAbortRequest())
+        CLog::Log(LOGERROR, "MSGQ_IS_ERROR returned true ({})", ret);
+
       break;
     }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
@@ -626,7 +626,9 @@ void CDVDRadioRDSData::Process()
 
     if (MSGQ_IS_ERROR(ret))
     {
-      CLog::Log(LOGERROR, "Got MSGQ_ABORT or MSGO_IS_ERROR return true ({})", ret);
+      if (!m_messageQueue.ReceivedAbortRequest())
+        CLog::Log(LOGERROR, "MSGQ_IS_ERROR returned true ({})", ret);
+
       break;
     }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerTeletext.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerTeletext.cpp
@@ -240,7 +240,9 @@ void CDVDTeletextData::Process()
 
     if (MSGQ_IS_ERROR(ret))
     {
-      CLog::Log(LOGERROR, "Got MSGQ_ABORT or MSGO_IS_ERROR return true ({})", ret);
+      if (!m_messageQueue.ReceivedAbortRequest())
+        CLog::Log(LOGERROR, "MSGQ_IS_ERROR returned true ({})", ret);
+
       break;
     }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -340,7 +340,9 @@ void CVideoPlayerVideo::Process()
 
     if (MSGQ_IS_ERROR(ret))
     {
-      CLog::Log(LOGERROR, "Got MSGQ_ABORT or MSGO_IS_ERROR return true");
+      if (!m_messageQueue.ReceivedAbortRequest())
+        CLog::Log(LOGERROR, "MSGQ_IS_ERROR returned true ({})", ret);
+
       break;
     }
     else if (ret == MSGQ_TIMEOUT)


### PR DESCRIPTION
I got an ERROR `Got MSGQ_ABORT or MSGO_IS_ERROR return true (-1)` logged whenever playback of a TV channel stopped. This has been the case at least as long as I'm using Kodi.

In fact it was MSGQ_ABORT triggering this. Looking at the doxy of MSGQ_ABORT it seems to be clear that this is not an error:

https://github.com/xbmc/xbmc/blob/master/xbmc/cores/VideoPlayer/DVDMessageQueue.h#L40

```c++
enum MsgQueueReturnCode
{
  MSGQ_OK = 1,
  MSGQ_TIMEOUT = 0,
  MSGQ_ABORT = -1, // negative for legacy, not an error actually
  MSGQ_NOT_INITIALIZED = -2,
  MSGQ_INVALID_MSG = -3,
  MSGQ_OUT_OF_MEMORY = -4
};

#define MSGQ_IS_ERROR(c)    (c < 0)
```

This PR changes behavior not to log anything in case of MSGQ_ABORT.

Runtime-tested on macOS and Android, no more ERRORs logged when stopping playback of a PVR channel.

@garbear @lrusak do the changes look okay for you?