### PR TITLE
Add abbreviated month options to shortDateFormats[]

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -38,6 +38,7 @@
 using namespace PVR;
 
 static std::string shortDateFormats[] = {
+    // clang-format off
   // short date formats using "/"
   "DD/MM/YYYY",
   "MM/DD/YYYY",
@@ -53,7 +54,13 @@ static std::string shortDateFormats[] = {
   "DD.M.YYYY",
   "D.M.YYYY",
   "D. M. YYYY",
-  "YYYY.MM.DD"
+  "YYYY.MM.DD",
+  // short date formats with abbreviated month and 2 digit year
+  "D-mmm-YY",
+  "DD-mmm-YY",
+  "D mmm YY",
+  "DD mmm YY",
+    // clang-format on
 };
 
 static std::string longDateFormats[] = {

--- a/xbmc/test/TestDateTime.cpp
+++ b/xbmc/test/TestDateTime.cpp
@@ -475,6 +475,19 @@ TEST_F(TestDateTime, GetAsLocalized)
   EXPECT_EQ(dateTime1.GetAsLocalizedTime(TIME_FORMAT(19)), "12:34:56");
   EXPECT_EQ(dateTime1.GetAsLocalizedTime(TIME_FORMAT(27)), "12:34:56 PM");
 
+  //Test abbreviated month and short year formats
+  CDateTime dateTime3;
+  dateTime3.SetDateTime(1991, 05, 9, 12, 34, 56); //Need a single digit date
+
+  g_langInfo.SetShortDateFormat("DD-mmm-YY");
+  g_langInfo.SetLongDateFormat("ddd, D MMMM YYYY");
+
+  //Actual formatted date
+  //Test short month name and 2 digit year.
+  EXPECT_EQ(dateTime3.GetAsLocalizedDate(false), "09-May-91");
+  //Test short day name and single digit day number.
+  EXPECT_EQ(dateTime3.GetAsLocalizedDate(true), "Thu, 9 May 1991");
+
   // not possible to use these three
   // EXPECT_EQ(dateTime1.GetAsLocalizedTime(TIME_FORMAT(32)), "");
   // EXPECT_EQ(dateTime1.GetAsLocalizedTime(TIME_FORMAT(64)), "");


### PR DESCRIPTION
## Description
Add several short date format options that have abbreviated month and 2 digit years. eg: DD-mmm-YY.
Added options to shortDateFormats[] in LangInfo.cpp.

## Motivation and context
Provide more date formats for users to choose from.
The added date formats were already supported internally.
They could be added via a Region in a langinfo.xml file, however, end users could not select them directly from the Setting GUI.

## How has this been tested?
1) Expected results observed in the GUI.
2) Added automated test to TestDateTime.cpp in the test suite.

## What is the effect on users?
Additional date formats.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
