### PR TITLE
COverlayRendererGL: split out GLES paths into COverlayRendererGLES

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/CMakeLists.txt
@@ -30,16 +30,16 @@ if(CORE_SYSTEM_NAME STREQUAL windows OR CORE_SYSTEM_NAME STREQUAL windowsstore)
 endif()
 
 if (OPENGL_FOUND OR OPENGLES_FOUND)
-  list(APPEND SOURCES OverlayRendererGL.cpp
-                      FrameBufferObject.cpp)
-  list(APPEND HEADERS OverlayRendererGL.h
-                      FrameBufferObject.h)
+  list(APPEND SOURCES FrameBufferObject.cpp)
+  list(APPEND HEADERS FrameBufferObject.h)
 endif()
 
 if(OPENGL_FOUND)
   list(APPEND SOURCES LinuxRendererGL.cpp
+                      OverlayRendererGL.cpp
                       RenderCaptureGL.cpp)
   list(APPEND HEADERS LinuxRendererGL.h
+                      OverlayRendererGL.h
                       RenderCaptureGL.h)
 endif()
 
@@ -50,8 +50,10 @@ if(OPENGLES_FOUND AND ("android" IN_LIST CORE_PLATFORM_NAME_LC OR
                        "x11" IN_LIST CORE_PLATFORM_NAME_LC OR
                        "wayland" IN_LIST CORE_PLATFORM_NAME_LC))
   list(APPEND SOURCES LinuxRendererGLES.cpp
+                      OverlayRendererGLES.cpp
                       RenderCaptureGLES.cpp)
   list(APPEND HEADERS LinuxRendererGLES.h
+                      OverlayRendererGLES.cpp
                       RenderCaptureGLES.h)
 endif()
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -23,9 +23,13 @@
 #include "windowing/GraphicContext.h"
 
 #include <mutex>
-#if defined(HAS_GL) || defined(HAS_GLES)
+#if defined(HAS_GL)
 #include "OverlayRendererGL.h"
-#elif defined(HAS_DX)
+#endif
+#if defined(HAS_GLES)
+#include "OverlayRendererGLES.h"
+#endif
+#if defined(HAS_DX)
 #include "OverlayRendererDX.h"
 #endif
 
@@ -534,9 +538,13 @@ std::shared_ptr<COverlay> CRenderer::ConvertLibass(
   }
 
   std::shared_ptr<COverlay> overlay = NULL;
-#if defined(HAS_GL) || defined(HAS_GLES)
+#if defined(HAS_GL)
   overlay = std::make_shared<COverlayGlyphGL>(images, rOpts.frameWidth, rOpts.frameHeight);
-#elif defined(HAS_DX)
+#endif
+#if defined(HAS_GLES)
+  overlay = std::make_shared<COverlayGlyphGLES>(images, rOpts.frameWidth, rOpts.frameHeight);
+#endif
+#if defined(HAS_DX)
   overlay = std::make_shared<COverlayQuadsDX>(images, rOpts.frameWidth, rOpts.frameHeight);
 #endif
 
@@ -581,12 +589,19 @@ std::shared_ptr<COverlay> CRenderer::Convert(CDVDOverlay& o, double pts)
     return r;
   }
 
-#if defined(HAS_GL) || defined(HAS_GLES)
+#if defined(HAS_GL)
   if (o.IsOverlayType(DVDOVERLAY_TYPE_IMAGE))
     r = std::make_shared<COverlayTextureGL>(static_cast<CDVDOverlayImage&>(o), m_rs);
   else if (o.IsOverlayType(DVDOVERLAY_TYPE_SPU))
     r = std::make_shared<COverlayTextureGL>(static_cast<CDVDOverlaySpu&>(o));
-#elif defined(HAS_DX)
+#endif
+#if defined(HAS_GLES)
+  if (o.IsOverlayType(DVDOVERLAY_TYPE_IMAGE))
+    r = std::make_shared<COverlayTextureGLES>(static_cast<CDVDOverlayImage&>(o), m_rs);
+  else if (o.IsOverlayType(DVDOVERLAY_TYPE_SPU))
+    r = std::make_shared<COverlayTextureGLES>(static_cast<CDVDOverlaySpu&>(o));
+#endif
+#if defined(HAS_DX)
   if (o.IsOverlayType(DVDOVERLAY_TYPE_IMAGE))
     r = std::make_shared<COverlayImageDX>(static_cast<CDVDOverlayImage&>(o), m_rs);
   else if (o.IsOverlayType(DVDOVERLAY_TYPE_SPU))

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.h
@@ -1,0 +1,67 @@
+/*
+ *      Initial code sponsored by: Voddler Inc (voddler.com)
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "OverlayRenderer.h"
+
+#include "system_gl.h"
+
+class CDVDOverlay;
+class CDVDOverlayImage;
+class CDVDOverlaySpu;
+class CDVDOverlaySSA;
+typedef struct ass_image ASS_Image;
+
+namespace OVERLAY
+{
+
+class COverlayTextureGLES : public COverlay
+{
+public:
+  /*! \brief Create the overlay for rendering
+     *  \param o The overlay image
+     *  \param rSource The video source rect size
+     */
+  explicit COverlayTextureGLES(const CDVDOverlayImage& o, CRect& rSource);
+  explicit COverlayTextureGLES(const CDVDOverlaySpu& o);
+  ~COverlayTextureGLES() override;
+
+  void Render(SRenderState& state) override;
+
+  GLuint m_texture = 0;
+  float m_u;
+  float m_v;
+  bool m_pma; /*< is alpha in texture premultiplied in the values */
+};
+
+class COverlayGlyphGLES : public COverlay
+{
+public:
+  COverlayGlyphGLES(ASS_Image* images, float width, float height);
+
+  ~COverlayGlyphGLES() override;
+
+  void Render(SRenderState& state) override;
+
+  struct VERTEX
+  {
+    GLfloat u, v;
+    GLubyte r, g, b, a;
+    GLfloat x, y, z;
+  };
+
+  std::vector<VERTEX> m_vertex;
+
+  GLuint m_texture = 0;
+  float m_u;
+  float m_v;
+};
+
+} // namespace OVERLAY


### PR DESCRIPTION
This creates a more readable, maintainable code base by splitting the GLES path out into it's own class.

This has no functional changes and simply shuffles code around.