### PR TITLE
[cmake] FindLibASS only add pkgconfig ldflags for KODI_DEPENDSBUILD

### DIFF
--- a/cmake/modules/FindASS.cmake
+++ b/cmake/modules/FindASS.cmake
@@ -16,27 +16,29 @@
 if(PKG_CONFIG_FOUND)
   pkg_check_modules(PC_ASS libass QUIET)
 
-  # Darwin platforms have lib options like -framework CoreServices. pkgconfig return of
-  # PC_ASS_LDFLAGS splits this into a list -framework;CoreServices, and when passed to linker
-  # This then treats them as individual flags and appends -l to CoreServices. eg -framework;-lCoreServices
-  # This causes failures, as -lCoreServices isnt a lib that can be found.
-  # This just formats the list data to append frameworks (eg "-framework CoreServices")
-  if(PC_ASS_LDFLAGS AND "-framework" IN_LIST PC_ASS_LDFLAGS)
-    set(_framework_command OFF)
-    foreach(flag ${PC_ASS_LDFLAGS})
-      if(flag STREQUAL "-framework")
-        set(_framework_command ON)
-        continue()
-      elseif(_framework_command)
-        list(APPEND ASS_LDFLAGS "-framework ${flag}")
-        set(_framework_command OFF)
-      else()
-        list(APPEND ASS_LDFLAGS ${flag})
-      endif()
-    endforeach()
-    unset(_framework_command)
-  else()
-    set(ASS_LDFLAGS ${PC_ASS_LDFLAGS})
+  if(KODI_DEPENDSBUILD)
+    # Darwin platforms have lib options like -framework CoreServices. pkgconfig return of
+    # PC_ASS_LDFLAGS splits this into a list -framework;CoreServices, and when passed to linker
+    # This then treats them as individual flags and appends -l to CoreServices. eg -framework;-lCoreServices
+    # This causes failures, as -lCoreServices isnt a lib that can be found.
+    # This just formats the list data to append frameworks (eg "-framework CoreServices")
+    if(PC_ASS_LDFLAGS AND "-framework" IN_LIST PC_ASS_LDFLAGS)
+      set(_framework_command OFF)
+      foreach(flag ${PC_ASS_LDFLAGS})
+        if(flag STREQUAL "-framework")
+          set(_framework_command ON)
+          continue()
+        elseif(_framework_command)
+          list(APPEND ASS_LDFLAGS "-framework ${flag}")
+          set(_framework_command OFF)
+        else()
+          list(APPEND ASS_LDFLAGS ${flag})
+        endif()
+      endforeach()
+      unset(_framework_command)
+    else()
+      set(ASS_LDFLAGS ${PC_ASS_LDFLAGS})
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
## Description
Only apply pkgconfig ld libs to KODI_DEPENDSBUILD where we know its a static lib. 

## Motivation and context
This leaves linux to use shared libs without linking other libs.
@neo1973 this should fix the linux issue i imagine.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
