### PR TITLE
[GUI] Avoid routing via app message when playing trailers from the GUI

### DIFF
--- a/xbmc/GUIUserMessages.h
+++ b/xbmc/GUIUserMessages.h
@@ -64,6 +64,9 @@ constexpr const int GUI_MSG_SCAN_FINISHED           = GUI_MSG_USER + 13;
 //  Player has requested the next item for caching purposes (PAPlayer)
 constexpr const int GUI_MSG_QUEUE_NEXT_ITEM         = GUI_MSG_USER + 16;
 
+//  Playback request for the trailer of a given item
+constexpr const int GUI_MSG_PLAY_TRAILER = GUI_MSG_USER + 17;
+
 // Visualisation messages when loading/unloading
 constexpr const int GUI_MSG_VISUALISATION_UNLOADING = GUI_MSG_USER + 117; // sent by vis
 constexpr const int GUI_MSG_VISUALISATION_LOADED    = GUI_MSG_USER + 118; // sent by vis

--- a/xbmc/utils/ContentUtils.cpp
+++ b/xbmc/utils/ContentUtils.cpp
@@ -44,3 +44,18 @@ const std::string ContentUtils::GetPreferredArtImage(const CFileItem& item)
   }
   return item.GetArt("thumb");
 }
+
+std::unique_ptr<CFileItem> ContentUtils::GeneratePlayableTrailerItem(const CFileItem& item,
+                                                                     const std::string& label)
+{
+  std::unique_ptr<CFileItem> trailerItem = std::make_unique<CFileItem>();
+  trailerItem->SetPath(item.GetVideoInfoTag()->m_strTrailer);
+  CVideoInfoTag* videoInfoTag = trailerItem->GetVideoInfoTag();
+  *videoInfoTag = *item.GetVideoInfoTag();
+  videoInfoTag->m_streamDetails.Reset();
+  videoInfoTag->m_strTitle = StringUtils::Format("{} ({})", videoInfoTag->m_strTitle, label);
+  trailerItem->SetArt(item.GetArt());
+  videoInfoTag->m_iDbId = -1;
+  videoInfoTag->m_iFileId = -1;
+  return trailerItem;
+}

--- a/xbmc/utils/ContentUtils.h
+++ b/xbmc/utils/ContentUtils.h
@@ -10,6 +10,7 @@
 
 #include "media/MediaType.h"
 
+#include <memory>
 #include <string>
 
 class CFileItem;
@@ -25,4 +26,13 @@ public:
     \return the preferred art image
   */
   static const std::string GetPreferredArtImage(const CFileItem& item);
+
+  /*! \brief Gets a trailer playable file item for a given item. Essentially this creates a new item which contains
+   the original item infotag and has the playable path and label changed.
+    \param item The CFileItem to process
+    \param label The label for the new item
+    \return a pointer to the trailer item
+  */
+  static std::unique_ptr<CFileItem> GeneratePlayableTrailerItem(const CFileItem& item,
+                                                                const std::string& label);
 };

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -30,7 +30,6 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "input/Key.h"
-#include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "music/MusicDatabase.h"
 #include "music/dialogs/GUIDialogMusicInfo.h"
@@ -1175,28 +1174,9 @@ void CGUIDialogVideoInfo::OnSetUserrating() const
 
 void CGUIDialogVideoInfo::PlayTrailer()
 {
-  CFileItem item;
-  item.SetPath(m_movieItem->GetVideoInfoTag()->m_strTrailer);
-  *item.GetVideoInfoTag() = *m_movieItem->GetVideoInfoTag();
-  item.GetVideoInfoTag()->m_streamDetails.Reset();
-  item.GetVideoInfoTag()->m_strTitle = StringUtils::Format(
-      "{} ({})", m_movieItem->GetVideoInfoTag()->m_strTitle, g_localizeStrings.Get(20410));
-  item.SetArt(m_movieItem->GetArt());
-  item.GetVideoInfoTag()->m_iDbId = -1;
-  item.GetVideoInfoTag()->m_iFileId = -1;
-
-  // Close the dialog.
   Close(true);
-
-  if (item.IsPlayList())
-  {
-    CFileItemList *l = new CFileItemList; //don't delete,
-    l->Add(std::make_shared<CFileItem>(item));
-    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_PLAY, -1, -1, static_cast<void*>(l));
-  }
-  else
-    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_PLAY, 0, 0,
-                                               static_cast<void*>(new CFileItem(item)));
+  CGUIMessage msg(GUI_MSG_PLAY_TRAILER, 0, 0, 0, 0, m_movieItem);
+  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
 }
 
 void CGUIDialogVideoInfo::SetLabel(int iControl, const std::string &strLabel)


### PR DESCRIPTION
## Description
While investigating https://forum.kodi.tv/showthread.php?tid=369593 I found that the proper way to play the trailer of the focused item is to go via GUI actions builtins (e.g. something like adding a  (**non-existent**) `Action(playtrailer)`). Adding support for infolabels on the `PlayMedia()` builtin like the op is doing is wrong since it requires adding dependencies on GUI: to parse the infolabel and also because no-context on the focused item exists for non GUI builtins. Actions, on the other end, belong to GUI and have the current focused context.

Searching for the way we currently play trailers I've found out the logic is buried down in GUIDialogVideoInfo which is contacting the application directly via app messaging. I think this is also wrong since, in an ideal world, a window/dialog should send the intent to its parent (windowmanager in this case) and from there the message should be routed to the application if needed. 
Since we still have a single thread for app and rendering, CApp currently has direct access to GUIMessages so ..._for the time being_... the aforementioned last step can be neglected.

Hence this PR moves the main trailer resolving logic to utils and makes the window send the trailer play intent via a GUI message which the application processes for playback. This makes the architecture a bit better and allows to reuse the same logic from other GUI parts of the code (namely actions) on a future PR.

## Motivation and context
Allow for a way to play trailers from skin timers.

## How has this been tested?
Manually, checking if we can still play the trailer from the video info dialog.

## What is the effect on users?
None, just an internal refactor

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

