### PR TITLE
ExifParser: Fix several out of bounds accesses while parsing exif information

### DIFF
--- a/xbmc/pictures/ExifParse.cpp
+++ b/xbmc/pictures/ExifParse.cpp
@@ -878,6 +878,13 @@ void CExifParse::ProcessGpsInfo(
   {
     const unsigned char* DirEntry = DIR_ENTRY_ADDR(DirStart, de);
 
+    // Fix from aosp 34a2564d3268a5ca1472c5076675782fbaf724d6
+    if (DirEntry + 12 > OffsetBase + ExifLength)
+    {
+      ErrNonfatal("GPS info directory goes past end of exif", 0, 0);
+      return;
+    }
+
     unsigned Tag        = Get16(DirEntry, m_MotorolaOrder);
     unsigned Format     = Get16(DirEntry+2, m_MotorolaOrder);
     unsigned Components = (unsigned)Get32(DirEntry+4, m_MotorolaOrder);


### PR DESCRIPTION
Several drafted images could crash kodi. This was tested with memory, address sanitizers enabled.
cmake -DENABLE_VAAPI=1 -DCORE_PLATFORM_NAME=wayland -DCMAKE_BUILD_TYPE=Debug -DAPP_RENDER_SYSTEM=gl -DECM_ENABLE_SANITIZERS=address,memory

Example Output:
SUMMARY: AddressSanitizer: heap-buffer-overflow (/home/fritsch/Desktop/xbmc-fritsch/xbmc/build/kodi-wayland+0x3dca321) in CExifParse::Get32(void const*, bool)
Shadow bytes around the buggy address:
  0x0c3c8004e070: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c3c8004e080: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c3c8004e090: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c3c8004e0a0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c3c8004e0b0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0c3c8004e0c0: 00 00 00 00 00[04]fa fa fa fa fa fa fa fa fa fa
  0x0c3c8004e0d0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c3c8004e0e0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c3c8004e0f0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c3c8004e100: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c3c8004e110: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==824657==ABORTING

via: https://paste.kodi.tv/kagukejefa.kodi

The issues were long fixed upstream: https://android.googlesource.com/platform/external/jhead/+/2a4c12f5e5808e309b9ba04fe8b1539debf466d1

Kodi should remove the copied libexif code and use jhead directly.

This fixes: #22377 