### PR TITLE
[tvOS] Reduce Siri remote pan gesture sensitivity

### DIFF
--- a/system/settings/darwin_tvos.xml
+++ b/system/settings/darwin_tvos.xml
@@ -71,21 +71,21 @@
         <!-- Siri remote sensitivity -->
         <setting id="input.siriremotehorizontalsensitivity" type="integer" label="34009">
           <level>2</level>
-          <default>400</default>
+          <default>1000</default>
           <constraints>
             <minimum>50</minimum>
             <step>50</step>
-            <maximum>1000</maximum>
+            <maximum>1500</maximum>
           </constraints>
           <control type="spinner" format="integer" delayed="false"/>
         </setting>
         <setting id="input.siriremoteverticalsensitivity" type="integer" label="34010">
           <level>2</level>
-          <default>300</default>
+          <default>550</default>
           <constraints>
             <minimum>50</minimum>
             <step>50</step>
-            <maximum>1000</maximum>
+            <maximum>1500</maximum>
           </constraints>
           <control type="spinner" format="integer" delayed="false"/>
         </setting>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
As reported [here](https://forum.kodi.tv/showthread.php?tid=368368), the refactoring of the Siri remote pan gesture merged from https://github.com/xbmc/xbmc/pull/19744 introduces issues: the pan gesture sensitivity is too hight and the user experience is bad (a feeling of crazy remote).

This PR increase default values of the pan gesture sensitivity to fix the user experience.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Kodi UI control is really bad with a Siri remote ATM.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Runtime test on Apple TV 4K.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Better Siri remote gesture experience.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
