### PR TITLE
[Windows][dxva] fix processor height

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
@@ -98,8 +98,7 @@ bool CRendererDXVA::Configure(const VideoPicture& picture, float fps, unsigned o
 
     // create processor
     m_processor = std::make_unique<DXVA::CProcessorHD>();
-    if (m_processor->PreInit() &&
-        m_processor->Open(m_sourceWidth, m_sourceWidth) &&
+    if (m_processor->PreInit() && m_processor->Open(m_sourceWidth, m_sourceHeight) &&
         m_processor->IsFormatSupported(dxgi_format, support_type))
     {
       return true;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Fixed what looks like a typo in the DXVA processor creation.
Unless there is a reason to pass the width twice for square textures.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Noticed in debug log processor being opened for (1920,1920) which didn't make sense
No reported issue that I know of.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 10, AMD GPU on current driver 31.x
files with h264, h265, vp9 codecs accelerated, in various sizes 4k 1080p 720p DVD and no noticeable issue,

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Reduced memory usage as smaller textures will be allocated.
The code had that typo since 2019 without major issue apparently.
Maybe compatibility with older drivers/hw or small memory devices is improved, or helps with odd uncommon issues.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
