### PR TITLE
[upnp] Fix crash due to lack of thread-safety

### DIFF
--- a/xbmc/network/upnp/UPnP.cpp
+++ b/xbmc/network/upnp/UPnP.cpp
@@ -34,6 +34,8 @@
 #include "utils/log.h"
 #include "video/VideoInfoTag.h"
 
+#include <memory>
+#include <mutex>
 #include <set>
 
 #include <Platinum/Source/Platinum/Platinum.h>
@@ -651,13 +653,14 @@ CUPnP::UpdateItem(const std::string& path, const CFileItem& item)
 void
 CUPnP::StartClient()
 {
-    if (m_MediaBrowser != NULL)
-        return;
+  std::unique_lock<CCriticalSection> lock(m_lockMediaBrowser);
+  if (m_MediaBrowser != NULL)
+    return;
 
-    CreateControlPoint();
+  CreateControlPoint();
 
-    // start browser
-    m_MediaBrowser = new CMediaBrowser(m_CtrlPointHolder->m_CtrlPoint);
+  // start browser
+  m_MediaBrowser = new CMediaBrowser(m_CtrlPointHolder->m_CtrlPoint);
 }
 
 /*----------------------------------------------------------------------
@@ -666,14 +669,15 @@ CUPnP::StartClient()
 void
 CUPnP::StopClient()
 {
-    if (m_MediaBrowser == NULL)
-        return;
+  std::unique_lock<CCriticalSection> lock(m_lockMediaBrowser);
+  if (m_MediaBrowser == NULL)
+    return;
 
-    delete m_MediaBrowser;
-    m_MediaBrowser = NULL;
+  delete m_MediaBrowser;
+  m_MediaBrowser = NULL;
 
-    if (!IsControllerStarted())
-        DestroyControlPoint();
+  if (!IsControllerStarted())
+    DestroyControlPoint();
 }
 
 /*----------------------------------------------------------------------

--- a/xbmc/network/upnp/UPnP.h
+++ b/xbmc/network/upnp/UPnP.h
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#include "threads/CriticalSection.h"
+
 #include <string>
 
 class NPT_LogHandler;
@@ -85,7 +87,9 @@ private:
     CUPnPRenderer* CreateRenderer(int port = 0);
     CUPnPServer*   CreateServer(int port = 0);
 
-public:
+    CCriticalSection m_lockMediaBrowser;
+
+  public:
     PLT_SyncMediaBrowser*       m_MediaBrowser;
     PLT_MediaController*        m_MediaController;
 


### PR DESCRIPTION
## Description
This is not easy to explain but Kodi is crashing a lot on startup if you start navigating in the interface quickly after start (e.g. using the mouse on estuary) to focus items. Or just if you happen to have `upnp://` items on the homescreen.
This happens specially in debug mode if UPnP is enabled (although it's also reproducible in release) and gets really annoying when developing (usually 3/4 startups until you can, luckily, avoid the crash...)

When kodi starts up, network services ask for the start of the UPnP server. At the same time, if you have items with upnp:// paths jobs are started to get the thumbnail of the items, asking for the startup of the UPnP server as well. Starting the server 
 should be innocuous and avoid the creation of `m_MediaBrowser` (returning early) but you might get into a race case where `m_MediaBrowser` is created multiple times.
Internally this adds multiple control points in libUpnp (https://github.com/xbmc/xbmc/blob/2b1626dcb1a208c411e5c42e3e20deca66aa382e/lib/libUPnP/Platinum/Source/Core/PltCtrlPoint.cpp#L345).

Problem happens when actual UPnP results are to be processed: https://github.com/xbmc/xbmc/blob/2b1626dcb1a208c411e5c42e3e20deca66aa382e/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltSyncMediaBrowser.cpp#L144
Processing the result deletes the userdata void* that is a member of `PLT_CtrlPointListenerOnActionResponseIterator` https://github.com/xbmc/xbmc/blob/2b1626dcb1a208c411e5c42e3e20deca66aa382e/lib/libUPnP/Platinum/Source/Core/PltCtrlPoint.cpp#L92 that, again, due to the timings each object is created can refer to the exact same object...leading to the crash.

This PR just lock-protects the UPnP server startup (and stop just for the sake of it), ensuring we don't end up creating multiple control points for no reason. It doesn't really have any side effects, upnp thumbnails will just wait for the server to be created before attempting to load. Can also be fixed in libupnp but I'd like to avoid adding patches to it - and kodi is wrong anyway.

PS: diff is a bit bigger than it needs to be because of auto clang-format. I don't intend to change the indented lines to our code guidelines. 