### PR TITLE
[MacOS][NativeWindowing] Don't toggle fullscreen if state is the same

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -870,6 +870,7 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
   m_lastDisplayNr = GetDisplayIndex(settings->GetString(CSettings::SETTING_VIDEOSCREEN_MONITOR));
   m_nWidth = res.iWidth;
   m_nHeight = res.iHeight;
+  const bool fullScreenState = m_bFullScreen;
   m_bFullScreen = fullScreen;
 
   //handle resolution/refreshrate switching early here
@@ -924,12 +925,14 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
     UnblankDisplays();
   }
 
-  m_fullscreenWillToggle = true;
   // toggle cocoa fullscreen mode
-  if ([m_appWindow respondsToSelector:@selector(toggleFullScreen:)])
+  if (fullScreenState != m_bFullScreen)
+  {
+    m_fullscreenWillToggle = true;
     [m_appWindow performSelectorOnMainThread:@selector(toggleFullScreen:)
                                   withObject:nil
                                waitUntilDone:YES];
+  }
 
   ResizeWindow(m_nWidth, m_nHeight, -1, -1);
 


### PR DESCRIPTION
## Description

When we change screen resolution or switch display/screen `SetFullScreen(fullscreenState, ...)` is called. Although we don't actually change the fullscreen state we toggle it anyway, causing inconsistencies of state in the interface. 

It'd be great if https://github.com/xbmc/xbmc/pull/22239 could be merged first as this one is easier to rebase than the other