### PR TITLE
[UPnP] Always show all all directories even if they don't contain items

### DIFF
--- a/xbmc/filesystem/UPnPDirectory.cpp
+++ b/xbmc/filesystem/UPnPDirectory.cpp
@@ -306,16 +306,6 @@ CUPnPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
                 continue;
             }
 
-            // never show empty containers in media views
-            if((*entry)->IsContainer()) {
-                if( (audio || video || image)
-                 && ((PLT_MediaContainer*)(*entry))->m_ChildrenCount == 0) {
-                    ++entry;
-                    continue;
-                }
-            }
-
-
             // keep count of classes
             classes[(*entry)->m_ObjectClass.type]++;
             CFileItemPtr pItem = BuildObject(*entry, UPnPClient);


### PR DESCRIPTION
## Description
Kodi is not showing all directories when you browse an UPnP source - this is legacy code that dates back from the svn. We show all directories everywhere else even if they are empty, so the same principle should apply to UPnP as well. Furthermore `m_ChildrenCount` doesn't exactly mean that the directory is empty, it might contain no items but simply other containers.

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/22031

## How has this been tested?
Jellyfin setup on a raspberry pi, just like the issue report.

## What is the effect on users?
UPnP should now show all directories (including those that only have other containers inside) and not only those that contain a playable item on the container

## Screenshots (if appropriate):
**Before:**
![image](https://user-images.githubusercontent.com/7375276/195983883-8df39be6-7a06-4e83-bb26-81552aaa95cf.png)
![image](https://user-images.githubusercontent.com/7375276/195983895-d236916b-7801-4296-8efa-802b11030851.png)


**Now:**

![image](https://user-images.githubusercontent.com/7375276/195983804-7494230d-9325-4185-8207-5ef31921241a.png)
![image](https://user-images.githubusercontent.com/7375276/195983811-0d0a25e5-ff5b-4852-90e1-a095c03b8c91.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
