### PR TITLE
[docs][doxygen] Document Skin.SelectBool builtin

### DIFF
--- a/xbmc/interfaces/builtins/SkinBuiltins.cpp
+++ b/xbmc/interfaces/builtins/SkinBuiltins.cpp
@@ -100,7 +100,11 @@ static int SetAddon(const std::vector<std::string>& params)
 
 /*! \brief Select and set a skin bool setting.
  *  \param params The parameters.
- *  \details params[0] = Names of skin settings.
+ *  \details params[0] = Number of a localized string to display as a header in a select dialog
+ *  \details params[1,...] = one or more number|skinbool-setting pairs where number is index of a localized string used as label
+ *  \details and skinbool-setting is a string of the skinbool setting name. The pairs are added to the select dialog list.
+ *  \details If the users confirms a (single) selection label in the select dialog, the paired skinbool is set to true and all others
+ *  \details in the list are set to false. Multi-select is not available.
  */
 static int SelectBool(const std::vector<std::string>& params)
 {
@@ -541,6 +545,18 @@ static int SkinTimerStop(const std::vector<std::string>& params)
 ///     xbmc.addon.audio\, xbmc.addon.image and xbmc.addon.executable.
 ///     @param[in] string[0]             Skin setting to store result in.
 ///     @param[in] type[1\,...]           Add-on types to allow selecting.
+///   }
+///   \table_row2_l{
+///     <b>`Skin.SelectBool(header\, label1|setting1\, label2|setting2\, ...)`</b>
+///     \anchor Skin_SelectBool,
+///     Pops up select dialog to select between multiple skin setting options.
+///     @param[in] header              Localized string to display as dialog select header.
+///     @param[in] pairs               One or more number|skinbool-setting pairs where number is index of a localized string used as label and
+///     skinbool-setting is a string of the skinbool setting name. The pairs are added to the select dialog list.
+///     @details If the users confirms a (single) selection label in the select dialog\, the paired skinbool is set to true and all others
+///     in the list are set to false. Multi-select is not available.</p>
+///     <b>Example:</b></p>
+///     <code>Skin.SelectBool(424\, 31411|RecentWidget\, 31412|RandomWidget\, 31413|InProgressWidget)</code>
 ///   }
 ///   \table_row2_l{
 ///     <b>`Skin.SetBool(setting[\,value])`</b>


### PR DESCRIPTION
## Description
`Skin.SelectBool` was missing in our list of builtin functions on doxygen

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/22886

## How has this been tested?
Generate docs and see:
![image](https://user-images.githubusercontent.com/7375276/224689666-a340df88-af84-4233-97bd-60a286851cc9.png)

