### PR TITLE
Fix crashes when no gui can be created

### DIFF
--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -167,6 +167,10 @@ bool CServiceManager::InitStageTwo(const std::string& profilesUserDataFolder)
   m_mediaManager.reset(new CMediaManager());
   m_mediaManager->Initialize();
 
+#if !defined(TARGET_WINDOWS) && defined(HAS_DVD_DRIVE)
+  m_DetectDVDType = std::make_unique<MEDIA_DETECT::CDetectDVDMedia>();
+#endif
+
 #if defined(HAS_FILESYSTEM_SMB)
   m_WSDiscovery = WSDiscovery::IWSDiscovery::GetInstance();
 #endif
@@ -184,7 +188,6 @@ bool CServiceManager::InitStageThree(const std::shared_ptr<CProfileManager>& pro
 #if !defined(TARGET_WINDOWS) && defined(HAS_DVD_DRIVE)
   // Start Thread for DVD Mediatype detection
   CLog::Log(LOGINFO, "[Media Detection] starting service for optical media detection");
-  m_DetectDVDType = std::make_unique<MEDIA_DETECT::CDetectDVDMedia>();
   m_DetectDVDType->Create(false);
 #endif
 

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -11,6 +11,7 @@
 #include "AndroidKey.h"
 #include "CompileInfo.h"
 #include "FileItem.h"
+#include "application/AppEnvironment.h"
 #include "application/AppParams.h"
 #include "application/Application.h"
 #include "application/ApplicationComponents.h"
@@ -637,7 +638,10 @@ void CXBMCApp::run()
   m_firstrun = false;
   android_printf(" => running XBMC_Run...");
 
-  status = XBMC_Run(true, std::make_shared<CAppParams>());
+  CAppEnvironment::SetUp(std::make_shared<CAppParams>());
+  status = XBMC_Run(true);
+  CAppEnvironment::TearDown();
+
   android_printf(" => XBMC_Run finished with %d", status);
 }
 

--- a/xbmc/platform/darwin/osx/XBMCApplication.mm
+++ b/xbmc/platform/darwin/osx/XBMCApplication.mm
@@ -10,6 +10,7 @@
 #import "XBMCApplication.h"
 
 #include "ServiceBroker.h"
+#include "application/AppEnvironment.h"
 #include "application/AppInboundProtocol.h"
 #include "application/AppParamParser.h"
 #include "messaging/ApplicationMessenger.h"
@@ -120,7 +121,9 @@ static NSMenu* setupWindowMenu()
   CAppParamParser appParamParser;
   appParamParser.Parse((const char**)gArgv, (int)gArgc);
 
-  XBMC_Run(true, appParamParser.GetAppParams());
+  CAppEnvironment::SetUp(appParamParser.GetAppParams());
+  XBMC_Run(true);
+  CAppEnvironment::TearDown();
 
   std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
   if (appPort)

--- a/xbmc/platform/posix/main.cpp
+++ b/xbmc/platform/posix/main.cpp
@@ -14,6 +14,7 @@
 #endif
 
 #include "PlatformPosix.h"
+#include "application/AppEnvironment.h"
 #include "application/AppParamParser.h"
 #include "platform/xbmc.h"
 
@@ -66,5 +67,9 @@ int main(int argc, char* argv[])
 #endif
   appParamParser.Parse(argv, argc);
 
-  return XBMC_Run(true, appParamParser.GetAppParams());
+  CAppEnvironment::SetUp(appParamParser.GetAppParams());
+  int status = XBMC_Run(true);
+  CAppEnvironment::TearDown();
+
+  return status;
 }

--- a/xbmc/platform/win10/Win10App.cpp
+++ b/xbmc/platform/win10/Win10App.cpp
@@ -8,6 +8,7 @@
 
 #include "Win10App.h"
 
+#include "application/AppEnvironment.h"
 #include "application/AppParamParser.h"
 #include "application/AppParams.h"
 #include "application/Application.h"
@@ -92,7 +93,9 @@ void App::Run()
       params->SetStandAlone(true);
 
     // Create and run the app
-    XBMC_Run(true, params);
+    CAppEnvironment::SetUp(params);
+    XBMC_Run(true);
+    CAppEnvironment::TearDown();
   }
 
   WSACleanup();

--- a/xbmc/platform/win32/WinMain.cpp
+++ b/xbmc/platform/win32/WinMain.cpp
@@ -8,6 +8,7 @@
 
 #include "CompileInfo.h"
 #include "ServiceBroker.h"
+#include "application/AppEnvironment.h"
 #include "application/AppParamParser.h"
 #include "application/AppParams.h"
 #include "platform/Environment.h"
@@ -112,8 +113,12 @@ INT WINAPI WinMain(HINSTANCE hInst, HINSTANCE, LPSTR commandLine, INT)
   SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOOPENFILEERRORBOX);
 #endif
 
+  CAppEnvironment::SetUp(params);
+
   // Create and run the app
-  int status = XBMC_Run(true, params);
+  int status = XBMC_Run(true);
+
+  CAppEnvironment::TearDown();
 
   for (int i = 0; i < argc; ++i)
     delete[] argv[i];

--- a/xbmc/platform/xbmc.cpp
+++ b/xbmc/platform/xbmc.cpp
@@ -6,7 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#include "application/AppEnvironment.h"
 #include "application/Application.h"
 #include "platform/MessagePrinter.h"
 
@@ -20,11 +19,9 @@
 #include "platform/android/activity/XBMCApp.h"
 #endif
 
-extern "C" int XBMC_Run(bool renderGUI, const std::shared_ptr<CAppParams>& params)
+extern "C" int XBMC_Run(bool renderGUI)
 {
   int status = -1;
-
-  CAppEnvironment::SetUp(params);
 
   if (!g_application.Create())
   {
@@ -77,8 +74,6 @@ extern "C" int XBMC_Run(bool renderGUI, const std::shared_ptr<CAppParams>& param
 #if defined(TARGET_ANDROID)
   CXBMCApp::Get().Deinitialize();
 #endif
-
-  CAppEnvironment::TearDown();
 
   return status;
 }

--- a/xbmc/platform/xbmc.h
+++ b/xbmc/platform/xbmc.h
@@ -12,4 +12,4 @@
 
 class CAppParams;
 
-extern "C" int XBMC_Run(bool renderGUI, const std::shared_ptr<CAppParams>& params);
+extern "C" int XBMC_Run(bool renderGUI);

--- a/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
+++ b/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
@@ -104,12 +104,11 @@ CPVRGUIChannelNavigator::CPVRGUIChannelNavigator()
 
 CPVRGUIChannelNavigator::~CPVRGUIChannelNavigator()
 {
-  CServiceBroker::GetGUI()
-      ->GetInfoManager()
-      .GetInfoProviders()
-      .GetPlayerInfoProvider()
-      .Events()
-      .Unsubscribe(this);
+  const auto gui = CServiceBroker::GetGUI();
+  if (!gui)
+    return;
+
+  gui->GetInfoManager().GetInfoProviders().GetPlayerInfoProvider().Events().Unsubscribe(this);
 }
 
 void CPVRGUIChannelNavigator::SubscribeToShowInfoEventStream()


### PR DESCRIPTION
This PR fixes three separate issues when the gui fails to be created (due to bad windowing).

```
2022-10-09 21:19:53.269 T:555913   debug <general>: CApplication::CreateGUI - trying to init wayland windowing system
2022-10-09 21:19:53.270 T:555913   debug <general>: CWinSystemWayland::InitWindowSystem - WAYLAND_DISPLAY env not set
2022-10-09 21:19:53.270 T:555913   debug <general>: CApplication::CreateGUI - unable to init wayland windowing system
2022-10-09 21:19:53.271 T:555913 critical <general>: CApplication::CreateGUI - unable to init windowing system
ERROR: Unable to create GUI. Exiting
```


1) [CServiceManager: move m_DetectDVDType allocation to InitStageTwo](https://github.com/xbmc/xbmc/commit/a0efb7ca432f44a8fac4d9d4459862de7b5d7110). This fixes an issue where m_DetectDVDType isn't constructed until `InitStageThree` which is only run after the gui is created. `DeInitStageThree` is always run during teardown regardless of the init level reached. I figured it would be better to make the `DeInitStageThree` call be able to be called regardless of the init_level rather than adding extra guards.

```
#0  CServiceManager::DeinitStageThree() (this=0x50ac8c0) at /home/lukas/Documents/git/xbmc/xbmc/ServiceManager.cpp:216
#1  0x0000000001ff2423 in CApplication::Cleanup() (this=0x4ff0b60) at /home/lukas/Documents/git/xbmc/xbmc/application/Application.cpp:1918
#2  0x0000000001d62f78 in XBMC_Run(bool, std::shared_ptr<CAppParams> const&) (renderGUI=true, params=std::shared_ptr<CAppParams> (use count 3, weak count 0) = {...}) at /home/lukas/Documents/git/xbmc/xbmc/platform/xbmc.cpp:43
#3  0x000000000173a528 in main(int, char**) (argc=3, argv=0x7fffffffda38) at /home/lukas/Documents/git/xbmc/xbmc/platform/posix/main.cpp:69
```

2) [CPVRGUIChannelNavigator: check gui for nullptr in destructor](https://github.com/xbmc/xbmc/commit/9a27844f8ef75bea062a4cd4e0775038fbc18d6d). This is needed because `CPVRGUIChannelNavigator` is constructed in a chain when `CPVRManager` is constructed (in `InitStageTwo`), however, This assumes the gui is available when the destructor is called for `CPVRGUIChannelNavigator`. Maybe a better solution is to register PVR components in two stages (without gui and with). I don't really like this change as it's just a guard but I think moving `CPVRGUIChannelNavigator` to be a pointer created in `CPVRGUIActionsChannels` is a bit out of my reach (lack of PVR knowledge). Maybe @ksooo has a better solution.

```
#0  std::__uniq_ptr_impl<CGUIInfoManager, std::default_delete<CGUIInfoManager> >::_M_ptr() const (this=0x28) at /usr/include/c++/12/bits/unique_ptr.h:191
#1  0x0000000001e858fc in std::unique_ptr<CGUIInfoManager, std::default_delete<CGUIInfoManager> >::get() const (this=0x28) at /usr/include/c++/12/bits/unique_ptr.h:462
#2  0x0000000001e851a8 in std::unique_ptr<CGUIInfoManager, std::default_delete<CGUIInfoManager> >::operator*() const (this=0x28) at /usr/include/c++/12/bits/unique_ptr.h:446
#3  0x0000000001e845ca in CGUIComponent::GetInfoManager() (this=0x0) at /home/lukas/Documents/git/xbmc/xbmc/guilib/GUIComponent.cpp:76
#4  0x0000000002450ac9 in PVR::CPVRGUIChannelNavigator::~CPVRGUIChannelNavigator() (this=0x533db10, __in_chrg=<optimized out>) at /home/lukas/Documents/git/xbmc/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp:108
#5  0x0000000002435d7d in PVR::CPVRGUIActionsChannels::~CPVRGUIActionsChannels() (this=0x533d6a0, __in_chrg=<optimized out>) at /home/lukas/Documents/git/xbmc/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp:162
#6  0x0000000002540226 in std::_Destroy<PVR::CPVRGUIActionsChannels>(PVR::CPVRGUIActionsChannels*) (__pointer=0x533d6a0) at /usr/include/c++/12/bits/stl_construct.h:151
#7  0x00000000025400d2 in std::allocator_traits<std::allocator<void> >::destroy<PVR::CPVRGUIActionsChannels>(std::allocator<void>&, PVR::CPVRGUIActionsChannels*) (__p=0x533d6a0) at /usr/include/c++/12/bits/alloc_traits.h:648
#8  0x000000000253fdc1 in std::_Sp_counted_ptr_inplace<PVR::CPVRGUIActionsChannels, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() (this=0x533d690) at /usr/include/c++/12/bits/shared_ptr_base.h:613
#9  0x000000000173a609 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() (this=0x533d690) at /usr/include/c++/12/bits/shared_ptr_base.h:346
#10 0x000000000173a7f5 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() (this=0x52a3b38, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/shared_ptr_base.h:1071
#11 0x0000000002539ccc in std::__shared_ptr<PVR::IPVRComponent, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() (this=0x52a3b30, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/shared_ptr_base.h:1524
#12 0x0000000002539ce8 in std::shared_ptr<PVR::IPVRComponent>::~shared_ptr() (this=0x52a3b30, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/shared_ptr.h:175
#13 0x0000000002539dd0 in std::pair<std::type_index const, std::shared_ptr<PVR::IPVRComponent> >::~pair() (this=0x52a3b28, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/stl_pair.h:185
#14 0x000000000253d106 in std::__new_allocator<std::__detail::_Hash_node<std::pair<std::type_index const, std::shared_ptr<PVR::IPVRComponent> >, false> >::destroy<std::pair<std::type_index const, std::shared_ptr<PVR::IPVRComponent> > >(std::pair<std::type_index const, std::shared_ptr<PVR::IPVRComponent> >*) (this=0x52f82b8, __p=0x52a3b28) at /usr/include/c++/12/bits/new_allocator.h:181
#15 0x000000000253bd6b in std::allocator_traits<std::allocator<std::__detail::_Hash_node<std::pair<std::type_index const, std::shared_ptr<PVR::IPVRComponent> >, false> > >::destroy<std::pair<std::type_index const, std::shared_ptr<PVR::IPVRComponent> > >(std::allocator<std::__detail::_Hash_node<std::pair<std::type_index const, std::shared_ptr<PVR::IPVRComponent> >, false> >&, std::pair<std::type_index const, std::shared_ptr<PVR::IPVRComponent> >*) (__a=..., __p=0x52a3b28)
    at /usr/include/c++/12/bits/alloc_traits.h:535
#16 0x000000000253ae9b in std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<std::type_index const, std::shared_ptr<PVR::IPVRComponent> >, false> > >::_M_deallocate_node(std::__detail::_Hash_node<std::pair<std::type_index const, std::shared_ptr<PVR::IPVRComponent> >, false>*) (this=0x52f82b8, __n=0x52a3b20) at /usr/include/c++/12/bits/hashtable_policy.h:1984
#17 0x000000000253d0be in std::_Hashtable<std::type_index, std::pair<std::type_index const, std::shared_ptr<PVR::IPVRComponent> >, std::allocator<std::pair<std::type_index const, std::shared_ptr<PVR::IPVRComponent> > >, std::__detail::_Select1st, std::equal_to<std::type_index>, std::hash<std::type_index>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::_M_erase(unsigned long, std::__detail::_Hash_node_base*, std::__detail::_Hash_node<std::pair<std::type_index const, std::shared_ptr<PVR::IPVRComponent> >, false>*) (this=0x52f82b8, __bkt=5, __prev_n=0x52f82c8, __n=0x52a3b20)
    at /usr/include/c++/12/bits/hashtable.h:2329
#18 0x000000000253bd22 in std::_Hashtable<std::type_index, std::pair<std::type_index const, std::shared_ptr<PVR::IPVRComponent> >, std::allocator<std::pair<std::type_index const, std::shared_ptr<PVR::IPVRComponent> > >, std::__detail::_Select1st, std::equal_to<std::type_index>, std::hash<std::type_index>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::_M_erase(std::integral_constant<bool, true>, std::type_index const&) (this=0x52f82b8, __k=...) at /usr/include/c++/12/bits/hashtable.h:2372
#19 0x000000000253ae5d in std::_Hashtable<std::type_index, std::pair<std::type_index const, std::shared_ptr<PVR::IPVRComponent> >, std::allocator<std::pair<std::type_index const, std::shared_ptr<PVR::IPVRComponent> > >, std::__detail::_Select1st, std::equal_to<std::type_index>, std::hash<std::type_index>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::erase(std::type_index const&) (this=0x52f82b8, __k=...) at /usr/include/c++/12/bits/hashtable.h:973
#20 0x000000000253aa05 in std::unordered_map<std::type_index, std::shared_ptr<PVR::IPVRComponent>, std::hash<std::type_index>, std::equal_to<std::type_index>, std::allocator<std::pair<std::type_index const, std::shared_ptr<PVR::IPVRComponent> > > >::erase(std::type_index const&) (this=0x52f82b8, __x=...) at /usr/include/c++/12/bits/unordered_map.h:763
#21 0x000000000253a23c in CComponentContainer<PVR::IPVRComponent>::DeregisterComponent(std::type_info const&) (this=0x52f8288, typeInfo=...) at /home/lukas/Documents/git/xbmc/xbmc/utils/ComponentContainer.h:71
#22 0x0000000002539ac4 in PVR::CPVRComponentRegistration::~CPVRComponentRegistration() (this=0x52f8280, __in_chrg=<optimized out>) at /home/lukas/Documents/git/xbmc/xbmc/pvr/PVRComponentRegistration.cpp:51
#23 0x0000000002539af0 in PVR::CPVRComponentRegistration::~CPVRComponentRegistration() (this=0x52f8280, __in_chrg=<optimized out>) at /home/lukas/Documents/git/xbmc/xbmc/pvr/PVRComponentRegistration.cpp:52
#24 0x000000000256f0f2 in std::_Sp_counted_ptr<PVR::CPVRComponentRegistration*, (__gnu_cxx::_Lock_policy)2>::_M_dispose() (this=0x517a630) at /usr/include/c++/12/bits/shared_ptr_base.h:428
#25 0x000000000173a609 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() (this=0x517a630) at /usr/include/c++/12/bits/shared_ptr_base.h:346
#26 0x000000000173a7f5 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() (this=0x532bdc8, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/shared_ptr_base.h:1071
#27 0x000000000256bd4a in std::__shared_ptr<PVR::CPVRComponentRegistration, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() (this=0x532bdc0, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/shared_ptr_base.h:1524
#28 0x000000000256bd66 in std::shared_ptr<PVR::CPVRComponentRegistration>::~shared_ptr() (this=0x532bdc0, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/shared_ptr.h:175
#29 0x0000000002563526 in PVR::CPVRManager::~CPVRManager() (this=0x532ba80, __in_chrg=<optimized out>) at /home/lukas/Documents/git/xbmc/xbmc/pvr/PVRManager.cpp:223
#30 0x00000000025635ea in PVR::CPVRManager::~CPVRManager() (this=0x532ba80, __in_chrg=<optimized out>) at /home/lukas/Documents/git/xbmc/xbmc/pvr/PVRManager.cpp:223
#31 0x0000000002271b54 in std::default_delete<PVR::CPVRManager>::operator()(PVR::CPVRManager*) const (this=0x50ac908, __ptr=0x532ba80) at /usr/include/c++/12/bits/unique_ptr.h:95
#32 0x0000000002272b04 in std::__uniq_ptr_impl<PVR::CPVRManager, std::default_delete<PVR::CPVRManager> >::reset(PVR::CPVRManager*) (this=0x50ac908, __p=0x0) at /usr/include/c++/12/bits/unique_ptr.h:203
#33 0x00000000022709ab in std::unique_ptr<PVR::CPVRManager, std::default_delete<PVR::CPVRManager> >::reset(PVR::CPVRManager*) (this=0x50ac908, __p=0x0) at /usr/include/c++/12/bits/unique_ptr.h:501
#34 0x000000000226e253 in CServiceManager::DeinitStageTwo() (this=0x50ac8c0) at /home/lukas/Documents/git/xbmc/xbmc/ServiceManager.cpp:249
#35 0x0000000001ff25d0 in CApplication::Cleanup() (this=0x4ff0b60) at /home/lukas/Documents/git/xbmc/xbmc/application/Application.cpp:1966
#36 0x0000000001d62f78 in XBMC_Run(bool, std::shared_ptr<CAppParams> const&) (renderGUI=true, params=std::shared_ptr<CAppParams> (use count 3, weak count 0) = {...}) at /home/lukas/Documents/git/xbmc/xbmc/platform/xbmc.cpp:43
#37 0x000000000173a528 in main(int, char**) (argc=3, argv=0x7fffffffda38) at /home/lukas/Documents/git/xbmc/xbmc/platform/posix/main.cpp:69
```

3) [move CAppEnvironment up one level to guarantee calling TearDown](https://github.com/xbmc/xbmc/commit/28f9a52a1ffa034dc4f116cf1c3fd70248f97c54). This is required so we can guarantee calling `CAppEnvironment::TearDown` when the gui fails to be created. This is because `TearDown` deinitializes
 `CSettingsComponent` proprerly.

```
#0  0x00007ffff648ec4c in __pthread_kill_implementation () at /lib64/libc.so.6
#1  0x00007ffff643e9c6 in raise () at /lib64/libc.so.6
#2  0x00007ffff64287f4 in abort () at /lib64/libc.so.6
#3  0x00007ffff60a2b57 in __gnu_cxx::__verbose_terminate_handler() [clone .cold] () at /lib64/libstdc++.so.6
#4  0x00007ffff60ae3dc in __cxxabiv1::__terminate(void (*)()) () at /lib64/libstdc++.so.6
#5  0x00007ffff60ae447 in  () at /lib64/libstdc++.so.6
#6  0x00007ffff60af175 in  () at /lib64/libstdc++.so.6
#7  0x00000000022e1f8a in CSettingsManager::CreateControl(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const (this=0x508d6b0, controlType="list")
    at /home/lukas/Documents/git/xbmc/xbmc/settings/lib/SettingsManager.cpp:994
#8  0x00000000022be16f in CSetting::Copy(CSetting const&) (this=0x515b6b0, setting=...) at /home/lukas/Documents/git/xbmc/xbmc/settings/lib/Setting.cpp:332
#9  0x00000000022c4aba in CSettingString::copy(CSettingString const&) (this=0x515b6b0, setting=...) at /home/lukas/Documents/git/xbmc/xbmc/settings/lib/Setting.cpp:1618
#10 0x00000000022c334d in CSettingString::CSettingString(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&) (this=0x515b6b0, id="locale.keyboardlayouts.0", setting=...)
    at /home/lukas/Documents/git/xbmc/xbmc/settings/lib/Setting.cpp:1371
#11 0x00000000022cea23 in std::_Construct<CSettingString, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&>(CSettingString*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&) (__p=0x515b6b0) at /usr/include/c++/12/bits/stl_construct.h:119
#12 0x00000000022ce65d in std::allocator_traits<std::allocator<void> >::construct<CSettingString, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&>(std::allocator<void>&, CSettingString*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&) (__p=0x515b6b0) at /usr/include/c++/12/bits/alloc_traits.h:635
#13 0x00000000022cdff8 in std::_Sp_counted_ptr_inplace<CSettingString, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&>(std::allocator<void>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&) (this=0x515b6a0, __a=...) at /usr/include/c++/12/bits/shared_ptr_base.h:604
#14 0x00000000022cd650 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<CSettingString, std::allocator<void>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&>(CSettingString*&, std::_Sp_alloc_shared_tag<std::allocator<void> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&) (this=0x7fffffffd368, __p=@0x7fffffffd360: 0x0, __a=...)
    at /usr/include/c++/12/bits/shared_ptr_base.h:971
#15 0x00000000022ca1b4 in std::__shared_ptr<CSettingString, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<void>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&>(std::_Sp_alloc_shared_tag<std::allocator<void> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&) (this=0x7fffffffd360, __tag=...)
    at /usr/include/c++/12/bits/shared_ptr_base.h:1712
#16 0x00000000022c84ab in std::shared_ptr<CSettingString>::shared_ptr<std::allocator<void>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&>(std::_Sp_alloc_shared_tag<std::allocator<void> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&) (this=0x7fffffffd360, __tag=...) at /usr/include/c++/12/bits/shared_ptr.h:464
#17 0x00000000022c6abc in std::make_shared<CSettingString, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&) () at /usr/include/c++/12/bits/shared_ptr.h:1010
#18 0x00000000022c35fd in CSettingString::Clone(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const (this=0x528a500, id="locale.keyboardlayouts.0")
    at /home/lukas/Documents/git/xbmc/xbmc/settings/lib/Setting.cpp:1388
#19 0x00000000022bf1aa in CSettingList::Reset() (this=0x528a0b0) at /home/lukas/Documents/git/xbmc/xbmc/settings/lib/Setting.cpp:510
#20 0x00000000022dd057 in CSettingsManager::Unload() (this=0x508d6b0) at /home/lukas/Documents/git/xbmc/xbmc/settings/lib/SettingsManager.cpp:210
#21 0x00000000022dd0fb in CSettingsManager::Clear() (this=0x508d6b0) at /home/lukas/Documents/git/xbmc/xbmc/settings/lib/SettingsManager.cpp:218
#22 0x000000000235f1f6 in CSettingsBase::Uninitialize() (this=0x508d610) at /home/lukas/Documents/git/xbmc/xbmc/settings/SettingsBase.cpp:152
#23 0x000000000235ec16 in CSettingsBase::~CSettingsBase() (this=0x508d610, __in_chrg=<optimized out>) at /home/lukas/Documents/git/xbmc/xbmc/settings/SettingsBase.cpp:28
#24 0x000000000235ea91 in CSettings::~CSettings() (this=0x508d610, __in_chrg=<optimized out>) at /home/lukas/Documents/git/xbmc/xbmc/settings/Settings.h:481
#25 0x000000000235eac8 in CSettings::~CSettings() (this=0x508d610, __in_chrg=<optimized out>) at /home/lukas/Documents/git/xbmc/xbmc/settings/Settings.h:481
#26 0x0000000002366ab4 in std::_Sp_counted_ptr<CSettings*, (__gnu_cxx::_Lock_policy)2>::_M_dispose() (this=0x508c050) at /usr/include/c++/12/bits/shared_ptr_base.h:428
#27 0x000000000173a609 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() (this=0x508c050) at /usr/include/c++/12/bits/shared_ptr_base.h:346
#28 0x000000000173a7f5 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() (this=0x508d5c8, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/shared_ptr_base.h:1071
#29 0x000000000183ebee in std::__shared_ptr<CSettings, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() (this=0x508d5c0, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/shared_ptr_base.h:1524
#30 0x000000000183ec0a in std::shared_ptr<CSettings>::~shared_ptr() (this=0x508d5c0, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/shared_ptr.h:175
#31 0x00000000023647ba in CSettingsComponent::~CSettingsComponent() (this=0x508d5b0, __in_chrg=<optimized out>) at /home/lukas/Documents/git/xbmc/xbmc/settings/SettingsComponent.cpp:44
#32 0x0000000001fe834c in std::_Destroy<CSettingsComponent>(CSettingsComponent*) (__pointer=0x508d5b0) at /usr/include/c++/12/bits/stl_construct.h:151
#33 0x0000000001fe832a in std::allocator_traits<std::allocator<void> >::destroy<CSettingsComponent>(std::allocator<void>&, CSettingsComponent*) (__p=0x508d5b0) at /usr/include/c++/12/bits/alloc_traits.h:648
#34 0x0000000001fe8223 in std::_Sp_counted_ptr_inplace<CSettingsComponent, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() (this=0x508d5a0) at /usr/include/c++/12/bits/shared_ptr_base.h:613
#35 0x000000000173a609 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() (this=0x508d5a0) at /usr/include/c++/12/bits/shared_ptr_base.h:346
#36 0x000000000173a7f5 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() (this=0x4fd9f88, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/shared_ptr_base.h:1071
#37 0x00000000017f9a80 in std::__shared_ptr<CSettingsComponent, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() (this=0x4fd9f80, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/shared_ptr_base.h:1524
#38 0x00000000017f9a9c in std::shared_ptr<CSettingsComponent>::~shared_ptr() (this=0x4fd9f80, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/shared_ptr.h:175
#39 0x000000000226a9ec in CServiceBroker::~CServiceBroker() (this=0x4fd9f30, __in_chrg=<optimized out>) at /home/lukas/Documents/git/xbmc/xbmc/ServiceBroker.cpp:30
#40 0x0000000001747380 in std::_Sp_counted_ptr<CServiceBroker*, (__gnu_cxx::_Lock_policy)2>::_M_dispose() (this=0x4ff0260) at /usr/include/c++/12/bits/shared_ptr_base.h:428
#41 0x000000000173a609 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() (this=0x4ff0260) at /usr/include/c++/12/bits/shared_ptr_base.h:346
#42 0x000000000173a7f5 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() (this=0x47b81f8 <g_serviceBrokerRef+8>, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/shared_ptr_base.h:1071
#43 0x0000000001741f64 in std::__shared_ptr<CServiceBroker, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() (this=0x47b81f0 <g_serviceBrokerRef>, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/shared_ptr_base.h:1524
#44 0x0000000001741f80 in std::shared_ptr<CServiceBroker>::~shared_ptr() (this=0x47b81f0 <g_serviceBrokerRef>, __in_chrg=<optimized out>) at /usr/include/c++/12/bits/shared_ptr.h:175
#45 0x00007ffff6441085 in __run_exit_handlers () at /lib64/libc.so.6
#46 0x00007ffff6441200 in on_exit () at /lib64/libc.so.6
#47 0x00007ffff6429557 in __libc_start_call_main () at /lib64/libc.so.6
#48 0x00007ffff6429609 in __libc_start_main_impl () at /lib64/libc.so.6
#49 0x000000000173a325 in _start ()
```

