### PR TITLE
[pipewire] 'Restore' missing StringUtils includes

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -15,6 +15,7 @@
 #include "cores/AudioEngine/Sinks/pipewire/PipewireNode.h"
 #include "cores/AudioEngine/Sinks/pipewire/PipewireStream.h"
 #include "cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.h"
+#include "utils/StringUtils.h"
 #include "utils/log.h"
 
 #include <pipewire/keys.h>

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
@@ -10,6 +10,7 @@
 
 #include "cores/AudioEngine/Sinks/pipewire/Pipewire.h"
 #include "cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.h"
+#include "utils/StringUtils.h"
 #include "utils/log.h"
 
 #include <spa/param/format.h>


### PR DESCRIPTION
## Description
Builds with pipewire got broken in https://github.com/xbmc/xbmc/pull/21975 due to the removal of StringUtils header for log.h.

## Motivation and context
Compile Kodi, and complete hacktoberfest :)

## How has this been tested?
Builds (`ENABLE_PIPEWIRE: ON`)

