### PR TITLE
[cmake] pipewire: actually set minimum version to 0.3.50

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,7 +204,7 @@ set(optional_deps Alsa
                   MDNS
                   MicroHttpd
                   NFS
-                  Pipewire
+                  Pipewire>=0.3.50
                   Plist
                   PulseAudio
                   Python


### PR DESCRIPTION
Let's actually check the version....

With this PR.

`-DENABLE_PIPEWIRE` not specified:
```
-- Could NOT find Pipewire: Found unsuitable version "0.3.49", but required is at least "0.3.50" (found /usr/lib64/libpipewire-0.3.so)
```

`-DENABLE_PIPEWIRE=ON`:
```
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find Pipewire: Found unsuitable version "0.3.49", but required is
  at least "0.3.50" (found /usr/lib64/libpipewire-0.3.so)
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:598 (_FPHSA_FAILURE_MESSAGE)
  cmake/modules/FindPipewire.cmake:44 (find_package_handle_standard_args)
  cmake/scripts/common/Macros.cmake:370 (find_package)
  cmake/scripts/common/Macros.cmake:421 (find_package_with_ver)
  CMakeLists.txt:219 (core_optional_dep)
```

fixes #22924 and #22932 