### PR TITLE
CPipewireStream: adjust Connect method params

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -361,7 +361,10 @@ bool CAESinkPipewire::Initialize(AEAudioFormat& format, std::string& device)
   for (size_t index = 0; index < pwChannels.size(); index++)
     info.position[index] = pwChannels[index];
 
-  if (!stream->Connect(id, info))
+  pw_stream_flags flags = static_cast<pw_stream_flags>(
+      PW_STREAM_FLAG_AUTOCONNECT | PW_STREAM_FLAG_INACTIVE | PW_STREAM_FLAG_MAP_BUFFERS);
+
+  if (!stream->Connect(id, info, flags))
   {
     loop->Unlock();
     return false;

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -373,7 +373,7 @@ bool CAESinkPipewire::Initialize(AEAudioFormat& format, std::string& device)
   pw_stream_flags flags = static_cast<pw_stream_flags>(
       PW_STREAM_FLAG_AUTOCONNECT | PW_STREAM_FLAG_INACTIVE | PW_STREAM_FLAG_MAP_BUFFERS);
 
-  if (!stream->Connect(id, params, flags))
+  if (!stream->Connect(id, PW_DIRECTION_OUTPUT, params, flags))
   {
     loop->Unlock();
     return false;

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
@@ -45,18 +45,14 @@ void CPipewireStream::AddListener(void* userdata)
   pw_stream_add_listener(m_stream.get(), &m_streamListener, &m_streamEvents, userdata);
 }
 
-bool CPipewireStream::Connect(uint32_t id, spa_audio_info_raw& info)
+bool CPipewireStream::Connect(uint32_t id, spa_audio_info_raw& info, const pw_stream_flags& flags)
 {
   std::array<uint8_t, 1024> buffer;
   auto builder = SPA_POD_BUILDER_INIT(buffer.data(), buffer.size());
   auto params = spa_format_audio_raw_build(&builder, SPA_PARAM_EnumFormat, &info);
 
-  int ret = pw_stream_connect(m_stream.get(), PW_DIRECTION_OUTPUT, id,
-                              static_cast<pw_stream_flags>(PW_STREAM_FLAG_AUTOCONNECT |
-                                                           PW_STREAM_FLAG_INACTIVE |
-                                                           PW_STREAM_FLAG_MAP_BUFFERS),
+  int ret = pw_stream_connect(m_stream.get(), PW_DIRECTION_OUTPUT, id, flags,
                               const_cast<const spa_pod**>(&params), 1);
-
   if (ret < 0)
   {
     CLog::Log(LOGERROR, "CPipewireStream: failed to connect stream: {}", spa_strerror(errno));

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
@@ -44,11 +44,11 @@ void CPipewireStream::AddListener(void* userdata)
 }
 
 bool CPipewireStream::Connect(uint32_t id,
+                              const pw_direction& direction,
                               std::vector<const spa_pod*>& params,
                               const pw_stream_flags& flags)
 {
-  int ret = pw_stream_connect(m_stream.get(), PW_DIRECTION_OUTPUT, id, flags, params.data(),
-                              params.size());
+  int ret = pw_stream_connect(m_stream.get(), direction, id, flags, params.data(), params.size());
   if (ret < 0)
   {
     CLog::Log(LOGERROR, "CPipewireStream: failed to connect stream: {}", spa_strerror(errno));

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
@@ -14,8 +14,6 @@
 
 #include <stdexcept>
 
-#include <spa/param/audio/format-utils.h>
-#include <spa/pod/builder.h>
 #include <spa/utils/result.h>
 
 namespace AE
@@ -45,14 +43,12 @@ void CPipewireStream::AddListener(void* userdata)
   pw_stream_add_listener(m_stream.get(), &m_streamListener, &m_streamEvents, userdata);
 }
 
-bool CPipewireStream::Connect(uint32_t id, spa_audio_info_raw& info, const pw_stream_flags& flags)
+bool CPipewireStream::Connect(uint32_t id,
+                              std::vector<const spa_pod*>& params,
+                              const pw_stream_flags& flags)
 {
-  std::array<uint8_t, 1024> buffer;
-  auto builder = SPA_POD_BUILDER_INIT(buffer.data(), buffer.size());
-  auto params = spa_format_audio_raw_build(&builder, SPA_PARAM_EnumFormat, &info);
-
-  int ret = pw_stream_connect(m_stream.get(), PW_DIRECTION_OUTPUT, id, flags,
-                              const_cast<const spa_pod**>(&params), 1);
+  int ret = pw_stream_connect(m_stream.get(), PW_DIRECTION_OUTPUT, id, flags, params.data(),
+                              params.size());
   if (ret < 0)
   {
     CLog::Log(LOGERROR, "CPipewireStream: failed to connect stream: {}", spa_strerror(errno));

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
@@ -9,10 +9,10 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include <pipewire/core.h>
 #include <pipewire/stream.h>
-#include <spa/param/audio/raw.h>
 
 namespace AE
 {
@@ -31,7 +31,7 @@ public:
   pw_stream* Get() const { return m_stream.get(); }
 
   void AddListener(void* userdata);
-  bool Connect(uint32_t id, spa_audio_info_raw& info, const pw_stream_flags& flags);
+  bool Connect(uint32_t id, std::vector<const spa_pod*>& params, const pw_stream_flags& flags);
 
   pw_stream_state GetState();
   void SetActive(bool active);

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
@@ -31,7 +31,7 @@ public:
   pw_stream* Get() const { return m_stream.get(); }
 
   void AddListener(void* userdata);
-  bool Connect(uint32_t id, spa_audio_info_raw& info);
+  bool Connect(uint32_t id, spa_audio_info_raw& info, const pw_stream_flags& flags);
 
   pw_stream_state GetState();
   void SetActive(bool active);

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
@@ -31,7 +31,10 @@ public:
   pw_stream* Get() const { return m_stream.get(); }
 
   void AddListener(void* userdata);
-  bool Connect(uint32_t id, std::vector<const spa_pod*>& params, const pw_stream_flags& flags);
+  bool Connect(uint32_t id,
+               const pw_direction& direction,
+               std::vector<const spa_pod*>& params,
+               const pw_stream_flags& flags);
 
   pw_stream_state GetState();
   void SetActive(bool active);


### PR DESCRIPTION
This PR basically pulls the logic out of the `CPipewireStream::Connect` method and moves it to the caller. This allows for more flexibility in the future when other types may be passed.

This also allows the caller to specify the `pw_stream_flags` for similar reasons above.

The same goes for `pw_direction`