### PR TITLE
[PVR] CPVRRecording: Encapsulate members

### DIFF
--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -405,8 +405,8 @@ void CFileItemHandler::HandleFileItem(const char* ID,
          object[ID] = item->GetPVRChannelInfoTag()->ChannelID();
       else if (item->HasEPGInfoTag() && item->GetEPGInfoTag()->DatabaseID() > 0)
         object[ID] = item->GetEPGInfoTag()->DatabaseID();
-      else if (item->HasPVRRecordingInfoTag() && item->GetPVRRecordingInfoTag()->m_iRecordingId > 0)
-         object[ID] = item->GetPVRRecordingInfoTag()->m_iRecordingId;
+      else if (item->HasPVRRecordingInfoTag() && item->GetPVRRecordingInfoTag()->RecordingID() > 0)
+        object[ID] = item->GetPVRRecordingInfoTag()->RecordingID();
       else if (item->HasPVRTimerInfoTag() && item->GetPVRTimerInfoTag()->m_iTimerId > 0)
          object[ID] = item->GetPVRTimerInfoTag()->m_iTimerId;
       else if (item->HasMusicInfoTag() && item->GetMusicInfoTag()->GetDatabaseId() > 0)

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -285,7 +285,7 @@ std::shared_ptr<CPVRClient> CPVRManager::GetClient(const CFileItem& item) const
   if (item.HasPVRChannelInfoTag())
     iClientID = item.GetPVRChannelInfoTag()->ClientID();
   else if (item.HasPVRRecordingInfoTag())
-    iClientID = item.GetPVRRecordingInfoTag()->m_iClientId;
+    iClientID = item.GetPVRRecordingInfoTag()->ClientID();
   else if (item.HasPVRTimerInfoTag())
     iClientID = item.GetPVRTimerInfoTag()->m_iClientId;
   else if (item.HasEPGInfoTag())

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -113,7 +113,6 @@ public:
     return m_triggerEvent.Wait(std::chrono::milliseconds(milliSeconds));
   }
 
-
 private:
   void AppendJob(CPVRJob* job);
 
@@ -566,7 +565,9 @@ void CPVRManager::Process()
     }
     catch (...)
     {
-      CLog::LogF(LOGERROR, "An error occurred while trying to execute the last PVR update job, trying to recover");
+      CLog::LogF(
+          LOGERROR,
+          "An error occurred while trying to execute the last PVR update job, trying to recover");
       bRestart = true;
     }
 
@@ -597,7 +598,8 @@ bool CPVRManager::SetWakeupCommand()
   if (!m_settings.GetBoolValue(CSettings::SETTING_PVRPOWERMANAGEMENT_ENABLED))
     return false;
 
-  const std::string strWakeupCommand(m_settings.GetStringValue(CSettings::SETTING_PVRPOWERMANAGEMENT_SETWAKEUPCMD));
+  const std::string strWakeupCommand(
+      m_settings.GetStringValue(CSettings::SETTING_PVRPOWERMANAGEMENT_SETWAKEUPCMD));
   if (!strWakeupCommand.empty() && m_timers)
   {
     const CDateTime nextEvent = m_timers->GetNextEventTime();
@@ -784,19 +786,19 @@ void CPVRManager::RestartParentalTimer()
 
 bool CPVRManager::IsParentalLocked(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
 {
-  return m_channelGroups &&
-         epgTag &&
-         IsCurrentlyParentalLocked(m_channelGroups->GetByUniqueID(epgTag->UniqueChannelID(), epgTag->ClientID()),
-                                   epgTag->IsParentalLocked());
+  return m_channelGroups && epgTag &&
+         IsCurrentlyParentalLocked(
+             m_channelGroups->GetByUniqueID(epgTag->UniqueChannelID(), epgTag->ClientID()),
+             epgTag->IsParentalLocked());
 }
 
 bool CPVRManager::IsParentalLocked(const std::shared_ptr<CPVRChannel>& channel) const
 {
-  return channel &&
-         IsCurrentlyParentalLocked(channel, channel->IsLocked());
+  return channel && IsCurrentlyParentalLocked(channel, channel->IsLocked());
 }
 
-bool CPVRManager::IsCurrentlyParentalLocked(const std::shared_ptr<CPVRChannel>& channel, bool bGenerallyLocked) const
+bool CPVRManager::IsCurrentlyParentalLocked(const std::shared_ptr<CPVRChannel>& channel,
+                                            bool bGenerallyLocked) const
 {
   bool bReturn = false;
 
@@ -805,15 +807,15 @@ bool CPVRManager::IsCurrentlyParentalLocked(const std::shared_ptr<CPVRChannel>& 
 
   const std::shared_ptr<CPVRChannel> currentChannel = m_playbackState->GetPlayingChannel();
 
-  if (// if channel in question is currently playing it must be currently unlocked.
+  if ( // if channel in question is currently playing it must be currently unlocked.
       (!currentChannel || channel != currentChannel) &&
       // parental control enabled
       m_settings.GetBoolValue(CSettings::SETTING_PVRPARENTAL_ENABLED))
   {
-    float parentalDurationMs = m_settings.GetIntValue(CSettings::SETTING_PVRPARENTAL_DURATION) * 1000.0f;
-    bReturn = m_parentalTimer &&
-        (!m_parentalTimer->IsRunning() ||
-          m_parentalTimer->GetElapsedMilliseconds() > parentalDurationMs);
+    float parentalDurationMs =
+        m_settings.GetIntValue(CSettings::SETTING_PVRPARENTAL_DURATION) * 1000.0f;
+    bReturn = m_parentalTimer && (!m_parentalTimer->IsRunning() ||
+                                  m_parentalTimer->GetElapsedMilliseconds() > parentalDurationMs);
   }
 
   return bReturn;
@@ -847,8 +849,10 @@ void CPVRManager::LocalizationChanged()
   std::unique_lock<CCriticalSection> lock(m_critSection);
   if (IsStarted())
   {
-    static_cast<CPVRChannelGroupInternal *>(m_channelGroups->GetGroupAllRadio().get())->CheckGroupName();
-    static_cast<CPVRChannelGroupInternal *>(m_channelGroups->GetGroupAllTV().get())->CheckGroupName();
+    static_cast<CPVRChannelGroupInternal*>(m_channelGroups->GetGroupAllRadio().get())
+        ->CheckGroupName();
+    static_cast<CPVRChannelGroupInternal*>(m_channelGroups->GetGroupAllTV().get())
+        ->CheckGroupName();
   }
 }
 
@@ -860,16 +864,13 @@ bool CPVRManager::EpgsCreated() const
 
 void CPVRManager::TriggerEpgsCreate()
 {
-  m_pendingUpdates->Append("pvr-create-epgs", [this]() {
-    return CreateChannelEpgs();
-  });
+  m_pendingUpdates->Append("pvr-create-epgs", [this]() { return CreateChannelEpgs(); });
 }
 
 void CPVRManager::TriggerRecordingsSizeInProgressUpdate()
 {
-  m_pendingUpdates->Append("pvr-update-recordings-size", [this]() {
-    return Recordings()->UpdateInProgressSize();
-  });
+  m_pendingUpdates->Append("pvr-update-recordings-size",
+                           [this]() { return Recordings()->UpdateInProgressSize(); });
 }
 
 void CPVRManager::TriggerRecordingsUpdate(int clientId)

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -28,449 +28,453 @@ class CStopWatch;
 
 namespace PVR
 {
-  class CPVRChannel;
-  class CPVRChannelGroup;
-  class CPVRChannelGroupsContainer;
-  class CPVRProviders;
-  class CPVRClient;
-  class CPVRClients;
-  class CPVRDatabase;
-  class CPVRGUIInfo;
-  class CPVRGUIProgressHandler;
-  class CPVRManagerJobQueue;
-  class CPVRPlaybackState;
-  class CPVRRecording;
-  class CPVRRecordings;
-  class CPVRTimers;
+class CPVRChannel;
+class CPVRChannelGroup;
+class CPVRChannelGroupsContainer;
+class CPVRProviders;
+class CPVRClient;
+class CPVRClients;
+class CPVRDatabase;
+class CPVRGUIInfo;
+class CPVRGUIProgressHandler;
+class CPVRManagerJobQueue;
+class CPVRPlaybackState;
+class CPVRRecording;
+class CPVRRecordings;
+class CPVRTimers;
 
-  enum class PVREvent
+enum class PVREvent
+{
+  // PVR Manager states
+  ManagerError = 0,
+  ManagerStopped,
+  ManagerStarting,
+  ManagerStopping,
+  ManagerInterrupted,
+  ManagerStarted,
+
+  // Channel events
+  ChannelPlaybackStopped,
+
+  // Channel group events
+  ChannelGroup,
+  ChannelGroupInvalidated,
+  ChannelGroupsInvalidated,
+  ChannelGroupsLoaded,
+
+  // Recording events
+  RecordingsInvalidated,
+
+  // Timer events
+  AnnounceReminder,
+  Timers,
+  TimersInvalidated,
+
+  // EPG events
+  Epg,
+  EpgActiveItem,
+  EpgContainer,
+  EpgItemUpdate,
+  EpgUpdatePending,
+  EpgDeleted,
+
+  // Saved searches events
+  SavedSearchesInvalidated,
+
+  // Item events
+  CurrentItem,
+
+  // Syetem events
+  SystemSleep,
+  SystemWake,
+};
+
+class CPVRManager : private CThread, public ANNOUNCEMENT::IAnnouncer
+{
+public:
+  /*!
+   * @brief Create a new CPVRManager instance, which handles all PVR related operations in XBMC.
+   */
+  CPVRManager();
+
+  /*!
+   * @brief Stop the PVRManager and destroy all objects it created.
+   */
+  ~CPVRManager() override;
+
+  void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
+                const std::string& sender,
+                const std::string& message,
+                const CVariant& data) override;
+
+  /*!
+   * @brief Get a PVR component.
+   * @return The component.
+   */
+  template<class T>
+  T& Get()
   {
-    // PVR Manager states
-    ManagerError = 0,
-    ManagerStopped,
-    ManagerStarting,
-    ManagerStopping,
-    ManagerInterrupted,
-    ManagerStarted,
+    return *m_components->GetComponent<T>();
+  }
 
-    // Channel events
-    ChannelPlaybackStopped,
+  /*!
+   * @brief Get the providers container.
+   * @return The providers container.
+   */
+  std::shared_ptr<CPVRProviders> Providers() const;
 
-    // Channel group events
-    ChannelGroup,
-    ChannelGroupInvalidated,
-    ChannelGroupsInvalidated,
-    ChannelGroupsLoaded,
+  /*!
+   * @brief Get the channel groups container.
+   * @return The groups container.
+   */
+  std::shared_ptr<CPVRChannelGroupsContainer> ChannelGroups() const;
 
-    // Recording events
-    RecordingsInvalidated,
+  /*!
+   * @brief Get the recordings container.
+   * @return The recordings container.
+   */
+  std::shared_ptr<CPVRRecordings> Recordings() const;
 
-    // Timer events
-    AnnounceReminder,
-    Timers,
-    TimersInvalidated,
+  /*!
+   * @brief Get the timers container.
+   * @return The timers container.
+   */
+  std::shared_ptr<CPVRTimers> Timers() const;
 
-    // EPG events
-    Epg,
-    EpgActiveItem,
-    EpgContainer,
-    EpgItemUpdate,
-    EpgUpdatePending,
-    EpgDeleted,
+  /*!
+   * @brief Get the timers container.
+   * @return The timers container.
+   */
+  std::shared_ptr<CPVRClients> Clients() const;
 
-    // Saved searches events
-    SavedSearchesInvalidated,
+  /*!
+   * @brief Get the instance of a client that matches the given item.
+   * @param item The item containing a PVR recording, a PVR channel, a PVR timer or a PVR EPG event.
+   * @return the requested client on success, nullptr otherwise.
+   */
+  std::shared_ptr<CPVRClient> GetClient(const CFileItem& item) const;
 
-    // Item events
-    CurrentItem,
+  /*!
+   * @brief Get the instance of a client that matches the given id.
+   * @param iClientId The id of a PVR client.
+   * @return the requested client on success, nullptr otherwise.
+   */
+  std::shared_ptr<CPVRClient> GetClient(int iClientId) const;
 
-    // Syetem events
-    SystemSleep,
-    SystemWake,
+  /*!
+   * @brief Get access to the pvr playback state.
+   * @return The playback state.
+   */
+  std::shared_ptr<CPVRPlaybackState> PlaybackState() const;
+
+  /*!
+   * @brief Get access to the epg container.
+   * @return The epg container.
+   */
+  CPVREpgContainer& EpgContainer();
+
+  /*!
+   * @brief Init PVRManager.
+   */
+  void Init();
+
+  /*!
+   * @brief Start the PVRManager, which loads all PVR data and starts some threads to update the PVR data.
+   */
+  void Start();
+
+  /*!
+   * @brief Stop PVRManager.
+   */
+  void Stop(bool bRestart = false);
+
+  /*!
+   * @brief Stop PVRManager, unload data.
+   */
+  void Unload();
+
+  /*!
+   * @brief Deinit PVRManager, unload data, unload addons.
+   */
+  void Deinit();
+
+  /*!
+   * @brief Propagate event on system sleep
+   */
+  void OnSleep();
+
+  /*!
+   * @brief Propagate event on system wake
+   */
+  void OnWake();
+
+  /*!
+   * @brief Get the TV database.
+   * @return The TV database.
+   */
+  std::shared_ptr<CPVRDatabase> GetTVDatabase() const;
+
+  /*!
+   * @brief Check whether the PVRManager has fully started.
+   * @return True if started, false otherwise.
+   */
+  bool IsStarted() const { return GetState() == ManagerState::STATE_STARTED; }
+
+  /*!
+   * @brief Check whether EPG tags for channels have been created.
+   * @return True if EPG tags have been created, false otherwise.
+   */
+  bool EpgsCreated() const;
+
+  /*!
+   * @brief Inform PVR manager that playback of an item just started.
+   * @param item The item that started to play.
+   */
+  void OnPlaybackStarted(const std::shared_ptr<CFileItem>& item);
+
+  /*!
+   * @brief Inform PVR manager that playback of an item was stopped due to user interaction.
+   * @param item The item that stopped to play.
+   */
+  void OnPlaybackStopped(const std::shared_ptr<CFileItem>& item);
+
+  /*!
+   * @brief Inform PVR manager that playback of an item has stopped without user interaction.
+   * @param item The item that ended to play.
+   */
+  void OnPlaybackEnded(const std::shared_ptr<CFileItem>& item);
+
+  /*!
+   * @brief Let the background thread create epg tags for all channels.
+   */
+  void TriggerEpgsCreate();
+
+  /*!
+   * @brief Let the background thread update the recordings list.
+   * @param clientId The id of the PVR client to update.
+   */
+  void TriggerRecordingsUpdate(int clientId);
+  void TriggerRecordingsUpdate();
+
+  /*!
+   * @brief Let the background thread update the size for any in progress recordings.
+   */
+  void TriggerRecordingsSizeInProgressUpdate();
+
+  /*!
+   * @brief Let the background thread update the timer list.
+   * @param clientId The id of the PVR client to update.
+   */
+  void TriggerTimersUpdate(int clientId);
+  void TriggerTimersUpdate();
+
+  /*!
+   * @brief Let the background thread update the channel list.
+   * @param clientId The id of the PVR client to update.
+   */
+  void TriggerChannelsUpdate(int clientId);
+  void TriggerChannelsUpdate();
+
+  /*!
+   * @brief Let the background thread update the provider list.
+   * @param clientId The id of the PVR client to update.
+   */
+  void TriggerProvidersUpdate(int clientId);
+  void TriggerProvidersUpdate();
+
+  /*!
+   * @brief Let the background thread update the channel groups list.
+   * @param clientId The id of the PVR client to update.
+   */
+  void TriggerChannelGroupsUpdate(int clientId);
+  void TriggerChannelGroupsUpdate();
+
+  /*!
+   * @brief Let the background thread search for all missing channel icons.
+   */
+  void TriggerSearchMissingChannelIcons();
+
+  /*!
+   * @brief Let the background thread erase stale texture db entries and image files.
+   */
+  void TriggerCleanupCachedImages();
+
+  /*!
+   * @brief Let the background thread search for missing channel icons for channels contained in the given group.
+   * @param group The channel group.
+   */
+  void TriggerSearchMissingChannelIcons(const std::shared_ptr<CPVRChannelGroup>& group);
+
+  /*!
+   * @brief Check whether names are still correct after the language settings changed.
+   */
+  void LocalizationChanged();
+
+  /*!
+   * @brief Check if parental lock is overridden at the given moment.
+   * @param channel The channel to check.
+   * @return True if parental lock is overridden, false otherwise.
+   */
+  bool IsParentalLocked(const std::shared_ptr<CPVRChannel>& channel) const;
+
+  /*!
+   * @brief Check if parental lock is overridden at the given moment.
+   * @param epgTag The epg tag to check.
+   * @return True if parental lock is overridden, false otherwise.
+   */
+  bool IsParentalLocked(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
+
+  /*!
+   * @brief Restart the parental timer.
+   */
+  void RestartParentalTimer();
+
+  /*!
+   * @brief Create EPG tags for all channels in internal channel groups
+   * @return True if EPG tags where created successfully, false otherwise
+   */
+  bool CreateChannelEpgs();
+
+  /*!
+   * @brief Signal a connection change of a client
+   */
+  void ConnectionStateChange(CPVRClient* client,
+                             const std::string& connectString,
+                             PVR_CONNECTION_STATE state,
+                             const std::string& message);
+
+  /*!
+   * @brief Query the events available for CEventStream
+   */
+  CEventStream<PVREvent>& Events() { return m_events; }
+
+  /*!
+   * @brief Publish an event
+   * @param state the event
+   */
+  void PublishEvent(PVREvent state);
+
+protected:
+  /*!
+   * @brief PVR update and control thread.
+   */
+  void Process() override;
+
+private:
+  /*!
+   * @brief Executes "pvrpowermanagement.setwakeupcmd"
+   */
+  bool SetWakeupCommand();
+
+  enum class ManagerState
+  {
+    STATE_ERROR = 0,
+    STATE_STOPPED,
+    STATE_STARTING,
+    STATE_SSTOPPING,
+    STATE_INTERRUPTED,
+    STATE_STARTED
   };
 
-  class CPVRManager : private CThread, public ANNOUNCEMENT::IAnnouncer
-  {
-  public:
-    /*!
-     * @brief Create a new CPVRManager instance, which handles all PVR related operations in XBMC.
-     */
-    CPVRManager();
-
-    /*!
-     * @brief Stop the PVRManager and destroy all objects it created.
-     */
-    ~CPVRManager() override;
-
-    void Announce(ANNOUNCEMENT::AnnouncementFlag flag,
-                  const std::string& sender,
-                  const std::string& message,
-                  const CVariant& data) override;
-
-    /*!
-     * @brief Get a PVR component.
-     * @return The component.
-     */
-    template<class T>
-    T& Get()
-    {
-      return *m_components->GetComponent<T>();
-    }
-
-    /*!
-     * @brief Get the providers container.
-     * @return The providers container.
-     */
-    std::shared_ptr<CPVRProviders> Providers() const;
-
-    /*!
-     * @brief Get the channel groups container.
-     * @return The groups container.
-     */
-    std::shared_ptr<CPVRChannelGroupsContainer> ChannelGroups() const;
-
-    /*!
-     * @brief Get the recordings container.
-     * @return The recordings container.
-     */
-    std::shared_ptr<CPVRRecordings> Recordings() const;
-
-    /*!
-     * @brief Get the timers container.
-     * @return The timers container.
-     */
-    std::shared_ptr<CPVRTimers> Timers() const;
-
-    /*!
-     * @brief Get the timers container.
-     * @return The timers container.
-     */
-    std::shared_ptr<CPVRClients> Clients() const;
-
-    /*!
-     * @brief Get the instance of a client that matches the given item.
-     * @param item The item containing a PVR recording, a PVR channel, a PVR timer or a PVR EPG event.
-     * @return the requested client on success, nullptr otherwise.
-     */
-    std::shared_ptr<CPVRClient> GetClient(const CFileItem& item) const;
-
-    /*!
-     * @brief Get the instance of a client that matches the given id.
-     * @param iClientId The id of a PVR client.
-     * @return the requested client on success, nullptr otherwise.
-     */
-    std::shared_ptr<CPVRClient> GetClient(int iClientId) const;
-
-    /*!
-     * @brief Get access to the pvr playback state.
-     * @return The playback state.
-     */
-    std::shared_ptr<CPVRPlaybackState> PlaybackState() const;
-
-    /*!
-     * @brief Get access to the epg container.
-     * @return The epg container.
-     */
-    CPVREpgContainer& EpgContainer();
-
-    /*!
-     * @brief Init PVRManager.
-     */
-    void Init();
-
-    /*!
-     * @brief Start the PVRManager, which loads all PVR data and starts some threads to update the PVR data.
-     */
-    void Start();
-
-    /*!
-     * @brief Stop PVRManager.
-     */
-    void Stop(bool bRestart = false);
-
-    /*!
-     * @brief Stop PVRManager, unload data.
-     */
-    void Unload();
-
-    /*!
-     * @brief Deinit PVRManager, unload data, unload addons.
-     */
-    void Deinit();
-
-    /*!
-     * @brief Propagate event on system sleep
-     */
-    void OnSleep();
-
-    /*!
-     * @brief Propagate event on system wake
-     */
-    void OnWake();
-
-    /*!
-     * @brief Get the TV database.
-     * @return The TV database.
-     */
-    std::shared_ptr<CPVRDatabase> GetTVDatabase() const;
-
-    /*!
-     * @brief Check whether the PVRManager has fully started.
-     * @return True if started, false otherwise.
-     */
-    bool IsStarted() const { return GetState() == ManagerState::STATE_STARTED; }
-
-    /*!
-     * @brief Check whether EPG tags for channels have been created.
-     * @return True if EPG tags have been created, false otherwise.
-     */
-    bool EpgsCreated() const;
-
-    /*!
-     * @brief Inform PVR manager that playback of an item just started.
-     * @param item The item that started to play.
-     */
-    void OnPlaybackStarted(const std::shared_ptr<CFileItem>& item);
-
-    /*!
-     * @brief Inform PVR manager that playback of an item was stopped due to user interaction.
-     * @param item The item that stopped to play.
-     */
-    void OnPlaybackStopped(const std::shared_ptr<CFileItem>& item);
-
-    /*!
-     * @brief Inform PVR manager that playback of an item has stopped without user interaction.
-     * @param item The item that ended to play.
-     */
-    void OnPlaybackEnded(const std::shared_ptr<CFileItem>& item);
-
-    /*!
-     * @brief Let the background thread create epg tags for all channels.
-     */
-    void TriggerEpgsCreate();
-
-    /*!
-     * @brief Let the background thread update the recordings list.
-     * @param clientId The id of the PVR client to update.
-     */
-    void TriggerRecordingsUpdate(int clientId);
-    void TriggerRecordingsUpdate();
-
-    /*!
-     * @brief Let the background thread update the size for any in progress recordings.
-     */
-    void TriggerRecordingsSizeInProgressUpdate();
-
-    /*!
-     * @brief Let the background thread update the timer list.
-     * @param clientId The id of the PVR client to update.
-     */
-    void TriggerTimersUpdate(int clientId);
-    void TriggerTimersUpdate();
-
-    /*!
-     * @brief Let the background thread update the channel list.
-     * @param clientId The id of the PVR client to update.
-     */
-    void TriggerChannelsUpdate(int clientId);
-    void TriggerChannelsUpdate();
-
-    /*!
-     * @brief Let the background thread update the provider list.
-     * @param clientId The id of the PVR client to update.
-     */
-    void TriggerProvidersUpdate(int clientId);
-    void TriggerProvidersUpdate();
-
-    /*!
-     * @brief Let the background thread update the channel groups list.
-     * @param clientId The id of the PVR client to update.
-     */
-    void TriggerChannelGroupsUpdate(int clientId);
-    void TriggerChannelGroupsUpdate();
-
-    /*!
-     * @brief Let the background thread search for all missing channel icons.
-     */
-    void TriggerSearchMissingChannelIcons();
-
-    /*!
-     * @brief Let the background thread erase stale texture db entries and image files.
-     */
-    void TriggerCleanupCachedImages();
-
-    /*!
-     * @brief Let the background thread search for missing channel icons for channels contained in the given group.
-     * @param group The channel group.
-     */
-    void TriggerSearchMissingChannelIcons(const std::shared_ptr<CPVRChannelGroup>& group);
-
-    /*!
-     * @brief Check whether names are still correct after the language settings changed.
-     */
-    void LocalizationChanged();
-
-    /*!
-     * @brief Check if parental lock is overridden at the given moment.
-     * @param channel The channel to check.
-     * @return True if parental lock is overridden, false otherwise.
-     */
-    bool IsParentalLocked(const std::shared_ptr<CPVRChannel>& channel) const;
-
-    /*!
-     * @brief Check if parental lock is overridden at the given moment.
-     * @param epgTag The epg tag to check.
-     * @return True if parental lock is overridden, false otherwise.
-     */
-    bool IsParentalLocked(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
-
-    /*!
-     * @brief Restart the parental timer.
-     */
-    void RestartParentalTimer();
-
-    /*!
-     * @brief Create EPG tags for all channels in internal channel groups
-     * @return True if EPG tags where created successfully, false otherwise
-     */
-    bool CreateChannelEpgs();
-
-    /*!
-     * @brief Signal a connection change of a client
-     */
-    void ConnectionStateChange(CPVRClient* client,
-                               const std::string& connectString,
-                               PVR_CONNECTION_STATE state,
-                               const std::string& message);
-
-    /*!
-     * @brief Query the events available for CEventStream
-     */
-    CEventStream<PVREvent>& Events() { return m_events; }
-
-    /*!
-     * @brief Publish an event
-     * @param state the event
-     */
-    void PublishEvent(PVREvent state);
-
-  protected:
-    /*!
-     * @brief PVR update and control thread.
-     */
-    void Process() override;
-
-  private:
-    /*!
-     * @brief Executes "pvrpowermanagement.setwakeupcmd"
-     */
-    bool SetWakeupCommand();
-
-    enum class ManagerState
-    {
-      STATE_ERROR = 0,
-      STATE_STOPPED,
-      STATE_STARTING,
-      STATE_SSTOPPING,
-      STATE_INTERRUPTED,
-      STATE_STARTED
-    };
-
-    /*!
-     * @return True while the PVRManager is initialising.
-     */
-    bool IsInitialising() const { return GetState() == ManagerState::STATE_STARTING; }
-
-    /*!
-     * @brief Check whether the PVRManager has been stopped.
-     * @return True if stopped, false otherwise.
-     */
-    bool IsStopped() const { return GetState() == ManagerState::STATE_STOPPED; }
-
-    /*!
-     * @brief Get the current state of the PVR manager.
-     * @return the state.
-     */
-    ManagerState GetState() const;
-
-    /*!
-     * @brief Set the current state of the PVR manager.
-     * @param state the new state.
-     */
-    void SetState(ManagerState state);
-
-    /*!
-     * @brief Wait until at least one client is up. Update all data from database and the given PVR clients.
-     * @param stateToCheck Required state of the PVR manager while this method gets called.
-     */
-    void UpdateComponents(ManagerState stateToCheck);
-
-    /*!
-     * @brief Update all data from database and the given PVR clients.
-     * @param stateToCheck Required state of the PVR manager while this method gets called.
-     * @param progressHandler The progress handler to use for showing the different stages.
-     * @return True if at least one client is known and successfully loaded, false otherwise.
-     */
-    bool UpdateComponents(ManagerState stateToCheck,
-                          const std::unique_ptr<CPVRGUIProgressHandler>& progressHandler);
-
-    /*!
-     * @brief Unload all PVR data (recordings, timers, channelgroups).
-     */
-    void UnloadComponents();
-
-    /*!
-     * @brief Check whether the given client id belongs to a known client.
-     * @return True if the client is known, false otherwise.
-     */
-    bool IsKnownClient(int clientID) const;
-
-    /*!
-     * @brief Reset all properties.
-     */
-    void ResetProperties();
-
-    /*!
-     * @brief Destroy PVRManager's objects.
-     */
-    void Clear();
-
-    /*!
-     * @brief Continue playback on the last played channel.
-     */
-    void TriggerPlayChannelOnStartup();
-
-    bool IsCurrentlyParentalLocked(const std::shared_ptr<CPVRChannel>& channel, bool bGenerallyLocked) const;
-
-    CEventSource<PVREvent> m_events;
-
-    /** @name containers */
-    //@{
-    std::shared_ptr<CPVRProviders> m_providers; /*!< pointer to the providers container */
-    std::shared_ptr<CPVRChannelGroupsContainer> m_channelGroups; /*!< pointer to the channel groups container */
-    std::shared_ptr<CPVRRecordings> m_recordings; /*!< pointer to the recordings container */
-    std::shared_ptr<CPVRTimers> m_timers; /*!< pointer to the timers container */
-    std::shared_ptr<CPVRClients> m_addons; /*!< pointer to the pvr addon container */
-    std::unique_ptr<CPVRGUIInfo> m_guiInfo; /*!< pointer to the guiinfo data */
-    std::shared_ptr<CPVRComponentRegistration> m_components; /*!< pointer to the PVR components */
-    CPVREpgContainer m_epgContainer; /*!< the epg container */
-    //@}
-
-    std::vector<std::shared_ptr<CPVRClient>> m_knownClients; /*!< vector with all known clients */
-    std::unique_ptr<CPVRManagerJobQueue> m_pendingUpdates; /*!< vector of pending pvr updates */
-    std::shared_ptr<CPVRDatabase> m_database; /*!< the database for all PVR related data */
-    mutable CCriticalSection m_critSection; /*!< critical section for all changes to this class, except for changes to triggers */
-    bool m_bFirstStart = true; /*!< true when the PVR manager was started first, false otherwise */
-    bool m_bEpgsCreated = false; /*!< true if epg data for channels has been created */
-
-    mutable CCriticalSection m_managerStateMutex;
-    ManagerState m_managerState = ManagerState::STATE_STOPPED;
-    std::unique_ptr<CStopWatch> m_parentalTimer;
-
-    CCriticalSection m_startStopMutex; // mutex for protecting pvr manager's start/restart/stop sequence */
-
-    const std::shared_ptr<CPVRPlaybackState> m_playbackState;
-    CPVRGUIActionListener m_actionListener;
-    CPVRSettings m_settings;
-  };
-}
+  /*!
+   * @return True while the PVRManager is initialising.
+   */
+  bool IsInitialising() const { return GetState() == ManagerState::STATE_STARTING; }
+
+  /*!
+   * @brief Check whether the PVRManager has been stopped.
+   * @return True if stopped, false otherwise.
+   */
+  bool IsStopped() const { return GetState() == ManagerState::STATE_STOPPED; }
+
+  /*!
+   * @brief Get the current state of the PVR manager.
+   * @return the state.
+   */
+  ManagerState GetState() const;
+
+  /*!
+   * @brief Set the current state of the PVR manager.
+   * @param state the new state.
+   */
+  void SetState(ManagerState state);
+
+  /*!
+   * @brief Wait until at least one client is up. Update all data from database and the given PVR clients.
+   * @param stateToCheck Required state of the PVR manager while this method gets called.
+   */
+  void UpdateComponents(ManagerState stateToCheck);
+
+  /*!
+   * @brief Update all data from database and the given PVR clients.
+   * @param stateToCheck Required state of the PVR manager while this method gets called.
+   * @param progressHandler The progress handler to use for showing the different stages.
+   * @return True if at least one client is known and successfully loaded, false otherwise.
+   */
+  bool UpdateComponents(ManagerState stateToCheck,
+                        const std::unique_ptr<CPVRGUIProgressHandler>& progressHandler);
+
+  /*!
+   * @brief Unload all PVR data (recordings, timers, channelgroups).
+   */
+  void UnloadComponents();
+
+  /*!
+   * @brief Check whether the given client id belongs to a known client.
+   * @return True if the client is known, false otherwise.
+   */
+  bool IsKnownClient(int clientID) const;
+
+  /*!
+   * @brief Reset all properties.
+   */
+  void ResetProperties();
+
+  /*!
+   * @brief Destroy PVRManager's objects.
+   */
+  void Clear();
+
+  /*!
+   * @brief Continue playback on the last played channel.
+   */
+  void TriggerPlayChannelOnStartup();
+
+  bool IsCurrentlyParentalLocked(const std::shared_ptr<CPVRChannel>& channel,
+                                 bool bGenerallyLocked) const;
+
+  CEventSource<PVREvent> m_events;
+
+  /** @name containers */
+  //@{
+  std::shared_ptr<CPVRProviders> m_providers; /*!< pointer to the providers container */
+  std::shared_ptr<CPVRChannelGroupsContainer>
+      m_channelGroups; /*!< pointer to the channel groups container */
+  std::shared_ptr<CPVRRecordings> m_recordings; /*!< pointer to the recordings container */
+  std::shared_ptr<CPVRTimers> m_timers; /*!< pointer to the timers container */
+  std::shared_ptr<CPVRClients> m_addons; /*!< pointer to the pvr addon container */
+  std::unique_ptr<CPVRGUIInfo> m_guiInfo; /*!< pointer to the guiinfo data */
+  std::shared_ptr<CPVRComponentRegistration> m_components; /*!< pointer to the PVR components */
+  CPVREpgContainer m_epgContainer; /*!< the epg container */
+  //@}
+
+  std::vector<std::shared_ptr<CPVRClient>> m_knownClients; /*!< vector with all known clients */
+  std::unique_ptr<CPVRManagerJobQueue> m_pendingUpdates; /*!< vector of pending pvr updates */
+  std::shared_ptr<CPVRDatabase> m_database; /*!< the database for all PVR related data */
+  mutable CCriticalSection
+      m_critSection; /*!< critical section for all changes to this class, except for changes to triggers */
+  bool m_bFirstStart = true; /*!< true when the PVR manager was started first, false otherwise */
+  bool m_bEpgsCreated = false; /*!< true if epg data for channels has been created */
+
+  mutable CCriticalSection m_managerStateMutex;
+  ManagerState m_managerState = ManagerState::STATE_STOPPED;
+  std::unique_ptr<CStopWatch> m_parentalTimer;
+
+  CCriticalSection
+      m_startStopMutex; // mutex for protecting pvr manager's start/restart/stop sequence */
+
+  const std::shared_ptr<CPVRPlaybackState> m_playbackState;
+  CPVRGUIActionListener m_actionListener;
+  CPVRSettings m_settings;
+};
+} // namespace PVR

--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -45,10 +45,7 @@ public:
   }
 
   // ITimerCallback implementation
-  void OnTimeout() override
-  {
-    m_state.UpdateLastWatched(m_channel, m_time);
-  }
+  void OnTimeout() override { m_state.UpdateLastWatched(m_channel, m_time); }
 
 private:
   CLastWatchedUpdateTimer() = delete;
@@ -57,7 +54,6 @@ private:
   const std::shared_ptr<CPVRChannelGroupMember> m_channel;
   const CDateTime m_time;
 };
-
 
 CPVRPlaybackState::CPVRPlaybackState() = default;
 
@@ -180,14 +176,17 @@ void CPVRPlaybackState::OnPlaybackStarted(const std::shared_ptr<CFileItem>& item
       }
     }
 
-    int iLastWatchedDelay = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_PVRPLAYBACK_DELAYMARKLASTWATCHED) * 1000;
+    int iLastWatchedDelay = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+                                CSettings::SETTING_PVRPLAYBACK_DELAYMARKLASTWATCHED) *
+                            1000;
     if (iLastWatchedDelay > 0)
     {
       // Insert new / replace existing last watched update timer
       if (m_lastWatchedUpdateTimer)
         m_lastWatchedUpdateTimer->Stop(true);
 
-      m_lastWatchedUpdateTimer.reset(new CLastWatchedUpdateTimer(*this, channel, CDateTime::GetUTCDateTime()));
+      m_lastWatchedUpdateTimer.reset(
+          new CLastWatchedUpdateTimer(*this, channel, CDateTime::GetUTCDateTime()));
       m_lastWatchedUpdateTimer->Start(std::chrono::milliseconds(iLastWatchedDelay));
     }
     else
@@ -216,7 +215,8 @@ void CPVRPlaybackState::OnPlaybackStarted(const std::shared_ptr<CFileItem>& item
 
   if (m_playingClientId != -1)
   {
-    const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_playingClientId);
+    const std::shared_ptr<CPVRClient> client =
+        CServiceBroker::GetPVRManager().GetClient(m_playingClientId);
     if (client)
       m_strPlayingClientName = client->GetFriendlyName();
   }
@@ -419,7 +419,8 @@ bool CPVRPlaybackState::IsRecording() const
 bool CPVRPlaybackState::IsRecordingOnPlayingChannel() const
 {
   const std::shared_ptr<CPVRChannel> currentChannel = GetPlayingChannel();
-  return currentChannel && CServiceBroker::GetPVRManager().Timers()->IsRecordingOnChannel(*currentChannel);
+  return currentChannel &&
+         CServiceBroker::GetPVRManager().Timers()->IsRecordingOnChannel(*currentChannel);
 }
 
 bool CPVRPlaybackState::IsPlayingActiveRecording() const

--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -199,8 +199,8 @@ void CPVRPlaybackState::OnPlaybackStarted(const std::shared_ptr<CFileItem>& item
   else if (item->HasPVRRecordingInfoTag())
   {
     m_playingRecording = item->GetPVRRecordingInfoTag();
-    m_playingClientId = m_playingRecording->m_iClientId;
-    m_strPlayingRecordingUniqueId = m_playingRecording->m_strRecordingId;
+    m_playingClientId = m_playingRecording->ClientID();
+    m_strPlayingRecordingUniqueId = m_playingRecording->ClientRecordingID();
   }
   else if (item->HasEPGInfoTag())
   {
@@ -259,7 +259,7 @@ bool CPVRPlaybackState::OnPlaybackStopped(const std::shared_ptr<CFileItem>& item
   }
   else if (item->HasPVRRecordingInfoTag() &&
            item->GetPVRRecordingInfoTag()->ClientID() == m_playingClientId &&
-           item->GetPVRRecordingInfoTag()->m_strRecordingId == m_strPlayingRecordingUniqueId)
+           item->GetPVRRecordingInfoTag()->ClientRecordingID() == m_strPlayingRecordingUniqueId)
   {
     bChanged = true;
     m_playingRecording.reset();
@@ -348,7 +348,7 @@ bool CPVRPlaybackState::IsPlayingRecording(const std::shared_ptr<CPVRRecording>&
   {
     const std::shared_ptr<CPVRRecording> current = GetPlayingRecording();
     if (current && current->ClientID() == recording->ClientID() &&
-        current->m_strRecordingId == recording->m_strRecordingId)
+        current->ClientRecordingID() == recording->ClientRecordingID())
       return true;
   }
 

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -314,7 +314,7 @@ void CPVRClient::WriteClientRecordingInfo(const CPVRRecording& xbmcRecording,
   xbmcRecording.RecordingTimeAsUTC().GetAsTime(recTime);
 
   addonRecording = {};
-  strncpy(addonRecording.strRecordingId, xbmcRecording.m_strRecordingId.c_str(),
+  strncpy(addonRecording.strRecordingId, xbmcRecording.ClientRecordingID().c_str(),
           sizeof(addonRecording.strRecordingId) - 1);
   strncpy(addonRecording.strTitle, xbmcRecording.m_strTitle.c_str(),
           sizeof(addonRecording.strTitle) - 1);
@@ -323,7 +323,7 @@ void CPVRClient::WriteClientRecordingInfo(const CPVRRecording& xbmcRecording,
   addonRecording.iSeriesNumber = xbmcRecording.m_iSeason;
   addonRecording.iEpisodeNumber = xbmcRecording.m_iEpisode;
   addonRecording.iYear = xbmcRecording.GetYear();
-  strncpy(addonRecording.strDirectory, xbmcRecording.m_strDirectory.c_str(),
+  strncpy(addonRecording.strDirectory, xbmcRecording.Directory().c_str(),
           sizeof(addonRecording.strDirectory) - 1);
   strncpy(addonRecording.strPlotOutline, xbmcRecording.m_strPlotOutline.c_str(),
           sizeof(addonRecording.strPlotOutline) - 1);
@@ -331,7 +331,7 @@ void CPVRClient::WriteClientRecordingInfo(const CPVRRecording& xbmcRecording,
           sizeof(addonRecording.strPlot) - 1);
   strncpy(addonRecording.strGenreDescription, xbmcRecording.GetGenresLabel().c_str(),
           sizeof(addonRecording.strGenreDescription) - 1);
-  strncpy(addonRecording.strChannelName, xbmcRecording.m_strChannelName.c_str(),
+  strncpy(addonRecording.strChannelName, xbmcRecording.ChannelName().c_str(),
           sizeof(addonRecording.strChannelName) - 1);
   strncpy(addonRecording.strIconPath, xbmcRecording.ClientIconPath().c_str(),
           sizeof(addonRecording.strIconPath) - 1);
@@ -342,8 +342,8 @@ void CPVRClient::WriteClientRecordingInfo(const CPVRRecording& xbmcRecording,
   addonRecording.recordingTime =
       recTime - CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRTimeCorrection;
   addonRecording.iDuration = xbmcRecording.GetDuration();
-  addonRecording.iPriority = xbmcRecording.m_iPriority;
-  addonRecording.iLifetime = xbmcRecording.m_iLifetime;
+  addonRecording.iPriority = xbmcRecording.Priority();
+  addonRecording.iLifetime = xbmcRecording.LifeTime();
   addonRecording.iGenreType = xbmcRecording.GenreType();
   addonRecording.iGenreSubType = xbmcRecording.GenreSubType();
   addonRecording.iPlayCount = xbmcRecording.GetLocalPlayCount();

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
@@ -55,7 +55,7 @@ void CGUIDialogPVRRecordingSettings::SetRecording(const std::shared_ptr<CPVRReco
   // Copy data we need from tag. Do not modify the tag itself until Save()!
   m_strTitle = m_recording->m_strTitle;
   m_iPlayCount = m_recording->GetLocalPlayCount();
-  m_iLifetime = m_recording->m_iLifetime;
+  m_iLifetime = m_recording->LifeTime();
 }
 
 void CGUIDialogPVRRecordingSettings::SetupView()
@@ -182,7 +182,7 @@ bool CGUIDialogPVRRecordingSettings::Save()
   m_recording->SetLocalPlayCount(m_iPlayCount);
 
   // Lifetime
-  m_recording->m_iLifetime = m_iLifetime;
+  m_recording->SetLifeTime(m_iLifetime);
 
   return true;
 }

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
@@ -36,8 +36,8 @@ using namespace KODI::MESSAGING;
 #define SETTING_RECORDING_PLAYCOUNT "recording.playcount"
 #define SETTING_RECORDING_LIFETIME "recording.lifetime"
 
-CGUIDialogPVRRecordingSettings::CGUIDialogPVRRecordingSettings() :
-  CGUIDialogSettingsManualBase(WINDOW_DIALOG_PVR_RECORDING_SETTING, "DialogSettings.xml")
+CGUIDialogPVRRecordingSettings::CGUIDialogPVRRecordingSettings()
+  : CGUIDialogSettingsManualBase(WINDOW_DIALOG_PVR_RECORDING_SETTING, "DialogSettings.xml")
 {
   m_loadType = LOAD_EVERY_TIME;
 }
@@ -86,7 +86,8 @@ void CGUIDialogPVRRecordingSettings::InitializeSettings()
   }
 
   std::shared_ptr<CSetting> setting = nullptr;
-  const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_recording->ClientID());
+  const std::shared_ptr<CPVRClient> client =
+      CServiceBroker::GetPVRManager().GetClient(m_recording->ClientID());
 
   // Name
   setting = AddEdit(group, SETTING_RECORDING_NAME, 19075, SettingLevel::Basic, m_strTitle);
@@ -94,11 +95,13 @@ void CGUIDialogPVRRecordingSettings::InitializeSettings()
 
   // Play count
   if (client && client->GetClientCapabilities().SupportsRecordingsPlayCount())
-    setting = AddEdit(group, SETTING_RECORDING_PLAYCOUNT, 567, SettingLevel::Basic, m_recording->GetLocalPlayCount());
+    setting = AddEdit(group, SETTING_RECORDING_PLAYCOUNT, 567, SettingLevel::Basic,
+                      m_recording->GetLocalPlayCount());
 
   // Lifetime
   if (client && client->GetClientCapabilities().SupportsRecordingsLifetimeChange())
-    setting = AddList(group, SETTING_RECORDING_LIFETIME, 19083, SettingLevel::Basic, m_iLifetime, LifetimesFiller, 19083);
+    setting = AddList(group, SETTING_RECORDING_LIFETIME, 19083, SettingLevel::Basic, m_iLifetime,
+                      LifetimesFiller, 19083);
 }
 
 bool CGUIDialogPVRRecordingSettings::CanEditRecording(const CFileItem& item)
@@ -106,15 +109,15 @@ bool CGUIDialogPVRRecordingSettings::CanEditRecording(const CFileItem& item)
   if (!item.HasPVRRecordingInfoTag())
     return false;
 
-  const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(item.GetPVRRecordingInfoTag()->ClientID());
+  const std::shared_ptr<CPVRClient> client =
+      CServiceBroker::GetPVRManager().GetClient(item.GetPVRRecordingInfoTag()->ClientID());
 
   if (!client)
     return false;
 
   const CPVRClientCapabilities& capabilities = client->GetClientCapabilities();
 
-  return capabilities.SupportsRecordingsRename() ||
-         capabilities.SupportsRecordingsPlayCount() ||
+  return capabilities.SupportsRecordingsRename() || capabilities.SupportsRecordingsPlayCount() ||
          capabilities.SupportsRecordingsLifetimeChange();
 }
 
@@ -197,10 +200,11 @@ void CGUIDialogPVRRecordingSettings::LifetimesFiller(const SettingConstPtr& sett
   {
     list.clear();
 
-    const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(pThis->m_recording->ClientID());
+    const std::shared_ptr<CPVRClient> client =
+        CServiceBroker::GetPVRManager().GetClient(pThis->m_recording->ClientID());
     if (client)
     {
-      std::vector<std::pair<std::string,int>> values;
+      std::vector<std::pair<std::string, int>> values;
       client->GetClientCapabilities().GetRecordingsLifetimeValues(values);
       std::transform(
           values.cbegin(), values.cend(), std::back_inserter(list),

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.h
@@ -21,38 +21,38 @@ struct IntegerSettingOption;
 
 namespace PVR
 {
-  class CPVRRecording;
+class CPVRRecording;
 
-  class CGUIDialogPVRRecordingSettings : public CGUIDialogSettingsManualBase
-  {
-  public:
-    CGUIDialogPVRRecordingSettings();
+class CGUIDialogPVRRecordingSettings : public CGUIDialogSettingsManualBase
+{
+public:
+  CGUIDialogPVRRecordingSettings();
 
-    void SetRecording(const std::shared_ptr<CPVRRecording>& recording);
-    static bool CanEditRecording(const CFileItem& item);
+  void SetRecording(const std::shared_ptr<CPVRRecording>& recording);
+  static bool CanEditRecording(const CFileItem& item);
 
-  protected:
-    // implementation of ISettingCallback
-    bool OnSettingChanging(const std::shared_ptr<const CSetting>& setting) override;
-    void OnSettingChanged(const std::shared_ptr<const CSetting>& setting) override;
+protected:
+  // implementation of ISettingCallback
+  bool OnSettingChanging(const std::shared_ptr<const CSetting>& setting) override;
+  void OnSettingChanged(const std::shared_ptr<const CSetting>& setting) override;
 
-    // specialization of CGUIDialogSettingsBase
-    bool AllowResettingSettings() const override { return false; }
-    bool Save() override;
-    void SetupView() override;
+  // specialization of CGUIDialogSettingsBase
+  bool AllowResettingSettings() const override { return false; }
+  bool Save() override;
+  void SetupView() override;
 
-    // specialization of CGUIDialogSettingsManualBase
-    void InitializeSettings() override;
+  // specialization of CGUIDialogSettingsManualBase
+  void InitializeSettings() override;
 
-  private:
-    static void LifetimesFiller(const std::shared_ptr<const CSetting>& setting,
-                                std::vector<IntegerSettingOption>& list,
-                                int& current,
-                                void* data);
+private:
+  static void LifetimesFiller(const std::shared_ptr<const CSetting>& setting,
+                              std::vector<IntegerSettingOption>& list,
+                              int& current,
+                              void* data);
 
-    std::shared_ptr<CPVRRecording> m_recording;
-    std::string m_strTitle;
-    int m_iPlayCount = 0;
-    int m_iLifetime = 0;
-  };
+  std::shared_ptr<CPVRRecording> m_recording;
+  std::string m_strTitle;
+  int m_iPlayCount = 0;
+  int m_iLifetime = 0;
+};
 } // namespace PVR

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -297,7 +297,8 @@ void GetSubDirectories(const CPVRRecordingsPath& recParentPath,
     if (recording->IsRadio() != bRadio)
       continue;
 
-    const std::string strCurrent = recParentPath.GetUnescapedSubDirectoryPath(recording->m_strDirectory);
+    const std::string strCurrent =
+        recParentPath.GetUnescapedSubDirectoryPath(recording->Directory());
     if (strCurrent.empty())
       continue;
 
@@ -401,7 +402,7 @@ bool CPVRGUIDirectory::GetRecordingsDirectory(CFileItemList& results) const
       // Omit recordings not matching criteria
       if (recording->IsDeleted() != recPath.IsDeleted() ||
           recording->IsRadio() != recPath.IsRadio() ||
-          !IsDirectoryMember(strDirectory, recording->m_strDirectory, bGrouped))
+          !IsDirectoryMember(strDirectory, recording->Directory(), bGrouped))
         continue;
 
       item = std::make_shared<CFileItem>(recording);

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -366,7 +366,8 @@ void GetSubDirectories(const CPVRRecordingsPath& recParentPath,
 bool CPVRGUIDirectory::GetRecordingsDirectory(CFileItemList& results) const
 {
   bool bGrouped = false;
-  const std::vector<std::shared_ptr<CPVRRecording>> recordings = CServiceBroker::GetPVRManager().Recordings()->GetAll();
+  const std::vector<std::shared_ptr<CPVRRecording>> recordings =
+      CServiceBroker::GetPVRManager().Recordings()->GetAll();
 
   if (m_url.HasOption("view"))
   {
@@ -383,7 +384,8 @@ bool CPVRGUIDirectory::GetRecordingsDirectory(CFileItemList& results) const
   }
   else
   {
-    bGrouped = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_PVRRECORD_GROUPRECORDINGS);
+    bGrouped = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+        CSettings::SETTING_PVRRECORD_GROUPRECORDINGS);
   }
 
   const CPVRRecordingsPath recPath(m_url.GetWithoutOptions());
@@ -426,13 +428,17 @@ bool CPVRGUIDirectory::GetSavedSearchesDirectory(bool bRadio, CFileItemList& res
   return true;
 }
 
-bool CPVRGUIDirectory::GetChannelGroupsDirectory(bool bRadio, bool bExcludeHidden, CFileItemList& results)
+bool CPVRGUIDirectory::GetChannelGroupsDirectory(bool bRadio,
+                                                 bool bExcludeHidden,
+                                                 CFileItemList& results)
 {
-  const CPVRChannelGroups* channelGroups = CServiceBroker::GetPVRManager().ChannelGroups()->Get(bRadio);
+  const CPVRChannelGroups* channelGroups =
+      CServiceBroker::GetPVRManager().ChannelGroups()->Get(bRadio);
   if (channelGroups)
   {
     std::shared_ptr<CFileItem> item;
-    const std::vector<std::shared_ptr<CPVRChannelGroup>> groups = channelGroups->GetMembers(bExcludeHidden);
+    const std::vector<std::shared_ptr<CPVRChannelGroup>> groups =
+        channelGroups->GetMembers(bExcludeHidden);
     for (const auto& group : groups)
     {
       item = std::make_shared<CFileItem>(group->GetPath(), true);
@@ -484,7 +490,10 @@ bool CPVRGUIDirectory::GetChannelsDirectory(CFileItemList& results) const
       }
       else
       {
-        group = CServiceBroker::GetPVRManager().ChannelGroups()->Get(path.IsRadio())->GetByName(strGroupName);
+        group = CServiceBroker::GetPVRManager()
+                    .ChannelGroups()
+                    ->Get(path.IsRadio())
+                    ->GetByName(strGroupName);
       }
 
       if (group)
@@ -530,7 +539,8 @@ bool GetTimersRootDirectory(const CPVRTimersPath& path,
 
   for (const auto& timer : timers)
   {
-    if ((bRadio == timer->m_bIsRadio || (bRules && timer->m_iClientChannelUid == PVR_TIMER_ANY_CHANNEL)) &&
+    if ((bRadio == timer->m_bIsRadio ||
+         (bRules && timer->m_iClientChannelUid == PVR_TIMER_ANY_CHANNEL)) &&
         (bRules == timer->IsTimerRule()) &&
         (!bHideDisabled || (timer->m_state != PVR_TIMER_STATE_DISABLED)))
     {
@@ -556,10 +566,8 @@ bool GetTimersSubDirectory(const CPVRTimersPath& path,
 
   for (const auto& timer : timers)
   {
-    if ((timer->m_bIsRadio == bRadio) &&
-        (timer->m_iParentClientIndex != PVR_TIMER_NO_PARENT) &&
-        (timer->m_iClientId == iClientId) &&
-        (timer->m_iParentClientIndex == iParentId) &&
+    if ((timer->m_bIsRadio == bRadio) && (timer->m_iParentClientIndex != PVR_TIMER_NO_PARENT) &&
+        (timer->m_iClientId == iClientId) && (timer->m_iParentClientIndex == iParentId) &&
         (!bHideDisabled || (timer->m_state != PVR_TIMER_STATE_DISABLED)))
     {
       item.reset(new CFileItem(timer));

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.h
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.h
@@ -104,4 +104,4 @@ private:
   const CURL m_url;
 };
 
-}
+} // namespace PVR

--- a/xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
@@ -214,7 +214,7 @@ bool CPVRGUIActionsRecordings::EditRecording(const CFileItemPtr& item) const
 
   std::shared_ptr<CPVRRecording> origRecording(new CPVRRecording);
   origRecording->Update(*recording,
-                        *CServiceBroker::GetPVRManager().GetClient(recording->m_iClientId));
+                        *CServiceBroker::GetPVRManager().GetClient(recording->ClientID()));
 
   if (!ShowRecordingSettings(recording))
     return false;
@@ -231,7 +231,7 @@ bool CPVRGUIActionsRecordings::EditRecording(const CFileItemPtr& item) const
       CLog::LogF(LOGERROR, "Setting recording playcount failed!");
   }
 
-  if (origRecording->m_iLifetime != recording->m_iLifetime)
+  if (origRecording->LifeTime() != recording->LifeTime())
   {
     if (!AsyncSetRecordingLifetime().Execute(item))
       CLog::LogF(LOGERROR, "Setting recording lifetime failed!");

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -490,7 +490,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
         return true;
       case VIDEOPLAYER_CHANNEL_NAME:
       case LISTITEM_CHANNEL_NAME:
-        strValue = recording->m_strChannelName;
+        strValue = recording->ChannelName();
         if (strValue.empty())
         {
           if (recording->ProviderName().empty())

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -54,22 +54,9 @@ class CPVRRecording final : public CVideoInfoTag
 public:
   static const std::string IMAGE_OWNER_PATTERN;
 
-  int m_iClientId; /*!< ID of the backend */
-  std::string m_strRecordingId; /*!< unique ID of the recording on the client */
-  std::string m_strChannelName; /*!< name of the channel this was recorded from */
-  int m_iPriority; /*!< priority of this recording */
-  int m_iLifetime; /*!< lifetime of this recording */
-  std::string m_strDirectory; /*!< directory of this recording on the client */
-  unsigned m_iRecordingId; /*!< id that won't change while xbmc is running */
-
   CPVRRecording();
   CPVRRecording(const PVR_RECORDING& recording, unsigned int iClientId);
 
-private:
-  CPVRRecording(const CPVRRecording& tag) = delete;
-  CPVRRecording& operator=(const CPVRRecording& other) = delete;
-
-public:
   bool operator==(const CPVRRecording& right) const;
   bool operator!=(const CPVRRecording& right) const;
 
@@ -270,6 +257,54 @@ public:
   int ClientID() const;
 
   /*!
+   * @brief Get the recording ID as upplied by the client
+   * @return the recording identifier
+   */
+  std::string ClientRecordingID() const { return m_strRecordingId; }
+
+  /*!
+   * @brief Get the recording ID as upplied by the client
+   * @return the recording identifier
+   */
+  unsigned int RecordingID() const { return m_iRecordingId; }
+
+  /*!
+   * @brief Set the recording ID
+   * @param recordingId The new identifier
+   */
+  void SetRecordingID(unsigned int recordingId) { m_iRecordingId = recordingId; }
+
+  /*!
+   * @brief Get the directory for this recording
+   * @return the directory
+   */
+  std::string Directory() const { return m_strDirectory; }
+
+  /*!
+   * @brief Get the priority for this recording
+   * @return the priority
+   */
+  int Priority() const { return m_iPriority; }
+
+  /*!
+   * @brief Get the lifetime for this recording
+   * @return the lifetime
+   */
+  int LifeTime() const { return m_iLifetime; }
+
+  /*!
+   * @brief Set the lifetime for this recording
+   * @param lifeTime The lifetime
+   */
+  void SetLifeTime(int lifeTime) { m_iLifetime = lifeTime; }
+
+  /*!
+   * @brief Get the channel name for this recording
+   * @return the channel name
+   */
+  std::string ChannelName() const { return m_strChannelName; }
+
+  /*!
    * @brief Return the icon path as given by the client.
    * @return The path.
    */
@@ -461,7 +496,18 @@ public:
   std::shared_ptr<CPVRProvider> GetProvider() const;
 
 private:
+  CPVRRecording(const CPVRRecording& tag) = delete;
+  CPVRRecording& operator=(const CPVRRecording& other) = delete;
+
   void UpdatePath();
+
+  int m_iClientId; /*!< ID of the backend */
+  std::string m_strRecordingId; /*!< unique ID of the recording on the client */
+  std::string m_strChannelName; /*!< name of the channel this was recorded from */
+  int m_iPriority; /*!< priority of this recording */
+  int m_iLifetime; /*!< lifetime of this recording */
+  std::string m_strDirectory; /*!< directory of this recording on the client */
+  unsigned int m_iRecordingId; /*!< id that won't change while xbmc is running */
 
   CPVRCachedImage m_iconPath; /*!< icon path */
   CPVRCachedImage m_thumbnailPath; /*!< thumbnail path */

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -145,9 +145,8 @@ std::shared_ptr<CPVRRecording> CPVRRecordings::GetById(unsigned int iId) const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   const auto it =
-      std::find_if(m_recordings.cbegin(), m_recordings.cend(), [iId](const auto& recording) {
-        return recording.second->m_iRecordingId == iId;
-      });
+      std::find_if(m_recordings.cbegin(), m_recordings.cend(),
+                   [iId](const auto& recording) { return recording.second->RecordingID() == iId; });
   return it != m_recordings.cend() ? (*it).second : std::shared_ptr<CPVRRecording>();
 }
 
@@ -200,7 +199,7 @@ void CPVRRecordings::UpdateFromClient(const std::shared_ptr<CPVRRecording>& tag,
       m_bDeletedTVRecordings = true;
   }
 
-  std::shared_ptr<CPVRRecording> existingTag = GetById(tag->m_iClientId, tag->m_strRecordingId);
+  std::shared_ptr<CPVRRecording> existingTag = GetById(tag->ClientID(), tag->ClientRecordingID());
   if (existingTag)
   {
     existingTag->Update(*tag, client);
@@ -209,8 +208,8 @@ void CPVRRecordings::UpdateFromClient(const std::shared_ptr<CPVRRecording>& tag,
   else
   {
     tag->UpdateMetadata(GetVideoDatabase(), client);
-    tag->m_iRecordingId = ++m_iLastId;
-    m_recordings.insert({CPVRRecordingUid(tag->m_iClientId, tag->m_strRecordingId), tag});
+    tag->SetRecordingID(++m_iLastId);
+    m_recordings.insert({CPVRRecordingUid(tag->ClientID(), tag->ClientRecordingID()), tag});
     if (tag->IsRadio())
       ++m_iRadioRecordings;
     else

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -175,7 +175,8 @@ std::shared_ptr<CPVRRecording> CPVRRecordings::GetByPath(const std::string& path
   return {};
 }
 
-std::shared_ptr<CPVRRecording> CPVRRecordings::GetById(int iClientId, const std::string& strRecordingId) const
+std::shared_ptr<CPVRRecording> CPVRRecordings::GetById(int iClientId,
+                                                       const std::string& strRecordingId) const
 {
   std::shared_ptr<CPVRRecording> retVal;
   std::unique_lock<CCriticalSection> lock(m_critSection);
@@ -217,7 +218,8 @@ void CPVRRecordings::UpdateFromClient(const std::shared_ptr<CPVRRecording>& tag,
   }
 }
 
-std::shared_ptr<CPVRRecording> CPVRRecordings::GetRecordingForEpgTag(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
+std::shared_ptr<CPVRRecording> CPVRRecordings::GetRecordingForEpgTag(
+    const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
 {
   if (!epgTag)
     return {};
@@ -252,7 +254,8 @@ std::shared_ptr<CPVRRecording> CPVRRecordings::GetRecordingForEpgTag(const std::
   return std::shared_ptr<CPVRRecording>();
 }
 
-bool CPVRRecordings::SetRecordingsPlayCount(const std::shared_ptr<CPVRRecording>& recording, int count)
+bool CPVRRecordings::SetRecordingsPlayCount(const std::shared_ptr<CPVRRecording>& recording,
+                                            int count)
 {
   return ChangeRecordingsPlayCount(recording, count);
 }
@@ -262,7 +265,8 @@ bool CPVRRecordings::IncrementRecordingsPlayCount(const std::shared_ptr<CPVRReco
   return ChangeRecordingsPlayCount(recording, INCREMENT_PLAY_COUNT);
 }
 
-bool CPVRRecordings::ChangeRecordingsPlayCount(const std::shared_ptr<CPVRRecording>& recording, int count)
+bool CPVRRecordings::ChangeRecordingsPlayCount(const std::shared_ptr<CPVRRecording>& recording,
+                                               int count)
 {
   if (recording)
   {

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -19,135 +19,136 @@ class CVideoDatabase;
 
 namespace PVR
 {
-  class CPVRClient;
-  class CPVREpgInfoTag;
-  class CPVRRecording;
-  class CPVRRecordingUid;
-  class CPVRRecordingsPath;
+class CPVRClient;
+class CPVREpgInfoTag;
+class CPVRRecording;
+class CPVRRecordingUid;
+class CPVRRecordingsPath;
 
-  class CPVRRecordings
-  {
-  public:
-    CPVRRecordings();
-    virtual ~CPVRRecordings();
+class CPVRRecordings
+{
+public:
+  CPVRRecordings();
+  virtual ~CPVRRecordings();
 
-    /*!
-     * @brief Update all recordings from the given PVR clients.
-     * @param clients The PVR clients data should be loaded for. Leave empty for all clients.
-     * @return True on success, false otherwise.
-     */
-    bool Update(const std::vector<std::shared_ptr<CPVRClient>>& clients);
+  /*!
+   * @brief Update all recordings from the given PVR clients.
+   * @param clients The PVR clients data should be loaded for. Leave empty for all clients.
+   * @return True on success, false otherwise.
+   */
+  bool Update(const std::vector<std::shared_ptr<CPVRClient>>& clients);
 
-    /*!
-     * @brief unload all recordings.
-     */
-    void Unload();
+  /*!
+   * @brief unload all recordings.
+   */
+  void Unload();
 
-    /*!
-     * @brief Update data with recordings from the given clients, sync with local data.
-     * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
-     * @return True on success, false otherwise.
-     */
-    bool UpdateFromClients(const std::vector<std::shared_ptr<CPVRClient>>& clients);
+  /*!
+   * @brief Update data with recordings from the given clients, sync with local data.
+   * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
+   * @return True on success, false otherwise.
+   */
+  bool UpdateFromClients(const std::vector<std::shared_ptr<CPVRClient>>& clients);
 
-    /*!
-     * @brief client has delivered a new/updated recording.
-     * @param tag The recording
-     * @param client The client the recording belongs to.
-     */
-    void UpdateFromClient(const std::shared_ptr<CPVRRecording>& tag, const CPVRClient& client);
+  /*!
+   * @brief client has delivered a new/updated recording.
+   * @param tag The recording
+   * @param client The client the recording belongs to.
+   */
+  void UpdateFromClient(const std::shared_ptr<CPVRRecording>& tag, const CPVRClient& client);
 
-    /*!
-     * @brief refresh the size of any in progress recordings from the clients.
-     */
-    void UpdateInProgressSize();
+  /*!
+   * @brief refresh the size of any in progress recordings from the clients.
+   */
+  void UpdateInProgressSize();
 
-    int GetNumTVRecordings() const;
-    bool HasDeletedTVRecordings() const;
-    int GetNumRadioRecordings() const;
-    bool HasDeletedRadioRecordings() const;
+  int GetNumTVRecordings() const;
+  bool HasDeletedTVRecordings() const;
+  int GetNumRadioRecordings() const;
+  bool HasDeletedRadioRecordings() const;
 
-    /*!
-     * @brief Set a recording's watched state
-     * @param recording The recording
-     * @param bWatched True to set watched, false to set unwatched state
-     * @return True on success, false otherwise
-     */
-    bool MarkWatched(const std::shared_ptr<CPVRRecording>& recording, bool bWatched);
+  /*!
+   * @brief Set a recording's watched state
+   * @param recording The recording
+   * @param bWatched True to set watched, false to set unwatched state
+   * @return True on success, false otherwise
+   */
+  bool MarkWatched(const std::shared_ptr<CPVRRecording>& recording, bool bWatched);
 
-    /*!
-     * @brief Reset a recording's resume point, if any
-     * @param recording The recording
-     * @return True on success, false otherwise
-     */
-    bool ResetResumePoint(const std::shared_ptr<CPVRRecording>& recording);
+  /*!
+   * @brief Reset a recording's resume point, if any
+   * @param recording The recording
+   * @return True on success, false otherwise
+   */
+  bool ResetResumePoint(const std::shared_ptr<CPVRRecording>& recording);
 
-    /*!
-     * @brief Get a list of all recordings
-     * @return the list of all recordings
-     */
-    std::vector<std::shared_ptr<CPVRRecording>> GetAll() const;
+  /*!
+   * @brief Get a list of all recordings
+   * @return the list of all recordings
+   */
+  std::vector<std::shared_ptr<CPVRRecording>> GetAll() const;
 
-    std::shared_ptr<CPVRRecording> GetByPath(const std::string& path) const;
-    std::shared_ptr<CPVRRecording> GetById(int iClientId, const std::string& strRecordingId) const;
-    std::shared_ptr<CPVRRecording> GetById(unsigned int iId) const;
+  std::shared_ptr<CPVRRecording> GetByPath(const std::string& path) const;
+  std::shared_ptr<CPVRRecording> GetById(int iClientId, const std::string& strRecordingId) const;
+  std::shared_ptr<CPVRRecording> GetById(unsigned int iId) const;
 
-    /*!
-     * @brief Get the recording for the given epg tag, if any.
-     * @param epgTag The epg tag.
-     * @return The requested recording, or an empty recordingptr if none was found.
-     */
-    std::shared_ptr<CPVRRecording> GetRecordingForEpgTag(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
+  /*!
+   * @brief Get the recording for the given epg tag, if any.
+   * @param epgTag The epg tag.
+   * @return The requested recording, or an empty recordingptr if none was found.
+   */
+  std::shared_ptr<CPVRRecording> GetRecordingForEpgTag(
+      const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
 
-    /*!
-     * @brief Erase stale texture db entries and image files.
-     * @return number of cleaned up images.
-     */
-    int CleanupCachedImages();
+  /*!
+   * @brief Erase stale texture db entries and image files.
+   * @return number of cleaned up images.
+   */
+  int CleanupCachedImages();
 
-  private:
-    mutable CCriticalSection m_critSection;
-    bool m_bIsUpdating = false;
-    std::map<CPVRRecordingUid, std::shared_ptr<CPVRRecording>> m_recordings;
-    unsigned int m_iLastId = 0;
-    std::unique_ptr<CVideoDatabase> m_database;
-    bool m_bDeletedTVRecordings = false;
-    bool m_bDeletedRadioRecordings = false;
-    unsigned int m_iTVRecordings = 0;
-    unsigned int m_iRadioRecordings = 0;
+private:
+  /*!
+   * @brief Get/Open the video database.
+   * @return A reference to the video database.
+   */
+  CVideoDatabase& GetVideoDatabase();
 
-    /*!
-     * @brief Get/Open the video database.
-     * @return A reference to the video database.
-     */
-    CVideoDatabase& GetVideoDatabase();
+  /*!
+   * @brief Set a recording's play count
+   * @param recording The recording
+   * @param count The new play count
+   * @return True on success, false otherwise
+   */
+  bool SetRecordingsPlayCount(const std::shared_ptr<CPVRRecording>& recording, int count);
 
-    /*!
-     * @brief Set a recording's play count
-     * @param recording The recording
-     * @param count The new play count
-     * @return True on success, false otherwise
-     */
-    bool SetRecordingsPlayCount(const std::shared_ptr<CPVRRecording>& recording, int count);
+  /*!
+   * @brief Increment a recording's play count
+   * @param recording The recording
+   * @return True on success, false otherwise
+   */
+  bool IncrementRecordingsPlayCount(const std::shared_ptr<CPVRRecording>& recording);
 
-    /*!
-     * @brief Increment a recording's play count
-     * @param recording The recording
-     * @return True on success, false otherwise
-     */
-    bool IncrementRecordingsPlayCount(const std::shared_ptr<CPVRRecording>& recording);
+  /*!
+   * @brief special value for parameter count of method ChangeRecordingsPlayCount
+   */
+  static const int INCREMENT_PLAY_COUNT = -1;
 
-    /*!
-     * @brief special value for parameter count of method ChangeRecordingsPlayCount
-     */
-    static const int INCREMENT_PLAY_COUNT = -1;
+  /*!
+   * @brief change the play count of the given recording
+   * @param recording The recording
+   * @param count The new play count or INCREMENT_PLAY_COUNT to denote that the current play count is to be incremented by one
+   * @return true if the play count was changed successfully
+   */
+  bool ChangeRecordingsPlayCount(const std::shared_ptr<CPVRRecording>& recording, int count);
 
-    /*!
-     * @brief change the play count of the given recording
-     * @param recording The recording
-     * @param count The new play count or INCREMENT_PLAY_COUNT to denote that the current play count is to be incremented by one
-     * @return true if the play count was changed successfully
-     */
-    bool ChangeRecordingsPlayCount(const std::shared_ptr<CPVRRecording>& recording, int count);
-  };
-}
+  mutable CCriticalSection m_critSection;
+  bool m_bIsUpdating = false;
+  std::map<CPVRRecordingUid, std::shared_ptr<CPVRRecording>> m_recordings;
+  unsigned int m_iLastId = 0;
+  std::unique_ptr<CVideoDatabase> m_database;
+  bool m_bDeletedTVRecordings = false;
+  bool m_bDeletedRadioRecordings = false;
+  unsigned int m_iTVRecordings = 0;
+  unsigned int m_iRadioRecordings = 0;
+};
+} // namespace PVR


### PR DESCRIPTION
Get rid of the public members of class `CPVRRecording`. Plus some clang-format commits to ensure clang-conformity of PVR source files while they are touched by PRs.

Runtime-tested on macOS and Android, latest kodi master.

@phunkyfish if you concentrate on the first commit, review should be straight forward.