### PR TITLE
[GUI][GUIImage] Fix inconsistencies for colordiffuse

### DIFF
--- a/xbmc/guilib/GUIImage.cpp
+++ b/xbmc/guilib/GUIImage.cpp
@@ -60,8 +60,19 @@ void CGUIImage::UpdateVisibility(const CGUIListItem *item)
   AllocateOnDemand();
 }
 
+void CGUIImage::UpdateDiffuseColor(const CGUIListItem* item)
+{
+  if (m_texture->SetDiffuseColor(m_diffuseColor, item))
+  {
+    MarkDirtyRegion();
+  }
+}
+
 void CGUIImage::UpdateInfo(const CGUIListItem *item)
 {
+  // Update the diffuse color. The texture diffuse color may depend on the current item
+  UpdateDiffuseColor(item);
+
   if (m_info.IsConstant())
     return; // nothing to do
 
@@ -155,9 +166,6 @@ void CGUIImage::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions
     if (m_texture->SetAlpha(GetFadeLevel(m_currentFadeTime)))
       MarkDirtyRegion();
   }
-
-  if (m_texture->SetDiffuseColor(m_diffuseColor))
-    MarkDirtyRegion();
 
   if (m_texture->Process(currentTime))
     MarkDirtyRegion();

--- a/xbmc/guilib/GUIImage.h
+++ b/xbmc/guilib/GUIImage.h
@@ -95,6 +95,12 @@ protected:
   unsigned char GetFadeLevel(unsigned int time) const;
   bool ProcessFading(CFadingTexture *texture, unsigned int frameTime, unsigned int currentTime);
 
+  /*!
+   * \brief Update the diffuse color based on the current item infos
+   * \param item the item to for info resolution
+  */
+  void UpdateDiffuseColor(const CGUIListItem* item);
+
   bool m_bDynamicResourceAlloc;
 
   // border + conditional info


### PR DESCRIPTION
## Description
This fixes the inconsistencies when using $info `colordiffuse` as an attribute of texture vs when its set directly in an image control.

Fixes https://github.com/xbmc/xbmc/issues/22433