### PR TITLE
CDMAHeapBufferObject: add includes to fix build

### DIFF
--- a/xbmc/utils/DMAHeapBufferObject.cpp
+++ b/xbmc/utils/DMAHeapBufferObject.cpp
@@ -15,9 +15,11 @@
 #include <array>
 
 #include <drm_fourcc.h>
+#include <fcntl.h>
 #include <linux/dma-heap.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
+#include <unistd.h>
 
 namespace
 {


### PR DESCRIPTION
Some of the header cleanups seems to have broken some code paths that aren't built by CI.

without:
```
/home/lukas/Documents/git/xbmc/xbmc/utils/DMAHeapBufferObject.cpp:44:14: error: ‘open’ was not declared in this scope; did you mean ‘popen’?
   44 |     int fd = open(path, O_RDWR);
      |              ^~~~

/home/lukas/Documents/git/xbmc/xbmc/utils/DMAHeapBufferObject.cpp:144:13: error: ‘close’ was not declared in this scope; did you mean ‘pclose’?
  144 |   int ret = close(m_fd);
      |             ^~~~~
```