### PR TITLE
[library] Fix clean db on startup

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -44,7 +44,6 @@
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
-#include "video/VideoLibraryQueue.h"
 #include "video/VideoThumbLoader.h"
 
 #include <algorithm>
@@ -87,7 +86,7 @@ namespace VIDEO
       if (m_bClean && m_pathsToScan.empty())
       {
         std::set<int> paths;
-        CVideoLibraryQueue::GetInstance().CleanLibrary(paths, false, m_handle);
+        m_database.CleanDatabase(m_handle, paths, false);
 
         if (m_handle)
           m_handle->MarkFinished();
@@ -145,7 +144,7 @@ namespace VIDEO
       if (!bCancelled)
       {
         if (m_bClean)
-          CVideoLibraryQueue::GetInstance().CleanLibrary(m_pathsToClean, false, m_handle);
+          m_database.CleanDatabase(m_handle, m_pathsToClean, false);
         else
         {
           if (m_handle)


### PR DESCRIPTION
## Description
Clean llibrary on update got broken in Nexus in commit https://github.com/xbmc/xbmc/commit/b6bcdb6753a2044839b81e68eecfb8b88eebc66e since the cleaning job will not be scheduled if another database job is running at the same time. The implementation is correct and fixes the execution paths from the gui/settings window or from builtins if other tasks are running. 

However it caused a small regression on startup if `cleanonupdate` advanced setting is enabled - the scanning job itself may ask for a library cleanup before ending its execution. In such cases the cleanup will not run because there's already a library processing job (yeap, the one who have just asked for the cleanup).

Investigating the code, there's no reason to go via the singleton/job path in these situations since `VideoInfoScanner` already has access to the database and can simply execute the cleanup. That way we can still clean the library without going via job executions (which is protected for concurrency).
@Montellese for review if possible.

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/21728

## How has this been tested?
Runtime tested on linux

## What is the effect on users?
cleanonupdate advanced setting should be working again.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

