### PR TITLE
[PVR]  Defer channel group publishing

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -509,6 +509,8 @@ void CPVRManager::Process()
   // Reinit playbackstate
   m_playbackState->ReInit();
 
+  PublishEvent(PVREvent::ChannelGroupsLoaded);
+
   m_guiInfo->Start();
   m_epgContainer.Start();
   m_timers->Start();
@@ -727,7 +729,8 @@ bool CPVRManager::UpdateComponents(ManagerState stateToCheck,
     return false;
   }
 
-  PublishEvent(PVREvent::ChannelGroupsLoaded);
+  if (stateToCheck != ManagerState::STATE_STARTING)
+    PublishEvent(PVREvent::ChannelGroupsLoaded);
 
   // Load all timers
   if (progressHandler)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->

Defer publishing of the PVREvent::ChannelGroupsLoaded event on startup

<!--- Describe your change in detail here. -->

Currently when PVR manager starts and the user has selected a PVR startup screen an event is published which the GUI screen reads.  The setup in the GUI logic gets the channel group and group members based on the PlaybackState which has not yet been Initialized with the proper context.  This change defers the publishing until after the  PlaybackState has been setup.

Note an addon can generate the PlaybackState reinit by doing a TriggerChannelGroups() call after the PVR Manager has started.


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->

If a PVR guide or channel list are selected on startup they will look until the user leaves the screen or selects a channel group.

<!--- If it fixes an open issue, please link to the issue here. -->

Forum link here https://forum.kodi.tv/showthread.php?tid=371036

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->

Tested with pvr.nextpvr, pvr.demo and pvr.dvblink which all experience the problem.  Did not test what happens when UpdateComponents() fails.  The publlish could happen now on success or failure in some situations.

pvr.hts triggers many TriggerChannelGroupUpdates() on startup so it doesn't experience this issue.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tried to limit to startup to limit impact.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
