### PR TITLE
Add "estimated playback time of current cached bytes" at Debug Info OSD

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4906,7 +4906,9 @@ void CVideoPlayer::UpdatePlayState(double timeout)
   else
     state.caching = false;
 
+  double queueTime = GetQueueTime();
   CacheInfo cache = GetCachingTimes();
+
   if (cache.valid)
   {
     state.cache_delay = std::max(0.0, cache.delay);
@@ -4916,8 +4918,8 @@ void CVideoPlayer::UpdatePlayState(double timeout)
   else
   {
     state.cache_delay = 0.0;
-    state.cache_level = std::min(1.0, GetQueueTime() / 8000.0);
-    state.cache_offset = GetQueueTime() / state.timeMax;
+    state.cache_level = std::min(1.0, queueTime / 8000.0);
+    state.cache_offset = queueTime / state.timeMax;
   }
 
   XFILE::SCacheStatus status;
@@ -4925,7 +4927,7 @@ void CVideoPlayer::UpdatePlayState(double timeout)
   {
     state.cache_bytes = status.forward;
     if(state.timeMax)
-      state.cache_bytes += m_pInputStream->GetLength() * (int64_t) (GetQueueTime() / state.timeMax);
+      state.cache_bytes += m_pInputStream->GetLength() * (int64_t)(queueTime / state.timeMax);
   }
   else
     state.cache_bytes = 0;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -88,6 +88,7 @@ struct SPlayerState
   double cache_level;   // current estimated required cache level
   double cache_delay;   // time until cache is expected to reach estimated level
   double cache_offset;  // percentage of file ahead of current position
+  double cache_time; // estimated playback time of current cached bytes
 };
 
 class CDVDInputStream;
@@ -239,9 +240,10 @@ protected:
 
 struct CacheInfo
 {
-  double level;
-  double delay;
-  double offset;
+  double level; // current estimated required cache level
+  double delay; // time until cache is expected to reach estimated level
+  double offset; // percentage of file ahead of current position
+  double time; // estimated playback time of current cached bytes
   bool valid;
 };
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -237,6 +237,14 @@ protected:
 // main class
 //------------------------------------------------------------------------------
 
+struct CacheInfo
+{
+  double level;
+  double delay;
+  double offset;
+  bool valid;
+};
+
 class CProcessInfo;
 class CJobQueue;
 
@@ -421,7 +429,7 @@ protected:
   void SetCaching(ECacheState state);
 
   double GetQueueTime();
-  bool GetCachingTimes(double& play_left, double& cache_left, double& file_offset);
+  CacheInfo GetCachingTimes();
 
   void FlushBuffers(double pts, bool accurate, bool sync);
 


### PR DESCRIPTION
## Description
Add "estimated playback time of current cached bytes" at Debug Info OSD

## Motivation and context
Currently is displayed "cache level" which is confusing because of the way it is calculated: the average bitrate of the video is used, considering only the duration and weight of the file. This really only works for CBR videos, causing cache level of 0% - 4% when the current bitrate is much lower than average.

In addition, the 100% cache level is not the same for a 80 Mbps video as for a 0.8 Mbps video, that is, the cached playback time is not the same. As a consequence of all this, it is much more appropriate display the cached playback time or "estimated playback time of current cached bytes".

Note that this time is the sum of VideoPlayer queue time + FileCache cached bytes.

Changes separated in 3 commits: the first two are only refactoring to allow the third one more easily.

NOTE: This really just changes the way the information is displayed. It has no effect on the performance of VideoPlayer but it may help to uncover some underlying problems with the queuing system and file cache.


## How has this been tested?
Runtime Windows x64 and Shield

## What is the effect on users?
Clearer cache information in Debug Info OSD.


## Screenshots (if appropriate):
**Before**
![before](https://user-images.githubusercontent.com/58434170/221650562-44922d88-052b-4b63-b9c8-4a99bb931ca7.png)

**After**
![after](https://user-images.githubusercontent.com/58434170/221650627-5d7c45e4-5276-4747-a835-d780c490701c.png)

**Different use cases:**
![after-low](https://user-images.githubusercontent.com/58434170/221650667-1d4f52df-3945-4a70-b69a-eb2b28cc64e9.png)
Low bitrate video => time cached is much higher with same cached bytes

![after-high](https://user-images.githubusercontent.com/58434170/221656301-c26dc900-817d-40e3-ae6e-089340bfef00.png)
High bitrate video => time cached is low and very similar to queue time (8.0s)

![after-no-cache](https://user-images.githubusercontent.com/58434170/221650949-1b34ebee-9235-4a99-8c6d-65f0b2402994.png)
With buffer mode 3 (no cache) cached time is 8.0s = VideoPlayer queue time (almost regardless of bitrate)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
