### PR TITLE
[video] CGUIWindowVideoBase::GetResumeString: We must not rely on item's folder flag.

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -640,11 +640,7 @@ std::string CGUIWindowVideoBase::GetResumeString(const CFileItem &item)
   const VIDEO_UTILS::ResumeInformation resumeInfo = VIDEO_UTILS::GetItemResumeInformation(item);
   if (resumeInfo.isResumable)
   {
-    if (item.m_bIsFolder)
-    {
-      return g_localizeStrings.Get(13362); // Continue watching
-    }
-    else if (resumeInfo.startOffset > 0)
+    if (resumeInfo.startOffset > 0)
     {
       std::string resumeString = StringUtils::Format(
           g_localizeStrings.Get(12022),
@@ -658,6 +654,10 @@ std::string CGUIWindowVideoBase::GetResumeString(const CFileItem &item)
         resumeString += " (" + partString + ")";
       }
       return resumeString;
+    }
+    else
+    {
+      return g_localizeStrings.Get(13362); // Continue watching
     }
   }
   return {};


### PR DESCRIPTION
Fixes #22163 

Same root cause as for #22149 - for plugins we cannot safely determine whether item represents a folder, if only the URL is available when creating the item, which is the case for favourites.

Runtime-tested on Android and macOS, latest Kodi master.

@enen92 can you please have a look. Low risk, I'd say.