### PR TITLE
Update meson to v1.0.0

### DIFF
--- a/tools/depends/native/meson/Makefile
+++ b/tools/depends/native/meson/Makefile
@@ -4,10 +4,10 @@ DEPS =../../Makefile.include Makefile ../../download-files.include
 
 # lib name, version
 LIBNAME=meson
-VERSION=0.59.2
+VERSION=1.0.0
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
-SHA512=126ac3a6c6b9e1fba1b3ac163f02d1eb0b61fedb312bcfe4996f6150522688d424f47283070c95101cc456afe9ea5cb462fb38f368d0c732952ffb8c600fda00
+SHA512=9b1195cfe856c1aa51bc79f6eb4d0f94925bb02d0a9fbd68a6a6ced6e5c252b09b22d9aac812640687e49b8d64a313ce48d0a69a3bf83ea8ffb8c9dab559fc23
 include ../../download-files.include
 
 all: .installed-$(PLATFORM)


### PR DESCRIPTION
## Description
Update meson build system to v1.0.0

## Motivation and context
I have code in development, this module requires meson to be at least 0.62, we only have 0.59.2 so that would fail

## How has this been tested?
Build libdrm without issue

## What is the effect on users?
None

## Types of change
- [x] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
