### PR TITLE
[Docs] Update codeguidelines to reflect cpp 17 features

### DIFF
--- a/docs/CODE_GUIDELINES.md
+++ b/docs/CODE_GUIDELINES.md
@@ -70,7 +70,7 @@ Conventions can be bent or broken in the interest of making code more readable a
 
 ## 2. Language standard
 
-We currently target the C++14 language standard. Do use C++14 features when possible. Do not use C++17 features.
+We currently target the C++17 language standard. Do use C++17 features when possible (and supported by all target platforms). Do not use C++20 features.
 
 **[back to top](#table-of-contents)**
 


### PR DESCRIPTION
## Description
I had the impression this was already changed in the code guidelines doc but it seems we still refer to C++14 as the enforced language standard. However, we've been using some c++17 features (e.g. `string_view`, `from_chars`, etc) and I recall some discussion about this somewhere in the past.

Brought in https://github.com/xbmc/xbmc/pull/22038