### PR TITLE
[AudioTrack RAW] Fix TrueHD and DD+ broken after pause or seek also fixes audio keep alive in all platforms

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2662,7 +2662,15 @@ void CActiveAE::LoadSettings()
   m_settings.resampleQuality = static_cast<AEQuality>(settings->GetInt(CSettings::SETTING_AUDIOOUTPUT_PROCESSQUALITY));
   m_settings.atempoThreshold = settings->GetInt(CSettings::SETTING_AUDIOOUTPUT_ATEMPOTHRESHOLD) / 100.0;
   m_settings.streamNoise = settings->GetBool(CSettings::SETTING_AUDIOOUTPUT_STREAMNOISE);
-  m_settings.silenceTimeout = settings->GetInt(CSettings::SETTING_AUDIOOUTPUT_STREAMSILENCE) * 60000;
+
+  // Audio keep alive timeout in minutes [0 - 10]
+  // but with setting "Always" minutes = 2147483647 (INT_MAX)
+  const int minutes = settings->GetInt(CSettings::SETTING_AUDIOOUTPUT_STREAMSILENCE);
+
+  if (minutes <= 10)
+    m_settings.silenceTimeout = minutes * 60000; // convert to ms
+  else
+    m_settings.silenceTimeout = minutes; // "Always" is 2147483647 ms (~596 hours)
 }
 
 void CActiveAE::Start()

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -1154,12 +1154,24 @@ void CActiveAESink::GenerateNoise()
 
 void CActiveAESink::SetSilenceTimer()
 {
-  if (m_extStreaming)
+  if (m_extStreaming) // handles playback
+  {
     m_extSilenceTimeout = std::chrono::milliseconds::max();
-  else if (m_extAppFocused)
-    m_extSilenceTimeout = m_silenceTimeOut;
+  }
+  else if (m_extAppFocused) // handles no playback/GUI and playback in pause and seek
+  {
+    // only true with AudioTrack RAW + passthrough + TrueHD or EAC3 (DD+)
+    const bool noSilenceOnPause =
+        !m_needIecPack && m_requestedFormat.m_dataFormat == AE_FMT_RAW &&
+        (m_sinkFormat.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD ||
+         m_sinkFormat.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_EAC3);
+
+    m_extSilenceTimeout = (noSilenceOnPause) ? 0ms : m_silenceTimeOut;
+  }
   else
+  {
     m_extSilenceTimeout = 0ms;
+  }
 
   m_extSilenceTimer.Set(m_extSilenceTimeout);
 }


### PR DESCRIPTION
## Description
Fixes:
- TrueHD and DD+ broken after pause or seek in AudioTrack RAW (Android only).
- Audio keep alive broken when setting is "Always" (all platforms).

Closes https://github.com/xbmc/xbmc/issues/22230
Closes https://github.com/xbmc/xbmc/issues/21317

For clarification does NOT fixes:
- Audio keep alive settings changes not apply without restart Kodi.
- TrueHD random dropouts using AudioTrack IEC (in case of users suffering from this issue).

## Motivation and context
Keep alive is broken mainly because overflow in INT_MAX value multiplied for 60000 to convert to ms here:

https://github.com/xbmc/xbmc/blob/077c7888fc58c05f27f061e306068cacb95843d2/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp#L2665

This is 128,849,018,820,000 which is not possible in a signed int :)

But also other bad things:

`std::chrono::milliseconds` type variables are not default zero initialized:

![not-initialized](https://user-images.githubusercontent.com/58434170/209941779-e202d4d1-781d-4549-9395-ab40b584e8d3.png)

Also in Android AudioTrack RAW only keep alive feature breaks TrueHD RAW stream because is not possible insert silence frames in middle of stream (possible is but not easy).

TrueHD is a complex format and some audio frames depends of previous audio frames, inserting zero data frames in essence corrupts the stream. At least must be necessary generate correct silence frames with correct config flags, length and CRCs followed by major_sync_frame of stream (not any random point of stream). This requires at least partial parse of raw stream same as IEC:

https://github.com/xbmc/xbmc/blob/077c7888fc58c05f27f061e306068cacb95843d2/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp#L190-L201

And sync cut points with next major_sync_frame

In the other hand with more simple audio formats as DTS this works because all audio frames are playable by itself (not requires previous special frames).

As simple workaround this PR disables inserting silence only in AudioTrack RAW + TrueHD or DD+. 
This introduces a small gap of time (less 1s) without audio after the pause or seek but is much better than the audio never coming back (or it returns intermittently because the stream is corrupted).

For the AVR it is as if the stream has ended (while it's paused or seeking) and when unpaused it starts synchronizing with the next major_sync_frame.


## How has this been tested?
Runtime tested Shield Pro 2019 + Denon X1600H


## What is the effect on users?
- Fixes TrueHD and DD+ broken after pause or seek in AudioTrack RAW (Android only).
- Fixes audio keep alive broken when setting is "Always" (all platforms).



## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
