### PR TITLE
[Pictures] fix race condition in thumbnails loading

### DIFF
--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -70,6 +70,17 @@ public:
    */
   void BackgroundCacheImage(const std::string &image);
 
+  /*! \brief Updates the in-process list.
+
+   Inserts the image url into the currently processing list 
+   to avoid 2 jobs being processed at once
+
+   \param image url of the image to start processing
+   \return true if list updated, false otherwise
+   \sa CacheImage
+   */
+  bool StartCacheImage(const std::string& image);
+
   /*! \brief Cache an image to image cache, optionally return the texture
 
    Caches the given image, returning the texture if the caller wants it.
@@ -199,7 +210,6 @@ private:
   bool SetCachedTextureValid(const std::string &url, bool updateable);
 
   void OnJobComplete(unsigned int jobID, bool success, CJob *job) override;
-  void OnJobProgress(unsigned int jobID, unsigned int progress, unsigned int total, const CJob *job) override;
 
   /*! \brief Called when a caching job has completed.
    Removes the job from our processing list, updates the database

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -58,15 +58,16 @@ bool CTextureCacheJob::DoWork()
 {
   if (ShouldCancel(0, 0))
     return false;
-  if (ShouldCancel(1, 0)) // HACK: second check is because we cancel the job in the first callback, but we don't detect it
-    return false;         //       until the second
 
   // check whether we need cache the job anyway
   bool needsRecaching = false;
   std::string path(CServiceBroker::GetTextureCache()->CheckCachedImage(m_url, needsRecaching));
   if (!path.empty() && !needsRecaching)
     return false;
-  return CacheTexture();
+  if (CServiceBroker::GetTextureCache()->StartCacheImage(m_url))
+    return CacheTexture();
+
+  return false;
 }
 
 bool CTextureCacheJob::CacheTexture(std::unique_ptr<CTexture>* out_texture)


### PR DESCRIPTION
## Description
This change fixes a race condition (in Pictures module) between `CGUILargeTextureManager` & `CTextureCache` which causes thumbnails creation to stop, especially for large folders. The key idea is to skip thumbnail creation if it is in progress in parallel and not attempt a `CancelJob` which causes the queue to stop.

## Motivation and context
_The issue as observed by the end user_: when a Pictures folder is opened, Kodi creates/loads the thumbnails. In the recent years, large folders have been a problem. Sometimes all thumbnails are created/cached fine. Sometimes, they don't load even after leaving the folder open for 10-15 mins. Scrolling through the list creates the thumbnails of visible images but this method is quite painful for folders with 1000+ images.
 
The issue after debugging:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`CPictureThumbLoader` uses `CTextureCache::BackgroundCacheImage()` to create a `CJobQueue` (`CTextureCache` is a `CJobQueue`) of all images in the folder for which thumbnails are required. Only the 1st job is actually added to `CJobManager` as the `CJobQueue` is initialized with `jobsAtOnce=1`. When the job is processed by `CJobManager`, `CJobQueue::OnJobComplete()` is called which queues the next job.
Sometimes, the thumbnails stop loading because `CJobQueue::OnJobComplete()` is not called and then the `CJobManager` is no longer fed with new jobs from the `CTextureCache` queue.
 
Why is `CJobQueue::OnJobComplete()` not called sometimes? Because `CJobManager::CancelJob()` was called for some job id which sets the `CWorkItem`'s `m_callback` to NULL.
 
Why is `CJobManager::CancelJob()` called? Because `CTextureCacheJob:: DoWork()` determined that the job should be cancelled.
 
And why? Because `CTextureCache::OnJobProgress()` determined that the same url is being processed currently.
 
And why again? Because `CGUILargeTextureManager::QueueImage()` had queued the same image for thumbnail creation.
 
So, there is a race between `CGUILargeTextureManager` & `CTextureCache` and in certain conditions, the `CTextureCache` stops feeding the `CJobManager`.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Env: Windows with VS2022.
Tested by using a folder with 500 images which would stop thumbnail creation before the fix. 

- tested fresh thumbnails creation (after deleting Textures.db and Thumbnails from userdata)
- tested regeneration of thumbnails
- tested other Pictures functionality like scrolling, slideshow

Other areas of code are minimally affected as the change is localized to TextureCache. Alternate fixes to logic of `CJobManager::CancelJob` were not considered to minimize regression.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
The thumbnails creation in Pictures module is more robust especially with larger folders.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
