### PR TITLE
Kodi-20.0-Nexus alpha1/alpha2/alpha3/beta1 crash on start-up on Android 5.1.1 - 2nd solution

### DIFF
--- a/tools/depends/target/libass/Makefile
+++ b/tools/depends/target/libass/Makefile
@@ -13,6 +13,11 @@ include ../../download-files.include
 CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
           ./configure --prefix=$(PREFIX) --disable-enca
 
+ifeq ($(OS),android)
+  # Fontconfig uses clang and not clang++, therefore we need the explicit stdc++ link to solve issue #22069 affecting only Android 5.x
+  export LDFLAGS+= -lstdc++
+endif
+
 LIBDYLIB=$(PLATFORM)/$(LIBNAME)/.libs/$(LIBNAME).a
 
 all: .installed-$(PLATFORM)


### PR DESCRIPTION
**Description**

Kodi-20.0-Nexus alpha1/alpha2/alpha3/beta1 crash on start-up on Android 5.1.1.

Ref :https://github.com/xbmc/xbmc/issues/22069

**Motivation and context**

As reported in the issue https://github.com/xbmc/xbmc/issues/22069, the reason of the crash is due to a FATAL EXCEPTION detected by Android 5.1.1. during the loading of libass.so Shared Library.

--------- beginning of crash
E/AndroidRuntime( 8096): FATAL EXCEPTION: main
E/AndroidRuntime( 8096): Process: org.xbmc.kodi, PID: 8096
E/AndroidRuntime( 8096): java.lang.UnsatisfiedLinkError: dlopen failed: cannot locate symbol "__gxx_personality_v0" referenced by "libass.so"...

Since the issue happens already with alpha1, I have git cloned Kodi till alpha1 tag and via multiple different git checkout, building and testing every time the .apk, I have identified that the pull causing the problem is:

[tools/depends][target] fontconfig bump 2.14.0 https://github.com/xbmc/xbmc/pull/21310

After several tests, using also the latest official version 2.14.1, my conclusion is that the issue is caused by the usage of the Meson Build system. Building fontconfig with the "old" autoconf system the problem disappear.

In order to keep building fontconfig  with meson and avoid to leave unresoved symbols I have moved this change

ifeq ($(OS),android)
 // Freetype with Harfbuzz support requires stdc++ lib linking
 // Fontconfig uses clang and not clang++, therefore we need the explicit stdc++ link
  export LDFLAGS+= -lstdc++
endif

 made by fuzzard  on the  "old"  fontconfig autoconf Makefile  in pull  #20166 into libass Makefile which is based on "old" autoconf system (up to now  libass cannot be built with meson)

With this change libass.so is built correctly and the issue on Android 5.x is not anymore present.

**How has this been tested?**

Tested on:

Amazon Fire TV Basic Edition:
Model : AFTT
Hardware : mt8127
SW : Fire OS 5.2.9.2 (681771820) (based on Android 5.1.1)

Samsung Galaxy Grand Prime smartphone with Android version 5.1.1

Tested also on other Android versions:

Zidoo X10 : Android 6.0.1
Fire TV Stick 4K Max : Android TV 9.0.0
NVIDIA SHIELD Android TV Pro : Android TV 11.0.0

What is the effect on users?

Kodi 20 not usable on Android 5.1.1

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

