### PR TITLE
[windowing] Cleanup SDL references and 'relicense' xbmc_event file to…

### DIFF
--- a/xbmc/windowing/XBMC_events.h
+++ b/xbmc/windowing/XBMC_events.h
@@ -1,10 +1,5 @@
 /*
- *      SDL - Simple DirectMedia Layer
- *  Copyright (C) 1997-2009 Sam Lantinga
- *      Sam Lantinga
- *      slouken@libsdl.org
- *
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2023 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -12,8 +7,6 @@
  */
 
 #pragma once
-
-/* Include file for SDL event handling */
 
 #include "Resolution.h"
 #include "input/XBMC_keyboard.h"


### PR DESCRIPTION
… team kodi

## Description
For some reason this file still has references to SDL (including the license) when by now it is 100% XBMC/Kodi. This removes the SDL license and attributes it 100% to team kodi.