### PR TITLE
[PVR] InstantRecordingActionSelector must reset selection dialog befo…

### DIFF
--- a/xbmc/pvr/guilib/PVRGUIActions.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActions.cpp
@@ -538,6 +538,7 @@ namespace PVR
     {
       if (m_pDlgSelect)
       {
+        m_pDlgSelect->Reset();
         m_pDlgSelect->SetMultiSelection(false);
         m_pDlgSelect->SetHeading(CVariant{19086}); // Instant recording action
       }


### PR DESCRIPTION
…re opening it to ensure proper state. Otherwise members of the dialog will still have values from previous dialog usage, for example, `m_focusToButton` will be set to true if last selection dialog usage was from addon settings dialog. Visible effect for the user is that the cancel button of the settings dialog is focused, not the proposed instant recording action.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish good to go in?