### PR TITLE
[pvr] Always retirieve the max DB ID for providers when reading them from the DB

### DIFF
--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -478,6 +478,14 @@ bool CPVRDatabase::Get(CPVRProviders& results,
   return bReturn;
 }
 
+int CPVRDatabase::GetMaxProviderId()
+{
+  std::string strQuery = PrepareSQL("SELECT max(idProvider) as maxProviderId from providers");
+  std::unique_lock<CCriticalSection> lock(m_critSection);
+
+  return GetSingleValueInt(strQuery);
+}
+
 /********** Channel methods **********/
 
 int CPVRDatabase::Get(bool bRadio,

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -183,6 +183,12 @@ namespace PVR
      */
     bool Get(CPVRProviders& results, const std::vector<std::shared_ptr<CPVRClient>>& clients) const;
 
+    /*!
+     * @brief Get the maximum provider id in the database
+     * @return The maximum provider id in the database
+     */
+    int GetMaxProviderId();
+
     //@}
 
     /*! @name Channel group methods */

--- a/xbmc/pvr/providers/PVRProviders.cpp
+++ b/xbmc/pvr/providers/PVRProviders.cpp
@@ -105,6 +105,8 @@ bool CPVRProviders::LoadFromDatabase(const std::vector<std::shared_ptr<CPVRClien
   const std::shared_ptr<CPVRDatabase> database = CServiceBroker::GetPVRManager().GetTVDatabase();
   if (database)
   {
+    m_iLastId = database->GetMaxProviderId();
+
     CPVRProviders providers;
     database->Get(providers, clients);
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

When loading providers from the DB only the active providers are loaded. The consequence of this is that we don't have awareness of the max database ID used. 

Without retrieving this value it is possible we attempt to add a new provider that would fail the DB constraint.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

On Mac, with pvr.vbox, pvr.iptvsimple and pvr.vuplus

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
