### PR TITLE
Addons avoid incorrect error message

### DIFF
--- a/xbmc/addons/addoninfo/AddonInfo.cpp
+++ b/xbmc/addons/addoninfo/AddonInfo.cpp
@@ -283,11 +283,17 @@ std::vector<AddonInstanceId> CAddonInfo::GetKnownInstanceIds() const
   if (!m_supportsInstanceSettings)
     return singletonInstance;
 
+  std::vector<AddonInstanceId> ret;
+
+  if (!XFILE::CDirectory::Exists(StringUtils::Format("special://profile/addon_data/{}/", m_id)))
+  {
+    ret.emplace_back(ADDON_FIRST_INSTANCE_ID);
+    return ret;
+  }
+
   const std::string searchPath = StringUtils::Format("special://profile/addon_data/{}/", m_id);
   CFileItemList items;
   XFILE::CDirectory::GetDirectory(searchPath, items, ".xml", XFILE::DIR_FLAG_NO_FILE_DIRS);
-
-  std::vector<AddonInstanceId> ret;
 
   for (const auto& item : items)
   {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
With a multi-instance plugin incorrect error messages are logged if the addon has not been setup.
<!--- Describe your change in detail here. -->

Normally in a typical single profile scenario Kodi multi-instance addons create the userdata settings directory when it is installed.  When multiple profiles are in use the settings directory is not created unless the addon is enabled for that profile.  There is no requirement to enable all addons.

This PR adds a return if the settings directory has not been created before checking for instance  configuration.  The return is the same as on failure.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It is a low priority, but this is not an error, addons don't need to be enabled in all profiles.

This error is generated in the logs

```
2023-01-11 13:04:15.950 T:7616    debug <general>: Thread PVRGUIProgressHandler start, auto delete: false
2023-01-11 13:04:15.956 T:20468   error <general>: XFILE::CDirectory::GetDirectory - Error getting C:\workspace\nexus-build\portable_data\userdata\profiles\Martin\addon_data\pvr.hts\
2023-01-11 13:04:15.956 T:20468   error <general>: XFILE::CDirectory::GetDirectory - Error getting special://profile/addon_data/pvr.hts/

```

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with pvr.hts and pvr.nextpvr installed in the master profile.  Create a new profile without enabling the addon to see the error messages.

Testing as been limited but because the return is the same it should be low risk.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
