### PR TITLE
AudioTrack: More generalization from the other end

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -442,7 +442,7 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
     }
 
     m_min_buffer_size = (unsigned int) min_buffer;
-    CLog::Log(LOGDEBUG, "Minimum size we need for stream: {}", m_min_buffer_size);
+    CLog::Log(LOGINFO, "Minimum size we need for stream: {} Bytes", m_min_buffer_size);
     double rawlength_in_seconds = 0.0;
     int multiplier = 1;
     unsigned int ac3FrameSize = 1;
@@ -546,7 +546,7 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
       }
       m_format.m_frames = static_cast<int>(period_size / m_format.m_frameSize);
 
-      CLog::Log(LOGDEBUG,
+      CLog::Log(LOGINFO,
                 "Audiotrack buffer params are: period time = {:.3f} ms, period size = "
                 "{} bytes, num periods = {}",
                 period_time * 1000, period_size, m_min_buffer_size / period_size);
@@ -555,8 +555,7 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
     if (m_passthrough && !m_info.m_wantsIECPassthrough)
       m_audiotrackbuffer_sec = rawlength_in_seconds;
 
-
-    CLog::Log(LOGDEBUG,
+    CLog::Log(LOGINFO,
               "Created Audiotrackbuffer with playing time of {:f} ms min buffer size: {} bytes",
               m_audiotrackbuffer_sec * 1000, m_min_buffer_size);
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -811,6 +811,13 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t **data, unsigned int frames, 
   if (!IsInitialized())
     return INT_MAX;
 
+  const double max_delay = m_passthrough ? 0.6 : 0.4;
+  if (m_delay > max_delay)
+  {
+    CLog::Log(LOGERROR, "Sink got stuck with large buffer {:f} - reopening", m_delay);
+    return INT_MAX;
+  }
+
   // for debugging only - can be removed if everything is really stable
   uint64_t startTime = CurrentHostCounter();
 


### PR DESCRIPTION
The new FireTV Cube reacts from a min_buffer time of view completely different to other devices, in the sense of that it returns actually "usable" values as min_buffer time. For DTS-HD-MA and TrueHD it already reports 128 ms minimal. Our concept did not assume this.

Therefore:
- Rework the buffer time search by extending it to start from min_buffer already and not blindly doubleing the value
- Move some logs from DEBUG to INFO as they are important to know and amazon changed the default log level so that DEBUG is not visible anymore. Our logging framework "blindly" uses this setting from Android