### PR TITLE
[Android] Use the new WindowInsetsController class

### DIFF
--- a/tools/android/packaging/xbmc/src/Main.java.in
+++ b/tools/android/packaging/xbmc/src/Main.java.in
@@ -17,6 +17,8 @@ import android.os.Looper;
 import android.util.Log;
 import android.view.Choreographer;
 import android.view.View;
+import android.view.WindowInsets;
+import android.view.WindowInsetsController;
 import android.widget.RelativeLayout;
 
 import java.util.ArrayList;
@@ -161,30 +163,33 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
     mMainView.setElevation(1);  // Always on Top
     mVideoLayout.addView(mMainView, layoutParams);
 
-    mDecorView.setOnSystemUiVisibilityChangeListener(new View.OnSystemUiVisibilityChangeListener()
+    if (Build.VERSION.SDK_INT < 30)
     {
-      @Override
-      public void onSystemUiVisibilityChange(int visibility)
+      mDecorView.setOnSystemUiVisibilityChangeListener(new View.OnSystemUiVisibilityChangeListener()
       {
-        if ((visibility & View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) == 0)
+        @Override
+        public void onSystemUiVisibilityChange(int visibility)
         {
-          handler.post(new Runnable()
+          if ((visibility & View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) == 0)
           {
-            public void run()
+            handler.post(new Runnable()
             {
-              // Immersive mode
-              mDecorView.setSystemUiVisibility(
-                      View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                              | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                              | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                              | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                              | View.SYSTEM_UI_FLAG_FULLSCREEN
-                              | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
-            }
-          });
+              public void run()
+              {
+                // Immersive mode
+                mDecorView.setSystemUiVisibility(
+                        View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                                | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                                | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                                | View.SYSTEM_UI_FLAG_FULLSCREEN
+                                | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+              }
+            });
+          }
         }
-      }
-    });
+      });
+    }
   }
 
   @Override
@@ -219,15 +224,28 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
   {
     super.onResume();
 
-    // Immersive mode
-    mDecorView.setSystemUiVisibility(
+    if (Build.VERSION.SDK_INT >= 30)
+    {
+      getWindow().setDecorFitsSystemWindows(false);
+      WindowInsetsController controller = getWindow().getInsetsController();
+      if (controller != null)
+      {
+        controller.hide(WindowInsets.Type.statusBars() | WindowInsets.Type.navigationBars());
+        controller.setSystemBarsBehavior(WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+      }
+    }
+    else
+    {
+      // Immersive mode
+      mDecorView.setSystemUiVisibility(
           View.SYSTEM_UI_FLAG_LAYOUT_STABLE
                   | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
                   | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
                   | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
                   | View.SYSTEM_UI_FLAG_FULLSCREEN
                   | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
-  
+    }
+
     // New intent ?
     for (final DelayedIntent delayedIntent : mDelayedIntents)
     {


### PR DESCRIPTION
## Description
Android 11 introduces a new `WindowInsetsController` class which allows you to do things that previously were controlled via `systemUiVisibility` flags, like hiding or showing the status bar or navigation bar or customizing their appearance and behavior.

## How has this been tested?
Works as expected on an Android 12 phone

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
