### PR TITLE
StringUtils: fix sorting by name with ascii punctuation and symbols o…

### DIFF
--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1135,7 +1135,7 @@ int64_t StringUtils::AlphaNumericCompare(const wchar_t* left, const wchar_t* rig
     if (lsym && rsym)
     {
       if (lc != rc)
-        return lc - rc;
+        return static_cast<int64_t>(lc) - static_cast<int64_t>(rc);
       else
       { // Same symbol advance to next wchar
         l++;
@@ -1312,7 +1312,7 @@ int StringUtils::AlphaNumericCollation(int nKey1, const void* pKey1, int nKey2, 
     if (lsym && rsym)
     {
       if (zA[i] != zB[j])
-        return zA[i] - zB[j];
+        return static_cast<int>(zA[i]) - static_cast<int>(zB[j]);
       else
       { // Same symbol advance to next
         i++;
@@ -1345,7 +1345,7 @@ int StringUtils::AlphaNumericCollation(int nKey1, const void* pKey1, int nKey2, 
     {
       if (!g_langInfo.UseLocaleCollation() || (lc <= 128 && rc <= 128))
         // Compare unicode (having applied accent folding collation to non-ascii chars).
-        return lc - rc;
+        return static_cast<int>(lc) - static_cast<int>(rc);
       else
       {
         // Fetch collation facet from locale to do comparison of wide char although on some


### PR DESCRIPTION
…n 32-bit ARM

## Description
After PR https://github.com/xbmc/xbmc/pull/17838 sorting by name is partially broken on 32-bit ARM when comparing ascii punctuation and symbols. The problem occur here https://github.com/xbmc/xbmc/blob/7523e8d04c1c6c219535035e928840bcb48df386/xbmc/utils/StringUtils.cpp#L1137-L1138
Looks like converting subtracted value from wchar_t to int64_t doesn't work on 32-bit ARM and it returns wrong value (negative as positive). That's why for example selecting sort descending and then sort ascending gives different results on first call and on second.

I'm not sure but maybe using `wcsncmp()` would be better solution? But I think calling such heavy function is not needed in this case because both values are plain char with value <128 .

```
@@ -1083,7 +1083,11 @@ int64_t StringUtils::AlphaNumericCompare
     if (lsym && rsym)
     {
       if (lc != rc)
-        return lc - rc;
+      {
+        // Compare unicode (having applied accent folding collation to non-ascii chars).
+        int i = wcsncmp(&lc, &rc, 1);
+        return i;
+      }
       else
       { // Same symbol advance to next wchar
         l++; 
```

Or using `compareWchar()` function

```
@@ -1082,8 +1082,9 @@ int64_t StringUtils::AlphaNumericCompare
       return 1;
     if (lsym && rsym)
     {
-      if (lc != rc)
-        return lc - rc;
+      int i = compareWchar(&lc, &rc);
+      if (i != 0)
+        return i;
       else
       { // Same symbol advance to next wchar
         l++; 

```

## Motivation and context
Fixes
issue https://github.com/xbmc/xbmc/issues/22373
forum discussion https://discourse.coreelec.org/t/sorting-the-movie-library-alphabetically-incorrect/19914

## How has this been tested?
Sorting 5 files in a folder as video source:
```
'CE 1.mkv'
'CE 2.mkv'
'CE.mkv'
'CE_1.mkv'
'CE_2.mkv'
```
on 3 devices with
CoreELEC-Amlogic-ng.arm-19.5-Matrix
LibreELEC-RK3399.arm-10.88.0-rockpro64
LibreELEC-Generic.x86_64-10.0-nightly

## What is the effect on users?
Having correctly sorted files by name in predictive order.

## Screenshots (if appropriate):
![screenshot00000](https://user-images.githubusercontent.com/1016324/211367112-3e3a3468-24a5-41af-a39e-11e810341b00.png)
![screenshot00001](https://user-images.githubusercontent.com/1016324/211367132-cf8c6c1b-1e90-4376-9ed0-12633b6688e1.png)
![screenshot00002](https://user-images.githubusercontent.com/1016324/211367150-50a64258-c8a6-4446-ac0a-181e795d0493.png)

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
