### PR TITLE
[Windows][Depends] taglib: reduce build time enabling parallel build

### DIFF
--- a/tools/depends/target/taglib/001-cmake-pdb-debug.patch
+++ b/tools/depends/target/taglib/001-cmake-pdb-debug.patch
@@ -12,11 +12,12 @@
  # Read version information from file taglib/toolkit/taglib.h into variables
 --- a/taglib/CMakeLists.txt
 +++ b/taglib/CMakeLists.txt
-@@ -341,6 +341,12 @@
+@@ -341,6 +341,13 @@
    target_link_libraries(tag ${ZLIB_LIBRARIES})
  endif()
  
 +if(MSVC)
++  target_compile_options(tag PRIVATE "/MP")
 +  set_target_properties(tag PROPERTIES COMPILE_PDB_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR} COMPILE_PDB_NAME tag COMPILE_PDB_NAME_DEBUG tagd)
 +  install(FILES ${PROJECT_BINARY_DIR}/RelWithDebInfo/tag.pdb DESTINATION lib CONFIGURATIONS RelWithDebInfo)
 +  install(FILES ${PROJECT_BINARY_DIR}/Debug/tagd.pdb DESTINATION lib CONFIGURATIONS Debug)


### PR DESCRIPTION
## Description
taglib: reduce Windows build time enabling parallel build (MSVC /MP flag)

## Motivation and context
taglib is very slow to build on Windows because source code contains many small files and are not build in parallel because MSVC /MP flag is not enabled.

Tested in two systems taglib build time before/after PR:

**Intel Core i5-6500 (4 cores)**
Before:  3m 49s   
After: 2m 21s

**Intel Core i7-13700k (24 cores)**
Before: 0m 46s   
After: 0m 14s

taglib is compiled every time in Jenkins, so this time reduction will be noticeable every time Kodi is build.

Surely the same could be applied to other Windows dependencies although the time difference will not be so noticeable in other cases. This should also be taken into account when adding new in tree dependencies.

https://learn.microsoft.com/en-us/cpp/build/reference/mp-build-with-multiple-processes?view=msvc-170


## How has this been tested?
Build taglib for Windows x64 and UWP-64 targets using Visual Studio 2022


## What is the effect on users?
Reduces Kodi build time on Windows


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
