### PR TITLE
[addonrepos] reduce log spam

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23031,7 +23031,12 @@ msgctxt "#39123"
 msgid "Artwork"
 msgstr ""
 
-#empty string with id 39124
+#. Label for component level debug logging setting
+#: xbmc/utils/log.cpp
+msgctxt "#39124"
+msgid "Verbose logging for the [B]Add-ons[/B] component"
+msgstr ""
+
 
 #: system/settings/settings.xml
 msgctxt "#39125"

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -452,10 +452,10 @@ bool CAddonMgr::FindInstallableById(const std::string& addonId, AddonPtr& result
   // get the latest version from all repos if the
   // addon is up-to-date or not installed yet
 
-  CLog::Log(LOGDEBUG,
-            "CAddonMgr::{}: addon {} is up-to-date or not installed. falling back to get latest "
-            "version from all repos",
-            __FUNCTION__, addonId);
+  CLog::LogFC(
+      LOGDEBUG, LOGADDONS,
+      "addon {} is up-to-date or not installed. falling back to get latest version from all repos",
+      addonId);
 
   return addonRepos.GetLatestAddonVersionFromAllRepos(addonId, result);
 }

--- a/xbmc/addons/AddonRepos.cpp
+++ b/xbmc/addons/AddonRepos.cpp
@@ -126,7 +126,7 @@ bool CAddonRepos::LoadAddonsFromDatabase(const std::string& addonId,
 
   for (const auto& repo : m_addonsByRepoMap)
   {
-    CLog::Log(LOGDEBUG, "ADDONS: {} - {} addon(s) loaded", repo.first, repo.second.size());
+    CLog::LogFC(LOGDEBUG, LOGADDONS, "{} - {} addon(s) loaded", repo.first, repo.second.size());
 
     const auto& addonsPerRepo = repo.second;
 
@@ -187,9 +187,8 @@ void CAddonRepos::BuildUpdateOrOutdatedList(const std::vector<std::shared_ptr<IA
 {
   std::shared_ptr<IAddon> update;
 
-  CLog::Log(LOGDEBUG, "CAddonRepos::{}: Building {} list from installed add-ons", __func__,
-            addonCheckType == AddonCheckType::OUTDATED_ADDONS ? "outdated" : "update");
-
+  CLog::LogFC(LOGDEBUG, LOGADDONS, "Building {} list from installed add-ons",
+              addonCheckType == AddonCheckType::OUTDATED_ADDONS ? "outdated" : "update");
   for (const auto& addon : installed)
   {
     if (DoAddonUpdateCheck(addon, update))
@@ -205,10 +204,8 @@ void CAddonRepos::BuildAddonsWithUpdateList(
 {
   std::shared_ptr<IAddon> update;
 
-  CLog::Log(LOGDEBUG,
-            "CAddonRepos::{}: Building combined addons-with-update map from installed add-ons",
-            __func__);
-
+  CLog::LogFC(LOGDEBUG, LOGADDONS,
+              "Building combined addons-with-update map from installed add-ons");
   for (const auto& addon : installed)
   {
     if (DoAddonUpdateCheck(addon, update))
@@ -221,8 +218,8 @@ void CAddonRepos::BuildAddonsWithUpdateList(
 bool CAddonRepos::DoAddonUpdateCheck(const std::shared_ptr<IAddon>& addon,
                                      std::shared_ptr<IAddon>& update) const
 {
-  CLog::Log(LOGDEBUG, "ADDONS: update check: addonID = {} / Origin = {} / Version = {}",
-            addon->ID(), addon->Origin(), addon->Version().asString());
+  CLog::LogFC(LOGDEBUG, LOGADDONS, "update check: addonID = {} / Origin = {} / Version = {}",
+              addon->ID(), addon->Origin(), addon->Version().asString());
 
   update.reset();
 
@@ -268,8 +265,8 @@ bool CAddonRepos::DoAddonUpdateCheck(const std::shared_ptr<IAddon>& addon,
 
   if (update != nullptr)
   {
-    CLog::Log(LOGDEBUG, "ADDONS: -- found -->: addonID = {} / Origin = {} / Version = {}",
-              update->ID(), update->Origin(), update->Version().asString());
+    CLog::LogFC(LOGDEBUG, LOGADDONS, "-- found -->: addonID = {} / Origin = {} / Version = {}",
+                update->ID(), update->Origin(), update->Version().asString());
     return true;
   }
 
@@ -451,14 +448,14 @@ bool CAddonRepos::FindDependency(const std::string& dependsId,
 
   repoForDep = std::static_pointer_cast<CRepository>(tmp);
 
-  CLog::Log(LOGDEBUG, "ADDONS: found dependency [{}] for install/update from repo [{}]",
-            dependencyToInstall->ID(), repoForDep->ID());
+  CLog::LogFC(LOGDEBUG, LOGADDONS, "found dependency [{}] for install/update from repo [{}]",
+              dependencyToInstall->ID(), repoForDep->ID());
 
   if (dependencyToInstall->HasType(AddonType::REPOSITORY))
   {
-    CLog::Log(LOGDEBUG,
-              "ADDONS: dependency with id [{}] has type ADDON_REPOSITORY and will not install!",
-              dependencyToInstall->ID());
+    CLog::LogFC(LOGDEBUG, LOGADDONS,
+                "dependency with id [{}] has type ADDON_REPOSITORY and will not install!",
+                dependencyToInstall->ID());
 
     return false;
   }

--- a/xbmc/commons/ilog.h
+++ b/xbmc/commons/ilog.h
@@ -44,3 +44,4 @@
 #define LOGEPG        (1 << (LOGMASKBIT + 16))
 #define LOGANNOUNCE   (1 << (LOGMASKBIT + 17))
 #define LOGWSDISCOVERY (1 << (LOGMASKBIT + 18))
+#define LOGADDONS (1 << (LOGMASKBIT + 19))

--- a/xbmc/commons/ilog.h
+++ b/xbmc/commons/ilog.h
@@ -8,40 +8,40 @@
 
 #pragma once
 
-#define LOG_LEVEL_NONE         -1 // nothing at all is logged
-#define LOG_LEVEL_NORMAL        0 // shows notice, error, severe and fatal
-#define LOG_LEVEL_DEBUG         1 // shows all
-#define LOG_LEVEL_DEBUG_FREEMEM 2 // shows all + shows freemem on screen
-#define LOG_LEVEL_MAX           LOG_LEVEL_DEBUG_FREEMEM
+constexpr int LOG_LEVEL_NONE = -1; // nothing at all is logged
+constexpr int LOG_LEVEL_NORMAL = 0; // shows notice, error, severe and fatal
+constexpr int LOG_LEVEL_DEBUG = 1; // shows all
+constexpr int LOG_LEVEL_DEBUG_FREEMEM = 2; // shows all + shows freemem on screen
+constexpr int LOG_LEVEL_MAX = LOG_LEVEL_DEBUG_FREEMEM;
 
 // ones we use in the code
-#define LOGDEBUG   0
-#define LOGINFO    1
-#define LOGWARNING 2
-#define LOGERROR   3
-#define LOGFATAL   4
-#define LOGNONE    5
+constexpr int LOGDEBUG = 0;
+constexpr int LOGINFO = 1;
+constexpr int LOGWARNING = 2;
+constexpr int LOGERROR = 3;
+constexpr int LOGFATAL = 4;
+constexpr int LOGNONE = 5;
 
 // extra masks - from bit 5
-#define LOGMASKBIT    5
-#define LOGMASK       ((1 << LOGMASKBIT) - 1)
+constexpr int LOGMASKBIT = 5;
+constexpr int LOGMASK = ((1 << LOGMASKBIT) - 1);
 
-#define LOGSAMBA      (1 << (LOGMASKBIT + 0))
-#define LOGCURL       (1 << (LOGMASKBIT + 1))
-#define LOGFFMPEG     (1 << (LOGMASKBIT + 2))
-#define LOGDBUS       (1 << (LOGMASKBIT + 4))
-#define LOGJSONRPC    (1 << (LOGMASKBIT + 5))
-#define LOGAUDIO      (1 << (LOGMASKBIT + 6))
-#define LOGAIRTUNES   (1 << (LOGMASKBIT + 7))
-#define LOGUPNP       (1 << (LOGMASKBIT + 8))
-#define LOGCEC        (1 << (LOGMASKBIT + 9))
-#define LOGVIDEO      (1 << (LOGMASKBIT + 10))
-#define LOGWEBSERVER  (1 << (LOGMASKBIT + 11))
-#define LOGDATABASE   (1 << (LOGMASKBIT + 12))
-#define LOGAVTIMING   (1 << (LOGMASKBIT + 13))
-#define LOGWINDOWING  (1 << (LOGMASKBIT + 14))
-#define LOGPVR        (1 << (LOGMASKBIT + 15))
-#define LOGEPG        (1 << (LOGMASKBIT + 16))
-#define LOGANNOUNCE   (1 << (LOGMASKBIT + 17))
-#define LOGWSDISCOVERY (1 << (LOGMASKBIT + 18))
-#define LOGADDONS (1 << (LOGMASKBIT + 19))
+constexpr int LOGSAMBA = (1 << (LOGMASKBIT + 0));
+constexpr int LOGCURL = (1 << (LOGMASKBIT + 1));
+constexpr int LOGFFMPEG = (1 << (LOGMASKBIT + 2));
+constexpr int LOGDBUS = (1 << (LOGMASKBIT + 4));
+constexpr int LOGJSONRPC = (1 << (LOGMASKBIT + 5));
+constexpr int LOGAUDIO = (1 << (LOGMASKBIT + 6));
+constexpr int LOGAIRTUNES = (1 << (LOGMASKBIT + 7));
+constexpr int LOGUPNP = (1 << (LOGMASKBIT + 8));
+constexpr int LOGCEC = (1 << (LOGMASKBIT + 9));
+constexpr int LOGVIDEO = (1 << (LOGMASKBIT + 10));
+constexpr int LOGWEBSERVER = (1 << (LOGMASKBIT + 11));
+constexpr int LOGDATABASE = (1 << (LOGMASKBIT + 12));
+constexpr int LOGAVTIMING = (1 << (LOGMASKBIT + 13));
+constexpr int LOGWINDOWING = (1 << (LOGMASKBIT + 14));
+constexpr int LOGPVR = (1 << (LOGMASKBIT + 15));
+constexpr int LOGEPG = (1 << (LOGMASKBIT + 16));
+constexpr int LOGANNOUNCE = (1 << (LOGMASKBIT + 17));
+constexpr int LOGWSDISCOVERY = (1 << (LOGMASKBIT + 18));
+constexpr int LOGADDONS = (1 << (LOGMASKBIT + 19));

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -214,6 +214,7 @@ void CLog::SettingOptionsLoggingComponentsFiller(const SettingConstPtr& setting,
   list.emplace_back(g_localizeStrings.Get(685), LOGPVR);
   list.emplace_back(g_localizeStrings.Get(686), LOGEPG);
   list.emplace_back(g_localizeStrings.Get(39117), LOGANNOUNCE);
+  list.emplace_back(g_localizeStrings.Get(39124), LOGADDONS);
 #ifdef HAS_DBUS
   list.emplace_back(g_localizeStrings.Get(674), LOGDBUS);
 #endif


### PR DESCRIPTION
time of this logspam has come

```
2022-11-14 10:00:22.023 T:551     debug <general>: ADDONS: update check: addonID = audioencoder.kodi.builtin.aac / Origin = b6a50484-93a0-4afb-a01c-8d17e059feda / Version = 1.0.2
2022-11-14 10:00:22.023 T:551     debug <general>: ADDONS: update check: addonID = audioencoder.kodi.builtin.wma / Origin = b6a50484-93a0-4afb-a01c-8d17e059feda / Version = 1.0.2
2022-11-14 10:00:22.023 T:551     debug <general>: ADDONS: update check: addonID = game.controller.default / Origin = b6a50484-93a0-4afb-a01c-8d17e059feda / Version = 1.0.33
2022-11-14 10:00:22.024 T:551     debug <general>: ADDONS: update check: addonID = game.controller.keyboard / Origin = b6a50484-93a0-4afb-a01c-8d17e059feda / Version = 1.1.20
2022-11-14 10:00:22.024 T:551     debug <general>: ADDONS: update check: addonID = game.controller.mouse / Origin = b6a50484-93a0-4afb-a01c-8d17e059feda / Version = 1.0.18
2022-11-14 10:00:22.024 T:551     debug <general>: ADDONS: update check: addonID = game.controller.snes / Origin = b6a50484-93a0-4afb-a01c-8d17e059feda / Version = 1.0.32
2022-11-14 10:00:22.024 T:551     debug <general>: ADDONS: update check: addonID = inputstream.adaptive / Origin = b6a50484-93a0-4afb-a01c-8d17e059feda / Version = 20.3.1
2022-11-14 10:00:22.024 T:551     debug <general>: ADDONS: update check: addonID = metadata.album.universal / Origin = b6a50484-93a0-4afb-a01c-8d17e059feda / Version = 3.1.9
2022-11-14 10:00:22.024 T:551     debug <general>: ADDONS: update check: addonID = metadata.artists.universal / Origin = b6a50484-93a0-4afb-a01c-8d17e059feda / Version = 4.3.10
.
.
```

it should be moved to a new component logging `ADD-ONS`

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document

