### PR TITLE
[Skin][Estuary] Fix player settings adjustments if autoclose video osd is active

### DIFF
--- a/addons/skin.estuary/xml/Custom_1101_SettingsList.xml
+++ b/addons/skin.estuary/xml/Custom_1101_SettingsList.xml
@@ -2,6 +2,8 @@
 <window type="dialog" id="1101">
 	<defaultcontrol always="true">11000</defaultcontrol>
 	<include>Animation_DialogPopupOpenClose</include>
+	<onunload>ClearProperty(settingslist_header,Home)</onunload>
+	<onunload>ClearProperty(settingslist_content,Home)</onunload>
 	<controls>
 		<control type="group">
 			<centerleft>50%</centerleft>

--- a/addons/skin.estuary/xml/Timers.xml
+++ b/addons/skin.estuary/xml/Timers.xml
@@ -3,8 +3,8 @@
     <timer>
         <name>autoclosevideoosd</name>
         <description>Timer to auto close the video OSD (if enabled in the skin settings)</description>
-        <start reset="true">Window.IsActive(videoosd) + Skin.HasSetting(OSDAutoClose)</start>
-        <reset>Window.IsActive(videoosd) + !System.IdleTime(1) + Integer.IsGreaterOrEqual(Skin.TimerElapsedSecs(autoclosevideoosd), 1)</reset>
+        <start reset="true">Window.IsActive(videoosd) + Skin.HasSetting(OSDAutoClose) + !String.IsEqual(window(home).Property(settingslist_content),osd) + !Window.IsActive(osdsubtitlesettings) + !Window.IsActive(osdaudiosettings) + !Window.IsActive(osdvideosettings) + !Window.IsActive(OSDCMSSettings)</start>
+        <reset>Window.IsActive(videoosd) + !System.IdleTime(1) + Integer.IsGreaterOrEqual(Skin.TimerElapsedSecs(autoclosevideoosd), 1) | String.IsEqual(window(home).Property(settingslist_content),osd) | Window.IsActive(osdsubtitlesettings) | Window.IsActive(osdaudiosettings) | Window.IsActive(osdvideosettings) | Window.IsActive(OSDCMSSettings)</reset>
         <stop>!Window.IsActive(videoosd) | String.IsEmpty(Skin.String(OSDAutoCloseTime)) + Integer.IsGreaterOrEqual(Skin.TimerElapsedSecs(autoclosevideoosd), 4) | !String.IsEmpty(Skin.String(OSDAutoCloseTime)) + Integer.IsGreaterOrEqual(Skin.TimerElapsedSecs(autoclosevideoosd),Skin.Numeric(OSDAutoCloseTime))</stop>
         <onstop>Dialog.Close(videoosd)</onstop>
     </timer>


### PR DESCRIPTION
## Description
If the autoclose video osd estuary setting is enabled, we close the video OSD after the time has elapsed. Video settings (subtitle, audio, video, cms, etc) are childrens (launched) from the video OSD which breaks callbacks if we set settings without the parent active.
This changes the timer definition to avoid closing the dialog if we are changing player settings.

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/22891

## How has this been tested?
Waiting for 4 seconds (period I have set to close the videoosd) while changing player settings. Verifying the osd is not closed unless we close the settings dialog. There's room for improvement, for instance, when confirming a subtitle delay we could well just close the subtitle setting dialog automatically leaving only the osd active (which will autoclose) or simply closing the osd automatically. There's also no need for control visibility if some of the settings dialogs are visible.

## What is the effect on users?
Settings should now work if the autoclose video osd timer is set.


