### PR TITLE
CActiveAESink: use std::unique_ptr<IAESink>

### DIFF
--- a/xbmc/cores/AudioEngine/AESinkFactory.cpp
+++ b/xbmc/cores/AudioEngine/AESinkFactory.cpp
@@ -60,14 +60,14 @@ void CAESinkFactory::ParseDevice(std::string &device, std::string &driver)
     driver.clear();
 }
 
-IAESink *CAESinkFactory::Create(std::string &device, AEAudioFormat &desiredFormat)
+std::unique_ptr<IAESink> CAESinkFactory::Create(std::string& device, AEAudioFormat& desiredFormat)
 {
   // extract the driver from the device string if it exists
   std::string driver;
   ParseDevice(device, driver);
 
   AEAudioFormat tmpFormat = desiredFormat;
-  IAESink *sink;
+  std::unique_ptr<IAESink> sink;
   std::string tmpDevice = device;
 
   for (const auto& reg : m_AESinkRegEntry)
@@ -75,7 +75,7 @@ IAESink *CAESinkFactory::Create(std::string &device, AEAudioFormat &desiredForma
     if (driver != reg.second.sinkName)
       continue;
 
-    sink = reg.second.createFunc(tmpDevice, tmpFormat);
+    sink.reset(reg.second.createFunc(tmpDevice, tmpFormat));
     if (sink)
     {
       desiredFormat = tmpFormat;

--- a/xbmc/cores/AudioEngine/AESinkFactory.cpp
+++ b/xbmc/cores/AudioEngine/AESinkFactory.cpp
@@ -75,7 +75,7 @@ std::unique_ptr<IAESink> CAESinkFactory::Create(std::string& device, AEAudioForm
     if (driver != reg.second.sinkName)
       continue;
 
-    sink.reset(reg.second.createFunc(tmpDevice, tmpFormat));
+    sink = reg.second.createFunc(tmpDevice, tmpFormat);
     if (sink)
     {
       desiredFormat = tmpFormat;

--- a/xbmc/cores/AudioEngine/AESinkFactory.h
+++ b/xbmc/cores/AudioEngine/AESinkFactory.h
@@ -11,6 +11,7 @@
 #include "Utils/AEAudioFormat.h"
 #include "Utils/AEDeviceInfo.h"
 
+#include <functional>
 #include <map>
 #include <memory>
 #include <stdint.h>
@@ -28,16 +29,16 @@ struct AESinkInfo
   AEDeviceInfoList m_deviceInfoList;
 };
 
-typedef IAESink* (*CreateSink)(std::string &device, AEAudioFormat &desiredFormat);
-typedef void (*Enumerate)(AEDeviceInfoList &list, bool force);
-typedef void (*Cleanup)();
+using CreateSink = std::function<IAESink*(std::string& device, AEAudioFormat& desiredFormat)>;
+using Enumerate = std::function<void(AEDeviceInfoList& list, bool force)>;
+using Cleanup = std::function<void()>;
 
 struct AESinkRegEntry
 {
   std::string sinkName;
-  CreateSink createFunc = nullptr;
-  Enumerate enumerateFunc = nullptr;
-  Cleanup cleanupFunc = nullptr;
+  CreateSink createFunc;
+  Enumerate enumerateFunc;
+  Cleanup cleanupFunc;
 };
 
 class CAESinkFactory

--- a/xbmc/cores/AudioEngine/AESinkFactory.h
+++ b/xbmc/cores/AudioEngine/AESinkFactory.h
@@ -12,6 +12,7 @@
 #include "Utils/AEDeviceInfo.h"
 
 #include <map>
+#include <memory>
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -47,7 +48,7 @@ public:
   static bool HasSinks();
 
   static void ParseDevice(std::string &device, std::string &driver);
-  static IAESink *Create(std::string &device, AEAudioFormat &desiredFormat);
+  static std::unique_ptr<IAESink> Create(std::string& device, AEAudioFormat& desiredFormat);
   static void EnumerateEx(std::vector<AESinkInfo>& list, bool force, const std::string& driver);
   static void Cleanup();
 

--- a/xbmc/cores/AudioEngine/AESinkFactory.h
+++ b/xbmc/cores/AudioEngine/AESinkFactory.h
@@ -29,7 +29,8 @@ struct AESinkInfo
   AEDeviceInfoList m_deviceInfoList;
 };
 
-using CreateSink = std::function<IAESink*(std::string& device, AEAudioFormat& desiredFormat)>;
+using CreateSink =
+    std::function<std::unique_ptr<IAESink>(std::string& device, AEAudioFormat& desiredFormat)>;
 using Enumerate = std::function<void(AEDeviceInfoList& list, bool force)>;
 using Cleanup = std::function<void()>;
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -59,8 +59,7 @@ void CActiveAESink::Dispose()
   {
     m_sink->Drain();
     m_sink->Deinitialize();
-    delete m_sink;
-    m_sink = nullptr;
+    m_sink.reset();
   }
 
   delete m_sampleOfSilence.pkt;
@@ -305,8 +304,7 @@ void CActiveAESink::StateMachine(int signal, Protocol *port, Message *msg)
           {
             m_sink->Drain();
             m_sink->Deinitialize();
-            delete m_sink;
-            m_sink = nullptr;
+            m_sink.reset();
           }
           m_state = S_TOP_UNCONFIGURED;
           msg->Reply(CSinkControlProtocol::ACC);
@@ -442,8 +440,7 @@ void CActiveAESink::StateMachine(int signal, Protocol *port, Message *msg)
           if (m_extError)
           {
             m_sink->Deinitialize();
-            delete m_sink;
-            m_sink = nullptr;
+            m_sink.reset();
             m_state = S_TOP_CONFIGURED_SUSPEND;
             m_extTimeout = 0ms;
           }
@@ -537,8 +534,7 @@ void CActiveAESink::StateMachine(int signal, Protocol *port, Message *msg)
         {
         case CSinkControlProtocol::TIMEOUT:
           m_sink->Deinitialize();
-          delete m_sink;
-          m_sink = nullptr;
+          m_sink.reset();
           m_state = S_TOP_CONFIGURED_SUSPEND;
           m_extTimeout = 10s;
           return;
@@ -585,8 +581,7 @@ void CActiveAESink::StateMachine(int signal, Protocol *port, Message *msg)
           if (m_extError)
           {
             m_sink->Deinitialize();
-            delete m_sink;
-            m_sink = nullptr;
+            m_sink.reset();
             m_state = S_TOP_CONFIGURED_SUSPEND;
           }
           else
@@ -826,8 +821,7 @@ void CActiveAESink::OpenSink()
   {
     m_sink->Drain();
     m_sink->Deinitialize();
-    delete m_sink;
-    m_sink = nullptr;
+    m_sink.reset();
   }
 
   // get the display name of the device
@@ -840,7 +834,7 @@ void CActiveAESink::OpenSink()
   // WARNING: this changes format and does not use passthrough
   m_sinkFormat = m_requestedFormat;
   CLog::Log(LOGDEBUG, "CActiveAESink::OpenSink - trying to open device {}", device);
-  m_sink = CAESinkFactory::Create(device, m_sinkFormat);
+  m_sink.reset(CAESinkFactory::Create(device, m_sinkFormat));
 
   // try first device in out list
   if (!m_sink && !m_sinkInfoList.empty())
@@ -852,7 +846,7 @@ void CActiveAESink::OpenSink()
       device = driver + ":" + device;
     m_sinkFormat = m_requestedFormat;
     CLog::Log(LOGDEBUG, "CActiveAESink::OpenSink - trying to open device {}", device);
-    m_sink = CAESinkFactory::Create(device, m_sinkFormat);
+    m_sink.reset(CAESinkFactory::Create(device, m_sinkFormat));
   }
 
   if (!m_sink)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -834,7 +834,7 @@ void CActiveAESink::OpenSink()
   // WARNING: this changes format and does not use passthrough
   m_sinkFormat = m_requestedFormat;
   CLog::Log(LOGDEBUG, "CActiveAESink::OpenSink - trying to open device {}", device);
-  m_sink.reset(CAESinkFactory::Create(device, m_sinkFormat));
+  m_sink = CAESinkFactory::Create(device, m_sinkFormat);
 
   // try first device in out list
   if (!m_sink && !m_sinkInfoList.empty())
@@ -846,7 +846,7 @@ void CActiveAESink::OpenSink()
       device = driver + ":" + device;
     m_sinkFormat = m_requestedFormat;
     CLog::Log(LOGDEBUG, "CActiveAESink::OpenSink - trying to open device {}", device);
-    m_sink.reset(CAESinkFactory::Create(device, m_sinkFormat));
+    m_sink = CAESinkFactory::Create(device, m_sinkFormat);
   }
 
   if (!m_sink)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
@@ -17,6 +17,7 @@
 #include "threads/Thread.h"
 #include "utils/ActorProtocol.h"
 
+#include <memory>
 #include <utility>
 
 class CAEBitstreamPacker;
@@ -145,7 +146,7 @@ protected:
   std::string m_deviceFriendlyName;
   std::string m_device;
   std::vector<AE::AESinkInfo> m_sinkInfoList;
-  IAESink *m_sink;
+  std::unique_ptr<IAESink> m_sink;
   AEAudioFormat m_sinkFormat, m_requestedFormat;
   CEngineStats *m_stats;
   float m_volume;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -109,14 +109,13 @@ void CAESinkALSA::Register()
   AE::CAESinkFactory::RegisterSink(entry);
 }
 
-IAESink* CAESinkALSA::Create(std::string &device, AEAudioFormat& desiredFormat)
+std::unique_ptr<IAESink> CAESinkALSA::Create(std::string& device, AEAudioFormat& desiredFormat)
 {
-  IAESink* sink = new CAESinkALSA();
+  auto sink = std::make_unique<CAESinkALSA>();
   if (sink->Initialize(desiredFormat, device))
     return sink;
 
-  delete sink;
-  return nullptr;
+  return {};
 }
 
 inline CAEChannelInfo CAESinkALSA::GetChannelLayoutRaw(const AEAudioFormat& format)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.h
@@ -27,7 +27,7 @@ public:
   ~CAESinkALSA() override;
 
   static void Register();
-  static IAESink* Create(std::string &device, AEAudioFormat &desiredFormat);
+  static std::unique_ptr<IAESink> Create(std::string& device, AEAudioFormat& desiredFormat);
   static void EnumerateDevicesEx(AEDeviceInfoList &list, bool force = false);
   static void Cleanup();
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -968,14 +968,14 @@ void CAESinkAUDIOTRACK::Register()
   AE::CAESinkFactory::RegisterSink(entry);
 }
 
-IAESink* CAESinkAUDIOTRACK::Create(std::string &device, AEAudioFormat& desiredFormat)
+std::unique_ptr<IAESink> CAESinkAUDIOTRACK::Create(std::string& device,
+                                                   AEAudioFormat& desiredFormat)
 {
-  IAESink* sink = new CAESinkAUDIOTRACK();
+  auto sink = std::make_unique<CAESinkAUDIOTRACK>();
   if (sink->Initialize(desiredFormat, device))
     return sink;
 
-  delete sink;
-  return nullptr;
+  return {};
 }
 
 void CAESinkAUDIOTRACK::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -40,7 +40,7 @@ public:
   void Drain() override;
   static void          EnumerateDevicesEx(AEDeviceInfoList &list, bool force = false);
   static void Register();
-  static IAESink* Create(std::string &device, AEAudioFormat &desiredFormat);
+  static std::unique_ptr<IAESink> Create(std::string& device, AEAudioFormat& desiredFormat);
 
 protected:
   static jni::CJNIAudioTrack *CreateAudioTrack(int stream, int sampleRate, int channelMask, int encoding, int bufferSize);

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINIOS.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINIOS.h
@@ -33,7 +33,7 @@ public:
 
   static void Register();
   static void EnumerateDevicesEx(AEDeviceInfoList &list, bool force);
-  static IAESink* Create(std::string &device, AEAudioFormat &desiredFormat);
+  static std::unique_ptr<IAESink> Create(std::string& device, AEAudioFormat& desiredFormat);
 
   bool Initialize(AEAudioFormat& format, std::string& device) override;
   void Deinitialize() override;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINIOS.mm
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINIOS.mm
@@ -598,14 +598,13 @@ void CAESinkDARWINIOS::Register()
   AE::CAESinkFactory::RegisterSink(reg);
 }
 
-IAESink* CAESinkDARWINIOS::Create(std::string &device, AEAudioFormat &desiredFormat)
+std::unique_ptr<IAESink> CAESinkDARWINIOS::Create(std::string& device, AEAudioFormat& desiredFormat)
 {
-  IAESink *sink = new CAESinkDARWINIOS();
+  auto sink = std::make_unique<CAESinkDARWINIOS>();
   if (sink->Initialize(desiredFormat, device))
     return sink;
 
-  delete sink;
-  return nullptr;
+  return {};
 }
 
 bool CAESinkDARWINIOS::Initialize(AEAudioFormat &format, std::string &device)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
@@ -169,14 +169,13 @@ void CAESinkDARWINOSX::Register()
   AE::CAESinkFactory::RegisterSink(reg);
 }
 
-IAESink* CAESinkDARWINOSX::Create(std::string &device, AEAudioFormat &desiredFormat)
+std::unique_ptr<IAESink> CAESinkDARWINOSX::Create(std::string& device, AEAudioFormat& desiredFormat)
 {
-  IAESink *sink = new CAESinkDARWINOSX();
+  auto sink = std::make_unique<CAESinkDARWINOSX>();
   if (sink->Initialize(desiredFormat, device))
     return sink;
 
-  delete sink;
-  return nullptr;
+  return {};
 }
 
 bool CAESinkDARWINOSX::Initialize(AEAudioFormat &format, std::string &device)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.h
@@ -25,7 +25,7 @@ public:
 
   static void Register();
   static void EnumerateDevicesEx(AEDeviceInfoList &list, bool force);
-  static IAESink* Create(std::string &device, AEAudioFormat &desiredFormat);
+  static std::unique_ptr<IAESink> Create(std::string& device, AEAudioFormat& desiredFormat);
 
   bool Initialize(AEAudioFormat& format, std::string& device) override;
   void Deinitialize() override;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINTVOS.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINTVOS.h
@@ -34,7 +34,7 @@ public:
 
   static void Register();
   static void EnumerateDevicesEx(AEDeviceInfoList& list, bool force);
-  static IAESink* Create(std::string& device, AEAudioFormat& desiredFormat);
+  static std::unique_ptr<IAESink> Create(std::string& device, AEAudioFormat& desiredFormat);
 
   bool Initialize(AEAudioFormat& format, std::string& device) override;
   void Deinitialize() override;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINTVOS.mm
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINTVOS.mm
@@ -625,14 +625,14 @@ void CAESinkDARWINTVOS::Register()
   AE::CAESinkFactory::RegisterSink(reg);
 }
 
-IAESink* CAESinkDARWINTVOS::Create(std::string& device, AEAudioFormat& desiredFormat)
+std::unique_ptr<IAESink> CAESinkDARWINTVOS::Create(std::string& device,
+                                                   AEAudioFormat& desiredFormat)
 {
-  IAESink* sink = new CAESinkDARWINTVOS();
+  auto sink = std::make_unique<CAESinkDARWINTVOS>();
   if (sink->Initialize(desiredFormat, device))
     return sink;
 
-  delete sink;
-  return nullptr;
+  return {};
 }
 
 bool CAESinkDARWINTVOS::Initialize(AEAudioFormat& format, std::string& device)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
@@ -109,14 +109,14 @@ void CAESinkDirectSound::Register()
   AE::CAESinkFactory::RegisterSink(reg);
 }
 
-IAESink* CAESinkDirectSound::Create(std::string &device, AEAudioFormat &desiredFormat)
+std::unique_ptr<IAESink> CAESinkDirectSound::Create(std::string& device,
+                                                    AEAudioFormat& desiredFormat)
 {
-  IAESink *sink = new CAESinkDirectSound();
+  auto sink = std::make_unique<CAESinkDirectSound>();
   if (sink->Initialize(desiredFormat, device))
     return sink;
 
-  delete sink;
-  return nullptr;
+  return {};
 }
 
 bool CAESinkDirectSound::Initialize(AEAudioFormat &format, std::string &device)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.h
@@ -27,7 +27,7 @@ public:
   virtual ~CAESinkDirectSound();
 
   static void Register();
-  static IAESink* Create(std::string &device, AEAudioFormat &desiredFormat);
+  static std::unique_ptr<IAESink> Create(std::string& device, AEAudioFormat& desiredFormat);
 
   virtual bool Initialize(AEAudioFormat &format, std::string &device);
   virtual void Deinitialize();

--- a/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp
@@ -71,14 +71,13 @@ void CAESinkOSS::Register()
   AE::CAESinkFactory::RegisterSink(entry);
 }
 
-IAESink* CAESinkOSS::Create(std::string &device, AEAudioFormat& desiredFormat)
+std::unique_ptr<IAESink> CAESinkOSS::Create(std::string& device, AEAudioFormat& desiredFormat)
 {
-  IAESink* sink = new CAESinkOSS();
+  auto sink = std::make_unique<CAESinkOSS>();
   if (sink->Initialize(desiredFormat, device))
     return sink;
 
-  delete sink;
-  return nullptr;
+  return {};
 }
 
 std::string CAESinkOSS::GetDeviceUse(const AEAudioFormat& format, const std::string &device)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkOSS.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkOSS.h
@@ -23,7 +23,7 @@ public:
   ~CAESinkOSS() override;
 
   static void Register();
-  static IAESink* Create(std::string &device, AEAudioFormat &desiredFormat);
+  static std::unique_ptr<IAESink> Create(std::string& device, AEAudioFormat& desiredFormat);
   static void EnumerateDevicesEx(AEDeviceInfoList &list, bool force = false);
 
   bool Initialize(AEAudioFormat &format, std::string &device) override;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -718,14 +718,13 @@ bool CAESinkPULSE::Register()
   return true;
 }
 
-IAESink* CAESinkPULSE::Create(std::string &device, AEAudioFormat& desiredFormat)
+std::unique_ptr<IAESink> CAESinkPULSE::Create(std::string& device, AEAudioFormat& desiredFormat)
 {
-  IAESink* sink = new CAESinkPULSE();
+  auto sink = std::make_unique<CAESinkPULSE>();
   if (sink->Initialize(desiredFormat, device))
     return sink;
 
-  delete sink;
-  return nullptr;
+  return {};
 }
 CAESinkPULSE::CAESinkPULSE()
 {

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
@@ -32,7 +32,7 @@ public:
   ~CAESinkPULSE() override;
 
   static bool Register();
-  static IAESink* Create(std::string &device, AEAudioFormat &desiredFormat);
+  static std::unique_ptr<IAESink> Create(std::string& device, AEAudioFormat& desiredFormat);
   static void EnumerateDevicesEx(AEDeviceInfoList &list, bool force = false);
   static void Cleanup();
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkSNDIO.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkSNDIO.cpp
@@ -155,14 +155,13 @@ void CAESinkSNDIO::Register()
   AE::CAESinkFactory::RegisterSink(entry);
 }
 
-IAESink* CAESinkSNDIO::Create(std::string &device, AEAudioFormat& desiredFormat)
+std::unique_ptr<IAESink> CAESinkSNDIO::Create(std::string& device, AEAudioFormat& desiredFormat)
 {
-  IAESink* sink = new CAESinkSNDIO();
+  auto sink = std::make_unique<CAESinkSNDIO>();
   if (sink->Initialize(desiredFormat, device))
     return sink;
 
-  delete sink;
-  return nullptr;
+  return {};
 }
 
 bool CAESinkSNDIO::Initialize(AEAudioFormat &format, std::string &device)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkSNDIO.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkSNDIO.h
@@ -25,7 +25,7 @@ public:
   ~CAESinkSNDIO() override;
 
   static void Register();
-  static IAESink* Create(std::string &device, AEAudioFormat &desiredFormat);
+  static std::unique_ptr<IAESink> Create(std::string& device, AEAudioFormat& desiredFormat);
   static void EnumerateDevicesEx(AEDeviceInfoList &list, bool force = false);
 
   bool Initialize(AEAudioFormat &format, std::string &device) override;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -70,14 +70,13 @@ void CAESinkWASAPI::Register()
   AE::CAESinkFactory::RegisterSink(reg);
 }
 
-IAESink* CAESinkWASAPI::Create(std::string &device, AEAudioFormat &desiredFormat)
+std::unique_ptr<IAESink> CAESinkWASAPI::Create(std::string& device, AEAudioFormat& desiredFormat)
 {
-  IAESink *sink = new CAESinkWASAPI();
+  auto sink = std::make_unique<CAESinkWASAPI>();
   if (sink->Initialize(desiredFormat, device))
     return sink;
 
-  delete sink;
-  return nullptr;
+  return {};
 }
 
 bool CAESinkWASAPI::Initialize(AEAudioFormat &format, std::string &device)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h
@@ -26,7 +26,7 @@ public:
     virtual ~CAESinkWASAPI();
 
     static void Register();
-    static IAESink* Create(std::string &device, AEAudioFormat &desiredFormat);
+    static std::unique_ptr<IAESink> Create(std::string& device, AEAudioFormat& desiredFormat);
     static void EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool force = false);
 
     // IAESink overrides

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
@@ -109,14 +109,13 @@ void CAESinkXAudio::Register()
   AE::CAESinkFactory::RegisterSink(reg);
 }
 
-IAESink* CAESinkXAudio::Create(std::string &device, AEAudioFormat &desiredFormat)
+std::unique_ptr<IAESink> CAESinkXAudio::Create(std::string& device, AEAudioFormat& desiredFormat)
 {
-  IAESink *sink = new CAESinkXAudio();
+  auto sink = std::make_unique<CAESinkXAudio>();
   if (sink->Initialize(desiredFormat, device))
     return sink;
 
-  delete sink;
-  return nullptr;
+  return {};
 }
 
 bool CAESinkXAudio::Initialize(AEAudioFormat &format, std::string &device)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.h
@@ -31,7 +31,7 @@ public:
     virtual ~CAESinkXAudio();
 
     static void Register();
-    static IAESink* Create(std::string &device, AEAudioFormat &desiredFormat);
+    static std::unique_ptr<IAESink> Create(std::string& device, AEAudioFormat& desiredFormat);
 
     bool Initialize (AEAudioFormat &format, std::string &device) override;
     void Deinitialize() override;

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -287,14 +287,13 @@ bool CAESinkPipewire::Register()
   return true;
 }
 
-IAESink* CAESinkPipewire::Create(std::string& device, AEAudioFormat& desiredFormat)
+std::unique_ptr<IAESink> CAESinkPipewire::Create(std::string& device, AEAudioFormat& desiredFormat)
 {
-  IAESink* sink = new CAESinkPipewire();
+  auto sink = std::make_unique<CAESinkPipewire>();
   if (sink->Initialize(desiredFormat, device))
     return sink;
 
-  delete sink;
-  return nullptr;
+  return {};
 }
 
 void CAESinkPipewire::EnumerateDevicesEx(AEDeviceInfoList& list, bool force)

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.h
@@ -29,7 +29,7 @@ public:
   ~CAESinkPipewire() override = default;
 
   static bool Register();
-  static IAESink* Create(std::string& device, AEAudioFormat& desiredFormat);
+  static std::unique_ptr<IAESink> Create(std::string& device, AEAudioFormat& desiredFormat);
   static void EnumerateDevicesEx(AEDeviceInfoList& list, bool force = false);
   static void Destroy();
 


### PR DESCRIPTION
More smart pointers for AudioEngine. This one is a bit bigger as it changes the registration method to use a unique_ptr as well and I wanted to PR it separately.

So not only is a unique_ptr used for the IAESink member in CActiveAESink but the factory methods also use a unique_ptr all the way through to when the sink is allocated.

I've also added a change to use `using + std::function` instead of `typedef`.

Again, I'm not aware of any issues here, it's just nice to have the use of smart pointers instead of manual new/delete.