### PR TITLE
Pipewire: use relative includes where possible

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
@@ -8,10 +8,10 @@
 
 #include "Pipewire.h"
 
-#include "cores/AudioEngine/Sinks/pipewire/PipewireContext.h"
-#include "cores/AudioEngine/Sinks/pipewire/PipewireCore.h"
-#include "cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h"
-#include "cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.h"
+#include "PipewireContext.h"
+#include "PipewireCore.h"
+#include "PipewireRegistry.h"
+#include "PipewireThreadLoop.h"
 #include "utils/log.h"
 
 #include <pipewire/pipewire.h>

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireContext.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireContext.cpp
@@ -8,7 +8,7 @@
 
 #include "PipewireContext.h"
 
-#include "cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.h"
+#include "PipewireThreadLoop.h"
 #include "utils/log.h"
 
 #include <stdexcept>

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireCore.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireCore.cpp
@@ -8,8 +8,8 @@
 
 #include "PipewireCore.h"
 
-#include "cores/AudioEngine/Sinks/pipewire/PipewireContext.h"
-#include "cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.h"
+#include "PipewireContext.h"
+#include "PipewireThreadLoop.h"
 #include "utils/log.h"
 
 #include <stdexcept>

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
@@ -8,10 +8,10 @@
 
 #include "PipewireNode.h"
 
-#include "cores/AudioEngine/Sinks/pipewire/PipewireContext.h"
-#include "cores/AudioEngine/Sinks/pipewire/PipewireCore.h"
-#include "cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h"
-#include "cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.h"
+#include "PipewireContext.h"
+#include "PipewireCore.h"
+#include "PipewireRegistry.h"
+#include "PipewireThreadLoop.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "cores/AudioEngine/Sinks/pipewire/PipewireProxy.h"
+#include "PipewireProxy.h"
 
 #include <memory>
 #include <set>

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireProxy.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireProxy.cpp
@@ -8,9 +8,9 @@
 
 #include "PipewireProxy.h"
 
+#include "PipewireRegistry.h"
 #include "ServiceBroker.h"
 #include "cores/AudioEngine/Interfaces/AE.h"
-#include "cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h"
 #include "utils/log.h"
 
 #include <stdexcept>

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
@@ -8,8 +8,8 @@
 
 #include "PipewireRegistry.h"
 
-#include "cores/AudioEngine/Sinks/pipewire/PipewireCore.h"
-#include "cores/AudioEngine/Sinks/pipewire/PipewireNode.h"
+#include "PipewireCore.h"
+#include "PipewireNode.h"
 #include "utils/log.h"
 
 #include <stdexcept>

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
@@ -34,6 +34,8 @@ CPipewireRegistry::CPipewireRegistry(CPipewireCore& core)
   pw_registry_add_listener(m_registry.get(), &m_registryListener, &m_registryEvents, this);
 }
 
+CPipewireRegistry::~CPipewireRegistry() = default;
+
 void CPipewireRegistry::OnGlobalAdded(void* userdata,
                                       uint32_t id,
                                       uint32_t permissions,

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include "cores/AudioEngine/Sinks/pipewire/PipewireProxy.h"
-
 #include <map>
 #include <memory>
 #include <string>
@@ -23,13 +21,14 @@ namespace PIPEWIRE
 {
 
 class CPipewireCore;
+class CPipewireProxy;
 
 class CPipewireRegistry
 {
 public:
   explicit CPipewireRegistry(CPipewireCore& core);
   CPipewireRegistry() = delete;
-  ~CPipewireRegistry() = default;
+  ~CPipewireRegistry();
 
   pw_registry* Get() const { return m_registry.get(); }
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
@@ -8,9 +8,9 @@
 
 #include "PipewireStream.h"
 
-#include "cores/AudioEngine/Sinks/pipewire/PipewireContext.h"
-#include "cores/AudioEngine/Sinks/pipewire/PipewireCore.h"
-#include "cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.h"
+#include "PipewireContext.h"
+#include "PipewireCore.h"
+#include "PipewireThreadLoop.h"
 #include "utils/log.h"
 
 #include <stdexcept>


### PR DESCRIPTION
This changes from using full paths (not sure why I did that originally) to using relative paths. No functional changes.

I also included a commit to forward declare a class to remove an include in a header.