### PR TITLE
Update gettext to v0.21.1

### DIFF
--- a/tools/depends/target/gettext/Makefile
+++ b/tools/depends/target/gettext/Makefile
@@ -3,10 +3,10 @@ DEPS = ../../Makefile.include Makefile ../../download-files.include
 
 # lib name, version
 LIBNAME=gettext
-VERSION=0.21
+VERSION=0.21.1
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.xz
-SHA512=f7e2968651879f8444d43a176a149db9f9411f4a03132a7f3b37c2ed97e3978ae6888169c995c1953cb78943b6e3573811abcbb8661b6631edbbe067b2699ddf
+SHA512=61e93bc9876effd3ca1c4e64ff6ba5bd84b24951ec2cc6f40a0e3248410e60f887552f29ca1f70541fb5524f6a4e8191fed288713c3e280e18922dd5bff1a2c9
 include ../../download-files.include
 
 # configuration settings


### PR DESCRIPTION
## Description
Updates gettext to v0.21.1

## Motivation and context
gettext is an older version.
https://ftp.gnu.org/pub/gnu/gettext/gettext-0.21.tar.xz will need uploading to kodi mirrors.

## How has this been tested?
Compiles gettext as normal

## What is the effect on users?
None

## Types of change
- [x] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
