### PR TITLE
Game OSD: Fix missing OnClick actions for video thumbnail dialogs

### DIFF
--- a/xbmc/games/dialogs/osd/DialogGameStretchMode.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameStretchMode.cpp
@@ -120,3 +120,9 @@ void CDialogGameStretchMode::PostExit()
 {
   m_stretchModes.clear();
 }
+
+bool CDialogGameStretchMode::OnClickAction()
+{
+  Close();
+  return true;
+}

--- a/xbmc/games/dialogs/osd/DialogGameStretchMode.h
+++ b/xbmc/games/dialogs/osd/DialogGameStretchMode.h
@@ -31,6 +31,7 @@ protected:
   void OnItemFocus(unsigned int index) override;
   unsigned int GetFocusedItem() const override;
   void PostExit() override;
+  bool OnClickAction() override;
 
 private:
   struct StretchModeProperties

--- a/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
@@ -142,6 +142,12 @@ void CDialogGameVideoFilter::PostExit()
   m_items.Clear();
 }
 
+bool CDialogGameVideoFilter::OnClickAction()
+{
+  Close();
+  return true;
+}
+
 void CDialogGameVideoFilter::GetProperties(const CFileItem& item,
                                            std::string& videoFilter,
                                            std::string& description)

--- a/xbmc/games/dialogs/osd/DialogGameVideoFilter.h
+++ b/xbmc/games/dialogs/osd/DialogGameVideoFilter.h
@@ -29,6 +29,7 @@ protected:
   void OnItemFocus(unsigned int index) override;
   unsigned int GetFocusedItem() const override;
   void PostExit() override;
+  bool OnClickAction() override;
 
 private:
   void InitVideoFilters();

--- a/xbmc/games/dialogs/osd/DialogGameVideoRotation.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoRotation.cpp
@@ -83,6 +83,12 @@ void CDialogGameVideoRotation::PostExit()
   m_rotations.clear();
 }
 
+bool CDialogGameVideoRotation::OnClickAction()
+{
+  Close();
+  return true;
+}
+
 std::string CDialogGameVideoRotation::GetRotationLabel(unsigned int rotationDegCCW)
 {
   switch (rotationDegCCW)

--- a/xbmc/games/dialogs/osd/DialogGameVideoRotation.h
+++ b/xbmc/games/dialogs/osd/DialogGameVideoRotation.h
@@ -31,6 +31,7 @@ protected:
   void OnItemFocus(unsigned int index) override;
   unsigned int GetFocusedItem() const override;
   void PostExit() override;
+  bool OnClickAction() override;
 
 private:
   // Helper functions


### PR DESCRIPTION
## Description

This PR fixes missing onclick actions for video thumbnails in the Video Filter, Stretch Mode and Rotation selection dialogs.

When adding the Menu in https://github.com/xbmc/xbmc/pull/22585, closing the dialog was factored out, so the dialogs now need to explicitly close themselves.

## Motivation and context

Reported here: https://forum.kodi.tv/showthread.php?tid=173361&pid=3139497#pid3139497

## How has this been tested?

Tested in Video Filter, Stretch Mode and Rotation dialogs. Pressing A on a thumbnail successfully closes the dialog.

Test builds are uploading as we speak.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
