### PR TITLE
[macos] Avoid toggling fullscreen twice on startup

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -694,14 +694,6 @@ bool CWinSystemOSX::CreateNewWindow(const std::string& name, bool fullScreen, RE
 
   [NSAnimationContext endGrouping];
 
-  if (fullScreen)
-  {
-    m_fullscreenWillToggle = true;
-    [appWindow performSelectorOnMainThread:@selector(toggleFullScreen:)
-                                withObject:nil
-                             waitUntilDone:YES];
-  }
-
   // get screen refreshrate - this is needed
   // when we startup in windowed mode and don't run through SetFullScreen
   int dummy;


### PR DESCRIPTION
## Description

This fixes another issue with the native windowing implementation on macos. When the window is first created we start in window mode and toggle fullscreen afterwards. The issue is that nearly at the same time we toggle fullscreen again in `SetVideoResolutionInternal(res, forceUpdate);` when on initWindow. As both calls happen pretty much simultaneously this causes all sort of weird issues when we first toggle manually to windowed mode. Also, it leads to incorrect values on the fullscreen mode setting (shows windowed while in fullscreen and fullscreen while on windowed mode). 