### PR TITLE
[macos][nativewindowing] Improvements for multi-screen setups

### DIFF
--- a/system/settings/darwin_osx.xml
+++ b/system/settings/darwin_osx.xml
@@ -9,4 +9,19 @@
       </group>
     </category>
   </section>
+  <section id="interface" label="14206" help="38102">
+    <category id="window" label="0" help="36135">
+      <visible>false</visible>
+      <group id="1">
+        <setting id="window.top" type="integer" label="0" help="36136">
+          <level>4</level>
+          <default>0</default>
+        </setting>
+        <setting id="window.left" type="integer" label="0" help="36136">
+          <level>4</level>
+          <default>0</default>
+        </setting>
+      </group>
+    </category>
+  </section>
 </settings>

--- a/xbmc/windowing/osx/OpenGL/OSXGLWindow.mm
+++ b/xbmc/windowing/osx/OpenGL/OSXGLWindow.mm
@@ -64,19 +64,17 @@
 
 - (void)windowDidMove:(NSNotification*)aNotification
 {
-  NSOpenGLContext* context = NSOpenGLContext.currentContext;
-  if (context)
+  if (self.contentView)
   {
-    if (context.view)
+    NSPoint window_origin = [self.contentView frame].origin;
+    XBMC_Event newEvent = {};
+    newEvent.type = XBMC_VIDEOMOVE;
+    newEvent.move.x = window_origin.x;
+    newEvent.move.y = window_origin.y;
+    std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+    if (appPort)
     {
-      NSPoint window_origin = [[[context view] window] frame].origin;
-      XBMC_Event newEvent = {};
-      newEvent.type = XBMC_VIDEOMOVE;
-      newEvent.move.x = window_origin.x;
-      newEvent.move.y = window_origin.y;
-      std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
-      if (appPort)
-        appPort->OnEvent(newEvent);
+      appPort->OnEvent(newEvent);
     }
   }
 }

--- a/xbmc/windowing/osx/OpenGL/OSXGLWindow.mm
+++ b/xbmc/windowing/osx/OpenGL/OSXGLWindow.mm
@@ -136,10 +136,11 @@
 
 - (void)windowDidChangeScreen:(NSNotification*)notification
 {
-  // user has moved the window to a
-  // different screen
-  //  if (CServiceBroker::GetWinSystem()->IsFullScreen())
-  //    CServiceBroker::GetWinSystem()->SetMovedToOtherScreen(true);
+  // user has moved the window to a different screen
+  CWinSystemOSX* winSystem = dynamic_cast<CWinSystemOSX*>(CServiceBroker::GetWinSystem());
+  if (!winSystem)
+    return;
+  winSystem->WindowChangedScreen();
 }
 
 - (NSSize)windowWillResize:(NSWindow*)sender toSize:(NSSize)frameSize

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -58,13 +58,15 @@ using namespace MESSAGING;
 using namespace WINDOWING;
 using namespace std::chrono_literals;
 
-#define MAX_DISPLAYS 32
-#define DEFAULT_SCREEN_NAME @"Default"
-
+namespace
+{
+constexpr int MAX_DISPLAYS = 32;
+constexpr const char* DEFAULT_SCREEN_NAME = "Default";
 //! MacOS specific window top position setting
-#define SETTING_WINDOW_TOP @"window.top"
+constexpr const char* SETTING_WINDOW_TOP = "window.top";
 //! MacOS specific window left position setting
-#define SETTING_WINDOW_LEFT @"window.left"
+constexpr const char* SETTING_WINDOW_LEFT = "window.left";
+} // namespace
 
 static NSWindow* blankingWindows[MAX_DISPLAYS];
 
@@ -159,7 +161,7 @@ NSString* screenNameForDisplay(NSUInteger screenIdx)
   // screen id 0 is always called "Default"
   if (screenIdx == 0)
   {
-    return DEFAULT_SCREEN_NAME;
+    return @(DEFAULT_SCREEN_NAME);
   }
 
   const CGDirectDisplayID displayID = GetDisplayID(screenIdx);
@@ -719,8 +721,8 @@ bool CWinSystemOSX::CreateNewWindow(const std::string& name, bool fullScreen, RE
       else
       {
         // if there are stored window positions use that as the origin point
-        const int top = settings->GetInt(SETTING_WINDOW_TOP.UTF8String);
-        const int left = settings->GetInt(SETTING_WINDOW_LEFT.UTF8String);
+        const int top = settings->GetInt(SETTING_WINDOW_TOP);
+        const int left = settings->GetInt(SETTING_WINDOW_LEFT);
 
         NSPoint windowPos;
         if (top != 0 || left != 0)
@@ -1251,8 +1253,8 @@ void CWinSystemOSX::OnMove(int x, int y)
   if (!m_bFullScreen)
   {
     dispatch_sync(dispatch_get_main_queue(), ^{
-      settings->SetInt(SETTING_WINDOW_LEFT.UTF8String, m_appWindow.frame.origin.x);
-      settings->SetInt(SETTING_WINDOW_TOP.UTF8String, m_appWindow.frame.origin.y);
+      settings->SetInt(SETTING_WINDOW_LEFT, m_appWindow.frame.origin.x);
+      settings->SetInt(SETTING_WINDOW_TOP, m_appWindow.frame.origin.y);
       settings->Save();
     });
   }
@@ -1314,7 +1316,7 @@ std::unique_ptr<CVideoSync> CWinSystemOSX::GetVideoSync(void* clock)
 std::vector<std::string> CWinSystemOSX::GetConnectedOutputs()
 {
   std::vector<std::string> outputs;
-  outputs.push_back(DEFAULT_SCREEN_NAME.UTF8String);
+  outputs.push_back(DEFAULT_SCREEN_NAME);
 
   // screen 0 is always the "Default" setting, avoid duplicating the available
   // screens here.

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -667,7 +667,11 @@ bool CWinSystemOSX::CreateNewWindow(const std::string& name, bool fullScreen, RE
   // screen index is not found/available.
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
   m_lastDisplayNr = GetDisplayIndex(settings->GetString(CSettings::SETTING_VIDEOSCREEN_MONITOR));
-  NSScreen* screen = [NSScreen.screens objectAtIndex:m_lastDisplayNr];
+  NSScreen* screen = nil;
+  if (m_lastDisplayNr < NSScreen.screens.count)
+  {
+    screen = [NSScreen.screens objectAtIndex:m_lastDisplayNr];
+  }
 
   // force initial window creation to be windowed, if fullscreen, it will switch to it below
   // fixes the white screen of death if starting fullscreen and switching to windowed.
@@ -714,29 +718,32 @@ bool CWinSystemOSX::CreateNewWindow(const std::string& name, bool fullScreen, RE
       [appWindow setContentView:view];
 
       // set the window to the appropriate screen and screen position
-      if (m_bFullScreen)
+      if (screen)
       {
-        [appWindow setFrameOrigin:screen.frame.origin];
-      }
-      else
-      {
-        // if there are stored window positions use that as the origin point
-        const int top = settings->GetInt(SETTING_WINDOW_TOP);
-        const int left = settings->GetInt(SETTING_WINDOW_LEFT);
-
-        NSPoint windowPos;
-        if (top != 0 || left != 0)
+        if (m_bFullScreen)
         {
-          windowPos = NSMakePoint(left, top);
+          [appWindow setFrameOrigin:screen.frame.origin];
         }
         else
         {
-          // otherwise center the window on the screen
-          windowPos =
-              NSMakePoint(screen.frame.origin.x + screen.frame.size.width / 2 - m_nWidth / 2,
-                          screen.frame.origin.y + screen.frame.size.height / 2 - m_nHeight / 2);
+          // if there are stored window positions use that as the origin point
+          const int top = settings->GetInt(SETTING_WINDOW_TOP);
+          const int left = settings->GetInt(SETTING_WINDOW_LEFT);
+
+          NSPoint windowPos;
+          if (top != 0 || left != 0)
+          {
+            windowPos = NSMakePoint(left, top);
+          }
+          else
+          {
+            // otherwise center the window on the screen
+            windowPos =
+                NSMakePoint(screen.frame.origin.x + screen.frame.size.width / 2 - m_nWidth / 2,
+                            screen.frame.origin.y + screen.frame.size.height / 2 - m_nHeight / 2);
+          }
+          [appWindow setFrameOrigin:windowPos];
         }
-        [appWindow setFrameOrigin:windowPos];
       }
     });
 

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1244,10 +1244,12 @@ void CWinSystemOSX::OnMove(int x, int y)
     oldRefreshRate = m_refreshRate;
 
     // send a message so that videoresolution (and refreshrate) is changed
-    NSWindow* win = m_appWindow;
-    NSRect frame = win.contentView.frame;
-    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_VIDEORESIZE, frame.size.width,
-                                               frame.size.height);
+    dispatch_sync(dispatch_get_main_queue(), ^{
+      NSWindow* win = m_appWindow;
+      NSRect frame = win.contentView.frame;
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_VIDEORESIZE, frame.size.width,
+                                                 frame.size.height);
+    });
   }
   // store window position in window mode
   if (!m_bFullScreen)

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1189,27 +1189,11 @@ void CWinSystemOSX::OnMove(int x, int y)
 
 void CWinSystemOSX::WindowChangedScreen()
 {
-  // user has moved the window to a
-  // different screen
-  NSOpenGLContext* context = [NSOpenGLContext currentContext];
-  m_lastDisplayNr = 0;
-
   // if we are here the user dragged the window to a different
   // screen and we return the screen of the window
-  if (context)
+  if (m_appWindow)
   {
-    NSView* view;
-
-    view = context.view;
-    if (view)
-    {
-      NSWindow* window;
-      window = view.window;
-      if (window)
-      {
-        m_lastDisplayNr = GetDisplayIndex(GetDisplayIDFromScreen(window.screen));
-      }
-    }
+    m_lastDisplayNr = GetDisplayIndex(GetDisplayIDFromScreen(m_appWindow.screen));
   }
 }
 

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -705,8 +705,20 @@ bool CWinSystemOSX::CreateNewWindow(const std::string& name, bool fullScreen, RE
       // associate with current window
       [appWindow setContentView:view];
 
-      // set the window to the appropriate screen
-      [appWindow setFrameOrigin:screen.frame.origin];
+      // set the window to the appropriate screen and screen position
+      if (m_bFullScreen)
+      {
+        [appWindow setFrameOrigin:screen.frame.origin];
+      }
+      else
+      {
+        // if in window mode we center the window on the screen
+        // TODO: we should remember window positions and use that instead, similar to what is currently done for windowsDX
+        NSPoint centerOfTheScreen =
+            NSMakePoint(screen.frame.origin.x + screen.frame.size.width / 2 - m_nWidth / 2,
+                        screen.frame.origin.y + screen.frame.size.height / 2 - m_nHeight / 2);
+        [appWindow setFrameOrigin:centerOfTheScreen];
+      }
     });
 
     [view.getGLContext makeCurrentContext];

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -641,6 +641,12 @@ bool CWinSystemOSX::DestroyWindowSystem()
 
 bool CWinSystemOSX::CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res)
 {
+  // find the screen where the application started the last time. It'd be the default screen if the
+  // screen index is not found/available.
+  const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+  m_lastDisplayNr = GetDisplayIndex(settings->GetString(CSettings::SETTING_VIDEOSCREEN_MONITOR));
+  NSScreen* screen = [NSScreen.screens objectAtIndex:m_lastDisplayNr];
+
   // force initial window creation to be windowed, if fullscreen, it will switch to it below
   // fixes the white screen of death if starting fullscreen and switching to windowed.
   RESOLUTION_INFO resInfo = CDisplaySettings::GetInstance().GetResolutionInfo(RES_WINDOW);
@@ -684,6 +690,9 @@ bool CWinSystemOSX::CreateNewWindow(const std::string& name, bool fullScreen, RE
 
       // associate with current window
       [appWindow setContentView:view];
+
+      // set the window to the appropriate screen
+      [appWindow setFrameOrigin:screen.frame.origin];
     });
 
     [view.getGLContext makeCurrentContext];


### PR DESCRIPTION
## Description
This PR improves the behaviour of Kodi on multi-screen setups using the "new" native windowing functionality. Essentially it fixes two issues:

- If a user drags the window to a different screen, kodi should react to this event and update its internal state (it was only partially implemented). The current screen no longer is the old one - which means that if the user toggles fullscreen state later, kodi was using the resolution of the old screen. At the same time, kodi should remember the screen/monitor currently in use for its monitor setting.
- When kodi starts it should create the window on the appropriate screen. On windowed mode it should center the window (~or better yet, remember the position and set it accordingly similar to https://github.com/xbmc/xbmc/pull/21820 which I plan to do later~ - done in https://github.com/xbmc/xbmc/pull/22746/commits/6dec4eb216bde3bba4c6976c9a8cad0e0327a532)

I've runtime tested this on multiple scenarios, e.g.: force unplugging the current display and confirm the window moves to the default display; start kodi without the previous display connected, dragging windows between displays, etc.
