### PR TITLE
[Windows] Fix SMB read chunk size when is not used FileCache

### DIFF
--- a/xbmc/platform/win32/filesystem/Win32File.cpp
+++ b/xbmc/platform/win32/filesystem/Win32File.cpp
@@ -761,3 +761,11 @@ int CWin32File::Stat(struct __stat64* statData)
 
   return 0;
 }
+
+int CWin32File::GetChunkSize()
+{
+  if (m_smbFile)
+    return 64 * 1024;
+
+  return 0;
+}

--- a/xbmc/platform/win32/filesystem/Win32File.h
+++ b/xbmc/platform/win32/filesystem/Win32File.h
@@ -40,6 +40,7 @@ namespace XFILE
     virtual bool Exists(const CURL& url);
     virtual int Stat(const CURL& url, struct __stat64* statData);
     virtual int Stat(struct __stat64* statData);
+    virtual int GetChunkSize();
 
   protected:
     explicit CWin32File(bool asSmbFile);


### PR DESCRIPTION
## Description
Fix SMB read chunk size when is not used FileCache

Fixes https://github.com/xbmc/xbmc/issues/18031

## Motivation and context
After https://github.com/xbmc/xbmc/pull/22897 found that SMB also has issues related to file chunk size.

In Android when not used FileCache chunk size is 64K instead of 128K when FileCache is used.

In Windows things are much worse and chunk size defaults to only 6144 bytes causing severe performance issues. This is reproducible playing Blu-Ray folders (BDMV) as by default are not used FileCache.

![chunk-size](https://user-images.githubusercontent.com/58434170/223200833-bf61777f-5043-4951-975d-2a61683cdc3b.png)


## How has this been tested?
Runtime tested Windows x64


## What is the effect on users?
Fixes severe issues at playback Blu-Ray's (BDMV) over SMB with default settings.



## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
