### PR TITLE
COverlay: add static create methods

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -22,18 +22,8 @@
 #include "settings/SettingsComponent.h"
 #include "windowing/GraphicContext.h"
 
-#include <mutex>
-#if defined(HAS_GL)
-#include "OverlayRendererGL.h"
-#endif
-#if defined(HAS_GLES)
-#include "OverlayRendererGLES.h"
-#endif
-#if defined(HAS_DX)
-#include "OverlayRendererDX.h"
-#endif
-
 #include <algorithm>
+#include <mutex>
 #include <utility>
 
 using namespace KODI;
@@ -537,16 +527,7 @@ std::shared_ptr<COverlay> CRenderer::ConvertLibass(
     }
   }
 
-  std::shared_ptr<COverlay> overlay = NULL;
-#if defined(HAS_GL)
-  overlay = std::make_shared<COverlayGlyphGL>(images, rOpts.frameWidth, rOpts.frameHeight);
-#endif
-#if defined(HAS_GLES)
-  overlay = std::make_shared<COverlayGlyphGLES>(images, rOpts.frameWidth, rOpts.frameHeight);
-#endif
-#if defined(HAS_DX)
-  overlay = std::make_shared<COverlayQuadsDX>(images, rOpts.frameWidth, rOpts.frameHeight);
-#endif
+  std::shared_ptr<COverlay> overlay = COverlay::Create(images, rOpts.frameWidth, rOpts.frameHeight);
 
   m_textureCache[m_textureid] = overlay;
   o.m_textureid = m_textureid;
@@ -589,24 +570,10 @@ std::shared_ptr<COverlay> CRenderer::Convert(CDVDOverlay& o, double pts)
     return r;
   }
 
-#if defined(HAS_GL)
   if (o.IsOverlayType(DVDOVERLAY_TYPE_IMAGE))
-    r = std::make_shared<COverlayTextureGL>(static_cast<CDVDOverlayImage&>(o), m_rs);
+    r = COverlay::Create(static_cast<CDVDOverlayImage&>(o), m_rs);
   else if (o.IsOverlayType(DVDOVERLAY_TYPE_SPU))
-    r = std::make_shared<COverlayTextureGL>(static_cast<CDVDOverlaySpu&>(o));
-#endif
-#if defined(HAS_GLES)
-  if (o.IsOverlayType(DVDOVERLAY_TYPE_IMAGE))
-    r = std::make_shared<COverlayTextureGLES>(static_cast<CDVDOverlayImage&>(o), m_rs);
-  else if (o.IsOverlayType(DVDOVERLAY_TYPE_SPU))
-    r = std::make_shared<COverlayTextureGLES>(static_cast<CDVDOverlaySpu&>(o));
-#endif
-#if defined(HAS_DX)
-  if (o.IsOverlayType(DVDOVERLAY_TYPE_IMAGE))
-    r = std::make_shared<COverlayImageDX>(static_cast<CDVDOverlayImage&>(o), m_rs);
-  else if (o.IsOverlayType(DVDOVERLAY_TYPE_SPU))
-    r = std::make_shared<COverlayImageDX>(static_cast<CDVDOverlaySpu&>(o));
-#endif
+    r = COverlay::Create(static_cast<CDVDOverlaySpu&>(o));
 
   m_textureCache[m_textureid] = r;
   o.m_textureid = m_textureid;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
@@ -21,6 +21,8 @@
 #include <memory>
 #include <vector>
 
+typedef struct ass_image ASS_Image;
+
 class CDVDOverlay;
 class CDVDOverlayLibass;
 class CDVDOverlayImage;
@@ -41,6 +43,10 @@ namespace OVERLAY {
   class COverlay
   {
   public:
+    static std::shared_ptr<COverlay> Create(const CDVDOverlayImage& o, CRect& rSource);
+    static std::shared_ptr<COverlay> Create(const CDVDOverlaySpu& o);
+    static std::shared_ptr<COverlay> Create(ASS_Image* images, float width, float height);
+
     COverlay();
     virtual ~COverlay();
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
@@ -61,6 +61,11 @@ static bool LoadTexture(int width, int height, int stride
   return true;
 }
 
+std::shared_ptr<COverlay> COverlay::Create(ASS_Image* images, float width, float height)
+{
+  return std::make_shared<COverlayQuadsDX>(images, width, height);
+}
+
 COverlayQuadsDX::COverlayQuadsDX(ASS_Image* images, float width, float height)
 {
   m_width  = 1.0;
@@ -196,6 +201,11 @@ void COverlayQuadsDX::Render(SRenderState &state)
   pGUIShader->RestoreBuffers();
 }
 
+std::shared_ptr<COverlay> COverlay::Create(const CDVDOverlayImage& o, CRect& rSource)
+{
+  return std::make_shared<COverlayImageDX>(o, rSource);
+}
+
 COverlayImageDX::~COverlayImageDX()
 {
 }
@@ -255,6 +265,11 @@ COverlayImageDX::COverlayImageDX(const CDVDOverlayImage& o, CRect& rSource)
     m_width = static_cast<float>(o.width);
     m_height = static_cast<float>(o.height);
   }
+}
+
+std::shared_ptr<COverlay> COverlay::Create(const CDVDOverlaySpu& o)
+{
+  return std::make_shared<COverlayImageDX>(o);
 }
 
 COverlayImageDX::COverlayImageDX(const CDVDOverlaySpu& o)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.h
@@ -15,7 +15,6 @@ class CDVDOverlay;
 class CDVDOverlayImage;
 class CDVDOverlaySpu;
 class CDVDOverlaySSA;
-typedef struct ass_image ASS_Image;
 
 namespace OVERLAY {
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
@@ -78,6 +78,11 @@ static void LoadTexture(GLenum target
   *v = (GLfloat)height / height2;
 }
 
+std::shared_ptr<COverlay> COverlay::Create(const CDVDOverlayImage& o, CRect& rSource)
+{
+  return std::make_shared<COverlayTextureGL>(o, rSource);
+}
+
 COverlayTextureGL::COverlayTextureGL(const CDVDOverlayImage& o, CRect& rSource)
 {
   glGenTextures(1, &m_texture);
@@ -145,6 +150,11 @@ COverlayTextureGL::COverlayTextureGL(const CDVDOverlayImage& o, CRect& rSource)
   }
 }
 
+std::shared_ptr<COverlay> COverlay::Create(const CDVDOverlaySpu& o)
+{
+  return std::make_shared<COverlayTextureGL>(o);
+}
+
 COverlayTextureGL::COverlayTextureGL(const CDVDOverlaySpu& o)
 {
   int min_x, max_x, min_y, max_y;
@@ -172,6 +182,11 @@ COverlayTextureGL::COverlayTextureGL(const CDVDOverlaySpu& o)
   m_width = static_cast<float>(max_x - min_x);
   m_height = static_cast<float>(max_y - min_y);
   m_pma = !!USE_PREMULTIPLIED_ALPHA;
+}
+
+std::shared_ptr<COverlay> COverlay::Create(ASS_Image* images, float width, float height)
+{
+  return std::make_shared<COverlayGlyphGL>(images, width, height);
 }
 
 COverlayGlyphGL::COverlayGlyphGL(ASS_Image* images, float width, float height)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.h
@@ -17,7 +17,6 @@ class CDVDOverlay;
 class CDVDOverlayImage;
 class CDVDOverlaySpu;
 class CDVDOverlaySSA;
-typedef struct ass_image ASS_Image;
 
 namespace OVERLAY {
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
@@ -137,6 +137,11 @@ static void LoadTexture(GLenum target,
   *v = (GLfloat)height / height2;
 }
 
+std::shared_ptr<COverlay> COverlay::Create(const CDVDOverlayImage& o, CRect& rSource)
+{
+  return std::make_shared<COverlayTextureGLES>(o, rSource);
+}
+
 COverlayTextureGLES::COverlayTextureGLES(const CDVDOverlayImage& o, CRect& rSource)
 {
   glGenTextures(1, &m_texture);
@@ -204,6 +209,11 @@ COverlayTextureGLES::COverlayTextureGLES(const CDVDOverlayImage& o, CRect& rSour
   }
 }
 
+std::shared_ptr<COverlay> COverlay::Create(const CDVDOverlaySpu& o)
+{
+  return std::make_shared<COverlayTextureGLES>(o);
+}
+
 COverlayTextureGLES::COverlayTextureGLES(const CDVDOverlaySpu& o)
 {
   int min_x, max_x, min_y, max_y;
@@ -231,6 +241,11 @@ COverlayTextureGLES::COverlayTextureGLES(const CDVDOverlaySpu& o)
   m_width = static_cast<float>(max_x - min_x);
   m_height = static_cast<float>(max_y - min_y);
   m_pma = !!USE_PREMULTIPLIED_ALPHA;
+}
+
+std::shared_ptr<COverlay> COverlay::Create(ASS_Image* images, float width, float height)
+{
+  return std::make_shared<COverlayGlyphGLES>(images, width, height);
 }
 
 COverlayGlyphGLES::COverlayGlyphGLES(ASS_Image* images, float width, float height)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.h
@@ -17,7 +17,6 @@ class CDVDOverlay;
 class CDVDOverlayImage;
 class CDVDOverlaySpu;
 class CDVDOverlaySSA;
-typedef struct ass_image ASS_Image;
 
 namespace OVERLAY
 {


### PR DESCRIPTION
As a follow up to #22818 this PR adds static `Create` methods for `COverlay`.

This allows for better abstraction as we can remove the ifdeffing in the base class.

No functional changes included.