### PR TITLE
WinSystemX11: fix XChangeProperty() call

### DIFF
--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -764,7 +764,7 @@ bool CWinSystemX11::SetWindow(int width, int height, bool fullscreen, const std:
       Atom fs = XInternAtom(m_dpy, "_NET_WM_STATE_FULLSCREEN", True);
       XChangeProperty(m_dpy, m_mainWindow, XInternAtom(m_dpy, "_NET_WM_STATE", True), XA_ATOM, 32, PropModeReplace, (unsigned char *) &fs, 1);
       // disable desktop compositing for KDE, when Kodi is in full-screen mode
-      int one = 1;
+      long one = 1;
       Atom composite = XInternAtom(m_dpy, "_KDE_NET_WM_BLOCK_COMPOSITING", True);
       if (composite != None)
       {


### PR DESCRIPTION
## Description
This commit fixes a new issue detected by the sanitizer. This issue crashes kodi when running with a "sanitized" version of libx11. This change updates the type to 'long'. Here are some explanations on this matter: https://stackoverflow.com/questions/43376991/stick-c-app-to-all-desktops

```
==26364==ERROR: AddressSanitizer: unknown-crash on address 0x7fff27c76b10 at pc 0x7fe889fbb84e bp 0x7fff27c76820 sp 0x7fff27c76818
READ of size 8 at 0x7fff27c76b10 thread T0
    #0 0x7fe889fbb84d in _XData32 libX11-1.8.3/src/XlibInt.c:1693
    #1 0x7fe889e489b8 in XChangeProperty libX11-1.8.3/src/ChProp.c:83
    #2 0xf35ea8b in KODI::WINDOWING::X11::CWinSystemX11::SetWindow(int, int, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int*) xbmc-8e01076bd20cab496c940687d3a0904b438ba03a/xbmc/windowing/X\11/WinSystemX11.cpp:778
    #3 0xf41c4b9 in KODI::WINDOWING::X11::CWinSystemX11GLContext::SetWindow(int, int, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int*) xbmc-8e01076bd20cab496c940687d3a0904b438ba03a/xbmc/wi\ndowing/X11/WinSystemX11GLContext.cpp:115
    #4 0xf354360 in KODI::WINDOWING::X11::CWinSystemX11::SetFullScreen(bool, RESOLUTION_INFO&, bool) xbmc-8e01076bd20cab496c940687d3a0904b438ba03a/xbmc/windowing/X11/WinSystemX11.cpp:292
    #5 0xf41411f in KODI::WINDOWING::X11::CWinSystemX11GLContext::SetFullScreen(bool, RESOLUTION_INFO&, bool) xbmc-8e01076bd20cab496c940687d3a0904b438ba03a/xbmc/windowing/X11/WinSystemX11GLContext.cpp:180
    #6 0xf337c0b in KODI::WINDOWING::X11::CWinSystemX11::CreateNewWindow(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, RESOLUTION_INFO&) xbmc-8e01076bd20cab496c940687d3a0904b438ba03a/xbmc/win\dowing/X11/WinSystemX11.cpp:105
    #7 0xf411f90 in KODI::WINDOWING::X11::CWinSystemX11GLContext::CreateNewWindow(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, RESOLUTION_INFO&) xbmc-8e01076bd20cab496c940687d3a0904b438ba03a\/xbmc/windowing/X11/WinSystemX11GLContext.cpp:140
    #8 0x790fa41 in CApplication::InitWindow(RESOLUTION) xbmc-8e01076bd20cab496c940687d3a0904b438ba03a/xbmc/application/Application.cpp:602
    #9 0x7918c75 in CApplication::CreateGUI() xbmc-8e01076bd20cab496c940687d3a0904b438ba03a/xbmc/application/Application.cpp:557
    #10 0x5a932fa in XBMC_Run xbmc-8e01076bd20cab496c940687d3a0904b438ba03a/xbmc/platform/xbmc.cpp:36
    #11 0x110e68a in main xbmc-8e01076bd20cab496c940687d3a0904b438ba03a/xbmc/platform/posix/main.cpp:71
    #12 0x7fe889552236 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #13 0x7fe8895522f1 in __libc_start_main_impl ../csu/libc-start.c:392
    #14 0x1232680 in _start (/usr/local/lib64/kodi/kodi.bin+0x1232680)

```
## Motivation and context
The goal is to clean up some issues detected by the sanitizer.

## How has this been tested?
For a fully sanitized executable, you could use the following options: "-fsanitize=bounds -fsanitize=address -fsanitize=undefined -fsanitize=unreachable -fsanitize=bool -fsanitize=enum -fsanitize=leak -fsanitize-recover=address"

An example below, or you could use the cmake option: -DECM_ENABLE_SANITIZERS
cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS_DEBUG="-ggdb -O2 -fno-omit-frame-pointer -fsanitize=leak" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=leak" -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=leak"

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
