### PR TITLE
[music][Estuary] Add ability to play albums directly from Estuary home screen, extend context menu functionality

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -949,6 +949,8 @@ msgstr ""
 
 #. generic "play" (some sort of media) label used in different places
 #: addons/skin.estuary/xml/DialogVideoInfo.xml
+#: addons/skin.estuary/xml/SkinSettings.xml
+#: addons/skin.estuary/xml/Variables.xml
 #: xbmc/dialogs/GUIDialogPlayEject.cpp
 #: xbmc/games/windows/GUIWindowGames.cpp
 #: xbmc/music/ContextMenus.h
@@ -21850,6 +21852,8 @@ msgctxt "#37014"
 msgid "Last used profile"
 msgstr ""
 
+#: addons/skin.estuary/xml/SkinSettings.xml
+#: addons/skin.estuary/xml/Variables.xml
 #: xbmc/music/ContextMenus.h
 #: xbmc/windows/GUIMediaWindow.cpp
 msgctxt "#37015"

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -21850,6 +21850,7 @@ msgctxt "#37014"
 msgid "Last used profile"
 msgstr ""
 
+#: xbmc/music/ContextMenus.h
 #: xbmc/windows/GUIMediaWindow.cpp
 msgctxt "#37015"
 msgid "Browse into"

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -22363,8 +22363,20 @@ msgctxt "#38081"
 msgid "Release status"
 msgstr ""
 
-#empty strings from id 38082 to 38099
-#strings 38082 to 38099 reserved for music library
+#. Displayed in a toast notification when music items are added to a playlist
+#: xbmc/music/MusicUtils.cpp
+msgctxt "#38082"
+msgid "Added to end of playlist"
+msgstr ""
+
+#. Displayed in a toast notification when music items are added to a playlist to play next
+#: xbmc/music/MusicUtils.cpp
+msgctxt "#38083"
+msgid "Added to playlist to play next"
+msgstr ""
+
+#empty strings from id 38084 to 38099
+#strings 38084 to 38099 reserved for music library
 
 #. Description of section #14200 "Player""
 #: system/settings/settings.xml

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -951,6 +951,8 @@ msgstr ""
 #: addons/skin.estuary/xml/DialogVideoInfo.xml
 #: xbmc/dialogs/GUIDialogPlayEject.cpp
 #: xbmc/games/windows/GUIWindowGames.cpp
+#: xbmc/music/ContextMenus.h
+#: xbmc/music/MusicUtils.cpp
 #: xbmc/video/ContextMenus.cpp
 #: xbmc/video/windows/GUIWindowVideoBase.cpp
 #: system/settings/settings.xml
@@ -4907,7 +4909,7 @@ msgctxt "#10007"
 msgid "System information"
 msgstr ""
 
-#: xbmc/music/windows/GUIWindowMusicBase.cpp
+#: xbmc/music/ContextMenus.h
 #: xbmc/video/ContextMenus.cpp
 #: xbmc/video/windows/GUIWindowVideoBase.cpp
 msgctxt "#10008"
@@ -6919,6 +6921,7 @@ msgid "Movie information"
 msgstr ""
 
 #: system/settings/settings.xml
+#: xbmc/music/ContextMenus.h
 #: xbmc/video/ContextMenus.cpp
 #: xbmc/video/windows/GUIWindowVideoBase.cpp
 msgctxt "#13347"
@@ -21847,7 +21850,7 @@ msgctxt "#37014"
 msgid "Last used profile"
 msgstr ""
 
-#: xbmc/Windows/GUIMediaWindow.cpp
+#: xbmc/windows/GUIMediaWindow.cpp
 msgctxt "#37015"
 msgid "Browse into"
 msgstr ""

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -4911,6 +4911,8 @@ msgctxt "#10007"
 msgid "System information"
 msgstr ""
 
+#: addons/skin.estuary/xml/SkinSettings.xml
+#: addons/skin.estuary/xml/Variables.xml
 #: xbmc/music/ContextMenus.h
 #: xbmc/video/ContextMenus.cpp
 #: xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -6922,6 +6924,8 @@ msgctxt "#13346"
 msgid "Movie information"
 msgstr ""
 
+#: addons/skin.estuary/xml/SkinSettings.xml
+#: addons/skin.estuary/xml/Variables.xml
 #: system/settings/settings.xml
 #: xbmc/music/ContextMenus.h
 #: xbmc/video/ContextMenus.cpp

--- a/addons/skin.estuary/language/resource.language.en_gb/strings.po
+++ b/addons/skin.estuary/language/resource.language.en_gb/strings.po
@@ -838,7 +838,13 @@ msgctxt "#31173"
 msgid "Video OSD autoclose time (seconds)"
 msgstr ""
 
-#empty strings from id 31174 to 31599
+#: /xml/SkinSettings.xml
+#. Setting to control what happens when clicking a music album on the home screen
+msgctxt "#31174"
+msgid "Default select action for albums on the home screen"
+msgstr ""
+
+#empty strings from id 31175 to 31599
 
 #: /xml/DialogPlayerProcessInfo.xml
 #. Label to show the video codec name

--- a/addons/skin.estuary/xml/DialogMusicInfo.xml
+++ b/addons/skin.estuary/xml/DialogMusicInfo.xml
@@ -360,22 +360,6 @@
 					<align>center</align>
 					<itemgap>-15</itemgap>
 					<orientation>horizontal</orientation>
-					<control type="radiobutton" id="155">
-						<include content="VideoInfoButtonsCommon">
-							<param name="icon" value="icons/infodialogs/play.png" />
-						</include>
-						<label>$LOCALIZE[208]</label>
-						<onup>130</onup>
-						<onleft>12</onleft>
-						<onright>120</onright>
-						<onclick condition="String.IsEmpty(ListItem.DBID)">PlayMedia($INFO[ListItem.FilenameAndPath])</onclick>
-						<onclick condition="System.AddonIsEnabled(script.playalbum) + String.IsEqual(ListItem.DBType,album)">RunScript(script.playalbum,albumid=$INFO[ListItem.DBID])</onclick>
-						<onclick condition="System.AddonIsEnabled(script.playalbum) + String.IsEqual(ListItem.DBType,song)">RunScript(script.playalbum,songid=$INFO[ListItem.DBID])</onclick>
-						<onclick condition="System.AddonIsEnabled(script.playalbum)">Action(close)</onclick>
-						<onclick condition="System.HasAddon(script.playalbum) + !System.AddonIsEnabled(script.playalbum) + !String.IsEmpty(ListItem.DBID)">EnableAddon(script.playalbum)</onclick>
-						<onclick condition="!System.HasAddon(script.playalbum) + !String.IsEmpty(ListItem.DBID)">InstallAddon(script.playalbum)</onclick>
-						<visible>!String.IsEqual(ListItem.DBType,artist)</visible>
-					</control>
 					<control type="group" id="420">
 						<width>264</width>
 						<visible>String.IsEqual(ListItem.DBType,album) | String.IsEqual(ListItem.DBType,song)</visible>
@@ -418,6 +402,11 @@
 						<onclick>ActivateWindow(1104)</onclick>
 						<visible>String.IsEqual(ListItem.DBType,artist) | String.IsEqual(ListItem.DBType,album)</visible>
 					</control>
+					<include content="InfoDialogButton">
+						<param name="id" value="8" />
+						<param name="icon" value="icons/infodialogs/play.png" />
+						<param name="label" value="$LOCALIZE[208]" />
+					</include>
 					<include content="InfoDialogButton">
 						<param name="id" value="6" />
 						<param name="icon" value="icons/infodialogs/update.png" />

--- a/addons/skin.estuary/xml/Home.xml
+++ b/addons/skin.estuary/xml/Home.xml
@@ -192,6 +192,8 @@
 							<param name="widget_target" value="music"/>
 							<param name="list_id" value="7100"/>
 							<param name="fallback_icon" value="DefaultMusicAlbums.png"/>
+							<param name="onclick_condition" value="true"/>
+							<param name="onclick_action" value="$VAR[AlbumOnClickActionVar]"/>
 						</include>
 						<include content="WidgetListSquare" condition="Library.HasContent(music)">
 							<param name="content_path" value="musicdb://recentlyaddedalbums/"/>
@@ -199,6 +201,8 @@
 							<param name="widget_target" value="music"/>
 							<param name="list_id" value="7200"/>
 							<param name="fallback_icon" value="DefaultMusicAlbums.png"/>
+							<param name="onclick_condition" value="true"/>
+							<param name="onclick_action" value="$VAR[AlbumOnClickActionVar]"/>
 						</include>
 						<include content="WidgetListSquare" condition="Library.HasContent(music)">
 							<param name="content_path" value="special://skin/playlists/random_albums.xsp"/>
@@ -206,6 +210,8 @@
 							<param name="widget_target" value="music"/>
 							<param name="list_id" value="7300"/>
 							<param name="fallback_icon" value="DefaultMusicAlbums.png"/>
+							<param name="onclick_condition" value="true"/>
+							<param name="onclick_action" value="$VAR[AlbumOnClickActionVar]"/>
 						</include>
 						<include content="WidgetListSquare" condition="Library.HasContent(music)">
 							<param name="content_path" value="special://skin/playlists/random_artists.xsp"/>
@@ -220,6 +226,8 @@
 							<param name="widget_target" value="music"/>
 							<param name="list_id" value="7500"/>
 							<param name="fallback_icon" value="DefaultMusicAlbums.png"/>
+							<param name="onclick_condition" value="true"/>
+							<param name="onclick_action" value="$VAR[AlbumOnClickActionVar]"/>
 						</include>
 						<include content="WidgetListSquare" condition="Library.HasContent(music)">
 							<param name="content_path" value="special://skin/playlists/mostplayed_albums.xsp"/>
@@ -229,6 +237,8 @@
 							<param name="fallback_icon" value="DefaultMusicAlbums.png"/>
 							<param name="sortby" value="playcount"/>
 							<param name="sortorder" value="descending"/>
+							<param name="onclick_condition" value="true"/>
+							<param name="onclick_action" value="$VAR[AlbumOnClickActionVar]"/>
 						</include>
 					</control>
 					<include content="ImageWidget" condition="!Library.HasContent(music)">

--- a/addons/skin.estuary/xml/Includes_Home.xml
+++ b/addons/skin.estuary/xml/Includes_Home.xml
@@ -213,6 +213,7 @@
 		<param name="sortorder">ascending</param>
 		<param name="widget_limit">15</param>
 		<param name="fallback_icon">DefaultAudio.png</param>
+		<param name="onclick_condition">false</param>
 		<definition>
 			<include content="CategoryLabel">
 				<param name="label">$PARAM[widget_header]</param>
@@ -229,6 +230,7 @@
 				<top>120</top>
 				<right>0</right>
 				<height>500</height>
+				<onclick condition="$PARAM[onclick_condition]">$PARAM[onclick_action]</onclick>
 				<include content="WidgetListCommon">
 					<param name="list_id" value="$PARAM[list_id]"/>
 				</include>

--- a/addons/skin.estuary/xml/SkinSettings.xml
+++ b/addons/skin.estuary/xml/SkinSettings.xml
@@ -195,6 +195,13 @@
 					<onclick condition="!System.HasAddon(plugin.library.node.editor)">InstallAddon(plugin.library.node.editor)</onclick>
 					<enable>!Skin.HasSetting(HomeMenuNoMusicButton)</enable>
 				</control>
+				<control type="button" id="625">
+					<label>- $LOCALIZE[31174]</label>
+					<include>DefaultSettingButton</include>
+					<onclick>Skin.SelectBool(31174, 37015|album_onclick_browse, 208|album_onclick_play)</onclick>
+					<label2>$VAR[AlbumOnClickActionLabel2Var]</label2>
+					<enable>!Skin.HasSetting(HomeMenuNoMusicButton)</enable>
+				</control>
 				<control type="radiobutton" id="6131">
 					<label>$LOCALIZE[20389]</label>
 					<include>DefaultSettingButton</include>

--- a/addons/skin.estuary/xml/SkinSettings.xml
+++ b/addons/skin.estuary/xml/SkinSettings.xml
@@ -198,7 +198,7 @@
 				<control type="button" id="625">
 					<label>- $LOCALIZE[31174]</label>
 					<include>DefaultSettingButton</include>
-					<onclick>Skin.SelectBool(31174, 37015|album_onclick_browse, 208|album_onclick_play)</onclick>
+					<onclick>Skin.SelectBool(31174, 37015|album_onclick_browse, 208|album_onclick_play, 10008|album_onclick_playnext, 13347|album_onclick_queue)</onclick>
 					<label2>$VAR[AlbumOnClickActionLabel2Var]</label2>
 					<enable>!Skin.HasSetting(HomeMenuNoMusicButton)</enable>
 				</control>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -183,11 +183,15 @@
 	<variable name="AlbumOnClickActionLabel2Var">
 		<value condition="Skin.HasSetting(album_onclick_browse)">$LOCALIZE[37015]</value>
 		<value condition="Skin.HasSetting(album_onclick_play)">$LOCALIZE[208]</value>
+		<value condition="Skin.HasSetting(album_onclick_playnext)">$LOCALIZE[10008]</value>
+		<value condition="Skin.HasSetting(album_onclick_queue)">$LOCALIZE[13347]</value>
 		<value>$LOCALIZE[37015]</value>
 	</variable>
 	<variable name="AlbumOnClickActionVar">
 		<value condition="Skin.HasSetting(album_onclick_browse)">ActivateWindow(music,musicdb://albums/$INFO[ListItem.DBID]/,return)</value>
 		<value condition="Skin.HasSetting(album_onclick_play)">PlayMedia(musicdb://albums/$INFO[ListItem.DBID]/)</value>
+		<value condition="Skin.HasSetting(album_onclick_playnext)">QueueMedia(musicdb://albums/$INFO[ListItem.DBID]/,playnext)</value>
+		<value condition="Skin.HasSetting(album_onclick_queue)">QueueMedia(musicdb://albums/$INFO[ListItem.DBID]/)</value>
 		<value>ActivateWindow(music,musicdb://albums/$INFO[ListItem.DBID]/,return)</value>
 	</variable>
 	<variable name="AddonLifecycleType">

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -180,6 +180,16 @@
 		<value condition="Skin.HasSetting(show_profileavatar)">$LOCALIZE[31166]</value>
 		<value>$LOCALIZE[16018]</value>
 	</variable>
+	<variable name="AlbumOnClickActionLabel2Var">
+		<value condition="Skin.HasSetting(album_onclick_browse)">$LOCALIZE[37015]</value>
+		<value condition="Skin.HasSetting(album_onclick_play)">$LOCALIZE[208]</value>
+		<value>$LOCALIZE[37015]</value>
+	</variable>
+	<variable name="AlbumOnClickActionVar">
+		<value condition="Skin.HasSetting(album_onclick_browse)">ActivateWindow(music,musicdb://albums/$INFO[ListItem.DBID]/,return)</value>
+		<value condition="Skin.HasSetting(album_onclick_play)">PlayMedia(musicdb://albums/$INFO[ListItem.DBID]/)</value>
+		<value>ActivateWindow(music,musicdb://albums/$INFO[ListItem.DBID]/,return)</value>
+	</variable>
 	<variable name="AddonLifecycleType">
 		<value condition="String.IsEqual(ListItem.AddonLifecycleType,$LOCALIZE[24170])">[COLOR button_focus]$LOCALIZE[24170][/COLOR][CR]$INFO[ListItem.AddonLifecycleDesc]</value> <!-- Deprecated -->
 		<value condition="String.IsEqual(ListItem.AddonLifecycleType,$LOCALIZE[24171])">[COLOR button_focus]$LOCALIZE[24171][/COLOR][CR]$INFO[ListItem.AddonLifecycleDesc]</value> <!-- Broken -->

--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -88,6 +88,7 @@ void CContextMenuManager::Init()
       std::make_shared<CONTEXTMENU::CRenameFavourite>(),
       std::make_shared<CONTEXTMENU::CRemoveFavourite>(),
       std::make_shared<CONTEXTMENU::CAddRemoveFavourite>(),
+      std::make_shared<CONTEXTMENU::CMusicBrowse>(),
       std::make_shared<CONTEXTMENU::CMusicPlay>(),
       std::make_shared<CONTEXTMENU::CMusicPlayNext>(),
       std::make_shared<CONTEXTMENU::CMusicQueue>(),

--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -88,6 +88,9 @@ void CContextMenuManager::Init()
       std::make_shared<CONTEXTMENU::CRenameFavourite>(),
       std::make_shared<CONTEXTMENU::CRemoveFavourite>(),
       std::make_shared<CONTEXTMENU::CAddRemoveFavourite>(),
+      std::make_shared<CONTEXTMENU::CMusicPlay>(),
+      std::make_shared<CONTEXTMENU::CMusicPlayNext>(),
+      std::make_shared<CONTEXTMENU::CMusicQueue>(),
   };
 
   ReloadAddonItems();

--- a/xbmc/music/ContextMenus.cpp
+++ b/xbmc/music/ContextMenus.cpp
@@ -9,14 +9,16 @@
 #include "ContextMenus.h"
 
 #include "FileItem.h"
+#include "ServiceBroker.h"
+#include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
+#include "music/MusicUtils.h"
 #include "music/dialogs/GUIDialogMusicInfo.h"
 #include "tags/MusicInfoTag.h"
 
 #include <utility>
 
-namespace CONTEXTMENU
-{
+using namespace CONTEXTMENU;
 
 CMusicInfo::CMusicInfo(MediaType mediaType)
   : CStaticContextMenuAction(19033), m_mediaType(std::move(mediaType))
@@ -36,4 +38,35 @@ bool CMusicInfo::Execute(const std::shared_ptr<CFileItem>& item) const
   return true;
 }
 
+bool CMusicPlay::IsVisible(const CFileItem& item) const
+{
+  return MUSIC_UTILS::IsItemPlayable(item);
+}
+
+bool CMusicPlay::Execute(const std::shared_ptr<CFileItem>& item) const
+{
+  MUSIC_UTILS::PlayItem(item);
+  return true;
+}
+
+bool CMusicPlayNext::IsVisible(const CFileItem& item) const
+{
+  return MUSIC_UTILS::IsItemPlayable(item);
+}
+
+bool CMusicPlayNext::Execute(const std::shared_ptr<CFileItem>& item) const
+{
+  MUSIC_UTILS::QueueItem(item, MUSIC_UTILS::QueuePosition::POSITION_BEGIN);
+  return true;
+}
+
+bool CMusicQueue::IsVisible(const CFileItem& item) const
+{
+  return MUSIC_UTILS::IsItemPlayable(item);
+}
+
+bool CMusicQueue::Execute(const std::shared_ptr<CFileItem>& item) const
+{
+  MUSIC_UTILS::QueueItem(item, MUSIC_UTILS::QueuePosition::POSITION_END);
+  return true;
 }

--- a/xbmc/music/ContextMenus.cpp
+++ b/xbmc/music/ContextMenus.cpp
@@ -9,6 +9,7 @@
 #include "ContextMenus.h"
 
 #include "FileItem.h"
+#include "GUIUserMessages.h"
 #include "ServiceBroker.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
@@ -35,6 +36,27 @@ bool CMusicInfo::IsVisible(const CFileItem& item) const
 bool CMusicInfo::Execute(const std::shared_ptr<CFileItem>& item) const
 {
   CGUIDialogMusicInfo::ShowFor(item.get());
+  return true;
+}
+
+bool CMusicBrowse::IsVisible(const CFileItem& item) const
+{
+  return item.m_bIsFolder && MUSIC_UTILS::IsItemPlayable(item);
+}
+
+bool CMusicBrowse::Execute(const std::shared_ptr<CFileItem>& item) const
+{
+  auto& windowMgr = CServiceBroker::GetGUI()->GetWindowManager();
+  if (windowMgr.GetActiveWindow() == WINDOW_MUSIC_NAV)
+  {
+    CGUIMessage msg(GUI_MSG_NOTIFY_ALL, WINDOW_MUSIC_NAV, 0, GUI_MSG_UPDATE);
+    msg.SetStringParam(item->GetPath());
+    windowMgr.SendMessage(msg);
+  }
+  else
+  {
+    windowMgr.ActivateWindow(WINDOW_MUSIC_NAV, {item->GetPath(), "return"});
+  }
   return true;
 }
 

--- a/xbmc/music/ContextMenus.h
+++ b/xbmc/music/ContextMenus.h
@@ -43,6 +43,13 @@ struct CSongInfo : CMusicInfo
   CSongInfo() : CMusicInfo(MediaTypeSong) {}
 };
 
+struct CMusicBrowse : CStaticContextMenuAction
+{
+  CMusicBrowse() : CStaticContextMenuAction(37015) {} // Browse into
+  bool IsVisible(const CFileItem& item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override;
+};
+
 struct CMusicPlay : CStaticContextMenuAction
 {
   CMusicPlay() : CStaticContextMenuAction(208) {} // Play

--- a/xbmc/music/ContextMenus.h
+++ b/xbmc/music/ContextMenus.h
@@ -13,6 +13,8 @@
 
 #include <memory>
 
+class CFileItem;
+
 namespace CONTEXTMENU
 {
 
@@ -41,4 +43,25 @@ struct CSongInfo : CMusicInfo
   CSongInfo() : CMusicInfo(MediaTypeSong) {}
 };
 
-}
+struct CMusicPlay : CStaticContextMenuAction
+{
+  CMusicPlay() : CStaticContextMenuAction(208) {} // Play
+  bool IsVisible(const CFileItem& item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override;
+};
+
+struct CMusicPlayNext : CStaticContextMenuAction
+{
+  CMusicPlayNext() : CStaticContextMenuAction(10008) {} // Play next
+  bool IsVisible(const CFileItem& item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override;
+};
+
+struct CMusicQueue : CStaticContextMenuAction
+{
+  CMusicQueue() : CStaticContextMenuAction(13347) {} // Queue item
+  bool IsVisible(const CFileItem& item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override;
+};
+
+} // namespace CONTEXTMENU

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -32,361 +32,369 @@ using namespace XFILE;
 
 namespace MUSIC_UTILS
 {
-  class CSetArtJob : public CJob
+class CSetArtJob : public CJob
+{
+  CFileItemPtr pItem;
+  std::string m_artType;
+  std::string m_newArt;
+
+public:
+  CSetArtJob(const CFileItemPtr& item, const std::string& type, const std::string& newArt)
+    : pItem(item), m_artType(type), m_newArt(newArt)
   {
-    CFileItemPtr pItem;
-    std::string m_artType;
-    std::string m_newArt;
-  public:
-    CSetArtJob(const CFileItemPtr& item, const std::string& type, const std::string& newArt)
-      : pItem(item), m_artType(type), m_newArt(newArt)
-    { }
+  }
 
-    ~CSetArtJob(void) override = default;
+  ~CSetArtJob(void) override = default;
 
-    bool HasSongExtraArtChanged(const CFileItemPtr& pSongItem,
-                                const std::string& type,
-                                const int itemID,
-                                CMusicDatabase& db)
+  bool HasSongExtraArtChanged(const CFileItemPtr& pSongItem,
+                              const std::string& type,
+                              const int itemID,
+                              CMusicDatabase& db)
+  {
+    if (!pSongItem->HasMusicInfoTag())
+      return false;
+    int idSong = pSongItem->GetMusicInfoTag()->GetDatabaseId();
+    if (idSong <= 0)
+      return false;
+    bool result = false;
+    if (type == MediaTypeAlbum)
+      // Update art when song is from album
+      result = (itemID == pSongItem->GetMusicInfoTag()->GetAlbumId());
+    else if (type == MediaTypeArtist)
     {
-      if (!pSongItem->HasMusicInfoTag())
-        return false;
-      int idSong = pSongItem->GetMusicInfoTag()->GetDatabaseId();
-      if (idSong <= 0)
-        return false;
-      bool result = false;
-      if (type == MediaTypeAlbum)
-        // Update art when song is from album
-        result = (itemID == pSongItem->GetMusicInfoTag()->GetAlbumId());
-      else if (type == MediaTypeArtist)
+      // Update art when artist is song or album artist of the song
+      if (pSongItem->HasProperty("artistid"))
       {
-        // Update art when artist is song or album artist of the song
-        if (pSongItem->HasProperty("artistid"))
+        // Check artistid property when we have it
+        for (CVariant::const_iterator_array varid =
+                 pSongItem->GetProperty("artistid").begin_array();
+             varid != pSongItem->GetProperty("artistid").end_array(); ++varid)
         {
-          // Check artistid property when we have it
-          for (CVariant::const_iterator_array varid =
-                   pSongItem->GetProperty("artistid").begin_array();
-               varid != pSongItem->GetProperty("artistid").end_array(); ++varid)
-          {
-            int idArtist = static_cast<int>(varid->asInteger());
-            result = (itemID == idArtist);
-            if (result)
-              break;
-          }
-        }
-        else
-        { // Check song artists in database
-          result = db.IsSongArtist(idSong, itemID);
-        }
-        if (!result)
-        {
-          // Check song album artists
-          result = db.IsSongAlbumArtist(idSong, itemID);
+          int idArtist = static_cast<int>(varid->asInteger());
+          result = (itemID == idArtist);
+          if (result)
+            break;
         }
       }
-      return result;
-    }
-
-    // Asynchronously update song, album or artist art in library
-    // and trigger update to album & artist art of the currently playing song
-    // and songs queued in the current playlist
-    bool DoWork(void) override
-    {
-      int itemID = pItem->GetMusicInfoTag()->GetDatabaseId();
-      if (itemID <= 0)
-        return false;
-      std::string type = pItem->GetMusicInfoTag()->GetType();
-      CMusicDatabase db;
-      if (!db.Open())
-        return false;
-      if (!m_newArt.empty())
-        db.SetArtForItem(itemID, type, m_artType, m_newArt);
       else
-        db.RemoveArtForItem(itemID, type, m_artType);
-      // Artwork changed so set datemodified field for artist, album or song
-      db.SetItemUpdated(itemID, type);
+      { // Check song artists in database
+        result = db.IsSongArtist(idSong, itemID);
+      }
+      if (!result)
+      {
+        // Check song album artists
+        result = db.IsSongAlbumArtist(idSong, itemID);
+      }
+    }
+    return result;
+  }
 
-      /* Update the art of the songs of the current music playlist.
+  // Asynchronously update song, album or artist art in library
+  // and trigger update to album & artist art of the currently playing song
+  // and songs queued in the current playlist
+  bool DoWork(void) override
+  {
+    int itemID = pItem->GetMusicInfoTag()->GetDatabaseId();
+    if (itemID <= 0)
+      return false;
+    std::string type = pItem->GetMusicInfoTag()->GetType();
+    CMusicDatabase db;
+    if (!db.Open())
+      return false;
+    if (!m_newArt.empty())
+      db.SetArtForItem(itemID, type, m_artType, m_newArt);
+    else
+      db.RemoveArtForItem(itemID, type, m_artType);
+    // Artwork changed so set datemodified field for artist, album or song
+    db.SetItemUpdated(itemID, type);
+
+    /* Update the art of the songs of the current music playlist.
       Song thumb is often a fallback from the album and fanart is from the artist(s).
       Clear the art if it is a song from the album or by the artist
       (as song or album artist) that has modified artwork. The new artwork gets
       loaded when the playlist is shown.
       */
-      bool clearcache(false);
-      const PLAYLIST::CPlayList& playlist =
-          CServiceBroker::GetPlaylistPlayer().GetPlaylist(PLAYLIST::TYPE_MUSIC);
+    bool clearcache(false);
+    const PLAYLIST::CPlayList& playlist =
+        CServiceBroker::GetPlaylistPlayer().GetPlaylist(PLAYLIST::TYPE_MUSIC);
 
-      for (int i = 0; i < playlist.size(); ++i)
+    for (int i = 0; i < playlist.size(); ++i)
+    {
+      CFileItemPtr songitem = playlist[i];
+      if (HasSongExtraArtChanged(songitem, type, itemID, db))
       {
-        CFileItemPtr songitem = playlist[i];
-        if (HasSongExtraArtChanged(songitem, type, itemID, db))
-        {
-          songitem->ClearArt(); // Art gets reloaded when the current playist is shown
-          clearcache = true;
-        }
+        songitem->ClearArt(); // Art gets reloaded when the current playist is shown
+        clearcache = true;
       }
-      if (clearcache)
-      {
-        // Clear the music playlist from cache
-        CFileItemList items("playlistmusic://");
-        items.RemoveDiscCache(WINDOW_MUSIC_PLAYLIST);
-      }
-
-      // Similarly update the art of the currently playing song so it shows on OSD
-      const auto& components = CServiceBroker::GetAppComponents();
-      const auto appPlayer = components.GetComponent<CApplicationPlayer>();
-      if (appPlayer->IsPlayingAudio() && g_application.CurrentFileItem().HasMusicInfoTag())
-      {
-        CFileItemPtr songitem = CFileItemPtr(new CFileItem(g_application.CurrentFileItem()));
-        if (HasSongExtraArtChanged(songitem, type, itemID, db))
-          g_application.UpdateCurrentPlayArt();
-      }
-
-      db.Close();
-      return true;
     }
-  };
-
-  class CSetSongRatingJob : public CJob
-  {
-    std::string strPath;
-    int idSong;
-    int iUserrating;
-  public:
-    CSetSongRatingJob(const std::string& filePath, int userrating) :
-      strPath(filePath),
-      idSong(-1),
-      iUserrating(userrating)
-    { }
-
-    CSetSongRatingJob(int songId, int userrating) :
-      strPath(),
-      idSong(songId),
-      iUserrating(userrating)
-    { }
-
-    ~CSetSongRatingJob(void) override = default;
-
-    bool DoWork(void) override
+    if (clearcache)
     {
-      // Asynchronously update song userrating in library
-      CMusicDatabase db;
-      if (db.Open())
-      {
-        if (idSong > 0)
-          db.SetSongUserrating(idSong, iUserrating);
-        else
-          db.SetSongUserrating(strPath, iUserrating);
-        db.Close();
-      }
-
-      return true;
+      // Clear the music playlist from cache
+      CFileItemList items("playlistmusic://");
+      items.RemoveDiscCache(WINDOW_MUSIC_PLAYLIST);
     }
-  };
 
-  void UpdateArtJob(const std::shared_ptr<CFileItem>& pItem,
-                    const std::string& strType,
-                    const std::string& strArt)
-  {
-    // Asynchronously update that type of art in the database
-    CSetArtJob *job = new CSetArtJob(pItem, strType, strArt);
-    CServiceBroker::GetJobManager()->AddJob(job, nullptr);
-  }
-
-  // Add art types required in Kodi and configured by the user
-  void AddHardCodedAndExtendedArtTypes(std::vector<std::string>& artTypes, const CMusicInfoTag& tag)
-  {
-    for (const auto& artType : GetArtTypesToScan(tag.GetType()))
+    // Similarly update the art of the currently playing song so it shows on OSD
+    const auto& components = CServiceBroker::GetAppComponents();
+    const auto appPlayer = components.GetComponent<CApplicationPlayer>();
+    if (appPlayer->IsPlayingAudio() && g_application.CurrentFileItem().HasMusicInfoTag())
     {
-      if (find(artTypes.begin(), artTypes.end(), artType) == artTypes.end())
-        artTypes.push_back(artType);
+      CFileItemPtr songitem = CFileItemPtr(new CFileItem(g_application.CurrentFileItem()));
+      if (HasSongExtraArtChanged(songitem, type, itemID, db))
+        g_application.UpdateCurrentPlayArt();
     }
-  }
-
-  // Add art types currently assigned to the media item
-  void AddCurrentArtTypes(std::vector<std::string>& artTypes, const CMusicInfoTag& tag,
-    CMusicDatabase& db)
-  {
-    std::map<std::string, std::string> currentArt;
-    db.GetArtForItem(tag.GetDatabaseId(), tag.GetType(), currentArt);
-    for (const auto& art : currentArt)
-    {
-      if (!art.second.empty() && find(artTypes.begin(), artTypes.end(), art.first) == artTypes.end())
-        artTypes.push_back(art.first);
-    }
-  }
-
-  // Add art types that exist for other media items of the same type
-  void AddMediaTypeArtTypes(std::vector<std::string>& artTypes, const CMusicInfoTag& tag,
-    CMusicDatabase& db)
-  {
-    std::vector<std::string> dbArtTypes;
-    db.GetArtTypes(tag.GetType(), dbArtTypes);
-    for (const auto& artType : dbArtTypes)
-    {
-      if (find(artTypes.begin(), artTypes.end(), artType) == artTypes.end())
-        artTypes.push_back(artType);
-    }
-  }
-
-  // Add art types from available but unassigned artwork for this media item
-  void AddAvailableArtTypes(std::vector<std::string>& artTypes, const CMusicInfoTag& tag,
-    CMusicDatabase& db)
-  {
-    for (const auto& artType : db.GetAvailableArtTypesForItem(tag.GetDatabaseId(), tag.GetType()))
-    {
-      if (find(artTypes.begin(), artTypes.end(), artType) == artTypes.end())
-        artTypes.push_back(artType);
-    }
-  }
-
-  bool FillArtTypesList(CFileItem& musicitem, CFileItemList& artlist)
-  {
-    const CMusicInfoTag& tag = *musicitem.GetMusicInfoTag();
-    if (tag.GetDatabaseId() < 1 || tag.GetType().empty())
-      return false;
-    if (tag.GetType() != MediaTypeArtist && tag.GetType() != MediaTypeAlbum && tag.GetType() != MediaTypeSong)
-      return false;
-
-    artlist.Clear();
-
-    CMusicDatabase db;
-    db.Open();
-
-    std::vector<std::string> artTypes;
-
-    AddHardCodedAndExtendedArtTypes(artTypes, tag);
-    AddCurrentArtTypes(artTypes, tag, db);
-    AddMediaTypeArtTypes(artTypes, tag, db);
-    AddAvailableArtTypes(artTypes, tag, db);
 
     db.Close();
+    return true;
+  }
+};
 
-    for (const auto& type : artTypes)
-    {
-      CFileItemPtr artitem(new CFileItem(type, false));
-      // Localise the names of common types of art
-      if (type == "banner")
-        artitem->SetLabel(g_localizeStrings.Get(20020));
-      else if (type == "fanart")
-        artitem->SetLabel(g_localizeStrings.Get(20445));
-      else if (type == "poster")
-        artitem->SetLabel(g_localizeStrings.Get(20021));
-      else if (type == "thumb")
-        artitem->SetLabel(g_localizeStrings.Get(21371));
-      else
-        artitem->SetLabel(type);
-      // Set art type as art item property
-      artitem->SetProperty("arttype", type);
-      // Set current art as art item thumb
-      if (musicitem.HasArt(type))
-        artitem->SetArt("thumb", musicitem.GetArt(type));
-      artlist.Add(artitem);
-    }
+class CSetSongRatingJob : public CJob
+{
+  std::string strPath;
+  int idSong;
+  int iUserrating;
 
-    return !artlist.IsEmpty();
+public:
+  CSetSongRatingJob(const std::string& filePath, int userrating)
+    : strPath(filePath), idSong(-1), iUserrating(userrating)
+  {
   }
 
-  std::string ShowSelectArtTypeDialog(CFileItemList& artitems)
+  CSetSongRatingJob(int songId, int userrating) : strPath(), idSong(songId), iUserrating(userrating)
   {
-    // Prompt for choice
-    CGUIDialogSelect *dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
-    if (!dialog)
+  }
+
+  ~CSetSongRatingJob(void) override = default;
+
+  bool DoWork(void) override
+  {
+    // Asynchronously update song userrating in library
+    CMusicDatabase db;
+    if (db.Open())
+    {
+      if (idSong > 0)
+        db.SetSongUserrating(idSong, iUserrating);
+      else
+        db.SetSongUserrating(strPath, iUserrating);
+      db.Close();
+    }
+
+    return true;
+  }
+};
+
+void UpdateArtJob(const std::shared_ptr<CFileItem>& pItem,
+                  const std::string& strType,
+                  const std::string& strArt)
+{
+  // Asynchronously update that type of art in the database
+  CSetArtJob* job = new CSetArtJob(pItem, strType, strArt);
+  CServiceBroker::GetJobManager()->AddJob(job, nullptr);
+}
+
+// Add art types required in Kodi and configured by the user
+void AddHardCodedAndExtendedArtTypes(std::vector<std::string>& artTypes, const CMusicInfoTag& tag)
+{
+  for (const auto& artType : GetArtTypesToScan(tag.GetType()))
+  {
+    if (find(artTypes.begin(), artTypes.end(), artType) == artTypes.end())
+      artTypes.push_back(artType);
+  }
+}
+
+// Add art types currently assigned to the media item
+void AddCurrentArtTypes(std::vector<std::string>& artTypes,
+                        const CMusicInfoTag& tag,
+                        CMusicDatabase& db)
+{
+  std::map<std::string, std::string> currentArt;
+  db.GetArtForItem(tag.GetDatabaseId(), tag.GetType(), currentArt);
+  for (const auto& art : currentArt)
+  {
+    if (!art.second.empty() && find(artTypes.begin(), artTypes.end(), art.first) == artTypes.end())
+      artTypes.push_back(art.first);
+  }
+}
+
+// Add art types that exist for other media items of the same type
+void AddMediaTypeArtTypes(std::vector<std::string>& artTypes,
+                          const CMusicInfoTag& tag,
+                          CMusicDatabase& db)
+{
+  std::vector<std::string> dbArtTypes;
+  db.GetArtTypes(tag.GetType(), dbArtTypes);
+  for (const auto& artType : dbArtTypes)
+  {
+    if (find(artTypes.begin(), artTypes.end(), artType) == artTypes.end())
+      artTypes.push_back(artType);
+  }
+}
+
+// Add art types from available but unassigned artwork for this media item
+void AddAvailableArtTypes(std::vector<std::string>& artTypes,
+                          const CMusicInfoTag& tag,
+                          CMusicDatabase& db)
+{
+  for (const auto& artType : db.GetAvailableArtTypesForItem(tag.GetDatabaseId(), tag.GetType()))
+  {
+    if (find(artTypes.begin(), artTypes.end(), artType) == artTypes.end())
+      artTypes.push_back(artType);
+  }
+}
+
+bool FillArtTypesList(CFileItem& musicitem, CFileItemList& artlist)
+{
+  const CMusicInfoTag& tag = *musicitem.GetMusicInfoTag();
+  if (tag.GetDatabaseId() < 1 || tag.GetType().empty())
+    return false;
+  if (tag.GetType() != MediaTypeArtist && tag.GetType() != MediaTypeAlbum &&
+      tag.GetType() != MediaTypeSong)
+    return false;
+
+  artlist.Clear();
+
+  CMusicDatabase db;
+  db.Open();
+
+  std::vector<std::string> artTypes;
+
+  AddHardCodedAndExtendedArtTypes(artTypes, tag);
+  AddCurrentArtTypes(artTypes, tag, db);
+  AddMediaTypeArtTypes(artTypes, tag, db);
+  AddAvailableArtTypes(artTypes, tag, db);
+
+  db.Close();
+
+  for (const auto& type : artTypes)
+  {
+    CFileItemPtr artitem(new CFileItem(type, false));
+    // Localise the names of common types of art
+    if (type == "banner")
+      artitem->SetLabel(g_localizeStrings.Get(20020));
+    else if (type == "fanart")
+      artitem->SetLabel(g_localizeStrings.Get(20445));
+    else if (type == "poster")
+      artitem->SetLabel(g_localizeStrings.Get(20021));
+    else if (type == "thumb")
+      artitem->SetLabel(g_localizeStrings.Get(21371));
+    else
+      artitem->SetLabel(type);
+    // Set art type as art item property
+    artitem->SetProperty("arttype", type);
+    // Set current art as art item thumb
+    if (musicitem.HasArt(type))
+      artitem->SetArt("thumb", musicitem.GetArt(type));
+    artlist.Add(artitem);
+  }
+
+  return !artlist.IsEmpty();
+}
+
+std::string ShowSelectArtTypeDialog(CFileItemList& artitems)
+{
+  // Prompt for choice
+  CGUIDialogSelect* dialog =
+      CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(
+          WINDOW_DIALOG_SELECT);
+  if (!dialog)
+    return "";
+
+  dialog->SetHeading(CVariant{13521});
+  dialog->Reset();
+  dialog->SetUseDetails(true);
+  dialog->EnableButton(true, 13516);
+
+  dialog->SetItems(artitems);
+  dialog->Open();
+
+  if (dialog->IsButtonPressed())
+  {
+    // Get the new art type name
+    std::string strArtTypeName;
+    if (!CGUIKeyboardFactory::ShowAndGetInput(strArtTypeName,
+                                              CVariant{g_localizeStrings.Get(13516)}, false))
       return "";
+    // Add new type to the list of art types
+    CFileItemPtr artitem(new CFileItem(strArtTypeName, false));
+    artitem->SetLabel(strArtTypeName);
+    artitem->SetProperty("arttype", strArtTypeName);
+    artitems.Add(artitem);
 
-    dialog->SetHeading(CVariant{ 13521 });
-    dialog->Reset();
-    dialog->SetUseDetails(true);
-    dialog->EnableButton(true, 13516);
+    return strArtTypeName;
+  }
 
-    dialog->SetItems(artitems);
+  return dialog->GetSelectedFileItem()->GetProperty("arttype").asString();
+}
+
+int ShowSelectRatingDialog(int iSelected)
+{
+  CGUIDialogSelect* dialog =
+      CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(
+          WINDOW_DIALOG_SELECT);
+  if (dialog)
+  {
+    dialog->SetHeading(CVariant{38023});
+    dialog->Add(g_localizeStrings.Get(38022));
+    for (int i = 1; i <= 10; i++)
+      dialog->Add(StringUtils::Format("{}: {}", g_localizeStrings.Get(563), i));
+    dialog->SetSelected(iSelected);
     dialog->Open();
 
-    if (dialog->IsButtonPressed())
-    {
-      // Get the new art type name
-      std::string strArtTypeName;
-      if (!CGUIKeyboardFactory::ShowAndGetInput(strArtTypeName, CVariant{ g_localizeStrings.Get(13516) }, false))
-        return "";
-      // Add new type to the list of art types
-      CFileItemPtr artitem(new CFileItem(strArtTypeName, false));
-      artitem->SetLabel(strArtTypeName);
-      artitem->SetProperty("arttype", strArtTypeName);
-      artitems.Add(artitem);
-
-      return strArtTypeName;
-    }
-
-    return dialog->GetSelectedFileItem()->GetProperty("arttype").asString();
+    int userrating = dialog->GetSelectedItem();
+    userrating = std::max(userrating, -1);
+    userrating = std::min(userrating, 10);
+    return userrating;
   }
+  return -1;
+}
 
-  int ShowSelectRatingDialog(int iSelected)
+void UpdateSongRatingJob(const std::shared_ptr<CFileItem>& pItem, int userrating)
+{
+  // Asynchronously update the song user rating in music library
+  const CMusicInfoTag* tag = pItem->GetMusicInfoTag();
+  CSetSongRatingJob* job;
+  if (tag && tag->GetType() == MediaTypeSong && tag->GetDatabaseId() > 0)
+    // Use song ID when known
+    job = new CSetSongRatingJob(tag->GetDatabaseId(), userrating);
+  else
+    job = new CSetSongRatingJob(pItem->GetPath(), userrating);
+  CServiceBroker::GetJobManager()->AddJob(job, nullptr);
+}
+
+std::vector<std::string> GetArtTypesToScan(const MediaType& mediaType)
+{
+  std::vector<std::string> arttypes;
+  // Get default types of art that are to be automatically fetched during scanning
+  if (mediaType == MediaTypeArtist)
   {
-    CGUIDialogSelect *dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
-    if (dialog)
+    arttypes = {"thumb", "fanart"};
+    for (auto& artType : CServiceBroker::GetSettingsComponent()->GetSettings()->GetList(
+             CSettings::SETTING_MUSICLIBRARY_ARTISTART_WHITELIST))
     {
-      dialog->SetHeading(CVariant{ 38023 });
-      dialog->Add(g_localizeStrings.Get(38022));
-      for (int i = 1; i <= 10; i++)
-        dialog->Add(StringUtils::Format("{}: {}", g_localizeStrings.Get(563), i));
-      dialog->SetSelected(iSelected);
-      dialog->Open();
-
-      int userrating = dialog->GetSelectedItem();
-      userrating = std::max(userrating, -1);
-      userrating = std::min(userrating, 10);
-      return userrating;
+      if (find(arttypes.begin(), arttypes.end(), artType.asString()) == arttypes.end())
+        arttypes.emplace_back(artType.asString());
     }
-    return -1;
   }
-
-  void UpdateSongRatingJob(const std::shared_ptr<CFileItem>& pItem, int userrating)
+  else if (mediaType == MediaTypeAlbum)
   {
-    // Asynchronously update the song user rating in music library
-    const CMusicInfoTag *tag = pItem->GetMusicInfoTag();
-    CSetSongRatingJob *job;
-    if (tag && tag->GetType() == MediaTypeSong && tag->GetDatabaseId() > 0)
-      // Use song ID when known
-      job = new CSetSongRatingJob(tag->GetDatabaseId(), userrating);
-    else
-      job = new CSetSongRatingJob(pItem->GetPath(), userrating);
-    CServiceBroker::GetJobManager()->AddJob(job, nullptr);
-  }
-
-  std::vector<std::string> GetArtTypesToScan(const MediaType& mediaType)
-  {
-    std::vector<std::string> arttypes;
-    // Get default types of art that are to be automatically fetched during scanning
-    if (mediaType == MediaTypeArtist)
+    arttypes = {"thumb"};
+    for (auto& artType : CServiceBroker::GetSettingsComponent()->GetSettings()->GetList(
+             CSettings::SETTING_MUSICLIBRARY_ALBUMART_WHITELIST))
     {
-      arttypes = { "thumb", "fanart" };
-      for (auto& artType : CServiceBroker::GetSettingsComponent()->GetSettings()->GetList(
-        CSettings::SETTING_MUSICLIBRARY_ARTISTART_WHITELIST))
-      {
-        if (find(arttypes.begin(), arttypes.end(), artType.asString()) == arttypes.end())
-          arttypes.emplace_back(artType.asString());
-      }
+      if (find(arttypes.begin(), arttypes.end(), artType.asString()) == arttypes.end())
+        arttypes.emplace_back(artType.asString());
     }
-    else if (mediaType == MediaTypeAlbum)
-    {
-      arttypes = { "thumb" };
-      for (auto& artType :
-        CServiceBroker::GetSettingsComponent()->GetSettings()->GetList(
-          CSettings::SETTING_MUSICLIBRARY_ALBUMART_WHITELIST))
-      {
-        if (find(arttypes.begin(), arttypes.end(), artType.asString()) == arttypes.end())
-          arttypes.emplace_back(artType.asString());
-      }
-    }
-    return arttypes;
   }
+  return arttypes;
+}
 
-  bool IsValidArtType(const std::string& potentialArtType)
-  {
-    // Check length and is ascii
-    return potentialArtType.length() <= 25 &&
-                 std::find_if_not(potentialArtType.begin(), potentialArtType.end(),
-                                  StringUtils::isasciialphanum) == potentialArtType.end();
-  }
+bool IsValidArtType(const std::string& potentialArtType)
+{
+  // Check length and is ascii
+  return potentialArtType.length() <= 25 &&
+         std::find_if_not(potentialArtType.begin(), potentialArtType.end(),
+                          StringUtils::isasciialphanum) == potentialArtType.end();
+}
 
-  } // namespace MUSIC_UTILS
+} // namespace MUSIC_UTILS

--- a/xbmc/music/MusicUtils.h
+++ b/xbmc/music/MusicUtils.h
@@ -61,8 +61,8 @@ void UpdateArtJob(const std::shared_ptr<CFileItem>& pItem,
 int ShowSelectRatingDialog(int iSelected);
 
 /*! \brief Helper function to asynchronously update the user rating of a song
-\param pItem pointer to song item being rated
-\param userrating the userrating 0 = no rating, 1 to 10
+  \param pItem pointer to song item being rated
+  \param userrating the userrating 0 = no rating, 1 to 10
   */
 void UpdateSongRatingJob(const std::shared_ptr<CFileItem>& pItem, int userrating);
 
@@ -75,9 +75,46 @@ std::vector<std::string> GetArtTypesToScan(const MediaType& mediaType);
 
 /*! \brief Validate string is acceptable as the name of an additional art type
   - limited length, and ascii alphanumberic characters only
-\param potentialArtType [in] potential art type name
-\return true if the art type is valid
+  \param potentialArtType [in] potential art type name
+  \return true if the art type is valid
   */
 bool IsValidArtType(const std::string& potentialArtType);
+
+/*! \brief Start playback of the given item. If the item is a folder, build a playlist with
+  all items contained in the folder and start playback of the playlist. If item is a single music
+  item, start playback directly, without adding it to the music playlist first.
+  \param item [in] the item to play
+  */
+void PlayItem(const std::shared_ptr<CFileItem>& item);
+
+enum class QueuePosition
+{
+  POSITION_BEGIN, // place at begin of queue, before other items
+  POSITION_END, // place at end of queue, after other items
+};
+
+/*! \brief Queue the given item in the currently active playlist. If none is active, put the
+  item into the music playlist. Start playback of the playlist, if player is not already playing.
+  \param item [in] the item to queue
+  \param pos [in] whether to place the item and the begin or the end of the queue
+  */
+void QueueItem(const std::shared_ptr<CFileItem>& item, QueuePosition pos);
+
+/*! \brief For a given item, get the items to put in a playlist. If the item is a folder, all
+  subitems will be added recursively to the returned item list. If the item is a playlist, the
+  playlist will be loaded and contained items will be added to the returned item list. Shows a
+  busy dialog if action takes certain amount of time to give the user visual feedback.
+  \param item [in] the item to add to the playlist
+  \param queuedItems [out] the items that can be put in a play list
+  \return true on success, false otherwise
+  */
+bool GetItemsForPlayList(const std::shared_ptr<CFileItem>& item, CFileItemList& queuedItems);
+
+/*!
+ \brief Check whether the given item can be played by the app playlist player as one or more songs.
+ \param item The item to check
+ \return True if playable, false otherwise.
+ */
+bool IsItemPlayable(const CFileItem& item);
 
 } // namespace MUSIC_UTILS

--- a/xbmc/music/MusicUtils.h
+++ b/xbmc/music/MusicUtils.h
@@ -19,7 +19,7 @@ class CFileItemList;
 
 namespace MUSIC_UTILS
 {
-  /*! \brief Show a dialog to allow the selection of type of art from a list.
+/*! \brief Show a dialog to allow the selection of type of art from a list.
   Input is a fileitem list, with each item having an "arttype" property
   e.g. "thumb", current art URL (if art exists), and label. One of these art types
   can be selected, or a new art type added. The new art type is added as a new item
@@ -28,9 +28,9 @@ namespace MUSIC_UTILS
   \return the selected art type e.g. "fanart" or empty string when cancelled.
   \sa FillArtTypesList
   */
-  std::string ShowSelectArtTypeDialog(CFileItemList& artitems);
+std::string ShowSelectArtTypeDialog(CFileItemList& artitems);
 
-  /*! \brief Helper function to build a list of art types for a music library item.
+/*! \brief Helper function to build a list of art types for a music library item.
   This fetches the possible types of art for a song, album or artist, and the
   current art URL (if the item has art of that type), for display on a dialog.
   \param musicitem a music CFileItem (song, album or artist)
@@ -39,9 +39,9 @@ namespace MUSIC_UTILS
   \return true if art types are retrieved, false if none is found.
   \sa ShowSelectArtTypeDialog
   */
-  bool FillArtTypesList(CFileItem& musicitem, CFileItemList& artlist);
+bool FillArtTypesList(CFileItem& musicitem, CFileItemList& artlist);
 
-  /*! \brief Helper function to asynchronously update art in the music database
+/*! \brief Helper function to asynchronously update art in the music database
   and then refresh the album & artist art of the currently playing song.
   For the song, album or artist this adds a job to the queue to update the art table
   modifying, adding or deleting that type of art. Changes to album or artist art are
@@ -50,34 +50,34 @@ namespace MUSIC_UTILS
   \param strType the type of art e.g. "fanart" or "thumb" etc.
   \param strArt art URL, when empty the entry for that type of art is deleted.
   */
-  void UpdateArtJob(const std::shared_ptr<CFileItem>& pItem,
-                    const std::string& strType,
-                    const std::string& strArt);
+void UpdateArtJob(const std::shared_ptr<CFileItem>& pItem,
+                  const std::string& strType,
+                  const std::string& strArt);
 
-  /*! \brief Show a dialog to allow the selection of user rating.
+/*! \brief Show a dialog to allow the selection of user rating.
   \param iSelected the rating to show initially
   \return the selected rating, 0 (no rating), 1 to 10 or -1 no rating selected
   */
-  int ShowSelectRatingDialog(int iSelected);
+int ShowSelectRatingDialog(int iSelected);
 
 /*! \brief Helper function to asynchronously update the user rating of a song
 \param pItem pointer to song item being rated
 \param userrating the userrating 0 = no rating, 1 to 10
-*/
-  void UpdateSongRatingJob(const std::shared_ptr<CFileItem>& pItem, int userrating);
+  */
+void UpdateSongRatingJob(const std::shared_ptr<CFileItem>& pItem, int userrating);
 
-  /*! \brief Get the types of art for an artist or album that are to be
+/*! \brief Get the types of art for an artist or album that are to be
   automatically fetched from local files during scanning
   \param mediaType [in] artist or album
   \return vector of art types that are to be fetched during scanning
   */
-  std::vector<std::string> GetArtTypesToScan(const MediaType& mediaType);
+std::vector<std::string> GetArtTypesToScan(const MediaType& mediaType);
 
-  /*! \brief Validate string is acceptable as the name of an additional art type
+/*! \brief Validate string is acceptable as the name of an additional art type
   - limited length, and ascii alphanumberic characters only
-  \param potentialArtType [in] potential art type name
- \return true if the art type is valid
- */
-  bool IsValidArtType(const std::string& potentialArtType);
+\param potentialArtType [in] potential art type name
+\return true if the art type is valid
+  */
+bool IsValidArtType(const std::string& potentialArtType);
 
-  } // namespace MUSIC_UTILS
+} // namespace MUSIC_UTILS

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -50,6 +50,7 @@ using namespace KODI::MESSAGING;
 
 #define CONTROL_BTN_REFRESH      6
 #define CONTROL_USERRATING       7
+#define CONTROL_BTN_PLAY 8
 #define CONTROL_BTN_GET_THUMB   10
 #define CONTROL_ARTISTINFO      12
 
@@ -407,6 +408,29 @@ bool CGUIDialogMusicInfo::OnMessage(CGUIMessage& message)
           }
         }
       }
+      else if (iControl == CONTROL_BTN_PLAY)
+      {
+        if (m_album.idAlbum >= 0)
+        {
+          // Play album
+          const std::string path = StringUtils::Format("musicdb://albums/{}", m_album.idAlbum);
+          OnPlayItem(std::make_shared<CFileItem>(path, m_album));
+          return true;
+        }
+        else
+        {
+          CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), iControl);
+          CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
+          const int iItem = msg.GetParam1();
+          if (iItem >= 0 && iItem < m_albumSongs->Size())
+          {
+            // Play selected song
+            OnPlayItem(m_albumSongs->Get(iItem));
+            return true;
+          }
+        }
+        return false;
+      }
     }
     break;
   }
@@ -552,11 +576,13 @@ void CGUIDialogMusicInfo::OnInitWindow()
   SET_CONTROL_LABEL(CONTROL_USERRATING, 38023);
   SET_CONTROL_LABEL(CONTROL_BTN_GET_THUMB, 13511);
   SET_CONTROL_LABEL(CONTROL_ARTISTINFO, 21891);
+  SET_CONTROL_LABEL(CONTROL_BTN_PLAY, 208);
 
   if (m_bArtistInfo)
   {
     SET_CONTROL_HIDDEN(CONTROL_ARTISTINFO);
     SET_CONTROL_HIDDEN(CONTROL_USERRATING);
+    SET_CONTROL_HIDDEN(CONTROL_BTN_PLAY);
   }
   CGUIDialog::OnInitWindow();
 }
@@ -1008,4 +1034,10 @@ void CGUIDialogMusicInfo::ShowFor(CFileItem* pItem)
         }
       }
     }
+}
+
+void CGUIDialogMusicInfo::OnPlayItem(const std::shared_ptr<CFileItem>& item)
+{
+  Close(true);
+  MUSIC_UTILS::PlayItem(item);
 }

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.h
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.h
@@ -62,6 +62,7 @@ protected:
   void OnArtistInfo(int id);
   void OnSetUserrating() const;
   void SetUserrating(int userrating) const;
+  void OnPlayItem(const std::shared_ptr<CFileItem>& item);
 
   CAlbum m_album;
   CArtist m_artist;

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -32,6 +32,7 @@
 
 #define CONTROL_BTN_REFRESH       6
 #define CONTROL_USERRATING        7
+#define CONTROL_BTN_PLAY 8
 #define CONTROL_BTN_GET_THUMB     10
 #define CONTROL_ALBUMINFO         12
 
@@ -183,6 +184,12 @@ bool CGUIDialogSongInfo::OnMessage(CGUIMessage& message)
           return true;
         }
       }
+      else if (iControl == CONTROL_BTN_PLAY)
+      {
+        OnPlaySong(m_song);
+        return true;
+      }
+      return false;
     }
     break;
   }
@@ -245,6 +252,7 @@ void CGUIDialogSongInfo::OnInitWindow()
   SET_CONTROL_LABEL(CONTROL_USERRATING, 38023);
   SET_CONTROL_LABEL(CONTROL_BTN_GET_THUMB, 13511);
   SET_CONTROL_LABEL(CONTROL_ALBUMINFO, 10523);
+  SET_CONTROL_LABEL(CONTROL_BTN_PLAY, 208);
 
   CGUIDialog::OnInitWindow();
 }
@@ -506,5 +514,10 @@ void CGUIDialogSongInfo::ShowFor(CFileItem* pItem)
       }
     }
   }
+}
 
+void CGUIDialogSongInfo::OnPlaySong(const std::shared_ptr<CFileItem>& item)
+{
+  Close(true);
+  MUSIC_UTILS::PlayItem(item);
 }

--- a/xbmc/music/dialogs/GUIDialogSongInfo.h
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.h
@@ -12,6 +12,8 @@
 #include "guilib/GUIDialog.h"
 #include "threads/Event.h"
 
+#include <memory>
+
 class CGUIDialogSongInfo :
       public CGUIDialog
 {
@@ -39,6 +41,7 @@ protected:
   void OnGetArt();
   void SetUserrating(int userrating);
   void OnSetUserrating();
+  void OnPlaySong(const std::shared_ptr<CFileItem>& item);
 
   CFileItemPtr m_song;
   CFileItemList m_artTypeList;

--- a/xbmc/music/windows/GUIWindowMusicBase.h
+++ b/xbmc/music/windows/GUIWindowMusicBase.h
@@ -70,8 +70,7 @@ protected:
 
   bool GetDirectory(const std::string &strDirectory, CFileItemList &items) override;
   virtual void OnRetrieveMusicInfo(CFileItemList& items);
-  void OnPrepareFileItems(CFileItemList &items) override;
-  void AddItemToPlayList(const CFileItemPtr &pItem, CFileItemList &queuedItems);
+  void OnPrepareFileItems(CFileItemList& items) override;
   void OnRipCD();
   std::string GetStartFolder(const std::string &dir) override;
   void OnItemLoaded(CFileItem* pItem) override {}

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
@@ -19,6 +19,7 @@
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/LocalizeStrings.h"
 #include "input/Key.h"
+#include "music/MusicUtils.h"
 #include "playlists/PlayListM3U.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -256,7 +257,7 @@ void CGUIWindowMusicPlaylistEditor::OnQueueItem(int iItem, bool)
   // and thus want a different layout for each item
   CFileItemPtr item(new CFileItem(*m_vecItems->Get(iItem)));
   CFileItemList newItems;
-  AddItemToPlayList(item, newItems);
+  MUSIC_UTILS::GetItemsForPlayList(item, newItems);
   AppendToPlaylist(newItems);
 }
 
@@ -431,4 +432,19 @@ void CGUIWindowMusicPlaylistEditor::OnPlaylistContext()
     OnMovePlaylistItem(item, 1);
   else if (btnid == CONTEXT_BUTTON_DELETE)
     OnDeletePlaylistItem(item);
+}
+
+bool CGUIWindowMusicPlaylistEditor::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
+{
+  switch (button)
+  {
+    case CONTEXT_BUTTON_QUEUE_ITEM:
+      OnQueueItem(itemNumber);
+      return true;
+
+    default:
+      break;
+  }
+
+  return CGUIWindowMusicBase::OnContextButton(itemNumber, button);
 }

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.h
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.h
@@ -28,7 +28,8 @@ protected:
   void UpdateButtons() override;
   bool Update(const std::string &strDirectory, bool updateFilterPath = true) override;
   void OnPrepareFileItems(CFileItemList &items) override;
-  void OnQueueItem(int iItem, bool) override;
+  bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
+  void OnQueueItem(int iItem, bool first = false) override;
   std::string GetStartFolder(const std::string& dir) override { return ""; }
 
   void OnSourcesContext();


### PR DESCRIPTION
This is somehow a followup for #20919 

@the-black-eagle had some very cool ideas how to enhance music context menus in general and Estuary home screen music item behavior (esp. click on albums) and I offered my help to get the initial implementation into shape. The result is this PR. Thanks @the-black-eagle that you have not taken offense because I took over and restarted with a new PR (we discussed this beforehand on Slack). For me it was the best way to understand how things work.

Okay, what's in here?

* music context menu items 'Play', 'Queue', Play next' and 'Browse into' are now available not only where they appeared before this PR in the Music windows, but also in the respective Estuary Home screen items (like 'Recently played albums').

![screenshot00001](https://user-images.githubusercontent.com/3226626/196735552-1ea2b1d5-0260-4213-9fb5-4af5955420dc.png)

* display a toast notification when something was added to the music playlist via context menu (only, if the queuing did not automatically start playback as that should be enough feedback for the user already)

![screenshot00005](https://user-images.githubusercontent.com/3226626/196735842-ca5faf58-ca50-4cd2-a934-3dd0783472c8.png)
![screenshot00002](https://user-images.githubusercontent.com/3226626/196735881-edbb0bee-cb93-4fb3-b5a5-ebe2503bd3fa.png)

* Add support to play complete albums directly from the Music and Song Info dialogs, making the 'script.album' external dependency in Estuary obsolete.

![screenshot00006](https://user-images.githubusercontent.com/3226626/196736684-bc204602-640e-4292-b711-26ec6dd4a2ba.png)
![screenshot00008](https://user-images.githubusercontent.com/3226626/196736712-cfd82c3b-fd49-4ba5-b453-e35d6c6a457f.png)

* Add an Estuary skin setting to control the default click action for music albums.

![screenshot00003](https://user-images.githubusercontent.com/3226626/196733606-7adf8f7d-167d-458a-a02a-fb067966ade4.png)
![screenshot00004](https://user-images.githubusercontent.com/3226626/196733630-6c616c3e-324d-4c35-8796-5ccf86f63c6c.png)

I tried to keep the different features in separate commits, so that review should somehow be not to difficult.

@the-black-eagle I would be thankful for comments and a runtime test/bug reports.

@enen92 might be interested in a code review.

@ronie wants to take a look at the Estuary changes I guess.

@DaveTBlake seems to be MIA, so I feel like we will not hear from him anytime soon. But in case you are listening, your feedback would be highly appreciated.