### PR TITLE
[PVR] Cleanup: Move data conversion functionality from CPVRClient to the respective classes

### DIFF
--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -289,20 +289,6 @@ int CPVRClient::GetID() const
 }
 
 /*!
- * @brief Copy over group info from xbmcGroup to addonGroup.
- * @param xbmcGroup The group on XBMC's side.
- * @param addonGroup The group on the addon's side.
- */
-void CPVRClient::WriteClientGroupInfo(const CPVRChannelGroup& xbmcGroup,
-                                      PVR_CHANNEL_GROUP& addonGroup)
-{
-  addonGroup = {};
-  addonGroup.bIsRadio = xbmcGroup.IsRadio();
-  strncpy(addonGroup.strGroupName, xbmcGroup.GroupName().c_str(),
-          sizeof(addonGroup.strGroupName) - 1);
-}
-
-/*!
  * @brief Copy over timer info from xbmcTimer to addonTimer.
  * @param xbmcTimer The timer on XBMC's side.
  * @param addonTimer The timer on the addon's side.
@@ -878,7 +864,7 @@ PVR_ERROR CPVRClient::GetChannelGroupMembers(
                        handle.dataAddress = &groupMembers;
 
                        PVR_CHANNEL_GROUP tag;
-                       WriteClientGroupInfo(*group, tag);
+                       group->FillAddonData(tag);
                        return addon->toAddon->GetChannelGroupMembers(addon, &handle, &tag);
                      },
                      m_clientCapabilities.SupportsChannelGroups());

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -809,14 +809,6 @@ private:
                                    PVR_CHANNEL_GROUP& addonGroup);
 
   /*!
-   * @brief Copy over recording info from xbmcRecording to addonRecording.
-   * @param xbmcRecording The recording on XBMC's side.
-   * @param addonRecording The recording on the addon's side.
-   */
-  static void WriteClientRecordingInfo(const CPVRRecording& xbmcRecording,
-                                       PVR_RECORDING& addonRecording);
-
-  /*!
    * @brief Copy over timer info from xbmcTimer to addonTimer.
    * @param xbmcTimer The timer on XBMC's side.
    * @param addonTimer The timer on the addon's side.

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -801,13 +801,6 @@ private:
   bool GetAddonProperties();
 
   /*!
-   * @brief Copy over timer info from xbmcTimer to addonTimer.
-   * @param xbmcTimer The timer on XBMC's side.
-   * @param addonTimer The timer on the addon's side.
-   */
-  static void WriteClientTimerInfo(const CPVRTimerInfoTag& xbmcTimer, PVR_TIMER& addonTimer);
-
-  /*!
    * @brief Copy over channel info from xbmcChannel to addonClient.
    * @param xbmcChannel The channel on XBMC's side.
    * @param addonChannel The channel on the addon's side.

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -801,14 +801,6 @@ private:
   bool GetAddonProperties();
 
   /*!
-   * @brief Copy over channel info from xbmcChannel to addonClient.
-   * @param xbmcChannel The channel on XBMC's side.
-   * @param addonChannel The channel on the addon's side.
-   */
-  static void WriteClientChannelInfo(const std::shared_ptr<CPVRChannel>& xbmcChannel,
-                                     PVR_CHANNEL& addonChannel);
-
-  /*!
    * @brief Write the given addon properties to the given properties container.
    * @param properties Pointer to an array of addon properties.
    * @param iPropertyCount The number of properties contained in the addon properties array.

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -801,14 +801,6 @@ private:
   bool GetAddonProperties();
 
   /*!
-   * @brief Copy over group info from xbmcGroup to addonGroup.
-   * @param xbmcGroup The group on XBMC's side.
-   * @param addonGroup The group on the addon's side.
-   */
-  static void WriteClientGroupInfo(const CPVRChannelGroup& xbmcGroup,
-                                   PVR_CHANNEL_GROUP& addonGroup);
-
-  /*!
    * @brief Copy over timer info from xbmcTimer to addonTimer.
    * @param xbmcTimer The timer on XBMC's side.
    * @param addonTimer The timer on the addon's side.

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -83,6 +83,22 @@ CPVRChannel::~CPVRChannel()
   ResetEPG();
 }
 
+void CPVRChannel::FillAddonData(PVR_CHANNEL& channel) const
+{
+  channel = {};
+  channel.iUniqueId = UniqueID();
+  channel.iChannelNumber = ClientChannelNumber().GetChannelNumber();
+  channel.iSubChannelNumber = ClientChannelNumber().GetSubChannelNumber();
+  strncpy(channel.strChannelName, ClientChannelName().c_str(), sizeof(channel.strChannelName) - 1);
+  strncpy(channel.strIconPath, ClientIconPath().c_str(), sizeof(channel.strIconPath) - 1);
+  channel.iEncryptionSystem = EncryptionSystem();
+  channel.bIsRadio = IsRadio();
+  channel.bIsHidden = IsHidden();
+  strncpy(channel.strMimeType, MimeType().c_str(), sizeof(channel.strMimeType) - 1);
+  channel.iClientProviderUid = ClientProviderUid();
+  channel.bHasArchive = HasArchive();
+}
+
 void CPVRChannel::Serialize(CVariant& value) const
 {
   value["channelid"] = m_iChannelId;

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -48,6 +48,12 @@ public:
   bool operator==(const CPVRChannel& right) const;
   bool operator!=(const CPVRChannel& right) const;
 
+  /*!
+   * @brief Copy over data to the given PVR_CHANNEL instance.
+   * @param channel The channel instance to fill.
+   */
+  void FillAddonData(PVR_CHANNEL& channel) const;
+
   void Serialize(CVariant& value) const override;
 
   /*! @name Kodi related channel methods

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -71,6 +71,14 @@ bool CPVRChannelGroup::operator!=(const CPVRChannelGroup& right) const
   return !(*this == right);
 }
 
+void CPVRChannelGroup::FillAddonData(PVR_CHANNEL_GROUP& group) const
+{
+  group = {};
+  group.bIsRadio = IsRadio();
+  strncpy(group.strGroupName, GroupName().c_str(), sizeof(group.strGroupName) - 1);
+  group.iPosition = GetPosition();
+}
+
 CCriticalSection CPVRChannelGroup::m_settingsSingletonCritSection;
 std::weak_ptr<CPVRChannelGroupSettings> CPVRChannelGroup::m_settingsSingleton;
 

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -46,9 +46,9 @@ CPVRChannelGroup::CPVRChannelGroup(const CPVRChannelsPath& path,
 
 CPVRChannelGroup::CPVRChannelGroup(const PVR_CHANNEL_GROUP& group,
                                    const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup)
-  : m_iPosition(group.iPosition)
-  , m_allChannelsGroup(allChannelsGroup)
-  , m_path(group.bIsRadio, group.strGroupName)
+  : m_iPosition(group.iPosition),
+    m_allChannelsGroup(allChannelsGroup),
+    m_path(group.bIsRadio, group.strGroupName)
 {
   GetSettings()->RegisterCallback(this);
 }
@@ -60,10 +60,8 @@ CPVRChannelGroup::~CPVRChannelGroup()
 
 bool CPVRChannelGroup::operator==(const CPVRChannelGroup& right) const
 {
-  return (m_iGroupType == right.m_iGroupType &&
-          m_iGroupId == right.m_iGroupId &&
-          m_iPosition == right.m_iPosition &&
-          m_path == right.m_path);
+  return (m_iGroupType == right.m_iGroupType && m_iGroupId == right.m_iGroupId &&
+          m_iPosition == right.m_iPosition && m_path == right.m_path);
 }
 
 bool CPVRChannelGroup::operator!=(const CPVRChannelGroup& right) const
@@ -170,7 +168,8 @@ void CPVRChannelGroup::SetPath(const CPVRChannelsPath& path)
   }
 }
 
-bool CPVRChannelGroup::SetChannelNumber(const std::shared_ptr<CPVRChannel>& channel, const CPVRChannelNumber& channelNumber)
+bool CPVRChannelGroup::SetChannelNumber(const std::shared_ptr<CPVRChannel>& channel,
+                                        const CPVRChannelNumber& channelNumber)
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   const auto it =
@@ -282,7 +281,8 @@ std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroup::GetByUniqueID(
   return it != m_members.end() ? it->second : std::shared_ptr<CPVRChannelGroupMember>();
 }
 
-std::shared_ptr<CPVRChannel> CPVRChannelGroup::GetByUniqueID(int iUniqueChannelId, int iClientID) const
+std::shared_ptr<CPVRChannel> CPVRChannelGroup::GetByUniqueID(int iUniqueChannelId,
+                                                             int iClientID) const
 {
   const std::shared_ptr<CPVRChannelGroupMember> groupMember =
       GetByUniqueID(std::make_pair(iClientID, iUniqueChannelId));
@@ -345,14 +345,16 @@ GroupMemberPair CPVRChannelGroup::GetLastAndPreviousToLastPlayedChannelGroupMemb
   return {last, previousToLast};
 }
 
-CPVRChannelNumber CPVRChannelGroup::GetChannelNumber(const std::shared_ptr<CPVRChannel>& channel) const
+CPVRChannelNumber CPVRChannelGroup::GetChannelNumber(
+    const std::shared_ptr<CPVRChannel>& channel) const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   const std::shared_ptr<CPVRChannelGroupMember> member = GetByUniqueID(channel->StorageId());
   return member ? member->ChannelNumber() : CPVRChannelNumber();
 }
 
-CPVRChannelNumber CPVRChannelGroup::GetClientChannelNumber(const std::shared_ptr<CPVRChannel>& channel) const
+CPVRChannelNumber CPVRChannelGroup::GetClientChannelNumber(
+    const std::shared_ptr<CPVRChannel>& channel) const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   const std::shared_ptr<CPVRChannelGroupMember> member = GetByUniqueID(channel->StorageId());
@@ -450,7 +452,7 @@ std::vector<std::shared_ptr<CPVRChannelGroupMember>> CPVRChannelGroup::GetMember
       case Include::ONLY_VISIBLE:
         if (member->Channel()->IsHidden())
           continue;
-       break;
+        break;
       default:
         break;
     }

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -23,523 +23,526 @@ struct PVR_CHANNEL_GROUP;
 
 namespace PVR
 {
-#define PVR_GROUP_TYPE_DEFAULT      0
-#define PVR_GROUP_TYPE_INTERNAL     1
+#define PVR_GROUP_TYPE_DEFAULT 0
+#define PVR_GROUP_TYPE_INTERNAL 1
 #define PVR_GROUP_TYPE_USER_DEFINED 2
 
-  enum class PVREvent;
+enum class PVREvent;
 
-  class CPVRChannel;
-  class CPVRChannelGroupMember;
-  class CPVRClient;
-  class CPVREpgInfoTag;
+class CPVRChannel;
+class CPVRChannelGroupMember;
+class CPVRClient;
+class CPVREpgInfoTag;
 
-  enum RenumberMode
+enum RenumberMode
+{
+  NORMAL = 0,
+  IGNORE_NUMBERING_FROM_ONE = 1
+};
+
+using GroupMemberPair =
+    std::pair<std::shared_ptr<CPVRChannelGroupMember>, std::shared_ptr<CPVRChannelGroupMember>>;
+
+class CPVRChannelGroup : public IChannelGroupSettingsCallback
+{
+  friend class CPVRDatabase;
+
+public:
+  static const int INVALID_GROUP_ID = -1;
+
+  /*!
+   * @brief Create a new channel group instance.
+   * @param path The channel group path.
+   * @param allChannelsGroup The channel group containing all TV or radio channels.
+   */
+  CPVRChannelGroup(const CPVRChannelsPath& path,
+                   const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup);
+
+  /*!
+   * @brief Create a new channel group instance from a channel group provided by an add-on.
+   * @param group The channel group provided by the add-on.
+   * @param allChannelsGroup The channel group containing all TV or radio channels.
+   */
+  CPVRChannelGroup(const PVR_CHANNEL_GROUP& group,
+                   const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup);
+
+  ~CPVRChannelGroup() override;
+
+  bool operator==(const CPVRChannelGroup& right) const;
+  bool operator!=(const CPVRChannelGroup& right) const;
+
+  /*!
+   * @brief Copy over data to the given PVR_CHANNEL_GROUP instance.
+   * @param group The group instance to fill.
+   */
+  void FillAddonData(PVR_CHANNEL_GROUP& group) const;
+
+  /*!
+   * @brief Query the events available for CEventStream
+   */
+  CEventStream<PVREvent>& Events() { return m_events; }
+
+  /*!
+   * @brief Load the channels from the database.
+   * @param channels All available channels.
+   * @param clients The PVR clients data should be loaded for. Leave empty for all clients.
+   * @return True when loaded successfully, false otherwise.
+   */
+  virtual bool LoadFromDatabase(
+      const std::map<std::pair<int, int>, std::shared_ptr<CPVRChannel>>& channels,
+      const std::vector<std::shared_ptr<CPVRClient>>& clients);
+
+  /*!
+   * @brief Clear all data.
+   */
+  virtual void Unload();
+
+  /*!
+   * @return The amount of group members
+   */
+  size_t Size() const;
+
+  /*!
+   * @brief Update data with channel group members from the given clients, sync with local data.
+   * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
+   * @return True on success, false otherwise.
+   */
+  virtual bool UpdateFromClients(const std::vector<std::shared_ptr<CPVRClient>>& clients);
+
+  /*!
+   * @brief Get the path of this group.
+   * @return the path.
+   */
+  const CPVRChannelsPath& GetPath() const;
+
+  /*!
+   * @brief Set the path of this group.
+   * @param the path.
+   */
+  void SetPath(const CPVRChannelsPath& path);
+
+  /*!
+   * @brief Change the channelnumber of a group. Used by CGUIDialogPVRChannelManager.
+   * Call SortByChannelNumber() and Renumber() after all changes are done.
+   * @param channel The channel to change the channel number for.
+   * @param channelNumber The new channel number.
+   */
+  bool SetChannelNumber(const std::shared_ptr<CPVRChannel>& channel,
+                        const CPVRChannelNumber& channelNumber);
+
+  /*!
+   * @brief Remove a channel from this container.
+   * @param channel The channel to remove.
+   * @return True if the channel was found and removed, false otherwise.
+   */
+  virtual bool RemoveFromGroup(const std::shared_ptr<CPVRChannel>& channel);
+
+  /*!
+   * @brief Append a channel to this container.
+   * @param channel The channel to append.
+   * @return True if the channel was appended, false otherwise.
+   */
+  virtual bool AppendToGroup(const std::shared_ptr<CPVRChannel>& channel);
+
+  /*!
+   * @brief Change the name of this group.
+   * @param strGroupName The new group name.
+   */
+  void SetGroupName(const std::string& strGroupName);
+
+  /*!
+   * @brief Persist changed or new data.
+   * @return True if the channel was persisted, false otherwise.
+   */
+  bool Persist();
+
+  /*!
+   * @brief Check whether a channel is in this container.
+   * @param channel The channel to find.
+   * @return True if the channel was found, false otherwise.
+   */
+  virtual bool IsGroupMember(const std::shared_ptr<CPVRChannel>& channel) const;
+
+  /*!
+   * @brief Check if this group is the internal group containing all channels.
+   * @return True if it's the internal group, false otherwise.
+   */
+  bool IsInternalGroup() const { return m_iGroupType == PVR_GROUP_TYPE_INTERNAL; }
+
+  /*!
+   * @brief True if this group holds radio channels, false if it holds TV channels.
+   * @return True if this group holds radio channels, false if it holds TV channels.
+   */
+  bool IsRadio() const;
+
+  /*!
+   * @brief The database ID of this group.
+   * @return The database ID of this group.
+   */
+  int GroupID() const;
+
+  /*!
+   * @brief Set the database ID of this group.
+   * @param iGroupId The new database ID.
+   */
+  void SetGroupID(int iGroupId);
+
+  /*!
+   * @brief Set the type of this group.
+   * @param the new type for this group.
+   */
+  void SetGroupType(int iGroupType);
+
+  /*!
+   * @brief Return the type of this group.
+   */
+  int GroupType() const;
+
+  /*!
+   * @return Time group has been watched last.
+   */
+  time_t LastWatched() const;
+
+  /*!
+   * @brief Last time group has been watched
+   * @param iLastWatched The new value.
+   */
+  void SetLastWatched(time_t iLastWatched);
+
+  /*!
+   * @return Time in milliseconds from epoch this group was last opened.
+   */
+  uint64_t LastOpened() const;
+
+  /*!
+   * @brief Set the time in milliseconds from epoch this group was last opened.
+   * @param iLastOpened The new value.
+   */
+  void SetLastOpened(uint64_t iLastOpened);
+
+  /*!
+   * @brief The name of this group.
+   * @return The name of this group.
+   */
+  std::string GroupName() const;
+
+  /*! @name Sort methods
+   */
+  //@{
+
+  /*!
+   * @brief Sort the group.
+   */
+  void Sort();
+
+  /*!
+   * @brief Sort the group and fix up channel numbers.
+   * @return True when numbering changed, false otherwise
+   */
+  bool SortAndRenumber();
+
+  /*!
+   * @brief Remove invalid channels and updates the channel numbers.
+   * @param mode the numbering mode to use
+   * @return True if something changed, false otherwise.
+   */
+  bool Renumber(RenumberMode mode = NORMAL);
+
+  //@}
+
+  // IChannelGroupSettingsCallback implementation
+  void UseBackendChannelOrderChanged() override;
+  void UseBackendChannelNumbersChanged() override;
+  void StartGroupChannelNumbersFromOneChanged() override;
+
+  /*!
+   * @brief Get the channel group member that was played last.
+   * @param iCurrentChannel The channelid of the current channel that is playing, or -1 if none
+   * @return The requested channel group member or nullptr.
+     */
+  std::shared_ptr<CPVRChannelGroupMember> GetLastPlayedChannelGroupMember(
+      int iCurrentChannel = -1) const;
+
+  /*!
+   * @brief Get the last and previous to last played channel group members.
+   * @return The members. pair.first contains the last, pair.second the previous to last member.
+   */
+  GroupMemberPair GetLastAndPreviousToLastPlayedChannelGroupMember() const;
+
+  /*!
+   * @brief Get a channel group member given it's active channel number
+   * @param channelNumber The channel number.
+   * @return The channel group member or nullptr if it wasn't found.
+   */
+  std::shared_ptr<CPVRChannelGroupMember> GetByChannelNumber(
+      const CPVRChannelNumber& channelNumber) const;
+
+  /*!
+   * @brief Get the channel number in this group of the given channel.
+   * @param channel The channel to get the channel number for.
+   * @return The channel number in this group.
+   */
+  CPVRChannelNumber GetChannelNumber(const std::shared_ptr<CPVRChannel>& channel) const;
+
+  /*!
+   * @brief Get the client channel number in this group of the given channel.
+   * @param channel The channel to get the channel number for.
+   * @return The client channel number in this group.
+   */
+  CPVRChannelNumber GetClientChannelNumber(const std::shared_ptr<CPVRChannel>& channel) const;
+
+  /*!
+   * @brief Get the next channel group member in this group.
+   * @param groupMember The current channel group member.
+   * @return The channel group member or nullptr if it wasn't found.
+   */
+  std::shared_ptr<CPVRChannelGroupMember> GetNextChannelGroupMember(
+      const std::shared_ptr<CPVRChannelGroupMember>& groupMember) const;
+
+  /*!
+   * @brief Get the previous channel group member in this group.
+   * @param groupMember The current channel group member.
+   * @return The channel group member or nullptr if it wasn't found.
+   */
+  std::shared_ptr<CPVRChannelGroupMember> GetPreviousChannelGroupMember(
+      const std::shared_ptr<CPVRChannelGroupMember>& groupMember) const;
+
+  /*!
+   * @brief Get a channel given it's channel ID.
+   * @param iChannelID The channel ID.
+   * @return The channel or NULL if it wasn't found.
+   */
+  std::shared_ptr<CPVRChannel> GetByChannelID(int iChannelID) const;
+
+  enum class Include
   {
-    NORMAL = 0,
-    IGNORE_NUMBERING_FROM_ONE = 1
+    ALL,
+    ONLY_HIDDEN,
+    ONLY_VISIBLE
   };
 
-  using GroupMemberPair =
-      std::pair<std::shared_ptr<CPVRChannelGroupMember>, std::shared_ptr<CPVRChannelGroupMember>>;
-
-  class CPVRChannelGroup : public IChannelGroupSettingsCallback
-  {
-    friend class CPVRDatabase;
-
-  public:
-    static const int INVALID_GROUP_ID = -1;
-
-    /*!
-     * @brief Create a new channel group instance.
-     * @param path The channel group path.
-     * @param allChannelsGroup The channel group containing all TV or radio channels.
-     */
-    CPVRChannelGroup(const CPVRChannelsPath& path,
-                     const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup);
-
-    /*!
-     * @brief Create a new channel group instance from a channel group provided by an add-on.
-     * @param group The channel group provided by the add-on.
-     * @param allChannelsGroup The channel group containing all TV or radio channels.
-     */
-    CPVRChannelGroup(const PVR_CHANNEL_GROUP& group, const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup);
-
-    ~CPVRChannelGroup() override;
-
-    bool operator ==(const CPVRChannelGroup& right) const;
-    bool operator !=(const CPVRChannelGroup& right) const;
-
-    /*!
-     * @brief Copy over data to the given PVR_CHANNEL_GROUP instance.
-     * @param group The group instance to fill.
-     */
-    void FillAddonData(PVR_CHANNEL_GROUP& group) const;
-
-    /*!
-     * @brief Query the events available for CEventStream
-     */
-    CEventStream<PVREvent>& Events() { return m_events; }
-
-    /*!
-     * @brief Load the channels from the database.
-     * @param channels All available channels.
-     * @param clients The PVR clients data should be loaded for. Leave empty for all clients.
-     * @return True when loaded successfully, false otherwise.
-     */
-    virtual bool LoadFromDatabase(
-        const std::map<std::pair<int, int>, std::shared_ptr<CPVRChannel>>& channels,
-        const std::vector<std::shared_ptr<CPVRClient>>& clients);
-
-    /*!
-     * @brief Clear all data.
-     */
-    virtual void Unload();
-
-    /*!
-     * @return The amount of group members
-     */
-    size_t Size() const;
-
-    /*!
-     * @brief Update data with channel group members from the given clients, sync with local data.
-     * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
-     * @return True on success, false otherwise.
-     */
-    virtual bool UpdateFromClients(const std::vector<std::shared_ptr<CPVRClient>>& clients);
-
-    /*!
-     * @brief Get the path of this group.
-     * @return the path.
-     */
-    const CPVRChannelsPath& GetPath() const;
-
-    /*!
-     * @brief Set the path of this group.
-     * @param the path.
-     */
-    void SetPath(const CPVRChannelsPath& path);
-
-    /*!
-     * @brief Change the channelnumber of a group. Used by CGUIDialogPVRChannelManager. Call SortByChannelNumber() and Renumber() after all changes are done.
-     * @param channel The channel to change the channel number for.
-     * @param channelNumber The new channel number.
-     */
-    bool SetChannelNumber(const std::shared_ptr<CPVRChannel>& channel, const CPVRChannelNumber& channelNumber);
-
-    /*!
-     * @brief Remove a channel from this container.
-     * @param channel The channel to remove.
-     * @return True if the channel was found and removed, false otherwise.
-     */
-    virtual bool RemoveFromGroup(const std::shared_ptr<CPVRChannel>& channel);
-
-    /*!
-     * @brief Append a channel to this container.
-     * @param channel The channel to append.
-     * @return True if the channel was appended, false otherwise.
-     */
-    virtual bool AppendToGroup(const std::shared_ptr<CPVRChannel>& channel);
-
-    /*!
-     * @brief Change the name of this group.
-     * @param strGroupName The new group name.
-     */
-    void SetGroupName(const std::string& strGroupName);
-
-    /*!
-     * @brief Persist changed or new data.
-     * @return True if the channel was persisted, false otherwise.
-     */
-    bool Persist();
-
-    /*!
-     * @brief Check whether a channel is in this container.
-     * @param channel The channel to find.
-     * @return True if the channel was found, false otherwise.
-     */
-    virtual bool IsGroupMember(const std::shared_ptr<CPVRChannel>& channel) const;
-
-    /*!
-     * @brief Check if this group is the internal group containing all channels.
-     * @return True if it's the internal group, false otherwise.
-     */
-    bool IsInternalGroup() const { return m_iGroupType == PVR_GROUP_TYPE_INTERNAL; }
-
-    /*!
-     * @brief True if this group holds radio channels, false if it holds TV channels.
-     * @return True if this group holds radio channels, false if it holds TV channels.
-     */
-    bool IsRadio() const;
-
-    /*!
-     * @brief The database ID of this group.
-     * @return The database ID of this group.
-     */
-    int GroupID() const;
-
-    /*!
-     * @brief Set the database ID of this group.
-     * @param iGroupId The new database ID.
-     */
-    void SetGroupID(int iGroupId);
-
-    /*!
-     * @brief Set the type of this group.
-     * @param the new type for this group.
-     */
-    void SetGroupType(int iGroupType);
-
-    /*!
-     * @brief Return the type of this group.
-     */
-    int GroupType() const;
-
-    /*!
-     * @return Time group has been watched last.
-     */
-    time_t LastWatched() const;
-
-    /*!
-     * @brief Last time group has been watched
-     * @param iLastWatched The new value.
-     */
-    void SetLastWatched(time_t iLastWatched);
-
-    /*!
-     * @return Time in milliseconds from epoch this group was last opened.
-     */
-    uint64_t LastOpened() const;
-
-    /*!
-     * @brief Set the time in milliseconds from epoch this group was last opened.
-     * @param iLastOpened The new value.
-     */
-    void SetLastOpened(uint64_t iLastOpened);
-
-    /*!
-     * @brief The name of this group.
-     * @return The name of this group.
-     */
-    std::string GroupName() const;
-
-    /*! @name Sort methods
-     */
-    //@{
-
-    /*!
-     * @brief Sort the group.
-     */
-    void Sort();
-
-    /*!
-     * @brief Sort the group and fix up channel numbers.
-     * @return True when numbering changed, false otherwise
-     */
-    bool SortAndRenumber();
-
-    /*!
-     * @brief Remove invalid channels and updates the channel numbers.
-     * @param mode the numbering mode to use
-     * @return True if something changed, false otherwise.
-     */
-    bool Renumber(RenumberMode mode = NORMAL);
-
-    //@}
-
-    // IChannelGroupSettingsCallback implementation
-    void UseBackendChannelOrderChanged() override;
-    void UseBackendChannelNumbersChanged() override;
-    void StartGroupChannelNumbersFromOneChanged() override;
-
-    /*!
-     * @brief Get the channel group member that was played last.
-     * @param iCurrentChannel The channelid of the current channel that is playing, or -1 if none
-     * @return The requested channel group member or nullptr.
-     */
-    std::shared_ptr<CPVRChannelGroupMember> GetLastPlayedChannelGroupMember(
-        int iCurrentChannel = -1) const;
-
-    /*!
-     * @brief Get the last and previous to last played channel group members.
-     * @return The members. pair.first contains the last, pair.second the previous to last member.
-     */
-    GroupMemberPair GetLastAndPreviousToLastPlayedChannelGroupMember() const;
-
-    /*!
-     * @brief Get a channel group member given it's active channel number
-     * @param channelNumber The channel number.
-     * @return The channel group member or nullptr if it wasn't found.
-     */
-    std::shared_ptr<CPVRChannelGroupMember> GetByChannelNumber(
-        const CPVRChannelNumber& channelNumber) const;
-
-    /*!
-     * @brief Get the channel number in this group of the given channel.
-     * @param channel The channel to get the channel number for.
-     * @return The channel number in this group.
-     */
-    CPVRChannelNumber GetChannelNumber(const std::shared_ptr<CPVRChannel>& channel) const;
-
-    /*!
-     * @brief Get the client channel number in this group of the given channel.
-     * @param channel The channel to get the channel number for.
-     * @return The client channel number in this group.
-     */
-    CPVRChannelNumber GetClientChannelNumber(const std::shared_ptr<CPVRChannel>& channel) const;
-
-    /*!
-     * @brief Get the next channel group member in this group.
-     * @param groupMember The current channel group member.
-     * @return The channel group member or nullptr if it wasn't found.
-     */
-    std::shared_ptr<CPVRChannelGroupMember> GetNextChannelGroupMember(
-        const std::shared_ptr<CPVRChannelGroupMember>& groupMember) const;
-
-    /*!
-     * @brief Get the previous channel group member in this group.
-     * @param groupMember The current channel group member.
-     * @return The channel group member or nullptr if it wasn't found.
-     */
-    std::shared_ptr<CPVRChannelGroupMember> GetPreviousChannelGroupMember(
-        const std::shared_ptr<CPVRChannelGroupMember>& groupMember) const;
-
-    /*!
-     * @brief Get a channel given it's channel ID.
-     * @param iChannelID The channel ID.
-     * @return The channel or NULL if it wasn't found.
-     */
-    std::shared_ptr<CPVRChannel> GetByChannelID(int iChannelID) const;
-
-    enum class Include
-    {
-      ALL,
-      ONLY_HIDDEN,
-      ONLY_VISIBLE
-    };
-
-    /*!
-     * @brief Get the current members of this group
-     * @param eFilter A filter to apply.
-     * @return The group members
-     */
-    std::vector<std::shared_ptr<CPVRChannelGroupMember>> GetMembers(
-        Include eFilter = Include::ALL) const;
-
-    /*!
-     * @brief Get the list of active channel numbers in a group.
-     * @param channelNumbers The list to store the numbers in.
-     */
-    void GetChannelNumbers(std::vector<std::string>& channelNumbers) const;
-
-    /*!
-     * @brief The amount of hidden channels in this container.
-     * @return The amount of hidden channels in this container.
-     */
-    virtual size_t GetNumHiddenChannels() const { return 0; }
-
-    /*!
-     * @brief Does this container holds channels.
-     * @return True if there is at least one channel in this container, otherwise false.
-     */
-    bool HasChannels() const;
-
-    /*!
-     * @return True if there is at least one new channel in this group that hasn't been persisted, false otherwise.
-     */
-    bool HasNewChannels() const;
-
-    /*!
-     * @return True if anything changed in this group that hasn't been persisted, false otherwise.
-     */
-    bool HasChanges() const;
-
-    /*!
-     * @return True if the group was never persisted, false otherwise.
-     */
-    bool IsNew() const;
-
-    /*!
-     * @brief Create an EPG table for each channel.
-     * @brief bForce Create the tables, even if they already have been created before.
-     * @return True if all tables were created successfully, false otherwise.
-     */
-    virtual bool CreateChannelEpgs(bool bForce = false);
-
-    /*!
-     * @brief Update a channel group member with given data.
-     * @param storageId The storage id of the channel.
-     * @param strChannelName The channel name to set.
-     * @param strIconPath The icon path to set.
-     * @param iEPGSource The EPG id.
-     * @param iChannelNumber The channel number to set.
-     * @param bHidden Set/Remove hidden flag for the channel group member identified by storage id.
-     * @param bEPGEnabled Set/Remove EPG enabled flag for the channel group member identified by storage id.
-     * @param bParentalLocked Set/Remove parental locked flag for the channel group member identified by storage id.
-     * @param bUserSetIcon Set/Remove user set icon flag for the channel group member identified by storage id.
-     * @param bUserSetHidden Set/Remove user set hidden flag for the channel group member identified by storage id.
-     * @return True on success, false otherwise.
-     */
-    bool UpdateChannel(const std::pair<int, int>& storageId,
-                       const std::string& strChannelName,
-                       const std::string& strIconPath,
-                       int iEPGSource,
-                       int iChannelNumber,
-                       bool bHidden,
-                       bool bEPGEnabled,
-                       bool bParentalLocked,
-                       bool bUserSetIcon,
-                       bool bUserSetHidden);
-
-    /*!
-     * @brief Get a channel given the channel number on the client.
-     * @param iUniqueChannelId The unique channel id on the client.
-     * @param iClientID The ID of the client.
-     * @return The channel or NULL if it wasn't found.
-     */
-    std::shared_ptr<CPVRChannel> GetByUniqueID(int iUniqueChannelId, int iClientID) const;
-
-    /*!
-     * @brief Get a channel group member given its storage id.
-     * @param id The storage id (a pair of client id and unique channel id).
-     * @return The channel group member or nullptr if it wasn't found.
-     */
-    std::shared_ptr<CPVRChannelGroupMember> GetByUniqueID(const std::pair<int, int>& id) const;
-
-    bool SetHidden(bool bHidden);
-    bool IsHidden() const;
-
-    int GetPosition() const;
-    void SetPosition(int iPosition);
-
-    /*!
-     * @brief Check, whether data for a given pvr client are currently valid. For instance, data
-     * can be invalid because the client's backend was offline when data was last queried.
-     * @param iClientId The id of the client.
-     * @return True, if data is currently valid, false otherwise.
-     */
-    bool HasValidDataForClient(int iClientId) const;
-
-    /*!
-     * @brief Check, whether data for given pvr clients are currently valid. For instance, data
-     * can be invalid because the client's backend was offline when data was last queried.
-     * @param clients The clients to check. Check all active clients if vector is empty.
-     * @return True, if data is currently valid, false otherwise.
-     */
-    bool HasValidDataForClients(const std::vector<std::shared_ptr<CPVRClient>>& clients) const;
-
-    /*!
-     * @brief Update the channel numbers according to the all channels group and publish event.
-     * @return True, if a channel number was changed, false otherwise.
-     */
-    bool UpdateChannelNumbersFromAllChannelsGroup();
-
-    /*!
-     * @brief Remove this group from database.
-     */
-    void Delete();
-
-    /*!
-     * @brief Whether this group is deleted.
-     * @return True, if deleted, false otherwise.
-     */
-    bool IsDeleted() const { return m_bDeleted; }
-
-    /*!
-     * @brief Erase stale texture db entries and image files.
-     * @return number of cleaned up images.
-     */
-    int CleanupCachedImages();
-
-  protected:
-    /*!
-     * @brief Remove deleted group members from this group.
-     * @param groupMembers The group members to use to update this list.
-     * @return The removed members .
-     */
-    virtual std::vector<std::shared_ptr<CPVRChannelGroupMember>> RemoveDeletedGroupMembers(
-        const std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers);
-
-    /*!
-     * @brief Update the current channel group members with the given list.
-     * @param groupMembers The group members to use to update this list.
-     * @return True if everything went well, false otherwise.
-     */
-    bool UpdateGroupEntries(
-        const std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers);
-
-    /*!
-     * @brief Sort the current channel list by client channel number.
-     */
-    void SortByClientChannelNumber();
-
-    /*!
-     * @brief Sort the current channel list by channel number.
-     */
-    void SortByChannelNumber();
-
-    /*!
-     * @brief Update the priority for all members of all channel groups.
-     */
-    bool UpdateClientPriorities();
-
-    std::shared_ptr<CPVRChannelGroupSettings> GetSettings() const;
-
-    int m_iGroupType = PVR_GROUP_TYPE_DEFAULT; /*!< The type of this group */
-    int m_iGroupId = INVALID_GROUP_ID; /*!< The ID of this group in the database */
-    bool m_bLoaded = false; /*!< True if this container is loaded, false otherwise */
-    bool m_bChanged = false; /*!< true if anything changed in this group that hasn't been persisted, false otherwise */
-    time_t m_iLastWatched = 0; /*!< last time group has been watched */
-    uint64_t m_iLastOpened = 0; /*!< time in milliseconds from epoch this group was last opened */
-    bool m_bHidden = false; /*!< true if this group is hidden, false otherwise */
-    int m_iPosition = 0; /*!< the position of this group within the group list */
-    std::vector<std::shared_ptr<CPVRChannelGroupMember>>
-        m_sortedMembers; /*!< members sorted by channel number */
-    std::map<std::pair<int, int>, std::shared_ptr<CPVRChannelGroupMember>>
-        m_members; /*!< members with key clientid+uniqueid */
-    mutable CCriticalSection m_critSection;
-    std::vector<int> m_failedClients;
-    CEventSource<PVREvent> m_events;
-    mutable std::shared_ptr<CPVRChannelGroupSettings> m_settings;
-
-    // the settings singleton shared between all group instances
-    static CCriticalSection m_settingsSingletonCritSection;
-    static std::weak_ptr<CPVRChannelGroupSettings> m_settingsSingleton;
-
-  private:
-    /*!
-     * @brief Load the channel group members stored in the database.
-     * @param clients The PVR clients to load data for. Leave empty for all clients.
-     * @return The amount of channel group members that were added.
-     */
-    int LoadFromDatabase(const std::vector<std::shared_ptr<CPVRClient>>& clients);
-
-    /*!
-     * @brief Delete channel group members from database.
-     * @param membersToDelete The channel group members.
-     */
-    void DeleteGroupMembersFromDb(
-        const std::vector<std::shared_ptr<CPVRChannelGroupMember>>& membersToDelete);
-
-    /*!
-     * @brief Update this group's data with a channel group member provided by a client.
-     * @param groupMember The updated group member.
-     * @return True if group member data were changed, false otherwise.
-     */
-    bool UpdateFromClient(const std::shared_ptr<CPVRChannelGroupMember>& groupMember);
-
-    /*!
-     * @brief Add new channel group members to this group; update data.
-     * @param groupMembers The group members to use to update this list.
-     * @return True if group member data were changed, false otherwise.
-     */
-    bool AddAndUpdateGroupMembers(
-        const std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers);
-
-    void OnSettingChanged();
-
-    std::shared_ptr<CPVRChannelGroup> m_allChannelsGroup;
-    CPVRChannelsPath m_path;
-    bool m_bDeleted = false;
-  };
-}
+  /*!
+   * @brief Get the current members of this group
+   * @param eFilter A filter to apply.
+   * @return The group members
+   */
+  std::vector<std::shared_ptr<CPVRChannelGroupMember>> GetMembers(
+      Include eFilter = Include::ALL) const;
+
+  /*!
+   * @brief Get the list of active channel numbers in a group.
+   * @param channelNumbers The list to store the numbers in.
+   */
+  void GetChannelNumbers(std::vector<std::string>& channelNumbers) const;
+
+  /*!
+   * @brief The amount of hidden channels in this container.
+   * @return The amount of hidden channels in this container.
+   */
+  virtual size_t GetNumHiddenChannels() const { return 0; }
+
+  /*!
+   * @brief Does this container holds channels.
+   * @return True if there is at least one channel in this container, otherwise false.
+   */
+  bool HasChannels() const;
+
+  /*!
+   * @return True if there is at least one new channel in this group that hasn't been persisted, false otherwise.
+   */
+  bool HasNewChannels() const;
+
+  /*!
+   * @return True if anything changed in this group that hasn't been persisted, false otherwise.
+   */
+  bool HasChanges() const;
+
+  /*!
+   * @return True if the group was never persisted, false otherwise.
+   */
+  bool IsNew() const;
+
+  /*!
+   * @brief Create an EPG table for each channel.
+   * @brief bForce Create the tables, even if they already have been created before.
+   * @return True if all tables were created successfully, false otherwise.
+   */
+  virtual bool CreateChannelEpgs(bool bForce = false);
+
+  /*!
+   * @brief Update a channel group member with given data.
+   * @param storageId The storage id of the channel.
+   * @param strChannelName The channel name to set.
+   * @param strIconPath The icon path to set.
+   * @param iEPGSource The EPG id.
+   * @param iChannelNumber The channel number to set.
+   * @param bHidden Set/Remove hidden flag for the channel group member identified by storage id.
+   * @param bEPGEnabled Set/Remove EPG enabled flag for the channel group member identified by storage id.
+   * @param bParentalLocked Set/Remove parental locked flag for the channel group member identified by storage id.
+   * @param bUserSetIcon Set/Remove user set icon flag for the channel group member identified by storage id.
+   * @param bUserSetHidden Set/Remove user set hidden flag for the channel group member identified by storage id.
+   * @return True on success, false otherwise.
+   */
+  bool UpdateChannel(const std::pair<int, int>& storageId,
+                     const std::string& strChannelName,
+                     const std::string& strIconPath,
+                     int iEPGSource,
+                     int iChannelNumber,
+                     bool bHidden,
+                     bool bEPGEnabled,
+                     bool bParentalLocked,
+                     bool bUserSetIcon,
+                     bool bUserSetHidden);
+
+  /*!
+   * @brief Get a channel given the channel number on the client.
+   * @param iUniqueChannelId The unique channel id on the client.
+   * @param iClientID The ID of the client.
+   * @return The channel or NULL if it wasn't found.
+   */
+  std::shared_ptr<CPVRChannel> GetByUniqueID(int iUniqueChannelId, int iClientID) const;
+
+  /*!
+   * @brief Get a channel group member given its storage id.
+   * @param id The storage id (a pair of client id and unique channel id).
+   * @return The channel group member or nullptr if it wasn't found.
+   */
+  std::shared_ptr<CPVRChannelGroupMember> GetByUniqueID(const std::pair<int, int>& id) const;
+
+  bool SetHidden(bool bHidden);
+  bool IsHidden() const;
+
+  int GetPosition() const;
+  void SetPosition(int iPosition);
+
+  /*!
+   * @brief Check, whether data for a given pvr client are currently valid. For instance, data
+   * can be invalid because the client's backend was offline when data was last queried.
+   * @param iClientId The id of the client.
+   * @return True, if data is currently valid, false otherwise.
+   */
+  bool HasValidDataForClient(int iClientId) const;
+
+  /*!
+   * @brief Check, whether data for given pvr clients are currently valid. For instance, data
+   * can be invalid because the client's backend was offline when data was last queried.
+   * @param clients The clients to check. Check all active clients if vector is empty.
+   * @return True, if data is currently valid, false otherwise.
+   */
+  bool HasValidDataForClients(const std::vector<std::shared_ptr<CPVRClient>>& clients) const;
+
+  /*!
+   * @brief Update the channel numbers according to the all channels group and publish event.
+   * @return True, if a channel number was changed, false otherwise.
+   */
+  bool UpdateChannelNumbersFromAllChannelsGroup();
+
+  /*!
+   * @brief Remove this group from database.
+   */
+  void Delete();
+
+  /*!
+   * @brief Whether this group is deleted.
+   * @return True, if deleted, false otherwise.
+   */
+  bool IsDeleted() const { return m_bDeleted; }
+
+  /*!
+   * @brief Erase stale texture db entries and image files.
+   * @return number of cleaned up images.
+   */
+  int CleanupCachedImages();
+
+protected:
+  /*!
+   * @brief Remove deleted group members from this group.
+   * @param groupMembers The group members to use to update this list.
+   * @return The removed members .
+   */
+  virtual std::vector<std::shared_ptr<CPVRChannelGroupMember>> RemoveDeletedGroupMembers(
+      const std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers);
+
+  /*!
+   * @brief Update the current channel group members with the given list.
+   * @param groupMembers The group members to use to update this list.
+   * @return True if everything went well, false otherwise.
+   */
+  bool UpdateGroupEntries(const std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers);
+
+  /*!
+   * @brief Sort the current channel list by client channel number.
+   */
+  void SortByClientChannelNumber();
+
+  /*!
+   * @brief Sort the current channel list by channel number.
+   */
+  void SortByChannelNumber();
+
+  /*!
+   * @brief Update the priority for all members of all channel groups.
+   */
+  bool UpdateClientPriorities();
+
+  std::shared_ptr<CPVRChannelGroupSettings> GetSettings() const;
+
+  int m_iGroupType = PVR_GROUP_TYPE_DEFAULT; /*!< The type of this group */
+  int m_iGroupId = INVALID_GROUP_ID; /*!< The ID of this group in the database */
+  bool m_bLoaded = false; /*!< True if this container is loaded, false otherwise */
+  bool m_bChanged =
+      false; /*!< true if anything changed in this group that hasn't been persisted, false otherwise */
+  time_t m_iLastWatched = 0; /*!< last time group has been watched */
+  uint64_t m_iLastOpened = 0; /*!< time in milliseconds from epoch this group was last opened */
+  bool m_bHidden = false; /*!< true if this group is hidden, false otherwise */
+  int m_iPosition = 0; /*!< the position of this group within the group list */
+  std::vector<std::shared_ptr<CPVRChannelGroupMember>>
+      m_sortedMembers; /*!< members sorted by channel number */
+  std::map<std::pair<int, int>, std::shared_ptr<CPVRChannelGroupMember>>
+      m_members; /*!< members with key clientid+uniqueid */
+  mutable CCriticalSection m_critSection;
+  std::vector<int> m_failedClients;
+  CEventSource<PVREvent> m_events;
+  mutable std::shared_ptr<CPVRChannelGroupSettings> m_settings;
+
+  // the settings singleton shared between all group instances
+  static CCriticalSection m_settingsSingletonCritSection;
+  static std::weak_ptr<CPVRChannelGroupSettings> m_settingsSingleton;
+
+private:
+  /*!
+   * @brief Load the channel group members stored in the database.
+   * @param clients The PVR clients to load data for. Leave empty for all clients.
+   * @return The amount of channel group members that were added.
+   */
+  int LoadFromDatabase(const std::vector<std::shared_ptr<CPVRClient>>& clients);
+
+  /*!
+   * @brief Delete channel group members from database.
+   * @param membersToDelete The channel group members.
+   */
+  void DeleteGroupMembersFromDb(
+      const std::vector<std::shared_ptr<CPVRChannelGroupMember>>& membersToDelete);
+
+  /*!
+   * @brief Update this group's data with a channel group member provided by a client.
+   * @param groupMember The updated group member.
+   * @return True if group member data were changed, false otherwise.
+   */
+  bool UpdateFromClient(const std::shared_ptr<CPVRChannelGroupMember>& groupMember);
+
+  /*!
+   * @brief Add new channel group members to this group; update data.
+   * @param groupMembers The group members to use to update this list.
+   * @return True if group member data were changed, false otherwise.
+   */
+  bool AddAndUpdateGroupMembers(
+      const std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers);
+
+  void OnSettingChanged();
+
+  std::shared_ptr<CPVRChannelGroup> m_allChannelsGroup;
+  CPVRChannelsPath m_path;
+  bool m_bDeleted = false;
+};
+} // namespace PVR

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -71,6 +71,12 @@ namespace PVR
     bool operator !=(const CPVRChannelGroup& right) const;
 
     /*!
+     * @brief Copy over data to the given PVR_CHANNEL_GROUP instance.
+     * @param group The group instance to fill.
+     */
+    void FillAddonData(PVR_CHANNEL_GROUP& group) const;
+
+    /*!
      * @brief Query the events available for CEventStream
      */
     CEventStream<PVREvent>& Events() { return m_events; }

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -176,6 +176,52 @@ bool CPVRRecording::operator!=(const CPVRRecording& right) const
   return !(*this == right);
 }
 
+void CPVRRecording::FillAddonData(PVR_RECORDING& recording) const
+{
+  time_t recTime;
+  RecordingTimeAsUTC().GetAsTime(recTime);
+
+  recording = {};
+  strncpy(recording.strRecordingId, ClientRecordingID().c_str(),
+          sizeof(recording.strRecordingId) - 1);
+  strncpy(recording.strTitle, m_strTitle.c_str(), sizeof(recording.strTitle) - 1);
+  strncpy(recording.strEpisodeName, m_strShowTitle.c_str(), sizeof(recording.strEpisodeName) - 1);
+  recording.iSeriesNumber = m_iSeason;
+  recording.iEpisodeNumber = m_iEpisode;
+  recording.iYear = GetYear();
+  strncpy(recording.strDirectory, Directory().c_str(), sizeof(recording.strDirectory) - 1);
+  strncpy(recording.strPlotOutline, m_strPlotOutline.c_str(), sizeof(recording.strPlotOutline) - 1);
+  strncpy(recording.strPlot, m_strPlot.c_str(), sizeof(recording.strPlot) - 1);
+  strncpy(recording.strGenreDescription, GetGenresLabel().c_str(),
+          sizeof(recording.strGenreDescription) - 1);
+  strncpy(recording.strChannelName, ChannelName().c_str(), sizeof(recording.strChannelName) - 1);
+  strncpy(recording.strIconPath, ClientIconPath().c_str(), sizeof(recording.strIconPath) - 1);
+  strncpy(recording.strThumbnailPath, ClientThumbnailPath().c_str(),
+          sizeof(recording.strThumbnailPath) - 1);
+  strncpy(recording.strFanartPath, ClientFanartPath().c_str(), sizeof(recording.strFanartPath) - 1);
+  recording.recordingTime =
+      recTime - CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRTimeCorrection;
+  recording.iDuration = GetDuration();
+  recording.iPriority = Priority();
+  recording.iLifetime = LifeTime();
+  recording.iGenreType = GenreType();
+  recording.iGenreSubType = GenreSubType();
+  recording.iPlayCount = GetLocalPlayCount();
+  recording.iLastPlayedPosition = std::lrint(GetLocalResumePoint().timeInSeconds);
+  recording.bIsDeleted = IsDeleted();
+  recording.iEpgEventId = m_iEpgEventId;
+  recording.iChannelUid = ChannelUid();
+  recording.channelType =
+      IsRadio() ? PVR_RECORDING_CHANNEL_TYPE_RADIO : PVR_RECORDING_CHANNEL_TYPE_TV;
+  if (FirstAired().IsValid())
+    strncpy(recording.strFirstAired, FirstAired().GetAsW3CDate().c_str(),
+            sizeof(recording.strFirstAired) - 1);
+  recording.iFlags = Flags();
+  recording.sizeInBytes = GetSizeInBytes();
+  strncpy(recording.strProviderName, ProviderName().c_str(), sizeof(recording.strProviderName) - 1);
+  recording.iClientProviderUid = ClientProviderUniqueId();
+}
+
 void CPVRRecording::Serialize(CVariant& value) const
 {
   CVideoInfoTag::Serialize(value);

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -60,6 +60,12 @@ public:
   bool operator==(const CPVRRecording& right) const;
   bool operator!=(const CPVRRecording& right) const;
 
+  /*!
+   * @brief Copy over data to the given PVR_RECORDING instance.
+   * @param recording The recording instance to fill.
+   */
+  void FillAddonData(PVR_RECORDING& recording) const;
+
   void Serialize(CVariant& value) const override;
 
   // ISortable implementation

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -36,22 +36,24 @@
 
 using namespace PVR;
 
-CPVRTimerInfoTag::CPVRTimerInfoTag(bool bRadio /* = false */) :
-  m_strTitle(g_localizeStrings.Get(19056)), // New Timer
-  m_iClientId(CServiceBroker::GetPVRManager().Clients()->GetFirstCreatedClientID()),
-  m_iClientIndex(PVR_TIMER_NO_CLIENT_INDEX),
-  m_iParentClientIndex(PVR_TIMER_NO_PARENT),
-  m_iClientChannelUid(PVR_CHANNEL_INVALID_UID),
-  m_iPriority(DEFAULT_RECORDING_PRIORITY),
-  m_iLifetime(DEFAULT_RECORDING_LIFETIME),
-  m_iPreventDupEpisodes(DEFAULT_RECORDING_DUPLICATEHANDLING),
-  m_bIsRadio(bRadio),
-  m_iMarginStart(CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_PVRRECORD_MARGINSTART)),
-  m_iMarginEnd(CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_PVRRECORD_MARGINEND)),
-  m_iEpgUid(EPG_TAG_INVALID_UID),
-  m_StartTime(CDateTime::GetUTCDateTime()),
-  m_StopTime(m_StartTime + CDateTimeSpan(0, 2, 0, 0)),
-  m_FirstDay(m_StartTime)
+CPVRTimerInfoTag::CPVRTimerInfoTag(bool bRadio /* = false */)
+  : m_strTitle(g_localizeStrings.Get(19056)), // New Timer
+    m_iClientId(CServiceBroker::GetPVRManager().Clients()->GetFirstCreatedClientID()),
+    m_iClientIndex(PVR_TIMER_NO_CLIENT_INDEX),
+    m_iParentClientIndex(PVR_TIMER_NO_PARENT),
+    m_iClientChannelUid(PVR_CHANNEL_INVALID_UID),
+    m_iPriority(DEFAULT_RECORDING_PRIORITY),
+    m_iLifetime(DEFAULT_RECORDING_LIFETIME),
+    m_iPreventDupEpisodes(DEFAULT_RECORDING_DUPLICATEHANDLING),
+    m_bIsRadio(bRadio),
+    m_iMarginStart(CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+        CSettings::SETTING_PVRRECORD_MARGINSTART)),
+    m_iMarginEnd(CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+        CSettings::SETTING_PVRRECORD_MARGINEND)),
+    m_iEpgUid(EPG_TAG_INVALID_UID),
+    m_StartTime(CDateTime::GetUTCDateTime()),
+    m_StopTime(m_StartTime + CDateTimeSpan(0, 2, 0, 0)),
+    m_FirstDay(m_StartTime)
 {
   static const uint64_t iMustHaveAttr = PVR_TIMER_TYPE_IS_MANUAL;
   static const uint64_t iMustNotHaveAttr =
@@ -68,7 +70,8 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(bool bRadio /* = false */) :
 
   // fallback to manual one-shot reminder, which is always available
   if (!type)
-    type = CPVRTimerType::CreateFromAttributes(iMustHaveAttr | PVR_TIMER_TYPE_IS_REMINDER, iMustNotHaveAttr, m_iClientId);
+    type = CPVRTimerType::CreateFromAttributes(iMustHaveAttr | PVR_TIMER_TYPE_IS_REMINDER,
+                                               iMustNotHaveAttr, m_iClientId);
 
   if (type)
     SetTimerType(type);
@@ -120,7 +123,9 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(const PVR_TIMER& timer,
     m_channel(channel)
 {
   if (timer.firstDay)
-    m_FirstDay = CDateTime(timer.firstDay + CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRTimeCorrection);
+    m_FirstDay = CDateTime(
+        timer.firstDay +
+        CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRTimeCorrection);
   else
     m_FirstDay = CDateTime::GetUTCDateTime();
 
@@ -154,7 +159,8 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(const PVR_TIMER& timer,
       else
         iMustNotHave |= PVR_TIMER_TYPE_IS_MANUAL;
 
-      const std::shared_ptr<CPVRTimerType> type = CPVRTimerType::CreateFromAttributes(iMustHave, iMustNotHave, m_iClientId);
+      const std::shared_ptr<CPVRTimerType> type =
+          CPVRTimerType::CreateFromAttributes(iMustHave, iMustNotHave, m_iClientId);
 
       if (type)
         SetTimerType(type);
@@ -182,7 +188,7 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(const PVR_TIMER& timer,
   UpdateEpgInfoTag();
 }
 
-bool CPVRTimerInfoTag::operator ==(const CPVRTimerInfoTag& right) const
+bool CPVRTimerInfoTag::operator==(const CPVRTimerInfoTag& right) const
 {
   bool bChannelsMatch = true;
   if (m_channel && right.m_channel)
@@ -190,37 +196,23 @@ bool CPVRTimerInfoTag::operator ==(const CPVRTimerInfoTag& right) const
   else if (m_channel != right.m_channel)
     bChannelsMatch = false;
 
-  return (bChannelsMatch &&
-          m_iClientIndex == right.m_iClientIndex &&
+  return (bChannelsMatch && m_iClientIndex == right.m_iClientIndex &&
           m_iParentClientIndex == right.m_iParentClientIndex &&
-          m_strSummary == right.m_strSummary &&
-          m_iClientChannelUid == right.m_iClientChannelUid &&
-          m_bIsRadio == right.m_bIsRadio &&
-          m_iPreventDupEpisodes == right.m_iPreventDupEpisodes &&
-          m_iRecordingGroup == right.m_iRecordingGroup &&
-          m_StartTime == right.m_StartTime &&
-          m_StopTime == right.m_StopTime &&
-          m_bStartAnyTime == right.m_bStartAnyTime &&
-          m_bEndAnyTime == right.m_bEndAnyTime &&
-          m_FirstDay == right.m_FirstDay &&
-          m_iWeekdays == right.m_iWeekdays &&
-          m_iPriority == right.m_iPriority &&
-          m_iLifetime == right.m_iLifetime &&
-          m_iMaxRecordings == right.m_iMaxRecordings &&
-          m_strFileNameAndPath == right.m_strFileNameAndPath &&
-          m_strTitle == right.m_strTitle &&
+          m_strSummary == right.m_strSummary && m_iClientChannelUid == right.m_iClientChannelUid &&
+          m_bIsRadio == right.m_bIsRadio && m_iPreventDupEpisodes == right.m_iPreventDupEpisodes &&
+          m_iRecordingGroup == right.m_iRecordingGroup && m_StartTime == right.m_StartTime &&
+          m_StopTime == right.m_StopTime && m_bStartAnyTime == right.m_bStartAnyTime &&
+          m_bEndAnyTime == right.m_bEndAnyTime && m_FirstDay == right.m_FirstDay &&
+          m_iWeekdays == right.m_iWeekdays && m_iPriority == right.m_iPriority &&
+          m_iLifetime == right.m_iLifetime && m_iMaxRecordings == right.m_iMaxRecordings &&
+          m_strFileNameAndPath == right.m_strFileNameAndPath && m_strTitle == right.m_strTitle &&
           m_strEpgSearchString == right.m_strEpgSearchString &&
           m_bFullTextEpgSearch == right.m_bFullTextEpgSearch &&
-          m_strDirectory == right.m_strDirectory &&
-          m_iClientId == right.m_iClientId &&
-          m_iMarginStart == right.m_iMarginStart &&
-          m_iMarginEnd == right.m_iMarginEnd &&
-          m_state == right.m_state &&
-          m_timerType == right.m_timerType &&
-          m_iTimerId == right.m_iTimerId &&
-          m_strSeriesLink == right.m_strSeriesLink &&
-          m_iEpgUid == right.m_iEpgUid &&
-          m_iTVChildTimersActive == right.m_iTVChildTimersActive &&
+          m_strDirectory == right.m_strDirectory && m_iClientId == right.m_iClientId &&
+          m_iMarginStart == right.m_iMarginStart && m_iMarginEnd == right.m_iMarginEnd &&
+          m_state == right.m_state && m_timerType == right.m_timerType &&
+          m_iTimerId == right.m_iTimerId && m_strSeriesLink == right.m_strSeriesLink &&
+          m_iEpgUid == right.m_iEpgUid && m_iTVChildTimersActive == right.m_iTVChildTimersActive &&
           m_iTVChildTimersConflictNOK == right.m_iTVChildTimersConflictNOK &&
           m_iTVChildTimersRecording == right.m_iTVChildTimersRecording &&
           m_iTVChildTimersErrors == right.m_iTVChildTimersErrors &&
@@ -230,7 +222,7 @@ bool CPVRTimerInfoTag::operator ==(const CPVRTimerInfoTag& right) const
           m_iRadioChildTimersErrors == right.m_iRadioChildTimersErrors);
 }
 
-bool CPVRTimerInfoTag::operator !=(const CPVRTimerInfoTag& right) const
+bool CPVRTimerInfoTag::operator!=(const CPVRTimerInfoTag& right) const
 {
   return !(*this == right);
 }
@@ -286,7 +278,9 @@ void CPVRTimerInfoTag::Serialize(CVariant& value) const
   value["endtime"] = m_StopTime.IsValid() ? m_StopTime.GetAsDBDateTime() : "";
   value["startanytime"] = m_bStartAnyTime;
   value["endanytime"] = m_bEndAnyTime;
-  value["runtime"] = m_StartTime.IsValid() && m_StopTime.IsValid() ? (m_StopTime - m_StartTime).GetSecondsTotal() : 0;
+  value["runtime"] = m_StartTime.IsValid() && m_StopTime.IsValid()
+                         ? (m_StopTime - m_StartTime).GetSecondsTotal()
+                         : 0;
   value["firstday"] = m_FirstDay.IsValid() ? m_FirstDay.GetAsDBDate() : "";
 
   CVariant weekdays(CVariant::VariantTypeArray);
@@ -317,39 +311,39 @@ void CPVRTimerInfoTag::Serialize(CVariant& value) const
 
   switch (m_state)
   {
-  case PVR_TIMER_STATE_NEW:
-    value["state"] = "new";
-    break;
-  case PVR_TIMER_STATE_SCHEDULED:
-    value["state"] = "scheduled";
-    break;
-  case PVR_TIMER_STATE_RECORDING:
-    value["state"] = "recording";
-    break;
-  case PVR_TIMER_STATE_COMPLETED:
-    value["state"] = "completed";
-    break;
-  case PVR_TIMER_STATE_ABORTED:
-    value["state"] = "aborted";
-    break;
-  case PVR_TIMER_STATE_CANCELLED:
-    value["state"] = "cancelled";
-    break;
-  case PVR_TIMER_STATE_CONFLICT_OK:
-    value["state"] = "conflict_ok";
-    break;
-  case PVR_TIMER_STATE_CONFLICT_NOK:
-    value["state"] = "conflict_notok";
-    break;
-  case PVR_TIMER_STATE_ERROR:
-    value["state"] = "error";
-    break;
-  case PVR_TIMER_STATE_DISABLED:
-    value["state"] = "disabled";
-    break;
-  default:
-    value["state"] = "unknown";
-    break;
+    case PVR_TIMER_STATE_NEW:
+      value["state"] = "new";
+      break;
+    case PVR_TIMER_STATE_SCHEDULED:
+      value["state"] = "scheduled";
+      break;
+    case PVR_TIMER_STATE_RECORDING:
+      value["state"] = "recording";
+      break;
+    case PVR_TIMER_STATE_COMPLETED:
+      value["state"] = "completed";
+      break;
+    case PVR_TIMER_STATE_ABORTED:
+      value["state"] = "aborted";
+      break;
+    case PVR_TIMER_STATE_CANCELLED:
+      value["state"] = "cancelled";
+      break;
+    case PVR_TIMER_STATE_CONFLICT_OK:
+      value["state"] = "conflict_ok";
+      break;
+    case PVR_TIMER_STATE_CONFLICT_NOK:
+      value["state"] = "conflict_notok";
+      break;
+    case PVR_TIMER_STATE_ERROR:
+      value["state"] = "error";
+      break;
+    case PVR_TIMER_STATE_DISABLED:
+      value["state"] = "disabled";
+      break;
+    default:
+      value["state"] = "unknown";
+      break;
   }
 
   value["istimerrule"] = m_timerType->IsTimerRule();
@@ -357,13 +351,13 @@ void CPVRTimerInfoTag::Serialize(CVariant& value) const
   value["isreadonly"] = m_timerType->IsReadOnly();
   value["isreminder"] = m_timerType->IsReminder();
 
-  value["epgsearchstring"]   = m_strEpgSearchString;
+  value["epgsearchstring"] = m_strEpgSearchString;
   value["fulltextepgsearch"] = m_bFullTextEpgSearch;
-  value["recordinggroup"]    = m_iRecordingGroup;
-  value["maxrecordings"]     = m_iMaxRecordings;
-  value["epguid"]            = m_iEpgUid;
+  value["recordinggroup"] = m_iRecordingGroup;
+  value["maxrecordings"] = m_iMaxRecordings;
+  value["epguid"] = m_iEpgUid;
   value["broadcastid"] = m_epgTag ? m_epgTag->DatabaseID() : -1;
-  value["serieslink"]        = m_strSeriesLink;
+  value["serieslink"] = m_strSeriesLink;
 
   value["clientid"] = m_iClientId;
 }
@@ -465,7 +459,8 @@ std::string CPVRTimerInfoTag::GetStatus(bool bRadio) const
       strReturn = g_localizeStrings.Get(19162); // "Recording active"
     else if ((m_iTVChildTimersErrors > 0 && !bRadio) || (m_iRadioChildTimersErrors > 0 && bRadio))
       strReturn = g_localizeStrings.Get(257); // "Error"
-    else if ((m_iTVChildTimersConflictNOK > 0 && !bRadio) || (m_iRadioChildTimersConflictNOK > 0 && bRadio))
+    else if ((m_iTVChildTimersConflictNOK > 0 && !bRadio) ||
+             (m_iRadioChildTimersConflictNOK > 0 && bRadio))
       strReturn = g_localizeStrings.Get(19276); // "Conflict error"
     else if ((m_iTVChildTimersActive > 0 && !bRadio) || (m_iRadioChildTimersActive > 0 && bRadio))
       strReturn = StringUtils::Format(g_localizeStrings.Get(19255),
@@ -499,16 +494,17 @@ void AppendDay(std::string& strReturn, unsigned int iId)
 }
 } // unnamed namespace
 
-std::string CPVRTimerInfoTag::GetWeekdaysString(unsigned int iWeekdays, bool bEpgBased, bool bLongMultiDaysFormat)
+std::string CPVRTimerInfoTag::GetWeekdaysString(unsigned int iWeekdays,
+                                                bool bEpgBased,
+                                                bool bLongMultiDaysFormat)
 {
   std::string strReturn;
 
   if (iWeekdays == PVR_WEEKDAY_NONE)
     return strReturn;
   else if (iWeekdays == PVR_WEEKDAY_ALLDAYS)
-    strReturn = bEpgBased
-              ? g_localizeStrings.Get(807) // "Any day"
-              : g_localizeStrings.Get(808); // "Every day"
+    strReturn = bEpgBased ? g_localizeStrings.Get(807) // "Any day"
+                          : g_localizeStrings.Get(808); // "Every day"
   else if (iWeekdays == PVR_WEEKDAY_MONDAY)
     strReturn = g_localizeStrings.Get(831); // "Mondays"
   else if (iWeekdays == PVR_WEEKDAY_TUESDAY)
@@ -668,7 +664,8 @@ bool CPVRTimerInfoTag::UpdateEntry(const std::shared_ptr<CPVRTimerInfoTag>& tag)
   return true;
 }
 
-bool CPVRTimerInfoTag::UpdateChildState(const std::shared_ptr<CPVRTimerInfoTag>& childTimer, bool bAdd)
+bool CPVRTimerInfoTag::UpdateChildState(const std::shared_ptr<CPVRTimerInfoTag>& childTimer,
+                                        bool bAdd)
 {
   if (!childTimer || childTimer->m_iParentClientIndex != m_iClientIndex)
     return false;
@@ -676,44 +673,44 @@ bool CPVRTimerInfoTag::UpdateChildState(const std::shared_ptr<CPVRTimerInfoTag>&
   int iDelta = bAdd ? +1 : -1;
   switch (childTimer->m_state)
   {
-  case PVR_TIMER_STATE_NEW:
-  case PVR_TIMER_STATE_SCHEDULED:
-  case PVR_TIMER_STATE_CONFLICT_OK:
-    if (childTimer->m_bIsRadio)
-      m_iRadioChildTimersActive += iDelta;
-    else
-      m_iTVChildTimersActive += iDelta;
-    break;
-  case PVR_TIMER_STATE_RECORDING:
-    if (childTimer->m_bIsRadio)
-    {
-      m_iRadioChildTimersActive += iDelta;
-      m_iRadioChildTimersRecording += iDelta;
-    }
-    else
-    {
-      m_iTVChildTimersActive += iDelta;
-      m_iTVChildTimersRecording += iDelta;
-    }
-    break;
-  case PVR_TIMER_STATE_CONFLICT_NOK:
-    if (childTimer->m_bIsRadio)
-      m_iRadioChildTimersConflictNOK += iDelta;
-    else
-      m_iTVChildTimersConflictNOK += iDelta;
-    break;
-  case PVR_TIMER_STATE_ERROR:
-    if (childTimer->m_bIsRadio)
-      m_iRadioChildTimersErrors += iDelta;
-    else
-      m_iTVChildTimersErrors += iDelta;
-    break;
-  case PVR_TIMER_STATE_COMPLETED:
-  case PVR_TIMER_STATE_ABORTED:
-  case PVR_TIMER_STATE_CANCELLED:
-  case PVR_TIMER_STATE_DISABLED:
-    //these are not the child timers we are looking for
-    break;
+    case PVR_TIMER_STATE_NEW:
+    case PVR_TIMER_STATE_SCHEDULED:
+    case PVR_TIMER_STATE_CONFLICT_OK:
+      if (childTimer->m_bIsRadio)
+        m_iRadioChildTimersActive += iDelta;
+      else
+        m_iTVChildTimersActive += iDelta;
+      break;
+    case PVR_TIMER_STATE_RECORDING:
+      if (childTimer->m_bIsRadio)
+      {
+        m_iRadioChildTimersActive += iDelta;
+        m_iRadioChildTimersRecording += iDelta;
+      }
+      else
+      {
+        m_iTVChildTimersActive += iDelta;
+        m_iTVChildTimersRecording += iDelta;
+      }
+      break;
+    case PVR_TIMER_STATE_CONFLICT_NOK:
+      if (childTimer->m_bIsRadio)
+        m_iRadioChildTimersConflictNOK += iDelta;
+      else
+        m_iTVChildTimersConflictNOK += iDelta;
+      break;
+    case PVR_TIMER_STATE_ERROR:
+      if (childTimer->m_bIsRadio)
+        m_iRadioChildTimersErrors += iDelta;
+      else
+        m_iTVChildTimersErrors += iDelta;
+      break;
+    case PVR_TIMER_STATE_COMPLETED:
+    case PVR_TIMER_STATE_ABORTED:
+    case PVR_TIMER_STATE_CANCELLED:
+    case PVR_TIMER_STATE_DISABLED:
+      //these are not the child timers we are looking for
+      break;
   }
   return true;
 }
@@ -758,8 +755,9 @@ std::string CPVRTimerInfoTag::ChannelIcon() const
 }
 
 std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTag::CreateReminderFromDate(
-  const CDateTime& start, int iDuration,
-  const std::shared_ptr<CPVRTimerInfoTag>& parent /* = std::shared_ptr<CPVRTimerInfoTag>() */)
+    const CDateTime& start,
+    int iDuration,
+    const std::shared_ptr<CPVRTimerInfoTag>& parent /* = std::shared_ptr<CPVRTimerInfoTag>() */)
 {
   bool bReadOnly = !!parent; // children of reminder rules are always read-only
   std::shared_ptr<CPVRTimerInfoTag> newTimer =
@@ -775,20 +773,28 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTag::CreateReminderFromDate(
   return newTimer;
 }
 
-static const time_t INSTANT_TIMER_START = 0; // PVR addon API: special start time value to denote an instant timer
+static const time_t INSTANT_TIMER_START =
+    0; // PVR addon API: special start time value to denote an instant timer
 
-std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTag::CreateInstantTimerTag(const std::shared_ptr<CPVRChannel>& channel, int iDuration /* = DEFAULT_PVRRECORD_INSTANTRECORDTIME */)
+std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTag::CreateInstantTimerTag(
+    const std::shared_ptr<CPVRChannel>& channel,
+    int iDuration /* = DEFAULT_PVRRECORD_INSTANTRECORDTIME */)
 {
   return CreateFromDate(channel, CDateTime(INSTANT_TIMER_START), iDuration, false, false);
 }
 
-std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTag::CreateTimerTag(const std::shared_ptr<CPVRChannel>& channel, const CDateTime& start, int iDuration)
+std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTag::CreateTimerTag(
+    const std::shared_ptr<CPVRChannel>& channel, const CDateTime& start, int iDuration)
 {
   return CreateFromDate(channel, start, iDuration, false, false);
 }
 
 std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTag::CreateFromDate(
-  const std::shared_ptr<CPVRChannel>& channel, const CDateTime& start, int iDuration, bool bCreateReminder, bool bReadOnly)
+    const std::shared_ptr<CPVRChannel>& channel,
+    const CDateTime& start,
+    int iDuration,
+    bool bCreateReminder,
+    bool bReadOnly)
 {
   if (!channel)
   {
@@ -841,7 +847,8 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTag::CreateFromDate(
 
     // timertype: manual one-shot timer for given client
     const std::shared_ptr<CPVRTimerType> timerType = CPVRTimerType::CreateFromAttributes(
-      iMustHaveAttribs, PVR_TIMER_TYPE_IS_REPEATING | PVR_TIMER_TYPE_FORBIDS_NEW_INSTANCES, channel->ClientID());
+        iMustHaveAttribs, PVR_TIMER_TYPE_IS_REPEATING | PVR_TIMER_TYPE_FORBIDS_NEW_INSTANCES,
+        channel->ClientID());
     if (!timerType)
     {
       CLog::LogF(LOGERROR, "Unable to create one shot manual timer type");
@@ -864,7 +871,8 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTag::CreateFromDate(
     newTimer->SetStartFromUTC(start);
 
   if (iDuration == DEFAULT_PVRRECORD_INSTANTRECORDTIME)
-    iDuration = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_PVRRECORD_INSTANTRECORDTIME);
+    iDuration = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+        CSettings::SETTING_PVRRECORD_INSTANTRECORDTIME);
 
   if (bInstantStart)
   {
@@ -899,8 +907,8 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTag::CreateFromDate(
 }
 
 std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTag::CreateReminderFromEpg(
-  const std::shared_ptr<CPVREpgInfoTag>& tag,
-  const std::shared_ptr<CPVRTimerInfoTag>& parent /* = std::shared_ptr<CPVRTimerInfoTag>() */)
+    const std::shared_ptr<CPVREpgInfoTag>& tag,
+    const std::shared_ptr<CPVRTimerInfoTag>& parent /* = std::shared_ptr<CPVRTimerInfoTag>() */)
 {
   bool bReadOnly = !!parent; // children of reminder rules are always read-only
   std::shared_ptr<CPVRTimerInfoTag> newTimer = CreateFromEpg(tag, false, true, bReadOnly);
@@ -917,7 +925,7 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTag::CreateReminderFromEpg(
 }
 
 std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTag::CreateFromEpg(
-  const std::shared_ptr<CPVREpgInfoTag>& tag, bool bCreateRule /* = false */)
+    const std::shared_ptr<CPVREpgInfoTag>& tag, bool bCreateRule /* = false */)
 {
   return CreateFromEpg(tag, bCreateRule, false, false);
 }
@@ -931,7 +939,8 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTag::CreateFromEpg(
   std::shared_ptr<CPVRTimerInfoTag> newTag(new CPVRTimerInfoTag());
 
   /* check if a valid channel is set */
-  const std::shared_ptr<CPVRChannel> channel = CServiceBroker::GetPVRManager().ChannelGroups()->GetChannelForEpgTag(tag);
+  const std::shared_ptr<CPVRChannel> channel =
+      CServiceBroker::GetPVRManager().ChannelGroups()->GetChannelForEpgTag(tag);
   if (!channel)
   {
     CLog::LogF(LOGERROR, "EPG tag has no channel");
@@ -969,10 +978,12 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTag::CreateFromEpg(
 
     if (!tag->SeriesLink().empty())
       timerType = CPVRTimerType::CreateFromAttributes(
-        iMustHaveAttribs | PVR_TIMER_TYPE_REQUIRES_EPG_SERIESLINK_ON_CREATE, iMustNotHaveAttribs, channel->ClientID());
+          iMustHaveAttribs | PVR_TIMER_TYPE_REQUIRES_EPG_SERIESLINK_ON_CREATE, iMustNotHaveAttribs,
+          channel->ClientID());
     if (!timerType)
       timerType = CPVRTimerType::CreateFromAttributes(
-        iMustHaveAttribs, iMustNotHaveAttribs | PVR_TIMER_TYPE_REQUIRES_EPG_SERIESLINK_ON_CREATE, channel->ClientID());
+          iMustHaveAttribs, iMustNotHaveAttribs | PVR_TIMER_TYPE_REQUIRES_EPG_SERIESLINK_ON_CREATE,
+          channel->ClientID());
     if (timerType)
     {
       if (timerType->SupportsEpgTitleMatch())
@@ -999,7 +1010,7 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTag::CreateFromEpg(
       iMustHaveAttribs |= PVR_TIMER_TYPE_IS_READONLY;
 
     timerType = CPVRTimerType::CreateFromAttributes(
-      iMustHaveAttribs, PVR_TIMER_TYPE_IS_REPEATING | iMustNotHaveAttribs, channel->ClientID());
+        iMustHaveAttribs, PVR_TIMER_TYPE_IS_REPEATING | iMustNotHaveAttribs, channel->ClientID());
   }
 
   if (!timerType)
@@ -1024,55 +1035,52 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTag::CreateFromEpg(
 
 namespace
 {
-  #define IsLeapYear(y) ((y % 4 == 0) && (y % 100 != 0 || y % 400 == 0))
+#define IsLeapYear(y) ((y % 4 == 0) && (y % 100 != 0 || y % 400 == 0))
 
-  int days_from_0(int year)
-  {
-    year--;
-    return 365 * year + (year / 400) - (year / 100) + (year / 4);
-  }
-
-  int days_from_1970(int32_t year)
-  {
-    static const int days_from_0_to_1970 = days_from_0(1970);
-    return days_from_0(year) - days_from_0_to_1970;
-  }
-
-  int days_from_1jan(int year, int month, int day)
-  {
-    static const int days[2][12] =
-    {
-      { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334 },
-      { 0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335 }
-    };
-    return days[IsLeapYear(year)][month - 1] + day - 1;
-  }
-
-  time_t mytimegm(struct tm* time)
-  {
-    int year = time->tm_year + 1900;
-    int month = time->tm_mon;
-
-    if (month > 11)
-    {
-      year += month / 12;
-      month %= 12;
-    }
-    else if (month < 0)
-    {
-      int years_diff = (-month + 11) / 12;
-      year -= years_diff;
-      month += 12 * years_diff;
-    }
-
-    month++;
-
-    int day_of_year = days_from_1jan(year, month, time->tm_mday);
-    int days_since_epoch = days_from_1970(year) + day_of_year;
-
-    return 3600 * 24 * days_since_epoch + 3600 * time->tm_hour + 60 * time->tm_min + time->tm_sec;
-  }
+int days_from_0(int year)
+{
+  year--;
+  return 365 * year + (year / 400) - (year / 100) + (year / 4);
 }
+
+int days_from_1970(int32_t year)
+{
+  static const int days_from_0_to_1970 = days_from_0(1970);
+  return days_from_0(year) - days_from_0_to_1970;
+}
+
+int days_from_1jan(int year, int month, int day)
+{
+  static const int days[2][12] = {{0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334},
+                                  {0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335}};
+  return days[IsLeapYear(year)][month - 1] + day - 1;
+}
+
+time_t mytimegm(struct tm* time)
+{
+  int year = time->tm_year + 1900;
+  int month = time->tm_mon;
+
+  if (month > 11)
+  {
+    year += month / 12;
+    month %= 12;
+  }
+  else if (month < 0)
+  {
+    int years_diff = (-month + 11) / 12;
+    year -= years_diff;
+    month += 12 * years_diff;
+  }
+
+  month++;
+
+  int day_of_year = days_from_1jan(year, month, time->tm_mday);
+  int days_since_epoch = days_from_1970(year) + day_of_year;
+
+  return 3600 * 24 * days_since_epoch + 3600 * time->tm_hour + 60 * time->tm_min + time->tm_sec;
+}
+} // namespace
 
 CDateTime CPVRTimerInfoTag::ConvertUTCToLocalTime(const CDateTime& utc)
 {
@@ -1212,34 +1220,34 @@ std::string CPVRTimerInfoTag::GetNotificationText() const
 
   switch (m_state)
   {
-  case PVR_TIMER_STATE_ABORTED:
-  case PVR_TIMER_STATE_CANCELLED:
+    case PVR_TIMER_STATE_ABORTED:
+    case PVR_TIMER_STATE_CANCELLED:
       stringID = 19224; // Recording aborted
-    break;
-  case PVR_TIMER_STATE_SCHEDULED:
-    if (IsTimerRule())
-      stringID = 19058; // Timer enabled
-    else
-      stringID = 19225; // Recording scheduled
-    break;
-  case PVR_TIMER_STATE_RECORDING:
-    stringID = 19226; // Recording started
-    break;
-  case PVR_TIMER_STATE_COMPLETED:
-    stringID = 19227; // Recording completed
-    break;
-  case PVR_TIMER_STATE_CONFLICT_OK:
-  case PVR_TIMER_STATE_CONFLICT_NOK:
-    stringID = 19277; // Recording conflict
-    break;
-  case PVR_TIMER_STATE_ERROR:
-    stringID = 19278; // Recording error
-    break;
-  case PVR_TIMER_STATE_DISABLED:
-    stringID = 19057; // Timer disabled
-    break;
-  default:
-    break;
+      break;
+    case PVR_TIMER_STATE_SCHEDULED:
+      if (IsTimerRule())
+        stringID = 19058; // Timer enabled
+      else
+        stringID = 19225; // Recording scheduled
+      break;
+    case PVR_TIMER_STATE_RECORDING:
+      stringID = 19226; // Recording started
+      break;
+    case PVR_TIMER_STATE_COMPLETED:
+      stringID = 19227; // Recording completed
+      break;
+    case PVR_TIMER_STATE_CONFLICT_OK:
+    case PVR_TIMER_STATE_CONFLICT_NOK:
+      stringID = 19277; // Recording conflict
+      break;
+    case PVR_TIMER_STATE_ERROR:
+      stringID = 19278; // Recording error
+      break;
+    case PVR_TIMER_STATE_DISABLED:
+      stringID = 19057; // Timer disabled
+      break;
+    default:
+      break;
   }
 
   if (stringID != 0)
@@ -1256,15 +1264,15 @@ std::string CPVRTimerInfoTag::GetDeletedNotificationText() const
   // The state in this case is the state the timer had when it was last seen
   switch (m_state)
   {
-  case PVR_TIMER_STATE_RECORDING:
-    stringID = 19227; // Recording completed
-    break;
-  case PVR_TIMER_STATE_SCHEDULED:
-  default:
-    if (IsTimerRule())
-      stringID = 828; // Timer rule deleted
-    else
-      stringID = 19228; // Timer deleted
+    case PVR_TIMER_STATE_RECORDING:
+      stringID = 19227; // Recording completed
+      break;
+    case PVR_TIMER_STATE_SCHEDULED:
+    default:
+      if (IsTimerRule())
+        stringID = 828; // Timer rule deleted
+      else
+        stringID = 19228; // Timer deleted
   }
 
   return StringUtils::Format("{}: '{}'", g_localizeStrings.Get(stringID), m_strTitle);
@@ -1292,7 +1300,11 @@ std::shared_ptr<CPVREpgInfoTag> CPVRTimerInfoTag::GetEpgInfoTag(bool bCreate /* 
     std::shared_ptr<CPVRChannel> channel(m_channel);
     if (!channel)
     {
-      channel = CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bIsRadio)->GetGroupAll()->GetByUniqueID(m_iClientChannelUid, m_iClientId);
+      channel = CServiceBroker::GetPVRManager()
+                    .ChannelGroups()
+                    ->Get(m_bIsRadio)
+                    ->GetGroupAll()
+                    ->GetByUniqueID(m_iClientChannelUid, m_iClientId);
 
       std::unique_lock<CCriticalSection> lock(m_critSection);
       m_channel = channel;
@@ -1321,7 +1333,8 @@ std::shared_ptr<CPVREpgInfoTag> CPVRTimerInfoTag::GetEpgInfoTag(bool bCreate /* 
           if (startTime > 0 && endTime > 0)
           {
             // try to fetch missing epg tag from backend
-            m_epgTag = epg->GetTagBetween(StartAsUTC() - CDateTimeSpan(0, 0, 2, 0), EndAsUTC() + CDateTimeSpan(0, 0, 2, 0), true);
+            m_epgTag = epg->GetTagBetween(StartAsUTC() - CDateTimeSpan(0, 0, 2, 0),
+                                          EndAsUTC() + CDateTimeSpan(0, 0, 2, 0), true);
             if (m_epgTag)
               m_iEpgUid = m_epgTag->UniqueBroadcastID();
           }
@@ -1345,7 +1358,11 @@ std::shared_ptr<CPVRChannel> CPVRTimerInfoTag::Channel() const
 
 std::shared_ptr<CPVRChannel> CPVRTimerInfoTag::UpdateChannel()
 {
-  const std::shared_ptr<CPVRChannel> channel(CServiceBroker::GetPVRManager().ChannelGroups()->Get(m_bIsRadio)->GetGroupAll()->GetByUniqueID(m_iClientChannelUid, m_iClientId));
+  const std::shared_ptr<CPVRChannel> channel(CServiceBroker::GetPVRManager()
+                                                 .ChannelGroups()
+                                                 ->Get(m_bIsRadio)
+                                                 ->GetGroupAll()
+                                                 ->GetByUniqueID(m_iClientChannelUid, m_iClientId));
 
   std::unique_lock<CCriticalSection> lock(m_critSection);
   m_channel = channel;

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -230,12 +230,50 @@ bool CPVRTimerInfoTag::operator ==(const CPVRTimerInfoTag& right) const
           m_iRadioChildTimersErrors == right.m_iRadioChildTimersErrors);
 }
 
-/**
- * Compare not equal for two CPVRTimerInfoTag
- */
 bool CPVRTimerInfoTag::operator !=(const CPVRTimerInfoTag& right) const
 {
   return !(*this == right);
+}
+
+void CPVRTimerInfoTag::FillAddonData(PVR_TIMER& timer) const
+{
+  time_t start, end, firstDay;
+  StartAsUTC().GetAsTime(start);
+  EndAsUTC().GetAsTime(end);
+  FirstDayAsUTC().GetAsTime(firstDay);
+  const std::shared_ptr<CPVREpgInfoTag> epgTag = GetEpgInfoTag();
+  const int iPVRTimeCorrection =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRTimeCorrection;
+
+  timer = {};
+  timer.iClientIndex = m_iClientIndex;
+  timer.iParentClientIndex = m_iParentClientIndex;
+  timer.state = m_state;
+  timer.iTimerType = GetTimerType()->GetTypeId();
+  timer.iClientChannelUid = m_iClientChannelUid;
+  strncpy(timer.strTitle, m_strTitle.c_str(), sizeof(timer.strTitle) - 1);
+  strncpy(timer.strEpgSearchString, m_strEpgSearchString.c_str(),
+          sizeof(timer.strEpgSearchString) - 1);
+  timer.bFullTextEpgSearch = m_bFullTextEpgSearch;
+  strncpy(timer.strDirectory, m_strDirectory.c_str(), sizeof(timer.strDirectory) - 1);
+  timer.iPriority = m_iPriority;
+  timer.iLifetime = m_iLifetime;
+  timer.iMaxRecordings = m_iMaxRecordings;
+  timer.iPreventDuplicateEpisodes = m_iPreventDupEpisodes;
+  timer.iRecordingGroup = m_iRecordingGroup;
+  timer.iWeekdays = m_iWeekdays;
+  timer.startTime = start - iPVRTimeCorrection;
+  timer.endTime = end - iPVRTimeCorrection;
+  timer.bStartAnyTime = m_bStartAnyTime;
+  timer.bEndAnyTime = m_bEndAnyTime;
+  timer.firstDay = firstDay - iPVRTimeCorrection;
+  timer.iEpgUid = epgTag ? epgTag->UniqueBroadcastID() : PVR_TIMER_NO_EPG_UID;
+  strncpy(timer.strSummary, m_strSummary.c_str(), sizeof(timer.strSummary) - 1);
+  timer.iMarginStart = m_iMarginStart;
+  timer.iMarginEnd = m_iMarginEnd;
+  timer.iGenreType = epgTag ? epgTag->GenreType() : 0;
+  timer.iGenreSubType = epgTag ? epgTag->GenreSubType() : 0;
+  strncpy(timer.strSeriesLink, SeriesLink().c_str(), sizeof(timer.strSeriesLink) - 1);
 }
 
 void CPVRTimerInfoTag::Serialize(CVariant& value) const

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -39,6 +39,12 @@ namespace PVR
     bool operator ==(const CPVRTimerInfoTag& right) const;
     bool operator !=(const CPVRTimerInfoTag& right) const;
 
+    /*!
+     * @brief Copy over data to the given PVR_TIMER instance.
+     * @param timer The timer instance to fill.
+     */
+    void FillAddonData(PVR_TIMER& timer) const;
+
     void Serialize(CVariant& value) const override;
 
     void UpdateSummary();

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -20,372 +20,394 @@ struct PVR_TIMER;
 
 namespace PVR
 {
-  class CPVRChannel;
-  class CPVREpgInfoTag;
+class CPVRChannel;
+class CPVREpgInfoTag;
 
-  enum class TimerOperationResult
+enum class TimerOperationResult
+{
+  OK = 0,
+  FAILED,
+  RECORDING // The timer was not deleted because it is currently recording (see DeleteTimer).
+};
+
+class CPVRTimerInfoTag final : public ISerializable
+{
+public:
+  explicit CPVRTimerInfoTag(bool bRadio = false);
+  CPVRTimerInfoTag(const PVR_TIMER& timer,
+                   const std::shared_ptr<CPVRChannel>& channel,
+                   unsigned int iClientId);
+
+  bool operator==(const CPVRTimerInfoTag& right) const;
+  bool operator!=(const CPVRTimerInfoTag& right) const;
+
+  /*!
+   * @brief Copy over data to the given PVR_TIMER instance.
+   * @param timer The timer instance to fill.
+   */
+  void FillAddonData(PVR_TIMER& timer) const;
+
+  void Serialize(CVariant& value) const override;
+
+  void UpdateSummary();
+
+  std::string GetStatus(bool bRadio) const;
+  std::string GetTypeAsString() const;
+
+  static const int DEFAULT_PVRRECORD_INSTANTRECORDTIME = -1;
+
+  /*!
+   * @brief create a tag for an instant timer for a given channel
+   * @param channel is the channel the instant timer is to be created for
+   * @param iDuration is the duration for the instant timer, DEFAULT_PVRRECORD_INSTANTRECORDTIME denotes system default (setting value)
+   * @return the timer or null if timer could not be created
+   */
+  static std::shared_ptr<CPVRTimerInfoTag> CreateInstantTimerTag(
+      const std::shared_ptr<CPVRChannel>& channel,
+      int iDuration = DEFAULT_PVRRECORD_INSTANTRECORDTIME);
+
+  /*!
+   * @brief create a tag for a timer for a given channel at given time for given duration
+   * @param channel is the channel the timer is to be created for
+   * @param start is the start time for the recording
+   * @param iDuration is the duration of the recording
+   * @return the timer or null if timer could not be created
+   */
+  static std::shared_ptr<CPVRTimerInfoTag> CreateTimerTag(
+      const std::shared_ptr<CPVRChannel>& channel, const CDateTime& start, int iDuration);
+
+  /*!
+   * @brief create a recording or reminder timer or timer rule for the given epg info tag.
+   * @param tag the epg info tag
+   * @param bCreateRule if true, create a timer rule, create a one shot timer otherwise
+   * @param bCreateReminder if true, create a reminder timer or rule, create a recording timer or rule otherwise
+   * @param bReadOnly whether the timer/rule is read only
+   * @return the timer or null if timer could not be created
+   */
+  static std::shared_ptr<CPVRTimerInfoTag> CreateFromEpg(const std::shared_ptr<CPVREpgInfoTag>& tag,
+                                                         bool bCreateRule,
+                                                         bool bCreateReminder,
+                                                         bool bReadOnly = false);
+
+  /*!
+   * @brief create a timer or timer rule for the given epg info tag.
+   * @param tag the epg info tag
+   * @param bCreateRule if true, create a timer rule, create a one shot timer otherwise
+   * @return the timer or null if timer could not be created
+   */
+  static std::shared_ptr<CPVRTimerInfoTag> CreateFromEpg(const std::shared_ptr<CPVREpgInfoTag>& tag,
+                                                         bool bCreateRule = false);
+
+  /*!
+   * @brief create a reminder timer for the given start date.
+   * @param start the start date
+   * @param iDuration the duration the reminder is valid
+   * @param parent If non-zero, the new timer will be made a child of the given timer rule
+   * @return the timer or null if timer could not be created
+   */
+  static std::shared_ptr<CPVRTimerInfoTag> CreateReminderFromDate(
+      const CDateTime& start,
+      int iDuration,
+      const std::shared_ptr<CPVRTimerInfoTag>& parent = std::shared_ptr<CPVRTimerInfoTag>());
+
+  /*!
+   * @brief create a reminder timer for the given epg info tag.
+   * @param tag the epg info tag
+   * @param parent If non-zero, the new timer will be made a child of the given timer rule
+   * @return the timer or null if timer could not be created
+   */
+  static std::shared_ptr<CPVRTimerInfoTag> CreateReminderFromEpg(
+      const std::shared_ptr<CPVREpgInfoTag>& tag,
+      const std::shared_ptr<CPVRTimerInfoTag>& parent = std::shared_ptr<CPVRTimerInfoTag>());
+
+  /*!
+   * @brief Associate the given epg tag with this timer.
+   * @param tag The epg tag to assign.
+   */
+  void SetEpgInfoTag(const std::shared_ptr<CPVREpgInfoTag>& tag);
+
+  /*!
+   * @brief get the epg info tag associated with this timer, if any
+   * @param bCreate if true, try to find the epg tag if not yet set (lazy evaluation)
+   * @return the epg info tag associated with this timer or null if there is no tag
+   */
+  std::shared_ptr<CPVREpgInfoTag> GetEpgInfoTag(bool bCreate = true) const;
+
+  std::string ChannelName() const;
+  std::string ChannelIcon() const;
+
+  /*!
+   * @brief Check whether this timer has an associated channel.
+   * @return True if this timer has a channel set, false otherwise.
+   */
+  bool HasChannel() const;
+
+  /*!
+   * @brief Get the channel associated with this timer, if any.
+   * @return the channel or null if non is associated with this timer.
+   */
+  std::shared_ptr<CPVRChannel> Channel() const;
+
+  /*!
+   * @brief updates this timer excluding the state of any children.
+   * @param tag A timer containing the data that shall be merged into this timer's data.
+   * @return true if the timer was updated successfully
+   */
+  bool UpdateEntry(const std::shared_ptr<CPVRTimerInfoTag>& tag);
+
+  /*!
+   * @brief merge in the state of this child timer.
+   * @param childTimer The child timer
+   * @param bAdd If true, add child's data to parent's state, otherwise subtract.
+   * @return true if the child timer's state was merged successfully
+   */
+  bool UpdateChildState(const std::shared_ptr<CPVRTimerInfoTag>& childTimer, bool bAdd);
+
+  /*!
+   * @brief reset the state of children related to this timer.
+   */
+  void ResetChildState();
+
+  bool IsActive() const
   {
-    OK = 0,
-    FAILED,
-    RECORDING // The timer was not deleted because it is currently recording (see DeleteTimer).
-  };
+    return m_state == PVR_TIMER_STATE_SCHEDULED || m_state == PVR_TIMER_STATE_RECORDING ||
+           m_state == PVR_TIMER_STATE_CONFLICT_OK || m_state == PVR_TIMER_STATE_CONFLICT_NOK ||
+           m_state == PVR_TIMER_STATE_ERROR;
+  }
 
-  class CPVRTimerInfoTag final : public ISerializable
+  /*!
+   * @return True if this timer won't result in a recording because it is broken for some reason,
+   * false otherwise
+   */
+  bool IsBroken() const
   {
-  public:
-    explicit CPVRTimerInfoTag(bool bRadio = false);
-    CPVRTimerInfoTag(const PVR_TIMER& timer, const std::shared_ptr<CPVRChannel>& channel, unsigned int iClientId);
+    return m_state == PVR_TIMER_STATE_CONFLICT_NOK || m_state == PVR_TIMER_STATE_ERROR;
+  }
 
-    bool operator ==(const CPVRTimerInfoTag& right) const;
-    bool operator !=(const CPVRTimerInfoTag& right) const;
+  /*!
+   * @return True if this timer won't result in a recording because it is in conflict with another
+   * timer or live stream, false otherwise
+   */
+  bool HasConflict() const { return m_state == PVR_TIMER_STATE_CONFLICT_NOK; }
 
-    /*!
-     * @brief Copy over data to the given PVR_TIMER instance.
-     * @param timer The timer instance to fill.
-     */
-    void FillAddonData(PVR_TIMER& timer) const;
+  bool IsRecording() const { return m_state == PVR_TIMER_STATE_RECORDING; }
 
-    void Serialize(CVariant& value) const override;
+  /*!
+   * @brief Gets the type of this timer.
+   * @return the timer type or NULL if this tag has no timer type.
+   */
+  const std::shared_ptr<CPVRTimerType> GetTimerType() const { return m_timerType; }
 
-    void UpdateSummary();
+  /*!
+   * @brief Sets the type of this timer.
+   * @param the new timer type.
+   */
+  void SetTimerType(const std::shared_ptr<CPVRTimerType>& type);
 
-    std::string GetStatus(bool bRadio) const;
-    std::string GetTypeAsString() const;
+  /*!
+   * @brief Checks whether this is a timer rule (vs. one time timer).
+   * @return True if this is a timer rule, false otherwise.
+   */
+  bool IsTimerRule() const { return m_timerType && m_timerType->IsTimerRule(); }
 
-    static const int DEFAULT_PVRRECORD_INSTANTRECORDTIME = -1;
+  /*!
+   * @brief Checks whether this is a reminder timer (vs. recording timer).
+   * @return True if this is a reminder timer, false otherwise.
+   */
+  bool IsReminder() const { return m_timerType && m_timerType->IsReminder(); }
 
-    /*!
-     * @brief create a tag for an instant timer for a given channel
-     * @param channel is the channel the instant timer is to be created for
-     * @param iDuration is the duration for the instant timer, DEFAULT_PVRRECORD_INSTANTRECORDTIME denotes system default (setting value)
-     * @return the timer or null if timer could not be created
-     */
-    static std::shared_ptr<CPVRTimerInfoTag> CreateInstantTimerTag(const std::shared_ptr<CPVRChannel>& channel, int iDuration = DEFAULT_PVRRECORD_INSTANTRECORDTIME);
+  /*!
+   * @brief Checks whether this is a manual (vs. epg-based) timer.
+   * @return True if this is a manual timer, false otherwise.
+   */
+  bool IsManual() const { return m_timerType && m_timerType->IsManual(); }
 
-    /*!
-     * @brief create a tag for a timer for a given channel at given time for given duration
-     * @param channel is the channel the timer is to be created for
-     * @param start is the start time for the recording
-     * @param iDuration is the duration of the recording
-     * @return the timer or null if timer could not be created
-     */
-    static std::shared_ptr<CPVRTimerInfoTag> CreateTimerTag(const std::shared_ptr<CPVRChannel>& channel, const CDateTime& start, int iDuration);
+  /*!
+   * @brief Checks whether this is an epg-based (vs. manual) timer.
+   * @return True if this is an epg-Based timer, false otherwise.
+   */
+  bool IsEpgBased() const { return !IsManual(); }
 
-    /*!
-     * @brief create a recording or reminder timer or timer rule for the given epg info tag.
-     * @param tag the epg info tag
-     * @param bCreateRule if true, create a timer rule, create a one shot timer otherwise
-     * @param bCreateReminder if true, create a reminder timer or rule, create a recording timer or rule otherwise
-     * @param bReadOnly whether the timer/rule is read only
-     * @return the timer or null if timer could not be created
-     */
-    static std::shared_ptr<CPVRTimerInfoTag> CreateFromEpg(
-        const std::shared_ptr<CPVREpgInfoTag>& tag,
-        bool bCreateRule,
-        bool bCreateReminder,
-        bool bReadOnly = false);
+  static CDateTime ConvertUTCToLocalTime(const CDateTime& utc);
+  static CDateTime ConvertLocalTimeToUTC(const CDateTime& local);
 
-    /*!
-     * @brief create a timer or timer rule for the given epg info tag.
-     * @param tag the epg info tag
-     * @param bCreateRule if true, create a timer rule, create a one shot timer otherwise
-     * @return the timer or null if timer could not be created
-     */
-    static std::shared_ptr<CPVRTimerInfoTag> CreateFromEpg(const std::shared_ptr<CPVREpgInfoTag>& tag, bool bCreateRule = false);
+  CDateTime StartAsUTC() const;
+  CDateTime StartAsLocalTime() const;
+  void SetStartFromUTC(const CDateTime& start);
+  void SetStartFromLocalTime(const CDateTime& start);
 
-    /*!
-     * @brief create a reminder timer for the given start date.
-     * @param start the start date
-     * @param iDuration the duration the reminder is valid
-     * @param parent If non-zero, the new timer will be made a child of the given timer rule
-     * @return the timer or null if timer could not be created
-     */
-    static std::shared_ptr<CPVRTimerInfoTag> CreateReminderFromDate(const CDateTime& start,
-                                                                    int iDuration,
-                                                                    const std::shared_ptr<CPVRTimerInfoTag>& parent = std::shared_ptr<CPVRTimerInfoTag>());
+  CDateTime EndAsUTC() const;
+  CDateTime EndAsLocalTime() const;
+  void SetEndFromUTC(const CDateTime& end);
+  void SetEndFromLocalTime(const CDateTime& end);
 
-    /*!
-     * @brief create a reminder timer for the given epg info tag.
-     * @param tag the epg info tag
-     * @param parent If non-zero, the new timer will be made a child of the given timer rule
-     * @return the timer or null if timer could not be created
-     */
-    static std::shared_ptr<CPVRTimerInfoTag> CreateReminderFromEpg(const std::shared_ptr<CPVREpgInfoTag>& tag,
-                                                                   const std::shared_ptr<CPVRTimerInfoTag>& parent = std::shared_ptr<CPVRTimerInfoTag>());
+  /*!
+   * @brief Get the duration of this timer in seconds, excluding padding times.
+   * @return The duration.
+   */
+  int GetDuration() const;
 
-    /*!
-     * @brief Associate the given epg tag with this timer.
-     * @param tag The epg tag to assign.
-     */
-    void SetEpgInfoTag(const std::shared_ptr<CPVREpgInfoTag>& tag);
+  CDateTime FirstDayAsUTC() const;
+  CDateTime FirstDayAsLocalTime() const;
+  void SetFirstDayFromUTC(const CDateTime& firstDay);
+  void SetFirstDayFromLocalTime(const CDateTime& firstDay);
 
-    /*!
-     * @brief get the epg info tag associated with this timer, if any
-     * @param bCreate if true, try to find the epg tag if not yet set (lazy evaluation)
-     * @return the epg info tag associated with this timer or null if there is no tag
-     */
-    std::shared_ptr<CPVREpgInfoTag> GetEpgInfoTag(bool bCreate = true) const;
+  unsigned int MarginStart() const { return m_iMarginStart; }
 
-    std::string ChannelName() const;
-    std::string ChannelIcon() const;
+  /*!
+   * @brief Get the text for the notification.
+   */
+  std::string GetNotificationText() const;
 
-    /*!
-     * @brief Check whether this timer has an associated channel.
-     * @return True if this timer has a channel set, false otherwise.
-     */
-    bool HasChannel() const;
+  /*!
+   * @brief Get the text for the notification when a timer has been deleted
+   */
+  std::string GetDeletedNotificationText() const;
 
-    /*!
-     * @brief Get the channel associated with this timer, if any.
-     * @return the channel or null if non is associated with this timer.
-     */
-    std::shared_ptr<CPVRChannel> Channel() const;
+  const std::string& Title() const;
+  const std::string& Summary() const;
+  const std::string& Path() const;
 
-    /*!
-     * @brief updates this timer excluding the state of any children.
-     * @param tag A timer containing the data that shall be merged into this timer's data.
-     * @return true if the timer was updated successfully
-     */
-    bool UpdateEntry(const std::shared_ptr<CPVRTimerInfoTag>& tag);
+  /*!
+   * @brief The series link for this timer.
+   * @return The series link or empty string, if not available.
+   */
+  const std::string& SeriesLink() const;
 
-    /*!
-     * @brief merge in the state of this child timer.
-     * @param childTimer The child timer
-     * @param bAdd If true, add child's data to parent's state, otherwise subtract.
-     * @return true if the child timer's state was merged successfully
-     */
-    bool UpdateChildState(const std::shared_ptr<CPVRTimerInfoTag>& childTimer, bool bAdd);
+  /*!
+   * @brief Get the UID of the epg event associated with this timer tag, if any.
+   * @return the UID or EPG_TAG_INVALID_UID.
+   */
+  unsigned int UniqueBroadcastID() const { return m_iEpgUid; }
 
-    /*!
-     * @brief reset the state of children related to this timer.
-     */
-    void ResetChildState();
+  /*!
+   * @brief Add this timer to the backend, transferring all local data of this timer to the backend.
+   * @return True on success, false otherwise.
+   */
+  bool AddToClient() const;
 
-    bool IsActive() const
-    {
-      return m_state == PVR_TIMER_STATE_SCHEDULED
-        || m_state == PVR_TIMER_STATE_RECORDING
-        || m_state == PVR_TIMER_STATE_CONFLICT_OK
-        || m_state == PVR_TIMER_STATE_CONFLICT_NOK
-        || m_state == PVR_TIMER_STATE_ERROR;
-    }
+  /*!
+   * @brief Delete this timer on the backend.
+   * @param bForce Control what to do in case the timer is currently recording.
+   *        True to force to delete the timer, false to return TimerDeleteResult::RECORDING.
+   * @return The result.
+   */
+  TimerOperationResult DeleteFromClient(bool bForce = false) const;
 
-    /*!
-     * @return True if this timer won't result in a recording because it is broken for some reason, false otherwise
-     */
-    bool IsBroken() const
-    {
-      return m_state == PVR_TIMER_STATE_CONFLICT_NOK
-        || m_state == PVR_TIMER_STATE_ERROR;
-    }
+  /*!
+   * @brief Update this timer on the backend, transferring all local data of this timer to the backend.
+   * @return True on success, false otherwise.
+   */
+  bool UpdateOnClient();
 
-    /*!
-     * @return True if this timer won't result in a recording because it is in conflict with another timer or live stream, false otherwise
-     */
-    bool HasConflict() const { return m_state == PVR_TIMER_STATE_CONFLICT_NOK; }
+  /*!
+   * @brief Persist this timer in the local database.
+   * @return True on success, false otherwise.
+   */
+  bool Persist();
 
-    bool IsRecording() const { return m_state == PVR_TIMER_STATE_RECORDING; }
+  /*!
+   * @brief Delete this timer from the local database.
+   * @return True on success, false otherwise.
+   */
+  bool DeleteFromDatabase();
 
-    /*!
-      * @brief Gets the type of this timer.
-      * @return the timer type or NULL if this tag has no timer type.
-      */
-    const std::shared_ptr<CPVRTimerType> GetTimerType() const { return m_timerType; }
+  /*!
+   * @brief Update the channel associated with this timer.
+   * @return the channel for the timer. Can be empty for epg based repeating timers (e.g. "match any channel" rules)
+   */
+  std::shared_ptr<CPVRChannel> UpdateChannel();
 
-    /*!
-      * @brief Sets the type of this timer.
-      * @param the new timer type.
-      */
-    void SetTimerType(const std::shared_ptr<CPVRTimerType>& type);
+  /*!
+   * @brief Return string representation for any possible combination of weekdays.
+   * @param iWeekdays weekdays as bit mask (0x01 = Mo, 0x02 = Tu, ...)
+   * @param bEpgBased context is an epg-based timer
+   * @param bLongMultiDaysFormat use long format. ("Mo-__-We-__-Fr-Sa-__" vs. "Mo-We-Fr-Sa")
+   * @return the weekdays string representation
+   */
+  static std::string GetWeekdaysString(unsigned int iWeekdays,
+                                       bool bEpgBased,
+                                       bool bLongMultiDaysFormat);
 
-    /*!
-      * @brief Checks whether this is a timer rule (vs. one time timer).
-      * @return True if this is a timer rule, false otherwise.
-      */
-    bool IsTimerRule() const { return m_timerType && m_timerType->IsTimerRule(); }
+  /*!
+   * @brief For timers scheduled by a timer rule, return the id of the rule (aka the id of the "parent" of the timer).
+   * @return the id of the timer rule or PVR_TIMER_NO_PARENT in case the timer was not scheduled by a timer rule.
+   */
+  int GetTimerRuleId() const { return m_iParentClientIndex; }
 
-    /*!
-     * @brief Checks whether this is a reminder timer (vs. recording timer).
-     * @return True if this is a reminder timer, false otherwise.
-     */
-    bool IsReminder() const { return m_timerType && m_timerType->IsReminder(); }
+  /*!
+   * @brief Check, whether this timer is owned by a pvr client or by Kodi.
+   * @return True, if owned by a pvr client, false otherwise.
+   */
+  bool IsOwnedByClient() const;
 
-    /*!
-      * @brief Checks whether this is a manual (vs. epg-based) timer.
-      * @return True if this is a manual timer, false otherwise.
-      */
-    bool IsManual() const { return m_timerType && m_timerType->IsManual(); }
+  std::string m_strTitle; /*!< @brief name of this timer */
+  std::string
+      m_strEpgSearchString; /*!< @brief a epg data match string for epg-based timer rules. Format is backend-dependent, for example regexp */
+  bool m_bFullTextEpgSearch =
+      false; /*!< @brief indicates whether only epg episode title can be matched by the pvr backend or "more" (backend-dependent") data. */
+  std::string m_strDirectory; /*!< @brief directory where the recording must be stored */
+  std::string m_strSummary; /*!< @brief summary string with the time to show inside a GUI list */
+  PVR_TIMER_STATE m_state = PVR_TIMER_STATE_SCHEDULED; /*!< @brief the state of this timer */
+  int m_iClientId; /*!< @brief ID of the backend */
+  int m_iClientIndex; /*!< @brief index number of the tag, given by the backend, PVR_TIMER_NO_CLIENT_INDEX for new */
+  int m_iParentClientIndex; /*!< @brief for timers scheduled by a timer rule, the index number of the parent, given by the backend, PVR_TIMER_NO_PARENT for no parent */
+  int m_iClientChannelUid; /*!< @brief channel uid */
+  bool m_bStartAnyTime =
+      false; /*!< @brief Ignore start date and time clock. Record at 'Any Time' */
+  bool m_bEndAnyTime = false; /*!< @brief Ignore end date and time clock. Record at 'Any Time' */
+  int m_iPriority; /*!< @brief priority of the timer */
+  int m_iLifetime; /*!< @brief lifetime of the timer in days */
+  int m_iMaxRecordings =
+      0; /*!< @brief (optional) backend setting for maximum number of recordings to keep*/
+  unsigned int m_iWeekdays; /*!< @brief bit based store of weekdays for timer rules */
+  unsigned int
+      m_iPreventDupEpisodes; /*!< @brief only record new episodes for epg-based timer rules */
+  unsigned int m_iRecordingGroup =
+      0; /*!< @brief (optional) if set, the addon/backend stores the recording to a group (sub-folder) */
+  std::string m_strFileNameAndPath; /*!< @brief file name is only for reference */
+  bool m_bIsRadio; /*!< @brief is radio channel if set */
+  unsigned int m_iTimerId = 0; /*!< @brief id that won't change as long as Kodi is running */
+  unsigned int
+      m_iMarginStart; /*!< @brief (optional) if set, the backend starts the recording iMarginStart minutes before startTime. */
+  unsigned int
+      m_iMarginEnd; /*!< @brief (optional) if set, the backend ends the recording iMarginEnd minutes after endTime. */
+  mutable unsigned int
+      m_iEpgUid; /*!< id of epg event associated with this timer, EPG_TAG_INVALID_UID if none. */
+  std::string m_strSeriesLink; /*!< series link */
 
-    /*!
-     * @brief Checks whether this is an epg-based (vs. manual) timer.
-     * @return True if this is an epg-Based timer, false otherwise.
-     */
-    bool IsEpgBased() const { return !IsManual(); }
+private:
+  CPVRTimerInfoTag(const CPVRTimerInfoTag& tag) = delete;
+  CPVRTimerInfoTag& operator=(const CPVRTimerInfoTag& orig) = delete;
 
-    static CDateTime ConvertUTCToLocalTime(const CDateTime& utc);
-    static CDateTime ConvertLocalTimeToUTC(const CDateTime& local);
+  std::string GetWeekdaysString() const;
+  void UpdateEpgInfoTag();
 
-    CDateTime StartAsUTC() const;
-    CDateTime StartAsLocalTime() const;
-    void SetStartFromUTC(const CDateTime& start);
-    void SetStartFromLocalTime(const CDateTime& start);
+  static std::shared_ptr<CPVRTimerInfoTag> CreateFromDate(
+      const std::shared_ptr<CPVRChannel>& channel,
+      const CDateTime& start,
+      int iDuration,
+      bool bCreateReminder,
+      bool bReadOnly);
 
-    CDateTime EndAsUTC() const;
-    CDateTime EndAsLocalTime() const;
-    void SetEndFromUTC(const CDateTime& end);
-    void SetEndFromLocalTime(const CDateTime& end);
+  mutable CCriticalSection m_critSection;
+  CDateTime m_StartTime; /*!< start time */
+  CDateTime m_StopTime; /*!< stop time */
+  CDateTime m_FirstDay; /*!< if it is a manual timer rule the first date it starts */
+  std::shared_ptr<CPVRTimerType> m_timerType; /*!< the type of this timer */
 
-    /*!
-     * @brief Get the duration of this timer in seconds, excluding padding times.
-     * @return The duration.
-     */
-    int GetDuration() const;
+  unsigned int m_iTVChildTimersActive = 0;
+  unsigned int m_iTVChildTimersConflictNOK = 0;
+  unsigned int m_iTVChildTimersRecording = 0;
+  unsigned int m_iTVChildTimersErrors = 0;
+  unsigned int m_iRadioChildTimersActive = 0;
+  unsigned int m_iRadioChildTimersConflictNOK = 0;
+  unsigned int m_iRadioChildTimersRecording = 0;
+  unsigned int m_iRadioChildTimersErrors = 0;
 
-    CDateTime FirstDayAsUTC() const;
-    CDateTime FirstDayAsLocalTime() const;
-    void SetFirstDayFromUTC(const CDateTime& firstDay);
-    void SetFirstDayFromLocalTime(const CDateTime& firstDay);
+  mutable std::shared_ptr<CPVREpgInfoTag> m_epgTag; /*!< epg info tag matching m_iEpgUid. */
+  mutable std::shared_ptr<CPVRChannel> m_channel;
 
-    unsigned int MarginStart() const { return m_iMarginStart; }
-
-    /*!
-     * @brief Get the text for the notification.
-     */
-    std::string GetNotificationText() const;
-
-    /*!
-     * @brief Get the text for the notification when a timer has been deleted
-     */
-    std::string GetDeletedNotificationText() const;
-
-    const std::string& Title() const;
-    const std::string& Summary() const;
-    const std::string& Path() const;
-
-    /*!
-     * @brief The series link for this timer.
-     * @return The series link or empty string, if not available.
-     */
-    const std::string& SeriesLink() const;
-
-    /*!
-     * @brief Get the UID of the epg event associated with this timer tag, if any.
-     * @return the UID or EPG_TAG_INVALID_UID.
-     */
-    unsigned int UniqueBroadcastID() const { return m_iEpgUid; }
-
-    /*!
-     * @brief Add this timer to the backend, transferring all local data of this timer to the backend.
-     * @return True on success, false otherwise.
-     */
-    bool AddToClient() const;
-
-    /*!
-     * @brief Delete this timer on the backend.
-     * @param bForce Control what to do in case the timer is currently recording.
-     *        True to force to delete the timer, false to return TimerDeleteResult::RECORDING.
-     * @return The result.
-     */
-    TimerOperationResult DeleteFromClient(bool bForce = false) const;
-
-    /*!
-     * @brief Update this timer on the backend, transferring all local data of this timer to the backend.
-     * @return True on success, false otherwise.
-     */
-    bool UpdateOnClient();
-
-    /*!
-     * @brief Persist this timer in the local database.
-     * @return True on success, false otherwise.
-     */
-    bool Persist();
-
-    /*!
-     * @brief Delete this timer from the local database.
-     * @return True on success, false otherwise.
-     */
-    bool DeleteFromDatabase();
-
-    /*!
-     * @brief Update the channel associated with this timer.
-     * @return the channel for the timer. Can be empty for epg based repeating timers (e.g. "match any channel" rules)
-     */
-    std::shared_ptr<CPVRChannel> UpdateChannel();
-
-    /*!
-     * @brief Return string representation for any possible combination of weekdays.
-     * @param iWeekdays weekdays as bit mask (0x01 = Mo, 0x02 = Tu, ...)
-     * @param bEpgBased context is an epg-based timer
-     * @param bLongMultiDaysFormat use long format. ("Mo-__-We-__-Fr-Sa-__" vs. "Mo-We-Fr-Sa")
-     * @return the weekdays string representation
-     */
-    static std::string GetWeekdaysString(unsigned int iWeekdays, bool bEpgBased, bool bLongMultiDaysFormat);
-
-    /*!
-     * @brief For timers scheduled by a timer rule, return the id of the rule (aka the id of the "parent" of the timer).
-     * @return the id of the timer rule or PVR_TIMER_NO_PARENT in case the timer was not scheduled by a timer rule.
-     */
-    int GetTimerRuleId() const { return m_iParentClientIndex; }
-
-    /*!
-     * @brief Check, whether this timer is owned by a pvr client or by Kodi.
-     * @return True, if owned by a pvr client, false otherwise.
-     */
-    bool IsOwnedByClient() const;
-
-    std::string m_strTitle; /*!< @brief name of this timer */
-    std::string m_strEpgSearchString; /*!< @brief a epg data match string for epg-based timer rules. Format is backend-dependent, for example regexp */
-    bool m_bFullTextEpgSearch = false; /*!< @brief indicates whether only epg episode title can be matched by the pvr backend or "more" (backend-dependent") data. */
-    std::string m_strDirectory; /*!< @brief directory where the recording must be stored */
-    std::string m_strSummary; /*!< @brief summary string with the time to show inside a GUI list */
-    PVR_TIMER_STATE m_state = PVR_TIMER_STATE_SCHEDULED; /*!< @brief the state of this timer */
-    int m_iClientId; /*!< @brief ID of the backend */
-    int m_iClientIndex; /*!< @brief index number of the tag, given by the backend, PVR_TIMER_NO_CLIENT_INDEX for new */
-    int m_iParentClientIndex; /*!< @brief for timers scheduled by a timer rule, the index number of the parent, given by the backend, PVR_TIMER_NO_PARENT for no parent */
-    int m_iClientChannelUid; /*!< @brief channel uid */
-    bool m_bStartAnyTime = false; /*!< @brief Ignore start date and time clock. Record at 'Any Time' */
-    bool m_bEndAnyTime = false; /*!< @brief Ignore end date and time clock. Record at 'Any Time' */
-    int m_iPriority; /*!< @brief priority of the timer */
-    int m_iLifetime; /*!< @brief lifetime of the timer in days */
-    int m_iMaxRecordings = 0; /*!< @brief (optional) backend setting for maximum number of recordings to keep*/
-    unsigned int m_iWeekdays; /*!< @brief bit based store of weekdays for timer rules */
-    unsigned int m_iPreventDupEpisodes; /*!< @brief only record new episodes for epg-based timer rules */
-    unsigned int m_iRecordingGroup = 0; /*!< @brief (optional) if set, the addon/backend stores the recording to a group (sub-folder) */
-    std::string m_strFileNameAndPath; /*!< @brief file name is only for reference */
-    bool m_bIsRadio; /*!< @brief is radio channel if set */
-    unsigned int m_iTimerId = 0; /*!< @brief id that won't change as long as Kodi is running */
-    unsigned int m_iMarginStart; /*!< @brief (optional) if set, the backend starts the recording iMarginStart minutes before startTime. */
-    unsigned int m_iMarginEnd; /*!< @brief (optional) if set, the backend ends the recording iMarginEnd minutes after endTime. */
-    mutable unsigned int m_iEpgUid; /*!< id of epg event associated with this timer, EPG_TAG_INVALID_UID if none. */
-    std::string m_strSeriesLink; /*!< series link */
-
-  private:
-    CPVRTimerInfoTag(const CPVRTimerInfoTag& tag) = delete;
-    CPVRTimerInfoTag& operator=(const CPVRTimerInfoTag& orig) = delete;
-
-    std::string GetWeekdaysString() const;
-    void UpdateEpgInfoTag();
-
-    static std::shared_ptr<CPVRTimerInfoTag> CreateFromDate(const std::shared_ptr<CPVRChannel>& channel, const CDateTime& start, int iDuration, bool bCreateReminder, bool bReadOnly);
-
-    mutable CCriticalSection m_critSection;
-    CDateTime m_StartTime; /*!< start time */
-    CDateTime m_StopTime; /*!< stop time */
-    CDateTime m_FirstDay; /*!< if it is a manual timer rule the first date it starts */
-    std::shared_ptr<CPVRTimerType> m_timerType; /*!< the type of this timer */
-
-    unsigned int m_iTVChildTimersActive = 0;
-    unsigned int m_iTVChildTimersConflictNOK = 0;
-    unsigned int m_iTVChildTimersRecording = 0;
-    unsigned int m_iTVChildTimersErrors = 0;
-    unsigned int m_iRadioChildTimersActive = 0;
-    unsigned int m_iRadioChildTimersConflictNOK = 0;
-    unsigned int m_iRadioChildTimersRecording = 0;
-    unsigned int m_iRadioChildTimersErrors = 0;
-
-    mutable std::shared_ptr<CPVREpgInfoTag> m_epgTag; /*!< epg info tag matching m_iEpgUid. */
-    mutable std::shared_ptr<CPVRChannel> m_channel;
-
-    mutable bool m_bProbedEpgTag = false;
-  };
-}
+  mutable bool m_bProbedEpgTag = false;
+};
+} // namespace PVR


### PR DESCRIPTION
We need data conversion from add-on API data types to Kodi PVR core data types. Add-on -> Kodi is done in the respective classes (e.g. PVR_RECORDING -> CPVRRecording).

The other direction Kodi -> Add-on is however implemented all in `CPVRClient`. This is error-prone as two files must be edited whenever the Add-on data types get extended and actually it was more than once forgotten to also adapt `CPVRClient`

This PR moves the Kodi -> Add-on conversion functionality away from `CPVRClient`into the respective classes (e.g. recording data conversion functions are now all in CPVRRecording.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish my goal is to keep you constantly busy. ;-) Once more two additional clang-format only commits in this PR.