### PR TITLE
Fix crash on X11 when WAYLAND_DISPLAY is set

### DIFF
--- a/xbmc/windowing/wayland/Connection.cpp
+++ b/xbmc/windowing/wayland/Connection.cpp
@@ -8,13 +8,28 @@
 
 #include "Connection.h"
 
+#include "utils/log.h"
+
 #include <cassert>
+#include <stdexcept>
 
 using namespace KODI::WINDOWING::WAYLAND;
 
 CConnection::CConnection()
 {
-  m_display.reset(new wayland::display_t);
+  try
+  {
+    m_display = std::make_unique<wayland::display_t>();
+  }
+  catch (const std::exception& err)
+  {
+    CLog::Log(LOGERROR, "Wayland connection error: {}", err.what());
+  }
+}
+
+bool CConnection::HasDisplay() const
+{
+  return static_cast<bool>(m_display);
 }
 
 wayland::display_t& CConnection::GetDisplay()

--- a/xbmc/windowing/wayland/Connection.h
+++ b/xbmc/windowing/wayland/Connection.h
@@ -27,6 +27,7 @@ class CConnection
 public:
   CConnection();
 
+  bool HasDisplay() const;
   wayland::display_t& GetDisplay();
 
 private:

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -158,11 +158,14 @@ bool CWinSystemWayland::InitWindowSystem()
   wayland::set_log_handler([](const std::string& message)
                            { CLog::Log(LOGWARNING, "wayland-client log message: {}", message); });
 
+  CLog::LogF(LOGINFO, "Connecting to Wayland server");
+  m_connection = std::make_unique<CConnection>();
+  if (!m_connection->HasDisplay())
+    return false;
+
   VIDEOPLAYER::CProcessInfoWayland::Register();
   RETRO::CRPProcessInfoWayland::Register();
 
-  CLog::LogF(LOGINFO, "Connecting to Wayland server");
-  m_connection.reset(new CConnection);
   m_registry.reset(new CRegistry{*m_connection});
 
   m_registry->RequestSingleton(m_compositor, 1, 4);


### PR DESCRIPTION
## Description

As title says, this PR fixes a crash when running on X11 and the `WAYLAND_DISPLAY` variable is set. My use case is my smarthome apartment, where I use the same systemd file to launch Kodi instances on a large mix of X11 and Wayland systems.

The systemd file has the following environment variables set to support launching on both X11 and Wayland:

```
#
# Kodi configuration
#

Environment=DISPLAY=:0
Environment=WAYLAND_DISPLAY=wayland-0
```

When launching on X11, Kodi sees the `WAYLAND_DISPLAY` variable and attempts to connect to Wayland, but doesn't catch the resulting exception and causes an abort.

To fix this, we simply handle the error.

## Motivation and context

Required for https://github.com/xbmc/xbmc/pull/21183

## How has this been tested?

Before, launching Kodi on X11 with the above systemd configuration:

```
2023-01-09 15:30:30.630 T:105667   debug <general>: CApplication::CreateGUI - trying to init wayland windowing system
2023-01-09 15:30:30.649 T:105667    info <general>: InitWindowSystem: Connecting to Wayland server
(abort due to unhandled exception)
```

After:

```
2023-01-09 15:30:30.630 T:105667   debug <general>: CApplication::CreateGUI - trying to init wayland windowing system
2023-01-09 15:30:30.649 T:105667    info <general>: InitWindowSystem: Connecting to Wayland server
2023-01-09 15:30:30.649 T:105667   debug <general>: Wayland connection error: Could not connect to Wayland display server via name
2023-01-09 15:30:30.649 T:105667   debug <general>: CApplication::CreateGUI - unable to init wayland windowing system
2023-01-09 15:30:30.649 T:105667   debug <general>: CApplication::CreateGUI - trying to init x11 windowing system
...
2023-01-09 15:30:30.701 T:105667    info <general>: CApplication::CreateGUI - using the x11 windowing system
```

## What is the effect on users?

* Fix crash on X11 when WAYLAND_DISPLAY is set

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
