### PR TITLE
[macos] Address a few deprecated warnings

### DIFF
--- a/xbmc/platform/darwin/osx/SDL/SDLMain.mm
+++ b/xbmc/platform/darwin/osx/SDL/SDLMain.mm
@@ -180,12 +180,12 @@ static void setupWindowMenu(void)
   if ([window level] == NSFloatingWindowLevel)
   {
     [window setLevel:NSNormalWindowLevel];
-    [sender setState:NSOffState];
+    [sender setState:NSControlStateValueOff];
   }
   else
   {
     [window setLevel:NSFloatingWindowLevel];
-    [sender setState:NSOnState];
+    [sender setState:NSControlStateValueOn];
   }
 }
 

--- a/xbmc/platform/darwin/osx/XBMCApplication.mm
+++ b/xbmc/platform/darwin/osx/XBMCApplication.mm
@@ -330,12 +330,12 @@ static NSMenu* setupWindowMenu()
   if (window.level == NSFloatingWindowLevel)
   {
     [window setLevel:NSNormalWindowLevel];
-    [sender setState:NSOffState];
+    [sender setState:NSControlStateValueOff];
   }
   else
   {
     [window setLevel:NSFloatingWindowLevel];
-    [sender setState:NSOnState];
+    [sender setState:NSControlStateValueOn];
   }
 }
 


### PR DESCRIPTION
## Description
Addresses a few compiler warnings related to deprecated usages:

```
[build] /Users/enen92/Github/xbmc/xbmc/platform/darwin/osx/XBMCApplication.mm:333:22: warning: 'NSOffState' is deprecated: first deprecated in macOS 10.14 [-Wdeprecated-declarations]
[build]     [sender setState:NSOffState];
[build]                      ^~~~~~~~~~
[build]                      NSControlStateValueOff
[build] /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.0.sdk/System/Library/Frameworks/AppKit.framework/Headers/NSCell.h:352:34: note: 'NSOffState' has been explicitly marked deprecated here
[build] static const NSControlStateValue NSOffState API_DEPRECATED_WITH_REPLACEMENT("NSControlStateValueOff", macos(10.0,10.14)) = NSControlStateValueOff;
[build]                                  ^
[build] /Users/enen92/Github/xbmc/xbmc/platform/darwin/osx/XBMCApplication.mm:338:22: warning: 'NSOnState' is deprecated: first deprecated in macOS 10.14 [-Wdeprecated-declarations]
[build]     [sender setState:NSOnState];
[build]                      ^~~~~~~~~
[build]                      NSControlStateValueOn
[build] /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.0.sdk/System/Library/Frameworks/AppKit.framework/Headers/NSCell.h:353:34: note: 'NSOnState' has been explicitly marked deprecated here
[build] static const NSControlStateValue NSOnState API_DEPRECATED_WITH_REPLACEMENT("NSControlStateValueOn", macos(10.0,10.14)) = NSControlStateValueOn;
[build]                                  ^
[build] 3 warnings generated.
```

Runtime tested