### PR TITLE
NFSFile: fix crash after 9dc30e8 when file not exist (NFSv3 & NFSv4)

### DIFF
--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -585,34 +585,34 @@ bool CNFSFile::Open(const CURL& url)
 
   std::unique_lock<CCriticalSection> lock(gNfsConnection);
 
-  auto NfsOpen = [this](const CURL& url, std::string& filename) -> bool
+  if (!gNfsConnection.Connect(url, filename))
+    return false;
+
+  m_pNfsContext = gNfsConnection.GetNfsContext();
+  m_exportPath = gNfsConnection.GetContextMapId();
+
+  int ret = nfs_open(m_pNfsContext, filename.c_str(), O_RDONLY, &m_pFileHandle);
+
+  if (ret == -11) // NFS4ERR_EXPIRED
   {
-    if (!gNfsConnection.Connect(url, filename))
-      return false;
-
-    m_pNfsContext = gNfsConnection.GetNfsContext();
-    m_exportPath = gNfsConnection.GetContextMapId();
-
-    return nfs_open(m_pNfsContext, filename.c_str(), O_RDONLY, &m_pFileHandle) == 0;
-  };
-
-  if (!NfsOpen(url, filename))
-  {
-    CLog::Log(LOGERROR,
+    CLog::Log(LOGWARNING,
               "CNFSFile::Open: Unable to open file - trying again with a new context: error: '{}'",
               nfs_get_error(m_pNfsContext));
 
     gNfsConnection.Deinit();
+    m_pNfsContext = gNfsConnection.GetNfsContext();
+    m_exportPath = gNfsConnection.GetContextMapId();
+    ret = nfs_open(m_pNfsContext, filename.c_str(), O_RDONLY, &m_pFileHandle);
+  }
 
-    if (!NfsOpen(url, filename))
-    {
-      CLog::Log(LOGERROR, "CNFSFile::Open: Unable to open file: '{}' error: '{}'",
-                url.GetFileName(), nfs_get_error(m_pNfsContext));
+  if (ret != 0)
+  {
+    CLog::Log(LOGERROR, "CNFSFile::Open: Unable to open file: '{}' error: '{}'", url.GetFileName(),
+              nfs_get_error(m_pNfsContext));
 
-      m_pNfsContext = nullptr;
-      m_exportPath.clear();
-      return false;
-    }
+    m_pNfsContext = nullptr;
+    m_exportPath.clear();
+    return false;
   }
 
   CLog::Log(LOGDEBUG, "CNFSFile::Open - opened {}", url.GetFileName());


### PR DESCRIPTION
## Description
NFSFile: fix crash after https://github.com/xbmc/xbmc/pull/22714 when file not exist


## Motivation and context
Fix crash opening any Blu-Ray BDMV folder structure using NFSv3 or v4. See: https://github.com/xbmc/xbmc/pull/22714#issuecomment-1439719284

```
2023-02-22 10:38:47.222 T:3260    debug <general>: NFS: Connected to server 192.168.50.13 and export /volume1/NAS
2023-02-22 10:38:47.222 T:3260    debug <general>: NFS: chunks: r/w 131072/131072
2023-02-22 10:38:47.223 T:3260    error <general>: CNFSFile::Open: Unable to open file: 'volume1/NAS/TEST-MEDIA/UHD/Full_UHD/Uncharted (2021) UHD/AACS/Unit_Key_RO.inf' error: 'open call failed with "NFS: Lookup of /TEST-MEDIA/UHD/Full_UHD/Uncharted (2021) UHD/AACS/Unit_Key_RO.inf failed with NFS3ERR_NOENT(-2)"'
Exception thrown at 0x00007FF64D8724CB in kodi.exe: 0xC0000005: Access violation reading location 0xFFFFFFFFFFFFFFFF.
```


## How has this been tested?
Runtime Windows x64 and Android (Shield)


## What is the effect on users?
Fix crash opening Blu-Ray BDMV folders structure using NFS network protocol


## Screenshots (if appropriate):

![crash](https://user-images.githubusercontent.com/58434170/220582953-21ec5b42-a3dc-43c8-903e-f83d1b1a4ae1.png)

![stack](https://user-images.githubusercontent.com/58434170/220582990-7612e609-5573-44a1-8186-a4f3623250d4.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
