### PR TITLE
[macos] native window: always use the same window mask regardless of …

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -648,14 +648,8 @@ bool CWinSystemOSX::CreateNewWindow(const std::string& name, bool fullScreen, RE
     [appWindow makeKeyWindow];
   }];
 
-  // for native fullscreen we always want to set the
-  // same windowed flags
-  NSUInteger windowStyleMask;
-  if (fullScreen)
-    windowStyleMask = NSWindowStyleMaskBorderless;
-  else
-    windowStyleMask = NSWindowStyleMaskTitled | NSWindowStyleMaskResizable |
-                      NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable;
+  const NSUInteger windowStyleMask = NSWindowStyleMaskTitled | NSWindowStyleMaskResizable |
+                                     NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable;
 
   if (m_appWindow == nullptr)
   {


### PR DESCRIPTION
…fullscreen status

## Description
This fixes another issue with the native windowing implementation. As far as I could see there's no way to change the window mask after the window has been created. Since on Kodi first run it will be always in fullscreen, it means we cannot change/exit fullscreen afterwards. We will also lack any borders and the top bar when we attempt to exit fullscreen creating all sort of issues with window positioning.
I don't think there's any need to have different window properties depending on the fact Kodi is running on fullscreen or not. If the app is in fullscreen the window will not have borders and is not resizable or minimizable anyway (those are only activated when we move out of fullscreen).