### PR TITLE
[backport][upnp]: add all KODI-19 supported real subtitle formats when act as a DLNA render

### DIFF
--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -32,6 +32,7 @@
 #include "video/VideoInfoTag.h"
 
 #include <algorithm>
+#include <array>
 
 #include <Platinum/Source/Platinum/Platinum.h>
 
@@ -40,6 +41,20 @@ using namespace XFILE;
 
 namespace UPNP
 {
+
+// the original version of content type here,eg: text/srt,which was defined 10 years ago (year 2013,commit 56519bec #L1158-L1161 )
+// is not a standard mime type. according to the specs of UPNP
+// http://upnp.org/specs/av/UPnP-av-ConnectionManager-v3-Service.pdf chapter "A.1.1 ProtocolInfo Definition"
+// "The <contentFormat> part for HTTP GET is described by a MIME type RFC https://www.ietf.org/rfc/rfc1341.txt"
+// all the pre-defined "text/*" MIME by IANA is here https://www.iana.org/assignments/media-types/media-types.xhtml#text
+// there is not any subtitle MIME for now (year 2022), we used to use text/srt|ssa|sub|idx, but,
+// kodi support SUP subtitle now, and SUP subtitle is not really a text(see below), to keep it
+// compatible, we suggest only to match the extension
+//
+// main purpose of this array is to share supported real subtitle formats when kodi act as a UPNP
+// server or UPNP/DLNA media render
+const std::array<std::string, 7> SupportedSubFormats = {"txt", "srt", "ssa", "ass",
+                                                        "sub", "smi", "idx"};
 
 /*----------------------------------------------------------------------
 |  GetClientQuirks
@@ -647,9 +662,12 @@ BuildObject(CFileItem&                    item,
             std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
             /* Hardcoded check for extension is not the best way, but it can't be allowed to pass all
                subtitle extension (ex. rar or zip). There are the most popular extensions support by UPnP devices.*/
-            if (ext == "txt" || ext == "srt" || ext == "ssa" || ext == "ass" || ext == "sub" || ext == "smi")
+            for (const std::string& type : SupportedSubFormats)
             {
+              if (type == ext)
+              {
                 subtitles.push_back(filenames[i]);
+              }
             }
         }
 
@@ -1100,22 +1118,23 @@ bool GetResource(const PLT_MediaObject* entry, CFileItem& item)
   }
 
   // look for subtitles
-  unsigned subs = 0;
+  unsigned subIdx = 0;
+
   for(unsigned r = 0; r < entry->m_Resources.GetItemCount(); r++)
   {
     const PLT_MediaItemResource& res  = entry->m_Resources[r];
     const PLT_ProtocolInfo&      info = res.m_ProtocolInfo;
-    static const char* allowed[] = { "text/srt"
-      , "text/ssa"
-      , "text/sub"
-      , "text/idx" };
-    for(const char* const type : allowed)
+
+    for (const std::string& type : SupportedSubFormats)
     {
-      if(info.Match(PLT_ProtocolInfo("*", "*", type, "*")))
+      if (type == info.GetContentType().Split("/").GetLastItem()->GetChars())
       {
-        std::string prop = StringUtils::Format("subtitle:%d", ++subs);
+        ++subIdx;
+        logger->info("adding subtitle: #{}, type '{}', URI '{}'", subIdx, type,
+                     res.m_Uri.GetChars());
+
+        std::string prop = StringUtils::Format("subtitle:%d", subIdx);
         item.SetProperty(prop, (const char*)res.m_Uri);
-        break;
       }
     }
   }


### PR DESCRIPTION
[backport][upnp]: add all KODI-19 supported real subtitle formats when act as a DLNA render

@enen92 

## Description

This is a backport of https://github.com/xbmc/xbmc/pull/22038 to kodi-19


## Motivation and context

This is a backport of https://github.com/xbmc/xbmc/pull/22038 to kodi-19

## How has this been tested?
 same as #22038 

## What is the effect on users?

user will have a full functional subtitle selection when play video by supported DLNA control point

## Screenshots (if appropriate):
 same as #22038 

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
