### PR TITLE
CActiveAE: make silence timeout use minutes all the way through

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -581,7 +581,8 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           }
           LoadSettings();
           m_sink.m_controlPort.SendOutMessage(CSinkControlProtocol::SETNOISETYPE, &m_settings.streamNoise, sizeof(bool));
-          m_sink.m_controlPort.SendOutMessage(CSinkControlProtocol::SETSILENCETIMEOUT, &m_settings.silenceTimeout, sizeof(int));
+          m_sink.m_controlPort.SendOutMessage(CSinkControlProtocol::SETSILENCETIMEOUT,
+                                              &m_settings.silenceTimeoutMinutes, sizeof(int));
           ChangeResamplers();
           if (!NeedReconfigureBuffers() && !NeedReconfigureSink())
             return;
@@ -1783,7 +1784,8 @@ bool CActiveAE::InitSink()
 
   // send message to sink
   m_sink.m_controlPort.SendOutMessage(CSinkControlProtocol::SETNOISETYPE, &m_settings.streamNoise, sizeof(bool));
-  m_sink.m_controlPort.SendOutMessage(CSinkControlProtocol::SETSILENCETIMEOUT, &m_settings.silenceTimeout, sizeof(int));
+  m_sink.m_controlPort.SendOutMessage(CSinkControlProtocol::SETSILENCETIMEOUT,
+                                      &m_settings.silenceTimeoutMinutes, sizeof(int));
 
   Message *reply;
   if (m_sink.m_controlPort.SendOutMessageSync(CSinkControlProtocol::CONFIGURE,
@@ -2650,7 +2652,7 @@ void CActiveAE::LoadSettings()
   m_settings.resampleQuality = static_cast<AEQuality>(settings->GetInt(CSettings::SETTING_AUDIOOUTPUT_PROCESSQUALITY));
   m_settings.atempoThreshold = settings->GetInt(CSettings::SETTING_AUDIOOUTPUT_ATEMPOTHRESHOLD) / 100.0;
   m_settings.streamNoise = settings->GetBool(CSettings::SETTING_AUDIOOUTPUT_STREAMNOISE);
-  m_settings.silenceTimeout = settings->GetInt(CSettings::SETTING_AUDIOOUTPUT_STREAMSILENCE) * 60000;
+  m_settings.silenceTimeoutMinutes = settings->GetInt(CSettings::SETTING_AUDIOOUTPUT_STREAMSILENCE);
 }
 
 void CActiveAE::Start()

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -62,7 +62,7 @@ struct AudioSettings
   AEQuality resampleQuality;
   double atempoThreshold;
   bool streamNoise;
-  int silenceTimeout;
+  int silenceTimeoutMinutes;
 };
 
 class CActiveAEControlProtocol : public Protocol

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -328,7 +328,7 @@ void CActiveAESink::StateMachine(int signal, Protocol *port, Message *msg)
           return;
 
         case CSinkControlProtocol::SETSILENCETIMEOUT:
-          m_silenceTimeOut = std::chrono::milliseconds(*reinterpret_cast<int*>(msg->data));
+          m_silenceTimeOut = std::chrono::minutes(*reinterpret_cast<int*>(msg->data));
           return;
 
         case CSinkControlProtocol::SETNOISETYPE:

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
@@ -123,7 +123,7 @@ protected:
   int m_state;
   bool m_bStateMachineSelfTrigger;
   std::chrono::milliseconds m_extTimeout;
-  std::chrono::milliseconds m_silenceTimeOut;
+  std::chrono::minutes m_silenceTimeOut{std::chrono::minutes::zero()};
   bool m_extError;
   std::chrono::milliseconds m_extSilenceTimeout;
   bool m_extAppFocused;


### PR DESCRIPTION
This is an alternative to #22387 and keeps everything (possible) as a `std::chrono::duration`

There is also more context here #22341

The struct member rename isn't needed but it makes it more clear that the value is in minutes from an int.

The problem is that the int overflows when converting the `always` (`std::numeric_limits<int>::max()`) value to milliseconds.

With this PR:
```
Thread 38 "AESink" hit Breakpoint 2, ActiveAE::CActiveAESink::StateMachine (this=0x53a4820, signal=7, port=0x53a4a08, msg=0x7fff80000c40) at /home/lukas/Documents/git/xbmc/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp:331
331	          m_silenceTimeOut = std::chrono::minutes(*reinterpret_cast<int*>(msg->data));
(gdb) print *reinterpret_cast<int*>(msg->data)
$8 = 2147483647
(gdb) n
332	          return;
(gdb) print m_silenceTimeOut
$9 = {__r = 2147483647}
```

Without this PR:
```
Thread 39 "AESink" hit Breakpoint 2, ActiveAE::CActiveAESink::StateMachine (this=0x53a4820, signal=7, port=0x53a4a08, msg=0x7fff80000c40) at /home/lukas/Documents/git/xbmc/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp:331
331	          m_silenceTimeOut = std::chrono::milliseconds(*reinterpret_cast<int*>(msg->data));
(gdb) print *reinterpret_cast<int*>(msg->data)
$11 = -60000
(gdb) n
332	          return;
(gdb) print m_silenceTimeOut
$12 = {__r = -60000}
```


