### PR TITLE
fixed: the GetMessage name potentially conflicts with windows defines

### DIFF
--- a/xbmc/commons/Exception.h
+++ b/xbmc/commons/Exception.h
@@ -80,7 +80,7 @@ namespace XbmcCommons
 
     virtual void LogThrowMessage(const char* prefix = NULL) const;
 
-    inline virtual const char* GetMessage() const { return message.c_str(); }
+    inline virtual const char* GetExMessage() const { return message.c_str(); }
   };
 
   /**

--- a/xbmc/interfaces/python/PythonSwig.cpp.template
+++ b/xbmc/interfaces/python/PythonSwig.cpp.template
@@ -220,16 +220,16 @@ void doMethod(Node method, MethodType methodType)
     }
     catch (const XBMCAddon::WrongTypeException& e)
     {
-      CLog::Log(LOGERROR,"EXCEPTION: {}",e.GetMessage());
-      PyErr_SetString(PyExc_TypeError, e.GetMessage()); <%
+      CLog::Log(LOGERROR,"EXCEPTION: {}",e.GetExMessage());
+      PyErr_SetString(PyExc_TypeError, e.GetExMessage()); <%
       if (!destructor) {  %>
       return NULL; <%
       } %>
     }
     catch (const XbmcCommons::Exception& e)
     {
-      CLog::Log(LOGERROR,"EXCEPTION: {}",e.GetMessage());
-      PyErr_SetString(PyExc_RuntimeError, e.GetMessage()); <%
+      CLog::Log(LOGERROR,"EXCEPTION: {}",e.GetExMessage());
+      PyErr_SetString(PyExc_RuntimeError, e.GetExMessage()); <%
       if (!destructor) {  %>
       return NULL; <%
       } %>
@@ -464,14 +464,14 @@ void doClassMethodInfo(Node clazz, List initTypeCalls)
     }
     catch (const XBMCAddon::WrongTypeException& e)
     {
-      CLog::Log(LOGERROR,"EXCEPTION: {}",e.GetMessage());
-      PyErr_SetString(PyExc_TypeError, e.GetMessage());
+      CLog::Log(LOGERROR,"EXCEPTION: {}",e.GetExMessage());
+      PyErr_SetString(PyExc_TypeError, e.GetExMessage());
       return NULL;
     }
     catch (const XbmcCommons::Exception& e)
     {
-      CLog::Log(LOGERROR,"EXCEPTION: {}",e.GetMessage());
-      PyErr_SetString(PyExc_RuntimeError, e.GetMessage());
+      CLog::Log(LOGERROR,"EXCEPTION: {}",e.GetExMessage());
+      PyErr_SetString(PyExc_RuntimeError, e.GetExMessage());
       return NULL;
     }
     catch (...)
@@ -498,14 +498,14 @@ void doClassMethodInfo(Node clazz, List initTypeCalls)
     }
     catch (const XBMCAddon::WrongTypeException& e)
     {
-      CLog::Log(LOGERROR,"EXCEPTION: {}",e.GetMessage());
-      PyErr_SetString(PyExc_TypeError, e.GetMessage());
+      CLog::Log(LOGERROR,"EXCEPTION: {}",e.GetExMessage());
+      PyErr_SetString(PyExc_TypeError, e.GetExMessage());
       return -1;
     }
     catch (const XbmcCommons::Exception& e)
     {
-      CLog::Log(LOGERROR,"EXCEPTION: {}",e.GetMessage());
-      PyErr_SetString(PyExc_RuntimeError, e.GetMessage());
+      CLog::Log(LOGERROR,"EXCEPTION: {}",e.GetExMessage());
+      PyErr_SetString(PyExc_RuntimeError, e.GetExMessage());
       return -1;
     }
     catch (...)
@@ -563,14 +563,14 @@ void doClassMethodInfo(Node clazz, List initTypeCalls)
     }
     catch (const XBMCAddon::WrongTypeException& e)
     {
-      CLog::Log(LOGERROR,"EXCEPTION: {}",e.GetMessage());
-      PyErr_SetString(PyExc_TypeError, e.GetMessage());
+      CLog::Log(LOGERROR,"EXCEPTION: {}",e.GetExMessage());
+      PyErr_SetString(PyExc_TypeError, e.GetExMessage());
       return NULL;
     }
     catch (const XbmcCommons::Exception& e)
     {
-      CLog::Log(LOGERROR,"EXCEPTION: {}",e.GetMessage());
-      PyErr_SetString(PyExc_RuntimeError, e.GetMessage());
+      CLog::Log(LOGERROR,"EXCEPTION: {}",e.GetExMessage());
+      PyErr_SetString(PyExc_RuntimeError, e.GetExMessage());
       return NULL;
     }
     catch (...)
@@ -604,14 +604,14 @@ void doClassMethodInfo(Node clazz, List initTypeCalls)
     }
     catch (const XBMCAddon::WrongTypeException& e)
     {
-      CLog::Log(LOGERROR,"EXCEPTION: {}",e.GetMessage());
-      PyErr_SetString(PyExc_TypeError, e.GetMessage());
+      CLog::Log(LOGERROR,"EXCEPTION: {}",e.GetExMessage());
+      PyErr_SetString(PyExc_TypeError, e.GetExMessage());
       return NULL;
     }
     catch (const XbmcCommons::Exception& e)
     {
-      CLog::Log(LOGERROR,"EXCEPTION: {}",e.GetMessage());
-      PyErr_SetString(PyExc_RuntimeError, e.GetMessage());
+      CLog::Log(LOGERROR,"EXCEPTION: {}",e.GetExMessage());
+      PyErr_SetString(PyExc_RuntimeError, e.GetExMessage());
       return NULL;
     }
     catch (...)

--- a/xbmc/interfaces/python/swig.h
+++ b/xbmc/interfaces/python/swig.h
@@ -193,8 +193,8 @@ namespace PythonBindings
       }
       catch (const XBMCAddon::WrongTypeException& e)
       {
-        CLog::Log(LOGERROR, "EXCEPTION: {}", e.GetMessage());
-        PyErr_SetString(PyExc_RuntimeError, e.GetMessage());
+        CLog::Log(LOGERROR, "EXCEPTION: {}", e.GetExMessage());
+        PyErr_SetString(PyExc_RuntimeError, e.GetExMessage());
       }
       return -1;
     }

--- a/xbmc/network/httprequesthandler/python/HTTPPythonWsgiInvoker.cpp
+++ b/xbmc/network/httprequesthandler/python/HTTPPythonWsgiInvoker.cpp
@@ -208,12 +208,12 @@ void CHTTPPythonWsgiInvoker::executeScript(FILE* fp, const std::string& script, 
   catch (const XBMCAddon::WrongTypeException& e)
   {
     logger->error("failed to prepare WsgiResponse object with wrong type exception: {}",
-                  e.GetMessage());
+                  e.GetExMessage());
     goto cleanup;
   }
   catch (const XbmcCommons::Exception& e)
   {
-    logger->error("failed to prepare WsgiResponse object with exception: {}", e.GetMessage());
+    logger->error("failed to prepare WsgiResponse object with exception: {}", e.GetExMessage());
     goto cleanup;
   }
   catch (...)
@@ -255,12 +255,12 @@ void CHTTPPythonWsgiInvoker::executeScript(FILE* fp, const std::string& script, 
     catch (const XBMCAddon::WrongTypeException& e)
     {
       logger->error("failed to parse result iterable object with wrong type exception: {}",
-                    e.GetMessage());
+                    e.GetExMessage());
       goto cleanup;
     }
     catch (const XbmcCommons::Exception& e)
     {
-      logger->error("failed to parse result iterable object with exception: {}", e.GetMessage());
+      logger->error("failed to parse result iterable object with exception: {}", e.GetExMessage());
       goto cleanup;
     }
     catch (...)


### PR DESCRIPTION
## Description
See title. rename to GetExMessage to avoid the issue

## Motivation and context
Less sensitivity to moving Windows.h around when clang-format throws a fit..

## How has this been tested?
It builds.

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
