### PR TITLE
[addons] improve logging for add-on directory matching err

### DIFF
--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -130,9 +130,9 @@ CRepository::CRepository(const AddonInfoPtr& addonInfo) : CAddon(addonInfo, Addo
   if (m_dirs.empty())
   {
     CLog::Log(LOGERROR,
-              "Repository add-on {} does not have any directory and won't be able to update/serve "
-              "addons! Please fix the addon.xml definition",
-              ID());
+              "Repository add-on {} does not have any directory matching {} and won't be able to "
+              "update/serve addons! Please fix the addon.xml definition",
+              ID(), version.asString());
   }
 
   for (auto const& dir : m_dirs)


### PR DESCRIPTION
Trying to use min/maxversions in my repsitory addon and I was getting an error that is not very helpful:

>error <general>: Repository add-on repository.fancybits does not have any directory and won't be able to update/serve addons! Please fix the addon.xml definition

This PR should improve the output slightly to make sense of what is happening.