### PR TITLE
Fix TrueHD and DD+ broken after pause or seek in AudioTrack RAW also fixes audio keep alive in all platforms

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2662,7 +2662,15 @@ void CActiveAE::LoadSettings()
   m_settings.resampleQuality = static_cast<AEQuality>(settings->GetInt(CSettings::SETTING_AUDIOOUTPUT_PROCESSQUALITY));
   m_settings.atempoThreshold = settings->GetInt(CSettings::SETTING_AUDIOOUTPUT_ATEMPOTHRESHOLD) / 100.0;
   m_settings.streamNoise = settings->GetBool(CSettings::SETTING_AUDIOOUTPUT_STREAMNOISE);
-  m_settings.silenceTimeout = settings->GetInt(CSettings::SETTING_AUDIOOUTPUT_STREAMSILENCE) * 60000;
+
+  // Audio keep alive timeout in minutes [0 - 10]
+  // but with setting "Always" minutes = 2147483647 (INT_MAX)
+  const int minutes = settings->GetInt(CSettings::SETTING_AUDIOOUTPUT_STREAMSILENCE);
+
+  if (minutes <= 10)
+    m_settings.silenceTimeout = minutes * 60000; // convert to ms
+  else
+    m_settings.silenceTimeout = minutes; // "Always" is 2147483647 ms (~596 hours)
 }
 
 void CActiveAE::Start()

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -1154,12 +1154,24 @@ void CActiveAESink::GenerateNoise()
 
 void CActiveAESink::SetSilenceTimer()
 {
-  if (m_extStreaming)
+  if (m_extStreaming) // handles playback
+  {
     m_extSilenceTimeout = std::chrono::milliseconds::max();
-  else if (m_extAppFocused)
-    m_extSilenceTimeout = m_silenceTimeOut;
+  }
+  else if (m_extAppFocused) // handles no playback/GUI and playback in pause and seek
+  {
+    // only true with AudioTrack RAW + passthrough + TrueHD or EAC3 (DD+)
+    const bool noSilenceOnPause =
+        !m_needIecPack && m_requestedFormat.m_dataFormat == AE_FMT_RAW &&
+        (m_sinkFormat.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD ||
+         m_sinkFormat.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_EAC3);
+
+    m_extSilenceTimeout = (noSilenceOnPause) ? 0ms : m_silenceTimeOut;
+  }
   else
+  {
     m_extSilenceTimeout = 0ms;
+  }
 
   m_extSilenceTimer.Set(m_extSilenceTimeout);
 }


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/22341



## What is the effect on users?
- Fixes TrueHD and DD+ broken after pause or seek in AudioTrack RAW (Android only).
- Fixes audio keep alive broken when setting is "Always" (all platforms).



## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
