### PR TITLE
[Windows] Improve formula for GUI SDR peak luminance setting

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2824,7 +2824,7 @@
         </dependencies>
         <control type="toggle" />
       </setting>
-      <setting id="videoscreen.guisdrpeakluminance" type="integer" label="36097" help="36547">
+      <setting id="videoscreen.guipeakluminance" type="integer" label="36097" help="36547">
         <requirement>HAS_DX</requirement>
         <dependencies>
           <dependency type="visible" on="property" name="ishdrdisplay"/>
@@ -2836,7 +2836,7 @@
           </dependency>
         </dependencies>
         <level>2</level>
-        <default>60</default>
+        <default>40</default>
         <control type="slider" format="percentage" range="0,100" />
       </setting>
       </group>

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -367,7 +367,7 @@ public:
   static constexpr auto SETTING_VIDEOSCREEN_10BITSURFACES = "videoscreen.10bitsurfaces";
   static constexpr auto SETTING_VIDEOSCREEN_USESYSTEMSDRPEAKLUMINANCE =
       "videoscreen.usesystemsdrpeakluminance";
-  static constexpr auto SETTING_VIDEOSCREEN_GUISDRPEAKLUMINANCE = "videoscreen.guisdrpeakluminance";
+  static constexpr auto SETTING_VIDEOSCREEN_GUISDRPEAKLUMINANCE = "videoscreen.guipeakluminance";
   static constexpr auto SETTING_AUDIOOUTPUT_AUDIODEVICE = "audiooutput.audiodevice";
   static constexpr auto SETTING_AUDIOOUTPUT_CHANNELS = "audiooutput.channels";
   static constexpr auto SETTING_AUDIOOUTPUT_CONFIG = "audiooutput.config";

--- a/xbmc/windowing/win10/WinSystemWin10.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10.cpp
@@ -29,6 +29,7 @@
 #include "platform/win10/AsyncHelpers.h"
 #include "platform/win32/CharsetConverter.h"
 
+#include <cmath>
 #include <mutex>
 
 #pragma pack(push,8)
@@ -665,8 +666,8 @@ float CWinSystemWin10::GetGuiSdrPeakLuminance() const
     return m_systemSdrPeakLuminance;
 
   // Max nits for 100% UI setting = 1000 nits, < 10000 nits, min 80 nits for 0%
-  int guiSdrPeak = settings->GetInt(CSettings::SETTING_VIDEOSCREEN_GUISDRPEAKLUMINANCE);
-  return 10000.0f / ((100 - guiSdrPeak) * 1.15f + 10);
+  const int guiSdrPeak = settings->GetInt(CSettings::SETTING_VIDEOSCREEN_GUISDRPEAKLUMINANCE);
+  return (80.0f * std::pow(std::exp(1.0f), 0.025257f * guiSdrPeak));
 }
 
 /*!

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -36,6 +36,7 @@
 #include "platform/win32/input/IRServerSuite.h"
 
 #include <algorithm>
+#include <cmath>
 #include <mutex>
 
 #include <tpcshrd.h>
@@ -1318,8 +1319,8 @@ float CWinSystemWin32::GetGuiSdrPeakLuminance() const
     return m_systemSdrPeakLuminance;
 
   // Max nits for 100% UI setting = 1000 nits, < 10000 nits, min 80 nits for 0%
-  int guiSdrPeak = settings->GetInt(CSettings::SETTING_VIDEOSCREEN_GUISDRPEAKLUMINANCE);
-  return 10000.0f / ((100 - guiSdrPeak) * 1.15f + 10);
+  const int guiSdrPeak = settings->GetInt(CSettings::SETTING_VIDEOSCREEN_GUISDRPEAKLUMINANCE);
+  return (80.0f * std::pow(std::exp(1.0f), 0.025257f * guiSdrPeak));
 }
 
 /*!


### PR DESCRIPTION
## Description
Improve formula for GUI SDR peak luminance setting

## Motivation and context
Follow-up of https://github.com/xbmc/xbmc/pull/22756

Better adjust and more coherent with Windows HDR/SDR balance setting:

![nits2](https://user-images.githubusercontent.com/58434170/219969661-a82c9099-119d-48cc-8426-5b8334a28e13.png)

```
  0% --> 80 nits
100% --> 1000 nits

```
new default 40% (~220 nits) matches with Windows HDR/SDR balance at default.

Setting name changed to apply new default.

~GUI control changed to spinner as suggested @jjd-uk in https://github.com/xbmc/xbmc/pull/22756#issuecomment-1436025652 to avoid issue with sliders not dimmed when disabled.~

## How has this been tested?
Runtime Windows 11 22H2

## What is the effect on users?
Better adjust of GUI SDR peak luminance and more coherence with built-in Windows HDR/SDR balance setting.

## Screenshots (if appropriate):

**Before**
![nits-old](https://user-images.githubusercontent.com/58434170/219970492-cc85fa05-9064-497b-a5ee-ccbe0a8b726e.png)

**After**
![nits2](https://user-images.githubusercontent.com/58434170/219970509-a9a3f8dc-33c7-4a43-8b19-a12fc0e91bdd.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
