### PR TITLE
Fix version format as they need to be sortable

### DIFF
--- a/tools/Linux/kodi.metainfo.xml.in
+++ b/tools/Linux/kodi.metainfo.xml.in
@@ -79,12 +79,12 @@
     </screenshots>
     <releases>
         <release date="2023-01-15" version="20.0-Nexus" type="stable"><url>https://kodi.tv/article/kodi-20-0-nexus-release/</url></release>
-        <release date="2022-12-21" version="20.0rc2-Nexus" type="development"><url>https://kodi.tv/article/kodi-nexus-rc-2/</url></release>
-        <release date="2022-12-10" version="20.0rc1-Nexus" type="development"><url>https://kodi.tv/article/kodi-nexus-rc-1/</url></release>
-        <release date="2022-11-08" version="20.0b1-Nexus" type="development"><url>https://kodi.tv/article/kodi-nexus-beta-1/</url></release>
-        <release date="2022-09-08" version="20.0a3-Nexus" type="development"><url>https://kodi.tv/article/kodi-nexus-alpha-3/</url></release>
-        <release date="2022-07-09" version="20.0a2-Nexus" type="development"><url>https://kodi.tv/article/kodi-nexus-alpha-2/</url></release>
-        <release date="2022-05-16" version="20.0a1-Nexus" type="development"><url>https://kodi.tv/article/kodi-nexus-alpha-1/</url></release>
+        <release date="2022-12-21" version="20.0~rc2-Nexus" type="development"><url>https://kodi.tv/article/kodi-nexus-rc-2/</url></release>
+        <release date="2022-12-10" version="20.0~rc1-Nexus" type="development"><url>https://kodi.tv/article/kodi-nexus-rc-1/</url></release>
+        <release date="2022-11-08" version="20.0~b1-Nexus" type="development"><url>https://kodi.tv/article/kodi-nexus-beta-1/</url></release>
+        <release date="2022-09-08" version="20.0~a3-Nexus" type="development"><url>https://kodi.tv/article/kodi-nexus-alpha-3/</url></release>
+        <release date="2022-07-09" version="20.0~a2-Nexus" type="development"><url>https://kodi.tv/article/kodi-nexus-alpha-2/</url></release>
+        <release date="2022-05-16" version="20.0~a1-Nexus" type="development"><url>https://kodi.tv/article/kodi-nexus-alpha-1/</url></release>
         <release date="2022-03-03" version="19.4-Matrix"/>
         <release date="2021-10-24" version="19.3-Matrix"/>
         <release date="2021-10-08" version="19.2-Matrix"/>


### PR DESCRIPTION
These need to be sortable according to the metainfo spec. This failed with the final 20 release, so this should prevent this in the future.
