### PR TITLE
[LoongArch] fix a typo.

### DIFF
--- a/xbmc/utils/MathUtils.h
+++ b/xbmc/utils/MathUtils.h
@@ -27,7 +27,7 @@
     defined(__alpha__) || \
     defined(__arc__) || \
     defined(__arm__) || \
-    defined(__loongarch) || \
+    defined(__loongarch__) || \
     defined(_M_ARM) || \
     defined(__mips__) || \
     defined(__or1k__) || \


### PR DESCRIPTION
Should be __loongarch__ not __loongarch.
Sorry for my mistake.
