### PR TITLE
Update libiconv to 1.17

### DIFF
--- a/tools/depends/target/libiconv/Makefile
+++ b/tools/depends/target/libiconv/Makefile
@@ -3,10 +3,10 @@ DEPS = ../../Makefile.include Makefile ../../download-files.include
 
 # lib name, version
 LIBNAME=libiconv
-VERSION=1.15
+VERSION=1.17
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
-SHA512=1233fe3ca09341b53354fd4bfe342a7589181145a1232c9919583a8c9979636855839049f3406f253a9d9829908816bb71fd6d34dd544ba290d6f04251376b1a
+SHA512=18a09de2d026da4f2d8b858517b0f26d853b21179cf4fa9a41070b2d140030ad9525637dc4f34fc7f27abca8acdc84c6751dfb1d426e78bf92af4040603ced86
 include ../../download-files.include
 
 # configuration settings


### PR DESCRIPTION
## Description
Update libiconv from 1.15 to 1.17

## Motivation and context
libiconv is quite an old version in tools/depends. This just updates to the latest version. Testeded to compile kodi on my target system.

## How has this been tested?
https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.17.tar.gz will need uploading to kodi mirrors

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
- [x] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
