### PR TITLE
[cmake][android] Fix Android packaing multithreaded builds

### DIFF
--- a/cmake/scripts/android/Install.cmake
+++ b/cmake/scripts/android/Install.cmake
@@ -152,7 +152,7 @@ if(CPU MATCHES i686)
 endif()
 foreach(target apk obb apk-obb apk-clean)
   add_custom_target(${target}
-      COMMAND env PATH=${NATIVEPREFIX}/bin:$ENV{PATH} ${CMAKE_MAKE_PROGRAM}
+      COMMAND env PATH=${NATIVEPREFIX}/bin:$ENV{PATH} ${CMAKE_MAKE_PROGRAM} -j1
               -C ${CMAKE_BINARY_DIR}/tools/android/packaging
               CMAKE_SOURCE_DIR=${CMAKE_SOURCE_DIR}
               CC=${CMAKE_C_COMPILER}

--- a/cmake/scripts/android/Install.cmake
+++ b/cmake/scripts/android/Install.cmake
@@ -109,6 +109,7 @@ function(add_bundle_file file destination relative)
     file(REMOVE ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/BundleFiles.cmake)
     add_custom_target(bundle_files COMMAND ${CMAKE_COMMAND} -P ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/BundleFiles.cmake)
     add_dependencies(bundle bundle_files)
+    add_dependencies(bundle_files ${APP_NAME_LC})
   endif()
 
   string(REPLACE "${relative}/" "" outfile ${file})


### PR DESCRIPTION
## Description
Easiest to read the descriptions of each commit.
However with both of these in place, on a Mac M1, i can now run for example
```
make apk -j10
```

And get a full complete apk built using multiple threads. Our dependency graphs arent really well optimised for multi threaded builds, but at least i can now do it.

Jenkins seems to just be pure luck that it works. It actually forces the apk target back to j1 anyway

```
18:59:59 make[4]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
```

And just lucky that it orders the bundle_files target after all its copy source files are actually built and in place.
I would like to do the bundle_files target without adding the hard dependency on the core app target, but if i used for eg the pack-skins target (which does the xbt packing), the next error is about libdvdnav, and i really dont want to hardcode that as a requirement.

```
CMake Error at build/BundleFiles.cmake:1987 (file):
  file COPY cannot find
  "/Users/brent/Dev/macos/build/system/players/VideoPlayer/libdvdnav-aarch64.so":
  No such file or directory.


make[3]: *** [CMakeFiles/bundle_files] Error 1
make[2]: *** [CMakeFiles/bundle_files.dir/all] Error 2
```

In general, i think our dependency ordering/targeting needs to be rejigged to really get the most out of things, but this works for now.

## Motivation and context
Allow faster builds of android

## How has this been tested?
Build android aarch64 apk on a Mac M1 (GNU Make 3.81)

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
