### PR TITLE
Implement front to back rendering

### DIFF
--- a/system/shaders/GL/1.2/gl_shader_vert.glsl
+++ b/system/shaders/GL/1.2/gl_shader_vert.glsl
@@ -29,11 +29,13 @@ varying vec4 m_cord1;
 varying vec4 m_colour;
 uniform mat4 m_proj;
 uniform mat4 m_model;
+uniform float m_depth;
 
 void main ()
 {
   mat4 mvp    = m_proj * m_model;
   gl_Position = mvp * m_attrpos;
+  gl_Position.z = m_depth * gl_Position.w;
   m_colour    = m_attrcol;
   m_cord0     = m_attrcord0;
   m_cord1     = m_attrcord1;

--- a/system/shaders/GL/1.2/gl_shader_vert_clip.glsl
+++ b/system/shaders/GL/1.2/gl_shader_vert_clip.glsl
@@ -18,6 +18,7 @@ varying vec4 m_colour;
 uniform mat4 m_matrix;
 uniform vec4 m_shaderClip;
 uniform vec4 m_cordStep;
+uniform float m_depth;
 
 // this shader can be used in cases where clipping via glScissor() is not
 // possible (e.g. when rotating). it can't discard triangles, but it may 
@@ -29,6 +30,9 @@ void main ()
   vec4 position = m_attrpos;
   position.xy = clamp(position.xy, m_shaderClip.xy, m_shaderClip.zw);
   gl_Position = m_matrix * position;
+
+  // set rendering depth
+  gl_Position.z = m_depth * gl_Position.w;
 
   // correct texture coordinates for clipped vertices
   vec2 clipDist = m_attrpos.xy - position.xy;

--- a/system/shaders/GL/1.2/gl_shader_vert_default.glsl
+++ b/system/shaders/GL/1.2/gl_shader_vert_default.glsl
@@ -28,4 +28,5 @@ void main ()
 {
   mat4 mvp    = m_proj * m_model;
   gl_Position = mvp * m_attrpos;
+  gl_Position.z = -1. * gl_Position.w;
 }

--- a/system/shaders/GL/1.2/gl_shader_vert_simple.glsl
+++ b/system/shaders/GL/1.2/gl_shader_vert_simple.glsl
@@ -16,10 +16,12 @@ varying vec4 m_cord0;
 varying vec4 m_cord1;
 varying vec4 m_colour;
 uniform mat4 m_matrix;
+uniform float m_depth;
 
 void main ()
 {
   gl_Position = m_matrix * m_attrpos;
+  gl_Position.z = m_depth * gl_Position.w;
   m_colour    = m_attrcol;
   m_cord0     = m_attrcord0;
   m_cord1     = m_attrcord1;

--- a/system/shaders/GL/1.2/gl_yuv2rgb_vertex.glsl
+++ b/system/shaders/GL/1.2/gl_yuv2rgb_vertex.glsl
@@ -32,6 +32,7 @@ void main ()
 {
   mat4 mvp    = m_proj * m_model;
   gl_Position = mvp * m_attrpos;
+  gl_Position.z = -1. * gl_Position.w;
   m_cordY     = m_attrcordY;
   m_cordU     = m_attrcordU;
   m_cordV     = m_attrcordV;

--- a/system/shaders/GL/1.5/gl_shader_vert.glsl
+++ b/system/shaders/GL/1.5/gl_shader_vert.glsl
@@ -9,11 +9,13 @@ out vec4 m_cord1;
 out vec4 m_colour;
 uniform mat4 m_proj;
 uniform mat4 m_model;
+uniform float m_depth;
 
 void main ()
 {
   mat4 mvp    = m_proj * m_model;
   gl_Position = mvp * m_attrpos;
+  gl_Position.z = m_depth * gl_Position.w;
   m_colour    = m_attrcol;
   m_cord0     = m_attrcord0;
   m_cord1     = m_attrcord1;

--- a/system/shaders/GL/1.5/gl_shader_vert_clip.glsl
+++ b/system/shaders/GL/1.5/gl_shader_vert_clip.glsl
@@ -18,6 +18,7 @@ out vec4 m_colour;
 uniform mat4 m_matrix;
 uniform vec4 m_shaderClip;
 uniform vec4 m_cordStep;
+uniform float m_depth;
 
 // this shader can be used in cases where clipping via glScissor() is not
 // possible (e.g. when rotating). it can't discard triangles, but it may 
@@ -29,6 +30,9 @@ void main ()
   vec4 position = m_attrpos;
   position.xy = clamp(position.xy, m_shaderClip.xy, m_shaderClip.zw);
   gl_Position = m_matrix * position;
+
+  // set rendering depth
+  gl_Position.z = m_depth * gl_Position.w;
 
   // correct texture coordinates for clipped vertices
   vec2 clipDist = m_attrpos.xy - position.xy;

--- a/system/shaders/GL/1.5/gl_shader_vert_default.glsl
+++ b/system/shaders/GL/1.5/gl_shader_vert_default.glsl
@@ -8,4 +8,5 @@ void main ()
 {
   mat4 mvp    = m_proj * m_model;
   gl_Position = mvp * m_attrpos;
+  gl_Position.z = -1. * gl_Position.w;
 }

--- a/system/shaders/GL/1.5/gl_shader_vert_simple.glsl
+++ b/system/shaders/GL/1.5/gl_shader_vert_simple.glsl
@@ -16,10 +16,12 @@ out vec4 m_cord0;
 out vec4 m_cord1;
 out vec4 m_colour;
 uniform mat4 m_matrix;
+uniform float m_depth;
 
 void main ()
 {
   gl_Position = m_matrix * m_attrpos;
+  gl_Position.z = m_depth * gl_Position.w;
   m_colour    = m_attrcol;
   m_cord0     = m_attrcord0;
   m_cord1     = m_attrcord1;

--- a/system/shaders/GL/1.5/gl_yuv2rgb_vertex.glsl
+++ b/system/shaders/GL/1.5/gl_yuv2rgb_vertex.glsl
@@ -14,6 +14,7 @@ void main ()
 {
   mat4 mvp = m_proj * m_model;
   gl_Position = mvp * m_attrpos;
+  gl_Position.z = -1. * gl_Position.w;
   m_cordY = m_attrcordY;
   m_cordU = m_attrcordU;
   m_cordV = m_attrcordV;

--- a/system/shaders/GLES/2.0/gles_shader.vert
+++ b/system/shaders/GLES/2.0/gles_shader.vert
@@ -30,11 +30,13 @@ varying lowp vec4 m_colour;
 uniform mat4 m_proj;
 uniform mat4 m_model;
 uniform mat4 m_coord0Matrix;
+uniform float m_depth;
 
 void main ()
 {
   mat4 mvp = m_proj * m_model;
   gl_Position = mvp * m_attrpos;
+  gl_Position.z = m_depth * gl_Position.w;
   m_colour = m_attrcol;
   m_cord0 = m_coord0Matrix * m_attrcord0;
   m_cord1 = m_attrcord1;

--- a/system/shaders/GLES/2.0/gles_shader_clip.vert
+++ b/system/shaders/GLES/2.0/gles_shader_clip.vert
@@ -18,6 +18,7 @@ varying vec4 m_colour;
 uniform mat4 m_matrix;
 uniform vec4 m_shaderClip;
 uniform vec4 m_cordStep;
+uniform float m_depth;
 
 // this shader can be used in cases where clipping via glScissor() is not
 // possible (e.g. when rotating). it can't discard triangles, but it may 
@@ -29,6 +30,9 @@ void main()
   vec4 position = m_attrpos;
   position.xy = clamp(position.xy, m_shaderClip.xy, m_shaderClip.zw);
   gl_Position = m_matrix * position;
+
+  // set rendering depth
+  gl_Position.z = m_depth * gl_Position.w;
 
   // correct texture coordinates for clipped vertices
   vec2 clipDist = m_attrpos.xy - position.xy;

--- a/system/shaders/GLES/2.0/gles_shader_simple.vert
+++ b/system/shaders/GLES/2.0/gles_shader_simple.vert
@@ -16,10 +16,14 @@ varying vec4 m_cord0;
 varying vec4 m_cord1;
 varying vec4 m_colour;
 uniform mat4 m_matrix;
+uniform float m_depth;
 
 void main()
 {
   gl_Position = m_matrix * m_attrpos;
+
+  // set rendering depth
+  gl_Position.z = m_depth * gl_Position.w;
   m_colour    = m_attrcol;
   m_cord0     = m_attrcord0;
   m_cord1     = m_attrcord1;

--- a/system/shaders/GLES/2.0/gles_yuv2rgb.vert
+++ b/system/shaders/GLES/2.0/gles_yuv2rgb.vert
@@ -34,6 +34,7 @@ void main ()
 {
   mat4 mvp = m_proj * m_model;
   gl_Position = mvp * m_attrpos;
+  gl_Position.z = -1. * gl_Position.w;
   m_cordY = m_attrcordY;
   m_cordU = m_attrcordU;
   m_cordV = m_attrcordV;

--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
@@ -184,6 +184,21 @@ int CRenderContext::GUIShaderGetUniCol()
   return -1;
 }
 
+int CRenderContext::GUIShaderGetDepth()
+{
+#if defined(HAS_GL)
+  CRenderSystemGL* renderingGL = dynamic_cast<CRenderSystemGL*>(m_rendering);
+  if (renderingGL != nullptr)
+    return static_cast<int>(renderingGL->ShaderGetDepth());
+#elif HAS_GLES >= 2
+  CRenderSystemGLES* renderingGLES = dynamic_cast<CRenderSystemGLES*>(m_rendering);
+  if (renderingGLES != nullptr)
+    return static_cast<int>(renderingGLES->GUIShaderGetDepth());
+#endif
+
+  return -1;
+}
+
 CGUIShaderDX* CRenderContext::GetGUIShader()
 {
 #if defined(HAS_DX)

--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.h
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.h
@@ -69,6 +69,7 @@ public:
   int GUIShaderGetPos();
   int GUIShaderGetCoord0();
   int GUIShaderGetUniCol();
+  int GUIShaderGetDepth();
 
   // DirectX rendering functions
   CGUIShaderDX* GetGUIShader();

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMA.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMA.cpp
@@ -85,6 +85,7 @@ void CRPRendererDMA::Render(uint8_t alpha)
   GLint vertLoc = m_context.GUIShaderGetPos();
   GLint loc = m_context.GUIShaderGetCoord0();
   GLint uniColLoc = m_context.GUIShaderGetUniCol();
+  GLint depthLoc = m_context.GUIShaderGetDepth();
 
   // Setup color values
   colour[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
@@ -122,6 +123,7 @@ void CRPRendererDMA::Render(uint8_t alpha)
 
   glUniform4f(uniColLoc, (colour[0] / 255.0f), (colour[1] / 255.0f), (colour[2] / 255.0f),
               (colour[3] / 255.0f));
+  glUniform1f(depthLoc, -1.0f);
   glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
 
   glDisableVertexAttribArray(vertLoc);

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.cpp
@@ -184,6 +184,7 @@ void CRPRendererGuiTexture::RenderInternal(bool clear, uint8_t alpha)
   GLint posLoc = m_context.GUIShaderGetPos();
   GLint tex0Loc = m_context.GUIShaderGetCoord0();
   GLint uniColLoc = m_context.GUIShaderGetUniCol();
+  GLint depthLoc = m_context.GUIShaderGetDepth();
 
   glGenBuffers(1, &vertexVBO);
   glBindBuffer(GL_ARRAY_BUFFER, vertexVBO);
@@ -212,6 +213,7 @@ void CRPRendererGuiTexture::RenderInternal(bool clear, uint8_t alpha)
 
   glUniform4f(uniColLoc, (colour[0] / 255.0f), (colour[1] / 255.0f), (colour[2] / 255.0f),
               (colour[3] / 255.0f));
+  glUniform1f(depthLoc, -1.0f);
 
   glGenBuffers(1, &indexVBO);
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexVBO);
@@ -246,6 +248,7 @@ void CRPRendererGuiTexture::RenderInternal(bool clear, uint8_t alpha)
   GLint posLoc = m_context.GUIShaderGetPos();
   GLint tex0Loc = m_context.GUIShaderGetCoord0();
   GLint uniColLoc = m_context.GUIShaderGetUniCol();
+  GLint depthLoc = m_context.GUIShaderGetDepth();
 
   glVertexAttribPointer(posLoc, 3, GL_FLOAT, 0, 0, ver);
   glVertexAttribPointer(tex0Loc, 2, GL_FLOAT, 0, 0, tex);
@@ -275,6 +278,7 @@ void CRPRendererGuiTexture::RenderInternal(bool clear, uint8_t alpha)
 
   glUniform4f(uniColLoc, (col[0] / 255.0f), (col[1] / 255.0f), (col[2] / 255.0f),
               (col[3] / 255.0f));
+  glUniform1f(depthLoc, -1.0f);
   glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, idx);
 
   glDisableVertexAttribArray(posLoc);

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
@@ -295,6 +295,7 @@ void CRPRendererOpenGL::Render(uint8_t alpha)
   PackedVertex vertex[4];
 
   GLint uniColLoc = m_context.GUIShaderGetUniCol();
+  GLint depthLoc = m_context.GUIShaderGetDepth();
 
   // Setup color values
   colour[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
@@ -326,6 +327,7 @@ void CRPRendererOpenGL::Render(uint8_t alpha)
 
   glUniform4f(uniColLoc, (colour[0] / 255.0f), (colour[1] / 255.0f), (colour[2] / 255.0f),
               (colour[3] / 255.0f));
+  glUniform1f(depthLoc, -1.0f);
 
   glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
 

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
@@ -128,8 +128,10 @@ void CRPRendererOpenGLES::DrawBlackBars()
   m_context.EnableGUIShader(GL_SHADER_METHOD::DEFAULT);
   GLint posLoc = m_context.GUIShaderGetPos();
   GLint uniCol = m_context.GUIShaderGetUniCol();
+  GLint depthLoc = m_context.GUIShaderGetDepth();
 
   glUniform4f(uniCol, m_clearColour / 255.0f, m_clearColour / 255.0f, m_clearColour / 255.0f, 1.0f);
+  glUniform1f(depthLoc, -1.0f);
 
   // top quad
   if (m_rotatedDestCoords[0].y > 0.0f)
@@ -268,6 +270,7 @@ void CRPRendererOpenGLES::Render(uint8_t alpha)
   GLint vertLoc = m_context.GUIShaderGetPos();
   GLint loc = m_context.GUIShaderGetCoord0();
   GLint uniColLoc = m_context.GUIShaderGetUniCol();
+  GLint depthLoc = m_context.GUIShaderGetDepth();
 
   // Setup color values
   colour[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
@@ -305,6 +308,7 @@ void CRPRendererOpenGLES::Render(uint8_t alpha)
 
   glUniform4f(uniColLoc, (colour[0] / 255.0f), (colour[1] / 255.0f), (colour[2] / 255.0f),
               (colour[3] / 255.0f));
+  glUniform1f(depthLoc, -1.0f);
   glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
 
   glDisableVertexAttribArray(vertLoc);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
@@ -116,7 +116,7 @@ CDebugRenderer::CRenderer::CRenderer() : OVERLAY::CRenderer()
 {
 }
 
-void CDebugRenderer::CRenderer::Render(int idx)
+void CDebugRenderer::CRenderer::Render(int idx, float depth)
 {
   std::vector<SElement>& list = m_buffers[idx];
   for (std::vector<SElement>::iterator it = list.begin(); it != list.end(); ++it)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.h
@@ -34,7 +34,7 @@ protected:
   {
   public:
     CRenderer();
-    void Render(int idx) override;
+    void Render(int idx, float depth = 1.0f) override;
     void CreateSubtitlesStyle();
 
   private:

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -224,8 +224,10 @@ void CRendererDRMPRIMEGLES::DrawBlackBars()
   renderSystem->EnableGUIShader(ShaderMethodGLES::SM_DEFAULT);
   GLint posLoc = renderSystem->GUIShaderGetPos();
   GLint uniCol = renderSystem->GUIShaderGetUniCol();
+  GLint depthLoc = renderSystem->GUIShaderGetDepth();
 
   glUniform4f(uniCol, m_clearColour / 255.0f, m_clearColour / 255.0f, m_clearColour / 255.0f, 1.0f);
+  glUniform1f(depthLoc, -1.0f);
 
   GLuint vertexVBO;
   glGenBuffers(1, &vertexVBO);
@@ -328,6 +330,7 @@ void CRendererDRMPRIMEGLES::Render(unsigned int flags, int index)
 
   GLint vertLoc = renderSystem->GUIShaderGetPos();
   GLint loc = renderSystem->GUIShaderGetCoord0();
+  GLint depthLoc = renderSystem->GUIShaderGetDepth();
 
   // top left
   vertex[0].x = m_rotatedDestCoords[0].x;
@@ -373,6 +376,8 @@ void CRendererDRMPRIMEGLES::Render(unsigned int flags, int index)
   glGenBuffers(1, &indexVBO);
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexVBO);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte) * 4, idx, GL_STATIC_DRAW);
+
+  glUniform1f(depthLoc, -1.0f);
 
   glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodec.cpp
@@ -112,8 +112,6 @@ bool CRendererMediaCodec::RenderHook(int index)
   CYuvPlane &plane = m_buffers[index].fields[0][0];
   CYuvPlane &planef = m_buffers[index].fields[m_currentField][0];
 
-  glDisable(GL_DEPTH_TEST);
-
   glActiveTexture(GL_TEXTURE0);
   glBindTexture(GL_TEXTURE_EXTERNAL_OES, plane.id);
 
@@ -139,6 +137,8 @@ bool CRendererMediaCodec::RenderHook(int index)
   glUniform1f(contrastLoc, m_videoSettings.m_Contrast * 0.02f);
   GLint   brightnessLoc = renderSystem->GUIShaderGetBrightness();
   glUniform1f(brightnessLoc, m_videoSettings.m_Brightness * 0.01f - 0.5f);
+  GLint depthLoc = renderSystem->GUIShaderGetDepth();
+  glUniform1f(depthLoc, -1.0f);
 
   glUniformMatrix4fv(renderSystem->GUIShaderGetCoord0Matrix(), 1, GL_FALSE, m_textureMatrix);
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -531,9 +531,56 @@ void CLinuxRendererGL::RenderUpdate(int index, int index2, bool clear, unsigned 
 void CLinuxRendererGL::ClearBackBuffer()
 {
   //set the entire backbuffer to black
-  glClearColor(m_clearColour, m_clearColour, m_clearColour, 0);
-  glClear(GL_COLOR_BUFFER_BIT);
-  glClearColor(0,0,0,0);
+  //if we do a two pass render, we have to draw a quad. else we might occlude OSD elements.
+  if (CServiceBroker::GetWinSystem()->GetGfxContext().GetRenderOrder() ==
+      RENDER_ORDER_ALL_BACK_TO_FRONT)
+  {
+    CServiceBroker::GetWinSystem()->GetGfxContext().Clear(0xff000000);
+  }
+  else
+  {
+    ClearBackBufferQuad();
+  }
+}
+
+void CLinuxRendererGL::ClearBackBufferQuad()
+{
+  CRect windowRect(0, 0, CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth(),
+                   CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight());
+  struct Svertex
+  {
+    float x, y;
+  };
+
+  std::vector<Svertex> vertices{
+      {windowRect.x1, windowRect.y2 * 2},
+      {windowRect.x1, windowRect.y1},
+      {windowRect.x2 * 2, windowRect.y1},
+  };
+
+  glDisable(GL_BLEND);
+
+  m_renderSystem->EnableShader(ShaderMethodGL::SM_DEFAULT);
+  GLint posLoc = m_renderSystem->ShaderGetPos();
+  GLint uniCol = m_renderSystem->ShaderGetUniCol();
+
+  glUniform4f(uniCol, m_clearColour / 255.0f, m_clearColour / 255.0f, m_clearColour / 255.0f, 1.0f);
+
+  GLuint vertexVBO;
+  glGenBuffers(1, &vertexVBO);
+  glBindBuffer(GL_ARRAY_BUFFER, vertexVBO);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(Svertex) * vertices.size(), vertices.data(), GL_STATIC_DRAW);
+
+  glVertexAttribPointer(posLoc, 2, GL_FLOAT, GL_FALSE, sizeof(Svertex), 0);
+  glEnableVertexAttribArray(posLoc);
+
+  glDrawArrays(GL_TRIANGLES, 0, vertices.size());
+
+  glDisableVertexAttribArray(posLoc);
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+  glDeleteBuffers(1, &vertexVBO);
+
+  m_renderSystem->DisableShader();
 }
 
 //draw black bars around the video quad, this is more efficient than glClear()
@@ -1047,8 +1094,6 @@ void CLinuxRendererGL::RenderSinglePass(int index, int field)
     LoadShaders(field);
   }
 
-  glDisable(GL_DEPTH_TEST);
-
   // Y
   glActiveTexture(GL_TEXTURE0);
   glBindTexture(m_textureTarget, planes[0].id);
@@ -1218,8 +1263,6 @@ void CLinuxRendererGL::RenderToFBO(int index, int field, bool weave /*= false*/)
       return;
     }
   }
-
-  glDisable(GL_DEPTH_TEST);
 
   // Y
   glActiveTexture(GL_TEXTURE0);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
@@ -87,6 +87,7 @@ protected:
 
   bool Render(unsigned int flags, int renderBuffer);
   void ClearBackBuffer();
+  void ClearBackBufferQuad();
   void DrawBlackBars();
 
   bool ValidateRenderer();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -91,7 +91,7 @@ protected:
   static const int FIELD_TOP{1};
   static const int FIELD_BOT{2};
 
-  virtual void Render(unsigned int flags, int index);
+  virtual bool Render(unsigned int flags, int index);
   virtual void RenderUpdateVideo(bool clear, unsigned int flags = 0, unsigned int alpha = 255);
 
   int NextYV12Texture();
@@ -212,5 +212,7 @@ protected:
   CRect m_viewRect;
 
 private:
+  void ClearBackBuffer();
+  void ClearBackBufferQuad();
   void DrawBlackBars();
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -138,7 +138,7 @@ void CRenderer::ReleaseUnused()
   }
 }
 
-void CRenderer::Render(int idx)
+void CRenderer::Render(int idx, float depth)
 {
   std::unique_lock<CCriticalSection> lock(m_section);
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
@@ -99,7 +99,7 @@ namespace OVERLAY {
     void Notify(const Observable& obs, const ObservableMessage msg) override;
 
     void AddOverlay(std::shared_ptr<CDVDOverlay> o, double pts, int index);
-    virtual void Render(int idx);
+    virtual void Render(int idx, float depth = 0.0f);
 
     /*!
      * \brief Release resources

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
@@ -293,6 +293,7 @@ void COverlayGlyphGL::Render(SRenderState& state)
   GLint posLoc  = renderSystem->ShaderGetPos();
   GLint colLoc  = renderSystem->ShaderGetCol();
   GLint tex0Loc = renderSystem->ShaderGetCoord0();
+  GLint depthLoc = renderSystem->ShaderGetDepth();
   GLint matrixUniformLoc = renderSystem->ShaderGetMatrix();
 
   CMatrixGL matrix = glMatrixProject.Get();
@@ -329,6 +330,8 @@ void COverlayGlyphGL::Render(SRenderState& state)
   glEnableVertexAttribArray(posLoc);
   glEnableVertexAttribArray(colLoc);
   glEnableVertexAttribArray(tex0Loc);
+
+  glUniform1f(depthLoc, -1.0f);
 
   glDrawArrays(GL_TRIANGLES, 0, vecVertices.size());
 
@@ -401,6 +404,7 @@ void COverlayTextureGL::Render(SRenderState& state)
   GLint posLoc = renderSystem->ShaderGetPos();
   GLint tex0Loc = renderSystem->ShaderGetCoord0();
   GLint uniColLoc = renderSystem->ShaderGetUniCol();
+  GLint depthLoc = renderSystem->ShaderGetDepth();
 
   GLfloat col[4] = {1.0f, 1.0f, 1.0f, 1.0f};
 
@@ -455,6 +459,8 @@ void COverlayTextureGL::Render(SRenderState& state)
   glGenBuffers(1, &indexVBO);
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexVBO);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte)*4, idx, GL_STATIC_DRAW);
+
+  glUniform1f(depthLoc, -1.0f);
 
   glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
@@ -352,6 +352,7 @@ void COverlayGlyphGLES::Render(SRenderState& state)
   GLint posLoc = renderSystem->GUIShaderGetPos();
   GLint colLoc = renderSystem->GUIShaderGetCol();
   GLint tex0Loc = renderSystem->GUIShaderGetCoord0();
+  GLint depthLoc = renderSystem->GUIShaderGetDepth();
   GLint matrixUniformLoc = renderSystem->GUIShaderGetMatrix();
 
   CMatrixGL matrix = glMatrixProject.Get();
@@ -385,6 +386,8 @@ void COverlayGlyphGLES::Render(SRenderState& state)
   glEnableVertexAttribArray(posLoc);
   glEnableVertexAttribArray(colLoc);
   glEnableVertexAttribArray(tex0Loc);
+
+  glUniform1f(depthLoc, -1.0f);
 
   glDrawArrays(GL_TRIANGLES, 0, vecVertices.size());
 
@@ -448,6 +451,7 @@ void COverlayTextureGLES::Render(SRenderState& state)
   GLint colLoc = renderSystem->GUIShaderGetCol();
   GLint tex0Loc = renderSystem->GUIShaderGetCoord0();
   GLint uniColLoc = renderSystem->GUIShaderGetUniCol();
+  GLint depthLoc = renderSystem->GUIShaderGetDepth();
 
   GLfloat col[4] = {1.0f, 1.0f, 1.0f, 1.0f};
   GLfloat ver[4][2];
@@ -463,6 +467,7 @@ void COverlayTextureGLES::Render(SRenderState& state)
   glEnableVertexAttribArray(tex0Loc);
 
   glUniform4f(uniColLoc, (col[0]), (col[1]), (col[2]), (col[3]));
+  glUniform1f(depthLoc, 1.0f);
   // Setup vertex position values
   ver[0][0] = ver[3][0] = rd.x1;
   ver[0][1] = ver[1][1] = rd.y1;

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -50,6 +50,7 @@ public:
   void AllocResources() override;
   void FreeResources(bool immediately = false) override;
   void UpdateVisibility(const CGUIListItem *item = NULL) override;
+  void AssignDepth() override;
 
   virtual unsigned int GetRows() const;
 
@@ -212,6 +213,14 @@ protected:
   bool          m_autoScrollIsReversed; // scroll backwards
 
   unsigned int m_lastRenderTime;
+
+  struct RENDERITEM
+  {
+    float posX;
+    float posY;
+    std::shared_ptr<CGUIListItem> item;
+    bool focused;
+  };
 
 private:
   bool OnContextMenu();

--- a/xbmc/guilib/GUIBorderedImage.cpp
+++ b/xbmc/guilib/GUIBorderedImage.cpp
@@ -56,9 +56,17 @@ void CGUIBorderedImage::Process(unsigned int currentTime, CDirtyRegionList &dirt
 
 void CGUIBorderedImage::Render()
 {
+  bool renderFrontToBack = CServiceBroker::GetWinSystem()->GetGfxContext().GetRenderOrder() ==
+                           RENDER_ORDER_FRONT_TO_BACK;
+
+  if (renderFrontToBack)
+    CGUIImage::Render();
+
   if (!m_borderImage->GetFileName().empty() && m_texture->ReadyToRender())
-    m_borderImage->Render();
-  CGUIImage::Render();
+    m_borderImage->Render(-1);
+
+  if (!renderFrontToBack)
+    CGUIImage::Render();
 }
 
 CRect CGUIBorderedImage::CalcRenderRegion() const

--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -110,15 +110,27 @@ void CGUIButtonControl::Process(unsigned int currentTime, CDirtyRegionList &dirt
 
 void CGUIButtonControl::Render()
 {
-  m_imgFocus->Render();
-  m_imgNoFocus->Render();
+  if (CServiceBroker::GetWinSystem()->GetGfxContext().GetRenderOrder() ==
+      RENDER_ORDER_FRONT_TO_BACK)
+  {
+    m_imgNoFocus->Render();
+    m_imgFocus->Render(-1);
+  }
+  else
+  {
+    m_imgFocus->Render(-1);
+    m_imgNoFocus->Render();
+    RenderText();
+  }
 
-  RenderText();
   CGUIControl::Render();
 }
 
 void CGUIButtonControl::RenderText()
 {
+  if (CServiceBroker::GetWinSystem()->GetGfxContext().GetRenderOrder() ==
+      RENDER_ORDER_FRONT_TO_BACK)
+    return;
   m_label.Render();
   m_label2.Render();
 }

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -488,6 +488,11 @@ float CGUIControl::GetHeight() const
   return m_height;
 }
 
+void CGUIControl::AssignDepth()
+{
+  m_cachedTransform.depth = CServiceBroker::GetWinSystem()->GetGfxContext().GetDepth();
+}
+
 void CGUIControl::MarkDirtyRegion(const unsigned int dirtyState)
 {
   // if the control is culled, bail

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -184,6 +184,7 @@ public:
   virtual float GetYPosition() const;
   virtual float GetWidth() const;
   virtual float GetHeight() const;
+  virtual void AssignDepth();
 
   void MarkDirtyRegion(const unsigned int dirtyState = DIRTY_STATE_CONTROL);
   bool IsControlDirty() const { return m_controlDirtyState != 0; }

--- a/xbmc/guilib/GUIControlGroup.cpp
+++ b/xbmc/guilib/GUIControlGroup.cpp
@@ -108,12 +108,26 @@ void CGUIControlGroup::Render()
   CPoint pos(GetPosition());
   CServiceBroker::GetWinSystem()->GetGfxContext().SetOrigin(pos.x, pos.y);
   CGUIControl *focusedControl = NULL;
-  for (auto *control : m_children)
+  if (CServiceBroker::GetWinSystem()->GetGfxContext().GetRenderOrder() ==
+      RENDER_ORDER_FRONT_TO_BACK)
   {
-    if (m_renderFocusedLast && control->HasFocus())
-      focusedControl = control;
-    else
-      control->DoRender();
+    for (auto it = m_children.rbegin(); it != m_children.rend(); ++it)
+    {
+      if (m_renderFocusedLast && (*it)->HasFocus())
+        focusedControl = (*it);
+      else
+        (*it)->DoRender();
+    }
+  }
+  else
+  {
+    for (auto* control : m_children)
+    {
+      if (m_renderFocusedLast && control->HasFocus())
+        focusedControl = control;
+      else
+        control->DoRender();
+    }
   }
   if (focusedControl)
     focusedControl->DoRender();
@@ -284,6 +298,23 @@ bool CGUIControlGroup::CanFocus() const
       return true;
   }
   return false;
+}
+
+void CGUIControlGroup::AssignDepth()
+{
+  CGUIControl* focusedControl = nullptr;
+  if (m_children.size())
+  {
+    for (auto* control : m_children)
+    {
+      if (m_renderFocusedLast && control->HasFocus())
+        focusedControl = control;
+      else
+        control->AssignDepth();
+    }
+  }
+  if (focusedControl)
+    focusedControl->AssignDepth();
 }
 
 void CGUIControlGroup::SetInitialVisibility()

--- a/xbmc/guilib/GUIControlGroup.h
+++ b/xbmc/guilib/GUIControlGroup.h
@@ -41,6 +41,7 @@ public:
   void FreeResources(bool immediately = false) override;
   void DynamicResourceAlloc(bool bOnOff) override;
   bool CanFocus() const override;
+  void AssignDepth() override;
 
   EVENT_RESULT SendMouseEvent(const CPoint& point, const KODI::MOUSE::CMouseEvent& event) override;
   void UnfocusFromPoint(const CPoint &point) override;

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -548,6 +548,9 @@ void CGUIEditControl::ProcessText(unsigned int currentTime)
 
 void CGUIEditControl::RenderText()
 {
+  if (CServiceBroker::GetWinSystem()->GetGfxContext().GetRenderOrder() ==
+      RENDER_ORDER_FRONT_TO_BACK)
+    return;
   m_label.Render();
 
   if (CServiceBroker::GetWinSystem()->GetGfxContext().SetClipRegion(m_clipRect.x1, m_clipRect.y1, m_clipRect.Width(), m_clipRect.Height()))

--- a/xbmc/guilib/GUIFadeLabelControl.cpp
+++ b/xbmc/guilib/GUIFadeLabelControl.cpp
@@ -128,6 +128,7 @@ void CGUIFadeLabelControl::Process(unsigned int currentTime, CDirtyRegionList &d
     m_fadeAnim.Animate(currentTime, true);
     m_fadeAnim.RenderAnimation(matrix);
     m_fadeMatrix = CServiceBroker::GetWinSystem()->GetGfxContext().AddTransform(matrix);
+    m_fadeMatrix.depth = m_fadeDepth;
 
     if (m_fadeAnim.GetState() == ANIM_STATE_APPLIED)
       m_fadeAnim.ResetAnimation();
@@ -170,6 +171,9 @@ bool CGUIFadeLabelControl::UpdateColors(const CGUIListItem* item)
 
 void CGUIFadeLabelControl::Render()
 {
+  if (CServiceBroker::GetWinSystem()->GetGfxContext().GetRenderOrder() ==
+      RENDER_ORDER_FRONT_TO_BACK)
+    return;
   if (!m_label.font)
   { // nothing to render
     CGUIControl::Render();
@@ -241,6 +245,12 @@ bool CGUIFadeLabelControl::OnMessage(CGUIMessage& message)
     }
   }
   return CGUIControl::OnMessage(message);
+}
+
+void CGUIFadeLabelControl::AssignDepth()
+{
+  CGUIControl::AssignDepth();
+  m_fadeDepth = m_cachedTransform.depth;
 }
 
 std::string CGUIFadeLabelControl::GetDescription() const

--- a/xbmc/guilib/GUIFadeLabelControl.h
+++ b/xbmc/guilib/GUIFadeLabelControl.h
@@ -17,6 +17,7 @@
 #include "GUILabel.h"
 #include "guilib/guiinfo/GUIInfoLabel.h"
 
+#include <cstdint>
 #include <vector>
 
 /*!
@@ -35,6 +36,7 @@ public:
   void Render() override;
   bool CanFocus() const override;
   bool OnMessage(CGUIMessage& message) override;
+  void AssignDepth() override;
 
   void SetInfo(const std::vector<KODI::GUILIB::GUIINFO::CGUIInfoLabel> &vecInfo);
   void SetScrolling(bool scroll) { m_scroll = scroll; }
@@ -74,5 +76,7 @@ protected:
   bool m_resetOnLabelChange;
   bool m_randomized;
   bool m_allLabelsShown = true;
+
+  uint32_t m_fadeDepth{0};
 };
 

--- a/xbmc/guilib/GUIFontTTFGL.cpp
+++ b/xbmc/guilib/GUIFontTTFGL.cpp
@@ -155,6 +155,7 @@ void CGUIFontTTFGL::LastEnd()
   GLint clipUniformLoc = renderSystem->ShaderGetClip();
   GLint coordStepUniformLoc = renderSystem->ShaderGetCoordStep();
   GLint matrixUniformLoc = renderSystem->ShaderGetMatrix();
+  GLint depthLoc = renderSystem->ShaderGetDepth();
 
   CreateStaticVertexBuffers();
 
@@ -238,6 +239,10 @@ void CGUIFontTTFGL::LastEnd()
       matrix.Translatef(fractX, fractY, 0.0f);
 
       glUniformMatrix4fv(matrixUniformLoc, 1, GL_FALSE, matrix);
+
+      // Apply the depth value of the layer
+      float depth = CServiceBroker::GetWinSystem()->GetGfxContext().GetTransformDepth();
+      glUniform1f(depthLoc, depth);
 
       // Bind the buffer to the OpenGL context's GL_ARRAY_BUFFER binding point
       glBindBuffer(GL_ARRAY_BUFFER, m_vertexTrans[i].m_vertexBuffer->bufferHandle);

--- a/xbmc/guilib/GUIFontTTFGLES.cpp
+++ b/xbmc/guilib/GUIFontTTFGLES.cpp
@@ -151,6 +151,7 @@ void CGUIFontTTFGLES::LastEnd()
   GLint clipUniformLoc = renderSystem->GUIShaderGetClip();
   GLint coordStepUniformLoc = renderSystem->GUIShaderGetCoordStep();
   GLint matrixUniformLoc = renderSystem->GUIShaderGetMatrix();
+  GLint depthLoc = renderSystem->GUIShaderGetDepth();
 
   CreateStaticVertexBuffers();
 
@@ -231,6 +232,10 @@ void CGUIFontTTFGLES::LastEnd()
       matrix.Scalef(context.GetGUIScaleX(), context.GetGUIScaleY(), 1.0f);
       // the gui matrix doesn't align to exact pixel coords atm. correct it here for now.
       matrix.Translatef(fractX, fractY, 0.0f);
+
+      // Apply the depth value of the layer
+      float depth = CServiceBroker::GetWinSystem()->GetGfxContext().GetTransformDepth();
+      glUniform1f(depthLoc, depth);
 
       glUniformMatrix4fv(matrixUniformLoc, 1, GL_FALSE, matrix);
 

--- a/xbmc/guilib/GUILabelControl.cpp
+++ b/xbmc/guilib/GUILabelControl.cpp
@@ -139,6 +139,9 @@ CRect CGUILabelControl::CalcRenderRegion() const
 
 void CGUILabelControl::Render()
 {
+  if (CServiceBroker::GetWinSystem()->GetGfxContext().GetRenderOrder() ==
+      RENDER_ORDER_FRONT_TO_BACK)
+    return;
   m_label.Render();
   CGUIControl::Render();
 }

--- a/xbmc/guilib/GUIListItemLayout.cpp
+++ b/xbmc/guilib/GUIListItemLayout.cpp
@@ -237,6 +237,11 @@ void CGUIListItemLayout::FreeResources(bool immediately)
   m_group.FreeResources(immediately);
 }
 
+void CGUIListItemLayout::AssignDepth()
+{
+  m_group.AssignDepth();
+}
+
 #ifdef _DEBUG
 void CGUIListItemLayout::DumpTextureUse()
 {

--- a/xbmc/guilib/GUIListItemLayout.h
+++ b/xbmc/guilib/GUIListItemLayout.h
@@ -34,6 +34,7 @@ public:
   void SetInvalid() { m_invalidated = true; }
   void FreeResources(bool immediately = false);
   void SetParentControl(CGUIControl* control) { m_group.SetParentControl(control); }
+  void AssignDepth();
 
   //#ifdef GUILIB_PYTHON_COMPATIBILITY
   void CreateListControlLayouts(float width, float height, bool focused, const CLabelInfo &labelInfo, const CLabelInfo &labelInfo2, const CTextureInfo &texture, const CTextureInfo &textureFocus, float texHeight, float iconWidth, float iconHeight, const std::string &nofocusCondition, const std::string &focusCondition);

--- a/xbmc/guilib/GUIListLabel.cpp
+++ b/xbmc/guilib/GUIListLabel.cpp
@@ -67,6 +67,9 @@ void CGUIListLabel::Process(unsigned int currentTime, CDirtyRegionList &dirtyreg
 
 void CGUIListLabel::Render()
 {
+  if (CServiceBroker::GetWinSystem()->GetGfxContext().GetRenderOrder() ==
+      RENDER_ORDER_FRONT_TO_BACK)
+    return;
   m_label.Render();
   CGUIControl::Render();
 }

--- a/xbmc/guilib/GUIPanelContainer.cpp
+++ b/xbmc/guilib/GUIPanelContainer.cpp
@@ -114,6 +114,7 @@ void CGUIPanelContainer::Render()
     std::shared_ptr<CGUIListItem> focusedItem;
     int current = (offset - cacheBefore) * m_itemsPerRow;
     int col = 0;
+    std::vector<RENDERITEM> renderitems;
     while (pos < end && m_items.size())
     {
       if (current >= (int)m_items.size())
@@ -132,9 +133,11 @@ void CGUIPanelContainer::Render()
         else
         {
           if (m_orientation == VERTICAL)
-            RenderItem(origin.x + col * m_layout->Size(HORIZONTAL), pos, item.get(), false);
+            renderitems.emplace_back(
+                RENDERITEM{origin.x + col * m_layout->Size(HORIZONTAL), pos, item, false});
           else
-            RenderItem(pos, origin.y + col * m_layout->Size(VERTICAL), item.get(), false);
+            renderitems.emplace_back(
+                RENDERITEM{pos, origin.y + col * m_layout->Size(VERTICAL), item, false});
         }
       }
       // increment our position
@@ -151,9 +154,27 @@ void CGUIPanelContainer::Render()
     if (focusedItem)
     {
       if (m_orientation == VERTICAL)
-        RenderItem(origin.x + focusedCol * m_layout->Size(HORIZONTAL), focusedPos, focusedItem.get(), true);
+        renderitems.emplace_back(RENDERITEM{origin.x + focusedCol * m_layout->Size(HORIZONTAL),
+                                            focusedPos, focusedItem, true});
       else
-        RenderItem(focusedPos, origin.y + focusedCol * m_layout->Size(VERTICAL), focusedItem.get(), true);
+        renderitems.emplace_back(RENDERITEM{
+            focusedPos, origin.y + focusedCol * m_layout->Size(VERTICAL), focusedItem, true});
+    }
+
+    if (CServiceBroker::GetWinSystem()->GetGfxContext().GetRenderOrder() ==
+        RENDER_ORDER_FRONT_TO_BACK)
+    {
+      for (auto it = std::crbegin(renderitems); it != std::crend(renderitems); it++)
+      {
+        RenderItem(it->posX, it->posY, it->item.get(), it->focused);
+      }
+    }
+    else
+    {
+      for (const auto& renderitem : renderitems)
+      {
+        RenderItem(renderitem.posX, renderitem.posY, renderitem.item.get(), renderitem.focused);
+      }
     }
 
     CServiceBroker::GetWinSystem()->GetGfxContext().RestoreClipRegion();

--- a/xbmc/guilib/GUISettingsSliderControl.cpp
+++ b/xbmc/guilib/GUISettingsSliderControl.cpp
@@ -81,6 +81,9 @@ void CGUISettingsSliderControl::Render()
 {
   m_buttonControl.Render();
   CGUISliderControl::Render();
+  if (CServiceBroker::GetWinSystem()->GetGfxContext().GetRenderOrder() ==
+      RENDER_ORDER_FRONT_TO_BACK)
+    return;
   m_label.Render();
 }
 

--- a/xbmc/guilib/GUISpinControl.cpp
+++ b/xbmc/guilib/GUISpinControl.cpp
@@ -555,6 +555,9 @@ void CGUISpinControl::Render()
 
 void CGUISpinControl::RenderText(float posX, float posY, float width, float height)
 {
+  if (CServiceBroker::GetWinSystem()->GetGfxContext().GetRenderOrder() ==
+      RENDER_ORDER_FRONT_TO_BACK)
+    return;
   m_label.SetMaxRect(posX, posY, width, height);
   m_label.SetColor(GetTextColor());
   m_label.Render();

--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -197,6 +197,10 @@ void CGUITextBox::Process(unsigned int currentTime, CDirtyRegionList &dirtyregio
 
 void CGUITextBox::Render()
 {
+  if (CServiceBroker::GetWinSystem()->GetGfxContext().GetRenderOrder() ==
+      RENDER_ORDER_FRONT_TO_BACK)
+    return;
+
   // render the repeat anim as appropriate
   if (m_autoScrollRepeatAnim)
     CServiceBroker::GetWinSystem()->GetGfxContext().SetTransform(m_cachedTextMatrix);
@@ -387,6 +391,12 @@ void CGUITextBox::ResetAutoScrolling()
   m_autoScrollDelayTime = 0;
   if (m_autoScrollRepeatAnim)
     m_autoScrollRepeatAnim->ResetAnimation();
+}
+
+void CGUITextBox::AssignDepth()
+{
+  CGUIControl::AssignDepth();
+  m_cachedTextMatrix.depth = m_cachedTransform.depth;
 }
 
 unsigned int CGUITextBox::GetRows() const

--- a/xbmc/guilib/GUITextBox.h
+++ b/xbmc/guilib/GUITextBox.h
@@ -49,6 +49,7 @@ public:
   void SetAutoScrolling(const TiXmlNode *node);
   void SetAutoScrolling(int delay, int time, int repeatTime, const std::string &condition = "");
   void ResetAutoScrolling();
+  void AssignDepth() override;
 
   bool GetCondition(int condition, int data) const override;
   virtual std::string GetLabel(int info) const;

--- a/xbmc/guilib/GUITexture.h
+++ b/xbmc/guilib/GUITexture.h
@@ -67,8 +67,12 @@ class CGUITexture;
 
 using CreateGUITextureFunc = std::function<CGUITexture*(
     float posX, float posY, float width, float height, const CTextureInfo& texture)>;
-using DrawQuadFunc = std::function<void(
-    const CRect& coords, UTILS::COLOR::Color color, CTexture* texture, const CRect* texCoords)>;
+using DrawQuadFunc = std::function<void(const CRect& coords,
+                                        UTILS::COLOR::Color color,
+                                        CTexture* texture,
+                                        const CRect* texCoords,
+                                        const float depth,
+                                        const bool blending)>;
 
 class CGUITexture
 {
@@ -85,10 +89,12 @@ public:
   static void DrawQuad(const CRect& coords,
                        UTILS::COLOR::Color color,
                        CTexture* texture = nullptr,
-                       const CRect* texCoords = nullptr);
+                       const CRect* texCoords = nullptr,
+                       const float depth = 1.0,
+                       const bool blending = true);
 
   bool Process(unsigned int currentTime);
-  void Render();
+  void Render(int32_t depthOffset = 0, int32_t overrideDepth = -1);
 
   void DynamicResourceAlloc(bool bOnOff);
   bool AllocResources();
@@ -172,6 +178,7 @@ protected:
   float m_posY;
   float m_width;
   float m_height;
+  float m_depth{0};
 
   CRect m_vertex;       // vertex coords to render
   bool m_invalid;       // if true, we need to recalculate

--- a/xbmc/guilib/GUITextureD3D.cpp
+++ b/xbmc/guilib/GUITextureD3D.cpp
@@ -140,7 +140,9 @@ void CGUITextureD3D::Draw(float *x, float *y, float *z, const CRect &texture, co
 void CGUITextureD3D::DrawQuad(const CRect& rect,
                               UTILS::COLOR::Color color,
                               CTexture* texture,
-                              const CRect* texCoords)
+                              const CRect* texCoords,
+                              const float depth,
+                              const bool blending)
 {
   unsigned numViews = 0;
   ID3D11ShaderResourceView* views = nullptr;

--- a/xbmc/guilib/GUITextureD3D.h
+++ b/xbmc/guilib/GUITextureD3D.h
@@ -21,7 +21,9 @@ public:
   static void DrawQuad(const CRect& coords,
                        UTILS::COLOR::Color color,
                        CTexture* texture = nullptr,
-                       const CRect* texCoords = nullptr);
+                       const CRect* texCoords = nullptr,
+                       const float depth = 1.0,
+                       const bool blending = true);
 
   CGUITextureD3D(float posX, float posY, float width, float height, const CTextureInfo& texture);
   ~CGUITextureD3D() override = default;

--- a/xbmc/guilib/GUITextureGL.h
+++ b/xbmc/guilib/GUITextureGL.h
@@ -27,7 +27,9 @@ public:
   static void DrawQuad(const CRect& coords,
                        UTILS::COLOR::Color color,
                        CTexture* texture = nullptr,
-                       const CRect* texCoords = nullptr);
+                       const CRect* texCoords = nullptr,
+                       const float depth = 1.0,
+                       const bool blending = true);
 
   CGUITextureGL(float posX, float posY, float width, float height, const CTextureInfo& texture);
   ~CGUITextureGL() override = default;

--- a/xbmc/guilib/GUITextureGLES.cpp
+++ b/xbmc/guilib/GUITextureGLES.cpp
@@ -114,11 +114,14 @@ void CGUITextureGLES::End()
     GLint tex0Loc = m_renderSystem->GUIShaderGetCoord0();
     GLint tex1Loc = m_renderSystem->GUIShaderGetCoord1();
     GLint uniColLoc = m_renderSystem->GUIShaderGetUniCol();
+    GLint depthLoc = m_renderSystem->GUIShaderGetDepth();
 
     if(uniColLoc >= 0)
     {
       glUniform4f(uniColLoc,(m_col[0] / 255.0f), (m_col[1] / 255.0f), (m_col[2] / 255.0f), (m_col[3] / 255.0f));
     }
+
+    glUniform1f(depthLoc, m_depth);
 
     if(m_diffuse.size())
     {
@@ -234,7 +237,9 @@ void CGUITextureGLES::Draw(float *x, float *y, float *z, const CRect &texture, c
 void CGUITextureGLES::DrawQuad(const CRect& rect,
                                UTILS::COLOR::Color color,
                                CTexture* texture,
-                               const CRect* texCoords)
+                               const CRect* texCoords,
+                               const float depth,
+                               const bool blending)
 {
   CRenderSystemGLES *renderSystem = dynamic_cast<CRenderSystemGLES*>(CServiceBroker::GetRenderSystem());
   if (texture)
@@ -243,8 +248,15 @@ void CGUITextureGLES::DrawQuad(const CRect& rect,
     texture->BindToUnit(0);
   }
 
-  glBlendFunc(GL_SRC_ALPHA,GL_ONE_MINUS_SRC_ALPHA);
-  glEnable(GL_BLEND);          // Turn Blending On
+  if (blending)
+  {
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glEnable(GL_BLEND);
+  }
+  else
+  {
+    glDisable(GL_BLEND);
+  }
 
   VerifyGLState();
 
@@ -261,6 +273,7 @@ void CGUITextureGLES::DrawQuad(const CRect& rect,
   GLint posLoc   = renderSystem->GUIShaderGetPos();
   GLint tex0Loc  = renderSystem->GUIShaderGetCoord0();
   GLint uniColLoc= renderSystem->GUIShaderGetUniCol();
+  GLint depthLoc = renderSystem->GUIShaderGetDepth();
 
   glVertexAttribPointer(posLoc,  3, GL_FLOAT, 0, 0, ver);
   if (texture)
@@ -277,6 +290,7 @@ void CGUITextureGLES::DrawQuad(const CRect& rect,
   col[3] = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::A, color);
 
   glUniform4f(uniColLoc, col[0] / 255.0f, col[1] / 255.0f, col[2] / 255.0f, col[3] / 255.0f);
+  glUniform1f(depthLoc, depth);
 
   ver[0][0] = ver[3][0] = rect.x1;
   ver[0][1] = ver[1][1] = rect.y1;

--- a/xbmc/guilib/GUITextureGLES.h
+++ b/xbmc/guilib/GUITextureGLES.h
@@ -36,7 +36,9 @@ public:
   static void DrawQuad(const CRect& coords,
                        UTILS::COLOR::Color color,
                        CTexture* texture = nullptr,
-                       const CRect* texCoords = nullptr);
+                       const CRect* texCoords = nullptr,
+                       const float depth = 1.0,
+                       const bool blending = true);
 
   CGUITextureGLES(float posX, float posY, float width, float height, const CTextureInfo& texture);
   ~CGUITextureGLES() override = default;

--- a/xbmc/guilib/GUIVideoControl.cpp
+++ b/xbmc/guilib/GUIVideoControl.cpp
@@ -9,6 +9,7 @@
 #include "GUIVideoControl.h"
 
 #include "GUIComponent.h"
+#include "GUITexture.h"
 #include "GUIWindowManager.h"
 #include "ServiceBroker.h"
 #include "application/ApplicationComponents.h"
@@ -17,6 +18,7 @@
 #include "input/actions/ActionIDs.h"
 #include "input/mouse/MouseEvent.h"
 #include "utils/ColorUtils.h"
+#include "windowing/GraphicContext.h"
 
 using namespace KODI;
 
@@ -41,6 +43,9 @@ void CGUIVideoControl::Process(unsigned int currentTime, CDirtyRegionList &dirty
 
 void CGUIVideoControl::Render()
 {
+  if (CServiceBroker::GetWinSystem()->GetGfxContext().GetRenderOrder() ==
+      RENDER_ORDER_FRONT_TO_BACK)
+    return;
   auto& components = CServiceBroker::GetAppComponents();
   const auto appPlayer = components.GetComponent<CApplicationPlayer>();
   if (appPlayer->IsRenderingVideo())
@@ -64,7 +69,14 @@ void CGUIVideoControl::Render()
       CRect region = GetRenderRegion();
       region.Intersect(old);
       CServiceBroker::GetWinSystem()->GetGfxContext().SetScissors(region);
-      CServiceBroker::GetWinSystem()->GetGfxContext().Clear(0);
+
+      // with dual pass rendering, we need to "clear" with a quad, as we need to conserve the already rendered layers
+      if (CServiceBroker::GetWinSystem()->GetGfxContext().GetRenderOrder() ==
+          RENDER_ORDER_BACK_TO_FRONT)
+        CGUITexture::DrawQuad(region, 0x00000000, nullptr, nullptr, -1.0f, false);
+      else if (CServiceBroker::GetWinSystem()->GetGfxContext().GetRenderOrder() ==
+               RENDER_ORDER_ALL_BACK_TO_FRONT)
+        CServiceBroker::GetWinSystem()->GetGfxContext().Clear(0);
       CServiceBroker::GetWinSystem()->GetGfxContext().SetScissors(old);
     }
     else

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -1078,6 +1078,8 @@ void CGUIWindow::ClearBackground()
   UTILS::COLOR::Color color = m_clearBackground;
   if (color)
     CServiceBroker::GetWinSystem()->GetGfxContext().Clear(color);
+  else if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiGeometryClear)
+    CServiceBroker::GetWinSystem()->GetGfxContext().Clear(0xff000000);
   else
     CServiceBroker::GetWinSystem()->GetGfxContext().Clear();
 }

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -1078,6 +1078,8 @@ void CGUIWindow::ClearBackground()
   UTILS::COLOR::Color color = m_clearBackground;
   if (color)
     CServiceBroker::GetWinSystem()->GetGfxContext().Clear(color);
+  else
+    CServiceBroker::GetWinSystem()->GetGfxContext().Clear();
 }
 
 void CGUIWindow::SetID(int id)

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -231,6 +231,12 @@ public:
 #endif
 private:
   void RenderPass() const;
+  /*! \brief Render in one back to front pass.
+   */
+  void RenderPassSingle() const;
+  /*! \brief Render opaque elements front to back, and transparent ones back to front
+   */
+  void RenderPassDual() const;
 
   void LoadNotOnDemandWindows();
   void UnloadNotOnDemandWindows();

--- a/xbmc/pictures/SlideShowPicture.cpp
+++ b/xbmc/pictures/SlideShowPicture.cpp
@@ -727,6 +727,9 @@ void CSlideShowPic::Move(float fDeltaX, float fDeltaY)
 
 void CSlideShowPic::Render()
 {
+  if (CServiceBroker::GetWinSystem()->GetGfxContext().GetRenderOrder() ==
+      RENDER_ORDER_FRONT_TO_BACK)
+    return;
   std::unique_lock<CCriticalSection> lock(m_textureAccess);
 
   Render(m_ax, m_ay, m_pImage.get(), (m_alpha << 24) | 0xFFFFFF);

--- a/xbmc/pictures/SlideShowPictureGL.cpp
+++ b/xbmc/pictures/SlideShowPictureGL.cpp
@@ -81,6 +81,7 @@ void CSlideShowPicGL::Render(float* x, float* y, CTexture* pTexture, UTILS::COLO
   GLint posLoc = renderSystem->ShaderGetPos();
   GLint tex0Loc = renderSystem->ShaderGetCoord0();
   GLint uniColLoc = renderSystem->ShaderGetUniCol();
+  GLint depthLoc = renderSystem->ShaderGetDepth();
 
   glGenBuffers(1, &vertexVBO);
   glBindBuffer(GL_ARRAY_BUFFER, vertexVBO);
@@ -102,6 +103,7 @@ void CSlideShowPicGL::Render(float* x, float* y, CTexture* pTexture, UTILS::COLO
 
   glUniform4f(uniColLoc, (colour[0] / 255.0f), (colour[1] / 255.0f), (colour[2] / 255.0f),
               (colour[3] / 255.0f));
+  glUniform1f(depthLoc, -1.0f);
 
   glGenBuffers(1, &indexVBO);
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexVBO);

--- a/xbmc/pictures/SlideShowPictureGLES.cpp
+++ b/xbmc/pictures/SlideShowPictureGLES.cpp
@@ -53,6 +53,7 @@ void CSlideShowPicGLES::Render(float* x, float* y, CTexture* pTexture, UTILS::CO
   GLint posLoc = renderSystem->GUIShaderGetPos();
   GLint tex0Loc = renderSystem->GUIShaderGetCoord0();
   GLint uniColLoc = renderSystem->GUIShaderGetUniCol();
+  GLint depthLoc = renderSystem->GUIShaderGetDepth();
 
   glVertexAttribPointer(posLoc, 3, GL_FLOAT, 0, 0, ver);
   glVertexAttribPointer(tex0Loc, 2, GL_FLOAT, 0, 0, tex);
@@ -88,6 +89,7 @@ void CSlideShowPicGLES::Render(float* x, float* y, CTexture* pTexture, UTILS::CO
 
   glUniform4f(uniColLoc, (col[0] / 255.0f), (col[1] / 255.0f), (col[2] / 255.0f),
               (col[3] / 255.0f));
+  glUniform1f(depthLoc, -1.0f);
   glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, idx);
 
   glDisableVertexAttribArray(posLoc);

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -207,11 +207,23 @@ void CGUIEPGGridContainer::Process(unsigned int currentTime, CDirtyRegionList& d
 
 void CGUIEPGGridContainer::Render()
 {
-  RenderChannels();
-  RenderRulerDate();
-  RenderRuler();
-  RenderProgrammeGrid();
-  RenderProgressIndicator();
+  if (CServiceBroker::GetWinSystem()->GetGfxContext().GetRenderOrder() ==
+      RENDER_ORDER_FRONT_TO_BACK)
+  {
+    RenderProgressIndicator();
+    RenderProgrammeGrid();
+    RenderRuler();
+    RenderRulerDate();
+    RenderChannels();
+  }
+  else
+  {
+    RenderChannels();
+    RenderRulerDate();
+    RenderRuler();
+    RenderProgrammeGrid();
+    RenderProgressIndicator();
+  }
 
   CGUIControl::Render();
 }
@@ -316,7 +328,7 @@ void CGUIEPGGridContainer::RenderProgressIndicator()
   if (CServiceBroker::GetWinSystem()->GetGfxContext().SetClipRegion(m_rulerPosX, m_rulerPosY, GetProgressIndicatorWidth(), GetProgressIndicatorHeight()))
   {
     m_guiProgressIndicatorTexture->SetDiffuseColor(m_diffuseColor);
-    m_guiProgressIndicatorTexture->Render();
+    m_guiProgressIndicatorTexture->Render(0, m_guiProgressIndicatorTextureDepth);
     CServiceBroker::GetWinSystem()->GetGfxContext().RestoreClipRegion();
   }
 }
@@ -2090,7 +2102,10 @@ void CGUIEPGGridContainer::GetProgrammeCacheOffsets(int& cacheBefore, int& cache
   }
 }
 
-void CGUIEPGGridContainer::HandleChannels(bool bRender, unsigned int currentTime, CDirtyRegionList& dirtyregions)
+void CGUIEPGGridContainer::HandleChannels(bool bRender,
+                                          unsigned int currentTime,
+                                          CDirtyRegionList& dirtyregions,
+                                          bool bAssignDepth)
 {
   if (!m_focusedChannelLayout || !m_channelLayout)
     return;
@@ -2171,6 +2186,13 @@ void CGUIEPGGridContainer::HandleChannels(bool bRender, unsigned int currentTime
             RenderItem(pos, originChannel.y, item.get(), false);
         }
       }
+      else if (bAssignDepth)
+      {
+        if (focused)
+          focusedItem = item;
+        else
+          AssignItemDepth(item.get(), false);
+      }
       else
       {
         // process our item
@@ -2198,9 +2220,16 @@ void CGUIEPGGridContainer::HandleChannels(bool bRender, unsigned int currentTime
 
     CServiceBroker::GetWinSystem()->GetGfxContext().RestoreClipRegion();
   }
+  else if (bAssignDepth && focusedItem)
+  {
+    AssignItemDepth(focusedItem.get(), true);
+  }
 }
 
-void CGUIEPGGridContainer::HandleRulerDate(bool bRender, unsigned int currentTime, CDirtyRegionList& dirtyregions)
+void CGUIEPGGridContainer::HandleRulerDate(bool bRender,
+                                           unsigned int currentTime,
+                                           CDirtyRegionList& dirtyregions,
+                                           bool bAssignDepth)
 {
   if (!m_rulerDateLayout || m_gridModel->RulerItemsSize() <= 1 || m_gridModel->IsZeroGridDuration())
     return;
@@ -2214,6 +2243,10 @@ void CGUIEPGGridContainer::HandleRulerDate(bool bRender, unsigned int currentTim
     RenderItem(m_posX, m_posY, item.get(), false);
     CServiceBroker::GetWinSystem()->GetGfxContext().RestoreClipRegion();
   }
+  else if (bAssignDepth)
+  {
+    AssignItemDepth(item.get(), false);
+  }
   else
   {
     const int rulerOffset = GetProgrammeScrollOffset();
@@ -2224,7 +2257,10 @@ void CGUIEPGGridContainer::HandleRulerDate(bool bRender, unsigned int currentTim
   }
 }
 
-void CGUIEPGGridContainer::HandleRuler(bool bRender, unsigned int currentTime, CDirtyRegionList& dirtyregions)
+void CGUIEPGGridContainer::HandleRuler(bool bRender,
+                                       unsigned int currentTime,
+                                       CDirtyRegionList& dirtyregions,
+                                       bool bAssignDepth)
 {
   if (!m_rulerLayout || m_gridModel->RulerItemsSize() <= 1 || m_gridModel->IsZeroGridDuration())
     return;
@@ -2252,6 +2288,12 @@ void CGUIEPGGridContainer::HandleRuler(bool bRender, unsigned int currentTime, C
       CServiceBroker::GetWinSystem()->GetGfxContext().SetClipRegion(m_rulerPosX, m_rulerPosY, m_gridWidth, m_rulerHeight);
     else
       CServiceBroker::GetWinSystem()->GetGfxContext().SetClipRegion(m_rulerPosX, m_rulerPosY, m_rulerWidth, m_gridHeight);
+  }
+  else if (bAssignDepth)
+  {
+    if (!m_rulerDateLayout)
+      AssignItemDepth(item.get(), false);
+    GetProgrammeCacheOffsets(cacheBeforeRuler, cacheAfterRuler);
   }
   else
   {
@@ -2311,6 +2353,8 @@ void CGUIEPGGridContainer::HandleRuler(bool bRender, unsigned int currentTime, C
     {
       if (bRender)
         RenderItem(pos, originRuler.y, item.get(), false);
+      else if (bAssignDepth)
+        AssignItemDepth(item.get(), false);
       else
         ProcessItem(pos, originRuler.y, item, lastitem, false, m_rulerLayout, m_rulerLayout, currentTime, dirtyregions, m_rulerWidth);
 
@@ -2320,6 +2364,8 @@ void CGUIEPGGridContainer::HandleRuler(bool bRender, unsigned int currentTime, C
     {
       if (bRender)
         RenderItem(originRuler.x, pos, item.get(), false);
+      else if (bAssignDepth)
+        AssignItemDepth(item.get(), false);
       else
         ProcessItem(originRuler.x, pos, item, lastitem, false, m_rulerLayout, m_rulerLayout, currentTime, dirtyregions, m_rulerHeight);
 
@@ -2333,7 +2379,10 @@ void CGUIEPGGridContainer::HandleRuler(bool bRender, unsigned int currentTime, C
     CServiceBroker::GetWinSystem()->GetGfxContext().RestoreClipRegion();
 }
 
-void CGUIEPGGridContainer::HandleProgrammeGrid(bool bRender, unsigned int currentTime, CDirtyRegionList& dirtyregions)
+void CGUIEPGGridContainer::HandleProgrammeGrid(bool bRender,
+                                               unsigned int currentTime,
+                                               CDirtyRegionList& dirtyregions,
+                                               bool bAssignDepth)
 {
   if (!m_focusedProgrammeLayout || !m_programmeLayout || m_gridModel->RulerItemsSize() <= 1 || m_gridModel->IsZeroGridDuration())
     return;
@@ -2348,7 +2397,7 @@ void CGUIEPGGridContainer::HandleProgrammeGrid(bool bRender, unsigned int curren
   {
     CServiceBroker::GetWinSystem()->GetGfxContext().SetClipRegion(m_gridPosX, m_gridPosY, m_gridWidth, m_gridHeight);
   }
-  else
+  else if (!bAssignDepth)
   {
     int cacheBeforeChannel, cacheAfterChannel;
     GetChannelCacheOffsets(cacheBeforeChannel, cacheAfterChannel);
@@ -2460,6 +2509,24 @@ void CGUIEPGGridContainer::HandleProgrammeGrid(bool bRender, unsigned int curren
               RenderItem(posB, posA2, item.get(), focused);
           }
         }
+        else if (bAssignDepth)
+        {
+          // reset to grid start position if first item is out of grid view
+          if (posA2 < posA)
+            posA2 = posA;
+
+          // render our item
+          if (focused)
+          {
+            focusedPosX = posA2;
+            focusedPosY = posB;
+            focusedItem = item;
+          }
+          else
+          {
+            AssignItemDepth(item.get(), focused);
+          }
+        }
         else
         {
           // calculate the size to truncate if item is out of grid view
@@ -2511,5 +2578,36 @@ void CGUIEPGGridContainer::HandleProgrammeGrid(bool bRender, unsigned int curren
     }
 
     CServiceBroker::GetWinSystem()->GetGfxContext().RestoreClipRegion();
+  }
+  else if (bAssignDepth && focusedItem)
+  {
+    AssignItemDepth(focusedItem.get(), true);
+  }
+}
+
+void CGUIEPGGridContainer::AssignDepth()
+{
+  unsigned int dummyTime = 0;
+  CDirtyRegionList dummyRegions;
+  HandleChannels(false, dummyTime, dummyRegions, true);
+  HandleRuler(false, dummyTime, dummyRegions, true);
+  HandleRulerDate(false, dummyTime, dummyRegions, true);
+  HandleProgrammeGrid(false, dummyTime, dummyRegions, true);
+  m_guiProgressIndicatorTextureDepth = CServiceBroker::GetWinSystem()->GetGfxContext().GetDepth();
+}
+
+void CGUIEPGGridContainer::AssignItemDepth(CGUIListItem* item, bool focused)
+{
+  if (focused)
+  {
+    if (item->GetFocusedLayout())
+      item->GetFocusedLayout()->AssignDepth();
+  }
+  else
+  {
+    if (item->GetFocusedLayout() && item->GetFocusedLayout()->IsAnimating(ANIM_TYPE_UNFOCUS))
+      item->GetFocusedLayout()->AssignDepth();
+    else if (item->GetLayout())
+      item->GetLayout()->AssignDepth();
   }
 }

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.h
@@ -128,6 +128,10 @@ namespace PVR
      */
     bool SetChannel(const CPVRChannelNumber& channelNumber);
 
+    virtual void AssignDepth() override;
+
+    void AssignItemDepth(CGUIListItem* item, bool focused);
+
   private:
     bool OnClick(int actionID);
     bool SelectItemFromPoint(const CPoint& point, bool justGrid = true);
@@ -201,10 +205,22 @@ namespace PVR
     bool OnMouseDoubleClick(int dwButton, const CPoint& point);
     bool OnMouseWheel(char wheel, const CPoint& point);
 
-    void HandleChannels(bool bRender, unsigned int currentTime, CDirtyRegionList& dirtyregions);
-    void HandleRuler(bool bRender, unsigned int currentTime, CDirtyRegionList& dirtyregions);
-    void HandleRulerDate(bool bRender, unsigned int currentTime, CDirtyRegionList& dirtyregions);
-    void HandleProgrammeGrid(bool bRender, unsigned int currentTime, CDirtyRegionList& dirtyregions);
+    void HandleChannels(bool bRender,
+                        unsigned int currentTime,
+                        CDirtyRegionList& dirtyregions,
+                        bool bAssignDepth = false);
+    void HandleRuler(bool bRender,
+                     unsigned int currentTime,
+                     CDirtyRegionList& dirtyregions,
+                     bool bAssignDepth = false);
+    void HandleRulerDate(bool bRender,
+                         unsigned int currentTime,
+                         CDirtyRegionList& dirtyregions,
+                         bool bAssignDepth = false);
+    void HandleProgrammeGrid(bool bRender,
+                             unsigned int currentTime,
+                             CDirtyRegionList& dirtyregions,
+                             bool bAssignDepth = false);
 
     float GetCurrentTimePositionOnPage() const;
     float GetProgressIndicatorWidth() const;
@@ -248,6 +264,7 @@ namespace PVR
     float m_analogScrollCount = 0;
 
     std::unique_ptr<CGUITexture> m_guiProgressIndicatorTexture;
+    uint32_t m_guiProgressIndicatorTextureDepth{0};
 
     std::shared_ptr<CFileItem> m_lastItem;
     std::shared_ptr<CFileItem> m_lastChannel;

--- a/xbmc/rendering/RenderSystem.cpp
+++ b/xbmc/rendering/RenderSystem.cpp
@@ -73,7 +73,7 @@ void CRenderSystemBase::ShowSplash(const std::string& message)
   }
 
   CServiceBroker::GetWinSystem()->GetGfxContext().lock();
-  CServiceBroker::GetWinSystem()->GetGfxContext().Clear();
+  CServiceBroker::GetWinSystem()->GetGfxContext().Clear(0xff000000);
 
   RESOLUTION_INFO res = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo();
   CServiceBroker::GetWinSystem()->GetGfxContext().SetRenderingResolution(res, true);

--- a/xbmc/rendering/RenderSystem.h
+++ b/xbmc/rendering/RenderSystem.h
@@ -21,6 +21,13 @@
  *   This interface is very basic since a lot of the actual details will go in to the derived classes
  */
 
+enum DEPTH_CULLING
+{
+  DEPTH_CULLING_OFF = 0,
+  DEPTH_CULLING_BACK_TO_FRONT,
+  DEPTH_CULLING_FRONT_TO_BACK,
+};
+
 class CGUIImage;
 class CGUITextLayout;
 
@@ -37,6 +44,7 @@ public:
   virtual bool BeginRender() = 0;
   virtual bool EndRender() = 0;
   virtual void PresentRender(bool rendered, bool videoLayer) = 0;
+  virtual void InvalidateColorBuffer() {}
   virtual bool ClearBuffers(UTILS::COLOR::Color color) = 0;
   virtual bool IsExtSupported(const char* extension) const = 0;
 
@@ -48,6 +56,8 @@ public:
   virtual CRect ClipRectToScissorRect(const CRect &rect) { return CRect(); }
   virtual void SetScissors(const CRect &rect) = 0;
   virtual void ResetScissors() = 0;
+
+  virtual void SetDepthCulling(DEPTH_CULLING culling) {}
 
   virtual void CaptureStateBlock() = 0;
   virtual void ApplyStateBlock() = 0;

--- a/xbmc/rendering/gl/GLShader.cpp
+++ b/xbmc/rendering/gl/GLShader.cpp
@@ -51,6 +51,7 @@ void CGLShader::OnCompiledAndLinked()
   m_hMatrix = glGetUniformLocation(ProgramHandle(), "m_matrix");
   m_hShaderClip = glGetUniformLocation(ProgramHandle(), "m_shaderClip");
   m_hCoordStep = glGetUniformLocation(ProgramHandle(), "m_cordStep");
+  m_hDepth = glGetUniformLocation(ProgramHandle(), "m_depth");
 
   // Vertex attributes
   m_hPos = glGetAttribLocation(ProgramHandle(),  "m_attrpos");

--- a/xbmc/rendering/gl/GLShader.h
+++ b/xbmc/rendering/gl/GLShader.h
@@ -25,6 +25,7 @@ public:
   GLint GetColLoc() {return m_hCol;}
   GLint GetCord0Loc() {return m_hCord0;}
   GLint GetCord1Loc() {return m_hCord1;}
+  GLint GetDepthLoc() { return m_hDepth; }
   GLint GetUniColLoc() {return m_hUniCol;}
   GLint GetModelLoc() {return m_hModel; }
   GLint GetMatrixLoc() { return m_hMatrix; }
@@ -49,6 +50,7 @@ protected:
   GLint m_hCol = 0;
   GLint m_hCord0 = 0;
   GLint m_hCord1 = 0;
+  GLint m_hDepth = 0;
 
   const GLfloat *m_proj = nullptr;
   const GLfloat *m_model = nullptr;

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -222,8 +222,7 @@ bool CRenderSystemGL::ResetRenderSystem(int width, int height)
   }
 
   glBlendFunc(GL_SRC_ALPHA, GL_ONE);
-  glEnable(GL_BLEND);          // Turn Blending On
-  glDisable(GL_DEPTH_TEST);
+  glEnable(GL_BLEND); // Turn Blending On
 
   return true;
 }
@@ -266,6 +265,30 @@ bool CRenderSystemGL::EndRender()
   return true;
 }
 
+void CRenderSystemGL::InvalidateColorBuffer()
+{
+  if (!m_bRenderCreated)
+    return;
+
+  /* clear is not affected by stipple pattern, so we can only clear on first frame */
+  if (m_stereoMode == RENDER_STEREO_MODE_INTERLACED && m_stereoView == RENDER_STEREO_VIEW_RIGHT)
+    return;
+
+  // some platforms prefer a clear, instead of rendering over
+  if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiGeometryClear)
+  {
+    ClearBuffers(0);
+    return;
+  }
+
+  if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiFrontToBackRendering)
+    return;
+
+  glClearDepthf(0);
+  glDepthMask(GL_TRUE);
+  glClear(GL_DEPTH_BUFFER_BIT);
+}
+
 bool CRenderSystemGL::ClearBuffers(UTILS::COLOR::Color color)
 {
   if (!m_bRenderCreated)
@@ -283,6 +306,14 @@ bool CRenderSystemGL::ClearBuffers(UTILS::COLOR::Color color)
   glClearColor(r, g, b, a);
 
   GLbitfield flags = GL_COLOR_BUFFER_BIT;
+
+  if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiFrontToBackRendering)
+  {
+    glClearDepthf(0);
+    glDepthMask(GL_TRUE);
+    flags |= GL_DEPTH_BUFFER_BIT;
+  }
+
   glClear(flags);
 
   return true;
@@ -503,6 +534,27 @@ void CRenderSystemGL::SetScissors(const CRect &rect)
 void CRenderSystemGL::ResetScissors()
 {
   SetScissors(CRect(0, 0, (float)m_width, (float)m_height));
+}
+
+void CRenderSystemGL::SetDepthCulling(DEPTH_CULLING culling)
+{
+  if (culling == DEPTH_CULLING_OFF)
+  {
+    glDisable(GL_DEPTH_TEST);
+    glDepthMask(GL_FALSE);
+  }
+  else if (culling == DEPTH_CULLING_BACK_TO_FRONT)
+  {
+    glEnable(GL_DEPTH_TEST);
+    glDepthMask(GL_FALSE);
+    glDepthFunc(GL_GEQUAL);
+  }
+  else if (culling == DEPTH_CULLING_FRONT_TO_BACK)
+  {
+    glEnable(GL_DEPTH_TEST);
+    glDepthMask(GL_TRUE);
+    glDepthFunc(GL_GREATER);
+  }
 }
 
 void CRenderSystemGL::GetGLSLVersion(int& major, int& minor)
@@ -806,6 +858,14 @@ GLint CRenderSystemGL::ShaderGetCoord1()
 {
   if (m_pShader[m_method])
     return m_pShader[m_method]->GetCord1Loc();
+
+  return -1;
+}
+
+GLint CRenderSystemGL::ShaderGetDepth()
+{
+  if (m_pShader[m_method])
+    return m_pShader[m_method]->GetDepthLoc();
 
   return -1;
 }

--- a/xbmc/rendering/gl/RenderSystemGL.h
+++ b/xbmc/rendering/gl/RenderSystemGL.h
@@ -75,6 +75,7 @@ public:
   bool BeginRender() override;
   bool EndRender() override;
   void PresentRender(bool rendered, bool videoLayer) override;
+  void InvalidateColorBuffer() override;
   bool ClearBuffers(UTILS::COLOR::Color color) override;
   bool IsExtSupported(const char* extension) const override;
 
@@ -88,6 +89,8 @@ public:
   CRect ClipRectToScissorRect(const CRect &rect) override;
   void SetScissors(const CRect &rect) override;
   void ResetScissors() override;
+
+  void SetDepthCulling(DEPTH_CULLING culling) override;
 
   void CaptureStateBlock() override;
   void ApplyStateBlock() override;
@@ -114,6 +117,7 @@ public:
   GLint ShaderGetCol();
   GLint ShaderGetCoord0();
   GLint ShaderGetCoord1();
+  GLint ShaderGetDepth();
   GLint ShaderGetUniCol();
   GLint ShaderGetModel();
   GLint ShaderGetMatrix();

--- a/xbmc/rendering/gles/GLESShader.cpp
+++ b/xbmc/rendering/gles/GLESShader.cpp
@@ -57,6 +57,7 @@ void CGLESShader::OnCompiledAndLinked()
   m_hMatrix = glGetUniformLocation(ProgramHandle(), "m_matrix");
   m_hShaderClip = glGetUniformLocation(ProgramHandle(), "m_shaderClip");
   m_hCoordStep = glGetUniformLocation(ProgramHandle(), "m_cordStep");
+  m_hDepth = glGetUniformLocation(ProgramHandle(), "m_depth");
 
   // Vertex attributes
   m_hPos    = glGetAttribLocation(ProgramHandle(),  "m_attrpos");

--- a/xbmc/rendering/gles/GLESShader.h
+++ b/xbmc/rendering/gles/GLESShader.h
@@ -25,6 +25,7 @@ public:
   GLint GetColLoc()   { return m_hCol;   }
   GLint GetCord0Loc() { return m_hCord0; }
   GLint GetCord1Loc() { return m_hCord1; }
+  GLint GetDepthLoc() { return m_hDepth; }
   GLint GetUniColLoc() { return m_hUniCol; }
   GLint GetCoord0MatrixLoc() { return m_hCoord0Matrix; }
   GLint GetFieldLoc() { return m_hField; }
@@ -59,6 +60,7 @@ protected:
   GLint m_hStep = 0;
   GLint m_hContrast = 0;
   GLint m_hBrightness = 0;
+  GLint m_hDepth = 0;
 
   const GLfloat *m_proj;
   const GLfloat *m_model;

--- a/xbmc/rendering/gles/RenderSystemGLES.h
+++ b/xbmc/rendering/gles/RenderSystemGLES.h
@@ -85,6 +85,7 @@ public:
   bool BeginRender() override;
   bool EndRender() override;
   void PresentRender(bool rendered, bool videoLayer) override;
+  void InvalidateColorBuffer() override;
   bool ClearBuffers(UTILS::COLOR::Color color) override;
   bool IsExtSupported(const char* extension) const override;
 
@@ -98,6 +99,8 @@ public:
   CRect ClipRectToScissorRect(const CRect &rect) override;
   void SetScissors(const CRect& rect) override;
   void ResetScissors() override;
+
+  void SetDepthCulling(DEPTH_CULLING culling) override;
 
   void CaptureStateBlock() override;
   void ApplyStateBlock() override;
@@ -129,6 +132,7 @@ public:
   GLint GUIShaderGetMatrix();
   GLint GUIShaderGetClip();
   GLint GUIShaderGetCoordStep();
+  GLint GUIShaderGetDepth();
 
 protected:
   virtual void SetVSyncImpl(bool enable) = 0;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -1224,6 +1224,8 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetInt(pElement, "algorithmdirtyregions",     m_guiAlgorithmDirtyRegions);
     XMLUtils::GetBoolean(pElement, "smartredraw", m_guiSmartRedraw);
     XMLUtils::GetInt(pElement, "anisotropicfiltering", m_guiAnisotropicFiltering);
+    XMLUtils::GetBoolean(pElement, "fronttobackrendering", m_guiFrontToBackRendering);
+    XMLUtils::GetBoolean(pElement, "geometryclear", m_guiGeometryClear);
   }
 
   std::string seekSteps;

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -335,7 +335,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_guiSmartRedraw;
     int32_t m_guiAnisotropicFiltering{0};
     bool m_guiFrontToBackRendering{false};
-    bool m_guiGeometryClear{false};
+    bool m_guiGeometryClear{true};
     unsigned int m_addonPackageFolderSize;
 
     bool m_jsonOutputCompact;

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -334,6 +334,8 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int  m_guiAlgorithmDirtyRegions;
     bool m_guiSmartRedraw;
     int32_t m_guiAnisotropicFiltering{0};
+    bool m_guiFrontToBackRendering{false};
+    bool m_guiGeometryClear{false};
     unsigned int m_addonPackageFolderSize;
 
     bool m_jsonOutputCompact;

--- a/xbmc/utils/TransformMatrix.h
+++ b/xbmc/utils/TransformMatrix.h
@@ -36,6 +36,7 @@ public:
     m[2][0] = m[2][1] = m[2][3] = 0.0f; m[2][2] = 1.0f;
     alpha = red = green = blue = 1.0f;
     identity = true;
+    depth = 0;
   };
   static TransformMatrix CreateTranslation(float transX, float transY, float transZ = 0)
   {
@@ -50,6 +51,7 @@ public:
     m[2][0] = m[2][1] = 0.0f; m[2][2] = 1.0f; m[2][3] = transZ;
     alpha = red = green = blue = 1.0f;
     identity = (transX == 0 && transY == 0 && transZ == 0);
+    depth = 0;
   }
   static TransformMatrix CreateScaler(float scaleX, float scaleY, float scaleZ = 1.0f)
   {
@@ -69,6 +71,7 @@ public:
     m[2][0] = 0.0f;    m[2][1] = 0.0f;    m[2][2] = scaleZ;  m[2][3] = centerZ*(1-scaleZ);
     alpha = red = green = blue = 1.0f;
     identity = (scaleX == 1 && scaleY == 1);
+    depth = 0;
   };
   void SetXRotation(float angle, float y, float z, float ar = 1.0f)
   { // angle about the X axis, centered at y,z where our coordinate system has aspect ratio ar.
@@ -79,6 +82,7 @@ public:
     m[2][0] = 0.0f;  m[2][1] = s;     m[2][2] = c;      m[2][3] = (-y*s-c*z) + z;
     alpha = red = green = blue = 1.0f;
     identity = (angle == 0);
+    depth = 0;
   }
   void SetYRotation(float angle, float x, float z, float ar = 1.0f)
   { // angle about the Y axis, centered at x,z where our coordinate system has aspect ratio ar.
@@ -89,6 +93,7 @@ public:
     m[2][0] = ar*s;  m[2][1] = 0.0f;  m[2][2] = c;      m[2][3] = -ar*x*s - c*z + z;
     alpha = red = green = blue = 1.0f;
     identity = (angle == 0);
+    depth = 0;
   }
   static TransformMatrix CreateZRotation(float angle, float x, float y, float ar = 1.0f)
   { // angle about the Z axis, centered at x,y where our coordinate system has aspect ratio ar.
@@ -106,6 +111,7 @@ public:
     m[2][0] = 0.0f;  m[2][1] = 0.0f;   m[2][2] = 1.0f;  m[2][3] = 0.0f;
     alpha = red = green = blue = 1.0f;
     identity = (angle == 0);
+    depth = 0;
   }
   static TransformMatrix CreateFader(float a)
   {
@@ -127,6 +133,7 @@ public:
     alpha = a;
     red = green = blue = 1.0f;
     identity = (a == 1.0f);
+    depth = 0;
   }
 
   void SetFader(float a, float r, float g, float b)
@@ -139,6 +146,7 @@ public:
     green = g;
     blue = b;
     identity = ((a == 1.0f) && (r == 1.0f) && (g == 1.0f) && (b == 1.0f));
+    depth = 0;
   }
 
   // multiplication operators
@@ -171,6 +179,7 @@ public:
     green *= right.green;
     blue *= right.blue;
     identity = false;
+    depth = std::max(depth, right.depth);
     return *this;
   }
 
@@ -198,6 +207,7 @@ public:
     result.green = green * right.green;
     result.blue = blue * right.blue;
     result.identity = false;
+    result.depth = std::max(depth, right.depth);
     return result;
   }
 
@@ -278,12 +288,14 @@ public:
   float green;
   float blue;
   bool identity;
+  uint32_t depth{0};
 };
 
 inline bool operator==(const TransformMatrix &a, const TransformMatrix &b)
 {
   bool comparison =
       a.alpha == b.alpha && a.red == b.red && a.green == b.green && a.blue == b.blue &&
+      a.depth == b.depth &&
       ((a.identity && b.identity) ||
        (!a.identity && !b.identity &&
         std::equal(&a.m[0][0], &a.m[0][0] + sizeof(a.m) / sizeof(a.m[0][0]), &b.m[0][0])));

--- a/xbmc/video/dialogs/GUIDialogTeletext.cpp
+++ b/xbmc/video/dialogs/GUIDialogTeletext.cpp
@@ -85,6 +85,9 @@ void CGUIDialogTeletext::Process(unsigned int currentTime, CDirtyRegionList &dir
 
 void CGUIDialogTeletext::Render()
 {
+  if (CServiceBroker::GetWinSystem()->GetGfxContext().GetRenderOrder() ==
+      RENDER_ORDER_FRONT_TO_BACK)
+    return;
   // Do not render if we have no texture
   if (!m_pTxtTexture)
   {
@@ -124,7 +127,7 @@ void CGUIDialogTeletext::Render()
 
   UTILS::COLOR::Color color =
       (static_cast<UTILS::COLOR::Color>(teletextFadeAmount * 2.55f) & 0xff) << 24 | 0xFFFFFF;
-  CGUITexture::DrawQuad(m_vertCoords, color, m_pTxtTexture.get());
+  CGUITexture::DrawQuad(m_vertCoords, color, m_pTxtTexture.get(), nullptr, -1.0f);
 
   CGUIDialog::Render();
 }

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -22,6 +22,7 @@
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "input/mouse/MouseEvent.h"
+#include "settings/AdvancedSettings.h"
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -182,6 +183,8 @@ void CGUIWindowFullScreen::ClearBackground()
   const auto appPlayer = components.GetComponent<CApplicationPlayer>();
   if (appPlayer->IsRenderingVideoLayer())
     CServiceBroker::GetWinSystem()->GetGfxContext().Clear(0);
+  else
+    CServiceBroker::GetWinSystem()->GetGfxContext().Clear();
 }
 
 void CGUIWindowFullScreen::OnWindowLoaded()
@@ -377,11 +380,19 @@ void CGUIWindowFullScreen::Process(unsigned int currentTime, CDirtyRegionList &d
 
 void CGUIWindowFullScreen::Render()
 {
-  CServiceBroker::GetWinSystem()->GetGfxContext().SetRenderingResolution(CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution(), false);
-  auto& components = CServiceBroker::GetAppComponents();
-  const auto appPlayer = components.GetComponent<CApplicationPlayer>();
-  appPlayer->Render(true, 255);
-  CServiceBroker::GetWinSystem()->GetGfxContext().SetRenderingResolution(m_coordsRes, m_needsScaling);
+  if (CServiceBroker::GetWinSystem()->GetGfxContext().GetRenderOrder() !=
+      RENDER_ORDER_FRONT_TO_BACK)
+  {
+    CServiceBroker::GetWinSystem()->GetGfxContext().SetRenderingResolution(
+        CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution(), false);
+    auto& components = CServiceBroker::GetAppComponents();
+    const auto appPlayer = components.GetComponent<CApplicationPlayer>();
+    // FIXME: remove clearing pass from renderer, it should be its own, dedicated function.
+    bool clear = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiGeometryClear;
+    appPlayer->Render(clear, 255);
+    CServiceBroker::GetWinSystem()->GetGfxContext().SetRenderingResolution(m_coordsRes,
+                                                                           m_needsScaling);
+  }
   CGUIWindow::Render();
 }
 

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -183,6 +183,8 @@ void CGUIWindowFullScreen::ClearBackground()
   const auto appPlayer = components.GetComponent<CApplicationPlayer>();
   if (appPlayer->IsRenderingVideoLayer())
     CServiceBroker::GetWinSystem()->GetGfxContext().Clear(0);
+  else if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiGeometryClear)
+    CServiceBroker::GetWinSystem()->GetGfxContext().Clear(0xff000000);
   else
     CServiceBroker::GetWinSystem()->GetGfxContext().Clear();
 }

--- a/xbmc/windowing/GraphicContext.cpp
+++ b/xbmc/windowing/GraphicContext.cpp
@@ -580,6 +580,11 @@ void CGraphicContext::ResetScreenParameters(RESOLUTION res)
   ResetOverscan(res, info.Overscan);
 }
 
+void CGraphicContext::Clear()
+{
+  CServiceBroker::GetRenderSystem()->InvalidateColorBuffer();
+}
+
 void CGraphicContext::Clear(UTILS::COLOR::Color color)
 {
   CServiceBroker::GetRenderSystem()->ClearBuffers(color);
@@ -822,6 +827,22 @@ void CGraphicContext::RestoreStereoFactor()
   UpdateCameraPosition(m_cameras.top(), m_stereoFactors.top());
 }
 
+float CGraphicContext::GetNormalizedDepth(uint32_t depth)
+{
+  float normalizedDepth = static_cast<float>(depth);
+  normalizedDepth /= m_layer;
+  normalizedDepth = normalizedDepth * 2 - 1;
+  return normalizedDepth;
+}
+
+float CGraphicContext::GetTransformDepth(int32_t depthOffset)
+{
+  float depth = static_cast<float>(m_finalTransform.matrix.depth + depthOffset);
+  depth /= m_layer;
+  depth = depth * 2 - 1;
+  return depth;
+}
+
 CRect CGraphicContext::GenerateAABB(const CRect &rect) const
 {
 // ------------------------
@@ -1004,6 +1025,24 @@ void CGraphicContext::GetAllowedResolutions(std::vector<RESOLUTION> &res)
   {
     res.push_back((RESOLUTION) r);
   }
+}
+
+void CGraphicContext::SetRenderOrder(RENDER_ORDER renderOrder)
+{
+  m_renderOrder = renderOrder;
+  if (renderOrder == RENDER_ORDER_ALL_BACK_TO_FRONT)
+    CServiceBroker::GetRenderSystem()->SetDepthCulling(DEPTH_CULLING_OFF);
+  else if (renderOrder == RENDER_ORDER_BACK_TO_FRONT)
+    CServiceBroker::GetRenderSystem()->SetDepthCulling(DEPTH_CULLING_BACK_TO_FRONT);
+  else if (renderOrder == RENDER_ORDER_FRONT_TO_BACK)
+    CServiceBroker::GetRenderSystem()->SetDepthCulling(DEPTH_CULLING_FRONT_TO_BACK);
+}
+
+uint32_t CGraphicContext::GetDepth(uint32_t addLayers)
+{
+  uint32_t layer = m_layer;
+  m_layer += addLayers;
+  return layer;
 }
 
 void CGraphicContext::SetFPS(float fps)

--- a/xbmc/windowing/X11/GLContextEGL.cpp
+++ b/xbmc/windowing/X11/GLContextEGL.cpp
@@ -341,7 +341,7 @@ bool CGLContextEGL::SuitableCheck(EGLDisplay eglDisplay, EGLConfig config)
     return false;
   if (!eglGetConfigAttrib(eglDisplay, config, EGL_BLUE_SIZE, &value) || value < 8)
     return false;
-  if (!eglGetConfigAttrib(eglDisplay, config, EGL_DEPTH_SIZE, &value) || value < 24)
+  if (!eglGetConfigAttrib(eglDisplay, config, EGL_DEPTH_SIZE, &value) || value < 16)
     return false;
 
   return true;

--- a/xbmc/windows/GUIWindowDebugInfo.cpp
+++ b/xbmc/windows/GUIWindowDebugInfo.cpp
@@ -179,7 +179,13 @@ void CGUIWindowDebugInfo::Process(unsigned int currentTime, CDirtyRegionList &di
 
 void CGUIWindowDebugInfo::Render()
 {
+  RENDER_ORDER renderOrder = CServiceBroker::GetWinSystem()->GetGfxContext().GetRenderOrder();
+  if (renderOrder == RENDER_ORDER_FRONT_TO_BACK)
+    return;
+  else if (renderOrder == RENDER_ORDER_BACK_TO_FRONT)
+    CServiceBroker::GetWinSystem()->GetGfxContext().SetRenderOrder(RENDER_ORDER_ALL_BACK_TO_FRONT);
   CServiceBroker::GetWinSystem()->GetGfxContext().SetRenderingResolution(CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(), false);
   if (m_layout)
     m_layout->RenderOutline(m_renderRegion.x1, m_renderRegion.y1, 0xffffffff, 0xff000000, 0, 0);
+  CServiceBroker::GetWinSystem()->GetGfxContext().SetRenderOrder(renderOrder);
 }


### PR DESCRIPTION
## Description
The PR splits the GUI rendering into two passes, if enabled in the advanced settings. In a first pass, all opaque elements get rendered in front to back order. In the second one, all elements with alpha blending enabled get rendered.

To enable it, you need to supply the following setting(s):
```
<advancedsettings>
  <gui>
    <fronttobackrendering>true</fronttobackrendering>
    <geometryclear>false</geometryclear>
  </gui>
</advancedsettings>
```

It also changes some details with clearing the screen, depending on the "geometryclear" setting. On tiling GPUs, it is better to clear the screen at the beginning of a frame, as it avoids loading previous frame content. But even on modern GPUs, a straight glClear() might be better, as the overdraw by the drawcall can be avoided. Screen clears can be done by copy engines, thus relieving the processing units.

Currently, this only works on GL/GLES. A DX dev would need to step up to bring this feature to Windows. It shouldn't be too hard tho.


## Motivation and context
Overdraw (rendering to a pixel multiple times) is very common with current skins. It is a main factor of framerate drops in Kodi.

By avoiding the rendering of covered areas, the overdraw can be reduced. Depending on the view, I could observe a reduction in overdraw by up to 50%. 

The performance uplift is depending on the GPU. Some desktop GPUs might experience slight performance degradation on very light skins. But on average, it should be a net performance gain. On most ARM GPUs, access to the depth buffer is free. Depending on how the GPU is rejecting covered polygons, it might skip rasterization or the fragment thread creation, saving GPU cycles. In any case, the texture bandwidth needed is most likely reduced, as the occluded areas don't need to be textured.

## How has this been tested?
GL and GLES compile and run fine on X11. On my RX570, I've seen performance improvements of up to 40% with some Estuary views.

## What is the effect on users?
More performance. I've hidden the improvement under an advanced setting, so it should not make a difference per default.

## Screenshots (if appropriate):
This view in Confluence improves from an overdraw of around 6.5:
![image(2)](https://user-images.githubusercontent.com/30039775/223185284-d87f331b-0d56-4c55-a89e-e4030287bd2e.png)
... to around 3.5:
![image(1)](https://user-images.githubusercontent.com/30039775/223185362-9f7e6de1-137e-4df6-9c17-c199a2f7f3b1.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
