### PR TITLE
[macos][nativewindow] Fix fullscreen update event

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -307,8 +307,7 @@ void CApplication::HandlePortEvents()
       {
         if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_fullScreen)
         {
-          CServiceBroker::GetWinSystem()->ResizeWindow(newEvent.resize.w, newEvent.resize.h,
-                                                       newEvent.move.x, newEvent.move.y);
+          CServiceBroker::GetWinSystem()->ResizeWindow(newEvent.resize.w, newEvent.resize.h, 0, 0);
         }
         break;
       }

--- a/xbmc/windowing/osx/OpenGL/OSXGLWindow.mm
+++ b/xbmc/windowing/osx/OpenGL/OSXGLWindow.mm
@@ -117,8 +117,6 @@
       // (from windowDidEndLiveResize). Kodi needs to rescale the UI - use a different event
       // type since XBMC_VIDEORESIZE is supposed to only be used in windowed mode
       newEvent.type = XBMC_FULLSCREEN_UPDATE;
-      newEvent.move.x = -1;
-      newEvent.move.y = -1;
     }
 
     newEvent.resize.w = width;


### PR DESCRIPTION
## Description
Found by @stevehartwell in https://github.com/xbmc/xbmc/commit/b6d48048c71c9c0211f45dbb6df702dda4fb3c39#r101245991. Same memory location is shared by both events so they can't hold distinct values (the move event can be neglected anyway).