### PR TITLE
[Windows] Update prepare-binary-addons-dev.bat script

### DIFF
--- a/tools/buildsteps/windows/prepare-binary-addons-dev.bat
+++ b/tools/buildsteps/windows/prepare-binary-addons-dev.bat
@@ -17,13 +17,10 @@ FOR %%b IN (%*) DO (
 )
 SETLOCAL DisableDelayedExpansion
 
-rem set Visual C++ build environment
-call "%VS140COMNTOOLS%..\..\VC\bin\amd64\vcvars64.bat" || call "%VS140COMNTOOLS%..\..\VC\bin\vcvars32.bat"
-
 SET WORKDIR=%WORKSPACE%
 
 IF "%WORKDIR%" == "" (
-  SET WORKDIR=%CD%\..\..
+  SET WORKDIR=%CD%\..\..\..
 )
 
 rem setup some paths that we need later
@@ -76,8 +73,8 @@ IF "%addon%" NEQ "" (
 )
 
 rem execute cmake to generate Visual Studio 12 project files
-cmake "%ADDONS_PATH%" -G "Visual Studio 16 2019" ^
-      -DCMAKE_BUILD_TYPE=Release ^
+cmake "%ADDONS_PATH%" -G "Visual Studio 17 2022" -A "x64" ^
+      -DCMAKE_BUILD_TYPE=Debug ^
       -DCMAKE_USER_MAKE_RULES_OVERRIDE="%SCRIPTS_PATH%/CFlagOverrides.cmake" ^
       -DCMAKE_USER_MAKE_RULES_OVERRIDE_CXX="%SCRIPTS_PATH%/CXXFlagOverrides.cmake" ^
       -DCMAKE_INSTALL_PREFIX=%WORKDIR%\addons ^


### PR DESCRIPTION
## Description

This PR gives the `prepare-binary-addons-dev.bat` script some love by updating it to VS 2022. It's more an auxiliary script useful for development, so this doesn't impact any runtime code, and nothing depends on it.

## Motivation and context

Recently, I was troubleshooting a problem on Windows, and these changes let me debug the binary add-on.

## How has this been tested?

Tested on Windows x64.

## What is the effect on users?

* None, it's a developer enhancement

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
