### PR TITLE
[Android] Packaging scripts cleanup

### DIFF
--- a/cmake/scripts/android/Install.cmake
+++ b/cmake/scripts/android/Install.cmake
@@ -1,11 +1,5 @@
 # Android packaging
 
-if(CMAKE_BUILD_TYPE STREQUAL Debug)
-  set(ANDROID_DEBUGGABLE true)
-else()
-  set(ANDROID_DEBUGGABLE false)
-endif()
-
 # Configure files into packaging environment.
 configure_file(${CMAKE_SOURCE_DIR}/tools/android/packaging/Makefile.in
                ${CMAKE_BINARY_DIR}/tools/android/packaging/Makefile @ONLY)

--- a/cmake/scripts/android/Install.cmake
+++ b/cmake/scripts/android/Install.cmake
@@ -137,19 +137,15 @@ foreach(file IN LISTS XBT_FILES install_data)
   add_bundle_file(${CMAKE_BINARY_DIR}/${file} ${datarootdir}/${APP_NAME_LC} ${CMAKE_BINARY_DIR})
 endforeach()
 
+# libdvdnav is currently the only LIBRARY_FILES item remaining for android
 foreach(library IN LISTS LIBRARY_FILES)
   add_bundle_file(${library} ${libdir}/${APP_NAME_LC} ${CMAKE_BINARY_DIR})
 endforeach()
 
-foreach(lib IN LISTS required_dyload dyload_optional ITEMS Shairplay)
-  string(TOUPPER ${lib} lib_up)
-  set(lib_so ${${lib_up}_SONAME})
-  if(lib_so AND EXISTS ${DEPENDS_PATH}/lib/${lib_so})
-    add_bundle_file(${DEPENDS_PATH}/lib/${lib_so} ${libdir} "")
-  endif()
-endforeach()
 add_bundle_file(${ASS_LIBRARY} ${libdir} "")
-add_bundle_file(Shairplay::Shairplay ${libdir} "")
+if(TARGET Shairplay::Shairplay)
+  add_bundle_file(Shairplay::Shairplay ${libdir} "")
+endif()
 
 # Main targets from Makefile.in
 if(CPU MATCHES i686)

--- a/tools/android/packaging/Makefile.in
+++ b/tools/android/packaging/Makefile.in
@@ -6,14 +6,11 @@ BUILD_TYPE_LC:=$(shell echo $(BUILD_TYPE) | tr A-Z a-z)
 OBJS = libshairplay.so \
   libass.so
 
-PLATFORM_OBJS =
 EXCLUDED_ADDONS =
 
 CMAKE_SOURCE_DIR = $(shell cd $(CURDIR)/../../..; pwd)
 APP_PACKAGE_DIR = $(subst .,/,@APP_PACKAGE@)
 COPYDIRS = system addons media
-GCC_VERSION=$(shell $(CC) -dumpversion)
-ZIP=zip
 
 ifeq ($(KODI_ANDROID_STORE_FILE),)
 export KODI_ANDROID_STORE_FILE:=$(HOME)/.android/debug.keystore
@@ -48,7 +45,7 @@ endif
 STLLIB=$(TOOLCHAIN)/sysroot/usr/lib/$(HOST)/libc++_shared.so
 
 SRCLIBS = $(addprefix $(PREFIX)/lib/,$(OBJS))
-DSTLIBS = $(CPU)/lib/lib@APP_NAME_LC@.so $(addprefix $(CPU)/lib/,$(OBJS)) $(addprefix $(CPU)/lib/,$(PLATFORM_OBJS))
+DSTLIBS = $(CPU)/lib/lib@APP_NAME_LC@.so $(addprefix $(CPU)/lib/,$(OBJS))
 libs= $(DSTLIBS)
 
 all: apk

--- a/tools/android/packaging/Makefile.in
+++ b/tools/android/packaging/Makefile.in
@@ -28,19 +28,6 @@ ifeq ($(KODI_ANDROID_KEY_PASSWORD),)
 export KODI_ANDROID_KEY_PASSWORD:=android
 endif
 
-#this fixes a android ndk fuckup where the paths to
-#prebuilt stuff follow different name schemes for
-#arm and x86
-ifeq ($(findstring x86_64,$(CPU)),x86_64)
-  ARCH=x86_64
-else ifeq ($(findstring x86,$(CPU)),x86)
-  ARCH=x86
-else ifeq ($(findstring arm64,$(CPU)),arm64)
-  ARCH=arm64
-else ifeq ($(findstring arm,$(CPU)),arm)
-  ARCH=arm
-endif
-
 # libc++
 STLLIB=$(TOOLCHAIN)/sysroot/usr/lib/$(HOST)/libc++_shared.so
 


### PR DESCRIPTION
## Description
Cleanups on android packaging scripts/cmake

## Motivation and context
Stumbled across some stuff, that isnt used any more.
I could (and personally probably prefer) to squash all this into a single commit, but figure this is a bit easier to follow why things are being removed.

@joseluismarti since you've done a bit of cleanup, mind having a look and giving your opinion.

## How has this been tested?
Build aarch64 apk

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
