### PR TITLE
[MUSIC] Fix missing space in sql select statement

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -5568,7 +5568,7 @@ bool CMusicDatabase::GetAlbumFromSong(int idSong, CAlbum& album)
     if (nullptr == m_pDS)
       return false;
 
-    std::string strSQL = PrepareSQL("SELECT albumview.* FROM song"
+    std::string strSQL = PrepareSQL("SELECT albumview.* FROM song "
                                     "JOIN albumview on song.idAlbum = albumview.idAlbum "
                                     "WHERE song.idSong='%i'",
                                     idSong);


### PR DESCRIPTION
## Description
Fixes an sql query issue

## Motivation and context
This issue was reported on the forum -> https://forum.kodi.tv/showthread.php?tid=370889

## How has this been tested?
Not tested, but it's pretty clear from the error message that the space between the word `song` and the word `JOIN` is missing.

## What is the effect on users?
Apart from fixing the error message, it means that the musicinfoloader can load the album details using the song id if the album id is unknown at that point.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
