### PR TITLE
[Subtitles][WebVTT] Fixed segmented webvtt sync

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodec.cpp
@@ -38,28 +38,3 @@ void CDVDOverlayCodec::GetAbsoluteTimes(double& starttime, double& stoptime, Dem
   else
     stoptime = 0;
 }
-
-bool CDVDOverlayCodec::GetSubtitlePacketExtraData(DemuxPacket* pPacket,
-                                                  SubtitlePacketExtraData& extraData)
-{
-  if (!pPacket->pSideData)
-    return false;
-
-  AVPacketSideData* sideData{reinterpret_cast<AVPacketSideData*>(pPacket->pSideData)};
-
-  for (int i{0}; i < pPacket->iSideDataElems; i++)
-  {
-    AVPacketSideData* sd = &sideData[i];
-
-    if (sd->type != AV_PKT_DATA_NEW_EXTRADATA)
-      continue;
-
-    if (sd->data && sd->size > 0)
-    {
-      extraData = *reinterpret_cast<SubtitlePacketExtraData*>(sd->data);
-      return true;
-    }
-  }
-
-  return false;
-}

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodec.h
@@ -94,14 +94,6 @@ protected:
     double m_chapterStartTime;
   };
 
-  /*!
-   * \brief Get subtitle extra data from packet side data with AV_PKT_DATA_NEW_EXTRADATA type.
-   * \param pPacket The demux packet
-   * \param extraData [OUT] The subtitle extra data
-   * \return True if extra data has been found, otherwise false
-   */
-  static bool GetSubtitlePacketExtraData(DemuxPacket* pPacket, SubtitlePacketExtraData& extraData);
-
 private:
   std::string m_codecName;
 };

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/OverlayCodecWebVTT.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/OverlayCodecWebVTT.cpp
@@ -80,12 +80,6 @@ OverlayMessage COverlayCodecWebVTT::Decode(DemuxPacket* pPacket)
 
   m_webvttHandler.Reset();
 
-  SubtitlePacketExtraData sideData;
-  if (GetSubtitlePacketExtraData(pPacket, sideData))
-  {
-    m_webvttHandler.SetPeriodStart(sideData.m_chapterStartTime);
-  }
-
   if (m_isISOFormat)
   {
     double prevSubStopTime = 0.0;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/OverlayCodecWebVTT.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/OverlayCodecWebVTT.cpp
@@ -80,6 +80,8 @@ OverlayMessage COverlayCodecWebVTT::Decode(DemuxPacket* pPacket)
 
   m_webvttHandler.Reset();
 
+  m_webvttHandler.SetPeriodStart(pPacket->m_ptsOffsetCorrection);
+
   if (m_isISOFormat)
   {
     double prevSubStopTime = 0.0;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -353,7 +353,7 @@ DemuxPacket* CInputStreamAddon::ReadDemux()
   if (!m_ifc.inputstream->toAddon->demux_read)
     return nullptr;
 
-  return static_cast<DemuxPacket*>(m_ifc.inputstream->toAddon->demux_read(m_ifc.inputstream));
+  return reinterpret_cast<DemuxPacket*>(m_ifc.inputstream->toAddon->demux_read(m_ifc.inputstream));
 }
 
 std::vector<CDemuxStream*> CInputStreamAddon::GetStreams() const

--- a/xbmc/cores/VideoPlayer/Interface/DemuxPacket.h
+++ b/xbmc/cores/VideoPlayer/Interface/DemuxPacket.h
@@ -40,6 +40,9 @@ extern "C"
 
       cryptoInfo = nullptr;
     }
+
+    //! @brief PTS offset correction applied to the PTS and DTS.
+    double m_ptsOffsetCorrection{0};
   };
 
 #ifdef __cplusplus

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2250,6 +2250,8 @@ bool CVideoPlayer::CheckPlayerInit(CCurrentStream& current)
 
 void CVideoPlayer::UpdateCorrection(DemuxPacket* pkt, double correction)
 {
+  pkt->m_ptsOffsetCorrection = correction;
+
   if(pkt->dts != DVD_NOPTS_VALUE)
     pkt->dts -= correction;
   if(pkt->pts != DVD_NOPTS_VALUE)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This PR add a new member to the `DemuxPacket` to attach the pts correction value to the packet itself, this value will be used to adjust the webvtt sync.

The reason why i add this new member to the `DemuxPacket` instead of `DEMUX_PACKET` https://github.com/xbmc/xbmc/blob/master/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream/demux_packet.h#L45
is that `DemuxPacket` struct is used only internally the VP core, unlike `DEMUX_PACKET` is used on binary addons interface.

from my research this is the flow (correct me if i am wrong):
1) binary addon create `DEMUX_PACKET`
2) VP get the `DEMUX_PACKET` from binary addon and cast the packet as `DemuxPacket`
3) VP when needed apply the PTS correction by changing the value to the `DemuxPacket`
4) VP feed each demuxer (like subtitle webvtt) with this `DemuxPacket`

Since PTS correction value is set by VP (after get the `DEMUX_PACKET`) and there is no need to expose this new member to the addons interface, add the member for VP internal use only seem the way, also to avoid rebuild all binary addons for nothing,
to take in account that is needed to backport it to Kodi 20, the change is non-invasive

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
see: https://github.com/xbmc/inputstream.adaptive/pull/1082

there are many type of segmented webvtt cases for vod and live content,
that in the past we have tried to fix with PR #21523 but new use cases has raised other problems,
thanks to @glennguy we have solved most of the problem inside ISAdaptive addon,
but some of them require to adjust subtitle with the pts correction that is already included in the pts value itself, done by the VP player

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
These are cases but i cant attach here:
- segmented webvtt with chapters
- segmented webvtt live
- segmented webvtt VOD, D+ example, case that require pts correction to sync correctly
- fmp4 webvtt

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Have segmented webvtt subtitles in-sync with the video

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
