### PR TITLE
[Cmake][android] Add target support to add_bundle_file function

### DIFF
--- a/cmake/scripts/android/Install.cmake
+++ b/cmake/scripts/android/Install.cmake
@@ -112,6 +112,18 @@ function(add_bundle_file file destination relative)
     add_dependencies(bundle_files ${APP_NAME_LC})
   endif()
 
+  if(TARGET ${file})
+    # Add support for IMPORTED lib targets
+    # If we need specific properties from other target types later, we can add them
+    # here with some validity checks
+    get_target_property(imploc_file ${file} IMPORTED_LOCATION)
+    if(imploc_file)
+      set(file ${imploc_file})
+    else()
+      return()
+    endif()
+  endif()
+
   string(REPLACE "${relative}/" "" outfile ${file})
   get_filename_component(file ${file} REALPATH)
   get_filename_component(outdir ${outfile} DIRECTORY)

--- a/cmake/scripts/android/Install.cmake
+++ b/cmake/scripts/android/Install.cmake
@@ -155,7 +155,7 @@ foreach(lib IN LISTS required_dyload dyload_optional ITEMS Shairplay)
   endif()
 endforeach()
 add_bundle_file(${ASS_LIBRARY} ${libdir} "")
-add_bundle_file(${SHAIRPLAY_LIBRARY} ${libdir} "")
+add_bundle_file(Shairplay::Shairplay ${libdir} "")
 
 # Main targets from Makefile.in
 if(CPU MATCHES i686)


### PR DESCRIPTION
## Description
adds support for the add_bundle_file macro to handle a target

## Motivation and context
was looking at the ass stuff for android, and thought that this macro may be more obvious with its current use if the first argument could be a target. Target's are the more "modern" cmake method of passing info around, so i thought, Why not.

## How has this been tested?
Build/Run aarch64 android (initially with an implementation that was for ASS::ASS target, but with the PR to move to a static lib for libass, figure i'll implement this for Shairplay::Shairplay, as it wont be changed to a static lib (duplicate symbols, and not really worth patching, and no upstream movement in shairplay for years)

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
