### PR TITLE
[Android] Use MediaDrm.close instead of release

### DIFF
--- a/xbmc/platform/android/media/drm/MediaDrmCryptoSession.cpp
+++ b/xbmc/platform/android/media/drm/MediaDrmCryptoSession.cpp
@@ -98,7 +98,7 @@ CMediaDrmCryptoSession::~CMediaDrmCryptoSession()
 
   CloseSession();
 
-  m_mediaDrm->release();
+  CJNIBase::GetSDKVersion() >= 28 ? m_mediaDrm->close() : m_mediaDrm->release();
   delete m_mediaDrm, m_mediaDrm = nullptr;
 }
 


### PR DESCRIPTION
## Description
The `MediaDrm.release()` method was deprecated in API level 28, replaced by `close()`.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
