### PR TITLE
[GUI] GetNumPages crash on small textbox with large font sizes

### DIFF
--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -394,7 +394,7 @@ unsigned int CGUITextBox::GetRows() const
 
 int CGUITextBox::GetNumPages() const
 {
-  return (GetRows() + m_itemsPerPage - 1) / m_itemsPerPage;
+  return m_itemsPerPage > 0 ? (GetRows() + m_itemsPerPage - 1) / m_itemsPerPage : 0;
 }
 
 int CGUITextBox::GetCurrentPage() const


### PR DESCRIPTION
## Description
When using a short textbox control with large font sizes, Kodi crashs when the skin references `Container(ID).NumPages` as described in #22136.

This textbox is not tall enough to accommodate the height of the label, thus the value of the `m_itemsPerPage` variable is 0.

A divide by zero error occurs in the `GetNumPages()` function.

## How has this been tested?
The error no longer occurs tested using the example code proposed in the issue.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
