### PR TITLE
add fmt::formatter for some video related enums

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -739,7 +739,7 @@ void CLinuxRendererGL::UpdateVideoFilter()
     CLog::Log(LOGWARNING,
               "CLinuxRendererGL::UpdateVideoFilter - chosen scaling method {}, is not supported by "
               "renderer",
-              (int)m_scalingMethod);
+              m_scalingMethod);
     m_scalingMethod = VS_SCALINGMETHOD_LINEAR;
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -532,7 +532,7 @@ void CLinuxRendererGLES::UpdateVideoFilter()
     CLog::Log(LOGWARNING,
               "CLinuxRendererGLES::UpdateVideoFilter - chosen scaling method {}, is not supported "
               "by renderer",
-              static_cast<int>(m_scalingMethod));
+              m_scalingMethod);
     m_scalingMethod = VS_SCALINGMETHOD_LINEAR;
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ShaderFormats.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ShaderFormats.h
@@ -8,6 +8,10 @@
 
 #pragma once
 
+#include "utils/Map.h"
+
+#include <fmt/format.h>
+
 enum EShaderFormat
 {
   SHADER_NONE,
@@ -20,5 +24,39 @@ enum EShaderFormat
   SHADER_NV12,
   SHADER_YUY2,
   SHADER_UYVY,
-  SHADER_NV12_RRG
+  SHADER_NV12_RRG,
+  SHADER_MAX,
+};
+
+template<>
+struct fmt::formatter<EShaderFormat> : fmt::formatter<std::string_view>
+{
+  template<typename FormatContext>
+  constexpr auto format(const EShaderFormat& shaderFormat, FormatContext& ctx)
+  {
+    const auto it = shaderFormatMap.find(shaderFormat);
+    if (it == shaderFormatMap.cend())
+      throw std::range_error("no shader format string found");
+
+    return fmt::formatter<string_view>::format(it->second, ctx);
+  }
+
+private:
+  static constexpr auto shaderFormatMap = make_map<EShaderFormat, std::string_view>({
+      {SHADER_NONE, "none"},
+      {SHADER_YV12, "YV12"},
+      {SHADER_YV12_9, "YV12 9bit"},
+      {SHADER_YV12_10, "YV12 10bit"},
+      {SHADER_YV12_12, "YV12 12bit"},
+      {SHADER_YV12_14, "YV12 14bit"},
+      {SHADER_YV12_16, "YV12 16bit"},
+      {SHADER_NV12, "NV12"},
+      {SHADER_YUY2, "YUY2"},
+      {SHADER_UYVY, "UYVY"},
+      {SHADER_NV12_RRG, "NV12 red/red/green"},
+  });
+
+  static_assert(SHADER_MAX == shaderFormatMap.size(),
+                "shaderFormatMap doesn't match the size of EShaderFormat, did you forget to "
+                "add/remove a mapping?");
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGL.cpp
@@ -99,7 +99,9 @@ ConvolutionFilterShader::ConvolutionFilterShader(ESCALINGMETHOD method, bool str
     defines += m_glslOutput->GetDefines();
   }
 
-  CLog::Log(LOGDEBUG, "GL: ConvolutionFilterShader: using {} defines:\n{}", shadername, defines);
+  CLog::Log(LOGDEBUG, "GL: using scaling method: {}", m_method);
+  CLog::Log(LOGDEBUG, "GL: using shader: {}", shadername);
+
   PixelShader()->LoadSource(shadername, defines);
   PixelShader()->AppendSource("gl_output.glsl");
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGLES.cpp
@@ -99,7 +99,9 @@ ConvolutionFilterShader::ConvolutionFilterShader(ESCALINGMETHOD method)
     m_internalformat = GL_RGBA;
   }
 
-  CLog::Log(LOGDEBUG, "GL: ConvolutionFilterShader: using {} defines:\n{}", shadername, defines);
+  CLog::Log(LOGDEBUG, "GLES: using scaling method: {}", m_method);
+  CLog::Log(LOGDEBUG, "GLES: using shader: {}", shadername);
+
   PixelShader()->LoadSource(shadername, defines);
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.cpp
@@ -104,7 +104,8 @@ BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(bool rect,
 
   VertexShader()->LoadSource("gl_yuv2rgb_vertex.glsl", m_defines);
 
-  CLog::Log(LOGDEBUG, "GL: BaseYUV2RGBGLSLShader: defines:\n{}", m_defines);
+  CLog::Log(LOGDEBUG, "GL: using shader format: {}", m_format);
+  CLog::Log(LOGDEBUG, "GL: using tonemap method: {}", toneMapMethod);
 
   m_convMatrix.SetDestinationColorPrimaries(dstPrimaries).SetSourceColorPrimaries(srcPrimaries);
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
@@ -68,7 +68,8 @@ BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(EShaderFormat format,
 
   VertexShader()->LoadSource("gles_yuv2rgb.vert", m_defines);
 
-  CLog::Log(LOGDEBUG, "GLES: BaseYUV2RGBGLSLShader: defines:\n{}", m_defines);
+  CLog::Log(LOGDEBUG, "GLES: using shader format: {}", m_format);
+  CLog::Log(LOGDEBUG, "GLES: using tonemap method: {}", m_toneMappingMethod);
 
   m_convMatrix.SetSourceColorPrimaries(srcPrimaries).SetDestinationColorPrimaries(dstPrimaries);
 }

--- a/xbmc/cores/VideoSettings.h
+++ b/xbmc/cores/VideoSettings.h
@@ -8,6 +8,12 @@
 
 #pragma once
 
+#include "utils/Map.h"
+
+#include <string_view>
+
+#include <fmt/format.h>
+
 // VideoSettings.h: interface for the CVideoSettings class.
 //
 //////////////////////////////////////////////////////////////////////
@@ -32,6 +38,41 @@ enum EINTERLACEMETHOD
   VS_INTERLACEMETHOD_VAAPI_MACI = 24,
   VS_INTERLACEMETHOD_DXVA_AUTO = 32,
   VS_INTERLACEMETHOD_MAX // do not use and keep as last enum value.
+};
+
+template<>
+struct fmt::formatter<EINTERLACEMETHOD> : fmt::formatter<std::string_view>
+{
+  template<typename FormatContext>
+  constexpr auto format(const EINTERLACEMETHOD& interlaceMethod, FormatContext& ctx)
+  {
+    const auto it = interlaceMethodMap.find(interlaceMethod);
+    if (it == interlaceMethodMap.cend())
+      throw std::range_error("no interlace method string found");
+
+    return fmt::formatter<string_view>::format(it->second, ctx);
+  }
+
+private:
+  static constexpr auto interlaceMethodMap = make_map<EINTERLACEMETHOD, std::string_view>({
+      {VS_INTERLACEMETHOD_NONE, "none"},
+      {VS_INTERLACEMETHOD_AUTO, "auto"},
+      {VS_INTERLACEMETHOD_RENDER_BLEND, "render blend"},
+      {VS_INTERLACEMETHOD_RENDER_WEAVE, "render weave"},
+      {VS_INTERLACEMETHOD_RENDER_BOB, "render bob"},
+      {VS_INTERLACEMETHOD_DEINTERLACE, "deinterlace"},
+      {VS_INTERLACEMETHOD_VDPAU_BOB, "vdpau bob"},
+      {VS_INTERLACEMETHOD_VDPAU_INVERSE_TELECINE, "vdpau inverse telecine"},
+      {VS_INTERLACEMETHOD_VDPAU_TEMPORAL, "vdpau temporal"},
+      {VS_INTERLACEMETHOD_VDPAU_TEMPORAL_HALF, "vdpau temporal half"},
+      {VS_INTERLACEMETHOD_VDPAU_TEMPORAL_SPATIAL, "vdpau temporal spatial"},
+      {VS_INTERLACEMETHOD_VDPAU_TEMPORAL_SPATIAL_HALF, "vdpau temporal spatial half"},
+      {VS_INTERLACEMETHOD_DEINTERLACE_HALF, "deinterlace half"},
+      {VS_INTERLACEMETHOD_VAAPI_BOB, "vaapi bob"},
+      {VS_INTERLACEMETHOD_VAAPI_MADI, "vaapi madi"},
+      {VS_INTERLACEMETHOD_VAAPI_MACI, "vaapi maci"},
+      {VS_INTERLACEMETHOD_DXVA_AUTO, "dxva auto"},
+  });
 };
 
 enum ESCALINGMETHOD

--- a/xbmc/cores/VideoSettings.h
+++ b/xbmc/cores/VideoSettings.h
@@ -150,6 +150,33 @@ enum ETONEMAPMETHOD
   VS_TONEMAPMETHOD_MAX
 };
 
+template<>
+struct fmt::formatter<ETONEMAPMETHOD> : fmt::formatter<std::string_view>
+{
+public:
+  template<typename FormatContext>
+  constexpr auto format(const ETONEMAPMETHOD& tonemapMethod, FormatContext& ctx)
+  {
+    const auto it = tonemapMethodMap.find(tonemapMethod);
+    if (it == tonemapMethodMap.cend())
+      throw std::range_error("no tonemap method string found");
+
+    return fmt::formatter<string_view>::format(it->second, ctx);
+  }
+
+private:
+  static constexpr auto tonemapMethodMap = make_map<ETONEMAPMETHOD, std::string_view>({
+      {VS_TONEMAPMETHOD_OFF, "off"},
+      {VS_TONEMAPMETHOD_REINHARD, "reinhard"},
+      {VS_TONEMAPMETHOD_ACES, "aces"},
+      {VS_TONEMAPMETHOD_HABLE, "hable"},
+  });
+
+  static_assert(VS_TONEMAPMETHOD_MAX == tonemapMethodMap.size(),
+                "tonemapMethodMap doesn't match the size of ETONEMAPMETHOD, did you forget to "
+                "add/remove a mapping?");
+};
+
 enum ViewMode
 {
   ViewModeNormal = 0,

--- a/xbmc/cores/VideoSettings.h
+++ b/xbmc/cores/VideoSettings.h
@@ -99,6 +99,48 @@ enum ESCALINGMETHOD
   VS_SCALINGMETHOD_MAX // do not use and keep as last enum value.
 };
 
+template<>
+struct fmt::formatter<ESCALINGMETHOD> : fmt::formatter<std::string_view>
+{
+public:
+  template<typename FormatContext>
+  constexpr auto format(const ESCALINGMETHOD& scalingMethod, FormatContext& ctx)
+  {
+    const auto it = scalingMethodMap.find(scalingMethod);
+    if (it == scalingMethodMap.cend())
+      throw std::range_error("no scaling method string found");
+
+    return fmt::formatter<string_view>::format(it->second, ctx);
+  }
+
+private:
+  static constexpr auto scalingMethodMap = make_map<ESCALINGMETHOD, std::string_view>({
+      {VS_SCALINGMETHOD_NEAREST, "nearest neighbour"},
+      {VS_SCALINGMETHOD_LINEAR, "linear"},
+      {VS_SCALINGMETHOD_CUBIC_B_SPLINE, "cubic b spline"},
+      {VS_SCALINGMETHOD_CUBIC_MITCHELL, "cubic mitchell"},
+      {VS_SCALINGMETHOD_CUBIC_CATMULL, "cubic catmull"},
+      {VS_SCALINGMETHOD_CUBIC_0_075, "cubic 0/075"},
+      {VS_SCALINGMETHOD_CUBIC_0_1, "cubic 0/1"},
+      {VS_SCALINGMETHOD_LANCZOS2, "lanczos2"},
+      {VS_SCALINGMETHOD_LANCZOS3_FAST, "lanczos3 fast"},
+      {VS_SCALINGMETHOD_LANCZOS3, "lanczos3"},
+      {VS_SCALINGMETHOD_SINC8, "sinc8"},
+      {VS_SCALINGMETHOD_BICUBIC_SOFTWARE, "bicubic software"},
+      {VS_SCALINGMETHOD_LANCZOS_SOFTWARE, "lanczos software"},
+      {VS_SCALINGMETHOD_SINC_SOFTWARE, "sinc software"},
+      {VS_SCALINGMETHOD_VDPAU_HARDWARE, "vdpau"},
+      {VS_SCALINGMETHOD_DXVA_HARDWARE, "dxva"},
+      {VS_SCALINGMETHOD_AUTO, "auto"},
+      {VS_SCALINGMETHOD_SPLINE36_FAST, "spline32 fast"},
+      {VS_SCALINGMETHOD_SPLINE36, "spline32"},
+  });
+
+  static_assert(VS_SCALINGMETHOD_MAX == scalingMethodMap.size(),
+                "scalingMethodMap doesn't match the size of ESCALINGMETHOD, did you forget to "
+                "add/remove a mapping?");
+};
+
 enum ETONEMAPMETHOD
 {
   VS_TONEMAPMETHOD_OFF = 0,

--- a/xbmc/rendering/gl/RenderSystemGL.h
+++ b/xbmc/rendering/gl/RenderSystemGL.h
@@ -11,6 +11,7 @@
 #include "GLShader.h"
 #include "rendering/RenderSystem.h"
 #include "utils/ColorUtils.h"
+#include "utils/Map.h"
 
 #include <map>
 #include <memory>
@@ -27,51 +28,37 @@ enum class ShaderMethodGL
   SM_MULTI,
   SM_FONTS,
   SM_TEXTURE_NOBLEND,
-  SM_MULTI_BLENDCOLOR
+  SM_MULTI_BLENDCOLOR,
+  SM_MAX
 };
 
 template<>
 struct fmt::formatter<ShaderMethodGL> : fmt::formatter<std::string_view>
 {
-
-public:
-  static constexpr auto toString(ShaderMethodGL method)
-  {
-    switch (method)
-    {
-      case ShaderMethodGL::SM_DEFAULT:
-        return "default";
-        break;
-      case ShaderMethodGL::SM_TEXTURE:
-        return "texture";
-        break;
-      case ShaderMethodGL::SM_TEXTURE_LIM:
-        return "texture limited";
-        break;
-      case ShaderMethodGL::SM_MULTI:
-        return "multi";
-        break;
-      case ShaderMethodGL::SM_FONTS:
-        return "fonts";
-        break;
-      case ShaderMethodGL::SM_TEXTURE_NOBLEND:
-        return "texture no blending";
-        break;
-      case ShaderMethodGL::SM_MULTI_BLENDCOLOR:
-        return "multi blend colour";
-        break;
-      default:
-        return "unknown";
-        break;
-    }
-  }
-
   template<typename FormatContext>
   constexpr auto format(const ShaderMethodGL& shaderMethod, FormatContext& ctx)
   {
-    auto shaderName = toString(shaderMethod);
-    return fmt::formatter<std::string_view>::format(shaderName, ctx);
+    const auto it = ShaderMethodGLMap.find(shaderMethod);
+    if (it == ShaderMethodGLMap.cend())
+      throw std::range_error("no string mapping found for shader method");
+
+    return fmt::formatter<string_view>::format(it->second, ctx);
   }
+
+private:
+  static constexpr auto ShaderMethodGLMap = make_map<ShaderMethodGL, std::string_view>({
+      {ShaderMethodGL::SM_DEFAULT, "default"},
+      {ShaderMethodGL::SM_TEXTURE, "texture"},
+      {ShaderMethodGL::SM_TEXTURE_LIM, "texture limited"},
+      {ShaderMethodGL::SM_MULTI, "multi"},
+      {ShaderMethodGL::SM_FONTS, "fonts"},
+      {ShaderMethodGL::SM_TEXTURE_NOBLEND, "texture no blending"},
+      {ShaderMethodGL::SM_MULTI_BLENDCOLOR, "multi blend colour"},
+  });
+
+  static_assert(static_cast<size_t>(ShaderMethodGL::SM_MAX) == ShaderMethodGLMap.size(),
+                "ShaderMethodGLMap doesn't match the size of ShaderMethodGL, did you forget to "
+                "add/remove a mapping?");
 };
 
 class CRenderSystemGL : public CRenderSystemBase

--- a/xbmc/rendering/gles/RenderSystemGLES.h
+++ b/xbmc/rendering/gles/RenderSystemGLES.h
@@ -11,6 +11,7 @@
 #include "GLESShader.h"
 #include "rendering/RenderSystem.h"
 #include "utils/ColorUtils.h"
+#include "utils/Map.h"
 
 #include <map>
 
@@ -31,66 +32,42 @@ enum class ShaderMethodGLES
   SM_TEXTURE_RGBA_BLENDCOLOR,
   SM_TEXTURE_RGBA_BOB,
   SM_TEXTURE_RGBA_BOB_OES,
-  SM_TEXTURE_NOALPHA
+  SM_TEXTURE_NOALPHA,
+  SM_MAX
 };
 
 template<>
 struct fmt::formatter<ShaderMethodGLES> : fmt::formatter<std::string_view>
 {
-
-public:
-  static constexpr auto toString(ShaderMethodGLES method)
-  {
-    switch (method)
-    {
-      case ShaderMethodGLES::SM_DEFAULT:
-        return "default";
-        break;
-      case ShaderMethodGLES::SM_TEXTURE:
-        return "texture";
-        break;
-      case ShaderMethodGLES::SM_MULTI:
-        return "multi";
-        break;
-      case ShaderMethodGLES::SM_FONTS:
-        return "fonts";
-        break;
-      case ShaderMethodGLES::SM_TEXTURE_NOBLEND:
-        return "texture no blending";
-        break;
-      case ShaderMethodGLES::SM_MULTI_BLENDCOLOR:
-        return "multi blend colour";
-        break;
-      case ShaderMethodGLES::SM_TEXTURE_RGBA:
-        return "texure rgba";
-        break;
-      case ShaderMethodGLES::SM_TEXTURE_RGBA_OES:
-        return "texure rgba OES";
-        break;
-      case ShaderMethodGLES::SM_TEXTURE_RGBA_BLENDCOLOR:
-        return "texture rgba blend colour";
-        break;
-      case ShaderMethodGLES::SM_TEXTURE_RGBA_BOB:
-        return "texure rgba bob";
-        break;
-      case ShaderMethodGLES::SM_TEXTURE_RGBA_BOB_OES:
-        return "texure rgba bob OES";
-        break;
-      case ShaderMethodGLES::SM_TEXTURE_NOALPHA:
-        return "texture no alpha";
-        break;
-      default:
-        return "unknown";
-        break;
-    }
-  }
-
   template<typename FormatContext>
   constexpr auto format(const ShaderMethodGLES& shaderMethod, FormatContext& ctx)
   {
-    auto shaderName = toString(shaderMethod);
-    return fmt::formatter<std::string_view>::format(shaderName, ctx);
+    const auto it = ShaderMethodGLESMap.find(shaderMethod);
+    if (it == ShaderMethodGLESMap.cend())
+      throw std::range_error("no string mapping found for shader method");
+
+    return fmt::formatter<string_view>::format(it->second, ctx);
   }
+
+private:
+  static constexpr auto ShaderMethodGLESMap = make_map<ShaderMethodGLES, std::string_view>({
+      {ShaderMethodGLES::SM_DEFAULT, "default"},
+      {ShaderMethodGLES::SM_TEXTURE, "texture"},
+      {ShaderMethodGLES::SM_MULTI, "multi"},
+      {ShaderMethodGLES::SM_FONTS, "fonts"},
+      {ShaderMethodGLES::SM_TEXTURE_NOBLEND, "texture no blending"},
+      {ShaderMethodGLES::SM_MULTI_BLENDCOLOR, "multi blend colour"},
+      {ShaderMethodGLES::SM_TEXTURE_RGBA, "texure rgba"},
+      {ShaderMethodGLES::SM_TEXTURE_RGBA_OES, "texture rgba OES"},
+      {ShaderMethodGLES::SM_TEXTURE_RGBA_BLENDCOLOR, "texture rgba blend colour"},
+      {ShaderMethodGLES::SM_TEXTURE_RGBA_BOB, "texture rgba bob"},
+      {ShaderMethodGLES::SM_TEXTURE_RGBA_BOB_OES, "texture rgba bob OES"},
+      {ShaderMethodGLES::SM_TEXTURE_NOALPHA, "texture no alpha"},
+  });
+
+  static_assert(static_cast<size_t>(ShaderMethodGLES::SM_MAX) == ShaderMethodGLESMap.size(),
+                "ShaderMethodGLESMap doesn't match the size of ShaderMethodGLES, did you forget to "
+                "add/remove a mapping?");
 };
 
 class CRenderSystemGLES : public CRenderSystemBase


### PR DESCRIPTION
This PR uses the new constexpr map class added in #21084 

The idea is to add mappings for some enums to a human readable strings. This allows better logging as it's more difficult to determine what is used when it just logs an int.

Unfortunately I cannot use a static_assert for each enum mapping as some don't use linear enum values.

For those that don't know, adding custom `fmt::formatter` methods allows logging specific types to a custom format. In this case we are mapping enums to `std::string_view` which can be logged.
