### PR TITLE
[discs][bluray] Handle BD_EVENT_DISCONTINUITY

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -487,6 +487,11 @@ void CDVDInputStreamBluray::ProcessEvent() {
       m_player->OnDiscNavResult(static_cast<void*>(&pid), BD_EVENT_STILL);
     break;
 
+  case BD_EVENT_DISCONTINUITY:
+    CLog::Log(LOGDEBUG, "CDVDInputStreamBluray - BD_EVENT_DISCONTINUITY");
+    m_hold = HOLD_STILL;
+    break;
+
     /* playback position */
 
   case BD_EVENT_ANGLE:


### PR DESCRIPTION
## Description
Kodi was not handling this event which is resulting in different sorts of errors for some blurays when playback is started from the bluray menu (`m_navmode == true`). Namely it'd result in VP `NextStream()` to jump directly to the next stream (since the inputstream was not in a still state) and also would affect the global video timeline.
Confirmed fixed by the issue reporter.

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/21913

## How has this been tested?
With the sample provided in the bug report along with other samples.

## What is the effect on users?
Some blurays would jump to incorrect items when discontinuities occur, not the case anymore. 

## Screenshots (if appropriate):
**Sample old behavior:**
![image](https://user-images.githubusercontent.com/7375276/192161845-afc6fa0a-4d51-40d8-be16-b141085fd5a7.png)


**Sample new behavior:**
![image](https://user-images.githubusercontent.com/7375276/192161772-8d1c8679-5a35-445b-af0d-12afefffda1e.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

