### PR TITLE
[PVR] Fix crash when renumbering channels and backend does not supply channel numbers.

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -855,7 +855,7 @@ bool CPVRChannelGroup::Renumber(RenumberMode mode /* = NORMAL */)
   for (auto& sortedMember : m_sortedMembers)
   {
     currentClientChannelNumber = sortedMember->ClientChannelNumber();
-    if (!currentClientChannelNumber.IsValid())
+    if (m_allChannelsGroup && !currentClientChannelNumber.IsValid())
       currentClientChannelNumber =
           m_allChannelsGroup->GetClientChannelNumber(sortedMember->Channel());
 


### PR DESCRIPTION
Backport of #22364 

@phunkyfish please review