### PR TITLE
[macOS] Keep backward compatibility to 10.13

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -668,6 +668,17 @@ bool CWinSystemOSX::CreateNewWindow(const std::string& name, bool fullScreen, RE
       NSString* title = [NSString stringWithUTF8String:m_name.c_str()];
       appWindow.backgroundColor = NSColor.blackColor;
       appWindow.title = title;
+      //! TODO: Remove me if minimum version is bumped to 10_14
+      if (![NSProcessInfo.processInfo
+              isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){.majorVersion = 10,
+                                                                         .minorVersion = 14,
+                                                                         .patchVersion = 0}])
+      {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        [appWindow setOneShot:NO];
+#pragma GCC diagnostic pop
+      }
 
       NSWindowCollectionBehavior behavior = appWindow.collectionBehavior;
       behavior |= NSWindowCollectionBehaviorFullScreenPrimary;


### PR DESCRIPTION
## Description
The stuff removed in https://github.com/xbmc/xbmc/pull/22229 and https://github.com/xbmc/xbmc/pull/22187 actually target macOS 10.14 as minimum version although our minimum supported version is still macOS 10.13.
Ugly as hell but better safe than sorry. Can be easily removed when we bump the minimum required version.