### PR TITLE
[video] Fix watched status not taken into account when queueing items.

### DIFF
--- a/xbmc/filesystem/VideoDatabaseDirectory.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory.cpp
@@ -29,6 +29,60 @@ CVideoDatabaseDirectory::CVideoDatabaseDirectory(void) = default;
 
 CVideoDatabaseDirectory::~CVideoDatabaseDirectory(void) = default;
 
+namespace
+{
+std::string GetChildContentType(const std::unique_ptr<CDirectoryNode>& node)
+{
+  switch (node->GetChildType())
+  {
+    case NODE_TYPE_EPISODES:
+    case NODE_TYPE_RECENTLY_ADDED_EPISODES:
+      return "episodes";
+    case NODE_TYPE_SEASONS:
+      return "seasons";
+    case NODE_TYPE_TITLE_MOVIES:
+    case NODE_TYPE_RECENTLY_ADDED_MOVIES:
+      return "movies";
+    case NODE_TYPE_TITLE_TVSHOWS:
+    case NODE_TYPE_INPROGRESS_TVSHOWS:
+      return "tvshows";
+    case NODE_TYPE_TITLE_MUSICVIDEOS:
+    case NODE_TYPE_RECENTLY_ADDED_MUSICVIDEOS:
+      return "musicvideos";
+    case NODE_TYPE_GENRE:
+      return "genres";
+    case NODE_TYPE_COUNTRY:
+      return "countries";
+    case NODE_TYPE_ACTOR:
+    {
+      CQueryParams params;
+      node->CollectQueryParams(params);
+      if (static_cast<VideoDbContentType>(params.GetContentType()) ==
+          VideoDbContentType::MUSICVIDEOS)
+        return "artists";
+
+      return "actors";
+    }
+    case NODE_TYPE_DIRECTOR:
+      return "directors";
+    case NODE_TYPE_STUDIO:
+      return "studios";
+    case NODE_TYPE_YEAR:
+      return "years";
+    case NODE_TYPE_MUSICVIDEOS_ALBUM:
+      return "albums";
+    case NODE_TYPE_SETS:
+      return "sets";
+    case NODE_TYPE_TAGS:
+      return "tags";
+    default:
+      break;
+  }
+  return {};
+}
+
+} // unnamed namespace
+
 bool CVideoDatabaseDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 {
   std::string path = CLegacyPathTranslation::TranslateVideoDbPath(url);
@@ -58,6 +112,8 @@ bool CVideoDatabaseDirectory::GetDirectory(const CURL& url, CFileItemList &items
     items.SetLabel(items.GetProperty("customtitle").asString());
   else
     items.SetLabel(pNode->GetLocalizedName());
+
+  items.SetContent(GetChildContentType(pNode));
 
   return bResult;
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.h
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNode.h
@@ -66,6 +66,7 @@ namespace XFILE
       bool GetChilds(CFileItemList& items);
       virtual NODE_TYPE GetChildType() const;
       virtual std::string GetLocalizedName() const;
+      void CollectQueryParams(CQueryParams& params) const;
 
       CDirectoryNode* GetParent() const;
 
@@ -76,8 +77,7 @@ namespace XFILE
       CDirectoryNode(NODE_TYPE Type, const std::string& strName, CDirectoryNode* pParent);
       static CDirectoryNode* CreateNode(NODE_TYPE Type, const std::string& strName, CDirectoryNode* pParent);
 
-      void AddOptions(const std::string &options);
-      void CollectQueryParams(CQueryParams& params) const;
+      void AddOptions(const std::string& options);
 
       const std::string& GetName() const;
       int GetID() const;

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -442,8 +442,6 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
         // the container folder thumb is the parent (i.e. season or show)
         if (itemsSize && (node == NODE_TYPE_EPISODES || node == NODE_TYPE_RECENTLY_ADDED_EPISODES))
         {
-          items.SetContent("episodes");
-
           int seasonID = -1;
           int seasonParam = params.GetSeason();
 
@@ -467,8 +465,6 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
               items.SetArtFallback("thumb", "season.banner");
           }
         }
-        else
-          items.SetContent("seasons");
       }
       else if (node == NODE_TYPE_TITLE_MOVIES ||
                node == NODE_TYPE_RECENTLY_ADDED_MOVIES)
@@ -484,40 +480,7 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
               items.SetArtFallback("thumb", "set.poster");
           }
         }
-        items.SetContent("movies");
       }
-      else if (node == NODE_TYPE_TITLE_TVSHOWS ||
-               node == NODE_TYPE_INPROGRESS_TVSHOWS)
-        items.SetContent("tvshows");
-      else if (node == NODE_TYPE_TITLE_MUSICVIDEOS ||
-               node == NODE_TYPE_RECENTLY_ADDED_MUSICVIDEOS)
-        items.SetContent("musicvideos");
-      else if (node == NODE_TYPE_GENRE)
-        items.SetContent("genres");
-      else if (node == NODE_TYPE_COUNTRY)
-        items.SetContent("countries");
-      else if (node == NODE_TYPE_ACTOR)
-      {
-        if (static_cast<VideoDbContentType>(params.GetContentType()) ==
-            VideoDbContentType::MUSICVIDEOS)
-          items.SetContent("artists");
-        else
-          items.SetContent("actors");
-      }
-      else if (node == NODE_TYPE_DIRECTOR)
-        items.SetContent("directors");
-      else if (node == NODE_TYPE_STUDIO)
-        items.SetContent("studios");
-      else if (node == NODE_TYPE_YEAR)
-        items.SetContent("years");
-      else if (node == NODE_TYPE_MUSICVIDEOS_ALBUM)
-        items.SetContent("albums");
-      else if (node == NODE_TYPE_SETS)
-        items.SetContent("sets");
-      else if (node == NODE_TYPE_TAGS)
-        items.SetContent("tags");
-      else
-        items.SetContent("");
     }
     else if (URIUtils::PathEquals(items.GetPath(), "special://videoplaylists/"))
       items.SetContent("playlists");


### PR DESCRIPTION
Fixes a regression introduced with v20.0 which was reported at the forum: https://forum.kodi.tv/showthread.php?tid=372279

Item list content type needs to be determined before queuing the items, because the type is needed to determine proper watched state here: https://github.com/xbmc/xbmc/blob/master/xbmc/video/VideoUtils.cpp#L225. Formerly it was okay to do this later, when video window content was loaded, because video playlist content compilation was done solely from inside the window class.

Runtime-tested on Android and macOS, latest master and Nexus.

@enen92 might be able to do the code review? Should be straight forward  - I moved setting the content type string from `CGUIWindowVideoNav::GetDirectory` to `CVideoDatabaseDirectory::GetDirectory`, without changing the logic.

@fuzzard I'd like to backport this one.