### PR TITLE
COutput: use std::chrono for message wait duration

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -1651,7 +1651,7 @@ void COutput::StateMachine(int signal, Protocol *port, Message *msg)
           ReleaseBufferPool(true);
           msg->Reply(COutputControlProtocol::ACC);
           m_state = O_TOP_UNCONFIGURED;
-          m_extTimeout = 10000;
+          m_extTimeout = 10s;
           return;
         default:
           break;
@@ -1667,7 +1667,7 @@ void COutput::StateMachine(int signal, Protocol *port, Message *msg)
           if (payload)
           {
             m_bufferPool->decodedPics.push_back(*(payload->GetPlayload()));
-            m_extTimeout = 0;
+            m_extTimeout = 0ms;
           }
           return;
         case COutputDataProtocol::RETURNPIC:
@@ -1675,13 +1675,13 @@ void COutput::StateMachine(int signal, Protocol *port, Message *msg)
           pic = *((CVaapiRenderPicture**)msg->data);
           QueueReturnPicture(pic);
           m_controlPort.SendInMessage(COutputControlProtocol::STATS);
-          m_extTimeout = 0;
+          m_extTimeout = 0ms;
           return;
         case COutputDataProtocol::RETURNPROCPIC:
           int id;
           id = *((int*)msg->data);
           ProcessReturnProcPicture(id);
-          m_extTimeout = 0;
+          m_extTimeout = 0ms;
           return;
         default:
           break;
@@ -1696,11 +1696,11 @@ void COutput::StateMachine(int signal, Protocol *port, Message *msg)
         {
         case COutputControlProtocol::TIMEOUT:
           ProcessSyncPicture();
-          m_extTimeout = 100;
+          m_extTimeout = 100ms;
           if (HasWork())
           {
             m_state = O_TOP_CONFIGURED_WORK;
-            m_extTimeout = 0;
+            m_extTimeout = 0ms;
           }
           return;
         default:
@@ -1721,19 +1721,19 @@ void COutput::StateMachine(int signal, Protocol *port, Message *msg)
             m_bufferPool->decodedPics.pop_front();
             InitCycle();
             m_state = O_TOP_CONFIGURED_STEP1;
-            m_extTimeout = 0;
+            m_extTimeout = 0ms;
             return;
           }
           else if (m_bufferPool->HasFree() &&
                    !m_bufferPool->processedPics.empty())
           {
             m_state = O_TOP_CONFIGURED_OUTPUT;
-            m_extTimeout = 0;
+            m_extTimeout = 0ms;
             return;
           }
           else
             m_state = O_TOP_CONFIGURED_IDLE;
-          m_extTimeout = 100;
+          m_extTimeout = 100ms;
           return;
         default:
           break;
@@ -1766,7 +1766,7 @@ void COutput::StateMachine(int signal, Protocol *port, Message *msg)
           }
           m_config.stats->DecDecoded();
           m_controlPort.SendInMessage(COutputControlProtocol::STATS);
-          m_extTimeout = 0;
+          m_extTimeout = 0ms;
           return;
         }
         default:
@@ -1787,11 +1787,11 @@ void COutput::StateMachine(int signal, Protocol *port, Message *msg)
           {
             m_bufferPool->processedPics.push_back(outPic);
             m_config.stats->IncProcessed();
-            m_extTimeout = 0;
+            m_extTimeout = 0ms;
             return;
           }
           m_state = O_TOP_CONFIGURED_IDLE;
-          m_extTimeout = 0;
+          m_extTimeout = 0ms;
           return;
         }
         default:
@@ -1821,7 +1821,7 @@ void COutput::StateMachine(int signal, Protocol *port, Message *msg)
             m_config.stats->DecProcessed();
           }
           m_state = O_TOP_CONFIGURED_IDLE;
-          m_extTimeout = 0;
+          m_extTimeout = 0ms;
           return;
         default:
           break;
@@ -1843,7 +1843,7 @@ void COutput::Process()
   bool gotMsg;
 
   m_state = O_TOP_UNCONFIGURED;
-  m_extTimeout = 1000;
+  m_extTimeout = 1s;
   m_bStateMachineSelfTrigger = false;
 
   while (!m_bStop)
@@ -1886,7 +1886,7 @@ void COutput::Process()
     }
 
     // wait for message
-    else if (m_outMsgEvent.Wait(std::chrono::milliseconds(m_extTimeout)))
+    else if (m_outMsgEvent.Wait(m_extTimeout))
     {
       continue;
     }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
@@ -356,7 +356,7 @@ protected:
   CDecoder &m_vaapi;
 
   // extended state variables for state machine
-  int m_extTimeout;
+  std::chrono::milliseconds m_extTimeout = std::chrono::milliseconds::zero();
   /// \brief Whether at least one interlaced frame was encountered in the video stream (indicating that more interlaced frames could potentially follow)
   bool m_seenInterlaced;
   CVaapiConfig m_config;


### PR DESCRIPTION
pretty straightforward, just moves the std::chrono type up the chain so we don't have to convert at the final destination.