### PR TITLE
[Android] Explicitly choosing a Looper during Handler construction

### DIFF
--- a/tools/android/packaging/xbmc/src/Main.java.in
+++ b/tools/android/packaging/xbmc/src/Main.java.in
@@ -13,6 +13,7 @@ import android.os.Build;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
 import android.util.Log;
 import android.view.Choreographer;
 import android.view.View;
@@ -32,7 +33,7 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
   private XBMCJsonRPC mJsonRPC = null;
   private View mDecorView = null;
   private RelativeLayout mVideoLayout = null;
-  private Handler handler = new Handler();
+  private Handler handler = new Handler(Looper.myLooper());
 
   private class DelayedIntent
   {

--- a/tools/android/packaging/xbmc/src/Splash.java.in
+++ b/tools/android/packaging/xbmc/src/Splash.java.in
@@ -21,6 +21,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
+import android.os.Looper;
 import android.os.Message;
 import android.provider.Settings;
 import android.text.Html;
@@ -106,6 +107,7 @@ public class Splash extends Activity
 
     StateMachine(Splash a)
     {
+      super(Looper.myLooper());
       this.mSplash = a;
     }
 


### PR DESCRIPTION
## Description
The way of creating an object of Handler using `Handler()` constructor is deprecated and can lead to bugs.

It's recommended to explicitly specify a looper for the handler using the `Handler (Looper looper)` constructor.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
