### PR TITLE
RetroPlayer: Savestate rendering

### DIFF
--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -638,6 +638,11 @@
 							<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
 							<bordersize>4</bordersize>
 						</control>
+						<control type="gamewindow">
+							<width>444</width>
+							<height>250</height>
+							<pixels>$INFO[ListItem.FilenameAndPath]</pixels>
+						</control>
 						<control type="label">
 							<top>250</top>
 							<width>444</width>
@@ -669,6 +674,11 @@
 							<texture border="4">$INFO[ListItem.Art(screenshot)]</texture>
 							<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
 							<bordersize>4</bordersize>
+						</control>
+						<control type="gamewindow">
+							<width>444</width>
+							<height>250</height>
+							<pixels>$INFO[ListItem.FilenameAndPath]</pixels>
 						</control>
 						<control type="label">
 							<top>250</top>

--- a/xbmc/cores/RetroPlayer/guibridge/IGUIRenderSettings.h
+++ b/xbmc/cores/RetroPlayer/guibridge/IGUIRenderSettings.h
@@ -39,6 +39,12 @@ public:
   virtual bool HasRotation() const { return true; }
 
   /*!
+   * \brief Returns true if this render target has a path to a savestate for
+   *        showing pixel data
+   */
+  virtual bool HasPixels() const { return true; }
+
+  /*!
    * \brief Get the settings used to render this target
    *
    * \return The render settings

--- a/xbmc/cores/RetroPlayer/guicontrols/GUIGameControl.cpp
+++ b/xbmc/cores/RetroPlayer/guicontrols/GUIGameControl.cpp
@@ -41,9 +41,11 @@ CGUIGameControl::CGUIGameControl(const CGUIGameControl& other)
     m_videoFilterInfo(other.m_videoFilterInfo),
     m_stretchModeInfo(other.m_stretchModeInfo),
     m_rotationInfo(other.m_rotationInfo),
+    m_pixelInfo(other.m_pixelInfo),
     m_bHasVideoFilter(other.m_bHasVideoFilter),
     m_bHasStretchMode(other.m_bHasStretchMode),
     m_bHasRotation(other.m_bHasRotation),
+    m_bHasPixels(other.m_bHasPixels),
     m_renderSettings(new CGUIRenderSettings(*this))
 {
   m_renderSettings->SetSettings(other.m_renderSettings->GetSettings());
@@ -70,6 +72,11 @@ void CGUIGameControl::SetStretchMode(const GUILIB::GUIINFO::CGUIInfoLabel& stret
 void CGUIGameControl::SetRotation(const KODI::GUILIB::GUIINFO::CGUIInfoLabel& rotation)
 {
   m_rotationInfo = rotation;
+}
+
+void CGUIGameControl::SetPixels(const KODI::GUILIB::GUIINFO::CGUIInfoLabel& pixels)
+{
+  m_pixelInfo = pixels;
 }
 
 IGUIRenderSettings* CGUIGameControl::GetRenderSettings() const
@@ -153,6 +160,13 @@ void CGUIGameControl::UpdateInfo(const CGUIListItem* item /* = nullptr */)
       m_renderSettings->SetRotationDegCCW(rotation);
       m_bHasRotation = true;
     }
+
+    std::string strPixels = m_pixelInfo.GetItemLabel(item);
+    if (!strPixels.empty())
+    {
+      m_renderSettings->SetPixels(strPixels);
+      m_bHasPixels = true;
+    }
   }
 }
 
@@ -161,6 +175,7 @@ void CGUIGameControl::Reset()
   m_bHasVideoFilter = false;
   m_bHasStretchMode = false;
   m_bHasRotation = false;
+  m_bHasPixels = false;
   m_renderSettings->Reset();
 }
 

--- a/xbmc/cores/RetroPlayer/guicontrols/GUIGameControl.h
+++ b/xbmc/cores/RetroPlayer/guicontrols/GUIGameControl.h
@@ -21,6 +21,11 @@ class CGUIRenderSettings;
 class CGUIRenderHandle;
 class IGUIRenderSettings;
 
+// Label to use when disabling rendering via the <pixels> property. A path
+// to pixel data is expected, but instead this constant can be provided to
+// skip a file existence check in the renderer.
+constexpr const char* NO_PIXEL_DATA = "-";
+
 class CGUIGameControl : public CGUIControl
 {
 public:
@@ -32,11 +37,13 @@ public:
   void SetVideoFilter(const KODI::GUILIB::GUIINFO::CGUIInfoLabel& videoFilter);
   void SetStretchMode(const KODI::GUILIB::GUIINFO::CGUIInfoLabel& stretchMode);
   void SetRotation(const KODI::GUILIB::GUIINFO::CGUIInfoLabel& rotation);
+  void SetPixels(const KODI::GUILIB::GUIINFO::CGUIInfoLabel& pixels);
 
   // Rendering functions
   bool HasVideoFilter() const { return m_bHasVideoFilter; }
   bool HasStretchMode() const { return m_bHasStretchMode; }
   bool HasRotation() const { return m_bHasRotation; }
+  bool HasPixels() const { return m_bHasPixels; }
   IGUIRenderSettings* GetRenderSettings() const;
 
   // implementation of CGUIControl
@@ -60,11 +67,13 @@ private:
   KODI::GUILIB::GUIINFO::CGUIInfoLabel m_videoFilterInfo;
   KODI::GUILIB::GUIINFO::CGUIInfoLabel m_stretchModeInfo;
   KODI::GUILIB::GUIINFO::CGUIInfoLabel m_rotationInfo;
+  KODI::GUILIB::GUIINFO::CGUIInfoLabel m_pixelInfo;
 
   // Rendering properties
   bool m_bHasVideoFilter = false;
   bool m_bHasStretchMode = false;
   bool m_bHasRotation = false;
+  bool m_bHasPixels = false;
   std::unique_ptr<CGUIRenderSettings> m_renderSettings;
   std::shared_ptr<CGUIRenderHandle> m_renderHandle;
 };

--- a/xbmc/cores/RetroPlayer/guicontrols/GUIRenderSettings.cpp
+++ b/xbmc/cores/RetroPlayer/guicontrols/GUIRenderSettings.cpp
@@ -34,6 +34,11 @@ bool CGUIRenderSettings::HasRotation() const
   return m_guiControl.HasRotation();
 }
 
+bool CGUIRenderSettings::HasPixels() const
+{
+  return m_guiControl.HasPixels();
+}
+
 CRenderSettings CGUIRenderSettings::GetSettings() const
 {
   std::unique_lock<CCriticalSection> lock(m_mutex);
@@ -88,4 +93,11 @@ void CGUIRenderSettings::SetRotationDegCCW(unsigned int rotationDegCCW)
   std::unique_lock<CCriticalSection> lock(m_mutex);
 
   m_renderSettings.VideoSettings().SetRenderRotation(rotationDegCCW);
+}
+
+void CGUIRenderSettings::SetPixels(const std::string& pixelPath)
+{
+  std::unique_lock<CCriticalSection> lock(m_mutex);
+
+  m_renderSettings.VideoSettings().SetPixels(pixelPath);
 }

--- a/xbmc/cores/RetroPlayer/guicontrols/GUIRenderSettings.h
+++ b/xbmc/cores/RetroPlayer/guicontrols/GUIRenderSettings.h
@@ -30,6 +30,7 @@ public:
   bool HasVideoFilter() const override;
   bool HasStretchMode() const override;
   bool HasRotation() const override;
+  bool HasPixels() const override;
   CRenderSettings GetSettings() const override;
   CRect GetDimensions() const override;
 
@@ -40,6 +41,7 @@ public:
   void SetVideoFilter(const std::string& videoFilter);
   void SetStretchMode(STRETCHMODE stretchMode);
   void SetRotationDegCCW(unsigned int rotationDegCCW);
+  void SetPixels(const std::string& pixelPath);
 
 private:
   // Construction parameters

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
@@ -19,6 +19,7 @@ extern "C"
 }
 
 #include <atomic>
+#include <future>
 #include <map>
 #include <memory>
 #include <set>
@@ -157,6 +158,12 @@ private:
   IRenderBuffer* GetRenderBuffer(IRenderBufferPool* bufferPool);
 
   /*!
+   * \brief Get a render buffer containing pixels from the specified savestate
+   */
+  IRenderBuffer* GetRenderBufferForSavestate(const std::string& savestatePath,
+                                             const IRenderBufferPool* bufferPool);
+
+  /*!
    * \brief Create a render buffer for the specified pool from a cached frame
    */
   void CreateRenderBuffer(IRenderBufferPool* bufferPool);
@@ -206,6 +213,8 @@ private:
 
   void GetVideoFrame(IRenderBuffer*& readableBuffer, std::vector<uint8_t>& cachedFrame);
   void FreeVideoFrame(IRenderBuffer* readableBuffer, std::vector<uint8_t> cachedFrame);
+  void LoadVideoFrameAsync(const std::string& savestatePath);
+  void LoadVideoFrameSync(const std::string& savestatePath);
 
   // Construction parameters
   CRPProcessInfo& m_processInfo;
@@ -234,6 +243,7 @@ private:
   unsigned int m_cachedRotationCCW{0};
   std::map<std::string, std::vector<IRenderBuffer*>>
       m_savestateBuffers; // Render buffers for savestates
+  std::vector<std::future<void>> m_savestateThreads;
 
   // State parameters
   enum class RENDER_STATE

--- a/xbmc/cores/RetroPlayer/rendering/RenderVideoSettings.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RenderVideoSettings.cpp
@@ -19,12 +19,13 @@ void CRenderVideoSettings::Reset()
   m_scalingMethod = SCALINGMETHOD::AUTO;
   m_stretchMode = STRETCHMODE::Normal;
   m_rotationDegCCW = 0;
+  m_pixelPath.clear();
 }
 
 bool CRenderVideoSettings::operator==(const CRenderVideoSettings& rhs) const
 {
   return m_scalingMethod == rhs.m_scalingMethod && m_stretchMode == rhs.m_stretchMode &&
-         m_rotationDegCCW == rhs.m_rotationDegCCW;
+         m_rotationDegCCW == rhs.m_rotationDegCCW && m_pixelPath == rhs.m_pixelPath;
 }
 
 bool CRenderVideoSettings::operator<(const CRenderVideoSettings& rhs) const
@@ -42,6 +43,11 @@ bool CRenderVideoSettings::operator<(const CRenderVideoSettings& rhs) const
   if (m_rotationDegCCW < rhs.m_rotationDegCCW)
     return true;
   if (m_rotationDegCCW > rhs.m_rotationDegCCW)
+    return false;
+
+  if (m_pixelPath < rhs.m_pixelPath)
+    return true;
+  if (m_pixelPath > rhs.m_pixelPath)
     return false;
 
   return false;
@@ -76,4 +82,8 @@ void CRenderVideoSettings::SetVideoFilter(const std::string& videoFilter)
   {
     m_scalingMethod = SCALINGMETHOD::AUTO;
   }
+}
+void CRenderVideoSettings::ResetPixels()
+{
+  m_pixelPath.clear();
 }

--- a/xbmc/cores/RetroPlayer/rendering/RenderVideoSettings.h
+++ b/xbmc/cores/RetroPlayer/rendering/RenderVideoSettings.h
@@ -46,10 +46,15 @@ public:
   unsigned int GetRenderRotation() const { return m_rotationDegCCW; }
   void SetRenderRotation(unsigned int rotationDegCCW) { m_rotationDegCCW = rotationDegCCW; }
 
+  std::string GetPixels() const { return m_pixelPath; }
+  void SetPixels(const std::string& pixelPath) { m_pixelPath = pixelPath; }
+  void ResetPixels();
+
 private:
   SCALINGMETHOD m_scalingMethod;
   STRETCHMODE m_stretchMode;
   unsigned int m_rotationDegCCW;
+  std::string m_pixelPath;
 };
 } // namespace RETRO
 } // namespace KODI

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.cpp
@@ -132,6 +132,11 @@ void CRPBaseRenderer::SetRenderRotation(unsigned int rotationDegCCW)
   m_renderSettings.VideoSettings().SetRenderRotation(rotationDegCCW);
 }
 
+void CRPBaseRenderer::SetPixels(const std::string& pixelPath)
+{
+  m_renderSettings.VideoSettings().SetPixels(pixelPath);
+}
+
 void CRPBaseRenderer::ManageRenderArea(const IRenderBuffer& renderBuffer)
 {
   // Get texture parameters

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.h
@@ -67,6 +67,7 @@ public:
   void SetScalingMethod(SCALINGMETHOD method);
   void SetStretchMode(STRETCHMODE stretchMode);
   void SetRenderRotation(unsigned int rotationDegCCW);
+  void SetPixels(const std::string& pixelPath);
 
   // Rendering properties
   bool IsVisible() const;

--- a/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
+++ b/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
@@ -264,7 +264,25 @@ void CDialogInGameSaves::OnNewSave()
     // "Error"
     // "An unknown error has occurred."
     CGUIDialogOK::ShowAndGetInput(257, 24071);
+    return;
   }
+
+  // Create a simulated savestate to update the GUI faster. We will be notified
+  // of the real savestate info via OnMessage() when the savestate creation
+  // completes.
+  auto savestate = RETRO::CSavestateDatabase::AllocateSavestate();
+
+  savestate->SetType(SAVE_TYPE::MANUAL);
+  savestate->SetCreated(CDateTime::GetUTCDateTime());
+
+  savestate->Finalize();
+
+  CFileItemPtr item = std::make_shared<CFileItem>();
+  CSavestateDatabase::GetSavestateItem(*savestate, savestatePath, *item);
+
+  m_savestateItems.AddFront(std::move(item), 0);
+
+  RefreshList();
 }
 
 void CDialogInGameSaves::OnLoad(CFileItem& focusedItem)

--- a/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
+++ b/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
@@ -13,6 +13,7 @@
 #include "XBDateTime.h"
 #include "cores/RetroPlayer/guibridge/GUIGameRenderManager.h"
 #include "cores/RetroPlayer/guibridge/GUIGameSettingsHandle.h"
+#include "cores/RetroPlayer/guicontrols/GUIGameControl.h"
 #include "cores/RetroPlayer/playback/IPlayback.h"
 #include "cores/RetroPlayer/savestates/ISavestate.h"
 #include "cores/RetroPlayer/savestates/SavestateDatabase.h"
@@ -38,6 +39,8 @@ CFileItemPtr CreateNewSaveItem()
 {
   CFileItemPtr item = std::make_shared<CFileItem>(g_localizeStrings.Get(15314)); // "Save"
 
+  // A nonexistent path ensures a gamewindow control won't render any pixels
+  item->SetPath(NO_PIXEL_DATA);
   item->SetArt("icon", "DefaultAddSource.png");
   item->SetProperty(SAVESTATE_CAPTION,
                     g_localizeStrings.Get(15315)); // "Save progress to a new save file"
@@ -366,6 +369,9 @@ void CDialogInGameSaves::OnDelete(CFileItem& focusedItem)
       m_savestateItems.Remove(&focusedItem);
 
       RefreshList();
+
+      auto gameSettings = CServiceBroker::GetGameRenderManager().RegisterGameSettingsDialog();
+      gameSettings->FreeSavestateResources(focusedItem.GetPath());
     }
     else
     {

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -1235,6 +1235,10 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
       GUIINFO::CGUIInfoLabel rotation;
       GetInfoLabel(pControlNode, "rotation", rotation, parentID);
       static_cast<RETRO::CGUIGameControl*>(control)->SetRotation(rotation);
+
+      GUIINFO::CGUIInfoLabel pixels;
+      GetInfoLabel(pControlNode, "pixels", pixels, parentID);
+      static_cast<RETRO::CGUIGameControl*>(control)->SetPixels(pixels);
     }
     break;
   case CGUIControl::GUICONTROL_FADELABEL:


### PR DESCRIPTION
## Description

The savestate manager has one last problem.

When you overwrite a savestate, the image doesn't update because the texture is cached and refcounted in the GUI. This PR fixes that by storing pixel data in the savestate and rendering it over the jpg thumbnail shown in game.

A number of changes were made to make this happen:

* The `<gamewindow>` control has been given a new field, `pixels`, that can point to a savestate, and that savestate will be rendered in the control
* The savestate FlatBuffer schema has been updated to version 3 for video data. Fully backwards and forward compatible, as the jpg is still shown if pixel data is missing from a v2 save.
* Memory access types have been implemented, so that we don't try to read video data from a write-only buffer
* All disk hits and bulk memory operations are done asynchronously off-thread

Because RetroPlayer is doing the rendering, that means that all effects, such as stretching, rotating and shaders, can be applied to the savestate thumbnails.

The PR comes in pretty hefty, so I've made a big effort to organize all changes into commits that can be reviewed individually.

## Motivation and context

This solution pulls together a lot of code from many of my discarded ideas in the past. The commit `RetroPlayer: Add memory access and alignment` is from 2018 when I was working on memory maps. The FlatBuffers schema was found in an old branch as well. It's pretty cool that the code ended up saving the day.

## How has this been tested?

As you can see in the diff, the skin has been modified with a `<gamewindow>` control using the new `pixels` field:

```xml
<control type="gamewindow">
    <width>444</width>
    <height>250</height>
    <pixels>$INFO[ListItem.FilenameAndPath]</pixels>
</control>
```

Test builds have been posted here: https://github.com/garbear/xbmc/releases

## What is the effect on users?

* Fixed thumbnails not refreshing when overwritten in the new savestate manager

Fortunately, with the 4k bug, it's easy to see what's being rendered by RetroPlayer and what's a jpg fallback..

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
