### PR TITLE
[Estuary] Fix background for WallWatchedIconVar

### DIFF
--- a/addons/skin.estuary/xml/View_53_Shift.xml
+++ b/addons/skin.estuary/xml/View_53_Shift.xml
@@ -123,15 +123,25 @@
 								<aligny>center</aligny>
 							</control>
 						</control>
-						<control type="image">
-							<left>35</left>
-							<top>518</top>
-							<width>32</width>
-							<height>32</height>
-							<align>left</align>
-							<aligny>center</aligny>
-							<texture>$VAR[WallWatchedIconVar]</texture>
-						</control>
+						<control type="group">
+							<visible>Listitem.IsCollection | ListItem.IsPlaying | Integer.IsGreater(ListItem.Playcount,0) | !Integer.IsEqual(ListItem.PercentPlayed,0)</visible>
+							<control type="image">
+								<left>30</left>
+								<top>470</top>
+								<width>80</width>
+								<height>80</height>
+								<texture>overlays/overlay-bg.png</texture>
+							</control>
+							<control type="image">
+								<left>35</left>
+								<top>518</top>
+								<width>32</width>
+								<height>32</height>
+								<align>left</align>
+								<aligny>center</aligny>
+								<texture>$VAR[WallWatchedIconVar]</texture>
+							</control>
+						</control>						
 						<control type="group">
 							<left>158</left>
 							<top>92</top>
@@ -211,14 +221,24 @@
 								<aligny>center</aligny>
 							</control>
 						</control>
-						<control type="image">
-							<left>35</left>
-							<top>518</top>
-							<width>32</width>
-							<height>32</height>
-							<align>left</align>
-							<aligny>center</aligny>
-							<texture>$VAR[WallWatchedIconVar]</texture>
+						<control type="group">
+							<visible>Listitem.IsCollection | ListItem.IsPlaying | Integer.IsGreater(ListItem.Playcount,0) | !Integer.IsEqual(ListItem.PercentPlayed,0)</visible>
+							<control type="image">
+								<left>30</left>
+								<top>470</top>
+								<width>80</width>
+								<height>80</height>
+								<texture>overlays/overlay-bg.png</texture>
+							</control>
+							<control type="image">
+								<left>35</left>
+								<top>518</top>
+								<width>32</width>
+								<height>32</height>
+								<align>left</align>
+								<aligny>center</aligny>
+								<texture>$VAR[WallWatchedIconVar]</texture>
+							</control>
 						</control>
 						<control type="group">
 							<left>158</left>

--- a/addons/skin.estuary/xml/View_54_InfoWall.xml
+++ b/addons/skin.estuary/xml/View_54_InfoWall.xml
@@ -304,7 +304,7 @@
 					<width>80</width>
 					<height>80</height>
 					<texture>overlays/overlay-bg.png</texture>
-					<visible>Listitem.IsCollection | ListItem.IsPlaying | Integer.IsGreater(ListItem.Playcount,0)</visible>
+					<visible>Listitem.IsCollection | ListItem.IsPlaying | Integer.IsGreater(ListItem.Playcount,0) | !Integer.IsEqual(ListItem.PercentPlayed,0)</visible>
 				</control>
 			</control>
 			<control type="group">


### PR DESCRIPTION
## Description
Infowall view is missing the icon background for inprogress.
Shift view is missing the icon background for inprogress & watched.

The missing background meant the white inprogress/watched icons could not be clearly seen when there's poster with white within the icon area.

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/22765

## How has this been tested?
Tested locally with a mix of watched, unwatched, & inprogress items.

## Screenshots (if appropriate):

**InfoWall Inprogress Before**

![infowall_inprogress_before](https://user-images.githubusercontent.com/5781142/222897762-ec1e4342-6cd8-4e31-9e9f-6f167af8edde.jpg)

**InfoWall Inprogress After**

![infowall_inprogress_after](https://user-images.githubusercontent.com/5781142/222897785-c8cca041-bec7-4040-af7e-08d184017133.jpg)

**Shift Inprogress Before**

![shift_inprogress_before](https://user-images.githubusercontent.com/5781142/222897801-51e8fe3f-abae-4274-9a53-c0d3f76f86a9.jpg)


**Shift Inprogress After**

![shift_inprogress_after](https://user-images.githubusercontent.com/5781142/222897819-702f8b45-ce73-4345-a3d3-991fec573a0a.jpg)

**Shift Watched Before**
![shift_watched_before](https://user-images.githubusercontent.com/5781142/222897848-b887f024-7b50-4694-8a69-7368e1026c59.jpg)

**Shift Watched After**

![shift_watched_after](https://user-images.githubusercontent.com/5781142/222897877-b6d9aedd-3451-43ff-aa7c-31ea9899239f.jpg)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
