### PR TITLE
[tools/depends][target] libass android libc++ link

### DIFF
--- a/tools/depends/target/libass/Makefile
+++ b/tools/depends/target/libass/Makefile
@@ -9,6 +9,12 @@ ARCHIVE=$(SOURCE).tar.gz
 SHA512=3b8022ca500d4a9e19e9b7106e29d23d4bca20012619c829bc3e77437bcb3c7bd8364800f7daeb3f2d8400afc7bbcaab487c7b30c429d9aed70e37ce4cb265a2
 include ../../download-files.include
 
+ifeq ($(OS),android)
+  # Android API Level 21/22 requires explicit link.
+  # This doesnt appear to be required for API Level 23+ (Android 6+)
+  export LDFLAGS+= -lstdc++
+endif
+
 # configuration settings
 CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
           ./configure --prefix=$(PREFIX) --disable-enca


### PR DESCRIPTION
## Description
Android 5 based OS's (API Level 21/22) require an explicit link to libc++ for libass. This isnt necessary for Android 6+ (API Level 23+) for whatever reason.

## Motivation and context
Fixes https://github.com/xbmc/xbmc/issues/22069

@howie-f mind giving this artifact one last try when its built.

## How has this been tested?
@howie-f has tested on a Fire TV Stick Gen 1

## What is the effect on users?
Android 5 based devices live for another day.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
