### PR TITLE
[GUI][GUIInfoLabel] Add support for complex expressions on the fallba…

### DIFF
--- a/xbmc/guilib/guiinfo/GUIInfoLabel.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoLabel.cpp
@@ -35,82 +35,134 @@ int CGUIInfoLabel::GetIntValue(int contextWindow) const
 
 void CGUIInfoLabel::SetLabel(const std::string &label, const std::string &fallback, int context /*= 0*/)
 {
+  Parse(label, m_infoLabel, context);
+  Parse(fallback, m_infoFallback, context);
   m_fallback = fallback;
-  Parse(label, context);
 }
 
-const std::string &CGUIInfoLabel::GetLabel(int contextWindow, bool preferImage, std::string *fallback /*= NULL*/) const
+bool CGUIInfoLabel::LabelNeedsUpdate(int context,
+                                     bool preferImages,
+                                     std::string* fallback,
+                                     const std::vector<CInfoPortion>& infoPortion) const
 {
-  bool needsUpdate = m_dirty;
-  if (!m_info.empty())
+  bool needsUpdate{false};
+  CGUIInfoManager& infoMgr = CServiceBroker::GetGUI()->GetInfoManager();
+  for (const auto& portion : infoPortion)
   {
-    CGUIInfoManager& infoMgr = CServiceBroker::GetGUI()->GetInfoManager();
-    for (const auto &portion : m_info)
+    if (portion.m_info)
     {
-      if (portion.m_info)
-      {
-        std::string infoLabel;
-        if (preferImage)
-          infoLabel = infoMgr.GetImage(portion.m_info, contextWindow, fallback);
-        if (infoLabel.empty())
-          infoLabel = infoMgr.GetLabel(portion.m_info, contextWindow, fallback);
-        needsUpdate |= portion.NeedsUpdate(infoLabel);
-      }
+      std::string infoLabel;
+      if (preferImages)
+        infoLabel = infoMgr.GetImage(portion.m_info, context, fallback);
+      if (infoLabel.empty())
+        infoLabel = infoMgr.GetLabel(portion.m_info, context, fallback);
+      needsUpdate |= portion.NeedsUpdate(infoLabel);
     }
   }
+  return needsUpdate;
+}
+
+const std::string& CGUIInfoLabel::GetLabel(int contextWindow,
+                                           bool preferImage,
+                                           std::string* fallback /*= NULL*/) const
+{
+  bool needsUpdate = m_dirty;
+  if (!m_infoLabel.empty())
+  {
+    needsUpdate |= LabelNeedsUpdate(contextWindow, preferImage, fallback, m_infoLabel);
+  }
   else
+  {
     needsUpdate = !m_label.empty();
+  }
+
+  if (!m_infoFallback.empty())
+  {
+    needsUpdate |=
+        LabelNeedsUpdate(contextWindow, preferImage, fallback, m_infoFallback) && m_label.empty();
+  }
 
   return CacheLabel(needsUpdate);
 }
 
-const std::string &CGUIInfoLabel::GetItemLabel(const CGUIListItem *item, bool preferImages, std::string *fallback /*= NULL*/) const
+bool CGUIInfoLabel::ItemLabelNeedsUpdate(const CGUIListItem* item,
+                                         bool preferImages,
+                                         std::string* fallback,
+                                         const std::vector<CInfoPortion>& infoPortion) const
 {
-  bool needsUpdate = m_dirty;
-  if (item->IsFileItem() && !m_info.empty())
+  bool needsUpdate{false};
+  CGUIInfoManager& infoMgr = CServiceBroker::GetGUI()->GetInfoManager();
+  for (const auto& portion : infoPortion)
   {
-    CGUIInfoManager& infoMgr = CServiceBroker::GetGUI()->GetInfoManager();
-    for (const auto &portion : m_info)
+    if (portion.m_info)
     {
-      if (portion.m_info)
-      {
-        std::string infoLabel;
-        if (preferImages)
-          infoLabel = infoMgr.GetItemImage(item, 0, portion.m_info, fallback);
-        else
-          infoLabel = infoMgr.GetItemLabel(static_cast<const CFileItem *>(item), 0, portion.m_info, fallback);
-        needsUpdate |= portion.NeedsUpdate(infoLabel);
-      }
+      std::string infoLabel;
+      if (preferImages)
+        infoLabel = infoMgr.GetItemImage(item, 0, portion.m_info, fallback);
+      else
+        infoLabel =
+            infoMgr.GetItemLabel(static_cast<const CFileItem*>(item), 0, portion.m_info, fallback);
+      needsUpdate |= portion.NeedsUpdate(infoLabel);
     }
   }
+  return needsUpdate;
+}
+
+const std::string& CGUIInfoLabel::GetItemLabel(const CGUIListItem* item,
+                                               bool preferImages,
+                                               std::string* fallback /*= nullptr */) const
+{
+  bool needsUpdate = m_dirty;
+  if (item->IsFileItem())
+  {
+    if (!m_infoLabel.empty())
+      needsUpdate |= ItemLabelNeedsUpdate(item, preferImages, fallback, m_infoLabel);
+
+    if (!m_infoFallback.empty())
+      needsUpdate |= ItemLabelNeedsUpdate(item, preferImages, fallback, m_infoFallback);
+  }
   else
+  {
     needsUpdate = !m_label.empty();
+  }
 
   return CacheLabel(needsUpdate);
+}
+
+void CGUIInfoLabel::RebuildLabel(std::string& label,
+                                 const std::vector<CInfoPortion>& infoPortion) const
+{
+  label.clear();
+  for (const auto& portion : infoPortion)
+  {
+    label += portion.Get();
+  }
 }
 
 const std::string &CGUIInfoLabel::CacheLabel(bool rebuild) const
 {
   if (rebuild)
   {
-    m_label.clear();
-    for (const auto &portion : m_info)
-      m_label += portion.Get();
+    RebuildLabel(m_label, m_infoLabel);
+    RebuildLabel(m_fallback, m_infoFallback);
     m_dirty = false;
   }
   if (m_label.empty())  // empty label, use the fallback
+  {
     return m_fallback;
+  }
+
   return m_label;
 }
 
 bool CGUIInfoLabel::IsEmpty() const
 {
-  return m_info.empty();
+  return m_infoLabel.empty();
 }
 
 bool CGUIInfoLabel::IsConstant() const
 {
-  return m_info.empty() || (m_info.size() == 1 && m_info[0].m_info == 0);
+  return m_infoLabel.empty() || (m_infoLabel.size() == 1 && m_infoLabel[0].m_info == 0);
 }
 
 bool CGUIInfoLabel::ReplaceSpecialKeywordReferences(const std::string &strInput, const std::string &strKeyword, const StringReplacerFunc &func, std::string &strOutput)
@@ -210,9 +262,11 @@ const static infoformat infoformatmap[] = {{ "$INFO[",    FORMATINFO},
                                            { "$VAR[",     FORMATVAR},
                                            { "$ESCVAR[",  FORMATESCVAR}};
 
-void CGUIInfoLabel::Parse(const std::string &label, int context)
+void CGUIInfoLabel::Parse(const std::string& label,
+                          std::vector<CInfoPortion>& infoPortion,
+                          int context)
 {
-  m_info.clear();
+  infoPortion.clear();
   m_dirty = true;
   // Step 1: Replace all $LOCALIZE[number] with the real string
   std::string work = ReplaceLocalize(label);
@@ -240,7 +294,7 @@ void CGUIInfoLabel::Parse(const std::string &label, int context)
     if (format != NONE)
     {
       if (pos1 > 0)
-        m_info.emplace_back(0, work.substr(0, pos1), "");
+        infoPortion.emplace_back(0, work.substr(0, pos1), "");
 
       pos2 = StringUtils::FindEndBracket(work, '[', ']', pos1 + len);
       if (pos2 != std::string::npos)
@@ -267,7 +321,8 @@ void CGUIInfoLabel::Parse(const std::string &label, int context)
             prefix = params[1];
           if (params.size() > 2)
             postfix = params[2];
-          m_info.emplace_back(info, prefix, postfix, format == FORMATESCINFO || format == FORMATESCVAR);
+          infoPortion.emplace_back(info, prefix, postfix,
+                                   format == FORMATESCINFO || format == FORMATESCVAR);
         }
         // and delete it from our work string
         work.erase(0, pos2 + 1);
@@ -282,7 +337,7 @@ void CGUIInfoLabel::Parse(const std::string &label, int context)
   while (format != NONE);
 
   if (!work.empty())
-    m_info.emplace_back(0, work, "");
+    infoPortion.emplace_back(0, work, "");
 }
 
 CGUIInfoLabel::CInfoPortion::CInfoPortion(int info, const std::string &prefix, const std::string &postfix, bool escaped /*= false */):


### PR DESCRIPTION
…ck label

## Description
Currently fallback labels cannot use complex expressions like the combination of infolabels or simple localized strings. This PR improves the status by unifying the logic of the main label and the fallback label (all elements supported in label are now available to the fallback as well).

Closes https://github.com/xbmc/xbmc/issues/22728

@scott967 can you runtime test if this solves your needs?