### PR TITLE
Remove clang warning in Dataset::setSqlParams

### DIFF
--- a/xbmc/dbwrappers/dataset.cpp
+++ b/xbmc/dbwrappers/dataset.cpp
@@ -120,12 +120,12 @@ Dataset::~Dataset()
   delete edit_object;
 }
 
-void Dataset::setSqlParams(const char* sqlFrmt, sqlType t, ...)
+void Dataset::setSqlParams(sqlType t, const char* sqlFrmt, ...)
 {
   va_list ap;
   char sqlCmd[DB_BUFF_MAX + 1];
 
-  va_start(ap, t);
+  va_start(ap, sqlFrmt);
 #ifndef TARGET_POSIX
   _vsnprintf(sqlCmd, DB_BUFF_MAX - 1, sqlFrmt, ap);
 #else

--- a/xbmc/dbwrappers/dataset.h
+++ b/xbmc/dbwrappers/dataset.h
@@ -292,7 +292,7 @@ public:
   /* status active is OK query */
   virtual bool isActive(void) { return active; }
 
-  virtual void setSqlParams(const char* sqlFrmt, sqlType t, ...);
+  virtual void setSqlParams(sqlType t, const char* sqlFrmt, ...);
 
   /* error handling */
   //  virtual void halt(const char *msg);


### PR DESCRIPTION
## Description
This warning appear in the build log:
```
xbmc/dbwrappers/dataset.cpp:128:16: warning: passing an object that undergoes default argument promotion to 'va_start' has undefined behavior [-Wvarargs]
   va_start(ap, t);
                ^
xbmc/dbwrappers/dataset.cpp:123:57: note: parameter of type 'dbiplus::sqlType' is declared here
void Dataset::setSqlParams(const char* sqlFrmt, sqlType t, ...)
```

`sqlFrmt` is the variable argument not `t`, you must change the order of them in the function declaration.

The call to the `va_start` macro must also be corrected.

## Motivation and context
The function is not used, but we remove the warning.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
