### PR TITLE
[PVR] Optimize CGUIDialogPVRGuideInfo

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -25,17 +25,17 @@
 
 using namespace PVR;
 
-#define CONTROL_BTN_FIND                4
-#define CONTROL_BTN_SWITCH              5
-#define CONTROL_BTN_RECORD              6
-#define CONTROL_BTN_OK                  7
-#define CONTROL_BTN_PLAY_RECORDING      8
-#define CONTROL_BTN_ADD_TIMER           9
-#define CONTROL_BTN_PLAY_EPGTAG        10
-#define CONTROL_BTN_SET_REMINDER       11
+#define CONTROL_BTN_FIND 4
+#define CONTROL_BTN_SWITCH 5
+#define CONTROL_BTN_RECORD 6
+#define CONTROL_BTN_OK 7
+#define CONTROL_BTN_PLAY_RECORDING 8
+#define CONTROL_BTN_ADD_TIMER 9
+#define CONTROL_BTN_PLAY_EPGTAG 10
+#define CONTROL_BTN_SET_REMINDER 11
 
 CGUIDialogPVRGuideInfo::CGUIDialogPVRGuideInfo()
-    : CGUIDialog(WINDOW_DIALOG_PVR_GUIDE_INFO, "DialogPVRInfo.xml")
+  : CGUIDialog(WINDOW_DIALOG_PVR_GUIDE_INFO, "DialogPVRInfo.xml")
 {
 }
 
@@ -165,13 +165,10 @@ bool CGUIDialogPVRGuideInfo::OnMessage(CGUIMessage& message)
 {
   switch (message.GetMessage())
   {
-  case GUI_MSG_CLICKED:
-    return OnClickButtonOK(message) ||
-           OnClickButtonRecord(message) ||
-           OnClickButtonPlay(message) ||
-           OnClickButtonFind(message) ||
-           OnClickButtonAddTimer(message) ||
-           OnClickButtonSetReminder(message);
+    case GUI_MSG_CLICKED:
+      return OnClickButtonOK(message) || OnClickButtonRecord(message) ||
+             OnClickButtonPlay(message) || OnClickButtonFind(message) ||
+             OnClickButtonAddTimer(message) || OnClickButtonSetReminder(message);
   }
 
   return CGUIDialog::OnMessage(message);

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.h
@@ -16,8 +16,6 @@ class CGUIMessage;
 
 namespace PVR
 {
-  class CPVREpgInfoTag;
-
   class CGUIDialogPVRGuideInfo : public CGUIDialog
   {
   public:
@@ -28,7 +26,7 @@ namespace PVR
     bool HasListItems() const override { return true; }
     CFileItemPtr GetCurrentListItem(int offset = 0) override;
 
-    void SetProgInfo(const std::shared_ptr<CPVREpgInfoTag>& tag);
+    void SetProgInfo(const std::shared_ptr<CFileItem>& item);
 
   protected:
     void OnInitWindow() override;
@@ -41,6 +39,6 @@ namespace PVR
     bool OnClickButtonAddTimer(const CGUIMessage& message);
     bool OnClickButtonSetReminder(const CGUIMessage& message);
 
-    std::shared_ptr<CPVREpgInfoTag> m_progItem;
+    std::shared_ptr<CFileItem> m_progItem;
   };
 }

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.h
@@ -16,29 +16,29 @@ class CGUIMessage;
 
 namespace PVR
 {
-  class CGUIDialogPVRGuideInfo : public CGUIDialog
-  {
-  public:
-    CGUIDialogPVRGuideInfo();
-    ~CGUIDialogPVRGuideInfo() override;
-    bool OnMessage(CGUIMessage& message) override;
-    bool OnInfo(int actionID) override;
-    bool HasListItems() const override { return true; }
-    CFileItemPtr GetCurrentListItem(int offset = 0) override;
+class CGUIDialogPVRGuideInfo : public CGUIDialog
+{
+public:
+  CGUIDialogPVRGuideInfo();
+  ~CGUIDialogPVRGuideInfo() override;
+  bool OnMessage(CGUIMessage& message) override;
+  bool OnInfo(int actionID) override;
+  bool HasListItems() const override { return true; }
+  CFileItemPtr GetCurrentListItem(int offset = 0) override;
 
-    void SetProgInfo(const std::shared_ptr<CFileItem>& item);
+  void SetProgInfo(const std::shared_ptr<CFileItem>& item);
 
-  protected:
-    void OnInitWindow() override;
+protected:
+  void OnInitWindow() override;
 
-  private:
-    bool OnClickButtonOK(const CGUIMessage& message);
-    bool OnClickButtonRecord(const CGUIMessage& message);
-    bool OnClickButtonPlay(const CGUIMessage& message);
-    bool OnClickButtonFind(const CGUIMessage& message);
-    bool OnClickButtonAddTimer(const CGUIMessage& message);
-    bool OnClickButtonSetReminder(const CGUIMessage& message);
+private:
+  bool OnClickButtonOK(const CGUIMessage& message);
+  bool OnClickButtonRecord(const CGUIMessage& message);
+  bool OnClickButtonPlay(const CGUIMessage& message);
+  bool OnClickButtonFind(const CGUIMessage& message);
+  bool OnClickButtonAddTimer(const CGUIMessage& message);
+  bool OnClickButtonSetReminder(const CGUIMessage& message);
 
-    std::shared_ptr<CFileItem> m_progItem;
-  };
-}
+  std::shared_ptr<CFileItem> m_progItem;
+};
+} // namespace PVR

--- a/xbmc/pvr/guilib/PVRGUIActionsEPG.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsEPG.cpp
@@ -76,7 +76,7 @@ bool CPVRGUIActionsEPG::ShowEPGInfo(const CFileItemPtr& item) const
     return false;
   }
 
-  pDlgInfo->SetProgInfo(epgTag);
+  pDlgInfo->SetProgInfo(std::make_shared<CFileItem>(epgTag));
   pDlgInfo->Open();
   return true;
 }


### PR DESCRIPTION
If the dialog is open, `CGUIDialogPVRGuideInfo::GetCurrentListItem` is called multiple times per second, to update control visibility state, so this function should be as performant as possible.

This is achieved by changing the dialog's member `m_progItem` from `CPVREpgInfoTag` to `CFileItem`, so that `CGUIDialogPVRGuideInfo::GetCurrentListItem` does not need to construct a CFileItem out of the EPG tag.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish another one to review. :-) Second commit is just clang-format, no functional changes.