### PR TITLE
Implement AdvancedSettings substitution regex.

### DIFF
--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -699,7 +699,7 @@ void CWakeOnAccess::QueueMACDiscoveryForAllRemotes()
   // add from path substitutions ..
   for (const auto& pathPair : advancedSettings->m_pathSubstitutions)
   {
-    CURL url(pathPair.second);
+    CURL url(std::get<1>(pathPair));
     AddHost (url.GetHostName(), hosts);
   }
 

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -11,10 +11,12 @@
 #include "pictures/PictureScalingAlgorithm.h"
 #include "settings/lib/ISettingCallback.h"
 #include "settings/lib/ISettingsHandler.h"
+#include "utils/RegExp.h"
 #include "utils/SortUtils.h"
 
 #include <set>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -218,7 +220,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     std::vector<std::string> m_trailerMatchRegExps;
     SETTINGS_TVSHOWLIST m_tvshowEnumRegExps;
     std::string m_tvshowMultiPartEnumRegExp;
-    typedef std::vector< std::pair<std::string, std::string> > StringMapping;
+    typedef std::vector<std::tuple<std::string, std::string, CRegExp>> StringMapping;
     StringMapping m_pathSubstitutions;
     int m_remoteDelay; ///< \brief number of remote messages to ignore before repeating
     bool m_bScanIRServer;

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -186,18 +186,22 @@ TEST_F(TestURIUtils, GetParentPath)
 TEST_F(TestURIUtils, SubstitutePath)
 {
   std::string from, to, ref, var;
+  CRegExp reg;
 
   from = "C:\\My Videos";
   to = "https://myserver/some%20other%20path";
-  CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_pathSubstitutions.push_back(std::make_pair(from, to));
+  CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_pathSubstitutions.push_back(
+      std::make_tuple(from, to, reg));
 
   from = "/this/path1";
   to = "/some/other/path2";
-  CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_pathSubstitutions.push_back(std::make_pair(from, to));
+  CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_pathSubstitutions.push_back(
+      std::make_tuple(from, to, reg));
 
   from = "davs://otherserver/my%20music%20path";
   to = "D:\\Local Music\\MP3 Collection";
-  CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_pathSubstitutions.push_back(std::make_pair(from, to));
+  CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_pathSubstitutions.push_back(
+      std::make_tuple(from, to, reg));
 
   ref = "https://myserver/some%20other%20path/sub%20dir/movie%20name.avi";
   var = URIUtils::SubstitutePath("C:\\My Videos\\sub dir\\movie name.avi");


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Pretty simple (and powerful) feature that allows users to specify regular expression matches for requested path substitutions. This allows users to still scan using a "local" filesystem, and serve media files from a remote path.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
SMB maxes out at 1.5MB/s.
NFS has a multitude of locking issues.
FileCache is stalled out.

I've gone back to what I know and use HTTP to serve media (where I get line speed). Directory scanning is still an absolute disaster on HTTP, so using SMB for this is very helpful. 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
<advancedsettings version="1.0">
  <cache>
    <memorysize>134217728</memorysize>
    <readfactor>64.0</readfactor>
    <chunksize>1048576</chunksize>
  </cache>
  <samba>
    <statfiles>false</statfiles>  <!-- Set to false to disable smb stat() on files to speed up listings of large directories (over slow links) -->
</samba>
 <pathsubstitution>
  <substitute>
    <from>smb://10.24.96.1/television/</from>
    <to>http://10.24.96.1:69/</to>
    <regex>mkv$|mp4$</regex>
  </substitute>
  <substitute>
    <from>smb://10.24.96.1/films/</from>
    <to>http://10.24.96.1:70/</to>
    <regex>mkv$|mp4$</regex>
  </substitute>
 </pathsubstitution>
</advancedsettings>
```

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

An expanded toolchest for adults.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1184902/224239753-0d98c6cc-b8a0-431a-8ba6-c03bed88be3b.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
