### PR TITLE
[tvOS] Add channel up/down support of the iPhone Apple TV remote app

### DIFF
--- a/system/keymaps/customcontroller.SiriRemote.xml
+++ b/system/keymaps/customcontroller.SiriRemote.xml
@@ -57,6 +57,8 @@
       <!-- Siri remote pan down                     --> <button id="24">Down</button>
       <!-- Siri remote pan left                     --> <button id="25">Left</button>
       <!-- Siri remote pan right                    --> <button id="26">Right</button>
+      <!-- Apple TV remote iPhone/iPad channel up   --> <button id="27">ChannelUp</button>
+      <!-- Apple TV remote iPhone/iPad channel down --> <button id="28">ChannelDown</button>
     </customcontroller>
   </global>
   <Home>

--- a/xbmc/platform/darwin/tvos/input/LibInputTouch.mm
+++ b/xbmc/platform/darwin/tvos/input/LibInputTouch.mm
@@ -80,6 +80,8 @@
     // single press keys
     case UIPressTypeSelect:
     case UIPressTypePlayPause:
+    case UIPressTypePageUp:
+    case UIPressTypePageDown:
       break;
 
     // auto-repeat keys
@@ -162,6 +164,23 @@
   menuRecognizer.allowedPressTypes = @[ @(UIPressTypeMenu) ];
   menuRecognizer.delegate = self;
   [g_xbmcController.glView addGestureRecognizer:menuRecognizer];
+
+  if (@available(tvOS 14.3, *)) {
+    auto pageUpTypes = @[ @(UIPressTypePageUp) ];
+    auto pageUpRecognizer =
+        [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(pageUpPressed:)];
+    pageUpRecognizer.allowedPressTypes = pageUpTypes;
+    pageUpRecognizer.delegate = self;
+    [g_xbmcController.glView addGestureRecognizer:pageUpRecognizer];
+
+    auto pageDownTypes = @[ @(UIPressTypePageDown) ];
+    auto pageDownRecognizer =
+        [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(pageDownPressed:)];
+    pageDownRecognizer.allowedPressTypes = pageDownTypes;
+    pageDownRecognizer.delegate = self;
+    [g_xbmcController.glView addGestureRecognizer:pageDownRecognizer];
+  }
+
 
   auto playPauseTypes = @[ @(UIPressTypePlayPause) ];
   auto playPauseRecognizer =
@@ -250,6 +269,34 @@
     case UIGestureRecognizerStateEnded:
       CLog::Log(LOGDEBUG, "Input: Siri remote select press (id: 5)");
       [g_xbmcController.inputHandler sendButtonPressed:5];
+      [g_xbmcController.inputHandler.inputRemote startSiriRemoteIdleTimer];
+      break;
+    default:
+      break;
+  }
+}
+
+- (void)pageUpPressed:(UITapGestureRecognizer*)sender
+{
+  switch (sender.state)
+  {
+    case UIGestureRecognizerStateEnded:
+      CLog::Log(LOGDEBUG, "Input: Siri remote page up press (id: 27)");
+      [g_xbmcController.inputHandler sendButtonPressed:27];
+      [g_xbmcController.inputHandler.inputRemote startSiriRemoteIdleTimer];
+      break;
+    default:
+      break;
+  }
+}
+
+- (void)pageDownPressed:(UITapGestureRecognizer*)sender
+{
+  switch (sender.state)
+  {
+    case UIGestureRecognizerStateEnded:
+      CLog::Log(LOGDEBUG, "Input: Siri remote page down press (id: 28)");
+      [g_xbmcController.inputHandler sendButtonPressed:28];
       [g_xbmcController.inputHandler.inputRemote startSiriRemoteIdleTimer];
       break;
     default:


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This PR add support of the channel up/down button that you can found on the Apple TV remote app preinstalled on iPhones and iPads.

![ios15-iphone12-pro-home-control-center-apple-tv-remote](https://user-images.githubusercontent.com/11562279/207973475-df6e8458-3717-498b-9152-3c889d085b76.png)


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Better user experience.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On an Apple TV 4K with an iPhone as remote.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Users are now able to use and customize the Kodi action of the channel up/down button of the Apple TV remote app.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
