### PR TITLE
AESinkAudioTrack: Restore old RAW behaviour

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -1149,10 +1149,20 @@ void CActiveAESink::SetSilenceTimer()
 {
   if (m_extStreaming)
     m_extSilenceTimeout = XbmcThreads::EndTime<decltype(m_extSilenceTimeout)>::Max();
-  else if (m_extAppFocused)
-    m_extSilenceTimeout = m_silenceTimeOut;
+  else if (m_extAppFocused) // handles no playback/GUI and playback in pause and seek
+  {
+    // only true with AudioTrack RAW + passthrough + TrueHD or EAC3 (DD+)
+    const bool noSilenceOnPause =
+        !m_needIecPack && m_requestedFormat.m_dataFormat == AE_FMT_RAW &&
+        (m_sinkFormat.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD ||
+         m_sinkFormat.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_EAC3);
+
+    m_extSilenceTimeout = (noSilenceOnPause) ? 0ms : m_silenceTimeOut;
+  }
   else
+  {
     m_extSilenceTimeout = 0ms;
+  }
 
   m_extSilenceTimer.Set(m_extSilenceTimeout);
 }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -811,7 +811,10 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t **data, unsigned int frames, 
   if (!IsInitialized())
     return INT_MAX;
 
-  if (m_delay > 1.0)
+  const bool isRawPt = m_passthrough && !m_info.m_wantsIECPassthrough;
+  const double max_delay = isRawPt ? 3.0 : 1.0;
+
+  if (m_delay > max_delay)
   {
     CLog::Log(LOGERROR, "Sink got stuck with large buffer {:f} - reopening", m_delay);
     return INT_MAX;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -319,6 +319,7 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
   m_headPos = 0;
   m_timestampPos = 0;
   m_linearmovingaverage.clear();
+  m_pause_ms = 0.0;
   CLog::Log(LOGDEBUG,
             "CAESinkAUDIOTRACK::Initialize requested: sampleRate {}; format: {}; channels: {}",
             format.m_sampleRate, CAEUtil::DataFormatToStr(format.m_dataFormat),
@@ -758,25 +759,33 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
 
   delay += m_hw_delay;
 
-  const bool rawPt = m_passthrough && !m_info.m_wantsIECPassthrough;
-  if (rawPt)
-  {
-    if (m_at_jni->getPlayState() == CJNIAudioTrack::PLAYSTATE_PAUSED)
-    {
-      delay = m_audiotrackbuffer_sec;
-      if (usesAdvancedLogging)
-      {
-        CLog::Log(LOGINFO, "Fake delay: {} ms", delay * 1000);
-      }
-    }
-  }
-
   if (usesAdvancedLogging)
   {
     CLog::Log(LOGINFO, "Combined Delay: {} ms", delay * 1000);
   }
   if (delay < 0.0)
     delay = 0.0;
+
+  // the RAW hack for simulating pause bursts should not come
+  // into the way of hw delay
+  if (m_pause_ms > 0.0)
+  {
+    double difference = (m_audiotrackbuffer_sec - delay) * 1000;
+    if (usesAdvancedLogging)
+    {
+      CLog::Log(LOGINFO, "Faking Pause-Bursts in Delay - returning smoothed {} ms Original {} ms",
+                m_audiotrackbuffer_sec * 1000, delay * 1000);
+      CLog::Log(LOGINFO, "Difference: {} ms m_pause_ms {}", difference, m_pause_ms);
+    }
+    // buffer not yet reached
+    if (difference > 0.0)
+      delay = m_audiotrackbuffer_sec;
+    else
+    {
+      CLog::Log(LOGINFO, "Resetting pause bursts as buffer level was reached! (2)");
+      m_pause_ms = 0.0;
+    }
+  }
 
   const double d = GetMovingAverageDelay(delay);
 
@@ -919,6 +928,22 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t **data, unsigned int frames, 
     if (m_delay < (m_audiotrackbuffer_sec - (m_format.m_streamInfo.GetDuration() / 1000.0)))
       extra_sleep = 0;
 
+    if (m_pause_ms > 0.0)
+    {
+      extra_sleep = 0;
+      m_pause_ms -= m_format.m_streamInfo.GetDuration();
+      if (m_pause_ms <= 0.0)
+      {
+        m_pause_ms = 0.0;
+        CLog::Log(LOGINFO, "Resetting pause bursts as buffer level was reached! (1)");
+      }
+    }
+    else
+    {
+      if (m_delay > 0.3)
+        extra_sleep *= 2;
+    }
+
     usleep(extra_sleep * 1000);
   }
   else
@@ -946,7 +971,11 @@ void CAESinkAUDIOTRACK::AddPause(unsigned int millis)
   if (m_at_jni->getPlayState() != CJNIAudioTrack::PLAYSTATE_PAUSED)
     m_at_jni->pause();
 
+  // This is a mixture to get it right between
+  // blocking, sleeping roughly and GetDelay smoothing
+  // In short: Shit in, shit out
   usleep(millis * 1000);
+  m_pause_ms += millis;
 }
 
 void CAESinkAUDIOTRACK::Drain()
@@ -966,6 +995,7 @@ void CAESinkAUDIOTRACK::Drain()
   m_timestampPos = 0;
   m_linearmovingaverage.clear();
   m_stampTimer.SetExpired();
+  m_pause_ms = 0.0;
 }
 
 void CAESinkAUDIOTRACK::Register()

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -88,6 +88,7 @@ private:
   bool               m_passthrough;
   double             m_audiotrackbuffer_sec;
   int                m_encoding;
+  double m_pause_ms = 0.0;
   double m_delay = 0.0;
   double m_hw_delay = 0.0;
   CJNIAudioTimestamp m_timestamp;


### PR DESCRIPTION
I debugged this thing with AddPause now for nearly a week. During my endavour I found that AddPause harms more for some formats than it helps: EAC3, TRUEHD.

Other RAW formats are broken on the Packer Level already DTS-HD-MA. It is impossible to revive the stream after seeking as it looks like the Android Packer got a hickup. Sadly I realized this far too late as I tested against DTS-HD-MA half of the time. Therefore every "micro optimization" I have done would need to be done again.

Out of those reasons I decided to go back to the version shipped in Nexus and additionally include @thexai change for simple not pause bursting for TrueHD and EAC3. For DTS-HD-MA this does not help, also cause of the underlaying issue.

During debugging I realized that the sink behaviour can be smoothed quite a bit when blocking when we have enough buffer. This also helps that the Audio Buffer does not shoot crow too fast.