### PR TITLE
[discs] Allow compilation of darwin driver on apple silicon

### DIFF
--- a/tools/depends/target/libcdio-gplv3/Makefile
+++ b/tools/depends/target/libcdio-gplv3/Makefile
@@ -23,7 +23,9 @@ all: .installed-$(PLATFORM)
 $(PLATFORM): $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE) $(DEPS)
 	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+ifeq ($(TARGET_PLATFORM),macosx)
 	cd $(PLATFORM); patch -p1 -i ../osx.patch
+endif
 	cd $(PLATFORM); patch -p1 -i ../01-fix-glob-on-android.patch
 	cd $(PLATFORM); $(AUTORECONF) -vif
 	cd $(PLATFORM); $(CONFIGURE)

--- a/tools/depends/target/libcdio-gplv3/osx.patch
+++ b/tools/depends/target/libcdio-gplv3/osx.patch
@@ -13,7 +13,7 @@
         ##     [Define 1 if you have AIX CD-ROM support])
         ;;
 -     darwin[[6-9]].*|darwin[[1-9]][[0-9]].*)
-+     x86_64-apple-darwin*)
++     *-apple-darwin*)
         AC_CHECK_HEADERS(IOKit/IOKitLib.h CoreFoundation/CFBase.h,
                          [have_iokit_h="yes"])
         if test "x$have_iokit_h" = "xyes" ; then


### PR DESCRIPTION
## Description
Looking into fixing https://github.com/xbmc/xbmc/issues/2225 since it's a regression of the discdrive platform split caused by me. It looks like for apple silicon the osx/darwin driver is not being built as part of our libcdio depends build. This patches enables it.
Runtime tested (doesn't yet fix the reported issue).