### PR TITLE
[backport] windowing: X11: Add missing <cstdint> include (fix build with GCC 13)

### DIFF
--- a/xbmc/windowing/X11/GLContext.h
+++ b/xbmc/windowing/X11/GLContext.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 #include <X11/Xlib.h>


### PR DESCRIPTION
Backport of https://github.com/xbmc/xbmc/pull/22627

## Description
Add missing `<cstdint>` include for `uintp64_t` and friends.

## Motivation and context
GCC 13 (as usual for new compiler releases) shuffles around some internal includes and so <cstdint> etc is no longer transitively included.

See https://www.gnu.org/software/gcc/gcc-13/porting_to.html.

Bug: https://bugs.gentoo.org/892503

## How has this been tested?

Tested with various GCC versions on Linux.

## What is the effect on users?

Fixes build with GCC 13. No effect on others.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
