### PR TITLE
VideoPlayerCodec: Stop dividing by zero

### DIFF
--- a/xbmc/cores/paplayer/VideoPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.cpp
@@ -181,7 +181,9 @@ bool VideoPlayerCodec::Init(const CFileItem &file, unsigned int filecache)
   // we have to decode initial data in order to get channels/samplerate
   // for sanity - we read no more than 10 packets
   int nErrors = 0;
-  for (int nPacket=0; nPacket < 10 && (m_channels == 0 || m_format.m_sampleRate == 0); nPacket++)
+  for (int nPacket = 0;
+       nPacket < 10 && (m_channels == 0 || m_format.m_sampleRate == 0 || m_format.m_frameSize == 0);
+       nPacket++)
   {
     uint8_t dummy[256];
     size_t nSize = 256;
@@ -239,6 +241,10 @@ bool VideoPlayerCodec::Init(const CFileItem &file, unsigned int filecache)
   if (NeedConvert(m_srcFormat.m_dataFormat))
   {
     m_needConvert = true;
+    // if we don't know the framesize yet, we will fail when converting
+    if (m_srcFormat.m_frameSize == 0)
+      return false;
+
     m_pResampler = ActiveAE::CAEResampleFactory::Create();
 
     SampleConfig dstConfig, srcConfig;


### PR DESCRIPTION
When parsing a file failed so that needed fields, in our case frameSize are not available a guess work like with m_channels or m_samplerate does not help. Therefore fail early.

Fixes: #22378