### PR TITLE
[Android] bump Gradle and Android Gradle Plugin

### DIFF
--- a/tools/android/packaging/build.gradle
+++ b/tools/android/packaging/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.2'
+        classpath 'com.android.tools.build:gradle:7.4.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/tools/android/packaging/gradle/wrapper/gradle-wrapper.properties
+++ b/tools/android/packaging/gradle/wrapper/gradle-wrapper.properties
@@ -3,5 +3,5 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
 

--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!-- BEGIN_INCLUDE(manifest) -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="@APP_PACKAGE@"
     android:installLocation="auto"
     android:versionCode="@APP_VERSION_CODE_ANDROID@"
     android:versionName="@APP_VERSION@">

--- a/tools/android/packaging/xbmc/build.gradle.in
+++ b/tools/android/packaging/xbmc/build.gradle.in
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
+    namespace '@APP_PACKAGE@'
     compileSdkVersion @TARGET_SDK@
     ndkPath "@NDKROOT@"
     defaultConfig {


### PR DESCRIPTION
## Description
This PR updates to the latest stable versions of the Gradle platform ([7.6](https://gradle.org/releases/)) and the Android Gradle Plugin ([7.4.0](https://mvnrepository.com/artifact/com.android.tools.build/gradle?repo=google)). 

These updates will be required in order to move to Android SDK 33.

Now setting the namespace (`org.xbmc.kodi`) via `AndroidManifest.xml`'s package attribute is deprecated, instead should be set in the `build.gradle` file.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
