### PR TITLE
[Estuary] Add EPG event start and end time to PVR progress in channel preview mode

### DIFF
--- a/addons/skin.estuary/xml/Includes_PVR.xml
+++ b/addons/skin.estuary/xml/Includes_PVR.xml
@@ -338,6 +338,26 @@
 		<control type="group">
 			<animation effect="fade" time="400">VisibleChange</animation>
 			<visible>Player.ChannelPreviewActive</visible>
+			<control type="label">
+				<top>22</top>
+				<right>20</right>
+				<width>400</width>
+				<height>50</height>
+				<align>right</align>
+				<aligny>center</aligny>
+				<font>font13</font>
+				<label>$INFO[VideoPlayer.EndTime]</label>
+			</control>
+			<control type="label">
+				<top>22</top>
+				<left>20</left>
+				<width>400</width>
+				<height>50</height>
+				<align>left</align>
+				<aligny>center</aligny>
+				<font>font13</font>
+				<label>$INFO[VideoPlayer.StartTime]</label>
+			</control>
 			<control type="progress">
 				<left>0</left>
 				<top>70</top>


### PR DESCRIPTION
In channel non-preview mode, we display start and end time of the current programme, but for some unknown reason this was missing in channel preview mode.

You enter channel preview mode, when pushing up/down two or more times in fullscreen video / music visualisation while playing a channel, so that information for another than the currently playing channel is displayed in the OSD.

Before:
![screenshot00004](https://user-images.githubusercontent.com/3226626/193403236-b6e78a9b-536e-4321-aabc-985eb89b69b7.png)

After:
![screenshot00003](https://user-images.githubusercontent.com/3226626/193403246-e0f13202-7145-430d-8928-199470149ce7.png)
