### PR TITLE
[utils][color] Fix typo in ConvertoToHexRGB

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleTagSami.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleTagSami.cpp
@@ -32,7 +32,7 @@ std::string TranslateColorValue(std::string value)
   StringUtils::ToLower(value);
   const auto itHtmlColor = UTILS::COLOR::HTML_BASIC_COLORS.find(value);
   if (itHtmlColor != UTILS::COLOR::HTML_BASIC_COLORS.cend())
-    return UTILS::COLOR::ConvertoToHexRGB(itHtmlColor->second);
+    return UTILS::COLOR::ConvertToHexRGB(itHtmlColor->second);
 
   // Try validate hex color value
   if (value.size() == 6)

--- a/xbmc/utils/ColorUtils.cpp
+++ b/xbmc/utils/ColorUtils.cpp
@@ -144,7 +144,7 @@ ColorFloats UTILS::COLOR::ConvertToFloats(const Color argb)
   return c;
 }
 
-std::string UTILS::COLOR::ConvertoToHexRGB(const Color argb)
+std::string UTILS::COLOR::ConvertToHexRGB(const Color argb)
 {
   return StringUtils::Format("{:06X}", argb & ~0xFF000000);
 }

--- a/xbmc/utils/ColorUtils.h
+++ b/xbmc/utils/ColorUtils.h
@@ -161,7 +161,7 @@ ColorFloats ConvertToFloats(const Color argb);
  * \param color The original color
  * \return The original color converted to hex RGB
  */
-std::string ConvertoToHexRGB(const Color argb);
+std::string ConvertToHexRGB(const Color argb);
 
 } // namespace COLOR
 } // namespace UTILS


### PR DESCRIPTION
## Description
Fixes a simple typo spotted in https://github.com/xbmc/xbmc/pull/22525