### PR TITLE
CRPProccessInfo: don't call createFunc when registering

### DIFF
--- a/xbmc/cores/RetroPlayer/process/RPProcessInfo.cpp
+++ b/xbmc/cores/RetroPlayer/process/RPProcessInfo.cpp
@@ -90,21 +90,7 @@ CRPProcessInfo* CRPProcessInfo::CreateInstance()
 
 void CRPProcessInfo::RegisterProcessControl(CreateRPProcessControl createFunc)
 {
-  std::unique_ptr<CRPProcessInfo> processInfo(createFunc());
-
-  std::unique_lock<CCriticalSection> lock(m_createSection);
-
-  if (processInfo)
-  {
-    CLog::Log(LOGINFO, "RetroPlayer[PROCESS]: Registering process control for {}",
-              processInfo->GetPlatformName());
-    m_processControl = createFunc;
-  }
-  else
-  {
-    CLog::Log(LOGERROR, "RetroPlayer[PROCESS]: Failed to register process control");
-    m_processControl = nullptr;
-  }
+  m_processControl = createFunc;
 }
 
 void CRPProcessInfo::RegisterRendererFactory(IRendererFactory* factory)


### PR DESCRIPTION
This fixes #22172 

I'm not sure what the original intent was here. Hopefully @garbear can provide some context. We only register one createFunc per platform. Maybe the log message for the registration of the platform was important?

This defers the allocation of CRPProcessInfo to when it is actually needed (in retroplayer when opening a file).

What's odd is that I don't actually get a `SIGABRT` like in the linked issue. I'm not sure if this is due to my local build being a debug build or something else.

Before:
```
Thread 1 "kodi.bin" hit Breakpoint 1, KODI::RETRO::CRenderContext::CRenderContext (this=0x532b770, rendering=0x5191bc8, windowing=0x51913e0, graphicsContext=..., displaySettings=..., mediaSettings=..., gameServices=...) at /home/lukas/Documents/git/xbmc/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp:38
38	  : m_rendering(rendering),
(gdb) n
39	    m_windowing(windowing),
(gdb) 
40	    m_graphicsContext(graphicsContext),
(gdb) 
41	    m_displaySettings(displaySettings),
(gdb) 
42	    m_mediaSettings(mediaSettings),
(gdb) 
43	    m_gameServices(gameServices)
(gdb) 
45	}
(gdb) print m_gameServices
$1 = (KODI::GAME::CGameServices &) <error reading variable: Cannot access memory at address 0x0>

```

call stack before:
```
#0  KODI::RETRO::CRenderContext::CRenderContext(CRenderSystemBase*, CWinSystemBase*, CGraphicContext&, CDisplaySettings&, CMediaSettings&, KODI::GAME::CGameServices&) (this=0x532b770, rendering=0x5191bc8, windowing=0x51913e0, graphicsContext=..., displaySettings=..., mediaSettings=..., gameServices=...) at /home/lukas/Documents/git/xbmc/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp:45
#1  0x00000000023c090d in KODI::RETRO::CRPProcessInfo::CRPProcessInfo(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (this=0x53f34e0, platformName="") at /home/lukas/Documents/git/xbmc/xbmc/cores/RetroPlayer/process/RPProcessInfo.cpp:45
#2  0x0000000002acdd99 in KODI::RETRO::CRPProcessInfoWayland::CRPProcessInfoWayland() (this=0x53f34e0) at /home/lukas/Documents/git/xbmc/xbmc/cores/RetroPlayer/process/wayland/RPProcessInfoWayland.cpp:14
#3  0x0000000002acde18 in KODI::RETRO::CRPProcessInfoWayland::Create() () at /home/lukas/Documents/git/xbmc/xbmc/cores/RetroPlayer/process/wayland/RPProcessInfoWayland.cpp:20
#4  0x00000000023c0d6b in KODI::RETRO::CRPProcessInfo::RegisterProcessControl(KODI::RETRO::CRPProcessInfo* (*)()) (createFunc=0x2acddf0 <KODI::RETRO::CRPProcessInfoWayland::Create()>) at /home/lukas/Documents/git/xbmc/xbmc/cores/RetroPlayer/process/RPProcessInfo.cpp:93
#5  0x0000000002acde56 in KODI::RETRO::CRPProcessInfoWayland::Register() () at /home/lukas/Documents/git/xbmc/xbmc/cores/RetroPlayer/process/wayland/RPProcessInfoWayland.cpp:25
#6  0x0000000002aa5e4e in KODI::WINDOWING::WAYLAND::CWinSystemWayland::InitWindowSystem() (this=0x51913e0) at /home/lukas/Documents/git/xbmc/xbmc/windowing/wayland/WinSystemWayland.cpp:162
#7  0x0000000002ac7c13 in KODI::WINDOWING::WAYLAND::CWinSystemWaylandEGLContext::InitWindowSystemEGL(int, int) (this=0x51913e0, renderableType=4, apiType=12448) at /home/lukas/Documents/git/xbmc/xbmc/windowing/wayland/WinSystemWaylandEGLContext.cpp:31
#8  0x0000000002ac8959 in KODI::WINDOWING::WAYLAND::CWinSystemWaylandEGLContextGLES::InitWindowSystem() (this=0x51913e0) at /home/lukas/Documents/git/xbmc/xbmc/windowing/wayland/WinSystemWaylandEGLContextGLES.cpp:40
#9  0x000000000201e754 in CApplication::CreateGUI() (this=0x503a740) at /home/lukas/Documents/git/xbmc/xbmc/application/Application.cpp:491

```

After:
```
Thread 1 "kodi.bin" hit Breakpoint 1, KODI::RETRO::CRenderContext::CRenderContext (this=0x5178660, rendering=0x53c81b8, windowing=0x53c79d0, graphicsContext=..., displaySettings=..., mediaSettings=..., gameServices=...) at /home/lukas/Documents/git/xbmc/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp:38
38	  : m_rendering(rendering),
(gdb) n
39	    m_windowing(windowing),
(gdb) 
40	    m_graphicsContext(graphicsContext),
(gdb) 
41	    m_displaySettings(displaySettings),
(gdb) 
42	    m_mediaSettings(mediaSettings),
(gdb) 
43	    m_gameServices(gameServices)
(gdb) 
45	}
(gdb) print m_gameServices
$1 = (KODI::GAME::CGameServices &) @0x6c3b5f0: {m_controllerManager = @0x5188ff0, m_gameRenderManager = @0x51fccd0, m_profileManager = @0x50a1ac0, Python Exception <class 'ValueError'>: Unsupported implementation for unique_ptr: std::__uniq_ptr_data<KODI::GAME::CGameSettings, std::default_delete<KODI::GAME::CGameSettings>, true, true>
m_gameSettings = {_M_t = {<std::__uniq_ptr_impl<KODI::GAME::CGameSettings, std::default_delete<KODI::GAME::CGameSettings> >> = {_M_t = std::tuple containing = {[1] = 0x6c34770, [2] = {<No data fields>}}}, <No data fields>}}, Python Exception <class 'ValueError'>: Unsupported implementation for unique_ptr: std::__uniq_ptr_data<KODI::GAME::CGameAgentManager, std::default_delete<KODI::GAME::CGameAgentManager>, true, true>
m_gameAgentManager = {
    _M_t = {<std::__uniq_ptr_impl<KODI::GAME::CGameAgentManager, std::default_delete<KODI::GAME::CGameAgentManager> >> = {_M_t = std::tuple containing = {[1] = 0x6ca1f60, [2] = {<No data fields>}}}, <No data fields>}}}
```

call stack after:
```
#0  KODI::RETRO::CRenderContext::CRenderContext(CRenderSystemBase*, CWinSystemBase*, CGraphicContext&, CDisplaySettings&, CMediaSettings&, KODI::GAME::CGameServices&) (this=0x5178660, rendering=0x53c81b8, windowing=0x53c79d0, graphicsContext=..., displaySettings=..., mediaSettings=..., gameServices=...) at /home/lukas/Documents/git/xbmc/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp:45
#1  0x00000000023c690d in KODI::RETRO::CRPProcessInfo::CRPProcessInfo(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (this=0x796a020, platformName="") at /home/lukas/Documents/git/xbmc/xbmc/cores/RetroPlayer/process/RPProcessInfo.cpp:45
#2  0x0000000002ad4fb1 in KODI::RETRO::CRPProcessInfoWayland::CRPProcessInfoWayland() (this=0x796a020) at /home/lukas/Documents/git/xbmc/xbmc/cores/RetroPlayer/process/wayland/RPProcessInfoWayland.cpp:14
#3  0x0000000002ad50c8 in std::make_unique<KODI::RETRO::CRPProcessInfoWayland>() () at /usr/include/c++/12/bits/unique_ptr.h:1065
#4  0x0000000002ad5020 in KODI::RETRO::CRPProcessInfoWayland::Create() () at /home/lukas/Documents/git/xbmc/xbmc/cores/RetroPlayer/process/wayland/RPProcessInfoWayland.cpp:20
#5  0x0000000002a2bfe0 in std::__invoke_impl<std::unique_ptr<KODI::RETRO::CRPProcessInfo, std::default_delete<KODI::RETRO::CRPProcessInfo> >, std::unique_ptr<KODI::RETRO::CRPProcessInfo, std::default_delete<KODI::RETRO::CRPProcessInfo> > (*&)()>(std::__invoke_other, std::unique_ptr<KODI::RETRO::CRPProcessInfo, std::default_delete<KODI::RETRO::CRPProcessInfo> > (*&)()) (__f=@0x4821b40: 0x2ad5008 <KODI::RETRO::CRPProcessInfoWayland::Create()>)
    at /usr/include/c++/12/bits/invoke.h:61
#6  0x0000000002a2be09 in std::__invoke_r<std::unique_ptr<KODI::RETRO::CRPProcessInfo, std::default_delete<KODI::RETRO::CRPProcessInfo> >, std::unique_ptr<KODI::RETRO::CRPProcessInfo, std::default_delete<KODI::RETRO::CRPProcessInfo> > (*&)()>(std::unique_ptr<KODI::RETRO::CRPProcessInfo, std::default_delete<KODI::RETRO::CRPProcessInfo> > (*&)()) (__fn=@0x4821b40: 0x2ad5008 <KODI::RETRO::CRPProcessInfoWayland::Create()>) at /usr/include/c++/12/bits/invoke.h:116
#7  0x0000000002a2bbfd in std::_Function_handler<std::unique_ptr<KODI::RETRO::CRPProcessInfo, std::default_delete<KODI::RETRO::CRPProcessInfo> > (), std::unique_ptr<KODI::RETRO::CRPProcessInfo, std::default_delete<KODI::RETRO::CRPProcessInfo> > (*)()>::_M_invoke(std::_Any_data const&) (__functor=...) at /usr/include/c++/12/bits/std_function.h:291
#8  0x00000000023c8299 in std::function<std::unique_ptr<KODI::RETRO::CRPProcessInfo, std::default_delete<KODI::RETRO::CRPProcessInfo> > ()>::operator()() const (this=0x4821b40 <KODI::RETRO::CRPProcessInfo::m_processControl>) at /usr/include/c++/12/bits/std_function.h:591
#9  0x00000000023c6cbb in KODI::RETRO::CRPProcessInfo::CreateInstance() () at /home/lukas/Documents/git/xbmc/xbmc/cores/RetroPlayer/process/RPProcessInfo.cpp:75
#10 0x00000000023e11dc in KODI::RETRO::CRetroPlayer::OpenFile(CFileItem const&, CPlayerOptions const&) (this=0x7670bd0, file=..., options=...) at /home/lukas/Documents/git/xbmc/xbmc/cores/RetroPlayer/RetroPlayer.cpp:89

```