### PR TITLE
ActiveAE: fix audio keep alive broken when setting is 'Always' in all platforms

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2651,7 +2651,15 @@ void CActiveAE::LoadSettings()
   m_settings.resampleQuality = static_cast<AEQuality>(settings->GetInt(CSettings::SETTING_AUDIOOUTPUT_PROCESSQUALITY));
   m_settings.atempoThreshold = settings->GetInt(CSettings::SETTING_AUDIOOUTPUT_ATEMPOTHRESHOLD) / 100.0;
   m_settings.streamNoise = settings->GetBool(CSettings::SETTING_AUDIOOUTPUT_STREAMNOISE);
-  m_settings.silenceTimeout = settings->GetInt(CSettings::SETTING_AUDIOOUTPUT_STREAMSILENCE) * 60000;
+
+  // Audio keep alive timeout in minutes [0 - 10]
+  // but with setting "Always" minutes = 2147483647 (INT_MAX)
+  const int minutes = settings->GetInt(CSettings::SETTING_AUDIOOUTPUT_STREAMSILENCE);
+
+  if (minutes <= 10)
+    m_settings.silenceTimeout = minutes * 60000; // convert to ms
+  else
+    m_settings.silenceTimeout = minutes; // "Always" is 2147483647 ms (~596 hours)
 }
 
 void CActiveAE::Start()


### PR DESCRIPTION
Singled-Out follow up of: #22341

Also needs to go into Nexus.