### PR TITLE
[addons] drop info message on zip install

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -21674,11 +21674,7 @@ msgctxt "#36636"
 msgid "You must first enter a password before web server authentication can be enabled."
 msgstr ""
 
-#. Text in confirm dialog when installing addon from zip
-#: xbmc/addons/GUIWindowAddonBrowser.cpp
-msgctxt "#36637"
-msgid "Note that add-ons installed from zip (excluding served repositories) will not auto-update and must be manually updated. Would you like to proceed?"
-msgstr ""
+#empty string with id 36637
 
 #. Menuitem at "Settings -> System -> Add-ons"
 #: ./system/settings/settings.xml

--- a/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
@@ -206,18 +206,14 @@ void CGUIWindowAddonBrowser::InstallFromZip()
   }
   else
   {
-    if (ShowYesNoDialogText(19098, 36637) == DialogResponse::CHOICE_YES)
+    // pop up filebrowser to grab an installed folder
+    VECSOURCES shares = *CMediaSourceSettings::GetInstance().GetSources("files");
+    CServiceBroker::GetMediaManager().GetLocalDrives(shares);
+    CServiceBroker::GetMediaManager().GetNetworkLocations(shares);
+    std::string path;
+    if (CGUIDialogFileBrowser::ShowAndGetFile(shares, "*.zip", g_localizeStrings.Get(24041), path))
     {
-      // pop up filebrowser to grab an installed folder
-      VECSOURCES shares = *CMediaSourceSettings::GetInstance().GetSources("files");
-      CServiceBroker::GetMediaManager().GetLocalDrives(shares);
-      CServiceBroker::GetMediaManager().GetNetworkLocations(shares);
-      std::string path;
-      if (CGUIDialogFileBrowser::ShowAndGetFile(shares, "*.zip", g_localizeStrings.Get(24041),
-                                                path))
-      {
-        CAddonInstaller::GetInstance().InstallFromZip(path);
-      }
+      CAddonInstaller::GetInstance().InstallFromZip(path);
     }
   }
 }


### PR DESCRIPTION
## Description
let's drop this.

![Unbenannt](https://user-images.githubusercontent.com/58829855/200839918-166e93f2-fe07-4e50-9d0e-bad7fe2a368f.png)

## Motivation and context
https://forum.kodi.tv/showthread.php?tid=370320

## What is the effect on users?
less confusion for users, less gray hair for moderators

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
