### PR TITLE
[VideoInfoScanner] Prevent logging errors by getting empty directory

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -2102,7 +2102,8 @@ namespace VIDEO
       if (!show.m_strPath.empty())
       {
         CDirectory::GetDirectory(show.m_strPath, items, extensions,
-          DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
+                                 DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE |
+                                     DIR_FLAG_NO_FILE_INFO);
       }
       extensions.erase(std::remove(extensions.begin(), extensions.end(), '.'), extensions.end());
       CRegExp reg;

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -2099,8 +2099,11 @@ namespace VIDEO
       int maxSeasons = 0;
       CFileItemList items;
       std::string extensions = CServiceBroker::GetFileExtensionProvider().GetPictureExtensions();
-      CDirectory::GetDirectory(show.m_strPath, items, extensions,
-        DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
+      if (!show.m_strPath.empty())
+      {
+        CDirectory::GetDirectory(show.m_strPath, items, extensions,
+          DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
+      }
       extensions.erase(std::remove(extensions.begin(), extensions.end(), '.'), extensions.end());
       CRegExp reg;
       if (items.Size() && reg.RegComp("season([0-9]+)(-[a-z0-9]+)?\\.(" + extensions + ")"))


### PR DESCRIPTION
## Description
Prevent logging errors by getting empty directory with scraper.

## Motivation and context
Got error message in UI with scraper but nothing to explain this error.
Just found "ERROR <general>: XFILE::CDirectory::GetDirectory - Error getting " in log without the specific directory.
That error is just because of empty directory in function parameter.

## How has this been tested?
Runtime tested with The TVDB v4 addon scraping in French some TV series test folder on my NAS.

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
