### PR TITLE
[macos][native windowing] Address a few deprecations

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -668,7 +668,6 @@ bool CWinSystemOSX::CreateNewWindow(const std::string& name, bool fullScreen, RE
       NSString* title = [NSString stringWithUTF8String:m_name.c_str()];
       appWindow.backgroundColor = NSColor.blackColor;
       appWindow.title = title;
-      [appWindow setOneShot:NO];
 
       NSWindowCollectionBehavior behavior = appWindow.collectionBehavior;
       behavior |= NSWindowCollectionBehaviorFullScreenPrimary;
@@ -1223,7 +1222,8 @@ void CWinSystemOSX::EnableVSync(bool enable)
 {
   // OpenGL Flush synchronised with vertical retrace
   GLint swapInterval = enable ? 1 : 0;
-  [NSOpenGLContext.currentContext setValues:&swapInterval forParameter:NSOpenGLCPSwapInterval];
+  [NSOpenGLContext.currentContext setValues:&swapInterval
+                               forParameter:NSOpenGLContextParameterSwapInterval];
 }
 
 std::unique_ptr<CVideoSync> CWinSystemOSX::GetVideoSync(void* clock)


### PR DESCRIPTION
## Description
This addresses two simple deprecations:

- 'setOneShot:' is deprecated: first deprecated in macOS 10.14 - This property does not do anything and should not be used
- 'NSOpenGLCPSwapInterval' is deprecated: first deprecated in macOS 10.14
Replace 'NSOpenGLCPSwapInterval' with 'NSOpenGLContextParameterSwapInterval'