### PR TITLE
[Windows] shrink window to fit the screen and avoid a crash

### DIFF
--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -175,9 +175,24 @@ bool CWinSystemWin32::CreateNewWindow(const std::string& name, bool fullScreen, 
     }
     else
     {
-      // centering window at desktop
-      m_nLeft += (screenRect.right - screenRect.left) / 2 - m_nWidth / 2;
-      m_nTop += (screenRect.bottom - screenRect.top) / 2 - m_nHeight / 2;
+      // Windowed mode: position and size in settings and most places in Kodi
+      // are for the client part of the window.
+      RECT rcWorkArea = GetScreenWorkArea(m_hMonitor);
+
+      int workAreaWidth = rcWorkArea.right - rcWorkArea.left;
+      int workAreaHeight = rcWorkArea.bottom - rcWorkArea.top;
+
+      RECT rcNcArea = GetNcAreaOffsets(m_windowStyle, false, m_windowExStyle);
+      int maxClientWidth = (rcWorkArea.right - rcNcArea.right) - (rcWorkArea.left - rcNcArea.left);
+      int maxClientHeight = (rcWorkArea.bottom - rcNcArea.bottom) - (rcWorkArea.top - rcNcArea.top);
+
+      m_nWidth = std::min<int>(m_nWidth, maxClientWidth);
+      m_nHeight = std::min<int>(m_nHeight, maxClientHeight);
+      CWinSystemBase::SetWindowResolution(m_nWidth, m_nHeight);
+
+      // center window on desktop
+      m_nLeft = rcWorkArea.left - rcNcArea.left + (maxClientWidth - m_nWidth) / 2;
+      m_nTop = rcWorkArea.top - rcNcArea.top + (maxClientHeight - m_nHeight) / 2;
     }
     m_ValidWindowedPosition = true;
   }
@@ -382,8 +397,31 @@ void CWinSystemWin32::AdjustWindow(bool forceResize)
         // restore previous window position
         m_nTop = top;
         m_nLeft = left;
-        m_ValidWindowedPosition = true;
       }
+      else
+      {
+        // Windowed mode: position and size in settings and most places in Kodi
+        // are for the client part of the window.
+        RECT rcWorkArea = GetScreenWorkArea(m_hMonitor);
+
+        int workAreaWidth = rcWorkArea.right - rcWorkArea.left;
+        int workAreaHeight = rcWorkArea.bottom - rcWorkArea.top;
+
+        RECT rcNcArea = GetNcAreaOffsets(m_windowStyle, false, m_windowExStyle);
+        int maxClientWidth =
+            (rcWorkArea.right - rcNcArea.right) - (rcWorkArea.left - rcNcArea.left);
+        int maxClientHeight =
+            (rcWorkArea.bottom - rcNcArea.bottom) - (rcWorkArea.top - rcNcArea.top);
+
+        m_nWidth = std::min<int>(m_nWidth, maxClientWidth);
+        m_nHeight = std::min<int>(m_nHeight, maxClientHeight);
+        CWinSystemBase::SetWindowResolution(m_nWidth, m_nHeight);
+
+        // center window on desktop
+        m_nLeft = rcWorkArea.left - rcNcArea.left + (maxClientWidth - m_nWidth) / 2;
+        m_nTop = rcWorkArea.top - rcNcArea.top + (maxClientHeight - m_nHeight) / 2;
+      }
+      m_ValidWindowedPosition = true;
     }
 
     rc.left = m_nLeft;
@@ -1353,4 +1391,29 @@ void CWinSystemWin32::CacheSystemSdrPeakLuminance()
     m_validSystemSdrPeakLuminance =
         CWIN32Util::GetSystemSdrWhiteLevel(md->DeviceNameW, &m_systemSdrPeakLuminance);
   }
+}
+
+RECT CWinSystemWin32::GetScreenWorkArea(HMONITOR handle) const
+{
+  MONITORINFO monitorInfo{};
+  monitorInfo.cbSize = sizeof(MONITORINFO);
+  if (!GetMonitorInfoW(handle, &monitorInfo))
+  {
+    CLog::LogF(LOGERROR, "GetMonitorInfoW failed with {}", GetLastError());
+    return RECT();
+  }
+  return monitorInfo.rcWork;
+}
+
+RECT CWinSystemWin32::GetNcAreaOffsets(DWORD dwStyle, BOOL bMenu, DWORD dwExStyle) const
+{
+  RECT rcNcArea{};
+  SetRectEmpty(&rcNcArea);
+
+  if (!AdjustWindowRectEx(&rcNcArea, dwStyle, false, dwExStyle))
+  {
+    CLog::LogF(LOGERROR, "AdjustWindowRectEx failed with {}", GetLastError());
+    return RECT();
+  }
+  return rcNcArea;
 }

--- a/xbmc/windowing/windows/WinSystemWin32.h
+++ b/xbmc/windowing/windows/WinSystemWin32.h
@@ -160,6 +160,16 @@ protected:
   void ResolutionChanged();
   static void SetForegroundWindowInternal(HWND hWnd);
   static RECT GetVirtualScreenRect();
+  /*!
+   * Retrieve the work area of the screen (exclude task bar and other occlusions)
+   */
+  RECT GetScreenWorkArea(HMONITOR handle) const;
+  /*!
+   * Retrieve size of the title bar and borders
+   * Add to coordinates to convert client coordinates to window coordinates
+   * Substract from coordinates to convert from window coordinates to client coordinates
+   */
+  RECT GetNcAreaOffsets(DWORD dwStyle, BOOL bMenu, DWORD dwExStyle) const;
 
   HWND m_hWnd;
   HMONITOR m_hMonitor;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
In windowed mode, adjust width and height from settings so that the window fits on the screen.
Take into account occlusions such as the Windows task bar and window Title bar / decorations.

I think this is a low risk approach that could be backported to v20,

A better fix untangling RenderSystem/WindowSystem, refining the new position and size and avoiding changing the settings value until the use changes the size or position will take more time and have more risk - probably fit for v21 only.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Kodi crashes in windowed mode when going to a smaller screen.
Steps:
1. Start Kodi on external 4k screen, windowed mode
2. Stop Kodi, disconnect external screen
3. Start Kodi on the builtin 1080p screen
4. crash

reported in issue #22667, and probably what is alluded to in some forum threads.

root cause: when the window is much larger than the available screen, Windows doesn't send an initial WM_SIZE message that indirectly intializes the swap chain and other DX resources that CRenderSystemDX::InitRenderSystem() relies on but does not initialize.
The message normally happens as a side-effect of CWinSystemWin32::CreateNewWindow() when the window fits in the screen.

That hidden dependency should not exist.
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 10, 2 screens, followed the steps above and more common situations of switching between windowed and fullscreen, resizing of the window.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Fix a crash on startup in windowed mode after unplugging a larger screen.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
