### PR TITLE
[Windows] fix: convert display setting to friendly name only for connected screens

### DIFF
--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -967,13 +967,16 @@ void CWinSystemWin32::UpdateResolutions()
   CWinSystemBase::UpdateResolutions();
   GetConnectedDisplays(m_displays);
 
-  // For the migration of setting videoscreen.monitor from GDI device string to EDID-based name
   const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
   std::string settingsMonitor = settings->GetString(CSettings::SETTING_VIDEOSCREEN_MONITOR);
   MONITOR_DETAILS* details = GetDisplayDetails(settingsMonitor);
   if (!details)
     return;
-  if (settingsMonitor != FromW(details->MonitorNameW))
+  // Migrate the setting to EDID-based name for connected and recognized screens.
+  // Other screens may be temporarily turned off, ignore so they're used once available again
+  if (settingsMonitor != FromW(details->MonitorNameW) &&
+      (settingsMonitor == FromW(details->DeviceStringW) ||
+       settingsMonitor == FromW(details->DeviceNameW)))
     CDisplaySettings::GetInstance().SetMonitor(FromW(details->MonitorNameW));
 
   float refreshRate;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Convert the setting to the friendly name only if the setting's screen was enumerated and one of its alternative names matches the setting's text.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The commit [44d3777](https://github.com/xbmc/xbmc/commit/44d3777fed22f3bbc755a00ed7bbed316ee907f5) / PR #22730 "[Windows] use the the display's friendly name when available" went a bit too far for multi-screen setups.

Scenario:
1. Set Kodi to fullscreen on secondary display. Close Kodi.
2. Turn off/unplug/undock secondary display so Windows doesn't see it anymore.
3. Start Kodi, Kodi opens on the primary screen. Close Kodi.
4. Reconnect/turn on secondary display so it's recognized by Windows again.
5. Start Kodi
Expected result (before the previous PR): Kodi starts on the external display.
Actual result: Kodi starts on the internal/primary screen because the previous PR modified the setting in step 3.

This PR restores the former behaviour, convenient in the case of a laptop with an external display for example.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Windows 10 with 2 screens.
Plugged/unplugged one screen per scenario above and a few more scenarios to confirm the name was still converted as needed.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Restored the behaviour of v20 and earlier.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
