### PR TITLE
[cmake] add version parsing to ccache, clang-format & patch

### DIFF
--- a/cmake/modules/buildtools/FindCCache.cmake
+++ b/cmake/modules/buildtools/FindCCache.cmake
@@ -8,8 +8,17 @@
 
 find_program(CCACHE_PROGRAM ccache)
 
+if(CCACHE_PROGRAM)
+  execute_process(COMMAND "${CCACHE_PROGRAM}" --version
+                  OUTPUT_VARIABLE CCACHE_VERSION
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+  string(REGEX MATCH "[^\n]* version [^\n]*" CCACHE_VERSION "${CCACHE_VERSION}")
+  string(REGEX REPLACE ".* version (.*)" "\\1" CCACHE_VERSION "${CCACHE_VERSION}")
+endif()
+
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(CCache REQUIRED_VARS CCACHE_PROGRAM)
+find_package_handle_standard_args(CCache REQUIRED_VARS CCACHE_PROGRAM
+                                  VERSION_VAR CCACHE_VERSION)
 
 if(CCACHE_FOUND)
   # Supports Unix Makefiles, Ninja and Xcode
@@ -25,3 +34,5 @@ if(CCACHE_FOUND)
   set(CMAKE_XCODE_ATTRIBUTE_LD "${CMAKE_BINARY_DIR}/launch-c" PARENT_SCOPE)
   set(CMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS "${CMAKE_BINARY_DIR}/launch-cxx" PARENT_SCOPE)
 endif()
+
+mark_as_advanced(CCACHE_PROGRAM)

--- a/cmake/modules/buildtools/FindClangFormat.cmake
+++ b/cmake/modules/buildtools/FindClangFormat.cmake
@@ -5,7 +5,15 @@
 
 find_program(CLANG_FORMAT_EXECUTABLE clang-format)
 
+if(CLANG_FORMAT_EXECUTABLE)
+  execute_process(COMMAND "${CLANG_FORMAT_EXECUTABLE}" --version
+                  OUTPUT_VARIABLE CLANG_FORMAT_VERSION
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+  string(REGEX REPLACE ".* version (.*)" "\\1" CLANG_FORMAT_VERSION "${CLANG_FORMAT_VERSION}")
+endif()
+
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(ClangFormat REQUIRED_VARS CLANG_FORMAT_EXECUTABLE)
+find_package_handle_standard_args(ClangFormat REQUIRED_VARS CLANG_FORMAT_EXECUTABLE
+                                  VERSION_VAR CLANG_FORMAT_VERSION)
 
 mark_as_advanced(CLANG_FORMAT_EXECUTABLE)

--- a/cmake/modules/buildtools/FindPatch.cmake
+++ b/cmake/modules/buildtools/FindPatch.cmake
@@ -68,10 +68,7 @@ if(CMAKE_HOST_WIN32 AND NOT PATCH_EXE)
 endif()
 
 include(FindPackageHandleStandardArgs)
-
-set(FPHSA_NAME_MISMATCHED 1) # Suppress warnings, see https://cmake.org/cmake/help/v3.17/module/FindPackageHandleStandardArgs.html
-find_package_handle_standard_args(PATCH REQUIRED_VARS PATCH_EXE)
-unset(FPHSA_NAME_MISMATCHED)
+find_package_handle_standard_args(Patch REQUIRED_VARS PATCH_EXE)
 
 if(PATCH_FOUND)
   set(PATCH_EXECUTABLE "${PATCH_EXE}")

--- a/cmake/modules/buildtools/FindPatch.cmake
+++ b/cmake/modules/buildtools/FindPatch.cmake
@@ -67,8 +67,16 @@ if(CMAKE_HOST_WIN32 AND NOT PATCH_EXE)
   find_program(PATCH_EXE NAMES patch.exe HINTS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/bin REQUIRED)
 endif()
 
+if(PATCH_EXE)
+  execute_process(COMMAND "${PATCH_EXE}" --version
+                  OUTPUT_VARIABLE PATCH_VERSION
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+  string(REGEX MATCH "[^\n]*patch [^\n]*" PATCH_VERSION "${PATCH_VERSION}")
+  string(REGEX REPLACE ".*patch (.*)" "\\1" PATCH_VERSION "${PATCH_VERSION}")
+endif()
+
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Patch REQUIRED_VARS PATCH_EXE)
+find_package_handle_standard_args(Patch REQUIRED_VARS PATCH_EXE VERSION_VAR PATCH_VERSION)
 
 if(PATCH_FOUND)
   set(PATCH_EXECUTABLE "${PATCH_EXE}")


### PR DESCRIPTION
## Description
add version parsing to ccache, clang-format and patch

## Motivation and context
allows requiring minimum or exact versions for finding those tools

## How has this been tested?
checked the CMake configuration log

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
