### PR TITLE
CDVDMessageQueue: change Get method to use std::chrono

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDMessageQueue.cpp
+++ b/xbmc/cores/VideoPlayer/DVDMessageQueue.cpp
@@ -159,7 +159,7 @@ MsgQueueReturnCode CDVDMessageQueue::Put(const std::shared_ptr<CDVDMsg>& pMsg,
 }
 
 MsgQueueReturnCode CDVDMessageQueue::Get(std::shared_ptr<CDVDMsg>& pMsg,
-                                         unsigned int iTimeoutInMilliSeconds,
+                                         std::chrono::milliseconds timeout,
                                          int& priority)
 {
   std::unique_lock<CCriticalSection> lock(m_section);
@@ -197,7 +197,7 @@ MsgQueueReturnCode CDVDMessageQueue::Get(std::shared_ptr<CDVDMsg>& pMsg,
       ret = MSGQ_OK;
       break;
     }
-    else if (!iTimeoutInMilliSeconds)
+    else if (timeout == 0ms)
     {
       ret = MSGQ_TIMEOUT;
       break;
@@ -208,7 +208,7 @@ MsgQueueReturnCode CDVDMessageQueue::Get(std::shared_ptr<CDVDMsg>& pMsg,
       lock.unlock();
 
       // wait for a new message
-      if (!m_hEvent.Wait(std::chrono::milliseconds(iTimeoutInMilliSeconds)))
+      if (!m_hEvent.Wait(timeout))
         return MSGQ_TIMEOUT;
 
       lock.lock();

--- a/xbmc/cores/VideoPlayer/DVDMessageQueue.h
+++ b/xbmc/cores/VideoPlayer/DVDMessageQueue.h
@@ -65,12 +65,12 @@ public:
    * priority,  minimum priority to get, outputs returned packets priority
    */
   MsgQueueReturnCode Get(std::shared_ptr<CDVDMsg>& pMsg,
-                         unsigned int iTimeoutInMilliSeconds,
+                         std::chrono::milliseconds timeout,
                          int& priority);
-  MsgQueueReturnCode Get(std::shared_ptr<CDVDMsg>& pMsg, unsigned int iTimeoutInMilliSeconds)
+  MsgQueueReturnCode Get(std::shared_ptr<CDVDMsg>& pMsg, std::chrono::milliseconds timeout)
   {
     int priority = 0;
-    return Get(pMsg, iTimeoutInMilliSeconds, priority);
+    return Get(pMsg, timeout, priority);
   }
 
   int GetDataSize() const { return m_iDataSize; }

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2591,7 +2591,7 @@ void CVideoPlayer::HandleMessages()
 {
   std::shared_ptr<CDVDMsg> pMsg = nullptr;
 
-  while (m_messenger.Get(pMsg, 0) == MSGQ_OK)
+  while (m_messenger.Get(pMsg, 0ms) == MSGQ_OK)
   {
     if (pMsg->IsType(CDVDMsg::PLAYER_OPENFILE) &&
         m_messenger.GetPacketCount(CDVDMsg::PLAYER_OPENFILE) == 0)

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -225,7 +225,8 @@ void CVideoPlayerAudio::Process()
   while (!m_bStop)
   {
     std::shared_ptr<CDVDMsg> pMsg;
-    int timeout = (int)(1000 * m_audioSink.GetCacheTime());
+    auto timeout = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::duration<double, std::ratio<1>>(m_audioSink.GetCacheTime()));
 
     // read next packet and return -1 on error
     int priority = 1;
@@ -245,7 +246,7 @@ void CVideoPlayerAudio::Process()
     if (onlyPrioMsgs)
     {
       priority = 1;
-      timeout = 0;
+      timeout = 0ms;
     }
 
     MsgQueueReturnCode ret = m_messageQueue.Get(pMsg, timeout, priority);
@@ -281,7 +282,7 @@ void CVideoPlayerAudio::Process()
           m_stalled = true;
         }
       }
-      if (timeout == 0)
+      if (timeout == 0ms)
         CThread::Sleep(10ms);
 
       continue;

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudioID3.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudioID3.cpp
@@ -27,6 +27,8 @@
 
 using namespace TagLib;
 
+using namespace std::chrono_literals;
+
 CVideoPlayerAudioID3::CVideoPlayerAudioID3(CProcessInfo& processInfo)
   : IDVDStreamPlayer(processInfo), CThread("VideoPlayerAudioID3"), m_messageQueue("id3")
 {
@@ -123,7 +125,7 @@ void CVideoPlayerAudioID3::Process()
   {
     std::shared_ptr<CDVDMsg> pMsg;
     int iPriority = (m_speed == DVD_PLAYSPEED_PAUSE) ? 1 : 0;
-    MsgQueueReturnCode ret = m_messageQueue.Get(pMsg, 2000, iPriority);
+    MsgQueueReturnCode ret = m_messageQueue.Get(pMsg, 2s, iPriority);
 
     // Timeout for ID3 tag data is not a bad thing, so we continue without error
     if (ret == MSGQ_TIMEOUT)

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
@@ -49,6 +49,8 @@ using namespace XFILE;
 using namespace PVR;
 using namespace KODI::MESSAGING;
 
+using namespace std::chrono_literals;
+
 /**
  * Universal Encoder Communication Protocol (UECP)
  * List of defined commands
@@ -612,7 +614,7 @@ void CDVDRadioRDSData::Process()
   {
     std::shared_ptr<CDVDMsg> pMsg;
     int iPriority = (m_speed == DVD_PLAYSPEED_PAUSE) ? 1 : 0;
-    MsgQueueReturnCode ret = m_messageQueue.Get(pMsg, 2000, iPriority);
+    MsgQueueReturnCode ret = m_messageQueue.Get(pMsg, 2s, iPriority);
 
     if (ret == MSGQ_TIMEOUT)
     {

--- a/xbmc/cores/VideoPlayer/VideoPlayerTeletext.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerTeletext.cpp
@@ -15,6 +15,8 @@
 
 #include <mutex>
 
+using namespace std::chrono_literals;
+
 const uint8_t rev_lut[32] =
 {
   0x00,0x08,0x04,0x0c, /*  upper nibble */
@@ -230,7 +232,7 @@ void CDVDTeletextData::Process()
   {
     std::shared_ptr<CDVDMsg> pMsg;
     int iPriority = (m_speed == DVD_PLAYSPEED_PAUSE) ? 1 : 0;
-    MsgQueueReturnCode ret = m_messageQueue.Get(pMsg, 2000, iPriority);
+    MsgQueueReturnCode ret = m_messageQueue.Get(pMsg, 2s, iPriority);
 
     if (ret == MSGQ_TIMEOUT)
     {

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -294,7 +294,8 @@ inline MsgQueueReturnCode CVideoPlayerVideo::GetMessage(std::shared_ptr<CDVDMsg>
                                                         unsigned int iTimeoutInMilliSeconds,
                                                         int& priority)
 {
-  MsgQueueReturnCode ret = m_messageQueue.Get(pMsg, iTimeoutInMilliSeconds, priority);
+  MsgQueueReturnCode ret =
+      m_messageQueue.Get(pMsg, std::chrono::milliseconds(iTimeoutInMilliSeconds), priority);
   m_processInfo.SetLevelVQ(m_messageQueue.GetLevel());
   return ret;
 }

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -291,11 +291,10 @@ inline void CVideoPlayerVideo::FlushMessages()
 }
 
 inline MsgQueueReturnCode CVideoPlayerVideo::GetMessage(std::shared_ptr<CDVDMsg>& pMsg,
-                                                        unsigned int iTimeoutInMilliSeconds,
+                                                        std::chrono::milliseconds timeout,
                                                         int& priority)
 {
-  MsgQueueReturnCode ret =
-      m_messageQueue.Get(pMsg, std::chrono::milliseconds(iTimeoutInMilliSeconds), priority);
+  MsgQueueReturnCode ret = m_messageQueue.Get(pMsg, timeout, priority);
   m_processInfo.SetLevelVQ(m_messageQueue.GetLevel());
   return ret;
 }
@@ -319,7 +318,8 @@ void CVideoPlayerVideo::Process()
 
   while (!m_bStop)
   {
-    int iQueueTimeOut = (int)(m_stalled ? frametime : frametime * 10) / 1000;
+    auto timeout = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::duration<double, std::micro>(m_stalled ? frametime : frametime * 10));
     int iPriority = 0;
 
     if (m_syncState == IDVDStreamPlayer::SYNC_WAITSYNC)
@@ -331,11 +331,11 @@ void CVideoPlayerVideo::Process()
     if (onlyPrioMsgs)
     {
       iPriority = 1;
-      iQueueTimeOut = 1;
+      timeout = 1ms;
     }
 
     std::shared_ptr<CDVDMsg> pMsg;
-    MsgQueueReturnCode ret = GetMessage(pMsg, iQueueTimeOut, iPriority);
+    MsgQueueReturnCode ret = GetMessage(pMsg, timeout, iPriority);
 
     onlyPrioMsgs = false;
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
@@ -93,7 +93,7 @@ protected:
   bool ProcessDecoderOutput(double &frametime, double &pts);
   void SendMessageBack(const std::shared_ptr<CDVDMsg>& pMsg, int priority = 0);
   MsgQueueReturnCode GetMessage(std::shared_ptr<CDVDMsg>& pMsg,
-                                unsigned int iTimeoutInMilliSeconds,
+                                std::chrono::milliseconds timeout,
                                 int& priority);
 
   EOutputState OutputPicture(const VideoPicture* src);


### PR DESCRIPTION
This removes the intermediate call to create a `std::chrono::duration`. Instead we can just pass the duration directly.

I've also included a similar commit for `CVideoPlayerVideo`.

The changes are pretty straight forward.