### PR TITLE
[cmake] Fix FlatC buildtools race

### DIFF
--- a/cmake/modules/FindFlatBuffers.cmake
+++ b/cmake/modules/FindFlatBuffers.cmake
@@ -5,9 +5,10 @@
 # This will define the following variables:
 #
 # FLATBUFFERS_FOUND - system has FlatBuffers compiler and headers
-# FLATBUFFERS_FLATC_EXECUTABLE - the flatc compiler executable
 # FLATBUFFERS_INCLUDE_DIRS - the FlatFuffers include directory
 # FLATBUFFERS_MESSAGES_INCLUDE_DIR - the directory for generated headers
+
+find_package(FlatC REQUIRED)
 
 if(ENABLE_INTERNAL_FLATBUFFERS)
   include(cmake/scripts/common/ModuleHelpers.cmake)

--- a/cmake/modules/buildtools/FindFlatC.cmake
+++ b/cmake/modules/buildtools/FindFlatC.cmake
@@ -4,8 +4,9 @@
 #
 # This will define the following variables:
 #
-# FLATBUFFERS_FOUND - system has FlatBuffers compiler and headers
+# FLATBUFFERS_FLATC_EXECUTABLE_FOUND - system has FlatBuffers compiler
 # FLATBUFFERS_FLATC_EXECUTABLE - the flatc compiler executable
+# FLATBUFFERS_FLATC_VERSION - the flatc compiler version
 #
 # and the following imported targets:
 #
@@ -13,15 +14,24 @@
 
 include(cmake/scripts/common/ModuleHelpers.cmake)
 
-set(MODULE_LC flatbuffers)
-
-SETUP_BUILD_VARS()
-
 # Check for existing FLATC.
 find_program(FLATBUFFERS_FLATC_EXECUTABLE NAMES flatc
                                           HINTS ${NATIVEPREFIX}/bin)
 
-if(NOT FLATBUFFERS_FLATC_EXECUTABLE)
+if(FLATBUFFERS_FLATC_EXECUTABLE)
+  execute_process(COMMAND "${FLATBUFFERS_FLATC_EXECUTABLE}" --version
+                  OUTPUT_VARIABLE FLATBUFFERS_FLATC_VERSION
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+  string(REGEX MATCH "[^\n]* version [^\n]*" FLATBUFFERS_FLATC_VERSION "${FLATBUFFERS_FLATC_VERSION}")
+  string(REGEX REPLACE ".* version (.*)" "\\1" FLATBUFFERS_FLATC_VERSION "${FLATBUFFERS_FLATC_VERSION}")
+
+else()
+
+  set(MODULE_LC flatbuffers)
+  # Duplicate URL may exist from FindFlatbuffers.cmake
+  # unset otherwise it thinks we are providing a local file location and incorrect concatenation happens
+  unset(FLATBUFFERS_URL)
+  SETUP_BUILD_VARS()
 
   # Override build type detection and always build as release
   set(FLATBUFFERS_BUILD_TYPE Release)
@@ -57,6 +67,7 @@ if(NOT FLATBUFFERS_FLATC_EXECUTABLE)
 
   set(BUILD_NAME flatc)
   set(BUILD_BYPRODUCTS ${FLATBUFFERS_FLATC_EXECUTABLE})
+  set(FLATBUFFERS_FLATC_VERSION ${FLATBUFFERS_VER})
 
   BUILD_DEP_TARGET()
 endif()
@@ -64,7 +75,7 @@ endif()
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(FlatC
                                   REQUIRED_VARS FLATBUFFERS_FLATC_EXECUTABLE
-                                  VERSION_VAR FLATBUFFERS_VER)
+                                  VERSION_VAR FLATBUFFERS_FLATC_VERSION)
 
 if(FLATC_FOUND)
 


### PR DESCRIPTION
## Description
Ran across a potential build failure when a prior flatc exectuable wasnt available.

## Motivation and context
Ran across a build failure on windows hosts where flatc wasnt built prior to use This fixes that, and ensures flatc target is built as a dependency to flatbuffers::flatbuffers target if the flatc executable doesnt exist.

## How has this been tested?
Build win64 target that was failing when no prior flatc executable was available

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
