### PR TITLE
[Subtitles] Default to white subtitles when color tag is not converted

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleTagSami.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleTagSami.cpp
@@ -108,20 +108,21 @@ void CDVDSubtitleTagSami::ConvertLine(std::string& strUTF8, const char* langClas
       {
         std::string tagOptionName = m_tagOptions->GetMatch(1);
         std::string tagOptionValue = m_tagOptions->GetMatch(2);
-        std::string colorHex = "FFFFFF";
         pos2 += static_cast<int>(tagOptionName.length() + tagOptionValue.length());
         if (tagOptionName == "color")
         {
           m_flag[FLAG_COLOR] = true;
+          std::string colorHex = "FFFFFF";
+          bool bHex = false;
           if (tagOptionValue[0] == '#' && tagOptionValue.size() >= 7)
           {
+            bHex = true;
             tagOptionValue.erase(0, 1);
             tagOptionValue.erase(6, tagOptionValue.size());
-            colorHex = tagOptionValue;
           }
           else if (tagOptionValue.size() == 6)
           {
-            bool bHex = true;
+            bHex = true;
             for (int i = 0; i < 6; i++)
             {
               char temp = tagOptionValue[i];
@@ -132,11 +133,10 @@ void CDVDSubtitleTagSami::ConvertLine(std::string& strUTF8, const char* langClas
                 break;
               }
             }
-            if (bHex)
-              colorHex = tagOptionValue;
           }
-          colorHex =
-              colorHex.substr(4, 2) + tagOptionValue.substr(2, 2) + tagOptionValue.substr(0, 2);
+          if (bHex)
+            colorHex = tagOptionValue.substr(4, 2) + tagOptionValue.substr(2, 2) +
+                       tagOptionValue.substr(0, 2);
           std::string tempColorTag = "{\\c&H" + colorHex + "&}";
           strUTF8.insert(pos, tempColorTag);
           pos += static_cast<int>(tempColorTag.length());


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Default to white subtitles instead of passing wrongly converted color names causing red subtitles in Kodi Player.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently html color names (like white, yellow, cyan) are mistakenly mixed with `FF` hex code in the `colorHex` string variable
For instance:
white becomes `FFitwh`
yellow becomes `FFllye`
cyan becomes `FFancy`

This causes subtitles to be shown in red color in Kodi Player when another color is defined in the subtitle source.
It's better to default all subtitles to white for now when no valid hex code is found.
At a later time html color name support can be implemented the right way.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using Kodi master branch with VRT NU Add-on: https://github.com/add-ons/plugin.video.vrt.nu/
## What is the effect on users?
Users get default white subtitles instead of wrongly red subtitles.

<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):
Wrong color conversion to red subtitle in current master branch:
![Screenshot at 2023-01-23 16-13-23](https://user-images.githubusercontent.com/45148099/214075704-faccfb18-a7c2-4ce2-9e13-ddc58ea0a42d.png)
Default to white with this PR:
![Screenshot at 2023-01-23 16-12-19](https://user-images.githubusercontent.com/45148099/214075692-8e467ba8-5540-418f-96d3-41f9161fa1a0.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
