### PR TITLE
[PVR] CPVRGUIActions refactor followup

### DIFF
--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -375,6 +375,12 @@ std::shared_ptr<CPVRChannel> CPVRPlaybackState::GetPlayingChannel() const
   return m_playingChannel ? m_playingChannel->Channel() : std::shared_ptr<CPVRChannel>();
 }
 
+std::shared_ptr<CPVRChannelGroupMember> CPVRPlaybackState::GetPlayingChannelGroupMember() const
+{
+  std::unique_lock<CCriticalSection> lock(m_critSection);
+  return m_playingChannel;
+}
+
 std::shared_ptr<CPVRRecording> CPVRPlaybackState::GetPlayingRecording() const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);

--- a/xbmc/pvr/PVRPlaybackState.h
+++ b/xbmc/pvr/PVRPlaybackState.h
@@ -138,6 +138,12 @@ public:
   std::shared_ptr<CPVRChannel> GetPlayingChannel() const;
 
   /*!
+   * @brief Return the channel group member that is currently playing.
+   * @return The channel group member or nullptr if none is playing.
+   */
+  std::shared_ptr<CPVRChannelGroupMember> GetPlayingChannelGroupMember() const;
+
+  /*!
    * @brief Return the recording that is currently playing.
    * @return The recording or nullptr if none is playing.
    */

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -25,7 +25,6 @@
 #include "pvr/epg/EpgContainer.h"
 #include "pvr/guilib/PVRGUIActionsChannels.h"
 #include "pvr/guilib/PVRGUIActionsPlayback.h"
-#include "pvr/guilib/PVRGUIActionsUtils.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 
@@ -90,7 +89,7 @@ void CGUIDialogPVRChannelsOSD::OnDeinitWindow(int nextWindowID)
 {
   if (m_group)
   {
-    CServiceBroker::GetPVRManager().Get<PVR::GUI::Utils>().SetSelectedItemPath(
+    CServiceBroker::GetPVRManager().Get<PVR::GUI::Channels>().SetSelectedChannelPath(
         m_group->IsRadio(), m_viewControl.GetSelectedItemPath());
 
     // next OnInitWindow will set the group which is then selected
@@ -193,7 +192,7 @@ void CGUIDialogPVRChannelsOSD::Update()
       {
         m_group = group;
         m_viewControl.SetSelectedItem(
-            pvrMgr.Get<PVR::GUI::Utils>().GetSelectedItemPath(channel->IsRadio()));
+            pvrMgr.Get<PVR::GUI::Channels>().GetSelectedChannelPath(channel->IsRadio()));
         SaveSelectedItemPath(group->GroupID());
       }
     }

--- a/xbmc/pvr/guilib/PVRGUIActionsChannels.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsChannels.h
@@ -11,6 +11,8 @@
 #include "pvr/IPVRComponent.h"
 #include "pvr/PVRChannelNumberInputHandler.h"
 #include "pvr/guilib/PVRGUIChannelNavigator.h"
+#include "pvr/settings/PVRSettings.h"
+#include "threads/CriticalSection.h"
 
 #include <memory>
 #include <string>
@@ -47,7 +49,7 @@ private:
 class CPVRGUIActionsChannels : public IPVRComponent
 {
 public:
-  CPVRGUIActionsChannels() = default;
+  CPVRGUIActionsChannels();
   virtual ~CPVRGUIActionsChannels() = default;
 
   /*!
@@ -116,6 +118,22 @@ public:
    */
   void OnPlaybackStopped(const std::shared_ptr<CFileItem>& item);
 
+  /*!
+   * @brief Get the currently selected channel item path; used across several windows/dialogs to
+   * share item selection.
+   * @param bRadio True to query the selected path for PVR radio, false for Live TV.
+   * @return the path.
+   */
+  std::string GetSelectedChannelPath(bool bRadio) const;
+
+  /*!
+   * @brief Set the currently selected channel item path; used across several windows/dialogs to
+   * share item selection.
+   * @param bRadio True to set the selected path for PVR radio, false for Live TV.
+   * @param path The new path to set.
+   */
+  void SetSelectedChannelPath(bool bRadio, const std::string& path);
+
 private:
   CPVRGUIActionsChannels(const CPVRGUIActionsChannels&) = delete;
   CPVRGUIActionsChannels const& operator=(CPVRGUIActionsChannels const&) = delete;
@@ -123,6 +141,11 @@ private:
   CPVRChannelSwitchingInputHandler m_channelNumberInputHandler;
   bool m_bChannelScanRunning{false};
   CPVRGUIChannelNavigator m_channelNavigator;
+
+  mutable CCriticalSection m_critSection;
+  CPVRSettings m_settings;
+  std::string m_selectedChannelPathTV;
+  std::string m_selectedChannelPathRadio;
 };
 
 namespace GUI

--- a/xbmc/pvr/guilib/PVRGUIActionsChannels.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsChannels.h
@@ -50,7 +50,7 @@ class CPVRGUIActionsChannels : public IPVRComponent
 {
 public:
   CPVRGUIActionsChannels();
-  virtual ~CPVRGUIActionsChannels() = default;
+  ~CPVRGUIActionsChannels() override = default;
 
   /*!
    * @brief Hide a channel, always showing a confirmation dialog.

--- a/xbmc/pvr/guilib/PVRGUIActionsClients.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsClients.h
@@ -16,7 +16,7 @@ class CPVRGUIActionsClients : public IPVRComponent
 {
 public:
   CPVRGUIActionsClients() = default;
-  virtual ~CPVRGUIActionsClients() = default;
+  ~CPVRGUIActionsClients() override = default;
 
   /*!
    * @brief Select and invoke client-specific settings actions

--- a/xbmc/pvr/guilib/PVRGUIActionsDatabase.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsDatabase.h
@@ -16,7 +16,7 @@ class CPVRGUIActionsDatabase : public IPVRComponent
 {
 public:
   CPVRGUIActionsDatabase() = default;
-  virtual ~CPVRGUIActionsDatabase() = default;
+  ~CPVRGUIActionsDatabase() override = default;
 
   /*!
    * @brief Reset the TV database to it's initial state and delete all the data.

--- a/xbmc/pvr/guilib/PVRGUIActionsEPG.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsEPG.h
@@ -20,7 +20,7 @@ class CPVRGUIActionsEPG : public IPVRComponent
 {
 public:
   CPVRGUIActionsEPG() = default;
-  virtual ~CPVRGUIActionsEPG() = default;
+  ~CPVRGUIActionsEPG() override = default;
 
   /*!
    * @brief Open a dialog with epg information for a given item.

--- a/xbmc/pvr/guilib/PVRGUIActionsParentalControl.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsParentalControl.h
@@ -28,7 +28,7 @@ class CPVRGUIActionsParentalControl : public IPVRComponent
 {
 public:
   CPVRGUIActionsParentalControl();
-  virtual ~CPVRGUIActionsParentalControl() = default;
+  ~CPVRGUIActionsParentalControl() override = default;
 
   /*!
    * @brief Check if channel is parental locked. Ask for PIN if necessary.

--- a/xbmc/pvr/guilib/PVRGUIActionsPlayback.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsPlayback.h
@@ -31,7 +31,7 @@ class CPVRGUIActionsPlayback : public IPVRComponent
 {
 public:
   CPVRGUIActionsPlayback();
-  virtual ~CPVRGUIActionsPlayback() = default;
+  ~CPVRGUIActionsPlayback() override = default;
 
   /*!
    * @brief Get a localized resume play label, if the given item can be resumed.

--- a/xbmc/pvr/guilib/PVRGUIActionsPowerManagement.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsPowerManagement.h
@@ -23,7 +23,7 @@ class CPVRGUIActionsPowerManagement : public IPVRComponent
 {
 public:
   CPVRGUIActionsPowerManagement();
-  virtual ~CPVRGUIActionsPowerManagement() = default;
+  ~CPVRGUIActionsPowerManagement() override = default;
 
   /*!
    * @brief Check whether the system Kodi is running on can be powered down

--- a/xbmc/pvr/guilib/PVRGUIActionsRecordings.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsRecordings.h
@@ -22,7 +22,7 @@ class CPVRGUIActionsRecordings : public IPVRComponent
 {
 public:
   CPVRGUIActionsRecordings() = default;
-  virtual ~CPVRGUIActionsRecordings() = default;
+  ~CPVRGUIActionsRecordings() override = default;
 
   /*!
    * @brief Open a dialog with information for a given recording.

--- a/xbmc/pvr/guilib/PVRGUIActionsTimers.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsTimers.h
@@ -24,7 +24,7 @@ class CPVRGUIActionsTimers : public IPVRComponent
 {
 public:
   CPVRGUIActionsTimers();
-  virtual ~CPVRGUIActionsTimers() = default;
+  ~CPVRGUIActionsTimers() override = default;
 
   /*!
    * @brief Open the timer settings dialog to create a new tv or radio timer.

--- a/xbmc/pvr/guilib/PVRGUIActionsUtils.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsUtils.cpp
@@ -10,64 +10,12 @@
 
 #include "FileItem.h"
 #include "ServiceBroker.h"
-#include "pvr/PVRItem.h"
 #include "pvr/PVRManager.h"
-#include "pvr/PVRPlaybackState.h"
-#include "pvr/channels/PVRChannel.h"
-#include "pvr/channels/PVRChannelGroupMember.h"
-#include "pvr/channels/PVRChannelGroupsContainer.h"
-#include "pvr/epg/EpgInfoTag.h"
-#include "pvr/guilib/PVRGUIActionsChannels.h"
 #include "pvr/guilib/PVRGUIActionsEPG.h"
 #include "pvr/guilib/PVRGUIActionsRecordings.h"
-#include "settings/Settings.h"
-
-#include <memory>
-#include <mutex>
-#include <string>
 
 namespace PVR
 {
-CPVRGUIActionsUtils::CPVRGUIActionsUtils()
-  : m_settings({CSettings::SETTING_PVRMANAGER_PRESELECTPLAYINGCHANNEL})
-{
-}
-
-void CPVRGUIActionsUtils::SetSelectedItemPath(bool bRadio, const std::string& path)
-{
-  std::unique_lock<CCriticalSection> lock(m_critSection);
-  if (bRadio)
-    m_selectedItemPathRadio = path;
-  else
-    m_selectedItemPathTV = path;
-}
-
-std::string CPVRGUIActionsUtils::GetSelectedItemPath(bool bRadio) const
-{
-  if (m_settings.GetBoolValue(CSettings::SETTING_PVRMANAGER_PRESELECTPLAYINGCHANNEL))
-  {
-    CPVRManager& mgr = CServiceBroker::GetPVRManager();
-
-    // if preselect playing channel is activated, return the path of the playing channel, if any.
-    const std::shared_ptr<CPVRChannelGroupMember> playingChannel =
-        mgr.PlaybackState()->GetPlayingChannelGroupMember();
-    if (playingChannel && playingChannel->IsRadio() == bRadio)
-      return playingChannel->Path();
-
-    const std::shared_ptr<CPVREpgInfoTag> playingTag = mgr.PlaybackState()->GetPlayingEpgTag();
-    if (playingTag && playingTag->IsRadio() == bRadio)
-    {
-      const std::shared_ptr<CPVRChannel> channel =
-          mgr.ChannelGroups()->GetChannelForEpgTag(playingTag);
-      if (channel)
-        return mgr.Get<PVR::GUI::Channels>().GetChannelGroupMember(channel)->Path();
-    }
-  }
-
-  std::unique_lock<CCriticalSection> lock(m_critSection);
-  return bRadio ? m_selectedItemPathRadio : m_selectedItemPathTV;
-}
-
 bool CPVRGUIActionsUtils::OnInfo(const std::shared_ptr<CFileItem>& item)
 {
   if (item->HasPVRRecordingInfoTag())

--- a/xbmc/pvr/guilib/PVRGUIActionsUtils.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsUtils.cpp
@@ -49,9 +49,10 @@ std::string CPVRGUIActionsUtils::GetSelectedItemPath(bool bRadio) const
     CPVRManager& mgr = CServiceBroker::GetPVRManager();
 
     // if preselect playing channel is activated, return the path of the playing channel, if any.
-    const std::shared_ptr<CPVRChannel> playingChannel = mgr.PlaybackState()->GetPlayingChannel();
+    const std::shared_ptr<CPVRChannelGroupMember> playingChannel =
+        mgr.PlaybackState()->GetPlayingChannelGroupMember();
     if (playingChannel && playingChannel->IsRadio() == bRadio)
-      return mgr.Get<PVR::GUI::Channels>().GetChannelGroupMember(playingChannel)->Path();
+      return playingChannel->Path();
 
     const std::shared_ptr<CPVREpgInfoTag> playingTag = mgr.PlaybackState()->GetPlayingEpgTag();
     if (playingTag && playingTag->IsRadio() == bRadio)

--- a/xbmc/pvr/guilib/PVRGUIActionsUtils.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsUtils.h
@@ -20,7 +20,7 @@ class CPVRGUIActionsUtils : public IPVRComponent
 {
 public:
   CPVRGUIActionsUtils() = default;
-  virtual ~CPVRGUIActionsUtils() = default;
+  ~CPVRGUIActionsUtils() override = default;
 
   /*!
      * @brief Process info action for the given item.

--- a/xbmc/pvr/guilib/PVRGUIActionsUtils.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsUtils.h
@@ -9,11 +9,8 @@
 #pragma once
 
 #include "pvr/IPVRComponent.h"
-#include "pvr/settings/PVRSettings.h"
-#include "threads/CriticalSection.h"
 
 #include <memory>
-#include <string>
 
 class CFileItem;
 
@@ -22,24 +19,8 @@ namespace PVR
 class CPVRGUIActionsUtils : public IPVRComponent
 {
 public:
-  CPVRGUIActionsUtils();
+  CPVRGUIActionsUtils() = default;
   virtual ~CPVRGUIActionsUtils() = default;
-
-  /*!
-     * @brief Get the currently selected item path; used across several windows/dialogs to share
-     * item selection.
-     * @param bRadio True to query the selected path for PVR radio, false for Live TV.
-     * @return the path.
-     */
-  std::string GetSelectedItemPath(bool bRadio) const;
-
-  /*!
-     * @brief Set the currently selected item path; used across several windows/dialogs to share
-     * item selection.
-     * @param bRadio True to set the selected path for PVR radio, false for Live TV.
-     * @param path The new path to set.
-     */
-  void SetSelectedItemPath(bool bRadio, const std::string& path);
 
   /*!
      * @brief Process info action for the given item.
@@ -50,11 +31,6 @@ public:
 private:
   CPVRGUIActionsUtils(const CPVRGUIActionsUtils&) = delete;
   CPVRGUIActionsUtils const& operator=(CPVRGUIActionsUtils const&) = delete;
-
-  mutable CCriticalSection m_critSection;
-  CPVRSettings m_settings;
-  std::string m_selectedItemPathTV;
-  std::string m_selectedItemPathRadio;
 };
 
 namespace GUI

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -28,7 +28,7 @@
 #include "pvr/channels/PVRChannelGroups.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/filesystem/PVRGUIDirectory.h"
-#include "pvr/guilib/PVRGUIActionsUtils.h"
+#include "pvr/guilib/PVRGUIActionsChannels.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
 
@@ -144,7 +144,7 @@ CGUIWindowPVRBase::~CGUIWindowPVRBase()
 
 void CGUIWindowPVRBase::UpdateSelectedItemPath()
 {
-  CServiceBroker::GetPVRManager().Get<PVR::GUI::Utils>().SetSelectedItemPath(
+  CServiceBroker::GetPVRManager().Get<PVR::GUI::Channels>().SetSelectedChannelPath(
       m_bRadio, m_viewControl.GetSelectedItemPath());
 }
 
@@ -290,7 +290,7 @@ void CGUIWindowPVRBase::OnInitWindow()
 
     // mark item as selected by channel path
     m_viewControl.SetSelectedItem(
-        CServiceBroker::GetPVRManager().Get<PVR::GUI::Utils>().GetSelectedItemPath(m_bRadio));
+        CServiceBroker::GetPVRManager().Get<PVR::GUI::Channels>().GetSelectedChannelPath(m_bRadio));
 
     // This has to be done after base class OnInitWindow to restore correct selection
     m_channelGroupsSelector->SelectChannelGroup(GetChannelGroup());

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -38,7 +38,6 @@
 #include "pvr/guilib/PVRGUIActionsEPG.h"
 #include "pvr/guilib/PVRGUIActionsPlayback.h"
 #include "pvr/guilib/PVRGUIActionsTimers.h"
-#include "pvr/guilib/PVRGUIActionsUtils.h"
 #include "pvr/recordings/PVRRecordings.h"
 #include "pvr/timers/PVRTimers.h"
 #include "settings/Settings.h"
@@ -79,8 +78,8 @@ void CGUIWindowPVRGuideBase::InitEpgGridControl()
   {
     CPVRManager& mgr = CServiceBroker::GetPVRManager();
 
-    const std::shared_ptr<CPVRChannel> channel =
-        mgr.ChannelGroups()->GetByPath(mgr.Get<PVR::GUI::Utils>().GetSelectedItemPath(m_bRadio));
+    const std::shared_ptr<CPVRChannel> channel = mgr.ChannelGroups()->GetByPath(
+        mgr.Get<PVR::GUI::Channels>().GetSelectedChannelPath(m_bRadio));
 
     if (channel)
     {
@@ -198,7 +197,7 @@ void CGUIWindowPVRGuideBase::UpdateSelectedItemPath()
     const std::shared_ptr<CPVRChannelGroupMember> groupMember =
         epgGridContainer->GetSelectedChannelGroupMember();
     if (groupMember)
-      CServiceBroker::GetPVRManager().Get<PVR::GUI::Utils>().SetSelectedItemPath(
+      CServiceBroker::GetPVRManager().Get<PVR::GUI::Channels>().SetSelectedChannelPath(
           m_bRadio, groupMember->Path());
   }
 }
@@ -229,7 +228,8 @@ bool CGUIWindowPVRGuideBase::Update(const std::string& strDirectory, bool update
     CGUIEPGGridContainer* epgGridContainer = GetGridControl();
     if (epgGridContainer)
       m_bChannelSelectionRestored = epgGridContainer->SetChannel(
-          CServiceBroker::GetPVRManager().Get<PVR::GUI::Utils>().GetSelectedItemPath(m_bRadio));
+          CServiceBroker::GetPVRManager().Get<PVR::GUI::Channels>().GetSelectedChannelPath(
+              m_bRadio));
   }
 
   return bReturn;


### PR DESCRIPTION
Nothing serious, just couple of things I noticed after merging the original PR:

1. Small runtime-optimization in `CPVRGUIActionsUtils::GetSelectedItemPath`
2. There was a circular dependency between `CPVRGUIACtionsChannels`and `CPVRGUIActionsUtils` - oops. Now, `Channels` does not use `Utils`anymore and vice versa.
3. CPVRGUIActions* dtors should be marked `override` since base class is `IPVRComponent` which introduces a virtual dtor

Runtime-tested on macOS and Android, latest Kodi master

@phunkyfish  when you find some time for a review...