### PR TITLE
[UPnP] Use base64 encoded values for objectIds

### DIFF
--- a/xbmc/network/upnp/UPnPInternal.h
+++ b/xbmc/network/upnp/UPnPInternal.h
@@ -118,5 +118,21 @@ namespace UPNP
 
   bool             GetResource(const PLT_MediaObject* entry, CFileItem& item);
   std::shared_ptr<CFileItem> GetFileItem(const NPT_String& uri, const NPT_String& meta);
+
+  /*!
+   * @brief Provided a given object id, encode it into a safe format to provide to UPnP clients
+   * @Note base64 is currently used as the safe format
+   * @param id the object it to encode
+   * @return the encoded object id
+  */
+  NPT_String EncodeObjectId(const std::string& id);
+
+  /*!
+   * @brief Provided a given encoded object id, decode it into a format known by the application
+   * @Note base64 is currently used as the expected input format
+   * @param id the object it to decode
+   * @return the decoded object id
+  */
+  NPT_String DecodeObjectId(const std::string& id);
 }
 


### PR DESCRIPTION
## Description
Currently Kodi uses vfs paths as object ids in UPnP. This is convenient from Kodi side (easier to read and to interpret) but causes all sort of issues for external clients when trying to list childrens or browse the metadata associated to those virtual paths. We have all sorts of virtual uris, some containing query arguments, repetition of query arguments on the same string, sort methods (which are then interpreted as json), etc. This is not compatible with DIDL (Digital Item Declaration Language) leading to most of the UPnP directories to show empty and/or without metadata in external clients.
Hence, for retaining the ease of use from our side, this PR suggests that we move from plain vfs urls to the resulting base64 encoded strings for the vfs uris which is safe to use. Easy to convert when debugging and are also logged to the kodi log along with the encoded string:

```
2023-02-26 10:47:12.157 T:2429179   debug <CUPnPServer[Kodi (MacBook-Air.local)]>: Returning UPnP response with 2 items out of 2 total matches
2023-02-26 10:47:12.654 T:2429183    info <CUPnPServer[Kodi (MacBook-Air.local)]>: Received UPnP Browse Metadata request for encoded object 'dmlkZW9kYjovL3R2c2hvd3MvdGl0bGVzLzEvMS8xP3NlYXNvbj0xJnR2c2hvd2lkPTEmeHNwPSU3YiUyMm9yZGVyJTIyJTNhJTdiJTIyZGlyZWN0aW9uJTIyJTNhJTIyYXNjZW5kaW5nJTIyJTJjJTIyaWdub3JlZm9sZGVycyUyMiUzYTAlMmMlMjJtZXRob2QlMjIlM2ElMjJzb3J0dGl0bGUlMjIlN2QlMmMlMjJ0eXBlJTIyJTNhJTIydHZzaG93cyUyMiU3ZA==' (plain value: 'videodb://tvshows/titles/1/1/1?season=1&tvshowid=1&xsp=%7b%22order%22%3a%7b%22direction%22%3a%22ascending%22%2c%22ignorefolders%22%3a0%2c%22method%22%3a%22sorttitle%22%7d%2c%22type%22%3a%22tvshows%22%7d')
2023-02-26 10:47:12.654 T:2429183   debug <CUPnPServer[Kodi (MacBook-Air.local)]>: Translated id to 'videodb://tvshows/titles/1/1/1?season=1&tvshowid=1&xsp=%7b%22order%22%3a%7b%22direction%22%3a%22ascending%22%2c%22ignorefolders%22%3a0%2c%22method%22%3a%22sorttitle%22%7d%2c%22type%22%3a%22tvshows%22%7d'
```


Depends (ideally) on https://github.com/xbmc/xbmc/pull/22858.

~~Plan to backport after it has been in master for a bit of time (maybe 20.2).~~ (will not be backported)
I wont be adjusting clang-format for now, those files are totally broken. Plan to do it in bulk after the two PRs are in.

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/22828

## How has this been tested?
Tested with the official client of my philips tv and kodi/server on mac. Original issue reporter (@misanthropos) reported similar results on the official Tizen client for Samsung TV and librelec. See the issue thread for additional details.

## What is the effect on users?
Make UPnP more widely compatible with external clients

## Screenshots (if appropriate):

**Before:**
![IMG20230226103119](https://user-images.githubusercontent.com/7375276/221405619-ff56ecf9-abc9-430f-a33c-d4a18c0eecbd.jpg)
![IMG20230226103200](https://user-images.githubusercontent.com/7375276/221405656-6fd79292-d63e-43eb-81f5-4e21ba47f006.jpg)


**After:**

![IMG20230226102852](https://user-images.githubusercontent.com/7375276/221405642-d8441c5e-2f73-4083-b0a7-4fcee343ee98.jpg)

![IMG20230226102941](https://user-images.githubusercontent.com/7375276/221405668-46eead23-665f-42c4-9351-a350d67e1d9e.jpg)
