### PR TITLE
Pipewire: add factory Create method

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -253,27 +253,9 @@ std::unique_ptr<PIPEWIRE::CPipewire> pipewire;
 
 bool CAESinkPipewire::Register()
 {
-  pipewire = std::make_unique<PIPEWIRE::CPipewire>();
-
-  bool success{false};
-
-  try
-  {
-    success = pipewire->Start();
-  }
-  catch (std::exception& e)
-  {
-    success = false;
-  }
-
-  if (!success)
-  {
-    CLog::Log(LOGERROR, "CAESinkPipewire::{} - failed to connect to server", __FUNCTION__);
-    pipewire.reset();
+  pipewire = PIPEWIRE::CPipewire::Create();
+  if (!pipewire)
     return false;
-  }
-
-  CLog::Log(LOGINFO, "CAESinkPipewire::{} - connected to server", __FUNCTION__);
 
   AE::AESinkRegEntry entry;
   entry.sinkName = "PIPEWIRE";

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
@@ -78,8 +78,7 @@ bool CPipewire::Start()
 
   if (ret == -ETIMEDOUT)
   {
-    CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - timed out out waiting for synchronization",
-              __FUNCTION__);
+    CLog::Log(LOGDEBUG, "Pipewire: timed out out waiting for synchronization");
     return false;
   }
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
@@ -75,3 +75,28 @@ bool CPipewire::Start()
 
   return true;
 }
+
+std::unique_ptr<CPipewire> CPipewire::Create()
+{
+  struct PipewireMaker : public CPipewire
+  {
+    using CPipewire::CPipewire;
+  };
+
+  auto pipewire = std::make_unique<PipewireMaker>();
+
+  try
+  {
+    if (!pipewire->Start())
+      return {};
+  }
+  catch (std::exception& e)
+  {
+    CLog::Log(LOGERROR, "Pipewire: failed to connect to server");
+    return {};
+  }
+
+  CLog::Log(LOGINFO, "Pipewire: connected to server");
+
+  return pipewire;
+}

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
@@ -56,7 +56,17 @@ bool CPipewire::Start()
     return false;
   }
 
-  m_core = std::make_unique<CPipewireCore>(*m_context);
+  try
+  {
+    m_core = std::make_unique<CPipewireCore>(*m_context);
+  }
+  catch (std::exception& e)
+  {
+    CLog::Log(LOGERROR, "Pipewire: failed to connect to server");
+    return false;
+  }
+
+  CLog::Log(LOGINFO, "Pipewire: connected to server");
 
   m_registry = std::make_unique<CPipewireRegistry>(*m_core);
 
@@ -85,18 +95,8 @@ std::unique_ptr<CPipewire> CPipewire::Create()
 
   auto pipewire = std::make_unique<PipewireMaker>();
 
-  try
-  {
-    if (!pipewire->Start())
-      return {};
-  }
-  catch (std::exception& e)
-  {
-    CLog::Log(LOGERROR, "Pipewire: failed to connect to server");
+  if (!pipewire->Start())
     return {};
-  }
-
-  CLog::Log(LOGINFO, "Pipewire: connected to server");
 
   return pipewire;
 }

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.h
@@ -23,7 +23,8 @@ class CPipewireRegistry;
 class CPipewire
 {
 public:
-  CPipewire();
+  static std::unique_ptr<CPipewire> Create();
+
   ~CPipewire();
 
   bool Start();
@@ -34,6 +35,8 @@ public:
   CPipewireRegistry& GetRegistry() { return *m_registry; }
 
 private:
+  CPipewire();
+
   std::unique_ptr<CPipewireThreadLoop> m_loop;
   std::unique_ptr<CPipewireContext> m_context;
   std::unique_ptr<CPipewireCore> m_core;


### PR DESCRIPTION
Currently pipewire is tied to `CAESinkPipewire` in AudioEngine. This PR breaks that tie and allows a new pipewire instance to be created through the new `CPipewire::Create()` factory method. This will be useful in the future if we have multiple instances of pipewire running.

This also moves the try/catch to be more specific about where we throw (we really only expect it to happen when connecting to the pipewire server.

The only gotcha that I see is `pw_deinit` as the docs state:
> Before 0.3.49 this function can only be called once after which the pipewire library can not be used again. This is usually called by test programs to check for memory leaks.

> Since 0.3.49 this function must be paired with an equal amount of [pw_init()](https://docs.pipewire.org/group__pw__pipewire.html#ga06c879b2d800579f4724109054368d99) calls to deinitialize the PipeWire library. The PipeWire library can be used again after being deinitialized with a new [pw_init()](https://docs.pipewire.org/group__pw__pipewire.html#ga06c879b2d800579f4724109054368d99) call.

ref: https://docs.pipewire.org/group__pw__pipewire.html#gafa6045cd7391b467af4575c6752d6c4e


Currently we only have once pipewire instance so this shouldn't matter but if we add more we should bump the minimum pipewire version to `0.3.49`