### PR TITLE
Pipewire: fix implementation for AudioEngine design

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -324,8 +324,8 @@ bool CAESinkPipewire::Initialize(AEAudioFormat& format, std::string& device)
 
   stream->AddListener(pipewire.get());
 
-  m_latency = 20; // ms
-  uint32_t frames = std::nearbyint((m_latency * format.m_sampleRate) / 1000.0);
+  m_latency = 20ms;
+  uint32_t frames = std::nearbyint(m_latency.count() * format.m_sampleRate);
   std::string fraction = StringUtils::Format("{}/{}", frames, format.m_sampleRate);
 
   std::array<spa_dict_item, 5> items = {
@@ -426,7 +426,7 @@ void CAESinkPipewire::Deinitialize()
 
 double CAESinkPipewire::GetCacheTotal()
 {
-  return m_latency / 1000.0;
+  return m_latency.count();
 }
 
 unsigned int CAESinkPipewire::AddPackets(uint8_t** data, unsigned int frames, unsigned int offset)
@@ -479,7 +479,7 @@ unsigned int CAESinkPipewire::AddPackets(uint8_t** data, unsigned int frames, un
 
 void CAESinkPipewire::GetDelay(AEDelayStatus& status)
 {
-  status.SetDelay(m_latency / 1000.0);
+  status.SetDelay(m_latency.count());
 }
 
 void CAESinkPipewire::Drain()

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -164,6 +164,28 @@ CAEChannelInfo PWChannelMapToAEChannelMap(std::vector<spa_audio_channel>& channe
   return channels;
 }
 
+std::chrono::duration<double, std::ratio<1>> PWTimeToAEDelay(const pw_time& time,
+                                                             const uint32_t& samplerate)
+{
+  const auto now = std::chrono::steady_clock::now();
+
+  const int64_t diff = now.time_since_epoch().count() - time.now;
+  const int64_t elapsed = (time.rate.denom * diff) / (time.rate.num * SPA_NSEC_PER_SEC);
+
+  const double fraction = static_cast<double>(time.rate.num) / time.rate.denom;
+
+  const auto delay = std::chrono::duration<double, std::ratio<1>>(
+      (time.buffered * fraction) + ((time.delay - elapsed) * fraction) +
+      (static_cast<double>(time.queued) / samplerate));
+
+  return delay;
+}
+
+constexpr std::chrono::duration<double, std::ratio<1>> DEFAULT_BUFFER_DURATION = 0.200s;
+constexpr int DEFAULT_PERIODS = 4;
+constexpr std::chrono::duration<double, std::ratio<1>> DEFAULT_PERIOD_DURATION =
+    DEFAULT_BUFFER_DURATION / 4;
+
 } // namespace
 
 namespace AE
@@ -324,8 +346,8 @@ bool CAESinkPipewire::Initialize(AEAudioFormat& format, std::string& device)
 
   stream->AddListener(pipewire.get());
 
-  m_latency = 20ms;
-  uint32_t frames = std::nearbyint(m_latency.count() * format.m_sampleRate);
+  m_latency = DEFAULT_BUFFER_DURATION;
+  uint32_t frames = std::nearbyint(DEFAULT_PERIOD_DURATION.count() * format.m_sampleRate);
   std::string fraction = StringUtils::Format("{}/{}", frames, format.m_sampleRate);
 
   std::array<spa_dict_item, 5> items = {
@@ -370,8 +392,18 @@ bool CAESinkPipewire::Initialize(AEAudioFormat& format, std::string& device)
 
   params.emplace_back(spa_format_audio_raw_build(&builder, SPA_PARAM_EnumFormat, &info));
 
-  pw_stream_flags flags = static_cast<pw_stream_flags>(
-      PW_STREAM_FLAG_AUTOCONNECT | PW_STREAM_FLAG_INACTIVE | PW_STREAM_FLAG_MAP_BUFFERS);
+  // clang-format off
+  params.emplace_back(static_cast<const spa_pod*>(spa_pod_builder_add_object(
+      &builder, SPA_TYPE_OBJECT_ParamBuffers, SPA_PARAM_Buffers,
+          SPA_PARAM_BUFFERS_buffers, SPA_POD_CHOICE_RANGE_Int(6, 6, 6),
+          SPA_PARAM_BUFFERS_blocks, SPA_POD_Int(1),
+          SPA_PARAM_BUFFERS_size, SPA_POD_Int(frames * pwChannels.size() * PWFormatToSampleSize(pwFormat)),
+          SPA_PARAM_BUFFERS_stride, SPA_POD_Int(pwChannels.size() * PWFormatToSampleSize(pwFormat)))));
+  // clang-format on
+
+  pw_stream_flags flags =
+      static_cast<pw_stream_flags>(PW_STREAM_FLAG_AUTOCONNECT | PW_STREAM_FLAG_INACTIVE |
+                                   PW_STREAM_FLAG_MAP_BUFFERS | PW_STREAM_FLAG_DRIVER);
 
   if (!stream->Connect(id, PW_DIRECTION_OUTPUT, params, flags))
   {
@@ -431,6 +463,8 @@ double CAESinkPipewire::GetCacheTotal()
 
 unsigned int CAESinkPipewire::AddPackets(uint8_t** data, unsigned int frames, unsigned int offset)
 {
+  const auto start = std::chrono::steady_clock::now();
+
   auto loop = pipewire->GetThreadLoop();
   auto& stream = pipewire->GetStream();
 
@@ -454,6 +488,8 @@ unsigned int CAESinkPipewire::AddPackets(uint8_t** data, unsigned int frames, un
     }
   }
 
+  pwBuffer->size = frames;
+
   spa_buffer* spaBuffer = pwBuffer->buffer;
   spa_data* spaData = &spaBuffer->datas[0];
 
@@ -472,6 +508,27 @@ unsigned int CAESinkPipewire::AddPackets(uint8_t** data, unsigned int frames, un
 
   stream->QueueBuffer(pwBuffer);
 
+  do
+  {
+    pw_time time = stream->GetTime();
+
+    const std::chrono::duration<double, std::ratio<1>> delay =
+        PWTimeToAEDelay(time, m_format.m_sampleRate);
+
+    const auto now = std::chrono::steady_clock::now();
+
+    const auto period = std::chrono::duration<double, std::ratio<1>>(static_cast<double>(frames) /
+                                                                     m_format.m_sampleRate);
+
+    if ((delay <= (m_latency - period)) || ((now - start) >= period))
+      break;
+
+    loop->Wait(5ms);
+
+  } while (true);
+
+  stream->TriggerProcess();
+
   loop->Unlock();
 
   return length / m_format.m_frameSize;
@@ -479,7 +536,24 @@ unsigned int CAESinkPipewire::AddPackets(uint8_t** data, unsigned int frames, un
 
 void CAESinkPipewire::GetDelay(AEDelayStatus& status)
 {
-  status.SetDelay(m_latency.count());
+  auto loop = pipewire->GetThreadLoop();
+  auto& stream = pipewire->GetStream();
+
+  loop->Lock();
+
+  pw_stream_state state = stream->GetState();
+
+  pw_time time = stream->GetTime();
+
+  loop->Unlock();
+
+  if (state != PW_STREAM_STATE_STREAMING)
+    return;
+
+  const std::chrono::duration<double, std::ratio<1>> delay =
+      PWTimeToAEDelay(time, m_format.m_sampleRate);
+
+  status.SetDelay(delay.count());
 }
 
 void CAESinkPipewire::Drain()

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -495,9 +495,6 @@ unsigned int CAESinkPipewire::AddPackets(uint8_t** data, unsigned int frames, un
 
   size_t length = frames * m_format.m_frameSize;
 
-  if (spaData->maxsize < length)
-    length = spaData->maxsize;
-
   void* buffer = data[0] + offset * m_format.m_frameSize;
 
   std::memcpy(spaData->data, buffer, length);
@@ -531,7 +528,7 @@ unsigned int CAESinkPipewire::AddPackets(uint8_t** data, unsigned int frames, un
 
   loop->Unlock();
 
-  return length / m_format.m_frameSize;
+  return frames;
 }
 
 void CAESinkPipewire::GetDelay(AEDelayStatus& status)

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.h
@@ -11,6 +11,8 @@
 #include "cores/AudioEngine/Interfaces/AESink.h"
 #include "cores/AudioEngine/Utils/AEDeviceInfo.h"
 
+#include <chrono>
+
 namespace AE
 {
 namespace SINK
@@ -41,7 +43,7 @@ public:
 
 private:
   AEAudioFormat m_format;
-  double m_latency;
+  std::chrono::duration<double, std::ratio<1>> m_latency;
 };
 
 } // namespace SINK

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
@@ -78,6 +78,18 @@ void CPipewireStream::QueueBuffer(pw_buffer* buffer)
   pw_stream_queue_buffer(m_stream.get(), buffer);
 }
 
+bool CPipewireStream::TriggerProcess() const
+{
+  int ret = pw_stream_trigger_process(m_stream.get());
+  if (ret < 0)
+  {
+    CLog::Log(LOGERROR, "CPipewireStream: failed to trigger process: {}", spa_strerror(errno));
+    return false;
+  }
+
+  return true;
+}
+
 void CPipewireStream::Flush(bool drain)
 {
   pw_stream_flush(m_stream.get(), drain);
@@ -93,6 +105,13 @@ void CPipewireStream::UpdateProperties(spa_dict* dict)
   pw_stream_update_properties(m_stream.get(), dict);
 }
 
+pw_time CPipewireStream::GetTime() const
+{
+  pw_time time;
+  pw_stream_get_time_n(m_stream.get(), &time, sizeof(time));
+
+  return time;
+}
 
 void CPipewireStream::StateChanged(void* userdata,
                                    enum pw_stream_state old,

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
@@ -42,11 +42,15 @@ public:
   pw_buffer* DequeueBuffer();
   void QueueBuffer(pw_buffer* buffer);
 
+  bool TriggerProcess() const;
+
   void Flush(bool drain);
 
   uint32_t GetNodeId();
 
   void UpdateProperties(spa_dict* dict);
+
+  pw_time GetTime() const;
 
 private:
   static void StateChanged(void* userdata,


### PR DESCRIPTION
This corrects the Pipewire implementation to properly fit into the AudioEngine framework.

This requires adding a latency adjustment and query. This is done by using `pw_stream_get_time_n` to query the pipewire stream time. The delay is calculated roughly off of the example described here -> https://docs.pipewire.org/structpw__time.html

This goes into the other fix of blocking in `AddPackets`. The sink is run in a thread and needs to block based on the length of the frames added. This behaviour is detailed here https://github.com/xbmc/xbmc/blob/a773ffe723082c4559d44294b73f8065d21e3900/xbmc/cores/AudioEngine/Interfaces/AESink.h#L50

So in a perfect world, if we submit 100ms of data, the `AddPackets` method should take 100ms to return. Then `GetDelay` should return the max amount the buffer should submit which would be 100ms.

@fritsch I made a couple small changes since your last comments. I wanted to make a PR so all comments can be tracked in one place 😺  Hopefully this finally resolves all your concerns.