### PR TITLE
[PVR] Optimize GUI label '(VideoPlayer|MusicPlayer|ListItem).ChannelNumberLabel' implementation.

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.cpp
@@ -12,7 +12,6 @@
 #include "guilib/LocalizeStrings.h"
 #include "pvr/PVRDatabase.h"
 #include "pvr/PVRManager.h"
-#include "pvr/PVRPlaybackState.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRChannelGroupMember.h"

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -766,8 +766,11 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item, const CGUIInf
       case VIDEOPLAYER_CHANNEL_NUMBER:
       case LISTITEM_CHANNEL_NUMBER:
       {
-        const std::shared_ptr<CPVRChannelGroupMember> groupMember =
-            CServiceBroker::GetPVRManager().Get<PVR::GUI::Channels>().GetChannelGroupMember(*item);
+        auto groupMember = item->GetPVRChannelGroupMemberInfoTag();
+        if (!groupMember)
+          groupMember =
+              CServiceBroker::GetPVRManager().Get<PVR::GUI::Channels>().GetChannelGroupMember(
+                  *item);
         if (groupMember)
         {
           strValue = groupMember->ChannelNumber().FormattedChannelNumber();


### PR DESCRIPTION
Just a small optimization to simply take the `CPVRChannelGroupMember`supplied with the item if present, saving the (expensive) call `CPVRGUIActionsChannels::GetChannelGroupMember`.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish should be a no-brainer to review. Second commit is (actually) an unrelated cleanup (one-liner).
