### PR TITLE
[upnp]: load library art before broadcasting remote watched state

### DIFF
--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -1196,6 +1196,11 @@ CUPnPServer::OnUpdateObject(PLT_ActionReference&             action,
         if (updatelisting) {
             db.LoadVideoInfo(file_path, tag);
             updated.SetFromVideoInfoTag(tag);
+            //! TODO: we should find a way to avoid obtaining the artwork just to
+            // update the playcount or similar properties. Maybe a flag in the GUI
+            // update message to inform we should only update the playback properties
+            // without touching other parts of the item.
+            CVideoThumbLoader().FillLibraryArt(updated);
         }
 
     } else if (updated.IsMusicDb()) {


### PR DESCRIPTION
## Description
When you mark a given item as watched on some remote client via upnp (and if the given item is in the library) a GUI message is broadcasted to update the item (e.g. set playcount). The issue is that the new item that is sent doesn't have the art member filled which results into removing the artwork on the current view.

Example,

**Kodi UI (kodi upnp server) before marking the item as watched on the external device:**

![image](https://user-images.githubusercontent.com/7375276/219002442-47e96aae-3f61-4bf5-a07b-4ae2e74ff21f.png)

**Kodi UI (kodi upnp server) after marking the item as watched on the external device without leaving the previous window:**

![image](https://user-images.githubusercontent.com/7375276/219002912-785f08b8-e241-4b78-9957-f4e82d9f4b8c.png)

**After this change:**

![image](https://user-images.githubusercontent.com/7375276/219005428-663114b5-87eb-4806-8b67-6c1d3781a174.png)
