### PR TITLE
[tools/depends][python3] Patch upstream issue memleak

### DIFF
--- a/tools/depends/target/python3/01-fix-memleak-PR99301.patch
+++ b/tools/depends/target/python3/01-fix-memleak-PR99301.patch
@@ -1,0 +1,38 @@
+--- a/Python/pystate.c
++++ b/Python/pystate.c
+@@ -341,6 +341,7 @@ PyInterpreterState_New(void)
+         interp = &runtime->_main_interpreter;
+         assert(interp->id == 0);
+         assert(interp->next == NULL);
++        assert(interp->_static);
+ 
+         interpreters->main = interp;
+     }
+@@ -355,6 +356,9 @@ PyInterpreterState_New(void)
+         // Set to _PyInterpreterState_INIT.
+         memcpy(interp, &initial._main_interpreter,
+                sizeof(*interp));
++        // We need to adjust any fields that are different from the initial
++        // interpreter (as defined in _PyInterpreterState_INIT):
++        interp->_static = false;
+ 
+         if (id < 0) {
+             /* overflow or Py_Initialize() not called yet! */
+@@ -817,6 +821,7 @@ new_threadstate(PyInterpreterState *interp)
+         assert(id == 1);
+         used_newtstate = 0;
+         tstate = &interp->_initial_thread;
++        assert(tstate->_static);
+     }
+     else {
+         // Every valid interpreter must have at least one thread.
+@@ -828,6 +833,9 @@ new_threadstate(PyInterpreterState *interp)
+         memcpy(tstate,
+                &initial._main_interpreter._initial_thread,
+                sizeof(*tstate));
++        // We need to adjust any fields that are different from the initial
++        // thread (as defined in _PyThreadState_INIT):
++        tstate->_static = false;
+     }
+     interp->threads.head = tstate;
+ 

--- a/tools/depends/target/python3/Makefile
+++ b/tools/depends/target/python3/Makefile
@@ -3,6 +3,7 @@ DEPS = ../../Makefile.include Makefile PYTHON3-VERSION ../../download-files.incl
                                  apple.patch \
                                  crosscompile.patch \
                                  darwin_embedded.patch \
+                                 01-fix-memleak-PR99301.patch \
                                  10-android-modules.patch \
                                  10-linux-modules.patch \
                                  10-osx-modules.patch \
@@ -56,6 +57,9 @@ all: .installed-$(PLATFORM)
 $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE) $(DEPS)
 	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+# Temp patch to resolve https://github.com/python/cpython/issues/99205
+# Remove in 3.11.1+ bump
+	cd $(PLATFORM); patch -p1 -i ../01-fix-memleak-PR99301.patch
 	cd $(PLATFORM); patch -p1 -i ../crosscompile.patch
 	cd $(PLATFORM); patch -p1 -i ../apple.patch
 ifeq ($(OS),darwin_embedded)


### PR DESCRIPTION
## Description
A memleak was found in cpython 3.11.0 that looks to potentially be reasonably serious.
Upstream issue is https://github.com/python/cpython/issues/99205 
This uses the merged upstream patch https://github.com/python/cpython/pull/99301 until we bump to a newer release (3.11.1+)

## Motivation and context
Stable Android/apple 

## How has this been tested?
Upstream cpython

## What is the effect on users?
Potentially more stable memory usage

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
