### PR TITLE
FileCache: streamline caching.

### DIFF
--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -86,8 +86,6 @@ CFileCache::CFileCache(const unsigned int flags)
     m_seekPossible(0),
     m_nSeekResult(0),
     m_seekPos(0),
-    m_readPos(0),
-    m_writePos(0),
     m_chunkSize(0),
     m_writeRate(0),
     m_writeRateActual(0),
@@ -211,14 +209,13 @@ bool CFileCache::Open(const CURL& url)
     return false;
   }
 
-  m_readPos = 0;
-  m_writePos = 0;
   m_writeRate = 1024 * 1024;
   m_writeRateActual = 0;
   m_writeRateLowSpeed = 0;
   m_bFilling = true;
   m_seekEvent.Reset();
   m_seekEnded.Reset();
+  m_readEvent.Reset();
 
   CThread::Create(false);
 
@@ -245,108 +242,111 @@ void CFileCache::Process()
 
   CWriteRate limiter;
   CWriteRate average;
+  CLog::Log(LOGINFO, "CFileCache::{} - <{}> allocated read buffer: {}", __FUNCTION__,
+    m_sourcePath, m_chunkSize);
 
   while (!m_bStop)
   {
-    // Update filesize
-    m_fileSize = m_source.GetLength();
-
-    // check for seek events
-    if (m_seekEvent.Wait(0ms))
+    while (!m_bStop && m_writeRate)
     {
-      m_seekEvent.Reset();
-      const int64_t cacheMaxPos = m_pCache->CachedDataEndPosIfSeekTo(m_seekPos);
-      const bool cacheReachEOF = (cacheMaxPos == m_fileSize);
-
-      bool sourceSeekFailed = false;
-      if (!cacheReachEOF)
-      {
-        m_nSeekResult = m_source.Seek(cacheMaxPos, SEEK_SET);
-        if (m_nSeekResult != cacheMaxPos)
-        {
-          CLog::Log(LOGERROR, "CFileCache::{} - <{}> error {} seeking. Seek returned {}",
-                    __FUNCTION__, m_sourcePath, GetLastError(), m_nSeekResult);
-          m_seekPossible = m_source.IoControl(IOCTRL_SEEK_POSSIBLE, NULL);
-          sourceSeekFailed = true;
-        }
-      }
-
-      if (!sourceSeekFailed)
-      {
-        const bool bCompleteReset = m_pCache->Reset(m_seekPos);
-        m_readPos = m_seekPos;
-        m_writePos = m_pCache->CachedDataEndPos();
-        assert(m_writePos == cacheMaxPos);
-        average.Reset(m_writePos, bCompleteReset); // Can only recalculate new average from scratch after a full reset (empty cache)
-        limiter.Reset(m_writePos);
-        m_nSeekResult = m_seekPos;
-        if (bCompleteReset)
-        {
-          CLog::Log(LOGDEBUG,
-                    "CFileCache::{} - <{}> cache completely reset for seek to position {}",
-                    __FUNCTION__, m_sourcePath, m_seekPos);
-          m_bFilling = true;
-          m_writeRateLowSpeed = 0;
-        }
-      }
-
-      m_seekEnded.Set();
-    }
-
-    while (m_writeRate)
-    {
-      if (m_writePos - m_readPos < m_writeRate * CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_cacheReadFactor)
+      if (m_pCache->CachedDataEndPos() - m_pCache->CachedDataStartPos() < m_writeRate * CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_cacheReadFactor)
       {
         limiter.Reset(m_writePos);
         break;
       }
 
-      if (limiter.Rate(m_writePos) < m_writeRate * CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_cacheReadFactor)
+      if (limiter.Rate(m_pCache->CachedDataEndPos()) < m_writeRate * CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_cacheReadFactor)
         break;
 
-      if (m_seekEvent.Wait(100ms))
-      {
-        if (!m_bStop)
+      if (m_readEvent.Wait(100ms)) {
+        if (m_seekEvent.Wait(0ms))
           m_seekEvent.Set();
         break;
       }
     }
 
-    const int64_t maxWrite = m_pCache->GetMaxWriteSize(m_chunkSize);
+    if (m_bStop)
+      break;
+
+    // Update filesize
+    m_fileSize = m_source.GetLength();
+
+    if (m_seekEvent.Wait(0ms)) // check for seek events
+    {
+      m_seekEvent.Reset();
+
+      if (m_seekPossible == 0) {
+        if (m_pCache->CachedDataEndPosIfSeekTo(m_seekPos) == m_seekPos) {
+          m_pCache->Reset(m_seekPos);
+          m_nSeekResult = m_seekPos;
+        } else if (m_seekPos > m_pCache->CachedDataEndPos()) {
+          m_pCache->Reset(m_pCache->CachedDataEndPos());
+          m_nSeekResult = m_pCache->CachedDataEndPos();
+        } else if (m_seekPos < m_pCache->CachedDataStartPos()) {
+          m_pCache->Reset(m_pCache->CachedDataStartPos());
+          m_nSeekResult = m_pCache->CachedDataStartPos();
+        } else {
+          m_nSeekResult = -1;
+        }
+      } else {
+        if (m_pCache->Reset(m_seekPos)) {
+          CLog::Log(LOGINFO,
+            "CFileCache::{} - <{}> cache completely reset to seek to position {}",
+            __FUNCTION__, m_sourcePath, m_pCache->CachedDataEndPos());
+        }
+
+        m_nSeekResult = m_source.Seek(m_pCache->CachedDataEndPos(), SEEK_SET);
+        if (m_nSeekResult != m_pCache->CachedDataEndPos()) {
+          CLog::Log(LOGINFO,
+            "CFileCache::{} - <{}> seek failed to position {}",
+             __FUNCTION__, m_sourcePath, m_seekPos);
+          m_pCache->Reset(m_source.Seek(0, SEEK_CUR));
+          m_seekPossible = m_source.IoControl(IOCTRL_SEEK_POSSIBLE, NULL);
+        }
+      }
+
+      average.Reset(m_pCache->CachedDataEndPos(), m_pCache->CachedDataEndPos() - m_pCache->CachedDataStartPos() == 0);
+      limiter.Reset(m_pCache->CachedDataEndPos());
+      m_bFilling = true;
+      m_seekEnded.Set();
+      continue;
+    } else if (m_fileSize == m_pCache->CachedDataEndPos()) {
+      m_pCache->EndOfInput();
+
+      // The thread event will now also cause the wait of an event to return a false.
+      if (AbortableWait(m_seekEvent) == WAIT_SIGNALED)
+      {
+        m_pCache->ClearEndOfInput();
+        if (!m_bStop)
+          m_seekEvent.Set(); // hack so that later we realize seek is needed
+        continue;
+      }
+
+      break; // while (!m_bStop)
+    }
+
     int64_t maxSourceRead = m_chunkSize;
     // Cap source read size by space available between current write position and EOF
     if (m_fileSize != 0)
-      maxSourceRead = std::min(maxSourceRead, m_fileSize - m_writePos);
+      maxSourceRead = std::min(maxSourceRead, m_fileSize - m_pCache->CachedDataEndPos());
 
+    maxSourceRead = m_pCache->GetMaxWriteSize(maxSourceRead);
     /* Only read from source if there's enough write space in the cache
-     * else we may keep disposing data and seeking back on (slow) source
-     */
-    if (maxWrite < maxSourceRead)
-    {
-      // Wait until sufficient cache write space is available
-      m_pCache->m_space.Wait(5ms);
+    * else we may keep disposing data and seeking back on (slow) source
+    */
+    if (maxSourceRead < 1) {
       continue;
     }
 
-    ssize_t iRead = 0;
-    if (maxSourceRead > 0)
-      iRead = m_source.Read(buffer.get(), maxSourceRead);
+    int iRead = m_source.Read(buffer.get(), maxSourceRead);
     if (iRead <= 0)
     {
       // Check for actual EOF and retry as long as we still have data in our cache
-      if (m_writePos < m_fileSize && m_pCache->WaitForData(0, 0ms) > 0)
+      if (m_pCache->CachedDataEndPos() < m_fileSize && m_pCache->WaitForData(0, 0ms) > 0)
       {
         CLog::Log(LOGWARNING, "CFileCache::{} - <{}> source read returned {}! Will retry",
                   __FUNCTION__, m_sourcePath, iRead);
 
-        // Wait a bit:
-        if (m_seekEvent.Wait(2000ms))
-        {
-          if (!m_bStop)
-            m_seekEvent.Set(); // hack so that later we realize seek is needed
-        }
-
-        // and retry:
         continue; // while (!m_bStop)
       }
       else
@@ -358,33 +358,20 @@ void CFileCache::Process()
           CLog::Log(LOGDEBUG,
                     "CFileCache::{} - <{}> source read didn't return any data! Hit eof(?)",
                     __FUNCTION__, m_sourcePath);
-        else if (m_writePos < m_fileSize)
+        else if (m_pCache->CachedDataEndPos() < m_fileSize)
           CLog::Log(LOGERROR,
                     "CFileCache::{} - <{}> source read didn't return any data before eof!",
                     __FUNCTION__, m_sourcePath);
         else
           CLog::Log(LOGDEBUG, "CFileCache::{} - <{}> source read hit eof", __FUNCTION__,
                     m_sourcePath);
-
-        m_pCache->EndOfInput();
-
-        // The thread event will now also cause the wait of an event to return a false.
-        if (AbortableWait(m_seekEvent) == WAIT_SIGNALED)
-        {
-          m_pCache->ClearEndOfInput();
-          if (!m_bStop)
-            m_seekEvent.Set(); // hack so that later we realize seek is needed
-        }
-        else
-          break; // while (!m_bStop)
       }
     }
 
     int iTotalWrite = 0;
     while (!m_bStop && (iTotalWrite < iRead))
     {
-      int iWrite = 0;
-      iWrite = m_pCache->WriteToCache(buffer.get() + iTotalWrite, iRead - iTotalWrite);
+      int iWrite = m_pCache->WriteToCache(buffer.get() + iTotalWrite, iRead - iTotalWrite);
 
       // write should always work. all handling of buffering and errors should be
       // done inside the cache strategy. only if unrecoverable error happened, WriteToCache would return error and we break.
@@ -394,10 +381,10 @@ void CFileCache::Process()
                   m_sourcePath);
         m_bStop = true;
         break;
-      }
-      else if (iWrite == 0)
-      {
-        m_pCache->m_space.Wait(5ms);
+      } else if (iWrite == 0 && m_readEvent.Wait(1ms)) {
+        CLog::Log(LOGERROR, "CFileCache::{} - <{}> LATENCY writing to cache remaining: {}/{}", __FUNCTION__,
+          m_sourcePath, iTotalWrite, iRead);
+        m_readEvent.Set();
       }
 
       iTotalWrite += iWrite;
@@ -410,9 +397,6 @@ void CFileCache::Process()
         break;
       }
     }
-
-    m_writePos += iTotalWrite;
-
     // under estimate write rate by a second, to
     // avoid uncertainty at start of caching
     m_writeRateActual = average.Rate(m_writePos, 1000);
@@ -477,7 +461,7 @@ retry:
   iRc = m_pCache->ReadFromCache((char *)lpBuf, uiBufSize);
   if (iRc > 0)
   {
-    m_readPos += iRc;
+    m_readEvent.Set();
     return (int)iRc;
   }
 
@@ -516,53 +500,51 @@ int64_t CFileCache::Seek(int64_t iFilePosition, int iWhence)
     return -1;
   }
 
-  int64_t iCurPos = m_readPos;
   int64_t iTarget = iFilePosition;
   if (iWhence == SEEK_END)
     iTarget = m_fileSize + iTarget;
   else if (iWhence == SEEK_CUR)
-    iTarget = iCurPos + iTarget;
+    iTarget = m_pCache->CachedDataStartPos() + iTarget;
   else if (iWhence != SEEK_SET)
     return -1;
 
-  if (iTarget == m_readPos)
-    return m_readPos;
-
-  if ((m_nSeekResult = m_pCache->Seek(iTarget)) != iTarget)
-  {
-    if (m_seekPossible == 0)
-      return m_nSeekResult;
-
-    // Never request closer to end than one chunk. Speeds up tag reading
-    m_seekPos = std::min(iTarget, std::max((int64_t)0, m_fileSize - m_chunkSize));
-
-    m_seekEvent.Set();
-    while (!m_seekEnded.Wait(100ms))
-    {
-      // SeekEnded will never be set if FileCache thread is not running
-      if (!CThread::IsRunning())
-        return -1;
-    }
-
-    /* wait for any remaining data */
-    if(m_seekPos < iTarget)
-    {
-      CLog::Log(LOGDEBUG, "CFileCache::{} - <{}> waiting for position {}", __FUNCTION__,
-                m_sourcePath, iTarget);
-      if (m_pCache->WaitForData(static_cast<uint32_t>(iTarget - m_seekPos), 10s) <
-          iTarget - m_seekPos)
-      {
-        CLog::Log(LOGWARNING, "CFileCache::{} - <{}> failed to get remaining data", __FUNCTION__,
-                  m_sourcePath);
-        return -1;
-      }
-      m_pCache->Seek(iTarget);
-    }
-    m_readPos = iTarget;
-    m_seekEvent.Reset();
+  if (iTarget == m_pCache->CachedDataStartPos()) {
+    return iTarget;
   }
-  else
-    m_readPos = iTarget;
+
+  // Never request closer to end than one chunk. Speeds up tag reading
+  m_seekPos = std::min(iTarget, std::max((int64_t)0, m_fileSize - m_chunkSize));
+  m_seekEvent.Set();
+  m_readEvent.Set();
+
+  while (!m_seekEnded.Wait(100ms))
+  {
+    // SeekEnded will never be set if FileCache thread is not running
+    if (!CThread::IsRunning())
+      return -1;
+  }
+
+  if (m_nSeekResult < 0) {
+     CLog::Log(LOGINFO, "CFileCache::{} - <{}> bad seek result {}", __FUNCTION__,
+              m_sourcePath, m_nSeekResult);
+    return m_nSeekResult;
+  }
+
+  if (m_seekPossible && m_nSeekResult < iTarget)
+  {
+    CLog::Log(LOGDEBUG, "CFileCache::{} - <{}> waiting for position {}", __FUNCTION__,
+              m_sourcePath, iTarget);
+    if (m_pCache->WaitForData(static_cast<uint32_t>(iTarget - m_nSeekResult), 10s) <
+        iTarget - m_nSeekResult)
+    {
+      CLog::Log(LOGWARNING, "CFileCache::{} - <{}> failed to get remaining data", __FUNCTION__,
+                m_sourcePath);
+      return m_nSeekResult;
+    }
+  } else if (!m_seekPossible) {
+    /* could be hours out... no point in having them suffer. */
+    return m_nSeekResult;
+  }
 
   return iTarget;
 }
@@ -580,7 +562,7 @@ void CFileCache::Close()
 
 int64_t CFileCache::GetPosition()
 {
-  return m_readPos;
+  return m_pCache->CachedDataStartPos();
 }
 
 int64_t CFileCache::GetLength()

--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -61,6 +61,7 @@ namespace XFILE
     std::string m_sourcePath;
     CEvent m_seekEvent;
     CEvent m_seekEnded;
+    CEvent m_readEvent;
     int64_t m_nSeekResult;
     int64_t m_seekPos;
     int64_t m_readPos;

--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -19,7 +19,6 @@
 
 namespace XFILE
 {
-
   class CFileCache : public IFile, public CThread
   {
   public:
@@ -62,10 +61,9 @@ namespace XFILE
     CEvent m_seekEvent;
     CEvent m_seekEnded;
     CEvent m_readEvent;
+    CEvent m_stallEvent;
     int64_t m_nSeekResult;
     int64_t m_seekPos;
-    int64_t m_readPos;
-    int64_t m_writePos;
     unsigned m_chunkSize;
     uint32_t m_writeRate;
     uint32_t m_writeRateActual;
@@ -76,5 +74,4 @@ namespace XFILE
     unsigned int m_flags;
     CCriticalSection m_sync;
   };
-
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

This removes a ton of waits, and streamlines media playback substantially. I'm getting 0sec seeking with NFS traffic over the internet all while using a dynamic cache.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Caching hasn't worked in XBMC for 20 years. I remember using FileZilla because AdvancedSettings.xml was required to playback files.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

NFSv4 over SSH with the chunk bug.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

"Life changing".

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed

This fixes https://github.com/xbmc/xbmc/issues/22702