### PR TITLE
Fix build with gcc 13 by including <cstdint>

### DIFF
--- a/xbmc/cores/RetroPlayer/cheevos/Cheevos.h
+++ b/xbmc/cores/RetroPlayer/cheevos/Cheevos.h
@@ -10,6 +10,7 @@
 
 #include "RConsoleIDs.h"
 
+#include <cstdint>
 #include <map>
 #include <string>
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/ColorManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/ColorManager.cpp
@@ -15,6 +15,7 @@
 #include "utils/TimeUtils.h"
 #include "utils/log.h"
 
+#include <cstdint>
 #include <math.h>
 #include <vector>
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/ColorManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/ColorManager.h
@@ -12,6 +12,7 @@
 #include <lcms2.h>
 #endif
 
+#include <cstdint>
 #include <string>
 
 extern "C"

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.h
@@ -13,6 +13,7 @@
 #include "platform/posix/utils/FileHandle.h"
 
 #include <array>
+#include <cstdint>
 
 #include <va/va.h>
 

--- a/xbmc/pictures/Picture.h
+++ b/xbmc/pictures/Picture.h
@@ -11,6 +11,8 @@
 #include "pictures/PictureScalingAlgorithm.h"
 #include "utils/Job.h"
 
+#include <cstddef>
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/xbmc/platform/Filesystem.h
+++ b/xbmc/platform/Filesystem.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <system_error>
 namespace KODI

--- a/xbmc/platform/posix/Filesystem.cpp
+++ b/xbmc/platform/posix/Filesystem.cpp
@@ -19,6 +19,7 @@
 #include <sys/statfs.h>
 #endif
 
+#include <cstdint>
 #include <cstdlib>
 #include <limits.h>
 #include <string.h>

--- a/xbmc/utils/CSSUtils.cpp
+++ b/xbmc/utils/CSSUtils.cpp
@@ -8,6 +8,7 @@
 
 #include "CSSUtils.h"
 
+#include <cstdint>
 #include <string>
 
 namespace

--- a/xbmc/utils/CharArrayParser.cpp
+++ b/xbmc/utils/CharArrayParser.cpp
@@ -10,6 +10,7 @@
 
 #include "utils/log.h"
 
+#include <cstdint>
 #include <cstring>
 
 void CCharArrayParser::Reset()

--- a/xbmc/utils/CharArrayParser.h
+++ b/xbmc/utils/CharArrayParser.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 /*!

--- a/xbmc/utils/StreamUtils.h
+++ b/xbmc/utils/StreamUtils.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 static constexpr int MP4_BOX_HEADER_SIZE = 8;

--- a/xbmc/windowing/X11/GLContextEGL.h
+++ b/xbmc/windowing/X11/GLContextEGL.h
@@ -12,6 +12,8 @@
 #include "system_egl.h"
 #include "threads/CriticalSection.h"
 
+#include <cstdint>
+
 #include <EGL/eglext.h>
 #ifdef HAVE_EGLEXTANGLE
 #include <EGL/eglext_angle.h>


### PR DESCRIPTION
Like other versions before, gcc 13 moved some includes around and as a result <cstdint> is no longer transitively included. Explicitly include it for uint*_t.

## How has this been tested?
Built locally with gcc-13.0.1_pre20230122

## What is the effect on users?
Just fixes the build with gcc 13.

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
