### PR TITLE
[favourites] CGUIWindowFavourites: Refresh content on item removal.

### DIFF
--- a/xbmc/favourites/GUIWindowFavourites.h
+++ b/xbmc/favourites/GUIWindowFavourites.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "favourites/FavouritesService.h"
 #include "windows/GUIMediaWindow.h"
 
 class CFileItem;
@@ -17,7 +18,7 @@ class CGUIWindowFavourites : public CGUIMediaWindow
 {
 public:
   CGUIWindowFavourites();
-  ~CGUIWindowFavourites() override = default;
+  ~CGUIWindowFavourites() override;
 
   static bool ChooseAndSetNewName(CFileItem& item);
   static bool ChooseAndSetNewThumbnail(CFileItem& item);
@@ -28,7 +29,10 @@ protected:
   std::string GetRootPath() const override { return "favourites://"; }
 
   bool OnSelect(int item) override;
-  bool OnPopupMenu(int iItem) override;
+  bool OnMessage(CGUIMessage& message) override;
 
   bool Update(const std::string& strDirectory, bool updateFilterPath = true) override;
+
+private:
+  void OnFavouritesEvent(const CFavouritesService::FavouritesUpdated& event);
 };


### PR DESCRIPTION
A bug fix for the new Favourites window. Content must be refreshed after removal of an item and correct selection must be restored.

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 can you look at the code changes, please?