### PR TITLE
[audio] TrueHD rework

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -76,8 +76,8 @@ void CEngineStats::GetDelay(AEDelayStatus& status)
   if (m_pcmOutput)
     status.delay += (double)m_bufferedSamples / m_sinkSampleRate;
   else
-    status.delay += static_cast<double>(m_bufferedSamples) *
-                    m_sinkFormat.m_streamInfo.GetDuration(m_sinkNeedIecPack) / 1000;
+    status.delay +=
+        static_cast<double>(m_bufferedSamples) * m_sinkFormat.m_streamInfo.GetDuration() / 1000;
 }
 
 void CEngineStats::AddStream(unsigned int streamid)
@@ -130,8 +130,7 @@ void CEngineStats::UpdateStream(CActiveAEStream *stream)
         if (m_pcmOutput)
           delay += (float)(*itBuf)->pkt->nb_samples / (*itBuf)->pkt->config.sample_rate;
         else
-          delay +=
-              static_cast<float>(m_sinkFormat.m_streamInfo.GetDuration(m_sinkNeedIecPack) / 1000.0);
+          delay += static_cast<float>(m_sinkFormat.m_streamInfo.GetDuration() / 1000.0);
       }
       str.m_bufferedTime = static_cast<double>(delay);
       stream->m_bufferedTime = 0;
@@ -149,8 +148,8 @@ void CEngineStats::GetDelay(AEDelayStatus& status, CActiveAEStream *stream)
   if (m_pcmOutput)
     status.delay += (double)m_bufferedSamples / m_sinkSampleRate;
   else
-    status.delay += static_cast<double>(m_bufferedSamples) *
-                    m_sinkFormat.m_streamInfo.GetDuration(m_sinkNeedIecPack) / 1000;
+    status.delay +=
+        static_cast<double>(m_bufferedSamples) * m_sinkFormat.m_streamInfo.GetDuration() / 1000;
 
   for (auto &str : m_streamStats)
   {
@@ -173,8 +172,8 @@ void CEngineStats::GetSyncInfo(CAESyncInfo& info, CActiveAEStream *stream)
   if (m_pcmOutput)
     status.delay += (double)m_bufferedSamples / m_sinkSampleRate;
   else
-    status.delay += static_cast<double>(m_bufferedSamples) *
-                    m_sinkFormat.m_streamInfo.GetDuration(m_sinkNeedIecPack) / 1000;
+    status.delay +=
+        static_cast<double>(m_bufferedSamples) * m_sinkFormat.m_streamInfo.GetDuration() / 1000;
 
   status.delay += static_cast<double>(m_sinkLatency);
 
@@ -229,9 +228,7 @@ float CEngineStats::GetWaterLevel()
   if (m_pcmOutput)
     return static_cast<float>(m_bufferedSamples) / m_sinkSampleRate;
   else
-    return static_cast<float>(m_bufferedSamples *
-                              m_sinkFormat.m_streamInfo.GetDuration(m_sinkNeedIecPack)) /
-           1000;
+    return static_cast<float>(m_bufferedSamples * m_sinkFormat.m_streamInfo.GetDuration()) / 1000;
 }
 
 void CEngineStats::SetSuspended(bool state)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -151,6 +151,13 @@ void CEngineStats::GetDelay(AEDelayStatus& status, CActiveAEStream *stream)
     status.delay +=
         static_cast<double>(m_bufferedSamples) * m_sinkFormat.m_streamInfo.GetDuration() / 1000;
 
+  if (!m_pcmOutput && m_sinkNeedIecPack &&
+      m_sinkFormat.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD)
+  {
+    // take into account MAT packer latency (half duration of MAT frame)
+    status.delay += m_sinkFormat.m_streamInfo.GetDuration() / 1000 / 2;
+  }
+
   for (auto &str : m_streamStats)
   {
     if (str.m_streamId == stream->m_id)
@@ -176,6 +183,13 @@ void CEngineStats::GetSyncInfo(CAESyncInfo& info, CActiveAEStream *stream)
         static_cast<double>(m_bufferedSamples) * m_sinkFormat.m_streamInfo.GetDuration() / 1000;
 
   status.delay += static_cast<double>(m_sinkLatency);
+
+  if (!m_pcmOutput && m_sinkNeedIecPack &&
+      m_sinkFormat.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD)
+  {
+    // take into account MAT packer latency (half duration of MAT frame)
+    status.delay += m_sinkFormat.m_streamInfo.GetDuration() / 1000 / 2;
+  }
 
   for (auto &str : m_streamStats)
   {

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -29,9 +29,12 @@ using namespace ActiveAE;
 
 using namespace std::chrono_literals;
 
-#define MAX_CACHE_LEVEL 0.4   // total cache time of stream in seconds
-#define MAX_WATER_LEVEL 0.2   // buffered time after stream stages in seconds
-#define MAX_BUFFER_TIME 0.1   // max time of a buffer in seconds
+namespace
+{
+constexpr float MAX_CACHE_LEVEL = 0.4f; // total cache time of stream in seconds;
+constexpr float MAX_WATER_LEVEL = 0.2f; // buffered time after stream stages in seconds;
+constexpr double MAX_BUFFER_TIME = 0.1; // max time of a buffer in seconds;
+} // unnamed namespace
 
 void CEngineStats::Reset(unsigned int sampleRate, bool pcm)
 {
@@ -217,8 +220,7 @@ float CEngineStats::GetCacheTotal()
 
 float CEngineStats::GetMaxDelay() const
 {
-  return static_cast<float>(MAX_CACHE_LEVEL) + static_cast<float>(MAX_WATER_LEVEL) +
-         m_sinkCacheTotal;
+  return MAX_CACHE_LEVEL + MAX_WATER_LEVEL + m_sinkCacheTotal;
 }
 
 float CEngineStats::GetWaterLevel()
@@ -1911,7 +1913,7 @@ bool CActiveAE::RunStages()
       float buftime = (float)(*it)->m_inputBuffers->m_format.m_frames / (*it)->m_inputBuffers->m_format.m_sampleRate;
       if ((*it)->m_inputBuffers->m_format.m_dataFormat == AE_FMT_RAW)
         buftime = (*it)->m_inputBuffers->m_format.m_streamInfo.GetDuration() / 1000;
-      while ((time < static_cast<float>(MAX_CACHE_LEVEL) || (*it)->m_streamIsBuffering) &&
+      while ((time < MAX_CACHE_LEVEL || (*it)->m_streamIsBuffering) &&
              !(*it)->m_inputBuffers->m_freeSamples.empty())
       {
         buffer = (*it)->m_inputBuffers->GetFreeBuffer();
@@ -1951,7 +1953,7 @@ bool CActiveAE::RunStages()
     }
   }
 
-  if (m_stats.GetWaterLevel() < static_cast<float>(MAX_WATER_LEVEL) &&
+  if (m_stats.GetWaterLevel() < (MAX_WATER_LEVEL + 0.0001f) &&
       (m_mode != MODE_TRANSCODE || (m_encoderBuffers && !m_encoderBuffers->m_freeSamples.empty())))
   {
     // calculate sync error

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1953,7 +1953,12 @@ bool CActiveAE::RunStages()
     }
   }
 
-  if (m_stats.GetWaterLevel() < (MAX_WATER_LEVEL + 0.0001f) &&
+  // TrueHD is very jumpy, meaning the frames don't come in equidistantly. They are only smoothed
+  // at the end when the IEC packing happens. Therefore adjust earlier.
+  const bool ignoreWL =
+      (m_mode == MODE_RAW && m_sinkFormat.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD);
+
+  if ((m_stats.GetWaterLevel() < (MAX_WATER_LEVEL + 0.0001f) || ignoreWL) &&
       (m_mode != MODE_TRANSCODE || (m_encoderBuffers && !m_encoderBuffers->m_freeSamples.empty())))
   {
     // calculate sync error

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -727,7 +727,8 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
                 1000.0 * (m_duration_written - playtime), delta / 1000000.0, playtime * 1000,
                 m_duration_written * 1000);
       CLog::Log(LOGINFO, "Head-Position {} Timestamp Position {} Delay-Offset: {} ms", m_headPos,
-                m_timestampPos, 1000.0 * (m_headPos - m_timestampPos) / m_sink_sampleRate);
+                m_timestampPos,
+                1000.0 * (static_cast<int64_t>(m_headPos - m_timestampPos)) / m_sink_sampleRate);
     }
     double hw_delay = m_duration_written - playtime;
     // correct by subtracting above measured delay, if lower delay gets automatically reduced

--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
@@ -61,7 +61,7 @@ CAEStreamParser::CAEStreamParser() :
   av_crc_init(m_crcTrueHD, 0, 16, 0x2D, sizeof(m_crcTrueHD));
 }
 
-double CAEStreamInfo::GetDuration(bool TrueHDHalfDuration /*= false*/) const
+double CAEStreamInfo::GetDuration() const
 {
   double duration = 0;
   switch (m_type)
@@ -81,8 +81,6 @@ double CAEStreamInfo::GetDuration(bool TrueHDHalfDuration /*= false*/) const
       else
         rate = 176400;
       duration = 3840.0 / rate;
-      if (TrueHDHalfDuration)
-        duration /= 2;
       break;
     case STREAM_TYPE_DTS_512:
     case STREAM_TYPE_DTSHD_CORE:

--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.h
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.h
@@ -22,7 +22,7 @@ extern "C" {
 class CAEStreamInfo
 {
 public:
-  double GetDuration(bool TrueHDHalfDuration = false) const;
+  double GetDuration() const;
   bool operator==(const CAEStreamInfo& info) const;
 
   enum DataType

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
@@ -224,7 +224,7 @@ void CDVDAudioCodecPassthrough::GetData(DVDAudioFrame &frame)
   frame.format = m_format;
   frame.planes = 1;
   frame.bits_per_sample = 8;
-  frame.duration = DVD_MSEC_TO_TIME(frame.format.m_streamInfo.GetDuration(!m_deviceIsRAW));
+  frame.duration = DVD_MSEC_TO_TIME(frame.format.m_streamInfo.GetDuration());
   frame.pts = m_currentPts;
   m_currentPts = DVD_NOPTS_VALUE;
 }

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -858,8 +858,17 @@ inline bool PAPlayer::ProcessStream(StreamInfo *si, double &freeBufferTime)
         free_space = (double)(si->m_stream->GetSpace() / si->m_bytesPerSample) / si->m_audioFormat.m_sampleRate;
       else
       {
-        free_space = static_cast<double>(si->m_stream->GetSpace()) *
-                     si->m_audioFormat.m_streamInfo.GetDuration() / 1000;
+        if (si->m_audioFormat.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD &&
+            !m_processInfo->WantsRawPassthrough())
+        {
+          free_space = static_cast<double>(si->m_stream->GetSpace()) *
+                       si->m_audioFormat.m_streamInfo.GetDuration() / 1000 / 2;
+        }
+        else
+        {
+          free_space = static_cast<double>(si->m_stream->GetSpace()) *
+                       si->m_audioFormat.m_streamInfo.GetDuration() / 1000;
+        }
       }
 
       freeBufferTime = std::max(freeBufferTime , free_space);
@@ -908,8 +917,17 @@ bool PAPlayer::QueueData(StreamInfo *si)
         CLog::Log(LOGERROR, "PAPlayer::QueueData - unknown error");
         return false;
       }
-      si->m_framesSent += si->m_audioFormat.m_streamInfo.GetDuration() / 1000 *
-                          si->m_audioFormat.m_streamInfo.m_sampleRate;
+      if (si->m_audioFormat.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD &&
+          !m_processInfo->WantsRawPassthrough())
+      {
+        si->m_framesSent += si->m_audioFormat.m_streamInfo.GetDuration() / 1000 / 2 *
+                            si->m_audioFormat.m_streamInfo.m_sampleRate;
+      }
+      else
+      {
+        si->m_framesSent += si->m_audioFormat.m_streamInfo.GetDuration() / 1000 *
+                            si->m_audioFormat.m_streamInfo.m_sampleRate;
+      }
     }
   }
 

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -858,9 +858,8 @@ inline bool PAPlayer::ProcessStream(StreamInfo *si, double &freeBufferTime)
         free_space = (double)(si->m_stream->GetSpace() / si->m_bytesPerSample) / si->m_audioFormat.m_sampleRate;
       else
       {
-        const bool isIEC = !m_processInfo->WantsRawPassthrough();
-        free_space = (double)si->m_stream->GetSpace() *
-                     si->m_audioFormat.m_streamInfo.GetDuration(isIEC) / 1000;
+        free_space = static_cast<double>(si->m_stream->GetSpace()) *
+                     si->m_audioFormat.m_streamInfo.GetDuration() / 1000;
       }
 
       freeBufferTime = std::max(freeBufferTime , free_space);
@@ -909,8 +908,7 @@ bool PAPlayer::QueueData(StreamInfo *si)
         CLog::Log(LOGERROR, "PAPlayer::QueueData - unknown error");
         return false;
       }
-      const bool isIEC = !m_processInfo->WantsRawPassthrough();
-      si->m_framesSent += si->m_audioFormat.m_streamInfo.GetDuration(isIEC) / 1000 *
+      si->m_framesSent += si->m_audioFormat.m_streamInfo.GetDuration() / 1000 *
                           si->m_audioFormat.m_streamInfo.m_sampleRate;
     }
   }


### PR DESCRIPTION
## Description
TrueHD rework

Closes https://github.com/xbmc/xbmc/issues/20391 (before was fixed only IEC, this PR fixes both RAW & IEC)

## Motivation and context
My understanding is that with TrueHD the water level constantly fluctuates around the `MAX_WATER_LEVEL` a little above and a little below but that's okay. The only problem is that AE was not designed with this in mind.

Changing constant value of `MAX_WATER_LEVEL` to other number does not fix the issue because still fluctuates (in other target level).

Note that this issue is **very old**: already **was happening in v18.9** and older and is unrelated to recent TrueHD rework to support high bitrate TrueHD (new MAT packer) and **is unrelated to the fact of use 12 or 24 audio units**.

**Confirmed things**

- This is the root cause of PAPlayer progress indicator jumps.
- And more important: this is also one of the causes of video stuttering in Android ("smoothing errors" also contributes here).  Basically Android stuttering issues can be avoided if the duration is falsified with the "ratio" trick (that it has been seen that it is not technically correct because the TrueHD MAT frames are 20ms on Sink) OR "patching" water level. This maybe is another workaround but is more near of true root cause.
- PAPlayer jumps in progress issue exists from before TrueHD MAT packer first rework in v19.3. See: https://github.com/xbmc/xbmc/issues/20391 Then is unrelated to use 12 or 24 audio units and even is unrelated to use IEC or RAW.

> Kodi version:
> 19.0, 19.1, 19.2
> 18.4, 18.5 etc


**Proposed Solution**

Root cause is that a/v sync only is calculated when current water level is < `MAX_WATER_LEVEL`:

https://github.com/xbmc/xbmc/blob/fa592d344eb0b5e2bc8864cb304173e696e36a79/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp#L1954-L1957

Then in TrueHD a/v sync is NOT calculated all the time and this causes issues mentioned above.

Proposed solution is calculate a/v sync error all the time in TrueHD only (regardless of water level).

Note that in any case water level is always less than `MAX_CACHE_LEVEL` then no side effects are expected.


## How has this been tested?
Runtime tested Windows 11 22H2 (Intel NUC8i3BEK + Denon X1600H)
Runtime tested Android (Shield FW 9.1.1 + Denon X1600H)

None issues found: absolute no TrueHD audio dropouts. Video super smooth. TrueHD a/v sync perfect. Debug info OSD better than ever a/v sync fluctuates a little around zero, perfectly stable. 

See: https://user-images.githubusercontent.com/58434170/217493470-d26ee717-dde6-4bda-9353-a3cabad78eac.mp4

For me it is the best version for Shield that has ever existed.


## What is the effect on users?
The differences are subtle as both master and Nexus already include TrueHD workarounds. Now has been perfected, everything is a little better. The only major difference is that this is the first and only Kodi version where the PAPlayer progress bar works well with TrueHD AudioTrack RAW.


## Screenshots (if appropriate):

**Before - Current master branch - AudioTrack RAW**
https://user-images.githubusercontent.com/58434170/217491726-1e10aebb-8ac6-4b0a-9e7f-d9c11abb5188.mp4

**After - This PR - AudioTrack RAW**
https://user-images.githubusercontent.com/58434170/217492052-7fa8435e-6fc0-42fc-bb13-0543c0b76037.mp4


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
