### PR TITLE
Port Dialog: Fix resetting multitaps

### DIFF
--- a/xbmc/games/ports/input/PortManager.cpp
+++ b/xbmc/games/ports/input/PortManager.cpp
@@ -222,7 +222,7 @@ void CPortManager::DeserializeControllers(const TiXmlElement* pPort, ControllerN
       continue;
     }
 
-    std::string controllerId = XMLUtils::GetAttribute(pPort, XML_ATTR_CONTROLLER_ID);
+    std::string controllerId = XMLUtils::GetAttribute(pController, XML_ATTR_CONTROLLER_ID);
 
     auto it = std::find_if(controllers.begin(), controllers.end(),
                            [&controllerId](const CControllerNode& controller) {


### PR DESCRIPTION
## Description

Currently, in the Port Dialog, if you try to Reset the ports, nothing will happen to controllers attached to a multitap. This was caused by a copy/paste error in the XML deserialization.

## Motivation and context

Multitaps don't currently function 100% correctly, and while working on https://github.com/kodi-game/game.libretro/pull/105 I came across this bug.

## How has this been tested?

Before, setting a controller to Disconnected and then clicking Reset does nothing, leaving the controller Disconnected.

![screenshot00001](https://user-images.githubusercontent.com/531482/220261530-0ee406c2-5280-4b9b-bc8b-97754b240937.png)

After, setting a controller to Disconnected and then clicking Reset correctly causes the ports to be reset.

![screenshot00000](https://user-images.githubusercontent.com/531482/220261457-2e8a8aec-4609-497e-8539-294faf61ca74.png)

## What is the effect on users?

* Improved Port Dialog

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
