### PR TITLE
Fix pkgconfig usage

### DIFF
--- a/cmake/modules/FindSmbClient.cmake
+++ b/cmake/modules/FindSmbClient.cmake
@@ -14,7 +14,7 @@
 #
 #   SmbClient::SmbClient   - The SmbClient library
 
-if(PKGCONFIG_FOUND)
+if(PKG_CONFIG_FOUND)
   pkg_check_modules(PC_SMBCLIENT smbclient QUIET)
 endif()
 


### PR DESCRIPTION
All other modules use the underscore separator, looks like a typo.

## Description
missing underscore separator at the pkgconfig check

## Motivation and context
Just noticed that typo and wanted to fix it

## How has this been tested?
Tested locally

## What is the effect on users?
Should have no impact except using the proper libraries available

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
