### PR TITLE
fix docker cross compilation with mounted windows folder

### DIFF
--- a/cmake/scripts/android/Macros.cmake
+++ b/cmake/scripts/android/Macros.cmake
@@ -1,1 +1,1 @@
-../linux/Macros.cmake
+include(cmake/scripts/linux/Macros.cmake)

--- a/cmake/scripts/freebsd/Install.cmake
+++ b/cmake/scripts/freebsd/Install.cmake
@@ -1,1 +1,1 @@
-../linux/Install.cmake
+include(cmake/scripts/linux/Install.cmake)

--- a/cmake/scripts/freebsd/PathSetup.cmake
+++ b/cmake/scripts/freebsd/PathSetup.cmake
@@ -1,1 +1,1 @@
-../linux/PathSetup.cmake
+include(cmake/scripts/linux/PathSetup.cmake)


### PR DESCRIPTION
## Description
I was trying to cross compile kodi for android on Windows using docker.
I cloned kodi source from Windows and mounted it into the docker.
git clone on windows doesn't support symbolic links and creates a file with symbolic link path as a content
This breaks compilation
```
xbmc# make -C tools/depends/target/cmakebuildsys BUILD_DIR=$HOME/convert/kodi-build
...
CMake Error at cmake/scripts/android/Macros.cmake:1:
  Parse error.  Expected a command name, got unquoted argument with text
  "../linux/Macros.cmake".
```
The fix substitutes symbolic links with files with CMake include command, this fix also included changes for freebsd folder.

## Motivation and context
To be able to checkout code on windows, mount it into the docker image and cross compile from docker.

## How has this been tested?
I tested only android build, but freebsd fix is similar so I don't expect any issues with this.
After the fix "make" step proceeded as expected.

## What is the effect on users?
Users will be able to cross-compile kodi for android on windows using docker and mount kodi repository that was cloned in windows.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [*] **New feature** (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [*] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [*] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
