### PR TITLE
CAESinkPipewire: const updates and improvements

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -220,22 +220,24 @@ void CAESinkPipewire::EnumerateDevicesEx(AEDeviceInfoList& list, bool force)
   auto loop = pipewire->GetThreadLoop();
   loop->Lock();
 
-  CAEDeviceInfo device;
-  device.m_deviceType = AE_DEVTYPE_PCM;
-  device.m_deviceName = "Default";
-  device.m_displayName = "Default";
-  device.m_displayNameExtra = "Default Output Device (PIPEWIRE)";
-  device.m_wantsIECPassthrough = true;
+  CAEDeviceInfo defaultDevice;
+  defaultDevice.m_deviceType = AE_DEVTYPE_PCM;
+  defaultDevice.m_deviceName = "Default";
+  defaultDevice.m_displayName = "Default";
+  defaultDevice.m_displayNameExtra = "Default Output Device (PIPEWIRE)";
+  defaultDevice.m_wantsIECPassthrough = true;
 
   std::for_each(formatMap.cbegin(), formatMap.cend(),
-                [&device](const auto& pair) { device.m_dataFormats.emplace_back(pair.second); });
+                [&defaultDevice](const auto& pair)
+                { defaultDevice.m_dataFormats.emplace_back(pair.second); });
 
   std::for_each(defaultSampleRates.cbegin(), defaultSampleRates.cend(),
-                [&device](const auto& rate) { device.m_sampleRates.emplace_back(rate); });
+                [&defaultDevice](const auto& rate)
+                { defaultDevice.m_sampleRates.emplace_back(rate); });
 
-  device.m_channels = CAEChannelInfo(AE_CH_LAYOUT_2_0);
+  defaultDevice.m_channels = CAEChannelInfo(AE_CH_LAYOUT_2_0);
 
-  list.emplace_back(device);
+  list.emplace_back(defaultDevice);
 
   for (const auto& global : pipewire->GetGlobals())
   {

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -53,7 +53,7 @@ constexpr auto formatMap = make_map<spa_audio_format, AEDataFormat>(
      {SPA_AUDIO_FORMAT_S24, AEDataFormat::AE_FMT_S24NE3},
      {SPA_AUDIO_FORMAT_F32, AEDataFormat::AE_FMT_FLOAT}});
 
-uint8_t PWFormatToSampleSize(spa_audio_format format)
+constexpr uint8_t PWFormatToSampleSize(spa_audio_format format)
 {
   switch (format)
   {
@@ -73,7 +73,7 @@ uint8_t PWFormatToSampleSize(spa_audio_format format)
   }
 }
 
-std::string PWFormatToString(spa_audio_format format)
+constexpr std::string_view PWFormatToString(spa_audio_format format)
 {
   switch (format)
   {
@@ -107,7 +107,7 @@ spa_audio_format AEFormatToPWFormat(AEDataFormat& format)
   return SPA_AUDIO_FORMAT_F32;
 }
 
-AEDataFormat PWFormatToAEFormat(spa_audio_format& format)
+constexpr AEDataFormat PWFormatToAEFormat(spa_audio_format& format)
 {
   return formatMap.at(format);
 }

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -230,8 +230,8 @@ void CAESinkPipewire::EnumerateDevicesEx(AEDeviceInfoList& list, bool force)
   std::for_each(formatMap.cbegin(), formatMap.cend(),
                 [&device](const auto& pair) { device.m_dataFormats.emplace_back(pair.second); });
 
-  for (const auto& rate : defaultSampleRates)
-    device.m_sampleRates.emplace_back(rate);
+  std::for_each(defaultSampleRates.cbegin(), defaultSampleRates.cend(),
+                [&device](const auto& rate) { device.m_sampleRates.emplace_back(rate); });
 
   device.m_channels = CAEChannelInfo(AE_CH_LAYOUT_2_0);
 
@@ -249,8 +249,8 @@ void CAESinkPipewire::EnumerateDevicesEx(AEDeviceInfoList& list, bool force)
     std::for_each(formatMap.cbegin(), formatMap.cend(),
                   [&device](const auto& pair) { device.m_dataFormats.emplace_back(pair.second); });
 
-    for (const auto& rate : defaultSampleRates)
-      device.m_sampleRates.emplace_back(rate);
+    std::for_each(defaultSampleRates.cbegin(), defaultSampleRates.cend(),
+                  [&device](const auto& rate) { device.m_sampleRates.emplace_back(rate); });
 
     auto proxy = global.second->proxy.get();
     auto node = static_cast<PIPEWIRE::CPipewireNode*>(proxy);


### PR DESCRIPTION
This PR uses the new constexpr map class added in #21084 

This allows marking some maps as constexpr.

I've also added a commit to fix a shadow variable.

No functional changes are present.