### PR TITLE
[Nexus] RetroPlayer: Fix gamewindow control not clearing render area

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -371,7 +371,7 @@ void CRPRenderManager::RenderControl(bool bClear,
   // Calculate alpha
   UTILS::COLOR::Color alpha = 255;
   if (bUseAlpha)
-    alpha = m_renderContext.MergeAlpha(0xFF000000) >> 24;
+    alpha = m_renderContext.MergeAlpha(UTILS::COLOR::BLACK) >> 24;
 
   RenderInternal(renderer, renderBuffer, false, alpha);
 

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -364,7 +364,7 @@ void CRPRenderManager::RenderControl(bool bClear,
     CRect region = renderRegion;
     region.Intersect(old);
     m_renderContext.SetScissors(region);
-    m_renderContext.Clear(0);
+    m_renderContext.Clear(UTILS::COLOR::BLACK);
     m_renderContext.SetScissors(old);
   }
 

--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
@@ -253,7 +253,7 @@ RESOLUTION CRenderContext::GetVideoResolution()
   return m_graphicsContext.GetVideoResolution();
 }
 
-void CRenderContext::Clear(UTILS::COLOR::Color color /* = 0 */)
+void CRenderContext::Clear(UTILS::COLOR::Color color)
 {
   m_graphicsContext.Clear(color);
 }

--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.h
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.h
@@ -85,7 +85,7 @@ public:
   bool IsFullScreenVideo();
   bool IsCalibrating();
   RESOLUTION GetVideoResolution();
-  void Clear(UTILS::COLOR::Color color = 0);
+  void Clear(UTILS::COLOR::Color color);
   RESOLUTION_INFO GetResInfo();
   void SetRenderingResolution(const RESOLUTION_INFO& res, bool needsScaling);
   UTILS::COLOR::Color MergeAlpha(UTILS::COLOR::Color color);

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
@@ -192,7 +192,8 @@ void CRPBaseRenderer::PreRender(bool clear)
 
   // Clear screen
   if (clear)
-    m_context.Clear(m_context.UseLimitedColor() ? 0x101010 : 0);
+    m_context.Clear(m_context.UseLimitedColor() ? UTILS::COLOR::LIMITED_BLACK
+                                                : UTILS::COLOR::BLACK);
 }
 
 void CRPBaseRenderer::PostRender()

--- a/xbmc/utils/ColorUtils.h
+++ b/xbmc/utils/ColorUtils.h
@@ -21,6 +21,7 @@ namespace COLOR
 typedef uint32_t Color;
 
 constexpr Color BLACK = 0xFF000000;
+constexpr Color LIMITED_BLACK = 0xFF101010;
 constexpr Color BLUE = 0xFF0099FF;
 constexpr Color BRIGHTGREEN = 0xFF00FF00;
 constexpr Color CYAN = 0xFF00FFFF;


### PR DESCRIPTION
## Description

Backport of https://github.com/xbmc/xbmc/pull/22334

## How has this been tested?

Compile-tested on Ubuntu 22.04. No runtime testing, as having forked Nexus a week ago means that the codebase is virtually the same as of now.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
