### PR TITLE
[Subtitles][WebVTT] Accept timestamp hours without leading zeros

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.cpp
@@ -42,11 +42,11 @@ constexpr char signatureLastChars[] = {'\x0A', '\x0D', '\x20', '\x09'};
 
 constexpr char tagPattern[] = "<(\\/)?([^a-zA-Z >]+)?([^\\d:. >]+)?(\\.[^ >]+)?(?> ([^>]+))?>";
 
-constexpr char cueTimePattern[] = "^(?>(\\d{2}):)?(\\d{2}):(\\d{2}\\.\\d{3})"
+constexpr char cueTimePattern[] = "^(?>(\\d+):)?(\\d{2}):(\\d{2}\\.\\d{3})"
                                   "[ \\t]*-->[ \\t]*"
-                                  "(?>(\\d{2}):)?(\\d{2}):(\\d{2}\\.\\d{3})";
+                                  "(?>(\\d+):)?(\\d{2}):(\\d{2}\\.\\d{3})";
 
-constexpr char timePattern[] = "<(?>(\\d{2}):)?(\\d{2}):(\\d{2}\\.\\d{3})>";
+constexpr char timePattern[] = "<(?>(\\d+):)?(\\d{2}):(\\d{2}\\.\\d{3})>";
 
 // Regex patterns for cue properties
 const std::map<std::string, std::string> cuePropsPatterns = {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Some webvtt files out of specs can have wrong formatted timestamps having the hours without leading zeros
i think this is due to converted subs and/or editors that do not follow in an accurate manner specs (see #22150)

example:
```
38
1:02:17.167 --> 1:02:18.669
Qu’on ferme la grille !
```

where should be: `01:02:17.167 --> 01:02:18.669`

This relax the parser to accept the hours without leading zeros
other player like MPV do the same

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#22150

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with file provided in issue, or also you can edit any file manually

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Show subtitles

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
