### PR TITLE
[video] Fix VIDEO_UTILS::Get*ResumeInformation …

### DIFF
--- a/xbmc/video/VideoUtils.cpp
+++ b/xbmc/video/VideoUtils.cpp
@@ -495,6 +495,9 @@ bool HasInProgressVideo(const std::string& path, CVideoDatabase& db)
 
 ResumeInformation GetFolderItemResumeInformation(const CFileItem& item)
 {
+  if (!item.m_bIsFolder)
+    return {};
+
   bool hasInProgressVideo = false;
 
   CFileItem folderItem(item);
@@ -637,7 +640,7 @@ ResumeInformation GetNonFolderItemResumeInformation(const CFileItem& item)
 
     if (bookmark.IsSet())
     {
-      resumeInfo.isResumable = true;
+      resumeInfo.isResumable = bookmark.IsPartWay();
       resumeInfo.startOffset = CUtil::ConvertSecsToMilliSecs(bookmark.timeInSeconds);
       resumeInfo.partNumber = static_cast<int>(bookmark.partNumber);
     }


### PR DESCRIPTION
… to handle bookmarks with end time but no resume position set properly and to check for not being a folder at the proper place.

Fixes #22176 

Runtime-tested on Android and macOS, latest master.

@enen92 if you find some tome for a review. Low regression risk for sure.