### PR TITLE
CGUIFontGL: split out GLES paths into CGUIFontGLES

### DIFF
--- a/xbmc/guilib/CMakeLists.txt
+++ b/xbmc/guilib/CMakeLists.txt
@@ -158,21 +158,23 @@ set(HEADERS DDSImage.h
             XBTFReader.h)
 
 if(OPENGL_FOUND OR OPENGLES_FOUND)
-  list(APPEND SOURCES GUIFontTTFGL.cpp
-                      Shader.cpp
+  list(APPEND SOURCES Shader.cpp
                       TextureGL.cpp)
-  list(APPEND HEADERS GUIFontTTFGL.h
-                      Shader.h
+  list(APPEND HEADERS Shader.h
                       TextureGL.h)
 
   if(OPENGL_FOUND)
-    list(APPEND SOURCES GUITextureGL.cpp)
-    list(APPEND HEADERS GUITextureGL.h)
+    list(APPEND SOURCES GUIFontTTFGL.cpp
+                        GUITextureGL.cpp)
+    list(APPEND HEADERS GUIFontTTFGL.h
+                        GUITextureGL.h)
   endif()
 
   if(OPENGLES_FOUND)
-    list(APPEND SOURCES GUITextureGLES.cpp)
-    list(APPEND HEADERS GUITextureGLES.h)
+    list(APPEND SOURCES GUIFontTTFGLES.cpp
+                        GUITextureGLES.cpp)
+    list(APPEND HEADERS GUIFontTTFGLES.h
+                        GUITextureGLES.h)
   endif()
 
 endif()

--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -18,8 +18,11 @@
 #include "windowing/GraphicContext.h"
 
 #include <mutex>
-#if defined(HAS_GLES) || defined(HAS_GL)
+#if defined(HAS_GL)
 #include "GUIFontTTFGL.h"
+#endif
+#if defined(HAS_GLES)
+#include "GUIFontTTFGLES.h"
 #endif
 #include "FileItem.h"
 #include "GUIControlFactory.h"
@@ -408,8 +411,12 @@ void GUIFontManager::Clear()
   m_vecFontFiles.clear();
   m_vecFontInfo.clear();
 
-#if defined(HAS_GLES) || defined(HAS_GL)
+#if defined(HAS_GL)
   CGUIFontTTFGL::DestroyStaticVertexBuffers();
+#endif
+
+#if defined(HAS_GLES)
+  CGUIFontTTFGLES::DestroyStaticVertexBuffers();
 #endif
 }
 

--- a/xbmc/guilib/GUIFontTTFGLES.h
+++ b/xbmc/guilib/GUIFontTTFGLES.h
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "GUIFontTTF.h"
+
+#include <string>
+#include <vector>
+
+#include "system_gl.h"
+
+class CGUIFontTTFGLES : public CGUIFontTTF
+{
+public:
+  explicit CGUIFontTTFGLES(const std::string& fontIdent);
+  ~CGUIFontTTFGLES(void) override;
+
+  bool FirstBegin() override;
+  void LastEnd() override;
+
+  CVertexBuffer CreateVertexBuffer(const std::vector<SVertex>& vertices) const override;
+  void DestroyVertexBuffer(CVertexBuffer& bufferHandle) const override;
+  static void CreateStaticVertexBuffers(void);
+  static void DestroyStaticVertexBuffers(void);
+
+protected:
+  std::unique_ptr<CTexture> ReallocTexture(unsigned int& newHeight) override;
+  bool CopyCharToTexture(FT_BitmapGlyph bitGlyph,
+                         unsigned int x1,
+                         unsigned int y1,
+                         unsigned int x2,
+                         unsigned int y2) override;
+  void DeleteHardwareTexture() override;
+
+  static GLuint m_elementArrayHandle;
+
+private:
+  unsigned int m_updateY1{0};
+  unsigned int m_updateY2{0};
+
+  enum TextureStatus
+  {
+    TEXTURE_VOID = 0,
+    TEXTURE_READY,
+    TEXTURE_REALLOCATED,
+    TEXTURE_UPDATED,
+  };
+
+  TextureStatus m_textureStatus{TEXTURE_VOID};
+
+  static bool m_staticVertexBufferCreated;
+};


### PR DESCRIPTION
This creates a more readable, maintainable code base by splitting the GLES path out into it's own class.

This has no functional changes and simply shuffles code around.