### PR TITLE
[Windows] Adds new setting to set the GUI peak luminance when the display is in HDR PQ mode

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -18854,7 +18854,13 @@ msgctxt "#36053"
 msgid "Tuner Device"
 msgstr ""
 
-#empty strings from id 36054 to 36097
+#empty strings from id 36054 to 36096
+
+#. Label of setting "System / Display / GUI peak luminance in HDR PQ mode"
+#: system/settings/settings.xml
+msgctxt "#36097"
+msgid "GUI peak luminance in HDR PQ mode"
+msgstr ""
 
 #. Label of setting "System / Display / Use 10 bit for SDR"
 #: system/settings/settings.xml
@@ -21081,7 +21087,11 @@ msgctxt "#36546"
 msgid "Sets the visual depth of subtitles for stereoscopic 3D videos. The higher the value, the closer the subtitles will appear to the viewer."
 msgstr ""
 
-#empty string with id 36547
+#. Description of setting with label #36097 "System / Display / GUI peak luminance in HDR PQ mode"
+#: system/settings/settings.xml
+msgctxt "#36547"
+msgid "Sets the peak luminance level for GUI elements while the display is in HDR PQ mode. This affects all OSD, subtitles and graphics that are SDR in origin."
+msgstr ""
 
 #. Description of setting with label #37021 "Set GUI resolution limit"
 #: system/settings/android.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2591,6 +2591,17 @@
           </constraints>
           <control type="spinner" format="string" />
         </setting>
+        <setting id="videoscreen.guisdrpeakluminance" type="integer" label="36097" help="36547">
+        <requirement>HAS_DX</requirement>
+          <dependencies>
+            <dependency type="visible">
+              <condition on="property" name="ishdrdisplay" />
+            </dependency>
+          </dependencies>
+          <level>2</level>
+          <default>60</default>
+          <control type="slider" format="percentage" range="0,100" />
+        </setting>
         <setting id="videoscreen.10bitsurfaces" type="integer" label="36098" help="36578">
         <requirement>HAS_DX</requirement>
           <level>3</level>

--- a/system/shaders/guishader_common.hlsl
+++ b/system/shaders/guishader_common.hlsl
@@ -47,6 +47,7 @@ cbuffer cbWorld : register(b0)
   float4x4 worldViewProj;
   float blackLevel;
   float colorRange;
+  float sdrPeakLum;
   int PQ;
 };
 
@@ -57,7 +58,6 @@ inline float3 transferPQ(float3 x)
   static const float ST2084_c1 = 3424.0f / 4096.0f;
   static const float ST2084_c2 = (2413.0f / 4096.0f) * 32.0f;
   static const float ST2084_c3 = (2392.0f / 4096.0f) * 32.0f;
-  static const float SDR_peak_lum = 100.0f;
   static const float3x3 matx =
   {
     0.627402, 0.329292, 0.043306,
@@ -69,7 +69,7 @@ inline float3 transferPQ(float3 x)
   // REC.709 to BT.2020
   x = mul(matx, x);
   // linear to PQ
-  x = pow(x / SDR_peak_lum, ST2084_m1);
+  x = pow(x / sdrPeakLum, ST2084_m1);
   x = (ST2084_c1 + ST2084_c2 * x) / (1.0f + ST2084_c3 * x);
   x = pow(x, ST2084_m2);
   return x;

--- a/xbmc/guilib/GUIShaderDX.cpp
+++ b/xbmc/guilib/GUIShaderDX.cpp
@@ -334,6 +334,7 @@ void CGUIShaderDX::ApplyChanges(void)
       buffer->wvp = worldViewProj;
       buffer->blackLevel = (DX::Windowing()->UseLimitedColor() ? 16.f / 255.f : 0.f);
       buffer->colorRange = (DX::Windowing()->UseLimitedColor() ? (235.f - 16.f) / 255.f : 1.0f);
+      buffer->sdrPeakLum = (100 - DX::Windowing()->GetGuiSdrPeakLuminance()) + 10;
       buffer->PQ = (DX::Windowing()->IsTransferPQ() ? 1 : 0);
 
       pContext->Unmap(m_pWVPBuffer.Get(), 0);

--- a/xbmc/guilib/GUIShaderDX.h
+++ b/xbmc/guilib/GUIShaderDX.h
@@ -106,6 +106,7 @@ private:
     DirectX::XMMATRIX wvp;
     float blackLevel;
     float colorRange;
+    float sdrPeakLum;
     int PQ;
   };
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -366,6 +366,7 @@ constexpr const char* CSettings::SETTING_VIDEOSCREEN_TESTPATTERN;
 constexpr const char* CSettings::SETTING_VIDEOSCREEN_LIMITEDRANGE;
 constexpr const char* CSettings::SETTING_VIDEOSCREEN_FRAMEPACKING;
 constexpr const char* CSettings::SETTING_VIDEOSCREEN_10BITSURFACES;
+constexpr const char* CSettings::SETTING_VIDEOSCREEN_GUISDRPEAKLUMINANCE;
 constexpr const char* CSettings::SETTING_AUDIOOUTPUT_AUDIODEVICE;
 constexpr const char* CSettings::SETTING_AUDIOOUTPUT_CHANNELS;
 constexpr const char* CSettings::SETTING_AUDIOOUTPUT_CONFIG;

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -365,6 +365,7 @@ public:
   static constexpr auto SETTING_VIDEOSCREEN_LIMITEDRANGE = "videoscreen.limitedrange";
   static constexpr auto SETTING_VIDEOSCREEN_FRAMEPACKING = "videoscreen.framepacking";
   static constexpr auto SETTING_VIDEOSCREEN_10BITSURFACES = "videoscreen.10bitsurfaces";
+  static constexpr auto SETTING_VIDEOSCREEN_GUISDRPEAKLUMINANCE = "videoscreen.guisdrpeakluminance";
   static constexpr auto SETTING_AUDIOOUTPUT_AUDIODEVICE = "audiooutput.audiodevice";
   static constexpr auto SETTING_AUDIOOUTPUT_CHANNELS = "audiooutput.channels";
   static constexpr auto SETTING_AUDIOOUTPUT_CONFIG = "audiooutput.config";

--- a/xbmc/windowing/win10/WinSystemWin10.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10.cpp
@@ -650,4 +650,11 @@ bool CWinSystemWin10::MessagePump()
   return m_winEvents->MessagePump();
 }
 
+int CWinSystemWin10::GetGuiSdrPeakLuminance() const
+{
+  const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+
+  return settings->GetInt(CSettings::SETTING_VIDEOSCREEN_GUISDRPEAKLUMINANCE);
+}
+
 #pragma pack(pop)

--- a/xbmc/windowing/win10/WinSystemWin10.h
+++ b/xbmc/windowing/win10/WinSystemWin10.h
@@ -94,6 +94,7 @@ public:
   virtual bool DPIChanged(WORD dpi, RECT windowRect) const;
   bool IsMinimized() const { return m_bMinimized; }
   void SetMinimized(bool minimized) { m_bMinimized = minimized; }
+  int GetGuiSdrPeakLuminance() const;
 
   bool CanDoWindowed() override;
 

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -1285,3 +1285,10 @@ RECT CWinSystemWin32::GetVirtualScreenRect()
 
   return rect;
 }
+
+int CWinSystemWin32::GetGuiSdrPeakLuminance() const
+{
+  const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+
+  return settings->GetInt(CSettings::SETTING_VIDEOSCREEN_GUISDRPEAKLUMINANCE);
+}

--- a/xbmc/windowing/windows/WinSystemWin32.h
+++ b/xbmc/windowing/windows/WinSystemWin32.h
@@ -109,6 +109,7 @@ public:
   virtual bool DPIChanged(WORD dpi, RECT windowRect) const;
   bool IsMinimized() const { return m_bMinimized; }
   void SetMinimized(bool minimized);
+  int GetGuiSdrPeakLuminance() const;
 
   // touchscreen support
   typedef BOOL(WINAPI *pGetGestureInfo)(HGESTUREINFO, PGESTUREINFO);


### PR DESCRIPTION
## Description
Adds new setting to set the GUI peak luminance when the display is in HDR PQ mode

## Motivation and context
This is a follow-up of https://github.com/xbmc/xbmc/pull/18984

While a fixed value of 100 nits should be mathematically correct, there are several reasons to prefer adjust it: different user preferences, perception that the OSD is less bright in HDR than SDR (compared to video), HDR subtitles too bright, differences in the TVs settings, etc.

Default value of 60% it is slightly brighter than before and can be adjusted from slightly less bright than before (0%) to much brighter than before (100%).

Changes can be seen in real time by tapping on the setting while HDR playback is on.

## How has this been tested?
Runtime on Intel NUC8i3BEK

## What is the effect on users?
Being able to calibrate GUI and subtitles luminance in HDR to match same luminance that SDR or adjust for a higher brightness level if desired.

## Screenshots (if appropriate):

![screenshot00005](https://user-images.githubusercontent.com/58434170/193768557-5f02bafc-a97a-42cb-aac2-8f10026bc1a5.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
