### PR TITLE
[tools/depends][target] samba patch innetgr check

### DIFF
--- a/tools/depends/target/samba-gplv3/07-innetgr-check.patch
+++ b/tools/depends/target/samba-gplv3/07-innetgr-check.patch
@@ -1,0 +1,31 @@
+--- a/lib/util/access.c
++++ b/lib/util/access.c
+@@ -115,7 +115,7 @@ static bool string_match(const char *tok,const char *s)
+ 			return true;
+ 		}
+ 	} else if (tok[0] == '@') { /* netgroup: look it up */
+-#ifdef HAVE_NETGROUP
++#if defined(HAVE_NETGROUP) && defined(HAVE_INNETGR)
+ 		DATA_BLOB tmp;
+ 		char *mydomain = NULL;
+ 		char *hostname = NULL;
+--- a/source3/auth/user_util.c
++++ b/source3/auth/user_util.c
+@@ -135,7 +135,7 @@
+ 
+ bool user_in_netgroup(TALLOC_CTX *ctx, const char *user, const char *ngname)
+ {
+-#ifdef HAVE_NETGROUP
++#if defined(HAVE_NETGROUP) && defined(HAVE_INNETGR)
+ 	char nis_domain_buf[256];
+ 	const char *nis_domain = NULL;
+ 	char *lowercase_user = NULL;
+@@ -180,7 +180,7 @@
+ 		DEBUG(5,("user_in_netgroup: Found\n"));
+ 		return true;
+ 	}
+-#endif /* HAVE_NETGROUP */
++#endif /* HAVE_NETGROUP and HAVE_INNETGR */
+ 	return false;
+ }
+ 

--- a/tools/depends/target/samba-gplv3/Makefile
+++ b/tools/depends/target/samba-gplv3/Makefile
@@ -73,6 +73,7 @@ $(PLATFORM): $(DEPS) | $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE)
 	cd $(PLATFORM); patch -p1 -i ../04-built-static.patch
 ifeq ($(OS),android)
 	cd $(PLATFORM); patch -p1 -i ../samba_android.patch
+	cd $(PLATFORM); patch -p1 -i ../07-innetgr-check.patch
 endif
 ifeq ($(OS), darwin_embedded)
 	cd $(PLATFORM); patch -p1 -i ../no_fork_and_exec.patch


### PR DESCRIPTION
## Description
Backport upstream patch to resolve a potential build failure. Experienced when targeting SDK 33 + NDK r25c (25.2.9519653)

## Motivation and context
This patch is in newer versions of samba (4.17.0+). https://gitlab.com/samba-team/samba/-/commit/fb937ddc838043deb82b6a557dce8f29001d0a19

Fixes android failures with SDK 33 and newer build tools

  > ld: error: undefined symbol: innetgr
  > referenced by access.c:157 (../../lib/util/access.c:157)
  >               access.c.65.o:(string_match) in archive /Users/Shared/xbmc-depends/aarch64-linux-android-33-debug/lib/libsmbclient.a
  clang++: error: linker command failed with exit code 1 (use -v to see invocation)
  make[3]: *** [libkodi.so] Error 1
  make[2]: *** [CMakeFiles/kodi.dir/all] Error 2
  make[1]: *** [CMakeFiles/apk.dir/rule] Error 2

## How has this been tested?
Build aarch64 and run (in conjunction with some other commits)

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
