### PR TITLE
[PVR] Misc recordings-related fixes

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -159,6 +159,7 @@ CFileItem::CFileItem(const std::shared_ptr<CPVREpgInfoTag>& tag)
   m_bIsFolder = false;
   m_epgInfoTag = tag;
   m_strPath = tag->Path();
+  m_bCanQueue = false;
   SetLabel(GetEpgTagTitle(tag));
   m_dateTime = tag->StartAsLocalTime();
 
@@ -193,6 +194,7 @@ CFileItem::CFileItem(const std::shared_ptr<PVR::CPVREpgSearchFilter>& filter)
   m_bIsFolder = true;
   m_epgSearchFilter = filter;
   m_strPath = filter->GetPath();
+  m_bCanQueue = false;
   SetLabel(filter->GetTitle());
 
   const CDateTime lastExec = filter->GetLastExecutedDateTime();
@@ -217,7 +219,7 @@ CFileItem::CFileItem(const std::shared_ptr<CPVRChannelGroupMember>& channelGroup
 
   m_strPath = channelGroupMember->Path();
   m_bIsFolder = false;
-
+  m_bCanQueue = false;
   SetLabel(channel->ChannelName());
 
   if (!channel->IconPath().empty())
@@ -252,6 +254,7 @@ CFileItem::CFileItem(const std::shared_ptr<CPVRRecording>& record)
   SetLabel(record->m_strTitle);
   m_dateTime = record->RecordingTimeAsLocalTime();
   m_dwSize = record->GetSizeInBytes();
+  m_bCanQueue = true;
 
   // Set art
   if (!record->IconPath().empty())
@@ -288,6 +291,7 @@ CFileItem::CFileItem(const std::shared_ptr<CPVRTimerInfoTag>& timer)
   m_strPath = timer->Path();
   SetLabel(timer->Title());
   m_dateTime = timer->StartAsLocalTime();
+  m_bCanQueue = false;
 
   if (!timer->ChannelIcon().empty())
     SetArt("icon", timer->ChannelIcon());

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -365,6 +365,8 @@ void GetSubDirectories(const CPVRRecordingsPath& recParentPath,
 
 bool CPVRGUIDirectory::GetRecordingsDirectory(CFileItemList& results) const
 {
+  results.SetContent("recordings");
+
   bool bGrouped = false;
   const std::vector<std::shared_ptr<CPVRRecording>> recordings =
       CServiceBroker::GetPVRManager().Recordings()->GetAll();

--- a/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
@@ -458,9 +458,12 @@ bool CPVRGUIActionsPlayback::PlayMedia(const CFileItem& item) const
       pvrItem = std::make_unique<CFileItem>(groupMember);
   }
   else if (URIUtils::IsPVRRecording(item.GetPath()) && !item.HasPVRRecordingInfoTag())
-    pvrItem = std::make_unique<CFileItem>(
-        CServiceBroker::GetPVRManager().Recordings()->GetByPath(item.GetPath()));
-
+  {
+    const std::shared_ptr<CPVRRecording> recording =
+        CServiceBroker::GetPVRManager().Recordings()->GetByPath(item.GetPath());
+    if (recording)
+      pvrItem = std::make_unique<CFileItem>(recording);
+  }
   bool bCheckResume = true;
   if (item.HasProperty("check_resume"))
     bCheckResume = item.GetProperty("check_resume").asBoolean();

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -422,6 +422,8 @@ void CPVRRecording::UpdateMetadata(CVideoDatabase& db, const CPVRClient& client)
       CVideoInfoTag::SetResumePoint(resumePoint);
   }
 
+  m_lastPlayed = db.GetLastPlayed(m_strFileNameAndPath);
+
   m_bGotMetaData = true;
 }
 

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -112,7 +112,8 @@ CPVRRecording::CPVRRecording(const PVR_RECORDING& recording, unsigned int iClien
 
   SetGenre(recording.iGenreType, recording.iGenreSubType, recording.strGenreDescription);
   CVideoInfoTag::SetPlayCount(recording.iPlayCount);
-  CVideoInfoTag::SetResumePoint(recording.iLastPlayedPosition, recording.iDuration, "");
+  if (recording.iLastPlayedPosition > 0 && recording.iDuration > recording.iLastPlayedPosition)
+    CVideoInfoTag::SetResumePoint(recording.iLastPlayedPosition, recording.iDuration, "");
   SetDuration(recording.iDuration);
 
   //  As the channel a recording was done on (probably long time ago) might no longer be
@@ -377,6 +378,7 @@ CBookmark CPVRRecording::GetResumePoint() const
     {
       CBookmark resumePoint(CVideoInfoTag::GetResumePoint());
       resumePoint.timeInSeconds = pos;
+      resumePoint.totalTimeInSeconds = (pos == 0) ? 0 : m_duration;
       CPVRRecording* pThis = const_cast<CPVRRecording*>(this);
       pThis->CVideoInfoTag::SetResumePoint(resumePoint);
     }

--- a/xbmc/pvr/recordings/PVRRecordingsPath.cpp
+++ b/xbmc/pvr/recordings/PVRRecordingsPath.cpp
@@ -21,9 +21,11 @@ using namespace PVR;
 
 const std::string CPVRRecordingsPath::PATH_RECORDINGS = "pvr://recordings/";
 const std::string CPVRRecordingsPath::PATH_ACTIVE_TV_RECORDINGS = "pvr://recordings/tv/active/";
-const std::string CPVRRecordingsPath::PATH_ACTIVE_RADIO_RECORDINGS = "pvr://recordings/radio/active/";
+const std::string CPVRRecordingsPath::PATH_ACTIVE_RADIO_RECORDINGS =
+    "pvr://recordings/radio/active/";
 const std::string CPVRRecordingsPath::PATH_DELETED_TV_RECORDINGS = "pvr://recordings/tv/deleted/";
-const std::string CPVRRecordingsPath::PATH_DELETED_RADIO_RECORDINGS = "pvr://recordings/radio/deleted/";
+const std::string CPVRRecordingsPath::PATH_DELETED_RADIO_RECORDINGS =
+    "pvr://recordings/radio/deleted/";
 
 CPVRRecordingsPath::CPVRRecordingsPath(const std::string& strPath)
 {
@@ -31,10 +33,9 @@ CPVRRecordingsPath::CPVRRecordingsPath(const std::string& strPath)
   const std::vector<std::string> segments = URIUtils::SplitPath(strVarPath);
 
   m_bValid = ((segments.size() >= 4) && // at least pvr://recordings/[tv|radio]/[active|deleted]
-               StringUtils::StartsWith(strVarPath, "pvr://") &&
-               (segments.at(1) == "recordings") &&
-               ((segments.at(2) == "tv") || (segments.at(2) == "radio")) &&
-               ((segments.at(3) == "active") || (segments.at(3) == "deleted")));
+              StringUtils::StartsWith(strVarPath, "pvr://") && (segments.at(1) == "recordings") &&
+              ((segments.at(2) == "tv") || (segments.at(2) == "radio")) &&
+              ((segments.at(3) == "active") || (segments.at(3) == "deleted")));
   if (m_bValid)
   {
     m_bRoot = (m_bValid && (segments.size() == 4));
@@ -76,15 +77,18 @@ CPVRRecordingsPath::CPVRRecordingsPath(bool bDeleted, bool bRadio)
 {
 }
 
-CPVRRecordingsPath::CPVRRecordingsPath(bool bDeleted, bool bRadio,
-                       const std::string& strDirectory, const std::string& strTitle,
-                       int iSeason, int iEpisode, int iYear,
-                       const std::string& strSubtitle, const std::string& strChannelName,
-                       const CDateTime& recordingTime, const std::string& strId)
-: m_bValid(true),
-  m_bRoot(false),
-  m_bActive(!bDeleted),
-  m_bRadio(bRadio)
+CPVRRecordingsPath::CPVRRecordingsPath(bool bDeleted,
+                                       bool bRadio,
+                                       const std::string& strDirectory,
+                                       const std::string& strTitle,
+                                       int iSeason,
+                                       int iEpisode,
+                                       int iYear,
+                                       const std::string& strSubtitle,
+                                       const std::string& strChannelName,
+                                       const CDateTime& recordingTime,
+                                       const std::string& strId)
+  : m_bValid(true), m_bRoot(false), m_bActive(!bDeleted), m_bRadio(bRadio)
 {
   std::string strDirectoryN(TrimSlashes(strDirectory));
   if (!strDirectoryN.empty())
@@ -139,7 +143,8 @@ std::string CPVRRecordingsPath::GetUnescapedSubDirectoryPath(const std::string& 
 
   /* adding "/" to make sure that base matches the complete folder name and not only parts of it */
   if (!strUnescapedDirectoryPath.empty() &&
-      (strUsePath.size() <= strUnescapedDirectoryPath.size() || !URIUtils::PathHasParent(strUsePath, strUnescapedDirectoryPath)))
+      (strUsePath.size() <= strUnescapedDirectoryPath.size() ||
+       !URIUtils::PathHasParent(strUsePath, strUnescapedDirectoryPath)))
     return strReturn;
 
   strUsePath.erase(0, strUnescapedDirectoryPath.size());
@@ -161,7 +166,8 @@ const std::string CPVRRecordingsPath::GetTitle() const
   {
     CRegExp reg(true);
     if (reg.RegComp("pvr://recordings/(.*/)*(.*), TV( \\(.*\\))?, "
-                    "(19[0-9][0-9]|20[0-9][0-9])[0-9][0-9][0-9][0-9]_[0-9][0-9][0-9][0-9][0-9][0-9], (.*).pvr"))
+                    "(19[0-9][0-9]|20[0-9][0-9])[0-9][0-9][0-9][0-9]_[0-9][0-9][0-9][0-9][0-9][0-9]"
+                    ", (.*).pvr"))
     {
       if (reg.RegFind(m_path.c_str()) >= 0)
         return reg.GetMatch(2);

--- a/xbmc/pvr/recordings/PVRRecordingsPath.cpp
+++ b/xbmc/pvr/recordings/PVRRecordingsPath.cpp
@@ -117,8 +117,8 @@ CPVRRecordingsPath::CPVRRecordingsPath(bool bDeleted, bool bRadio,
 
   m_directoryPath = StringUtils::Format("{}{}{}{}{}", strDirectoryN, strTitleN, strSeasonEpisodeN,
                                         strYearN, strSubtitleN);
-  m_params = StringUtils::Format(", TV{}, {}, {}.pvr", strChannelNameN.c_str(),
-                                 recordingTime.GetAsSaveString().c_str(), strId.c_str());
+  m_params = StringUtils::Format(", TV{}, {}, {}.pvr", strChannelNameN,
+                                 recordingTime.GetAsSaveString(), strId);
   m_path = StringUtils::Format("pvr://recordings/{}/{}/{}{}", bRadio ? "radio" : "tv",
                                bDeleted ? "deleted" : "active", m_directoryPath, m_params);
 }
@@ -182,6 +182,7 @@ void CPVRRecordingsPath::AppendSegment(const std::string& strSegment)
     m_directoryPath.push_back('/');
 
   m_directoryPath += strVarSegment;
+  m_directoryPath.push_back('/');
 
   size_t paramStart = m_path.find(", TV");
   if (paramStart == std::string::npos)
@@ -191,6 +192,7 @@ void CPVRRecordingsPath::AppendSegment(const std::string& strSegment)
 
     // append the segment
     m_path += strVarSegment;
+    m_path.push_back('/');
   }
   else
   {

--- a/xbmc/pvr/recordings/PVRRecordingsPath.h
+++ b/xbmc/pvr/recordings/PVRRecordingsPath.h
@@ -14,49 +14,55 @@ class CDateTime;
 
 namespace PVR
 {
-  class CPVRRecordingsPath
-  {
-  public:
-    static const std::string PATH_RECORDINGS;
-    static const std::string PATH_ACTIVE_TV_RECORDINGS;
-    static const std::string PATH_ACTIVE_RADIO_RECORDINGS;
-    static const std::string PATH_DELETED_TV_RECORDINGS;
-    static const std::string PATH_DELETED_RADIO_RECORDINGS;
+class CPVRRecordingsPath
+{
+public:
+  static const std::string PATH_RECORDINGS;
+  static const std::string PATH_ACTIVE_TV_RECORDINGS;
+  static const std::string PATH_ACTIVE_RADIO_RECORDINGS;
+  static const std::string PATH_DELETED_TV_RECORDINGS;
+  static const std::string PATH_DELETED_RADIO_RECORDINGS;
 
-    explicit CPVRRecordingsPath(const std::string& strPath);
-    CPVRRecordingsPath(bool bDeleted, bool bRadio);
-    CPVRRecordingsPath(bool bDeleted, bool bRadio,
-                       const std::string& strDirectory, const std::string& strTitle,
-                       int iSeason, int iEpisode, int iYear,
-                       const std::string& strSubtitle, const std::string& strChannelName,
-                       const CDateTime& recordingTime, const std::string& strId);
+  explicit CPVRRecordingsPath(const std::string& strPath);
+  CPVRRecordingsPath(bool bDeleted, bool bRadio);
+  CPVRRecordingsPath(bool bDeleted,
+                     bool bRadio,
+                     const std::string& strDirectory,
+                     const std::string& strTitle,
+                     int iSeason,
+                     int iEpisode,
+                     int iYear,
+                     const std::string& strSubtitle,
+                     const std::string& strChannelName,
+                     const CDateTime& recordingTime,
+                     const std::string& strId);
 
-    operator std::string() const { return m_path; }
+  operator std::string() const { return m_path; }
 
-    bool IsValid() const { return m_bValid; }
+  bool IsValid() const { return m_bValid; }
 
-    const std::string& GetPath() const { return m_path; }
-    bool IsRecordingsRoot() const { return m_bRoot; }
-    bool IsActive() const { return m_bActive; }
-    bool IsDeleted() const { return !IsActive(); }
-    bool IsRadio() const { return m_bRadio; }
-    bool IsTV() const { return !IsRadio(); }
-    std::string GetUnescapedDirectoryPath() const;
-    std::string GetUnescapedSubDirectoryPath(const std::string& strPath) const;
+  const std::string& GetPath() const { return m_path; }
+  bool IsRecordingsRoot() const { return m_bRoot; }
+  bool IsActive() const { return m_bActive; }
+  bool IsDeleted() const { return !IsActive(); }
+  bool IsRadio() const { return m_bRadio; }
+  bool IsTV() const { return !IsRadio(); }
+  std::string GetUnescapedDirectoryPath() const;
+  std::string GetUnescapedSubDirectoryPath(const std::string& strPath) const;
 
-    const std::string GetTitle() const;
-    void AppendSegment(const std::string& strSegment);
+  const std::string GetTitle() const;
+  void AppendSegment(const std::string& strSegment);
 
-  private:
-    static std::string TrimSlashes(const std::string& strString);
-    size_t GetDirectoryPathPosition() const;
+private:
+  static std::string TrimSlashes(const std::string& strString);
+  size_t GetDirectoryPathPosition() const;
 
-    bool m_bValid;
-    bool m_bRoot;
-    bool m_bActive;
-    bool m_bRadio;
-    std::string m_directoryPath;
-    std::string m_params;
-    std::string m_path;
-  };
-}
+  bool m_bValid;
+  bool m_bRoot;
+  bool m_bActive;
+  bool m_bRadio;
+  std::string m_directoryPath;
+  std::string m_params;
+  std::string m_path;
+};
+} // namespace PVR

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -98,14 +98,18 @@ void CSaveFileState::DoWork(CFileItem& item,
                         redactPath);
 
               // consider this item as played
-              videodatabase.IncrementPlayCount(item);
-              item.GetVideoInfoTag()->IncrementPlayCount();
+              const CDateTime newLastPlayed = videodatabase.IncrementPlayCount(item);
 
               item.SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, true);
               updateListing = true;
 
               if (item.HasVideoInfoTag())
               {
+                item.GetVideoInfoTag()->IncrementPlayCount();
+
+                if (newLastPlayed.IsValid())
+                  item.GetVideoInfoTag()->m_lastPlayed = newLastPlayed;
+
                 CVariant data;
                 data["id"] = item.GetVideoInfoTag()->m_iDbId;
                 data["type"] = item.GetVideoInfoTag()->m_type;
@@ -115,7 +119,12 @@ void CSaveFileState::DoWork(CFileItem& item,
             }
           }
           else
-            videodatabase.UpdateLastPlayed(item);
+          {
+            const CDateTime newLastPlayed = videodatabase.UpdateLastPlayed(item);
+
+            if (item.HasVideoInfoTag() && newLastPlayed.IsValid())
+              item.GetVideoInfoTag()->m_lastPlayed = newLastPlayed;
+          }
 
           if (!item.HasVideoInfoTag() ||
               item.GetVideoInfoTag()->GetResumePoint().timeInSeconds != bookmark.timeInSeconds)

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -6025,6 +6025,42 @@ int CVideoDatabase::GetPlayCount(const CFileItem &item)
   return GetPlayCount(GetFileId(item));
 }
 
+CDateTime CVideoDatabase::GetLastPlayed(int iFileId)
+{
+  if (iFileId < 0)
+    return {}; // not in db, so not watched
+
+  try
+  {
+    // error!
+    if (nullptr == m_pDB)
+      return {};
+    if (nullptr == m_pDS)
+      return {};
+
+    std::string strSQL = PrepareSQL("select lastPlayed from files WHERE idFile=%i", iFileId);
+    CDateTime lastPlayed;
+    if (m_pDS->query(strSQL))
+    {
+      // there should only ever be one row returned
+      if (m_pDS->num_rows() == 1)
+        lastPlayed.SetFromDBDateTime(m_pDS->fv(0).get_asString());
+      m_pDS->close();
+    }
+    return lastPlayed;
+  }
+  catch (...)
+  {
+    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+  }
+  return {};
+}
+
+CDateTime CVideoDatabase::GetLastPlayed(const std::string& strFilenameAndPath)
+{
+  return GetLastPlayed(GetFileId(strFilenameAndPath));
+}
+
 void CVideoDatabase::UpdateFanart(const CFileItem& item, VideoDbContentType type)
 {
   if (nullptr == m_pDB)

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -460,6 +460,13 @@ public:
    */
   int GetPlayCount(const std::string& strFilenameAndPath);
 
+  /*! \brief Get the last played time of a filename and path
+   \param strFilenameAndPath filename and path to get the last played time for
+   \return the last played time of the item, or an invalid CDateTime on error
+   \sa UpdateLastPlayed
+   */
+  CDateTime GetLastPlayed(const std::string& strFilenameAndPath);
+
   /*! \brief Update the last played time of an item
    Updates the last played date
    \param item CFileItem to update the last played time for
@@ -1096,6 +1103,13 @@ private:
    \sa SetPlayCount, IncrementPlayCount, GetPlayCounts
    */
   int GetPlayCount(int iFileId);
+
+  /*! \brief Get the last played time of a filename and path
+   \param iFileId file id to get the playcount for
+   \return the last played time of the item, or an invalid CDateTime on error
+   \sa UpdateLastPlayed
+   */
+  CDateTime GetLastPlayed(int iFileId);
 
   int GetMinSchemaVersion() const override { return 75; }
   int GetSchemaVersion() const override;

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -430,21 +430,24 @@ public:
   int AddNewEpisode(int idShow, CVideoInfoTag& details);
 
   // editing functions
-  /*! \brief Set the playcount of an item
+  /*! \brief Set the playcount of an item, update last played time
    Sets the playcount and last played date to a given value
    \param item CFileItem to set the playcount for
    \param count The playcount to set.
-   \param date The date the file was last viewed (does not denote the video was watched to completion).  If empty we current datetime (if count > 0) or never viewed (if count = 0).
+   \param date The date the file was last viewed (does not denote the video was watched to completion).
+   If empty we use current datetime (if count > 0) or never viewed (if count = 0).
+   \return on success, the new last played time set, invalid datetime otherwise.
    \sa GetPlayCount, IncrementPlayCount, UpdateLastPlayed
    */
-  void SetPlayCount(const CFileItem &item, int count, const CDateTime &date = CDateTime());
+  CDateTime SetPlayCount(const CFileItem& item, int count, const CDateTime& date = CDateTime());
 
   /*! \brief Increment the playcount of an item
    Increments the playcount and updates the last played date
    \param item CFileItem to increment the playcount for
+   \return on success, the new last played time set, invalid datetime otherwise.
    \sa GetPlayCount, SetPlayCount, GetPlayCounts
    */
-  void IncrementPlayCount(const CFileItem &item);
+  CDateTime IncrementPlayCount(const CFileItem& item);
 
   /*! \brief Get the playcount of an item
    \param item CFileItem to get the playcount for
@@ -470,9 +473,10 @@ public:
   /*! \brief Update the last played time of an item
    Updates the last played date
    \param item CFileItem to update the last played time for
+   \return on success, the last played time set, invalid datetime otherwise.
    \sa GetPlayCount, SetPlayCount, IncrementPlayCount, GetPlayCounts
    */
-  void UpdateLastPlayed(const CFileItem &item);
+  CDateTime UpdateLastPlayed(const CFileItem& item);
 
   /*! \brief Get the playcount and resume point of a list of items
    Note that if the resume point is already set on an item, it won't be overridden.

--- a/xbmc/video/jobs/VideoLibraryMarkWatchedJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryMarkWatchedJob.cpp
@@ -70,10 +70,14 @@ bool CVideoLibraryMarkWatchedJob::Work(CVideoDatabase &db)
     if (item->HasPVRRecordingInfoTag() &&
         CServiceBroker::GetPVRManager().Recordings()->MarkWatched(item->GetPVRRecordingInfoTag(), m_mark))
     {
+      CDateTime newLastPlayed;
       if (m_mark)
-        db.IncrementPlayCount(*item);
+        newLastPlayed = db.IncrementPlayCount(*item);
       else
-        db.SetPlayCount(*item, 0);
+        newLastPlayed = db.SetPlayCount(*item, 0);
+
+      if (newLastPlayed.IsValid())
+        item->GetVideoInfoTag()->m_lastPlayed = newLastPlayed;
 
       continue;
     }
@@ -97,10 +101,14 @@ bool CVideoLibraryMarkWatchedJob::Work(CVideoDatabase &db)
     // With both mark as watched and unwatched we want the resume bookmarks to be reset
     db.ClearBookMarksOfFile(path, CBookmark::RESUME);
 
+    CDateTime newLastPlayed;
     if (m_mark)
-      db.IncrementPlayCount(*item);
+      newLastPlayed = db.IncrementPlayCount(*item);
     else
-      db.SetPlayCount(*item, 0);
+      newLastPlayed = db.SetPlayCount(*item, 0);
+
+    if (newLastPlayed.IsValid() && item->HasVideoInfoTag())
+      item->GetVideoInfoTag()->m_lastPlayed = newLastPlayed;
   }
 
   db.CommitTransaction();


### PR DESCRIPTION
Fixes I spotted lately while working on another, upcoming feature:

1) Recording folder's paths did not always end with a slash. Thus, detection of type when just the URL was not reliably possible.
2) Last played time for recordings was never retrieved from video database, although stored there.
3) When filling a recordings directory, the correct content type "recordings" was not set at the respective file item list.
4) Recordings resume point was also set when the actual play time was 0 (no progress). But at several places in Kodi code, the pure presence of a bookmark will be (mis-)interpreted as "in progress" (Look at the implementation of `CBookmark::IsSet` and using code).
5) Fix for a nullptr crash when clicking a favourite pointing to a no longer existing recording.
6) PVR fileitem did not set the 'canqueue' property correctly.
7) The last played time stored to video database was not propagated immediately so the new time was not available immediately at the respective entities.

Runtime-tested on macOS and Android, latest master.

@phunkyfish hopefully you find some time for a code reviw. 