### PR TITLE
Forward Setting Changes to ApplicationVolumeHandling class

### DIFF
--- a/xbmc/application/ApplicationSettingsHandling.cpp
+++ b/xbmc/application/ApplicationSettingsHandling.cpp
@@ -117,7 +117,7 @@ void CApplicationSettingsHandling::OnSettingChanged(const std::shared_ptr<const 
   if (m_powerHandling.OnSettingChanged(*setting))
     return;
 
-  if (m_powerHandling.OnSettingChanged(*setting))
+  if (m_volumeHandling.OnSettingChanged(*setting))
     return;
 
   const std::string& settingId = setting->GetId();


### PR DESCRIPTION
## Description
The OnSettingChanged callback needs to be forwarded to the volume handling class.

## Motivation and context
Fixes #21915

## How has this been tested?
1. Play a song that is tagged with both track gain and album gain
2. Change the ReplayGain mode
3. Play the same song again
4. Verify in the ReplayGain log statement that the setting change in step 2 took effect

## What is the effect on users?
Bug fix

## Screenshots (if appropriate):
N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
