### PR TITLE
Add CFileUtils::Exists

### DIFF
--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -13,13 +13,13 @@
 #include "GUIUserMessages.h"
 #include "PlayListPlayer.h"
 #include "ServiceBroker.h"
+#include "URL.h"
 #include "application/Application.h"
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPowerHandling.h"
 #include "cores/playercorefactory/PlayerCoreFactory.h"
 #include "filesystem/Directory.h"
 #include "filesystem/DirectoryFactory.h"
-#include "filesystem/File.h"
 #include "filesystem/StackDirectory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
@@ -37,11 +37,12 @@
 #include "storage/DetectDVDType.h"
 #endif
 #include "storage/MediaManager.h"
-#include "video/VideoDatabase.h"
+#include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
-#include "utils/log.h"
 #include "utils/Variant.h"
+#include "utils/log.h"
+#include "video/VideoDatabase.h"
 
 #ifdef HAS_CDDA_RIPPER
 #include "cdrip/CDDARipper.h"
@@ -190,7 +191,7 @@ bool CAutorun::RunDisc(IDirectory* pDir, const std::string& strDrive, int& nAdde
         && (bypassSettings || bAutorunDVDs))
         {
           std::string path = URIUtils::AddFileToFolder(pItem->GetPath(), "VIDEO_TS.IFO");
-          if(!CFile::Exists(path))
+          if (!CFileUtils::Exists(path))
             path = URIUtils::AddFileToFolder(pItem->GetPath(), "video_ts.ifo");
           CFileItemPtr item(new CFileItem(path, false));
           item->SetLabel(CServiceBroker::GetMediaManager().GetDiskLabel(strDrive));

--- a/xbmc/DynamicDll.cpp
+++ b/xbmc/DynamicDll.cpp
@@ -9,10 +9,8 @@
 #include "DynamicDll.h"
 
 #include "SectionLoader.h"
-#include "filesystem/File.h"
+#include "utils/FileUtils.h"
 #include "utils/log.h"
-
-using namespace XFILE;
 
 DllDynamic::DllDynamic()
 {
@@ -59,7 +57,7 @@ void DllDynamic::Unload()
 
 bool DllDynamic::CanLoad()
 {
-  return CFile::Exists(m_strDllName);
+  return CFileUtils::Exists(m_strDllName);
 }
 
 bool DllDynamic::EnableDelayedUnload(bool bOnOff)

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -15,7 +15,6 @@
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPlayer.h"
 #include "cores/DataCacheCore.h"
-#include "filesystem/File.h"
 #include "guilib/guiinfo/GUIInfo.h"
 #include "guilib/guiinfo/GUIInfoHelper.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
@@ -26,6 +25,7 @@
 #include "playlists/PlayListTypes.h"
 #include "settings/SkinSettings.h"
 #include "utils/CharsetConverter.h"
+#include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -11016,7 +11016,7 @@ void CGUIInfoManager::SetCurrentItem(const CFileItem &item)
 
 void CGUIInfoManager::SetCurrentAlbumThumb(const std::string &thumbFileName)
 {
-  if (XFILE::CFile::Exists(thumbFileName))
+  if (CFileUtils::Exists(thumbFileName))
     m_currentFile->SetArt("thumb", thumbFileName);
   else
   {

--- a/xbmc/InfoScanner.cpp
+++ b/xbmc/InfoScanner.cpp
@@ -9,7 +9,7 @@
 #include "InfoScanner.h"
 
 #include "URL.h"
-#include "filesystem/File.h"
+#include "utils/FileUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
@@ -17,7 +17,7 @@ bool CInfoScanner::HasNoMedia(const std::string &strDirectory) const
 {
   std::string noMediaFile = URIUtils::AddFileToFolder(strDirectory, ".nomedia");
 
-  if (!URIUtils::IsPlugin(strDirectory) && XFILE::CFile::Exists(noMediaFile))
+  if (!URIUtils::IsPlugin(strDirectory) && CFileUtils::Exists(noMediaFile))
   {
     CLog::Log(LOGWARNING,
               "Skipping item '{}' with '.nomedia' file in parent directory, it won't be added to "

--- a/xbmc/PasswordManager.cpp
+++ b/xbmc/PasswordManager.cpp
@@ -10,10 +10,10 @@
 
 #include "ServiceBroker.h"
 #include "URL.h"
-#include "filesystem/File.h"
 #include "profiles/ProfileManager.h"
 #include "profiles/dialogs/GUIDialogLockSettings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
@@ -143,7 +143,7 @@ void CPasswordManager::Load()
   const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
   std::string passwordsFile = profileManager->GetUserDataItem("passwords.xml");
-  if (XFILE::CFile::Exists(passwordsFile))
+  if (CFileUtils::Exists(passwordsFile))
   {
     CXBMCTinyXML doc;
     if (!doc.LoadFile(passwordsFile))

--- a/xbmc/ThumbLoader.cpp
+++ b/xbmc/ThumbLoader.cpp
@@ -11,9 +11,7 @@
 #include "FileItem.h"
 #include "ServiceBroker.h"
 #include "TextureCache.h"
-#include "filesystem/File.h"
-
-using namespace XFILE;
+#include "utils/FileUtils.h"
 
 CThumbLoader::CThumbLoader() :
   CBackgroundInfoLoader()
@@ -114,13 +112,13 @@ std::string CProgramThumbLoader::GetLocalThumb(const CFileItem &item)
   if (item.m_bIsFolder)
   {
     std::string folderThumb = item.GetFolderThumb();
-    if (CFile::Exists(folderThumb))
+    if (CFileUtils::Exists(folderThumb))
       return folderThumb;
   }
   else
   {
     std::string fileThumb(item.GetTBNFile());
-    if (CFile::Exists(fileThumb))
+    if (CFileUtils::Exists(fileThumb))
       return fileThumb;
   }
   return "";

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -24,8 +24,8 @@
 #include "events/EventLog.h"
 #include "events/NotificationEvent.h"
 #include "filesystem/Directory.h"
-#include "filesystem/File.h"
 #include "filesystem/SpecialProtocol.h"
+#include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/XMLUtils.h"
@@ -1277,7 +1277,7 @@ void CAddonMgr::FindAddons(ADDON_INFO_LIST& addonmap, const std::string& path)
     for (int i = 0; i < items.Size(); ++i)
     {
       std::string path = items[i]->GetPath();
-      if (XFILE::CFile::Exists(path + "addon.xml"))
+      if (CFileUtils::Exists(path + "addon.xml"))
       {
         AddonInfoPtr addonInfo = CAddonInfoBuilder::Generate(path);
         if (addonInfo)

--- a/xbmc/addons/FontResource.cpp
+++ b/xbmc/addons/FontResource.cpp
@@ -10,15 +10,11 @@
 #include "AddonManager.h"
 #include "ServiceBroker.h"
 #include "addons/addoninfo/AddonInfo.h"
-#include "filesystem/File.h"
 #include "filesystem/SpecialProtocol.h"
-#include "guilib/GUIWindowManager.h"
 #include "messaging/ApplicationMessenger.h"
-#include "messaging/helpers/DialogHelper.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-
-using namespace XFILE;
+#include "utils/FileUtils.h"
 
 namespace ADDON
 {
@@ -37,7 +33,7 @@ void CFontResource::OnPostInstall(bool update, bool modal)
 bool CFontResource::GetFont(const std::string& file, std::string& path) const
 {
   std::string result = CSpecialProtocol::TranslatePathConvertCase(Path()+"/resources/"+file);
-  if (CFile::Exists(result))
+  if (CFileUtils::Exists(result))
   {
     path = result;
     return true;

--- a/xbmc/addons/ImageResource.cpp
+++ b/xbmc/addons/ImageResource.cpp
@@ -8,8 +8,8 @@
 #include "ImageResource.h"
 
 #include "URL.h"
-#include "filesystem/File.h"
 #include "filesystem/XbtManager.h"
+#include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 
@@ -59,7 +59,7 @@ bool CImageResource::HasXbt(CURL& xbtUrl) const
 {
   std::string resourcePath = GetResourcePath();
   std::string xbtPath = URIUtils::AddFileToFolder(resourcePath, "Textures.xbt");
-  if (!XFILE::CFile::Exists(xbtPath))
+  if (!CFileUtils::Exists(xbtPath))
     return false;
 
   // translate it into a xbt:// URL

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -14,7 +14,6 @@
 #include "dialogs/GUIDialogKaiToast.h"
 // fallback for new skin resolution code
 #include "filesystem/Directory.h"
-#include "filesystem/File.h"
 #include "filesystem/SpecialProtocol.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
@@ -27,6 +26,7 @@
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingDefinitions.h"
 #include "threads/Timer.h"
+#include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
@@ -261,7 +261,7 @@ std::string CSkinInfo::GetSkinPath(const std::string& strFile, RESOLUTION_INFO *
   *res = *std::min_element(m_resolutions.begin(), m_resolutions.end(), closestRes(target));
 
   std::string strPath = URIUtils::AddFileToFolder(strPathToUse, res->strMode, strFile);
-  if (CFile::Exists(strPath))
+  if (CFileUtils::Exists(strPath))
     return strPath;
 
   // use the default resolution
@@ -272,7 +272,7 @@ std::string CSkinInfo::GetSkinPath(const std::string& strFile, RESOLUTION_INFO *
 
 bool CSkinInfo::HasSkinFile(const std::string &strFile) const
 {
-  return CFile::Exists(GetSkinPath(strFile));
+  return CFileUtils::Exists(GetSkinPath(strFile));
 }
 
 void CSkinInfo::LoadIncludes()

--- a/xbmc/addons/interfaces/gui/Window.cpp
+++ b/xbmc/addons/interfaces/gui/Window.cpp
@@ -18,13 +18,13 @@
 #include "addons/binary-addons/AddonDll.h"
 #include "application/Application.h"
 #include "controls/Rendering.h"
-#include "filesystem/File.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIRenderingControl.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/TextureManager.h"
 #include "input/Key.h"
 #include "messaging/ApplicationMessenger.h"
+#include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
@@ -134,7 +134,7 @@ KODI_GUI_WINDOW_HANDLE Interface_GUIWindow::create(KODI_HANDLE kodiBase,
   RESOLUTION_INFO res;
   std::string strSkinPath = g_SkinInfo->GetSkinPath(xml_filename, &res);
 
-  if (!XFILE::CFile::Exists(strSkinPath))
+  if (!CFileUtils::Exists(strSkinPath))
   {
     std::string str("none");
     ADDON::AddonInfoPtr addonInfo = std::make_shared<ADDON::CAddonInfo>(str, ADDON::ADDON_SKIN);
@@ -146,7 +146,7 @@ KODI_GUI_WINDOW_HANDLE Interface_GUIWindow::create(KODI_HANDLE kodiBase,
     strSkinPath = g_SkinInfo->GetSkinPath(xml_filename, &res, basePath);
 
     // Check for the matching folder for the skin in the fallback skins folder (if it exists)
-    if (XFILE::CFile::Exists(basePath))
+    if (CFileUtils::Exists(basePath))
     {
       addonInfo->SetPath(basePath);
       const std::shared_ptr<ADDON::CSkinInfo> skinInfo =
@@ -155,7 +155,7 @@ KODI_GUI_WINDOW_HANDLE Interface_GUIWindow::create(KODI_HANDLE kodiBase,
       strSkinPath = skinInfo->GetSkinPath(xml_filename, &res);
     }
 
-    if (!XFILE::CFile::Exists(strSkinPath))
+    if (!CFileUtils::Exists(strSkinPath))
     {
       // Finally fallback to the DefaultSkin as it didn't exist in either the Kodi Skin folder or the fallback skin folder
       addonInfo->SetPath(URIUtils::AddFileToFolder(fallbackPath, default_skin));
@@ -164,7 +164,7 @@ KODI_GUI_WINDOW_HANDLE Interface_GUIWindow::create(KODI_HANDLE kodiBase,
 
       skinInfo->Start();
       strSkinPath = skinInfo->GetSkinPath(xml_filename, &res);
-      if (!XFILE::CFile::Exists(strSkinPath))
+      if (!CFileUtils::Exists(strSkinPath))
       {
         CLog::Log(LOGERROR,
                   "Interface_GUIWindow::{}: {}/{} - XML File '{}' for Window is missing, contact "

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -27,9 +27,9 @@
 #include "addons/AddonManager.h"
 #include "cores/VideoPlayer/Interface/InputStreamConstants.h"
 #include "filesystem/CurlFile.h"
-#include "filesystem/File.h"
 #include "filesystem/IFileTypes.h"
 #include "storage/MediaManager.h"
+#include "utils/FileUtils.h"
 #include "utils/URIUtils.h"
 
 
@@ -74,11 +74,11 @@ std::shared_ptr<CDVDInputStream> CDVDFactoryInputStream::CreateInputStream(IVide
     CURL url("udf://");
     url.SetHostName(file);
     url.SetFileName("BDMV/index.bdmv");
-    if(XFILE::CFile::Exists(url.Get()))
+    if (CFileUtils::Exists(url.Get()))
       return std::shared_ptr<CDVDInputStreamBluray>(new CDVDInputStreamBluray(pPlayer, fileitem));
     url.SetHostName(file);
     url.SetFileName("BDMV/INDEX.BDM");
-    if (XFILE::CFile::Exists(url.Get()))
+    if (CFileUtils::Exists(url.Get()))
       return std::shared_ptr<CDVDInputStreamBluray>(new CDVDInputStreamBluray(pPlayer, fileitem));
 #endif
 
@@ -89,8 +89,8 @@ std::shared_ptr<CDVDInputStream> CDVDFactoryInputStream::CreateInputStream(IVide
   if (file.compare(CServiceBroker::GetMediaManager().TranslateDevicePath("")) == 0)
   {
 #ifdef HAVE_LIBBLURAY
-    if(XFILE::CFile::Exists(URIUtils::AddFileToFolder(file, "BDMV", "index.bdmv"))
-            || XFILE::CFile::Exists(URIUtils::AddFileToFolder(file, "BDMV", "INDEX.BDM")))
+    if (CFileUtils::Exists(URIUtils::AddFileToFolder(file, "BDMV", "index.bdmv")) ||
+        CFileUtils::Exists(URIUtils::AddFileToFolder(file, "BDMV", "INDEX.BDM")))
       return std::shared_ptr<CDVDInputStreamBluray>(new CDVDInputStreamBluray(pPlayer, fileitem));
 #endif
 

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
@@ -14,15 +14,14 @@
 #include "URL.h"
 #include "cores/IPlayerCallback.h"
 #include "cores/VideoPlayer/Interface/InputStreamConstants.h"
-#include "cores/paplayer/PAPlayer.h"
 #include "dialogs/GUIDialogContextMenu.h"
-#include "filesystem/File.h"
 #include "guilib/LocalizeStrings.h"
 #include "profiles/ProfileManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/SettingsManager.h"
+#include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
@@ -319,7 +318,7 @@ bool CPlayerCoreFactory::LoadConfiguration(const std::string &file, bool clear)
   std::unique_lock<CCriticalSection> lock(m_section);
 
   CLog::Log(LOGINFO, "Loading player core factory settings from {}.", file);
-  if (!XFILE::CFile::Exists(file))
+  if (!CFileUtils::Exists(file))
   { // tell the user it doesn't exist
     CLog::Log(LOGINFO, "{} does not exist. Skipping.", file);
     return false;

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -15,12 +15,11 @@
 #include "GUIPassword.h"
 #include "GUIUserMessages.h"
 #include "ServiceBroker.h"
-#include "TextureCache.h"
+#include "TextureDatabase.h"
 #include "URL.h"
 #include "Util.h"
 #include "addons/Scraper.h"
 #include "favourites/FavouritesService.h"
-#include "filesystem/File.h"
 #include "guilib/GUIButtonControl.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIControlGroupList.h"
@@ -34,6 +33,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
+#include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
@@ -384,7 +384,7 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
       }
       // see if there's a local thumb for this item
       std::string folderThumb = item->GetFolderThumb();
-      if (XFILE::CFile::Exists(folderThumb))
+      if (CFileUtils::Exists(folderThumb))
       {
         CFileItemPtr local(new CFileItem("thumb://Local", false));
         local->SetArt("thumb", folderThumb);

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -32,8 +32,9 @@
 #include "pvr/recordings/PVRRecordingsPath.h"
 
 #if defined(TARGET_ANDROID)
+#include "utils/FileUtils.h"
+
 #include "platform/android/activity/XBMCApp.h"
-#include "filesystem/File.h"
 #endif
 
 #ifdef TARGET_WINDOWS_STORE
@@ -300,7 +301,7 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
 #if defined(TARGET_ANDROID)
     // add the default android video directory
     std::string path;
-    if (CXBMCApp::GetExternalStorage(path, "videos") && !path.empty() && CFile::Exists(path))
+    if (CXBMCApp::GetExternalStorage(path, "videos") && !path.empty() && CFileUtils::Exists(path))
     {
       share1.strPath = path;
       share1.strName = g_localizeStrings.Get(20241);
@@ -346,7 +347,7 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
 #if defined(TARGET_ANDROID)
     // add the default android music directory
     std::string path;
-    if (CXBMCApp::GetExternalStorage(path, "pictures") && !path.empty() && CFile::Exists(path))
+    if (CXBMCApp::GetExternalStorage(path, "pictures") && !path.empty() && CFileUtils::Exists(path))
     {
       share1.strPath = path;
       share1.strName = g_localizeStrings.Get(20242);
@@ -355,7 +356,7 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
     }
 
     path.clear();
-    if (CXBMCApp::GetExternalStorage(path, "photos") && !path.empty() && CFile::Exists(path))
+    if (CXBMCApp::GetExternalStorage(path, "photos") && !path.empty() && CFileUtils::Exists(path))
     {
       share1.strPath = path;
       share1.strName = g_localizeStrings.Get(20243);

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -15,13 +15,13 @@
 #include "URL.h"
 #include "dialogs/GUIDialogBusy.h"
 #include "filesystem/Directory.h"
-#include "filesystem/File.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "settings/DiscSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "threads/IRunnable.h"
+#include "utils/FileUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
@@ -72,7 +72,7 @@ bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item)
     CURL url2("udf://");
     url2.SetHostName(item.GetDynPath());
     url2.SetFileName("BDMV/index.bdmv");
-    if (XFILE::CFile::Exists(url2.Get()))
+    if (CFileUtils::Exists(url2.Get()))
     {
       url2.SetFileName("");
 

--- a/xbmc/favourites/FavouritesService.cpp
+++ b/xbmc/favourites/FavouritesService.cpp
@@ -13,10 +13,10 @@
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "Util.h"
-#include "filesystem/File.h"
 #include "profiles/ProfileManager.h"
 #include "settings/SettingsComponent.h"
 #include "utils/ContentUtils.h"
+#include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/XBMCTinyXML.h"
@@ -150,13 +150,13 @@ void CFavouritesService::ReInit(std::string userDataFolder)
   m_favourites.SetContent("favourites");
 
   std::string favourites = "special://xbmc/system/favourites.xml";
-  if (XFILE::CFile::Exists(favourites))
+  if (CFileUtils::Exists(favourites))
     LoadFromFile(favourites, m_favourites);
   else
     CLog::Log(LOGDEBUG, "CFavourites::Load - no system favourites found, skipping");
 
   favourites = URIUtils::AddFileToFolder(m_userDataFolder, "favourites.xml");
-  if (XFILE::CFile::Exists(favourites))
+  if (CFileUtils::Exists(favourites))
     LoadFromFile(favourites, m_favourites);
   else
     CLog::Log(LOGDEBUG, "CFavourites::Load - no userdata favourites found, skipping");

--- a/xbmc/filesystem/FavouritesDirectory.cpp
+++ b/xbmc/filesystem/FavouritesDirectory.cpp
@@ -9,10 +9,11 @@
 #include "FavouritesDirectory.h"
 
 #include "Directory.h"
-#include "File.h"
 #include "ServiceBroker.h"
+#include "URL.h"
 #include "favourites/FavouritesService.h"
 #include "profiles/ProfileManager.h"
+#include "utils/FileUtils.h"
 #include "utils/URIUtils.h"
 
 namespace XFILE
@@ -29,12 +30,12 @@ bool CFavouritesDirectory::Exists(const CURL& url)
 {
   if (url.IsProtocol("favourites"))
   {
-    if (XFILE::CFile::Exists("special://xbmc/system/favourites.xml"))
+    if (CFileUtils::Exists("special://xbmc/system/favourites.xml"))
       return true;
 
     const std::string favouritesXml = URIUtils::AddFileToFolder(m_profileManager->GetProfileUserDataFolder(), "favourites.xml");
 
-    return XFILE::CFile::Exists(favouritesXml);
+    return CFileUtils::Exists(favouritesXml);
   }
 
   return XFILE::CDirectory::Exists(url);

--- a/xbmc/filesystem/LibraryDirectory.cpp
+++ b/xbmc/filesystem/LibraryDirectory.cpp
@@ -9,7 +9,6 @@
 #include "LibraryDirectory.h"
 
 #include "Directory.h"
-#include "File.h"
 #include "FileItem.h"
 #include "GUIInfoManager.h"
 #include "SmartPlaylistDirectory.h"
@@ -18,6 +17,7 @@
 #include "guilib/TextureManager.h"
 #include "playlists/SmartPlayList.h"
 #include "profiles/ProfileManager.h"
+#include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/XMLUtils.h"
@@ -134,7 +134,7 @@ bool CLibraryDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
 TiXmlElement *CLibraryDirectory::LoadXML(const std::string &xmlFile)
 {
-  if (!CFile::Exists(xmlFile))
+  if (!CFileUtils::Exists(xmlFile))
     return nullptr;
 
   if (!m_doc.LoadFile(xmlFile))
@@ -175,7 +175,7 @@ std::string CLibraryDirectory::GetNode(const CURL& url)
   std::string xmlNode = libDir;
   URIUtils::RemoveSlashAtEnd(xmlNode);
 
-  if (CFile::Exists(xmlNode))
+  if (CFileUtils::Exists(xmlNode))
     return xmlNode;
 
   return "";

--- a/xbmc/filesystem/SourcesDirectory.cpp
+++ b/xbmc/filesystem/SourcesDirectory.cpp
@@ -8,7 +8,6 @@
 
 #include "SourcesDirectory.h"
 
-#include "File.h"
 #include "FileItem.h"
 #include "ServiceBroker.h"
 #include "URL.h"
@@ -18,6 +17,7 @@
 #include "profiles/ProfileManager.h"
 #include "settings/MediaSourceSettings.h"
 #include "storage/MediaManager.h"
+#include "utils/FileUtils.h"
 #include "utils/URIUtils.h"
 
 using namespace XFILE;
@@ -60,7 +60,7 @@ bool CSourcesDirectory::GetDirectory(const VECSOURCES &sources, CFileItemList &i
       CUtil::GetDVDDriveIcon( pItem->GetPath(), strIcon );
       // CDetectDVDMedia::SetNewDVDShareUrl() caches disc thumb as special://temp/dvdicon.tbn
       std::string strThumb = "special://temp/dvdicon.tbn";
-      if (XFILE::CFile::Exists(strThumb))
+      if (CFileUtils::Exists(strThumb))
         pItem->SetArt("thumb", strThumb);
     }
     else if (URIUtils::IsProtocol(pItem->GetPath(), "addons"))

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -19,7 +19,6 @@
 #include "addons/BinaryAddonCache.h"
 #include "addons/addoninfo/AddonInfo.h"
 #include "filesystem/Directory.h"
-#include "filesystem/File.h"
 #include "filesystem/SpecialProtocol.h"
 #include "games/GameServices.h"
 #include "games/addons/cheevos/GameClientCheevos.h"
@@ -33,6 +32,7 @@
 #include "input/actions/ActionIDs.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -200,7 +200,7 @@ bool CGameClient::OpenFile(const CFileItem& file,
     return false;
 
   // Some cores "succeed" to load the file even if it doesn't exist
-  if (!XFILE::CFile::Exists(file.GetPath()))
+  if (!CFileUtils::Exists(file.GetPath()))
   {
 
     // Failed to play game

--- a/xbmc/games/ports/input/PortManager.cpp
+++ b/xbmc/games/ports/input/PortManager.cpp
@@ -9,11 +9,11 @@
 #include "PortManager.h"
 
 #include "URL.h"
-#include "filesystem/File.h"
 #include "games/controllers/Controller.h"
 #include "games/controllers/types/ControllerHub.h"
 #include "games/controllers/types/ControllerNode.h"
 #include "games/ports/types/PortNode.h"
+#include "utils/FileUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/XBMCTinyXML.h"
 #include "utils/XMLUtils.h"
@@ -59,7 +59,7 @@ void CPortManager::SetControllerTree(const CControllerTree& controllerTree)
 
 void CPortManager::LoadXML()
 {
-  if (!XFILE::CFile::Exists(m_xmlPath))
+  if (!CFileUtils::Exists(m_xmlPath))
   {
     CLog::Log(LOGDEBUG, "Can't load port config, file doesn't exist: {}", m_xmlPath);
     return;

--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -26,9 +26,9 @@
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "filesystem/Directory.h"
-#include "filesystem/File.h"
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingDefinitions.h"
+#include "utils/FileUtils.h"
 #include "utils/FontUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -50,7 +50,7 @@ constexpr const char* XML_FONTCACHE_FILENAME = "fontcache.xml";
 
 bool LoadXMLData(const std::string& filepath, CXBMCTinyXML& xmlDoc)
 {
-  if (!XFILE::CFile::Exists(filepath))
+  if (!CFileUtils::Exists(filepath))
   {
     CLog::LogF(LOGDEBUG, "Couldn't load '{}' the file don't exists", filepath);
     return false;
@@ -110,7 +110,7 @@ void GUIFontManager::RescaleFontSizeAndAspect(CGraphicContext& context,
 
 static bool CheckFont(std::string& strPath, const std::string& newPath, const std::string& filename)
 {
-  if (!XFILE::CFile::Exists(strPath))
+  if (!CFileUtils::Exists(strPath))
   {
     strPath = URIUtils::AddFileToFolder(newPath, filename);
 #ifdef TARGET_POSIX

--- a/xbmc/guilib/guiinfo/LibraryGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/LibraryGUIInfo.cpp
@@ -10,14 +10,15 @@
 
 #include "FileItem.h"
 #include "ServiceBroker.h"
+#include "URL.h"
 #include "filesystem/Directory.h"
-#include "filesystem/File.h"
 #include "guilib/guiinfo/GUIInfo.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
 #include "music/MusicDatabase.h"
 #include "music/MusicLibraryQueue.h"
 #include "profiles/ProfileManager.h"
 #include "settings/SettingsComponent.h"
+#include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "video/VideoDatabase.h"
@@ -264,7 +265,7 @@ bool CLibraryGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contex
 
       std::string nodePath = URIUtils::AddFileToFolder(libDir, url.GetHostName() + "/");
       nodePath = URIUtils::AddFileToFolder(nodePath, url.GetFileName());
-      value = XFILE::CFile::Exists(nodePath);
+      value = CFileUtils::Exists(nodePath);
       return true;
     }
     case LIBRARY_IS_SCANNING:

--- a/xbmc/input/IRTranslator.cpp
+++ b/xbmc/input/IRTranslator.cpp
@@ -9,10 +9,10 @@
 #include "IRTranslator.h"
 
 #include "ServiceBroker.h"
-#include "filesystem/File.h"
 #include "input/remote/IRRemote.h"
 #include "profiles/ProfileManager.h"
 #include "settings/SettingsComponent.h"
+#include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/XBMCTinyXML.h"
@@ -31,14 +31,14 @@ void CIRTranslator::Load(const std::string& irMapName)
   bool success = false;
 
   std::string irMapPath = URIUtils::AddFileToFolder("special://xbmc/system/", irMapName);
-  if (XFILE::CFile::Exists(irMapPath))
+  if (CFileUtils::Exists(irMapPath))
     success |= LoadIRMap(irMapPath);
   else
     CLog::Log(LOGDEBUG, "CIRTranslator::Load - no system {} found, skipping", irMapName);
 
   irMapPath =
       CServiceBroker::GetSettingsComponent()->GetProfileManager()->GetUserDataItem(irMapName);
-  if (XFILE::CFile::Exists(irMapPath))
+  if (CFileUtils::Exists(irMapPath))
     success |= LoadIRMap(irMapPath);
   else
     CLog::Log(LOGDEBUG, "CIRTranslator::Load - no userdata {} found, skipping", irMapName);

--- a/xbmc/interfaces/generic/ScriptInvocationManager.cpp
+++ b/xbmc/interfaces/generic/ScriptInvocationManager.cpp
@@ -8,10 +8,10 @@
 
 #include "ScriptInvocationManager.h"
 
-#include "filesystem/File.h"
 #include "interfaces/generic/ILanguageInvocationHandler.h"
 #include "interfaces/generic/ILanguageInvoker.h"
 #include "interfaces/generic/LanguageInvokerThread.h"
+#include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/XTimeUtils.h"
@@ -21,8 +21,6 @@
 #include <mutex>
 #include <utility>
 #include <vector>
-
-using namespace XFILE;
 
 CScriptInvocationManager::~CScriptInvocationManager()
 {
@@ -228,7 +226,7 @@ int CScriptInvocationManager::ExecuteAsync(
   if (script.empty())
     return -1;
 
-  if (!CFile::Exists(script, false))
+  if (!CFileUtils::Exists(script, false))
   {
     CLog::Log(LOGERROR, "{} - Not executing non-existing script {}", __FUNCTION__, script);
     return -1;
@@ -249,7 +247,7 @@ int CScriptInvocationManager::ExecuteAsync(
   if (script.empty() || languageInvoker == NULL)
     return -1;
 
-  if (!CFile::Exists(script, false))
+  if (!CFileUtils::Exists(script, false))
   {
     CLog::Log(LOGERROR, "{} - Not executing non-existing script {}", __FUNCTION__, script);
     return -1;
@@ -302,7 +300,7 @@ int CScriptInvocationManager::ExecuteSync(
   if (script.empty())
     return -1;
 
-  if (!CFile::Exists(script, false))
+  if (!CFileUtils::Exists(script, false))
   {
     CLog::Log(LOGERROR, "{} - Not executing non-existing script {}", __FUNCTION__, script);
     return -1;

--- a/xbmc/interfaces/json-rpc/AddonsOperations.cpp
+++ b/xbmc/interfaces/json-rpc/AddonsOperations.cpp
@@ -15,14 +15,13 @@
 #include "addons/AddonManager.h"
 #include "addons/PluginSource.h"
 #include "addons/addoninfo/AddonInfo.h"
-#include "filesystem/File.h"
 #include "messaging/ApplicationMessenger.h"
+#include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 
 using namespace JSONRPC;
 using namespace ADDON;
-using namespace XFILE;
 
 JSONRPC_STATUS CAddonsOperations::GetAddons(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
@@ -302,7 +301,7 @@ void CAddonsOperations::FillDetails(const std::shared_ptr<ADDON::IAddon>& addon,
       // holds where the art will be, not whether it exists.
       bool needsRecaching;
       std::string image = CServiceBroker::GetTextureCache()->CheckCachedImage(url, needsRecaching);
-      if (!image.empty() || CFile::Exists(url))
+      if (!image.empty() || CFileUtils::Exists(url))
         object[field] = CTextureUtils::GetWrappedImageURL(url);
       else
         object[field] = "";

--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -16,7 +16,6 @@
 #include "VideoLibrary.h"
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_epg.h" // EPG_TAG_INVALID_UID
 #include "filesystem/Directory.h"
-#include "filesystem/File.h"
 #include "music/MusicThumbLoader.h"
 #include "music/tags/MusicInfoTag.h"
 #include "pictures/PictureInfoTag.h"
@@ -28,6 +27,7 @@
 #include "pvr/recordings/PVRRecordings.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "pvr/timers/PVRTimers.h"
+#include "utils/FileUtils.h"
 #include "utils/ISerializable.h"
 #include "utils/SortUtils.h"
 #include "utils/URIUtils.h"
@@ -508,7 +508,8 @@ bool CFileItemHandler::FillFileItemList(const CVariant &parameterObject, CFileIt
   CFileOperations::FillFileItemList(parameterObject, list);
 
   std::string file = parameterObject["file"].asString();
-  if (!file.empty() && (URIUtils::IsURL(file) || (CFile::Exists(file) && !CDirectory::Exists(file))))
+  if (!file.empty() &&
+      (URIUtils::IsURL(file) || (CFileUtils::Exists(file) && !CDirectory::Exists(file))))
   {
     bool added = false;
     for (int index = 0; index < list.Size(); index++)

--- a/xbmc/interfaces/json-rpc/FileOperations.cpp
+++ b/xbmc/interfaces/json-rpc/FileOperations.cpp
@@ -16,7 +16,6 @@
 #include "Util.h"
 #include "VideoLibrary.h"
 #include "filesystem/Directory.h"
-#include "filesystem/File.h"
 #include "media/MediaLockState.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSourceSettings.h"
@@ -169,7 +168,7 @@ JSONRPC_STATUS CFileOperations::GetDirectory(const std::string &method, ITranspo
 JSONRPC_STATUS CFileOperations::GetFileDetails(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
   std::string file = parameterObject["file"].asString();
-  if (!CFile::Exists(file))
+  if (!CFileUtils::Exists(file))
     return InvalidParams;
 
   if (!CFileUtils::RemoteAccessAllowed(file))
@@ -225,7 +224,7 @@ JSONRPC_STATUS CFileOperations::SetFileDetails(const std::string &method, ITrans
     return InvalidParams;
 
   std::string file = parameterObject["file"].asString();
-  if (!CFile::Exists(file))
+  if (!CFileUtils::Exists(file))
     return InvalidParams;
 
   if (!CFileUtils::RemoteAccessAllowed(file))
@@ -298,7 +297,7 @@ bool CFileOperations::FillFileItem(
 
   bool status = false;
   std::string strFilename = originalItem->GetPath();
-  if (!strFilename.empty() && (CDirectory::Exists(strFilename) || CFile::Exists(strFilename)))
+  if (!strFilename.empty() && (CDirectory::Exists(strFilename) || CFileUtils::Exists(strFilename)))
   {
     if (media == "video")
       status = CVideoLibrary::FillFileItem(strFilename, item, parameterObject);

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -21,7 +21,6 @@
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPowerHandling.h"
 #include "cores/AudioEngine/Interfaces/AE.h"
-#include "filesystem/File.h"
 #include "guilib/GUIAudioManager.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
@@ -38,6 +37,7 @@
 #include "threads/SystemClock.h"
 #include "utils/Crc32.h"
 #include "utils/FileExtensionProvider.h"
+#include "utils/FileUtils.h"
 #include "utils/LangCodeExpander.h"
 #include "utils/MemUtils.h"
 #include "utils/StringUtils.h"
@@ -325,7 +325,7 @@ namespace XBMCAddon
         return;
 
       CGUIComponent* gui = CServiceBroker::GetGUI();
-      if (XFILE::CFile::Exists(filename) && gui)
+      if (CFileUtils::Exists(filename) && gui)
       {
         gui->GetAudioManager().PlayPythonSound(filename,useCached);
       }

--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -14,10 +14,10 @@
 #include "addons/Addon.h"
 #include "addons/Skin.h"
 #include "addons/addoninfo/AddonInfo.h"
-#include "filesystem/File.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/TextureManager.h"
+#include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 
@@ -99,7 +99,7 @@ namespace XBMCAddon
       std::string strSkinPath = g_SkinInfo->GetSkinPath(xmlFilename, &res);
       m_isMedia = isMedia;
 
-      if (!XFILE::CFile::Exists(strSkinPath))
+      if (!CFileUtils::Exists(strSkinPath))
       {
         std::string str("none");
         ADDON::AddonInfoPtr addonInfo = std::make_shared<ADDON::CAddonInfo>(str, ADDON::ADDON_SKIN);
@@ -112,7 +112,7 @@ namespace XBMCAddon
         strSkinPath = g_SkinInfo->GetSkinPath(xmlFilename, &res, basePath);
 
         // Check for the matching folder for the skin in the fallback skins folder (if it exists)
-        if (XFILE::CFile::Exists(basePath))
+        if (CFileUtils::Exists(basePath))
         {
           addonInfo->SetPath(basePath);
           std::shared_ptr<ADDON::CSkinInfo> skinInfo = std::make_shared<ADDON::CSkinInfo>(addonInfo, res);
@@ -120,7 +120,7 @@ namespace XBMCAddon
           strSkinPath = skinInfo->GetSkinPath(xmlFilename, &res);
         }
 
-        if (!XFILE::CFile::Exists(strSkinPath))
+        if (!CFileUtils::Exists(strSkinPath))
         {
           // Finally fallback to the DefaultSkin as it didn't exist in either the XBMC Skin folder or the fallback skin folder
           addonInfo->SetPath(URIUtils::AddFileToFolder(fallbackPath, defaultSkin));
@@ -128,7 +128,7 @@ namespace XBMCAddon
 
           skinInfo->Start();
           strSkinPath = skinInfo->GetSkinPath(xmlFilename, &res);
-          if (!XFILE::CFile::Exists(strSkinPath))
+          if (!CFileUtils::Exists(strSkinPath))
             throw WindowException("XML File for Window is missing");
         }
       }

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -18,19 +18,18 @@
 #include "addons/AddonManager.h"
 #include "addons/addoninfo/AddonInfo.h"
 #include "dialogs/GUIDialogKaiToast.h"
-#include "filesystem/File.h"
 #include "filesystem/SpecialProtocol.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "interfaces/python/PyContext.h"
-#include "interfaces/python/XBPython.h"
 #include "interfaces/python/pythreadstate.h"
 #include "interfaces/python/swig.h"
 #include "messaging/ApplicationMessenger.h"
 #include "threads/SingleLock.h"
 #include "threads/SystemClock.h"
 #include "utils/CharsetConverter.h"
+#include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/XTimeUtils.h"
@@ -115,7 +114,7 @@ bool CPythonInvoker::Execute(
   if (script.empty())
     return false;
 
-  if (!CFile::Exists(script))
+  if (!CFileUtils::Exists(script))
   {
     CLog::Log(LOGERROR, "CPythonInvoker({}): python script \"{}\" does not exist", GetId(),
               CSpecialProtocol::TranslatePath(script));

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -13,17 +13,16 @@
 #include "GUIUserMessages.h"
 #include "ServiceBroker.h"
 #include "TextureCache.h"
+#include "URL.h"
 #include "dialogs/GUIDialogBusy.h"
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "filesystem/Directory.h"
-#include "filesystem/File.h"
-#include "filesystem/MusicDatabaseDirectory.h"
+#include "filesystem/MusicDatabaseDirectory/QueryParams.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "input/Key.h"
-#include "messaging/helpers/DialogHelper.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "music/MusicDatabase.h"
 #include "music/MusicLibraryQueue.h"
@@ -32,13 +31,14 @@
 #include "music/dialogs/GUIDialogSongInfo.h"
 #include "music/infoscanner/MusicInfoScanner.h"
 #include "music/tags/MusicInfoTag.h"
-#include "music/windows/GUIWindowMusicNav.h"
+#include "music/windows/GUIWindowMusicBase.h"
 #include "profiles/ProfileManager.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
 #include "utils/FileExtensionProvider.h"
+#include "utils/FileUtils.h"
 #include "utils/ProgressJob.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -794,7 +794,7 @@ void CGUIDialogMusicInfo::OnGetArt()
     paths.emplace_back(m_album.strPath);
   for (const auto& path : paths)
   {
-    if (!localArt.empty() && CFile::Exists(localArt))
+    if (!localArt.empty() && CFileUtils::Exists(localArt))
       break;
     if (!path.empty())
     {
@@ -823,7 +823,7 @@ void CGUIDialogMusicInfo::OnGetArt()
       }
     }
   }
-  if (!localArt.empty() && CFile::Exists(localArt))
+  if (!localArt.empty() && CFileUtils::Exists(localArt))
   {
     CFileItemPtr item(new CFileItem("Local Art: " + localArt, false));
     item->SetArt("thumb", localArt);
@@ -890,7 +890,7 @@ void CGUIDialogMusicInfo::OnGetArt()
       newArt = m_item->GetArt("thumb");
     else if (StringUtils::StartsWith(result, "Local Art: "))
       newArt = localArt;
-    else if (CFile::Exists(result))
+    else if (CFileUtils::Exists(result))
       newArt = result;
     else // none
       newArt.clear();

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -16,7 +16,6 @@
 #include "Util.h"
 #include "dialogs/GUIDialogBusy.h"
 #include "dialogs/GUIDialogFileBrowser.h"
-#include "filesystem/File.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
@@ -29,8 +28,7 @@
 #include "settings/MediaSourceSettings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
-
-using namespace XFILE;
+#include "utils/FileUtils.h"
 
 #define CONTROL_BTN_REFRESH       6
 #define CONTROL_USERRATING        7
@@ -373,7 +371,7 @@ void CGUIDialogSongInfo::OnGetArt()
       CFileItem item(m_song->GetMusicInfoTag()->GetURL(), false);
       localThumb = item.GetUserMusicThumb(true);
     }
-    if (CFile::Exists(localThumb))
+    if (CFileUtils::Exists(localThumb))
     {
       CFileItemPtr item(new CFileItem("thumb://Local", false));
       item->SetArt("thumb", localThumb);
@@ -431,7 +429,7 @@ void CGUIDialogSongInfo::OnGetArt()
       newArt = localThumb;
 //    else if (result == "thumb://Embedded")
 //      newArt = embeddedArt;
-    else if (CFile::Exists(result))
+    else if (CFileUtils::Exists(result))
       newArt = result;
     else // none
       newArt.clear();

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -16,6 +16,7 @@
 #include "NfoFile.h"
 #include "ServiceBroker.h"
 #include "TextureCache.h"
+#include "URL.h"
 #include "Util.h"
 #include "addons/AddonSystemSettings.h"
 #include "addons/Scraper.h"
@@ -26,7 +27,6 @@
 #include "events/EventLog.h"
 #include "events/MediaLibraryEvent.h"
 #include "filesystem/Directory.h"
-#include "filesystem/File.h"
 #include "filesystem/MusicDatabaseDirectory.h"
 #include "filesystem/MusicDatabaseDirectory/DirectoryNode.h"
 #include "filesystem/SmartPlaylistDirectory.h"
@@ -45,6 +45,7 @@
 #include "settings/SettingsComponent.h"
 #include "utils/Digest.h"
 #include "utils/FileExtensionProvider.h"
+#include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
@@ -1486,7 +1487,7 @@ CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album,
   std::string strNfo = URIUtils::AddFileToFolder(path, "album.nfo");
   CInfoScanner::INFO_TYPE result = CInfoScanner::NO_NFO;
   CNfoFile nfoReader;
-  existsNFO = XFILE::CFile::Exists(strNfo);
+  existsNFO = CFileUtils::Exists(strNfo);
   // When on GUI ask user if they want to ignore nfo and refresh from Internet
   if (existsNFO && pDialog && CGUIDialogYesNo::ShowAndGetInput(10523, 20446))
   {
@@ -1753,7 +1754,7 @@ CMusicInfoScanner::DownloadArtistInfo(const CArtist& artist,
   if (artistpathfound)
   {
     strNfo = URIUtils::AddFileToFolder(path, "artist.nfo");
-    existsNFO = XFILE::CFile::Exists(strNfo);
+    existsNFO = CFileUtils::Exists(strNfo);
   }
 
   // If not there fall back local to music files (historic location for those album artists with a unique folder)
@@ -1763,7 +1764,7 @@ CMusicInfoScanner::DownloadArtistInfo(const CArtist& artist,
     if (artistpathfound)
     {
       strNfo = URIUtils::AddFileToFolder(path, "artist.nfo");
-      existsNFO = XFILE::CFile::Exists(strNfo);
+      existsNFO = CFileUtils::Exists(strNfo);
     }
     else
       CLog::Log(LOGDEBUG, "{} not have path, nfo file not possible", artist.strArtist);

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -39,7 +39,6 @@
 #include "dialogs/GUIDialogSmartPlaylistEditor.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "filesystem/Directory.h"
-#include "filesystem/File.h"
 #include "filesystem/MusicDatabaseDirectory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
@@ -55,13 +54,14 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
+#include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
-#include "video/dialogs/GUIDialogVideoInfo.h"
 #include "video/VideoInfoTag.h"
+#include "video/dialogs/GUIDialogVideoInfo.h"
 #include "view/GUIViewState.h"
 
 #include <algorithm>
@@ -412,7 +412,7 @@ void CGUIWindowMusicBase::OnQueueItem(int iItem, bool first)
     const std::shared_ptr<CProfileManager> profileManager =
       CServiceBroker::GetSettingsComponent()->GetProfileManager();
     if ((item->GetPath() == profileManager->GetUserDataItem("PartyMode.xsp")) &&
-      !XFILE::CFile::Exists(item->GetPath()))
+        !CFileUtils::Exists(item->GetPath()))
       return;
   }
 
@@ -572,7 +572,7 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
     // When "PartyMode.xsp" not exist, only context menu button is edit
     if (item->IsSmartPlayList() &&
         (item->GetPath() == profileManager->GetUserDataItem("PartyMode.xsp")) &&
-        !XFILE::CFile::Exists(item->GetPath()))
+        !CFileUtils::Exists(item->GetPath()))
     {
       buttons.Add(CONTEXT_BUTTON_EDIT_SMART_PLAYLIST, 586);
       return;
@@ -795,7 +795,7 @@ void CGUIWindowMusicBase::PlayItem(int iItem)
     const std::shared_ptr<CProfileManager> profileManager =
         CServiceBroker::GetSettingsComponent()->GetProfileManager();
     if ((pItem->GetPath() == profileManager->GetUserDataItem("PartyMode.xsp")) &&
-        !XFILE::CFile::Exists(pItem->GetPath()))
+        !CFileUtils::Exists(pItem->GetPath()))
       return;
   }
 

--- a/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPJsonRpcHandler.cpp
@@ -10,12 +10,10 @@
 
 #include "ServiceBroker.h"
 #include "URL.h"
-#include "filesystem/File.h"
 #include "interfaces/json-rpc/JSONRPC.h"
 #include "interfaces/json-rpc/JSONServiceDescription.h"
-#include "interfaces/json-rpc/JSONUtils.h"
-#include "network/WebServer.h"
 #include "network/httprequesthandler/HTTPRequestHandlerUtils.h"
+#include "utils/FileUtils.h"
 #include "utils/JSONVariantWriter.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
@@ -138,7 +136,7 @@ bool CHTTPJsonRpcHandler::appendPostData(const char *data, size_t size)
 
 bool CHTTPJsonRpcHandler::CHTTPTransportLayer::PrepareDownload(const char *path, CVariant &details, std::string &protocol)
 {
-  if (!XFILE::CFile::Exists(path))
+  if (!CFileUtils::Exists(path))
     return false;
 
   protocol = "http";

--- a/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPVfsHandler.cpp
@@ -12,11 +12,10 @@
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "Util.h"
-#include "filesystem/File.h"
 #include "media/MediaLockState.h"
-#include "network/WebServer.h"
 #include "settings/MediaSourceSettings.h"
 #include "storage/MediaManager.h"
+#include "utils/FileUtils.h"
 #include "utils/URIUtils.h"
 
 CHTTPVfsHandler::CHTTPVfsHandler(const HTTPRequest &request)
@@ -29,7 +28,7 @@ CHTTPVfsHandler::CHTTPVfsHandler(const HTTPRequest &request)
   {
     file = m_request.pathUrl.substr(5);
 
-    if (XFILE::CFile::Exists(file))
+    if (CFileUtils::Exists(file))
     {
       bool accessible = false;
       if (file.substr(0, 8) == "image://")

--- a/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPWebinterfaceHandler.cpp
@@ -13,7 +13,6 @@
 #include "addons/AddonSystemSettings.h"
 #include "addons/Webinterface.h"
 #include "filesystem/Directory.h"
-#include "filesystem/File.h"
 #include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -66,7 +65,7 @@ int CHTTPWebinterfaceHandler::ResolveUrl(const std::string &url, std::string &pa
   if (!CFileUtils::CheckFileAccessAllowed(path))
     return MHD_HTTP_NOT_FOUND;
 
-  if (!XFILE::CFile::Exists(path))
+  if (!CFileUtils::Exists(path))
     return MHD_HTTP_NOT_FOUND;
 
   return MHD_HTTP_OK;

--- a/xbmc/network/upnp/UPnPSettings.cpp
+++ b/xbmc/network/upnp/UPnPSettings.cpp
@@ -9,7 +9,7 @@
 #include "UPnPSettings.h"
 
 #include "ServiceBroker.h"
-#include "filesystem/File.h"
+#include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/XBMCTinyXML.h"
 #include "utils/XMLUtils.h"
@@ -23,8 +23,6 @@
 #define XML_MAX_ITEMS     "MaxReturnedItems"
 #define XML_RENDERER_UUID "UUIDRenderer"
 #define XML_RENDERER_PORT "PortRenderer"
-
-using namespace XFILE;
 
 CUPnPSettings::CUPnPSettings() : m_logger(CServiceBroker::GetLogging().GetLogger("CUPnPSettings"))
 {
@@ -53,7 +51,7 @@ bool CUPnPSettings::Load(const std::string &file)
 
   Clear();
 
-  if (!CFile::Exists(file))
+  if (!CFileUtils::Exists(file))
     return false;
 
   CXBMCTinyXML doc;

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -10,7 +10,6 @@
 
 #include "Util.h"
 #include "XBDateTime.h"
-#include "filesystem/File.h"
 #include "games/controllers/Controller.h"
 #include "guilib/LocalizeStrings.h"
 #include "input/joysticks/interfaces/IInputHandler.h"
@@ -21,6 +20,7 @@
 #include "peripherals/bus/PeripheralBus.h"
 #include "peripherals/bus/virtual/PeripheralBusAddon.h"
 #include "settings/lib/Setting.h"
+#include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/XBMCTinyXML.h"
 #include "utils/XMLUtils.h"
@@ -161,7 +161,7 @@ bool CPeripheral::Initialise(void)
         "special://profile/peripheral_data/{}_{}_{}.xml",
         PeripheralTypeTranslator::BusTypeToString(m_mappedBusType), m_strVendorId, m_strProductId);
 
-    if (!XFILE::CFile::Exists(m_strSettingsFile))
+    if (!CFileUtils::Exists(m_strSettingsFile))
       m_strSettingsFile = StringUtils::Format(
           "special://profile/peripheral_data/{}_{}_{}_{}.xml",
           PeripheralTypeTranslator::BusTypeToString(m_mappedBusType), m_strVendorId, m_strProductId,

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -15,7 +15,6 @@
 #include "TextureCache.h"
 #include "URL.h"
 #include "filesystem/Directory.h"
-#include "filesystem/File.h"
 #include "filesystem/MultiPathDirectory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
@@ -23,6 +22,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/FileExtensionProvider.h"
+#include "utils/FileUtils.h"
 #include "utils/URIUtils.h"
 #include "video/VideoThumbLoader.h"
 
@@ -134,7 +134,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
   if (pItem->IsCBR() || pItem->IsCBZ())
   {
     std::string strTBN(URIUtils::ReplaceExtension(pItem->GetPath(),".tbn"));
-    if (CFile::Exists(strTBN))
+    if (CFileUtils::Exists(strTBN))
     {
       db.SetTextureForPath(pItem->GetPath(), "thumb", strTBN);
       CServiceBroker::GetTextureCache()->BackgroundCacheImage(strTBN);
@@ -161,7 +161,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
     if (pItem->IsMultiPath())
       pathToUrl = CURL(CMultiPathDirectory::GetFirstPath(pItem->GetPath()));
     thumb = URIUtils::AddFileToFolder(pathToUrl.Get(), thumb);
-    if (CFile::Exists(thumb))
+    if (CFileUtils::Exists(thumb))
     {
       db.SetTextureForPath(pItem->GetPath(), "thumb", thumb);
       CServiceBroker::GetTextureCache()->BackgroundCacheImage(thumb);

--- a/xbmc/pvr/guilib/PVRGUIChannelIconUpdater.cpp
+++ b/xbmc/pvr/guilib/PVRGUIChannelIconUpdater.cpp
@@ -12,7 +12,6 @@
 #include "ServiceBroker.h"
 #include "Util.h"
 #include "filesystem/Directory.h"
-#include "filesystem/File.h"
 #include "guilib/LocalizeStrings.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRChannelGroup.h"
@@ -21,6 +20,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/FileUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
@@ -71,7 +71,7 @@ void CPVRGUIChannelIconUpdater::SearchAndUpdateMissingChannelIcons() const
       progressHandler->UpdateProgress(channel->ChannelName(), channelIndex++, members.size());
 
       // skip if an icon is already set and exists
-      if (XFILE::CFile::Exists(channel->IconPath()))
+      if (CFileUtils::Exists(channel->IconPath()))
         continue;
 
       // reset icon before searching for a new one

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -8,19 +8,16 @@
 
 #include "RenderSystemGL.h"
 
-#include "filesystem/File.h"
+#include "ServiceBroker.h"
+#include "URL.h"
 #include "guilib/GUITextureGL.h"
 #include "rendering/MatrixGL.h"
-#include "settings/AdvancedSettings.h"
-#include "settings/DisplaySettings.h"
+#include "utils/FileUtils.h"
 #include "utils/GLUtils.h"
 #include "utils/MathUtils.h"
-#include "utils/StringUtils.h"
-#include "utils/SystemInfo.h"
-#include "utils/TimeUtils.h"
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
-#include "windowing/GraphicContext.h"
+#include "windowing/WinSystem.h"
 
 using namespace std::chrono_literals;
 
@@ -788,7 +785,7 @@ std::string CRenderSystemGL::GetShaderPath(const std::string &filename)
   {
     std::string file = "special://xbmc/system/shaders/GL/4.0/" + filename;
     const CURL pathToUrl(file);
-    if (XFILE::CFile::Exists(pathToUrl))
+    if (CFileUtils::Exists(pathToUrl.Get()))
       return "GL/4.0/";
   }
   if (m_glslMajor >= 2 || (m_glslMajor == 1 && m_glslMinor >= 50))

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -10,8 +10,8 @@
 
 #include "LangInfo.h"
 #include "ServiceBroker.h"
+#include "URL.h"
 #include "application/AppParams.h"
-#include "filesystem/File.h"
 #include "filesystem/SpecialProtocol.h"
 #include "network/DNSNameCache.h"
 #include "profiles/ProfileManager.h"
@@ -19,6 +19,7 @@
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingsManager.h"
+#include "utils/FileUtils.h"
 #include "utils/LangCodeExpander.h"
 #include "utils/StringUtils.h"
 #include "utils/SystemInfo.h"
@@ -34,7 +35,6 @@
 #include <vector>
 
 using namespace ADDON;
-using namespace XFILE;
 
 CAdvancedSettings::CAdvancedSettings()
 {
@@ -481,7 +481,7 @@ bool CAdvancedSettings::Load(const CProfileManager &profileManager)
 void CAdvancedSettings::ParseSettingsFile(const std::string &file)
 {
   CXBMCTinyXML advancedXML;
-  if (!CFile::Exists(file))
+  if (!CFileUtils::Exists(file))
   {
     CLog::Log(LOGINFO, "No settings file to load ({})", file);
     return;

--- a/xbmc/settings/MediaSourceSettings.cpp
+++ b/xbmc/settings/MediaSourceSettings.cpp
@@ -11,11 +11,11 @@
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "Util.h"
-#include "filesystem/File.h"
 #include "media/MediaLockState.h"
 #include "network/WakeOnAccess.h"
 #include "profiles/ProfileManager.h"
 #include "settings/SettingsComponent.h"
+#include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/XBMCTinyXML.h"
@@ -28,8 +28,6 @@
 #define SOURCES_FILE  "sources.xml"
 #define XML_SOURCES   "sources"
 #define XML_SOURCE    "source"
-
-using namespace XFILE;
 
 CMediaSourceSettings::CMediaSourceSettings()
 {
@@ -76,7 +74,7 @@ bool CMediaSourceSettings::Load(const std::string &file)
 {
   Clear();
 
-  if (!CFile::Exists(file))
+  if (!CFileUtils::Exists(file))
     return false;
 
   CLog::Log(LOGINFO, "CMediaSourceSettings: loading media sources from {}", file);

--- a/xbmc/settings/SubtitlesSettings.cpp
+++ b/xbmc/settings/SubtitlesSettings.cpp
@@ -8,15 +8,12 @@
 
 #include "SubtitlesSettings.h"
 
-#include "FileItem.h"
-#include "filesystem/Directory.h"
-#include "filesystem/File.h"
 #include "guilib/GUIFontManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "settings/Settings.h"
 #include "settings/lib/Setting.h"
+#include "utils/FileUtils.h"
 #include "utils/FontUtils.h"
-#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 
 using namespace KODI;
@@ -179,7 +176,7 @@ void CSubtitlesSettings::SettingOptionsSubtitleFontsFiller(const SettingConstPtr
   // From application system fonts folder we add the default font only
   std::string defaultFontPath =
       URIUtils::AddFileToFolder("special://xbmc/media/Fonts/", UTILS::FONT::FONT_DEFAULT_FILENAME);
-  if (XFILE::CFile::Exists(defaultFontPath))
+  if (CFileUtils::Exists(defaultFontPath))
   {
     std::string familyName = UTILS::FONT::GetFontFamily(defaultFontPath);
     if (!familyName.empty())

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -35,12 +35,12 @@
 #include "addons/VFSEntry.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogPlayEject.h"
-#include "filesystem/File.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/FileUtils.h"
 #include "utils/JobManager.h"
 #include "utils/StringUtils.h"
 #include "utils/XBMCTinyXML.h"
@@ -49,8 +49,6 @@
 
 #include <string>
 #include <vector>
-
-using namespace XFILE;
 
 #ifdef HAS_DVD_DRIVE
 using namespace MEDIA_DETECT;
@@ -758,14 +756,14 @@ UTILS::DISCS::DiscInfo CMediaManager::GetDiscInfo(const std::string& mediaPath)
   }
 
   // check for DVD discs
-  if (XFILE::CFile::Exists(pathVideoTS))
+  if (CFileUtils::Exists(pathVideoTS))
   {
     info = UTILS::DISCS::ProbeDVDDiscInfo(pathVideoTS);
     if (!info.empty())
       return info;
   }
   // check for Blu-ray discs
-  if (XFILE::CFile::Exists(URIUtils::AddFileToFolder(mediaPath, "BDMV", "index.bdmv")))
+  if (CFileUtils::Exists(URIUtils::AddFileToFolder(mediaPath, "BDMV", "index.bdmv")))
   {
     info = UTILS::DISCS::ProbeBlurayDiscInfo(mediaPath);
   }

--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -10,7 +10,6 @@
 
 #include "CompileInfo.h"
 #include "FileOperationJob.h"
-#include "JobManager.h"
 #include "ServiceBroker.h"
 #include "StringUtils.h"
 #include "URIUtils.h"
@@ -354,4 +353,9 @@ bool CFileUtils::CheckFileAccessAllowed(const std::string &filePath)
   if (! isImage)
     return CFileUtils::RemoteAccessAllowed(decodePath);
   return true;
+}
+
+bool CFileUtils::Exists(const std::string& strFileName, bool bUseCache)
+{
+  return CFile::Exists(strFileName, bUseCache);
 }

--- a/xbmc/utils/FileUtils.h
+++ b/xbmc/utils/FileUtils.h
@@ -20,6 +20,7 @@ public:
   static bool CheckFileAccessAllowed(const std::string &filePath);
   static bool DeleteItem(const std::shared_ptr<CFileItem>& item);
   static bool DeleteItem(const std::string &strPath);
+  static bool Exists(const std::string& strFileName, bool bUseCache = true);
   static bool RenameFile(const std::string &strFile);
   static bool RemoteAccessAllowed(const std::string &strPath);
   static unsigned int LoadFile(const std::string &filename, void* &outputBuffer);

--- a/xbmc/utils/RssManager.cpp
+++ b/xbmc/utils/RssManager.cpp
@@ -11,22 +11,19 @@
 #include "ServiceBroker.h"
 #include "addons/AddonInstaller.h"
 #include "addons/AddonManager.h"
-#include "filesystem/File.h"
 #include "interfaces/builtins/Builtins.h"
-#include "messaging/helpers/DialogHelper.h"
 #include "profiles/ProfileManager.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
+#include "utils/FileUtils.h"
 #include "utils/RssReader.h"
 #include "utils/StringUtils.h"
-#include "utils/Variant.h"
 #include "utils/log.h"
 
 #include <mutex>
 #include <utility>
 
-using namespace XFILE;
 using namespace KODI::MESSAGING;
 
 
@@ -100,7 +97,7 @@ bool CRssManager::Load()
   std::unique_lock<CCriticalSection> lock(m_critical);
 
   std::string rssXML = profileManager->GetUserDataItem("RssFeeds.xml");
-  if (!CFile::Exists(rssXML))
+  if (!CFileUtils::Exists(rssXML))
     return false;
 
   CXBMCTinyXML rssDoc;

--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
@@ -21,7 +21,6 @@
 #include "cores/IPlayer.h"
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "dialogs/GUIDialogYesNo.h"
-#include "filesystem/File.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
@@ -34,6 +33,7 @@
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingDefinitions.h"
 #include "settings/lib/SettingsManager.h"
+#include "utils/FileUtils.h"
 #include "utils/LangCodeExpander.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -160,7 +160,7 @@ std::string CGUIDialogSubtitleSettings::BrowseForSubtitle()
   {
     if (URIUtils::HasExtension(strPath, ".sub"))
     {
-      if (XFILE::CFile::Exists(URIUtils::ReplaceExtension(strPath, ".idx")))
+      if (CFileUtils::Exists(URIUtils::ReplaceExtension(strPath, ".idx")))
         strPath = URIUtils::ReplaceExtension(strPath, ".idx");
     }
 

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -17,7 +17,6 @@
 #include "application/ApplicationPlayer.h"
 #include "dialogs/GUIDialogContextMenu.h"
 #include "dialogs/GUIDialogKaiToast.h"
-#include "filesystem/File.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
@@ -30,6 +29,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/Crc32.h"
+#include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
@@ -219,7 +219,7 @@ void CGUIDialogVideoBookmarks::UpdateItem(unsigned int chapterIdx)
     std::string time = StringUtils::Format("chapter://{}/{}", m_filePath, chapterIdx);
     std::string cachefile = CServiceBroker::GetTextureCache()->GetCachedPath(
         CServiceBroker::GetTextureCache()->GetCacheFile(time) + ".jpg");
-    if (XFILE::CFile::Exists(cachefile))
+    if (CFileUtils::Exists(cachefile))
     {
       (*m_vecItems)[itemPos]->SetArt("thumb", cachefile);
     }
@@ -288,7 +288,7 @@ void CGUIDialogVideoBookmarks::OnRefreshList()
     std::string chapterPath = StringUtils::Format("chapter://{}/{}", m_filePath, i);
     std::string cachefile = CServiceBroker::GetTextureCache()->GetCachedPath(
         CServiceBroker::GetTextureCache()->GetCacheFile(chapterPath) + ".jpg");
-    if (XFILE::CFile::Exists(cachefile))
+    if (CFileUtils::Exists(cachefile))
       item->SetArt("thumb", cachefile);
     else if (i > m_jobsStarted && CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_MYVIDEOS_EXTRACTCHAPTERTHUMBS))
     {

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -20,7 +20,6 @@
 #include "dialogs/GUIDialogSelect.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "filesystem/Directory.h"
-#include "filesystem/File.h"
 #include "filesystem/VideoDatabaseDirectory.h"
 #include "filesystem/VideoDatabaseDirectory/QueryParams.h"
 #include "guilib/GUIComponent.h"
@@ -976,7 +975,7 @@ void CGUIDialogVideoInfo::OnGetArt()
         newThumb = localThumb;
       else if (result == "thumb://Embedded")
         newThumb = embeddedArt;
-      else if (CFile::Exists(result))
+      else if (CFileUtils::Exists(result))
         newThumb = result;
       else // none
         newThumb.clear();
@@ -1130,7 +1129,7 @@ void CGUIDialogVideoInfo::OnGetFanart()
     }
     result = m_movieItem->GetVideoInfoTag()->m_fanart.GetImageURL();
   }
-  else if (StringUtils::EqualsNoCase(result, "fanart://None") || !CFile::Exists(result))
+  else if (StringUtils::EqualsNoCase(result, "fanart://None") || !CFileUtils::Exists(result))
     result.clear();
 
   // set the fanart image
@@ -2110,7 +2109,7 @@ bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const std::shared_ptr<CFileItem
     {
       std::string picturePath;
       std::string strThumb = URIUtils::AddFileToFolder(picturePath, "folder.jpg");
-      if (XFILE::CFile::Exists(strThumb))
+      if (CFileUtils::Exists(strThumb))
       {
         CFileItemPtr pItem(new CFileItem(strThumb,false));
         pItem->SetLabel(g_localizeStrings.Get(13514));
@@ -2145,13 +2144,13 @@ bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const std::shared_ptr<CFileItem
     if (!artistPath.empty())
     {
       strThumb = URIUtils::AddFileToFolder(artistPath, "folder.jpg");
-      existsThumb = CFile::Exists(strThumb);
+      existsThumb = CFileUtils::Exists(strThumb);
     }
     // If not there fall back local to music files (historic location for those album artists with a unique folder)
     if (!existsThumb && !artistOldPath.empty())
     {
       strThumb = URIUtils::AddFileToFolder(artistOldPath, "folder.jpg");
-      existsThumb = CFile::Exists(strThumb);
+      existsThumb = CFileUtils::Exists(strThumb);
     }
 
     if (existsThumb)
@@ -2376,7 +2375,7 @@ bool CGUIDialogVideoInfo::OnGetFanart(const std::shared_ptr<CFileItem>& videoIte
       StringUtils::EqualsNoCase(result, "fanart://Current"))
     return false;
 
-  else if (StringUtils::EqualsNoCase(result, "fanart://None") || !CFile::Exists(result))
+  else if (StringUtils::EqualsNoCase(result, "fanart://None") || !CFileUtils::Exists(result))
     result.clear();
   if (!result.empty() && flip)
     result = CTextureUtils::GetWrappedImageURL(result, "", "flipped");

--- a/xbmc/video/tags/VideoTagLoaderNFO.cpp
+++ b/xbmc/video/tags/VideoTagLoaderNFO.cpp
@@ -10,9 +10,10 @@
 
 #include "FileItem.h"
 #include "NfoFile.h"
+#include "URL.h"
 #include "filesystem/Directory.h"
-#include "filesystem/File.h"
 #include "filesystem/StackDirectory.h"
+#include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -35,7 +36,7 @@ CVideoTagLoaderNFO::CVideoTagLoaderNFO(const CFileItem& item,
 
 bool CVideoTagLoaderNFO::HasInfo() const
 {
-  return !m_path.empty() && CFile::Exists(m_path);
+  return !m_path.empty() && CFileUtils::Exists(m_path);
 }
 
 CInfoScanner::INFO_TYPE CVideoTagLoaderNFO::Load(CVideoInfoTag& tag,
@@ -112,7 +113,7 @@ std::string CVideoTagLoaderNFO::FindNFO(const CFileItem& item,
     if (movieFolder && !item.IsStack())
     { // looking up by folder name - movie.nfo takes priority - but not for stacked items (handled below)
       nfoFile = URIUtils::AddFileToFolder(strPath, "movie.nfo");
-      if (CFile::Exists(nfoFile))
+      if (CFileUtils::Exists(nfoFile))
         return nfoFile;
     }
 
@@ -144,7 +145,7 @@ std::string CVideoTagLoaderNFO::FindNFO(const CFileItem& item,
     }
 
     // test file existence
-    if (!nfoFile.empty() && !CFile::Exists(nfoFile))
+    if (!nfoFile.empty() && !CFileUtils::Exists(nfoFile))
       nfoFile.clear();
 
     if (nfoFile.empty()) // final attempt - strip off any cd1 folders

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -30,7 +30,6 @@
 #include "dialogs/GUIDialogMediaFilter.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "dialogs/GUIDialogSmartPlaylistEditor.h"
-#include "filesystem/File.h"
 #include "filesystem/FileDirectoryFactory.h"
 #include "filesystem/MultiPathDirectory.h"
 #include "filesystem/PluginDirectory.h"
@@ -1084,7 +1083,7 @@ bool CGUIMediaWindow::OnClick(int iItem, const std::string &player)
         (pItem->GetPath() == profileManager->GetUserDataItem("PartyMode-Video.xsp")))
     {
       // party mode playlist item - if it doesn't exist, prompt for user to define it
-      if (!XFILE::CFile::Exists(pItem->GetPath()))
+      if (!CFileUtils::Exists(pItem->GetPath()))
       {
         m_vecItems->RemoveDiscCache(GetID());
         if (CGUIDialogSmartPlaylistEditor::EditPlaylist(pItem->GetPath()))


### PR DESCRIPTION
## Description
This proxies CFile::Exists. Allows for having less code depend on the full CFile machinery and its dependencies (URL.h in particular)

## Motivation and context
Less rebuild time

## How has this been tested?
It builds

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
