### PR TITLE
AudioTrack: Increase robustness

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -516,14 +516,14 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
       // the period calculation starts
       // after the buffer division to get even division results
       int c = 1;
-      if (m_audiotrackbuffer_sec > 0.2)
+      if (m_audiotrackbuffer_sec > 0.25)
       {
         CLog::Log(LOGWARNING,
                   "Audiobuffer is already very large {:f} ms - Reducing to a sensible value",
                   1000.0 * m_audiotrackbuffer_sec);
-        int buffer_frames = m_sink_sampleRate / 5; // 200 ms
+        int buffer_frames = m_sink_sampleRate / 4; // 250 ms
         m_min_buffer_size = buffer_frames * m_sink_frameSize;
-        c = 4; // 50 ms
+        c = 5; // 50 ms
       }
       // update potential new buffertime
       m_audiotrackbuffer_sec =
@@ -811,8 +811,7 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t **data, unsigned int frames, 
   if (!IsInitialized())
     return INT_MAX;
 
-  const double max_delay = m_passthrough ? 0.6 : 0.4;
-  if (m_delay > max_delay)
+  if (m_delay > 1.0)
   {
     CLog::Log(LOGERROR, "Sink got stuck with large buffer {:f} - reopening", m_delay);
     return INT_MAX;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -442,7 +442,7 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
     }
 
     m_min_buffer_size = (unsigned int) min_buffer;
-    CLog::Log(LOGDEBUG, "Minimum size we need for stream: {}", m_min_buffer_size);
+    CLog::Log(LOGINFO, "Minimum size we need for stream: {} Bytes", m_min_buffer_size);
     double rawlength_in_seconds = 0.0;
     int multiplier = 1;
     unsigned int ac3FrameSize = 1;
@@ -558,7 +558,7 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
       }
       m_format.m_frames = static_cast<int>(period_size / m_format.m_frameSize);
 
-      CLog::Log(LOGDEBUG,
+      CLog::Log(LOGINFO,
                 "Audiotrack buffer params are: period time = {:.3f} ms, period size = "
                 "{} bytes, num periods = {}",
                 period_time * 1000, period_size, m_min_buffer_size / period_size);
@@ -567,8 +567,7 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
     if (m_passthrough && !m_info.m_wantsIECPassthrough)
       m_audiotrackbuffer_sec = rawlength_in_seconds;
 
-
-    CLog::Log(LOGDEBUG,
+    CLog::Log(LOGINFO,
               "Created Audiotrackbuffer with playing time of {:f} ms min buffer size: {} bytes",
               m_audiotrackbuffer_sec * 1000, m_min_buffer_size);
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -812,6 +812,13 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t **data, unsigned int frames, 
   if (!IsInitialized())
     return INT_MAX;
 
+  const double max_delay = m_passthrough ? 0.6 : 0.4;
+  if (m_delay > max_delay)
+  {
+    CLog::Log(LOGERROR, "Sink got stuck with large buffer {:f} - reopening", m_delay);
+    return INT_MAX;
+  }
+
   // for debugging only - can be removed if everything is really stable
   uint64_t startTime = CurrentHostCounter();
 


### PR DESCRIPTION
Backport of https://github.com/xbmc/xbmc/pull/22764 and https://github.com/xbmc/xbmc/pull/22800

- Increases the robustness for detection period / buffers, especially when API already returns high values
- Make sure to tell AE when sink is not moving and running full
- Move certain important logs from debug to info, so that they are visible on amazon devices.


Side-Effect of second change: works around Cube 3rd Gen Firmware issue with 2 channel IEC