### PR TITLE
[VideoPlayerVideo] Log an error when codec extradata is required

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -114,8 +114,11 @@ bool CVideoPlayerVideo::OpenStream(CDVDStreamInfo hint)
         hint.codec == AV_CODEC_ID_WMV3 ||
         hint.codec == AV_CODEC_ID_VC1 ||
         hint.codec == AV_CODEC_ID_AV1)
-      // clang-format on
+    {
+      CLog::LogF(LOGERROR, "Codec id {} require extradata.", hint.codec);
       return false;
+    }
+    // clang-format on
   }
 
   CLog::Log(LOGINFO, "Creating video codec with codec id: {}", hint.codec);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Let VP print a error in the log when you play a video with a codec that require extradata
and VP stop the playback without messages or details in the log

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
More times are happens to me while testing with InputStreamAdaptive that while trying to play a test video
the VP stops without provide an detailed reason on the log

for example:
```
2023-01-29 17:15:29.761 T:11080   debug <general>: CDVDDemuxClient::RequestStream(): added/updated stream 1001 with codec_id 27
2023-01-29 17:15:29.764 T:11080    info <general>: Opening stream: 1001 source: 256
2023-01-29 17:15:29.765 T:11080   debug <general>: AddOnLog: inputstream.adaptive: OpenStream(1001)
2023-01-29 17:15:32.616 T:11080   debug <general>: AddOnLog: inputstream.adaptive: GetStream(1001)
2023-01-29 17:15:32.617 T:11080 warning <general>: CVideoPlayer::OpenStream - Unsupported stream 1001. Stream disabled.
```

this can happens when some videos are for some reason unsupported or features bad implemented in the InputStream addons,
for this last case is useful know the reason of disabled stream, without every time investigate on all things from scratch

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
none

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
