### PR TITLE
Simple FoldCase for Turkish-I issue #19883

### DIFF
--- a/xbmc/utils/AlarmClock.cpp
+++ b/xbmc/utils/AlarmClock.cpp
@@ -31,8 +31,7 @@ CAlarmClock::~CAlarmClock() = default;
 void CAlarmClock::Start(const std::string& strName, float n_secs, const std::string& strCommand, bool bSilent /* false */, bool bLoop /* false */)
 {
   // make lower case so that lookups are case-insensitive
-  std::string lowerName(strName);
-  StringUtils::ToLower(lowerName);
+  std::string lowerName = StringUtils::FoldCase(strName);
   Stop(lowerName);
   SAlarmClockEvent event;
   event.m_fSecs = static_cast<double>(n_secs);
@@ -82,8 +81,7 @@ void CAlarmClock::Stop(const std::string& strName, bool bSilent /* false */)
 {
   std::unique_lock<CCriticalSection> lock(m_events);
 
-  std::string lowerName(strName);
-  StringUtils::ToLower(lowerName);          // lookup as lowercase only
+  std::string lowerName = StringUtils::FoldCase(strName);
   std::map<std::string,SAlarmClockEvent>::iterator iter = m_event.find(lowerName);
 
   if (iter == m_event.end())

--- a/xbmc/utils/CharsetDetection.cpp
+++ b/xbmc/utils/CharsetDetection.cpp
@@ -71,7 +71,11 @@ bool CCharsetDetection::DetectXmlEncoding(const char* const xmlContent, const si
   /* try to read encoding from XML declaration */
   if (GetXmlEncodingFromDeclaration(xmlContent, contentLength, detectedEncoding))
   {
-    StringUtils::ToUpper(detectedEncoding);
+    // It would be cleaner to use FoldCase (FoldCaseUpper is unstandard), but it
+    // would require everything compared against "detectedEncoding" to be changed to
+    // lower case. Not a big change, but add some risk.
+
+    detectedEncoding = StringUtils::FoldCaseUpper(detectedEncoding);
 
     /* make some safety checks */
     if (detectedEncoding == "UTF-8")
@@ -113,7 +117,7 @@ bool CCharsetDetection::DetectXmlEncoding(const char* const xmlContent, const si
 
   /* found encoding in converted XML declaration, we know correct endianness and number of bytes per char */
   /* make some safety checks */
-  StringUtils::ToUpper(declaredEncoding);
+  declaredEncoding = StringUtils::FoldCaseUpper(declaredEncoding);
   if (declaredEncoding == guessedEncoding)
     return true;
 

--- a/xbmc/utils/Crc32.cpp
+++ b/xbmc/utils/Crc32.cpp
@@ -103,8 +103,7 @@ uint32_t Crc32::Compute(const std::string& strValue)
 
 uint32_t Crc32::ComputeFromLowerCase(const std::string& strValue)
 {
-  std::string strLower = strValue;
-  StringUtils::ToLower(strLower);
-  return Compute(strLower);
+  std::string strFolded = StringUtils::FoldCase(strValue);
+  return Compute(strFolded);
 }
 

--- a/xbmc/utils/Digest.cpp
+++ b/xbmc/utils/Digest.cpp
@@ -68,8 +68,7 @@ std::string CDigest::TypeToString(Type type)
 
 CDigest::Type CDigest::TypeFromString(std::string const& type)
 {
-  std::string typeLower{type};
-  StringUtils::ToLower(typeLower);
+  std::string typeLower = StringUtils::FoldCase(type);
   if (type == "md5")
   {
     return Type::MD5;

--- a/xbmc/utils/FileExtensionProvider.cpp
+++ b/xbmc/utils/FileExtensionProvider.cpp
@@ -104,8 +104,7 @@ bool CFileExtensionProvider::CanOperateExtension(const std::string& path) const
    */
 
   // Get file extensions to find addon related to it.
-  std::string strExtension = URIUtils::GetExtension(path);
-  StringUtils::ToLower(strExtension);
+  std::string strExtension = StringUtils::FoldCase(URIUtils::GetExtension(path));
   if (!strExtension.empty() && CServiceBroker::IsAddonInterfaceUp())
   {
     std::vector<std::unique_ptr<KODI::ADDONS::IAddonSupportCheck>> supportList;

--- a/xbmc/utils/HttpHeader.cpp
+++ b/xbmc/utils/HttpHeader.cpp
@@ -76,7 +76,7 @@ bool CHttpHeader::ParseLine(const std::string& headerLine)
     std::string strValue(headerLine, valueStart + 1);
 
     StringUtils::Trim(strParam, m_whitespaceChars);
-    StringUtils::ToLower(strParam);
+    strParam = StringUtils::FoldCase(strParam);
 
     StringUtils::Trim(strValue, m_whitespaceChars);
 
@@ -93,8 +93,7 @@ bool CHttpHeader::ParseLine(const std::string& headerLine)
 
 void CHttpHeader::AddParam(const std::string& param, const std::string& value, const bool overwrite /*= false*/)
 {
-  std::string paramLower(param);
-  StringUtils::ToLower(paramLower);
+  std::string paramLower = StringUtils::FoldCase(param);
   StringUtils::Trim(paramLower, m_whitespaceChars);
   if (paramLower.empty())
     return;
@@ -122,8 +121,7 @@ void CHttpHeader::AddParam(const std::string& param, const std::string& value, c
 
 std::string CHttpHeader::GetValue(const std::string& strParam) const
 {
-  std::string paramLower(strParam);
-  StringUtils::ToLower(paramLower);
+  std::string paramLower = StringUtils::FoldCase(strParam);
 
   return GetValueRaw(paramLower);
 }
@@ -142,7 +140,7 @@ std::string CHttpHeader::GetValueRaw(const std::string& strParam) const
 
 std::vector<std::string> CHttpHeader::GetValues(std::string strParam) const
 {
-  StringUtils::ToLower(strParam);
+  strParam = StringUtils::FoldCase(strParam);
   std::vector<std::string> values;
 
   for (HeaderParams::const_iterator iter = m_params.begin(); iter != m_params.end(); ++iter)
@@ -180,11 +178,10 @@ std::string CHttpHeader::GetMimeType(void) const
 
 std::string CHttpHeader::GetCharset(void) const
 {
-  std::string strValue(GetValueRaw("content-type"));
+  std::string strValue = StringUtils::FoldCaseUpper(GetValueRaw("content-type"));
   if (strValue.empty())
     return strValue;
 
-  StringUtils::ToUpper(strValue);
   const size_t len = strValue.length();
 
   // extract charset value from 'contenttype/contentsubtype;pram1=param1Val ; charset=XXXX\t;param2=param2Val'

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -71,9 +71,8 @@ void CLangCodeExpander::LoadUserCodes(const TiXmlElement* pRootElement)
       const TiXmlNode* pLong = pLangCode->FirstChildElement("long");
       if (pShort != NULL && pLong != NULL)
       {
-        sShort = pShort->FirstChild()->Value();
+        sShort = StringUtils::FoldCase(pShort->FirstChild()->Value());
         sLong = pLong->FirstChild()->Value();
-        StringUtils::ToLower(sShort);
 
         m_mapUser[sShort] = sLong;
       }
@@ -138,8 +137,8 @@ bool CLangCodeExpander::ConvertISO6391ToISO6392B(const std::string& strISO6391,
   if (strISO6391.length() != 2)
     return false;
 
-  std::string strISO6391Lower(strISO6391);
-  StringUtils::ToLower(strISO6391Lower);
+  std::string strISO6391Lower = StringUtils::FoldCase(strISO6391);
+
   StringUtils::Trim(strISO6391Lower);
 
   for (const auto& codes : LanguageCodes)
@@ -174,8 +173,7 @@ bool CLangCodeExpander::ConvertToISO6392B(const std::string& strCharCode,
 
   if (strCharCode.size() == 3)
   {
-    std::string charCode(strCharCode);
-    StringUtils::ToLower(charCode);
+    std::string charCode = StringUtils::FoldCase(strCharCode);
     for (const auto& codes : LanguageCodes)
     {
       if (charCode == codes.iso639_2b ||
@@ -255,8 +253,7 @@ bool CLangCodeExpander::ConvertISO31661Alpha2ToISO31661Alpha3(const std::string&
   if (strISO31661Alpha2.length() != 2)
     return false;
 
-  std::string strLower(strISO31661Alpha2);
-  StringUtils::ToLower(strLower);
+  std::string strLower = StringUtils::FoldCase(strISO31661Alpha2);
   StringUtils::Trim(strLower);
   for (const auto& codes : RegionCodes)
   {
@@ -276,8 +273,7 @@ bool CLangCodeExpander::ConvertWindowsLanguageCodeToISO6392B(
   if (strWindowsLanguageCode.length() != 3)
     return false;
 
-  std::string strLower(strWindowsLanguageCode);
-  StringUtils::ToLower(strLower);
+  std::string strLower = StringUtils::FoldCase(strWindowsLanguageCode);
   for (const auto& codes : LanguageCodes)
   {
     if ((codes.win_id && strLower == codes.win_id) || strLower == codes.iso639_2b)
@@ -311,8 +307,7 @@ bool CLangCodeExpander::ConvertToISO6391(const std::string& lang, std::string& c
   }
   else if (lang.length() == 3)
   {
-    std::string lower(lang);
-    StringUtils::ToLower(lower);
+    std::string lower = StringUtils::FoldCase(lang);
     for (const auto& codes : LanguageCodes)
     {
       if (lower == codes.iso639_2b || (codes.win_id && lower == codes.win_id))
@@ -405,8 +400,7 @@ bool CLangCodeExpander::LookupInUserMap(const std::string& code, std::string& de
     return false;
 
   // make sure we convert to lowercase before trying to find it
-  std::string sCode(code);
-  StringUtils::ToLower(sCode);
+  std::string sCode = StringUtils::FoldCase(code);
   StringUtils::Trim(sCode);
 
   STRINGLOOKUPTABLE::iterator it = m_mapUser.find(sCode);
@@ -424,9 +418,8 @@ bool CLangCodeExpander::LookupInLangAddons(const std::string& code, std::string&
   if (code.empty())
     return false;
 
-  std::string sCode{code};
+  std::string sCode = StringUtils::FoldCase(code);
   StringUtils::Trim(sCode);
-  StringUtils::ToLower(sCode);
   StringUtils::Replace(sCode, '-', '_');
 
   desc = g_langInfo.GetEnglishLanguageName(sCode);
@@ -439,8 +432,7 @@ bool CLangCodeExpander::LookupInISO639Tables(const std::string& code, std::strin
     return false;
 
   long longcode;
-  std::string sCode(code);
-  StringUtils::ToLower(sCode);
+  std::string sCode = StringUtils::FoldCase(code);
   StringUtils::Trim(sCode);
 
   if (sCode.length() == 2)

--- a/xbmc/utils/Locale.cpp
+++ b/xbmc/utils/Locale.cpp
@@ -95,9 +95,7 @@ std::string CLocale::ToStringLC() const
   if (!m_valid)
     return "";
 
-  std::string locale = ToString();
-  StringUtils::ToLower(locale);
-
+  std::string locale = StringUtils::FoldCase(ToString());
   return locale;
 }
 
@@ -119,8 +117,7 @@ std::string CLocale::ToShortStringLC() const
   if (!m_valid)
     return "";
 
-  std::string locale = ToShortString();
-  StringUtils::ToLower(locale);
+  std::string locale = StringUtils::FoldCase(ToShortString());
 
   return locale;
 }
@@ -239,14 +236,12 @@ bool CLocale::ParseLocale(const std::string &locale, std::string &language, std:
   pos = tmp.find('_');
   if (pos != std::string::npos)
   {
-    territory = tmp.substr(pos + 1);
-    StringUtils::ToUpper(territory);
+    territory = StringUtils::FoldCaseUpper(tmp.substr(pos + 1));
     tmp = tmp.substr(0, pos);
   }
 
   // what remains is the language
-  language = tmp;
-  StringUtils::ToLower(language);
+  language = StringUtils::FoldCase(tmp);
 
   return CheckValidity(language, territory, codeset, modifier);
 }
@@ -256,8 +251,8 @@ void CLocale::Initialize()
   m_valid = CheckValidity(m_language, m_territory, m_codeset, m_modifier);
   if (m_valid)
   {
-    StringUtils::ToLower(m_language);
-    StringUtils::ToUpper(m_territory);
+    m_language = StringUtils::FoldCase(m_language);
+    m_territory = StringUtils::FoldCaseUpper(m_territory);
   }
 }
 

--- a/xbmc/utils/Mime.cpp
+++ b/xbmc/utils/Mime.cpp
@@ -523,7 +523,7 @@ std::string CMime::GetMimeType(const std::string &extension)
   size_t posNotPoint = ext.find_first_not_of('.');
   if (posNotPoint != std::string::npos && posNotPoint > 0)
     ext = extension.substr(posNotPoint);
-  transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+  ext = StringUtils::FoldCase(ext);
 
   std::map<std::string, std::string>::const_iterator it = m_mimetypes.find(ext);
   if (it != m_mimetypes.end())
@@ -693,8 +693,8 @@ bool CMime::parseMimeType(const std::string& mimeType, std::string& type, std::s
     return false;
   }
 
-  StringUtils::ToLower(type);
-  StringUtils::ToLower(subtype);
+  type = StringUtils::FoldCase(type);
+  subtype = StringUtils::FoldCase(subtype);
 
   return true;
 }

--- a/xbmc/utils/ScraperParser.cpp
+++ b/xbmc/utils/ScraperParser.cpp
@@ -247,7 +247,7 @@ void CScraperParser::ParseExpression(const std::string& input, std::string& dest
     int iCompare = -1;
     pExpression->QueryIntAttribute("compare",&iCompare);
     if (iCompare > -1)
-      StringUtils::ToLower(m_param[iCompare-1]);
+      m_param[iCompare - 1] = StringUtils::FoldCase(m_param[iCompare - 1]);
     std::string curInput = input;
     for (int iBuf=0;iBuf<MAX_SCRAPER_BUFFERS;++iBuf)
     {
@@ -307,8 +307,7 @@ void CScraperParser::ParseExpression(const std::string& input, std::string& dest
         ReplaceBuffers(strResult);
         if (iCompare > -1)
         {
-          std::string strResultNoCase = strResult;
-          StringUtils::ToLower(strResultNoCase);
+          std::string strResultNoCase = StringUtils::FoldCase(strResult);
           if (strResultNoCase.find(m_param[iCompare-1]) != std::string::npos)
             dest += strResult;
         }

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -30,13 +30,16 @@
 #include "LangInfo.h"
 #include "StringUtils.h"
 #include "XBDateTime.h"
+#include "utils/log.h"
 
 #include <algorithm>
 #include <array>
 #include <assert.h>
+#include <codecvt>
 #include <functional>
 #include <inttypes.h>
 #include <iomanip>
+#include <locale>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -76,12 +79,33 @@ static constexpr const char* ADDON_GUID_RE = "^(\\{){0,1}[0-9a-fA-F]{8}\\-[0-9a-
 /* empty string for use in returns by ref */
 const std::string StringUtils::Empty = "";
 
+// TODO: Review use of unicode_lowers & unicode_uppers. I believe they should be eliminated
+// and replaced with std::tolower/toupper
+//
+// The use of unicode_lowers and unicode_uppers predates Kodi 20. It is used for wstring ToLower
+// and ToUpper methods instead of c++ tolower/toupper. This is different from std::string Tolower
+// and ToUpper which do use c++ tolower/toupper. This is puzzling since the behavior is
+// significantly different. One of the differences is that these tables ignore locale, while
+// std::tolower(c, locale) & std:toupper(c, locale) ONLY change the case of characters
+// which are in the given (or current) locale.
+//
+// It is also possible that these tables were used to get some of the benefits of "FoldCase"
+// (perhaps not realizing it). FoldCase uses much newer and more complete tables from ICU
+// (see unicode_fold_upper & unicode_fold_lower, below).
+//
+// Review the comments and decide whether to continue using unicode_uppers/unicode_lowers
+// and related code. In my opinion it is a mistake to continue their use.
+
 //	Copyright (c) Leigh Brasington 2012.  All rights reserved.
 //  This code may be used and reproduced without written permission.
 //  http://www.leighb.com/tounicupper.htm
 //
 //	The tables were constructed from
 //	http://publib.boulder.ibm.com/infocenter/iseries/v7r1m0/index.jsp?topic=%2Fnls%2Frbagslowtoupmaptable.htm
+
+// These characters can be converted to/from upper/lower case independent of locale.
+// This means that there is no locale where the the conversion gives different
+// results, like some characters do.
 
 static constexpr wchar_t unicode_lowers[] = {
   (wchar_t)0x0061, (wchar_t)0x0062, (wchar_t)0x0063, (wchar_t)0x0064, (wchar_t)0x0065, (wchar_t)0x0066, (wchar_t)0x0067, (wchar_t)0x0068, (wchar_t)0x0069,
@@ -237,6 +261,653 @@ static const wchar_t unicode_uppers[] = {
   (wchar_t)0xFF32, (wchar_t)0xFF33, (wchar_t)0xFF34, (wchar_t)0xFF35, (wchar_t)0xFF36, (wchar_t)0xFF37, (wchar_t)0xFF38, (wchar_t)0xFF39, (wchar_t)0xFF3A
 };
 
+/* Case folding tables (unicode_fold_upper & unicode_fold_lower) are derived from Unicode Inc.
+ *  Data file, CaseFolding.txt (CaseFolding-14.0.0.txt, 2021-03-08). Copyright follows below.
+ *
+ * These tables provide for "simple case folding" that is not locale sensitive. They do NOT
+ * support "Full Case Folding" which can fold single characters into multiple, or multiple
+ * into single, etc. CaseFolding.txt can be found in the ICUC4 source directory:
+ * icu/source/data/unidata.
+ *
+ * Terms of use:
+ *
+ * UNICODE, INC. LICENSE AGREEMENT - DATA FILES AND SOFTWARE
+ *
+ * See Terms of Use <https://www.unicode.org/copyright.html>
+ * for definitions of Unicode Inc.’s Data Files and Software.
+ *
+ * NOTICE TO USER: Carefully read the following legal agreement.
+ * BY DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING UNICODE INC.'S
+ * DATA FILES ("DATA FILES"), AND/OR SOFTWARE ("SOFTWARE"),
+ * YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+ * TERMS AND CONDITIONS OF THIS AGREEMENT.
+ * IF YOU DO NOT AGREE, DO NOT DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE
+ * THE DATA FILES OR SOFTWARE.
+ *
+ * COPYRIGHT AND PERMISSION NOTICE
+ *
+ * Copyright © 1991-2022 Unicode, Inc. All rights reserved.
+ * Distributed under the Terms of Use in https://www.unicode.org/copyright.html.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of the Unicode data files and any associated documentation
+ * (the "Data Files") or Unicode software and any associated documentation
+ * (the "Software") to deal in the Data Files or Software
+ * without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, and/or sell copies of
+ * the Data Files or Software, and to permit persons to whom the Data Files
+ * or Software are furnished to do so, provided that either
+ * (a) this copyright and permission notice appear with all copies
+ * of the Data Files or Software, or
+ * (b) this copyright and permission notice appear in associated
+ * Documentation.
+ *
+ * THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
+ * ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
+ * NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
+ * DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+ * DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+ * TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THE DATA FILES OR SOFTWARE.
+ *
+ * Except as contained in this notice, the name of a copyright holder
+ * shall not be used in advertising or otherwise to promote the sale,
+ * use or other dealings in these Data Files or Software without prior
+ * written authorization of the copyright holder.
+ */
+
+// unicode_fold_upper is the upper-case equivalent to unicode_fold_lower.
+// The lists are ordered such that the (lower) folded-case equivalent of unicode_fold_upper[n]
+// is at unicode_fold_lower[n]. Note that the terms here "upper/lower case" are informal.
+
+static const char32_t unicode_fold_upper[] = {
+    (char32_t)0x0041,  (char32_t)0x0042,  (char32_t)0x0043,  (char32_t)0x0044,  (char32_t)0x0045,
+    (char32_t)0x0046,  (char32_t)0x0047,  (char32_t)0x0048,  (char32_t)0x0049,  (char32_t)0x004A,
+    (char32_t)0x004B,  (char32_t)0x004C,  (char32_t)0x004D,  (char32_t)0x004E,  (char32_t)0x004F,
+    (char32_t)0x0050,  (char32_t)0x0051,  (char32_t)0x0052,  (char32_t)0x0053,  (char32_t)0x0054,
+    (char32_t)0x0055,  (char32_t)0x0056,  (char32_t)0x0057,  (char32_t)0x0058,  (char32_t)0x0059,
+    (char32_t)0x005A,  (char32_t)0x00B5,  (char32_t)0x00C0,  (char32_t)0x00C1,  (char32_t)0x00C2,
+    (char32_t)0x00C3,  (char32_t)0x00C4,  (char32_t)0x00C5,  (char32_t)0x00C6,  (char32_t)0x00C7,
+    (char32_t)0x00C8,  (char32_t)0x00C9,  (char32_t)0x00CA,  (char32_t)0x00CB,  (char32_t)0x00CC,
+    (char32_t)0x00CD,  (char32_t)0x00CE,  (char32_t)0x00CF,  (char32_t)0x00D0,  (char32_t)0x00D1,
+    (char32_t)0x00D2,  (char32_t)0x00D3,  (char32_t)0x00D4,  (char32_t)0x00D5,  (char32_t)0x00D6,
+    (char32_t)0x00D8,  (char32_t)0x00D9,  (char32_t)0x00DA,  (char32_t)0x00DB,  (char32_t)0x00DC,
+    (char32_t)0x00DD,  (char32_t)0x00DE,  (char32_t)0x0100,  (char32_t)0x0102,  (char32_t)0x0104,
+    (char32_t)0x0106,  (char32_t)0x0108,  (char32_t)0x010A,  (char32_t)0x010C,  (char32_t)0x010E,
+    (char32_t)0x0110,  (char32_t)0x0112,  (char32_t)0x0114,  (char32_t)0x0116,  (char32_t)0x0118,
+    (char32_t)0x011A,  (char32_t)0x011C,  (char32_t)0x011E,  (char32_t)0x0120,  (char32_t)0x0122,
+    (char32_t)0x0124,  (char32_t)0x0126,  (char32_t)0x0128,  (char32_t)0x012A,  (char32_t)0x012C,
+    (char32_t)0x012E,  (char32_t)0x0132,  (char32_t)0x0134,  (char32_t)0x0136,  (char32_t)0x0139,
+    (char32_t)0x013B,  (char32_t)0x013D,  (char32_t)0x013F,  (char32_t)0x0141,  (char32_t)0x0143,
+    (char32_t)0x0145,  (char32_t)0x0147,  (char32_t)0x014A,  (char32_t)0x014C,  (char32_t)0x014E,
+    (char32_t)0x0150,  (char32_t)0x0152,  (char32_t)0x0154,  (char32_t)0x0156,  (char32_t)0x0158,
+    (char32_t)0x015A,  (char32_t)0x015C,  (char32_t)0x015E,  (char32_t)0x0160,  (char32_t)0x0162,
+    (char32_t)0x0164,  (char32_t)0x0166,  (char32_t)0x0168,  (char32_t)0x016A,  (char32_t)0x016C,
+    (char32_t)0x016E,  (char32_t)0x0170,  (char32_t)0x0172,  (char32_t)0x0174,  (char32_t)0x0176,
+    (char32_t)0x0178,  (char32_t)0x0179,  (char32_t)0x017B,  (char32_t)0x017D,  (char32_t)0x017F,
+    (char32_t)0x0181,  (char32_t)0x0182,  (char32_t)0x0184,  (char32_t)0x0186,  (char32_t)0x0187,
+    (char32_t)0x0189,  (char32_t)0x018A,  (char32_t)0x018B,  (char32_t)0x018E,  (char32_t)0x018F,
+    (char32_t)0x0190,  (char32_t)0x0191,  (char32_t)0x0193,  (char32_t)0x0194,  (char32_t)0x0196,
+    (char32_t)0x0197,  (char32_t)0x0198,  (char32_t)0x019C,  (char32_t)0x019D,  (char32_t)0x019F,
+    (char32_t)0x01A0,  (char32_t)0x01A2,  (char32_t)0x01A4,  (char32_t)0x01A6,  (char32_t)0x01A7,
+    (char32_t)0x01A9,  (char32_t)0x01AC,  (char32_t)0x01AE,  (char32_t)0x01AF,  (char32_t)0x01B1,
+    (char32_t)0x01B2,  (char32_t)0x01B3,  (char32_t)0x01B5,  (char32_t)0x01B7,  (char32_t)0x01B8,
+    (char32_t)0x01BC,  (char32_t)0x01C4,  (char32_t)0x01C5,  (char32_t)0x01C7,  (char32_t)0x01C8,
+    (char32_t)0x01CA,  (char32_t)0x01CB,  (char32_t)0x01CD,  (char32_t)0x01CF,  (char32_t)0x01D1,
+    (char32_t)0x01D3,  (char32_t)0x01D5,  (char32_t)0x01D7,  (char32_t)0x01D9,  (char32_t)0x01DB,
+    (char32_t)0x01DE,  (char32_t)0x01E0,  (char32_t)0x01E2,  (char32_t)0x01E4,  (char32_t)0x01E6,
+    (char32_t)0x01E8,  (char32_t)0x01EA,  (char32_t)0x01EC,  (char32_t)0x01EE,  (char32_t)0x01F1,
+    (char32_t)0x01F2,  (char32_t)0x01F4,  (char32_t)0x01F6,  (char32_t)0x01F7,  (char32_t)0x01F8,
+    (char32_t)0x01FA,  (char32_t)0x01FC,  (char32_t)0x01FE,  (char32_t)0x0200,  (char32_t)0x0202,
+    (char32_t)0x0204,  (char32_t)0x0206,  (char32_t)0x0208,  (char32_t)0x020A,  (char32_t)0x020C,
+    (char32_t)0x020E,  (char32_t)0x0210,  (char32_t)0x0212,  (char32_t)0x0214,  (char32_t)0x0216,
+    (char32_t)0x0218,  (char32_t)0x021A,  (char32_t)0x021C,  (char32_t)0x021E,  (char32_t)0x0220,
+    (char32_t)0x0222,  (char32_t)0x0224,  (char32_t)0x0226,  (char32_t)0x0228,  (char32_t)0x022A,
+    (char32_t)0x022C,  (char32_t)0x022E,  (char32_t)0x0230,  (char32_t)0x0232,  (char32_t)0x023A,
+    (char32_t)0x023B,  (char32_t)0x023D,  (char32_t)0x023E,  (char32_t)0x0241,  (char32_t)0x0243,
+    (char32_t)0x0244,  (char32_t)0x0245,  (char32_t)0x0246,  (char32_t)0x0248,  (char32_t)0x024A,
+    (char32_t)0x024C,  (char32_t)0x024E,  (char32_t)0x0345,  (char32_t)0x0370,  (char32_t)0x0372,
+    (char32_t)0x0376,  (char32_t)0x037F,  (char32_t)0x0386,  (char32_t)0x0388,  (char32_t)0x0389,
+    (char32_t)0x038A,  (char32_t)0x038C,  (char32_t)0x038E,  (char32_t)0x038F,  (char32_t)0x0391,
+    (char32_t)0x0392,  (char32_t)0x0393,  (char32_t)0x0394,  (char32_t)0x0395,  (char32_t)0x0396,
+    (char32_t)0x0397,  (char32_t)0x0398,  (char32_t)0x0399,  (char32_t)0x039A,  (char32_t)0x039B,
+    (char32_t)0x039C,  (char32_t)0x039D,  (char32_t)0x039E,  (char32_t)0x039F,  (char32_t)0x03A0,
+    (char32_t)0x03A1,  (char32_t)0x03A3,  (char32_t)0x03A4,  (char32_t)0x03A5,  (char32_t)0x03A6,
+    (char32_t)0x03A7,  (char32_t)0x03A8,  (char32_t)0x03A9,  (char32_t)0x03AA,  (char32_t)0x03AB,
+    (char32_t)0x03C2,  (char32_t)0x03CF,  (char32_t)0x03D0,  (char32_t)0x03D1,  (char32_t)0x03D5,
+    (char32_t)0x03D6,  (char32_t)0x03D8,  (char32_t)0x03DA,  (char32_t)0x03DC,  (char32_t)0x03DE,
+    (char32_t)0x03E0,  (char32_t)0x03E2,  (char32_t)0x03E4,  (char32_t)0x03E6,  (char32_t)0x03E8,
+    (char32_t)0x03EA,  (char32_t)0x03EC,  (char32_t)0x03EE,  (char32_t)0x03F0,  (char32_t)0x03F1,
+    (char32_t)0x03F4,  (char32_t)0x03F5,  (char32_t)0x03F7,  (char32_t)0x03F9,  (char32_t)0x03FA,
+    (char32_t)0x03FD,  (char32_t)0x03FE,  (char32_t)0x03FF,  (char32_t)0x0400,  (char32_t)0x0401,
+    (char32_t)0x0402,  (char32_t)0x0403,  (char32_t)0x0404,  (char32_t)0x0405,  (char32_t)0x0406,
+    (char32_t)0x0407,  (char32_t)0x0408,  (char32_t)0x0409,  (char32_t)0x040A,  (char32_t)0x040B,
+    (char32_t)0x040C,  (char32_t)0x040D,  (char32_t)0x040E,  (char32_t)0x040F,  (char32_t)0x0410,
+    (char32_t)0x0411,  (char32_t)0x0412,  (char32_t)0x0413,  (char32_t)0x0414,  (char32_t)0x0415,
+    (char32_t)0x0416,  (char32_t)0x0417,  (char32_t)0x0418,  (char32_t)0x0419,  (char32_t)0x041A,
+    (char32_t)0x041B,  (char32_t)0x041C,  (char32_t)0x041D,  (char32_t)0x041E,  (char32_t)0x041F,
+    (char32_t)0x0420,  (char32_t)0x0421,  (char32_t)0x0422,  (char32_t)0x0423,  (char32_t)0x0424,
+    (char32_t)0x0425,  (char32_t)0x0426,  (char32_t)0x0427,  (char32_t)0x0428,  (char32_t)0x0429,
+    (char32_t)0x042A,  (char32_t)0x042B,  (char32_t)0x042C,  (char32_t)0x042D,  (char32_t)0x042E,
+    (char32_t)0x042F,  (char32_t)0x0460,  (char32_t)0x0462,  (char32_t)0x0464,  (char32_t)0x0466,
+    (char32_t)0x0468,  (char32_t)0x046A,  (char32_t)0x046C,  (char32_t)0x046E,  (char32_t)0x0470,
+    (char32_t)0x0472,  (char32_t)0x0474,  (char32_t)0x0476,  (char32_t)0x0478,  (char32_t)0x047A,
+    (char32_t)0x047C,  (char32_t)0x047E,  (char32_t)0x0480,  (char32_t)0x048A,  (char32_t)0x048C,
+    (char32_t)0x048E,  (char32_t)0x0490,  (char32_t)0x0492,  (char32_t)0x0494,  (char32_t)0x0496,
+    (char32_t)0x0498,  (char32_t)0x049A,  (char32_t)0x049C,  (char32_t)0x049E,  (char32_t)0x04A0,
+    (char32_t)0x04A2,  (char32_t)0x04A4,  (char32_t)0x04A6,  (char32_t)0x04A8,  (char32_t)0x04AA,
+    (char32_t)0x04AC,  (char32_t)0x04AE,  (char32_t)0x04B0,  (char32_t)0x04B2,  (char32_t)0x04B4,
+    (char32_t)0x04B6,  (char32_t)0x04B8,  (char32_t)0x04BA,  (char32_t)0x04BC,  (char32_t)0x04BE,
+    (char32_t)0x04C0,  (char32_t)0x04C1,  (char32_t)0x04C3,  (char32_t)0x04C5,  (char32_t)0x04C7,
+    (char32_t)0x04C9,  (char32_t)0x04CB,  (char32_t)0x04CD,  (char32_t)0x04D0,  (char32_t)0x04D2,
+    (char32_t)0x04D4,  (char32_t)0x04D6,  (char32_t)0x04D8,  (char32_t)0x04DA,  (char32_t)0x04DC,
+    (char32_t)0x04DE,  (char32_t)0x04E0,  (char32_t)0x04E2,  (char32_t)0x04E4,  (char32_t)0x04E6,
+    (char32_t)0x04E8,  (char32_t)0x04EA,  (char32_t)0x04EC,  (char32_t)0x04EE,  (char32_t)0x04F0,
+    (char32_t)0x04F2,  (char32_t)0x04F4,  (char32_t)0x04F6,  (char32_t)0x04F8,  (char32_t)0x04FA,
+    (char32_t)0x04FC,  (char32_t)0x04FE,  (char32_t)0x0500,  (char32_t)0x0502,  (char32_t)0x0504,
+    (char32_t)0x0506,  (char32_t)0x0508,  (char32_t)0x050A,  (char32_t)0x050C,  (char32_t)0x050E,
+    (char32_t)0x0510,  (char32_t)0x0512,  (char32_t)0x0514,  (char32_t)0x0516,  (char32_t)0x0518,
+    (char32_t)0x051A,  (char32_t)0x051C,  (char32_t)0x051E,  (char32_t)0x0520,  (char32_t)0x0522,
+    (char32_t)0x0524,  (char32_t)0x0526,  (char32_t)0x0528,  (char32_t)0x052A,  (char32_t)0x052C,
+    (char32_t)0x052E,  (char32_t)0x0531,  (char32_t)0x0532,  (char32_t)0x0533,  (char32_t)0x0534,
+    (char32_t)0x0535,  (char32_t)0x0536,  (char32_t)0x0537,  (char32_t)0x0538,  (char32_t)0x0539,
+    (char32_t)0x053A,  (char32_t)0x053B,  (char32_t)0x053C,  (char32_t)0x053D,  (char32_t)0x053E,
+    (char32_t)0x053F,  (char32_t)0x0540,  (char32_t)0x0541,  (char32_t)0x0542,  (char32_t)0x0543,
+    (char32_t)0x0544,  (char32_t)0x0545,  (char32_t)0x0546,  (char32_t)0x0547,  (char32_t)0x0548,
+    (char32_t)0x0549,  (char32_t)0x054A,  (char32_t)0x054B,  (char32_t)0x054C,  (char32_t)0x054D,
+    (char32_t)0x054E,  (char32_t)0x054F,  (char32_t)0x0550,  (char32_t)0x0551,  (char32_t)0x0552,
+    (char32_t)0x0553,  (char32_t)0x0554,  (char32_t)0x0555,  (char32_t)0x0556,  (char32_t)0x10A0,
+    (char32_t)0x10A1,  (char32_t)0x10A2,  (char32_t)0x10A3,  (char32_t)0x10A4,  (char32_t)0x10A5,
+    (char32_t)0x10A6,  (char32_t)0x10A7,  (char32_t)0x10A8,  (char32_t)0x10A9,  (char32_t)0x10AA,
+    (char32_t)0x10AB,  (char32_t)0x10AC,  (char32_t)0x10AD,  (char32_t)0x10AE,  (char32_t)0x10AF,
+    (char32_t)0x10B0,  (char32_t)0x10B1,  (char32_t)0x10B2,  (char32_t)0x10B3,  (char32_t)0x10B4,
+    (char32_t)0x10B5,  (char32_t)0x10B6,  (char32_t)0x10B7,  (char32_t)0x10B8,  (char32_t)0x10B9,
+    (char32_t)0x10BA,  (char32_t)0x10BB,  (char32_t)0x10BC,  (char32_t)0x10BD,  (char32_t)0x10BE,
+    (char32_t)0x10BF,  (char32_t)0x10C0,  (char32_t)0x10C1,  (char32_t)0x10C2,  (char32_t)0x10C3,
+    (char32_t)0x10C4,  (char32_t)0x10C5,  (char32_t)0x10C7,  (char32_t)0x10CD,  (char32_t)0x13F8,
+    (char32_t)0x13F9,  (char32_t)0x13FA,  (char32_t)0x13FB,  (char32_t)0x13FC,  (char32_t)0x13FD,
+    (char32_t)0x1C80,  (char32_t)0x1C81,  (char32_t)0x1C82,  (char32_t)0x1C83,  (char32_t)0x1C84,
+    (char32_t)0x1C85,  (char32_t)0x1C86,  (char32_t)0x1C87,  (char32_t)0x1C88,  (char32_t)0x1C90,
+    (char32_t)0x1C91,  (char32_t)0x1C92,  (char32_t)0x1C93,  (char32_t)0x1C94,  (char32_t)0x1C95,
+    (char32_t)0x1C96,  (char32_t)0x1C97,  (char32_t)0x1C98,  (char32_t)0x1C99,  (char32_t)0x1C9A,
+    (char32_t)0x1C9B,  (char32_t)0x1C9C,  (char32_t)0x1C9D,  (char32_t)0x1C9E,  (char32_t)0x1C9F,
+    (char32_t)0x1CA0,  (char32_t)0x1CA1,  (char32_t)0x1CA2,  (char32_t)0x1CA3,  (char32_t)0x1CA4,
+    (char32_t)0x1CA5,  (char32_t)0x1CA6,  (char32_t)0x1CA7,  (char32_t)0x1CA8,  (char32_t)0x1CA9,
+    (char32_t)0x1CAA,  (char32_t)0x1CAB,  (char32_t)0x1CAC,  (char32_t)0x1CAD,  (char32_t)0x1CAE,
+    (char32_t)0x1CAF,  (char32_t)0x1CB0,  (char32_t)0x1CB1,  (char32_t)0x1CB2,  (char32_t)0x1CB3,
+    (char32_t)0x1CB4,  (char32_t)0x1CB5,  (char32_t)0x1CB6,  (char32_t)0x1CB7,  (char32_t)0x1CB8,
+    (char32_t)0x1CB9,  (char32_t)0x1CBA,  (char32_t)0x1CBD,  (char32_t)0x1CBE,  (char32_t)0x1CBF,
+    (char32_t)0x1E00,  (char32_t)0x1E02,  (char32_t)0x1E04,  (char32_t)0x1E06,  (char32_t)0x1E08,
+    (char32_t)0x1E0A,  (char32_t)0x1E0C,  (char32_t)0x1E0E,  (char32_t)0x1E10,  (char32_t)0x1E12,
+    (char32_t)0x1E14,  (char32_t)0x1E16,  (char32_t)0x1E18,  (char32_t)0x1E1A,  (char32_t)0x1E1C,
+    (char32_t)0x1E1E,  (char32_t)0x1E20,  (char32_t)0x1E22,  (char32_t)0x1E24,  (char32_t)0x1E26,
+    (char32_t)0x1E28,  (char32_t)0x1E2A,  (char32_t)0x1E2C,  (char32_t)0x1E2E,  (char32_t)0x1E30,
+    (char32_t)0x1E32,  (char32_t)0x1E34,  (char32_t)0x1E36,  (char32_t)0x1E38,  (char32_t)0x1E3A,
+    (char32_t)0x1E3C,  (char32_t)0x1E3E,  (char32_t)0x1E40,  (char32_t)0x1E42,  (char32_t)0x1E44,
+    (char32_t)0x1E46,  (char32_t)0x1E48,  (char32_t)0x1E4A,  (char32_t)0x1E4C,  (char32_t)0x1E4E,
+    (char32_t)0x1E50,  (char32_t)0x1E52,  (char32_t)0x1E54,  (char32_t)0x1E56,  (char32_t)0x1E58,
+    (char32_t)0x1E5A,  (char32_t)0x1E5C,  (char32_t)0x1E5E,  (char32_t)0x1E60,  (char32_t)0x1E62,
+    (char32_t)0x1E64,  (char32_t)0x1E66,  (char32_t)0x1E68,  (char32_t)0x1E6A,  (char32_t)0x1E6C,
+    (char32_t)0x1E6E,  (char32_t)0x1E70,  (char32_t)0x1E72,  (char32_t)0x1E74,  (char32_t)0x1E76,
+    (char32_t)0x1E78,  (char32_t)0x1E7A,  (char32_t)0x1E7C,  (char32_t)0x1E7E,  (char32_t)0x1E80,
+    (char32_t)0x1E82,  (char32_t)0x1E84,  (char32_t)0x1E86,  (char32_t)0x1E88,  (char32_t)0x1E8A,
+    (char32_t)0x1E8C,  (char32_t)0x1E8E,  (char32_t)0x1E90,  (char32_t)0x1E92,  (char32_t)0x1E94,
+    (char32_t)0x1E9B,  (char32_t)0x1E9E,  (char32_t)0x1EA0,  (char32_t)0x1EA2,  (char32_t)0x1EA4,
+    (char32_t)0x1EA6,  (char32_t)0x1EA8,  (char32_t)0x1EAA,  (char32_t)0x1EAC,  (char32_t)0x1EAE,
+    (char32_t)0x1EB0,  (char32_t)0x1EB2,  (char32_t)0x1EB4,  (char32_t)0x1EB6,  (char32_t)0x1EB8,
+    (char32_t)0x1EBA,  (char32_t)0x1EBC,  (char32_t)0x1EBE,  (char32_t)0x1EC0,  (char32_t)0x1EC2,
+    (char32_t)0x1EC4,  (char32_t)0x1EC6,  (char32_t)0x1EC8,  (char32_t)0x1ECA,  (char32_t)0x1ECC,
+    (char32_t)0x1ECE,  (char32_t)0x1ED0,  (char32_t)0x1ED2,  (char32_t)0x1ED4,  (char32_t)0x1ED6,
+    (char32_t)0x1ED8,  (char32_t)0x1EDA,  (char32_t)0x1EDC,  (char32_t)0x1EDE,  (char32_t)0x1EE0,
+    (char32_t)0x1EE2,  (char32_t)0x1EE4,  (char32_t)0x1EE6,  (char32_t)0x1EE8,  (char32_t)0x1EEA,
+    (char32_t)0x1EEC,  (char32_t)0x1EEE,  (char32_t)0x1EF0,  (char32_t)0x1EF2,  (char32_t)0x1EF4,
+    (char32_t)0x1EF6,  (char32_t)0x1EF8,  (char32_t)0x1EFA,  (char32_t)0x1EFC,  (char32_t)0x1EFE,
+    (char32_t)0x1F08,  (char32_t)0x1F09,  (char32_t)0x1F0A,  (char32_t)0x1F0B,  (char32_t)0x1F0C,
+    (char32_t)0x1F0D,  (char32_t)0x1F0E,  (char32_t)0x1F0F,  (char32_t)0x1F18,  (char32_t)0x1F19,
+    (char32_t)0x1F1A,  (char32_t)0x1F1B,  (char32_t)0x1F1C,  (char32_t)0x1F1D,  (char32_t)0x1F28,
+    (char32_t)0x1F29,  (char32_t)0x1F2A,  (char32_t)0x1F2B,  (char32_t)0x1F2C,  (char32_t)0x1F2D,
+    (char32_t)0x1F2E,  (char32_t)0x1F2F,  (char32_t)0x1F38,  (char32_t)0x1F39,  (char32_t)0x1F3A,
+    (char32_t)0x1F3B,  (char32_t)0x1F3C,  (char32_t)0x1F3D,  (char32_t)0x1F3E,  (char32_t)0x1F3F,
+    (char32_t)0x1F48,  (char32_t)0x1F49,  (char32_t)0x1F4A,  (char32_t)0x1F4B,  (char32_t)0x1F4C,
+    (char32_t)0x1F4D,  (char32_t)0x1F59,  (char32_t)0x1F5B,  (char32_t)0x1F5D,  (char32_t)0x1F5F,
+    (char32_t)0x1F68,  (char32_t)0x1F69,  (char32_t)0x1F6A,  (char32_t)0x1F6B,  (char32_t)0x1F6C,
+    (char32_t)0x1F6D,  (char32_t)0x1F6E,  (char32_t)0x1F6F,  (char32_t)0x1F88,  (char32_t)0x1F89,
+    (char32_t)0x1F8A,  (char32_t)0x1F8B,  (char32_t)0x1F8C,  (char32_t)0x1F8D,  (char32_t)0x1F8E,
+    (char32_t)0x1F8F,  (char32_t)0x1F98,  (char32_t)0x1F99,  (char32_t)0x1F9A,  (char32_t)0x1F9B,
+    (char32_t)0x1F9C,  (char32_t)0x1F9D,  (char32_t)0x1F9E,  (char32_t)0x1F9F,  (char32_t)0x1FA8,
+    (char32_t)0x1FA9,  (char32_t)0x1FAA,  (char32_t)0x1FAB,  (char32_t)0x1FAC,  (char32_t)0x1FAD,
+    (char32_t)0x1FAE,  (char32_t)0x1FAF,  (char32_t)0x1FB8,  (char32_t)0x1FB9,  (char32_t)0x1FBA,
+    (char32_t)0x1FBB,  (char32_t)0x1FBC,  (char32_t)0x1FBE,  (char32_t)0x1FC8,  (char32_t)0x1FC9,
+    (char32_t)0x1FCA,  (char32_t)0x1FCB,  (char32_t)0x1FCC,  (char32_t)0x1FD8,  (char32_t)0x1FD9,
+    (char32_t)0x1FDA,  (char32_t)0x1FDB,  (char32_t)0x1FE8,  (char32_t)0x1FE9,  (char32_t)0x1FEA,
+    (char32_t)0x1FEB,  (char32_t)0x1FEC,  (char32_t)0x1FF8,  (char32_t)0x1FF9,  (char32_t)0x1FFA,
+    (char32_t)0x1FFB,  (char32_t)0x1FFC,  (char32_t)0x2126,  (char32_t)0x212A,  (char32_t)0x212B,
+    (char32_t)0x2132,  (char32_t)0x2160,  (char32_t)0x2161,  (char32_t)0x2162,  (char32_t)0x2163,
+    (char32_t)0x2164,  (char32_t)0x2165,  (char32_t)0x2166,  (char32_t)0x2167,  (char32_t)0x2168,
+    (char32_t)0x2169,  (char32_t)0x216A,  (char32_t)0x216B,  (char32_t)0x216C,  (char32_t)0x216D,
+    (char32_t)0x216E,  (char32_t)0x216F,  (char32_t)0x2183,  (char32_t)0x24B6,  (char32_t)0x24B7,
+    (char32_t)0x24B8,  (char32_t)0x24B9,  (char32_t)0x24BA,  (char32_t)0x24BB,  (char32_t)0x24BC,
+    (char32_t)0x24BD,  (char32_t)0x24BE,  (char32_t)0x24BF,  (char32_t)0x24C0,  (char32_t)0x24C1,
+    (char32_t)0x24C2,  (char32_t)0x24C3,  (char32_t)0x24C4,  (char32_t)0x24C5,  (char32_t)0x24C6,
+    (char32_t)0x24C7,  (char32_t)0x24C8,  (char32_t)0x24C9,  (char32_t)0x24CA,  (char32_t)0x24CB,
+    (char32_t)0x24CC,  (char32_t)0x24CD,  (char32_t)0x24CE,  (char32_t)0x24CF,  (char32_t)0x2C00,
+    (char32_t)0x2C01,  (char32_t)0x2C02,  (char32_t)0x2C03,  (char32_t)0x2C04,  (char32_t)0x2C05,
+    (char32_t)0x2C06,  (char32_t)0x2C07,  (char32_t)0x2C08,  (char32_t)0x2C09,  (char32_t)0x2C0A,
+    (char32_t)0x2C0B,  (char32_t)0x2C0C,  (char32_t)0x2C0D,  (char32_t)0x2C0E,  (char32_t)0x2C0F,
+    (char32_t)0x2C10,  (char32_t)0x2C11,  (char32_t)0x2C12,  (char32_t)0x2C13,  (char32_t)0x2C14,
+    (char32_t)0x2C15,  (char32_t)0x2C16,  (char32_t)0x2C17,  (char32_t)0x2C18,  (char32_t)0x2C19,
+    (char32_t)0x2C1A,  (char32_t)0x2C1B,  (char32_t)0x2C1C,  (char32_t)0x2C1D,  (char32_t)0x2C1E,
+    (char32_t)0x2C1F,  (char32_t)0x2C20,  (char32_t)0x2C21,  (char32_t)0x2C22,  (char32_t)0x2C23,
+    (char32_t)0x2C24,  (char32_t)0x2C25,  (char32_t)0x2C26,  (char32_t)0x2C27,  (char32_t)0x2C28,
+    (char32_t)0x2C29,  (char32_t)0x2C2A,  (char32_t)0x2C2B,  (char32_t)0x2C2C,  (char32_t)0x2C2D,
+    (char32_t)0x2C2E,  (char32_t)0x2C2F,  (char32_t)0x2C60,  (char32_t)0x2C62,  (char32_t)0x2C63,
+    (char32_t)0x2C64,  (char32_t)0x2C67,  (char32_t)0x2C69,  (char32_t)0x2C6B,  (char32_t)0x2C6D,
+    (char32_t)0x2C6E,  (char32_t)0x2C6F,  (char32_t)0x2C70,  (char32_t)0x2C72,  (char32_t)0x2C75,
+    (char32_t)0x2C7E,  (char32_t)0x2C7F,  (char32_t)0x2C80,  (char32_t)0x2C82,  (char32_t)0x2C84,
+    (char32_t)0x2C86,  (char32_t)0x2C88,  (char32_t)0x2C8A,  (char32_t)0x2C8C,  (char32_t)0x2C8E,
+    (char32_t)0x2C90,  (char32_t)0x2C92,  (char32_t)0x2C94,  (char32_t)0x2C96,  (char32_t)0x2C98,
+    (char32_t)0x2C9A,  (char32_t)0x2C9C,  (char32_t)0x2C9E,  (char32_t)0x2CA0,  (char32_t)0x2CA2,
+    (char32_t)0x2CA4,  (char32_t)0x2CA6,  (char32_t)0x2CA8,  (char32_t)0x2CAA,  (char32_t)0x2CAC,
+    (char32_t)0x2CAE,  (char32_t)0x2CB0,  (char32_t)0x2CB2,  (char32_t)0x2CB4,  (char32_t)0x2CB6,
+    (char32_t)0x2CB8,  (char32_t)0x2CBA,  (char32_t)0x2CBC,  (char32_t)0x2CBE,  (char32_t)0x2CC0,
+    (char32_t)0x2CC2,  (char32_t)0x2CC4,  (char32_t)0x2CC6,  (char32_t)0x2CC8,  (char32_t)0x2CCA,
+    (char32_t)0x2CCC,  (char32_t)0x2CCE,  (char32_t)0x2CD0,  (char32_t)0x2CD2,  (char32_t)0x2CD4,
+    (char32_t)0x2CD6,  (char32_t)0x2CD8,  (char32_t)0x2CDA,  (char32_t)0x2CDC,  (char32_t)0x2CDE,
+    (char32_t)0x2CE0,  (char32_t)0x2CE2,  (char32_t)0x2CEB,  (char32_t)0x2CED,  (char32_t)0x2CF2,
+    (char32_t)0xA640,  (char32_t)0xA642,  (char32_t)0xA644,  (char32_t)0xA646,  (char32_t)0xA648,
+    (char32_t)0xA64A,  (char32_t)0xA64C,  (char32_t)0xA64E,  (char32_t)0xA650,  (char32_t)0xA652,
+    (char32_t)0xA654,  (char32_t)0xA656,  (char32_t)0xA658,  (char32_t)0xA65A,  (char32_t)0xA65C,
+    (char32_t)0xA65E,  (char32_t)0xA660,  (char32_t)0xA662,  (char32_t)0xA664,  (char32_t)0xA666,
+    (char32_t)0xA668,  (char32_t)0xA66A,  (char32_t)0xA66C,  (char32_t)0xA680,  (char32_t)0xA682,
+    (char32_t)0xA684,  (char32_t)0xA686,  (char32_t)0xA688,  (char32_t)0xA68A,  (char32_t)0xA68C,
+    (char32_t)0xA68E,  (char32_t)0xA690,  (char32_t)0xA692,  (char32_t)0xA694,  (char32_t)0xA696,
+    (char32_t)0xA698,  (char32_t)0xA69A,  (char32_t)0xA722,  (char32_t)0xA724,  (char32_t)0xA726,
+    (char32_t)0xA728,  (char32_t)0xA72A,  (char32_t)0xA72C,  (char32_t)0xA72E,  (char32_t)0xA732,
+    (char32_t)0xA734,  (char32_t)0xA736,  (char32_t)0xA738,  (char32_t)0xA73A,  (char32_t)0xA73C,
+    (char32_t)0xA73E,  (char32_t)0xA740,  (char32_t)0xA742,  (char32_t)0xA744,  (char32_t)0xA746,
+    (char32_t)0xA748,  (char32_t)0xA74A,  (char32_t)0xA74C,  (char32_t)0xA74E,  (char32_t)0xA750,
+    (char32_t)0xA752,  (char32_t)0xA754,  (char32_t)0xA756,  (char32_t)0xA758,  (char32_t)0xA75A,
+    (char32_t)0xA75C,  (char32_t)0xA75E,  (char32_t)0xA760,  (char32_t)0xA762,  (char32_t)0xA764,
+    (char32_t)0xA766,  (char32_t)0xA768,  (char32_t)0xA76A,  (char32_t)0xA76C,  (char32_t)0xA76E,
+    (char32_t)0xA779,  (char32_t)0xA77B,  (char32_t)0xA77D,  (char32_t)0xA77E,  (char32_t)0xA780,
+    (char32_t)0xA782,  (char32_t)0xA784,  (char32_t)0xA786,  (char32_t)0xA78B,  (char32_t)0xA78D,
+    (char32_t)0xA790,  (char32_t)0xA792,  (char32_t)0xA796,  (char32_t)0xA798,  (char32_t)0xA79A,
+    (char32_t)0xA79C,  (char32_t)0xA79E,  (char32_t)0xA7A0,  (char32_t)0xA7A2,  (char32_t)0xA7A4,
+    (char32_t)0xA7A6,  (char32_t)0xA7A8,  (char32_t)0xA7AA,  (char32_t)0xA7AB,  (char32_t)0xA7AC,
+    (char32_t)0xA7AD,  (char32_t)0xA7AE,  (char32_t)0xA7B0,  (char32_t)0xA7B1,  (char32_t)0xA7B2,
+    (char32_t)0xA7B3,  (char32_t)0xA7B4,  (char32_t)0xA7B6,  (char32_t)0xA7B8,  (char32_t)0xA7BA,
+    (char32_t)0xA7BC,  (char32_t)0xA7BE,  (char32_t)0xA7C0,  (char32_t)0xA7C2,  (char32_t)0xA7C4,
+    (char32_t)0xA7C5,  (char32_t)0xA7C6,  (char32_t)0xA7C7,  (char32_t)0xA7C9,  (char32_t)0xA7D0,
+    (char32_t)0xA7D6,  (char32_t)0xA7D8,  (char32_t)0xA7F5,  (char32_t)0xAB70,  (char32_t)0xAB71,
+    (char32_t)0xAB72,  (char32_t)0xAB73,  (char32_t)0xAB74,  (char32_t)0xAB75,  (char32_t)0xAB76,
+    (char32_t)0xAB77,  (char32_t)0xAB78,  (char32_t)0xAB79,  (char32_t)0xAB7A,  (char32_t)0xAB7B,
+    (char32_t)0xAB7C,  (char32_t)0xAB7D,  (char32_t)0xAB7E,  (char32_t)0xAB7F,  (char32_t)0xAB80,
+    (char32_t)0xAB81,  (char32_t)0xAB82,  (char32_t)0xAB83,  (char32_t)0xAB84,  (char32_t)0xAB85,
+    (char32_t)0xAB86,  (char32_t)0xAB87,  (char32_t)0xAB88,  (char32_t)0xAB89,  (char32_t)0xAB8A,
+    (char32_t)0xAB8B,  (char32_t)0xAB8C,  (char32_t)0xAB8D,  (char32_t)0xAB8E,  (char32_t)0xAB8F,
+    (char32_t)0xAB90,  (char32_t)0xAB91,  (char32_t)0xAB92,  (char32_t)0xAB93,  (char32_t)0xAB94,
+    (char32_t)0xAB95,  (char32_t)0xAB96,  (char32_t)0xAB97,  (char32_t)0xAB98,  (char32_t)0xAB99,
+    (char32_t)0xAB9A,  (char32_t)0xAB9B,  (char32_t)0xAB9C,  (char32_t)0xAB9D,  (char32_t)0xAB9E,
+    (char32_t)0xAB9F,  (char32_t)0xABA0,  (char32_t)0xABA1,  (char32_t)0xABA2,  (char32_t)0xABA3,
+    (char32_t)0xABA4,  (char32_t)0xABA5,  (char32_t)0xABA6,  (char32_t)0xABA7,  (char32_t)0xABA8,
+    (char32_t)0xABA9,  (char32_t)0xABAA,  (char32_t)0xABAB,  (char32_t)0xABAC,  (char32_t)0xABAD,
+    (char32_t)0xABAE,  (char32_t)0xABAF,  (char32_t)0xABB0,  (char32_t)0xABB1,  (char32_t)0xABB2,
+    (char32_t)0xABB3,  (char32_t)0xABB4,  (char32_t)0xABB5,  (char32_t)0xABB6,  (char32_t)0xABB7,
+    (char32_t)0xABB8,  (char32_t)0xABB9,  (char32_t)0xABBA,  (char32_t)0xABBB,  (char32_t)0xABBC,
+    (char32_t)0xABBD,  (char32_t)0xABBE,  (char32_t)0xABBF,  (char32_t)0xFF21,  (char32_t)0xFF22,
+    (char32_t)0xFF23,  (char32_t)0xFF24,  (char32_t)0xFF25,  (char32_t)0xFF26,  (char32_t)0xFF27,
+    (char32_t)0xFF28,  (char32_t)0xFF29,  (char32_t)0xFF2A,  (char32_t)0xFF2B,  (char32_t)0xFF2C,
+    (char32_t)0xFF2D,  (char32_t)0xFF2E,  (char32_t)0xFF2F,  (char32_t)0xFF30,  (char32_t)0xFF31,
+    (char32_t)0xFF32,  (char32_t)0xFF33,  (char32_t)0xFF34,  (char32_t)0xFF35,  (char32_t)0xFF36,
+    (char32_t)0xFF37,  (char32_t)0xFF38,  (char32_t)0xFF39,  (char32_t)0xFF3A,  (char32_t)0x10400,
+    (char32_t)0x10401, (char32_t)0x10402, (char32_t)0x10403, (char32_t)0x10404, (char32_t)0x10405,
+    (char32_t)0x10406, (char32_t)0x10407, (char32_t)0x10408, (char32_t)0x10409, (char32_t)0x1040A,
+    (char32_t)0x1040B, (char32_t)0x1040C, (char32_t)0x1040D, (char32_t)0x1040E, (char32_t)0x1040F,
+    (char32_t)0x10410, (char32_t)0x10411, (char32_t)0x10412, (char32_t)0x10413, (char32_t)0x10414,
+    (char32_t)0x10415, (char32_t)0x10416, (char32_t)0x10417, (char32_t)0x10418, (char32_t)0x10419,
+    (char32_t)0x1041A, (char32_t)0x1041B, (char32_t)0x1041C, (char32_t)0x1041D, (char32_t)0x1041E,
+    (char32_t)0x1041F, (char32_t)0x10420, (char32_t)0x10421, (char32_t)0x10422, (char32_t)0x10423,
+    (char32_t)0x10424, (char32_t)0x10425, (char32_t)0x10426, (char32_t)0x10427, (char32_t)0x104B0,
+    (char32_t)0x104B1, (char32_t)0x104B2, (char32_t)0x104B3, (char32_t)0x104B4, (char32_t)0x104B5,
+    (char32_t)0x104B6, (char32_t)0x104B7, (char32_t)0x104B8, (char32_t)0x104B9, (char32_t)0x104BA,
+    (char32_t)0x104BB, (char32_t)0x104BC, (char32_t)0x104BD, (char32_t)0x104BE, (char32_t)0x104BF,
+    (char32_t)0x104C0, (char32_t)0x104C1, (char32_t)0x104C2, (char32_t)0x104C3, (char32_t)0x104C4,
+    (char32_t)0x104C5, (char32_t)0x104C6, (char32_t)0x104C7, (char32_t)0x104C8, (char32_t)0x104C9,
+    (char32_t)0x104CA, (char32_t)0x104CB, (char32_t)0x104CC, (char32_t)0x104CD, (char32_t)0x104CE,
+    (char32_t)0x104CF, (char32_t)0x104D0, (char32_t)0x104D1, (char32_t)0x104D2, (char32_t)0x104D3,
+    (char32_t)0x10570, (char32_t)0x10571, (char32_t)0x10572, (char32_t)0x10573, (char32_t)0x10574,
+    (char32_t)0x10575, (char32_t)0x10576, (char32_t)0x10577, (char32_t)0x10578, (char32_t)0x10579,
+    (char32_t)0x1057A, (char32_t)0x1057C, (char32_t)0x1057D, (char32_t)0x1057E, (char32_t)0x1057F,
+    (char32_t)0x10580, (char32_t)0x10581, (char32_t)0x10582, (char32_t)0x10583, (char32_t)0x10584,
+    (char32_t)0x10585, (char32_t)0x10586, (char32_t)0x10587, (char32_t)0x10588, (char32_t)0x10589,
+    (char32_t)0x1058A, (char32_t)0x1058C, (char32_t)0x1058D, (char32_t)0x1058E, (char32_t)0x1058F,
+    (char32_t)0x10590, (char32_t)0x10591, (char32_t)0x10592, (char32_t)0x10594, (char32_t)0x10595,
+    (char32_t)0x10C80, (char32_t)0x10C81, (char32_t)0x10C82, (char32_t)0x10C83, (char32_t)0x10C84,
+    (char32_t)0x10C85, (char32_t)0x10C86, (char32_t)0x10C87, (char32_t)0x10C88, (char32_t)0x10C89,
+    (char32_t)0x10C8A, (char32_t)0x10C8B, (char32_t)0x10C8C, (char32_t)0x10C8D, (char32_t)0x10C8E,
+    (char32_t)0x10C8F, (char32_t)0x10C90, (char32_t)0x10C91, (char32_t)0x10C92, (char32_t)0x10C93,
+    (char32_t)0x10C94, (char32_t)0x10C95, (char32_t)0x10C96, (char32_t)0x10C97, (char32_t)0x10C98,
+    (char32_t)0x10C99, (char32_t)0x10C9A, (char32_t)0x10C9B, (char32_t)0x10C9C, (char32_t)0x10C9D,
+    (char32_t)0x10C9E, (char32_t)0x10C9F, (char32_t)0x10CA0, (char32_t)0x10CA1, (char32_t)0x10CA2,
+    (char32_t)0x10CA3, (char32_t)0x10CA4, (char32_t)0x10CA5, (char32_t)0x10CA6, (char32_t)0x10CA7,
+    (char32_t)0x10CA8, (char32_t)0x10CA9, (char32_t)0x10CAA, (char32_t)0x10CAB, (char32_t)0x10CAC,
+    (char32_t)0x10CAD, (char32_t)0x10CAE, (char32_t)0x10CAF, (char32_t)0x10CB0, (char32_t)0x10CB1,
+    (char32_t)0x10CB2, (char32_t)0x118A0, (char32_t)0x118A1, (char32_t)0x118A2, (char32_t)0x118A3,
+    (char32_t)0x118A4, (char32_t)0x118A5, (char32_t)0x118A6, (char32_t)0x118A7, (char32_t)0x118A8,
+    (char32_t)0x118A9, (char32_t)0x118AA, (char32_t)0x118AB, (char32_t)0x118AC, (char32_t)0x118AD,
+    (char32_t)0x118AE, (char32_t)0x118AF, (char32_t)0x118B0, (char32_t)0x118B1, (char32_t)0x118B2,
+    (char32_t)0x118B3, (char32_t)0x118B4, (char32_t)0x118B5, (char32_t)0x118B6, (char32_t)0x118B7,
+    (char32_t)0x118B8, (char32_t)0x118B9, (char32_t)0x118BA, (char32_t)0x118BB, (char32_t)0x118BC,
+    (char32_t)0x118BD, (char32_t)0x118BE, (char32_t)0x118BF, (char32_t)0x16E40, (char32_t)0x16E41,
+    (char32_t)0x16E42, (char32_t)0x16E43, (char32_t)0x16E44, (char32_t)0x16E45, (char32_t)0x16E46,
+    (char32_t)0x16E47, (char32_t)0x16E48, (char32_t)0x16E49, (char32_t)0x16E4A, (char32_t)0x16E4B,
+    (char32_t)0x16E4C, (char32_t)0x16E4D, (char32_t)0x16E4E, (char32_t)0x16E4F, (char32_t)0x16E50,
+    (char32_t)0x16E51, (char32_t)0x16E52, (char32_t)0x16E53, (char32_t)0x16E54, (char32_t)0x16E55,
+    (char32_t)0x16E56, (char32_t)0x16E57, (char32_t)0x16E58, (char32_t)0x16E59, (char32_t)0x16E5A,
+    (char32_t)0x16E5B, (char32_t)0x16E5C, (char32_t)0x16E5D, (char32_t)0x16E5E, (char32_t)0x16E5F,
+    (char32_t)0x1E900, (char32_t)0x1E901, (char32_t)0x1E902, (char32_t)0x1E903, (char32_t)0x1E904,
+    (char32_t)0x1E905, (char32_t)0x1E906, (char32_t)0x1E907, (char32_t)0x1E908, (char32_t)0x1E909,
+    (char32_t)0x1E90A, (char32_t)0x1E90B, (char32_t)0x1E90C, (char32_t)0x1E90D, (char32_t)0x1E90E,
+    (char32_t)0x1E90F, (char32_t)0x1E910, (char32_t)0x1E911, (char32_t)0x1E912, (char32_t)0x1E913,
+    (char32_t)0x1E914, (char32_t)0x1E915, (char32_t)0x1E916, (char32_t)0x1E917, (char32_t)0x1E918,
+    (char32_t)0x1E919, (char32_t)0x1E91A, (char32_t)0x1E91B, (char32_t)0x1E91C, (char32_t)0x1E91D,
+    (char32_t)0x1E91E, (char32_t)0x1E91F, (char32_t)0x1E920, (char32_t)0x1E921};
+
+static const char32_t unicode_fold_lower[] = {
+    (char32_t)0x0061,  (char32_t)0x0062,  (char32_t)0x0063,  (char32_t)0x0064,  (char32_t)0x0065,
+    (char32_t)0x0066,  (char32_t)0x0067,  (char32_t)0x0068,  (char32_t)0x0069,  (char32_t)0x006A,
+    (char32_t)0x006B,  (char32_t)0x006C,  (char32_t)0x006D,  (char32_t)0x006E,  (char32_t)0x006F,
+    (char32_t)0x0070,  (char32_t)0x0071,  (char32_t)0x0072,  (char32_t)0x0073,  (char32_t)0x0074,
+    (char32_t)0x0075,  (char32_t)0x0076,  (char32_t)0x0077,  (char32_t)0x0078,  (char32_t)0x0079,
+    (char32_t)0x007A,  (char32_t)0x03BC,  (char32_t)0x00E0,  (char32_t)0x00E1,  (char32_t)0x00E2,
+    (char32_t)0x00E3,  (char32_t)0x00E4,  (char32_t)0x00E5,  (char32_t)0x00E6,  (char32_t)0x00E7,
+    (char32_t)0x00E8,  (char32_t)0x00E9,  (char32_t)0x00EA,  (char32_t)0x00EB,  (char32_t)0x00EC,
+    (char32_t)0x00ED,  (char32_t)0x00EE,  (char32_t)0x00EF,  (char32_t)0x00F0,  (char32_t)0x00F1,
+    (char32_t)0x00F2,  (char32_t)0x00F3,  (char32_t)0x00F4,  (char32_t)0x00F5,  (char32_t)0x00F6,
+    (char32_t)0x00F8,  (char32_t)0x00F9,  (char32_t)0x00FA,  (char32_t)0x00FB,  (char32_t)0x00FC,
+    (char32_t)0x00FD,  (char32_t)0x00FE,  (char32_t)0x0101,  (char32_t)0x0103,  (char32_t)0x0105,
+    (char32_t)0x0107,  (char32_t)0x0109,  (char32_t)0x010B,  (char32_t)0x010D,  (char32_t)0x010F,
+    (char32_t)0x0111,  (char32_t)0x0113,  (char32_t)0x0115,  (char32_t)0x0117,  (char32_t)0x0119,
+    (char32_t)0x011B,  (char32_t)0x011D,  (char32_t)0x011F,  (char32_t)0x0121,  (char32_t)0x0123,
+    (char32_t)0x0125,  (char32_t)0x0127,  (char32_t)0x0129,  (char32_t)0x012B,  (char32_t)0x012D,
+    (char32_t)0x012F,  (char32_t)0x0133,  (char32_t)0x0135,  (char32_t)0x0137,  (char32_t)0x013A,
+    (char32_t)0x013C,  (char32_t)0x013E,  (char32_t)0x0140,  (char32_t)0x0142,  (char32_t)0x0144,
+    (char32_t)0x0146,  (char32_t)0x0148,  (char32_t)0x014B,  (char32_t)0x014D,  (char32_t)0x014F,
+    (char32_t)0x0151,  (char32_t)0x0153,  (char32_t)0x0155,  (char32_t)0x0157,  (char32_t)0x0159,
+    (char32_t)0x015B,  (char32_t)0x015D,  (char32_t)0x015F,  (char32_t)0x0161,  (char32_t)0x0163,
+    (char32_t)0x0165,  (char32_t)0x0167,  (char32_t)0x0169,  (char32_t)0x016B,  (char32_t)0x016D,
+    (char32_t)0x016F,  (char32_t)0x0171,  (char32_t)0x0173,  (char32_t)0x0175,  (char32_t)0x0177,
+    (char32_t)0x00FF,  (char32_t)0x017A,  (char32_t)0x017C,  (char32_t)0x017E,  (char32_t)0x0073,
+    (char32_t)0x0253,  (char32_t)0x0183,  (char32_t)0x0185,  (char32_t)0x0254,  (char32_t)0x0188,
+    (char32_t)0x0256,  (char32_t)0x0257,  (char32_t)0x018C,  (char32_t)0x01DD,  (char32_t)0x0259,
+    (char32_t)0x025B,  (char32_t)0x0192,  (char32_t)0x0260,  (char32_t)0x0263,  (char32_t)0x0269,
+    (char32_t)0x0268,  (char32_t)0x0199,  (char32_t)0x026F,  (char32_t)0x0272,  (char32_t)0x0275,
+    (char32_t)0x01A1,  (char32_t)0x01A3,  (char32_t)0x01A5,  (char32_t)0x0280,  (char32_t)0x01A8,
+    (char32_t)0x0283,  (char32_t)0x01AD,  (char32_t)0x0288,  (char32_t)0x01B0,  (char32_t)0x028A,
+    (char32_t)0x028B,  (char32_t)0x01B4,  (char32_t)0x01B6,  (char32_t)0x0292,  (char32_t)0x01B9,
+    (char32_t)0x01BD,  (char32_t)0x01C6,  (char32_t)0x01C6,  (char32_t)0x01C9,  (char32_t)0x01C9,
+    (char32_t)0x01CC,  (char32_t)0x01CC,  (char32_t)0x01CE,  (char32_t)0x01D0,  (char32_t)0x01D2,
+    (char32_t)0x01D4,  (char32_t)0x01D6,  (char32_t)0x01D8,  (char32_t)0x01DA,  (char32_t)0x01DC,
+    (char32_t)0x01DF,  (char32_t)0x01E1,  (char32_t)0x01E3,  (char32_t)0x01E5,  (char32_t)0x01E7,
+    (char32_t)0x01E9,  (char32_t)0x01EB,  (char32_t)0x01ED,  (char32_t)0x01EF,  (char32_t)0x01F3,
+    (char32_t)0x01F3,  (char32_t)0x01F5,  (char32_t)0x0195,  (char32_t)0x01BF,  (char32_t)0x01F9,
+    (char32_t)0x01FB,  (char32_t)0x01FD,  (char32_t)0x01FF,  (char32_t)0x0201,  (char32_t)0x0203,
+    (char32_t)0x0205,  (char32_t)0x0207,  (char32_t)0x0209,  (char32_t)0x020B,  (char32_t)0x020D,
+    (char32_t)0x020F,  (char32_t)0x0211,  (char32_t)0x0213,  (char32_t)0x0215,  (char32_t)0x0217,
+    (char32_t)0x0219,  (char32_t)0x021B,  (char32_t)0x021D,  (char32_t)0x021F,  (char32_t)0x019E,
+    (char32_t)0x0223,  (char32_t)0x0225,  (char32_t)0x0227,  (char32_t)0x0229,  (char32_t)0x022B,
+    (char32_t)0x022D,  (char32_t)0x022F,  (char32_t)0x0231,  (char32_t)0x0233,  (char32_t)0x2C65,
+    (char32_t)0x023C,  (char32_t)0x019A,  (char32_t)0x2C66,  (char32_t)0x0242,  (char32_t)0x0180,
+    (char32_t)0x0289,  (char32_t)0x028C,  (char32_t)0x0247,  (char32_t)0x0249,  (char32_t)0x024B,
+    (char32_t)0x024D,  (char32_t)0x024F,  (char32_t)0x03B9,  (char32_t)0x0371,  (char32_t)0x0373,
+    (char32_t)0x0377,  (char32_t)0x03F3,  (char32_t)0x03AC,  (char32_t)0x03AD,  (char32_t)0x03AE,
+    (char32_t)0x03AF,  (char32_t)0x03CC,  (char32_t)0x03CD,  (char32_t)0x03CE,  (char32_t)0x03B1,
+    (char32_t)0x03B2,  (char32_t)0x03B3,  (char32_t)0x03B4,  (char32_t)0x03B5,  (char32_t)0x03B6,
+    (char32_t)0x03B7,  (char32_t)0x03B8,  (char32_t)0x03B9,  (char32_t)0x03BA,  (char32_t)0x03BB,
+    (char32_t)0x03BC,  (char32_t)0x03BD,  (char32_t)0x03BE,  (char32_t)0x03BF,  (char32_t)0x03C0,
+    (char32_t)0x03C1,  (char32_t)0x03C3,  (char32_t)0x03C4,  (char32_t)0x03C5,  (char32_t)0x03C6,
+    (char32_t)0x03C7,  (char32_t)0x03C8,  (char32_t)0x03C9,  (char32_t)0x03CA,  (char32_t)0x03CB,
+    (char32_t)0x03C3,  (char32_t)0x03D7,  (char32_t)0x03B2,  (char32_t)0x03B8,  (char32_t)0x03C6,
+    (char32_t)0x03C0,  (char32_t)0x03D9,  (char32_t)0x03DB,  (char32_t)0x03DD,  (char32_t)0x03DF,
+    (char32_t)0x03E1,  (char32_t)0x03E3,  (char32_t)0x03E5,  (char32_t)0x03E7,  (char32_t)0x03E9,
+    (char32_t)0x03EB,  (char32_t)0x03ED,  (char32_t)0x03EF,  (char32_t)0x03BA,  (char32_t)0x03C1,
+    (char32_t)0x03B8,  (char32_t)0x03B5,  (char32_t)0x03F8,  (char32_t)0x03F2,  (char32_t)0x03FB,
+    (char32_t)0x037B,  (char32_t)0x037C,  (char32_t)0x037D,  (char32_t)0x0450,  (char32_t)0x0451,
+    (char32_t)0x0452,  (char32_t)0x0453,  (char32_t)0x0454,  (char32_t)0x0455,  (char32_t)0x0456,
+    (char32_t)0x0457,  (char32_t)0x0458,  (char32_t)0x0459,  (char32_t)0x045A,  (char32_t)0x045B,
+    (char32_t)0x045C,  (char32_t)0x045D,  (char32_t)0x045E,  (char32_t)0x045F,  (char32_t)0x0430,
+    (char32_t)0x0431,  (char32_t)0x0432,  (char32_t)0x0433,  (char32_t)0x0434,  (char32_t)0x0435,
+    (char32_t)0x0436,  (char32_t)0x0437,  (char32_t)0x0438,  (char32_t)0x0439,  (char32_t)0x043A,
+    (char32_t)0x043B,  (char32_t)0x043C,  (char32_t)0x043D,  (char32_t)0x043E,  (char32_t)0x043F,
+    (char32_t)0x0440,  (char32_t)0x0441,  (char32_t)0x0442,  (char32_t)0x0443,  (char32_t)0x0444,
+    (char32_t)0x0445,  (char32_t)0x0446,  (char32_t)0x0447,  (char32_t)0x0448,  (char32_t)0x0449,
+    (char32_t)0x044A,  (char32_t)0x044B,  (char32_t)0x044C,  (char32_t)0x044D,  (char32_t)0x044E,
+    (char32_t)0x044F,  (char32_t)0x0461,  (char32_t)0x0463,  (char32_t)0x0465,  (char32_t)0x0467,
+    (char32_t)0x0469,  (char32_t)0x046B,  (char32_t)0x046D,  (char32_t)0x046F,  (char32_t)0x0471,
+    (char32_t)0x0473,  (char32_t)0x0475,  (char32_t)0x0477,  (char32_t)0x0479,  (char32_t)0x047B,
+    (char32_t)0x047D,  (char32_t)0x047F,  (char32_t)0x0481,  (char32_t)0x048B,  (char32_t)0x048D,
+    (char32_t)0x048F,  (char32_t)0x0491,  (char32_t)0x0493,  (char32_t)0x0495,  (char32_t)0x0497,
+    (char32_t)0x0499,  (char32_t)0x049B,  (char32_t)0x049D,  (char32_t)0x049F,  (char32_t)0x04A1,
+    (char32_t)0x04A3,  (char32_t)0x04A5,  (char32_t)0x04A7,  (char32_t)0x04A9,  (char32_t)0x04AB,
+    (char32_t)0x04AD,  (char32_t)0x04AF,  (char32_t)0x04B1,  (char32_t)0x04B3,  (char32_t)0x04B5,
+    (char32_t)0x04B7,  (char32_t)0x04B9,  (char32_t)0x04BB,  (char32_t)0x04BD,  (char32_t)0x04BF,
+    (char32_t)0x04CF,  (char32_t)0x04C2,  (char32_t)0x04C4,  (char32_t)0x04C6,  (char32_t)0x04C8,
+    (char32_t)0x04CA,  (char32_t)0x04CC,  (char32_t)0x04CE,  (char32_t)0x04D1,  (char32_t)0x04D3,
+    (char32_t)0x04D5,  (char32_t)0x04D7,  (char32_t)0x04D9,  (char32_t)0x04DB,  (char32_t)0x04DD,
+    (char32_t)0x04DF,  (char32_t)0x04E1,  (char32_t)0x04E3,  (char32_t)0x04E5,  (char32_t)0x04E7,
+    (char32_t)0x04E9,  (char32_t)0x04EB,  (char32_t)0x04ED,  (char32_t)0x04EF,  (char32_t)0x04F1,
+    (char32_t)0x04F3,  (char32_t)0x04F5,  (char32_t)0x04F7,  (char32_t)0x04F9,  (char32_t)0x04FB,
+    (char32_t)0x04FD,  (char32_t)0x04FF,  (char32_t)0x0501,  (char32_t)0x0503,  (char32_t)0x0505,
+    (char32_t)0x0507,  (char32_t)0x0509,  (char32_t)0x050B,  (char32_t)0x050D,  (char32_t)0x050F,
+    (char32_t)0x0511,  (char32_t)0x0513,  (char32_t)0x0515,  (char32_t)0x0517,  (char32_t)0x0519,
+    (char32_t)0x051B,  (char32_t)0x051D,  (char32_t)0x051F,  (char32_t)0x0521,  (char32_t)0x0523,
+    (char32_t)0x0525,  (char32_t)0x0527,  (char32_t)0x0529,  (char32_t)0x052B,  (char32_t)0x052D,
+    (char32_t)0x052F,  (char32_t)0x0561,  (char32_t)0x0562,  (char32_t)0x0563,  (char32_t)0x0564,
+    (char32_t)0x0565,  (char32_t)0x0566,  (char32_t)0x0567,  (char32_t)0x0568,  (char32_t)0x0569,
+    (char32_t)0x056A,  (char32_t)0x056B,  (char32_t)0x056C,  (char32_t)0x056D,  (char32_t)0x056E,
+    (char32_t)0x056F,  (char32_t)0x0570,  (char32_t)0x0571,  (char32_t)0x0572,  (char32_t)0x0573,
+    (char32_t)0x0574,  (char32_t)0x0575,  (char32_t)0x0576,  (char32_t)0x0577,  (char32_t)0x0578,
+    (char32_t)0x0579,  (char32_t)0x057A,  (char32_t)0x057B,  (char32_t)0x057C,  (char32_t)0x057D,
+    (char32_t)0x057E,  (char32_t)0x057F,  (char32_t)0x0580,  (char32_t)0x0581,  (char32_t)0x0582,
+    (char32_t)0x0583,  (char32_t)0x0584,  (char32_t)0x0585,  (char32_t)0x0586,  (char32_t)0x2D00,
+    (char32_t)0x2D01,  (char32_t)0x2D02,  (char32_t)0x2D03,  (char32_t)0x2D04,  (char32_t)0x2D05,
+    (char32_t)0x2D06,  (char32_t)0x2D07,  (char32_t)0x2D08,  (char32_t)0x2D09,  (char32_t)0x2D0A,
+    (char32_t)0x2D0B,  (char32_t)0x2D0C,  (char32_t)0x2D0D,  (char32_t)0x2D0E,  (char32_t)0x2D0F,
+    (char32_t)0x2D10,  (char32_t)0x2D11,  (char32_t)0x2D12,  (char32_t)0x2D13,  (char32_t)0x2D14,
+    (char32_t)0x2D15,  (char32_t)0x2D16,  (char32_t)0x2D17,  (char32_t)0x2D18,  (char32_t)0x2D19,
+    (char32_t)0x2D1A,  (char32_t)0x2D1B,  (char32_t)0x2D1C,  (char32_t)0x2D1D,  (char32_t)0x2D1E,
+    (char32_t)0x2D1F,  (char32_t)0x2D20,  (char32_t)0x2D21,  (char32_t)0x2D22,  (char32_t)0x2D23,
+    (char32_t)0x2D24,  (char32_t)0x2D25,  (char32_t)0x2D27,  (char32_t)0x2D2D,  (char32_t)0x13F0,
+    (char32_t)0x13F1,  (char32_t)0x13F2,  (char32_t)0x13F3,  (char32_t)0x13F4,  (char32_t)0x13F5,
+    (char32_t)0x0432,  (char32_t)0x0434,  (char32_t)0x043E,  (char32_t)0x0441,  (char32_t)0x0442,
+    (char32_t)0x0442,  (char32_t)0x044A,  (char32_t)0x0463,  (char32_t)0xA64B,  (char32_t)0x10D0,
+    (char32_t)0x10D1,  (char32_t)0x10D2,  (char32_t)0x10D3,  (char32_t)0x10D4,  (char32_t)0x10D5,
+    (char32_t)0x10D6,  (char32_t)0x10D7,  (char32_t)0x10D8,  (char32_t)0x10D9,  (char32_t)0x10DA,
+    (char32_t)0x10DB,  (char32_t)0x10DC,  (char32_t)0x10DD,  (char32_t)0x10DE,  (char32_t)0x10DF,
+    (char32_t)0x10E0,  (char32_t)0x10E1,  (char32_t)0x10E2,  (char32_t)0x10E3,  (char32_t)0x10E4,
+    (char32_t)0x10E5,  (char32_t)0x10E6,  (char32_t)0x10E7,  (char32_t)0x10E8,  (char32_t)0x10E9,
+    (char32_t)0x10EA,  (char32_t)0x10EB,  (char32_t)0x10EC,  (char32_t)0x10ED,  (char32_t)0x10EE,
+    (char32_t)0x10EF,  (char32_t)0x10F0,  (char32_t)0x10F1,  (char32_t)0x10F2,  (char32_t)0x10F3,
+    (char32_t)0x10F4,  (char32_t)0x10F5,  (char32_t)0x10F6,  (char32_t)0x10F7,  (char32_t)0x10F8,
+    (char32_t)0x10F9,  (char32_t)0x10FA,  (char32_t)0x10FD,  (char32_t)0x10FE,  (char32_t)0x10FF,
+    (char32_t)0x1E01,  (char32_t)0x1E03,  (char32_t)0x1E05,  (char32_t)0x1E07,  (char32_t)0x1E09,
+    (char32_t)0x1E0B,  (char32_t)0x1E0D,  (char32_t)0x1E0F,  (char32_t)0x1E11,  (char32_t)0x1E13,
+    (char32_t)0x1E15,  (char32_t)0x1E17,  (char32_t)0x1E19,  (char32_t)0x1E1B,  (char32_t)0x1E1D,
+    (char32_t)0x1E1F,  (char32_t)0x1E21,  (char32_t)0x1E23,  (char32_t)0x1E25,  (char32_t)0x1E27,
+    (char32_t)0x1E29,  (char32_t)0x1E2B,  (char32_t)0x1E2D,  (char32_t)0x1E2F,  (char32_t)0x1E31,
+    (char32_t)0x1E33,  (char32_t)0x1E35,  (char32_t)0x1E37,  (char32_t)0x1E39,  (char32_t)0x1E3B,
+    (char32_t)0x1E3D,  (char32_t)0x1E3F,  (char32_t)0x1E41,  (char32_t)0x1E43,  (char32_t)0x1E45,
+    (char32_t)0x1E47,  (char32_t)0x1E49,  (char32_t)0x1E4B,  (char32_t)0x1E4D,  (char32_t)0x1E4F,
+    (char32_t)0x1E51,  (char32_t)0x1E53,  (char32_t)0x1E55,  (char32_t)0x1E57,  (char32_t)0x1E59,
+    (char32_t)0x1E5B,  (char32_t)0x1E5D,  (char32_t)0x1E5F,  (char32_t)0x1E61,  (char32_t)0x1E63,
+    (char32_t)0x1E65,  (char32_t)0x1E67,  (char32_t)0x1E69,  (char32_t)0x1E6B,  (char32_t)0x1E6D,
+    (char32_t)0x1E6F,  (char32_t)0x1E71,  (char32_t)0x1E73,  (char32_t)0x1E75,  (char32_t)0x1E77,
+    (char32_t)0x1E79,  (char32_t)0x1E7B,  (char32_t)0x1E7D,  (char32_t)0x1E7F,  (char32_t)0x1E81,
+    (char32_t)0x1E83,  (char32_t)0x1E85,  (char32_t)0x1E87,  (char32_t)0x1E89,  (char32_t)0x1E8B,
+    (char32_t)0x1E8D,  (char32_t)0x1E8F,  (char32_t)0x1E91,  (char32_t)0x1E93,  (char32_t)0x1E95,
+    (char32_t)0x1E61,  (char32_t)0x00DF,  (char32_t)0x1EA1,  (char32_t)0x1EA3,  (char32_t)0x1EA5,
+    (char32_t)0x1EA7,  (char32_t)0x1EA9,  (char32_t)0x1EAB,  (char32_t)0x1EAD,  (char32_t)0x1EAF,
+    (char32_t)0x1EB1,  (char32_t)0x1EB3,  (char32_t)0x1EB5,  (char32_t)0x1EB7,  (char32_t)0x1EB9,
+    (char32_t)0x1EBB,  (char32_t)0x1EBD,  (char32_t)0x1EBF,  (char32_t)0x1EC1,  (char32_t)0x1EC3,
+    (char32_t)0x1EC5,  (char32_t)0x1EC7,  (char32_t)0x1EC9,  (char32_t)0x1ECB,  (char32_t)0x1ECD,
+    (char32_t)0x1ECF,  (char32_t)0x1ED1,  (char32_t)0x1ED3,  (char32_t)0x1ED5,  (char32_t)0x1ED7,
+    (char32_t)0x1ED9,  (char32_t)0x1EDB,  (char32_t)0x1EDD,  (char32_t)0x1EDF,  (char32_t)0x1EE1,
+    (char32_t)0x1EE3,  (char32_t)0x1EE5,  (char32_t)0x1EE7,  (char32_t)0x1EE9,  (char32_t)0x1EEB,
+    (char32_t)0x1EED,  (char32_t)0x1EEF,  (char32_t)0x1EF1,  (char32_t)0x1EF3,  (char32_t)0x1EF5,
+    (char32_t)0x1EF7,  (char32_t)0x1EF9,  (char32_t)0x1EFB,  (char32_t)0x1EFD,  (char32_t)0x1EFF,
+    (char32_t)0x1F00,  (char32_t)0x1F01,  (char32_t)0x1F02,  (char32_t)0x1F03,  (char32_t)0x1F04,
+    (char32_t)0x1F05,  (char32_t)0x1F06,  (char32_t)0x1F07,  (char32_t)0x1F10,  (char32_t)0x1F11,
+    (char32_t)0x1F12,  (char32_t)0x1F13,  (char32_t)0x1F14,  (char32_t)0x1F15,  (char32_t)0x1F20,
+    (char32_t)0x1F21,  (char32_t)0x1F22,  (char32_t)0x1F23,  (char32_t)0x1F24,  (char32_t)0x1F25,
+    (char32_t)0x1F26,  (char32_t)0x1F27,  (char32_t)0x1F30,  (char32_t)0x1F31,  (char32_t)0x1F32,
+    (char32_t)0x1F33,  (char32_t)0x1F34,  (char32_t)0x1F35,  (char32_t)0x1F36,  (char32_t)0x1F37,
+    (char32_t)0x1F40,  (char32_t)0x1F41,  (char32_t)0x1F42,  (char32_t)0x1F43,  (char32_t)0x1F44,
+    (char32_t)0x1F45,  (char32_t)0x1F51,  (char32_t)0x1F53,  (char32_t)0x1F55,  (char32_t)0x1F57,
+    (char32_t)0x1F60,  (char32_t)0x1F61,  (char32_t)0x1F62,  (char32_t)0x1F63,  (char32_t)0x1F64,
+    (char32_t)0x1F65,  (char32_t)0x1F66,  (char32_t)0x1F67,  (char32_t)0x1F80,  (char32_t)0x1F81,
+    (char32_t)0x1F82,  (char32_t)0x1F83,  (char32_t)0x1F84,  (char32_t)0x1F85,  (char32_t)0x1F86,
+    (char32_t)0x1F87,  (char32_t)0x1F90,  (char32_t)0x1F91,  (char32_t)0x1F92,  (char32_t)0x1F93,
+    (char32_t)0x1F94,  (char32_t)0x1F95,  (char32_t)0x1F96,  (char32_t)0x1F97,  (char32_t)0x1FA0,
+    (char32_t)0x1FA1,  (char32_t)0x1FA2,  (char32_t)0x1FA3,  (char32_t)0x1FA4,  (char32_t)0x1FA5,
+    (char32_t)0x1FA6,  (char32_t)0x1FA7,  (char32_t)0x1FB0,  (char32_t)0x1FB1,  (char32_t)0x1F70,
+    (char32_t)0x1F71,  (char32_t)0x1FB3,  (char32_t)0x03B9,  (char32_t)0x1F72,  (char32_t)0x1F73,
+    (char32_t)0x1F74,  (char32_t)0x1F75,  (char32_t)0x1FC3,  (char32_t)0x1FD0,  (char32_t)0x1FD1,
+    (char32_t)0x1F76,  (char32_t)0x1F77,  (char32_t)0x1FE0,  (char32_t)0x1FE1,  (char32_t)0x1F7A,
+    (char32_t)0x1F7B,  (char32_t)0x1FE5,  (char32_t)0x1F78,  (char32_t)0x1F79,  (char32_t)0x1F7C,
+    (char32_t)0x1F7D,  (char32_t)0x1FF3,  (char32_t)0x03C9,  (char32_t)0x006B,  (char32_t)0x00E5,
+    (char32_t)0x214E,  (char32_t)0x2170,  (char32_t)0x2171,  (char32_t)0x2172,  (char32_t)0x2173,
+    (char32_t)0x2174,  (char32_t)0x2175,  (char32_t)0x2176,  (char32_t)0x2177,  (char32_t)0x2178,
+    (char32_t)0x2179,  (char32_t)0x217A,  (char32_t)0x217B,  (char32_t)0x217C,  (char32_t)0x217D,
+    (char32_t)0x217E,  (char32_t)0x217F,  (char32_t)0x2184,  (char32_t)0x24D0,  (char32_t)0x24D1,
+    (char32_t)0x24D2,  (char32_t)0x24D3,  (char32_t)0x24D4,  (char32_t)0x24D5,  (char32_t)0x24D6,
+    (char32_t)0x24D7,  (char32_t)0x24D8,  (char32_t)0x24D9,  (char32_t)0x24DA,  (char32_t)0x24DB,
+    (char32_t)0x24DC,  (char32_t)0x24DD,  (char32_t)0x24DE,  (char32_t)0x24DF,  (char32_t)0x24E0,
+    (char32_t)0x24E1,  (char32_t)0x24E2,  (char32_t)0x24E3,  (char32_t)0x24E4,  (char32_t)0x24E5,
+    (char32_t)0x24E6,  (char32_t)0x24E7,  (char32_t)0x24E8,  (char32_t)0x24E9,  (char32_t)0x2C30,
+    (char32_t)0x2C31,  (char32_t)0x2C32,  (char32_t)0x2C33,  (char32_t)0x2C34,  (char32_t)0x2C35,
+    (char32_t)0x2C36,  (char32_t)0x2C37,  (char32_t)0x2C38,  (char32_t)0x2C39,  (char32_t)0x2C3A,
+    (char32_t)0x2C3B,  (char32_t)0x2C3C,  (char32_t)0x2C3D,  (char32_t)0x2C3E,  (char32_t)0x2C3F,
+    (char32_t)0x2C40,  (char32_t)0x2C41,  (char32_t)0x2C42,  (char32_t)0x2C43,  (char32_t)0x2C44,
+    (char32_t)0x2C45,  (char32_t)0x2C46,  (char32_t)0x2C47,  (char32_t)0x2C48,  (char32_t)0x2C49,
+    (char32_t)0x2C4A,  (char32_t)0x2C4B,  (char32_t)0x2C4C,  (char32_t)0x2C4D,  (char32_t)0x2C4E,
+    (char32_t)0x2C4F,  (char32_t)0x2C50,  (char32_t)0x2C51,  (char32_t)0x2C52,  (char32_t)0x2C53,
+    (char32_t)0x2C54,  (char32_t)0x2C55,  (char32_t)0x2C56,  (char32_t)0x2C57,  (char32_t)0x2C58,
+    (char32_t)0x2C59,  (char32_t)0x2C5A,  (char32_t)0x2C5B,  (char32_t)0x2C5C,  (char32_t)0x2C5D,
+    (char32_t)0x2C5E,  (char32_t)0x2C5F,  (char32_t)0x2C61,  (char32_t)0x026B,  (char32_t)0x1D7D,
+    (char32_t)0x027D,  (char32_t)0x2C68,  (char32_t)0x2C6A,  (char32_t)0x2C6C,  (char32_t)0x0251,
+    (char32_t)0x0271,  (char32_t)0x0250,  (char32_t)0x0252,  (char32_t)0x2C73,  (char32_t)0x2C76,
+    (char32_t)0x023F,  (char32_t)0x0240,  (char32_t)0x2C81,  (char32_t)0x2C83,  (char32_t)0x2C85,
+    (char32_t)0x2C87,  (char32_t)0x2C89,  (char32_t)0x2C8B,  (char32_t)0x2C8D,  (char32_t)0x2C8F,
+    (char32_t)0x2C91,  (char32_t)0x2C93,  (char32_t)0x2C95,  (char32_t)0x2C97,  (char32_t)0x2C99,
+    (char32_t)0x2C9B,  (char32_t)0x2C9D,  (char32_t)0x2C9F,  (char32_t)0x2CA1,  (char32_t)0x2CA3,
+    (char32_t)0x2CA5,  (char32_t)0x2CA7,  (char32_t)0x2CA9,  (char32_t)0x2CAB,  (char32_t)0x2CAD,
+    (char32_t)0x2CAF,  (char32_t)0x2CB1,  (char32_t)0x2CB3,  (char32_t)0x2CB5,  (char32_t)0x2CB7,
+    (char32_t)0x2CB9,  (char32_t)0x2CBB,  (char32_t)0x2CBD,  (char32_t)0x2CBF,  (char32_t)0x2CC1,
+    (char32_t)0x2CC3,  (char32_t)0x2CC5,  (char32_t)0x2CC7,  (char32_t)0x2CC9,  (char32_t)0x2CCB,
+    (char32_t)0x2CCD,  (char32_t)0x2CCF,  (char32_t)0x2CD1,  (char32_t)0x2CD3,  (char32_t)0x2CD5,
+    (char32_t)0x2CD7,  (char32_t)0x2CD9,  (char32_t)0x2CDB,  (char32_t)0x2CDD,  (char32_t)0x2CDF,
+    (char32_t)0x2CE1,  (char32_t)0x2CE3,  (char32_t)0x2CEC,  (char32_t)0x2CEE,  (char32_t)0x2CF3,
+    (char32_t)0xA641,  (char32_t)0xA643,  (char32_t)0xA645,  (char32_t)0xA647,  (char32_t)0xA649,
+    (char32_t)0xA64B,  (char32_t)0xA64D,  (char32_t)0xA64F,  (char32_t)0xA651,  (char32_t)0xA653,
+    (char32_t)0xA655,  (char32_t)0xA657,  (char32_t)0xA659,  (char32_t)0xA65B,  (char32_t)0xA65D,
+    (char32_t)0xA65F,  (char32_t)0xA661,  (char32_t)0xA663,  (char32_t)0xA665,  (char32_t)0xA667,
+    (char32_t)0xA669,  (char32_t)0xA66B,  (char32_t)0xA66D,  (char32_t)0xA681,  (char32_t)0xA683,
+    (char32_t)0xA685,  (char32_t)0xA687,  (char32_t)0xA689,  (char32_t)0xA68B,  (char32_t)0xA68D,
+    (char32_t)0xA68F,  (char32_t)0xA691,  (char32_t)0xA693,  (char32_t)0xA695,  (char32_t)0xA697,
+    (char32_t)0xA699,  (char32_t)0xA69B,  (char32_t)0xA723,  (char32_t)0xA725,  (char32_t)0xA727,
+    (char32_t)0xA729,  (char32_t)0xA72B,  (char32_t)0xA72D,  (char32_t)0xA72F,  (char32_t)0xA733,
+    (char32_t)0xA735,  (char32_t)0xA737,  (char32_t)0xA739,  (char32_t)0xA73B,  (char32_t)0xA73D,
+    (char32_t)0xA73F,  (char32_t)0xA741,  (char32_t)0xA743,  (char32_t)0xA745,  (char32_t)0xA747,
+    (char32_t)0xA749,  (char32_t)0xA74B,  (char32_t)0xA74D,  (char32_t)0xA74F,  (char32_t)0xA751,
+    (char32_t)0xA753,  (char32_t)0xA755,  (char32_t)0xA757,  (char32_t)0xA759,  (char32_t)0xA75B,
+    (char32_t)0xA75D,  (char32_t)0xA75F,  (char32_t)0xA761,  (char32_t)0xA763,  (char32_t)0xA765,
+    (char32_t)0xA767,  (char32_t)0xA769,  (char32_t)0xA76B,  (char32_t)0xA76D,  (char32_t)0xA76F,
+    (char32_t)0xA77A,  (char32_t)0xA77C,  (char32_t)0x1D79,  (char32_t)0xA77F,  (char32_t)0xA781,
+    (char32_t)0xA783,  (char32_t)0xA785,  (char32_t)0xA787,  (char32_t)0xA78C,  (char32_t)0x0265,
+    (char32_t)0xA791,  (char32_t)0xA793,  (char32_t)0xA797,  (char32_t)0xA799,  (char32_t)0xA79B,
+    (char32_t)0xA79D,  (char32_t)0xA79F,  (char32_t)0xA7A1,  (char32_t)0xA7A3,  (char32_t)0xA7A5,
+    (char32_t)0xA7A7,  (char32_t)0xA7A9,  (char32_t)0x0266,  (char32_t)0x025C,  (char32_t)0x0261,
+    (char32_t)0x026C,  (char32_t)0x026A,  (char32_t)0x029E,  (char32_t)0x0287,  (char32_t)0x029D,
+    (char32_t)0xAB53,  (char32_t)0xA7B5,  (char32_t)0xA7B7,  (char32_t)0xA7B9,  (char32_t)0xA7BB,
+    (char32_t)0xA7BD,  (char32_t)0xA7BF,  (char32_t)0xA7C1,  (char32_t)0xA7C3,  (char32_t)0xA794,
+    (char32_t)0x0282,  (char32_t)0x1D8E,  (char32_t)0xA7C8,  (char32_t)0xA7CA,  (char32_t)0xA7D1,
+    (char32_t)0xA7D7,  (char32_t)0xA7D9,  (char32_t)0xA7F6,  (char32_t)0x13A0,  (char32_t)0x13A1,
+    (char32_t)0x13A2,  (char32_t)0x13A3,  (char32_t)0x13A4,  (char32_t)0x13A5,  (char32_t)0x13A6,
+    (char32_t)0x13A7,  (char32_t)0x13A8,  (char32_t)0x13A9,  (char32_t)0x13AA,  (char32_t)0x13AB,
+    (char32_t)0x13AC,  (char32_t)0x13AD,  (char32_t)0x13AE,  (char32_t)0x13AF,  (char32_t)0x13B0,
+    (char32_t)0x13B1,  (char32_t)0x13B2,  (char32_t)0x13B3,  (char32_t)0x13B4,  (char32_t)0x13B5,
+    (char32_t)0x13B6,  (char32_t)0x13B7,  (char32_t)0x13B8,  (char32_t)0x13B9,  (char32_t)0x13BA,
+    (char32_t)0x13BB,  (char32_t)0x13BC,  (char32_t)0x13BD,  (char32_t)0x13BE,  (char32_t)0x13BF,
+    (char32_t)0x13C0,  (char32_t)0x13C1,  (char32_t)0x13C2,  (char32_t)0x13C3,  (char32_t)0x13C4,
+    (char32_t)0x13C5,  (char32_t)0x13C6,  (char32_t)0x13C7,  (char32_t)0x13C8,  (char32_t)0x13C9,
+    (char32_t)0x13CA,  (char32_t)0x13CB,  (char32_t)0x13CC,  (char32_t)0x13CD,  (char32_t)0x13CE,
+    (char32_t)0x13CF,  (char32_t)0x13D0,  (char32_t)0x13D1,  (char32_t)0x13D2,  (char32_t)0x13D3,
+    (char32_t)0x13D4,  (char32_t)0x13D5,  (char32_t)0x13D6,  (char32_t)0x13D7,  (char32_t)0x13D8,
+    (char32_t)0x13D9,  (char32_t)0x13DA,  (char32_t)0x13DB,  (char32_t)0x13DC,  (char32_t)0x13DD,
+    (char32_t)0x13DE,  (char32_t)0x13DF,  (char32_t)0x13E0,  (char32_t)0x13E1,  (char32_t)0x13E2,
+    (char32_t)0x13E3,  (char32_t)0x13E4,  (char32_t)0x13E5,  (char32_t)0x13E6,  (char32_t)0x13E7,
+    (char32_t)0x13E8,  (char32_t)0x13E9,  (char32_t)0x13EA,  (char32_t)0x13EB,  (char32_t)0x13EC,
+    (char32_t)0x13ED,  (char32_t)0x13EE,  (char32_t)0x13EF,  (char32_t)0xFF41,  (char32_t)0xFF42,
+    (char32_t)0xFF43,  (char32_t)0xFF44,  (char32_t)0xFF45,  (char32_t)0xFF46,  (char32_t)0xFF47,
+    (char32_t)0xFF48,  (char32_t)0xFF49,  (char32_t)0xFF4A,  (char32_t)0xFF4B,  (char32_t)0xFF4C,
+    (char32_t)0xFF4D,  (char32_t)0xFF4E,  (char32_t)0xFF4F,  (char32_t)0xFF50,  (char32_t)0xFF51,
+    (char32_t)0xFF52,  (char32_t)0xFF53,  (char32_t)0xFF54,  (char32_t)0xFF55,  (char32_t)0xFF56,
+    (char32_t)0xFF57,  (char32_t)0xFF58,  (char32_t)0xFF59,  (char32_t)0xFF5A,  (char32_t)0x10428,
+    (char32_t)0x10429, (char32_t)0x1042A, (char32_t)0x1042B, (char32_t)0x1042C, (char32_t)0x1042D,
+    (char32_t)0x1042E, (char32_t)0x1042F, (char32_t)0x10430, (char32_t)0x10431, (char32_t)0x10432,
+    (char32_t)0x10433, (char32_t)0x10434, (char32_t)0x10435, (char32_t)0x10436, (char32_t)0x10437,
+    (char32_t)0x10438, (char32_t)0x10439, (char32_t)0x1043A, (char32_t)0x1043B, (char32_t)0x1043C,
+    (char32_t)0x1043D, (char32_t)0x1043E, (char32_t)0x1043F, (char32_t)0x10440, (char32_t)0x10441,
+    (char32_t)0x10442, (char32_t)0x10443, (char32_t)0x10444, (char32_t)0x10445, (char32_t)0x10446,
+    (char32_t)0x10447, (char32_t)0x10448, (char32_t)0x10449, (char32_t)0x1044A, (char32_t)0x1044B,
+    (char32_t)0x1044C, (char32_t)0x1044D, (char32_t)0x1044E, (char32_t)0x1044F, (char32_t)0x104D8,
+    (char32_t)0x104D9, (char32_t)0x104DA, (char32_t)0x104DB, (char32_t)0x104DC, (char32_t)0x104DD,
+    (char32_t)0x104DE, (char32_t)0x104DF, (char32_t)0x104E0, (char32_t)0x104E1, (char32_t)0x104E2,
+    (char32_t)0x104E3, (char32_t)0x104E4, (char32_t)0x104E5, (char32_t)0x104E6, (char32_t)0x104E7,
+    (char32_t)0x104E8, (char32_t)0x104E9, (char32_t)0x104EA, (char32_t)0x104EB, (char32_t)0x104EC,
+    (char32_t)0x104ED, (char32_t)0x104EE, (char32_t)0x104EF, (char32_t)0x104F0, (char32_t)0x104F1,
+    (char32_t)0x104F2, (char32_t)0x104F3, (char32_t)0x104F4, (char32_t)0x104F5, (char32_t)0x104F6,
+    (char32_t)0x104F7, (char32_t)0x104F8, (char32_t)0x104F9, (char32_t)0x104FA, (char32_t)0x104FB,
+    (char32_t)0x10597, (char32_t)0x10598, (char32_t)0x10599, (char32_t)0x1059A, (char32_t)0x1059B,
+    (char32_t)0x1059C, (char32_t)0x1059D, (char32_t)0x1059E, (char32_t)0x1059F, (char32_t)0x105A0,
+    (char32_t)0x105A1, (char32_t)0x105A3, (char32_t)0x105A4, (char32_t)0x105A5, (char32_t)0x105A6,
+    (char32_t)0x105A7, (char32_t)0x105A8, (char32_t)0x105A9, (char32_t)0x105AA, (char32_t)0x105AB,
+    (char32_t)0x105AC, (char32_t)0x105AD, (char32_t)0x105AE, (char32_t)0x105AF, (char32_t)0x105B0,
+    (char32_t)0x105B1, (char32_t)0x105B3, (char32_t)0x105B4, (char32_t)0x105B5, (char32_t)0x105B6,
+    (char32_t)0x105B7, (char32_t)0x105B8, (char32_t)0x105B9, (char32_t)0x105BB, (char32_t)0x105BC,
+    (char32_t)0x10CC0, (char32_t)0x10CC1, (char32_t)0x10CC2, (char32_t)0x10CC3, (char32_t)0x10CC4,
+    (char32_t)0x10CC5, (char32_t)0x10CC6, (char32_t)0x10CC7, (char32_t)0x10CC8, (char32_t)0x10CC9,
+    (char32_t)0x10CCA, (char32_t)0x10CCB, (char32_t)0x10CCC, (char32_t)0x10CCD, (char32_t)0x10CCE,
+    (char32_t)0x10CCF, (char32_t)0x10CD0, (char32_t)0x10CD1, (char32_t)0x10CD2, (char32_t)0x10CD3,
+    (char32_t)0x10CD4, (char32_t)0x10CD5, (char32_t)0x10CD6, (char32_t)0x10CD7, (char32_t)0x10CD8,
+    (char32_t)0x10CD9, (char32_t)0x10CDA, (char32_t)0x10CDB, (char32_t)0x10CDC, (char32_t)0x10CDD,
+    (char32_t)0x10CDE, (char32_t)0x10CDF, (char32_t)0x10CE0, (char32_t)0x10CE1, (char32_t)0x10CE2,
+    (char32_t)0x10CE3, (char32_t)0x10CE4, (char32_t)0x10CE5, (char32_t)0x10CE6, (char32_t)0x10CE7,
+    (char32_t)0x10CE8, (char32_t)0x10CE9, (char32_t)0x10CEA, (char32_t)0x10CEB, (char32_t)0x10CEC,
+    (char32_t)0x10CED, (char32_t)0x10CEE, (char32_t)0x10CEF, (char32_t)0x10CF0, (char32_t)0x10CF1,
+    (char32_t)0x10CF2, (char32_t)0x118C0, (char32_t)0x118C1, (char32_t)0x118C2, (char32_t)0x118C3,
+    (char32_t)0x118C4, (char32_t)0x118C5, (char32_t)0x118C6, (char32_t)0x118C7, (char32_t)0x118C8,
+    (char32_t)0x118C9, (char32_t)0x118CA, (char32_t)0x118CB, (char32_t)0x118CC, (char32_t)0x118CD,
+    (char32_t)0x118CE, (char32_t)0x118CF, (char32_t)0x118D0, (char32_t)0x118D1, (char32_t)0x118D2,
+    (char32_t)0x118D3, (char32_t)0x118D4, (char32_t)0x118D5, (char32_t)0x118D6, (char32_t)0x118D7,
+    (char32_t)0x118D8, (char32_t)0x118D9, (char32_t)0x118DA, (char32_t)0x118DB, (char32_t)0x118DC,
+    (char32_t)0x118DD, (char32_t)0x118DE, (char32_t)0x118DF, (char32_t)0x16E60, (char32_t)0x16E61,
+    (char32_t)0x16E62, (char32_t)0x16E63, (char32_t)0x16E64, (char32_t)0x16E65, (char32_t)0x16E66,
+    (char32_t)0x16E67, (char32_t)0x16E68, (char32_t)0x16E69, (char32_t)0x16E6A, (char32_t)0x16E6B,
+    (char32_t)0x16E6C, (char32_t)0x16E6D, (char32_t)0x16E6E, (char32_t)0x16E6F, (char32_t)0x16E70,
+    (char32_t)0x16E71, (char32_t)0x16E72, (char32_t)0x16E73, (char32_t)0x16E74, (char32_t)0x16E75,
+    (char32_t)0x16E76, (char32_t)0x16E77, (char32_t)0x16E78, (char32_t)0x16E79, (char32_t)0x16E7A,
+    (char32_t)0x16E7B, (char32_t)0x16E7C, (char32_t)0x16E7D, (char32_t)0x16E7E, (char32_t)0x16E7F,
+    (char32_t)0x1E922, (char32_t)0x1E923, (char32_t)0x1E924, (char32_t)0x1E925, (char32_t)0x1E926,
+    (char32_t)0x1E927, (char32_t)0x1E928, (char32_t)0x1E929, (char32_t)0x1E92A, (char32_t)0x1E92B,
+    (char32_t)0x1E92C, (char32_t)0x1E92D, (char32_t)0x1E92E, (char32_t)0x1E92F, (char32_t)0x1E930,
+    (char32_t)0x1E931, (char32_t)0x1E932, (char32_t)0x1E933, (char32_t)0x1E934, (char32_t)0x1E935,
+    (char32_t)0x1E936, (char32_t)0x1E937, (char32_t)0x1E938, (char32_t)0x1E939, (char32_t)0x1E93A,
+    (char32_t)0x1E93B, (char32_t)0x1E93C, (char32_t)0x1E93D, (char32_t)0x1E93E, (char32_t)0x1E93F,
+    (char32_t)0x1E940, (char32_t)0x1E941, (char32_t)0x1E942, (char32_t)0x1E943};
 
 std::string StringUtils::FormatV(const char *fmt, va_list args)
 {
@@ -327,6 +998,20 @@ std::wstring StringUtils::FormatV(const wchar_t *fmt, va_list args)
   return L"";
 }
 
+std::wstring StringUtils::UTF8ToWString(std::string_view str)
+{
+  std::wstring_convert<std::codecvt_utf8<wchar_t>> conv;
+  std::wstring result = conv.from_bytes(str.data(), str.data() + str.length());
+  return result;
+}
+
+std::string StringUtils::WStringToUTF8(std::wstring_view str)
+{
+  std::wstring_convert<std::codecvt_utf8<wchar_t>> conv;
+  std::string result = conv.to_bytes(str.data(), str.data() + str.length());
+  return result;
+}
+
 int compareWchar (const void* a, const void* b)
 {
   if (*(const wchar_t*)a <  *(const wchar_t*)b)
@@ -335,6 +1020,33 @@ int compareWchar (const void* a, const void* b)
     return 1;
   return 0;
 }
+
+int compareChar32_t(const void* a, const void* b)
+{
+  if (*(const char32_t*)a < *(const char32_t*)b)
+    return -1;
+  else if (*(const char32_t*)a > *(const char32_t*)b)
+    return 1;
+  return 0;
+}
+
+/*
+ * TODO: suggest removal of tolowerUnicode and toupperUnicode and simply 
+ * use std:tolowercase/touppercase for ToLower & ToUpper.
+ *
+ * Performs a conversion to lowercase using UTF16 tables that are language/locale
+ * agnostic. This means that the tables only contains conversions where
+ * there is no conflict (such as when some characters follow different casing rules
+ * depending upon language or context). Locale agnostic characters
+ * can safely be converted to lower case without breaking a particular
+ * language's rule.
+ *
+ * It is questionable if this should be used for tolower, since ignoring
+ * locale is non-standard behavior. Further, this creates a problem where ToLower(wstring)
+ * produces different results than ToLower(string), but that is how
+ * StringUtils has behaved for some time. Finally, the table may be a bit out of date,
+ * being 10 years old.
+ */
 
 wchar_t tolowerUnicode(const wchar_t& c)
 {
@@ -345,6 +1057,9 @@ wchar_t tolowerUnicode(const wchar_t& c)
   return c;
 }
 
+/*
+ * Comments similar to those for tolowerUnicode, above, apply here.
+ */
 wchar_t toupperUnicode(const wchar_t& c)
 {
   wchar_t* p = (wchar_t*) bsearch (&c, unicode_lowers, sizeof(unicode_lowers) / sizeof(wchar_t), sizeof(wchar_t), compareWchar);
@@ -354,58 +1069,430 @@ wchar_t toupperUnicode(const wchar_t& c)
   return c;
 }
 
-template<typename Str, typename Fn>
-void transformString(const Str& input, Str& output, Fn fn)
+/*!
+ * \brief Folds the case of the given Unicode (32-bit) character
+ *
+ * Performs "simple" case folding using data from Unicode Inc.'s ICUC4 (License near top of file).
+ * Read the description preceding the tables (unicode_fold_upper, unicode_fold_lower) or
+ * from the API documentation for FoldCase.
+ */
+char32_t foldCaseUnicode(const char32_t& c)
 {
-  std::transform(input.begin(), input.end(), output.begin(), fn);
+  char32_t* p =
+      (char32_t*)bsearch(&c, unicode_fold_upper, sizeof(unicode_fold_upper) / sizeof(char32_t),
+                         sizeof(char32_t), compareChar32_t);
+  if (p)
+    return *(unicode_fold_lower + (p - unicode_fold_upper));
+
+  return c;
 }
 
-std::string StringUtils::ToUpper(const std::string& str)
+char32_t foldCaseUpperUnicode(const char32_t& c)
 {
-  std::string result(str.size(), '\0');
-  transformString(str, result, ::toupper);
+  char32_t* p =
+      (char32_t*)bsearch(&c, unicode_fold_lower, sizeof(unicode_fold_lower) / sizeof(char32_t),
+                         sizeof(char32_t), compareChar32_t);
+  if (p)
+    return *(unicode_fold_upper + (p - unicode_fold_lower));
+
+  return c;
+}
+
+/*
+ * This method to be removed in this PR once the codebase no longer depends upon it. After that,
+ * there will be just one signature: std::string ToUpper(std:string_view, locale).
+ * (Can this be done without marking it "deprecated" for a while? Even when
+ * there are no current users?)
+ */
+void StringUtils::ToUpper(std::string& str)
+{
+  std::string result = StringUtils::ToUpper(std::string_view(str));
+  result.swap(str);
+}
+
+/*
+  * This method to be removed in this PR once the codebase no longer depends upon it. After that,
+  * there will be just one signature: std::string ToUpper(std:wstring_view, locale).
+  * (Can this be done without marking it "deprecated" for a while? Even when
+  * there are no current users?)
+  */
+void StringUtils::ToUpper(std::wstring& str)
+{
+  std::wstring result = StringUtils::ToUpper(std::wstring_view(str));
+  result.swap(str);
+}
+
+/*
+  * These methods kept until all usages have been switched to string_view version.
+  *
+  * Disabled these signatures because it can conflict with the new
+  * string_view signature, which is compatible with this signature.
+  *
+ std::string StringUtils::ToLower(const std::string& str)
+ {
+   std::string result = StringUtils::ToLower(std::string_view(str));
+   return result;
+ }
+
+ std::wstring StringUtils::ToLower(const std::wstring& str)
+ {
+   std::wstring result = StringUtils::ToLower(std::wstring_view(str));
+   return result;
+ }
+ */
+
+/*
+  * This method to be removed in this PR once the codebase no longer depends upon it. After that,
+  * there will be just one signature: std::string ToUpper(std:wstring_view, locale).
+  * (Can this be done without marking it "deprecated" for a while? Even when
+  * there are no current users?)
+  */
+void StringUtils::ToLower(std::string& str)
+{
+  std::string result = StringUtils::ToLower(std::string_view(str));
+  result.swap(str);
+}
+
+/*
+  * This method to be removed in this PR once the codebase no longer depends upon it. After that,
+  * there will be just one signature: std::string ToUpper(std:wstring_view, locale).
+  * (Can this be done without marking it "deprecated" for a while? Even when
+  * there are no current users?)
+  */
+void StringUtils::ToLower(std::wstring& str)
+{
+  std::wstring result = StringUtils::ToLower(std::wstring_view(str));
+  result.swap(str);
+}
+
+/*
+  * New method signature. Complies with Kodi rules: return by value, and
+  * string_view is more efficient and flexible.
+  */
+std::string StringUtils::ToLower(std::string_view str,
+                                 std::locale locale /* = g_langInfo.GetSystemLocale()) */)
+{
+  /*
+    * Since C++'s tolower(char, locale) operates on only a byte at a time, it's
+    * UTF8 accuracy is inferior to tolower(wchar_t, locale). Further, the results
+    * of ToLower(string_view) can be different from ToLower(wstring_view). To
+    * address these problems, convert to wstring and use ToLower(wstring_view).
+    */
+
+  if (str.length() == 0)
+    return std::string(str);
+
+    // TODO: Remove TEST_LOWER before completing PR
+#undef TEST_LOWER
+// #define TEST_LOWER 1
+#ifdef TEST_LOWER
+  // Compare result of ToLower (utf8) vs ToLower(UTF32)
+
+  std::string resultUTF8; // Assumes lengths don't change.
+  for (char c : str)
+  {
+    resultUTF8.push_back(tolower(c, locale));
+  }
+#endif
+
+  std::wstring wstr = UTF8ToWString(str);
+  std::wstring wresult;
+
+  for (wchar_t c : wstr)
+  {
+    wresult.push_back(tolower(c, locale));
+  }
+  std::string result = WStringToUTF8(wresult);
+#ifdef TEST_LOWER
+
+  if (result.compare(resultUTF8) != 0)
+  {
+    std::cout << "ToLower different result for utf8 and wstring src: " << str
+              << " utf8 lower: " << resultUTF8 << " vs: " << result << std::endl;
+  }
+  // else
+  // {
+  //   std::cout << "ToLower SAME result for utf8 and wstring src: " << str << " utf8 lower: " << resultUTF8 << " vs: " << result << std::endl;
+  //}
+#endif
+
   return result;
 }
 
-std::wstring StringUtils::ToUpper(const std::wstring& str)
+/*
+  * This method to be removed in this PR once the codebase no longer depends upon it. After that,
+  * there will be just one signature: std::string ToUpper(std:wstring_view, locale).
+  * (Can this be done without marking it "deprecated" for a while? Even when
+  * there are no current users?)
+  */
+std::wstring ToLower(const wchar_t* str, std::locale locale)
 {
-  std::wstring result(str.size(), '\0');
-  transformString(str, result, toupperUnicode);
+  if (!str)
+  {
+    return std::wstring();
+  }
+  std::wstring data(str);
+  StringUtils::ToLower(data, locale);
+  return data;
+  // std::use_facet<std::ctype<wchar_t>>(locale).tolower(&data[0], &data[0] + data.size());
+  // return data;
+}
+
+std::wstring StringUtils::ToLower(std::wstring_view str,
+                                  std::locale locale /* = g_langInfo.GetSystemLocale()) */)
+{
+  // TODO: Consider eliminating use of "tolowerUnicode".
+  //
+  // Preserves non-standard behavior of previous versions of Kodi by using a locale
+  // agnostic case conversion table:
+  //
+  //  - Produces different results from ToLower(string)
+  //  - The tables used for char conversion OMITs a number of characters
+  //    that should be changed.
+
+  if (str.length() == 0)
+    return std::wstring(str);
+
+  std::wstring result;
+  for (wchar_t c : str)
+  {
+    // result.push_back(tolower(c, locale));
+    result.push_back(tolowerUnicode(c));
+  }
   return result;
 }
 
-void StringUtils::ToUpper(std::string &str)
+std::string StringUtils::ToUpper(std::string_view str,
+                                 std::locale locale /* = g_langInfo.GetSystemLocale()) */)
 {
-  transformString(str, str, ::toupper);
+  /*
+   * Since C++'s toupper(char, locale) operates on only a byte at a time, it's
+   * UTF8 accuracy is not that great, this method acts as a wrapper around
+   * ToUpper(wstring_view). This gives better accuracy and consistent results
+   * with the wstring version, but at a higher cpu cost. This decision is easily reversed.
+   */
+
+  std::wstring wstr = UTF8ToWString(str);
+  std::wstring result;
+  for (wchar_t c : wstr)
+  {
+    result.push_back(toupper(c, locale));
+  }
+  return WStringToUTF8(result);
 }
 
-void StringUtils::ToUpper(std::wstring &str)
+std::wstring StringUtils::ToUpper(std::wstring_view str,
+                                  std::locale locale /* = g_langInfo.GetSystemLocale()) */)
 {
-  transformString(str, str, toupperUnicode);
-}
+  if (str.length() == 0)
+    return std::wstring(str);
 
-std::string StringUtils::ToLower(const std::string& str)
-{
-  std::string result(str.size(), '\0');
-  transformString(str, result, ::tolower);
+  std::wstring result; // Assumes lengths don't change.
+  for (wchar_t c : str)
+  {
+    // TODO: Consider eliminating use of "toupperUnicode/tolowerUnicode".
+    //
+    // Preserves non-standard behavior of previous versions of Kodi by using a locale
+    // agnostic case conversion table:
+    //
+    //  - Produces different results from ToUpper(string)
+    //  - The tables used for char conversion OMITs a number of characters
+    //    that should be changed.
+    // Will address in issue 22003
+
+    // result.push_back(toupper(c, locale));
+    result.push_back(toupperUnicode(c));
+  }
   return result;
 }
 
-std::wstring StringUtils::ToLower(const std::wstring& str)
+std::u32string StringUtils::FoldCase(std::u32string_view str)
 {
-  std::wstring result(str.size(), '\0');
-  transformString(str, result, tolowerUnicode);
+  // Common code to do actual case folding
+
+  if (str.length() == 0)
+    return std::u32string(str);
+
+  // C++ FoldCase doesn't change string length; more sophisticated libs, such as ICU
+  // can.
+
+  std::u32string result;
+  for (auto i = str.begin(); i != str.end(); i++)
+  {
+    char32_t fold_c = foldCaseUnicode(*i);
+    result.push_back(fold_c);
+  }
   return result;
 }
 
-void StringUtils::ToLower(std::string &str)
+// TODO: Remove VERIFY_ASCII prior to completing PR
+#undef VERIFY_ASCII
+// #define VERIFY_ASCII 1
+std::wstring StringUtils::FoldCase(std::wstring_view str)
 {
-  transformString(str, str, ::tolower);
+  // In the multi-lingual world, FoldCase is used instead of ToLower to 'normalize'
+  // unique-ids, such as property ids, map keys, etc. In the good-'ol days of ASCII
+  // ToLower was fine, but when you have ToLower changing behavior depending upon
+  // the current locale, you have a disaster. For the curious, look up "Turkish-I"
+  // problem.
+  //
+  // FoldCase is designed to transform strings so that unimportant differences
+  // (letter case, some accents, etc.) are neutralized by monocasing, etc..
+  // Full case folding goes further and converts strings into a canonical
+  // form (ex: German sharfes-S (looks like a script B) is converted to
+  // to "ss").
+  //
+  // The FoldCase here does not support full case folding, but as long as key ids
+  // remain essentially ASCII, or at least not too exotic, then this FoldCase
+  // should be fine. (A library, such as ICUC4 is required for more advanced
+  // Folding).
+  //
+  // Even though Kodi appears to have fairly well behaved unique-ids, it is
+  // very easy to create bad ones and they can be hard to detect.
+  //  - The "Turkish-I" problem caught everyone by surprise. No one knew
+  //    that in a few Turkic locales, changing the case of "i" caused a non-Latin
+  //    "i" to appear (I think a "dotless 'i', but maybe a dotted 'I'). The
+  //    problem prevented Kodi from starting at all.
+  //  - As I write this, there are at least five instances where a translated
+  //    value for a device name ("keyboard," etc.) is used as the unique-id.
+  //    This was only found by detecting non-ASCII ids AND setting locale to
+  //    Russian. The problem might be benign, but a lot of testing or
+  //    research is required to be sure.
+  //  - Python addons face the same problem. This code does NOT address
+  //    that issue.
+  //
+  // The FoldCase here is based on character data from ICU4C. (The library
+  // and data are constantly changing. The current version is from 2021.)
+  // The data is in UTF32 format. Since C++ string functions, such as
+  // tolower(char) only examines one byte at a time (for UTF8),
+  // it is unable to properly process multi-byte characters. Similarly
+  // for UTF16, multi-UTF16 code-unit characters are not properly
+  // processed (fortunately there are far fewer characters longer than
+  // 16-bits than for 8-bit ones). For this reason, both versions of
+  // FoldCase (UTF8 and wstring) converts its argument to utf32 to
+  // perform the fold and then back to the original UTF8, wstring,
+  // etc. after the fold.
+  //
+
+  if (str.length() == 0)
+    return std::wstring(str);
+
+  // C++ tolower/toupper (which Foldcase uses) doesn't change string length;
+  // more sophisticated libs, such as ICU can.
+
+  // TODO: Consider performance impact and improvements:
+  //       1- Creating string_view signatures for CharacterConverter
+  //       2- If desperate, use char32_t[] so malloc is not used
+
+  std::u32string utf32Str;
+  const std::wstring strTmp{str}; // Need to change CharsetConvert to use string-view.
+  g_charsetConverter.wToUtf32(strTmp, utf32Str);
+  std::u32string foldedStr = StringUtils::FoldCase(utf32Str);
+  std::wstring result;
+  g_charsetConverter.utf32ToW(foldedStr, result);
+
+#ifdef VERIFY_ASCII
+  bool nonAscii = false;
+  for (wchar_t c : str)
+  {
+    if (not isascii(c))
+    {
+      nonAscii = true;
+      break;
+    }
+  }
+  if (nonAscii)
+  {
+    CLog::Log(LOGWARNING, "StringUtils::FoldCase: Non-ASCII input: {}\n", WStringToUTF8(str));
+  }
+#endif
+
+  return result;
 }
 
-void StringUtils::ToLower(std::wstring &str)
+std::string StringUtils::FoldCase(std::string_view str)
 {
-  transformString(str, str, tolowerUnicode);
+  // To get same behavior and better accuracy as the wstring version, convert to utf32string.
+
+  const std::string strTmp(str);
+  std::u32string utf32Str(U"");
+  g_charsetConverter.utf8ToUtf32(strTmp, utf32Str);
+  std::u32string foldedStr = StringUtils::FoldCase(utf32Str);
+  std::string result;
+  g_charsetConverter.utf32ToUtf8(foldedStr, result);
+
+  // TODO: Remove VERIFY_ASCII before PR complete
+#ifdef VERIFY_ASCII
+  bool nonAscii = false;
+  for (wchar_t c : str)
+  {
+    if (not isascii(c))
+    {
+      nonAscii = true;
+      break;
+    }
+    result.push_back(tolowerUnicode(c));
+  }
+  if (nonAscii)
+  {
+    CLog::Log(LOGWARNING, "StringUtils::FoldCase: Non-ASCII input: {}\n", str);
+  }
+  return result;
+#endif
+  return result;
+}
+
+std::u32string StringUtils::FoldCaseUpper(std::u32string_view str)
+{
+  // Common code to do actual case folding
+
+  if (str.length() == 0)
+    return std::u32string(str);
+
+  // C++ FoldCase doesn't change string length; more sophisticated libs, such as ICU
+  // can.
+
+  std::u32string result;
+  for (auto i = str.begin(); i != str.end(); i++)
+  {
+    char32_t fold_c = foldCaseUpperUnicode(*i);
+    result.push_back(fold_c);
+  }
+  return result;
+}
+
+std::wstring StringUtils::FoldCaseUpper(std::wstring_view str)
+{
+  // Similar to FoldCase.
+
+  if (str.length() == 0)
+    return std::wstring(str);
+
+  // C++ FoldCase doesn't change string length, more sophisticated libs, such as ICU
+  // can.
+
+  // Perform the case-fold using UTF32 for maximum accuracy.
+
+  std::u32string utf32Str;
+  std::wstring strTmp{str}; // Need to change CharsetConvert to use string-view.
+  g_charsetConverter.wToUtf32(strTmp, utf32Str);
+  const std::u32string foldedStr = StringUtils::FoldCaseUpper(utf32Str);
+  std::wstring result;
+  g_charsetConverter.utf32ToW(foldedStr, result);
+  return result;
+}
+
+std::string StringUtils::FoldCaseUpper(std::string_view str)
+{
+  // To get same behavior and better accuracy as the wstring version, convert to utf32string.
+
+  std::string strTmp(str);
+  std::u32string utf32Str;
+  g_charsetConverter.utf8ToUtf32(strTmp, utf32Str);
+  std::u32string foldedStr = StringUtils::FoldCaseUpper(utf32Str);
+  std::string result;
+  g_charsetConverter.utf32ToUtf8(foldedStr, result);
+  return result;
 }
 
 void StringUtils::ToCapitalize(std::string &str)
@@ -433,8 +1520,15 @@ void StringUtils::ToCapitalize(std::wstring &str)
   }
 }
 
+// TODO: Change all caseless comparisons to use same FoldCase algorithm.
+// Will address in followup commit to this PR. Current code is no worse than what it was.
+
 bool StringUtils::EqualsNoCase(const std::string &str1, const std::string &str2)
 {
+  // It would be more accurate to FoldCase using wstring, since tolower(byte) does not
+  // work so well with multi-byte characters. However, converting to wstring and back does add cost.
+  // This will be addressed in latter commit to this PR.
+
   // before we do the char-by-char comparison, first compare sizes of both strings.
   // This led to a 33% improvement in benchmarking on average. (size() just returns a member of std::string)
   if (str1.size() != str2.size())
@@ -454,7 +1548,11 @@ bool StringUtils::EqualsNoCase(const char *s1, const char *s2)
   {
     const char c1 = *s1++; // const local variable should help compiler to optimize
     c2 = *s2++;
-    if (c1 != c2 && ::tolower(c1) != ::tolower(c2)) // This includes the possibility that one of the characters is the null-terminator, which implies a string mismatch.
+    if (c1 != c2 &&
+        tolower(c1, getFOLD_LOCALE()) !=
+            tolower(
+                c2,
+                getFOLD_LOCALE())) // This includes the possibility that one of the characters is the null-terminator, which implies a string mismatch.
       return false;
   } while (c2 != '\0'); // At this point, we know c1 == c2, so there's no need to test them both.
   return true;
@@ -474,8 +1572,12 @@ int StringUtils::CompareNoCase(const char* s1, const char* s2, size_t n /* = 0 *
     const char c1 = *s1++; // const local variable should help compiler to optimize
     c2 = *s2++;
     index++;
-    if (c1 != c2 && ::tolower(c1) != ::tolower(c2)) // This includes the possibility that one of the characters is the null-terminator, which implies a string mismatch.
-      return ::tolower(c1) - ::tolower(c2);
+    if (c1 != c2 &&
+        tolower(c1, getFOLD_LOCALE()) !=
+            tolower(
+                c2,
+                getFOLD_LOCALE())) // This includes the possibility that one of the characters is the null-terminator, which implies a string mismatch.
+      return tolower(c1, getFOLD_LOCALE()) - tolower(c2, getFOLD_LOCALE());
   } while (c2 != '\0' &&
            index != n); // At this point, we know c1 == c2, so there's no need to test them both.
   return 0;
@@ -664,6 +1766,8 @@ bool StringUtils::StartsWith(const char *s1, const char *s2)
   return true;
 }
 
+// TODO: Change to use FoldCase algorithm
+
 bool StringUtils::StartsWithNoCase(const std::string &str1, const std::string &str2)
 {
   return StartsWithNoCase(str1.c_str(), str2.c_str());
@@ -678,7 +1782,7 @@ bool StringUtils::StartsWithNoCase(const char *s1, const char *s2)
 {
   while (*s2 != '\0')
   {
-    if (::tolower(*s1) != ::tolower(*s2))
+    if (tolower(*s1, getFOLD_LOCALE()) != tolower(*s2, getFOLD_LOCALE()))
       return false;
     s1++;
     s2++;
@@ -705,11 +1809,12 @@ bool StringUtils::EndsWithNoCase(const std::string &str1, const std::string &str
 {
   if (str1.size() < str2.size())
     return false;
+
   const char *s1 = str1.c_str() + str1.size() - str2.size();
   const char *s2 = str2.c_str();
   while (*s2 != '\0')
   {
-    if (::tolower(*s1) != ::tolower(*s2))
+    if (tolower(*s1, getFOLD_LOCALE()) != tolower(*s2, getFOLD_LOCALE()))
       return false;
     s1++;
     s2++;
@@ -722,10 +1827,11 @@ bool StringUtils::EndsWithNoCase(const std::string &str1, const char *s2)
   size_t len2 = strlen(s2);
   if (str1.size() < len2)
     return false;
+
   const char *s1 = str1.c_str() + str1.size() - len2;
   while (*s2 != '\0')
   {
-    if (::tolower(*s1) != ::tolower(*s2))
+    if (tolower(*s1, getFOLD_LOCALE()) != tolower(*s2, getFOLD_LOCALE()))
       return false;
     s1++;
     s2++;
@@ -1258,11 +2364,15 @@ int StringUtils::AlphaNumericCollation(int nKey1, const void* pKey1, int nKey2, 
   //Not a binary match, so process character at a time
   const unsigned char* zA = static_cast<const unsigned char*>(pKey1);
   const unsigned char* zB = static_cast<const unsigned char*>(pKey2);
-  wchar_t lc, rc;
+  wchar_t lc;
+  wchar_t rc;
   unsigned char bytes;
-  int64_t lnum, rnum;
-  bool lsym, rsym;
-  int ld, rd;
+  int64_t lnum;
+  int64_t rnum;
+  bool lsym;
+  bool rsym;
+  int ld;
+  int rd;
   int i = 0;
   int j = 0;
   // Looping Unicode point at a time through potentially 1 to 4 multi-byte encoded UTF8 data
@@ -1479,7 +2589,8 @@ std::string StringUtils::SecondsToTimeString(long lSeconds, TIME_FORMAT format)
 
 bool StringUtils::IsNaturalNumber(const std::string& str)
 {
-  size_t i = 0, n = 0;
+  size_t i = 0;
+  size_t n = 0;
   // allow whitespace,digits,whitespace
   while (i < str.size() && isspace((unsigned char) str[i]))
     i++;
@@ -1494,7 +2605,8 @@ bool StringUtils::IsNaturalNumber(const std::string& str)
 
 bool StringUtils::IsInteger(const std::string& str)
 {
-  size_t i = 0, n = 0;
+  size_t i = 0;
+  size_t n = 0;
   // allow whitespace,-,digits,whitespace
   while (i < str.size() && isspace((unsigned char) str[i]))
     i++;
@@ -1693,20 +2805,29 @@ int StringUtils::FindEndBracket(const std::string &str, char opener, char closer
 
 void StringUtils::WordToDigits(std::string &word)
 {
+
+  // Works ONLY with ASCII!
+
   static const char word_to_letter[] = "22233344455566677778889999";
-  StringUtils::ToLower(word);
-  for (unsigned int i = 0; i < word.size(); ++i)
+  std::string digits = StringUtils::FoldCase(word);
+  for (unsigned int i = 0; i < digits.size(); ++i)
   { // NB: This assumes ascii, which probably needs extending at some  point.
-    char letter = word[i];
+    char letter = digits[i];
+    if (letter > 0x7f)
+    {
+      CLog::Log(LOGWARNING, "StringUtils.WordToDigits: Non-ASCII input: {}\n", word);
+    }
+
     if ((letter >= 'a' && letter <= 'z')) // assume contiguous letter range
     {
-      word[i] = word_to_letter[letter-'a'];
+      digits[i] = word_to_letter[letter - 'a'];
     }
     else if (letter < '0' || letter > '9') // We want to keep 0-9!
     {
-      word[i] = ' ';  // replace everything else with a space
+      digits[i] = ' '; // replace everything else with a space
     }
   }
+  digits.swap(word);
 }
 
 std::string StringUtils::CreateUUID()

--- a/xbmc/utils/TextSearch.cpp
+++ b/xbmc/utils/TextSearch.cpp
@@ -28,7 +28,7 @@ bool CTextSearch::Search(const std::string &strHaystack) const
 
   std::string strSearch(strHaystack);
   if (!m_bCaseSensitive)
-    StringUtils::ToLower(strSearch);
+    strSearch = StringUtils::FoldCase(strSearch);
 
   /* check whether any of the NOT terms matches and return false if there's a match */
   for (unsigned int iNotPtr = 0; iNotPtr < m_NOT.size(); iNotPtr++)
@@ -90,7 +90,7 @@ void CTextSearch::ExtractSearchTerms(const std::string &strSearchTerm, TextSearc
   StringUtils::Trim(strParsedSearchTerm);
 
   if (!m_bCaseSensitive)
-    StringUtils::ToLower(strParsedSearchTerm);
+    strParsedSearchTerm = StringUtils::FoldCase(strParsedSearchTerm);
 
   bool bNextAND(defaultSearchMode == SEARCH_DEFAULT_AND);
   bool bNextOR(defaultSearchMode == SEARCH_DEFAULT_OR);

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -100,14 +100,14 @@ bool URIUtils::HasExtension(const std::string& strFileName, const std::string& s
   if (pos == std::string::npos || strFileName[pos] != '.')
     return false;
 
-  const std::string extensionLower = StringUtils::ToLower(strFileName.substr(pos));
+  const std::string extensionFolded = StringUtils::FoldCase(strFileName.substr(pos));
 
-  const std::vector<std::string> extensionsLower =
-      StringUtils::Split(StringUtils::ToLower(strExtensions), '|');
+  const std::vector<std::string> extensionsFolded =
+      StringUtils::Split(StringUtils::FoldCase(strExtensions), '|');
 
-  for (const auto& ext : extensionsLower)
+  for (const auto& ext : extensionsFolded)
   {
-    if (StringUtils::EndsWith(ext, extensionLower))
+    if (StringUtils::EndsWith(ext, extensionFolded))
       return true;
   }
 
@@ -129,8 +129,7 @@ void URIUtils::RemoveExtension(std::string& strFileName)
   size_t period = strFileName.find_last_of("./\\");
   if (period != std::string::npos && strFileName[period] == '.')
   {
-    std::string strExtension = strFileName.substr(period);
-    StringUtils::ToLower(strExtension);
+    std::string strExtension = StringUtils::FoldCase(strFileName.substr(period));
     strExtension += "|";
 
     std::string strFileMask;
@@ -738,8 +737,7 @@ bool URIUtils::IsHD(const std::string& strFileName)
 
 bool URIUtils::IsDVD(const std::string& strFile)
 {
-  std::string strFileLow = strFile;
-  StringUtils::ToLower(strFileLow);
+  std::string strFileLow = StringUtils::FoldCase(strFile);
   if (strFileLow.find("video_ts.ifo") != std::string::npos && IsOnDVD(strFile))
     return true;
 

--- a/xbmc/utils/XBMCTinyXML.cpp
+++ b/xbmc/utils/XBMCTinyXML.cpp
@@ -38,7 +38,7 @@ CXBMCTinyXML::CXBMCTinyXML(const std::string& documentName)
 CXBMCTinyXML::CXBMCTinyXML(const std::string& documentName, const std::string& documentCharset)
 : TiXmlDocument(documentName), m_SuggestedCharset(documentCharset)
 {
-  StringUtils::ToUpper(m_SuggestedCharset);
+  m_SuggestedCharset = StringUtils::FoldCaseUpper(m_SuggestedCharset);
 }
 
 bool CXBMCTinyXML::LoadFile(TiXmlEncoding encoding)
@@ -83,8 +83,7 @@ bool CXBMCTinyXML::LoadFile(const std::string& _filename, TiXmlEncoding encoding
 
 bool CXBMCTinyXML::LoadFile(const std::string& _filename, const std::string& documentCharset)
 {
-  m_SuggestedCharset = documentCharset;
-  StringUtils::ToUpper(m_SuggestedCharset);
+  m_SuggestedCharset = StringUtils::FoldCaseUpper(documentCharset);
   return LoadFile(_filename, TIXML_ENCODING_UNKNOWN);
 }
 
@@ -121,8 +120,7 @@ bool CXBMCTinyXML::SaveFile(const std::string& filename) const
 
 bool CXBMCTinyXML::Parse(const std::string& data, const std::string& dataCharset)
 {
-  m_SuggestedCharset = dataCharset;
-  StringUtils::ToUpper(m_SuggestedCharset);
+  m_SuggestedCharset = StringUtils::FoldCaseUpper(dataCharset);
   return Parse(data, TIXML_ENCODING_UNKNOWN);
 }
 

--- a/xbmc/utils/XMLUtils.cpp
+++ b/xbmc/utils/XMLUtils.cpp
@@ -97,8 +97,7 @@ bool XMLUtils::GetBoolean(const TiXmlNode* pRootNode, const char* strTag, bool& 
 {
   const TiXmlNode* pNode = pRootNode->FirstChild(strTag );
   if (!pNode || !pNode->FirstChild()) return false;
-  std::string strEnabled = pNode->FirstChild()->ValueStr();
-  StringUtils::ToLower(strEnabled);
+  std::string strEnabled = StringUtils::FoldCase(pNode->FirstChild()->ValueStr());
   if (strEnabled == "off" || strEnabled == "no" || strEnabled == "disabled" || strEnabled == "false" || strEnabled == "0" )
     bBoolValue = false;
   else

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -103,8 +103,7 @@ void CLog::Initialize(const std::string& path)
     return;
 
   // put together the path to the log file(s)
-  std::string appName = CCompileInfo::GetAppName();
-  StringUtils::ToLower(appName);
+  std::string appName = StringUtils::FoldCase(CCompileInfo::GetAppName());
   const std::string filePathBase = URIUtils::AddFileToFolder(path, appName);
   const std::string filePath = filePathBase + LogFileExtension;
   const std::string oldFilePath = filePathBase + ".old" + LogFileExtension;

--- a/xbmc/utils/test/TestLocale.cpp
+++ b/xbmc/utils/test/TestLocale.cpp
@@ -48,8 +48,7 @@ TEST(TestLocale, LanguageLocale)
 TEST(TestLocale, LanguageTerritoryLocale)
 {
   const std::string strLocale = LanguageCodeEnglish + TerritorySeparator + TerritoryCodeBritain;
-  std::string strLocaleLC = strLocale;
-  StringUtils::ToLower(strLocaleLC);
+  std::string strLocaleLC = StringUtils::FoldCase(strLocale);
 
   CLocale locale(LanguageCodeEnglish, TerritoryCodeBritain);
   ASSERT_TRUE(locale.IsValid());
@@ -66,8 +65,7 @@ TEST(TestLocale, LanguageTerritoryLocale)
 TEST(TestLocale, LanguageCodesetLocale)
 {
   const std::string strLocale = LanguageCodeEnglish + CodesetSeparator + CodesetUtf8;
-  std::string strLocaleLC = strLocale;
-  StringUtils::ToLower(strLocaleLC);
+  std::string strLocaleLC = StringUtils::FoldCase(strLocale);
 
   CLocale locale(LanguageCodeEnglish, "", CodesetUtf8);
   ASSERT_TRUE(locale.IsValid());
@@ -84,8 +82,7 @@ TEST(TestLocale, LanguageCodesetLocale)
 TEST(TestLocale, LanguageModifierLocale)
 {
   const std::string strLocale = LanguageCodeEnglish + ModifierSeparator + ModifierLatin;
-  std::string strLocaleLC = strLocale;
-  StringUtils::ToLower(strLocaleLC);
+  std::string strLocaleLC = StringUtils::FoldCase(strLocale);
 
   CLocale locale(LanguageCodeEnglish, "", "", ModifierLatin);
   ASSERT_TRUE(locale.IsValid());
@@ -102,11 +99,9 @@ TEST(TestLocale, LanguageModifierLocale)
 TEST(TestLocale, LanguageTerritoryCodesetLocale)
 {
   const std::string strLocaleShort = LanguageCodeEnglish + TerritorySeparator + TerritoryCodeBritain;
-  std::string strLocaleShortLC = strLocaleShort;
-  StringUtils::ToLower(strLocaleShortLC);
+  std::string strLocaleShortLC = StringUtils::FoldCase(strLocaleShort);
   const std::string strLocale = strLocaleShort + CodesetSeparator + CodesetUtf8;
-  std::string strLocaleLC = strLocale;
-  StringUtils::ToLower(strLocaleLC);
+  std::string strLocaleLC = StringUtils::FoldCase(strLocale);
 
   CLocale locale(LanguageCodeEnglish, TerritoryCodeBritain, CodesetUtf8);
   ASSERT_TRUE(locale.IsValid());
@@ -123,11 +118,9 @@ TEST(TestLocale, LanguageTerritoryCodesetLocale)
 TEST(TestLocale, LanguageTerritoryModifierLocale)
 {
   const std::string strLocaleShort = LanguageCodeEnglish + TerritorySeparator + TerritoryCodeBritain;
-  std::string strLocaleShortLC = strLocaleShort;
-  StringUtils::ToLower(strLocaleShortLC);
+  std::string strLocaleShortLC = StringUtils::FoldCase(strLocaleShort);
   const std::string strLocale = strLocaleShort + ModifierSeparator + ModifierLatin;
-  std::string strLocaleLC = strLocale;
-  StringUtils::ToLower(strLocaleLC);
+  std::string strLocaleLC = StringUtils::FoldCase(strLocale);
 
   CLocale locale(LanguageCodeEnglish, TerritoryCodeBritain, "", ModifierLatin);
   ASSERT_TRUE(locale.IsValid());
@@ -144,11 +137,9 @@ TEST(TestLocale, LanguageTerritoryModifierLocale)
 TEST(TestLocale, LanguageTerritoryCodesetModifierLocale)
 {
   const std::string strLocaleShort = LanguageCodeEnglish + TerritorySeparator + TerritoryCodeBritain;
-  std::string strLocaleShortLC = strLocaleShort;
-  StringUtils::ToLower(strLocaleShortLC);
+  std::string strLocaleShortLC = StringUtils::FoldCase(strLocaleShort);
   const std::string strLocale = strLocaleShort + CodesetSeparator + CodesetUtf8 + ModifierSeparator + ModifierLatin;
-  std::string strLocaleLC = strLocale;
-  StringUtils::ToLower(strLocaleLC);
+  std::string strLocaleLC = StringUtils::FoldCase(strLocale);
 
   CLocale locale(LanguageCodeEnglish, TerritoryCodeBritain, CodesetUtf8, ModifierLatin);
   ASSERT_TRUE(locale.IsValid());
@@ -165,11 +156,9 @@ TEST(TestLocale, LanguageTerritoryCodesetModifierLocale)
 TEST(TestLocale, FullStringLocale)
 {
   const std::string strLocaleShort = LanguageCodeEnglish + TerritorySeparator + TerritoryCodeBritain;
-  std::string strLocaleShortLC = strLocaleShort;
-  StringUtils::ToLower(strLocaleShortLC);
+  std::string strLocaleShortLC = StringUtils::FoldCase(strLocaleShort);
   const std::string strLocale = strLocaleShort + CodesetSeparator + CodesetUtf8 + ModifierSeparator + ModifierLatin;
-  std::string strLocaleLC = strLocale;
-  StringUtils::ToLower(strLocaleLC);
+  std::string strLocaleLC = StringUtils::FoldCase(strLocale);
 
   CLocale locale(strLocale);
   ASSERT_TRUE(locale.IsValid());

--- a/xbmc/utils/test/TestRegExp.cpp
+++ b/xbmc/utils/test/TestRegExp.cpp
@@ -138,8 +138,7 @@ TEST_F(TestRegExpLog, DumpOvector)
   ssize_t bytesread;
   XFILE::CFile file;
 
-  std::string appName = CCompileInfo::GetAppName();
-  StringUtils::ToLower(appName);
+  std::string appName = StringUtils::FoldCase(CCompileInfo::GetAppName());
   logfile = CSpecialProtocol::TranslatePath("special://temp/") + appName + ".log";
   CServiceBroker::GetLogging().Initialize(
       CSpecialProtocol::TranslatePath("special://temp/").c_str());

--- a/xbmc/utils/test/Testlog.cpp
+++ b/xbmc/utils/test/Testlog.cpp
@@ -34,8 +34,7 @@ TEST_F(Testlog, Log)
   XFILE::CFile file;
   CRegExp regex;
 
-  std::string appName = CCompileInfo::GetAppName();
-  StringUtils::ToLower(appName);
+  std::string appName = StringUtils::FoldCase(CCompileInfo::GetAppName());
   logfile = CSpecialProtocol::TranslatePath("special://temp/") + appName + ".log";
   CServiceBroker::GetLogging().Initialize(
       CSpecialProtocol::TranslatePath("special://temp/").c_str());
@@ -80,8 +79,7 @@ TEST_F(Testlog, SetLogLevel)
 {
   std::string logfile;
 
-  std::string appName = CCompileInfo::GetAppName();
-  StringUtils::ToLower(appName);
+  std::string appName = StringUtils::FoldCase(CCompileInfo::GetAppName());
   logfile = CSpecialProtocol::TranslatePath("special://temp/") + appName + ".log";
   CServiceBroker::GetLogging().Initialize(
       CSpecialProtocol::TranslatePath("special://temp/").c_str());


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

This change improves on patch for Turkish-I problem (19883). This fix is inferior to using Unicode ICUC4 library, but time does not now permit that change. (I started a PR for ICU4C #21690, but I think that I should delete it and create new one when appropriate, especially since numerous changes will be required to the PR).

The FoldCase here simply performs a ToLower using the locale en_GB.UTF8. The Turkish-I problem caused Kodi to be non-functional due to ToLower not treating ASCII i/I and Turkish "I" characters in a "normal" manner. This caused all sorts of problems when the key to lookup tables, etc. were normalized to lower case (or upper case). By specifying en_GB.UTF8 for Folding this problem is averted.

This will ONLY work with ASCII characters (or whatever en_GB defines). This should be sufficient, but there may be some odd cases where a key does not obey this rule. To address that problem, ICU should be used.

Many simple changes were required in code to convert all of the ToLower/ToUpper usages to FoldCase/FoldCaseUpper. Another change made was to use string_view instead of string for arguments and to return values by function return instead of by reference. This is in keeping with Kodi guidelines and performance improvement.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Provides a better fix to #19883. It is still imperfect since it only address case folding and only works for characters in en_GB locale. But this should get the lion's share of problems and is definitely better than fix made in Matrix.
Problems not addressed by fix include: 
- non-ASCII characters (should be rare for key values, but not impossible)
- Does not address changes of case changing length of string
- General Unicode issues. C++ Unicode support is weak.
- 
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran Kodi using various languages, including Turkish on Ubuntu 22.10 (be sure to install Turkish on Ubuntu and set LANG=tr_TR.
Added several FoldCase test cases to TestStringUtils. Did not add tests for wstring. Code is almost identical.  Ran all tests from make check.
(This code was based on my ICU based solution where I ran many tests over months.)

I did spot one POSSIBLE regression, but I don't think so. Currently Kodi nightly builds don't like to install on Ubuntu and blow up with a missing or broken wayland lib. My builds work just fine, EXCEPT when on the video top level menu item I don't see icons in the main window (Catagories: Movies, Files). I suspect that I don't have the right images installed.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Allows Kodi to run in Turkish and several related languages.  

## Screenshots (if appropriate):
Image showing missing icons mentioned above. 
![image](https://user-images.githubusercontent.com/10661641/194437528-64ef4a2a-3854-4bd0-8056-08fb179b71bf.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
