### PR TITLE
PlatformLinux: Prefer Pipewire over Pulse

### DIFF
--- a/xbmc/platform/linux/PlatformLinux.cpp
+++ b/xbmc/platform/linux/PlatformLinux.cpp
@@ -114,9 +114,9 @@ bool CPlatformLinux::InitStageOne()
   }
   else
   {
-    if (!OPTIONALS::PulseAudioRegister())
+    if (!OPTIONALS::PipewireRegister())
     {
-      if (!OPTIONALS::PipewireRegister())
+      if (!OPTIONALS::PulseAudioRegister())
       {
         if (!OPTIONALS::ALSARegister())
         {


### PR DESCRIPTION
I realized from user feedback that certain distribution ship with pipewire enabled and tunnel e.g. pulse and alsa through it. Through to our factory we end up with a pulse emulation via pipewire.

Therefore let's try Pipewire first and then fallback to Pulse if this does not succeed.

Reasoning: Pulse does not emulate Pipewire, only the other way round