### PR TITLE
[Android] remove google breakpad script

### DIFF
--- a/cmake/scripts/android/Install.cmake
+++ b/cmake/scripts/android/Install.cmake
@@ -11,8 +11,6 @@ configure_file(${CMAKE_SOURCE_DIR}/tools/android/packaging/Makefile.in
                ${CMAKE_BINARY_DIR}/tools/android/packaging/Makefile @ONLY)
 configure_file(${CMAKE_SOURCE_DIR}/tools/android/packaging/gradle.properties
                ${CMAKE_BINARY_DIR}/tools/android/packaging/gradle.properties COPYONLY)
-configure_file(${CMAKE_SOURCE_DIR}/tools/android/packaging/make_symbols.sh
-               ${CMAKE_BINARY_DIR}/tools/android/packaging/make_symbols.sh COPYONLY)
 configure_file(${CMAKE_SOURCE_DIR}/tools/android/packaging/build.gradle
                ${CMAKE_BINARY_DIR}/tools/android/packaging/build.gradle COPYONLY)
 configure_file(${CMAKE_SOURCE_DIR}/tools/android/packaging/gradlew

--- a/tools/android/packaging/make_symbols.sh
+++ b/tools/android/packaging/make_symbols.sh
@@ -1,6 +1,0 @@
-FN=$(basename "$1")
-dump_syms "$1" > $FN.sym
-HASH=`head -n 1 $FN.sym | cut -d " " -f 4`
-mkdir -p symbols/$FN/$HASH
-mv $FN.sym symbols/$FN/$HASH
-echo "$FN.sym generated"


### PR DESCRIPTION
## Description
google breakpad was removed (#10226 and #13025) but they forgot to remove the `make_symbols.sh` script

## How has this been tested?
Tested on Android TV 9

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
