### PR TITLE
[subtitles][closed captions] implement cc_hide_displayed for EIA608

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/contrib/cc_decoder.c
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/contrib/cc_decoder.c
@@ -505,12 +505,21 @@ static cc_buffer_t *active_ccbuffer(cc_decoder_t *dec)
   return &mem->channel[mem->channel_no];
 }
 
+static void cc_hide_displayed(cc_decoder_t* dec)
+{
+  for (int i = 0; i < CC_ROWS * CC_COLUMNS + 1; i++)
+  {
+    dec->text[i] = '\0';
+  }
+  dec->callback(0, dec->userdata);
+}
+
 static void cc_swap_buffers(cc_decoder_t *dec)
 {
   cc_memory_t *temp;
 
   /* hide caption in displayed memory */
-  /* cc_hide_displayed(dec); */
+  cc_hide_displayed(dec);
 
   temp = dec->on_buf;
   dec->on_buf = dec->off_buf;
@@ -675,7 +684,7 @@ static void cc_decode_misc_control_code(cc_decoder_t* dec, int channel, uint8_t 
     break;
 
   case 0x2c:             /* EDM - erase displayed memory */
-    /* cc_hide_displayed(dec); */
+    cc_hide_displayed(dec);
     ccmem_clear(dec->on_buf);
     break;
 


### PR DESCRIPTION
## Description
Currently kodi lacks any way to hide displayed closed captions. For realtime decoding (e.g. when `POP_UP` style is employed) the last subtitle is removed when the next one is decoded and so on. Due to this reason, kodi has a (rather long) default display duration for closed caption entries. However, a few control commands explicitly remove the overlay from the screen without really having to wait for the next one to appear: the case of EDM - erase displayed memory.
From ANSI/CTA-608-E S-2019:

>> Erase Display: In Caption Mode, to clear the screen of all characters (and accompanying background) in
response to codes transmitted on line 21. The caption service provider can accomplish the erasure either
by sending an Erase Displayed Memory (EDM) command or by sending an Erase Non-Displayed Memory
(ENM) command followed by an End of Caption (EOC) command, effectively making a blank caption
"appear." Display can also be erased by the receiver when the caption memory erasure conditions are
met, such as the user changing TV channels. 

This PR implements the missing method, forcing an empty demuxpacket to be sent to the cc caption codec, effectively removing the current displayed text. Same approach [already exists in ffmpeg](https://github.com/FFmpeg/FFmpeg/blob/73fada029c527fda6c248785a948c61249fd4b2d/libavcodec/ccaption_dec.c#L672-L675).

## Motivation and context
Some overlays are displaying for too long, sometimes even blocking burned-in video text:

**Before:**
![image](https://user-images.githubusercontent.com/7375276/213762745-0ae2a040-d8c2-43d5-9717-fa18978d7a72.png)
![image](https://user-images.githubusercontent.com/7375276/213762996-c4721f05-f0e7-4ade-bc37-07979742f7a1.png)


**After:**
![image](https://user-images.githubusercontent.com/7375276/213762729-3a8c6b51-e281-417b-8eb2-31d85b0ab6c0.png)
![image](https://user-images.githubusercontent.com/7375276/213762826-c402fff1-bc7f-474c-b7e3-75e40b36bf8c.png)

