### PR TITLE
Pipewire use references where possible

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.h
@@ -31,10 +31,10 @@ public:
 
   bool Start();
 
-  CPipewireThreadLoop* GetThreadLoop() { return m_loop.get(); }
-  CPipewireContext* GetContext() { return m_context.get(); }
-  CPipewireCore* GetCore() { return m_core.get(); }
-  CPipewireRegistry* GetRegistry() { return m_registry.get(); }
+  CPipewireThreadLoop& GetThreadLoop() { return *m_loop; }
+  CPipewireContext& GetContext() { return *m_context; }
+  CPipewireCore& GetCore() { return *m_core; }
+  CPipewireRegistry& GetRegistry() { return *m_registry; }
   std::shared_ptr<CPipewireStream>& GetStream() { return m_stream; }
 
 private:

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireCore.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireCore.cpp
@@ -46,11 +46,11 @@ void CPipewireCore::Sync()
 
 void CPipewireCore::OnCoreDone(void* userdata, uint32_t id, int seq)
 {
-  auto core = reinterpret_cast<CPipewireCore*>(userdata);
-  auto loop = &core->GetContext().GetThreadLoop();
+  auto& core = *reinterpret_cast<CPipewireCore*>(userdata);
+  auto& loop = core.GetContext().GetThreadLoop();
 
-  if (core->GetSync() == seq)
-    loop->Signal(false);
+  if (core.GetSync() == seq)
+    loop.Signal(false);
 }
 
 pw_core_events CPipewireCore::CreateCoreEvents()

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
@@ -50,17 +50,17 @@ void CPipewireNode::EnumerateFormats()
 
 void CPipewireNode::Info(void* userdata, const struct pw_node_info* info)
 {
-  auto node = reinterpret_cast<CPipewireNode*>(userdata);
+  auto& node = *reinterpret_cast<CPipewireNode*>(userdata);
 
-  if (node->m_info)
+  if (node.m_info)
   {
     CLog::Log(LOGDEBUG, "CPipewireNode::{} - node {} changed", __FUNCTION__, info->id);
-    pw_node_info* m_info = node->m_info.get();
+    pw_node_info* m_info = node.m_info.get();
     m_info = pw_node_info_update(m_info, info);
   }
   else
   {
-    node->m_info.reset(pw_node_info_update(node->m_info.get(), info));
+    node.m_info.reset(pw_node_info_update(node.m_info.get(), info));
   }
 }
 
@@ -178,12 +178,12 @@ void CPipewireNode::Param(void* userdata,
                           uint32_t next,
                           const struct spa_pod* param)
 {
-  auto node = reinterpret_cast<CPipewireNode*>(userdata);
-  auto loop = &node->GetRegistry().GetCore().GetContext().GetThreadLoop();
+  auto& node = *reinterpret_cast<CPipewireNode*>(userdata);
+  auto& loop = node.GetRegistry().GetCore().GetContext().GetThreadLoop();
 
-  node->Parse(SPA_POD_TYPE(param), SPA_POD_BODY(param), SPA_POD_BODY_SIZE(param));
+  node.Parse(SPA_POD_TYPE(param), SPA_POD_BODY(param), SPA_POD_BODY_SIZE(param));
 
-  loop->Signal(false);
+  loop.Signal(false);
 }
 
 pw_node_events CPipewireNode::CreateNodeEvents()

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
@@ -48,7 +48,7 @@ void CPipewireRegistry::OnGlobalAdded(void* userdata,
                                       uint32_t version,
                                       const struct spa_dict* props)
 {
-  auto registry = reinterpret_cast<CPipewireRegistry*>(userdata);
+  auto& registry = *reinterpret_cast<CPipewireRegistry*>(userdata);
 
   if (strcmp(type, PW_TYPE_INTERFACE_Node) == 0)
   {
@@ -67,7 +67,7 @@ void CPipewireRegistry::OnGlobalAdded(void* userdata,
     if (!desc)
       return;
 
-    auto& globals = registry->GetGlobals();
+    auto& globals = registry.GetGlobals();
 
     globals[id] = std::make_unique<global>();
     globals[id]->name = std::string(name);
@@ -77,14 +77,14 @@ void CPipewireRegistry::OnGlobalAdded(void* userdata,
     globals[id]->type = std::string(type);
     globals[id]->version = version;
     globals[id]->properties.reset(pw_properties_new_dict(props));
-    globals[id]->proxy = std::make_unique<CPipewireNode>(*registry, id, type);
+    globals[id]->proxy = std::make_unique<CPipewireNode>(registry, id, type);
   }
 }
 
 void CPipewireRegistry::OnGlobalRemoved(void* userdata, uint32_t id)
 {
-  auto registry = reinterpret_cast<CPipewireRegistry*>(userdata);
-  auto& globals = registry->GetGlobals();
+  auto& registry = *reinterpret_cast<CPipewireRegistry*>(userdata);
+  auto& globals = registry.GetGlobals();
 
   auto global = globals.find(id);
   if (global != globals.end())

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
@@ -117,40 +117,40 @@ void CPipewireStream::StateChanged(void* userdata,
                                    enum pw_stream_state state,
                                    const char* error)
 {
-  auto stream = reinterpret_cast<CPipewireStream*>(userdata);
-  auto loop = &stream->GetCore().GetContext().GetThreadLoop();
+  auto& stream = *reinterpret_cast<CPipewireStream*>(userdata);
+  auto& loop = stream.GetCore().GetContext().GetThreadLoop();
 
   CLog::Log(LOGDEBUG, "CPipewireStream::{} - stream state changed {} -> {}", __FUNCTION__,
             pw_stream_state_as_string(old), pw_stream_state_as_string(state));
 
   if (state == PW_STREAM_STATE_STREAMING)
-    CLog::Log(LOGDEBUG, "CPipewireStream::{} - stream node {}", __FUNCTION__, stream->GetNodeId());
+    CLog::Log(LOGDEBUG, "CPipewireStream::{} - stream node {}", __FUNCTION__, stream.GetNodeId());
 
   if (state == PW_STREAM_STATE_ERROR)
     CLog::Log(LOGDEBUG, "CPipewireStream::{} - stream node {} error: {}", __FUNCTION__,
-              stream->GetNodeId(), error);
+              stream.GetNodeId(), error);
 
-  loop->Signal(false);
+  loop.Signal(false);
 }
 
 void CPipewireStream::Process(void* userdata)
 {
-  auto stream = reinterpret_cast<CPipewireStream*>(userdata);
-  auto loop = &stream->GetCore().GetContext().GetThreadLoop();
+  auto& stream = *reinterpret_cast<CPipewireStream*>(userdata);
+  auto& loop = stream.GetCore().GetContext().GetThreadLoop();
 
-  loop->Signal(false);
+  loop.Signal(false);
 }
 
 void CPipewireStream::Drained(void* userdata)
 {
-  auto stream = reinterpret_cast<CPipewireStream*>(userdata);
-  auto loop = &stream->GetCore().GetContext().GetThreadLoop();
+  auto& stream = *reinterpret_cast<CPipewireStream*>(userdata);
+  auto& loop = stream.GetCore().GetContext().GetThreadLoop();
 
-  stream->SetActive(false);
+  stream.SetActive(false);
 
   CLog::Log(LOGDEBUG, "CPipewireStream::{}", __FUNCTION__);
 
-  loop->Signal(false);
+  loop.Signal(false);
 }
 
 pw_stream_events CPipewireStream::CreateStreamEvents()


### PR DESCRIPTION
This is a follow up to #22440 where we keep references to the main pipewire objects.

This makes sense because for pipewire to work we need the main objects (`CPipewireThreadLoop`, `CPipewireContext`, `CPipewireCore`, and `CPipewireRegistry`) to be valid. Returning a reference for these object means they cannot be `nullptr`.

This is something that should have been a part of the initial implementation but unfortunately I didn't have as much understanding at the time.