### PR TITLE
[windowing] Add new display option "Limit framerate while sleeping"

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7587,9 +7587,21 @@ msgctxt "#13525"
 msgid "When enabled, use the original year of release rather than the album release year (if available)."
 msgstr ""
 
-#empty strings from id 13526 to 13549
+#empty strings from id 13526 to 13546
 
 #: system/settings/settings.xml
+msgctxt "#13547"
+msgid "Limit framerate while sleeping"
+msgstr ""
+
+msgctxt "#13548"
+msgid "Off"
+msgstr ""
+
+msgctxt "#13549"
+msgid "{0:d} FPS"
+msgstr ""
+
 msgctxt "#13550"
 msgid "Delay after change of refresh rate"
 msgstr ""
@@ -20915,7 +20927,11 @@ msgctxt "#36434"
 msgid "If enabled, switch to the channel with the programme to remind when auto-closing the reminder popup."
 msgstr ""
 
-#empty string with id 36435
+#. Description of setting with label #13547 "Limit framerate while sleeping"
+#: system/settings/settings.xml
+msgctxt "#36435"
+msgid "Limit framerate while the interface is not used to use less energy"
+msgstr ""
 
 #. Description for setting #407: "Hardware keyboard layouts"
 #. Setting in System -> Input -> Hardware keyboard layouts

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2584,6 +2584,14 @@
           </dependencies>
           <control type="toggle" />
         </setting>
+        <setting id="videoscreen.sleepframerate" type="integer" parent="videoscreen.screen" label="13547" help="36435">
+          <level>2</level>
+          <default>25</default>
+          <constraints>
+            <options>sleepframerates</options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
         <setting id="videoscreen.delayrefreshchange" type="integer" parent="videoscreen.screen" label="13550" help="36165">
           <level>2</level>
           <default>0</default>

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -17,7 +17,6 @@
 #include "utils/FileUtils.h"
 #include "utils/GLUtils.h"
 #include "utils/MathUtils.h"
-#include "utils/XTimeUtils.h"
 #include "utils/log.h"
 #include "windowing/WinSystem.h"
 
@@ -324,9 +323,6 @@ void CRenderSystemGL::PresentRender(bool rendered, bool videoLayer)
     return;
 
   PresentRenderImpl(rendered);
-
-  if (!rendered)
-    KODI::TIME::Sleep(40ms);
 }
 
 void CRenderSystemGL::SetVSync(bool enable)

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -16,8 +16,6 @@
 #include "utils/GLUtils.h"
 #include "utils/MathUtils.h"
 #include "utils/SystemInfo.h"
-#include "utils/TimeUtils.h"
-#include "utils/XTimeUtils.h"
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
 
@@ -228,10 +226,6 @@ void CRenderSystemGLES::PresentRender(bool rendered, bool videoLayer)
     return;
 
   PresentRenderImpl(rendered);
-
-  // if video is rendered to a separate layer, we should not block this thread
-  if (!rendered && !videoLayer)
-    KODI::TIME::Sleep(40ms);
 }
 
 void CRenderSystemGLES::SetVSync(bool enable)

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -720,6 +720,19 @@ void CDisplaySettings::SettingOptionsModesFiller(const std::shared_ptr<const CSe
   std::sort(list.begin(), list.end(), ModeSort);
 }
 
+void CDisplaySettings::SettingOptionsSleepFrameratesFiller(
+    const SettingConstPtr& setting,
+    std::vector<IntegerSettingOption>& list,
+    int& current,
+    void* data)
+{
+  list.emplace_back(g_localizeStrings.Get(13548), 0);
+  for (int i = 1; i < 10; i++)
+    list.emplace_back(StringUtils::Format(g_localizeStrings.Get(13549), i), i);
+  for (int j = 10; j <= 60; j+=5)
+    list.emplace_back(StringUtils::Format(g_localizeStrings.Get(13549), j), j);
+}
+
 void CDisplaySettings::SettingOptionsRefreshChangeDelaysFiller(
     const SettingConstPtr& setting,
     std::vector<IntegerSettingOption>& list,

--- a/xbmc/settings/DisplaySettings.h
+++ b/xbmc/settings/DisplaySettings.h
@@ -93,6 +93,11 @@ public:
                                         std::vector<StringSettingOption>& list,
                                         std::string& current,
                                         void* data);
+  static void SettingOptionsSleepFrameratesFiller(
+      const std::shared_ptr<const CSetting>& setting,
+      std::vector<IntegerSettingOption>& list,
+      int& current,
+      void* data);
   static void SettingOptionsRefreshChangeDelaysFiller(
       const std::shared_ptr<const CSetting>& setting,
       std::vector<IntegerSettingOption>& list,

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -794,6 +794,7 @@ void CSettings::InitializeOptionFillers()
   GetSettingsManager()->RegisterSettingOptionsFiller(
       "subtitlesfonts", SUBTITLES::CSubtitlesSettings::SettingOptionsSubtitleFontsFiller);
   GetSettingsManager()->RegisterSettingOptionsFiller("languagenames", CLangInfo::SettingOptionsLanguageNamesFiller);
+  GetSettingsManager()->RegisterSettingOptionsFiller("sleepframerates", CDisplaySettings::SettingOptionsSleepFrameratesFiller);
   GetSettingsManager()->RegisterSettingOptionsFiller("refreshchangedelays", CDisplaySettings::SettingOptionsRefreshChangeDelaysFiller);
   GetSettingsManager()->RegisterSettingOptionsFiller("refreshrates", CDisplaySettings::SettingOptionsRefreshRatesFiller);
   GetSettingsManager()->RegisterSettingOptionsFiller("regions", CLangInfo::SettingOptionsRegionsFiller);

--- a/xbmc/windowing/GraphicContext.h
+++ b/xbmc/windowing/GraphicContext.h
@@ -195,6 +195,7 @@ protected:
   bool m_bCalibrating = false;
   RESOLUTION m_Resolution = RES_INVALID;
   float m_fFPSOverride = 0.0f;
+  int m_iSleepFrames = 0;
 
   RESOLUTION_INFO m_windowResolution;
   std::stack<CPoint> m_cameras;

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -21,7 +21,6 @@
 #include "utils/DumbBufferObject.h"
 #include "utils/GBMBufferObject.h"
 #include "utils/UDMABufferObject.h"
-#include "utils/XTimeUtils.h"
 #include "utils/log.h"
 #include "windowing/WindowSystemFactory.h"
 
@@ -137,10 +136,6 @@ void CWinSystemGbmGLContext::PresentRender(bool rendered, bool videoLayer)
       for (auto resource : m_resources)
         resource->OnResetDisplay();
     }
-  }
-  else
-  {
-    KODI::TIME::Sleep(10ms);
   }
 }
 

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -25,7 +25,6 @@
 #include "utils/DumbBufferObject.h"
 #include "utils/GBMBufferObject.h"
 #include "utils/UDMABufferObject.h"
-#include "utils/XTimeUtils.h"
 #include "utils/log.h"
 #include "windowing/WindowSystemFactory.h"
 
@@ -146,10 +145,6 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
       for (auto resource : m_resources)
         resource->OnResetDisplay();
     }
-  }
-  else
-  {
-    KODI::TIME::Sleep(10ms);
   }
 }
 

--- a/xbmc/windowing/win10/WinSystemWin10DX.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10DX.cpp
@@ -11,7 +11,6 @@
 #include "input/touch/generic/GenericTouchActionHandler.h"
 #include "input/touch/generic/GenericTouchInputHandler.h"
 #include "rendering/dx/DirectXHelper.h"
-#include "utils/XTimeUtils.h"
 #include "utils/log.h"
 #include "windowing/WindowSystemFactory.h"
 
@@ -47,9 +46,6 @@ void CWinSystemWin10DX::PresentRenderImpl(bool rendered)
     m_delayDispReset = false;
     OnDisplayReset();
   }
-
-  if (!rendered)
-    KODI::TIME::Sleep(40ms);
 }
 
 bool CWinSystemWin10DX::CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res)

--- a/xbmc/windowing/windows/WinSystemWin32DX.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32DX.cpp
@@ -14,7 +14,6 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/SystemInfo.h"
-#include "utils/XTimeUtils.h"
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
 #include "windowing/WindowSystemFactory.h"
@@ -80,9 +79,6 @@ void CWinSystemWin32DX::PresentRenderImpl(bool rendered)
     m_delayDispReset = false;
     OnDisplayReset();
   }
-
-  if (!rendered)
-    KODI::TIME::Sleep(40ms);
 }
 
 bool CWinSystemWin32DX::CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res)


### PR DESCRIPTION
## Description
Add a new option under Display settings called "Limit framerate while sleeping"
This unifies the sleep time of the various rendering/windowing systems and lets the user customize the framerate while the interface is idle.
The available options for this new settings is 60 FPS, 55 FPS, 50 FPS, 45 FPS, 40 FPS, 35 FPS, 30 FPS, 25 FPS (default), 20 FPS, 15 FPS, 10 FPS, 9 FPS, 8 FPS, 7 FPS, 6 FPS, 5 FPS, 4 FPS, 3 FPS, 2 FPS, 1 FPS and Off.
Setting it to "Off" in reality equals a 100 FPS setting due to the base sleep duration further explained below.

## Motivation and context
I use this with a low very setting of 3 FPS on my Raspberry Pi to avoid it clocking the CPU to max MHz while the TV is off and Kodi isn't in use at all.

Unlike the `KODI::TIME::Sleep(40ms);` as currently done in `CRenderSystemGL`, `CRenderSystemGLES`, `CWinSystemWin10DX` and `CWinSystemWin32DX`, the systems for GBM `CWinSystemGbmGLESContext` and `CWinSystemGbmGLContext` only have `KODI::TIME::Sleep(10ms);` in them which I think is a bit aggressive, especially for SoC devices like the Raspberry Pi. Personally I want much larger sleep than even 40ms so I think it's best to leave this to the user. On very low settings (large sleep time) it is noticeable how input is delayed when waking up the interface but I'm happy with that to keep my device cool while not in use.

## How has this been tested?
I can only build Kodi on my Raspberry Pi so ARM with GBM is the only platform I have confirmed.

## What is the effect on users?
I set the new setting "Limit framerate while sleeping" to default to "25 FPS". 25 FPS then results in a 40ms sleep while idle which means it's the same as it was on GL, GLES, Win10DX and Win32DX but 4 times larger than what it was in GbmGLESContext and GbmGLContext. 
It is very hard to notice a difference between a sleep of 10ms or 40ms while the interface is not animating in any way so I don't think it matters and I think it's best to unify the sleep across rendering/windowing systems anyway.

One way with how the behavior differs is that for 60 frames after the last rendered frame it only sleeps 10ms. That is to keep input smooth without entering the longer sleep durations, for example while navigating through a list of items. Having it idle at 5 FPS or lower becomes noticeable especially with a mouse but even with a controller/remote control as it waits for 200ms or more until it reacts to input.  I was pondering how long that base sleep duration while not rendering should be. If it were set to 40ms it would fully match the current behavior of GL, GLES, Win10DX and Win32DX but then the available options 60 FPS, 55 FPS, 50 FPS, 45 FPS, 40 FPS, 35 FPS, 30 FPS and Off would need to be removed as they result in a sleep time less than that 40ms. 
I'm open to suggestions. It also could base it at 40ms unless the user overrides the new option to be higher than 25 FPS. Another thing I'm open to suggestions is the name, description and format of the options. Instead of "framerate" it could be "sleep time" and the options would be in milliseconds and not FPS. But I think a normal user understands FPS more. Or maybe it's just users who play video games...

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

Not sure about documentation, are all advanced/expert display options documented?