### PR TITLE
[osx][Nativewindowing] Avoid duplication of available outputs for the…

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -152,7 +152,7 @@ NSString* screenNameForDisplay(NSUInteger screenIdx)
   else
   {
     // ensure screen name is unique by appending displayid
-    screenName = [screenName stringByAppendingFormat:@" (%@)", [@(displayID) stringValue]];
+    screenName = [screenName stringByAppendingFormat:@" (%@)", [@(displayID - 1) stringValue]];
   }
 
   return screenName;
@@ -1257,10 +1257,12 @@ std::vector<std::string> CWinSystemOSX::GetConnectedOutputs()
   std::vector<std::string> outputs;
   outputs.push_back("Default");
 
+  // screen 0 is always the "Default" setting, avoid duplicating the available
+  // screens here.
   const NSUInteger numDisplays = NSScreen.screens.count;
-  if (numDisplays > 0)
+  if (numDisplays > 1)
   {
-    for (NSUInteger disp = 0; disp <= numDisplays - 1; disp++)
+    for (NSUInteger disp = 1; disp <= numDisplays - 1; disp++)
     {
       NSString* const dispName = screenNameForDisplay(disp);
       outputs.push_back(dispName.UTF8String);


### PR DESCRIPTION
… default screen

## Description
Kodi has the "Default" entry for the default display in the list of connected outputs. However, we append every connected output even if its the default (screen 0). This results into annoying feedback for the user, showing more options than those that should be available.

## How has this been tested?
Runtime tested on osx with more than 1 screen connected (and no screen connected)

## What is the effect on users?
Only the "Default" display should now be available in the settings screen if kodi is started with no additional connected outputs (with no chance to change to a different - same - screen.

**Before:**
<img width="1470" alt="image" src="https://user-images.githubusercontent.com/7375276/209392145-4aa7a811-dcc6-4f68-b1d7-192d5bf6cbed.png">


**PR:**
<img width="1470" alt="image" src="https://user-images.githubusercontent.com/7375276/209391946-7a51b123-e256-4829-8199-ef98b5321afb.png">

