### PR TITLE
Android: Added action and category as extra parameters

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1514,7 +1514,9 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
                               pMsg->params.size() > 2 ? pMsg->params[2] : "",
                               pMsg->params.size() > 3 ? pMsg->params[3] : "",
                               pMsg->params.size() > 4 ? pMsg->params[4] : "",
-                              pMsg->params.size() > 5 ? pMsg->params[5] : "");
+                              pMsg->params.size() > 5 ? pMsg->params[5] : "",
+                              pMsg->params.size() > 6 ? pMsg->params[6] : "",
+                              pMsg->params.size() > 7 ? pMsg->params[7] : "");
     }
 #endif
   }

--- a/xbmc/interfaces/builtins/AndroidBuiltins.cpp
+++ b/xbmc/interfaces/builtins/AndroidBuiltins.cpp
@@ -17,8 +17,10 @@
  *           params[1] = intent (optional)
  *           params[2] = datatype (optional)
  *           params[3] = dataURI (optional)
- *           params[4] = flags (optional)
- *           params[5] = extras (optional)
+ *           params[4] = action (optional)
+ *           params[5] = category (optional)
+ *           params[6] = flags (optional)
+ *           params[7] = extras (optional)
  */
 static int LaunchAndroidActivity(const std::vector<std::string>& params)
 {

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -971,11 +971,13 @@ std::vector<androidPackage> CXBMCApp::GetApplications() const
   return m_applications;
 }
 
-// Note intent, dataType, dataURI, flags, extras all default to ""
+// Note intent, dataType, dataURI, action, category, flags, extras all default to ""
 bool CXBMCApp::StartActivity(const std::string& package,
                              const std::string& intent,
                              const std::string& dataType,
                              const std::string& dataURI,
+                             const std::string& action,
+                             const std::string& category,
                              const std::string& flags,
                              const std::string& extras)
 {
@@ -983,6 +985,8 @@ bool CXBMCApp::StartActivity(const std::string& package,
   CLog::LogF(LOGDEBUG, "intent: {}", intent);
   CLog::LogF(LOGDEBUG, "dataType: {}", dataType);
   CLog::LogF(LOGDEBUG, "dataURI: {}", dataURI);
+  CLog::LogF(LOGDEBUG, "action: {}", action);
+  CLog::LogF(LOGDEBUG, "category: {}", category);
   CLog::LogF(LOGDEBUG, "flags: {}", flags);
   CLog::LogF(LOGDEBUG, "extras: {}", extras);
 
@@ -1004,6 +1008,12 @@ bool CXBMCApp::StartActivity(const std::string& package,
 
     newIntent.setDataAndType(jniURI, dataType);
   }
+
+  if (!action.empty())
+    newIntent.setAction(action);
+
+  if (!category.empty())
+    newIntent.addCategory(category);
 
   if (!flags.empty())
   {

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -163,6 +163,8 @@ public:
                             const std::string& intent = std::string(),
                             const std::string& dataType = std::string(),
                             const std::string& dataURI = std::string(),
+                            const std::string& action = std::string(),
+                            const std::string& category = std::string(),
                             const std::string& flags = std::string(),
                             const std::string& extras = std::string());
   std::vector<androidPackage> GetApplications() const;


### PR DESCRIPTION
## Description
Extended the available parameters for starting an android activity. Added the action and category parameters to associate with the intent/app.

## Motivation and context
This changes is needed to be able to fully activate android applications from Kodi with extended parameters. Currently is only possible to simply open up a basic android app, but with this change we can activate apps with extended parameters making it possible to incorporate android apps more into Kodi.
Also since the latest Android OS updates it isn't possible to do it through normal shell/bash commands. This will solve it for many addons currently using this technique.

## How has this been tested?
System and code tests. Tested on local android emulators. Working as expected.
Needs more testing on different types of android machines and OS versions to see if it solves for all versions.

## What is the effect on users?
Won't break current usage (Matrix) of StartAndroidActivity(). But users executing Android commands can now use more parameters in their calls. All addon developers trying to execute Android commands through shell commands should now use this command through the Kodi api instead.

## Screenshots (if appropriate):
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
