### PR TITLE
[Matrix][PVR] InstantRecordingActionSelector must reset selection dialog befo…

### DIFF
--- a/xbmc/pvr/guilib/PVRGUIActions.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActions.cpp
@@ -525,6 +525,7 @@ namespace PVR
     {
       if (m_pDlgSelect)
       {
+        m_pDlgSelect->Reset();
         m_pDlgSelect->SetMultiSelection(false);
         m_pDlgSelect->SetHeading(CVariant{19086}); // Instant recording action
       }


### PR DESCRIPTION
…re opening it to ensure proper state.

Backport of #21877