### PR TITLE
[Subtitles] Partial fix for text/border color gap problem

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -37,7 +37,6 @@ constexpr int ASS_BORDER_STYLE_BOX = 3; // Box + drop shadow
 constexpr int ASS_BORDER_STYLE_SQUARE_BOX = 4; // Square box + outline
 
 constexpr int ASS_FONT_ENCODING_AUTO = -1;
-constexpr int COLOR_OPACITY_30 = 30;
 
 // Convert RGB/ARGB to RGBA by also applying the opacity value
 COLOR::Color ConvColor(COLOR::Color argbColor, int opacity = 100)
@@ -411,11 +410,20 @@ void CDVDSubtitlesLibass::ApplyStyle(const std::shared_ptr<struct style>& subSty
     style->Bold = isFontBold * -1;
     style->Italic = isFontItalic * -1;
 
+    //! @todo Libass has a problem with color transparencies when set to:
+    //! PrimaryColour/SecondaryColour/OutlineColour by causing a gap between border
+    //! and text color. As workaround the SecondaryColour must have no transparency
+    //! this will fix just use cases without transparencies, for a full fix will be
+    //! needed in future update libass library having the gap fix.
+
     // Set default subtitles color
     style->PrimaryColour = ConvColor(subStyle->fontColor, subStyle->fontOpacity);
     // Set secondary colour for karaoke
     // left part is filled with PrimaryColour, right one with SecondaryColour
-    style->SecondaryColour = ConvColor(subStyle->fontColor, COLOR_OPACITY_30);
+    //! @bug in libass - force secondary color without transparency otherwise
+    //! cause a visible color gap, we also avoid reusing the same primary
+    //! color otherwise the karaoke effect will not be visible.
+    style->SecondaryColour = ConvColor(COLOR::BLACK);
 
     // Configure the effects
     double lineSpacing = 0.0;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
As shown in this screenshot, there is a color gap between subtitle text and the border color (open full image)
![immagine](https://user-images.githubusercontent.com/3257156/190918504-1b786666-0f4c-46cf-b895-f688a453beec.png)

The problem come from this line:

https://github.com/xbmc/xbmc/blob/26099d46a15fd468757dfb8eec57387b67698a45/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp#L418

where we set a little transparency for karaoke effect to `SecondaryColour`,
so this partial fix consists in full remove the transparency to the `SecondaryColour`.

This will fix use cases where the user _dont set_ transparency to the text (PrimaryColour and OutlineColour)
but when the user choose to set a kind of transparency the gap problem however persist.

So problem come from libass library such as the complexity of managing transparencies see comment https://github.com/libass/libass/issues/647#issuecomment-1250339401
this will be full fixed in a future libass release, which when will be released we should update our packages

~I will provide a test build to issue author for a confirmation~
confirmed

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Partial fix for #21867

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally by playing a video with SRT and set text full solid white and big border full solid white

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
A partial fix for gap problem when transparencies are not used

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
