### PR TITLE
[macos] fix nativewindow live resize

### DIFF
--- a/xbmc/windowing/osx/OpenGL/OSXGLWindow.mm
+++ b/xbmc/windowing/osx/OpenGL/OSXGLWindow.mm
@@ -89,6 +89,7 @@
 - (void)windowDidEndLiveResize:(NSNotification*)notification
 {
   m_resizeState = false;
+  [self windowDidResize:notification];
 }
 
 - (void)windowDidResize:(NSNotification*)aNotification


### PR DESCRIPTION
## Description
Got a new mac with apple silicon (yeah I know..) and decided to give a go to native windowing (now in v20). Not really interested in fixing most of the bugs (not a platform I actually use for kodi) but this one is annoying and affects the development process. It seems live window resize doesn't work properly and the elements on the skin are incorrectly displayed. 
It seems this happens because we don't notify the window delegate that the live resize action has finished.

**before:**
https://www.youtube.com/watch?v=z_kxfUodyUA

**pr:**
https://www.youtube.com/watch?v=8FoISmQtpf4

