### PR TITLE
[Estuary][MusicViz] Fix label height

### DIFF
--- a/addons/skin.estuary/xml/MusicVisualisation.xml
+++ b/addons/skin.estuary/xml/MusicVisualisation.xml
@@ -95,7 +95,7 @@
 					<itemgap>20</itemgap>
 					<control type="label">
 						<width>100</width>
-						<height>40</height>
+						<height>35</height>
 						<label>$INFO[MusicPlayer.Year]</label>
 						<font>font37</font>
 						<shadowcolor>black</shadowcolor>
@@ -105,7 +105,7 @@
 					</control>
 					<control type="label">
 						<width min="0" max="1130">auto</width>
-						<height>40</height>
+						<height>35</height>
 						<label>$INFO[MusicPlayer.Genre]</label>
 						<font>font37</font>
 						<shadowcolor>black</shadowcolor>


### PR DESCRIPTION
## Description
_"that's hard to see"_ bla bla bla _"man, that is 1/2 pixel only"_ bla bla bla _"Shhh, don't tell him about our kerning"_ bla bla bla

## Motivation and context
Pixel perfect kodi :)

## How has this been tested?
Compile and see, check music viz screen while playing audio

## What is the effect on users?
g's will be displayed on their whole pixel-perfect glory in the music viz screen of estuary

## Screenshots (if appropriate):

**Before:**
![image](https://user-images.githubusercontent.com/7375276/224975088-c7f93d10-d0ce-4ed8-b2c5-f8a58543f5ab.png)


**Now:**
![image](https://user-images.githubusercontent.com/7375276/224974649-602f238f-6860-4e71-8e42-f6013fbfcc92.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

