### PR TITLE
Game OSD: Allow rename/delete savestates in-game

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -6555,7 +6555,7 @@ msgctxt "#13205"
 msgid "Unknown"
 msgstr ""
 
-#. unused?
+#. Label in the game OSD to overwrite an existing savestate
 msgctxt "#13206"
 msgid "Overwrite"
 msgstr ""

--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -251,7 +251,7 @@
 					</control>
 					<control type="label">
 						<left>0</left>
-						<top>240</top>
+						<top>238</top>
 						<right>20</right>
 						<height>20</height>
 						<font>font14</font>
@@ -261,7 +261,7 @@
 					</control>
 					<control type="textbox">
 						<left>0</left>
-						<top>260</top>
+						<top>262</top>
 						<right>20</right>
 						<height>40</height>
 						<font>font10</font>
@@ -290,7 +290,7 @@
 					</control>
 					<control type="label">
 						<left>0</left>
-						<top>240</top>
+						<top>238</top>
 						<right>20</right>
 						<height>20</height>
 						<align>center</align>
@@ -301,7 +301,7 @@
 					</control>
 					<control type="textbox">
 						<left>0</left>
-						<top>260</top>
+						<top>262</top>
 						<right>20</right>
 						<height>40</height>
 						<font>font10</font>
@@ -351,7 +351,7 @@
 				<left>14</left>
 				<right>14</right>
 				<bottom>0</bottom>
-				<height>20</height>
+				<height>16</height>
 				<font>font12</font>
 				<align>left</align>
 				<shadowcolor>text_shadow</shadowcolor>

--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -635,7 +635,6 @@
 							<width>444</width>
 							<height>250</height>
 							<texture border="8" colordiffuse="button_focus">buttons/thumbnail_focused.png</texture>
-							<visible>Control.HasFocus(10811)</visible>
 						</control>
 					</control>
 				</focusedlayout>

--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -346,7 +346,7 @@
 					<param name="label" value="$LOCALIZE[222]" />
 				</include>
 			</control>
-			<control type="label" id="12">
+			<control type="label" id="10812">
 				<description>Caption area</description>
 				<left>14</left>
 				<right>14</right>
@@ -380,7 +380,7 @@
 				<animation effect="fade" start="100" end="0" time="300">WindowClose</animation>
 				<texture colordiffuse="E6FFFFFF">dialogs/dialog-bg-nobo.png</texture>
 			</control>
-			<control type="panel" id="11">
+			<control type="panel" id="10811">
 				<top>30</top>
 				<scrolltime tween="sine">200</scrolltime>
 				<orientation>horizontal</orientation>
@@ -448,12 +448,12 @@
 							<width>444</width>
 							<height>250</height>
 							<texture border="8" colordiffuse="button_focus">buttons/thumbnail_focused.png</texture>
-							<visible>Control.HasFocus(11)</visible>
+							<visible>Control.HasFocus(10811)</visible>
 						</control>
 					</control>
 				</focusedlayout>
 			</control>
-			<control type="textbox" id="12">
+			<control type="textbox" id="10812">
 				<description>Description Area</description>
 				<top>410</top>
 				<left>100</left>
@@ -486,7 +486,7 @@
 				<animation effect="fade" start="100" end="0" time="300">WindowClose</animation>
 				<texture colordiffuse="E6FFFFFF">dialogs/dialog-bg-nobo.png</texture>
 			</control>
-			<control type="panel" id="11">
+			<control type="panel" id="10811">
 				<top>30</top>
 				<scrolltime tween="sine">200</scrolltime>
 				<orientation>horizontal</orientation>
@@ -554,7 +554,7 @@
 							<width>444</width>
 							<height>250</height>
 							<texture border="8" colordiffuse="button_focus">buttons/thumbnail_focused.png</texture>
-							<visible>Control.HasFocus(11)</visible>
+							<visible>Control.HasFocus(10811)</visible>
 						</control>
 					</control>
 				</focusedlayout>
@@ -581,7 +581,7 @@
 				<animation effect="fade" start="100" end="0" time="300">WindowClose</animation>
 				<texture colordiffuse="E6FFFFFF">dialogs/dialog-bg-nobo.png</texture>
 			</control>
-			<control type="panel" id="11">
+			<control type="panel" id="10811">
 				<top>30</top>
 				<scrolltime tween="sine">200</scrolltime>
 				<orientation>horizontal</orientation>
@@ -635,12 +635,12 @@
 							<width>444</width>
 							<height>250</height>
 							<texture border="8" colordiffuse="button_focus">buttons/thumbnail_focused.png</texture>
-							<visible>Control.HasFocus(11)</visible>
+							<visible>Control.HasFocus(10811)</visible>
 						</control>
 					</control>
 				</focusedlayout>
 			</control>
-			<control type="textbox" id="12">
+			<control type="textbox" id="10812">
 				<description>Description Area</description>
 				<top>410</top>
 				<left>100</left>

--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -246,7 +246,7 @@
 						<top>7</top>
 						<width>400</width>
 						<height>220</height>
-						<texture>$INFO[ListItem.Icon]</texture>
+						<texture>$INFO[ListItem.Art(screenshot)]</texture>
 						<aspectratio>keep</aspectratio>
 					</control>
 					<control type="label">
@@ -285,7 +285,7 @@
 						<top>7</top>
 						<width>400</width>
 						<height>220</height>
-						<texture>$INFO[ListItem.Icon]</texture>
+						<texture>$INFO[ListItem.Art(screenshot)]</texture>
 						<aspectratio>keep</aspectratio>
 					</control>
 					<control type="label">
@@ -598,6 +598,14 @@
 							<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
 							<bordersize>4</bordersize>
 						</control>
+						<control type="image">
+							<width>444</width>
+							<height>250</height>
+							<aspectratio>scale</aspectratio>
+							<texture border="4">$INFO[ListItem.Art(screenshot)]</texture>
+							<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
+							<bordersize>4</bordersize>
+						</control>
 						<control type="label">
 							<top>250</top>
 							<width>444</width>
@@ -619,6 +627,14 @@
 							<height>250</height>
 							<aspectratio>scale</aspectratio>
 							<texture border="4">$INFO[ListItem.Icon]</texture>
+							<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
+							<bordersize>4</bordersize>
+						</control>
+						<control type="image">
+							<width>444</width>
+							<height>250</height>
+							<aspectratio>scale</aspectratio>
+							<texture border="4">$INFO[ListItem.Art(screenshot)]</texture>
 							<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
 							<bordersize>4</bordersize>
 						</control>

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -520,7 +520,10 @@ std::string CRetroPlayer::GetPlayingGame() const
 
 std::string CRetroPlayer::CreateSavestate(bool autosave)
 {
-  return m_playback->CreateSavestate(autosave);
+  if (m_playback)
+    return m_playback->CreateSavestate(autosave);
+
+  return "";
 }
 
 bool CRetroPlayer::LoadSavestate(const std::string& path)

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -526,10 +526,10 @@ std::string CRetroPlayer::CreateSavestate(bool autosave)
   return "";
 }
 
-bool CRetroPlayer::LoadSavestate(const std::string& path)
+bool CRetroPlayer::LoadSavestate(const std::string& savestatePath)
 {
   if (m_playback)
-    return m_playback->LoadSavestate(path);
+    return m_playback->LoadSavestate(savestatePath);
 
   return false;
 }

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -526,6 +526,14 @@ std::string CRetroPlayer::CreateSavestate(bool autosave)
   return "";
 }
 
+bool CRetroPlayer::UpdateSavestate(const std::string& savestatePath)
+{
+  if (m_playback)
+    return !m_playback->CreateSavestate(false, savestatePath).empty();
+
+  return false;
+}
+
 bool CRetroPlayer::LoadSavestate(const std::string& savestatePath)
 {
   if (m_playback)

--- a/xbmc/cores/RetroPlayer/RetroPlayer.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.h
@@ -73,6 +73,7 @@ public:
   std::string GameClientID() const override;
   std::string GetPlayingGame() const override;
   std::string CreateSavestate(bool autosave) override;
+  bool UpdateSavestate(const std::string& savestatePath) override;
   bool LoadSavestate(const std::string& savestatePath) override;
   void CloseOSDCallback() override;
 

--- a/xbmc/cores/RetroPlayer/RetroPlayer.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.h
@@ -73,7 +73,7 @@ public:
   std::string GameClientID() const override;
   std::string GetPlayingGame() const override;
   std::string CreateSavestate(bool autosave) override;
-  bool LoadSavestate(const std::string& path) override;
+  bool LoadSavestate(const std::string& savestatePath) override;
   void CloseOSDCallback() override;
 
   // Implementation of IPlaybackCallback

--- a/xbmc/cores/RetroPlayer/guibridge/GUIGameRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/guibridge/GUIGameRenderManager.cpp
@@ -231,12 +231,12 @@ std::string CGUIGameRenderManager::CreateSavestate(bool autosave)
   return "";
 }
 
-bool CGUIGameRenderManager::LoadSavestate(const std::string& path)
+bool CGUIGameRenderManager::LoadSavestate(const std::string& savestatePath)
 {
   std::unique_lock<CCriticalSection> lock(m_callbackMutex);
 
   if (m_gameCallback != nullptr)
-    return m_gameCallback->LoadSavestate(path);
+    return m_gameCallback->LoadSavestate(savestatePath);
 
   return false;
 }

--- a/xbmc/cores/RetroPlayer/guibridge/GUIGameRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/guibridge/GUIGameRenderManager.cpp
@@ -231,6 +231,16 @@ std::string CGUIGameRenderManager::CreateSavestate(bool autosave)
   return "";
 }
 
+bool CGUIGameRenderManager::UpdateSavestate(const std::string& savestatePath)
+{
+  std::unique_lock<CCriticalSection> lock(m_callbackMutex);
+
+  if (m_gameCallback != nullptr)
+    return m_gameCallback->UpdateSavestate(savestatePath);
+
+  return false;
+}
+
 bool CGUIGameRenderManager::LoadSavestate(const std::string& savestatePath)
 {
   std::unique_lock<CCriticalSection> lock(m_callbackMutex);

--- a/xbmc/cores/RetroPlayer/guibridge/GUIGameRenderManager.h
+++ b/xbmc/cores/RetroPlayer/guibridge/GUIGameRenderManager.h
@@ -147,7 +147,7 @@ protected:
   std::string GameClientID();
   std::string GetPlayingGame();
   std::string CreateSavestate(bool autosave);
-  bool LoadSavestate(const std::string& path);
+  bool LoadSavestate(const std::string& savestatePath);
   void CloseOSD();
 
 private:

--- a/xbmc/cores/RetroPlayer/guibridge/GUIGameRenderManager.h
+++ b/xbmc/cores/RetroPlayer/guibridge/GUIGameRenderManager.h
@@ -147,6 +147,7 @@ protected:
   std::string GameClientID();
   std::string GetPlayingGame();
   std::string CreateSavestate(bool autosave);
+  bool UpdateSavestate(const std::string& savestatePath);
   bool LoadSavestate(const std::string& savestatePath);
   void CloseOSD();
 

--- a/xbmc/cores/RetroPlayer/guibridge/GUIGameSettingsHandle.cpp
+++ b/xbmc/cores/RetroPlayer/guibridge/GUIGameSettingsHandle.cpp
@@ -38,6 +38,11 @@ std::string CGUIGameSettingsHandle::CreateSavestate(bool autosave)
   return m_renderManager.CreateSavestate(autosave);
 }
 
+bool CGUIGameSettingsHandle::UpdateSavestate(const std::string& savestatePath)
+{
+  return m_renderManager.UpdateSavestate(savestatePath);
+}
+
 bool CGUIGameSettingsHandle::LoadSavestate(const std::string& savestatePath)
 {
   return m_renderManager.LoadSavestate(savestatePath);

--- a/xbmc/cores/RetroPlayer/guibridge/GUIGameSettingsHandle.cpp
+++ b/xbmc/cores/RetroPlayer/guibridge/GUIGameSettingsHandle.cpp
@@ -38,9 +38,9 @@ std::string CGUIGameSettingsHandle::CreateSavestate(bool autosave)
   return m_renderManager.CreateSavestate(autosave);
 }
 
-bool CGUIGameSettingsHandle::LoadSavestate(const std::string& path)
+bool CGUIGameSettingsHandle::LoadSavestate(const std::string& savestatePath)
 {
-  return m_renderManager.LoadSavestate(path);
+  return m_renderManager.LoadSavestate(savestatePath);
 }
 
 void CGUIGameSettingsHandle::CloseOSD()

--- a/xbmc/cores/RetroPlayer/guibridge/GUIGameSettingsHandle.h
+++ b/xbmc/cores/RetroPlayer/guibridge/GUIGameSettingsHandle.h
@@ -52,12 +52,12 @@ public:
   /*!
    * \brief Load a savestate for the current game being played
    *
-   * \param path The path to the created savestate file returned by
+   * \param savestatePath The path to the created savestate file returned by
    * CreateSavestate()
    *
    * \return True if the savestate was loaded successfully, false otherwise
    */
-  bool LoadSavestate(const std::string& path);
+  bool LoadSavestate(const std::string& savestatePath);
 
   /*!
    * \brief Close the in-game OSD

--- a/xbmc/cores/RetroPlayer/guibridge/GUIGameSettingsHandle.h
+++ b/xbmc/cores/RetroPlayer/guibridge/GUIGameSettingsHandle.h
@@ -50,6 +50,16 @@ public:
   std::string CreateSavestate(bool autosave);
 
   /*!
+   * \brief Update a savestate for the current game being played
+   *
+   * \param savestatePath The path to the created savestate file returned by
+   * CreateSavestate()
+   *
+   * \return True if the savestate was updated successfully, false otherwise
+   */
+  bool UpdateSavestate(const std::string& savestatePath);
+
+  /*!
    * \brief Load a savestate for the current game being played
    *
    * \param savestatePath The path to the created savestate file returned by

--- a/xbmc/cores/RetroPlayer/guibridge/IGameCallback.h
+++ b/xbmc/cores/RetroPlayer/guibridge/IGameCallback.h
@@ -36,18 +36,22 @@ public:
   virtual std::string GetPlayingGame() const = 0;
 
   /*!
-   * \brief Creates a Savestate
+   * \brief Creates a savestate
    *
    * \param autosave Whether the save type is auto
+   *
+   * \return The path to the created savestate, or empty on error
    */
   virtual std::string CreateSavestate(bool autosave) = 0;
 
   /*!
    * \brief Loads a savestate
    *
-   * \param path The path to the savestate
+   * \param savestate The path to the savestate
+   *
+   * \return True if the savestate was loaded, false on error
    */
-  virtual bool LoadSavestate(const std::string& path) = 0;
+  virtual bool LoadSavestate(const std::string& savestatePath) = 0;
 
   /*!
    * \brief Closes the OSD

--- a/xbmc/cores/RetroPlayer/guibridge/IGameCallback.h
+++ b/xbmc/cores/RetroPlayer/guibridge/IGameCallback.h
@@ -45,6 +45,15 @@ public:
   virtual std::string CreateSavestate(bool autosave) = 0;
 
   /*!
+   * \brief Updates a savestate with the current game being played
+   *
+   * \param savestate The path to the savestate
+   *
+   * \return True if the savestate was updated, false on error
+   */
+  virtual bool UpdateSavestate(const std::string& savestatePath) = 0;
+
+  /*!
    * \brief Loads a savestate
    *
    * \param savestate The path to the savestate

--- a/xbmc/cores/RetroPlayer/playback/IPlayback.h
+++ b/xbmc/cores/RetroPlayer/playback/IPlayback.h
@@ -39,7 +39,7 @@ public:
   // Savestates
   virtual std::string CreateSavestate(
       bool autosave) = 0; // Returns the path of savestate on success
-  virtual bool LoadSavestate(const std::string& path) = 0;
+  virtual bool LoadSavestate(const std::string& savestatePath) = 0;
 };
 } // namespace RETRO
 } // namespace KODI

--- a/xbmc/cores/RetroPlayer/playback/IPlayback.h
+++ b/xbmc/cores/RetroPlayer/playback/IPlayback.h
@@ -38,7 +38,8 @@ public:
 
   // Savestates
   virtual std::string CreateSavestate(
-      bool autosave) = 0; // Returns the path of savestate on success
+      bool autosave,
+      const std::string& savestatePath = "") = 0; // Returns the path of savestate on success
   virtual bool LoadSavestate(const std::string& savestatePath) = 0;
 };
 } // namespace RETRO

--- a/xbmc/cores/RetroPlayer/playback/RealtimePlayback.h
+++ b/xbmc/cores/RetroPlayer/playback/RealtimePlayback.h
@@ -32,7 +32,7 @@ public:
   void SetSpeed(double speedFactor) override {}
   void PauseAsync() override {}
   std::string CreateSavestate(bool autosave) override { return ""; }
-  bool LoadSavestate(const std::string& path) override { return false; }
+  bool LoadSavestate(const std::string& savestatePath) override { return false; }
 };
 } // namespace RETRO
 } // namespace KODI

--- a/xbmc/cores/RetroPlayer/playback/RealtimePlayback.h
+++ b/xbmc/cores/RetroPlayer/playback/RealtimePlayback.h
@@ -31,7 +31,10 @@ public:
   double GetSpeed() const override { return 1.0; }
   void SetSpeed(double speedFactor) override {}
   void PauseAsync() override {}
-  std::string CreateSavestate(bool autosave) override { return ""; }
+  std::string CreateSavestate(bool autosave, const std::string& savestatePath = "") override
+  {
+    return "";
+  }
   bool LoadSavestate(const std::string& savestatePath) override { return false; }
 };
 } // namespace RETRO

--- a/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.cpp
+++ b/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.cpp
@@ -203,7 +203,7 @@ std::string CReversiblePlayback::CreateSavestate(bool autosave)
   return savePath;
 }
 
-bool CReversiblePlayback::LoadSavestate(const std::string& path)
+bool CReversiblePlayback::LoadSavestate(const std::string& savestatePath)
 {
   const size_t memorySize = m_gameClient->SerializeSize();
 
@@ -214,7 +214,7 @@ bool CReversiblePlayback::LoadSavestate(const std::string& path)
   bool bSuccess = false;
 
   std::unique_ptr<ISavestate> savestate = CSavestateDatabase::AllocateSavestate();
-  if (m_savestateDatabase->GetSavestate(path, *savestate) &&
+  if (m_savestateDatabase->GetSavestate(savestatePath, *savestate) &&
       savestate->GetMemorySize() == memorySize)
   {
     {
@@ -232,7 +232,7 @@ bool CReversiblePlayback::LoadSavestate(const std::string& path)
       m_totalFrameCount = savestate->TimestampFrames();
       bSuccess = true;
       if (savestate->Type() == SAVE_TYPE::AUTO)
-        m_autosavePath = path;
+        m_autosavePath = savestatePath;
     }
   }
 

--- a/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.cpp
+++ b/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.cpp
@@ -19,7 +19,6 @@
 #include "games/GameServices.h"
 #include "games/GameSettings.h"
 #include "games/addons/GameClient.h"
-#include "guilib/LocalizeStrings.h"
 #include "utils/MathUtils.h"
 #include "utils/URIUtils.h"
 
@@ -143,8 +142,6 @@ std::string CReversiblePlayback::CreateSavestate(bool autosave)
       if (m_savestateDatabase->GetSavestate(m_autosavePath, *loadedSavestate))
         label = loadedSavestate->Label();
     }
-    if (label.empty())
-      label = g_localizeStrings.Get(15316); // "Autosave"
   }
 
   const CDateTime nowUTC = CDateTime::GetUTCDateTime();

--- a/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.cpp
+++ b/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.cpp
@@ -16,6 +16,7 @@
 #include "cores/RetroPlayer/savestates/ISavestate.h"
 #include "cores/RetroPlayer/savestates/SavestateDatabase.h"
 #include "cores/RetroPlayer/streams/memory/DeltaPairMemoryStream.h"
+#include "filesystem/File.h"
 #include "games/GameServices.h"
 #include "games/GameSettings.h"
 #include "games/addons/GameClient.h"
@@ -116,7 +117,8 @@ void CReversiblePlayback::PauseAsync()
   m_gameLoop.PauseAsync();
 }
 
-std::string CReversiblePlayback::CreateSavestate(bool autosave)
+std::string CReversiblePlayback::CreateSavestate(bool autosave,
+                                                 const std::string& savestatePath /* = "" */)
 {
   const size_t memorySize = m_gameClient->SerializeSize();
 
@@ -130,20 +132,25 @@ std::string CReversiblePlayback::CreateSavestate(bool autosave)
     return "";
   }
 
-  std::string label = "";
+  std::string savePath(savestatePath);
+  if (autosave && savePath.empty())
+    savePath = m_autosavePath;
 
-  std::string caption = m_cheevos->GetRichPresenceEvaluation();
+  // Clear autosave path so the next autosave is created in a new slot and
+  // does not overwrite the newly-created manual save
+  if (!autosave && savePath == m_autosavePath)
+    m_autosavePath.clear();
 
-  if (autosave)
+  // Attempt to get existing properties
+  std::unique_ptr<ISavestate> loadedSavestate;
+  if (!savePath.empty() && XFILE::CFile::Exists(savePath))
   {
-    if (!m_autosavePath.empty())
-    {
-      std::unique_ptr<ISavestate> loadedSavestate = CSavestateDatabase::AllocateSavestate();
-      if (m_savestateDatabase->GetSavestate(m_autosavePath, *loadedSavestate))
-        label = loadedSavestate->Label();
-    }
+    loadedSavestate = CSavestateDatabase::AllocateSavestate();
+    if (!m_savestateDatabase->GetSavestate(savePath, *loadedSavestate))
+      loadedSavestate.reset();
   }
 
+  const std::string caption = m_cheevos->GetRichPresenceEvaluation();
   const CDateTime nowUTC = CDateTime::GetUTCDateTime();
   const std::string gameFileName = URIUtils::GetFileName(m_gameClient->GetGamePath());
   const uint64_t timestampFrames = m_totalFrameCount;
@@ -156,7 +163,7 @@ std::string CReversiblePlayback::CreateSavestate(bool autosave)
   std::unique_ptr<ISavestate> savestate = CSavestateDatabase::AllocateSavestate();
 
   savestate->SetType(autosave ? SAVE_TYPE::AUTO : SAVE_TYPE::MANUAL);
-  savestate->SetLabel(label);
+  savestate->SetLabel(loadedSavestate ? loadedSavestate->Label() : "");
   savestate->SetCaption(caption);
   savestate->SetCreated(nowUTC);
   savestate->SetGameFileName(gameFileName);
@@ -182,10 +189,6 @@ std::string CReversiblePlayback::CreateSavestate(bool autosave)
   }
 
   savestate->Finalize();
-
-  std::string savePath;
-  if (autosave)
-    savePath = m_autosavePath;
 
   if (!m_savestateDatabase->AddSavestate(savePath, m_gameClient->GetGamePath(), *savestate))
   {

--- a/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.h
+++ b/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.h
@@ -54,7 +54,7 @@ public:
   double GetSpeed() const override;
   void SetSpeed(double speedFactor) override;
   void PauseAsync() override;
-  std::string CreateSavestate(bool autosave) override;
+  std::string CreateSavestate(bool autosave, const std::string& savestatePath = "") override;
   bool LoadSavestate(const std::string& savestatePath) override;
 
   // implementation of IGameLoopCallback

--- a/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.h
+++ b/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.h
@@ -55,7 +55,7 @@ public:
   void SetSpeed(double speedFactor) override;
   void PauseAsync() override;
   std::string CreateSavestate(bool autosave) override;
-  bool LoadSavestate(const std::string& path) override;
+  bool LoadSavestate(const std::string& savestatePath) override;
 
   // implementation of IGameLoopCallback
   void FrameEvent() override;

--- a/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
@@ -67,7 +67,7 @@ bool CSavestateDatabase::AddSavestate(std::string& savestatePath,
   if (save.Serialize(data, size))
   {
     XFILE::CFile file;
-    if (file.OpenForWrite(path))
+    if (file.OpenForWrite(path, true))
     {
       const ssize_t written = file.Write(data, size);
       if (written == static_cast<ssize_t>(size))

--- a/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
@@ -182,7 +182,7 @@ void CSavestateDatabase::GetSavestateItem(const ISavestate& savestate,
   item.SetLabel(label);
   item.SetLabel2(label2);
   item.SetPath(savestatePath);
-  item.SetArt("icon", MakeThumbnailPath(savestatePath));
+  item.SetArt("screenshot", MakeThumbnailPath(savestatePath));
   item.SetProperty(SAVESTATE_CAPTION, savestate.Caption());
   item.m_dateTime = dateUTC;
 }

--- a/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.h
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <string>
 
+class CFileItem;
 class CFileItemList;
 
 namespace KODI
@@ -37,17 +38,22 @@ public:
                         const std::string& gamePath,
                         const std::string& gameClient = "");
 
-  bool RenameSavestate(const std::string& savestatePath, const std::string& label);
+  static void GetSavestateItem(const ISavestate& savestate,
+                               const std::string& savestatePath,
+                               CFileItem& item);
+
+  std::unique_ptr<ISavestate> RenameSavestate(const std::string& savestatePath,
+                                              const std::string& label);
 
   bool DeleteSavestate(const std::string& savestatePath);
 
   bool ClearSavestatesOfGame(const std::string& gamePath, const std::string& gameClient = "");
 
-  std::string MakeThumbnailPath(const std::string& savestatePath);
+  static std::string MakeThumbnailPath(const std::string& savestatePath);
 
 private:
-  std::string MakePath(const std::string& gamePath);
-  bool CreateFolderIfNotExists(const std::string& path);
+  static std::string MakePath(const std::string& gamePath);
+  static bool CreateFolderIfNotExists(const std::string& path);
 };
 } // namespace RETRO
 } // namespace KODI

--- a/xbmc/games/dialogs/osd/DialogGameSaves.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameSaves.cpp
@@ -32,7 +32,7 @@ using namespace GAME;
 namespace
 {
 constexpr int CONTROL_DETAILED_LIST = 6;
-constexpr int CONTROL_DESCRIPTION = 12;
+constexpr int CONTROL_DESCRIPTION = 10812;
 } // namespace
 
 CDialogGameSaves::CDialogGameSaves() : CGUIDialogSelect(WINDOW_DIALOG_GAME_SAVES)

--- a/xbmc/games/dialogs/osd/DialogGameSaves.h
+++ b/xbmc/games/dialogs/osd/DialogGameSaves.h
@@ -36,7 +36,7 @@ private:
   /*!
    * \brief Called every frame with the item being focused
    */
-  void OnFocus(const CFileItemPtr& item);
+  void OnFocus(const CFileItem& item);
 
   /*!
    * \brief Called every frame if no item is focused
@@ -44,9 +44,19 @@ private:
   void OnFocusLost();
 
   /*!
-   * \brief Called when a popup menu is opened for an item
+   * \brief Called when a context menu is opened for an item
    */
-  void OnPopupMenu(const CFileItemPtr& item);
+  void OnContextMenu(CFileItem& item);
+
+  /*!
+  * \brief Called when "Rename" is selected from the context menu
+  */
+  void OnRename(CFileItem& item);
+
+  /*!
+  * \brief Called when "Delete" is selected from the context menu
+  */
+  void OnDelete(CFileItem& item);
 
   /*!
    * \brief Called every frame with the caption to set

--- a/xbmc/games/dialogs/osd/DialogGameVideoSelect.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoSelect.cpp
@@ -85,19 +85,46 @@ bool CDialogGameVideoSelect::OnMessage(CGUIMessage& message)
         if (m_viewControl->HasControl(controlId))
         {
           if (OnClickAction())
-          {
-            // Changed from sending ACTION_SHOW_OSD to closing the dialog
-            Close();
-
             return true;
-          }
         }
       }
-      break;
-    }
-    case GUI_MSG_REFRESH_LIST:
-    {
-      OnRefreshList();
+      else if (actionId == ACTION_CONTEXT_MENU || actionId == ACTION_MOUSE_RIGHT_CLICK)
+      {
+        const int controlId = message.GetSenderId();
+        if (m_viewControl->HasControl(controlId))
+        {
+          if (OnMenuAction())
+            return true;
+        }
+      }
+      else if (actionId == ACTION_CREATE_BOOKMARK)
+      {
+        const int controlId = message.GetSenderId();
+        if (m_viewControl->HasControl(controlId))
+        {
+          if (OnOverwriteAction())
+            return true;
+        }
+      }
+      else if (actionId == ACTION_RENAME_ITEM)
+      {
+        const int controlId = message.GetSenderId();
+        if (m_viewControl->HasControl(controlId))
+        {
+          if (OnRenameAction())
+            return true;
+        }
+      }
+      else if (actionId == ACTION_DELETE_ITEM)
+      {
+        const int controlId = message.GetSenderId();
+        if (m_viewControl->HasControl(controlId))
+        {
+          if (OnDeleteAction())
+            return true;
+        }
+      }
+
       break;
     }
     default:
@@ -170,7 +197,7 @@ void CDialogGameVideoSelect::Update()
   // Empty the list ready for population
   Clear();
 
-  OnRefreshList();
+  RefreshList();
 
   // CServiceBroker::GetWinSystem()->GetGfxContext().Unlock();
 }
@@ -181,7 +208,7 @@ void CDialogGameVideoSelect::Clear()
   m_vecItems->Clear();
 }
 
-void CDialogGameVideoSelect::OnRefreshList()
+void CDialogGameVideoSelect::RefreshList()
 {
   m_vecItems->Clear();
 
@@ -192,6 +219,10 @@ void CDialogGameVideoSelect::OnRefreshList()
   auto focusedIndex = GetFocusedItem();
   m_viewControl->SetSelectedItem(focusedIndex);
   OnItemFocus(focusedIndex);
+
+  // Refresh the panel container
+  CGUIMessage message(GUI_MSG_REFRESH_THUMBS, GetID(), CONTROL_THUMBS);
+  CServiceBroker::GetGUI()->GetWindowManager().SendMessage(message, GetID());
 }
 
 void CDialogGameVideoSelect::SaveSettings()

--- a/xbmc/games/dialogs/osd/DialogGameVideoSelect.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoSelect.cpp
@@ -81,14 +81,13 @@ bool CDialogGameVideoSelect::OnMessage(CGUIMessage& message)
         const int controlId = message.GetSenderId();
         if (m_viewControl->HasControl(controlId))
         {
-          using namespace MESSAGING;
+          if (OnClickAction())
+          {
+            // Changed from sending ACTION_SHOW_OSD to closing the dialog
+            Close();
 
-          OnClickAction();
-
-          // Changed from sending ACTION_SHOW_OSD to closing the dialog
-          Close();
-
-          return true;
+            return true;
+          }
         }
       }
       break;

--- a/xbmc/games/dialogs/osd/DialogGameVideoSelect.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoSelect.cpp
@@ -28,9 +28,12 @@
 using namespace KODI;
 using namespace GAME;
 
-#define CONTROL_HEADING 1
-#define CONTROL_THUMBS 11
-#define CONTROL_DESCRIPTION 12
+namespace
+{
+constexpr unsigned int CONTROL_HEADING = 1;
+constexpr unsigned int CONTROL_THUMBS = 10811;
+constexpr unsigned int CONTROL_DESCRIPTION = 10812;
+} // namespace
 
 CDialogGameVideoSelect::CDialogGameVideoSelect(int windowId)
   : CGUIDialog(windowId, "DialogSelect.xml"),

--- a/xbmc/games/dialogs/osd/DialogGameVideoSelect.h
+++ b/xbmc/games/dialogs/osd/DialogGameVideoSelect.h
@@ -53,7 +53,17 @@ protected:
   virtual void PostExit() = 0;
   // override this to do something when an item is selected
   virtual bool OnClickAction() { return false; }
+  // override this to do something when an item's context menu is opened
+  virtual bool OnMenuAction() { return false; }
+  // override this to do something when an item is overwritten with a new savestate
+  virtual bool OnOverwriteAction() { return false; }
+  // override this to do something when an item is renamed
+  virtual bool OnRenameAction() { return false; }
+  // override this to do something when an item is deleted
+  virtual bool OnDeleteAction() { return false; }
 
+  // GUI functions
+  void RefreshList();
   void OnDescriptionChange(const std::string& description);
 
   std::shared_ptr<RETRO::CGUIGameVideoHandle> m_gameVideoHandle;
@@ -61,8 +71,6 @@ protected:
 private:
   void Update();
   void Clear();
-
-  void OnRefreshList();
 
   void SaveSettings();
 

--- a/xbmc/games/dialogs/osd/DialogGameVideoSelect.h
+++ b/xbmc/games/dialogs/osd/DialogGameVideoSelect.h
@@ -52,7 +52,7 @@ protected:
   virtual unsigned int GetFocusedItem() const = 0;
   virtual void PostExit() = 0;
   // override this to do something when an item is selected
-  virtual void OnClickAction() {}
+  virtual bool OnClickAction() { return false; }
 
   void OnDescriptionChange(const std::string& description);
 

--- a/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
+++ b/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
@@ -80,7 +80,7 @@ void CDialogInGameSaves::PostExit()
   m_items.Clear();
 }
 
-void CDialogInGameSaves::OnClickAction()
+bool CDialogInGameSaves::OnClickAction()
 {
   if (static_cast<int>(m_focusedItemIndex) < m_items.Size())
   {
@@ -95,5 +95,9 @@ void CDialogInGameSaves::OnClickAction()
       gameSettings->LoadSavestate(savePath);
 
     gameSettings->CloseOSD();
+
+    return true;
   }
+
+  return false;
 }

--- a/xbmc/games/dialogs/osd/DialogInGameSaves.h
+++ b/xbmc/games/dialogs/osd/DialogInGameSaves.h
@@ -34,10 +34,6 @@ protected:
 private:
   void InitSavedGames();
 
-  static void GetProperties(const CFileItem& item,
-                            std::string& videoFilter,
-                            std::string& description);
-
   CFileItemList m_items;
   unsigned int m_focusedItemIndex = false;
 };

--- a/xbmc/games/dialogs/osd/DialogInGameSaves.h
+++ b/xbmc/games/dialogs/osd/DialogInGameSaves.h
@@ -29,7 +29,7 @@ protected:
   void OnItemFocus(unsigned int index) override;
   unsigned int GetFocusedItem() const override;
   void PostExit() override;
-  void OnClickAction() override;
+  bool OnClickAction() override;
 
 private:
   void InitSavedGames();

--- a/xbmc/games/dialogs/osd/DialogInGameSaves.h
+++ b/xbmc/games/dialogs/osd/DialogInGameSaves.h
@@ -11,6 +11,8 @@
 #include "DialogGameVideoSelect.h"
 #include "FileItem.h"
 
+#include <string>
+
 namespace KODI
 {
 namespace GAME
@@ -30,11 +32,22 @@ protected:
   unsigned int GetFocusedItem() const override;
   void PostExit() override;
   bool OnClickAction() override;
+  bool OnMenuAction() override;
+  bool OnOverwriteAction() override;
+  bool OnRenameAction() override;
+  bool OnDeleteAction() override;
+
+  void OnNewSave();
+  void OnLoad(CFileItem& focusedItem);
+  void OnOverwrite(CFileItem& focusedItem);
+  void OnRename(CFileItem& focusedItem);
+  void OnDelete(CFileItem& focusedItem);
 
 private:
   void InitSavedGames();
 
-  CFileItemList m_items;
+  CFileItemList m_savestateItems;
+  const CFileItemPtr m_newSaveItem;
   unsigned int m_focusedItemIndex = false;
 };
 } // namespace GAME

--- a/xbmc/games/ports/windows/GUIPortList.cpp
+++ b/xbmc/games/ports/windows/GUIPortList.cpp
@@ -139,11 +139,16 @@ void CGUIPortList::SetFocused()
   m_viewControl->SetFocused();
 }
 
-void CGUIPortList::OnSelect()
+bool CGUIPortList::OnSelect()
 {
   const int itemIndex = m_viewControl->GetSelectedItem();
   if (itemIndex >= 0)
+  {
     OnItemSelect(static_cast<unsigned int>(itemIndex));
+    return true;
+  }
+
+  return false;
 }
 
 void CGUIPortList::ResetPorts()

--- a/xbmc/games/ports/windows/GUIPortList.h
+++ b/xbmc/games/ports/windows/GUIPortList.h
@@ -43,7 +43,7 @@ public:
   void Refresh() override;
   void FrameMove() override;
   void SetFocused() override;
-  void OnSelect() override;
+  bool OnSelect() override;
   void ResetPorts() override;
 
 private:

--- a/xbmc/games/ports/windows/GUIPortWindow.cpp
+++ b/xbmc/games/ports/windows/GUIPortWindow.cpp
@@ -167,9 +167,9 @@ void CGUIPortWindow::FocusPortList()
   m_portList->SetFocused();
 }
 
-void CGUIPortWindow::OnClickAction()
+bool CGUIPortWindow::OnClickAction()
 {
-  m_portList->OnSelect();
+  return m_portList->OnSelect();
 }
 
 void CGUIPortWindow::ResetPorts()

--- a/xbmc/games/ports/windows/GUIPortWindow.h
+++ b/xbmc/games/ports/windows/GUIPortWindow.h
@@ -40,7 +40,7 @@ private:
   // Actions for port list
   void UpdatePortList();
   void FocusPortList();
-  void OnClickAction();
+  bool OnClickAction();
 
   // Actions for the available buttons
   void ResetPorts();

--- a/xbmc/games/ports/windows/IPortList.h
+++ b/xbmc/games/ports/windows/IPortList.h
@@ -68,6 +68,8 @@ public:
 
   /*!
    * \brief Query the ID of the current control in this list
+   *
+   * \return The control ID, or -1 if no control is currently active
    */
   virtual int GetCurrentControl() = 0;
 
@@ -88,8 +90,10 @@ public:
 
   /*!
    * \brief The port list has been selected
+   *
+   * \brief True if a control was active, false of all controls were inactive
    */
-  virtual void OnSelect() = 0;
+  virtual bool OnSelect() = 0;
 
   /*!
    * \brief Reset the ports to their game add-on's default configuration


### PR DESCRIPTION
## Description

This PR applies a series of fixes and improvements to the existing OSD, then adds a feature that lets you rename/delete savestates from within the game.

The menu uses the existing context menu dialog, which doesn't really fit the aesthetics of the game thumbnail dialog.

But at least, though fugly, it functions 100% correctly. Maybe we can special-case the context menu dialog to play nicely with the game thumb dialog.

## Motivation and context

As stated [here](https://github.com/xbmc/xbmc/pull/22490#issuecomment-1399924449) by @KOPRajs, this ability is desired, and it's worse UX when missing.

## How has this been tested?

Testing is currently being done on my latest round of RetroPlayer builds:

Build can be found at https://github.com/garbear/xbmc/releases

## What is the effect on users?

* Allow renaming/deleting savestates from within a game

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
