### PR TITLE
[listproviders] Fix deadlock CDirectoryProvider vs. CSubscription.

### DIFF
--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -350,19 +350,20 @@ void CDirectoryProvider::OnFavouritesEvent(const CFavouritesService::FavouritesU
 
 void CDirectoryProvider::Reset()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
-  if (m_jobID)
-    CServiceBroker::GetJobManager()->CancelJob(m_jobID);
-  m_jobID = 0;
-  m_items.clear();
-  m_currentTarget.clear();
-  m_currentUrl.clear();
-  m_itemTypes.clear();
-  m_currentSort.sortBy = SortByNone;
-  m_currentSort.sortOrder = SortOrderAscending;
-  m_currentLimit = 0;
-  m_updateState = OK;
-  lock.unlock();
+  {
+    std::unique_lock<CCriticalSection> lock(m_section);
+    if (m_jobID)
+      CServiceBroker::GetJobManager()->CancelJob(m_jobID);
+    m_jobID = 0;
+    m_items.clear();
+    m_currentTarget.clear();
+    m_currentUrl.clear();
+    m_itemTypes.clear();
+    m_currentSort.sortBy = SortByNone;
+    m_currentSort.sortOrder = SortOrderAscending;
+    m_currentLimit = 0;
+    m_updateState = OK;
+  }
 
   std::unique_lock<CCriticalSection> subscriptionLock(m_subscriptionSection);
   if (m_isSubscribed)
@@ -529,13 +530,14 @@ bool CDirectoryProvider::IsUpdating() const
 
 bool CDirectoryProvider::UpdateURL()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
-  std::string value(m_url.GetLabel(m_parentID, false));
-  if (value == m_currentUrl)
-    return false;
+  {
+    std::unique_lock<CCriticalSection> lock(m_section);
+    std::string value(m_url.GetLabel(m_parentID, false));
+    if (value == m_currentUrl)
+      return false;
 
-  m_currentUrl = value;
-  lock.unlock();
+    m_currentUrl = value;
+  }
 
   std::unique_lock<CCriticalSection> subscriptionLock(m_subscriptionSection);
   if (!m_isSubscribed)

--- a/xbmc/listproviders/DirectoryProvider.h
+++ b/xbmc/listproviders/DirectoryProvider.h
@@ -74,7 +74,6 @@ public:
   void OnJobComplete(unsigned int jobID, bool success, CJob *job) override;
 private:
   UpdateState      m_updateState;
-  bool             m_isAnnounced;
   unsigned int     m_jobID;
   KODI::GUILIB::GUIINFO::CGUIInfoLabel m_url;
   KODI::GUILIB::GUIINFO::CGUIInfoLabel m_target;
@@ -97,4 +96,7 @@ private:
   void OnPVRManagerEvent(const PVR::PVREvent& event);
   void OnFavouritesEvent(const CFavouritesService::FavouritesUpdated& event);
   std::string GetTarget(const CFileItem& item) const;
+
+  CCriticalSection m_subscriptionSection;
+  bool m_isSubscribed{false};
 };


### PR DESCRIPTION
Fixes a deadlock mentioned by @emveepee on Slack. 

The deadlock happens for example when PVR publishes messages while the directory provider is unsubscribing from the PVR event stream.

GUI thread has CDirectoryProvider instance mutex, wants CSubscription instance mutex

```
Not Flagged	>	15256	0	Main Thread	msvcp140d.dll!00007ff9dfa72b2b
 
 	 	 	 	 	[External Code]
 	 	 	 	 	kodi.exe!XbmcThreads::CountingLockable<std::recursive_mutex>::lock() Line 50
 	 	 	 	 	[External Code]
 	 	 	 	 	kodi.exe!detail::CSubscription<enum PVR::PVREvent,CDirectoryProvider>::IsOwnedBy(void * obj) Line 53
 	 	 	 	 	kodi.exe!CEventStream<enum PVR::PVREvent>::Unsubscribe<CDirectoryProvider>(CDirectoryProvider * obj) Line 43
 	 	 	 	 	kodi.exe!CDirectoryProvider::Reset() Line 375
 	 	 	 	 	kodi.exe!CDirectoryProvider::~CDirectoryProvider() Line 207
 	 	 	 	 	[External Code]
 	 	 	 	 	kodi.exe!CGUIBaseContainer::~CGUIBaseContainer() Line 110
 	 	 	 	 	kodi.exe!CGUIPanelContainer::~CGUIPanelContainer() Line 28
 	 	 	 	 	[External Code]
 	 	 	 	 	kodi.exe!CGUIControlGroup::ClearAll() Line 523
 	 	 	 	 	kodi.exe!CGUIControlGroup::~CGUIControlGroup() Line 54
 	 	 	 	 	kodi.exe!CGUIControlGroupList::~CGUIControlGroupList() Line 35
 	 	 	 	 	[External Code]
 	 	 	 	 	kodi.exe!CGUIControlGroup::ClearAll() Line 523
 	 	 	 	 	kodi.exe!CGUIControlGroup::~CGUIControlGroup() Line 54
 	 	 	 	 	[External Code]
 	 	 	 	 	kodi.exe!CGUIControlGroup::ClearAll() Line 523
 	 	 	 	 	kodi.exe!CGUIControlGroup::~CGUIControlGroup() Line 54
 	 	 	 	 	[External Code]
 	 	 	 	 	kodi.exe!CGUIControlGroup::ClearAll() Line 523
 	 	 	 	 	kodi.exe!CGUIControlGroup::~CGUIControlGroup() Line 54
 	 	 	 	 	[External Code]
 	 	 	 	 	kodi.exe!CGUIControlGroup::ClearAll() Line 523
 	 	 	 	 	kodi.exe!CGUIWindow::ClearAll() Line 808
 	 	 	 	 	kodi.exe!CGUIWindow::FreeResources(bool forceUnload) Line 791
 	 	 	 	 	kodi.exe!CGUIWindowManager::DeInitialize() Line 1442
 	 	 	 	 	kodi.exe!CApplicationSkinHandling::UnloadSkin() Line 236
 	 	 	 	 	kodi.exe!CApplicationSkinHandling::LoadSkin(const std::string & skinID) Line 113
 	 	 	 	 	kodi.exe!CApplicationSkinHandling::ReloadSkin(bool confirm) Line 390
 	 	 	 	 	kodi.exe!CApplication::OnMessage(CGUIMessage & message) Line 2719
 	 	 	 	 	kodi.exe!CGUIWindowManager::SendMessageW(CGUIMessage & message) Line 499
 	 	 	 	 	kodi.exe!CGUIWindowManager::DispatchThreadMessages() Line 1562
 	 	 	 	 	kodi.exe!CApplication::Process() Line 3103
 	 	 	 	 	kodi.exe!CApplication::Run() Line 1909
 	 	 	 	 	kodi.exe!XBMC_Run(bool renderGUI) Line 61
 	 	 	 	 	kodi.exe!WinMain(HINSTANCE__ * hInst, HINSTANCE__ * __formal, char * commandLine, int __formal) Line 119
 	 	 	 	 	[External Code]
```

Second thread wants CDirectoryProvider instance mutex, has CSubscription instance mutex

```
Not Flagged		1692	0	Worker Thread	msvcp140d.dll!00007ff9dfa72b2b

 	 	 	 	 	[External Code]
 	 	 	 	 	kodi.exe!XbmcThreads::CountingLockable<std::recursive_mutex>::lock() Line 50
 	 	 	 	 	[External Code]
 	 	 	 	 	kodi.exe!CDirectoryProvider::OnPVRManagerEvent(const PVR::PVREvent & event) Line 333
 	 	 	 	 	kodi.exe!detail::CSubscription<enum PVR::PVREvent,CDirectoryProvider>::HandleEvent(const PVR::PVREvent & event) Line 68
 	 	 	 	 	kodi.exe!CEventSource<enum PVR::PVREvent>::Publish::__l2::<lambda_1>::operator()() Line 78
 	 	 	 	 	kodi.exe!CLambdaJob<`CEventSource<enum PVR::PVREvent>::Publish<enum PVR::PVREvent>'::`2'::<lambda_1>>::DoWork() Line 40
 	 	 	 	 	kodi.exe!CJobWorker::Process() Line 55
 	 	 	 	 	kodi.exe!CThread::Action() Line 267
 	 	 	 	 	kodi.exe!CThread::Create::__l10::<lambda_1>::operator()(CThread * pThread, std::promise<bool> promise) Line 140
 	 	 	 	 	[External Code]
```

Runtime-tested on macOS, latest kodi master. @emveepee runtime-tested the patch on Nexus.

@garbear does the fix look correct to you? Idea is to introduce dedicated mutex to protect subscription/unsubscription.