### PR TITLE
Peripheral API v3.0.0: Show "actual" controllers in the UI

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -2264,6 +2264,7 @@ msgctxt "#479"
 msgid "Skin & language"
 msgstr ""
 
+#: system/peripherals.xml
 #: system/settings/settings.xml
 #: addons/skin.estuary/xml/Includes.xml
 msgctxt "#480"

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -58,8 +58,9 @@
   </peripheral>
 
   <peripheral class="joystick" name="joystick" mapTo="joystick">
-    <setting key="left_stick_deadzone" type="float" label="35078" order="1" value="0.2" min="0.0" step="0.05" max="1.0" />
-    <setting key="right_stick_deadzone" type="float" label="35079" order="2" value="0.2" min="0.0" step="0.05" max="1.0" />
+    <setting key="appearance" type="addon" addontype="kodi.game.controller" label="480" order="1"/>
+    <setting key="left_stick_deadzone" type="float" label="35078" order="2" value="0.2" min="0.0" step="0.05" max="1.0" />
+    <setting key="right_stick_deadzone" type="float" label="35079" order="3" value="0.2" min="0.0" step="0.05" max="1.0" />
   </peripheral>
 
 </peripherals>

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -57,7 +57,7 @@
      <setting key="keymap" value="osmc" label="35007" configurable="1"/>
   </peripheral>
 
-  <peripheral class="joystick" mapTo="joystick">
+  <peripheral class="joystick" name="joystick" mapTo="joystick">
     <setting key="left_stick_deadzone" type="float" label="35078" order="1" value="0.2" min="0.0" step="0.05" max="1.0" />
     <setting key="right_stick_deadzone" type="float" label="35079" order="2" value="0.2" min="0.0" step="0.05" max="1.0" />
   </peripheral>

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -149,7 +149,7 @@ bool CServiceManager::InitStageTwo(const std::string& profilesUserDataFolder)
 
   m_contextMenuManager.reset(new CContextMenuManager(*m_addonMgr));
 
-  m_gameControllerManager.reset(new GAME::CControllerManager);
+  m_gameControllerManager = std::make_unique<GAME::CControllerManager>(*m_addonMgr);
   m_inputManager.reset(new CInputManager());
   m_inputManager->InitializeInputs();
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Peripheral.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Peripheral.h
@@ -409,6 +409,41 @@ public:
   //----------------------------------------------------------------------------
 
   //============================================================================
+  /// @brief Get the ID of the controller that best represents the peripheral's
+  /// appearance.
+  ///
+  /// @param[in] joystick The device's joystick properties; unknown values may
+  ///                     be left at their default
+  /// @param[out] controllerId The controller ID of the appearance, or empty
+  ///                          if the appearance is unknown
+  ///
+  /// @return @ref PERIPHERAL_NO_ERROR if successful
+  ///
+  virtual PERIPHERAL_ERROR GetAppearance(const kodi::addon::Joystick& joystick,
+                                         std::string& controllerId)
+  {
+    return PERIPHERAL_ERROR_NOT_IMPLEMENTED;
+  }
+  //----------------------------------------------------------------------------
+
+  //============================================================================
+  /// @brief Set the ID of the controller that best represents the peripheral's
+  /// appearance.
+  ///
+  /// @param[in] joystick The device's joystick properties; unknown values may
+  ///                     be left at their default
+  /// @param[in] controllerId The controller ID of the appearance
+  ///
+  /// @return @ref PERIPHERAL_NO_ERROR if successful
+  ///
+  virtual PERIPHERAL_ERROR SetAppearance(const kodi::addon::Joystick& joystick,
+                                         const std::string& controllerId)
+  {
+    return PERIPHERAL_ERROR_NOT_IMPLEMENTED;
+  }
+  //----------------------------------------------------------------------------
+
+  //============================================================================
   /// @brief Get the features that allow translating the joystick into the
   /// controller profile.
   ///
@@ -612,6 +647,8 @@ private:
 
     instance->peripheral->toAddon->get_joystick_info = ADDON_GetJoystickInfo;
     instance->peripheral->toAddon->free_joystick_info = ADDON_FreeJoystickInfo;
+    instance->peripheral->toAddon->get_appearance = ADDON_GetAppearance;
+    instance->peripheral->toAddon->set_appearance = ADDON_SetAppearance;
     instance->peripheral->toAddon->get_features = ADDON_GetFeatures;
     instance->peripheral->toAddon->free_features = ADDON_FreeFeatures;
     instance->peripheral->toAddon->map_features = ADDON_MapFeatures;
@@ -730,6 +767,42 @@ private:
       return;
 
     kodi::addon::Joystick::FreeStruct(*info);
+  }
+
+  inline static PERIPHERAL_ERROR ADDON_GetAppearance(const AddonInstance_Peripheral* addonInstance,
+                                                     const JOYSTICK_INFO* joystick,
+                                                     char* buffer,
+                                                     unsigned int bufferSize)
+  {
+    if (addonInstance == nullptr || joystick == nullptr || buffer == nullptr || bufferSize == 0)
+      return PERIPHERAL_ERROR_INVALID_PARAMETERS;
+
+    kodi::addon::Joystick addonJoystick(*joystick);
+    std::string controllerId;
+
+    PERIPHERAL_ERROR err = static_cast<CInstancePeripheral*>(addonInstance->toAddon->addonInstance)
+                               ->GetAppearance(addonJoystick, controllerId);
+    if (err == PERIPHERAL_NO_ERROR)
+    {
+      std::strncpy(buffer, controllerId.c_str(), bufferSize - 1);
+      buffer[bufferSize - 1] = '\0';
+    }
+
+    return err;
+  }
+
+  inline static PERIPHERAL_ERROR ADDON_SetAppearance(const AddonInstance_Peripheral* addonInstance,
+                                                     const JOYSTICK_INFO* joystick,
+                                                     const char* controllerId)
+  {
+    if (addonInstance == nullptr || joystick == nullptr || controllerId == nullptr)
+      return PERIPHERAL_ERROR_INVALID_PARAMETERS;
+
+    kodi::addon::Joystick addonJoystick(*joystick);
+    std::string strControllerId(controllerId);
+
+    return static_cast<CInstancePeripheral*>(addonInstance->toAddon->addonInstance)
+        ->SetAppearance(addonJoystick, strControllerId);
   }
 
   inline static PERIPHERAL_ERROR ADDON_GetFeatures(const AddonInstance_Peripheral* addonInstance,

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/peripheral.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/peripheral.h
@@ -609,13 +609,17 @@ extern "C"
   typedef struct AddonToKodiFuncTable_Peripheral
   {
     KODI_HANDLE kodiInstance;
+
     void (*trigger_scan)(void* kodiInstance);
+
     void (*refresh_button_maps)(void* kodiInstance,
                                 const char* device_name,
                                 const char* controller_id);
+
     unsigned int (*feature_count)(void* kodiInstance,
                                   const char* controller_id,
                                   JOYSTICK_FEATURE_TYPE type);
+
     JOYSTICK_FEATURE_TYPE(*feature_type)
     (void* kodiInstance, const char* controller_id, const char* feature_name);
   } AddonToKodiFuncTable_Peripheral;
@@ -628,20 +632,25 @@ extern "C"
 
     void(__cdecl* get_capabilities)(const struct AddonInstance_Peripheral* addonInstance,
                                     struct PERIPHERAL_CAPABILITIES* capabilities);
+
     PERIPHERAL_ERROR(__cdecl* perform_device_scan)
     (const struct AddonInstance_Peripheral* addonInstance,
      unsigned int* peripheral_count,
      struct PERIPHERAL_INFO** scan_results);
+
     void(__cdecl* free_scan_results)(const struct AddonInstance_Peripheral* addonInstance,
                                      unsigned int peripheral_count,
                                      struct PERIPHERAL_INFO* scan_results);
+
     PERIPHERAL_ERROR(__cdecl* get_events)
     (const struct AddonInstance_Peripheral* addonInstance,
      unsigned int* event_count,
      struct PERIPHERAL_EVENT** events);
+
     void(__cdecl* free_events)(const struct AddonInstance_Peripheral* addonInstance,
                                unsigned int event_count,
                                struct PERIPHERAL_EVENT* events);
+
     bool(__cdecl* send_event)(const struct AddonInstance_Peripheral* addonInstance,
                               const struct PERIPHERAL_EVENT* event);
 
@@ -651,43 +660,65 @@ extern "C"
     (const struct AddonInstance_Peripheral* addonInstance,
      unsigned int index,
      struct JOYSTICK_INFO* info);
+
     void(__cdecl* free_joystick_info)(const struct AddonInstance_Peripheral* addonInstance,
                                       struct JOYSTICK_INFO* info);
+
+    PERIPHERAL_ERROR(__cdecl* get_appearance)
+    (const struct AddonInstance_Peripheral* addonInstance,
+     const struct JOYSTICK_INFO* joystick,
+     char* buffer,
+     unsigned int bufferSize);
+
+    PERIPHERAL_ERROR(__cdecl* set_appearance)
+    (const struct AddonInstance_Peripheral* addonInstance,
+     const struct JOYSTICK_INFO* joystick,
+     const char* controller_id);
+
     PERIPHERAL_ERROR(__cdecl* get_features)
     (const struct AddonInstance_Peripheral* addonInstance,
      const struct JOYSTICK_INFO* joystick,
      const char* controller_id,
      unsigned int* feature_count,
      struct JOYSTICK_FEATURE** features);
+
     void(__cdecl* free_features)(const struct AddonInstance_Peripheral* addonInstance,
                                  unsigned int feature_count,
                                  struct JOYSTICK_FEATURE* features);
+
     PERIPHERAL_ERROR(__cdecl* map_features)
     (const struct AddonInstance_Peripheral* addonInstance,
      const struct JOYSTICK_INFO* joystick,
      const char* controller_id,
      unsigned int feature_count,
      const struct JOYSTICK_FEATURE* features);
+
     PERIPHERAL_ERROR(__cdecl* get_ignored_primitives)
     (const struct AddonInstance_Peripheral* addonInstance,
      const struct JOYSTICK_INFO* joystick,
      unsigned int* feature_count,
      struct JOYSTICK_DRIVER_PRIMITIVE** primitives);
+
     void(__cdecl* free_primitives)(const struct AddonInstance_Peripheral* addonInstance,
                                    unsigned int,
                                    struct JOYSTICK_DRIVER_PRIMITIVE* primitives);
+
     PERIPHERAL_ERROR(__cdecl* set_ignored_primitives)
     (const struct AddonInstance_Peripheral* addonInstance,
      const struct JOYSTICK_INFO* joystick,
      unsigned int primitive_count,
      const struct JOYSTICK_DRIVER_PRIMITIVE* primitives);
+
     void(__cdecl* save_button_map)(const struct AddonInstance_Peripheral* addonInstance,
                                    const struct JOYSTICK_INFO* joystick);
+
     void(__cdecl* revert_button_map)(const struct AddonInstance_Peripheral* addonInstance,
                                      const struct JOYSTICK_INFO* joystick);
+
     void(__cdecl* reset_button_map)(const struct AddonInstance_Peripheral* addonInstance,
                                     const struct JOYSTICK_INFO* joystick,
                                     const char* controller_id);
+
     void(__cdecl* power_off_joystick)(const struct AddonInstance_Peripheral* addonInstance,
                                       unsigned int index);
     ///}

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -124,8 +124,8 @@
                                                       "addon-instance/inputstream/StreamCrypto.h" \
                                                       "addon-instance/inputstream/TimingConstants.h"
 
-#define ADDON_INSTANCE_VERSION_PERIPHERAL             "2.0.0"
-#define ADDON_INSTANCE_VERSION_PERIPHERAL_MIN         "2.0.0"
+#define ADDON_INSTANCE_VERSION_PERIPHERAL             "3.0.0"
+#define ADDON_INSTANCE_VERSION_PERIPHERAL_MIN         "3.0.0"
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_XML_ID      "kodi.binary.instance.peripheral"
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_DEPENDS     "addon-instance/Peripheral.h" \
                                                       "addon-instance/PeripheralUtils.h"

--- a/xbmc/games/controllers/ControllerManager.cpp
+++ b/xbmc/games/controllers/ControllerManager.cpp
@@ -10,12 +10,16 @@
 
 #include "Controller.h"
 #include "ControllerIDs.h"
-#include "ServiceBroker.h"
 #include "addons/AddonManager.h"
 #include "addons/addoninfo/AddonType.h"
 
 using namespace KODI;
 using namespace GAME;
+
+CControllerManager::CControllerManager(ADDON::CAddonMgr& addonManager)
+  : m_addonManager(addonManager)
+{
+}
 
 ControllerPtr CControllerManager::GetController(const std::string& controllerId)
 {
@@ -26,8 +30,8 @@ ControllerPtr CControllerManager::GetController(const std::string& controllerId)
   if (!cachedController && m_failedControllers.find(controllerId) == m_failedControllers.end())
   {
     AddonPtr addon;
-    if (CServiceBroker::GetAddonMgr().GetAddon(controllerId, addon, AddonType::GAME_CONTROLLER,
-                                               OnlyEnabled::CHOICE_NO))
+    if (m_addonManager.GetAddon(controllerId, addon, AddonType::GAME_CONTROLLER,
+                                OnlyEnabled::CHOICE_NO))
       cachedController = LoadController(addon);
   }
 
@@ -56,7 +60,7 @@ ControllerVector CControllerManager::GetControllers()
   ControllerVector controllers;
 
   VECADDONS addons;
-  if (CServiceBroker::GetAddonMgr().GetInstalledAddons(addons, AddonType::GAME_CONTROLLER))
+  if (m_addonManager.GetInstalledAddons(addons, AddonType::GAME_CONTROLLER))
   {
     for (auto& addon : addons)
     {

--- a/xbmc/games/controllers/ControllerManager.h
+++ b/xbmc/games/controllers/ControllerManager.h
@@ -10,10 +10,16 @@
 
 #include "ControllerTypes.h"
 #include "addons/IAddon.h"
+#include "threads/CriticalSection.h"
 
 #include <map>
 #include <set>
 #include <string>
+
+namespace ADDON
+{
+struct AddonEvent;
+} // namespace ADDON
 
 namespace KODI
 {
@@ -23,7 +29,7 @@ class CControllerManager
 {
 public:
   CControllerManager(ADDON::CAddonMgr& addonManager);
-  ~CControllerManager() = default;
+  ~CControllerManager();
 
   /*!
    * \brief Get a controller
@@ -67,6 +73,10 @@ public:
   ControllerVector GetControllers();
 
 private:
+  // Add-on event handler
+  void OnEvent(const ADDON::AddonEvent& event);
+
+  // Utility functions
   ControllerPtr LoadController(const ADDON::AddonPtr& addon);
 
   // Construction parameters
@@ -75,6 +85,9 @@ private:
   // Controller state
   std::map<std::string, ControllerPtr> m_cache;
   std::set<std::string> m_failedControllers; // Controllers that failed to load
+
+  // Synchronization parameters
+  CCriticalSection m_mutex;
 };
 } // namespace GAME
 } // namespace KODI

--- a/xbmc/games/controllers/ControllerManager.h
+++ b/xbmc/games/controllers/ControllerManager.h
@@ -22,7 +22,7 @@ namespace GAME
 class CControllerManager
 {
 public:
-  CControllerManager() = default;
+  CControllerManager(ADDON::CAddonMgr& addonManager);
   ~CControllerManager() = default;
 
   /*!
@@ -69,6 +69,10 @@ public:
 private:
   ControllerPtr LoadController(const ADDON::AddonPtr& addon);
 
+  // Construction parameters
+  ADDON::CAddonMgr& m_addonManager;
+
+  // Controller state
   std::map<std::string, ControllerPtr> m_cache;
   std::set<std::string> m_failedControllers; // Controllers that failed to load
 };

--- a/xbmc/input/joysticks/interfaces/IButtonMap.h
+++ b/xbmc/input/joysticks/interfaces/IButtonMap.h
@@ -67,6 +67,24 @@ public:
   virtual bool IsEmpty(void) const = 0;
 
   /*!
+   * \brief Get the ID of the controller profile that best represents the
+   * appearance of the peripheral
+   *
+   * \return The controller ID, or empty if the appearance is unknown
+   */
+  virtual std::string GetAppearance() const = 0;
+
+  /*!
+  * \brief Set the ID of the controller that best represents the appearance
+  * of the peripheral
+  *
+  * \param controllerId The controller ID, or empty to unset the appearance
+  *
+  * \return True if the appearance was set, false on error
+  */
+  virtual bool SetAppearance(const std::string& controllerId) const = 0;
+
+  /*!
    * \brief Get the feature associated with a driver primitive
    *
    * Multiple primitives can be mapped to the same feature. For example,

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -12,6 +12,7 @@
 #include "EventScanner.h"
 #include "addons/AddonButtonMap.h"
 #include "addons/AddonManager.h"
+#include "addons/addoninfo/AddonInfo.h"
 #include "addons/addoninfo/AddonType.h"
 #include "addons/gui/GUIDialogAddonSettings.h"
 #include "addons/gui/GUIWindowAddonBrowser.h"
@@ -51,6 +52,7 @@
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/ThreadMessage.h"
 #include "peripherals/dialogs/GUIDialogPeripherals.h"
+#include "settings/SettingAddon.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
@@ -614,6 +616,14 @@ void CPeripherals::GetSettingsFromMappingsFile(
         int iValue = currentNode->Attribute("value") ? atoi(currentNode->Attribute("value")) : 0;
         setting = std::make_shared<CSettingInt>(strKey, iLabelId, iValue, enums);
       }
+    }
+    else if (StringUtils::EqualsNoCase(strSettingsType, "addon"))
+    {
+      std::string addonFilter = XMLUtils::GetAttribute(currentNode, "addontype");
+      ADDON::AddonType addonType = ADDON::CAddonInfo::TranslateType(addonFilter);
+      std::string strValue = XMLUtils::GetAttribute(currentNode, "value");
+      setting = std::make_shared<CSettingAddon>(strKey, iLabelId, strValue);
+      static_cast<CSettingAddon&>(*setting).SetAddonType(addonType);
     }
     else
     {

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -456,7 +456,7 @@ bool CPeripherals::GetMappingForDevice(const CPeripheralBus& bus,
                 strProductId, mapping.m_strDeviceName,
                 PeripheralTypeTranslator::TypeToString(mapping.m_mappedTo));
       result.m_mappedType = mapping.m_mappedTo;
-      if (!mapping.m_strDeviceName.empty())
+      if (result.m_strDeviceName.empty() && !mapping.m_strDeviceName.empty())
         result.m_strDeviceName = mapping.m_strDeviceName;
       return true;
     }

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -341,6 +341,11 @@ public:
    */
   KODI::GAME::CControllerManager& GetControllerProfiles() { return m_controllerProfiles; }
 
+  /*!
+   * \brief Get a mutex that allows for add-on install tasks to block on each other
+   */
+  CCriticalSection& GetAddonInstallMutex() { return m_addonInstallMutex; }
+
 private:
   bool LoadMappings();
   bool GetMappingForDevice(const CPeripheralBus& bus, PeripheralScanResult& result) const;
@@ -361,5 +366,6 @@ private:
   std::unique_ptr<CEventScanner> m_eventScanner;
   mutable CCriticalSection m_critSectionBusses;
   mutable CCriticalSection m_critSectionMappings;
+  CCriticalSection m_addonInstallMutex;
 };
 } // namespace PERIPHERALS

--- a/xbmc/peripherals/addons/AddonButtonMap.cpp
+++ b/xbmc/peripherals/addons/AddonButtonMap.cpp
@@ -46,6 +46,7 @@ std::string CAddonButtonMap::Location(void) const
 
 bool CAddonButtonMap::Load(void)
 {
+  std::string controllerAppearance;
   FeatureMap features;
   DriverMap driverMap;
   PrimitiveVector ignoredPrimitives;
@@ -70,6 +71,7 @@ bool CAddonButtonMap::Load(void)
 
   {
     std::unique_lock<CCriticalSection> lock(m_mutex);
+    m_controllerAppearance = std::move(controllerAppearance);
     m_features = std::move(features);
     m_driverMap = std::move(driverMap);
     m_ignoredPrimitives = CPeripheralAddonTranslator::TranslatePrimitives(ignoredPrimitives);
@@ -89,6 +91,18 @@ bool CAddonButtonMap::IsEmpty(void) const
   std::unique_lock<CCriticalSection> lock(m_mutex);
 
   return m_driverMap.empty();
+}
+
+std::string CAddonButtonMap::GetAppearance() const
+{
+  std::unique_lock<CCriticalSection> lock(m_mutex);
+
+  return m_controllerAppearance;
+}
+
+bool CAddonButtonMap::SetAppearance(const std::string& controllerId) const
+{
+  return false;
 }
 
 bool CAddonButtonMap::GetFeature(const CDriverPrimitive& primitive, FeatureName& feature)

--- a/xbmc/peripherals/addons/AddonButtonMap.cpp
+++ b/xbmc/peripherals/addons/AddonButtonMap.cpp
@@ -54,6 +54,7 @@ bool CAddonButtonMap::Load(void)
   bool bSuccess = false;
   if (auto addon = m_addon.lock())
   {
+    bSuccess |= addon->GetAppearance(m_device, controllerAppearance);
     bSuccess |= addon->GetFeatures(m_device, m_strControllerId, features);
     bSuccess |= addon->GetIgnoredPrimitives(m_device, ignoredPrimitives);
   }
@@ -102,6 +103,9 @@ std::string CAddonButtonMap::GetAppearance() const
 
 bool CAddonButtonMap::SetAppearance(const std::string& controllerId) const
 {
+  if (auto addon = m_addon.lock())
+    return addon->SetAppearance(m_device, controllerId);
+
   return false;
 }
 

--- a/xbmc/peripherals/addons/AddonButtonMap.h
+++ b/xbmc/peripherals/addons/AddonButtonMap.h
@@ -39,6 +39,10 @@ public:
 
   bool IsEmpty(void) const override;
 
+  std::string GetAppearance() const override;
+
+  bool SetAppearance(const std::string& controllerId) const override;
+
   bool GetFeature(const KODI::JOYSTICK::CDriverPrimitive& primitive,
                   KODI::JOYSTICK::FeatureName& feature) override;
 
@@ -122,12 +126,18 @@ private:
   static JOYSTICK_FEATURE_PRIMITIVE GetPrimitiveIndex(KODI::JOYSTICK::WHEEL_DIRECTION dir);
   static JOYSTICK_FEATURE_PRIMITIVE GetPrimitiveIndex(KODI::JOYSTICK::THROTTLE_DIRECTION dir);
 
+  // Construction parameters
   CPeripheral* const m_device;
-  std::weak_ptr<CPeripheralAddon> m_addon;
+  const std::weak_ptr<CPeripheralAddon> m_addon;
   const std::string m_strControllerId;
+
+  // Button map state
+  std::string m_controllerAppearance;
   FeatureMap m_features;
   DriverMap m_driverMap;
   JoystickPrimitiveVector m_ignoredPrimitives;
+
+  // Synchronization parameters
   mutable CCriticalSection m_mutex;
 };
 } // namespace PERIPHERALS

--- a/xbmc/peripherals/addons/PeripheralAddon.h
+++ b/xbmc/peripherals/addons/PeripheralAddon.h
@@ -80,6 +80,8 @@ public:
   //@{
   bool GetJoystickProperties(unsigned int index, CPeripheralJoystick& joystick);
   bool HasButtonMaps(void) const { return m_bProvidesButtonMaps; }
+  bool GetAppearance(const CPeripheral* device, std::string& controllerId);
+  bool SetAppearance(const CPeripheral* device, const std::string& controllerId);
   bool GetFeatures(const CPeripheral* device,
                    const std::string& strControllerId,
                    FeatureMap& features);

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -20,6 +20,7 @@
 #include "peripherals/addons/PeripheralAddon.h"
 #include "peripherals/bus/PeripheralBus.h"
 #include "peripherals/bus/virtual/PeripheralBusAddon.h"
+#include "settings/SettingAddon.h"
 #include "settings/lib/Setting.h"
 #include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
@@ -269,12 +270,21 @@ void CPeripheral::AddSetting(const std::string& strKey, const SettingConstPtr& s
       break;
       case SettingType::String:
       {
-        std::shared_ptr<const CSettingString> mappedSetting =
-            std::static_pointer_cast<const CSettingString>(setting);
-        std::shared_ptr<CSettingString> stringSetting =
-            std::make_shared<CSettingString>(strKey, *mappedSetting);
-        if (stringSetting)
+        if (std::dynamic_pointer_cast<const CSettingAddon>(setting))
         {
+          std::shared_ptr<const CSettingAddon> mappedSetting =
+              std::static_pointer_cast<const CSettingAddon>(setting);
+          std::shared_ptr<CSettingAddon> addonSetting =
+              std::make_shared<CSettingAddon>(strKey, *mappedSetting);
+          addonSetting->SetVisible(mappedSetting->IsVisible());
+          deviceSetting.m_setting = addonSetting;
+        }
+        else
+        {
+          std::shared_ptr<const CSettingString> mappedSetting =
+              std::static_pointer_cast<const CSettingString>(setting);
+          std::shared_ptr<CSettingString> stringSetting =
+              std::make_shared<CSettingString>(strKey, *mappedSetting);
           stringSetting->SetVisible(mappedSetting->IsVisible());
           deviceSetting.m_setting = stringSetting;
         }

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -11,6 +11,7 @@
 #include "Util.h"
 #include "XBDateTime.h"
 #include "games/controllers/Controller.h"
+#include "games/controllers/ControllerLayout.h"
 #include "guilib/LocalizeStrings.h"
 #include "input/joysticks/interfaces/IInputHandler.h"
 #include "peripherals/Peripherals.h"
@@ -674,8 +675,13 @@ std::string CPeripheral::GetIcon() const
 {
   std::string icon;
 
+  // Try controller profile
+  const GAME::ControllerPtr controller = ControllerProfile();
+  if (controller)
+    icon = controller->Layout().ImagePath();
+
   // Try add-on
-  if (m_busType == PERIPHERAL_BUS_ADDON)
+  if (icon.empty() && m_busType == PERIPHERAL_BUS_ADDON)
   {
     CPeripheralBusAddon* bus = static_cast<CPeripheralBusAddon*>(m_bus);
 
@@ -687,14 +693,6 @@ std::string CPeripheral::GetIcon() const
       if (!addonIcon.empty())
         icon = std::move(addonIcon);
     }
-  }
-
-  // Try controller profile
-  if (icon.empty())
-  {
-    const GAME::ControllerPtr controller = ControllerProfile();
-    if (controller)
-      icon = controller->Icon();
   }
 
   // Fallback

--- a/xbmc/peripherals/devices/Peripheral.h
+++ b/xbmc/peripherals/devices/Peripheral.h
@@ -257,9 +257,16 @@ public:
    *
    * \return The controller profile, or empty if unknown
    */
-  virtual KODI::GAME::ControllerPtr ControllerProfile() const
+  virtual KODI::GAME::ControllerPtr ControllerProfile() const { return m_controllerProfile; }
+
+  /*!
+   * \brief Set the controller profile for this peripheral
+   *
+   * \param controller The new controller profile
+   */
+  virtual void SetControllerProfile(const KODI::GAME::ControllerPtr& controller)
   {
-    return KODI::GAME::ControllerPtr{};
+    m_controllerProfile = controller;
   }
 
 protected:
@@ -294,5 +301,6 @@ protected:
   std::map<KODI::MOUSE::IMouseInputHandler*, std::unique_ptr<KODI::MOUSE::IMouseDriverHandler>>
       m_mouseHandlers;
   std::map<KODI::JOYSTICK::IButtonMapper*, std::unique_ptr<CAddonButtonMapping>> m_buttonMappers;
+  KODI::GAME::ControllerPtr m_controllerProfile;
 };
 } // namespace PERIPHERALS

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -8,11 +8,11 @@
 
 #include "PeripheralJoystick.h"
 
-#include "ServiceBroker.h"
 #include "application/Application.h"
 #include "games/GameServices.h"
 #include "games/controllers/Controller.h"
 #include "games/controllers/ControllerIDs.h"
+#include "games/controllers/ControllerManager.h"
 #include "input/InputManager.h"
 #include "input/joysticks/DeadzoneFilter.h"
 #include "input/joysticks/JoystickMonitor.h"
@@ -205,8 +205,7 @@ GAME::ControllerPtr CPeripheralJoystick::ControllerProfile() const
 {
   //! @todo Allow the user to change which controller profile represents their
   // controller. For now, just use the default.
-  GAME::CGameServices& gameServices = CServiceBroker::GetGameServices();
-  return gameServices.GetDefaultController();
+  return m_manager.GetControllerProfiles().GetDefaultController();
 }
 
 bool CPeripheralJoystick::OnButtonMotion(unsigned int buttonIndex, bool bPressed)

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -8,6 +8,9 @@
 
 #include "PeripheralJoystick.h"
 
+#include "ServiceBroker.h"
+#include "addons/AddonInstaller.h"
+#include "addons/AddonManager.h"
 #include "application/Application.h"
 #include "games/GameServices.h"
 #include "games/controllers/Controller.h"
@@ -65,6 +68,10 @@ CPeripheralJoystick::~CPeripheralJoystick(void)
   m_appInput.reset();
   m_deadzoneFilter.reset();
   m_buttonMap.reset();
+
+  // Wait for remaining install tasks
+  for (std::future<void>& task : m_installTasks)
+    task.wait();
 }
 
 bool CPeripheralJoystick::InitialiseFeature(const PeripheralFeature feature)
@@ -95,6 +102,7 @@ bool CPeripheralJoystick::InitialiseFeature(const PeripheralFeature feature)
         if (m_buttonMap->Load())
         {
           InitializeDeadzoneFiltering(*m_buttonMap);
+          InitializeControllerProfile(*m_buttonMap);
         }
         else
         {
@@ -126,6 +134,54 @@ bool CPeripheralJoystick::InitialiseFeature(const PeripheralFeature feature)
 void CPeripheralJoystick::InitializeDeadzoneFiltering(IButtonMap& buttonMap)
 {
   m_deadzoneFilter.reset(new CDeadzoneFilter(&buttonMap, this));
+}
+
+void CPeripheralJoystick::InitializeControllerProfile(IButtonMap& buttonMap)
+{
+  const std::string controllerId = buttonMap.GetAppearance();
+  if (controllerId.empty())
+    return;
+
+  auto controller = m_manager.GetControllerProfiles().GetController(controllerId);
+  if (controller)
+    CPeripheral::SetControllerProfile(controller);
+  else
+  {
+    std::unique_lock<CCriticalSection> lock(m_controllerInstallMutex);
+
+    // Deposit controller into queue
+    m_controllersToInstall.emplace(controllerId);
+
+    // Clean up finished install tasks
+    m_installTasks.erase(std::remove_if(m_installTasks.begin(), m_installTasks.end(),
+                                        [](std::future<void>& task) {
+                                          return task.wait_for(std::chrono::seconds(0)) ==
+                                                 std::future_status::ready;
+                                        }),
+                         m_installTasks.end());
+
+    // Install controller off-thread
+    std::future<void> installTask = std::async(std::launch::async, [this]() {
+      // Withdraw controller from queue
+      std::string controllerToInstall;
+      {
+        std::unique_lock<CCriticalSection> lock(m_controllerInstallMutex);
+        if (!m_controllersToInstall.empty())
+        {
+          controllerToInstall = m_controllersToInstall.front();
+          m_controllersToInstall.pop();
+        }
+      }
+
+      // Do the install
+      GAME::ControllerPtr controller = InstallAsync(controllerToInstall);
+      if (controller)
+        CPeripheral::SetControllerProfile(controller);
+    });
+
+    // Hold the task to prevent the destructor from completing during an install
+    m_installTasks.emplace_back(std::move(installTask));
+  }
 }
 
 void CPeripheralJoystick::OnUserNotification()
@@ -192,9 +248,36 @@ IKeymap* CPeripheralJoystick::GetKeymap(const std::string& controllerId)
 
 GAME::ControllerPtr CPeripheralJoystick::ControllerProfile() const
 {
-  //! @todo Allow the user to change which controller profile represents their
-  // controller. For now, just use the default.
+  // Button map has the freshest state
+  if (m_buttonMap)
+  {
+    const std::string controllerId = m_buttonMap->GetAppearance();
+    if (!controllerId.empty())
+    {
+      auto controller = m_manager.GetControllerProfiles().GetController(controllerId);
+      if (controller)
+        return controller;
+    }
+  }
+
+  // Fall back to last set controller profile
+  if (m_controllerProfile)
+    return m_controllerProfile;
+
+  // Fall back to default controller
   return m_manager.GetControllerProfiles().GetDefaultController();
+}
+
+void CPeripheralJoystick::SetControllerProfile(const KODI::GAME::ControllerPtr& controller)
+{
+  CPeripheral::SetControllerProfile(controller);
+
+  // Save preference to buttonmap
+  if (m_buttonMap)
+  {
+    if (m_buttonMap->SetAppearance(controller->ID()))
+      m_buttonMap->SaveButtonMap();
+  }
 }
 
 bool CPeripheralJoystick::OnButtonMotion(unsigned int buttonIndex, bool bPressed)
@@ -412,4 +495,43 @@ void CPeripheralJoystick::SetSupportsPowerOff(bool bSupportsPowerOff)
                      m_features.end());
   else if (std::find(m_features.begin(), m_features.end(), FEATURE_POWER_OFF) == m_features.end())
     m_features.push_back(FEATURE_POWER_OFF);
+}
+
+GAME::ControllerPtr CPeripheralJoystick::InstallAsync(const std::string& controllerId)
+{
+  GAME::ControllerPtr controller;
+
+  // Only 1 install at a time. Remaining installs will wake when this one
+  // is done.
+  std::unique_lock<CCriticalSection> lockInstall(m_manager.GetAddonInstallMutex());
+
+  CLog::LogF(LOGDEBUG, "Installing {}", controllerId);
+
+  if (InstallSync(controllerId))
+    controller = m_manager.GetControllerProfiles().GetController(controllerId);
+  else
+    CLog::LogF(LOGERROR, "Failed to install {}", controllerId);
+
+  return controller;
+}
+
+bool CPeripheralJoystick::InstallSync(const std::string& controllerId)
+{
+  // If the addon isn't installed we need to install it
+  bool installed = CServiceBroker::GetAddonMgr().IsAddonInstalled(controllerId);
+  if (!installed)
+  {
+    ADDON::AddonPtr installedAddon;
+    installed = ADDON::CAddonInstaller::GetInstance().InstallModal(
+        controllerId, installedAddon, ADDON::InstallModalPrompt::CHOICE_NO);
+  }
+
+  if (installed)
+  {
+    // Make sure add-on is enabled
+    if (CServiceBroker::GetAddonMgr().IsAddonDisabled(controllerId))
+      CServiceBroker::GetAddonMgr().EnableAddon(controllerId);
+  }
+
+  return installed;
 }

--- a/xbmc/peripherals/devices/PeripheralJoystick.h
+++ b/xbmc/peripherals/devices/PeripheralJoystick.h
@@ -10,11 +10,14 @@
 
 #include "Peripheral.h"
 #include "XBDateTime.h"
+#include "games/controllers/ControllerTypes.h"
 #include "input/joysticks/JoystickTypes.h"
 #include "input/joysticks/interfaces/IDriverReceiver.h"
 #include "threads/CriticalSection.h"
 
+#include <future>
 #include <memory>
+#include <queue>
 #include <string>
 #include <vector>
 
@@ -58,6 +61,7 @@ public:
   IKeymap* GetKeymap(const std::string& controllerId) override;
   CDateTime LastActive() override { return m_lastActive; }
   KODI::GAME::ControllerPtr ControllerProfile() const override;
+  void SetControllerProfile(const KODI::GAME::ControllerPtr& controller) override;
 
   bool OnButtonMotion(unsigned int buttonIndex, bool bPressed);
   bool OnHatMotion(unsigned int hatIndex, KODI::JOYSTICK::HAT_STATE state);
@@ -105,8 +109,13 @@ public:
 
 protected:
   void InitializeDeadzoneFiltering(KODI::JOYSTICK::IButtonMap& buttonMap);
+  void InitializeControllerProfile(KODI::JOYSTICK::IButtonMap& buttonMap);
 
   void PowerOff();
+
+  // Helper functions
+  KODI::GAME::ControllerPtr InstallAsync(const std::string& controllerId);
+  static bool InstallSync(const std::string& controllerId);
 
   struct DriverHandler
   {
@@ -123,6 +132,8 @@ protected:
   unsigned int m_motorCount;
   bool m_supportsPowerOff;
   CDateTime m_lastActive;
+  std::queue<std::string> m_controllersToInstall;
+  std::vector<std::future<void>> m_installTasks;
 
   // Input clients
   std::unique_ptr<KODI::JOYSTICK::CKeymapHandling> m_appInput;
@@ -134,5 +145,6 @@ protected:
 
   // Synchronization parameters
   CCriticalSection m_handlerMutex;
+  CCriticalSection m_controllerInstallMutex;
 };
 } // namespace PERIPHERALS

--- a/xbmc/peripherals/devices/PeripheralJoystick.h
+++ b/xbmc/peripherals/devices/PeripheralJoystick.h
@@ -104,7 +104,7 @@ public:
   void SetSupportsPowerOff(bool bSupportsPowerOff); // specialized to update m_features
 
 protected:
-  void InitializeDeadzoneFiltering();
+  void InitializeDeadzoneFiltering(KODI::JOYSTICK::IButtonMap& buttonMap);
 
   void PowerOff();
 

--- a/xbmc/peripherals/devices/PeripheralKeyboard.cpp
+++ b/xbmc/peripherals/devices/PeripheralKeyboard.cpp
@@ -81,6 +81,9 @@ void CPeripheralKeyboard::UnregisterKeyboardDriverHandler(
 
 GAME::ControllerPtr CPeripheralKeyboard::ControllerProfile() const
 {
+  if (m_controllerProfile)
+    return m_controllerProfile;
+
   return m_manager.GetControllerProfiles().GetDefaultKeyboard();
 }
 

--- a/xbmc/peripherals/devices/PeripheralKeyboard.cpp
+++ b/xbmc/peripherals/devices/PeripheralKeyboard.cpp
@@ -8,9 +8,9 @@
 
 #include "PeripheralKeyboard.h"
 
-#include "ServiceBroker.h"
 #include "games/GameServices.h"
 #include "games/controllers/Controller.h"
+#include "games/controllers/ControllerManager.h"
 #include "input/InputManager.h"
 #include "peripherals/Peripherals.h"
 
@@ -81,8 +81,7 @@ void CPeripheralKeyboard::UnregisterKeyboardDriverHandler(
 
 GAME::ControllerPtr CPeripheralKeyboard::ControllerProfile() const
 {
-  GAME::CGameServices& gameServices = CServiceBroker::GetGameServices();
-  return gameServices.GetDefaultKeyboard();
+  return m_manager.GetControllerProfiles().GetDefaultKeyboard();
 }
 
 bool CPeripheralKeyboard::OnKeyPress(const CKey& key)

--- a/xbmc/peripherals/devices/PeripheralMouse.cpp
+++ b/xbmc/peripherals/devices/PeripheralMouse.cpp
@@ -8,9 +8,9 @@
 
 #include "PeripheralMouse.h"
 
-#include "ServiceBroker.h"
 #include "games/GameServices.h"
 #include "games/controllers/Controller.h"
+#include "games/controllers/ControllerManager.h"
 #include "input/InputManager.h"
 #include "peripherals/Peripherals.h"
 
@@ -76,8 +76,7 @@ void CPeripheralMouse::UnregisterMouseDriverHandler(MOUSE::IMouseDriverHandler* 
 
 GAME::ControllerPtr CPeripheralMouse::ControllerProfile() const
 {
-  GAME::CGameServices& gameServices = CServiceBroker::GetGameServices();
-  return gameServices.GetDefaultMouse();
+  return m_manager.GetControllerProfiles().GetDefaultMouse();
 }
 
 bool CPeripheralMouse::OnPosition(int x, int y)

--- a/xbmc/peripherals/devices/PeripheralMouse.cpp
+++ b/xbmc/peripherals/devices/PeripheralMouse.cpp
@@ -76,6 +76,9 @@ void CPeripheralMouse::UnregisterMouseDriverHandler(MOUSE::IMouseDriverHandler* 
 
 GAME::ControllerPtr CPeripheralMouse::ControllerProfile() const
 {
+  if (m_controllerProfile)
+    return m_controllerProfile;
+
   return m_manager.GetControllerProfiles().GetDefaultMouse();
 }
 

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
@@ -12,16 +12,24 @@
 #include "ServiceBroker.h"
 #include "addons/Skin.h"
 #include "dialogs/GUIDialogYesNo.h"
+#include "games/controllers/Controller.h"
+#include "games/controllers/ControllerManager.h"
 #include "guilib/GUIMessage.h"
 #include "peripherals/Peripherals.h"
+#include "settings/SettingAddon.h"
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingSection.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
 
+#include <string_view>
 #include <utility>
 
+using namespace KODI;
 using namespace PERIPHERALS;
+
+// Settings for peripherals
+constexpr std::string_view SETTING_APPEARANCE = "appearance";
 
 CGUIDialogPeripheralSettings::CGUIDialogPeripheralSettings()
   : CGUIDialogSettingsManualBase(WINDOW_DIALOG_PERIPHERAL_SETTINGS, "DialogSettings.xml"),
@@ -49,6 +57,16 @@ bool CGUIDialogPeripheralSettings::OnMessage(CGUIMessage& message)
   return CGUIDialogSettingsManualBase::OnMessage(message);
 }
 
+void CGUIDialogPeripheralSettings::RegisterPeripheralManager(CPeripherals& manager)
+{
+  m_manager = &manager;
+}
+
+void CGUIDialogPeripheralSettings::UnregisterPeripheralManager()
+{
+  m_manager = nullptr;
+}
+
 void CGUIDialogPeripheralSettings::SetFileItem(const CFileItem* item)
 {
   if (item == NULL)
@@ -67,14 +85,43 @@ void CGUIDialogPeripheralSettings::OnSettingChanged(const std::shared_ptr<const 
 
   CGUIDialogSettingsManualBase::OnSettingChanged(setting);
 
+  const std::string& settingId = setting->GetId();
+
   // we need to copy the new value of the setting from the copy to the
   // original setting
   std::map<std::string, std::shared_ptr<CSetting>>::iterator itSetting =
-      m_settingsMap.find(setting->GetId());
+      m_settingsMap.find(settingId);
   if (itSetting == m_settingsMap.end())
     return;
 
   itSetting->second->FromString(setting->ToString());
+
+  // Get peripheral associated with this setting
+  PeripheralPtr peripheral;
+  if (m_item != nullptr)
+    peripheral = CServiceBroker::GetPeripherals().GetByPath(m_item->GetPath());
+
+  if (!peripheral)
+    return;
+
+  if (settingId == SETTING_APPEARANCE)
+  {
+    // Get the controller profile of the new appearance
+    GAME::ControllerPtr controller;
+
+    if (setting->GetType() == SettingType::String)
+    {
+      std::shared_ptr<const CSettingString> settingString =
+          std::static_pointer_cast<const CSettingString>(setting);
+      const std::string& addonId = settingString->GetValue();
+
+      if (m_manager != nullptr)
+        controller = m_manager->GetControllerProfiles().GetController(addonId);
+    }
+
+    if (controller)
+      peripheral->SetControllerProfile(controller);
+  }
 }
 
 bool CGUIDialogPeripheralSettings::Save()
@@ -208,11 +255,38 @@ void CGUIDialogPeripheralSettings::InitializeSettings()
 
       case SettingType::String:
       {
-        std::shared_ptr<CSettingString> settingString = std::make_shared<CSettingString>(
-            setting->GetId(), *std::static_pointer_cast<CSettingString>(setting));
-        settingString->SetControl(GetEditControl("string"));
+        if (auto settingAsAddon = std::dynamic_pointer_cast<const CSettingAddon>(setting))
+        {
+          std::shared_ptr<CSettingAddon> settingAddon =
+              std::make_shared<CSettingAddon>(setting->GetId(), *settingAsAddon);
 
-        settingCopy = std::static_pointer_cast<CSetting>(settingString);
+          // Control properties
+          const std::string format = "addon";
+          const bool delayed = false;
+          const int heading = -1;
+          const bool hideValue = false;
+          const bool showInstalledAddons = true;
+          const bool showInstallableAddons = true;
+          const bool showMoreAddons = false;
+
+          settingAddon->SetControl(GetButtonControl(format, delayed, heading, hideValue,
+                                                    showInstalledAddons, showInstallableAddons,
+                                                    showMoreAddons));
+
+          GAME::ControllerPtr controller = peripheral->ControllerProfile();
+          if (controller)
+            settingAddon->SetValue(controller->ID());
+
+          settingCopy = std::static_pointer_cast<CSetting>(settingAddon);
+        }
+        else
+        {
+          std::shared_ptr<CSettingString> settingString = std::make_shared<CSettingString>(
+              setting->GetId(), *std::static_pointer_cast<CSettingString>(setting));
+          settingString->SetControl(GetEditControl("string"));
+
+          settingCopy = std::static_pointer_cast<CSetting>(settingString);
+        }
         break;
       }
 

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.h
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.h
@@ -14,6 +14,8 @@ class CFileItem;
 
 namespace PERIPHERALS
 {
+class CPeripherals;
+
 class CGUIDialogPeripheralSettings : public CGUIDialogSettingsManualBase
 {
 public:
@@ -22,6 +24,9 @@ public:
 
   // specializations of CGUIControl
   bool OnMessage(CGUIMessage& message) override;
+
+  void RegisterPeripheralManager(CPeripherals& manager);
+  void UnregisterPeripheralManager();
 
   virtual void SetFileItem(const CFileItem* item);
 
@@ -38,6 +43,8 @@ protected:
   // specialization of CGUIDialogSettingsManualBase
   void InitializeSettings() override;
 
+  // Dialog state
+  CPeripherals* m_manager{nullptr};
   CFileItem* m_item;
   bool m_initialising = false;
   std::map<std::string, std::shared_ptr<CSetting>> m_settingsMap;

--- a/xbmc/peripherals/dialogs/GUIDialogPeripherals.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripherals.cpp
@@ -118,7 +118,9 @@ void CGUIDialogPeripherals::Show(CPeripherals& manager)
 
         // Open settings dialog
         pSettingsDialog->SetFileItem(pItem.get());
+        pSettingsDialog->RegisterPeripheralManager(manager);
         pSettingsDialog->Open();
+        pSettingsDialog->UnregisterPeripheralManager();
       }
     }
   } while (pDialog->IsConfirmed());


### PR DESCRIPTION
## Description

This PR completes a task I've long wanted to do: showing the underlying "actual" controller in the UI. Instead of being shown an array of outdated Xbox 360 controllers, you're shown the controller that you're actually using.

![screenshot00001](https://user-images.githubusercontent.com/531482/221161442-0622de51-5e14-4360-81ff-03b8895957a4.png)

Specifically, this PR adds a new feature to peripheral add-ons, the "appearance" attribute which takes the ID of a controller profile. This is intended to be the best representation of the given controller, visually.

If "appearance" is missing, it will be deduced from the buttonmap: By default, if only one controller is mapped, that is deduced to be its visual appearance. If more than one controllers are mapped, it will be ignored and shown as the default controller.

## How has this been tested?

Test builds have been uploaded to: https://github.com/garbear/xbmc/releases

My ultimate goal was to connect a new, unseen controller not mapped to the default profile and have it work. Of course, this requires the "base buttonmap" or "codex" discussed in previous issues.

However, even though the controller works without an existing profile, in theory it can work better if the profile is installed. The problem is singularly with analog sticks which need the controller profile installed. I added a quick hack to peripheral.joystick in https://github.com/xbmc/peripheral.joystick/pull/266, so this shouldn't be an issue.

## Related PRs

Requires https://github.com/xbmc/peripheral.joystick/pull/266

## What is the effect on users?

Visualize current controller in the UI.

## Motivation and context

Next is that all hotkeys, like "Select + X", are shown in terms of the user's controller.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
