### PR TITLE
[skin, gui] Look for <fontset> definitions in xml files in /fonts directory

### DIFF
--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -15,6 +15,7 @@
 #include "addons/FontResource.h"
 #include "addons/Skin.h"
 #include "addons/addoninfo/AddonType.h"
+#include "filesystem/SpecialProtocol.h"
 #include "windowing/GraphicContext.h"
 
 #include <mutex>
@@ -42,10 +43,7 @@
 #include <algorithm>
 #include <set>
 
-#ifdef TARGET_POSIX
-#include "filesystem/SpecialProtocol.h"
-#endif
-
+using namespace XFILE;
 using namespace ADDON;
 
 namespace
@@ -420,50 +418,69 @@ void GUIFontManager::Clear()
 #endif
 }
 
+bool GUIFontManager::LoadFontsFromFile(const std::string& fontsetFilePath,
+                                       const std::string& fontSet,
+                                       std::string& firstFontset)
+{
+  CXBMCTinyXML xmlDoc;
+  if (LoadXMLData(fontsetFilePath, xmlDoc))
+  {
+    TiXmlElement* rootElement = xmlDoc.RootElement();
+    g_SkinInfo->ResolveIncludes(rootElement);
+    const TiXmlElement* fontsetElement = rootElement->FirstChildElement("fontset");
+    while (fontsetElement)
+    {
+      const char* idAttr = fontsetElement->Attribute("id");
+      if (idAttr)
+      {
+        // Take note of the first fontset available in case we can't load the fontset requested
+        if (firstFontset.empty())
+          firstFontset = idAttr;
+
+        if (StringUtils::EqualsNoCase(fontSet, idAttr))
+        {
+          // Found the requested fontset, so load the fonts and return
+          CLog::LogF(LOGINFO, "Loading <fontset> with name '{}' from '{}'", fontSet,
+                     fontsetFilePath);
+          LoadFonts(fontsetElement->FirstChild("font"));
+          return true;
+        }
+      }
+      fontsetElement = fontsetElement->NextSiblingElement("fontset");
+    }
+  }
+  return false;
+}
+
 void GUIFontManager::LoadFonts(const std::string& fontSet)
 {
-  // Get the file to load fonts from:
-  const std::string filePath = g_SkinInfo->GetSkinPath("Font.xml", &m_skinResolution);
-  CLog::LogF(LOGINFO, "Loading fonts from '{}'", filePath);
-
-  CXBMCTinyXML xmlDoc;
-  if (!LoadXMLData(filePath, xmlDoc))
+  std::string firstFontset;
+  // Try to load the fontset from Font.xml
+  const std::string fontsetFilePath = g_SkinInfo->GetSkinPath("Font.xml", &m_skinResolution);
+  if (LoadFontsFromFile(fontsetFilePath, fontSet, firstFontset))
     return;
 
-  TiXmlElement* pRootElement = xmlDoc.RootElement();
-  // Resolve includes in Font.xml
-  g_SkinInfo->ResolveIncludes(pRootElement);
-  // take note of the first font available in case we can't load the one specified
-  std::string firstFont;
-  const TiXmlElement* pChild = pRootElement->FirstChildElement("fontset");
-  while (pChild)
-  {
-    const char* idAttr = pChild->Attribute("id");
-    if (idAttr)
-    {
-      if (firstFont.empty())
-        firstFont = idAttr;
+  // If we got here, then the requested fontset was not found in the skin's Font.xml file
+  // Look at additional fontsets that are defined in .xml files in the skin's fonts directory
+  CFileItemList xmlFileItems;
+  CDirectory::GetDirectory(CSpecialProtocol::TranslatePath("special://skin/fonts"), xmlFileItems,
+                           ".xml", DIR_FLAG_BYPASS_CACHE);
+  for (int i = 0; i < xmlFileItems.Size(); i++)
+    if (LoadFontsFromFile(xmlFileItems[i]->GetPath(), fontSet, firstFontset))
+      return;
 
-      if (StringUtils::EqualsNoCase(fontSet, idAttr))
-      {
-        LoadFonts(pChild->FirstChild("font"));
-        return;
-      }
-    }
-    pChild = pChild->NextSiblingElement("fontset");
-  }
-
-  // no fontset was loaded, try the first
-  if (!firstFont.empty())
+  // Requested fontset was not found, try the first
+  if (!firstFontset.empty())
   {
-    CLog::Log(LOGWARNING,
-              "GUIFontManager::{}: File doesn't have <fontset> with name '{}', defaulting to first "
-              "fontset",
-              __func__, fontSet);
-    LoadFonts(firstFont);
+    CLog::LogF(LOGWARNING,
+               "Fontset with name '{}' was not found, "
+               "defaulting to first fontset '{}' ",
+               fontSet, firstFontset);
+    LoadFonts(firstFontset);
   }
   else
-    CLog::LogF(LOGERROR, "File '{}' doesn't have a valid <fontset>", filePath);
+    CLog::LogF(LOGERROR, "No valid <fontset> found in '{}' or in xml files in fonts directory",
+               fontsetFilePath);
 }
 
 void GUIFontManager::LoadFonts(const TiXmlNode* fontNode)

--- a/xbmc/guilib/GUIFontManager.h
+++ b/xbmc/guilib/GUIFontManager.h
@@ -127,6 +127,9 @@ protected:
 
 private:
   void LoadUserFonts();
+  bool LoadFontsFromFile(const std::string& fontsetFilePath,
+                         const std::string& fontSet,
+                         std::string& firstFontset);
 
   mutable CCriticalSection m_critSection;
   std::vector<FontMetadata> m_userFontsCache;


### PR DESCRIPTION
Modified SettingOptionsSkinFontsFiller in addons/Skin.cpp to get the names of available fontsets from any xml files in the skin's /fonts directory, along with from the Font.xml file. Modified LoadFonts in guilib/GUIFontManager to look for fontset definitions from any xml file in the skin's /fonts directory along with from the Font.xml file.

## Description
<!--- Describe your change in detail here. -->
This change allows new fontsets to be defined without having to edit a skin's Font.xml file.
New fontsets can be defined by adding xml files to the skin's /fonts directory. 

When searching for available fontsets to display for selection in

Settings->Interface->Skin->Fonts

the code will now also look in any xml files in the skin's /fonts directory for the names of 
available fontsets. The names of the fontsets included for selection will correspond to any &lt;fontset&gt; definitions found in the xml files.

When searching for fontset definitions to load, the code will now also look in any xml files in
the skin's /fonts directory and load the fonts defined by the selected fontset.

The new xml files must follow the same xml format as the existing Font.xml file. 


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
When creating new themes for a skin it is possible to define new graphic elements by providing
a file in the skin's /media directory, for example media/ThemeName.xbt. 

It is also possible to define new color definitions for your
theme by providing a file in the skin's /colors directory, for example colors/ThemeName.xml. 

Currently, if you want to define a fontset definition for your theme, you must edit the skin's Font.xml file, so typically a theme creator will not go to the trouble of providing theme specific fonts. 

With this change, a theme creator will be able to provide a fontset definition by providing a file in the skin's /fonts directory, for example fonts/ThemeName.xml. The theme creator must also provide the specific font files needed by the defined fontset. 

So, for example, a complete theme for a skin could now be provided in a zip file with content like:
 - media/ThemeName.xbt
 - colors/ThemeName.xml
 - fonts/ThemeName.xml
 - fonts/ThemeNameFont1.ttf
 - fonts/ThemeNameFont2.ttf
 - ...

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Windows 10 with xbmc/master. 

Used the metropolis skin to test theme changes.

1. Added ThemeName.xml file to Kodi/addons/skin.metropolis/fonts. Contents of fonts/ThemeName.xml had a &lt;fontset&gt; definition named ThemeName. The &lt;fontset&gt; included &lt;font&gt; definitions that required 
new ttf files. The new ttf files were added to the /fonts directory.
2. From Settings->Interface->Skin->Fonts made sure that 'ThemeName' was now one of the available options.
3. Selected 'ThemeName' from the selection list and made sure that the correct fonts were loaded.
4. Made sure that &lt;include&gt; directives work in the xml files that are in the /fonts directory.
5. Tested error paths
	- Bad xml file in /fonts does not cause errors in looking for or loading fonts.
	- Deleting or corrupting xml file in /fonts directory after fontset is selected results in default fontset being used.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Made it easier to customize kodi by allowing new fontsets to be defined in separate files.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

## Notes
The Skin page in the wiki would need to be updated:
[https://kodi.wiki/view/Settings/Interface/Skin](https://kodi.wiki/view/Settings/Interface/Skin)

The section on 'Theme' and 'Fonts' would need some new content. 

For the 'Theme' section, add the line:

If a fontset matching the theme name is available, this will also be applied when changing themes.

For the 'Fonts' section, add the line:

Adding an xml file to the skin's Font folder will enable you to add to the fontsets available to the skin. The new xml file must follow the same format as the skin's Font.xml file.