### PR TITLE
[PVR] Rework PVR windows late init.

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -682,6 +682,7 @@ bool CPVRManager::UpdateComponents(ManagerState stateToCheck,
   {
     CLog::LogFC(LOGDEBUG, LOGPVR, "All created PVR clients gone!");
     m_knownClients.clear(); // start over
+    PublishEvent(PVREvent::ClientsInvalidated);
     return false;
   }
 
@@ -717,6 +718,7 @@ bool CPVRManager::UpdateComponents(ManagerState stateToCheck,
   {
     CLog::LogF(LOGERROR, "Failed to load PVR providers.");
     m_knownClients.clear(); // start over
+    PublishEvent(PVREvent::ClientsInvalidated);
     return false;
   }
 
@@ -724,10 +726,9 @@ bool CPVRManager::UpdateComponents(ManagerState stateToCheck,
   {
     CLog::LogF(LOGERROR, "Failed to load PVR channels / groups.");
     m_knownClients.clear(); // start over
+    PublishEvent(PVREvent::ClientsInvalidated);
     return false;
   }
-
-  PublishEvent(PVREvent::ChannelGroupsLoaded);
 
   // Load all timers
   if (progressHandler)
@@ -737,6 +738,7 @@ bool CPVRManager::UpdateComponents(ManagerState stateToCheck,
   {
     CLog::LogF(LOGERROR, "Failed to load PVR timers.");
     m_knownClients.clear(); // start over
+    PublishEvent(PVREvent::ClientsInvalidated);
     return false;
   }
 
@@ -748,9 +750,11 @@ bool CPVRManager::UpdateComponents(ManagerState stateToCheck,
   {
     CLog::LogF(LOGERROR, "Failed to load PVR recordings.");
     m_knownClients.clear(); // start over
+    PublishEvent(PVREvent::ClientsInvalidated);
     return false;
   }
 
+  PublishEvent(PVREvent::ClientsInvalidated);
   return true;
 }
 

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -60,7 +60,6 @@ enum class PVREvent
   ChannelGroup,
   ChannelGroupInvalidated,
   ChannelGroupsInvalidated,
-  ChannelGroupsLoaded,
 
   // Recording events
   RecordingsInvalidated,
@@ -69,6 +68,9 @@ enum class PVREvent
   AnnounceReminder,
   Timers,
   TimersInvalidated,
+
+  // Client events
+  ClientsInvalidated,
 
   // EPG events
   Epg,
@@ -84,7 +86,7 @@ enum class PVREvent
   // Item events
   CurrentItem,
 
-  // Syetem events
+  // System events
   SystemSleep,
   SystemWake,
 };

--- a/xbmc/pvr/windows/GUIWindowPVRBase.h
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.h
@@ -112,9 +112,6 @@ namespace PVR
 
     virtual void UpdateSelectedItemPath();
 
-    void RegisterObservers();
-    void UnregisterObservers();
-
     CCriticalSection m_critSection;
     std::string m_channelGroupPath;
     bool m_bRadio;

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -572,18 +572,19 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
     {
       switch (static_cast<PVREvent>(message.GetParam1()))
       {
-        case PVREvent::ChannelGroupsLoaded:
-          // late init
-          InitChannelGroup();
-          InitEpgGridControl();
+        case PVREvent::ManagerStarted:
+          if (InitChannelGroup())
+            InitEpgGridControl();
           break;
 
         case PVREvent::ChannelGroup:
         case PVREvent::ChannelGroupInvalidated:
+        case PVREvent::ClientsInvalidated:
         case PVREvent::ChannelPlaybackStopped:
         case PVREvent::Epg:
         case PVREvent::EpgContainer:
-          Refresh(true);
+          if (InitChannelGroup())
+            Refresh(true);
           break;
 
         case PVREvent::Timers:


### PR DESCRIPTION
This is a follow-up to #22389, which only provided quick fix. This PR is what I consider the real fix.

@emveepee could you do a runtime-test? You had several good use cases last time.

I runtime-tested this for a couple of weeks already and found no side effects or regressions.

@phunkyfish ready for another code review?