### PR TITLE
Pipewire: constify methods 

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
@@ -32,7 +32,7 @@ CPipewireNode::~CPipewireNode()
   spa_hook_remove(&m_objectListener);
 }
 
-void CPipewireNode::EnumerateFormats()
+void CPipewireNode::EnumerateFormats() const
 {
   if (!m_info)
     return;
@@ -112,7 +112,7 @@ static std::set<T> ParseArray(uint32_t type, void* body, uint32_t size)
   }
 }
 
-void CPipewireNode::Parse(uint32_t type, void* body, uint32_t size)
+void CPipewireNode::Parse(uint32_t type, void* body, uint32_t size) const
 {
   switch (type)
   {

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.h
@@ -28,7 +28,7 @@ class CPipewireRegistry;
 class CPipewireNode : public CPipewireProxy
 {
 public:
-  explicit CPipewireNode(CPipewireRegistry& registry, uint32_t id, const char* type);
+  CPipewireNode(CPipewireRegistry& registry, uint32_t id, const char* type);
   CPipewireNode() = delete;
   ~CPipewireNode() override;
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.h
@@ -32,17 +32,17 @@ public:
   CPipewireNode() = delete;
   ~CPipewireNode() override;
 
-  void EnumerateFormats();
+  void EnumerateFormats() const;
 
-  pw_node_info* GetInfo() { return m_info.get(); }
+  pw_node_info* GetInfo() const { return m_info.get(); }
 
-  std::set<spa_audio_format>& GetFormats() { return m_formats; }
-  std::set<spa_audio_channel>& GetChannels() { return m_channels; }
-  std::set<uint32_t>& GetRates() { return m_rates; }
-  std::set<spa_audio_iec958_codec>& GetIEC958Codecs() { return m_iec958Codecs; }
+  std::set<spa_audio_format>& GetFormats() const { return m_formats; }
+  std::set<spa_audio_channel>& GetChannels() const { return m_channels; }
+  std::set<uint32_t>& GetRates() const { return m_rates; }
+  std::set<spa_audio_iec958_codec>& GetIEC958Codecs() const { return m_iec958Codecs; }
 
 private:
-  void Parse(uint32_t type, void* body, uint32_t size);
+  void Parse(uint32_t type, void* body, uint32_t size) const;
 
   static void Info(void* userdata, const struct pw_node_info* info);
   static void Param(void* userdata,
@@ -65,10 +65,10 @@ private:
 
   std::unique_ptr<pw_node_info, PipewireNodeInfoDeleter> m_info;
 
-  std::set<spa_audio_format> m_formats;
-  std::set<spa_audio_channel> m_channels;
-  std::set<uint32_t> m_rates;
-  std::set<spa_audio_iec958_codec> m_iec958Codecs;
+  mutable std::set<spa_audio_format> m_formats;
+  mutable std::set<spa_audio_channel> m_channels;
+  mutable std::set<uint32_t> m_rates;
+  mutable std::set<spa_audio_iec958_codec> m_iec958Codecs;
 };
 
 } // namespace PIPEWIRE

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireProxy.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireProxy.h
@@ -28,10 +28,7 @@ public:
   CPipewireRegistry& GetRegistry() const { return m_registry; }
 
 protected:
-  explicit CPipewireProxy(CPipewireRegistry& registry,
-                          uint32_t id,
-                          const char* type,
-                          uint32_t version);
+  CPipewireProxy(CPipewireRegistry& registry, uint32_t id, const char* type, uint32_t version);
 
   struct PipewireProxyDeleter
   {

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
@@ -41,7 +41,7 @@ CPipewireStream::~CPipewireStream()
 bool CPipewireStream::Connect(uint32_t id,
                               const pw_direction& direction,
                               std::vector<const spa_pod*>& params,
-                              const pw_stream_flags& flags)
+                              const pw_stream_flags& flags) const
 {
   int ret = pw_stream_connect(m_stream.get(), direction, id, flags, params.data(), params.size());
   if (ret < 0)
@@ -53,22 +53,22 @@ bool CPipewireStream::Connect(uint32_t id,
   return true;
 }
 
-pw_stream_state CPipewireStream::GetState()
+pw_stream_state CPipewireStream::GetState() const
 {
   return pw_stream_get_state(m_stream.get(), nullptr);
 }
 
-void CPipewireStream::SetActive(bool active)
+void CPipewireStream::SetActive(bool active) const
 {
   pw_stream_set_active(m_stream.get(), active);
 }
 
-pw_buffer* CPipewireStream::DequeueBuffer()
+pw_buffer* CPipewireStream::DequeueBuffer() const
 {
   return pw_stream_dequeue_buffer(m_stream.get());
 }
 
-void CPipewireStream::QueueBuffer(pw_buffer* buffer)
+void CPipewireStream::QueueBuffer(pw_buffer* buffer) const
 {
   pw_stream_queue_buffer(m_stream.get(), buffer);
 }
@@ -85,17 +85,17 @@ bool CPipewireStream::TriggerProcess() const
   return true;
 }
 
-void CPipewireStream::Flush(bool drain)
+void CPipewireStream::Flush(bool drain) const
 {
   pw_stream_flush(m_stream.get(), drain);
 }
 
-uint32_t CPipewireStream::GetNodeId()
+uint32_t CPipewireStream::GetNodeId() const
 {
   return pw_stream_get_node_id(m_stream.get());
 }
 
-void CPipewireStream::UpdateProperties(spa_dict* dict)
+void CPipewireStream::UpdateProperties(spa_dict* dict) const
 {
   pw_stream_update_properties(m_stream.get(), dict);
 }

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
@@ -35,21 +35,21 @@ public:
   bool Connect(uint32_t id,
                const pw_direction& direction,
                std::vector<const spa_pod*>& params,
-               const pw_stream_flags& flags);
+               const pw_stream_flags& flags) const;
 
-  pw_stream_state GetState();
-  void SetActive(bool active);
+  pw_stream_state GetState() const;
+  void SetActive(bool active) const;
 
-  pw_buffer* DequeueBuffer();
-  void QueueBuffer(pw_buffer* buffer);
+  pw_buffer* DequeueBuffer() const;
+  void QueueBuffer(pw_buffer* buffer) const;
 
   bool TriggerProcess() const;
 
-  void Flush(bool drain);
+  void Flush(bool drain) const;
 
-  uint32_t GetNodeId();
+  uint32_t GetNodeId() const;
 
-  void UpdateProperties(spa_dict* dict);
+  void UpdateProperties(spa_dict* dict) const;
 
   pw_time GetTime() const;
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.cpp
@@ -25,12 +25,12 @@ CPipewireThreadLoop::CPipewireThreadLoop()
   }
 }
 
-bool CPipewireThreadLoop::Start()
+bool CPipewireThreadLoop::Start() const
 {
   return pw_thread_loop_start(m_mainloop.get()) == 0;
 }
 
-void CPipewireThreadLoop::Stop()
+void CPipewireThreadLoop::Stop() const
 {
   pw_thread_loop_stop(m_mainloop.get());
 }
@@ -45,7 +45,7 @@ void CPipewireThreadLoop::Unlock() const
   pw_thread_loop_unlock(m_mainloop.get());
 }
 
-int CPipewireThreadLoop::Wait(std::chrono::nanoseconds timeout)
+int CPipewireThreadLoop::Wait(std::chrono::nanoseconds timeout) const
 {
   timespec abstime;
   pw_thread_loop_get_time(m_mainloop.get(), &abstime, timeout.count());
@@ -53,7 +53,7 @@ int CPipewireThreadLoop::Wait(std::chrono::nanoseconds timeout)
   return pw_thread_loop_timed_wait_full(m_mainloop.get(), &abstime);
 }
 
-void CPipewireThreadLoop::Signal(bool accept)
+void CPipewireThreadLoop::Signal(bool accept) const
 {
   pw_thread_loop_signal(m_mainloop.get(), accept);
 }

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireThreadLoop.h
@@ -26,14 +26,14 @@ public:
 
   pw_loop* Get() const { return pw_thread_loop_get_loop(m_mainloop.get()); }
 
-  bool Start();
-  void Stop();
+  bool Start() const;
+  void Stop() const;
 
   void Lock() const;
   void Unlock() const;
 
-  int Wait(std::chrono::nanoseconds timeout);
-  void Signal(bool accept);
+  int Wait(std::chrono::nanoseconds timeout) const;
+  void Signal(bool accept) const;
 
 private:
   struct PipewireThreadLoopDeleter


### PR DESCRIPTION
This adds const to a bunch of pipewire methods. I'm not 100% sure on the mutable members or if that is worth doing.

I also added two commits to fix the use of explicit.