### PR TITLE
VaapiEGL.h: replace gl includes with system_gl.h

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -38,7 +38,9 @@ ExperimentalAutoDetectBinPacking: false
 ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
 IncludeBlocks: Regroup
 IncludeCategories:
-  - Regex:           '(["/]PlatformDefs|"(system|system_gl))\.h"'
+  - Regex:           '<EGL/.*\.h>'
+    Priority:        6
+  - Regex:           '(["/]PlatformDefs|"(system|system_gl|system_egl))\.h"'
     Priority:        5
   - Regex:           '"platform/[^/]+/'
     Priority:        2

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.h
@@ -8,27 +8,18 @@
 
 #pragma once
 
-#include <array>
-
-#if defined(HAS_GL)
-// always define GL_GLEXT_PROTOTYPES before include gl headers
-#if !defined(GL_GLEXT_PROTOTYPES)
-#define GL_GLEXT_PROTOTYPES
-#endif
-#include <GL/gl.h>
-#elif defined(HAS_GLES)
-#include <GLES2/gl2.h>
-#include <GLES2/gl2ext.h>
-#include <GLES3/gl3.h>
-#endif
-
-#include "system_egl.h"
 #include "utils/Geometry.h"
 
 #include "platform/posix/utils/FileHandle.h"
 
-#include <EGL/eglext.h>
+#include <array>
+
 #include <va/va.h>
+
+#include "system_egl.h"
+#include "system_gl.h"
+
+#include <EGL/eglext.h>
 
 namespace VAAPI
 {


### PR DESCRIPTION
This cleans up the VaapiEGL.h header to use the `system_gl.h` header.

I also had to add a commit for clang-format to order any other EGL headers to be after `system_egl.h` (for example: `EGL/eglext.h`)