### PR TITLE
[discs] Fix double free when eject fails

### DIFF
--- a/xbmc/platform/posix/storage/discs/DiscDriveHandlerPosix.cpp
+++ b/xbmc/platform/posix/storage/discs/DiscDriveHandlerPosix.cpp
@@ -115,10 +115,10 @@ void CDiscDriveHandlerPosix::EjectDriveTray(const std::string& devicePath)
   while (cdio && retries-- > 0)
   {
     const driver_return_code_t ret = libCdio->cdio_eject_media(&cdio);
-    libCdio->cdio_destroy(cdio);
     if (ret == DRIVER_OP_SUCCESS)
       break;
   }
+  libCdio->cdio_destroy(cdio);
 }
 
 void CDiscDriveHandlerPosix::CloseDriveTray(const std::string& devicePath)


### PR DESCRIPTION
We currently destroy the same cdio data structure at each eject retries. cdio_destroy does not set the cdio structure to NULL, only free its members. Thus the second cdio_destroy runs and attempts to free the cdio env members a second time (especially src_name) and the program aborts.

Fixes error:
free(): invalid pointer
and
double free or corruption (out)

The eject in Nexus on linux fails when there is an escaped character
 in the mount point.
For one DVD titles with a space ends up in /proc/mounts and /etc/mtabi escaped with the \040 escape sequence. Sadly umount (called by libcdio) cannot decode those octal escape sequences for space and fails. This is a libcdio issue.
This libcdio issue unhides the kodi double free segfault at the second rety to eject from kodi.

## Description
I move the cdio destroy out of the loop to run it once, not at each eject retries.

## Motivation and context
The destroy is only required if all retries failed (cdio is destroyed and set to NULL by cdio_eject_media if success).
To have it run twice on the same cdio structure triggers a double free corruption and kodi crashes. 
The previous behavior (pre 20.0a1-Nexus, before https://github.com/xbmc/xbmc/commit/75e79865f33b5982ad5b0b21fcacfb7d6b99dd19  was:
  ```
int nRetries=3;
  while (nRetries-- > 0)
  {
    CdIo_t* cdio = c_cdio->cdio_open(dvdDevice, DRIVER_UNKNOWN);
    if (cdio)
    {
      c_cdio->cdio_eject_media(&cdio);
      c_cdio->cdio_destroy(cdio);
    }
```
That is for each retry, open, eject, destroy. The current one is open, eject, destroy, eject, destroy, eject, destroy. The one in this PR is open, eject, eject, eject, destroy.


backtrace with debug build of current implementation, when pressing eject on a DVD that fails to eject (cannot umount as libcdio does not translate *fstab escapte' characters in the mount point path (https://savannah.gnu.org/bugs/index.php?63091):
```
Detaching after fork from child process 969974]
umount: /media/prahal/BLACK\040WIDOW: No such file or directory
double free or corruption (out)
--Type <RET> for more, q to quit, c to continue without paging--c

Thread 1 "kodi.bin" received signal SIGABRT, Aborted.
__pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at ./nptl/pthread_kill.c:44
44	./nptl/pthread_kill.c: No such file or directory.
(gdb) bt
#0  __pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at ./nptl/pthread_kill.c:44
#1  0x00007ffff3f8989f in __pthread_kill_internal (signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:78
#2  0x00007ffff3f3da52 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#3  0x00007ffff3f28469 in __GI_abort () at ./stdlib/abort.c:79
#4  0x00007ffff3f7dc18 in __libc_message (action=action@entry=do_abort, fmt=fmt@entry=0x7ffff40b4689 "%s\n") at ../sysdeps/posix/libc_fatal.c:155
#5  0x00007ffff3f9355a in malloc_printerr (str=str@entry=0x7ffff40b7230 "double free or corruption (out)") at ./malloc/malloc.c:5531
#6  0x00007ffff3f95140 in _int_free (av=0x7ffff40f2c60 <main_arena>, p=0x55555b3938d0, have_lock=<optimized out>, have_lock@entry=0) at ./malloc/malloc.c:4471
#7  0x00007ffff3f97781 in __GI___libc_free (mem=<optimized out>) at ./malloc/malloc.c:3274
#8  0x00007ffff7c8ec26 in cdio_generic_free (p_user_data=0x55555b3989d0) at ./lib/driver/_cdio_generic.c:107
#9  0x00007ffff7c916fd in cdio_destroy (p_cdio=0x55555b393760) at ./lib/driver/device.c:367
#10 0x0000555557605c6a in MEDIA_DETECT::CLibcdio::cdio_destroy(_CdIo*) (this=0x5555592d1140, p_cdio=0x55555b393760)
    at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/storage/cdioSupport.cpp:136
#11 0x00005555570df802 in CDiscDriveHandlerPosix::EjectDriveTray(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
    (this=0x5555592d1130, devicePath="/dev/cdrom") at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/platform/posix/storage/discs/DiscDriveHandlerPosix.cpp:118
#12 0x00005555570df9db in CDiscDriveHandlerPosix::ToggleDriveTray(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
    (this=0x5555592d1130, devicePath="/dev/cdrom") at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/platform/posix/storage/discs/DiscDriveHandlerPosix.cpp:149
#13 0x00005555576013be in CMediaManager::ToggleTray(char) (this=0x55555936c640, cDriveLetter=0 '\000')
    at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/storage/MediaManager.cpp:668
#14 0x00005555580e74d1 in Eject(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) (params=std::vector of length 0, capacity 0)
    at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/interfaces/builtins/OpticalBuiltins.cpp:27
#15 0x00005555580de50e in CBuiltins::Execute(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
    (this=0x555559167a60 <CBuiltins::GetInstance()::sBuiltins>, execString="EjectTray()")
    at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/interfaces/builtins/Builtins.cpp:154
#16 0x00005555578b9f25 in CApplication::ExecuteXBMCAction(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::shared_ptr<CGUIListItem> const&) (this=0x5555591c82e0, actionStr="EjectTray()", item=std::shared_ptr<class CGUIListItem> (empty) = {...})
    at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/application/Application.cpp:2904
#17 0x00005555578b9926 in CApplication::OnMessage(CGUIMessage&) (this=0x5555591c82e0, message=...)
    at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/application/Application.cpp:2881
#18 0x00005555577f179d in CGUIWindowManager::SendMessage(CGUIMessage&) (this=0x555559d940e0, message=...)
    at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/guilib/GUIWindowManager.cpp:486
#19 0x000055555772e393 in CGUIAction::ExecuteActions(int, int, std::shared_ptr<CGUIListItem> const&) const
    (this=0x7fffffffbbb0, controlID=21100568, parentID=10000, item=std::shared_ptr<class CGUIListItem> (empty) = {...})
    at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/guilib/GUIAction.cpp:47
#20 0x0000555557745002 in CGUIButtonControl::OnClick() (this=0x55555ae746b0) at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/guilib/GUIButtonControl.cpp:389
#21 0x00005555577443af in CGUIButtonControl::OnAction(CAction const&) (this=0x55555ae746b0, action=...)
    at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/guilib/GUIButtonControl.cpp:208
#22 0x0000555557744cec in CGUIButtonControl::OnMouseEvent(CPointGen<float> const&, CMouseEvent const&) (this=0x55555ae746b0, point=..., event=...)
    at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/guilib/GUIButtonControl.cpp:342
#23 0x000055555774e770 in CGUIControl::SendMouseEvent(CPointGen<float> const&, CMouseEvent const&) (this=0x55555ae746b0, point=..., event=...)
--Type <RET> for more, q to quit, c to continue without paging--c
    at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/guilib/GUIControl.cpp:584
#24 0x0000555557767802 in CGUIControlGroupList::SendMouseEvent(CPointGen<float> const&, CMouseEvent const&) (this=0x55555ae72e90, point=..., event=...) at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/guilib/GUIControlGroupList.cpp:388
#25 0x0000555557767802 in CGUIControlGroupList::SendMouseEvent(CPointGen<float> const&, CMouseEvent const&) (this=0x55555ae71fe0, point=..., event=...) at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/guilib/GUIControlGroupList.cpp:388
#26 0x00005555577623ab in CGUIControlGroup::SendMouseEvent(CPointGen<float> const&, CMouseEvent const&) (this=0x55555ae71a90, point=..., event=...) at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/guilib/GUIControlGroup.cpp:368
#27 0x00005555577623ab in CGUIControlGroup::SendMouseEvent(CPointGen<float> const&, CMouseEvent const&) (this=0x55555ae71680, point=..., event=...) at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/guilib/GUIControlGroup.cpp:368
#28 0x00005555577623ab in CGUIControlGroup::SendMouseEvent(CPointGen<float> const&, CMouseEvent const&) (this=0x55555a6dea40, point=..., event=...) at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/guilib/GUIControlGroup.cpp:368
#29 0x00005555577623ab in CGUIControlGroup::SendMouseEvent(CPointGen<float> const&, CMouseEvent const&) (this=0x55555a6decc0, point=..., event=...) at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/guilib/GUIControlGroup.cpp:368
#30 0x00005555577623ab in CGUIControlGroup::SendMouseEvent(CPointGen<float> const&, CMouseEvent const&) (this=0x555559d379f0, point=..., event=...) at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/guilib/GUIControlGroup.cpp:368
#31 0x00005555577e7f15 in CGUIWindow::OnMouseAction(CAction const&) (this=0x555559d379f0, action=...) at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/guilib/GUIWindow.cpp:510
#32 0x00005555577e784f in CGUIWindow::OnAction(CAction const&) (this=0x555559d379f0, action=...) at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/guilib/GUIWindow.cpp:420
#33 0x00005555574a0aa3 in CGUIWindowHome::OnAction(CAction const&) (this=0x555559d379f0, action=...) at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/windows/GUIWindowHome.cpp:54
#34 0x00005555577f4936 in CGUIWindowManager::HandleAction(CAction const&) const (this=0x555559d940e0, action=...) at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/guilib/GUIWindowManager.cpp:1173
#35 0x00005555577f46be in CGUIWindowManager::OnAction(CAction const&) const (this=0x555559d940e0, action=...) at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/guilib/GUIWindowManager.cpp:1118
#36 0x00005555578aff9b in CApplication::OnAction(CAction const&) (this=0x5555591c82e0, action=...) at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/application/Application.cpp:968
#37 0x00005555576dc281 in CInputManager::ProcessMouse(int) (this=0x55555936d570, windowId=10000) at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/input/InputManager.cpp:163
#38 0x00005555576dd644 in CInputManager::OnEvent(XBMC_Event&) (this=0x55555936d570, newEvent=...) at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/input/InputManager.cpp:391
#39 0x00005555578abbda in CApplication::HandlePortEvents() (this=0x5555591c82e0) at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/application/Application.cpp:317
#40 0x00005555578b3eb6 in CApplication::FrameMove(bool, bool) (this=0x5555591c82e0, processEvents=true, processGUI=true) at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/application/Application.cpp:1759
#41 0x00005555578b451a in CApplication::Run() (this=0x5555591c82e0) at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/application/Application.cpp:1862
#42 0x0000555557637cc7 in XBMC_Run(bool, std::shared_ptr<CAppParams> const&) (renderGUI=true, params=std::shared_ptr<class CAppParams> (use count 3, weak count 0) = {...}) at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/platform/xbmc.cpp:64
#43 0x0000555556e60cdd in main(int, char**) (argc=1, argv=0x7fffffffdde8) at /home/prahal/Projects/WIP/kodi_libcdio_free/kodi/xbmc/xbmc/platform/posix/main.cpp:69
```



## How has this been tested?
I tested multiple ways but one without a DVD drive or a DVD with a space in the title is to use cdemu.
build and install cdemu. With ffmpeg, dvdauthor and genisoimage one can reproduce.

```
ffmpeg -f lavfi -i color=size=1280x720:rate=25:color=black -f lavfi -i anullsrc=channel_layout=stereo:sample_rate=44100  -target pal-dvd -aspect 16:9 -t 10 output.mpeg
VIDEO_FORMAT=PAL dvdauthor -t -o ./dvd output.mpeg
VIDEO_FORMAT=PAL dvdauthor -T -o ./dvd output.mpeg 
genisoimage -o dvdvideo.iso -V A\ TEST -dvd-video dvd
cdemu load 0 dvdvideo.iso
```
you now have in /proc/mounts
`/dev/sr0 /media/prahal/A\040TEST udf ro,nosuid,nodev,relatime,uid=1000,gid=1000,iocharset=utf8 0 0
`
run kodi, select disk, and click on the eject button.

The code that crashes dates back to https://github.com/xbmc/xbmc/commit/8ef956e54199a7c57caf40cbfc76d09633fbc118 ie [20.0a1-Nexus](https://github.com/xbmc/xbmc/releases/tag/20.0a1-Nexus).


Another test is to insert a DVD that has a title with space in it in a DVD drive. Then try to eject it with kodi >= 20.0a1.


## What is the effect on users?
This fix prevents the user to have to restart kodi each times he tries to eject a DVD which titles has spaces from within kodi.

## Screenshots (if appropriate):

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
