### PR TITLE
[application] Optimize CApplication::GetComponent call frequency

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -2633,7 +2633,6 @@ void CApplication::StopPlaying()
 
 bool CApplication::OnMessage(CGUIMessage& message)
 {
-  const auto appPlayer = GetComponent<CApplicationPlayer>();
   switch (message.GetMessage())
   {
   case GUI_MSG_NOTIFY_ALL:
@@ -2705,7 +2704,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
     {
 #ifdef TARGET_DARWIN_EMBEDDED
       // @TODO move this away to platform code
-      CDarwinUtils::SetScheduling(appPlayer->IsPlayingVideo());
+      CDarwinUtils::SetScheduling(GetComponent<CApplicationPlayer>()->IsPlayingVideo());
 #endif
       PLAYLIST::CPlayList playList = CServiceBroker::GetPlaylistPlayer().GetPlaylist(
           CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist());
@@ -2745,6 +2744,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
                                                          m_itemCurrentFile, param);
 
       // we don't want a busy dialog when switching channels
+      const auto appPlayer = GetComponent<CApplicationPlayer>();
       if (!m_itemCurrentFile->IsLiveTV() ||
           (!appPlayer->IsPlayingVideo() && !appPlayer->IsPlayingAudio()))
       {
@@ -2768,7 +2768,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
           CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist());
       if (iNext < 0 || iNext >= playlist.size())
       {
-        appPlayer->OnNothingToQueueNotify();
+        GetComponent<CApplicationPlayer>()->OnNothingToQueueNotify();
         return true; // nothing to do
       }
 
@@ -2782,6 +2782,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
       // Don't queue if next media type is different from current one
       bool bNothingToQueue = false;
 
+      const auto appPlayer = GetComponent<CApplicationPlayer>();
       if (!file.IsVideo() && appPlayer->IsPlayingVideo())
         bNothingToQueue = true;
       else if ((!file.IsAudio() || file.IsVideo()) && appPlayer->IsPlayingAudio())
@@ -2863,7 +2864,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
     }
     ResetCurrentItem();
     if (!CServiceBroker::GetPlaylistPlayer().PlayNext(1, true))
-      appPlayer->ClosePlayer();
+      GetComponent<CApplicationPlayer>()->ClosePlayer();
 
     PlaybackCleanup();
 
@@ -2874,7 +2875,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
 
   case GUI_MSG_PLAYLISTPLAYER_STOPPED:
     ResetCurrentItem();
-    if (appPlayer->IsPlaying())
+    if (GetComponent<CApplicationPlayer>()->IsPlaying())
       StopPlaying();
     PlaybackCleanup();
     return true;

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.h
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.h
@@ -18,6 +18,7 @@
 #include <utility>
 #include <vector>
 
+class CApplicationPlayer;
 class CDataCacheCore;
 
 namespace KODI
@@ -57,17 +58,10 @@ public:
   bool ToggleShowInfo();
 
 private:
-  std::unique_ptr<CFileItem> m_currentItem;
-
-  std::atomic_bool m_playerShowTime;
-  std::atomic_bool m_playerShowInfo;
-
   int GetTotalPlayTime() const;
   int GetPlayTime() const;
   int GetPlayTimeRemaining() const;
   float GetSeekPercent() const;
-
-  CEventSource<PlayerShowInfoChangedEvent> m_events;
 
   std::string GetCurrentPlayTime(TIME_FORMAT format) const;
   std::string GetCurrentPlayTimeRemaining(TIME_FORMAT format) const;
@@ -84,6 +78,12 @@ private:
                                                        std::time_t duration) const;
   std::vector<std::pair<float, float>> GetChapters(const CDataCacheCore& data,
                                                    std::time_t duration) const;
+
+  std::unique_ptr<CFileItem> m_currentItem;
+  std::atomic_bool m_playerShowTime{false};
+  std::atomic_bool m_playerShowInfo{false};
+  const std::shared_ptr<CApplicationPlayer> m_appPlayer;
+  CEventSource<PlayerShowInfoChangedEvent> m_events;
 };
 
 } // namespace GUIINFO

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -43,6 +43,11 @@
 using namespace KODI::GUILIB;
 using namespace KODI::GUILIB::GUIINFO;
 
+CVideoGUIInfo::CVideoGUIInfo()
+  : m_appPlayer(CServiceBroker::GetAppComponents().GetComponent<CApplicationPlayer>())
+{
+}
+
 int CVideoGUIInfo::GetPercentPlayed(const CVideoInfoTag* tag) const
 {
   CBookmark bookmark = tag->GetResumePoint();
@@ -58,9 +63,7 @@ bool CVideoGUIInfo::InitCurrentItem(CFileItem *item)
   if (item && item->IsVideo())
   {
     // special case where .strm is used to start an audio stream
-    const auto& components = CServiceBroker::GetAppComponents();
-    const auto appPlayer = components.GetComponent<CApplicationPlayer>();
-    if (item->IsInternetStream() && appPlayer->IsPlayingAudio())
+    if (item->IsInternetStream() && m_appPlayer->IsPlayingAudio())
       return false;
 
     CLog::Log(LOGDEBUG, "CVideoGUIInfo::InitCurrentItem({})", CURL::GetRedacted(item->GetPath()));
@@ -536,10 +539,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
       return true;
       break;
     case VIDEOPLAYER_COVER:
-    {
-      const auto& components = CServiceBroker::GetAppComponents();
-      const auto appPlayer = components.GetComponent<CApplicationPlayer>();
-      if (appPlayer->IsPlayingVideo())
+      if (m_appPlayer->IsPlayingVideo())
       {
         if (fallback)
           *fallback = "DefaultVideoCover.png";
@@ -548,7 +548,6 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         return true;
       }
       break;
-    }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // LISTITEM_*
@@ -718,12 +717,9 @@ bool CVideoGUIInfo::GetInt(int& value, const CGUIListItem *gitem, int contextWin
     // VIDEOPLAYER_*
     ///////////////////////////////////////////////////////////////////////////////////////////////
     case VIDEOPLAYER_AUDIOSTREAMCOUNT:
-    {
-      const auto& components = CServiceBroker::GetAppComponents();
-      const auto appPlayer = components.GetComponent<CApplicationPlayer>();
-      value = appPlayer->GetAudioStreamCount();
+      value = m_appPlayer->GetAudioStreamCount();
       return true;
-    }
+
     default:
       break;
   }
@@ -735,9 +731,6 @@ bool CVideoGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contextW
 {
   if (!gitem->IsFileItem())
     return false;
-
-  const auto& components = CServiceBroker::GetAppComponents();
-  const auto appPlayer = components.GetComponent<CApplicationPlayer>();
 
   const CFileItem *item = static_cast<const CFileItem*>(gitem);
   const CVideoInfoTag* tag = item->GetVideoInfoTag();
@@ -792,16 +785,16 @@ bool CVideoGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contextW
               CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_FULLSCREEN_GAME;
       return true;
     case VIDEOPLAYER_HASMENU:
-      value = appPlayer->GetSupportedMenuType() != MenuType::NONE;
+      value = m_appPlayer->GetSupportedMenuType() != MenuType::NONE;
       return true;
     case VIDEOPLAYER_HASTELETEXT:
-      value = appPlayer->HasTeletextCache();
+      value = m_appPlayer->HasTeletextCache();
       return true;
     case VIDEOPLAYER_HASSUBTITLES:
-      value = appPlayer->GetSubtitleCount() > 0;
+      value = m_appPlayer->GetSubtitleCount() > 0;
       return true;
     case VIDEOPLAYER_SUBTITLESENABLED:
-      value = appPlayer->GetSubtitleVisible();
+      value = m_appPlayer->GetSubtitleVisible();
       return true;
     case VIDEOPLAYER_IS_STEREOSCOPIC:
       value = !CServiceBroker::GetDataCacheCore().GetVideoStereoMode().empty();

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.h
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.h
@@ -10,6 +10,9 @@
 
 #include "guilib/guiinfo/GUIInfoProvider.h"
 
+#include <memory>
+
+class CApplicationPlayer;
 class CVideoInfoTag;
 
 namespace KODI
@@ -24,7 +27,7 @@ class CGUIInfo;
 class CVideoGUIInfo : public CGUIInfoProvider
 {
 public:
-  CVideoGUIInfo() = default;
+  CVideoGUIInfo();
   ~CVideoGUIInfo() override = default;
 
   // KODI::GUILIB::GUIINFO::IGUIInfoProvider implementation
@@ -41,6 +44,8 @@ public:
 private:
   int GetPercentPlayed(const CVideoInfoTag* tag) const;
   bool GetPlaylistInfo(std::string& value, const CGUIInfo& info) const;
+
+  const std::shared_ptr<CApplicationPlayer> m_appPlayer;
 };
 
 } // namespace GUIINFO

--- a/xbmc/input/WindowTranslator.cpp
+++ b/xbmc/input/WindowTranslator.cpp
@@ -288,16 +288,11 @@ CWindowTranslator::WindowMapByID CWindowTranslator::CreateWindowMappingByID()
 
 int CWindowTranslator::GetVirtualWindow(int windowId)
 {
-  const auto& components = CServiceBroker::GetAppComponents();
-  const auto appPlayer = components.GetComponent<CApplicationPlayer>();
   if (windowId == WINDOW_FULLSCREEN_VIDEO)
   {
-    // check if we're in a DVD menu
-    if (appPlayer->IsInMenu())
-      return WINDOW_VIDEO_MENU;
-    // special casing for Live TV
-    else if (g_application.CurrentFileItem().HasPVRChannelInfoTag())
+    if (g_application.CurrentFileItem().HasPVRChannelInfoTag())
     {
+      // special casing for Live TV
       if (CServiceBroker::GetPVRManager()
               .Get<PVR::GUI::Channels>()
               .GetChannelNumberInputHandler()
@@ -311,15 +306,24 @@ int CWindowTranslator::GetVirtualWindow(int windowId)
       else
         return WINDOW_FULLSCREEN_LIVETV;
     }
-    // special casing for numeric seek
-    else if (appPlayer && appPlayer->GetSeekHandler().HasTimeCode())
-      return WINDOW_VIDEO_TIME_SEEK;
+    else
+    {
+      const auto& components = CServiceBroker::GetAppComponents();
+      const auto appPlayer = components.GetComponent<CApplicationPlayer>();
+
+      // check if we're in a DVD menu
+      if (appPlayer->IsInMenu())
+        return WINDOW_VIDEO_MENU;
+      // special casing for numeric seek
+      else if (appPlayer->GetSeekHandler().HasTimeCode())
+        return WINDOW_VIDEO_TIME_SEEK;
+    }
   }
   else if (windowId == WINDOW_VISUALISATION)
   {
-    // special casing for PVR radio
     if (g_application.CurrentFileItem().HasPVRChannelInfoTag())
     {
+      // special casing for PVR radio
       if (CServiceBroker::GetPVRManager()
               .Get<PVR::GUI::Channels>()
               .GetChannelNumberInputHandler()
@@ -333,9 +337,15 @@ int CWindowTranslator::GetVirtualWindow(int windowId)
       else
         return WINDOW_FULLSCREEN_RADIO;
     }
-    // special casing for numeric seek
-    else if (appPlayer && appPlayer->GetSeekHandler().HasTimeCode())
-      return WINDOW_VIDEO_TIME_SEEK;
+    else
+    {
+      const auto& components = CServiceBroker::GetAppComponents();
+      const auto appPlayer = components.GetComponent<CApplicationPlayer>();
+
+      // special casing for numeric seek
+      if (appPlayer->GetSeekHandler().HasTimeCode())
+        return WINDOW_VIDEO_TIME_SEEK;
+    }
   }
 
   return windowId;

--- a/xbmc/storage/DetectDVDType.cpp
+++ b/xbmc/storage/DetectDVDType.cpp
@@ -64,10 +64,11 @@ void CDetectDVDMedia::Process()
     m_cdio->cdio_destroy(p_cdio);
 #endif
 
-  while (( !m_bStop ))
+  const auto& components = CServiceBroker::GetAppComponents();
+  const auto appPlayer = components.GetComponent<CApplicationPlayer>();
+
+  while (!m_bStop)
   {
-    const auto& components = CServiceBroker::GetAppComponents();
-    const auto appPlayer = components.GetComponent<CApplicationPlayer>();
     if (appPlayer->IsPlayingVideo())
     {
       CThread::Sleep(10000ms);
@@ -77,7 +78,7 @@ void CDetectDVDMedia::Process()
       UpdateDvdrom();
       m_bStartup = false;
       CThread::Sleep(2000ms);
-      if ( m_bAutorun )
+      if (m_bAutorun)
       {
         // Media in drive, wait 1.5s more to be sure the device is ready for playback
         CThread::Sleep(1500ms);

--- a/xbmc/windows/GUIWindowHome.cpp
+++ b/xbmc/windows/GUIWindowHome.cpp
@@ -43,16 +43,18 @@ CGUIWindowHome::~CGUIWindowHome(void)
 bool CGUIWindowHome::OnAction(const CAction &action)
 {
   static unsigned int min_hold_time = 1000;
-  const auto& components = CServiceBroker::GetAppComponents();
-  const auto appPlayer = components.GetComponent<CApplicationPlayer>();
-  if (action.GetID() == ACTION_NAV_BACK && action.GetHoldTime() < min_hold_time &&
-      appPlayer->IsPlaying())
+  if (action.GetID() == ACTION_NAV_BACK && action.GetHoldTime() < min_hold_time)
   {
-    CGUIComponent* gui = CServiceBroker::GetGUI();
-    if (gui)
-      gui->GetWindowManager().SwitchToFullScreen();
+    const auto& components = CServiceBroker::GetAppComponents();
+    const auto appPlayer = components.GetComponent<CApplicationPlayer>();
+    if (appPlayer->IsPlaying())
+    {
+      CGUIComponent* gui = CServiceBroker::GetGUI();
+      if (gui)
+        gui->GetWindowManager().SwitchToFullScreen();
 
-    return true;
+      return true;
+    }
   }
   return CGUIWindow::OnAction(action);
 }


### PR DESCRIPTION
Avoid calling `CApplication::GetComponent` in frequently called functions if not really necessary - it is rather expensive (mutex lock + std::unordered_map::find). Example: Skins are requesting Player/Video/... GUI labels/bools/ints "all the time".

Runtime-tested on macOS and Android, latest Kodi master. When Kodi is just sitting on the Estuary Home screen, playing nothing, number of calls to `CApplication::GetComponent`  are significantly reduced compared to same test scenario before this PR.

@notspiff I hope you are fine with this.

