### PR TITLE
[gui, skin] When theme changes, also change to matching fontset

### DIFF
--- a/xbmc/application/ApplicationSkinHandling.cpp
+++ b/xbmc/application/ApplicationSkinHandling.cpp
@@ -474,15 +474,24 @@ bool CApplicationSkinHandling::OnSettingChanged(const CSetting& setting)
       std::shared_ptr<CSettingString> skinColorsSetting = std::static_pointer_cast<CSettingString>(
           CServiceBroker::GetSettingsComponent()->GetSettings()->GetSetting(
               CSettings::SETTING_LOOKANDFEEL_SKINCOLORS));
+      std::shared_ptr<CSettingString> skinFontSetting = std::static_pointer_cast<CSettingString>(
+          CServiceBroker::GetSettingsComponent()->GetSettings()->GetSetting(
+              CSettings::SETTING_LOOKANDFEEL_FONT));
       m_ignoreSkinSettingChanges = true;
 
-      // we also need to adjust the skin color setting
-      std::string colorTheme = static_cast<const CSettingString&>(setting).GetValue();
-      URIUtils::RemoveExtension(colorTheme);
-      if (setting.IsDefault() || StringUtils::EqualsNoCase(colorTheme, "Textures"))
+      // we also need to adjust the skin color theme and fontset
+      std::string theme = static_cast<const CSettingString&>(setting).GetValue();
+      if (setting.IsDefault() || StringUtils::EqualsNoCase(theme, "Textures.xbt"))
+      {
         skinColorsSetting->Reset();
+        skinFontSetting->Reset();
+      }
       else
-        skinColorsSetting->SetValue(colorTheme);
+      {
+        URIUtils::RemoveExtension(theme);
+        skinColorsSetting->SetValue(theme);
+        skinFontSetting->SetValue(theme);
+      }
     }
 
     m_ignoreSkinSettingChanges = false;

--- a/xbmc/interfaces/builtins/SkinBuiltins.cpp
+++ b/xbmc/interfaces/builtins/SkinBuiltins.cpp
@@ -420,15 +420,11 @@ static int SetTheme(const std::vector<std::string>& params)
   if (iTheme != -1 && iTheme < (int)vecTheme.size())
     strSkinTheme = vecTheme[iTheme];
 
+  // Because of the way callbacks are implemented, calling  settings->SetString(...)
+  // causes ApplicationSkinHandling::OnSettingChanged(...) to be called.
+  // The ApplicationSkinHandling::OnSettingChanged method will do all the work of
+  // changing to the new theme, including reloading the skin.
   settings->SetString(CSettings::SETTING_LOOKANDFEEL_SKINTHEME, strSkinTheme);
-  // also set the default color theme
-  std::string colorTheme(URIUtils::ReplaceExtension(strSkinTheme, ".xml"));
-  if (StringUtils::EqualsNoCase(colorTheme, "Textures.xml"))
-    colorTheme = "defaults.xml";
-  settings->SetString(CSettings::SETTING_LOOKANDFEEL_SKINCOLORS, colorTheme);
-  auto& components = CServiceBroker::GetAppComponents();
-  const auto appSkin = components.GetComponent<CApplicationSkinHandling>();
-  appSkin->ReloadSkin();
 
   return 0;
 }


### PR DESCRIPTION


## Description
Modified CApplicationSkinHandling::OnSettingChanged so that when the skin theme changes, the fontset will also change to a fontset that matches the theme name, if that fontset exists. If a matching fontset does not exist, the fontset will be set to the default fontset.
Modified SkinBuiltins::SetTheme to remove unnecessary logic for handling the theme change.

## Motivation and context
When a skin theme changes, if a matching color theme is found, the color theme is automatically changed as well.
Themes could also having matching fontsets. Currently, when a theme changes, and a matching fontset exists, the user must manually select the matching fontset to change to. This pull request will automatically change to a matching fontset when the theme changes. 


## How has this been tested?
Built and tested on Windows 10 with master branch, using Microsoft Visual Studio Community 2022 (64-bit) - Current
Version 17.4.5

Tested using the metropolis skin, because it has multiple themes. Added an additional fontset into Font.xml with a name that matched one of the themes.
1) Used the Gui to change from one theme to another. When changing to a theme with no matching fontset, the fontset was set to the default fontset. When changing to the theme with the matching fontset, the fontset was changed to the one that matched the theme name. The color themes were also changed correctly.
2) Created a button on one of the Metropolis screens to call xbmc.executebuiltin('Skin.Theme(1)'). Using the button caused the skin to rotate through its themes. When changing to a theme with no matching fontset, the fontset was set to the default fontset. When changing to the theme with the matching fontset, the fontset was changed to the one that matched the theme name. The color themes were also changed correctly.

Changing themes and fontsets at any time is already supported by the code, so making the change to a new fontset automatic should not affect other areas of the code.

## What is the effect on users?
For a particular skin, if a theme has a matching fontset, this will make it easier for users. If a theme does not have a matching fontset, this will change to the default fontset, which is different behavior than currently.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ?] **Breaking change** (fix or feature that will cause existing functionality to change)
-          Existing functionality does not change the fontset when a theme is selected, I'm not sure if this is considered 'breaking', but the fontset may now change when a theme is selected.
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
