### PR TITLE
[Windows][Installer] fix the missing .html files of Chorus2 with proper exclusion of .h

### DIFF
--- a/tools/buildsteps/windows/BuildSetup.bat
+++ b/tools/buildsteps/windows/BuildSetup.bat
@@ -101,11 +101,11 @@ set WORKSPACE=%base_dir%\kodi-build.%TARGET_PLATFORM%
   Echo xbmc.old.log>>exclude.txt
   Echo kodi.log>>exclude.txt
   Echo kodi.old.log>>exclude.txt
-  Echo .so>>exclude.txt
-  Echo .h>>exclude.txt
-  Echo .cpp>>exclude.txt
-  Echo .exp>>exclude.txt
-  Echo .lib>>exclude.txt
+  Echo .so\>>exclude.txt
+  Echo .h\>>exclude.txt
+  Echo .cpp\>>exclude.txt
+  Echo .exp\>>exclude.txt
+  Echo .lib\>>exclude.txt
   rem Exclude userdata files
   Echo userdata\advancedsettings.xml>>exclude.txt
   Echo userdata\guisettings.xml>>exclude.txt
@@ -230,11 +230,11 @@ set WORKSPACE=%base_dir%\kodi-build.%TARGET_PLATFORM%
     goto DIE
   )
   copy %PDB% %APP_PDBFILE% > nul
-  POPD
   ECHO ------------------------------------------------------------
   ECHO Done!
   ECHO Setup is located at %CD%\%APP_SETUPFILE%
   ECHO ------------------------------------------------------------
+  POPD
   GOTO END
 
 :MAKE_APPX


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/22811


## What is the effect on users?
Working Chorus 2 web interface in Nexus after installation.



## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
