### PR TITLE
CStructHdl: remove superfluous assert that generates a warning

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h
@@ -132,8 +132,6 @@ public:
 
   const CStructHdl& operator=(const CStructHdl& right)
   {
-    assert(&right.m_cStructure);
-
     if (this == &right)
       return *this;
 


### PR DESCRIPTION
This fixes the following warning:

```
xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h:135:4: warning: the address of ‘kodi::addon::CStructHdl<kodi::addon::StreamCryptoSession, STREAM_CRYPTO_SESSION>::m_cStructure’ will never be NULL [-Waddress]
```

full warning:
```
In file included from /home/lukas/Documents/git/xbmc/xbmc/addons/AddonProvider.h:11,
                 from /home/lukas/Documents/git/xbmc/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h:13,
                 from /home/lukas/Documents/git/xbmc/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp:9:
/home/lukas/Documents/git/xbmc/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h: In instantiation of ‘const kodi::addon::CStructHdl<CPP_CLASS, C_STRUCT>& kodi::addon::CStructHdl<CPP_CLASS, C_STRUCT>::operator=(const kodi::addon::CStructHdl<CPP_CLASS, C_STRUCT>&) [with CPP_CLASS = kodi::addon::StreamCryptoSession; C_STRUCT = STREAM_CRYPTO_SESSION]’:
/home/lukas/Documents/git/xbmc/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/inputstream/StreamCrypto.h:54:24:   required from here
/home/lukas/Documents/git/xbmc/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h:135:4: warning: the address of ‘kodi::addon::CStructHdl<kodi::addon::StreamCryptoSession, STREAM_CRYPTO_SESSION>::m_cStructure’ will never be NULL [-Waddress]
/home/lukas/Documents/git/xbmc/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h:187:13: note: ‘kodi::addon::CStructHdl<kodi::addon::StreamCryptoSession, STREAM_CRYPTO_SESSION>::m_cStructure’ declared here
/home/lukas/Documents/git/xbmc/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h: In instantiation of ‘const kodi::addon::CStructHdl<CPP_CLASS, C_STRUCT>& kodi::addon::CStructHdl<CPP_CLASS, C_STRUCT>::operator=(const kodi::addon::CStructHdl<CPP_CLASS, C_STRUCT>&) [with CPP_CLASS = kodi::addon::InputstreamMasteringMetadata; C_STRUCT = INPUTSTREAM_MASTERING_METADATA]’:
/home/lukas/Documents/git/xbmc/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Inputstream.h:272:33:   required from here
/home/lukas/Documents/git/xbmc/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h:135:4: warning: the address of ‘kodi::addon::CStructHdl<kodi::addon::InputstreamMasteringMetadata, INPUTSTREAM_MASTERING_METADATA>::m_cStructure’ will never be NULL [-Waddress]
/home/lukas/Documents/git/xbmc/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h:187:13: note: ‘kodi::addon::CStructHdl<kodi::addon::InputstreamMasteringMetadata, INPUTSTREAM_MASTERING_METADATA>::m_cStructure’ declared here
/home/lukas/Documents/git/xbmc/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h: In instantiation of ‘const kodi::addon::CStructHdl<CPP_CLASS, C_STRUCT>& kodi::addon::CStructHdl<CPP_CLASS, C_STRUCT>::operator=(const kodi::addon::CStructHdl<CPP_CLASS, C_STRUCT>&) [with CPP_CLASS = kodi::addon::InputstreamContentlightMetadata; C_STRUCT = INPUTSTREAM_CONTENTLIGHT_METADATA]’:
/home/lukas/Documents/git/xbmc/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Inputstream.h:440:36:   required from here
/home/lukas/Documents/git/xbmc/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h:135:4: warning: the address of ‘kodi::addon::CStructHdl<kodi::addon::InputstreamContentlightMetadata, INPUTSTREAM_CONTENTLIGHT_METADATA>::m_cStructure’ will never be NULL [-Waddress]
/home/lukas/Documents/git/xbmc/xbmc/addons/kodi-dev-kit/include/kodi/AddonBase.h:187:13: note: ‘kodi::addon::CStructHdl<kodi::addon::InputstreamContentlightMetadata, INPUTSTREAM_CONTENTLIGHT_METADATA>::m_cStructure’ declared here
```
