### PR TITLE
Android: Add android class parameters

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -1521,7 +1521,8 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
                               pMsg->params.size() > 4 ? pMsg->params[4] : "",
                               pMsg->params.size() > 5 ? pMsg->params[5] : "",
                               pMsg->params.size() > 6 ? pMsg->params[6] : "",
-                              pMsg->params.size() > 7 ? pMsg->params[7] : "");
+                              pMsg->params.size() > 7 ? pMsg->params[7] : "",
+                              pMsg->params.size() > 8 ? pMsg->params[8] : "");
     }
 #endif
   }

--- a/xbmc/interfaces/builtins/AndroidBuiltins.cpp
+++ b/xbmc/interfaces/builtins/AndroidBuiltins.cpp
@@ -21,6 +21,7 @@
  *           params[5] = extras (optional)
  *           params[6] = action (optional)
  *           params[7] = category (optional)
+ *           params[8] = className (optional)
  */
 static int LaunchAndroidActivity(const std::vector<std::string>& params)
 {
@@ -42,21 +43,31 @@ static int LaunchAndroidActivity(const std::vector<std::string>& params)
 ///     Function,
 ///     Description }
 ///   \table_row2_l{
-///     <b>`StartAndroidActivity(package\,[intent\,dataType\,dataURI])`</b>
+///     <b>`StartAndroidActivity(package\,[intent\,dataType\,dataURI\,flags\,extras\,action\,category\,className])`</b>
 ///     ,
 ///     Launch an Android native app with the given package name. Optional parms
-///     (in order): intent\, dataType\, dataURI.
+///     (in order): intent\, dataType\, dataURI\, flags\, extras\, action\,
+///     category\, className.
 ///     @param[in] package
 ///     @param[in] intent (optional)
 ///     @param[in] datatype (optional)
 ///     @param[in] dataURI (optional)
+///     @param[in] flags (optional)
+///     @param[in] extras (optional)
+///     @param[in] action (optional)
+///     @param[in] category (optional)
+///     @param[in] className (optional)
+///     <p><hr>
+///     @skinning_v20 Added parameters `flags`\,`extras`\,`action`\,`category`\,`className`.
+///     <p>
 ///   }
 /// \table_end
 ///
 
 CBuiltins::CommandMap CAndroidBuiltins::GetOperations() const
 {
-  return {
-           {"startandroidactivity",    {"Launch an Android native app with the given package name.  Optional parms (in order): intent, dataType, dataURI.", 1, LaunchAndroidActivity}}
-         };
+  return {{"startandroidactivity",
+           {"Launch an Android native app with the given package name.  Optional parms (in order): "
+            "intent, dataType, dataURI, flags, extras, action, category, className.",
+            1, LaunchAndroidActivity}}};
 }

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -971,7 +971,7 @@ std::vector<androidPackage> CXBMCApp::GetApplications() const
   return m_applications;
 }
 
-// Note intent, dataType, dataURI, action, category, flags, extras all default to ""
+// Note intent, dataType, dataURI, action, category, flags, extras, className all default to ""
 bool CXBMCApp::StartActivity(const std::string& package,
                              const std::string& intent,
                              const std::string& dataType,
@@ -979,7 +979,8 @@ bool CXBMCApp::StartActivity(const std::string& package,
                              const std::string& flags,
                              const std::string& extras,
                              const std::string& action,
-                             const std::string& category)
+                             const std::string& category,
+                             const std::string& className)
 {
   CLog::LogF(LOGDEBUG, "package: {}", package);
   CLog::LogF(LOGDEBUG, "intent: {}", intent);
@@ -989,6 +990,7 @@ bool CXBMCApp::StartActivity(const std::string& package,
   CLog::LogF(LOGDEBUG, "extras: {}", extras);
   CLog::LogF(LOGDEBUG, "action: {}", action);
   CLog::LogF(LOGDEBUG, "category: {}", category);
+  CLog::LogF(LOGDEBUG, "className: {}", className);
 
   CJNIIntent newIntent = intent.empty() ?
     GetPackageManager().getLaunchIntentForPackage(package) :
@@ -1057,6 +1059,9 @@ bool CXBMCApp::StartActivity(const std::string& package,
   }
 
   newIntent.setPackage(package);
+  if (!className.empty())
+    newIntent.setClassName(package, className);
+
   startActivity(newIntent);
   if (xbmc_jnienv()->ExceptionCheck())
   {

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -166,7 +166,8 @@ public:
                             const std::string& flags = std::string(),
                             const std::string& extras = std::string(),
                             const std::string& action = std::string(),
-                            const std::string& category = std::string());
+                            const std::string& category = std::string(),
+                            const std::string& className = std::string());
   std::vector<androidPackage> GetApplications() const;
 
   /*!


### PR DESCRIPTION
## Description
Added an extra parameter for StartAndroidActivity to have full control over launching Android apps.

## Motivation and context
Iteration on #21883. Added extra parameter to also support different corner cases for launching Android apps.
Included updated documentation which was missing before.

## How has this been tested?
Code tests and local machine with android emulators.

## What is the effect on users?
Non-breaking. Just more options.

## Screenshots (if appropriate):
None

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
