### PR TITLE
[PlayListPlayer] Fix playlist hint on playlist file with multiple paths

### DIFF
--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -597,9 +597,16 @@ int PlayOrQueueMedia(const std::vector<std::string>& params, bool forcePlay)
     }
 
     if ((item.IsAudio() || item.IsVideo()) && !item.IsSmartPlayList())
+    {
+      if (!item.HasProperty("playlist_type_hint"))
+        item.SetProperty("playlist_type_hint", PLAYLIST::TYPE_MUSIC);
+
       CServiceBroker::GetPlaylistPlayer().Play(std::make_shared<CFileItem>(item), "");
+    }
     else
+    {
       g_application.PlayMedia(item, "", PLAYLIST::TYPE_NONE);
+    }
   }
 
   return 0;

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -741,7 +741,7 @@ bool CGUIWindowMusicBase::OnPlayMedia(int iItem, const std::string &player)
       OnQueueItem(iItem);
       return true;
     }
-    pItem->SetProperty("playlist_type_hint", PLAYLIST::TYPE_MUSIC);
+    pItem->SetProperty("playlist_type_hint", m_guiState->GetPlaylist());
     CServiceBroker::GetPlaylistPlayer().Play(pItem, player);
     return true;
   }

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1005,7 +1005,7 @@ bool CGUIWindowVideoBase::OnPlayMedia(int iItem, const std::string &player)
   }
   CLog::Log(LOGDEBUG, "{} {}", __FUNCTION__, CURL::GetRedacted(item.GetPath()));
 
-  item.SetProperty("playlist_type_hint", PLAYLIST::TYPE_VIDEO);
+  item.SetProperty("playlist_type_hint", m_guiState->GetPlaylist());
 
   PlayMovie(&item, player);
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This is a hidden nested bug that come from a very old Kodi version,
that has been highlighted from my PR #21667 due to a secondary bug in the GUI state (fixed by that PR)

This problem is shown only for a particular use case (seem used by PVR channels export list but i am not aware),
when you play a item in a playlist file (e.g. m3u) which there is no way to determine the type of playlist from the path,
see example below (save to a .m3u file, and play it from `Video` Kodi menu)
```
#EXTM3U
#EXTINF:123, Sample 1 not works
http://127.0.0.1/this_is_a_test
#EXTINF:123, Sample 2 works
https://www.libde265.org/hevc-bitstreams/tos-1720x720-cfg01.mkv
```

On this example you can see a playlist file with multiple paths, where on the first sample there is no extension and in some cases kodi is not able to detect the type of playlist, depends on behaviour, a bit longer to explain

**What happen on Kodi <= 19.4 (so without my PR #21667):**
if you try play it playback starts because the GUI state is forced set (wrongly) to Music
https://github.com/xbmc/xbmc/blob/19.3-Matrix/xbmc/view/GUIViewState.cpp#L104
but why works? because since has been forced to be Music state on a Video GUI section, this GUI state check for `Play next song automatically` music setting, and if enabled, play the item by using `CGUIMediaWindow::OnPlayAndQueueMedia`, this method force to set the playlist by using the value of the GUI state (music playlist), but if you disable music setting `Play next song automatically`, playback will be broken because the item is played by `CGUIWindowVideoBase::OnPlayMedia`

**What happen on Kodi >= 19.5 (with my PR merged #21667):**
if you try play it playback is broken, because my PR has fixed the wrong GUI state from Music to Video
https://github.com/xbmc/xbmc/commit/40f5992102fc3299b2c07fdea2ee011803f4a28d#diff-116fe3583aebce74e1139ea69013e7489c848e02355191da026c4c552ec434db
then the item is played by using `CGUIWindowVideoBase::OnPlayMedia`.
On these new Kodi versions exists two workarounds that could be used to make playback working:
- Play item by using context menu "Play from here" (because play item by using `CGUIMediaWindow::OnPlayAndQueueMedia`)
- Add to the playlist file `#KODIPROP:mimetype=video/mp4` (before the broken sample 1 path)

What the difference from method used for playback `OnPlayAndQueueMedia` and `OnPlayMedia`?
- `OnPlayMedia`: Used to play a single item, detect playlist type by using IsAudio/IsVideo https://github.com/xbmc/xbmc/blob/master/xbmc/PlayListPlayer.cpp#L272-L275, on this particular case playback fails because IsAudio/IsVideo become both false and `playlist_type_hint` is so ignored

- `OnPlayAndQueueMedia`: Used to play selected item and add others in queue, Force set the playlist type by using value provided by GUI state https://github.com/xbmc/xbmc/blob/master/xbmc/windows/GUIMediaWindow.cpp#L1515, then IsAudio/IsVideo are not used (the reason of the different behaviours)

I dont think that this change broken something, since now the hint `playlist_type_hint` is used on both cases (IsAudio/IsVideo are both true or both false), but this playlist system is a beastly mess so observations welcome

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On PR #21667 i fixed wrong playlist type, but has highlight a old problem on another particular use case
see forum https://forum.kodi.tv/showthread.php?tid=370986
so playlist type is not detected and playback not works by printing this warning on log
`WARNING <general>: Playlist Player: ListItem type must be audio or video, use ListItem:setInfo to specify!`

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By using sample above

~i need to ask a feedback confirmation on forum~
confirmed by comment below and on the forum link

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Play playlist file items without problems and warning

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
