### PR TITLE
[PVR] Quick fix/workaround for empty channel/guide window when used a…

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -339,6 +339,8 @@ bool CGUIWindowPVRBase::OnMessage(CGUIMessage& message)
           m_viewControl.SetFocused();
           break;
         }
+        case PVREvent::ManagerStarted:
+          [[fallthrough]];
         case PVREvent::ChannelGroupsInvalidated:
         {
           std::shared_ptr<CPVRChannelGroup> group =


### PR DESCRIPTION
…s startup window due to missing window content refresh after PVR Manager started.

Supersedes #22374.

This is a quick fix with low regression risk. The root cause of the problem is identified but fix is rather high effort. Therefore we will go with a quick fix for now and I put the real fix on my todo list.

Root cause: When used as a startup window, loading window content must be deferred until the component responsible to deliver the data for the window is fully initialized. PVR startup is async. This logic is currently (maybe always was broken). Details are discussed in #22374.

Runtime-tested by me and @emveepee

@phunkyfish please review.