### PR TITLE
Fix infinite loops in CPluginFile

### DIFF
--- a/xbmc/filesystem/PluginFile.cpp
+++ b/xbmc/filesystem/PluginFile.cpp
@@ -18,9 +18,39 @@ CPluginFile::CPluginFile(void) : COverrideFile(false)
 
 CPluginFile::~CPluginFile(void) = default;
 
+bool CPluginFile::Open(const CURL& url)
+{
+  return false;
+}
+
 bool CPluginFile::Exists(const CURL& url)
 {
   return true;
+}
+
+int CPluginFile::Stat(const CURL& url, struct __stat64* buffer)
+{
+  return -1;
+}
+
+int CPluginFile::Stat(struct __stat64* buffer)
+{
+  return -1;
+}
+
+bool CPluginFile::OpenForWrite(const CURL& url, bool bOverWrite)
+{
+  return false;
+}
+
+bool CPluginFile::Delete(const CURL& url)
+{
+  return false;
+}
+
+bool CPluginFile::Rename(const CURL& url, const CURL& urlnew)
+{
+  return false;
 }
 
 std::string CPluginFile::TranslatePath(const CURL& url)

--- a/xbmc/filesystem/PluginFile.h
+++ b/xbmc/filesystem/PluginFile.h
@@ -17,7 +17,13 @@ class CPluginFile : public COverrideFile
 public:
   CPluginFile(void);
   ~CPluginFile(void) override;
+  bool Open(const CURL& url) override;
   bool Exists(const CURL& url) override;
+  int Stat(const CURL& url, struct __stat64* buffer) override;
+  int Stat(struct __stat64* buffer) override;
+  bool OpenForWrite(const CURL& url, bool bOverWrite = false) override;
+  bool Delete(const CURL& url) override;
+  bool Rename(const CURL& url, const CURL& urlnew) override;
 
 protected:
   std::string TranslatePath(const CURL& url) override;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
`CFile` would call into `CPluginFile`, which is a `COverrideFile`. `CPluginFile` was using the default implementations of `COverrideFile`, which would call back into `CFile` and start the cycle all over again. It doesn't make sense to do these operations on a plugin file so `CPluginFile` now provides simple implementations to break the cycle.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #22448. Kodi would crash when using a plugin source with a scraper.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran the simple reproducer in issue #22448 to verify it no longer crashes.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Kodi no longer crashes.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
