### PR TITLE
[Windows] Avoids include <Windowsx.h>

### DIFF
--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -42,20 +42,18 @@
 #include <math.h>
 
 #include <Shlobj.h>
-#include <Windowsx.h>
 #include <dbt.h>
 
 HWND g_hWnd = nullptr;
-
-#ifdef IsMinimized
-#undef IsMinimized
-#endif
 
 #ifndef LODWORD
 #define LODWORD(longval) ((DWORD)((DWORDLONG)(longval)))
 #endif
 
 #define ROTATE_ANGLE_DEGREE(arg) GID_ROTATE_ANGLE_FROM_ARGUMENT(LODWORD(arg)) * 180 / M_PI
+
+#define GET_X_LPARAM(lp) ((int)(short)LOWORD(lp))
+#define GET_Y_LPARAM(lp) ((int)(short)HIWORD(lp))
 
 /* Masks for processing the windows KEYDOWN and KEYUP messages */
 #define REPEATED_KEYMASK  (1<<30)

--- a/xbmc/windowing/windows/WinSystemWin32.h
+++ b/xbmc/windowing/windows/WinSystemWin32.h
@@ -69,10 +69,6 @@ struct MONITOR_DETAILS
   std::wstring DeviceNameW;
 };
 
-#ifdef IsMinimized
-#undef IsMinimized
-#endif
-
 class CIRServerSuite;
 
 class CWinSystemWin32 : public CWinSystemBase


### PR DESCRIPTION
## Description
Avoids include `<Windowsx.h>`

## Motivation and context
See https://github.com/xbmc/xbmc/pull/21893#discussion_r977835724

Anyway no worth include it because only is used for definition of `GET_X_LPARAM`, `GET_Y_LPARAM`

## How has this been tested?
Build Windows x64

## What is the effect on users?
Nothing

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
