### PR TITLE
cec: add alternative (terminology) German language code

### DIFF
--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -563,6 +563,8 @@ void CPeripheralCecAdapter::SetMenuLanguage(const char* strLanguage)
     strGuiLanguage = "cs_cz";
   else if (!strcmp(strLanguage, "dan"))
     strGuiLanguage = "da_dk";
+  else if (!strcmp(strLanguage, "deu"))
+    strGuiLanguage = "de_de";
   else if (!strcmp(strLanguage, "dut"))
     strGuiLanguage = "nl_nl";
   else if (!strcmp(strLanguage, "eng"))


### PR DESCRIPTION
## Description
Add alternative German language code to CECAdapter class.

ISO 639-2 specifies both 'ger' and 'deu' for German language, in `bibliographic` and `terminology` code. German (among other languages) have different codes for each.

## Motivation and context
HDMI CEC specification says that bibliographic codes shall be used (CEC 13.6.2 Feature Description).
My TV (Sony) uses the terminology code rather than the bibliographic code when indicating the Manua Language on CEC.

Here is a snippet from `cec-ctl -S` output
```
        System Information for device 0 (TV) from device 1 (Recording Device 1):
                CEC Version                : 1.4
                Physical Address           : 0.0.0.0
                Primary Device Type        : TV
                Vendor ID                  : 0x080046 (Sony)
                OSD Name                   : 'TV'
                Menu Language              : deu
                Power Status               : On
```

kodi also logs a warning caused by this:
> WARNING <general>: SetMenuLanguage - TV menu language set to unknown value 'deu'

## How has this been tested?
I rebuild the 19.4 Matrix package using the PKBUILD from https://archlinuxarm.org/packages/armv7h/kodi-rpi/files. And added this patch.

~Actual testing is still pending as compiling takes a while.~

With this patch the warning is gone.

## What is the effect on users?
Due to this incompatible language code the automatic menu language selection is defunct on such a TV.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
