### PR TITLE
[PVR] Fix PVR windows handling for action "back".

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -225,22 +225,6 @@ bool CGUIWindowPVRBase::OnAction(const CAction& action)
   return CGUIMediaWindow::OnAction(action);
 }
 
-bool CGUIWindowPVRBase::OnBack(int actionID)
-{
-  if (actionID == ACTION_NAV_BACK)
-  {
-    // don't call CGUIMediaWindow as it will attempt to go to the parent folder which we don't want.
-    if (GetPreviousWindow() != WINDOW_FULLSCREEN_VIDEO)
-    {
-      CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_HOME);
-      return true;
-    }
-    else
-      return CGUIWindow::OnBack(actionID);
-  }
-  return CGUIMediaWindow::OnBack(actionID);
-}
-
 bool CGUIWindowPVRBase::ActivatePreviousChannelGroup()
 {
   const std::shared_ptr<CPVRChannelGroup> channelGroup = GetChannelGroup();

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -62,7 +62,6 @@ namespace PVR
     bool Update(const std::string& strDirectory, bool updateFilterPath = true) override;
     void UpdateButtons() override;
     bool OnAction(const CAction& action) override;
-    bool OnBack(int actionID) override;
     void SetInvalid() override;
     bool CanBeActivated() const override;
 

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -57,6 +57,18 @@ CGUIWindowPVRChannelsBase::~CGUIWindowPVRChannelsBase()
       this);
 }
 
+std::string CGUIWindowPVRChannelsBase::GetRootPath() const
+{
+  //! @todo Would it make sense to change GetRootPath() declaration in CGUIMediaWindow
+  //! to be non-const to get rid of the const_cast's here?
+
+  CGUIWindowPVRChannelsBase* pThis = const_cast<CGUIWindowPVRChannelsBase*>(this);
+  if (pThis->InitChannelGroup())
+    return pThis->GetDirectoryPath();
+
+  return CGUIWindowPVRBase::GetRootPath();
+}
+
 void CGUIWindowPVRChannelsBase::GetContextButtons(int itemNumber, CContextButtons& buttons)
 {
   // Add parent buttons before the Manage button

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.h
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.h
@@ -22,6 +22,7 @@ public:
   CGUIWindowPVRChannelsBase(bool bRadio, int id, const std::string& xmlFile);
   ~CGUIWindowPVRChannelsBase() override;
 
+  std::string GetRootPath() const override;
   bool OnMessage(CGUIMessage& message) override;
   void GetContextButtons(int itemNumber, CContextButtons& buttons) override;
   bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -959,3 +959,13 @@ void CPVRRefreshTimelineItemsThread::Process()
   m_ready.Reset();
   m_done.Set();
 }
+
+std::string CGUIWindowPVRTVGuide::GetRootPath() const
+{
+  return "pvr://guide/tv/";
+}
+
+std::string CGUIWindowPVRRadioGuide::GetRootPath() const
+{
+  return "pvr://guide/radio/";
+}

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -100,12 +100,14 @@ class CGUIWindowPVRTVGuide : public CGUIWindowPVRGuideBase
 {
 public:
   CGUIWindowPVRTVGuide() : CGUIWindowPVRGuideBase(false, WINDOW_TV_GUIDE, "MyPVRGuide.xml") {}
+  std::string GetRootPath() const override;
 };
 
 class CGUIWindowPVRRadioGuide : public CGUIWindowPVRGuideBase
 {
 public:
   CGUIWindowPVRRadioGuide() : CGUIWindowPVRGuideBase(true, WINDOW_RADIO_GUIDE, "MyPVRGuide.xml") {}
+  std::string GetRootPath() const override;
 };
 
 class CPVRRefreshTimelineItemsThread : public CThread

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -36,13 +36,12 @@
 
 using namespace PVR;
 
-CGUIWindowPVRRecordingsBase::CGUIWindowPVRRecordingsBase(bool bRadio, int id, const std::string& xmlFile) :
-  CGUIWindowPVRBase(bRadio, id, xmlFile),
-  m_bShowDeletedRecordings(false),
-  m_settings({
-    CSettings::SETTING_PVRRECORD_GROUPRECORDINGS,
-    CSettings::SETTING_MYVIDEOS_SELECTACTION
-  })
+CGUIWindowPVRRecordingsBase::CGUIWindowPVRRecordingsBase(bool bRadio,
+                                                         int id,
+                                                         const std::string& xmlFile)
+  : CGUIWindowPVRBase(bRadio, id, xmlFile),
+    m_settings(
+        {CSettings::SETTING_PVRRECORD_GROUPRECORDINGS, CSettings::SETTING_MYVIDEOS_SELECTACTION})
 {
 }
 
@@ -411,4 +410,14 @@ bool CGUIWindowPVRRecordingsBase::GetFilteredItems(const std::string& filter, CF
     items.Remove(0);
 
   return listchanged;
+}
+
+std::string CGUIWindowPVRTVRecordings::GetRootPath() const
+{
+  return CPVRRecordingsPath(m_bShowDeletedRecordings, false);
+}
+
+std::string CGUIWindowPVRRadioRecordings::GetRootPath() const
+{
+  return CPVRRecordingsPath(m_bShowDeletedRecordings, true);
 }

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.h
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.h
@@ -39,12 +39,13 @@ namespace PVR
     void OnPrepareFileItems(CFileItemList& items) override;
     bool GetFilteredItems(const std::string& filter, CFileItemList& items) override;
 
+    bool m_bShowDeletedRecordings{false};
+
   private:
     bool OnContextButtonDeleteAll(CFileItem* item, CONTEXT_BUTTON button);
 
     CVideoThumbLoader m_thumbLoader;
     CVideoDatabase m_database;
-    bool m_bShowDeletedRecordings;
     CPVRSettings m_settings;
   };
 
@@ -52,11 +53,13 @@ namespace PVR
   {
   public:
     CGUIWindowPVRTVRecordings() : CGUIWindowPVRRecordingsBase(false, WINDOW_TV_RECORDINGS, "MyPVRRecordings.xml") {}
+    std::string GetRootPath() const override;
   };
 
   class CGUIWindowPVRRadioRecordings : public CGUIWindowPVRRecordingsBase
   {
   public:
     CGUIWindowPVRRadioRecordings() : CGUIWindowPVRRecordingsBase(true, WINDOW_RADIO_RECORDINGS, "MyPVRRecordings.xml") {}
+    std::string GetRootPath() const override;
   };
 }

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -507,6 +507,11 @@ void CGUIWindowPVRSearchBase::SetSearchFilter(
   m_searchfilter = searchFilter;
 }
 
+std::string CGUIWindowPVRTVSearch::GetRootPath() const
+{
+  return CPVREpgSearchPath::PATH_TV_SEARCH;
+}
+
 std::string CGUIWindowPVRTVSearch::GetStartFolder(const std::string& dir)
 {
   return CPVREpgSearchPath::PATH_TV_SEARCH;
@@ -517,6 +522,11 @@ std::string CGUIWindowPVRTVSearch::GetDirectoryPath()
   return URIUtils::PathHasParent(m_vecItems->GetPath(), CPVREpgSearchPath::PATH_TV_SEARCH)
              ? m_vecItems->GetPath()
              : CPVREpgSearchPath::PATH_TV_SEARCH;
+}
+
+std::string CGUIWindowPVRRadioSearch::GetRootPath() const
+{
+  return CPVREpgSearchPath::PATH_RADIO_SEARCH;
 }
 
 std::string CGUIWindowPVRRadioSearch::GetStartFolder(const std::string& dir)

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.h
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.h
@@ -70,6 +70,7 @@ namespace PVR
     CGUIWindowPVRTVSearch() : CGUIWindowPVRSearchBase(false, WINDOW_TV_SEARCH, "MyPVRSearch.xml") {}
 
   protected:
+    std::string GetRootPath() const override;
     std::string GetStartFolder(const std::string& dir) override;
     std::string GetDirectoryPath() override;
   };
@@ -80,6 +81,7 @@ namespace PVR
     CGUIWindowPVRRadioSearch() : CGUIWindowPVRSearchBase(true, WINDOW_RADIO_SEARCH, "MyPVRSearch.xml") {}
 
   protected:
+    std::string GetRootPath() const override;
     std::string GetStartFolder(const std::string& dir) override;
     std::string GetDirectoryPath() override;
   };

--- a/xbmc/pvr/windows/GUIWindowPVRTimerRules.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimerRules.cpp
@@ -19,6 +19,11 @@ CGUIWindowPVRTVTimerRules::CGUIWindowPVRTVTimerRules()
 {
 }
 
+std::string CGUIWindowPVRTVTimerRules::GetRootPath() const
+{
+  return CPVRTimersPath::PATH_TV_TIMER_RULES;
+}
+
 std::string CGUIWindowPVRTVTimerRules::GetDirectoryPath()
 {
   const std::string basePath(CPVRTimersPath(false, true).GetPath());
@@ -28,6 +33,11 @@ std::string CGUIWindowPVRTVTimerRules::GetDirectoryPath()
 CGUIWindowPVRRadioTimerRules::CGUIWindowPVRRadioTimerRules()
 : CGUIWindowPVRTimersBase(true, WINDOW_RADIO_TIMER_RULES, "MyPVRTimers.xml")
 {
+}
+
+std::string CGUIWindowPVRRadioTimerRules::GetRootPath() const
+{
+  return CPVRTimersPath::PATH_RADIO_TIMER_RULES;
 }
 
 std::string CGUIWindowPVRRadioTimerRules::GetDirectoryPath()

--- a/xbmc/pvr/windows/GUIWindowPVRTimerRules.h
+++ b/xbmc/pvr/windows/GUIWindowPVRTimerRules.h
@@ -21,6 +21,7 @@ namespace PVR
     ~CGUIWindowPVRTVTimerRules() override = default;
 
   protected:
+    std::string GetRootPath() const override;
     std::string GetDirectoryPath() override;
   };
 
@@ -31,6 +32,7 @@ namespace PVR
     ~CGUIWindowPVRRadioTimerRules() override = default;
 
   protected:
+    std::string GetRootPath() const override;
     std::string GetDirectoryPath() override;
   };
 }

--- a/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.cpp
@@ -19,6 +19,11 @@ CGUIWindowPVRTVTimers::CGUIWindowPVRTVTimers()
 {
 }
 
+std::string CGUIWindowPVRTVTimers::GetRootPath() const
+{
+  return CPVRTimersPath::PATH_TV_TIMERS;
+}
+
 std::string CGUIWindowPVRTVTimers::GetDirectoryPath()
 {
   const std::string basePath(CPVRTimersPath(false, false).GetPath());
@@ -28,6 +33,11 @@ std::string CGUIWindowPVRTVTimers::GetDirectoryPath()
 CGUIWindowPVRRadioTimers::CGUIWindowPVRRadioTimers()
 : CGUIWindowPVRTimersBase(true, WINDOW_RADIO_TIMERS, "MyPVRTimers.xml")
 {
+}
+
+std::string CGUIWindowPVRRadioTimers::GetRootPath() const
+{
+  return CPVRTimersPath::PATH_RADIO_TIMERS;
 }
 
 std::string CGUIWindowPVRRadioTimers::GetDirectoryPath()

--- a/xbmc/pvr/windows/GUIWindowPVRTimers.h
+++ b/xbmc/pvr/windows/GUIWindowPVRTimers.h
@@ -20,6 +20,7 @@ namespace PVR
     CGUIWindowPVRTVTimers();
 
   protected:
+    std::string GetRootPath() const override;
     std::string GetDirectoryPath() override;
   };
 
@@ -29,6 +30,7 @@ namespace PVR
     CGUIWindowPVRRadioTimers();
 
   protected:
+    std::string GetRootPath() const override;
     std::string GetDirectoryPath() override;
   };
 }


### PR DESCRIPTION
As discussed on Slack, special handling of PVR windows for action "back" is buggy and not in sync with the window handling (history) of the rest of Kodi. This PR aligns PVR handling for action "back" with the UX of the rest of the Kodi windows.

One of the bugs fixed:
* Go to LiveTV in the main menu (Estuary Home screen)
* This brings up the guide window
* Press "left" to get to the side menu
* Chose the "channels" icon
* This brings me to the channels window
* Now press back => you end in the main menu (Estuary Home screen), not in the guide window

Runtime-tested on macOS and Android, latest Kodi master.

@a1rwulf, @phunkyfish  for code review?