### PR TITLE
[MUSIC] Refresh GUI when song details updated via json for currently …

### DIFF
--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -1022,7 +1022,11 @@ JSONRPC_STATUS CAudioLibrary::SetSongDetails(const std::string &method, ITranspo
   if (!musicdatabase.UpdateSong(song, updateartists))
     return InternalError;
 
-  CJSONRPCUtils::NotifyItemUpdated();
+  CFileItemPtr pItem(new CFileItem(song));
+  CMusicThumbLoader loader;
+  loader.FillLibraryArt(*pItem); // get associated art for this item
+
+  CJSONRPCUtils::NotifyItemUpdated(pItem); // tell the gui this item has changed
   return ACK;
 }
 

--- a/xbmc/interfaces/json-rpc/JSONRPC.cpp
+++ b/xbmc/interfaces/json-rpc/JSONRPC.cpp
@@ -379,6 +379,14 @@ void CJSONRPCUtils::NotifyItemUpdated()
   CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(message);
 }
 
+void CJSONRPCUtils::NotifyItemUpdated(const CFileItemPtr& pItem)
+{
+  CGUIMessage message(GUI_MSG_NOTIFY_ALL,
+                      CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow(), 0,
+                      GUI_MSG_UPDATE_ITEM, 0, pItem);
+  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(message);
+}
+
 void CJSONRPCUtils::NotifyItemUpdated(const CVideoInfoTag& info,
                                       const std::map<std::string, std::string>& artwork)
 {

--- a/xbmc/interfaces/json-rpc/JSONRPCUtils.h
+++ b/xbmc/interfaces/json-rpc/JSONRPCUtils.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "FileItem.h"
 #include "IClient.h"
 #include "ITransportLayer.h"
 
@@ -157,6 +158,7 @@ namespace JSONRPC
   {
   public:
     static void NotifyItemUpdated();
+    static void NotifyItemUpdated(const CFileItemPtr& pItem);
     static void NotifyItemUpdated(const CVideoInfoTag& info,
                                   const std::map<std::string, std::string>& artwork);
   };


### PR DESCRIPTION
…ly playing item

## Description
When calling AudioLibrary.SetSongDetails using json, changing a value (eg, userrating) will not be reflected in the GUI, despite the db and associated `CMusicInfoTag()` both containing the new value(s). GUI will continue to display the original value(s) until playback is stopped and re-started.

## Motivation and context
Originally raised in [this forum thread](https://forum.kodi.tv/showthread.php?tid=371920).  Updating song details such as userrating, mood, votes etc  via json-rpc should be reflected in the GUI immediately.

## How has this been tested?

I've tested this using the OP's skin and custom script (both available in the linked thread).  Observing the appropriate variables in a debugger showed that whilst they are updated correctly, the GUI does not re-read the tag info, therefore the info on screen does not update without stopping and restarting playback. 

I looked at how the videolibrary calls the GUI to re-read the tag info when it updates and followed a similar method.

<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
Means that the GUI will update ListItems etc when updating song details dynamically using the json-rpc interface.  

Albums and artists need to be added for any items that could be updated on-the-fly (genres, themes, moods etc), in a later PR.
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
