### PR TITLE
[android] FileManager add special://logpath to FileManager default list

### DIFF
--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -525,6 +525,13 @@ bool CGUIWindowFileManager::Update(int iList, const std::string &strDirectory)
       iItem->SetLabelPreformatted(true);
       m_vecItems[iList]->Add(iItem);
     #endif
+    #ifdef TARGET_ANDROID
+      CFileItemPtr iItem(new CFileItem("special://logpath", true));
+      iItem->SetLabel("Logs");
+      iItem->SetArt("thumb", "DefaultFolder.png");
+      iItem->SetLabelPreformatted(true);
+      m_vecItems[iList]->Add(iItem);
+    #endif
   }
 
   // if we have a .tbn file, use itself as the thumb


### PR DESCRIPTION
## Description
Adds Logs folder to Filemanager list to more easily allow filemanager operations on logs to eg copy log file to another destination

## Motivation and context
You can use the kodi log uploader addon to upload a log (or view), but i thought a simpler way for AndroidTV users might be to allow them to use Filemanager to copy to another destination (eg smb share, usb stick, etc)

If people dont think this is of value, thats fine, can be closed.

## How has this been tested?
Ran on Android 12 phone. Was able to open and manipulate log (eg copy to a share).

## What is the effect on users?
Able to copy a kodi log file using filemanager on android devices

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
