### PR TITLE
[AdvancedSettings] Add bdremux word for library scan

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -201,13 +201,13 @@ void CAdvancedSettings::Initialize()
   m_videoCleanStringRegExps.emplace_back(
       "[ "
       "_\\,\\.\\(\\)\\[\\]\\-](10bit|480p|480i|576p|576i|720p|720i|1080p|1080i|2160p|3d|aac|ac3|"
-      "aka|atmos|avi|bd5|bdrip|bluray|brrip|cam|cd[1-9]|custom|dc|ddp|divx|divx5|dolbydigital|"
-      "dolbyvision|dsr|dsrip|dts|dts-hdma|dts-hra|dts-x|dv|dvd|dvd5|dvd9|dvdivx|dvdrip|dvdscr|"
-      "dvdscreener|extended|fragment|fs|h264|h265|hdr|hdr10|hevc|hddvd|hdrip|hdtv|hdtvrip|hrhd|"
-      "hrhdtv|internal|limited|multisubs|nfofix|ntsc|ogg|ogm|pal|pdtv|proper|r3|r5|read.nfo|"
-      "remastered|remux|repack|rerip|retail|screener|se|svcd|tc|telecine|telesync|truehd|ts|uhd|"
-      "unrated|ws|x264|x265|xvid|xvidvd|xxx|web-dl|webrip|www.www|\\[.*\\])([ "
-      "_\\,\\.\\(\\)\\[\\]\\-]|$)");
+      "aka|atmos|avi|bd5|bdrip|bdremux|bluray|brrip|cam|cd[1-9]|custom|dc|ddp|divx|divx5|"
+      "dolbydigital|dolbyvision|dsr|dsrip|dts|dts-hdma|dts-hra|dts-x|dv|dvd|dvd5|dvd9|dvdivx|"
+      "dvdrip|dvdscr|dvdscreener|extended|fragment|fs|h264|h265|hdr|hdr10|hevc|hddvd|hdrip|"
+      "hdtv|hdtvrip|hrhd|hrhdtv|internal|limited|multisubs|nfofix|ntsc|ogg|ogm|pal|pdtv|proper|"
+      "r3|r5|read.nfo|remastered|remux|repack|rerip|retail|screener|se|svcd|tc|telecine|"
+      "telesync|truehd|ts|uhd|unrated|ws|x264|x265|xvid|xvidvd|xxx|web-dl|webrip|www.www|"
+      "\\[.*\\])([ _\\,\\.\\(\\)\\[\\]\\-]|$)");
   m_videoCleanStringRegExps.emplace_back("(\\[.*\\])");
 
   // this vector will be inserted at the end to


### PR DESCRIPTION
## Description
BDRemux world is quite popular in file names. Adding this word to the cleanup reg expression which is used for detecting the movie name will help to automatically detect more movies.

## Motivation and context
This helps with better movie name detection

## How has this been tested?
**Before:**
Kodi didn't find the movie with name: "My Movie.BDRemux.mkv". Kodi was sending "My Movie.BDRemux" and "My Movie BDRemux" strings to the themoviedb site.
**After:**
Kodi sends "My Movie" string to themoviedb site and the movie is found.

I also added some tests, there are other issues with other files but those fixes are more sensitive. I'd like to test on a bigger set of filenames.

## What is the effect on users?
Better movie detection for the movie library.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
