### PR TITLE
[addons] Multi-instance settings selection dialog improvements

### DIFF
--- a/xbmc/addons/gui/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonSettings.cpp
@@ -257,7 +257,7 @@ bool CGUIDialogAddonSettings::ShowForAddon(const ADDON::AddonPtr& addon,
               item.SetLabel((*it).GetProperty("name").asString());
               dialog->Add(item);
             }
-            dialog->SetButtonFocus(true);
+            dialog->SetSelected(0);
             dialog->Open();
             if (dialog->IsButtonPressed())
               continue;

--- a/xbmc/addons/gui/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonSettings.cpp
@@ -162,7 +162,8 @@ bool CGUIDialogAddonSettings::ShowForAddon(const ADDON::AddonPtr& addon,
     {
       while (true)
       {
-        const std::vector<ADDON::AddonInstanceId> ids = addon->GetKnownInstanceIds();
+        std::vector<ADDON::AddonInstanceId> ids = addon->GetKnownInstanceIds();
+        std::sort(ids.begin(), ids.end(), [](const auto& a, const auto& b) { return a < b; });
 
         CFileItemList itemsGeneral;
         CFileItemList itemsInstances;

--- a/xbmc/addons/gui/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonSettings.cpp
@@ -182,7 +182,10 @@ bool CGUIDialogAddonSettings::ShowForSingleInstance(
   dialog->Open();
 
   if (!dialog->IsConfirmed())
+  {
+    addon->ReloadSettings(instanceId);
     return false;
+  }
 
   if (saveToDisk)
     addon->SaveSettings(instanceId);

--- a/xbmc/addons/gui/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonSettings.cpp
@@ -138,161 +138,26 @@ bool CGUIDialogAddonSettings::OnAction(const CAction& action)
 bool CGUIDialogAddonSettings::ShowForAddon(const ADDON::AddonPtr& addon,
                                            bool saveToDisk /* = true */)
 {
-  if (addon == nullptr)
+  if (!addon)
+  {
+    CLog::LogF(LOGERROR, "No addon given!");
     return false;
+  }
 
   if (!g_passwordManager.CheckMenuLock(WINDOW_ADDON_BROWSER))
     return false;
 
-  bool byNew = false;
-  bool enabled = false;
-  ADDON::AddonInstanceId instanceId = ADDON::ADDON_SETTINGS_ID;
-
   if (addon->SupportsInstanceSettings())
-  {
-    static constexpr int ADDON_SETTINGS = 0;
-    static constexpr int ADD_INSTANCE = 100;
-    static constexpr int REMOVE_INSTANCE = 101;
-    static constexpr int GENERAL_BUTTON_START = ADD_INSTANCE;
+    return ShowForMultipleInstances(addon, saveToDisk);
+  else
+    return ShowForSingleInstance(addon, saveToDisk);
+}
 
-    CGUIDialogSelect* dialog =
-        CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(
-            WINDOW_DIALOG_SELECT);
-    if (dialog)
-    {
-      while (true)
-      {
-        std::vector<ADDON::AddonInstanceId> ids = addon->GetKnownInstanceIds();
-        std::sort(ids.begin(), ids.end(), [](const auto& a, const auto& b) { return a < b; });
-
-        CFileItemList itemsGeneral;
-        CFileItemList itemsInstances;
-
-        dialog->Reset();
-        dialog->SetHeading(10012); // Add-on configurations and settings
-        dialog->SetUseDetails(false);
-
-        {
-          const CFileItemPtr item =
-              std::make_shared<CFileItem>(g_localizeStrings.Get(10014)); // Add add-on configuration
-          item->SetProperty("id", ADD_INSTANCE);
-          itemsGeneral.Add(item);
-        }
-        // Have always minimal 1 available and not allow this button in this case
-        if (ids.size() > 1)
-        {
-          const CFileItemPtr item = std::make_shared<CFileItem>(
-              g_localizeStrings.Get(10015)); // Remove add-on configuration
-          item->SetProperty("id", REMOVE_INSTANCE);
-          itemsGeneral.Add(item);
-        }
-        if (addon->HasSettings(ADDON_SETTINGS_ID))
-        {
-          const CFileItemPtr item =
-              std::make_shared<CFileItem>(g_localizeStrings.Get(10013)); // Edit Add-on settings
-          item->SetProperty("id", ADDON_SETTINGS);
-          itemsGeneral.Add(item);
-        }
-
-        ADDON::AddonInstanceId highestId = 0;
-        for (const auto& id : ids)
-        {
-          std::string name;
-          addon->GetSettingString(ADDON_SETTING_INSTANCE_NAME_VALUE, name, id);
-          if (name.empty())
-            name = g_localizeStrings.Get(13205); // Unknown
-
-          bool enabled{false};
-          addon->GetSettingBool(ADDON_SETTING_INSTANCE_ENABLED_VALUE, enabled, id);
-
-          const std::string label = StringUtils::Format(
-              g_localizeStrings.Get(10020), name,
-              g_localizeStrings.Get(enabled ? 305 : 13106)); // Edit "config name" [enabled state]
-
-          const CFileItemPtr item = std::make_shared<CFileItem>(label);
-          item->SetProperty("id", id);
-          item->SetProperty("name", name);
-          itemsInstances.Add(item);
-          if (id > highestId)
-            highestId = id;
-        }
-
-        for (auto& it : itemsGeneral)
-          dialog->Add(*it);
-
-        for (auto& it : itemsInstances)
-          dialog->Add(*it);
-
-        // Select first instance config item or first item
-        dialog->SetSelected(itemsInstances.Size() > 0 ? itemsGeneral.Size() : 0);
-
-        dialog->Open();
-
-        if (dialog->IsButtonPressed())
-          return false;
-
-        if (dialog->IsConfirmed())
-        {
-          const CFileItemPtr& item = dialog->GetSelectedFileItem();
-          instanceId = item->GetProperty("id").asInteger();
-          if (instanceId < GENERAL_BUTTON_START)
-          {
-            break;
-          }
-          else if (instanceId == ADD_INSTANCE)
-          {
-            instanceId = highestId + 1;
-            addon->GetSettings(instanceId);
-            addon->UpdateSettingString(ADDON_SETTING_INSTANCE_NAME_VALUE, "", instanceId);
-            addon->UpdateSettingBool(ADDON_SETTING_INSTANCE_ENABLED_VALUE, true, instanceId);
-            addon->SaveSettings(instanceId);
-            byNew = true;
-            break;
-          }
-          else if (instanceId == REMOVE_INSTANCE)
-          {
-            dialog->Reset();
-            dialog->SetHeading(10010); // Select add-on configuration to remove
-            dialog->SetUseDetails(false);
-            for (auto& it : itemsInstances)
-            {
-              CFileItem item(*it);
-              item.SetLabel((*it).GetProperty("name").asString());
-              dialog->Add(item);
-            }
-            dialog->SetSelected(0);
-            dialog->Open();
-            if (dialog->IsButtonPressed())
-              continue;
-
-            if (dialog->IsConfirmed())
-            {
-              const CFileItemPtr& item = dialog->GetSelectedFileItem();
-              const std::string label = StringUtils::Format(
-                  g_localizeStrings.Get(10019),
-                  item->GetProperty("name")
-                      .asString()); // Do you want to remove the add-on configuration "config name"?
-
-              if (CGUIDialogYesNo::ShowAndGetInput(10009, // Confirm add-on configuration removal
-                                                   label))
-              {
-                instanceId = item->GetProperty("id").asInteger();
-                addon->DeleteInstanceSettings(instanceId);
-                CServiceBroker::GetAddonMgr().PublishInstanceRemoved(addon->ID(), instanceId);
-              }
-
-              return false;
-            }
-          }
-        }
-        else
-          return false;
-      }
-    }
-
-    addon->GetSettingBool(ADDON_SETTING_INSTANCE_ENABLED_VALUE, enabled, instanceId);
-  }
-
+bool CGUIDialogAddonSettings::ShowForSingleInstance(
+    const ADDON::AddonPtr& addon,
+    bool saveToDisk,
+    ADDON::AddonInstanceId instanceId /* = ADDON::ADDON_SETTINGS_ID */)
+{
   if (!addon->HasSettings(instanceId))
   {
     // addon does not support settings, inform user
@@ -304,38 +169,194 @@ bool CGUIDialogAddonSettings::ShowForAddon(const ADDON::AddonPtr& addon,
   CGUIDialogAddonSettings* dialog =
       CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogAddonSettings>(
           WINDOW_DIALOG_ADDON_SETTINGS);
-  if (dialog == nullptr)
+  if (!dialog)
+  {
+    CLog::LogF(LOGERROR, "Unable to get WINDOW_DIALOG_ADDON_SETTINGS instance!");
     return false;
+  }
 
   dialog->m_addon = addon;
   dialog->m_instanceId = instanceId;
   dialog->m_saveToDisk = saveToDisk;
+
   dialog->Open();
 
   if (!dialog->IsConfirmed())
+    return false;
+
+  if (saveToDisk)
+    addon->SaveSettings(instanceId);
+
+  return true;
+}
+
+bool CGUIDialogAddonSettings::ShowForMultipleInstances(const ADDON::AddonPtr& addon,
+                                                       bool saveToDisk)
+{
+  CGUIDialogSelect* dialog =
+      CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(
+          WINDOW_DIALOG_SELECT);
+  if (!dialog)
   {
-    // Remove instance settings if added by new and not set
-    if (byNew)
-      addon->DeleteInstanceSettings(instanceId);
+    CLog::LogF(LOGERROR, "Unable to get WINDOW_DIALOG_SELECT instance!");
     return false;
   }
 
-  if (saveToDisk)
-    addon->SaveSettings(dialog->m_instanceId);
+  static constexpr int ADDON_SETTINGS = 0;
+  static constexpr int ADD_INSTANCE = 100;
+  static constexpr int REMOVE_INSTANCE = 101;
+  static constexpr int GENERAL_BUTTON_START = ADD_INSTANCE;
 
-  // If added new, publish his add to related places and start the use of new instance
-  if (instanceId != ADDON_SETTINGS_ID)
+  ADDON::AddonInstanceId instanceId = ADDON::ADDON_SETTINGS_ID;
+  bool newInstance{false};
+
+  while (true)
   {
-    bool enabledNow = false;
-    addon->GetSettingBool(ADDON_SETTING_INSTANCE_ENABLED_VALUE, enabledNow, instanceId);
-    if (byNew || enabled != enabledNow)
+    std::vector<ADDON::AddonInstanceId> ids = addon->GetKnownInstanceIds();
+    std::sort(ids.begin(), ids.end(), [](const auto& a, const auto& b) { return a < b; });
+
+    dialog->Reset();
+    dialog->SetHeading(10012); // Add-on configurations and settings
+    dialog->SetUseDetails(false);
+
+    CFileItemList itemsGeneral;
+
+    CFileItemPtr item =
+        std::make_shared<CFileItem>(g_localizeStrings.Get(10014)); // Add add-on configuration
+    item->SetProperty("id", ADD_INSTANCE);
+    itemsGeneral.Add(item);
+
+    if (ids.size() > 1) // Forbid removal of last instance
     {
-      CServiceBroker::GetAddonMgr().PublishInstanceAdded(addon->ID(), instanceId);
+      item =
+          std::make_shared<CFileItem>(g_localizeStrings.Get(10015)); // Remove add-on configuration
+      item->SetProperty("id", REMOVE_INSTANCE);
+      itemsGeneral.Add(item);
     }
-    else if (!enabledNow && enabled != enabledNow)
+
+    if (addon->HasSettings(ADDON_SETTINGS_ID))
     {
-      CServiceBroker::GetAddonMgr().PublishInstanceRemoved(addon->ID(), instanceId);
+      item = std::make_shared<CFileItem>(g_localizeStrings.Get(10013)); // Edit Add-on settings
+      item->SetProperty("id", ADDON_SETTINGS);
+      itemsGeneral.Add(item);
     }
+
+    CFileItemList itemsInstances;
+    ADDON::AddonInstanceId highestId = 0;
+    for (const auto& id : ids)
+    {
+      std::string name;
+      addon->GetSettingString(ADDON_SETTING_INSTANCE_NAME_VALUE, name, id);
+      if (name.empty())
+        name = g_localizeStrings.Get(13205); // Unknown
+
+      bool enabled = false;
+      addon->GetSettingBool(ADDON_SETTING_INSTANCE_ENABLED_VALUE, enabled, id);
+
+      const std::string label = StringUtils::Format(
+          g_localizeStrings.Get(10020), name,
+          g_localizeStrings.Get(enabled ? 305 : 13106)); // Edit "config name" [enabled state]
+
+      item = std::make_shared<CFileItem>(label);
+      item->SetProperty("id", id);
+      item->SetProperty("name", name);
+      itemsInstances.Add(item);
+      if (id > highestId)
+        highestId = id;
+    }
+
+    for (auto& it : itemsGeneral)
+      dialog->Add(*it);
+
+    for (auto& it : itemsInstances)
+      dialog->Add(*it);
+
+    // Select first instance config item or first item
+    dialog->SetSelected(itemsInstances.Size() > 0 ? itemsGeneral.Size() : 0);
+
+    dialog->Open();
+
+    if (dialog->IsButtonPressed() || !dialog->IsConfirmed())
+      return false;
+
+    item = dialog->GetSelectedFileItem();
+    instanceId = item->GetProperty("id").asInteger();
+    if (instanceId < GENERAL_BUTTON_START)
+    {
+      break;
+    }
+    else if (instanceId == ADD_INSTANCE)
+    {
+      instanceId = highestId + 1;
+      addon->GetSettings(instanceId);
+      addon->UpdateSettingString(ADDON_SETTING_INSTANCE_NAME_VALUE, "", instanceId);
+      addon->UpdateSettingBool(ADDON_SETTING_INSTANCE_ENABLED_VALUE, true, instanceId);
+      addon->SaveSettings(instanceId);
+      newInstance = true;
+      break;
+    }
+    else if (instanceId == REMOVE_INSTANCE)
+    {
+      dialog->Reset();
+      dialog->SetHeading(10010); // Select add-on configuration to remove
+      dialog->SetUseDetails(false);
+
+      for (auto& it : itemsInstances)
+      {
+        CFileItem item(*it);
+        item.SetLabel((*it).GetProperty("name").asString());
+        dialog->Add(item);
+      }
+
+      dialog->SetSelected(0);
+      dialog->Open();
+
+      if (!dialog->IsButtonPressed() && dialog->IsConfirmed())
+      {
+        item = dialog->GetSelectedFileItem();
+        const std::string label = StringUtils::Format(
+            g_localizeStrings.Get(10019),
+            item->GetProperty("name")
+                .asString()); // Do you want to remove the add-on configuration "config name"?
+
+        if (CGUIDialogYesNo::ShowAndGetInput(10009, // Confirm add-on configuration removal
+                                             label))
+        {
+          instanceId = item->GetProperty("id").asInteger();
+          addon->DeleteInstanceSettings(instanceId);
+          CServiceBroker::GetAddonMgr().PublishInstanceRemoved(addon->ID(), instanceId);
+        }
+
+        return false;
+      }
+    }
+  } // while (true)
+
+  bool enabled = false;
+  addon->GetSettingBool(ADDON_SETTING_INSTANCE_ENABLED_VALUE, enabled, instanceId);
+
+  if (ShowForSingleInstance(addon, saveToDisk, instanceId))
+  {
+    if (instanceId != ADDON_SETTINGS_ID)
+    {
+      // Publish new/removed instance configuration and start the use of new instance
+      bool enabledNow = false;
+      addon->GetSettingBool(ADDON_SETTING_INSTANCE_ENABLED_VALUE, enabledNow, instanceId);
+      if (newInstance || enabled != enabledNow)
+      {
+        CServiceBroker::GetAddonMgr().PublishInstanceAdded(addon->ID(), instanceId);
+      }
+      else if (!enabledNow && enabled != enabledNow)
+      {
+        CServiceBroker::GetAddonMgr().PublishInstanceRemoved(addon->ID(), instanceId);
+      }
+    }
+  }
+  else if (newInstance)
+  {
+    // Remove instance settings if just added but not succeeded (e.g. dialog cancelled)
+    addon->DeleteInstanceSettings(instanceId);
+    return false;
   }
 
   return true;

--- a/xbmc/addons/gui/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonSettings.cpp
@@ -222,7 +222,9 @@ bool CGUIDialogAddonSettings::ShowForAddon(const ADDON::AddonPtr& addon,
         for (auto& it : itemsInstances)
           dialog->Add(*it);
 
-        dialog->SetButtonFocus(true);
+        // Select first instance config item or first item
+        dialog->SetSelected(itemsInstances.Size() > 0 ? itemsGeneral.Size() : 0);
+
         dialog->Open();
 
         if (dialog->IsButtonPressed())

--- a/xbmc/addons/gui/GUIDialogAddonSettings.h
+++ b/xbmc/addons/gui/GUIDialogAddonSettings.h
@@ -43,6 +43,11 @@ protected:
   void OnSettingAction(const std::shared_ptr<const CSetting>& setting) override;
 
 private:
+  static bool ShowForSingleInstance(const ADDON::AddonPtr& addon,
+                                    bool saveToDisk,
+                                    ADDON::AddonInstanceId instanceId = ADDON::ADDON_SETTINGS_ID);
+  static bool ShowForMultipleInstances(const ADDON::AddonPtr& addon, bool saveToDisk);
+
   ADDON::AddonPtr m_addon;
   ADDON::AddonInstanceId m_instanceId{ADDON::ADDON_SETTINGS_ID};
   bool m_saveToDisk = false;


### PR DESCRIPTION
Some functional improvements:
* Instance removal selection dialog: set initial selection to the first instance, not to the cancel button.
* Multi-instance selection dialog: set initial selection to first instance, not to the cancel button.
* Multi-instance selection dialog: sort instances by instance id so that instances appear in the order they were created.
* Multi-instance selection dialog: do not exit the dialog after adding/removing/editing instances. Makes it possible to add/edit/remove multiple instances with far less clicks.

Non-functional improvemnts:
* code refactoring to slice `ShowForAddon` into (hopefully) more readable code pieces.

Fixes:
* get rid of limitation to 99 instances, for which btw. overflow error logic was not implemented. 
* addon/instance settings must be reloaded if dialog was cancelled to actually revert (unsaved) settings changes done in the dialog.


Runtime-tested on macOS and Android, latest Kodi master.

@AlwinEsch I hope you find some time to review this soon. Best to review commit by commit, skipping the refactor commit, which is almost unreadable and does not introduce any functional changes.