### PR TITLE
WinSystemX11: fix XStringListToTextProperty() cleanup

### DIFF
--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -845,6 +845,8 @@ bool CWinSystemX11::SetWindow(int width, int height, bool fullscreen, const std:
                             class_hints);
       XFree(class_hints);
       XFree(wm_hints);
+      XFree(iconName.value);
+      XFree(windowName.value);
 
       // register interest in the delete window message
       Atom wmDeleteMessage = XInternAtom(m_dpy, "WM_DELETE_WINDOW", False);


### PR DESCRIPTION
## Description
This commit fixes a minor issue detected by the sanitizer. The logs are available below.

## Motivation and context
The goal is to clean up some issues detected by the sanitizer.

## How has this been tested?
-DECM_ENABLE_SANITIZERS='leak' exists, but it does not pass the proper option to the linker.

You could add the options below for the tests:
cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS_DEBUG="-ggdb -O2 -fno-omit-frame-pointer -fsanitize=leak" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=leak" -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=leak"

The python library interferes with the sanitizer, "export PYTHONMALLOC=malloc" is not sufficient to fix this issue. Removing "runner.py" could be sufficient to fix this problem, otherwise disabling CPythonInvoker() is required.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
