### PR TITLE
fix:  text with unicode characters missing in font freeze Kodi

### DIFF
--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -492,11 +492,6 @@ void CGUIFontTTF::DrawTextInternal(CGraphicContext& context,
 
       // grab the next character
       Character* ch = &characters.front();
-      if (ch->m_glyphAndStyle == 0)
-      {
-        characters.pop();
-        continue;
-      }
 
       if ((text[glyph.m_glyphInfo.cluster] & 0xffff) == static_cast<character_t>('\t'))
       {


### PR DESCRIPTION
## Description
Fixes the issue of unicode characters that freeze Nexus.

When a unicode character does not exist in a font, Matrix showed the .notdef / box character instead.

In Nexus such characters are handled inconsistently, sometimes resulting in an exception / freeze.

GetTextWidthInternal() called by CGUIFontTTF::DrawTextInternal line 405 takes into account the space used by the .notdef/codepoint/glyph 0 characters.
However the block of line 495 pops the glyph without increasing cursorX so eventually the condition to stop the loop fails and the code attempts to dequeue another time from an empty "characters" queue, causing an exception and the freeze.

This patch reverts to Matrix behavior and displays the .notdef / box characters for the unicode characters missing in the font.

Alternatively maybe they were skipped on purpose and the behavior change was incomplete? In that case it's GetTextWidthInternal and the loop of line 462 that need to change to skip the codepoint 0 characters.

Let me know.

note: I am the ex-team member CrystalP but was not able to submit under that handle because my team email was suspended so I can't get into the related github. If you reactivate I'll redo the PR.

## Motivation and context
My specific case: Kodi v20 crashes with the skin Confluence and its default font roboto-regular when displaying file names that contain some unicode characters that don't exist in the font.
For example filename when dumping https://www.youtube.com/watch?v=BRAWVIX7mv0 with yt-dlp
It contains unicode 0xff1f that does not exist in the roboto font.
Additional condition for the freeze: the text must be long enough to overflow the label and would normally have some characters truncated + ellipsis(...) added at the end.

The same problem was reported by other users about emojis with default skin and font.

Solves issue [22473](https://github.com/xbmc/xbmc/issues/22473) and [22565](https://github.com/xbmc/xbmc/issues/22565) - maybe others?
Reported many times in the forums as well.

## How has this been tested?
Tested on Windows 10 x64.
I left a conditional breakpoint to track down other cases that cause characters with codepoint 0 but didn't find any after casually navigating through the various screens.

## What is the effect on users?
Fixes a "freeze" of Kodi when displaying some unicode characters.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
