### PR TITLE
ApplicationStackHelper: move to ApplicationComponents

### DIFF
--- a/xbmc/application/Application.h
+++ b/xbmc/application/Application.h
@@ -12,7 +12,6 @@
 #include "application/ApplicationEnums.h"
 #include "application/ApplicationPlayerCallback.h"
 #include "application/ApplicationSettingsHandling.h"
-#include "application/ApplicationStackHelper.h"
 #include "guilib/IMsgTargetCallback.h"
 #include "guilib/IWindowManagerCallback.h"
 #include "messaging/IMessageTarget.h"
@@ -121,7 +120,6 @@ public:
   const CFileItem& CurrentUnstackedItem();
   bool OnMessage(CGUIMessage& message) override;
   std::string GetCurrentPlayer();
-  const CApplicationStackHelper& GetAppStackHelper() const;
 
   int  GetMessageMask() override;
   void OnApplicationMessage(KODI::MESSAGING::ThreadMessage* pMsg) override;
@@ -252,7 +250,6 @@ private:
   std::atomic_uint m_WaitingExternalCalls;        /*!< counts threads which are waiting to be processed in FrameMove */
   unsigned int m_ProcessedExternalCalls = 0;      /*!< counts calls which are processed during one "door open" cycle in FrameMove */
   unsigned int m_ProcessedExternalDecay = 0;      /*!< counts to close door after a few frames of no python activity */
-  CApplicationStackHelper m_stackHelper;
   int m_ExitCode{EXITCODE_QUIT};
 };
 

--- a/xbmc/application/ApplicationPlayerCallback.h
+++ b/xbmc/application/ApplicationPlayerCallback.h
@@ -19,7 +19,7 @@ class CFileItem;
 class CApplicationPlayerCallback : public IPlayerCallback
 {
 public:
-  CApplicationPlayerCallback(CApplicationStackHelper& stackHelper);
+  CApplicationPlayerCallback();
 
   void OnPlayBackEnded() override;
   void OnPlayBackStarted(const CFileItem& file) override;
@@ -38,7 +38,6 @@ public:
   void StoreVideoSettings(const CFileItem& fileItem, const CVideoSettings& vs) override;
 
 protected:
-  CApplicationStackHelper& m_stackHelper; //!< Reference to application stack helper
   std::shared_ptr<CFileItem> m_itemCurrentFile; //!< Currently playing file
   CEvent m_playerEvent;
 };

--- a/xbmc/application/ApplicationStackHelper.h
+++ b/xbmc/application/ApplicationStackHelper.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "application/IApplicationComponent.h"
 #include "threads/CriticalSection.h"
 
 #include <map>
@@ -17,7 +18,7 @@
 class CFileItem;
 class CFileItemList;
 
-class CApplicationStackHelper
+class CApplicationStackHelper : public IApplicationComponent
 {
 public:
   CApplicationStackHelper(void);

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -16,6 +16,7 @@
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPlayer.h"
 #include "application/ApplicationPowerHandling.h"
+#include "application/ApplicationStackHelper.h"
 #include "cores/AudioEngine/Interfaces/AE.h"
 #include "dialogs/GUIDialogBusyNoCancel.h"
 #include "dialogs/GUIDialogKaiToast.h"
@@ -262,12 +263,13 @@ void CPowerManager::StorePlayerState()
     // set the actual offset instead of store and load it from database
     m_lastPlayedFileItem->SetStartOffset(appPlayer->GetTime());
     // in case of regular stack, correct the start offset by adding current part start time
-    if (g_application.GetAppStackHelper().IsPlayingRegularStack())
-      m_lastPlayedFileItem->SetStartOffset(
-          m_lastPlayedFileItem->GetStartOffset() +
-          g_application.GetAppStackHelper().GetCurrentStackPartStartTimeMs());
+    const auto stackHelper = components.GetComponent<CApplicationStackHelper>();
+    if (stackHelper->IsPlayingRegularStack())
+      m_lastPlayedFileItem->SetStartOffset(m_lastPlayedFileItem->GetStartOffset() +
+                                           stackHelper->GetCurrentStackPartStartTimeMs());
     // in case of iso stack, keep track of part number
-    m_lastPlayedFileItem->m_lStartPartNumber = g_application.GetAppStackHelper().IsPlayingISOStack() ? g_application.GetAppStackHelper().GetCurrentPartNumber() + 1 : 1;
+    m_lastPlayedFileItem->m_lStartPartNumber =
+        stackHelper->IsPlayingISOStack() ? stackHelper->GetCurrentPartNumber() + 1 : 1;
     // for iso and iso stacks, keep track of playerstate
     m_lastPlayedFileItem->SetProperty("savedplayerstate", appPlayer->GetPlayerState());
     CLog::Log(LOGDEBUG,

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -15,7 +15,8 @@
 #include "URIUtils.h"
 #include "URL.h"
 #include "Util.h"
-#include "application/Application.h"
+#include "application/ApplicationComponents.h"
+#include "application/ApplicationStackHelper.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
@@ -165,9 +166,10 @@ void CSaveFileState::DoWork(CFileItem& item,
 
           // Could be part of an ISO stack. In this case the bookmark is saved onto the part.
           // In order to properly update the list, we need to refresh the stack's resume point
-          const CApplicationStackHelper& stackHelper = g_application.GetAppStackHelper();
-          if (stackHelper.HasRegisteredStack(item) &&
-              stackHelper.GetRegisteredStackTotalTimeMs(item) == 0)
+          const auto& components = CServiceBroker::GetAppComponents();
+          const auto stackHelper = components.GetComponent<CApplicationStackHelper>();
+          if (stackHelper->HasRegisteredStack(item) &&
+              stackHelper->GetRegisteredStackTotalTimeMs(item) == 0)
             videodatabase.GetResumePoint(*(msgItem->GetVideoInfoTag()));
 
           CGUIMessage message(GUI_MSG_NOTIFY_ALL, CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow(), 0, GUI_MSG_UPDATE_ITEM, 0, msgItem);


### PR DESCRIPTION
## Description
ApplicationStackHelper: move to ApplicationComponents

## Motivation and context
Split up the monothonic Application.h into pieces to avoid the hot header.

## How has this been tested?
It builds

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

Sits on top of https://github.com/xbmc/xbmc/pull/21938