### PR TITLE
[cmake] pipewire: set minimum version to 0.3.50

### DIFF
--- a/cmake/modules/FindPipewire.cmake
+++ b/cmake/modules/FindPipewire.cmake
@@ -12,7 +12,7 @@
 #
 
 if(PKG_CONFIG_FOUND)
-  pkg_check_modules(PC_PIPEWIRE libpipewire-0.3>=0.3.34 QUIET)
+  pkg_check_modules(PC_PIPEWIRE libpipewire-0.3>=0.3.50 QUIET)
   pkg_check_modules(PC_SPA libspa-0.2>=0.2 QUIET)
 endif()
 


### PR DESCRIPTION
This fixes #22924 

I never checked the minimum pipewire version required in #22442

ref: https://docs.pipewire.org/group__pw__stream.html#ga721dc4d5ec4c406ecb0469bfefea468f
ref: https://github.com/PipeWire/pipewire/commit/5a9d2679ca480db7083887e9c48db7367e4bb1f5