### PR TITLE
RetroPlayer: Add "zoom" stretch mode

### DIFF
--- a/xbmc/cores/GameSettings.h
+++ b/xbmc/cores/GameSettings.h
@@ -48,12 +48,19 @@ enum class STRETCHMODE
    *        on 4K TVs)
    */
   Original,
+
+  /*!
+   * \brief Show the game at its normal aspect ratio but zoom to fill the
+   * viewing area
+   */
+  Zoom,
 };
 
 constexpr const char* STRETCHMODE_NORMAL_ID = "normal";
 constexpr const char* STRETCHMODE_STRETCH_4_3_ID = "4:3";
 constexpr const char* STRETCHMODE_FULLSCREEN_ID = "fullscreen";
 constexpr const char* STRETCHMODE_ORIGINAL_ID = "original";
+constexpr const char* STRETCHMODE_ZOOM_ID = "zoom";
 
 enum class RENDERFEATURE
 {

--- a/xbmc/cores/RetroPlayer/RetroPlayerUtils.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayerUtils.cpp
@@ -23,6 +23,8 @@ const char* CRetroPlayerUtils::StretchModeToIdentifier(STRETCHMODE stretchMode)
       return STRETCHMODE_FULLSCREEN_ID;
     case STRETCHMODE::Original:
       return STRETCHMODE_ORIGINAL_ID;
+    case STRETCHMODE::Zoom:
+      return STRETCHMODE_ZOOM_ID;
     default:
       break;
   }
@@ -40,6 +42,8 @@ STRETCHMODE CRetroPlayerUtils::IdentifierToStretchMode(const std::string& stretc
     return STRETCHMODE::Fullscreen;
   else if (stretchMode == STRETCHMODE_ORIGINAL_ID)
     return STRETCHMODE::Original;
+  else if (stretchMode == STRETCHMODE_ZOOM_ID)
+    return STRETCHMODE::Zoom;
 
   return STRETCHMODE::Normal;
 }

--- a/xbmc/cores/RetroPlayer/rendering/RenderUtils.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RenderUtils.cpp
@@ -29,6 +29,7 @@ void CRenderUtils::CalculateStretchMode(STRETCHMODE stretchMode,
   switch (stretchMode)
   {
     case STRETCHMODE::Normal:
+    case STRETCHMODE::Zoom:
     {
       switch (rotationDegCCW)
       {
@@ -172,6 +173,56 @@ void CRenderUtils::ClipRect(const CRect& viewRect, CRect& sourceRect, CRect& des
     sourceRect.y1 += (destRect.y1 - original.y1) * scaleY;
     sourceRect.x2 += (destRect.x2 - original.x2) * scaleX;
     sourceRect.y2 += (destRect.y2 - original.y2) * scaleY;
+  }
+}
+
+void CRenderUtils::CropSource(CRect& sourceRect,
+                              unsigned int rotationDegCCW,
+                              float viewWidth,
+                              float viewHeight,
+                              float sourceWidth,
+                              float sourceHeight,
+                              float destWidth,
+                              float destHeight)
+{
+  float reduceX = 0.0f;
+  float reduceY = 0.0f;
+
+  switch (rotationDegCCW)
+  {
+    case 90:
+    case 270:
+    {
+      if (destWidth < viewWidth)
+        reduceX = (1.0f - destWidth / viewWidth);
+
+      if (destHeight < viewHeight)
+        reduceY = (1.0f - destHeight / viewHeight);
+
+      break;
+    }
+    default:
+    {
+      if (destHeight < viewHeight)
+        reduceX = (1.0f - destHeight / viewHeight);
+
+      if (destWidth < viewWidth)
+        reduceY = (1.0f - destWidth / viewWidth);
+
+      break;
+    }
+  }
+
+  if (reduceX > 0.0f)
+  {
+    sourceRect.x1 += sourceRect.Width() * reduceX / 2.0f;
+    sourceRect.x2 = sourceWidth - sourceRect.x1;
+  }
+
+  if (reduceY > 0.0f)
+  {
+    sourceRect.y1 += sourceRect.Height() * reduceY / 2.0f;
+    sourceRect.y2 = sourceHeight - sourceRect.y1;
   }
 }
 

--- a/xbmc/cores/RetroPlayer/rendering/RenderUtils.h
+++ b/xbmc/cores/RetroPlayer/rendering/RenderUtils.h
@@ -36,6 +36,15 @@ public:
 
   static void ClipRect(const CRect& viewRect, CRect& sourceRect, CRect& destRect);
 
+  static void CropSource(CRect& sourceRect,
+                         unsigned int rotationDegCCW,
+                         float viewWidth,
+                         float viewHeight,
+                         float sourceWidth,
+                         float sourceHeight,
+                         float destWidth,
+                         float destHeight);
+
   static std::array<CPoint, 4> ReorderDrawPoints(const CRect& destRect,
                                                  unsigned int orientationDegCCW);
 };

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
@@ -176,6 +176,15 @@ void CRPBaseRenderer::ManageRenderArea(const IRenderBuffer& renderBuffer)
   if (!(m_context.IsFullScreenVideo() || m_context.IsCalibrating()))
     CRenderUtils::ClipRect(viewRect, m_sourceRect, destRect);
 
+  if (stretchMode == STRETCHMODE::Zoom)
+  {
+    // Crop for zoom mode
+    CRenderUtils::CropSource(m_sourceRect, rotationDegCCW, viewRect.Width(), viewRect.Height(),
+                             static_cast<float>(sourceWidth), static_cast<float>(sourceHeight),
+                             destRect.Width(), destRect.Height());
+    destRect = viewRect;
+  }
+
   // Adapt the drawing rect points if we have to rotate
   m_rotatedDestCoords = CRenderUtils::ReorderDrawPoints(destRect, rotationDegCCW);
 }


### PR DESCRIPTION
## Description

This PR adds a new stretch mode to RetroPlayer named "zoom". It shows the game at its normal aspect ratio but zooms to fill the viewing area.

## Motivation and context

Admittedly, a "zoom" mode is not desired for RetroPlayer, because you don't want to hide any game pixels. However, in my Smart Home PR (https://github.com/xbmc/xbmc/pull/21183), I use RetroPlayer to show camera views, and hiding pixels of cameras is acceptable because you're not usually concerned with pixels on the periphery of the center of the field of view.

I'm PRing the RetroPlayer change to reduce the maintenance burden of rebasing the Smart Home work, which I regularly keep up to date as it runs my apartment.

The PR is also nice and clean, not touching any existing lines of code.

## How has this been tested?

Tested with the following change:

```patch
--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -351,7 +351,7 @@
                                                        <width>444</width>
                                                        <height>250</height>
                                                        <videofilter>$INFO[ListItem.Property(game.videofilter)]</videofilter>
-                                                       <stretchmode>$INFO[ListItem.Property(game.stretchmode)]</stretchmode>
+                                                       <stretchmode>zoom</stretchmode>
                                                        <rotation>$INFO[ListItem.Property(game.videorotation)]</rotation>
                                                </control>
                                                <control type="label">
@@ -374,7 +374,7 @@
                                                        <width>444</width>
                                                        <height>250</height>
                                                        <videofilter>$INFO[ListItem.Property(game.videofilter)]</videofilter>
-                                                       <stretchmode>$INFO[ListItem.Property(game.stretchmode)]</stretchmode>
+                                                       <stretchmode>zoom</stretchmode>
                                                        <rotation>$INFO[ListItem.Property(game.videorotation)]</rotation>
                                                </control>
                                                <control type="label">
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
