### PR TITLE
Android: Revisit Audiotrack and Shield behaviour

### DIFF
--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
@@ -597,6 +597,13 @@ bool CProcessInfo::IsTempoAllowed(float tempo)
   return false;
 }
 
+unsigned int CProcessInfo::GetMaxPassthroughOffSyncDuration() const
+{
+  return CServiceBroker::GetSettingsComponent()
+      ->GetAdvancedSettings()
+      ->m_maxPassthroughOffSyncDuration;
+}
+
 void CProcessInfo::SetLevelVQ(int level)
 {
   m_levelVQ = level;

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
@@ -109,6 +109,7 @@ public:
   bool GetGuiRender();
   void SetVideoRender(bool video);
   bool GetVideoRender();
+  unsigned int GetMaxPassthroughOffSyncDuration() const;
 
   void SetPlayTimes(time_t start, int64_t current, int64_t min, int64_t max);
   int64_t GetMaxTime();

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
@@ -115,5 +115,6 @@ protected:
   SInfo            m_info;
 
   bool m_displayReset = false;
+  unsigned int m_disconAdjustTimeMs = 10; // maximum sync-off before adjusting
 };
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -592,6 +592,8 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
 
     XMLUtils::GetFloat(pElement, "limiterhold", m_limiterHold, 0.0f, 100.0f);
     XMLUtils::GetFloat(pElement, "limiterrelease", m_limiterRelease, 0.001f, 100.0f);
+    XMLUtils::GetUInt(pElement, "maxpassthroughoffsyncduration", m_maxPassthroughOffSyncDuration,
+                      10, 100);
   }
 
   pElement = pRootElement->FirstChildElement("x11");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -159,6 +159,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int m_videoIgnoreSecondsAtStart;
     float m_videoIgnorePercentAtEnd;
     float m_audioApplyDrc;
+    unsigned int m_maxPassthroughOffSyncDuration = 10; // when 10 ms off adjust
 
     int   m_videoVDPAUScaling;
     float m_videoNonLinStretchRatio;


### PR DESCRIPTION
These are the current changes from the TrueHD forum testrun. During investigation it was found out that the Shield has some severe implementation bugs on the AudioTrack level. The patches describe these in detail in the commit messages.

While I am personally not happy with the AdvancedSetting change, I lack the time to properly do an Expert GUI setting for this. We have roughly 15 GUI settings for Resampling, but none for PT. Especially for a platform with a bad Delay implementation like Android, this is sadly needed as workarounds and smoothing cannot solve the issue we see here.

Example of a maximum of 49 ms discont in passthrough mode.
```
<advancedsettings>
  <audio>
    <maxpassthroughoffsyncduration>49</maxpassthroughoffsyncduration>
  </audio>
</advancedsettings>
```