### PR TITLE
PVR Timer description enhancement

### DIFF
--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -491,7 +491,7 @@ public:
    * @param results The container to store the result in.
    * @return PVR_ERROR_NO_ERROR if the list has been fetched successfully.
    */
-  PVR_ERROR GetTimerTypes(std::vector<std::shared_ptr<CPVRTimerType>>& results) const;
+  PVR_ERROR GetTimerTypes(std::vector<std::shared_ptr<CPVRTimerType>>& results);
 
   //@}
   /** @name PVR live stream methods */
@@ -1035,6 +1035,8 @@ private:
       m_ignoreClient; /*!< signals to PVRManager to ignore this client until it has been connected */
   std::vector<std::shared_ptr<CPVRTimerType>>
       m_timertypes; /*!< timer types supported by this backend */
+  std::vector<std::shared_ptr<CPVRTimerType>>
+      m_formattedTimerTypes; /*!< timer types supported by this backend for instance GUI */
   mutable int m_iPriority; /*!< priority of the client */
   mutable bool m_bPriorityFetched;
 

--- a/xbmc/pvr/timers/PVRTimerType.cpp
+++ b/xbmc/pvr/timers/PVRTimerType.cpp
@@ -189,6 +189,25 @@ CPVRTimerType::CPVRTimerType(unsigned int iTypeId,
   InitDescription();
 }
 
+CPVRTimerType::CPVRTimerType(const CPVRTimerType& orig)
+  : m_iClientId(orig.m_iClientId),
+    m_iTypeId(orig.m_iTypeId),
+    m_iAttributes(orig.m_iAttributes),
+    m_strDescription(orig.m_strDescription),
+    m_priorityValues(orig.m_priorityValues),
+    m_iPriorityDefault(orig.m_iPriorityDefault),
+    m_lifetimeValues(orig.m_lifetimeValues),
+    m_iLifetimeDefault(orig.m_iLifetimeDefault),
+    m_maxRecordingsValues(orig.m_maxRecordingsValues),
+    m_iMaxRecordingsDefault(orig.m_iMaxRecordingsDefault),
+    m_preventDupEpisodesValues(orig.m_preventDupEpisodesValues),
+    m_iPreventDupEpisodesDefault(orig.m_iPreventDupEpisodesDefault),
+    m_recordingGroupValues(orig.m_recordingGroupValues),
+    m_iRecordingGroupDefault(orig.m_iRecordingGroupDefault),
+    m_strBackendDescription(orig.m_strBackendDescription)
+{
+}
+
 CPVRTimerType::~CPVRTimerType() = default;
 
 bool CPVRTimerType::operator ==(const CPVRTimerType& right) const
@@ -234,6 +253,7 @@ void CPVRTimerType::InitDescription()
     }
     m_strDescription = g_localizeStrings.Get(id);
   }
+  m_strBackendDescription = m_strDescription;
 
   // add reminder/recording prefix
   int prefixId = (m_iAttributes & PVR_TIMER_TYPE_IS_REMINDER)
@@ -241,6 +261,12 @@ void CPVRTimerType::InitDescription()
     : 825; // Recording: ...
 
   m_strDescription = StringUtils::Format(g_localizeStrings.Get(prefixId), m_strDescription);
+}
+
+void CPVRTimerType::FormatBackendDescription(std::string instanceName)
+{
+  // prefix the GUI display with the instance name instead of Recording:
+  m_strDescription = StringUtils::Format("{0}: {1}", instanceName, m_strBackendDescription);
 }
 
 void CPVRTimerType::InitAttributeValues(const PVR_TIMER_TYPE& type)

--- a/xbmc/pvr/timers/PVRTimerType.h
+++ b/xbmc/pvr/timers/PVRTimerType.h
@@ -65,11 +65,9 @@ namespace PVR
     CPVRTimerType(unsigned int iTypeId,
                   uint64_t iAttributes,
                   const std::string& strDescription = "");
+    CPVRTimerType(const CPVRTimerType& orig);
 
     virtual ~CPVRTimerType();
-
-    CPVRTimerType(const CPVRTimerType& type) = delete;
-    CPVRTimerType& operator=(const CPVRTimerType& orig) = delete;
 
     bool operator ==(const CPVRTimerType& right) const;
     bool operator !=(const CPVRTimerType& right) const;
@@ -384,6 +382,13 @@ namespace PVR
      */
     int GetRecordingGroupDefault() const { return m_iRecordingGroupDefault; }
 
+    /*!
+    * @brief update the strDescription with instance name
+    * @param an instance identifying string
+    * @return the formatted string
+    */
+    void FormatBackendDescription(std::string instanceName);
+
   private:
     void InitDescription();
     void InitAttributeValues(const PVR_TIMER_TYPE& type);
@@ -397,6 +402,7 @@ namespace PVR
     unsigned int m_iTypeId;
     uint64_t m_iAttributes;
     std::string m_strDescription;
+    std::string m_strBackendDescription;
     std::vector< std::pair<std::string, int> > m_priorityValues;
     int m_iPriorityDefault = DEFAULT_RECORDING_PRIORITY;
     std::vector< std::pair<std::string, int> > m_lifetimeValues;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->

Add an identifier to the strDescription when multiple recording clients have been enabled.   

<!--- Describe your change in detail here. -->

The raw descriptions from the server are stored and when necessary, when multiple recording clients are found format the string with a instance identifer.  This can can be instance name or the  add-on name for non-instanced client.

If only one recording client is dynamically determined there is no change.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->

Users cannot tell from the timer and timer rules selection dialogs which client they are creating or editing timers for.  

<!--- If it fixes an open issue, please link to the issue here. -->

Not open, but prior to Nexus users wouldn't typically have multiple recording backends.  With pvr.hts and pvr.nextpvr allowing multiple instances this will have the potential to raise an issue.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with pvr.hts, pvr.nextpvr, pvr.demo and pvr.iptvsimple and various combinations.

Note my C++ skills are not sufficient to determine if the new shared ptr I am making is safe so this will need to be reviewed.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->

Most users will see no change.    Users with multiple recording clients will see a identifier for their recordings.  For them the "Recording: "  prefix is removed in the current implementation for space and readability.  Users may need to change the instance name in the client setting  for readability.

<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/2148031/210098701-b6e7f1c6-57c7-40e6-90b8-26d19fca3f28.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
