### PR TITLE
webos: Skip first argument

### DIFF
--- a/xbmc/platform/linux/AppParamParserWebOS.cpp
+++ b/xbmc/platform/linux/AppParamParserWebOS.cpp
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (C) 2005-2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "AppParamParserWebOS.h"
+
+void CAppParamParserWebOS::ParseArg(const std::string& arg)
+{
+  // On webOS the app launcher adds a JSON as the first argument by default. These arguments do not contain
+  // useful information. So to avoid kodi trying to parse these args and misinterpret them as a video file.
+  if (m_nArgs++ == 0 && arg.size() > 1 && arg.front() == '{' && arg.back() == '}')
+    return;
+
+  CAppParamParserLinux::ParseArg(arg);
+}

--- a/xbmc/platform/linux/AppParamParserWebOS.h
+++ b/xbmc/platform/linux/AppParamParserWebOS.h
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (C) 2005-2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "AppParamParserLinux.h"
+
+class CAppParamParserWebOS : public CAppParamParserLinux
+{
+public:
+  CAppParamParserWebOS() = default;
+  ~CAppParamParserWebOS() = default;
+
+protected:
+  void ParseArg(const std::string& arg) override;
+
+private:
+  int m_nArgs{0};
+};

--- a/xbmc/platform/linux/CMakeLists.txt
+++ b/xbmc/platform/linux/CMakeLists.txt
@@ -13,6 +13,11 @@ set(HEADERS AppParamParserLinux.h
             SysfsPath.h
             TimeUtils.h)
 
+if(TARGET_WEBOS)
+  list(APPEND SOURCES AppParamParserWebOS.cpp)
+  list(APPEND HEADERS AppParamParserWebOS.h)
+endif()
+
 if(ALSA_FOUND)
   list(APPEND SOURCES FDEventMonitor.cpp)
   list(APPEND HEADERS FDEventMonitor.h)

--- a/xbmc/platform/posix/main.cpp
+++ b/xbmc/platform/posix/main.cpp
@@ -22,6 +22,10 @@
 #include "platform/linux/AppParamParserLinux.h"
 #endif
 
+#ifdef TARGET_WEBOS
+#include "platform/linux/AppParamParserWebOS.h"
+#endif
+
 #include <cstdio>
 #include <cstring>
 #include <errno.h>
@@ -60,7 +64,9 @@ int main(int argc, char* argv[])
 
   setlocale(LC_NUMERIC, "C");
 
-#if defined(TARGET_LINUX) || defined(TARGET_FREEBSD)
+#ifdef TARGET_WEBOS
+  CAppParamParserWebOS appParamParser;
+#elif defined(TARGET_LINUX) || defined(TARGET_FREEBSD)
   CAppParamParserLinux appParamParser;
 #else
   CAppParamParser appParamParser;


### PR DESCRIPTION
## Description
webOS adds some JSON arguments when launched as the first parameter. This leads to kodi misinterpreting this JSON object as an video file causing an error notification on startup.

## Motivation and context
Avoid showing an error notification on startup

## How has this been tested?
Tested on LG C2

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
