### PR TITLE
[CGUIDialogContextMenu] fix memory leak

### DIFF
--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -126,17 +126,17 @@ void CGUIDialogContextMenu::SetupButtons()
   CGUIControlGroupList* pGroupList = dynamic_cast<CGUIControlGroupList *>(GetControl(GROUP_LIST));
 
   // add our buttons
-  for (unsigned int i = 0; i < m_buttons.size(); i++)
+  if (pGroupList)
   {
-    CGUIButtonControl *pButton = new CGUIButtonControl(*pButtonTemplate);
-    if (pButton)
-    { // set the button's ID and position
-      int id = BUTTON_START + i;
-      pButton->SetID(id);
-      pButton->SetVisible(true);
-      pButton->SetLabel(m_buttons[i].second);
-      if (pGroupList)
-      {
+    for (unsigned int i = 0; i < m_buttons.size(); i++)
+    {
+      CGUIButtonControl* pButton = new CGUIButtonControl(*pButtonTemplate);
+      if (pButton)
+      { // set the button's ID and position
+        int id = BUTTON_START + i;
+        pButton->SetID(id);
+        pButton->SetVisible(true);
+        pButton->SetLabel(m_buttons[i].second);
         pButton->SetPosition(pButtonTemplate->GetXPosition(), pButtonTemplate->GetYPosition());
         // try inserting context buttons at position specified by template
         // button, if template button is not in grouplist fallback to adding
@@ -591,7 +591,10 @@ void CGUIDialogContextMenu::OnDeinitWindow(int nextWindowID)
   {
     const CGUIControl *control = GetControl(BUTTON_START + i);
     if (control)
+    {
       RemoveControl(control);
+      delete control;
+    }
   }
 
   m_buttons.clear();


### PR DESCRIPTION


## Description
This memory leak is happening when a context menu is opened. The logs are available below.

## Motivation and context
The goal is to clean up some issues detected by the sanitizer.

## How has this been tested?
The option "-fsanitize=leak" is required and should be passed to the compiler and the linker. For a fully sanitized executable, you could use the following options: "-fsanitize=bounds -fsanitize=address -fsanitize=undefined -fsanitize=unreachable -fsanitize=bool -fsanitize=enum -fsanitize=leak -fsanitize-recover=address"

An example below, or you could use the cmake option: -DECM_ENABLE_SANITIZERS
cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS_DEBUG="-ggdb -O2 -fno-omit-frame-pointer -fsanitize=leak" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=leak" -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=leak"

The gcc sanitizer operates properly with a debug version of Python-3.11 compiled with the following options: '--without-pymalloc --with-pydebug --with-valgrind'. As a reminder with Python-3.8 the same options were not enough to generate a "sanitized" compatible python library.

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
