### PR TITLE
[PVR] CPVRTimerInfoTag: Encapsulate members.

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -291,7 +291,7 @@ CFileItem::CFileItem(const std::shared_ptr<CPVRTimerInfoTag>& timer)
 
   if (!timer->ChannelIcon().empty())
     SetArt("icon", timer->ChannelIcon());
-  else if (timer->m_bIsRadio)
+  else if (timer->IsRadio())
     SetArt("icon", "DefaultMusicSongs.png");
   else
     SetArt("icon", "DefaultTVShows.png");

--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -115,7 +115,7 @@ bool CFileItemHandler::GetField(const std::string& field,
       {
         const std::shared_ptr<PVR::CPVRTimerInfoTag> timer =
             CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(item->GetEPGInfoTag());
-        result[field] = (timer && (timer->GetTimerRuleId() != PVR_TIMER_NO_PARENT));
+        result[field] = (timer && timer->HasParent());
         return true;
       }
       else if (field == "hasrecording")
@@ -376,8 +376,8 @@ void CFileItemHandler::HandleFileItem(const char* ID,
           object["file"] = item->GetVideoInfoTag()->GetPath().c_str();
         if (item->HasMusicInfoTag() && !item->GetMusicInfoTag()->GetURL().empty())
           object["file"] = item->GetMusicInfoTag()->GetURL().c_str();
-        if (item->HasPVRTimerInfoTag() && !item->GetPVRTimerInfoTag()->m_strFileNameAndPath.empty())
-          object["file"] = item->GetPVRTimerInfoTag()->m_strFileNameAndPath.c_str();
+        if (item->HasPVRTimerInfoTag() && !item->GetPVRTimerInfoTag()->Path().empty())
+          object["file"] = item->GetPVRTimerInfoTag()->Path().c_str();
 
         if (!object.isMember("file"))
           object["file"] = item->GetDynPath().c_str();
@@ -407,8 +407,8 @@ void CFileItemHandler::HandleFileItem(const char* ID,
         object[ID] = item->GetEPGInfoTag()->DatabaseID();
       else if (item->HasPVRRecordingInfoTag() && item->GetPVRRecordingInfoTag()->RecordingID() > 0)
         object[ID] = item->GetPVRRecordingInfoTag()->RecordingID();
-      else if (item->HasPVRTimerInfoTag() && item->GetPVRTimerInfoTag()->m_iTimerId > 0)
-         object[ID] = item->GetPVRTimerInfoTag()->m_iTimerId;
+      else if (item->HasPVRTimerInfoTag() && item->GetPVRTimerInfoTag()->TimerID() > 0)
+        object[ID] = item->GetPVRTimerInfoTag()->TimerID();
       else if (item->HasMusicInfoTag() && item->GetMusicInfoTag()->GetDatabaseId() > 0)
         object[ID] = item->GetMusicInfoTag()->GetDatabaseId();
       else if (item->HasVideoInfoTag() && item->GetVideoInfoTag()->m_iDbId > 0)

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -440,7 +440,7 @@ namespace PVR
     std::string ToggleTimerState::GetLabel(const CFileItem& item) const
     {
       const std::shared_ptr<CPVRTimerInfoTag> timer(item.GetPVRTimerInfoTag());
-      if (timer && timer->m_state != PVR_TIMER_STATE_DISABLED)
+      if (timer && !timer->IsDisabled())
         return g_localizeStrings.Get(844); /* Deactivate */
 
       return g_localizeStrings.Get(843); /* Activate */
@@ -498,7 +498,7 @@ namespace PVR
     {
       const std::shared_ptr<CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
       if (timer && !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER))
-        return timer->GetTimerRuleId() != PVR_TIMER_NO_PARENT;
+        return timer->HasParent();
 
       return false;
     }

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -36,734 +36,745 @@
 
 namespace PVR
 {
-  namespace CONTEXTMENUITEM
+namespace CONTEXTMENUITEM
+{
+#define DECL_STATICCONTEXTMENUITEM(clazz) \
+  class clazz : public CStaticContextMenuAction \
+  { \
+  public: \
+    explicit clazz(uint32_t label) : CStaticContextMenuAction(label) {} \
+    bool IsVisible(const CFileItem& item) const override; \
+    bool Execute(const CFileItemPtr& item) const override; \
+  };
+
+#define DECL_CONTEXTMENUITEM(clazz) \
+  class clazz : public IContextMenuItem \
+  { \
+  public: \
+    std::string GetLabel(const CFileItem& item) const override; \
+    bool IsVisible(const CFileItem& item) const override; \
+    bool Execute(const CFileItemPtr& item) const override; \
+  };
+
+DECL_STATICCONTEXTMENUITEM(PlayEpgTag);
+DECL_STATICCONTEXTMENUITEM(PlayRecording);
+DECL_CONTEXTMENUITEM(ShowInformation);
+DECL_STATICCONTEXTMENUITEM(ShowChannelGuide);
+DECL_STATICCONTEXTMENUITEM(FindSimilar);
+DECL_STATICCONTEXTMENUITEM(StartRecording);
+DECL_STATICCONTEXTMENUITEM(StopRecording);
+DECL_STATICCONTEXTMENUITEM(AddTimerRule);
+DECL_CONTEXTMENUITEM(EditTimerRule);
+DECL_STATICCONTEXTMENUITEM(DeleteTimerRule);
+DECL_CONTEXTMENUITEM(EditTimer);
+DECL_CONTEXTMENUITEM(DeleteTimer);
+DECL_STATICCONTEXTMENUITEM(EditRecording);
+DECL_CONTEXTMENUITEM(DeleteRecording);
+DECL_STATICCONTEXTMENUITEM(UndeleteRecording);
+DECL_STATICCONTEXTMENUITEM(DeleteWatchedRecordings);
+DECL_CONTEXTMENUITEM(ToggleTimerState);
+DECL_STATICCONTEXTMENUITEM(AddReminder);
+DECL_STATICCONTEXTMENUITEM(ExecuteSearch);
+DECL_STATICCONTEXTMENUITEM(EditSearch);
+DECL_STATICCONTEXTMENUITEM(RenameSearch);
+DECL_STATICCONTEXTMENUITEM(DeleteSearch);
+
+class PVRClientMenuHook : public IContextMenuItem
+{
+public:
+  explicit PVRClientMenuHook(const CPVRClientMenuHook& hook) : m_hook(hook) {}
+
+  std::string GetLabel(const CFileItem& item) const override;
+  bool IsVisible(const CFileItem& item) const override;
+  bool Execute(const CFileItemPtr& item) const override;
+
+  const CPVRClientMenuHook& GetHook() const { return m_hook; }
+
+private:
+  const CPVRClientMenuHook m_hook;
+};
+
+std::shared_ptr<CPVRTimerInfoTag> GetTimerInfoTagFromItem(const CFileItem& item)
+{
+  std::shared_ptr<CPVRTimerInfoTag> timer;
+
+  const std::shared_ptr<CPVREpgInfoTag> epg(item.GetEPGInfoTag());
+  if (epg)
+    timer = CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epg);
+
+  if (!timer)
+    timer = item.GetPVRTimerInfoTag();
+
+  return timer;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Play epg tag
+
+bool PlayEpgTag::IsVisible(const CFileItem& item) const
+{
+  const std::shared_ptr<CPVREpgInfoTag> epg(item.GetEPGInfoTag());
+  if (epg)
+    return epg->IsPlayable();
+
+  return false;
+}
+
+bool PlayEpgTag::Execute(const CFileItemPtr& item) const
+{
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayEpgTag(item);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Play recording
+
+bool PlayRecording::IsVisible(const CFileItem& item) const
+{
+  const std::shared_ptr<CPVRRecording> recording =
+      CServiceBroker::GetPVRManager().Recordings()->GetRecordingForEpgTag(item.GetEPGInfoTag());
+  if (recording)
+    return !recording->IsDeleted();
+
+  return false;
+}
+
+bool PlayRecording::Execute(const CFileItemPtr& item) const
+{
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayRecording(
+      item, true /* bCheckResume */);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Show information (epg, recording)
+
+std::string ShowInformation::GetLabel(const CFileItem& item) const
+{
+  if (item.GetPVRRecordingInfoTag())
+    return g_localizeStrings.Get(19053); /* Recording Information */
+
+  return g_localizeStrings.Get(19047); /* Programme information */
+}
+
+bool ShowInformation::IsVisible(const CFileItem& item) const
+{
+  const std::shared_ptr<CPVRChannel> channel(item.GetPVRChannelInfoTag());
+  if (channel)
+    return channel->GetEPGNow().get() != nullptr;
+
+  if (item.HasEPGInfoTag())
+    return !item.GetEPGInfoTag()->IsGapTag();
+
+  const std::shared_ptr<CPVRTimerInfoTag> timer(item.GetPVRTimerInfoTag());
+  if (timer && !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER))
+    return timer->GetEpgInfoTag().get() != nullptr;
+
+  if (item.GetPVRRecordingInfoTag())
+    return true;
+
+  return false;
+}
+
+bool ShowInformation::Execute(const CFileItemPtr& item) const
+{
+  if (item->GetPVRRecordingInfoTag())
+    return CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().ShowRecordingInfo(item);
+
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowEPGInfo(item);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Show channel guide
+
+bool ShowChannelGuide::IsVisible(const CFileItem& item) const
+{
+  const std::shared_ptr<CPVRChannel> channel(item.GetPVRChannelInfoTag());
+  if (channel)
+    return channel->GetEPGNow().get() != nullptr;
+
+  return false;
+}
+
+bool ShowChannelGuide::Execute(const CFileItemPtr& item) const
+{
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowChannelEPG(item);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Find similar
+
+bool FindSimilar::IsVisible(const CFileItem& item) const
+{
+  const std::shared_ptr<CPVRChannel> channel(item.GetPVRChannelInfoTag());
+  if (channel)
+    return channel->GetEPGNow().get() != nullptr;
+
+  if (item.HasEPGInfoTag())
+    return !item.GetEPGInfoTag()->IsGapTag();
+
+  const std::shared_ptr<CPVRTimerInfoTag> timer(item.GetPVRTimerInfoTag());
+  if (timer && !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER))
+    return timer->GetEpgInfoTag().get() != nullptr;
+
+  const std::shared_ptr<CPVRRecording> recording(item.GetPVRRecordingInfoTag());
+  if (recording)
+    return !recording->IsDeleted();
+
+  return false;
+}
+
+bool FindSimilar::Execute(const CFileItemPtr& item) const
+{
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().FindSimilar(item);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Start recording
+
+bool StartRecording::IsVisible(const CFileItem& item) const
+{
+  const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(item);
+
+  std::shared_ptr<CPVRChannel> channel = item.GetPVRChannelInfoTag();
+  if (channel)
+    return client && client->GetClientCapabilities().SupportsTimers() &&
+           !CServiceBroker::GetPVRManager().Timers()->IsRecordingOnChannel(*channel);
+
+  const std::shared_ptr<CPVREpgInfoTag> epg = item.GetEPGInfoTag();
+  if (epg && epg->IsRecordable())
   {
-    #define DECL_STATICCONTEXTMENUITEM(clazz) \
-    class clazz : public CStaticContextMenuAction \
-    { \
-    public: \
-      explicit clazz(uint32_t label) : CStaticContextMenuAction(label) {} \
-      bool IsVisible(const CFileItem& item) const override; \
-      bool Execute(const CFileItemPtr& item) const override; \
-    };
-
-    #define DECL_CONTEXTMENUITEM(clazz) \
-    class clazz : public IContextMenuItem \
-    { \
-    public: \
-      std::string GetLabel(const CFileItem& item) const override; \
-      bool IsVisible(const CFileItem& item) const override; \
-      bool Execute(const CFileItemPtr& item) const override; \
-    };
-
-    DECL_STATICCONTEXTMENUITEM(PlayEpgTag);
-    DECL_STATICCONTEXTMENUITEM(PlayRecording);
-    DECL_CONTEXTMENUITEM(ShowInformation);
-    DECL_STATICCONTEXTMENUITEM(ShowChannelGuide);
-    DECL_STATICCONTEXTMENUITEM(FindSimilar);
-    DECL_STATICCONTEXTMENUITEM(StartRecording);
-    DECL_STATICCONTEXTMENUITEM(StopRecording);
-    DECL_STATICCONTEXTMENUITEM(AddTimerRule);
-    DECL_CONTEXTMENUITEM(EditTimerRule);
-    DECL_STATICCONTEXTMENUITEM(DeleteTimerRule);
-    DECL_CONTEXTMENUITEM(EditTimer);
-    DECL_CONTEXTMENUITEM(DeleteTimer);
-    DECL_STATICCONTEXTMENUITEM(EditRecording);
-    DECL_CONTEXTMENUITEM(DeleteRecording);
-    DECL_STATICCONTEXTMENUITEM(UndeleteRecording);
-    DECL_STATICCONTEXTMENUITEM(DeleteWatchedRecordings);
-    DECL_CONTEXTMENUITEM(ToggleTimerState);
-    DECL_STATICCONTEXTMENUITEM(AddReminder);
-    DECL_STATICCONTEXTMENUITEM(ExecuteSearch);
-    DECL_STATICCONTEXTMENUITEM(EditSearch);
-    DECL_STATICCONTEXTMENUITEM(RenameSearch);
-    DECL_STATICCONTEXTMENUITEM(DeleteSearch);
-
-    class PVRClientMenuHook : public IContextMenuItem
+    if (epg->IsGapTag())
     {
-    public:
-      explicit PVRClientMenuHook(const CPVRClientMenuHook& hook) : m_hook(hook) {}
-
-      std::string GetLabel(const CFileItem& item) const override;
-      bool IsVisible(const CFileItem& item) const override;
-      bool Execute(const CFileItemPtr& item) const override;
-
-      const CPVRClientMenuHook& GetHook() const { return m_hook; }
-
-    private:
-      const CPVRClientMenuHook m_hook;
-    };
-
-    std::shared_ptr<CPVRTimerInfoTag> GetTimerInfoTagFromItem(const CFileItem& item)
-    {
-      std::shared_ptr<CPVRTimerInfoTag> timer;
-
-      const std::shared_ptr<CPVREpgInfoTag> epg(item.GetEPGInfoTag());
-      if (epg)
-        timer = CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epg);
-
-      if (!timer)
-        timer = item.GetPVRTimerInfoTag();
-
-      return timer;
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////
-    // Play epg tag
-
-    bool PlayEpgTag::IsVisible(const CFileItem& item) const
-    {
-      const std::shared_ptr<CPVREpgInfoTag> epg(item.GetEPGInfoTag());
-      if (epg)
-        return epg->IsPlayable();
-
-      return false;
-    }
-
-    bool PlayEpgTag::Execute(const CFileItemPtr& item) const
-    {
-      return CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayEpgTag(item);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////
-    // Play recording
-
-    bool PlayRecording::IsVisible(const CFileItem& item) const
-    {
-      const std::shared_ptr<CPVRRecording> recording = CServiceBroker::GetPVRManager().Recordings()->GetRecordingForEpgTag(item.GetEPGInfoTag());
-      if (recording)
-        return !recording->IsDeleted();
-
-      return false;
-    }
-
-    bool PlayRecording::Execute(const CFileItemPtr& item) const
-    {
-      return CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayRecording(
-          item, true /* bCheckResume */);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////
-    // Show information (epg, recording)
-
-    std::string ShowInformation::GetLabel(const CFileItem& item) const
-    {
-      if (item.GetPVRRecordingInfoTag())
-        return g_localizeStrings.Get(19053); /* Recording Information */
-
-      return g_localizeStrings.Get(19047); /* Programme information */
-    }
-
-    bool ShowInformation::IsVisible(const CFileItem& item) const
-    {
-      const std::shared_ptr<CPVRChannel> channel(item.GetPVRChannelInfoTag());
+      channel = CServiceBroker::GetPVRManager().ChannelGroups()->GetChannelForEpgTag(epg);
       if (channel)
-        return channel->GetEPGNow().get() != nullptr;
-
-      if (item.HasEPGInfoTag())
-        return !item.GetEPGInfoTag()->IsGapTag();
-
-      const std::shared_ptr<CPVRTimerInfoTag> timer(item.GetPVRTimerInfoTag());
-      if (timer && !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER))
-        return timer->GetEpgInfoTag().get() != nullptr;
-
-      if (item.GetPVRRecordingInfoTag())
-        return true;
-
-      return false;
-    }
-
-    bool ShowInformation::Execute(const CFileItemPtr& item) const
-    {
-      if (item->GetPVRRecordingInfoTag())
-        return CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().ShowRecordingInfo(item);
-
-      return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowEPGInfo(item);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////
-    // Show channel guide
-
-    bool ShowChannelGuide::IsVisible(const CFileItem& item) const
-    {
-      const std::shared_ptr<CPVRChannel> channel(item.GetPVRChannelInfoTag());
-      if (channel)
-        return channel->GetEPGNow().get() != nullptr;
-
-      return false;
-    }
-
-    bool ShowChannelGuide::Execute(const CFileItemPtr& item) const
-    {
-      return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowChannelEPG(item);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////
-    // Find similar
-
-    bool FindSimilar::IsVisible(const CFileItem& item) const
-    {
-      const std::shared_ptr<CPVRChannel> channel(item.GetPVRChannelInfoTag());
-      if (channel)
-        return channel->GetEPGNow().get() != nullptr;
-
-      if (item.HasEPGInfoTag())
-        return !item.GetEPGInfoTag()->IsGapTag();
-
-      const std::shared_ptr<CPVRTimerInfoTag> timer(item.GetPVRTimerInfoTag());
-      if (timer && !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER))
-        return timer->GetEpgInfoTag().get() != nullptr;
-
-      const std::shared_ptr<CPVRRecording> recording(item.GetPVRRecordingInfoTag());
-      if (recording)
-        return !recording->IsDeleted();
-
-      return false;
-    }
-
-    bool FindSimilar::Execute(const CFileItemPtr& item) const
-    {
-      return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().FindSimilar(item);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////
-    // Start recording
-
-    bool StartRecording::IsVisible(const CFileItem& item) const
-    {
-      const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(item);
-
-      std::shared_ptr<CPVRChannel> channel = item.GetPVRChannelInfoTag();
-      if (channel)
+      {
         return client && client->GetClientCapabilities().SupportsTimers() &&
                !CServiceBroker::GetPVRManager().Timers()->IsRecordingOnChannel(*channel);
-
-      const std::shared_ptr<CPVREpgInfoTag> epg = item.GetEPGInfoTag();
-      if (epg && epg->IsRecordable())
-      {
-        if (epg->IsGapTag())
-        {
-          channel = CServiceBroker::GetPVRManager().ChannelGroups()->GetChannelForEpgTag(epg);
-          if (channel)
-          {
-            return client && client->GetClientCapabilities().SupportsTimers() &&
-                !CServiceBroker::GetPVRManager().Timers()->IsRecordingOnChannel(*channel);
-          }
-        }
-        else
-        {
-          return client && client->GetClientCapabilities().SupportsTimers() &&
-              !CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epg);
-        }
       }
-      return false;
     }
-
-    bool StartRecording::Execute(const CFileItemPtr& item) const
+    else
     {
-      const std::shared_ptr<CPVREpgInfoTag> epgTag = item->GetEPGInfoTag();
-      if (!epgTag || epgTag->IsActive())
-      {
-        // instant recording
-        std::shared_ptr<CPVRChannel> channel;
-        if (epgTag)
-          channel = CServiceBroker::GetPVRManager().ChannelGroups()->GetChannelForEpgTag(epgTag);
-
-        if (!channel)
-          channel = item->GetPVRChannelInfoTag();
-
-        if (channel)
-          return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().SetRecordingOnChannel(
-              channel, true);
-      }
-
-      return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().AddTimer(item, false);
+      return client && client->GetClientCapabilities().SupportsTimers() &&
+             !CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epg);
     }
+  }
+  return false;
+}
 
-    ///////////////////////////////////////////////////////////////////////////////
-    // Stop recording
+bool StartRecording::Execute(const CFileItemPtr& item) const
+{
+  const std::shared_ptr<CPVREpgInfoTag> epgTag = item->GetEPGInfoTag();
+  if (!epgTag || epgTag->IsActive())
+  {
+    // instant recording
+    std::shared_ptr<CPVRChannel> channel;
+    if (epgTag)
+      channel = CServiceBroker::GetPVRManager().ChannelGroups()->GetChannelForEpgTag(epgTag);
 
-    bool StopRecording::IsVisible(const CFileItem& item) const
+    if (!channel)
+      channel = item->GetPVRChannelInfoTag();
+
+    if (channel)
+      return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().SetRecordingOnChannel(channel,
+                                                                                           true);
+  }
+
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().AddTimer(item, false);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Stop recording
+
+bool StopRecording::IsVisible(const CFileItem& item) const
+{
+  const std::shared_ptr<CPVRRecording> recording(item.GetPVRRecordingInfoTag());
+  if (recording && recording->IsInProgress())
+    return true;
+
+  std::shared_ptr<CPVRChannel> channel = item.GetPVRChannelInfoTag();
+  if (channel)
+    return CServiceBroker::GetPVRManager().Timers()->IsRecordingOnChannel(*channel);
+
+  const std::shared_ptr<CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
+  if (timer && !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER))
+    return timer->IsRecording();
+
+  const std::shared_ptr<CPVREpgInfoTag> epg = item.GetEPGInfoTag();
+  if (epg && epg->IsGapTag())
+  {
+    channel = CServiceBroker::GetPVRManager().ChannelGroups()->GetChannelForEpgTag(epg);
+    if (channel)
+      return CServiceBroker::GetPVRManager().Timers()->IsRecordingOnChannel(*channel);
+  }
+
+  return false;
+}
+
+bool StopRecording::Execute(const CFileItemPtr& item) const
+{
+  const std::shared_ptr<CPVREpgInfoTag> epgTag = item->GetEPGInfoTag();
+  if (epgTag && epgTag->IsGapTag())
+  {
+    // instance recording
+    const std::shared_ptr<CPVRChannel> channel =
+        CServiceBroker::GetPVRManager().ChannelGroups()->GetChannelForEpgTag(epgTag);
+    if (channel)
+      return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().SetRecordingOnChannel(channel,
+                                                                                           false);
+  }
+
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().StopRecording(item);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Edit recording
+
+bool EditRecording::IsVisible(const CFileItem& item) const
+{
+  const std::shared_ptr<CPVRRecording> recording(item.GetPVRRecordingInfoTag());
+  if (recording && !recording->IsDeleted() && !recording->IsInProgress())
+  {
+    return CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().CanEditRecording(item);
+  }
+  return false;
+}
+
+bool EditRecording::Execute(const CFileItemPtr& item) const
+{
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().EditRecording(item);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Delete recording
+
+std::string DeleteRecording::GetLabel(const CFileItem& item) const
+{
+  const std::shared_ptr<CPVRRecording> recording(item.GetPVRRecordingInfoTag());
+  if (recording && recording->IsDeleted())
+    return g_localizeStrings.Get(19291); /* Delete permanently */
+
+  return g_localizeStrings.Get(117); /* Delete */
+}
+
+bool DeleteRecording::IsVisible(const CFileItem& item) const
+{
+  const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(item);
+  if (client && !client->GetClientCapabilities().SupportsRecordingsDelete())
+    return false;
+
+  const std::shared_ptr<CPVRRecording> recording(item.GetPVRRecordingInfoTag());
+  if (recording && !recording->IsInProgress())
+    return true;
+
+  // recordings folder?
+  if (item.m_bIsFolder &&
+      CServiceBroker::GetPVRManager().Clients()->AnyClientSupportingRecordingsDelete())
+  {
+    const CPVRRecordingsPath path(item.GetPath());
+    return path.IsValid() && !path.IsRecordingsRoot();
+  }
+
+  return false;
+}
+
+bool DeleteRecording::Execute(const CFileItemPtr& item) const
+{
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().DeleteRecording(item);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Undelete recording
+
+bool UndeleteRecording::IsVisible(const CFileItem& item) const
+{
+  const std::shared_ptr<CPVRRecording> recording(item.GetPVRRecordingInfoTag());
+  if (recording && recording->IsDeleted())
+    return true;
+
+  return false;
+}
+
+bool UndeleteRecording::Execute(const CFileItemPtr& item) const
+{
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().UndeleteRecording(item);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Delete watched recordings
+
+bool DeleteWatchedRecordings::IsVisible(const CFileItem& item) const
+{
+  // recordings folder?
+  if (item.m_bIsFolder && !item.IsParentFolder())
+    return CPVRRecordingsPath(item.GetPath()).IsValid();
+
+  return false;
+}
+
+bool DeleteWatchedRecordings::Execute(const std::shared_ptr<CFileItem>& item) const
+{
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().DeleteWatchedRecordings(item);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Add reminder
+
+bool AddReminder::IsVisible(const CFileItem& item) const
+{
+  const std::shared_ptr<CPVREpgInfoTag> epg = item.GetEPGInfoTag();
+  if (epg && !CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epg) &&
+      epg->StartAsLocalTime() > CDateTime::GetCurrentDateTime())
+    return true;
+
+  return false;
+}
+
+bool AddReminder::Execute(const std::shared_ptr<CFileItem>& item) const
+{
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().AddReminder(item);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Activate / deactivate timer or timer rule
+
+std::string ToggleTimerState::GetLabel(const CFileItem& item) const
+{
+  const std::shared_ptr<CPVRTimerInfoTag> timer(item.GetPVRTimerInfoTag());
+  if (timer && !timer->IsDisabled())
+    return g_localizeStrings.Get(844); /* Deactivate */
+
+  return g_localizeStrings.Get(843); /* Activate */
+}
+
+bool ToggleTimerState::IsVisible(const CFileItem& item) const
+{
+  const std::shared_ptr<CPVRTimerInfoTag> timer(item.GetPVRTimerInfoTag());
+  if (!timer || URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER) ||
+      timer->IsBroken())
+    return false;
+
+  return timer->GetTimerType()->SupportsEnableDisable();
+}
+
+bool ToggleTimerState::Execute(const CFileItemPtr& item) const
+{
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().ToggleTimerState(item);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Add timer rule
+
+bool AddTimerRule::IsVisible(const CFileItem& item) const
+{
+  const std::shared_ptr<CPVREpgInfoTag> epg = item.GetEPGInfoTag();
+  return (epg && !epg->IsGapTag() &&
+          !CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epg));
+}
+
+bool AddTimerRule::Execute(const CFileItemPtr& item) const
+{
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().AddTimerRule(item, true, true);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Edit timer rule
+
+std::string EditTimerRule::GetLabel(const CFileItem& item) const
+{
+  const std::shared_ptr<CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
+  if (timer && !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER))
+  {
+    const std::shared_ptr<CPVRTimerInfoTag> parentTimer(
+        CServiceBroker::GetPVRManager().Timers()->GetTimerRule(timer));
+    if (parentTimer)
     {
-      const std::shared_ptr<CPVRRecording> recording(item.GetPVRRecordingInfoTag());
-      if (recording && recording->IsInProgress())
-        return true;
-
-      std::shared_ptr<CPVRChannel> channel = item.GetPVRChannelInfoTag();
-      if (channel)
-        return CServiceBroker::GetPVRManager().Timers()->IsRecordingOnChannel(*channel);
-
-      const std::shared_ptr<CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
-      if (timer && !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER))
-        return timer->IsRecording();
-
-      const std::shared_ptr<CPVREpgInfoTag> epg = item.GetEPGInfoTag();
-      if (epg && epg->IsGapTag())
-      {
-        channel = CServiceBroker::GetPVRManager().ChannelGroups()->GetChannelForEpgTag(epg);
-        if (channel)
-          return CServiceBroker::GetPVRManager().Timers()->IsRecordingOnChannel(*channel);
-      }
-
-      return false;
+      if (!parentTimer->GetTimerType()->IsReadOnly())
+        return g_localizeStrings.Get(19243); /* Edit timer rule */
     }
+  }
 
-    bool StopRecording::Execute(const CFileItemPtr& item) const
+  return g_localizeStrings.Get(19304); /* View timer rule */
+}
+
+bool EditTimerRule::IsVisible(const CFileItem& item) const
+{
+  const std::shared_ptr<CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
+  if (timer && !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER))
+    return timer->HasParent();
+
+  return false;
+}
+
+bool EditTimerRule::Execute(const CFileItemPtr& item) const
+{
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().EditTimerRule(item);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Delete timer rule
+
+bool DeleteTimerRule::IsVisible(const CFileItem& item) const
+{
+  const std::shared_ptr<CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
+  if (timer && !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER))
+  {
+    const std::shared_ptr<CPVRTimerInfoTag> parentTimer(
+        CServiceBroker::GetPVRManager().Timers()->GetTimerRule(timer));
+    if (parentTimer)
+      return parentTimer->GetTimerType()->AllowsDelete();
+  }
+
+  return false;
+}
+
+bool DeleteTimerRule::Execute(const CFileItemPtr& item) const
+{
+  auto& timers = CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>();
+  const std::shared_ptr<CFileItem> parentTimer = timers.GetTimerRule(item);
+  if (parentTimer)
+    return timers.DeleteTimerRule(parentTimer);
+
+  return false;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Edit / View timer
+
+std::string EditTimer::GetLabel(const CFileItem& item) const
+{
+  const std::shared_ptr<CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
+  if (timer)
+  {
+    const std::shared_ptr<CPVRTimerType> timerType = timer->GetTimerType();
+    if (item.GetEPGInfoTag())
     {
-      const std::shared_ptr<CPVREpgInfoTag> epgTag = item->GetEPGInfoTag();
-      if (epgTag && epgTag->IsGapTag())
-      {
-        // instance recording
-        const std::shared_ptr<CPVRChannel> channel =
-            CServiceBroker::GetPVRManager().ChannelGroups()->GetChannelForEpgTag(epgTag);
-        if (channel)
-          return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().SetRecordingOnChannel(
-              channel, false);
-      }
-
-      return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().StopRecording(item);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////
-    // Edit recording
-
-    bool EditRecording::IsVisible(const CFileItem& item) const
-    {
-      const std::shared_ptr<CPVRRecording> recording(item.GetPVRRecordingInfoTag());
-      if (recording && !recording->IsDeleted() && !recording->IsInProgress())
-      {
-        return CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().CanEditRecording(item);
-      }
-      return false;
-    }
-
-    bool EditRecording::Execute(const CFileItemPtr& item) const
-    {
-      return CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().EditRecording(item);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////
-    // Delete recording
-
-    std::string DeleteRecording::GetLabel(const CFileItem& item) const
-    {
-      const std::shared_ptr<CPVRRecording> recording(item.GetPVRRecordingInfoTag());
-      if (recording && recording->IsDeleted())
-        return g_localizeStrings.Get(19291); /* Delete permanently */
-
-      return g_localizeStrings.Get(117); /* Delete */
-    }
-
-    bool DeleteRecording::IsVisible(const CFileItem& item) const
-    {
-      const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(item);
-      if (client && !client->GetClientCapabilities().SupportsRecordingsDelete())
-        return false;
-
-      const std::shared_ptr<CPVRRecording> recording(item.GetPVRRecordingInfoTag());
-      if (recording && !recording->IsInProgress())
-        return true;
-
-      // recordings folder?
-      if (item.m_bIsFolder &&
-          CServiceBroker::GetPVRManager().Clients()->AnyClientSupportingRecordingsDelete())
-      {
-        const CPVRRecordingsPath path(item.GetPath());
-        return path.IsValid() && !path.IsRecordingsRoot();
-      }
-
-      return false;
-    }
-
-    bool DeleteRecording::Execute(const CFileItemPtr& item) const
-    {
-      return CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().DeleteRecording(item);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////
-    // Undelete recording
-
-    bool UndeleteRecording::IsVisible(const CFileItem& item) const
-    {
-      const std::shared_ptr<CPVRRecording> recording(item.GetPVRRecordingInfoTag());
-      if (recording && recording->IsDeleted())
-        return true;
-
-      return false;
-    }
-
-    bool UndeleteRecording::Execute(const CFileItemPtr& item) const
-    {
-      return CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().UndeleteRecording(item);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////
-    // Delete watched recordings
-
-    bool DeleteWatchedRecordings::IsVisible(const CFileItem& item) const
-    {
-      // recordings folder?
-      if (item.m_bIsFolder && !item.IsParentFolder())
-        return CPVRRecordingsPath(item.GetPath()).IsValid();
-
-      return false;
-    }
-
-    bool DeleteWatchedRecordings::Execute(const std::shared_ptr<CFileItem>& item) const
-    {
-      return CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().DeleteWatchedRecordings(
-          item);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////
-    // Add reminder
-
-    bool AddReminder::IsVisible(const CFileItem& item) const
-    {
-      const std::shared_ptr<CPVREpgInfoTag> epg = item.GetEPGInfoTag();
-      if (epg &&
-          !CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epg) &&
-          epg->StartAsLocalTime() > CDateTime::GetCurrentDateTime())
-        return true;
-
-      return false;
-    }
-
-    bool AddReminder::Execute(const std::shared_ptr<CFileItem>& item) const
-    {
-      return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().AddReminder(item);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////
-    // Activate / deactivate timer or timer rule
-
-    std::string ToggleTimerState::GetLabel(const CFileItem& item) const
-    {
-      const std::shared_ptr<CPVRTimerInfoTag> timer(item.GetPVRTimerInfoTag());
-      if (timer && !timer->IsDisabled())
-        return g_localizeStrings.Get(844); /* Deactivate */
-
-      return g_localizeStrings.Get(843); /* Activate */
-    }
-
-    bool ToggleTimerState::IsVisible(const CFileItem& item) const
-    {
-      const std::shared_ptr<CPVRTimerInfoTag> timer(item.GetPVRTimerInfoTag());
-      if (!timer || URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER) || timer->IsBroken())
-        return false;
-
-      return timer->GetTimerType()->SupportsEnableDisable();
-    }
-
-    bool ToggleTimerState::Execute(const CFileItemPtr& item) const
-    {
-      return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().ToggleTimerState(item);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////
-    // Add timer rule
-
-    bool AddTimerRule::IsVisible(const CFileItem& item) const
-    {
-      const std::shared_ptr<CPVREpgInfoTag> epg = item.GetEPGInfoTag();
-      return (epg && !epg->IsGapTag() &&
-              !CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epg));
-    }
-
-    bool AddTimerRule::Execute(const CFileItemPtr& item) const
-    {
-      return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().AddTimerRule(item, true, true);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////
-    // Edit timer rule
-
-    std::string EditTimerRule::GetLabel(const CFileItem& item) const
-    {
-      const std::shared_ptr<CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
-      if (timer && !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER))
-      {
-        const std::shared_ptr<CPVRTimerInfoTag> parentTimer(CServiceBroker::GetPVRManager().Timers()->GetTimerRule(timer));
-        if (parentTimer)
-        {
-          if (!parentTimer->GetTimerType()->IsReadOnly())
-            return g_localizeStrings.Get(19243); /* Edit timer rule */
-        }
-      }
-
-      return g_localizeStrings.Get(19304); /* View timer rule */
-    }
-
-    bool EditTimerRule::IsVisible(const CFileItem& item) const
-    {
-      const std::shared_ptr<CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
-      if (timer && !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER))
-        return timer->HasParent();
-
-      return false;
-    }
-
-    bool EditTimerRule::Execute(const CFileItemPtr& item) const
-    {
-      return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().EditTimerRule(item);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////
-    // Delete timer rule
-
-    bool DeleteTimerRule::IsVisible(const CFileItem& item) const
-    {
-      const std::shared_ptr<CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
-      if (timer && !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER))
-      {
-        const std::shared_ptr<CPVRTimerInfoTag> parentTimer(CServiceBroker::GetPVRManager().Timers()->GetTimerRule(timer));
-        if (parentTimer)
-          return parentTimer->GetTimerType()->AllowsDelete();
-      }
-
-      return false;
-    }
-
-    bool DeleteTimerRule::Execute(const CFileItemPtr& item) const
-    {
-      auto& timers = CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>();
-      const std::shared_ptr<CFileItem> parentTimer = timers.GetTimerRule(item);
-      if (parentTimer)
-        return timers.DeleteTimerRule(parentTimer);
-
-      return false;
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////
-    // Edit / View timer
-
-    std::string EditTimer::GetLabel(const CFileItem& item) const
-    {
-      const std::shared_ptr<CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
-      if (timer)
-      {
-        const std::shared_ptr<CPVRTimerType> timerType = timer->GetTimerType();
-        if (item.GetEPGInfoTag())
-        {
-          if (timerType->IsReminder())
-            return g_localizeStrings.Get(timerType->IsReadOnly() ? 829 /* View reminder */
-                                                                 : 830); /* Edit reminder */
-          else
-            return g_localizeStrings.Get(timerType->IsReadOnly() ? 19241 /* View timer */
-                                                                 : 19242); /* Edit timer */
-        }
-        else
-          return g_localizeStrings.Get(timerType->IsReadOnly() ? 21483 : 21450); /* View/Edit */
-      }
-      return g_localizeStrings.Get(19241); /* View timer */
-    }
-
-    bool EditTimer::IsVisible(const CFileItem& item) const
-    {
-      const std::shared_ptr<CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
-      return timer && (!item.GetEPGInfoTag() || !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER));
-    }
-
-    bool EditTimer::Execute(const CFileItemPtr& item) const
-    {
-      return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().EditTimer(item);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////
-    // Delete timer
-
-    std::string DeleteTimer::GetLabel(const CFileItem& item) const
-    {
-      if (item.GetPVRTimerInfoTag())
-        return g_localizeStrings.Get(117); /* Delete */
-
-      const std::shared_ptr<CPVREpgInfoTag> epg = item.GetEPGInfoTag();
-      if (epg)
-      {
-        const std::shared_ptr<CPVRTimerInfoTag> timer = CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epg);
-        if (timer && timer->IsReminder())
-          return g_localizeStrings.Get(827); /* Delete reminder */
-      }
-      return g_localizeStrings.Get(19060); /* Delete timer */
-    }
-
-    bool DeleteTimer::IsVisible(const CFileItem& item) const
-    {
-      const std::shared_ptr<CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
-      if (timer && (!item.GetEPGInfoTag() || !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER)) && !timer->IsRecording())
-        return timer->GetTimerType()->AllowsDelete();
-
-      return false;
-    }
-
-    bool DeleteTimer::Execute(const CFileItemPtr& item) const
-    {
-      return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().DeleteTimer(item);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////
-    // PVR Client menu hook
-
-    std::string PVRClientMenuHook::GetLabel(const CFileItem& item) const
-    {
-      return m_hook.GetLabel();
-    }
-
-    bool PVRClientMenuHook::IsVisible(const CFileItem& item) const
-    {
-      const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(item);
-      if (!client || m_hook.GetAddonId() != client->ID())
-        return false;
-
-      if (m_hook.IsAllHook())
-        return !item.m_bIsFolder && !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER);
-      else if (m_hook.IsEpgHook())
-        return item.IsEPG();
-      else if (m_hook.IsChannelHook())
-        return item.IsPVRChannel();
-      else if (m_hook.IsDeletedRecordingHook())
-        return item.IsDeletedPVRRecording();
-      else if (m_hook.IsRecordingHook())
-        return item.IsUsablePVRRecording();
-      else if (m_hook.IsTimerHook())
-        return item.IsPVRTimer();
+      if (timerType->IsReminder())
+        return g_localizeStrings.Get(timerType->IsReadOnly() ? 829 /* View reminder */
+                                                             : 830); /* Edit reminder */
       else
-        return false;
+        return g_localizeStrings.Get(timerType->IsReadOnly() ? 19241 /* View timer */
+                                                             : 19242); /* Edit timer */
     }
-
-    bool PVRClientMenuHook::Execute(const CFileItemPtr& item) const
-    {
-      const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(*item);
-      if (!client)
-        return false;
-
-      if (item->IsEPG())
-        return client->CallEpgTagMenuHook(m_hook, item->GetEPGInfoTag()) == PVR_ERROR_NO_ERROR;
-      else if (item->IsPVRChannel())
-        return client->CallChannelMenuHook(m_hook, item->GetPVRChannelInfoTag()) == PVR_ERROR_NO_ERROR;
-      else if (item->IsDeletedPVRRecording())
-        return client->CallRecordingMenuHook(m_hook, item->GetPVRRecordingInfoTag(), true) == PVR_ERROR_NO_ERROR;
-      else if (item->IsUsablePVRRecording())
-        return client->CallRecordingMenuHook(m_hook, item->GetPVRRecordingInfoTag(), false) == PVR_ERROR_NO_ERROR;
-      else if (item->IsPVRTimer())
-        return client->CallTimerMenuHook(m_hook, item->GetPVRTimerInfoTag()) == PVR_ERROR_NO_ERROR;
-      else
-        return false;
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////
-    // Execute saved search
-
-    bool ExecuteSearch::IsVisible(const CFileItem& item) const
-    {
-      return item.HasEPGSearchFilter();
-    }
-
-    bool ExecuteSearch::Execute(const std::shared_ptr<CFileItem>& item) const
-    {
-      return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ExecuteSavedSearch(item);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////
-    // Edit saved search
-
-    bool EditSearch::IsVisible(const CFileItem& item) const
-    {
-      return item.HasEPGSearchFilter();
-    }
-
-    bool EditSearch::Execute(const std::shared_ptr<CFileItem>& item) const
-    {
-      return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().EditSavedSearch(item);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////
-    // Rename saved search
-
-    bool RenameSearch::IsVisible(const CFileItem& item) const
-    {
-      return item.HasEPGSearchFilter();
-    }
-
-    bool RenameSearch::Execute(const std::shared_ptr<CFileItem>& item) const
-    {
-      return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().RenameSavedSearch(item);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////////
-    // Delete saved search
-
-    bool DeleteSearch::IsVisible(const CFileItem& item) const
-    {
-      return item.HasEPGSearchFilter();
-    }
-
-    bool DeleteSearch::Execute(const std::shared_ptr<CFileItem>& item) const
-    {
-      return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().DeleteSavedSearch(item);
-    }
-
-  } // namespace CONEXTMENUITEM
-
-  CPVRContextMenuManager& CPVRContextMenuManager::GetInstance()
-  {
-    static CPVRContextMenuManager instance;
-    return instance;
+    else
+      return g_localizeStrings.Get(timerType->IsReadOnly() ? 21483 : 21450); /* View/Edit */
   }
+  return g_localizeStrings.Get(19241); /* View timer */
+}
 
-  CPVRContextMenuManager::CPVRContextMenuManager()
-    : m_items({
-          std::make_shared<CONTEXTMENUITEM::PlayEpgTag>(19190), /* Play programme */
-          std::make_shared<CONTEXTMENUITEM::PlayRecording>(19687), /* Play recording */
-          std::make_shared<CONTEXTMENUITEM::ShowInformation>(),
-          std::make_shared<CONTEXTMENUITEM::ShowChannelGuide>(19686), /* Channel guide */
-          std::make_shared<CONTEXTMENUITEM::FindSimilar>(19003), /* Find similar */
-          std::make_shared<CONTEXTMENUITEM::ToggleTimerState>(),
-          std::make_shared<CONTEXTMENUITEM::AddTimerRule>(19061), /* Add timer */
-          std::make_shared<CONTEXTMENUITEM::EditTimerRule>(),
-          std::make_shared<CONTEXTMENUITEM::DeleteTimerRule>(19295), /* Delete timer rule */
-          std::make_shared<CONTEXTMENUITEM::EditTimer>(),
-          std::make_shared<CONTEXTMENUITEM::DeleteTimer>(),
-          std::make_shared<CONTEXTMENUITEM::StartRecording>(264), /* Record */
-          std::make_shared<CONTEXTMENUITEM::StopRecording>(19059), /* Stop recording */
-          std::make_shared<CONTEXTMENUITEM::EditRecording>(21450), /* Edit */
-          std::make_shared<CONTEXTMENUITEM::DeleteRecording>(),
-          std::make_shared<CONTEXTMENUITEM::UndeleteRecording>(19290), /* Undelete */
-          std::make_shared<CONTEXTMENUITEM::DeleteWatchedRecordings>(19327), /* Delete watched */
-          std::make_shared<CONTEXTMENUITEM::AddReminder>(826), /* Set reminder */
-          std::make_shared<CONTEXTMENUITEM::ExecuteSearch>(137), /* Search */
-          std::make_shared<CONTEXTMENUITEM::EditSearch>(21450), /* Edit */
-          std::make_shared<CONTEXTMENUITEM::RenameSearch>(118), /* Rename */
-          std::make_shared<CONTEXTMENUITEM::DeleteSearch>(117), /* Delete */
-      })
+bool EditTimer::IsVisible(const CFileItem& item) const
+{
+  const std::shared_ptr<CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
+  return timer && (!item.GetEPGInfoTag() ||
+                   !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER));
+}
+
+bool EditTimer::Execute(const CFileItemPtr& item) const
+{
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().EditTimer(item);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Delete timer
+
+std::string DeleteTimer::GetLabel(const CFileItem& item) const
+{
+  if (item.GetPVRTimerInfoTag())
+    return g_localizeStrings.Get(117); /* Delete */
+
+  const std::shared_ptr<CPVREpgInfoTag> epg = item.GetEPGInfoTag();
+  if (epg)
   {
+    const std::shared_ptr<CPVRTimerInfoTag> timer =
+        CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epg);
+    if (timer && timer->IsReminder())
+      return g_localizeStrings.Get(827); /* Delete reminder */
   }
+  return g_localizeStrings.Get(19060); /* Delete timer */
+}
 
-  void CPVRContextMenuManager::AddMenuHook(const CPVRClientMenuHook& hook)
+bool DeleteTimer::IsVisible(const CFileItem& item) const
+{
+  const std::shared_ptr<CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
+  if (timer &&
+      (!item.GetEPGInfoTag() ||
+       !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER)) &&
+      !timer->IsRecording())
+    return timer->GetTimerType()->AllowsDelete();
+
+  return false;
+}
+
+bool DeleteTimer::Execute(const CFileItemPtr& item) const
+{
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().DeleteTimer(item);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// PVR Client menu hook
+
+std::string PVRClientMenuHook::GetLabel(const CFileItem& item) const
+{
+  return m_hook.GetLabel();
+}
+
+bool PVRClientMenuHook::IsVisible(const CFileItem& item) const
+{
+  const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(item);
+  if (!client || m_hook.GetAddonId() != client->ID())
+    return false;
+
+  if (m_hook.IsAllHook())
+    return !item.m_bIsFolder &&
+           !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER);
+  else if (m_hook.IsEpgHook())
+    return item.IsEPG();
+  else if (m_hook.IsChannelHook())
+    return item.IsPVRChannel();
+  else if (m_hook.IsDeletedRecordingHook())
+    return item.IsDeletedPVRRecording();
+  else if (m_hook.IsRecordingHook())
+    return item.IsUsablePVRRecording();
+  else if (m_hook.IsTimerHook())
+    return item.IsPVRTimer();
+  else
+    return false;
+}
+
+bool PVRClientMenuHook::Execute(const CFileItemPtr& item) const
+{
+  const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(*item);
+  if (!client)
+    return false;
+
+  if (item->IsEPG())
+    return client->CallEpgTagMenuHook(m_hook, item->GetEPGInfoTag()) == PVR_ERROR_NO_ERROR;
+  else if (item->IsPVRChannel())
+    return client->CallChannelMenuHook(m_hook, item->GetPVRChannelInfoTag()) == PVR_ERROR_NO_ERROR;
+  else if (item->IsDeletedPVRRecording())
+    return client->CallRecordingMenuHook(m_hook, item->GetPVRRecordingInfoTag(), true) ==
+           PVR_ERROR_NO_ERROR;
+  else if (item->IsUsablePVRRecording())
+    return client->CallRecordingMenuHook(m_hook, item->GetPVRRecordingInfoTag(), false) ==
+           PVR_ERROR_NO_ERROR;
+  else if (item->IsPVRTimer())
+    return client->CallTimerMenuHook(m_hook, item->GetPVRTimerInfoTag()) == PVR_ERROR_NO_ERROR;
+  else
+    return false;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Execute saved search
+
+bool ExecuteSearch::IsVisible(const CFileItem& item) const
+{
+  return item.HasEPGSearchFilter();
+}
+
+bool ExecuteSearch::Execute(const std::shared_ptr<CFileItem>& item) const
+{
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ExecuteSavedSearch(item);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Edit saved search
+
+bool EditSearch::IsVisible(const CFileItem& item) const
+{
+  return item.HasEPGSearchFilter();
+}
+
+bool EditSearch::Execute(const std::shared_ptr<CFileItem>& item) const
+{
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().EditSavedSearch(item);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Rename saved search
+
+bool RenameSearch::IsVisible(const CFileItem& item) const
+{
+  return item.HasEPGSearchFilter();
+}
+
+bool RenameSearch::Execute(const std::shared_ptr<CFileItem>& item) const
+{
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().RenameSavedSearch(item);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Delete saved search
+
+bool DeleteSearch::IsVisible(const CFileItem& item) const
+{
+  return item.HasEPGSearchFilter();
+}
+
+bool DeleteSearch::Execute(const std::shared_ptr<CFileItem>& item) const
+{
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().DeleteSavedSearch(item);
+}
+
+} // namespace CONTEXTMENUITEM
+
+CPVRContextMenuManager& CPVRContextMenuManager::GetInstance()
+{
+  static CPVRContextMenuManager instance;
+  return instance;
+}
+
+CPVRContextMenuManager::CPVRContextMenuManager()
+  : m_items({
+        std::make_shared<CONTEXTMENUITEM::PlayEpgTag>(19190), /* Play programme */
+        std::make_shared<CONTEXTMENUITEM::PlayRecording>(19687), /* Play recording */
+        std::make_shared<CONTEXTMENUITEM::ShowInformation>(),
+        std::make_shared<CONTEXTMENUITEM::ShowChannelGuide>(19686), /* Channel guide */
+        std::make_shared<CONTEXTMENUITEM::FindSimilar>(19003), /* Find similar */
+        std::make_shared<CONTEXTMENUITEM::ToggleTimerState>(),
+        std::make_shared<CONTEXTMENUITEM::AddTimerRule>(19061), /* Add timer */
+        std::make_shared<CONTEXTMENUITEM::EditTimerRule>(),
+        std::make_shared<CONTEXTMENUITEM::DeleteTimerRule>(19295), /* Delete timer rule */
+        std::make_shared<CONTEXTMENUITEM::EditTimer>(),
+        std::make_shared<CONTEXTMENUITEM::DeleteTimer>(),
+        std::make_shared<CONTEXTMENUITEM::StartRecording>(264), /* Record */
+        std::make_shared<CONTEXTMENUITEM::StopRecording>(19059), /* Stop recording */
+        std::make_shared<CONTEXTMENUITEM::EditRecording>(21450), /* Edit */
+        std::make_shared<CONTEXTMENUITEM::DeleteRecording>(),
+        std::make_shared<CONTEXTMENUITEM::UndeleteRecording>(19290), /* Undelete */
+        std::make_shared<CONTEXTMENUITEM::DeleteWatchedRecordings>(19327), /* Delete watched */
+        std::make_shared<CONTEXTMENUITEM::AddReminder>(826), /* Set reminder */
+        std::make_shared<CONTEXTMENUITEM::ExecuteSearch>(137), /* Search */
+        std::make_shared<CONTEXTMENUITEM::EditSearch>(21450), /* Edit */
+        std::make_shared<CONTEXTMENUITEM::RenameSearch>(118), /* Rename */
+        std::make_shared<CONTEXTMENUITEM::DeleteSearch>(117), /* Delete */
+    })
+{
+}
+
+void CPVRContextMenuManager::AddMenuHook(const CPVRClientMenuHook& hook)
+{
+  if (hook.IsSettingsHook())
+    return; // settings hooks are not handled using context menus
+
+  const auto item = std::make_shared<CONTEXTMENUITEM::PVRClientMenuHook>(hook);
+  m_items.emplace_back(item);
+  m_events.Publish(PVRContextMenuEvent(PVRContextMenuEventAction::ADD_ITEM, item));
+}
+
+void CPVRContextMenuManager::RemoveMenuHook(const CPVRClientMenuHook& hook)
+{
+  if (hook.IsSettingsHook())
+    return; // settings hooks are not handled using context menus
+
+  for (auto it = m_items.begin(); it < m_items.end(); ++it)
   {
-    if (hook.IsSettingsHook())
-      return; // settings hooks are not handled using context menus
-
-    const auto item = std::make_shared<CONTEXTMENUITEM::PVRClientMenuHook>(hook);
-    m_items.emplace_back(item);
-    m_events.Publish(PVRContextMenuEvent(PVRContextMenuEventAction::ADD_ITEM, item));
-  }
-
-  void CPVRContextMenuManager::RemoveMenuHook(const CPVRClientMenuHook& hook)
-  {
-    if (hook.IsSettingsHook())
-      return; // settings hooks are not handled using context menus
-
-    for (auto it = m_items.begin(); it < m_items.end(); ++it)
+    const CONTEXTMENUITEM::PVRClientMenuHook* cmh =
+        dynamic_cast<const CONTEXTMENUITEM::PVRClientMenuHook*>((*it).get());
+    if (cmh && cmh->GetHook() == hook)
     {
-      const CONTEXTMENUITEM::PVRClientMenuHook* cmh = dynamic_cast<const CONTEXTMENUITEM::PVRClientMenuHook*>((*it).get());
-      if (cmh && cmh->GetHook() == hook)
-      {
-        m_events.Publish(PVRContextMenuEvent(PVRContextMenuEventAction::REMOVE_ITEM, *it));
-        m_items.erase(it);
-        return;
-      }
+      m_events.Publish(PVRContextMenuEvent(PVRContextMenuEventAction::REMOVE_ITEM, *it));
+      m_items.erase(it);
+      return;
     }
   }
+}
 
 } // namespace PVR

--- a/xbmc/pvr/PVRContextMenus.h
+++ b/xbmc/pvr/PVRContextMenus.h
@@ -17,46 +17,49 @@ class IContextMenuItem;
 
 namespace PVR
 {
-  enum class PVRContextMenuEventAction
+enum class PVRContextMenuEventAction
+{
+  ADD_ITEM,
+  REMOVE_ITEM
+};
+
+struct PVRContextMenuEvent
+{
+  PVRContextMenuEvent(const PVRContextMenuEventAction& a,
+                      const std::shared_ptr<IContextMenuItem>& i)
+    : action(a), item(i)
   {
-    ADD_ITEM,
-    REMOVE_ITEM
-  };
+  }
 
-  struct PVRContextMenuEvent
-  {
-    PVRContextMenuEvent(const PVRContextMenuEventAction& a, const std::shared_ptr<IContextMenuItem>& i)
-    : action(a), item(i) {}
+  PVRContextMenuEventAction action;
+  std::shared_ptr<IContextMenuItem> item;
+};
 
-    PVRContextMenuEventAction action;
-    std::shared_ptr<IContextMenuItem> item;
-  };
+class CPVRClientMenuHook;
 
-  class CPVRClientMenuHook;
+class CPVRContextMenuManager
+{
+public:
+  static CPVRContextMenuManager& GetInstance();
 
-  class CPVRContextMenuManager
-  {
-  public:
-    static CPVRContextMenuManager& GetInstance();
+  std::vector<std::shared_ptr<IContextMenuItem>> GetMenuItems() const { return m_items; }
 
-    std::vector<std::shared_ptr<IContextMenuItem>> GetMenuItems() const { return m_items; }
+  void AddMenuHook(const CPVRClientMenuHook& hook);
+  void RemoveMenuHook(const CPVRClientMenuHook& hook);
 
-    void AddMenuHook(const CPVRClientMenuHook& hook);
-    void RemoveMenuHook(const CPVRClientMenuHook& hook);
+  /*!
+   * @brief Query the events available for CEventStream
+   */
+  CEventStream<PVRContextMenuEvent>& Events() { return m_events; }
 
-    /*!
-     * @brief Query the events available for CEventStream
-     */
-    CEventStream<PVRContextMenuEvent>& Events() { return m_events; }
+private:
+  CPVRContextMenuManager();
+  CPVRContextMenuManager(const CPVRContextMenuManager&) = delete;
+  CPVRContextMenuManager const& operator=(CPVRContextMenuManager const&) = delete;
+  virtual ~CPVRContextMenuManager() = default;
 
-  private:
-    CPVRContextMenuManager();
-    CPVRContextMenuManager(const CPVRContextMenuManager&) = delete;
-    CPVRContextMenuManager const& operator=(CPVRContextMenuManager const&) = delete;
-    virtual ~CPVRContextMenuManager() = default;
-
-    std::vector<std::shared_ptr<IContextMenuItem>> m_items;
-    CEventSource<PVRContextMenuEvent> m_events;
-  };
+  std::vector<std::shared_ptr<IContextMenuItem>> m_items;
+  CEventSource<PVRContextMenuEvent> m_events;
+};
 
 } // namespace PVR

--- a/xbmc/pvr/PVRItem.cpp
+++ b/xbmc/pvr/PVRItem.cpp
@@ -25,138 +25,143 @@
 
 namespace PVR
 {
-  std::shared_ptr<CPVREpgInfoTag> CPVRItem::GetEpgInfoTag() const
+std::shared_ptr<CPVREpgInfoTag> CPVRItem::GetEpgInfoTag() const
+{
+  if (m_item->IsEPG())
   {
-    if (m_item->IsEPG())
-    {
-      return m_item->GetEPGInfoTag();
-    }
-    else if (m_item->IsPVRChannel())
-    {
-      return m_item->GetPVRChannelInfoTag()->GetEPGNow();
-    }
-    else if (m_item->IsPVRTimer())
-    {
-      return m_item->GetPVRTimerInfoTag()->GetEpgInfoTag();
-    }
-    else if (URIUtils::IsPVR(m_item->GetDynPath()))
-    {
-      CLog::LogF(LOGERROR, "Unsupported item type!");
-    }
-    return {};
+    return m_item->GetEPGInfoTag();
   }
+  else if (m_item->IsPVRChannel())
+  {
+    return m_item->GetPVRChannelInfoTag()->GetEPGNow();
+  }
+  else if (m_item->IsPVRTimer())
+  {
+    return m_item->GetPVRTimerInfoTag()->GetEpgInfoTag();
+  }
+  else if (URIUtils::IsPVR(m_item->GetDynPath()))
+  {
+    CLog::LogF(LOGERROR, "Unsupported item type!");
+  }
+  return {};
+}
 
-  std::shared_ptr<CPVREpgInfoTag> CPVRItem::GetNextEpgInfoTag() const
+std::shared_ptr<CPVREpgInfoTag> CPVRItem::GetNextEpgInfoTag() const
+{
+  if (m_item->IsEPG())
   {
-    if (m_item->IsEPG())
-    {
-      const std::shared_ptr<CPVRChannel> channel = CServiceBroker::GetPVRManager().ChannelGroups()->GetChannelForEpgTag(m_item->GetEPGInfoTag());
-      if (channel)
-        return channel->GetEPGNext();
-    }
-    else if (m_item->IsPVRChannel())
-    {
-      return m_item->GetPVRChannelInfoTag()->GetEPGNext();
-    }
-    else if (m_item->IsPVRTimer())
-    {
-      const std::shared_ptr<CPVRChannel> channel = m_item->GetPVRTimerInfoTag()->Channel();
-      if (channel)
-        return channel->GetEPGNext();
-    }
-    else if (URIUtils::IsPVR(m_item->GetDynPath()))
-    {
-      CLog::LogF(LOGERROR, "Unsupported item type!");
-    }
-    return {};
+    const std::shared_ptr<CPVRChannel> channel =
+        CServiceBroker::GetPVRManager().ChannelGroups()->GetChannelForEpgTag(
+            m_item->GetEPGInfoTag());
+    if (channel)
+      return channel->GetEPGNext();
   }
+  else if (m_item->IsPVRChannel())
+  {
+    return m_item->GetPVRChannelInfoTag()->GetEPGNext();
+  }
+  else if (m_item->IsPVRTimer())
+  {
+    const std::shared_ptr<CPVRChannel> channel = m_item->GetPVRTimerInfoTag()->Channel();
+    if (channel)
+      return channel->GetEPGNext();
+  }
+  else if (URIUtils::IsPVR(m_item->GetDynPath()))
+  {
+    CLog::LogF(LOGERROR, "Unsupported item type!");
+  }
+  return {};
+}
 
-  std::shared_ptr<CPVRChannel> CPVRItem::GetChannel() const
+std::shared_ptr<CPVRChannel> CPVRItem::GetChannel() const
+{
+  if (m_item->IsPVRChannel())
   {
-    if (m_item->IsPVRChannel())
-    {
-      return m_item->GetPVRChannelInfoTag();
-    }
-    else if (m_item->IsEPG())
-    {
-      return CServiceBroker::GetPVRManager().ChannelGroups()->GetChannelForEpgTag(m_item->GetEPGInfoTag());
-    }
-    else if (m_item->IsPVRTimer())
-    {
-      return m_item->GetPVRTimerInfoTag()->Channel();
-    }
-    else if (m_item->IsPVRRecording())
-    {
-      return m_item->GetPVRRecordingInfoTag()->Channel();
-    }
-    else if (URIUtils::IsPVR(m_item->GetDynPath()))
-    {
-      CLog::LogF(LOGERROR, "Unsupported item type!");
-    }
-    return {};
+    return m_item->GetPVRChannelInfoTag();
   }
+  else if (m_item->IsEPG())
+  {
+    return CServiceBroker::GetPVRManager().ChannelGroups()->GetChannelForEpgTag(
+        m_item->GetEPGInfoTag());
+  }
+  else if (m_item->IsPVRTimer())
+  {
+    return m_item->GetPVRTimerInfoTag()->Channel();
+  }
+  else if (m_item->IsPVRRecording())
+  {
+    return m_item->GetPVRRecordingInfoTag()->Channel();
+  }
+  else if (URIUtils::IsPVR(m_item->GetDynPath()))
+  {
+    CLog::LogF(LOGERROR, "Unsupported item type!");
+  }
+  return {};
+}
 
-  std::shared_ptr<CPVRTimerInfoTag> CPVRItem::GetTimerInfoTag() const
+std::shared_ptr<CPVRTimerInfoTag> CPVRItem::GetTimerInfoTag() const
+{
+  if (m_item->IsPVRTimer())
   {
-    if (m_item->IsPVRTimer())
-    {
-      return m_item->GetPVRTimerInfoTag();
-    }
-    else if (m_item->IsEPG())
-    {
-      return CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(m_item->GetEPGInfoTag());
-    }
-    else if (m_item->IsPVRChannel())
-    {
-      return CServiceBroker::GetPVRManager().Timers()->GetActiveTimerForChannel(m_item->GetPVRChannelInfoTag());
-    }
-    else if (URIUtils::IsPVR(m_item->GetDynPath()))
-    {
-      CLog::LogF(LOGERROR, "Unsupported item type!");
-    }
-    return {};
+    return m_item->GetPVRTimerInfoTag();
   }
+  else if (m_item->IsEPG())
+  {
+    return CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(m_item->GetEPGInfoTag());
+  }
+  else if (m_item->IsPVRChannel())
+  {
+    return CServiceBroker::GetPVRManager().Timers()->GetActiveTimerForChannel(
+        m_item->GetPVRChannelInfoTag());
+  }
+  else if (URIUtils::IsPVR(m_item->GetDynPath()))
+  {
+    CLog::LogF(LOGERROR, "Unsupported item type!");
+  }
+  return {};
+}
 
-  std::shared_ptr<CPVRRecording> CPVRItem::GetRecording() const
+std::shared_ptr<CPVRRecording> CPVRItem::GetRecording() const
+{
+  if (m_item->IsPVRRecording())
   {
-    if (m_item->IsPVRRecording())
-    {
-      return m_item->GetPVRRecordingInfoTag();
-    }
-    else if (m_item->IsEPG())
-    {
-      return CServiceBroker::GetPVRManager().Recordings()->GetRecordingForEpgTag(m_item->GetEPGInfoTag());
-    }
-    else if (URIUtils::IsPVR(m_item->GetDynPath()))
-    {
-      CLog::LogF(LOGERROR, "Unsupported item type!");
-    }
-    return {};
+    return m_item->GetPVRRecordingInfoTag();
   }
+  else if (m_item->IsEPG())
+  {
+    return CServiceBroker::GetPVRManager().Recordings()->GetRecordingForEpgTag(
+        m_item->GetEPGInfoTag());
+  }
+  else if (URIUtils::IsPVR(m_item->GetDynPath()))
+  {
+    CLog::LogF(LOGERROR, "Unsupported item type!");
+  }
+  return {};
+}
 
-  bool CPVRItem::IsRadio() const
+bool CPVRItem::IsRadio() const
+{
+  if (m_item->IsPVRChannel())
   {
-    if (m_item->IsPVRChannel())
-    {
-      return m_item->GetPVRChannelInfoTag()->IsRadio();
-    }
-    else if (m_item->IsEPG())
-    {
-      return m_item->GetEPGInfoTag()->IsRadio();
-    }
-    else if (m_item->IsPVRRecording())
-    {
-      return m_item->GetPVRRecordingInfoTag()->IsRadio();
-    }
-    else if (m_item->IsPVRTimer())
-    {
-      return m_item->GetPVRTimerInfoTag()->IsRadio();
-    }
-    else if (URIUtils::IsPVR(m_item->GetDynPath()))
-    {
-      CLog::LogF(LOGERROR, "Unsupported item type!");
-    }
-    return false;
+    return m_item->GetPVRChannelInfoTag()->IsRadio();
   }
+  else if (m_item->IsEPG())
+  {
+    return m_item->GetEPGInfoTag()->IsRadio();
+  }
+  else if (m_item->IsPVRRecording())
+  {
+    return m_item->GetPVRRecordingInfoTag()->IsRadio();
+  }
+  else if (m_item->IsPVRTimer())
+  {
+    return m_item->GetPVRTimerInfoTag()->IsRadio();
+  }
+  else if (URIUtils::IsPVR(m_item->GetDynPath()))
+  {
+    CLog::LogF(LOGERROR, "Unsupported item type!");
+  }
+  return false;
+}
 
 } // namespace PVR

--- a/xbmc/pvr/PVRItem.cpp
+++ b/xbmc/pvr/PVRItem.cpp
@@ -150,7 +150,7 @@ namespace PVR
     }
     else if (m_item->IsPVRTimer())
     {
-      return m_item->GetPVRTimerInfoTag()->m_bIsRadio;
+      return m_item->GetPVRTimerInfoTag()->IsRadio();
     }
     else if (URIUtils::IsPVR(m_item->GetDynPath()))
     {

--- a/xbmc/pvr/PVRItem.h
+++ b/xbmc/pvr/PVRItem.h
@@ -14,27 +14,27 @@ class CFileItem;
 
 namespace PVR
 {
-  class CPVRChannel;
-  class CPVREpgInfoTag;
-  class CPVRRecording;
-  class CPVRTimerInfoTag;
+class CPVRChannel;
+class CPVREpgInfoTag;
+class CPVRRecording;
+class CPVRTimerInfoTag;
 
-  class CPVRItem
-  {
-  public:
-    explicit CPVRItem(const std::shared_ptr<CFileItem>& item) : m_item(item.get()) {}
-    explicit CPVRItem(const CFileItem* item) : m_item(item) {}
+class CPVRItem
+{
+public:
+  explicit CPVRItem(const std::shared_ptr<CFileItem>& item) : m_item(item.get()) {}
+  explicit CPVRItem(const CFileItem* item) : m_item(item) {}
 
-    std::shared_ptr<CPVREpgInfoTag> GetEpgInfoTag() const;
-    std::shared_ptr<CPVREpgInfoTag> GetNextEpgInfoTag() const;
-    std::shared_ptr<CPVRChannel> GetChannel() const;
-    std::shared_ptr<CPVRTimerInfoTag> GetTimerInfoTag() const;
-    std::shared_ptr<CPVRRecording> GetRecording() const;
+  std::shared_ptr<CPVREpgInfoTag> GetEpgInfoTag() const;
+  std::shared_ptr<CPVREpgInfoTag> GetNextEpgInfoTag() const;
+  std::shared_ptr<CPVRChannel> GetChannel() const;
+  std::shared_ptr<CPVRTimerInfoTag> GetTimerInfoTag() const;
+  std::shared_ptr<CPVRRecording> GetRecording() const;
 
-    bool IsRadio() const;
+  bool IsRadio() const;
 
-  private:
-    const CFileItem* m_item;
-  };
+private:
+  const CFileItem* m_item;
+};
 
 } // namespace PVR

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -286,7 +286,7 @@ std::shared_ptr<CPVRClient> CPVRManager::GetClient(const CFileItem& item) const
   else if (item.HasPVRRecordingInfoTag())
     iClientID = item.GetPVRRecordingInfoTag()->ClientID();
   else if (item.HasPVRTimerInfoTag())
-    iClientID = item.GetPVRTimerInfoTag()->m_iClientId;
+    iClientID = item.GetPVRTimerInfoTag()->ClientID();
   else if (item.HasEPGInfoTag())
     iClientID = item.GetEPGInfoTag()->ClientID();
   else if (URIUtils::IsPVRChannel(item.GetPath()))

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -42,38 +42,38 @@
 using namespace PVR;
 using namespace KODI::MESSAGING;
 
-#define SETTING_TMR_TYPE          "timer.type"
-#define SETTING_TMR_ACTIVE        "timer.active"
-#define SETTING_TMR_NAME          "timer.name"
-#define SETTING_TMR_EPGSEARCH     "timer.epgsearch"
-#define SETTING_TMR_FULLTEXT      "timer.fulltext"
-#define SETTING_TMR_CHANNEL       "timer.channel"
+#define SETTING_TMR_TYPE "timer.type"
+#define SETTING_TMR_ACTIVE "timer.active"
+#define SETTING_TMR_NAME "timer.name"
+#define SETTING_TMR_EPGSEARCH "timer.epgsearch"
+#define SETTING_TMR_FULLTEXT "timer.fulltext"
+#define SETTING_TMR_CHANNEL "timer.channel"
 #define SETTING_TMR_START_ANYTIME "timer.startanytime"
-#define SETTING_TMR_END_ANYTIME   "timer.endanytime"
-#define SETTING_TMR_START_DAY     "timer.startday"
-#define SETTING_TMR_END_DAY       "timer.endday"
-#define SETTING_TMR_BEGIN         "timer.begin"
-#define SETTING_TMR_END           "timer.end"
-#define SETTING_TMR_WEEKDAYS      "timer.weekdays"
-#define SETTING_TMR_FIRST_DAY     "timer.firstday"
-#define SETTING_TMR_NEW_EPISODES  "timer.newepisodes"
-#define SETTING_TMR_BEGIN_PRE     "timer.startmargin"
-#define SETTING_TMR_END_POST      "timer.endmargin"
-#define SETTING_TMR_PRIORITY      "timer.priority"
-#define SETTING_TMR_LIFETIME      "timer.lifetime"
-#define SETTING_TMR_MAX_REC       "timer.maxrecordings"
-#define SETTING_TMR_DIR           "timer.directory"
-#define SETTING_TMR_REC_GROUP     "timer.recgroup"
+#define SETTING_TMR_END_ANYTIME "timer.endanytime"
+#define SETTING_TMR_START_DAY "timer.startday"
+#define SETTING_TMR_END_DAY "timer.endday"
+#define SETTING_TMR_BEGIN "timer.begin"
+#define SETTING_TMR_END "timer.end"
+#define SETTING_TMR_WEEKDAYS "timer.weekdays"
+#define SETTING_TMR_FIRST_DAY "timer.firstday"
+#define SETTING_TMR_NEW_EPISODES "timer.newepisodes"
+#define SETTING_TMR_BEGIN_PRE "timer.startmargin"
+#define SETTING_TMR_END_POST "timer.endmargin"
+#define SETTING_TMR_PRIORITY "timer.priority"
+#define SETTING_TMR_LIFETIME "timer.lifetime"
+#define SETTING_TMR_MAX_REC "timer.maxrecordings"
+#define SETTING_TMR_DIR "timer.directory"
+#define SETTING_TMR_REC_GROUP "timer.recgroup"
 
-#define TYPE_DEP_VISIBI_COND_ID_POSTFIX     "visibi.typedep"
-#define TYPE_DEP_ENABLE_COND_ID_POSTFIX     "enable.typedep"
-#define CHANNEL_DEP_VISIBI_COND_ID_POSTFIX  "visibi.channeldep"
-#define START_ANYTIME_DEP_VISIBI_COND_ID_POSTFIX  "visibi.startanytimedep"
-#define END_ANYTIME_DEP_VISIBI_COND_ID_POSTFIX    "visibi.endanytimedep"
+#define TYPE_DEP_VISIBI_COND_ID_POSTFIX "visibi.typedep"
+#define TYPE_DEP_ENABLE_COND_ID_POSTFIX "enable.typedep"
+#define CHANNEL_DEP_VISIBI_COND_ID_POSTFIX "visibi.channeldep"
+#define START_ANYTIME_DEP_VISIBI_COND_ID_POSTFIX "visibi.startanytimedep"
+#define END_ANYTIME_DEP_VISIBI_COND_ID_POSTFIX "visibi.endanytimedep"
 
-CGUIDialogPVRTimerSettings::CGUIDialogPVRTimerSettings() :
-  CGUIDialogSettingsManualBase(WINDOW_DIALOG_PVR_TIMER_SETTING, "DialogSettings.xml"),
-  m_iWeekdays(PVR_WEEKDAY_NONE)
+CGUIDialogPVRTimerSettings::CGUIDialogPVRTimerSettings()
+  : CGUIDialogSettingsManualBase(WINDOW_DIALOG_PVR_TIMER_SETTING, "DialogSettings.xml"),
+    m_iWeekdays(PVR_WEEKDAY_NONE)
 {
   m_loadType = LOAD_EVERY_TIME;
 }
@@ -104,9 +104,12 @@ void CGUIDialogPVRTimerSettings::SetTimer(const std::shared_ptr<CPVRTimerInfoTag
   m_timerType = m_timerInfoTag->GetTimerType();
   m_bIsRadio = m_timerInfoTag->m_bIsRadio;
   m_bIsNewTimer = m_timerInfoTag->m_iClientIndex == PVR_TIMER_NO_CLIENT_INDEX;
-  m_bTimerActive = m_bIsNewTimer || !m_timerType->SupportsEnableDisable() || !(m_timerInfoTag->m_state == PVR_TIMER_STATE_DISABLED);
-  m_bStartAnyTime = m_bIsNewTimer || !m_timerType->SupportsStartAnyTime() || m_timerInfoTag->m_bStartAnyTime;
-  m_bEndAnyTime = m_bIsNewTimer || !m_timerType->SupportsEndAnyTime() || m_timerInfoTag->m_bEndAnyTime;
+  m_bTimerActive = m_bIsNewTimer || !m_timerType->SupportsEnableDisable() ||
+                   !(m_timerInfoTag->m_state == PVR_TIMER_STATE_DISABLED);
+  m_bStartAnyTime =
+      m_bIsNewTimer || !m_timerType->SupportsStartAnyTime() || m_timerInfoTag->m_bStartAnyTime;
+  m_bEndAnyTime =
+      m_bIsNewTimer || !m_timerType->SupportsEndAnyTime() || m_timerInfoTag->m_bEndAnyTime;
   m_strTitle = m_timerInfoTag->m_strTitle;
 
   m_startLocalTime = m_timerInfoTag->StartAsLocalTime();
@@ -133,7 +136,8 @@ void CGUIDialogPVRTimerSettings::SetTimer(const std::shared_ptr<CPVRTimerInfoTag
   m_iLifetime = m_timerInfoTag->m_iLifetime;
   m_iMaxRecordings = m_timerInfoTag->m_iMaxRecordings;
 
-  if (m_bIsNewTimer && m_timerInfoTag->m_strDirectory.empty() && m_timerType->SupportsRecordingFolders())
+  if (m_bIsNewTimer && m_timerInfoTag->m_strDirectory.empty() &&
+      m_timerType->SupportsRecordingFolders())
     m_strDirectory = m_strTitle;
   else
     m_strDirectory = m_timerInfoTag->m_strDirectory;
@@ -245,11 +249,13 @@ void CGUIDialogPVRTimerSettings::InitializeSettings()
   AddTypeDependentEnableCondition(setting, SETTING_TMR_ACTIVE);
 
   // Name
-  setting = AddEdit(group, SETTING_TMR_NAME, 19075, SettingLevel::Basic, m_strTitle, true, false, 19097);
+  setting =
+      AddEdit(group, SETTING_TMR_NAME, 19075, SettingLevel::Basic, m_strTitle, true, false, 19097);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_NAME);
 
   // epg search string (only for epg-based timer rules)
-  setting = AddEdit(group, SETTING_TMR_EPGSEARCH, 804, SettingLevel::Basic, m_strEpgSearchString, true, false, 805);
+  setting = AddEdit(group, SETTING_TMR_EPGSEARCH, 804, SettingLevel::Basic, m_strEpgSearchString,
+                    true, false, 805);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_EPGSEARCH);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_EPGSEARCH);
 
@@ -259,7 +265,8 @@ void CGUIDialogPVRTimerSettings::InitializeSettings()
   AddTypeDependentEnableCondition(setting, SETTING_TMR_FULLTEXT);
 
   // Channel
-  setting = AddList(group, SETTING_TMR_CHANNEL, 19078, SettingLevel::Basic, 0, ChannelsFiller, 19078);
+  setting =
+      AddList(group, SETTING_TMR_CHANNEL, 19078, SettingLevel::Basic, 0, ChannelsFiller, 19078);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_CHANNEL);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_CHANNEL);
 
@@ -280,7 +287,8 @@ void CGUIDialogPVRTimerSettings::InitializeSettings()
   if (m_iWeekdays & PVR_WEEKDAY_SUNDAY)
     weekdaysPreselect.push_back(PVR_WEEKDAY_SUNDAY);
 
-  setting = AddList(group, SETTING_TMR_WEEKDAYS, 19079, SettingLevel::Basic, weekdaysPreselect, WeekdaysFiller, 19079, 1, -1, true, -1, WeekdaysValueFormatter);
+  setting = AddList(group, SETTING_TMR_WEEKDAYS, 19079, SettingLevel::Basic, weekdaysPreselect,
+                    WeekdaysFiller, 19079, 1, -1, true, -1, WeekdaysValueFormatter);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_WEEKDAYS);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_WEEKDAYS);
 
@@ -290,7 +298,8 @@ void CGUIDialogPVRTimerSettings::InitializeSettings()
   AddTypeDependentEnableCondition(setting, SETTING_TMR_START_ANYTIME);
 
   // Start day (day + month + year only, no hours, minutes)
-  setting = AddSpinner(group, SETTING_TMR_START_DAY, 19128, SettingLevel::Basic, GetDateAsIndex(m_startLocalTime), DaysFiller);
+  setting = AddSpinner(group, SETTING_TMR_START_DAY, 19128, SettingLevel::Basic,
+                       GetDateAsIndex(m_startLocalTime), DaysFiller);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_START_DAY);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_START_DAY);
   AddStartAnytimeDependentVisibilityCondition(setting, SETTING_TMR_START_DAY);
@@ -307,7 +316,8 @@ void CGUIDialogPVRTimerSettings::InitializeSettings()
   AddTypeDependentEnableCondition(setting, SETTING_TMR_END_ANYTIME);
 
   // End day (day + month + year only, no hours, minutes)
-  setting = AddSpinner(group, SETTING_TMR_END_DAY, 19129, SettingLevel::Basic, GetDateAsIndex(m_endLocalTime), DaysFiller);
+  setting = AddSpinner(group, SETTING_TMR_END_DAY, 19129, SettingLevel::Basic,
+                       GetDateAsIndex(m_endLocalTime), DaysFiller);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_END_DAY);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_END_DAY);
   AddEndAnytimeDependentVisibilityCondition(setting, SETTING_TMR_END_DAY);
@@ -319,53 +329,63 @@ void CGUIDialogPVRTimerSettings::InitializeSettings()
   AddEndAnytimeDependentVisibilityCondition(setting, SETTING_TMR_END);
 
   // First day (only for timer rules)
-  setting = AddSpinner(group, SETTING_TMR_FIRST_DAY, 19084, SettingLevel::Basic, GetDateAsIndex(m_firstDayLocalTime), DaysFiller);
+  setting = AddSpinner(group, SETTING_TMR_FIRST_DAY, 19084, SettingLevel::Basic,
+                       GetDateAsIndex(m_firstDayLocalTime), DaysFiller);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_FIRST_DAY);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_FIRST_DAY);
 
   // "Prevent duplicate episodes" (only for timer rules)
-  setting = AddList(group, SETTING_TMR_NEW_EPISODES, 812, SettingLevel::Basic, m_iPreventDupEpisodes, DupEpisodesFiller, 812);
+  setting = AddList(group, SETTING_TMR_NEW_EPISODES, 812, SettingLevel::Basic,
+                    m_iPreventDupEpisodes, DupEpisodesFiller, 812);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_NEW_EPISODES);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_NEW_EPISODES);
 
   // Pre and post record time
-  setting = AddList(group, SETTING_TMR_BEGIN_PRE, 813, SettingLevel::Basic, m_iMarginStart, MarginTimeFiller, 813);
+  setting = AddList(group, SETTING_TMR_BEGIN_PRE, 813, SettingLevel::Basic, m_iMarginStart,
+                    MarginTimeFiller, 813);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_BEGIN_PRE);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_BEGIN_PRE);
 
-  setting = AddList(group, SETTING_TMR_END_POST,  814, SettingLevel::Basic, m_iMarginEnd, MarginTimeFiller, 814);
+  setting = AddList(group, SETTING_TMR_END_POST, 814, SettingLevel::Basic, m_iMarginEnd,
+                    MarginTimeFiller, 814);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_END_POST);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_END_POST);
 
   // Priority
-  setting = AddList(group, SETTING_TMR_PRIORITY, 19082, SettingLevel::Basic, m_iPriority, PrioritiesFiller, 19082);
+  setting = AddList(group, SETTING_TMR_PRIORITY, 19082, SettingLevel::Basic, m_iPriority,
+                    PrioritiesFiller, 19082);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_PRIORITY);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_PRIORITY);
 
   // Lifetime
-  setting = AddList(group, SETTING_TMR_LIFETIME, 19083, SettingLevel::Basic, m_iLifetime, LifetimesFiller, 19083);
+  setting = AddList(group, SETTING_TMR_LIFETIME, 19083, SettingLevel::Basic, m_iLifetime,
+                    LifetimesFiller, 19083);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_LIFETIME);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_LIFETIME);
 
   // MaxRecordings
-  setting = AddList(group, SETTING_TMR_MAX_REC, 818, SettingLevel::Basic, m_iMaxRecordings, MaxRecordingsFiller, 818);
+  setting = AddList(group, SETTING_TMR_MAX_REC, 818, SettingLevel::Basic, m_iMaxRecordings,
+                    MaxRecordingsFiller, 818);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_MAX_REC);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_MAX_REC);
 
   // Recording folder
-  setting = AddEdit(group, SETTING_TMR_DIR, 19076, SettingLevel::Basic, m_strDirectory, true, false, 19104);
+  setting = AddEdit(group, SETTING_TMR_DIR, 19076, SettingLevel::Basic, m_strDirectory, true, false,
+                    19104);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_DIR);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_DIR);
 
   // Recording group
-  setting = AddList(group, SETTING_TMR_REC_GROUP, 811, SettingLevel::Basic, m_iRecordingGroup, RecordingGroupFiller, 811);
+  setting = AddList(group, SETTING_TMR_REC_GROUP, 811, SettingLevel::Basic, m_iRecordingGroup,
+                    RecordingGroupFiller, 811);
   AddTypeDependentVisibilityCondition(setting, SETTING_TMR_REC_GROUP);
   AddTypeDependentEnableCondition(setting, SETTING_TMR_REC_GROUP);
 }
 
 int CGUIDialogPVRTimerSettings::GetWeekdaysFromSetting(const SettingConstPtr& setting)
 {
-  std::shared_ptr<const CSettingList> settingList = std::static_pointer_cast<const CSettingList>(setting);
+  std::shared_ptr<const CSettingList> settingList =
+      std::static_pointer_cast<const CSettingList>(setting);
   if (settingList->GetElementType() != SettingType::Integer)
   {
     CLog::LogF(LOGERROR, "Wrong weekdays element type");
@@ -457,15 +477,18 @@ void CGUIDialogPVRTimerSettings::OnSettingChanged(const std::shared_ptr<const CS
   }
   else if (settingId == SETTING_TMR_START_DAY)
   {
-    SetDateFromIndex(m_startLocalTime, std::static_pointer_cast<const CSettingInt>(setting)->GetValue());
+    SetDateFromIndex(m_startLocalTime,
+                     std::static_pointer_cast<const CSettingInt>(setting)->GetValue());
   }
   else if (settingId == SETTING_TMR_END_DAY)
   {
-    SetDateFromIndex(m_endLocalTime, std::static_pointer_cast<const CSettingInt>(setting)->GetValue());
+    SetDateFromIndex(m_endLocalTime,
+                     std::static_pointer_cast<const CSettingInt>(setting)->GetValue());
   }
   else if (settingId == SETTING_TMR_FIRST_DAY)
   {
-    SetDateFromIndex(m_firstDayLocalTime, std::static_pointer_cast<const CSettingInt>(setting)->GetValue());
+    SetDateFromIndex(m_firstDayLocalTime,
+                     std::static_pointer_cast<const CSettingInt>(setting)->GetValue());
   }
   else if (settingId == SETTING_TMR_NEW_EPISODES)
   {
@@ -593,11 +616,13 @@ bool CGUIDialogPVRTimerSettings::Save()
   m_timerInfoTag->m_bIsRadio = m_bIsRadio;
   m_timerInfoTag->UpdateChannel();
 
-  if (!m_timerType->SupportsStartAnyTime() || !m_timerType->IsEpgBased()) // Start anytime toggle is not displayed
+  if (!m_timerType->SupportsStartAnyTime() ||
+      !m_timerType->IsEpgBased()) // Start anytime toggle is not displayed
     m_bStartAnyTime = false; // Assume start time change needs checking for
   m_timerInfoTag->m_bStartAnyTime = m_bStartAnyTime;
 
-  if (!m_timerType->SupportsEndAnyTime() || !m_timerType->IsEpgBased()) // End anytime toggle is not displayed
+  if (!m_timerType->SupportsEndAnyTime() ||
+      !m_timerType->IsEpgBased()) // End anytime toggle is not displayed
     m_bEndAnyTime = false; // Assume end time change needs checking for
   m_timerInfoTag->m_bEndAnyTime = m_bEndAnyTime;
 
@@ -614,17 +639,21 @@ bool CGUIDialogPVRTimerSettings::Save()
         m_endLocalTime += CDateTimeSpan(1, 0, 0, 0);
         if (m_endLocalTime < m_startLocalTime)
         {
-          CLog::Log(LOGWARNING, "Timer settings dialog: End before start. Setting end time to start time.");
+          CLog::Log(LOGWARNING,
+                    "Timer settings dialog: End before start. Setting end time to start time.");
           m_endLocalTime = m_startLocalTime;
         }
       }
-      else if (m_endLocalTime > (m_startLocalTime + CDateTimeSpan(1, 0, 0, 0))) // Or the duration is more than a day
+      else if (m_endLocalTime >
+               (m_startLocalTime + CDateTimeSpan(1, 0, 0, 0))) // Or the duration is more than a day
       {
         CLog::LogFC(LOGDEBUG, LOGPVR, "End > 1 day after start, removing a day.");
         m_endLocalTime -= CDateTimeSpan(1, 0, 0, 0);
         if (m_endLocalTime > (m_startLocalTime + CDateTimeSpan(1, 0, 0, 0)))
         {
-          CLog::Log(LOGWARNING, "Timer settings dialog: End > 1 day after start. Setting end time to start time.");
+          CLog::Log(
+              LOGWARNING,
+              "Timer settings dialog: End > 1 day after start. Setting end time to start time.");
           m_endLocalTime = m_startLocalTime;
         }
       }
@@ -711,8 +740,7 @@ void CGUIDialogPVRTimerSettings::AddCondition(const std::shared_ptr<CSetting>& s
 {
   GetSettingsManager()->AddDynamicCondition(identifier, condition, this);
   CSettingDependency dep(depType, GetSettingsManager());
-  dep.And()->Add(
-    CSettingDependencyConditionPtr(
+  dep.And()->Add(CSettingDependencyConditionPtr(
       new CSettingDependencyCondition(identifier, "true", settingId, false, GetSettingsManager())));
   SettingDependencies deps(setting->GetDependencies());
   deps.push_back(dep);
@@ -730,18 +758,16 @@ int CGUIDialogPVRTimerSettings::GetDateAsIndex(const CDateTime& datetime)
 void CGUIDialogPVRTimerSettings::SetDateFromIndex(CDateTime& datetime, int date)
 {
   const CDateTime newDate(static_cast<time_t>(date));
-  datetime.SetDateTime(
-    newDate.GetYear(), newDate.GetMonth(), newDate.GetDay(),
-    datetime.GetHour(), datetime.GetMinute(), datetime.GetSecond());
+  datetime.SetDateTime(newDate.GetYear(), newDate.GetMonth(), newDate.GetDay(), datetime.GetHour(),
+                       datetime.GetMinute(), datetime.GetSecond());
 }
 
 void CGUIDialogPVRTimerSettings::SetTimeFromSystemTime(CDateTime& datetime,
                                                        const KODI::TIME::SystemTime& time)
 {
   const CDateTime newTime(time);
-  datetime.SetDateTime(
-    datetime.GetYear(), datetime.GetMonth(), datetime.GetDay(),
-    newTime.GetHour(), newTime.GetMinute(), newTime.GetSecond());
+  datetime.SetDateTime(datetime.GetYear(), datetime.GetMonth(), datetime.GetDay(),
+                       newTime.GetHour(), newTime.GetMinute(), newTime.GetSecond());
 }
 
 void CGUIDialogPVRTimerSettings::InitializeTypesList()
@@ -798,7 +824,8 @@ void CGUIDialogPVRTimerSettings::InitializeTypesList()
     if (!type->IsTimerRule())
     {
       const std::shared_ptr<CPVREpgInfoTag> epgTag(m_timerInfoTag->GetEpgInfoTag());
-      bool bCanRecord = epgTag ? epgTag->IsRecordable() : m_timerInfoTag->EndAsLocalTime() > CDateTime::GetCurrentDateTime();
+      bool bCanRecord = epgTag ? epgTag->IsRecordable()
+                               : m_timerInfoTag->EndAsLocalTime() > CDateTime::GetCurrentDateTime();
       if (!bCanRecord)
         continue;
     }
@@ -823,23 +850,24 @@ void CGUIDialogPVRTimerSettings::InitializeChannelsList()
   const CPVRClientMap clients = CServiceBroker::GetPVRManager().Clients()->GetCreatedClients();
   for (const auto& client : clients)
   {
-    m_channelEntries.insert({index, ChannelDescriptor(PVR_CHANNEL_INVALID_UID,
-                                                      client.second->GetID(),
-                                                      g_localizeStrings.Get(809))}); // "Any channel"
+    m_channelEntries.insert(
+        {index, ChannelDescriptor(PVR_CHANNEL_INVALID_UID, client.second->GetID(),
+                                  g_localizeStrings.Get(809))}); // "Any channel"
     ++index;
   }
 
   // Add regular channels
-  const std::shared_ptr<CPVRChannelGroup> allGroup = CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAll(m_bIsRadio);
+  const std::shared_ptr<CPVRChannelGroup> allGroup =
+      CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAll(m_bIsRadio);
   const std::vector<std::shared_ptr<CPVRChannelGroupMember>> groupMembers =
       allGroup->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
   for (const auto& groupMember : groupMembers)
   {
     const std::shared_ptr<CPVRChannel> channel = groupMember->Channel();
-    const std::string channelDescription =
-        StringUtils::Format("{} {}", groupMember->ChannelNumber().FormattedChannelNumber(),
-                            channel->ChannelName());
-    m_channelEntries.insert({index, ChannelDescriptor(channel->UniqueID(), channel->ClientID(), channelDescription)});
+    const std::string channelDescription = StringUtils::Format(
+        "{} {}", groupMember->ChannelNumber().FormattedChannelNumber(), channel->ChannelName());
+    m_channelEntries.insert(
+        {index, ChannelDescriptor(channel->UniqueID(), channel->ClientID(), channelDescription)});
     ++index;
   }
 }
@@ -855,8 +883,10 @@ void CGUIDialogPVRTimerSettings::TypesFiller(const SettingConstPtr& setting,
     list.clear();
     current = 0;
 
-    static const std::vector<std::pair<std::string, CVariant>> reminderTimerProps{std::make_pair("PVR.IsRemindingTimer", CVariant{true})};
-    static const std::vector<std::pair<std::string, CVariant>> recordingTimerProps{std::make_pair("PVR.IsRecordingTimer", CVariant{true})};
+    static const std::vector<std::pair<std::string, CVariant>> reminderTimerProps{
+        std::make_pair("PVR.IsRemindingTimer", CVariant{true})};
+    static const std::vector<std::pair<std::string, CVariant>> recordingTimerProps{
+        std::make_pair("PVR.IsRecordingTimer", CVariant{true})};
 
     bool foundCurrent(false);
     for (const auto& typeEntry : pThis->m_typeEntries)
@@ -898,7 +928,8 @@ void CGUIDialogPVRTimerSettings::ChannelsFiller(const SettingConstPtr& setting,
             !pThis->m_timerType->SupportsAnyChannel())
           continue;
 
-        list.emplace_back(IntegerSettingOption(channelEntry.second.description, channelEntry.first));
+        list.emplace_back(
+            IntegerSettingOption(channelEntry.second.description, channelEntry.first));
       }
 
       if (!foundCurrent && (pThis->m_channel == channelEntry.second))
@@ -926,8 +957,10 @@ void CGUIDialogPVRTimerSettings::DaysFiller(const SettingConstPtr& setting,
     // Data range: "today" until "yesterday next year"
     const CDateTime now(CDateTime::GetCurrentDateTime());
     CDateTime time(now.GetYear(), now.GetMonth(), now.GetDay(), 0, 0, 0);
-    const CDateTime yesterdayPlusOneYear(CDateTime(time.GetYear() + 1, time.GetMonth(), time.GetDay(), time.GetHour(), time.GetMinute(), time.GetSecond())
-		- CDateTimeSpan(1, 0, 0, 0));
+    const CDateTime yesterdayPlusOneYear(CDateTime(time.GetYear() + 1, time.GetMonth(),
+                                                   time.GetDay(), time.GetHour(), time.GetMinute(),
+                                                   time.GetSecond()) -
+                                         CDateTimeSpan(1, 0, 0, 0));
 
     CDateTime oldCDateTime;
     if (setting->GetId() == SETTING_TMR_FIRST_DAY)
@@ -936,7 +969,8 @@ void CGUIDialogPVRTimerSettings::DaysFiller(const SettingConstPtr& setting,
       oldCDateTime = pThis->m_timerInfoTag->StartAsLocalTime();
     else
       oldCDateTime = pThis->m_timerInfoTag->EndAsLocalTime();
-    const CDateTime oldCDate(oldCDateTime.GetYear(), oldCDateTime.GetMonth(), oldCDateTime.GetDay(), 0, 0, 0);
+    const CDateTime oldCDate(oldCDateTime.GetYear(), oldCDateTime.GetMonth(), oldCDateTime.GetDay(),
+                             0, 0, 0);
 
     if ((oldCDate < time) || (oldCDate > yesterdayPlusOneYear))
       list.emplace_back(oldCDate.GetAsLocalizedDate(true /*long date*/), GetDateAsIndex(oldCDate));
@@ -968,7 +1002,7 @@ void CGUIDialogPVRTimerSettings::DupEpisodesFiller(const SettingConstPtr& settin
   {
     list.clear();
 
-    std::vector<std::pair<std::string,int>> values;
+    std::vector<std::pair<std::string, int>> values;
     pThis->m_timerType->GetPreventDuplicateEpisodesValues(values);
     std::transform(values.cbegin(), values.cend(), std::back_inserter(list), [](const auto& value) {
       return IntegerSettingOption(value.first, value.second);
@@ -1013,7 +1047,7 @@ void CGUIDialogPVRTimerSettings::PrioritiesFiller(const SettingConstPtr& setting
   {
     list.clear();
 
-    std::vector<std::pair<std::string,int>> values;
+    std::vector<std::pair<std::string, int>> values;
     pThis->m_timerType->GetPriorityValues(values);
     std::transform(values.cbegin(), values.cend(), std::back_inserter(list), [](const auto& value) {
       return IntegerSettingOption(value.first, value.second);
@@ -1050,7 +1084,7 @@ void CGUIDialogPVRTimerSettings::LifetimesFiller(const SettingConstPtr& setting,
   {
     list.clear();
 
-    std::vector<std::pair<std::string,int>> values;
+    std::vector<std::pair<std::string, int>> values;
     pThis->m_timerType->GetLifetimeValues(values);
     std::transform(values.cbegin(), values.cend(), std::back_inserter(list), [](const auto& value) {
       return IntegerSettingOption(value.first, value.second);
@@ -1089,7 +1123,7 @@ void CGUIDialogPVRTimerSettings::MaxRecordingsFiller(const SettingConstPtr& sett
   {
     list.clear();
 
-    std::vector<std::pair<std::string,int>> values;
+    std::vector<std::pair<std::string, int>> values;
     pThis->m_timerType->GetMaxRecordingsValues(values);
     std::transform(values.cbegin(), values.cend(), std::back_inserter(list), [](const auto& value) {
       return IntegerSettingOption(value.first, value.second);
@@ -1126,7 +1160,7 @@ void CGUIDialogPVRTimerSettings::RecordingGroupFiller(const SettingConstPtr& set
   {
     list.clear();
 
-    std::vector<std::pair<std::string,int>> values;
+    std::vector<std::pair<std::string, int>> values;
     pThis->m_timerType->GetRecordingGroupValues(values);
     std::transform(values.cbegin(), values.cend(), std::back_inserter(list), [](const auto& value) {
       return IntegerSettingOption(value.first, value.second);
@@ -1229,12 +1263,9 @@ bool CGUIDialogPVRTimerSettings::TypeReadOnlyCondition(const std::string& condit
   // For existing one time epg-based timers, disable editing of epg-filled data.
   if (!pThis->m_bIsNewTimer && pThis->m_timerType->IsEpgBasedOnetime())
   {
-    if ((cond == SETTING_TMR_NAME)      ||
-        (cond == SETTING_TMR_CHANNEL)   ||
-        (cond == SETTING_TMR_START_DAY) ||
-        (cond == SETTING_TMR_END_DAY)   ||
-        (cond == SETTING_TMR_BEGIN)     ||
-        (cond == SETTING_TMR_END))
+    if ((cond == SETTING_TMR_NAME) || (cond == SETTING_TMR_CHANNEL) ||
+        (cond == SETTING_TMR_START_DAY) || (cond == SETTING_TMR_END_DAY) ||
+        (cond == SETTING_TMR_BEGIN) || (cond == SETTING_TMR_END))
       return false;
   }
 
@@ -1262,7 +1293,8 @@ void CGUIDialogPVRTimerSettings::AddTypeDependentVisibilityCondition(
   // Show or hide setting depending on attributes of the selected timer type
   std::string id(identifier);
   id.append(TYPE_DEP_VISIBI_COND_ID_POSTFIX);
-  AddCondition(setting, id, TypeSupportsCondition, SettingDependencyType::Visible, SETTING_TMR_TYPE);
+  AddCondition(setting, id, TypeSupportsCondition, SettingDependencyType::Visible,
+               SETTING_TMR_TYPE);
 }
 
 bool CGUIDialogPVRTimerSettings::TypeSupportsCondition(const std::string& condition,
@@ -1346,7 +1378,8 @@ void CGUIDialogPVRTimerSettings::AddStartAnytimeDependentVisibilityCondition(
   // Show or hide setting depending on value of setting "any time"
   std::string id(identifier);
   id.append(START_ANYTIME_DEP_VISIBI_COND_ID_POSTFIX);
-  AddCondition(setting, id, StartAnytimeSetCondition, SettingDependencyType::Visible, SETTING_TMR_START_ANYTIME);
+  AddCondition(setting, id, StartAnytimeSetCondition, SettingDependencyType::Visible,
+               SETTING_TMR_START_ANYTIME);
 }
 
 bool CGUIDialogPVRTimerSettings::StartAnytimeSetCondition(const std::string& condition,
@@ -1378,8 +1411,7 @@ bool CGUIDialogPVRTimerSettings::StartAnytimeSetCondition(const std::string& con
   std::string cond(condition);
   cond.erase(cond.find(START_ANYTIME_DEP_VISIBI_COND_ID_POSTFIX));
 
-  if ((cond == SETTING_TMR_START_DAY) ||
-      (cond == SETTING_TMR_BEGIN))
+  if ((cond == SETTING_TMR_START_DAY) || (cond == SETTING_TMR_BEGIN))
   {
     bool bAnytime = std::static_pointer_cast<const CSettingBool>(setting)->GetValue();
     return !bAnytime;
@@ -1393,7 +1425,8 @@ void CGUIDialogPVRTimerSettings::AddEndAnytimeDependentVisibilityCondition(
   // Show or hide setting depending on value of setting "any time"
   std::string id(identifier);
   id.append(END_ANYTIME_DEP_VISIBI_COND_ID_POSTFIX);
-  AddCondition(setting, id, EndAnytimeSetCondition, SettingDependencyType::Visible, SETTING_TMR_END_ANYTIME);
+  AddCondition(setting, id, EndAnytimeSetCondition, SettingDependencyType::Visible,
+               SETTING_TMR_END_ANYTIME);
 }
 
 bool CGUIDialogPVRTimerSettings::EndAnytimeSetCondition(const std::string& condition,
@@ -1425,8 +1458,7 @@ bool CGUIDialogPVRTimerSettings::EndAnytimeSetCondition(const std::string& condi
   std::string cond(condition);
   cond.erase(cond.find(END_ANYTIME_DEP_VISIBI_COND_ID_POSTFIX));
 
-  if ((cond == SETTING_TMR_END_DAY)   ||
-      (cond == SETTING_TMR_END))
+  if ((cond == SETTING_TMR_END_DAY) || (cond == SETTING_TMR_END))
   {
     bool bAnytime = std::static_pointer_cast<const CSettingBool>(setting)->GetValue();
     return !bAnytime;

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -749,7 +749,7 @@ void CGUIDialogPVRTimerSettings::InitializeTypesList()
   m_typeEntries.clear();
 
   // If timer is read-only or was created by a timer rule, only add current type, for information. Type can't be changed.
-  if (m_timerType->IsReadOnly() || m_timerInfoTag->GetTimerRuleId() != PVR_TIMER_NO_PARENT)
+  if (m_timerType->IsReadOnly() || m_timerInfoTag->HasParent())
   {
     m_typeEntries.insert(std::make_pair(0, m_timerType));
     return;

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
@@ -25,174 +25,172 @@ struct IntegerSettingOption;
 
 namespace PVR
 {
-  class CPVRTimerInfoTag;
-  class CPVRTimerType;
+class CPVRTimerInfoTag;
+class CPVRTimerType;
 
-  class CGUIDialogPVRTimerSettings : public CGUIDialogSettingsManualBase
-  {
-  public:
-    CGUIDialogPVRTimerSettings();
-    ~CGUIDialogPVRTimerSettings() override;
+class CGUIDialogPVRTimerSettings : public CGUIDialogSettingsManualBase
+{
+public:
+  CGUIDialogPVRTimerSettings();
+  ~CGUIDialogPVRTimerSettings() override;
 
-    bool CanBeActivated() const override;
+  bool CanBeActivated() const override;
 
-    void SetTimer(const std::shared_ptr<CPVRTimerInfoTag>& timer);
+  void SetTimer(const std::shared_ptr<CPVRTimerInfoTag>& timer);
 
-  protected:
-    // implementation of ISettingCallback
-    void OnSettingChanged(const std::shared_ptr<const CSetting>& setting) override;
-    void OnSettingAction(const std::shared_ptr<const CSetting>& setting) override;
+protected:
+  // implementation of ISettingCallback
+  void OnSettingChanged(const std::shared_ptr<const CSetting>& setting) override;
+  void OnSettingAction(const std::shared_ptr<const CSetting>& setting) override;
 
-    // specialization of CGUIDialogSettingsBase
-    bool AllowResettingSettings() const override { return false; }
-    bool Save() override;
-    void SetupView() override;
+  // specialization of CGUIDialogSettingsBase
+  bool AllowResettingSettings() const override { return false; }
+  bool Save() override;
+  void SetupView() override;
 
-    // specialization of CGUIDialogSettingsManualBase
-    void InitializeSettings() override;
+  // specialization of CGUIDialogSettingsManualBase
+  void InitializeSettings() override;
 
-  private:
-    bool Validate();
-    void InitializeTypesList();
-    void InitializeChannelsList();
-    void SetButtonLabels();
+private:
+  bool Validate();
+  void InitializeTypesList();
+  void InitializeChannelsList();
+  void SetButtonLabels();
 
-    static int GetDateAsIndex(const CDateTime& datetime);
-    static void SetDateFromIndex(CDateTime& datetime, int date);
-    static void SetTimeFromSystemTime(CDateTime& datetime, const KODI::TIME::SystemTime& time);
+  static int GetDateAsIndex(const CDateTime& datetime);
+  static void SetDateFromIndex(CDateTime& datetime, int date);
+  static void SetTimeFromSystemTime(CDateTime& datetime, const KODI::TIME::SystemTime& time);
 
-    static int GetWeekdaysFromSetting(const std::shared_ptr<const CSetting>& setting);
+  static int GetWeekdaysFromSetting(const std::shared_ptr<const CSetting>& setting);
 
-    static void TypesFiller(const std::shared_ptr<const CSetting>& setting,
-                            std::vector<IntegerSettingOption>& list,
-                            int& current,
-                            void* data);
-    static void ChannelsFiller(const std::shared_ptr<const CSetting>& setting,
-                               std::vector<IntegerSettingOption>& list,
-                               int& current,
-                               void* data);
-    static void DaysFiller(const std::shared_ptr<const CSetting>& setting,
-                           std::vector<IntegerSettingOption>& list,
-                           int& current,
-                           void* data);
-    static void DupEpisodesFiller(const std::shared_ptr<const CSetting>& setting,
-                                  std::vector<IntegerSettingOption>& list,
-                                  int& current,
-                                  void* data);
-    static void WeekdaysFiller(const std::shared_ptr<const CSetting>& setting,
-                               std::vector<IntegerSettingOption>& list,
-                               int& current,
-                               void* data);
-    static void PrioritiesFiller(const std::shared_ptr<const CSetting>& setting,
-                                 std::vector<IntegerSettingOption>& list,
-                                 int& current,
-                                 void* data);
-    static void LifetimesFiller(const std::shared_ptr<const CSetting>& setting,
+  static void TypesFiller(const std::shared_ptr<const CSetting>& setting,
+                          std::vector<IntegerSettingOption>& list,
+                          int& current,
+                          void* data);
+  static void ChannelsFiller(const std::shared_ptr<const CSetting>& setting,
+                             std::vector<IntegerSettingOption>& list,
+                             int& current,
+                             void* data);
+  static void DaysFiller(const std::shared_ptr<const CSetting>& setting,
+                         std::vector<IntegerSettingOption>& list,
+                         int& current,
+                         void* data);
+  static void DupEpisodesFiller(const std::shared_ptr<const CSetting>& setting,
                                 std::vector<IntegerSettingOption>& list,
                                 int& current,
                                 void* data);
-    static void MaxRecordingsFiller(const std::shared_ptr<const CSetting>& setting,
-                                    std::vector<IntegerSettingOption>& list,
-                                    int& current,
+  static void WeekdaysFiller(const std::shared_ptr<const CSetting>& setting,
+                             std::vector<IntegerSettingOption>& list,
+                             int& current,
+                             void* data);
+  static void PrioritiesFiller(const std::shared_ptr<const CSetting>& setting,
+                               std::vector<IntegerSettingOption>& list,
+                               int& current,
+                               void* data);
+  static void LifetimesFiller(const std::shared_ptr<const CSetting>& setting,
+                              std::vector<IntegerSettingOption>& list,
+                              int& current,
+                              void* data);
+  static void MaxRecordingsFiller(const std::shared_ptr<const CSetting>& setting,
+                                  std::vector<IntegerSettingOption>& list,
+                                  int& current,
+                                  void* data);
+  static void RecordingGroupFiller(const std::shared_ptr<const CSetting>& setting,
+                                   std::vector<IntegerSettingOption>& list,
+                                   int& current,
+                                   void* data);
+  static void MarginTimeFiller(const std::shared_ptr<const CSetting>& setting,
+                               std::vector<IntegerSettingOption>& list,
+                               int& current,
+                               void* data);
+
+  static std::string WeekdaysValueFormatter(const std::shared_ptr<const CSetting>& setting);
+
+  void AddCondition(const std::shared_ptr<CSetting>& setting,
+                    const std::string& identifier,
+                    SettingConditionCheck condition,
+                    SettingDependencyType depType,
+                    const std::string& settingId);
+
+  void AddTypeDependentEnableCondition(const std::shared_ptr<CSetting>& setting,
+                                       const std::string& identifier);
+  static bool TypeReadOnlyCondition(const std::string& condition,
+                                    const std::string& value,
+                                    const std::shared_ptr<const CSetting>& setting,
                                     void* data);
-    static void RecordingGroupFiller(const std::shared_ptr<const CSetting>& setting,
-                                     std::vector<IntegerSettingOption>& list,
-                                     int& current,
-                                     void* data);
-    static void MarginTimeFiller(const std::shared_ptr<const CSetting>& setting,
-                                 std::vector<IntegerSettingOption>& list,
-                                 int& current,
-                                 void* data);
 
-    static std::string WeekdaysValueFormatter(const std::shared_ptr<const CSetting>& setting);
+  void AddTypeDependentVisibilityCondition(const std::shared_ptr<CSetting>& setting,
+                                           const std::string& identifier);
+  static bool TypeSupportsCondition(const std::string& condition,
+                                    const std::string& value,
+                                    const std::shared_ptr<const CSetting>& setting,
+                                    void* data);
 
-    void AddCondition(const std::shared_ptr<CSetting>& setting,
-                      const std::string& identifier,
-                      SettingConditionCheck condition,
-                      SettingDependencyType depType,
-                      const std::string& settingId);
-
-    void AddTypeDependentEnableCondition(const std::shared_ptr<CSetting>& setting,
-                                         const std::string& identifier);
-    static bool TypeReadOnlyCondition(const std::string& condition,
-                                      const std::string& value,
-                                      const std::shared_ptr<const CSetting>& setting,
-                                      void* data);
-
-    void AddTypeDependentVisibilityCondition(const std::shared_ptr<CSetting>& setting,
-                                             const std::string& identifier);
-    static bool TypeSupportsCondition(const std::string& condition,
-                                      const std::string& value,
-                                      const std::shared_ptr<const CSetting>& setting,
-                                      void* data);
-
-    void AddStartAnytimeDependentVisibilityCondition(const std::shared_ptr<CSetting>& setting,
-                                                     const std::string& identifier);
-    static bool StartAnytimeSetCondition(const std::string& condition,
-                                         const std::string& value,
-                                         const std::shared_ptr<const CSetting>& setting,
-                                         void* data);
-    void AddEndAnytimeDependentVisibilityCondition(const std::shared_ptr<CSetting>& setting,
+  void AddStartAnytimeDependentVisibilityCondition(const std::shared_ptr<CSetting>& setting,
                                                    const std::string& identifier);
-    static bool EndAnytimeSetCondition(const std::string& condition,
+  static bool StartAnytimeSetCondition(const std::string& condition,
                                        const std::string& value,
                                        const std::shared_ptr<const CSetting>& setting,
                                        void* data);
+  void AddEndAnytimeDependentVisibilityCondition(const std::shared_ptr<CSetting>& setting,
+                                                 const std::string& identifier);
+  static bool EndAnytimeSetCondition(const std::string& condition,
+                                     const std::string& value,
+                                     const std::shared_ptr<const CSetting>& setting,
+                                     void* data);
 
-    typedef std::map<int, std::shared_ptr<CPVRTimerType>> TypeEntriesMap;
+  typedef std::map<int, std::shared_ptr<CPVRTimerType>> TypeEntriesMap;
 
-    typedef struct ChannelDescriptor
+  typedef struct ChannelDescriptor
+  {
+    int channelUid;
+    int clientId;
+    std::string description;
+
+    ChannelDescriptor(int _channelUid = PVR_CHANNEL_INVALID_UID,
+                      int _clientId = -1,
+                      const std::string& _description = "")
+      : channelUid(_channelUid), clientId(_clientId), description(_description)
     {
-      int channelUid;
-      int clientId;
-      std::string description;
+    }
 
-      ChannelDescriptor(int _channelUid = PVR_CHANNEL_INVALID_UID,
-                        int _clientId = -1,
-                        const std::string& _description = "")
-      : channelUid(_channelUid),
-        clientId(_clientId),
-        description(_description)
-      {}
+    inline bool operator==(const ChannelDescriptor& right) const
+    {
+      return (channelUid == right.channelUid && clientId == right.clientId &&
+              description == right.description);
+    }
 
-      inline bool operator ==(const ChannelDescriptor& right) const
-      {
-        return (channelUid == right.channelUid &&
-                clientId == right.clientId &&
-                description == right.description);
-      }
+  } ChannelDescriptor;
 
-    } ChannelDescriptor;
+  typedef std::map<int, ChannelDescriptor> ChannelEntriesMap;
 
-    typedef std::map <int, ChannelDescriptor> ChannelEntriesMap;
+  std::shared_ptr<CPVRTimerInfoTag> m_timerInfoTag;
+  TypeEntriesMap m_typeEntries;
+  ChannelEntriesMap m_channelEntries;
+  std::string m_timerStartTimeStr;
+  std::string m_timerEndTimeStr;
 
-    std::shared_ptr<CPVRTimerInfoTag> m_timerInfoTag;
-    TypeEntriesMap m_typeEntries;
-    ChannelEntriesMap m_channelEntries;
-    std::string m_timerStartTimeStr;
-    std::string m_timerEndTimeStr;
-
-    std::shared_ptr<CPVRTimerType> m_timerType;
-    bool m_bIsRadio = false;
-    bool m_bIsNewTimer = true;
-    bool m_bTimerActive = false;
-    std::string m_strTitle;
-    std::string m_strEpgSearchString;
-    bool m_bFullTextEpgSearch = true;
-    ChannelDescriptor m_channel;
-    CDateTime m_startLocalTime;
-    CDateTime m_endLocalTime;
-    bool m_bStartAnyTime = false;
-    bool m_bEndAnyTime = false;
-    unsigned int m_iWeekdays;
-    CDateTime m_firstDayLocalTime;
-    unsigned int m_iPreventDupEpisodes = 0;
-    unsigned int m_iMarginStart = 0;
-    unsigned int m_iMarginEnd = 0;
-    int m_iPriority = 0;
-    int m_iLifetime = 0;
-    int m_iMaxRecordings = 0;
-    std::string m_strDirectory;
-    unsigned int m_iRecordingGroup = 0;
-  };
+  std::shared_ptr<CPVRTimerType> m_timerType;
+  bool m_bIsRadio = false;
+  bool m_bIsNewTimer = true;
+  bool m_bTimerActive = false;
+  std::string m_strTitle;
+  std::string m_strEpgSearchString;
+  bool m_bFullTextEpgSearch = true;
+  ChannelDescriptor m_channel;
+  CDateTime m_startLocalTime;
+  CDateTime m_endLocalTime;
+  bool m_bStartAnyTime = false;
+  bool m_bEndAnyTime = false;
+  unsigned int m_iWeekdays;
+  CDateTime m_firstDayLocalTime;
+  unsigned int m_iPreventDupEpisodes = 0;
+  unsigned int m_iMarginStart = 0;
+  unsigned int m_iMarginEnd = 0;
+  int m_iPriority = 0;
+  int m_iLifetime = 0;
+  int m_iMaxRecordings = 0;
+  std::string m_strDirectory;
+  unsigned int m_iRecordingGroup = 0;
+};
 } // namespace PVR

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -539,13 +539,12 @@ bool GetTimersRootDirectory(const CPVRTimersPath& path,
 
   for (const auto& timer : timers)
   {
-    if ((bRadio == timer->m_bIsRadio ||
-         (bRules && timer->m_iClientChannelUid == PVR_TIMER_ANY_CHANNEL)) &&
-        (bRules == timer->IsTimerRule()) &&
-        (!bHideDisabled || (timer->m_state != PVR_TIMER_STATE_DISABLED)))
+    if ((bRadio == timer->IsRadio() ||
+         (bRules && timer->ClientChannelUID() == PVR_TIMER_ANY_CHANNEL)) &&
+        (bRules == timer->IsTimerRule()) && (!bHideDisabled || !timer->IsDisabled()))
     {
       const auto item = std::make_shared<CFileItem>(timer);
-      const CPVRTimersPath timersPath(path.GetPath(), timer->m_iClientId, timer->m_iClientIndex);
+      const CPVRTimersPath timersPath(path.GetPath(), timer->ClientID(), timer->ClientIndex());
       item->SetPath(timersPath.GetPath());
       results.Add(item);
     }
@@ -566,12 +565,11 @@ bool GetTimersSubDirectory(const CPVRTimersPath& path,
 
   for (const auto& timer : timers)
   {
-    if ((timer->m_bIsRadio == bRadio) && (timer->m_iParentClientIndex != PVR_TIMER_NO_PARENT) &&
-        (timer->m_iClientId == iClientId) && (timer->m_iParentClientIndex == iParentId) &&
-        (!bHideDisabled || (timer->m_state != PVR_TIMER_STATE_DISABLED)))
+    if ((timer->IsRadio() == bRadio) && timer->HasParent() && (timer->ClientID() == iClientId) &&
+        (timer->ParentClientIndex() == iParentId) && (!bHideDisabled || !timer->IsDisabled()))
     {
       item.reset(new CFileItem(timer));
-      const CPVRTimersPath timersPath(path.GetPath(), timer->m_iClientId, timer->m_iClientIndex);
+      const CPVRTimersPath timersPath(path.GetPath(), timer->ClientID(), timer->ClientIndex());
       item->SetPath(timersPath.GetPath());
       results.Add(item);
     }

--- a/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
@@ -552,10 +552,10 @@ bool CPVRGUIActionsTimers::ToggleTimerState(const CFileItemPtr& item) const
     return false;
 
   const std::shared_ptr<CPVRTimerInfoTag> timer(item->GetPVRTimerInfoTag());
-  if (timer->m_state == PVR_TIMER_STATE_DISABLED)
-    timer->m_state = PVR_TIMER_STATE_SCHEDULED;
+  if (timer->IsDisabled())
+    timer->SetState(PVR_TIMER_STATE_SCHEDULED);
   else
-    timer->m_state = PVR_TIMER_STATE_DISABLED;
+    timer->SetState(PVR_TIMER_STATE_DISABLED);
 
   if (CServiceBroker::GetPVRManager().Timers()->UpdateTimer(timer))
     return true;
@@ -884,7 +884,7 @@ void CPVRGUIActionsTimers::AnnounceReminder(const std::shared_ptr<CPVRTimerInfoT
 
   bool bCanRecord = false;
   const std::shared_ptr<CPVRClient> client =
-      CServiceBroker::GetPVRManager().GetClient(timer->m_iClientId);
+      CServiceBroker::GetPVRManager().GetClient(timer->ClientID());
   if (client && client->GetClientCapabilities().SupportsTimers())
   {
     bCanRecord = true;

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -1391,7 +1391,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item,
       {
         const std::shared_ptr<CPVRTimerInfoTag> timer = CPVRItem(item).GetTimerInfoTag();
         if (timer)
-          bValue = timer->GetTimerRuleId() != PVR_TIMER_NO_PARENT;
+          bValue = timer->HasParent();
         return true;
       }
       break;
@@ -1409,7 +1409,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item,
       {
         const std::shared_ptr<CPVRTimerInfoTag> timer = CPVRItem(item).GetTimerInfoTag();
         if (timer)
-          bValue = timer->IsReminder() && (timer->GetTimerRuleId() != PVR_TIMER_NO_PARENT);
+          bValue = timer->IsReminder() && timer->HasParent();
         return true;
       }
       break;

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -586,7 +586,7 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRRecording::GetRecordingTimer() const
 
   for (const auto& timer : recordingTimers)
   {
-    if (timer->m_iClientId == ClientID() && timer->m_iClientChannelUid == ChannelUid())
+    if (timer->ClientID() == ClientID() && timer->ClientChannelUID() == ChannelUid())
     {
       // first, match epg event uids, if available
       if (timer->UniqueBroadcastID() == BroadcastUid() &&
@@ -595,8 +595,8 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRRecording::GetRecordingTimer() const
 
       // alternatively, match start and end times
       const CDateTime timerStart =
-          timer->StartAsUTC() - CDateTimeSpan(0, 0, timer->m_iMarginStart, 0);
-      const CDateTime timerEnd = timer->EndAsUTC() + CDateTimeSpan(0, 0, timer->m_iMarginEnd, 0);
+          timer->StartAsUTC() - CDateTimeSpan(0, 0, timer->MarginStart(), 0);
+      const CDateTime timerEnd = timer->EndAsUTC() + CDateTimeSpan(0, 0, timer->MarginEnd(), 0);
       if (timerStart <= RecordingTimeAsUTC() && timerEnd >= EndTimeAsUTC())
         return timer;
     }

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -1356,7 +1356,7 @@ std::shared_ptr<CPVRChannel> CPVRTimerInfoTag::Channel() const
   return m_channel;
 }
 
-std::shared_ptr<CPVRChannel> CPVRTimerInfoTag::UpdateChannel()
+void CPVRTimerInfoTag::UpdateChannel()
 {
   const std::shared_ptr<CPVRChannel> channel(CServiceBroker::GetPVRManager()
                                                  .ChannelGroups()
@@ -1366,7 +1366,6 @@ std::shared_ptr<CPVRChannel> CPVRTimerInfoTag::UpdateChannel()
 
   std::unique_lock<CCriticalSection> lock(m_critSection);
   m_channel = channel;
-  return m_channel;
 }
 
 const std::string& CPVRTimerInfoTag::Title() const

--- a/xbmc/pvr/timers/PVRTimerRuleMatcher.cpp
+++ b/xbmc/pvr/timers/PVRTimerRuleMatcher.cpp
@@ -16,9 +16,9 @@
 
 using namespace PVR;
 
-CPVRTimerRuleMatcher::CPVRTimerRuleMatcher(const std::shared_ptr<CPVRTimerInfoTag>& timerRule, const CDateTime& start)
-: m_timerRule(timerRule),
-  m_start(CPVRTimerInfoTag::ConvertUTCToLocalTime(start))
+CPVRTimerRuleMatcher::CPVRTimerRuleMatcher(const std::shared_ptr<CPVRTimerInfoTag>& timerRule,
+                                           const CDateTime& start)
+  : m_timerRule(timerRule), m_start(CPVRTimerInfoTag::ConvertUTCToLocalTime(start))
 {
 }
 
@@ -38,8 +38,8 @@ CDateTime CPVRTimerRuleMatcher::GetNextTimerStart() const
     return CDateTime(); // invalid datetime
 
   const CDateTime startDateLocal = m_timerRule->GetTimerType()->SupportsFirstDay()
-                                   ? m_timerRule->FirstDayAsLocalTime()
-                                   : m_start;
+                                       ? m_timerRule->FirstDayAsLocalTime()
+                                       : m_start;
   const CDateTime startTimeLocal = m_timerRule->StartAsLocalTime();
   CDateTime nextStart(startDateLocal.GetYear(), startDateLocal.GetMonth(), startDateLocal.GetDay(),
                       startTimeLocal.GetHour(), startTimeLocal.GetMinute(), 0);
@@ -71,14 +71,9 @@ CDateTime CPVRTimerRuleMatcher::GetNextTimerStart() const
 
 bool CPVRTimerRuleMatcher::Matches(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
 {
-  return epgTag &&
-         CPVRTimerInfoTag::ConvertUTCToLocalTime(epgTag->EndAsUTC()) > m_start &&
-         MatchSeriesLink(epgTag) &&
-         MatchChannel(epgTag) &&
-         MatchStart(epgTag) &&
-         MatchEnd(epgTag) &&
-         MatchDayOfWeek(epgTag) &&
-         MatchSearchText(epgTag);
+  return epgTag && CPVRTimerInfoTag::ConvertUTCToLocalTime(epgTag->EndAsUTC()) > m_start &&
+         MatchSeriesLink(epgTag) && MatchChannel(epgTag) && MatchStart(epgTag) &&
+         MatchEnd(epgTag) && MatchDayOfWeek(epgTag) && MatchSearchText(epgTag);
 }
 
 bool CPVRTimerRuleMatcher::MatchSeriesLink(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
@@ -109,12 +104,10 @@ bool CPVRTimerRuleMatcher::MatchStart(const std::shared_ptr<CPVREpgInfoTag>& epg
   {
     // only year, month and day do matter here...
     const CDateTime startEpgLocal = CPVRTimerInfoTag::ConvertUTCToLocalTime(epgTag->StartAsUTC());
-    const CDateTime startEpg(startEpgLocal.GetYear(),
-                             startEpgLocal.GetMonth(),
+    const CDateTime startEpg(startEpgLocal.GetYear(), startEpgLocal.GetMonth(),
                              startEpgLocal.GetDay(), 0, 0, 0);
     const CDateTime firstDayLocal = m_timerRule->FirstDayAsLocalTime();
-    const CDateTime startTimer(firstDayLocal.GetYear(),
-                               firstDayLocal.GetMonth(),
+    const CDateTime startTimer(firstDayLocal.GetYear(), firstDayLocal.GetMonth(),
                                firstDayLocal.GetDay(), 0, 0, 0);
     if (startEpg < startTimer)
       return false;
@@ -129,7 +122,8 @@ bool CPVRTimerRuleMatcher::MatchStart(const std::shared_ptr<CPVREpgInfoTag>& epg
     const CDateTime startEpgLocal = CPVRTimerInfoTag::ConvertUTCToLocalTime(epgTag->StartAsUTC());
     const CDateTime startEpg(2000, 1, 1, startEpgLocal.GetHour(), startEpgLocal.GetMinute(), 0);
     const CDateTime startTimerLocal = m_timerRule->StartAsLocalTime();
-    const CDateTime startTimer(2000, 1, 1, startTimerLocal.GetHour(), startTimerLocal.GetMinute(), 0);
+    const CDateTime startTimer(2000, 1, 1, startTimerLocal.GetHour(), startTimerLocal.GetMinute(),
+                               0);
     return startEpg >= startTimer;
   }
   else

--- a/xbmc/pvr/timers/PVRTimerRuleMatcher.cpp
+++ b/xbmc/pvr/timers/PVRTimerRuleMatcher.cpp
@@ -51,7 +51,7 @@ CDateTime CPVRTimerRuleMatcher::GetNextTimerStart() const
   }
 
   if (m_timerRule->GetTimerType()->SupportsWeekdays() &&
-      m_timerRule->m_iWeekdays != PVR_WEEKDAY_ALLDAYS)
+      m_timerRule->WeekDays() != PVR_WEEKDAY_ALLDAYS)
   {
     bool bMatch = false;
     while (!bMatch)
@@ -60,7 +60,7 @@ CDateTime CPVRTimerRuleMatcher::GetNextTimerStart() const
       if (startWeekday == 0)
         startWeekday = 7;
 
-      bMatch = ((1 << (startWeekday - 1)) & m_timerRule->m_iWeekdays);
+      bMatch = ((1 << (startWeekday - 1)) & m_timerRule->WeekDays());
       if (!bMatch)
         nextStart += oneDay;
     }
@@ -92,13 +92,13 @@ bool CPVRTimerRuleMatcher::MatchSeriesLink(const std::shared_ptr<CPVREpgInfoTag>
 bool CPVRTimerRuleMatcher::MatchChannel(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
 {
   if (m_timerRule->GetTimerType()->SupportsAnyChannel() &&
-      m_timerRule->m_iClientChannelUid == PVR_CHANNEL_INVALID_UID)
+      m_timerRule->ClientChannelUID() == PVR_CHANNEL_INVALID_UID)
     return true; // matches any channel
 
   if (m_timerRule->GetTimerType()->SupportsChannels())
-    return m_timerRule->m_iClientChannelUid != PVR_CHANNEL_INVALID_UID &&
-           epgTag->ClientID() == m_timerRule->m_iClientId &&
-           epgTag->UniqueChannelID() == m_timerRule->m_iClientChannelUid;
+    return m_timerRule->ClientChannelUID() != PVR_CHANNEL_INVALID_UID &&
+           epgTag->ClientID() == m_timerRule->ClientID() &&
+           epgTag->UniqueChannelID() == m_timerRule->ClientChannelUID();
   else
     return true;
 }
@@ -120,8 +120,7 @@ bool CPVRTimerRuleMatcher::MatchStart(const std::shared_ptr<CPVREpgInfoTag>& epg
       return false;
   }
 
-  if (m_timerRule->GetTimerType()->SupportsStartAnyTime() &&
-      m_timerRule->m_bStartAnyTime)
+  if (m_timerRule->GetTimerType()->SupportsStartAnyTime() && m_timerRule->IsStartAnyTime())
     return true; // matches any start time
 
   if (m_timerRule->GetTimerType()->SupportsStartTime())
@@ -139,8 +138,7 @@ bool CPVRTimerRuleMatcher::MatchStart(const std::shared_ptr<CPVREpgInfoTag>& epg
 
 bool CPVRTimerRuleMatcher::MatchEnd(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
 {
-  if (m_timerRule->GetTimerType()->SupportsEndAnyTime() &&
-      m_timerRule->m_bEndAnyTime)
+  if (m_timerRule->GetTimerType()->SupportsEndAnyTime() && m_timerRule->IsEndAnyTime())
     return true; // matches any end time
 
   if (m_timerRule->GetTimerType()->SupportsEndTime())
@@ -160,14 +158,14 @@ bool CPVRTimerRuleMatcher::MatchDayOfWeek(const std::shared_ptr<CPVREpgInfoTag>&
 {
   if (m_timerRule->GetTimerType()->SupportsWeekdays())
   {
-    if (m_timerRule->m_iWeekdays != PVR_WEEKDAY_ALLDAYS)
+    if (m_timerRule->WeekDays() != PVR_WEEKDAY_ALLDAYS)
     {
       const CDateTime startEpgLocal = CPVRTimerInfoTag::ConvertUTCToLocalTime(epgTag->StartAsUTC());
       int startWeekday = startEpgLocal.GetDayOfWeek();
       if (startWeekday == 0)
         startWeekday = 7;
 
-      return ((1 << (startWeekday - 1)) & m_timerRule->m_iWeekdays);
+      return ((1 << (startWeekday - 1)) & m_timerRule->WeekDays());
     }
   }
   return true;
@@ -175,13 +173,12 @@ bool CPVRTimerRuleMatcher::MatchDayOfWeek(const std::shared_ptr<CPVREpgInfoTag>&
 
 bool CPVRTimerRuleMatcher::MatchSearchText(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
 {
-  if (m_timerRule->GetTimerType()->SupportsEpgFulltextMatch() &&
-      m_timerRule->m_bFullTextEpgSearch)
+  if (m_timerRule->GetTimerType()->SupportsEpgFulltextMatch() && m_timerRule->IsFullTextEpgSearch())
   {
     if (!m_textSearch)
     {
       m_textSearch.reset(new CRegExp(true /* case insensitive */));
-      m_textSearch->RegComp(m_timerRule->m_strEpgSearchString);
+      m_textSearch->RegComp(m_timerRule->EpgSearchString());
     }
     return m_textSearch->RegFind(epgTag->Title()) >= 0 ||
            m_textSearch->RegFind(epgTag->EpisodeName()) >= 0 ||
@@ -193,7 +190,7 @@ bool CPVRTimerRuleMatcher::MatchSearchText(const std::shared_ptr<CPVREpgInfoTag>
     if (!m_textSearch)
     {
       m_textSearch.reset(new CRegExp(true /* case insensitive */));
-      m_textSearch->RegComp(m_timerRule->m_strEpgSearchString);
+      m_textSearch->RegComp(m_timerRule->EpgSearchString());
     }
     return m_textSearch->RegFind(epgTag->Title()) >= 0;
   }

--- a/xbmc/pvr/timers/PVRTimerRuleMatcher.h
+++ b/xbmc/pvr/timers/PVRTimerRuleMatcher.h
@@ -16,32 +16,32 @@ class CRegExp;
 
 namespace PVR
 {
-  class CPVRChannel;
-  class CPVRTimerInfoTag;
-  class CPVREpgInfoTag;
+class CPVRChannel;
+class CPVRTimerInfoTag;
+class CPVREpgInfoTag;
 
-  class CPVRTimerRuleMatcher
-  {
-  public:
-    CPVRTimerRuleMatcher(const std::shared_ptr<CPVRTimerInfoTag>& timerRule, const CDateTime& start);
-    virtual ~CPVRTimerRuleMatcher();
+class CPVRTimerRuleMatcher
+{
+public:
+  CPVRTimerRuleMatcher(const std::shared_ptr<CPVRTimerInfoTag>& timerRule, const CDateTime& start);
+  virtual ~CPVRTimerRuleMatcher();
 
-    std::shared_ptr<CPVRTimerInfoTag> GetTimerRule() const { return m_timerRule; }
+  std::shared_ptr<CPVRTimerInfoTag> GetTimerRule() const { return m_timerRule; }
 
-    std::shared_ptr<CPVRChannel> GetChannel() const;
-    CDateTime GetNextTimerStart() const;
-    bool Matches(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
+  std::shared_ptr<CPVRChannel> GetChannel() const;
+  CDateTime GetNextTimerStart() const;
+  bool Matches(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
 
-  private:
-    bool MatchSeriesLink(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
-    bool MatchChannel(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
-    bool MatchStart(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
-    bool MatchEnd(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
-    bool MatchDayOfWeek(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
-    bool MatchSearchText(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
+private:
+  bool MatchSeriesLink(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
+  bool MatchChannel(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
+  bool MatchStart(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
+  bool MatchEnd(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
+  bool MatchDayOfWeek(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
+  bool MatchSearchText(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
 
-    const std::shared_ptr<CPVRTimerInfoTag> m_timerRule;
-    CDateTime m_start;
-    mutable std::unique_ptr<CRegExp> m_textSearch;
-  };
-}
+  const std::shared_ptr<CPVRTimerInfoTag> m_timerRule;
+  CDateTime m_start;
+  mutable std::unique_ptr<CRegExp> m_textSearch;
+};
+} // namespace PVR


### PR DESCRIPTION
Get rid of the public members of class `CPVRTimerInfoTag`. Plus some clang-format commits to ensure clang-conformity of PVR source files while they are touched by PRs.

Runtime-tested on macOS and Android, latest kodi master.

@phunkyfish if you concentrate on the first commit, review should be straight forward.