### PR TITLE
[Teletext] Subtle improvements for teletext subtitles

### DIFF
--- a/xbmc/video/Teletext.cpp
+++ b/xbmc/video/Teletext.cpp
@@ -1292,16 +1292,37 @@ void CTeletextDecoder::RenderPage()
         }
       }
 
-      /* Update on every changed second */
-      if (m_txtCache->TimeString[7] != prevTimeSec)
+      if (!IsSubtitlePage(m_txtCache->Page))
       {
-        prevTimeSec = m_txtCache->TimeString[7];
+        /* Update on every changed second */
+        if (m_txtCache->TimeString[7] != prevTimeSec)
+        {
+          prevTimeSec = m_txtCache->TimeString[7];
+          m_updateTexture = true;
+        }
+      }
+      else
+      {
         m_updateTexture = true;
       }
     }
     DoFlashing(StartRow);
     m_txtCache->NationalSubset = national_subset_bak;
   }
+}
+
+bool CTeletextDecoder::IsSubtitlePage(int pageNumber) const
+{
+  if (!m_txtCache)
+    return false;
+
+  for (const auto subPage : m_txtCache->SubtitlePages)
+  {
+    if (subPage.page == pageNumber)
+      return true;
+  }
+
+  return false;
 }
 
 void CTeletextDecoder::DoFlashing(int startrow)

--- a/xbmc/video/Teletext.cpp
+++ b/xbmc/video/Teletext.cpp
@@ -1165,7 +1165,7 @@ void CTeletextDecoder::RenderPage()
         if (c == NULL)
           return;
 
-        c = {};
+        *c = {};
         m_RenderInfo.SubtitleCache[j] = c;
       }
       c->Valid = true;

--- a/xbmc/video/Teletext.h
+++ b/xbmc/video/Teletext.h
@@ -55,6 +55,7 @@ private:
   void PageInput(int Number);
   void GetNextPageOne(bool up);
   void GetNextSubPage(int offset);
+  bool IsSubtitlePage(int pageNumber) const;
   void SwitchZoomMode();
   void SwitchTranspMode();
   void SwitchHintMode();


### PR DESCRIPTION
## Description
This PR brings two fixes:

- [02ae94749d8098b377800d57b612ec453142e0f8](https://github.com/xbmc/xbmc/commit/02ae94749d8098b377800d57b612ec453142e0f8) fixes a crash when adjusting the subtitle delay introduced with the removal of the memset call in https://github.com/xbmc/xbmc/pull/19608/files#diff-823c96f3464de14074ec6619ba423fc185fe95a286ce451b5b426746f4dc24ddL1166

- [9649f6c80aa679d19011c365e938d6bde0ca6fd3](https://github.com/xbmc/xbmc/commit/9649f6c80aa679d19011c365e938d6bde0ca6fd3) Makes sure the page is refreshed if the page being displayed is a subtitle page. Quite often you need to actually hit submit for the next subtitle to be displayed.

Still far from optimal (honestly still a crap user experience) but should at least make teletext subtitles more usable. 