### PR TITLE
[Subtitles][Libass] Fix line spacing to avoid overlap box

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -456,7 +456,7 @@ void CDVDSubtitlesLibass::ApplyStyle(const std::shared_ptr<struct style>& subSty
           ConvColor(subStyle->shadowColor, subStyle->shadowOpacity); // Set the box shadow color
       style->Shadow = (10.00 / 100 * subStyle->shadowSize) * scale; // Set the box shadow size
       // By default a box overlaps the other, then we increase a bit the line spacing
-      lineSpacing = 6.0;
+      lineSpacing = 8.0 * scaleDefault;
     }
     else if (subStyle->borderStyle == BorderType::SQUARE_BOX)
     {
@@ -468,7 +468,9 @@ void CDVDSubtitlesLibass::ApplyStyle(const std::shared_ptr<struct style>& subSty
       style->Shadow = 4 * scale; // Space between the text and the box edges
     }
 
-    ass_set_line_spacing(m_renderer, lineSpacing);
+    // ass_set_line_spacing do not scale, so we have to scale to frame size
+    ass_set_line_spacing(m_renderer,
+                         lineSpacing / playResY * static_cast<double>(opts.frameHeight));
 
     style->Blur = (10.00 / 100 * subStyle->blur);
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Fix line spacing to avoid overlap box when multiline text is displayed

sidenote:
i have attached a 500x zoom of the screenshot (with fixes) to point out a box rendering weirdness
this problem is already known from my part only mentioned here to remember it
![immagine](https://user-images.githubusercontent.com/3257156/215789454-c0dbc16b-9c06-4da8-af3f-f5462a3f6ff4.png)
artefacts can be seen around the box, so slight jagged box borders
which could be seen slightly more pronounced between two boxes
not found ways to workaround it i could be libass library problem

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #22636

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With regular SRT by set BOX effect and a background color with 50% opacity
and with a ASS subtitle by enabling overrides subtitle styles settings

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
see screenshot

## Screenshots (if appropriate):
BEFORE
![immagine](https://user-images.githubusercontent.com/3257156/215788948-fcf556ac-a031-4d1c-a356-fa64046ac1b8.png)

AFTER
![immagine](https://user-images.githubusercontent.com/3257156/215789000-3160e101-25bb-4660-8bf5-6b538110c6c4.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
