### PR TITLE
[Estuary] Rework channel number / name visualisation in PVR OSD

### DIFF
--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -292,14 +292,21 @@
 			<height>380</height>
 			<control type="label">
 				<left>20</left>
+				<width>80%</width>
+				<top>-200</top>
+				<height>25</height>
+				<label>$INFO[VideoPlayer.ChannelName]</label>
+				<shadowcolor>text_shadow</shadowcolor>
+				<font>font45_title</font>
+			</control>
+			<control type="label">
+				<left>20</left>
 				<width>290</width>
-				<top>-80</top>
+				<top>-160</top>
 				<height>25</height>
 				<label>$INFO[VideoPlayer.ChannelNumberLabel]</label>
-				<shadowcolor>black</shadowcolor>
-				<align>center</align>
+				<shadowcolor>text_shadow</shadowcolor>
 				<font>WeatherTemp</font>
-				<aligny>center</aligny>
 			</control>
 			<control type="image">
 				<left>0</left>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -352,7 +352,7 @@
 		<value condition="VideoPlayer.Content(musicvideos)">$VAR[NowPlayingSublabelVar,,[CR]]$INFO[player.chapter,[COLOR button_focus]$LOCALIZE[21396]: [/COLOR]]$INFO[Player.ChapterCount,/]$INFO[Player.ChapterName, - ]</value>
 		<value condition="VideoPlayer.Content(episodes) + !player.chaptercount">$INFO[VideoPlayer.Season,[COLOR button_focus][CAPITALIZE]$LOCALIZE[36906][/CAPITALIZE]:[/COLOR] S]$INFO[VideoPlayer.Episode,E,: ]$INFO[VideoPlayer.Title]</value>
 		<value condition="VideoPlayer.Content(episodes) + player.chaptercount">$INFO[VideoPlayer.Season,[COLOR button_focus][CAPITALIZE]$LOCALIZE[36906][/CAPITALIZE]:[/COLOR] S]$INFO[VideoPlayer.Episode,E, - ]$INFO[VideoPlayer.Title,,[CR]]$INFO[player.chapter,[COLOR button_focus]$LOCALIZE[21396]:[/COLOR] ]$INFO[Player.ChapterCount,/]$INFO[Player.ChapterName, - ]</value>
-		<value condition="VideoPlayer.Content(LiveTV) | PVR.IsPlayingRecording | PVR.IsPlayingEpgTag">$INFO[VideoPlayer.ChannelNumberLabel,([COLOR button_focus],[/COLOR]) ]$INFO[VideoPlayer.ChannelName] $INFO[VideoPlayer.EpisodeName, - ]</value>
+		<value condition="VideoPlayer.Content(LiveTV) | PVR.IsPlayingRecording | PVR.IsPlayingEpgTag">$INFO[VideoPlayer.Season,[COLOR button_focus][CAPITALIZE]$LOCALIZE[36906][/CAPITALIZE]:[/COLOR] S]$INFO[VideoPlayer.Episode,E, - ]$INFO[VideoPlayer.EpisodeName]</value>
 		<value condition="player.chaptercount + [!VideoPlayer.Content(episodes) + !VideoPlayer.Content(LiveTV)]">$INFO[player.chapter,[COLOR button_focus]$LOCALIZE[21396]:[/COLOR] ]$INFO[Player.ChapterCount,/]$INFO[Player.ChapterName, - ]</value>
 		<value>$INFO[VideoPlayer.Genre]</value>
 	</variable>


### PR DESCRIPTION
Some changes to the Live TV OSD:
* Remove channel number from topbar - it was displayed twice
* Remove channel name from topbar - we now use the topbar as for other media - 1st line is title (season), second line is subtitle (episode)
* Add channel name on top of the channel number - for Live TV channel name and number are key information, so display it at a prominent place
* Add season and episode number to topbar's second line, before subtitle

Before:
![screenshot00002](https://user-images.githubusercontent.com/3226626/193402887-a7fce58f-f334-4fa2-ac18-b68b14951f87.png)

After:
![screenshot00001](https://user-images.githubusercontent.com/3226626/193402894-90dcdd68-0187-4a34-8170-38f1929586b0.png)


(And no, I will not add a skin setting to let users restore the old layout. ;-)