### PR TITLE
CRPProccessInfo: make CreateInstance return a unique_ptr

### DIFF
--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -86,7 +86,7 @@ bool CRetroPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options
   // Check if we should open in standalone mode
   const bool bStandalone = fileCopy.GetPath().empty();
 
-  m_processInfo.reset(CRPProcessInfo::CreateInstance());
+  m_processInfo = CRPProcessInfo::CreateInstance();
   if (!m_processInfo)
   {
     CLog::Log(LOGERROR, "RetroPlayer[PLAYER]: Failed to create - no process info registered");

--- a/xbmc/cores/RetroPlayer/process/RPProcessInfo.cpp
+++ b/xbmc/cores/RetroPlayer/process/RPProcessInfo.cpp
@@ -64,9 +64,9 @@ CRPProcessInfo::CRPProcessInfo(std::string platformName)
 
 CRPProcessInfo::~CRPProcessInfo() = default;
 
-CRPProcessInfo* CRPProcessInfo::CreateInstance()
+std::unique_ptr<CRPProcessInfo> CRPProcessInfo::CreateInstance()
 {
-  CRPProcessInfo* processInfo = nullptr;
+  std::unique_ptr<CRPProcessInfo> processInfo;
 
   std::unique_lock<CCriticalSection> lock(m_createSection);
 
@@ -74,7 +74,7 @@ CRPProcessInfo* CRPProcessInfo::CreateInstance()
   {
     processInfo = m_processControl();
 
-    if (processInfo != nullptr)
+    if (processInfo)
       CLog::Log(LOGINFO, "RetroPlayer[PROCESS]: Created process info for {}",
                 processInfo->GetPlatformName());
     else

--- a/xbmc/cores/RetroPlayer/process/RPProcessInfo.h
+++ b/xbmc/cores/RetroPlayer/process/RPProcessInfo.h
@@ -35,7 +35,7 @@ class IRenderBufferPool;
 /*!
  * \brief Process info factory
  */
-using CreateRPProcessControl = std::function<CRPProcessInfo*()>;
+using CreateRPProcessControl = std::function<std::unique_ptr<CRPProcessInfo>()>;
 
 /*!
  * \brief Rendering factory
@@ -77,7 +77,7 @@ public:
 class CRPProcessInfo
 {
 public:
-  static CRPProcessInfo* CreateInstance();
+  static std::unique_ptr<CRPProcessInfo> CreateInstance();
   static void RegisterProcessControl(CreateRPProcessControl createFunc);
   static void RegisterRendererFactory(IRendererFactory* factory);
 

--- a/xbmc/cores/RetroPlayer/process/RPProcessInfo.h
+++ b/xbmc/cores/RetroPlayer/process/RPProcessInfo.h
@@ -12,6 +12,7 @@
 #include "cores/RetroPlayer/RetroPlayerTypes.h"
 #include "threads/CriticalSection.h"
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -34,7 +35,7 @@ class IRenderBufferPool;
 /*!
  * \brief Process info factory
  */
-using CreateRPProcessControl = CRPProcessInfo* (*)();
+using CreateRPProcessControl = std::function<CRPProcessInfo*()>;
 
 /*!
  * \brief Rendering factory

--- a/xbmc/cores/RetroPlayer/process/X11/RPProcessInfoX11.cpp
+++ b/xbmc/cores/RetroPlayer/process/X11/RPProcessInfoX11.cpp
@@ -15,9 +15,9 @@ CRPProcessInfoX11::CRPProcessInfoX11() : CRPProcessInfo("X11")
 {
 }
 
-CRPProcessInfo* CRPProcessInfoX11::Create()
+std::unique_ptr<CRPProcessInfo> CRPProcessInfoX11::Create()
 {
-  return new CRPProcessInfoX11();
+  return std::make_unique<CRPProcessInfoX11>();
 }
 
 void CRPProcessInfoX11::Register()

--- a/xbmc/cores/RetroPlayer/process/X11/RPProcessInfoX11.h
+++ b/xbmc/cores/RetroPlayer/process/X11/RPProcessInfoX11.h
@@ -19,7 +19,7 @@ class CRPProcessInfoX11 : public CRPProcessInfo
 public:
   CRPProcessInfoX11();
 
-  static CRPProcessInfo* Create();
+  static std::unique_ptr<CRPProcessInfo> Create();
   static void Register();
 };
 } // namespace RETRO

--- a/xbmc/cores/RetroPlayer/process/android/RPProcessInfoAndroid.cpp
+++ b/xbmc/cores/RetroPlayer/process/android/RPProcessInfoAndroid.cpp
@@ -15,9 +15,9 @@ CRPProcessInfoAndroid::CRPProcessInfoAndroid() : CRPProcessInfo("Android")
 {
 }
 
-CRPProcessInfo* CRPProcessInfoAndroid::Create()
+std::unique_ptr<CRPProcessInfo> CRPProcessInfoAndroid::Create()
 {
-  return new CRPProcessInfoAndroid();
+  return std::make_unique<CRPProcessInfoAndroid>();
 }
 
 void CRPProcessInfoAndroid::Register()

--- a/xbmc/cores/RetroPlayer/process/android/RPProcessInfoAndroid.h
+++ b/xbmc/cores/RetroPlayer/process/android/RPProcessInfoAndroid.h
@@ -19,7 +19,7 @@ class CRPProcessInfoAndroid : public CRPProcessInfo
 public:
   CRPProcessInfoAndroid();
 
-  static CRPProcessInfo* Create();
+  static std::unique_ptr<CRPProcessInfo> Create();
   static void Register();
 };
 } // namespace RETRO

--- a/xbmc/cores/RetroPlayer/process/gbm/RPProcessInfoGbm.cpp
+++ b/xbmc/cores/RetroPlayer/process/gbm/RPProcessInfoGbm.cpp
@@ -15,9 +15,9 @@ CRPProcessInfoGbm::CRPProcessInfoGbm() : CRPProcessInfo("GBM")
 {
 }
 
-CRPProcessInfo* CRPProcessInfoGbm::Create()
+std::unique_ptr<CRPProcessInfo> CRPProcessInfoGbm::Create()
 {
-  return new CRPProcessInfoGbm();
+  return std::make_unique<CRPProcessInfoGbm>();
 }
 
 void CRPProcessInfoGbm::Register()

--- a/xbmc/cores/RetroPlayer/process/gbm/RPProcessInfoGbm.h
+++ b/xbmc/cores/RetroPlayer/process/gbm/RPProcessInfoGbm.h
@@ -19,7 +19,7 @@ class CRPProcessInfoGbm : public CRPProcessInfo
 public:
   CRPProcessInfoGbm();
 
-  static CRPProcessInfo* Create();
+  static std::unique_ptr<CRPProcessInfo> Create();
   static void Register();
 };
 } // namespace RETRO

--- a/xbmc/cores/RetroPlayer/process/ios/RPProcessInfoIOS.cpp
+++ b/xbmc/cores/RetroPlayer/process/ios/RPProcessInfoIOS.cpp
@@ -15,9 +15,9 @@ CRPProcessInfoIOS::CRPProcessInfoIOS() : CRPProcessInfo("iOS")
 {
 }
 
-CRPProcessInfo* CRPProcessInfoIOS::Create()
+std::unique_ptr<CRPProcessInfo> CRPProcessInfoIOS::Create()
 {
-  return new CRPProcessInfoIOS();
+  return std::make_unique<CRPProcessInfoIOS>();
 }
 
 void CRPProcessInfoIOS::Register()

--- a/xbmc/cores/RetroPlayer/process/ios/RPProcessInfoIOS.h
+++ b/xbmc/cores/RetroPlayer/process/ios/RPProcessInfoIOS.h
@@ -21,7 +21,7 @@ class CRPProcessInfoIOS : public CRPProcessInfo
 public:
   CRPProcessInfoIOS();
 
-  static CRPProcessInfo* Create();
+  static std::unique_ptr<CRPProcessInfo> Create();
   static void Register();
 };
 } // namespace RETRO

--- a/xbmc/cores/RetroPlayer/process/osx/RPProcessInfoOSX.cpp
+++ b/xbmc/cores/RetroPlayer/process/osx/RPProcessInfoOSX.cpp
@@ -15,9 +15,9 @@ CRPProcessInfoOSX::CRPProcessInfoOSX() : CRPProcessInfo("macOS")
 {
 }
 
-CRPProcessInfo* CRPProcessInfoOSX::Create()
+std::unique_ptr<CRPProcessInfo> CRPProcessInfoOSX::Create()
 {
-  return new CRPProcessInfoOSX();
+  return std::make_unique<CRPProcessInfoOSX>();
 }
 
 void CRPProcessInfoOSX::Register()

--- a/xbmc/cores/RetroPlayer/process/osx/RPProcessInfoOSX.h
+++ b/xbmc/cores/RetroPlayer/process/osx/RPProcessInfoOSX.h
@@ -19,7 +19,7 @@ class CRPProcessInfoOSX : public CRPProcessInfo
 public:
   CRPProcessInfoOSX();
 
-  static CRPProcessInfo* Create();
+  static std::unique_ptr<CRPProcessInfo> Create();
   static void Register();
 };
 } // namespace RETRO

--- a/xbmc/cores/RetroPlayer/process/wayland/RPProcessInfoWayland.cpp
+++ b/xbmc/cores/RetroPlayer/process/wayland/RPProcessInfoWayland.cpp
@@ -15,9 +15,9 @@ CRPProcessInfoWayland::CRPProcessInfoWayland() : CRPProcessInfo("Wayland")
 {
 }
 
-CRPProcessInfo* CRPProcessInfoWayland::Create()
+std::unique_ptr<CRPProcessInfo> CRPProcessInfoWayland::Create()
 {
-  return new CRPProcessInfoWayland();
+  return std::make_unique<CRPProcessInfoWayland>();
 }
 
 void CRPProcessInfoWayland::Register()

--- a/xbmc/cores/RetroPlayer/process/wayland/RPProcessInfoWayland.h
+++ b/xbmc/cores/RetroPlayer/process/wayland/RPProcessInfoWayland.h
@@ -19,7 +19,7 @@ class CRPProcessInfoWayland : public CRPProcessInfo
 public:
   CRPProcessInfoWayland();
 
-  static CRPProcessInfo* Create();
+  static std::unique_ptr<CRPProcessInfo> Create();
   static void Register();
 };
 } // namespace RETRO

--- a/xbmc/cores/RetroPlayer/process/windows/RPProcessInfoWin.cpp
+++ b/xbmc/cores/RetroPlayer/process/windows/RPProcessInfoWin.cpp
@@ -17,9 +17,9 @@ CRPProcessInfoWin::CRPProcessInfoWin() : CRPProcessInfo("Windows")
 {
 }
 
-CRPProcessInfo* CRPProcessInfoWin::Create()
+std::unique_ptr<CRPProcessInfo> CRPProcessInfoWin::Create()
 {
-  return new CRPProcessInfoWin();
+  return std::make_unique<CRPProcessInfoWin>();
 }
 
 void CRPProcessInfoWin::Register()

--- a/xbmc/cores/RetroPlayer/process/windows/RPProcessInfoWin.h
+++ b/xbmc/cores/RetroPlayer/process/windows/RPProcessInfoWin.h
@@ -19,7 +19,7 @@ class CRPProcessInfoWin : public CRPProcessInfo
 public:
   CRPProcessInfoWin();
 
-  static CRPProcessInfo* Create();
+  static std::unique_ptr<CRPProcessInfo> Create();
   static void Register();
 };
 } // namespace RETRO


### PR DESCRIPTION
I made this change when I was investigating #22185 

since `m_processInfo` is already of type `std::unique_ptr<CRPProcessInfo>` we might as well make `RPProcessInfo::CreateInstance` return the same type.

I also made a change so that `CreateRPProcessControl` uses std::function for definition (more readable IMO).