### PR TITLE
AddonInstaller: Add missing log when install from zip fails

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -423,6 +423,11 @@ bool CAddonInstaller::InstallFromZip(const std::string &path)
       eventLog->AddWithNotification(EventPtr(
           new CNotificationEvent(24045, StringUtils::Format(g_localizeStrings.Get(24143), path),
                                  "special://xbmc/media/icon256x256.png", EventLevel::Error)));
+
+    CLog::Log(
+        LOGERROR,
+        "CAddonInstaller: installing addon failed '{}' - itemsize: {}, first item is folder: {}",
+        CURL::GetRedacted(path), items.Size(), items[0]->m_bIsFolder);
     return false;
   }
 


### PR DESCRIPTION
## Description
Log if addon zip file is in wrong format and installation fails because of that.

## Motivation and context
I was debugging such a case with a GSOC student at devcon and found that this special case is not logged at all.

## How has this been tested?
Install an addon with wrong zip format.
Now gives:
```
2022-10-11 15:29:57.949 T:21193   error <general>: CAddonInstaller: installing addon failed '/home/a1rwulf/Downloads/addon-broken.zip' - itemsize: 3, first item is folder: true
```

## What is the effect on users?
A way to figure out fast when an addon installation fails due to zip layout being wrong.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
