### PR TITLE
[Android] Replace JsonParser constructor

### DIFF
--- a/tools/android/packaging/xbmc/src/XBMCJsonRPC.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCJsonRPC.java.in
@@ -7,7 +7,6 @@ import java.util.HashSet;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 
 import android.app.Notification;
@@ -156,10 +155,7 @@ public class XBMCJsonRPC
       if (stringResp == null)
         return null;
 
-      JsonParser parser = new JsonParser();
-      JsonElement element = parser.parse(stringResp);
-      JsonObject resp = element.getAsJsonObject();
-      return resp;
+      return JsonParser.parseString(stringResp).getAsJsonObject();
     }
     catch (Exception e)
     {
@@ -177,10 +173,7 @@ public class XBMCJsonRPC
       if (stringResp == null)
         return null;
 
-      JsonParser parser = new JsonParser();
-      JsonElement element = parser.parse(stringResp);
-      JsonArray resp = element.getAsJsonArray();
-      return resp;
+      return JsonParser.parseString(stringResp).getAsJsonArray();
     }
     catch (Exception e)
     {


### PR DESCRIPTION
## Description
Based on the [javadoc](https://javadoc.io/doc/com.google.code.gson/gson/2.10.1/com.google.gson/com/google/gson/JsonParser.html) for Gson 2.10.1:

> No need to instantiate this class, use the static methods instead.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
