### PR TITLE
[upnp]: add all KODI supported real subtitle formats when act as a DLNA render

### DIFF
--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -30,6 +30,8 @@
 #include "video/VideoInfoTag.h"
 
 #include <algorithm>
+#include <array>
+#include <string_view>
 
 #include <Platinum/Source/Platinum/Platinum.h>
 
@@ -38,6 +40,24 @@ using namespace XFILE;
 
 namespace UPNP
 {
+
+// the original version of content type here,eg: text/srt,which was defined 10 years ago (year 2013,commit 56519bec #L1158-L1161 )
+// is not a standard mime type. according to the specs of UPNP
+// http://upnp.org/specs/av/UPnP-av-ConnectionManager-v3-Service.pdf chapter "A.1.1 ProtocolInfo Definition"
+// "The <contentFormat> part for HTTP GET is described by a MIME type RFC https://www.ietf.org/rfc/rfc1341.txt"
+// all the pre-defined "text/*" MIME by IANA is here https://www.iana.org/assignments/media-types/media-types.xhtml#text
+// there is not any subtitle MIME for now (year 2022), we used to use text/srt|ssa|sub|idx, but,
+// kodi support SUP subtitle now, and SUP subtitle is not really a text(see below), to keep it
+// compatible, we suggest only to match the extension
+//
+// main purpose of this array is to share supported real subtitle formats when kodi act as a UPNP
+// server or UPNP/DLNA media render
+constexpr std::array<std::string_view, 9> SupportedSubFormats = {
+    "txt", "srt", "ssa", "ass", "sub", "smi", "vtt",
+    // "sup" subtitle is not a real TEXT,
+    // and there is no real STD subtitle RFC of DLNA,
+    // so we only match the extension of the "fake" content type
+    "sup", "idx"};
 
 /*----------------------------------------------------------------------
 |  GetClientQuirks
@@ -660,10 +680,12 @@ BuildObject(CFileItem&                    item,
             std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
             /* Hardcoded check for extension is not the best way, but it can't be allowed to pass all
                subtitle extension (ex. rar or zip). There are the most popular extensions support by UPnP devices.*/
-            if (ext == "txt" || ext == "srt" || ext == "ssa" || ext == "ass" || ext == "sub" ||
-                ext == "smi" || ext == "vtt" || ext == "sup")
+            for (std::string_view type : SupportedSubFormats)
             {
+              if (type == ext)
+              {
                 subtitles.push_back(filenames[i]);
+              }
             }
         }
 
@@ -1150,22 +1172,23 @@ bool GetResource(const PLT_MediaObject* entry, CFileItem& item)
   }
 
   // look for subtitles
-  unsigned subs = 0;
+  unsigned subIdx = 0;
+
   for(unsigned r = 0; r < entry->m_Resources.GetItemCount(); r++)
   {
     const PLT_MediaItemResource& res  = entry->m_Resources[r];
     const PLT_ProtocolInfo&      info = res.m_ProtocolInfo;
-    static const char* allowed[] = { "text/srt"
-      , "text/ssa"
-      , "text/sub"
-      , "text/idx" };
-    for(const char* const type : allowed)
+
+    for (std::string_view type : SupportedSubFormats)
     {
-      if(info.Match(PLT_ProtocolInfo("*", "*", type, "*")))
+      if (type == info.GetContentType().Split("/").GetLastItem()->GetChars())
       {
-        std::string prop = StringUtils::Format("subtitle:{}", ++subs);
+        ++subIdx;
+        logger->info("adding subtitle: #{}, type '{}', URI '{}'", subIdx, type,
+                     res.m_Uri.GetChars());
+
+        std::string prop = StringUtils::Format("subtitle:{}", subIdx);
         item.SetProperty(prop, (const char*)res.m_Uri);
-        break;
       }
     }
   }


### PR DESCRIPTION
upnp: add all KODI supported real subtitle formats when act as a DLNA render
          and share the white list with the KODI DLNA server

## Description
- KODI support work as a DLNA media render with the supported format of subtitle
- KODI has [a builtin  subtitle white list almost 10 years ago in year 2013](https://github.com/xbmc/xbmc/blame/00d752bfbe862c67e189d461859e31f471981d33/xbmc/network/upnp/UPnPInternal.cpp#L1158-L1161), which is obviously outdated
- KODI has[ another builtin similar subtitle white list](https://github.com/xbmc/xbmc/blob/bdf0f9b468475a4fc4e603eebef004175182968c/xbmc/network/upnp/UPnPInternal.cpp#L663), which is maintained actively
- this PR makes them share the white list and keep the white list of  DLNA media render up to date

## Motivation and context
Reading : 
- https://emby.media/community/index.php?/topic/111848-dlna-configuration-profile-error/&do=findComment&comment=1188987
- https://emby.media/community/index.php?/topic/112866-dlna-subtitle-index-is-ignored-by-dlna-plugin-1089/&do=findComment&comment=1189227
EMBY can "DLNA" a movie along with all it's subtitle to KODI
But, the white list of subtitle of DLNA media render is outdated
so KODI will reject all the subtitle not in the list,such as ass/ssa
which makes the subtitle function broken


## How has this been tested?

- [x] as a DLNA render:

local build pass and tested with[ emby](https://emby.media/) dlna server,all subttitles functional

- [x] as a UPNP/DLNA server:

local build pass and tested with [Bubble upnp](https://play.google.com/store/apps/details?id=com.bubblesoft.android.bubbleupnp&hl=en&gl=US) app

- [x] ENV
```
Distributor ID:	ManjaroLinux
Description:	Manjaro Linux
Release:	22.0.0
Codename:	Sikaris
```

## What is the effect on users?
user will have a full functional subtitle selection when play video by supported DLNA control point

## Screenshots (if appropriate):
![2022-10-12_14-45](https://user-images.githubusercontent.com/423077/196036575-7552be9d-3436-4797-b1ed-aa2ee6613467.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
