### PR TITLE
[video] VIDEO_UTILS: We must not rely on item's folder flag...

### DIFF
--- a/xbmc/video/VideoUtils.cpp
+++ b/xbmc/video/VideoUtils.cpp
@@ -649,10 +649,11 @@ ResumeInformation GetNonFolderItemResumeInformation(const CFileItem& item)
 
 ResumeInformation GetItemResumeInformation(const CFileItem& item)
 {
-  if (item.m_bIsFolder)
-    return GetFolderItemResumeInformation(item);
-  else
-    return GetNonFolderItemResumeInformation(item);
+  ResumeInformation info = GetNonFolderItemResumeInformation(item);
+  if (info.isResumable)
+    return info;
+
+  return GetFolderItemResumeInformation(item);
 }
 
 } // namespace VIDEO_UTILS


### PR DESCRIPTION
 ... in `GetItemResumeInformation`. For example for plugins there is no way to determine the flag reliably if only the URL is available when constructing the item instance, which is the case for favourites.

Fixes #22149 

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 whenever you find some time for another code review. Low regression risk, I'd say.
