### PR TITLE
Pipewire heirarchy rework

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -13,6 +13,7 @@
 #include "cores/AudioEngine/Sinks/pipewire/Pipewire.h"
 #include "cores/AudioEngine/Sinks/pipewire/PipewireCore.h"
 #include "cores/AudioEngine/Sinks/pipewire/PipewireNode.h"
+#include "cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h"
 #include "cores/AudioEngine/Sinks/pipewire/PipewireStream.h"
 #include "cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.h"
 #include "utils/Map.h"
@@ -241,7 +242,8 @@ void CAESinkPipewire::EnumerateDevicesEx(AEDeviceInfoList& list, bool force)
 
   list.emplace_back(defaultDevice);
 
-  for (const auto& global : pipewire->GetGlobals())
+  auto registry = pipewire->GetRegistry();
+  for (const auto& global : registry->GetGlobals())
   {
     CAEDeviceInfo device;
     device.m_deviceType = AE_DEVTYPE_PCM;
@@ -300,7 +302,8 @@ bool CAESinkPipewire::Initialize(AEAudioFormat& format, std::string& device)
 
   loop->Lock();
 
-  auto& globals = pipewire->GetGlobals();
+  auto registry = pipewire->GetRegistry();
+  auto& globals = registry->GetGlobals();
 
   uint32_t id;
   if (device == "Default")

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -323,7 +323,7 @@ bool CAESinkPipewire::Initialize(AEAudioFormat& format, std::string& device)
     id = target->first;
   }
 
-  stream = std::make_shared<PIPEWIRE::CPipewireStream>(core->Get());
+  stream = std::make_shared<PIPEWIRE::CPipewireStream>(*core);
 
   stream->AddListener(pipewire.get());
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -325,7 +325,7 @@ bool CAESinkPipewire::Initialize(AEAudioFormat& format, std::string& device)
 
   stream = std::make_shared<PIPEWIRE::CPipewireStream>(*core);
 
-  stream->AddListener(pipewire.get());
+  stream->AddListener();
 
   m_latency = 20; // ms
   uint32_t frames = std::nearbyint((m_latency * format.m_sampleRate) / 1000.0);

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
@@ -62,7 +62,7 @@ bool CPipewire::Start()
   }
 
   m_core = std::make_unique<CPipewireCore>(*m_context);
-  m_core->AddListener(this);
+  m_core->AddListener();
 
   m_registry = std::make_unique<CPipewireRegistry>(m_core->Get());
   m_registry->AddListener(this);

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
@@ -64,7 +64,7 @@ bool CPipewire::Start()
   m_core = std::make_unique<CPipewireCore>(*m_context);
   m_core->AddListener();
 
-  m_registry = std::make_unique<CPipewireRegistry>(m_core->Get());
+  m_registry = std::make_unique<CPipewireRegistry>(*m_core);
   m_registry->AddListener(this);
 
   m_core->Sync();

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
@@ -51,7 +51,7 @@ bool CPipewire::Start()
 {
   m_loop = std::make_unique<CPipewireThreadLoop>();
 
-  m_context = std::make_unique<CPipewireContext>(m_loop->Get());
+  m_context = std::make_unique<CPipewireContext>(*m_loop);
 
   m_loop->Lock();
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
@@ -65,7 +65,7 @@ bool CPipewire::Start()
   m_core->AddListener();
 
   m_registry = std::make_unique<CPipewireRegistry>(*m_core);
-  m_registry->AddListener(this);
+  m_registry->AddListener();
 
   m_core->Sync();
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
@@ -61,7 +61,7 @@ bool CPipewire::Start()
     return false;
   }
 
-  m_core = std::make_unique<CPipewireCore>(m_context->Get());
+  m_core = std::make_unique<CPipewireCore>(*m_context);
   m_core->AddListener(this);
 
   m_registry = std::make_unique<CPipewireRegistry>(m_core->Get());

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.h
@@ -8,13 +8,7 @@
 
 #pragma once
 
-#include "cores/AudioEngine/Sinks/pipewire/PipewireProxy.h"
-
-#include <map>
 #include <memory>
-#include <string>
-
-#include <pipewire/properties.h>
 
 namespace AE
 {
@@ -43,28 +37,7 @@ public:
   CPipewireRegistry* GetRegistry() { return m_registry.get(); }
   std::shared_ptr<CPipewireStream>& GetStream() { return m_stream; }
 
-  struct PipewirePropertiesDeleter
-  {
-    void operator()(pw_properties* p) { pw_properties_free(p); }
-  };
-
-  struct global
-  {
-    std::string name;
-    std::string description;
-    uint32_t id;
-    uint32_t permissions;
-    std::string type;
-    uint32_t version;
-    std::unique_ptr<pw_properties, PipewirePropertiesDeleter> properties;
-    std::unique_ptr<CPipewireProxy> proxy;
-  };
-
-  std::map<uint32_t, std::unique_ptr<global>>& GetGlobals() { return m_globals; }
-
 private:
-  std::map<uint32_t, std::unique_ptr<global>> m_globals;
-
   std::unique_ptr<CPipewireThreadLoop> m_loop;
   std::unique_ptr<CPipewireContext> m_context;
   std::unique_ptr<CPipewireCore> m_core;

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireContext.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireContext.cpp
@@ -8,6 +8,7 @@
 
 #include "PipewireContext.h"
 
+#include "cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.h"
 #include "utils/log.h"
 
 #include <stdexcept>
@@ -19,9 +20,9 @@ namespace SINK
 namespace PIPEWIRE
 {
 
-CPipewireContext::CPipewireContext(pw_loop* loop)
+CPipewireContext::CPipewireContext(CPipewireThreadLoop& loop) : m_threadLoop(loop)
 {
-  m_context.reset(pw_context_new(loop, nullptr, 0));
+  m_context.reset(pw_context_new(loop.Get(), nullptr, 0));
   if (!m_context)
   {
     CLog::Log(LOGERROR, "CPipewireContext: failed to create context: {}", strerror(errno));

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireContext.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireContext.h
@@ -19,16 +19,22 @@ namespace SINK
 namespace PIPEWIRE
 {
 
+class CPipewireThreadLoop;
+
 class CPipewireContext
 {
 public:
-  explicit CPipewireContext(pw_loop* loop);
+  explicit CPipewireContext(CPipewireThreadLoop& loop);
   CPipewireContext() = delete;
   ~CPipewireContext() = default;
 
   pw_context* Get() const { return m_context.get(); }
 
+  CPipewireThreadLoop& GetThreadLoop() const { return m_threadLoop; }
+
 private:
+  CPipewireThreadLoop& m_threadLoop;
+
   struct PipewireContextDeleter
   {
     void operator()(pw_context* p) { pw_context_destroy(p); }

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireCore.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireCore.cpp
@@ -8,7 +8,6 @@
 
 #include "PipewireCore.h"
 
-#include "cores/AudioEngine/Sinks/pipewire/Pipewire.h"
 #include "cores/AudioEngine/Sinks/pipewire/PipewireContext.h"
 #include "cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.h"
 #include "utils/log.h"
@@ -38,9 +37,9 @@ CPipewireCore::~CPipewireCore()
   spa_hook_remove(&m_coreListener);
 }
 
-void CPipewireCore::AddListener(void* userdata)
+void CPipewireCore::AddListener()
 {
-  pw_core_add_listener(m_core.get(), &m_coreListener, &m_coreEvents, userdata);
+  pw_core_add_listener(m_core.get(), &m_coreListener, &m_coreEvents, this);
 }
 
 void CPipewireCore::Sync()
@@ -50,9 +49,8 @@ void CPipewireCore::Sync()
 
 void CPipewireCore::OnCoreDone(void* userdata, uint32_t id, int seq)
 {
-  auto pipewire = reinterpret_cast<CPipewire*>(userdata);
-  auto core = pipewire->GetCore();
-  auto loop = pipewire->GetThreadLoop();
+  auto core = reinterpret_cast<CPipewireCore*>(userdata);
+  auto loop = &core->GetContext().GetThreadLoop();
 
   if (core->GetSync() == seq)
     loop->Signal(false);

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireCore.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireCore.cpp
@@ -9,6 +9,7 @@
 #include "PipewireCore.h"
 
 #include "cores/AudioEngine/Sinks/pipewire/Pipewire.h"
+#include "cores/AudioEngine/Sinks/pipewire/PipewireContext.h"
 #include "cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.h"
 #include "utils/log.h"
 
@@ -21,9 +22,10 @@ namespace SINK
 namespace PIPEWIRE
 {
 
-CPipewireCore::CPipewireCore(pw_context* context) : m_coreEvents(CreateCoreEvents())
+CPipewireCore::CPipewireCore(CPipewireContext& context)
+  : m_context(context), m_coreEvents(CreateCoreEvents())
 {
-  m_core.reset(pw_context_connect(context, nullptr, 0));
+  m_core.reset(pw_context_connect(context.Get(), nullptr, 0));
   if (!m_core)
   {
     CLog::Log(LOGERROR, "CPipewireCore: failed to create core: {}", strerror(errno));

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireCore.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireCore.h
@@ -32,7 +32,7 @@ public:
 
   CPipewireContext& GetContext() const { return m_context; }
 
-  void AddListener(void* userdata);
+  void AddListener();
 
   void Sync();
   int GetSync() const { return m_sync; }

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireCore.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireCore.h
@@ -19,16 +19,21 @@ namespace SINK
 namespace PIPEWIRE
 {
 
+class CPipewireContext;
+
 class CPipewireCore
 {
 public:
-  explicit CPipewireCore(pw_context* context);
+  explicit CPipewireCore(CPipewireContext& context);
   CPipewireCore() = delete;
   ~CPipewireCore();
 
   pw_core* Get() const { return m_core.get(); }
 
+  CPipewireContext& GetContext() const { return m_context; }
+
   void AddListener(void* userdata);
+
   void Sync();
   int GetSync() const { return m_sync; }
 
@@ -36,6 +41,8 @@ private:
   static void OnCoreDone(void* userdata, uint32_t id, int seq);
 
   static pw_core_events CreateCoreEvents();
+
+  CPipewireContext& m_context;
 
   const pw_core_events m_coreEvents;
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
@@ -8,7 +8,8 @@
 
 #include "PipewireNode.h"
 
-#include "cores/AudioEngine/Sinks/pipewire/Pipewire.h"
+#include "cores/AudioEngine/Sinks/pipewire/PipewireContext.h"
+#include "cores/AudioEngine/Sinks/pipewire/PipewireCore.h"
 #include "cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h"
 #include "cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.h"
 #include "utils/StringUtils.h"
@@ -34,13 +35,11 @@ CPipewireNode::~CPipewireNode()
   spa_hook_remove(&m_objectListener);
 }
 
-void CPipewireNode::AddListener(void* userdata)
+void CPipewireNode::AddListener()
 {
-  m_pipewire = reinterpret_cast<CPipewire*>(userdata);
-
   pw_proxy_add_object_listener(m_proxy.get(), &m_objectListener, &m_nodeEvents, this);
 
-  CPipewireProxy::AddListener(userdata);
+  CPipewireProxy::AddListener();
 }
 
 void CPipewireNode::EnumerateFormats()
@@ -186,8 +185,7 @@ void CPipewireNode::Param(void* userdata,
                           const struct spa_pod* param)
 {
   auto node = reinterpret_cast<CPipewireNode*>(userdata);
-  auto pipewire = node->GetPipewire();
-  auto loop = pipewire->GetThreadLoop();
+  auto loop = &node->GetRegistry().GetCore().GetContext().GetThreadLoop();
 
   node->Parse(SPA_POD_TYPE(param), SPA_POD_BODY(param), SPA_POD_BODY_SIZE(param));
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
@@ -9,6 +9,7 @@
 #include "PipewireNode.h"
 
 #include "cores/AudioEngine/Sinks/pipewire/Pipewire.h"
+#include "cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h"
 #include "cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
@@ -23,7 +24,7 @@ namespace SINK
 namespace PIPEWIRE
 {
 
-CPipewireNode::CPipewireNode(pw_registry* registry, uint32_t id, const char* type)
+CPipewireNode::CPipewireNode(CPipewireRegistry& registry, uint32_t id, const char* type)
   : CPipewireProxy(registry, id, type, PW_VERSION_NODE), m_nodeEvents(CreateNodeEvents())
 {
 }

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.h
@@ -24,11 +24,12 @@ namespace PIPEWIRE
 {
 
 class CPipewire;
+class CPipewireRegistry;
 
 class CPipewireNode : public CPipewireProxy
 {
 public:
-  explicit CPipewireNode(pw_registry* registry, uint32_t id, const char* type);
+  explicit CPipewireNode(CPipewireRegistry& registry, uint32_t id, const char* type);
   CPipewireNode() = delete;
   ~CPipewireNode() override;
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.h
@@ -33,7 +33,7 @@ public:
   CPipewireNode() = delete;
   ~CPipewireNode() override;
 
-  void AddListener(void* userdata) override;
+  void AddListener() override;
 
   void EnumerateFormats();
 
@@ -42,8 +42,6 @@ public:
   std::set<spa_audio_format>& GetFormats() { return m_formats; }
   std::set<spa_audio_channel>& GetChannels() { return m_channels; }
   std::set<uint32_t>& GetRates() { return m_rates; }
-
-  CPipewire* GetPipewire() { return m_pipewire; }
 
 private:
   void Parse(uint32_t type, void* body, uint32_t size);
@@ -72,8 +70,6 @@ private:
   std::set<spa_audio_format> m_formats;
   std::set<spa_audio_channel> m_channels;
   std::set<uint32_t> m_rates;
-
-  CPipewire* m_pipewire;
 };
 
 } // namespace PIPEWIRE

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireProxy.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireProxy.cpp
@@ -10,6 +10,7 @@
 
 #include "ServiceBroker.h"
 #include "cores/AudioEngine/Interfaces/AE.h"
+#include "cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h"
 #include "utils/log.h"
 
 #include <stdexcept>
@@ -21,13 +22,14 @@ namespace SINK
 namespace PIPEWIRE
 {
 
-CPipewireProxy::CPipewireProxy(pw_registry* registry,
+CPipewireProxy::CPipewireProxy(CPipewireRegistry& registry,
                                uint32_t id,
                                const char* type,
                                uint32_t version)
-  : m_proxyEvents(CreateProxyEvents())
+  : m_registry(registry), m_proxyEvents(CreateProxyEvents())
 {
-  m_proxy.reset(reinterpret_cast<pw_proxy*>(pw_registry_bind(registry, id, type, version, 0)));
+  m_proxy.reset(
+      reinterpret_cast<pw_proxy*>(pw_registry_bind(registry.Get(), id, type, version, 0)));
   if (!m_proxy)
   {
     CLog::Log(LOGERROR, "CPipewireProxy: failed to create proxy: {}", strerror(errno));

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireProxy.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireProxy.cpp
@@ -42,9 +42,9 @@ CPipewireProxy::~CPipewireProxy()
   spa_hook_remove(&m_proxyListener);
 }
 
-void CPipewireProxy::AddListener(void* userdata)
+void CPipewireProxy::AddListener()
 {
-  pw_proxy_add_listener(m_proxy.get(), &m_proxyListener, &m_proxyEvents, nullptr);
+  pw_proxy_add_listener(m_proxy.get(), &m_proxyListener, &m_proxyEvents, this);
 }
 
 void CPipewireProxy::Bound(void* userdata, uint32_t id)

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireProxy.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireProxy.h
@@ -27,7 +27,7 @@ public:
   CPipewireProxy() = delete;
   virtual ~CPipewireProxy();
 
-  virtual void AddListener(void* userdata);
+  virtual void AddListener();
 
   CPipewireRegistry& GetRegistry() const { return m_registry; }
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireProxy.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireProxy.h
@@ -19,6 +19,8 @@ namespace SINK
 namespace PIPEWIRE
 {
 
+class CPipewireRegistry;
+
 class CPipewireProxy
 {
 public:
@@ -27,8 +29,13 @@ public:
 
   virtual void AddListener(void* userdata);
 
+  CPipewireRegistry& GetRegistry() const { return m_registry; }
+
 protected:
-  explicit CPipewireProxy(pw_registry* registry, uint32_t id, const char* type, uint32_t version);
+  explicit CPipewireProxy(CPipewireRegistry& registry,
+                          uint32_t id,
+                          const char* type,
+                          uint32_t version);
 
   struct PipewireProxyDeleter
   {
@@ -42,6 +49,8 @@ private:
   static void Removed(void* userdata);
 
   static pw_proxy_events CreateProxyEvents();
+
+  CPipewireRegistry& m_registry;
 
   const pw_proxy_events m_proxyEvents;
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
@@ -77,7 +77,7 @@ void CPipewireRegistry::OnGlobalAdded(void* userdata,
     globals[id]->type = std::string(type);
     globals[id]->version = version;
     globals[id]->properties.reset(pw_properties_new_dict(props));
-    globals[id]->proxy = std::make_unique<CPipewireNode>(registry->Get(), id, type);
+    globals[id]->proxy = std::make_unique<CPipewireNode>(*registry, id, type);
     globals[id]->proxy->AddListener(userdata);
   }
 }

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
@@ -78,7 +78,7 @@ void CPipewireRegistry::OnGlobalAdded(void* userdata,
     globals[id]->version = version;
     globals[id]->properties.reset(pw_properties_new_dict(props));
     globals[id]->proxy = std::make_unique<CPipewireNode>(*registry, id, type);
-    globals[id]->proxy->AddListener(userdata);
+    globals[id]->proxy->AddListener();
   }
 }
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
@@ -48,6 +48,7 @@ void CPipewireRegistry::OnGlobalAdded(void* userdata,
                                       const struct spa_dict* props)
 {
   auto pipewire = reinterpret_cast<CPipewire*>(userdata);
+  auto registry = pipewire->GetRegistry();
 
   if (strcmp(type, PW_TYPE_INTERFACE_Node) == 0)
   {
@@ -66,9 +67,9 @@ void CPipewireRegistry::OnGlobalAdded(void* userdata,
     if (!desc)
       return;
 
-    auto& globals = pipewire->GetGlobals();
+    auto& globals = registry->GetGlobals();
 
-    globals[id] = std::make_unique<CPipewire::global>();
+    globals[id] = std::make_unique<global>();
     globals[id]->name = std::string(name);
     globals[id]->description = std::string(desc);
     globals[id]->id = id;
@@ -76,7 +77,7 @@ void CPipewireRegistry::OnGlobalAdded(void* userdata,
     globals[id]->type = std::string(type);
     globals[id]->version = version;
     globals[id]->properties.reset(pw_properties_new_dict(props));
-    globals[id]->proxy = std::make_unique<CPipewireNode>(pipewire->GetRegistry()->Get(), id, type);
+    globals[id]->proxy = std::make_unique<CPipewireNode>(registry->Get(), id, type);
     globals[id]->proxy->AddListener(userdata);
   }
 }
@@ -84,7 +85,8 @@ void CPipewireRegistry::OnGlobalAdded(void* userdata,
 void CPipewireRegistry::OnGlobalRemoved(void* userdata, uint32_t id)
 {
   auto pipewire = reinterpret_cast<CPipewire*>(userdata);
-  auto& globals = pipewire->GetGlobals();
+  auto registry = pipewire->GetRegistry();
+  auto& globals = registry->GetGlobals();
 
   auto global = globals.find(id);
   if (global != globals.end())

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
@@ -9,6 +9,7 @@
 #include "PipewireRegistry.h"
 
 #include "cores/AudioEngine/Sinks/pipewire/Pipewire.h"
+#include "cores/AudioEngine/Sinks/pipewire/PipewireCore.h"
 #include "cores/AudioEngine/Sinks/pipewire/PipewireNode.h"
 #include "utils/log.h"
 
@@ -25,9 +26,10 @@ namespace SINK
 namespace PIPEWIRE
 {
 
-CPipewireRegistry::CPipewireRegistry(pw_core* core) : m_registryEvents(CreateRegistryEvents())
+CPipewireRegistry::CPipewireRegistry(CPipewireCore& core)
+  : m_core(core), m_registryEvents(CreateRegistryEvents())
 {
-  m_registry.reset(pw_core_get_registry(core, PW_VERSION_REGISTRY, 0));
+  m_registry.reset(pw_core_get_registry(core.Get(), PW_VERSION_REGISTRY, 0));
   if (!m_registry)
   {
     CLog::Log(LOGERROR, "CPipewireRegistry: failed to create registry: {}", strerror(errno));

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
@@ -8,7 +8,6 @@
 
 #include "PipewireRegistry.h"
 
-#include "cores/AudioEngine/Sinks/pipewire/Pipewire.h"
 #include "cores/AudioEngine/Sinks/pipewire/PipewireCore.h"
 #include "cores/AudioEngine/Sinks/pipewire/PipewireNode.h"
 #include "utils/log.h"
@@ -37,9 +36,9 @@ CPipewireRegistry::CPipewireRegistry(CPipewireCore& core)
   }
 }
 
-void CPipewireRegistry::AddListener(void* userdata)
+void CPipewireRegistry::AddListener()
 {
-  pw_registry_add_listener(m_registry.get(), &m_registryListener, &m_registryEvents, userdata);
+  pw_registry_add_listener(m_registry.get(), &m_registryListener, &m_registryEvents, this);
 }
 
 void CPipewireRegistry::OnGlobalAdded(void* userdata,
@@ -49,8 +48,7 @@ void CPipewireRegistry::OnGlobalAdded(void* userdata,
                                       uint32_t version,
                                       const struct spa_dict* props)
 {
-  auto pipewire = reinterpret_cast<CPipewire*>(userdata);
-  auto registry = pipewire->GetRegistry();
+  auto registry = reinterpret_cast<CPipewireRegistry*>(userdata);
 
   if (strcmp(type, PW_TYPE_INTERFACE_Node) == 0)
   {
@@ -86,8 +84,7 @@ void CPipewireRegistry::OnGlobalAdded(void* userdata,
 
 void CPipewireRegistry::OnGlobalRemoved(void* userdata, uint32_t id)
 {
-  auto pipewire = reinterpret_cast<CPipewire*>(userdata);
-  auto registry = pipewire->GetRegistry();
+  auto registry = reinterpret_cast<CPipewireRegistry*>(userdata);
   auto& globals = registry->GetGlobals();
 
   auto global = globals.find(id);

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h
@@ -37,7 +37,7 @@ public:
 
   CPipewireCore& GetCore() const { return m_core; }
 
-  void AddListener(void* userdata);
+  void AddListener();
 
   struct PipewirePropertiesDeleter
   {

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h
@@ -24,16 +24,21 @@ namespace SINK
 namespace PIPEWIRE
 {
 
+class CPipewireCore;
+
 class CPipewireRegistry
 {
 public:
-  explicit CPipewireRegistry(pw_core* core);
+  explicit CPipewireRegistry(CPipewireCore& core);
   CPipewireRegistry() = delete;
   ~CPipewireRegistry() = default;
 
   pw_registry* Get() const { return m_registry.get(); }
 
+  CPipewireCore& GetCore() const { return m_core; }
+
   void AddListener(void* userdata);
+
   struct PipewirePropertiesDeleter
   {
     void operator()(pw_properties* p) { pw_properties_free(p); }
@@ -63,6 +68,8 @@ private:
   static void OnGlobalRemoved(void* userdata, uint32_t id);
 
   static pw_registry_events CreateRegistryEvents();
+
+  CPipewireCore& m_core;
 
   const pw_registry_events m_registryEvents;
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h
@@ -8,9 +8,14 @@
 
 #pragma once
 
+#include "cores/AudioEngine/Sinks/pipewire/PipewireProxy.h"
+
+#include <map>
 #include <memory>
+#include <string>
 
 #include <pipewire/core.h>
+#include <pipewire/properties.h>
 
 namespace AE
 {
@@ -29,6 +34,24 @@ public:
   pw_registry* Get() const { return m_registry.get(); }
 
   void AddListener(void* userdata);
+  struct PipewirePropertiesDeleter
+  {
+    void operator()(pw_properties* p) { pw_properties_free(p); }
+  };
+
+  struct global
+  {
+    std::string name;
+    std::string description;
+    uint32_t id;
+    uint32_t permissions;
+    std::string type;
+    uint32_t version;
+    std::unique_ptr<pw_properties, PipewirePropertiesDeleter> properties;
+    std::unique_ptr<CPipewireProxy> proxy;
+  };
+
+  std::map<uint32_t, std::unique_ptr<global>>& GetGlobals() { return m_globals; }
 
 private:
   static void OnGlobalAdded(void* userdata,
@@ -50,6 +73,8 @@ private:
   };
 
   std::unique_ptr<pw_registry, PipewireRegistryDeleter> m_registry;
+
+  std::map<uint32_t, std::unique_ptr<global>> m_globals;
 };
 
 } // namespace PIPEWIRE

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
@@ -8,7 +8,7 @@
 
 #include "PipewireStream.h"
 
-#include "cores/AudioEngine/Sinks/pipewire/Pipewire.h"
+#include "cores/AudioEngine/Sinks/pipewire/PipewireContext.h"
 #include "cores/AudioEngine/Sinks/pipewire/PipewireCore.h"
 #include "cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.h"
 #include "utils/log.h"
@@ -40,9 +40,9 @@ CPipewireStream::~CPipewireStream()
   spa_hook_remove(&m_streamListener);
 }
 
-void CPipewireStream::AddListener(void* userdata)
+void CPipewireStream::AddListener()
 {
-  pw_stream_add_listener(m_stream.get(), &m_streamListener, &m_streamEvents, userdata);
+  pw_stream_add_listener(m_stream.get(), &m_streamListener, &m_streamEvents, this);
 }
 
 bool CPipewireStream::Connect(uint32_t id,
@@ -101,9 +101,8 @@ void CPipewireStream::StateChanged(void* userdata,
                                    enum pw_stream_state state,
                                    const char* error)
 {
-  auto pipewire = reinterpret_cast<CPipewire*>(userdata);
-  auto loop = pipewire->GetThreadLoop();
-  auto stream = pipewire->GetStream();
+  auto stream = reinterpret_cast<CPipewireStream*>(userdata);
+  auto loop = &stream->GetCore().GetContext().GetThreadLoop();
 
   CLog::Log(LOGDEBUG, "CPipewireStream::{} - stream state changed {} -> {}", __FUNCTION__,
             pw_stream_state_as_string(old), pw_stream_state_as_string(state));
@@ -120,17 +119,16 @@ void CPipewireStream::StateChanged(void* userdata,
 
 void CPipewireStream::Process(void* userdata)
 {
-  auto pipewire = reinterpret_cast<CPipewire*>(userdata);
-  auto loop = pipewire->GetThreadLoop();
+  auto stream = reinterpret_cast<CPipewireStream*>(userdata);
+  auto loop = &stream->GetCore().GetContext().GetThreadLoop();
 
   loop->Signal(false);
 }
 
 void CPipewireStream::Drained(void* userdata)
 {
-  auto pipewire = reinterpret_cast<CPipewire*>(userdata);
-  auto loop = pipewire->GetThreadLoop();
-  auto stream = pipewire->GetStream();
+  auto stream = reinterpret_cast<CPipewireStream*>(userdata);
+  auto loop = &stream->GetCore().GetContext().GetThreadLoop();
 
   stream->SetActive(false);
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
@@ -9,6 +9,7 @@
 #include "PipewireStream.h"
 
 #include "cores/AudioEngine/Sinks/pipewire/Pipewire.h"
+#include "cores/AudioEngine/Sinks/pipewire/PipewireCore.h"
 #include "cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.h"
 #include "utils/log.h"
 
@@ -23,9 +24,10 @@ namespace SINK
 namespace PIPEWIRE
 {
 
-CPipewireStream::CPipewireStream(pw_core* core) : m_streamEvents(CreateStreamEvents())
+CPipewireStream::CPipewireStream(CPipewireCore& core)
+  : m_core(core), m_streamEvents(CreateStreamEvents())
 {
-  m_stream.reset(pw_stream_new(core, nullptr, pw_properties_new(nullptr, nullptr)));
+  m_stream.reset(pw_stream_new(core.Get(), nullptr, pw_properties_new(nullptr, nullptr)));
   if (!m_stream)
   {
     CLog::Log(LOGERROR, "CPipewireStream: failed to create stream: {}", strerror(errno));

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
@@ -21,14 +21,18 @@ namespace SINK
 namespace PIPEWIRE
 {
 
+class CPipewireCore;
+
 class CPipewireStream
 {
 public:
-  explicit CPipewireStream(pw_core* core);
+  explicit CPipewireStream(CPipewireCore& core);
   CPipewireStream() = delete;
   ~CPipewireStream();
 
   pw_stream* Get() const { return m_stream.get(); }
+
+  CPipewireCore& GetCore() const { return m_core; }
 
   void AddListener(void* userdata);
   bool Connect(uint32_t id,
@@ -57,6 +61,8 @@ private:
   static void Drained(void* userdata);
 
   static pw_stream_events CreateStreamEvents();
+
+  CPipewireCore& m_core;
 
   const pw_stream_events m_streamEvents;
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
@@ -34,7 +34,7 @@ public:
 
   CPipewireCore& GetCore() const { return m_core; }
 
-  void AddListener(void* userdata);
+  void AddListener();
   bool Connect(uint32_t id,
                const pw_direction& direction,
                std::vector<const spa_pod*>& params,


### PR DESCRIPTION
This changes the pipewire model from the single entry point of `CPipewire` to each class owning a reference to the object used to create it. This allows following the chain to get the object that is required. Basically a tree is created something like this.

```
CPipewireThreadLoop
|- CPipewireContext
   |- CPipewireCore
      |- CPipewireStream
      |- CPipewireRegistry
         |- CPipewireProxy -> CPipewireNode
```

The classes `CPipewireThreadLoop`, `CPipewireContext`, `CPipewireCore`, `CPipewireRegistry`, and `CPipewireStream` (though it will be pulled out at a later PR).

The idea is to turn `CPipewire` into a sort of platform service that can be accessed from other parts than just AudioEngine.

This also makes the handling of the static events more sensical.

I also move the globals (pipewire nodes) to `CPipewireRegistry` as it should be. I'm not sure why I ever had it in `CPipewire`.