### PR TITLE
[CDemuxStream] fix ExtraData related memory leak

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
@@ -82,14 +82,14 @@ public:
     source = STREAM_SOURCE_NONE;
     iDuration = 0;
     pPrivate = NULL;
-    ExtraData = NULL;
     ExtraSize = 0;
     disabled = false;
     changes = 0;
     flags = StreamFlags::FLAG_NONE;
   }
 
-  virtual ~CDemuxStream() { delete[] ExtraData; }
+  virtual ~CDemuxStream() = default;
+  CDemuxStream(CDemuxStream&&) = default;
 
   virtual std::string GetStreamName();
 
@@ -105,7 +105,7 @@ public:
 
   int iDuration; // in mseconds
   void* pPrivate; // private pointer for the demuxer
-  uint8_t* ExtraData; // extra data for codec to use
+  std::unique_ptr<uint8_t[]> ExtraData; // extra data for codec to use
   unsigned int ExtraSize; // size of extra data
 
   StreamFlags flags;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
@@ -319,7 +319,7 @@ void CDVDDemuxCC::Handler(int service, void *userdata)
     stream.flags = FLAG_HEARING_IMPAIRED;
     stream.codec = AV_CODEC_ID_TEXT;
     stream.uniqueId = service;
-    ctx->m_streams.push_back(stream);
+    ctx->m_streams.push_back(std::move(stream));
 
     streamdata data;
     data.streamIdx = idx;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -154,14 +154,12 @@ bool CDVDDemuxClient::ParsePacket(DemuxPacket* pkt)
     int len = stream->m_parser->parser->split(stream->m_context, pkt->pData, pkt->iSize);
     if (len > 0 && len < FF_MAX_EXTRADATA_SIZE)
     {
-      if (st->ExtraData)
-        delete[] st->ExtraData;
       st->changes++;
       st->disabled = false;
       st->ExtraSize = len;
-      st->ExtraData = new uint8_t[len+AV_INPUT_BUFFER_PADDING_SIZE];
-      memcpy(st->ExtraData, pkt->pData, len);
-      memset(st->ExtraData + len, 0 , AV_INPUT_BUFFER_PADDING_SIZE);
+      st->ExtraData = std::make_unique<uint8_t[]>(len + AV_INPUT_BUFFER_PADDING_SIZE);
+      memcpy(st->ExtraData.get(), pkt->pData, len);
+      memset(st->ExtraData.get() + len, 0, AV_INPUT_BUFFER_PADDING_SIZE);
       stream->m_parser_split = false;
       change = true;
       CLog::Log(LOGDEBUG, "CDVDDemuxClient::ParsePacket - split extradata");
@@ -435,8 +433,7 @@ void CDVDDemuxClient::SetStreamProps(CDemuxStream *stream, std::map<int, std::sh
     streamAudio->iBitsPerSample  = source->iBitsPerSample;
     if (source->ExtraSize > 0 && source->ExtraData)
     {
-      delete[] streamAudio->ExtraData;
-      streamAudio->ExtraData = new uint8_t[source->ExtraSize];
+      streamAudio->ExtraData = std::make_unique<uint8_t[]>(source->ExtraSize);
       streamAudio->ExtraSize = source->ExtraSize;
       for (unsigned int j=0; j<source->ExtraSize; j++)
         streamAudio->ExtraData[j] = source->ExtraData[j];
@@ -476,8 +473,7 @@ void CDVDDemuxClient::SetStreamProps(CDemuxStream *stream, std::map<int, std::sh
     streamVideo->iBitRate = source->iBitRate;
     if (source->ExtraSize > 0 && source->ExtraData)
     {
-      delete[] streamVideo->ExtraData;
-      streamVideo->ExtraData = new uint8_t[source->ExtraSize];
+      streamVideo->ExtraData = std::make_unique<uint8_t[]>(source->ExtraSize);
       streamVideo->ExtraSize = source->ExtraSize;
       for (unsigned int j=0; j<source->ExtraSize; j++)
         streamVideo->ExtraData[j] = source->ExtraData[j];
@@ -519,8 +515,7 @@ void CDVDDemuxClient::SetStreamProps(CDemuxStream *stream, std::map<int, std::sh
 
     if (source->ExtraSize == 4)
     {
-      delete[] streamSubtitle->ExtraData;
-      streamSubtitle->ExtraData = new uint8_t[4];
+      streamSubtitle->ExtraData = std::make_unique<uint8_t[]>(4);
       streamSubtitle->ExtraSize = 4;
       for (int j=0; j<4; j++)
         streamSubtitle->ExtraData[j] = source->ExtraData[j];

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1880,8 +1880,9 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
     if (stream->type != STREAM_NONE && pStream->codecpar->extradata && pStream->codecpar->extradata_size > 0)
     {
       stream->ExtraSize = pStream->codecpar->extradata_size;
-      stream->ExtraData = new uint8_t[pStream->codecpar->extradata_size];
-      memcpy(stream->ExtraData, pStream->codecpar->extradata, pStream->codecpar->extradata_size);
+      stream->ExtraData = std::make_unique<uint8_t[]>(pStream->codecpar->extradata_size);
+      memcpy(stream->ExtraData.get(), pStream->codecpar->extradata,
+             pStream->codecpar->extradata_size);
     }
 
 #ifdef HAVE_LIBBLURAY

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.cpp
@@ -114,8 +114,8 @@ bool CDVDDemuxVobsub::Open(const std::string& filename, int source, const std::s
   for(unsigned i=0;i<m_Streams.size();i++)
   {
     m_Streams[i]->ExtraSize = state.extra.length()+1;
-    m_Streams[i]->ExtraData = new uint8_t[m_Streams[i]->ExtraSize];
-    strcpy((char*)m_Streams[i]->ExtraData, state.extra.c_str());
+    m_Streams[i]->ExtraData = std::make_unique<uint8_t[]>(m_Streams[i]->ExtraSize);
+    strcpy((char*)m_Streams[i]->ExtraData.get(), state.extra.c_str());
   }
 
   return true;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -530,7 +530,7 @@ KODI_HANDLE CInputStreamAddon::cb_get_stream_transfer(KODI_HANDLE handle,
 
   if (stream->m_ExtraData && stream->m_ExtraSize)
   {
-    demuxStream->ExtraData = new uint8_t[stream->m_ExtraSize];
+    demuxStream->ExtraData = std::make_unique<uint8_t[]>(stream->m_ExtraSize);
     demuxStream->ExtraSize = stream->m_ExtraSize;
     for (unsigned int j = 0; j < stream->m_ExtraSize; ++j)
       demuxStream->ExtraData[j] = stream->m_ExtraData[j];

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.cpp
@@ -322,7 +322,7 @@ void CInputStreamPVRBase::UpdateStreamMap()
 
       if (stream.iSubtitleInfo)
       {
-        streamSubtitle->ExtraData = new uint8_t[4];
+        streamSubtitle->ExtraData = std::make_unique<uint8_t[]>(4);
         streamSubtitle->ExtraSize = 4;
         streamSubtitle->ExtraData[0] = (stream.iSubtitleInfo >> 8) & 0xff;
         streamSubtitle->ExtraData[1] = (stream.iSubtitleInfo >> 0) & 0xff;

--- a/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
@@ -266,7 +266,7 @@ void CDVDStreamInfo::Assign(const CDemuxStream& right, bool withextradata)
     extradata = malloc(extrasize);
     if (!extradata)
       return;
-    memcpy(extradata, right.ExtraData, extrasize);
+    memcpy(extradata, right.ExtraData.get(), extrasize);
   }
 
   cryptoSession = right.cryptoSession;


### PR DESCRIPTION
## Description
This commit fixes an issue detected by the sanitizer which generates a minor memory leak. The logs are available below.

## Motivation and context
The goal is to clean up some issues detected by the sanitizer.

## How has this been tested?
The option "-fsanitize=leak" is required and should be passed to the compiler and the linker. For a fully sanitized executable, you could use the following options: "-fsanitize=bounds -fsanitize=address -fsanitize=undefined -fsanitize=unreachable -fsanitize=bool -fsanitize=enum -fsanitize=leak -fsanitize-recover=address"

An example below, or you could use the cmake option: -DECM_ENABLE_SANITIZERS
cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS_DEBUG="-ggdb -O2 -fno-omit-frame-pointer -fsanitize=leak" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=leak" -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=leak"

The python library interferes with the sanitizer, "export PYTHONMALLOC=malloc" is not sufficient to fix this issue. Removing "runner.py" could be sufficient to fix this problem, otherwise disabling CPythonInvoker() is required.

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
