### PR TITLE
[FileItem][PVR] Optimize: Get rid of the expensive ctor taking an EPG tag and a channel group member

### DIFF
--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -113,8 +113,6 @@ public:
   explicit CFileItem(const MUSIC_INFO::CMusicInfoTag& music);
   explicit CFileItem(const CVideoInfoTag& movie);
   explicit CFileItem(const std::shared_ptr<PVR::CPVREpgInfoTag>& tag);
-  CFileItem(const std::shared_ptr<PVR::CPVREpgInfoTag>& tag,
-            const std::shared_ptr<PVR::CPVRChannelGroupMember>& groupMember);
   explicit CFileItem(const std::shared_ptr<PVR::CPVREpgSearchFilter>& filter);
   explicit CFileItem(const std::shared_ptr<PVR::CPVRChannelGroupMember>& channelGroupMember);
   explicit CFileItem(const std::shared_ptr<PVR::CPVRRecording>& record);
@@ -629,10 +627,9 @@ private:
   CBookmark GetResumePoint() const;
 
   /*!
-   \brief If given channel is radio, fill item's music tag from given epg tag and channel info.
+   \brief Fill item's music tag from given epg tag.
    */
-  void FillMusicInfoTag(const std::shared_ptr<PVR::CPVRChannelGroupMember>& groupMember,
-                        const std::shared_ptr<PVR::CPVREpgInfoTag>& tag);
+  void FillMusicInfoTag(const std::shared_ptr<PVR::CPVREpgInfoTag>& tag);
 
   std::string m_strPath;            ///< complete path to item
   std::string m_strDynPath;

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -336,6 +336,11 @@ bool CPVRChannel::SetIconPath(const std::string& strIconPath, bool bIsUserSetIco
     return false;
 
   m_iconPath.SetClientImage(strIconPath);
+
+  const std::shared_ptr<CPVREpg> epg = GetEPG();
+  if (epg)
+    epg->GetChannelData()->SetChannelIconPath(strIconPath);
+
   m_bChanged = true;
   m_bIsUserSetIcon = bIsUserSetIcon && !IconPath().empty();
   return true;

--- a/xbmc/pvr/epg/EpgChannelData.cpp
+++ b/xbmc/pvr/epg/EpgChannelData.cpp
@@ -27,7 +27,8 @@ CPVREpgChannelData::CPVREpgChannelData(const CPVRChannel& channel)
     m_bIsLocked(channel.IsLocked()),
     m_bIsEPGEnabled(channel.EPGEnabled()),
     m_iChannelId(channel.ChannelID()),
-    m_strChannelName(channel.ChannelName())
+    m_strChannelName(channel.ChannelName()),
+    m_strChannelIconPath(channel.IconPath())
 {
 }
 
@@ -94,4 +95,14 @@ const std::string& CPVREpgChannelData::ChannelName() const
 void CPVREpgChannelData::SetChannelName(const std::string& strChannelName)
 {
   m_strChannelName = strChannelName;
+}
+
+const std::string& CPVREpgChannelData::ChannelIconPath() const
+{
+  return m_strChannelIconPath;
+}
+
+void CPVREpgChannelData::SetChannelIconPath(const std::string& strChannelIconPath)
+{
+  m_strChannelIconPath = strChannelIconPath;
 }

--- a/xbmc/pvr/epg/EpgChannelData.cpp
+++ b/xbmc/pvr/epg/EpgChannelData.cpp
@@ -14,8 +14,7 @@
 using namespace PVR;
 
 CPVREpgChannelData::CPVREpgChannelData(int iClientId, int iUniqueClientChannelId)
-: m_iClientId(iClientId),
-  m_iUniqueClientChannelId(iUniqueClientChannelId)
+  : m_iClientId(iClientId), m_iUniqueClientChannelId(iUniqueClientChannelId)
 {
 }
 

--- a/xbmc/pvr/epg/EpgChannelData.h
+++ b/xbmc/pvr/epg/EpgChannelData.h
@@ -41,6 +41,9 @@ namespace PVR
     const std::string& ChannelName() const;
     void SetChannelName(const std::string& strChannelName);
 
+    const std::string& ChannelIconPath() const;
+    void SetChannelIconPath(const std::string& strChannelIconPath);
+
   private:
     const bool m_bIsRadio = false;
     const int m_iClientId = -1;
@@ -51,5 +54,6 @@ namespace PVR
     bool m_bIsEPGEnabled = true;
     int m_iChannelId = -1;
     std::string m_strChannelName;
+    std::string m_strChannelIconPath;
   };
 }

--- a/xbmc/pvr/epg/EpgChannelData.h
+++ b/xbmc/pvr/epg/EpgChannelData.h
@@ -13,47 +13,47 @@
 
 namespace PVR
 {
-  class CPVRChannel;
+class CPVRChannel;
 
-  class CPVREpgChannelData
-  {
-  public:
-    CPVREpgChannelData() = default;
-    CPVREpgChannelData(int iClientId, int iUniqueClientChannelId);
-    explicit CPVREpgChannelData(const CPVRChannel& channel);
+class CPVREpgChannelData
+{
+public:
+  CPVREpgChannelData() = default;
+  CPVREpgChannelData(int iClientId, int iUniqueClientChannelId);
+  explicit CPVREpgChannelData(const CPVRChannel& channel);
 
-    int ClientId() const;
-    int UniqueClientChannelId() const;
-    bool IsRadio() const;
+  int ClientId() const;
+  int UniqueClientChannelId() const;
+  bool IsRadio() const;
 
-    bool IsHidden() const;
-    void SetHidden(bool bIsHidden);
+  bool IsHidden() const;
+  void SetHidden(bool bIsHidden);
 
-    bool IsLocked() const;
-    void SetLocked(bool bIsLocked);
+  bool IsLocked() const;
+  void SetLocked(bool bIsLocked);
 
-    bool IsEPGEnabled() const;
-    void SetEPGEnabled(bool bIsEPGEnabled);
+  bool IsEPGEnabled() const;
+  void SetEPGEnabled(bool bIsEPGEnabled);
 
-    int ChannelId() const;
-    void SetChannelId(int iChannelId);
+  int ChannelId() const;
+  void SetChannelId(int iChannelId);
 
-    const std::string& ChannelName() const;
-    void SetChannelName(const std::string& strChannelName);
+  const std::string& ChannelName() const;
+  void SetChannelName(const std::string& strChannelName);
 
-    const std::string& ChannelIconPath() const;
-    void SetChannelIconPath(const std::string& strChannelIconPath);
+  const std::string& ChannelIconPath() const;
+  void SetChannelIconPath(const std::string& strChannelIconPath);
 
-  private:
-    const bool m_bIsRadio = false;
-    const int m_iClientId = -1;
-    const int m_iUniqueClientChannelId = -1;
+private:
+  const bool m_bIsRadio = false;
+  const int m_iClientId = -1;
+  const int m_iUniqueClientChannelId = -1;
 
-    bool m_bIsHidden = false;
-    bool m_bIsLocked = false;
-    bool m_bIsEPGEnabled = true;
-    int m_iChannelId = -1;
-    std::string m_strChannelName;
-    std::string m_strChannelIconPath;
-  };
-}
+  bool m_bIsHidden = false;
+  bool m_bIsLocked = false;
+  bool m_bIsEPGEnabled = true;
+  int m_iChannelId = -1;
+  std::string m_strChannelName;
+  std::string m_strChannelIconPath;
+};
+} // namespace PVR

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -141,7 +141,7 @@ void CPVREpgInfoTag::SetChannelData(const std::shared_ptr<CPVREpgChannelData>& d
     m_channelData.reset(new CPVREpgChannelData);
 }
 
-bool CPVREpgInfoTag::operator ==(const CPVREpgInfoTag& right) const
+bool CPVREpgInfoTag::operator==(const CPVREpgInfoTag& right) const
 {
   if (this == &right)
     return true;
@@ -153,7 +153,7 @@ bool CPVREpgInfoTag::operator ==(const CPVREpgInfoTag& right) const
           m_channelData->ClientId() == right.m_channelData->ClientId());
 }
 
-bool CPVREpgInfoTag::operator !=(const CPVREpgInfoTag& right) const
+bool CPVREpgInfoTag::operator!=(const CPVREpgInfoTag& right) const
 {
   if (this == &right)
     return false;
@@ -370,12 +370,16 @@ const std::string CPVREpgInfoTag::GetCastLabel() const
 
 const std::string CPVREpgInfoTag::GetDirectorsLabel() const
 {
-  return StringUtils::Join(m_directors, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator);
+  return StringUtils::Join(
+      m_directors,
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator);
 }
 
 const std::string CPVREpgInfoTag::GetWritersLabel() const
 {
-  return StringUtils::Join(m_writers, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator);
+  return StringUtils::Join(
+      m_writers,
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoItemSeparator);
 }
 
 const std::string CPVREpgInfoTag::GetGenresLabel() const
@@ -569,7 +573,8 @@ std::vector<PVR_EDL_ENTRY> CPVREpgInfoTag::GetEdl() const
   std::vector<PVR_EDL_ENTRY> edls;
 
   std::unique_lock<CCriticalSection> lock(m_critSection);
-  const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_channelData->ClientId());
+  const std::shared_ptr<CPVRClient> client =
+      CServiceBroker::GetPVRManager().GetClient(m_channelData->ClientId());
 
   if (client && client->GetClientCapabilities().SupportsEpgTagEdl())
     client->GetEpgTagEdl(shared_from_this(), edls);
@@ -593,7 +598,8 @@ bool CPVREpgInfoTag::IsRecordable() const
   bool bIsRecordable = false;
 
   std::unique_lock<CCriticalSection> lock(m_critSection);
-  const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_channelData->ClientId());
+  const std::shared_ptr<CPVRClient> client =
+      CServiceBroker::GetPVRManager().GetClient(m_channelData->ClientId());
   if (!client || (client->IsRecordable(shared_from_this(), bIsRecordable) != PVR_ERROR_NO_ERROR))
   {
     // event end time based fallback
@@ -607,7 +613,8 @@ bool CPVREpgInfoTag::IsPlayable() const
   bool bIsPlayable = false;
 
   std::unique_lock<CCriticalSection> lock(m_critSection);
-  const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_channelData->ClientId());
+  const std::shared_ptr<CPVRClient> client =
+      CServiceBroker::GetPVRManager().GetClient(m_channelData->ClientId());
   if (!client || (client->IsPlayable(shared_from_this(), bIsPlayable) != PVR_ERROR_NO_ERROR))
   {
     // fallback
@@ -618,7 +625,8 @@ bool CPVREpgInfoTag::IsPlayable() const
 
 bool CPVREpgInfoTag::IsSeries() const
 {
-  if ((m_iFlags & EPG_TAG_FLAG_IS_SERIES) > 0 || SeriesNumber() >= 0 || EpisodeNumber() >= 0 || EpisodePart() >= 0)
+  if ((m_iFlags & EPG_TAG_FLAG_IS_SERIES) > 0 || SeriesNumber() >= 0 || EpisodeNumber() >= 0 ||
+      EpisodePart() >= 0)
     return true;
   else
     return false;

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -280,6 +280,12 @@ int CPVREpgInfoTag::UniqueChannelID() const
   return m_channelData->UniqueClientChannelId();
 }
 
+std::string CPVREpgInfoTag::ChannelIconPath() const
+{
+  std::unique_lock<CCriticalSection> lock(m_critSection);
+  return m_channelData->ChannelIconPath();
+}
+
 CDateTime CPVREpgInfoTag::StartAsUTC() const
 {
   return m_startTime;

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -141,6 +141,12 @@ namespace PVR
     int UniqueChannelID() const;
 
     /*!
+     * @brief Get the path for the icon of the channel associated with this event.
+     * @return The channel icon path.
+     */
+    std::string ChannelIconPath() const;
+
+    /*!
      * @brief Get the event's start time.
      * @return The start time in UTC.
      */

--- a/xbmc/pvr/epg/EpgInfoTag.h
+++ b/xbmc/pvr/epg/EpgInfoTag.h
@@ -22,486 +22,492 @@ struct PVR_EDL_ENTRY;
 
 namespace PVR
 {
-  class CPVREpgChannelData;
-  class CPVREpgDatabase;
-
-  class CPVREpgInfoTag final : public ISerializable,
-                               public std::enable_shared_from_this<CPVREpgInfoTag>
-  {
-    friend class CPVREpgDatabase;
-
-  public:
-    static const std::string IMAGE_OWNER_PATTERN;
-
-    /*!
-     * @brief Create a new EPG infotag.
-     * @param data The tag's data.
-     * @param iClientId The client id.
-     * @param channelData The channel data.
-     * @param iEpgId The id of the EPG this tag belongs to.
-     */
-    CPVREpgInfoTag(const EPG_TAG& data, int iClientId, const std::shared_ptr<CPVREpgChannelData>& channelData, int iEpgID);
-
-    /*!
-     * @brief Create a new EPG infotag.
-     * @param channelData The channel data.
-     * @param iEpgId The id of the EPG this tag belongs to.
-     * @param start The start time of the event
-     * @param end The end time of the event
-     * @param bIsGapTagTrue if this is a "gap" tag, false if this is a real EPG event
-     */
-    CPVREpgInfoTag(const std::shared_ptr<CPVREpgChannelData>& channelData,
-                   int iEpgID,
-                   const CDateTime& start,
-                   const CDateTime& end,
-                   bool bIsGapTag);
-
-    /*!
-     * @brief Set data for the channel linked to this EPG infotag.
-     * @param data The channel data.
-     */
-    void SetChannelData(const std::shared_ptr<CPVREpgChannelData>& data);
-
-    bool operator ==(const CPVREpgInfoTag& right) const;
-    bool operator !=(const CPVREpgInfoTag& right) const;
-
-    // ISerializable implementation
-    void Serialize(CVariant& value) const override;
-
-    /*!
-     * @brief Get the identifier of the client that serves this event.
-     * @return The identifier.
-     */
-    int ClientID() const;
-
-    /*!
-     * @brief Check if this event is currently active.
-     * @return True if it's active, false otherwise.
-     */
-    bool IsActive() const;
-
-    /*!
-     * @brief Check if this event is in the past.
-     * @return True when this event has already passed, false otherwise.
-     */
-    bool WasActive() const;
-
-    /*!
-     * @brief Check if this event is in the future.
-     * @return True when this event is an upcoming event, false otherwise.
-     */
-    bool IsUpcoming() const;
-
-    /*!
-     * @brief Get the progress of this tag in percent.
-     * @return The current progress of this tag.
-     */
-    float ProgressPercentage() const;
-
-    /*!
-     * @brief Get the progress of this tag in seconds.
-     * @return The current progress of this tag in seconds.
-     */
-    int Progress() const;
-
-    /*!
-     * @brief Get EPG ID of this tag.
-     * @return The epg ID.
-     */
-    int EpgID() const;
-
-    /*!
-     * @brief Sets the EPG id for this event.
-     * @param iEpgID The EPG id.
-     */
-    void SetEpgID(int iEpgID);
-
-    /*!
-     * @brief Change the unique broadcast ID of this event.
-     * @param iUniqueBroadcastId The new unique broadcast ID.
-     */
-    void SetUniqueBroadcastID(unsigned int iUniqueBroadcastID);
-
-    /*!
-     * @brief Get the unique broadcast ID.
-     * @return The unique broadcast ID.
-     */
-    unsigned int UniqueBroadcastID() const;
-
-    /*!
-     * @brief Get the event's database ID.
-     * @return The database ID.
-     */
-    int DatabaseID() const;
-
-    /*!
-     * @brief Get the unique ID of the channel associated with this event.
-     * @return The unique channel ID.
-     */
-    int UniqueChannelID() const;
-
-    /*!
-     * @brief Get the path for the icon of the channel associated with this event.
-     * @return The channel icon path.
-     */
-    std::string ChannelIconPath() const;
-
-    /*!
-     * @brief Get the event's start time.
-     * @return The start time in UTC.
-     */
-    CDateTime StartAsUTC() const;
-
-    /*!
-     * @brief Get the event's start time.
-     * @return The start time as local time.
-     */
-    CDateTime StartAsLocalTime() const;
-
-    /*!
-     * @brief Get the event's end time.
-     * @return The end time in UTC.
-     */
-    CDateTime EndAsUTC() const;
-
-    /*!
-     * @brief Get the event's end time.
-     * @return The end time as local time.
-     */
-    CDateTime EndAsLocalTime() const;
-
-    /*!
-     * @brief Change the event's end time.
-     * @param end The new end time.
-     */
-    void SetEndFromUTC(const CDateTime& end);
-
-    /*!
-     * @brief Get the duration of this event in seconds.
-     * @return The duration.
-     */
-    int GetDuration() const;
-
-    /*!
-     * @brief Get the title of this event.
-     * @return The title.
-     */
-    std::string Title() const;
-
-    /*!
-     * @brief Get the plot outline of this event.
-     * @return The plot outline.
-     */
-    std::string PlotOutline() const;
-
-    /*!
-     * @brief Get the plot of this event.
-     * @return The plot.
-     */
-    std::string Plot() const;
-
-    /*!
-     * @brief Get the original title of this event.
-     * @return The original title.
-     */
-    std::string OriginalTitle() const;
-
-    /*!
-     * @brief Get the cast of this event.
-     * @return The cast.
-     */
-    const std::vector<std::string> Cast() const;
-
-    /*!
-     * @brief Get the director(s) of this event.
-     * @return The director(s).
-     */
-    const std::vector<std::string> Directors() const;
-
-    /*!
-     * @brief Get the writer(s) of this event.
-     * @return The writer(s).
-     */
-    const std::vector<std::string> Writers() const;
-
-    /*!
-     * @brief Get the cast of this event as formatted string.
-     * @return The cast label.
-     */
-    const std::string GetCastLabel() const;
-
-    /*!
-     * @brief Get the director(s) of this event as formatted string.
-     * @return The directors label.
-     */
-    const std::string GetDirectorsLabel() const;
-
-    /*!
-     * @brief Get the writer(s) of this event as formatted string.
-     * @return The writers label.
-     */
-    const std::string GetWritersLabel() const;
-
-    /*!
-     * @brief Get the genre(s) of this event as formatted string.
-     * @return The genres label.
-     */
-    const std::string GetGenresLabel() const;
-
-    /*!
-     * @brief Get the year of this event.
-     * @return The year.
-     */
-    int Year() const;
-
-    /*!
-     * @brief Get the imdbnumber of this event.
-     * @return The imdbnumber.
-     */
-    std::string IMDBNumber() const;
-
-    /*!
-     * @brief Get the genre type ID of this event.
-     * @return The genre type ID.
-     */
-    int GenreType() const;
-
-    /*!
-     * @brief Get the genre subtype ID of this event.
-     * @return The genre subtype ID.
-     */
-    int GenreSubType() const;
-
-    /*!
-     * @brief Get the genre description of this event.
-     * @return The genre.
-     */
-    std::string GenreDescription() const;
-
-    /*!
-     * @brief Get the genre as human readable string.
-     * @return The genre.
-     */
-    const std::vector<std::string> Genre() const;
-
-    /*!
-     * @brief Get the first air date of this event.
-     * @return The first air date.
-     */
-    CDateTime FirstAired() const;
-
-    /*!
-     * @brief Get the parental rating of this event.
-     * @return The parental rating.
-     */
-    int ParentalRating() const;
-
-    /*!
-     * @brief Get the parental rating code of this event.
-     * @return The parental rating code.
-     */
-    std::string ParentalRatingCode() const;
-
-    /*!
-     * @brief Get the star rating of this event.
-     * @return The star rating.
-     */
-    int StarRating() const;
-
-    /*!
-     * @brief The series number of this event.
-     * @return The series number.
-     */
-    int SeriesNumber() const;
-
-    /*!
-     * @brief The series link for this event.
-     * @return The series link or empty string, if not available.
-     */
-    std::string SeriesLink() const;
-
-    /*!
-     * @brief The episode number of this event.
-     * @return The episode number.
-     */
-    int EpisodeNumber() const;
-
-    /*!
-     * @brief The episode part number of this event.
-     * @return The episode part number.
-     */
-    int EpisodePart() const;
-
-    /*!
-     * @brief The episode name of this event.
-     * @return The episode name.
-     */
-    std::string EpisodeName() const;
-
-    /*!
-     * @brief Get the path to the icon for this event used by Kodi.
-     * @return The path to the icon
-     */
-    std::string IconPath() const;
-
-    /*!
-     * @brief Get the path to the icon for this event as given by the client.
-     * @return The path to the icon
-     */
-    std::string ClientIconPath() const;
-
-    /*!
-     * @brief The path to this event.
-     * @return The path.
-     */
-    std::string Path() const;
-
-    /*!
-     * @brief Check if this event can be recorded.
-     * @return True if it can be recorded, false otherwise.
-     */
-    bool IsRecordable() const;
-
-    /*!
-     * @brief Check if this event can be played.
-     * @return True if it can be played, false otherwise.
-     */
-    bool IsPlayable() const;
-
-    /*!
-     * @brief Write query to persist this tag in the query queue of the given database.
-     * @param database The database.
-     * @return True on success, false otherwise.
-     */
-    bool QueuePersistQuery(const std::shared_ptr<CPVREpgDatabase>& database);
-
-    /*!
-     * @brief Update the information in this tag with the info in the given tag.
-     * @param tag The new info.
-     * @param bUpdateBroadcastId If set to false, the tag BroadcastId (locally unique) will not be checked/updated
-     * @return True if something changed, false otherwise.
-     */
-    bool Update(const CPVREpgInfoTag& tag, bool bUpdateBroadcastId = true);
-
-    /*!
-     * @brief Retrieve the edit decision list (EDL) of an EPG tag.
-     * @return The edit decision list (empty on error)
-     */
-    std::vector<PVR_EDL_ENTRY> GetEdl() const;
-
-    /*!
-     * @brief Check whether this tag has any series attributes.
-     * @return True if this tag has any series attributes, false otherwise
-     */
-    bool IsSeries() const;
-
-    /*!
-     * @brief Check whether this tag is associated with a radion or TV channel.
-     * @return True if this tag is associated with a radio channel, false otherwise.
-     */
-    bool IsRadio() const;
-
-    /*!
-     * @brief Check whether this event is parental locked.
-     * @return True if whether this event is parental locked, false otherwise.
-     */
-    bool IsParentalLocked() const;
-
-    /*!
-     * @brief Check whether this event is a real event or a gap in the EPG timeline.
-     * @return True if this event is a gap, false otherwise.
-     */
-    bool IsGapTag() const;
-
-    /*!
-     * @brief Check whether this tag will be flagged as new.
-     * @return True if this tag will be flagged as new, false otherwise
-     */
-    bool IsNew() const;
-
-    /*!
-     * @brief Check whether this tag will be flagged as a premiere.
-     * @return True if this tag will be flagged as a premiere, false otherwise
-     */
-    bool IsPremiere() const;
-
-    /*!
-     * @brief Check whether this tag will be flagged as a finale.
-     * @return True if this tag will be flagged as a finale, false otherwise
-     */
-    bool IsFinale() const;
-
-    /*!
-     * @brief Check whether this tag will be flagged as live.
-     * @return True if this tag will be flagged as live, false otherwise
-     */
-    bool IsLive() const;
-
-    /*!
-     * @brief Return the flags (EPG_TAG_FLAG_*) of this event as a bitfield.
-     * @return the flags.
-     */
-    unsigned int Flags() const { return m_iFlags; }
-
-    /*!
-     * @brief Split the given string into tokens. Interprets occurrences of EPG_STRING_TOKEN_SEPARATOR in the string as separator.
-     * @param str The string to tokenize.
-     * @return the tokens.
-     */
-    static const std::vector<std::string> Tokenize(const std::string& str);
-
-    /*!
-     * @brief Combine the given strings to a single string. Inserts EPG_STRING_TOKEN_SEPARATOR as separator.
-     * @param tokens The tokens.
-     * @return the combined string.
-     */
-    static const std::string DeTokenize(const std::vector<std::string>& tokens);
-
-  private:
-    CPVREpgInfoTag(int iEpgID, const std::string& iconPath);
-
-    CPVREpgInfoTag() = delete;
-    CPVREpgInfoTag(const CPVREpgInfoTag& tag) = delete;
-    CPVREpgInfoTag& operator =(const CPVREpgInfoTag& other) = delete;
-
-    /*!
+class CPVREpgChannelData;
+class CPVREpgDatabase;
+
+class CPVREpgInfoTag final : public ISerializable,
+                             public std::enable_shared_from_this<CPVREpgInfoTag>
+{
+  friend class CPVREpgDatabase;
+
+public:
+  static const std::string IMAGE_OWNER_PATTERN;
+
+  /*!
+   * @brief Create a new EPG infotag.
+   * @param data The tag's data.
+   * @param iClientId The client id.
+   * @param channelData The channel data.
+   * @param iEpgId The id of the EPG this tag belongs to.
+   */
+  CPVREpgInfoTag(const EPG_TAG& data,
+                 int iClientId,
+                 const std::shared_ptr<CPVREpgChannelData>& channelData,
+                 int iEpgID);
+
+  /*!
+   * @brief Create a new EPG infotag.
+   * @param channelData The channel data.
+   * @param iEpgId The id of the EPG this tag belongs to.
+   * @param start The start time of the event
+   * @param end The end time of the event
+   * @param bIsGapTagTrue if this is a "gap" tag, false if this is a real EPG event
+   */
+  CPVREpgInfoTag(const std::shared_ptr<CPVREpgChannelData>& channelData,
+                 int iEpgID,
+                 const CDateTime& start,
+                 const CDateTime& end,
+                 bool bIsGapTag);
+
+  /*!
+   * @brief Set data for the channel linked to this EPG infotag.
+   * @param data The channel data.
+   */
+  void SetChannelData(const std::shared_ptr<CPVREpgChannelData>& data);
+
+  bool operator==(const CPVREpgInfoTag& right) const;
+  bool operator!=(const CPVREpgInfoTag& right) const;
+
+  // ISerializable implementation
+  void Serialize(CVariant& value) const override;
+
+  /*!
+   * @brief Get the identifier of the client that serves this event.
+   * @return The identifier.
+   */
+  int ClientID() const;
+
+  /*!
+   * @brief Check if this event is currently active.
+   * @return True if it's active, false otherwise.
+   */
+  bool IsActive() const;
+
+  /*!
+   * @brief Check if this event is in the past.
+   * @return True when this event has already passed, false otherwise.
+   */
+  bool WasActive() const;
+
+  /*!
+   * @brief Check if this event is in the future.
+   * @return True when this event is an upcoming event, false otherwise.
+   */
+  bool IsUpcoming() const;
+
+  /*!
+   * @brief Get the progress of this tag in percent.
+   * @return The current progress of this tag.
+   */
+  float ProgressPercentage() const;
+
+  /*!
+   * @brief Get the progress of this tag in seconds.
+   * @return The current progress of this tag in seconds.
+   */
+  int Progress() const;
+
+  /*!
+   * @brief Get EPG ID of this tag.
+   * @return The epg ID.
+   */
+  int EpgID() const;
+
+  /*!
+   * @brief Sets the EPG id for this event.
+   * @param iEpgID The EPG id.
+   */
+  void SetEpgID(int iEpgID);
+
+  /*!
+   * @brief Change the unique broadcast ID of this event.
+   * @param iUniqueBroadcastId The new unique broadcast ID.
+   */
+  void SetUniqueBroadcastID(unsigned int iUniqueBroadcastID);
+
+  /*!
+   * @brief Get the unique broadcast ID.
+   * @return The unique broadcast ID.
+   */
+  unsigned int UniqueBroadcastID() const;
+
+  /*!
+   * @brief Get the event's database ID.
+   * @return The database ID.
+   */
+  int DatabaseID() const;
+
+  /*!
+   * @brief Get the unique ID of the channel associated with this event.
+   * @return The unique channel ID.
+   */
+  int UniqueChannelID() const;
+
+  /*!
+   * @brief Get the path for the icon of the channel associated with this event.
+   * @return The channel icon path.
+   */
+  std::string ChannelIconPath() const;
+
+  /*!
+   * @brief Get the event's start time.
+   * @return The start time in UTC.
+   */
+  CDateTime StartAsUTC() const;
+
+  /*!
+   * @brief Get the event's start time.
+   * @return The start time as local time.
+   */
+  CDateTime StartAsLocalTime() const;
+
+  /*!
+   * @brief Get the event's end time.
+   * @return The end time in UTC.
+   */
+  CDateTime EndAsUTC() const;
+
+  /*!
+   * @brief Get the event's end time.
+   * @return The end time as local time.
+   */
+  CDateTime EndAsLocalTime() const;
+
+  /*!
+   * @brief Change the event's end time.
+   * @param end The new end time.
+   */
+  void SetEndFromUTC(const CDateTime& end);
+
+  /*!
+   * @brief Get the duration of this event in seconds.
+   * @return The duration.
+   */
+  int GetDuration() const;
+
+  /*!
+   * @brief Get the title of this event.
+   * @return The title.
+   */
+  std::string Title() const;
+
+  /*!
+   * @brief Get the plot outline of this event.
+   * @return The plot outline.
+   */
+  std::string PlotOutline() const;
+
+  /*!
+   * @brief Get the plot of this event.
+   * @return The plot.
+   */
+  std::string Plot() const;
+
+  /*!
+   * @brief Get the original title of this event.
+   * @return The original title.
+   */
+  std::string OriginalTitle() const;
+
+  /*!
+   * @brief Get the cast of this event.
+   * @return The cast.
+   */
+  const std::vector<std::string> Cast() const;
+
+  /*!
+   * @brief Get the director(s) of this event.
+   * @return The director(s).
+   */
+  const std::vector<std::string> Directors() const;
+
+  /*!
+   * @brief Get the writer(s) of this event.
+   * @return The writer(s).
+   */
+  const std::vector<std::string> Writers() const;
+
+  /*!
+   * @brief Get the cast of this event as formatted string.
+   * @return The cast label.
+   */
+  const std::string GetCastLabel() const;
+
+  /*!
+   * @brief Get the director(s) of this event as formatted string.
+   * @return The directors label.
+   */
+  const std::string GetDirectorsLabel() const;
+
+  /*!
+   * @brief Get the writer(s) of this event as formatted string.
+   * @return The writers label.
+   */
+  const std::string GetWritersLabel() const;
+
+  /*!
+   * @brief Get the genre(s) of this event as formatted string.
+   * @return The genres label.
+   */
+  const std::string GetGenresLabel() const;
+
+  /*!
+   * @brief Get the year of this event.
+   * @return The year.
+   */
+  int Year() const;
+
+  /*!
+   * @brief Get the imdbnumber of this event.
+   * @return The imdbnumber.
+   */
+  std::string IMDBNumber() const;
+
+  /*!
+   * @brief Get the genre type ID of this event.
+   * @return The genre type ID.
+   */
+  int GenreType() const;
+
+  /*!
+   * @brief Get the genre subtype ID of this event.
+   * @return The genre subtype ID.
+   */
+  int GenreSubType() const;
+
+  /*!
+   * @brief Get the genre description of this event.
+   * @return The genre.
+   */
+  std::string GenreDescription() const;
+
+  /*!
+   * @brief Get the genre as human readable string.
+   * @return The genre.
+   */
+  const std::vector<std::string> Genre() const;
+
+  /*!
+   * @brief Get the first air date of this event.
+   * @return The first air date.
+   */
+  CDateTime FirstAired() const;
+
+  /*!
+   * @brief Get the parental rating of this event.
+   * @return The parental rating.
+   */
+  int ParentalRating() const;
+
+  /*!
+   * @brief Get the parental rating code of this event.
+   * @return The parental rating code.
+   */
+  std::string ParentalRatingCode() const;
+
+  /*!
+   * @brief Get the star rating of this event.
+   * @return The star rating.
+   */
+  int StarRating() const;
+
+  /*!
+   * @brief The series number of this event.
+   * @return The series number.
+   */
+  int SeriesNumber() const;
+
+  /*!
+   * @brief The series link for this event.
+   * @return The series link or empty string, if not available.
+   */
+  std::string SeriesLink() const;
+
+  /*!
+   * @brief The episode number of this event.
+   * @return The episode number.
+   */
+  int EpisodeNumber() const;
+
+  /*!
+   * @brief The episode part number of this event.
+   * @return The episode part number.
+   */
+  int EpisodePart() const;
+
+  /*!
+   * @brief The episode name of this event.
+   * @return The episode name.
+   */
+  std::string EpisodeName() const;
+
+  /*!
+   * @brief Get the path to the icon for this event used by Kodi.
+   * @return The path to the icon
+   */
+  std::string IconPath() const;
+
+  /*!
+   * @brief Get the path to the icon for this event as given by the client.
+   * @return The path to the icon
+   */
+  std::string ClientIconPath() const;
+
+  /*!
+   * @brief The path to this event.
+   * @return The path.
+   */
+  std::string Path() const;
+
+  /*!
+   * @brief Check if this event can be recorded.
+   * @return True if it can be recorded, false otherwise.
+   */
+  bool IsRecordable() const;
+
+  /*!
+   * @brief Check if this event can be played.
+   * @return True if it can be played, false otherwise.
+   */
+  bool IsPlayable() const;
+
+  /*!
+   * @brief Write query to persist this tag in the query queue of the given database.
+   * @param database The database.
+   * @return True on success, false otherwise.
+   */
+  bool QueuePersistQuery(const std::shared_ptr<CPVREpgDatabase>& database);
+
+  /*!
+   * @brief Update the information in this tag with the info in the given tag.
+   * @param tag The new info.
+   * @param bUpdateBroadcastId If set to false, the tag BroadcastId (locally unique) will not be
+   * checked/updated
+   * @return True if something changed, false otherwise.
+   */
+  bool Update(const CPVREpgInfoTag& tag, bool bUpdateBroadcastId = true);
+
+  /*!
+   * @brief Retrieve the edit decision list (EDL) of an EPG tag.
+   * @return The edit decision list (empty on error)
+   */
+  std::vector<PVR_EDL_ENTRY> GetEdl() const;
+
+  /*!
+   * @brief Check whether this tag has any series attributes.
+   * @return True if this tag has any series attributes, false otherwise
+   */
+  bool IsSeries() const;
+
+  /*!
+   * @brief Check whether this tag is associated with a radion or TV channel.
+   * @return True if this tag is associated with a radio channel, false otherwise.
+   */
+  bool IsRadio() const;
+
+  /*!
+   * @brief Check whether this event is parental locked.
+   * @return True if whether this event is parental locked, false otherwise.
+   */
+  bool IsParentalLocked() const;
+
+  /*!
+   * @brief Check whether this event is a real event or a gap in the EPG timeline.
+   * @return True if this event is a gap, false otherwise.
+   */
+  bool IsGapTag() const;
+
+  /*!
+   * @brief Check whether this tag will be flagged as new.
+   * @return True if this tag will be flagged as new, false otherwise
+   */
+  bool IsNew() const;
+
+  /*!
+   * @brief Check whether this tag will be flagged as a premiere.
+   * @return True if this tag will be flagged as a premiere, false otherwise
+   */
+  bool IsPremiere() const;
+
+  /*!
+   * @brief Check whether this tag will be flagged as a finale.
+   * @return True if this tag will be flagged as a finale, false otherwise
+   */
+  bool IsFinale() const;
+
+  /*!
+   * @brief Check whether this tag will be flagged as live.
+   * @return True if this tag will be flagged as live, false otherwise
+   */
+  bool IsLive() const;
+
+  /*!
+   * @brief Return the flags (EPG_TAG_FLAG_*) of this event as a bitfield.
+   * @return the flags.
+   */
+  unsigned int Flags() const { return m_iFlags; }
+
+  /*!
+   * @brief Split the given string into tokens. Interprets occurrences of EPG_STRING_TOKEN_SEPARATOR
+   * in the string as separator.
+   * @param str The string to tokenize.
+   * @return the tokens.
+   */
+  static const std::vector<std::string> Tokenize(const std::string& str);
+
+  /*!
+   * @brief Combine the given strings to a single string. Inserts EPG_STRING_TOKEN_SEPARATOR as
+   * separator.
+   * @param tokens The tokens.
+   * @return the combined string.
+   */
+  static const std::string DeTokenize(const std::vector<std::string>& tokens);
+
+private:
+  CPVREpgInfoTag(int iEpgID, const std::string& iconPath);
+
+  CPVREpgInfoTag() = delete;
+  CPVREpgInfoTag(const CPVREpgInfoTag& tag) = delete;
+  CPVREpgInfoTag& operator=(const CPVREpgInfoTag& other) = delete;
+
+  /*!
      * @brief Get current time, taking timeshifting into account.
      * @return The playing time.
      */
-    CDateTime GetCurrentPlayingTime() const;
+  CDateTime GetCurrentPlayingTime() const;
 
-    int m_iDatabaseID = -1; /*!< database ID */
-    int m_iGenreType = 0; /*!< genre type */
-    int m_iGenreSubType = 0; /*!< genre subtype */
-    std::string m_strGenreDescription; /*!< genre description */
-    int m_iParentalRating = 0; /*!< parental rating */
-    std::string m_strParentalRatingCode; /*!< parental rating code */
-    int m_iStarRating = 0; /*!< star rating */
-    int m_iSeriesNumber = -1; /*!< series number */
-    int m_iEpisodeNumber = -1; /*!< episode number */
-    int m_iEpisodePart = -1; /*!< episode part number */
-    unsigned int m_iUniqueBroadcastID = 0; /*!< unique broadcast ID */
-    std::string m_strTitle; /*!< title */
-    std::string m_strPlotOutline; /*!< plot outline */
-    std::string m_strPlot; /*!< plot */
-    std::string m_strOriginalTitle; /*!< original title */
-    std::vector<std::string> m_cast; /*!< cast */
-    std::vector<std::string> m_directors; /*!< director(s) */
-    std::vector<std::string> m_writers; /*!< writer(s) */
-    int m_iYear = 0; /*!< year */
-    std::string m_strIMDBNumber; /*!< imdb number */
-    mutable std::vector<std::string> m_genre; /*!< genre */
-    std::string m_strEpisodeName; /*!< episode name */
-    CPVRCachedImage m_iconPath; /*!< the path to the icon */
-    CDateTime m_startTime; /*!< event start time */
-    CDateTime m_endTime; /*!< event end time */
-    CDateTime m_firstAired; /*!< first airdate */
-    unsigned int m_iFlags = 0; /*!< the flags applicable to this EPG entry */
-    std::string m_strSeriesLink; /*!< series link */
-    bool m_bIsGapTag = false;
+  int m_iDatabaseID = -1; /*!< database ID */
+  int m_iGenreType = 0; /*!< genre type */
+  int m_iGenreSubType = 0; /*!< genre subtype */
+  std::string m_strGenreDescription; /*!< genre description */
+  int m_iParentalRating = 0; /*!< parental rating */
+  std::string m_strParentalRatingCode; /*!< parental rating code */
+  int m_iStarRating = 0; /*!< star rating */
+  int m_iSeriesNumber = -1; /*!< series number */
+  int m_iEpisodeNumber = -1; /*!< episode number */
+  int m_iEpisodePart = -1; /*!< episode part number */
+  unsigned int m_iUniqueBroadcastID = 0; /*!< unique broadcast ID */
+  std::string m_strTitle; /*!< title */
+  std::string m_strPlotOutline; /*!< plot outline */
+  std::string m_strPlot; /*!< plot */
+  std::string m_strOriginalTitle; /*!< original title */
+  std::vector<std::string> m_cast; /*!< cast */
+  std::vector<std::string> m_directors; /*!< director(s) */
+  std::vector<std::string> m_writers; /*!< writer(s) */
+  int m_iYear = 0; /*!< year */
+  std::string m_strIMDBNumber; /*!< imdb number */
+  mutable std::vector<std::string> m_genre; /*!< genre */
+  std::string m_strEpisodeName; /*!< episode name */
+  CPVRCachedImage m_iconPath; /*!< the path to the icon */
+  CDateTime m_startTime; /*!< event start time */
+  CDateTime m_endTime; /*!< event end time */
+  CDateTime m_firstAired; /*!< first airdate */
+  unsigned int m_iFlags = 0; /*!< the flags applicable to this EPG entry */
+  std::string m_strSeriesLink; /*!< series link */
+  bool m_bIsGapTag = false;
 
-    mutable CCriticalSection m_critSection;
-    std::shared_ptr<CPVREpgChannelData> m_channelData;
-    int m_iEpgID = -1;
-  };
-}
+  mutable CCriticalSection m_critSection;
+  std::shared_ptr<CPVREpgChannelData> m_channelData;
+  int m_iEpgID = -1;
+};
+} // namespace PVR

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
@@ -42,8 +42,7 @@ std::shared_ptr<CFileItem> CGUIEPGGridContainerModel::CreateGapItem(int iChannel
 {
   const std::shared_ptr<CPVRChannel> channel = m_channelItems[iChannel]->GetPVRChannelInfoTag();
   const std::shared_ptr<CPVREpgInfoTag> gapTag = channel->CreateEPGGapTag(m_gridStart, m_gridEnd);
-  return std::make_shared<CFileItem>(gapTag,
-                                     m_channelItems[iChannel]->GetPVRChannelGroupMemberInfoTag());
+  return std::make_shared<CFileItem>(gapTag);
 }
 
 std::vector<std::shared_ptr<CPVREpgInfoTag>> CGUIEPGGridContainerModel::GetEPGTimeline(
@@ -168,8 +167,7 @@ std::shared_ptr<CFileItem> CGUIEPGGridContainerModel::CreateEpgTags(int iChannel
     if (GetFirstEventBlock(tag) > GetLastEventBlock(tag))
       continue;
 
-    const std::shared_ptr<CFileItem> item = std::make_shared<CFileItem>(
-        tag, m_channelItems[iChannel]->GetPVRChannelGroupMemberInfoTag());
+    const std::shared_ptr<CFileItem> item = std::make_shared<CFileItem>(tag);
     if (!result && IsEventMemberOfBlock(tag, iBlock))
       result = item;
 
@@ -259,8 +257,7 @@ std::shared_ptr<CFileItem> CGUIEPGGridContainerModel::GetEpgTagsBefore(EpgTags& 
       if (GetFirstEventBlock(*it) > GetLastEventBlock(*it))
         continue;
 
-      const std::shared_ptr<CFileItem> item = std::make_shared<CFileItem>(
-          *it, m_channelItems[iChannel]->GetPVRChannelGroupMemberInfoTag());
+      const std::shared_ptr<CFileItem> item = std::make_shared<CFileItem>(*it);
       if (!result && IsEventMemberOfBlock(*it, iBlock))
         result = item;
 
@@ -322,8 +319,7 @@ std::shared_ptr<CFileItem> CGUIEPGGridContainerModel::GetEpgTagsAfter(EpgTags& e
       if (GetFirstEventBlock(*it) > GetLastEventBlock(*it))
         continue;
 
-      const std::shared_ptr<CFileItem> item = std::make_shared<CFileItem>(
-          *it, m_channelItems[iChannel]->GetPVRChannelGroupMemberInfoTag());
+      const std::shared_ptr<CFileItem> item = std::make_shared<CFileItem>(*it);
       if (!result && IsEventMemberOfBlock(*it, iBlock))
         result = item;
 
@@ -563,8 +559,7 @@ bool CGUIEPGGridContainerModel::FreeProgrammeMemory(int firstChannel,
           if (GetFirstEventBlock(tag) > GetLastEventBlock(tag))
             continue;
 
-          epgTags.tags.emplace_back(std::make_shared<CFileItem>(
-              tag, m_channelItems[i]->GetPVRChannelGroupMemberInfoTag()));
+          epgTags.tags.emplace_back(std::make_shared<CFileItem>(tag));
         }
       }
     }

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
@@ -90,7 +90,8 @@ void CGUIEPGGridContainerModel::Initialize(const std::unique_ptr<CFileItemList>&
     m_gridStart = CDateTime::GetUTCDateTime() - CDateTimeSpan(0, 0, GetGridStartPadding(), 0);
     m_gridEnd = m_gridStart + CDateTimeSpan(0, 0, iBlocksPerPage * MINSPERBLOCK, 0);
   }
-  else if (gridStart > (CDateTime::GetUTCDateTime() - CDateTimeSpan(0, 0, GetGridStartPadding(), 0)))
+  else if (gridStart >
+           (CDateTime::GetUTCDateTime() - CDateTimeSpan(0, 0, GetGridStartPadding(), 0)))
   {
     // adjust to start "now minus GRID_START_PADDING minutes".
     m_gridStart = CDateTime::GetUTCDateTime() - CDateTimeSpan(0, 0, GetGridStartPadding(), 0);
@@ -469,7 +470,8 @@ void CGUIEPGGridContainerModel::DecreaseGridItemWidth(int iChannel, int iBlock, 
 
 unsigned int CGUIEPGGridContainerModel::GetGridStartPadding() const
 {
-  unsigned int iPastMinutes = CServiceBroker::GetPVRManager().EpgContainer().GetPastDaysToDisplay() * 24 * 60;
+  unsigned int iPastMinutes =
+      CServiceBroker::GetPVRManager().EpgContainer().GetPastDaysToDisplay() * 24 * 60;
 
   if (iPastMinutes < GRID_START_PADDING)
     return iPastMinutes;
@@ -637,7 +639,8 @@ int CGUIEPGGridContainerModel::GetNowBlock() const
   return GetBlock(CDateTime::GetUTCDateTime()) - GetPageNowOffset();
 }
 
-int CGUIEPGGridContainerModel::GetFirstEventBlock(const std::shared_ptr<CPVREpgInfoTag>& event) const
+int CGUIEPGGridContainerModel::GetFirstEventBlock(
+    const std::shared_ptr<CPVREpgInfoTag>& event) const
 {
   const CDateTime eventStart = event->StartAsUTC();
   int diff;

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
@@ -22,156 +22,157 @@ class CFileItemList;
 
 namespace PVR
 {
-  struct GridItem
+struct GridItem
+{
+  GridItem(const std::shared_ptr<CFileItem>& _item, float _width, int _startBlock, int _endBlock)
+    : item(_item), originWidth(_width), width(_width), startBlock(_startBlock), endBlock(_endBlock)
   {
-    GridItem(const std::shared_ptr<CFileItem>& _item, float _width, int _startBlock, int _endBlock)
-      : item(_item),
-        originWidth(_width),
-        width(_width),
-        startBlock(_startBlock),
-        endBlock(_endBlock)
-    {
-    }
+  }
 
-    bool operator==(const GridItem& other) const
-    {
-      return (startBlock == other.startBlock && endBlock == other.endBlock);
-    }
+  bool operator==(const GridItem& other) const
+  {
+    return (startBlock == other.startBlock && endBlock == other.endBlock);
+  }
 
-    std::shared_ptr<CFileItem> item;
-    float originWidth = 0.0f;
-    float width = 0.0f;
-    int startBlock = 0;
-    int endBlock = 0;
+  std::shared_ptr<CFileItem> item;
+  float originWidth = 0.0f;
+  float width = 0.0f;
+  int startBlock = 0;
+  int endBlock = 0;
+};
+
+class CPVREpgInfoTag;
+
+class CGUIEPGGridContainerModel
+{
+public:
+  static constexpr int MINSPERBLOCK = 5; // minutes
+
+  CGUIEPGGridContainerModel() = default;
+  virtual ~CGUIEPGGridContainerModel() = default;
+
+  void Initialize(const std::unique_ptr<CFileItemList>& items,
+                  const CDateTime& gridStart,
+                  const CDateTime& gridEnd,
+                  int iFirstChannel,
+                  int iChannelsPerPage,
+                  int iFirstBlock,
+                  int iBlocksPerPage,
+                  int iRulerUnit,
+                  float fBlockSize);
+  void SetInvalid();
+
+  static const int INVALID_INDEX = -1;
+  void FindChannelAndBlockIndex(int channelUid,
+                                unsigned int broadcastUid,
+                                int eventOffset,
+                                int& newChannelIndex,
+                                int& newBlockIndex) const;
+
+  void FreeChannelMemory(int keepStart, int keepEnd);
+  bool FreeProgrammeMemory(int firstChannel, int lastChannel, int firstBlock, int lastBlock);
+  void FreeRulerMemory(int keepStart, int keepEnd);
+
+  std::shared_ptr<CFileItem> GetChannelItem(int iIndex) const { return m_channelItems[iIndex]; }
+  bool HasChannelItems() const { return !m_channelItems.empty(); }
+  int ChannelItemsSize() const { return static_cast<int>(m_channelItems.size()); }
+  int GetLastChannel() const
+  {
+    return m_channelItems.empty() ? -1 : static_cast<int>(m_channelItems.size()) - 1;
+  }
+
+  std::shared_ptr<CFileItem> GetRulerItem(int iIndex) const { return m_rulerItems[iIndex]; }
+  int RulerItemsSize() const { return static_cast<int>(m_rulerItems.size()); }
+
+  int GridItemsSize() const { return m_blocks; }
+  bool IsSameGridItem(int iChannel, int iBlock1, int iBlock2) const;
+  std::shared_ptr<CFileItem> GetGridItem(int iChannel, int iBlock) const;
+  int GetGridItemStartBlock(int iChannel, int iBlock) const;
+  int GetGridItemEndBlock(int iChannel, int iBlock) const;
+  CDateTime GetGridItemEndTime(int iChannel, int iBlock) const;
+  float GetGridItemWidth(int iChannel, int iBlock) const;
+  float GetGridItemOriginWidth(int iChannel, int iBlock) const;
+  void DecreaseGridItemWidth(int iChannel, int iBlock, float fSize);
+
+  bool IsZeroGridDuration() const { return (m_gridEnd - m_gridStart) == CDateTimeSpan(0, 0, 0, 0); }
+  const CDateTime& GetGridStart() const { return m_gridStart; }
+  const CDateTime& GetGridEnd() const { return m_gridEnd; }
+  unsigned int GetGridStartPadding() const;
+
+  unsigned int GetPageNowOffset() const;
+  int GetNowBlock() const;
+  int GetLastBlock() const { return m_blocks - 1; }
+
+  CDateTime GetStartTimeForBlock(int block) const;
+  int GetBlock(const CDateTime& datetime) const;
+  int GetFirstEventBlock(const std::shared_ptr<CPVREpgInfoTag>& event) const;
+  int GetLastEventBlock(const std::shared_ptr<CPVREpgInfoTag>& event) const;
+  bool IsEventMemberOfBlock(const std::shared_ptr<CPVREpgInfoTag>& event, int iBlock) const;
+
+  std::unique_ptr<CFileItemList> GetCurrentTimeLineItems(int firstChannel, int numChannels) const;
+
+private:
+  GridItem* GetGridItemPtr(int iChannel, int iBlock) const;
+  std::shared_ptr<CFileItem> CreateGapItem(int iChannel) const;
+  std::shared_ptr<CFileItem> GetItem(int iChannel, int iBlock) const;
+
+  std::vector<std::shared_ptr<CPVREpgInfoTag>> GetEPGTimeline(int iChannel,
+                                                              const CDateTime& minEventEnd,
+                                                              const CDateTime& maxEventStart) const;
+
+  struct EpgTags
+  {
+    std::vector<std::shared_ptr<CFileItem>> tags;
+    int firstBlock = -1;
+    int lastBlock = -1;
   };
 
-  class CPVREpgInfoTag;
+  using EpgTagsMap = std::unordered_map<int, EpgTags>;
 
-  class CGUIEPGGridContainerModel
+  std::shared_ptr<CFileItem> CreateEpgTags(int iChannel, int iBlock) const;
+  std::shared_ptr<CFileItem> GetEpgTags(EpgTagsMap::iterator& itEpg,
+                                        int iChannel,
+                                        int iBlock) const;
+  std::shared_ptr<CFileItem> GetEpgTagsBefore(EpgTags& epgTags, int iChannel, int iBlock) const;
+  std::shared_ptr<CFileItem> GetEpgTagsAfter(EpgTags& epgTags, int iChannel, int iBlock) const;
+
+  mutable EpgTagsMap m_epgItems;
+
+  CDateTime m_gridStart;
+  CDateTime m_gridEnd;
+
+  std::vector<std::shared_ptr<CFileItem>> m_channelItems;
+  std::vector<std::shared_ptr<CFileItem>> m_rulerItems;
+
+  struct GridCoordinates
   {
-  public:
-    static constexpr int MINSPERBLOCK = 5; // minutes
+    GridCoordinates(int _channel, int _block) : channel(_channel), block(_block) {}
 
-    CGUIEPGGridContainerModel() = default;
-    virtual ~CGUIEPGGridContainerModel() = default;
-
-    void Initialize(const std::unique_ptr<CFileItemList>& items,
-                    const CDateTime& gridStart,
-                    const CDateTime& gridEnd,
-                    int iFirstChannel,
-                    int iChannelsPerPage,
-                    int iFirstBlock,
-                    int iBlocksPerPage,
-                    int iRulerUnit,
-                    float fBlockSize);
-    void SetInvalid();
-
-    static const int INVALID_INDEX = -1;
-    void FindChannelAndBlockIndex(int channelUid, unsigned int broadcastUid, int eventOffset, int& newChannelIndex, int& newBlockIndex) const;
-
-    void FreeChannelMemory(int keepStart, int keepEnd);
-    bool FreeProgrammeMemory(int firstChannel, int lastChannel, int firstBlock, int lastBlock);
-    void FreeRulerMemory(int keepStart, int keepEnd);
-
-    std::shared_ptr<CFileItem> GetChannelItem(int iIndex) const { return m_channelItems[iIndex]; }
-    bool HasChannelItems() const { return !m_channelItems.empty(); }
-    int ChannelItemsSize() const { return static_cast<int>(m_channelItems.size()); }
-    int GetLastChannel() const
+    bool operator==(const GridCoordinates& other) const
     {
-      return m_channelItems.empty() ? -1 : static_cast<int>(m_channelItems.size()) - 1;
+      return (channel == other.channel && block == other.block);
     }
 
-    std::shared_ptr<CFileItem> GetRulerItem(int iIndex) const { return m_rulerItems[iIndex]; }
-    int RulerItemsSize() const { return static_cast<int>(m_rulerItems.size()); }
-
-    int GridItemsSize() const { return m_blocks; }
-    bool IsSameGridItem(int iChannel, int iBlock1, int iBlock2) const;
-    std::shared_ptr<CFileItem> GetGridItem(int iChannel, int iBlock) const;
-    int GetGridItemStartBlock(int iChannel, int iBlock) const;
-    int GetGridItemEndBlock(int iChannel, int iBlock) const;
-    CDateTime GetGridItemEndTime(int iChannel, int iBlock) const;
-    float GetGridItemWidth(int iChannel, int iBlock) const;
-    float GetGridItemOriginWidth(int iChannel, int iBlock) const;
-    void DecreaseGridItemWidth(int iChannel, int iBlock, float fSize);
-
-    bool IsZeroGridDuration() const { return (m_gridEnd - m_gridStart) == CDateTimeSpan(0, 0, 0, 0); }
-    const CDateTime& GetGridStart() const { return m_gridStart; }
-    const CDateTime& GetGridEnd() const { return m_gridEnd; }
-    unsigned int GetGridStartPadding() const;
-
-    unsigned int GetPageNowOffset() const;
-    int GetNowBlock() const;
-    int GetLastBlock() const { return m_blocks - 1; }
-
-    CDateTime GetStartTimeForBlock(int block) const;
-    int GetBlock(const CDateTime& datetime) const;
-    int GetFirstEventBlock(const std::shared_ptr<CPVREpgInfoTag>& event) const;
-    int GetLastEventBlock(const std::shared_ptr<CPVREpgInfoTag>& event) const;
-    bool IsEventMemberOfBlock(const std::shared_ptr<CPVREpgInfoTag>& event, int iBlock) const;
-
-    std::unique_ptr<CFileItemList> GetCurrentTimeLineItems(int firstChannel, int numChannels) const;
-
-  private:
-    GridItem* GetGridItemPtr(int iChannel, int iBlock) const;
-    std::shared_ptr<CFileItem> CreateGapItem(int iChannel) const;
-    std::shared_ptr<CFileItem> GetItem(int iChannel, int iBlock) const;
-
-    std::vector<std::shared_ptr<CPVREpgInfoTag>> GetEPGTimeline(
-        int iChannel, const CDateTime& minEventEnd, const CDateTime& maxEventStart) const;
-
-    struct EpgTags
-    {
-      std::vector<std::shared_ptr<CFileItem>> tags;
-      int firstBlock = -1;
-      int lastBlock = -1;
-    };
-
-    using EpgTagsMap = std::unordered_map<int, EpgTags>;
-
-    std::shared_ptr<CFileItem> CreateEpgTags(int iChannel, int iBlock) const;
-    std::shared_ptr<CFileItem> GetEpgTags(EpgTagsMap::iterator& itEpg,
-                                          int iChannel,
-                                          int iBlock) const;
-    std::shared_ptr<CFileItem> GetEpgTagsBefore(EpgTags& epgTags, int iChannel, int iBlock) const;
-    std::shared_ptr<CFileItem> GetEpgTagsAfter(EpgTags& epgTags, int iChannel, int iBlock) const;
-
-    mutable EpgTagsMap m_epgItems;
-
-    CDateTime m_gridStart;
-    CDateTime m_gridEnd;
-
-    std::vector<std::shared_ptr<CFileItem>> m_channelItems;
-    std::vector<std::shared_ptr<CFileItem>> m_rulerItems;
-
-    struct GridCoordinates
-    {
-      GridCoordinates(int _channel, int _block) : channel(_channel), block(_block) {}
-
-      bool operator==(const GridCoordinates& other) const
-      {
-        return (channel == other.channel && block == other.block);
-      }
-
-      int channel = 0;
-      int block = 0;
-    };
-
-    struct GridCoordinatesHash
-    {
-      std::size_t operator()(const GridCoordinates& coordinates) const
-      {
-        return std::hash<int>()(coordinates.channel) ^ std::hash<int>()(coordinates.block);
-      }
-    };
-
-    mutable std::unordered_map<GridCoordinates, GridItem, GridCoordinatesHash> m_gridIndex;
-
-    int m_blocks = 0;
-    float m_fBlockSize = 0.0f;
-
-    int m_firstActiveChannel = 0;
-    int m_lastActiveChannel = 0;
-    int m_firstActiveBlock = 0;
-    int m_lastActiveBlock = 0;
+    int channel = 0;
+    int block = 0;
   };
-}
+
+  struct GridCoordinatesHash
+  {
+    std::size_t operator()(const GridCoordinates& coordinates) const
+    {
+      return std::hash<int>()(coordinates.channel) ^ std::hash<int>()(coordinates.block);
+    }
+  };
+
+  mutable std::unordered_map<GridCoordinates, GridItem, GridCoordinatesHash> m_gridIndex;
+
+  int m_blocks = 0;
+  float m_fBlockSize = 0.0f;
+
+  int m_firstActiveChannel = 0;
+  int m_lastActiveChannel = 0;
+  int m_firstActiveBlock = 0;
+  int m_lastActiveBlock = 0;
+};
+} // namespace PVR


### PR DESCRIPTION
What subject says - a performance improvement when construction `CFileItem` instances for `CPVREpgInfoTag`s.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish another one to review. :-) Only first commit contains functional changes. The others are purely clang-format, no functional changes.