### PR TITLE
[music] Fix crash when queueing multichannel audio files.

### DIFF
--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -564,12 +564,19 @@ void CAsyncGetItemsForPlaylist::GetItemsForPlaylist(const std::shared_ptr<CFileI
 
 void ShowToastNotification(const CFileItem& item, int titleId)
 {
-  const std::string localizedMediaType =
-      CMediaTypes::GetCapitalLocalization(item.GetMusicInfoTag()->GetType());
+  std::string localizedMediaType;
+  std::string title;
 
-  std::string title = item.GetMusicInfoTag()->GetTitle();
+  if (item.HasMusicInfoTag())
+  {
+    localizedMediaType = CMediaTypes::GetCapitalLocalization(item.GetMusicInfoTag()->GetType());
+    title = item.GetMusicInfoTag()->GetTitle();
+  }
+
   if (title.empty())
     title = item.GetLabel();
+  if (title.empty())
+    return; // no meaningful toast possible.
 
   const std::string message =
       localizedMediaType.empty() ? title : localizedMediaType + ": " + title;


### PR DESCRIPTION
Fixes #22124 
Follout from #22048

Was a simple and stupid nullptr deref. We do not always have a music info tag, especially not when navigating/controlling outside of the library structures.
 
Runtime-tested on macOS, latest master.

@enen92 does the fix look sane and safe?