### PR TITLE
[skintimers] use GUI interface for builtin execution and allow multiple builtin executions

### DIFF
--- a/xbmc/addons/gui/skin/SkinTimer.cpp
+++ b/xbmc/addons/gui/skin/SkinTimer.cpp
@@ -7,22 +7,21 @@
  */
 #include "SkinTimer.h"
 
-#include "interfaces/builtins/Builtins.h"
 #include "interfaces/info/Info.h"
 
 CSkinTimer::CSkinTimer(const std::string& name,
                        const INFO::InfoPtr& startCondition,
                        const INFO::InfoPtr& resetCondition,
                        const INFO::InfoPtr& stopCondition,
-                       const std::string& startAction,
-                       const std::string& stopAction,
+                       const CGUIAction& startActions,
+                       const CGUIAction& stopActions,
                        bool resetOnStart)
   : m_name{name},
     m_startCondition{startCondition},
     m_resetCondition{resetCondition},
     m_stopCondition{stopCondition},
-    m_startAction{startAction},
-    m_stopAction{stopAction},
+    m_startActions{startActions},
+    m_stopActions{stopActions},
     m_resetOnStart{resetOnStart}
 {
 }
@@ -83,16 +82,16 @@ INFO::InfoPtr CSkinTimer::GetStopCondition() const
 
 void CSkinTimer::OnStart()
 {
-  if (!m_startAction.empty())
+  if (m_startActions.HasAnyActions())
   {
-    CBuiltins::GetInstance().Execute(m_startAction);
+    m_startActions.ExecuteActions();
   }
 }
 
 void CSkinTimer::OnStop()
 {
-  if (!m_stopAction.empty())
+  if (m_stopActions.HasAnyActions())
   {
-    CBuiltins::GetInstance().Execute(m_stopAction);
+    m_stopActions.ExecuteActions();
   }
 }

--- a/xbmc/addons/gui/skin/SkinTimer.h
+++ b/xbmc/addons/gui/skin/SkinTimer.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "guilib/GUIAction.h"
 #include "interfaces/info/InfoExpression.h"
 #include "utils/Stopwatch.h"
 
@@ -28,16 +29,16 @@ public:
   * \param startCondition - the boolean info expression to start the timer (may be null)
   * \param resetCondition - the boolean info expression to reset the timer (may be null)
   * \param stopCondition - the boolean info expression to stop the timer (may be null)
-  * \param startAction - the builtin function to execute on timer start (may be empty)
-  * \param stopAction - the builtin function to execute on timer stop (may be empty)
+  * \param startActions - the builtin functions to execute on timer start (actions may be empty)
+  * \param stopActions - the builtin functions to execute on timer stop (actions may be empty)
   * \param resetOnStart - if the timer should be reset when started (i.e. start from zero if true or resumed if false)
   */
   CSkinTimer(const std::string& name,
              const INFO::InfoPtr& startCondition,
              const INFO::InfoPtr& resetCondition,
              const INFO::InfoPtr& stopCondition,
-             const std::string& startAction,
-             const std::string& stopAction,
+             const CGUIAction& startActions,
+             const CGUIAction& stopActions,
              bool resetOnStart);
 
   /*! \brief Default skin timer destructor */
@@ -100,10 +101,10 @@ private:
   INFO::InfoPtr m_resetCondition;
   /*! The info boolean expression that automatically stops the timer if evaluated true */
   INFO::InfoPtr m_stopCondition;
-  /*! The builtin function to be executed when the timer is started */
-  std::string m_startAction;
-  /*! The builtin function to be executed when the timer is stopped */
-  std::string m_stopAction;
+  /*! The builtin functions to be executed when the timer is started */
+  CGUIAction m_startActions;
+  /*! The builtin functions to be executed when the timer is stopped */
+  CGUIAction m_stopActions;
   /*! if the timer should be reset on start (or just resumed) */
   bool m_resetOnStart{false};
 };

--- a/xbmc/addons/gui/skin/SkinTimers.dox
+++ b/xbmc/addons/gui/skin/SkinTimers.dox
@@ -121,6 +121,22 @@ but have the timer resetting to 0 seconds if the user provides some input to Kod
 </timer>
 ~~~~~~~~~~~~~
 
+Finer conditional granularity can also be applied to the `onstop` or `onstart` actions. This allows the skinner to create generic timers which respect a 
+limited set of conditions but trigger different actions depending on a condition applied only to the action.
+The following timer plays the trailer of a given item when the user is in the videos window, the item has a trailer, the player is not playing and the
+global idle time is greater than 3 seconds.
+As you can see, the first action (notification) is triggered for any item. The actual playback, on the other hand, will only play if the focused
+item has the label "MyAwesomeMovie".
+
+~~~~~~~~~~~~~{.xml}
+<timer>
+    <name>trailer_autoplay_idle_timer</name>
+    <start reset="true">System.IdleTime(3) + Window.IsVisible(videos) + !Player.HasMedia + !String.IsEmpty(ListItem.Trailer)</start>
+    <onstart>Notification(skintimer try play, $INFO[ListItem.Trailer], 1000)</onstart>
+    <onstart condition="String.IsEqual(ListItem.Label,MyAwesomeMovie)">PlayMedia($INFO[ListItem.Trailer],1,noresume)</onstart>
+</timer>
+~~~~~~~~~~~~~
+
 --------------------------------------------------------------------------------
 \section Skin_Timers_sect3 Available tags
 
@@ -133,8 +149,11 @@ Skin timers have the following available tags:
 | start         | An info bool expression that the skinning engine should use to automatically start the timer <b>(optional)</b>
 | reset         | An info bool expression that the skinning engine should use to automatically reset the timer <b>(optional)</b>
 | stop          | An info bool expression that the skinning engine should use to automatically stop the timer <b>(optional)</b>
-| onstart       | A builtin function that the skinning engine should execute when the timer is started <b>(optional)</b>
-| onstop        | A builtin function that the skinning engine should execute when the timer is stopped <b>(optional)</b>
+| onstart       | A builtin function that the skinning engine should execute when the timer is started <b>(optional)</b><b>(can be repeated)</b>. Supports an additional `"condition"` as element attribute.
+| onstop        | A builtin function that the skinning engine should execute when the timer is stopped <b>(optional)</b><b>(can be repeated)</b>. Supports an additional `"condition"` as element attribute.
+
+@note If multiple onstart or onstop actions exist, their execution is triggered sequentially.
+@note Both onstart and onstop actions support fine-grained conditional granularity by specifying a "condition" attribute (see the examples above).
 
 --------------------------------------------------------------------------------
 \section Skin_Timers_sect4 See also

--- a/xbmc/guilib/GUIAction.cpp
+++ b/xbmc/guilib/GUIAction.cpp
@@ -14,6 +14,11 @@
 #include "ServiceBroker.h"
 #include "utils/StringUtils.h"
 
+namespace
+{
+constexpr int DEFAULT_CONTROL_ID = 0;
+}
+
 CGUIAction::CExecutableAction::CExecutableAction(const std::string& action) : m_action{action}
 {
 }
@@ -47,6 +52,11 @@ void CGUIAction::CExecutableAction::SetAction(const std::string& action)
 CGUIAction::CGUIAction(int controlID)
 {
   SetNavigation(controlID);
+}
+
+bool CGUIAction::ExecuteActions() const
+{
+  return ExecuteActions(DEFAULT_CONTROL_ID, DEFAULT_CONTROL_ID);
 }
 
 bool CGUIAction::ExecuteActions(int controlID, int parentID, const CGUIListItemPtr &item /* = NULL */) const

--- a/xbmc/guilib/GUIAction.h
+++ b/xbmc/guilib/GUIAction.h
@@ -76,7 +76,10 @@ public:
 
   CGUIAction() = default;
   explicit CGUIAction(int controlID);
-
+  /**
+   * Execute actions without specifying any target control or parent control. Action will use the default focused control.
+   */
+  bool ExecuteActions() const;
   /**
    * Execute actions (no navigation paths); if action is paired with condition - evaluate condition first
    */


### PR DESCRIPTION
## Description
Currently when skintimer's onstop/onstart builtin functions are executed they lack any GUI context. As such, actions that would otherwise run without any issues in other parts of the GUI code (e.g. those that require the expansion of GUI info/var expressions) would behave differently when triggered from skintimers. A good example is the use-case of playing the trailer of the item when in the video list, focusing an item, for some time:

```
<timer>
  <name>trailer_autoplay_idle_timer</name>
  <start reset="true">System.IdleTime(3) + Window.IsVisible(videos) + !Player.HasMedia + !String.IsEmpty(ListItem.Trailer)</start>
  <onstart>Notification(skintimer try play, $INFO[ListItem.Trailer], 1000)</onstart>
  <onstart>PlayMedia($INFO[ListItem.Trailer],1,noresume)</onstart>
</timer>
```

`<onstart>PlayMedia($INFO[ListItem.Trailer],1,noresume)</onstart>` would fail to play because it needs to get routed via GUI so that `$INFO[ListItem.Trailer]` is resolved first.

Furthermore, currently only one `onstop` or `onstart` actions are supported unlike other parts of the GUI component (namely windows) where multiple actions are triggered sequentially. The refactor provided in https://github.com/xbmc/xbmc/pull/21921 allow us to solve both cases.

Context for this was provided in the forums: https://forum.kodi.tv/showthread.php?tid=369593

## How has this been tested?
With the timer provided above. Also checked the timers we have in estuary (close video osd and close overlay). With the timer above it has been verified that when the condition is valid (first time we are in the video window and 3 seconds have elapsed, a notification is issued and the trailer starts playing in the background).

## What is the effect on users?
Some advanced use-cases (netflix-like trailer playback on idle) should now be possible to create. 

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/7375276/192734809-1c2027bb-954a-4cf4-a1cb-1809bde602d5.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
