### PR TITLE
[PVR]  Connection eventlog changes

### DIFF
--- a/xbmc/pvr/PVREventLogJob.cpp
+++ b/xbmc/pvr/PVREventLogJob.cpp
@@ -16,14 +16,22 @@
 namespace PVR
 {
 
-CPVREventLogJob::CPVREventLogJob(bool bNotifyUser, bool bError, const std::string& label, const std::string& msg, const std::string& icon)
+CPVREventLogJob::CPVREventLogJob(bool bNotifyUser,
+                                 EventLevel eLevel,
+                                 const std::string& label,
+                                 const std::string& msg,
+                                 const std::string& icon)
 {
-  AddEvent(bNotifyUser, bError, label, msg, icon);
+  AddEvent(bNotifyUser, eLevel, label, msg, icon);
 }
 
-void CPVREventLogJob::AddEvent(bool bNotifyUser, bool bError, const std::string& label, const std::string& msg, const std::string& icon)
+void CPVREventLogJob::AddEvent(bool bNotifyUser,
+                               EventLevel eLevel,
+                               const std::string& label,
+                               const std::string& msg,
+                               const std::string& icon)
 {
-  m_events.emplace_back(Event(bNotifyUser, bError, label, msg, icon));
+  m_events.emplace_back(Event(bNotifyUser, eLevel, label, msg, icon));
 }
 
 bool CPVREventLogJob::DoWork()
@@ -31,15 +39,16 @@ bool CPVREventLogJob::DoWork()
   for (const auto& event : m_events)
   {
     if (event.m_bNotifyUser)
-      CGUIDialogKaiToast::QueueNotification(
-        event.m_bError ? CGUIDialogKaiToast::Error : CGUIDialogKaiToast::Info, event.m_label.c_str(), event.m_msg, 5000, true);
+      CGUIDialogKaiToast::QueueNotification(event.m_eLevel == EventLevel::Error
+                                                ? CGUIDialogKaiToast::Error
+                                                : CGUIDialogKaiToast::Info,
+                                            event.m_label, event.m_msg, 5000, true);
 
     // Write event log entry.
     auto eventLog = CServiceBroker::GetEventLog();
     if (eventLog)
       eventLog->Add(std::make_shared<CNotificationEvent>(event.m_label, event.m_msg, event.m_icon,
-                                                         event.m_bError ? EventLevel::Error
-                                                                        : EventLevel::Information));
+                                                         event.m_eLevel));
   }
   return true;
 }

--- a/xbmc/pvr/PVREventLogJob.h
+++ b/xbmc/pvr/PVREventLogJob.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "events/EventLog.h"
 #include "utils/Job.h"
 
 #include <string>
@@ -19,11 +20,21 @@ class CPVREventLogJob : public CJob
 {
 public:
   CPVREventLogJob() = default;
-  CPVREventLogJob(bool bNotifyUser, bool bError, const std::string& label, const std::string& msg, const std::string& icon);
+
+  CPVREventLogJob(bool bNotifyUser,
+                  EventLevel eLevel,
+                  const std::string& label,
+                  const std::string& msg,
+                  const std::string& icon);
+
   ~CPVREventLogJob() override = default;
   const char* GetType() const override { return "pvr-eventlog-job"; }
 
-  void AddEvent(bool bNotifyUser, bool bError, const std::string& label, const std::string& msg, const std::string& icon);
+  void AddEvent(bool bNotifyUser,
+                EventLevel eLevel,
+                const std::string& label,
+                const std::string& msg,
+                const std::string& icon);
 
   bool DoWork() override;
 
@@ -31,13 +42,19 @@ private:
   struct Event
   {
     bool m_bNotifyUser;
-    bool m_bError;
+    EventLevel m_eLevel{EventLevel::Information};
     std::string m_label;
     std::string m_msg;
     std::string m_icon;
 
-    Event(bool bNotifyUser, bool bError, const std::string& label, const std::string& msg, const std::string& icon)
-    : m_bNotifyUser(bNotifyUser), m_bError(bError), m_label(label), m_msg(msg), m_icon(icon) {}
+    Event(bool bNotifyUser,
+          EventLevel elevel,
+          const std::string& label,
+          const std::string& msg,
+          const std::string& icon)
+      : m_bNotifyUser(bNotifyUser), m_eLevel(elevel), m_label(label), m_msg(msg), m_icon(icon)
+    {
+    }
   };
 
   std::vector<Event> m_events;

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -163,9 +163,10 @@ public:
   const std::string& GetConnectionString() const;
 
   /*!
-   * @return A friendly name for this add-on that can be used in log messages.
+   * @brief A friendly name used to uniquely identify the addon instance
+   * @return string that can be used in log messages and the GUI.
    */
-  const std::string& GetFriendlyName() const;
+  const std::string GetFriendlyName() const;
 
   /*!
    * @brief Get the disk space reported by the server.
@@ -801,6 +802,12 @@ private:
   bool GetAddonProperties();
 
   /*!
+   * @brief reads the client's name string properties
+   * @return True on success, false otherwise.
+   */
+  bool GetAddonNameStringProperties();
+
+  /*!
    * @brief Write the given addon properties to the given properties container.
    * @param properties Pointer to an array of addon properties.
    * @param iPropertyCount The number of properties contained in the addon properties array.
@@ -1042,7 +1049,6 @@ private:
   std::string m_strBackendName; /*!< the cached backend version */
   std::string m_strBackendVersion; /*!< the cached backend version */
   std::string m_strConnectionString; /*!< the cached connection string */
-  std::string m_strFriendlyName; /*!< the cached friendly name */
   std::string m_strBackendHostname; /*!< the cached backend hostname */
   CPVRClientCapabilities m_clientCapabilities; /*!< the cached add-on's capabilities */
   std::shared_ptr<CPVRClientMenuHooks> m_menuhooks; /*!< the menu hooks for this add-on */

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -397,9 +397,9 @@ struct SBackend
     /*!
      * @brief Notify a change of an addon connection state.
      * @param client The changed client.
-     * @param strConnectionString A human-readable string identifiying the addon.
+     * @param strConnectionString A human-readable string providing additional information.
      * @param newState The new connection state.
-     * @param strMessage A human readable message providing additional information.
+     * @param strMessage A human readable string replacing default state message.
      */
     void ConnectionStateChange(CPVRClient* client,
                                const std::string& strConnectionString,

--- a/xbmc/pvr/guilib/PVRGUIActionsClients.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsClients.cpp
@@ -73,7 +73,7 @@ bool CPVRGUIActionsClients::ProcessSettingsMenuHooks()
       if (clients.size() == 1)
         pDialog->Add(hook.second.GetLabel());
       else
-        pDialog->Add(hook.first->GetBackendName() + ": " + hook.second.GetLabel());
+        pDialog->Add(hook.first->GetFriendlyName() + ": " + hook.second.GetLabel());
     }
 
     pDialog->Open();

--- a/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
@@ -829,7 +829,7 @@ void AddEventLogEntry(const std::shared_ptr<CPVRTimerInfoTag>& timer, int idEpg,
       CServiceBroker::GetPVRManager().GetClient(timer->GetTimerType()->GetClientId());
   if (client)
   {
-    name = client->Name();
+    name = client->GetFriendlyName();
     icon = client->Icon();
   }
   else
@@ -840,7 +840,7 @@ void AddEventLogEntry(const std::shared_ptr<CPVRTimerInfoTag>& timer, int idEpg,
 
   CPVREventLogJob* job = new CPVREventLogJob;
   job->AddEvent(false, // do not display a toast, only log event
-                false, // info, no error
+                EventLevel::Information, // info, no error
                 name, GetAnnouncerText(timer, idEpg, idNoEpg), icon);
   CServiceBroker::GetJobManager()->AddJob(job, nullptr);
 }

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -387,8 +387,8 @@ bool CPVRTimers::UpdateEntries(const CPVRTimersContainer& timers,
         if (client)
         {
           job->AddEvent(m_settings.GetBoolValue(CSettings::SETTING_PVRRECORD_TIMERNOTIFICATIONS),
-                        false, // info, no error
-                        client->Name(), entry.second, client->Icon());
+                        EventLevel::Information, // info, no error
+                        client->GetFriendlyName(), entry.second, client->Icon());
         }
       }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->

In investigation why PR #22212 did not always show the friendly name a few functional changes are required

- if the pvr client has not provided name string don't show Unknown show the generic addon name
- use the pvr client provided event log name if supplied
- log pvr connection messages
- create name strings from pvr even when the state is not connected.

<!--- Describe your change in detail here. -->

Currently the CPVRManager::ConnectionStateChange(CPVRClient* client, const std::string& connectString, PVR_CONNECTION_STATE state, const std::string&)

1. PVR does not use the second paramater for the user supplied event title.

Change will use this value if suppled.

2. PVR Does not output connection string unless all notifications are logged.

Change PVR connection messages to Basic level.
Given the nature of this change I will submit a few PR's to address what looks like incorret of clear use of ConnectionStateChange() in
pvr.vdr.vnsi and pvr.nextpvr  pvr.filmon could be changed since the URL for the title might seem odd.

3. PVR Fails to use a useful title if ConnectionStateChange() is called before the addon is created.

a. Fallback to the generic name used before PR #22212 if the friendly name is still the default.
b. A second commit is provided to attempt to get name information from the addon in all states.  It is not clear why PVRClient::SetConnectionState() did not always call GetAddonProperties() so the function was split into name string and other functions.  GetAddonProperties() could be restructured and always called too.  GetAddonProperties() is actually an odd function as a failure in it will cause the addon to not load but only when SetConnectionState is called and passed PVR_CONNECTION_STATE_CONNECTED.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->

Logging information event messages requires all notifications to be logged.  The friendlyName is not always friendly or clear.  When connections are dropped there is an error logged but by default there is no corresponding log after reconnecting.

<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with pvr.nextpvr with several state changes.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Better information on the event log.  Better state information on connections, especially after disconnects.


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed## Description
