### PR TITLE
Compability with linux kernels < 4.4

### DIFF
--- a/xbmc/windowing/wayland/InputProcessorPointer.cpp
+++ b/xbmc/windowing/wayland/InputProcessorPointer.cpp
@@ -12,7 +12,7 @@
 
 #include <cmath>
 
-#include <linux/input-event-codes.h>
+#include <linux/input.h>
 
 using namespace KODI::WINDOWING::WAYLAND;
 

--- a/xbmc/windowing/wayland/WindowDecorator.cpp
+++ b/xbmc/windowing/wayland/WindowDecorator.cpp
@@ -18,7 +18,7 @@
 #include <mutex>
 #include <vector>
 
-#include <linux/input-event-codes.h>
+#include <linux/input.h>
 
 using namespace KODI::UTILS::POSIX;
 using namespace KODI::WINDOWING::WAYLAND;


### PR DESCRIPTION
`<linux/input-event-codes.h>` is only available starting from linux kernel 4.4 onwards. Before 4.4 `<linux/input.h>` included the defines from `<linux/input-event-codes.h>`.

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Allow building the wayland backend on linux kernels < 4.4.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The included kernel header `<linux/input-event-codes.h>` is only available from 4.4 onwards. Before 4.4 the necessary defines exist in `<linux/input.h>`.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
None, on newer kernels `<linux/input.h>` includes `<linux/input-event-codes.h>`.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
