### PR TITLE
[Backport] RetroPlayer: Faster in-game savestate dialog and autosaves

### DIFF
--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -18,6 +18,7 @@
 #include "cores/DataCacheCore.h"
 #include "cores/IPlayerCallback.h"
 #include "cores/RetroPlayer/cheevos/Cheevos.h"
+#include "cores/RetroPlayer/guibridge/GUIGameMessenger.h"
 #include "cores/RetroPlayer/guibridge/GUIGameRenderManager.h"
 #include "cores/RetroPlayer/guiplayback/GUIPlaybackControl.h"
 #include "cores/RetroPlayer/playback/IPlayback.h"
@@ -96,6 +97,7 @@ bool CRetroPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options
   m_processInfo->SetDataCache(&CServiceBroker::GetDataCacheCore());
   m_processInfo->ResetInfo();
 
+  m_guiMessenger = std::make_unique<CGUIGameMessenger>(*m_processInfo);
   m_renderManager.reset(new CRPRenderManager(*m_processInfo));
 
   std::unique_lock<CCriticalSection> lock(m_mutex);
@@ -611,8 +613,8 @@ void CRetroPlayer::CreatePlayback(const std::string& savestatePath)
   {
     m_playback->Deinitialize();
     m_playback = std::make_unique<CReversiblePlayback>(
-        m_gameClient.get(), *m_renderManager, m_cheevos.get(), m_gameClient->GetFrameRate(),
-        m_gameClient->GetSerializeSize());
+        m_gameClient.get(), *m_renderManager, m_cheevos.get(), *m_guiMessenger,
+        m_gameClient->GetFrameRate(), m_gameClient->GetSerializeSize());
   }
   else
     ResetPlayback();

--- a/xbmc/cores/RetroPlayer/RetroPlayer.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.h
@@ -28,6 +28,7 @@ class CGameServices;
 namespace RETRO
 {
 class CCheevos;
+class CGUIGameMessenger;
 class CRetroPlayerInput;
 class CRPProcessInfo;
 class CRPRenderManager;
@@ -124,6 +125,7 @@ private:
 
   // Subsystems
   std::unique_ptr<CRPProcessInfo> m_processInfo;
+  std::unique_ptr<CGUIGameMessenger> m_guiMessenger;
   std::unique_ptr<CRPRenderManager> m_renderManager;
   std::unique_ptr<CRPStreamManager> m_streamManager;
   std::unique_ptr<CRetroPlayerInput> m_input;

--- a/xbmc/cores/RetroPlayer/guibridge/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/guibridge/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(SOURCES GUIGameRenderManager.cpp
+set(SOURCES GUIGameMessenger.cpp
+            GUIGameRenderManager.cpp
             GUIGameSettings.cpp
             GUIGameSettingsHandle.cpp
             GUIGameVideoHandle.cpp
@@ -7,7 +8,8 @@ set(SOURCES GUIGameRenderManager.cpp
             GUIRenderTargetFactory.cpp
 )
 
-set(HEADERS GUIGameRenderManager.h
+set(HEADERS GUIGameMessenger.h
+            GUIGameRenderManager.h
             GUIGameSettings.h
             GUIGameSettingsHandle.h
             GUIGameVideoHandle.h

--- a/xbmc/cores/RetroPlayer/guibridge/GUIGameMessenger.cpp
+++ b/xbmc/cores/RetroPlayer/guibridge/GUIGameMessenger.cpp
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GUIGameMessenger.h"
+
+#include "FileItem.h"
+#include "cores/RetroPlayer/process/RPProcessInfo.h"
+#include "cores/RetroPlayer/rendering/RenderContext.h"
+#include "cores/RetroPlayer/savestates/SavestateDatabase.h"
+#include "guilib/GUIComponent.h"
+#include "guilib/GUIMessage.h"
+#include "guilib/GUIWindowManager.h"
+#include "guilib/WindowIDs.h"
+
+using namespace KODI;
+using namespace RETRO;
+
+CGUIGameMessenger::CGUIGameMessenger(CRPProcessInfo& processInfo)
+  : m_guiComponent(processInfo.GetRenderContext().GUI())
+{
+}
+
+void CGUIGameMessenger::RefreshSavestates(const std::string& savestatePath /* = "" */,
+                                          ISavestate* savestate /* = nullptr */)
+{
+  if (m_guiComponent != nullptr)
+  {
+    CGUIMessage message(GUI_MSG_REFRESH_THUMBS, 0, WINDOW_DIALOG_IN_GAME_SAVES);
+
+    // Add path, if given
+    if (!savestatePath.empty())
+      message.SetStringParam(savestatePath);
+
+    // Add savestate info, if given
+    if (savestate != nullptr)
+    {
+      CFileItemPtr item = std::make_shared<CFileItem>();
+      CSavestateDatabase::GetSavestateItem(*savestate, savestatePath, *item);
+      message.SetItem(std::static_pointer_cast<CGUIListItem>(item));
+    }
+
+    // Notify the in-game savestate dialog
+    m_guiComponent->GetWindowManager().SendThreadMessage(message, WINDOW_DIALOG_IN_GAME_SAVES);
+  }
+}

--- a/xbmc/cores/RetroPlayer/guibridge/GUIGameMessenger.h
+++ b/xbmc/cores/RetroPlayer/guibridge/GUIGameMessenger.h
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+
+class CGUIComponent;
+
+namespace KODI
+{
+namespace RETRO
+{
+class CRPProcessInfo;
+class ISavestate;
+
+/*!
+ * \brief Class to send messages to the GUI, if a GUI is present
+ */
+class CGUIGameMessenger
+{
+public:
+  CGUIGameMessenger(CRPProcessInfo& processInfo);
+
+  /*!
+   * \brief Refresh savestate GUI elements being displayed
+   *
+   * \param savestatePath The savestate to refresh, or empty to refresh all savestates
+   * \param savestate Optional savestate info to send with the message
+   */
+  void RefreshSavestates(const std::string& savestatePath = "", ISavestate* savestate = nullptr);
+
+private:
+  CGUIComponent* const m_guiComponent;
+};
+} // namespace RETRO
+} // namespace KODI

--- a/xbmc/cores/RetroPlayer/process/RPProcessInfo.cpp
+++ b/xbmc/cores/RetroPlayer/process/RPProcessInfo.cpp
@@ -42,7 +42,8 @@ CRPProcessInfo::CRPProcessInfo(std::string platformName)
                                        CServiceBroker::GetWinSystem()->GetGfxContext(),
                                        CDisplaySettings::GetInstance(),
                                        CMediaSettings::GetInstance(),
-                                       CServiceBroker::GetGameServices()))
+                                       CServiceBroker::GetGameServices(),
+                                       CServiceBroker::GetGUI()))
 {
   for (auto& rendererFactory : m_rendererFactories)
   {

--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
@@ -34,13 +34,15 @@ CRenderContext::CRenderContext(CRenderSystemBase* rendering,
                                CGraphicContext& graphicsContext,
                                CDisplaySettings& displaySettings,
                                CMediaSettings& mediaSettings,
-                               GAME::CGameServices& gameServices)
+                               GAME::CGameServices& gameServices,
+                               CGUIComponent* guiComponent)
   : m_rendering(rendering),
     m_windowing(windowing),
     m_graphicsContext(graphicsContext),
     m_displaySettings(displaySettings),
     m_mediaSettings(mediaSettings),
-    m_gameServices(gameServices)
+    m_gameServices(gameServices),
+    m_guiComponent(guiComponent)
 {
 }
 

--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.h
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.h
@@ -17,6 +17,7 @@ class CCriticalSection;
 class CDisplaySettings;
 class CGameSettings;
 class CGraphicContext;
+class CGUIComponent;
 class CGUIShaderDX;
 class CMediaSettings;
 class CRenderSystemBase;
@@ -47,11 +48,13 @@ public:
                  CGraphicContext& graphicsContext,
                  CDisplaySettings& displaySettings,
                  CMediaSettings& mediaSettings,
-                 GAME::CGameServices& gameServices);
+                 GAME::CGameServices& gameServices,
+                 CGUIComponent* guiComponent);
 
   CRenderSystemBase* Rendering() { return m_rendering; }
   CWinSystemBase* Windowing() { return m_windowing; }
   CGraphicContext& GraphicsContext() { return m_graphicsContext; }
+  CGUIComponent* GUI() { return m_guiComponent; }
 
   // Rendering functions
   void SetViewPort(const CRect& viewPort);
@@ -113,6 +116,7 @@ private:
   CDisplaySettings& m_displaySettings;
   CMediaSettings& m_mediaSettings;
   GAME::CGameServices& m_gameServices;
+  CGUIComponent* const m_guiComponent;
 };
 } // namespace RETRO
 } // namespace KODI

--- a/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
@@ -40,7 +40,7 @@ std::unique_ptr<ISavestate> CSavestateDatabase::AllocateSavestate()
   return savestate;
 }
 
-bool CSavestateDatabase::AddSavestate(std::string& savestatePath,
+bool CSavestateDatabase::AddSavestate(const std::string& savestatePath,
                                       const std::string& gamePath,
                                       const ISavestate& save)
 {
@@ -48,17 +48,9 @@ bool CSavestateDatabase::AddSavestate(std::string& savestatePath,
   std::string path;
 
   if (savestatePath.empty())
-  {
-    path = MakePath(gamePath);
-    path = URIUtils::AddFileToFolder(path, save.Created().GetAsSaveString() + SAVESTATE_EXTENSION);
-
-    // return the path to the new savestate
-    savestatePath = path;
-  }
+    path = MakeSavestatePath(gamePath, save.Created());
   else
-  {
     path = savestatePath;
-  }
 
   CLog::Log(LOGDEBUG, "Saving savestate to {}", CURL::GetRedacted(path));
 
@@ -183,6 +175,7 @@ void CSavestateDatabase::GetSavestateItem(const ISavestate& savestate,
   item.SetLabel2(label2);
   item.SetPath(savestatePath);
   item.SetArt("screenshot", MakeThumbnailPath(savestatePath));
+  item.SetProperty(SAVESTATE_LABEL, savestate.Label());
   item.SetProperty(SAVESTATE_CAPTION, savestate.Caption());
   item.m_dateTime = dateUTC;
 }
@@ -235,6 +228,13 @@ bool CSavestateDatabase::ClearSavestatesOfGame(const std::string& gamePath,
 {
   //! @todo
   return false;
+}
+
+std::string CSavestateDatabase::MakeSavestatePath(const std::string& gamePath,
+                                                  const CDateTime& creationTime)
+{
+  std::string path = MakePath(gamePath);
+  return URIUtils::AddFileToFolder(path, creationTime.GetAsSaveString() + SAVESTATE_EXTENSION);
 }
 
 std::string CSavestateDatabase::MakeThumbnailPath(const std::string& savestatePath)

--- a/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.h
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <string>
 
+class CDateTime;
 class CFileItem;
 class CFileItemList;
 
@@ -28,7 +29,7 @@ public:
 
   static std::unique_ptr<ISavestate> AllocateSavestate();
 
-  bool AddSavestate(std::string& savestatePath,
+  bool AddSavestate(const std::string& savestatePath,
                     const std::string& gamePath,
                     const ISavestate& save);
 
@@ -49,6 +50,7 @@ public:
 
   bool ClearSavestatesOfGame(const std::string& gamePath, const std::string& gameClient = "");
 
+  static std::string MakeSavestatePath(const std::string& gamePath, const CDateTime& creationTime);
   static std::string MakeThumbnailPath(const std::string& savestatePath);
 
 private:

--- a/xbmc/games/dialogs/DialogGameDefines.h
+++ b/xbmc/games/dialogs/DialogGameDefines.h
@@ -9,6 +9,7 @@
 #pragma once
 
 // Name of list item property for savestate captions
+constexpr auto SAVESTATE_LABEL = "savestate.label";
 constexpr auto SAVESTATE_CAPTION = "savestate.caption";
 
 // Control IDs for game dialogs

--- a/xbmc/games/dialogs/osd/DialogGameVideoSelect.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoSelect.cpp
@@ -121,6 +121,11 @@ bool CDialogGameVideoSelect::OnMessage(CGUIMessage& message)
 
       break;
     }
+    case GUI_MSG_REFRESH_LIST:
+    {
+      RefreshList();
+      break;
+    }
     default:
       break;
   }
@@ -216,7 +221,7 @@ void CDialogGameVideoSelect::RefreshList()
 
   // Refresh the panel container
   CGUIMessage message(GUI_MSG_REFRESH_THUMBS, GetID(), CONTROL_VIDEO_THUMBS);
-  CServiceBroker::GetGUI()->GetWindowManager().SendMessage(message, GetID());
+  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(message, GetID());
 }
 
 void CDialogGameVideoSelect::SaveSettings()

--- a/xbmc/games/dialogs/osd/DialogInGameSaves.h
+++ b/xbmc/games/dialogs/osd/DialogInGameSaves.h
@@ -10,6 +10,7 @@
 
 #include "DialogGameVideoSelect.h"
 #include "FileItem.h"
+#include "guilib/GUIListItem.h"
 
 #include <string>
 
@@ -22,6 +23,9 @@ class CDialogInGameSaves : public CDialogGameVideoSelect
 public:
   CDialogInGameSaves();
   ~CDialogInGameSaves() override = default;
+
+  // implementation of CGUIControl via CDialogGameVideoSelect
+  bool OnMessage(CGUIMessage& message) override;
 
 protected:
   // implementation of CDialogGameVideoSelect
@@ -45,6 +49,27 @@ protected:
 
 private:
   void InitSavedGames();
+  void OnItemRefresh(const std::string& itemPath, CGUIListItemPtr itemInfo);
+
+  /*!
+   * \brief Translates the GUI list item received in a GUI message into a
+   *        CFileItem with savestate properties
+   *
+   * When a savestate is overwritten, we optimistically populate the GUI list
+   * with a simulated savestate for immediate user feedback. Later (about a
+   * quarter second) a message arrives with the real savestate info.
+   *
+   * \param messagePath The savestate path, pass as the message's string param
+   * \param messageItem The savestate info, if known, or empty if unknown
+   *
+   * If messageItem is empty, the savestate will be loaded from disk, which
+   * is potentially expensive.
+   *
+   * \return A savestate item for the GUI, or empty if no savestate information
+   *         can be obtained
+   */
+  static CFileItemPtr TranslateMessageItem(const std::string& messagePath,
+                                           CGUIListItemPtr messageItem);
 
   CFileItemList m_savestateItems;
   const CFileItemPtr m_newSaveItem;

--- a/xbmc/guilib/GUIMessage.cpp
+++ b/xbmc/guilib/GUIMessage.cpp
@@ -139,3 +139,8 @@ size_t CGUIMessage::GetNumStringParams() const
 {
   return m_params.size();
 }
+
+void CGUIMessage::SetItem(CGUIListItemPtr item)
+{
+  m_item = std::move(item);
+}

--- a/xbmc/guilib/GUIMessage.h
+++ b/xbmc/guilib/GUIMessage.h
@@ -389,6 +389,7 @@ public:
   void SetStringParams(const std::vector<std::string> &params);
   const std::string& GetStringParam(size_t param = 0) const;
   size_t GetNumStringParams() const;
+  void SetItem(CGUIListItemPtr item);
 
 private:
   std::string m_strLabel;


### PR DESCRIPTION
## Description

Backport of https://github.com/xbmc/xbmc/pull/22646

## How has this been tested?

Compiles successfully.

Included in test builds: https://github.com/garbear/xbmc/releases

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
