### PR TITLE
[settings][airplay] Fix password setting order/dependencies

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2290,11 +2290,20 @@
           </dependencies>
           <control type="toggle" />
         </setting>
-        <setting id="services.useairplaypassword" type="boolean" parent="services.airplay" label="1272" help="36344">
+        <setting id="services.airplayvideosupport" type="boolean" parent="services.airplay" label="1268" help="36549">
+          <level>3</level>
+          <default>false</default>
+          <dependencies>
+            <dependency type="enable" setting="services.airplay">true</dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
+        <setting id="services.useairplaypassword" type="boolean" parent="services.airplayvideosupport" label="1272" help="36344">
           <level>1</level>
           <default>false</default>
           <dependencies>
             <dependency type="enable" setting="services.airplay">true</dependency>
+            <dependency type="enable" setting="services.airplayvideosupport">true</dependency>
           </dependencies>
           <control type="toggle" />
         </setting>
@@ -2310,14 +2319,6 @@
           <control type="edit" format="string">
             <hidden>true</hidden>
           </control>
-        </setting>
-        <setting id="services.airplayvideosupport" type="boolean" parent="services.airplay" label="1268" help="36549">
-          <level>3</level>
-          <default>false</default>
-          <dependencies>
-            <dependency type="enable" setting="services.airplay">true</dependency>
-          </dependencies>
-          <control type="toggle" />
         </setting>
       </group>
     </category>


### PR DESCRIPTION
## Description
This was found by @DaVukovic in `#skin-estuary` a while ago, PRing so it doesn't get forgotten. The use password for airplay depends actually on "enable picture and video support" not really only on generic airplay support. Currently you can't enable the setting since it depends on the fact the server has started (which only happens if the aforementioned setting is enabled).
This reorders the settings and fixes their dependencies.

<img width="1102" alt="image" src="https://user-images.githubusercontent.com/7375276/219864041-2833a1e8-4bab-4ac6-acb7-50b2313772e5.png">
