### PR TITLE
[Subtitles] Always use frame margins with native ass

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -292,7 +292,8 @@ ASS_Image* CDVDSubtitlesLibass::RenderImage(double pts,
   {
     ass_set_storage_size(m_renderer, static_cast<int>(opts.sourceWidth),
                          static_cast<int>(opts.sourceHeight));
-    useFrameMargins = opts.marginsMode != MarginsMode::DISABLED;
+    useFrameMargins =
+        opts.marginsMode == MarginsMode::DISABLED || opts.marginsMode == MarginsMode::INSIDE_VIDEO;
   }
   else
   {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
A recent regression there are so much use cases to consider

This change make by default framemargins enabled when native ass/ssa subtitle are used without override settings enabled,
instead when override settings are enabled the framemargins will be enabled only with subtitle position "bottom/top of video"

to test with cropped video

~i will provide a test build to the user to have a confirmation~
confirmed

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #21860

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
User have provided sample video/subtitle on #21860

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Right subtitle position

## Screenshots (if appropriate):
Before
![immagine](https://user-images.githubusercontent.com/3257156/190441659-b9e9ab33-0b56-4448-beac-dd7f3ed10640.png)

After
![immagine](https://user-images.githubusercontent.com/3257156/190440458-a4ecedf1-765f-4e34-9fa3-8e40f697b1dc.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
