### PR TITLE
[TrueHD] Fix CEngineStats delay/sync in TrueHD IEC + PAPlayer fixes

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -73,7 +73,8 @@ void CEngineStats::GetDelay(AEDelayStatus& status)
   if (m_pcmOutput)
     status.delay += (double)m_bufferedSamples / m_sinkSampleRate;
   else
-    status.delay += (double)m_bufferedSamples * m_sinkFormat.m_streamInfo.GetDuration() / 1000;
+    status.delay += static_cast<double>(m_bufferedSamples) *
+                    m_sinkFormat.m_streamInfo.GetDuration(m_sinkNeedIecPack) / 1000;
 }
 
 void CEngineStats::AddStream(unsigned int streamid)
@@ -126,7 +127,8 @@ void CEngineStats::UpdateStream(CActiveAEStream *stream)
         if (m_pcmOutput)
           delay += (float)(*itBuf)->pkt->nb_samples / (*itBuf)->pkt->config.sample_rate;
         else
-          delay += static_cast<float>(m_sinkFormat.m_streamInfo.GetDuration() / 1000.0);
+          delay +=
+              static_cast<float>(m_sinkFormat.m_streamInfo.GetDuration(m_sinkNeedIecPack) / 1000.0);
       }
       str.m_bufferedTime = static_cast<double>(delay);
       stream->m_bufferedTime = 0;
@@ -144,7 +146,8 @@ void CEngineStats::GetDelay(AEDelayStatus& status, CActiveAEStream *stream)
   if (m_pcmOutput)
     status.delay += (double)m_bufferedSamples / m_sinkSampleRate;
   else
-    status.delay += (double)m_bufferedSamples * m_sinkFormat.m_streamInfo.GetDuration() / 1000;
+    status.delay += static_cast<double>(m_bufferedSamples) *
+                    m_sinkFormat.m_streamInfo.GetDuration(m_sinkNeedIecPack) / 1000;
 
   for (auto &str : m_streamStats)
   {
@@ -167,7 +170,8 @@ void CEngineStats::GetSyncInfo(CAESyncInfo& info, CActiveAEStream *stream)
   if (m_pcmOutput)
     status.delay += (double)m_bufferedSamples / m_sinkSampleRate;
   else
-    status.delay += (double)m_bufferedSamples * m_sinkFormat.m_streamInfo.GetDuration() / 1000;
+    status.delay += static_cast<double>(m_bufferedSamples) *
+                    m_sinkFormat.m_streamInfo.GetDuration(m_sinkNeedIecPack) / 1000;
 
   status.delay += static_cast<double>(m_sinkLatency);
 
@@ -223,7 +227,9 @@ float CEngineStats::GetWaterLevel()
   if (m_pcmOutput)
     return static_cast<float>(m_bufferedSamples) / m_sinkSampleRate;
   else
-    return static_cast<float>(m_bufferedSamples * m_sinkFormat.m_streamInfo.GetDuration()) / 1000;
+    return static_cast<float>(m_bufferedSamples *
+                              m_sinkFormat.m_streamInfo.GetDuration(m_sinkNeedIecPack)) /
+           1000;
 }
 
 void CEngineStats::SetSuspended(bool state)
@@ -1810,6 +1816,7 @@ bool CActiveAE::InitSink()
       m_stats.SetSinkCacheTotal(data->cacheTotal);
       m_stats.SetSinkLatency(data->latency);
       m_stats.SetCurrentSinkFormat(m_sinkFormat);
+      m_stats.SetSinkNeedIec(m_sink.NeedIecPack());
     }
     reply->Release();
   }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -199,6 +199,7 @@ public:
   void SetCurrentSinkFormat(const AEAudioFormat& SinkFormat);
   void SetSinkCacheTotal(float time) { m_sinkCacheTotal = time; }
   void SetSinkLatency(float time) { m_sinkLatency = time; }
+  void SetSinkNeedIec(bool needIEC) { m_sinkNeedIecPack = needIEC; }
   bool IsSuspended();
   AEAudioFormat GetCurrentSinkFormat();
 protected:
@@ -210,6 +211,7 @@ protected:
   bool m_suspended;
   AEAudioFormat m_sinkFormat;
   bool m_pcmOutput;
+  bool m_sinkNeedIecPack{false};
   CCriticalSection m_lock;
   struct StreamStats
   {

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
@@ -100,6 +100,7 @@ public:
   bool HasPassthroughDevice();
   bool SupportsFormat(const std::string &device, AEAudioFormat &format);
   bool DeviceExist(std::string driver, const std::string& device);
+  bool NeedIecPack() const { return m_needIecPack; }
   CSinkControlProtocol m_controlPort;
   CSinkDataProtocol m_dataPort;
 
@@ -150,7 +151,7 @@ protected:
   float m_volume;
   int m_sinkLatency;
   CAEBitstreamPacker *m_packer;
-  bool m_needIecPack;
+  bool m_needIecPack{false};
   bool m_streamNoise;
 };
 

--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
@@ -61,7 +61,7 @@ CAEStreamParser::CAEStreamParser() :
   av_crc_init(m_crcTrueHD, 0, 16, 0x2D, sizeof(m_crcTrueHD));
 }
 
-double CAEStreamInfo::GetDuration(bool paPlayer /*= false*/) const
+double CAEStreamInfo::GetDuration(bool TrueHDHalfDuration /*= false*/) const
 {
   double duration = 0;
   switch (m_type)
@@ -81,7 +81,7 @@ double CAEStreamInfo::GetDuration(bool paPlayer /*= false*/) const
       else
         rate = 176400;
       duration = 3840.0 / rate;
-      if (paPlayer)
+      if (TrueHDHalfDuration)
         duration /= 2;
       break;
     case STREAM_TYPE_DTS_512:

--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.h
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.h
@@ -22,7 +22,7 @@ extern "C" {
 class CAEStreamInfo
 {
 public:
-  double GetDuration(bool paPlayer = false) const;
+  double GetDuration(bool TrueHDHalfDuration = false) const;
   bool operator==(const CAEStreamInfo& info) const;
 
   enum DataType

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -857,8 +857,11 @@ inline bool PAPlayer::ProcessStream(StreamInfo *si, double &freeBufferTime)
       if (si->m_audioFormat.m_dataFormat != AE_FMT_RAW)
         free_space = (double)(si->m_stream->GetSpace() / si->m_bytesPerSample) / si->m_audioFormat.m_sampleRate;
       else
+      {
+        const bool isIEC = !m_processInfo->WantsRawPassthrough();
         free_space = (double)si->m_stream->GetSpace() *
-                     si->m_audioFormat.m_streamInfo.GetDuration(true) / 1000;
+                     si->m_audioFormat.m_streamInfo.GetDuration(isIEC) / 1000;
+      }
 
       freeBufferTime = std::max(freeBufferTime , free_space);
     }
@@ -906,7 +909,8 @@ bool PAPlayer::QueueData(StreamInfo *si)
         CLog::Log(LOGERROR, "PAPlayer::QueueData - unknown error");
         return false;
       }
-      si->m_framesSent += si->m_audioFormat.m_streamInfo.GetDuration(true) / 1000 *
+      const bool isIEC = !m_processInfo->WantsRawPassthrough();
+      si->m_framesSent += si->m_audioFormat.m_streamInfo.GetDuration(isIEC) / 1000 *
                           si->m_audioFormat.m_streamInfo.m_sampleRate;
     }
   }


### PR DESCRIPTION
## Description
Fix CEngineStats delay/sync in TrueHD IEC + PAPlayer fixes

- Fixes Debug Info OSD is imprecise (oscillate) witch TrueHD IEC.
- Fixes PAPlayer progress indicator is imprecise (oscillate) witch TrueHD IEC.
- Fixes PAPlayer progress indicator is wrong duration in Android using TrueHD RAW.
- Improves `CAEStreamInfo::GetDuration()` parameter name.
- Closes https://github.com/xbmc/xbmc/issues/20391


## Motivation and context
While this not fixes any TrueHD dropout, some things still wrong related to TrueHD. This tries to fix a few detected issues...


## How has this been tested?
Runtime tested Windows 11 + NUCi3BEK + Denon X1600H Video player and PAPlayer (.mka THD file)
Runtime tested Nvidia Shield Pro IEC + RAW


## What is the effect on users?
See description


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
