### PR TITLE
DRMPRIMEEGL: Also map the plane modifiers

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
@@ -82,6 +82,7 @@ bool CDRMPRIMETexture::Map(CVideoBufferDRMPRIME* buffer)
     for (int i = 0; i < layer->nb_planes; i++)
     {
       planes[i].fd = descriptor->objects[layer->planes[i].object_index].fd;
+      planes[i].modifier = descriptor->objects[layer->planes[i].object_index].format_modifier;
       planes[i].offset = layer->planes[i].offset;
       planes[i].pitch = layer->planes[i].pitch;
     }


### PR DESCRIPTION
## Description
Also map the plane modifiers

## Motivation and context
Currently hardware formats that include modifiers cannot be rendered with EGL.
The modifiers are required for rendering a plane but currently are lose between the decoder and EGL renderer `CEGLImage::CEGLImage` tries to use them, but they are never set.

## How has this been tested?
Latest master of mesa ("v3d: Also expose DRM_FORMAT_MOD_BROADCOM_SAND128 with PIPE_FORMAT_P030")
includes support for importing from hardware decoded buffers. But without this patch you get a garbled mess.
With this patch hardware formats like Broadcom 8-bit (SAND128) and 10-bit (P030) can now be correctly rendered

## What is the effect on users?
In a standard drm/gbm build, the EGL renderer becomes usable with hw decoded hevc.
Performance is decent (1080p24 for example is fine). 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
