### PR TITLE
[guillib] Handle Page Up/Down/Home/End in settings / CGUIControlGroupList

### DIFF
--- a/xbmc/guilib/GUIControlGroup.cpp
+++ b/xbmc/guilib/GUIControlGroup.cpp
@@ -127,7 +127,6 @@ void CGUIControlGroup::RenderEx()
 
 bool CGUIControlGroup::OnAction(const CAction &action)
 {
-  assert(false);  // unimplemented
   return false;
 }
 

--- a/xbmc/guilib/GUIControlGroupList.h
+++ b/xbmc/guilib/GUIControlGroupList.h
@@ -15,6 +15,12 @@
 
 #include "GUIControlGroup.h"
 
+struct SGUIControlAndOffset
+{
+  CGUIControl* control{nullptr};
+  float offset{0.f};
+};
+
 /*!
  \ingroup controls
  \brief list of controls that is scrollable
@@ -33,6 +39,7 @@ public:
 
   void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
   void Render() override;
+  bool OnAction(const CAction& action) override;
   bool OnMessage(CGUIMessage& message) override;
 
   EVENT_RESULT SendMouseEvent(const CPoint &point, const CMouseEvent &event) override;
@@ -64,6 +71,28 @@ protected:
 
   int GetNumItems() const;
   int GetSelectedItem() const;
+  /*!
+   * \brief Returns the position of the specified child control
+   * \param control The control to be located.
+   * \return Position of the control.
+   *         -1 for a control that is not visible or cannot be found.
+   */
+  float GetControlOffset(const CGUIControl* control) const;
+  /*!
+   * \brief Locate a visible and focusable child control at/close to the specified position
+   * \param target Ideal position of the control
+   * \param direction >0: Favor the control at or after the target for direction, otherwise
+   *        the control before or at target.
+   * \return Best match control & position.
+   *         The control may be null and the offset 0 if there aren't any visible focusable controls in the list.
+   */
+  SGUIControlAndOffset GetFocusableControlAt(float target, int direction) const;
+  /*!
+   * \brief Scroll the list of controls, update the selected control and the pager.
+   * \param pages direction and amount of scrolling.
+   *        For example 1 to scroll down/right one page, -0.5 to scroll up/left half a page
+   */
+  void ScrollPages(float pages);
 
   float m_itemGap;
   int m_pageControl;

--- a/xbmc/guilib/GUIControlGroupList.h
+++ b/xbmc/guilib/GUIControlGroupList.h
@@ -58,11 +58,12 @@ public:
 
   // based on grouplist orientation pick one value as minSize;
   void SetMinSize(float minWidth, float minHeight);
+  // shut up warning about hiding an overloaded virtual function
+  using CGUIControlGroup::GetFirstFocusableControl;
+
 protected:
   EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event) override;
   bool IsControlOnScreen(float pos, const CGUIControl* control) const;
-  bool IsFirstFocusableControl(const CGUIControl *control) const;
-  bool IsLastFocusableControl(const CGUIControl *control) const;
   void ValidateOffset();
   void CalculateItemGap();
   inline float Size(const CGUIControl *control) const;
@@ -93,6 +94,20 @@ protected:
    *        For example 1 to scroll down/right one page, -0.5 to scroll up/left half a page
    */
   void ScrollPages(float pages);
+  /*!
+   * \brief Change the selected control and scroll to the specified position.
+   * \param control New selected control
+   * \param offset Offset of the top of the visible view
+   */
+  void MoveTo(CGUIControl* control, float offset);
+  /*!
+   * Return the first visible and focusable child control.
+   */
+  CGUIControl* GetFirstFocusableControl() const;
+  /*!
+   * Return the last visible and focusable child control.
+   */
+  CGUIControl* GetLastFocusableControl() const;
 
   float m_itemGap;
   int m_pageControl;

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -420,8 +420,12 @@ bool CGUIWindow::OnAction(const CAction &action)
   CGUIControl *focusedControl = GetFocusedControl();
   if (focusedControl)
   {
-    if (focusedControl->OnAction(action))
-      return true;
+    while (focusedControl && focusedControl != this)
+    {
+      if (focusedControl->OnAction(action))
+        return true;
+      focusedControl = focusedControl->GetParentControl();
+    }
   }
   else
   {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

CGUIControlGroupList is the core of many settings screens and doesn't handle page up/down/home/end.

There are two main aspects of this change:

### 1/ Get the page up/down/home/end actions to GUIControlGroupList (first commit)

Currently the parent GUIWindow dispatches the actions only to the focused control. The focused control is a child of GUIControlGroupList, for example a radio button setting,
 
There were two possibilities to fix this:

a. used here, simple: if the focused control did not handle the action, send it to its parents until it's handled or there are no more parents. There may be side-effects but I haven't seen them.
Potential side-effects could be reduced by filtering the actions passed to parents to page up/down/home/end and/or check focused status of the parent

b. more complex: alter ControlGroupList so it presents itself to the GGUIWindow as the focused control and acts as a proxy for its child controls. It will receive the actions, handle them or dispatch them to the real selected control.
There may be unexpected side-effects in messaging, caching of m_focusedControl, maybe other places.


### 2/ Handle the actions in GUIControlGroupList (second commit)

The containers that already handle scrolling assume items of fixed size, visible and enabled.
Those assumptions are broken for the GUIControlGroupList and a different algorithm was needed, with a visually equivalent result.

Home: move the view to the top and select the first visible focusable child.
End:  move the view to the bottom and select the last visible focusable child.
Page Up / Down: Move the view and change the currently selected control by a page up or down. Maintain the relative position of the selection in the view as much as possible.

In theory the problem could be recursive (CGUIControlGroupList with children of type CGUIControlGroup/List or GUIBaseContainer derived (CGUIFixedListContainer, CGUIWrappingListContainer, CGUIPanelContainer, CGUIListContainer))
I didn't see examples and it looks like rendering would break so I didn't try to handle.

Please note that the GUISpinControl absorbs the page up/down and gets in the way, of scrolling even though there isn't always a visible change in the spinner in response. Behavior unchanged by this PR, some adjustments wouldn't hurt in a future PR.

- The third commit is an optimization for ACTION_LAST_PAGE to find the last control more efficiently. Commit kept separate to avoid confusing things for the review as it touches a bit of existing code. IsVisible is redundant because already tested by CanFocus.


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Page Up / Down / Home / End keys don't work in the CGUIControlGroupList controls, used very frequently in the settings screens, and other places too.

A few examples:

![image](https://user-images.githubusercontent.com/489377/222643220-4a66f1d3-e227-42ab-9276-786e3b49ba2a.png)


![image](https://user-images.githubusercontent.com/489377/222054395-b5fce936-292e-453e-88c9-1122b3ef66a2.png)

more surprising:
![image](https://user-images.githubusercontent.com/489377/222054517-88d5cf71-ddfe-4791-adbe-122087b0e69c.png)

![image](https://user-images.githubusercontent.com/489377/222643884-04fcea72-6d49-4421-b97f-763a5d6b6c72.png)


## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 10 computer though the change is platform independent.
Tested on all standard settings screens of Kodi, many many many attempts and combinations.
Perfect results for home/end, good enough in my opinion for page up/down.
The control selected after page up/down is not always perfect (off by +1 or -1) because of a few factors:
- the child controls have varying sizes
- non-focusable controls force the selection to jump further (group names, separators, disabled settings)
- usually less than 2 pages in the settings so the selection or view often cannot move as far as they normally would.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Page Up / Down / Home / End keys behave in a standard way in the settings and other screens using CGUIControlGroupList.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
