### PR TITLE
[upnp]: fix state reporting

### DIFF
--- a/xbmc/network/upnp/UPnP.cpp
+++ b/xbmc/network/upnp/UPnP.cpp
@@ -245,10 +245,10 @@ public:
             NPT_String::Format("<upnp:lastPlaybackPosition>%ld</upnp:lastPlaybackPosition>",
               time)));
 
-          NPT_String curr_value = "<upnp:lastPlayerState>";
+          NPT_String curr_value = "<xbmc:lastPlayerState>";
           PLT_Didl::AppendXmlEscape(curr_value, item.GetVideoInfoTag()->GetResumePoint().playerState.c_str());
           curr_value += "</xbmc:lastPlayerState>";
-          NPT_String new_value = "<upnp:lastPlayerState>";
+          NPT_String new_value = "<xbmc:lastPlayerState>";
           PLT_Didl::AppendXmlEscape(new_value, bookmark.playerState.c_str());
           new_value += "</xbmc:lastPlayerState>";
           values.insert(std::make_pair(curr_value, new_value));


### PR DESCRIPTION
## Description
No idea how this has ever worked since the root cause is the fact we construct an incorrect xml model (open tag `<upnp:lastPlayerState>` and companion close tag `<xbmc:lastPlayerState>`). Tag parser complains and returns early in libplatinum (https://github.com/xbmc/xbmc/blob/master/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltMediaServer.cpp#L388). Looking into the code the tag is xbmc specific.

Fixes https://github.com/xbmc/xbmc/issues/22769

Runtime tested using Kodi as client (phone) and kodi as upnp server (desktop). Also tested against other upnp servers (jellyfin)