### PR TITLE
VideoPlayerAudio: use simple algorithm for self-learning max allowed a/v Out-Of-Sync

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -229,6 +229,18 @@ void CVideoPlayerAudio::Process()
   m_audioStats.Start();
   m_disconAdjustCounter = 0;
 
+  // Only enable "learning" if advancedsettings m_maxPassthroughOffSyncDuration
+  // not exists or has it's default 10 ms value, otherwise use advancedsettings value
+  if (m_disconAdjustTimeMs == 10)
+  {
+    m_disconTimer.Set(30s);
+    m_disconLearning = true;
+  }
+  else
+  {
+    m_disconLearning = false;
+  }
+
   bool onlyPrioMsgs = false;
 
   while (!m_bStop)
@@ -530,10 +542,27 @@ bool CVideoPlayerAudio::ProcessDecoderOutput(DVDAudioFrame &audioframe)
     audioframe.hasDownmix = true;
   }
 
-
+  if (m_synctype == SYNC_DISCON)
   {
     double syncerror = m_audioSink.GetSyncError();
-    if (m_synctype == SYNC_DISCON && fabs(syncerror) > DVD_MSEC_TO_TIME(m_disconAdjustTimeMs))
+
+    if (m_disconLearning)
+    {
+      const double syncErr = std::abs(syncerror);
+      if (syncErr > DVD_MSEC_TO_TIME(m_disconAdjustTimeMs))
+        m_disconAdjustTimeMs = DVD_TIME_TO_MSEC(syncErr);
+      if (m_disconTimer.IsTimePast())
+      {
+        m_disconLearning = false;
+        m_disconAdjustTimeMs = (static_cast<double>(m_disconAdjustTimeMs) * 1.15) + 5.0;
+        if (m_disconAdjustTimeMs > 100) // sanity check
+          m_disconAdjustTimeMs = 100;
+
+        CLog::LogF(LOGINFO, "Changed max allowed Out-Of-Sync value to {} ms due self-learning",
+                   m_disconAdjustTimeMs);
+      }
+    }
+    else if (std::abs(syncerror) > DVD_MSEC_TO_TIME(m_disconAdjustTimeMs))
     {
       double correction = m_pClock->ErrorAdjust(syncerror, "CVideoPlayerAudio::OutputPacket");
       if (correction != 0)

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
@@ -117,5 +117,7 @@ protected:
   bool m_displayReset = false;
   unsigned int m_disconAdjustTimeMs = 10; // maximum sync-off before adjusting
   int m_disconAdjustCounter = 0;
+  XbmcThreads::EndTime<> m_disconTimer;
+  bool m_disconLearning = false;
 };
 


### PR DESCRIPTION
## Description
Use simple algorithm for self-learning max allowed a/v Out-Of-Sync

Algorithm runs for 30 seconds to learn what is going on: During this time *no* corrections are done, but the internal m_disconAdjustTimeMs is updated to a new value, when the sync error is higher than m_disconAdjustTimeMs. 

After 30 seconds the learning stops and the final m_disconAdjustTimeMs is set as: `m_disconAdjustTimeMs * 1.15 + 5.0`

## Motivation and context
Follow-up of https://github.com/xbmc/xbmc/pull/22664 and https://github.com/xbmc/xbmc/pull/22770

Some users has trouble to find advanced setting `maxpassthroughoffsyncduration` that works well in their setup. Also this number is variable because is HW specific and even depends of "part of HW" and protocol used: USB, Ethernet, WiFi, NFS, SMB, HTTPS. 

Also generic trouble due need configure advancedsettings, etc.

Magic number calculated should work well in 99% of cases or at least better than current default or not optimized handwritten value. Default 10 ms seems clearly insufficient for Shield but still works fine for some users. 

It seems a much more robust solution to use an "adaptive" value.


## How has this been tested?
Shield 2019 (FW 9.1.1) using Ethernet (NFS) and also tested USB
Windows 11 22H2 - Intel NUC8i3BEK + Denon X1600H

Tested both 1080p SRD and 4K HDR videos


## What is the effect on users?
Even greater happiness :)



## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
