### PR TITLE
CGameClient: make sure to initialize CGameClientStreams in OpenStandalone

### DIFF
--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -274,6 +274,9 @@ bool CGameClient::OpenStandalone(RETRO::IStreamManager& streamManager, IGameInpu
 
   GAME_ERROR error = GAME_ERROR_FAILED;
 
+  // Loading the game might require the stream subsystem to be initialized
+  Streams().Initialize(streamManager);
+
   try
   {
     LogError(error = m_ifc.game->toAddon->LoadStandalone(m_ifc.game), "LoadStandalone()");
@@ -286,11 +289,13 @@ bool CGameClient::OpenStandalone(RETRO::IStreamManager& streamManager, IGameInpu
   if (error != GAME_ERROR_NO_ERROR)
   {
     NotifyError(error);
+    Streams().Deinitialize();
     return false;
   }
 
   if (!InitializeGameplay("", streamManager, input))
   {
+    Streams().Deinitialize();
     return false;
   }
 


### PR DESCRIPTION
This fixes #22159 

I think this got broken in https://github.com/xbmc/xbmc/commit/961f86ffde3ca14bc2634c94a601f47ac160758e

This makes sure the `CGameClientStreams` object is initialized and that the `m_streamManager` member exists before calling `OpenStream`, otherwise the streams will never be created.

before:
```
Thread 77 "GameLoop" hit Breakpoint 1, KODI::GAME::CGameClientStreams::OpenStream (this=0x51e96a0, properties=...) at /home/lukas/Documents/git/xbmc/xbmc/games/addons/streams/GameClientStreams.cpp:42
42        if (m_streamManager == nullptr)
(gdb) print m_streamManager
$1 = (KODI::RETRO::IStreamManager *) 0x0
```