### PR TITLE
[contextmenu] fix queue/playnext items in music (root) addons

### DIFF
--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -857,6 +857,7 @@ CFileItemPtr CAddonsDirectory::FileItemFromAddon(const AddonPtr &addon,
   //! @todo fix hacks that depends on these
   item->SetProperty("Addon.ID", addon->ID());
   item->SetProperty("Addon.Name", addon->Name());
+  item->SetCanQueue(false);
   const auto it = addon->ExtraInfo().find("language");
   if (it != addon->ExtraInfo().end())
     item->SetProperty("Addon.Language", it->second);

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -572,6 +572,7 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
 
     if (!item->IsParentFolder())
     {
+      //! @todo get rid of IsAddonsPath and IsScript check. CanQueue should be enough!
       if (item->CanQueue() && !item->IsAddonsPath() && !item->IsScript())
       {
         buttons.Add(CONTEXT_BUTTON_QUEUE_ITEM, 13347); //queue


### PR DESCRIPTION
## Description
In the music base view we are presenting context menus which target audio files also for addon listings. This doesn't make sense and doesn't work (you can't queue, play, etc a plugin).
There is no pretty way to detect if the item is a root plugin path (e.g. plugin://plugin.audio.radio_de), the only way is to check if the addon properties are set on the item (Addon.Id, Addon.Name).

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/16708

## How has this been tested?
Manually, Linux.

## What is the effect on users?
Those incorrect music context menu items should not be shown anymore in music plugins

## Screenshots (if appropriate):

**Before:**
![image](https://user-images.githubusercontent.com/7375276/190700620-f0423a28-2d92-4f5e-a7d5-7871f4d3dba0.png)
![image](https://user-images.githubusercontent.com/7375276/190700665-89c3a59c-4125-4bcd-9d39-34eaf9a4cb7e.png)


**Now:**
![image](https://user-images.githubusercontent.com/7375276/190700275-19b1f9fa-2437-47ae-b894-bcf736e83d76.png)
![image](https://user-images.githubusercontent.com/7375276/190700322-9044116b-0542-4904-9fe9-e1f9649dd44e.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
