### PR TITLE
[Teletext] Fix flashing regression due to std:chrono change

### DIFF
--- a/xbmc/video/Teletext.cpp
+++ b/xbmc/video/Teletext.cpp
@@ -22,6 +22,8 @@
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
 
+using namespace std::chrono_literals;
+
 static inline void SDL_memset4(uint32_t* dst, uint32_t val, size_t len)
 {
   for (; len > 0; --len)
@@ -1337,7 +1339,9 @@ void CTeletextDecoder::DoFlashing(int startrow)
   /* Flashing */
   TextPageAttr_t flashattr;
   char flashchar;
-  long flashphase = std::chrono::steady_clock::now().time_since_epoch().count() % 1000;
+  std::chrono::milliseconds flashphase = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                             std::chrono::steady_clock::now().time_since_epoch()) %
+                                         1000;
 
   int srow = startrow;
   int erow = 24;
@@ -1369,25 +1373,37 @@ void CTeletextDecoder::DoFlashing(int startrow)
         switch (flashattr.flashing &0x1c) // Flash Rate
         {
           case 0x00 :  // 1 Hz
-            if (flashphase>500) doflash = true;
+            if (flashphase > 500ms)
+              doflash = true;
             break;
           case 0x04 :  // 2 Hz  Phase 1
-            if (flashphase<250) doflash = true;
+            if (flashphase < 250ms)
+              doflash = true;
             break;
           case 0x08 :  // 2 Hz  Phase 2
-            if (flashphase>=250 && flashphase<500) doflash = true;
+            if (flashphase >= 250ms && flashphase < 500ms)
+              doflash = true;
             break;
           case 0x0c :  // 2 Hz  Phase 3
-            if (flashphase>=500 && flashphase<750) doflash = true;
+            if (flashphase >= 500ms && flashphase < 750ms)
+              doflash = true;
             break;
           case 0x10 :  // incremental flash
             incflash++;
             if (incflash>3) incflash = 1;
             switch (incflash)
             {
-              case 1: if (flashphase<250) doflash = true; break;
-              case 2: if (flashphase>=250 && flashphase<500) doflash = true;break;
-              case 3: if (flashphase>=500 && flashphase<750) doflash = true;
+              case 1:
+                if (flashphase < 250ms)
+                  doflash = true;
+                break;
+              case 2:
+                if (flashphase >= 250ms && flashphase < 500ms)
+                  doflash = true;
+                break;
+              case 3:
+                if (flashphase >= 500ms && flashphase < 750ms)
+                  doflash = true;
             }
             break;
           case 0x14 :  // decremental flash
@@ -1395,9 +1411,17 @@ void CTeletextDecoder::DoFlashing(int startrow)
             if (decflash<1) decflash = 3;
             switch (decflash)
             {
-              case 1: if (flashphase<250) doflash = true; break;
-              case 2: if (flashphase>=250 && flashphase<500) doflash = true;break;
-              case 3: if (flashphase>=500 && flashphase<750) doflash = true;
+              case 1:
+                if (flashphase < 250ms)
+                  doflash = true;
+                break;
+              case 2:
+                if (flashphase >= 250ms && flashphase < 500ms)
+                  doflash = true;
+                break;
+              case 3:
+                if (flashphase >= 500ms && flashphase < 750ms)
+                  doflash = true;
             }
             break;
 

--- a/xbmc/video/Teletext.cpp
+++ b/xbmc/video/Teletext.cpp
@@ -1404,6 +1404,7 @@ void CTeletextDecoder::DoFlashing(int startrow)
               case 3:
                 if (flashphase >= 500ms && flashphase < 750ms)
                   doflash = true;
+                break;
             }
             break;
           case 0x14 :  // decremental flash
@@ -1422,6 +1423,7 @@ void CTeletextDecoder::DoFlashing(int startrow)
               case 3:
                 if (flashphase >= 500ms && flashphase < 750ms)
                   doflash = true;
+                break;
             }
             break;
 


### PR DESCRIPTION
## Description
This fixes another regression from the move to `std::chrono` which leads for the flashing operation in Teletext to happen at a much higher rate / frequency than the one expected. Results were compared to an actual tv displaying the same page (in this case it flashes at 1Hz - 1 time per second).

See explanation in https://stackoverflow.com/questions/21050994/stdchrono-default-duration-for-time-since-epoch

This might explain why https://github.com/xbmc/xbmc/issues/21317 also got broken...

**Master:**

https://www.youtube.com/watch?v=oWqP27r2s4M

**PR:**

https://www.youtube.com/watch?v=6yS8jwJXoRA