### PR TITLE
[macos-nativeWindow] main thread exit waits for xbmc thread [ resolves #22788 ]

### DIFF
--- a/xbmc/platform/darwin/osx/Info.plist.in
+++ b/xbmc/platform/darwin/osx/Info.plist.in
@@ -32,5 +32,7 @@
 	<string>@CMAKE_OSX_DEPLOYMENT_TARGET@</string>
 	<key>CFBundleSignature</key>
 	<string>@APP_NAME@</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Description
**Note**: the issue that this PR applies to is for a macOS build of Kodi configured with `--with-windowsystem=native` and cmake with `APP_WINDOW_SYSTEM=native`. Builds with this configuration are not publicly released, as far as I know.

Implement the `NSApplicationDelegate` to wait for the XBMC main loop thread to exit, after which it is safe to call destructors to global static objects.
<!--- Describe your change in detail here. -->
- `-[NSApplicationDelegate applicationWillFinishLaunching:]`
   - create XBMC main thread
   - create thread exit observer
   - start XBMC main thread
- `-[NSApplicationDelegate applicationShouldTerminate:]`
   - if `GetAppPort()` is `nullptr`, tell `NSApplication` to exit immediately
   - else post `XBMC_QUIT` and tell `NSApplication` to enter a modal runLoop
- on thread exit observer block:
   - tell `NSApplication` to exit modal runLoop
   - proceed with `-[NSApplication terminate:]`
- use blocks (closures) instead of method selectors
- call `NSApplicationMain()` as prescribed by Apple for all objective-C applications.
- remove dead code, unused includes
- add `const`s as required by `NSApplicationMain()`

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This resolves https://github.com/xbmc/xbmc/issues/22788

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
foreach method in [quit via dock menu, quit via menubar Quit, logout, shutdown]
1. launch Kodi in debugger
2. quit via {method}

Note: Jenkins builds Kodi.app with the `APP_WINDOW_SYSTEM=sdl` configuration, which does not have this issue.

## What is the effect on users?
Avoids crashes on application exit via system shutdown, logout, dock menu, menubar menu, applescripts, and shortcuts.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
