### PR TITLE
WinSystem.cpp: remove unneeded include

### DIFF
--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -19,9 +19,6 @@
 #include "windowing/GraphicContext.h"
 
 #include <mutex>
-#if HAS_GLES
-#include "guilib/GUIFontTTFGL.h"
-#endif
 
 const char* CWinSystemBase::SETTING_WINSYSTEM_IS_HDR_DISPLAY = "winsystem.ishdrdisplay";
 


### PR DESCRIPTION
I noticed this when I was working on some other stuff. This has long been not needed.

I believe it was originally for creating/destroying static vertex buffers but that is handled in the `CGUIFontTTFGL` class now.