### PR TITLE
CPipewireGlobal: add class to help with registry globals 

### DIFF
--- a/xbmc/cores/AudioEngine/CMakeLists.txt
+++ b/xbmc/cores/AudioEngine/CMakeLists.txt
@@ -73,6 +73,7 @@ if(PIPEWIRE_FOUND)
                       Sinks/pipewire/Pipewire.cpp
                       Sinks/pipewire/PipewireContext.cpp
                       Sinks/pipewire/PipewireCore.cpp
+                      Sinks/pipewire/PipewireGlobal.cpp
                       Sinks/pipewire/PipewireNode.cpp
                       Sinks/pipewire/PipewireProxy.cpp
                       Sinks/pipewire/PipewireRegistry.cpp
@@ -82,6 +83,7 @@ if(PIPEWIRE_FOUND)
                       Sinks/pipewire/Pipewire.h
                       Sinks/pipewire/PipewireContext.h
                       Sinks/pipewire/PipewireCore.h
+                      Sinks/pipewire/PipewireGlobal.h
                       Sinks/pipewire/PipewireNode.h
                       Sinks/pipewire/PipewireProxy.h
                       Sinks/pipewire/PipewireRegistry.h

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -317,9 +317,9 @@ void CAESinkPipewire::EnumerateDevicesEx(AEDeviceInfoList& list, bool force)
     std::for_each(defaultSampleRates.cbegin(), defaultSampleRates.cend(),
                   [&device](const auto& rate) { device.m_sampleRates.emplace_back(rate); });
 
-    auto node = global.second->node.get();
+    auto& node = *global.second->node;
 
-    node->EnumerateFormats();
+    node.EnumerateFormats();
 
     int ret = loop.Wait(5s);
     if (ret == -ETIMEDOUT)
@@ -330,7 +330,7 @@ void CAESinkPipewire::EnumerateDevicesEx(AEDeviceInfoList& list, bool force)
       continue;
     }
 
-    auto& channels = node->GetChannels();
+    auto& channels = node.GetChannels();
     if (channels.size() < 1)
       continue;
 
@@ -341,7 +341,7 @@ void CAESinkPipewire::EnumerateDevicesEx(AEDeviceInfoList& list, bool force)
         device.m_channels += ch->second;
     }
 
-    for (const auto& iec958Codec : node->GetIEC958Codecs())
+    for (const auto& iec958Codec : node.GetIEC958Codecs())
     {
       auto streamTypes = PWIEC958CodecToAEStreamInfoDataTypeList(iec958Codec);
       device.m_streamTypes.insert(device.m_streamTypes.end(), streamTypes.begin(),

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -317,8 +317,7 @@ void CAESinkPipewire::EnumerateDevicesEx(AEDeviceInfoList& list, bool force)
     std::for_each(defaultSampleRates.cbegin(), defaultSampleRates.cend(),
                   [&device](const auto& rate) { device.m_sampleRates.emplace_back(rate); });
 
-    auto proxy = global.second->proxy.get();
-    auto node = static_cast<PIPEWIRE::CPipewireNode*>(proxy);
+    auto node = global.second->node.get();
 
     node->EnumerateFormats();
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -9,6 +9,7 @@
 #include "AESinkPipewire.h"
 
 #include "CompileInfo.h"
+#include "PipewireGlobal.h"
 #include "cores/AudioEngine/AESinkFactory.h"
 #include "cores/AudioEngine/Sinks/pipewire/Pipewire.h"
 #include "cores/AudioEngine/Sinks/pipewire/PipewireCore.h"
@@ -306,9 +307,10 @@ void CAESinkPipewire::EnumerateDevicesEx(AEDeviceInfoList& list, bool force)
   {
     CAEDeviceInfo device;
     device.m_deviceType = AE_DEVTYPE_PCM;
-    device.m_deviceName = global.second->name;
-    device.m_displayName = global.second->description;
-    device.m_displayNameExtra = global.second->description + " (PIPEWIRE)";
+    device.m_deviceName = global.second->GetName();
+    device.m_displayName = global.second->GetDescription();
+    device.m_displayNameExtra =
+        StringUtils::Format("{} (PIPEWIRE)", global.second->GetDescription());
     device.m_wantsIECPassthrough = true;
 
     std::for_each(formatMap.cbegin(), formatMap.cend(),
@@ -317,8 +319,7 @@ void CAESinkPipewire::EnumerateDevicesEx(AEDeviceInfoList& list, bool force)
     std::for_each(defaultSampleRates.cbegin(), defaultSampleRates.cend(),
                   [&device](const auto& rate) { device.m_sampleRates.emplace_back(rate); });
 
-    auto& node = *global.second->node;
-
+    auto& node = global.second->GetNode();
     node.EnumerateFormats();
 
     int ret = loop.Wait(5s);
@@ -381,7 +382,7 @@ bool CAESinkPipewire::Initialize(AEAudioFormat& format, std::string& device)
   else
   {
     auto target = std::find_if(globals.begin(), globals.end(),
-                               [&device](const auto& p) { return device == p.second->name; });
+                               [&device](const auto& p) { return device == p.second->GetName(); });
     if (target == globals.end())
       return false;
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireGlobal.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireGlobal.cpp
@@ -1,0 +1,16 @@
+/*
+ *  Copyright (C) 2010-2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PipewireGlobal.h"
+
+#include "PipewireNode.h"
+
+using namespace KODI;
+using namespace PIPEWIRE;
+
+CPipewireGlobal::~CPipewireGlobal() = default;

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireGlobal.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireGlobal.h
@@ -1,0 +1,109 @@
+/*
+ *  Copyright (C) 2010-2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include <memory>
+#include <string>
+
+#include <pipewire/properties.h>
+
+namespace KODI
+{
+namespace PIPEWIRE
+{
+
+class CPipewireNode;
+
+struct PipewirePropertiesDeleter
+{
+  void operator()(pw_properties* p) { pw_properties_free(p); }
+};
+
+class CPipewireGlobal
+{
+public:
+  CPipewireGlobal() = default;
+  ~CPipewireGlobal();
+
+  CPipewireGlobal& SetName(std::string_view name)
+  {
+    m_name = name;
+    return *this;
+  }
+
+  std::string_view GetName() const { return m_name; }
+
+  CPipewireGlobal& SetDescription(std::string_view description)
+  {
+    m_description = description;
+    return *this;
+  }
+
+  std::string_view GetDescription() const { return m_description; }
+
+  CPipewireGlobal& SetID(uint32_t id)
+  {
+    m_id = id;
+    return *this;
+  }
+
+  uint32_t GetID() const { return m_id; }
+
+  CPipewireGlobal& SetPermissions(uint32_t permissions)
+  {
+    m_permissions = permissions;
+    return *this;
+  }
+
+  uint32_t GetPermissions() const { return m_permissions; }
+
+  CPipewireGlobal& SetType(std::string_view type)
+  {
+    m_type = type;
+    return *this;
+  }
+
+  std::string_view GetType() const { return m_type; }
+
+  CPipewireGlobal& SetVersion(uint32_t version)
+  {
+    m_version = version;
+    return *this;
+  }
+
+  uint32_t GetVersion() const { return m_version; }
+
+  CPipewireGlobal& SetProperties(
+      std::unique_ptr<pw_properties, PipewirePropertiesDeleter> properties)
+  {
+    m_properties = std::move(properties);
+    return *this;
+  }
+
+  const pw_properties& GetProperties() const { return *m_properties; }
+
+  CPipewireGlobal& SetNode(std::unique_ptr<CPipewireNode> node)
+  {
+    m_node = std::move(node);
+    return *this;
+  }
+
+  CPipewireNode& GetNode() const { return *m_node; }
+
+private:
+  std::string_view m_name;
+  std::string_view m_description;
+  uint32_t m_id;
+  uint32_t m_permissions;
+  std::string_view m_type;
+  uint32_t m_version;
+  std::unique_ptr<pw_properties, PipewirePropertiesDeleter> m_properties;
+  std::unique_ptr<CPipewireNode> m_node;
+};
+
+} // namespace PIPEWIRE
+} // namespace KODI

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
@@ -73,7 +73,7 @@ void CPipewireRegistry::OnGlobalAdded(void* userdata,
   globals[id]->type = std::string(type);
   globals[id]->version = version;
   globals[id]->properties.reset(pw_properties_new_dict(props));
-  globals[id]->proxy = std::make_unique<CPipewireNode>(registry, id, type);
+  globals[id]->node = std::make_unique<CPipewireNode>(registry, id, type);
 }
 
 void CPipewireRegistry::OnGlobalRemoved(void* userdata, uint32_t id)

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
@@ -45,35 +45,35 @@ void CPipewireRegistry::OnGlobalAdded(void* userdata,
 {
   auto& registry = *reinterpret_cast<CPipewireRegistry*>(userdata);
 
-  if (strcmp(type, PW_TYPE_INTERFACE_Node) == 0)
-  {
-    const char* mediaClass = spa_dict_lookup(props, PW_KEY_MEDIA_CLASS);
-    if (!mediaClass)
-      return;
+  if (strcmp(type, PW_TYPE_INTERFACE_Node) != 0)
+    return;
 
-    if (strcmp(mediaClass, "Audio/Sink") != 0)
-      return;
+  const char* mediaClass = spa_dict_lookup(props, PW_KEY_MEDIA_CLASS);
+  if (!mediaClass)
+    return;
 
-    const char* name = spa_dict_lookup(props, PW_KEY_NODE_NAME);
-    if (!name)
-      return;
+  if (strcmp(mediaClass, "Audio/Sink") != 0)
+    return;
 
-    const char* desc = spa_dict_lookup(props, PW_KEY_NODE_DESCRIPTION);
-    if (!desc)
-      return;
+  const char* name = spa_dict_lookup(props, PW_KEY_NODE_NAME);
+  if (!name)
+    return;
 
-    auto& globals = registry.GetGlobals();
+  const char* desc = spa_dict_lookup(props, PW_KEY_NODE_DESCRIPTION);
+  if (!desc)
+    return;
 
-    globals[id] = std::make_unique<global>();
-    globals[id]->name = std::string(name);
-    globals[id]->description = std::string(desc);
-    globals[id]->id = id;
-    globals[id]->permissions = permissions;
-    globals[id]->type = std::string(type);
-    globals[id]->version = version;
-    globals[id]->properties.reset(pw_properties_new_dict(props));
-    globals[id]->proxy = std::make_unique<CPipewireNode>(registry, id, type);
-  }
+  auto& globals = registry.GetGlobals();
+
+  globals[id] = std::make_unique<global>();
+  globals[id]->name = std::string(name);
+  globals[id]->description = std::string(desc);
+  globals[id]->id = id;
+  globals[id]->permissions = permissions;
+  globals[id]->type = std::string(type);
+  globals[id]->version = version;
+  globals[id]->properties.reset(pw_properties_new_dict(props));
+  globals[id]->proxy = std::make_unique<CPipewireNode>(registry, id, type);
 }
 
 void CPipewireRegistry::OnGlobalRemoved(void* userdata, uint32_t id)

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
@@ -88,13 +88,14 @@ void CPipewireRegistry::OnGlobalRemoved(void* userdata, uint32_t id)
   auto& registry = *reinterpret_cast<CPipewireRegistry*>(userdata);
   auto& globals = registry.GetGlobals();
 
-  auto global = globals.find(id);
-  if (global != globals.end())
+  auto it = globals.find(id);
+  if (it != globals.end())
   {
+    const auto& [globalId, global] = *it;
     CLog::Log(LOGDEBUG, "CPipewireRegistry::{} - id={} type={}", __FUNCTION__, id,
-              global->second->GetType());
+              global->GetType());
 
-    globals.erase(global);
+    globals.erase(it);
   }
 }
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h
@@ -21,7 +21,7 @@ namespace PIPEWIRE
 {
 
 class CPipewireCore;
-class CPipewireProxy;
+class CPipewireNode;
 
 class CPipewireRegistry
 {
@@ -48,7 +48,7 @@ public:
     std::string type;
     uint32_t version;
     std::unique_ptr<pw_properties, PipewirePropertiesDeleter> properties;
-    std::unique_ptr<CPipewireProxy> proxy;
+    std::unique_ptr<CPipewireNode> node;
   };
 
   std::map<uint32_t, std::unique_ptr<global>>& GetGlobals() { return m_globals; }

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.h
@@ -13,7 +13,6 @@
 #include <string>
 
 #include <pipewire/core.h>
-#include <pipewire/properties.h>
 
 namespace KODI
 {
@@ -21,7 +20,7 @@ namespace PIPEWIRE
 {
 
 class CPipewireCore;
-class CPipewireNode;
+class CPipewireGlobal;
 
 class CPipewireRegistry
 {
@@ -34,24 +33,7 @@ public:
 
   CPipewireCore& GetCore() const { return m_core; }
 
-  struct PipewirePropertiesDeleter
-  {
-    void operator()(pw_properties* p) { pw_properties_free(p); }
-  };
-
-  struct global
-  {
-    std::string name;
-    std::string description;
-    uint32_t id;
-    uint32_t permissions;
-    std::string type;
-    uint32_t version;
-    std::unique_ptr<pw_properties, PipewirePropertiesDeleter> properties;
-    std::unique_ptr<CPipewireNode> node;
-  };
-
-  std::map<uint32_t, std::unique_ptr<global>>& GetGlobals() { return m_globals; }
+  std::map<uint32_t, std::unique_ptr<CPipewireGlobal>>& GetGlobals() { return m_globals; }
 
 private:
   static void OnGlobalAdded(void* userdata,
@@ -76,7 +58,7 @@ private:
 
   std::unique_ptr<pw_registry, PipewireRegistryDeleter> m_registry;
 
-  std::map<uint32_t, std::unique_ptr<global>> m_globals;
+  std::map<uint32_t, std::unique_ptr<CPipewireGlobal>> m_globals;
 };
 
 } // namespace PIPEWIRE


### PR DESCRIPTION
This PR splits the pipewire `global` out into a separate class `CPipewireGlobal`. This helper class adds getters/setters that IMO help with readability.

No functional changes are present.

This also includes a couple other QOL improvements such as using references and structured bindings.