### PR TITLE
[PVR] CPVRTimersPath: Fix definitions for radio timers path and tv timer rules path constants

### DIFF
--- a/xbmc/pvr/timers/PVRTimersPath.cpp
+++ b/xbmc/pvr/timers/PVRTimersPath.cpp
@@ -20,8 +20,8 @@ using namespace PVR;
 const std::string CPVRTimersPath::PATH_ADDTIMER = "pvr://timers/addtimer/";
 const std::string CPVRTimersPath::PATH_NEW = "pvr://timers/new/";
 const std::string CPVRTimersPath::PATH_TV_TIMERS = "pvr://timers/tv/timers/";
-const std::string CPVRTimersPath::PATH_TV_TIMER_RULES = "pvr://timers/radio/timers/";
-const std::string CPVRTimersPath::PATH_RADIO_TIMERS = "pvr://timers/tv/rules/";
+const std::string CPVRTimersPath::PATH_RADIO_TIMERS = "pvr://timers/radio/timers/";
+const std::string CPVRTimersPath::PATH_TV_TIMER_RULES = "pvr://timers/tv/rules/";
 const std::string CPVRTimersPath::PATH_RADIO_TIMER_RULES = "pvr://timers/radio/rules/";
 
 CPVRTimersPath::CPVRTimersPath(const std::string& strPath)

--- a/xbmc/pvr/timers/PVRTimersPath.cpp
+++ b/xbmc/pvr/timers/PVRTimersPath.cpp
@@ -60,10 +60,9 @@ bool CPVRTimersPath::Init(const std::string& strPath)
   m_path = strVarPath;
   const std::vector<std::string> segments = URIUtils::SplitPath(m_path);
 
-  m_bValid = (((segments.size() == 4) || (segments.size() == 6)) &&
-                (segments.at(1) == "timers") &&
-                ((segments.at(2) == "radio") || (segments.at(2) == "tv")) &&
-                ((segments.at(3) == "rules") || (segments.at(3) == "timers")));
+  m_bValid = (((segments.size() == 4) || (segments.size() == 6)) && (segments.at(1) == "timers") &&
+              ((segments.at(2) == "radio") || (segments.at(2) == "tv")) &&
+              ((segments.at(3) == "rules") || (segments.at(3) == "timers")));
   m_bRoot = (m_bValid && (segments.size() == 4));
   m_bRadio = (m_bValid && (segments.at(2) == "radio"));
   m_bTimerRules = (m_bValid && (segments.at(3) == "rules"));

--- a/xbmc/pvr/timers/PVRTimersPath.h
+++ b/xbmc/pvr/timers/PVRTimersPath.h
@@ -12,39 +12,39 @@
 
 namespace PVR
 {
-  class CPVRTimersPath
-  {
-  public:
-    static const std::string PATH_ADDTIMER;
-    static const std::string PATH_NEW;
-    static const std::string PATH_TV_TIMERS;
-    static const std::string PATH_TV_TIMER_RULES;
-    static const std::string PATH_RADIO_TIMERS;
-    static const std::string PATH_RADIO_TIMER_RULES;
+class CPVRTimersPath
+{
+public:
+  static const std::string PATH_ADDTIMER;
+  static const std::string PATH_NEW;
+  static const std::string PATH_TV_TIMERS;
+  static const std::string PATH_TV_TIMER_RULES;
+  static const std::string PATH_RADIO_TIMERS;
+  static const std::string PATH_RADIO_TIMER_RULES;
 
-    explicit CPVRTimersPath(const std::string& strPath);
-    CPVRTimersPath(const std::string& strPath, int iClientId, int iParentId);
-    CPVRTimersPath(bool bRadio, bool bTimerRules);
+  explicit CPVRTimersPath(const std::string& strPath);
+  CPVRTimersPath(const std::string& strPath, int iClientId, int iParentId);
+  CPVRTimersPath(bool bRadio, bool bTimerRules);
 
-    bool IsValid() const { return m_bValid; }
+  bool IsValid() const { return m_bValid; }
 
-    const std::string& GetPath() const { return m_path; }
-    bool IsTimersRoot() const { return m_bRoot; }
-    bool IsTimerRule() const { return !IsTimersRoot(); }
-    bool IsRadio() const { return m_bRadio; }
-    bool IsRules() const { return m_bTimerRules; }
-    int GetClientId() const { return m_iClientId; }
-    int GetParentId() const { return m_iParentId; }
+  const std::string& GetPath() const { return m_path; }
+  bool IsTimersRoot() const { return m_bRoot; }
+  bool IsTimerRule() const { return !IsTimersRoot(); }
+  bool IsRadio() const { return m_bRadio; }
+  bool IsRules() const { return m_bTimerRules; }
+  int GetClientId() const { return m_iClientId; }
+  int GetParentId() const { return m_iParentId; }
 
-  private:
-    bool Init(const std::string& strPath);
+private:
+  bool Init(const std::string& strPath);
 
-    std::string m_path;
-    bool m_bValid = false;
-    bool m_bRoot = false;
-    bool m_bRadio = false;
-    bool m_bTimerRules = false;
-    int m_iClientId = -1;
-    int m_iParentId = 0;
-  };
-}
+  std::string m_path;
+  bool m_bValid = false;
+  bool m_bRoot = false;
+  bool m_bRadio = false;
+  bool m_bTimerRules = false;
+  int m_iClientId = -1;
+  int m_iParentId = 0;
+};
+} // namespace PVR


### PR DESCRIPTION
Stupid c/p error I guess: PATH_RADIO_TIMERS and PATH_TV_TIMER_RULES definitions were swapped.

Runtime-tested on macOS and Android, works as designed now.

@phunkyfish another no-brainer, plus one clang-format commit.