### PR TITLE
[Android] Show storage permissions granted in logs

### DIFF
--- a/xbmc/platform/android/PlatformAndroid.cpp
+++ b/xbmc/platform/android/PlatformAndroid.cpp
@@ -18,6 +18,7 @@
 #include <stdlib.h>
 
 #include <androidjni/Build.h>
+#include <androidjni/PackageManager.h>
 
 CPlatform* CPlatform::CreateInstance()
 {
@@ -46,8 +47,18 @@ void CPlatformAndroid::PlatformSyslog()
       "Product: {}, Device: {}, Board: {} - Manufacturer: {}, Brand: {}, Model: {}, Hardware: {}",
       CJNIBuild::PRODUCT, CJNIBuild::DEVICE, CJNIBuild::BOARD, CJNIBuild::MANUFACTURER,
       CJNIBuild::BRAND, CJNIBuild::MODEL, CJNIBuild::HARDWARE);
+
   std::string extstorage;
   bool extready = CXBMCApp::GetExternalStorage(extstorage);
-  CLog::Log(LOGINFO, "External storage path = {}; status = {}", extstorage,
-            extready ? "ok" : "nok");
+  CLog::Log(
+      LOGINFO, "External storage path = {}; status = {}; Permissions = {}{}", extstorage,
+      extready ? "ok" : "nok",
+      CJNIContext::checkCallingOrSelfPermission("android.permission.MANAGE_EXTERNAL_STORAGE") ==
+              CJNIPackageManager::PERMISSION_GRANTED
+          ? "MANAGE_EXTERNAL_STORAGE "
+          : "",
+      CJNIContext::checkCallingOrSelfPermission("android.permission.WRITE_EXTERNAL_STORAGE") ==
+              CJNIPackageManager::PERMISSION_GRANTED
+          ? "WRITE_EXTERNAL_STORAGE"
+          : "");
 }


### PR DESCRIPTION
## Description
Useful to identify which storage permissions the user has granted

Sample:
```
info <general>: External storage path = /storage/emulated/0; status = ok; Permissions = WRITE_EXTERNAL_STORAGE
```

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
