### PR TITLE
[PVR] Fix crash when renumbering channels and backend does not supply channel numbers

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -855,7 +855,7 @@ bool CPVRChannelGroup::Renumber(RenumberMode mode /* = NORMAL */)
   for (auto& sortedMember : m_sortedMembers)
   {
     currentClientChannelNumber = sortedMember->ClientChannelNumber();
-    if (!currentClientChannelNumber.IsValid())
+    if (m_allChannelsGroup && !currentClientChannelNumber.IsValid())
       currentClientChannelNumber =
           m_allChannelsGroup->GetClientChannelNumber(sortedMember->Channel());
 


### PR DESCRIPTION
Fixes an issue reported in the forum and in Slack.

Runtime-tested on macOS and Android, latest Kodi master.

@emveepee please confirm the fix.