### PR TITLE
[cmake] set policy CMP0135 to NEW 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,11 @@ if(POLICY CMP0069)
   cmake_policy(SET CMP0069 NEW)
 endif()
 
+if(POLICY CMP0135)
+  set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)
+  cmake_policy(SET CMP0135 NEW)
+endif()
+
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/buildtools)
 if(DEPENDS_DIR)


### PR DESCRIPTION
ref: https://cmake.org/cmake/help/latest/policy/CMP0135.html

~~This is only needed when `externalproject_add` is used with an archive url. I believe I found all the places that this is used/needed.~~

EDIT: this just sets the cmake policy for CMP0135 instead.

This fixes the following warnings:

```
CMake Warning (dev) at /usr/share/cmake/Modules/ExternalProject.cmake:3075 (message):
  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is
  not set.  The policy's OLD behavior will be used.  When using a URL
  download, the timestamps of extracted files should preferably be that of
  the time of extraction, otherwise code that depends on the extracted
  contents might not be rebuilt if the URL changes.  The OLD behavior
  preserves the timestamps from the archive instead, but this is usually not
  what you want.  Update your project to the NEW behavior or specify the
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this
  robustness issue.
Call Stack (most recent call first):
  /usr/share/cmake/Modules/ExternalProject.cmake:4185 (_ep_add_download_command)
  cmake/scripts/common/ModuleHelpers.cmake:383 (externalproject_add)
  cmake/modules/FindLibDvdCSS.cmake:87 (BUILD_DEP_TARGET)
  cmake/modules/FindLibDvdRead.cmake:22 (find_package)
  cmake/modules/FindLibDvdNav.cmake:21 (find_package)
  cmake/modules/FindLibDvd.cmake:5 (find_package)
  cmake/scripts/common/Macros.cmake:372 (find_package)
  cmake/scripts/common/Macros.cmake:386 (find_package_with_ver)
  CMakeLists.txt:215 (core_require_dep)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at /usr/share/cmake/Modules/ExternalProject.cmake:3075 (message):
  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is
  not set.  The policy's OLD behavior will be used.  When using a URL
  download, the timestamps of extracted files should preferably be that of
  the time of extraction, otherwise code that depends on the extracted
  contents might not be rebuilt if the URL changes.  The OLD behavior
  preserves the timestamps from the archive instead, but this is usually not
  what you want.  Update your project to the NEW behavior or specify the
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this
  robustness issue.
Call Stack (most recent call first):
  /usr/share/cmake/Modules/ExternalProject.cmake:4185 (_ep_add_download_command)
  cmake/scripts/common/ModuleHelpers.cmake:383 (externalproject_add)
  cmake/modules/FindLibDvdRead.cmake:106 (BUILD_DEP_TARGET)
  cmake/modules/FindLibDvdNav.cmake:21 (find_package)
  cmake/modules/FindLibDvd.cmake:5 (find_package)
  cmake/scripts/common/Macros.cmake:372 (find_package)
  cmake/scripts/common/Macros.cmake:386 (find_package_with_ver)
  CMakeLists.txt:215 (core_require_dep)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at /usr/share/cmake/Modules/ExternalProject.cmake:3075 (message):
  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is
  not set.  The policy's OLD behavior will be used.  When using a URL
  download, the timestamps of extracted files should preferably be that of
  the time of extraction, otherwise code that depends on the extracted
  contents might not be rebuilt if the URL changes.  The OLD behavior
  preserves the timestamps from the archive instead, but this is usually not
  what you want.  Update your project to the NEW behavior or specify the
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this
  robustness issue.
Call Stack (most recent call first):
  /usr/share/cmake/Modules/ExternalProject.cmake:4185 (_ep_add_download_command)
  cmake/scripts/common/ModuleHelpers.cmake:383 (externalproject_add)
  cmake/modules/FindLibDvdNav.cmake:100 (BUILD_DEP_TARGET)
  cmake/modules/FindLibDvd.cmake:5 (find_package)
  cmake/scripts/common/Macros.cmake:372 (find_package)
  cmake/scripts/common/Macros.cmake:386 (find_package_with_ver)
  CMakeLists.txt:215 (core_require_dep)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at /usr/share/cmake/Modules/ExternalProject.cmake:3075 (message):
  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is
  not set.  The policy's OLD behavior will be used.  When using a URL
  download, the timestamps of extracted files should preferably be that of
  the time of extraction, otherwise code that depends on the extracted
  contents might not be rebuilt if the URL changes.  The OLD behavior
  preserves the timestamps from the archive instead, but this is usually not
  what you want.  Update your project to the NEW behavior or specify the
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this
  robustness issue.
Call Stack (most recent call first):
  /usr/share/cmake/Modules/ExternalProject.cmake:4185 (_ep_add_download_command)
  cmake/scripts/common/ModuleHelpers.cmake:383 (externalproject_add)
  cmake/modules/FindRapidJSON.cmake:33 (BUILD_DEP_TARGET)
  cmake/scripts/common/Macros.cmake:372 (find_package)
  cmake/scripts/common/Macros.cmake:386 (find_package_with_ver)
  CMakeLists.txt:215 (core_require_dep)
This warning is for project developers.  Use -Wno-dev to suppress it.
```