### PR TITLE
[utils][favourites] Encapsulate 'exec strings' and 'Favourites URLs'.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -8772,44 +8772,43 @@ msgid "Action"
 msgstr ""
 
 #. Label for an action associated with a favourite.
-#: xbmc/Util.cpp
+#: xbmc/favourites/FavouritesURL.cpp
 msgctxt "#15218"
 msgid "Play media"
 msgstr ""
 
 #. Label for an action associated with a favourite
-#: xbmc/Util.cpp
+#: xbmc/favourites/FavouritesURL.cpp
 msgctxt "#15219"
 msgid "Show picture"
 msgstr ""
 
 #. Label for an action associated with a favourite. Placeholder will be filled with the name of the window the favourite's content will be displayed in.
-#: xbmc/favourites/FavouritesService.cpp
-#: xbmc/Util.cpp
+#: xbmc/favourites/FavouritesURL.cpp
 msgctxt "#15220"
 msgid "Show content in \"{}\""
 msgstr ""
 
 #. Label for an action associated with a favourite
-#: xbmc/Util.cpp
+#: xbmc/favourites/FavouritesURL.cpp
 msgctxt "#15221"
 msgid "Execute script"
 msgstr ""
 
 #. Label for an action associated with a favourite
-#: xbmc/Util.cpp
+#: xbmc/favourites/FavouritesURL.cpp
 msgctxt "#15222"
 msgid "Execute Android app"
 msgstr ""
 
 #. Label for an action associated with a favourite
-#: xbmc/Util.cpp
+#: xbmc/favourites/FavouritesURL.cpp
 msgctxt "#15223"
 msgid "Execute add-on"
 msgstr ""
 
 #. Label for an action associated with a favourite
-#: xbmc/Util.cpp
+#: xbmc/favourites/FavouritesURL.cpp
 msgctxt "#15224"
 msgid "Other / Unknown"
 msgstr ""

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -129,11 +129,7 @@ public:
    \param paramString the string to break up
    \param parameters the returned parameters
    */
-  static void SplitParams(const std::string &paramString, std::vector<std::string> &parameters);
-  static void SplitExecFunction(const std::string &execString, std::string &function, std::vector<std::string> &parameters);
-  static std::string GetExecPath(const CFileItem& item, const std::string& contextWindow);
-  static std::string GetExecActionLabelFromPath(const std::string& path);
-  static std::string GetExecProviderLabelFromPath(const std::string& path);
+  static void SplitParams(const std::string& paramString, std::vector<std::string>& parameters);
   static int GetMatchingSource(const std::string& strPath, VECSOURCES& VECSOURCES, bool& bIsSourceName);
   static std::string TranslateSpecialSource(const std::string &strSpecial);
   static void DeleteDirectoryCache(const std::string &prefix = "");

--- a/xbmc/favourites/CMakeLists.txt
+++ b/xbmc/favourites/CMakeLists.txt
@@ -2,12 +2,14 @@ set(SOURCES ContextMenus.cpp
             GUIDialogFavourites.cpp
             GUIViewStateFavourites.cpp
             GUIWindowFavourites.cpp
-            FavouritesService.cpp)
+            FavouritesService.cpp
+            FavouritesURL.cpp)
 
 set(HEADERS ContextMenus.h
             GUIDialogFavourites.h
             GUIViewStateFavourites.h
             GUIWindowFavourites.h
-            FavouritesService.h)
+            FavouritesService.h
+            FavouritesURL.h)
 
 core_add_library(favourites)

--- a/xbmc/favourites/FavouritesService.h
+++ b/xbmc/favourites/FavouritesService.h
@@ -15,12 +15,6 @@
 #include <string>
 #include <vector>
 
-enum class FavAction : int
-{
-  PLAYMEDIA,
-  SHOWPICTURE,
-};
-
 class CFavouritesService
 {
 public:

--- a/xbmc/favourites/FavouritesURL.cpp
+++ b/xbmc/favourites/FavouritesURL.cpp
@@ -1,0 +1,210 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "FavouritesURL.h"
+
+#include "FileItem.h"
+#include "ServiceBroker.h"
+#include "URL.h"
+#include "addons/AddonManager.h"
+#include "addons/IAddon.h"
+#include "guilib/LocalizeStrings.h"
+#include "input/WindowTranslator.h"
+#include "utils/ExecString.h"
+#include "utils/StringUtils.h"
+#include "utils/SystemInfo.h"
+#include "utils/URIUtils.h"
+#include "utils/log.h"
+
+#include <vector>
+
+namespace
+{
+std::string GetActionString(CFavouritesURL::Action action)
+{
+  switch (action)
+  {
+    case CFavouritesURL::Action::ACTIVATE_WINDOW:
+      return "activatewindow";
+    case CFavouritesURL::Action::PLAY_MEDIA:
+      return "playmedia";
+    case CFavouritesURL::Action::SHOW_PICTURE:
+      return "showpicture";
+    case CFavouritesURL::Action::RUN_SCRIPT:
+      return "runscript";
+    case CFavouritesURL::Action::RUN_ADDON:
+      return "runaddon";
+    case CFavouritesURL::Action::START_ANDROID_ACTIVITY:
+      return "startandroidactivity";
+    default:
+      CLog::LogF(LOGERROR, "Unsupported action");
+      return {};
+  }
+}
+
+CFavouritesURL::Action GetActionId(const std::string& actionString)
+{
+  if (actionString == "activatewindow")
+    return CFavouritesURL::Action::ACTIVATE_WINDOW;
+  else if (actionString == "playmedia")
+    return CFavouritesURL::Action::PLAY_MEDIA;
+  else if (actionString == "showpicture")
+    return CFavouritesURL::Action::SHOW_PICTURE;
+  else if (actionString == "runscript")
+    return CFavouritesURL::Action::RUN_SCRIPT;
+  else if (actionString == "runaddon")
+    return CFavouritesURL::Action::RUN_ADDON;
+  else if (actionString == "startandroidactivity")
+    return CFavouritesURL::Action::START_ANDROID_ACTIVITY;
+  else
+  {
+    CLog::LogF(LOGERROR, "Unsupported action");
+    return CFavouritesURL::Action::UNKNOWN;
+  }
+}
+} // namespace
+
+CFavouritesURL::CFavouritesURL(const std::string& favouritesURL)
+{
+  const CURL url(favouritesURL);
+  if (url.GetProtocol() != "favourites")
+  {
+    CLog::LogF(LOGERROR, "Invalid protocol");
+    return;
+  }
+
+  m_exec = CExecString(CURL::Decode(url.GetHostName()));
+  if (m_exec.IsValid())
+    m_valid = Parse(GetActionId(m_exec.GetFunction()), m_exec.GetParams());
+}
+
+CFavouritesURL::CFavouritesURL(const CExecString& execString) : m_exec(execString)
+{
+  if (m_exec.IsValid())
+    m_valid = Parse(GetActionId(m_exec.GetFunction()), m_exec.GetParams());
+}
+
+CFavouritesURL::CFavouritesURL(Action action, const std::vector<std::string>& params)
+  : m_exec(GetActionString(action), params)
+{
+  if (m_exec.IsValid())
+    m_valid = Parse(action, params);
+}
+
+CFavouritesURL::CFavouritesURL(const CFileItem& item, int contextWindow)
+  : m_exec(item, std::to_string(contextWindow))
+{
+  if (m_exec.IsValid())
+    m_valid = Parse(GetActionId(m_exec.GetFunction()), m_exec.GetParams());
+}
+
+bool CFavouritesURL::Parse(CFavouritesURL::Action action, const std::vector<std::string>& params)
+{
+  m_action = action;
+
+  bool pathIsAddonID = false;
+
+  switch (action)
+  {
+    case Action::ACTIVATE_WINDOW:
+      if (params.empty())
+      {
+        CLog::LogF(LOGERROR, "Missing parameter");
+        return false;
+      }
+
+      // mandatory: window name/id
+      m_windowId = CWindowTranslator::TranslateWindow(params[0]);
+
+      if (params.size() > 1)
+      {
+        // optional: target url/path
+        m_target = StringUtils::DeParamify(params[1]);
+      }
+      m_actionLabel =
+          StringUtils::Format(g_localizeStrings.Get(15220), // Show content in '<windowname>'
+                              g_localizeStrings.Get(m_windowId));
+      break;
+    case Action::PLAY_MEDIA:
+      if (params.empty())
+      {
+        CLog::LogF(LOGERROR, "Missing parameter");
+        return false;
+      }
+      m_target = StringUtils::DeParamify(params[0]);
+      m_actionLabel = g_localizeStrings.Get(15218); // Play media
+      break;
+    case Action::SHOW_PICTURE:
+      if (params.empty())
+      {
+        CLog::LogF(LOGERROR, "Missing parameter");
+        return false;
+      }
+      m_target = StringUtils::DeParamify(params[0]);
+      m_actionLabel = g_localizeStrings.Get(15219); // Show picture
+      break;
+    case Action::RUN_SCRIPT:
+      if (params.empty())
+      {
+        CLog::LogF(LOGERROR, "Missing parameter");
+        return false;
+      }
+      m_target = StringUtils::DeParamify(params[0]);
+      m_actionLabel = g_localizeStrings.Get(15221); // Execute script
+      pathIsAddonID = true;
+      break;
+    case Action::RUN_ADDON:
+      if (params.empty())
+      {
+        CLog::LogF(LOGERROR, "Missing parameter");
+        return false;
+      }
+      m_target = StringUtils::DeParamify(params[0]);
+      m_actionLabel = g_localizeStrings.Get(15223); // Execute add-on
+      pathIsAddonID = true;
+      break;
+    case Action::START_ANDROID_ACTIVITY:
+      if (params.empty())
+      {
+        CLog::LogF(LOGERROR, "Missing parameter");
+        return false;
+      }
+      m_target = StringUtils::DeParamify(params[0]);
+      m_actionLabel = g_localizeStrings.Get(15222); // Execute Android app
+      break;
+    default:
+      CLog::LogF(LOGWARNING, "Unsupported action, treating as playmedia(param[0])");
+      if (params.empty())
+      {
+        CLog::LogF(LOGERROR, "Missing parameter");
+        return false;
+      }
+      m_action = CFavouritesURL::Action::PLAY_MEDIA;
+      m_target = StringUtils::DeParamify(params[0]);
+      m_actionLabel = g_localizeStrings.Get(15224); // Other / Unknown
+      break;
+  }
+
+  m_path = StringUtils::Format("favourites://{}", CURL::Encode(GetExecString()));
+  m_isDir = URIUtils::HasSlashAtEnd(m_target, true);
+
+  if (pathIsAddonID || URIUtils::IsPlugin(m_target))
+  {
+    // get the add-on name
+    const std::string plugin = pathIsAddonID ? m_target : CURL(m_target).GetHostName();
+
+    ADDON::AddonPtr addon;
+    CServiceBroker::GetAddonMgr().GetAddon(plugin, addon, ADDON::OnlyEnabled::CHOICE_NO);
+    if (addon)
+      m_providerLabel = addon->Name();
+  }
+  if (m_providerLabel.empty())
+    m_providerLabel = CSysInfo::GetAppName();
+
+  return true;
+}

--- a/xbmc/favourites/FavouritesURL.h
+++ b/xbmc/favourites/FavouritesURL.h
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (C) 2012-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "utils/ExecString.h"
+
+#include <string>
+#include <vector>
+
+class CFileItem;
+
+class CFavouritesURL
+{
+public:
+  enum class Action
+  {
+    UNKNOWN,
+    ACTIVATE_WINDOW,
+    PLAY_MEDIA,
+    SHOW_PICTURE,
+    RUN_SCRIPT,
+    RUN_ADDON,
+    START_ANDROID_ACTIVITY,
+  };
+
+  explicit CFavouritesURL(const std::string& favouritesURL);
+  explicit CFavouritesURL(const CExecString& execString);
+  CFavouritesURL(Action action, const std::vector<std::string>& params);
+  CFavouritesURL(const CFileItem& item, int contextWindow);
+
+  virtual ~CFavouritesURL() = default;
+
+  std::string GetURL() const { return m_path; }
+
+  bool IsValid() const { return m_valid && m_exec.IsValid(); }
+
+  bool IsDir() const { return m_isDir; }
+
+  std::string GetExecString() const { return m_exec.GetExecString(); }
+  Action GetAction() const { return m_action; }
+  std::vector<std::string> GetParams() const { return m_exec.GetParams(); }
+  std::string GetTarget() const { return m_target; }
+  int GetWindowID() const { return m_windowId; }
+  std::string GetActionLabel() const { return m_actionLabel; }
+  std::string GetProviderLabel() const { return m_providerLabel; }
+
+private:
+  bool Parse(CFavouritesURL::Action action, const std::vector<std::string>& params);
+
+  CExecString m_exec;
+
+  bool m_valid{false};
+  std::string m_path;
+  Action m_action{Action::UNKNOWN};
+  std::string m_target;
+  int m_windowId{-1};
+  bool m_isDir{false};
+  std::string m_actionLabel;
+  std::string m_providerLabel;
+};

--- a/xbmc/favourites/GUIDialogFavourites.cpp
+++ b/xbmc/favourites/GUIDialogFavourites.cpp
@@ -10,8 +10,8 @@
 
 #include "ContextMenuManager.h"
 #include "ServiceBroker.h"
-#include "Util.h"
 #include "dialogs/GUIDialogContextMenu.h"
+#include "favourites/FavouritesURL.h"
 #include "favourites/GUIWindowFavourites.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIMessage.h"
@@ -88,7 +88,7 @@ void CGUIDialogFavourites::OnClick(int item)
     return;
 
   CGUIMessage message(GUI_MSG_EXECUTE, 0, GetID());
-  message.SetStringParam(CUtil::GetExecPath(*(*m_favourites)[item], std::to_string(GetID())));
+  message.SetStringParam(CFavouritesURL(*(*m_favourites)[item], GetID()).GetExecString());
 
   Close();
 

--- a/xbmc/favourites/GUIWindowFavourites.cpp
+++ b/xbmc/favourites/GUIWindowFavourites.cpp
@@ -10,8 +10,8 @@
 
 #include "FileItem.h"
 #include "ServiceBroker.h"
-#include "Util.h"
 #include "dialogs/GUIDialogFileBrowser.h"
+#include "favourites/FavouritesURL.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
@@ -45,7 +45,7 @@ bool CGUIWindowFavourites::OnSelect(int item)
     return false;
 
   CGUIMessage message(GUI_MSG_EXECUTE, 0, GetID());
-  message.SetStringParam(CUtil::GetExecPath(*(*m_vecItems)[item], std::to_string(GetID())));
+  message.SetStringParam(CFavouritesURL(*(*m_vecItems)[item], GetID()).GetExecString());
   CServiceBroker::GetGUI()->GetWindowManager().SendMessage(message);
 
   return true;

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -14,7 +14,6 @@
 #include "KeymapEnvironment.h"
 #include "ServiceBroker.h"
 #include "TouchTranslator.h"
-#include "Util.h"
 #include "XBMC_vkeys.h"
 #include "application/AppInboundProtocol.h"
 #include "application/Application.h"
@@ -36,6 +35,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
+#include "utils/ExecString.h"
 #include "utils/Geometry.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
@@ -681,23 +681,24 @@ bool CInputManager::AlwaysProcess(const CAction& action)
   // check if this button is mapped to a built-in function
   if (!action.GetName().empty())
   {
-    std::string builtInFunction;
-    std::vector<std::string> params;
-    CUtil::SplitExecFunction(action.GetName(), builtInFunction, params);
-    StringUtils::ToLower(builtInFunction);
-
-    // should this button be handled normally or just cancel the screensaver?
-    if (builtInFunction == "powerdown" || builtInFunction == "reboot" ||
-        builtInFunction == "restart" || builtInFunction == "restartapp" ||
-        builtInFunction == "suspend" || builtInFunction == "hibernate" ||
-        builtInFunction == "quit" || builtInFunction == "shutdown" ||
-        builtInFunction == "volumeup" || builtInFunction == "volumedown" ||
-        builtInFunction == "mute" || builtInFunction == "RunAppleScript" ||
-        builtInFunction == "RunAddon" || builtInFunction == "RunPlugin" ||
-        builtInFunction == "RunScript" || builtInFunction == "System.Exec" ||
-        builtInFunction == "System.ExecWait")
+    const CExecString exec(action.GetName());
+    if (exec.IsValid())
     {
-      return true;
+      const std::string builtInFunction = exec.GetFunction();
+
+      // should this button be handled normally or just cancel the screensaver?
+      if (builtInFunction == "powerdown" || builtInFunction == "reboot" ||
+          builtInFunction == "restart" || builtInFunction == "restartapp" ||
+          builtInFunction == "suspend" || builtInFunction == "hibernate" ||
+          builtInFunction == "quit" || builtInFunction == "shutdown" ||
+          builtInFunction == "volumeup" || builtInFunction == "volumedown" ||
+          builtInFunction == "mute" || builtInFunction == "RunAppleScript" ||
+          builtInFunction == "RunAddon" || builtInFunction == "RunPlugin" ||
+          builtInFunction == "RunScript" || builtInFunction == "System.Exec" ||
+          builtInFunction == "System.ExecWait")
+      {
+        return true;
+      }
     }
   }
 

--- a/xbmc/interfaces/builtins/Builtins.cpp
+++ b/xbmc/interfaces/builtins/Builtins.cpp
@@ -11,26 +11,25 @@
 #include "ApplicationBuiltins.h"
 #include "CECBuiltins.h"
 #include "GUIBuiltins.h"
-#include "GUIControlBuiltins.h"
 #include "GUIContainerBuiltins.h"
+#include "GUIControlBuiltins.h"
 #include "LibraryBuiltins.h"
 #include "OpticalBuiltins.h"
+#include "PVRBuiltins.h"
 #include "PictureBuiltins.h"
 #include "PlayerBuiltins.h"
 #include "ProfileBuiltins.h"
-#include "PVRBuiltins.h"
+#include "ServiceBroker.h"
 #include "SkinBuiltins.h"
 #include "SystemBuiltins.h"
 #include "WeatherBuiltins.h"
-
-#include "ServiceBroker.h"
 #include "input/InputManager.h"
 #include "powermanagement/PowerTypes.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "Util.h"
-#include "utils/log.h"
+#include "utils/ExecString.h"
 #include "utils/StringUtils.h"
+#include "utils/log.h"
 
 #if defined(TARGET_ANDROID)
 #include "AndroidBuiltins.h"
@@ -76,10 +75,12 @@ CBuiltins& CBuiltins::GetInstance()
 
 bool CBuiltins::HasCommand(const std::string& execString)
 {
-  std::string function;
-  std::vector<std::string> parameters;
-  CUtil::SplitExecFunction(execString, function, parameters);
-  StringUtils::ToLower(function);
+  const CExecString exec(execString);
+  if (!exec.IsValid())
+    return false;
+
+  const std::string function = exec.GetFunction();
+  const std::vector<std::string> parameters = exec.GetParams();
 
   if (CServiceBroker::GetInputManager().HasBuiltin(function))
     return true;
@@ -96,10 +97,11 @@ bool CBuiltins::HasCommand(const std::string& execString)
 
 bool CBuiltins::IsSystemPowerdownCommand(const std::string& execString)
 {
-  std::string execute;
-  std::vector<std::string> params;
-  CUtil::SplitExecFunction(execString, execute, params);
-  StringUtils::ToLower(execute);
+  const CExecString exec(execString);
+  if (!exec.IsValid())
+    return false;
+
+  const std::string execute = exec.GetFunction();
 
   // Check if action is resulting in system powerdown.
   if (execute == "reboot"    ||
@@ -142,10 +144,12 @@ void CBuiltins::GetHelp(std::string &help)
 
 int CBuiltins::Execute(const std::string& execString)
 {
-  std::string execute;
-  std::vector<std::string> params;
-  CUtil::SplitExecFunction(execString, execute, params);
-  StringUtils::ToLower(execute);
+  const CExecString exec(execString);
+  if (!exec.IsValid())
+    return -1;
+
+  const std::string execute = exec.GetFunction();
+  const std::vector<std::string> params = exec.GetParams();
 
   const auto& it = m_command.find(execute);
   if (it != m_command.end())

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -36,6 +36,7 @@
 #include "storage/discs/IDiscDriveHandler.h"
 #include "threads/SystemClock.h"
 #include "utils/Crc32.h"
+#include "utils/ExecString.h"
 #include "utils/FileExtensionProvider.h"
 #include "utils/FileUtils.h"
 #include "utils/LangCodeExpander.h"
@@ -95,10 +96,13 @@ namespace XBMCAddon
       // builtins is no anarchy
       // enforce some rules here
       // DialogBusy must not be activated, it is modal dialog
-      std::string execute;
-      std::vector<std::string> params;
-      CUtil::SplitExecFunction(function, execute, params);
-      StringUtils::ToLower(execute);
+      const CExecString exec(function);
+      if (!exec.IsValid())
+        return;
+
+      const std::string execute = exec.GetFunction();
+      const std::vector<std::string> params = exec.GetParams();
+
       if (StringUtils::EqualsNoCase(execute, "activatewindow") ||
           StringUtils::EqualsNoCase(execute, "closedialog"))
       {

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -11,7 +11,6 @@
 #include "ContextMenuManager.h"
 #include "FileItem.h"
 #include "ServiceBroker.h"
-#include "Util.h"
 #include "addons/AddonManager.h"
 #include "addons/gui/GUIDialogAddonInfo.h"
 #include "favourites/FavouritesService.h"
@@ -27,6 +26,7 @@
 #include "pvr/guilib/PVRGUIActionsUtils.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/ExecString.h"
 #include "utils/JobManager.h"
 #include "utils/SortUtils.h"
 #include "utils/URIUtils.h"
@@ -421,7 +421,7 @@ bool CDirectoryProvider::OnClick(const CGUIListItemPtr &item)
     fileItem.SetPath(fileItem.GetProperty("node.target_url").asString());
 
   // grab the execute string
-  const std::string execute = CUtil::GetExecPath(fileItem, GetTarget(fileItem));
+  const std::string execute = CExecString(fileItem, GetTarget(fileItem)).GetExecString();
   if (!execute.empty())
   {
     CGUIMessage message(GUI_MSG_EXECUTE, 0, 0);

--- a/xbmc/test/TestUtil.cpp
+++ b/xbmc/test/TestUtil.cpp
@@ -46,47 +46,6 @@ TEST(TestUtil, MakeLegalPath)
   EXPECT_EQ(CUtil::MakeLegalPath(path), "smb://foo/bar_/");
 }
 
-TEST(TestUtil, SplitExec)
-{
-  std::string function;
-  std::vector<std::string> params;
-  CUtil::SplitExecFunction("ActivateWindow(Video, \"C:\\test\\foo\")", function, params);
-  EXPECT_EQ(function,  "ActivateWindow");
-  EXPECT_EQ(params.size(), 2U);
-  EXPECT_EQ(params[0], "Video");
-  EXPECT_EQ(params[1], "C:\\test\\foo");
-  params.clear();
-  CUtil::SplitExecFunction("ActivateWindow(Video, \"C:\\test\\foo\\\")", function, params);
-  EXPECT_EQ(function,  "ActivateWindow");
-  EXPECT_EQ(params.size(), 2U);
-  EXPECT_EQ(params[0], "Video");
-  EXPECT_EQ(params[1], "C:\\test\\foo");
-  params.clear();
-  CUtil::SplitExecFunction("ActivateWindow(Video, \"C:\\\\test\\\\foo\\\\\")", function, params);
-  EXPECT_EQ(function,  "ActivateWindow");
-  EXPECT_EQ(params.size(), 2U);
-  EXPECT_EQ(params[0], "Video");
-  EXPECT_EQ(params[1], "C:\\test\\foo\\");
-  params.clear();
-  CUtil::SplitExecFunction("ActivateWindow(Video, \"C:\\\\\\\\test\\\\\\foo\\\\\")", function, params);
-  EXPECT_EQ(function,  "ActivateWindow");
-  EXPECT_EQ(params.size(), 2U);
-  EXPECT_EQ(params[0], "Video");
-  EXPECT_EQ(params[1], "C:\\\\test\\\\foo\\");
-  params.clear();
-  CUtil::SplitExecFunction("SetProperty(Foo,\"\")", function, params);
-  EXPECT_EQ(function,  "SetProperty");
-  EXPECT_EQ(params.size(), 2U);
-  EXPECT_EQ(params[0], "Foo");
-  EXPECT_EQ(params[1], "");
-  params.clear();
-  CUtil::SplitExecFunction("SetProperty(foo,ba(\"ba black )\",sheep))", function, params);
-  EXPECT_EQ(function,  "SetProperty");
-  EXPECT_EQ(params.size(), 2U);
-  EXPECT_EQ(params[0], "foo");
-  EXPECT_EQ(params[1], "ba(\"ba black )\",sheep)");
-}
-
 TEST(TestUtil, MakeShortenPath)
 {
   std::string result;

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SOURCES ActorProtocol.cpp
             DiscsUtils.cpp
             EndianSwap.cpp
             EmbeddedArt.cpp
+            ExecString.cpp
             FileExtensionProvider.cpp
             Fanart.cpp
             FileOperationJob.cpp
@@ -100,6 +101,7 @@ set(HEADERS ActorProtocol.h
             EndianSwap.h
             EventStream.h
             EventStreamDetail.h
+            ExecString.h
             FileExtensionProvider.h
             Fanart.h
             FileOperationJob.h

--- a/xbmc/utils/ExecString.cpp
+++ b/xbmc/utils/ExecString.cpp
@@ -1,0 +1,244 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ExecString.h"
+
+#include "FileItem.h"
+#include "ServiceBroker.h"
+#include "URL.h"
+#include "music/tags/MusicInfoTag.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
+#include "utils/StringUtils.h"
+#include "utils/Variant.h"
+#include "utils/log.h"
+#include "video/VideoInfoTag.h"
+
+CExecString::CExecString(const std::string& execString)
+{
+  m_valid = Parse(execString);
+}
+
+CExecString::CExecString(const std::string& function, const std::vector<std::string>& params)
+  : m_function(function), m_params(params)
+{
+  m_valid = !m_function.empty();
+
+  if (m_valid)
+    SetExecString();
+}
+
+CExecString::CExecString(const CFileItem& item, const std::string& contextWindow)
+{
+  m_valid = Parse(item, contextWindow);
+}
+
+namespace
+{
+void SplitParams(const std::string& paramString, std::vector<std::string>& parameters)
+{
+  bool inQuotes = false;
+  bool lastEscaped = false; // only every second character can be escaped
+  int inFunction = 0;
+  size_t whiteSpacePos = 0;
+  std::string parameter;
+  parameters.clear();
+  for (size_t pos = 0; pos < paramString.size(); pos++)
+  {
+    char ch = paramString[pos];
+    bool escaped = (pos > 0 && paramString[pos - 1] == '\\' && !lastEscaped);
+    lastEscaped = escaped;
+    if (inQuotes)
+    { // if we're in a quote, we accept everything until the closing quote
+      if (ch == '"' && !escaped)
+      { // finished a quote - no need to add the end quote to our string
+        inQuotes = false;
+      }
+    }
+    else
+    { // not in a quote, so check if we should be starting one
+      if (ch == '"' && !escaped)
+      { // start of quote - no need to add the quote to our string
+        inQuotes = true;
+      }
+      if (inFunction && ch == ')')
+      { // end of a function
+        inFunction--;
+      }
+      if (ch == '(')
+      { // start of function
+        inFunction++;
+      }
+      if (!inFunction && ch == ',')
+      { // not in a function, so a comma signifies the end of this parameter
+        if (whiteSpacePos)
+          parameter = parameter.substr(0, whiteSpacePos);
+        // trim off start and end quotes
+        if (parameter.length() > 1 && parameter[0] == '"' &&
+            parameter[parameter.length() - 1] == '"')
+          parameter = parameter.substr(1, parameter.length() - 2);
+        else if (parameter.length() > 3 && parameter[parameter.length() - 1] == '"')
+        {
+          // check name="value" style param.
+          size_t quotaPos = parameter.find('"');
+          if (quotaPos > 1 && quotaPos < parameter.length() - 1 && parameter[quotaPos - 1] == '=')
+          {
+            parameter.erase(parameter.length() - 1);
+            parameter.erase(quotaPos);
+          }
+        }
+        parameters.push_back(parameter);
+        parameter.clear();
+        whiteSpacePos = 0;
+        continue;
+      }
+    }
+    if ((ch == '"' || ch == '\\') && escaped)
+    { // escaped quote or backslash
+      parameter[parameter.size() - 1] = ch;
+      continue;
+    }
+    // whitespace handling - we skip any whitespace at the left or right of an unquoted parameter
+    if (ch == ' ' && !inQuotes)
+    {
+      if (parameter.empty()) // skip whitespace on left
+        continue;
+      if (!whiteSpacePos) // make a note of where whitespace starts on the right
+        whiteSpacePos = parameter.size();
+    }
+    else
+      whiteSpacePos = 0;
+    parameter += ch;
+  }
+  if (inFunction || inQuotes)
+    CLog::Log(LOGWARNING, "{}({}) - end of string while searching for ) or \"", __FUNCTION__,
+              paramString);
+  if (whiteSpacePos)
+    parameter.erase(whiteSpacePos);
+  // trim off start and end quotes
+  if (parameter.size() > 1 && parameter[0] == '"' && parameter[parameter.size() - 1] == '"')
+    parameter = parameter.substr(1, parameter.size() - 2);
+  else if (parameter.size() > 3 && parameter[parameter.size() - 1] == '"')
+  {
+    // check name="value" style param.
+    size_t quotaPos = parameter.find('"');
+    if (quotaPos > 1 && quotaPos < parameter.length() - 1 && parameter[quotaPos - 1] == '=')
+    {
+      parameter.erase(parameter.length() - 1);
+      parameter.erase(quotaPos);
+    }
+  }
+  if (!parameter.empty() || parameters.size())
+    parameters.push_back(parameter);
+}
+
+void SplitExecFunction(const std::string& execString,
+                       std::string& function,
+                       std::vector<std::string>& parameters)
+{
+  std::string paramString;
+
+  size_t iPos = execString.find('(');
+  size_t iPos2 = execString.rfind(')');
+  if (iPos != std::string::npos && iPos2 != std::string::npos)
+  {
+    paramString = execString.substr(iPos + 1, iPos2 - iPos - 1);
+    function = execString.substr(0, iPos);
+  }
+  else
+    function = execString;
+
+  // remove any whitespace, and the standard prefix (if it exists)
+  StringUtils::Trim(function);
+
+  SplitParams(paramString, parameters);
+}
+} // namespace
+
+bool CExecString::Parse(const std::string& execString)
+{
+  m_execString = execString;
+  SplitExecFunction(m_execString, m_function, m_params);
+
+  // Keep original function case in execstring, lowercase it in function
+  StringUtils::ToLower(m_function);
+  return true;
+}
+
+bool CExecString::Parse(const CFileItem& item, const std::string& contextWindow)
+{
+  if (item.IsFavourite())
+  {
+    const CURL url(item.GetPath());
+    Parse(CURL::Decode(url.GetHostName()));
+  }
+  else if (item.m_bIsFolder &&
+           (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_playlistAsFolders ||
+            !(item.IsSmartPlayList() || item.IsPlayList())))
+  {
+    if (!contextWindow.empty())
+      Build("ActivateWindow", {contextWindow, StringUtils::Paramify(item.GetPath()), "return"});
+  }
+  else if (item.IsScript() && item.GetPath().size() > 9) // script://<foo>
+    Build("RunScript", {StringUtils::Paramify(item.GetPath().substr(9))});
+  else if (item.IsAddonsPath() && item.GetPath().size() > 9) // addons://<foo>
+  {
+    const CURL url(item.GetPath());
+    if (url.GetHostName() == "install")
+      Build("InstallFromZip", {});
+    else if (url.GetHostName() == "check_for_updates")
+      Build("UpdateAddonRepos", {"showProgress"});
+    else
+      Build("RunAddon", {StringUtils::Paramify(url.GetFileName())});
+  }
+  else if (item.IsAndroidApp() && item.GetPath().size() > 26) // androidapp://sources/apps/<foo>
+    Build("StartAndroidActivity", {StringUtils::Paramify(item.GetPath().substr(26))});
+  else // assume a media file
+  {
+    if (item.IsVideoDb() && item.HasVideoInfoTag())
+      BuildPlayMedia(item, StringUtils::Paramify(item.GetVideoInfoTag()->m_strFileNameAndPath));
+    else if (item.IsMusicDb() && item.HasMusicInfoTag())
+      BuildPlayMedia(item, StringUtils::Paramify(item.GetMusicInfoTag()->GetURL()));
+    else if (item.IsPicture())
+      Build("ShowPicture", {StringUtils::Paramify(item.GetPath())});
+    else
+    {
+      // Everything else will be treated as PlayMedia for item's path
+      BuildPlayMedia(item, StringUtils::Paramify(item.GetPath()));
+    }
+  }
+  return true;
+}
+
+void CExecString::Build(const std::string& function, const std::vector<std::string>& params)
+{
+  m_function = function;
+  m_params = params;
+  SetExecString();
+}
+
+void CExecString::BuildPlayMedia(const CFileItem& item, const std::string& target)
+{
+  std::vector<std::string> params{target};
+
+  if (item.HasProperty("playlist_type_hint"))
+    params.emplace_back("playlist_type_hint=" + item.GetProperty("playlist_type_hint").asString());
+
+  Build("PlayMedia", params);
+}
+
+void CExecString::SetExecString()
+{
+  if (m_params.empty())
+    m_execString = m_function;
+  else
+    m_execString = StringUtils::Format("{}({})", m_function, StringUtils::Join(m_params, ","));
+
+  // Keep original function case in execstring, lowercase it in function
+  StringUtils::ToLower(m_function);
+}

--- a/xbmc/utils/ExecString.h
+++ b/xbmc/utils/ExecString.h
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (C) 2012-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+class CFileItem;
+
+class CExecString
+{
+public:
+  CExecString() = default;
+  explicit CExecString(const std::string& execString);
+  CExecString(const std::string& function, const std::vector<std::string>& params);
+  CExecString(const CFileItem& item, const std::string& contextWindow);
+
+  virtual ~CExecString() = default;
+
+  std::string GetExecString() const { return m_execString; }
+
+  bool IsValid() const { return m_valid; }
+
+  std::string GetFunction() const { return m_function; }
+  std::vector<std::string> GetParams() const { return m_params; }
+
+private:
+  bool Parse(const std::string& execString);
+  bool Parse(const CFileItem& item, const std::string& contextWindow);
+
+  void Build(const std::string& function, const std::vector<std::string>& params);
+  void BuildPlayMedia(const CFileItem& item, const std::string& target);
+
+  void SetExecString();
+
+  bool m_valid{false};
+  std::string m_function;
+  std::vector<std::string> m_params;
+  std::string m_execString;
+};

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1791,6 +1791,26 @@ std::string StringUtils::Paramify(const std::string &param)
   return "\"" + result + "\"";
 }
 
+std::string StringUtils::DeParamify(const std::string& param)
+{
+  std::string result = param;
+
+  // remove double quotes around the whole string
+  if (StringUtils::StartsWith(result, "\"") && StringUtils::EndsWith(result, "\""))
+  {
+    result.erase(0, 1);
+    result.pop_back();
+
+    // unescape double quotes
+    StringUtils::Replace(result, "\\\"", "\"");
+
+    // unescape backspaces
+    StringUtils::Replace(result, "\\\\", "\\");
+  }
+
+  return result;
+}
+
 std::vector<std::string> StringUtils::Tokenize(const std::string &input, const std::string &delimiters)
 {
   std::vector<std::string> tokens;

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -355,6 +355,15 @@ public:
    */
   static std::string Paramify(const std::string &param);
 
+  /*! \brief Unescapes the given string.
+
+   Unescapes backslashes and double-quotes and removes double-quotes around the whole string.
+
+   \param param String to unescape/deparamify
+   \return Unescaped/Deparamified string
+   */
+  static std::string DeParamify(const std::string& param);
+
   /*! \brief Split a string by the specified delimiters.
    Splits a string using one or more delimiting characters, ignoring empty tokens.
    Differs from Split() in two ways:

--- a/xbmc/utils/test/CMakeLists.txt
+++ b/xbmc/utils/test/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCES TestAlarmClock.cpp
             TestDatabaseUtils.cpp
             TestDigest.cpp
             TestEndianSwap.cpp
+            TestExecString.cpp
             TestFileOperationJob.cpp
             TestFileUtils.cpp
             TestGlobalsHandling.cpp

--- a/xbmc/utils/test/TestExecString.cpp
+++ b/xbmc/utils/test/TestExecString.cpp
@@ -1,0 +1,118 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "FileItem.h"
+#include "utils/ExecString.h"
+
+#include <gtest/gtest.h>
+
+TEST(TestExecString, ctor_1)
+{
+  {
+    const CExecString exec("ActivateWindow(Video, \"C:\\test\\foo\")");
+    EXPECT_EQ(exec.IsValid(), true);
+    EXPECT_EQ(exec.GetFunction(), "activatewindow");
+    EXPECT_EQ(exec.GetParams().size(), 2U);
+    EXPECT_EQ(exec.GetParams()[0], "Video");
+    EXPECT_EQ(exec.GetParams()[1], "C:\\test\\foo");
+    EXPECT_EQ(exec.GetExecString(), "ActivateWindow(Video, \"C:\\test\\foo\")");
+  }
+  {
+    const CExecString exec("ActivateWindow(Video, \"C:\\test\\foo\\\")");
+    EXPECT_EQ(exec.IsValid(), true);
+    EXPECT_EQ(exec.GetFunction(), "activatewindow");
+    EXPECT_EQ(exec.GetParams().size(), 2U);
+    EXPECT_EQ(exec.GetParams()[0], "Video");
+    EXPECT_EQ(exec.GetParams()[1], "C:\\test\\foo");
+    EXPECT_EQ(exec.GetExecString(), "ActivateWindow(Video, \"C:\\test\\foo\\\")");
+  }
+  {
+    const CExecString exec("ActivateWindow(Video, \"C:\\\\test\\\\foo\\\\\")");
+    EXPECT_EQ(exec.IsValid(), true);
+    EXPECT_EQ(exec.GetFunction(), "activatewindow");
+    EXPECT_EQ(exec.GetParams().size(), 2U);
+    EXPECT_EQ(exec.GetParams()[0], "Video");
+    EXPECT_EQ(exec.GetParams()[1], "C:\\test\\foo\\");
+    EXPECT_EQ(exec.GetExecString(), "ActivateWindow(Video, \"C:\\\\test\\\\foo\\\\\")");
+  }
+  {
+    const CExecString exec("ActivateWindow(Video, \"C:\\\\\\\\test\\\\\\foo\\\\\")");
+    EXPECT_EQ(exec.IsValid(), true);
+    EXPECT_EQ(exec.GetFunction(), "activatewindow");
+    EXPECT_EQ(exec.GetParams().size(), 2U);
+    EXPECT_EQ(exec.GetParams()[0], "Video");
+    EXPECT_EQ(exec.GetParams()[1], "C:\\\\test\\\\foo\\");
+    EXPECT_EQ(exec.GetExecString(), "ActivateWindow(Video, \"C:\\\\\\\\test\\\\\\foo\\\\\")");
+  }
+  {
+    const CExecString exec("SetProperty(Foo,\"\")");
+    EXPECT_EQ(exec.IsValid(), true);
+    EXPECT_EQ(exec.GetFunction(), "setproperty");
+    EXPECT_EQ(exec.GetParams().size(), 2U);
+    EXPECT_EQ(exec.GetParams()[0], "Foo");
+    EXPECT_EQ(exec.GetParams()[1], "");
+    EXPECT_EQ(exec.GetExecString(), "SetProperty(Foo,\"\")");
+  }
+  {
+    const CExecString exec("SetProperty(foo,ba(\"ba black )\",sheep))");
+    EXPECT_EQ(exec.IsValid(), true);
+    EXPECT_EQ(exec.GetFunction(), "setproperty");
+    EXPECT_EQ(exec.GetParams().size(), 2U);
+    EXPECT_EQ(exec.GetParams()[0], "foo");
+    EXPECT_EQ(exec.GetParams()[1], "ba(\"ba black )\",sheep)");
+    EXPECT_EQ(exec.GetExecString(), "SetProperty(foo,ba(\"ba black )\",sheep))");
+  }
+}
+
+TEST(TestExecString, ctor_2)
+{
+  {
+    const CExecString exec("ActivateWindow", {"Video", "C:\\test\\foo"});
+    EXPECT_EQ(exec.IsValid(), true);
+    EXPECT_EQ(exec.GetFunction(), "activatewindow");
+    EXPECT_EQ(exec.GetParams().size(), 2U);
+    EXPECT_EQ(exec.GetParams()[0], "Video");
+    EXPECT_EQ(exec.GetParams()[1], "C:\\test\\foo");
+    EXPECT_EQ(exec.GetExecString(), "ActivateWindow(Video,C:\\test\\foo)");
+  }
+}
+
+TEST(TestExecString, ctor_3)
+{
+  {
+    const CFileItem item("C:\\test\\foo", true);
+    const CExecString exec(item, "Video");
+    EXPECT_EQ(exec.IsValid(), true);
+    EXPECT_EQ(exec.GetFunction(), "activatewindow");
+    EXPECT_EQ(exec.GetParams().size(), 3U);
+    EXPECT_EQ(exec.GetParams()[0], "Video");
+    EXPECT_EQ(exec.GetParams()[1], "\"C:\\\\test\\\\foo\\\\\"");
+    EXPECT_EQ(exec.GetParams()[2], "return");
+    EXPECT_EQ(exec.GetExecString(), "ActivateWindow(Video,\"C:\\\\test\\\\foo\\\\\",return)");
+  }
+  {
+    const CFileItem item("C:\\test\\foo\\", true);
+    const CExecString exec(item, "Video");
+    EXPECT_EQ(exec.IsValid(), true);
+    EXPECT_EQ(exec.GetFunction(), "activatewindow");
+    EXPECT_EQ(exec.GetParams().size(), 3U);
+    EXPECT_EQ(exec.GetParams()[0], "Video");
+    EXPECT_EQ(exec.GetParams()[1], "\"C:\\\\test\\\\foo\\\\\"");
+    EXPECT_EQ(exec.GetParams()[2], "return");
+    EXPECT_EQ(exec.GetExecString(), "ActivateWindow(Video,\"C:\\\\test\\\\foo\\\\\",return)");
+  }
+  {
+    const CFileItem item("C:\\test\\foo", false);
+    const CExecString exec(item, "Video");
+    EXPECT_EQ(exec.IsValid(), true);
+    EXPECT_EQ(exec.GetFunction(), "playmedia");
+    EXPECT_EQ(exec.GetParams().size(), 1U);
+    EXPECT_EQ(exec.GetParams()[0], "\"C:\\\\test\\\\foo\"");
+    EXPECT_EQ(exec.GetExecString(), "PlayMedia(\"C:\\\\test\\\\foo\")");
+  }
+}


### PR DESCRIPTION
Add classes `CExecString` and `CFavouritesURL`, adapt code base to use these new classes.

Currently, "exec strings" (strings, encoding a function call, like calling a builtin) are not encapsulated, some free functions float around in `CUtil` and there is code scattered across our code base interpreting and manipulating those strings directly. Same applies for Favourites URLs, which internally use exec strings.

This PR encapsulates both exec strings (class `CExecString`) and Favourites URLs (class `CFavouritesURL`).

I need this not only to cleanup the code, but also for an upcoming feature for Nexus. :-)

Runtime-tested on macOS and Android, latest Kodi master.

@garbear would be great if you find some time for a code review.