### PR TITLE
[Subtitles][Closed Captions] Add support for style modifiers for EIA608

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/contrib/cc_decoder.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/contrib/cc_decoder.h
@@ -24,6 +24,19 @@
 #define CC_COLUMNS 32
 #define CC_CHANNELS 2
 
+/* colors specified by the EIA 608 standard */
+enum cc_colors
+{
+  WHITE,
+  GREEN,
+  BLUE,
+  CYAN,
+  RED,
+  YELLOW,
+  MAGENTA,
+  BLACK
+};
+
 typedef struct cc_attribute_s {
   uint8_t italic;
   uint8_t underline;
@@ -96,6 +109,7 @@ struct cc_decoder_s
   void(*callback)(int service, void *userdata);
   char text[CC_ROWS*CC_COLUMNS + 1];
   int textlen;
+  cc_attribute_t textattr;
 };
 
 typedef struct cc_decoder_s cc_decoder_t;

--- a/xbmc/utils/ColorUtils.h
+++ b/xbmc/utils/ColorUtils.h
@@ -45,6 +45,8 @@ constexpr Color BLUE = 0xFF0000FF;
 constexpr Color NAVY = 0xFF000080;
 constexpr Color FUCHSIA = 0xFFFF00FF;
 constexpr Color PURPLE = 0xFF800080;
+constexpr Color MAGENTA = 0xFFFF00FF;
+constexpr Color CYAN = 0xFF00FFFF;
 
 struct ColorInfo
 {


### PR DESCRIPTION
## Description
Currently kodi lacks support for style modifiers (italics, font color, underline, etc) for closed captions. This implements it respecting the standard definition. Follows an implementation similar to what the ffmpeg decoder does, however without adding the corresponding modifier tags for ASS and using generic tags the tagger can then recognize and convert to ass.

Loads of stuff that can still be improved, out of the scope of the current PR:
- positioning
- background (by default the standard states it should be a black box, kodi should have some way of disabling this behaviour if we decide to implement it)
- add the actual 2 tracks as 2 different subtitles

## Motivation and context
Improve our closed captions. Support colors, underline and italics.

## How has this been tested?
Using public samples. For colors the best one are those provided by dash:
https://livesim.dashif.org/dash/vod/testpic_2s/cea608.mpd (mp4 download provided below)

https://user-images.githubusercontent.com/7375276/213738051-faa0b4e0-d4b6-4513-afdc-19a635b3c3ec.mp4

## What is the effect on users?
Colors, italics and underline should now be present in CC captions (eia608)

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/7375276/213739208-045e44f0-d3de-47e0-81cf-b74ea5aafb2f.png)

![image](https://user-images.githubusercontent.com/7375276/213739418-b301a8eb-7e0c-4401-a406-2d6ae27035fa.png)

![image](https://user-images.githubusercontent.com/7375276/213740001-1ab48e96-7367-4810-ad1e-8af435997b98.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
