### PR TITLE
[Android] Use dolby-vision codec if supported by the device

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -546,7 +546,7 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
                   "Display: {}, MediaCodec: {}",
                   displaySupportsDovi, mediaCodecSupportsDovi);
 
-        if (displaySupportsDovi && mediaCodecSupportsDovi)
+        if (mediaCodecSupportsDovi)
         {
           m_mime = "video/dolby-vision";
           m_formatname = isDvhe ? "amc-dvhe" : "amc-dvh1";


### PR DESCRIPTION
## Description
If the Android device supports the dolby-vision codec, perhaps we should use it for this type of content even if the TV does not support this format.

In tests I have done with my TV that supports HDR, HDR 10+ and HLG but not Dolby and Amazon Fire TV Stick 4K Max:

Before the change this type of content was played with the hevc codec (`OMX.MTK.VIDEO.DECODER.HEVC`) and now it uses the dolby-vision codec (`OMX.MTK.VIDEO.DECODER.DVHE.STN`), although the picture quality is similar in both cases.

Add this PR in case someone wants to test with this or another device.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
