### PR TITLE
[Subtitles] Make m_ccDecoder a unique_ptr

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
@@ -90,7 +90,6 @@ CDVDDemuxCC::CDVDDemuxCC(AVCodecID codec) : m_codec(codec)
 {
   m_hasData = false;
   m_curPts = 0.0;
-  m_ccDecoder = NULL;
 }
 
 CDVDDemuxCC::~CDVDDemuxCC()
@@ -339,7 +338,7 @@ void CDVDDemuxCC::Handler(int service, void *userdata)
 
 bool CDVDDemuxCC::OpenDecoder()
 {
-  m_ccDecoder = new CDecoderCC708();
+  m_ccDecoder = std::make_unique<CDecoderCC708>();
   m_ccDecoder->Init(Handler, this);
   return true;
 }
@@ -348,8 +347,7 @@ void CDVDDemuxCC::Dispose()
 {
   m_streams.clear();
   m_streamdata.clear();
-  delete m_ccDecoder;
-  m_ccDecoder = NULL;
+  m_ccDecoder.reset();
 
   while (!m_ccReorderBuffer.empty())
   {

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.h
@@ -10,6 +10,7 @@
 
 #include "DVDDemux.h"
 
+#include <memory>
 #include <vector>
 
 class CCaptionBlock;
@@ -53,6 +54,6 @@ protected:
   double m_curPts;
   std::vector<CCaptionBlock*> m_ccReorderBuffer;
   std::vector<CCaptionBlock*> m_ccTempBuffer;
-  CDecoderCC708 *m_ccDecoder;
+  std::unique_ptr<CDecoderCC708> m_ccDecoder;
   AVCodecID m_codec;
 };


### PR DESCRIPTION
## Description
Low hanging fruit, just makes `CDVDDemuxCC` use a smart pointer (unique) for the decoder member.