### PR TITLE
[Windows] use the the display's friendly name when available

### DIFF
--- a/xbmc/platform/win32/WIN32Util.h
+++ b/xbmc/platform/win32/WIN32Util.h
@@ -82,4 +82,5 @@ public:
   static void PlatformSyslog();
 
   static VideoDriverInfo GetVideoDriverInfo(const UINT vendorId, const std::wstring& driverDesc);
+  static std::wstring GetDisplayFriendlyName(const std::wstring& GdiDeviceName);
 };

--- a/xbmc/windowing/windows/WinSystemWin32.h
+++ b/xbmc/windowing/windows/WinSystemWin32.h
@@ -68,6 +68,7 @@ struct MONITOR_DETAILS
   std::wstring MonitorNameW;
   std::wstring CardNameW;
   std::wstring DeviceNameW;
+  std::wstring DeviceStringW; // GDI device, for migration of the monitor setting from Kodi < 21
 };
 
 class CIRServerSuite;


### PR DESCRIPTION
## Description
Show the screen's friendly name in Settings>System>Display instead of "Generic PnP Monitor" when available.

The API has been available since Windows 7, and in case of problem or missing name from EDID the code falls back to "Generic PnP Monitor" names.

I'm not familiar with the Windows Store version and left it unimplemented. Maybe there's no need as that environment is more modern.

Commit 1 enumerates the screens with the new names, but they're not recognized by Kodi's settings on startup and a default "Generic PnP Monitor #1" entry is automatically added to the list of screen and selected, until the user changes the screen.

Commit 2 matches the existing setting value with new style name or old style name and going to settings after startup shows the new name. The new name is not saved until leaving the settings or closing Kodi, but bypassing settings update logic in order to write immediately to guisettings.xml may not be a good idea, as the mode and resolution settings depend on the screen.

Without the
` if (!m_hWnd)
    return true;`
in CWinSystemWin32::SetFullScreen, an exception is thrown during startup in the RenderSystemDX that's not initialized yet at the time the settings propagate the new screen setting.

## Motivation and context
Use in Kodi the nice screen names displayed in the settings of Windows 10 (for example, LG TV instead of Generic PnP Monitor).

Some screens already have a proper name without this patch, not sure why. More info available with DP than with HDMI? Installing a driver for the screen provides a name that the GDI APIs can use?

## How has this been tested?
Windows 10 with 2 screens, one of which used to show as Generic PnP Monitor.
Tested the migration from gdi-style names in guisettings.xml in a multi-monitor setup to confirm.

## What is the effect on users?

Without the second part there is an impact on users with multiple screens as Kodi starts on the desktop's primary screen the first time, until the setting is changed in Kodi.

<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

I tried including before/after screenshots, not sure how to insert images here, so here is the ASCII version :-)

Before: 
`Monitor          Generic PnP Monitor #1`

After:
`Monitor:          LG TV #1`

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
