### PR TITLE
[PVR] Fix CPVRChannelNumberInputHandler timer handling.

### DIFF
--- a/xbmc/pvr/PVRChannelNumberInputHandler.cpp
+++ b/xbmc/pvr/PVRChannelNumberInputHandler.cpp
@@ -62,7 +62,7 @@ void CPVRChannelNumberInputHandler::OnTimeout()
 
 void CPVRChannelNumberInputHandler::ExecuteAction()
 {
-  m_timer.Stop();
+  m_timer.Stop(true /* wait until worker thread ended */);
   OnTimeout();
 }
 


### PR DESCRIPTION
Direct channel number input has a special feature to ensure the typed number actually can be recognized on screen. 

Whenever a new digit is entered, we check whether we now have a unique channel number. For example, when we have only 1 and 10 as channel numbers, after entering 1, we wait for another couple of seconds for more input as we do not know whether user wants to switch to channel 1 or 10. If noting more gets entered, we automatically switch to channel 1 after the grace period. If 0 gets entered after 1, there is no need to wait as 10 is unique and we can switch to channel 10 immediately. In this situation, the entered number will be displayed on screen for another half second, to give user feedback. Otherwise they would see "1" on screen, but no "10" even after entering the "0" (I hope this is somehow understandable, not so easy to explain I feel).

Having that said, the .5 seconds delay feature somehow got broken and will be restored by this PR.

Technically, to fix this, we need to wait for the involved thread to finish (we did not before this PR), otherwise we cannot determine whether to start the .5 seconds delay. => https://github.com/xbmc/xbmc/blob/master/xbmc/pvr/PVRChannelNumberInputHandler.cpp#L48-L59

Runtime-tested on macOS, latest Kodi master.

@phunkyfish I keep you busy. ;-)