### PR TITLE
[android][drm] Catch unexpected errors from api callback

### DIFF
--- a/xbmc/platform/android/media/drm/MediaDrmCryptoSession.cpp
+++ b/xbmc/platform/android/media/drm/MediaDrmCryptoSession.cpp
@@ -184,17 +184,33 @@ void CMediaDrmCryptoSession::SetPropertyString(const std::string& name, const st
 // Crypto methods
 Buffer CMediaDrmCryptoSession::Decrypt(const Buffer& cipherKeyId, const Buffer& input, const Buffer& iv)
 {
-  if (m_cryptoSession)
-    return CharVecBuffer(m_cryptoSession->decrypt(CharVecBuffer(cipherKeyId), CharVecBuffer(input), CharVecBuffer(iv)));
+  try
+  {
+    if (m_cryptoSession)
+      return CharVecBuffer(m_cryptoSession->decrypt(CharVecBuffer(cipherKeyId),
+                                                    CharVecBuffer(input), CharVecBuffer(iv)));
+  }
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "Failed to decrypt, see logcat for details.");
+  }
 
   return Buffer();
 }
 
 Buffer CMediaDrmCryptoSession::Encrypt(const Buffer& cipherKeyId, const Buffer& input, const Buffer& iv)
 {
-  if (m_cryptoSession)
-    return CharVecBuffer(m_cryptoSession->encrypt(CharVecBuffer(cipherKeyId), CharVecBuffer(input), CharVecBuffer(iv)));
-
+  try
+  {
+    if (m_cryptoSession)
+      return CharVecBuffer(m_cryptoSession->encrypt(CharVecBuffer(cipherKeyId),
+                                                    CharVecBuffer(input), CharVecBuffer(iv)));
+  }
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "Failed to encrypt, see logcat for details.");
+  }
+  
   return Buffer();
 }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This is a test to check if android DRM errors are captured without crashing kodi

since i can't build locally I'll put jenkins to work and i will test

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is an attempt to prevent Kodi crashes when unexpected errors could happens when you use DRM encrypted sessions
see #22312

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Try to avoid kodi crash

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
