### PR TITLE
[LanguageCodes] Iso table takes precedence over language addons

### DIFF
--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -88,6 +88,9 @@ bool CLangCodeExpander::Lookup(const std::string& code, std::string& desc)
   if (LookupInUserMap(code, desc))
     return true;
 
+  if (LookupInISO639Tables(code, desc))
+    return true;
+
   if (LookupInLangAddons(code, desc))
     return true;
 
@@ -112,12 +115,7 @@ bool CLangCodeExpander::Lookup(const std::string& code, std::string& desc)
 
       return true;
     }
-
-    return false;
   }
-
-  if (LookupInISO639Tables(code, desc))
-    return true;
 
   return false;
 }
@@ -199,11 +197,6 @@ bool CLangCodeExpander::ConvertToISO6392B(const std::string& strCharCode,
   }
   else if (strCharCode.size() > 3)
   {
-    // First try search on language addons
-    strISO6392B = g_langInfo.ConvertEnglishNameToAddonLocale(strCharCode);
-    if (!strISO6392B.empty())
-      return true;
-
     for (const auto& codes : g_iso639_2)
     {
       if (StringUtils::EqualsNoCase(strCharCode, codes.name))
@@ -212,6 +205,11 @@ bool CLangCodeExpander::ConvertToISO6392B(const std::string& strCharCode,
         return true;
       }
     }
+
+    // Try search on language addons
+    strISO6392B = g_langInfo.ConvertEnglishNameToAddonLocale(strCharCode);
+    if (!strISO6392B.empty())
+      return true;
   }
   return false;
 }
@@ -375,11 +373,6 @@ bool CLangCodeExpander::ReverseLookup(const std::string& desc, std::string& code
     }
   }
 
-  // Find on language addons
-  code = g_langInfo.ConvertEnglishNameToAddonLocale(descTmp);
-  if (!code.empty())
-    return true;
-
   for (const auto& codes : g_iso639_1)
   {
     if (StringUtils::EqualsNoCase(descTmp, codes.name))
@@ -397,6 +390,11 @@ bool CLangCodeExpander::ReverseLookup(const std::string& desc, std::string& code
       return true;
     }
   }
+
+  // Find on language addons
+  code = g_langInfo.ConvertEnglishNameToAddonLocale(descTmp);
+  if (!code.empty())
+    return true;
 
   return false;
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This regression is due to changes introduced with #21776

to fix the problem i need to change the proprities in how a language code is search:
before: user table -> lang addons -> iso table
now: user table -> iso table -> lang addons

this because if we search for lang code for "french" name,
and we search before on language addons we return "fr-fr"
where instead we should return the iso "fr" (as before all these changes)

so search lang codes on the language addons is now just a fallback/workaround
in the future search codes on lang addons must be removed with the possible introduction of IETF BCP 47

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #21880

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested as explained in the issue  #21880
but tested with service addon "OpenSubtiles.com" instead of "OpenSubtiles.org"

Tried again also the sample test referred to PR #21776

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
