### PR TITLE
Controller Dialog: Fix "Ignore Input" buttons not being saved

### DIFF
--- a/xbmc/input/joysticks/interfaces/IButtonMapper.h
+++ b/xbmc/input/joysticks/interfaces/IButtonMapper.h
@@ -110,15 +110,15 @@ public:
   virtual void OnLateAxis(const IButtonMap* buttonMap, unsigned int axisIndex) = 0;
 
   // Button map callback interface
-  void SetButtonMapCallback(const std::string& deviceName, IButtonMapCallback* callback)
+  void SetButtonMapCallback(const std::string& deviceLocation, IButtonMapCallback* callback)
   {
-    m_callbacks[deviceName] = callback;
+    m_callbacks[deviceLocation] = callback;
   }
   void ResetButtonMapCallbacks(void) { m_callbacks.clear(); }
   std::map<std::string, IButtonMapCallback*>& ButtonMapCallbacks(void) { return m_callbacks; }
 
 private:
-  std::map<std::string, IButtonMapCallback*> m_callbacks;
+  std::map<std::string, IButtonMapCallback*> m_callbacks; // Device location -> callback
 };
 } // namespace JOYSTICK
 } // namespace KODI

--- a/xbmc/peripherals/addons/AddonButtonMapping.cpp
+++ b/xbmc/peripherals/addons/AddonButtonMapping.cpp
@@ -38,7 +38,7 @@ CAddonButtonMapping::CAddonButtonMapping(CPeripherals& manager,
       m_buttonMapping.reset(new CButtonMapping(mapper, m_buttonMap.get(), keymap));
 
       // Allow the mapper to save our button map
-      mapper->SetButtonMapCallback(peripheral->DeviceName(), this);
+      mapper->SetButtonMapCallback(peripheral->Location(), this);
     }
     else
       m_buttonMap.reset();


### PR DESCRIPTION
## Description

When cherry-picking the controller fix from GSoC 2020 in https://github.com/xbmc/xbmc/pull/20075, one place wasn't updated to use device location instead of device name, and as a result saving buttonmaps is broken in the "Ignore Input" sub-dialog.

## Motivation and context

Discovered when testing https://github.com/xbmc/xbmc/pull/22856.

## How has this been tested?

Tested as part of https://github.com/xbmc/xbmc/pull/22856.

Test builds have been uploaded to https://github.com/garbear/xbmc/releases

## What is the effect on users?

* Fixed bug in Controller Mapping Dialog

## Screenshots (if appropriate):

![screenshot00002](https://user-images.githubusercontent.com/531482/221332324-8aea1665-84bf-401c-8f12-188e220f1fde.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
