### PR TITLE
[music][video] (Music|Video)Utils::IsItemPlayable: Fix playlist detection

### DIFF
--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -787,6 +787,9 @@ bool IsItemPlayable(const CFileItem& item)
   // Include playlists located at one of the possible music playlist locations
   if (item.IsPlayList())
   {
+    if (StringUtils::StartsWithNoCase(item.GetMimeType(), "audio/"))
+      return true;
+
     if (StringUtils::StartsWithNoCase(item.GetPath(), "special://musicplaylists/") ||
         StringUtils::StartsWithNoCase(item.GetPath(), "special://profile/playlists/music/"))
       return true;

--- a/xbmc/video/VideoUtils.cpp
+++ b/xbmc/video/VideoUtils.cpp
@@ -410,6 +410,9 @@ bool IsItemPlayable(const CFileItem& item)
   // Include playlists located at one of the possible video/mixed playlist locations
   if (item.IsPlayList())
   {
+    if (StringUtils::StartsWithNoCase(item.GetMimeType(), "video/"))
+      return true;
+
     if (StringUtils::StartsWithNoCase(item.GetPath(), "special://videoplaylists/") ||
         StringUtils::StartsWithNoCase(item.GetPath(), "special://profile/playlists/video/") ||
         StringUtils::StartsWithNoCase(item.GetPath(), "special://profile/playlists/mixed/"))


### PR DESCRIPTION
@basilgello fixes the problem you have reported here: https://github.com/xbmc/xbmc/pull/22107#issuecomment-1352027885, could you please review and  runtime test?

Runtime-tested on macOS, latest Kodi master.

Needs backport.