### PR TITLE
[macOS][nativewindow] Resize/reposition while in fullscreen (XBMC_FUL…

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -295,12 +295,23 @@ void CApplication::HandlePortEvents()
             //auto& gfxContext = CServiceBroker::GetWinSystem()->GetGfxContext();
             //gfxContext.SetVideoResolution(gfxContext.GetVideoResolution(), true);
             // try to resize window back to it's full screen size
+            //! TODO: DX windowing should emit XBMC_FULLSCREEN_UPDATE instead with the proper dimensions
+            //! and position to avoid the ifdef in common code
             auto& res_info = CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP);
             CServiceBroker::GetWinSystem()->ResizeWindow(res_info.iScreenWidth, res_info.iScreenHeight, 0, 0);
           }
 #endif
         }
         break;
+      case XBMC_FULLSCREEN_UPDATE:
+      {
+        if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_fullScreen)
+        {
+          CServiceBroker::GetWinSystem()->ResizeWindow(newEvent.resize.w, newEvent.resize.h,
+                                                       newEvent.move.x, newEvent.move.y);
+        }
+        break;
+      }
       case XBMC_VIDEOMOVE:
       {
         CServiceBroker::GetWinSystem()->OnMove(newEvent.move.x, newEvent.move.y);

--- a/xbmc/windowing/XBMC_events.h
+++ b/xbmc/windowing/XBMC_events.h
@@ -19,23 +19,25 @@
 #include "input/XBMC_keyboard.h"
 
 /* Event enumerations */
-typedef enum {
-       XBMC_NOEVENT = 0,        /* Unused (do not remove) */
-       XBMC_KEYDOWN,            /* Keys pressed */
-       XBMC_KEYUP,              /* Keys released */
-       XBMC_MOUSEMOTION,        /* Mouse moved */
-       XBMC_MOUSEBUTTONDOWN,    /* Mouse button pressed */
-       XBMC_MOUSEBUTTONUP,      /* Mouse button released */
-       XBMC_QUIT,               /* User-requested quit */
-       XBMC_VIDEORESIZE,        /* User resized video mode */
-       XBMC_VIDEOMOVE,          /* User moved the window */
-       XBMC_MODECHANGE,         /* Video mode must be changed */
-       XBMC_TOUCH,
-       XBMC_BUTTON,             /* Button (remote) pressed */
-       XBMC_SETFOCUS,
-       XBMC_USEREVENT,
+typedef enum
+{
+  XBMC_NOEVENT = 0, /* Unused (do not remove) */
+  XBMC_KEYDOWN, /* Keys pressed */
+  XBMC_KEYUP, /* Keys released */
+  XBMC_MOUSEMOTION, /* Mouse moved */
+  XBMC_MOUSEBUTTONDOWN, /* Mouse button pressed */
+  XBMC_MOUSEBUTTONUP, /* Mouse button released */
+  XBMC_QUIT, /* User-requested quit */
+  XBMC_VIDEORESIZE, /* User resized video mode */
+  XBMC_FULLSCREEN_UPDATE, /* Triggered by an OS event when Kodi is running in fullscreen, rescale and repositioning is required  */
+  XBMC_VIDEOMOVE, /* User moved the window */
+  XBMC_MODECHANGE, /* Video mode must be changed */
+  XBMC_TOUCH,
+  XBMC_BUTTON, /* Button (remote) pressed */
+  XBMC_SETFOCUS,
+  XBMC_USEREVENT,
 
-       XBMC_MAXEVENT = 256      /* XBMC_EventType is represented as uchar */
+  XBMC_MAXEVENT = 256 /* XBMC_EventType is represented as uchar */
 } XBMC_EventType;
 
 /* Keyboard event structure */


### PR DESCRIPTION
…LSCREEN_UPDATE) event

## Description
This fixes window rescaling when toggling fullscreen in MacOS native windowing, being actually the first build that makes kodi usable for me on the desktop. Haven't yet checked the multi-display behaviour.
Similar to what happens in windows, macos might trigger the window resize even if we are running on fullscreen. Since the actual dimensions and position may depend on the underlying OS (see https://github.com/xbmc/xbmc/pull/15460) I added a new event `XBMC_FULLSCREEN_UPDATE` for that. This should not cause regressions and would allow us to update the windows path at somepoint in the future (for O*).

The following video ilustrates the issues with current master:

https://www.youtube.com/watch?v=vTJIzxzdRQc

This video shows how it behaves now (note it also includes https://github.com/xbmc/xbmc/pull/22227 https://github.com/xbmc/xbmc/pull/22228  https://github.com/xbmc/xbmc/pull/22229): 

https://www.youtube.com/watch?v=zFTdPTbDWqw