### PR TITLE
[GUIImage] Fix regression for color diffuse if no info is set

### DIFF
--- a/xbmc/guilib/GUIImage.cpp
+++ b/xbmc/guilib/GUIImage.cpp
@@ -70,8 +70,9 @@ void CGUIImage::UpdateDiffuseColor(const CGUIListItem* item)
 
 void CGUIImage::UpdateInfo(const CGUIListItem *item)
 {
-  // Update the diffuse color. The texture diffuse color may depend on the current item
-  UpdateDiffuseColor(item);
+  // The texture may also depend on info conditions. Update the diffuse color in that case.
+  if (m_texture->GetDiffuseColor().HasInfo())
+    UpdateDiffuseColor(item);
 
   if (m_info.IsConstant())
     return; // nothing to do
@@ -166,6 +167,9 @@ void CGUIImage::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions
     if (m_texture->SetAlpha(GetFadeLevel(m_currentFadeTime)))
       MarkDirtyRegion();
   }
+
+  if (!m_texture->GetDiffuseColor().HasInfo())
+    UpdateDiffuseColor(nullptr);
 
   if (m_texture->Process(currentTime))
     MarkDirtyRegion();

--- a/xbmc/guilib/GUITexture.h
+++ b/xbmc/guilib/GUITexture.h
@@ -116,6 +116,12 @@ public:
   const CRect& GetRenderRect() const { return m_vertex; }
   bool IsLazyLoaded() const { return m_info.useLarge; }
 
+  /*!
+   * @brief Get the diffuse color (info color) associated to this texture
+   * @return the infocolor associated to this texture
+  */
+  KODI::GUILIB::GUIINFO::CGUIInfoColor GetDiffuseColor() const { return m_info.diffuseColor; }
+
   bool HitTest(const CPoint& point) const
   {
     return CRect(m_posX, m_posY, m_posX + m_width, m_posY + m_height).PtInRect(point);

--- a/xbmc/guilib/guiinfo/GUIInfoColor.h
+++ b/xbmc/guilib/guiinfo/GUIInfoColor.h
@@ -37,6 +37,12 @@ public:
   bool Update(const CGUIListItem* item = nullptr);
   void Parse(const std::string &label, int context);
 
+  /*!
+   * @brief Check if the infocolor has an info condition bound to its color definition (or otherwise, if it's constant color)
+   * @return true if the color depends on an info condition, false otherwise
+  */
+  bool HasInfo() const { return m_info != 0; }
+
 private:
   int m_info = 0;
   UTILS::COLOR::Color m_color;


### PR DESCRIPTION
## Description
Unfortunately https://github.com/xbmc/xbmc/pull/22848 caused regressions for image controls that set a diffuse color on the texture and don't really depend on info conditions.

Fixes https://github.com/xbmc/xbmc/issues/22863

## How has this been tested

Using the colorpicker dialog in estuary by changing the colordiffuse property from an image inner element to a texture attribute (the motivation of the original change, which is well described in https://github.com/xbmc/xbmc/issues/22433). Tested using the titan mod skin under nexus where colordiffuse is not bound to info values - which currently leads image blocks to be displayed fully white.
This change makes the 2 test use-cases work properly, retaining old behavior in the titan mod skin while supporting the two modes of operation (old inconsistency) for colordiffuse in `<image>` elements.
