### PR TITLE
[Settings][Screensaver] Add setting to disable screensaver while playing audio

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23434,3 +23434,14 @@ msgstr ""
 msgctxt "#39191"
 msgid "HDR"
 msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#39192"
+msgid "Disable screensaver when playing audio"
+msgstr ""
+
+#. Description of setting with label #39192 "Disable screensaver when playing audio"
+#: system/settings/settings.xml
+msgctxt "#39193"
+msgid "If music is being played, the screensaver will never be activated"
+msgstr ""

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7083,10 +7083,7 @@ msgctxt "#13391"
 msgid "Eject / Load"
 msgstr ""
 
-#: system/settings/settings.xml
-msgctxt "#13392"
-msgid "Use visualisation if playing audio"
-msgstr ""
+#empty string with id 13392
 
 #: xbmc/windows/GUIWindowFileManager.cpp
 msgctxt "#13393"
@@ -19186,11 +19183,7 @@ msgctxt "#36132"
 msgid "Preview the selected screensaver."
 msgstr ""
 
-#. Description of setting with label #13392 "Use visualisation if playing audio"
-#: system/settings/settings.xml
-msgctxt "#36133"
-msgid "If music is being played, the selected visualisation will be started instead of displaying the screensaver."
-msgstr ""
+#empty string with id 36133
 
 #. Description of setting with label #22014 "Use dim if paused during video playback"
 #: system/settings/settings.xml

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -679,6 +679,7 @@ msgid "Free"
 msgstr ""
 
 #: addons/skin.estuary/xml/Includes.xml
+#: system/settings/settings.xml
 msgctxt "#157"
 msgid "Video"
 msgstr ""

--- a/system/settings/darwin_tvos.xml
+++ b/system/settings/darwin_tvos.xml
@@ -7,9 +7,6 @@
         <setting id="screensaver.mode">
           <default></default>
         </setting>
-        <setting id="screensaver.usemusicvisinstead">
-          <default>false</default>
-        </setting>
         <setting id="screensaver.usedimonpause">
           <default>false</default>
         </setting>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3991,6 +3991,15 @@
           </dependencies>
           <control type="toggle" />
         </setting>
+        <setting id="screensaver.disableforaudio" type="boolean" label="39192" help="39193">
+          <level>0</level>
+          <default>true</default>
+          <dependencies>
+            <dependency type="enable" setting="screensaver.mode" operator="!is"></dependency>
+            <dependency type="enable" setting="screensaver.usemusicvisinstead" operator="!is">true</dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
         <setting id="screensaver.usedimonpause" type="boolean" label="22014" help="36134">
           <level>1</level>
           <default>true</default>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3982,38 +3982,40 @@
             <formatlabel>14044</formatlabel>
           </control>
         </setting>
-        <setting id="screensaver.usemusicvisinstead" type="boolean" label="13392" help="36133">
-          <level>0</level>
-          <default>true</default>
-          <dependencies>
-            <dependency type="enable" setting="screensaver.mode" operator="!is"></dependency>
-            <dependency type="enable" setting="musicplayer.visualisation" operator="!is"></dependency>
-          </dependencies>
-          <control type="toggle" />
-        </setting>
-        <setting id="screensaver.disableforaudio" type="boolean" label="39192" help="39193">
-          <level>0</level>
-          <default>true</default>
-          <dependencies>
-            <dependency type="enable" setting="screensaver.mode" operator="!is"></dependency>
-            <dependency type="enable" setting="screensaver.usemusicvisinstead" operator="!is">true</dependency>
-          </dependencies>
-          <control type="toggle" />
-        </setting>
-        <setting id="screensaver.usedimonpause" type="boolean" label="22014" help="36134">
-          <level>1</level>
-          <default>true</default>
-          <dependencies>
-            <dependency type="enable">
-              <and>
-                <condition setting="screensaver.mode" operator="!is">screensaver.xbmc.builtin.dim</condition>
-                <condition setting="screensaver.mode" operator="!is"></condition>
-              </and>
-            </dependency>
-          </dependencies>
-          <control type="toggle" />
-        </setting>
       </group>
+      <group id="2" label="14221">
+          <setting id="screensaver.disableforaudio" type="boolean" label="39192" help="39193">
+            <level>0</level>
+            <default>true</default>
+            <dependencies>
+              <dependency type="enable" setting="screensaver.mode" operator="!is"></dependency>
+            </dependencies>
+            <control type="toggle" />
+          </setting>
+          <setting id="screensaver.usemusicvisinstead" type="boolean" label="13392" help="36133">
+            <level>0</level>
+            <default>true</default>
+            <dependencies>
+              <dependency type="enable" setting="musicplayer.visualisation" operator="!is"></dependency>
+            </dependencies>
+            <control type="toggle" />
+          </setting>
+        </group>
+        <group id="3" label="157">
+          <setting id="screensaver.usedimonpause" type="boolean" label="22014" help="36134">
+            <level>1</level>
+            <default>true</default>
+            <dependencies>
+              <dependency type="enable">
+                <and>
+                  <condition setting="screensaver.mode" operator="!is">screensaver.xbmc.builtin.dim</condition>
+                  <condition setting="screensaver.mode" operator="!is"></condition>
+                </and>
+              </dependency>
+            </dependencies>
+            <control type="toggle" />
+          </setting>
+        </group>
     </category>
     <category id="masterlock" label="12360" help="36395">
       <access>CheckMasterLock</access>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3987,6 +3987,7 @@
           <default>true</default>
           <dependencies>
             <dependency type="enable" setting="screensaver.mode" operator="!is"></dependency>
+            <dependency type="enable" setting="musicplayer.visualisation" operator="!is"></dependency>
           </dependencies>
           <control type="toggle" />
         </setting>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3992,14 +3992,6 @@
             </dependencies>
             <control type="toggle" />
           </setting>
-          <setting id="screensaver.usemusicvisinstead" type="boolean" label="13392" help="36133">
-            <level>0</level>
-            <default>true</default>
-            <dependencies>
-              <dependency type="enable" setting="musicplayer.visualisation" operator="!is"></dependency>
-            </dependencies>
-            <control type="toggle" />
-          </setting>
         </group>
         <group id="3" label="157">
           <setting id="screensaver.usedimonpause" type="boolean" label="22014" help="36134">

--- a/xbmc/application/ApplicationPowerHandling.cpp
+++ b/xbmc/application/ApplicationPowerHandling.cpp
@@ -300,13 +300,10 @@ void CApplicationPowerHandling::CheckScreenSaverAndDPMS()
   if (appPlayer && appPlayer->IsPlayingVideo() && !appPlayer->IsPaused())
     haveIdleActivity = true;
 
-  // Are we playing some music in fullscreen vis?
+  // Are we playing audio and screensaver is disabled globally for audio?
   else if (appPlayer && appPlayer->IsPlayingAudio() &&
-           CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_VISUALISATION &&
-           !CServiceBroker::GetSettingsComponent()
-                ->GetSettings()
-                ->GetString(CSettings::SETTING_MUSICPLAYER_VISUALISATION)
-                .empty())
+           CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+               CSettings::SETTING_SCREENSAVER_DISABLEFORAUDIO))
   {
     haveIdleActivity = true;
   }
@@ -377,20 +374,6 @@ void CApplicationPowerHandling::ActivateScreenSaver(bool forceType /*= false */)
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
   const auto& components = CServiceBroker::GetAppComponents();
   const auto appPlayer = components.GetComponent<CApplicationPlayer>();
-  if (appPlayer && appPlayer->IsPlayingAudio() &&
-      // don't activate screensaver if 'use visualization instead'
-      ((settings->GetBool(CSettings::SETTING_SCREENSAVER_USEMUSICVISINSTEAD) &&
-        !settings->GetString(CSettings::SETTING_MUSICPLAYER_VISUALISATION).empty()) ||
-       // don't activate screensaver if disabled globally for audio
-       (settings->GetBool(CSettings::SETTING_SCREENSAVER_DISABLEFORAUDIO))))
-  {
-    // just activate the visualisation if user toggled the usemusicvisinstead option (and not activated already)
-    if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() != WINDOW_VISUALISATION)
-    {
-      CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_VISUALISATION);
-    }
-    return;
-  }
 
   m_screensaverActive = true;
   CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::GUI, "OnScreensaverActivated");

--- a/xbmc/application/ApplicationPowerHandling.cpp
+++ b/xbmc/application/ApplicationPowerHandling.cpp
@@ -378,10 +378,17 @@ void CApplicationPowerHandling::ActivateScreenSaver(bool forceType /*= false */)
   const auto& components = CServiceBroker::GetAppComponents();
   const auto appPlayer = components.GetComponent<CApplicationPlayer>();
   if (appPlayer && appPlayer->IsPlayingAudio() &&
-      settings->GetBool(CSettings::SETTING_SCREENSAVER_USEMUSICVISINSTEAD) &&
-      !settings->GetString(CSettings::SETTING_MUSICPLAYER_VISUALISATION).empty())
-  { // just activate the visualisation if user toggled the usemusicvisinstead option
-    CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_VISUALISATION);
+      // don't activate screensaver if 'use visualization instead'
+      ((settings->GetBool(CSettings::SETTING_SCREENSAVER_USEMUSICVISINSTEAD) &&
+        !settings->GetString(CSettings::SETTING_MUSICPLAYER_VISUALISATION).empty()) ||
+       // don't activate screensaver if disabled globally for audio
+       (settings->GetBool(CSettings::SETTING_SCREENSAVER_DISABLEFORAUDIO))))
+  {
+    // just activate the visualisation if user toggled the usemusicvisinstead option (and not activated already)
+    if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() != WINDOW_VISUALISATION)
+    {
+      CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_VISUALISATION);
+    }
     return;
   }
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -98,7 +98,6 @@ constexpr const char* CSettings::SETTING_SCREENSAVER_MODE;
 constexpr const char* CSettings::SETTING_SCREENSAVER_SETTINGS;
 constexpr const char* CSettings::SETTING_SCREENSAVER_PREVIEW;
 constexpr const char* CSettings::SETTING_SCREENSAVER_TIME;
-constexpr const char* CSettings::SETTING_SCREENSAVER_USEMUSICVISINSTEAD;
 constexpr const char* CSettings::SETTING_SCREENSAVER_USEDIMONPAUSE;
 constexpr const char* CSettings::SETTING_WINDOW_WIDTH;
 constexpr const char* CSettings::SETTING_WINDOW_HEIGHT;

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -63,7 +63,6 @@ public:
   static constexpr auto SETTING_SCREENSAVER_SETTINGS = "screensaver.settings";
   static constexpr auto SETTING_SCREENSAVER_PREVIEW = "screensaver.preview";
   static constexpr auto SETTING_SCREENSAVER_TIME = "screensaver.time";
-  static constexpr auto SETTING_SCREENSAVER_USEMUSICVISINSTEAD = "screensaver.usemusicvisinstead";
   static constexpr auto SETTING_SCREENSAVER_DISABLEFORAUDIO = "screensaver.disableforaudio";
   static constexpr auto SETTING_SCREENSAVER_USEDIMONPAUSE = "screensaver.usedimonpause";
   static constexpr auto SETTING_WINDOW_WIDTH = "window.width";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -64,6 +64,7 @@ public:
   static constexpr auto SETTING_SCREENSAVER_PREVIEW = "screensaver.preview";
   static constexpr auto SETTING_SCREENSAVER_TIME = "screensaver.time";
   static constexpr auto SETTING_SCREENSAVER_USEMUSICVISINSTEAD = "screensaver.usemusicvisinstead";
+  static constexpr auto SETTING_SCREENSAVER_DISABLEFORAUDIO = "screensaver.disableforaudio";
   static constexpr auto SETTING_SCREENSAVER_USEDIMONPAUSE = "screensaver.usedimonpause";
   static constexpr auto SETTING_WINDOW_WIDTH = "window.width";
   static constexpr auto SETTING_WINDOW_HEIGHT = "window.height";


### PR DESCRIPTION
## Description
After a while investigating https://github.com/xbmc/xbmc/issues/22956 I think I've finally found what the reported issue is. Currently we have an option to disable the screensaver (e.g. dim) if a visualisation add-on is set and we are playing audio -> this works well. However, I doubt most users will realise that the artist slideshow or any image displaying and animating in the background of the music OSD does not count as a visualisation. For such cases, the screensaver will be triggered.
Hence this PR adds a generic setting to disable the screensaver being activated while playing audio and also reorganises the settings a bit better on the screensaver section (splitting between audio and video). Also disables the visualization setting if no visualization addon is set (to reduce confusion amongst users).

@howie-f for review (it's just a couple of ifs), @KarellenX will need wiki if goes in due to the new setting (and improved screen)

## Motivation and context
Closes https://github.com/xbmc/xbmc/issues/22956

## How has this been tested?
Playing audio with the setting enabled and no visualization set, confirming screensaver does not dim. Checking if a visualization is enabled the visualization triggers and is kept activated (without dim) just like before.

## What is the effect on users?
Should now be able to avoid the screensaver if playing audio, globally.
Settings should also be a bit more organised now.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/7375276/224773494-d6251a1b-9731-4422-afef-521131a70e34.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
