### PR TITLE
[PVR][Estuary] Timer settings dialog: Show client name in timer type …

### DIFF
--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -54,6 +54,27 @@
 						<height>110</height>
 						<texture>$VAR[InfoWallThumbVar]</texture>
 						<aspectratio>keep</aspectratio>
+						<visible>!ListItem.Property(PVR.IsRecordingTimer) + !ListItem.Property(PVR.IsRemindingTimer)</visible>
+					</control>
+					<control type="image">
+						<left>27</left>
+						<top>22</top>
+						<width>80</width>
+						<height>80</height>
+						<aspectratio align="top">keep</aspectratio>
+						<aligny>center</aligny>
+						<texture>icons/pvr/timers/recording.png</texture>
+						<visible>ListItem.Property(PVR.IsRecordingTimer)</visible>
+					</control>
+					<control type="image">
+						<left>27</left>
+						<top>22</top>
+						<width>80</width>
+						<height>80</height>
+						<aspectratio align="top">keep</aspectratio>
+						<aligny>center</aligny>
+						<texture>icons/pvr/timers/bell.png</texture>
+						<visible>ListItem.Property(PVR.IsRemindingTimer)</visible>
 					</control>
 					<control type="label">
 						<left>135</left>
@@ -90,6 +111,27 @@
 						<height>110</height>
 						<texture>$VAR[InfoWallThumbVar]</texture>
 						<aspectratio>keep</aspectratio>
+						<visible>!ListItem.Property(PVR.IsRecordingTimer) + !ListItem.Property(PVR.IsRemindingTimer)</visible>
+					</control>
+					<control type="image">
+						<left>27</left>
+						<top>22</top>
+						<width>80</width>
+						<height>80</height>
+						<aspectratio align="top">keep</aspectratio>
+						<aligny>center</aligny>
+						<texture>icons/pvr/timers/recording.png</texture>
+						<visible>ListItem.Property(PVR.IsRecordingTimer)</visible>
+					</control>
+					<control type="image">
+						<left>27</left>
+						<top>22</top>
+						<width>80</width>
+						<height>80</height>
+						<aspectratio align="top">keep</aspectratio>
+						<aligny>center</aligny>
+						<texture>icons/pvr/timers/bell.png</texture>
+						<visible>ListItem.Property(PVR.IsRemindingTimer)</visible>
 					</control>
 					<control type="label">
 						<left>135</left>

--- a/xbmc/settings/SettingControl.h
+++ b/xbmc/settings/SettingControl.h
@@ -196,12 +196,16 @@ public:
   SettingControlListValueFormatter GetFormatter() const { return m_formatter; }
   void SetFormatter(SettingControlListValueFormatter formatter) { m_formatter = formatter; }
 
+  bool UseDetails() const { return m_useDetails; }
+  void SetUseDetails(bool useDetails) { m_useDetails = useDetails; }
+
 protected:
   int m_heading = -1;
   bool m_multiselect = false;
   bool m_hideValue = false;
   int m_addButtonLabel = -1;
   SettingControlListValueFormatter m_formatter = nullptr;
+  bool m_useDetails{false};
 };
 
 class CSettingControlSlider;

--- a/xbmc/settings/dialogs/GUIDialogSettingsManualBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsManualBase.cpp
@@ -697,7 +697,8 @@ std::shared_ptr<CSettingString> CGUIDialogSettingsManualBase::AddList(
     StringSettingOptionsFiller filler,
     int heading,
     bool visible /* = true */,
-    int help /* = -1 */)
+    int help /* = -1 */,
+    bool details /* = false */)
 {
   if (group == NULL || id.empty() || label < 0 || filler == NULL ||
       GetSetting(id) != NULL)
@@ -707,7 +708,7 @@ std::shared_ptr<CSettingString> CGUIDialogSettingsManualBase::AddList(
   if (setting == NULL)
     return NULL;
 
-  setting->SetControl(GetListControl("string", false, heading, false));
+  setting->SetControl(GetListControl("string", false, heading, false, nullptr, details));
   setting->SetOptionsFiller(filler, this);
   setSettingDetails(setting, level, visible, help);
 
@@ -724,7 +725,8 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddList(
     const TranslatableIntegerSettingOptions& entries,
     int heading,
     bool visible /* = true */,
-    int help /* = -1 */)
+    int help /* = -1 */,
+    bool details /* = false */)
 {
   if (group == NULL || id.empty() || label < 0 || entries.empty() ||
       GetSetting(id) != NULL)
@@ -734,7 +736,7 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddList(
   if (setting == NULL)
     return NULL;
 
-  setting->SetControl(GetListControl("integer", false, heading, false));
+  setting->SetControl(GetListControl("integer", false, heading, false, nullptr, details));
   setting->SetTranslatableOptions(entries);
   setSettingDetails(setting, level, visible, help);
 
@@ -751,7 +753,8 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddList(
     const IntegerSettingOptions& entries,
     int heading,
     bool visible /* = true */,
-    int help /* = -1 */)
+    int help /* = -1 */,
+    bool details /* = false */)
 {
   if (group == NULL || id.empty() || label < 0 || entries.empty() ||
       GetSetting(id) != NULL)
@@ -761,7 +764,7 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddList(
   if (setting == NULL)
     return NULL;
 
-  setting->SetControl(GetListControl("integer", false, heading, false));
+  setting->SetControl(GetListControl("integer", false, heading, false, nullptr, details));
   setting->SetOptions(entries);
   setSettingDetails(setting, level, visible, help);
 
@@ -778,7 +781,8 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddList(
     IntegerSettingOptionsFiller filler,
     int heading,
     bool visible /* = true */,
-    int help /* = -1 */)
+    int help /* = -1 */,
+    bool details /* = false */)
 {
   if (group == NULL || id.empty() || label < 0 || filler == NULL ||
       GetSetting(id) != NULL)
@@ -788,7 +792,7 @@ std::shared_ptr<CSettingInt> CGUIDialogSettingsManualBase::AddList(
   if (setting == NULL)
     return NULL;
 
-  setting->SetControl(GetListControl("integer", false, heading, false));
+  setting->SetControl(GetListControl("integer", false, heading, false, nullptr, details));
   setting->SetOptionsFiller(filler, this);
   setSettingDetails(setting, level, visible, help);
 
@@ -807,7 +811,8 @@ std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddList(
     int minimumItems /* = 0 */,
     int maximumItems /* = -1 */,
     bool visible /* = true */,
-    int help /* = -1 */)
+    int help /* = -1 */,
+    bool details /* = false */)
 {
   if (group == NULL || id.empty() || label < 0 || filler == NULL ||
       GetSetting(id) != NULL)
@@ -832,7 +837,7 @@ std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddList(
   // setting the default will also set the actual value on an unchanged setting
   setting->SetDefault(settingValues);
 
-  setting->SetControl(GetListControl("string", false, heading, true));
+  setting->SetControl(GetListControl("string", false, heading, true, nullptr, details));
   setting->SetMinimumItems(minimumItems);
   setting->SetMaximumItems(maximumItems);
   setSettingDetails(setting, level, visible, help);
@@ -852,7 +857,8 @@ std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddList(
     int minimumItems /* = 0 */,
     int maximumItems /* = -1 */,
     bool visible /* = true */,
-    int help /* = -1 */)
+    int help /* = -1 */,
+    bool details /* = false */)
 {
   if (group == NULL || id.empty() || label < 0 || entries.empty() ||
       GetSetting(id) != NULL)
@@ -877,7 +883,7 @@ std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddList(
   // setting the default will also set the actual value on an unchanged setting
   setting->SetDefault(settingValues);
 
-  setting->SetControl(GetListControl("integer", false, heading, true));
+  setting->SetControl(GetListControl("integer", false, heading, true, nullptr, details));
   setting->SetMinimumItems(minimumItems);
   setting->SetMaximumItems(maximumItems);
   setSettingDetails(setting, level, visible, help);
@@ -897,7 +903,8 @@ std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddList(
     int minimumItems /* = 0 */,
     int maximumItems /* = -1 */,
     bool visible /* = true */,
-    int help /* = -1 */)
+    int help /* = -1 */,
+    bool details /* = false */)
 {
   if (group == NULL || id.empty() || label < 0 || entries.empty() ||
       GetSetting(id) != NULL)
@@ -922,7 +929,7 @@ std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddList(
   // setting the default will also set the actual value on an unchanged setting
   setting->SetDefault(settingValues);
 
-  setting->SetControl(GetListControl("integer", false, heading, true));
+  setting->SetControl(GetListControl("integer", false, heading, true, nullptr, details));
   setting->SetMinimumItems(minimumItems);
   setting->SetMaximumItems(maximumItems);
   setSettingDetails(setting, level, visible, help);
@@ -943,7 +950,8 @@ std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddList(
     int maximumItems /* = -1 */,
     bool visible /* = true */,
     int help /* = -1 */,
-    SettingControlListValueFormatter formatter /* = NULL */)
+    SettingControlListValueFormatter formatter /* = NULL */,
+    bool details /* = false */)
 {
   if (group == NULL || id.empty() || label < 0 || filler == NULL ||
       GetSetting(id) != NULL)
@@ -968,7 +976,7 @@ std::shared_ptr<CSettingList> CGUIDialogSettingsManualBase::AddList(
   // setting the default will also set the actual value on an unchanged setting
   setting->SetDefault(settingValues);
 
-  setting->SetControl(GetListControl("integer", false, heading, true, formatter));
+  setting->SetControl(GetListControl("integer", false, heading, true, formatter, details));
   setting->SetMinimumItems(minimumItems);
   setting->SetMaximumItems(maximumItems);
   setSettingDetails(setting, level, visible, help);
@@ -1550,7 +1558,13 @@ std::shared_ptr<ISettingControl> CGUIDialogSettingsManualBase::GetSpinnerControl
   return control;
 }
 
-std::shared_ptr<ISettingControl> CGUIDialogSettingsManualBase::GetListControl(const std::string &format, bool delayed /* = false */, int heading /* = -1 */, bool multiselect /* = false */,SettingControlListValueFormatter formatter /* = NULL */)
+std::shared_ptr<ISettingControl> CGUIDialogSettingsManualBase::GetListControl(
+    const std::string& format,
+    bool delayed /* = false */,
+    int heading /* = -1 */,
+    bool multiselect /* = false */,
+    SettingControlListValueFormatter formatter /* = NULL */,
+    bool details /* = false */)
 {
   std::shared_ptr<CSettingControlList> control = std::make_shared<CSettingControlList>();
   if (!control->SetFormat(format))
@@ -1560,6 +1574,7 @@ std::shared_ptr<ISettingControl> CGUIDialogSettingsManualBase::GetListControl(co
   control->SetHeading(heading);
   control->SetMultiSelect(multiselect);
   control->SetFormatter(formatter);
+  control->SetUseDetails(details);
 
   return control;
 }

--- a/xbmc/settings/dialogs/GUIDialogSettingsManualBase.h
+++ b/xbmc/settings/dialogs/GUIDialogSettingsManualBase.h
@@ -288,7 +288,8 @@ protected:
                                           StringSettingOptionsFiller filler,
                                           int heading,
                                           bool visible = true,
-                                          int help = -1);
+                                          int help = -1,
+                                          bool details = false);
   std::shared_ptr<CSettingInt> AddList(const std::shared_ptr<CSettingGroup>& group,
                                        const std::string& id,
                                        int label,
@@ -297,7 +298,8 @@ protected:
                                        const TranslatableIntegerSettingOptions& entries,
                                        int heading,
                                        bool visible = true,
-                                       int help = -1);
+                                       int help = -1,
+                                       bool details = false);
   std::shared_ptr<CSettingInt> AddList(const std::shared_ptr<CSettingGroup>& group,
                                        const std::string& id,
                                        int label,
@@ -306,7 +308,8 @@ protected:
                                        const IntegerSettingOptions& entries,
                                        int heading,
                                        bool visible = true,
-                                       int help = -1);
+                                       int help = -1,
+                                       bool details = false);
   std::shared_ptr<CSettingInt> AddList(const std::shared_ptr<CSettingGroup>& group,
                                        const std::string& id,
                                        int label,
@@ -315,7 +318,8 @@ protected:
                                        IntegerSettingOptionsFiller filler,
                                        int heading,
                                        bool visible = true,
-                                       int help = -1);
+                                       int help = -1,
+                                       bool details = false);
   std::shared_ptr<CSettingList> AddList(const std::shared_ptr<CSettingGroup>& group,
                                         const std::string& id,
                                         int label,
@@ -326,7 +330,8 @@ protected:
                                         int minimumItems = 0,
                                         int maximumItems = -1,
                                         bool visible = true,
-                                        int help = -1);
+                                        int help = -1,
+                                        bool details = false);
   std::shared_ptr<CSettingList> AddList(const std::shared_ptr<CSettingGroup>& group,
                                         const std::string& id,
                                         int label,
@@ -337,7 +342,8 @@ protected:
                                         int minimumItems = 0,
                                         int maximumItems = -1,
                                         bool visible = true,
-                                        int help = -1);
+                                        int help = -1,
+                                        bool details = false);
   std::shared_ptr<CSettingList> AddList(const std::shared_ptr<CSettingGroup>& group,
                                         const std::string& id,
                                         int label,
@@ -348,7 +354,8 @@ protected:
                                         int minimumItems = 0,
                                         int maximumItems = -1,
                                         bool visible = true,
-                                        int help = -1);
+                                        int help = -1,
+                                        bool details = false);
   std::shared_ptr<CSettingList> AddList(const std::shared_ptr<CSettingGroup>& group,
                                         const std::string& id,
                                         int label,
@@ -360,7 +367,8 @@ protected:
                                         int maximumItems = -1,
                                         bool visible = true,
                                         int help = -1,
-                                        SettingControlListValueFormatter formatter = NULL);
+                                        SettingControlListValueFormatter formatter = nullptr,
+                                        bool details = false);
 
   // slider controls
   std::shared_ptr<CSettingInt> AddPercentageSlider(const std::shared_ptr<CSettingGroup>& group,
@@ -588,7 +596,13 @@ protected:
   std::shared_ptr<ISettingControl> GetButtonControl(const std::string &format, bool delayed = false, int heading = -1, bool hideValue = false, bool showInstalledAddons = true,
     bool showInstallableAddons = false, bool showMoreAddons = true);
   std::shared_ptr<ISettingControl> GetSpinnerControl(const std::string &format, bool delayed = false, int minimumLabel = -1, int formatLabel = -1, const std::string &formatString = "");
-  std::shared_ptr<ISettingControl> GetListControl(const std::string &format, bool delayed = false, int heading = -1, bool multiselect = false, SettingControlListValueFormatter formatter = NULL);
+  std::shared_ptr<ISettingControl> GetListControl(
+      const std::string& format,
+      bool delayed = false,
+      int heading = -1,
+      bool multiselect = false,
+      SettingControlListValueFormatter formatter = nullptr,
+      bool details = false);
   std::shared_ptr<ISettingControl> GetSliderControl(const std::string &format, bool delayed = false, int heading = -1, bool usePopup = false, int formatLabel = -1, const std::string &formatString = "");
   std::shared_ptr<ISettingControl> GetRangeControl(const std::string &format, bool delayed = false, int formatLabel = -1, int valueFormatLabel = -1, const std::string &valueFormatString = "");
 

--- a/xbmc/settings/lib/SettingDefinitions.h
+++ b/xbmc/settings/lib/SettingDefinitions.h
@@ -68,11 +68,16 @@ struct IntegerSettingOption
   IntegerSettingOption(const std::string& _label, int _value)
   : label(_label), value(_value) {}
 
-  IntegerSettingOption(const std::string& _label, int _value,
+  IntegerSettingOption(const std::string& _label,
+                       const std::string& _label2,
+                       int _value,
                        const std::vector<std::pair<std::string, CVariant>>& props)
-  : label(_label), value(_value), properties(props) {}
+    : label(_label), label2(_label2), value(_value), properties(props)
+  {
+  }
 
   std::string label;
+  std::string label2;
   int value = 0;
   std::vector<std::pair<std::string, CVariant>> properties;
 };
@@ -82,11 +87,16 @@ struct StringSettingOption
   StringSettingOption(const std::string& _label, const std::string& _value)
   : label(_label), value(_value) {}
 
-  StringSettingOption(const std::string& _label, const std::string& _value,
+  StringSettingOption(const std::string& _label,
+                      const std::string& _label2,
+                      const std::string& _value,
                       const std::vector<std::pair<std::string, CVariant>>& props)
-  : label(_label), value(_value), properties(props) {}
+    : label(_label), label2(_label2), value(_value), properties(props)
+  {
+  }
 
   std::string label;
+  std::string label2;
   std::string value;
   std::vector<std::pair<std::string, CVariant>> properties;
 };

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -68,12 +68,14 @@ static std::string Localize(std::uint32_t code,
 
 template<typename TValueType>
 static CFileItemPtr GetFileItem(const std::string& label,
+                                const std::string& label2,
                                 const TValueType& value,
                                 const std::vector<std::pair<std::string, CVariant>>& properties,
                                 const std::set<TValueType>& selectedValues)
 {
   CFileItemPtr item(new CFileItem(label));
   item->SetProperty("value", value);
+  item->SetLabel2(label2);
 
   for (const auto& prop : properties)
     item->SetProperty(prop.first, prop.second);
@@ -678,6 +680,7 @@ bool CGUIControlListSetting::OnClick()
     dialog->SetHeading(CVariant{Localize(m_pSetting->GetLabel())});
     dialog->SetItems(options);
     dialog->SetMultiSelection(control->CanMultiSelect());
+    dialog->SetUseDetails(control->UseDetails());
     dialog->Open();
 
     if (!dialog->IsConfirmed())
@@ -897,7 +900,8 @@ bool CGUIControlListSetting::GetIntegerItems(const SettingConstPtr& setting,
 
   // turn them into CFileItems and add them to the item list
   for (const auto& option : options)
-    items.Add(GetFileItem(option.label, option.value, option.properties, selectedValues));
+    items.Add(
+        GetFileItem(option.label, option.label2, option.value, option.properties, selectedValues));
 
   return true;
 }
@@ -914,7 +918,8 @@ bool CGUIControlListSetting::GetStringItems(const SettingConstPtr& setting,
 
   // turn them into CFileItems and add them to the item list
   for (const auto& option : options)
-    items.Add(GetFileItem(option.label, option.value, option.properties, selectedValues));
+    items.Add(
+        GetFileItem(option.label, option.label2, option.value, option.properties, selectedValues));
 
   return true;
 }


### PR DESCRIPTION
…selection dialog if more than one client supports timers.

This would be my approach to fix the problem described in #22350 

Here is how it looks like:

![screenshot00002](https://user-images.githubusercontent.com/3226626/210177997-4e876396-2c3a-456b-a376-5864429d070c.png)

@emveepee what do you think?

Runtime-tested on macOS and Android; latest Kodi master.
