### PR TITLE
Pipewire: move listener creation to constructors

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -347,8 +347,6 @@ bool CAESinkPipewire::Initialize(AEAudioFormat& format, std::string& device)
 
   stream = std::make_shared<PIPEWIRE::CPipewireStream>(*core);
 
-  stream->AddListener();
-
   m_latency = DEFAULT_BUFFER_DURATION;
   uint32_t frames = std::nearbyint(DEFAULT_PERIOD_DURATION.count() * format.m_sampleRate);
   std::string fraction = StringUtils::Format("{}/{}", frames, format.m_sampleRate);

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
@@ -62,7 +62,6 @@ bool CPipewire::Start()
   }
 
   m_core = std::make_unique<CPipewireCore>(*m_context);
-  m_core->AddListener();
 
   m_registry = std::make_unique<CPipewireRegistry>(*m_core);
   m_registry->AddListener();

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireCore.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireCore.cpp
@@ -30,16 +30,13 @@ CPipewireCore::CPipewireCore(CPipewireContext& context)
     CLog::Log(LOGERROR, "CPipewireCore: failed to create core: {}", strerror(errno));
     throw std::runtime_error("CPipewireCore: failed to create core");
   }
+
+  pw_core_add_listener(m_core.get(), &m_coreListener, &m_coreEvents, this);
 }
 
 CPipewireCore::~CPipewireCore()
 {
   spa_hook_remove(&m_coreListener);
-}
-
-void CPipewireCore::AddListener()
-{
-  pw_core_add_listener(m_core.get(), &m_coreListener, &m_coreEvents, this);
 }
 
 void CPipewireCore::Sync()

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireCore.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireCore.h
@@ -32,8 +32,6 @@ public:
 
   CPipewireContext& GetContext() const { return m_context; }
 
-  void AddListener();
-
   void Sync();
   int GetSync() const { return m_sync; }
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
@@ -28,16 +28,12 @@ namespace PIPEWIRE
 CPipewireNode::CPipewireNode(CPipewireRegistry& registry, uint32_t id, const char* type)
   : CPipewireProxy(registry, id, type, PW_VERSION_NODE), m_nodeEvents(CreateNodeEvents())
 {
+  pw_proxy_add_object_listener(m_proxy.get(), &m_objectListener, &m_nodeEvents, this);
 }
 
 CPipewireNode::~CPipewireNode()
 {
   spa_hook_remove(&m_objectListener);
-}
-
-void CPipewireNode::AddListener()
-{
-  pw_proxy_add_object_listener(m_proxy.get(), &m_objectListener, &m_nodeEvents, this);
 }
 
 void CPipewireNode::EnumerateFormats()

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
@@ -38,8 +38,6 @@ CPipewireNode::~CPipewireNode()
 void CPipewireNode::AddListener()
 {
   pw_proxy_add_object_listener(m_proxy.get(), &m_objectListener, &m_nodeEvents, this);
-
-  CPipewireProxy::AddListener();
 }
 
 void CPipewireNode::EnumerateFormats()

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.h
@@ -33,7 +33,7 @@ public:
   CPipewireNode() = delete;
   ~CPipewireNode() override;
 
-  void AddListener() override;
+  void AddListener();
 
   void EnumerateFormats();
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.h
@@ -33,8 +33,6 @@ public:
   CPipewireNode() = delete;
   ~CPipewireNode() override;
 
-  void AddListener();
-
   void EnumerateFormats();
 
   pw_node_info* GetInfo() { return m_info.get(); }

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireProxy.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireProxy.cpp
@@ -35,16 +35,13 @@ CPipewireProxy::CPipewireProxy(CPipewireRegistry& registry,
     CLog::Log(LOGERROR, "CPipewireProxy: failed to create proxy: {}", strerror(errno));
     throw std::runtime_error("CPipewireProxy: failed to create proxy");
   }
+
+  pw_proxy_add_listener(m_proxy.get(), &m_proxyListener, &m_proxyEvents, this);
 }
 
 CPipewireProxy::~CPipewireProxy()
 {
   spa_hook_remove(&m_proxyListener);
-}
-
-void CPipewireProxy::AddListener()
-{
-  pw_proxy_add_listener(m_proxy.get(), &m_proxyListener, &m_proxyEvents, this);
 }
 
 void CPipewireProxy::Bound(void* userdata, uint32_t id)

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireProxy.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireProxy.h
@@ -27,8 +27,6 @@ public:
   CPipewireProxy() = delete;
   virtual ~CPipewireProxy();
 
-  virtual void AddListener();
-
   CPipewireRegistry& GetRegistry() const { return m_registry; }
 
 protected:

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
@@ -78,7 +78,6 @@ void CPipewireRegistry::OnGlobalAdded(void* userdata,
     globals[id]->version = version;
     globals[id]->properties.reset(pw_properties_new_dict(props));
     globals[id]->proxy = std::make_unique<CPipewireNode>(*registry, id, type);
-    globals[id]->proxy->AddListener();
   }
 }
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
@@ -33,16 +33,13 @@ CPipewireStream::CPipewireStream(CPipewireCore& core)
     CLog::Log(LOGERROR, "CPipewireStream: failed to create stream: {}", strerror(errno));
     throw std::runtime_error("CPipewireStream: failed to create stream");
   }
+
+  pw_stream_add_listener(m_stream.get(), &m_streamListener, &m_streamEvents, this);
 }
 
 CPipewireStream::~CPipewireStream()
 {
   spa_hook_remove(&m_streamListener);
-}
-
-void CPipewireStream::AddListener()
-{
-  pw_stream_add_listener(m_stream.get(), &m_streamListener, &m_streamEvents, this);
 }
 
 bool CPipewireStream::Connect(uint32_t id,

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
@@ -34,7 +34,6 @@ public:
 
   CPipewireCore& GetCore() const { return m_core; }
 
-  void AddListener();
   bool Connect(uint32_t id,
                const pw_direction& direction,
                std::vector<const spa_pod*>& params,


### PR DESCRIPTION
This removes the `AddListener` methods and moves the `*_add_listener` calls to the constructor of each class.

Now that we use `this` as userdata it doesn't make sense to have a separate method that needs to be called right after the object creation.

In terms of RAII this makes the object ready to use immediately after construction.