### PR TITLE
[video] Fix playlist window data

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -29,6 +29,7 @@
 #include "utils/URIUtils.h"
 #include "video/VideoLibraryQueue.h"
 #include "video/VideoUtils.h"
+#include "video/windows/GUIWindowVideoBase.h"
 #include "video/windows/GUIWindowVideoNav.h"
 
 #include <memory>
@@ -385,7 +386,7 @@ void CGUIWindowPVRRecordingsBase::OnPrepareFileItems(CFileItemList& items)
   {
     if (m_database.Open())
     {
-      CGUIWindowVideoNav::LoadVideoInfo(files, m_database, false);
+      CGUIWindowVideoBase::LoadVideoInfo(files, m_database, false);
       m_database.Close();
     }
     m_thumbLoader.Load(files);

--- a/xbmc/video/windows/GUIWindowVideoBase.h
+++ b/xbmc/video/windows/GUIWindowVideoBase.h
@@ -71,6 +71,16 @@ public:
    */
   static std::string GetResumeString(const CFileItem &item);
 
+  /*! \brief Load video information from the database for these items (public static version)
+   Useful for grabbing information for file listings, from watched status to full metadata
+   \param items the items to load information for.
+   \param database open database object to retrieve the data from
+   \param allowReplaceLabels allow label replacement if according GUI setting is enabled
+   */
+  static void LoadVideoInfo(CFileItemList& items,
+                            CVideoDatabase& database,
+                            bool allowReplaceLabels = true);
+
 protected:
   void OnScan(const std::string& strPath, bool scanAll = false);
   bool Update(const std::string &strDirectory, bool updateFilterPath = true) override;

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -16,7 +16,6 @@
 #include "dialogs/GUIDialogMediaSource.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "filesystem/Directory.h"
-#include "filesystem/MultiPathDirectory.h"
 #include "filesystem/VideoDatabaseDirectory.h"
 #include "filesystem/VideoDatabaseFile.h"
 #include "guilib/GUIComponent.h"
@@ -490,7 +489,7 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
       if (items.GetLabel().empty() && m_rootDir.IsSource(items.GetPath(), CMediaSourceSettings::GetInstance().GetSources("video"), &label))
         items.SetLabel(label);
       if (!items.IsSourcesPath() && !items.IsLibraryFolder())
-        LoadVideoInfo(items);
+        LoadVideoInfo(items, m_database);
     }
 
     CVideoDbUrl videoUrl;
@@ -505,106 +504,6 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
     }
   }
   return bResult;
-}
-
-void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items)
-{
-  LoadVideoInfo(items, m_database);
-}
-
-void CGUIWindowVideoNav::LoadVideoInfo(CFileItemList &items, CVideoDatabase &database, bool allowReplaceLabels)
-{
-  //! @todo this could possibly be threaded as per the music info loading,
-  //!       we could also cache the info
-  if (!items.GetContent().empty() && !items.IsPlugin())
-    return; // don't load for listings that have content set and weren't created from plugins
-
-  std::string content = items.GetContent();
-  // determine content only if it isn't set
-  if (content.empty())
-  {
-    content = database.GetContentForPath(items.GetPath());
-    items.SetContent((content.empty() && !items.IsPlugin()) ? "files" : content);
-  }
-
-  /*
-    If we have a matching item in the library, so we can assign the metadata to it. In addition, we can choose
-    * whether the item is stacked down (eg in the case of folders representing a single item)
-    * whether or not we assign the library's labels to the item, or leave the item as is.
-
-    As certain users (read: certain developers) don't want either of these to occur, we compromise by stacking
-    items down only if stacking is available and enabled.
-
-    Similarly, we assign the "clean" library labels to the item only if the "Replace filenames with library titles"
-    setting is enabled.
-    */
-  const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-  const bool stackItems    = items.GetProperty("isstacked").asBoolean() || (StackingAvailable(items) && settings->GetBool(CSettings::SETTING_MYVIDEOS_STACKVIDEOS));
-  const bool replaceLabels = allowReplaceLabels && settings->GetBool(CSettings::SETTING_MYVIDEOS_REPLACELABELS);
-
-  CFileItemList dbItems;
-  /* NOTE: In the future when GetItemsForPath returns all items regardless of whether they're "in the library"
-           we won't need the fetchedPlayCounts code, and can "simply" do this directly on absence of content. */
-  bool fetchedPlayCounts = false;
-  if (!content.empty())
-  {
-    database.GetItemsForPath(content, items.GetPath(), dbItems);
-    dbItems.SetFastLookup(true);
-  }
-
-  for (int i = 0; i < items.Size(); i++)
-  {
-    CFileItemPtr pItem = items[i];
-    CFileItemPtr match;
-
-    if (pItem->m_bIsFolder && !pItem->IsParentFolder())
-    {
-      // we need this for enabling the right context menu entries, like mark watched / unwatched
-      pItem->SetProperty("IsVideoFolder", true);
-    }
-
-    if (!content.empty()) /* optical media will be stacked down, so it's path won't match the base path */
-    {
-      std::string pathToMatch = pItem->IsOpticalMediaFile() ? pItem->GetLocalMetadataPath() : pItem->GetPath();
-      if (URIUtils::IsMultiPath(pathToMatch))
-        pathToMatch = CMultiPathDirectory::GetFirstPath(pathToMatch);
-      match = dbItems.Get(pathToMatch);
-    }
-    if (match)
-    {
-      pItem->UpdateInfo(*match, replaceLabels);
-
-      if (stackItems)
-      {
-        if (match->m_bIsFolder)
-          pItem->SetPath(match->GetVideoInfoTag()->m_strPath);
-        else
-          pItem->SetPath(match->GetVideoInfoTag()->m_strFileNameAndPath);
-        // if we switch from a file to a folder item it means we really shouldn't be sorting files and
-        // folders separately
-        if (pItem->m_bIsFolder != match->m_bIsFolder)
-        {
-          items.SetSortIgnoreFolders(true);
-          pItem->m_bIsFolder = match->m_bIsFolder;
-        }
-      }
-    }
-    else
-    {
-      /* NOTE: Currently we GetPlayCounts on our items regardless of whether content is set
-                as if content is set, GetItemsForPaths doesn't return anything not in the content tables.
-                This code can be removed once the content tables are always filled */
-      if (!pItem->m_bIsFolder && !fetchedPlayCounts)
-      {
-        database.GetPlayCounts(items.GetPath(), items);
-        fetchedPlayCounts = true;
-      }
-
-      // set the watched overlay
-      if (pItem->IsVideo())
-        pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, pItem->HasVideoInfoTag() && pItem->GetVideoInfoTag()->GetPlayCount() > 0);
-    }
-  }
 }
 
 void CGUIWindowVideoNav::UpdateButtons()

--- a/xbmc/video/windows/GUIWindowVideoNav.h
+++ b/xbmc/video/windows/GUIWindowVideoNav.h
@@ -39,21 +39,7 @@ public:
 
   void OnItemInfo(const CFileItem& fileItem, ADDON::ScraperPtr &info) override;
 
-  /*! \brief Load video information from the database for these items (public static version)
-   Useful for grabbing information for file listings, from watched status to full metadata
-   \param items the items to load information for.
-   \param database open database object to retrieve the data from
-   \param allowReplaceLabels allow label replacement if according GUI setting is enabled
-   */
-  static void LoadVideoInfo(CFileItemList &items, CVideoDatabase &database, bool allowReplaceLabels = true);
-
 protected:
-  /*! \brief Load video information from the database for these items
-   Useful for grabbing information for file listings, from watched status to full metadata
-   \param items the items to load information for.
-   */
-  void LoadVideoInfo(CFileItemList &items);
-
   bool ApplyWatchedFilter(CFileItemList &items);
   bool GetFilteredItems(const std::string &filter, CFileItemList &items) override;
 

--- a/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
+++ b/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
@@ -25,6 +25,7 @@
 #include "input/actions/ActionIDs.h"
 #include "playlists/PlayListM3U.h"
 #include "settings/MediaSettings.h"
+#include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/URIUtils.h"
@@ -52,6 +53,25 @@ CGUIWindowVideoPlaylist::CGUIWindowVideoPlaylist()
 }
 
 CGUIWindowVideoPlaylist::~CGUIWindowVideoPlaylist() = default;
+
+void CGUIWindowVideoPlaylist::OnPrepareFileItems(CFileItemList& items)
+{
+  CGUIWindowVideoBase::OnPrepareFileItems(items);
+
+  if (items.IsEmpty())
+    return;
+
+  if (!items.IsVideoDb() && !items.IsVirtualDirectoryRoot())
+  { // load info from the database
+    std::string label;
+    if (items.GetLabel().empty() &&
+        m_rootDir.IsSource(items.GetPath(), CMediaSourceSettings::GetInstance().GetSources("video"),
+                           &label))
+      items.SetLabel(label);
+    if (!items.IsSourcesPath() && !items.IsLibraryFolder())
+      LoadVideoInfo(items, m_database);
+  }
+}
 
 bool CGUIWindowVideoPlaylist::OnMessage(CGUIMessage& message)
 {

--- a/xbmc/video/windows/GUIWindowVideoPlaylist.h
+++ b/xbmc/video/windows/GUIWindowVideoPlaylist.h
@@ -16,6 +16,7 @@ public:
   CGUIWindowVideoPlaylist(void);
   ~CGUIWindowVideoPlaylist(void) override;
 
+  void OnPrepareFileItems(CFileItemList& items) override;
   bool OnMessage(CGUIMessage& message) override;
   bool OnAction(const CAction &action) override;
   bool OnBack(int actionID) override;


### PR DESCRIPTION
Video info (like watched status) must be loaded from database when opening the playlist window. Otherwise some data, like before mentioned watched status will not be available / displayed in the playlist window. This got broken somewhere in the past with some PR or never did work correctly. Don't know - but now it works. ;-)

BTW, the music component already does it like introduced by this PR, and fetches song data in `CGUIWindowMusicBase::OnPrepareFileItems` already. My fix got inspired by this.

Runtime-tested on macOS and Android, latest master and also on Nexus.

@enen92 maybe something you can have a look at?  