### PR TITLE
ApplicationVolumeHandling: move to ApplicationComponents

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -29,6 +29,7 @@
 #include "application/ApplicationPlayer.h"
 #include "application/ApplicationPowerHandling.h"
 #include "application/ApplicationSkinHandling.h"
+#include "application/ApplicationVolumeHandling.h"
 #include "cores/AudioEngine/Engines/ActiveAE/ActiveAE.h"
 #include "cores/IPlayer.h"
 #include "cores/playercorefactory/PlayerCoreFactory.h"
@@ -219,8 +220,7 @@ using namespace std::chrono_literals;
 #define MAX_FFWD_SPEED 5
 
 CApplication::CApplication(void)
-  : CApplicationPlayerCallback(m_stackHelper),
-    CApplicationSettingsHandling(static_cast<CApplicationVolumeHandling&>(*this))
+  : CApplicationPlayerCallback(m_stackHelper)
 #ifdef HAS_DVD_DRIVE
     ,
     m_Autorun(new CAutorun())
@@ -240,10 +240,12 @@ CApplication::CApplication(void)
   RegisterComponent(std::make_shared<CApplicationPlayer>());
   RegisterComponent(std::make_shared<CApplicationPowerHandling>());
   RegisterComponent(std::make_shared<CApplicationSkinHandling>(this, this, m_bInitializing));
+  RegisterComponent(std::make_shared<CApplicationVolumeHandling>());
 }
 
 CApplication::~CApplication(void)
 {
+  DeregisterComponent(typeid(CApplicationVolumeHandling));
   DeregisterComponent(typeid(CApplicationSkinHandling));
   DeregisterComponent(typeid(CApplicationPowerHandling));
   DeregisterComponent(typeid(CApplicationPlayer));
@@ -424,7 +426,7 @@ bool CApplication::Create()
   CServiceBroker::RegisterAE(m_pActiveAE.get());
 
   // initialize m_replayGainSettings
-  CacheReplayGainSettings(*settings);
+  GetComponent<CApplicationVolumeHandling>()->CacheReplayGainSettings(*settings);
 
   // load the keyboard layouts
   if (!keyboardLayoutManager->Load())
@@ -605,8 +607,12 @@ bool CApplication::Initialize()
 {
   m_pActiveAE->Start();
   // restore AE's previous volume state
-  SetHardwareVolume(m_volumeLevel);
-  CServiceBroker::GetActiveAE()->SetMute(m_muted);
+
+  const auto appVolume = GetComponent<CApplicationVolumeHandling>();
+  const auto level = appVolume->GetVolumeRatio();
+  const auto muted = appVolume->IsMuted();
+  appVolume->SetHardwareVolume(level);
+  CServiceBroker::GetActiveAE()->SetMute(muted);
 
 #if defined(HAS_DVD_DRIVE) && !defined(TARGET_WINDOWS) // somehow this throws an "unresolved external symbol" on win32
   // turn off cdio logging
@@ -1355,8 +1361,9 @@ bool CApplication::OnAction(const CAction &action)
 
   if (action.GetID() == ACTION_MUTE)
   {
-    ToggleMute();
-    ShowVolumeBar(&action);
+    const auto appVolume = GetComponent<CApplicationVolumeHandling>();
+    appVolume->ToggleMute();
+    appVolume->ShowVolumeBar(&action);
     return true;
   }
 
@@ -1377,11 +1384,12 @@ bool CApplication::OnAction(const CAction &action)
   // Check for global volume control
   if ((action.GetAmount() && (action.GetID() == ACTION_VOLUME_UP || action.GetID() == ACTION_VOLUME_DOWN)) || action.GetID() == ACTION_VOLUME_SET)
   {
+    const auto appVolume = GetComponent<CApplicationVolumeHandling>();
     if (!appPlayer->IsPassthrough())
     {
-      if (m_muted)
-        UnMute();
-      float volume = m_volumeLevel;
+      if (appVolume->IsMuted())
+        appVolume->UnMute();
+      float volume = appVolume->GetVolumeRatio();
       int volumesteps = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_AUDIOOUTPUT_VOLUMESTEPS);
       // sanity check
       if (volumesteps == 0)
@@ -1389,9 +1397,13 @@ bool CApplication::OnAction(const CAction &action)
 
 // Android has steps based on the max available volume level
 #if defined(TARGET_ANDROID)
-      float step = (VOLUME_MAXIMUM - VOLUME_MINIMUM) / CXBMCApp::GetMaxSystemVolume();
+      float step = (CApplicationVolumeHandling::VOLUME_MAXIMUM -
+                    CApplicationVolumeHandling::VOLUME_MINIMUM) /
+                   CXBMCApp::GetMaxSystemVolume();
 #else
-      float step   = (VOLUME_MAXIMUM - VOLUME_MINIMUM) / volumesteps;
+      float step = (CApplicationVolumeHandling::VOLUME_MAXIMUM -
+                    CApplicationVolumeHandling::VOLUME_MINIMUM) /
+                   volumesteps;
 
       if (action.GetRepeat())
         step *= action.GetRepeat() * 50; // 50 fps
@@ -1402,13 +1414,14 @@ bool CApplication::OnAction(const CAction &action)
         volume -= action.GetAmount() * action.GetAmount() * step;
       else
         volume = action.GetAmount() * step;
-      if (volume != m_volumeLevel)
-        SetVolume(volume, false);
+      if (volume != appVolume->GetVolumeRatio())
+        appVolume->SetVolume(volume, false);
     }
     // show visual feedback of volume or passthrough indicator
-    ShowVolumeBar(&action);
+    appVolume->ShowVolumeBar(&action);
     return true;
   }
+
   if (action.GetID() == ACTION_GUIPROFILE_BEGIN)
   {
     CGUIControlProfiler::Instance().SetOutputFile(CSpecialProtocol::TranslatePath("special://home/guiprofiler.xml"));
@@ -1510,7 +1523,7 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
   case TMSG_VOLUME_SHOW:
   {
     CAction action(pMsg->param1);
-    ShowVolumeBar(&action);
+    GetComponent<CApplicationVolumeHandling>()->ShowVolumeBar(&action);
   }
   break;
 
@@ -2514,9 +2527,10 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
       CLog::LogF(LOGDEBUG, "Ignored {} playback thread messages", dMsgCount);
   }
 
+  const auto appVolume = GetComponent<CApplicationVolumeHandling>();
   appPlayer->OpenFile(item, options, m_ServiceManager->GetPlayerCoreFactory(), player, *this);
-  appPlayer->SetVolume(m_volumeLevel);
-  appPlayer->SetMute(m_muted);
+  appPlayer->SetVolume(appVolume->GetVolumeRatio());
+  appPlayer->SetMute(appVolume->IsMuted());
 
 #if !defined(TARGET_POSIX)
   CGUIComponent *gui = CServiceBroker::GetGUI();
@@ -2654,8 +2668,10 @@ bool CApplication::OnMessage(CGUIMessage& message)
         CServiceBroker::GetGUI()->GetWindowManager().Delete(WINDOW_SPLASH);
 
         // show the volumebar if the volume is muted
-        if (IsMuted() || GetVolumeRatio() <= VOLUME_MINIMUM)
-          ShowVolumeBar();
+        const auto appVolume = GetComponent<CApplicationVolumeHandling>();
+        if (appVolume->IsMuted() ||
+            appVolume->GetVolumeRatio() <= CApplicationVolumeHandling::VOLUME_MINIMUM)
+          appVolume->ShowVolumeBar();
 
         if (!m_incompatibleAddons.empty())
         {

--- a/xbmc/application/Application.h
+++ b/xbmc/application/Application.h
@@ -13,7 +13,6 @@
 #include "application/ApplicationPlayerCallback.h"
 #include "application/ApplicationSettingsHandling.h"
 #include "application/ApplicationStackHelper.h"
-#include "application/ApplicationVolumeHandling.h"
 #include "guilib/IMsgTargetCallback.h"
 #include "guilib/IWindowManagerCallback.h"
 #include "messaging/IMessageTarget.h"
@@ -88,8 +87,7 @@ class CApplication : public IWindowManagerCallback,
                      public KODI::MESSAGING::IMessageTarget,
                      public CApplicationComponents,
                      public CApplicationPlayerCallback,
-                     public CApplicationSettingsHandling,
-                     public CApplicationVolumeHandling
+                     public CApplicationSettingsHandling
 {
 friend class CAppInboundProtocol;
 

--- a/xbmc/application/ApplicationSettingsHandling.cpp
+++ b/xbmc/application/ApplicationSettingsHandling.cpp
@@ -38,12 +38,6 @@ bool IsPlaying(const std::string& condition,
 }
 } // namespace
 
-CApplicationSettingsHandling::CApplicationSettingsHandling(
-    CApplicationVolumeHandling& volumeHandling)
-  : m_volumeHandling(volumeHandling)
-{
-}
-
 void CApplicationSettingsHandling::RegisterSettings()
 {
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
@@ -118,7 +112,8 @@ void CApplicationSettingsHandling::OnSettingChanged(const std::shared_ptr<const 
   if (appSkin->OnSettingChanged(*setting))
     return;
 
-  if (m_volumeHandling.OnSettingChanged(*setting))
+  const auto appVolume = components.GetComponent<CApplicationVolumeHandling>();
+  if (appVolume->OnSettingChanged(*setting))
     return;
 
   const auto appPower = components.GetComponent<CApplicationPowerHandling>();
@@ -205,10 +200,14 @@ bool CApplicationSettingsHandling::OnSettingUpdate(const std::shared_ptr<CSettin
 
 bool CApplicationSettingsHandling::Load(const TiXmlNode* settings)
 {
-  return m_volumeHandling.Load(settings);
+  auto& components = CServiceBroker::GetAppComponents();
+  const auto appVolume = components.GetComponent<CApplicationVolumeHandling>();
+  return appVolume->Load(settings);
 }
 
 bool CApplicationSettingsHandling::Save(TiXmlNode* settings) const
 {
-  return m_volumeHandling.Save(settings);
+  const auto& components = CServiceBroker::GetAppComponents();
+  const auto appVolume = components.GetComponent<CApplicationVolumeHandling>();
+  return appVolume->Save(settings);
 }

--- a/xbmc/application/ApplicationSettingsHandling.h
+++ b/xbmc/application/ApplicationSettingsHandling.h
@@ -12,8 +12,6 @@
 #include "settings/lib/ISettingCallback.h"
 #include "settings/lib/ISettingsHandler.h"
 
-class CApplicationVolumeHandling;
-
 /*!
  * \brief Class handling application support for settings.
  */
@@ -22,9 +20,6 @@ class CApplicationSettingsHandling : public ISettingCallback,
                                      public ISettingsHandler,
                                      public ISubSettings
 {
-public:
-  explicit CApplicationSettingsHandling(CApplicationVolumeHandling& volumeHandling);
-
 protected:
   void RegisterSettings();
   void UnregisterSettings();
@@ -36,6 +31,4 @@ protected:
   bool OnSettingUpdate(const std::shared_ptr<CSetting>& setting,
                        const char* oldSettingId,
                        const TiXmlNode* oldSettingNode) override;
-
-  CApplicationVolumeHandling& m_volumeHandling;
 };

--- a/xbmc/application/ApplicationVolumeHandling.h
+++ b/xbmc/application/ApplicationVolumeHandling.h
@@ -8,7 +8,10 @@
 
 #pragma once
 
+#include "application/IApplicationComponent.h"
+
 class CAction;
+class CApplication;
 class CSetting;
 class CSettings;
 class TiXmlNode;
@@ -16,8 +19,10 @@ class TiXmlNode;
 /*!
  * \brief Class handling application support for audio volume management.
  */
-class CApplicationVolumeHandling
+class CApplicationVolumeHandling : public IApplicationComponent
 {
+  friend class CApplication;
+
 public:
   // replay gain settings struct for quick access by the player multiple
   // times per second (saves doing settings lookup)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -8,7 +8,8 @@
 #include "AESinkPULSE.h"
 
 #include "ServiceBroker.h"
-#include "application/Application.h"
+#include "application/ApplicationComponents.h"
+#include "application/ApplicationVolumeHandling.h"
 #include "cores/AudioEngine/AESinkFactory.h"
 #include "threads/SingleLock.h"
 #include "utils/StringUtils.h"
@@ -1180,10 +1181,12 @@ void CAESinkPULSE::SetVolume(float volume)
        m_volume_needs_update = false;
        pa_volume_t n_vol = pa_cvolume_avg(&m_Volume);
        n_vol = std::min(n_vol, PA_VOLUME_NORM);
-       per_cent_volume = (float) n_vol / PA_VOLUME_NORM;
+       per_cent_volume = static_cast<float>(n_vol) / PA_VOLUME_NORM;
        // only update internal volume
        pa_threaded_mainloop_unlock(m_MainLoop);
-       g_application.SetVolume(per_cent_volume, false);
+       auto& components = CServiceBroker::GetAppComponents();
+       const auto appVolume = components.GetComponent<CApplicationVolumeHandling>();
+       appVolume->SetVolume(per_cent_volume, false);
        return;
     }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
@@ -26,6 +26,8 @@
 #include "Interface/DemuxPacket.h"
 #include "ServiceBroker.h"
 #include "application/Application.h"
+#include "application/ApplicationComponents.h"
+#include "application/ApplicationVolumeHandling.h"
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "guilib/GUIComponent.h"
@@ -882,10 +884,12 @@ unsigned int CDVDRadioRDSData::DecodeTA_TP(const uint8_t* msgElement)
   {
     CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(19021), g_localizeStrings.Get(29930));
     m_TA_TP_TrafficAdvisory = true;
-    m_TA_TP_TrafficVolume = g_application.GetVolumePercent();
+    auto& components = CServiceBroker::GetAppComponents();
+    const auto appVolume = components.GetComponent<CApplicationVolumeHandling>();
+    m_TA_TP_TrafficVolume = appVolume->GetVolumePercent();
     float trafAdvVol = (float)CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt("pvrplayback.trafficadvisoryvolume");
     if (trafAdvVol)
-      g_application.SetVolume(m_TA_TP_TrafficVolume+trafAdvVol);
+      appVolume->SetVolume(m_TA_TP_TrafficVolume + trafAdvVol);
 
     CVariant data(CVariant::VariantTypeObject);
     data["on"] = true;
@@ -895,7 +899,9 @@ unsigned int CDVDRadioRDSData::DecodeTA_TP(const uint8_t* msgElement)
   if (!traffic_announcement && m_TA_TP_TrafficAdvisory && CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool("pvrplayback.trafficadvisory"))
   {
     m_TA_TP_TrafficAdvisory = false;
-    g_application.SetVolume(m_TA_TP_TrafficVolume);
+    auto& components = CServiceBroker::GetAppComponents();
+    const auto appVolume = components.GetComponent<CApplicationVolumeHandling>();
+    appVolume->SetVolume(m_TA_TP_TrafficVolume);
 
     CVariant data(CVariant::VariantTypeObject);
     data["on"] = false;

--- a/xbmc/cores/paplayer/AudioDecoder.cpp
+++ b/xbmc/cores/paplayer/AudioDecoder.cpp
@@ -12,7 +12,8 @@
 #include "FileItem.h"
 #include "ICodec.h"
 #include "ServiceBroker.h"
-#include "application/Application.h"
+#include "application/ApplicationComponents.h"
+#include "application/ApplicationVolumeHandling.h"
 #include "music/tags/MusicInfoTag.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -345,7 +346,10 @@ bool CAudioDecoder::CanSeek()
 float CAudioDecoder::GetReplayGain(float &peakVal)
 {
 #define REPLAY_GAIN_DEFAULT_LEVEL 89.0f
-  const auto& replayGainSettings = g_application.GetReplayGainSettings();
+  auto& components = CServiceBroker::GetAppComponents();
+  const auto appVolume = components.GetComponent<CApplicationVolumeHandling>();
+
+  const auto& replayGainSettings = appVolume->GetReplayGainSettings();
   if (replayGainSettings.iType == ReplayGain::NONE)
     return 1.0f;
 

--- a/xbmc/dialogs/GUIDialogVolumeBar.cpp
+++ b/xbmc/dialogs/GUIDialogVolumeBar.cpp
@@ -9,7 +9,9 @@
 #include "GUIDialogVolumeBar.h"
 
 #include "IGUIVolumeBarCallback.h"
-#include "application/Application.h"
+#include "application/ApplicationComponents.h"
+#include "application/ApplicationVolumeHandling.h"
+#include "guilib/GUIMessage.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 
@@ -29,8 +31,10 @@ bool CGUIDialogVolumeBar::OnAction(const CAction &action)
 {
   if (action.GetID() == ACTION_VOLUME_UP || action.GetID() == ACTION_VOLUME_DOWN || action.GetID() == ACTION_VOLUME_SET || action.GetID() == ACTION_MUTE)
   {
-    if (g_application.IsMuted() ||
-        g_application.GetVolumeRatio() <= CApplicationVolumeHandling::VOLUME_MINIMUM)
+    const auto& components = CServiceBroker::GetAppComponents();
+    const auto appVolume = components.GetComponent<CApplicationVolumeHandling>();
+    if (appVolume->IsMuted() ||
+        appVolume->GetVolumeRatio() <= CApplicationVolumeHandling::VOLUME_MINIMUM)
     { // cancel the timer, dialog needs to stay visible
       CancelAutoClose();
     }
@@ -46,7 +50,7 @@ bool CGUIDialogVolumeBar::OnAction(const CAction &action)
 
 bool CGUIDialogVolumeBar::OnMessage(CGUIMessage& message)
 {
-  switch ( message.GetMessage() )
+  switch (message.GetMessage())
   {
   case GUI_MSG_WINDOW_INIT:
   case GUI_MSG_WINDOW_DEINIT:

--- a/xbmc/games/dialogs/osd/DialogGameVolume.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVolume.cpp
@@ -9,7 +9,8 @@
 #include "DialogGameVolume.h"
 
 #include "ServiceBroker.h"
-#include "application/Application.h"
+#include "application/ApplicationComponents.h"
+#include "application/ApplicationVolumeHandling.h"
 #include "dialogs/GUIDialogVolumeBar.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIDialog.h"
@@ -96,7 +97,9 @@ void CDialogGameVolume::OnSliderChange(void* data, CGUISliderControl* slider)
   if (std::fabs(volumePercent - m_volumePercent) > 0.1f)
   {
     m_volumePercent = volumePercent;
-    g_application.SetVolume(volumePercent, true);
+    auto& components = CServiceBroker::GetAppComponents();
+    const auto appVolume = components.GetComponent<CApplicationVolumeHandling>();
+    appVolume->SetVolume(volumePercent, true);
   }
 }
 
@@ -135,7 +138,9 @@ void CDialogGameVolume::OnStateChanged()
 
 float CDialogGameVolume::GetVolumePercent() const
 {
-  return g_application.GetVolumePercent();
+  const auto& components = CServiceBroker::GetAppComponents();
+  const auto appVolume = components.GetComponent<CApplicationVolumeHandling>();
+  return appVolume->GetVolumePercent();
 }
 
 std::string CDialogGameVolume::GetLabel()

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -16,6 +16,7 @@
 #include "application/Application.h"
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPlayer.h"
+#include "application/ApplicationVolumeHandling.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
 #include "cores/DataCacheCore.h"
 #include "cores/EdlEdit.h"
@@ -36,7 +37,8 @@
 using namespace KODI::GUILIB::GUIINFO;
 
 CPlayerGUIInfo::CPlayerGUIInfo()
-  : m_appPlayer(CServiceBroker::GetAppComponents().GetComponent<CApplicationPlayer>())
+  : m_appPlayer(CServiceBroker::GetAppComponents().GetComponent<CApplicationPlayer>()),
+    m_appVolume(CServiceBroker::GetAppComponents().GetComponent<CApplicationVolumeHandling>())
 {
 }
 
@@ -180,7 +182,7 @@ bool CPlayerGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
       return true;
     case PLAYER_VOLUME:
       value =
-          StringUtils::Format("{:2.1f} dB", CAEUtil::PercentToGain(g_application.GetVolumeRatio()));
+          StringUtils::Format("{:2.1f} dB", CAEUtil::PercentToGain(m_appVolume->GetVolumeRatio()));
       return true;
     case PLAYER_SUBTITLE_DELAY:
       value = StringUtils::Format("{:2.3f} s", m_appPlayer->GetVideoSettings().m_SubtitleDelay);
@@ -360,7 +362,7 @@ bool CPlayerGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int contextWi
     // PLAYER_*
     ///////////////////////////////////////////////////////////////////////////////////////////////
     case PLAYER_VOLUME:
-      value = static_cast<int>(g_application.GetVolumePercent());
+      value = static_cast<int>(m_appVolume->GetVolumePercent());
       return true;
     case PLAYER_PROGRESS:
       value = std::lrintf(g_application.GetPercentage());
@@ -409,8 +411,8 @@ bool CPlayerGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
       value = m_playerShowTime;
       return true;
     case PLAYER_MUTED:
-      value = (g_application.IsMuted() ||
-               g_application.GetVolumeRatio() <= CApplicationVolumeHandling::VOLUME_MINIMUM);
+      value = (m_appVolume->IsMuted() ||
+               m_appVolume->GetVolumeRatio() <= CApplicationVolumeHandling::VOLUME_MINIMUM);
       return true;
     case PLAYER_HAS_MEDIA:
       value = m_appPlayer->IsPlaying();

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.h
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.h
@@ -19,6 +19,7 @@
 #include <vector>
 
 class CApplicationPlayer;
+class CApplicationVolumeHandling;
 class CDataCacheCore;
 
 namespace KODI
@@ -83,6 +84,7 @@ private:
   std::atomic_bool m_playerShowTime{false};
   std::atomic_bool m_playerShowInfo{false};
   const std::shared_ptr<CApplicationPlayer> m_appPlayer;
+  const std::shared_ptr<CApplicationVolumeHandling> m_appVolume;
   CEventSource<PlayerShowInfoChangedEvent> m_events;
 };
 

--- a/xbmc/interfaces/builtins/ApplicationBuiltins.cpp
+++ b/xbmc/interfaces/builtins/ApplicationBuiltins.cpp
@@ -9,9 +9,9 @@
 #include "ApplicationBuiltins.h"
 
 #include "ServiceBroker.h"
-#include "application/Application.h"
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPowerHandling.h"
+#include "application/ApplicationVolumeHandling.h"
 #include "filesystem/ZipManager.h"
 #include "input/actions/ActionIDs.h"
 #include "interfaces/AnnouncementManager.h"
@@ -58,7 +58,9 @@ static int Extract(const std::vector<std::string>& params)
  */
 static int Mute(const std::vector<std::string>& params)
 {
-  g_application.ToggleMute();
+  auto& components = CServiceBroker::GetAppComponents();
+  const auto appVolume = components.GetComponent<CApplicationVolumeHandling>();
+  appVolume->ToggleMute();
 
   return 0;
 }
@@ -93,13 +95,15 @@ static int NotifyAll(const std::vector<std::string>& params)
  */
 static int SetVolume(const std::vector<std::string>& params)
 {
-  float oldVolume = g_application.GetVolumePercent();
-  float volume = (float)strtod(params[0].c_str(), nullptr);
+  auto& components = CServiceBroker::GetAppComponents();
+  const auto appVolume = components.GetComponent<CApplicationVolumeHandling>();
+  float oldVolume = appVolume->GetVolumePercent();
+  float volume = static_cast<float>(strtod(params[0].c_str(), nullptr));
 
-  g_application.SetVolume(volume);
-  if(oldVolume != volume)
+  appVolume->SetVolume(volume);
+  if (oldVolume != volume)
   {
-    if(params.size() > 1 && StringUtils::EqualsNoCase(params[1], "showVolumeBar"))
+    if (params.size() > 1 && StringUtils::EqualsNoCase(params[1], "showVolumeBar"))
     {
       CServiceBroker::GetAppMessenger()->PostMsg(
           TMSG_VOLUME_SHOW, oldVolume < volume ? ACTION_VOLUME_UP : ACTION_VOLUME_DOWN);

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -15,10 +15,10 @@
 #include "GUIInfoManager.h"
 #include "ServiceBroker.h"
 #include "URL.h"
-#include "application/Application.h"
 #include "application/ApplicationActionListeners.h"
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPlayer.h"
+#include "application/ApplicationVolumeHandling.h"
 #include "cores/VideoPlayer/DVDDemuxers/DVDDemuxBXA.h"
 #include "filesystem/File.h"
 #include "filesystem/PipeFile.h"
@@ -496,7 +496,11 @@ void  CAirTunesServer::AudioOutputFunctions::audio_set_volume(void *cls, void *s
   CAirPlayServer::backupVolume();
 #endif
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_SERVICES_AIRPLAYVOLUMECONTROL))
-    g_application.SetVolume(volPercent, false);//non-percent volume 0.0-1.0
+  {
+    auto& components = CServiceBroker::GetAppComponents();
+    const auto appVolume = components.GetComponent<CApplicationVolumeHandling>();
+    appVolume->SetVolume(volPercent, false); //non-percent volume 0.0-1.0
+  }
 }
 
 void  CAirTunesServer::AudioOutputFunctions::audio_process(void *cls, void *session, const void *buffer, int buflen)

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -20,6 +20,7 @@
 #include "application/Application.h"
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPlayer.h"
+#include "application/ApplicationVolumeHandling.h"
 #include "filesystem/SpecialProtocol.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
@@ -706,7 +707,9 @@ CUPnPRenderer::OnSetVolume(PLT_ActionReference& action)
 {
     NPT_String volume;
     NPT_CHECK_SEVERE(action->GetArgumentValue("DesiredVolume", volume));
-    g_application.SetVolume((float)strtod((const char*)volume, NULL));
+    auto& components = CServiceBroker::GetAppComponents();
+    const auto appVolume = components.GetComponent<CApplicationVolumeHandling>();
+    appVolume->SetVolume((float)strtod((const char*)volume, NULL));
     return NPT_SUCCESS;
 }
 
@@ -718,8 +721,10 @@ CUPnPRenderer::OnSetMute(PLT_ActionReference& action)
 {
     NPT_String mute;
     NPT_CHECK_SEVERE(action->GetArgumentValue("DesiredMute",mute));
-    if((mute == "1") ^ g_application.IsMuted())
-        g_application.ToggleMute();
+    auto& components = CServiceBroker::GetAppComponents();
+    const auto appVolume = components.GetComponent<CApplicationVolumeHandling>();
+    if ((mute == "1") ^ appVolume->IsMuted())
+      appVolume->ToggleMute();
     return NPT_SUCCESS;
 }
 

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -9,10 +9,11 @@
 #include "PeripheralCecAdapter.h"
 
 #include "ServiceBroker.h"
-#include "application/Application.h"
 #include "application/ApplicationComponents.h"
+#include "application/ApplicationEnums.h"
 #include "application/ApplicationPlayer.h"
 #include "application/ApplicationPowerHandling.h"
+#include "application/ApplicationVolumeHandling.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
@@ -1619,8 +1620,10 @@ std::string CPeripheralCecAdapterUpdateThread::UpdateAudioSystemStatus(void)
 
     // set amp present
     m_adapter->SetAudioSystemConnected(true);
-    g_application.SetMute(false);
-    g_application.SetVolume(CApplicationVolumeHandling::VOLUME_MAXIMUM, false);
+    auto& components = CServiceBroker::GetAppComponents();
+    const auto appVolume = components.GetComponent<CApplicationVolumeHandling>();
+    appVolume->SetMute(false);
+    appVolume->SetVolume(CApplicationVolumeHandling::VOLUME_MAXIMUM, false);
   }
   else
   {

--- a/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
@@ -11,12 +11,13 @@
 #include "GUIPassword.h"
 #include "ServiceBroker.h"
 #include "addons/Skin.h"
-#include "application/Application.h"
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPlayer.h"
+#include "application/ApplicationVolumeHandling.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
 #include "cores/IPlayer.h"
 #include "dialogs/GUIDialogYesNo.h"
+#include "guilib/GUIMessage.h"
 #include "guilib/LocalizeStrings.h"
 #include "profiles/ProfileManager.h"
 #include "settings/AdvancedSettings.h"
@@ -52,11 +53,12 @@ CGUIDialogAudioSettings::~CGUIDialogAudioSettings() = default;
 void CGUIDialogAudioSettings::FrameMove()
 {
   // update the volume setting if necessary
-  float newVolume = g_application.GetVolumeRatio();
+  const auto& components = CServiceBroker::GetAppComponents();
+  const auto appVolume = components.GetComponent<CApplicationVolumeHandling>();
+  float newVolume = appVolume->GetVolumeRatio();
   if (newVolume != m_volume)
     GetSettingsManager()->SetNumber(SETTING_AUDIO_VOLUME, static_cast<double>(newVolume));
 
-  const auto& components = CServiceBroker::GetAppComponents();
   const auto appPlayer = components.GetComponent<CApplicationPlayer>();
   if (appPlayer->HasPlayer())
   {
@@ -106,7 +108,8 @@ void CGUIDialogAudioSettings::OnSettingChanged(const std::shared_ptr<const CSett
   if (settingId == SETTING_AUDIO_VOLUME)
   {
     m_volume = static_cast<float>(std::static_pointer_cast<const CSettingNumber>(setting)->GetValue());
-    g_application.SetVolume(m_volume, false); // false - value is not in percent
+    const auto appVolume = components.GetComponent<CApplicationVolumeHandling>();
+    appVolume->SetVolume(m_volume, false); // false - value is not in percent
   }
   else if (settingId == SETTING_AUDIO_VOLUME_AMPLIFICATION)
   {
@@ -245,7 +248,8 @@ void CGUIDialogAudioSettings::InitializeSettings()
 
   // audio settings
   // audio volume setting
-  m_volume = g_application.GetVolumeRatio();
+  const auto appVolume = components.GetComponent<CApplicationVolumeHandling>();
+  m_volume = appVolume->GetVolumeRatio();
   std::shared_ptr<CSettingNumber> settingAudioVolume =
       AddSlider(groupAudio, SETTING_AUDIO_VOLUME, 13376, SettingLevel::Basic, m_volume, 14054,
                 CApplicationVolumeHandling::VOLUME_MINIMUM,


### PR DESCRIPTION
## Description
ApplicationVolumeHandling: move to ApplicationComponents

## Motivation and context
Split up the monothonic Application.h into pieces to avoid the hot header.

## How has this been tested?
It builds..

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

Sits on top of https://github.com/xbmc/xbmc/pull/21936
