### PR TITLE
[PVR] Optimize Player.ChannelPreviewActive GUI info bool calculation

### DIFF
--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -134,7 +134,11 @@ std::string CPlayerGUIInfo::GetSeekTime(TIME_FORMAT format) const
 
 void CPlayerGUIInfo::SetShowInfo(bool showinfo)
 {
-  m_playerShowInfo = showinfo;
+  if (showinfo != m_playerShowInfo)
+  {
+    m_playerShowInfo = showinfo;
+    m_events.Publish(PlayerShowInfoChangedEvent(m_playerShowInfo));
+  }
 }
 
 bool CPlayerGUIInfo::ToggleShowInfo()

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.h
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.h
@@ -10,6 +10,7 @@
 
 #include "XBDateTime.h"
 #include "guilib/guiinfo/GUIInfoProvider.h"
+#include "utils/EventStream.h"
 
 #include <atomic>
 #include <memory>
@@ -27,11 +28,21 @@ namespace GUIINFO
 
 class CGUIInfo;
 
+struct PlayerShowInfoChangedEvent
+{
+  explicit PlayerShowInfoChangedEvent(bool showInfo) : m_showInfo(showInfo) {}
+  virtual ~PlayerShowInfoChangedEvent() = default;
+
+  bool m_showInfo{false};
+};
+
 class CPlayerGUIInfo : public CGUIInfoProvider
 {
 public:
   CPlayerGUIInfo();
   ~CPlayerGUIInfo() override;
+
+  CEventStream<PlayerShowInfoChangedEvent>& Events() { return m_events; }
 
   // KODI::GUILIB::GUIINFO::IGUIInfoProvider implementation
   bool InitCurrentItem(CFileItem *item) override;
@@ -54,6 +65,8 @@ private:
   int GetPlayTime() const;
   int GetPlayTimeRemaining() const;
   float GetSeekPercent() const;
+
+  CEventSource<PlayerShowInfoChangedEvent> m_events;
 
   std::string GetCurrentPlayTime(TIME_FORMAT format) const;
   std::string GetCurrentPlayTimeRemaining(TIME_FORMAT format) const;

--- a/xbmc/pvr/guilib/PVRGUIChannelNavigator.h
+++ b/xbmc/pvr/guilib/PVRGUIChannelNavigator.h
@@ -26,154 +26,164 @@ struct PlayerShowInfoChangedEvent;
 
 namespace PVR
 {
-  enum class ChannelSwitchMode
+enum class ChannelSwitchMode
+{
+  NO_SWITCH, // no channel switch
+  INSTANT_OR_DELAYED_SWITCH // switch according to SETTING_PVRPLAYBACK_CHANNELENTRYTIMEOUT
+};
+
+struct PVRPreviewAndPlayerShowInfoChangedEvent
+{
+  explicit PVRPreviewAndPlayerShowInfoChangedEvent(bool previewAndPlayerShowInfo)
+    : m_previewAndPlayerShowInfo(previewAndPlayerShowInfo)
   {
-    NO_SWITCH, // no channel switch
-    INSTANT_OR_DELAYED_SWITCH // switch according to SETTING_PVRPLAYBACK_CHANNELENTRYTIMEOUT
-  };
+  }
+  virtual ~PVRPreviewAndPlayerShowInfoChangedEvent() = default;
 
-  struct PVRPreviewAndPlayerShowInfoChangedEvent
+  bool m_previewAndPlayerShowInfo{false};
+};
+
+class CPVRChannelGroupMember;
+
+class CPVRGUIChannelNavigator
+{
+public:
+  CPVRGUIChannelNavigator();
+  virtual ~CPVRGUIChannelNavigator();
+
+  /*!
+   * @brief Subscribe to the event stream for changes of channel preview and player show info.
+   * @param owner The subscriber.
+   * @param fn The callback function of the subscriber for the events.
+   */
+  template<typename A>
+  void Subscribe(A* owner, void (A::*fn)(const PVRPreviewAndPlayerShowInfoChangedEvent&))
   {
-    explicit PVRPreviewAndPlayerShowInfoChangedEvent(bool previewAndPlayerShowInfo)
-      : m_previewAndPlayerShowInfo(previewAndPlayerShowInfo)
-    {
-    }
-    virtual ~PVRPreviewAndPlayerShowInfoChangedEvent() = default;
+    SubscribeToShowInfoEventStream();
+    m_events.Subscribe(owner, fn);
+  }
 
-    bool m_previewAndPlayerShowInfo{false};
-  };
-
-  class CPVRChannelGroupMember;
-
-  class CPVRGUIChannelNavigator
+  /*!
+   * @brief Unsubscribe from the event stream for changes of channel preview and player show info.
+   * @param obj The subscriber.
+   */
+  template<typename A>
+  void Unsubscribe(A* obj)
   {
-  public:
-    CPVRGUIChannelNavigator();
-    virtual ~CPVRGUIChannelNavigator();
+    m_events.Unsubscribe(obj);
+  }
 
-    /*!
-     * @brief Subscribe to the event stream for changes of channel preview and player show info.
-     * @param owner The subscriber.
-     * @param fn The callback function of the subscriber for the events.
-     */
-    template<typename A>
-    void Subscribe(A* owner, void (A::*fn)(const PVRPreviewAndPlayerShowInfoChangedEvent&))
-    {
-      SubscribeToShowInfoEventStream();
-      m_events.Subscribe(owner, fn);
-    }
+  /*!
+   * @brief CEventStream callback for player show info flag changes.
+   * @param event The event.
+   */
+  void Notify(const KODI::GUILIB::GUIINFO::PlayerShowInfoChangedEvent& event);
 
-    /*!
-     * @brief Unsubscribe from the event stream for changes of channel preview and player show info.
-     * @param obj The subscriber.
-     */
-    template<typename A>
-    void Unsubscribe(A* obj)
-    {
-      m_events.Unsubscribe(obj);
-    }
+  /*!
+   * @brief Select the next channel in currently playing channel group, relative to the currently
+   * selected channel.
+   * @param eSwitchMode controls whether only the channel info OSD is triggered or whether
+   * additionally a (delayed) channel switch will be done.
+   */
+  void SelectNextChannel(ChannelSwitchMode eSwitchMode);
 
-    /*!
-     * @brief CEventStream callback for player show info flag changes.
-     * @param event The event.
-     */
-    void Notify(const KODI::GUILIB::GUIINFO::PlayerShowInfoChangedEvent& event);
+  /*!
+   * @brief Select the previous channel in currently playing channel group, relative to the
+   * currently selected channel.
+   * @param eSwitchMode controls whether only the channel info OSD is triggered or whether
+   * additionally a (delayed) channel switch will be done.
+   */
+  void SelectPreviousChannel(ChannelSwitchMode eSwitchMode);
 
-    /*!
-     * @brief Select the next channel in currently playing channel group, relative to the currently selected channel.
-     * @param eSwitchMode controls whether only the channel info OSD is triggered or whether additionally a (delayed) channel switch will be done.
-     */
-    void SelectNextChannel(ChannelSwitchMode eSwitchMode);
+  /*!
+   * @brief Switch to the currently selected channel.
+   */
+  void SwitchToCurrentChannel();
 
-    /*!
-     * @brief Select the previous channel in currently playing channel group, relative to the currently selected channel.
-     * @param eSwitchMode controls whether only the channel info OSD is triggered or whether additionally a (delayed) channel switch will be done.
-     */
-    void SelectPreviousChannel(ChannelSwitchMode eSwitchMode);
+  /*!
+   * @brief Query the state of channel preview.
+   * @return True, if the currently selected channel is different from the currently playing
+   * channel, False otherwise.
+   */
+  bool IsPreview() const;
 
-    /*!
-     * @brief Switch to the currently selected channel.
-     */
-    void SwitchToCurrentChannel();
+  /*!
+   * @brief Query the state of channel preview and channel info OSD.
+   * @return True, if the currently selected channel is different from the currently playing channel
+   * and channel info OSD is active, False otherwise.
+   */
+  bool IsPreviewAndShowInfo() const;
 
-    /*!
-     * @brief Query the state of channel preview.
-     * @return True, if the currently selected channel is different from the currently playing channel, False otherwise.
-     */
-    bool IsPreview() const;
+  /*!
+   * @brief Show the channel info OSD.
+   */
+  void ShowInfo();
 
-    /*!
-     * @brief Query the state of channel preview and channel info OSD.
-     * @return True, if the currently selected channel is different from the currently playing channel and channel info OSD is active, False otherwise.
-     */
-    bool IsPreviewAndShowInfo() const;
+  /*!
+   * @brief Hide the channel info OSD.
+   */
+  void HideInfo();
 
-    /*!
-     * @brief Show the channel info OSD.
-     */
-    void ShowInfo();
+  /*!
+   * @brief Toggle the channel info OSD visibility.
+   */
+  void ToggleInfo();
 
-    /*!
-     * @brief Hide the channel info OSD.
-     */
-    void HideInfo();
+  /*!
+   * @brief Set a new playing channel group member and show the channel info OSD for the new
+   * channel.
+   * @param groupMember The new playing channel group member
+   */
+  void SetPlayingChannel(const std::shared_ptr<CPVRChannelGroupMember>& groupMember);
 
-    /*!
-     * @brief Toggle the channel info OSD visibility.
-     */
-    void ToggleInfo();
+  /*!
+   * @brief Clear the currently playing channel and hide the channel info OSD.
+   */
+  void ClearPlayingChannel();
 
-    /*!
-     * @brief Set a new playing channel group member and show the channel info OSD for the new channel.
-     * @param groupMember The new playing channel group member
-     */
-    void SetPlayingChannel(const std::shared_ptr<CPVRChannelGroupMember>& groupMember);
+private:
+  /*!
+   * @brief Get next or previous channel group member of the playing channel group, relative to the
+   * currently selected channel group member.
+   * @param bNext True to get the next channel group member, false to get the previous channel group
+   * member.
+   * @param return The channel or nullptr if not found.
+   */
+  std::shared_ptr<CPVRChannelGroupMember> GetNextOrPrevChannel(bool bNext);
 
-    /*!
-     * @brief Clear the currently playing channel and hide the channel info OSD.
-     */
-    void ClearPlayingChannel();
+  /*!
+   * @brief Select a given channel group member, display channel info OSD, switch according to given
+   * switch mode.
+   * @param groupMember The channel group member to select.
+   * @param eSwitchMode The channel switch mode.
+   */
+  void SelectChannel(const std::shared_ptr<CPVRChannelGroupMember>& groupMember,
+                     ChannelSwitchMode eSwitchMode);
 
-  private:
-    /*!
-     * @brief Get next or previous channel group member of the playing channel group, relative to the currently selected channel group member.
-     * @param bNext True to get the next channel group member, false to get the previous channel group member.
-     * @param return The channel or nullptr if not found.
-     */
-    std::shared_ptr<CPVRChannelGroupMember> GetNextOrPrevChannel(bool bNext);
+  /*!
+   * @brief Show the channel info OSD.
+   * @param bForce True ignores value of SETTING_PVRMENU_DISPLAYCHANNELINFO and always activates the
+   * info, False acts aaccording settings value.
+   */
+  void ShowInfo(bool bForce);
 
-    /*!
-     * @brief Select a given channel group member, display channel info OSD, switch according to given switch mode.
-     * @param groupMember The channel group member to select.
-     * @param eSwitchMode The channel switch mode.
-     */
-    void SelectChannel(const std::shared_ptr<CPVRChannelGroupMember>& groupMember,
-                       ChannelSwitchMode eSwitchMode);
+  /*!
+   * @brief Subscribe to the event stream for changes of player show info.
+   */
+  void SubscribeToShowInfoEventStream();
 
-    /*!
-     * @brief Show the channel info OSD.
-     * @param bForce True ignores value of SETTING_PVRMENU_DISPLAYCHANNELINFO and always activates the info, False acts aaccording settings value.
-     */
-    void ShowInfo(bool bForce);
+  /*!
+   * @brief Check if property preview and show info value changed, inform subscribers in case.
+   */
+  void CheckAndPublishPreviewAndPlayerShowInfoChangedEvent();
 
-    /*!
-     * @brief Subscribe to the event stream for changes of player show info.
-     */
-    void SubscribeToShowInfoEventStream();
-
-    /*!
-     * @brief Check if property preview and show info value changed, inform subscribers in case.
-     */
-    void CheckAndPublishPreviewAndPlayerShowInfoChangedEvent();
-
-    mutable CCriticalSection m_critSection;
-    std::shared_ptr<CPVRChannelGroupMember> m_playingChannel;
-    std::shared_ptr<CPVRChannelGroupMember> m_currentChannel;
-    int m_iChannelEntryJobId = -1;
-    int m_iChannelInfoJobId = -1;
-    CEventSource<PVRPreviewAndPlayerShowInfoChangedEvent> m_events;
-    bool m_playerShowInfo{false};
-    bool m_previewAndPlayerShowInfo{false};
-  };
-
+  mutable CCriticalSection m_critSection;
+  std::shared_ptr<CPVRChannelGroupMember> m_playingChannel;
+  std::shared_ptr<CPVRChannelGroupMember> m_currentChannel;
+  int m_iChannelEntryJobId = -1;
+  int m_iChannelInfoJobId = -1;
+  CEventSource<PVRPreviewAndPlayerShowInfoChangedEvent> m_events;
+  bool m_playerShowInfo{false};
+  bool m_previewAndPlayerShowInfo{false};
+};
 } // namespace PVR

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.h
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.h
@@ -37,6 +37,7 @@ namespace PVR
 {
 enum class PVREvent;
 struct PVRChannelNumberInputChangedEvent;
+struct PVRPreviewAndPlayerShowInfoChangedEvent;
 
 class CPVRGUIInfo : public KODI::GUILIB::GUIINFO::CGUIInfoProvider, private CThread
 {
@@ -58,6 +59,12 @@ public:
    * @param event The event.
    */
   void Notify(const PVRChannelNumberInputChangedEvent& event);
+
+  /*!
+   * @brief CEventStream callback for channel preview and player show info changes.
+   * @param event The event.
+   */
+  void Notify(const PVRPreviewAndPlayerShowInfoChangedEvent& event);
 
   // KODI::GUILIB::GUIINFO::IGUIInfoProvider implementation
   bool InitCurrentItem(CFileItem* item) override;
@@ -193,6 +200,7 @@ private:
   std::vector<SBackend> m_backendProperties;
 
   std::string m_channelNumberInput;
+  bool m_previewAndPlayerShowInfo{false};
 
   mutable CCriticalSection m_critSection;
 


### PR DESCRIPTION
Same motivation and approach as for #21961, this time for the GUI info bool `Player.ChannelPreviewActive`.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish be my guest for a code review. Only the first commit is of actual interest. The other commit is clang-format.