### PR TITLE
[Windows] Add setting to use OS max SDR brightness when the output is in HDR PQ mode

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -18960,7 +18960,13 @@ msgctxt "#36053"
 msgid "Tuner Device"
 msgstr ""
 
-#empty strings from id 36054 to 36096
+#empty strings from id 36054 to 36095
+
+#. Label of setting "System / Display / Use system HDR/SDR brightness balance"
+#: system/settings/settings.xml
+msgctxt "#36096"
+msgid "Use system HDR/SDR brightness balance"
+msgstr ""
 
 #. Label of setting "System / Display / GUI peak luminance in HDR PQ mode"
 #: system/settings/settings.xml
@@ -23414,4 +23420,16 @@ msgstr ""
 #: xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
 msgctxt "#39189"
 msgid "Available only with manual subtitle position"
+msgstr ""
+
+#. Help text for setting "Use system HDR/SDR brightness balance" of label #36096
+#: system/settings/settings.xml
+msgctxt "#39190"
+msgid "[ON] The brightness of the GUI in HDR mode follows the system's setting. This affects all OSD, subtitles and graphics that are SDR in origin.[CR][OFF] Set the max brightness manually."
+msgstr ""
+
+#. System / Display "HDR" settings group label
+#: system/settings/settings.xml
+msgctxt "#39191"
+msgid "HDR"
 msgstr ""

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2591,17 +2591,6 @@
           </constraints>
           <control type="spinner" format="string" />
         </setting>
-        <setting id="videoscreen.guisdrpeakluminance" type="integer" label="36097" help="36547">
-        <requirement>HAS_DX</requirement>
-          <dependencies>
-            <dependency type="visible">
-              <condition on="property" name="ishdrdisplay" />
-            </dependency>
-          </dependencies>
-          <level>2</level>
-          <default>60</default>
-          <control type="slider" format="percentage" range="0,100" />
-        </setting>
         <setting id="videoscreen.10bitsurfaces" type="integer" label="36098" help="36578">
         <requirement>HAS_DX</requirement>
           <level>3</level>
@@ -2820,7 +2809,37 @@
           <control type="spinner" format="integer" />
         </setting>
       </group>
-      <group id="2" label="14126">
+      <group id="2" label="39191">
+      <setting id="videoscreen.usesystemsdrpeakluminance" type="boolean" label="36096" help="39190">
+        <level>2</level>
+        <default>true</default>
+        <dependencies>
+          <dependency type="visible">
+            <and>
+              <condition on="property" name="ishdrdisplay" />
+              <condition on="property" name="hassystemsdrpeakluminance" />
+            </and>
+          </dependency>
+        </dependencies>
+        <control type="toggle" />
+      </setting>
+      <setting id="videoscreen.guisdrpeakluminance" type="integer" label="36097" help="36547">
+        <requirement>HAS_DX</requirement>
+        <dependencies>
+          <dependency type="visible" on="property" name="ishdrdisplay"/>
+          <dependency type="enable">
+            <or>
+              <condition on="property" name="hassystemsdrpeakluminance" operator="!is" />
+              <condition setting="videoscreen.usesystemsdrpeakluminance" operator="is">false</condition>
+            </or>
+          </dependency>
+        </dependencies>
+        <level>2</level>
+        <default>60</default>
+        <control type="slider" format="percentage" range="0,100" />
+      </setting>
+      </group>
+      <group id="3" label="14126">
         <setting id="videoscreen.whitelist" type="list[string]" parent="videoscreen.screen" label="14126" help="36443">
           <level>3</level>
           <default></default>
@@ -2850,7 +2869,7 @@
           <control type="toggle" />
         </setting>
       </group>
-      <group id="3" label="14232">
+      <group id="4" label="14232">
         <setting id="videoscreen.stereoscopicmode" type="integer" label="36500" help="36539">
           <level>2</level>
           <default>0</default>
@@ -2871,7 +2890,7 @@
           <control type="list" format="integer"/>
         </setting>
       </group>
-      <group id="4" label="496">
+      <group id="5" label="496">
         <setting id="videoscreen.noofbuffers" type="integer" label="36043" help="36552">
           <level>2</level>
           <default>3</default> <!-- triple buffers -->

--- a/xbmc/guilib/GUIShaderDX.cpp
+++ b/xbmc/guilib/GUIShaderDX.cpp
@@ -334,7 +334,8 @@ void CGUIShaderDX::ApplyChanges(void)
       buffer->wvp = worldViewProj;
       buffer->blackLevel = (DX::Windowing()->UseLimitedColor() ? 16.f / 255.f : 0.f);
       buffer->colorRange = (DX::Windowing()->UseLimitedColor() ? (235.f - 16.f) / 255.f : 1.0f);
-      buffer->sdrPeakLum = (100 - DX::Windowing()->GetGuiSdrPeakLuminance()) + 10;
+      if (DX::Windowing()->IsTransferPQ())
+        buffer->sdrPeakLum = 10000.0f / DX::Windowing()->GetGuiSdrPeakLuminance();
       buffer->PQ = (DX::Windowing()->IsTransferPQ() ? 1 : 0);
 
       pContext->Unmap(m_pWVPBuffer.Get(), 0);

--- a/xbmc/platform/win32/WIN32Util.h
+++ b/xbmc/platform/win32/WIN32Util.h
@@ -78,6 +78,7 @@ public:
   // HDR display support
   static HDR_STATUS ToggleWindowsHDR(DXGI_MODE_DESC& modeDesc);
   static HDR_STATUS GetWindowsHDRStatus();
+  static bool GetSystemSdrWhiteLevel(const std::wstring& gdiDeviceName, float* sdrWhiteLevel);
 
   static void PlatformSyslog();
 

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -1273,6 +1273,9 @@ void DX::DeviceResources::SetHdrColorSpace(const DXGI_COLOR_SPACE_TYPE colorSpac
     {
       m_IsTransferPQ = (colorSpace == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020);
 
+      if (m_IsTransferPQ)
+        DX::Windowing()->CacheSystemSdrPeakLuminance();
+
       CLog::LogF(LOGDEBUG, "DXGI SetColorSpace1 success");
     }
     else

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -102,6 +102,14 @@ bool HasPowerOffFeature(const std::string& condition,
   return CServiceBroker::GetPeripherals().SupportsFeature(PERIPHERALS::FEATURE_POWER_OFF);
 }
 
+bool HasSystemSdrPeakLuminance(const std::string& condition,
+                               const std::string& value,
+                               const SettingConstPtr& setting,
+                               void* data)
+{
+  return CServiceBroker::GetWinSystem()->HasSystemSdrPeakLuminance();
+}
+
 bool IsFullscreen(const std::string& condition,
                   const std::string& value,
                   const SettingConstPtr& setting,
@@ -447,6 +455,7 @@ void CSettingConditions::Initialize()
   m_complexConditions.emplace("hasrumblefeature", HasRumbleFeature);
   m_complexConditions.emplace("hasrumblecontroller", HasRumbleController);
   m_complexConditions.emplace("haspowerofffeature", HasPowerOffFeature);
+  m_complexConditions.emplace("hassystemsdrpeakluminance", HasSystemSdrPeakLuminance);
   m_complexConditions.emplace("isfullscreen", IsFullscreen);
   m_complexConditions.emplace("ishdrdisplay", IsHDRDisplay);
   m_complexConditions.emplace("ismasteruser", IsMasterUser);

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -366,6 +366,7 @@ constexpr const char* CSettings::SETTING_VIDEOSCREEN_TESTPATTERN;
 constexpr const char* CSettings::SETTING_VIDEOSCREEN_LIMITEDRANGE;
 constexpr const char* CSettings::SETTING_VIDEOSCREEN_FRAMEPACKING;
 constexpr const char* CSettings::SETTING_VIDEOSCREEN_10BITSURFACES;
+constexpr const char* CSettings::SETTING_VIDEOSCREEN_USESYSTEMSDRPEAKLUMINANCE;
 constexpr const char* CSettings::SETTING_VIDEOSCREEN_GUISDRPEAKLUMINANCE;
 constexpr const char* CSettings::SETTING_AUDIOOUTPUT_AUDIODEVICE;
 constexpr const char* CSettings::SETTING_AUDIOOUTPUT_CHANNELS;

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -365,6 +365,8 @@ public:
   static constexpr auto SETTING_VIDEOSCREEN_LIMITEDRANGE = "videoscreen.limitedrange";
   static constexpr auto SETTING_VIDEOSCREEN_FRAMEPACKING = "videoscreen.framepacking";
   static constexpr auto SETTING_VIDEOSCREEN_10BITSURFACES = "videoscreen.10bitsurfaces";
+  static constexpr auto SETTING_VIDEOSCREEN_USESYSTEMSDRPEAKLUMINANCE =
+      "videoscreen.usesystemsdrpeakluminance";
   static constexpr auto SETTING_VIDEOSCREEN_GUISDRPEAKLUMINANCE = "videoscreen.guisdrpeakluminance";
   static constexpr auto SETTING_AUDIOOUTPUT_AUDIODEVICE = "audiooutput.audiodevice";
   static constexpr auto SETTING_AUDIOOUTPUT_CHANNELS = "audiooutput.channels";

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -173,8 +173,8 @@ public:
   virtual HDR_STATUS ToggleHDR() { return HDR_STATUS::HDR_UNSUPPORTED; }
   virtual HDR_STATUS GetOSHDRStatus() { return HDR_STATUS::HDR_UNSUPPORTED; }
   virtual CHDRCapabilities GetDisplayHDRCapabilities() const { return {}; }
-
   static const char* SETTING_WINSYSTEM_IS_HDR_DISPLAY;
+  virtual bool HasSystemSdrPeakLuminance() { return false; }
 
   // Gets debug info from video renderer
   virtual DEBUG_INFO_RENDER GetDebugInfo() { return {}; }

--- a/xbmc/windowing/win10/WinSystemWin10.h
+++ b/xbmc/windowing/win10/WinSystemWin10.h
@@ -81,6 +81,7 @@ public:
   bool Show(bool raise = true) override;
   std::string GetClipboardText() override;
   bool UseLimitedColor() override;
+  bool HasSystemSdrPeakLuminance() override;
 
   // videosync
   std::unique_ptr<CVideoSync> GetVideoSync(void *clock) override;
@@ -96,7 +97,8 @@ public:
   virtual bool DPIChanged(WORD dpi, RECT windowRect) const;
   bool IsMinimized() const { return m_bMinimized; }
   void SetMinimized(bool minimized) { m_bMinimized = minimized; }
-  int GetGuiSdrPeakLuminance() const;
+  float GetGuiSdrPeakLuminance() const;
+  void CacheSystemSdrPeakLuminance();
 
   bool CanDoWindowed() override;
 
@@ -150,6 +152,9 @@ protected:
   bool m_bFirstResChange = true;
 
   winrt::Windows::UI::Core::CoreWindow m_coreWindow = nullptr;
+
+  bool m_validSystemSdrPeakLuminance{false};
+  float m_systemSdrPeakLuminance{.0f};
 };
 
 #pragma pack(pop)

--- a/xbmc/windowing/windows/WinSystemWin32.h
+++ b/xbmc/windowing/windows/WinSystemWin32.h
@@ -95,6 +95,7 @@ public:
   bool Show(bool raise = true) override;
   std::string GetClipboardText() override;
   bool UseLimitedColor() override;
+  bool HasSystemSdrPeakLuminance() override;
 
   // videosync
   std::unique_ptr<CVideoSync> GetVideoSync(void *clock) override;
@@ -112,7 +113,8 @@ public:
   virtual bool DPIChanged(WORD dpi, RECT windowRect) const;
   bool IsMinimized() const { return m_bMinimized; }
   void SetMinimized(bool minimized);
-  int GetGuiSdrPeakLuminance() const;
+  float GetGuiSdrPeakLuminance() const;
+  void CacheSystemSdrPeakLuminance();
 
   void SetSizeMoveMode(bool mode) { m_bSizeMoveEnabled = mode; }
   bool IsInSizeMoveMode() const { return m_bSizeMoveEnabled; }
@@ -190,6 +192,9 @@ protected:
 
   static const char* SETTING_WINDOW_TOP;
   static const char* SETTING_WINDOW_LEFT;
+
+  bool m_validSystemSdrPeakLuminance{false};
+  float m_systemSdrPeakLuminance{.0f};
 };
 
 extern HWND g_hWnd;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

This PR expands on PR #21973 that added a setting to control the brightness of Kodi's subtitles and other GUI elements in HDR playback.

Windows 10 1709 added support for "HDR/SDR brightness balance" in Windows HD Color Settings for the same thing.

This PR creates a new setting (on by default, visible only for the platforms that support it) that controls the retrieval of the max brightness from the system to push it to the GUI shaders instead of the value derived from the setting added by PR #21973.
The 2 settings are now grouped in a new group "HDR" for readability.

WinSystemWin32 and GUIShaderDX were modified to use a value in nits, clamp it to 10000 nits (the maximum in PQ, value 1 in a normalized texture) and scale the SDR rgb values of the shader.


One open question:
- The API was added in Windows 10 version 1709, I'm not sure how earlier versions will react and don't have a PC to try it. Will DisplayConfigGetDeviceInfo return ERROR_NOT_SUPPORTED or throw an exception, or...  Version checking is not advised by MS but I didn't find a way to query the existence of the API.

## Motivation and context
Integrate Kodi with Windows setting "HDR/SDR brightness balance" to remove the need for manual configuration in Kodi and achieve consistency with other Windows applications.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
## How has this been tested?
Windows 10 22H2 x64 & UWP x64, 1 screen HDR 1 screen SDR, the brightness matched perfectly that of other apps.

I don't have Windows 10 < 1709 to see what happens before the feature was supported by Windows.

<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
The max brightness of subtitlles and GUI in HDR playback should be OK out of the box and adjustments made in Windows for other apps will be reflected in Kodi as well.

The user can still go to Kodi settings to disable this mode and select a max brightness manually (added by PR #21973)

<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
