### PR TITLE
pipewire: adjust namespaces

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -246,10 +246,8 @@ constexpr int DEFAULT_LATENCY_DIVIDER = 3;
 
 } // namespace
 
-namespace AE
-{
-namespace SINK
-{
+using namespace AE::SINK;
+using namespace KODI;
 
 std::unique_ptr<PIPEWIRE::CPipewire> pipewire;
 
@@ -666,6 +664,3 @@ void CAESinkPipewire::Drain()
 
   loop.Unlock();
 }
-
-} // namespace SINK
-} // namespace AE

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.h
@@ -13,14 +13,18 @@
 
 #include <chrono>
 
-namespace AE
-{
-namespace SINK
+namespace KODI
 {
 namespace PIPEWIRE
 {
 class CPipewireStream;
 }
+} // namespace KODI
+
+namespace AE
+{
+namespace SINK
+{
 
 class CAESinkPipewire : public IAESink
 {
@@ -49,7 +53,7 @@ private:
   AEAudioFormat m_format;
   std::chrono::duration<double, std::ratio<1>> m_latency;
 
-  std::unique_ptr<PIPEWIRE::CPipewireStream> m_stream;
+  std::unique_ptr<KODI::PIPEWIRE::CPipewireStream> m_stream;
 };
 
 } // namespace SINK

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
@@ -18,12 +18,8 @@
 
 using namespace std::chrono_literals;
 
-namespace AE
-{
-namespace SINK
-{
-namespace PIPEWIRE
-{
+using namespace KODI;
+using namespace PIPEWIRE;
 
 CPipewire::CPipewire()
 {
@@ -79,7 +75,3 @@ bool CPipewire::Start()
 
   return true;
 }
-
-} // namespace PIPEWIRE
-} // namespace SINK
-} // namespace AE

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.h
@@ -10,9 +10,7 @@
 
 #include <memory>
 
-namespace AE
-{
-namespace SINK
+namespace KODI
 {
 namespace PIPEWIRE
 {
@@ -43,5 +41,4 @@ private:
 };
 
 } // namespace PIPEWIRE
-} // namespace SINK
-} // namespace AE
+} // namespace KODI

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireContext.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireContext.cpp
@@ -13,12 +13,8 @@
 
 #include <stdexcept>
 
-namespace AE
-{
-namespace SINK
-{
-namespace PIPEWIRE
-{
+using namespace KODI;
+using namespace PIPEWIRE;
 
 CPipewireContext::CPipewireContext(CPipewireThreadLoop& loop) : m_threadLoop(loop)
 {
@@ -29,7 +25,3 @@ CPipewireContext::CPipewireContext(CPipewireThreadLoop& loop) : m_threadLoop(loo
     throw std::runtime_error("CPipewireContext: failed to create context");
   }
 }
-
-} // namespace PIPEWIRE
-} // namespace SINK
-} // namespace AE

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireContext.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireContext.h
@@ -12,9 +12,7 @@
 
 #include <pipewire/context.h>
 
-namespace AE
-{
-namespace SINK
+namespace KODI
 {
 namespace PIPEWIRE
 {
@@ -44,5 +42,4 @@ private:
 };
 
 } // namespace PIPEWIRE
-} // namespace SINK
-} // namespace AE
+} // namespace KODI

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireCore.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireCore.cpp
@@ -14,12 +14,8 @@
 
 #include <stdexcept>
 
-namespace AE
-{
-namespace SINK
-{
-namespace PIPEWIRE
-{
+using namespace KODI;
+using namespace PIPEWIRE;
 
 CPipewireCore::CPipewireCore(CPipewireContext& context)
   : m_context(context), m_coreEvents(CreateCoreEvents())
@@ -61,7 +57,3 @@ pw_core_events CPipewireCore::CreateCoreEvents()
 
   return coreEvents;
 }
-
-} // namespace PIPEWIRE
-} // namespace SINK
-} // namespace AE

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireCore.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireCore.h
@@ -12,9 +12,7 @@
 
 #include <pipewire/core.h>
 
-namespace AE
-{
-namespace SINK
+namespace KODI
 {
 namespace PIPEWIRE
 {
@@ -57,5 +55,4 @@ private:
 };
 
 } // namespace PIPEWIRE
-} // namespace SINK
-} // namespace AE
+} // namespace KODI

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
@@ -18,12 +18,8 @@
 #include <spa/param/format.h>
 #include <spa/pod/iter.h>
 
-namespace AE
-{
-namespace SINK
-{
-namespace PIPEWIRE
-{
+using namespace KODI;
+using namespace PIPEWIRE;
 
 CPipewireNode::CPipewireNode(CPipewireRegistry& registry, uint32_t id, const char* type)
   : CPipewireProxy(registry, id, type, PW_VERSION_NODE), m_nodeEvents(CreateNodeEvents())
@@ -201,7 +197,3 @@ pw_node_events CPipewireNode::CreateNodeEvents()
 
   return nodeEvents;
 }
-
-} // namespace PIPEWIRE
-} // namespace SINK
-} // namespace AE

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.h
@@ -17,9 +17,7 @@
 #include <spa/param/audio/iec958.h>
 #include <spa/param/audio/raw.h>
 
-namespace AE
-{
-namespace SINK
+namespace KODI
 {
 namespace PIPEWIRE
 {
@@ -74,5 +72,4 @@ private:
 };
 
 } // namespace PIPEWIRE
-} // namespace SINK
-} // namespace AE
+} // namespace KODI

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireProxy.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireProxy.cpp
@@ -15,12 +15,8 @@
 
 #include <stdexcept>
 
-namespace AE
-{
-namespace SINK
-{
-namespace PIPEWIRE
-{
+using namespace KODI;
+using namespace PIPEWIRE;
 
 CPipewireProxy::CPipewireProxy(CPipewireRegistry& registry,
                                uint32_t id,
@@ -71,7 +67,3 @@ pw_proxy_events CPipewireProxy::CreateProxyEvents()
 
   return proxyEvents;
 }
-
-} // namespace PIPEWIRE
-} // namespace SINK
-} // namespace AE

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireProxy.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireProxy.h
@@ -12,9 +12,7 @@
 
 #include <pipewire/core.h>
 
-namespace AE
-{
-namespace SINK
+namespace KODI
 {
 namespace PIPEWIRE
 {
@@ -56,5 +54,4 @@ private:
 };
 
 } // namespace PIPEWIRE
-} // namespace SINK
-} // namespace AE
+} // namespace KODI

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
@@ -18,12 +18,8 @@
 #include <pipewire/node.h>
 #include <pipewire/type.h>
 
-namespace AE
-{
-namespace SINK
-{
-namespace PIPEWIRE
-{
+using namespace KODI;
+using namespace PIPEWIRE;
 
 CPipewireRegistry::CPipewireRegistry(CPipewireCore& core)
   : m_core(core), m_registryEvents(CreateRegistryEvents())
@@ -102,7 +98,3 @@ pw_registry_events CPipewireRegistry::CreateRegistryEvents()
 
   return registryEvents;
 }
-
-} // namespace PIPEWIRE
-} // namespace SINK
-} // namespace AE

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h
@@ -17,9 +17,7 @@
 #include <pipewire/core.h>
 #include <pipewire/properties.h>
 
-namespace AE
-{
-namespace SINK
+namespace KODI
 {
 namespace PIPEWIRE
 {
@@ -83,5 +81,4 @@ private:
 };
 
 } // namespace PIPEWIRE
-} // namespace SINK
-} // namespace AE
+} // namespace KODI

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
@@ -17,12 +17,8 @@
 
 #include <spa/utils/result.h>
 
-namespace AE
-{
-namespace SINK
-{
-namespace PIPEWIRE
-{
+using namespace KODI;
+using namespace PIPEWIRE;
 
 CPipewireStream::CPipewireStream(CPipewireCore& core)
   : m_core(core), m_streamEvents(CreateStreamEvents())
@@ -163,7 +159,3 @@ pw_stream_events CPipewireStream::CreateStreamEvents()
 
   return streamEvents;
 }
-
-} // namespace PIPEWIRE
-} // namespace SINK
-} // namespace AE

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
@@ -14,9 +14,7 @@
 #include <pipewire/core.h>
 #include <pipewire/stream.h>
 
-namespace AE
-{
-namespace SINK
+namespace KODI
 {
 namespace PIPEWIRE
 {
@@ -80,5 +78,4 @@ private:
 };
 
 } // namespace PIPEWIRE
-} // namespace SINK
-} // namespace AE
+} // namespace KODI

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.cpp
@@ -12,12 +12,8 @@
 
 #include <stdexcept>
 
-namespace AE
-{
-namespace SINK
-{
-namespace PIPEWIRE
-{
+using namespace KODI;
+using namespace PIPEWIRE;
 
 CPipewireThreadLoop::CPipewireThreadLoop()
 {
@@ -61,7 +57,3 @@ void CPipewireThreadLoop::Signal(bool accept)
 {
   pw_thread_loop_signal(m_mainloop.get(), accept);
 }
-
-} // namespace PIPEWIRE
-} // namespace SINK
-} // namespace AE

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.h
@@ -13,9 +13,7 @@
 
 #include <pipewire/thread-loop.h>
 
-namespace AE
-{
-namespace SINK
+namespace KODI
 {
 namespace PIPEWIRE
 {
@@ -47,5 +45,4 @@ private:
 };
 
 } // namespace PIPEWIRE
-} // namespace SINK
-} // namespace AE
+} // namespace KODI


### PR DESCRIPTION
This adjust some of the namespacing used by pipewire. I went a bit overboard in the original implementation. The main reason for doing this is to eventually move the pipewire core code out of AudioEngine and into the platform/linux area.

This makes all core pipewire classes use the `PIPEWIRE` namespace and `CAESinkPipewire` use `AE::SINK` namespaces.

This also changes the cpp files to use the `using` directive. I'm not sure why I originally wrapped the entire files.
