### PR TITLE
[Addons] Having no repos is no error

### DIFF
--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -687,6 +687,13 @@ bool CAddonDatabase::GetRepositoryContent(const std::string& id, VECADDONS& addo
 
     if (repoIds.empty())
     {
+      if (id.empty())
+      {
+        CLog::Log(LOGDEBUG, "CAddonDatabase: no valid repository, continuing");
+        addons = {};
+        return true;
+      }
+
       CLog::Log(LOGDEBUG, "CAddonDatabase: no valid repository matching '{}'", id);
       return false;
     }

--- a/xbmc/addons/AddonRepos.cpp
+++ b/xbmc/addons/AddonRepos.cpp
@@ -106,6 +106,8 @@ bool CAddonRepos::LoadAddonsFromDatabase(const std::string& addonId,
   {
     // load full repository content
     m_addonDb.GetRepositoryContent(m_allAddons);
+    if (m_allAddons.empty())
+      return true;
   }
   else
   {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Allow edge case of having no valid repositories defined. It is not possible to install
addons from zip without.

Backport of #22912

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Without internet access no addons can be installed from zip.


## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
To repoduce the issue:

1. Delete Addon*.db.
2. Disable networking or cut internet connection.
3. Start kodi.
4. Install addon from zip


The installation will silently fail:

```
2023-02-16 18:35:21.513 T:6778    debug <general>: CAddonInstaller: installing from zip '/home/mg/build/kodi/script.hello.world-matrix.zip'
2023-02-16 18:35:21.514 T:6839    debug <general>: CAddonDatabase: SELECT repo.id FROM repo .. took 0 ms
2023-02-16 18:35:21.514 T:6839    debug <general>: CAddonDatabase: no valid repository matching ''
2023-02-16 18:35:21.530 T:6778    debug <general>: CGUIMediaWindow::GetDirectory (addons://)
2023-02-16 18:35:21.530 T:6778    debug <general>:   ParentPath = [addons://]
2023-02-16 18:35:21.530 T:6917    debug <general>: Thread waiting start, auto delete: false
2023-02-16 18:35:21.531 T:6917    debug <general>: CAddonDatabase: SELECT repo.id FROM repo .. took 0 ms
2023-02-16 18:35:21.531 T:6917    debug <general>: CAddonDatabase: no valid repository matching ''
2023-02-16 18:35:21.531 T:6917    debug <general>: CAddonMgr::GetAvailableUpdatesOrOutdatedAddons took 0 ms
2023-02-16 18:35:21.531 T:6917    debug <general>: Thread waiting 140351243269888 terminating
2023-02-16 18:35:21.532 T:6918    debug <general>: Thread BackgroundLoader start, auto delete: false
2023-02-16 18:35:21.532 T:6918    debug <general>: Thread BackgroundLoader 140351033550592 terminating
```

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Addon installation from zip is always possible.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
