### PR TITLE
[Windows] fix refresh rate not switch back to 60Hz/GUI after HDR toggle on Windows 11 22H2

### DIFF
--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -1237,9 +1237,10 @@ HDR_STATUS DX::DeviceResources::ToggleHDR()
   DXGI_MODE_DESC md = {};
   GetDisplayMode(&md);
 
-  // Toggle display HDR
+  DX::Windowing()->SetTogglingHDR(true);
   DX::Windowing()->SetAlteringWindow(true);
 
+  // Toggle display HDR
   HDR_STATUS hdrStatus = CWIN32Util::ToggleWindowsHDR(md);
 
   // Kill swapchain

--- a/xbmc/windowing/win10/WinSystemWin10.h
+++ b/xbmc/windowing/win10/WinSystemWin10.h
@@ -91,6 +91,8 @@ public:
   // CWinSystemWin10
   bool IsAlteringWindow() const { return m_IsAlteringWindow; }
   void SetAlteringWindow(bool altering) { m_IsAlteringWindow = altering; }
+  bool IsTogglingHDR() const { return false; }
+  void SetTogglingHDR(bool toggling) {}
   virtual bool DPIChanged(WORD dpi, RECT windowRect) const;
   bool IsMinimized() const { return m_bMinimized; }
   void SetMinimized(bool minimized) { m_bMinimized = minimized; }

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -556,7 +556,10 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
     }
     case WM_DISPLAYCHANGE:
       CLog::LogFC(LOGDEBUG, LOGWINDOWING, "display change event");
-      if (g_application.GetRenderGUI() && !DX::Windowing()->IsAlteringWindow() && GET_X_LPARAM(lParam) > 0 && GET_Y_LPARAM(lParam) > 0)
+      if (DX::Windowing()->IsTogglingHDR() || DX::Windowing()->IsAlteringWindow())
+        return (0);
+
+      if (g_application.GetRenderGUI() && GET_X_LPARAM(lParam) > 0 && GET_Y_LPARAM(lParam) > 0)
       {
         DX::Windowing()->UpdateResolutions();
       }
@@ -797,6 +800,16 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
     case BONJOUR_BROWSER_EVENT:
       CZeroconfBrowser::GetInstance()->ProcessResults();
       break;
+    case WM_TIMER:
+    {
+      if (wParam == ID_TIMER_HDR)
+      {
+        CLog::LogFC(LOGDEBUG, LOGWINDOWING, "finish toggling HDR event");
+        DX::Windowing()->SetTogglingHDR(false);
+        KillTimer(hWnd, wParam);
+      }
+      break;
+    }
     default:;
   }
   return(DefWindowProc(hWnd, uMsg, wParam, lParam));

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -1198,3 +1198,11 @@ bool CWinSystemWin32::MessagePump()
 {
   return m_winEvents->MessagePump();
 }
+
+void CWinSystemWin32::SetTogglingHDR(bool toggling)
+{
+  if (toggling)
+    SetTimer(m_hWnd, ID_TIMER_HDR, 6000U, nullptr);
+
+  m_IsTogglingHDR = toggling;
+}

--- a/xbmc/windowing/windows/WinSystemWin32.h
+++ b/xbmc/windowing/windows/WinSystemWin32.h
@@ -19,6 +19,7 @@ static const DWORD WINDOWED_STYLE = WS_OVERLAPPEDWINDOW | WS_CLIPCHILDREN;
 static const DWORD WINDOWED_EX_STYLE = NULL;
 static const DWORD FULLSCREEN_WINDOW_STYLE = WS_POPUP | WS_SYSMENU | WS_CLIPCHILDREN;
 static const DWORD FULLSCREEN_WINDOW_EX_STYLE = WS_EX_APPWINDOW;
+static const UINT ID_TIMER_HDR = 34U;
 
 /* Controls the way the window appears and behaves. */
 enum WINDOW_STATE
@@ -107,6 +108,8 @@ public:
   HWND GetHwnd() const { return m_hWnd; }
   bool IsAlteringWindow() const { return m_IsAlteringWindow; }
   void SetAlteringWindow(bool altering) { m_IsAlteringWindow = altering; }
+  bool IsTogglingHDR() const { return m_IsTogglingHDR; }
+  void SetTogglingHDR(bool toggling);
   virtual bool DPIChanged(WORD dpi, RECT windowRect) const;
   bool IsMinimized() const { return m_bMinimized; }
   void SetMinimized(bool minimized) { m_bMinimized = minimized; }
@@ -174,6 +177,7 @@ protected:
   HICON m_hIcon;
   bool m_ValidWindowedPosition;
   bool m_IsAlteringWindow;
+  bool m_IsTogglingHDR{false};
 
   CCriticalSection m_resourceSection;
   std::vector<IDispResource*> m_resources;


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/22063



## What is the effect on users?
Fixes refresh rate not returns to 60Hz / GUI after stopping HDR playback on Windows 11 22H2


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
