### PR TITLE
VideoBufferDMA: Support exporting YCbCr444 buffers

### DIFF
--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDMA.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDMA.cpp
@@ -119,20 +119,27 @@ bool CVideoBufferDMA::Alloc()
 
 void CVideoBufferDMA::Export(AVFrame* frame, uint32_t width, uint32_t height)
 {
-  m_planes = av_pix_fmt_count_planes(static_cast<AVPixelFormat>(frame->format));
+  AVPixelFormat pix_fmt = static_cast<AVPixelFormat>(frame->format);
+  m_planes = av_pix_fmt_count_planes(pix_fmt);
+  int h_shift;
+  int v_shift;
 
-  if (m_planes < 2)
-    throw std::runtime_error(
-        "non-planar formats not supported: " +
-        std::string(av_get_pix_fmt_name(static_cast<AVPixelFormat>(frame->format))));
+  if (av_pix_fmt_get_chroma_sub_sample(pix_fmt, &h_shift, &v_shift))
+    throw std::runtime_error("unable to determine chroma_sub_sample: " +
+                             std::string(av_get_pix_fmt_name(pix_fmt)));
+
+  if (m_planes < 2 || m_planes > 3)
+    throw std::runtime_error("only 2 or 3 plane formats supported: " +
+                             std::string(av_get_pix_fmt_name(pix_fmt)));
 
   for (uint32_t plane = 0; plane < m_planes; plane++)
   {
     m_strides[plane] =
         av_image_get_linesize(static_cast<AVPixelFormat>(frame->format), width, plane);
-    m_offsets[plane] =
-        plane == 0 ? 0 : (m_offsets[plane - 1] + m_strides[plane - 1] * (height >> (plane - 1)));
   }
+  m_offsets[0] = 0;
+  m_offsets[1] = m_strides[0] * height;
+  m_offsets[2] = m_offsets[1] + (m_strides[1] * height >> v_shift);
 
   if (CServiceBroker::GetLogging().CanLogComponent(LOGVIDEO))
   {


### PR DESCRIPTION

## Description
Fix incorrect colours with YCbCr444 pixel format and EGL rendering
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
The current code assumes chroma is decimated by two, but that is not necessarily the case. DRMPRIME decode with EGL rendering of YCbCr444 video will have corrupted colours.

Ask ffmpeg what the chroma decimation is.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Tested on Pi4 using DRMPRIME decoder and EGL rendering

[This](http://v2v.cc/~j/theora_testsuite/ducks_take_off_444_720p25.ogg) is a suitable test file
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
No more incorrect colours
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
