### PR TITLE
[macOS] set NSApplicationActivationPolicyRegular if NSApplicationActi…

### DIFF
--- a/xbmc/platform/darwin/osx/XBMCApplication.mm
+++ b/xbmc/platform/darwin/osx/XBMCApplication.mm
@@ -335,6 +335,17 @@ int main(int argc, const char* argv[])
     auto appDelegate = [XBMCDelegate new];
     [NSApplication sharedApplication].delegate = appDelegate;
 
+#if defined(_DEBUG)
+    // HACK: for unbundled apps (e.g. executing kodi.bin directly from xcode) the
+    // default policy is NSApplicationActivationPolicyProhibited (no dock and may not create windows)
+    // since Kodi does not currently support any headless mode force it to regular (the default for bundled)
+    // TODO: If headless is supported in the future or if setting NSApplicationActivationPolicyProhibited is
+    // intentional (e.g. from Info.Plist) this might need to be revisited later.
+    if ([NSApp activationPolicy] == NSApplicationActivationPolicyProhibited)
+    {
+      [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+    }
+#endif
     return NSApplicationMain(argc, argv);
   }
 }


### PR DESCRIPTION
…vationPolicyProhibited (unbundled executable)

## Description
This is a fallback from https://github.com/xbmc/xbmc/pull/22789. While it is an hack it affects the development workflow we are all used to.
When launching kodi.bin (unbundled) - e.g. from xcode - apple defaults to [`NSApplicationActivationPolicyProhibited`](https://developer.apple.com/documentation/appkit/nsapplicationactivationpolicy/nsapplicationactivationpolicyprohibited) which results in no dock and the inability to create windows (it's left on the background).
Since kodi does not support any headless mode at the moment (and there's no reason to set in on the bundle to anything rather than `NSApplicationActivationPolicyRegular`) this forces the policy if prohibited.
It might need to be revisited in the future if headless is supported, regardless it doesn't really cause any harm, it's a one liner, a simplifies the development workflow (restoring the old behavior).

cc @ksooo 
cc @stevehartwell (sorry :) )