### PR TITLE
[Subtitles][WebVTT] Fix overlapped subtitles on malformed segments

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.h
@@ -14,6 +14,7 @@
 
 #include <deque>
 #include <map>
+#include <memory>
 #include <stdio.h>
 #include <string>
 #include <string_view>
@@ -209,6 +210,9 @@ private:
   void ConvertAddSubtitle(std::vector<subtitleData>* subList);
   void LoadColors();
   double GetTimeFromRegexTS(CRegExp& regex, int indexStart = 1);
+
+  // Last subtitle data added, must persist and be updated between all demuxer packages
+  std::unique_ptr<subtitleData> m_lastSubtitleData;
 
   std::string m_previousLines[3];
   bool m_overrideStyle{false};


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Fix overlapped subtitles on malformed stream segments
by checking the last subtitle added between all WebVTT segments

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While working to fix WebVTT segmented case
with https://github.com/xbmc/inputstream.adaptive/pull/1082 (PR required to test it)
we have found another problem on malformed stream segments

some streams add the last subtitle cue (of current segment packet) also on the next segment packet,
and so this cause to parse same subtitle twice and overlapping subtitles to be displayed

time ago i have fixed a similar case for Youtube case,
but seem that this malformed cases are known
other parsers do similar things to check this problem:
https://github.com/video-dev/hls.js/blob/1fd478ab0c170d7046b92d456caba3405751af6c/src/utils/webvtt-parser.ts#L45-L64

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with: https://cdn-ue1-prod.tsv2.amagi.tv/avod/simplestream-lds-ldtimln/ODYPPCS001EP001/ODYPPCS001EP001.m3u8
it require InputStream Adaptive patched with mentioned PR above

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Show video without overlapped text

## Screenshots (if appropriate):
BEFORE
![immagine](https://user-images.githubusercontent.com/3257156/215425999-08f57456-49a3-4880-a8f6-1f751502e458.png)

AFTER
![immagine](https://user-images.githubusercontent.com/3257156/215426046-d82b6022-10b1-4188-b2e1-209f8ea7ad45.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
