### PR TITLE
Add a/v corrections counter in Debug Info OSD

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
@@ -116,5 +116,6 @@ protected:
 
   bool m_displayReset = false;
   unsigned int m_disconAdjustTimeMs = 10; // maximum sync-off before adjusting
+  int m_disconAdjustCounter = 0;
 };
 


### PR DESCRIPTION
## Description
Add a/v corrections counter in Debug Info OSD

## Motivation and context
Users can view in realtime `CDVDClock::ErrorAdjust` without need enable debug log

This is related to new advancedsetting `<maxpassthroughoffsyncduration>` introduced in https://github.com/xbmc/xbmc/pull/22664

And discussed in this thread: https://forum.kodi.tv/showthread.php?tid=371292

On Shield, this is an indicator that micro-stuttering is occurring and then is usefully to calibrate minimal `maxpassthroughoffsyncduration` value required to avoid this.

It is also very useful to know if stuttering are due to this or something else.


## How has this been tested?
Runtime Windows x64


## What is the effect on users?
More happiness


## Screenshots (if appropriate):

![discon3](https://user-images.githubusercontent.com/58434170/218879250-2f5b34fe-300e-4e6a-a632-04f0091502fc.png)



## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
