### PR TITLE
[Teletext] Fix crash due to incorrect persistency of sbit (small bitm…

### DIFF
--- a/xbmc/video/Teletext.cpp
+++ b/xbmc/video/Teletext.cpp
@@ -703,6 +703,7 @@ void CTeletextDecoder::EndDecoder()
   /* close freetype */
   if (m_Manager)
   {
+    FTC_Node_Unref(m_anode, m_Manager);
     FTC_Manager_Done(m_Manager);
   }
   if (m_Library)
@@ -2255,7 +2256,7 @@ void CTeletextDecoder::RenderCharIntern(TextRenderInfo_t* RenderInfo, int Char, 
     return;
   }
 
-  if (FTC_SBitCache_Lookup(m_Cache, &m_TypeTTF, glyph, &m_sBit, NULL) != 0)
+  if (FTC_SBitCache_Lookup(m_Cache, &m_TypeTTF, glyph, &m_sBit, &m_anode) != 0)
   {
     FillRect(m_TextureBuffer, m_RenderInfo.Width, m_RenderInfo.PosX, m_RenderInfo.PosY + yoffset, curfontwidth, m_RenderInfo.FontHeight, bgcolor);
     m_RenderInfo.PosX += curfontwidth;
@@ -2282,7 +2283,7 @@ void CTeletextDecoder::RenderCharIntern(TextRenderInfo_t* RenderInfo, int Char, 
       Char = G2table[0][0x20+ Attribute->diacrit];
     if ((glyph = FT_Get_Char_Index(m_Face, Char)))
     {
-      if (FTC_SBitCache_Lookup(m_Cache, &m_TypeTTF, glyph, &sbit_diacrit, NULL) == 0)
+      if (FTC_SBitCache_Lookup(m_Cache, &m_TypeTTF, glyph, &sbit_diacrit, &m_anode) == 0)
       {
         sbitbuffer = localbuffer;
         memcpy(sbitbuffer,m_sBit->buffer,m_sBit->pitch*m_sBit->height);

--- a/xbmc/video/Teletext.h
+++ b/xbmc/video/Teletext.h
@@ -184,6 +184,8 @@ private:
   FTC_SBitCache       m_Cache;            /*  "       "   "  */
   FTC_SBit            m_sBit;             /*  "       "   "  */
   FT_Face             m_Face;             /*  "       "   "  */
+  /*! An opaque handle to a cache node object. Each cache node is reference-counted. */
+  FTC_Node m_anode;
   FTC_ImageTypeRec    m_TypeTTF;          /*  "       "   "  */
   int                 m_Ascender;         /*  "       "   "  */
 


### PR DESCRIPTION
…ap descriptor)

## Description

I don't use teletext much but often I do click on the teletext button by mistake and hit back again before the window has time to load :). This most of the time results in a crash.
I can also reproduce the same crash just displaying the teletext window. The crashdump is below:

```
(gdb) bt full
#0  __memcpy_avx_unaligned_erms () at ../sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S:273
No locals.
#1  0x000055555744c5c5 in CTeletextDecoder::RenderCharIntern (this=0x55555bd7a2d0, RenderInfo=0x55555bd7a380, Char=184, 
    Attribute=0x55555bd7b6b8, zoom=0, yoffset=720) at /home/arch/Github/xbmc/xbmc/video/Teletext.cpp:2288
        sbit_diacrit = 0x55555d0447d8
        Row = 22
        Pitch = 0
        glyph = 123
        bgcolor = 4278190332
        fgcolor = 4294769916
        factor = 2
        xfactor = 1
        sbitbuffer = 0x7fffffff9300 ""
        national_subset_local = 9
        curfontwidth = 32
--Type <RET> for more, q to quit, c to continue without paging--
        t = 32
        curfontwidth2 = 32
        alphachar = 67
        __FUNCTION__ = "RenderCharIntern"
        localbuffer = "\000\000\000\000\000\000\000\000\000KxŰ\316\360\060`\234\027[\000\000\000\000\030\036\207\\UU\000\000`\223\377\377\377\177\000\000\001\000\000\000\000\000\000\000\001\000\000\000\000\000\000\000\001", '\000' <repeats 15 times>, "\354@\363VUU\000\000\f\000\000\000\000\000\000\000\020_;ZUU\000\000\200\223\377\377\377\177\000\000\373\251\363VUU\000\000\006\024\b\031\016\000\002\b\020_;ZUU\000\000\240\223\377\377\377\177\000\000\250\223\363VUU\000\000p\253 [UU\000\000\360\223\377\377\377\177\000\000\300\223\377\377\377\177\000\000\n\202\363VUU\000\000\017\000\000\000\000\000\000\000\360\223\377\377\377\177\000\000\340\224\377\377\377\177\000\000\360"...
        backupTTFshiftY = 0
        p = 0x55555e370700
        f = -1
        he = 20
#2  0x000055555744a76f in CTeletextDecoder::RenderCharBB (this=0x55555bd7a2d0, Char=67, Attribute=0x55555bd7b6b8)
    at /home/arch/Github/xbmc/xbmc/video/Teletext.cpp:1809
No locals.
#3  0x0000555557448dce in CTeletextDecoder::DoRenderPage (this=0x55555bd7a2d0, startrow=0, national_subset_bak=0)
    at /home/arch/Github/xbmc/xbmc/video/Teletext.cpp:1506
        col = 8
        index = 520
        row = 13
#4  0x0000555557447c35 in CTeletextDecoder::RenderPage (this=0x55555bd7a2d0)
    at /home/arch/Github/xbmc/xbmc/video/Teletext.cpp:1206
        StartRow = 0
        national_subset_bak = 0
#5  0x00005555573f9a3b in CGUIDialogTeletext::Render (this=0x55555bd79e80)
    at /home/arch/Github/xbmc/xbmc/video/dialogs/GUIDialogTeletext.cpp:91

            textureBuffer = 0x55555756883f <std::stack<CGraphicContext::UITransform, std::deque<CGraphicContext::UITransform, std::allocator<CGraphicContext::UITransform> > >::push(CGraphicContext::UITransform const&)+35> "\220\311\303UH\211\345H\203\354\020H\211}\370H\213E\370H\211\307\350F\v"
        color = 32767
#6  0x0000555557837db2 in CGUIControl::DoRender (this=0x55555bd79e80)
    at /home/arch/Github/xbmc/xbmc/guilib/GUIControl.cpp:203
        hasStereo = false
#7  0x00005555578dbf03 in CGUIWindow::DoRender (this=0x55555bd79e80) at /home/arch/Github/xbmc/xbmc/guilib/GUIWindow.cpp:351
No locals.
#8  0x00005555578ea64b in CGUIWindowManager::RenderPass (this=0x55555ba61910)
    at /home/arch/Github/xbmc/xbmc/guilib/GUIWindowManager.cpp:1256
        window = @0x55555c871e08: 0x55555bd79e80
        __for_range = std::vector of length 5, capacity 5 = {0x55555bd4c5e0, 0x55555c48cce0, 0x55555bd851b0, 0x55555bd79e80, 
          0x55555bd5c250}
        __for_begin = 0x55555bd79e80
        __for_end = 0xc1
        pWindow = 0x55555bd83cb0
        renderList = std::vector of length 5, capacity 5 = {0x55555bd4c5e0, 0x55555c48cce0, 0x55555bd851b0, 0x55555bd79e80, 
          0x55555bd5c250}
#9  0x00005555578ea9b0 in CGUIWindowManager::Render (this=0x55555ba61910)
    at /home/arch/Github/xbmc/xbmc/guilib/GUIWindowManager.cpp:1296
        __PRETTY_FUNCTION__ = "bool CGUIWindowManager::Render()"
        lock = {sec = @0x55555ad10658, count = 0}
        dirtyRegions = std::vector of length 1, capacity 1 = {{<CRectGen<float>> = {x1 = 0, y1 = 0, x2 = 1920, y2 = 1026}, 
            m_age = 0}}
        hasRendered = false
#10 0x00005555579b7658 in CApplication::Render (this=0x55555abead10)
``` 

--------
Looking at the root cause, Kodi is using the cache sub-system of freetype incorrectly by storing the small bitmap descriptor without binding to a cache node. This pretty much means the `m_sBit` we store as a member can vanish at any point:
https://github.com/xbmc/xbmc/blob/master/xbmc/video/Teletext.cpp#L2258

From [freetype docs](https://freetype.org/freetype2/docs/reference/ft2-cache_subsystem.html#ftc_sbitcache_lookup):

> If anode is NULL, the cache node is left unchanged, which means that the bitmap could be flushed out of the cache on the next call to one of the caching sub-system APIs. Don't assume that it is persistent!

> If anode is not NULL, it receives the address of the cache node containing the bitmap, after increasing its reference count. This ensures that the node (as well as the image) will always be kept in the cache until you call [FTC_Node_Unref](https://freetype.org/freetype2/docs/reference/ft2-cache_subsystem.html#ftc_node_unref) to ‘release’ it.

Hence, this PR just makes sure we properly define a cache node as a member and correctly call the API as we need to store the texture to be cached until we are done with it.



