### PR TITLE
AESinkAudioTrack: Revert sanity checking

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -811,12 +811,6 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t **data, unsigned int frames, 
   if (!IsInitialized())
     return INT_MAX;
 
-  if (m_delay > 1.0)
-  {
-    CLog::Log(LOGERROR, "Sink got stuck with large buffer {:f} - reopening", m_delay);
-    return INT_MAX;
-  }
-
   // for debugging only - can be removed if everything is really stable
   uint64_t startTime = CurrentHostCounter();
 


### PR DESCRIPTION
This technically reverts:
0917ef9d7a00b04eb69961dbde6e93c2b15248f4
and also the 1 second adjustment inside
1e3715ce15259fe630a3774044b833f64579d8e3

When I check forum posts I see that on this platform several devices really work awefully bad. They open large buffers and start running very late ... we will hit more and more of those devices, therefore I want to revert this for our stable release and continue testing and finding such devices in master.
