### PR TITLE
FileCache: Take read factor into account

### DIFF
--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -427,7 +427,7 @@ void CFileCache::Process()
       const int64_t forward = m_pCache->WaitForData(0, 0ms);
       if (forward + m_chunkSize >= m_forwardCacheSize)
       {
-        if (m_writeRateActual < m_writeRate)
+        if (m_writeRateActual < m_writeRate * CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_cacheReadFactor)
           m_writeRateLowSpeed = m_writeRateActual;
 
         m_bFilling = false;


### PR DESCRIPTION
I realized that in version v20 the ReadFactor Logic was moved from VideoPlayer entirely into the FileCache. Here the writeRate is compared against the current rate multiplied with the cachefactor from advancedsettings.xml, which is 4 by default.

I think for the "lowreadrate" detection this also needs to be taken into account.

In general I want to fix the issue, that we have a forward cache of 20 MB but only 3/4/5/6/7/8/10% filled reported to VideoPlayer, which is most likely wrong. This change does not fix this, but wants to open the discussion.

My general understanding of how things should work is that at the beginning:
- The cache is filled (especially if buffermode 1 is used) -> 100% [CHECK]
- During runtime the Cache should stay filled and the Per Centage value should fluctuage around 100% [NO CHECK]

