### PR TITLE
Add Dolby Vision support

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -499,7 +499,8 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
       m_formatname = "amc-hevc";
 
       bool isDvhe = (m_hints.codec_tag == MKTAG('d', 'v', 'h', 'e'));
-      bool isDvh1 = (m_hints.codec_tag == MKTAG('d', 'v', 'h', '1'));
+      bool isDvh1 = (m_hints.codec_tag == MKTAG('d', 'v', 'h', '1') ||
+                     m_hints.codec_tag == MKBETAG('d', 'v', 'v', 'C'));
 
       if (isDvhe || isDvh1)
       {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -500,7 +500,18 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
 
       bool isDvhe = (m_hints.codec_tag == MKTAG('d', 'v', 'h', 'e'));
       bool isDvh1 = (m_hints.codec_tag == MKTAG('d', 'v', 'h', '1') ||
-                     m_hints.codec_tag == MKBETAG('d', 'v', 'v', 'C'));
+                     m_hints.codec_tag == MKBETAG('d', 'v', 'v', 'C') ||
+                     m_hints.codec_tag == MKBETAG('d', 'v', 'c', 'C'));
+
+      // some files don't have dvhe or dvh1 tag set up but have Dolby Vision side data
+      if (!isDvhe && !isDvh1 && m_hints.hdrType == StreamHdrType::HDR_TYPE_DOLBYVISION)
+      {
+        // page 10, table 2 from https://professional.dolby.com/siteassets/content-creation/dolby-vision-for-content-creators/dolby-vision-streams-within-the-http-live-streaming-format-v2.0-13-november-2018.pdf
+        if (m_hints.codec_tag == MKTAG('h', 'v', 'c', '1'))
+          isDvh1 = true;
+        else
+          isDvhe = true;
+      }
 
       if (isDvhe || isDvh1)
       {

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1715,6 +1715,9 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
         if (!stereoMode.empty())
           st->stereo_mode = stereoMode;
 
+        side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_DOVI_CONF, &size);
+        if (size > 0 && side_data)
+          pStream->codecpar->codec_tag = MKBETAG('d', 'v', 'v', 'C');
 
         if (m_pInput->IsStreamType(DVDSTREAM_TYPE_DVD))
         {

--- a/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
@@ -56,6 +56,7 @@ void CDVDStreamInfo::Clear()
   ptsinvalid = false;
   forced_aspect = false;
   bitsperpixel = 0;
+  hdrType = StreamHdrType::HDR_TYPE_NONE;
   colorSpace = AVCOL_SPC_UNSPECIFIED;
   colorRange = AVCOL_RANGE_UNSPECIFIED;
   colorPrimaries = AVCOL_PRI_UNSPECIFIED;
@@ -106,6 +107,7 @@ bool CDVDStreamInfo::Equal(const CDVDStreamInfo& right, int compare)
   || bitsperpixel != right.bitsperpixel
   || bitdepth != right.bitdepth
   || vfr != right.vfr
+  || hdrType != right.hdrType
   || colorSpace != right.colorSpace
   || colorRange != right.colorRange
   || colorPrimaries != right.colorPrimaries
@@ -227,6 +229,7 @@ void CDVDStreamInfo::Assign(const CDVDStreamInfo& right, bool withextradata)
   bitdepth = right.bitdepth;
   vfr = right.vfr;
   codecOptions = right.codecOptions;
+  hdrType = right.hdrType;
   colorSpace = right.colorSpace;
   colorRange = right.colorRange;
   colorPrimaries = right.colorPrimaries;
@@ -296,6 +299,7 @@ void CDVDStreamInfo::Assign(const CDemuxStream& right, bool withextradata)
     orientation = stream->iOrientation;
     bitsperpixel = stream->iBitsPerPixel;
     bitdepth = stream->bitDepth;
+    hdrType = stream->hdr_type;
     colorSpace = stream->colorSpace;
     colorRange = stream->colorRange;
     colorPrimaries = stream->colorPrimaries;

--- a/xbmc/cores/VideoPlayer/DVDStreamInfo.h
+++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.h
@@ -68,6 +68,7 @@ public:
   int orientation; // orientation of the video in degrees counter clockwise
   int bitsperpixel;
   int bitdepth;
+  StreamHdrType hdrType;
   AVColorSpace colorSpace;
   AVColorRange colorRange;
   AVColorPrimaries colorPrimaries;


### PR DESCRIPTION
## Description
Add Dolby Vision support for files with a Matroska container (.mkv) on Android devices. 

## Motivation and context
Now that FFMpeg was updated it's possible to use the provided code without the need for a custom FFMpeg build. 
It's slightly modified version of previews commit (https://github.com/xbmc/xbmc/pull/18965) to accomodate the small API changes made by FFMpeg. 

## How has this been tested?
The package was built for ARM architecture (32bits) and test with the Nvidia Shield 2019 with the latest firmware update (Android 11) with a LG OLED.

Tested with HDR+DV content i.e. UHD Bluray remux. 
Tested with DV only content i.e. TV Shows.

A debug apk can be found here for testing with other devices:
https://github.com/fandangos/Kodi-HDR-Edition/releases/

## What is the effect on users?
The end user will be able to watch Dolby Vision files that have a matroska container. 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
