### PR TITLE
DecoderFilterManager: fix comparison operator for height validity check

### DIFF
--- a/xbmc/media/decoderfilter/DecoderFilterManager.cpp
+++ b/xbmc/media/decoderfilter/DecoderFilterManager.cpp
@@ -54,7 +54,7 @@ bool CDecoderFilter::isValid(const CDVDStreamInfo& streamInfo) const
     return false;
 
   // remove codec pitch for comparison
-  if (m_minHeight && (streamInfo.height & ~31) <= m_minHeight)
+  if (m_minHeight && (streamInfo.height & ~31) < m_minHeight)
     return false;
 
   return true;


### PR DESCRIPTION
## Description
Comparison operator of `<=` in `CDecoderFilter::isValid()` should be `<`:

```diff
 bool CDecoderFilter::isValid(const CDVDStreamInfo& streamInfo) const
 {
   uint32_t flags = FLAG_GENERAL_ALLOWED; 

   if (streamInfo.stills)
     flags |= FLAG_STILLS_ALLOWED;
 
   if (streamInfo.dvd)
     flags |= FLAG_DVD_ALLOWED;
 
   if ((flags & m_flags) != flags)
     return false;
 
   // remove codec pitch for comparison
-  if (m_minHeight && (streamInfo.height & ~31) <= m_minHeight)
+  if (m_minHeight && (streamInfo.height & ~31) < m_minHeight)
     return false;
 
   return true;
 }
```

As `m_minHeight` represents the minimum _valid_ height the filter should allow, and the conditional check returns false if the condition is true. So an equal minHeight is valid and should fail the conditional check.

## Motivation and context
Currently, only the Android platform uses the DecoderFilterManager. When this function first appeared in #15744, the only decoder filters were instantiated with a min height of 0 so this wasn't exposed. When #17121 added some filters that had a min height of 720, this path started to be used in practice.

I noticed that a live tv stream I was watching at 720p on my nvidia shield had some audio stuttering. I looked into it and realized that it was using the software decoder/upscaler, but the 1080i streams were correctly using the hardware decoder. The 2019 shield pro has a really good upscaler that only works when the hardware decoder is in use.

## How has this been tested?
I changed my decoderfilter.xml file to a min-height of 719 for the mpeg2v decoder and verified that the 720p stream did in fact start using the hardware decoder.

## What is the effect on users?
720p mpeg4, mpeg2, and h263 content on Android will now use the hardware decoder by default

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
