### PR TITLE
[Windows] handle WM_INITMENU event to disable move from system menu when window is in full screen

### DIFF
--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -855,6 +855,18 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
       }
       break;
     }
+    case WM_INITMENU:
+    {
+      HMENU hm = GetSystemMenu(hWnd, FALSE);
+      if (hm)
+      {
+        if (DX::Windowing()->IsFullScreen())
+          EnableMenuItem(hm, SC_MOVE, MF_BYCOMMAND | MF_DISABLED | MF_GRAYED);
+        else
+          EnableMenuItem(hm, SC_MOVE, MF_BYCOMMAND | MF_ENABLED);
+      }
+      break;
+    }
     default:;
   }
   return(DefWindowProc(hWnd, uMsg, wParam, lParam));

--- a/xbmc/windowing/windows/WinSystemWin32.h
+++ b/xbmc/windowing/windows/WinSystemWin32.h
@@ -98,7 +98,6 @@ public:
   // videosync
   std::unique_ptr<CVideoSync> GetVideoSync(void *clock) override;
 
-  bool WindowedMode() const { return m_state != WINDOW_STATE_FULLSCREEN; }
   bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
 
   std::vector<std::string> GetConnectedOutputs() override;


### PR DESCRIPTION
## Description
Handle WM_INITMENU event to disable move from system menu when window is in full screen.

Supersedes https://github.com/xbmc/xbmc/pull/22628
Closes https://github.com/xbmc/xbmc/issues/16571


## Motivation and context
Is not very important bug although issue is open and active from 2019...

Proper solution is handle `WM_INITMENU` generated one time before system menu is displayed, this gives an opportunity to adjust its contents. Others solutions as remove permanently move option are not valid because it also changes the property of the window to non-movable (not even dragging the title bar in mode windowed).

In a separate commit is removed method `WindowedMode()` as found not used anywhere.


## How has this been tested?
Runtime tested Windows x64 in full screen exclusive and full screen windowed.   


## What is the effect on users?
Avoids main window can be moved using system menu (Alt + Space) when is in full screen.


## Screenshots (if appropriate):

**Before**
![before](https://user-images.githubusercontent.com/58434170/216009226-f58980a1-2196-4de4-a706-d54d7a8496f8.png)

**After**
![after](https://user-images.githubusercontent.com/58434170/216009291-f57e38a4-2d71-45be-a219-d052ad007dc1.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
