### PR TITLE
[Teletext] Fix nullptr crash

### DIFF
--- a/xbmc/video/Teletext.cpp
+++ b/xbmc/video/Teletext.cpp
@@ -2264,6 +2264,9 @@ void CTeletextDecoder::RenderCharIntern(TextRenderInfo_t* RenderInfo, int Char, 
 
   /* render char */
   sbitbuffer = m_sBit->buffer;
+  if (!sbitbuffer)
+    return;
+
   unsigned char localbuffer[1000]; // should be enough to store one character-bitmap...
   // add diacritical marks
   if (Attribute->diacrit)


### PR DESCRIPTION
## Description
This a simple nullptr dereference crash that happens quite often when you open the teletext screen (often by mistake) and hit back too quickly before the page displays (by copying the - now - nullptr buffer contents to the local buffer).