### PR TITLE
[MacOS][NativeWindowing] Programmatically move windows when user changes monitor setting

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2524,6 +2524,9 @@
           <constraints>
             <options>monitors</options>
           </constraints>
+          <dependencies>
+            <dependency type="enable" on="property" name="SupportsScreenMove" />
+          </dependencies>
           <control type="spinner" format="string" delayed="true" />
         </setting>
         <setting id="videoscreen.screen" type="integer" label="240" help="36351">

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2526,6 +2526,7 @@
           </constraints>
           <dependencies>
             <dependency type="enable" on="property" name="SupportsScreenMove" />
+            <dependency type="update" setting="videoscreen.screenmode" />
           </dependencies>
           <control type="spinner" format="string" delayed="true" />
         </setting>

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -303,6 +303,7 @@ bool CDisplaySettings::OnSettingChanging(const std::shared_ptr<const CSetting>& 
   }
   else if (settingId == CSettings::SETTING_VIDEOSCREEN_MONITOR)
   {
+    CServiceBroker::GetWinSystem()->NotifyScreenChangeIntention();
     CServiceBroker::GetWinSystem()->UpdateResolutions();
     RESOLUTION newRes = GetResolutionForScreen();
 

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -110,6 +110,14 @@ bool HasSystemSdrPeakLuminance(const std::string& condition,
   return CServiceBroker::GetWinSystem()->HasSystemSdrPeakLuminance();
 }
 
+bool SupportsScreenMove(const std::string& condition,
+                        const std::string& value,
+                        const SettingConstPtr& setting,
+                        void* data)
+{
+  return CServiceBroker::GetWinSystem()->SupportsScreenMove();
+}
+
 bool IsHDRDisplay(const std::string& condition,
                   const std::string& value,
                   const SettingConstPtr& setting,
@@ -448,6 +456,7 @@ void CSettingConditions::Initialize()
   m_complexConditions.emplace("hasrumblecontroller", HasRumbleController);
   m_complexConditions.emplace("haspowerofffeature", HasPowerOffFeature);
   m_complexConditions.emplace("hassystemsdrpeakluminance", HasSystemSdrPeakLuminance);
+  m_complexConditions.emplace("supportsscreenmove", SupportsScreenMove);
   m_complexConditions.emplace("ishdrdisplay", IsHDRDisplay);
   m_complexConditions.emplace("ismasteruser", IsMasterUser);
   m_complexConditions.emplace("hassubtitlesfontextensions", HasSubtitlesFontExtensions);

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -1196,6 +1196,9 @@ void CSettingsManager::UpdateSettingByDependency(const std::string &settingId, S
         if (settingString->GetOptionsType() == SettingOptionsType::Dynamic)
           settingString->UpdateDynamicOptions();
       }
+      // when a setting depends on another, it might need to refresh its visible/enable status
+      // after been updated. E.g. if it depends on some complex setting condition
+      RefreshVisibilityAndEnableStatus(setting);
       break;
     }
 
@@ -1209,6 +1212,34 @@ void CSettingsManager::UpdateSettingByDependency(const std::string &settingId, S
     case SettingDependencyType::Unknown:
     default:
       break;
+  }
+}
+
+void CSettingsManager::RefreshVisibilityAndEnableStatus(
+    const std::shared_ptr<const CSetting>& setting)
+{
+  bool updateVisibility{false};
+  bool updateEnableStatus{false};
+  for (const auto& dep : setting->GetDependencies())
+  {
+    if (dep.GetType() == SettingDependencyType::Enable)
+    {
+      updateEnableStatus = true;
+    }
+
+    if (dep.GetType() == SettingDependencyType::Visible)
+    {
+      updateVisibility = true;
+    }
+  }
+
+  if (updateVisibility)
+  {
+    OnSettingPropertyChanged(setting, "visible");
+  }
+  if (updateEnableStatus)
+  {
+    OnSettingPropertyChanged(setting, "enabled");
   }
 }
 

--- a/xbmc/settings/lib/SettingsManager.h
+++ b/xbmc/settings/lib/SettingsManager.h
@@ -505,6 +505,16 @@ private:
 
   using SettingMap = std::map<std::string, Setting>;
 
+  /*!
+   * \brief Refresh the visibility and enable status of a given setting
+   *
+   * \details A setting might have its visibility/enable status bound to complex conditions and, at the same time, depend
+   * on other settings. When those settings change, the visibility/enable status need to be refreshed (i.e. the complex condition must be re-evaluated)
+   *
+   * \param setting Setting object
+  */
+  void RefreshVisibilityAndEnableStatus(const std::shared_ptr<const CSetting>& setting);
+
   void ResolveSettingDependencies(const std::shared_ptr<CSetting>& setting);
   void ResolveSettingDependencies(const Setting& setting);
 

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -125,6 +125,12 @@ public:
   unsigned int GetHeight() { return m_nHeight; }
   virtual bool CanDoWindowed() { return true; }
   bool IsFullScreen() { return m_bFullScreen; }
+
+  /*! \brief Check if the windowing system supports moving windows across screens
+    \return true if the windowing system supports moving windows across screens, false otherwise
+  */
+  virtual bool SupportsScreenMove() { return true; }
+
   virtual void UpdateResolutions();
   void SetWindowResolution(int width, int height);
   std::vector<RESOLUTION_WHR> ScreenResolutions(float refreshrate);

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -109,6 +109,12 @@ public:
   // notifications
   virtual void OnMove(int x, int y) {}
 
+  /**
+   * \brief Used to signal the windowing system about the intention of the user to change the main display
+   * \details triggered, for example, when the user manually changes the monitor setting
+  */
+  virtual void NotifyScreenChangeIntention() {}
+
   // OS System screensaver
   /**
    * Get OS screen saver inhibit implementation if available

--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -64,6 +64,12 @@ public:
   */
   bool SupportsScreenMove() override;
 
+  /**
+   * \brief Used to signal the windowing system about the intention of the user to change the main display
+   * \details triggered, for example, when the user manually changes the monitor setting
+  */
+  void NotifyScreenChangeIntention() override;
+
   void Register(IDispResource* resource) override;
   void Unregister(IDispResource* resource) override;
 

--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -59,6 +59,11 @@ public:
 
   std::string GetClipboardText() override;
 
+  /*! \brief Check if the windowing system supports moving windows across screens
+   *  \return true if the windowing system supports moving windows across screens, false otherwise
+  */
+  bool SupportsScreenMove() override;
+
   void Register(IDispResource* resource) override;
   void Unregister(IDispResource* resource) override;
 

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1279,6 +1279,35 @@ void CWinSystemOSX::WindowChangedScreen()
   }
 }
 
+void CWinSystemOSX::NotifyScreenChangeIntention()
+{
+  if (!SupportsScreenMove())
+  {
+    return;
+  }
+
+  // find the future displayId and the screen object
+  const NSUInteger dispIdx =
+      GetDisplayIndex(CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(
+          CSettings::SETTING_VIDEOSCREEN_MONITOR));
+  NSScreen* screen = nil;
+  if (dispIdx < NSScreen.screens.count)
+  {
+    screen = [NSScreen.screens objectAtIndex:dispIdx];
+  }
+  // move the window to the center of the new screen
+  if (dispIdx != m_lastDisplayNr && screen)
+  {
+    NSPoint windowPos =
+        NSMakePoint(screen.frame.origin.x + screen.frame.size.width / 2 - m_nWidth / 2,
+                    screen.frame.origin.y + screen.frame.size.height / 2 - m_nHeight / 2);
+    dispatch_sync(dispatch_get_main_queue(), ^{
+      [m_appWindow setFrameOrigin:windowPos];
+    });
+    m_lastDisplayNr = dispIdx;
+  }
+}
+
 CGLContextObj CWinSystemOSX::GetCGLContextObj()
 {
   __block CGLContextObj cglcontex = nullptr;

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1380,3 +1380,9 @@ std::string CWinSystemOSX::GetClipboardText()
 void CWinSystemOSX::ShowOSMouse(bool show)
 {
 }
+
+bool CWinSystemOSX::SupportsScreenMove()
+{
+  // macOS doesn't allow programatically moving windows across screens if the window is fullscreen
+  return !m_bFullScreen;
+}


### PR DESCRIPTION
## Description
This continues the endeavour to improve macOS native windowing and its UX by bringing a few improvements also for settings and windowing systems in general.

When a user changes the monitor setting manually, the window should be moved to the selected screen. MacOS doesn't allow moving windows when running on fullscreen so, a new `SupportsScreenMove` complex condition was added to settings that ends up calling the respective windowing implementation for verification. With this, I've found another bug where the visibility (and/or enable status) of settings that depend on complex conditions was not being updated

Hence, this PR:
- Disables the monitor setting if running fullscreen on macOS (nativewindowing)
- Moves kodi to the proper screen when the user changes the setting in windowed mode

**Windowed (window will be moved if another screen is selected):**
<img width="1466" alt="image" src="https://user-images.githubusercontent.com/7375276/225294404-29ffc1dd-d02b-41b3-846e-b9276b3176a9.png">

**Fullscreen (setting disabled)**
<img width="1470" alt="image" src="https://user-images.githubusercontent.com/7375276/225294496-4d8fa31b-1674-4983-9648-f8006660314f.png">

## Motivation and context
Improve UX for native windowing on macos

## How has this been tested?
Runtime tested on macos (apple silicon) with native windowing

## What is the effect on users?
Better immediate feedback to settings change

