### PR TITLE
[Windows] fix refresh rate not switch back to 60Hz/GUI after HDR toggle on Windows 11 22H2

### DIFF
--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -1288,9 +1288,10 @@ HDR_STATUS DX::DeviceResources::ToggleHDR()
   DXGI_MODE_DESC md = {};
   GetDisplayMode(&md);
 
-  // Toggle display HDR
+  DX::Windowing()->SetTogglingHDR(true);
   DX::Windowing()->SetAlteringWindow(true);
 
+  // Toggle display HDR
   HDR_STATUS hdrStatus = CWIN32Util::ToggleWindowsHDR(md);
 
   // Kill swapchain

--- a/xbmc/windowing/win10/WinSystemWin10.h
+++ b/xbmc/windowing/win10/WinSystemWin10.h
@@ -91,6 +91,8 @@ public:
   // CWinSystemWin10
   bool IsAlteringWindow() const { return m_IsAlteringWindow; }
   void SetAlteringWindow(bool altering) { m_IsAlteringWindow = altering; }
+  bool IsTogglingHDR() const { return false; }
+  void SetTogglingHDR(bool toggling) {}
   virtual bool DPIChanged(WORD dpi, RECT windowRect) const;
   bool IsMinimized() const { return m_bMinimized; }
   void SetMinimized(bool minimized) { m_bMinimized = minimized; }

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -575,10 +575,12 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
     case WM_DISPLAYCHANGE:
     {
       CLog::LogFC(LOGDEBUG, LOGWINDOWING, "display change event");
+      if (DX::Windowing()->IsTogglingHDR() || DX::Windowing()->IsAlteringWindow())
+        return (0);
+
       const auto& components = CServiceBroker::GetAppComponents();
       const auto appPower = components.GetComponent<CApplicationPowerHandling>();
-      if (appPower->GetRenderGUI() && !DX::Windowing()->IsAlteringWindow() &&
-          GET_X_LPARAM(lParam) > 0 && GET_Y_LPARAM(lParam) > 0)
+      if (appPower->GetRenderGUI() && GET_X_LPARAM(lParam) > 0 && GET_Y_LPARAM(lParam) > 0)
       {
         DX::Windowing()->UpdateResolutions();
       }
@@ -852,6 +854,16 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
           }
           break;
         }
+      }
+      break;
+    }
+    case WM_TIMER:
+    {
+      if (wParam == ID_TIMER_HDR)
+      {
+        CLog::LogFC(LOGDEBUG, LOGWINDOWING, "finish toggling HDR event");
+        DX::Windowing()->SetTogglingHDR(false);
+        KillTimer(hWnd, wParam);
       }
       break;
     }

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -1276,6 +1276,14 @@ bool CWinSystemWin32::MessagePump()
   return m_winEvents->MessagePump();
 }
 
+void CWinSystemWin32::SetTogglingHDR(bool toggling)
+{
+  if (toggling)
+    SetTimer(m_hWnd, ID_TIMER_HDR, 6000U, nullptr);
+
+  m_IsTogglingHDR = toggling;
+}
+
 RECT CWinSystemWin32::GetVirtualScreenRect()
 {
   RECT rect = {};

--- a/xbmc/windowing/windows/WinSystemWin32.h
+++ b/xbmc/windowing/windows/WinSystemWin32.h
@@ -20,6 +20,7 @@ static const DWORD WINDOWED_STYLE = WS_OVERLAPPEDWINDOW | WS_CLIPCHILDREN;
 static const DWORD WINDOWED_EX_STYLE = NULL;
 static const DWORD FULLSCREEN_WINDOW_STYLE = WS_POPUP | WS_SYSMENU | WS_CLIPCHILDREN;
 static const DWORD FULLSCREEN_WINDOW_EX_STYLE = WS_EX_APPWINDOW;
+static const UINT ID_TIMER_HDR = 34U;
 
 /* Controls the way the window appears and behaves. */
 enum WINDOW_STATE
@@ -106,6 +107,8 @@ public:
   HWND GetHwnd() const { return m_hWnd; }
   bool IsAlteringWindow() const { return m_IsAlteringWindow; }
   void SetAlteringWindow(bool altering) { m_IsAlteringWindow = altering; }
+  bool IsTogglingHDR() const { return m_IsTogglingHDR; }
+  void SetTogglingHDR(bool toggling);
   virtual bool DPIChanged(WORD dpi, RECT windowRect) const;
   bool IsMinimized() const { return m_bMinimized; }
   void SetMinimized(bool minimized);
@@ -174,6 +177,7 @@ protected:
   HICON m_hIcon;
   bool m_ValidWindowedPosition;
   bool m_IsAlteringWindow;
+  bool m_IsTogglingHDR{false};
 
   CCriticalSection m_resourceSection;
   std::vector<IDispResource*> m_resources;


### PR DESCRIPTION
## Description
Fix refresh rate not switch back to 60Hz/GUI after HDR toggle on Windows 11 22H2.

Fixes https://github.com/xbmc/xbmc/issues/21314

## Motivation and context
Root cause is that Windows 11 22H2 generates additional `WM_DISPLAYCHANGE` events on HDR toggle. 

On Windows 10 and 11 (before 22H2) all events are generated while `DX::Windowing()->IsAlteringWindow()` is `true` and then is skipped `DX::Windowing()->UpdateResolutions()`. 

On Windows 11 22H2 some `WM_DISPLAYCHANGE` events are received latter and is executed `UpdateResolutions()` while display is at 23.976 Hz (video playback). Then list of resolutions is altered and is considered 23 Hz as `RES_DESKTOP`. When stop playback not switch back to 60 Hz because 23 Hz is already considered "target resolution".

The solution is inhibit  `WM_DISPLAYCHANGE` events during HDR toggle. At first attempt this code (https://github.com/thexai/xbmc/commit/de056474c2d732aec74f8b31a035c9331fe934a6 ) works well and serves to understand what is needed. But it has quite a few drawbacks. It only works on Windows 11 22H2 and it might even stop working in the future. The best solution is not to depend on events `WM_DISPLAYCHANGE` to consider HDR toggle has finished. 

This is the reason for using a timer. It is a robust solution because it simply inhibits `WM_DISPLAYCHANGE` events for a time after the HDR switching begins (regardless of the number of events that are generated and how long they take to arrive).

This basic Win32 API timer has been expressly chosen and not a more advanced C++ timer since it fits very well with what is intended and works in the same thread that processes the window events. This in this case is an advantage because if the events are delayed for any reason, the arrival of the `WM_TIMER` event is also delayed and in the end what matters is that `WM_TIMER` arrives after all `WM_DISPLAYCHANGE` events. The timer does not need to be precise but to keep pace with the timing of events.


## How has this been tested?
Runtime tested on Intel NUC8i3BEK and NVIDIA RTX 2060 with Windows 11 22H2


## What is the effect on users?
Fixes refresh rate not returns to 60Hz / GUI after stopping HDR playback on Windows 11 22H2 


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
