### PR TITLE
Revert "[Android] ndk-build: delete Android.mk and Application.mk"

### DIFF
--- a/tools/android/packaging/xbmc/jni/Android.mk
+++ b/tools/android/packaging/xbmc/jni/Android.mk
@@ -1,0 +1,3 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+LOCAL_MODULE    := xbmc

--- a/tools/android/packaging/xbmc/jni/Application.mk
+++ b/tools/android/packaging/xbmc/jni/Application.mk
@@ -1,0 +1,5 @@
+APP_PLATFORM := android-9
+APP_OPTIM = debug
+APP_ABI := armeabi-v7a
+# This would support both ARVMv5TE and ARMv7
+#APP_ABI := armeabi armeabi-v7a


### PR DESCRIPTION
Reverts xbmc/xbmc#22089

`Android.mk` is not used to build kodi, however it's required if we want to debug using [ndk-gdb](https://developer.android.com/ndk/guides/ndk-gdb).