### PR TITLE
Update OSMC controller support definition to match new VID/PID

### DIFF
--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -52,7 +52,7 @@
     <setting key="keymap" value="wetek-play" label="35007" configurable="0" />
   </peripheral>
 
-  <peripheral vendor_product="2252:1037,2017:1688,2017:1689" bus="usb" name="OSMC RF Remote" mapTo="hid">
+  <peripheral vendor_product="2252:1037,2017:1688,2017:1689,2017:1690" bus="usb" name="OSMC RF Remote" mapTo="hid">
      <setting key="do_not_use_custom_keymap" type="bool" value="0" label="35009" order="1"/>
      <setting key="keymap" value="osmc" label="35007" configurable="1"/>
   </peripheral>


### PR DESCRIPTION
Signed-off-by: Sam Nazarko <email@samnazarko.co.uk>

## Description

This ensures that the existing OSMC RF keymap is applied to new OSMC RF dongles with an updated VID/PID map. 
The keymap and device are electrically identical, but we have chosen to use a new VID/PID to signify a significantly newer batch and manufacture process. 

## Motivation and context

To make the remote function as expected.

## How has this been tested?

OSMC and LibreELEC (with LE PR submitted at https://github.com/LibreELEC/LibreELEC.tv/pull/7089). 

## What is the effect on users?

Remote works as expected

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
