### PR TITLE
Games: Fix loading game with no savestates

### DIFF
--- a/xbmc/games/dialogs/GUIDialogSelectSavestate.cpp
+++ b/xbmc/games/dialogs/GUIDialogSelectSavestate.cpp
@@ -27,7 +27,8 @@ bool CGUIDialogSelectSavestate::ShowAndGetSavestate(const std::string& gamePath,
   if (dialog == nullptr)
     return true;
 
-  dialog->Open(gamePath);
+  if (!dialog->Open(gamePath))
+    return true;
 
   if (dialog->IsConfirmed())
   {


### PR DESCRIPTION
## Description

As title says, when I broke the dependency in https://github.com/xbmc/xbmc/pull/22686 I left out a small check for games with no savestates, causing them to not load.

This PR adds the missing check, fixing loading games with no savestates.

## Motivation and context

Reported in https://github.com/garbear/xbmc/issues/132

## How has this been tested?

Test builds in progress.

Tested game with no savestates.

Before: Playing a game does nothing and logs the error:

```
No compatible game client selected
```

After, no error is logged, the list of emulators is correctly shown, allowing the game to play.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
