### PR TITLE
[Nexus][vfs] ReadString(): buffer overflow fix, add documentation and make implementation consitent

### DIFF
--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -1056,7 +1056,7 @@ extern "C"
     {
       if (pFile->GetPosition() < pFile->GetLength())
       {
-        bool bRead = pFile->ReadString(pszString, num);
+        bool bRead = pFile->ReadString(pszString, num - 1);
         if (bRead)
         {
           return pszString;

--- a/xbmc/cores/RetroPlayer/cheevos/Cheevos.cpp
+++ b/xbmc/cores/RetroPlayer/cheevos/Cheevos.cpp
@@ -85,7 +85,7 @@ bool CCheevos::LoadData()
   response.CURLOpen(0);
 
   char responseStr[RESPONSE_SIZE];
-  response.ReadString(responseStr, RESPONSE_SIZE);
+  response.ReadString(responseStr, RESPONSE_SIZE - 1);
 
   response.Close();
 

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -108,7 +108,7 @@ bool CEdl::ReadEdl(const std::string& strMovie, const float fFramesPerSecond)
   int iLine = 0;
   std::string strBuffer;
   strBuffer.resize(1024);
-  while (edlFile.ReadString(&strBuffer[0], 1024))
+  while (edlFile.ReadString(&strBuffer[0], 1023))
   {
     // Log any errors from previous run in the loop
     if (bError)

--- a/xbmc/filesystem/FTPDirectory.cpp
+++ b/xbmc/filesystem/FTPDirectory.cpp
@@ -42,7 +42,7 @@ bool CFTPDirectory::GetDirectory(const CURL& url2, CFileItemList &items)
   bool serverNotUseUTF8 = url.GetProtocolOption("utf8") == "0";
 
   char buffer[MAX_PATH + 1024];
-  while( reader.ReadString(buffer, sizeof(buffer)) )
+  while (reader.ReadString(buffer, sizeof(buffer) - 1))
   {
     std::string strBuffer = buffer;
 

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -768,6 +768,10 @@ bool CFile::ReadString(char *szLine, int iLineLength)
       if(aByte == traits::eof())
         break;
 
+      *szLine = traits::to_char_type(aByte);
+      szLine++;
+      iLineLength--;
+
       if(aByte == traits::to_int_type('\n'))
       {
         if(m_pBuffer->sgetc() == traits::to_int_type('\r'))
@@ -781,16 +785,9 @@ bool CFile::ReadString(char *szLine, int iLineLength)
           m_pBuffer->sbumpc();
         break;
       }
-
-      *szLine = traits::to_char_type(aByte);
-      szLine++;
-      iLineLength--;
     }
 
-    // if we have no space for terminating character we failed
-    if(iLineLength==0)
-      return false;
-
+    // there has to be the space for terminating character (at szLine[iLineLength])
     *szLine = 0;
 
     return true;

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -72,6 +72,16 @@ public:
    *         or undetectable error occur, -1 in case of any explicit error
    */
   ssize_t Read(void* bufPtr, size_t bufSize);
+  /**
+   * Attempt to read a line up to iLineLength bytes from currently opened file into
+   * szLine. If a newline is read, it is stored into the buffer. A terminating null
+   * byte is stored after the last character in the buffer, therefore szLine has to
+   * be at least of length iLineLength + 1.
+   * @param szLine      pointer to string buffer
+   * @param iLineLength size of the buffer - 1
+   * @return True if any bytes were read and stored in szLine, False if no bytes
+   *         are available to read (end of file was reached) or error occur
+   */
   bool ReadString(char *szLine, int iLineLength);
   /**
    * Attempt to write bufSize bytes from buffer bufPtr into currently opened file.

--- a/xbmc/playlists/PlayListPLS.cpp
+++ b/xbmc/playlists/PlayListPLS.cpp
@@ -87,7 +87,7 @@ bool CPlayListPLS::Load(const std::string &strFile)
   // if we find another http stream, then load it.
   while (true)
   {
-    if ( !file.ReadString(szLine, sizeof(szLine) ) )
+    if (!file.ReadString(szLine, sizeof(szLine) - 1))
     {
       file.Close();
       return size() > 0;
@@ -103,7 +103,7 @@ bool CPlayListPLS::Load(const std::string &strFile)
   }
 
   bool bFailed = false;
-  while (file.ReadString(szLine, sizeof(szLine) ) )
+  while (file.ReadString(szLine, sizeof(szLine) - 1))
   {
     strLine = szLine;
     StringUtils::RemoveCRLF(strLine);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
- Fix possible buffer overflow when using CFile::ReadString()
- Add documentation of CFile::ReadString()
- Fix CFile::ReadString() to match documentation

Nexus Backport of #22222

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Looking at #22039 I noticed the unusual buffer length parameter of CFile::ReadString(),
was wondering if there are other wrong use cases and found some. First commit contains 
the fixes.

Second commit add function documentation. It describes the implementation of [IFile](https://github.com/xbmc/xbmc/blob/26adddf24d919b812a1bedf2507d5d33d4ebdbcf/xbmc/filesystem/IFile.cpp) and [CCurFile](https://github.com/xbmc/xbmc/blob/26adddf24d919b812a1bedf2507d5d33d4ebdbcf/xbmc/filesystem/CurlFile.cpp#L1251)

Third commit is making the function behavior consistent changing CFile::ReadString().

Needed fix for kodi::vfs::ReadLine() (#22039) is not included.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

In my private Nexus and Matrix Linux test builds.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Less random crashes from buffer overflow. 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
