### PR TITLE
Do not compile samba-gplv3 with lttng if found

### DIFF
--- a/tools/depends/target/samba-gplv3/Makefile
+++ b/tools/depends/target/samba-gplv3/Makefile
@@ -30,7 +30,8 @@ CONFIGURE=./configure --prefix=$(PREFIX) \
           --disable-symbol-versions \
           --without-json \
           --without-libarchive \
-          --without-regedit
+          --without-regedit \
+          --without-lttng
 
 LIBDYLIB=$(PLATFORM)/bin/default/source3/libsmb/libsmbclient.a
 


### PR DESCRIPTION
## Description
Removes linking samba-gplv3 with lttng

## Motivation and context
When you use the tools/depends system to build the necessary dependencies, your buildroot system may have liblttng installed. Samba-gplv3 module detects this and adds this is a library to link to.

In the end this means kodi requires libttng on the target device, which is not required.

It adds unnecessary third party libraries that need to be installed on the device.

This fixes that issue.

## How has this been tested?
This module has been compiled and works normally.

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] All new and existing tests passed
