### PR TITLE
[cmake] FindFmt fix internal build without existing fmt lib

### DIFF
--- a/cmake/modules/FindFmt.cmake
+++ b/cmake/modules/FindFmt.cmake
@@ -40,6 +40,8 @@ if((NOT TARGET fmt::fmt OR Fmt_FIND_REQUIRED) AND NOT TARGET fmt)
       if(FMT_VERSION VERSION_LESS ${Fmt_FIND_VERSION})
         set(FORCE_BUILD ON)
       endif()
+    else()
+      set(FORCE_BUILD ON)
     endif()
 
     if(${FORCE_BUILD} OR FMT_VERSION VERSION_LESS ${${MODULE}_VER})


### PR DESCRIPTION
## Description
Fix building internal FMT when no prior fmt lib exists.

## Motivation and context
Fixes the issue https://github.com/xbmc/xbmc/pull/22055 was attempting to fix

## How has this been tested?
Local with/without fmt in depends before cmake generation

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
