### PR TITLE
CAEResampleFactory: return a unique_ptr in Create

### DIFF
--- a/xbmc/cores/AudioEngine/AEResampleFactory.cpp
+++ b/xbmc/cores/AudioEngine/AEResampleFactory.cpp
@@ -12,9 +12,9 @@
 namespace ActiveAE
 {
 
-IAEResample *CAEResampleFactory::Create(uint32_t flags /* = 0 */)
+std::unique_ptr<IAEResample> CAEResampleFactory::Create(uint32_t flags /* = 0 */)
 {
-  return new CActiveAEResampleFFMPEG();
+  return std::make_unique<CActiveAEResampleFFMPEG>();
 }
 
 }

--- a/xbmc/cores/AudioEngine/AEResampleFactory.h
+++ b/xbmc/cores/AudioEngine/AEResampleFactory.h
@@ -27,7 +27,7 @@ enum AEResampleFactoryOptions
 class CAEResampleFactory
 {
 public:
-  static IAEResample *Create(uint32_t flags = 0U);
+  static std::unique_ptr<IAEResample> Create(uint32_t flags = 0U);
 };
 
 }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -3242,8 +3242,8 @@ bool CActiveAE::ResampleSound(CActiveAESound *sound)
     }
   }
 
-  auto resampler =
-      std::unique_ptr<IAEResample>(CAEResampleFactory::Create(AERESAMPLEFACTORY_QUICK_RESAMPLE));
+  std::unique_ptr<IAEResample> resampler =
+      CAEResampleFactory::Create(AERESAMPLEFACTORY_QUICK_RESAMPLE);
 
   resampler->Init(dst_config, orig_config,
                   false,

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -3242,7 +3242,8 @@ bool CActiveAE::ResampleSound(CActiveAESound *sound)
     }
   }
 
-  IAEResample *resampler = CAEResampleFactory::Create(AERESAMPLEFACTORY_QUICK_RESAMPLE);
+  auto resampler =
+      std::unique_ptr<IAEResample>(CAEResampleFactory::Create(AERESAMPLEFACTORY_QUICK_RESAMPLE));
 
   resampler->Init(dst_config, orig_config,
                   false,
@@ -3258,10 +3259,8 @@ bool CActiveAE::ResampleSound(CActiveAESound *sound)
 
   dst_buffer = sound->InitSound(false, dst_config, dst_samples);
   if (!dst_buffer)
-  {
-    delete resampler;
     return false;
-  }
+
   int samples = resampler->Resample(dst_buffer, dst_samples,
                                     sound->GetSound(true)->data,
                                     sound->GetSound(true)->nb_samples,
@@ -3269,7 +3268,6 @@ bool CActiveAE::ResampleSound(CActiveAESound *sound)
 
   sound->GetSound(false)->nb_samples = samples;
 
-  delete resampler;
   sound->SetConverted(true);
   return true;
 }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
@@ -170,7 +170,7 @@ bool CActiveAEBufferPoolResample::Create(unsigned int totaltime, bool remap, boo
 
 void CActiveAEBufferPoolResample::ChangeResampler()
 {
-  m_resampler.reset(CAEResampleFactory::Create());
+  m_resampler = CAEResampleFactory::Create();
 
   SampleConfig dstConfig, srcConfig;
   dstConfig.channel_layout = CAEUtil::GetAVChannelLayout(m_format.m_channelLayout);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
@@ -145,8 +145,6 @@ CActiveAEBufferPoolResample::CActiveAEBufferPoolResample(const AEAudioFormat& in
 CActiveAEBufferPoolResample::~CActiveAEBufferPoolResample()
 {
   Flush();
-
-  delete m_resampler;
 }
 
 bool CActiveAEBufferPoolResample::Create(unsigned int totaltime, bool remap, bool upmix, bool normalize)
@@ -172,13 +170,7 @@ bool CActiveAEBufferPoolResample::Create(unsigned int totaltime, bool remap, boo
 
 void CActiveAEBufferPoolResample::ChangeResampler()
 {
-  if (m_resampler)
-  {
-    delete m_resampler;
-    m_resampler = NULL;
-  }
-
-  m_resampler = CAEResampleFactory::Create();
+  m_resampler.reset(CAEResampleFactory::Create());
 
   SampleConfig dstConfig, srcConfig;
   dstConfig.channel_layout = CAEUtil::GetAVChannelLayout(m_format.m_channelLayout);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
@@ -102,7 +102,7 @@ protected:
   int64_t m_lastSamplePts = 0;
   bool m_remap = false;
   CSampleBuffer *m_procSample = nullptr;
-  IAEResample *m_resampler = nullptr;
+  std::unique_ptr<IAEResample> m_resampler;
   double m_resampleRatio = 1.0;
   double m_centerMixLevel = M_SQRT1_2;
   bool m_fillPackets = false;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -1125,7 +1125,8 @@ void CActiveAESink::GenerateNoise()
   }
 
   SampleConfig config = m_sampleOfSilence.pkt->config;
-  IAEResample *resampler = CAEResampleFactory::Create(AERESAMPLEFACTORY_QUICK_RESAMPLE);
+  auto resampler =
+      std::unique_ptr<IAEResample>(CAEResampleFactory::Create(AERESAMPLEFACTORY_QUICK_RESAMPLE));
 
   SampleConfig dstConfig, srcConfig;
   dstConfig.channel_layout = config.channel_layout;
@@ -1149,7 +1150,6 @@ void CActiveAESink::GenerateNoise()
                      (uint8_t**)&noise, m_sampleOfSilence.pkt->max_nb_samples, 1.0);
 
   KODI::MEMORY::AlignedFree(noise);
-  delete resampler;
 }
 
 void CActiveAESink::SetSilenceTimer()

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -1125,8 +1125,8 @@ void CActiveAESink::GenerateNoise()
   }
 
   SampleConfig config = m_sampleOfSilence.pkt->config;
-  auto resampler =
-      std::unique_ptr<IAEResample>(CAEResampleFactory::Create(AERESAMPLEFACTORY_QUICK_RESAMPLE));
+  std::unique_ptr<IAEResample> resampler =
+      CAEResampleFactory::Create(AERESAMPLEFACTORY_QUICK_RESAMPLE);
 
   SampleConfig dstConfig, srcConfig;
   dstConfig.channel_layout = config.channel_layout;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -98,7 +98,7 @@ void CActiveAEStream::InitRemapper()
   {
     CLog::Log(LOGDEBUG, "CActiveAEStream::{} - initialize remapper", __FUNCTION__);
 
-    m_remapper.reset(CAEResampleFactory::Create());
+    m_remapper = CAEResampleFactory::Create();
     uint64_t avLayout = CAEUtil::GetAVChannelLayout(m_format.m_channelLayout);
 
     // build layout according to ffmpeg channel order

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -42,7 +42,6 @@ CActiveAEStream::CActiveAEStream(AEAudioFormat* format, unsigned int streamid, C
   m_leftoverBuffer = new uint8_t[m_format.m_frameSize];
   m_leftoverBytes = 0;
   m_forceResampler = false;
-  m_remapper = NULL;
   m_remapBuffer = NULL;
   m_streamResampleRatio = 1.0;
   m_streamResampleMode = 0;
@@ -58,7 +57,6 @@ CActiveAEStream::CActiveAEStream(AEAudioFormat* format, unsigned int streamid, C
 CActiveAEStream::~CActiveAEStream()
 {
   delete [] m_leftoverBuffer;
-  delete m_remapper;
   delete m_remapBuffer;
 }
 
@@ -100,7 +98,7 @@ void CActiveAEStream::InitRemapper()
   {
     CLog::Log(LOGDEBUG, "CActiveAEStream::{} - initialize remapper", __FUNCTION__);
 
-    m_remapper = CAEResampleFactory::Create();
+    m_remapper.reset(CAEResampleFactory::Create());
     uint64_t avLayout = CAEUtil::GetAVChannelLayout(m_format.m_channelLayout);
 
     // build layout according to ffmpeg channel order

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
@@ -207,7 +207,7 @@ protected:
   int m_leftoverBytes;
   CSampleBuffer *m_currentBuffer;
   CSoundPacket *m_remapBuffer;
-  IAEResample *m_remapper;
+  std::unique_ptr<IAEResample> m_remapper;
   double m_lastPts;
   double m_lastPtsJump;
   std::chrono::milliseconds m_errorInterval{1000};

--- a/xbmc/cores/paplayer/VideoPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.cpp
@@ -29,7 +29,6 @@ VideoPlayerCodec::VideoPlayerCodec()
   m_nAudioStream = -1;
   m_nDecodedLen = 0;
   m_bInited = false;
-  m_pResampler = NULL;
   m_needConvert = false;
   m_channels = 0;
 
@@ -245,7 +244,7 @@ bool VideoPlayerCodec::Init(const CFileItem &file, unsigned int filecache)
     if (m_srcFormat.m_frameSize == 0)
       return false;
 
-    m_pResampler = ActiveAE::CAEResampleFactory::Create();
+    m_pResampler.reset(ActiveAE::CAEResampleFactory::Create());
 
     SampleConfig dstConfig, srcConfig;
     dstConfig.channel_layout = CAEUtil::GetAVChannelLayout(m_srcFormat.m_channelLayout);
@@ -296,8 +295,7 @@ void VideoPlayerCodec::DeInit()
 
   m_pAudioCodec.reset();
 
-  delete m_pResampler;
-  m_pResampler = NULL;
+  m_pResampler.reset();
 
   // cleanup format information
   m_TotalTime = 0;

--- a/xbmc/cores/paplayer/VideoPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.cpp
@@ -244,7 +244,7 @@ bool VideoPlayerCodec::Init(const CFileItem &file, unsigned int filecache)
     if (m_srcFormat.m_frameSize == 0)
       return false;
 
-    m_pResampler.reset(ActiveAE::CAEResampleFactory::Create());
+    m_pResampler = ActiveAE::CAEResampleFactory::Create();
 
     SampleConfig dstConfig, srcConfig;
     dstConfig.channel_layout = CAEUtil::GetAVChannelLayout(m_srcFormat.m_channelLayout);

--- a/xbmc/cores/paplayer/VideoPlayerCodec.h
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.h
@@ -53,7 +53,7 @@ private:
   bool m_bInited;
   bool m_bCanSeek;
 
-  ActiveAE::IAEResample *m_pResampler;
+  std::unique_ptr<ActiveAE::IAEResample> m_pResampler;
   DVDAudioFrame m_audioFrame;
   int m_planes;
   bool m_needConvert;


### PR DESCRIPTION
I noticed a lot of manual new/delete in AudioEngine. I have a few branches to move these to smart pointers. The first is the factory method `CAEResampleFactory::Create`.

This makes `CAEResampleFactory::Create` return `std::unique_ptr<IAEResample>`.

This also makes all the objects that use `CAEResampleFactory::Create` a `std::unique_ptr<IAEResample>`.
