### PR TITLE
[Android] Remove OBB expansion files

### DIFF
--- a/cmake/scripts/android/Install.cmake
+++ b/cmake/scripts/android/Install.cmake
@@ -150,7 +150,7 @@ endif()
 if(CPU MATCHES i686)
   set(CPU x86)
 endif()
-foreach(target apk obb apk-obb apk-clean)
+foreach(target apk apk-clean)
   add_custom_target(${target}
       COMMAND env PATH=${NATIVEPREFIX}/bin:$ENV{PATH} ${CMAKE_MAKE_PROGRAM} -j1
               -C ${CMAKE_BINARY_DIR}/tools/android/packaging

--- a/tools/android/packaging/Makefile.in
+++ b/tools/android/packaging/Makefile.in
@@ -38,10 +38,6 @@ all: apk
 
 apk: apk-clean sharedapk package
 
-obb: apk-clean sharedobb
-
-apk-obb: apk-clean sharedobb package
-
 xbmc/assets:
 	mkdir -p xbmc/assets
 
@@ -57,11 +53,6 @@ shared:
 
 sharedapk: shared | xbmc/assets
 	cp -rfp assets/* ./xbmc/assets
-
-sharedobb: shared
-	rm -f $(CMAKE_SOURCE_DIR)/main.@APP_NAME_LC@.obb
-	$(ZIP) -9 -q -r $(CMAKE_SOURCE_DIR)/main.@APP_NAME_LC@.obb assets
-	@echo "$(CMAKE_SOURCE_DIR)/main.@APP_NAME_LC@.obb created"
 
 python: | xbmc/assets
 	mkdir -p xbmc/assets/python@PYTHON_VERSION@/lib/
@@ -129,5 +120,5 @@ apk-clean:
 	rm -f xbmc/res/drawable-xxxhdpi/splash.*
 	rm -rf assets
 
-.PHONY: force libs assets python sharedapk sharedobb res package
+.PHONY: force libs assets python sharedapk res package
 

--- a/tools/android/packaging/xbmc/src/Splash.java.in
+++ b/tools/android/packaging/xbmc/src/Splash.java.in
@@ -39,8 +39,6 @@ import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.System;
-import java.net.HttpURLConnection;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -67,8 +65,6 @@ public class Splash extends Activity
   private static final int CheckingPermissionsInfo = 11;
   private static final int CheckExternalStorage = 12;
   private static final int RecordAudioPermission = 13;
-  private static final int DownloadingObb = 90;
-  private static final int DownloadObbDone = 91;
   private static final int StartingXBMC = 99;
 
   private static final String TAG = "@APP_NAME@";
@@ -180,11 +176,6 @@ public class Splash extends Activity
           mSplash.mTextView.setText("Clearing cache...");
           mSplash.mProgress.setVisibility(View.INVISIBLE);
           break;
-        case DownloadingObb:
-          break;
-        case DownloadObbDone:
-          new FillCache(mSplash).execute();
-          break;
         case Caching:
           if (!mCachingDone)
             new FillCache(mSplash).execute();
@@ -251,136 +242,6 @@ public class Splash extends Activity
   }
 
   private StateMachine mStateMachine = new StateMachine(this);
-
-  private class DownloadObb extends AsyncTask<String, Integer, Integer>
-  {
-    private Splash mSplash = null;
-    private int mProgressStatus = 0;
-
-    public DownloadObb(Splash splash)
-    {
-      this.mSplash = splash;
-    }
-
-    @Override
-    protected Integer doInBackground(String... sUrl)
-    {
-      InputStream input = null;
-      OutputStream output = null;
-      HttpURLConnection connection = null;
-
-      String src = sUrl[0];
-      String dest = sUrl[1];
-      File fObb = new File(dest);
-
-      Log.d(TAG, "Downloading " + src + " to " + dest);
-
-      if (!fObb.getParentFile().exists() && !fObb.getParentFile().mkdirs())
-      {
-        Log.e(TAG, "Error creating directory " + fObb.getParentFile().getAbsolutePath());
-        return -1;
-      }
-
-      int ret = 0;
-      try
-      {
-        URL url = new URL(src);
-        connection = (HttpURLConnection) url.openConnection();
-        connection.connect();
-
-        // expect HTTP 200 OK, so we don't mistakenly save error report
-        // instead of the file
-        if (connection.getResponseCode() != HttpURLConnection.HTTP_OK)
-        {
-          return -1;
-        }
-
-        // this will be useful to display download percentage
-        // might be -1: server did not report the length
-        int fileLength = connection.getContentLength();
-
-        // download the file
-        input = connection.getInputStream();
-        output = new FileOutputStream(dest);
-
-        byte data[] = new byte[4096];
-        long total = 0;
-        int count;
-        mProgress.setProgress(0);
-        mProgress.setMax(fileLength);
-        while ((count = input.read(data)) != -1)
-        {
-          // allow canceling with back button
-          if (isCancelled())
-          {
-            ret = -1;
-            break;
-          }
-          total += count;
-          // publishing the progress....
-          if (fileLength > 0) // only if total length is known
-            publishProgress((int) total);
-          output.write(data, 0, count);
-        }
-      }
-      catch (Exception e)
-      {
-        return -1;
-      }
-      finally
-      {
-        try
-        {
-          if (output != null)
-            output.close();
-          if (input != null)
-            input.close();
-        }
-        catch (IOException ignored)
-        {
-        }
-
-        if (connection != null)
-          connection.disconnect();
-      }
-      if (ret == 0)
-        mState = DownloadObbDone;
-      else
-        fObb.delete();
-
-      publishProgress(0);
-      return ret;
-    }
-
-    @Override
-    protected void onProgressUpdate(Integer... values)
-    {
-      switch (mState)
-      {
-        case DownloadingObb:
-          mSplash.mTextView.setText("Downloading OBB...");
-          mSplash.mProgress.setVisibility(View.VISIBLE);
-          mSplash.mProgress.setProgress(values[0]);
-          break;
-        case DownloadObbDone:
-          mSplash.mProgress.setVisibility(View.INVISIBLE);
-          break;
-      }
-    }
-
-    @Override
-    protected void onPostExecute(Integer result)
-    {
-      super.onPostExecute(result);
-      if (result < 0)
-      {
-        mState = InError;
-        mErrorMsg = "Cannot download obb.";
-      }
-
-      mStateMachine.sendEmptyMessage(mState);
-    }
-  }
 
   private class FillCache extends AsyncTask<Void, Integer, Integer>
   {
@@ -651,32 +512,6 @@ public class Splash extends Activity
 
     sPackagePath = getPackageResourcePath();
     fPackagePath = new File(sPackagePath);
-    String obbfn = "";
-    if (fPackagePath.length() < 50 * 1024 * 1024)
-    {
-      sPackagePath = XBMCProperties.getStringProperty("@APP_NAME_LC@.obb", "");
-      if (sPackagePath.equals(""))
-      {
-        try
-        {
-          obbfn = "main." + getPackageManager().getPackageInfo(getPackageName(), 0).versionCode + "." + getPackageName() + ".obb";
-          sPackagePath = Environment.getExternalStorageDirectory()
-                  + "/Android/obb/" + getPackageName() + "/" + obbfn;
-        }
-        catch (Exception e)
-        {
-        }
-      }
-
-      fPackagePath = new File(sPackagePath);
-      if (fPackagePath.length() < 10 * 1024 * 1024)
-        fPackagePath.delete();  // borked download
-      if (!fPackagePath.exists())
-      {
-        mState = DownloadingObb;
-        new DownloadObb(this).execute("http://mirrors.@APP_NAME_LC@.tv/releases/android/obb/" + obbfn, sPackagePath);
-      }
-    }
   }
 
   private boolean ParseCpuFeature()
@@ -982,7 +817,7 @@ public class Splash extends Activity
 
         SetupEnvironment();
 
-        if ((mState != DownloadingObb && mState != InError) && fXbmcHome.exists() && fXbmcHome.lastModified() >= fPackagePath.lastModified() && !mInstallLibs)
+        if (mState != InError && fXbmcHome.exists() && fXbmcHome.lastModified() >= fPackagePath.lastModified() && !mInstallLibs)
         {
           mState = CachingDone;
           mCachingDone = true;
@@ -990,7 +825,7 @@ public class Splash extends Activity
       }
     }
 
-    if ((mState != DownloadingObb && mState != InError) && mCachingDone && mExternalStorageChecked && mPermissionOK)
+    if (mState != InError && mCachingDone && mExternalStorageChecked && mPermissionOK)
     {
       startXBMC();
       return;
@@ -1000,7 +835,7 @@ public class Splash extends Activity
     mProgress = (ProgressBar) findViewById(R.id.progressBar1);
     mTextView = (TextView) findViewById(R.id.textView1);
 
-    if (mState == DownloadingObb || mState == InError || mState == CheckingPermissionsInfo)
+    if (mState == InError || mState == CheckingPermissionsInfo)
     {
       mStateMachine.sendEmptyMessage(mState);
       return;

--- a/tools/buildsteps/android-arm64-v8a/package
+++ b/tools/buildsteps/android-arm64-v8a/package
@@ -2,11 +2,7 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=android
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "x$BUILD_OBB" == "xtrue" ]; then
-  TARGET=apk-obb
-else
-  TARGET=apk
-fi
+TARGET=apk
 
 cd $WORKSPACE/build;make -j$BUILDTHREADS $TARGET
 
@@ -16,7 +12,3 @@ cd $WORKSPACE
 #e.x. xbmc-20130314-8c2fb31-Frodo-arm64-v8a.apk
 UPLOAD_FILENAME="kodi-$(getBuildRevDateStr)-arm64-v8a"
 mv kodiapp-arm64-v8a-*.apk $UPLOAD_FILENAME.apk
-if [ -f *.obb ]
-then
-  mv *.obb $UPLOAD_FILENAME.obb
-fi

--- a/tools/buildsteps/android-x86_64/package
+++ b/tools/buildsteps/android-x86_64/package
@@ -2,11 +2,7 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=android
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "x$BUILD_OBB" == "xtrue" ]; then
-  TARGET=apk-obb
-else
-  TARGET=apk
-fi
+TARGET=apk
 
 cd $WORKSPACE/build;make -j$BUILDTHREADS $TARGET
 
@@ -16,7 +12,3 @@ cd $WORKSPACE
 #e.x. xbmc-20130314-8c2fb31-Frodo-x86_64.apk
 UPLOAD_FILENAME="kodi-$(getBuildRevDateStr)-x86_64"
 mv kodiapp-x86_64-*.apk $UPLOAD_FILENAME.apk
-if [ -f *.obb ]
-then
-  mv *.obb $UPLOAD_FILENAME.obb
-fi

--- a/tools/buildsteps/android/package
+++ b/tools/buildsteps/android/package
@@ -2,11 +2,7 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=android
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "x$BUILD_OBB" == "xtrue" ]; then
-  TARGET=apk-obb
-else
-  TARGET=apk
-fi
+TARGET=apk
 
 cd $WORKSPACE/build;make -j$BUILDTHREADS $TARGET
 
@@ -16,7 +12,3 @@ cd $WORKSPACE
 #e.x. xbmc-20130314-8c2fb31-Frodo-armeabi-v7a.apk
 UPLOAD_FILENAME="kodi-$(getBuildRevDateStr)-armeabi-v7a"
 mv kodiapp-armeabi-*.apk $UPLOAD_FILENAME.apk
-if [ -f *.obb ]
-then
-  mv *.obb $UPLOAD_FILENAME.obb
-fi

--- a/tools/buildsteps/androidx86/package
+++ b/tools/buildsteps/androidx86/package
@@ -2,11 +2,7 @@ WORKSPACE=${WORKSPACE:-$( cd $(dirname $0)/../../.. ; pwd -P )}
 XBMC_PLATFORM_DIR=android
 . $WORKSPACE/tools/buildsteps/defaultenv
 
-if [ "x$BUILD_OBB" == "xtrue" ]; then
-  TARGET=apk-obb
-else
-  TARGET=apk
-fi
+TARGET=apk
 
 cd $WORKSPACE/build;make -j$BUILDTHREADS $TARGET
 
@@ -16,7 +12,3 @@ cd $WORKSPACE
 #e.x. xbmc-20130314-8c2fb31-Frodo-x86.apk
 UPLOAD_FILENAME="kodi-$(getBuildRevDateStr)-x86"
 mv kodiapp-x86-*.apk $UPLOAD_FILENAME.apk
-if [ -f *.obb ]
-then
-  mv *.obb $UPLOAD_FILENAME.obb
-fi


### PR DESCRIPTION
## Description
These files are used as a workaround for the 100MB app size limit in the Play Store. If the app exceeds 100 MB, we will have to split the output package into the main part (APK) and the expansion file (OBB).

Kodi has not used this way of distributing the app for a long time and there is no problem with the size of the APK.

I propose to clean up and remove the code that builds these OBB files.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
