### PR TITLE
remove deprecated extra artwork settings from AS.xml

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1111,12 +1111,6 @@
         </setting>
       </group>
       <group id="4" label="39123">
-        <!-- Hidden setting indicating video art settings have been migrated from old advancedsettings.xml format-->
-        <setting id="videolibrary.artsettingsupdated" type="boolean" label="0" help="">
-          <level>4</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
         <setting id="videolibrary.artworklevel" type="integer" label="39137" help="39138">
           <level>1</level>
           <default>0</default>
@@ -1305,12 +1299,6 @@
         </setting>
       </group>
       <group id="3" label="39123">
-        <!-- Hidden setting indicating music art settings have been migrated from old advancedsettings.xml format-->
-        <setting id="musiclibrary.artsettings" type="boolean" label="0" help="">
-          <level>4</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
         <setting id="musiclibrary.artworklevel" type="integer" label="39137" help="39138">
           <level>1</level>
           <default>0</default>

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -297,8 +297,6 @@ void CAdvancedSettings::Initialize()
   m_bShoutcastArt = true;
 
   m_musicThumbs = "folder.jpg|Folder.jpg|folder.JPG|Folder.JPG|cover.jpg|Cover.jpg|cover.jpeg|thumb.jpg|Thumb.jpg|thumb.JPG|Thumb.JPG";
-  m_musicArtistExtraArt = {};
-  m_musicAlbumExtraArt = {};
 
   m_bMusicLibraryAllItemsOnBottom = false;
   m_bMusicLibraryCleanOnUpdate = false;
@@ -318,13 +316,6 @@ void CAdvancedSettings::Initialize()
   m_bVideoLibraryUseFastHash = true;
   m_bVideoScannerIgnoreErrors = false;
   m_iVideoLibraryDateAdded = 1; // prefer mtime over ctime and current time
-
-  m_videoEpisodeExtraArt = {};
-  m_videoTvShowExtraArt = {};
-  m_videoTvSeasonExtraArt = {};
-  m_videoMovieExtraArt = {};
-  m_videoMovieSetExtraArt = {};
-  m_videoMusicVideoExtraArt = {};
 
   m_iEpgUpdateCheckInterval = 300; /* Check every X seconds, if EPG data need to be updated. This does not mean that
                                       every X seconds an EPG update is actually triggered, it's just the interval how
@@ -810,9 +801,6 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
         separator = separator->NextSibling("separator");
       }
     }
-
-    SetExtraArtwork(pElement->FirstChildElement("artistextraart"), m_musicArtistExtraArt);
-    SetExtraArtwork(pElement->FirstChildElement("albumextraart"), m_musicAlbumExtraArt);
   }
 
   pElement = pRootElement->FirstChildElement("videolibrary");
@@ -826,13 +814,6 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetBoolean(pElement, "importwatchedstate", m_bVideoLibraryImportWatchedState);
     XMLUtils::GetBoolean(pElement, "importresumepoint", m_bVideoLibraryImportResumePoint);
     XMLUtils::GetInt(pElement, "dateadded", m_iVideoLibraryDateAdded);
-
-    SetExtraArtwork(pElement->FirstChildElement("episodeextraart"), m_videoEpisodeExtraArt);
-    SetExtraArtwork(pElement->FirstChildElement("tvshowextraart"), m_videoTvShowExtraArt);
-    SetExtraArtwork(pElement->FirstChildElement("tvseasonextraart"), m_videoTvSeasonExtraArt);
-    SetExtraArtwork(pElement->FirstChildElement("movieextraart"), m_videoMovieExtraArt);
-    SetExtraArtwork(pElement->FirstChildElement("moviesetextraart"), m_videoMovieSetExtraArt);
-    SetExtraArtwork(pElement->FirstChildElement("musicvideoextraart"), m_videoMusicVideoExtraArt);
   }
 
   pElement = pRootElement->FirstChildElement("videoscanner");
@@ -1259,9 +1240,6 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
 
   // load in the settings overrides
   CServiceBroker::GetSettingsComponent()->GetSettings()->LoadHidden(pRootElement);
-
-  // Migration of old style art options from advanced setting to GUI setting
-  MigrateOldArtSettings();
 }
 
 void CAdvancedSettings::Clear()
@@ -1465,95 +1443,5 @@ void ConvertToWhitelist(const std::vector<std::string>& oldlist, std::vector<CVa
     std::string strFamilyType = it.substr(0, last_index + 1); // "fanart" of "fanart16"
     if (std::find(whitelist.begin(), whitelist.end(), strFamilyType) == whitelist.end())
       whitelist.emplace_back(strFamilyType);
-  }
-}
-
-void CAdvancedSettings::MigrateOldArtSettings()
-{
-  const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-  if (!settings->GetBool(CSettings::SETTING_MUSICLIBRARY_ARTSETTINGS_UPDATED))
-  {
-    CLog::Log(LOGINFO, "Migrating old music library artwork settings to new GUI settings");
-    // Convert numeric art type variants into simple art type family entry
-    // e.g. {"banner", "fanart1", "fanart2", "fanart3"... } into { "banner", "fanart"}
-    if (!m_musicArtistExtraArt.empty())
-    {
-      std::vector<CVariant> whitelist;
-      ConvertToWhitelist(m_musicArtistExtraArt, whitelist);
-      settings->SetList(CSettings::SETTING_MUSICLIBRARY_ARTISTART_WHITELIST, whitelist);
-    }
-    if (!m_musicAlbumExtraArt.empty())
-    {
-      std::vector<CVariant> whitelist;
-      ConvertToWhitelist(m_musicAlbumExtraArt, whitelist);
-      settings->SetList(CSettings::SETTING_MUSICLIBRARY_ALBUMART_WHITELIST, whitelist);
-    }
-
-    // Convert value like "folder.jpg|Folder.jpg|folder.JPG|Folder.JPG|cover.jpg|Cover.jpg|
-    // cover.jpeg|thumb.jpg|Thumb.jpg|thumb.JPG|Thumb.JPG" into case-insensitive unique elements
-    // e.g. {"folder.jpg", "cover.jpg", "cover.jpeg", "thumb.jpg"}
-    if (!m_musicThumbs.empty())
-    {
-      std::vector<std::string> thumbs1 = StringUtils::Split(m_musicThumbs, "|");
-      std::vector<std::string> thumbs2;
-      for (auto& it : thumbs1)
-      {
-        StringUtils::ToLower(it);
-        if (std::find(thumbs2.begin(), thumbs2.end(), it) == thumbs2.end())
-          thumbs2.emplace_back(it);
-      }
-      std::vector<CVariant> thumbs;
-      thumbs.reserve(thumbs2.size());
-      for (const auto& it : thumbs2)
-        thumbs.emplace_back(it);
-      settings->SetList(CSettings::SETTING_MUSICLIBRARY_MUSICTHUMBS, thumbs);
-    }
-
-    // Whitelists configured, set artwork level to custom
-    if (!m_musicAlbumExtraArt.empty() || !m_musicArtistExtraArt.empty())
-      settings->SetInt(CSettings::SETTING_MUSICLIBRARY_ARTWORKLEVEL, 2);
-
-    // Flag migration of settings so not done again
-    settings->SetBool(CSettings::SETTING_MUSICLIBRARY_ARTSETTINGS_UPDATED, true);
-  }
-
-  if (!settings->GetBool(CSettings::SETTING_VIDEOLIBRARY_ARTSETTINGS_UPDATED))
-  {
-    CLog::Log(LOGINFO, "Migrating old video library artwork settings to new GUI settings");
-    // Convert numeric art type variants into simple art type family entry
-    // e.g. {"banner", "fanart1", "fanart2", "fanart3"... } into { "banner", "fanart"}
-    if (!m_videoEpisodeExtraArt.empty())
-    {
-      std::vector<CVariant> whitelist;
-      ConvertToWhitelist(m_videoEpisodeExtraArt, whitelist);
-      settings->SetList(CSettings::SETTING_VIDEOLIBRARY_EPISODEART_WHITELIST, whitelist);
-    }
-    if (!m_videoTvShowExtraArt.empty())
-    {
-      std::vector<CVariant> whitelist;
-      ConvertToWhitelist(m_videoTvShowExtraArt, whitelist);
-      settings->SetList(CSettings::SETTING_VIDEOLIBRARY_TVSHOWART_WHITELIST, whitelist);
-    }
-    if (!m_videoMovieExtraArt.empty())
-    {
-      std::vector<CVariant> whitelist;
-      ConvertToWhitelist(m_videoMovieExtraArt, whitelist);
-      settings->SetList(CSettings::SETTING_VIDEOLIBRARY_MOVIEART_WHITELIST, whitelist);
-    }
-    if (!m_videoMusicVideoExtraArt.empty())
-    {
-      std::vector<CVariant> whitelist;
-      ConvertToWhitelist(m_videoMusicVideoExtraArt, whitelist);
-      settings->SetList(CSettings::SETTING_VIDEOLIBRARY_MUSICVIDEOART_WHITELIST, whitelist);
-    }
-
-    // Whitelists configured, set artwork level to custom
-    if (!m_videoEpisodeExtraArt.empty() || !m_videoTvShowExtraArt.empty()
-        || !m_videoMovieExtraArt.empty() || !m_videoMusicVideoExtraArt.empty())
-      settings->SetInt(CSettings::SETTING_VIDEOLIBRARY_ARTWORK_LEVEL,
-        CSettings::MUSICLIBRARY_ARTWORK_LEVEL_CUSTOM);
-
-    // Flag migration of settings so not done again
-    settings->SetBool(CSettings::SETTING_VIDEOLIBRARY_ARTSETTINGS_UPDATED, true);
   }
 }

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -242,8 +242,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_bShoutcastArt;
 
     std::string m_musicThumbs;
-    std::vector<std::string> m_musicArtistExtraArt;
-    std::vector<std::string> m_musicAlbumExtraArt;
 
     int m_iMusicLibraryRecentlyAddedItems;
     int m_iMusicLibraryDateAdded;
@@ -264,12 +262,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_bVideoLibraryUseFastHash;
     bool m_bVideoLibraryImportWatchedState{true};
     bool m_bVideoLibraryImportResumePoint{true};
-    std::vector<std::string> m_videoEpisodeExtraArt;
-    std::vector<std::string> m_videoTvShowExtraArt;
-    std::vector<std::string> m_videoTvSeasonExtraArt;
-    std::vector<std::string> m_videoMovieExtraArt;
-    std::vector<std::string> m_videoMovieSetExtraArt;
-    std::vector<std::string> m_videoMusicVideoExtraArt;
 
     bool m_bVideoScannerIgnoreErrors;
     int m_iVideoLibraryDateAdded;
@@ -387,5 +379,4 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     void Initialize();
     void Clear();
     void SetExtraArtwork(const TiXmlElement* arttypes, std::vector<std::string>& artworkMap);
-    void MigrateOldArtSettings();
 };

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -94,8 +94,6 @@ public:
       "videolibrary.episodeartwhitelist";
   static constexpr auto SETTING_VIDEOLIBRARY_MUSICVIDEOART_WHITELIST =
       "videolibrary.musicvideoartwhitelist";
-  static constexpr auto SETTING_VIDEOLIBRARY_ARTSETTINGS_UPDATED =
-      "videolibrary.artsettingsupdated";
   static constexpr auto SETTING_VIDEOLIBRARY_SHOWPERFORMERS =
       "videolibrary.musicvideosallperformers";
   static constexpr auto SETTING_LOCALE_AUDIOLANGUAGE = "locale.audiolanguage";
@@ -253,7 +251,6 @@ public:
       "musiclibrary.artistartwhitelist";
   static constexpr auto SETTING_MUSICLIBRARY_ALBUMART_WHITELIST = "musiclibrary.albumartwhitelist";
   static constexpr auto SETTING_MUSICLIBRARY_MUSICTHUMBS = "musiclibrary.musicthumbs";
-  static constexpr auto SETTING_MUSICLIBRARY_ARTSETTINGS_UPDATED = "musiclibrary.artsettings";
   static constexpr auto SETTING_MUSICLIBRARY_ALBUMSSCRAPER = "musiclibrary.albumsscraper";
   static constexpr auto SETTING_MUSICLIBRARY_ARTISTSSCRAPER = "musiclibrary.artistsscraper";
   static constexpr auto SETTING_MUSICLIBRARY_OVERRIDETAGS = "musiclibrary.overridetags";


### PR DESCRIPTION
## Description
Remove the advancedsettings.xml configuration for extra artwork. This was added in v18, then we moved it to GUI settings in v19, with one-time migration functionality. v21 seems a good time to remove the deprecated settings and migration code.

## Motivation and context
Simplify. Remove deprecated stuff. Prove that advancedsettings.xml _can_ be moved / removed later. Just gotta remember to do it. 😄 

## How has this been tested?
Manual testing. It doesn't do anything.

## What is the effect on users?
Simplifies configuration.

📰 Extraart configurations in advancedsettings.xml for Kodi 18 will no longer be migrated to the new GUI settings when upgrading. If you had meaningful configuration there, check that the artwork settings in the GUI match your preferences.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
