### PR TITLE
[Settings] Remove IsFullScreen complex condition

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2580,7 +2580,7 @@
           <level>1</level>
           <default>false</default>
           <dependencies>
-            <dependency type="enable" on="property" name="IsFullscreen" />
+            <dependency type="enable" setting="videoscreen.screen" operator="!is">-1</dependency> <!-- DM_WINDOWED -->
           </dependencies>
           <control type="toggle" />
         </setting>

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -110,14 +110,6 @@ bool HasSystemSdrPeakLuminance(const std::string& condition,
   return CServiceBroker::GetWinSystem()->HasSystemSdrPeakLuminance();
 }
 
-bool IsFullscreen(const std::string& condition,
-                  const std::string& value,
-                  const SettingConstPtr& setting,
-                  void* data)
-{
-  return CServiceBroker::GetWinSystem()->IsFullScreen();
-}
-
 bool IsHDRDisplay(const std::string& condition,
                   const std::string& value,
                   const SettingConstPtr& setting,
@@ -456,7 +448,6 @@ void CSettingConditions::Initialize()
   m_complexConditions.emplace("hasrumblecontroller", HasRumbleController);
   m_complexConditions.emplace("haspowerofffeature", HasPowerOffFeature);
   m_complexConditions.emplace("hassystemsdrpeakluminance", HasSystemSdrPeakLuminance);
-  m_complexConditions.emplace("isfullscreen", IsFullscreen);
   m_complexConditions.emplace("ishdrdisplay", IsHDRDisplay);
   m_complexConditions.emplace("ismasteruser", IsMasterUser);
   m_complexConditions.emplace("hassubtitlesfontextensions", HasSubtitlesFontExtensions);


### PR DESCRIPTION
## Description
Long story short, the `IsFullScreen` complex condition does not work and settings that depend on this condition misbehave. The issue is that if you make a given setting depend on `IsFullScreen` the condition will always be evaluated while in the process of toggling fullscreen. You'll need to refresh the settings window (e.g. by selecting another page and get back) for the condition to be evaluated correctly. Since we already do the same for other settings (e.g. resolution, fake fullscreen, etc), just reuse the same condition for "blank other displays".

## Motivation and context
Found while working on other stuff (macos native windowing)

## How has this been tested?
Tested on linux by toggling fullscreen/windowed (using `\` shortcut) and checking the "Blank other display" setting does not react accordingly (should be disabled if running windowed).

## What is the effect on users?
Better feedback for settings change

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

