### PR TITLE
[Valgrind] Fix some jumps depending on uninitialized values

### DIFF
--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -818,6 +818,7 @@ void CDateTime::GetAsTm(tm& time) const
   KODI::TIME::SystemTime st;
   GetAsSystemTime(st);
 
+  time = {};
   time.tm_year = st.year - 1900;
   time.tm_mon = st.month - 1;
   time.tm_wday = st.dayOfWeek;
@@ -825,6 +826,7 @@ void CDateTime::GetAsTm(tm& time) const
   time.tm_hour = st.hour;
   time.tm_min = st.minute;
   time.tm_sec = st.second;
+  time.tm_isdst = -1;
 
   mktime(&time);
 }

--- a/xbmc/addons/VFSEntry.cpp
+++ b/xbmc/addons/VFSEntry.cpp
@@ -290,6 +290,7 @@ int CVFSEntry::Stat(const CURL& url, struct __stat64* buffer)
   STAT_STRUCTURE statBuffer = {};
   ret = m_ifc.vfs->toAddon->stat(m_ifc.vfs, &url2.url, &statBuffer);
 
+  *buffer = {};
   buffer->st_dev = statBuffer.deviceId;
   buffer->st_ino = statBuffer.fileSerialNumber;
   buffer->st_size = statBuffer.size;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -488,10 +488,9 @@ protected:
     mutable CCriticalSection m_section;
     CSelectionStreams m_selectionStreams;
     std::vector<ProgramInfo> m_programs;
-    int m_program;
-    int m_videoIndex;
-    int m_audioIndex;
-    int m_subtitleIndex;
+    int m_videoIndex{-1};
+    int m_audioIndex{-1};
+    int m_subtitleIndex{-1};
   } m_content;
 
   int m_playSpeed;

--- a/xbmc/cores/paplayer/VideoPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.cpp
@@ -22,17 +22,9 @@
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
-VideoPlayerCodec::VideoPlayerCodec()
+VideoPlayerCodec::VideoPlayerCodec() : m_processInfo(CProcessInfo::CreateInstance())
 {
   m_CodecName = "VideoPlayer";
-  m_pDemuxer = NULL;
-  m_nAudioStream = -1;
-  m_nDecodedLen = 0;
-  m_bInited = false;
-  m_needConvert = false;
-  m_channels = 0;
-
-  m_processInfo.reset(CProcessInfo::CreateInstance());
 }
 
 VideoPlayerCodec::~VideoPlayerCodec()

--- a/xbmc/cores/paplayer/VideoPlayerCodec.h
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.h
@@ -41,24 +41,24 @@ public:
 private:
   CAEStreamInfo::DataType GetPassthroughStreamType(AVCodecID codecId, int samplerate, int profile);
 
-  CDVDDemux* m_pDemuxer;
+  CDVDDemux* m_pDemuxer{nullptr};
   std::shared_ptr<CDVDInputStream> m_pInputStream;
   std::unique_ptr<CDVDAudioCodec> m_pAudioCodec;
 
   std::string m_strContentType;
   std::string m_strFileName;
-  int m_nAudioStream;
-  size_t m_nDecodedLen;
+  int m_nAudioStream{-1};
+  size_t m_nDecodedLen{0};
 
-  bool m_bInited;
-  bool m_bCanSeek;
+  bool m_bInited{false};
+  bool m_bCanSeek{false};
 
   std::unique_ptr<ActiveAE::IAEResample> m_pResampler;
-  DVDAudioFrame m_audioFrame;
-  int m_planes;
-  bool m_needConvert;
-  AEAudioFormat m_srcFormat;
-  int m_channels;
+  DVDAudioFrame m_audioFrame{};
+  int m_planes{0};
+  bool m_needConvert{false};
+  AEAudioFormat m_srcFormat{};
+  int m_channels{0};
 
   std::unique_ptr<CProcessInfo> m_processInfo;
 };

--- a/xbmc/filesystem/ZipFile.cpp
+++ b/xbmc/filesystem/ZipFile.cpp
@@ -262,6 +262,7 @@ int CZipFile::Stat(const CURL& url, struct __stat64* buffer)
   {
     if (url.GetFileName().empty() && CFile::Exists(url.GetHostName()))
     { // when accessing the zip "root" recognize it as a directory
+      *buffer = {};
       buffer->st_mode = _S_IFDIR;
       return 0;
     }

--- a/xbmc/pictures/SlideShowPicture.h
+++ b/xbmc/pictures/SlideShowPicture.h
@@ -111,10 +111,10 @@ private:
   float m_fZoomAmount;
   float m_fZoomLeft;
   float m_fZoomTop;
-  float m_ax[4], m_ay[4];
-  float m_sx[4], m_sy[4];
-  float m_bx[4], m_by[4];
-  float m_ox[4], m_oy[4];
+  float m_ax[4]{}, m_ay[4]{};
+  float m_sx[4]{}, m_sy[4]{};
+  float m_bx[4]{}, m_by[4]{};
+  float m_ox[4]{}, m_oy[4]{};
 
   // transition and display effects
   DISPLAY_EFFECT m_displayEffect = EFFECT_NONE;

--- a/xbmc/platform/posix/filesystem/PosixFile.cpp
+++ b/xbmc/platform/posix/filesystem/PosixFile.cpp
@@ -351,6 +351,7 @@ int CPosixFile::Stat(const CURL& url, struct __stat64* buffer)
   ret = statx(dirfd, filename.c_str(), flags, mask, &stxbuf);
   if (ret == 0)
   {
+    *buffer = {};
     buffer->st_mtime = stxbuf.stx_mtime.tv_sec; // modification time
     if (stxbuf.stx_btime.tv_sec != 0)
       buffer->st_ctime = stxbuf.stx_btime.tv_sec; // birth (creation) time

--- a/xbmc/platform/win10/filesystem/WinLibraryFile.cpp
+++ b/xbmc/platform/win10/filesystem/WinLibraryFile.cpp
@@ -424,6 +424,8 @@ int CWinLibraryFile::Stat(const StorageFile& file, struct __stat64* statData)
   if (file == nullptr)
     return -1;
 
+  *statData = {};
+
   /* set st_gid */
   statData->st_gid = 0; // UNIX group ID is always zero on Win32
   /* set st_uid */

--- a/xbmc/platform/win32/filesystem/Win32File.cpp
+++ b/xbmc/platform/win32/filesystem/Win32File.cpp
@@ -484,6 +484,8 @@ int CWin32File::Stat(const CURL& url, struct __stat64* statData)
 
   FindClose(hSearch);
 
+  *statData = {};
+
   /* set st_gid */
   statData->st_gid = 0; // UNIX group ID is always zero on Win32
 
@@ -623,6 +625,8 @@ int CWin32File::Stat(struct __stat64* statData)
 
   if (m_hFile == INVALID_HANDLE_VALUE)
     return -1;
+
+  *statData = {};
 
   /* set st_gid */
   statData->st_gid = 0; // UNIX group ID is always zero on Win32

--- a/xbmc/test/TestDateTime.cpp
+++ b/xbmc/test/TestDateTime.cpp
@@ -78,15 +78,46 @@ TEST_F(TestDateTime, TimeTOperators)
 
 TEST_F(TestDateTime, TmOperators)
 {
-  CDateTime dateTime1(1991, 5, 14, 12, 34, 56);
-  CDateTime dateTime2(1991, 5, 14, 12, 34, 57);
+  {
+    CDateTime dateTime1(1991, 5, 14, 12, 34, 56);
 
-  tm t;
-  dateTime2.GetAsTm(t);
+    tm t1;
+    dateTime1.GetAsTm(t1);
 
-  EXPECT_TRUE(dateTime1 < t);
-  EXPECT_FALSE(dateTime1 > t);
-  EXPECT_FALSE(dateTime1 == t);
+    EXPECT_FALSE(dateTime1 < t1);
+    EXPECT_FALSE(dateTime1 > t1);
+    EXPECT_TRUE(dateTime1 == t1);
+
+    CDateTime dateTime2(1991, 5, 14, 12, 34, 57);
+
+    tm t2;
+    dateTime2.GetAsTm(t2);
+
+    EXPECT_TRUE(dateTime1 < t2);
+    EXPECT_FALSE(dateTime1 > t2);
+    EXPECT_FALSE(dateTime1 == t2);
+  }
+
+  // same test but opposite daylight saving
+  {
+    CDateTime dateTime1(1991, 1, 14, 12, 34, 56);
+
+    tm t1;
+    dateTime1.GetAsTm(t1);
+
+    EXPECT_FALSE(dateTime1 < t1);
+    EXPECT_FALSE(dateTime1 > t1);
+    EXPECT_TRUE(dateTime1 == t1);
+
+    CDateTime dateTime2(1991, 1, 14, 12, 34, 57);
+
+    tm t2;
+    dateTime2.GetAsTm(t2);
+
+    EXPECT_TRUE(dateTime1 < t2);
+    EXPECT_FALSE(dateTime1 > t2);
+    EXPECT_FALSE(dateTime1 == t2);
+  }
 }
 
 // no way to test this platform agnostically (for now) so just log it.
@@ -553,13 +584,24 @@ TEST_F(TestDateTime, GetAsTime)
 
 TEST_F(TestDateTime, GetAsTm)
 {
-  CDateTime dateTime;
-  dateTime.SetDateTime(1991, 05, 14, 12, 34, 56);
+  {
+    CDateTime dateTime;
+    dateTime.SetDateTime(1991, 05, 14, 12, 34, 56);
 
-  tm time;
-  dateTime.GetAsTm(time);
+    tm time;
+    dateTime.GetAsTm(time);
+    EXPECT_TRUE(dateTime == time);
+  }
 
-  EXPECT_TRUE(dateTime == time);
+  // same test but opposite daylight saving
+  {
+    CDateTime dateTime;
+    dateTime.SetDateTime(1991, 01, 14, 12, 34, 56);
+
+    tm time;
+    dateTime.GetAsTm(time);
+    EXPECT_TRUE(dateTime == time);
+  }
 }
 
 // Disabled pending std::chrono and std::date changes.


### PR DESCRIPTION
## Description
See title and Valgrind output in commit messages.

## Motivation and context
Remove undefined behaviour and maybe improve stability.

## How has this been tested?
Errors in Valgrind are gone, Kodi still runs :)

## What is the effect on users?
None.

## Screenshots (if appropriate):
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
