### PR TITLE
changed: avoid AddonManager.h includes in headers

### DIFF
--- a/xbmc/ContextMenuItem.cpp
+++ b/xbmc/ContextMenuItem.cpp
@@ -11,9 +11,9 @@
 #include "FileItem.h"
 #include "GUIInfoManager.h"
 #include "addons/AddonManager.h"
-#include "addons/ContextMenuAddon.h"
 #include "addons/IAddon.h"
 #include "guilib/GUIComponent.h"
+#include "guilib/LocalizeStrings.h"
 #ifdef HAS_PYTHON
 #include "interfaces/generic/ScriptInvocationManager.h"
 #include "interfaces/python/ContextItemAddonInvoker.h"
@@ -21,6 +21,11 @@
 #endif
 #include "ServiceBroker.h"
 #include "utils/StringUtils.h"
+
+std::string CStaticContextMenuAction::GetLabel(const CFileItem& item) const
+{
+  return g_localizeStrings.Get(m_label);
+}
 
 bool CContextMenuItem::IsVisible(const CFileItem& item) const
 {
@@ -42,7 +47,7 @@ bool CContextMenuItem::IsGroup() const
   return !m_groupId.empty();
 }
 
-bool CContextMenuItem::Execute(const CFileItemPtr& item) const
+bool CContextMenuItem::Execute(const std::shared_ptr<CFileItem>& item) const
 {
   if (!item || m_library.empty() || IsGroup())
     return false;

--- a/xbmc/ContextMenuItem.h
+++ b/xbmc/ContextMenuItem.h
@@ -8,16 +8,21 @@
 
 #pragma once
 
-#include "addons/AddonManager.h"
-#include "addons/IAddon.h"
-#include "addons/gui/GUIDialogAddonSettings.h"
-#include "guilib/LocalizeStrings.h"
-
 #include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+class CFileItem;
 
 namespace ADDON
 {
   class CContextMenuAddon;
+}
+
+namespace INFO
+{
+class InfoBool;
 }
 
 class IContextMenuItem
@@ -25,7 +30,7 @@ class IContextMenuItem
 public:
   virtual ~IContextMenuItem() = default;
   virtual bool IsVisible(const CFileItem& item) const = 0;
-  virtual bool Execute(const CFileItemPtr& item) const = 0;
+  virtual bool Execute(const std::shared_ptr<CFileItem>& item) const = 0;
   virtual std::string GetLabel(const CFileItem& item) const = 0;
   virtual bool IsGroup() const { return false; }
 };
@@ -35,10 +40,7 @@ class CStaticContextMenuAction : public IContextMenuItem
 {
 public:
   explicit CStaticContextMenuAction(uint32_t label) : m_label(label) {}
-  std::string GetLabel(const CFileItem& item) const final
-  {
-    return g_localizeStrings.Get(m_label);
-  }
+  std::string GetLabel(const CFileItem& item) const final;
   bool IsGroup() const final { return false; }
 private:
   const uint32_t m_label;
@@ -54,7 +56,7 @@ public:
   bool IsVisible(const CFileItem& item) const override ;
   bool IsParentOf(const CContextMenuItem& menuItem) const;
   bool IsGroup() const override ;
-  bool Execute(const CFileItemPtr& item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override;
   bool operator==(const CContextMenuItem& other) const;
   std::string ToString() const;
 
@@ -83,6 +85,6 @@ private:
   std::vector<std::string> m_args;
 
   std::string m_visibilityCondition;
-  mutable INFO::InfoPtr m_infoBool;
+  mutable std::shared_ptr<INFO::InfoBool> m_infoBool;
   mutable bool m_infoBoolRegistered{false};
 };

--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -14,6 +14,7 @@
 #include "ServiceBroker.h"
 #include "addons/Addon.h"
 #include "addons/AddonEvents.h"
+#include "addons/AddonManager.h"
 #include "addons/ContextMenuAddon.h"
 #include "addons/ContextMenus.h"
 #include "addons/IAddon.h"
@@ -222,7 +223,7 @@ ContextMenuView CContextMenuManager::GetAddonItems(const CFileItem& fileItem, co
   return result;
 }
 
-bool CONTEXTMENU::ShowFor(const CFileItemPtr& fileItem, const CContextMenuItem& root)
+bool CONTEXTMENU::ShowFor(const std::shared_ptr<CFileItem>& fileItem, const CContextMenuItem& root)
 {
   if (!fileItem)
     return false;
@@ -272,7 +273,7 @@ bool CONTEXTMENU::ShowFor(const CFileItemPtr& fileItem, const CContextMenuItem& 
              : menuItems[selected - propertyMenuSize]->Execute(fileItem);
 }
 
-bool CONTEXTMENU::LoopFrom(const IContextMenuItem& menu, const CFileItemPtr& fileItem)
+bool CONTEXTMENU::LoopFrom(const IContextMenuItem& menu, const std::shared_ptr<CFileItem>& fileItem)
 {
   if (!fileItem)
     return false;

--- a/xbmc/ContextMenuManager.h
+++ b/xbmc/ContextMenuManager.h
@@ -9,10 +9,17 @@
 #pragma once
 
 #include "ContextMenuItem.h"
-#include "addons/ContextMenuAddon.h"
+#include "threads/CriticalSection.h"
 
+#include <memory>
 #include <utility>
 #include <vector>
+
+namespace ADDON
+{
+struct AddonEvent;
+class CAddonMgr;
+} // namespace ADDON
 
 namespace PVR
 {
@@ -63,10 +70,11 @@ namespace CONTEXTMENU
   /*!
    * Starts the context menu loop for a file item.
    * */
-  bool ShowFor(const CFileItemPtr& fileItem, const CContextMenuItem& root=CContextMenuManager::MAIN);
+bool ShowFor(const std::shared_ptr<CFileItem>& fileItem,
+             const CContextMenuItem& root = CContextMenuManager::MAIN);
 
-  /*!
+/*!
    * Shortcut for continuing the context menu loop from an existing menu item.
    */
-  bool LoopFrom(const IContextMenuItem& menu, const CFileItemPtr& fileItem);
+bool LoopFrom(const IContextMenuItem& menu, const std::shared_ptr<CFileItem>& fileItem);
 }

--- a/xbmc/ContextMenus.cpp
+++ b/xbmc/ContextMenus.cpp
@@ -12,8 +12,10 @@
 #include "favourites/FavouritesService.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
+#include "guilib/LocalizeStrings.h"
 #include "input/WindowTranslator.h"
 #include "storage/MediaManager.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 
@@ -29,7 +31,7 @@ namespace CONTEXTMENU
 #endif
   }
 
-  bool CEjectDisk::Execute(const CFileItemPtr& item) const
+  bool CEjectDisk::Execute(const std::shared_ptr<CFileItem>& item) const
   {
 #ifdef HAS_DVD_DRIVE
     CServiceBroker::GetMediaManager().ToggleTray(
@@ -44,7 +46,7 @@ namespace CONTEXTMENU
     return item.IsRemovable() && !item.IsDVD() && !item.IsCDDA();
   }
 
-  bool CEjectDrive::Execute(const CFileItemPtr& item) const
+  bool CEjectDrive::Execute(const std::shared_ptr<CFileItem>& item) const
   {
     return CServiceBroker::GetMediaManager().Eject(item->GetPath());
   }
@@ -94,7 +96,7 @@ bool CAddRemoveFavourite::IsVisible(const CFileItem& item) const
          item.GetPath() == "pvr://search/radio/";
 }
 
-bool CAddRemoveFavourite::Execute(const CFileItemPtr& item) const
+bool CAddRemoveFavourite::Execute(const std::shared_ptr<CFileItem>& item) const
 {
   return CServiceBroker::GetFavouritesService().AddOrRemove(*item.get(), GetTargetWindowID(*item));
 }

--- a/xbmc/ContextMenus.h
+++ b/xbmc/ContextMenus.h
@@ -10,6 +10,7 @@
 
 #include "ContextMenuItem.h"
 
+#include <memory>
 
 namespace CONTEXTMENU
 {
@@ -18,14 +19,14 @@ struct CEjectDisk : CStaticContextMenuAction
 {
   CEjectDisk() : CStaticContextMenuAction(13391) {} // Eject/Load CD/DVD!
   bool IsVisible(const CFileItem& item) const override;
-  bool Execute(const CFileItemPtr& item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override;
 };
 
 struct CEjectDrive : CStaticContextMenuAction
 {
   CEjectDrive() : CStaticContextMenuAction(13420) {} // Eject Removable HDD!
   bool IsVisible(const CFileItem& item) const override;
-  bool Execute(const CFileItemPtr& item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override;
 };
 
 struct CAddRemoveFavourite : IContextMenuItem
@@ -33,7 +34,7 @@ struct CAddRemoveFavourite : IContextMenuItem
   CAddRemoveFavourite() = default;
   std::string GetLabel(const CFileItem& item) const override;
   bool IsVisible(const CFileItem& item) const override;
-  bool Execute(const CFileItemPtr& item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override;
 };
 
 }

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -11,6 +11,7 @@
 #include "ContextMenuManager.h"
 #include "DatabaseManager.h"
 #include "PlayListPlayer.h"
+#include "addons/AddonManager.h"
 #include "addons/BinaryAddonCache.h"
 #include "addons/ExtsMimeSupportList.h"
 #include "addons/RepositoryUpdater.h"

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -10,7 +10,6 @@
 
 #include "XBDateTime.h"
 #include "addons/AddonBuilder.h"
-#include "addons/AddonManager.h"
 #include "addons/addoninfo/AddonInfo.h"
 #include "addons/addoninfo/AddonInfoBuilder.h"
 #include "dbwrappers/dataset.h"

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -11,6 +11,7 @@
 #include "AddonDatabase.h"
 #include "AddonUpdateRules.h"
 #include "addons/Addon.h"
+#include "addons/IAddonManagerCallback.h"
 #include "addons/Repository.h"
 #include "addons/addoninfo/AddonType.h"
 #include "threads/CriticalSection.h"
@@ -65,21 +66,6 @@ namespace ADDON
   struct CAddonWithUpdate;
 
   using AddonInfos = std::vector<AddonInfoPtr>;
-
-  /**
-  * Class - IAddonMgrCallback
-  * This callback should be inherited by any class which manages
-  * specific addon types. Could be mostly used for Dll addon types to handle
-  * cleanup before restart/removal
-  */
-  class IAddonMgrCallback
-  {
-    public:
-      virtual ~IAddonMgrCallback() = default;
-      virtual bool RequestRestart(const std::string& addonId,
-                                  AddonInstanceId instanceId,
-                                  bool datachanged) = 0;
-  };
 
   /**
   * Class - CAddonMgr

--- a/xbmc/addons/CMakeLists.txt
+++ b/xbmc/addons/CMakeLists.txt
@@ -53,6 +53,7 @@ set(HEADERS Addon.h
             FontResource.h
             GameResource.h
             IAddon.h
+            IAddonManagerCallback.h
             IAddonSupportCheck.h
             ImageDecoder.h
             ImageResource.h

--- a/xbmc/addons/ContextMenuAddon.cpp
+++ b/xbmc/addons/ContextMenuAddon.cpp
@@ -8,10 +8,9 @@
 
 #include "ContextMenuAddon.h"
 
-#include "AddonManager.h"
 #include "ContextMenuItem.h"
 #include "ContextMenuManager.h"
-#include "ServiceBroker.h"
+#include "guilib/LocalizeStrings.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 

--- a/xbmc/addons/IAddonManagerCallback.h
+++ b/xbmc/addons/IAddonManagerCallback.h
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "addons/IAddon.h"
+
+#include <string>
+
+namespace ADDON
+{
+/**
+  * Class - IAddonMgrCallback
+  * This callback should be inherited by any class which manages
+  * specific addon types. Could be mostly used for Dll addon types to handle
+  * cleanup before restart/removal
+  */
+class IAddonMgrCallback
+{
+public:
+  virtual ~IAddonMgrCallback() = default;
+  virtual bool RequestRestart(const std::string& addonId,
+                              AddonInstanceId instanceId,
+                              bool datachanged) = 0;
+};
+
+} /* namespace ADDON */

--- a/xbmc/addons/ImageResource.cpp
+++ b/xbmc/addons/ImageResource.cpp
@@ -7,9 +7,7 @@
  */
 #include "ImageResource.h"
 
-#include "ServiceBroker.h"
 #include "URL.h"
-#include "addons/AddonManager.h"
 #include "filesystem/File.h"
 #include "filesystem/XbtManager.h"
 #include "utils/StringUtils.h"

--- a/xbmc/addons/PluginSource.cpp
+++ b/xbmc/addons/PluginSource.cpp
@@ -8,8 +8,6 @@
 
 #include "PluginSource.h"
 
-#include "AddonManager.h"
-#include "ServiceBroker.h"
 #include "URL.h"
 #include "addons/addoninfo/AddonInfo.h"
 #include "utils/StringUtils.h"

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -8,7 +8,6 @@
 
 #include "Skin.h"
 
-#include "AddonManager.h"
 #include "FileItem.h"
 #include "ServiceBroker.h"
 #include "Util.h"

--- a/xbmc/addons/Webinterface.cpp
+++ b/xbmc/addons/Webinterface.cpp
@@ -8,8 +8,6 @@
 
 #include "Webinterface.h"
 
-#include "ServiceBroker.h"
-#include "addons/AddonManager.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"

--- a/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
@@ -26,6 +26,7 @@
 #include "filesystem/AddonsDirectory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
+#include "guilib/LocalizeStrings.h"
 #include "input/Key.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "platform/Platform.h"

--- a/xbmc/favourites/ContextMenus.cpp
+++ b/xbmc/favourites/ContextMenus.cpp
@@ -21,7 +21,7 @@ namespace CONTEXTMENU
     return URIUtils::IsProtocol(item.GetPath(), "favourites");
   }
 
-  bool CFavouriteContextMenuAction::Execute(const CFileItemPtr& item) const
+  bool CFavouriteContextMenuAction::Execute(const std::shared_ptr<CFileItem>& item) const
   {
     CFileItemList items;
     CServiceBroker::GetFavouritesService().GetAll(items);
@@ -36,19 +36,21 @@ namespace CONTEXTMENU
     return false;
   }
 
-  bool CRemoveFavourite::DoExecute(CFileItemList &items, const CFileItemPtr& item) const
+  bool CRemoveFavourite::DoExecute(CFileItemList& items,
+                                   const std::shared_ptr<CFileItem>& item) const
   {
     int iBefore = items.Size();
     items.Remove(item.get());
     return items.Size() == iBefore - 1;
   }
 
-  bool CRenameFavourite::DoExecute(CFileItemList&, const CFileItemPtr& item) const
+  bool CRenameFavourite::DoExecute(CFileItemList&, const std::shared_ptr<CFileItem>& item) const
   {
     return CGUIDialogFavourites::ChooseAndSetNewName(item);
   }
 
-  bool CChooseThumbnailForFavourite::DoExecute(CFileItemList&, const CFileItemPtr& item) const
+  bool CChooseThumbnailForFavourite::DoExecute(CFileItemList&,
+                                               const std::shared_ptr<CFileItem>& item) const
   {
     return CGUIDialogFavourites::ChooseAndSetNewThumbnail(item);
   }

--- a/xbmc/favourites/ContextMenus.h
+++ b/xbmc/favourites/ContextMenus.h
@@ -10,6 +10,8 @@
 
 #include "ContextMenuItem.h"
 
+#include <memory>
+
 class CFileItemList;
 
 namespace CONTEXTMENU
@@ -20,10 +22,11 @@ class CFavouriteContextMenuAction : public CStaticContextMenuAction
 public:
   explicit CFavouriteContextMenuAction(uint32_t label) : CStaticContextMenuAction(label) {}
   bool IsVisible(const CFileItem& item) const override;
-  bool Execute(const CFileItemPtr& item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override;
+
 protected:
   ~CFavouriteContextMenuAction() override = default;
-  virtual bool DoExecute(CFileItemList& items, const CFileItemPtr& item) const = 0;
+  virtual bool DoExecute(CFileItemList& items, const std::shared_ptr<CFileItem>& item) const = 0;
 };
 
 class CRemoveFavourite : public CFavouriteContextMenuAction
@@ -31,7 +34,7 @@ class CRemoveFavourite : public CFavouriteContextMenuAction
 public:
   CRemoveFavourite() : CFavouriteContextMenuAction(15015) {} // Remove
 protected:
-  bool DoExecute(CFileItemList& items, const CFileItemPtr& item) const override;
+  bool DoExecute(CFileItemList& items, const std::shared_ptr<CFileItem>& item) const override;
 };
 
 class CRenameFavourite : public CFavouriteContextMenuAction
@@ -39,7 +42,7 @@ class CRenameFavourite : public CFavouriteContextMenuAction
 public:
   CRenameFavourite() : CFavouriteContextMenuAction(118) {} // Rename
 protected:
-  bool DoExecute(CFileItemList& items, const CFileItemPtr& item) const override;
+  bool DoExecute(CFileItemList& items, const std::shared_ptr<CFileItem>& item) const override;
 };
 
 class CChooseThumbnailForFavourite : public CFavouriteContextMenuAction
@@ -47,7 +50,7 @@ class CChooseThumbnailForFavourite : public CFavouriteContextMenuAction
 public:
   CChooseThumbnailForFavourite() : CFavouriteContextMenuAction(20019) {} // Choose thumbnail
 protected:
-  bool DoExecute(CFileItemList& items, const CFileItemPtr& item) const override;
+  bool DoExecute(CFileItemList& items, const std::shared_ptr<CFileItem>& item) const override;
 };
 
 }

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -13,6 +13,7 @@
 #include "URL.h"
 #include "addons/AddonDatabase.h"
 #include "addons/AddonInstaller.h"
+#include "addons/AddonManager.h"
 #include "addons/AddonRepos.h"
 #include "addons/AddonSystemSettings.h"
 #include "addons/PluginSource.h"

--- a/xbmc/filesystem/AddonsDirectory.h
+++ b/xbmc/filesystem/AddonsDirectory.h
@@ -9,12 +9,20 @@
 #pragma once
 
 #include "IDirectory.h"
-#include "addons/AddonManager.h"
+
+#include <memory>
+#include <vector>
 
 class CFileItem;
 class CFileItemList;
 class CURL;
 typedef std::shared_ptr<CFileItem> CFileItemPtr;
+
+namespace ADDON
+{
+class IAddon;
+using VECADDONS = std::vector<std::shared_ptr<IAddon>>;
+} // namespace ADDON
 
 namespace XFILE
 {
@@ -51,7 +59,9 @@ namespace XFILE
                                      const ADDON::VECADDONS& addons,
                                      CFileItemList& items,
                                      const std::string& label);
-    static CFileItemPtr FileItemFromAddon(const ADDON::AddonPtr &addon, const std::string& path, bool folder = false);
+    static CFileItemPtr FileItemFromAddon(const std::shared_ptr<ADDON::IAddon>& addon,
+                                          const std::string& path,
+                                          bool folder = false);
 
     /*! \brief Returns true if `path` is a path or subpath of the repository directory, otherwise false */
     static bool IsRepoDirectory(const CURL& path);

--- a/xbmc/filesystem/DirectoryFactory.cpp
+++ b/xbmc/filesystem/DirectoryFactory.cpp
@@ -80,6 +80,7 @@
 #include "ResourceDirectory.h"
 #include "ServiceBroker.h"
 #include "addons/VFSEntry.h"
+#include "utils/StringUtils.h"
 
 using namespace ADDON;
 

--- a/xbmc/interfaces/builtins/ProfileBuiltins.cpp
+++ b/xbmc/interfaces/builtins/ProfileBuiltins.cpp
@@ -12,7 +12,6 @@
 #include "GUIUserMessages.h"
 #include "ServiceBroker.h"
 #include "Util.h"
-#include "addons/AddonManager.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "favourites/FavouritesService.h"
 #include "guilib/GUIComponent.h"

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -11,6 +11,7 @@
 #include "ContextMenuManager.h"
 #include "FileItem.h"
 #include "ServiceBroker.h"
+#include "addons/AddonManager.h"
 #include "addons/gui/GUIDialogAddonInfo.h"
 #include "favourites/FavouritesService.h"
 #include "filesystem/Directory.h"

--- a/xbmc/music/ContextMenus.cpp
+++ b/xbmc/music/ContextMenus.cpp
@@ -30,7 +30,7 @@ bool CMusicInfo::IsVisible(const CFileItem& item) const
          (m_mediaType == MediaTypeAlbum && item.IsVideoDb() && item.HasProperty("album_musicid"));
 }
 
-bool CMusicInfo::Execute(const CFileItemPtr& item) const
+bool CMusicInfo::Execute(const std::shared_ptr<CFileItem>& item) const
 {
   CGUIDialogMusicInfo::ShowFor(item.get());
   return true;

--- a/xbmc/music/ContextMenus.h
+++ b/xbmc/music/ContextMenus.h
@@ -11,6 +11,8 @@
 #include "ContextMenuItem.h"
 #include "media/MediaType.h"
 
+#include <memory>
+
 namespace CONTEXTMENU
 {
 
@@ -18,7 +20,8 @@ struct CMusicInfo : CStaticContextMenuAction
 {
   explicit CMusicInfo(MediaType mediaType);
   bool IsVisible(const CFileItem& item) const override;
-  bool Execute(const CFileItemPtr& item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override;
+
 private:
   const MediaType m_mediaType;
 };

--- a/xbmc/music/dialogs/GUIDialogInfoProviderSettings.cpp
+++ b/xbmc/music/dialogs/GUIDialogInfoProviderSettings.cpp
@@ -10,6 +10,7 @@
 
 #include "ServiceBroker.h"
 #include "Util.h"
+#include "addons/AddonManager.h"
 #include "addons/AddonSystemSettings.h"
 #include "addons/gui/GUIDialogAddonSettings.h"
 #include "addons/gui/GUIWindowAddonBrowser.h"

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -17,7 +17,6 @@
 #include "ServiceBroker.h"
 #include "TextureCache.h"
 #include "Util.h"
-#include "addons/AddonManager.h"
 #include "addons/AddonSystemSettings.h"
 #include "addons/Scraper.h"
 #include "dialogs/GUIDialogExtendedProgressBar.h"

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -15,7 +15,6 @@
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "Util.h"
-#include "addons/AddonManager.h"
 #include "addons/AddonSystemSettings.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "filesystem/MusicDatabaseDirectory.h"

--- a/xbmc/network/GUIDialogNetworkSetup.cpp
+++ b/xbmc/network/GUIDialogNetworkSetup.cpp
@@ -10,7 +10,6 @@
 
 #include "ServiceBroker.h"
 #include "URL.h"
-#include "addons/AddonManager.h"
 #include "addons/VFSEntry.h"
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "guilib/GUIComponent.h"

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -10,7 +10,6 @@
 
 #include "FileItem.h"
 #include "PeripheralAddonTranslator.h"
-#include "addons/AddonManager.h"
 #include "addons/addoninfo/AddonInfo.h"
 #include "filesystem/Directory.h"
 #include "filesystem/SpecialProtocol.h"

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp
@@ -468,7 +468,8 @@ void CPeripheralBusAddon::UnRegisterAddon(const std::string& addonId)
   }
 }
 
-void CPeripheralBusAddon::PromptEnableAddons(const std::vector<ADDON::AddonInfoPtr>& disabledAddons)
+void CPeripheralBusAddon::PromptEnableAddons(
+    const std::vector<std::shared_ptr<ADDON::CAddonInfo>>& disabledAddons)
 {
   using namespace ADDON;
   using namespace MESSAGING::HELPERS;

--- a/xbmc/peripherals/bus/virtual/PeripheralBusAddon.h
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusAddon.h
@@ -8,13 +8,18 @@
 
 #pragma once
 
-#include "addons/AddonManager.h"
 #include "peripherals/PeripheralTypes.h"
 #include "peripherals/bus/PeripheralBus.h"
 
 #include <memory>
 #include <string>
 #include <vector>
+
+namespace ADDON
+{
+struct AddonEvent;
+class CAddonInfo;
+} // namespace ADDON
 
 namespace PERIPHERALS
 {
@@ -80,7 +85,7 @@ private:
   void OnEvent(const ADDON::AddonEvent& event);
   void UnRegisterAddon(const std::string& addonId);
 
-  void PromptEnableAddons(const std::vector<ADDON::AddonInfoPtr>& disabledAddons);
+  void PromptEnableAddons(const std::vector<std::shared_ptr<ADDON::CAddonInfo>>& disabledAddons);
 
   PeripheralAddonVector m_addons;
   PeripheralAddonVector m_failedAddons;

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -9,6 +9,7 @@
 #include "Peripheral.h"
 
 #include "Util.h"
+#include "XBDateTime.h"
 #include "filesystem/File.h"
 #include "games/controllers/Controller.h"
 #include "guilib/LocalizeStrings.h"

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -10,6 +10,7 @@
 
 #include "ServiceBroker.h"
 #include "addons/AddonEvents.h"
+#include "addons/AddonManager.h"
 #include "addons/addoninfo/AddonInfo.h"
 #include "guilib/LocalizeStrings.h"
 #include "messaging/ApplicationMessenger.h"

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "addons/AddonManager.h"
+#include "addons/IAddonManagerCallback.h"
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_general.h"
 #include "threads/CriticalSection.h"
 
@@ -18,9 +18,12 @@
 #include <string>
 #include <vector>
 
+class CVariant;
+
 namespace ADDON
 {
   struct AddonEvent;
+  class CAddonInfo;
 }
 
 namespace PVR
@@ -413,10 +416,10 @@ struct SBackend
 
     bool GetAddonsWithStatus(
         const std::string& changedAddonId,
-        std::vector<std::pair<ADDON::AddonInfoPtr, bool>>& addonsWithStatus) const;
+        std::vector<std::pair<std::shared_ptr<ADDON::CAddonInfo>, bool>>& addonsWithStatus) const;
 
     std::vector<std::pair<ADDON::AddonInstanceId, bool>> GetInstanceIdsWithStatus(
-        const ADDON::AddonInfoPtr& addon, bool addonIsEnabled) const;
+        const std::shared_ptr<ADDON::CAddonInfo>& addon, bool addonIsEnabled) const;
 
     /*!
      * @brief Get the client instance for a given client id.

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
@@ -9,6 +9,7 @@
 #include "GUIDialogContentSettings.h"
 
 #include "ServiceBroker.h"
+#include "addons/AddonManager.h"
 #include "addons/AddonSystemSettings.h"
 #include "addons/gui/GUIDialogAddonSettings.h"
 #include "addons/gui/GUIWindowAddonBrowser.h"

--- a/xbmc/utils/ScraperParser.cpp
+++ b/xbmc/utils/ScraperParser.cpp
@@ -8,7 +8,6 @@
 
 #include "ScraperParser.h"
 
-#include "addons/AddonManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "RegExp.h"
 #include "HTMLUtil.h"

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -17,6 +17,7 @@
 #include "filesystem/Directory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
+#include "guilib/LocalizeStrings.h"
 #include "playlists/PlayList.h"
 #include "settings/MediaSettings.h"
 #include "utils/URIUtils.h"
@@ -45,7 +46,7 @@ bool CVideoInfo::IsVisible(const CFileItem& item) const
   return item.GetVideoInfoTag()->m_type == m_mediaType;
 }
 
-bool CVideoInfo::Execute(const CFileItemPtr& item) const
+bool CVideoInfo::Execute(const std::shared_ptr<CFileItem>& item) const
 {
   CGUIDialogVideoInfo::ShowFor(*item);
   return true;
@@ -60,7 +61,7 @@ bool CRemoveResumePoint::IsVisible(const CFileItem& itemIn) const
   return CGUIWindowVideoBase::HasResumeItemOffset(&item);
 }
 
-bool CRemoveResumePoint::Execute(const CFileItemPtr& item) const
+bool CRemoveResumePoint::Execute(const std::shared_ptr<CFileItem>& item) const
 {
   CVideoLibraryQueue::GetInstance().ResetResumePoint(item);
   return true;
@@ -86,7 +87,7 @@ bool CMarkWatched::IsVisible(const CFileItem& item) const
   return item.GetVideoInfoTag()->GetPlayCount() == 0;
 }
 
-bool CMarkWatched::Execute(const CFileItemPtr& item) const
+bool CMarkWatched::Execute(const std::shared_ptr<CFileItem>& item) const
 {
   CVideoLibraryQueue::GetInstance().MarkAsWatched(item, true);
   return true;
@@ -112,7 +113,7 @@ bool CMarkUnWatched::IsVisible(const CFileItem& item) const
   return item.GetVideoInfoTag()->GetPlayCount() > 0;
 }
 
-bool CMarkUnWatched::Execute(const CFileItemPtr& item) const
+bool CMarkUnWatched::Execute(const std::shared_ptr<CFileItem>& item) const
 {
   CVideoLibraryQueue::GetInstance().MarkAsWatched(item, false);
   return true;
@@ -293,7 +294,7 @@ void SetPathAndPlay(CFileItem& item)
 
 } // unnamed namespace
 
-bool CResume::Execute(const CFileItemPtr& itemIn) const
+bool CResume::Execute(const std::shared_ptr<CFileItem>& itemIn) const
 {
   CFileItem item(itemIn->GetItemToPlay());
 #ifdef HAS_DVD_DRIVE
@@ -337,7 +338,7 @@ bool CPlay::IsVisible(const CFileItem& itemIn) const
   return item.IsVideo() || item.IsLiveTV() || item.IsDVD() || item.IsCDDA();
 }
 
-bool CPlay::Execute(const CFileItemPtr& itemIn) const
+bool CPlay::Execute(const std::shared_ptr<CFileItem>& itemIn) const
 {
   CFileItem item(itemIn->GetItemToPlay());
 #ifdef HAS_DVD_DRIVE
@@ -359,7 +360,7 @@ bool CQueue::IsVisible(const CFileItem& item) const
   return false; //! @todo implement
 }
 
-bool CQueue::Execute(const CFileItemPtr& item) const
+bool CQueue::Execute(const std::shared_ptr<CFileItem>& item) const
 {
   if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_VIDEO_PLAYLIST)
     return false; // Already queued
@@ -385,7 +386,7 @@ bool CPlayNext::IsVisible(const CFileItem& item) const
   return false; //! @todo implement
 }
 
-bool CPlayNext::Execute(const CFileItemPtr& item) const
+bool CPlayNext::Execute(const std::shared_ptr<CFileItem>& item) const
 {
   if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_VIDEO_PLAYLIST)
     return false; // Already queued
@@ -413,7 +414,7 @@ bool CPlayAndQueue::IsVisible(const CFileItem& item) const
   return false; //! @todo implement
 }
 
-bool CPlayAndQueue::Execute(const CFileItemPtr& item) const
+bool CPlayAndQueue::Execute(const std::shared_ptr<CFileItem>& item) const
 {
   const int windowId = CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow();
   if (windowId == WINDOW_VIDEO_PLAYLIST)

--- a/xbmc/video/ContextMenus.h
+++ b/xbmc/video/ContextMenus.h
@@ -12,6 +12,8 @@
 #include "VideoLibraryQueue.h"
 #include "media/MediaType.h"
 
+#include <memory>
+
 namespace CONTEXTMENU
 {
 
@@ -20,7 +22,8 @@ class CVideoInfo : public CStaticContextMenuAction
 public:
   explicit CVideoInfo(MediaType mediaType);
   bool IsVisible(const CFileItem& item) const override;
-  bool Execute(const CFileItemPtr& item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override;
+
 private:
   const MediaType m_mediaType;
 };
@@ -49,56 +52,56 @@ struct CRemoveResumePoint : CStaticContextMenuAction
 {
   CRemoveResumePoint() : CStaticContextMenuAction(38209) {}
   bool IsVisible(const CFileItem& item) const override;
-  bool Execute(const CFileItemPtr& item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override;
 };
 
 struct CMarkWatched : CStaticContextMenuAction
 {
   CMarkWatched() : CStaticContextMenuAction(16103) {}
   bool IsVisible(const CFileItem& item) const override;
-  bool Execute(const CFileItemPtr& item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override;
 };
 
 struct CMarkUnWatched : CStaticContextMenuAction
 {
   CMarkUnWatched() : CStaticContextMenuAction(16104) {}
   bool IsVisible(const CFileItem& item) const override;
-  bool Execute(const CFileItemPtr& item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override;
 };
 
 struct CResume : IContextMenuItem
 {
   std::string GetLabel(const CFileItem& item) const override;
   bool IsVisible(const CFileItem& item) const override;
-  bool Execute(const CFileItemPtr& _item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& _item) const override;
 };
 
 struct CPlay : IContextMenuItem
 {
   std::string GetLabel(const CFileItem& item) const override;
   bool IsVisible(const CFileItem& item) const override;
-  bool Execute(const CFileItemPtr& _item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& _item) const override;
 };
 
 struct CQueue : CStaticContextMenuAction
 {
   CQueue() : CStaticContextMenuAction(13347) {} // Queue item
   bool IsVisible(const CFileItem& item) const override;
-  bool Execute(const CFileItemPtr& item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override;
 };
 
 struct CPlayNext : CStaticContextMenuAction
 {
   CPlayNext() : CStaticContextMenuAction(10008) {} // Play next
   bool IsVisible(const CFileItem& item) const override;
-  bool Execute(const CFileItemPtr& item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override;
 };
 
 struct CPlayAndQueue : CStaticContextMenuAction
 {
   CPlayAndQueue() : CStaticContextMenuAction(13412) {} // Play from here
   bool IsVisible(const CFileItem& item) const override;
-  bool Execute(const CFileItemPtr& item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override;
 };
 
 }


### PR DESCRIPTION
and remove unnecessary includes

## Description
Reduce hotness of AddonManager.h
Before: 134 files rebuilt
After: 84 files rebuilt

## Motivation and context
Less rebuilds

## How has this been tested?
It builds

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
