### PR TITLE
video: remove ffmpeg bsf hack

### DIFF
--- a/xbmc/cores/FFmpeg.h
+++ b/xbmc/cores/FFmpeg.h
@@ -73,5 +73,4 @@ public:
 };
 
 std::tuple<uint8_t*, int> GetPacketExtradata(const AVPacket* pkt,
-                                             const AVCodecParserContext* parserCtx,
-                                             AVCodecContext* codecCtx);
+                                             const AVCodecParameters* codecPar);

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -162,7 +162,15 @@ bool CDVDDemuxClient::ParsePacket(DemuxPacket* pkt)
     avpkt->size = pkt->iSize;
     avpkt->dts = avpkt->pts = AV_NOPTS_VALUE;
 
-    auto [retExtraData, len] = GetPacketExtradata(avpkt, stream->m_parser, stream->m_context);
+    AVCodecParameters* codecPar = nullptr;
+    int ret = avcodec_parameters_from_context(codecPar, stream->m_context);
+    if (ret < 0)
+    {
+      CLog::LogF(LOGERROR, "avcodec_parameters_from_context failed");
+      return false;
+    }
+
+    auto [retExtraData, len] = GetPacketExtradata(avpkt, codecPar);
     if (len > 0)
     {
       st->changes++;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -2290,8 +2290,7 @@ void CDVDDemuxFFmpeg::ParsePacket(AVPacket* pkt)
         parser->second->m_parserCtx->parser &&
         !st->codecpar->extradata)
     {
-      auto [retExtraData, i] =
-          GetPacketExtradata(pkt, parser->second->m_parserCtx, parser->second->m_codecCtx);
+      auto [retExtraData, i] = GetPacketExtradata(pkt, st->codecpar);
       if (i > 0)
       {
         st->codecpar->extradata_size = i;


### PR DESCRIPTION
Manually setting the codecID on the bsf filter is wrong. `avcodec_parameters_copy` should be used instead.

## Description
I've been looking into ffmpeg bitstream filters (bsf) because of the extraction of closed captions data. While trying to implement a bsf chain (and hitting the wall a couple of times) I've learned a bit about the API. It turns out our current usage of extradata (manually copying the codec id to the filter) is wrong. 

See also: https://stackoverflow.com/questions/65782600/how-do-you-properly-free-a-bitstreamfilter-bsf-without-getting-a-double-free-e
