### PR TITLE
[Android] Use SYSTEM_UI_FLAG_IMMERSIVE_STICKY flag instead of its value

### DIFF
--- a/tools/android/packaging/xbmc/src/Main.java.in
+++ b/tools/android/packaging/xbmc/src/Main.java.in
@@ -171,21 +171,14 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
           {
             public void run()
             {
-              if (android.os.Build.VERSION.SDK_INT >= 19)
-              {
-                // Immersive mode
-
-                // Constants from API > 17
-                final int API_SYSTEM_UI_FLAG_IMMERSIVE_STICKY = 0x00001000;
-
-                mDecorView.setSystemUiVisibility(
-                        View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                                | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                                | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                                | View.SYSTEM_UI_FLAG_FULLSCREEN
-                                | API_SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
-              }
+              // Immersive mode
+              mDecorView.setSystemUiVisibility(
+                      View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                              | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                              | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                              | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                              | View.SYSTEM_UI_FLAG_FULLSCREEN
+                              | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
             }
           });
         }
@@ -225,22 +218,15 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
   {
     super.onResume();
 
-    if (android.os.Build.VERSION.SDK_INT >= 19)
-    {
-      // Immersive mode
-
-      // Constants from API > 17
-      final int API_SYSTEM_UI_FLAG_IMMERSIVE_STICKY = 0x00001000;
-
-      mDecorView.setSystemUiVisibility(
-              View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                      | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                      | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                      | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                      | View.SYSTEM_UI_FLAG_FULLSCREEN
-                      | API_SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
-    }
-
+    // Immersive mode
+    mDecorView.setSystemUiVisibility(
+          View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                  | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                  | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                  | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                  | View.SYSTEM_UI_FLAG_FULLSCREEN
+                  | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+  
     // New intent ?
     for (final DelayedIntent delayedIntent : mDelayedIntents)
     {


### PR DESCRIPTION
## Description
Replace the constant value defined directly in the code by the corresponding Android API constant:

SYSTEM_UI_FLAG_IMMERSIVE_STICKY
Constant Value: 4096 (0x00001000)

## How has this been tested?
Builds and runs fine on Android TV 9

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
