### PR TITLE
CRenderSystemGL: allow using OpenGL debugging callbacks

### DIFF
--- a/xbmc/utils/GLUtils.cpp
+++ b/xbmc/utils/GLUtils.cpp
@@ -23,6 +23,7 @@
 namespace
 {
 
+// clang-format off
 #define X(VAL) std::make_pair(VAL, #VAL)
 std::map<GLenum, const char*> glErrors =
 {
@@ -49,6 +50,14 @@ std::map<GLenum, const char*> glErrorSource = {
     X(GL_DEBUG_SOURCE_APPLICATION_KHR),
     X(GL_DEBUG_SOURCE_OTHER_KHR),
 #endif
+#if defined(HAS_GL) && defined(TARGET_LINUX)
+    X(GL_DEBUG_SOURCE_API),
+    X(GL_DEBUG_SOURCE_WINDOW_SYSTEM),
+    X(GL_DEBUG_SOURCE_SHADER_COMPILER),
+    X(GL_DEBUG_SOURCE_THIRD_PARTY),
+    X(GL_DEBUG_SOURCE_APPLICATION),
+    X(GL_DEBUG_SOURCE_OTHER),
+#endif
 };
 
 std::map<GLenum, const char*> glErrorType = {
@@ -61,6 +70,15 @@ std::map<GLenum, const char*> glErrorType = {
     X(GL_DEBUG_TYPE_OTHER_KHR),
     X(GL_DEBUG_TYPE_MARKER_KHR),
 #endif
+#if defined(HAS_GL) && defined(TARGET_LINUX)
+    X(GL_DEBUG_TYPE_ERROR),
+    X(GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR),
+    X(GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR),
+    X(GL_DEBUG_TYPE_PORTABILITY),
+    X(GL_DEBUG_TYPE_PERFORMANCE),
+    X(GL_DEBUG_TYPE_OTHER),
+    X(GL_DEBUG_TYPE_MARKER),
+#endif
 };
 
 std::map<GLenum, const char*> glErrorSeverity = {
@@ -70,8 +88,15 @@ std::map<GLenum, const char*> glErrorSeverity = {
     X(GL_DEBUG_SEVERITY_LOW_KHR),
     X(GL_DEBUG_SEVERITY_NOTIFICATION_KHR),
 #endif
+#if defined(HAS_GL) && defined(TARGET_LINUX)
+    X(GL_DEBUG_SEVERITY_HIGH),
+    X(GL_DEBUG_SEVERITY_MEDIUM),
+    X(GL_DEBUG_SEVERITY_LOW),
+    X(GL_DEBUG_SEVERITY_NOTIFICATION),
+#endif
 };
 #undef X
+// clang-format on
 
 } // namespace
 


### PR DESCRIPTION
This adds the ability to use the OpenGL debug callbacks like our OpenGLES renderer has. This was added for OpenGLES way back in https://github.com/xbmc/xbmc/commit/ed2efb85e17ad7c8656e967e5bf18d17fcd1354d but I never took the time to do it for OpenGL also.

Apparently this is only available for OpenGL 4.3 or newer so we'll see https://registry.khronos.org/OpenGL-Refpages/gl4/html/glDebugMessageCallback.xhtml
