### PR TITLE
[MacOS][NativeWindowing] Implement safe area insets

### DIFF
--- a/xbmc/windowing/GraphicContext.cpp
+++ b/xbmc/windowing/GraphicContext.cpp
@@ -640,6 +640,7 @@ void CGraphicContext::SetResInfo(RESOLUTION res, const RESOLUTION_INFO& info)
   curr.Overscan   = info.Overscan;
   curr.iSubtitles = info.iSubtitles;
   curr.fPixelRatio = info.fPixelRatio;
+  curr.guiInsets = info.guiInsets;
 
   if(info.dwFlags & D3DPRESENTFLAG_MODE3DSBS)
   {


### PR DESCRIPTION
## Description

Unfortunately recent macbooks models include one of the wonders of the world: "The Notch". This allows to increase the screen size while fucking up everything else :)

On those devices, several screen resolutions are available: some that take advantage of the whole screen area (~3:2 in aspect ratio) and others in 16:10 aspect ratio that only take into account the safe area (that below the notch). When in fullscreen using one of the 3:2 resolutions, the application can only take advantage of the safe area, a black bar is displayed around the notch and a resize event is triggered with the new dimensions to fit the safe area. The menu bar however, can be displayed on the area to the sides of the notch.
 
For example in my laptop using the default resolution of 1470x958, when Kodi initialises and moves to fullscreen the window is resized to 1470x920 (the 16:10 resolution counterpart). 

<img width="1209" alt="image" src="https://user-images.githubusercontent.com/7375276/208547614-bc5b1578-2bc3-4966-9cc0-1dc24a443b88.png">

While since https://github.com/xbmc/xbmc/pull/22232 Kodi is already able to correctly scale the UI when going to fullscreen in those resolutions, the overscan is kept as is - leading to the bottom of the window to be scaled out of the screen. The overscan needs to be fixed to match the new height (the default in every resolution if unchanged by the user).

This PR addresses this issue and also fixes the reset operation in the calibration screen (needs to be handled by the windowing system and not only by the context). It makes sure it only takes effect if the overscan bottom value is equal to the resolution height (the default value) and the window height is different to the screen height.

**Master:**
<img width="1470" alt="image" src="https://user-images.githubusercontent.com/7375276/208549301-54038637-2ffb-49a6-a2aa-8328e158b0dc.png">

**PR:**

<img width="1470" alt="image" src="https://user-images.githubusercontent.com/7375276/208548913-9c59df09-d8bc-42f2-bd77-3ce42121d9e8.png">

