### PR TITLE
[Subtitles] fix Flush() related memory leak

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDOverlayContainer.cpp
+++ b/xbmc/cores/VideoPlayer/DVDOverlayContainer.cpp
@@ -115,10 +115,14 @@ void CDVDOverlayContainer::Flush()
   std::unique_lock<CCriticalSection> lock(*this);
 
   // Flush only the overlays marked as flushable
-  m_overlays.erase(
-      std::remove_if(m_overlays.begin(), m_overlays.end(),
-                     [](CDVDOverlay* ov) { return ov->IsOverlayContainerFlushable(); }),
-      m_overlays.end());
+  m_overlays.erase(std::remove_if(m_overlays.begin(), m_overlays.end(),
+                                  [](CDVDOverlay* ov) {
+                                    bool isFlushable = ov->IsOverlayContainerFlushable();
+                                    if (isFlushable)
+                                      ov->Release();
+                                    return isFlushable;
+                                  }),
+                   m_overlays.end());
 }
 
 void CDVDOverlayContainer::Clear()


### PR DESCRIPTION
## Description
This commit fixes an issue detected by the sanitizer which generates a cascade of memory leaks. This specific issue is problematic, for instance in the logs below we get more than 4MB lost in a matter of minutes.

## Motivation and context
The goal is to clean up some issues detected by the sanitizer.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
-DECM_ENABLE_SANITIZERS='leak' exists, but it does not pass the proper option to the linker.

You could add the options below for the tests:
cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS_DEBUG="-ggdb -O2 -fno-omit-frame-pointer -fsanitize=leak" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=leak" -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=leak"

The python library interferes with the sanitizer, "export PYTHONMALLOC=malloc" is not sufficient to fix this issue. Removing "runner.py" could be sufficient to fix this problem, otherwise disabling CPythonInvoker() is required.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
