### PR TITLE
[PVR] CPVRGUIActions*: Reduce usage of 'const shared_ptr<CFileItem>&' parameters.

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -2259,8 +2259,7 @@ bool CApplication::PlayMedia(CFileItem& item, const std::string& player, PLAYLIS
   }
   else if (item.IsPVR())
   {
-    return CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayMedia(
-        CFileItemPtr(new CFileItem(item)));
+    return CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayMedia(item);
   }
 
   CURL path(item.GetPath());

--- a/xbmc/application/ApplicationPlayerCallback.cpp
+++ b/xbmc/application/ApplicationPlayerCallback.cpp
@@ -44,7 +44,7 @@ void CApplicationPlayerCallback::OnPlayBackEnded()
 {
   CLog::LogF(LOGDEBUG, "CApplicationPlayerCallback::OnPlayBackEnded");
 
-  CServiceBroker::GetPVRManager().OnPlaybackEnded(m_itemCurrentFile);
+  CServiceBroker::GetPVRManager().OnPlaybackEnded(*m_itemCurrentFile);
 
   CVariant data(CVariant::VariantTypeObject);
   data["end"] = true;
@@ -89,7 +89,7 @@ void CApplicationPlayerCallback::OnPlayBackStarted(const CFileItem& file)
     CServiceBroker::GetJobManager()->PauseJobs();
   }
 
-  CServiceBroker::GetPVRManager().OnPlaybackStarted(m_itemCurrentFile);
+  CServiceBroker::GetPVRManager().OnPlaybackStarted(*m_itemCurrentFile);
   m_stackHelper.OnPlayBackStarted(file);
 
   m_playerEvent.Reset();
@@ -199,7 +199,7 @@ void CApplicationPlayerCallback::OnPlayBackStopped()
 {
   CLog::LogF(LOGDEBUG, "CApplication::OnPlayBackStopped");
 
-  CServiceBroker::GetPVRManager().OnPlaybackStopped(m_itemCurrentFile);
+  CServiceBroker::GetPVRManager().OnPlaybackStopped(*m_itemCurrentFile);
 
   CVariant data(CVariant::VariantTypeObject);
   data["end"] = false;

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -752,8 +752,7 @@ JSONRPC_STATUS CPlayerOperations::Open(const std::string &method, ITransportLaye
     if (!epgTag || !epgTag->IsPlayable())
       return InvalidParams;
 
-    if (!CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayEpgTag(
-            std::make_shared<CFileItem>(epgTag)))
+    if (!CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayEpgTag(CFileItem(epgTag)))
       return FailedToExecute;
 
     return ACK;
@@ -774,7 +773,7 @@ JSONRPC_STATUS CPlayerOperations::Open(const std::string &method, ITransportLaye
       return InvalidParams;
 
     if (!CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayMedia(
-            std::make_shared<CFileItem>(groupMember)))
+            CFileItem(groupMember)))
       return FailedToExecute;
 
     return ACK;
@@ -789,8 +788,7 @@ JSONRPC_STATUS CPlayerOperations::Open(const std::string &method, ITransportLaye
     if (!recording)
       return InvalidParams;
 
-    if (!CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayMedia(
-            std::make_shared<CFileItem>(recording)))
+    if (!CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayMedia(CFileItem(recording)))
       return FailedToExecute;
 
     return ACK;

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -442,7 +442,7 @@ bool CDirectoryProvider::OnInfo(const CGUIListItemPtr& item)
   }
   else if (fileItem->IsPVR())
   {
-    return CServiceBroker::GetPVRManager().Get<PVR::GUI::Utils>().OnInfo(fileItem);
+    return CServiceBroker::GetPVRManager().Get<PVR::GUI::Utils>().OnInfo(*fileItem);
   }
   else if (fileItem->HasVideoInfoTag())
   {

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -122,7 +122,7 @@ bool PlayEpgTag::IsVisible(const CFileItem& item) const
 
 bool PlayEpgTag::Execute(const CFileItemPtr& item) const
 {
-  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayEpgTag(item);
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayEpgTag(*item);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -141,7 +141,7 @@ bool PlayRecording::IsVisible(const CFileItem& item) const
 bool PlayRecording::Execute(const CFileItemPtr& item) const
 {
   return CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayRecording(
-      item, true /* bCheckResume */);
+      *item, true /* bCheckResume */);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -179,7 +179,7 @@ bool ShowInformation::Execute(const CFileItemPtr& item) const
   if (item->GetPVRRecordingInfoTag())
     return CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().ShowRecordingInfo(item);
 
-  return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowEPGInfo(item);
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowEPGInfo(*item);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -196,7 +196,7 @@ bool ShowChannelGuide::IsVisible(const CFileItem& item) const
 
 bool ShowChannelGuide::Execute(const CFileItemPtr& item) const
 {
-  return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowChannelEPG(item);
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowChannelEPG(*item);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -224,7 +224,7 @@ bool FindSimilar::IsVisible(const CFileItem& item) const
 
 bool FindSimilar::Execute(const CFileItemPtr& item) const
 {
-  return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().FindSimilar(item);
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().FindSimilar(*item);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -671,7 +671,7 @@ bool ExecuteSearch::IsVisible(const CFileItem& item) const
 
 bool ExecuteSearch::Execute(const std::shared_ptr<CFileItem>& item) const
 {
-  return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ExecuteSavedSearch(item);
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ExecuteSavedSearch(*item);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -684,7 +684,7 @@ bool EditSearch::IsVisible(const CFileItem& item) const
 
 bool EditSearch::Execute(const std::shared_ptr<CFileItem>& item) const
 {
-  return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().EditSavedSearch(item);
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().EditSavedSearch(*item);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -697,7 +697,7 @@ bool RenameSearch::IsVisible(const CFileItem& item) const
 
 bool RenameSearch::Execute(const std::shared_ptr<CFileItem>& item) const
 {
-  return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().RenameSavedSearch(item);
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().RenameSavedSearch(*item);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -710,7 +710,7 @@ bool DeleteSearch::IsVisible(const CFileItem& item) const
 
 bool DeleteSearch::Execute(const std::shared_ptr<CFileItem>& item) const
 {
-  return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().DeleteSavedSearch(item);
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().DeleteSavedSearch(*item);
 }
 
 } // namespace CONTEXTMENUITEM

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -177,7 +177,7 @@ bool ShowInformation::IsVisible(const CFileItem& item) const
 bool ShowInformation::Execute(const CFileItemPtr& item) const
 {
   if (item->GetPVRRecordingInfoTag())
-    return CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().ShowRecordingInfo(item);
+    return CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().ShowRecordingInfo(*item);
 
   return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowEPGInfo(*item);
 }
@@ -340,7 +340,7 @@ bool EditRecording::IsVisible(const CFileItem& item) const
 
 bool EditRecording::Execute(const CFileItemPtr& item) const
 {
-  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().EditRecording(item);
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().EditRecording(*item);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -378,7 +378,7 @@ bool DeleteRecording::IsVisible(const CFileItem& item) const
 
 bool DeleteRecording::Execute(const CFileItemPtr& item) const
 {
-  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().DeleteRecording(item);
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().DeleteRecording(*item);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -395,7 +395,7 @@ bool UndeleteRecording::IsVisible(const CFileItem& item) const
 
 bool UndeleteRecording::Execute(const CFileItemPtr& item) const
 {
-  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().UndeleteRecording(item);
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().UndeleteRecording(*item);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -412,7 +412,7 @@ bool DeleteWatchedRecordings::IsVisible(const CFileItem& item) const
 
 bool DeleteWatchedRecordings::Execute(const std::shared_ptr<CFileItem>& item) const
 {
-  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().DeleteWatchedRecordings(item);
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().DeleteWatchedRecordings(*item);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -278,7 +278,7 @@ bool StartRecording::Execute(const CFileItemPtr& item) const
                                                                                            true);
   }
 
-  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().AddTimer(item, false);
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().AddTimer(*item, false);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -322,7 +322,7 @@ bool StopRecording::Execute(const CFileItemPtr& item) const
                                                                                            false);
   }
 
-  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().StopRecording(item);
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().StopRecording(*item);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -430,7 +430,7 @@ bool AddReminder::IsVisible(const CFileItem& item) const
 
 bool AddReminder::Execute(const std::shared_ptr<CFileItem>& item) const
 {
-  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().AddReminder(item);
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().AddReminder(*item);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -457,7 +457,7 @@ bool ToggleTimerState::IsVisible(const CFileItem& item) const
 
 bool ToggleTimerState::Execute(const CFileItemPtr& item) const
 {
-  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().ToggleTimerState(item);
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().ToggleTimerState(*item);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -472,7 +472,7 @@ bool AddTimerRule::IsVisible(const CFileItem& item) const
 
 bool AddTimerRule::Execute(const CFileItemPtr& item) const
 {
-  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().AddTimerRule(item, true, true);
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().AddTimerRule(*item, true, true);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -506,7 +506,7 @@ bool EditTimerRule::IsVisible(const CFileItem& item) const
 
 bool EditTimerRule::Execute(const CFileItemPtr& item) const
 {
-  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().EditTimerRule(item);
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().EditTimerRule(*item);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -529,9 +529,9 @@ bool DeleteTimerRule::IsVisible(const CFileItem& item) const
 bool DeleteTimerRule::Execute(const CFileItemPtr& item) const
 {
   auto& timers = CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>();
-  const std::shared_ptr<CFileItem> parentTimer = timers.GetTimerRule(item);
+  const std::shared_ptr<CFileItem> parentTimer = timers.GetTimerRule(*item);
   if (parentTimer)
-    return timers.DeleteTimerRule(parentTimer);
+    return timers.DeleteTimerRule(*parentTimer);
 
   return false;
 }
@@ -569,7 +569,7 @@ bool EditTimer::IsVisible(const CFileItem& item) const
 
 bool EditTimer::Execute(const CFileItemPtr& item) const
 {
-  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().EditTimer(item);
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().EditTimer(*item);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -605,7 +605,7 @@ bool DeleteTimer::IsVisible(const CFileItem& item) const
 
 bool DeleteTimer::Execute(const CFileItemPtr& item) const
 {
-  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().DeleteTimer(item);
+  return CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().DeleteTimer(*item);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/xbmc/pvr/PVRItem.h
+++ b/xbmc/pvr/PVRItem.h
@@ -24,6 +24,7 @@ class CPVRItem
 public:
   explicit CPVRItem(const std::shared_ptr<CFileItem>& item) : m_item(item.get()) {}
   explicit CPVRItem(const CFileItem* item) : m_item(item) {}
+  explicit CPVRItem(const CFileItem& item) : m_item(&item) {}
 
   std::shared_ptr<CPVREpgInfoTag> GetEpgInfoTag() const;
   std::shared_ptr<CPVREpgInfoTag> GetNextEpgInfoTag() const;

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -821,14 +821,14 @@ bool CPVRManager::IsCurrentlyParentalLocked(const std::shared_ptr<CPVRChannel>& 
   return bReturn;
 }
 
-void CPVRManager::OnPlaybackStarted(const CFileItemPtr& item)
+void CPVRManager::OnPlaybackStarted(const CFileItem& item)
 {
   m_playbackState->OnPlaybackStarted(item);
   Get<PVR::GUI::Channels>().OnPlaybackStarted(item);
   m_epgContainer.OnPlaybackStarted();
 }
 
-void CPVRManager::OnPlaybackStopped(const CFileItemPtr& item)
+void CPVRManager::OnPlaybackStopped(const CFileItem& item)
 {
   // Playback ended due to user interaction
   if (m_playbackState->OnPlaybackStopped(item))
@@ -838,7 +838,7 @@ void CPVRManager::OnPlaybackStopped(const CFileItemPtr& item)
   m_epgContainer.OnPlaybackStopped();
 }
 
-void CPVRManager::OnPlaybackEnded(const CFileItemPtr& item)
+void CPVRManager::OnPlaybackEnded(const CFileItem& item)
 {
   // Playback ended, but not due to user interaction
   OnPlaybackStopped(item);

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -230,19 +230,19 @@ public:
    * @brief Inform PVR manager that playback of an item just started.
    * @param item The item that started to play.
    */
-  void OnPlaybackStarted(const std::shared_ptr<CFileItem>& item);
+  void OnPlaybackStarted(const CFileItem& item);
 
   /*!
    * @brief Inform PVR manager that playback of an item was stopped due to user interaction.
    * @param item The item that stopped to play.
    */
-  void OnPlaybackStopped(const std::shared_ptr<CFileItem>& item);
+  void OnPlaybackStopped(const CFileItem& item);
 
   /*!
    * @brief Inform PVR manager that playback of an item has stopped without user interaction.
    * @param item The item that ended to play.
    */
-  void OnPlaybackEnded(const std::shared_ptr<CFileItem>& item);
+  void OnPlaybackEnded(const CFileItem& item);
 
   /*!
    * @brief Let the background thread create epg tags for all channels.

--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -139,7 +139,7 @@ void CPVRPlaybackState::Clear()
   m_activeGroupRadio.reset();
 }
 
-void CPVRPlaybackState::OnPlaybackStarted(const std::shared_ptr<CFileItem>& item)
+void CPVRPlaybackState::OnPlaybackStarted(const CFileItem& item)
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
 
@@ -148,9 +148,9 @@ void CPVRPlaybackState::OnPlaybackStarted(const std::shared_ptr<CFileItem>& item
   m_playingEpgTag.reset();
   ClearData();
 
-  if (item->HasPVRChannelGroupMemberInfoTag())
+  if (item.HasPVRChannelGroupMemberInfoTag())
   {
-    const std::shared_ptr<CPVRChannelGroupMember> channel = item->GetPVRChannelGroupMemberInfoTag();
+    const std::shared_ptr<CPVRChannelGroupMember> channel = item.GetPVRChannelGroupMemberInfoTag();
 
     m_playingChannel = channel;
     m_playingGroupId = m_playingChannel->GroupID();
@@ -195,20 +195,20 @@ void CPVRPlaybackState::OnPlaybackStarted(const std::shared_ptr<CFileItem>& item
       UpdateLastWatched(channel, CDateTime::GetUTCDateTime());
     }
   }
-  else if (item->HasPVRRecordingInfoTag())
+  else if (item.HasPVRRecordingInfoTag())
   {
-    m_playingRecording = item->GetPVRRecordingInfoTag();
+    m_playingRecording = item.GetPVRRecordingInfoTag();
     m_playingClientId = m_playingRecording->ClientID();
     m_strPlayingRecordingUniqueId = m_playingRecording->ClientRecordingID();
   }
-  else if (item->HasEPGInfoTag())
+  else if (item.HasEPGInfoTag())
   {
-    m_playingEpgTag = item->GetEPGInfoTag();
+    m_playingEpgTag = item.GetEPGInfoTag();
     m_playingClientId = m_playingEpgTag->ClientID();
     m_playingEpgTagChannelUniqueId = m_playingEpgTag->UniqueChannelID();
     m_playingEpgTagUniqueId = m_playingEpgTag->UniqueBroadcastID();
   }
-  else if (item->HasPVRChannelInfoTag())
+  else if (item.HasPVRChannelInfoTag())
   {
     CLog::LogFC(LOGERROR, LOGPVR, "Channel item without channel group member!");
   }
@@ -222,7 +222,7 @@ void CPVRPlaybackState::OnPlaybackStarted(const std::shared_ptr<CFileItem>& item
   }
 }
 
-bool CPVRPlaybackState::OnPlaybackStopped(const std::shared_ptr<CFileItem>& item)
+bool CPVRPlaybackState::OnPlaybackStopped(const CFileItem& item)
 {
   // Playback ended due to user interaction
 
@@ -230,9 +230,9 @@ bool CPVRPlaybackState::OnPlaybackStopped(const std::shared_ptr<CFileItem>& item
 
   bool bChanged = false;
 
-  if (item->HasPVRChannelGroupMemberInfoTag() &&
-      item->GetPVRChannelGroupMemberInfoTag()->Channel()->ClientID() == m_playingClientId &&
-      item->GetPVRChannelGroupMemberInfoTag()->Channel()->UniqueID() == m_playingChannelUniqueId)
+  if (item.HasPVRChannelGroupMemberInfoTag() &&
+      item.GetPVRChannelGroupMemberInfoTag()->Channel()->ClientID() == m_playingClientId &&
+      item.GetPVRChannelGroupMemberInfoTag()->Channel()->UniqueID() == m_playingChannelUniqueId)
   {
     bool bUpdateLastWatched = true;
 
@@ -257,23 +257,23 @@ bool CPVRPlaybackState::OnPlaybackStopped(const std::shared_ptr<CFileItem>& item
     m_playingChannel.reset();
     ClearData();
   }
-  else if (item->HasPVRRecordingInfoTag() &&
-           item->GetPVRRecordingInfoTag()->ClientID() == m_playingClientId &&
-           item->GetPVRRecordingInfoTag()->ClientRecordingID() == m_strPlayingRecordingUniqueId)
+  else if (item.HasPVRRecordingInfoTag() &&
+           item.GetPVRRecordingInfoTag()->ClientID() == m_playingClientId &&
+           item.GetPVRRecordingInfoTag()->ClientRecordingID() == m_strPlayingRecordingUniqueId)
   {
     bChanged = true;
     m_playingRecording.reset();
     ClearData();
   }
-  else if (item->HasEPGInfoTag() && item->GetEPGInfoTag()->ClientID() == m_playingClientId &&
-           item->GetEPGInfoTag()->UniqueChannelID() == m_playingEpgTagChannelUniqueId &&
-           item->GetEPGInfoTag()->UniqueBroadcastID() == m_playingEpgTagUniqueId)
+  else if (item.HasEPGInfoTag() && item.GetEPGInfoTag()->ClientID() == m_playingClientId &&
+           item.GetEPGInfoTag()->UniqueChannelID() == m_playingEpgTagChannelUniqueId &&
+           item.GetEPGInfoTag()->UniqueBroadcastID() == m_playingEpgTagUniqueId)
   {
     bChanged = true;
     m_playingEpgTag.reset();
     ClearData();
   }
-  else if (item->HasPVRChannelInfoTag())
+  else if (item.HasPVRChannelInfoTag())
   {
     CLog::LogFC(LOGERROR, LOGPVR, "Channel item without channel group member!");
   }
@@ -281,7 +281,7 @@ bool CPVRPlaybackState::OnPlaybackStopped(const std::shared_ptr<CFileItem>& item
   return bChanged;
 }
 
-void CPVRPlaybackState::OnPlaybackEnded(const std::shared_ptr<CFileItem>& item)
+void CPVRPlaybackState::OnPlaybackEnded(const CFileItem& item)
 {
   // Playback ended, but not due to user interaction
   OnPlaybackStopped(item);

--- a/xbmc/pvr/PVRPlaybackState.h
+++ b/xbmc/pvr/PVRPlaybackState.h
@@ -51,20 +51,20 @@ public:
    * @brief Inform that playback of an item just started.
    * @param item The item that started to play.
    */
-  void OnPlaybackStarted(const std::shared_ptr<CFileItem>& item);
+  void OnPlaybackStarted(const CFileItem& item);
 
   /*!
    * @brief Inform that playback of an item was stopped due to user interaction.
    * @param item The item that stopped to play.
    * @return True, if the state has changed, false otherwise
    */
-  bool OnPlaybackStopped(const std::shared_ptr<CFileItem>& item);
+  bool OnPlaybackStopped(const CFileItem& item);
 
   /*!
    * @brief Inform that playback of an item has stopped without user interaction.
    * @param item The item that ended to play.
    */
-  void OnPlaybackEnded(const std::shared_ptr<CFileItem>& item);
+  void OnPlaybackEnded(const CFileItem& item);
 
   /*!
    * @brief Check if a TV channel, radio channel or recording is playing.

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -238,19 +238,20 @@ void CGUIDialogPVRChannelsOSD::RestoreControlStates()
   }
 }
 
-void CGUIDialogPVRChannelsOSD::GotoChannel(int item)
+void CGUIDialogPVRChannelsOSD::GotoChannel(int iItem)
 {
-  if (item < 0 || item >= m_vecItems->Size())
+  if (iItem < 0 || iItem >= m_vecItems->Size())
     return;
 
   // Preserve the item before closing self, because this will clear m_vecItems
-  const CFileItemPtr itemptr = m_vecItems->Get(item);
+  const std::shared_ptr<CFileItem> item = m_vecItems->Get(iItem);
+
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
           CSettings::SETTING_PVRMENU_CLOSECHANNELOSDONSWITCH))
     Close();
 
   CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(
-      itemptr, true /* bCheckResume */);
+      *item, true /* bCheckResume */);
 }
 
 void CGUIDialogPVRChannelsOSD::Notify(const PVREvent& event)

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -66,15 +66,14 @@ bool CGUIDialogPVRGuideInfo::OnClickButtonRecord(const CGUIMessage& message)
         mgr.Timers()->GetTimerForEpgTag(m_progItem->GetEPGInfoTag());
     if (timerTag)
     {
-      const CFileItemPtr item(new CFileItem(timerTag));
       if (timerTag->IsRecording())
-        bReturn = mgr.Get<PVR::GUI::Timers>().StopRecording(item);
+        bReturn = mgr.Get<PVR::GUI::Timers>().StopRecording(CFileItem(timerTag));
       else
-        bReturn = mgr.Get<PVR::GUI::Timers>().DeleteTimer(item);
+        bReturn = mgr.Get<PVR::GUI::Timers>().DeleteTimer(CFileItem(timerTag));
     }
     else
     {
-      bReturn = mgr.Get<PVR::GUI::Timers>().AddTimer(m_progItem, false);
+      bReturn = mgr.Get<PVR::GUI::Timers>().AddTimer(*m_progItem, false);
     }
   }
 
@@ -93,7 +92,7 @@ bool CGUIDialogPVRGuideInfo::OnClickButtonAddTimer(const CGUIMessage& message)
     auto& mgr = CServiceBroker::GetPVRManager();
     if (m_progItem && !mgr.Timers()->GetTimerForEpgTag(m_progItem->GetEPGInfoTag()))
     {
-      bReturn = mgr.Get<PVR::GUI::Timers>().AddTimerRule(m_progItem, true, true);
+      bReturn = mgr.Get<PVR::GUI::Timers>().AddTimerRule(*m_progItem, true, true);
     }
   }
 
@@ -112,7 +111,7 @@ bool CGUIDialogPVRGuideInfo::OnClickButtonSetReminder(const CGUIMessage& message
     auto& mgr = CServiceBroker::GetPVRManager();
     if (m_progItem && !mgr.Timers()->GetTimerForEpgTag(m_progItem->GetEPGInfoTag()))
     {
-      bReturn = mgr.Get<PVR::GUI::Timers>().AddReminder(m_progItem);
+      bReturn = mgr.Get<PVR::GUI::Timers>().AddReminder(*m_progItem);
     }
   }
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -132,17 +132,20 @@ bool CGUIDialogPVRGuideInfo::OnClickButtonPlay(const CGUIMessage& message)
   {
     Close();
 
-    if (message.GetSenderId() == CONTROL_BTN_PLAY_RECORDING)
-      CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayRecording(
-          m_progItem, true /* bCheckResume */);
-    else if (message.GetSenderId() == CONTROL_BTN_PLAY_EPGTAG &&
-             m_progItem->GetEPGInfoTag()->IsPlayable())
-      CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayEpgTag(m_progItem);
-    else
-      CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(
-          m_progItem, true /* bCheckResume */);
+    if (m_progItem)
+    {
+      if (message.GetSenderId() == CONTROL_BTN_PLAY_RECORDING)
+        CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayRecording(
+            *m_progItem, true /* bCheckResume */);
+      else if (message.GetSenderId() == CONTROL_BTN_PLAY_EPGTAG &&
+               m_progItem->GetEPGInfoTag()->IsPlayable())
+        CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayEpgTag(*m_progItem);
+      else
+        CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(
+            *m_progItem, true /* bCheckResume */);
 
-    bReturn = true;
+      bReturn = true;
+    }
   }
 
   return bReturn;

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -155,7 +155,8 @@ bool CGUIDialogPVRGuideInfo::OnClickButtonFind(const CGUIMessage& message)
   if (message.GetSenderId() == CONTROL_BTN_FIND)
   {
     Close();
-    return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().FindSimilar(m_progItem);
+    if (m_progItem)
+      return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().FindSimilar(*m_progItem);
   }
 
   return bReturn;

--- a/xbmc/pvr/dialogs/GUIDialogPVRItemsViewBase.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRItemsViewBase.cpp
@@ -25,8 +25,7 @@
 using namespace PVR;
 
 CGUIDialogPVRItemsViewBase::CGUIDialogPVRItemsViewBase(int id, const std::string& xmlFile)
-: CGUIDialog(id, xmlFile),
-  m_vecItems(new CFileItemList)
+  : CGUIDialog(id, xmlFile), m_vecItems(new CFileItemList)
 {
 }
 
@@ -100,7 +99,9 @@ void CGUIDialogPVRItemsViewBase::ShowInfo(int itemIdx)
 
 bool CGUIDialogPVRItemsViewBase::ContextMenu(int itemIdx)
 {
-  auto InRange = [](size_t i, std::pair<size_t, size_t> range){ return i >= range.first && i < range.second; };
+  auto InRange = [](size_t i, std::pair<size_t, size_t> range) {
+    return i >= range.first && i < range.second;
+  };
 
   if (itemIdx < 0 || itemIdx >= m_vecItems->Size())
     return false;
@@ -112,13 +113,15 @@ bool CGUIDialogPVRItemsViewBase::ContextMenu(int itemIdx)
   CContextButtons buttons;
 
   // Add the global menu
-  const ContextMenuView globalMenu = CServiceBroker::GetContextMenuManager().GetItems(*item, CContextMenuManager::MAIN);
+  const ContextMenuView globalMenu =
+      CServiceBroker::GetContextMenuManager().GetItems(*item, CContextMenuManager::MAIN);
   auto globalMenuRange = std::make_pair(buttons.size(), buttons.size() + globalMenu.size());
   for (const auto& menu : globalMenu)
     buttons.emplace_back(~buttons.size(), menu->GetLabel(*item));
 
   // Add addon menus
-  const ContextMenuView addonMenu = CServiceBroker::GetContextMenuManager().GetAddonItems(*item, CContextMenuManager::MAIN);
+  const ContextMenuView addonMenu =
+      CServiceBroker::GetContextMenuManager().GetAddonItems(*item, CContextMenuManager::MAIN);
   auto addonMenuRange = std::make_pair(buttons.size(), buttons.size() + addonMenu.size());
   for (const auto& menu : addonMenu)
     buttons.emplace_back(~buttons.size(), menu->GetLabel(*item));

--- a/xbmc/pvr/dialogs/GUIDialogPVRItemsViewBase.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRItemsViewBase.cpp
@@ -95,7 +95,7 @@ void CGUIDialogPVRItemsViewBase::ShowInfo(int itemIdx)
   if (!item)
     return;
 
-  CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowEPGInfo(item);
+  CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowEPGInfo(*item);
 }
 
 bool CGUIDialogPVRItemsViewBase::ContextMenu(int itemIdx)

--- a/xbmc/pvr/dialogs/GUIDialogPVRItemsViewBase.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRItemsViewBase.h
@@ -18,30 +18,30 @@ class CFileItemList;
 
 namespace PVR
 {
-  class CGUIDialogPVRItemsViewBase : public CGUIDialog
-  {
-  public:
-    CGUIDialogPVRItemsViewBase() = delete;
-    CGUIDialogPVRItemsViewBase(int id, const std::string& xmlFile);
-    ~CGUIDialogPVRItemsViewBase() override = default;
+class CGUIDialogPVRItemsViewBase : public CGUIDialog
+{
+public:
+  CGUIDialogPVRItemsViewBase() = delete;
+  CGUIDialogPVRItemsViewBase(int id, const std::string& xmlFile);
+  ~CGUIDialogPVRItemsViewBase() override = default;
 
-    void OnWindowLoaded() override;
-    void OnWindowUnload() override;
-    bool OnAction(const CAction& action) override;
+  void OnWindowLoaded() override;
+  void OnWindowUnload() override;
+  bool OnAction(const CAction& action) override;
 
-  protected:
-    void Init();
+protected:
+  void Init();
 
-    void OnInitWindow() override;
-    void OnDeinitWindow(int nextWindowID) override;
-    CGUIControl* GetFirstFocusableControl(int id) override;
+  void OnInitWindow() override;
+  void OnDeinitWindow(int nextWindowID) override;
+  CGUIControl* GetFirstFocusableControl(int id) override;
 
-    std::unique_ptr<CFileItemList> m_vecItems;
-    CGUIViewControl m_viewControl;
+  std::unique_ptr<CFileItemList> m_vecItems;
+  CGUIViewControl m_viewControl;
 
-  private:
-    void Clear();
-    void ShowInfo(int itemIdx);
-    bool ContextMenu(int iItemIdx);
-  };
-}
+private:
+  void Clear();
+  void ShowInfo(int itemIdx);
+  bool ContextMenu(int iItemIdx);
+};
+} // namespace PVR

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.cpp
@@ -94,9 +94,9 @@ bool CGUIDialogPVRRecordingInfo::OnInfo(int actionID)
   return true;
 }
 
-void CGUIDialogPVRRecordingInfo::SetRecording(const CFileItem* item)
+void CGUIDialogPVRRecordingInfo::SetRecording(const CFileItem& item)
 {
-  *m_recordItem = *item;
+  m_recordItem = std::make_shared<CFileItem>(item);
 }
 
 CFileItemPtr CGUIDialogPVRRecordingInfo::GetCurrentListItem(int offset)

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.cpp
@@ -63,7 +63,7 @@ bool CGUIDialogPVRRecordingInfo::OnClickButtonPlay(const CGUIMessage& message)
 
     if (m_recordItem)
       CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayRecording(
-          m_recordItem, true /* check resume */);
+          *m_recordItem, true /* check resume */);
 
     bReturn = true;
   }

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.cpp
@@ -18,12 +18,11 @@
 using namespace PVR;
 
 #define CONTROL_BTN_FIND 4
-#define CONTROL_BTN_OK  7
-#define CONTROL_BTN_PLAY_RECORDING  8
+#define CONTROL_BTN_OK 7
+#define CONTROL_BTN_PLAY_RECORDING 8
 
 CGUIDialogPVRRecordingInfo::CGUIDialogPVRRecordingInfo()
-  : CGUIDialog(WINDOW_DIALOG_PVR_RECORDING_INFO, "DialogPVRInfo.xml")
-  , m_recordItem(new CFileItem)
+  : CGUIDialog(WINDOW_DIALOG_PVR_RECORDING_INFO, "DialogPVRInfo.xml"), m_recordItem(new CFileItem)
 {
 }
 
@@ -32,9 +31,7 @@ bool CGUIDialogPVRRecordingInfo::OnMessage(CGUIMessage& message)
   switch (message.GetMessage())
   {
     case GUI_MSG_CLICKED:
-      return OnClickButtonOK(message) ||
-             OnClickButtonPlay(message) ||
-             OnClickButtonFind(message);
+      return OnClickButtonOK(message) || OnClickButtonPlay(message) || OnClickButtonFind(message);
   }
 
   return CGUIDialog::OnMessage(message);

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.cpp
@@ -80,7 +80,7 @@ bool CGUIDialogPVRRecordingInfo::OnClickButtonFind(const CGUIMessage& message)
     Close();
 
     if (m_recordItem)
-      CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().FindSimilar(m_recordItem);
+      CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().FindSimilar(*m_recordItem);
 
     bReturn = true;
   }

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.h
@@ -15,23 +15,23 @@ class CGUIMessage;
 
 namespace PVR
 {
-  class CGUIDialogPVRRecordingInfo : public CGUIDialog
-  {
-  public:
-    CGUIDialogPVRRecordingInfo();
-    ~CGUIDialogPVRRecordingInfo() override = default;
-    bool OnMessage(CGUIMessage& message) override;
-    bool OnInfo(int actionID) override;
-    bool HasListItems() const override { return true; }
-    CFileItemPtr GetCurrentListItem(int offset = 0) override;
+class CGUIDialogPVRRecordingInfo : public CGUIDialog
+{
+public:
+  CGUIDialogPVRRecordingInfo();
+  ~CGUIDialogPVRRecordingInfo() override = default;
+  bool OnMessage(CGUIMessage& message) override;
+  bool OnInfo(int actionID) override;
+  bool HasListItems() const override { return true; }
+  CFileItemPtr GetCurrentListItem(int offset = 0) override;
 
-    void SetRecording(const CFileItem& item);
+  void SetRecording(const CFileItem& item);
 
-  private:
-    bool OnClickButtonFind(const CGUIMessage& message);
-    bool OnClickButtonOK(const CGUIMessage& message);
-    bool OnClickButtonPlay(const CGUIMessage& message);
+private:
+  bool OnClickButtonFind(const CGUIMessage& message);
+  bool OnClickButtonOK(const CGUIMessage& message);
+  bool OnClickButtonPlay(const CGUIMessage& message);
 
-    CFileItemPtr m_recordItem;
-  };
-}
+  CFileItemPtr m_recordItem;
+};
+} // namespace PVR

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.h
@@ -25,7 +25,7 @@ namespace PVR
     bool HasListItems() const override { return true; }
     CFileItemPtr GetCurrentListItem(int offset = 0) override;
 
-    void SetRecording(const CFileItem* item);
+    void SetRecording(const CFileItem& item);
 
   private:
     bool OnClickButtonFind(const CGUIMessage& message);

--- a/xbmc/pvr/guilib/PVRGUIActionListener.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionListener.cpp
@@ -92,7 +92,8 @@ void CPVRGUIActionListener::OnPVRManagerEvent(const PVREvent& event)
 ChannelSwitchMode CPVRGUIActionListener::GetChannelSwitchMode(int iAction)
 {
   if ((iAction == ACTION_MOVE_UP || iAction == ACTION_MOVE_DOWN) &&
-      CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_PVRPLAYBACK_CONFIRMCHANNELSWITCH))
+      CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+          CSettings::SETTING_PVRPLAYBACK_CONFIRMCHANNELSWITCH))
     return ChannelSwitchMode::NO_SWITCH;
 
   return ChannelSwitchMode::INSTANT_OR_DELAYED_SWITCH;
@@ -159,11 +160,13 @@ bool CPVRGUIActionListener::OnAction(const CAction& action)
       if (!bIsPlayingPVR)
         return false;
 
-      if (CServiceBroker::GetGUI()->GetWindowManager().IsWindowActive(WINDOW_FULLSCREEN_VIDEO) || CServiceBroker::GetGUI()->GetWindowManager().IsWindowActive(WINDOW_VISUALISATION))
+      if (CServiceBroker::GetGUI()->GetWindowManager().IsWindowActive(WINDOW_FULLSCREEN_VIDEO) ||
+          CServiceBroker::GetGUI()->GetWindowManager().IsWindowActive(WINDOW_VISUALISATION))
       {
         // do not consume action if a python modal is the top most dialog
         // as a python modal can't return that it consumed the action.
-        if (CServiceBroker::GetGUI()->GetWindowManager().IsPythonWindow(CServiceBroker::GetGUI()->GetWindowManager().GetTopmostModalDialog()))
+        if (CServiceBroker::GetGUI()->GetWindowManager().IsPythonWindow(
+                CServiceBroker::GetGUI()->GetWindowManager().GetTopmostModalDialog()))
           return false;
 
         char cCharacter;
@@ -173,7 +176,8 @@ bool CPVRGUIActionListener::OnAction(const CAction& action)
         }
         else
         {
-          int iRemote = bIsJumpSMS ? action.GetID() - (ACTION_JUMP_SMS2 - REMOTE_2) : action.GetID();
+          int iRemote =
+              bIsJumpSMS ? action.GetID() - (ACTION_JUMP_SMS2 - REMOTE_2) : action.GetID();
           cCharacter = static_cast<char>(iRemote - REMOTE_0) + '0';
         }
         CServiceBroker::GetPVRManager()
@@ -317,15 +321,21 @@ void CPVRGUIActionListener::OnSettingChanged(const std::shared_ptr<const CSettin
   const std::string& settingId = setting->GetId();
   if (settingId == CSettings::SETTING_PVRPARENTAL_ENABLED)
   {
-    if (std::static_pointer_cast<const CSettingBool>(setting)->GetValue() && CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_PVRPARENTAL_PIN).empty())
+    if (std::static_pointer_cast<const CSettingBool>(setting)->GetValue() &&
+        CServiceBroker::GetSettingsComponent()
+            ->GetSettings()
+            ->GetString(CSettings::SETTING_PVRPARENTAL_PIN)
+            .empty())
     {
       std::string newPassword = "";
       // password set... save it
       if (CGUIDialogNumeric::ShowAndVerifyNewPassword(newPassword))
-        CServiceBroker::GetSettingsComponent()->GetSettings()->SetString(CSettings::SETTING_PVRPARENTAL_PIN, newPassword);
+        CServiceBroker::GetSettingsComponent()->GetSettings()->SetString(
+            CSettings::SETTING_PVRPARENTAL_PIN, newPassword);
       // password not set... disable parental
       else
-        std::static_pointer_cast<CSettingBool>(std::const_pointer_cast<CSetting>(setting))->SetValue(false);
+        std::static_pointer_cast<CSettingBool>(std::const_pointer_cast<CSetting>(setting))
+            ->SetValue(false);
     }
   }
   else if (settingId == CSettings::SETTING_EPG_PAST_DAYSTODISPLAY)
@@ -358,7 +368,8 @@ void CPVRGUIActionListener::OnSettingAction(const std::shared_ptr<const CSetting
   {
     if (CServiceBroker::GetPVRManager().IsStarted())
     {
-      CGUIDialog* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetDialog(WINDOW_DIALOG_PVR_CLIENT_PRIORITIES);
+      CGUIDialog* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetDialog(
+          WINDOW_DIALOG_PVR_CLIENT_PRIORITIES);
       if (dialog)
       {
         dialog->Open();
@@ -370,7 +381,8 @@ void CPVRGUIActionListener::OnSettingAction(const std::shared_ptr<const CSetting
   {
     if (CServiceBroker::GetPVRManager().IsStarted())
     {
-      CGUIDialog* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetDialog(WINDOW_DIALOG_PVR_CHANNEL_MANAGER);
+      CGUIDialog* dialog =
+          CServiceBroker::GetGUI()->GetWindowManager().GetDialog(WINDOW_DIALOG_PVR_CHANNEL_MANAGER);
       if (dialog)
         dialog->Open();
     }
@@ -379,7 +391,8 @@ void CPVRGUIActionListener::OnSettingAction(const std::shared_ptr<const CSetting
   {
     if (CServiceBroker::GetPVRManager().IsStarted())
     {
-      CGUIDialog* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetDialog(WINDOW_DIALOG_PVR_GROUP_MANAGER);
+      CGUIDialog* dialog =
+          CServiceBroker::GetGUI()->GetWindowManager().GetDialog(WINDOW_DIALOG_PVR_GROUP_MANAGER);
       if (dialog)
         dialog->Open();
     }

--- a/xbmc/pvr/guilib/PVRGUIActionListener.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionListener.cpp
@@ -290,7 +290,7 @@ bool CPVRGUIActionListener::OnAction(const CAction& action)
         return false;
 
       CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(
-          std::make_shared<CFileItem>(groupMember), false);
+          CFileItem(groupMember), false);
       return true;
     }
 

--- a/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
@@ -180,9 +180,9 @@ void CPVRGUIActionsChannels::Notify(const PVRChannelNumberInputChangedEvent& eve
   m_events.Publish(event);
 }
 
-bool CPVRGUIActionsChannels::HideChannel(const std::shared_ptr<CFileItem>& item) const
+bool CPVRGUIActionsChannels::HideChannel(const CFileItem& item) const
 {
-  const std::shared_ptr<CPVRChannel> channel(item->GetPVRChannelInfoTag());
+  const std::shared_ptr<CPVRChannel> channel = item.GetPVRChannelInfoTag();
 
   if (!channel)
     return false;
@@ -370,9 +370,9 @@ CPVRGUIChannelNavigator& CPVRGUIActionsChannels::GetChannelNavigator()
   return m_channelNavigator;
 }
 
-void CPVRGUIActionsChannels::OnPlaybackStarted(const CFileItemPtr& item)
+void CPVRGUIActionsChannels::OnPlaybackStarted(const CFileItem& item)
 {
-  const std::shared_ptr<CPVRChannelGroupMember> groupMember = GetChannelGroupMember(*item);
+  const std::shared_ptr<CPVRChannelGroupMember> groupMember = GetChannelGroupMember(item);
   if (groupMember)
   {
     m_channelNavigator.SetPlayingChannel(groupMember);
@@ -380,9 +380,9 @@ void CPVRGUIActionsChannels::OnPlaybackStarted(const CFileItemPtr& item)
   }
 }
 
-void CPVRGUIActionsChannels::OnPlaybackStopped(const CFileItemPtr& item)
+void CPVRGUIActionsChannels::OnPlaybackStopped(const CFileItem& item)
 {
-  if (item->HasPVRChannelInfoTag() || item->HasEPGInfoTag())
+  if (item.HasPVRChannelInfoTag() || item.HasEPGInfoTag())
   {
     m_channelNavigator.ClearPlayingChannel();
   }

--- a/xbmc/pvr/guilib/PVRGUIActionsChannels.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsChannels.h
@@ -81,7 +81,7 @@ public:
    * @param item containing a channel or an epg tag.
    * @return true on success, false otherwise.
    */
-  bool HideChannel(const std::shared_ptr<CFileItem>& item) const;
+  bool HideChannel(const CFileItem& item) const;
 
   /*!
    * @brief Open a selection dialog and start a channel scan on the selected client.
@@ -134,13 +134,13 @@ public:
    * @brief Inform GUI actions that playback of an item just started.
    * @param item The item that started to play.
    */
-  void OnPlaybackStarted(const std::shared_ptr<CFileItem>& item);
+  void OnPlaybackStarted(const CFileItem& item);
 
   /*!
    * @brief Inform GUI actions that playback of an item was stopped due to user interaction.
    * @param item The item that stopped to play.
    */
-  void OnPlaybackStopped(const std::shared_ptr<CFileItem>& item);
+  void OnPlaybackStopped(const CFileItem& item);
 
   /*!
    * @brief Get the currently selected channel item path; used across several windows/dialogs to

--- a/xbmc/pvr/guilib/PVRGUIActionsEPG.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsEPG.cpp
@@ -53,7 +53,7 @@ PVR::CGUIWindowPVRSearchBase* GetSearchWindow(bool bRadio)
 }
 } // unnamed namespace
 
-bool CPVRGUIActionsEPG::ShowEPGInfo(const CFileItemPtr& item) const
+bool CPVRGUIActionsEPG::ShowEPGInfo(const CFileItem& item) const
 {
   const std::shared_ptr<CPVRChannel> channel(CPVRItem(item).GetChannel());
   if (channel && CServiceBroker::GetPVRManager().Get<PVR::GUI::Parental>().CheckParentalLock(
@@ -81,7 +81,7 @@ bool CPVRGUIActionsEPG::ShowEPGInfo(const CFileItemPtr& item) const
   return true;
 }
 
-bool CPVRGUIActionsEPG::ShowChannelEPG(const CFileItemPtr& item) const
+bool CPVRGUIActionsEPG::ShowChannelEPG(const CFileItem& item) const
 {
   const std::shared_ptr<CPVRChannel> channel(CPVRItem(item).GetChannel());
   if (channel && CServiceBroker::GetPVRManager().Get<PVR::GUI::Parental>().CheckParentalLock(
@@ -101,7 +101,7 @@ bool CPVRGUIActionsEPG::ShowChannelEPG(const CFileItemPtr& item) const
   return true;
 }
 
-bool CPVRGUIActionsEPG::FindSimilar(const std::shared_ptr<CFileItem>& item) const
+bool CPVRGUIActionsEPG::FindSimilar(const CFileItem& item) const
 {
   CGUIWindowPVRSearchBase* windowSearch = GetSearchWindow(CPVRItem(item).IsRadio());
   if (!windowSearch)
@@ -136,9 +136,9 @@ bool CPVRGUIActionsEPG::FindSimilar(const std::shared_ptr<CFileItem>& item) cons
   return true;
 };
 
-bool CPVRGUIActionsEPG::ExecuteSavedSearch(const std::shared_ptr<CFileItem>& item)
+bool CPVRGUIActionsEPG::ExecuteSavedSearch(const CFileItem& item)
 {
-  const auto searchFilter = item->GetEPGSearchFilter();
+  const auto searchFilter = item.GetEPGSearchFilter();
 
   if (!searchFilter)
   {
@@ -155,9 +155,9 @@ bool CPVRGUIActionsEPG::ExecuteSavedSearch(const std::shared_ptr<CFileItem>& ite
   return true;
 }
 
-bool CPVRGUIActionsEPG::EditSavedSearch(const std::shared_ptr<CFileItem>& item)
+bool CPVRGUIActionsEPG::EditSavedSearch(const CFileItem& item)
 {
-  const auto searchFilter = item->GetEPGSearchFilter();
+  const auto searchFilter = item.GetEPGSearchFilter();
 
   if (!searchFilter)
   {
@@ -175,9 +175,9 @@ bool CPVRGUIActionsEPG::EditSavedSearch(const std::shared_ptr<CFileItem>& item)
   return true;
 }
 
-bool CPVRGUIActionsEPG::RenameSavedSearch(const std::shared_ptr<CFileItem>& item)
+bool CPVRGUIActionsEPG::RenameSavedSearch(const CFileItem& item)
 {
-  const auto searchFilter = item->GetEPGSearchFilter();
+  const auto searchFilter = item.GetEPGSearchFilter();
 
   if (!searchFilter)
   {
@@ -197,9 +197,9 @@ bool CPVRGUIActionsEPG::RenameSavedSearch(const std::shared_ptr<CFileItem>& item
   return false;
 }
 
-bool CPVRGUIActionsEPG::DeleteSavedSearch(const std::shared_ptr<CFileItem>& item)
+bool CPVRGUIActionsEPG::DeleteSavedSearch(const CFileItem& item)
 {
-  const auto searchFilter = item->GetEPGSearchFilter();
+  const auto searchFilter = item.GetEPGSearchFilter();
 
   if (!searchFilter)
   {
@@ -209,7 +209,7 @@ bool CPVRGUIActionsEPG::DeleteSavedSearch(const std::shared_ptr<CFileItem>& item
 
   if (CGUIDialogYesNo::ShowAndGetInput(CVariant{122}, // "Confirm delete"
                                        CVariant{19338}, // "Delete this saved search?"
-                                       CVariant{""}, CVariant{item->GetLabel()}))
+                                       CVariant{""}, CVariant{item.GetLabel()}))
   {
     return CServiceBroker::GetPVRManager().EpgContainer().DeleteSavedSearch(*searchFilter);
   }

--- a/xbmc/pvr/guilib/PVRGUIActionsEPG.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsEPG.h
@@ -10,8 +10,6 @@
 
 #include "pvr/IPVRComponent.h"
 
-#include <memory>
-
 class CFileItem;
 
 namespace PVR
@@ -27,14 +25,14 @@ public:
    * @param item containing epg data to show. item must be an epg tag, a channel or a timer.
    * @return true on success, false otherwise.
    */
-  bool ShowEPGInfo(const std::shared_ptr<CFileItem>& item) const;
+  bool ShowEPGInfo(const CFileItem& item) const;
 
   /*!
    * @brief Open a dialog with the epg list for a given item.
    * @param item containing channel info. item must be an epg tag, a channel or a timer.
    * @return true on success, false otherwise.
    */
-  bool ShowChannelEPG(const std::shared_ptr<CFileItem>& item) const;
+  bool ShowChannelEPG(const CFileItem& item) const;
 
   /*!
    * @brief Open a window containing a list of epg tags 'similar' to a given item.
@@ -42,35 +40,35 @@ public:
    * recording.
    * @return true on success, false otherwise.
    */
-  bool FindSimilar(const std::shared_ptr<CFileItem>& item) const;
+  bool FindSimilar(const CFileItem& item) const;
 
   /*!
    * @brief Execute a saved search. Displays result in search window if it is open.
    * @param item The item containing a search filter.
    * @return True on success, false otherwise.
    */
-  bool ExecuteSavedSearch(const std::shared_ptr<CFileItem>& item);
+  bool ExecuteSavedSearch(const CFileItem& item);
 
   /*!
    * @brief Edit a saved search. Opens the search dialog.
    * @param item The item containing a search filter.
    * @return True on success, false otherwise.
    */
-  bool EditSavedSearch(const std::shared_ptr<CFileItem>& item);
+  bool EditSavedSearch(const CFileItem& item);
 
   /*!
    * @brief Rename a saved search. Opens a title input dialog.
    * @param item The item containing a search filter.
    * @return True on success, false otherwise.
    */
-  bool RenameSavedSearch(const std::shared_ptr<CFileItem>& item);
+  bool RenameSavedSearch(const CFileItem& item);
 
   /*!
    * @brief Delete a saved search. Opens confirmation dialog before deleting.
    * @param item The item containing a search filter.
    * @return True on success, false otherwise.
    */
-  bool DeleteSavedSearch(const std::shared_ptr<CFileItem>& item);
+  bool DeleteSavedSearch(const CFileItem& item);
 
 private:
   CPVRGUIActionsEPG(const CPVRGUIActionsEPG&) = delete;

--- a/xbmc/pvr/guilib/PVRGUIActionsPlayback.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsPlayback.h
@@ -11,7 +11,6 @@
 #include "pvr/IPVRComponent.h"
 #include "pvr/settings/PVRSettings.h"
 
-#include <memory>
 #include <string>
 
 class CFileItem;
@@ -48,7 +47,7 @@ public:
    * beginning ig no resume data are available.
    * @return true on success, false otherwise.
    */
-  bool ResumePlayRecording(const std::shared_ptr<CFileItem>& item, bool bFallbackToPlay) const;
+  bool ResumePlayRecording(const CFileItem& item, bool bFallbackToPlay) const;
 
   /*!
    * @brief Play recording.
@@ -56,14 +55,14 @@ public:
    * @param bCheckResume controls resume check.
    * @return true on success, false otherwise.
    */
-  bool PlayRecording(const std::shared_ptr<CFileItem>& item, bool bCheckResume) const;
+  bool PlayRecording(const CFileItem& item, bool bCheckResume) const;
 
   /*!
    * @brief Play EPG tag.
    * @param item containing an epg tag.
    * @return true on success, false otherwise.
    */
-  bool PlayEpgTag(const std::shared_ptr<CFileItem>& item) const;
+  bool PlayEpgTag(const CFileItem& item) const;
 
   /*!
    * @brief Switch channel.
@@ -72,14 +71,14 @@ public:
    * present.
    * @return true on success, false otherwise.
    */
-  bool SwitchToChannel(const std::shared_ptr<CFileItem>& item, bool bCheckResume) const;
+  bool SwitchToChannel(const CFileItem& item, bool bCheckResume) const;
 
   /*!
    * @brief Playback the given file item.
    * @param item containing a channel or a recording.
    * @return True if the item could be played, false otherwise.
    */
-  bool PlayMedia(const std::shared_ptr<CFileItem>& item) const;
+  bool PlayMedia(const CFileItem& item) const;
 
   /*!
    * @brief Start playback of the last played channel, and if there is none, play first channel in
@@ -121,7 +120,7 @@ private:
    * @param item containing a recording or an epg tag.
    * @return true, to play/resume the item, false otherwise.
    */
-  bool CheckResumeRecording(const std::shared_ptr<CFileItem>& item) const;
+  bool CheckResumeRecording(const CFileItem& item) const;
 
   /*!
    * @brief Check "play minimized" settings value and switch to fullscreen if not set.

--- a/xbmc/pvr/guilib/PVRGUIActionsPowerManagement.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsPowerManagement.cpp
@@ -135,7 +135,7 @@ bool CPVRGUIActionsPowerManagement::AllLocalBackendsIdle(
       CServiceBroker::GetPVRManager().Timers()->GetActiveRecordings();
   for (const auto& timer : activeRecordings)
   {
-    if (EventOccursOnLocalBackend(std::make_shared<CFileItem>(timer)))
+    if (EventOccursOnLocalBackend(timer))
     {
       causingEvent = timer;
       return false;
@@ -154,7 +154,7 @@ bool CPVRGUIActionsPowerManagement::AllLocalBackendsIdle(
       return false;
     }
 
-    if (EventOccursOnLocalBackend(std::make_shared<CFileItem>(timer)))
+    if (EventOccursOnLocalBackend(timer))
     {
       causingEvent = timer;
       return false;
@@ -164,17 +164,15 @@ bool CPVRGUIActionsPowerManagement::AllLocalBackendsIdle(
 }
 
 bool CPVRGUIActionsPowerManagement::EventOccursOnLocalBackend(
-    const std::shared_ptr<CFileItem>& item) const
+    const std::shared_ptr<CPVRTimerInfoTag>& event) const
 {
-  if (item && item->HasPVRTimerInfoTag())
+  const std::shared_ptr<CPVRClient> client =
+      CServiceBroker::GetPVRManager().GetClient(CFileItem(event));
+  if (client)
   {
-    const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(*item);
-    if (client)
-    {
-      const std::string hostname = client->GetBackendHostname();
-      if (!hostname.empty() && CServiceBroker::GetNetwork().IsLocalHost(hostname))
-        return true;
-    }
+    const std::string hostname = client->GetBackendHostname();
+    if (!hostname.empty() && CServiceBroker::GetNetwork().IsLocalHost(hostname))
+      return true;
   }
   return false;
 }

--- a/xbmc/pvr/guilib/PVRGUIActionsPowerManagement.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsPowerManagement.h
@@ -40,7 +40,7 @@ private:
   CPVRGUIActionsPowerManagement const& operator=(CPVRGUIActionsPowerManagement const&) = delete;
 
   bool AllLocalBackendsIdle(std::shared_ptr<CPVRTimerInfoTag>& causingEvent) const;
-  bool EventOccursOnLocalBackend(const std::shared_ptr<CFileItem>& item) const;
+  bool EventOccursOnLocalBackend(const std::shared_ptr<CPVRTimerInfoTag>& event) const;
   bool IsNextEventWithinBackendIdleTime() const;
 
   CPVRSettings m_settings;

--- a/xbmc/pvr/guilib/PVRGUIActionsRecordings.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsRecordings.h
@@ -29,14 +29,14 @@ public:
    * @param item containing a recording.
    * @return true on success, false otherwise.
    */
-  bool ShowRecordingInfo(const std::shared_ptr<CFileItem>& item) const;
+  bool ShowRecordingInfo(const CFileItem& item) const;
 
   /*!
    * @brief Open the recording settings dialog to edit a recording.
    * @param item containing the recording to edit.
    * @return true on success, false otherwise.
    */
-  bool EditRecording(const std::shared_ptr<CFileItem>& item) const;
+  bool EditRecording(const CFileItem& item) const;
 
   /*!
    * @brief Check if any recording settings can be edited.
@@ -50,7 +50,7 @@ public:
    * @param item containing a recording to delete.
    * @return true, if the recording was deleted successfully, false otherwise.
    */
-  bool DeleteRecording(const std::shared_ptr<CFileItem>& item) const;
+  bool DeleteRecording(const CFileItem& item) const;
 
   /*!
    * @brief Delete all watched recordings contained in the given folder, always showing a
@@ -58,7 +58,7 @@ public:
    * @param item containing a recording folder containing the items to delete.
    * @return true, if the recordings were deleted successfully, false otherwise.
    */
-  bool DeleteWatchedRecordings(const std::shared_ptr<CFileItem>& item) const;
+  bool DeleteWatchedRecordings(const CFileItem& item) const;
 
   /*!
    * @brief Delete all recordings from trash, always showing a confirmation dialog.
@@ -71,7 +71,7 @@ public:
    * @param item containing a recording to undelete.
    * @return true, if the recording was undeleted successfully, false otherwise.
    */
-  bool UndeleteRecording(const std::shared_ptr<CFileItem>& item) const;
+  bool UndeleteRecording(const CFileItem& item) const;
 
 private:
   CPVRGUIActionsRecordings(const CPVRGUIActionsRecordings&) = delete;
@@ -82,14 +82,14 @@ private:
    * @param item the recording to delete.
    * @return true, to proceed with delete, false otherwise.
    */
-  bool ConfirmDeleteRecording(const std::shared_ptr<CFileItem>& item) const;
+  bool ConfirmDeleteRecording(const CFileItem& item) const;
 
   /*!
    * @brief Open a dialog to confirm delete all watched recordings contained in the given folder.
    * @param item containing a recording folder containing the items to delete.
    * @return true, to proceed with delete, false otherwise.
    */
-  bool ConfirmDeleteWatchedRecordings(const std::shared_ptr<CFileItem>& item) const;
+  bool ConfirmDeleteWatchedRecordings(const CFileItem& item) const;
 
   /*!
    * @brief Open a dialog to confirm to permanently remove all deleted recordings.

--- a/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
@@ -76,7 +76,7 @@ bool CPVRGUIActionsTimers::ShowTimerSettings(const std::shared_ptr<CPVRTimerInfo
   return pDlgInfo->IsConfirmed();
 }
 
-bool CPVRGUIActionsTimers::AddReminder(const std::shared_ptr<CFileItem>& item) const
+bool CPVRGUIActionsTimers::AddReminder(const CFileItem& item) const
 {
   const std::shared_ptr<CPVREpgInfoTag> epgTag = CPVRItem(item).GetEpgInfoTag();
   if (!epgTag)
@@ -114,19 +114,19 @@ bool CPVRGUIActionsTimers::AddTimer(bool bRadio) const
   return false;
 }
 
-bool CPVRGUIActionsTimers::AddTimer(const CFileItemPtr& item, bool bShowTimerSettings) const
+bool CPVRGUIActionsTimers::AddTimer(const CFileItem& item, bool bShowTimerSettings) const
 {
   return AddTimer(item, false, bShowTimerSettings, false);
 }
 
-bool CPVRGUIActionsTimers::AddTimerRule(const std::shared_ptr<CFileItem>& item,
+bool CPVRGUIActionsTimers::AddTimerRule(const CFileItem& item,
                                         bool bShowTimerSettings,
                                         bool bFallbackToOneShotTimer) const
 {
   return AddTimer(item, true, bShowTimerSettings, bFallbackToOneShotTimer);
 }
 
-bool CPVRGUIActionsTimers::AddTimer(const std::shared_ptr<CFileItem>& item,
+bool CPVRGUIActionsTimers::AddTimer(const CFileItem& item,
                                     bool bCreateRule,
                                     bool bShowTimerSettings,
                                     bool bFallbackToOneShotTimer) const
@@ -529,9 +529,9 @@ bool CPVRGUIActionsTimers::SetRecordingOnChannel(const std::shared_ptr<CPVRChann
   return bReturn;
 }
 
-bool CPVRGUIActionsTimers::ToggleTimer(const CFileItemPtr& item) const
+bool CPVRGUIActionsTimers::ToggleTimer(const CFileItem& item) const
 {
-  if (!item->HasEPGInfoTag())
+  if (!item.HasEPGInfoTag())
     return false;
 
   const std::shared_ptr<CPVRTimerInfoTag> timer(CPVRItem(item).GetTimerInfoTag());
@@ -546,12 +546,12 @@ bool CPVRGUIActionsTimers::ToggleTimer(const CFileItemPtr& item) const
     return AddTimer(item, false);
 }
 
-bool CPVRGUIActionsTimers::ToggleTimerState(const CFileItemPtr& item) const
+bool CPVRGUIActionsTimers::ToggleTimerState(const CFileItem& item) const
 {
-  if (!item->HasPVRTimerInfoTag())
+  if (!item.HasPVRTimerInfoTag())
     return false;
 
-  const std::shared_ptr<CPVRTimerInfoTag> timer(item->GetPVRTimerInfoTag());
+  const std::shared_ptr<CPVRTimerInfoTag> timer = item.GetPVRTimerInfoTag();
   if (timer->IsDisabled())
     timer->SetState(PVR_TIMER_STATE_SCHEDULED);
   else
@@ -567,7 +567,7 @@ bool CPVRGUIActionsTimers::ToggleTimerState(const CFileItemPtr& item) const
   return false;
 }
 
-bool CPVRGUIActionsTimers::EditTimer(const CFileItemPtr& item) const
+bool CPVRGUIActionsTimers::EditTimer(const CFileItem& item) const
 {
   const std::shared_ptr<CPVRTimerInfoTag> timer(CPVRItem(item).GetTimerInfoTag());
   if (!timer)
@@ -613,23 +613,22 @@ bool CPVRGUIActionsTimers::EditTimer(const CFileItemPtr& item) const
   return false;
 }
 
-bool CPVRGUIActionsTimers::EditTimerRule(const CFileItemPtr& item) const
+bool CPVRGUIActionsTimers::EditTimerRule(const CFileItem& item) const
 {
   const std::shared_ptr<CFileItem> parentTimer = GetTimerRule(item);
   if (parentTimer)
-    return EditTimer(parentTimer);
+    return EditTimer(*parentTimer);
 
   return false;
 }
 
-std::shared_ptr<CFileItem> CPVRGUIActionsTimers::GetTimerRule(
-    const std::shared_ptr<CFileItem>& item) const
+std::shared_ptr<CFileItem> CPVRGUIActionsTimers::GetTimerRule(const CFileItem& item) const
 {
   std::shared_ptr<CPVRTimerInfoTag> timer;
-  if (item && item->HasEPGInfoTag())
-    timer = CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(item->GetEPGInfoTag());
-  else if (item && item->HasPVRTimerInfoTag())
-    timer = item->GetPVRTimerInfoTag();
+  if (item.HasEPGInfoTag())
+    timer = CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(item.GetEPGInfoTag());
+  else if (item.HasPVRTimerInfoTag())
+    timer = item.GetPVRTimerInfoTag();
 
   if (timer)
   {
@@ -640,17 +639,17 @@ std::shared_ptr<CFileItem> CPVRGUIActionsTimers::GetTimerRule(
   return {};
 }
 
-bool CPVRGUIActionsTimers::DeleteTimer(const CFileItemPtr& item) const
+bool CPVRGUIActionsTimers::DeleteTimer(const CFileItem& item) const
 {
   return DeleteTimer(item, false, false);
 }
 
-bool CPVRGUIActionsTimers::DeleteTimerRule(const CFileItemPtr& item) const
+bool CPVRGUIActionsTimers::DeleteTimerRule(const CFileItem& item) const
 {
   return DeleteTimer(item, false, true);
 }
 
-bool CPVRGUIActionsTimers::DeleteTimer(const CFileItemPtr& item,
+bool CPVRGUIActionsTimers::DeleteTimer(const CFileItem& item,
                                        bool bIsRecording,
                                        bool bDeleteRule) const
 {
@@ -783,7 +782,7 @@ bool CPVRGUIActionsTimers::ConfirmDeleteTimer(const std::shared_ptr<CPVRTimerInf
   return bConfirmed;
 }
 
-bool CPVRGUIActionsTimers::StopRecording(const CFileItemPtr& item) const
+bool CPVRGUIActionsTimers::StopRecording(const CFileItem& item) const
 {
   if (!DeleteTimer(item, true, false))
     return false;
@@ -963,7 +962,7 @@ void CPVRGUIActionsTimers::AnnounceReminder(const std::shared_ptr<CPVRTimerInfoT
     if (newTimer)
     {
       // schedule recording
-      AddTimer(std::make_shared<CFileItem>(newTimer), false);
+      AddTimer(CFileItem(newTimer), false);
     }
 
     if (bAutoClosed)

--- a/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
@@ -981,7 +981,7 @@ void CPVRGUIActionsTimers::AnnounceReminder(const std::shared_ptr<CPVRTimerInfoT
     if (groupMember)
     {
       CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(
-          std::make_shared<CFileItem>(groupMember), false);
+          CFileItem(groupMember), false);
 
       if (bAutoClosed)
       {

--- a/xbmc/pvr/guilib/PVRGUIActionsTimers.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsTimers.h
@@ -40,7 +40,7 @@ public:
    * creating the timer.
    * @return true, if the timer was created successfully, false otherwise.
    */
-  bool AddTimer(const std::shared_ptr<CFileItem>& item, bool bShowTimerSettings) const;
+  bool AddTimer(const CFileItem& item, bool bShowTimerSettings) const;
 
   /*!
    * @brief Add a timer to the client. Doesn't add the timer to the container. The backend will
@@ -59,7 +59,7 @@ public:
    * timer instead.
    * @return true, if the timer rule was created successfully, false otherwise.
    */
-  bool AddTimerRule(const std::shared_ptr<CFileItem>& item,
+  bool AddTimerRule(const CFileItem& item,
                     bool bShowTimerSettings,
                     bool bFallbackToOneShotTimer) const;
 
@@ -68,49 +68,49 @@ public:
    * @param item containing an epg tag.
    * @return true on success, false otherwise.
    */
-  bool ToggleTimer(const std::shared_ptr<CFileItem>& item) const;
+  bool ToggleTimer(const CFileItem& item) const;
 
   /*!
    * @brief Toggles a given timer's enabled/disabled state.
    * @param item containing a timer.
    * @return true on success, false otherwise.
    */
-  bool ToggleTimerState(const std::shared_ptr<CFileItem>& item) const;
+  bool ToggleTimerState(const CFileItem& item) const;
 
   /*!
    * @brief Open the timer settings dialog to edit an existing timer.
    * @param item containing an epg tag or a timer.
    * @return true on success, false otherwise.
    */
-  bool EditTimer(const std::shared_ptr<CFileItem>& item) const;
+  bool EditTimer(const CFileItem& item) const;
 
   /*!
    * @brief Open the timer settings dialog to edit an existing timer rule.
    * @param item containing an epg tag or a timer.
    * @return true on success, false otherwise.
    */
-  bool EditTimerRule(const std::shared_ptr<CFileItem>& item) const;
+  bool EditTimerRule(const CFileItem& item) const;
 
   /*!
    * @brief Get the timer rule for a given timer
    * @param item containing an item to query the timer rule for. item must be a timer or an epg tag.
    * @return The timer rule item, or nullptr if none was found.
    */
-  std::shared_ptr<CFileItem> GetTimerRule(const std::shared_ptr<CFileItem>& item) const;
+  std::shared_ptr<CFileItem> GetTimerRule(const CFileItem& item) const;
 
   /*!
    * @brief Delete a timer, always showing a confirmation dialog.
    * @param item containing a timer to delete. item must be a timer, an epg tag or a channel.
    * @return true, if the timer was deleted successfully, false otherwise.
    */
-  bool DeleteTimer(const std::shared_ptr<CFileItem>& item) const;
+  bool DeleteTimer(const CFileItem& item) const;
 
   /*!
    * @brief Delete a timer rule, always showing a confirmation dialog.
    * @param item containing a timer rule to delete. item must be a timer, an epg tag or a channel.
    * @return true, if the timer rule was deleted successfully, false otherwise.
    */
-  bool DeleteTimerRule(const std::shared_ptr<CFileItem>& item) const;
+  bool DeleteTimerRule(const CFileItem& item) const;
 
   /*!
    * @brief Toggle recording on the currently playing channel, if any.
@@ -131,14 +131,14 @@ public:
    * @param item containing a recording to stop. item must be a timer, an epg tag or a channel.
    * @return true, if the recording was stopped successfully, false otherwise.
    */
-  bool StopRecording(const std::shared_ptr<CFileItem>& item) const;
+  bool StopRecording(const CFileItem& item) const;
 
   /*!
    * @brief Create a new reminder timer, non-interactive.
    * @param item containing epg data to create a reminder timer for. item must be an epg tag.
    * @return true, if the timer was created successfully, false otherwise.
    */
-  bool AddReminder(const std::shared_ptr<CFileItem>& item) const;
+  bool AddReminder(const CFileItem& item) const;
 
   /*!
    * @brief Announce due reminders, if any.
@@ -167,7 +167,7 @@ private:
    * to create a one-shot timer instead.
    * @return true, if the timer or timer rule was created successfully, false otherwise.
    */
-  bool AddTimer(const std::shared_ptr<CFileItem>& item,
+  bool AddTimer(const CFileItem& item,
                 bool bCreateRule,
                 bool bShowTimerSettings,
                 bool bFallbackToOneShotTimer) const;
@@ -182,9 +182,7 @@ private:
    * created by a rule.
    * @return true, if the timer or timer rule was deleted successfully, false otherwise.
   */
-  bool DeleteTimer(const std::shared_ptr<CFileItem>& item,
-                   bool bIsRecording,
-                   bool bDeleteRule) const;
+  bool DeleteTimer(const CFileItem& item, bool bIsRecording, bool bDeleteRule) const;
 
   /*!
    * @brief Delete a timer or timer rule, showing a confirmation dialog in case a timer currently

--- a/xbmc/pvr/guilib/PVRGUIActionsUtils.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsUtils.cpp
@@ -24,11 +24,11 @@ bool CPVRGUIActionsUtils::OnInfo(const std::shared_ptr<CFileItem>& item)
   }
   else if (item->HasPVRChannelInfoTag() || item->HasPVRTimerInfoTag())
   {
-    return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowEPGInfo(item);
+    return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowEPGInfo(*item);
   }
   else if (item->HasEPGSearchFilter())
   {
-    return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().EditSavedSearch(item);
+    return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().EditSavedSearch(*item);
   }
   return false;
 }

--- a/xbmc/pvr/guilib/PVRGUIActionsUtils.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsUtils.cpp
@@ -16,19 +16,19 @@
 
 namespace PVR
 {
-bool CPVRGUIActionsUtils::OnInfo(const std::shared_ptr<CFileItem>& item)
+bool CPVRGUIActionsUtils::OnInfo(const CFileItem& item)
 {
-  if (item->HasPVRRecordingInfoTag())
+  if (item.HasPVRRecordingInfoTag())
   {
-    return CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().ShowRecordingInfo(*item);
+    return CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().ShowRecordingInfo(item);
   }
-  else if (item->HasPVRChannelInfoTag() || item->HasPVRTimerInfoTag())
+  else if (item.HasPVRChannelInfoTag() || item.HasPVRTimerInfoTag())
   {
-    return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowEPGInfo(*item);
+    return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowEPGInfo(item);
   }
-  else if (item->HasEPGSearchFilter())
+  else if (item.HasEPGSearchFilter())
   {
-    return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().EditSavedSearch(*item);
+    return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().EditSavedSearch(item);
   }
   return false;
 }

--- a/xbmc/pvr/guilib/PVRGUIActionsUtils.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsUtils.cpp
@@ -20,7 +20,7 @@ bool CPVRGUIActionsUtils::OnInfo(const std::shared_ptr<CFileItem>& item)
 {
   if (item->HasPVRRecordingInfoTag())
   {
-    return CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().ShowRecordingInfo(item);
+    return CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().ShowRecordingInfo(*item);
   }
   else if (item->HasPVRChannelInfoTag() || item->HasPVRTimerInfoTag())
   {

--- a/xbmc/pvr/guilib/PVRGUIActionsUtils.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsUtils.h
@@ -10,8 +10,6 @@
 
 #include "pvr/IPVRComponent.h"
 
-#include <memory>
-
 class CFileItem;
 
 namespace PVR
@@ -26,7 +24,7 @@ public:
      * @brief Process info action for the given item.
      * @param item The item.
      */
-  bool OnInfo(const std::shared_ptr<CFileItem>& item);
+  bool OnInfo(const CFileItem& item);
 
 private:
   CPVRGUIActionsUtils(const CPVRGUIActionsUtils&) = delete;

--- a/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
+++ b/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
@@ -232,7 +232,7 @@ void CPVRGUIChannelNavigator::SelectChannel(
 
 void CPVRGUIChannelNavigator::SwitchToCurrentChannel()
 {
-  CFileItemPtr item;
+  std::unique_ptr<CFileItem> item;
 
   {
     std::unique_lock<CCriticalSection> lock(m_critSection);
@@ -243,11 +243,11 @@ void CPVRGUIChannelNavigator::SwitchToCurrentChannel()
       m_iChannelEntryJobId = -1;
     }
 
-    item.reset(new CFileItem(m_currentChannel));
+    item = std::make_unique<CFileItem>(m_currentChannel);
   }
 
   if (item)
-    CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(item, false);
+    CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(*item, false);
 }
 
 bool CPVRGUIChannelNavigator::IsPreview() const

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -201,7 +201,7 @@ bool CGUIWindowPVRChannelsBase::OnMessage(CGUIMessage& message)
               break;
             case ACTION_DELETE_ITEM:
               CServiceBroker::GetPVRManager().Get<PVR::GUI::Channels>().HideChannel(
-                  m_vecItems->Get(iItem));
+                  *(m_vecItems->Get(iItem)));
               break;
             case ACTION_CONTEXT_MENU:
             case ACTION_MOUSE_RIGHT_CLICK:

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -197,7 +197,7 @@ bool CGUIWindowPVRChannelsBase::OnMessage(CGUIMessage& message)
               break;
             case ACTION_SHOW_INFO:
               CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowEPGInfo(
-                  m_vecItems->Get(iItem));
+                  *(m_vecItems->Get(iItem)));
               break;
             case ACTION_DELETE_ITEM:
               CServiceBroker::GetPVRManager().Get<PVR::GUI::Channels>().HideChannel(

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -193,7 +193,7 @@ bool CGUIWindowPVRChannelsBase::OnMessage(CGUIMessage& message)
             case ACTION_MOUSE_LEFT_CLICK:
             case ACTION_PLAYER_PLAY:
               CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(
-                  m_vecItems->Get(iItem), true);
+                  *(m_vecItems->Get(iItem)), true);
               break;
             case ACTION_SHOW_INFO:
               CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowEPGInfo(

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -458,7 +458,7 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
                   bReturn = true;
                   break;
                 case EPG_SELECT_ACTION_RECORD:
-                  CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().ToggleTimer(pItem);
+                  CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().ToggleTimer(*pItem);
                   bReturn = true;
                   break;
                 case EPG_SELECT_ACTION_SMART_SELECT:
@@ -480,7 +480,7 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
                     {
                       // future event
                       if (CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(tag))
-                        CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().EditTimer(pItem);
+                        CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().EditTimer(*pItem);
                       else
                       {
                         bool bCanRecord = true;
@@ -500,7 +500,7 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
                                                          CVariant{iTextID}, CVariant{iNoButtonID},
                                                          CVariant{19165}); // Yes => "Switch"
                         if (ret == HELPERS::DialogResponse::CHOICE_NO)
-                          CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().AddTimer(pItem,
+                          CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().AddTimer(*pItem,
                                                                                            false);
                         else if (ret == HELPERS::DialogResponse::CHOICE_YES)
                           CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(
@@ -535,11 +535,11 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
               bReturn = true;
               break;
             case ACTION_RECORD:
-              CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().ToggleTimer(pItem);
+              CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().ToggleTimer(*pItem);
               bReturn = true;
               break;
             case ACTION_PVR_SHOW_TIMER_RULE:
-              CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().AddTimerRule(pItem, true,
+              CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().AddTimerRule(*pItem, true,
                                                                                    false);
               bReturn = true;
               break;

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -444,12 +444,12 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
                   bReturn = true;
                   break;
                 case EPG_SELECT_ACTION_SWITCH:
-                  CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(pItem,
+                  CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(*pItem,
                                                                                             true);
                   bReturn = true;
                   break;
                 case EPG_SELECT_ACTION_PLAY_RECORDING:
-                  CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayRecording(pItem,
+                  CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayRecording(*pItem,
                                                                                           true);
                   bReturn = true;
                   break;
@@ -474,7 +474,7 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
                     {
                       // current event
                       CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(
-                          pItem, true);
+                          *pItem, true);
                     }
                     else if (now < start)
                     {
@@ -504,7 +504,7 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
                                                                                            false);
                         else if (ret == HELPERS::DialogResponse::CHOICE_YES)
                           CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(
-                              pItem, true);
+                              *pItem, true);
                       }
                     }
                     else
@@ -512,9 +512,10 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
                       // past event
                       if (CServiceBroker::GetPVRManager().Recordings()->GetRecordingForEpgTag(tag))
                         CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayRecording(
-                            pItem, true);
+                            *pItem, true);
                       else if (tag->IsPlayable())
-                        CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayEpgTag(pItem);
+                        CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayEpgTag(
+                            *pItem);
                       else
                         CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowEPGInfo(*pItem);
                     }
@@ -529,7 +530,7 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
               bReturn = true;
               break;
             case ACTION_PLAYER_PLAY:
-              CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(pItem,
+              CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(*pItem,
                                                                                         true);
               bReturn = true;
               break;

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -454,7 +454,7 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
                   bReturn = true;
                   break;
                 case EPG_SELECT_ACTION_INFO:
-                  CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowEPGInfo(pItem);
+                  CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowEPGInfo(*pItem);
                   bReturn = true;
                   break;
                 case EPG_SELECT_ACTION_RECORD:
@@ -516,7 +516,7 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
                       else if (tag->IsPlayable())
                         CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayEpgTag(pItem);
                       else
-                        CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowEPGInfo(pItem);
+                        CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowEPGInfo(*pItem);
                     }
                     bReturn = true;
                   }
@@ -525,7 +525,7 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
               }
               break;
             case ACTION_SHOW_INFO:
-              CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowEPGInfo(pItem);
+              CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowEPGInfo(*pItem);
               bReturn = true;
               break;
             case ACTION_PLAYER_PLAY:

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -237,7 +237,7 @@ bool CGUIWindowPVRRecordingsBase::OnMessage(CGUIMessage& message)
               if (message.GetParam1() == ACTION_PLAYER_PLAY)
               {
                 CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayRecording(
-                    item, true /* check resume */);
+                    *item, true /* check resume */);
                 bReturn = true;
               }
               else
@@ -250,12 +250,12 @@ bool CGUIWindowPVRRecordingsBase::OnMessage(CGUIMessage& message)
                     break;
                   case SELECT_ACTION_PLAY_OR_RESUME:
                     CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayRecording(
-                        item, true /* check resume */);
+                        *item, true /* check resume */);
                     bReturn = true;
                     break;
                   case SELECT_ACTION_RESUME:
                     CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().ResumePlayRecording(
-                        item, true /* fall back to play if no resume possible */);
+                        *item, true /* fall back to play if no resume possible */);
                     bReturn = true;
                     break;
                   case SELECT_ACTION_INFO:

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -260,7 +260,7 @@ bool CGUIWindowPVRRecordingsBase::OnMessage(CGUIMessage& message)
                     break;
                   case SELECT_ACTION_INFO:
                     CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().ShowRecordingInfo(
-                        item);
+                        *item);
                     bReturn = true;
                     break;
                   default:
@@ -276,11 +276,11 @@ bool CGUIWindowPVRRecordingsBase::OnMessage(CGUIMessage& message)
               bReturn = true;
               break;
             case ACTION_SHOW_INFO:
-              CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().ShowRecordingInfo(item);
+              CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().ShowRecordingInfo(*item);
               bReturn = true;
               break;
             case ACTION_DELETE_ITEM:
-              CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().DeleteRecording(item);
+              CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().DeleteRecording(*item);
               bReturn = true;
               break;
             default:

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -55,7 +55,8 @@ void CGUIWindowPVRRecordingsBase::OnWindowLoaded()
 std::string CGUIWindowPVRRecordingsBase::GetDirectoryPath()
 {
   const std::string basePath = CPVRRecordingsPath(m_bShowDeletedRecordings, m_bRadio);
-  return URIUtils::PathHasParent(m_vecItems->GetPath(), basePath) ? m_vecItems->GetPath() : basePath;
+  return URIUtils::PathHasParent(m_vecItems->GetPath(), basePath) ? m_vecItems->GetPath()
+                                                                  : basePath;
 }
 
 void CGUIWindowPVRRecordingsBase::GetContextButtons(int itemNumber, CContextButtons& buttons)
@@ -90,8 +91,7 @@ void CGUIWindowPVRRecordingsBase::GetContextButtons(int itemNumber, CContextButt
 
 bool CGUIWindowPVRRecordingsBase::OnAction(const CAction& action)
 {
-  if (action.GetID() == ACTION_PARENT_DIR ||
-      action.GetID() == ACTION_NAV_BACK)
+  if (action.GetID() == ACTION_PARENT_DIR || action.GetID() == ACTION_NAV_BACK)
   {
     CPVRRecordingsPath path(m_vecItems->GetPath());
     if (path.IsValid() && !path.IsRecordingsRoot())
@@ -128,10 +128,11 @@ bool CGUIWindowPVRRecordingsBase::OnContextButton(int itemNumber, CONTEXT_BUTTON
   CFileItemPtr pItem = m_vecItems->Get(itemNumber);
 
   return OnContextButtonDeleteAll(pItem.get(), button) ||
-      CGUIMediaWindow::OnContextButton(itemNumber, button);
+         CGUIMediaWindow::OnContextButton(itemNumber, button);
 }
 
-bool CGUIWindowPVRRecordingsBase::Update(const std::string& strDirectory, bool updateFilterPath /* = true */)
+bool CGUIWindowPVRRecordingsBase::Update(const std::string& strDirectory,
+                                         bool updateFilterPath /* = true */)
 {
   m_thumbLoader.StopThread();
 
@@ -159,7 +160,8 @@ bool CGUIWindowPVRRecordingsBase::Update(const std::string& strDirectory, bool u
     }
   }
 
-  if (bReturn && iOldCount > 0 && m_vecItems->GetObjectCount() == 0 && oldPath == m_vecItems->GetPath())
+  if (bReturn && iOldCount > 0 && m_vecItems->GetObjectCount() == 0 &&
+      oldPath == m_vecItems->GetPath())
   {
     /* go to the parent folder if we're in a subdirectory and for instance just deleted the last item */
     const CPVRRecordingsPath path(m_vecItems->GetPath());
@@ -186,18 +188,24 @@ void CGUIWindowPVRRecordingsBase::UpdateButtons()
   bool bGroupRecordings = m_settings.GetBoolValue(CSettings::SETTING_PVRRECORD_GROUPRECORDINGS);
   SET_CONTROL_SELECTED(GetID(), CONTROL_BTNGROUPITEMS, bGroupRecordings);
 
-  CGUIRadioButtonControl* btnShowDeleted = static_cast<CGUIRadioButtonControl*>(GetControl(CONTROL_BTNSHOWDELETED));
+  CGUIRadioButtonControl* btnShowDeleted =
+      static_cast<CGUIRadioButtonControl*>(GetControl(CONTROL_BTNSHOWDELETED));
   if (btnShowDeleted)
   {
-    btnShowDeleted->SetVisible(m_bRadio ? CServiceBroker::GetPVRManager().Recordings()->HasDeletedRadioRecordings() : CServiceBroker::GetPVRManager().Recordings()->HasDeletedTVRecordings());
+    btnShowDeleted->SetVisible(
+        m_bRadio ? CServiceBroker::GetPVRManager().Recordings()->HasDeletedRadioRecordings()
+                 : CServiceBroker::GetPVRManager().Recordings()->HasDeletedTVRecordings());
     btnShowDeleted->SetSelected(m_bShowDeletedRecordings);
   }
 
   CGUIWindowPVRBase::UpdateButtons();
-  SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, m_bShowDeletedRecordings ? g_localizeStrings.Get(19179) : ""); /* Deleted recordings trash */
+  SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, m_bShowDeletedRecordings
+                                               ? g_localizeStrings.Get(19179)
+                                               : ""); /* Deleted recordings trash */
 
   const CPVRRecordingsPath path(m_vecItems->GetPath());
-  SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, bGroupRecordings && path.IsValid() ? path.GetUnescapedDirectoryPath() : "");
+  SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2,
+                    bGroupRecordings && path.IsValid() ? path.GetUnescapedDirectoryPath() : "");
 }
 
 bool CGUIWindowPVRRecordingsBase::OnMessage(CGUIMessage& message)
@@ -291,14 +299,16 @@ bool CGUIWindowPVRRecordingsBase::OnMessage(CGUIMessage& message)
       }
       else if (message.GetSenderId() == CONTROL_BTNGROUPITEMS)
       {
-        const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+        const std::shared_ptr<CSettings> settings =
+            CServiceBroker::GetSettingsComponent()->GetSettings();
         settings->ToggleBool(CSettings::SETTING_PVRRECORD_GROUPRECORDINGS);
         settings->Save();
         Refresh(true);
       }
       else if (message.GetSenderId() == CONTROL_BTNSHOWDELETED)
       {
-        CGUIRadioButtonControl* radioButton = static_cast<CGUIRadioButtonControl*>(GetControl(CONTROL_BTNSHOWDELETED));
+        CGUIRadioButtonControl* radioButton =
+            static_cast<CGUIRadioButtonControl*>(GetControl(CONTROL_BTNSHOWDELETED));
         if (radioButton)
         {
           m_bShowDeletedRecordings = radioButton->IsSelected();

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.h
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.h
@@ -20,46 +20,52 @@ class CFileItem;
 
 namespace PVR
 {
-  class CGUIWindowPVRRecordingsBase : public CGUIWindowPVRBase
+class CGUIWindowPVRRecordingsBase : public CGUIWindowPVRBase
+{
+public:
+  CGUIWindowPVRRecordingsBase(bool bRadio, int id, const std::string& xmlFile);
+  ~CGUIWindowPVRRecordingsBase() override;
+
+  void OnWindowLoaded() override;
+  bool OnMessage(CGUIMessage& message) override;
+  bool OnAction(const CAction& action) override;
+  void GetContextButtons(int itemNumber, CContextButtons& buttons) override;
+  bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
+  bool Update(const std::string& strDirectory, bool updateFilterPath = true) override;
+  void UpdateButtons() override;
+
+protected:
+  std::string GetDirectoryPath() override;
+  void OnPrepareFileItems(CFileItemList& items) override;
+  bool GetFilteredItems(const std::string& filter, CFileItemList& items) override;
+
+  bool m_bShowDeletedRecordings{false};
+
+private:
+  bool OnContextButtonDeleteAll(CFileItem* item, CONTEXT_BUTTON button);
+
+  CVideoThumbLoader m_thumbLoader;
+  CVideoDatabase m_database;
+  CPVRSettings m_settings;
+};
+
+class CGUIWindowPVRTVRecordings : public CGUIWindowPVRRecordingsBase
+{
+public:
+  CGUIWindowPVRTVRecordings()
+    : CGUIWindowPVRRecordingsBase(false, WINDOW_TV_RECORDINGS, "MyPVRRecordings.xml")
   {
-  public:
-    CGUIWindowPVRRecordingsBase(bool bRadio, int id, const std::string& xmlFile);
-    ~CGUIWindowPVRRecordingsBase() override;
+  }
+  std::string GetRootPath() const override;
+};
 
-    void OnWindowLoaded() override;
-    bool OnMessage(CGUIMessage& message) override;
-    bool OnAction(const CAction& action) override;
-    void GetContextButtons(int itemNumber, CContextButtons& buttons) override;
-    bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
-    bool Update(const std::string& strDirectory, bool updateFilterPath = true) override;
-    void UpdateButtons() override;
-
-  protected:
-    std::string GetDirectoryPath() override;
-    void OnPrepareFileItems(CFileItemList& items) override;
-    bool GetFilteredItems(const std::string& filter, CFileItemList& items) override;
-
-    bool m_bShowDeletedRecordings{false};
-
-  private:
-    bool OnContextButtonDeleteAll(CFileItem* item, CONTEXT_BUTTON button);
-
-    CVideoThumbLoader m_thumbLoader;
-    CVideoDatabase m_database;
-    CPVRSettings m_settings;
-  };
-
-  class CGUIWindowPVRTVRecordings : public CGUIWindowPVRRecordingsBase
+class CGUIWindowPVRRadioRecordings : public CGUIWindowPVRRecordingsBase
+{
+public:
+  CGUIWindowPVRRadioRecordings()
+    : CGUIWindowPVRRecordingsBase(true, WINDOW_RADIO_RECORDINGS, "MyPVRRecordings.xml")
   {
-  public:
-    CGUIWindowPVRTVRecordings() : CGUIWindowPVRRecordingsBase(false, WINDOW_TV_RECORDINGS, "MyPVRRecordings.xml") {}
-    std::string GetRootPath() const override;
-  };
-
-  class CGUIWindowPVRRadioRecordings : public CGUIWindowPVRRecordingsBase
-  {
-  public:
-    CGUIWindowPVRRadioRecordings() : CGUIWindowPVRRecordingsBase(true, WINDOW_RADIO_RECORDINGS, "MyPVRRecordings.xml") {}
-    std::string GetRootPath() const override;
-  };
-}
+  }
+  std::string GetRootPath() const override;
+};
+} // namespace PVR

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -275,7 +275,7 @@ bool CGUIWindowPVRSearchBase::OnMessage(CGUIMessage& message)
             return true;
 
           case ACTION_RECORD:
-            CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().ToggleTimer(pItem);
+            CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().ToggleTimer(*pItem);
             return true;
         }
       }

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -127,16 +127,16 @@ bool CGUIWindowPVRSearchBase::OnContextButton(int itemNumber, CONTEXT_BUTTON but
       CGUIMediaWindow::OnContextButton(itemNumber, button);
 }
 
-void CGUIWindowPVRSearchBase::SetItemToSearch(const CFileItemPtr& item)
+void CGUIWindowPVRSearchBase::SetItemToSearch(const CFileItem& item)
 {
-  if (item->HasEPGSearchFilter())
+  if (item.HasEPGSearchFilter())
   {
-    SetSearchFilter(item->GetEPGSearchFilter());
+    SetSearchFilter(item.GetEPGSearchFilter());
   }
-  else if (item->IsUsablePVRRecording())
+  else if (item.IsUsablePVRRecording())
   {
     SetSearchFilter(std::make_shared<CPVREpgSearchFilter>(m_bRadio));
-    m_searchfilter->SetSearchPhrase(item->GetPVRRecordingInfoTag()->m_strTitle);
+    m_searchfilter->SetSearchPhrase(item.GetPVRRecordingInfoTag()->m_strTitle);
   }
   else
   {
@@ -256,7 +256,7 @@ bool CGUIWindowPVRSearchBase::OnMessage(CGUIMessage& message)
 
             if (bIsSavedSearch)
             {
-              OpenDialogSearch(pItem);
+              OpenDialogSearch(*pItem);
             }
             else if (pItem->GetPath() == CPVREpgSearchPath::PATH_SEARCH_DIALOG)
             {
@@ -264,7 +264,7 @@ bool CGUIWindowPVRSearchBase::OnMessage(CGUIMessage& message)
             }
             else
             {
-              CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowEPGInfo(pItem);
+              CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().ShowEPGInfo(*pItem);
             }
             return true;
           }
@@ -402,10 +402,9 @@ bool CGUIWindowPVRSearchBase::OnContextButtonClear(CFileItem* item, CONTEXT_BUTT
   return bReturn;
 }
 
-CGUIDialogPVRGuideSearch::Result CGUIWindowPVRSearchBase::OpenDialogSearch(
-    const std::shared_ptr<CFileItem>& item)
+CGUIDialogPVRGuideSearch::Result CGUIWindowPVRSearchBase::OpenDialogSearch(const CFileItem& item)
 {
-  const auto searchFilter = item->GetEPGSearchFilter();
+  const auto searchFilter = item.GetEPGSearchFilter();
   if (!searchFilter)
     return CGUIDialogPVRGuideSearch::Result::CANCEL;
 

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.h
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.h
@@ -19,70 +19,72 @@ class CFileItem;
 
 namespace PVR
 {
-  class CPVREpgSearchFilter;
+class CPVREpgSearchFilter;
 
-  class CGUIWindowPVRSearchBase : public CGUIWindowPVRBase
+class CGUIWindowPVRSearchBase : public CGUIWindowPVRBase
+{
+public:
+  CGUIWindowPVRSearchBase(bool bRadio, int id, const std::string& xmlFile);
+  ~CGUIWindowPVRSearchBase() override;
+
+  bool OnAction(const CAction& action) override;
+  bool OnMessage(CGUIMessage& message) override;
+  void GetContextButtons(int itemNumber, CContextButtons& buttons) override;
+  bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
+  bool Update(const std::string& strDirectory, bool updateFilterPath = true) override;
+  void UpdateButtons() override;
+
+  /*!
+   * @brief set the item to search similar events for.
+   * @param item the epg event to search similar events for.
+   */
+  void SetItemToSearch(const CFileItem& item);
+
+  /*!
+   * @brief Open the search dialog for the given search filter item.
+   * @param item the epg search filter.
+   * @return The result of the dialog
+   */
+  CGUIDialogPVRGuideSearch::Result OpenDialogSearch(const CFileItem& item);
+
+protected:
+  void OnPrepareFileItems(CFileItemList& items) override;
+
+private:
+  bool OnContextButtonClear(CFileItem* item, CONTEXT_BUTTON button);
+
+  CGUIDialogPVRGuideSearch::Result OpenDialogSearch(
+      const std::shared_ptr<CPVREpgSearchFilter>& searchFilter);
+
+  void ExecuteSearch();
+
+  void SetSearchFilter(const std::shared_ptr<CPVREpgSearchFilter>& searchFilter);
+
+  bool m_bSearchConfirmed;
+  std::shared_ptr<CPVREpgSearchFilter> m_searchfilter;
+};
+
+class CGUIWindowPVRTVSearch : public CGUIWindowPVRSearchBase
+{
+public:
+  CGUIWindowPVRTVSearch() : CGUIWindowPVRSearchBase(false, WINDOW_TV_SEARCH, "MyPVRSearch.xml") {}
+
+protected:
+  std::string GetRootPath() const override;
+  std::string GetStartFolder(const std::string& dir) override;
+  std::string GetDirectoryPath() override;
+};
+
+class CGUIWindowPVRRadioSearch : public CGUIWindowPVRSearchBase
+{
+public:
+  CGUIWindowPVRRadioSearch() : CGUIWindowPVRSearchBase(true, WINDOW_RADIO_SEARCH, "MyPVRSearch.xml")
   {
-  public:
-    CGUIWindowPVRSearchBase(bool bRadio, int id, const std::string& xmlFile);
-    ~CGUIWindowPVRSearchBase() override;
+  }
 
-    bool OnAction(const CAction& action) override;
-    bool OnMessage(CGUIMessage& message) override;
-    void GetContextButtons(int itemNumber, CContextButtons& buttons) override;
-    bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
-    bool Update(const std::string& strDirectory, bool updateFilterPath = true) override;
-    void UpdateButtons() override;
-
-    /*!
-     * @brief set the item to search similar events for.
-     * @param item the epg event to search similar events for.
-     */
-    void SetItemToSearch(const CFileItem& item);
-
-    /*!
-     * @brief Open the search dialog for the given search filter item.
-     * @param item the epg search filter.
-     * @return The result of the dialog
-     */
-    CGUIDialogPVRGuideSearch::Result OpenDialogSearch(const CFileItem& item);
-
-  protected:
-    void OnPrepareFileItems(CFileItemList& items) override;
-
-  private:
-    bool OnContextButtonClear(CFileItem* item, CONTEXT_BUTTON button);
-
-    CGUIDialogPVRGuideSearch::Result OpenDialogSearch(
-        const std::shared_ptr<CPVREpgSearchFilter>& searchFilter);
-
-    void ExecuteSearch();
-
-    void SetSearchFilter(const std::shared_ptr<CPVREpgSearchFilter>& searchFilter);
-
-    bool m_bSearchConfirmed;
-    std::shared_ptr<CPVREpgSearchFilter> m_searchfilter;
-  };
-
-  class CGUIWindowPVRTVSearch : public CGUIWindowPVRSearchBase
-  {
-  public:
-    CGUIWindowPVRTVSearch() : CGUIWindowPVRSearchBase(false, WINDOW_TV_SEARCH, "MyPVRSearch.xml") {}
-
-  protected:
-    std::string GetRootPath() const override;
-    std::string GetStartFolder(const std::string& dir) override;
-    std::string GetDirectoryPath() override;
-  };
-
-  class CGUIWindowPVRRadioSearch : public CGUIWindowPVRSearchBase
-  {
-  public:
-    CGUIWindowPVRRadioSearch() : CGUIWindowPVRSearchBase(true, WINDOW_RADIO_SEARCH, "MyPVRSearch.xml") {}
-
-  protected:
-    std::string GetRootPath() const override;
-    std::string GetStartFolder(const std::string& dir) override;
-    std::string GetDirectoryPath() override;
-  };
-}
+protected:
+  std::string GetRootPath() const override;
+  std::string GetStartFolder(const std::string& dir) override;
+  std::string GetDirectoryPath() override;
+};
+} // namespace PVR

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.h
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.h
@@ -38,14 +38,14 @@ namespace PVR
      * @brief set the item to search similar events for.
      * @param item the epg event to search similar events for.
      */
-    void SetItemToSearch(const CFileItemPtr& item);
+    void SetItemToSearch(const CFileItem& item);
 
     /*!
      * @brief Open the search dialog for the given search filter item.
      * @param item the epg search filter.
      * @return The result of the dialog
      */
-    CGUIDialogPVRGuideSearch::Result OpenDialogSearch(const std::shared_ptr<CFileItem>& item);
+    CGUIDialogPVRGuideSearch::Result OpenDialogSearch(const CFileItem& item);
 
   protected:
     void OnPrepareFileItems(CFileItemList& items) override;

--- a/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
@@ -29,8 +29,8 @@
 
 using namespace PVR;
 
-CGUIWindowPVRTimersBase::CGUIWindowPVRTimersBase(bool bRadio, int id, const std::string& xmlFile) :
-  CGUIWindowPVRBase(bRadio, id, xmlFile)
+CGUIWindowPVRTimersBase::CGUIWindowPVRTimersBase(bool bRadio, int id, const std::string& xmlFile)
+  : CGUIWindowPVRBase(bRadio, id, xmlFile)
 {
 }
 
@@ -38,8 +38,7 @@ CGUIWindowPVRTimersBase::~CGUIWindowPVRTimersBase() = default;
 
 bool CGUIWindowPVRTimersBase::OnAction(const CAction& action)
 {
-  if (action.GetID() == ACTION_PARENT_DIR ||
-      action.GetID() == ACTION_NAV_BACK)
+  if (action.GetID() == ACTION_PARENT_DIR || action.GetID() == ACTION_NAV_BACK)
   {
     CPVRTimersPath path(m_vecItems->GetPath());
     if (path.IsValid() && path.IsTimerRule())
@@ -67,14 +66,16 @@ void CGUIWindowPVRTimersBase::OnPrepareFileItems(CFileItemList& items)
   }
 }
 
-bool CGUIWindowPVRTimersBase::Update(const std::string& strDirectory, bool updateFilterPath /* = true */)
+bool CGUIWindowPVRTimersBase::Update(const std::string& strDirectory,
+                                     bool updateFilterPath /* = true */)
 {
   int iOldCount = m_vecItems->GetObjectCount();
   const std::string oldPath = m_vecItems->GetPath();
 
   bool bReturn = CGUIWindowPVRBase::Update(strDirectory);
 
-  if (bReturn && iOldCount > 0 && m_vecItems->GetObjectCount() == 0 && oldPath == m_vecItems->GetPath())
+  if (bReturn && iOldCount > 0 && m_vecItems->GetObjectCount() == 0 &&
+      oldPath == m_vecItems->GetPath())
   {
     /* go to the parent folder if we're in a subdirectory and for instance just deleted the last item */
     const CPVRTimersPath path(m_vecItems->GetPath());
@@ -90,7 +91,9 @@ bool CGUIWindowPVRTimersBase::Update(const std::string& strDirectory, bool updat
 
 void CGUIWindowPVRTimersBase::UpdateButtons()
 {
-  SET_CONTROL_SELECTED(GetID(), CONTROL_BTNHIDEDISABLEDTIMERS, CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_PVRTIMERS_HIDEDISABLEDTIMERS));
+  SET_CONTROL_SELECTED(GetID(), CONTROL_BTNHIDEDISABLEDTIMERS,
+                       CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                           CSettings::SETTING_PVRTIMERS_HIDEDISABLEDTIMERS));
 
   CGUIWindowPVRBase::UpdateButtons();
 
@@ -151,7 +154,8 @@ bool CGUIWindowPVRTimersBase::OnMessage(CGUIMessage& message)
       }
       else if (message.GetSenderId() == CONTROL_BTNHIDEDISABLEDTIMERS)
       {
-        const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+        const std::shared_ptr<CSettings> settings =
+            CServiceBroker::GetSettingsComponent()->GetSettings();
         settings->ToggleBool(CSettings::SETTING_PVRTIMERS_HIDEDISABLEDTIMERS);
         settings->Save();
         Update(GetDirectoryPath());

--- a/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
@@ -131,7 +131,7 @@ bool CGUIWindowPVRTimersBase::OnMessage(CGUIMessage& message)
               else
               {
                 m_currentFileItem.reset();
-                ActionShowTimer(item);
+                ActionShowTimer(*item);
               }
               break;
             }
@@ -141,7 +141,7 @@ bool CGUIWindowPVRTimersBase::OnMessage(CGUIMessage& message)
               break;
             case ACTION_DELETE_ITEM:
               CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().DeleteTimer(
-                  m_vecItems->Get(iItem));
+                  *(m_vecItems->Get(iItem)));
               break;
             default:
               bReturn = false;
@@ -184,14 +184,14 @@ bool CGUIWindowPVRTimersBase::OnMessage(CGUIMessage& message)
   return bReturn || CGUIWindowPVRBase::OnMessage(message);
 }
 
-bool CGUIWindowPVRTimersBase::ActionShowTimer(const CFileItemPtr& item)
+bool CGUIWindowPVRTimersBase::ActionShowTimer(const CFileItem& item)
 {
   bool bReturn = false;
 
   /* Check if "Add timer..." entry is selected, if yes
      create a new timer and open settings dialog, otherwise
      open settings for selected timer entry */
-  if (URIUtils::PathEquals(item->GetPath(), CPVRTimersPath::PATH_ADDTIMER))
+  if (URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER))
     bReturn = CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().AddTimer(m_bRadio);
   else
     bReturn = CServiceBroker::GetPVRManager().Get<PVR::GUI::Timers>().EditTimer(item);

--- a/xbmc/pvr/windows/GUIWindowPVRTimersBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRTimersBase.h
@@ -29,7 +29,7 @@ namespace PVR
     void UpdateButtons() override;
 
   private:
-    bool ActionShowTimer(const std::shared_ptr<CFileItem>& item);
+    bool ActionShowTimer(const CFileItem& item);
 
     std::shared_ptr<CFileItem> m_currentFileItem;
   };

--- a/xbmc/pvr/windows/GUIWindowPVRTimersBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRTimersBase.h
@@ -16,21 +16,21 @@ class CFileItem;
 
 namespace PVR
 {
-  class CGUIWindowPVRTimersBase : public CGUIWindowPVRBase
-  {
-  public:
-    CGUIWindowPVRTimersBase(bool bRadio, int id, const std::string& xmlFile);
-    ~CGUIWindowPVRTimersBase() override;
+class CGUIWindowPVRTimersBase : public CGUIWindowPVRBase
+{
+public:
+  CGUIWindowPVRTimersBase(bool bRadio, int id, const std::string& xmlFile);
+  ~CGUIWindowPVRTimersBase() override;
 
-    bool OnMessage(CGUIMessage& message) override;
-    bool OnAction(const CAction& action) override;
-    void OnPrepareFileItems(CFileItemList& items) override;
-    bool Update(const std::string& strDirectory, bool updateFilterPath = true) override;
-    void UpdateButtons() override;
+  bool OnMessage(CGUIMessage& message) override;
+  bool OnAction(const CAction& action) override;
+  void OnPrepareFileItems(CFileItemList& items) override;
+  bool Update(const std::string& strDirectory, bool updateFilterPath = true) override;
+  void UpdateButtons() override;
 
-  private:
-    bool ActionShowTimer(const CFileItem& item);
+private:
+  bool ActionShowTimer(const CFileItem& item);
 
-    std::shared_ptr<CFileItem> m_currentFileItem;
-  };
-}
+  std::shared_ptr<CFileItem> m_currentFileItem;
+};
+} // namespace PVR


### PR DESCRIPTION
CPVRGUIActions*: Reduce usage of `const shared_ptr<CFileItem>&` parameters. Use `const CFileItem&` instead.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish , @garbear best reviewed commit by commit. 