### PR TITLE
[Android] Set the tag that identifies the app messages in the Logcat

### DIFF
--- a/tools/android/packaging/xbmc/src/Main.java.in
+++ b/tools/android/packaging/xbmc/src/Main.java.in
@@ -62,7 +62,7 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
     @Override
     public void run()
     {
-      Log.d(TAG, "Updating recommendations");
+      Log.d(TAG, "Main: Updating recommendations");
       new Thread()
       {
         public void run()
@@ -194,12 +194,12 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
     // Delay until after Resume
     if (mPaused)
     {
-      Log.d("Main", "onNewIntent (delayed)");
+      Log.d(TAG, "Main: onNewIntent (delayed)");
       mDelayedIntents.add(new DelayedIntent(new Intent(intent), 500));
     }
     else
     {
-      Log.d("Main", "onNewIntent (immediate)");
+      Log.d(TAG, "Main: onNewIntent (immediate)");
       _onNewIntent(intent);
     }
   }
@@ -242,7 +242,7 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
           }
           catch (UnsatisfiedLinkError e)
           {
-            Log.e("Main", "Native not registered");
+            Log.e(TAG, "Main: Native not registered");
           }
         }
       }, delayedIntent.mDelay);

--- a/tools/android/packaging/xbmc/src/XBMCBroadcastReceiver.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCBroadcastReceiver.java.in
@@ -10,7 +10,7 @@ public class XBMCBroadcastReceiver extends BroadcastReceiver
 {
   native void _onReceive(Intent intent);
 
-  private static final String TAG = "@APP_NAME@Receiver";
+  private static final String TAG = "@APP_NAME@";
 
   @Override
   public void onReceive(Context context, Intent intent)
@@ -35,7 +35,7 @@ public class XBMCBroadcastReceiver extends BroadcastReceiver
       }
       catch (UnsatisfiedLinkError e)
       {
-        Log.e(TAG, "Native not registered");
+        Log.e(TAG, "XBMCBroadcastReceiver: Native not registered");
       }
     }
   }

--- a/tools/android/packaging/xbmc/src/XBMCFile.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCFile.java.in
@@ -13,7 +13,7 @@ public class XBMCFile
   native byte[] _read();
   native boolean _eof();
 
-  private static String TAG = "@APP_NAME@file";
+  private static String TAG = "@APP_NAME@";
 
   public XBMCFile()
   {
@@ -29,12 +29,12 @@ public class XBMCFile
     catch (Exception e)
     {
       e.printStackTrace();
-      Log.e(TAG, "Open: Exception");
+      Log.e(TAG, "XBMCFile.Open: Exception");
       return false;
     }
     catch (UnsatisfiedLinkError e)
     {
-      Log.e(TAG, "Open: Not available");
+      Log.e(TAG, "XBMCFile.Open: Not available");
       return false;
     }
   }
@@ -48,12 +48,12 @@ public class XBMCFile
     catch (Exception e)
     {
       e.printStackTrace();
-      Log.e(TAG, "Close: Exception");
+      Log.e(TAG, "XBMCFile.Close: Exception");
       return;
     }
     catch (UnsatisfiedLinkError e)
     {
-      Log.e(TAG, "Close: Not available");
+      Log.e(TAG, "XBMCFile.Close: Not available");
       return;
     }
   }
@@ -67,12 +67,12 @@ public class XBMCFile
     catch (Exception e)
     {
       e.printStackTrace();
-      Log.e(TAG, "Read: Exception");
+      Log.e(TAG, "XBMCFile.Read: Exception");
       return new byte[0];
     }
     catch (UnsatisfiedLinkError e)
     {
-      Log.e(TAG, "Read: Not available");
+      Log.e(TAG, "XBMCFile.Read: Not available");
       return new byte[0];
     }
   }
@@ -86,12 +86,12 @@ public class XBMCFile
     catch (Exception e)
     {
       e.printStackTrace();
-      Log.e(TAG, "Eof: Exception");
+      Log.e(TAG, "XBMCFile.Eof: Exception");
       return false;
     }
     catch (UnsatisfiedLinkError e)
     {
-      Log.e(TAG, "Eof: Not available");
+      Log.e(TAG, "XBMCFile.Eof: Not available");
       return false;
     }
   }

--- a/tools/android/packaging/xbmc/src/XBMCJsonRPC.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCJsonRPC.java.in
@@ -60,7 +60,7 @@ public class XBMCJsonRPC
 
   private final static int MAX_ITEMS = 20;
 
-  private static String TAG = "@APP_NAME@json";
+  private static String TAG = "@APP_NAME@";
 
   private String m_xbmc_web_url = "http://localhost:8080";
   private HashSet<Integer> mRecomendationIds = new HashSet<Integer>();
@@ -137,13 +137,13 @@ public class XBMCJsonRPC
     }
     catch (Exception e)
     {
-      Log.e(TAG, "Failed to read JSON");
+      Log.e(TAG, "XBMCJsonRPC: Failed to read JSON");
       e.printStackTrace();
       return null;
     }
     catch (UnsatisfiedLinkError e)
     {
-      Log.e(TAG, "_requestJSON: Not available");
+      Log.e(TAG, "XBMCJsonRPC: _requestJSON: Not available");
       return null;
     }
   }
@@ -163,7 +163,7 @@ public class XBMCJsonRPC
     }
     catch (Exception e)
     {
-      Log.e(TAG, "Failed to parse JSON");
+      Log.e(TAG, "XBMCJsonRPC: Failed to parse JSON");
       e.printStackTrace();
       return null;
     }
@@ -184,7 +184,7 @@ public class XBMCJsonRPC
     }
     catch (Exception e)
     {
-      Log.e(TAG, "Failed to parse JSON");
+      Log.e(TAG, "XBMCJsonRPC: Failed to parse JSON");
       e.printStackTrace();
       return null;
     }
@@ -495,7 +495,7 @@ public class XBMCJsonRPC
               45*60*1000,
               -1
             });
-            Log.d(TAG, "tvshow: " + tvshow.get("title").getAsString() + ", " + tvshow.get("year").getAsInt());
+            Log.d(TAG, "XBMCJsonRPC: tvshow: " + tvshow.get("title").getAsString() + ", " + tvshow.get("year").getAsInt());
             nb_shows++;
             totCount++;
           }

--- a/tools/android/packaging/xbmc/src/XBMCMainView.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCMainView.java.in
@@ -18,7 +18,7 @@ public class XBMCMainView extends SurfaceView implements SurfaceHolder.Callback
   native void _surfaceCreated(SurfaceHolder holder);
   native void _surfaceDestroyed(SurfaceHolder holder);
 
-  private static final String TAG = "XBMCMainView";
+  private static final String TAG = "@APP_NAME@";
 
   public boolean mIsCreated = false;
 
@@ -29,7 +29,7 @@ public class XBMCMainView extends SurfaceView implements SurfaceHolder.Callback
     getHolder().addCallback(this);
     getHolder().setFormat(PixelFormat.TRANSPARENT);
 
-    Log.d(TAG, "Created");
+    Log.d(TAG, "XBMCMainView: Created");
 }
 
   public XBMCMainView(Context context, AttributeSet attrs, int defStyle)
@@ -39,7 +39,7 @@ public class XBMCMainView extends SurfaceView implements SurfaceHolder.Callback
     getHolder().addCallback(this);
     getHolder().setFormat(PixelFormat.TRANSPARENT);
 
-    Log.d(TAG, "Created");
+    Log.d(TAG, "XBMCMainView: Created");
   }
 
   public XBMCMainView(Context context, AttributeSet attrs)
@@ -50,7 +50,7 @@ public class XBMCMainView extends SurfaceView implements SurfaceHolder.Callback
   @Override
   public void surfaceCreated(SurfaceHolder holder)
   {
-    Log.d(TAG, "Surface Created");
+    Log.d(TAG, "XBMCMainView: Surface Created");
     mIsCreated = true;
     _attach();
     _surfaceCreated(holder);
@@ -63,14 +63,14 @@ public class XBMCMainView extends SurfaceView implements SurfaceHolder.Callback
     if (holder != getHolder())
       return;
 
-    Log.d(TAG, "Surface Changed, format:" + format + ", width:" + width + ", height:" + height);
+    Log.d(TAG, "XBMCMainView: Surface Changed, format:" + format + ", width:" + width + ", height:" + height);
     _surfaceChanged(holder, format, width, height);
   }
 
   @Override
   public void surfaceDestroyed(SurfaceHolder holder)
   {
-    Log.d(TAG, "Surface Destroyed");
+    Log.d(TAG, "XBMCMainView: Surface Destroyed");
     mIsCreated = false;
     _surfaceDestroyed(holder);
   }

--- a/tools/android/packaging/xbmc/src/XBMCMediaSession.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCMediaSession.java.in
@@ -32,7 +32,7 @@ public class XBMCMediaSession
 
   native boolean _onMediaButtonEvent(Intent intent);
 
-  private static final String TAG = "XBMCMediaSession";
+  private static final String TAG = "@APP_NAME@";
 
   private class XBMCMediaSessionCallback extends MediaSession.Callback
   {
@@ -40,7 +40,7 @@ public class XBMCMediaSession
     @Override
     public void onPlay()
     {
-      Log.d(TAG, "onPlay: ");
+      Log.d(TAG, "XBMCMediaSession.onPlay: ");
       super.onPlay();
       _onPlayRequested();
     }
@@ -48,7 +48,7 @@ public class XBMCMediaSession
     @Override
     public void onPause()
     {
-      Log.d(TAG, "onPause: ");
+      Log.d(TAG, "XBMCMediaSession.onPause: ");
       super.onPause();
       _onPauseRequested();
     }
@@ -56,7 +56,7 @@ public class XBMCMediaSession
     @Override
     public void onSkipToNext()
     {
-      Log.d(TAG, "onSkipToNext: ");
+      Log.d(TAG, "XBMCMediaSession.onSkipToNext: ");
       super.onSkipToNext();
       _onNextRequested();
     }
@@ -64,7 +64,7 @@ public class XBMCMediaSession
     @Override
     public void onSkipToPrevious()
     {
-      Log.d(TAG, "onSkipToPrevious: ");
+      Log.d(TAG, "XBMCMediaSession.onSkipToPrevious: ");
       super.onSkipToPrevious();
       _onPreviousRequested();
     }
@@ -72,7 +72,7 @@ public class XBMCMediaSession
     @Override
     public void onFastForward()
     {
-      Log.d(TAG, "onFastForward: ");
+      Log.d(TAG, "XBMCMediaSession.onFastForward: ");
       super.onFastForward();
       _onForwardRequested();
     }
@@ -80,7 +80,7 @@ public class XBMCMediaSession
     @Override
     public void onRewind()
     {
-      Log.d(TAG, "onRewind: ");
+      Log.d(TAG, "XBMCMediaSession.onRewind: ");
       super.onRewind();
       _onRewindRequested();
     }
@@ -88,7 +88,7 @@ public class XBMCMediaSession
     @Override
     public void onStop()
     {
-      Log.d(TAG, "onStop: ");
+      Log.d(TAG, "XBMCMediaSession.onStop: ");
       super.onStop();
       _onStopRequested();
     }
@@ -96,7 +96,7 @@ public class XBMCMediaSession
     @Override
     public void onSeekTo(long pos)
     {
-      Log.d(TAG, "onSeekTo: ");
+      Log.d(TAG, "XBMCMediaSession.onSeekTo: ");
       super.onSeekTo(pos);
       _onSeekRequested(pos);
     }
@@ -104,7 +104,7 @@ public class XBMCMediaSession
     @Override
     public boolean onMediaButtonEvent(Intent intent)
     {
-      Log.d(TAG, "onMediaButtonEvent: ");
+      Log.d(TAG, "XBMCMediaSession.onMediaButtonEvent: ");
       if (!_onMediaButtonEvent(intent))
         return super.onMediaButtonEvent(intent);
       return true;

--- a/tools/android/packaging/xbmc/src/XBMCProperties.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCProperties.java.in
@@ -10,7 +10,7 @@ import android.util.Log;
 
 public class XBMCProperties
 {
-  private static final String TAG = "@APP_NAME@properties";
+  private static final String TAG = "@APP_NAME@";
 
   private static boolean isInitialized()
   {
@@ -24,7 +24,7 @@ public class XBMCProperties
     File fProp = new File(propfn);
     if (fProp.exists())
     {
-      Log.i(TAG, "Loading " + propfn);
+      Log.i(TAG, "XBMCProperties: Loading " + propfn);
       try
       {
         Properties sysProp = new Properties(System.getProperties());
@@ -34,7 +34,7 @@ public class XBMCProperties
       }
       catch (Exception e)
       {
-        Log.e(TAG, "Error loading " + propfn + " (" + e.getMessage() + ")");
+        Log.e(TAG, "XBMCProperties: Error loading " + propfn + " (" + e.getMessage() + ")");
       }
     }
     System.setProperty("xbmc.proploaded", "yes");

--- a/tools/android/packaging/xbmc/src/XBMCSearchableActivity.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCSearchableActivity.java.in
@@ -13,7 +13,7 @@ import android.widget.ListView;
 public class XBMCSearchableActivity extends Activity
 {
 
-  private static final String TAG = "@APP_NAME@Search";
+  private static final String TAG = "@APP_NAME@";
 
   private ListView mListView;
 
@@ -57,7 +57,7 @@ public class XBMCSearchableActivity extends Activity
   private void doAction(Intent origIntent)
   {
     Uri data = origIntent.getData();
-    Log.d(TAG, "LAUNCH: " + data.toString());
+    Log.d(TAG, "XBMCSearchableActivity: LAUNCH: " + data.toString());
 
     Intent newIntent = new Intent(origIntent.getAction(), data);
     newIntent.setDataAndType(data, "video/*");
@@ -69,7 +69,7 @@ public class XBMCSearchableActivity extends Activity
 
   private void handleIntent(Intent intent)
   {
-    Log.d(TAG, "NEW INTENT: " + intent.getAction() + "; DATA=" + intent.getData().toString());
+    Log.d(TAG, "XBMCSearchableActivity: NEW INTENT: " + intent.getAction() + "; DATA=" + intent.getData().toString());
 
     if (Intent.ACTION_SEARCH.equals(intent.getAction()))
     {

--- a/tools/android/packaging/xbmc/src/XBMCSettingsContentObserver.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCSettingsContentObserver.java.in
@@ -11,7 +11,7 @@ public class XBMCSettingsContentObserver extends ContentObserver
 {
   native void _onVolumeChanged(int newVolume);
 
-  private static final String TAG = "@APP_NAME_LC@";
+  private static final String TAG = "@APP_NAME@";
 
   int previousVolume;
   Context context;
@@ -39,7 +39,7 @@ public class XBMCSettingsContentObserver extends ContentObserver
   {
     super.onChange(selfChange);
 
-    Log.d(TAG, "Setting changed: " + uri.toString());
+    Log.d(TAG, "XBMCSettingsContentObserver: Setting changed: " + uri.toString());
 
     if (
             uri.compareTo(Uri.parse("content://settings/system/volume_music_speaker")) == 0 ||
@@ -59,7 +59,7 @@ public class XBMCSettingsContentObserver extends ContentObserver
         }
         catch (UnsatisfiedLinkError e)
         {
-          Log.e("XBMCSettingsContentObserver", "Native not registered");
+          Log.e(TAG, "XBMCSettingsContentObserver: Native not registered");
         }
       }
     }

--- a/tools/android/packaging/xbmc/src/XBMCURIUtils.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCURIUtils.java.in
@@ -6,7 +6,7 @@ public class XBMCURIUtils
 {
   native String _substitutePath(String path);
 
-  private static String TAG = "@APP_NAME@uriutils";
+  private static String TAG = "@APP_NAME@";
 
   public XBMCURIUtils()
   {
@@ -21,7 +21,7 @@ public class XBMCURIUtils
     catch (Exception e)
     {
       e.printStackTrace();
-      Log.e(TAG, "substitutePath: Exception");
+      Log.e(TAG, "XBMCURIUtils.substitutePath: Exception");
       return null;
     }
   }

--- a/tools/android/packaging/xbmc/src/XBMCVideoView.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCVideoView.java.in
@@ -20,7 +20,7 @@ public class XBMCVideoView extends SurfaceView implements
 
   native void _surfaceDestroyed(SurfaceHolder holder);
 
-  private static final String TAG = "XBMCVideoPlayView";
+  private static final String TAG = "@APP_NAME@";
 
   public boolean mIsCreated = false;
   private RelativeLayout mVideoLayout = null;
@@ -92,7 +92,7 @@ public class XBMCVideoView extends SurfaceView implements
     }
     else
     {
-      Log.d(TAG, "getSurface() = " + getHolder().getSurface());
+      Log.d(TAG, "XBMCVideoView.getSurface() = " + getHolder().getSurface());
       return getHolder().getSurface();
     }
   }
@@ -127,7 +127,7 @@ public class XBMCVideoView extends SurfaceView implements
   @Override
   public void surfaceCreated(SurfaceHolder holder)
   {
-    Log.d(TAG, "Created");
+    Log.d(TAG, "XBMCVideoView: Created");
     mIsCreated = true;
     _surfaceCreated(holder);
   }
@@ -141,14 +141,14 @@ public class XBMCVideoView extends SurfaceView implements
 
     _surfaceChanged(holder, format, width, height);
 
-    Log.d(TAG, "Changed, format:" + format + ", width:" + width
+    Log.d(TAG, "XBMCVideoView: Changed, format:" + format + ", width:" + width
             + ", height:" + height);
   }
 
   @Override
   public void surfaceDestroyed(SurfaceHolder holder)
   {
-    Log.d(TAG, "Destroyed");
+    Log.d(TAG, "XBMCVideoView: Destroyed");
     mIsCreated = false;
     _surfaceDestroyed(holder);
   }

--- a/tools/android/packaging/xbmc/src/channels/SyncChannelJobService.java.in
+++ b/tools/android/packaging/xbmc/src/channels/SyncChannelJobService.java.in
@@ -43,14 +43,14 @@ import @APP_PACKAGE@.model.File;
 public class SyncChannelJobService extends JobService
 {
 
-  private static final String TAG = "RecommendChannelJobSvc";
+  private static final String TAG = "@APP_NAME@";
 
   private SyncChannelTask mSyncChannelTask;
 
   @Override
   public boolean onStartJob(final JobParameters jobParameters)
   {
-    Log.d(TAG, "Starting channel creation job");
+    Log.d(TAG, "SyncChannelJobService: Starting channel creation job");
 
     mSyncChannelTask =
             new SyncChannelTask(getApplicationContext())

--- a/tools/android/packaging/xbmc/src/channels/SyncProgramsJobService.java.in
+++ b/tools/android/packaging/xbmc/src/channels/SyncProgramsJobService.java.in
@@ -52,21 +52,21 @@ import java.util.List;
 public class SyncProgramsJobService extends JobService
 {
 
-  private static final String TAG = "SyncProgramsJobService";
+  private static final String TAG = "@APP_NAME@";
 
   private SyncProgramsTask mSyncProgramsTask;
 
   @Override
   public boolean onStartJob(final JobParameters jobParameters)
   {
-    Log.d(TAG, "onStartJob(): " + jobParameters);
+    Log.d(TAG, "SyncProgramsJobService.onStartJob(): " + jobParameters);
 
     final long channelId = getChannelId(jobParameters);
     if (channelId == -1L)
     {
       return false;
     }
-    Log.d(TAG, "onStartJob(): Scheduling syncing for programs for channel " + channelId);
+    Log.d(TAG, "SyncProgramsJobService.onStartJob(): Scheduling syncing for programs for channel " + channelId);
 
     mSyncProgramsTask =
             new SyncProgramsTask(getApplicationContext())
@@ -156,7 +156,7 @@ public class SyncProgramsJobService extends JobService
  */
     private void syncPrograms(long channelId, String uri, List<Media> initialMedias)
     {
-      Log.d(TAG, "Sync programs for channel: " + channelId);
+      Log.d(TAG, "SyncProgramsJobService: Sync programs for channel: " + channelId);
       List<Media> medias = new ArrayList<>(initialMedias);
 
       try (Cursor cursor =
@@ -176,14 +176,14 @@ public class SyncProgramsJobService extends JobService
           if (uri.isEmpty())
           {
             // Suggestion channel
-            Log.d(TAG, "Suggestion channel is browsable: " + channelId);
+            Log.d(TAG, "SyncProgramsJobService: Suggestion channel is browsable: " + channelId);
 
             deletePrograms(channelId, medias);
             medias = createPrograms(channelId, jsonrpc.getSuggestions());
           }
           else
           {
-            Log.d(TAG, "Channel is browsable: " + channelId);
+            Log.d(TAG, "SyncProgramsJobService: Channel is browsable: " + channelId);
 
             String xbmcURL = Uri.parse(uri).getFragment();
             List<File> files = jsonrpc.getFiles(xbmcURL);
@@ -213,7 +213,7 @@ public class SyncProgramsJobService extends JobService
         if (programUri != null)
         {
           long programId = ContentUris.parseId(programUri);
-          Log.d(TAG, "Inserted new program: " + programId);
+          Log.d(TAG, "SyncProgramsJobService: Inserted new program: " + programId);
           media.setProgramId(programId);
           mediasAdded.add(media);
         }
@@ -239,7 +239,7 @@ public class SyncProgramsJobService extends JobService
                                 null,
                                 null);
       }
-      Log.d(TAG, "Deleted " + count + " programs for  channel " + channelId);
+      Log.d(TAG, "SyncProgramsJobService: Deleted " + count + " programs for  channel " + channelId);
 
       // Remove our local records to stay in sync with the TV Provider.
       XBMCDatabase.removeMedias(getApplicationContext(), channelId);

--- a/tools/android/packaging/xbmc/src/channels/util/SharedPreferencesHelper.java.in
+++ b/tools/android/packaging/xbmc/src/channels/util/SharedPreferencesHelper.java.in
@@ -39,7 +39,7 @@ import java.util.Set;
  */
 public final class SharedPreferencesHelper {
 
-  private static final String TAG = "SharedPreferencesHelper";
+  private static final String TAG = "@APP_NAME@";
 
   private static final String PREFS_NAME = "@APP_PACKAGE@";
   private static final String PREFS_SUBSCRIPTIONS_KEY =
@@ -116,7 +116,7 @@ public final class SharedPreferencesHelper {
         list.add(mGson.fromJson(contactString, clazz));
       }
     } catch (JsonSyntaxException e) {
-      Log.e(TAG, "Could not parse json.", e);
+      Log.e(TAG, "SharedPreferencesHelper: Could not parse json.", e);
       return Collections.emptyList();
     }
     return list;

--- a/tools/android/packaging/xbmc/src/channels/util/TvUtil.java.in
+++ b/tools/android/packaging/xbmc/src/channels/util/TvUtil.java.in
@@ -48,7 +48,7 @@ import @APP_PACKAGE@.channels.model.Subscription;
 public class TvUtil
 {
 
-  private static final String TAG = "TvUtil";
+  private static final String TAG = "@APP_NAME@";
   private static final int CHANNEL_JOB_ID = 500;
   private static final int CHANNEL_TRIGGERED_JOB_ID_OFFSET = 1000;
   private static final int CHANNEL_TIMED_JOB_ID_OFFSET = 2000;
@@ -87,7 +87,7 @@ public class TvUtil
         {
           Log.d(
                   TAG,
-                  "Channel already exists. Returning channel "
+                  "TvUtil: Channel already exists. Returning channel "
                           + channel.getId()
                           + " from TV Provider.");
           return channel.getId();
@@ -111,7 +111,7 @@ public class TvUtil
             .setDisplayName(subscription.getName())
             .setAppLinkIntent(playlistIntent);
 
-    Log.d(TAG, "Creating channel: " + subscription.getName());
+    Log.d(TAG, "TvUtil: Creating channel: " + subscription.getName());
     Uri channelUrl = null;
     try
     {
@@ -121,16 +121,16 @@ public class TvUtil
                               TvContractCompat.Channels.CONTENT_URI,
                               builder.build().toContentValues());
     } catch (IllegalArgumentException e) {
-      Log.e(TAG, "Failed to add channel to the tv provider");
+      Log.e(TAG, "TvUtil: Failed to add channel to the tv provider");
       e.printStackTrace();
     }
 
     if (channelUrl == null)
       return 0;
 
-    Log.d(TAG, "channel insert at " + channelUrl);
+    Log.d(TAG, "TvUtil: channel insert at " + channelUrl);
     long channelId = ContentUris.parseId(channelUrl);
-    Log.d(TAG, "channel id " + channelId);
+    Log.d(TAG, "TvUtil: channel id " + channelId);
 
     Bitmap bitmap = convertToBitmap(context, subscription.getChannelLogo());
     ChannelLogoUtils.storeChannelLogo(context, channelId, bitmap);
@@ -208,7 +208,7 @@ public class TvUtil
     builder.setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY);
     builder.setMinimumLatency(10000);
 
-    Log.d(TAG, "Scheduled channel creation.");
+    Log.d(TAG, "TvUtil: Scheduled channel creation.");
     scheduler.schedule(builder.build());
   }
 
@@ -269,7 +269,7 @@ public class TvUtil
     builder.setExtras(bundle);
 
     JobInfo job = builder.build();
-    Log.d(TAG, "scheduleTimedSyncingProgramsForChannel: minperiod=" + job.getMinPeriodMillis());
+    Log.d(TAG, "TvUtil: scheduleTimedSyncingProgramsForChannel: minperiod=" + job.getMinPeriodMillis());
 
     scheduler.schedule(job);
   }

--- a/tools/android/packaging/xbmc/src/content/XBMCFileContentProvider.java.in
+++ b/tools/android/packaging/xbmc/src/content/XBMCFileContentProvider.java.in
@@ -18,7 +18,7 @@ import java.util.List;
 
 public class XBMCFileContentProvider extends XBMCContentProvider
 {
-  private static String TAG = "@APP_NAME@_File_Provider";
+  private static String TAG = "@APP_NAME@";
 
   public static final String AUTHORITY = AUTHORITY_ROOT + ".file";
 
@@ -132,7 +132,7 @@ public class XBMCFileContentProvider extends XBMCContentProvider
     }
     catch (IOException e)
     {
-      Log.e(getClass().getSimpleName(), "Exception opening pipe", e);
+      Log.e(TAG, "XBMCFileContentProvider: Exception opening pipe", e);
       throw new FileNotFoundException("Could not open pipe for: "
               + uri.toString());
     }
@@ -177,7 +177,7 @@ public class XBMCFileContentProvider extends XBMCContentProvider
       }
       catch (Exception e)
       {
-        Log.e(getClass().getSimpleName(), "Exception transferring file", e);
+        Log.e(TAG, "XBMCFileContentProvider: Exception transferring file", e);
       }
     }
   }

--- a/tools/android/packaging/xbmc/src/content/XBMCMediaContentProvider.java.in
+++ b/tools/android/packaging/xbmc/src/content/XBMCMediaContentProvider.java.in
@@ -11,7 +11,7 @@ import @APP_PACKAGE@.XBMCJsonRPC;
 
 public class XBMCMediaContentProvider extends XBMCContentProvider
 {
-  private static String TAG = "@APP_NAME@_Media_Provider";
+  private static String TAG = "@APP_NAME@";
 
   public static final String AUTHORITY = AUTHORITY_ROOT + ".media";
   public static final String SUGGEST_PATH = "suggestions";
@@ -64,7 +64,7 @@ public class XBMCMediaContentProvider extends XBMCContentProvider
   public Cursor query(Uri uri, String[] projection, String selection,
           String[] selectionArgs, String sortOrder)
   {
-    Log.d(TAG, "query: " + uri.toString());
+    Log.d(TAG, "XBMCMediaContentProvider.query: " + uri.toString());
 
     switch (URI_MATCHER.match(uri))
     {

--- a/tools/android/packaging/xbmc/src/content/XBMCYTDLContentProvider.java.in
+++ b/tools/android/packaging/xbmc/src/content/XBMCYTDLContentProvider.java.in
@@ -18,7 +18,7 @@ import @APP_PACKAGE@.XBMCProperties;
 
 public class XBMCYTDLContentProvider extends XBMCContentProvider
 {
-  private static String TAG = "@APP_NAME@_YTDL_Provider";
+  private static String TAG = "@APP_NAME@";
 
   public static String AUTHORITY = AUTHORITY_ROOT + ".ytdl";
 
@@ -106,7 +106,7 @@ public class XBMCYTDLContentProvider extends XBMCContentProvider
     }
     catch (IOException e)
     {
-      Log.e(getClass().getSimpleName(), "Exception opening pipe", e);
+      Log.e(TAG, "XBMCYTDLContentProvider: Exception opening pipe", e);
       throw new FileNotFoundException("Could not open pipe for: "
               + uri.toString());
     }

--- a/tools/android/packaging/xbmc/src/model/File.java.in
+++ b/tools/android/packaging/xbmc/src/model/File.java.in
@@ -26,13 +26,11 @@ import java.io.Serializable;
  */
 public class File implements Serializable
 {
-
   public static final String NAME = "name";
   public static final String CATEGORY = "category";
   public static final String URI = "uri";
   public static final String MEDIATYPE = "mediatype";
   public static final String ID = "id";
-  private static final String TAG = "File";
   private String name;
   private String category;
   private String mediatype;

--- a/tools/android/packaging/xbmc/src/model/Media.java.in
+++ b/tools/android/packaging/xbmc/src/model/Media.java.in
@@ -22,9 +22,6 @@ import java.io.Serializable;
  */
 public class Media implements Serializable
 {
-
-  private static final String TAG = "Media";
-
   private long id;
   private String title;
   private String description;


### PR DESCRIPTION
## Description
The tag used by Java code to identify debug messages in the device's message log should match the one used in Clog. 

In this way we can capture all the messages generated by the app which eases the debugging.

## How has this been tested?
Tested on Android TV 12

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
