### PR TITLE
[Android] MediaDrm: catch restoreKeys exceptions

### DIFF
--- a/xbmc/platform/android/media/drm/MediaDrmCryptoSession.cpp
+++ b/xbmc/platform/android/media/drm/MediaDrmCryptoSession.cpp
@@ -170,8 +170,17 @@ void CMediaDrmCryptoSession::RestoreKeys(const std::string& keySetId)
   if (m_mediaDrm && keySetId != m_keySetId)
   {
     m_mediaDrm->restoreKeys(*m_sessionId, std::vector<char>(keySetId.begin(), keySetId.end()));
-    m_hasKeys = true;
-    m_keySetId = keySetId;
+    if (xbmc_jnienv()->ExceptionCheck())
+    {
+      CLog::Log(LOGERROR, "MediaDrm: restoreKeys exception");
+      xbmc_jnienv()->ExceptionDescribe();
+      xbmc_jnienv()->ExceptionClear();
+    }
+    else
+    {
+      m_hasKeys = true;
+      m_keySetId = keySetId;
+    }
   }
 }
 


### PR DESCRIPTION
## Description
Catch and log possible exceptions when restoring persisted offline keys into a new session.

In particular, catches the exceptions that are thrown when trying to restore multiple offline licenses or restoring a license if a license has already been loaded.

`MediaDrm-JNI: Illegal state exception: Failed to restore keys: ERROR_DRM_LICENSE_STATE`

Fixes the issue described in https://github.com/xbmc/xbmc/issues/22312

## How has this been tested?
Install N€tflix addon and play a video, no crash and first video plays smoothly

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
