### PR TITLE
[Subtitles] Fix subtitles in livestreams with high start timestamps

### DIFF
--- a/xbmc/cores/VideoPlayer/Interface/TimingConstants.h
+++ b/xbmc/cores/VideoPlayer/Interface/TimingConstants.h
@@ -8,10 +8,15 @@
 
 #pragma once
 
+#include <cstdint>
+
 #define DVD_TIME_BASE 1000000
 #define DVD_NOPTS_VALUE 0xFFF0000000000000
 
-constexpr int DVD_TIME_TO_MSEC(double x) { return static_cast<int>(x * 1000 / DVD_TIME_BASE); }
+constexpr int64_t DVD_TIME_TO_MSEC(double x)
+{
+  return static_cast<int64_t>(x * 1000 / DVD_TIME_BASE);
+}
 constexpr double DVD_SEC_TO_TIME(double x) { return x * DVD_TIME_BASE; }
 constexpr double DVD_MSEC_TO_TIME(double x) { return x * DVD_TIME_BASE / 1000; }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Cast double precision timestamps to a 64 bits integer in DVD_TIME_TO_MSEC instead of casting to a normal integer

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some livestreams use very high start PTS timestamps that are too big to store as a normal integer value. This causes a problem displaying live subtitles. All start timestamps of the subtitles wrongly get the highest possible integer value of 2147483648 and are shown on top of each other on the screen. (See screenshot).
This problem is fixed when we cast double precision timestamps to a 64 bits integer in DVD_TIME_TO_MSEC.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using Kodi master branch with the livestreams from the VRT NU Add-on: https://github.com/add-ons/plugin.video.vrt.nu/

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):
Wrong subtitles using normal integer start timestamps (getting highest possible integer value 2147483648)
![Screenshot at 2023-01-23 14-45-51](https://user-images.githubusercontent.com/45148099/214059563-f98fcbe6-b06c-40fc-935b-6172e672f50d.png)
Fixed subtitles using 64 bits integer start timestamps:
![Screenshot at 2023-01-23 14-47-37](https://user-images.githubusercontent.com/45148099/214059575-dfa7d0a8-4c44-4ab3-a2df-a00cf5d6ed9f.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
