### PR TITLE
[Settings] hide empty groups of settings

### DIFF
--- a/xbmc/settings/lib/SettingSection.cpp
+++ b/xbmc/settings/lib/SettingSection.cpp
@@ -158,7 +158,7 @@ SettingList CSettingGroup::GetSettings(SettingLevel level) const
   SettingList settings;
   for (const auto& setting : m_settings)
   {
-    if (setting->GetLevel() <= level && setting->MeetsRequirements())
+    if (setting->GetLevel() <= level && setting->MeetsRequirements() && setting->IsVisible())
       settings.push_back(setting);
   }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Hide in the Settings GUI the settings groups that don't contain at least one visible setting, by taking into account IsVisible() of each setting when building the list of settings in a group.

The absence of this feature looks like an oversight, as the next hierarchy level up (categories) has the logic to hide categories that don't contain visible groups, and the settings themselves have the ability to make themselves not visible as well.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Dynamic visibility dependencies on settings in a group can cause all the settings of the group to be hidden, but the group label still shows. This can be confusing for the user and takes space needlessly.

This will be useful for [PR#22756](https://github.com/xbmc/xbmc/pull/22756), which creates a group of two settings that will be invisible on platforms and systems that don't support GUI SDR peak level adjustment in HDR PQ mode. The group label should not be visible in that case.

Going forward it may be possible to clean up the existing settings menus a bit as it's possible that some settings were displayed so far "disabled" instead of "hidden" to work around the problem of empty groups with the label still showing.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 10, though the change is not platform specific.

Altered existing settings of a group to try combinations of the attributes that affect the visibility of a setting <requirement>, <visible>, <dependency type="visible">. When all settings of a group were hidden, the group label was not displayed anymore.

Checked that there was no impact on code using constructs like CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_XXXXXXXX).
When the setting doesn't exist in guisettings.xml, or for different default or non-default values of the setting in guisettings.xml
The setting was still accessed regardless of visibility of the setting and visibility of its group.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Cleaner/shorter settings screens.

## Screenshots (if appropriate):
Settings visible - group visible
![image](https://user-images.githubusercontent.com/489377/219829512-3dbce5ad-9175-41ab-8b41-e58db238712a.png)

Before PR: Settings hidden (no platform support) but group label remains
![image](https://user-images.githubusercontent.com/489377/219829522-48ccc4eb-7de6-46b8-a9b0-8b5ca51bb544.png)

After PR: Settings hidden, the group label is hidden as well
![image](https://user-images.githubusercontent.com/489377/219829494-219246b4-20fc-491e-a5f4-7be844040ecf.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [*] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [*] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [*] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed