### PR TITLE
changed: split out service container from Platform

### DIFF
--- a/xbmc/platform/linux/PlatformLinux.cpp
+++ b/xbmc/platform/linux/PlatformLinux.cpp
@@ -129,12 +129,12 @@ bool CPlatformLinux::InitStageOne()
   m_lirc.reset(OPTIONALS::LircRegister());
 
 #if defined(HAS_ALSA)
-  RegisterService(std::make_shared<CFDEventMonitor>());
+  RegisterComponent(std::make_shared<CFDEventMonitor>());
 #if defined(HAVE_LIBUDEV)
-  RegisterService(std::make_shared<CALSADeviceMonitor>());
+  RegisterComponent(std::make_shared<CALSADeviceMonitor>());
 #endif
 #if !defined(HAVE_X11)
-  RegisterService(std::make_shared<CALSAHControlMonitor>());
+  RegisterComponent(std::make_shared<CALSAHControlMonitor>());
 #endif
 #endif // HAS_ALSA
   return true;
@@ -144,12 +144,12 @@ void CPlatformLinux::DeinitStageOne()
 {
 #if defined(HAS_ALSA)
 #if !defined(HAVE_X11)
-  DeregisterService(typeid(CALSAHControlMonitor));
+  DeregisterComponent(typeid(CALSAHControlMonitor));
 #endif
 #if defined(HAVE_LIBUDEV)
-  DeregisterService(typeid(CALSADeviceMonitor));
+  DeregisterComponent(typeid(CALSADeviceMonitor));
 #endif
-  DeregisterService(typeid(CFDEventMonitor));
+  DeregisterComponent(typeid(CFDEventMonitor));
 #endif // HAS_ALSA
 }
 

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -90,6 +90,7 @@ set(HEADERS ActorProtocol.h
             CharsetDetection.h
             CPUInfo.h
             ColorUtils.h
+            ComponentContainer.h
             ContentUtils.h
             Crc32.h
             CSSUtils.h

--- a/xbmc/utils/ComponentContainer.h
+++ b/xbmc/utils/ComponentContainer.h
@@ -1,0 +1,81 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "threads/CriticalSection.h"
+
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <typeindex>
+#include <unordered_map>
+
+//! \brief A generic container for components.
+//! \details A component has to be derived from the BaseType.
+//!          Only a single instance of each derived type can be registered.
+//!          Intended use is through inheritance.
+template<class BaseType>
+class CComponentContainer
+{
+public:
+  //! \brief Obtain a component.
+  template<class T>
+  std::shared_ptr<T> GetComponent()
+  {
+    std::unique_lock<CCriticalSection> lock(m_critSection);
+    const auto it = m_components.find(std::type_index(typeid(T)));
+    if (it != m_components.end())
+      return std::static_pointer_cast<T>((*it).second);
+
+    return nullptr;
+  }
+
+  //! \brief Obtain a component.
+  template<class T>
+  std::shared_ptr<const T> GetComponent() const
+  {
+    std::unique_lock<CCriticalSection> lock(m_critSection);
+    const auto it = m_components.find(std::type_index(typeid(T)));
+    if (it != m_components.end())
+      return std::static_pointer_cast<const T>((*it).second);
+
+    return nullptr;
+  }
+
+  //! \brief Returns number of registered components.
+  std::size_t size() const { return m_components.size(); }
+
+protected:
+  //! \brief Register a new component instance.
+  void RegisterComponent(const std::shared_ptr<BaseType>& component)
+  {
+    if (!component)
+      return;
+
+    // Note: Extra var needed to avoid clang warning
+    // "Expression with side effects will be evaluated despite being used as an operand to 'typeid'"
+    // https://stackoverflow.com/questions/46494928/clang-warning-on-expression-side-effects
+    const auto& componentRef = *component;
+
+    std::unique_lock<CCriticalSection> lock(m_critSection);
+    m_components.insert({std::type_index(typeid(componentRef)), component});
+  }
+
+  //! \brief Deregister a component.
+  void DeregisterComponent(const std::type_info& typeInfo)
+  {
+    std::unique_lock<CCriticalSection> lock(m_critSection);
+    m_components.erase(typeInfo);
+  }
+
+private:
+  mutable CCriticalSection m_critSection; //!< Critical section for map updates
+  std::unordered_map<std::type_index, std::shared_ptr<BaseType>>
+      m_components; //!< Map of components
+};

--- a/xbmc/utils/test/CMakeLists.txt
+++ b/xbmc/utils/test/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES TestAlarmClock.cpp
             TestBitstreamStats.cpp
             TestCharsetConverter.cpp
             TestCPUInfo.cpp
+            TestComponentContainer.cpp
             TestCrc32.cpp
             TestDatabaseUtils.cpp
             TestDigest.cpp

--- a/xbmc/utils/test/TestComponentContainer.cpp
+++ b/xbmc/utils/test/TestComponentContainer.cpp
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (C) 2015-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "utils/ComponentContainer.h"
+
+#include <utility>
+
+#include <gtest/gtest.h>
+
+class BaseTestType
+{
+public:
+  virtual ~BaseTestType() = default;
+};
+
+struct DerivedType1 : public BaseTestType
+{
+  int a = 1;
+};
+
+struct DerivedType2 : public BaseTestType
+{
+  int a = 2;
+};
+
+struct DerivedType3 : public BaseTestType
+{
+  int a = 3;
+};
+
+class TestContainer : public CComponentContainer<BaseTestType>
+{
+  FRIEND_TEST(TestComponentContainer, Generic);
+};
+
+TEST(TestComponentContainer, Generic)
+{
+  TestContainer container;
+
+  // check that we can register types
+  container.RegisterComponent(std::make_shared<DerivedType1>());
+  EXPECT_EQ(container.size(), 1u);
+  container.RegisterComponent(std::make_shared<DerivedType2>());
+  EXPECT_EQ(container.size(), 2u);
+
+  // check that trying to register a component twice does nothing
+  container.RegisterComponent(std::make_shared<DerivedType2>());
+  EXPECT_EQ(container.size(), 2u);
+
+  // check that first component is valid
+  const auto t1 = container.GetComponent<DerivedType1>();
+  EXPECT_TRUE(t1 != nullptr);
+  EXPECT_EQ(t1->a, 1);
+
+  // check that second component is valid
+  const auto t2 = container.GetComponent<DerivedType2>();
+  EXPECT_TRUE(t2 != nullptr);
+  EXPECT_EQ(t2->a, 2);
+
+  // check that third component is not there
+  const auto t3 = container.GetComponent<DerivedType3>();
+  EXPECT_TRUE(t3 == nullptr);
+
+  // check that component instance is constant
+  const auto t4 = container.GetComponent<DerivedType1>();
+  EXPECT_EQ(t1.get(), t4.get());
+
+  // check we can call the const overload for GetComponent
+  // and that the returned type is const
+  const auto t5 = const_cast<const TestContainer&>(container).GetComponent<DerivedType1>();
+  EXPECT_TRUE(std::is_const_v<typename decltype(t5)::element_type>);
+}


### PR DESCRIPTION
## Description
split out the service container parts from CPlatform.
put this in a generic ComponentContainer template so the code is reusable.

## Motivation and context
I want to reuse this code for application components.

## How has this been tested?
It builds and runs

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed