### PR TITLE
Some header cleanups

### DIFF
--- a/xbmc/XBDateTime.h
+++ b/xbmc/XBDateTime.h
@@ -9,69 +9,12 @@
 #pragma once
 
 #include "utils/IArchivable.h"
+#include "utils/TimeFormat.h"
 #include "utils/XTimeUtils.h"
 
 #include <string>
 
 #include "PlatformDefs.h"
-
-/*! \brief TIME_FORMAT enum/bitmask used for formatting time strings
- Note the use of bitmasking, e.g.
-  TIME_FORMAT_HH_MM_SS = TIME_FORMAT_HH | TIME_FORMAT_MM | TIME_FORMAT_SS
- \sa StringUtils::SecondsToTimeString
- \note For InfoLabels use the equivalent value listed (bold)
-  on the description of each enum value.
- \note<b>Example:</b> 3661 seconds => h=1, hh=01, m=1, mm=01, ss=01, hours=1, mins=61, secs=3661
- <p><hr>
- @skinning_v18 **[Infolabels Updated]** Added <b>secs</b>, <b>mins</b>, <b>hours</b> (total time) and **m** as possible formats for
- InfoLabels that support the definition of a time format. Examples are:
-   - \link Player_SeekOffset_format `Player.SeekOffset(format)`\endlink
-   - \link Player_TimeRemaining_format `Player.TimeRemaining(format)`\endlink
-   - \link Player_Time_format `Player.Time(format)`\endlink
-   - \link Player_Duration_format `Player.Duration(format)`\endlink
-   - \link Player_FinishTime_format `Player.FinishTime(format)`\endlink
-   - \link Player_StartTime_format `Player.StartTime(format)` \endlink
-   - \link Player_SeekNumeric_format `Player.SeekNumeric(format)`\endlink
-   - \link ListItem_Duration_format `ListItem.Duration(format)`\endlink
-   - \link PVR_EpgEventDuration_format `PVR.EpgEventDuration(format)`\endlink
-   - \link PVR_EpgEventElapsedTime_format `PVR.EpgEventElapsedTime(format)`\endlink
-   - \link PVR_EpgEventRemainingTime_format `PVR.EpgEventRemainingTime(format)`\endlink
-   - \link PVR_EpgEventSeekTime_format `PVR.EpgEventSeekTime(format)`\endlink
-   - \link PVR_EpgEventFinishTime_format `PVR.EpgEventFinishTime(format)`\endlink
-   - \link PVR_TimeShiftStart_format `PVR.TimeShiftStart(format)`\endlink
-   - \link PVR_TimeShiftEnd_format `PVR.TimeShiftEnd(format)`\endlink
-   - \link PVR_TimeShiftCur_format `PVR.TimeShiftCur(format)`\endlink
-   - \link PVR_TimeShiftOffset_format `PVR.TimeShiftOffset(format)`\endlink
-   - \link PVR_TimeshiftProgressDuration_format `PVR.TimeshiftProgressDuration(format)`\endlink
-   - \link PVR_TimeshiftProgressEndTime `PVR.TimeshiftProgressEndTime`\endlink
-   - \link PVR_TimeshiftProgressEndTime_format `PVR.TimeshiftProgressEndTime(format)`\endlink
-   - \link ListItem_NextDuration_format `ListItem.NextDuration(format)` \endlink
-  <p>
- */
-enum TIME_FORMAT
-{
-  TIME_FORMAT_GUESS = 0, ///< usually used as the fallback value if the format value is empty
-  TIME_FORMAT_SS = 1, ///< <b>ss</b> - seconds only
-  TIME_FORMAT_MM = 2, ///< <b>mm</b> - minutes only (2-digit)
-  TIME_FORMAT_MM_SS = 3, ///< <b>mm:ss</b> - minutes and seconds
-  TIME_FORMAT_HH = 4, ///< <b>hh</b> - hours only (2-digit)
-  TIME_FORMAT_HH_SS = 5, ///< <b>hh:ss</b> - hours and seconds (this is not particularly useful)
-  TIME_FORMAT_HH_MM = 6, ///< <b>hh:mm</b> - hours and minutes
-  TIME_FORMAT_HH_MM_SS = 7, ///< <b>hh:mm:ss</b> - hours, minutes and seconds
-  TIME_FORMAT_XX = 8, ///<  <b>xx</b> - returns AM/PM for a 12-hour clock
-  TIME_FORMAT_HH_MM_XX =
-      14, ///< <b>hh:mm xx</b> - returns hours and minutes in a 12-hour clock format (AM/PM)
-  TIME_FORMAT_HH_MM_SS_XX =
-      15, ///< <b>hh:mm:ss xx</b> - returns hours (2-digit), minutes and seconds in a 12-hour clock format (AM/PM)
-  TIME_FORMAT_H = 16, ///< <b>h</b> - hours only (1-digit)
-  TIME_FORMAT_H_MM_SS = 19, ///< <b>hh:mm:ss</b> - hours, minutes and seconds
-  TIME_FORMAT_H_MM_SS_XX =
-      27, ///< <b>hh:mm:ss xx</b> - returns hours (1-digit), minutes and seconds in a 12-hour clock format (AM/PM)
-  TIME_FORMAT_SECS = 32, ///<  <b>secs</b> - total time in seconds
-  TIME_FORMAT_MINS = 64, ///<  <b>mins</b> - total time in minutes
-  TIME_FORMAT_HOURS = 128, ///< <b>hours</b> - total time in hours
-  TIME_FORMAT_M = 256 ///< <b>m</b> - minutes only (1-digit)
-};
 
 class CDateTime;
 

--- a/xbmc/addons/RepositoryUpdater.h
+++ b/xbmc/addons/RepositoryUpdater.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "XBDateTime.h"
 #include "addons/AddonEvents.h"
 #include "addons/Repository.h"
 #include "settings/lib/ISettingCallback.h"
@@ -17,6 +16,8 @@
 #include "utils/EventStream.h"
 
 #include <vector>
+
+class CDateTime;
 
 namespace ADDON
 {

--- a/xbmc/addons/binary-addons/AddonDll.h
+++ b/xbmc/addons/binary-addons/AddonDll.h
@@ -11,7 +11,6 @@
 #include "BinaryAddonManager.h"
 #include "DllAddon.h"
 #include "addons/Addon.h"
-#include "utils/XMLUtils.h"
 
 // Global addon callback handle classes
 #include "addons/interfaces/AddonBase.h"

--- a/xbmc/cores/RetroPlayer/savestates/ISavestate.h
+++ b/xbmc/cores/RetroPlayer/savestates/ISavestate.h
@@ -9,11 +9,12 @@
 #pragma once
 
 #include "SavestateTypes.h"
-#include "XBDateTime.h"
 
 #include <stdint.h>
 #include <string>
 #include <vector>
+
+class CDateTime;
 
 namespace KODI
 {

--- a/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.cpp
@@ -8,6 +8,7 @@
 
 #include "SavestateFlatBuffer.h"
 
+#include "XBDateTime.h"
 #include "savestate_generated.h"
 #include "utils/log.h"
 

--- a/xbmc/dialogs/GUIDialogNumeric.cpp
+++ b/xbmc/dialogs/GUIDialogNumeric.cpp
@@ -9,6 +9,7 @@
 #include "GUIDialogNumeric.h"
 
 #include "ServiceBroker.h"
+#include "XBDateTime.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUILabelControl.h"
 #include "guilib/GUIWindowManager.h"

--- a/xbmc/dialogs/GUIDialogNumeric.h
+++ b/xbmc/dialogs/GUIDialogNumeric.h
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include "XBDateTime.h"
 #include "guilib/GUIDialog.h"
+#include "utils/XTimeUtils.h"
 
 #include <cstdint>
 

--- a/xbmc/filesystem/SpecialProtocol.cpp
+++ b/xbmc/filesystem/SpecialProtocol.cpp
@@ -7,18 +7,21 @@
  */
 
 #include "SpecialProtocol.h"
+
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "Util.h"
-#include "windowing/GraphicContext.h"
 #include "profiles/ProfileManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "utils/log.h"
 #include "utils/URIUtils.h"
+#include "utils/log.h"
+#include "windowing/GraphicContext.h"
 
 #include <cassert>
+
+#include "PlatformDefs.h"
 #ifdef TARGET_POSIX
 #include <dirent.h>
 #include "utils/StringUtils.h"

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -644,13 +644,13 @@ std::string CPlayerGUIInfo::GetContentRanges(int iInfo) const
   CDataCacheCore& data = CServiceBroker::GetDataCacheCore();
   std::vector<std::pair<float, float>> ranges;
 
-  time_t start;
+  std::time_t start;
   int64_t current;
   int64_t min;
   int64_t max;
   data.GetPlayTimes(start, current, min, max);
 
-  time_t duration = max - start * 1000;
+  std::time_t duration = max - start * 1000;
   if (duration > 0)
   {
     switch (iInfo)
@@ -685,7 +685,7 @@ std::string CPlayerGUIInfo::GetContentRanges(int iInfo) const
 }
 
 std::vector<std::pair<float, float>> CPlayerGUIInfo::GetEditList(const CDataCacheCore& data,
-                                                                 time_t duration) const
+                                                                 std::time_t duration) const
 {
   std::vector<std::pair<float, float>> ranges;
 
@@ -700,7 +700,7 @@ std::vector<std::pair<float, float>> CPlayerGUIInfo::GetEditList(const CDataCach
 }
 
 std::vector<std::pair<float, float>> CPlayerGUIInfo::GetCuts(const CDataCacheCore& data,
-                                                             time_t duration) const
+                                                             std::time_t duration) const
 {
   std::vector<std::pair<float, float>> ranges;
 
@@ -718,7 +718,7 @@ std::vector<std::pair<float, float>> CPlayerGUIInfo::GetCuts(const CDataCacheCor
 }
 
 std::vector<std::pair<float, float>> CPlayerGUIInfo::GetSceneMarkers(const CDataCacheCore& data,
-                                                                     time_t duration) const
+                                                                     std::time_t duration) const
 {
   std::vector<std::pair<float, float>> ranges;
 
@@ -736,7 +736,7 @@ std::vector<std::pair<float, float>> CPlayerGUIInfo::GetSceneMarkers(const CData
 }
 
 std::vector<std::pair<float, float>> CPlayerGUIInfo::GetChapters(const CDataCacheCore& data,
-                                                                 time_t duration) const
+                                                                 std::time_t duration) const
 {
   std::vector<std::pair<float, float>> ranges;
 

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.h
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.h
@@ -8,11 +8,12 @@
 
 #pragma once
 
-#include "XBDateTime.h"
 #include "guilib/guiinfo/GUIInfoProvider.h"
 #include "utils/EventStream.h"
+#include "utils/TimeFormat.h"
 
 #include <atomic>
+#include <ctime>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -76,12 +77,13 @@ private:
 
   std::string GetContentRanges(int iInfo) const;
   std::vector<std::pair<float, float>> GetEditList(const CDataCacheCore& data,
-                                                   time_t duration) const;
-  std::vector<std::pair<float, float>> GetCuts(const CDataCacheCore& data, time_t duration) const;
+                                                   std::time_t duration) const;
+  std::vector<std::pair<float, float>> GetCuts(const CDataCacheCore& data,
+                                               std::time_t duration) const;
   std::vector<std::pair<float, float>> GetSceneMarkers(const CDataCacheCore& data,
-                                                       time_t duration) const;
+                                                       std::time_t duration) const;
   std::vector<std::pair<float, float>> GetChapters(const CDataCacheCore& data,
-                                                   time_t duration) const;
+                                                   std::time_t duration) const;
 };
 
 } // namespace GUIINFO

--- a/xbmc/interfaces/json-rpc/CMakeLists.txt
+++ b/xbmc/interfaces/json-rpc/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SOURCES AddonsOperations.cpp
             InputOperations.cpp
             JSONRPC.cpp
             JSONServiceDescription.cpp
+            JSONUtils.cpp
             PlayerOperations.cpp
             PlaylistOperations.cpp
             ProfilesOperations.cpp

--- a/xbmc/interfaces/json-rpc/JSONUtils.cpp
+++ b/xbmc/interfaces/json-rpc/JSONUtils.cpp
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "JSONUtils.h"
+
+#include "XBDateTime.h"
+
+namespace JSONRPC
+{
+
+void CJSONUtils::SetFromDBDate(const CVariant& jsonDate, CDateTime& date)
+{
+  if (!jsonDate.isString())
+    return;
+
+  if (jsonDate.empty())
+    date.Reset();
+  else
+    date.SetFromDBDate(jsonDate.asString());
+}
+
+void CJSONUtils::SetFromDBDateTime(const CVariant& jsonDate, CDateTime& date)
+{
+  if (!jsonDate.isString())
+    return;
+
+  if (jsonDate.empty())
+    date.Reset();
+  else
+    date.SetFromDBDateTime(jsonDate.asString());
+}
+
+} // namespace JSONRPC

--- a/xbmc/interfaces/json-rpc/JSONUtils.h
+++ b/xbmc/interfaces/json-rpc/JSONUtils.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "JSONRPCUtils.h"
-#include "XBDateTime.h"
 #include "playlists/SmartPlayList.h"
 #include "utils/JSONVariantParser.h"
 #include "utils/JSONVariantWriter.h"
@@ -20,6 +19,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <vector>
+
+class CDateTime;
 
 namespace JSONRPC
 {
@@ -462,27 +463,9 @@ namespace JSONRPC
         stringArray.push_back(it->asString());
     }
 
-    static void SetFromDBDate(const CVariant &jsonDate, CDateTime &date)
-    {
-      if (!jsonDate.isString())
-        return;
+    static void SetFromDBDate(const CVariant& jsonDate, CDateTime& date);
 
-      if (jsonDate.empty())
-        date.Reset();
-      else
-        date.SetFromDBDate(jsonDate.asString());
-    }
-
-    static void SetFromDBDateTime(const CVariant &jsonDate, CDateTime &date)
-    {
-      if (!jsonDate.isString())
-        return;
-
-      if (jsonDate.empty())
-        date.Reset();
-      else
-        date.SetFromDBDateTime(jsonDate.asString());
-    }
+    static void SetFromDBDateTime(const CVariant& jsonDate, CDateTime& date);
 
     static bool GetXspFiltering(const std::string &type, const CVariant &filter, std::string &xsp)
     {

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -711,3 +711,8 @@ bool CPeripheral::operator!=(const PeripheralScanResult& right) const
 {
   return !(*this == right);
 }
+
+CDateTime CPeripheral::LastActive()
+{
+  return CDateTime();
+}

--- a/xbmc/peripherals/devices/Peripheral.h
+++ b/xbmc/peripherals/devices/Peripheral.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "XBDateTime.h"
 #include "games/controllers/ControllerTypes.h"
 #include "input/joysticks/interfaces/IInputProvider.h"
 #include "input/keyboard/interfaces/IKeyboardInputProvider.h"
@@ -21,6 +20,7 @@
 #include <vector>
 
 class TiXmlDocument;
+class CDateTime;
 class CSetting;
 class IKeymap;
 
@@ -250,7 +250,7 @@ public:
    *
    * \return The time of last activation, or invalid if unknown/never active
    */
-  virtual CDateTime LastActive() { return CDateTime(); }
+  virtual CDateTime LastActive();
 
   /*!
    * \brief Get the controller profile that best represents this peripheral

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -37,6 +37,7 @@ public:
 #else
 
 #include "PeripheralHID.h"
+#include "XBDateTime.h"
 #include "interfaces/AnnouncementManager.h"
 #include "threads/CriticalSection.h"
 #include "threads/Thread.h"

--- a/xbmc/peripherals/devices/PeripheralJoystick.h
+++ b/xbmc/peripherals/devices/PeripheralJoystick.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Peripheral.h"
+#include "XBDateTime.h"
 #include "input/joysticks/JoystickTypes.h"
 #include "input/joysticks/interfaces/IDriverReceiver.h"
 #include "threads/CriticalSection.h"

--- a/xbmc/peripherals/devices/PeripheralKeyboard.h
+++ b/xbmc/peripherals/devices/PeripheralKeyboard.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Peripheral.h"
+#include "XBDateTime.h"
 #include "input/keyboard/interfaces/IKeyboardDriverHandler.h"
 #include "threads/CriticalSection.h"
 

--- a/xbmc/peripherals/devices/PeripheralMouse.h
+++ b/xbmc/peripherals/devices/PeripheralMouse.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Peripheral.h"
+#include "XBDateTime.h"
 #include "input/mouse/interfaces/IMouseDriverHandler.h"
 #include "threads/CriticalSection.h"
 

--- a/xbmc/platform/darwin/DarwinUtils.mm
+++ b/xbmc/platform/darwin/DarwinUtils.mm
@@ -29,6 +29,7 @@
 
 #include <mutex>
 
+#include "PlatformDefs.h"
 
 // platform strings are based on http://theiphonewiki.com/wiki/Models
 const char* CDarwinUtils::getIosPlatformString(void)

--- a/xbmc/platform/linux/FDEventMonitor.cpp
+++ b/xbmc/platform/linux/FDEventMonitor.cpp
@@ -18,6 +18,8 @@
 #include <sys/eventfd.h>
 #include <unistd.h>
 
+#include "PlatformDefs.h"
+
 CFDEventMonitor::CFDEventMonitor() :
   CThread("FDEventMonitor")
 {

--- a/xbmc/platform/linux/input/LIRC.cpp
+++ b/xbmc/platform/linux/input/LIRC.cpp
@@ -25,6 +25,8 @@
 #include <sys/un.h>
 #include <unistd.h>
 
+#include "PlatformDefs.h"
+
 using namespace std::chrono_literals;
 
 CLirc::CLirc() : CThread("Lirc")

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "XBDateTime.h"
 #include "pvr/channels/PVRChannelGroupSettings.h"
 #include "pvr/channels/PVRChannelNumber.h"
 #include "pvr/channels/PVRChannelsPath.h"

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "XBDateTime.h"
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_epg.h"
 #include "pvr/settings/PVRSettings.h"
 #include "threads/CriticalSection.h"
@@ -23,6 +22,8 @@
 #include <string>
 #include <utility>
 #include <vector>
+
+class CDateTime;
 
 namespace PVR
 {

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "XBDateTime.h"
 #include "guilib/DirtyRegion.h"
 #include "guilib/GUIControl.h"
 #include "guilib/GUIListItemLayout.h"
@@ -22,6 +21,7 @@
 #include <utility>
 #include <vector>
 
+class CDateTime;
 class CFileItem;
 class CFileItemList;
 class CGUIListItem;

--- a/xbmc/pvr/guilib/guiinfo/PVRGUITimesInfo.h
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUITimesInfo.h
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include "XBDateTime.h"
 #include "threads/CriticalSection.h"
+#include "utils/TimeFormat.h"
 
 #include <memory>
 

--- a/xbmc/pvr/recordings/PVRRecordingsPath.cpp
+++ b/xbmc/pvr/recordings/PVRRecordingsPath.cpp
@@ -9,6 +9,7 @@
 #include "PVRRecordingsPath.h"
 
 #include "URL.h"
+#include "XBDateTime.h"
 #include "utils/RegExp.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "XBDateTime.h"
 #include "pvr/settings/PVRSettings.h"
 #include "threads/Thread.h"
 
@@ -16,6 +15,8 @@
 #include <memory>
 #include <queue>
 #include <vector>
+
+class CDateTime;
 
 namespace PVR
 {

--- a/xbmc/settings/SettingDateTime.cpp
+++ b/xbmc/settings/SettingDateTime.cpp
@@ -9,6 +9,7 @@
 #include "SettingDateTime.h"
 
 #include "XBDateTime.h"
+#include "utils/TimeUtils.h"
 
 #include <shared_mutex>
 
@@ -39,6 +40,16 @@ bool CSettingDate::CheckValidity(const std::string &value) const
   return CDateTime::FromDBDate(value).IsValid();
 }
 
+CDateTime CSettingDate::GetDate() const
+{
+  return CDateTime::FromDBDate(GetValue());
+}
+
+bool CSettingDate::SetDate(const CDateTime& date)
+{
+  return SetValue(date.GetAsDBDate());
+}
+
 CSettingTime::CSettingTime(const std::string &id, CSettingsManager *settingsManager /* = NULL */)
   : CSettingString(id, settingsManager)
 { }
@@ -64,4 +75,14 @@ bool CSettingTime::CheckValidity(const std::string &value) const
     return false;
 
   return CDateTime::FromDBTime(value).IsValid();
+}
+
+CDateTime CSettingTime::GetTime() const
+{
+  return CDateTime::FromDBTime(GetValue());
+}
+
+bool CSettingTime::SetTime(const CDateTime& time)
+{
+  return SetValue(CTimeUtils::WithoutSeconds(time.GetAsDBTime()));
 }

--- a/xbmc/settings/SettingDateTime.h
+++ b/xbmc/settings/SettingDateTime.h
@@ -8,9 +8,9 @@
 
 #pragma once
 
-#include "XBDateTime.h"
 #include "settings/lib/Setting.h"
-#include "utils/TimeUtils.h"
+
+class CDateTime;
 
 class CSettingDate : public CSettingString
 {
@@ -24,8 +24,8 @@ public:
 
   bool CheckValidity(const std::string &value) const override;
 
-  CDateTime GetDate() const { return CDateTime::FromDBDate(GetValue()); }
-  bool SetDate(const CDateTime& date) { return SetValue(date.GetAsDBDate()); }
+  CDateTime GetDate() const;
+  bool SetDate(const CDateTime& date);
 };
 
 class CSettingTime : public CSettingString
@@ -40,6 +40,6 @@ public:
 
   bool CheckValidity(const std::string &value) const override;
 
-  CDateTime GetTime() const { return CDateTime::FromDBTime(GetValue()); }
-  bool SetTime(const CDateTime& time) { return SetValue(CTimeUtils::WithoutSeconds(time.GetAsDBTime())); }
+  CDateTime GetTime() const;
+  bool SetTime(const CDateTime& time);
 };

--- a/xbmc/utils/Archive.cpp
+++ b/xbmc/utils/Archive.cpp
@@ -11,6 +11,7 @@
 #include "IArchivable.h"
 #include "filesystem/File.h"
 #include "utils/Variant.h"
+#include "utils/XTimeUtils.h"
 #include "utils/log.h"
 
 #include <algorithm>

--- a/xbmc/utils/Archive.h
+++ b/xbmc/utils/Archive.h
@@ -8,8 +8,7 @@
 
 #pragma once
 
-#include "XBDateTime.h"
-
+#include <cstring>
 #include <memory>
 #include <string>
 #include <vector>
@@ -22,6 +21,10 @@ namespace XFILE
 }
 class CVariant;
 class IArchivable;
+namespace KODI::TIME
+{
+struct SystemTime;
+}
 
 class CArchive
 {

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -164,6 +164,7 @@ set(HEADERS ActorProtocol.h
             SystemInfo.h
             Temperature.h
             TextSearch.h
+            TimeFormat.h
             TimeUtils.h
             TransformMatrix.h
             URIUtils.h

--- a/xbmc/utils/DumbBufferObject.cpp
+++ b/xbmc/utils/DumbBufferObject.cpp
@@ -19,6 +19,8 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
+#include "PlatformDefs.h"
+
 using namespace KODI::WINDOWING::GBM;
 
 std::unique_ptr<CBufferObject> CDumbBufferObject::Create()

--- a/xbmc/utils/RssReader.h
+++ b/xbmc/utils/RssReader.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "XBDateTime.h"
 #include "threads/CriticalSection.h"
 #include "threads/Thread.h"
 #include "utils/IRssObserver.h"
@@ -17,6 +16,11 @@
 #include <list>
 #include <string>
 #include <vector>
+
+namespace KODI::TIME
+{
+struct SystemTime;
+}
 
 class CRssReader : public CThread
 {

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -29,6 +29,7 @@
 #include "CharsetConverter.h"
 #include "LangInfo.h"
 #include "StringUtils.h"
+#include "XBDateTime.h"
 
 #include <algorithm>
 #include <array>

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -31,7 +31,7 @@
 #undef FMT_DEPRECATED
 #define FMT_DEPRECATED
 #endif
-#include "XBDateTime.h"
+#include "utils/TimeFormat.h"
 #include "utils/params_check_macros.h"
 
 #include <fmt/format.h>

--- a/xbmc/utils/TimeFormat.h
+++ b/xbmc/utils/TimeFormat.h
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+/*! \brief TIME_FORMAT enum/bitmask used for formatting time strings
+ Note the use of bitmasking, e.g.
+  TIME_FORMAT_HH_MM_SS = TIME_FORMAT_HH | TIME_FORMAT_MM | TIME_FORMAT_SS
+ \sa StringUtils::SecondsToTimeString
+ \note For InfoLabels use the equivalent value listed (bold)
+  on the description of each enum value.
+ \note<b>Example:</b> 3661 seconds => h=1, hh=01, m=1, mm=01, ss=01, hours=1, mins=61, secs=3661
+ <p><hr>
+ @skinning_v18 **[Infolabels Updated]** Added <b>secs</b>, <b>mins</b>, <b>hours</b> (total time) and **m** as possible formats for
+ InfoLabels that support the definition of a time format. Examples are:
+   - \link Player_SeekOffset_format `Player.SeekOffset(format)`\endlink
+   - \link Player_TimeRemaining_format `Player.TimeRemaining(format)`\endlink
+   - \link Player_Time_format `Player.Time(format)`\endlink
+   - \link Player_Duration_format `Player.Duration(format)`\endlink
+   - \link Player_FinishTime_format `Player.FinishTime(format)`\endlink
+   - \link Player_StartTime_format `Player.StartTime(format)` \endlink
+   - \link Player_SeekNumeric_format `Player.SeekNumeric(format)`\endlink
+   - \link ListItem_Duration_format `ListItem.Duration(format)`\endlink
+   - \link PVR_EpgEventDuration_format `PVR.EpgEventDuration(format)`\endlink
+   - \link PVR_EpgEventElapsedTime_format `PVR.EpgEventElapsedTime(format)`\endlink
+   - \link PVR_EpgEventRemainingTime_format `PVR.EpgEventRemainingTime(format)`\endlink
+   - \link PVR_EpgEventSeekTime_format `PVR.EpgEventSeekTime(format)`\endlink
+   - \link PVR_EpgEventFinishTime_format `PVR.EpgEventFinishTime(format)`\endlink
+   - \link PVR_TimeShiftStart_format `PVR.TimeShiftStart(format)`\endlink
+   - \link PVR_TimeShiftEnd_format `PVR.TimeShiftEnd(format)`\endlink
+   - \link PVR_TimeShiftCur_format `PVR.TimeShiftCur(format)`\endlink
+   - \link PVR_TimeShiftOffset_format `PVR.TimeShiftOffset(format)`\endlink
+   - \link PVR_TimeshiftProgressDuration_format `PVR.TimeshiftProgressDuration(format)`\endlink
+   - \link PVR_TimeshiftProgressEndTime `PVR.TimeshiftProgressEndTime`\endlink
+   - \link PVR_TimeshiftProgressEndTime_format `PVR.TimeshiftProgressEndTime(format)`\endlink
+   - \link ListItem_NextDuration_format `ListItem.NextDuration(format)` \endlink
+  <p>
+ */
+enum TIME_FORMAT
+{
+  TIME_FORMAT_GUESS = 0, ///< usually used as the fallback value if the format value is empty
+  TIME_FORMAT_SS = 1, ///< <b>ss</b> - seconds only
+  TIME_FORMAT_MM = 2, ///< <b>mm</b> - minutes only (2-digit)
+  TIME_FORMAT_MM_SS = 3, ///< <b>mm:ss</b> - minutes and seconds
+  TIME_FORMAT_HH = 4, ///< <b>hh</b> - hours only (2-digit)
+  TIME_FORMAT_HH_SS = 5, ///< <b>hh:ss</b> - hours and seconds (this is not particularly useful)
+  TIME_FORMAT_HH_MM = 6, ///< <b>hh:mm</b> - hours and minutes
+  TIME_FORMAT_HH_MM_SS = 7, ///< <b>hh:mm:ss</b> - hours, minutes and seconds
+  TIME_FORMAT_XX = 8, ///<  <b>xx</b> - returns AM/PM for a 12-hour clock
+  TIME_FORMAT_HH_MM_XX =
+      14, ///< <b>hh:mm xx</b> - returns hours and minutes in a 12-hour clock format (AM/PM)
+  TIME_FORMAT_HH_MM_SS_XX =
+      15, ///< <b>hh:mm:ss xx</b> - returns hours (2-digit), minutes and seconds in a 12-hour clock format (AM/PM)
+  TIME_FORMAT_H = 16, ///< <b>h</b> - hours only (1-digit)
+  TIME_FORMAT_H_MM_SS = 19, ///< <b>hh:mm:ss</b> - hours, minutes and seconds
+  TIME_FORMAT_H_MM_SS_XX =
+      27, ///< <b>hh:mm:ss xx</b> - returns hours (1-digit), minutes and seconds in a 12-hour clock format (AM/PM)
+  TIME_FORMAT_SECS = 32, ///<  <b>secs</b> - total time in seconds
+  TIME_FORMAT_MINS = 64, ///<  <b>mins</b> - total time in minutes
+  TIME_FORMAT_HOURS = 128, ///< <b>hours</b> - total time in hours
+  TIME_FORMAT_M = 256 ///< <b>m</b> - minutes only (1-digit)
+};

--- a/xbmc/utils/UDMABufferObject.cpp
+++ b/xbmc/utils/UDMABufferObject.cpp
@@ -18,6 +18,8 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
+#include "PlatformDefs.h"
+
 namespace
 {
 

--- a/xbmc/utils/XMLUtils.cpp
+++ b/xbmc/utils/XMLUtils.cpp
@@ -7,8 +7,10 @@
  */
 
 #include "XMLUtils.h"
-#include "URL.h"
+
 #include "StringUtils.h"
+#include "URL.h"
+#include "XBDateTime.h"
 
 bool XMLUtils::GetHex(const TiXmlNode* pRootNode, const char* strTag, uint32_t& hexValue)
 {

--- a/xbmc/utils/test/TestArchive.cpp
+++ b/xbmc/utils/test/TestArchive.cpp
@@ -10,11 +10,11 @@
 #  include <windows.h>
 #endif
 
+#include "filesystem/File.h"
+#include "test/TestUtils.h"
 #include "utils/Archive.h"
 #include "utils/Variant.h"
-#include "filesystem/File.h"
-
-#include "test/TestUtils.h"
+#include "utils/XTimeUtils.h"
 
 #include <gtest/gtest.h>
 

--- a/xbmc/utils/test/TestSystemInfo.cpp
+++ b/xbmc/utils/test/TestSystemInfo.cpp
@@ -17,6 +17,8 @@
 
 #include <gtest/gtest.h>
 
+#include "PlatformDefs.h"
+
 class TestSystemInfo : public testing::Test
 {
 protected:

--- a/xbmc/windowing/X11/GLContextEGL.cpp
+++ b/xbmc/windowing/X11/GLContextEGL.cpp
@@ -24,6 +24,7 @@
 #include <EGL/eglext.h>
 #include <unistd.h>
 
+#include "PlatformDefs.h"
 #include "system_gl.h"
 
 #define EGL_NO_CONFIG (EGLConfig)0

--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
@@ -22,6 +22,8 @@
 #include <EGL/eglext.h>
 #include <unistd.h>
 
+#include "PlatformDefs.h"
+
 void CWinSystemAndroidGLESContext::Register()
 {
   KODI::WINDOWING::CWindowSystemFactory::RegisterWindowSystem(CreateWinSystem);

--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -15,6 +15,8 @@
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
 
+#include "PlatformDefs.h"
+
 using namespace KODI::WINDOWING::GBM;
 
 namespace


### PR DESCRIPTION
## Description
Avoiding includes in headers.

XMLUtils.h: 184 -> 61 files rebuilt
XBDateTime.h: 1078 -> 532 files rebuilt.

## Motivation and context
Reduce hotness of headers.

## How has this been tested?
It builds.

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
