### PR TITLE
[GUIWindowVideoBase] Fix bluray scan to library single BDMV folder

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -233,7 +233,7 @@ void CGUIWindowVideoBase::OnItemInfo(const CFileItem& fileItem, ADDON::ScraperPt
                                DIR_FLAG_DEFAULTS);
 
       // Check for cases 1_dir/1_dir/.../file (e.g. by packages where have a extra folder)
-      while (items.Size() == 1 && items[0]->m_bIsFolder)
+      while (items.Size() == 1 && items[0]->m_bIsFolder && items[0]->GetOpticalMediaPath().empty())
       {
         const std::string path = items[0]->GetPath();
         items.Clear();


### PR DESCRIPTION
## Description
Fixes movie name detection when a Blueray's folder with single BDMV folder is added to the library with "Scan to library". See https://github.com/xbmc/xbmc/issues/22606 for more details.

## Motivation and context
Fixes:  https://github.com/xbmc/xbmc/issues/22606
Kodi will not drill down single folders while "Scan to library" if they are DVD or Bluray.

## How has this been tested?
Movie name is detected correctly after the fix.

## What is the effect on users?
Users will not need to enter movie name manually when adding such Bluray folders.

## Screenshots (if appropriate):

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
