### PR TITLE
Pipewire: implement passthrough support

### DIFF
--- a/cmake/modules/FindPipewire.cmake
+++ b/cmake/modules/FindPipewire.cmake
@@ -12,7 +12,7 @@
 #
 
 if(PKG_CONFIG_FOUND)
-  pkg_check_modules(PC_PIPEWIRE libpipewire-0.3>=0.3.24 QUIET)
+  pkg_check_modules(PC_PIPEWIRE libpipewire-0.3>=0.3.34 QUIET)
   pkg_check_modules(PC_SPA libspa-0.2>=0.2 QUIET)
 endif()
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -399,7 +399,7 @@ bool CAESinkPipewire::Initialize(AEAudioFormat& format, std::string& device)
   // clang-format off
   params.emplace_back(static_cast<const spa_pod*>(spa_pod_builder_add_object(
       &builder, SPA_TYPE_OBJECT_ParamBuffers, SPA_PARAM_Buffers,
-          SPA_PARAM_BUFFERS_buffers, SPA_POD_CHOICE_RANGE_Int(6, 6, 6),
+          SPA_PARAM_BUFFERS_buffers, SPA_POD_CHOICE_RANGE_Int(20, 16, 24),
           SPA_PARAM_BUFFERS_blocks, SPA_POD_Int(1),
           SPA_PARAM_BUFFERS_size, SPA_POD_Int(frames * pwChannels.size() * PWFormatToSampleSize(pwFormat)),
           SPA_PARAM_BUFFERS_stride, SPA_POD_Int(pwChannels.size() * PWFormatToSampleSize(pwFormat)))));

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -519,7 +519,7 @@ unsigned int CAESinkPipewire::AddPackets(uint8_t** data, unsigned int frames, un
 
     const auto now = std::chrono::steady_clock::now();
 
-    if ((delay <= (m_latency - period)) || ((now - start) >= period))
+    if ((delay <= (DEFAULT_BUFFER_DURATION - DEFAULT_PERIOD_DURATION)) || ((now - start) >= period))
       break;
 
     loop.Wait(5ms);

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -507,6 +507,9 @@ unsigned int CAESinkPipewire::AddPackets(uint8_t** data, unsigned int frames, un
 
   m_stream->QueueBuffer(pwBuffer);
 
+  const auto period = std::chrono::duration<double, std::ratio<1>>(static_cast<double>(frames) /
+                                                                   m_format.m_sampleRate);
+
   do
   {
     pw_time time = m_stream->GetTime();
@@ -515,9 +518,6 @@ unsigned int CAESinkPipewire::AddPackets(uint8_t** data, unsigned int frames, un
         PWTimeToAEDelay(time, m_format.m_sampleRate);
 
     const auto now = std::chrono::steady_clock::now();
-
-    const auto period = std::chrono::duration<double, std::ratio<1>>(static_cast<double>(frames) /
-                                                                     m_format.m_sampleRate);
 
     if ((delay <= (m_latency - period)) || ((now - start) >= period))
       break;

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -187,6 +187,8 @@ constexpr int DEFAULT_PERIODS = 4;
 constexpr std::chrono::duration<double, std::ratio<1>> DEFAULT_PERIOD_DURATION =
     DEFAULT_BUFFER_DURATION / DEFAULT_PERIODS;
 
+constexpr int DEFAULT_LATENCY_DIVIDER = 3;
+
 } // namespace
 
 namespace AE
@@ -348,7 +350,8 @@ bool CAESinkPipewire::Initialize(AEAudioFormat& format, std::string& device)
 
   m_latency = DEFAULT_BUFFER_DURATION;
   uint32_t frames = std::nearbyint(DEFAULT_PERIOD_DURATION.count() * format.m_sampleRate);
-  std::string fraction = StringUtils::Format("{}/{}", frames, format.m_sampleRate);
+  std::string fraction =
+      StringUtils::Format("{}/{}", frames / DEFAULT_LATENCY_DIVIDER, format.m_sampleRate);
 
   std::array<spa_dict_item, 5> items = {
       SPA_DICT_ITEM_INIT(PW_KEY_MEDIA_TYPE, "Audio"),
@@ -374,7 +377,8 @@ bool CAESinkPipewire::Initialize(AEAudioFormat& format, std::string& device)
   CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - framesize: {}", __FUNCTION__,
             pwChannels.size() * PWFormatToSampleSize(pwFormat));
   CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - latency: {}/{} ({:.3f}s)", __FUNCTION__, frames,
-            format.m_sampleRate, static_cast<double>(frames) / format.m_sampleRate);
+            format.m_sampleRate,
+            static_cast<double>(frames) / DEFAULT_LATENCY_DIVIDER / format.m_sampleRate);
 
   spa_audio_info_raw info{};
   info.format = pwFormat;

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -185,7 +185,7 @@ std::chrono::duration<double, std::ratio<1>> PWTimeToAEDelay(const pw_time& time
 constexpr std::chrono::duration<double, std::ratio<1>> DEFAULT_BUFFER_DURATION = 0.200s;
 constexpr int DEFAULT_PERIODS = 4;
 constexpr std::chrono::duration<double, std::ratio<1>> DEFAULT_PERIOD_DURATION =
-    DEFAULT_BUFFER_DURATION / 4;
+    DEFAULT_BUFFER_DURATION / DEFAULT_PERIODS;
 
 } // namespace
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -448,17 +448,6 @@ bool CAESinkPipewire::Initialize(AEAudioFormat& format, std::string& device)
   auto pwChannels = AEChannelMapToPWChannelMap(format.m_channelLayout);
   format.m_channelLayout = PWChannelMapToAEChannelMap(pwChannels);
 
-  CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - rate: {}", __FUNCTION__, format.m_sampleRate);
-  CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - channels: {}", __FUNCTION__, pwChannels.size());
-  CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - format: {}", __FUNCTION__, PWFormatToString(pwFormat));
-  CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - samplesize: {}", __FUNCTION__,
-            PWFormatToSampleSize(pwFormat));
-  CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - framesize: {}", __FUNCTION__,
-            pwChannels.size() * PWFormatToSampleSize(pwFormat));
-  CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - latency: {}/{} ({:.3f}s)", __FUNCTION__, frames,
-            format.m_sampleRate,
-            static_cast<double>(frames) / DEFAULT_LATENCY_DIVIDER / format.m_sampleRate);
-
   std::array<uint8_t, 1024> buffer;
   auto builder = SPA_POD_BUILDER_INIT(buffer.data(), buffer.size());
 
@@ -510,6 +499,17 @@ bool CAESinkPipewire::Initialize(AEAudioFormat& format, std::string& device)
     loop.Unlock();
     return false;
   }
+
+  CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - rate: {}", __FUNCTION__, format.m_sampleRate);
+  CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - channels: {}", __FUNCTION__, pwChannels.size());
+  CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - format: {}", __FUNCTION__, PWFormatToString(pwFormat));
+  CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - samplesize: {}", __FUNCTION__,
+            PWFormatToSampleSize(pwFormat));
+  CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - framesize: {}", __FUNCTION__,
+            pwChannels.size() * PWFormatToSampleSize(pwFormat));
+  CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - latency: {}/{} ({:.3f}s)", __FUNCTION__, frames,
+            format.m_sampleRate,
+            static_cast<double>(frames) / DEFAULT_LATENCY_DIVIDER / format.m_sampleRate);
 
   pw_stream_state state;
   do

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
@@ -153,6 +153,12 @@ void CPipewireNode::Parse(uint32_t type, void* body, uint32_t size)
                     prop->value.type, SPA_POD_CONTENTS(spa_pod_prop, prop), prop->value.size);
                 break;
               }
+              case SPA_FORMAT_AUDIO_iec958Codec:
+              {
+                m_iec958Codecs = ParseArray<spa_audio_iec958_codec>(
+                    prop->value.type, SPA_POD_CONTENTS(spa_pod_prop, prop), prop->value.size);
+                break;
+              }
               default:
                 break;
             }

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.h
@@ -14,6 +14,7 @@
 #include <set>
 
 #include <pipewire/node.h>
+#include <spa/param/audio/iec958.h>
 #include <spa/param/audio/raw.h>
 
 namespace AE
@@ -40,6 +41,7 @@ public:
   std::set<spa_audio_format>& GetFormats() { return m_formats; }
   std::set<spa_audio_channel>& GetChannels() { return m_channels; }
   std::set<uint32_t>& GetRates() { return m_rates; }
+  std::set<spa_audio_iec958_codec>& GetIEC958Codecs() { return m_iec958Codecs; }
 
 private:
   void Parse(uint32_t type, void* body, uint32_t size);
@@ -68,6 +70,7 @@ private:
   std::set<spa_audio_format> m_formats;
   std::set<spa_audio_channel> m_channels;
   std::set<uint32_t> m_rates;
+  std::set<spa_audio_iec958_codec> m_iec958Codecs;
 };
 
 } // namespace PIPEWIRE


### PR DESCRIPTION
This adds support for passthrough formats when using the pipewire sink.

This bumps the minimum pipewire version required to [0.3.34](https://gitlab.freedesktop.org/pipewire/pipewire/-/releases/0.3.34). I'm not sure if this is the actual minimum as I didn't try and compile against it. I just looked for relevant changes that are needed for these changes. For example: https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/8147772cf59a5508ac1351684b5947401f1416ba

The main bulk of the changes is to support using `spa_audio_info_iec958` which allows us to use passthrough. Pipewire supports all codecs that we support (including HD formats). Though I've only tested DTS, AC3, DTS-HD MA, and TrueHD. I don't think I have any EAC3 sources.

This still may need some tweaking in the future as I've only tested this on my workstation and not a low powered device.