### PR TITLE
[Android] Revert main layout background transparency to black

### DIFF
--- a/tools/android/packaging/xbmc/res/layout/activity_main.xml
+++ b/tools/android/packaging/xbmc/res/layout/activity_main.xml
@@ -2,6 +2,6 @@
   android:id="@+id/VideoLayout"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
-  android:background="@android:color/transparent">
+  android:background="@android:color/black">
 </RelativeLayout>
 

--- a/tools/android/packaging/xbmc/src/Main.java.in
+++ b/tools/android/packaging/xbmc/src/Main.java.in
@@ -208,7 +208,6 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
   public void onStart()
   {
     super.onStart();
-    mDecorView.setBackgroundColor(Color.TRANSPARENT);
 
     Choreographer.getInstance().removeFrameCallback(this);
     Choreographer.getInstance().postFrameCallback(this);


### PR DESCRIPTION
## Description
This improves playback for devices that don't properly support non-fullscreen renders, in Dolby Vision mode only.
Since Kodi renders to a cropped view (using margins), the default background is transparent.
Some devices have problems with this transparent background, and instead renders it as a higher black floor for some reason.
This makes cropped videos (or any that don't fill the view) have noticeable elevated black in letterboxing areas.
For some reason, this only affects Dolby Vision mode.

Known devices with this bug: FireTV Stick 4K Max, FireTV Cube 3rd gen.

The change is now simply a revert of 6f984677ed840f391d78307955a7df39f3016eb8, as discussed.

## Motivation and context
Improves playback quality of Dolby Vision videos that were cropped, and that don't have 16:9 stored dimensions.

## How has this been tested?
Runtime tested on FireTV Stick 4K Max.

## What is the effect on users?
Impacts main app code to remove a workaround added in https://github.com/xbmc/xbmc/pull/15225.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
