### PR TITLE
CPipewire: remove ownership of CPipewireStream

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.h
@@ -17,6 +17,10 @@ namespace AE
 {
 namespace SINK
 {
+namespace PIPEWIRE
+{
+class CPipewireStream;
+}
 
 class CAESinkPipewire : public IAESink
 {
@@ -44,6 +48,8 @@ public:
 private:
   AEAudioFormat m_format;
   std::chrono::duration<double, std::ratio<1>> m_latency;
+
+  std::unique_ptr<PIPEWIRE::CPipewireStream> m_stream;
 };
 
 } // namespace SINK

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
@@ -38,7 +38,6 @@ CPipewire::~CPipewire()
     m_loop->Stop();
   }
 
-  m_stream.reset();
   m_registry.reset();
   m_core.reset();
   m_context.reset();

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.h
@@ -21,7 +21,6 @@ class CPipewireThreadLoop;
 class CPipewireContext;
 class CPipewireCore;
 class CPipewireRegistry;
-class CPipewireStream;
 
 class CPipewire
 {
@@ -35,14 +34,12 @@ public:
   CPipewireContext& GetContext() { return *m_context; }
   CPipewireCore& GetCore() { return *m_core; }
   CPipewireRegistry& GetRegistry() { return *m_registry; }
-  std::shared_ptr<CPipewireStream>& GetStream() { return m_stream; }
 
 private:
   std::unique_ptr<CPipewireThreadLoop> m_loop;
   std::unique_ptr<CPipewireContext> m_context;
   std::unique_ptr<CPipewireCore> m_core;
   std::unique_ptr<CPipewireRegistry> m_registry;
-  std::shared_ptr<CPipewireStream> m_stream;
 };
 
 } // namespace PIPEWIRE


### PR DESCRIPTION
The CPipewireStream class should be owned by whoever creates the stream

