### PR TITLE
[tools/depends] add asflags as predefined flag option

### DIFF
--- a/tools/depends/Makefile.include.in
+++ b/tools/depends/Makefile.include.in
@@ -69,6 +69,7 @@ OBJDUMP=@OBJDUMP@
 CMAKE=@prefix@/@tool_dir@/bin/cmake -DCMAKE_TOOLCHAIN_FILE=$(PREFIX)/share/Toolchain.cmake -DCMAKE_INSTALL_PREFIX=$(PREFIX)
 CFLAGS=@platform_cflags@ @platform_includes@ -isystem @prefix@/@deps_dir@/include
 LDFLAGS=-L@prefix@/@deps_dir@/lib @platform_ldflags@
+ASFLAGS=@platform_asflags@
 CXXFLAGS=@platform_cxxflags@ @platform_includes@ -isystem @prefix@/@deps_dir@/include
 CPPFLAGS=@platform_cflags@ @platform_includes@ -isystem @prefix@/@deps_dir@/include
 # set configured FFmpeg configure options

--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -342,12 +342,14 @@ case $host in
         if test "x$use_cpu" = "xauto"; then
           use_cpu=$host_cpu
         fi
+        platform_asflags="-DPIC"
         meson_cpu="x86"
       ;;
       x86_64*-linux-android*)
         if test "x$use_cpu" = "xauto"; then
           use_cpu=$host_cpu
         fi
+        platform_asflags="-DPIC"
         meson_cpu="x86_64"
       ;;
       *)
@@ -696,6 +698,7 @@ AC_SUBST(use_tarballs)
 AC_SUBST(target_platform)
 AC_SUBST(use_firmware)
 AC_SUBST(cross_compiling)
+AC_SUBST(platform_asflags)
 AC_SUBST(platform_cflags)
 AC_SUBST(platform_cxxflags)
 AC_SUBST(platform_cflags_release)
@@ -843,6 +846,7 @@ echo -e "cpu:\t\t\t $use_cpu"
 echo -e "host:\t\t $use_host"
 echo -e "CC:\t\t $CC"
 echo -e "CXX:\t\t $CXX"
+echo -e "asflags:\t\t $platform_asflags"
 echo -e "cflags:\t\t $platform_cflags"
 echo -e "cxxflags:\t\t $platform_cxxflags"
 echo -e "ldflags:\t\t $platform_ldflags"

--- a/tools/depends/target/Toolchain.cmake.in
+++ b/tools/depends/target/Toolchain.cmake.in
@@ -95,6 +95,7 @@ if(CORE_SYSTEM_NAME STREQUAL android)
   string(REPLACE ":" ";" SDK_BUILDTOOLS_PATH "@build_tools_path@")
 endif()
 
+set(CMAKE_ASM_NASM_FLAGS "@platform_asflags@")
 set(CMAKE_C_FLAGS "@platform_cflags@ @platform_includes@ -isystem @prefix@/@deps_dir@/include")
 set(CMAKE_CXX_FLAGS "@platform_cxxflags@ @platform_includes@ -isystem @prefix@/@deps_dir@/include")
 set(CMAKE_C_FLAGS_RELEASE "@platform_cflags_release@ @platform_includes@ -isystem @prefix@/@deps_dir@/include")

--- a/tools/depends/target/config.site.in
+++ b/tools/depends/target/config.site.in
@@ -20,6 +20,7 @@ if test "@platform_os@" = "darwin_embedded" ; then
   export CCAS="--tag CC @prefix@/@tool_dir@/bin/gas-preprocessor.pl @CCACHE@ @CC@ -arch @use_cpu@"
 fi
 
+ASFLAGS="@platform_asflags@"
 CFLAGS="@platform_cflags@ @platform_includes@ -isystem @prefix@/@deps_dir@/include $CFLAGS"
 LDFLAGS="-L@prefix@/@deps_dir@/lib @platform_ldflags@ $LDFLAGS"
 CXXFLAGS="@platform_cxxflags@ @platform_includes@ -isystem @prefix@/@deps_dir@/include $CXXFLAGS"

--- a/tools/depends/target/libass/Makefile
+++ b/tools/depends/target/libass/Makefile
@@ -5,10 +5,6 @@ ifeq ($(OS),android)
   # Android API Level 21/22 requires explicit link.
   # This doesnt appear to be required for API Level 23+ (Android 6+)
   export LDFLAGS+= -lstdc++
-  
-  ifeq ($(CPU),i686)
-    export ASFLAGS+= -DPIC=1
-  endif
 endif
 
 # configuration settings


### PR DESCRIPTION
## Description
Add asflag as configured option. Primary use is setting -DPIC for x86/x86_64 android libs (libass/PIL) nasm usage.

## Motivation and context
Resolve at a higher level the need to set -DPIC for nasm usage

## How has this been tested?
@joseluismarti has runtime tested i686 Android SDK 21

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
