### PR TITLE
Fix double attempt to find flatc compiler

### DIFF
--- a/cmake/modules/buildtools/FindFlatC.cmake
+++ b/cmake/modules/buildtools/FindFlatC.cmake
@@ -12,86 +12,86 @@
 #
 #   flatbuffers::flatc - The FlatC compiler
 
-include(cmake/scripts/common/ModuleHelpers.cmake)
+if(NOT TARGET flatbuffers::flatc)
+  include(cmake/scripts/common/ModuleHelpers.cmake)
 
-# Check for existing FLATC.
-find_program(FLATBUFFERS_FLATC_EXECUTABLE NAMES flatc
-                                          HINTS ${NATIVEPREFIX}/bin)
+  # Check for existing FLATC.
+  find_program(FLATBUFFERS_FLATC_EXECUTABLE NAMES flatc
+                                            HINTS ${NATIVEPREFIX}/bin)
 
-if(FLATBUFFERS_FLATC_EXECUTABLE)
-  execute_process(COMMAND "${FLATBUFFERS_FLATC_EXECUTABLE}" --version
-                  OUTPUT_VARIABLE FLATBUFFERS_FLATC_VERSION
-                  OUTPUT_STRIP_TRAILING_WHITESPACE)
-  string(REGEX MATCH "[^\n]* version [^\n]*" FLATBUFFERS_FLATC_VERSION "${FLATBUFFERS_FLATC_VERSION}")
-  string(REGEX REPLACE ".* version (.*)" "\\1" FLATBUFFERS_FLATC_VERSION "${FLATBUFFERS_FLATC_VERSION}")
+  if(FLATBUFFERS_FLATC_EXECUTABLE)
+    execute_process(COMMAND "${FLATBUFFERS_FLATC_EXECUTABLE}" --version
+                    OUTPUT_VARIABLE FLATBUFFERS_FLATC_VERSION
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    string(REGEX MATCH "[^\n]* version [^\n]*" FLATBUFFERS_FLATC_VERSION "${FLATBUFFERS_FLATC_VERSION}")
+    string(REGEX REPLACE ".* version (.*)" "\\1" FLATBUFFERS_FLATC_VERSION "${FLATBUFFERS_FLATC_VERSION}")
 
-else()
-
-  set(MODULE_LC flatbuffers)
-  # Duplicate URL may exist from FindFlatbuffers.cmake
-  # unset otherwise it thinks we are providing a local file location and incorrect concatenation happens
-  unset(FLATBUFFERS_URL)
-  SETUP_BUILD_VARS()
-
-  # Override build type detection and always build as release
-  set(FLATBUFFERS_BUILD_TYPE Release)
-
-  if(NATIVEPREFIX)
-    set(INSTALL_DIR "${NATIVEPREFIX}/bin")
-    set(FLATBUFFERS_INSTALL_PREFIX ${NATIVEPREFIX})
   else()
-    set(INSTALL_DIR "${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/bin")
-    set(FLATBUFFERS_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR})
+
+    set(MODULE_LC flatbuffers)
+    # Duplicate URL may exist from FindFlatbuffers.cmake
+    # unset otherwise it thinks we are providing a local file location and incorrect concatenation happens
+    unset(FLATBUFFERS_URL)
+    SETUP_BUILD_VARS()
+
+    # Override build type detection and always build as release
+    set(FLATBUFFERS_BUILD_TYPE Release)
+
+    if(NATIVEPREFIX)
+      set(INSTALL_DIR "${NATIVEPREFIX}/bin")
+      set(FLATBUFFERS_INSTALL_PREFIX ${NATIVEPREFIX})
+    else()
+      set(INSTALL_DIR "${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/bin")
+      set(FLATBUFFERS_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR})
+    endif()
+
+    set(CMAKE_ARGS -DFLATBUFFERS_CODE_COVERAGE=OFF
+                   -DFLATBUFFERS_BUILD_TESTS=OFF
+                   -DFLATBUFFERS_INSTALL=ON
+                   -DFLATBUFFERS_BUILD_FLATLIB=OFF
+                   -DFLATBUFFERS_BUILD_FLATC=ON
+                   -DFLATBUFFERS_BUILD_FLATHASH=OFF
+                   -DFLATBUFFERS_BUILD_GRPCTEST=OFF
+                   -DFLATBUFFERS_BUILD_SHAREDLIB=OFF)
+
+    # Set host build info for buildtool
+    if(EXISTS "${NATIVEPREFIX}/share/Toolchain-Native.cmake")
+      set(FLATBUFFERS_TOOLCHAIN_FILE "${NATIVEPREFIX}/share/Toolchain-Native.cmake")
+    endif()
+
+    if(WIN32 OR WINDOWS_STORE)
+      # Make sure we generate for host arch, not target
+      set(FLATBUFFERS_GENERATOR_PLATFORM CMAKE_GENERATOR_PLATFORM ${HOSTTOOLSET})
+    endif()
+
+    set(FLATBUFFERS_FLATC_EXECUTABLE ${INSTALL_DIR}/flatc CACHE INTERNAL "FlatBuffer compiler")
+
+    set(BUILD_NAME flatc)
+    set(BUILD_BYPRODUCTS ${FLATBUFFERS_FLATC_EXECUTABLE})
+    set(FLATBUFFERS_FLATC_VERSION ${FLATBUFFERS_VER})
+
+    BUILD_DEP_TARGET()
   endif()
 
-  set(CMAKE_ARGS -DFLATBUFFERS_CODE_COVERAGE=OFF
-                 -DFLATBUFFERS_BUILD_TESTS=OFF
-                 -DFLATBUFFERS_INSTALL=ON
-                 -DFLATBUFFERS_BUILD_FLATLIB=OFF
-                 -DFLATBUFFERS_BUILD_FLATC=ON
-                 -DFLATBUFFERS_BUILD_FLATHASH=OFF
-                 -DFLATBUFFERS_BUILD_GRPCTEST=OFF
-                 -DFLATBUFFERS_BUILD_SHAREDLIB=OFF)
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(FlatC
+                                    REQUIRED_VARS FLATBUFFERS_FLATC_EXECUTABLE
+                                    VERSION_VAR FLATBUFFERS_FLATC_VERSION)
 
-  # Set host build info for buildtool
-  if(EXISTS "${NATIVEPREFIX}/share/Toolchain-Native.cmake")
-    set(FLATBUFFERS_TOOLCHAIN_FILE "${NATIVEPREFIX}/share/Toolchain-Native.cmake")
-  endif()
+  if(FLATC_FOUND)
 
-  if(WIN32 OR WINDOWS_STORE)
-    # Make sure we generate for host arch, not target
-    set(FLATBUFFERS_GENERATOR_PLATFORM CMAKE_GENERATOR_PLATFORM ${HOSTTOOLSET})
-  endif()
-
-  set(FLATBUFFERS_FLATC_EXECUTABLE ${INSTALL_DIR}/flatc CACHE INTERNAL "FlatBuffer compiler")
-
-  set(BUILD_NAME flatc)
-  set(BUILD_BYPRODUCTS ${FLATBUFFERS_FLATC_EXECUTABLE})
-  set(FLATBUFFERS_FLATC_VERSION ${FLATBUFFERS_VER})
-
-  BUILD_DEP_TARGET()
-endif()
-
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(FlatC
-                                  REQUIRED_VARS FLATBUFFERS_FLATC_EXECUTABLE
-                                  VERSION_VAR FLATBUFFERS_FLATC_VERSION)
-
-if(FLATC_FOUND)
-
-  if(NOT TARGET flatbuffers::flatc)
     add_library(flatbuffers::flatc UNKNOWN IMPORTED)
     set_target_properties(flatbuffers::flatc PROPERTIES
                                              FOLDER "External Projects")
+
+    if(TARGET flatc)
+      add_dependencies(flatbuffers::flatc flatc)
+    endif()
+  else()
+    if(FLATC_FIND_REQUIRED)
+      message(FATAL_ERROR "Flatc compiler not found.")
+    endif()
   endif()
 
-  if(TARGET flatc)
-    add_dependencies(flatbuffers::flatc flatc)
-  endif()
-else()
-  if(FLATC_FIND_REQUIRED)
-    message(FATAL_ERROR "Flatc compiler not found.")
-  endif()
+  mark_as_advanced(FLATBUFFERS_FLATC_EXECUTABLE)
 endif()
-
-mark_as_advanced(FLATBUFFERS_FLATC_EXECUTABLE)


### PR DESCRIPTION
## Description

When rebasing https://github.com/xbmc/xbmc/pull/21183, I hit an error where find_package(FlatC) was called twice, once from [CMakeLists.txt](https://github.com/xbmc/xbmc/blob/master/CMakeLists.txt#L145) (as it's a required build tool) and once from [FindFlatBuffers.cmake](https://github.com/xbmc/xbmc/blob/master/cmake/modules/FindFlatBuffers.cmake#L11) (as it's a direct dependency of FindFlatBuffers.cmake).

By wrapping FindFlatC,cmake in a guard that checks for an existing target, we can fix the problem.

The whole file is indented, so to see the commit without whitepace changes, append `?w=1`:

* https://github.com/garbear/xbmc/commit/fix-find-flatc?w=1

## Motivation and context

Fix build after https://github.com/xbmc/xbmc/pull/22095

## How has this been tested?

Before: Compiling fails with the error:

```
[  8%] Building C++ header for savestate.fbs
/bin/sh: 1: /home/garrett/Documents/kodi/build/build/bin/flatc: not found
```

After: Compiling succeeds.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
