### PR TITLE
Add application component container

### DIFF
--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -283,6 +283,11 @@ CMediaManager& CServiceBroker::GetMediaManager()
   return g_application.m_ServiceManager->GetMediaManager();
 }
 
+CApplicationComponents& CServiceBroker::GetAppComponents()
+{
+  return g_application;
+}
+
 CGUIComponent* CServiceBroker::GetGUI()
 {
   return g_serviceBroker.m_pGUI;

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -51,10 +51,13 @@ class CApplicationMessenger;
 } // namespace KODI
 
 class CAppParams;
+template<class T>
+class CComponentContainer;
 class CContextMenuManager;
 class XBPython;
 class CDataCacheCore;
 class IAE;
+class IApplicationComponent;
 class CFavouritesService;
 class CInputManager;
 class CFileExtensionProvider;
@@ -162,6 +165,7 @@ public:
   static CDatabaseManager& GetDatabaseManager();
   static CEventLog* GetEventLog();
   static CMediaManager& GetMediaManager();
+  static CComponentContainer<IApplicationComponent>& GetAppComponents();
 
   static CGUIComponent* GetGUI();
   static void RegisterGUI(CGUIComponent* gui);

--- a/xbmc/application/Application.h
+++ b/xbmc/application/Application.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "ServiceManager.h"
-#include "application/ApplicationActionListeners.h"
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationEnums.h"
 #include "application/ApplicationPlayer.h"
@@ -90,7 +89,6 @@ class CApplication : public IWindowManagerCallback,
                      public IMsgTargetCallback,
                      public KODI::MESSAGING::IMessageTarget,
                      public CApplicationComponents,
-                     public CApplicationActionListeners,
                      public CApplicationPlayerCallback,
                      public CApplicationPowerHandling,
                      public CApplicationSettingsHandling,

--- a/xbmc/application/Application.h
+++ b/xbmc/application/Application.h
@@ -10,6 +10,7 @@
 
 #include "ServiceManager.h"
 #include "application/ApplicationActionListeners.h"
+#include "application/ApplicationComponents.h"
 #include "application/ApplicationEnums.h"
 #include "application/ApplicationPlayer.h"
 #include "application/ApplicationPlayerCallback.h"
@@ -88,6 +89,7 @@ namespace MUSIC_INFO
 class CApplication : public IWindowManagerCallback,
                      public IMsgTargetCallback,
                      public KODI::MESSAGING::IMessageTarget,
+                     public CApplicationComponents,
                      public CApplicationActionListeners,
                      public CApplicationPlayerCallback,
                      public CApplicationPowerHandling,

--- a/xbmc/application/ApplicationActionListeners.h
+++ b/xbmc/application/ApplicationActionListeners.h
@@ -8,9 +8,12 @@
 
 #pragma once
 
+#include "application/IApplicationComponent.h"
+
 #include <vector>
 
 class CAction;
+class CApplication;
 class CCriticalSection;
 class IActionListener;
 
@@ -18,8 +21,10 @@ class IActionListener;
  * \brief Class handling application support for action listeners.
  */
 
-class CApplicationActionListeners
+class CApplicationActionListeners : public IApplicationComponent
 {
+  friend class CApplication;
+
 public:
   CApplicationActionListeners(CCriticalSection& sect);
 

--- a/xbmc/application/ApplicationComponents.h
+++ b/xbmc/application/ApplicationComponents.h
@@ -1,0 +1,15 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "application/IApplicationComponent.h"
+#include "utils/ComponentContainer.h"
+
+//! \brief Convenience alias for application components.
+using CApplicationComponents = CComponentContainer<IApplicationComponent>;

--- a/xbmc/application/IApplicationComponent.h
+++ b/xbmc/application/IApplicationComponent.h
@@ -1,0 +1,16 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+//! \brief Base class for application components.
+class IApplicationComponent
+{
+public:
+  virtual ~IApplicationComponent() = default;
+};

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -17,6 +17,8 @@
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "application/Application.h"
+#include "application/ApplicationActionListeners.h"
+#include "application/ApplicationComponents.h"
 #include "cores/VideoPlayer/DVDDemuxers/DVDDemuxBXA.h"
 #include "filesystem/File.h"
 #include "filesystem/PipeFile.h"
@@ -670,16 +672,19 @@ CAirTunesServer::~CAirTunesServer()
 
 void CAirTunesServer::RegisterActionListener(bool doRegister)
 {
+  auto& components = CServiceBroker::GetAppComponents();
+  const auto appListener = components.GetComponent<CApplicationActionListeners>();
+
   if (doRegister)
   {
     CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this);
-    g_application.RegisterActionListener(this);
+    appListener->RegisterActionListener(this);
     ServerInstance->Create();
   }
   else
   {
     CServiceBroker::GetAnnouncementManager()->RemoveAnnouncer(this);
-    g_application.UnregisterActionListener(this);
+    appListener->UnregisterActionListener(this);
     ServerInstance->StopThread(true);
   }
 }

--- a/xbmc/pvr/guilib/PVRGUIActionListener.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionListener.cpp
@@ -10,6 +10,8 @@
 
 #include "ServiceBroker.h"
 #include "application/Application.h"
+#include "application/ApplicationActionListeners.h"
+#include "application/ApplicationComponents.h"
 #include "dialogs/GUIDialogNumeric.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
@@ -37,7 +39,9 @@ namespace PVR
 
 CPVRGUIActionListener::CPVRGUIActionListener()
 {
-  g_application.RegisterActionListener(this);
+  auto& components = CServiceBroker::GetAppComponents();
+  const auto appListener = components.GetComponent<CApplicationActionListeners>();
+  appListener->RegisterActionListener(this);
   CServiceBroker::GetSettingsComponent()->GetSettings()->RegisterCallback(
       this,
       {CSettings::SETTING_PVRPARENTAL_ENABLED, CSettings::SETTING_PVRMANAGER_RESETDB,
@@ -51,7 +55,9 @@ CPVRGUIActionListener::CPVRGUIActionListener()
 CPVRGUIActionListener::~CPVRGUIActionListener()
 {
   CServiceBroker::GetSettingsComponent()->GetSettings()->UnregisterCallback(this);
-  g_application.UnregisterActionListener(this);
+  auto& components = CServiceBroker::GetAppComponents();
+  const auto appListener = components.GetComponent<CApplicationActionListeners>();
+  appListener->UnregisterActionListener(this);
 }
 
 void CPVRGUIActionListener::Init(CPVRManager& mgr)


### PR DESCRIPTION
## Description
- adds application component container
- move first component into it - the ApplicationActionListener

## Motivation and context
Split out parts of CApplication in separate classes. Expose the container of such components through the ServiceBroker so
other parts of the code can use them, without being dependent on one big monolith. IOW; reduce
the amount of Application.h inclusions and increase modularity.

## How has this been tested?
Builds and runs

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
