### PR TITLE
Build an Android App Bundle (AAB) for each ABI

### DIFF
--- a/tools/android/packaging/Makefile.in
+++ b/tools/android/packaging/Makefile.in
@@ -129,9 +129,12 @@ java: res
 	@cp -R xbmc/src/* xbmc/java/$(APP_PACKAGE_DIR)/
 
 package: libs python java
-	@echo "Gradle build and sign..."
+	@echo "\nGradle build and sign APK..."
 	ANDROID_HOME=$(SDKROOT) ./gradlew assemble$(BUILD_TYPE)
 	@cp xbmc/build/outputs/apk/$(BUILD_TYPE_LC)/xbmc-$(BUILD_TYPE_LC).apk $(CMAKE_SOURCE_DIR)/@APP_NAME_LC@app-$(CPU)-$(BUILD_TYPE_LC).apk
+	@echo "\nGradle build and sign AAB..."
+	ANDROID_HOME=$(SDKROOT) ./gradlew bundle$(BUILD_TYPE)
+	@cp xbmc/build/outputs/bundle/$(BUILD_TYPE_LC)/xbmc-$(BUILD_TYPE_LC).aab $(CMAKE_SOURCE_DIR)/@APP_NAME_LC@app-$(CPU)-$(BUILD_TYPE_LC).aab
 
 $(PREFIX)/lib/xbmc/lib@APP_NAME_LC@.so: $(SRCLIBS)
 	$(MAKE) -C ../../depends/target/xbmc

--- a/tools/buildsteps/android-arm64-v8a/package
+++ b/tools/buildsteps/android-arm64-v8a/package
@@ -16,6 +16,7 @@ cd $WORKSPACE
 #e.x. xbmc-20130314-8c2fb31-Frodo-arm64-v8a.apk
 UPLOAD_FILENAME="kodi-$(getBuildRevDateStr)-arm64-v8a"
 mv kodiapp-arm64-v8a-*.apk $UPLOAD_FILENAME.apk
+mv kodiapp-arm64-v8a-*.aab $UPLOAD_FILENAME.aab
 if [ -f *.obb ]
 then
   mv *.obb $UPLOAD_FILENAME.obb

--- a/tools/buildsteps/android-x86_64/package
+++ b/tools/buildsteps/android-x86_64/package
@@ -16,6 +16,7 @@ cd $WORKSPACE
 #e.x. xbmc-20130314-8c2fb31-Frodo-x86_64.apk
 UPLOAD_FILENAME="kodi-$(getBuildRevDateStr)-x86_64"
 mv kodiapp-x86_64-*.apk $UPLOAD_FILENAME.apk
+mv kodiapp-x86_64-*.aab $UPLOAD_FILENAME.aab
 if [ -f *.obb ]
 then
   mv *.obb $UPLOAD_FILENAME.obb

--- a/tools/buildsteps/android/package
+++ b/tools/buildsteps/android/package
@@ -16,6 +16,7 @@ cd $WORKSPACE
 #e.x. xbmc-20130314-8c2fb31-Frodo-armeabi-v7a.apk
 UPLOAD_FILENAME="kodi-$(getBuildRevDateStr)-armeabi-v7a"
 mv kodiapp-armeabi-*.apk $UPLOAD_FILENAME.apk
+mv kodiapp-armeabi-*.aab $UPLOAD_FILENAME.aab
 if [ -f *.obb ]
 then
   mv *.obb $UPLOAD_FILENAME.obb

--- a/tools/buildsteps/androidx86/package
+++ b/tools/buildsteps/androidx86/package
@@ -16,6 +16,7 @@ cd $WORKSPACE
 #e.x. xbmc-20130314-8c2fb31-Frodo-x86.apk
 UPLOAD_FILENAME="kodi-$(getBuildRevDateStr)-x86"
 mv kodiapp-x86-*.apk $UPLOAD_FILENAME.apk
+mv kodiapp-x86-*.aab $UPLOAD_FILENAME.aab
 if [ -f *.obb ]
 then
   mv *.obb $UPLOAD_FILENAME.obb


### PR DESCRIPTION
## Description
"Android App Bundle" (AAB) is the format for publishing apps on Google Play which is replacing APKs.

This proposal adds the build in AAB format.

Both package formats are now available.

## How to install the .aab file
We need to download [Bundletool](https://github.com/google/bundletool/releases) to manipulate the app bundle.

Extract a single `.apk` file from the `.aab` file:
```
java -jar bundletool-all-1.13.1.jar build-apks --bundle=kodiapp-armeabi-v7a-debug.aab --output=kodiapp.apks --mode=universal
```
Extract the `.apk`:
```
unzip -p kodiapp.apks universal.apk > kodiapp-armeabi-v7a-debug.apk
```

## How has this been tested?
I install the .aab file on Android TV 9 and it works fine.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
