### PR TITLE
Update/libasound 1.2.8

### DIFF
--- a/tools/depends/target/alsa-lib/Makefile
+++ b/tools/depends/target/alsa-lib/Makefile
@@ -3,10 +3,10 @@ DEPS = ../../Makefile.include Makefile ../../download-files.include
 
 # lib name, version
 LIBNAME=libasound
-VERSION=1.1.4.1
+VERSION=1.2.8
 SOURCE=alsa-lib-$(VERSION)
 ARCHIVE=$(SOURCE).tar.bz2
-SHA512=7b548c4ee29c4a1230a0edcd5d19219831290f96a214180a6530628acc05278d1348376195287d188f4f44d6be1914391c63994f1b50985c3eee74352da26b0b
+SHA512=865ff05a8f589996f8d63d43a91c961f1b64144f3e1d17c7074b7ac16f25b3fd1c371d46ed63a8cc20fa01e63c76b75f1a9802b56889ae1073854dd050d27688
 include ../../download-files.include
 
 # configuration settings


### PR DESCRIPTION
## Description
This updates alsa-lib to 1.2.8 from 1.1.4.1

## Motivation and context
This is a simple library update. The current version in depends is 1.1.4.1 which was released 01-Jun-2017.

## How has this been tested?
Updated in tools/depends/target/alsa-lib. Compiled library, then linked kodi. This library is only used for compilation and linking. Not used on my target device.

https://www.alsa-project.org/files/pub/lib/alsa-lib-1.2.8.tar.bz2 will need uploading to kodi mirrors.

## What is the effect on users?
None

## Types of change
- [x] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
