### PR TITLE
[Android] All Files Access permission in Android TV

### DIFF
--- a/tools/android/packaging/xbmc/src/Splash.java.in
+++ b/tools/android/packaging/xbmc/src/Splash.java.in
@@ -142,7 +142,7 @@ public class Splash extends Activity
                   RECORDAUDIO_RESULT_CODE);
           break;
         case CheckingPermissions:
-          if ((Build.VERSION.SDK_INT >= 30) && !isAndroidTV())
+          if (Build.VERSION.SDK_INT >= 33 || (Build.VERSION.SDK_INT >= 30 && !isAndroidTV()))
           {
             try
             {
@@ -759,7 +759,7 @@ public class Splash extends Activity
   private boolean CheckPermissions()
   {
     boolean retVal = false;
-    if ((Build.VERSION.SDK_INT >= 30) && !isAndroidTV())
+    if (Build.VERSION.SDK_INT >= 33 || (Build.VERSION.SDK_INT >= 30 && !isAndroidTV()))
     {
       if (Environment.isExternalStorageManager())
       {


### PR DESCRIPTION
## Description
With the release of Android 13, the "All Files Access" special permission can now be requested and managed on Android TV devices (see [related commit](https://android.googlesource.com/platform/packages/apps/TvSettings/+/acf7e38c21ba835620ddca41872bb6b26f89e659)).

This PR adds the logic to request it from the user on Android TV 13 and beyond.

At the moment on Android TV 11 or 12 devices, it's possible to get similar behaviour by changing the "Files and media" permission manually to: Settings > Apps > Kodi > Permissions > Files and media > "Allow all the time" 
(credits to @CastagnaIT).

## How has this been tested?
Tested on AVD with Android Tiramisu Preview (Google TV)

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
