### PR TITLE
Bump Android SDK 33

### DIFF
--- a/cmake/platform/android/android.cmake
+++ b/cmake/platform/android/android.cmake
@@ -2,6 +2,6 @@ set(PLATFORM_REQUIRED_DEPS LibAndroidJNI OpenGLES EGL LibZip)
 set(APP_RENDER_SYSTEM gles)
 
 # Store SDK compile version
-set(TARGET_SDK 31)
+set(TARGET_SDK 33)
 # Minimum supported SDK version
 set(TARGET_MINSDK 21)

--- a/docs/README.Android.md
+++ b/docs/README.Android.md
@@ -80,12 +80,12 @@ Create needed directories:
 mkdir -p $HOME/android-tools/android-sdk-linux/cmdline-tools
 ```
 
-Extract Android SDK:
+Extract Android SDK Command line tools:
 ```
 unzip $HOME/Downloads/commandlinetools-linux-6200805_latest.zip -d $HOME/android-tools/android-sdk-linux/cmdline-tools
 ```
 
-**NOTE:** Since we're using the latest SDK available, filename can change over time. Adapt the `unzip` command accordingly.
+**NOTE:** Since we're using the latest SDK Command line tools available, filename can change over time. Adapt the `unzip` command accordingly.
 
 Extract Android NDK:
 ```
@@ -98,8 +98,8 @@ Before Android SDK can be used, you need to accept the licenses and configure it
 cd $HOME/android-tools/android-sdk-linux/cmdline-tools/tools/bin
 ./sdkmanager --sdk_root=$(pwd)/../.. --licenses
 ./sdkmanager --sdk_root=$(pwd)/../.. platform-tools
-./sdkmanager --sdk_root=$(pwd)/../.. "platforms;android-28"
-./sdkmanager --sdk_root=$(pwd)/../.. "build-tools;28.0.3"
+./sdkmanager --sdk_root=$(pwd)/../.. "platforms;android-33"
+./sdkmanager --sdk_root=$(pwd)/../.. "build-tools;30.0.3"
 ```
 
 ### 3.3. Create a key to sign debug APKs


### PR DESCRIPTION
## Description
Bump Android SDK to API level 33 (Android 13).

Review the behavior changes and aside from the necessary Gradle update (#22687) Kodi is not affected.

## How has this been tested?
Tested several days on Android TV 9 and it works fine.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
