### PR TITLE
[Subtitle][SAMI] Fix regex to find Sync tag

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSami.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSami.cpp
@@ -35,7 +35,7 @@ bool CDVDSubtitleParserSami::Open(CDVDStreamInfo& hints)
     return false;
 
   CRegExp regLine(true);
-  if (!regLine.RegComp("<SYNC START=\"?([0-9]+)\"?>(.+)"))
+  if (!regLine.RegComp("<SYNC START=\"?([0-9]+)\"?>(.+)?"))
     return false;
   CRegExp regClassID(true);
   if (!regClassID.RegComp("<P Class=\"?([\\w\\d]+)\"?>"))

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSami.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSami.cpp
@@ -48,7 +48,9 @@ bool CDVDSubtitleParserSami::Open(CDVDStreamInfo& hints)
   CDVDSubtitleTagSami TagConv;
   if (!TagConv.Init())
     return false;
+
   TagConv.LoadHead(m_pStream.get());
+
   // If there are more languages contained in a file,
   // try getting the language class ID that matches the language name
   // specified in the filename
@@ -71,7 +73,7 @@ bool CDVDSubtitleParserSami::Open(CDVDStreamInfo& hints)
     }
   }
 
-  const char* langClassID = NULL;
+  const char* langClassID{nullptr};
   if (!strClassID.empty())
   {
     StringUtils::ToLower(strClassID);
@@ -100,17 +102,25 @@ bool CDVDSubtitleParserSami::Open(CDVDStreamInfo& hints)
     int pos = regLine.RegFind(line);
     if (pos > -1) // Sync tag found
     {
-      double currStartTime = (double)atoi(regLine.GetMatch(1).c_str());
+      double currStartTime = static_cast<double>(std::atoi(regLine.GetMatch(1).c_str()));
       double currPTSStartTime = currStartTime * DVD_TIME_BASE / 1000;
-      std::string text = regLine.GetMatch(2);
 
       // We set the duration for the previous line (Event) by using the current start time
       ChangeSubtitleStopTime(prevSubId, currPTSStartTime);
 
       // We try to get text after Sync tag (if exists)
-      TagConv.ConvertLine(text, langClassID);
-      TagConv.CloseTag(text);
-      prevSubId = AddSubtitle(text, currPTSStartTime, currPTSStartTime + defaultDuration);
+      std::string text = regLine.GetMatch(2);
+      if (text.empty())
+      {
+        prevSubId = NO_SUBTITLE_ID;
+      }
+      else
+      {
+        TagConv.ConvertLine(text, langClassID);
+        TagConv.CloseTag(text);
+        prevSubId = AddSubtitle(text, currPTSStartTime, currPTSStartTime + defaultDuration);
+      }
+
       lastPTSStartTime = currPTSStartTime;
     }
     else
@@ -120,6 +130,7 @@ bool CDVDSubtitleParserSami::Open(CDVDStreamInfo& hints)
       // but they have to match the current language Class ID (if set)
       if (!strClassID.empty() && strClassID != lastLangClassID)
         continue;
+
       std::string text(line);
       TagConv.ConvertLine(text, langClassID);
       TagConv.CloseTag(text);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Fix the regex to find Sync tag
there may not always be inline text (after) the Sync tag

I think better wait an answer from author reported before merge, just to be sure

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Report to forum
https://forum.kodi.tv/showthread.php?tid=364572&pid=3117442#pid3117442

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
[SAMI_Test.zip](https://github.com/xbmc/xbmc/files/9992259/SAMI_Test.zip)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Display SAMI subtitles

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
