### PR TITLE
[addons] fix compile issue w/ KODI_ADDON_INSTANCE_INFO

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
@@ -251,7 +251,7 @@ extern "C"
 
   typedef int KODI_ADDON_INSTANCE_TYPE;
 
-  struct KODI_ADDON_INSTANCE_INFO
+  typedef struct KODI_ADDON_INSTANCE_INFO
   {
     KODI_ADDON_INSTANCE_TYPE type;
     uint32_t number;
@@ -262,7 +262,7 @@ extern "C"
     bool first_instance;
 
     struct KODI_ADDON_INSTANCE_FUNC_CB* functions;
-  };
+  } KODI_ADDON_INSTANCE_INFO;
 
   typedef struct KODI_ADDON_INSTANCE_STRUCT
   {


### PR DESCRIPTION
same as https://github.com/xbmc/xbmc/pull/22438 but against master. sorry i opened backport version first