### PR TITLE
Cleanup some headers to reduce compile dependencies

### DIFF
--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -15,7 +15,6 @@
 
 #include "LockType.h"
 #include "XBDateTime.h"
-#include "addons/IAddon.h"
 #include "guilib/GUIListItem.h"
 #include "threads/CriticalSection.h"
 #include "utils/IArchivable.h"
@@ -28,6 +27,11 @@
 #include <string>
 #include <utility>
 #include <vector>
+
+namespace ADDON
+{
+class IAddon;
+}
 
 namespace MUSIC_INFO
 {

--- a/xbmc/PasswordManager.cpp
+++ b/xbmc/PasswordManager.cpp
@@ -14,6 +14,7 @@
 #include "profiles/ProfileManager.h"
 #include "profiles/dialogs/GUIDialogLockSettings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/StringUtils.h"
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 

--- a/xbmc/addons/addoninfo/AddonExtensions.cpp
+++ b/xbmc/addons/addoninfo/AddonExtensions.cpp
@@ -8,7 +8,14 @@
 
 #include "AddonExtensions.h"
 
+#include "utils/StringUtils.h"
+
 using namespace ADDON;
+
+bool SExtValue::asBoolean() const
+{
+  return StringUtils::EqualsNoCase(str, "true");
+}
 
 const SExtValue CAddonExtensions::GetValue(const std::string& id) const
 {

--- a/xbmc/addons/addoninfo/AddonExtensions.h
+++ b/xbmc/addons/addoninfo/AddonExtensions.h
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include "utils/StringUtils.h"
-
 #include <stdlib.h>
 #include <string>
 #include <vector>
@@ -24,9 +22,9 @@ struct SExtValue
 {
   explicit SExtValue(const std::string& strValue) : str(strValue) { }
   const std::string& asString() const { return str; }
-  bool asBoolean() const { return StringUtils::EqualsNoCase(str, "true"); }
-  int asInteger() const { return atoi(str.c_str()); }
-  float asFloat() const { return static_cast<float>(atof(str.c_str())); }
+  bool asBoolean() const;
+  int asInteger() const { return std::atoi(str.c_str()); }
+  float asFloat() const { return static_cast<float>(std::atof(str.c_str())); }
   bool empty() const { return str.empty(); }
   const std::string str;
 };

--- a/xbmc/addons/addoninfo/AddonType.cpp
+++ b/xbmc/addons/addoninfo/AddonType.cpp
@@ -9,6 +9,7 @@
 #include "AddonType.h"
 
 #include "addons/addoninfo/AddonInfo.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 
 namespace ADDON

--- a/xbmc/addons/gui/GUIHelpers.cpp
+++ b/xbmc/addons/gui/GUIHelpers.cpp
@@ -10,6 +10,7 @@
 
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/LocalizeStrings.h"
+#include "utils/StringUtils.h"
 
 using namespace ADDON;
 using namespace ADDON::GUI;

--- a/xbmc/addons/gui/skin/SkinTimerManager.cpp
+++ b/xbmc/addons/gui/skin/SkinTimerManager.cpp
@@ -12,6 +12,7 @@
 #include "ServiceBroker.h"
 #include "guilib/GUIAction.h"
 #include "guilib/GUIComponent.h"
+#include "utils/StringUtils.h"
 #include "utils/XBMCTinyXML.h"
 #include "utils/log.h"
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -22,6 +22,7 @@
 #include <androidjni/AudioManager.h>
 #include <androidjni/AudioTrack.h>
 #include <androidjni/Build.h>
+#include <unistd.h>
 
 // This is an alternative to the linear weighted delay smoothing
 // advantages: only one history value needs to be stored

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINTVOS.mm
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINTVOS.mm
@@ -26,6 +26,7 @@
 
 #import <AVFoundation/AVAudioSession.h>
 #include <AudioToolbox/AudioToolbox.h>
+#include <unistd.h>
 
 using namespace std::chrono_literals;
 

--- a/xbmc/cores/DllLoader/dll.cpp
+++ b/xbmc/cores/DllLoader/dll.cpp
@@ -13,6 +13,7 @@
 #include "dll_tracker.h"
 #include "dll_util.h"
 #include "filesystem/SpecialProtocol.h"
+#include "utils/StringUtils.h"
 #include "utils/log.h"
 
 #include <climits>

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecCCText.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecCCText.cpp
@@ -13,6 +13,7 @@
 #include "DVDStreamInfo.h"
 #include "cores/VideoPlayer/DVDSubtitles/DVDSubtitleTagSami.h"
 #include "cores/VideoPlayer/Interface/DemuxPacket.h"
+#include "utils/StringUtils.h"
 #include "utils/log.h"
 
 namespace

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecText.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecText.cpp
@@ -13,6 +13,7 @@
 #include "DVDStreamInfo.h"
 #include "cores/VideoPlayer/DVDSubtitles/DVDSubtitleTagSami.h"
 #include "cores/VideoPlayer/Interface/DemuxPacket.h"
+#include "utils/StringUtils.h"
 #include "utils/log.h"
 
 #include <memory>

--- a/xbmc/cores/VideoPlayer/test/edl/TestEdl.cpp
+++ b/xbmc/cores/VideoPlayer/test/edl/TestEdl.cpp
@@ -13,6 +13,8 @@
 #include "settings/SettingsComponent.h"
 #include "test/TestUtils.h"
 
+#include <cmath>
+
 #include <gtest/gtest.h>
 
 using namespace EDL;

--- a/xbmc/cores/playercorefactory/CMakeLists.txt
+++ b/xbmc/cores/playercorefactory/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(SOURCES PlayerCoreFactory.cpp
+set(SOURCES PlayerCoreConfig.cpp
+            PlayerCoreFactory.cpp
             PlayerSelectionRule.cpp)
 
 set(HEADERS PlayerCoreConfig.h

--- a/xbmc/cores/playercorefactory/PlayerCoreConfig.cpp
+++ b/xbmc/cores/playercorefactory/PlayerCoreConfig.cpp
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PlayerCoreConfig.h"
+
+#include "cores/ExternalPlayer/ExternalPlayer.h"
+#include "cores/IPlayer.h"
+#include "cores/RetroPlayer/RetroPlayer.h"
+#include "cores/VideoPlayer/VideoPlayer.h"
+#include "cores/paplayer/PAPlayer.h"
+#ifdef HAS_UPNP
+#include "network/upnp/UPnPPlayer.h"
+#endif
+#include "utils/StringUtils.h"
+#include "utils/XBMCTinyXML.h"
+#include "utils/log.h"
+
+#include <utility>
+
+CPlayerCoreConfig::CPlayerCoreConfig(std::string name,
+                                     std::string type,
+                                     const TiXmlElement* pConfig,
+                                     const std::string& id /* = "" */)
+  : m_name(std::move(name)), m_id(id), m_type(std::move(type))
+{
+  if (pConfig)
+  {
+    m_config.reset(static_cast<TiXmlElement*>(pConfig->Clone()));
+    const char* sAudio = pConfig->Attribute("audio");
+    const char* sVideo = pConfig->Attribute("video");
+    m_bPlaysAudio = sAudio && StringUtils::CompareNoCase(sAudio, "true") == 0;
+    m_bPlaysVideo = sVideo && StringUtils::CompareNoCase(sVideo, "true") == 0;
+  }
+
+  CLog::Log(LOGDEBUG, "CPlayerCoreConfig::<ctor>: created player {}", m_name);
+}
+
+std::shared_ptr<IPlayer> CPlayerCoreConfig::CreatePlayer(IPlayerCallback& callback) const
+{
+  std::shared_ptr<IPlayer> player;
+
+  if (m_type.compare("video") == 0)
+  {
+    player = std::make_shared<CVideoPlayer>(callback);
+  }
+  else if (m_type.compare("music") == 0)
+  {
+    player = std::make_shared<PAPlayer>(callback);
+  }
+  else if (m_type.compare("game") == 0)
+  {
+    player = std::make_shared<KODI::RETRO::CRetroPlayer>(callback);
+  }
+  else if (m_type.compare("external") == 0)
+  {
+    player = std::make_shared<CExternalPlayer>(callback);
+  }
+
+#if defined(HAS_UPNP)
+  else if (m_type.compare("remote") == 0)
+  {
+    player = std::make_shared<UPNP::CUPnPPlayer>(callback, m_id.c_str());
+  }
+#endif
+  else
+    return nullptr;
+
+  if (!player)
+    return nullptr;
+
+  player->m_name = m_name;
+  player->m_type = m_type;
+
+  if (player->Initialize(m_config.get()))
+    return player;
+
+  return nullptr;
+}

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
@@ -24,6 +24,7 @@
 #include "settings/lib/SettingsManager.h"
 #include "utils/StringUtils.h"
 #include "utils/XMLUtils.h"
+#include "utils/log.h"
 
 #include <mutex>
 #include <sstream>

--- a/xbmc/cores/playercorefactory/PlayerSelectionRule.cpp
+++ b/xbmc/cores/playercorefactory/PlayerSelectionRule.cpp
@@ -15,6 +15,7 @@
 #include "settings/SettingsComponent.h"
 #include "utils/RegExp.h"
 #include "utils/StreamDetails.h"
+#include "utils/StringUtils.h"
 #include "utils/XBMCTinyXML.h"
 #include "utils/XMLUtils.h"
 #include "utils/log.h"

--- a/xbmc/guilib/GUITextureGL.cpp
+++ b/xbmc/guilib/GUITextureGL.cpp
@@ -18,6 +18,8 @@
 
 #include <cstddef>
 
+#include "PlatformDefs.h"
+
 void CGUITextureGL::Register()
 {
   CGUITexture::Register(CGUITextureGL::CreateTexture, CGUITextureGL::DrawQuad);

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -22,6 +22,7 @@
 #include "input/actions/ActionIDs.h"
 #include "input/actions/ActionTranslator.h"
 #include "input/mouse/MouseTranslator.h"
+#include "utils/StringUtils.h"
 #include "utils/XBMCTinyXML.h"
 #include "utils/log.h"
 

--- a/xbmc/interfaces/builtins/PVRBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PVRBuiltins.cpp
@@ -19,6 +19,7 @@
 #include "pvr/PVRManager.h"
 #include "pvr/guilib/PVRGUIActionsTimers.h"
 #include "pvr/windows/GUIWindowPVRGuide.h"
+#include "utils/StringUtils.h"
 #include "utils/log.h"
 
 #include <algorithm>

--- a/xbmc/interfaces/legacy/Window.cpp
+++ b/xbmc/interfaces/legacy/Window.cpp
@@ -18,6 +18,7 @@
 #include "guilib/GUIRadioButtonControl.h"
 #include "guilib/GUIWindowManager.h"
 #include "messaging/ApplicationMessenger.h"
+#include "utils/StringUtils.h"
 #include "utils/Variant.h"
 
 #define ACTIVE_WINDOW CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow()

--- a/xbmc/listproviders/StaticProvider.cpp
+++ b/xbmc/listproviders/StaticProvider.cpp
@@ -8,6 +8,7 @@
 
 #include "StaticProvider.h"
 
+#include "utils/StringUtils.h"
 #include "utils/TimeUtils.h"
 #include "utils/XMLUtils.h"
 

--- a/xbmc/music/MusicInfoLoader.cpp
+++ b/xbmc/music/MusicInfoLoader.cpp
@@ -22,6 +22,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/Archive.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 

--- a/xbmc/music/MusicThumbLoader.cpp
+++ b/xbmc/music/MusicThumbLoader.cpp
@@ -13,6 +13,7 @@
 #include "music/infoscanner/MusicInfoScanner.h"
 #include "music/tags/MusicInfoTag.h"
 #include "music/tags/MusicInfoTagLoaderFactory.h"
+#include "utils/StringUtils.h"
 #include "video/VideoThumbLoader.h"
 
 #include <utility>

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -25,6 +25,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/JobManager.h"
+#include "utils/StringUtils.h"
 
 using namespace MUSIC_INFO;
 using namespace XFILE;

--- a/xbmc/network/httprequesthandler/python/HTTPPythonWsgiInvoker.cpp
+++ b/xbmc/network/httprequesthandler/python/HTTPPythonWsgiInvoker.cpp
@@ -15,6 +15,7 @@
 #include "interfaces/legacy/wsgi/WsgiInputStream.h"
 #include "interfaces/legacy/wsgi/WsgiResponse.h"
 #include "interfaces/python/swig.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 
 #include <utility>

--- a/xbmc/platform/darwin/DarwinUtils.mm
+++ b/xbmc/platform/darwin/DarwinUtils.mm
@@ -10,6 +10,7 @@
 #include "DllPaths.h"
 #include "GUIUserMessages.h"
 #include "application/Application.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 

--- a/xbmc/platform/darwin/osx/CocoaInterface.mm
+++ b/xbmc/platform/darwin/osx/CocoaInterface.mm
@@ -10,6 +10,7 @@
 #include "CompileInfo.h"
 #import "DllPaths_generated.h"
 #include "ServiceBroker.h"
+#include "utils/StringUtils.h"
 #include "utils/log.h"
 #if defined(HAS_SDL)
 #include "windowing/osx/SDL/WinSystemOSXSDL.h"

--- a/xbmc/platform/darwin/osx/XBMCHelper.cpp
+++ b/xbmc/platform/darwin/osx/XBMCHelper.cpp
@@ -29,6 +29,7 @@
 #include <sstream>
 
 #include <mach-o/dyld.h>
+#include <unistd.h>
 
 #include "PlatformDefs.h"
 

--- a/xbmc/platform/darwin/osx/network/NetworkOsx.cpp
+++ b/xbmc/platform/darwin/osx/network/NetworkOsx.cpp
@@ -22,6 +22,7 @@
 #include <net/route.h>
 #include <netinet/if_ether.h>
 #include <sys/sockio.h>
+#include <unistd.h>
 
 CNetworkInterfaceOsx::CNetworkInterfaceOsx(CNetworkPosix* network,
                                            const std::string& interfaceName,

--- a/xbmc/platform/darwin/tvos/XBMCController.mm
+++ b/xbmc/platform/darwin/tvos/XBMCController.mm
@@ -42,6 +42,7 @@
 
 #import <AVKit/AVDisplayManager.h>
 #import <AVKit/UIWindow.h>
+#include <unistd.h>
 
 XBMCController* g_xbmcController;
 

--- a/xbmc/platform/freebsd/CPUInfoFreebsd.cpp
+++ b/xbmc/platform/freebsd/CPUInfoFreebsd.cpp
@@ -14,6 +14,13 @@
 #include <array>
 #include <vector>
 
+// clang-format off
+/* sys/types.h must be included early, esp. before sysy/systl.h, otherwise:
+   /usr/include/sys/sysctl.h:1117:25: error: unknown type name 'u_int' */
+
+#include <sys/types.h>
+// clang-format on
+
 #if defined(__i386__) || defined(__x86_64__)
 #include <cpuid.h>
 #elif __has_include(<sys/auxv.h>)
@@ -22,7 +29,6 @@
 
 #include <sys/resource.h>
 #include <sys/sysctl.h>
-#include <sys/types.h>
 
 namespace
 {

--- a/xbmc/platform/linux/FDEventMonitor.cpp
+++ b/xbmc/platform/linux/FDEventMonitor.cpp
@@ -16,6 +16,7 @@
 
 #include <poll.h>
 #include <sys/eventfd.h>
+#include <unistd.h>
 
 CFDEventMonitor::CFDEventMonitor() :
   CThread("FDEventMonitor")

--- a/xbmc/platform/linux/input/LIRC.cpp
+++ b/xbmc/platform/linux/input/LIRC.cpp
@@ -23,6 +23,7 @@
 #include <lirc/lirc_client.h>
 #include <sys/socket.h>
 #include <sys/un.h>
+#include <unistd.h>
 
 using namespace std::chrono_literals;
 

--- a/xbmc/platform/linux/powermanagement/LogindUPowerSyscall.cpp
+++ b/xbmc/platform/linux/powermanagement/LogindUPowerSyscall.cpp
@@ -9,6 +9,7 @@
 
 #include "LogindUPowerSyscall.h"
 
+#include "utils/StringUtils.h"
 #include "utils/log.h"
 
 #include <string.h>

--- a/xbmc/platform/win32/network/WSDiscoveryWin32.cpp
+++ b/xbmc/platform/win32/network/WSDiscoveryWin32.cpp
@@ -8,6 +8,7 @@
 
 #include "WSDiscoveryWin32.h"
 
+#include "utils/StringUtils.h"
 #include "utils/log.h"
 
 #include "platform/win32/CharsetConverter.h"

--- a/xbmc/playlists/PlayListXSPF.cpp
+++ b/xbmc/playlists/PlayListXSPF.cpp
@@ -11,6 +11,7 @@
 
 #include "FileItem.h"
 #include "URL.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/XBMCTinyXML.h"
 #include "utils/log.h"

--- a/xbmc/pvr/epg/EpgDatabase.cpp
+++ b/xbmc/pvr/epg/EpgDatabase.cpp
@@ -16,6 +16,7 @@
 #include "pvr/epg/EpgSearchFilter.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/StringUtils.h"
 #include "utils/log.h"
 
 #include <memory>

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -31,6 +31,7 @@
 #include "pvr/guilib/PVRGUIActionsTimers.h"
 #include "pvr/recordings/PVRRecording.h"
 #include "threads/IRunnable.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 

--- a/xbmc/utils/ContentUtils.cpp
+++ b/xbmc/utils/ContentUtils.cpp
@@ -9,6 +9,7 @@
 #include "ContentUtils.h"
 
 #include "FileItem.h"
+#include "utils/StringUtils.h"
 #include "video/VideoInfoTag.h"
 
 namespace

--- a/xbmc/utils/DumbBufferObject.cpp
+++ b/xbmc/utils/DumbBufferObject.cpp
@@ -15,7 +15,9 @@
 #include "windowing/gbm/WinSystemGbmEGLContext.h"
 
 #include <drm_fourcc.h>
+#include <fcntl.h>
 #include <sys/mman.h>
+#include <unistd.h>
 
 using namespace KODI::WINDOWING::GBM;
 

--- a/xbmc/utils/EGLImage.cpp
+++ b/xbmc/utils/EGLImage.cpp
@@ -11,6 +11,7 @@
 #include "ServiceBroker.h"
 #include "utils/DRMHelpers.h"
 #include "utils/EGLUtils.h"
+#include "utils/StringUtils.h"
 #include "utils/log.h"
 
 #include <map>

--- a/xbmc/utils/FileExtensionProvider.h
+++ b/xbmc/utils/FileExtensionProvider.h
@@ -8,14 +8,20 @@
 
 #pragma once
 
-#include "addons/AddonEvents.h"
-#include "addons/addoninfo/AddonInfo.h"
-#include "settings/AdvancedSettings.h"
+#include "addons/addoninfo/AddonType.h"
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace ADDON
 {
   class CAddonMgr;
+  struct AddonEvent;
 }
+
+class CAdvancedSettings;
 
 class CFileExtensionProvider
 {

--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -15,6 +15,7 @@
 #include "URIUtils.h"
 #include "Util.h"
 #include "Variant.h"
+#include "addons/IAddon.h"
 #include "guilib/LocalizeStrings.h"
 #include "music/tags/MusicInfoTag.h"
 #include "pictures/PictureInfoTag.h"

--- a/xbmc/utils/UDMABufferObject.cpp
+++ b/xbmc/utils/UDMABufferObject.cpp
@@ -12,9 +12,11 @@
 #include "utils/log.h"
 
 #include <drm_fourcc.h>
+#include <fcntl.h>
 #include <linux/udmabuf.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
+#include <unistd.h>
 
 namespace
 {

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -17,6 +17,7 @@
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingsManager.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 
 #include <cstring>
@@ -293,4 +294,9 @@ void CLog::SetComponentLogLevel(const std::vector<CVariant>& components)
 
     m_componentLogLevels |= static_cast<uint32_t>(component.asInteger());
   }
+}
+
+void CLog::FormatLineBreaks(std::string& message)
+{
+  StringUtils::Replace(message, "\n", "\n                                                   ");
 }

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -28,7 +28,6 @@
 #include "settings/lib/ISettingsHandler.h"
 #include "settings/lib/SettingDefinitions.h"
 #include "utils/IPlatformLog.h"
-#include "utils/StringUtils.h"
 #include "utils/logtypes.h"
 
 #include <string>
@@ -130,7 +129,7 @@ private:
     auto message = fmt::format(format, std::forward<Args>(args)...);
 
     // fixup newline alignment, number of spaces should equal prefix length
-    StringUtils::Replace(message, "\n", "\n                                                   ");
+    FormatLineBreaks(message);
 
     m_defaultLogger->log(level, message);
   }
@@ -138,6 +137,8 @@ private:
   Logger CreateLogger(const std::string& loggerName);
 
   void SetComponentLogLevel(const std::vector<CVariant>& components);
+
+  void FormatLineBreaks(std::string& message);
 
   std::unique_ptr<IPlatformLog> m_platform;
   std::shared_ptr<spdlog::sinks::dist_sink<std::mutex>> m_sinks;

--- a/xbmc/windowing/X11/GLContextEGL.cpp
+++ b/xbmc/windowing/X11/GLContextEGL.cpp
@@ -22,6 +22,7 @@
 #include <mutex>
 
 #include <EGL/eglext.h>
+#include <unistd.h>
 
 #include "system_gl.h"
 

--- a/xbmc/windowing/X11/VideoSyncOML.cpp
+++ b/xbmc/windowing/X11/VideoSyncOML.cpp
@@ -13,6 +13,8 @@
 #include "windowing/GraphicContext.h"
 #include "windowing/X11/WinSystemX11GLContext.h"
 
+#include <unistd.h>
+
 using namespace KODI::WINDOWING::X11;
 
 bool CVideoSyncOML::Setup(PUPDATECLOCK func)

--- a/xbmc/windowing/android/AndroidUtils.cpp
+++ b/xbmc/windowing/android/AndroidUtils.cpp
@@ -12,6 +12,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/SettingsManager.h"
+#include "utils/StringUtils.h"
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
 

--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
@@ -20,6 +20,7 @@
 #include "platform/android/activity/XBMCApp.h"
 
 #include <EGL/eglext.h>
+#include <unistd.h>
 
 void CWinSystemAndroidGLESContext::Register()
 {

--- a/xbmc/windowing/gbm/VideoSyncGbm.cpp
+++ b/xbmc/windowing/gbm/VideoSyncGbm.cpp
@@ -22,6 +22,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include <unistd.h>
+
 CVideoSyncGbm::CVideoSyncGbm(void* clock)
   : CVideoSync(clock), m_winSystem(CServiceBroker::GetWinSystem())
 {

--- a/xbmc/windowing/gbm/drm/DRMConnector.cpp
+++ b/xbmc/windowing/gbm/drm/DRMConnector.cpp
@@ -8,6 +8,7 @@
 
 #include "DRMConnector.h"
 
+#include "utils/XTimeUtils.h"
 #include "utils/log.h"
 
 #include <map>

--- a/xbmc/windowing/gbm/drm/DRMPlane.cpp
+++ b/xbmc/windowing/gbm/drm/DRMPlane.cpp
@@ -10,6 +10,7 @@
 
 #include "DRMUtils.h"
 #include "utils/DRMHelpers.h"
+#include "utils/StringUtils.h"
 #include "utils/log.h"
 
 using namespace KODI::WINDOWING::GBM;

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -26,6 +26,7 @@
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/StringUtils.h"
 #include "utils/SystemInfo.h"
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"


### PR DESCRIPTION
More or less random stuff I spotted while working on other things.

1) expensive header `utils/StringUtils.h` included in prominent header `utils/log.h` (and others), indirectly pulling `StringUtils` including its dependencies into many many cpp files.
2) expensive header `addons/IAddon.h` included in prominent header `FileItem.h`, indirectly pulling addon related types into many many cpp/h files completely unrelated to addon functionality.

Runtime-tested on macOS and Android, latest Kodi master.

@notspiff maybe you can do the review?