### PR TITLE
[PVR] Optimize PVR.ChannelNumberInput GUI label calculation

### DIFF
--- a/xbmc/pvr/PVRChannelNumberInputHandler.cpp
+++ b/xbmc/pvr/PVRChannelNumberInputHandler.cpp
@@ -18,20 +18,20 @@
 #include <mutex>
 #include <string>
 
+using namespace PVR;
 using namespace std::chrono_literals;
 
-namespace PVR
-{
-
 CPVRChannelNumberInputHandler::CPVRChannelNumberInputHandler()
-: CPVRChannelNumberInputHandler(CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRNumericChannelSwitchTimeout, CHANNEL_NUMBER_INPUT_MAX_DIGITS)
+  : CPVRChannelNumberInputHandler(CServiceBroker::GetSettingsComponent()
+                                      ->GetAdvancedSettings()
+                                      ->m_iPVRNumericChannelSwitchTimeout,
+                                  CHANNEL_NUMBER_INPUT_MAX_DIGITS)
 {
 }
 
-CPVRChannelNumberInputHandler::CPVRChannelNumberInputHandler(int iDelay, int iMaxDigits /* = CHANNEL_NUMBER_INPUT_MAX_DIGITS */)
-: m_iDelay(iDelay),
-  m_iMaxDigits(iMaxDigits),
-  m_timer(this)
+CPVRChannelNumberInputHandler::CPVRChannelNumberInputHandler(
+    int iDelay, int iMaxDigits /* = CHANNEL_NUMBER_INPUT_MAX_DIGITS */)
+  : m_iDelay(iDelay), m_iMaxDigits(iMaxDigits), m_timer(this)
 {
 }
 
@@ -188,5 +188,3 @@ void CPVRChannelNumberInputHandler::SetLabel(const std::string& label)
     m_events.Publish(PVRChannelNumberInputChangedEvent(m_label));
   }
 }
-
-} // namespace PVR

--- a/xbmc/pvr/PVRChannelNumberInputHandler.h
+++ b/xbmc/pvr/PVRChannelNumberInputHandler.h
@@ -11,12 +11,20 @@
 #include "pvr/channels/PVRChannelNumber.h"
 #include "threads/CriticalSection.h"
 #include "threads/Timer.h"
+#include "utils/EventStream.h"
 
 #include <string>
 #include <vector>
 
 namespace PVR
 {
+struct PVRChannelNumberInputChangedEvent
+{
+  explicit PVRChannelNumberInputChangedEvent(const std::string& input) : m_input(input) {}
+  virtual ~PVRChannelNumberInputChangedEvent() = default;
+
+  std::string m_input;
+};
 
 class CPVRChannelNumberInputHandler : private ITimerCallback
 {
@@ -33,6 +41,12 @@ public:
   CPVRChannelNumberInputHandler(int iDelay, int iMaxDigits = CHANNEL_NUMBER_INPUT_MAX_DIGITS);
 
   ~CPVRChannelNumberInputHandler() override = default;
+
+  /*!
+   * @brief Get the events available for CEventStream.
+   * @return The events.
+   */
+  CEventStream<PVRChannelNumberInputChangedEvent>& Events() { return m_events; }
 
   // implementation of ITimerCallback
   void OnTimeout() override;
@@ -90,12 +104,15 @@ protected:
 private:
   void ExecuteAction();
 
+  void SetLabel(const std::string& label);
+
   std::vector<std::string> m_sortedChannelNumbers;
   const int m_iDelay;
   const int m_iMaxDigits;
   std::string m_inputBuffer;
   std::string m_label;
   CTimer m_timer;
+  CEventSource<PVRChannelNumberInputChangedEvent> m_events;
 };
 
 } // namespace PVR

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -41,11 +41,14 @@ using namespace std::chrono_literals;
 CGUIDialogPVRChannelsOSD::CGUIDialogPVRChannelsOSD()
 : CGUIDialogPVRItemsViewBase(WINDOW_DIALOG_PVR_OSD_CHANNELS, "DialogPVRChannelsOSD.xml")
 {
+  CServiceBroker::GetPVRManager().Get<PVR::GUI::Channels>().RegisterChannelNumberInputHandler(this);
 }
 
 CGUIDialogPVRChannelsOSD::~CGUIDialogPVRChannelsOSD()
 {
-  CServiceBroker::GetPVRManager().Events().Unsubscribe(this);
+  auto& mgr = CServiceBroker::GetPVRManager();
+  mgr.Events().Unsubscribe(this);
+  mgr.Get<PVR::GUI::Channels>().DeregisterChannelNumberInputHandler(this);
 }
 
 bool CGUIDialogPVRChannelsOSD::OnMessage(CGUIMessage& message)

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -39,7 +39,7 @@ using namespace std::chrono_literals;
 #define MAX_INVALIDATION_FREQUENCY 2000ms // limit to one invalidation per X milliseconds
 
 CGUIDialogPVRChannelsOSD::CGUIDialogPVRChannelsOSD()
-: CGUIDialogPVRItemsViewBase(WINDOW_DIALOG_PVR_OSD_CHANNELS, "DialogPVRChannelsOSD.xml")
+  : CGUIDialogPVRItemsViewBase(WINDOW_DIALOG_PVR_OSD_CHANNELS, "DialogPVRChannelsOSD.xml")
 {
   CServiceBroker::GetPVRManager().Get<PVR::GUI::Channels>().RegisterChannelNumberInputHandler(this);
 }
@@ -77,7 +77,8 @@ bool CGUIDialogPVRChannelsOSD::OnMessage(CGUIMessage& message)
 
 void CGUIDialogPVRChannelsOSD::OnInitWindow()
 {
-  if (!CServiceBroker::GetPVRManager().PlaybackState()->IsPlayingTV() && !CServiceBroker::GetPVRManager().PlaybackState()->IsPlayingRadio())
+  if (!CServiceBroker::GetPVRManager().PlaybackState()->IsPlayingTV() &&
+      !CServiceBroker::GetPVRManager().PlaybackState()->IsPlayingRadio())
   {
     Close();
     return;
@@ -131,10 +132,11 @@ bool CGUIDialogPVRChannelsOSD::OnAction(const CAction& action)
       SaveControlStates();
 
       // switch to next or previous group
-      const CPVRChannelGroups* groups = CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_group->IsRadio());
+      const CPVRChannelGroups* groups =
+          CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_group->IsRadio());
       const std::shared_ptr<CPVRChannelGroup> nextGroup = action.GetID() == ACTION_NEXT_CHANNELGROUP
-                                                        ? groups->GetNextGroup(*m_group)
-                                                        : groups->GetPreviousGroup(*m_group);
+                                                              ? groups->GetNextGroup(*m_group)
+                                                              : groups->GetPreviousGroup(*m_group);
       CServiceBroker::GetPVRManager().PlaybackState()->SetActiveChannelGroup(nextGroup);
       m_group = nextGroup;
       Init();
@@ -243,7 +245,8 @@ void CGUIDialogPVRChannelsOSD::GotoChannel(int item)
 
   // Preserve the item before closing self, because this will clear m_vecItems
   const CFileItemPtr itemptr = m_vecItems->Get(item);
-  if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_PVRMENU_CLOSECHANNELOSDONSWITCH))
+  if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+          CSettings::SETTING_PVRMENU_CLOSECHANNELOSDONSWITCH))
     Close();
 
   CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.h
@@ -18,44 +18,44 @@
 
 namespace PVR
 {
-  enum class PVREvent;
+enum class PVREvent;
 
-  class CPVRChannelGroup;
+class CPVRChannelGroup;
 
-  class CGUIDialogPVRChannelsOSD : public CGUIDialogPVRItemsViewBase, public CPVRChannelNumberInputHandler
-  {
-  public:
-    CGUIDialogPVRChannelsOSD();
-    ~CGUIDialogPVRChannelsOSD() override;
-    bool OnMessage(CGUIMessage& message) override;
-    bool OnAction(const CAction& action) override;
+class CGUIDialogPVRChannelsOSD : public CGUIDialogPVRItemsViewBase,
+                                 public CPVRChannelNumberInputHandler
+{
+public:
+  CGUIDialogPVRChannelsOSD();
+  ~CGUIDialogPVRChannelsOSD() override;
+  bool OnMessage(CGUIMessage& message) override;
+  bool OnAction(const CAction& action) override;
 
-    /*!
-     * @brief CEventStream callback for PVR events.
-     * @param event The event.
-     */
-    void Notify(const PVREvent& event);
+  /*!
+   * @brief CEventStream callback for PVR events.
+   * @param event The event.
+   */
+  void Notify(const PVREvent& event);
 
-    // CPVRChannelNumberInputHandler implementation
-    void GetChannelNumbers(std::vector<std::string>& channelNumbers) override;
-    void OnInputDone() override;
+  // CPVRChannelNumberInputHandler implementation
+  void GetChannelNumbers(std::vector<std::string>& channelNumbers) override;
+  void OnInputDone() override;
 
-  protected:
-    void OnInitWindow() override;
-    void OnDeinitWindow(int nextWindowID) override;
-    void RestoreControlStates() override;
-    void SaveControlStates() override;
-    void SetInvalid() override;
+protected:
+  void OnInitWindow() override;
+  void OnDeinitWindow(int nextWindowID) override;
+  void RestoreControlStates() override;
+  void SaveControlStates() override;
+  void SetInvalid() override;
 
-  private:
-    void GotoChannel(int iItem);
-    void Update();
-    void SaveSelectedItemPath(int iGroupID);
-    std::string GetLastSelectedItemPath(int iGroupID) const;
+private:
+  void GotoChannel(int iItem);
+  void Update();
+  void SaveSelectedItemPath(int iGroupID);
+  std::string GetLastSelectedItemPath(int iGroupID) const;
 
-    std::shared_ptr<CPVRChannelGroup> m_group;
-    std::map<int, std::string> m_groupSelectedItemPaths;
-    XbmcThreads::EndTime<> m_refreshTimeout;
-  };
-}
-
+  std::shared_ptr<CPVRChannelGroup> m_group;
+  std::map<int, std::string> m_groupSelectedItemPaths;
+  XbmcThreads::EndTime<> m_refreshTimeout;
+};
+} // namespace PVR

--- a/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
@@ -153,6 +153,31 @@ void CPVRChannelSwitchingInputHandler::SwitchToPreviousChannel()
 CPVRGUIActionsChannels::CPVRGUIActionsChannels()
   : m_settings({CSettings::SETTING_PVRMANAGER_PRESELECTPLAYINGCHANNEL})
 {
+  RegisterChannelNumberInputHandler(&m_channelNumberInputHandler);
+}
+
+CPVRGUIActionsChannels::~CPVRGUIActionsChannels()
+{
+  DeregisterChannelNumberInputHandler(&m_channelNumberInputHandler);
+}
+
+void CPVRGUIActionsChannels::RegisterChannelNumberInputHandler(
+    CPVRChannelNumberInputHandler* handler)
+{
+  if (handler)
+    handler->Events().Subscribe(this, &CPVRGUIActionsChannels::Notify);
+}
+
+void CPVRGUIActionsChannels::DeregisterChannelNumberInputHandler(
+    CPVRChannelNumberInputHandler* handler)
+{
+  if (handler)
+    handler->Events().Unsubscribe(this);
+}
+
+void CPVRGUIActionsChannels::Notify(const PVRChannelNumberInputChangedEvent& event)
+{
+  m_events.Publish(event);
 }
 
 bool CPVRGUIActionsChannels::HideChannel(const std::shared_ptr<CFileItem>& item) const

--- a/xbmc/pvr/guilib/PVRGUIActionsChannels.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsChannels.h
@@ -50,7 +50,31 @@ class CPVRGUIActionsChannels : public IPVRComponent
 {
 public:
   CPVRGUIActionsChannels();
-  ~CPVRGUIActionsChannels() override = default;
+  ~CPVRGUIActionsChannels() override;
+
+  /*!
+   * @brief Get the events available for CEventStream.
+   * @return The events.
+   */
+  CEventStream<PVRChannelNumberInputChangedEvent>& Events() { return m_events; }
+
+  /*!
+   * @brief Register a handler for channel number input.
+   * @param handler The handler to register.
+   */
+  void RegisterChannelNumberInputHandler(CPVRChannelNumberInputHandler* handler);
+
+  /*!
+   * @brief Deregister a handler for channel number input.
+   * @param handler The handler to deregister.
+   */
+  void DeregisterChannelNumberInputHandler(CPVRChannelNumberInputHandler* handler);
+
+  /*!
+   * @brief CEventStream callback for channel number input changes.
+   * @param event The event.
+   */
+  void Notify(const PVRChannelNumberInputChangedEvent& event);
 
   /*!
    * @brief Hide a channel, always showing a confirmation dialog.
@@ -141,6 +165,7 @@ private:
   CPVRChannelSwitchingInputHandler m_channelNumberInputHandler;
   bool m_bChannelScanRunning{false};
   CPVRGUIChannelNavigator m_channelNavigator;
+  CEventSource<PVRChannelNumberInputChangedEvent> m_events;
 
   mutable CCriticalSection m_critSection;
   CPVRSettings m_settings;

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -71,16 +71,16 @@ void CPVRGUIInfo::ResetProperties()
   m_bHasTVRecordings = false;
   m_bHasRadioRecordings = false;
   m_iCurrentActiveClient = 0;
-  m_strPlayingClientName        .clear();
-  m_strBackendName              .clear();
-  m_strBackendVersion           .clear();
-  m_strBackendHost              .clear();
-  m_strBackendTimers            .clear();
-  m_strBackendRecordings        .clear();
-  m_strBackendDeletedRecordings .clear();
+  m_strPlayingClientName.clear();
+  m_strBackendName.clear();
+  m_strBackendVersion.clear();
+  m_strBackendHost.clear();
+  m_strBackendTimers.clear();
+  m_strBackendRecordings.clear();
+  m_strBackendDeletedRecordings.clear();
   m_strBackendProviders.clear();
   m_strBackendChannelGroups.clear();
-  m_strBackendChannels          .clear();
+  m_strBackendChannels.clear();
   m_iBackendDiskTotal = 0;
   m_iBackendDiskUsed = 0;
   m_bIsPlayingTV = false;
@@ -104,8 +104,10 @@ void CPVRGUIInfo::ResetProperties()
 void CPVRGUIInfo::ClearQualityInfo(PVR_SIGNAL_STATUS& qualityInfo)
 {
   memset(&qualityInfo, 0, sizeof(qualityInfo));
-  strncpy(qualityInfo.strAdapterName, g_localizeStrings.Get(13106).c_str(), PVR_ADDON_NAME_STRING_LENGTH - 1);
-  strncpy(qualityInfo.strAdapterStatus, g_localizeStrings.Get(13106).c_str(), PVR_ADDON_NAME_STRING_LENGTH - 1);
+  strncpy(qualityInfo.strAdapterName, g_localizeStrings.Get(13106).c_str(),
+          PVR_ADDON_NAME_STRING_LENGTH - 1);
+  strncpy(qualityInfo.strAdapterStatus, g_localizeStrings.Get(13106).c_str(),
+          PVR_ADDON_NAME_STRING_LENGTH - 1);
 }
 
 void CPVRGUIInfo::ClearDescrambleInfo(PVR_DESCRAMBLE_INFO& descrambleInfo)
@@ -318,50 +320,55 @@ bool CPVRGUIInfo::InitCurrentItem(CFileItem* item)
   return false;
 }
 
-bool CPVRGUIInfo::GetLabel(std::string& value, const CFileItem* item, int contextWindow, const CGUIInfo& info, std::string* fallback) const
+bool CPVRGUIInfo::GetLabel(std::string& value,
+                           const CFileItem* item,
+                           int contextWindow,
+                           const CGUIInfo& info,
+                           std::string* fallback) const
 {
-  return GetListItemAndPlayerLabel(item, info, value) ||
-         GetPVRLabel(item, info, value) ||
+  return GetListItemAndPlayerLabel(item, info, value) || GetPVRLabel(item, info, value) ||
          GetRadioRDSLabel(item, info, value);
 }
 
 namespace
 {
-  std::string GetAsLocalizedDateString(const CDateTime& datetime, bool bLongDate)
+std::string GetAsLocalizedDateString(const CDateTime& datetime, bool bLongDate)
+{
+  return datetime.IsValid() ? datetime.GetAsLocalizedDate(bLongDate) : "";
+}
+
+std::string GetAsLocalizedTimeString(const CDateTime& datetime)
+{
+  return datetime.IsValid() ? datetime.GetAsLocalizedTime("", false) : "";
+}
+
+std::string GetAsLocalizedDateTimeString(const CDateTime& datetime)
+{
+  return datetime.IsValid() ? datetime.GetAsLocalizedDateTime(false, false) : "";
+}
+
+std::string GetEpgTagTitle(const std::shared_ptr<CPVREpgInfoTag>& epgTag)
+{
+  if (epgTag)
   {
-    return datetime.IsValid() ? datetime.GetAsLocalizedDate(bLongDate) : "";
+    if (CServiceBroker::GetPVRManager().IsParentalLocked(epgTag))
+      return g_localizeStrings.Get(19266); // Parental locked
+    else if (!epgTag->Title().empty())
+      return epgTag->Title();
   }
 
-  std::string GetAsLocalizedTimeString(const CDateTime& datetime)
-  {
-    return datetime.IsValid() ? datetime.GetAsLocalizedTime("", false) : "";
-  }
+  if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+          CSettings::SETTING_EPG_HIDENOINFOAVAILABLE))
+    return g_localizeStrings.Get(19055); // no information available
 
-  std::string GetAsLocalizedDateTimeString(const CDateTime& datetime)
-  {
-    return datetime.IsValid() ? datetime.GetAsLocalizedDateTime(false, false) : "";
-  }
-
-  std::string GetEpgTagTitle(const std::shared_ptr<CPVREpgInfoTag>& epgTag)
-  {
-    if (epgTag)
-    {
-      if (CServiceBroker::GetPVRManager().IsParentalLocked(epgTag))
-        return g_localizeStrings.Get(19266); // Parental locked
-      else if (!epgTag->Title().empty())
-        return epgTag->Title();
-    }
-
-    if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-            CSettings::SETTING_EPG_HIDENOINFOAVAILABLE))
-      return g_localizeStrings.Get(19055); // no information available
-
-    return {};
-  }
+  return {};
+}
 
 } // unnamed namespace
 
-bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInfo& info, std::string& strValue) const
+bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
+                                            const CGUIInfo& info,
+                                            std::string& strValue) const
 {
   const std::shared_ptr<CPVRTimerInfoTag> timer = item->GetPVRTimerInfoTag();
   if (timer)
@@ -386,7 +393,8 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
       case LISTITEM_DURATION:
         if (timer->GetDuration() > 0)
         {
-          strValue = StringUtils::SecondsToTimeString(timer->GetDuration(), static_cast<TIME_FORMAT>(info.GetData4()));
+          strValue = StringUtils::SecondsToTimeString(timer->GetDuration(),
+                                                      static_cast<TIME_FORMAT>(info.GetData4()));
           return true;
         }
         return false;
@@ -394,7 +402,9 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
         strValue = timer->Title();
         return true;
       case LISTITEM_COMMENT:
-        strValue = timer->GetStatus(CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_RADIO_TIMER_RULES);
+        strValue =
+            timer->GetStatus(CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() ==
+                             WINDOW_RADIO_TIMER_RULES);
         return true;
       case LISTITEM_TIMERTYPE:
         strValue = timer->GetTypeAsString();
@@ -455,7 +465,8 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
       case LISTITEM_EXPIRATION_TIME:
         if (recording->HasExpirationTime())
         {
-          strValue = GetAsLocalizedTimeString(recording->ExpirationTimeAsLocalTime());;
+          strValue = GetAsLocalizedTimeString(recording->ExpirationTimeAsLocalTime());
+          ;
           return true;
         }
         break;
@@ -658,7 +669,8 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
       case LISTITEM_NEXT_DURATION:
         if (epgTag->GetDuration() > 0)
         {
-          strValue = StringUtils::SecondsToTimeString(epgTag->GetDuration(), static_cast<TIME_FORMAT>(info.GetData4()));
+          strValue = StringUtils::SecondsToTimeString(epgTag->GetDuration(),
+                                                      static_cast<TIME_FORMAT>(info.GetData4()));
           return true;
         }
         return false;
@@ -800,7 +812,9 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
   return false;
 }
 
-bool CPVRGUIInfo::GetPVRLabel(const CFileItem* item, const CGUIInfo& info, std::string& strValue) const
+bool CPVRGUIInfo::GetPVRLabel(const CFileItem* item,
+                              const CGUIInfo& info,
+                              std::string& strValue) const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
 
@@ -808,7 +822,8 @@ bool CPVRGUIInfo::GetPVRLabel(const CFileItem* item, const CGUIInfo& info, std::
   {
     case PVR_EPG_EVENT_ICON:
     {
-      const std::shared_ptr<CPVREpgInfoTag> epgTag = (item->IsPVRChannel() || item->IsEPG()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
+      const std::shared_ptr<CPVREpgInfoTag> epgTag =
+          (item->IsPVRChannel() || item->IsEPG()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
       if (epgTag)
       {
         strValue = epgTag->IconPath();
@@ -817,26 +832,33 @@ bool CPVRGUIInfo::GetPVRLabel(const CFileItem* item, const CGUIInfo& info, std::
     }
     case PVR_EPG_EVENT_DURATION:
     {
-      const std::shared_ptr<CPVREpgInfoTag> epgTag = (item->IsPVRChannel() || item->IsEPG()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
+      const std::shared_ptr<CPVREpgInfoTag> epgTag =
+          (item->IsPVRChannel() || item->IsEPG()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
       strValue = m_timesInfo.GetEpgEventDuration(epgTag, static_cast<TIME_FORMAT>(info.GetData1()));
       return true;
     }
-   case PVR_EPG_EVENT_ELAPSED_TIME:
+    case PVR_EPG_EVENT_ELAPSED_TIME:
     {
-      const std::shared_ptr<CPVREpgInfoTag> epgTag = (item->IsPVRChannel() || item->IsEPG()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
-      strValue = m_timesInfo.GetEpgEventElapsedTime(epgTag, static_cast<TIME_FORMAT>(info.GetData1()));
+      const std::shared_ptr<CPVREpgInfoTag> epgTag =
+          (item->IsPVRChannel() || item->IsEPG()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
+      strValue =
+          m_timesInfo.GetEpgEventElapsedTime(epgTag, static_cast<TIME_FORMAT>(info.GetData1()));
       return true;
     }
     case PVR_EPG_EVENT_REMAINING_TIME:
     {
-      const std::shared_ptr<CPVREpgInfoTag> epgTag = (item->IsPVRChannel() || item->IsEPG()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
-      strValue = m_timesInfo.GetEpgEventRemainingTime(epgTag, static_cast<TIME_FORMAT>(info.GetData1()));
+      const std::shared_ptr<CPVREpgInfoTag> epgTag =
+          (item->IsPVRChannel() || item->IsEPG()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
+      strValue =
+          m_timesInfo.GetEpgEventRemainingTime(epgTag, static_cast<TIME_FORMAT>(info.GetData1()));
       return true;
     }
     case PVR_EPG_EVENT_FINISH_TIME:
     {
-      const std::shared_ptr<CPVREpgInfoTag> epgTag = (item->IsPVRChannel() || item->IsEPG()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
-      strValue = m_timesInfo.GetEpgEventFinishTime(epgTag, static_cast<TIME_FORMAT>(info.GetData1()));
+      const std::shared_ptr<CPVREpgInfoTag> epgTag =
+          (item->IsPVRChannel() || item->IsEPG()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
+      strValue =
+          m_timesInfo.GetEpgEventFinishTime(epgTag, static_cast<TIME_FORMAT>(info.GetData1()));
       return true;
     }
     case PVR_TIMESHIFT_START_TIME:
@@ -852,10 +874,12 @@ bool CPVRGUIInfo::GetPVRLabel(const CFileItem* item, const CGUIInfo& info, std::
       strValue = m_timesInfo.GetTimeshiftOffset(static_cast<TIME_FORMAT>(info.GetData1()));
       return true;
     case PVR_TIMESHIFT_PROGRESS_DURATION:
-      strValue = m_timesInfo.GetTimeshiftProgressDuration(static_cast<TIME_FORMAT>(info.GetData1()));
+      strValue =
+          m_timesInfo.GetTimeshiftProgressDuration(static_cast<TIME_FORMAT>(info.GetData1()));
       return true;
     case PVR_TIMESHIFT_PROGRESS_START_TIME:
-      strValue = m_timesInfo.GetTimeshiftProgressStartTime(static_cast<TIME_FORMAT>(info.GetData1()));
+      strValue =
+          m_timesInfo.GetTimeshiftProgressStartTime(static_cast<TIME_FORMAT>(info.GetData1()));
       return true;
     case PVR_TIMESHIFT_PROGRESS_END_TIME:
       strValue = m_timesInfo.GetTimeshiftProgressEndTime(static_cast<TIME_FORMAT>(info.GetData1()));
@@ -1020,12 +1044,15 @@ bool CPVRGUIInfo::GetPVRLabel(const CFileItem* item, const CGUIInfo& info, std::
   return false;
 }
 
-bool CPVRGUIInfo::GetRadioRDSLabel(const CFileItem* item, const CGUIInfo& info, std::string& strValue) const
+bool CPVRGUIInfo::GetRadioRDSLabel(const CFileItem* item,
+                                   const CGUIInfo& info,
+                                   std::string& strValue) const
 {
   if (!item->HasPVRChannelInfoTag())
     return false;
 
-  const std::shared_ptr<CPVRRadioRDSInfoTag> tag = item->GetPVRChannelInfoTag()->GetRadioRDSInfoTag();
+  const std::shared_ptr<CPVRRadioRDSInfoTag> tag =
+      item->GetPVRChannelInfoTag()->GetRadioRDSInfoTag();
   if (tag)
   {
     switch (info.m_info)
@@ -1183,17 +1210,21 @@ bool CPVRGUIInfo::GetFallbackLabel(std::string& value,
   return false;
 }
 
-bool CPVRGUIInfo::GetInt(int& value, const CGUIListItem* item, int contextWindow, const CGUIInfo& info) const
+bool CPVRGUIInfo::GetInt(int& value,
+                         const CGUIListItem* item,
+                         int contextWindow,
+                         const CGUIInfo& info) const
 {
   if (!item->IsFileItem())
     return false;
 
   const CFileItem* fitem = static_cast<const CFileItem*>(item);
-  return GetListItemAndPlayerInt(fitem, info, value) ||
-         GetPVRInt(fitem, info, value);
+  return GetListItemAndPlayerInt(fitem, info, value) || GetPVRInt(fitem, info, value);
 }
 
-bool CPVRGUIInfo::GetListItemAndPlayerInt(const CFileItem* item, const CGUIInfo& info, int& iValue) const
+bool CPVRGUIInfo::GetListItemAndPlayerInt(const CFileItem* item,
+                                          const CGUIInfo& info,
+                                          int& iValue) const
 {
   switch (info.m_info)
   {
@@ -1217,13 +1248,15 @@ bool CPVRGUIInfo::GetPVRInt(const CFileItem* item, const CGUIInfo& info, int& iV
   {
     case PVR_EPG_EVENT_DURATION:
     {
-      const std::shared_ptr<CPVREpgInfoTag> epgTag = (item->IsPVRChannel() || item->IsEPG()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
+      const std::shared_ptr<CPVREpgInfoTag> epgTag =
+          (item->IsPVRChannel() || item->IsEPG()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
       iValue = m_timesInfo.GetEpgEventDuration(epgTag);
       return true;
     }
     case PVR_EPG_EVENT_PROGRESS:
     {
-      const std::shared_ptr<CPVREpgInfoTag> epgTag = (item->IsPVRChannel() || item->IsEPG()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
+      const std::shared_ptr<CPVREpgInfoTag> epgTag =
+          (item->IsPVRChannel() || item->IsEPG()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
       iValue = m_timesInfo.GetEpgEventProgress(epgTag);
       return true;
     }
@@ -1267,18 +1300,22 @@ bool CPVRGUIInfo::GetPVRInt(const CFileItem* item, const CGUIInfo& info, int& iV
   return false;
 }
 
-bool CPVRGUIInfo::GetBool(bool& value, const CGUIListItem* item, int contextWindow, const CGUIInfo& info) const
+bool CPVRGUIInfo::GetBool(bool& value,
+                          const CGUIListItem* item,
+                          int contextWindow,
+                          const CGUIInfo& info) const
 {
   if (!item->IsFileItem())
     return false;
 
   const CFileItem* fitem = static_cast<const CFileItem*>(item);
-  return GetListItemAndPlayerBool(fitem, info, value) ||
-         GetPVRBool(fitem, info, value) ||
+  return GetListItemAndPlayerBool(fitem, info, value) || GetPVRBool(fitem, info, value) ||
          GetRadioRDSBool(fitem, info, value);
 }
 
-bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item, const CGUIInfo& info, bool& bValue) const
+bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item,
+                                           const CGUIInfo& info,
+                                           bool& bValue) const
 {
   switch (info.m_info)
   {
@@ -1299,7 +1336,8 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item, const CGUIInfo
     case LISTITEM_ISRECORDING:
       if (item->IsPVRChannel())
       {
-        bValue = CServiceBroker::GetPVRManager().Timers()->IsRecordingOnChannel(*item->GetPVRChannelInfoTag());
+        bValue = CServiceBroker::GetPVRManager().Timers()->IsRecordingOnChannel(
+            *item->GetPVRChannelInfoTag());
         return true;
       }
       else if (item->IsEPG() || item->IsPVRTimer())
@@ -1534,8 +1572,11 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item, const CGUIInfo
       if (item->IsPVRRecording())
       {
         const std::shared_ptr<CPVRRecording> recording = item->GetPVRRecordingInfoTag();
-        const std::shared_ptr<CPVREpg> epg = recording->Channel() ? recording->Channel()->GetEPG() : nullptr;
-        const std::shared_ptr<CPVREpgInfoTag> epgTag = CServiceBroker::GetPVRManager().EpgContainer().GetTagById(epg, recording->BroadcastUid());
+        const std::shared_ptr<CPVREpg> epg =
+            recording->Channel() ? recording->Channel()->GetEPG() : nullptr;
+        const std::shared_ptr<CPVREpgInfoTag> epgTag =
+            CServiceBroker::GetPVRManager().EpgContainer().GetTagById(epg,
+                                                                      recording->BroadcastUid());
         bValue = (epgTag && epgTag->IsActive());
         return true;
       }
@@ -1638,7 +1679,8 @@ bool CPVRGUIInfo::GetRadioRDSBool(const CFileItem* item, const CGUIInfo& info, b
   if (!item->HasPVRChannelInfoTag())
     return false;
 
-  const std::shared_ptr<CPVRRadioRDSInfoTag> tag = item->GetPVRChannelInfoTag()->GetRadioRDSInfoTag();
+  const std::shared_ptr<CPVRRadioRDSInfoTag> tag =
+      item->GetPVRChannelInfoTag()->GetRadioRDSInfoTag();
   if (tag)
   {
     switch (info.m_info)
@@ -1653,7 +1695,8 @@ bool CPVRGUIInfo::GetRadioRDSBool(const CFileItem* item, const CGUIInfo& info, b
         bValue = (!tag->GetEMailHotline().empty() || !tag->GetPhoneHotline().empty());
         return true;
       case RDS_HAS_STUDIO_DATA:
-        bValue = (!tag->GetEMailStudio().empty() || !tag->GetSMSStudio().empty() || !tag->GetPhoneStudio().empty());
+        bValue = (!tag->GetEMailStudio().empty() || !tag->GetSMSStudio().empty() ||
+                  !tag->GetPhoneStudio().empty());
         return true;
     }
   }
@@ -1813,7 +1856,8 @@ void CPVRGUIInfo::CharInfoEncryption(std::string& strValue) const
   }
   else
   {
-    const std::shared_ptr<CPVRChannel> channel = CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel();
+    const std::shared_ptr<CPVRChannel> channel =
+        CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel();
     if (channel)
     {
       strValue = channel->EncryptionName();

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -123,7 +123,10 @@ void CPVRGUIInfo::Start()
 void CPVRGUIInfo::Stop()
 {
   StopThread();
-  CServiceBroker::GetPVRManager().Events().Unsubscribe(this);
+
+  auto& mgr = CServiceBroker::GetPVRManager();
+  mgr.Get<PVR::GUI::Channels>().Events().Unsubscribe(this);
+  mgr.Events().Unsubscribe(this);
 
   CGUIComponent* gui = CServiceBroker::GetGUI();
   if (gui)
@@ -139,14 +142,23 @@ void CPVRGUIInfo::Notify(const PVREvent& event)
     UpdateTimersCache();
 }
 
+void CPVRGUIInfo::Notify(const PVRChannelNumberInputChangedEvent& event)
+{
+  std::unique_lock<CCriticalSection> lock(m_critSection);
+  m_channelNumberInput = event.m_input;
+}
+
 void CPVRGUIInfo::Process()
 {
   auto toggleIntervalMs = std::chrono::milliseconds(
       CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRInfoToggleInterval);
   XbmcThreads::EndTime<> cacheTimer(toggleIntervalMs);
 
+  auto& mgr = CServiceBroker::GetPVRManager();
+  mgr.Events().Subscribe(this, &CPVRGUIInfo::Notify);
+  mgr.Get<PVR::GUI::Channels>().Events().Subscribe(this, &CPVRGUIInfo::Notify);
+
   /* updated on request */
-  CServiceBroker::GetPVRManager().Events().Subscribe(this, &CPVRGUIInfo::Notify);
   UpdateTimersCache();
 
   /* update the backend cache once initially */
@@ -1001,10 +1013,7 @@ bool CPVRGUIInfo::GetPVRLabel(const CFileItem* item, const CGUIInfo& info, std::
       CharInfoTotalDiskSpace(strValue);
       return true;
     case PVR_CHANNEL_NUMBER_INPUT:
-      strValue = CServiceBroker::GetPVRManager()
-                     .Get<PVR::GUI::Channels>()
-                     .GetChannelNumberInputHandler()
-                     .GetChannelNumberLabel();
+      strValue = m_channelNumberInput;
       return true;
   }
 

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.h
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.h
@@ -36,6 +36,7 @@ namespace GUIINFO
 namespace PVR
 {
   enum class PVREvent;
+  struct PVRChannelNumberInputChangedEvent;
 
   class CPVRGUIInfo : public KODI::GUILIB::GUIINFO::CGUIInfoProvider, private CThread
   {
@@ -51,6 +52,12 @@ namespace PVR
      * @param event The event.
      */
     void Notify(const PVREvent& event);
+
+    /*!
+     * @brief CEventStream callback for channel number input changes.
+     * @param event The event.
+     */
+    void Notify(const PVRChannelNumberInputChangedEvent& event);
 
     // KODI::GUILIB::GUIINFO::IGUIInfoProvider implementation
     bool InitCurrentItem(CFileItem* item) override;
@@ -158,6 +165,8 @@ namespace PVR
     PVR_SIGNAL_STATUS m_qualityInfo; /*!< stream quality information */
     PVR_DESCRAMBLE_INFO m_descrambleInfo; /*!< stream descramble information */
     std::vector<SBackend> m_backendProperties;
+
+    std::string m_channelNumberInput;
 
     mutable CCriticalSection m_critSection;
 

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.h
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.h
@@ -28,156 +28,182 @@ namespace GUILIB
 {
 namespace GUIINFO
 {
-  class CGUIInfo;
+class CGUIInfo;
 }
-}
-}
+} // namespace GUILIB
+} // namespace KODI
 
 namespace PVR
 {
-  enum class PVREvent;
-  struct PVRChannelNumberInputChangedEvent;
+enum class PVREvent;
+struct PVRChannelNumberInputChangedEvent;
 
-  class CPVRGUIInfo : public KODI::GUILIB::GUIINFO::CGUIInfoProvider, private CThread
-  {
-  public:
-    CPVRGUIInfo();
-    ~CPVRGUIInfo() override = default;
+class CPVRGUIInfo : public KODI::GUILIB::GUIINFO::CGUIInfoProvider, private CThread
+{
+public:
+  CPVRGUIInfo();
+  ~CPVRGUIInfo() override = default;
 
-    void Start();
-    void Stop();
+  void Start();
+  void Stop();
 
-    /*!
-     * @brief CEventStream callback for PVR events.
-     * @param event The event.
-     */
-    void Notify(const PVREvent& event);
+  /*!
+   * @brief CEventStream callback for PVR events.
+   * @param event The event.
+   */
+  void Notify(const PVREvent& event);
 
-    /*!
-     * @brief CEventStream callback for channel number input changes.
-     * @param event The event.
-     */
-    void Notify(const PVRChannelNumberInputChangedEvent& event);
+  /*!
+   * @brief CEventStream callback for channel number input changes.
+   * @param event The event.
+   */
+  void Notify(const PVRChannelNumberInputChangedEvent& event);
 
-    // KODI::GUILIB::GUIINFO::IGUIInfoProvider implementation
-    bool InitCurrentItem(CFileItem* item) override;
-    bool GetLabel(std::string& value, const CFileItem* item, int contextWindow, const KODI::GUILIB::GUIINFO::CGUIInfo& info, std::string* fallback) const override;
-    bool GetFallbackLabel(std::string& value,
-                          const CFileItem* item,
-                          int contextWindow,
-                          const KODI::GUILIB::GUIINFO::CGUIInfo& info,
-                          std::string* fallback) override;
-    bool GetInt(int& value, const CGUIListItem* item, int contextWindow, const KODI::GUILIB::GUIINFO::CGUIInfo& info) const override;
-    bool GetBool(bool& value, const CGUIListItem* item, int contextWindow, const KODI::GUILIB::GUIINFO::CGUIInfo& info) const override;
+  // KODI::GUILIB::GUIINFO::IGUIInfoProvider implementation
+  bool InitCurrentItem(CFileItem* item) override;
+  bool GetLabel(std::string& value,
+                const CFileItem* item,
+                int contextWindow,
+                const KODI::GUILIB::GUIINFO::CGUIInfo& info,
+                std::string* fallback) const override;
+  bool GetFallbackLabel(std::string& value,
+                        const CFileItem* item,
+                        int contextWindow,
+                        const KODI::GUILIB::GUIINFO::CGUIInfo& info,
+                        std::string* fallback) override;
+  bool GetInt(int& value,
+              const CGUIListItem* item,
+              int contextWindow,
+              const KODI::GUILIB::GUIINFO::CGUIInfo& info) const override;
+  bool GetBool(bool& value,
+               const CGUIListItem* item,
+               int contextWindow,
+               const KODI::GUILIB::GUIINFO::CGUIInfo& info) const override;
 
-  private:
-    void ResetProperties();
-    void ClearQualityInfo(PVR_SIGNAL_STATUS& qualityInfo);
-    void ClearDescrambleInfo(PVR_DESCRAMBLE_INFO& descrambleInfo);
+private:
+  void ResetProperties();
+  void ClearQualityInfo(PVR_SIGNAL_STATUS& qualityInfo);
+  void ClearDescrambleInfo(PVR_DESCRAMBLE_INFO& descrambleInfo);
 
-    void Process() override;
+  void Process() override;
 
-    void UpdateTimersCache();
-    void UpdateBackendCache();
-    void UpdateQualityData();
-    void UpdateDescrambleData();
-    void UpdateMisc();
-    void UpdateNextTimer();
-    void UpdateTimeshiftData();
-    void UpdateTimeshiftProgressData();
+  void UpdateTimersCache();
+  void UpdateBackendCache();
+  void UpdateQualityData();
+  void UpdateDescrambleData();
+  void UpdateMisc();
+  void UpdateNextTimer();
+  void UpdateTimeshiftData();
+  void UpdateTimeshiftProgressData();
 
-    void UpdateTimersToggle();
+  void UpdateTimersToggle();
 
-    bool GetListItemAndPlayerLabel(const CFileItem* item, const KODI::GUILIB::GUIINFO::CGUIInfo& info, std::string& strValue) const;
-    bool GetPVRLabel(const CFileItem* item, const KODI::GUILIB::GUIINFO::CGUIInfo& info, std::string& strValue) const;
-    bool GetRadioRDSLabel(const CFileItem* item, const KODI::GUILIB::GUIINFO::CGUIInfo& info, std::string& strValue) const;
+  bool GetListItemAndPlayerLabel(const CFileItem* item,
+                                 const KODI::GUILIB::GUIINFO::CGUIInfo& info,
+                                 std::string& strValue) const;
+  bool GetPVRLabel(const CFileItem* item,
+                   const KODI::GUILIB::GUIINFO::CGUIInfo& info,
+                   std::string& strValue) const;
+  bool GetRadioRDSLabel(const CFileItem* item,
+                        const KODI::GUILIB::GUIINFO::CGUIInfo& info,
+                        std::string& strValue) const;
 
-    bool GetListItemAndPlayerInt(const CFileItem* item, const KODI::GUILIB::GUIINFO::CGUIInfo& info, int& iValue) const;
-    bool GetPVRInt(const CFileItem* item, const KODI::GUILIB::GUIINFO::CGUIInfo& info, int& iValue) const;
-    int GetTimeShiftSeekPercent() const;
+  bool GetListItemAndPlayerInt(const CFileItem* item,
+                               const KODI::GUILIB::GUIINFO::CGUIInfo& info,
+                               int& iValue) const;
+  bool GetPVRInt(const CFileItem* item,
+                 const KODI::GUILIB::GUIINFO::CGUIInfo& info,
+                 int& iValue) const;
+  int GetTimeShiftSeekPercent() const;
 
-    bool GetListItemAndPlayerBool(const CFileItem* item, const KODI::GUILIB::GUIINFO::CGUIInfo& info, bool& bValue) const;
-    bool GetPVRBool(const CFileItem* item, const KODI::GUILIB::GUIINFO::CGUIInfo& info, bool& bValue) const;
-    bool GetRadioRDSBool(const CFileItem* item, const KODI::GUILIB::GUIINFO::CGUIInfo& info, bool& bValue) const;
+  bool GetListItemAndPlayerBool(const CFileItem* item,
+                                const KODI::GUILIB::GUIINFO::CGUIInfo& info,
+                                bool& bValue) const;
+  bool GetPVRBool(const CFileItem* item,
+                  const KODI::GUILIB::GUIINFO::CGUIInfo& info,
+                  bool& bValue) const;
+  bool GetRadioRDSBool(const CFileItem* item,
+                       const KODI::GUILIB::GUIINFO::CGUIInfo& info,
+                       bool& bValue) const;
 
-    void CharInfoBackendNumber(std::string& strValue) const;
-    void CharInfoTotalDiskSpace(std::string& strValue) const;
-    void CharInfoSignal(std::string& strValue) const;
-    void CharInfoSNR(std::string& strValue) const;
-    void CharInfoBER(std::string& strValue) const;
-    void CharInfoUNC(std::string& strValue) const;
-    void CharInfoFrontendName(std::string& strValue) const;
-    void CharInfoFrontendStatus(std::string& strValue) const;
-    void CharInfoBackendName(std::string& strValue) const;
-    void CharInfoBackendVersion(std::string& strValue) const;
-    void CharInfoBackendHost(std::string& strValue) const;
-    void CharInfoBackendDiskspace(std::string& strValue) const;
-    void CharInfoBackendProviders(std::string& strValue) const;
-    void CharInfoBackendChannelGroups(std::string& strValue) const;
-    void CharInfoBackendChannels(std::string& strValue) const;
-    void CharInfoBackendTimers(std::string& strValue) const;
-    void CharInfoBackendRecordings(std::string& strValue) const;
-    void CharInfoBackendDeletedRecordings(std::string& strValue) const;
-    void CharInfoPlayingClientName(std::string& strValue) const;
-    void CharInfoEncryption(std::string& strValue) const;
-    void CharInfoService(std::string& strValue) const;
-    void CharInfoMux(std::string& strValue) const;
-    void CharInfoProvider(std::string& strValue) const;
+  void CharInfoBackendNumber(std::string& strValue) const;
+  void CharInfoTotalDiskSpace(std::string& strValue) const;
+  void CharInfoSignal(std::string& strValue) const;
+  void CharInfoSNR(std::string& strValue) const;
+  void CharInfoBER(std::string& strValue) const;
+  void CharInfoUNC(std::string& strValue) const;
+  void CharInfoFrontendName(std::string& strValue) const;
+  void CharInfoFrontendStatus(std::string& strValue) const;
+  void CharInfoBackendName(std::string& strValue) const;
+  void CharInfoBackendVersion(std::string& strValue) const;
+  void CharInfoBackendHost(std::string& strValue) const;
+  void CharInfoBackendDiskspace(std::string& strValue) const;
+  void CharInfoBackendProviders(std::string& strValue) const;
+  void CharInfoBackendChannelGroups(std::string& strValue) const;
+  void CharInfoBackendChannels(std::string& strValue) const;
+  void CharInfoBackendTimers(std::string& strValue) const;
+  void CharInfoBackendRecordings(std::string& strValue) const;
+  void CharInfoBackendDeletedRecordings(std::string& strValue) const;
+  void CharInfoPlayingClientName(std::string& strValue) const;
+  void CharInfoEncryption(std::string& strValue) const;
+  void CharInfoService(std::string& strValue) const;
+  void CharInfoMux(std::string& strValue) const;
+  void CharInfoProvider(std::string& strValue) const;
 
-    /** @name PVRGUIInfo data */
-    //@{
-    CPVRGUIAnyTimerInfo m_anyTimersInfo; // tv + radio
-    CPVRGUITVTimerInfo m_tvTimersInfo;
-    CPVRGUIRadioTimerInfo m_radioTimersInfo;
+  /** @name PVRGUIInfo data */
+  //@{
+  CPVRGUIAnyTimerInfo m_anyTimersInfo; // tv + radio
+  CPVRGUITVTimerInfo m_tvTimersInfo;
+  CPVRGUIRadioTimerInfo m_radioTimersInfo;
 
-    CPVRGUITimesInfo m_timesInfo;
+  CPVRGUITimesInfo m_timesInfo;
 
-    bool m_bHasTVRecordings;
-    bool m_bHasRadioRecordings;
-    unsigned int m_iCurrentActiveClient;
-    std::string m_strPlayingClientName;
-    std::string m_strBackendName;
-    std::string m_strBackendVersion;
-    std::string m_strBackendHost;
-    std::string m_strBackendTimers;
-    std::string m_strBackendRecordings;
-    std::string m_strBackendDeletedRecordings;
-    std::string m_strBackendProviders;
-    std::string m_strBackendChannelGroups;
-    std::string m_strBackendChannels;
-    long long m_iBackendDiskTotal;
-    long long m_iBackendDiskUsed;
-    bool m_bIsPlayingTV;
-    bool m_bIsPlayingRadio;
-    bool m_bIsPlayingRecording;
-    bool m_bIsPlayingEpgTag;
-    bool m_bIsPlayingEncryptedStream;
-    bool m_bHasTVChannels;
-    bool m_bHasRadioChannels;
-    bool m_bCanRecordPlayingChannel;
-    bool m_bIsRecordingPlayingChannel;
-    bool m_bIsPlayingActiveRecording;
-    std::string m_strPlayingTVGroup;
-    std::string m_strPlayingRadioGroup;
+  bool m_bHasTVRecordings;
+  bool m_bHasRadioRecordings;
+  unsigned int m_iCurrentActiveClient;
+  std::string m_strPlayingClientName;
+  std::string m_strBackendName;
+  std::string m_strBackendVersion;
+  std::string m_strBackendHost;
+  std::string m_strBackendTimers;
+  std::string m_strBackendRecordings;
+  std::string m_strBackendDeletedRecordings;
+  std::string m_strBackendProviders;
+  std::string m_strBackendChannelGroups;
+  std::string m_strBackendChannels;
+  long long m_iBackendDiskTotal;
+  long long m_iBackendDiskUsed;
+  bool m_bIsPlayingTV;
+  bool m_bIsPlayingRadio;
+  bool m_bIsPlayingRecording;
+  bool m_bIsPlayingEpgTag;
+  bool m_bIsPlayingEncryptedStream;
+  bool m_bHasTVChannels;
+  bool m_bHasRadioChannels;
+  bool m_bCanRecordPlayingChannel;
+  bool m_bIsRecordingPlayingChannel;
+  bool m_bIsPlayingActiveRecording;
+  std::string m_strPlayingTVGroup;
+  std::string m_strPlayingRadioGroup;
 
-    //@}
+  //@}
 
-    PVR_SIGNAL_STATUS m_qualityInfo; /*!< stream quality information */
-    PVR_DESCRAMBLE_INFO m_descrambleInfo; /*!< stream descramble information */
-    std::vector<SBackend> m_backendProperties;
+  PVR_SIGNAL_STATUS m_qualityInfo; /*!< stream quality information */
+  PVR_DESCRAMBLE_INFO m_descrambleInfo; /*!< stream descramble information */
+  std::vector<SBackend> m_backendProperties;
 
-    std::string m_channelNumberInput;
+  std::string m_channelNumberInput;
 
-    mutable CCriticalSection m_critSection;
+  mutable CCriticalSection m_critSection;
 
-    /**
-     * The various backend-related fields will only be updated when this
-     * flag is set. This is done to limit the amount of unnecessary
-     * backend querying when we're not displaying any of the queried
-     * information.
-     */
-    mutable std::atomic<bool> m_updateBackendCacheRequested;
+  /**
+   * The various backend-related fields will only be updated when this
+   * flag is set. This is done to limit the amount of unnecessary
+   * backend querying when we're not displaying any of the queried
+   * information.
+   */
+  mutable std::atomic<bool> m_updateBackendCacheRequested;
 
-    bool m_bRegistered;
-  };
-}
+  bool m_bRegistered;
+};
+} // namespace PVR

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -43,9 +43,10 @@
 
 using namespace PVR;
 
-CGUIWindowPVRChannelsBase::CGUIWindowPVRChannelsBase(bool bRadio, int id, const std::string& xmlFile) :
-  CGUIWindowPVRBase(bRadio, id, xmlFile),
-  m_bShowHiddenChannels(false)
+CGUIWindowPVRChannelsBase::CGUIWindowPVRChannelsBase(bool bRadio,
+                                                     int id,
+                                                     const std::string& xmlFile)
+  : CGUIWindowPVRBase(bRadio, id, xmlFile), m_bShowHiddenChannels(false)
 {
   CServiceBroker::GetPVRManager().Get<PVR::GUI::Channels>().RegisterChannelNumberInputHandler(this);
 }
@@ -70,10 +71,11 @@ bool CGUIWindowPVRChannelsBase::OnContextButton(int itemNumber, CONTEXT_BUTTON b
     return false;
 
   return OnContextButtonManage(m_vecItems->Get(itemNumber), button) ||
-      CGUIMediaWindow::OnContextButton(itemNumber, button);
+         CGUIMediaWindow::OnContextButton(itemNumber, button);
 }
 
-bool CGUIWindowPVRChannelsBase::Update(const std::string& strDirectory, bool updateFilterPath /* = true */)
+bool CGUIWindowPVRChannelsBase::Update(const std::string& strDirectory,
+                                       bool updateFilterPath /* = true */)
 {
   bool bReturn = CGUIWindowPVRBase::Update(strDirectory);
 
@@ -94,15 +96,20 @@ bool CGUIWindowPVRChannelsBase::Update(const std::string& strDirectory, bool upd
 
 void CGUIWindowPVRChannelsBase::UpdateButtons()
 {
-  CGUIRadioButtonControl* btnShowHidden = static_cast<CGUIRadioButtonControl*>(GetControl(CONTROL_BTNSHOWHIDDEN));
+  CGUIRadioButtonControl* btnShowHidden =
+      static_cast<CGUIRadioButtonControl*>(GetControl(CONTROL_BTNSHOWHIDDEN));
   if (btnShowHidden)
   {
-    btnShowHidden->SetVisible(CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAll(m_bRadio)->GetNumHiddenChannels() > 0);
+    btnShowHidden->SetVisible(CServiceBroker::GetPVRManager()
+                                  .ChannelGroups()
+                                  ->GetGroupAll(m_bRadio)
+                                  ->GetNumHiddenChannels() > 0);
     btnShowHidden->SetSelected(m_bShowHiddenChannels);
   }
 
   CGUIWindowPVRBase::UpdateButtons();
-  SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, m_bShowHiddenChannels ? g_localizeStrings.Get(19022) : GetChannelGroup()->GroupName());
+  SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, m_bShowHiddenChannels ? g_localizeStrings.Get(19022)
+                                                                 : GetChannelGroup()->GroupName());
 }
 
 bool CGUIWindowPVRChannelsBase::OnAction(const CAction& action)
@@ -170,33 +177,34 @@ bool CGUIWindowPVRChannelsBase::OnMessage(CGUIMessage& message)
           bReturn = true;
           switch (message.GetParam1())
           {
-           case ACTION_SELECT_ITEM:
-           case ACTION_MOUSE_LEFT_CLICK:
-           case ACTION_PLAYER_PLAY:
-             CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(
-                 m_vecItems->Get(iItem), true);
-             break;
-           case ACTION_SHOW_INFO:
-             CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowEPGInfo(
-                 m_vecItems->Get(iItem));
-             break;
-           case ACTION_DELETE_ITEM:
-             CServiceBroker::GetPVRManager().Get<PVR::GUI::Channels>().HideChannel(
-                 m_vecItems->Get(iItem));
-             break;
-           case ACTION_CONTEXT_MENU:
-           case ACTION_MOUSE_RIGHT_CLICK:
-             OnPopupMenu(iItem);
-             break;
-           default:
-             bReturn = false;
-             break;
+            case ACTION_SELECT_ITEM:
+            case ACTION_MOUSE_LEFT_CLICK:
+            case ACTION_PLAYER_PLAY:
+              CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(
+                  m_vecItems->Get(iItem), true);
+              break;
+            case ACTION_SHOW_INFO:
+              CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowEPGInfo(
+                  m_vecItems->Get(iItem));
+              break;
+            case ACTION_DELETE_ITEM:
+              CServiceBroker::GetPVRManager().Get<PVR::GUI::Channels>().HideChannel(
+                  m_vecItems->Get(iItem));
+              break;
+            case ACTION_CONTEXT_MENU:
+            case ACTION_MOUSE_RIGHT_CLICK:
+              OnPopupMenu(iItem);
+              break;
+            default:
+              bReturn = false;
+              break;
           }
         }
       }
       else if (message.GetSenderId() == CONTROL_BTNSHOWHIDDEN)
       {
-        CGUIRadioButtonControl* radioButton = static_cast<CGUIRadioButtonControl*>(GetControl(CONTROL_BTNSHOWHIDDEN));
+        CGUIRadioButtonControl* radioButton =
+            static_cast<CGUIRadioButtonControl*>(GetControl(CONTROL_BTNSHOWHIDDEN));
         if (radioButton)
         {
           m_bShowHiddenChannels = radioButton->IsSelected();
@@ -244,7 +252,8 @@ bool CGUIWindowPVRChannelsBase::OnMessage(CGUIMessage& message)
   return bReturn || CGUIWindowPVRBase::OnMessage(message);
 }
 
-bool CGUIWindowPVRChannelsBase::OnContextButtonManage(const CFileItemPtr& item, CONTEXT_BUTTON button)
+bool CGUIWindowPVRChannelsBase::OnContextButtonManage(const CFileItemPtr& item,
+                                                      CONTEXT_BUTTON button)
 {
   bool bReturn = false;
 
@@ -289,10 +298,10 @@ void CGUIWindowPVRChannelsBase::UpdateEpg(const CFileItemPtr& item)
 {
   const std::shared_ptr<CPVRChannel> channel(item->GetPVRChannelInfoTag());
 
-  if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{19251}, // "Update guide information"
-                                        CVariant{19252}, // "Schedule guide update for this channel?"
-                                        CVariant{""},
-                                        CVariant{channel->ChannelName()}))
+  if (!CGUIDialogYesNo::ShowAndGetInput(
+          CVariant{19251}, // "Update guide information"
+          CVariant{19252}, // "Schedule guide update for this channel?"
+          CVariant{""}, CVariant{channel->ChannelName()}))
     return;
 
   const std::shared_ptr<CPVREpg> epg = channel->GetEPG();
@@ -322,7 +331,9 @@ void CGUIWindowPVRChannelsBase::UpdateEpg(const CFileItemPtr& item)
 
 void CGUIWindowPVRChannelsBase::ShowChannelManager()
 {
-  CGUIDialogPVRChannelManager* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogPVRChannelManager>(WINDOW_DIALOG_PVR_CHANNEL_MANAGER);
+  CGUIDialogPVRChannelManager* dialog =
+      CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogPVRChannelManager>(
+          WINDOW_DIALOG_PVR_CHANNEL_MANAGER);
   if (!dialog)
     return;
 
@@ -335,7 +346,9 @@ void CGUIWindowPVRChannelsBase::ShowChannelManager()
 void CGUIWindowPVRChannelsBase::ShowGroupManager()
 {
   /* Load group manager dialog */
-  CGUIDialogPVRGroupManager* pDlgInfo = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogPVRGroupManager>(WINDOW_DIALOG_PVR_GROUP_MANAGER);
+  CGUIDialogPVRGroupManager* pDlgInfo =
+      CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogPVRGroupManager>(
+          WINDOW_DIALOG_PVR_GROUP_MANAGER);
   if (!pDlgInfo)
     return;
 

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -47,9 +47,14 @@ CGUIWindowPVRChannelsBase::CGUIWindowPVRChannelsBase(bool bRadio, int id, const 
   CGUIWindowPVRBase(bRadio, id, xmlFile),
   m_bShowHiddenChannels(false)
 {
+  CServiceBroker::GetPVRManager().Get<PVR::GUI::Channels>().RegisterChannelNumberInputHandler(this);
 }
 
-CGUIWindowPVRChannelsBase::~CGUIWindowPVRChannelsBase() = default;
+CGUIWindowPVRChannelsBase::~CGUIWindowPVRChannelsBase()
+{
+  CServiceBroker::GetPVRManager().Get<PVR::GUI::Channels>().DeregisterChannelNumberInputHandler(
+      this);
+}
 
 void CGUIWindowPVRChannelsBase::GetContextButtons(int itemNumber, CContextButtons& buttons)
 {

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.h
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.h
@@ -16,49 +16,49 @@
 
 namespace PVR
 {
-  class CGUIWindowPVRChannelsBase : public CGUIWindowPVRBase, public CPVRChannelNumberInputHandler
-  {
-  public:
-    CGUIWindowPVRChannelsBase(bool bRadio, int id, const std::string& xmlFile);
-    ~CGUIWindowPVRChannelsBase() override;
+class CGUIWindowPVRChannelsBase : public CGUIWindowPVRBase, public CPVRChannelNumberInputHandler
+{
+public:
+  CGUIWindowPVRChannelsBase(bool bRadio, int id, const std::string& xmlFile);
+  ~CGUIWindowPVRChannelsBase() override;
 
-    bool OnMessage(CGUIMessage& message) override;
-    void GetContextButtons(int itemNumber, CContextButtons& buttons) override;
-    bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
-    bool Update(const std::string& strDirectory, bool updateFilterPath = true) override;
-    void UpdateButtons() override;
-    bool OnAction(const CAction& action) override;
+  bool OnMessage(CGUIMessage& message) override;
+  void GetContextButtons(int itemNumber, CContextButtons& buttons) override;
+  bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
+  bool Update(const std::string& strDirectory, bool updateFilterPath = true) override;
+  void UpdateButtons() override;
+  bool OnAction(const CAction& action) override;
 
-    // CPVRChannelNumberInputHandler implementation
-    void GetChannelNumbers(std::vector<std::string>& channelNumbers) override;
-    void OnInputDone() override;
+  // CPVRChannelNumberInputHandler implementation
+  void GetChannelNumbers(std::vector<std::string>& channelNumbers) override;
+  void OnInputDone() override;
 
-  private:
-    bool OnContextButtonManage(const CFileItemPtr& item, CONTEXT_BUTTON button);
+private:
+  bool OnContextButtonManage(const CFileItemPtr& item, CONTEXT_BUTTON button);
 
-    void ShowChannelManager();
-    void ShowGroupManager();
-    void UpdateEpg(const CFileItemPtr& item);
+  void ShowChannelManager();
+  void ShowGroupManager();
+  void UpdateEpg(const CFileItemPtr& item);
 
-  protected:
-    bool m_bShowHiddenChannels;
-  };
+protected:
+  bool m_bShowHiddenChannels;
+};
 
-  class CGUIWindowPVRTVChannels : public CGUIWindowPVRChannelsBase
-  {
-  public:
-    CGUIWindowPVRTVChannels();
+class CGUIWindowPVRTVChannels : public CGUIWindowPVRChannelsBase
+{
+public:
+  CGUIWindowPVRTVChannels();
 
-  protected:
-    std::string GetDirectoryPath() override;
-  };
+protected:
+  std::string GetDirectoryPath() override;
+};
 
-  class CGUIWindowPVRRadioChannels : public CGUIWindowPVRChannelsBase
-  {
-  public:
-    CGUIWindowPVRRadioChannels();
+class CGUIWindowPVRRadioChannels : public CGUIWindowPVRChannelsBase
+{
+public:
+  CGUIWindowPVRRadioChannels();
 
-  protected:
-    std::string GetDirectoryPath() override;
-  };
-}
+protected:
+  std::string GetDirectoryPath() override;
+};
+} // namespace PVR

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -131,7 +131,8 @@ void CGUIWindowPVRGuideBase::OnDeinitWindow(int nextWindowID)
 
   m_bChannelSelectionRestored = false;
 
-  CGUIDialog* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetDialog(WINDOW_DIALOG_PVR_GUIDE_CONTROLS);
+  CGUIDialog* dialog =
+      CServiceBroker::GetGUI()->GetWindowManager().GetDialog(WINDOW_DIALOG_PVR_GUIDE_CONTROLS);
   if (dialog && dialog->IsDialogRunning())
   {
     dialog->Close();
@@ -155,10 +156,8 @@ void CGUIWindowPVRGuideBase::StopRefreshTimelineItemsThread()
 
 void CGUIWindowPVRGuideBase::NotifyEvent(const PVREvent& event)
 {
-  if (event == PVREvent::Epg ||
-      event == PVREvent::EpgContainer ||
-      event == PVREvent::ChannelGroupInvalidated ||
-      event == PVREvent::ChannelGroup)
+  if (event == PVREvent::Epg || event == PVREvent::EpgContainer ||
+      event == PVREvent::ChannelGroupInvalidated || event == PVREvent::ChannelGroup)
   {
     m_bRefreshTimelineItems = true;
     // no base class call => do async refresh
@@ -216,7 +215,8 @@ void CGUIWindowPVRGuideBase::UpdateButtons()
   SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, group ? group->GroupName() : "");
 }
 
-bool CGUIWindowPVRGuideBase::Update(const std::string& strDirectory, bool updateFilterPath /* = true */)
+bool CGUIWindowPVRGuideBase::Update(const std::string& strDirectory,
+                                    bool updateFilterPath /* = true */)
 {
   if (m_bUpdating)
   {
@@ -289,14 +289,14 @@ bool CGUIWindowPVRGuideBase::ShouldNavigateToGridContainer(int iAction)
 {
   CGUIEPGGridContainer* epgGridContainer = GetGridControl();
   CGUIControl* control = GetControl(CONTROL_LSTCHANNELGROUPS);
-  if (epgGridContainer && control &&
-      GetFocusedControlID() == control->GetID())
+  if (epgGridContainer && control && GetFocusedControlID() == control->GetID())
   {
     int iNavigationId = control->GetAction(iAction).GetNavigation();
     if (iNavigationId > 0)
     {
       control = epgGridContainer;
-      while (control != this) // navigation target could be the grid control or one of its parent controls.
+      while (control !=
+             this) // navigation target could be the grid control or one of its parent controls.
       {
         if (iNavigationId == control->GetID())
         {
@@ -654,7 +654,8 @@ bool CGUIWindowPVRGuideBase::OnContextButtonNavigate(CONTEXT_BUTTON button)
     if (g_SkinInfo->HasSkinFile("DialogPVRGuideControls.xml"))
     {
       // use controls dialog
-      CGUIDialog* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetDialog(WINDOW_DIALOG_PVR_GUIDE_CONTROLS);
+      CGUIDialog* dialog =
+          CServiceBroker::GetGUI()->GetWindowManager().GetDialog(WINDOW_DIALOG_PVR_GUIDE_CONTROLS);
       if (dialog && !dialog->IsDialogRunning())
       {
         dialog->Open();
@@ -823,7 +824,8 @@ bool CGUIWindowPVRGuideBase::Go12HoursForward()
 bool CGUIWindowPVRGuideBase::GotoDate(int deltaHours)
 {
   CGUIEPGGridContainer* epgGridContainer = GetGridControl();
-  epgGridContainer->GoToDate(epgGridContainer->GetSelectedDate() + CDateTimeSpan(0, deltaHours, 0, 0));
+  epgGridContainer->GoToDate(epgGridContainer->GetSelectedDate() +
+                             CDateTimeSpan(0, deltaHours, 0, 0));
   return true;
 }
 
@@ -876,10 +878,10 @@ void CGUIWindowPVRGuideBase::GetChannelNumbers(std::vector<std::string>& channel
 }
 
 CPVRRefreshTimelineItemsThread::CPVRRefreshTimelineItemsThread(CGUIWindowPVRGuideBase* pGuideWindow)
-: CThread("epg-grid-refresh-timeline-items"),
-  m_pGuideWindow(pGuideWindow),
-  m_ready(true),
-  m_done(false)
+  : CThread("epg-grid-refresh-timeline-items"),
+    m_pGuideWindow(pGuideWindow),
+    m_ready(true),
+    m_done(false)
 {
 }
 
@@ -921,7 +923,8 @@ void CPVRRefreshTimelineItemsThread::Process()
 
     if (m_pGuideWindow->RefreshTimelineItems() && !m_bStop)
     {
-      CGUIMessage m(GUI_MSG_REFRESH_LIST, m_pGuideWindow->GetID(), 0, static_cast<int>(PVREvent::Epg));
+      CGUIMessage m(GUI_MSG_REFRESH_LIST, m_pGuideWindow->GetID(), 0,
+                    static_cast<int>(PVREvent::Epg));
       CServiceBroker::GetAppMessenger()->SendGUIMessage(m);
     }
 

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -57,10 +57,14 @@ using namespace std::chrono_literals;
 CGUIWindowPVRGuideBase::CGUIWindowPVRGuideBase(bool bRadio, int id, const std::string& xmlFile)
   : CGUIWindowPVRBase(bRadio, id, xmlFile)
 {
+  CServiceBroker::GetPVRManager().Get<PVR::GUI::Channels>().RegisterChannelNumberInputHandler(this);
 }
 
 CGUIWindowPVRGuideBase::~CGUIWindowPVRGuideBase()
 {
+  CServiceBroker::GetPVRManager().Get<PVR::GUI::Channels>().DeregisterChannelNumberInputHandler(
+      this);
+
   m_bRefreshTimelineItems = false;
   m_bSyncRefreshTimelineItems = false;
   StopRefreshTimelineItemsThread();

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -22,106 +22,106 @@ class CGUIMessage;
 
 namespace PVR
 {
-  enum class PVREvent;
+enum class PVREvent;
 
-  class CPVRChannelGroup;
-  class CGUIEPGGridContainer;
-  class CPVRRefreshTimelineItemsThread;
+class CPVRChannelGroup;
+class CGUIEPGGridContainer;
+class CPVRRefreshTimelineItemsThread;
 
-  class CGUIWindowPVRGuideBase : public CGUIWindowPVRBase, public CPVRChannelNumberInputHandler
-  {
-  public:
-    CGUIWindowPVRGuideBase(bool bRadio, int id, const std::string& xmlFile);
-    ~CGUIWindowPVRGuideBase() override;
+class CGUIWindowPVRGuideBase : public CGUIWindowPVRBase, public CPVRChannelNumberInputHandler
+{
+public:
+  CGUIWindowPVRGuideBase(bool bRadio, int id, const std::string& xmlFile);
+  ~CGUIWindowPVRGuideBase() override;
 
-    void OnInitWindow() override;
-    void OnDeinitWindow(int nextWindowID) override;
-    bool OnMessage(CGUIMessage& message) override;
-    bool OnAction(const CAction& action) override;
-    void GetContextButtons(int itemNumber, CContextButtons& buttons) override;
-    bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
-    void UpdateButtons() override;
-    void SetInvalid() override;
-    bool Update(const std::string& strDirectory, bool updateFilterPath = true) override;
+  void OnInitWindow() override;
+  void OnDeinitWindow(int nextWindowID) override;
+  bool OnMessage(CGUIMessage& message) override;
+  bool OnAction(const CAction& action) override;
+  void GetContextButtons(int itemNumber, CContextButtons& buttons) override;
+  bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
+  void UpdateButtons() override;
+  void SetInvalid() override;
+  bool Update(const std::string& strDirectory, bool updateFilterPath = true) override;
 
-    void NotifyEvent(const PVREvent& event) override;
+  void NotifyEvent(const PVREvent& event) override;
 
-    bool RefreshTimelineItems();
+  bool RefreshTimelineItems();
 
-    // CPVRChannelNumberInputHandler implementation
-    void GetChannelNumbers(std::vector<std::string>& channelNumbers) override;
-    void OnInputDone() override;
+  // CPVRChannelNumberInputHandler implementation
+  void GetChannelNumbers(std::vector<std::string>& channelNumbers) override;
+  void OnInputDone() override;
 
-    bool GotoBegin();
-    bool GotoEnd();
-    bool GotoCurrentProgramme();
-    bool GotoDate(int deltaHours);
-    bool OpenDateSelectionDialog();
-    bool Go12HoursBack();
-    bool Go12HoursForward();
-    bool GotoFirstChannel();
-    bool GotoLastChannel();
-    bool GotoPlayingChannel();
+  bool GotoBegin();
+  bool GotoEnd();
+  bool GotoCurrentProgramme();
+  bool GotoDate(int deltaHours);
+  bool OpenDateSelectionDialog();
+  bool Go12HoursBack();
+  bool Go12HoursForward();
+  bool GotoFirstChannel();
+  bool GotoLastChannel();
+  bool GotoPlayingChannel();
 
-  protected:
-    void UpdateSelectedItemPath() override;
-    std::string GetDirectoryPath() override { return ""; }
-    bool GetDirectory(const std::string& strDirectory, CFileItemList& items) override;
-    void FormatAndSort(CFileItemList& items) override;
-    CFileItemPtr GetCurrentListItem(int offset = 0) override;
+protected:
+  void UpdateSelectedItemPath() override;
+  std::string GetDirectoryPath() override { return ""; }
+  bool GetDirectory(const std::string& strDirectory, CFileItemList& items) override;
+  void FormatAndSort(CFileItemList& items) override;
+  CFileItemPtr GetCurrentListItem(int offset = 0) override;
 
-    void ClearData() override;
+  void ClearData() override;
 
-  private:
-    CGUIEPGGridContainer* GetGridControl();
-    void InitEpgGridControl();
+private:
+  CGUIEPGGridContainer* GetGridControl();
+  void InitEpgGridControl();
 
-    bool OnContextButtonNavigate(CONTEXT_BUTTON button);
+  bool OnContextButtonNavigate(CONTEXT_BUTTON button);
 
-    bool ShouldNavigateToGridContainer(int iAction);
+  bool ShouldNavigateToGridContainer(int iAction);
 
-    void StartRefreshTimelineItemsThread();
-    void StopRefreshTimelineItemsThread();
+  void StartRefreshTimelineItemsThread();
+  void StopRefreshTimelineItemsThread();
 
-    void RefreshView(CGUIMessage& message, bool bInitGridControl);
+  void RefreshView(CGUIMessage& message, bool bInitGridControl);
 
-    int GetCurrentListItemIndex(const std::shared_ptr<CFileItem>& item);
+  int GetCurrentListItemIndex(const std::shared_ptr<CFileItem>& item);
 
-    std::unique_ptr<CPVRRefreshTimelineItemsThread> m_refreshTimelineItemsThread;
-    std::atomic_bool m_bRefreshTimelineItems{false};
-    std::atomic_bool m_bSyncRefreshTimelineItems{false};
+  std::unique_ptr<CPVRRefreshTimelineItemsThread> m_refreshTimelineItemsThread;
+  std::atomic_bool m_bRefreshTimelineItems{false};
+  std::atomic_bool m_bSyncRefreshTimelineItems{false};
 
-    std::shared_ptr<CPVRChannelGroup> m_cachedChannelGroup;
+  std::shared_ptr<CPVRChannelGroup> m_cachedChannelGroup;
 
-    bool m_bChannelSelectionRestored{false};
-  };
+  bool m_bChannelSelectionRestored{false};
+};
 
-  class CGUIWindowPVRTVGuide : public CGUIWindowPVRGuideBase
-  {
-  public:
-    CGUIWindowPVRTVGuide() : CGUIWindowPVRGuideBase(false, WINDOW_TV_GUIDE, "MyPVRGuide.xml") {}
-  };
+class CGUIWindowPVRTVGuide : public CGUIWindowPVRGuideBase
+{
+public:
+  CGUIWindowPVRTVGuide() : CGUIWindowPVRGuideBase(false, WINDOW_TV_GUIDE, "MyPVRGuide.xml") {}
+};
 
-  class CGUIWindowPVRRadioGuide : public CGUIWindowPVRGuideBase
-  {
-  public:
-    CGUIWindowPVRRadioGuide() : CGUIWindowPVRGuideBase(true, WINDOW_RADIO_GUIDE, "MyPVRGuide.xml") {}
-  };
+class CGUIWindowPVRRadioGuide : public CGUIWindowPVRGuideBase
+{
+public:
+  CGUIWindowPVRRadioGuide() : CGUIWindowPVRGuideBase(true, WINDOW_RADIO_GUIDE, "MyPVRGuide.xml") {}
+};
 
-  class CPVRRefreshTimelineItemsThread : public CThread
-  {
-  public:
-    explicit CPVRRefreshTimelineItemsThread(CGUIWindowPVRGuideBase* pGuideWindow);
-    ~CPVRRefreshTimelineItemsThread() override;
+class CPVRRefreshTimelineItemsThread : public CThread
+{
+public:
+  explicit CPVRRefreshTimelineItemsThread(CGUIWindowPVRGuideBase* pGuideWindow);
+  ~CPVRRefreshTimelineItemsThread() override;
 
-    void Process() override;
+  void Process() override;
 
-    void DoRefresh(bool bWait);
-    void Stop();
+  void DoRefresh(bool bWait);
+  void Stop();
 
-  private:
-    CGUIWindowPVRGuideBase* m_pGuideWindow;
-    CEvent m_ready;
-    CEvent m_done;
-  };
-}
+private:
+  CGUIWindowPVRGuideBase* m_pGuideWindow;
+  CEvent m_ready;
+  CEvent m_done;
+};
+} // namespace PVR


### PR DESCRIPTION
As `PVR.ChannelNumberInput` label's value will be evaluated several times a second when playing media in fullscreen video window or music visualization window, I wanted to optimize its calculation. Instead of blindly pulling the value via `CServiceBroker::GetPVRManager().Get<PVR::GUI::Channels().GetChannelNumberInputHandler().GetChannelNumberLabel()` on every request, it will be now be pushed by the different channel number input handlers (published as event by the handlers, PVRGUIInfo is subscribed) only in case the value changes. `PVRGUIInfo` now holds the current value of the label in a member variable and only needs to return the value of this member variable, which makes the implementation as fast as it could be (I guess).

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish be my guest for a code review. Only the first commit is of actual interest. The others are just file-by-file clang-formats I'm doing along the way to get all PVR source files clang-format compliant over time.