### PR TITLE
Revert "[Estuary] Home screen: TV/Radio: On click, open the Guide window, not the Channels window.

### DIFF
--- a/addons/skin.estuary/xml/Home.xml
+++ b/addons/skin.estuary/xml/Home.xml
@@ -961,7 +961,7 @@
 						<item>
 							<label>$LOCALIZE[19020]</label>
 							<property name="menu_id">$NUMBER[12000]</property>
-							<onclick>ActivateWindow(TVGuide)</onclick>
+							<onclick>ActivateWindow(TVChannels)</onclick>
 							<thumb>icons/sidemenu/livetv.png</thumb>
 							<property name="id">livetv</property>
 							<visible>!Skin.HasSetting(HomeMenuNoTVButton)</visible>
@@ -969,7 +969,7 @@
 						<item>
 							<label>$LOCALIZE[19021]</label>
 							<property name="menu_id">$NUMBER[13000]</property>
-							<onclick>ActivateWindow(RadioGuide)</onclick>
+							<onclick>ActivateWindow(RadioChannels)</onclick>
 							<thumb>icons/sidemenu/radio.png</thumb>
 							<property name="id">radio</property>
 							<visible>!Skin.HasSetting(HomeMenuNoRadioButton)</visible>


### PR DESCRIPTION
Reason: see discussion here #21516