### PR TITLE
[tools/depends][target] libmicrohttpd - disable timespec_get apple platforms

### DIFF
--- a/tools/depends/target/libmicrohttpd/Makefile
+++ b/tools/depends/target/libmicrohttpd/Makefile
@@ -15,6 +15,13 @@ ifeq ($(DEBUG_BUILD), yes)
   CONFIGURE+= --enable-asserts
 endif
 
+ifeq ($(findstring apple-darwin, $(HOST)), apple-darwin)
+  # blanket disable timespec_get use for apple platforms. timespec_get was introduced in
+  # __API_AVAILABLE(macosx(10.15), ios(13.0), tvos(13.0), watchos(6.0)) but older platforms
+  # are failing to run.
+  CONFIGURE+= mhd_cv_func_timespec_get=no
+endif
+
 LIBDYLIB=$(PLATFORM)/src/microhttpd/.libs/$(LIBNAME).a
 
 all: .installed-$(PLATFORM)


### PR DESCRIPTION
## Description
Fixes #22244

## Motivation and context
disable timespec_get for apple platforms. Was introduced in __API_AVAILABLE(macosx(10.15), ios(13.0), tvos(13.0), watchos(6.0)) however older platforms (reported 10.13.6) fail to run.

## How has this been tested?

## What is the effect on users?
Older Macos platforms able to run with up to date libmicrohttp dependency

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
