### PR TITLE
Fix/improve dirty regions on GBM/Wayland/X11 (EGL)

### DIFF
--- a/xbmc/guilib/DirtyRegionTracker.cpp
+++ b/xbmc/guilib/DirtyRegionTracker.cpp
@@ -18,9 +18,8 @@
 #include <algorithm>
 #include <stdio.h>
 
-CDirtyRegionTracker::CDirtyRegionTracker(int buffering)
+CDirtyRegionTracker::CDirtyRegionTracker()
 {
-  m_buffering = buffering;
   m_solver = NULL;
 }
 
@@ -76,11 +75,10 @@ CDirtyRegionList CDirtyRegionTracker::GetDirtyRegions()
   return output;
 }
 
-void CDirtyRegionTracker::CleanMarkedRegions()
+void CDirtyRegionTracker::CleanMarkedRegions(int bufferAge)
 {
-  int buffering = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiVisualizeDirtyRegions ? 20 : m_buffering;
-  m_markedRegions.erase(
-      std::remove_if(m_markedRegions.begin(), m_markedRegions.end(),
-                     [buffering](CDirtyRegion& r) { return r.UpdateAge() >= buffering; }),
-      m_markedRegions.end());
+  m_markedRegions.erase(std::remove_if(m_markedRegions.begin(), m_markedRegions.end(),
+                                       [bufferAge](CDirtyRegion& r)
+                                       { return r.UpdateAge() > bufferAge; }),
+                        m_markedRegions.end());
 }

--- a/xbmc/guilib/DirtyRegionTracker.h
+++ b/xbmc/guilib/DirtyRegionTracker.h
@@ -10,26 +10,19 @@
 
 #include "IDirtyRegionSolver.h"
 
-#if defined(TARGET_DARWIN_EMBEDDED)
-#define DEFAULT_BUFFERING 4
-#else
-#define DEFAULT_BUFFERING 3
-#endif
-
 class CDirtyRegionTracker
 {
 public:
-  explicit CDirtyRegionTracker(int buffering = DEFAULT_BUFFERING);
+  CDirtyRegionTracker();
   ~CDirtyRegionTracker();
   void SelectAlgorithm();
   void MarkDirtyRegion(const CDirtyRegion &region);
 
   const CDirtyRegionList &GetMarkedRegions() const;
   CDirtyRegionList GetDirtyRegions();
-  void CleanMarkedRegions();
+  void CleanMarkedRegions(int bufferAge);
 
 private:
   CDirtyRegionList m_markedRegions;
-  int m_buffering;
   IDirtyRegionSolver *m_solver;
 };

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1350,11 +1350,25 @@ bool CGUIWindowManager::Render()
   assert(CServiceBroker::GetAppMessenger()->IsProcessThread());
   CSingleExit lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
+  int bufferAge = CServiceBroker::GetWinSystem()->GetBufferAge();
+  bool visualizeDirtyRegions =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiVisualizeDirtyRegions;
+  if (visualizeDirtyRegions)
+    bufferAge = 20;
+  if (bufferAge)
+    m_tracker.CleanMarkedRegions(bufferAge + 1);
+  else
+    m_tracker.CleanMarkedRegions(10);
+
   CDirtyRegionList dirtyRegions = m_tracker.GetDirtyRegions();
+  CServiceBroker::GetWinSystem()->SetDirtyRegions(dirtyRegions);
 
   bool hasRendered = false;
   // If we visualize the regions we will always render the entire viewport
-  if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiVisualizeDirtyRegions || CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiAlgorithmDirtyRegions == DIRTYREGION_SOLVER_FILL_VIEWPORT_ALWAYS)
+  // If the buffer age is zero, the current content is undefined and has to be rendered
+  if (visualizeDirtyRegions || bufferAge == 0 ||
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiAlgorithmDirtyRegions ==
+          DIRTYREGION_SOLVER_FILL_VIEWPORT_ALWAYS)
   {
     RenderPass();
     hasRendered = true;
@@ -1381,7 +1395,7 @@ bool CGUIWindowManager::Render()
     CServiceBroker::GetWinSystem()->GetGfxContext().ResetScissors();
   }
 
-  if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiVisualizeDirtyRegions)
+  if (visualizeDirtyRegions)
   {
     CServiceBroker::GetWinSystem()->GetGfxContext().SetRenderingResolution(CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(), false);
     const CDirtyRegionList &markedRegions  = m_tracker.GetMarkedRegions();
@@ -1397,8 +1411,6 @@ bool CGUIWindowManager::Render()
 void CGUIWindowManager::AfterRender()
 {
   CServiceBroker::GetWinSystem()->GetGfxContext().ResetDepth();
-  m_tracker.CleanMarkedRegions();
-
   CGUIWindow* pWindow = GetWindow(GetActiveWindow());
   if (pWindow)
     pWindow->AfterRender();

--- a/xbmc/utils/EGLUtils.h
+++ b/xbmc/utils/EGLUtils.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "guilib/DirtyRegion.h"
 #include "threads/CriticalSection.h"
 
 #include <array>
@@ -17,6 +18,8 @@
 #include <vector>
 
 #include "system_egl.h"
+
+#include <EGL/eglext.h>
 
 class CEGLUtils
 {
@@ -201,6 +204,8 @@ public:
   void DestroyContext();
   bool SetVSync(bool enable);
   bool TrySwapBuffers();
+  void SetDamagedRegions(const CDirtyRegionList& dirtyRegions);
+  int GetBufferAge();
   bool IsPlatformSupported() const;
   EGLint GetConfigAttrib(EGLint attribute) const;
 
@@ -237,4 +242,8 @@ private:
   EGLConfig m_eglConfig{}, m_eglHDRConfig{};
   EGLContext m_eglUploadContext{EGL_NO_CONTEXT};
   mutable CCriticalSection m_textureUploadLock;
+
+  PFNEGLSETDAMAGEREGIONKHRPROC m_eglSetDamageRegionKHR{nullptr};
+  bool m_partialUpdateSupport{false};
+  bool m_bufferAgeSupport{false};
 };

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -14,6 +14,7 @@
 #include "VideoSync.h"
 #include "WinEvents.h"
 #include "cores/VideoPlayer/VideoRenderers/DebugInfo.h"
+#include "guilib/DirtyRegion.h"
 #include "guilib/DispResource.h"
 #include "utils/HDRCapabilities.h"
 
@@ -68,6 +69,8 @@ public:
   virtual bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) = 0;
   virtual bool DisplayHardwareScalingEnabled() { return false; }
   virtual void UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo) { }
+  virtual void SetDirtyRegions(const CDirtyRegionList& dirtyRegionsList) {}
+  virtual int GetBufferAge() { return 2; }
   virtual bool MoveWindow(int topLeft, int topRight){return false;}
   virtual void FinishModeChange(RESOLUTION res){}
   virtual void FinishWindowResize(int newWidth, int newHeight) {ResizeWindow(newWidth, newHeight, -1, -1);}

--- a/xbmc/windowing/X11/GLContext.h
+++ b/xbmc/windowing/X11/GLContext.h
@@ -28,7 +28,9 @@ public:
   virtual void SetVSync(bool enable) = 0;
   virtual void SwapBuffers() = 0;
   virtual void QueryExtensions() = 0;
+  virtual bool IsBufferAgeSupported() { return false; }
   virtual uint64_t GetVblankTiming(uint64_t& msc, uint64_t& interval) { return 0; }
+  virtual int GetBufferAge() { return 2; }
   bool IsExtSupported(const char* extension) const;
 
   const std::string& ExtPrefix() const { return m_extPrefix; }

--- a/xbmc/windowing/X11/GLContextEGL.cpp
+++ b/xbmc/windowing/X11/GLContextEGL.cpp
@@ -607,3 +607,14 @@ void CGLContextEGL::QueryExtensions()
 
   CLog::Log(LOGDEBUG, "EGL_EXTENSIONS:{}", m_extensions);
 }
+
+int CGLContextEGL::GetBufferAge()
+{
+#ifdef EGL_BUFFER_AGE_EXT
+  EGLint age;
+  eglQuerySurface(m_eglDisplay, m_eglSurface, EGL_BUFFER_AGE_EXT, &age);
+  return static_cast<int>(age);
+#else
+  return CGLContext::GetBufferAge();
+#endif
+}

--- a/xbmc/windowing/X11/GLContextEGL.h
+++ b/xbmc/windowing/X11/GLContextEGL.h
@@ -35,6 +35,8 @@ public:
   void SetVSync(bool enable) override;
   void SwapBuffers() override;
   void QueryExtensions() override;
+  bool IsBufferAgeSupported() override { return IsExtSupported("EGL_EXT_buffer_age"); }
+  int GetBufferAge() override;
   uint64_t GetVblankTiming(uint64_t &msc, uint64_t &interval) override;
 
   bool BindTextureUploadContext();

--- a/xbmc/windowing/X11/WinSystemX11GLContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
@@ -169,6 +169,7 @@ bool CWinSystemX11GLContext::CreateNewWindow(const std::string& name, bool fullS
     return false;
 
   m_pGLContext->QueryExtensions();
+  m_bufferAgeSupport = m_pGLContext->IsBufferAgeSupported();
   return true;
 }
 

--- a/xbmc/windowing/X11/WinSystemX11GLContext.h
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.h
@@ -10,9 +10,11 @@
 
 #include "WinSystemX11.h"
 #include "rendering/gl/RenderSystemGL.h"
-#include "system_egl.h"
+#include "windowing/X11/GLContext.h"
 
 #include <memory>
+
+#include "system_egl.h"
 
 class CGLContext;
 class CVideoReferenceClock;
@@ -43,6 +45,7 @@ public:
   bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
   bool DestroyWindowSystem() override;
   bool DestroyWindow() override;
+  int GetBufferAge() override { return m_bufferAgeSupport ? m_pGLContext->GetBufferAge() : 2; }
 
   bool IsExtSupported(const char* extension) const override;
 
@@ -77,6 +80,8 @@ protected:
     void operator()(CVaapiProxy *p) const;
   };
   std::unique_ptr<CVaapiProxy, delete_CVaapiProxy> m_vaapiProxy;
+
+  bool m_bufferAgeSupport{false};
 };
 
 }

--- a/xbmc/windowing/X11/WinSystemX11GLESContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLESContext.cpp
@@ -150,6 +150,7 @@ bool CWinSystemX11GLESContext::CreateNewWindow(const std::string& name, bool ful
     return false;
 
   m_pGLContext->QueryExtensions();
+  m_bufferAgeSupport = m_pGLContext->IsBufferAgeSupported();
   return true;
 }
 

--- a/xbmc/windowing/X11/WinSystemX11GLESContext.h
+++ b/xbmc/windowing/X11/WinSystemX11GLESContext.h
@@ -11,6 +11,7 @@
 #include "EGL/egl.h"
 #include "WinSystemX11.h"
 #include "rendering/gles/RenderSystemGLES.h"
+#include "windowing/X11/GLContextEGL.h"
 
 class CGLContextEGL;
 
@@ -38,6 +39,7 @@ public:
   bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
   bool DestroyWindowSystem() override;
   bool DestroyWindow() override;
+  int GetBufferAge() override { return m_bufferAgeSupport ? m_pGLContext->GetBufferAge() : 2; }
 
   bool IsExtSupported(const char* extension) const override;
 
@@ -59,6 +61,7 @@ protected:
 
   CGLContextEGL* m_pGLContext = nullptr;
   bool m_newGlContext;
+  bool m_bufferAgeSupport{false};
 };
 
 } // namespace X11

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
@@ -34,6 +34,11 @@ public:
                        bool fullScreen,
                        RESOLUTION_INFO& res) override;
   bool DestroyWindow() override;
+  void SetDirtyRegions(const CDirtyRegionList& dirtyRegions) override
+  {
+    m_eglContext.SetDamagedRegions(dirtyRegions);
+  }
+  int GetBufferAge() override { return m_eglContext.GetBufferAge(); }
 
   bool BindTextureUploadContext() override;
   bool UnbindTextureUploadContext() override;

--- a/xbmc/windowing/tvos/WinSystemTVOS.h
+++ b/xbmc/windowing/tvos/WinSystemTVOS.h
@@ -51,6 +51,7 @@ public:
   bool DestroyWindow() override;
   bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
   bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
+  int GetBufferAge() override { return 3; }
   void UpdateResolutions() override;
   bool CanDoWindowed() override { return false; }
 

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContext.h
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContext.h
@@ -42,6 +42,11 @@ public:
                        RESOLUTION_INFO& res) override;
   bool DestroyWindow() override;
   bool DestroyWindowSystem() override;
+  void SetDirtyRegions(const CDirtyRegionList& dirtyRegions) override
+  {
+    m_eglContext.SetDamagedRegions(dirtyRegions);
+  }
+  int GetBufferAge() override { return m_eglContext.GetBufferAge(); }
 
   bool BindTextureUploadContext() override;
   bool UnbindTextureUploadContext() override;


### PR DESCRIPTION
## Description
The previous dirty region implementation was inconsistent across the different platforms.

For X11, we just guessed how old the buffer we draw to is.

For GBM and Wayland, we guessed as well. But instead of just writing to the buffer, the GPU driver does a copy of the previous (N-1) buffer, because we specified the surface with the attribute "EGL_SWAP_BEHAVIOR" set to "EGL_BUFFER_PRESERVED".

With the patch, we can query the exact buffer age via "EGL_EXT_buffer_age". Even better, if "EGL_KHR_partial_update" is available, we can give the damaged region to the GPU driver, which in turn can omit untouched regions from rendering. The latter is only implemented on GBM/Wayland, but could be added to X11 (but I don't see much value in doing that).

If we can't query the buffer age, there are default values to fall back to ("2" for triple buffering, "3" on IOS). 

"EGL_KHR_partial_update" based dirty region rendering is only available when providing the following settings file ("algorithmdirtyregions" can be 1 or 2):
```
<advancedsettings>
  <gui>
    <algorithmdirtyregions>1</algorithmdirtyregions>
  </gui>
</advancedsettings>
```

## Motivation and context
Depending on the GPU, its driver and the windowing system; there might be some unnecessary copying going on. This patch might reduce GPU load.

Especially tile based GPUs which are using "EGL_KHR_partial_update" might see an performance uplift in certain situations.

## How has this been tested?
On my RX570 on X11, all dirty region modes are working fine.

On an Odroid C2 running LibreElec 11, it seems to run fine now.


## What is the effect on users?
More performance. The GPU only has to render updated parts. Less memory bandwidth consumed in certain situations. The device might run a bit cooler.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
