### PR TITLE
[curl] add support for HTTPS proxy type

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -4188,8 +4188,13 @@ msgctxt "#1185"
 msgid "SOCKS5 with remote DNS resolving"
 msgstr ""
 
-#empty strings from id 1186 to 1199
-#strings 1186 to 1189 reserved for more proxy types
+#: system/settings/settings.xml
+msgctxt "#1186"
+msgid "HTTPS"
+msgstr ""
+
+#empty strings from id 1187 to 1199
+#strings 1187 to 1199 reserved for more proxy types
 
 #: xbmc/settings/win32.xml
 msgctxt "#1200"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3255,6 +3255,7 @@
           <constraints>
             <options>
               <option label="1181">0</option> <!-- PROXY_HTTP -->
+              <option label="1186">5</option> <!-- PROXY_HTTPS -->
               <option label="1182">1</option> <!-- PROXY_SOCKS4 -->
               <option label="1183">2</option> <!-- PROXY_SOCKS4A -->
               <option label="1184">3</option> <!-- PROXY_SOCKS5 -->

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -45,11 +45,8 @@ using namespace std::chrono_literals;
 #define FITS_INT(a) (((a) <= INT_MAX) && ((a) >= INT_MIN))
 
 curl_proxytype proxyType2CUrlProxyType[] = {
-  CURLPROXY_HTTP,
-  CURLPROXY_SOCKS4,
-  CURLPROXY_SOCKS4A,
-  CURLPROXY_SOCKS5,
-  CURLPROXY_SOCKS5_HOSTNAME,
+    CURLPROXY_HTTP,   CURLPROXY_SOCKS4,          CURLPROXY_SOCKS4A,
+    CURLPROXY_SOCKS5, CURLPROXY_SOCKS5_HOSTNAME, CURLPROXY_HTTPS,
 };
 
 #define FILLBUFFER_OK         0
@@ -1050,6 +1047,8 @@ void CCurlFile::SetProxy(const std::string &type, const std::string &host,
   m_proxytype = CCurlFile::PROXY_HTTP;
   if (type == "http")
     m_proxytype = CCurlFile::PROXY_HTTP;
+  else if (type == "https")
+    m_proxytype = CCurlFile::PROXY_HTTPS;
   else if (type == "socks4")
     m_proxytype = CCurlFile::PROXY_SOCKS4;
   else if (type == "socks4a")

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -31,6 +31,7 @@ namespace XFILE
         PROXY_SOCKS4A,
         PROXY_SOCKS5,
         PROXY_SOCKS5_REMOTE,
+        PROXY_HTTPS,
       } ProxyType;
 
     public:


### PR DESCRIPTION
## Description

Added support for HTTPS proxies under `Settings/System/Internet access`.

The `CURLPROXY_HTTPS` type was introduced in curl 7.52.0 (December 2016).

## Motivation and context

Provides users with the option to use HTTPS proxies in addition to plaintext HTTP and SOCKS proxies.

## How has this been tested?

Tested on a Windows build by installing an addon and verifying via Wireshark that the addon download used the proxy.

## What is the effect on users?

Added support for HTTPS proxies under `Settings/System/Internet access`.

<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation (https://kodi.wiki/view/Settings/System/Internet_access)
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed