### PR TITLE
[Android] ndk-build: delete Android.mk and Application.mk

### DIFF
--- a/tools/android/packaging/xbmc/jni/Android.mk
+++ b/tools/android/packaging/xbmc/jni/Android.mk
@@ -1,3 +1,0 @@
-LOCAL_PATH := $(call my-dir)
-include $(CLEAR_VARS)
-LOCAL_MODULE    := xbmc

--- a/tools/android/packaging/xbmc/jni/Application.mk
+++ b/tools/android/packaging/xbmc/jni/Application.mk
@@ -1,5 +1,0 @@
-APP_PLATFORM := android-9
-APP_OPTIM = debug
-APP_ABI := armeabi-v7a
-# This would support both ARVMv5TE and ARMv7
-#APP_ABI := armeabi armeabi-v7a


### PR DESCRIPTION
## Description
The configuration files `Android.mk` and `Application.mk` are part of the [ndk-build](https://developer.android.com/ndk/guides/ndk-build) script used to build Android projects.

These files can be deleted as Kodi uses a customized toolchain for the project instead.

## How has this been tested?
It builds and runs fine on Android TV 9

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
