### PR TITLE
ActiveAE: use smart pointers for buffer pools

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -17,6 +17,7 @@
 #include "threads/Thread.h"
 
 #include <list>
+#include <memory>
 #include <queue>
 #include <string>
 #include <utility>
@@ -368,15 +369,16 @@ protected:
   std::unique_ptr<CActiveAESettings> m_settingsHandler;
 
   // buffers
-  CActiveAEBufferPoolResample *m_sinkBuffers;
-  CActiveAEBufferPoolResample *m_vizBuffers;
-  CActiveAEBufferPool *m_vizBuffersInput;
-  CActiveAEBufferPool *m_silenceBuffers;  // needed to drive gui sounds if we have no streams
-  CActiveAEBufferPool *m_encoderBuffers;
+  std::unique_ptr<CActiveAEBufferPoolResample> m_sinkBuffers;
+  std::unique_ptr<CActiveAEBufferPoolResample> m_vizBuffers;
+  std::unique_ptr<CActiveAEBufferPool> m_vizBuffersInput;
+  std::unique_ptr<CActiveAEBufferPool>
+      m_silenceBuffers; // needed to drive gui sounds if we have no streams
+  std::unique_ptr<CActiveAEBufferPool> m_encoderBuffers;
 
   // streams
   std::list<CActiveAEStream*> m_streams;
-  std::list<CActiveAEBufferPool*> m_discardBufferPools;
+  std::list<std::unique_ptr<CActiveAEBufferPool>> m_discardBufferPools;
   unsigned int m_streamIdGen;
 
   // gui sounds

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -595,14 +595,13 @@ CActiveAEStreamBuffers::CActiveAEStreamBuffers(const AEAudioFormat& inputFormat,
                                                AEQuality quality)
   : m_inputFormat(inputFormat)
 {
-  m_resampleBuffers = new CActiveAEBufferPoolResample(inputFormat, outputFormat, quality);
-  m_atempoBuffers = new CActiveAEBufferPoolAtempo(outputFormat);
+  m_resampleBuffers =
+      std::make_unique<CActiveAEBufferPoolResample>(inputFormat, outputFormat, quality);
+  m_atempoBuffers = std::make_unique<CActiveAEBufferPoolAtempo>(outputFormat);
 }
 
 CActiveAEStreamBuffers::~CActiveAEStreamBuffers()
 {
-  delete m_resampleBuffers;
-  delete m_atempoBuffers;
 }
 
 bool CActiveAEStreamBuffers::HasInputLevel(int level)
@@ -764,18 +763,14 @@ void CActiveAEStreamBuffers::ForceResampler(bool force)
   m_resampleBuffers->ForceResampler(force);
 }
 
-CActiveAEBufferPool* CActiveAEStreamBuffers::GetResampleBuffers()
+std::unique_ptr<CActiveAEBufferPool> CActiveAEStreamBuffers::GetResampleBuffers()
 {
-  CActiveAEBufferPool *ret = m_resampleBuffers;
-  m_resampleBuffers = nullptr;
-  return ret;
+  return std::move(m_resampleBuffers);
 }
 
-CActiveAEBufferPool* CActiveAEStreamBuffers::GetAtempoBuffers()
+std::unique_ptr<CActiveAEBufferPool> CActiveAEStreamBuffers::GetAtempoBuffers()
 {
-  CActiveAEBufferPool *ret = m_atempoBuffers;
-  m_atempoBuffers = nullptr;
-  return ret;
+  return std::move(m_atempoBuffers);
 }
 
 bool CActiveAEStreamBuffers::HasWork()

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
@@ -111,16 +111,16 @@ public:
   bool DoesNormalize();
   void ForceResampler(bool force);
   bool HasWork();
-  CActiveAEBufferPool *GetResampleBuffers();
-  CActiveAEBufferPool *GetAtempoBuffers();
+  std::unique_ptr<CActiveAEBufferPool> GetResampleBuffers();
+  std::unique_ptr<CActiveAEBufferPool> GetAtempoBuffers();
 
   AEAudioFormat m_inputFormat;
   std::deque<CSampleBuffer*> m_outputSamples;
   std::deque<CSampleBuffer*> m_inputSamples;
 
 protected:
-  CActiveAEBufferPoolResample *m_resampleBuffers;
-  CActiveAEBufferPoolAtempo *m_atempoBuffers;
+  std::unique_ptr<CActiveAEBufferPoolResample> m_resampleBuffers;
+  std::unique_ptr<CActiveAEBufferPoolAtempo> m_atempoBuffers;
 
 private:
   CActiveAEStreamBuffers(const CActiveAEStreamBuffers&) = delete;
@@ -213,7 +213,7 @@ protected:
   std::chrono::milliseconds m_errorInterval{1000};
 
   // only accessed by engine
-  CActiveAEBufferPool *m_inputBuffers;
+  std::unique_ptr<CActiveAEBufferPool> m_inputBuffers;
   CActiveAEStreamBuffers *m_processingBuffers;
   std::deque<CSampleBuffer*> m_processingSamples;
   CActiveAEDataProtocol *m_streamPort;


### PR DESCRIPTION
This is an alternative to #22201

Thanks to @repojohnray for doing the investigative work.

Pretty straight forward. Simply uses smart pointers to avoid memory leaks upon destruction. Not overly important right now but may be in the future if ActiveAE can ever be stopped and started on demand.