### PR TITLE
CPythonInvoker: code cleanup

### DIFF
--- a/xbmc/interfaces/python/AddonPythonInvoker.cpp
+++ b/xbmc/interfaces/python/AddonPythonInvoker.cpp
@@ -84,45 +84,33 @@ PyObject* PyInit_Module_xbmcvfs(void);
 
 using namespace PythonBindings;
 
-typedef struct
+namespace
 {
-  const char *name;
-  CPythonInvoker::PythonModuleInitialization initialization;
-} PythonModule;
-
-static PythonModule PythonModules[] =
+// clang-format off
+const _inittab PythonModules[] =
   {
     { "xbmcdrm",    PyInit_Module_xbmcdrm    },
     { "xbmcgui",    PyInit_Module_xbmcgui    },
     { "xbmc",       PyInit_Module_xbmc       },
     { "xbmcplugin", PyInit_Module_xbmcplugin },
     { "xbmcaddon",  PyInit_Module_xbmcaddon  },
-    { "xbmcvfs",    PyInit_Module_xbmcvfs    }
+    { "xbmcvfs",    PyInit_Module_xbmcvfs    },
+    { nullptr,      nullptr }
   };
+// clang-format on
+} // namespace
 
 CAddonPythonInvoker::CAddonPythonInvoker(ILanguageInvocationHandler *invocationHandler)
   : CPythonInvoker(invocationHandler)
 {
-  PyImport_AppendInittab("xbmcdrm", PyInit_Module_xbmcdrm);
-  PyImport_AppendInittab("xbmcgui", PyInit_Module_xbmcgui);
-  PyImport_AppendInittab("xbmc", PyInit_Module_xbmc);
-  PyImport_AppendInittab("xbmcplugin", PyInit_Module_xbmcplugin);
-  PyImport_AppendInittab("xbmcaddon", PyInit_Module_xbmcaddon);
-  PyImport_AppendInittab("xbmcvfs", PyInit_Module_xbmcvfs);
 }
 
 CAddonPythonInvoker::~CAddonPythonInvoker() = default;
 
-std::map<std::string, CPythonInvoker::PythonModuleInitialization> CAddonPythonInvoker::getModules() const
+void CAddonPythonInvoker::GlobalInitializeModules(void)
 {
-  static std::map<std::string, PythonModuleInitialization> modules;
-  if (modules.empty())
-  {
-    for (const PythonModule& pythonModule : PythonModules)
-      modules.insert(std::make_pair(pythonModule.name, pythonModule.initialization));
-  }
-
-  return modules;
+  if (PyImport_ExtendInittab(const_cast<_inittab*>(PythonModules)))
+    CLog::Log(LOGWARNING, "CAddonPythonInvoker(): unable to extend inittab");
 }
 
 const char* CAddonPythonInvoker::getInitializationScript() const

--- a/xbmc/interfaces/python/AddonPythonInvoker.h
+++ b/xbmc/interfaces/python/AddonPythonInvoker.h
@@ -16,8 +16,9 @@ public:
   explicit CAddonPythonInvoker(ILanguageInvocationHandler *invocationHandler);
   ~CAddonPythonInvoker() override;
 
+  static void GlobalInitializeModules(void);
+
 protected:
   // overrides of CPythonInvoker
-  std::map<std::string, PythonModuleInitialization> getModules() const override;
   const char* getInitializationScript() const override;
 };

--- a/xbmc/interfaces/python/PythonInvoker.h
+++ b/xbmc/interfaces/python/PythonInvoker.h
@@ -31,8 +31,6 @@ public:
 
   bool IsStopping() const override { return m_stop || ILanguageInvoker::IsStopping(); }
 
-  typedef PyObject* (*PythonModuleInitialization)();
-
 protected:
   // implementation of ILanguageInvoker
   bool execute(const std::string& script, const std::vector<std::string>& arguments) override;
@@ -42,7 +40,6 @@ protected:
   void onExecutionFailed() override;
 
   // custom virtual methods
-  virtual std::map<std::string, PythonModuleInitialization> getModules() const = 0;
   virtual const char* getInitializationScript() const = 0;
   virtual void onInitialization();
   // actually a PyObject* but don't wanna draw Python.h include into the header
@@ -59,8 +56,6 @@ protected:
   CCriticalSection m_critical;
 
 private:
-  void initializeModules(const std::map<std::string, PythonModuleInitialization>& modules);
-  bool initializeModule(PythonModuleInitialization module);
   void getAddonModuleDeps(const ADDON::AddonPtr& addon, std::set<std::string>& paths);
   bool execute(const std::string& script, std::vector<std::wstring>& arguments);
   FILE* PyFile_AsFileWithMode(PyObject* py_file, const char* mode);
@@ -73,4 +68,13 @@ private:
   bool m_systemExitThrown = false;
 
   static CCriticalSection s_critical;
+
+private:
+  struct PyObjectDeleter
+  {
+    void operator()(PyObject* p) const;
+  };
+
+public:
+  typedef std::unique_ptr<PyObject, PyObjectDeleter> PyObjectPtr;
 };

--- a/xbmc/network/httprequesthandler/python/HTTPPythonWsgiInvoker.h
+++ b/xbmc/network/httprequesthandler/python/HTTPPythonWsgiInvoker.h
@@ -29,13 +29,14 @@ public:
   CHTTPPythonWsgiInvoker(ILanguageInvocationHandler* invocationHandler, HTTPPythonRequest* request);
   ~CHTTPPythonWsgiInvoker() override;
 
+  static void GlobalInitializeModules(void);
+
   // implementations of CHTTPPythonInvoker
   HTTPPythonRequest* GetRequest() override;
 
 protected:
   // overrides of CPythonInvoker
   void executeScript(FILE* fp, const std::string& script, PyObject* moduleDict) override;
-  std::map<std::string, PythonModuleInitialization> getModules() const override;
   const char* getInitializationScript() const override;
 
 private:


### PR DESCRIPTION
## Description
This commit fixes the memory leaks and updates initializeModule(). The function initializeModule() was allocating the python objects which were immediately leaked. The proper python initialization of these modules is done by PyImport_AppendInittab().

## Motivation and context
The goal is to clean up some issues detected by the sanitizer.

## How has this been tested?
The option "-fsanitize=leak" is required and should be passed to the compiler and the linker. For a fully sanitized executable, you could use the following options: "-fsanitize=bounds -fsanitize=address -fsanitize=undefined -fsanitize=unreachable -fsanitize=bool -fsanitize=enum -fsanitize=leak -fsanitize-recover=address"

An example below, or you could use the cmake option: -DECM_ENABLE_SANITIZERS
cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS_DEBUG="-ggdb -O2 -fno-omit-frame-pointer -fsanitize=leak" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=leak" -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=leak"

The gcc sanitizer operates properly with a debug version of Python-3.11 compiled with the following options: '--without-pymalloc --with-pydebug --with-valgrind'. As a reminder with Python-3.8 the same options were not enough to generate a "sanitized" compatible python library.

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
