### PR TITLE
CAndroidFeatures: Remove unused GetVersion() function and unnecessary imports

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.cpp
@@ -26,8 +26,6 @@
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
-#include "platform/android/activity/AndroidFeatures.h"
-
 #include <cassert>
 #include <stdexcept>
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -32,7 +32,6 @@
 #include "utils/log.h"
 #include "windowing/android/AndroidUtils.h"
 
-#include "platform/android/activity/AndroidFeatures.h"
 #include "platform/android/activity/JNIXBMCSurfaceTextureOnFrameAvailableListener.h"
 #include "platform/android/activity/XBMCApp.h"
 

--- a/xbmc/platform/android/activity/AndroidFeatures.cpp
+++ b/xbmc/platform/android/activity/AndroidFeatures.cpp
@@ -25,38 +25,6 @@ bool CAndroidFeatures::HasNeon()
   return false;
 }
 
-int CAndroidFeatures::GetVersion()
-{
-  static int version = -1;
-
-  if (version == -1)
-  {
-    version = 0;
-
-    JNIEnv *jenv = xbmc_jnienv();
-
-    jclass jcOsBuild = jenv->FindClass("android/os/Build$VERSION");
-    if (jcOsBuild == NULL)
-    {
-      CLog::Log(LOGERROR, "{}: Error getting class android.os.Build.VERSION", __PRETTY_FUNCTION__);
-      return version;
-    }
-
-    jint iSdkVersion = jenv->GetStaticIntField(jcOsBuild, jenv->GetStaticFieldID(jcOsBuild, "SDK_INT", "I"));
-    CLog::Log(LOGDEBUG, "{}: android.os.Build.VERSION {}", __PRETTY_FUNCTION__, (int)iSdkVersion);
-
-    // <= 10 Gingerbread
-    // <= 13 Honeycomb
-    // <= 15 IceCreamSandwich
-    //       JellyBean
-    // <= 19 KitKat
-    version = iSdkVersion;
-
-    jenv->DeleteLocalRef(jcOsBuild);
-  }
-  return version;
-}
-
 int CAndroidFeatures::GetCPUCount()
 {
   static int count = -1;

--- a/xbmc/platform/android/activity/AndroidFeatures.h
+++ b/xbmc/platform/android/activity/AndroidFeatures.h
@@ -15,6 +15,5 @@ class CAndroidFeatures
   public:
 
   static bool         HasNeon();
-  static int          GetVersion();
   static int          GetCPUCount();
 };

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -13,9 +13,6 @@
 #include "addons/Skin.h"
 #include "addons/addoninfo/AddonType.h"
 #include "application/AppParams.h"
-#if defined(TARGET_ANDROID)
-#include "platform/android/activity/AndroidFeatures.h"
-#endif // defined(TARGET_ANDROID)
 #include "cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.h"
 #include "ServiceBroker.h"
 #include "GUIPassword.h"


### PR DESCRIPTION
## Description
The `CAndroidFeatures::GetVersion()` function returns the Android SDK version currently running on the device. 

I propose to remove this function as it's not used and more concise alternatives are currently in use: `CJNIBase::GetSDKVersion()`, `CJNIBuild::SDK_INT` or `CXBMCApp::GetSDKVersion()`.

Also remove some unnecessary `AndroidFeatures.h` imports.

## How has this been tested?
Tested on Android TV 9

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
