### PR TITLE
AESinkAudioTrack: Be more conservative with overrun values

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -516,14 +516,14 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
       // the period calculation starts
       // after the buffer division to get even division results
       int c = 1;
-      if (m_audiotrackbuffer_sec > 0.2)
+      if (m_audiotrackbuffer_sec > 0.25)
       {
         CLog::Log(LOGWARNING,
                   "Audiobuffer is already very large {:f} ms - Reducing to a sensible value",
                   1000.0 * m_audiotrackbuffer_sec);
-        int buffer_frames = m_sink_sampleRate / 5; // 200 ms
+        int buffer_frames = m_sink_sampleRate / 4; // 250 ms
         m_min_buffer_size = buffer_frames * m_sink_frameSize;
-        c = 4; // 50 ms
+        c = 5; // 50 ms
       }
       // update potential new buffertime
       m_audiotrackbuffer_sec =
@@ -811,8 +811,7 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t **data, unsigned int frames, 
   if (!IsInitialized())
     return INT_MAX;
 
-  const double max_delay = m_passthrough ? 0.6 : 0.4;
-  if (m_delay > max_delay)
+  if (m_delay > 1.0)
   {
     CLog::Log(LOGERROR, "Sink got stuck with large buffer {:f} - reopening", m_delay);
     return INT_MAX;


### PR DESCRIPTION
There are devices in the wild, especially with BT speakers which open a quite large buffer for their use-case. They open with around 250 ms and use more than 500 ms for buffering their BT streaming.

Only really bailout if we are far enough off.

Fixup: 92279dad1aae84b147de6ca6b22a85692e3494a4

From user's log with Amazon Device and wireless speakers:
info <general>: Trying to open: samplerate: 44100, channelMask: 12, encoding: 4
info <general>: Minimum size we need for stream: 79240 Bytes
warning <general>: Audiobuffer is already very large 224.603175 ms - Reducing to a sensible value
info <general>: Audiotrack buffer params are: period time = 50.000 ms, period size = 17640 bytes, num periods = 4
info <general>: Created Audiotrackbuffer with playing time of 200.000000 ms min buffer size: 70560 bytes
info <general>: CAESinkAUDIOTRACK::Initializing with: m_sampleRate: 44100 format: AE_FMT_FLOAT (AE) method: PCM stream-type: PCM-STREAM min_buffer_size: 70560 m_frames: 2205 m_frameSize: 8 channels: 2

resulting easily in:
error <general>: Sink got stuck with large buffer 0.438069 - reopening
error <general>: CActiveAESink::OutputSamples - sink returned error