### PR TITLE
[Discs] Fix physical drive access on macOS

### DIFF
--- a/xbmc/platform/posix/storage/discs/DiscDriveHandlerPosix.cpp
+++ b/xbmc/platform/posix/storage/discs/DiscDriveHandlerPosix.cpp
@@ -45,6 +45,7 @@ DriveState CDiscDriveHandlerPosix::GetDriveState(const std::string& devicePath)
   switch (status)
   {
     case CdioTrayStatus::CLOSED:
+    case CdioTrayStatus::UNKNOWN:
       driveStatus = DriveState::CLOSED_MEDIA_UNDEFINED;
       break;
 

--- a/xbmc/storage/cdioSupport.cpp
+++ b/xbmc/storage/cdioSupport.cpp
@@ -25,6 +25,8 @@ namespace
 constexpr int CDIO_TRAY_STATUS_CLOSED = 0;
 /* Helper constexpr to hide the 1 return code for tray open */
 constexpr int CDIO_TRAY_STATUS_OPEN = 1;
+/* Helper constexpr to hide the -2 driver code for unsupported tray status get operation */
+constexpr int CDIO_TRAY_STATUS_OP_UNSUPPORTED = -2;
 } // namespace
 
 using namespace MEDIA_DETECT;
@@ -154,6 +156,8 @@ CdioTrayStatus CLibcdio::mmc_get_tray_status(const CdIo_t* p_cdio)
       return CdioTrayStatus::CLOSED;
     case CDIO_TRAY_STATUS_OPEN:
       return CdioTrayStatus::OPEN;
+    case CDIO_TRAY_STATUS_OP_UNSUPPORTED:
+      return CdioTrayStatus::UNKNOWN;
     default:
       break;
   }

--- a/xbmc/storage/cdioSupport.h
+++ b/xbmc/storage/cdioSupport.h
@@ -105,7 +105,9 @@ enum class CdioTrayStatus
   CLOSED,
   /* The MMC tray state is reported open */
   OPEN,
-  /* Driver error */
+  /* The MMC tray status operation is not supported */
+  UNKNOWN,
+  /* Generic driver error */
   DRIVER_ERROR
 };
 


### PR DESCRIPTION
## Description
It looks like the osx libcdio driver does not support the `mmc_get_tray_status` returning an unsupported driver operation code (-2) and since https://github.com/xbmc/xbmc/pull/21143 we abort with `DRIVE_NOT_READY` in case of any driver error (even if the call is simply unsupported). Thus, this is a regression compared to the old behaviour.

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/22257

## How has this been tested?
Runtime tested on macOS 13.01 (apple silicon)

## What is the effect on users?
Fix optical disc support under macOS for O* (and nexus)
