### PR TITLE
[PVR] Fix sort by channel backend order.

### DIFF
--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -1673,8 +1673,7 @@ void CPVRClient::cb_transfer_channel_group_member(void* kodiInstance,
       auto* groupMembers =
           static_cast<std::vector<std::shared_ptr<CPVRChannelGroupMember>>*>(handle->dataAddress);
       groupMembers->emplace_back(
-          std::make_shared<CPVRChannelGroupMember>(-1, // real id will be added later
-                                                   member->strGroupName, channel));
+          std::make_shared<CPVRChannelGroupMember>(member->strGroupName, member->iOrder, channel));
     }
   });
 }

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -70,6 +70,7 @@ CPVRChannel::CPVRChannel(const PVR_CHANNEL& channel, unsigned int iClientId)
     m_strClientChannelName(channel.strChannelName),
     m_strMimeType(channel.strMimeType),
     m_iClientEncryptionSystem(channel.iEncryptionSystem),
+    m_iClientOrder(channel.iOrder),
     m_iClientProviderUid(channel.iClientProviderUid)
 {
   if (m_strChannelName.empty())

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -573,7 +573,7 @@ bool CPVRChannelGroup::UpdateFromClient(const std::shared_ptr<CPVRChannelGroupMe
     }
 
     existingMember->SetClientChannelNumber(channel->ClientChannelNumber());
-    existingMember->SetOrder(channel->ClientOrder());
+    existingMember->SetOrder(groupMember->Order());
 
     if (existingMember->NeedsSave())
     {

--- a/xbmc/pvr/channels/PVRChannelGroupMember.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupMember.cpp
@@ -21,6 +21,15 @@
 
 using namespace PVR;
 
+CPVRChannelGroupMember::CPVRChannelGroupMember(const std::string& groupName,
+                                               int order,
+                                               const std::shared_ptr<CPVRChannel>& channel)
+  : m_clientChannelNumber(channel->ClientChannelNumber()), m_iOrder(order)
+{
+  SetChannel(channel);
+  SetGroupName(groupName);
+}
+
 CPVRChannelGroupMember::CPVRChannelGroupMember(int iGroupID,
                                                const std::string& groupName,
                                                const std::shared_ptr<CPVRChannel>& channel)

--- a/xbmc/pvr/channels/PVRChannelGroupMember.h
+++ b/xbmc/pvr/channels/PVRChannelGroupMember.h
@@ -27,6 +27,10 @@ class CPVRChannelGroupMember : public ISerializable, public ISortable
 public:
   CPVRChannelGroupMember() : m_bNeedsSave(false) {}
 
+  CPVRChannelGroupMember(const std::string& groupName,
+                         int order,
+                         const std::shared_ptr<CPVRChannel>& channel);
+
   CPVRChannelGroupMember(int iGroupID,
                          const std::string& groupName,
                          const std::shared_ptr<CPVRChannel>& channel);


### PR DESCRIPTION
Fixes #22496 

Runtime-tested on macOS and Android, latest Kodi master.
Runtime-tested by issue submitter, confirming it working.

@phunkyfish when you find time for code review. Sorry that I broke stuff you introduced.