### PR TITLE
[Android] MediaSession flags are no longer used

### DIFF
--- a/tools/android/packaging/xbmc/src/XBMCMediaSession.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCMediaSession.java.in
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.media.MediaMetadata;
 import android.media.session.MediaSession;
 import android.media.session.PlaybackState;
+import android.os.Build;
 import android.util.Log;
 
 /**
@@ -118,7 +119,9 @@ public class XBMCMediaSession
   {
     Log.d(TAG, "XBMCMediaSession init");
     this.mSession = new MediaSession(Main.MainActivity, "XBMC_session");
-    this.mSession.setFlags(MediaSession.FLAG_HANDLES_MEDIA_BUTTONS | MediaSession.FLAG_HANDLES_TRANSPORT_CONTROLS);
+    if (Build.VERSION.SDK_INT < 26) {
+      this.mSession.setFlags(MediaSession.FLAG_HANDLES_MEDIA_BUTTONS | MediaSession.FLAG_HANDLES_TRANSPORT_CONTROLS);
+    }
 
     Main.MainActivity.runOnUiThread(new Runnable()
     {


### PR DESCRIPTION
## Description
The flags `FLAG_HANDLES_MEDIA_BUTTONS` and `FLAG_HANDLES_TRANSPORT_CONTROLS` were deprecated in API level 26.

All media sessions are expected to handle media button events and transport controls now.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
