### PR TITLE
[Backport] RetroPlayer: Code improvements

### DIFF
--- a/addons/skin.estuary/xml/GameOSD.xml
+++ b/addons/skin.estuary/xml/GameOSD.xml
@@ -6,6 +6,7 @@
 	<controls>
 		<control type="group" id="1">
 			<visible>!Window.IsActive(1101) + !Window.IsActive(GameVideoFilter) + !Window.IsActive(GameStretchMode) + !Window.IsActive(GameControllers) + !Window.IsActive(GameVideoRotation) + !Window.IsActive(InGameSaves)</visible>
+			<include>Visible_Fade</include>
 			<control type="group" id="10">
 				<visible>System.GetBool(gamesgeneral.showosdhelp)</visible>
 				<defaultcontrol always="true">1103</defaultcontrol>

--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -346,7 +346,7 @@
 					<param name="label" value="$LOCALIZE[222]" />
 				</include>
 			</control>
-			<control type="label" id="10812">
+			<control type="label" id="10822">
 				<description>Caption area</description>
 				<left>14</left>
 				<right>14</right>

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -287,7 +287,7 @@ void CRPRenderManager::Flush()
 void CRPRenderManager::RenderWindow(bool bClear, const RESOLUTION_INFO& coordsRes)
 {
   // Get a renderer for the fullscreen window
-  std::shared_ptr<CRPBaseRenderer> renderer = GetRenderer(nullptr);
+  std::shared_ptr<CRPBaseRenderer> renderer = GetRendererForSettings(nullptr);
   if (!renderer)
     return;
 
@@ -339,7 +339,7 @@ void CRPRenderManager::RenderControl(bool bClear,
                                      const IGUIRenderSettings* renderSettings)
 {
   // Get a renderer for the control
-  std::shared_ptr<CRPBaseRenderer> renderer = GetRenderer(renderSettings);
+  std::shared_ptr<CRPBaseRenderer> renderer = GetRendererForSettings(renderSettings);
   if (!renderer)
     return;
 
@@ -442,7 +442,7 @@ void CRPRenderManager::RenderInternal(const std::shared_ptr<CRPBaseRenderer>& re
   renderer->RenderFrame(bClear, alpha);
 }
 
-std::shared_ptr<CRPBaseRenderer> CRPRenderManager::GetRenderer(
+std::shared_ptr<CRPBaseRenderer> CRPRenderManager::GetRendererForSettings(
     const IGUIRenderSettings* renderSettings)
 {
   std::shared_ptr<CRPBaseRenderer> renderer;
@@ -459,7 +459,7 @@ std::shared_ptr<CRPBaseRenderer> CRPRenderManager::GetRenderer(
   // Check renderers in order of buffer pools
   for (IRenderBufferPool* bufferPool : m_processInfo.GetBufferManager().GetBufferPools())
   {
-    renderer = GetRenderer(bufferPool, effectiveRenderSettings);
+    renderer = GetRendererForPool(bufferPool, effectiveRenderSettings);
     if (renderer)
       break;
   }
@@ -474,7 +474,7 @@ std::shared_ptr<CRPBaseRenderer> CRPRenderManager::GetRenderer(
   return renderer;
 }
 
-std::shared_ptr<CRPBaseRenderer> CRPRenderManager::GetRenderer(
+std::shared_ptr<CRPBaseRenderer> CRPRenderManager::GetRendererForPool(
     IRenderBufferPool* bufferPool, const CRenderSettings& renderSettings)
 {
   std::shared_ptr<CRPBaseRenderer> renderer;

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -716,19 +716,19 @@ void CRPRenderManager::SaveThumbnail(const std::string& path)
   const int stride = CRenderTranslator::TranslateWidthToBytes(width, format);
 
   unsigned int scaleWidth = 400;
-  unsigned int scaleHeigth = 220;
-  CPicture::GetScale(width, height, scaleWidth, scaleHeigth);
+  unsigned int scaleHeight = 220;
+  CPicture::GetScale(width, height, scaleWidth, scaleHeight);
 
   const int bytesPerPixel = 4;
-  std::vector<uint8_t> scaledImage(scaleWidth * scaleHeigth * bytesPerPixel);
+  std::vector<uint8_t> scaledImage(scaleWidth * scaleHeight * bytesPerPixel);
 
   const AVPixelFormat outFormat = AV_PIX_FMT_BGR0;
   const int scaleStride = CRenderTranslator::TranslateWidthToBytes(scaleWidth, outFormat);
 
   if (CPicture::ScaleImage(copiedData.data(), width, height, stride, format, scaledImage.data(),
-                           scaleWidth, scaleHeigth, scaleStride, outFormat))
+                           scaleWidth, scaleHeight, scaleStride, outFormat))
   {
-    CPicture::CreateThumbnailFromSurface(scaledImage.data(), scaleWidth, scaleHeigth, scaleStride,
+    CPicture::CreateThumbnailFromSurface(scaledImage.data(), scaleWidth, scaleHeight, scaleStride,
                                          path);
   }
 }

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -703,17 +703,17 @@ void CRPRenderManager::SaveThumbnail(const std::string& thumbnailPath)
     return;
   }
 
-  const uint8_t* const data = m_renderBuffers[0]->GetMemory();
-  const size_t size = m_renderBuffers[0]->GetFrameSize();
+  const uint8_t* const sourceData = m_renderBuffers[0]->GetMemory();
+  const size_t sourceSize = m_renderBuffers[0]->GetFrameSize();
   const unsigned int width = m_renderBuffers[0]->GetWidth();
   const unsigned int height = m_renderBuffers[0]->GetHeight();
-  const AVPixelFormat format = m_renderBuffers[0]->GetFormat();
+  const AVPixelFormat sourceFormat = m_renderBuffers[0]->GetFormat();
 
-  std::vector<uint8_t> copiedData(data, data + size);
+  std::vector<uint8_t> copiedData(sourceData, sourceData + sourceSize);
 
   m_bufferMutex.unlock();
 
-  const int stride = CRenderTranslator::TranslateWidthToBytes(width, format);
+  const int stride = CRenderTranslator::TranslateWidthToBytes(width, sourceFormat);
 
   unsigned int scaleWidth = 400;
   unsigned int scaleHeight = 220;
@@ -725,8 +725,8 @@ void CRPRenderManager::SaveThumbnail(const std::string& thumbnailPath)
   const AVPixelFormat outFormat = AV_PIX_FMT_BGR0;
   const int scaleStride = CRenderTranslator::TranslateWidthToBytes(scaleWidth, outFormat);
 
-  if (CPicture::ScaleImage(copiedData.data(), width, height, stride, format, scaledImage.data(),
-                           scaleWidth, scaleHeight, scaleStride, outFormat))
+  if (CPicture::ScaleImage(copiedData.data(), width, height, stride, sourceFormat,
+                           scaledImage.data(), scaleWidth, scaleHeight, scaleStride, outFormat))
   {
     CPicture::CreateThumbnailFromSurface(scaledImage.data(), scaleWidth, scaleHeight, scaleStride,
                                          thumbnailPath);

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -693,7 +693,7 @@ CRenderVideoSettings CRPRenderManager::GetEffectiveSettings(
   return effectiveSettings;
 }
 
-void CRPRenderManager::SaveThumbnail(const std::string& path)
+void CRPRenderManager::SaveThumbnail(const std::string& thumbnailPath)
 {
   m_bufferMutex.lock();
 
@@ -729,7 +729,7 @@ void CRPRenderManager::SaveThumbnail(const std::string& path)
                            scaleWidth, scaleHeight, scaleStride, outFormat))
   {
     CPicture::CreateThumbnailFromSurface(scaledImage.data(), scaleWidth, scaleHeight, scaleStride,
-                                         path);
+                                         thumbnailPath);
   }
   else
   {

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -631,13 +631,13 @@ void CRPRenderManager::CopyFrame(IRenderBuffer* renderBuffer,
     const unsigned int targetStride =
         static_cast<unsigned int>(renderBuffer->GetFrameSize() / renderBuffer->GetHeight());
 
-    if (m_format == renderBuffer->GetFormat())
+    if (format == renderBuffer->GetFormat())
     {
       if (sourceStride == targetStride)
         std::memcpy(target, source, size);
       else
       {
-        const unsigned int widthBytes = CRenderTranslator::TranslateWidthToBytes(width, m_format);
+        const unsigned int widthBytes = CRenderTranslator::TranslateWidthToBytes(width, format);
         if (widthBytes > 0)
         {
           for (unsigned int i = 0; i < height; i++)

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -55,10 +55,13 @@ void CRPRenderManager::Deinitialize()
 {
   CLog::Log(LOGDEBUG, "RetroPlayer[RENDER]: Deinitializing render manager");
 
-  for (auto& pixelScaler : m_scalers)
+  for (auto& pixelScalerMap : m_scalers)
   {
-    if (pixelScaler.second != nullptr)
-      sws_freeContext(pixelScaler.second);
+    for (auto& pixelScaler : pixelScalerMap.second)
+    {
+      if (pixelScaler.second != nullptr)
+        sws_freeContext(pixelScaler.second);
+    }
   }
   m_scalers.clear();
 
@@ -647,7 +650,7 @@ void CRPRenderManager::CopyFrame(IRenderBuffer* renderBuffer,
     }
     else
     {
-      SwsContext*& scalerContext = m_scalers[renderBuffer->GetFormat()];
+      SwsContext*& scalerContext = m_scalers[format][renderBuffer->GetFormat()];
       scalerContext = sws_getCachedContext(
           scalerContext, width, height, format, renderBuffer->GetWidth(), renderBuffer->GetHeight(),
           renderBuffer->GetFormat(), SWS_FAST_BILINEAR, nullptr, nullptr, nullptr);

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -481,7 +481,7 @@ std::shared_ptr<CRPBaseRenderer> CRPRenderManager::GetRenderer(
 
   if (!bufferPool->IsCompatible(renderSettings.VideoSettings()))
   {
-    CLog::Log(LOGERROR, "RetroPlayer[RENDER]: buffer pool is not compatible with renderer");
+    CLog::Log(LOGDEBUG, "RetroPlayer[RENDER]: buffer pool is not compatible with renderer");
     return renderer;
   }
 
@@ -501,7 +501,7 @@ std::shared_ptr<CRPBaseRenderer> CRPRenderManager::GetRenderer(
   // If buffer pool has no compatible renderers, create one now
   if (!renderer)
   {
-    CLog::Log(LOGERROR, "RetroPlayer[RENDER]: Creating renderer for {}",
+    CLog::Log(LOGDEBUG, "RetroPlayer[RENDER]: Creating renderer for {}",
               m_processInfo.GetRenderSystemName(bufferPool));
 
     renderer.reset(m_processInfo.CreateRenderer(bufferPool, renderSettings));
@@ -593,7 +593,7 @@ IRenderBuffer* CRPRenderManager::CreateFromCache(std::vector<uint8_t>& cachedFra
 
   if (!ownedFrame.empty())
   {
-    CLog::Log(LOGERROR, "RetroPlayer[RENDER]: Creating render buffer for renderer");
+    CLog::Log(LOGERROR, "RetroPlayer[RENDER]: Creating render buffer for renderer from cache");
 
     IRenderBuffer* renderBuffer = bufferPool->GetBuffer(width, height);
     if (renderBuffer != nullptr)
@@ -730,5 +730,10 @@ void CRPRenderManager::SaveThumbnail(const std::string& path)
   {
     CPicture::CreateThumbnailFromSurface(scaledImage.data(), scaleWidth, scaleHeight, scaleStride,
                                          path);
+  }
+  else
+  {
+    CLog::Log(LOGERROR, "Failed to scale image from size {}x{} to size {}x{}", width, height,
+              scaleWidth, scaleHeight);
   }
 }

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
@@ -108,7 +108,8 @@ public:
   bool SupportsRenderFeature(RENDERFEATURE feature) const override;
   bool SupportsScalingMethod(SCALINGMETHOD method) const override;
 
-  void SaveThumbnail(const std::string& path);
+  // Savestate functions
+  void SaveThumbnail(const std::string& thumbnailPath);
 
 private:
   /*!

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
@@ -206,7 +206,7 @@ private:
   std::set<std::shared_ptr<CRPBaseRenderer>> m_renderers;
   std::vector<IRenderBuffer*> m_pendingBuffers; // Only access from game thread
   std::vector<IRenderBuffer*> m_renderBuffers;
-  std::map<AVPixelFormat, SwsContext*> m_scalers;
+  std::map<AVPixelFormat, std::map<AVPixelFormat, SwsContext*>> m_scalers; // From -> to -> context
   std::vector<uint8_t> m_cachedFrame;
   unsigned int m_cachedWidth = 0;
   unsigned int m_cachedHeight = 0;

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
@@ -114,13 +114,13 @@ private:
   /*!
    * \brief Get or create a renderer compatible with the given render settings
    */
-  std::shared_ptr<CRPBaseRenderer> GetRenderer(const IGUIRenderSettings* renderSettings);
+  std::shared_ptr<CRPBaseRenderer> GetRendererForSettings(const IGUIRenderSettings* renderSettings);
 
   /*!
    * \brief Get or create a renderer for the given buffer pool and render settings
    */
-  std::shared_ptr<CRPBaseRenderer> GetRenderer(IRenderBufferPool* bufferPool,
-                                               const CRenderSettings& renderSettings);
+  std::shared_ptr<CRPBaseRenderer> GetRendererForPool(IRenderBufferPool* bufferPool,
+                                                      const CRenderSettings& renderSettings);
 
   /*!
    * \brief Render a frame using the given renderer

--- a/xbmc/games/dialogs/DialogGameDefines.h
+++ b/xbmc/games/dialogs/DialogGameDefines.h
@@ -10,3 +10,10 @@
 
 // Name of list item property for savestate captions
 constexpr auto SAVESTATE_CAPTION = "savestate.caption";
+
+// Control IDs for game dialogs
+constexpr unsigned int CONTROL_VIDEO_HEADING = 10810;
+constexpr unsigned int CONTROL_VIDEO_THUMBS = 10811;
+constexpr unsigned int CONTROL_VIDEO_DESCRIPTION = 10812;
+constexpr unsigned int CONTROL_SAVES_DETAILED_LIST = 6;
+constexpr unsigned int CONTROL_SAVES_DESCRIPTION = 10822;

--- a/xbmc/games/dialogs/osd/DialogGameSaves.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameSaves.cpp
@@ -30,12 +30,6 @@
 using namespace KODI;
 using namespace GAME;
 
-namespace
-{
-constexpr int CONTROL_DETAILED_LIST = 6;
-constexpr int CONTROL_DESCRIPTION = 10812;
-} // namespace
-
 CDialogGameSaves::CDialogGameSaves() : CGUIDialogSelect(WINDOW_DIALOG_GAME_SAVES)
 {
 }
@@ -46,7 +40,7 @@ bool CDialogGameSaves::OnMessage(CGUIMessage& message)
   {
     case GUI_MSG_CLICKED:
     {
-      if (m_viewControl.HasControl(CONTROL_DETAILED_LIST))
+      if (m_viewControl.HasControl(CONTROL_SAVES_DETAILED_LIST))
       {
         int action = message.GetParam1();
         if (action == ACTION_CONTEXT_MENU || action == ACTION_MOUSE_RIGHT_CLICK)
@@ -74,7 +68,7 @@ bool CDialogGameSaves::OnMessage(CGUIMessage& message)
 
 void CDialogGameSaves::FrameMove()
 {
-  CGUIControl* itemContainer = GetControl(CONTROL_DETAILED_LIST);
+  CGUIControl* itemContainer = GetControl(CONTROL_SAVES_DETAILED_LIST);
   if (itemContainer != nullptr)
   {
     if (itemContainer->HasFocus())
@@ -154,7 +148,7 @@ void CDialogGameSaves::OnRename(CFileItem& item)
       RETRO::CSavestateDatabase::GetSavestateItem(*newSavestate, savestatePath, item);
 
       // Refresh thumbnails
-      CGUIMessage message(GUI_MSG_REFRESH_LIST, GetID(), CONTROL_DETAILED_LIST);
+      CGUIMessage message(GUI_MSG_REFRESH_LIST, GetID(), CONTROL_SAVES_DETAILED_LIST);
       OnMessage(message);
     }
     else
@@ -180,7 +174,7 @@ void CDialogGameSaves::OnDelete(CFileItem& item)
       m_vecList->Remove(&item);
 
       // Refresh thumbnails
-      CGUIMessage message(GUI_MSG_REFRESH_LIST, GetID(), CONTROL_DETAILED_LIST);
+      CGUIMessage message(GUI_MSG_REFRESH_LIST, GetID(), CONTROL_SAVES_DETAILED_LIST);
       OnMessage(message);
     }
     else
@@ -199,7 +193,7 @@ void CDialogGameSaves::HandleCaption(const std::string& caption)
     m_currentCaption = caption;
 
     // Update the GUI label
-    CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), CONTROL_DESCRIPTION);
+    CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), CONTROL_SAVES_DESCRIPTION);
     msg.SetLabel(m_currentCaption);
     CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg, GetID());
   }

--- a/xbmc/games/dialogs/osd/DialogGameVideoSelect.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoSelect.cpp
@@ -12,6 +12,7 @@
 #include "ServiceBroker.h"
 #include "cores/RetroPlayer/guibridge/GUIGameRenderManager.h"
 #include "cores/RetroPlayer/guibridge/GUIGameVideoHandle.h"
+#include "games/dialogs/DialogGameDefines.h"
 #include "guilib/GUIBaseContainer.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIMessage.h"
@@ -27,13 +28,6 @@
 
 using namespace KODI;
 using namespace GAME;
-
-namespace
-{
-constexpr unsigned int CONTROL_HEADING = 1;
-constexpr unsigned int CONTROL_THUMBS = 10811;
-constexpr unsigned int CONTROL_DESCRIPTION = 10812;
-} // namespace
 
 CDialogGameVideoSelect::CDialogGameVideoSelect(int windowId)
   : CGUIDialog(windowId, "DialogSelect.xml"),
@@ -136,7 +130,7 @@ bool CDialogGameVideoSelect::OnMessage(CGUIMessage& message)
 
 void CDialogGameVideoSelect::FrameMove()
 {
-  CGUIBaseContainer* thumbs = dynamic_cast<CGUIBaseContainer*>(GetControl(CONTROL_THUMBS));
+  CGUIBaseContainer* thumbs = dynamic_cast<CGUIBaseContainer*>(GetControl(CONTROL_VIDEO_THUMBS));
   if (thumbs != nullptr)
     OnItemFocus(thumbs->GetSelectedItem());
 
@@ -148,7 +142,7 @@ void CDialogGameVideoSelect::OnWindowLoaded()
   CGUIDialog::OnWindowLoaded();
 
   m_viewControl->SetParentWindow(GetID());
-  m_viewControl->AddView(GetControl(CONTROL_THUMBS));
+  m_viewControl->AddView(GetControl(CONTROL_VIDEO_THUMBS));
 }
 
 void CDialogGameVideoSelect::OnWindowUnload()
@@ -166,11 +160,11 @@ void CDialogGameVideoSelect::OnInitWindow()
 
   Update();
 
-  CGUIMessage msg(GUI_MSG_SETFOCUS, GetID(), CONTROL_THUMBS);
+  CGUIMessage msg(GUI_MSG_SETFOCUS, GetID(), CONTROL_VIDEO_THUMBS);
   OnMessage(msg);
 
   std::string heading = GetHeading();
-  SET_CONTROL_LABEL(CONTROL_HEADING, heading);
+  SET_CONTROL_LABEL(CONTROL_VIDEO_HEADING, heading);
 
   FrameMove();
 }
@@ -221,7 +215,7 @@ void CDialogGameVideoSelect::RefreshList()
   OnItemFocus(focusedIndex);
 
   // Refresh the panel container
-  CGUIMessage message(GUI_MSG_REFRESH_THUMBS, GetID(), CONTROL_THUMBS);
+  CGUIMessage message(GUI_MSG_REFRESH_THUMBS, GetID(), CONTROL_VIDEO_THUMBS);
   CServiceBroker::GetGUI()->GetWindowManager().SendMessage(message, GetID());
 }
 
@@ -239,7 +233,7 @@ void CDialogGameVideoSelect::SaveSettings()
 
 void CDialogGameVideoSelect::OnDescriptionChange(const std::string& description)
 {
-  CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), CONTROL_DESCRIPTION);
+  CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), CONTROL_VIDEO_THUMBS);
   msg.SetLabel(description);
   CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg, GetID());
 }


### PR DESCRIPTION
## Description

Backport of https://github.com/xbmc/xbmc/pull/22645

## Motivation and context

Get savestate manager in the best position possible for v20.1.

## How has this been tested?

Tested (developed actually) against Nexus in my RetroPlayer branch.

I've uploaded test builds that include this PR: https://github.com/garbear/xbmc/releases

## What is the effect on users?

* Node, it's a code improvement

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
