### PR TITLE
Estuary: Remove extra empty <controls></controls>

### DIFF
--- a/addons/skin.estuary/xml/DialogGameControllers.xml
+++ b/addons/skin.estuary/xml/DialogGameControllers.xml
@@ -11,6 +11,4 @@
 		<include condition="Window.IsActive(gamecontrollers)">GameDialogControllers</include>
 		<include condition="Window.IsActive(gameports)">GameDialogPorts</include>
 	</controls>
-	<controls>
-	</controls>
 </window>


### PR DESCRIPTION
## Description

As title says. There's an empty `<controls></controls>` in the controller dialog xml file.

## Motivation and context

Pointed out by @HitcherUK here: https://github.com/xbmc/xbmc/pull/20505#discussion_r1090814974

## How has this been tested?

Haven't tested yet because there's no code changes, but I'll test before merging.

## What is the effect on users?

* None

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
