### PR TITLE
Fix build on m68k

### DIFF
--- a/xbmc/cores/DllLoader/DllLoader.h
+++ b/xbmc/cores/DllLoader/DllLoader.h
@@ -18,6 +18,7 @@
     !defined(__arc__) && \
     !defined(__arm__) && \
     !defined(__loongarch__) && \
+    !defined(__m68k__) && \
     !defined(__mips__) && \
     !defined(__powerpc__) && \
     !defined(__or1k__) && \

--- a/xbmc/cores/DllLoader/ldt_keeper.c
+++ b/xbmc/cores/DllLoader/ldt_keeper.c
@@ -24,6 +24,7 @@
     !defined(__arc__) &&\
     !defined(__arm__) && \
     !defined(__loongarch__) && \
+    !defined(__m68k__) && \
     !defined(__mips__) && \
     !defined(__or1k__) && \
     !defined(__powerpc__) && \

--- a/xbmc/utils/MathUtils.h
+++ b/xbmc/utils/MathUtils.h
@@ -29,6 +29,7 @@
     defined(__arm__) || \
     defined(__loongarch__) || \
     defined(_M_ARM) || \
+    defined(__m68k__) || \
     defined(__mips__) || \
     defined(__or1k__) || \
     defined(__powerpc__) || \


### PR DESCRIPTION
Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>

## Description
This patch will fix building for this arch:
```
-- Core system type: linux
-- CPU: m68k, ARCH: m68k
-- Cross-Compiling: TRUE
```
## How has this been tested?
Build-tested using a buildroot toolchain
```
m68k-linux-gcc.br_real (Buildroot toolchains.bootlin.com-2021.11-1) 10.3.0
```
## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
