### PR TITLE
[Video][Subtitles] Use ffmpeg A53 sidedata instead of custom demuxer

### DIFF
--- a/xbmc/cores/VideoPlayer/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/CMakeLists.txt
@@ -37,6 +37,7 @@ set(HEADERS AudioSinkAE.h
             VideoPlayerTeletext.h
             VideoPlayerVideo.h
             VideoReferenceClock.h
+            Interface/CaptionBlock.h
             Interface/StreamInfo.h
             Interface/DemuxPacket.h
             Interface/DemuxCrypto.h

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/contrib/cc_decoder708.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/contrib/cc_decoder708.cpp
@@ -1186,7 +1186,7 @@ void CDecoderCC708::Init(void (*handler)(int service, void *userdata), void *use
   ccx_decoders_708_init(m_cc708decoders, handler, userdata, this);
 }
 
-void CDecoderCC708::Decode(const unsigned char *data, int datalength)
+void CDecoderCC708::Decode(const std::vector<uint8_t>& data)
 {
-  decode_708(data, datalength, m_cc708decoders);
+  decode_708(data.data(), data.size(), m_cc708decoders);
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/contrib/cc_decoder708.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/contrib/cc_decoder708.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include <sys/stat.h>
 
 extern "C"{
@@ -292,7 +294,7 @@ public:
   CDecoderCC708();
   virtual ~CDecoderCC708();
   void Init(void (*handler)(int service, void *userdata), void *userdata);
-  void Decode(const unsigned char *data, int datalength);
+  void Decode(const std::vector<uint8_t>& data);
   bool m_inited;
   cc708_service_decoder* m_cc708decoders;
   cc_decoder_t *m_cc608decoder;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.cpp
@@ -79,5 +79,46 @@ VideoPicture& VideoPicture::SetParams(const VideoPicture &pic)
   return *this;
 }
 
-VideoPicture::VideoPicture(VideoPicture const&) = default;
-VideoPicture& VideoPicture::operator=(VideoPicture const&) = default;
+VideoPicture& VideoPicture::operator=(VideoPicture const& pic)
+{
+  if (this != &pic)
+  {
+    if (videoBuffer)
+      videoBuffer->Release();
+    videoBuffer = pic.videoBuffer;
+    if (videoBuffer)
+      videoBuffer->Acquire();
+
+    pts = pic.pts;
+    dts = pic.dts;
+    iFlags = pic.iFlags;
+    iRepeatPicture = pic.iRepeatPicture;
+    iDuration = pic.iDuration;
+    iFrameType = pic.iFrameType;
+    color_space = pic.color_space;
+    color_range = pic.color_range;
+    chroma_position = pic.chroma_position;
+    color_primaries = pic.color_primaries;
+    color_transfer = pic.color_transfer;
+    colorBits = pic.colorBits;
+    stereoMode = pic.stereoMode;
+
+    iWidth = pic.iWidth;
+    iHeight = pic.iHeight;
+    iDisplayWidth = pic.iDisplayWidth;
+    iDisplayHeight = pic.iDisplayHeight;
+
+    hasDisplayMetadata = pic.hasDisplayMetadata;
+    hasLightMetadata = pic.hasLightMetadata;
+
+    qp_table = pic.qp_table;
+    qstride = pic.qstride;
+    qscale_type = pic.qscale_type;
+    pict_type = pic.pict_type;
+
+    if (pic.HasA53SideData())
+      SetA53SideData(pic.m_A53SideData.get());
+  }
+
+  return *this;
+}

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -42,6 +42,38 @@ public:
   VideoPicture& SetParams(const VideoPicture &pic);
   void Reset(); // reinitialize members, videoBuffer will be released if set!
 
+  /*!
+   * \brief Checks if the video picture has A53 side data (closed captions).
+   *
+   * \return true if the video picture has A53 side data, false otherwise
+  */
+  bool HasA53SideData() const { return m_A53SideData != nullptr; }
+
+  /*!
+   * \brief Gets the A53 side data of the video picture (closed captions)
+   * \return the A53 side data, reseting the value
+  */
+  AVBufferRef* ConsumeA53SideData()
+  {
+    AVBufferRef* sideData = m_A53SideData;
+    m_A53SideData = nullptr;
+    return sideData;
+  }
+
+  /*!
+   * \brief Set the A53 side data on the video picture
+   *
+   * \param[in] sideData the data to store as A53 side data
+  */
+  void SetA53SideData(AVBufferRef* sideData) { m_A53SideData = av_buffer_ref(sideData); }
+
+  /*!
+   * \brief Releases the sidedata data, decreasing its reference count
+   *
+   * \param[in] sideData pointer to the sidedata pointer
+  */
+  void ReleaseA53SideData(AVBufferRef** sideData) const { av_buffer_unref(sideData); }
+
   CVideoBuffer *videoBuffer = nullptr;
 
   double pts; // timestamp in seconds, used in the CVideoPlayer class to keep track of pts
@@ -78,6 +110,7 @@ public:
 private:
   VideoPicture(VideoPicture const&);
   VideoPicture& operator=(VideoPicture const&);
+  AVBufferRef* m_A53SideData;
 };
 
 #define DVP_FLAG_TOP_FIELD_FIRST    0x00000001

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -1107,6 +1107,13 @@ bool CDVDVideoCodecFFmpeg::GetPictureCommon(VideoPicture* pVideoPicture)
   else
     pVideoPicture->dts = m_dts;
 
+  // ATSC A53 Closed Captions (side data)
+  sd = av_frame_get_side_data(m_pFrame, AV_FRAME_DATA_A53_CC);
+  if (sd)
+  {
+    pVideoPicture->SetA53SideData(sd->buf);
+  }
+
   m_dts = DVD_NOPTS_VALUE;
 
   int64_t bpts = m_pFrame->best_effort_timestamp;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
@@ -10,80 +10,17 @@
 
 #include "DVDDemuxUtils.h"
 #include "cores/VideoPlayer/DVDCodecs/Overlay/contrib/cc_decoder708.h"
+#include "cores/VideoPlayer/Interface/CaptionBlock.h"
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
 
 #include <algorithm>
 
-class CBitstream
+namespace
 {
-public:
-  CBitstream(uint8_t *data, int bits)
-  {
-    m_data = data;
-    m_offset = 0;
-    m_len = bits;
-    m_error = false;
-  }
-  unsigned int readBits(int num)
-  {
-    int r = 0;
-    while (num > 0)
-    {
-      if (m_offset >= m_len)
-      {
-        m_error = true;
-        return 0;
-      }
-      num--;
-      if (m_data[m_offset / 8] & (1 << (7 - (m_offset & 7))))
-        r |= 1 << num;
-      m_offset++;
-    }
-    return r;
-  }
-  unsigned int readGolombUE(int maxbits = 32)
-  {
-    int lzb = -1;
-    int bits = 0;
-    for (int b = 0; !b; lzb++, bits++)
-    {
-      if (bits > maxbits)
-        return 0;
-      b = readBits(1);
-    }
-    return (1 << lzb) - 1 + readBits(lzb);
-  }
-
-private:
-  uint8_t *m_data;
-  int m_offset;
-  int m_len;
-  bool m_error;
-};
-
-class CCaptionBlock
+bool reorder_sort(CCaptionBlock* lhs, CCaptionBlock* rhs)
 {
-  CCaptionBlock(const CCaptionBlock&) = delete;
-  CCaptionBlock& operator=(const CCaptionBlock&) = delete;
-public:
-  explicit CCaptionBlock(int size)
-  {
-    m_data = (uint8_t*)malloc(size);
-    m_size = size;
-    m_pts = 0.0; //silence coverity uninitialized warning, is set elsewhere
-  }
-  virtual ~CCaptionBlock()
-  {
-    free(m_data);
-  }
-  double m_pts;
-  uint8_t *m_data;
-  int m_size;
-};
-
-bool reorder_sort (CCaptionBlock *lhs, CCaptionBlock *rhs)
-{
-  return (lhs->m_pts > rhs->m_pts);
+  return (lhs->GetPTS() > rhs->GetPTS());
+}
 }
 
 CDVDDemuxCC::CDVDDemuxCC(AVCodecID codec) : m_codec(codec)
@@ -126,159 +63,20 @@ int CDVDDemuxCC::GetNrOfStreams() const
   return m_streams.size();
 }
 
-DemuxPacket* CDVDDemuxCC::Read(DemuxPacket *pSrcPacket)
+DemuxPacket* CDVDDemuxCC::Process(CCaptionBlock* captionBlock)
 {
-  DemuxPacket *pPacket = NULL;
-  uint32_t startcode = 0xffffffff;
-  int picType = 0;
-  int p = 0;
-  int len;
-
-  if (!pSrcPacket)
+  if (captionBlock)
   {
-    pPacket = Decode();
-    return pPacket;
-  }
-  if (pSrcPacket->pts == DVD_NOPTS_VALUE)
-  {
-    return pPacket;
+    m_ccReorderBuffer.push_back(captionBlock);
   }
 
-  while (!m_ccTempBuffer.empty())
+  if (!m_ccDecoder)
   {
-    m_ccReorderBuffer.push_back(m_ccTempBuffer.back());
-    m_ccTempBuffer.pop_back();
+    if (!OpenDecoder())
+      return nullptr;
   }
-
-  while ((len = pSrcPacket->iSize - p) > 3)
-  {
-    if ((startcode & 0xffffff00) == 0x00000100)
-    {
-      if (m_codec == AV_CODEC_ID_MPEG2VIDEO)
-      {
-        int scode = startcode & 0xFF;
-        if (scode == 0x00)
-        {
-          if (len > 4)
-          {
-            uint8_t *buf = pSrcPacket->pData + p;
-            picType = (buf[1] & 0x38) >> 3;
-          }
-        }
-        else if (scode == 0xb2) // user data
-        {
-          uint8_t *buf = pSrcPacket->pData + p;
-          if (len >= 6 &&
-            buf[0] == 'G' && buf[1] == 'A' && buf[2] == '9' && buf[3] == '4' &&
-            buf[4] == 3 && (buf[5] & 0x40))
-          {
-            int cc_count = buf[5] & 0x1f;
-            if (cc_count > 0 && len >= 7 + cc_count * 3)
-            {
-              CCaptionBlock *cc = new CCaptionBlock(cc_count * 3);
-              memcpy(cc->m_data, buf + 7, cc_count * 3);
-              cc->m_pts = pSrcPacket->pts;
-              if (picType == 1 || picType == 2)
-                m_ccTempBuffer.push_back(cc);
-              else
-                m_ccReorderBuffer.push_back(cc);
-            }
-          }
-          else if (len >= 6 &&
-                   buf[0] == 'C' && buf[1] == 'C' && buf[2] == 1)
-          {
-            int oddidx = (buf[4] & 0x80) ? 0 : 1;
-            int cc_count = (buf[4] & 0x3e) >> 1;
-            int extrafield = buf[4] & 0x01;
-            if (extrafield)
-              cc_count++;
-
-            if (cc_count > 0 && len >= 5 + cc_count * 3 * 2)
-            {
-              CCaptionBlock *cc = new CCaptionBlock(cc_count * 3);
-              uint8_t *src = buf + 5;
-              uint8_t *dst = cc->m_data;
-
-              for (int i = 0; i < cc_count; i++)
-              {
-                for (int j = 0; j < 2; j++)
-                {
-                  if (i == cc_count - 1 && extrafield && j == 1)
-                    break;
-
-                  if ((oddidx == j) && (src[0] == 0xFF))
-                  {
-                    dst[0] = 0x04;
-                    dst[1] = src[1];
-                    dst[2] = src[2];
-                    dst += 3;
-                  }
-                  src += 3;
-                }
-              }
-              cc->m_pts = pSrcPacket->pts;
-              m_ccReorderBuffer.push_back(cc);
-              picType = 1;
-            }
-          }
-        }
-      }
-      else if (m_codec == AV_CODEC_ID_H264)
-      {
-        int scode = startcode & 0x9F;
-        // slice data comes after SEI
-        if (scode >= 1 && scode <= 5)
-        {
-          uint8_t *buf = pSrcPacket->pData + p;
-          CBitstream bs(buf, len * 8);
-          bs.readGolombUE();
-          int sliceType = bs.readGolombUE();
-          if (sliceType == 2 || sliceType == 7) // I slice
-            picType = 1;
-          else if (sliceType == 0 || sliceType == 5) // P slice
-            picType = 2;
-          if (picType == 0)
-          {
-            while (!m_ccTempBuffer.empty())
-            {
-              m_ccReorderBuffer.push_back(m_ccTempBuffer.back());
-              m_ccTempBuffer.pop_back();
-            }
-          }
-        }
-        if (scode == 0x06) // SEI
-        {
-          uint8_t *buf = pSrcPacket->pData + p;
-          if (len >= 12 &&
-            buf[3] == 0 && buf[4] == 49 &&
-            buf[5] == 'G' && buf[6] == 'A' && buf[7] == '9' && buf[8] == '4' && buf[9] == 3)
-          {
-            uint8_t *userdata = buf + 10;
-            int cc_count = userdata[0] & 0x1f;
-            if (len >= cc_count * 3 + 10)
-            {
-              CCaptionBlock *cc = new CCaptionBlock(cc_count * 3);
-              memcpy(cc->m_data, userdata + 2, cc_count * 3);
-              cc->m_pts = pSrcPacket->pts;
-              m_ccTempBuffer.push_back(cc);
-            }
-          }
-        }
-      }
-    }
-    startcode = startcode << 8 | pSrcPacket->pData[p++];
-  }
-
-  if ((picType == 1 || picType == 2) && !m_ccReorderBuffer.empty())
-  {
-    if (!m_ccDecoder)
-    {
-      if (!OpenDecoder())
-        return NULL;
-    }
-    std::sort(m_ccReorderBuffer.begin(), m_ccReorderBuffer.end(), reorder_sort);
-    pPacket = Decode();
-  }
+  std::sort(m_ccReorderBuffer.begin(), m_ccReorderBuffer.end(), reorder_sort);
+  DemuxPacket* pPacket = Decode();
   return pPacket;
 }
 
@@ -369,8 +167,8 @@ DemuxPacket* CDVDDemuxCC::Decode()
   {
     CCaptionBlock *cc = m_ccReorderBuffer.back();
     m_ccReorderBuffer.pop_back();
-    m_curPts = cc->m_pts;
-    m_ccDecoder->Decode(cc->m_data, cc->m_size);
+    m_curPts = cc->GetPTS();
+    m_ccDecoder->Decode(cc->GetData());
     delete cc;
   }
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
@@ -15,10 +15,8 @@
 
 #include <algorithm>
 
-CDVDDemuxCC::CDVDDemuxCC(AVCodecID codec) : m_codec(codec)
+CDVDDemuxCC::CDVDDemuxCC() : m_hasData{false}, m_curPts{0.0}
 {
-  m_hasData = false;
-  m_curPts = 0.0;
 }
 
 CDVDDemuxCC::~CDVDDemuxCC()

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.h
@@ -19,7 +19,7 @@ class CDecoderCC708;
 class CDVDDemuxCC : public CDVDDemux
 {
 public:
-  explicit CDVDDemuxCC(AVCodecID codec);
+  explicit CDVDDemuxCC();
   ~CDVDDemuxCC() override;
 
   bool Reset() override { return true; }
@@ -54,5 +54,4 @@ protected:
   double m_curPts;
   std::vector<CCaptionBlock*> m_ccTempBuffer;
   std::unique_ptr<CDecoderCC708> m_ccDecoder;
-  AVCodecID m_codec;
 };

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.h
@@ -33,7 +33,7 @@ public:
   std::vector<CDemuxStream*> GetStreams() const override;
   int GetNrOfStreams() const override;
 
-  DemuxPacket* Read(DemuxPacket *packet);
+  DemuxPacket* Process(CCaptionBlock* captionBlock);
   static void Handler(int service, void *userdata);
 
 protected:

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.h
@@ -52,7 +52,6 @@ protected:
   std::vector<CDemuxStreamSubtitle> m_streams;
   bool m_hasData;
   double m_curPts;
-  std::vector<CCaptionBlock*> m_ccReorderBuffer;
   std::vector<CCaptionBlock*> m_ccTempBuffer;
   std::unique_ptr<CDecoderCC708> m_ccDecoder;
   AVCodecID m_codec;

--- a/xbmc/cores/VideoPlayer/DVDMessage.h
+++ b/xbmc/cores/VideoPlayer/DVDMessage.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "FileItem.h"
+#include "Interface/CaptionBlock.h"
 #include "cores/IPlayer.h"
 
 #include <atomic>
@@ -65,7 +66,8 @@ public:
 
     // subtitle related messages
     SUBTITLE_CLUTCHANGE,
-    SUBTITLE_ADDFILE
+    SUBTITLE_ADDFILE,
+    SUBTITLE_A53_DATA // ATSC A53 Closed Captions
   };
   // clang-format on
 
@@ -330,4 +332,35 @@ public:
   ~CDVDMsgSubtitleClutChange() override = default;
 
   uint8_t m_data[16][4];
+};
+
+/*!
+ * \brief Message to convey a closed caption data block.
+ *
+ * Usually closed caption data is stored as side data of the video picture. Hence it needs to be
+ * transported from the player video player back to parent, and from there fed into the subtitle
+ * player
+ */
+class CDVDMsgSubtitleCCData : public CDVDMsg
+{
+public:
+  /*!
+  * \brief Create a closed caption transport message
+  *
+  * \param[in] data - the closed caption data to transport
+  */
+  explicit CDVDMsgSubtitleCCData(std::unique_ptr<CCaptionBlock>& data) : CDVDMsg(SUBTITLE_A53_DATA)
+  {
+    m_ccData = std::move(data);
+  }
+
+  /*!
+  * \brief Default destructor
+  */
+  ~CDVDMsgSubtitleCCData() override = default;
+
+  /*!
+  * \brief The closed caption data to store within the message
+  */
+  std::unique_ptr<CCaptionBlock> m_ccData;
 };

--- a/xbmc/cores/VideoPlayer/Interface/CaptionBlock.h
+++ b/xbmc/cores/VideoPlayer/Interface/CaptionBlock.h
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (C) 2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <vector>
+
+/*!
+ * \brief Abstracts a Closed Caption data block
+ */
+class CCaptionBlock
+{
+public:
+  /*!
+   * \brief Closed Caption block constructor
+   *
+   * \param[in] pts - the presentation timestamp of this closed caption
+   * \param[in] data - the data to store on the block
+   * \param[in] size - the size of the data to store
+  */
+  CCaptionBlock(double pts, uint8_t* data, int size) : m_pts(pts)
+  {
+    m_data.resize(size);
+    std::copy(data, data + size, m_data.data());
+  }
+
+  CCaptionBlock(const CCaptionBlock&) = delete;
+  CCaptionBlock& operator=(const CCaptionBlock&) = delete;
+  ~CCaptionBlock() = default;
+
+  /*!
+   * \brief Get the presentation timestamp (pts) of the closed caption block
+   *
+   * \return the pts of the closed caption block
+  */
+  double GetPTS() const { return m_pts; }
+
+  /*!
+   * \brief Get the data stored in the closed caption block
+   *
+   * \return the data stored in the closed caption block
+  */
+  const std::vector<uint8_t>& GetData() const { return m_data; }
+
+private:
+  /*!
+   * \brief the presentation timestamp of the closed caption block
+  */
+  double m_pts{0.0};
+  /*!
+   * \brief the data of the closed caption block
+  */
+  std::vector<uint8_t> m_data;
+};

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3789,7 +3789,7 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
   // open CC demuxer (video may have ATSC a53 side data)
   if (!m_pCCDemuxer)
   {
-    m_pCCDemuxer = std::make_unique<CDVDDemuxCC>(hint.codec);
+    m_pCCDemuxer = std::make_unique<CDVDDemuxCC>();
     m_SelectionStreams.Clear(STREAM_NONE, STREAM_SOURCE_VIDEOMUX);
   }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3756,7 +3756,7 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
   if(m_CurrentVideo.id < 0 ||
      m_CurrentVideo.hint != hint)
   {
-    if (hint.codec == AV_CODEC_ID_MPEG2VIDEO || hint.codec == AV_CODEC_ID_H264)
+    if (m_pCCDemuxer)
       m_pCCDemuxer.reset();
 
     if (!player->OpenStream(hint))
@@ -3786,8 +3786,8 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
   static_cast<IDVDStreamPlayerVideo*>(player)->SendMessage(
       std::make_shared<CDVDMsg>(CDVDMsg::PLAYER_REQUEST_STATE), 1);
 
-  // open CC demuxer if video is mpeg2
-  if ((hint.codec == AV_CODEC_ID_MPEG2VIDEO || hint.codec == AV_CODEC_ID_H264) && !m_pCCDemuxer)
+  // open CC demuxer (video may have ATSC a53 side data)
+  if (!m_pCCDemuxer)
   {
     m_pCCDemuxer = std::make_unique<CDVDDemuxCC>(hint.codec);
     m_SelectionStreams.Clear(STREAM_NONE, STREAM_SOURCE_VIDEOMUX);

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -739,10 +739,9 @@ bool CVideoPlayerVideo::ProcessDecoderOutput(double &frametime, double &pts)
         CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
             CSettings::SETTING_SUBTITLES_PARSECAPTIONS))
     {
-      AVBufferRef* a53SideData = m_picture.ConsumeA53SideData();
+      std::unique_ptr<AVBufferRef, AVBufferRefDeleter> a53SideData = m_picture.GetA53SideData();
       auto ccData =
           std::make_unique<CCaptionBlock>(m_picture.pts, a53SideData->data, a53SideData->size);
-      m_picture.ReleaseA53SideData(&a53SideData);
       m_messageParent.Put(std::make_shared<CDVDMsgSubtitleCCData>(ccData));
     }
 


### PR DESCRIPTION

## Description
While Kodi's closed caption decoder (although outdated when compared to upstream) is still far superior than that decoder contained within ffmpeg, the same can't be said about our custom demuxer implementation. There are a lot of reports/samples out there that simply cannot be played in Kodi but work just fine in mpv or ffplay. While investigating https://github.com/xbmc/xbmc/pull/22143 I realised the root cause of the problem was the fact our demuxed was extended from an initial support of `AV_CODEC_ID_MPEG2VIDEO` to `AV_CODEC_ID_H264` reusing some assumptions that only make sense in the former codec case (e.g. the start code). This code is complex and not maintained, ffmpeg seem to always fill the A53 side data with the closed caption data block, so we might want to use that instead in our demuxer (taking advantage of the already existing decoding code).

User feedback is appreciated...
@matthuisman would be great to know if this finally fixes the CC captions not available in some of your addons.

@ksooo it'd be nice if you could have a look into the code if you find some time. Looking for a pure code review (stuff to improve), I am not expecting you to be familiar with the inner-workings of the thing.

## Motivation and context
Improve subtitles and simplify our codebase at the same time. Get an alternative to the https://github.com/xbmc/xbmc/pull/22143 revert

## How has this been tested?
Runtime tested with all my CC samples, some that did work and others that didn't work. Those that used to not have captions detected now show the subtitle stream.

## What is the effect on users?
Hopefully better support for CC captions in Omega

## Screenshots (if appropriate):
**Before:**
<img width="774" alt="image" src="https://user-images.githubusercontent.com/7375276/209485351-57a468cd-6a68-447a-88c0-ff90a1d627b4.png">

**PR:**
<img width="778" alt="image" src="https://user-images.githubusercontent.com/7375276/209485287-4eeac0b0-f7dd-4681-bef1-1ce76386ff21.png">

<img width="798" alt="image" src="https://user-images.githubusercontent.com/7375276/209485268-b7973566-df91-4ca5-98e6-8e86576ae9ad.png">

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

