### PR TITLE
[clang-tidy] fix performance-* warnings

### DIFF
--- a/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
@@ -205,8 +205,7 @@ std::unique_ptr<ISavestate> CSavestateDatabase::RenameSavestate(const std::strin
 
   newSavestate->Finalize();
 
-  std::string path = savestatePath;
-  if (!AddSavestate(path, "", *newSavestate))
+  if (!AddSavestate(savestatePath, "", *newSavestate))
     return {};
 
   return newSavestate;

--- a/xbmc/cores/VideoPlayer/DVDOverlayContainer.cpp
+++ b/xbmc/cores/VideoPlayer/DVDOverlayContainer.cpp
@@ -19,7 +19,7 @@ CDVDOverlayContainer::~CDVDOverlayContainer()
   Clear();
 }
 
-void CDVDOverlayContainer::ProcessAndAddOverlayIfValid(std::shared_ptr<CDVDOverlay> pOverlay)
+void CDVDOverlayContainer::ProcessAndAddOverlayIfValid(const std::shared_ptr<CDVDOverlay>& pOverlay)
 {
   std::unique_lock<CCriticalSection> lock(*this);
 

--- a/xbmc/cores/VideoPlayer/DVDOverlayContainer.h
+++ b/xbmc/cores/VideoPlayer/DVDOverlayContainer.h
@@ -33,7 +33,7 @@ public:
   *
   * \param pPicture pointer to the overlay to be evaluated and possibly added to the collection
   */
-  void ProcessAndAddOverlayIfValid(std::shared_ptr<CDVDOverlay> pPicture);
+  void ProcessAndAddOverlayIfValid(const std::shared_ptr<CDVDOverlay>& pPicture);
 
   VecOverlays* GetOverlays(); // get the first overlay in this fifo
   bool ContainsOverlayType(DVDOverlayType type);

--- a/xbmc/favourites/FavouritesUtils.cpp
+++ b/xbmc/favourites/FavouritesUtils.cpp
@@ -84,13 +84,13 @@ bool MoveItem(CFileItemList& items, const std::shared_ptr<CFileItem>& item, int 
   int nextItem = (itemPos + amount) % items.Size();
   if (nextItem < 0)
   {
-    const auto itemToAdd(item);
+    const auto& itemToAdd(item);
     items.Remove(itemPos);
     items.Add(itemToAdd);
   }
   else if (nextItem == 0)
   {
-    const auto itemToAdd(item);
+    const auto& itemToAdd(item);
     items.Remove(itemPos);
     items.AddFront(itemToAdd, 0);
   }

--- a/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
+++ b/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
@@ -64,7 +64,7 @@ bool CDialogInGameSaves::OnMessage(CGUIMessage& message)
 
         if (!itemPath.empty())
         {
-          OnItemRefresh(itemPath, std::move(itemInfo));
+          OnItemRefresh(itemPath, itemInfo);
         }
         else
         {
@@ -127,7 +127,7 @@ unsigned int CDialogInGameSaves::GetFocusedItem() const
 void CDialogInGameSaves::OnItemRefresh(const std::string& itemPath, const CGUIListItemPtr& itemInfo)
 {
   // Turn the message params into a savestate item
-  CFileItemPtr item = TranslateMessageItem(itemPath, std::move(itemInfo));
+  CFileItemPtr item = TranslateMessageItem(itemPath, itemInfo);
   if (item)
   {
     // Look up existing savestate by path
@@ -137,9 +137,9 @@ void CDialogInGameSaves::OnItemRefresh(const std::string& itemPath, const CGUILi
 
     // Update savestate or add a new one
     if (it != m_savestateItems.cend())
-      **it = std::move(*item);
+      **it = *item;
     else
-      m_savestateItems.AddFront(std::move(item), 0);
+      m_savestateItems.AddFront(item, 0);
 
     RefreshList();
   }

--- a/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
+++ b/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
@@ -124,7 +124,7 @@ unsigned int CDialogInGameSaves::GetFocusedItem() const
   return m_focusedControl;
 }
 
-void CDialogInGameSaves::OnItemRefresh(const std::string& itemPath, CGUIListItemPtr itemInfo)
+void CDialogInGameSaves::OnItemRefresh(const std::string& itemPath, const CGUIListItemPtr& itemInfo)
 {
   // Turn the message params into a savestate item
   CFileItemPtr item = TranslateMessageItem(itemPath, std::move(itemInfo));
@@ -377,7 +377,7 @@ void CDialogInGameSaves::OnDelete(CFileItem& focusedItem)
 }
 
 CFileItemPtr CDialogInGameSaves::TranslateMessageItem(const std::string& messagePath,
-                                                      CGUIListItemPtr messageItem)
+                                                      const CGUIListItemPtr& messageItem)
 {
   CFileItemPtr item;
 

--- a/xbmc/games/dialogs/osd/DialogInGameSaves.h
+++ b/xbmc/games/dialogs/osd/DialogInGameSaves.h
@@ -49,7 +49,7 @@ protected:
 
 private:
   void InitSavedGames();
-  void OnItemRefresh(const std::string& itemPath, CGUIListItemPtr itemInfo);
+  void OnItemRefresh(const std::string& itemPath, const CGUIListItemPtr& itemInfo);
 
   /*!
    * \brief Translates the GUI list item received in a GUI message into a
@@ -69,7 +69,7 @@ private:
    *         can be obtained
    */
   static CFileItemPtr TranslateMessageItem(const std::string& messagePath,
-                                           CGUIListItemPtr messageItem);
+                                           const CGUIListItemPtr& messageItem);
 
   CFileItemList m_savestateItems;
   const CFileItemPtr m_newSaveItem;


### PR DESCRIPTION
## Description
fix performance-* clang-tidy warnings

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed