### PR TITLE
[FileSystem] Fix cache for WebDAV

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -1048,7 +1048,7 @@ bool URIUtils::IsStreamedFilesystem(const std::string& strPath)
   if (url.IsProtocol("stack"))
     return IsStreamedFilesystem(CStackDirectory::GetFirstStackedFile(strPath));
 
-  if (IsUPnP(strPath) || IsFTP(strPath) || IsHTTP(strPath, true))
+  if (IsUPnP(strPath) || IsFTP(strPath) || IsHTTP(strPath, true) || IsDAV(strPath))
     return true;
 
   //! @todo sftp/ssh special case has to be handled by vfs addon

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -298,10 +298,19 @@ TEST_F(TestURIUtils, IsInRAR)
 
 TEST_F(TestURIUtils, IsInternetStream)
 {
-  CURL url1("http://path/to/file");
-  CURL url2("https://path/to/file");
-  EXPECT_TRUE(URIUtils::IsInternetStream(url1));
-  EXPECT_TRUE(URIUtils::IsInternetStream(url2));
+  EXPECT_TRUE(URIUtils::IsInternetStream("http://path/to/file"));
+  EXPECT_TRUE(URIUtils::IsInternetStream("https://path/to/file"));
+  EXPECT_FALSE(URIUtils::IsInternetStream("ftp://path/to/file"));
+  EXPECT_FALSE(URIUtils::IsInternetStream("ftps://path/to/file"));
+  EXPECT_FALSE(URIUtils::IsInternetStream("dav://path/to/file"));
+  EXPECT_FALSE(URIUtils::IsInternetStream("davs://path/to/file"));
+
+  EXPECT_TRUE(URIUtils::IsInternetStream("http://path/to/file", true));
+  EXPECT_TRUE(URIUtils::IsInternetStream("https://path/to/file", true));
+  EXPECT_TRUE(URIUtils::IsInternetStream("ftp://path/to/file", true));
+  EXPECT_TRUE(URIUtils::IsInternetStream("ftps://path/to/file", true));
+  EXPECT_TRUE(URIUtils::IsInternetStream("dav://path/to/file", true));
+  EXPECT_TRUE(URIUtils::IsInternetStream("davs://path/to/file", true));
 }
 
 TEST_F(TestURIUtils, IsInZIP)


### PR DESCRIPTION
## Description
Fix video cache for WebDAV filesystem.
Update `URIUtils::IsStreamedFilesystem()` to return true for WebDAV protocol.

## Motivation and context
Video cache for WebDAV is broken in all buffer mode. As described in the [wiki](https://kodi.wiki/view/HOW-TO:Modify_the_video_cache), WebDAV is Internet stream and cache should be enabled if buffer mode is `CACHE_BUFFER_MODE_INTERNET`.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
Fix video cache for WebDAV filesystem.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
