### PR TITLE
Use 64K file read chunk size for local files: USB files, external hard drives, etc.

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -142,12 +142,15 @@ BitstreamStats CDVDInputStreamFile::GetBitstreamStats() const
     return m_stats;
 }
 
+// Use value returned by filesystem if is > 1
+// otherwise defaults to 64K
 int CDVDInputStreamFile::GetBlockSize()
 {
-  if(m_pFile)
-    return m_pFile->GetChunkSize();
-  else
-    return 0;
+  int chunk = 0;
+  if (m_pFile)
+    chunk = m_pFile->GetChunkSize();
+
+  return ((chunk > 1) ? chunk : 64 * 1024);
 }
 
 void CDVDInputStreamFile::SetReadRate(uint32_t rate)

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -360,7 +360,12 @@ bool CFile::Open(const CURL& file, const unsigned int flags)
       return false;
     }
 
-    if (m_pFile->GetChunkSize() && !(m_flags & READ_CHUNKED))
+    constexpr int64_t len = 200 * 1024 * 1024; // 200 MB
+
+    // Use CFileStreamBuffer for all "big" files (audio/video files) when FileCache is not used
+    // This also makes use of 64K file read chunk size, suitable for localfiles, USB files, etc.
+    // Also enbles basic cache for Blu-Ray but only big .m2ts files (main audio/video files only)
+    if ((m_pFile->GetChunkSize() || m_pFile->GetLength() > len) && !(m_flags & READ_CHUNKED))
     {
       m_pBuffer = std::make_unique<CFileStreamBuffer>(0);
       m_pBuffer->Attach(m_pFile.get());


### PR DESCRIPTION
## Description
Use 64K file read chunk size for local files: USB files, external hard drives, etc.

## Motivation and context
Follow-up of https://github.com/xbmc/xbmc/pull/22920. See: https://github.com/xbmc/xbmc/pull/22920#issuecomment-1458288763

Shield has some low performance issues reading high bitrate files from USB disks (high CPU load).

Now when FileCache is not used (default for local files) read chunk size defaults to only 4096 bytes and is not used `CFileStreamBuffer` because `GetChunkSize()` returns zero for all local files. 

Read chunks of only 4096 bytes causes excessive "read calls" per second when bitrate is 80 - 120 Mbps. This contributes to high CPU load.

This PR also enables basic file cache for Blu-Ray but only big .m2ts files. All others small files (mpls, clpi, java resources, etc.) behaves as before. Tested and works fine.

## How has this been tested?
Runtime Windows x64 and Android (Shield)
Tested media files at USB and Blu-Ray folders on local disk and SMB / NFS.

## What is the effect on users?
Better performance reading local files or in general when FileCache is not used or disabled.

One forum user has reported some improvements (https://forum.kodi.tv/showthread.php?tid=373526&pid=3159342#pid3159342) but not definitive conclusions as this is only one of possible factors that cause high CPU load on Shield.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
