### PR TITLE
Fix CMake warning in windows/ArchSetup.cmake

### DIFF
--- a/cmake/scripts/windows/ArchSetup.cmake
+++ b/cmake/scripts/windows/ArchSetup.cmake
@@ -10,7 +10,7 @@ endif()
 # -------- Host Settings ---------
 
 set(_gentoolset ${CMAKE_GENERATOR_TOOLSET})
-string(REPLACE "host=" "" HOSTTOOLSET ${_gentoolset})
+string(REPLACE "host=" "" HOSTTOOLSET "${_gentoolset}")
 unset(_gentoolset)
 
 # -------- Architecture settings ---------


### PR DESCRIPTION
## Description

This fixes a dev warning printed by CMake on Windows when generator toolset is not specified:

```
CMake Error at cmake/scripts/windows/ArchSetup.cmake:13 (string):
  string sub-command REPLACE requires at least four arguments.
Call Stack (most recent call first):
  cmake/scripts/common/ArchSetup.cmake:79 (include)
  CMakeLists.txt:39 (include)
```