### PR TITLE
[info] Add System.Setting(hideunwatchedepisodethumbs) info bool

### DIFF
--- a/addons/skin.estuary/xml/DialogVideoInfo.xml
+++ b/addons/skin.estuary/xml/DialogVideoInfo.xml
@@ -34,7 +34,7 @@
 				</control>
 				<control type="group">
 					<visible>String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,video)</visible>
-					<visible>!String.IsEmpty(ListItem.Thumb) + !String.IsEqual(ListItem.Thumb,ListItem.Art(poster))</visible>
+					<visible>!String.IsEmpty(ListItem.Art(thumb)) + !String.IsEqual(ListItem.Art(thumb),ListItem.Art(poster))</visible>
 					<control type="image">
 						<left>4</left>
 						<top>4</top>
@@ -49,7 +49,7 @@
 						<width>506</width>
 						<height>801</height>
 						<aspectratio>keep</aspectratio>
-						<texture>$INFO[ListItem.Thumb]</texture>
+						<texture>$VAR[ShiftThumbVar]</texture>
 						<bordertexture border="21" infill="false">overlays/shadow.png</bordertexture>
 						<bordersize>20</bordersize>
 					</control>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -48,7 +48,10 @@
 		<value condition="ListItem.IsParentFolder">DefaultFolderBackSquare.png</value>
 		<value condition="String.IsEmpty(Listitem.Thumb) + [String.IsEqual(listitem.dbtype,album) | String.IsEqual(listitem.dbtype,artist)]">DefaultAudio.png</value>
 		<value condition="ListItem.IsFolder + String.IsEmpty(ListItem.Thumb)">DefaultFolderSquare.png</value>
-		<value>$INFO[ListItem.Thumb]</value>
+		<value condition="String.IsEqual(ListItem.DbType,episode) + System.Setting(hideunwatchedepisodethumbs) + Integer.IsEqual(ListItem.Playcount,0) + !String.IsEmpty(Listitem.Art(fanart))">$INFO[Listitem.Art(fanart)]</value>
+		<value condition="String.IsEqual(ListItem.DbType,episode) + System.Setting(hideunwatchedepisodethumbs) + Integer.IsEqual(ListItem.Playcount,0) + String.IsEmpty(Listitem.Art(fanart))">OverlaySpoiler.png</value>
+		<value condition="String.IsEqual(ListItem.DbType,episode) + [ !System.Setting(hideunwatchedepisodethumbs) | Integer.IsGreater(ListItem.Playcount,0) ]">$INFO[Listitem.Art(thumb)]</value>
+		<value>$INFO[ListItem.Art(thumb)]</value>
 	</variable>
 	<variable name="MusicInfoThumbVar">
 		<value condition="!String.IsEmpty(Listitem.Art(thumb))">$INFO[Listitem.Art(thumb)]</value>
@@ -58,6 +61,9 @@
 	</variable>
 	<variable name="InfoWallThumbVar">
 		<value condition="!String.IsEqual(listitem.dbtype,musicvideo) + !String.IsEmpty(Listitem.Art(poster))">$INFO[Listitem.Art(poster)]</value>
+		<value condition="String.IsEqual(ListItem.DbType,episode) + System.Setting(hideunwatchedepisodethumbs) + Integer.IsEqual(ListItem.Playcount,0) + !String.IsEmpty(Listitem.Art(fanart))">$INFO[Listitem.Art(fanart)]</value>
+		<value condition="String.IsEqual(ListItem.DbType,episode) + System.Setting(hideunwatchedepisodethumbs) + Integer.IsEqual(ListItem.Playcount,0) + String.IsEmpty(Listitem.Art(fanart))">OverlaySpoiler.png</value>
+		<value condition="String.IsEqual(ListItem.DbType,episode) + [ !System.Setting(hideunwatchedepisodethumbs) | Integer.IsGreater(ListItem.Playcount,0) ]">$INFO[Listitem.Art(thumb)]</value>
 		<value>$INFO[ListItem.Icon]</value>
 	</variable>
 	<variable name="PosterThumbVar">

--- a/addons/skin.estuary/xml/View_50_List.xml
+++ b/addons/skin.estuary/xml/View_50_List.xml
@@ -249,7 +249,7 @@
 					<height>330</height>
 					<aspectratio aligny="bottom">keep</aspectratio>
 					<fadetime>300</fadetime>
-					<texture background="true">$INFO[ListItem.Icon]</texture>
+					<texture background="true">$VAR[ShiftThumbVar]</texture>
 					<visible>String.IsEqual(ListItem.DbType,episode)</visible>
 				</control>
 				<control type="image">

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1994,6 +1994,14 @@ const infomap system_labels[] = {
 ///     @return **True** if 'hide watched items' is selected.
 ///     <p>
 ///   }
+///   \table_row3{   <b>`System.Setting(hideunwatchedepisodethumbs)`</b>,
+///                  \anchor System_Setting_HideUnwatchedEpisodeThumbs
+///                  _boolean_,
+///     @return **True** if 'hide unwatched episode setting is enabled'\, **False** otherwise.
+///     <p><hr>
+///     @skinning_v20 **[New Boolean Condition]** \link System_Setting_HideUnwatchedEpisodeThumbs `System.Setting(hideunwatchedepisodethumbs)`\endlink
+///     <p>
+///   }
 /// \table_end
 ///
 /// -----------------------------------------------------------------------------

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -29,6 +29,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/DisplaySettings.h"
 #include "settings/MediaSettings.h"
+#include "settings/SettingUtils.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
@@ -683,6 +684,15 @@ bool CSystemGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
           value = CMediaSettings::GetInstance().GetWatchedMode(window->CurrentDirectory().GetContent()) == WatchedModeUnwatched;
           return true;
         }
+      }
+      else if (StringUtils::EqualsNoCase(info.GetData3(), "hideunwatchedepisodethumbs"))
+      {
+        const std::shared_ptr<CSettingList> setting(std::dynamic_pointer_cast<CSettingList>(
+            CServiceBroker::GetSettingsComponent()->GetSettings()->GetSetting(
+                CSettings::SETTING_VIDEOLIBRARY_SHOWUNWATCHEDPLOTS)));
+        value = setting && !CSettingUtils::FindIntInList(
+                               setting, CSettings::VIDEOLIBRARY_THUMB_SHOW_UNWATCHED_EPISODE);
+        return true;
       }
       break;
     }


### PR DESCRIPTION
## Description
As discussed on https://github.com/xbmc/xbmc/issues/21656 currently `Listitem.Thumb` and `Listitem.Art(thumb)` have different behaviors. Historically, Kodi (xbmc) had a single source of truth for the image of a given item (Listitem.thumb). This infolabel returned different art types depending on the media item (poster for movies, thumb for episodes, etc). Things got worse when advanced logic was introduced in those infolabels - for example hiding the thumb if "hide thumbs for unwatched episode" setting is enabled. This not only makes the code cumbersome (it's even dumped into CFileItem) as highly limits the possibilities for skins: atm kodi places the fanart in `Listitem.Thumb` if the setting is enabled, but what if the skin wants to show something else instead?

IMHO this type of logic belongs to conditionals in the presentation layer (skins) and not really on the core. Unfortunately changing this as a PoC on Estuary is not possible due to missing infobools. Hence, this PR is the first step, introduces `System.Setting(hideunwatchedepisodethumbs)` so that skins can detect if the setting is enabled and react accordingly.

**Note:** The PR adds a new info and doesn't reuse `System.GetBool` (info bool to get boolean settings )because the actual setting is a list (list[integer]).

**Note2:**: Next step towards closing https://github.com/xbmc/xbmc/issues/21656 is to implement this logic in Estuary, removing `Listitem.Thumb` and `Listitem.Icon` usages as both are deprecated since Matrix. Luckily we can remove those infolabels in O*.

## Motivation and context
PoC for fixing https://github.com/xbmc/xbmc/issues/21656

