### PR TITLE
EndTime: fix overflow when doing large comparisons

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -587,7 +587,8 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           }
           LoadSettings();
           m_sink.m_controlPort.SendOutMessage(CSinkControlProtocol::SETNOISETYPE, &m_settings.streamNoise, sizeof(bool));
-          m_sink.m_controlPort.SendOutMessage(CSinkControlProtocol::SETSILENCETIMEOUT, &m_settings.silenceTimeout, sizeof(int));
+          m_sink.m_controlPort.SendOutMessage(CSinkControlProtocol::SETSILENCETIMEOUT,
+                                              &m_settings.silenceTimeoutMinutes, sizeof(int));
           ChangeResamplers();
           if (!NeedReconfigureBuffers() && !NeedReconfigureSink())
             return;
@@ -1795,7 +1796,8 @@ bool CActiveAE::InitSink()
 
   // send message to sink
   m_sink.m_controlPort.SendOutMessage(CSinkControlProtocol::SETNOISETYPE, &m_settings.streamNoise, sizeof(bool));
-  m_sink.m_controlPort.SendOutMessage(CSinkControlProtocol::SETSILENCETIMEOUT, &m_settings.silenceTimeout, sizeof(int));
+  m_sink.m_controlPort.SendOutMessage(CSinkControlProtocol::SETSILENCETIMEOUT,
+                                      &m_settings.silenceTimeoutMinutes, sizeof(int));
 
   Message *reply;
   if (m_sink.m_controlPort.SendOutMessageSync(CSinkControlProtocol::CONFIGURE,
@@ -2662,7 +2664,7 @@ void CActiveAE::LoadSettings()
   m_settings.resampleQuality = static_cast<AEQuality>(settings->GetInt(CSettings::SETTING_AUDIOOUTPUT_PROCESSQUALITY));
   m_settings.atempoThreshold = settings->GetInt(CSettings::SETTING_AUDIOOUTPUT_ATEMPOTHRESHOLD) / 100.0;
   m_settings.streamNoise = settings->GetBool(CSettings::SETTING_AUDIOOUTPUT_STREAMNOISE);
-  m_settings.silenceTimeout = settings->GetInt(CSettings::SETTING_AUDIOOUTPUT_STREAMSILENCE) * 60000;
+  m_settings.silenceTimeoutMinutes = settings->GetInt(CSettings::SETTING_AUDIOOUTPUT_STREAMSILENCE);
 }
 
 void CActiveAE::Start()

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -61,7 +61,7 @@ struct AudioSettings
   AEQuality resampleQuality;
   double atempoThreshold;
   bool streamNoise;
-  int silenceTimeout;
+  int silenceTimeoutMinutes;
 };
 
 class CActiveAEControlProtocol : public Protocol

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.cpp
@@ -126,7 +126,8 @@ void CActiveAESettings::SettingOptionsAudioStreamsilenceFiller(
 {
   std::unique_lock<CCriticalSection> lock(m_instance->m_cs);
 
-  list.emplace_back(g_localizeStrings.Get(20422), std::numeric_limits<int>::max());
+  list.emplace_back(g_localizeStrings.Get(20422),
+                    XbmcThreads::EndTime<std::chrono::minutes>::Max().count());
   list.emplace_back(g_localizeStrings.Get(13551), 0);
 
   if (m_instance->m_audioEngine.SupportsSilenceTimeout())

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -1155,7 +1155,7 @@ void CActiveAESink::GenerateNoise()
 void CActiveAESink::SetSilenceTimer()
 {
   if (m_extStreaming)
-    m_extSilenceTimeout = std::chrono::milliseconds::max();
+    m_extSilenceTimeout = XbmcThreads::EndTime<decltype(m_extSilenceTimeout)>::Max();
   else if (m_extAppFocused)
     m_extSilenceTimeout = m_silenceTimeOut;
   else

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -328,7 +328,7 @@ void CActiveAESink::StateMachine(int signal, Protocol *port, Message *msg)
           return;
 
         case CSinkControlProtocol::SETSILENCETIMEOUT:
-          m_silenceTimeOut = std::chrono::milliseconds(*reinterpret_cast<int*>(msg->data));
+          m_silenceTimeOut = std::chrono::minutes(*reinterpret_cast<int*>(msg->data));
           return;
 
         case CSinkControlProtocol::SETNOISETYPE:

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
@@ -123,7 +123,7 @@ protected:
   int m_state;
   bool m_bStateMachineSelfTrigger;
   std::chrono::milliseconds m_extTimeout;
-  std::chrono::milliseconds m_silenceTimeOut;
+  std::chrono::minutes m_silenceTimeOut{std::chrono::minutes::zero()};
   bool m_extError;
   std::chrono::milliseconds m_extSilenceTimeout;
   bool m_extAppFocused;

--- a/xbmc/guilib/GUIListItemLayout.h
+++ b/xbmc/guilib/GUIListItemLayout.h
@@ -62,7 +62,7 @@ protected:
   INFO::InfoPtr m_condition;
   KODI::GUILIB::GUIINFO::CGUIInfoBool m_isPlaying;
   std::chrono::milliseconds m_infoUpdateMillis =
-      std::chrono::milliseconds(std::numeric_limits<std::chrono::milliseconds::rep>::max());
+      XbmcThreads::EndTime<decltype(m_infoUpdateMillis)>::Max();
   XbmcThreads::EndTime<> m_infoUpdateTimeout;
 };
 

--- a/xbmc/threads/SystemClock.h
+++ b/xbmc/threads/SystemClock.h
@@ -32,10 +32,7 @@ template<typename T>
 class EndTime<T, true>
 {
 public:
-  explicit EndTime(const T duration)
-    : m_startTime(std::chrono::steady_clock::now()), m_totalWaitTime(duration)
-  {
-  }
+  explicit EndTime(const T duration) { Set(duration); }
 
   EndTime() = default;
   EndTime(const EndTime& right) = delete;

--- a/xbmc/threads/SystemClock.h
+++ b/xbmc/threads/SystemClock.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "utils/log.h"
+
 #include <chrono>
 #include <limits>
 #include <thread>
@@ -38,17 +40,26 @@ public:
   EndTime(const EndTime& right) = delete;
   ~EndTime() = default;
 
+  static constexpr T Max() { return m_max; }
+
   void Set(const T duration)
   {
     m_startTime = std::chrono::steady_clock::now();
-    m_totalWaitTime = duration;
+
+    if (duration > m_max)
+    {
+      m_totalWaitTime = m_max;
+      CLog::Log(LOGWARNING, "duration ({}) greater than max ({}) - duration will be truncated!",
+                duration.count(), m_max.count());
+    }
+    else
+    {
+      m_totalWaitTime = duration;
+    }
   }
 
   bool IsTimePast() const
   {
-    if (m_totalWaitTime == m_infinity)
-      return false;
-
     const auto now = std::chrono::steady_clock::now();
 
     return ((now - m_startTime) >= m_totalWaitTime);
@@ -56,9 +67,6 @@ public:
 
   T GetTimeLeft() const
   {
-    if (m_totalWaitTime == m_infinity)
-      return m_infinity;
-
     const auto now = std::chrono::steady_clock::now();
 
     const auto left = ((m_startTime + m_totalWaitTime) - now);
@@ -71,9 +79,9 @@ public:
 
   void SetExpired() { m_totalWaitTime = T::zero(); }
 
-  void SetInfinite() { m_totalWaitTime = m_infinity; }
+  void SetInfinite() { m_totalWaitTime = m_max; }
 
-  bool IsInfinite() const { return (m_totalWaitTime == m_infinity); }
+  bool IsInfinite() const { return (m_totalWaitTime == m_max); }
 
   T GetInitialTimeoutValue() const { return m_totalWaitTime; }
 
@@ -83,7 +91,8 @@ private:
   std::chrono::steady_clock::time_point m_startTime;
   T m_totalWaitTime = T::zero();
 
-  const T m_infinity = T::max();
+  static constexpr T m_max =
+      std::chrono::duration_cast<T>(std::chrono::steady_clock::duration::max());
 };
 
 } // namespace XbmcThreads

--- a/xbmc/threads/SystemClock.h
+++ b/xbmc/threads/SystemClock.h
@@ -81,8 +81,6 @@ public:
 
   void SetInfinite() { m_totalWaitTime = m_max; }
 
-  bool IsInfinite() const { return (m_totalWaitTime == m_max); }
-
   T GetInitialTimeoutValue() const { return m_totalWaitTime; }
 
   std::chrono::steady_clock::time_point GetStartTime() const { return m_startTime; }

--- a/xbmc/threads/test/TestEndTime.cpp
+++ b/xbmc/threads/test/TestEndTime.cpp
@@ -30,7 +30,8 @@ void CommonTests(XbmcThreads::EndTime<T>& endTime)
   EXPECT_EQ(T::zero(), endTime.GetTimeLeft());
 
   endTime.SetInfinite();
-  EXPECT_EQ(T::max(), endTime.GetInitialTimeoutValue());
+  EXPECT_GE(T::max(), endTime.GetInitialTimeoutValue());
+  EXPECT_EQ(XbmcThreads::EndTime<T>::Max(), endTime.GetInitialTimeoutValue());
   endTime.SetExpired();
   EXPECT_EQ(T::zero(), endTime.GetInitialTimeoutValue());
 }

--- a/xbmc/threads/test/TestEndTime.cpp
+++ b/xbmc/threads/test/TestEndTime.cpp
@@ -59,3 +59,19 @@ TEST(TestEndTime, DoubleMicroSeconds)
 
   CommonTests(endTime);
 }
+
+TEST(TestEndTime, SteadyClockDuration)
+{
+  XbmcThreads::EndTime<std::chrono::steady_clock::duration> endTime(100ms);
+
+  CommonTests(endTime);
+
+  endTime.SetInfinite();
+  EXPECT_EQ(std::chrono::steady_clock::duration::max(), endTime.GetInitialTimeoutValue());
+
+  endTime.SetExpired();
+  EXPECT_EQ(std::chrono::steady_clock::duration::zero(), endTime.GetInitialTimeoutValue());
+
+  endTime.Set(endTime.Max());
+  EXPECT_EQ(std::chrono::steady_clock::duration::max(), endTime.GetInitialTimeoutValue());
+}


### PR DESCRIPTION
Backport of: #22452 and #22416 as they both logically belong together.

- Fixes Stream-Silence for Audio
- Fixes various overflows when using new chrono infrastructure, which is already in Nexus