### PR TITLE
[Nexus] RetroPlayer: Fix gamewindow control ignoring non-itemlayout properties

### DIFF
--- a/xbmc/cores/RetroPlayer/guicontrols/GUIGameControl.cpp
+++ b/xbmc/cores/RetroPlayer/guicontrols/GUIGameControl.cpp
@@ -126,10 +126,10 @@ void CGUIGameControl::SetHeight(float height)
 
 void CGUIGameControl::UpdateInfo(const CGUIListItem* item /* = nullptr */)
 {
-  Reset();
-
   if (item)
   {
+    Reset();
+
     std::string strVideoFilter = m_videoFilterInfo.GetItemLabel(item);
     if (!strVideoFilter.empty())
     {


### PR DESCRIPTION
## Description

Backport of https://github.com/xbmc/xbmc/pull/22462

## How has this been tested?

https://github.com/xbmc/xbmc/pull/22462 was also tested on Nexus branch before merging.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
