### PR TITLE
[video][PVR] Feature: Continue watching TV shows, seasons, movie sets and PVR recordings folders

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -5717,6 +5717,8 @@ msgstr ""
 #empty strings from id 12015 to 12020
 
 #. Label of various controls for starting playback from the beginning
+#: addons/skin.estuary/xml/SkinSettings.xml
+#: addons/skin.estuary/xml/Variables.xml
 #: xbmc/Autorun.cpp
 #: xbmc/pvr/PVRContextMenus.cpp
 #: xbmc/pvr/PVRGUIActions.cpp
@@ -6994,6 +6996,8 @@ msgid "Enable voice"
 msgstr ""
 
 #. label for resume context menu item for video folders (like a TV show or a single season of a TV show)
+#: addons/skin.estuary/xml/SkinSettings.xml
+#: addons/skin.estuary/xml/Variables.xml
 #: xbmc/video/windows/GUIWindowVideoBase.cpp
 msgctxt "#13362"
 msgid "Continue watching"

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -6993,7 +6993,13 @@ msgctxt "#13361"
 msgid "Enable voice"
 msgstr ""
 
-#empty strings from id 13362 to 13374
+#. label for resume context menu item for video folders (like a TV show or a single season of a TV show)
+#: xbmc/video/windows/GUIWindowVideoBase.cpp
+msgctxt "#13362"
+msgid "Continue watching"
+msgstr ""
+
+#empty strings from id 13363 to 13374
 
 msgctxt "#13375"
 msgid "Enable device"

--- a/addons/skin.estuary/language/resource.language.en_gb/strings.po
+++ b/addons/skin.estuary/language/resource.language.en_gb/strings.po
@@ -844,7 +844,19 @@ msgctxt "#31174"
 msgid "Default select action for albums on the home screen"
 msgstr ""
 
-#empty strings from id 31175 to 31599
+#: /xml/SkinSettings.xml
+#. Setting to control what happens when clicking a TV show on the home screen
+msgctxt "#31175"
+msgid "Default select action for TV shows on the home screen"
+msgstr ""
+
+#: /xml/SkinSettings.xml
+#. Setting to control what happens when clicking a movie set on the home screen
+msgctxt "#31176"
+msgid "Default select action for movie sets on the home screen"
+msgstr ""
+
+#empty strings from id 31177 to 31599
 
 #: /xml/DialogPlayerProcessInfo.xml
 #. Label to show the video codec name

--- a/addons/skin.estuary/xml/Home.xml
+++ b/addons/skin.estuary/xml/Home.xml
@@ -96,6 +96,8 @@
 							<param name="widget_target" value="videos"/>
 							<param name="sortby" value="random"/>
 							<param name="list_id" value="5600"/>
+							<param name="onclick_condition" value="true"/>
+							<param name="onclick_action" value="$VAR[MovieSetOnClickActionVar]"/>
 						</include>
 					</control>
 					<include content="ImageWidget" condition="!Library.HasContent(movies)">
@@ -131,6 +133,8 @@
 							<param name="widget_header" value="$LOCALIZE[626]"/>
 							<param name="widget_target" value="videos"/>
 							<param name="list_id" value="6100"/>
+							<param name="onclick_condition" value="true"/>
+							<param name="onclick_action" value="$VAR[TVShowOnClickActionVar]"/>
 						</include>
 						<include content="WidgetListEpisodes" condition="Library.HasContent(tvshows)">
 							<param name="content_path" value="special://skin/playlists/recent_unwatched_episodes.xsp"/>
@@ -143,6 +147,8 @@
 							<param name="widget_header" value="$LOCALIZE[31122]"/>
 							<param name="widget_target" value="videos"/>
 							<param name="list_id" value="6300"/>
+							<param name="onclick_condition" value="true"/>
+							<param name="onclick_action" value="$VAR[TVShowOnClickActionVar]"/>
 						</include>
 						<include content="WidgetListCategories" condition="Library.HasContent(tvshows)">
 							<param name="content_path" value="videodb://tvshows/genres/"/>

--- a/addons/skin.estuary/xml/Includes_Home.xml
+++ b/addons/skin.estuary/xml/Includes_Home.xml
@@ -26,6 +26,7 @@
 		</definition>
 	</include>
 	<include name="WidgetListPoster">
+		<param name="onclick_condition">false</param>
 		<definition>
 			<include content="CategoryLabel">
 				<param name="label">$PARAM[widget_header]</param>
@@ -41,6 +42,7 @@
 				<visible>Integer.IsGreater(Container($PARAM[list_id]).NumItems,0) | Container($PARAM[list_id]).IsUpdating</visible>
 				<right>0</right>
 				<height>503</height>
+				<onclick condition="$PARAM[onclick_condition]">$PARAM[onclick_action]</onclick>
 				<include content="WidgetListCommon">
 					<param name="list_id" value="$PARAM[list_id]"/>
 				</include>

--- a/addons/skin.estuary/xml/SkinSettings.xml
+++ b/addons/skin.estuary/xml/SkinSettings.xml
@@ -167,6 +167,13 @@
 					<onclick condition="!System.HasAddon(plugin.library.node.editor)">InstallAddon(plugin.library.node.editor)</onclick>
 					<enable>!Skin.HasSetting(HomeMenuNoMovieButton)</enable>
 				</control>
+				<control type="button" id="627">
+					<label>- $LOCALIZE[31176]</label>
+					<include>DefaultSettingButton</include>
+					<onclick>Skin.SelectBool(31176, 37015|movieset_onclick_browse, 13362|movieset_onclick_continuewatching, 12021|movieset_onclick_playfrombeginning, 10008|movieset_onclick_playnext, 13347|movieset_onclick_queue)</onclick>
+					<label2>$VAR[MovieSetOnClickActionLabel2Var]</label2>
+					<enable>!Skin.HasSetting(HomeMenuNoMovieButton)</enable>
+				</control>
 				<control type="radiobutton" id="612">
 					<label>$LOCALIZE[20343]</label>
 					<include>DefaultSettingButton</include>
@@ -179,6 +186,13 @@
 					<onclick condition="System.AddonIsEnabled(plugin.library.node.editor)">ActivateWindow(programs,plugin://plugin.library.node.editor/?ltype=video,return)</onclick>
 					<onclick condition="System.HasAddon(plugin.library.node.editor) + !System.AddonIsEnabled(plugin.library.node.editor)">EnableAddon(plugin.library.node.editor)</onclick>
 					<onclick condition="!System.HasAddon(plugin.library.node.editor)">InstallAddon(plugin.library.node.editor)</onclick>
+					<enable>!Skin.HasSetting(HomeMenuNoTVShowButton)</enable>
+				</control>
+				<control type="button" id="626">
+					<label>- $LOCALIZE[31175]</label>
+					<include>DefaultSettingButton</include>
+					<onclick>Skin.SelectBool(31175, 37015|tvshow_onclick_browse, 13362|tvshow_onclick_continuewatching, 12021|tvshow_onclick_playfrombeginning, 10008|tvshow_onclick_playnext, 13347|tvshow_onclick_queue)</onclick>
+					<label2>$VAR[TVShowOnClickActionLabel2Var]</label2>
 					<enable>!Skin.HasSetting(HomeMenuNoTVShowButton)</enable>
 				</control>
 				<control type="radiobutton" id="613">

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -194,6 +194,38 @@
 		<value condition="Skin.HasSetting(album_onclick_queue)">QueueMedia(musicdb://albums/$INFO[ListItem.DBID]/)</value>
 		<value>ActivateWindow(music,musicdb://albums/$INFO[ListItem.DBID]/,return)</value>
 	</variable>
+	<variable name="TVShowOnClickActionLabel2Var">
+		<value condition="Skin.HasSetting(tvshow_onclick_browse)">$LOCALIZE[37015]</value>
+		<value condition="Skin.HasSetting(tvshow_onclick_continuewatching)">$LOCALIZE[13362]</value>
+		<value condition="Skin.HasSetting(tvshow_onclick_playfrombeginning)">$LOCALIZE[12021]</value>
+		<value condition="Skin.HasSetting(tvshow_onclick_playnext)">$LOCALIZE[10008]</value>
+		<value condition="Skin.HasSetting(tvshow_onclick_queue)">$LOCALIZE[13347]</value>
+		<value>$LOCALIZE[37015]</value>
+	</variable>
+	<variable name="TVShowOnClickActionVar">
+		<value condition="Skin.HasSetting(tvshow_onclick_browse)">ActivateWindow(videos,videodb://tvshows/titles/$INFO[ListItem.DBID]/,return)</value>
+		<value condition="Skin.HasSetting(tvshow_onclick_continuewatching)">PlayMedia(videodb://tvshows/titles/$INFO[ListItem.DBID]/,resume)</value>
+		<value condition="Skin.HasSetting(tvshow_onclick_playfrombeginning)">PlayMedia(videodb://tvshows/titles/$INFO[ListItem.DBID]/,noresume)</value>
+		<value condition="Skin.HasSetting(tvshow_onclick_playnext)">QueueMedia(videodb://tvshows/titles/$INFO[ListItem.DBID]/,playnext)</value>
+		<value condition="Skin.HasSetting(tvshow_onclick_queue)">QueueMedia(videodb://tvshows/titles/$INFO[ListItem.DBID]/)</value>
+		<value>ActivateWindow(videos,videodb://tvshows/titles/$INFO[ListItem.DBID]/,return)</value>
+	</variable>
+	<variable name="MovieSetOnClickActionLabel2Var">
+		<value condition="Skin.HasSetting(movieset_onclick_browse)">$LOCALIZE[37015]</value>
+		<value condition="Skin.HasSetting(movieset_onclick_continuewatching)">$LOCALIZE[13362]</value>
+		<value condition="Skin.HasSetting(movieset_onclick_playfrombeginning)">$LOCALIZE[12021]</value>
+		<value condition="Skin.HasSetting(movieset_onclick_playnext)">$LOCALIZE[10008]</value>
+		<value condition="Skin.HasSetting(movieset_onclick_queue)">$LOCALIZE[13347]</value>
+		<value>$LOCALIZE[37015]</value>
+	</variable>
+	<variable name="MovieSetOnClickActionVar">
+		<value condition="Skin.HasSetting(movieset_onclick_browse)">ActivateWindow(videos,videodb://movies/sets/$INFO[ListItem.DBID]/,return)</value>
+		<value condition="Skin.HasSetting(movieset_onclick_continuewatching)">PlayMedia(videodb://movies/sets/$INFO[ListItem.DBID]/,resume)</value>
+		<value condition="Skin.HasSetting(movieset_onclick_playfrombeginning)">PlayMedia(videodb://movies/sets/$INFO[ListItem.DBID]/,noresume)</value>
+		<value condition="Skin.HasSetting(movieset_onclick_playnext)">QueueMedia(videodb://movies/sets/$INFO[ListItem.DBID]/,playnext)</value>
+		<value condition="Skin.HasSetting(movieset_onclick_queue)">QueueMedia(videodb://movies/sets/$INFO[ListItem.DBID]/)</value>
+		<value>ActivateWindow(videos,videodb://movies/sets/$INFO[ListItem.DBID]/,return)</value>
+	</variable>
 	<variable name="AddonLifecycleType">
 		<value condition="String.IsEqual(ListItem.AddonLifecycleType,$LOCALIZE[24170])">[COLOR button_focus]$LOCALIZE[24170][/COLOR][CR]$INFO[ListItem.AddonLifecycleDesc]</value> <!-- Deprecated -->
 		<value condition="String.IsEqual(ListItem.AddonLifecycleType,$LOCALIZE[24171])">[COLOR button_focus]$LOCALIZE[24171][/COLOR][CR]$INFO[ListItem.AddonLifecycleDesc]</value> <!-- Broken -->

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -517,8 +517,15 @@ public:
   // finds a matching local trailer file
   std::string FindTrailer() const;
 
-  virtual bool LoadMusicTag();
-  virtual bool LoadGameTag();
+  bool LoadMusicTag();
+  bool LoadGameTag();
+
+  /*! \brief Load detailed data for an item constructed with only a path and a folder flag
+   Fills item's video info tag, sets item properties.
+
+   \return true on success, false otherwise.
+   */
+  bool LoadDetails();
 
   /* Returns the content type of this item if known */
   const std::string& GetMimeType() const { return m_mimetype; }

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -28,6 +28,7 @@
 #include "settings/SettingsComponent.h"
 #include "utils/URIUtils.h"
 #include "video/VideoLibraryQueue.h"
+#include "video/VideoUtils.h"
 #include "video/windows/GUIWindowVideoNav.h"
 
 #include <memory>
@@ -235,18 +236,23 @@ bool CGUIWindowPVRRecordingsBase::OnMessage(CGUIMessage& message)
                 break;
               }
 
-              if (item->m_bIsFolder)
+              if (!item->IsParentFolder() && message.GetParam1() == ACTION_PLAYER_PLAY)
+              {
+                if (item->m_bIsFolder)
+                {
+                  if (CGUIWindowVideoNav::ShowResumeMenu(*item))
+                    VIDEO_UTILS::PlayItem(item);
+                }
+                else
+                  CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayRecording(
+                      *item, true /* check resume */);
+
+                bReturn = true;
+              }
+              else if (item->m_bIsFolder)
               {
                 // recording folders and ".." folders in subfolders are handled by base class.
                 bReturn = false;
-                break;
-              }
-
-              if (message.GetParam1() == ACTION_PLAYER_PLAY)
-              {
-                CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayRecording(
-                    *item, true /* check resume */);
-                bReturn = true;
               }
               else
               {

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -61,7 +61,8 @@ bool CVideoRemoveResumePoint::IsVisible(const CFileItem& itemIn) const
   if (item.IsDeleted()) // e.g. trashed pvr recording
     return false;
 
-  return CGUIWindowVideoBase::HasResumeItemOffset(&item);
+  // Folders don't have a resume point
+  return !item.m_bIsFolder && VIDEO_UTILS::GetItemResumeInformation(item).isResumable;
 }
 
 bool CVideoRemoveResumePoint::Execute(const std::shared_ptr<CFileItem>& item) const
@@ -166,7 +167,7 @@ bool CVideoResume::IsVisible(const CFileItem& itemIn) const
   if (item.IsDeleted()) // e.g. trashed pvr recording
     return false;
 
-  return CGUIWindowVideoBase::HasResumeItemOffset(&item);
+  return VIDEO_UTILS::GetItemResumeInformation(item).isResumable;
 }
 
 namespace
@@ -294,7 +295,7 @@ std::string CVideoPlay::GetLabel(const CFileItem& itemIn) const
   CFileItem item(itemIn.GetItemToPlay());
   if (item.IsLiveTV())
     return g_localizeStrings.Get(19000); // Switch to channel
-  if (CGUIWindowVideoBase::HasResumeItemOffset(&item))
+  if (VIDEO_UTILS::GetItemResumeInformation(item).isResumable)
     return g_localizeStrings.Get(12021); // Play from beginning
   return g_localizeStrings.Get(208); // Play
 }

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -513,11 +513,12 @@ public:
   bool LoadVideoInfo(const std::string& strFilenameAndPath, CVideoInfoTag& details, int getDetails = VideoDbDetailsAll);
   bool GetMovieInfo(const std::string& strFilenameAndPath, CVideoInfoTag& details, int idMovie = -1, int getDetails = VideoDbDetailsAll);
   bool GetTvShowInfo(const std::string& strPath, CVideoInfoTag& details, int idTvShow = -1, CFileItem* item = NULL, int getDetails = VideoDbDetailsAll);
+  bool GetSeasonInfo(int idSeason, CVideoInfoTag& details, CFileItem* item);
   bool GetSeasonInfo(int idSeason, CVideoInfoTag& details, bool allDetails = true);
   bool GetEpisodeBasicInfo(const std::string& strFilenameAndPath, CVideoInfoTag& details, int idEpisode  = -1);
   bool GetEpisodeInfo(const std::string& strFilenameAndPath, CVideoInfoTag& details, int idEpisode = -1, int getDetails = VideoDbDetailsAll);
   bool GetMusicVideoInfo(const std::string& strFilenameAndPath, CVideoInfoTag& details, int idMVideo = -1, int getDetails = VideoDbDetailsAll);
-  bool GetSetInfo(int idSet, CVideoInfoTag& details);
+  bool GetSetInfo(int idSet, CVideoInfoTag& details, CFileItem* item = nullptr);
   bool GetFileInfo(const std::string& strFilenameAndPath, CVideoInfoTag& details, int idFile = -1);
 
   int GetPathId(const std::string& strPath);
@@ -653,6 +654,7 @@ public:
   bool GetResumePoint(CVideoInfoTag& tag);
   bool GetStreamDetails(CFileItem& item);
   bool GetStreamDetails(CVideoInfoTag& tag) const;
+  bool GetDetailsByTypeAndId(CFileItem& item, VideoDbContentType type, int id);
   CVideoInfoTag GetDetailsByTypeAndId(VideoDbContentType type, int id);
 
   // scraper settings
@@ -1114,6 +1116,8 @@ private:
    \sa UpdateLastPlayed
    */
   CDateTime GetLastPlayed(int iFileId);
+
+  bool GetSeasonInfo(int idSeason, CVideoInfoTag& details, bool allDetails, CFileItem* item);
 
   int GetMinSchemaVersion() const override { return 75; }
   int GetSchemaVersion() const override;

--- a/xbmc/video/VideoUtils.h
+++ b/xbmc/video/VideoUtils.h
@@ -52,4 +52,18 @@ bool GetItemsForPlayList(const std::shared_ptr<CFileItem>& item, CFileItemList& 
  */
 bool IsItemPlayable(const CFileItem& item);
 
+struct ResumeInformation
+{
+  bool isResumable{false}; // the playback of the item can be resumed
+  int64_t startOffset{0}; // a start offset
+  int partNumber{0}; // a part number
+};
+
+/*!
+ \brief Check whether playback of the given item can be resumed, get detailed information.
+ \param item The item to retrieve information for
+ \return The resume information.
+ */
+ResumeInformation GetItemResumeInformation(const CFileItem& item);
+
 } // namespace VIDEO_UTILS

--- a/xbmc/video/windows/GUIWindowVideoBase.h
+++ b/xbmc/video/windows/GUIWindowVideoBase.h
@@ -33,9 +33,7 @@ public:
   bool OnMessage(CGUIMessage& message) override;
   bool OnAction(const CAction &action) override;
 
-  void PlayMovie(const CFileItem *item, const std::string &player = "");
-  static void GetResumeItemOffset(const CFileItem *item, int64_t& startoffset, int& partNumber);
-  static bool HasResumeItemOffset(const CFileItem *item);
+  void PlayMovie(const CFileItem* item, const std::string& player = "");
 
   virtual void OnItemInfo(const CFileItem& fileItem, ADDON::ScraperPtr& scraper);
 

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -284,6 +284,16 @@ void CGUIViewState::GetSortMethodLabelMasks(LABEL_MASKS& masks) const
   masks.m_strLabel2Folder.clear();
 }
 
+std::vector<SortDescription> CGUIViewState::GetSortDescriptions() const
+{
+  std::vector<SortDescription> descriptions;
+  for (const auto& desc : m_sortMethods)
+  {
+    descriptions.emplace_back(desc.m_sortDescription);
+  }
+  return descriptions;
+}
+
 void CGUIViewState::AddSortMethod(SortBy sortBy, int buttonLabel, const LABEL_MASKS &labelMasks, SortAttribute sortAttributes /* = SortAttributeNone */, SortOrder sortOrder /* = SortOrderNone */)
 {
   AddSortMethod(sortBy, sortAttributes, buttonLabel, labelMasks, sortOrder);

--- a/xbmc/view/GUIViewState.h
+++ b/xbmc/view/GUIViewState.h
@@ -41,6 +41,8 @@ public:
   int GetSortOrderLabel() const;
   void GetSortMethodLabelMasks(LABEL_MASKS& masks) const;
 
+  std::vector<SortDescription> GetSortDescriptions() const;
+
   SortOrder SetNextSortOrder();
   SortOrder GetSortOrder() const;
 


### PR DESCRIPTION
This PR adds the possibility to 'continue watching' (aka resume) for certain video folders, namely

* TV shows, incl. all seasons
* Single seasons of TV shows
* PVR recordings folders
* Movie sets

Functionality is available in the respective windows and for respective Estuary Home screen widgets via item's context menu or if default select action is Play. For the latter case, after clicking a resumable item, a small context menu will appear asking the user whether they want to continue playback were they last left or start playback right from the beginning of the TV show/season/movie set/recording folder. This is very similar to the exiting functionality for single episodes/movies/recordings:

![screenshot00001](https://user-images.githubusercontent.com/3226626/200422232-80d7fc5d-35fa-4501-91c3-add5b1bff829.png)
![screenshot00002](https://user-images.githubusercontent.com/3226626/200422229-abd0f911-2f7d-488d-8944-7902d7dd2591.png)
![screenshot00003](https://user-images.githubusercontent.com/3226626/200422224-e08dc24e-973d-40ac-92bf-9f58039afc84.png)
![screenshot00004](https://user-images.githubusercontent.com/3226626/200422216-b5188f13-614d-4d7e-a2f8-c700deb382ea.png)
![screenshot00006](https://user-images.githubusercontent.com/3226626/200422205-600bf60d-4293-41a1-a74e-2df030424300.png)

Estuary gets extended with two new skin settings which can be used to control click behavior for TV shows and movie sets on the Estuary Home screen:

![screenshot00005](https://user-images.githubusercontent.com/3226626/200421687-7c1c03bf-6cc5-4771-a21a-69738100d04e.png)
![screenshot00008](https://user-images.githubusercontent.com/3226626/200421680-051e63a8-7edd-45f5-93bb-871576e58531.png)
A TV show/season/movie set/recording folder is considered "resumable", if

* the folder contains at least one completely unwatched episode/movie/recording or
* the folder contains at least one in-progress episode/movie/recording (the video has a resume point)

The internal video playlist for the folder to resume will be assembled as follows:

1. obtain all items for the folder, then sort items by season+episode/date, ascending
2. remove everything that is completely watched
3. find the in-progress item that was watched latest, if there is one put it at the beginning of the playlist

I carefully runtime-tested the features on Android and macOS, latest Kodi master.

@enen92 could you look over the code changes, please?
@ronie I hope you find some time the very next days to review the skin chnages. OTOH, I'm quite confident that they are okay as they are implemented exactly the same way as I did for music album select setting lately. ;-)
@the-black-eagle maybe you find soeme time for a runtime-test

Other runtime-testers are very welcome, like always.

**Heads-up @fuzzard ** I really worked hard to get this feature into the state it currently has and consider it stable. I would really like to see this in v20 as it really adds end user value - tbh, this feature is long overdue!