### PR TITLE
RetroPlayer: Improve reading from write-only memory

### DIFF
--- a/xbmc/cores/RetroPlayer/RetroPlayerTypes.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayerTypes.h
@@ -18,5 +18,18 @@ namespace RETRO
 class IRenderBufferPool;
 using RenderBufferPoolPtr = std::shared_ptr<IRenderBufferPool>;
 using RenderBufferPoolVector = std::vector<RenderBufferPoolPtr>;
+
+enum class DataAccess
+{
+  READ_ONLY,
+  WRITE_ONLY,
+  READ_WRITE
+};
+
+enum class DataAlignment
+{
+  DATA_UNALIGNED,
+  DATA_ALIGNED,
+};
 } // namespace RETRO
 } // namespace KODI

--- a/xbmc/cores/RetroPlayer/buffers/IRenderBuffer.h
+++ b/xbmc/cores/RetroPlayer/buffers/IRenderBuffer.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "cores/RetroPlayer/RetroPlayerTypes.h"
+
 extern "C"
 {
 #include <libavutil/pixfmt.h>
@@ -38,6 +40,8 @@ public:
   virtual void Update() {} //! @todo Remove me
   virtual size_t GetFrameSize() const = 0;
   virtual uint8_t* GetMemory() = 0;
+  virtual DataAccess GetMemoryAccess() const = 0;
+  virtual DataAlignment GetMemoryAlignment() const { return DataAlignment::DATA_UNALIGNED; }
   virtual void ReleaseMemory() {}
   virtual bool UploadTexture() = 0;
   virtual void BindToUnit(unsigned int unit) {}

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferDMA.h
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferDMA.h
@@ -40,6 +40,7 @@ public:
   bool Allocate(AVPixelFormat format, unsigned int width, unsigned int height) override;
   size_t GetFrameSize() const override;
   uint8_t* GetMemory() override;
+  DataAccess GetMemoryAccess() const override { return DataAccess::READ_WRITE; }
   void ReleaseMemory() override;
 
   // implementation of IRenderBuffer

--- a/xbmc/cores/RetroPlayer/buffers/video/RenderBufferGuiTexture.h
+++ b/xbmc/cores/RetroPlayer/buffers/video/RenderBufferGuiTexture.h
@@ -29,6 +29,7 @@ public:
   bool Allocate(AVPixelFormat format, unsigned int width, unsigned int height) override;
   size_t GetFrameSize() const override;
   uint8_t* GetMemory() override;
+  DataAccess GetMemoryAccess() const override { return DataAccess::READ_WRITE; }
   bool UploadTexture() override;
   void BindToUnit(unsigned int unit) override;
 

--- a/xbmc/cores/RetroPlayer/buffers/video/RenderBufferSysMem.h
+++ b/xbmc/cores/RetroPlayer/buffers/video/RenderBufferSysMem.h
@@ -32,6 +32,7 @@ public:
   bool Allocate(AVPixelFormat format, unsigned int width, unsigned int height) override;
   size_t GetFrameSize() const override;
   uint8_t* GetMemory() override;
+  DataAccess GetMemoryAccess() const override { return DataAccess::READ_WRITE; }
 
   // Utility functions
   static size_t GetBufferSize(AVPixelFormat format, unsigned int width, unsigned int height);

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
@@ -39,6 +39,7 @@ class CRPProcessInfo;
 class IGUIRenderSettings;
 class IRenderBuffer;
 class IRenderBufferPool;
+struct VideoStreamBuffer;
 
 /*!
  * \brief Renders video frames provided by the game loop
@@ -81,8 +82,7 @@ public:
                  unsigned int nominalHeight,
                  unsigned int maxWidth,
                  unsigned int maxHeight);
-  bool GetVideoBuffer(
-      unsigned int width, unsigned int height, AVPixelFormat& format, uint8_t*& data, size_t& size);
+  std::vector<VideoStreamBuffer> GetVideoBuffers(unsigned int width, unsigned int height);
   void AddFrame(const uint8_t* data,
                 size_t size,
                 unsigned int width,
@@ -189,6 +189,9 @@ private:
 
   void CheckFlush();
 
+  void GetVideoFrame(IRenderBuffer*& readableBuffer, std::vector<uint8_t>& cachedFrame);
+  void FreeVideoFrame(IRenderBuffer* readableBuffer, std::vector<uint8_t> cachedFrame);
+
   // Construction parameters
   CRPProcessInfo& m_processInfo;
   CRenderContext& m_renderContext;
@@ -210,6 +213,7 @@ private:
   std::vector<uint8_t> m_cachedFrame;
   unsigned int m_cachedWidth = 0;
   unsigned int m_cachedHeight = 0;
+  unsigned int m_cachedRotationCCW{0};
 
   // State parameters
   enum class RENDER_STATE

--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerVideo.cpp
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerVideo.cpp
@@ -13,6 +13,8 @@
 #include "cores/RetroPlayer/rendering/RenderTranslator.h"
 #include "utils/log.h"
 
+#include <algorithm>
+
 using namespace KODI;
 using namespace RETRO;
 
@@ -72,8 +74,31 @@ bool CRetroPlayerVideo::GetStreamBuffer(unsigned int width,
 
   if (m_bOpen)
   {
-    return m_renderManager.GetVideoBuffer(width, height, videoBuffer.pixfmt, videoBuffer.data,
-                                          videoBuffer.size);
+    m_buffers = m_renderManager.GetVideoBuffers(width, height);
+
+    std::sort(m_buffers.begin(), m_buffers.end(),
+              [](const VideoStreamBuffer& lhs, const VideoStreamBuffer& rhs) {
+                // Prefer read-write over write only
+                if (lhs.access == DataAccess::READ_WRITE && rhs.access != DataAccess::READ_WRITE)
+                  return true;
+                if (lhs.access != DataAccess::READ_WRITE && rhs.access == DataAccess::READ_WRITE)
+                  return false;
+
+                // Prefer aligned over unaligned
+                if (lhs.alignment == DataAlignment::DATA_ALIGNED &&
+                    rhs.alignment != DataAlignment::DATA_ALIGNED)
+                  return true;
+                if (lhs.alignment != DataAlignment::DATA_ALIGNED &&
+                    rhs.alignment == DataAlignment::DATA_ALIGNED)
+                  return false;
+
+                return false;
+              });
+
+    //! @todo This comment was in the original code
+    //! @todo Handle multiple buffers
+    if (!m_buffers.empty())
+      videoBuffer = m_buffers.at(0);
   }
 
   return false;
@@ -104,6 +129,8 @@ void CRetroPlayerVideo::AddStreamData(const StreamPacket& packet)
     m_renderManager.AddFrame(videoPacket.data, videoPacket.size, videoPacket.width,
                              videoPacket.height, orientationDegCCW);
   }
+
+  m_buffers.clear();
 }
 
 void CRetroPlayerVideo::CloseStream()

--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerVideo.h
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerVideo.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "IRetroPlayerStream.h"
+#include "cores/RetroPlayer/RetroPlayerTypes.h"
 
 extern "C"
 {
@@ -49,9 +50,19 @@ struct VideoStreamProperties : public StreamProperties
 
 struct VideoStreamBuffer : public StreamBuffer
 {
-  AVPixelFormat pixfmt;
-  uint8_t* data;
-  size_t size;
+  VideoStreamBuffer() = default;
+
+  VideoStreamBuffer(
+      AVPixelFormat pixfmt, uint8_t* data, size_t size, DataAccess access, DataAlignment alignment)
+    : pixfmt(pixfmt), data(data), size(size), access(access), alignment(alignment)
+  {
+  }
+
+  AVPixelFormat pixfmt{AV_PIX_FMT_NONE};
+  uint8_t* data{nullptr};
+  size_t size{0};
+  DataAccess access{DataAccess::READ_WRITE};
+  DataAlignment alignment{DataAlignment::DATA_UNALIGNED};
 };
 
 struct VideoStreamPacket : public StreamPacket
@@ -96,6 +107,7 @@ private:
 
   // Stream properties
   bool m_bOpen = false;
+  std::vector<VideoStreamBuffer> m_buffers;
 };
 } // namespace RETRO
 } // namespace KODI


### PR DESCRIPTION
## Description

This PR adds memory access and alignment types to RetroPlayer. These are used to avoid reading from a write-only buffer when creating a screenshot thumbnail from the render buffer, where you might not be able to read back the memory written to it.

Additionally, the screenshot saver has been modified so that, if all render buffers are write-only, then it will use the video frame that was cached when the game was paused. This would work in the savestate dialog, but the frame is only cached on game pause, so autosaves would be missing thumbnails.

To solve this, we could create more advanced caching where the screenshot saver requests a cached frame from the next round of pixels coming in. Instead, I'd just show a generic "autosave" icon in the GUI when an autosave can't generate a thumbnail, as manual saves will all have pictures anyway.

## Motivation and context

Final PR before https://github.com/xbmc/xbmc/pull/22635 is ready for review.

Interestingly, this commit is from 2018, when I was working on memory streams (like video streams, instead of manually serializing state). I'll need this change for that and when it's also depended on by savestate rendering it's a good time to get it in.

## How has this been tested?

Tested as part of https://github.com/xbmc/xbmc/pull/22635.

## What is the effect on users?

* Originally labeled this as a fix because I thought our DMA buffers were write-only, but we don't actually use write-only buffers currently. (I think the old MMAL buffers were write-only)
* So no effect on users

## Screenshots (if appropriate):

Screenshot incoming.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
