### PR TITLE
Improve Dolby Vision detection for Android

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -501,6 +501,16 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
       bool isDvhe = (m_hints.codec_tag == MKTAG('d', 'v', 'h', 'e'));
       bool isDvh1 = (m_hints.codec_tag == MKTAG('d', 'v', 'h', '1'));
 
+      // some files don't have dvhe or dvh1 tag set up but have Dolby Vision side data
+      if (!isDvhe && !isDvh1 && m_hints.hdrType == StreamHdrType::HDR_TYPE_DOLBYVISION)
+      {
+        // page 10, table 2 from https://professional.dolby.com/siteassets/content-creation/dolby-vision-for-content-creators/dolby-vision-streams-within-the-http-live-streaming-format-v2.0-13-november-2018.pdf
+        if (m_hints.codec_tag == MKTAG('h', 'v', 'c', '1'))
+          isDvh1 = true;
+        else
+          isDvhe = true;
+      }
+
       if (isDvhe || isDvh1)
       {
         bool displaySupportsDovi = CAndroidUtils::GetDisplayHDRCapabilities().SupportsDolbyVision();

--- a/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
@@ -56,6 +56,7 @@ void CDVDStreamInfo::Clear()
   ptsinvalid = false;
   forced_aspect = false;
   bitsperpixel = 0;
+  hdrType = StreamHdrType::HDR_TYPE_NONE;
   colorSpace = AVCOL_SPC_UNSPECIFIED;
   colorRange = AVCOL_RANGE_UNSPECIFIED;
   colorPrimaries = AVCOL_PRI_UNSPECIFIED;
@@ -106,6 +107,7 @@ bool CDVDStreamInfo::Equal(const CDVDStreamInfo& right, int compare)
   || bitsperpixel != right.bitsperpixel
   || bitdepth != right.bitdepth
   || vfr != right.vfr
+  || hdrType != right.hdrType
   || colorSpace != right.colorSpace
   || colorRange != right.colorRange
   || colorPrimaries != right.colorPrimaries
@@ -227,6 +229,7 @@ void CDVDStreamInfo::Assign(const CDVDStreamInfo& right, bool withextradata)
   bitdepth = right.bitdepth;
   vfr = right.vfr;
   codecOptions = right.codecOptions;
+  hdrType = right.hdrType;
   colorSpace = right.colorSpace;
   colorRange = right.colorRange;
   colorPrimaries = right.colorPrimaries;
@@ -296,6 +299,7 @@ void CDVDStreamInfo::Assign(const CDemuxStream& right, bool withextradata)
     orientation = stream->iOrientation;
     bitsperpixel = stream->iBitsPerPixel;
     bitdepth = stream->bitDepth;
+    hdrType = stream->hdr_type;
     colorSpace = stream->colorSpace;
     colorRange = stream->colorRange;
     colorPrimaries = stream->colorPrimaries;

--- a/xbmc/cores/VideoPlayer/DVDStreamInfo.h
+++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.h
@@ -68,6 +68,7 @@ public:
   int orientation; // orientation of the video in degrees counter clockwise
   int bitsperpixel;
   int bitdepth;
+  StreamHdrType hdrType;
   AVColorSpace colorSpace;
   AVColorRange colorRange;
   AVColorPrimaries colorPrimaries;


### PR DESCRIPTION
## Description
Improve Dolby Vision detection on Android devices.
Possibly fixes: https://github.com/xbmc/xbmc/issues/20740
Probably substitutes https://github.com/xbmc/xbmc/pull/22410

## Motivation and context
Some DV files are played as HDR or SDR instead of Dolby Vision. This PR is intended to fix this.

## How has this been tested?
I've tested this on Ugoos AM6 Plus (firmware 0.5.4) and LG C2 TV with the sample files from Kodi Samples 4k https://kodi.wiki/view/Samples:
```
24. http://media.developer.dolby.com/DolbyVision_Atmos/mp4/P81_GlassBlowing2_3840x2160%4059.94fps_15200kbps_fmp4.mp4
HDR format : Dolby Vision, Version 1.0, dvhe.08.09, BL+RPU, HDR10 compatible / SMPTE ST 2086, HDR10 compatible
Codec ID : hev1

13. https://drive.google.com/file/d/1cTRNwacsV-8J8PtcYNVDXBmGZF1SOynj/view?usp=sharing iPhone11_4K-recorder_59.940DV+HLG.mov
HDR format : Dolby Vision, Version 1.0, dvhe.08.12, BL+RPU, HLG compatible
Codec ID : hvc1

19. https://img.photographyblog.com/reviews/apple_iphone_13_pro/sample_images/4K60p.mov
HDR format : Dolby Vision, Version 1.0, dvhe.08.10, BL+RPU, HLG compatible
Codec ID : hvc1
```

Files should be played from the local drive, Kodi have some cache issues when playing them from http storage because they are small, other big DV files play normally from remote storage.

It should also help with these files but those are DV FEL and have freeze issues even if they are detected as DV on TV.
```
21. https://drive.google.com/file/d/0BwxFVkl63-lEWmNWcGl4eVRWS2M/view?usp=sharing&resourcekey=0-WkmICjhK5yus4EAaPuSuSw LG Demo DolbyVision Trailer.mkv
HDR format : Dolby Vision, Version 1.0, dvhe.04.06, BL+EL+RPU
Codec ID : 36

20. https://drive.google.com/file/d/0BwxFVkl63-lEc3k0aldZaGtaVm8/view?resourcekey=0-ECypkFcgdKx1YiojpUCWBA LG Demo DolbyVision Comparison.mkv
HDR format : Dolby Vision, Version 1.0, dvhe.04.06, BL+EL+RPU
Codec ID : 36
```

## What is the effect on users?
The end user will be able to watch more Dolby Vision files in DV format on Android.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
