### PR TITLE
GUIBaseContainer: comparison of unsigned expression is always true

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -421,8 +421,8 @@ bool CGUIBaseContainer::OnAction(const CAction &action)
   case ACTION_PLAYER_PLAY:
     if (m_listProvider)
     {
-      const size_t selected = GetSelectedItem();
-      if (selected >= 0 && selected < m_items.size())
+      const int selected = GetSelectedItem();
+      if (selected >= 0 && selected < static_cast<int>(m_items.size()))
       {
         if (m_listProvider->OnPlay(m_items[selected]))
           return true;


### PR DESCRIPTION
## Description
Fix the following warning:
``` 
GUIBaseContainer.cpp:427:20: warning: comparison of unsigned expression in ‘>= 0’ is always true [-Wtype-limits]
  427 |       if (selected >= 0 && selected < m_items.size())
      |           ~~~~~~~~~^~~~
```

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
