### PR TITLE
Fileitem.h cleanups

### DIFF
--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -8,6 +8,7 @@
 
 #include "Autorun.h"
 
+#include "FileItem.h"
 #include "GUIPassword.h"
 #include "GUIUserMessages.h"
 #include "PlayListPlayer.h"

--- a/xbmc/ContextMenuItem.cpp
+++ b/xbmc/ContextMenuItem.cpp
@@ -7,10 +7,12 @@
  */
 
 #include "ContextMenuItem.h"
+
+#include "FileItem.h"
+#include "GUIInfoManager.h"
 #include "addons/AddonManager.h"
 #include "addons/ContextMenuAddon.h"
 #include "addons/IAddon.h"
-#include "GUIInfoManager.h"
 #include "guilib/GUIComponent.h"
 #ifdef HAS_PYTHON
 #include "interfaces/generic/ScriptInvocationManager.h"

--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -10,6 +10,7 @@
 
 #include "ContextMenuItem.h"
 #include "ContextMenus.h"
+#include "FileItem.h"
 #include "ServiceBroker.h"
 #include "addons/Addon.h"
 #include "addons/ContextMenuAddon.h"

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -8,6 +8,7 @@
 
 #include "PlayListPlayer.h"
 
+#include "FileItem.h"
 #include "GUIUserMessages.h"
 #include "PartyModeManager.h"
 #include "ServiceBroker.h"

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "AddonBuilder.h"
-#include "FileItem.h"
 #include "addons/Addon.h"
 #include "addons/addoninfo/AddonInfoBuilder.h"
 #include "dbwrappers/Database.h"

--- a/xbmc/addons/AudioDecoder.cpp
+++ b/xbmc/addons/AudioDecoder.cpp
@@ -7,6 +7,7 @@
 
 #include "AudioDecoder.h"
 
+#include "FileItem.h"
 #include "addons/interfaces/AudioEngine.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
 #include "filesystem/File.h"

--- a/xbmc/addons/ContextMenus.cpp
+++ b/xbmc/addons/ContextMenus.cpp
@@ -9,6 +9,7 @@
 #include "ContextMenus.h"
 
 #include "AddonManager.h"
+#include "FileItem.h"
 #include "Repository.h"
 #include "RepositoryUpdater.h"
 #include "ServiceBroker.h"
@@ -19,6 +20,11 @@ namespace CONTEXTMENU
 {
 
 using namespace ADDON;
+
+bool CAddonInfo::IsVisible(const CFileItem& item) const
+{
+  return item.HasAddonInfo();
+}
 
 bool CAddonSettings::IsVisible(const CFileItem& item) const
 {

--- a/xbmc/addons/ContextMenus.cpp
+++ b/xbmc/addons/ContextMenus.cpp
@@ -29,7 +29,7 @@ bool CAddonSettings::IsVisible(const CFileItem& item) const
          addon->CanHaveAddonOrInstanceSettings();
 }
 
-bool CAddonSettings::Execute(const CFileItemPtr& item) const
+bool CAddonSettings::Execute(const std::shared_ptr<CFileItem>& item) const
 {
   AddonPtr addon;
   return CServiceBroker::GetAddonMgr().GetAddon(item->GetAddonInfo()->ID(), addon, ADDON_UNKNOWN,
@@ -42,7 +42,7 @@ bool CCheckForUpdates::IsVisible(const CFileItem& item) const
   return item.HasAddonInfo() && item.GetAddonInfo()->Type() == ADDON::ADDON_REPOSITORY;
 }
 
-bool CCheckForUpdates::Execute(const CFileItemPtr& item) const
+bool CCheckForUpdates::Execute(const std::shared_ptr<CFileItem>& item) const
 {
   AddonPtr addon;
   if (item->HasAddonInfo() &&
@@ -63,7 +63,7 @@ bool CEnableAddon::IsVisible(const CFileItem& item) const
       CServiceBroker::GetAddonMgr().CanAddonBeEnabled(item.GetAddonInfo()->ID());
 }
 
-bool CEnableAddon::Execute(const CFileItemPtr& item) const
+bool CEnableAddon::Execute(const std::shared_ptr<CFileItem>& item) const
 {
   // Check user want to enable if lifecycle not normal
   if (!ADDON::GUI::CHelpers::DialogAddonLifecycleUseAsk(item->GetAddonInfo()))
@@ -79,7 +79,7 @@ bool CDisableAddon::IsVisible(const CFileItem& item) const
       CServiceBroker::GetAddonMgr().CanAddonBeDisabled(item.GetAddonInfo()->ID());
 }
 
-bool CDisableAddon::Execute(const CFileItemPtr& item) const
+bool CDisableAddon::Execute(const std::shared_ptr<CFileItem>& item) const
 {
   return CServiceBroker::GetAddonMgr().DisableAddon(item->GetAddonInfo()->ID(),
                                                     AddonDisabledReason::USER);

--- a/xbmc/addons/ContextMenus.h
+++ b/xbmc/addons/ContextMenus.h
@@ -9,8 +9,11 @@
 #pragma once
 
 #include "ContextMenuItem.h"
-#include "FileItem.h"
 #include "addons/gui/GUIDialogAddonInfo.h"
+
+#include <memory>
+
+class CFileItem;
 
 namespace CONTEXTMENU
 {
@@ -19,7 +22,7 @@ struct CAddonInfo : CStaticContextMenuAction
 {
   CAddonInfo() : CStaticContextMenuAction(19033) {}
   bool IsVisible(const CFileItem& item) const override { return item.HasAddonInfo(); }
-  bool Execute(const CFileItemPtr& item) const override
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override
   {
     return CGUIDialogAddonInfo::ShowForItem(item);
   }
@@ -29,27 +32,27 @@ struct CAddonSettings : CStaticContextMenuAction
 {
   CAddonSettings() : CStaticContextMenuAction(10004) {}
   bool IsVisible(const CFileItem& item) const override;
-  bool Execute(const CFileItemPtr& item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override;
 };
 
 struct CCheckForUpdates : CStaticContextMenuAction
 {
   CCheckForUpdates() : CStaticContextMenuAction(24034) {}
   bool IsVisible(const CFileItem& item) const override;
-  bool Execute(const CFileItemPtr& item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override;
 };
 
 struct CEnableAddon : CStaticContextMenuAction
 {
   CEnableAddon() : CStaticContextMenuAction(24022) {}
   bool IsVisible(const CFileItem& item) const override;
-  bool Execute(const CFileItemPtr& item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override;
 };
 
 struct CDisableAddon : CStaticContextMenuAction
 {
   CDisableAddon() : CStaticContextMenuAction(24021) {}
   bool IsVisible(const CFileItem& item) const override;
-  bool Execute(const CFileItemPtr& item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override;
 };
 }

--- a/xbmc/addons/ContextMenus.h
+++ b/xbmc/addons/ContextMenus.h
@@ -21,7 +21,7 @@ namespace CONTEXTMENU
 struct CAddonInfo : CStaticContextMenuAction
 {
   CAddonInfo() : CStaticContextMenuAction(19033) {}
-  bool IsVisible(const CFileItem& item) const override { return item.HasAddonInfo(); }
+  bool IsVisible(const CFileItem& item) const override;
   bool Execute(const std::shared_ptr<CFileItem>& item) const override
   {
     return CGUIDialogAddonInfo::ShowForItem(item);

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -7,7 +7,9 @@
  */
 
 #include "Skin.h"
+
 #include "AddonManager.h"
+#include "FileItem.h"
 #include "ServiceBroker.h"
 #include "Util.h"
 #include "dialogs/GUIDialogKaiToast.h"

--- a/xbmc/addons/VFSEntry.h
+++ b/xbmc/addons/VFSEntry.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "FileItem.h"
 #include "addons/binary-addons/AddonInstanceHandler.h"
 #include "addons/kodi-dev-kit/include/kodi/addon-instance/VFS.h"
 #include "filesystem/IDirectory.h"

--- a/xbmc/addons/addoninfo/AddonInfo.cpp
+++ b/xbmc/addons/addoninfo/AddonInfo.cpp
@@ -8,6 +8,7 @@
 
 #include "AddonInfo.h"
 
+#include "FileItem.h"
 #include "LangInfo.h"
 #include "ServiceBroker.h"
 #include "addons/AddonManager.h"

--- a/xbmc/addons/interfaces/Filesystem.cpp
+++ b/xbmc/addons/interfaces/Filesystem.cpp
@@ -8,6 +8,7 @@
 
 #include "Filesystem.h"
 
+#include "FileItem.h"
 #include "Util.h"
 #include "addons/binary-addons/AddonDll.h"
 #include "filesystem/CurlFile.h"

--- a/xbmc/application/Application.h
+++ b/xbmc/application/Application.h
@@ -53,6 +53,7 @@ namespace ADDON
   class CSkinInfo;
   class IAddon;
   typedef std::shared_ptr<IAddon> AddonPtr;
+  class CAddonInfo;
 }
 
 namespace ANNOUNCEMENT
@@ -253,7 +254,7 @@ protected:
 
   std::unique_ptr<CInertialScrollingHandler> m_pInertialScrollingHandler;
 
-  std::vector<ADDON::AddonInfoPtr>
+  std::vector<std::shared_ptr<ADDON::CAddonInfo>>
       m_incompatibleAddons; /*!< Result of addon migration (incompatible addon infos) */
 
 public:

--- a/xbmc/application/ApplicationPlayerCallback.cpp
+++ b/xbmc/application/ApplicationPlayerCallback.cpp
@@ -8,6 +8,7 @@
 
 #include "ApplicationPlayerCallback.h"
 
+#include "FileItem.h"
 #include "GUIUserMessages.h"
 #include "PlayListPlayer.h"
 #include "ServiceBroker.h"

--- a/xbmc/application/ApplicationPlayerCallback.h
+++ b/xbmc/application/ApplicationPlayerCallback.h
@@ -8,11 +8,13 @@
 
 #pragma once
 
-#include "FileItem.h"
 #include "cores/IPlayerCallback.h"
 #include "threads/Event.h"
 
+#include <memory>
+
 class CApplicationStackHelper;
+class CFileItem;
 
 class CApplicationPlayerCallback : public IPlayerCallback
 {
@@ -37,6 +39,6 @@ public:
 
 protected:
   CApplicationStackHelper& m_stackHelper; //!< Reference to application stack helper
-  CFileItemPtr m_itemCurrentFile; //!< Currently playing file
+  std::shared_ptr<CFileItem> m_itemCurrentFile; //!< Currently playing file
   CEvent m_playerEvent;
 };

--- a/xbmc/application/ApplicationSkinHandling.cpp
+++ b/xbmc/application/ApplicationSkinHandling.cpp
@@ -8,6 +8,7 @@
 
 #include "ApplicationSkinHandling.h"
 
+#include "FileItem.h"
 #include "GUIInfoManager.h"
 #include "GUILargeTextureManager.h"
 #include "GUIUserMessages.h"

--- a/xbmc/application/ApplicationStackHelper.cpp
+++ b/xbmc/application/ApplicationStackHelper.cpp
@@ -8,6 +8,7 @@
 
 #include "ApplicationStackHelper.h"
 
+#include "FileItem.h"
 #include "Util.h"
 #include "cores/VideoPlayer/DVDFileInfo.h"
 #include "filesystem/StackDirectory.h"

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.h
@@ -8,12 +8,11 @@
 
 #pragma once
 
-#include "FileItem.h"
-
 #include <memory>
 #include <string>
 #include <vector>
 
+class CFileItem;
 class CDVDInputStream;
 class IVideoPlayer;
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "DVDMessageQueue.h"
-#include "FileItem.h"
 #include "IVideoPlayer.h"
 #include "threads/Thread.h"
 #include "utils/Stopwatch.h"

--- a/xbmc/cores/paplayer/PAPlayer.h
+++ b/xbmc/cores/paplayer/PAPlayer.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "AudioDecoder.h"
-#include "FileItem.h"
 #include "cores/AudioEngine/Interfaces/AE.h"
 #include "cores/AudioEngine/Interfaces/IAudioCallback.h"
 #include "cores/IPlayer.h"
@@ -82,7 +81,7 @@ protected:
 private:
   struct StreamInfo
   {
-    CFileItem m_fileItem;
+    std::unique_ptr<CFileItem> m_fileItem;
     std::unique_ptr<CFileItem> m_nextFileItem;
     CAudioDecoder m_decoder;             /* the stream decoder */
     int64_t m_startOffset;               /* the stream start offset */

--- a/xbmc/cores/playercorefactory/PlayerSelectionRule.cpp
+++ b/xbmc/cores/playercorefactory/PlayerSelectionRule.cpp
@@ -8,6 +8,7 @@
 
 #include "PlayerSelectionRule.h"
 
+#include "FileItem.h"
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "settings/Settings.h"

--- a/xbmc/cores/playercorefactory/PlayerSelectionRule.h
+++ b/xbmc/cores/playercorefactory/PlayerSelectionRule.h
@@ -8,12 +8,12 @@
 
 #pragma once
 
-#include "FileItem.h"
 #include "PlayerCoreFactory.h"
 
 #include <string>
 #include <vector>
 
+class CFileItem;
 class CRegExp;
 class TiXmlElement;
 

--- a/xbmc/dialogs/GUIDialogPlayEject.h
+++ b/xbmc/dialogs/GUIDialogPlayEject.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "FileItem.h"
 #include "GUIDialogYesNo.h"
 
 class CGUIDialogPlayEject : public CGUIDialogYesNo

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -9,6 +9,7 @@
 
 #include "GUIDialogSimpleMenu.h"
 
+#include "FileItem.h"
 #include "GUIDialogSelect.h"
 #include "ServiceBroker.h"
 #include "URL.h"

--- a/xbmc/dialogs/GUIDialogSimpleMenu.h
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.h
@@ -8,10 +8,12 @@
 
 #pragma once
 
-#include "FileItem.h"
 #include "filesystem/Directory.h"
 
 #include <string>
+
+class CFileItem;
+class CFileItemList;
 
 class CGUIDialogSimpleMenu
 {

--- a/xbmc/events/EventLog.cpp
+++ b/xbmc/events/EventLog.cpp
@@ -8,6 +8,7 @@
 
 #include "EventLog.h"
 
+#include "FileItem.h"
 #include "GUIUserMessages.h"
 #include "ServiceBroker.h"
 #include "dialogs/GUIDialogKaiToast.h"

--- a/xbmc/favourites/ContextMenus.h
+++ b/xbmc/favourites/ContextMenus.h
@@ -10,6 +10,7 @@
 
 #include "ContextMenuItem.h"
 
+class CFileItemList;
 
 namespace CONTEXTMENU
 {

--- a/xbmc/filesystem/AddonsDirectory.h
+++ b/xbmc/filesystem/AddonsDirectory.h
@@ -11,6 +11,8 @@
 #include "IDirectory.h"
 #include "addons/AddonManager.h"
 
+class CFileItem;
+class CFileItemList;
 class CURL;
 typedef std::shared_ptr<CFileItem> CFileItemPtr;
 

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -12,6 +12,7 @@
 #include "LangInfo.h"
 #include "URL.h"
 #include "filesystem/BlurayCallback.h"
+#include "filesystem/Directory.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/LangCodeExpander.h"
 #include "utils/RegExp.h"
@@ -109,7 +110,8 @@ std::string CBlurayDirectory::GetDiscInfoString(DiscInfo info)
   return "";
 }
 
-CFileItemPtr CBlurayDirectory::GetTitle(const BLURAY_TITLE_INFO* title, const std::string& label)
+std::shared_ptr<CFileItem> CBlurayDirectory::GetTitle(const BLURAY_TITLE_INFO* title,
+                                                      const std::string& label)
 {
   std::string buf;
   std::string chap;

--- a/xbmc/filesystem/BlurayDirectory.h
+++ b/xbmc/filesystem/BlurayDirectory.h
@@ -8,9 +8,13 @@
 
 #pragma once
 
-#include "Directory.h"
-#include "FileItem.h"
+#include "IDirectory.h"
 #include "URL.h"
+
+#include <memory>
+
+class CFileItem;
+class CFileItemList;
 
 typedef struct bluray BLURAY;
 typedef struct bd_title_info BLURAY_TITLE_INFO;
@@ -18,7 +22,7 @@ typedef struct bd_title_info BLURAY_TITLE_INFO;
 namespace XFILE
 {
 
-class CBlurayDirectory: public XFILE::IDirectory
+class CBlurayDirectory : public IDirectory
 {
 public:
   CBlurayDirectory() = default;
@@ -41,7 +45,7 @@ private:
   void         GetRoot  (CFileItemList &items);
   void         GetTitles(bool main, CFileItemList &items);
   std::vector<BLURAY_TITLE_INFO*> GetUserPlaylists();
-  CFileItemPtr GetTitle(const BLURAY_TITLE_INFO* title, const std::string& label);
+  std::shared_ptr<CFileItem> GetTitle(const BLURAY_TITLE_INFO* title, const std::string& label);
   CURL         GetUnderlyingCURL(const CURL& url);
   std::string  HexToString(const uint8_t * buf, int count);
   CURL          m_url;

--- a/xbmc/filesystem/DAVDirectory.h
+++ b/xbmc/filesystem/DAVDirectory.h
@@ -8,9 +8,11 @@
 
 #pragma once
 
-#include "FileItem.h"
 #include "IDirectory.h"
-#include "utils/XBMCTinyXML.h"
+
+class CFileItem;
+class CFileItemList;
+class TiXmlElement;
 
 namespace XFILE
 {

--- a/xbmc/filesystem/EventsDirectory.cpp
+++ b/xbmc/filesystem/EventsDirectory.cpp
@@ -9,6 +9,7 @@
 
 #include "EventsDirectory.h"
 
+#include "FileItem.h"
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "events/EventLog.h"
@@ -52,7 +53,8 @@ bool CEventsDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   return true;
 }
 
-CFileItemPtr CEventsDirectory::EventToFileItem(const EventPtr& eventItem)
+std::shared_ptr<CFileItem> CEventsDirectory::EventToFileItem(
+    const std::shared_ptr<const IEvent>& eventItem)
 {
   if (!eventItem)
     return CFileItemPtr();

--- a/xbmc/filesystem/EventsDirectory.h
+++ b/xbmc/filesystem/EventsDirectory.h
@@ -8,8 +8,13 @@
 
 #pragma once
 
-#include "FileItem.h"
 #include "filesystem/IDirectory.h"
+
+#include <memory>
+
+class CFileItem;
+class CFileItemList;
+class IEvent;
 
 #define PROPERTY_EVENT_IDENTIFIER  "Event.ID"
 #define PROPERTY_EVENT_LEVEL       "Event.Level"
@@ -29,6 +34,7 @@ namespace XFILE
     bool Exists(const CURL& url) override { return true; }
     bool AllowAll() const override { return true; }
 
-    static CFileItemPtr EventToFileItem(const EventPtr& activity);
+    static std::shared_ptr<CFileItem> EventToFileItem(
+        const std::shared_ptr<const IEvent>& activity);
   };
 }

--- a/xbmc/filesystem/PlaylistDirectory.cpp
+++ b/xbmc/filesystem/PlaylistDirectory.cpp
@@ -8,6 +8,7 @@
 
 #include "PlaylistDirectory.h"
 
+#include "FileItem.h"
 #include "PlayListPlayer.h"
 #include "URL.h"
 #include "playlists/PlayList.h"

--- a/xbmc/filesystem/PlaylistFileDirectory.cpp
+++ b/xbmc/filesystem/PlaylistFileDirectory.cpp
@@ -8,8 +8,9 @@
 
 #include "PlaylistFileDirectory.h"
 
-#include "File.h"
+#include "FileItem.h"
 #include "URL.h"
+#include "filesystem/File.h"
 #include "playlists/PlayList.h"
 #include "playlists/PlayListFactory.h"
 

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -53,16 +53,14 @@ std::string GetOriginalPluginPath(const CFileItem& item)
 }
 } // unnamed namespace
 
-CPluginDirectory::CPluginDirectory() : m_cancelled(false)
+CPluginDirectory::CPluginDirectory()
+  : m_listItems(new CFileItemList), m_fileResult(new CFileItem), m_cancelled(false)
+
 {
-  m_listItems = new CFileItemList;
-  m_fileResult = new CFileItem;
 }
 
 CPluginDirectory::~CPluginDirectory(void)
 {
-  delete m_listItems;
-  delete m_fileResult;
 }
 
 bool CPluginDirectory::StartScript(const std::string& strPath, bool resume)

--- a/xbmc/filesystem/PluginDirectory.h
+++ b/xbmc/filesystem/PluginDirectory.h
@@ -14,6 +14,7 @@
 #include "threads/Event.h"
 
 #include <atomic>
+#include <memory>
 #include <string>
 
 class CURL;
@@ -78,8 +79,8 @@ protected:
 private:
   bool StartScript(const std::string& strPath, bool resume);
 
-  CFileItemList* m_listItems;
-  CFileItem* m_fileResult;
+  std::unique_ptr<CFileItemList> m_listItems;
+  std::unique_ptr<CFileItem> m_fileResult;
 
   std::atomic<bool> m_cancelled;
   bool m_success = false; // set by script in EndOfDirectory

--- a/xbmc/filesystem/RSSDirectory.h
+++ b/xbmc/filesystem/RSSDirectory.h
@@ -8,8 +8,14 @@
 
 #pragma once
 
-#include "FileItem.h"
 #include "IFileDirectory.h"
+#include "XBDateTime.h"
+#include "threads/CriticalSection.h"
+
+#include <map>
+#include <string>
+
+class CFileItemList;
 
 namespace XFILE
 {

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeEpisodes.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeEpisodes.cpp
@@ -8,6 +8,7 @@
 
 #include "DirectoryNodeEpisodes.h"
 
+#include "FileItem.h"
 #include "QueryParams.h"
 #include "video/VideoDatabase.h"
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeInProgressTvShows.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeInProgressTvShows.cpp
@@ -8,6 +8,7 @@
 
 #include "DirectoryNodeInProgressTvShows.h"
 
+#include "FileItem.h"
 #include "video/VideoDatabase.h"
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedEpisodes.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedEpisodes.cpp
@@ -8,6 +8,7 @@
 
 #include "DirectoryNodeRecentlyAddedEpisodes.h"
 
+#include "FileItem.h"
 #include "video/VideoDatabase.h"
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMovies.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMovies.cpp
@@ -8,6 +8,7 @@
 
 #include "DirectoryNodeRecentlyAddedMovies.h"
 
+#include "FileItem.h"
 #include "video/VideoDatabase.h"
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMusicVideos.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeRecentlyAddedMusicVideos.cpp
@@ -8,6 +8,7 @@
 
 #include "DirectoryNodeRecentlyAddedMusicVideos.h"
 
+#include "FileItem.h"
 #include "video/VideoDatabase.h"
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMovies.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMovies.cpp
@@ -8,6 +8,7 @@
 
 #include "DirectoryNodeTitleMovies.h"
 
+#include "FileItem.h"
 #include "QueryParams.h"
 #include "video/VideoDatabase.h"
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMusicVideos.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleMusicVideos.cpp
@@ -8,6 +8,7 @@
 
 #include "DirectoryNodeTitleMusicVideos.h"
 
+#include "FileItem.h"
 #include "QueryParams.h"
 #include "video/VideoDatabase.h"
 

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleTvShows.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTitleTvShows.cpp
@@ -8,6 +8,7 @@
 
 #include "DirectoryNodeTitleTvShows.h"
 
+#include "FileItem.h"
 #include "QueryParams.h"
 #include "video/VideoDatabase.h"
 

--- a/xbmc/games/addons/GameClientProperties.cpp
+++ b/xbmc/games/addons/GameClientProperties.cpp
@@ -8,6 +8,7 @@
 
 #include "GameClientProperties.h"
 
+#include "FileItem.h"
 #include "GameClient.h"
 #include "ServiceBroker.h"
 #include "addons/AddonManager.h"

--- a/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
+++ b/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
@@ -8,6 +8,7 @@
 
 #include "GUIDialogSelectGameClient.h"
 
+#include "FileItem.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "filesystem/AddonsDirectory.h"
 #include "games/addons/GameClient.h"

--- a/xbmc/guilib/guiinfo/GUIInfoHelper.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoHelper.cpp
@@ -8,6 +8,7 @@
 
 #include "GUIInfoHelper.h"
 
+#include "FileItem.h"
 #include "PlayListPlayer.h"
 #include "ServiceBroker.h"
 #include "guilib/GUIComponent.h"

--- a/xbmc/guilib/guiinfo/LibraryGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/LibraryGUIInfo.cpp
@@ -8,6 +8,7 @@
 
 #include "guilib/guiinfo/LibraryGUIInfo.h"
 
+#include "FileItem.h"
 #include "ServiceBroker.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -8,6 +8,7 @@
 
 #include "guilib/guiinfo/SystemGUIInfo.h"
 
+#include "FileItem.h"
 #include "GUIPassword.h"
 #include "LangInfo.h"
 #include "ServiceBroker.h"

--- a/xbmc/input/WindowTranslator.cpp
+++ b/xbmc/input/WindowTranslator.cpp
@@ -8,6 +8,7 @@
 
 #include "WindowTranslator.h"
 
+#include "FileItem.h"
 #include "ServiceBroker.h"
 #include "application/Application.h"
 #include "application/ApplicationComponents.h"

--- a/xbmc/interfaces/AnnouncementManager.cpp
+++ b/xbmc/interfaces/AnnouncementManager.cpp
@@ -163,7 +163,7 @@ void CAnnouncementManager::DoAnnounce(AnnouncementFlag flag,
 void CAnnouncementManager::DoAnnounce(AnnouncementFlag flag,
                                       const std::string& sender,
                                       const std::string& message,
-                                      const CFileItemPtr& item,
+                                      const std::shared_ptr<CFileItem>& item,
                                       const CVariant& data)
 {
   if (item == nullptr)

--- a/xbmc/interfaces/AnnouncementManager.h
+++ b/xbmc/interfaces/AnnouncementManager.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "FileItem.h"
 #include "IAnnouncer.h"
 #include "threads/CriticalSection.h"
 #include "threads/Event.h"
@@ -16,8 +15,10 @@
 #include "utils/Variant.h"
 
 #include <list>
+#include <memory>
 #include <vector>
 
+class CFileItem;
 class CVariant;
 
 namespace ANNOUNCEMENT
@@ -65,7 +66,7 @@ namespace ANNOUNCEMENT
     void DoAnnounce(AnnouncementFlag flag,
                     const std::string& sender,
                     const std::string& message,
-                    const CFileItemPtr& item,
+                    const std::shared_ptr<CFileItem>& item,
                     const CVariant& data);
     void DoAnnounce(AnnouncementFlag flag,
                     const std::string& sender,
@@ -77,7 +78,7 @@ namespace ANNOUNCEMENT
       AnnouncementFlag flag;
       std::string sender;
       std::string message;
-      CFileItemPtr item;
+      std::shared_ptr<CFileItem> item;
       CVariant data;
     };
     std::list<CAnnounceData> m_announcementQueue;

--- a/xbmc/interfaces/json-rpc/AddonsOperations.cpp
+++ b/xbmc/interfaces/json-rpc/AddonsOperations.cpp
@@ -265,7 +265,7 @@ static CVariant Serialize(const AddonPtr& addon)
   return variant;
 }
 
-void CAddonsOperations::FillDetails(const AddonPtr& addon,
+void CAddonsOperations::FillDetails(const std::shared_ptr<ADDON::IAddon>& addon,
                                     const CVariant& fields,
                                     CVariant& result,
                                     CAddonDatabase& addondb,

--- a/xbmc/interfaces/json-rpc/AddonsOperations.h
+++ b/xbmc/interfaces/json-rpc/AddonsOperations.h
@@ -9,11 +9,13 @@
 #pragma once
 
 #include "JSONRPC.h"
-#include "addons/IAddon.h"
+
+#include <memory>
 
 namespace ADDON
 {
 class CAddonDatabase;
+class IAddon;
 }
 
 class CVariant;
@@ -30,7 +32,7 @@ namespace JSONRPC
     static JSONRPC_STATUS ExecuteAddon(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
 
   private:
-    static void FillDetails(const ADDON::AddonPtr& addon,
+    static void FillDetails(const std::shared_ptr<ADDON::IAddon>& addon,
                             const CVariant& fields,
                             CVariant& result,
                             ADDON::CAddonDatabase& addondb,

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -1065,7 +1065,10 @@ JSONRPC_STATUS CAudioLibrary::Clean(const std::string &method, ITransportLayer *
   return ACK;
 }
 
-bool CAudioLibrary::FillFileItem(const std::string &strFilename, CFileItemPtr &item, const CVariant &parameterObject /* = CVariant(CVariant::VariantTypeArray) */)
+bool CAudioLibrary::FillFileItem(
+    const std::string& strFilename,
+    std::shared_ptr<CFileItem>& item,
+    const CVariant& parameterObject /* = CVariant(CVariant::VariantTypeArray) */)
 {
   CMusicDatabase musicdatabase;
   if (strFilename.empty())
@@ -1168,7 +1171,8 @@ bool CAudioLibrary::FillFileItemList(const CVariant &parameterObject, CFileItemL
   return success;
 }
 
-void CAudioLibrary::FillItemArtistIDs(const std::vector<int>& artistids, CFileItemPtr& item)
+void CAudioLibrary::FillItemArtistIDs(const std::vector<int>& artistids,
+                                      std::shared_ptr<CFileItem>& item)
 {
   // Add artistIds as separate property as not part of CMusicInfoTag
   CVariant artistidObj(CVariant::VariantTypeArray);
@@ -1178,7 +1182,9 @@ void CAudioLibrary::FillItemArtistIDs(const std::vector<int>& artistids, CFileIt
   item->SetProperty("artistid", artistidObj);
 }
 
-void CAudioLibrary::FillAlbumItem(const CAlbum &album, const std::string &path, CFileItemPtr &item)
+void CAudioLibrary::FillAlbumItem(const CAlbum& album,
+                                  const std::string& path,
+                                  std::shared_ptr<CFileItem>& item)
 {
   item = CFileItemPtr(new CFileItem(path, album));
   // Add album artistIds as separate property as not part of CMusicInfoTag

--- a/xbmc/interfaces/json-rpc/AudioLibrary.h
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.h
@@ -11,10 +11,14 @@
 #include "FileItemHandler.h"
 #include "JSONRPC.h"
 
+#include <memory>
 #include <set>
 #include <string>
 #include <vector>
 
+class CAlbum;
+class CFileitem;
+class CFileitemList;
 class CMusicDatabase;
 class CVariant;
 
@@ -49,7 +53,10 @@ namespace JSONRPC
     static JSONRPC_STATUS Export(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
     static JSONRPC_STATUS Clean(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
 
-    static bool FillFileItem(const std::string &strFilename, CFileItemPtr &item, const CVariant &parameterObject = CVariant(CVariant::VariantTypeArray));
+    static bool FillFileItem(
+        const std::string& strFilename,
+        std::shared_ptr<CFileItem>& item,
+        const CVariant& parameterObject = CVariant(CVariant::VariantTypeArray));
     static bool FillFileItemList(const CVariant &parameterObject, CFileItemList &list);
 
     static JSONRPC_STATUS GetAdditionalDetails(const CVariant &parameterObject, CFileItemList &items);
@@ -64,8 +71,11 @@ namespace JSONRPC
                                                    CMusicDatabase& musicdatabase);
 
   private:
-    static void FillAlbumItem(const CAlbum &album, const std::string &path, CFileItemPtr &item);
-    static void FillItemArtistIDs(const std::vector<int>& artistids, CFileItemPtr& item);
+    static void FillAlbumItem(const CAlbum& album,
+                              const std::string& path,
+                              std::shared_ptr<CFileItem>& item);
+    static void FillItemArtistIDs(const std::vector<int>& artistids,
+                                  std::shared_ptr<CFileItem>& item);
 
     static bool CheckForAdditionalProperties(const CVariant &properties, const std::set<std::string> &checkProperties, std::set<std::string> &foundProperties);
   };

--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -43,7 +43,12 @@ using namespace MUSIC_INFO;
 using namespace JSONRPC;
 using namespace XFILE;
 
-bool CFileItemHandler::GetField(const std::string &field, const CVariant &info, const CFileItemPtr &item, CVariant &result, bool &fetchedArt, CThumbLoader *thumbLoader /* = NULL */)
+bool CFileItemHandler::GetField(const std::string& field,
+                                const CVariant& info,
+                                const std::shared_ptr<CFileItem>& item,
+                                CVariant& result,
+                                bool& fetchedArt,
+                                CThumbLoader* thumbLoader /* = NULL */)
 {
   if (result.isMember(field) && !result[field].empty())
     return true;
@@ -254,7 +259,11 @@ bool CFileItemHandler::GetField(const std::string &field, const CVariant &info, 
   return false;
 }
 
-void CFileItemHandler::FillDetails(const ISerializable *info, const CFileItemPtr &item, std::set<std::string> &fields, CVariant &result, CThumbLoader *thumbLoader /* = NULL */)
+void CFileItemHandler::FillDetails(const ISerializable* info,
+                                   const std::shared_ptr<CFileItem>& item,
+                                   std::set<std::string>& fields,
+                                   CVariant& result,
+                                   CThumbLoader* thumbLoader /* = NULL */)
 {
   if (info == NULL || fields.empty())
     return;
@@ -325,7 +334,7 @@ void CFileItemHandler::HandleFileItemList(const char *ID, bool allowFile, const 
 void CFileItemHandler::HandleFileItem(const char* ID,
                                       bool allowFile,
                                       const char* resultname,
-                                      const CFileItemPtr& item,
+                                      const std::shared_ptr<CFileItem>& item,
                                       const CVariant& parameterObject,
                                       const CVariant& validFields,
                                       CVariant& result,
@@ -346,7 +355,7 @@ void CFileItemHandler::HandleFileItem(const char* ID,
 void CFileItemHandler::HandleFileItem(const char* ID,
                                       bool allowFile,
                                       const char* resultname,
-                                      const CFileItemPtr& item,
+                                      const std::shared_ptr<CFileItem>& item,
                                       const CVariant& parameterObject,
                                       const std::set<std::string>& validFields,
                                       CVariant& result,

--- a/xbmc/interfaces/json-rpc/FileItemHandler.h
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.h
@@ -8,12 +8,14 @@
 
 #pragma once
 
-#include "FileItem.h"
 #include "JSONRPC.h"
 #include "JSONUtils.h"
 
+#include <memory>
 #include <set>
 
+class CFileItem;
+class CFileItemList;
 class CThumbLoader;
 class CVariant;
 
@@ -22,31 +24,40 @@ namespace JSONRPC
   class CFileItemHandler : public CJSONUtils
   {
   protected:
-    static void FillDetails(const ISerializable *info, const CFileItemPtr &item, std::set<std::string> &fields, CVariant &result, CThumbLoader *thumbLoader = NULL);
+    static void FillDetails(const ISerializable* info,
+                            const std::shared_ptr<CFileItem>& item,
+                            std::set<std::string>& fields,
+                            CVariant& result,
+                            CThumbLoader* thumbLoader = nullptr);
     static void HandleFileItemList(const char *ID, bool allowFile, const char *resultname, CFileItemList &items, const CVariant &parameterObject, CVariant &result, bool sortLimit = true);
     static void HandleFileItemList(const char *ID, bool allowFile, const char *resultname, CFileItemList &items, const CVariant &parameterObject, CVariant &result, int size, bool sortLimit = true);
     static void HandleFileItem(const char* ID,
                                bool allowFile,
                                const char* resultname,
-                               const CFileItemPtr& item,
+                               const std::shared_ptr<CFileItem>& item,
                                const CVariant& parameterObject,
                                const CVariant& validFields,
                                CVariant& result,
                                bool append = true,
-                               CThumbLoader* thumbLoader = NULL);
+                               CThumbLoader* thumbLoader = nullptr);
     static void HandleFileItem(const char* ID,
                                bool allowFile,
                                const char* resultname,
-                               const CFileItemPtr& item,
+                               const std::shared_ptr<CFileItem>& item,
                                const CVariant& parameterObject,
                                const std::set<std::string>& validFields,
                                CVariant& result,
                                bool append = true,
-                               CThumbLoader* thumbLoader = NULL);
+                               CThumbLoader* thumbLoader = nullptr);
 
     static bool FillFileItemList(const CVariant &parameterObject, CFileItemList &list);
   private:
     static void Sort(CFileItemList &items, const CVariant& parameterObject);
-    static bool GetField(const std::string &field, const CVariant &info, const CFileItemPtr &item, CVariant &result, bool &fetchedArt, CThumbLoader *thumbLoader = NULL);
+    static bool GetField(const std::string& field,
+                         const CVariant& info,
+                         const std::shared_ptr<CFileItem>& item,
+                         CVariant& result,
+                         bool& fetchedArt,
+                         CThumbLoader* thumbLoader = nullptr);
   };
 }

--- a/xbmc/interfaces/json-rpc/FileItemHandler.h
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.h
@@ -18,6 +18,7 @@ class CFileItem;
 class CFileItemList;
 class CThumbLoader;
 class CVariant;
+class ISerializable;
 
 namespace JSONRPC
 {

--- a/xbmc/interfaces/json-rpc/FileOperations.cpp
+++ b/xbmc/interfaces/json-rpc/FileOperations.cpp
@@ -285,8 +285,8 @@ JSONRPC_STATUS CFileOperations::Download(const std::string &method, ITransportLa
 }
 
 bool CFileOperations::FillFileItem(
-    const CFileItemPtr& originalItem,
-    CFileItemPtr& item,
+    const std::shared_ptr<CFileItem>& originalItem,
+    std::shared_ptr<CFileItem>& item,
     const std::string& media /* = "" */,
     const CVariant& parameterObject /* = CVariant(CVariant::VariantTypeArray) */)
 {

--- a/xbmc/interfaces/json-rpc/FileOperations.h
+++ b/xbmc/interfaces/json-rpc/FileOperations.h
@@ -11,6 +11,9 @@
 #include "FileItemHandler.h"
 #include "JSONRPC.h"
 
+#include <memory>
+
+class CFileItem;
 class CVariant;
 
 namespace JSONRPC
@@ -27,8 +30,8 @@ namespace JSONRPC
     static JSONRPC_STATUS Download(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
 
     static bool FillFileItem(
-        const CFileItemPtr& originalItem,
-        CFileItemPtr& item,
+        const std::shared_ptr<CFileItem>& originalItem,
+        std::shared_ptr<CFileItem>& item,
         const std::string& media = "",
         const CVariant& parameterObject = CVariant(CVariant::VariantTypeArray));
     static bool FillFileItemList(const CVariant &parameterObject, CFileItemList &list);

--- a/xbmc/interfaces/json-rpc/GUIOperations.h
+++ b/xbmc/interfaces/json-rpc/GUIOperations.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "JSONRPC.h"
+#include "rendering/RenderSystemTypes.h"
 
 class CVariant;
 

--- a/xbmc/interfaces/json-rpc/JSONRPC.cpp
+++ b/xbmc/interfaces/json-rpc/JSONRPC.cpp
@@ -8,12 +8,16 @@
 
 #include "JSONRPC.h"
 
+#include "GUIUserMessages.h"
 #include "ServiceBroker.h"
 #include "ServiceDescription.h"
 #include "TextureDatabase.h"
 #include "addons/Addon.h"
 #include "addons/IAddon.h"
 #include "dbwrappers/DatabaseQuery.h"
+#include "guilib/GUIComponent.h"
+#include "guilib/GUIMessage.h"
+#include "guilib/GUIWindowManager.h"
 #include "input/WindowTranslator.h"
 #include "input/actions/ActionTranslator.h"
 #include "interfaces/AnnouncementManager.h"
@@ -361,4 +365,23 @@ inline void CJSONRPC::BuildResponse(const CVariant& request, JSONRPC_STATUS code
       response["error"]["message"] = "Internal error.";
       break;
   }
+}
+
+void CJSONRPCUtils::NotifyItemUpdated()
+{
+  CGUIMessage message(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE,
+                      CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow());
+  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(message);
+}
+
+void CJSONRPCUtils::NotifyItemUpdated(const CVideoInfoTag& info,
+                                      const std::map<std::string, std::string>& artwork)
+{
+  CFileItemPtr msgItem(new CFileItem(info));
+  if (!artwork.empty())
+    msgItem->SetArt(artwork);
+  CGUIMessage message(GUI_MSG_NOTIFY_ALL,
+                      CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow(), 0,
+                      GUI_MSG_UPDATE_ITEM, 0, msgItem);
+  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(message);
 }

--- a/xbmc/interfaces/json-rpc/JSONRPC.cpp
+++ b/xbmc/interfaces/json-rpc/JSONRPC.cpp
@@ -8,6 +8,7 @@
 
 #include "JSONRPC.h"
 
+#include "FileItem.h"
 #include "GUIUserMessages.h"
 #include "ServiceBroker.h"
 #include "ServiceDescription.h"

--- a/xbmc/interfaces/json-rpc/JSONRPCUtils.h
+++ b/xbmc/interfaces/json-rpc/JSONRPCUtils.h
@@ -8,15 +8,14 @@
 
 #pragma once
 
-#include "FileItem.h"
-#include "GUIUserMessages.h"
 #include "IClient.h"
 #include "ITransportLayer.h"
-#include "ServiceBroker.h"
-#include "guilib/GUIComponent.h"
-#include "guilib/GUIWindowManager.h"
+
+#include <map>
+#include <string>
 
 class CVariant;
+class CVideoInfoTag;
 
 namespace JSONRPC
 {
@@ -157,19 +156,8 @@ namespace JSONRPC
   class CJSONRPCUtils
   {
   public:
-    static inline void NotifyItemUpdated()
-    {
-      CGUIMessage message(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE, CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow());
-      CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(message);
-    }
-    static inline void NotifyItemUpdated(const CVideoInfoTag& info,
-                                         const std::map<std::string, std::string>& artwork)
-    {
-      CFileItemPtr msgItem(new CFileItem(info));
-      if (!artwork.empty())
-        msgItem->SetArt(artwork);
-      CGUIMessage message(GUI_MSG_NOTIFY_ALL, CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow(), 0, GUI_MSG_UPDATE_ITEM, 0, msgItem);
-      CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(message);
-    }
+    static void NotifyItemUpdated();
+    static void NotifyItemUpdated(const CVideoInfoTag& info,
+                                  const std::map<std::string, std::string>& artwork);
   };
 }

--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -8,6 +8,7 @@
 
 #include "PVROperations.h"
 
+#include "FileItem.h"
 #include "ServiceBroker.h"
 #include "pvr/PVRManager.h"
 #include "pvr/PVRPlaybackState.h"

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -23,6 +23,7 @@
 #include "application/ApplicationPlayer.h"
 #include "cores/IPlayer.h"
 #include "cores/playercorefactory/PlayerCoreFactory.h"
+#include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
 #include "interfaces/builtins/Builtins.h"

--- a/xbmc/interfaces/json-rpc/PlaylistOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlaylistOperations.cpp
@@ -8,6 +8,7 @@
 
 #include "PlaylistOperations.h"
 
+#include "FileItem.h"
 #include "GUIUserMessages.h"
 #include "PlayListPlayer.h"
 #include "ServiceBroker.h"

--- a/xbmc/interfaces/json-rpc/PlaylistOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlaylistOperations.cpp
@@ -11,6 +11,7 @@
 #include "GUIUserMessages.h"
 #include "PlayListPlayer.h"
 #include "ServiceBroker.h"
+#include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/Key.h"
 #include "messaging/ApplicationMessenger.h"

--- a/xbmc/interfaces/json-rpc/PlaylistOperations.h
+++ b/xbmc/interfaces/json-rpc/PlaylistOperations.h
@@ -8,10 +8,10 @@
 
 #pragma once
 
-#include "FileItem.h"
 #include "FileItemHandler.h"
 #include "JSONRPC.h"
 
+class CFileItemList;
 class CVariant;
 
 namespace PLAYLIST

--- a/xbmc/interfaces/json-rpc/ProfilesOperations.cpp
+++ b/xbmc/interfaces/json-rpc/ProfilesOperations.cpp
@@ -8,6 +8,7 @@
 
 #include "ProfilesOperations.h"
 
+#include "FileItem.h"
 #include "GUIPassword.h"
 #include "ServiceBroker.h"
 #include "guilib/LocalizeStrings.h"

--- a/xbmc/interfaces/json-rpc/TextureOperations.cpp
+++ b/xbmc/interfaces/json-rpc/TextureOperations.cpp
@@ -8,6 +8,7 @@
 
 #include "TextureOperations.h"
 
+#include "FileItem.h"
 #include "ServiceBroker.h"
 #include "TextureCache.h"
 #include "TextureDatabase.h"

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -8,6 +8,7 @@
 
 #include "VideoLibrary.h"
 
+#include "FileItem.h"
 #include "PVROperations.h"
 #include "ServiceBroker.h"
 #include "TextureDatabase.h"

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -1004,7 +1004,10 @@ JSONRPC_STATUS CVideoLibrary::Clean(const std::string &method, ITransportLayer *
   return ACK;
 }
 
-bool CVideoLibrary::FillFileItem(const std::string &strFilename, CFileItemPtr &item, const CVariant &parameterObject /* = CVariant(CVariant::VariantTypeArray) */)
+bool CVideoLibrary::FillFileItem(
+    const std::string& strFilename,
+    std::shared_ptr<CFileItem>& item,
+    const CVariant& parameterObject /* = CVariant(CVariant::VariantTypeArray) */)
 {
   CVideoDatabase videodatabase;
   if (strFilename.empty())

--- a/xbmc/interfaces/json-rpc/VideoLibrary.h
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.h
@@ -12,9 +12,12 @@
 #include "JSONRPC.h"
 #include "utils/DatabaseUtils.h"
 
+#include <memory>
 #include <string>
 #include <vector>
 
+class CFileItem;
+class CFileItemList;
 class CVideoDatabase;
 class CVariant;
 
@@ -69,7 +72,10 @@ namespace JSONRPC
     static JSONRPC_STATUS Export(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
     static JSONRPC_STATUS Clean(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
 
-    static bool FillFileItem(const std::string &strFilename, CFileItemPtr &item, const CVariant &parameterObject = CVariant(CVariant::VariantTypeArray));
+    static bool FillFileItem(
+        const std::string& strFilename,
+        std::shared_ptr<CFileItem>& item,
+        const CVariant& parameterObject = CVariant(CVariant::VariantTypeArray));
     static bool FillFileItemList(const CVariant &parameterObject, CFileItemList &list);
     static void UpdateResumePoint(const CVariant &parameterObject, CVideoInfoTag &details, CVideoDatabase &videodatabase);
 

--- a/xbmc/interfaces/legacy/ModuleXbmcvfs.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmcvfs.cpp
@@ -8,6 +8,7 @@
 
 #include "ModuleXbmcvfs.h"
 
+#include "FileItem.h"
 #include "LanguageHook.h"
 #include "URL.h"
 #include "Util.h"

--- a/xbmc/music/ContextMenus.cpp
+++ b/xbmc/music/ContextMenus.cpp
@@ -8,6 +8,7 @@
 
 #include "ContextMenus.h"
 
+#include "FileItem.h"
 #include "guilib/GUIWindowManager.h"
 #include "music/dialogs/GUIDialogMusicInfo.h"
 #include "tags/MusicInfoTag.h"

--- a/xbmc/music/ContextMenus.h
+++ b/xbmc/music/ContextMenus.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #include "ContextMenuItem.h"
-
+#include "media/MediaType.h"
 
 namespace CONTEXTMENU
 {

--- a/xbmc/music/MusicLibraryQueue.h
+++ b/xbmc/music/MusicLibraryQueue.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "FileItem.h"
 #include "settings/LibExportSettings.h"
 #include "threads/CriticalSection.h"
 #include "utils/JobManager.h"

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -8,6 +8,7 @@
 
 #include "MusicUtils.h"
 
+#include "FileItem.h"
 #include "PlayListPlayer.h"
 #include "ServiceBroker.h"
 #include "application/Application.h"

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -183,7 +183,7 @@ namespace MUSIC_UTILS
     }
   };
 
-  void UpdateArtJob(const CFileItemPtr& pItem,
+  void UpdateArtJob(const std::shared_ptr<CFileItem>& pItem,
                     const std::string& strType,
                     const std::string& strArt)
   {
@@ -339,7 +339,7 @@ namespace MUSIC_UTILS
     return -1;
   }
 
-  void UpdateSongRatingJob(const CFileItemPtr& pItem, int userrating)
+  void UpdateSongRatingJob(const std::shared_ptr<CFileItem>& pItem, int userrating)
   {
     // Asynchronously update the song user rating in music library
     const CMusicInfoTag *tag = pItem->GetMusicInfoTag();

--- a/xbmc/music/MusicUtils.h
+++ b/xbmc/music/MusicUtils.h
@@ -8,7 +8,14 @@
 
 #pragma once
 
-#include "FileItem.h"
+#include "media/MediaType.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+class CFileItem;
+class CFileItemList;
 
 namespace MUSIC_UTILS
 {
@@ -43,7 +50,7 @@ namespace MUSIC_UTILS
   \param strType the type of art e.g. "fanart" or "thumb" etc.
   \param strArt art URL, when empty the entry for that type of art is deleted.
   */
-  void UpdateArtJob(const CFileItemPtr& pItem,
+  void UpdateArtJob(const std::shared_ptr<CFileItem>& pItem,
                     const std::string& strType,
                     const std::string& strArt);
 
@@ -57,7 +64,7 @@ namespace MUSIC_UTILS
 \param pItem pointer to song item being rated
 \param userrating the userrating 0 = no rating, 1 to 10
 */
-  void UpdateSongRatingJob(const CFileItemPtr& pItem, int userrating);
+  void UpdateSongRatingJob(const std::shared_ptr<CFileItem>& pItem, int userrating);
 
   /*! \brief Get the types of art for an artist or album that are to be
   automatically fetched from local files during scanning

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.h
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.h
@@ -8,13 +8,14 @@
 
 #pragma once
 
-#include "FileItem.h"
 #include "MediaSource.h"
 #include "guilib/GUIDialog.h"
 #include "music/Album.h"
 #include "music/Artist.h"
 #include "music/Song.h"
 #include "threads/Event.h"
+
+#include <memory>
 
 class CFileItem;
 class CFileItemList;
@@ -70,9 +71,9 @@ protected:
   bool m_bArtistInfo = false;
   bool m_cancelled = false;
   bool m_scraperAddInfo = false;
-  CFileItemList* m_albumSongs;
-  CFileItemPtr m_item;
-  CFileItemList m_artTypeList;
+  std::unique_ptr<CFileItemList> m_albumSongs;
+  std::shared_ptr<CFileItem> m_item;
+  std::unique_ptr<CFileItemList> m_artTypeList;
   CEvent m_event;
   std::string m_fallbackartpath;
 };

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -8,6 +8,7 @@
 
 #include "GUIWindowMusicPlaylist.h"
 
+#include "FileItem.h"
 #include "GUIUserMessages.h"
 #include "PartyModeManager.h"
 #include "PlayListPlayer.h"

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -8,10 +8,10 @@
 
 #include "NetworkServices.h"
 
-#include <utility>
-
 #include "ServiceBroker.h"
 #include "dialogs/GUIDialogKaiToast.h"
+#include "guilib/GUIComponent.h"
+#include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "interfaces/json-rpc/JSONRPC.h"
 #include "messaging/ApplicationMessenger.h"
@@ -21,14 +21,16 @@
 #include "network/Network.h"
 #include "network/TCPServer.h"
 #include "settings/AdvancedSettings.h"
-#include "settings/lib/Setting.h"
-#include "settings/lib/SettingsManager.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "utils/log.h"
+#include "settings/lib/Setting.h"
+#include "settings/lib/SettingsManager.h"
 #include "utils/RssManager.h"
 #include "utils/SystemInfo.h"
 #include "utils/Variant.h"
+#include "utils/log.h"
+
+#include <utility>
 
 #ifdef TARGET_LINUX
 #include "Util.h"

--- a/xbmc/network/TCPServer.cpp
+++ b/xbmc/network/TCPServer.cpp
@@ -8,9 +8,10 @@
 
 #include "TCPServer.h"
 
-#include "Network.h"
+#include "ServiceBroker.h"
 #include "interfaces/AnnouncementManager.h"
 #include "interfaces/json-rpc/JSONRPC.h"
+#include "network/Network.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/Variant.h"

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -949,8 +949,8 @@ PopulateTagFromObject(CVideoInfoTag&         tag,
     return NPT_SUCCESS;
 }
 
-CFileItemPtr BuildObject(PLT_MediaObject* entry,
-                         UPnPService      upnp_service /* = UPnPServiceNone */)
+std::shared_ptr<CFileItem> BuildObject(PLT_MediaObject* entry,
+                                       UPnPService upnp_service /* = UPnPServiceNone */)
 {
   NPT_String ObjectClass = entry->m_ObjectClass.type.ToLowercase();
 
@@ -1174,7 +1174,7 @@ bool GetResource(const PLT_MediaObject* entry, CFileItem& item)
   return true;
 }
 
-CFileItemPtr GetFileItem(const NPT_String& uri, const NPT_String& meta)
+std::shared_ptr<CFileItem> GetFileItem(const NPT_String& uri, const NPT_String& meta)
 {
     PLT_MediaObjectListReference list;
     PLT_MediaObject*             object = NULL;

--- a/xbmc/network/upnp/UPnPInternal.h
+++ b/xbmc/network/upnp/UPnPInternal.h
@@ -8,8 +8,7 @@
 
 #pragma once
 
-#include "FileItem.h"
-
+#include <memory>
 #include <string>
 
 #include <Neptune/Source/Core/NptReferences.h>
@@ -114,10 +113,10 @@ namespace UPNP
                                CUPnPServer*                   upnp_server = NULL,
                                UPnPService                    upnp_service = UPnPServiceNone);
 
-  CFileItemPtr     BuildObject(PLT_MediaObject* entry,
-                               UPnPService      upnp_service = UPnPServiceNone);
+  std::shared_ptr<CFileItem> BuildObject(PLT_MediaObject* entry,
+                                         UPnPService upnp_service = UPnPServiceNone);
 
   bool             GetResource(const PLT_MediaObject* entry, CFileItem& item);
-  CFileItemPtr     GetFileItem(const NPT_String& uri, const NPT_String& meta);
+  std::shared_ptr<CFileItem> GetFileItem(const NPT_String& uri, const NPT_String& meta);
 }
 

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -257,7 +257,7 @@ NPT_String CUPnPServer::BuildSafeResourceUri(const NPT_HttpUrl &rooturi,
 /*----------------------------------------------------------------------
 |   CUPnPServer::Build
 +---------------------------------------------------------------------*/
-PLT_MediaObject* CUPnPServer::Build(const CFileItemPtr& item,
+PLT_MediaObject* CUPnPServer::Build(const std::shared_ptr<CFileItem>& item,
                                     bool with_count,
                                     const PLT_HttpRequestContext& context,
                                     NPT_Reference<CThumbLoader>& thumb_loader,

--- a/xbmc/network/upnp/UPnPServer.h
+++ b/xbmc/network/upnp/UPnPServer.h
@@ -8,16 +8,20 @@
 
 #pragma once
 
-#include "FileItem.h"
 #include "interfaces/IAnnouncer.h"
 #include "utils/logtypes.h"
 
+#include <map>
+#include <memory>
+#include <string>
 #include <utility>
 
 #include <Platinum/Source/Devices/MediaConnect/PltMediaConnect.h>
 
-class CVariant;
+class CFileItem;
+class CFileItemList;
 class CThumbLoader;
+class CVariant;
 class PLT_MediaObject;
 class PLT_HttpRequestContext;
 
@@ -109,7 +113,7 @@ public:
     void UpdateContainer(const std::string& id);
     void PropagateUpdates();
 
-    PLT_MediaObject* Build(const CFileItemPtr& item,
+    PLT_MediaObject* Build(const std::shared_ptr<CFileItem>& item,
                            bool with_count,
                            const PLT_HttpRequestContext& context,
                            NPT_Reference<CThumbLoader>& thumbLoader,

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -8,6 +8,7 @@
 
 #include "PeripheralAddon.h"
 
+#include "FileItem.h"
 #include "PeripheralAddonTranslator.h"
 #include "addons/AddonManager.h"
 #include "filesystem/Directory.h"

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -9,6 +9,7 @@
 #include "GUIWindowPictures.h"
 
 #include "Autorun.h"
+#include "FileItem.h"
 #include "GUIDialogPictureInfo.h"
 #include "GUIPassword.h"
 #include "GUIWindowSlideShow.h"

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -10,6 +10,7 @@
 
 #include "AndroidKey.h"
 #include "CompileInfo.h"
+#include "FileItem.h"
 #include "application/AppParams.h"
 #include "application/Application.h"
 #include "application/ApplicationComponents.h"

--- a/xbmc/platform/android/filesystem/AndroidAppDirectory.h
+++ b/xbmc/platform/android/filesystem/AndroidAppDirectory.h
@@ -8,8 +8,10 @@
 
 #pragma once
 
-#include "FileItem.h"
 #include "filesystem/IDirectory.h"
+
+class CFileItemList;
+
 namespace XFILE
 {
 

--- a/xbmc/platform/darwin/ios/IOSEAGLView.mm
+++ b/xbmc/platform/darwin/ios/IOSEAGLView.mm
@@ -8,6 +8,7 @@
 
 #import "IOSEAGLView.h"
 
+#include "FileItem.h"
 #import "IOSScreenManager.h"
 #include "ServiceBroker.h"
 #include "Util.h"

--- a/xbmc/platform/darwin/tvos/TVOSTopShelf.h
+++ b/xbmc/platform/darwin/tvos/TVOSTopShelf.h
@@ -8,8 +8,9 @@
 
 #pragma once
 
-#include "FileItem.h"
 #include "threads/CriticalSection.h"
+
+class CFileItemList;
 
 typedef enum
 {

--- a/xbmc/playlists/PlayList.cpp
+++ b/xbmc/playlists/PlayList.cpp
@@ -8,6 +8,7 @@
 
 #include "PlayList.h"
 
+#include "FileItem.h"
 #include "PlayListFactory.h"
 #include "ServiceBroker.h"
 #include "filesystem/File.h"
@@ -60,7 +61,7 @@ void CPlayList::AnnounceClear()
   CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Playlist, "OnClear", data);
 }
 
-void CPlayList::AnnounceAdd(const CFileItemPtr& item, int pos)
+void CPlayList::AnnounceAdd(const std::shared_ptr<CFileItem>& item, int pos)
 {
   if (m_id == TYPE_NONE)
     return;
@@ -71,7 +72,7 @@ void CPlayList::AnnounceAdd(const CFileItemPtr& item, int pos)
   CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Playlist, "OnAdd", item, data);
 }
 
-void CPlayList::Add(const CFileItemPtr &item, int iPosition, int iOrder)
+void CPlayList::Add(const std::shared_ptr<CFileItem>& item, int iPosition, int iOrder)
 {
   int iOldSize = size();
   if (iPosition < 0 || iPosition >= iOldSize)
@@ -105,7 +106,7 @@ void CPlayList::Add(const CFileItemPtr &item, int iPosition, int iOrder)
   AnnounceAdd(item, iPosition);
 }
 
-void CPlayList::Add(const CFileItemPtr &item)
+void CPlayList::Add(const std::shared_ptr<CFileItem>& item)
 {
   Add(item, -1, -1);
 }
@@ -153,7 +154,7 @@ void CPlayList::Insert(const CFileItemList& items, int iPosition /* = -1 */)
   }
 }
 
-void CPlayList::Insert(const CFileItemPtr &item, int iPosition /* = -1 */)
+void CPlayList::Insert(const std::shared_ptr<CFileItem>& item, int iPosition /* = -1 */)
 {
   // out of bounds so just add to the end
   int iSize = size();
@@ -227,7 +228,7 @@ int CPlayList::size() const
   return (int)m_vecItems.size();
 }
 
-const CFileItemPtr CPlayList::operator[] (int iItem) const
+const std::shared_ptr<CFileItem> CPlayList::operator[](int iItem) const
 {
   if (iItem < 0 || iItem >= size())
   {
@@ -238,7 +239,7 @@ const CFileItemPtr CPlayList::operator[] (int iItem) const
   return m_vecItems[iItem];
 }
 
-CFileItemPtr CPlayList::operator[] (int iItem)
+std::shared_ptr<CFileItem> CPlayList::operator[](int iItem)
 {
   if (iItem < 0 || iItem >= size())
   {
@@ -503,7 +504,7 @@ void CPlayList::UpdateItem(const CFileItem *item)
   }
 }
 
-const std::string& CPlayList::ResolveURL(const CFileItemPtr &item ) const
+const std::string& CPlayList::ResolveURL(const std::shared_ptr<CFileItem>& item) const
 {
   if (item->IsMusicDb() && item->HasMusicInfoTag())
     return item->GetMusicInfoTag()->GetURL();

--- a/xbmc/playlists/PlayList.h
+++ b/xbmc/playlists/PlayList.h
@@ -8,12 +8,14 @@
 
 #pragma once
 
-#include "FileItem.h"
 #include "PlayListTypes.h"
 
 #include <memory>
 #include <string>
 #include <vector>
+
+class CFileItem;
+class CFileItemList;
 
 namespace PLAYLIST
 {
@@ -29,13 +31,13 @@ public:
   virtual void Save(const std::string& strFileName) const {};
 
   void Add(const CPlayList& playlist);
-  void Add(const CFileItemPtr &pItem);
+  void Add(const std::shared_ptr<CFileItem>& pItem);
   void Add(const CFileItemList& items);
 
   // for Party Mode
   void Insert(const CPlayList& playlist, int iPosition = -1);
   void Insert(const CFileItemList& items, int iPosition = -1);
-  void Insert(const CFileItemPtr& item, int iPosition = -1);
+  void Insert(const std::shared_ptr<CFileItem>& item, int iPosition = -1);
 
   int FindOrder(int iOrder) const;
   const std::string& GetName() const;
@@ -47,8 +49,8 @@ public:
   int size() const;
   int RemoveDVDItems();
 
-  const CFileItemPtr operator[] (int iItem) const;
-  CFileItemPtr operator[] (int iItem);
+  const std::shared_ptr<CFileItem> operator[](int iItem) const;
+  std::shared_ptr<CFileItem> operator[](int iItem);
 
   void Shuffle(int iPosition = 0);
   void UnShuffle();
@@ -62,7 +64,7 @@ public:
 
   void UpdateItem(const CFileItem *item);
 
-  const std::string& ResolveURL(const CFileItemPtr &item) const;
+  const std::string& ResolveURL(const std::shared_ptr<CFileItem>& item) const;
 
 protected:
   PLAYLIST::Id m_id;
@@ -73,17 +75,17 @@ protected:
   bool m_bWasPlayed;
 
 //  CFileItemList m_vecItems;
-  std::vector <CFileItemPtr> m_vecItems;
-  typedef std::vector <CFileItemPtr>::iterator ivecItems;
+  std::vector<std::shared_ptr<CFileItem>> m_vecItems;
+  typedef std::vector<std::shared_ptr<CFileItem>>::iterator ivecItems;
 
 private:
-  void Add(const CFileItemPtr& item, int iPosition, int iOrderOffset);
+  void Add(const std::shared_ptr<CFileItem>& item, int iPosition, int iOrderOffset);
   void DecrementOrder(int iOrder);
   void IncrementOrder(int iPosition, int iOrder);
 
   void AnnounceRemove(int pos);
   void AnnounceClear();
-  void AnnounceAdd(const CFileItemPtr& item, int pos);
+  void AnnounceAdd(const std::shared_ptr<CFileItem>& item, int pos);
 };
 
 typedef std::shared_ptr<CPlayList> CPlayListPtr;

--- a/xbmc/playlists/PlayListB4S.cpp
+++ b/xbmc/playlists/PlayListB4S.cpp
@@ -8,6 +8,7 @@
 
 #include "PlayListB4S.h"
 
+#include "FileItem.h"
 #include "Util.h"
 #include "filesystem/File.h"
 #include "music/tags/MusicInfoTag.h"

--- a/xbmc/playlists/PlayListFactory.cpp
+++ b/xbmc/playlists/PlayListFactory.cpp
@@ -8,13 +8,14 @@
 
 #include "PlayListFactory.h"
 
-#include "PlayListB4S.h"
-#include "PlayListM3U.h"
-#include "PlayListPLS.h"
-#include "PlayListURL.h"
-#include "PlayListWPL.h"
-#include "PlayListXML.h"
-#include "PlayListXSPF.h"
+#include "FileItem.h"
+#include "playlists/PlayListB4S.h"
+#include "playlists/PlayListM3U.h"
+#include "playlists/PlayListPLS.h"
+#include "playlists/PlayListURL.h"
+#include "playlists/PlayListWPL.h"
+#include "playlists/PlayListXML.h"
+#include "playlists/PlayListXSPF.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 

--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -8,6 +8,7 @@
 
 #include "PlayListM3U.h"
 
+#include "FileItem.h"
 #include "URL.h"
 #include "Util.h"
 #include "filesystem/File.h"

--- a/xbmc/playlists/PlayListPLS.cpp
+++ b/xbmc/playlists/PlayListPLS.cpp
@@ -8,6 +8,7 @@
 
 #include "PlayListPLS.h"
 
+#include "FileItem.h"
 #include "PlayListFactory.h"
 #include "Util.h"
 #include "filesystem/File.h"

--- a/xbmc/playlists/PlayListURL.cpp
+++ b/xbmc/playlists/PlayListURL.cpp
@@ -8,6 +8,7 @@
 
 #include "PlayListURL.h"
 
+#include "FileItem.h"
 #include "filesystem/File.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"

--- a/xbmc/playlists/PlayListWPL.cpp
+++ b/xbmc/playlists/PlayListWPL.cpp
@@ -8,6 +8,7 @@
 
 #include "PlayListWPL.h"
 
+#include "FileItem.h"
 #include "Util.h"
 #include "filesystem/File.h"
 #include "utils/StringUtils.h"

--- a/xbmc/playlists/PlayListXML.cpp
+++ b/xbmc/playlists/PlayListXML.cpp
@@ -8,6 +8,7 @@
 
 #include "PlayListXML.h"
 
+#include "FileItem.h"
 #include "Util.h"
 #include "filesystem/File.h"
 #include "media/MediaLockState.h"

--- a/xbmc/playlists/PlayListXSPF.cpp
+++ b/xbmc/playlists/PlayListXSPF.cpp
@@ -9,6 +9,7 @@
 
 #include "PlayListXSPF.h"
 
+#include "FileItem.h"
 #include "URL.h"
 #include "utils/URIUtils.h"
 #include "utils/XBMCTinyXML.h"

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -8,6 +8,7 @@
 
 #include "PowerManager.h"
 
+#include "FileItem.h"
 #include "PowerTypes.h"
 #include "ServiceBroker.h"
 #include "application/AppParams.h"

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -9,6 +9,7 @@
 #include "PVRContextMenus.h"
 
 #include "ContextMenuItem.h"
+#include "FileItem.h"
 #include "ServiceBroker.h"
 #include "guilib/LocalizeStrings.h"
 #include "pvr/PVRManager.h"

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -8,6 +8,7 @@
 
 #include "PVRManager.h"
 
+#include "FileItem.h"
 #include "ServiceBroker.h"
 #include "guilib/LocalizeStrings.h"
 #include "interfaces/AnnouncementManager.h"

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -26,6 +26,7 @@ namespace PVR
 {
 class CPVRChannel;
 class CPVRChannelGroup;
+class CPVRChannelGroupMember;
 class CPVRChannelGroups;
 class CPVRProvider;
 class CPVRProvidersContainer;

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -25,35 +25,37 @@ namespace ADDON
 
 namespace PVR
 {
-  class CPVRChannelGroupInternal;
-  class CPVRChannelGroup;
-  class CPVRChannelGroups;
-  class CPVRProvidersContainer;
-  class CPVRClient;
-  class CPVREpg;
-  class CPVRRecordings;
-  class CPVRTimerType;
-  class CPVRTimersContainer;
+class CPVRChannel;
+class CPVRChannelGroupInternal;
+class CPVRChannelGroup;
+class CPVRChannelGroupMember;
+class CPVRChannelGroups;
+class CPVRProvidersContainer;
+class CPVRClient;
+class CPVREpg;
+class CPVRRecordings;
+class CPVRTimerType;
+class CPVRTimersContainer;
 
-  typedef std::map<int, std::shared_ptr<CPVRClient>> CPVRClientMap;
+typedef std::map<int, std::shared_ptr<CPVRClient>> CPVRClientMap;
 
-  /**
+/**
    * Holds generic data about a backend (number of channels etc.)
    */
-  struct SBackend
-  {
-    std::string name;
-    std::string version;
-    std::string host;
-    int numTimers = 0;
-    int numRecordings = 0;
-    int numDeletedRecordings = 0;
-    int numProviders = 0;
-    int numChannelGroups = 0;
-    int numChannels = 0;
-    uint64_t diskUsed = 0;
-    uint64_t diskTotal = 0;
-  };
+struct SBackend
+{
+  std::string name;
+  std::string version;
+  std::string host;
+  int numTimers = 0;
+  int numRecordings = 0;
+  int numDeletedRecordings = 0;
+  int numProviders = 0;
+  int numChannelGroups = 0;
+  int numChannels = 0;
+  uint64_t diskUsed = 0;
+  uint64_t diskTotal = 0;
+};
 
   class CPVRClients : public ADDON::IAddonMgrCallback
   {

--- a/xbmc/pvr/guilib/PVRGUIActionListener.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionListener.cpp
@@ -8,6 +8,7 @@
 
 #include "PVRGUIActionListener.h"
 
+#include "FileItem.h"
 #include "ServiceBroker.h"
 #include "application/Application.h"
 #include "application/ApplicationActionListeners.h"

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -8,6 +8,7 @@
 
 #include "PVRGUIInfo.h"
 
+#include "FileItem.h"
 #include "GUIInfoManager.h"
 #include "ServiceBroker.h"
 #include "application/Application.h"

--- a/xbmc/test/TestBasicEnvironment.cpp
+++ b/xbmc/test/TestBasicEnvironment.cpp
@@ -8,6 +8,7 @@
 
 #include "TestBasicEnvironment.h"
 
+#include "FileItem.h"
 #include "ServiceBroker.h"
 #include "TestUtils.h"
 #include "application/AppEnvironment.h"

--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -46,7 +46,7 @@ bool CFileUtils::DeleteItem(const std::string &strPath)
   return DeleteItem(item);
 }
 
-bool CFileUtils::DeleteItem(const CFileItemPtr &item)
+bool CFileUtils::DeleteItem(const std::shared_ptr<CFileItem>& item)
 {
   if (!item || item->IsParentFolder())
     return false;

--- a/xbmc/utils/FileUtils.h
+++ b/xbmc/utils/FileUtils.h
@@ -8,15 +8,17 @@
 
 #pragma once
 
-#include "FileItem.h"
-
+#include <memory>
 #include <string>
+
+class CFileItem;
+class CDateTime;
 
 class CFileUtils
 {
 public:
   static bool CheckFileAccessAllowed(const std::string &filePath);
-  static bool DeleteItem(const CFileItemPtr &item);
+  static bool DeleteItem(const std::shared_ptr<CFileItem>& item);
   static bool DeleteItem(const std::string &strPath);
   static bool RenameFile(const std::string &strFile);
   static bool RemoteAccessAllowed(const std::string &strPath);

--- a/xbmc/utils/test/TestFileUtils.cpp
+++ b/xbmc/utils/test/TestFileUtils.cpp
@@ -6,6 +6,7 @@
  *  See LICENSES/README.md for more information.
  */
 
+#include "FileItem.h"
 #include "filesystem/File.h"
 #include "test/TestUtils.h"
 #include "utils/FileUtils.h"

--- a/xbmc/video/ContextMenus.h
+++ b/xbmc/video/ContextMenus.h
@@ -10,6 +10,7 @@
 
 #include "ContextMenuItem.h"
 #include "VideoLibraryQueue.h"
+#include "media/MediaType.h"
 
 namespace CONTEXTMENU
 {

--- a/xbmc/video/Episode.h
+++ b/xbmc/video/Episode.h
@@ -8,12 +8,14 @@
 
 #pragma once
 
-#include "FileItem.h"
 #include "XBDateTime.h"
 #include "utils/ScraperUrl.h"
 
+#include <memory>
 #include <string>
 #include <vector>
+
+class CFileItem;
 
 // single episode information
 namespace VIDEO
@@ -28,7 +30,7 @@ namespace VIDEO
     std::string strTitle;
     CDateTime   cDate;
     CScraperUrl cScraperUrl;
-    CFileItemPtr item;
+    std::shared_ptr<CFileItem> item;
     EPISODE(int Season = -1, int Episode = -1, int Subepisode = 0, bool Folder = false)
     {
       iSeason     = Season;

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -11,6 +11,7 @@
 #include "InfoScanner.h"
 #include "VideoDatabase.h"
 #include "addons/Scraper.h"
+#include "guilib/GUIListItem.h"
 
 #include <set>
 #include <string>

--- a/xbmc/video/VideoLibraryQueue.cpp
+++ b/xbmc/video/VideoLibraryQueue.cpp
@@ -124,13 +124,19 @@ bool CVideoLibraryQueue::CleanLibraryModal(const std::set<int>& paths /* = std::
   return true;
 }
 
-void CVideoLibraryQueue::RefreshItem(CFileItemPtr item, bool ignoreNfo /* = false */, bool forceRefresh /* = true */, bool refreshAll /* = false */, const std::string& searchTitle /* = "" */)
+void CVideoLibraryQueue::RefreshItem(std::shared_ptr<CFileItem> item,
+                                     bool ignoreNfo /* = false */,
+                                     bool forceRefresh /* = true */,
+                                     bool refreshAll /* = false */,
+                                     const std::string& searchTitle /* = "" */)
 {
   AddJob(new CVideoLibraryRefreshingJob(std::move(item), forceRefresh, refreshAll, ignoreNfo,
                                         searchTitle));
 }
 
-bool CVideoLibraryQueue::RefreshItemModal(CFileItemPtr item, bool forceRefresh /* = true */, bool refreshAll /* = false */)
+bool CVideoLibraryQueue::RefreshItemModal(std::shared_ptr<CFileItem> item,
+                                          bool forceRefresh /* = true */,
+                                          bool refreshAll /* = false */)
 {
   // we can't perform a modal item refresh if other jobs are running
   if (IsRunning())
@@ -145,7 +151,7 @@ bool CVideoLibraryQueue::RefreshItemModal(CFileItemPtr item, bool forceRefresh /
   return result;
 }
 
-void CVideoLibraryQueue::MarkAsWatched(const CFileItemPtr &item, bool watched)
+void CVideoLibraryQueue::MarkAsWatched(const std::shared_ptr<CFileItem>& item, bool watched)
 {
   if (item == NULL)
     return;
@@ -153,7 +159,7 @@ void CVideoLibraryQueue::MarkAsWatched(const CFileItemPtr &item, bool watched)
   AddJob(new CVideoLibraryMarkWatchedJob(item, watched));
 }
 
-void CVideoLibraryQueue::ResetResumePoint(const CFileItemPtr& item)
+void CVideoLibraryQueue::ResetResumePoint(const std::shared_ptr<CFileItem>& item)
 {
   if (item == nullptr)
     return;

--- a/xbmc/video/VideoLibraryQueue.h
+++ b/xbmc/video/VideoLibraryQueue.h
@@ -8,13 +8,14 @@
 
 #pragma once
 
-#include "FileItem.h"
 #include "threads/CriticalSection.h"
 #include "utils/JobManager.h"
 
 #include <map>
+#include <memory>
 #include <set>
 
+class CFileItem;
 class CGUIDialogProgressBarHandle;
 class CVideoLibraryJob;
 
@@ -84,7 +85,11 @@ public:
    \param[in] refreshAll Whether to refresh all sub-items (in case of a tvshow)
    \param[in] searchTitle Title to use for the search (instead of determining it from the item's filename/path)
    */
-  void RefreshItem(CFileItemPtr item, bool ignoreNfo = false, bool forceRefresh = true, bool refreshAll = false, const std::string& searchTitle = "");
+  void RefreshItem(std::shared_ptr<CFileItem> item,
+                   bool ignoreNfo = false,
+                   bool forceRefresh = true,
+                   bool refreshAll = false,
+                   const std::string& searchTitle = "");
 
   /*!
    \brief Refreshes the details of the given item with a modal dialog.
@@ -94,7 +99,9 @@ public:
    \param[in] refreshAll Whether to refresh all sub-items (in case of a tvshow)
    \return True if the item has been successfully refreshed, false otherwise.
   */
-  bool RefreshItemModal(CFileItemPtr item, bool forceRefresh = true, bool refreshAll = false);
+  bool RefreshItemModal(std::shared_ptr<CFileItem> item,
+                        bool forceRefresh = true,
+                        bool refreshAll = false);
 
   /*!
    \brief Queue a watched status update job.
@@ -102,14 +109,14 @@ public:
    \param[in] item Item to update watched status for
    \param[in] watched New watched status
    */
-  void MarkAsWatched(const CFileItemPtr &item, bool watched);
+  void MarkAsWatched(const std::shared_ptr<CFileItem>& item, bool watched);
 
   /*!
    \brief Queue a reset resume point job.
 
    \param[in] item Item to reset the resume point for
    */
-  void ResetResumePoint(const CFileItemPtr& item);
+  void ResetResumePoint(const std::shared_ptr<CFileItem>& item);
 
   /*!
    \brief Adds the given job to the queue.

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -8,6 +8,7 @@
 
 #include "GUIDialogSubtitles.h"
 
+#include "FileItem.h"
 #include "LangInfo.h"
 #include "ServiceBroker.h"
 #include "URL.h"

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1235,7 +1235,7 @@ void CGUIDialogVideoInfo::AddItemPathToFileBrowserSources(VECSOURCES& sources,
   AddItemPathStringToFileBrowserSources(sources, itemDir, g_localizeStrings.Get(36041));
 }
 
-int CGUIDialogVideoInfo::ManageVideoItem(const CFileItemPtr &item)
+int CGUIDialogVideoInfo::ManageVideoItem(const std::shared_ptr<CFileItem>& item)
 {
   if (item == nullptr || !item->IsVideoDb() || !item->HasVideoInfoTag() || item->GetVideoInfoTag()->m_iDbId < 0)
     return -1;
@@ -1383,7 +1383,7 @@ int CGUIDialogVideoInfo::ManageVideoItem(const CFileItemPtr &item)
 }
 
 //Add change a title's name
-bool CGUIDialogVideoInfo::UpdateVideoItemTitle(const CFileItemPtr &pItem)
+bool CGUIDialogVideoInfo::UpdateVideoItemTitle(const std::shared_ptr<CFileItem>& pItem)
 {
   if (pItem == nullptr || !pItem->HasVideoInfoTag())
     return false;
@@ -1455,7 +1455,7 @@ bool CGUIDialogVideoInfo::UpdateVideoItemTitle(const CFileItemPtr &pItem)
   return true;
 }
 
-bool CGUIDialogVideoInfo::CanDeleteVideoItem(const CFileItemPtr &item)
+bool CGUIDialogVideoInfo::CanDeleteVideoItem(const std::shared_ptr<CFileItem>& item)
 {
   if (item == nullptr || !item->HasVideoInfoTag())
     return false;
@@ -1474,7 +1474,8 @@ bool CGUIDialogVideoInfo::CanDeleteVideoItem(const CFileItemPtr &item)
           !CVideoDatabaseDirectory::IsAllItem(item->GetPath()));
 }
 
-bool CGUIDialogVideoInfo::DeleteVideoItemFromDatabase(const CFileItemPtr &item, bool unavailable /* = false */)
+bool CGUIDialogVideoInfo::DeleteVideoItemFromDatabase(const std::shared_ptr<CFileItem>& item,
+                                                      bool unavailable /* = false */)
 {
   if (item == nullptr || !item->HasVideoInfoTag() ||
       !CanDeleteVideoItem(item))
@@ -1577,7 +1578,8 @@ bool CGUIDialogVideoInfo::DeleteVideoItemFromDatabase(const CFileItemPtr &item, 
   return true;
 }
 
-bool CGUIDialogVideoInfo::DeleteVideoItem(const CFileItemPtr &item, bool unavailable /* = false */)
+bool CGUIDialogVideoInfo::DeleteVideoItem(const std::shared_ptr<CFileItem>& item,
+                                          bool unavailable /* = false */)
 {
   if (item == nullptr)
     return false;
@@ -1628,7 +1630,7 @@ bool CGUIDialogVideoInfo::DeleteVideoItem(const CFileItemPtr &item, bool unavail
   return true;
 }
 
-bool CGUIDialogVideoInfo::ManageMovieSets(const CFileItemPtr &item)
+bool CGUIDialogVideoInfo::ManageMovieSets(const std::shared_ptr<CFileItem>& item)
 {
   if (item == nullptr)
     return false;
@@ -1725,7 +1727,8 @@ bool CGUIDialogVideoInfo::GetMoviesForSet(const CFileItem *setItem, CFileItemLis
     return false;
 }
 
-bool CGUIDialogVideoInfo::GetSetForMovie(const CFileItem *movieItem, CFileItemPtr &selectedSet)
+bool CGUIDialogVideoInfo::GetSetForMovie(const CFileItem* movieItem,
+                                         std::shared_ptr<CFileItem>& selectedSet)
 {
   if (movieItem == nullptr || !movieItem->HasVideoInfoTag())
     return false;
@@ -1903,7 +1906,7 @@ bool CGUIDialogVideoInfo::GetItemsForTag(const std::string &strHeading, const st
   return items.Size() > 0;
 }
 
-bool CGUIDialogVideoInfo::AddItemsToTag(const CFileItemPtr &tagItem)
+bool CGUIDialogVideoInfo::AddItemsToTag(const std::shared_ptr<CFileItem>& tagItem)
 {
   if (tagItem == nullptr || !tagItem->HasVideoInfoTag())
     return false;
@@ -1936,7 +1939,7 @@ bool CGUIDialogVideoInfo::AddItemsToTag(const CFileItemPtr &tagItem)
   return true;
 }
 
-bool CGUIDialogVideoInfo::RemoveItemsFromTag(const CFileItemPtr &tagItem)
+bool CGUIDialogVideoInfo::RemoveItemsFromTag(const std::shared_ptr<CFileItem>& tagItem)
 {
   if (tagItem == nullptr || !tagItem->HasVideoInfoTag())
     return false;
@@ -1992,7 +1995,8 @@ std::string FindLocalMovieSetArtworkFile(const CFileItemPtr& item, const std::st
 }
 } // namespace
 
-bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const CFileItemPtr &item, const MediaType &type)
+bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const std::shared_ptr<CFileItem>& item,
+                                                 const MediaType& type)
 {
   if (item == nullptr || !item->HasVideoInfoTag() || type.empty())
     return false;
@@ -2231,7 +2235,7 @@ std::string CGUIDialogVideoInfo::GetLocalizedVideoType(const std::string &strTyp
   return "";
 }
 
-bool CGUIDialogVideoInfo::UpdateVideoItemSortTitle(const CFileItemPtr &pItem)
+bool CGUIDialogVideoInfo::UpdateVideoItemSortTitle(const std::shared_ptr<CFileItem>& pItem)
 {
   // dont allow update while scanning
   if (CVideoLibraryQueue::GetInstance().IsScanningLibrary())
@@ -2265,7 +2269,9 @@ bool CGUIDialogVideoInfo::UpdateVideoItemSortTitle(const CFileItemPtr &pItem)
   return database.UpdateVideoSortTitle(iDbId, currentTitle, iType);
 }
 
-bool CGUIDialogVideoInfo::LinkMovieToTvShow(const CFileItemPtr &item, bool bRemove, CVideoDatabase &database)
+bool CGUIDialogVideoInfo::LinkMovieToTvShow(const std::shared_ptr<CFileItem>& item,
+                                            bool bRemove,
+                                            CVideoDatabase& database)
 {
   int dbId = item->GetVideoInfoTag()->m_iDbId;
 
@@ -2329,7 +2335,7 @@ bool CGUIDialogVideoInfo::LinkMovieToTvShow(const CFileItemPtr &item, bool bRemo
   return false;
 }
 
-bool CGUIDialogVideoInfo::OnGetFanart(const CFileItemPtr &videoItem)
+bool CGUIDialogVideoInfo::OnGetFanart(const std::shared_ptr<CFileItem>& videoItem)
 {
   if (videoItem == nullptr || !videoItem->HasVideoInfoTag())
     return false;

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.h
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.h
@@ -8,10 +8,14 @@
 
 #pragma once
 
-#include "FileItem.h"
 #include "MediaSource.h"
 #include "guilib/GUIDialog.h"
+#include "media/MediaType.h"
 
+#include <memory>
+
+class CFileItem;
+class CFileItemList;
 class CVideoDatabase;
 
 class CGUIDialogVideoInfo :
@@ -29,28 +33,29 @@ public:
   bool HasUpdatedUserrating() const { return m_hasUpdatedUserrating; }
 
   std::string GetThumbnail() const;
-  CFileItemPtr GetCurrentListItem(int offset = 0) override { return m_movieItem; }
+  std::shared_ptr<CFileItem> GetCurrentListItem(int offset = 0) override { return m_movieItem; }
   const CFileItemList& CurrentDirectory() const { return *m_castList; }
   bool HasListItems() const override { return true; }
 
   static void AddItemPathToFileBrowserSources(VECSOURCES &sources, const CFileItem &item);
 
-  static int ManageVideoItem(const CFileItemPtr &item);
-  static bool UpdateVideoItemTitle(const CFileItemPtr &pItem);
-  static bool CanDeleteVideoItem(const CFileItemPtr &item);
-  static bool DeleteVideoItemFromDatabase(const CFileItemPtr &item, bool unavailable = false);
-  static bool DeleteVideoItem(const CFileItemPtr &item, bool unavailable = false);
+  static int ManageVideoItem(const std::shared_ptr<CFileItem>& item);
+  static bool UpdateVideoItemTitle(const std::shared_ptr<CFileItem>& pItem);
+  static bool CanDeleteVideoItem(const std::shared_ptr<CFileItem>& item);
+  static bool DeleteVideoItemFromDatabase(const std::shared_ptr<CFileItem>& item,
+                                          bool unavailable = false);
+  static bool DeleteVideoItem(const std::shared_ptr<CFileItem>& item, bool unavailable = false);
 
-  static bool ManageMovieSets(const CFileItemPtr &item);
+  static bool ManageMovieSets(const std::shared_ptr<CFileItem>& item);
   static bool GetMoviesForSet(const CFileItem *setItem, CFileItemList &originalMovies, CFileItemList &selectedMovies);
-  static bool GetSetForMovie(const CFileItem *movieItem, CFileItemPtr &selectedSet);
+  static bool GetSetForMovie(const CFileItem* movieItem, std::shared_ptr<CFileItem>& selectedSet);
   static bool SetMovieSet(const CFileItem *movieItem, const CFileItem *selectedSet);
 
   static bool GetItemsForTag(const std::string &strHeading, const std::string &type, CFileItemList &items, int idTag = -1, bool showAll = true);
-  static bool AddItemsToTag(const CFileItemPtr &tagItem);
-  static bool RemoveItemsFromTag(const CFileItemPtr &tagItem);
+  static bool AddItemsToTag(const std::shared_ptr<CFileItem>& tagItem);
+  static bool RemoveItemsFromTag(const std::shared_ptr<CFileItem>& tagItem);
 
-  static bool ManageVideoItemArtwork(const CFileItemPtr &item, const MediaType &type);
+  static bool ManageVideoItemArtwork(const std::shared_ptr<CFileItem>& item, const MediaType& type);
 
   static std::string GetLocalizedVideoType(const std::string &strType);
 
@@ -86,15 +91,17 @@ protected:
   void OnSetUserrating() const;
   void PlayTrailer();
 
-  static bool UpdateVideoItemSortTitle(const CFileItemPtr &pItem);
-  static bool LinkMovieToTvShow(const CFileItemPtr &item, bool bRemove, CVideoDatabase &database);
+  static bool UpdateVideoItemSortTitle(const std::shared_ptr<CFileItem>& pItem);
+  static bool LinkMovieToTvShow(const std::shared_ptr<CFileItem>& item,
+                                bool bRemove,
+                                CVideoDatabase& database);
 
   /*! \brief Pop up a fanart chooser. Does not utilise remote URLs.
    \param videoItem the item to choose fanart for.
    */
-  static bool OnGetFanart(const CFileItemPtr &videoItem);
+  static bool OnGetFanart(const std::shared_ptr<CFileItem>& videoItem);
 
-  CFileItemPtr m_movieItem;
+  std::shared_ptr<CFileItem> m_movieItem;
   CFileItemList *m_castList;
   bool m_bViewReview = false;
   bool m_bRefresh = false;

--- a/xbmc/video/jobs/VideoLibraryMarkWatchedJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryMarkWatchedJob.cpp
@@ -23,9 +23,9 @@
 #include "utils/URIUtils.h"
 #include "video/VideoDatabase.h"
 
-CVideoLibraryMarkWatchedJob::CVideoLibraryMarkWatchedJob(const CFileItemPtr &item, bool mark)
-  : m_item(item),
-    m_mark(mark)
+CVideoLibraryMarkWatchedJob::CVideoLibraryMarkWatchedJob(const std::shared_ptr<CFileItem>& item,
+                                                         bool mark)
+  : m_item(item), m_mark(mark)
 { }
 
 CVideoLibraryMarkWatchedJob::~CVideoLibraryMarkWatchedJob() = default;

--- a/xbmc/video/jobs/VideoLibraryMarkWatchedJob.h
+++ b/xbmc/video/jobs/VideoLibraryMarkWatchedJob.h
@@ -8,8 +8,11 @@
 
 #pragma once
 
-#include "FileItem.h"
 #include "video/jobs/VideoLibraryJob.h"
+
+#include <memory>
+
+class CFileItem;
 
 /*!
  \brief Video library job implementation for marking items as watched/unwatched.
@@ -23,7 +26,7 @@ public:
    \param[in] item Item to be marked as watched/unwatched
    \param[in] mark Whether to mark the item as watched or unwatched
   */
-  CVideoLibraryMarkWatchedJob(const CFileItemPtr &item, bool mark);
+  CVideoLibraryMarkWatchedJob(const std::shared_ptr<CFileItem>& item, bool mark);
   ~CVideoLibraryMarkWatchedJob() override;
 
   const char *GetType() const override { return "CVideoLibraryMarkWatchedJob"; }
@@ -33,6 +36,6 @@ protected:
   bool Work(CVideoDatabase &db) override;
 
 private:
-  CFileItemPtr m_item;
+  std::shared_ptr<CFileItem> m_item;
   bool m_mark;
 };

--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
@@ -8,6 +8,7 @@
 
 #include "VideoLibraryRefreshingJob.h"
 
+#include "FileItem.h"
 #include "ServiceBroker.h"
 #include "TextureDatabase.h"
 #include "addons/Scraper.h"

--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
@@ -35,7 +35,7 @@
 using namespace KODI::MESSAGING;
 using namespace VIDEO;
 
-CVideoLibraryRefreshingJob::CVideoLibraryRefreshingJob(CFileItemPtr item,
+CVideoLibraryRefreshingJob::CVideoLibraryRefreshingJob(std::shared_ptr<CFileItem> item,
                                                        bool forceRefresh,
                                                        bool refreshAll,
                                                        bool ignoreNfo /* = false */,

--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.h
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.h
@@ -8,10 +8,12 @@
 
 #pragma once
 
-#include "FileItem.h"
 #include "video/jobs/VideoLibraryProgressJob.h"
 
+#include <memory>
 #include <string>
+
+class CFileItem;
 
 /*!
  \brief Video library job implementation for refreshing a single item.
@@ -28,7 +30,11 @@ public:
    \param[in] ignoreNfo Whether or not to ignore local NFO files
    \param[in] searchTitle Title to use for the search (instead of determining it from the item's filename/path)
   */
-  CVideoLibraryRefreshingJob(CFileItemPtr item, bool forceRefresh, bool refreshAll, bool ignoreNfo = false, const std::string& searchTitle = "");
+  CVideoLibraryRefreshingJob(std::shared_ptr<CFileItem> item,
+                             bool forceRefresh,
+                             bool refreshAll,
+                             bool ignoreNfo = false,
+                             const std::string& searchTitle = "");
 
   ~CVideoLibraryRefreshingJob() override;
 
@@ -41,7 +47,7 @@ protected:
   bool Work(CVideoDatabase &db) override;
 
 private:
-  CFileItemPtr m_item;
+  std::shared_ptr<CFileItem> m_item;
   bool m_forceRefresh;
   bool m_refreshAll;
   bool m_ignoreNfo;

--- a/xbmc/video/jobs/VideoLibraryResetResumePointJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryResetResumePointJob.cpp
@@ -24,7 +24,8 @@
 #include "utils/URIUtils.h"
 #include "video/VideoDatabase.h"
 
-CVideoLibraryResetResumePointJob::CVideoLibraryResetResumePointJob(const CFileItemPtr& item)
+CVideoLibraryResetResumePointJob::CVideoLibraryResetResumePointJob(
+    const std::shared_ptr<CFileItem>& item)
   : m_item(item)
 {
 }

--- a/xbmc/video/jobs/VideoLibraryResetResumePointJob.h
+++ b/xbmc/video/jobs/VideoLibraryResetResumePointJob.h
@@ -11,6 +11,8 @@
 #include "FileItem.h"
 #include "video/jobs/VideoLibraryJob.h"
 
+#include <memory>
+
 /*!
  \brief Video library job implementation for resetting a resume point.
  */
@@ -22,7 +24,7 @@ public:
 
    \param[in] item Item for that the resume point shall be reset.
   */
-  CVideoLibraryResetResumePointJob(const CFileItemPtr& item);
+  CVideoLibraryResetResumePointJob(const std::shared_ptr<CFileItem>& item);
   ~CVideoLibraryResetResumePointJob() override = default;
 
   const char *GetType() const override { return "CVideoLibraryResetResumePointJob"; }
@@ -32,5 +34,5 @@ protected:
   bool Work(CVideoDatabase &db) override;
 
 private:
-  CFileItemPtr m_item;
+  std::shared_ptr<CFileItem> m_item;
 };

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -9,6 +9,7 @@
 #include "GUIMediaWindow.h"
 
 #include "ContextMenuManager.h"
+#include "FileItem.h"
 #include "FileItemListModification.h"
 #include "GUIPassword.h"
 #include "GUIUserMessages.h"


### PR DESCRIPTION
## Description
FileItem.h is an extremely hot header. Let's not feed its ego more than neecssary.

## Motivation and context
Reduce rebuild time when touching Fileitem.h's naughty bits.

## How has this been tested?
It builds.

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

Before PR: 617 files rebuilt.
After PR: 407 files rebuilt.