### PR TITLE
[guilib][EditControl] Improved rendering of label texts

### DIFF
--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -493,7 +493,7 @@ void CGUIEditControl::ProcessText(unsigned int currentTime)
     }
     else
     { // align by whatever the skinner requests
-      align |= (m_label2.GetLabelInfo().align & 3);
+      align |= (m_label2.GetLabelInfo().align & (XBFONT_RIGHT | XBFONT_CENTER_X));
     }
 
     changed |= m_label2.SetMaxRect(m_clipRect.x1 + m_textOffset, m_posY, m_clipRect.Width() - m_textOffset, m_height);

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -22,18 +22,37 @@
 #include "utils/ColorUtils.h"
 #include "utils/Digest.h"
 #include "utils/Variant.h"
+#include "utils/log.h"
 #include "windowing/WinSystem.h"
+
+#include <algorithm>
 
 using namespace KODI::GUILIB;
 
 using KODI::UTILITY::CDigest;
 
-const char* CGUIEditControl::smsLetters[10] = { " !@#$%^&*()[]{}<>/\\|0", ".,;:\'\"-+_=?`~1", "abc2ABC", "def3DEF", "ghi4GHI", "jkl5JKL", "mno6MNO", "pqrs7PQRS", "tuv8TUV", "wxyz9WXYZ" };
-const unsigned int CGUIEditControl::smsDelay = 1000;
-
 #ifdef TARGET_WINDOWS
 extern HWND g_hWnd;
 #endif
+
+namespace
+{
+constexpr std::string_view smsLetters[] = {" !@#$%^&*()[]{}<>/\\|0",
+                                           ".,;:\'\"-+_=?`~1",
+                                           "abc2ABC",
+                                           "def3DEF",
+                                           "ghi4GHI",
+                                           "jkl5JKL",
+                                           "mno6MNO",
+                                           "pqrs7PQRS",
+                                           "tuv8TUV",
+                                           "wxyz9WXYZ"};
+
+constexpr float smsDelay = 1000;
+
+// Additional space between left label text and left label text in pixels
+constexpr float TEXT_SPACE = 20.0f;
+} // unnamed namespace
 
 CGUIEditControl::CGUIEditControl(int parentID, int controlID, float posX, float posY,
                                  float width, float height, const CTextureInfo &textureFocus, const CTextureInfo &textureNoFocus,
@@ -42,20 +61,27 @@ CGUIEditControl::CGUIEditControl(int parentID, int controlID, float posX, float 
 {
   DefaultConstructor();
   SetLabel(text);
+
+  // if skinner forgot to set height
+  if (m_height == 0 && m_label.GetLabelInfo().font)
+  {
+    m_height = m_label.GetLabelInfo().font->GetTextHeight(1);
+    CLog::LogF(LOGWARNING,
+               "No height has been set for GUI edit control ID {}, fallback to font height",
+               controlID);
+  }
 }
 
 void CGUIEditControl::DefaultConstructor()
 {
   ControlType = GUICONTROL_EDIT;
   m_textOffset = 0;
-  m_textWidth = GetWidth();
   m_cursorPos = 0;
   m_cursorBlink = 0;
   m_inputHeading = g_localizeStrings.Get(16028);
   m_inputType = INPUT_TYPE_TEXT;
   m_smsLastKey = 0;
   m_smsKeyIndex = 0;
-  m_label.SetAlign(m_label.GetLabelInfo().align & XBFONT_CENTER_Y); // left align
   m_label2.GetLabelInfo().offsetX = 0;
   m_isMD5 = false;
   m_invalidInput = false;
@@ -379,25 +405,22 @@ void CGUIEditControl::SetInputType(CGUIEditControl::INPUT_TYPE type, const CVari
   //! @todo Verify the current input string?
 }
 
-void CGUIEditControl::RecalcLabelPosition()
+void CGUIEditControl::RecalcRightLabelPosition()
 {
   // ensure that our cursor is within our width
   ValidateCursor();
 
-  std::wstring text = GetDisplayedText();
-  m_textWidth = m_label.CalcTextWidth(text + L'|');
-  float beforeCursorWidth = m_label.CalcTextWidth(text.substr(0, m_cursorPos));
-  float afterCursorWidth = m_label.CalcTextWidth(text.substr(0, m_cursorPos) + L'|');
-  float leftTextWidth = m_label.GetRenderRect().Width();
-  float maxTextWidth = m_label.GetMaxWidth();
+  const std::wstring text = GetDisplayedText();
+  const float textWidth = m_label2.CalcTextWidth(text + L'|');
+  const float beforeCursorWidth = m_label2.CalcTextWidth(text.substr(0, m_cursorPos));
+  const float afterCursorWidth = m_label2.CalcTextWidth(text.substr(0, m_cursorPos) + L'|');
+  const float leftTextWidth = std::min(m_label.GetTextWidth(), m_label.GetMaxWidth());
+  float maxTextWidth = m_width - 2 * m_label.GetLabelInfo().offsetX;
+
   if (leftTextWidth > 0)
-    maxTextWidth -= leftTextWidth + spaceWidth;
+    maxTextWidth -= leftTextWidth + TEXT_SPACE;
 
-  // if skinner forgot to set height :p
-  if (m_height == 0 && m_label.GetLabelInfo().font)
-    m_height = m_label.GetLabelInfo().font->GetTextHeight(1);
-
-  if (m_textWidth > maxTextWidth)
+  if (textWidth > maxTextWidth)
   { // we render taking up the full width, so make sure our cursor position is
     // within the render window
     if (m_textOffset + afterCursorWidth > maxTextWidth)
@@ -410,9 +433,9 @@ void CGUIEditControl::RecalcLabelPosition()
       // otherwise use original position
       m_textOffset = -beforeCursorWidth;
     }
-    else if (m_textOffset + m_textWidth < maxTextWidth)
+    else if (m_textOffset + textWidth < maxTextWidth)
     { // we have more text than we're allowed, but we aren't filling all the space
-      m_textOffset = maxTextWidth - m_textWidth;
+      m_textOffset = maxTextWidth - textWidth;
     }
   }
   else
@@ -424,45 +447,55 @@ void CGUIEditControl::ProcessText(unsigned int currentTime)
   if (m_smsTimer.IsRunning() && m_smsTimer.GetElapsedMilliseconds() > smsDelay)
     UpdateText();
 
-  if (m_bInvalidated)
-  {
-    m_label.SetMaxRect(m_posX, m_posY, m_width, m_height);
-    m_label.SetText(m_info.GetLabel(GetParentID()));
-    RecalcLabelPosition();
-  }
-
   bool changed = false;
+  changed |= m_label.SetText(m_info.GetLabel(m_parentID));
 
-  m_clipRect.x1 = m_label.GetRenderRect().x1;
-  m_clipRect.x2 = m_clipRect.x1 + m_label.GetMaxWidth();
+  m_clipRect.x1 = m_posX + m_label.GetLabelInfo().offsetX;
+  m_clipRect.x2 = m_clipRect.x1 + m_width - 2 * m_label.GetLabelInfo().offsetX;
   m_clipRect.y1 = m_posY;
   m_clipRect.y2 = m_posY + m_height;
 
-  // start by rendering the normal text
-  float leftTextWidth = m_label.GetRenderRect().Width();
+  // Limit left text max width to 50% of space when focused, otherwise 70%
+  const float maxTextWidth = m_width * (HasFocus() ? 0.5f : 0.7f);
+
+  const float leftTextWidth =
+      std::min(m_label.GetTextWidth(), maxTextWidth - 2 * m_label.GetLabelInfo().offsetX);
+
+  changed |= m_label.SetMaxRect(m_posX, m_posY, maxTextWidth, m_height);
+
+  if (m_bInvalidated)
+  {
+    if (!HasFocus() && leftTextWidth > 0)
+      m_textOffset = 0;
+    else
+      RecalcRightLabelPosition();
+  }
+
   if (leftTextWidth > 0)
   {
     // render the text on the left
+    changed |= m_label.SetScrolling(HasFocus());
     changed |= m_label.SetColor(GetTextColor());
     changed |= m_label.Process(currentTime);
 
-    m_clipRect.x1 += leftTextWidth + spaceWidth;
+    m_clipRect.x1 += leftTextWidth + TEXT_SPACE;
   }
+
+  // render the text on the right
 
   if (CServiceBroker::GetWinSystem()->GetGfxContext().SetClipRegion(m_clipRect.x1, m_clipRect.y1, m_clipRect.Width(), m_clipRect.Height()))
   {
+    // set alignment for right label text
     uint32_t align = m_label.GetLabelInfo().align & XBFONT_CENTER_Y; // start aligned left
-    if (m_label2.GetTextWidth() < m_clipRect.Width())
-    { // align text as our text fits
-      if (leftTextWidth > 0)
-      { // right align as we have 2 labels
-        align |= XBFONT_RIGHT;
-      }
-      else
-      { // align by whatever the skinner requests
-        align |= (m_label2.GetLabelInfo().align & 3);
-      }
+    if (leftTextWidth > 0)
+    { // right align as we have 2 labels
+      align |= XBFONT_RIGHT;
     }
+    else
+    { // align by whatever the skinner requests
+      align |= (m_label2.GetLabelInfo().align & 3);
+    }
+
     changed |= m_label2.SetMaxRect(m_clipRect.x1 + m_textOffset, m_posY, m_clipRect.Width() - m_textOffset, m_height);
 
     std::wstring text = GetDisplayedText();
@@ -482,7 +515,12 @@ void CGUIEditControl::ProcessText(unsigned int currentTime)
 
     changed |= m_label2.SetAlign(align);
     changed |= m_label2.SetColor(GetTextColor());
-    changed |= m_label2.SetOverflow(CGUILabel::OVER_FLOW_CLIP);
+
+    if (HasFocus() || leftTextWidth == 0)
+      changed |= m_label2.SetOverflow(CGUILabel::OVER_FLOW_CLIP);
+    else
+      changed |= m_label2.SetOverflow(CGUILabel::OVER_FLOW_TRUNCATE);
+
     changed |= m_label2.Process(currentTime);
     CServiceBroker::GetWinSystem()->GetGfxContext().RestoreClipRegion();
   }
@@ -658,7 +696,7 @@ void CGUIEditControl::OnSMSCharacter(unsigned int key)
     m_smsKeyIndex = 0;
   }
 
-  m_smsKeyIndex = m_smsKeyIndex % strlen(smsLetters[key]);
+  m_smsKeyIndex = m_smsKeyIndex % smsLetters[key].size();
 
   m_text2.insert(m_text2.begin() + m_cursorPos++, smsLetters[key][m_smsKeyIndex]);
   UpdateText();

--- a/xbmc/guilib/GUIEditControl.h
+++ b/xbmc/guilib/GUIEditControl.h
@@ -81,7 +81,13 @@ protected:
   std::wstring GetDisplayedText() const;
   std::string GetDescriptionByIndex(int index) const override;
   bool SetStyledText(const std::wstring &text);
-  void RecalcLabelPosition();
+
+  /*!
+   * \brief Recalculate the text offset position for the right label
+   *        by updating m_textOffset and validate the cursor position.
+   */
+  void RecalcRightLabelPosition();
+
   void ValidateCursor();
   void UpdateText(bool sendUpdate = true);
   void OnPasteClipboard();
@@ -100,10 +106,7 @@ protected:
   std::string  m_text;
   KODI::GUILIB::GUIINFO::CGUIInfoLabel m_hintInfo;
   float m_textOffset;
-  float m_textWidth;
   CRect m_clipRect; ///< clipping rect for the second label
-
-  static const int spaceWidth = 5;
 
   unsigned int m_cursorPos;
   unsigned int m_cursorBlink;
@@ -125,7 +128,4 @@ protected:
   std::wstring m_edit;
   int          m_editOffset;
   int          m_editLength;
-
-  static const char*        smsLetters[10];
-  static const unsigned int smsDelay;
 };

--- a/xbmc/guilib/GUIFont.cpp
+++ b/xbmc/guilib/GUIFont.cpp
@@ -256,8 +256,6 @@ bool CGUIFont::ClippedRegionIsEmpty(
 {
   if (alignment & XBFONT_CENTER_X)
     x -= width * 0.5f;
-  else if (alignment & XBFONT_RIGHT)
-    x -= width;
   if (alignment & XBFONT_CENTER_Y)
     y -= m_font->GetLineHeight(m_lineSpacing);
 

--- a/xbmc/guilib/GUILabel.cpp
+++ b/xbmc/guilib/GUILabel.cpp
@@ -115,20 +115,22 @@ void CGUILabel::Render()
     float posY = m_renderRect.y1;
     uint32_t align = 0;
     if (!overFlows)
-    { // hack for right and centered multiline text, as GUITextLayout::Render() treats posX as the right hand
-      // or center edge of the text (see GUIFontTTF::DrawTextInternal), and this has already been taken care of
+    { // hack for centered multiline text, as GUITextLayout::Render() treats posX as
+      // center edge of the text (see GUIFontTTF::DrawTextInternal), and this has already been taken care of
       // in UpdateRenderRect(), but we wish to still pass the horizontal alignment info through (so that multiline text
       // is aligned correctly), so we must undo the UpdateRenderRect() changes for horizontal alignment.
-      if (m_label.align & XBFONT_RIGHT)
-        posX += m_renderRect.Width();
-      else if (m_label.align & XBFONT_CENTER_X)
+      if (m_label.align & XBFONT_CENTER_X)
         posX += m_renderRect.Width() * 0.5f;
       if (m_label.align & XBFONT_CENTER_Y) // need to pass a centered Y so that <angle> will rotate around the correct point.
         posY += m_renderRect.Height() * 0.5f;
       align = m_label.align;
     }
     else
+    {
       align |= XBFONT_TRUNCATED;
+      if (m_label.align & XBFONT_RIGHT)
+        align |= XBFONT_RIGHT;
+    }
     m_textLayout.Render(posX, posY, m_label.angle, color, m_label.shadowColor, align, m_overflowType == OVER_FLOW_CLIP ? m_textLayout.GetTextWidth() : m_renderRect.Width(), renderSolid);
   }
 }

--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -241,10 +241,22 @@ void CGUITextBox::Render()
 
       while (posY < m_posY + m_renderHeight && current < (int)m_lines.size())
       {
+        const CGUIString& lineString = m_lines[current];
+        float linePosX = posX;
         uint32_t align = alignment;
-        if (m_lines[current].m_text.size() && m_lines[current].m_carriageReturn)
+
+        if (lineString.m_text.size() && lineString.m_carriageReturn)
           align &= ~XBFONT_JUSTIFIED; // last line of a paragraph shouldn't be justified
-        m_font->DrawText(posX, posY, m_colors, m_label.shadowColor, m_lines[current].m_text, align, m_width);
+
+        if (align & XBFONT_RIGHT)
+        {
+          // We need to adjust the posX in similar way the CGUILabel recalculate the render rect
+          // see CGUILabel::UpdateRenderRect()
+          linePosX -= GetTextWidth(lineString.GetAsWstring());
+        }
+
+        m_font->DrawText(linePosX, posY, m_colors, m_label.shadowColor, lineString.m_text, align,
+                         m_width);
         posY += m_itemHeight;
         current++;
       }

--- a/xbmc/guilib/GUITextLayout.cpp
+++ b/xbmc/guilib/GUITextLayout.cpp
@@ -29,6 +29,18 @@ std::string CGUIString::GetAsString() const
   return text;
 }
 
+std::wstring CGUIString::GetAsWstring() const
+{
+  std::wstring text;
+  text.reserve(m_text.size());
+  // Get text without style
+  for (const auto& it : m_text)
+  {
+    text += static_cast<wchar_t>(it & 0xffff);
+  }
+  return text;
+}
+
 CGUITextLayout::CGUITextLayout(CGUIFont *font, bool wrap, float fHeight, CGUIFont *borderFont)
 {
   m_varFont = m_font = font;

--- a/xbmc/guilib/GUITextLayout.h
+++ b/xbmc/guilib/GUITextLayout.h
@@ -44,6 +44,7 @@ public:
   CGUIString(iString start, iString end, bool carriageReturn);
 
   std::string GetAsString() const;
+  std::wstring GetAsWstring() const;
 
   vecText m_text;
   bool m_carriageReturn; // true if we have a carriage return here

--- a/xbmc/guilib/GUITextLayout.h
+++ b/xbmc/guilib/GUITextLayout.h
@@ -46,6 +46,10 @@ public:
   std::string GetAsString() const;
   std::wstring GetAsWstring() const;
 
+  // The text is UTF-16 and the data stored in a character_t hold multiple informations by bits:
+  // <16 bits: are unicode code bits
+  // 16-24 bits: are color bits
+  // 24-32 bits: are style bits (see FONT_STYLE_* flags)
   vecText m_text;
   bool m_carriageReturn; // true if we have a carriage return here
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This PR fix labels on the edit control and since was related implement truncate for right-aligned text by removing some GUI label hacks

**Truncate for right-aligned text**
the previous implementation did not contemplate truncate for right-aligned text
so was not possible add ellipses ("...") to the left nor truncate to the left the text,
so some hacks were made to the GUI to limit some use cases (like force x offset to shift the rendering and so hidden the text that exceeds the available space, force remove align attribute...),
so here i implemented truncate for right-aligned text, imo a good find for edit control and in general to let the user know that the text is truncated to the left

**Edit control, labels improvements**
If on the edit control you set the text on the left and on the right labels (like on settings panel),
and the left label text is so long that exceeds the control width, will result that overlap and erase the text on the right label and so remove the editable field, as you can see on the first screenshot below (and on https://github.com/xbmc/xbmc/issues/21184#issuecomment-1094801495)

This PR improve the situation by limiting the maximum width for the left lable text,
then when not focused it can take max 70% of space, when focused max to 50% to allow have more space when editing the value

Previous broken implementation, the right label start to be erased
![immagine](https://user-images.githubusercontent.com/3257156/216788040-131f2061-e02c-4c2d-b4df-680d30ee2a23.png)

Now, on preview, the left label width limited to max 70%, the left label and right label when the text exceeds the available space ellipses ("...") will be add to the appropriate position, and the text is truncated on the left for right-aligned text
![immagine](https://user-images.githubusercontent.com/3257156/218139687-7f56f1ff-bbe7-4ea0-96b6-67643733e223.png)

Now, with focus, so while editing, the left label width is limited to max 50% of space and the text auto-scroll
![immagine](https://user-images.githubusercontent.com/3257156/216787902-642a5903-382b-4b05-9d15-06be81f0de53.png)

Another example, with short text on left label:
![immagine](https://user-images.githubusercontent.com/3257156/218140275-4b2feb4e-1c6e-46b6-bdf6-f96435c33edd.png)
in this case the right label can take all space available to display in full the preview value

**Edit control, related alignment bugfix**
This bug can be shown easily with keyboard window, so when you edit a text,
initially the text is shown at center of the gray text box,
but if you write a long text that exceeds the limits of the gray text box width,
and after you delete all the text, will lost the text alignment and "fallback" as left-aligned text
as following screenshot
![immagine](https://user-images.githubusercontent.com/3257156/218140778-42b0b65b-8e25-4308-af61-79905a354488.png)
the fix take care to preserve the alignment

Changes to GUIFontTTF.cpp are required because our rendering works as left-to-right.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #21184

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
a couple of editing control with text, numeric, IP field and keyboard window

for GUI label i tested truncate for right-aligned text with a python addon on a custom XML window
by using
```xml
<control type="label" id="55000">
...
  <scroll>false</scroll> <!-- false to apply truncate-->
  <align>right</align>
...
```

verified CGUITextBox for possible regressions on right-aligned text
```xml
<control type="textbox" id="55001">
...
  <autoscroll>false</autoscroll>
  <align>right</align>
...
```

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
for GUI label support truncate for right-aligned text
in general better user experience

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
