### PR TITLE
[tvOS] Better user experience with Siri remote pan gesture

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16138,7 +16138,10 @@ msgctxt "#24162"
 msgid "Use Kodi virtual keyboard"
 msgstr ""
 
-#empty string with id 24163
+#: system/settings/darwin_tvos.xml
+msgctxt "#24163"
+msgid "The higher the value, the more sensitive the pan gesture"
+msgstr ""
 
 #. Header text for yes/no dialog about enable of broken add-on
 #: xbmc/addons/gui/GUIHelpers.cpp

--- a/system/settings/darwin_tvos.xml
+++ b/system/settings/darwin_tvos.xml
@@ -69,23 +69,23 @@
           </dependencies>
         </setting>
         <!-- Siri remote sensitivity -->
-        <setting id="input.siriremotehorizontalsensitivity" type="integer" label="34009">
+        <setting id="input.siriremotehorizontalsensitivity" type="integer" label="34009" help="24163">
           <level>2</level>
-          <default>1000</default>
+          <default>500</default>
           <constraints>
             <minimum>50</minimum>
             <step>50</step>
-            <maximum>1500</maximum>
+            <maximum>1450</maximum>
           </constraints>
           <control type="spinner" format="integer" delayed="false"/>
         </setting>
-        <setting id="input.siriremoteverticalsensitivity" type="integer" label="34010">
+        <setting id="input.siriremoteverticalsensitivity" type="integer" label="34010" help="24163">
           <level>2</level>
-          <default>550</default>
+          <default>650</default>
           <constraints>
             <minimum>50</minimum>
             <step>50</step>
-            <maximum>1500</maximum>
+            <maximum>1450</maximum>
           </constraints>
           <control type="spinner" format="integer" delayed="false"/>
         </setting>

--- a/xbmc/platform/darwin/tvos/input/LibInputTouch.mm
+++ b/xbmc/platform/darwin/tvos/input/LibInputTouch.mm
@@ -442,6 +442,7 @@
   auto translation = [sender translationInView:sender.view];
   auto velocity = [sender velocityInView:sender.view];
   auto direction = [self getPanDirection:velocity];
+  const auto maxSensitivity = 1500;
 
   switch (sender.state)
   {
@@ -458,7 +459,7 @@
         case UIPanGestureRecognizerDirectionUp:
         {
           if (fabs(m_lastGesturePoint.y - translation.y) >
-              g_xbmcController.inputHandler.inputSettings.siriRemoteVerticalSensitivity)
+              maxSensitivity - g_xbmcController.inputHandler.inputSettings.siriRemoteVerticalSensitivity)
           {
             CLog::Log(LOGDEBUG, "Input: Siri remote pan up (id: 23)");
             keyId = 23;
@@ -468,7 +469,7 @@
         case UIPanGestureRecognizerDirectionDown:
         {
           if (fabs(m_lastGesturePoint.y - translation.y) >
-              g_xbmcController.inputHandler.inputSettings.siriRemoteVerticalSensitivity)
+              maxSensitivity - g_xbmcController.inputHandler.inputSettings.siriRemoteVerticalSensitivity)
           {
             CLog::Log(LOGDEBUG, "Input: Siri remote pan down (id: 24)");
             keyId = 24;
@@ -478,7 +479,7 @@
         case UIPanGestureRecognizerDirectionLeft:
         {
           if (fabs(m_lastGesturePoint.x - translation.x) >
-              g_xbmcController.inputHandler.inputSettings.siriRemoteHorizontalSensitivity)
+              maxSensitivity - g_xbmcController.inputHandler.inputSettings.siriRemoteHorizontalSensitivity)
           {
             CLog::Log(LOGDEBUG, "Input: Siri remote pan left (id: 25)");
             keyId = 25;
@@ -488,7 +489,7 @@
         case UIPanGestureRecognizerDirectionRight:
         {
           if (fabs(m_lastGesturePoint.x - translation.x) >
-              g_xbmcController.inputHandler.inputSettings.siriRemoteHorizontalSensitivity)
+              maxSensitivity - g_xbmcController.inputHandler.inputSettings.siriRemoteHorizontalSensitivity)
           {
             CLog::Log(LOGDEBUG, "Input: Siri remote pan right (id: 26)");
             keyId = 26;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

The Siri remote pan gesture sensitive setting is counter-intuitive because you have to increase the value to reduce sensitivity.

This PR inverse the setting order and add an help message.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Better user experience.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Runtime test on Apple TV.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
