### PR TITLE
[Windows] BuildSetup.bat: removes blue color from terminal

### DIFF
--- a/tools/buildsteps/windows/BuildSetup.bat
+++ b/tools/buildsteps/windows/BuildSetup.bat
@@ -20,7 +20,6 @@ rem noprompt to avoid all prompts
 rem nobinaryaddons to skip building binary addons
 rem sh to use sh shell instead rxvt
 CLS
-COLOR 1B
 TITLE %APP_NAME% for Windows Build Script
 rem ----PURPOSE----
 rem - Create a working application build with a single click
@@ -171,8 +170,7 @@ set WORKSPACE=%base_dir%\kodi-build.%TARGET_PLATFORM%
     IF EXIST error.log del error.log > NUL
   )
 
-  rem restore color and title, some scripts mess these up
-  COLOR 1B
+  rem restore title, some scripts mess these up
   TITLE %APP_NAME% for Windows Build Script
 
   IF EXIST exclude.txt del exclude.txt > NUL


### PR DESCRIPTION
## Description
BuildSetup.bat: removes blue color from terminal

## Motivation and context
In Windows 11 22H2 it looks ugly because the blue background does not cover the entire terminal and most importantly CMake and VisualStudio already use colors to highlight warnings (yellow) and errors (red). The blue color shades this.


## What is the effect on users?
No more blue color in BuildSetup terminal

## Screenshots (if appropriate):
**Before**
![before](https://user-images.githubusercontent.com/58434170/200165803-dc5d029b-e7f2-4eab-af23-bd8a25b2d4ee.png)

**After**
![after](https://user-images.githubusercontent.com/58434170/200165808-319dcb88-8dca-42e6-96a7-b45a019aff28.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
