### PR TITLE
[CDVDOverlay] Replace custom reference counting with std::shared_ptr

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlay.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlay.h
@@ -111,7 +111,6 @@ protected:
 };
 
 using VecOverlays = std::vector<std::shared_ptr<CDVDOverlay>>;
-using VecOverlaysIter = std::vector<std::shared_ptr<CDVDOverlay>>::iterator;
 
 class CDVDOverlayGroup : public CDVDOverlay
 {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlay.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlay.h
@@ -56,7 +56,7 @@ public:
 
   virtual ~CDVDOverlay() = default;
 
-  bool IsOverlayType(DVDOverlayType type) { return (m_type == type); }
+  bool IsOverlayType(DVDOverlayType type) const { return (m_type == type); }
 
   /**
    * return a copy to VideoPlayerSubtitle in order to have hw resources cleared
@@ -75,7 +75,7 @@ public:
   /*
    * \brief Return true if the text alignment (left/center/right) is enabled otherwise false.
    */
-  bool IsTextAlignEnabled() { return m_enableTextAlign; }
+  bool IsTextAlignEnabled() const { return m_enableTextAlign; }
 
   /*
    * \brief Allow/Disallow the overlay container to flush the overlay.
@@ -85,7 +85,7 @@ public:
   /*
    * \brief Return true when the overlay container can flush the overlay on flush events.
    */
-  bool IsOverlayContainerFlushable() { return m_overlayContainerFlushable; }
+  bool IsOverlayContainerFlushable() const { return m_overlayContainerFlushable; }
 
   /*
    * \brief Specify if the margins are handled by the subtitle codec/parser.

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodec.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlay.h"
 #include "cores/VideoPlayer/DVDDemuxers/DVDDemux.h"
 
 #include <string>
@@ -49,11 +50,6 @@ public:
   virtual bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options) = 0;
 
   /*
-   * Dispose, Free all resources
-   */
-  virtual void Dispose() = 0;
-
-  /*
    * returns one or a combination of VC_ messages
    * pData and iSize can be NULL, this means we should flush the rest of the data.
    */
@@ -75,7 +71,7 @@ public:
    * returns a valid overlay or NULL
    * the data is valid until the next Decode call
    */
-  virtual CDVDOverlay* GetOverlay() = 0;
+  virtual std::shared_ptr<CDVDOverlay> GetOverlay() = 0;
 
   /*
    * return codecs name

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecCCText.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecCCText.cpp
@@ -35,25 +35,10 @@ CDVDOverlayCodecCCText::CDVDOverlayCodecCCText() : CDVDOverlayCodec("CC Text Sub
   m_changePrevStopTime = false;
 }
 
-CDVDOverlayCodecCCText::~CDVDOverlayCodecCCText()
-{
-  Dispose();
-}
-
 bool CDVDOverlayCodecCCText::Open(CDVDStreamInfo& hints, CDVDCodecOptions& options)
 {
-  Dispose();
-
+  m_pOverlay.reset();
   return Initialize();
-}
-
-void CDVDOverlayCodecCCText::Dispose()
-{
-  if (m_pOverlay)
-  {
-    m_pOverlay->Release();
-    m_pOverlay = nullptr;
-  }
 }
 
 OverlayMessage CDVDOverlayCodecCCText::Decode(DemuxPacket* pPacket)
@@ -135,18 +120,12 @@ void CDVDOverlayCodecCCText::PostProcess(std::string& text)
 
 void CDVDOverlayCodecCCText::Reset()
 {
-  Dispose();
   Flush();
 }
 
 void CDVDOverlayCodecCCText::Flush()
 {
-  if (m_pOverlay)
-  {
-    m_pOverlay->Release();
-    m_pOverlay = nullptr;
-  }
-
+  m_pOverlay.reset();
   m_prevSubId = NO_SUBTITLE_ID;
   m_prevPTSStart = 0.0;
   m_prevText.clear();
@@ -155,11 +134,11 @@ void CDVDOverlayCodecCCText::Flush()
   FlushSubtitles();
 }
 
-CDVDOverlay* CDVDOverlayCodecCCText::GetOverlay()
+std::shared_ptr<CDVDOverlay> CDVDOverlayCodecCCText::GetOverlay()
 {
   if (m_pOverlay)
     return nullptr;
   m_pOverlay = CreateOverlay();
   m_pOverlay->SetTextAlignEnabled(true);
-  return m_pOverlay->Acquire();
+  return m_pOverlay;
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecCCText.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecCCText.h
@@ -18,19 +18,18 @@ class CDVDOverlayCodecCCText : public CDVDOverlayCodec, private CSubtitlesAdapte
 {
 public:
   CDVDOverlayCodecCCText();
-  ~CDVDOverlayCodecCCText() override;
+  ~CDVDOverlayCodecCCText() override = default;
   bool Open(CDVDStreamInfo& hints, CDVDCodecOptions& options) override;
   OverlayMessage Decode(DemuxPacket* pPacket) override;
   void Reset() override;
   void Flush() override;
-  CDVDOverlay* GetOverlay() override;
+  std::shared_ptr<CDVDOverlay> GetOverlay() override;
 
   // Specialization of CSubtitlesAdapter
   void PostProcess(std::string& text) override;
 
 private:
-  void Dispose() override;
-  CDVDOverlay* m_pOverlay;
+  std::shared_ptr<CDVDOverlay> m_pOverlay;
   int m_prevSubId;
   double m_prevPTSStart;
   std::string m_prevText;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.h
@@ -27,10 +27,9 @@ public:
   OverlayMessage Decode(DemuxPacket* pPacket) override;
   void Reset() override;
   void Flush() override;
-  CDVDOverlay* GetOverlay() override;
+  std::shared_ptr<CDVDOverlay> GetOverlay() override;
 
 private:
-  void Dispose() override;
   AVCodecContext* m_pCodecContext;
   AVSubtitle      m_Subtitle;
   int             m_SubtitleIndex;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecSSA.h
@@ -18,16 +18,15 @@ class CDVDOverlayCodecSSA : public CDVDOverlayCodec
 {
 public:
   CDVDOverlayCodecSSA();
-  ~CDVDOverlayCodecSSA() override;
+  ~CDVDOverlayCodecSSA() override = default;
   bool Open(CDVDStreamInfo& hints, CDVDCodecOptions& options) override;
   OverlayMessage Decode(DemuxPacket* pPacket) override;
   void Reset() override;
   void Flush() override;
-  CDVDOverlay* GetOverlay() override;
+  std::shared_ptr<CDVDOverlay> GetOverlay() override;
 
 private:
-  void Dispose() override;
   std::shared_ptr<CDVDSubtitlesLibass> m_libass;
-  CDVDOverlaySSA* m_pOverlay;
+  std::shared_ptr<CDVDOverlaySSA> m_pOverlay;
   int m_order;
 };

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecTX3G.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecTX3G.cpp
@@ -81,28 +81,14 @@ CDVDOverlayCodecTX3G::CDVDOverlayCodecTX3G() : CDVDOverlayCodec("TX3G Subtitle D
 {
 }
 
-CDVDOverlayCodecTX3G::~CDVDOverlayCodecTX3G()
-{
-  Dispose();
-}
-
 bool CDVDOverlayCodecTX3G::Open(CDVDStreamInfo& hints, CDVDCodecOptions& options)
 {
   if (hints.codec != AV_CODEC_ID_MOV_TEXT)
     return false;
 
-  Dispose();
+  m_pOverlay.reset();
 
   return Initialize();
-}
-
-void CDVDOverlayCodecTX3G::Dispose()
-{
-  if (m_pOverlay)
-  {
-    m_pOverlay->Release();
-    m_pOverlay = nullptr;
-  }
 }
 
 OverlayMessage CDVDOverlayCodecTX3G::Decode(DemuxPacket* pPacket)
@@ -262,25 +248,19 @@ void CDVDOverlayCodecTX3G::PostProcess(std::string& text)
 
 void CDVDOverlayCodecTX3G::Reset()
 {
-  Dispose();
   Flush();
 }
 
 void CDVDOverlayCodecTX3G::Flush()
 {
-  if (m_pOverlay)
-  {
-    m_pOverlay->Release();
-    m_pOverlay = nullptr;
-  }
-
+  m_pOverlay.reset();
   FlushSubtitles();
 }
 
-CDVDOverlay* CDVDOverlayCodecTX3G::GetOverlay()
+std::shared_ptr<CDVDOverlay> CDVDOverlayCodecTX3G::GetOverlay()
 {
   if (m_pOverlay)
     return nullptr;
   m_pOverlay = CreateOverlay();
-  return m_pOverlay->Acquire();
+  return m_pOverlay;
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecTX3G.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecTX3G.h
@@ -17,17 +17,16 @@ class CDVDOverlayCodecTX3G : public CDVDOverlayCodec, private CSubtitlesAdapter
 {
 public:
   CDVDOverlayCodecTX3G();
-  ~CDVDOverlayCodecTX3G() override;
+  ~CDVDOverlayCodecTX3G() override = default;
   bool Open(CDVDStreamInfo& hints, CDVDCodecOptions& options) override;
   OverlayMessage Decode(DemuxPacket* pPacket) override;
   void Reset() override;
   void Flush() override;
-  CDVDOverlay* GetOverlay() override;
+  std::shared_ptr<CDVDOverlay> GetOverlay() override;
 
   // Specialization of CSubtitlesAdapter
   void PostProcess(std::string& text) override;
 
 private:
-  void Dispose() override;
-  CDVDOverlay* m_pOverlay{nullptr};
+  std::shared_ptr<CDVDOverlay> m_pOverlay;
 };

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecText.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecText.cpp
@@ -23,11 +23,6 @@ CDVDOverlayCodecText::CDVDOverlayCodecText() : CDVDOverlayCodec("Text Subtitle D
   m_pOverlay = nullptr;
 }
 
-CDVDOverlayCodecText::~CDVDOverlayCodecText()
-{
-  Dispose();
-}
-
 bool CDVDOverlayCodecText::Open(CDVDStreamInfo& hints, CDVDCodecOptions& options)
 {
   if (hints.codec != AV_CODEC_ID_TEXT && hints.codec != AV_CODEC_ID_SSA &&
@@ -36,18 +31,9 @@ bool CDVDOverlayCodecText::Open(CDVDStreamInfo& hints, CDVDCodecOptions& options
 
   m_codecId = hints.codec;
 
-  Dispose();
+  m_pOverlay.reset();
 
   return Initialize();
-}
-
-void CDVDOverlayCodecText::Dispose()
-{
-  if (m_pOverlay)
-  {
-    m_pOverlay->Release();
-    m_pOverlay = nullptr;
-  }
 }
 
 OverlayMessage CDVDOverlayCodecText::Decode(DemuxPacket* pPacket)
@@ -101,25 +87,19 @@ void CDVDOverlayCodecText::PostProcess(std::string& text)
 
 void CDVDOverlayCodecText::Reset()
 {
-  Dispose();
   Flush();
 }
 
 void CDVDOverlayCodecText::Flush()
 {
-  if (m_pOverlay)
-  {
-    m_pOverlay->Release();
-    m_pOverlay = nullptr;
-  }
-
+  m_pOverlay.reset();
   FlushSubtitles();
 }
 
-CDVDOverlay* CDVDOverlayCodecText::GetOverlay()
+std::shared_ptr<CDVDOverlay> CDVDOverlayCodecText::GetOverlay()
 {
   if (m_pOverlay)
     return nullptr;
   m_pOverlay = CreateOverlay();
-  return m_pOverlay->Acquire();
+  return m_pOverlay;
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecText.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecText.h
@@ -23,19 +23,18 @@ class CDVDOverlayCodecText : public CDVDOverlayCodec, private CSubtitlesAdapter
 {
 public:
   CDVDOverlayCodecText();
-  ~CDVDOverlayCodecText() override;
+  ~CDVDOverlayCodecText() override = default;
   bool Open(CDVDStreamInfo& hints, CDVDCodecOptions& options) override;
   OverlayMessage Decode(DemuxPacket* pPacket) override;
   void Reset() override;
   void Flush() override;
-  CDVDOverlay* GetOverlay() override;
+  std::shared_ptr<CDVDOverlay> GetOverlay() override;
 
   // Specialization of CSubtitlesAdapter
   void PostProcess(std::string& text) override;
 
 private:
-  void Dispose() override;
-  CDVDOverlay* m_pOverlay;
+  std::shared_ptr<CDVDOverlay> m_pOverlay;
   CDVDStreamInfo m_hints;
   AVCodecID m_codecId{AV_CODEC_ID_NONE};
 };

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayImage.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayImage.h
@@ -62,9 +62,9 @@ public:
 
   ~CDVDOverlayImage() override = default;
 
-  CDVDOverlayImage* Clone() override
+  std::shared_ptr<CDVDOverlay> Clone() override
   {
-    return new CDVDOverlayImage(*this);
+    return std::make_shared<CDVDOverlayImage>(*this);
   }
 
   uint8_t* data_at(int sub_x, int sub_y) const

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayLibass.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayLibass.h
@@ -24,6 +24,8 @@ public:
 
   CDVDOverlayLibass(const CDVDOverlayLibass& src) : CDVDOverlay(src), m_libass(src.m_libass) {}
 
+  ~CDVDOverlayLibass() override = default;
+
   /*!
   \brief Getter for Libass handler
   \return The Libass handler.

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlaySSA.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlaySSA.h
@@ -24,5 +24,5 @@ public:
 
   ~CDVDOverlaySSA() override = default;
 
-  CDVDOverlaySSA* Clone() override { return new CDVDOverlaySSA(*this); }
+  std::shared_ptr<CDVDOverlay> Clone() override { return std::make_shared<CDVDOverlaySSA>(*this); }
 };

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlaySpu.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlaySpu.h
@@ -65,6 +65,8 @@ public:
     memcpy(highlight_color, src.highlight_color, sizeof(highlight_color));
   }
 
+  ~CDVDOverlaySpu() override = default;
+
   uint8_t result[2*65536 + 20]; // rle data
   int pTFData; // pointer to top field picture data (needs rle parsing)
   int pBFData; // pointer to bottom field picture data (needs rle parsing)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayText.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayText.h
@@ -24,7 +24,7 @@ public:
 
   ~CDVDOverlayText() override = default;
 
-  CDVDOverlayText* Clone() override { return new CDVDOverlayText(*this); }
+  std::shared_ptr<CDVDOverlay> Clone() override { return std::make_shared<CDVDOverlayText>(*this); }
 
   void SetTextAlignEnabled(bool enable) override { m_enableTextAlign = enable; }
 };

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/OverlayCodecWebVTT.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/OverlayCodecWebVTT.cpp
@@ -26,14 +26,9 @@ COverlayCodecWebVTT::COverlayCodecWebVTT() : CDVDOverlayCodec("WebVTT Subtitle D
   m_pOverlay = nullptr;
 }
 
-COverlayCodecWebVTT::~COverlayCodecWebVTT()
-{
-  Dispose();
-}
-
 bool COverlayCodecWebVTT::Open(CDVDStreamInfo& hints, CDVDCodecOptions& options)
 {
-  Dispose();
+  m_pOverlay.reset();
 
   if (!Initialize())
     return false;
@@ -59,15 +54,6 @@ bool COverlayCodecWebVTT::Open(CDVDStreamInfo& hints, CDVDCodecOptions& options)
   }
 
   return true;
-}
-
-void COverlayCodecWebVTT::Dispose()
-{
-  if (m_pOverlay)
-  {
-    m_pOverlay->Release();
-    m_pOverlay = nullptr;
-  }
 }
 
 OverlayMessage COverlayCodecWebVTT::Decode(DemuxPacket* pPacket)
@@ -147,22 +133,18 @@ void COverlayCodecWebVTT::Flush()
 {
   if (m_allowFlush)
   {
-    if (m_pOverlay)
-    {
-      m_pOverlay->Release();
-      m_pOverlay = nullptr;
-    }
+    m_pOverlay.reset();
     m_previousSubIds.clear();
     FlushSubtitles();
   }
 }
 
-CDVDOverlay* COverlayCodecWebVTT::GetOverlay()
+std::shared_ptr<CDVDOverlay> COverlayCodecWebVTT::GetOverlay()
 {
   if (m_pOverlay)
     return nullptr;
   m_pOverlay = CreateOverlay();
   m_pOverlay->SetOverlayContainerFlushable(m_allowFlush);
   m_pOverlay->SetForcedMargins(m_webvttHandler.IsForcedMargins());
-  return m_pOverlay->Acquire();
+  return m_pOverlay;
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/OverlayCodecWebVTT.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/OverlayCodecWebVTT.h
@@ -21,16 +21,15 @@ class COverlayCodecWebVTT : public CDVDOverlayCodec, private CSubtitlesAdapter
 {
 public:
   COverlayCodecWebVTT();
-  ~COverlayCodecWebVTT() override;
+  ~COverlayCodecWebVTT() override = default;
   bool Open(CDVDStreamInfo& hints, CDVDCodecOptions& options) override;
   OverlayMessage Decode(DemuxPacket* pPacket) override;
   void Reset() override;
   void Flush() override;
-  CDVDOverlay* GetOverlay() override;
+  std::shared_ptr<CDVDOverlay> GetOverlay() override;
 
 private:
-  void Dispose() override;
-  CDVDOverlay* m_pOverlay;
+  std::shared_ptr<CDVDOverlay> m_pOverlay;
   CWebVTTISOHandler m_webvttHandler;
   bool m_isISOFormat{false};
   bool m_allowFlush{true};

--- a/xbmc/cores/VideoPlayer/DVDDemuxSPU.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxSPU.cpp
@@ -497,7 +497,7 @@ std::shared_ptr<CDVDOverlaySpu> CDVDDemuxSPU::ParseRLE(std::shared_ptr<CDVDOverl
     if (!pSPU->bHasColor)
     {
       CLog::Log(LOGINFO, "{} - no color palette found, using default", __FUNCTION__);
-      FindSubtitleColor(i_border, stats, pSPU.get());
+      FindSubtitleColor(i_border, stats, *pSPU);
     }
 
     // check alpha values, for non forced spu's we use a default value
@@ -532,7 +532,7 @@ std::shared_ptr<CDVDOverlaySpu> CDVDDemuxSPU::ParseRLE(std::shared_ptr<CDVDOverl
   return pSPU;
 }
 
-void CDVDDemuxSPU::FindSubtitleColor(int last_color, int stats[4], CDVDOverlaySpu* pSPU)
+void CDVDDemuxSPU::FindSubtitleColor(int last_color, int stats[4], CDVDOverlaySpu& pSPU)
 {
   const int COLOR_INNER = 0;
   const int COLOR_SHADE = 1;
@@ -558,7 +558,7 @@ void CDVDDemuxSPU::FindSubtitleColor(int last_color, int stats[4], CDVDOverlaySp
 
 
   int nrOfUsedColors = 0;
-  for (int alpha : pSPU->alpha)
+  for (int alpha : pSPU.alpha)
   {
     if (alpha > 0) nrOfUsedColors++;
   }
@@ -573,11 +573,11 @@ void CDVDDemuxSPU::FindSubtitleColor(int last_color, int stats[4], CDVDOverlaySp
     // only one color is used, probably the inner color
     for (int i = 0; i < 4; i++) // find the position that is used
     {
-      if (pSPU->alpha[i] > 0)
+      if (pSPU.alpha[i] > 0)
       {
-        pSPU->color[i][0] = custom_subtitle_color[COLOR_INNER][0]; // Y
-        pSPU->color[i][1] = custom_subtitle_color[COLOR_INNER][1]; // Cr ?
-        pSPU->color[i][2] = custom_subtitle_color[COLOR_INNER][2]; // Cb ?
+        pSPU.color[i][0] = custom_subtitle_color[COLOR_INNER][0]; // Y
+        pSPU.color[i][1] = custom_subtitle_color[COLOR_INNER][1]; // Cr ?
+        pSPU.color[i][2] = custom_subtitle_color[COLOR_INNER][2]; // Cb ?
         return;
       }
     }
@@ -591,9 +591,9 @@ void CDVDDemuxSPU::FindSubtitleColor(int last_color, int stats[4], CDVDOverlaySp
     {
       int i, i_inner = -1, i_shade = -1;
       // Set the border color, the last color is probably the border color
-      pSPU->color[last_color][0] = custom_subtitle_color[COLOR_BORDER][0];
-      pSPU->color[last_color][1] = custom_subtitle_color[COLOR_BORDER][1];
-      pSPU->color[last_color][2] = custom_subtitle_color[COLOR_BORDER][2];
+      pSPU.color[last_color][0] = custom_subtitle_color[COLOR_BORDER][0];
+      pSPU.color[last_color][1] = custom_subtitle_color[COLOR_BORDER][1];
+      pSPU.color[last_color][2] = custom_subtitle_color[COLOR_BORDER][2];
       stats[last_color] = 0;
 
     // find the inner colors
@@ -626,18 +626,18 @@ void CDVDDemuxSPU::FindSubtitleColor(int last_color, int stats[4], CDVDOverlaySp
     if ( i_inner != -1 )
     {
       // white color
-        pSPU->color[i_inner][0] = custom_subtitle_color[COLOR_INNER][0]; // Y
-        pSPU->color[i_inner][1] = custom_subtitle_color[COLOR_INNER][1]; // Cr ?
-        pSPU->color[i_inner][2] = custom_subtitle_color[COLOR_INNER][2]; // Cb ?
+      pSPU.color[i_inner][1] = custom_subtitle_color[COLOR_INNER][1]; // Cr ?
+      pSPU.color[i_inner][2] = custom_subtitle_color[COLOR_INNER][2]; // Cb ?
+      pSPU.color[i_inner][0] = custom_subtitle_color[COLOR_INNER][0]; // Y
     }
 
     /* Set the anti-aliasing color */
     if ( i_shade != -1 )
     {
       // gray
-        pSPU->color[i_shade][0] = custom_subtitle_color[COLOR_SHADE][0];
-        pSPU->color[i_shade][1] = custom_subtitle_color[COLOR_SHADE][1];
-        pSPU->color[i_shade][2] = custom_subtitle_color[COLOR_SHADE][2];
+      pSPU.color[i_shade][0] = custom_subtitle_color[COLOR_SHADE][0];
+      pSPU.color[i_shade][1] = custom_subtitle_color[COLOR_SHADE][1];
+      pSPU.color[i_shade][2] = custom_subtitle_color[COLOR_SHADE][2];
     }
 
       DebugLog("ParseRLE: using custom palette (border %i, inner %i, shade %i)", last_color, i_inner, i_shade);

--- a/xbmc/cores/VideoPlayer/DVDDemuxSPU.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxSPU.cpp
@@ -13,6 +13,7 @@
 #include "utils/log.h"
 
 #include <locale.h>
+#include <memory>
 #include <stdlib.h>
 
 #undef ALIGN
@@ -64,7 +65,7 @@ void CDVDDemuxSPU::FlushCurrentPacket()
   memset(&m_spuData, 0, sizeof(m_spuData));
 }
 
-CDVDOverlaySpu* CDVDDemuxSPU::AddData(uint8_t* data, int iSize, double pts)
+std::shared_ptr<CDVDOverlaySpu> CDVDDemuxSPU::AddData(uint8_t* data, int iSize, double pts)
 {
   SPUData* pSPUData = &m_spuData;
 
@@ -148,7 +149,7 @@ CDVDOverlaySpu* CDVDDemuxSPU::AddData(uint8_t* data, int iSize, double pts)
 #define SET_DSPXA   0x06
 #define CHG_COLCON  0x07
 
-CDVDOverlaySpu* CDVDDemuxSPU::ParsePacket(SPUData* pSPUData)
+std::shared_ptr<CDVDOverlaySpu> CDVDDemuxSPU::ParsePacket(SPUData* pSPUData)
 {
   unsigned int alpha[4];
   uint8_t* pUnparsedData = NULL;
@@ -163,7 +164,7 @@ CDVDOverlaySpu* CDVDDemuxSPU::ParsePacket(SPUData* pSPUData)
     DebugLog("GetPacket, missing end of data 0xff");
   }
 
-  CDVDOverlaySpu* pSPUInfo = new CDVDOverlaySpu();
+  auto pSPUInfo = std::make_shared<CDVDOverlaySpu>();
   uint8_t* p = pSPUData->data; // pointer to walk through all data
 
   // get data length
@@ -307,7 +308,6 @@ CDVDOverlaySpu* CDVDDemuxSPU::ParsePacket(SPUData* pSPUData)
 
       default:
         DebugLog("GetPacket, error parsing control sequence");
-        delete pSPUInfo;
         return NULL;
         break;
       }
@@ -347,7 +347,8 @@ inline unsigned int AddNibble(unsigned int i_code, const uint8_t* p_src, unsigne
  * convenient structure for later decoding. For more information on the
  * subtitles format, see http://sam.zoy.org/doc/dvd/subtitles/index.html
  *****************************************************************************/
-CDVDOverlaySpu* CDVDDemuxSPU::ParseRLE(CDVDOverlaySpu* pSPU, uint8_t* pUnparsedData)
+std::shared_ptr<CDVDOverlaySpu> CDVDDemuxSPU::ParseRLE(std::shared_ptr<CDVDOverlaySpu> pSPU,
+                                                       uint8_t* pUnparsedData)
 {
   uint8_t* p_src = pUnparsedData;
 
@@ -403,7 +404,6 @@ CDVDOverlaySpu* CDVDDemuxSPU::ParseRLE(CDVDOverlaySpu* pSPU, uint8_t* pUnparsedD
               {
                 /* We have a boo boo ! */
                 CLog::Log(LOGERROR, "ParseRLE: unknown RLE code {:#4x}", i_code);
-                pSPU->Release();
                 return NULL;
               }
             }
@@ -415,7 +415,6 @@ CDVDOverlaySpu* CDVDDemuxSPU::ParseRLE(CDVDOverlaySpu* pSPU, uint8_t* pUnparsedD
       {
         CLog::Log(LOGERROR, "ParseRLE: out of bounds, {} at ({},{}) is out of {}x{}", i_code >> 2,
                   i_x, i_y, i_width, i_height);
-        pSPU->Release();
         return NULL;
       }
 
@@ -437,7 +436,6 @@ CDVDOverlaySpu* CDVDDemuxSPU::ParseRLE(CDVDOverlaySpu* pSPU, uint8_t* pUnparsedD
       {
         CLog::Log(LOGERROR, "ParseRLE: Overrunning our data range.  Need {} bytes",
                   (long)((uint8_t*)p_dest - pSPU->result));
-        pSPU->Release();
         return NULL;
       }
       *p_dest++ = i_code;
@@ -447,7 +445,6 @@ CDVDOverlaySpu* CDVDDemuxSPU::ParseRLE(CDVDOverlaySpu* pSPU, uint8_t* pUnparsedD
     if ( i_x > i_width )
     {
       CLog::Log(LOGERROR, "ParseRLE: i_x overflowed, {} > {}", i_x, i_width);
-      pSPU->Release();
       return NULL;
     }
 
@@ -477,14 +474,12 @@ CDVDOverlaySpu* CDVDDemuxSPU::ParseRLE(CDVDOverlaySpu* pSPU, uint8_t* pUnparsedD
       {
         CLog::Log(LOGERROR, "ParseRLE: Overrunning our data range.  Need {} bytes",
                   (long)((uint8_t*)p_dest - pSPU->result));
-        pSPU->Release();
         return NULL;
       }
       *p_dest++ = i_width << 2;
       i_y++;
     }
 
-    pSPU->Release();
     return NULL;
   }
 
@@ -502,7 +497,7 @@ CDVDOverlaySpu* CDVDDemuxSPU::ParseRLE(CDVDOverlaySpu* pSPU, uint8_t* pUnparsedD
     if (!pSPU->bHasColor)
     {
       CLog::Log(LOGINFO, "{} - no color palette found, using default", __FUNCTION__);
-      FindSubtitleColor(i_border, stats, pSPU);
+      FindSubtitleColor(i_border, stats, pSPU.get());
     }
 
     // check alpha values, for non forced spu's we use a default value

--- a/xbmc/cores/VideoPlayer/DVDDemuxSPU.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxSPU.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <memory>
 #include <stdint.h>
 
 struct AVFrame;
@@ -32,9 +33,11 @@ public:
   CDVDDemuxSPU();
   ~CDVDDemuxSPU();
 
-  CDVDOverlaySpu* AddData(uint8_t* data, int iSize, double pts); // returns a packet from ParsePacket if possible
+  std::shared_ptr<CDVDOverlaySpu> AddData(
+      uint8_t* data, int iSize, double pts); // returns a packet from ParsePacket if possible
 
-  CDVDOverlaySpu* ParseRLE(CDVDOverlaySpu* pSPU, uint8_t* pUnparsedData);
+  std::shared_ptr<CDVDOverlaySpu> ParseRLE(std::shared_ptr<CDVDOverlaySpu> pSPU,
+                                           uint8_t* pUnparsedData);
   static void FindSubtitleColor(int last_color, int stats[4], CDVDOverlaySpu* pSPU);
   static bool CanDisplayWithAlphas(const int a[4], const int stats[4]);
 
@@ -48,7 +51,7 @@ public:
   bool m_bHasClut;
 
 protected:
-  CDVDOverlaySpu* ParsePacket(SPUData* pSPUData);
+  std::shared_ptr<CDVDOverlaySpu> ParsePacket(SPUData* pSPUData);
 
   SPUData m_spuData;
 };

--- a/xbmc/cores/VideoPlayer/DVDDemuxSPU.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxSPU.h
@@ -38,7 +38,7 @@ public:
 
   std::shared_ptr<CDVDOverlaySpu> ParseRLE(std::shared_ptr<CDVDOverlaySpu> pSPU,
                                            uint8_t* pUnparsedData);
-  static void FindSubtitleColor(int last_color, int stats[4], CDVDOverlaySpu* pSPU);
+  static void FindSubtitleColor(int last_color, int stats[4], CDVDOverlaySpu& pSPU);
   static bool CanDisplayWithAlphas(const int a[4], const int stats[4]);
 
   void Reset();

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -1148,7 +1148,9 @@ bool CDVDInputStreamNavigator::SetAngle(int angle)
   return (status == DVDNAV_STATUS_OK);
 }
 
-bool CDVDInputStreamNavigator::GetCurrentButtonInfo(CDVDOverlaySpu* pOverlayPicture, CDVDDemuxSPU* pSPU, int iButtonType)
+bool CDVDInputStreamNavigator::GetCurrentButtonInfo(CDVDOverlaySpu& pOverlayPicture,
+                                                    CDVDDemuxSPU* pSPU,
+                                                    int iButtonType)
 {
   int colorAndAlpha[4][4];
   dvdnav_highlight_area_t hl;
@@ -1168,10 +1170,10 @@ bool CDVDInputStreamNavigator::GetCurrentButtonInfo(CDVDOverlaySpu* pOverlayPict
                               m_dll.dvdnav_get_current_nav_pci(m_dvdnav), button, iButtonType, &hl))
   {
     // button cropping information
-    pOverlayPicture->crop_i_x_start = hl.sx;
-    pOverlayPicture->crop_i_x_end = hl.ex;
-    pOverlayPicture->crop_i_y_start = hl.sy;
-    pOverlayPicture->crop_i_y_end = hl.ey;
+    pOverlayPicture.crop_i_x_start = hl.sx;
+    pOverlayPicture.crop_i_x_end = hl.ex;
+    pOverlayPicture.crop_i_y_start = hl.sy;
+    pOverlayPicture.crop_i_y_end = hl.ey;
   }
 
   if (pSPU->m_bHasClut)
@@ -1190,9 +1192,9 @@ bool CDVDInputStreamNavigator::GetCurrentButtonInfo(CDVDOverlaySpu* pOverlayPict
 
     for (int i = 0; i < 4; i++)
     {
-      pOverlayPicture->highlight_alpha[i] = colorAndAlpha[i][3];
+      pOverlayPicture.highlight_alpha[i] = colorAndAlpha[i][3];
       for (int j = 0; j < 3; j++)
-        pOverlayPicture->highlight_color[i][j] = colorAndAlpha[i][j];
+        pOverlayPicture.highlight_color[i][j] = colorAndAlpha[i][j];
     }
   }
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
@@ -80,7 +80,9 @@ public:
 
   int GetCurrentButton() override;
   int GetTotalButtons() override;
-  bool GetCurrentButtonInfo(CDVDOverlaySpu* pOverlayPicture, CDVDDemuxSPU* pSPU, int iButtonType /* 0 = selection, 1 = action (clicked)*/);
+  bool GetCurrentButtonInfo(CDVDOverlaySpu& pOverlayPicture,
+                            CDVDDemuxSPU* pSPU,
+                            int iButtonType /* 0 = selection, 1 = action (clicked)*/);
 
   /*!
    * \brief Get the supported menu type

--- a/xbmc/cores/VideoPlayer/DVDOverlayContainer.cpp
+++ b/xbmc/cores/VideoPlayer/DVDOverlayContainer.cpp
@@ -165,7 +165,7 @@ void CDVDOverlayContainer::UpdateOverlayInfo(
           (*it) = pOverlaySpu;
         }
 
-        if (pStream->GetCurrentButtonInfo(pOverlaySpu.get(), pSpu, iAction))
+        if (pStream->GetCurrentButtonInfo(*pOverlaySpu, pSpu, iAction))
         {
           pOverlaySpu->m_textureid = 0;
         }

--- a/xbmc/cores/VideoPlayer/DVDOverlayContainer.cpp
+++ b/xbmc/cores/VideoPlayer/DVDOverlayContainer.cpp
@@ -51,23 +51,17 @@ VecOverlays* CDVDOverlayContainer::GetOverlays()
   return &m_overlays;
 }
 
-VecOverlaysIter CDVDOverlayContainer::Remove(VecOverlaysIter itOverlay)
+VecOverlays::iterator CDVDOverlayContainer::Remove(VecOverlays::iterator itOverlay)
 {
-  VecOverlaysIter itNext;
-
-  {
-    std::unique_lock<CCriticalSection> lock(*this);
-    itNext = m_overlays.erase(itOverlay);
-  }
-
-  return itNext;
+  std::unique_lock<CCriticalSection> lock(*this);
+  return m_overlays.erase(itOverlay);
 }
 
 void CDVDOverlayContainer::CleanUp(double pts)
 {
   std::unique_lock<CCriticalSection> lock(*this);
 
-  VecOverlaysIter it = m_overlays.begin();
+  auto it = m_overlays.begin();
   while (it != m_overlays.end())
   {
     const std::shared_ptr<CDVDOverlay>& pOverlay = *it;
@@ -86,7 +80,7 @@ void CDVDOverlayContainer::CleanUp(double pts)
     else if (pOverlay->bForced)
     {
       //Check for newer replacements
-      VecOverlaysIter it2 = it;
+      auto it2 = it;
       bool bNewer = false;
       while (!bNewer && ++it2 != m_overlays.end())
       {
@@ -134,7 +128,7 @@ bool CDVDOverlayContainer::ContainsOverlayType(DVDOverlayType type)
 
   std::unique_lock<CCriticalSection> lock(*this);
 
-  VecOverlaysIter it = m_overlays.begin();
+  auto it = m_overlays.begin();
   while (!result && it != m_overlays.end())
   {
     if ((*it)->IsOverlayType(type)) result = true;

--- a/xbmc/cores/VideoPlayer/DVDOverlayContainer.cpp
+++ b/xbmc/cores/VideoPlayer/DVDOverlayContainer.cpp
@@ -8,21 +8,19 @@
 
 #include "DVDOverlayContainer.h"
 
+#include "DVDCodecs/Overlay/DVDOverlay.h"
 #include "DVDInputStreams/DVDInputStreamNavigator.h"
 
+#include <memory>
 #include <mutex>
-
-CDVDOverlayContainer::CDVDOverlayContainer() = default;
 
 CDVDOverlayContainer::~CDVDOverlayContainer()
 {
   Clear();
 }
 
-void CDVDOverlayContainer::ProcessAndAddOverlayIfValid(CDVDOverlay* pOverlay)
+void CDVDOverlayContainer::ProcessAndAddOverlayIfValid(std::shared_ptr<CDVDOverlay> pOverlay)
 {
-  pOverlay->Acquire();
-
   std::unique_lock<CCriticalSection> lock(*this);
 
   // markup any non ending overlays, to finish
@@ -56,14 +54,11 @@ VecOverlays* CDVDOverlayContainer::GetOverlays()
 VecOverlaysIter CDVDOverlayContainer::Remove(VecOverlaysIter itOverlay)
 {
   VecOverlaysIter itNext;
-  CDVDOverlay* pOverlay = *itOverlay;
 
   {
     std::unique_lock<CCriticalSection> lock(*this);
     itNext = m_overlays.erase(itOverlay);
   }
-
-  pOverlay->Release();
 
   return itNext;
 }
@@ -75,7 +70,7 @@ void CDVDOverlayContainer::CleanUp(double pts)
   VecOverlaysIter it = m_overlays.begin();
   while (it != m_overlays.end())
   {
-    CDVDOverlay* pOverlay = *it;
+    const std::shared_ptr<CDVDOverlay>& pOverlay = *it;
 
     // never delete forced overlays, they are used in menu's
     // clear takes care of removing them
@@ -95,7 +90,7 @@ void CDVDOverlayContainer::CleanUp(double pts)
       bool bNewer = false;
       while (!bNewer && ++it2 != m_overlays.end())
       {
-        CDVDOverlay* pOverlay2 = *it2;
+        const std::shared_ptr<CDVDOverlay>& pOverlay2 = *it2;
         if (pOverlay2->bForced && pOverlay2->iPTSStartTime <= pts) bNewer = true;
       }
 
@@ -116,11 +111,8 @@ void CDVDOverlayContainer::Flush()
 
   // Flush only the overlays marked as flushable
   m_overlays.erase(std::remove_if(m_overlays.begin(), m_overlays.end(),
-                                  [](CDVDOverlay* ov) {
-                                    bool isFlushable = ov->IsOverlayContainerFlushable();
-                                    if (isFlushable)
-                                      ov->Release();
-                                    return isFlushable;
+                                  [](const std::shared_ptr<CDVDOverlay>& ov) {
+                                    return ov->IsOverlayContainerFlushable();
                                   }),
                    m_overlays.end());
 }
@@ -128,10 +120,6 @@ void CDVDOverlayContainer::Flush()
 void CDVDOverlayContainer::Clear()
 {
   std::unique_lock<CCriticalSection> lock(*this);
-  for (auto &overlay : m_overlays)
-  {
-    overlay->Release();
-  }
   m_overlays.clear();
 }
 
@@ -171,20 +159,19 @@ void CDVDOverlayContainer::UpdateOverlayInfo(
   {
     if ((*it)->IsOverlayType(DVDOVERLAY_TYPE_SPU))
     {
-      CDVDOverlaySpu* pOverlaySpu = (CDVDOverlaySpu*)(*it);
+      auto pOverlaySpu = std::static_pointer_cast<CDVDOverlaySpu>(*it);
 
       // make sure its a forced (menu) overlay
       // set menu spu color and alpha data if there is a valid menu overlay
       if (pOverlaySpu->bForced)
       {
-        if (pOverlaySpu->Acquire()->Release() > 1)
+        if (pOverlaySpu.use_count() > 1)
         {
-          pOverlaySpu = new CDVDOverlaySpu(*pOverlaySpu);
-          (*it)->Release();
+          pOverlaySpu = std::make_shared<CDVDOverlaySpu>(*pOverlaySpu);
           (*it) = pOverlaySpu;
         }
 
-        if(pStream->GetCurrentButtonInfo(pOverlaySpu, pSpu, iAction))
+        if (pStream->GetCurrentButtonInfo(pOverlaySpu.get(), pSpu, iAction))
         {
           pOverlaySpu->m_textureid = 0;
         }

--- a/xbmc/cores/VideoPlayer/DVDOverlayContainer.h
+++ b/xbmc/cores/VideoPlayer/DVDOverlayContainer.h
@@ -53,7 +53,7 @@ public:
                          int iAction);
 
 private:
-  VecOverlaysIter Remove(VecOverlaysIter itOverlay); // removes a specific overlay
+  VecOverlays::iterator Remove(VecOverlays::iterator itOverlay); // removes a specific overlay
 
   VecOverlays m_overlays;
 };

--- a/xbmc/cores/VideoPlayer/DVDOverlayContainer.h
+++ b/xbmc/cores/VideoPlayer/DVDOverlayContainer.h
@@ -19,7 +19,6 @@ class CDVDDemuxSPU;
 class CDVDOverlayContainer : public CCriticalSection
 {
 public:
-  CDVDOverlayContainer();
   virtual ~CDVDOverlayContainer();
 
   /*!
@@ -34,7 +33,7 @@ public:
   *
   * \param pPicture pointer to the overlay to be evaluated and possibly added to the collection
   */
-  void ProcessAndAddOverlayIfValid(CDVDOverlay* pPicture);
+  void ProcessAndAddOverlayIfValid(std::shared_ptr<CDVDOverlay> pPicture);
 
   VecOverlays* GetOverlays(); // get the first overlay in this fifo
   bool ContainsOverlayType(DVDOverlayType type);

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleLineCollection.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleLineCollection.cpp
@@ -9,7 +9,7 @@
 #include "DVDSubtitleLineCollection.h"
 
 #include <stddef.h>
-
+#include <utility>
 
 CDVDSubtitleLineCollection::CDVDSubtitleLineCollection()
 {
@@ -25,10 +25,10 @@ CDVDSubtitleLineCollection::~CDVDSubtitleLineCollection()
   Clear();
 }
 
-void CDVDSubtitleLineCollection::Add(CDVDOverlay* pOverlay)
+void CDVDSubtitleLineCollection::Add(std::shared_ptr<CDVDOverlay> pOverlay)
 {
   ListElement* pElement = new ListElement;
-  pElement->pOverlay = pOverlay;
+  pElement->pOverlay = std::move(pOverlay);
   pElement->pNext = NULL;
 
   if (!m_pHead)
@@ -56,17 +56,15 @@ void CDVDSubtitleLineCollection::Sort()
     {
       if (p1->pOverlay->iPTSStartTime > p2->pOverlay->iPTSStartTime)
       {
-        CDVDOverlay* temp = p1->pOverlay;
-        p1->pOverlay = p2->pOverlay;
-        p2->pOverlay = temp;
+        std::swap(p1->pOverlay, p2->pOverlay);
       }
     }
   }
 }
 
-CDVDOverlay* CDVDSubtitleLineCollection::Get(double iPts)
+std::shared_ptr<CDVDOverlay> CDVDSubtitleLineCollection::Get(double iPts)
 {
-  CDVDOverlay* pOverlay = NULL;
+  std::shared_ptr<CDVDOverlay> pOverlay;
 
   if (m_pCurrent)
   {
@@ -100,7 +98,6 @@ void CDVDSubtitleLineCollection::Clear()
     pElement = m_pHead;
     m_pHead = pElement->pNext;
 
-    pElement->pOverlay->Release();
     delete pElement;
   }
 

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleLineCollection.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleLineCollection.h
@@ -12,7 +12,7 @@
 
 typedef struct stListElement
 {
-  CDVDOverlay* pOverlay;
+  std::shared_ptr<CDVDOverlay> pOverlay;
   struct stListElement* pNext;
 
 } ListElement;
@@ -26,10 +26,10 @@ public:
   //void Lock()   { EnterCriticalSection(&m_critSection); }
   //void Unlock() { LeaveCriticalSection(&m_critSection); }
 
-  void Add(CDVDOverlay* pSubtitle);
+  void Add(std::shared_ptr<CDVDOverlay> pSubtitle);
   void Sort();
 
-  CDVDOverlay* Get(double iPts = 0LL); // get the first overlay in this fifo
+  std::shared_ptr<CDVDOverlay> Get(double iPts = 0LL); // get the first overlay in this fifo
 
   void Reset();
 

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParser.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParser.h
@@ -25,7 +25,7 @@ public:
   virtual bool Open(CDVDStreamInfo &hints) = 0;
   virtual void Dispose() = 0;
   virtual void Reset() = 0;
-  virtual CDVDOverlay* Parse(double iPts) = 0;
+  virtual std::shared_ptr<CDVDOverlay> Parse(double iPts) = 0;
   virtual const std::string& GetName() const = 0;
 };
 
@@ -35,9 +35,9 @@ class CDVDSubtitleParserCollection
 public:
   explicit CDVDSubtitleParserCollection(const std::string& strFile) : m_filename(strFile) {}
   ~CDVDSubtitleParserCollection() override = default;
-  CDVDOverlay* Parse(double iPts) override
+  std::shared_ptr<CDVDOverlay> Parse(double iPts) override
   {
-    CDVDOverlay* o = m_collection.Get(iPts);
+    std::shared_ptr<CDVDOverlay> o = m_collection.Get(iPts);
     if(o == NULL)
       return o;
     return o->Clone();

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSSA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSSA.cpp
@@ -39,7 +39,7 @@ bool CDVDSubtitleParserSSA::Open(CDVDStreamInfo& hints)
   if (!m_libass->CreateTrack(const_cast<char*>(data.c_str()), data.length()))
     return false;
 
-  CDVDOverlaySSA* overlay = new CDVDOverlaySSA(m_libass);
+  auto overlay = std::make_shared<CDVDOverlaySSA>(m_libass);
   overlay->iPTSStartTime = 0.0;
   overlay->iPTSStopTime = DVD_NOPTS_VALUE;
   auto overrideStyles{

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitleParserWebVTT.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitleParserWebVTT.cpp
@@ -71,7 +71,7 @@ bool CSubtitleParserWebVTT::Open(CDVDStreamInfo& hints)
     AddSubtitle(subData.text, subData.startTime, subData.stopTime, &opts);
   }
 
-  CDVDOverlay* overlay = CreateOverlay();
+  std::shared_ptr<CDVDOverlay> overlay = CreateOverlay();
   overlay->SetForcedMargins(m_webvttHandler.IsForcedMargins());
   m_collection.Add(overlay);
 

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesAdapter.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesAdapter.cpp
@@ -75,7 +75,7 @@ void CSubtitlesAdapter::FlushSubtitles()
   m_libass->FlushEvents();
 }
 
-CDVDOverlay* CSubtitlesAdapter::CreateOverlay()
+std::shared_ptr<CDVDOverlay> CSubtitlesAdapter::CreateOverlay()
 {
   // Warning with Libass the overlay does not contain image or text then is not tied to Libass Events
   // any variation of the overlay Start/Stop PTS time will cause problems with the rendering.
@@ -89,7 +89,7 @@ CDVDOverlay* CSubtitlesAdapter::CreateOverlay()
   // - When an overlay disable the renderer, Libass has no possibility to
   //   complete the rendering of text animations (not sure if related to previous problem)
   //   with the result of displaying broken animations on the screen.
-  CDVDOverlayText* overlay = new CDVDOverlayText(m_libass);
+  auto overlay = std::make_shared<CDVDOverlayText>(m_libass);
   overlay->iPTSStartTime = 0.0;
   overlay->iPTSStopTime = DVD_NOPTS_VALUE;
   return overlay;

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesAdapter.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitlesAdapter.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "SubtitlesStyle.h"
+#include "cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlay.h"
 
 #include <memory>
 #include <string>
@@ -76,7 +77,7 @@ public:
 
   void FlushSubtitles();
 
-  CDVDOverlay* CreateOverlay();
+  std::shared_ptr<CDVDOverlay> CreateOverlay();
 
 protected:
   /*!

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4016,7 +4016,8 @@ int CVideoPlayer::OnDiscNavResult(void* pData, int iMessage)
     switch (iMessage)
     {
     case BD_EVENT_MENU_OVERLAY:
-      m_overlayContainer.ProcessAndAddOverlayIfValid(static_cast<CDVDOverlay*>(pData));
+      m_overlayContainer.ProcessAndAddOverlayIfValid(
+          *static_cast<std::shared_ptr<CDVDOverlay>*>(pData));
       break;
     case BD_EVENT_PLAYLIST_STOP:
       m_dvd.state = DVDSTATE_NORMAL;

--- a/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.cpp
@@ -52,23 +52,22 @@ void CVideoPlayerSubtitle::SendMessage(std::shared_ptr<CDVDMsg> pMsg, int priori
 
       if (result == OverlayMessage::OC_OVERLAY)
       {
-        CDVDOverlay* overlay;
+        std::shared_ptr<CDVDOverlay> overlay;
 
         while ((overlay = m_pOverlayCodec->GetOverlay()))
         {
           m_pOverlayContainer->ProcessAndAddOverlayIfValid(overlay);
-          overlay->Release();
         }
       }
     }
     else if (m_streaminfo.codec == AV_CODEC_ID_DVD_SUBTITLE)
     {
-      CDVDOverlaySpu* pSPUInfo = m_dvdspus.AddData(pPacket->pData, pPacket->iSize, pPacket->pts);
+      std::shared_ptr<CDVDOverlaySpu> pSPUInfo =
+          m_dvdspus.AddData(pPacket->pData, pPacket->iSize, pPacket->pts);
       if (pSPUInfo)
       {
         CLog::Log(LOGDEBUG, "CVideoPlayer::ProcessSubData: Got complete SPU packet");
         m_pOverlayContainer->ProcessAndAddOverlayIfValid(pSPUInfo);
-        pSPUInfo->Release();
       }
     }
 
@@ -190,7 +189,7 @@ void CVideoPlayerSubtitle::Process(double pts, double offset)
     if(m_pOverlayContainer->GetSize() >= 5)
       return;
 
-    CDVDOverlay* pOverlay = m_pSubtitleFileParser->Parse(pts);
+    std::shared_ptr<CDVDOverlay> pOverlay = m_pSubtitleFileParser->Parse(pts);
     // add all overlays which fit the pts
     while(pOverlay)
     {
@@ -199,7 +198,6 @@ void CVideoPlayerSubtitle::Process(double pts, double offset)
         pOverlay->iPTSStopTime -= offset;
 
       m_pOverlayContainer->ProcessAndAddOverlayIfValid(pOverlay);
-      pOverlay->Release();
       pOverlay = m_pSubtitleFileParser->Parse(pts);
     }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -10,6 +10,7 @@
 
 #include "DVDCodecs/DVDCodecUtils.h"
 #include "DVDCodecs/DVDFactoryCodec.h"
+#include "DVDCodecs/Overlay/DVDOverlay.h"
 #include "DVDCodecs/Video/DVDVideoCodecFFmpeg.h"
 #include "ServiceBroker.h"
 #include "cores/VideoPlayer/Interface/DemuxPacket.h"
@@ -23,6 +24,7 @@
 
 #include <iomanip>
 #include <iterator>
+#include <memory>
 #include <mutex>
 #include <numeric>
 #include <sstream>
@@ -808,7 +810,7 @@ void CVideoPlayerVideo::ProcessOverlays(const VideoPicture* pSource, double pts)
     //Both forced and subs should check timing
     while (it != pVecOverlays->end())
     {
-      CDVDOverlay* pOverlay = *it++;
+      std::shared_ptr<CDVDOverlay>& pOverlay = *it++;
       if(!pOverlay->bForced && !m_bRenderSubs)
         continue;
 
@@ -817,8 +819,9 @@ void CVideoPlayerVideo::ProcessOverlays(const VideoPicture* pSource, double pts)
       if((pOverlay->iPTSStartTime <= pts2 && (pOverlay->iPTSStopTime > pts2 || pOverlay->iPTSStopTime == 0LL)))
       {
         if(pOverlay->IsOverlayType(DVDOVERLAY_TYPE_GROUP))
-          overlays.insert(overlays.end(), static_cast<CDVDOverlayGroup*>(pOverlay)->m_overlays.begin()
-                                        , static_cast<CDVDOverlayGroup*>(pOverlay)->m_overlays.end());
+          overlays.insert(overlays.end(),
+                          static_cast<CDVDOverlayGroup&>(*pOverlay).m_overlays.begin(),
+                          static_cast<CDVDOverlayGroup&>(*pOverlay).m_overlays.end());
         else
           overlays.push_back(pOverlay);
       }

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -804,7 +804,7 @@ void CVideoPlayerVideo::ProcessOverlays(const VideoPicture* pSource, double pts)
     std::unique_lock<CCriticalSection> lock(*m_pOverlayContainer);
 
     VecOverlays* pVecOverlays = m_pOverlayContainer->GetOverlays();
-    VecOverlaysIter it = pVecOverlays->begin();
+    auto it = pVecOverlays->begin();
 
     //Check all overlays and render those that should be rendered, based on time and forced
     //Both forced and subs should check timing

--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
@@ -131,7 +131,7 @@ void CDebugRenderer::CRenderer::Render(int idx)
         CreateSubtitlesStyle();
 
       std::shared_ptr<COverlay> o =
-          ConvertLibass(ovAss.get(), it->pts, updateStyle, m_debugOverlayStyle);
+          ConvertLibass(*ovAss, it->pts, updateStyle, m_debugOverlayStyle);
 
       if (o)
         OVERLAY::CRenderer::Render(o.get());

--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
@@ -50,11 +50,7 @@ void CDebugRenderer::Dispose()
 {
   m_isInitialized = false;
   m_overlayRenderer.Flush();
-  if (m_overlay)
-  {
-    m_overlay->Release();
-    m_overlay = nullptr;
-  }
+  m_overlay.reset();
   if (m_adapter)
   {
     delete m_adapter;
@@ -126,7 +122,7 @@ void CDebugRenderer::CRenderer::Render(int idx)
   {
     if (it->overlay_dvd)
     {
-      CDVDOverlayLibass* ovAss = static_cast<CDVDOverlayLibass*>(it->overlay_dvd);
+      auto ovAss = std::static_pointer_cast<CDVDOverlayLibass>(it->overlay_dvd);
       if (!ovAss || !ovAss->GetLibassHandler())
         continue;
 
@@ -134,10 +130,11 @@ void CDebugRenderer::CRenderer::Render(int idx)
       if (updateStyle)
         CreateSubtitlesStyle();
 
-      COverlay* o = ConvertLibass(ovAss, it->pts, updateStyle, m_debugOverlayStyle);
+      std::shared_ptr<COverlay> o =
+          ConvertLibass(ovAss.get(), it->pts, updateStyle, m_debugOverlayStyle);
 
       if (o)
-        OVERLAY::CRenderer::Render(o);
+        OVERLAY::CRenderer::Render(o.get());
     }
   }
   ReleaseUnused();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.h
@@ -49,5 +49,5 @@ protected:
 private:
   CSubtitlesAdapter* m_adapter{nullptr};
   std::atomic_bool m_isInitialized{false};
-  CDVDOverlay* m_overlay{nullptr};
+  std::shared_ptr<CDVDOverlay> m_overlay;
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
@@ -143,7 +143,7 @@ namespace OVERLAY {
     };
 
     void Render(COverlay* o);
-    std::shared_ptr<COverlay> Convert(CDVDOverlay* o, double pts);
+    std::shared_ptr<COverlay> Convert(CDVDOverlay& o, double pts);
     /*!
     * \brief Convert the overlay to a overlay renderer
     * \param o The overlay to convert
@@ -152,7 +152,7 @@ namespace OVERLAY {
     * \return True if success, false if error
     */
     std::shared_ptr<COverlay> ConvertLibass(
-        CDVDOverlayLibass* o,
+        CDVDOverlayLibass& o,
         double pts,
         bool updateStyle,
         const std::shared_ptr<struct KODI::SUBTITLES::STYLE::style>& overlayStyle);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "BaseRenderer.h"
+#include "cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlay.h"
 #include "cores/VideoPlayer/DVDSubtitles/SubtitlesStyle.h"
 #include "settings/SubtitlesSettings.h"
 #include "threads/CriticalSection.h"
@@ -91,7 +92,7 @@ namespace OVERLAY {
     // Implementation of Observer
     void Notify(const Observable& obs, const ObservableMessage msg) override;
 
-    void AddOverlay(CDVDOverlay* o, double pts, int index);
+    void AddOverlay(std::shared_ptr<CDVDOverlay> o, double pts, int index);
     virtual void Render(int idx);
 
     /*!
@@ -138,11 +139,11 @@ namespace OVERLAY {
         pts = 0.0;
       }
       double pts;
-      CDVDOverlay* overlay_dvd;
+      std::shared_ptr<CDVDOverlay> overlay_dvd;
     };
 
     void Render(COverlay* o);
-    COverlay* Convert(CDVDOverlay* o, double pts);
+    std::shared_ptr<COverlay> Convert(CDVDOverlay* o, double pts);
     /*!
     * \brief Convert the overlay to a overlay renderer
     * \param o The overlay to convert
@@ -150,7 +151,7 @@ namespace OVERLAY {
     * \param subStyle The style to be used, MUST BE SET ONLY at the first call or when user change settings
     * \return True if success, false if error
     */
-    COverlay* ConvertLibass(
+    std::shared_ptr<COverlay> ConvertLibass(
         CDVDOverlayLibass* o,
         double pts,
         bool updateStyle,
@@ -175,7 +176,7 @@ namespace OVERLAY {
 
     CCriticalSection m_section;
     std::vector<SElement> m_buffers[NUM_BUFFERS];
-    std::map<unsigned int, COverlay*> m_textureCache;
+    std::map<unsigned int, std::shared_ptr<COverlay>> m_textureCache;
     static unsigned int m_textureid;
     CRect m_rv; // Frame size
     CRect m_rs; // Source size

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
@@ -200,29 +200,29 @@ COverlayImageDX::~COverlayImageDX()
 {
 }
 
-COverlayImageDX::COverlayImageDX(CDVDOverlayImage* o, CRect& rSource)
+COverlayImageDX::COverlayImageDX(const CDVDOverlayImage& o, CRect& rSource)
 {
-  if (o->palette.empty())
+  if (o.palette.empty())
   {
     m_pma = false;
-    uint32_t* rgba = reinterpret_cast<uint32_t*>(o->pixels.data());
-    Load(rgba, o->width, o->height, o->linesize);
+    const uint32_t* rgba = reinterpret_cast<const uint32_t*>(o.pixels.data());
+    Load(rgba, o.width, o.height, o.linesize);
   }
   else
   {
-    std::vector<uint32_t> rgba(o->width * o->height);
+    std::vector<uint32_t> rgba(o.width * o.height);
     m_pma = !!USE_PREMULTIPLIED_ALPHA;
     convert_rgba(o, m_pma, rgba);
-    Load(rgba.data(), o->width, o->height, o->width * 4);
+    Load(rgba.data(), o.width, o.height, o.width * 4);
   }
 
-  if (o->source_width > 0 && o->source_height > 0)
+  if (o.source_width > 0 && o.source_height > 0)
   {
     m_pos = POSITION_RELATIVE;
-    m_x = (0.5f * o->width + o->x) / o->source_width;
-    m_y = (0.5f * o->height + o->y) / o->source_height;
+    m_x = (0.5f * o.width + o.x) / o.source_width;
+    m_y = (0.5f * o.height + o.y) / o.source_height;
 
-    const float subRatio{static_cast<float>(o->source_width) / o->source_height};
+    const float subRatio{static_cast<float>(o.source_width) / o.source_height};
     const float vidRatio{rSource.Width() / rSource.Height()};
 
     // We always consider aligning 4/3 subtitles to the video,
@@ -231,8 +231,8 @@ COverlayImageDX::COverlayImageDX(CDVDOverlayImage* o, CRect& rSource)
     if (std::fabs(subRatio - vidRatio) < 0.001f || IsSquareResolution(subRatio))
     {
       m_align = ALIGN_VIDEO;
-      m_width = static_cast<float>(o->width) / o->source_width;
-      m_height = static_cast<float>(o->height) / o->source_height;
+      m_width = static_cast<float>(o.width) / o.source_width;
+      m_height = static_cast<float>(o.height) / o.source_height;
     }
     else
     {
@@ -240,40 +240,40 @@ COverlayImageDX::COverlayImageDX(CDVDOverlayImage* o, CRect& rSource)
       // Then we cannot align to video otherwise the subtitles will be deformed
       // better align to screen by keeping the aspect-ratio.
       m_align = ALIGN_SCREEN_AR;
-      m_width = static_cast<float>(o->width);
-      m_height = static_cast<float>(o->height);
-      m_source_width = static_cast<float>(o->source_width);
-      m_source_height = static_cast<float>(o->source_height);
+      m_width = static_cast<float>(o.width);
+      m_height = static_cast<float>(o.height);
+      m_source_width = static_cast<float>(o.source_width);
+      m_source_height = static_cast<float>(o.source_height);
     }
   }
   else
   {
     m_align = ALIGN_VIDEO;
     m_pos = POSITION_ABSOLUTE;
-    m_x = static_cast<float>(o->x);
-    m_y = static_cast<float>(o->y);
-    m_width = static_cast<float>(o->width);
-    m_height = static_cast<float>(o->height);
+    m_x = static_cast<float>(o.x);
+    m_y = static_cast<float>(o.y);
+    m_width = static_cast<float>(o.width);
+    m_height = static_cast<float>(o.height);
   }
 }
 
-COverlayImageDX::COverlayImageDX(CDVDOverlaySpu* o)
+COverlayImageDX::COverlayImageDX(const CDVDOverlaySpu& o)
 {
   int min_x, max_x, min_y, max_y;
-  std::vector<uint32_t> rgba(o->width * o->height);
+  std::vector<uint32_t> rgba(o.width * o.height);
 
   convert_rgba(o, USE_PREMULTIPLIED_ALPHA, min_x, max_x, min_y, max_y, rgba);
-  Load(rgba.data() + min_x + min_y * o->width, max_x - min_x, max_y - min_y, o->width * 4);
+  Load(rgba.data() + min_x + min_y * o.width, max_x - min_x, max_y - min_y, o.width * 4);
 
   m_align = ALIGN_VIDEO;
   m_pos = POSITION_ABSOLUTE;
-  m_x = static_cast<float>(min_x + o->x);
-  m_y = static_cast<float>(min_y + o->y);
+  m_x = static_cast<float>(min_x + o.x);
+  m_y = static_cast<float>(min_y + o.y);
   m_width = static_cast<float>(max_x - min_x);
   m_height = static_cast<float>(max_y - min_y);
 }
 
-void COverlayImageDX::Load(uint32_t* rgba, int width, int height, int stride)
+void COverlayImageDX::Load(const uint32_t* rgba, int width, int height, int stride)
 {
   float u, v;
   if(!LoadTexture(width

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.h
@@ -41,11 +41,11 @@ namespace OVERLAY {
      *  \param o The overlay image
      *  \param rSource The video source rect size
      */
-    explicit COverlayImageDX(CDVDOverlayImage* o, CRect& rSource);
-    explicit COverlayImageDX(CDVDOverlaySpu*   o);
+    explicit COverlayImageDX(const CDVDOverlayImage& o, CRect& rSource);
+    explicit COverlayImageDX(const CDVDOverlaySpu& o);
     virtual ~COverlayImageDX();
 
-    void Load(uint32_t* rgba, int width, int height, int stride);
+    void Load(const uint32_t* rgba, int width, int height, int stride);
     void Render(SRenderState& state);
 
     CD3DTexture            m_texture;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.h
@@ -28,8 +28,8 @@ namespace OVERLAY {
      *  \param o The overlay image
      *  \param rSource The video source rect size
      */
-    explicit COverlayTextureGL(CDVDOverlayImage* o, CRect& rSource);
-    explicit COverlayTextureGL(CDVDOverlaySpu* o);
+    explicit COverlayTextureGL(const CDVDOverlayImage& o, CRect& rSource);
+    explicit COverlayTextureGL(const CDVDOverlaySpu& o);
     ~COverlayTextureGL() override;
 
     void Render(SRenderState& state) override;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererUtil.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererUtil.h
@@ -36,8 +36,8 @@ struct SQuads
   std::vector<SQuad> quad;
 };
 
-void convert_rgba(CDVDOverlayImage* o, bool mergealpha, std::vector<uint32_t>& rgba);
-void convert_rgba(CDVDOverlaySpu* o,
+void convert_rgba(const CDVDOverlayImage& o, bool mergealpha, std::vector<uint32_t>& rgba);
+void convert_rgba(const CDVDOverlaySpu& o,
                   bool mergealpha,
                   int& min_x,
                   int& max_x,

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -1046,7 +1046,7 @@ bool CRenderManager::AddVideoPicture(const VideoPicture& picture, volatile std::
   return true;
 }
 
-void CRenderManager::AddOverlay(CDVDOverlay* o, double pts)
+void CRenderManager::AddOverlay(std::shared_ptr<CDVDOverlay> o, double pts)
 {
   int idx;
   {
@@ -1056,7 +1056,7 @@ void CRenderManager::AddOverlay(CDVDOverlay* o, double pts)
     idx = m_free.front();
   }
   std::unique_lock<CCriticalSection> lock(m_datalock);
-  m_overlays.AddOverlay(o, pts, idx);
+  m_overlays.AddOverlay(std::move(o), pts, idx);
 }
 
 bool CRenderManager::Supports(ERENDERFEATURE feature) const

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -96,7 +96,7 @@ public:
 
   bool Configure(const VideoPicture& picture, float fps, unsigned int orientation, int buffers = 0);
   bool AddVideoPicture(const VideoPicture& picture, volatile std::atomic_bool& bStop, EINTERLACEMETHOD deintMethod, bool wait);
-  void AddOverlay(CDVDOverlay* o, double pts);
+  void AddOverlay(std::shared_ptr<CDVDOverlay> o, double pts);
   void ShowVideo(bool enable);
 
   /**


### PR DESCRIPTION
## Description
Replace custom reference counting in `CDVDOverlay` and sub classes with `std::shared_ptr`. Also convert some function signatures to accept (const) references instead of pointers where nullptr wouldn't be allowed anyway.

## Motivation and context
A while ago I stumbled over this code and found the custom reference counting very old school and prone to errors by forgetting to call `Acquire()`/`Release()`.

## How has this been tested?
Tested some videos with subtitles. **I'm sure I didn't hit most of the code paths that way :disappointed:**. Tests were done with address + leak sanitizers, no memory errors detected.

## What is the effect on users?
None

## Screenshots (if appropriate):
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
