### PR TITLE
[macos] identify apple silicon as "ARM Mac OS X" in user agent

### DIFF
--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -1126,6 +1126,8 @@ std::string CSysInfo::GetUserAgent()
   std::string cpuFam(GetBuildTargetCpuFamily());
   if (cpuFam == "x86")
     result += "Intel ";
+  else if (cpuFam == "ARM")
+    result += "ARM ";
   result += "Mac OS X ";
   std::string OSXVersion(GetOsVersion());
   StringUtils::Replace(OSXVersion, '.', '_');


### PR DESCRIPTION
before:

>        "user-agent": "Kodi/20.0-RC2 (Macintosh; Mac OS X 12_6) App_Bitness/64 Version/20.0-RC2-(19.90.905)-Git:20230111-21ec545866",


after:

>        "user-agent": "Kodi/20.0-RC2 (Macintosh; ARM Mac OS X 12_6) App_Bitness/64 Version/20.0-RC2-(19.90.905)-Git:20230111-21ec545866",
