### PR TITLE
[addons] AddonMgr::GetOrphanedDependencies() must fetch all add-ons, …

### DIFF
--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -319,7 +319,7 @@ bool CAddonMgr::HasAvailableUpdates()
 std::vector<std::shared_ptr<IAddon>> CAddonMgr::GetOrphanedDependencies() const
 {
   std::vector<std::shared_ptr<IAddon>> allAddons;
-  GetAddonsInternal(AddonType::UNKNOWN, allAddons, OnlyEnabled::CHOICE_YES,
+  GetAddonsInternal(AddonType::UNKNOWN, allAddons, OnlyEnabled::CHOICE_NO,
                     CheckIncompatible::CHOICE_YES);
 
   std::vector<std::shared_ptr<IAddon>> orphanedDependencies;


### PR DESCRIPTION
…not only the enabled ones

## Description
backport of #22353 

fixes bug report
```
If two add-ons share a dependency and one add-on is disabled,
uninstalling the active one removes the shared dependencies.

Currently using Nexus rc2, but it happened on rc1 and beta1 as well (didn’t tested alpha).
```