### PR TITLE
[favourites][listproviders] Fix playback of "playmedia" items

### DIFF
--- a/xbmc/favourites/GUIWindowFavourites.cpp
+++ b/xbmc/favourites/GUIWindowFavourites.cpp
@@ -74,11 +74,15 @@ bool CGUIWindowFavourites::OnAction(const CAction& action)
     if (selectedItem < 0 || selectedItem >= m_vecItems->Size())
       return false;
 
-    // Resolve the favourite
     const CFavouritesURL favURL((*m_vecItems)[selectedItem]->GetPath());
     if (!favURL.IsValid())
       return false;
 
+    // If action is playmedia, just play it
+    if (favURL.GetAction() == CFavouritesURL::Action::PLAY_MEDIA)
+      return ExecuteAction(favURL.GetExecString());
+
+    // Resolve and check the target
     const auto item = std::make_shared<CFileItem>(favURL.GetTarget(), favURL.IsDir());
     if (CPlayerUtils::IsItemPlayable(*item))
     {

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -451,6 +451,10 @@ bool CDirectoryProvider::OnPlay(const CGUIListItemPtr& item)
     const CFavouritesURL url(fileItem.GetPath());
     if (url.IsValid())
     {
+      // If action is playmedia, just play it
+      if (url.GetAction() == CFavouritesURL::Action::PLAY_MEDIA)
+        return ExecuteAction(url.GetExecString());
+
       CFileItem targetItem(url.GetTarget(), url.IsDir());
       fileItem = targetItem;
     }


### PR DESCRIPTION
(just play it, no further checks needed). - Click on favourites window items, click on favourites home screen widget items are the main use cases.

Simplifies code, fixes playback of plugin items representing a playable media, via action "play" (P on keyboard, Play key on remote, ... given standard key mappings are used).

Runtime-tested on Android and macOS, latest Kodi master.

@enen92 mind taking a look, very low regression risk.