### PR TITLE
Add support for action "play" to many more items

### DIFF
--- a/xbmc/favourites/GUIWindowFavourites.h
+++ b/xbmc/favourites/GUIWindowFavourites.h
@@ -29,6 +29,7 @@ protected:
   std::string GetRootPath() const override { return "favourites://"; }
 
   bool OnSelect(int item) override;
+  bool OnAction(const CAction& action) override;
   bool OnMessage(CGUIMessage& message) override;
 
   bool Update(const std::string& strDirectory, bool updateFilterPath = true) override;

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -418,6 +418,18 @@ bool CGUIBaseContainer::OnAction(const CAction &action)
 
     return false;
 
+  case ACTION_PLAYER_PLAY:
+    if (m_listProvider)
+    {
+      const size_t selected = GetSelectedItem();
+      if (selected >= 0 && selected < m_items.size())
+      {
+        if (m_listProvider->OnPlay(m_items[selected]))
+          return true;
+      }
+    }
+    break;
+
   case ACTION_FIRST_PAGE:
     SelectItem(0);
     return true;

--- a/xbmc/listproviders/DirectoryProvider.h
+++ b/xbmc/listproviders/DirectoryProvider.h
@@ -64,6 +64,7 @@ public:
   void Fetch(std::vector<CGUIListItemPtr> &items) override;
   void Reset() override;
   bool OnClick(const CGUIListItemPtr &item) override;
+  bool OnPlay(const CGUIListItemPtr& item) override;
   bool OnInfo(const CGUIListItemPtr &item) override;
   bool OnContextMenu(const CGUIListItemPtr &item) override;
   bool IsUpdating() const override;

--- a/xbmc/listproviders/IListProvider.h
+++ b/xbmc/listproviders/IListProvider.h
@@ -75,6 +75,12 @@ public:
    */
   virtual bool OnClick(const CGUIListItemPtr &item)=0;
 
+  /*! \brief Play event on an item.
+   \param item the item to play.
+   \return true if the event was handled, false otherwise.
+   */
+  virtual bool OnPlay(const CGUIListItemPtr& item) { return false; }
+
   /*! \brief Open the info dialog for an item provided by this IListProvider.
    \param item the item that was clicked.
    \return true if the dialog was shown, false otherwise.

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -46,6 +46,7 @@ set(SOURCES ActorProtocol.cpp
             MovingSpeed.cpp
             Observer.cpp
             POUtils.cpp
+            PlayerUtils.cpp
             RecentlyAddedJob.cpp
             RegExp.cpp
             rfft.cpp
@@ -144,6 +145,7 @@ set(HEADERS ActorProtocol.h
             Observer.h
             params_check_macros.h
             POUtils.h
+            PlayerUtils.h
             ProgressJob.h
             RecentlyAddedJob.h
             RegExp.h

--- a/xbmc/utils/PlayerUtils.cpp
+++ b/xbmc/utils/PlayerUtils.cpp
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PlayerUtils.h"
+
+#include "FileItem.h"
+#include "music/MusicUtils.h"
+#include "utils/Variant.h"
+#include "video/VideoUtils.h"
+
+bool CPlayerUtils::IsItemPlayable(const CFileItem& itemIn)
+{
+  const CFileItem item(itemIn.GetItemToPlay());
+
+  // General
+  if (item.IsParentFolder())
+    return false;
+
+  // Plugins
+  if (item.IsPlugin() && item.GetProperty("isplayable").asBoolean())
+    return true;
+
+  // Music
+  if (MUSIC_UTILS::IsItemPlayable(item))
+    return true;
+
+  // Movies / TV Shows / Music Videos
+  if (VIDEO_UTILS::IsItemPlayable(item))
+    return true;
+
+  //! @todo add more types on demand.
+
+  return false;
+}

--- a/xbmc/utils/PlayerUtils.h
+++ b/xbmc/utils/PlayerUtils.h
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+class CFileItem;
+
+class CPlayerUtils
+{
+public:
+  static bool IsItemPlayable(const CFileItem& item);
+};


### PR DESCRIPTION
Technically, this PR extends `CDirectoryProvider` and `CGUIWindowFavourites` to handle the action `ACTION_PLAYER_PLAY`.

For the end user, this adds to just press play on their remote or p on their keyboard (or whatever action "play" was mapped by the user to) on many of the Home screen widget items usually to find in the Kodi GUI (movies, episodes, Live-TV channels, recordings, but also whole folders like music albums, recording folders, movie sets, whole TV Shows, ...) ... and this will also work for favourites, both on the Home screen and from within the new Favourites window.

I carefully runtime-tested this on macOS and Android, and consider the risk to break something very low.

@enen92 could you do a code review, please?

@fuzzard this is the last PR with late features for Nexus. Only fixes from my end once this one got merged. ;-)