### PR TITLE
[favourites][keymaps] Favourites Browser window: Catch-up on features of the deprecated Favourites dialog

### DIFF
--- a/system/keymaps/appcommand.xml
+++ b/system/keymaps/appcommand.xml
@@ -7,7 +7,7 @@
       <browser_refresh/>
       <browser_stop>Stop</browser_stop>
       <browser_search/>
-      <browser_favorites>ActivateWindow(Favourites)</browser_favorites>
+      <browser_favorites>ActivateWindow(FavouritesBrowser)</browser_favorites>
       <browser_home>FirstPage</browser_home>
       <volume_mute/>
       <volume_down/>

--- a/system/keymaps/customcontroller.AppleRemote.xml
+++ b/system/keymaps/customcontroller.AppleRemote.xml
@@ -91,7 +91,7 @@
   </global>
   <Home>
     <customcontroller name="AppleRemote">
-      <button id="6">ActivateWindow(Favourites)</button>
+      <button id="6">ActivateWindow(FavouritesBrowser)</button>
       <button id="8">ActivateWindow(shutdownmenu)</button>
     </customcontroller>
   </Home>

--- a/system/keymaps/customcontroller.Harmony.xml
+++ b/system/keymaps/customcontroller.Harmony.xml
@@ -91,7 +91,7 @@
       <!-- F5			-->  <button id="193">OSD</button>
       <!-- F7			-->  <button id="195">ActivateWindow(Home)</button>
       <!-- F6			-->  <button id="194">ActivateWindow(Programs)</button>
-      <!-- F8			-->  <button id="196">ActivateWindow(favourites)</button>
+      <!-- F8			-->  <button id="196">ActivateWindow(FavouritesBrowser)</button>
       <!-- F9			-->  <button id="173">ShowVideoMenu</button>
       <!-- F10			-->  <button id="174">ShowSubtitles</button>
       <!-- F11			-->  <button id="175">NextSubtitle</button>

--- a/system/keymaps/customcontroller.SiriRemote.xml
+++ b/system/keymaps/customcontroller.SiriRemote.xml
@@ -19,7 +19,7 @@
 <!--    </customcontroller>                                                                       -->
 
 <!-- Note that the action can be a built-in function.                                            -->
-<!--            eg <button id="6">ActivateWindow(Favourites)</button>                            -->
+<!--            eg <button id="6">ActivateWindow(FavouritesBrowser)</button>                     -->
 <!-- would bring up Favourites when the button with the id of 6 is press. In this case, "Menu"   -->
 
 <!--                                                                                             -->
@@ -63,7 +63,7 @@
   </global>
   <Home>
     <customcontroller name="SiriRemote">
-      <button id="6">ActivateWindow(Favourites)</button>
+      <button id="6">ActivateWindow(FavouritesBrowser)</button>
     </customcontroller>
   </Home>
   <FullscreenVideo>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -670,6 +670,14 @@
       <backspace mod="longpress">ActivateWindow(Home)</backspace>
     </keyboard>
   </Favourites>
+  <FavouritesBrowser>
+    <keyboard>
+      <u>MoveItemUp</u>
+      <d>MoveItemDown</d>
+      <delete>Delete</delete>
+      <backspace mod="longpress">ActivateWindow(Home)</backspace>
+    </keyboard>
+  </FavouritesBrowser>
   <NumericInput>
     <keyboard>
       <backspace>Close</backspace>

--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -114,8 +114,8 @@
       <browser_refresh/>
       <browser_stop/>
       <browser_search/>
-      <browser_favorites>ActivateWindow(Favourites)</browser_favorites>
-      <favorites>ActivateWindow(Favourites)</favorites>
+      <browser_favorites>ActivateWindow(FavouritesBrowser)</browser_favorites>
+      <favorites>ActivateWindow(FavouritesBrowser)</favorites>
       <config>ActivateWindow(Settings)</config>
       <browser_home>ActivateWindow(Home)</browser_home>
       <homepage>ActivateWindow(Home)</homepage>

--- a/system/keymaps/wetek-play/keyboard.xml
+++ b/system/keymaps/wetek-play/keyboard.xml
@@ -29,11 +29,11 @@
   </Global>
   <Home>
     <keyboard>
-      <backspace>ActivateWindow(Favourites)</backspace>
+      <backspace>ActivateWindow(FavouritesBrowser)</backspace>
       <backspace mod="longpress">ActivateWindow(ShutdownMenu)</backspace>
-      <browser_back>ActivateWindow(Favourites)</browser_back>
+      <browser_back>ActivateWindow(FavouritesBrowser)</browser_back>
       <browser_back mod="longpress">ActivateWindow(ShutdownMenu)</browser_back>
-      <escape>ActivateWindow(Favourites)</escape>
+      <escape>ActivateWindow(FavouritesBrowser)</escape>
       <escape mod="longpress">ActivateWindow(ShutdownMenu)</escape>
     </keyboard>
   </Home>

--- a/xbmc/favourites/CMakeLists.txt
+++ b/xbmc/favourites/CMakeLists.txt
@@ -3,13 +3,15 @@ set(SOURCES ContextMenus.cpp
             GUIViewStateFavourites.cpp
             GUIWindowFavourites.cpp
             FavouritesService.cpp
-            FavouritesURL.cpp)
+            FavouritesURL.cpp
+            FavouritesUtils.cpp)
 
 set(HEADERS ContextMenus.h
             GUIDialogFavourites.h
             GUIViewStateFavourites.h
             GUIWindowFavourites.h
             FavouritesService.h
-            FavouritesURL.h)
+            FavouritesURL.h
+            FavouritesUtils.h)
 
 core_add_library(favourites)

--- a/xbmc/favourites/ContextMenus.cpp
+++ b/xbmc/favourites/ContextMenus.cpp
@@ -40,7 +40,7 @@ namespace CONTEXTMENU
   bool CMoveUpFavourite::DoExecute(CFileItemList& items,
                                    const std::shared_ptr<CFileItem>& item) const
   {
-    return CGUIWindowFavourites::MoveItem(items, *item, -1);
+    return CGUIWindowFavourites::MoveItem(items, item, -1);
   }
 
   bool CMoveUpFavourite::IsVisible(const CFileItem& item) const
@@ -52,7 +52,7 @@ namespace CONTEXTMENU
   bool CMoveDownFavourite::DoExecute(CFileItemList& items,
                                      const std::shared_ptr<CFileItem>& item) const
   {
-    return CGUIWindowFavourites::MoveItem(items, *item, +1);
+    return CGUIWindowFavourites::MoveItem(items, item, +1);
   }
 
   bool CMoveDownFavourite::IsVisible(const CFileItem& item) const
@@ -64,9 +64,7 @@ namespace CONTEXTMENU
   bool CRemoveFavourite::DoExecute(CFileItemList& items,
                                    const std::shared_ptr<CFileItem>& item) const
   {
-    int iBefore = items.Size();
-    items.Remove(item.get());
-    return items.Size() == iBefore - 1;
+    return CGUIWindowFavourites::RemoveItem(items, item);
   }
 
   bool CRenameFavourite::DoExecute(CFileItemList&, const std::shared_ptr<CFileItem>& item) const

--- a/xbmc/favourites/ContextMenus.cpp
+++ b/xbmc/favourites/ContextMenus.cpp
@@ -11,9 +11,8 @@
 #include "FileItem.h"
 #include "ServiceBroker.h"
 #include "favourites/FavouritesService.h"
-#include "favourites/GUIWindowFavourites.h"
+#include "favourites/FavouritesUtils.h"
 #include "utils/URIUtils.h"
-
 
 namespace CONTEXTMENU
 {
@@ -40,42 +39,42 @@ namespace CONTEXTMENU
   bool CMoveUpFavourite::DoExecute(CFileItemList& items,
                                    const std::shared_ptr<CFileItem>& item) const
   {
-    return CGUIWindowFavourites::MoveItem(items, item, -1);
+    return FAVOURITES_UTILS::MoveItem(items, item, -1);
   }
 
   bool CMoveUpFavourite::IsVisible(const CFileItem& item) const
   {
     return CFavouriteContextMenuAction::IsVisible(item) &&
-           CGUIWindowFavourites::ShouldEnableMoveItems();
+           FAVOURITES_UTILS::ShouldEnableMoveItems();
   }
 
   bool CMoveDownFavourite::DoExecute(CFileItemList& items,
                                      const std::shared_ptr<CFileItem>& item) const
   {
-    return CGUIWindowFavourites::MoveItem(items, item, +1);
+    return FAVOURITES_UTILS::MoveItem(items, item, +1);
   }
 
   bool CMoveDownFavourite::IsVisible(const CFileItem& item) const
   {
     return CFavouriteContextMenuAction::IsVisible(item) &&
-           CGUIWindowFavourites::ShouldEnableMoveItems();
+           FAVOURITES_UTILS::ShouldEnableMoveItems();
   }
 
   bool CRemoveFavourite::DoExecute(CFileItemList& items,
                                    const std::shared_ptr<CFileItem>& item) const
   {
-    return CGUIWindowFavourites::RemoveItem(items, item);
+    return FAVOURITES_UTILS::RemoveItem(items, item);
   }
 
   bool CRenameFavourite::DoExecute(CFileItemList&, const std::shared_ptr<CFileItem>& item) const
   {
-    return CGUIWindowFavourites::ChooseAndSetNewName(*item);
+    return FAVOURITES_UTILS::ChooseAndSetNewName(*item);
   }
 
   bool CChooseThumbnailForFavourite::DoExecute(CFileItemList&,
                                                const std::shared_ptr<CFileItem>& item) const
   {
-    return CGUIWindowFavourites::ChooseAndSetNewThumbnail(*item);
+    return FAVOURITES_UTILS::ChooseAndSetNewThumbnail(*item);
   }
 
 } // namespace CONTEXTMENU

--- a/xbmc/favourites/FavouritesUtils.cpp
+++ b/xbmc/favourites/FavouritesUtils.cpp
@@ -1,0 +1,124 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "FavouritesUtils.h"
+
+#include "FileItem.h"
+#include "ServiceBroker.h"
+#include "dialogs/GUIDialogFileBrowser.h"
+#include "favourites/GUIWindowFavourites.h"
+#include "guilib/GUIComponent.h"
+#include "guilib/GUIKeyboardFactory.h"
+#include "guilib/GUIWindowManager.h"
+#include "guilib/LocalizeStrings.h"
+#include "storage/MediaManager.h"
+#include "utils/Variant.h"
+#include "view/GUIViewState.h"
+
+#include <string>
+
+namespace FAVOURITES_UTILS
+{
+bool ChooseAndSetNewName(CFileItem& item)
+{
+  std::string label = item.GetLabel();
+  if (CGUIKeyboardFactory::ShowAndGetInput(label, CVariant{g_localizeStrings.Get(16008)},
+                                           false)) // Enter new title
+  {
+    item.SetLabel(label);
+    return true;
+  }
+  return false;
+}
+
+bool ChooseAndSetNewThumbnail(CFileItem& item)
+{
+  CFileItemList prefilledItems;
+  if (item.HasArt("thumb"))
+  {
+    const auto current = std::make_shared<CFileItem>("thumb://Current", false);
+    current->SetArt("thumb", item.GetArt("thumb"));
+    current->SetLabel(g_localizeStrings.Get(20016)); // Current thumb
+    prefilledItems.Add(current);
+  }
+
+  const auto none = std::make_shared<CFileItem>("thumb://None", false);
+  none->SetArt("icon", item.GetArt("icon"));
+  none->SetLabel(g_localizeStrings.Get(20018)); // No thumb
+  prefilledItems.Add(none);
+
+  std::string thumb;
+  VECSOURCES sources;
+  CServiceBroker::GetMediaManager().GetLocalDrives(sources);
+  if (CGUIDialogFileBrowser::ShowAndGetImage(prefilledItems, sources, g_localizeStrings.Get(1030),
+                                             thumb)) // Browse for image
+  {
+    item.SetArt("thumb", thumb);
+    return true;
+  }
+  return false;
+}
+
+bool MoveItem(CFileItemList& items, const std::shared_ptr<CFileItem>& item, int amount)
+{
+  if (items.Size() < 2 || amount == 0)
+    return false;
+
+  int itemPos = -1;
+  for (const auto& i : items)
+  {
+    itemPos++;
+
+    if (i->GetPath() == item->GetPath())
+      break;
+  }
+
+  if (itemPos < 0 || itemPos >= items.Size())
+    return false;
+
+  int nextItem = (itemPos + amount) % items.Size();
+  if (nextItem < 0)
+  {
+    const auto itemToAdd(item);
+    items.Remove(itemPos);
+    items.Add(itemToAdd);
+  }
+  else if (nextItem == 0)
+  {
+    const auto itemToAdd(item);
+    items.Remove(itemPos);
+    items.AddFront(itemToAdd, 0);
+  }
+  else
+  {
+    items.Swap(itemPos, nextItem);
+  }
+  return true;
+}
+
+bool RemoveItem(CFileItemList& items, const std::shared_ptr<CFileItem>& item)
+{
+  int iBefore = items.Size();
+  items.Remove(item.get());
+  return items.Size() == iBefore - 1;
+}
+
+bool ShouldEnableMoveItems()
+{
+  auto& mgr = CServiceBroker::GetGUI()->GetWindowManager();
+  CGUIWindowFavourites* window = mgr.GetWindow<CGUIWindowFavourites>(WINDOW_FAVOURITES);
+  if (window && window->IsActive())
+  {
+    const CGUIViewState* state = window->GetViewState();
+    if (state && state->GetSortMethod().sortBy != SortByUserPreference)
+      return false; // in favs window, allow move only if current sort method is by user preference
+  }
+  return true;
+}
+
+} // namespace FAVOURITES_UTILS

--- a/xbmc/favourites/FavouritesUtils.h
+++ b/xbmc/favourites/FavouritesUtils.h
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <memory>
+
+class CFileItem;
+class CFileItemList;
+
+namespace FAVOURITES_UTILS
+{
+bool ChooseAndSetNewName(CFileItem& item);
+bool ChooseAndSetNewThumbnail(CFileItem& item);
+bool MoveItem(CFileItemList& items, const std::shared_ptr<CFileItem>& item, int amount);
+bool RemoveItem(CFileItemList& items, const std::shared_ptr<CFileItem>& item);
+bool ShouldEnableMoveItems();
+
+} // namespace FAVOURITES_UTILS

--- a/xbmc/favourites/GUIDialogFavourites.cpp
+++ b/xbmc/favourites/GUIDialogFavourites.cpp
@@ -12,7 +12,7 @@
 #include "ServiceBroker.h"
 #include "dialogs/GUIDialogContextMenu.h"
 #include "favourites/FavouritesURL.h"
-#include "favourites/GUIWindowFavourites.h"
+#include "favourites/FavouritesUtils.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
@@ -176,7 +176,7 @@ void CGUIDialogFavourites::OnRename(int item)
   if (item < 0 || item >= m_favourites->Size())
     return;
 
-  if (CGUIWindowFavourites::ChooseAndSetNewName(*(*m_favourites)[item]))
+  if (FAVOURITES_UTILS::ChooseAndSetNewName(*(*m_favourites)[item]))
   {
     m_favouritesService.Save(*m_favourites);
     UpdateList();
@@ -188,7 +188,7 @@ void CGUIDialogFavourites::OnSetThumb(int item)
   if (item < 0 || item >= m_favourites->Size())
     return;
 
-  if (CGUIWindowFavourites::ChooseAndSetNewThumbnail(*(*m_favourites)[item]))
+  if (FAVOURITES_UTILS::ChooseAndSetNewThumbnail(*(*m_favourites)[item]))
   {
     m_favouritesService.Save(*m_favourites);
     UpdateList();

--- a/xbmc/favourites/GUIWindowFavourites.h
+++ b/xbmc/favourites/GUIWindowFavourites.h
@@ -11,20 +11,11 @@
 #include "favourites/FavouritesService.h"
 #include "windows/GUIMediaWindow.h"
 
-class CFileItem;
-class CFileItemList;
-
 class CGUIWindowFavourites : public CGUIMediaWindow
 {
 public:
   CGUIWindowFavourites();
   ~CGUIWindowFavourites() override;
-
-  static bool ChooseAndSetNewName(CFileItem& item);
-  static bool ChooseAndSetNewThumbnail(CFileItem& item);
-  static bool MoveItem(CFileItemList& items, const std::shared_ptr<CFileItem>& item, int amount);
-  static bool RemoveItem(CFileItemList& items, const std::shared_ptr<CFileItem>& item);
-  static bool ShouldEnableMoveItems();
 
 protected:
   std::string GetRootPath() const override { return "favourites://"; }

--- a/xbmc/favourites/GUIWindowFavourites.h
+++ b/xbmc/favourites/GUIWindowFavourites.h
@@ -22,7 +22,8 @@ public:
 
   static bool ChooseAndSetNewName(CFileItem& item);
   static bool ChooseAndSetNewThumbnail(CFileItem& item);
-  static bool MoveItem(CFileItemList& items, const CFileItem& item, int amount);
+  static bool MoveItem(CFileItemList& items, const std::shared_ptr<CFileItem>& item, int amount);
+  static bool RemoveItem(CFileItemList& items, const std::shared_ptr<CFileItem>& item);
   static bool ShouldEnableMoveItems();
 
 protected:
@@ -36,4 +37,6 @@ protected:
 
 private:
   void OnFavouritesEvent(const CFavouritesService::FavouritesUpdated& event);
+  bool MoveItem(int item, int amount);
+  bool RemoveItem(int item);
 };


### PR DESCRIPTION
The PR catches up on the features of the deprecated Favourites dialog, that were simply forgotten to implement in the first place:

* support actions up/down plus key mapping for u and d keys
* support action delete plus key mapping for delete key
* change keymaps to open the Favourites Browser window where today the Favourites dialog will be opened

Was requested in the forum: https://forum.kodi.tv/showthread.php?tid=371608

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 not sure you are the right person to review?

@fuzzard I want to backport this as i consider the missing functionality a regression.