### PR TITLE
[Estuary] Rework PVR Channelgroup Manager dialog layout.

### DIFF
--- a/addons/skin.estuary/xml/DialogPVRGroupManager.xml
+++ b/addons/skin.estuary/xml/DialogPVRGroupManager.xml
@@ -1,24 +1,143 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <window>
-	<defaultcontrol always="true">26</defaultcontrol>
+	<defaultcontrol always="true">29</defaultcontrol>
 	<include>Animation_DialogPopupOpenClose</include>
 	<controls>
 		<control type="group">
 			<centertop>50%</centertop>
-			<height>880</height>
+			<height>995</height>
 			<centerleft>50%</centerleft>
-			<width>1720</width>
+			<width>1820</width>
 			<include content="DialogBackgroundCommons">
-				<param name="width" value="1720" />
-				<param name="height" value="880" />
+				<param name="width" value="1820" />
+				<param name="height" value="995" />
 				<param name="header_label" value="$VAR[PVRGroupMgrHeader]$INFO[Container(13).NumItems, (,)]" />
 				<param name="header_id" value="1" />
 			</include>
-			<control type="grouplist" id="9000">
+			<control type="group">
 				<left>0</left>
-				<top>50</top>
+				<top>80</top>
+				<control type="label">
+					<description>name label</description>
+					<left>0</left>
+					<top>0</top>
+					<width>440</width>
+					<height>70</height>
+					<label>$LOCALIZE[31089]: [COLOR white]$INFO[Container(13).NumItems][/COLOR]</label>
+					<align>center</align>
+					<aligny>center</aligny>
+					<textcolor>button_focus</textcolor>
+				</control>
+				<control type="image">
+					<left>0</left>
+					<top>55</top>
+					<width>440</width>
+					<height>855</height>
+					<texture border="40">buttons/dialogbutton-nofo.png</texture>
+				</control>
+				<control type="list" id="13">
+					<left>20</left>
+					<top>75</top>
+					<width>400</width>
+					<height>815</height>
+					<onup>13</onup>
+					<ondown>13</ondown>
+					<onleft>9000</onleft>
+					<onright>73</onright>
+					<pagecontrol>73</pagecontrol>
+					<scrolltime>200</scrolltime>
+					<itemlayout width="400" height="70">
+						<control type="label">
+							<left>20</left>
+							<right>70</right>
+							<height>70</height>
+							<aligny>center</aligny>
+							<font>font27</font>
+							<textcolor>grey</textcolor>
+							<label>$INFO[ListItem.Label]</label>
+						</control>
+						<control type="image">
+							<width>60</width>
+							<height>60</height>
+							<right>5</right>
+							<top>5</top>
+							<texture>$INFO[ListItem.Icon]</texture>
+							<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
+							<bordersize>2</bordersize>
+							<aspectratio>keep</aspectratio>
+						</control>
+					</itemlayout>
+					<focusedlayout width="400" height="70">
+						<control type="image">
+							<left>0</left>
+							<top>0</top>
+							<right>0</right>
+							<bottom>0</bottom>
+							<texture colordiffuse="button_focus">lists/focus.png</texture>
+							<visible>Control.HasFocus(13)</visible>
+						</control>
+						<control type="label">
+							<left>20</left>
+							<right>70</right>
+							<height>70</height>
+							<aligny>center</aligny>
+							<font>font27</font>
+							<label>$INFO[ListItem.Label]</label>
+							<scroll>true</scroll>
+						</control>
+						<control type="image">
+							<width>60</width>
+							<height>60</height>
+							<right>5</right>
+							<top>5</top>
+							<texture>$INFO[ListItem.Icon]</texture>
+							<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
+							<bordersize>2</bordersize>
+							<aspectratio>keep</aspectratio>
+						</control>
+					</focusedlayout>
+				</control>
+				<control type="scrollbar" id="73">
+					<left>420</left>
+					<top>75</top>
+					<width>12</width>
+					<height>815</height>
+					<onleft>13</onleft>
+					<onright>11</onright>
+					<ondown>73</ondown>
+					<onup>73</onup>
+					<orientation>vertical</orientation>
+				</control>
+			</control>
+			<control type="group">
+				<description>Channels list</description>
+				<left>440</left>
+				<top>80</top>
+				<include content="ChannelManagerList">
+					<param name="header_id" value="21" />
+					<param name="list_id" value="11" />
+					<param name="scrollbar_id" value="71" />
+					<param name="onright" value="12" />
+					<param name="onleft" value="73" />
+				</include>
+			</control>
+			<control type="group">
+				<description>Grouped Channels list</description>
+				<left>940</left>
+				<top>80</top>
+				<include content="ChannelManagerList">
+					<param name="header_id" value="22" />
+					<param name="list_id" value="12" />
+					<param name="scrollbar_id" value="72" />
+					<param name="onright" value="9000" />
+					<param name="onleft" value="71" />
+				</include>
+			</control>
+			<control type="grouplist" id="9000">
+				<left>1450</left>
+				<top>70</top>
 				<width>370</width>
-				<height>600</height>
+				<height>715</height>
 				<itemgap>-20</itemgap>
 				<align>center</align>
 				<orientation>vertical</orientation>
@@ -26,6 +145,13 @@
 				<onright>13</onright>
 				<onup>9000</onup>
 				<ondown>9000</ondown>
+				<control type="button" id="29">
+					<description>OK</description>
+					<width>370</width>
+					<include>SettingsItemCommon</include>
+					<font>font25_title</font>
+					<label>$LOCALIZE[186]</label>
+				</control>
 				<control type="button" id="26">
 					<description>Add Group</description>
 					<width>370</width>
@@ -72,142 +198,16 @@
 					<altlabel>$LOCALIZE[19173]</altlabel>
 					<usealttexture>!String.IsEmpty(Window.Property(IsRadio))</usealttexture>
 				</control>
-				<control type="button" id="29">
-					<description>OK</description>
-					<width>370</width>
-					<include>SettingsItemCommon</include>
-					<font>font25_title</font>
-					<label>$LOCALIZE[186]</label>
-				</control>
 			</control>
 			<control type="image">
-				<left>85</left>
-				<bottom>30</bottom>
-				<width>200</width>
+				<left>1450</left>
+				<bottom>50</bottom>
+				<width>370</width>
 				<height>200</height>
 				<texture>$INFO[Container(13).ListItem.Icon]</texture>
 				<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
 				<bordersize>2</bordersize>
 				<aspectratio>keep</aspectratio>
-			</control>
-			<control type="group">
-				<left>350</left>
-				<top>80</top>
-				<control type="label">
-					<description>name label</description>
-					<left>0</left>
-					<top>0</top>
-					<width>360</width>
-					<height>70</height>
-					<label>$LOCALIZE[31089]: [COLOR white]$INFO[Container(13).NumItems][/COLOR]</label>
-					<align>center</align>
-					<aligny>center</aligny>
-					<textcolor>button_focus</textcolor>
-				</control>
-				<control type="image">
-					<left>0</left>
-					<top>55</top>
-					<width>360</width>
-					<height>740</height>
-					<texture border="40">buttons/dialogbutton-nofo.png</texture>
-				</control>
-				<control type="list" id="13">
-					<left>20</left>
-					<top>75</top>
-					<width>320</width>
-					<height>700</height>
-					<onup>13</onup>
-					<ondown>13</ondown>
-					<onleft>9000</onleft>
-					<onright>73</onright>
-					<pagecontrol>73</pagecontrol>
-					<scrolltime>200</scrolltime>
-					<itemlayout width="320" height="70">
-						<control type="label">
-							<left>20</left>
-							<right>70</right>
-							<height>70</height>
-							<aligny>center</aligny>
-							<font>font27</font>
-							<textcolor>grey</textcolor>
-							<label>$INFO[ListItem.Label]</label>
-						</control>
-						<control type="image">
-							<width>60</width>
-							<height>60</height>
-							<right>5</right>
-							<top>5</top>
-							<texture>$INFO[ListItem.Icon]</texture>
-							<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
-							<bordersize>2</bordersize>
-							<aspectratio>keep</aspectratio>
-						</control>
-					</itemlayout>
-					<focusedlayout width="320" height="70">
-						<control type="image">
-							<left>0</left>
-							<top>0</top>
-							<right>0</right>
-							<bottom>0</bottom>
-							<texture colordiffuse="button_focus">lists/focus.png</texture>
-							<visible>Control.HasFocus(13)</visible>
-						</control>
-						<control type="label">
-							<left>20</left>
-							<right>70</right>
-							<height>70</height>
-							<aligny>center</aligny>
-							<font>font27</font>
-							<label>$INFO[ListItem.Label]</label>
-							<scroll>true</scroll>
-						</control>
-						<control type="image">
-							<width>60</width>
-							<height>60</height>
-							<right>5</right>
-							<top>5</top>
-							<texture>$INFO[ListItem.Icon]</texture>
-							<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
-							<bordersize>2</bordersize>
-							<aspectratio>keep</aspectratio>
-						</control>
-					</focusedlayout>
-				</control>
-				<control type="scrollbar" id="73">
-					<left>340</left>
-					<top>75</top>
-					<width>12</width>
-					<height>700</height>
-					<onleft>13</onleft>
-					<onright>11</onright>
-					<ondown>73</ondown>
-					<onup>73</onup>
-					<orientation>vertical</orientation>
-				</control>
-			</control>
-			<control type="group">
-				<description>Channels list</description>
-				<left>700</left>
-				<top>80</top>
-				<include content="ChannelManagerList">
-					<param name="header_id" value="21" />
-					<param name="list_id" value="11" />
-					<param name="scrollbar_id" value="71" />
-					<param name="onright" value="12" />
-					<param name="onleft" value="73" />
-				</include>
-			</control>
-			<control type="group">
-				<description>Grouped Channels list</description>
-				<left>1200</left>
-				<top>80</top>
-				<include content="ChannelManagerList">
-					<param name="header_id" value="22" />
-					<param name="list_id" value="12" />
-					<param name="scrollbar_id" value="72" />
-					<param name="onright" value="9000" />
-					<param name="onleft" value="71" />
-				</include>
 			</control>
 		</control>
 		<control type="label" id="20">

--- a/addons/skin.estuary/xml/Includes_PVR.xml
+++ b/addons/skin.estuary/xml/Includes_PVR.xml
@@ -186,14 +186,14 @@
 			<left>0</left>
 			<top>55</top>
 			<width>510</width>
-			<height>740</height>
+			<height>855</height>
 			<texture border="40">buttons/dialogbutton-nofo.png</texture>
 		</control>
 		<control type="list" id="$PARAM[list_id]">
 			<left>20</left>
 			<top>75</top>
 			<width>470</width>
-			<height>700</height>
+			<height>815</height>
 			<onup>$PARAM[list_id]</onup>
 			<ondown>$PARAM[list_id]</ondown>
 			<onleft>$PARAM[onleft]</onleft>
@@ -253,7 +253,7 @@
 			<left>495</left>
 			<top>75</top>
 			<width>12</width>
-			<height>700</height>
+			<height>815</height>
 			<onleft>$PARAM[list_id]</onleft>
 			<onright>$PARAM[onright]</onright>
 			<ondown>$PARAM[scrollbar_id]</ondown>


### PR DESCRIPTION
Some changes to the PVR channel group manager:
* Increase dialog dimensions so that it matches the dimensions of the PVR channel manager, increase lists heights and widths accordingly
* Put buttons on the right, where all (?) other dialogs have it
* Put the OK button as the first button
* Default select the OK button

Before:
![screenshot00005](https://user-images.githubusercontent.com/3226626/193402082-61b8bcf6-87c6-46d2-bbf6-1ecfdb1185b9.png)

After:
![screenshot00006](https://user-images.githubusercontent.com/3226626/193402086-73ccbe00-76a1-4711-a4e1-c9bd00e2ffdb.png)
