### PR TITLE
[Macos][NativeWindowing] Get GL context on main thread

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1193,11 +1193,13 @@ void CWinSystemOSX::WindowChangedScreen()
 
 CGLContextObj CWinSystemOSX::GetCGLContextObj()
 {
-  CGLContextObj cglcontex = nullptr;
+  __block CGLContextObj cglcontex = nullptr;
   if (m_appWindow)
   {
-    OSXGLView* contentView = m_appWindow.contentView;
-    cglcontex = contentView.getGLContext.CGLContextObj;
+    dispatch_sync(dispatch_get_main_queue(), ^{
+      OSXGLView* contentView = m_appWindow.contentView;
+      cglcontex = contentView.getGLContext.CGLContextObj;
+    });
   }
 
   return cglcontex;


### PR DESCRIPTION
## Description
This fixes another issue in macos native window, the GL context is being obtained out of the main thread. Similar implementation is already done for `FlushBuffer()`

```
Main Thread Checker: UI API called on a background thread: -[NSWindow contentView]
PID: 52298, TID: 1766740, Thread name: (none), Queue name: com.apple.root.default-qos.overcommit, QoS: 0
Backtrace:
4   kodi.bin                            0x000000010261bc64 _ZN13CWinSystemOSX16GetCGLContextObjEv + 56
5   kodi.bin                            0x0000000100a5dcbc _ZN12CRendererVTB13UploadTextureEi + 272
6   kodi.bin                            0x0000000100a62dfc _ZN16CLinuxRendererGL6RenderEji + 124
7   kodi.bin                            0x0000000100a6232c _ZN16CLinuxRendererGL12RenderUpdateEiibjj + 372
8   kodi.bin                            0x0000000100a9e70c _ZN14CRenderManager13PresentSingleEbjj + 248
9   kodi.bin                            0x0000000100a9de3c _ZN14CRenderManager6RenderEbjjb + 440
10  kodi.bin                            0x00000001009d3310 _ZN12CVideoPlayer6RenderEbjb + 80
11  kodi.bin                            0x000000010069184c _ZN18CApplicationPlayer6RenderEbjb + 112
12  kodi.bin                            0x00000001010c5098 _ZN16CGUIVideoControl6RenderEv + 720
13  kodi.bin                            0x0000000100f73888 _ZN11CGUIControl8DoRenderEv + 408
14  kodi.bin                            0x0000000100f95750 _ZN16CGUIControlGroup6RenderEv + 212
15  kodi.bin                            0x0000000100f73888 _ZN11CGUIControl8DoRenderEv + 408
16  kodi.bin                            0x00000001010d0ea4 _ZN10CGUIWindow8DoRenderEv + 88
17  kodi.bin                            0x00000001010e68c4 _ZNK17CGUIWindowManager10RenderPassEv + 88
18  kodi.bin                            0x00000001010e6df8 _ZN17CGUIWindowManager6RenderEv + 724
19  kodi.bin                            0x0000000100649664 _ZN12CApplication6RenderEv + 884
20  kodi.bin                            0x00000001010e79cc _ZN17CGUIWindowManager17ProcessRenderLoopEb + 312
21  kodi.bin                            0x0000000100faeb68 _ZN10CGUIDialog17ProcessRenderLoopEb + 48
22  kodi.bin                            0x0000000100b3cf60 _ZN14CGUIDialogBusy11WaitOnEventER6CEventjb + 364
23  kodi.bin                            0x0000000100652270 _ZN12CApplication9OnMessageER11CGUIMessage + 3164
24  kodi.bin                            0x00000001010e1d8c _ZN17CGUIWindowManager11SendMessageER11CGUIMessage + 140
25  kodi.bin                            0x00000001010e8aa0 _ZN17CGUIWindowManager22DispatchThreadMessagesEv + 224
26  kodi.bin                            0x00000001006548d0 _ZN12CApplication7ProcessEv + 36
27  kodi.bin                            0x000000010064ebc8 _ZN12CApplication3RunEv + 336
28  kodi.bin                            0x0000000101a7b414 XBMC_Run + 356
29  kodi.bin                            0x000000010000c5dc -[XBMCDelegate mainLoopThread:] + 148
30  Foundation                          0x0000000187f9d470 __NSThread__start__ + 716
31  libsystem_pthread.dylib             0x000000011177d5d4 _pthread_start + 148
32  libsystem_pthread.dylib             0x0000000111787a88 thread_start + 8
2022-12-08 12:01:52.327657+0000 kodi.bin[52298:1766740] [reports] Main Thread Checker: UI API called on a background thread: -[NSWindow contentView]
PID: 52298, TID: 1766740, Thread name: (none), Queue name: com.apple.root.default-qos.overcommit, QoS: 0
Backtrace:
4   kodi.bin                            0x000000010261bc64 _ZN13CWinSystemOSX16GetCGLContextObjEv + 56
5   kodi.bin                            0x0000000100a5dcbc _ZN12CRendererVTB13UploadTextureEi + 272
6   kodi.bin                            0x0000000100a62dfc _ZN16CLinuxRendererGL6RenderEji + 124
7   kodi.bin                            0x0000000100a6232c _ZN16CLinuxRendererGL12RenderUpdateEiibjj + 372
8   kodi.bin                            0x0000000100a9e70c _ZN14CRenderManager13PresentSingleEbjj + 248
9   kodi.bin                            0x0000000100a9de3c _ZN14CRenderManager6RenderEbjjb + 440
10  kodi.bin                            0x00000001009d3310 _ZN12CVideoPlayer6RenderEbjb + 80
11  kodi.bin                            0x000000010069184c _ZN18CApplicationPlayer6RenderEbjb + 112
12  kodi.bin                            0x00000001010c5098 _ZN16CGUIVideoControl6RenderEv + 720
13  kodi.bin                            0x0000000100f73888 _ZN11CGUIControl8DoRenderEv + 408
14  kodi.bin                            0x0000000100f95750 _ZN16CGUIControlGroup6RenderEv + 212
15  kodi.bin                            0x0000000100f73888 _ZN11CGUIControl8DoRenderEv + 408
16  kodi.bin                            0x00000001010d0ea4 _ZN10CGUIWindow8DoRenderEv + 88
17  kodi.bin                            0x00000001010e68c4 _ZNK17CGUIWindowManager10RenderPassEv + 88
18  kodi.bin                            0x00000001010e6df8 _ZN17CGUIWindowManager6RenderEv + 724
19  kodi.bin                            0x0000000100649664 _ZN12CApplication6RenderEv + 884
20  kodi.bin                            0x00000001010e79cc _ZN17CGUIWindowManager17ProcessRenderLoopEb + 312
21  kodi.bin                            0x0000000100faeb68 _ZN10CGUIDialog17ProcessRenderLoopEb + 48
22  kodi.bin                            0x0000000100b3cf60 _ZN14CGUIDialogBusy11WaitOnEventER6CEventjb + 364
23  kodi.bin                            0x0000000100652270 _ZN12CApplication9OnMessageER11CGUIMessage + 3164
24  kodi.bin                            0x00000001010e1d8c _ZN17CGUIWindowManager11SendMessageER11CGUIMessage + 140
25  kodi.bin                            0x00000001010e8aa0 _ZN17CGUIWindowManager22DispatchThreadMessagesEv + 224
26  kodi.bin                            0x00000001006548d0 _ZN12CApplication7ProcessEv + 36
27  kodi.bin                            0x000000010064ebc8 _ZN12CApplication3RunEv + 336
28  kodi.bin                            0x0000000101a7b414 XBMC_Run + 356
29  kodi.bin                            0x000000010000c5dc -[XBMCDelegate mainLoopThread:] + 148
30  Foundation                          0x0000000187f9d470 __NSThread__start__ + 716
31  libsystem_pthread.dylib             0x000000011177d5d4 _pthread_start + 148
32  libsystem_pthread.dylib             0x0000000111787a88 thread_start + 8
```