### PR TITLE
[Android] Replace Resources.getDrawableForDensity method

### DIFF
--- a/xbmc/platform/android/filesystem/AndroidAppFile.cpp
+++ b/xbmc/platform/android/filesystem/AndroidAppFile.cpp
@@ -112,7 +112,7 @@ unsigned int CFileAndroidApp::ReadIcon(unsigned char** lpBuf, unsigned int* widt
       for (int i=0; densities[i] != -1 && !bmp; ++i)
       {
         int density = densities[i];
-        CJNIDrawable drw = res.getDrawableForDensity(m_icon, density);
+        CJNIDrawable drw = res.getDrawableForDensity(m_icon, density, CJNIContext::getTheme());
         if (xbmc_jnienv()->ExceptionCheck())
           xbmc_jnienv()->ExceptionClear();
         else if (!drw);


### PR DESCRIPTION
## Description
Replace `getDrawableForDensity(int id, int density)` method deprecated in API level 22, use instead `getDrawableForDensity(int id, int density, Resources.Theme theme)` available since level 21.

Depends on xbmc/libandroidjni#41

## How has this been tested?
Tested on Android TV 12

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
