### PR TITLE
[sqlite] fix memory leak

### DIFF
--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -350,12 +350,13 @@ int SqliteDatabase::connect(bool create)
       active = true;
       return DB_CONNECTION_OK;
     }
-
-    return DB_CONNECTION_NONE;
   }
   catch (const DbErrors&)
   {
   }
+
+  sqlite3_close(conn);
+
   return DB_CONNECTION_NONE;
 }
 


### PR DESCRIPTION
This memory leak is related to DB_CONNECTION_NONE.

## Description
This commit fixes an issue detected by the sanitizer which generates a memory leak. This issue is bothersome for a "sanitized" version of kodi-test, for the normal version of kodi this issue is triggered when a database file is missing. The logs are available below.

## Motivation and context
The goal is to clean up some issues detected by the sanitizer.

## How has this been tested?
The option "-fsanitize=leak" is required and should be passed to the compiler and the linker. For a fully sanitized executable, you could use the following options: "-fsanitize=bounds -fsanitize=address -fsanitize=undefined -fsanitize=unreachable -fsanitize=bool -fsanitize=enum -fsanitize=leak -fsanitize-recover=address"

An example below, or you could use the cmake option: -DECM_ENABLE_SANITIZERS
cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS_DEBUG="-ggdb -O2 -fno-omit-frame-pointer -fsanitize=leak" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=leak" -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=leak"

The python library interferes with the sanitizer, "export PYTHONMALLOC=malloc" is not sufficient to fix this issue. Removing "runner.py" could be sufficient to fix this problem, otherwise disabling CPythonInvoker() is required.

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
