### PR TITLE
[fix] freeze caused by unicode characters missing in font

### DIFF
--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -492,11 +492,6 @@ void CGUIFontTTF::DrawTextInternal(CGraphicContext& context,
 
       // grab the next character
       Character* ch = &characters.front();
-      if (ch->m_glyphAndStyle == 0)
-      {
-        characters.pop();
-        continue;
-      }
 
       if ((text[glyph.m_glyphInfo.cluster] & 0xffff) == static_cast<character_t>('\t'))
       {


### PR DESCRIPTION
(replacement of PR#22648, under my team account)

## Description
Fixes the issue of unicode characters freezing Nexus.

When a unicode character does not exist in a font, Matrix showed the .notdef / box character instead.

In Nexus such characters are handled inconsistently, sometimes resulting in an exception / freeze.

GetTextWidthInternal() called by CGUIFontTTF::DrawTextInternal line 405, and the loop at line 462 take into account the space used by the .notdef/codepoint/glyph 0 characters to populate the "characters" queue.
However the block of line 495 pops the glyph without increasing cursorX so eventually the condition to stop the loop fails and the code attempts to dequeue too many times from the empty "characters" queue, causing an exception and the freeze.

This patch reverts to the behavior of Matrix and displays the .notdef / box characters for the unicode characters missing in the font.

Alternatively maybe they were skipped on purpose and the behavior change was incomplete? In that case additional changes are needed in GetTextWidthInternal and the loop of line 462 to skip the codepoint 0 characters.

Let me know which way you want to go.

## Motivation and context
My case: Kodi v20 crashes with the skin Confluence and its default font roboto-regular when displaying file names that contain some unicode characters that don't exist in the font.
For example filename when dumping https://www.youtube.com/watch?v=BRAWVIX7mv0 with yt-dlp and browsing it in the Videos view.
The filename contains unicode 0xff1f, which does not exist in the roboto font.
Additional condition for the freeze: the text must be long enough to overflow the label. It would normally have some characters truncated + ellipsis(...) added at the end.

The same problem was reported by other users about emojis with default skin and font.

Solves issue [22473](https://github.com/xbmc/xbmc/issues/22473) and [22565](https://github.com/xbmc/xbmc/issues/22565) - maybe others?
Reported many times in the forums as well, usually in relation with the addons, especially the youtube addon.

## How has this been tested?
Tested on Windows 10 x64.

Just in case some code was using the value 0 as a failure return code instead of the .notdef glyph, I set a conditional breakpoint and navigated casually through the various screens but nothing came up other than valid .notdef glyph uses.

## What is the effect on users?
Fixes a freeze of Kodi when displaying some unicode characters.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
