### PR TITLE
Resolution: use iScreenWidth, iScreenHeight in GetMaxAllowedResolution

### DIFF
--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -444,11 +444,11 @@ void CResolutionUtils::GetMaxAllowedResolution(unsigned int& width, unsigned int
     {
       RESOLUTION res = CDisplaySettings::GetInstance().GetResFromString(mode.asString());
       RESOLUTION_INFO resInfo{CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(res)};
-      if (static_cast<unsigned int>(resInfo.iWidth) > maxWidth &&
-          static_cast<unsigned int>(resInfo.iHeight) > maxHeight)
+      if (static_cast<unsigned int>(resInfo.iScreenWidth) > maxWidth &&
+          static_cast<unsigned int>(resInfo.iScreenHeight) > maxHeight)
       {
-        maxWidth = static_cast<unsigned int>(resInfo.iWidth);
-        maxHeight = static_cast<unsigned int>(resInfo.iHeight);
+        maxWidth = static_cast<unsigned int>(resInfo.iScreenWidth);
+        maxHeight = static_cast<unsigned int>(resInfo.iScreenHeight);
       }
     }
   }
@@ -460,11 +460,11 @@ void CResolutionUtils::GetMaxAllowedResolution(unsigned int& width, unsigned int
     for (const auto& res : resList)
     {
       RESOLUTION_INFO resInfo{CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(res)};
-      if (static_cast<unsigned int>(resInfo.iWidth) > maxWidth &&
-          static_cast<unsigned int>(resInfo.iHeight) > maxHeight)
+      if (static_cast<unsigned int>(resInfo.iScreenWidth) > maxWidth &&
+          static_cast<unsigned int>(resInfo.iScreenHeight) > maxHeight)
       {
-        maxWidth = static_cast<unsigned int>(resInfo.iWidth);
-        maxHeight = static_cast<unsigned int>(resInfo.iHeight);
+        maxWidth = static_cast<unsigned int>(resInfo.iScreenWidth);
+        maxHeight = static_cast<unsigned int>(resInfo.iScreenHeight);
       }
     }
   }


### PR DESCRIPTION
## Description
GetMaxAllowedResolution is used by inputstream.adaptive addon to decide on stream resolution in Representation Chooser. As it decides on video resolution, Kodi should return maximal possible video resolution, not UI resolution.
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
Allow ISA switch to 4K if display supports it.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Built and runtime-tested in Nexus branch for Linux.
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
Allow ISA switch to 4K if display supports it.
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):
No screenshot, but log:
for display with
```
Found resolution 1920 x 1080 with 1920 x 1080 @ 50.000000 Hz
Found resolution 1920 x 1080 with 3840 x 2160 @ 50.000000 Hz
```

Before:
```
AddOnLog: inputstream.adaptive: [Repr. chooser] Resolution set: 1920x1080, max allowed: 1920x1080, Adjust refresh rate: 1
...
AddOnLog: inputstream.adaptive: [Repr. chooser] Screen resolution has changed: 1920x1080
```

After:
```
AddOnLog: inputstream.adaptive: [Repr. chooser] Resolution set: 1920x1080, max allowed: 3840x2160, Adjust refresh rate: 1
...
AddOnLog: inputstream.adaptive: [Repr. chooser] Screen resolution has changed: 3840x2160
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
