### PR TITLE
[Subtitles] Fix RTL on subtitles

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -35,8 +35,6 @@ constexpr int ASS_BORDER_STYLE_OUTLINE = 1; // Outline + drop shadow
 constexpr int ASS_BORDER_STYLE_BOX = 3; // Box + drop shadow
 constexpr int ASS_BORDER_STYLE_SQUARE_BOX = 4; // Square box + outline
 
-constexpr int ASS_FONT_ENCODING_AUTO = -1;
-
 // Convert RGB/ARGB to RGBA by also applying the opacity value
 COLOR::Color ConvColor(COLOR::Color argbColor, int opacity = 100)
 {
@@ -397,10 +395,6 @@ void CDVDSubtitlesLibass::ApplyStyle(const std::shared_ptr<struct style>& subSty
     // Extra space between characters causes the underlined
     // text line to become more discontinuous (test on LibAss 15.1)
     style->Spacing = 0;
-
-    // Set automatic paragraph direction (not VSFilter-compatible)
-    // to fix wrong RTL text direction when there are unicode chars
-    style->Encoding = ASS_FONT_ENCODING_AUTO;
 
     bool isFontBold =
         (subStyle->fontStyle == FontStyle::BOLD || subStyle->fontStyle == FontStyle::BOLD_ITALIC);

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.cpp
@@ -177,8 +177,12 @@ void TranslateEscapeChars(std::string& text)
 {
   if (text.find('&') != std::string::npos)
   {
-    StringUtils::Replace(text, "&lrm;", u8"\u200e");
-    StringUtils::Replace(text, "&rlm;", u8"\u200f");
+    // The specs says to use unicode
+    // U+200E for "&lrm;" and U+200F for "&rlm;"
+    // but libass rendering assume the text as left-to-right,
+    // to display text in the right order we have to use embedded codes
+    StringUtils::Replace(text, "&lrm;", u8"\u202a");
+    StringUtils::Replace(text, "&rlm;", u8"\u202b");
     StringUtils::Replace(text, "&#x2068;", u8"\u2068");
     StringUtils::Replace(text, "&#x2069;", u8"\u2069");
     StringUtils::Replace(text, "&amp;", "&");


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Fix display of Right-To-Left text

i write my conclusions on my changes for how little knowledge i have around this

in the past i tried fix RTL on WebVTT with PR #20458 i was thinking was working good for all use cases, but clearly looking to issue #22398 is not so

my old attempt #20458 consist to set libass Encoding to -1 (that means set fribidi to `FRIBIDI_PAR_ON`)
in this way the direction of text is automatically detected, but in some cases may be wrong, e.g. for missing U+200F unicode marks
or for how has been written adapted subs like SRT (reversed punctuation workaround for RTL text https://github.com/xbmc/xbmc/issues/22398#issuecomment-1397381393)

To fix text direction problem we need to keep default libass Encoding (that set fribidi to `FRIBIDI_PAR_LTR`), so libass always assume the text as left-to-right.
And then for webvtt case use the unicode emdedded direction (U+202A  / U+202B), instead of unicode marks direction (U+200E / U+200F) for `&lrm;`, `&rlm;` unicode escapes.

some similar explanations:
https://github.com/libass/libass/issues/295#issuecomment-354893352
https://github.com/libass/libass/issues/374#issuecomment-595509685

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #22398

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
These are the use cases to test

SRT RTL:
[Hebrew_subs.srt.txt](https://github.com/xbmc/xbmc/files/10558463/Hebrew_subs.srt.txt)

WebVTT without unicode escapes mixed test read, notes inside the file:
[Test-rtl.vtt.txt](https://github.com/xbmc/xbmc/files/10558472/Test-rtl.vtt.txt)

WebVTT with unicode escapes RLM (right to left):
[RLM_shintel_s1e1_hebrew.vtt.txt](https://github.com/xbmc/xbmc/files/10558482/RLM_shintel_s1e1_hebrew.vtt.txt)
[RLM_The.Irishman.WEBRip.Netflix.ar.vtt.txt](https://github.com/xbmc/xbmc/files/10558489/RLM_The.Irishman.WEBRip.Netflix.ar.vtt.txt)

WebVTT with unicode escapes LRM (left to right):
[LRM_Wet.Hot.American.Summer.First.Day.of.Camp.S01E01.Campers.Arrive.vtt.txt](https://github.com/xbmc/xbmc/files/10558497/LRM_Wet.Hot.American.Summer.First.Day.of.Camp.S01E01.Campers.Arrive.vtt.txt)

arabic confirmed by user https://github.com/xbmc/xbmc/issues/22398#issuecomment-1407669141
other hebrew tests reported to works correclty by users in issue #22398

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Have RTL and LTR working on all kind of subtitles

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
