### PR TITLE
[Backport] Savestate Manager: Break dependency on DialogSelect and add "Saved with"

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -18543,7 +18543,11 @@ msgctxt "#35254"
 msgid "Save the game automatically during game play, if supported. Resume playing where you left off."
 msgstr ""
 
-#empty string with id 35255
+#. Label for showing which emulator the game was saved with
+#: system/settings/settings.xml
+msgctxt "#35255"
+msgid "Saved with:"
+msgstr ""
 
 #. Error message when a game client fails to install when a game is being launched
 #: xbmc/games/dialogs/GUIDialogSelectGameClient.cpp

--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -198,165 +198,153 @@
 		<control type="group">
 			<centertop>50%</centertop>
 			<centerleft>50%</centerleft>
-			<height>750</height>
-			<width>1220</width>
+			<width>1639</width>
+			<height>919</height>
 			<include content="DialogBackgroundCommons">
-				<param name="width" value="1220" />
-				<param name="height" value="780" />
-				<param name="header_label" value="" />
-				<param name="header_id" value="1" />
+				<param name="width" value="1639" />
+				<param name="height" value="919" />
+				<param name="header_label" value="35260" />
+				<param name="header_id" value="10820" />
 			</include>
-			<control type="image">
-				<left>0</left>
-				<top>80</top>
-				<width>920</width>
-				<bottom>2</bottom>
-				<texture border="40">buttons/dialogbutton-nofo.png</texture>
-			</control>
-			<control type="list" id="3">
-				<left>20</left>
+			<control type="group">
+				<description>Content area</description>
 				<top>100</top>
-				<width>880</width>
 				<bottom>20</bottom>
-				<onup>3</onup>
-				<ondown>3</ondown>
-				<onleft>9001</onleft>
-				<onright>61</onright>
-				<pagecontrol>61</pagecontrol>
-				<scrolltime>200</scrolltime>
-				<include content="DefaultSimpleListLayout">
-					<param name="width" value="880" />
-					<param name="list_id" value="3" />
-				</include>
-			</control>
-			<control type="panel" id="6">
-				<left>40</left>
-				<top>100</top>
-				<width>880</width>
-				<bottom>20</bottom>
-				<onup>6</onup>
-				<ondown>6</ondown>
-				<onleft>9001</onleft>
-				<onright>61</onright>
-				<pagecontrol>61</pagecontrol>
-				<scrolltime>200</scrolltime>
-				<itemlayout height="300" width="420">
+				<left>30</left>
+				<right>30</right>
+				<control type="group">
+					<description>Panel area, including scroll bar</description>
+					<width>1224</width>
+					<height>748</height>
 					<control type="image">
-						<left>10</left>
-						<top>7</top>
-						<width>400</width>
-						<height>220</height>
-						<texture>$INFO[ListItem.Art(screenshot)]</texture>
-						<aspectratio>keep</aspectratio>
+						<left>-20</left>
+						<right>-20</right>
+						<top>-20</top>
+						<bottom>-20</bottom>
+						<texture border="40">buttons/dialogbutton-nofo.png</texture>
+					</control>
+					<control type="panel" id="3">
+						<onright>9001</onright>
+						<pagecontrol>61</pagecontrol>
+						<scrolltime>200</scrolltime>
+						<itemlayout width="408" height="374">
+							<control type="image">
+								<left>10</left>
+								<right>10</right>
+								<top>10</top>
+								<height>256</height>
+								<texture>$INFO[ListItem.Art(screenshot)]</texture>
+								<aspectratio>keep</aspectratio>
+							</control>
+							<control type="label">
+								<left>10</left>
+								<right>10</right>
+								<top>286</top>
+								<height>20</height>
+								<align>center</align>
+								<aligny>center</aligny>
+								<scroll>true</scroll>
+								<font>font13</font>
+								<label>$INFO[ListItem.Label]</label>
+								<shadowcolor>text_shadow</shadowcolor>
+							</control>
+							<control type="label">
+								<left>10</left>
+								<right>10</right>
+								<top>322</top>
+								<height>20</height>
+								<align>center</align>
+								<aligny>center</aligny>
+								<scroll>true</scroll>
+								<font>font27</font>
+								<label>$INFO[ListItem.Label2]</label>
+								<shadowcolor>text_shadow</shadowcolor>
+							</control>
+						</itemlayout>
+						<focusedlayout width="408" height="374">
+							<control type="image">
+								<texture colordiffuse="button_focus">lists/focus.png</texture>
+								<visible>Control.HasFocus(3)</visible>
+							</control>
+							<control type="image">
+								<left>10</left>
+								<right>10</right>
+								<top>10</top>
+								<height>256</height>
+								<texture>$INFO[ListItem.Art(screenshot)]</texture>
+								<aspectratio>keep</aspectratio>
+							</control>
+							<control type="label">
+								<left>10</left>
+								<right>10</right>
+								<top>286</top>
+								<height>20</height>
+								<align>center</align>
+								<aligny>center</aligny>
+								<scroll>true</scroll>
+								<font>font13</font>
+								<label>$INFO[ListItem.Label]</label>
+								<shadowcolor>text_shadow</shadowcolor>
+							</control>
+							<control type="label">
+								<left>10</left>
+								<right>10</right>
+								<top>322</top>
+								<height>20</height>
+								<align>center</align>
+								<aligny>center</aligny>
+								<scroll>true</scroll>
+								<font>font27</font>
+								<label>$INFO[ListItem.Label2]</label>
+								<shadowcolor>text_shadow</shadowcolor>
+							</control>
+						</focusedlayout>
+					</control>
+					<control type="scrollbar" id="61">
+						<description>Scroll bar</description>
+						<right>-20</right>
+						<width>12</width>
+						<orientation>vertical</orientation>
+					</control>
+				</control>
+				<control type="grouplist" id="9001">
+					<description>Buttons on the right</description>
+					<left>1302</left>
+					<top>-20</top>
+					<onleft>3</onleft>
+					<itemgap>dialogbuttons_itemgap</itemgap>
+					<include content="DefaultDialogButton">
+						<param name="id" value="10825" />
+						<param name="label" value="$LOCALIZE[35261]" />
+					</include>
+					<include content="DefaultDialogButton">
+						<param name="id" value="10826" />
+						<param name="label" value="$LOCALIZE[222]" />
+					</include>
+				</control>
+				<control type="group">
+					<description>Bottom bar of text area</description>
+					<height>40</height>
+					<bottom>0</bottom>
+					<control type="label" id="10822">
+						<description>Caption area</description>
+						<right>200</right>
+						<font>font12</font>
+						<align>left</align>
+						<aligny>center</aligny>
+						<shadowcolor>text_shadow</shadowcolor>
 					</control>
 					<control type="label">
-						<left>0</left>
-						<top>238</top>
-						<right>20</right>
-						<height>20</height>
-						<font>font14</font>
-						<align>center</align>
-						<aligny>center</aligny>
-						<label>$INFO[ListItem.Label]</label>
-					</control>
-					<control type="textbox">
-						<left>0</left>
-						<top>262</top>
-						<right>20</right>
-						<height>40</height>
-						<font>font10</font>
-						<align>center</align>
+						<description>Item count</description>
+						<right>0</right>
+						<width>200</width>
+						<font>font12</font>
+						<align>right</align>
 						<aligny>center</aligny>
 						<textcolor>grey</textcolor>
-						<label>$INFO[ListItem.Label2]</label>
+						<label>$VAR[SelectLabel]</label>
 					</control>
-				</itemlayout>
-				<focusedlayout height="300" width="420">
-					<control type="image">
-						<left>0</left>
-						<top>0</top>
-						<right>0</right>
-						<bottom>0</bottom>
-						<texture colordiffuse="button_focus">lists/focus.png</texture>
-						<visible>Control.HasFocus(6)</visible>
-					</control>
-					<control type="image">
-						<left>10</left>
-						<top>7</top>
-						<width>400</width>
-						<height>220</height>
-						<texture>$INFO[ListItem.Art(screenshot)]</texture>
-						<aspectratio>keep</aspectratio>
-					</control>
-					<control type="label">
-						<left>0</left>
-						<top>238</top>
-						<right>20</right>
-						<height>20</height>
-						<align>center</align>
-						<aligny>center</aligny>
-						<scroll>true</scroll>
-						<font>font14</font>
-						<label>$INFO[ListItem.Label]</label>
-					</control>
-					<control type="textbox">
-						<left>0</left>
-						<top>262</top>
-						<right>20</right>
-						<height>40</height>
-						<font>font10</font>
-						<align>center</align>
-						<aligny>center</aligny>
-						<label>$INFO[ListItem.Label2]</label>
-					</control>
-				</focusedlayout>
-			</control>
-			<control type="scrollbar" id="61">
-				<left>910</left>
-				<top>100</top>
-				<width>12</width>
-				<bottom>20</bottom>
-				<onleft condition="Control.IsVisible(3)">3</onleft>
-				<onleft condition="Control.IsVisible(6)">6</onleft>
-				<onright>9001</onright>
-				<orientation>vertical</orientation>
-			</control>
-			<control type="label">
-				<left>925</left>
-				<bottom>10</bottom>
-				<width>275</width>
-				<height>35</height>
-				<font>font12</font>
-				<align>right</align>
-				<textcolor>grey</textcolor>
-				<label>$VAR[SelectLabel]</label>
-			</control>
-			<control type="grouplist" id="9001">
-				<left>920</left>
-				<top>80</top>
-				<onleft>61</onleft>
-				<itemgap>dialogbuttons_itemgap</itemgap>
-				<onright>3</onright>
-				<include content="DefaultDialogButton">
-					<param name="id" value="5" />
-					<param name="label" value="" />
-				</include>
-				<include content="DefaultDialogButton">
-					<param name="id" value="7" />
-					<param name="label" value="$LOCALIZE[222]" />
-				</include>
-			</control>
-			<control type="label" id="10822">
-				<description>Caption area</description>
-				<left>14</left>
-				<right>14</right>
-				<bottom>0</bottom>
-				<height>16</height>
-				<font>font12</font>
-				<align>left</align>
-				<shadowcolor>text_shadow</shadowcolor>
-				<autoscroll time="3000" delay="5000" repeat="5000">true</autoscroll>
-				<label></label>
+				</control>
 			</control>
 		</control>
 	</include>

--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -323,6 +323,50 @@
 					</include>
 				</control>
 				<control type="group">
+					<description>Emulator name and icon</description>
+					<right>0</right>
+					<width>310</width>
+					<top>162</top>
+					<height>330</height>
+					<bottom>50</bottom>
+					<control type="group">
+						<left>52</left>
+						<control type="image">
+							<left>-20</left>
+							<right>-20</right>
+							<top>-20</top>
+							<bottom>-20</bottom>
+							<texture border="40">buttons/dialogbutton-nofo.png</texture>
+						</control>
+						<control type="label">
+							<description>Label for Saved with: text</description>
+							<top>14</top>
+							<height>20</height>
+							<font>font16</font>
+							<shadowcolor>text_shadow</shadowcolor>
+							<label>35255</label>
+							<align>center</align>
+						</control>
+						<control type="label" id="10823">
+							<description>Emulator name</description>
+							<top>60</top>
+							<height>20</height>
+							<font>font23_narrow</font>
+							<textcolor>button_focus</textcolor>
+							<shadowcolor>text_shadow</shadowcolor>
+							<align>center</align>
+						</control>
+						<control type="image" id="10824">
+							<description>Emulator icon</description>
+							<top>108</top>
+							<height>192</height>
+							<right>33</right>
+							<width>192</width>
+							<aspectratio>keep</aspectratio>
+						</control>
+					</control>
+				</control>
+				<control type="group">
 					<description>Bottom bar of text area</description>
 					<height>40</height>
 					<bottom>0</bottom>

--- a/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
@@ -184,6 +184,7 @@ void CSavestateDatabase::GetSavestateItem(const ISavestate& savestate,
   item.SetPath(savestatePath);
   item.SetArt("screenshot", MakeThumbnailPath(savestatePath));
   item.SetProperty(SAVESTATE_CAPTION, savestate.Caption());
+  item.SetProperty(SAVESTATE_GAME_CLIENT, savestate.GameClientID());
   item.m_dateTime = dateUTC;
 }
 

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -106,6 +106,8 @@ CGameClient::CGameClient(const ADDON::AddonInfoPtr& addonInfo)
       addonInfo->Type(AddonType::GAMEDLL)->GetValue(GAME_PROPERTY_SUPPORTS_VFS).asBoolean();
   m_bSupportsStandalone =
       addonInfo->Type(AddonType::GAMEDLL)->GetValue(GAME_PROPERTY_SUPPORTS_STANDALONE).asBoolean();
+
+  std::tie(m_emulatorName, m_platforms) = ParseLibretroName(Name());
 }
 
 CGameClient::~CGameClient(void)
@@ -693,4 +695,38 @@ bool CGameClient::cb_input_event(KODI_HANDLE kodiInstance, const game_input_even
     return false;
 
   return gameClient->Input().ReceiveInputEvent(*event);
+}
+
+std::pair<std::string, std::string> CGameClient::ParseLibretroName(const std::string& addonName)
+{
+  std::string emulatorName;
+  std::string platforms;
+
+  // libretro has a de-facto standard for naming their cores. If the
+  // core emulates one or more platforms, then the format is:
+  //
+  //   "Platforms (Emulator name)"
+  //
+  // Otherwise, the format is just the name with no platforms:
+  //
+  //   "Emulator name"
+  //
+  // The has been observed for all 130 cores we package.
+  //
+  size_t beginPos = addonName.find('(');
+  size_t endPos = addonName.find(')');
+
+  if (beginPos != std::string::npos && endPos != std::string::npos && beginPos < endPos)
+  {
+    emulatorName = addonName.substr(beginPos + 1, endPos - beginPos - 1);
+    platforms = addonName.substr(0, beginPos);
+    StringUtils::TrimRight(platforms);
+  }
+  else
+  {
+    emulatorName = addonName;
+    platforms.clear();
+  }
+
+  return std::make_pair(emulatorName, platforms);
 }

--- a/xbmc/games/addons/GameClient.h
+++ b/xbmc/games/addons/GameClient.h
@@ -18,6 +18,7 @@
 #include <set>
 #include <stdint.h>
 #include <string>
+#include <utility>
 
 class CFileItem;
 
@@ -141,6 +142,8 @@ public:
   const std::set<std::string>& GetExtensions() const { return m_extensions; }
   bool SupportsAllExtensions() const { return m_bSupportsAllExtensions; }
   bool IsExtensionValid(const std::string& strExtension) const;
+  const std::string& GetEmulatorName() const { return m_emulatorName; }
+  const std::string& GetPlatforms() const { return m_platforms; }
 
   // Start/stop gameplay
   bool Initialize(void);
@@ -212,6 +215,24 @@ private:
   static bool cb_input_event(KODI_HANDLE kodiInstance, const game_input_event* event);
   //@}
 
+  /*!
+   * \brief Parse the name of a libretro game add-on into its emulator name
+   * and platforms
+   *
+   * \param addonName The name of the add-on, e.g. "Nintendo - SNES / SFC (Snes9x 2002)"
+   *
+   * \return A tuple of two strings:
+   *   - first:  the emulator name, e.g. "Snes9x 2002"
+   *   - second: the platforms, e.g. "Nintendo - SNES / SFC"
+   *
+   * For cores that don't emulate a platform, such as 2048 with the add-on name
+   * "2048", then the emulator name will be the add-on name and platforms
+   * will be empty, e.g.:
+   *   - first:  "2048"
+   *   - second: ""
+   */
+  static std::pair<std::string, std::string> ParseLibretroName(const std::string& addonName);
+
   // Game subsystems
   GameClientSubsystems m_subsystems;
 
@@ -220,7 +241,8 @@ private:
   bool m_bSupportsStandalone;
   std::set<std::string> m_extensions;
   bool m_bSupportsAllExtensions;
-  // GamePlatforms         m_platforms;
+  std::string m_emulatorName;
+  std::string m_platforms;
 
   // Properties of the current playing file
   std::atomic_bool m_bIsPlaying; // True between OpenFile() and CloseFile()

--- a/xbmc/games/dialogs/DialogGameDefines.h
+++ b/xbmc/games/dialogs/DialogGameDefines.h
@@ -10,10 +10,17 @@
 
 // Name of list item property for savestate captions
 constexpr auto SAVESTATE_CAPTION = "savestate.caption";
+constexpr auto SAVESTATE_GAME_CLIENT = "savestate.gameclient";
 
 // Control IDs for game dialogs
 constexpr unsigned int CONTROL_VIDEO_HEADING = 10810;
 constexpr unsigned int CONTROL_VIDEO_THUMBS = 10811;
 constexpr unsigned int CONTROL_VIDEO_DESCRIPTION = 10812;
-constexpr unsigned int CONTROL_SAVES_DETAILED_LIST = 6;
+constexpr unsigned int CONTROL_SAVES_HEADING = 10820;
+constexpr unsigned int CONTROL_SAVES_DETAILED_LIST = 3; // Select dialog defaults to this control ID
 constexpr unsigned int CONTROL_SAVES_DESCRIPTION = 10822;
+constexpr unsigned int CONTROL_SAVES_EMULATOR_NAME = 10823;
+constexpr unsigned int CONTROL_SAVES_EMULATOR_ICON = 10824;
+constexpr unsigned int CONTROL_SAVES_NEW_BUTTON = 10825;
+constexpr unsigned int CONTROL_SAVES_CANCEL_BUTTON = 10826;
+constexpr unsigned int CONTROL_NUMBER_OF_ITEMS = 10827;

--- a/xbmc/games/dialogs/GUIDialogSelectSavestate.cpp
+++ b/xbmc/games/dialogs/GUIDialogSelectSavestate.cpp
@@ -8,16 +8,10 @@
 
 #include "GUIDialogSelectSavestate.h"
 
-#include "FileItem.h"
 #include "ServiceBroker.h"
-#include "cores/RetroPlayer/savestates/ISavestate.h"
-#include "cores/RetroPlayer/savestates/SavestateDatabase.h"
 #include "games/dialogs/osd/DialogGameSaves.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
-#include "utils/StringUtils.h"
-#include "utils/Variant.h"
 #include "utils/log.h"
 
 using namespace KODI;
@@ -26,82 +20,38 @@ using namespace GAME;
 bool CGUIDialogSelectSavestate::ShowAndGetSavestate(const std::string& gamePath,
                                                     std::string& savestatePath)
 {
-  RETRO::CSavestateDatabase db;
-  CFileItemList items;
-  bool bSuccess = false;
-
   savestatePath = "";
 
-  if (!db.GetSavestatesNav(items, gamePath))
-    return bSuccess;
+  // Can't ask the user if there's no dialog
+  CDialogGameSaves* dialog = GetDialog();
+  if (dialog == nullptr)
+    return true;
 
-  LogSavestates(items);
+  dialog->Open(gamePath);
 
-  items.Sort(SortByDate, SortOrderDescending);
-
-  // if there are no saves there is no need to prompt the user
-  if (items.Size() == 0)
+  if (dialog->IsConfirmed())
   {
-    savestatePath = "";
+    savestatePath = dialog->GetSelectedItemPath();
     return true;
   }
-  else
+  else if (dialog->IsNewPressed())
   {
-    // "Select savestate"
-    CDialogGameSaves* dialog = GetDialog(g_localizeStrings.Get(35260));
-
-    if (dialog != nullptr)
-    {
-      dialog->SetItems(items);
-      dialog->Open();
-
-      if (dialog->IsConfirmed())
-      {
-        std::string itemPath = dialog->GetSelectedItemPath();
-
-        if (!itemPath.empty())
-        {
-          savestatePath = itemPath;
-          bSuccess = true;
-        }
-        else
-        {
-          CLog::Log(LOGDEBUG, "Select savestate dialog: User selected invalid savestate");
-        }
-      }
-      else if (dialog->IsButtonPressed())
-      {
-        CLog::Log(LOGDEBUG, "Select savestate dialog: New savestate selected");
-        bSuccess = true;
-      }
-    }
+    CLog::Log(LOGDEBUG, "Select savestate dialog: New savestate selected");
+    return true;
   }
 
-  return bSuccess;
+  // User canceled the dialog
+  return false;
 }
 
-CDialogGameSaves* CGUIDialogSelectSavestate::GetDialog(const std::string& title)
+CDialogGameSaves* CGUIDialogSelectSavestate::GetDialog()
 {
   CDialogGameSaves* dialog =
       CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CDialogGameSaves>(
           WINDOW_DIALOG_GAME_SAVES);
 
   if (dialog != nullptr)
-  {
     dialog->Reset();
-    dialog->SetHeading(CVariant{title});
-    dialog->SetUseDetails(true);
-    dialog->EnableButton(true, 35261); // "New"
-  }
 
   return dialog;
-}
-
-void CGUIDialogSelectSavestate::LogSavestates(const CFileItemList& items)
-{
-  CLog::Log(LOGDEBUG, "Select savestate dialog: Found {} saves", items.Size());
-  for (int i = 0; i < items.Size(); i++)
-  {
-    CLog::Log(LOGDEBUG, "{}", items[i]->GetPath());
-  }
 }

--- a/xbmc/games/dialogs/GUIDialogSelectSavestate.cpp
+++ b/xbmc/games/dialogs/GUIDialogSelectSavestate.cpp
@@ -27,7 +27,8 @@ bool CGUIDialogSelectSavestate::ShowAndGetSavestate(const std::string& gamePath,
   if (dialog == nullptr)
     return true;
 
-  dialog->Open(gamePath);
+  if (!dialog->Open(gamePath))
+    return true;
 
   if (dialog->IsConfirmed())
   {

--- a/xbmc/games/dialogs/GUIDialogSelectSavestate.h
+++ b/xbmc/games/dialogs/GUIDialogSelectSavestate.h
@@ -10,8 +10,6 @@
 
 #include <string>
 
-class CFileItemList;
-
 namespace KODI
 {
 namespace GAME
@@ -24,8 +22,7 @@ public:
   static bool ShowAndGetSavestate(const std::string& gamePath, std::string& savestatePath);
 
 private:
-  static CDialogGameSaves* GetDialog(const std::string& title);
-  static void LogSavestates(const CFileItemList& savestates);
+  static CDialogGameSaves* GetDialog();
 };
 } // namespace GAME
 } // namespace KODI

--- a/xbmc/games/dialogs/osd/DialogGameSaves.h
+++ b/xbmc/games/dialogs/osd/DialogGameSaves.h
@@ -91,6 +91,11 @@ private:
    */
   void HandleCaption(const std::string& caption);
 
+  /*!
+  * \brief Called every frame with the game client to set
+  */
+  void HandleGameClient(const std::string& gameClientId);
+
   // Dialog parameters
   std::unique_ptr<CGUIViewControl> m_viewControl;
   std::unique_ptr<CFileItemList> m_vecList;
@@ -102,6 +107,7 @@ private:
 
   // State parameters
   std::string m_currentCaption;
+  std::string m_currentGameClient;
 };
 } // namespace GAME
 } // namespace KODI

--- a/xbmc/games/dialogs/osd/DialogGameSaves.h
+++ b/xbmc/games/dialogs/osd/DialogGameSaves.h
@@ -8,15 +8,21 @@
 
 #pragma once
 
-#include "dialogs/GUIDialogSelect.h"
+#include "guilib/GUIDialog.h"
 
+#include <memory>
+#include <string>
+
+class CFileItem;
+class CFileItemList;
 class CGUIMessage;
+class CGUIViewControl;
 
 namespace KODI
 {
 namespace GAME
 {
-class CDialogGameSaves : public CGUIDialogSelect
+class CDialogGameSaves : public CGUIDialog
 {
 public:
   CDialogGameSaves();
@@ -28,10 +34,32 @@ public:
   // implementation of CGUIWindow via CGUIDialog
   void FrameMove() override;
 
+  // Player interface
+  void Reset();
+  bool Open(const std::string& gamePath);
+  bool IsConfirmed() const { return m_bConfirmed; }
+  bool IsNewPressed() const { return m_bNewPressed; }
   std::string GetSelectedItemPath();
+
+protected:
+  // implementation of CGUIWIndow via CGUIDialog
+  void OnInitWindow() override;
+  void OnDeinitWindow(int nextWindowID) override;
+  void OnWindowLoaded() override;
+  void OnWindowUnload() override;
 
 private:
   using CGUIControl::OnFocus;
+
+  /*!
+   * \breif Called when opening to set the item list
+   */
+  void SetItems(const CFileItemList& itemList);
+
+  /*!
+   * \brief Called when an item has been selected
+   */
+  void OnSelect(const CFileItem& item);
 
   /*!
    * \brief Called every frame with the item being focused
@@ -62,6 +90,15 @@ private:
    * \brief Called every frame with the caption to set
    */
   void HandleCaption(const std::string& caption);
+
+  // Dialog parameters
+  std::unique_ptr<CGUIViewControl> m_viewControl;
+  std::unique_ptr<CFileItemList> m_vecList;
+  std::shared_ptr<CFileItem> m_selectedItem;
+
+  // Player parameters
+  bool m_bConfirmed{false};
+  bool m_bNewPressed{false};
 
   // State parameters
   std::string m_currentCaption;


### PR DESCRIPTION
## Description

Backport of https://github.com/xbmc/xbmc/pull/22686

## Motivation and context

Breaks a dependency and fixes a usability issue.

## How has this been tested?

Build succeeds.

Included in test builds: https://github.com/garbear/xbmc/releases

## What is the effect on users?

* Improves new savestate manager

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
