### PR TITLE
Added keyboard mapping DownloadSubtitles

### DIFF
--- a/project/BuildDependencies/bin/.wget-hsts
+++ b/project/BuildDependencies/bin/.wget-hsts
@@ -1,0 +1,7 @@
+# HSTS 1.0 Known Hosts database for GNU Wget.
+# Edit at your own risk.
+# <hostname>	<port>	<incl. subdomains>	<created>	<max-age>
+mirrors.up.pt	0	1	1666906530	63072000
+aka.ms	0	1	1666911358	31536000
+github.com	0	1	1666906839	31536000
+codeload.github.com	0	0	1666906839	31536000

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -370,6 +370,7 @@
       <zoom>AspectRatio</zoom>
       <t>ShowSubtitles</t>
       <t mod="ctrl">SubtitleAlign</t>
+      <t mod="alt">DownloadSubtitles</t>
       <l>NextSubtitle</l>
       <left>StepBack</left>
       <right>StepForward</right>

--- a/xbmc/input/actions/ActionIDs.h
+++ b/xbmc/input/actions/ActionIDs.h
@@ -428,6 +428,9 @@
 //! Used to queue an item to the next position in the playlist
 #define ACTION_QUEUE_ITEM_NEXT 251
 
+//! Turn subtitles on/off. Can be used in videoFullScreen.xml window id=2005
+#define ACTION_DOWNLOAD_SUBTITLES 252
+
 #define ACTION_HDR_TOGGLE 260 //!< Toggle display HDR on/off
 
 #define ACTION_CYCLE_TONEMAP_METHOD 261 //!< Switch to next tonemap method

--- a/xbmc/input/actions/ActionTranslator.cpp
+++ b/xbmc/input/actions/ActionTranslator.cpp
@@ -49,6 +49,7 @@ static const std::map<ActionName, ActionID> ActionMappings = {
     {"chapterorbigstepback", ACTION_CHAPTER_OR_BIG_STEP_BACK},
     {"osd", ACTION_SHOW_OSD},
     {"showsubtitles", ACTION_SHOW_SUBTITLES},
+    {"downloadsubtitles", ACTION_DOWNLOAD_SUBTITLES},
     {"nextsubtitle", ACTION_NEXT_SUBTITLE},
     {"browsesubtitle", ACTION_BROWSE_SUBTITLE},
     {"cyclesubtitle", ACTION_CYCLE_SUBTITLE},

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -15,6 +15,7 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "dialogs/GUIDialogSlider.h"
+#include "dialogs/GUIDialogSubtitles.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUISliderControl.h"
 #include "guilib/GUIWindowManager.h"
@@ -77,6 +78,17 @@ bool CPlayerController::OnAction(const CAction &action)
           sub = g_localizeStrings.Get(1223);
         CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info,
                                               g_localizeStrings.Get(287), sub, DisplTime, false, MsgTime);
+        return true;
+      }
+
+      case ACTION_DOWNLOAD_SUBTITLES:
+      {
+        CGUIDialogSubtitles *dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSubtitles>(WINDOW_DIALOG_SUBTITLES);
+        if (dialog)
+        {
+          dialog->Open();
+        }
+
         return true;
       }
 


### PR DESCRIPTION
## Description
Added keyboard mapping Alt+T to access the Download Subtitles dialog immediately, with no need to use remote/pad/joystick simply to download subtitles to a current full screen video

## Motivation and context
To download subtitles today, one have to use pad/mouse to open the subtitles settings dialog (cogwheel at the bottom-right corner of the screen), and only from there you can open the dialog to download new subtitles (which also pauses the video). This isn't very user-friendly, when watching a binge of foreign TV series, having to repeatedly pause the video while trying to find the right icon to click. Now, with the new keyboard mapping, Alt+T simply opens the download dialog, and pauses the video automatically. This is similar to existing mappings, like T (hide/display subtitles) and Ctrl+T (change subtitles alignment).

## How has this been tested?
Tested on mac and windows x64 machines. The changes to the code are very limited and have no affect over other parts of the code.

## What is the effect on users?
Enhanced ease-of-use to end-users used to download subtitles many times.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
