### PR TITLE
[libjpeg-turbo] Use position-independent code

### DIFF
--- a/tools/depends/target/libjpeg-turbo/Makefile
+++ b/tools/depends/target/libjpeg-turbo/Makefile
@@ -2,6 +2,12 @@ include ../../Makefile.include LIBJPEG-TURBO-VERSION ../../download-files.includ
 DEPS = ../../Makefile.include LIBJPEG-TURBO-VERSION Makefile ../../download-files.include \
                                   01-disable-executables.patch
 
+CMAKE_ARGS=-B build \
+           -DCMAKE_ASM_NASM_COMPILER:FILEPATH=$(NATIVEPREFIX)/bin/nasm \
+           -DENABLE_SHARED:BOOL=OFF \
+           -DWITH_JPEG8:BOOL=ON \
+           -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
+
 LIBDYLIB=$(PLATFORM)/build/libjpeg.a
 
 all: .installed-$(PLATFORM)
@@ -10,7 +16,7 @@ $(PLATFORM): $(DEPS) | $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE)
 	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 	cd $(PLATFORM); patch -p1 -i ../01-disable-executables.patch
-	cd $(PLATFORM); $(CMAKE) -B build -DCMAKE_ASM_NASM_COMPILER:FILEPATH=$(NATIVEPREFIX)/bin/nasm -DENABLE_SHARED:BOOL=OFF -DWITH_JPEG8:BOOL=ON
+	cd $(PLATFORM); $(CMAKE) $(CMAKE_ARGS)
 
 $(LIBDYLIB): $(PLATFORM)
 	$(MAKE) -C $(PLATFORM)/build


### PR DESCRIPTION
## Description
It is preferable to use position-independent code in shared libraries. Such an approach reduces load time and improves security.

From Android API level >= 23, the OS will refuse to load any shared library that contains text relocations.

Related info: https://github.com/libjpeg-turbo/libjpeg-turbo/issues/155

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
