### PR TITLE
[Android] preferredRefreshRate is ignored if preferredDisplayModeId is set

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -702,7 +702,6 @@ void CXBMCApp::SetDisplayModeCallback(void* modeVariant)
 {
   CVariant* modeV = static_cast<CVariant*>(modeVariant);
   int mode = (*modeV)["mode"].asInteger();
-  float rate = (*modeV)["rate"].asFloat();
   delete modeV;
 
   CJNIWindow window = getWindow();
@@ -712,7 +711,6 @@ void CXBMCApp::SetDisplayModeCallback(void* modeVariant)
     if (params.getpreferredDisplayModeId() != mode)
     {
       params.setpreferredDisplayModeId(mode);
-      params.setpreferredRefreshRate(rate);
       window.setAttributes(params);
       return;
     }
@@ -764,7 +762,6 @@ void CXBMCApp::SetDisplayMode(int mode, float rate)
   m_displayChangeEvent.Reset();
   std::map<std::string, CVariant> vmap;
   vmap["mode"] = mode;
-  vmap["rate"] = rate;
   m_refreshRate = rate;
   CVariant *variant = new CVariant(vmap);
   runNativeOnUiThread(SetDisplayModeCallback, variant);


### PR DESCRIPTION
## Description
When set the Id of the preferred display mode for the window and also set the value of the preferred refresh rate, this desired rate value is ignored.

This behavior is correct since each of the supported display modes has its own refresh rate.

Remove the `setpreferredRefreshRate()` call in this case. 

## How has this been tested?
Tested on Android TV 9 and correctly switches display mode.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
