### PR TITLE
[application] Re-introduce CApplication::GetRenderGUI().

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -3495,6 +3495,11 @@ bool CApplication::ProcessAndStartPlaylist(const std::string& strPlayList,
   return false;
 }
 
+bool CApplication::GetRenderGUI() const
+{
+  return GetComponent<CApplicationPowerHandling>()->GetRenderGUI();
+}
+
 bool CApplication::SetLanguage(const std::string &strLanguage)
 {
   // nothing to be done if the language hasn't changed

--- a/xbmc/application/Application.h
+++ b/xbmc/application/Application.h
@@ -184,6 +184,8 @@ public:
 
   bool IsAppFocused() const { return m_AppFocused; }
 
+  bool GetRenderGUI() const override;
+
   bool SetLanguage(const std::string &strLanguage);
   bool LoadLanguage(bool reload);
 


### PR DESCRIPTION
Fixes fallout from #21934 

Runtime-tested, confirming that both bugs reported are fixed by this PR.

@notspiff give me your thumbs-up, please.