### PR TITLE
CXBMCApp::android_printf() uses CLog when the logging system is up

### DIFF
--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -57,6 +57,11 @@ void CServiceBroker::CreateLogging()
   g_serviceBroker.m_logging = std::make_unique<CLog>();
 }
 
+bool CServiceBroker::IsLoggingUp()
+{
+  return g_serviceBroker.m_logging ? true : false;
+}
+
 void CServiceBroker::DestroyLogging()
 {
   g_serviceBroker.m_logging.reset();

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -127,6 +127,7 @@ public:
 
   static CLog& GetLogging();
   static void CreateLogging();
+  static bool IsLoggingUp();
   static void DestroyLogging();
 
   static std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> GetAnnouncementManager();

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -770,7 +770,19 @@ int CXBMCApp::android_printf(const char *format, ...)
   // For use before CLog is setup by XBMC_Run()
   va_list args;
   va_start(args, format);
-  int result = __android_log_vprint(ANDROID_LOG_VERBOSE, "Kodi", format, args);
+  int result;
+  if (CServiceBroker::IsLoggingUp())
+  {
+    std::string message;
+    int len = vsnprintf(0, 0, format, args);
+    message.resize(len);
+    result = vsnprintf(&message[0], len + 1, format, args);
+    CLog::Log(LOGDEBUG, message);
+  }
+  else
+  {
+    result = __android_log_vprint(ANDROID_LOG_VERBOSE, "Kodi", format, args);
+  }
   va_end(args);
   return result;
 }


### PR DESCRIPTION
## Description
When displaying the system message logs by `adb logcat -s Kodi`, a debug message similar to the following is displayed each time a key is pressed:

```
V Kodi    : CAndroidKey: key down (dev:-1; src:33554433; code: 22; repeat: 0; flags: 0x8; alt: no; shift: no; sym: no)
V Kodi    : CAndroidKey: key up (dev:-1; src:33554433; code: 22; repeat: 0; flags: 0x8; alt: no; shift: no; sym: no)
```

These messages appear all the time and are unnecessary as we can activate the Kodi debug log on demand and display the following debug messages:

```
D Kodi    : debug <general>: Keyboard: scancode: 0x16, sym: 0x113, unicode: 0x00, modifier: 0x0
D Kodi    : debug <general>: HandleKey: right (0xf083) pressed, window 10016, action is Right
D Kodi    : debug <general>: Keyboard: scancode: 0x16, sym: 0x113, unicode: 0x00, modifier: 0x0
```

.~~I propose to hide the `CAndroidKey` debug messages to reduce this debug information overload..~~

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
