### PR TITLE
[cmake] drop disabling compiler warnings

### DIFF
--- a/cmake/scripts/common/ArchSetup.cmake
+++ b/cmake/scripts/common/ArchSetup.cmake
@@ -167,17 +167,6 @@ if(NOT MSVC)
     -Wno-unused-parameter # from -Wextra
   )
 
-  if(CMAKE_COMPILER_IS_GNUCXX)
-    add_options(ALL_LANGUAGES ALL_BUILDS
-      -Wno-cast-function-type # from -Wextra
-    )
-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    add_options(ALL_LANGUAGES ALL_BUILDS
-      -Wno-bad-function-cast
-      -Wno-deprecated
-    )
-  endif()
-
   add_options(CXX ALL_BUILDS
     -Wnon-virtual-dtor
   )

--- a/xbmc/interfaces/swig/CMakeLists.txt
+++ b/xbmc/interfaces/swig/CMakeLists.txt
@@ -63,3 +63,7 @@ add_dependencies(python_binding ${GLOBAL_TARGET_DEPS})
 if(CORE_SYSTEM_NAME STREQUAL windowsstore)
   set_target_properties(python_binding PROPERTIES STATIC_LIBRARY_FLAGS "/ignore:4264")
 endif()
+if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+  set_target_properties(python_binding PROPERTIES
+                        COMPILE_FLAGS -Wno-cast-function-type) # from -Wextra
+endif()


### PR DESCRIPTION
## Description
The warnings have been already fixed, so dropping those flags doesn't generate more warnings then before.

## Motivation and context
don't hide compiler warnings from the developers

## How has this been tested?
compiled Kodi for
- Linux with GCC 13 and Clang 16
- Android
- iOS
- macOS
- tvOS

and compared generated warnings before and after this change

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
