### PR TITLE
NFSv3 and NFSv4 fixes and improvements

### DIFF
--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -432,11 +432,20 @@ void CNfsConnection::keepAlive(const std::string& _exportPath, struct nfsfh* _pF
   if (!pContext)// this should normally never happen - paranoia
     pContext = m_pNfsContext;
 
-  CLog::Log(LOGINFO, "NFS: sending keep alive after {} s.",
-            std::chrono::duration_cast<std::chrono::seconds>(KEEP_ALIVE_TIMEOUT).count());
+  CLog::LogF(LOGDEBUG, "sending keep alive after {}s.",
+             std::chrono::duration_cast<std::chrono::seconds>(KEEP_ALIVE_TIMEOUT).count());
+
   std::unique_lock<CCriticalSection> lock(*this);
+
   nfs_lseek(pContext, _pFileHandle, 0, SEEK_CUR, &offset);
-  nfs_read(pContext, _pFileHandle, 32, buffer);
+
+  int bytes = nfs_read(pContext, _pFileHandle, 32, buffer);
+  if (bytes < 0)
+  {
+    CLog::LogF(LOGERROR, "nfs_read - Error ({}, {})", bytes, nfs_get_error(pContext));
+    return;
+  }
+
   nfs_lseek(pContext, _pFileHandle, offset, SEEK_SET, &offset);
 }
 

--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -329,9 +329,21 @@ bool CNfsConnection::Connect(const CURL& url, std::string &relativePath)
     }
     m_exportPath = exportPath;
     m_hostName = url.GetHostName();
-    //read chunksize only works after mount
+
+    // read chunksize only works after mount
     m_readChunkSize = nfs_get_readmax(m_pNfsContext);
     m_writeChunkSize = nfs_get_writemax(m_pNfsContext);
+
+    if (m_readChunkSize == 0)
+    {
+      CLog::Log(LOGDEBUG, "NFS Server did not return max read chunksize - Using 128K default");
+      m_readChunkSize = 128 * 1024; // 128K
+    }
+    if (m_writeChunkSize == 0)
+    {
+      CLog::Log(LOGDEBUG, "NFS Server did not return max write chunksize - Using 128K default");
+      m_writeChunkSize = 128 * 1024; // 128K
+    }
 
     if (contextRet == CNfsConnection::ContextStatus::NEW)
     {

--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -45,16 +45,16 @@ using namespace std::chrono_literals;
 
 namespace
 {
+// Default "lease_time" on most Linux NFSv4 servers are 90s.
+// See: https://linux-nfs.org/wiki/index.php/NFS_lock_recovery_notes
+// Keep alive interval should be always less than lease_time to avoid client session expires
 
-constexpr auto CONTEXT_TIMEOUT = 6min;
-
-constexpr auto KEEP_ALIVE_TIMEOUT = 3min;
-
-constexpr auto IDLE_TIMEOUT = 3min;
+constexpr auto CONTEXT_TIMEOUT = 60s; // 2/3 parts of lease_time
+constexpr auto KEEP_ALIVE_TIMEOUT = 45s; // half of lease_time
+constexpr auto IDLE_TIMEOUT = 30s; // close fast unused contexts when no active connections
 
 constexpr auto SETTING_NFS_VERSION = "nfs.version";
-
-} // namespace
+} // unnamed namespace
 
 CNfsConnection::CNfsConnection()
   : m_pNfsContext(NULL),


### PR DESCRIPTION
## Description
NFSv3 and NFSv4 fixes and improvements:

- Fixes session expiration due insufficient keep alive interval (NFSv4 only).
- Fixes attempt to reuse cached but expired NFS contexts (NFSv4 only).
- Fixes crash when read Blu-Ray BDMV structures and some optional files not exist (NFSv3 & NFSv4).
- Use 128K read/write chunk size in NFSv4  (NFSv4 servers do not enforce or limit to any specific value).
- Fixes https://github.com/xbmc/xbmc/issues/22862
- Fixes https://github.com/xbmc/xbmc/pull/22714#issuecomment-1439719284

## Motivation and context
Due to the big differences between NFSv3 and NFSv4, certain changes are necessary, especially everything related to time outs and keep alive:

> NFSv3 is stateless. That effectively means that the NFS server (ONTAP) doesn't keep track of which filesystems are mounted, by whom, or which locks are truly in place. Tracking NFS client state is not part of the NFSv3 standard.
> 
> In contrast, NFSv4 is stateful. The NFSv4 server tracks which clients are using which filesystems, which files exist, which files and/or regions of files are locked, etc. This means there needs to be regular communication between an NFSv4 server to keep the state data current.

https://community.netapp.com/t5/Tech-ONTAP-Blogs/NFSv3-and-NFSv4-What-s-the-difference/ba-p/441316

> The client queries the server's "lease_time" attribute. (Default 90s on Linux.)
> Normal filesystem activity starts. The client ensures that it sends one rpc (may be some sort of no-op) at least every lease_time, to reassure the server that it's still active.

> NFSv3 also has the notion of grace periods and reclaim flags on lock requests. The main differences are:
> there's no lease time, and clients aren't required to poll the server regularly.

https://linux-nfs.org/wiki/index.php/NFS_lock_recovery_notes

## How has this been tested?
Runtime Windows x64 and Android (Shield). 
As NFSv4 server used Synology NAS (DSM 7.1.1) Indeed, it has been proven that it has 90s "lease_time".
Tested NFSv3 and NFSv4, tested and reproduced all issues mentioned.

## What is the effect on users?
- Fixes random `NFS4ERR_EXPIRED` errors at open files any time.
- Fixes video playback stalls and closes after pause due insufficient keep alive of NFSv4 session.
- Fixes crash opening Blu-Ray folders (BDMV) if some optional files not present (very common).
- Fixes slow NFSv4 read when not using file cache due very small read chunk size.


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
