### PR TITLE
tools/depends: collection of build fixes and improvements

### DIFF
--- a/tools/depends/native/autoconf-archive/Makefile
+++ b/tools/depends/native/autoconf-archive/Makefile
@@ -14,8 +14,6 @@ include ../../download-files.include
 # configuration settings
 CONFIGURE=./configure --prefix=$(PREFIX)
 
-LIBDYLIB=$(PLATFORM)/bin/autoconf
-
 all: .installed-$(PLATFORM)
 
 
@@ -23,11 +21,8 @@ $(PLATFORM): $(DEPS) | $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE)
 	-rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 
-$(LIBDYLIB): $(PLATFORM)
+.installed-$(PLATFORM): $(PLATFORM)
 	cd $(PLATFORM); $(CONFIGURE)
-	$(MAKE) -C $(PLATFORM)
-
-.installed-$(PLATFORM): $(LIBDYLIB)
 	$(MAKE) -C $(PLATFORM) install
 	touch $@
 

--- a/tools/depends/native/meson/Makefile
+++ b/tools/depends/native/meson/Makefile
@@ -10,8 +10,6 @@ ARCHIVE=$(SOURCE).tar.gz
 SHA512=126ac3a6c6b9e1fba1b3ac163f02d1eb0b61fedb312bcfe4996f6150522688d424f47283070c95101cc456afe9ea5cb462fb38f368d0c732952ffb8c600fda00
 include ../../download-files.include
 
-LIBDYLIB=$(PLATFORM)/build
-
 all: .installed-$(PLATFORM)
 
 
@@ -20,10 +18,8 @@ $(PLATFORM): $(DEPS) | $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 	cd $(PLATFORM); $(NATIVEPREFIX)/bin/python3 setup.py config
 
-$(LIBDYLIB): $(PLATFORM)
+.installed-$(PLATFORM): $(PLATFORM)
 	cd $(PLATFORM); $(NATIVEPREFIX)/bin/python3 setup.py build
-
-.installed-$(PLATFORM): $(LIBDYLIB)
 	cd $(PLATFORM); $(NATIVEPREFIX)/bin/python3 setup.py install --prefix="$(NATIVEPREFIX)"
 	touch $@
 

--- a/tools/depends/native/perlmodule-parseyapp/Makefile
+++ b/tools/depends/native/perlmodule-parseyapp/Makefile
@@ -18,8 +18,6 @@ CONFIGURE=./configure --prefix=$(PREFIX)
 export PERL_MB_OPT=
 export PERL_MM_OPT=
 
-LIBDYLIB=$(PLATFORM)/bin/autoconf
-
 all: .installed-$(PLATFORM)
 
 
@@ -27,11 +25,9 @@ $(PLATFORM): $(DEPS) | $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE)
 	-rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 
-$(LIBDYLIB): $(PLATFORM)
+.installed-$(PLATFORM): $(PLATFORM)
 	cd $(PLATFORM); perl Makefile.PL PREFIX=$(NATIVEPREFIX)
 	cd $(PLATFORM); $(MAKE)
-
-.installed-$(PLATFORM): $(LIBDYLIB)
 	cd $(PLATFORM); $(MAKE) install
 	touch $@
 

--- a/tools/depends/native/wayland-scanner/Makefile
+++ b/tools/depends/native/wayland-scanner/Makefile
@@ -14,8 +14,6 @@ include ../../download-files.include
 # configuration settings
 CONFIGURE=./configure --prefix=$(PREFIX) --disable-libraries --disable-documentation --disable-dtd-validation
 
-APP=$(PLATFORM)/wayland-scanner
-
 all: .installed-$(PLATFORM)
 
 
@@ -24,10 +22,8 @@ $(PLATFORM): $(DEPS) | $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 	cd $(PLATFORM); $(CONFIGURE)
 
-$(APP): $(PLATFORM)
+.installed-$(PLATFORM): $(PLATFORM)
 	$(MAKE) -C $(PLATFORM)
-
-.installed-$(PLATFORM): $(APP)
 	$(MAKE) -C $(PLATFORM) install
 	touch $@
 

--- a/tools/depends/native/waylandpp-scanner/Makefile
+++ b/tools/depends/native/waylandpp-scanner/Makefile
@@ -11,8 +11,6 @@ ARCHIVE=$(SOURCE).tar.gz
 SHA512=bf1b8a9e69b87547fc65989b9eaff88a442d8b2f01f5446cef960000b093390b1e557536837fbf38bb6d9a4f93e3985ea34c3253f94925b0f571b4606c980832
 include ../../download-files.include
 
-APP=$(PLATFORM)/wayland-scanner++
-
 CMAKE_OPTIONS := -DBUILD_DOCUMENTATION=OFF \
                  -DBUILD_LIBRARIES=OFF \
                  -DBUILD_EXAMPLES=OFF \
@@ -32,10 +30,8 @@ $(PLATFORM): $(DEPS) | $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE)
 	mkdir -p $(BUILDDIR)
 	cd $(BUILDDIR); $(NATIVEPREFIX)/bin/cmake $(CMAKE_OPTIONS) ..
 
-$(APP): $(PLATFORM)
+.installed-$(PLATFORM): $(PLATFORM)
 	$(MAKE) -C $(BUILDDIR)
-
-.installed-$(PLATFORM): $(APP)
 	$(MAKE) -C $(BUILDDIR) install
 	touch $@
 

--- a/tools/depends/target/bzip2/Makefile
+++ b/tools/depends/target/bzip2/Makefile
@@ -12,8 +12,6 @@ include ../../download-files.include
 # configuration settings
 CONFIGURE=./configure --prefix=$(PREFIX) --disable-shared
 
-LIBDYLIB=$(PLATFORM)/libbz2.a
-
 all: .installed-$(PLATFORM)
 
 
@@ -22,10 +20,8 @@ $(PLATFORM): $(DEPS) | $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 	cd $(PLATFORM); patch -p1 -i ../Makefile.patch
 
-$(LIBDYLIB): $(PLATFORM)
+.installed-$(PLATFORM): $(PLATFORM)
 	$(MAKE) -C $(PLATFORM) PREFIX=$(PREFIX) CC="$(CC)" CFLAGS="$(CFLAGS)" LDFLAGS="$(LDFLAGS)" AR="$(AR)"
-
-.installed-$(PLATFORM): $(LIBDYLIB)
 	$(MAKE) -C $(PLATFORM) install PREFIX=$(PREFIX)
 	rm $(PREFIX)/bin/bzip2
 	touch $@

--- a/tools/depends/target/gnutls/Makefile
+++ b/tools/depends/target/gnutls/Makefile
@@ -12,9 +12,19 @@ SHA512=72c78d7fcb024393c1d15f2a1856608ae4460ba43cc5bbbb4c29b80508cae6cb822df4638
 include ../../download-files.include
 
 # configuration settings
-CONFIGURE=./configure --prefix=$(PREFIX) --disable-shared --without-p11-kit --disable-nls --with-included-unistring \
-                      --with-included-libtasn1 --enable-local-libopts --disable-doc --disable-tests --disable-guile \
-                      --disable-tools $(CONFIGURE_OPTIONS)
+CONFIGURE=./configure --prefix=$(PREFIX) \
+                      --disable-shared \
+                      --without-p11-kit \
+                      --disable-nls \
+                      --with-included-unistring \
+                      --with-included-libtasn1 \
+                      --enable-local-libopts \
+                      --disable-doc \
+                      --disable-tests \
+                      --disable-guile \
+                      --disable-tools \
+                      --without-idn \
+                      $(CONFIGURE_OPTIONS)
 
 LIBDYLIB=$(PLATFORM)/lib/.libs/lib$(LIBNAME).a
 

--- a/tools/depends/target/harfbuzz/Makefile
+++ b/tools/depends/target/harfbuzz/Makefile
@@ -37,7 +37,7 @@ export CC CXX CFLAGS CXXFLAGS
 endif
 export PKG_CONFIG_LIBDIR=$(PREFIX)/lib/pkgconfig
 
-LIBDYLIB=$(PLATFORM)/build/lib/lib$(LIBNAME).a
+LIBDYLIB=$(PLATFORM)/build/src/lib$(LIBNAME).a
 
 all: .installed-$(PLATFORM)
 

--- a/tools/depends/target/libffi/Makefile
+++ b/tools/depends/target/libffi/Makefile
@@ -2,7 +2,11 @@ include ../../Makefile.include LIBFFI-VERSION ../../download-files.include
 DEPS = ../../Makefile.include Makefile LIBFFI-VERSION ../../download-files.include
 
 # configuration settings
-CONFIGURE= ./configure --prefix=$(PREFIX) --disable-shared --disable-builddir
+CONFIGURE= ./configure --prefix=$(PREFIX) \
+                       --libdir=$(PREFIX)/lib \
+                       --disable-multi-os-directory \
+                       --disable-shared \
+                       --disable-builddir
 
 LIBDYLIB=$(PLATFORM)/.libs/$(LIBNAME).a
 

--- a/tools/depends/target/liblzo2/Makefile
+++ b/tools/depends/target/liblzo2/Makefile
@@ -2,7 +2,7 @@ include ../../Makefile.include LIBLZO2-VERSION ../../download-files.include
 DEPS = ../../Makefile.include Makefile LIBLZO2-VERSION ../../download-files.include
 
 # configuration options
-CMAKE_OPTIONS=-DCMAKE_BUILD_TYPE=Release \ 
+CMAKE_OPTIONS=-DCMAKE_BUILD_TYPE=Release \
               -DENABLE_STATIC=ON \
               -DENABLE_SHARED=OFF \
               -DCMAKE_INSTALL_PREFIX=$(PREFIX)

--- a/tools/depends/target/libva/Makefile
+++ b/tools/depends/target/libva/Makefile
@@ -32,6 +32,7 @@ else
 export CC CXX CFLAGS CXXFLAGS
 endif
 export PKG_CONFIG_LIBDIR=$(PREFIX)/lib/pkgconfig
+export PKG_CONFIG_PATH=$(PREFIX)/lib/pkgconfig
 
 LIBDYLIB=$(PLATFORM)/build/va/$(LIBNAME).so
 

--- a/tools/depends/target/libva/Makefile
+++ b/tools/depends/target/libva/Makefile
@@ -16,7 +16,7 @@ endif
 # configuration settings
 CONFIGURE = $(NATIVEPREFIX)/bin/python3 $(NATIVEPREFIX)/bin/meson \
 	--prefix=$(PREFIX) \
-  --libdir=lib \
+	--libdir=lib \
 	--buildtype=$(MESON_BUILD_TYPE) \
 	-Ddisable_drm=false \
 	-Denable_docs=false \

--- a/tools/depends/target/nettle/Makefile
+++ b/tools/depends/target/nettle/Makefile
@@ -19,8 +19,6 @@ endif
 CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
           ./configure --prefix=$(PREFIX) --disable-shared --disable-fat --disable-openssl --disable-documentation $(CONFIGURE_FLAGS)
 
-LIBDYLIB=$(PLATFORM)/lib$(LIBNAME).a
-
 all: .installed-$(PLATFORM)
 
 
@@ -31,10 +29,8 @@ $(PLATFORM): $(DEPS) | $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE)
 	cd $(PLATFORM); $(AUTORECONF)
 	cd $(PLATFORM); $(CONFIGURE) CCPIC=" "
 
-$(LIBDYLIB): $(PLATFORM)
+.installed-$(PLATFORM): $(PLATFORM)
 	$(MAKE) -C $(PLATFORM)
-
-.installed-$(PLATFORM): $(LIBDYLIB)
 	$(MAKE) -C $(PLATFORM) install
 	touch $@
 

--- a/tools/depends/target/openssl/Makefile
+++ b/tools/depends/target/openssl/Makefile
@@ -13,7 +13,7 @@ include ../../download-files.include
 ifeq ($(OS), linux)
   # Need to export our vars to override "default" conf data of openssl
   TARGETOPT=--with-zlib-include=$(PREFIX)/include --with-zlib-lib=$(PREFIX)/lib
-  CONFIGURE=MACHINE=$(PLATFORM) ./config no-shared zlib no-tests no-asm $(TARGETOPT) --prefix=$(PREFIX)
+  CONFIGURE=MACHINE=$(PLATFORM) ./config no-shared zlib no-tests no-asm $(TARGETOPT) --prefix=$(PREFIX) --libdir=lib
 else
   ifeq ($(OS), android)
     TARGETOPT=--with-zlib-include=$(PREFIX)/include --with-zlib-lib=$(PREFIX)/lib -D__ANDROID_API__=$(NDK_LEVEL)

--- a/tools/depends/target/pythonmodule-pycryptodome/Makefile
+++ b/tools/depends/target/pythonmodule-pycryptodome/Makefile
@@ -25,13 +25,6 @@ export CC CFLAGS
 export LDSHARED LDFLAGS
 export PYTHONPATH=$(PYTHON_SITE_PKG)
 
-LIBDYLIB=$(PLATFORM)/build/lib.$(OS)-$(CPU)-$(PYTHON_VERSION)/Cryptodome
-ifeq ($(NATIVE_OS), osx)
-  # this module will always recompile. currently the hardcoded 10.4 is incorrect
-  # and would need to be generated based on sdk version that we dont currently collect
-	LIBDYLIB=$(PLATFORM)/build/lib.macosx-10.4-$(CPU)-$(PYTHON_VERSION)/Cryptodome
-endif
-
 all: .installed-$(PLATFORM)
 
 
@@ -44,10 +37,8 @@ ifeq ($(OS),android)
 	cd $(PLATFORM); patch -p1 -i ../03-android-dlopen.patch
 endif
 
-$(LIBDYLIB): $(PLATFORM)
+.installed-$(PLATFORM): $(PLATFORM)
 	cd $(PLATFORM); touch .separate_namespace && $(NATIVEPREFIX)/bin/python3 setup.py build_ext --plat-name $(OS)-$(CPU)
-
-.installed-$(PLATFORM): $(LIBDYLIB)
 	cd $(PLATFORM); $(NATIVEPREFIX)/bin/python3 setup.py install --prefix=$(PREFIX)
 	cd $(PYTHON_SITE_PKG); mkdir -p Cryptodome && cp -rf pycryptodomex*.egg/Cryptodome/* ./Cryptodome && rm -rf pycryptodomex*.egg
 	touch $@

--- a/tools/depends/target/samba-gplv3/Makefile
+++ b/tools/depends/target/samba-gplv3/Makefile
@@ -58,6 +58,9 @@ export CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
 export HOST
 export PKG_CONFIG_LIBDIR=$(PREFIX)/lib/pkgconfig
 
+# samba doesn't build with distcc
+export DISTCC_HOSTS=
+
 all: .installed-$(PLATFORM)
 
 $(PLATFORM): $(DEPS) | $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE)

--- a/tools/depends/target/wayland/Makefile
+++ b/tools/depends/target/wayland/Makefile
@@ -12,8 +12,6 @@ include ../../download-files.include
 # configuration settings
 CONFIGURE=./configure --prefix=$(PREFIX) --with-host-scanner --disable-documentation --disable-dtd-validation
 
-LIBDYLIB=$(PLATFORM)/.libs/libwayland-client.la
-
 all: .installed-$(PLATFORM)
 
 
@@ -22,10 +20,8 @@ $(PLATFORM): $(DEPS) | $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 	cd $(PLATFORM); $(CONFIGURE)
 
-$(LIBDYLIB): $(PLATFORM)
+.installed-$(PLATFORM): $(PLATFORM)
 	$(MAKE) -C $(PLATFORM)
-
-.installed-$(PLATFORM): $(LIBDYLIB)
 	$(MAKE) -C $(PLATFORM) install
 
 	# remove the target wayland scanner from the sysroot. We only want to use the native one


### PR DESCRIPTION
This is a collection of fixes that I've put together to allow building on my fedora 37 host.

This mainly allows rerunning the makefile without rebuilding targets.

There is a couple commits that fix installing to `lib64` and install to `lib` instead.

I had to disable idna support in gnutls as I would get a link issue with ffmpeg as it tried to link against my host libidna.

I also had to disable distcc in samba as it would fail to build otherwise. ref: https://bugs.gentoo.org/749324

We really should just remove the `LIBDYLIB` pattern we have and have the `unpack, configure, build, install` as just one target.