### PR TITLE
Support UTF-8 Encoded M3U Playlists

### DIFF
--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -305,9 +305,8 @@ void CGUIWindowMusicPlayList::SavePlayList()
   std::string strNewFileName;
   if (CGUIKeyboardFactory::ShowAndGetInput(strNewFileName, CVariant{g_localizeStrings.Get(16012)}, false))
   {
-    // need 2 rename it
     strNewFileName = CUtil::MakeLegalFileName(strNewFileName);
-    strNewFileName += ".m3u";
+    strNewFileName += ".m3u8";
     std::string strPath = URIUtils::AddFileToFolder(
       CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_SYSTEM_PLAYLISTSPATH),
       "music",

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
@@ -342,7 +342,7 @@ void CGUIWindowMusicPlaylistEditor::OnLoadPlaylist()
   // Prompt user for file to load from music playlists folder
   std::string playlist;
   if (CGUIDialogFileBrowser::ShowAndGetFile("special://musicplaylists/",
-                                            ".m3u|.pls|.b4s|.wpl|.xspf", g_localizeStrings.Get(656),
+                                            ".m3u|.m3u8|.pls|.b4s|.wpl|.xspf", g_localizeStrings.Get(656),
                                             playlist))
     LoadPlaylist(playlist);
 }
@@ -371,16 +371,20 @@ void CGUIWindowMusicPlaylistEditor::OnSavePlaylist()
 {
   // saves playlist to the playlist folder
   std::string name = URIUtils::GetFileName(m_strLoadedPlaylist);
-  URIUtils::RemoveExtension(name);
+  std::string extension = URIUtils::GetExtension(m_strLoadedPlaylist);
+  if (extension.empty())
+    extension = ".m3u8";
+  else
+    URIUtils::RemoveExtension(name);
 
   if (CGUIKeyboardFactory::ShowAndGetInput(name, CVariant{g_localizeStrings.Get(16012)}, false))
-  { // save playlist as an .m3u
+  {
     PLAYLIST::CPlayListM3U playlist;
     playlist.Add(*m_playlist);
     std::string path = URIUtils::AddFileToFolder(
       CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_SYSTEM_PLAYLISTSPATH),
       "music",
-      name + ".m3u");
+      name + extension);
 
     playlist.Save(path);
     m_strLoadedPlaylist = name;

--- a/xbmc/playlists/PlayListFactory.cpp
+++ b/xbmc/playlists/PlayListFactory.cpp
@@ -71,7 +71,7 @@ CPlayList* CPlayListFactory::Create(const CFileItem& item)
   std::string extension = URIUtils::GetExtension(path);
   StringUtils::ToLower(extension);
 
-  if (extension == ".m3u" || extension == ".strm")
+  if (extension == ".m3u" || (extension == ".m3u8" && !item.IsInternetStream()) || extension == ".strm")
     return new CPlayListM3U();
 
   if (extension == ".pls")
@@ -134,12 +134,12 @@ bool CPlayListFactory::IsPlaylist(const CFileItem& item)
 bool CPlayListFactory::IsPlaylist(const CURL& url)
 {
   return URIUtils::HasExtension(url,
-                                ".m3u|.b4s|.pls|.strm|.wpl|.asx|.ram|.url|.pxml|.xspf");
+                                ".m3u|.m3u8|.b4s|.pls|.strm|.wpl|.asx|.ram|.url|.pxml|.xspf");
 }
 
 bool CPlayListFactory::IsPlaylist(const std::string& filename)
 {
   return URIUtils::HasExtension(filename,
-                     ".m3u|.b4s|.pls|.strm|.wpl|.asx|.ram|.url|.pxml|.xspf");
+                     ".m3u|.m3u8|.b4s|.pls|.strm|.wpl|.asx|.ram|.url|.pxml|.xspf");
 }
 

--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -69,6 +69,10 @@ bool CPlayListM3U::Load(const std::string& strFileName)
   int iStartOffset = 0;
   int iEndOffset = 0;
 
+  bool utf8 = false;
+  if (URIUtils::GetExtension(strFileName) == ".m3u8")
+    utf8 = true;
+
   Clear();
 
   m_strPlayListName = URIUtils::GetFileName(strFileName);
@@ -101,7 +105,8 @@ bool CPlayListM3U::Load(const std::string& strFileName)
         lDuration = atoi(strLength.c_str());
         iComma++;
         strInfo = strLine.substr(iComma);
-        g_charsetConverter.unknownToUTF8(strInfo);
+        if (!utf8)
+          g_charsetConverter.unknownToUTF8(strInfo);
       }
     }
     else if (StringUtils::StartsWith(strLine, OffsetMarker))
@@ -150,7 +155,8 @@ bool CPlayListM3U::Load(const std::string& strFileName)
 
       if (strFileName.length() > 0)
       {
-        g_charsetConverter.unknownToUTF8(strFileName);
+        if (!utf8)
+          g_charsetConverter.unknownToUTF8(strFileName);
 
         // If no info was read from from the extended tag information, use the file name
         if (strInfo.length() == 0)
@@ -211,6 +217,9 @@ void CPlayListM3U::Save(const std::string& strFileName) const
 {
   if (!m_vecItems.size())
     return;
+  bool utf8 = false;
+  if (URIUtils::GetExtension(strFileName) == ".m3u8")
+    utf8 = true;
   std::string strPlaylist = CUtil::MakeLegalPath(strFileName);
   CFile file;
   if (!file.OpenForWrite(strPlaylist,true))
@@ -226,7 +235,8 @@ void CPlayListM3U::Save(const std::string& strFileName) const
   {
     CFileItemPtr item = m_vecItems[i];
     std::string strDescription=item->GetLabel();
-    g_charsetConverter.utf8ToStringCharset(strDescription);
+    if (!utf8)
+      g_charsetConverter.utf8ToStringCharset(strDescription);
     strLine = StringUtils::Format("{}:{},{}\n", InfoMarker,
                                   item->GetMusicInfoTag()->GetDuration(), strDescription);
     if (file.Write(strLine.c_str(), strLine.size()) != static_cast<ssize_t>(strLine.size()))
@@ -238,7 +248,8 @@ void CPlayListM3U::Save(const std::string& strFileName) const
       file.Write(strLine.c_str(),strLine.size());
     }
     std::string strFileName = ResolveURL(item);
-    g_charsetConverter.utf8ToStringCharset(strFileName);
+    if (!utf8)
+      g_charsetConverter.utf8ToStringCharset(strFileName);
     strLine = StringUtils::Format("{}\n", strFileName);
     if (file.Write(strLine.c_str(), strLine.size()) != static_cast<ssize_t>(strLine.size()))
       return; // error

--- a/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
+++ b/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
@@ -399,7 +399,7 @@ void CGUIWindowVideoPlaylist::SavePlayList()
   {
     // need 2 rename it
     strNewFileName = CUtil::MakeLegalFileName(strNewFileName);
-    strNewFileName += ".m3u";
+    strNewFileName += ".m3u8";
     std::string strPath = URIUtils::AddFileToFolder(
       CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_SYSTEM_PLAYLISTSPATH),
       "video",


### PR DESCRIPTION
## Description
This PR adds support for UTF-8 encoded M3U playlists with file extension `.m3u8`.

### Current Behavior
Kodi can read UTF-8 encoded data in an M3U playlist created by another program, but only for the `.m3u` file extension, not `.m3u8`. The bigger issue is with the playlist editing feature. When saving a playlist, Kodi strips out any characters that are not in the locale's default non-Unicode encoding. This means that any files with paths that contain Unicode characters can't be played back, even though Kodi never raised any errors when the playlist was saved.

### Proposed Implementation
Write M3U8 format by default for all *new* playlists. When editing existing playlists, preserve its file extension.

## Motivation and context
This has been a longstanding issue and feature request. See the following:
- [https://forum.kodi.tv/showthread.php?tid=348581](https://forum.kodi.tv/showthread.php?tid=348581)
- [https://forum.kodi.tv/showthread.php?tid=279902](https://forum.kodi.tv/showthread.php?tid=279902)
- #17835

## How has this been tested?
- Verified new playlists are created as `.m3u8`
- Verified saving an existing `.m3u` playlist does not convert it to `.m3u8`
- Verified HLS streaming still works (it also uses .m3u8 file extension)  

## What is the effect on users?
Feature request is implemented. See **Motivation and context** section

## Screenshots (if appropriate):
N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
