### PR TITLE
[addons] fix compile issue w/ KODI_ADDON_INSTANCE_INFO

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
@@ -251,7 +251,7 @@ extern "C"
 
   typedef int KODI_ADDON_INSTANCE_TYPE;
 
-  struct KODI_ADDON_INSTANCE_INFO
+  typedef struct KODI_ADDON_INSTANCE_INFO
   {
     KODI_ADDON_INSTANCE_TYPE type;
     uint32_t number;
@@ -262,7 +262,7 @@ extern "C"
     bool first_instance;
 
     struct KODI_ADDON_INSTANCE_FUNC_CB* functions;
-  };
+  } KODI_ADDON_INSTANCE_INFO;
 
   typedef struct KODI_ADDON_INSTANCE_STRUCT
   {


### PR DESCRIPTION
## Description

Compiling my pvr binary add-on for Nexus, I see this error:

```
include/kodi/c-api/addon_base.h:269:11: error: must use 'struct' tag to refer to type 'KODI_ADDON_INSTANCE_INFO'
    const KODI_ADDON_INSTANCE_INFO* info;
```

## Motivation and context

Fix build failure.

My build environment is macOS:

```
Apple clang version 13.1.6 (clang-1316.0.21.2.5)
Target: x86_64-apple-darwin21.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

## How has this been tested?

Compile test passed.

## What is the effect on users?

No affect on users, addon dev only.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
