### PR TITLE
[listproviders] Fix deadlock CDirectoryProvider vs. CSubscription.

### DIFF
--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -350,19 +350,20 @@ void CDirectoryProvider::OnFavouritesEvent(const CFavouritesService::FavouritesU
 
 void CDirectoryProvider::Reset()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
-  if (m_jobID)
-    CServiceBroker::GetJobManager()->CancelJob(m_jobID);
-  m_jobID = 0;
-  m_items.clear();
-  m_currentTarget.clear();
-  m_currentUrl.clear();
-  m_itemTypes.clear();
-  m_currentSort.sortBy = SortByNone;
-  m_currentSort.sortOrder = SortOrderAscending;
-  m_currentLimit = 0;
-  m_updateState = OK;
-  lock.unlock();
+  {
+    std::unique_lock<CCriticalSection> lock(m_section);
+    if (m_jobID)
+      CServiceBroker::GetJobManager()->CancelJob(m_jobID);
+    m_jobID = 0;
+    m_items.clear();
+    m_currentTarget.clear();
+    m_currentUrl.clear();
+    m_itemTypes.clear();
+    m_currentSort.sortBy = SortByNone;
+    m_currentSort.sortOrder = SortOrderAscending;
+    m_currentLimit = 0;
+    m_updateState = OK;
+  }
 
   std::unique_lock<CCriticalSection> subscriptionLock(m_subscriptionSection);
   if (m_isSubscribed)
@@ -529,13 +530,14 @@ bool CDirectoryProvider::IsUpdating() const
 
 bool CDirectoryProvider::UpdateURL()
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
-  std::string value(m_url.GetLabel(m_parentID, false));
-  if (value == m_currentUrl)
-    return false;
+  {
+    std::unique_lock<CCriticalSection> lock(m_section);
+    std::string value(m_url.GetLabel(m_parentID, false));
+    if (value == m_currentUrl)
+      return false;
 
-  m_currentUrl = value;
-  lock.unlock();
+    m_currentUrl = value;
+  }
 
   std::unique_lock<CCriticalSection> subscriptionLock(m_subscriptionSection);
   if (!m_isSubscribed)

--- a/xbmc/listproviders/DirectoryProvider.h
+++ b/xbmc/listproviders/DirectoryProvider.h
@@ -74,7 +74,6 @@ public:
   void OnJobComplete(unsigned int jobID, bool success, CJob *job) override;
 private:
   UpdateState      m_updateState;
-  bool             m_isAnnounced;
   unsigned int     m_jobID;
   KODI::GUILIB::GUIINFO::CGUIInfoLabel m_url;
   KODI::GUILIB::GUIINFO::CGUIInfoLabel m_target;
@@ -97,4 +96,7 @@ private:
   void OnPVRManagerEvent(const PVR::PVREvent& event);
   void OnFavouritesEvent(const CFavouritesService::FavouritesUpdated& event);
   std::string GetTarget(const CFileItem& item) const;
+
+  CCriticalSection m_subscriptionSection;
+  bool m_isSubscribed{false};
 };


### PR DESCRIPTION
Backport of #22459 

@garbear Please review/approve. I cherry picked the master commits without changes.

@fuzzard if there is still the chance, we should merge this for Nexus Final