### PR TITLE
Revert "[subtitles] Fix CC condition for valid captions"

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
@@ -153,9 +153,7 @@ DemuxPacket* CDVDDemuxCC::Read(DemuxPacket *pSrcPacket)
 
   while ((len = pSrcPacket->iSize - p) > 3)
   {
-    uint8_t* buf = pSrcPacket->pData + p;
-    bool validCaption = (buf[0] & 0x04) > 0;
-    if (validCaption)
+    if ((startcode & 0xffffff00) == 0x00000100)
     {
       if (m_codec == AV_CODEC_ID_MPEG2VIDEO)
       {
@@ -164,11 +162,13 @@ DemuxPacket* CDVDDemuxCC::Read(DemuxPacket *pSrcPacket)
         {
           if (len > 4)
           {
+            uint8_t *buf = pSrcPacket->pData + p;
             picType = (buf[1] & 0x38) >> 3;
           }
         }
         else if (scode == 0xb2) // user data
         {
+          uint8_t *buf = pSrcPacket->pData + p;
           if (len >= 6 &&
             buf[0] == 'G' && buf[1] == 'A' && buf[2] == '9' && buf[3] == '4' &&
             buf[4] == 3 && (buf[5] & 0x40))
@@ -230,6 +230,7 @@ DemuxPacket* CDVDDemuxCC::Read(DemuxPacket *pSrcPacket)
         // slice data comes after SEI
         if (scode >= 1 && scode <= 5)
         {
+          uint8_t *buf = pSrcPacket->pData + p;
           CBitstream bs(buf, len * 8);
           bs.readGolombUE();
           int sliceType = bs.readGolombUE();
@@ -248,6 +249,7 @@ DemuxPacket* CDVDDemuxCC::Read(DemuxPacket *pSrcPacket)
         }
         if (scode == 0x06) // SEI
         {
+          uint8_t *buf = pSrcPacket->pData + p;
           if (len >= 12 &&
             buf[3] == 0 && buf[4] == 49 &&
             buf[5] == 'G' && buf[6] == 'A' && buf[7] == '9' && buf[8] == '4' && buf[9] == 3)


### PR DESCRIPTION
This reverts commit e089287ab02181bb57189557365888858088502c.

## Description
Originally added to fix an issue with a user provided sample, the implementation/condition is actually wrong: the valid bit should be used only when decoding the subs and for demuxing (it already exists on the decoders). The demuxer implementation also seems to be wrong, the 0x00000100 start code seems to only be valid for mpeg2 and doesn't apply for h264 that being the root cause for the original issue.

I think the way to improve this is the future is to drop our custom demuxer and rely only ffmpeg A53 side data (AV_FRAME_DATA_A53_CC) to obtain the CC packets. Then we can reuse the current infrastructure for decoding (similar to what mythtv does).

As this solution requires time and we are almost near release let's just revert this for now. Maybe for O* the situation can be improved.

Closes https://github.com/xbmc/xbmc/issues/22132
