### PR TITLE
RetroPlayer: Fix gamewindow control ignoring properties outside a list

### DIFF
--- a/xbmc/cores/RetroPlayer/guicontrols/GUIGameControl.cpp
+++ b/xbmc/cores/RetroPlayer/guicontrols/GUIGameControl.cpp
@@ -126,10 +126,10 @@ void CGUIGameControl::SetHeight(float height)
 
 void CGUIGameControl::UpdateInfo(const CGUIListItem* item /* = nullptr */)
 {
-  Reset();
-
   if (item)
   {
+    Reset();
+
     std::string strVideoFilter = m_videoFilterInfo.GetItemLabel(item);
     if (!strVideoFilter.empty())
     {


### PR DESCRIPTION
## Description

Currently, we only use the gamewindow control in a list with listitems. As such, the gamewindow calculates the listitem properties from the itemlayout. However, when used outside a list, the properties (video filter, stretch mode, rotation, etc) are always reset, which effectively means they can't be used outside a list.

This PR fixes that behavior by only resetting the gamewindow properties if the control is inside a list.

## Motivation and context

I discovered this error because my cameraview control introduced in https://github.com/xbmc/xbmc/pull/21183 uses the same base code and has the same problem. I fixed the problem for the cameraview control, and the fix is identical for the gamewindow control.

## How has this been tested?

Currently, it's a lot easier to test my nearly-identical camera control (as it also pumps pixels into RetroPlayer), which I did with the following code:

```xml
<control type="cameraview">
	<topic>/oasis/kinect2/sd/image_color_rect</topic>
	<stretchmode>zoom</stretchmode>
</control>
```

Before, the `stretchmode` property is ignored - it's initially set correctly, but because the cameraview control isn't in a list, `Reset()` clears the stretchmode.

After, the stretchmode property is no longer reset, as would be suggested by this PR's diff, and the stretchmode works correctly.

## What is the effect on users?

* Only affects future use cases of the gamewindow control, in case it's ever used outside a list

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
