### PR TITLE
[backport] TrueHD fixes + AudioTrack fixes + PAPlayer fixes

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -74,7 +74,8 @@ void CEngineStats::GetDelay(AEDelayStatus& status)
   if (m_pcmOutput)
     status.delay += (double)m_bufferedSamples / m_sinkSampleRate;
   else
-    status.delay += (double)m_bufferedSamples * m_sinkFormat.m_streamInfo.GetDuration() / 1000;
+    status.delay += static_cast<double>(m_bufferedSamples) *
+                    m_sinkFormat.m_streamInfo.GetDuration(m_sinkNeedIecPack) / 1000;
 }
 
 void CEngineStats::AddStream(unsigned int streamid)
@@ -127,7 +128,8 @@ void CEngineStats::UpdateStream(CActiveAEStream *stream)
         if (m_pcmOutput)
           delay += (float)(*itBuf)->pkt->nb_samples / (*itBuf)->pkt->config.sample_rate;
         else
-          delay += static_cast<float>(m_sinkFormat.m_streamInfo.GetDuration() / 1000.0);
+          delay +=
+              static_cast<float>(m_sinkFormat.m_streamInfo.GetDuration(m_sinkNeedIecPack) / 1000.0);
       }
       str.m_bufferedTime = static_cast<double>(delay);
       stream->m_bufferedTime = 0;
@@ -145,7 +147,8 @@ void CEngineStats::GetDelay(AEDelayStatus& status, CActiveAEStream *stream)
   if (m_pcmOutput)
     status.delay += (double)m_bufferedSamples / m_sinkSampleRate;
   else
-    status.delay += (double)m_bufferedSamples * m_sinkFormat.m_streamInfo.GetDuration() / 1000;
+    status.delay += static_cast<double>(m_bufferedSamples) *
+                    m_sinkFormat.m_streamInfo.GetDuration(m_sinkNeedIecPack) / 1000;
 
   for (auto &str : m_streamStats)
   {
@@ -168,7 +171,8 @@ void CEngineStats::GetSyncInfo(CAESyncInfo& info, CActiveAEStream *stream)
   if (m_pcmOutput)
     status.delay += (double)m_bufferedSamples / m_sinkSampleRate;
   else
-    status.delay += (double)m_bufferedSamples * m_sinkFormat.m_streamInfo.GetDuration() / 1000;
+    status.delay += static_cast<double>(m_bufferedSamples) *
+                    m_sinkFormat.m_streamInfo.GetDuration(m_sinkNeedIecPack) / 1000;
 
   status.delay += static_cast<double>(m_sinkLatency);
 
@@ -224,7 +228,9 @@ float CEngineStats::GetWaterLevel()
   if (m_pcmOutput)
     return static_cast<float>(m_bufferedSamples) / m_sinkSampleRate;
   else
-    return static_cast<float>(m_bufferedSamples * m_sinkFormat.m_streamInfo.GetDuration()) / 1000;
+    return static_cast<float>(m_bufferedSamples *
+                              m_sinkFormat.m_streamInfo.GetDuration(m_sinkNeedIecPack)) /
+           1000;
 }
 
 void CEngineStats::SetSuspended(bool state)
@@ -1822,6 +1828,7 @@ bool CActiveAE::InitSink()
       m_stats.SetSinkCacheTotal(data->cacheTotal);
       m_stats.SetSinkLatency(data->latency);
       m_stats.SetCurrentSinkFormat(m_sinkFormat);
+      m_stats.SetSinkNeedIec(m_sink.NeedIecPack());
     }
     reply->Release();
   }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -198,6 +198,7 @@ public:
   void SetCurrentSinkFormat(const AEAudioFormat& SinkFormat);
   void SetSinkCacheTotal(float time) { m_sinkCacheTotal = time; }
   void SetSinkLatency(float time) { m_sinkLatency = time; }
+  void SetSinkNeedIec(bool needIEC) { m_sinkNeedIecPack = needIEC; }
   bool IsSuspended();
   AEAudioFormat GetCurrentSinkFormat();
 protected:
@@ -209,6 +210,7 @@ protected:
   bool m_suspended;
   AEAudioFormat m_sinkFormat;
   bool m_pcmOutput;
+  bool m_sinkNeedIecPack{false};
   CCriticalSection m_lock;
   struct StreamStats
   {

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
@@ -100,6 +100,7 @@ public:
   bool HasPassthroughDevice();
   bool SupportsFormat(const std::string &device, AEAudioFormat &format);
   bool DeviceExist(std::string driver, const std::string& device);
+  bool NeedIecPack() const { return m_needIecPack; }
   CSinkControlProtocol m_controlPort;
   CSinkDataProtocol m_dataPort;
 
@@ -150,7 +151,7 @@ protected:
   float m_volume;
   int m_sinkLatency;
   CAEBitstreamPacker *m_packer;
-  bool m_needIecPack;
+  bool m_needIecPack{false};
   bool m_streamNoise;
 };
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -910,7 +910,7 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t **data, unsigned int frames, 
     // exactly once with the last package for some 100 ms
     double extra_sleep = 0.0;
     if (time_to_add_ms < m_format.m_streamInfo.GetDuration())
-      extra_sleep = (m_format.m_streamInfo.GetDuration() - time_to_add_ms) / 2.0;
+      extra_sleep = (m_format.m_streamInfo.GetDuration() - time_to_add_ms);
 
     // if there is still place, just add it without blocking
     if (m_delay < (m_audiotrackbuffer_sec - (m_format.m_streamInfo.GetDuration() / 1000.0)))
@@ -938,7 +938,7 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t **data, unsigned int frames, 
       double time_should_ms = 1000.0 * written_frames / m_format.m_sampleRate;
       double time_off = time_should_ms - time_to_add_ms;
       if (time_off > 0)
-        usleep(time_off * 500); // sleep half the error away
+        usleep(time_off * 1000); // sleep the error away
     }
   }
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -425,6 +425,7 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
       atChannelMask = CJNIAudioFormat::CHANNEL_OUT_STEREO;
   }
 
+  bool retried = false;
   while (!m_at_jni)
   {
     CLog::Log(LOGINFO, "Trying to open: samplerate: {}, channelMask: {}, encoding: {}",
@@ -578,6 +579,18 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
         {
           atChannelMask = CJNIAudioFormat::CHANNEL_OUT_STEREO;
           CLog::Log(LOGDEBUG, "AESinkAUDIOTRACK - Retrying with a stereo layout");
+          continue;
+        }
+      }
+      else
+      {
+        if (!retried)
+        {
+          retried = true;
+          CLog::Log(LOGWARNING, "AESinkAUDIOTRACK - Unable to open PT device - will retry once");
+          // Seems that some devices don't properly implement pause + flush, which during seek
+          // might open the device too fast - let's retry
+          usleep(200 * 1000);
           continue;
         }
       }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -651,6 +651,11 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
     return;
   }
 
+  double ratio = (m_passthrough && m_info.m_wantsIECPassthrough &&
+                  (m_format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD))
+                     ? 2.0
+                     : 1.0;
+
   bool usesAdvancedLogging = CServiceBroker::GetLogging().CanLogComponent(LOGAUDIO);
   // In their infinite wisdom, Google decided to make getPlaybackHeadPosition
   // return a 32bit "int" that you should "interpret as unsigned."  As such,
@@ -665,7 +670,7 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
   // and add head_pos which wrapped around, e.g. 0x0001 0000 0000 -> 0x0001 0000 0004
   m_headPos = (m_headPos & UINT64_UPPER_BYTES) | (uint64_t)head_pos;
 
-  double gone = static_cast<double>(m_headPos) / m_sink_sampleRate;
+  double gone = static_cast<double>(m_headPos) / m_sink_sampleRate / ratio;
 
   // if sink is run dry without buffer time written anymore
   if (gone > m_duration_written)
@@ -717,7 +722,7 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
     }
     m_timestampPos = stamphead;
 
-    double playtime = m_timestampPos / static_cast<double>(m_sink_sampleRate);
+    double playtime = m_timestampPos / static_cast<double>(m_sink_sampleRate) / ratio;
 
     if (usesAdvancedLogging)
     {

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -750,12 +750,7 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
 
   delay += m_hw_delay;
 
-  // stop smoothing if we have the new API available
-  // though normal RAW still is really bad delay wise
-  bool rawPt = m_passthrough && !m_info.m_wantsIECPassthrough;
-  if ((m_hw_delay != 0) && !rawPt)
-    m_linearmovingaverage.clear();
-
+  const bool rawPt = m_passthrough && !m_info.m_wantsIECPassthrough;
   if (rawPt)
   {
     if (m_at_jni->getPlayState() == CJNIAudioTrack::PLAYSTATE_PAUSED)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -905,7 +905,7 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t **data, unsigned int frames, 
     // exactly once with the last package for some 100 ms
     double extra_sleep = 0.0;
     if (time_to_add_ms < m_format.m_streamInfo.GetDuration())
-      extra_sleep = (m_format.m_streamInfo.GetDuration() - time_to_add_ms);
+      extra_sleep = (m_format.m_streamInfo.GetDuration() - time_to_add_ms) / 2;
 
     // if there is still place, just add it without blocking
     if (m_delay < (m_audiotrackbuffer_sec - (m_format.m_streamInfo.GetDuration() / 1000.0)))
@@ -922,7 +922,7 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t **data, unsigned int frames, 
       double time_should_ms = 1000.0 * written_frames / m_format.m_sampleRate;
       double time_off = time_should_ms - time_to_add_ms;
       if (time_off > 0)
-        usleep(time_off * 1000); // sleep the error away
+        usleep(time_off * 500); // sleep half the error on average away
     }
   }
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -88,7 +88,6 @@ private:
   bool               m_passthrough;
   double             m_audiotrackbuffer_sec;
   int                m_encoding;
-  double m_pause_ms = 0.0;
   double m_delay = 0.0;
   double m_hw_delay = 0.0;
   CJNIAudioTimestamp m_timestamp;

--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
@@ -61,7 +61,7 @@ CAEStreamParser::CAEStreamParser() :
   av_crc_init(m_crcTrueHD, 0, 16, 0x2D, sizeof(m_crcTrueHD));
 }
 
-double CAEStreamInfo::GetDuration(bool paPlayer /*= false*/) const
+double CAEStreamInfo::GetDuration(bool TrueHDHalfDuration /*= false*/) const
 {
   double duration = 0;
   switch (m_type)
@@ -81,7 +81,7 @@ double CAEStreamInfo::GetDuration(bool paPlayer /*= false*/) const
       else
         rate = 176400;
       duration = 3840.0 / rate;
-      if (paPlayer)
+      if (TrueHDHalfDuration)
         duration /= 2;
       break;
     case STREAM_TYPE_DTS_512:

--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.h
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.h
@@ -22,7 +22,7 @@ extern "C" {
 class CAEStreamInfo
 {
 public:
-  double GetDuration(bool paPlayer = false) const;
+  double GetDuration(bool TrueHDHalfDuration = false) const;
   bool operator==(const CAEStreamInfo& info) const;
 
   enum DataType

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
@@ -224,7 +224,7 @@ void CDVDAudioCodecPassthrough::GetData(DVDAudioFrame &frame)
   frame.format = m_format;
   frame.planes = 1;
   frame.bits_per_sample = 8;
-  frame.duration = DVD_MSEC_TO_TIME(frame.format.m_streamInfo.GetDuration());
+  frame.duration = DVD_MSEC_TO_TIME(frame.format.m_streamInfo.GetDuration(!m_deviceIsRAW));
   frame.pts = m_currentPts;
   m_currentPts = DVD_NOPTS_VALUE;
 }

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -857,8 +857,11 @@ inline bool PAPlayer::ProcessStream(StreamInfo *si, double &freeBufferTime)
       if (si->m_audioFormat.m_dataFormat != AE_FMT_RAW)
         free_space = (double)(si->m_stream->GetSpace() / si->m_bytesPerSample) / si->m_audioFormat.m_sampleRate;
       else
+      {
+        const bool isIEC = !m_processInfo->WantsRawPassthrough();
         free_space = (double)si->m_stream->GetSpace() *
-                     si->m_audioFormat.m_streamInfo.GetDuration(true) / 1000;
+                     si->m_audioFormat.m_streamInfo.GetDuration(isIEC) / 1000;
+      }
 
       freeBufferTime = std::max(freeBufferTime , free_space);
     }
@@ -906,7 +909,8 @@ bool PAPlayer::QueueData(StreamInfo *si)
         CLog::Log(LOGERROR, "PAPlayer::QueueData - unknown error");
         return false;
       }
-      si->m_framesSent += si->m_audioFormat.m_streamInfo.GetDuration(true) / 1000 *
+      const bool isIEC = !m_processInfo->WantsRawPassthrough();
+      si->m_framesSent += si->m_audioFormat.m_streamInfo.GetDuration(isIEC) / 1000 *
                           si->m_audioFormat.m_streamInfo.m_sampleRate;
     }
   }


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/22392, https://github.com/xbmc/xbmc/pull/22530 and https://github.com/xbmc/xbmc/pull/22552


## Motivation and context
All TrueHD fixes for Nexus


## What is the effect on users?
- Fixes TrueHD dropouts in Android AudioTrack IEC only.
- Fixes Debug Info OSD is imprecise (oscillate) witch TrueHD IEC.
- Fixes PAPlayer progress indicator is imprecise (oscillate) witch TrueHD IEC.
- Fixes PAPlayer progress indicator is wrong duration in Android using TrueHD RAW.



## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
