### PR TITLE
[Nexus] Fix crash on X11 when WAYLAND_DISPLAY is set

### DIFF
--- a/xbmc/windowing/wayland/Connection.cpp
+++ b/xbmc/windowing/wayland/Connection.cpp
@@ -8,13 +8,28 @@
 
 #include "Connection.h"
 
+#include "utils/log.h"
+
 #include <cassert>
+#include <stdexcept>
 
 using namespace KODI::WINDOWING::WAYLAND;
 
 CConnection::CConnection()
 {
-  m_display.reset(new wayland::display_t);
+  try
+  {
+    m_display = std::make_unique<wayland::display_t>();
+  }
+  catch (const std::exception& err)
+  {
+    CLog::Log(LOGERROR, "Wayland connection error: {}", err.what());
+  }
+}
+
+bool CConnection::HasDisplay() const
+{
+  return static_cast<bool>(m_display);
 }
 
 wayland::display_t& CConnection::GetDisplay()

--- a/xbmc/windowing/wayland/Connection.h
+++ b/xbmc/windowing/wayland/Connection.h
@@ -27,6 +27,7 @@ class CConnection
 public:
   CConnection();
 
+  bool HasDisplay() const;
   wayland::display_t& GetDisplay();
 
 private:

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -158,11 +158,14 @@ bool CWinSystemWayland::InitWindowSystem()
   wayland::set_log_handler([](const std::string& message)
                            { CLog::Log(LOGWARNING, "wayland-client log message: {}", message); });
 
+  CLog::LogF(LOGINFO, "Connecting to Wayland server");
+  m_connection = std::make_unique<CConnection>();
+  if (!m_connection->HasDisplay())
+    return false;
+
   VIDEOPLAYER::CProcessInfoWayland::Register();
   RETRO::CRPProcessInfoWayland::Register();
 
-  CLog::LogF(LOGINFO, "Connecting to Wayland server");
-  m_connection.reset(new CConnection);
   m_registry.reset(new CRegistry{*m_connection});
 
   m_registry->RequestSingleton(m_compositor, 1, 4);


### PR DESCRIPTION
## Description

Backport of https://github.com/xbmc/xbmc/pull/22429

## How has this been tested?

https://github.com/xbmc/xbmc/pull/22429 was also tested on Nexus branch before merging.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
