### PR TITLE
[addons] AddonMgr::GetOrphanedDependencies() must fetch all add-ons, …

### DIFF
--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -319,7 +319,7 @@ bool CAddonMgr::HasAvailableUpdates()
 std::vector<std::shared_ptr<IAddon>> CAddonMgr::GetOrphanedDependencies() const
 {
   std::vector<std::shared_ptr<IAddon>> allAddons;
-  GetAddonsInternal(AddonType::UNKNOWN, allAddons, OnlyEnabled::CHOICE_YES,
+  GetAddonsInternal(AddonType::UNKNOWN, allAddons, OnlyEnabled::CHOICE_NO,
                     CheckIncompatible::CHOICE_YES);
 
   std::vector<std::shared_ptr<IAddon>> orphanedDependencies;


### PR DESCRIPTION
…not only the enabled ones

this should fix
```
If two add-ons share a dependency and one add-on is disabled,
uninstalling the active one removes the shared dependencies.

Currently using Nexus rc2, but it happened on rc1 and beta1 as well (didn’t tested alpha).
```
reported here https://discourse.coreelec.org/t/coreelec-20-0-nexus-rc2-discussion/19879/17
thanks @emveepee
@enen92 mind having a look? should be a no-brainer

## How has this been tested?
it hasnt been but the fix looks obvious

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
