### PR TITLE
[MacOS][NativeWindowing] Fix display localized name, fix compiler warnings, remove deadcode

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -91,7 +91,7 @@ public:
 protected:
   std::unique_ptr<KODI::WINDOWING::IOSScreenSaver> GetOSScreenSaverImpl() override;
 
-  void GetScreenResolution(int* w, int* h, double* fps, int screenIdx);
+  void GetScreenResolution(int* w, int* h, double* fps, unsigned long screenIdx);
   void EnableVSync(bool enable);
   bool SwitchToVideoMode(int width, int height, double refreshrate);
   void FillInVideoModes();
@@ -107,7 +107,7 @@ protected:
   NSWindow* m_appWindow;
   OSXGLView* m_glView;
   bool m_movedToOtherScreen;
-  int m_lastDisplayNr;
+  unsigned long m_lastDisplayNr;
   double m_refreshRate;
 
   CCriticalSection m_resourceSection;


### PR DESCRIPTION
## Description

Started to give a go to multi-monitor/tv setup with native windowing. It's broken as hell :)
This PR mainly fixes the friendly/localized name for the several displays ([Since macOS 10.15 this is now part of the API](https://developer.apple.com/documentation/appkit/nsscreen/3228043-localizedname)).

Also fixes loads of compiler warnings due to implicit conversions.

Step by step, hopefully we might be able to drop SDL for v21.