### PR TITLE
[PVR] Fix for duplicate resume dialogs

### DIFF
--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -506,6 +506,7 @@ int PlayOrQueueMedia(const std::vector<std::string>& params, bool forcePlay)
   {
     if (CGUIWindowVideoBase::ShowResumeMenu(item) == false)
       return false;
+    item.SetProperty("check_resume", false);
   }
 
   if (item.m_bIsFolder || item.IsPlayList())

--- a/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
@@ -462,7 +462,10 @@ bool CPVRGUIActionsPlayback::PlayMedia(const CFileItem& item) const
     const std::shared_ptr<CPVRRecording> recording =
         CServiceBroker::GetPVRManager().Recordings()->GetByPath(item.GetPath());
     if (recording)
+    {
       pvrItem = std::make_unique<CFileItem>(recording);
+      pvrItem->SetStartOffset(item.GetStartOffset());
+    }
   }
   bool bCheckResume = true;
   if (item.HasProperty("check_resume"))


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->

Stop Kodi from presenting a second resume dialog after the user has made an initial selection.


<!--- Describe your change in detail here. -->

After a user makes a selection to resume a recording set the "check_resume" property to stop the player from presenting it again.  Also when the play media function is called copy the startOffset flag to the playing PVR item.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Avoids a user annoyance selecting the resume point twice.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested from the main TV window on recordings.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

Video of the issue https://imgur.com/a/SAKGADC


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
