### PR TITLE
[Android] ndk-build: delete Application.mk

### DIFF
--- a/tools/android/packaging/xbmc/jni/Application.mk
+++ b/tools/android/packaging/xbmc/jni/Application.mk
@@ -1,5 +1,0 @@
-APP_PLATFORM := android-9
-APP_OPTIM = debug
-APP_ABI := armeabi-v7a
-# This would support both ARVMv5TE and ARMv7
-#APP_ABI := armeabi armeabi-v7a


### PR DESCRIPTION
## Description
This configuration file is part of the ndk-build script used to build Android projects.

Can be deleted as Kodi uses a customized toolchain for the project instead.

## How has this been tested?
Kodi builds and runs fine on Android TV 9

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
