### PR TITLE
Fix audio/video issues when refreshrate switch is on

### DIFF
--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -224,10 +224,15 @@ void CWinSystemAndroid::InitiateModeChange()
                                     "videoscreen.delayrefreshchange") *
                                 100);
 
-  if (delay < 2000ms)
+  if (delay > 0ms && delay < 2000ms)
     delay = 2000ms;
+
   m_dispResetTimer->Stop();
-  m_dispResetTimer->Start(delay);
+  if (delay > 0ms)
+  {
+    CLog::LogF(LOGDEBUG, "Start dispResetTimer with delay: {}", delay);
+    m_dispResetTimer->Start(delay);
+  }
 
   SetHdmiState(false);
 }

--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -230,7 +230,7 @@ void CWinSystemAndroid::InitiateModeChange()
   m_dispResetTimer->Stop();
   if (delay > 0ms)
   {
-    CLog::LogF(LOGDEBUG, "Start dispResetTimer with delay: {}", delay);
+    CLog::LogF(LOGDEBUG, "Start dispResetTimer with delay: {}", delay.count());
     m_dispResetTimer->Start(delay);
   }
 


### PR DESCRIPTION
InitModeChange is only called when the system supports the HDMI_AUDIO_PLUG event.
If the user does not configure a delay after refresh rate switching, we rely on this event to signal ResetDisplay.

If we would still start the 2s timer and the AV equipment takes longer to do the refreshrate switch, we might send ResetDisplay (and thus reconfigure AE) exactly when HDMI is unavailable which breaks the whole av pipeline.

If the user sets a delay after refreshrate we keep the old logic to start a timer with at least 2s delay, so it's up to the user to set a timer high enough to make sure HDMI is already available when the timer expires.

## Motivation and context
Fix refreshrate switch breaking A/V for subsequent playbacks.
Most of the time I had to reboot my shield to get back to a workable state.

## How has this been tested?
Nvidia Shield with maybe a shitty TV/AVR combination where I sometimes get multiple HDMI_AUDIO_PLUG events with
HDMI off and the on event takes way longer then 2sec to arrive.

## What is the effect on users?
Keep a functional kodi when refreshrate switches take longer than 2s.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
