### PR TITLE
[dllwrapper] wrap dll_stat64 and dll_fstat64

### DIFF
--- a/xbmc/cores/DllLoader/exports/wrapper.c
+++ b/xbmc/cores/DllLoader/exports/wrapper.c
@@ -388,6 +388,11 @@ int __wrap_stat(const char *path, struct _stat *buffer)
   return dll_stat(path, buffer);
 }
 
+int __wrap_stat64(const char* path, struct stat64* buffer)
+{
+  return dll_stat64(path, buffer);
+}
+
 int __wrap___xstat(int __ver, const char *__filename, struct stat *__stat_buf)
 {
   return dll_stat(__filename, __stat_buf);
@@ -431,6 +436,11 @@ int __wrap___fxstat(int ver, int fd, struct stat *buf)
 int __wrap_fstat(int fd, struct _stat *buf)
 {
   return dll_fstat(fd, buf);
+}
+
+int __wrap_fstat64(int fd, struct stat64* buf)
+{
+  return dll_fstat64(fd, buf);
 }
 
 int __wrap_setvbuf(FILE *stream, char *buf, int type, size_t size)


### PR DESCRIPTION
## Description
stat64() and fstat64() are referenced from built libdvdnav-arm.so. Adding __wrap_stat64() and _wrap_fstat64() to wrapper.c.

## Motivation and context
Fixes playing DVD folder over network on CoreELEC (arm platform).
Fixes https://github.com/xbmc/xbmc/issues/21670

```
2023-02-02 19:23.780 T:838      info <general>: VideoPlayer::OpenFile: http://server/dvd_test_folder/VIDEO_TS/VIDEO_TS.IFO
2023-02-02 19:23.780 T:947     debug <general>: Thread VideoPlayer start, auto delete: false
2023-02-02 19:23.780 T:838     debug <general>: OnPlayBackStarted: CApplication::OnPlayBackStarted
2023-02-02 19:23.794 T:838     debug <general>: CVideoGUIInfo::InitCurrentItem(http://server/dvd_test_folder/VIDEO_TS/VIDEO_TS.IFO)
2023-02-02 19:23.796 T:947     debug <general>: CCurlFile::GetMimeType - <http://server/dvd_test_folder/VIDEO_TS/VIDEO_TS.IFO> -> 
2023-02-02 19:23.796 T:947      info <general>: Creating InputStream
2023-02-02 19:23.796 T:947     debug <general>: SECTION:LoadDLL(special://xbmcbin/system/players/VideoPlayer/libdvdnav-arm.so)
2023-02-02 19:23.797 T:947     debug <general>: Loading: /usr/lib/kodi/system/players/VideoPlayer/libdvdnav-arm.so
2023-02-02 19:23.802 T:947      info <general>:   msg: libdvdcss debug: 
2023-02-02 19:23.802 T:947      info <general>:   msg: opening target `http://server/dvd_test_folder'
2023-02-02 19:23.802 T:947     debug <general>:   msg: 
                                                   
2023-02-02 19:23.802 T:947      info <general>:   msg: libdvdcss debug: 
2023-02-02 19:23.802 T:947      info <general>:   msg: using libc API for access
2023-02-02 19:23.802 T:947     debug <general>:   msg: 
                                                   
2023-02-02 19:23.803 T:947      info <general>:   msg: libdvdcss error: 
2023-02-02 19:23.803 T:947      info <general>:   msg: failed to open device http://server/dvd_test_folder (No such file or directory)
2023-02-02 19:23.803 T:947     debug <general>:   msg: 
                                                   
2023-02-02 19:23.803 T:947     error <general>: Libdvd: Could not open http://server/dvd_test_folder with libdvdcss.
2023-02-02 19:23.803 T:947     error <general>: Libdvd: Can't open http://server/dvd_test_folder for reading
2023-02-02 19:23.803 T:947     error <general>: Libdvd: vm: failed to open/read the DVD
2023-02-02 19:23.803 T:947     error <general>: Error on dvdnav_open
2023-02-02 19:23.803 T:947     error <general>: CVideoPlayer::OpenInputStream - error opening [http://server/dvd_test_folder/VIDEO_TS/VIDEO_TS.IFO]
2023-02-02 19:23.803 T:947      info <general>: CVideoPlayer::OnExit()
2023-02-02 19:23.803 T:947     debug <general>: Thread VideoPlayer 3793728192 terminating
2023-02-02 19:23.806 T:867     debug <general>: Loading settings for http://server/dvd_test_folder/VIDEO_TS/VIDEO_TS.IFO
2023-02-02 19:23.817 T:867      info <general>: Deleting settings information for files http://server/dvd_test_folder/VIDEO_TS/VIDEO_TS.IFO
2023-02-02 19:23.919 T:867     debug <general>: OnPlayBackStopped: CApplication::OnPlayBackStopped

```


## How has this been tested?
Own build on CoreELEC.

## What is the effect on users?
Allows playing DVD folder from network over smb or http.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
