### PR TITLE
CThread: add formatter for std::thread::id and some cleanup

### DIFF
--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -117,7 +117,6 @@ void CThread::Create(bool bAutoDelete)
         // to be set before anything else is done.
         currentThread = pThread;
 
-        std::string name;
         bool autodelete;
 
         if (pThread == nullptr)
@@ -127,14 +126,12 @@ void CThread::Create(bool bAutoDelete)
           return;
         }
 
-        name = pThread->m_ThreadName;
-
         autodelete = pThread->m_bAutoDelete;
 
         pThread->m_impl = IThreadImpl::CreateThreadImpl(pThread->m_thread->native_handle());
-        pThread->m_impl->SetThreadInfo(name);
+        pThread->m_impl->SetThreadInfo(pThread->m_ThreadName);
 
-        CLog::Log(LOGDEBUG, "Thread {} start, auto delete: {}", name,
+        CLog::Log(LOGDEBUG, "Thread {} start, auto delete: {}", pThread->m_ThreadName,
                   (autodelete ? "true" : "false"));
 
         pThread->m_StartEvent.Set();
@@ -143,13 +140,14 @@ void CThread::Create(bool bAutoDelete)
 
         if (autodelete)
         {
-          CLog::Log(LOGDEBUG, "Thread {} {} terminating (autodelete)", name,
+          CLog::Log(LOGDEBUG, "Thread {} {} terminating (autodelete)", pThread->m_ThreadName,
                     std::this_thread::get_id());
           delete pThread;
           pThread = NULL;
         }
         else
-          CLog::Log(LOGDEBUG, "Thread {} {} terminating", name, std::this_thread::get_id());
+          CLog::Log(LOGDEBUG, "Thread {} {} terminating", pThread->m_ThreadName,
+                    std::this_thread::get_id());
       }
       catch (const std::exception& e)
       {

--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -117,8 +117,6 @@ void CThread::Create(bool bAutoDelete)
         // to be set before anything else is done.
         currentThread = pThread;
 
-        bool autodelete;
-
         if (pThread == nullptr)
         {
           CLog::Log(LOGERROR, "{}, sanity failed. thread is NULL.", __FUNCTION__);
@@ -126,19 +124,17 @@ void CThread::Create(bool bAutoDelete)
           return;
         }
 
-        autodelete = pThread->m_bAutoDelete;
-
         pThread->m_impl = IThreadImpl::CreateThreadImpl(pThread->m_thread->native_handle());
         pThread->m_impl->SetThreadInfo(pThread->m_ThreadName);
 
         CLog::Log(LOGDEBUG, "Thread {} start, auto delete: {}", pThread->m_ThreadName,
-                  (autodelete ? "true" : "false"));
+                  (pThread->m_bAutoDelete ? "true" : "false"));
 
         pThread->m_StartEvent.Set();
 
         pThread->Action();
 
-        if (autodelete)
+        if (pThread->m_bAutoDelete)
         {
           CLog::Log(LOGDEBUG, "Thread {} {} terminating (autodelete)", pThread->m_ThreadName,
                     std::this_thread::get_id());

--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -22,6 +22,13 @@
 #include <mutex>
 #include <stdlib.h>
 
+#include <fmt/ostream.h>
+
+template<>
+struct fmt::formatter<std::thread::id> : ostream_formatter
+{
+};
+
 static thread_local CThread* currentThread;
 
 //////////////////////////////////////////////////////////////////////
@@ -122,9 +129,6 @@ void CThread::Create(bool bAutoDelete)
 
         name = pThread->m_ThreadName;
 
-        std::stringstream ss;
-        ss << std::this_thread::get_id();
-        std::string id = ss.str();
         autodelete = pThread->m_bAutoDelete;
 
         pThread->m_impl = IThreadImpl::CreateThreadImpl(pThread->m_thread->native_handle());
@@ -139,12 +143,13 @@ void CThread::Create(bool bAutoDelete)
 
         if (autodelete)
         {
-          CLog::Log(LOGDEBUG, "Thread {} {} terminating (autodelete)", name, id);
+          CLog::Log(LOGDEBUG, "Thread {} {} terminating (autodelete)", name,
+                    std::this_thread::get_id());
           delete pThread;
           pThread = NULL;
         }
         else
-          CLog::Log(LOGDEBUG, "Thread {} {} terminating", name, id);
+          CLog::Log(LOGDEBUG, "Thread {} {} terminating", name, std::this_thread::get_id());
       }
       catch (const std::exception& e)
       {


### PR DESCRIPTION
This removes the use of std::stringstream and adds a formatter for `std::thread::id` using fmt.

In the latest versions of fmtlib there is a `<fmt/std.h>` header but it is only available since 9.0.0 which may not be available on some platforms.

I've also added a couple other commits to cleanup some temp variables.