### PR TITLE
[PVR] Quick fix/workaround for empty channel/guide window when used a…

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -339,6 +339,8 @@ bool CGUIWindowPVRBase::OnMessage(CGUIMessage& message)
           m_viewControl.SetFocused();
           break;
         }
+        case PVREvent::ManagerStarted:
+          [[fallthrough]];
         case PVREvent::ChannelGroupsInvalidated:
         {
           std::shared_ptr<CPVRChannelGroup> group =


### PR DESCRIPTION
…s startup window due to missing window content refresh after PVR Manager started.

Backport of #22389

@phunkyfish please review. Regression risk is low to zero.