### PR TITLE
Windows Installer: fix Chorus2 missing files & displayed installer path

### DIFF
--- a/tools/buildsteps/windows/BuildSetup.bat
+++ b/tools/buildsteps/windows/BuildSetup.bat
@@ -100,11 +100,11 @@ set WORKSPACE=%base_dir%\kodi-build.%TARGET_PLATFORM%
   Echo xbmc.old.log>>exclude.txt
   Echo kodi.log>>exclude.txt
   Echo kodi.old.log>>exclude.txt
-  Echo .so>>exclude.txt
-  Echo .h>>exclude.txt
-  Echo .cpp>>exclude.txt
-  Echo .exp>>exclude.txt
-  Echo .lib>>exclude.txt
+  Echo .so\>>exclude.txt
+  Echo .h\>>exclude.txt
+  Echo .cpp\>>exclude.txt
+  Echo .exp\>>exclude.txt
+  Echo .lib\>>exclude.txt
   rem Exclude userdata files
   Echo userdata\advancedsettings.xml>>exclude.txt
   Echo userdata\guisettings.xml>>exclude.txt
@@ -228,11 +228,11 @@ set WORKSPACE=%base_dir%\kodi-build.%TARGET_PLATFORM%
     goto DIE
   )
   copy %PDB% %APP_PDBFILE% > nul
-  POPD
   ECHO ------------------------------------------------------------
   ECHO Done!
   ECHO Setup is located at %CD%\%APP_SETUPFILE%
   ECHO ------------------------------------------------------------
+  POPD
   GOTO END
 
 :MAKE_APPX


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

- Fixed in BuildSetup.bat the pattern that was supposed to exclude .h files, but ended up also excluding .html since .h is contained in .html
- Fixed the other file extension patterns for correctness and consistency, although I don't think they were causing problems.
- Moved a POPD instruction in order to display the correct location of the built installer

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Non-functional Chorus2 web interface in Nexus reported by a few users in the forums,

Opening localhost:8080 only returns a "File not found" error in the browser

[HTTP error on local Kodi web server](https://forum.kodi.tv/showthread.php?tid=372078)
[Kodi 20 - default Webinterface not working - File not found](https://forum.kodi.tv/showthread.php?tid=371615)
[Solved Is Chorus2 left out from standard install in v20?](https://forum.kodi.tv/showthread.php?tid=371469)

I think this is a candidate for a backport for a 20.1 as it makes the default web interface functional.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Compared the count of files in the build tree vs the temp tree for the installer, checked the .html files of Chorus2.
Opened the web interface in a browser after install with an installer built with the PR.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Working Chorus 2 web interface in Nexus after installation.

The path to the installer displayed by BuildSetup.bat is accurate.

## Screenshots (if appropriate):
Nexus 20.0 installer:
![image](https://user-images.githubusercontent.com/489377/219849048-742648b2-648a-4abe-9095-7f17626c7313.png)

With the PR:
![image](https://user-images.githubusercontent.com/489377/219849346-2e993ed7-1b2e-423d-946f-a332928a40e7.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [*] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [*] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [*] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
