### PR TITLE
[guilib] only use the blocking image loader for skin textures

### DIFF
--- a/addons/skin.estouchy/xml/DialogAddonInfo.xml
+++ b/addons/skin.estouchy/xml/DialogAddonInfo.xml
@@ -57,7 +57,7 @@
 				<width>260</width>
 				<height>300</height>
 				<aspectratio>keep</aspectratio>
-				<texture background="true">$INFO[ListItem.Icon]</texture>
+				<texture>$INFO[ListItem.Icon]</texture>
 			</control>
 			<control type="label">
 				<posx>280</posx>

--- a/addons/skin.estouchy/xml/DialogMusicInfo.xml
+++ b/addons/skin.estouchy/xml/DialogMusicInfo.xml
@@ -180,7 +180,7 @@
 				<width>260</width>
 				<height>360</height>
 				<aspectratio>keep</aspectratio>
-				<texture background="true">$INFO[ListItem.Icon]</texture>
+				<texture>$INFO[ListItem.Icon]</texture>
 			</control>
 			<control type="textbox">
 				<description>Description Value for Albums</description>
@@ -340,7 +340,7 @@
 				<width>260</width>
 				<height>360</height>
 				<aspectratio>keep</aspectratio>
-				<texture background="true">$INFO[ListItem.Icon]</texture>
+				<texture>$INFO[ListItem.Icon]</texture>
 			</control>
 			<control type="textbox">
 				<description>Description Value for Artists</description>

--- a/addons/skin.estouchy/xml/DialogPVRChannelGuide.xml
+++ b/addons/skin.estouchy/xml/DialogPVRChannelGuide.xml
@@ -61,7 +61,7 @@
 					<posy>2</posy>
 					<width>86</width>
 					<height>86</height>
-					<texture background="true">$VAR[PosterThumb]</texture>
+					<texture>$VAR[PosterThumb]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
 				<control type="label">
@@ -133,7 +133,7 @@
 					<posy>2</posy>
 					<width>86</width>
 					<height>86</height>
-					<texture background="true">$VAR[PosterThumb]</texture>
+					<texture>$VAR[PosterThumb]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
 				<control type="label">

--- a/addons/skin.estouchy/xml/DialogPVRChannelManager.xml
+++ b/addons/skin.estouchy/xml/DialogPVRChannelManager.xml
@@ -68,7 +68,7 @@
 					<posy>5</posy>
 					<width>60</width>
 					<height>60</height>
-					<texture background="true">$INFO[ListItem.Icon]</texture>
+					<texture>$INFO[ListItem.Icon]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
 				<control type="label">
@@ -96,7 +96,7 @@
 					<posy>5</posy>
 					<width>60</width>
 					<height>60</height>
-					<texture background="true">$INFO[ListItem.Icon]</texture>
+					<texture>$INFO[ListItem.Icon]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
 				<control type="label">

--- a/addons/skin.estouchy/xml/DialogPVRChannelsOSD.xml
+++ b/addons/skin.estouchy/xml/DialogPVRChannelsOSD.xml
@@ -61,7 +61,7 @@
 					<posy>5</posy>
 					<width>80</width>
 					<height>80</height>
-					<texture background="true">$VAR[PosterThumb]</texture>
+					<texture>$VAR[PosterThumb]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
 				<control type="label">
@@ -133,7 +133,7 @@
 					<posy>5</posy>
 					<width>80</width>
 					<height>80</height>
-					<texture background="true">$VAR[PosterThumb]</texture>
+					<texture>$VAR[PosterThumb]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
 				<control type="label">

--- a/addons/skin.estouchy/xml/DialogPVRGroupManager.xml
+++ b/addons/skin.estouchy/xml/DialogPVRGroupManager.xml
@@ -77,7 +77,7 @@
 					<posy>5</posy>
 					<width>60</width>
 					<height>60</height>
-					<texture background="true">$INFO[ListItem.Icon]</texture>
+					<texture>$INFO[ListItem.Icon]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
 				<control type="label">
@@ -105,7 +105,7 @@
 					<posy>5</posy>
 					<width>60</width>
 					<height>60</height>
-					<texture background="true">$INFO[ListItem.Icon]</texture>
+					<texture>$INFO[ListItem.Icon]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
 				<control type="label">
@@ -173,7 +173,7 @@
 					<posy>5</posy>
 					<width>60</width>
 					<height>60</height>
-					<texture background="true">$INFO[ListItem.Icon]</texture>
+					<texture>$INFO[ListItem.Icon]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
 				<control type="label">
@@ -201,7 +201,7 @@
 					<posy>5</posy>
 					<width>60</width>
 					<height>60</height>
-					<texture background="true">$INFO[ListItem.Icon]</texture>
+					<texture>$INFO[ListItem.Icon]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
 				<control type="label">
@@ -277,7 +277,7 @@
 					<posy>5</posy>
 					<width>60</width>
 					<height>60</height>
-					<texture background="true">$INFO[ListItem.Icon]</texture>
+					<texture>$INFO[ListItem.Icon]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
 				<control type="label">
@@ -305,7 +305,7 @@
 					<posy>5</posy>
 					<width>60</width>
 					<height>60</height>
-					<texture background="true">$INFO[ListItem.Icon]</texture>
+					<texture>$INFO[ListItem.Icon]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
 				<control type="label">

--- a/addons/skin.estouchy/xml/DialogPVRInfo.xml
+++ b/addons/skin.estouchy/xml/DialogPVRInfo.xml
@@ -46,7 +46,7 @@
 				<width>260</width>
 				<height>360</height>
 				<aspectratio>keep</aspectratio>
-				<texture background="true">$INFO[ListItem.Icon]</texture>
+				<texture>$INFO[ListItem.Icon]</texture>
 			</control>
 			<control type="textbox" id="400">
 				<description>Description</description>

--- a/addons/skin.estouchy/xml/DialogVideoInfo.xml
+++ b/addons/skin.estouchy/xml/DialogVideoInfo.xml
@@ -54,7 +54,7 @@
 				<width>240</width>
 				<height>330</height>
 				<aspectratio>keep</aspectratio>
-				<texture background="true">$INFO[ListItem.Icon]</texture>
+				<texture>$INFO[ListItem.Icon]</texture>
 			</control>
 			<control type="textbox" id="600">
 				<description>Description Value</description>

--- a/addons/skin.estouchy/xml/FileBrowser.xml
+++ b/addons/skin.estouchy/xml/FileBrowser.xml
@@ -141,7 +141,7 @@
 					<posy>0</posy>
 					<width>260</width>
 					<height>260</height>
-					<texture background="true">$INFO[ListItem.Icon]</texture>
+					<texture>$INFO[ListItem.Icon]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
 				<control type="label">
@@ -162,7 +162,7 @@
 					<posy>0</posy>
 					<width>260</width>
 					<height>260</height>
-					<texture background="true">$INFO[ListItem.Icon]</texture>
+					<texture>$INFO[ListItem.Icon]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
 				<control type="image">

--- a/addons/skin.estouchy/xml/FileManager.xml
+++ b/addons/skin.estouchy/xml/FileManager.xml
@@ -55,7 +55,7 @@
 						<posy>5</posy>
 						<width>70</width>
 						<height>70</height>
-						<texture background="true">$INFO[ListItem.Icon]</texture>
+						<texture>$INFO[ListItem.Icon]</texture>
 						<aspectratio>keep</aspectratio>
 					</control>
 					<control type="label">
@@ -95,7 +95,7 @@
 						<posy>5</posy>
 						<width>70</width>
 						<height>70</height>
-						<texture background="true">$INFO[ListItem.Icon]</texture>
+						<texture>$INFO[ListItem.Icon]</texture>
 						<aspectratio>keep</aspectratio>
 					</control>
 					<control type="label">
@@ -184,7 +184,7 @@
 						<posy>5</posy>
 						<width>70</width>
 						<height>70</height>
-						<texture background="true">$INFO[ListItem.Icon]</texture>
+						<texture>$INFO[ListItem.Icon]</texture>
 						<aspectratio>keep</aspectratio>
 					</control>
 					<control type="label">
@@ -224,7 +224,7 @@
 						<posy>5</posy>
 						<width>70</width>
 						<height>70</height>
-						<texture background="true">$INFO[ListItem.Icon]</texture>
+						<texture>$INFO[ListItem.Icon]</texture>
 						<aspectratio>keep</aspectratio>
 					</control>
 					<control type="label">

--- a/addons/skin.estouchy/xml/Includes.xml
+++ b/addons/skin.estouchy/xml/Includes.xml
@@ -127,7 +127,7 @@
 			<posy>0</posy>
 			<include>ScreenWidth</include>
 			<height>960</height>
-			<texture background="true">$INFO[Container.Art(tvshow.fanart)]</texture>
+			<texture>$INFO[Container.Art(tvshow.fanart)]</texture>
 			<aspectratio>scale</aspectratio>
 			<fadetime>FanartCrossfadeTime</fadetime>
 			<visible>Container.Content(Seasons) | Container.Content(Episodes)</visible>
@@ -137,7 +137,7 @@
 			<posy>0</posy>
 			<include>ScreenWidth</include>
 			<height>960</height>
-			<texture background="true">$INFO[Container.Art(artist.fanart)]</texture>
+			<texture>$INFO[Container.Art(artist.fanart)]</texture>
 			<aspectratio>scale</aspectratio>
 			<fadetime>FanartCrossfadeTime</fadetime>
 			<visible>Container.Content(Albums) | Container.Content(Songs)</visible>
@@ -147,7 +147,7 @@
 			<posy>0</posy>
 			<include>ScreenWidth</include>
 			<height>960</height>
-			<texture background="true">$INFO[ListItem.Art(fanart)]</texture>
+			<texture>$INFO[ListItem.Art(fanart)]</texture>
 			<aspectratio>scale</aspectratio>
 			<fadetime>FanartCrossfadeTime</fadetime>
 			<visible>![Container.Content(Seasons) | Container.Content(Episodes) | Container.Content(Albums) | Container.Content(Songs)]</visible>
@@ -158,7 +158,7 @@
 			<posy>0</posy>
 			<include>ScreenWidth</include>
 			<height>960</height>
-			<texture background="true">$INFO[Player.Art(fanart)]</texture>
+			<texture>$INFO[Player.Art(fanart)]</texture>
 			<aspectratio>scale</aspectratio>
 			<fadetime>FanartCrossfadeTime</fadetime>
 			<visible>Player.HasMedia</visible>

--- a/addons/skin.estouchy/xml/IncludesHomeRecentlyAdded.xml
+++ b/addons/skin.estouchy/xml/IncludesHomeRecentlyAdded.xml
@@ -54,7 +54,7 @@
 							<posy>15</posy>
 							<width>180</width>
 							<height>270</height>
-							<texture background="true">$VAR[PosterThumb]</texture>
+							<texture>$VAR[PosterThumb]</texture>
 						</control>
 						<control type="label">
 							<posx>10</posx>
@@ -85,7 +85,7 @@
 							<posy>15</posy>
 							<width>180</width>
 							<height>270</height>
-							<texture background="true">$VAR[PosterThumb]</texture>
+							<texture>$VAR[PosterThumb]</texture>
 						</control>
 						<control type="label">
 							<posx>10</posx>
@@ -148,7 +148,7 @@
 							<width>250</width>
 							<height>140</height>
 							<aspectratio>scale</aspectratio>
-							<texture background="true">$INFO[Listitem.Icon]</texture>
+							<texture>$INFO[Listitem.Icon]</texture>
 						</control>
 						<control type="label">
 							<posx>15</posx>
@@ -192,7 +192,7 @@
 							<width>250</width>
 							<height>140</height>
 							<aspectratio>scale</aspectratio>
-							<texture background="true">$INFO[Listitem.Icon]</texture>
+							<texture>$INFO[Listitem.Icon]</texture>
 						</control>
 						<control type="label">
 							<posx>15</posx>
@@ -265,7 +265,7 @@
 							<posy>15</posy>
 							<width>180</width>
 							<height>165</height>
-							<texture background="true">$INFO[Listitem.Icon]</texture>
+							<texture>$INFO[Listitem.Icon]</texture>
 						</control>
 						<control type="label">
 							<posx>15</posx>
@@ -296,7 +296,7 @@
 							<posy>15</posy>
 							<width>180</width>
 							<height>165</height>
-							<texture background="true">$INFO[Listitem.Icon]</texture>
+							<texture>$INFO[Listitem.Icon]</texture>
 						</control>
 						<control type="label">
 							<posx>15</posx>
@@ -357,7 +357,7 @@
 							<posy>15</posy>
 							<width>180</width>
 							<height>165</height>
-							<texture background="true">$INFO[Listitem.Icon]</texture>
+							<texture>$INFO[Listitem.Icon]</texture>
 						</control>
 						<control type="label">
 							<posx>15</posx>
@@ -388,7 +388,7 @@
 							<posy>15</posy>
 							<width>180</width>
 							<height>165</height>
-							<texture background="true">$INFO[Listitem.Icon]</texture>
+							<texture>$INFO[Listitem.Icon]</texture>
 						</control>
 						<control type="label">
 							<posx>15</posx>

--- a/addons/skin.estouchy/xml/MusicVisualisation.xml
+++ b/addons/skin.estouchy/xml/MusicVisualisation.xml
@@ -10,7 +10,7 @@
 			<posy>0</posy>
 			<include>ScreenWidth</include>
 			<height>960</height>
-			<texture background="true">$INFO[Player.Art(fanart)]</texture>
+			<texture>$INFO[Player.Art(fanart)]</texture>
 			<aspectratio>scale</aspectratio>
 			<fadetime>FanartCrossfadeTime</fadetime>
 		</control>

--- a/addons/skin.estouchy/xml/MyMusicPlaylistEditor.xml
+++ b/addons/skin.estouchy/xml/MyMusicPlaylistEditor.xml
@@ -56,7 +56,7 @@
 						<posy>5</posy>
 						<width>70</width>
 						<height>70</height>
-						<texture background="true">$INFO[ListItem.Icon]</texture>
+						<texture>$INFO[ListItem.Icon]</texture>
 						<aspectratio>keep</aspectratio>
 					</control>
 					<control type="label">
@@ -96,7 +96,7 @@
 						<posy>5</posy>
 						<width>70</width>
 						<height>70</height>
-						<texture background="true">$INFO[ListItem.Icon]</texture>
+						<texture>$INFO[ListItem.Icon]</texture>
 						<aspectratio>keep</aspectratio>
 					</control>
 					<control type="label">
@@ -184,7 +184,7 @@
 						<posy>5</posy>
 						<width>70</width>
 						<height>70</height>
-						<texture background="true">$INFO[ListItem.Icon]</texture>
+						<texture>$INFO[ListItem.Icon]</texture>
 						<aspectratio>keep</aspectratio>
 					</control>
 					<control type="label">
@@ -224,7 +224,7 @@
 						<posy>5</posy>
 						<width>70</width>
 						<height>70</height>
-						<texture background="true">$INFO[ListItem.Icon]</texture>
+						<texture>$INFO[ListItem.Icon]</texture>
 						<aspectratio>keep</aspectratio>
 					</control>
 					<control type="label">

--- a/addons/skin.estouchy/xml/ViewsList.xml
+++ b/addons/skin.estouchy/xml/ViewsList.xml
@@ -40,7 +40,7 @@
 					<posy>4</posy>
 					<width>62</width>
 					<height>62</height>
-					<texture background="true">$VAR[PosterThumb]</texture>
+					<texture>$VAR[PosterThumb]</texture>
 					<aspectratio>keep</aspectratio>
 					<visible>Container.Content(Movies) | Container.Content(Seasons) | Container.Content(TVShows) | Container.Content(Episodes) | Container.Content(MusicVideos) | Container.Content(Videos) | Container.Content(Artists) | Container.Content(Albums) | Container.Content(Songs) | [Container.Content(Addons) + !ListItem.IsFolder] | Container.Content(Actors) | Container.Content(Sets) | [Window.IsVisible(Pictures) + !String.IsEmpty(Container.FolderPath)]</visible>
 				</control>
@@ -49,7 +49,7 @@
 					<posy>4</posy>
 					<width>62</width>
 					<height>62</height>
-					<texture background="true">$INFO[Listitem.Icon]</texture>
+					<texture>$INFO[Listitem.Icon]</texture>
 					<aspectratio>keep</aspectratio>
 					<visible>[Container.Content() + !Window.IsVisible(Pictures)] | Container.Content(Files) | Container.Content(Games) | Container.Content(Genres) | Container.Content(Years) | Container.Content(Directors) | Container.Content(Studios) | Container.Content(Countries) | Container.Content(Tags) | [Container.Content(Addons) + ListItem.IsFolder] | [Window.IsVisible(Pictures) + String.IsEmpty(Container.FolderPath)]</visible>
 				</control>
@@ -182,7 +182,7 @@
 					<posy>4</posy>
 					<width>62</width>
 					<height>62</height>
-					<texture background="true">$VAR[PosterThumb]</texture>
+					<texture>$VAR[PosterThumb]</texture>
 					<aspectratio>keep</aspectratio>
 					<visible>Container.Content(Movies) | Container.Content(Seasons) | Container.Content(TVShows) | Container.Content(Episodes) | Container.Content(MusicVideos) | Container.Content(Videos) | Container.Content(Artists) | Container.Content(Albums) | Container.Content(Songs) | [Container.Content(Addons) + !ListItem.IsFolder] | Container.Content(Actors) | Container.Content(Sets) | [Window.IsVisible(Pictures) + !String.IsEmpty(Container.FolderPath)]</visible>
 				</control>
@@ -191,7 +191,7 @@
 					<posy>4</posy>
 					<width>62</width>
 					<height>62</height>
-					<texture background="true">$INFO[Listitem.Icon]</texture>
+					<texture>$INFO[Listitem.Icon]</texture>
 					<aspectratio>keep</aspectratio>
 					<visible>[Container.Content() + !Window.IsVisible(Pictures)] | Container.Content(Files) | Container.Content(Games) | Container.Content(Genres) | Container.Content(Years) | Container.Content(Directors) | Container.Content(Studios) | Container.Content(Countries) | Container.Content(Tags) | [Container.Content(Addons) + ListItem.IsFolder] | [Window.IsVisible(Pictures) + String.IsEmpty(Container.FolderPath)]</visible>
 				</control>
@@ -316,7 +316,7 @@
 					<posy>4</posy>
 					<width>82</width>
 					<height>82</height>
-					<texture background="true">$INFO[ListItem.Icon]</texture>
+					<texture>$INFO[ListItem.Icon]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
 				<control type="label">
@@ -366,7 +366,7 @@
 					<posy>4</posy>
 					<width>82</width>
 					<height>82</height>
-					<texture background="true">$INFO[ListItem.Icon]</texture>
+					<texture>$INFO[ListItem.Icon]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
 				<control type="label">

--- a/addons/skin.estouchy/xml/ViewsPVR.xml
+++ b/addons/skin.estouchy/xml/ViewsPVR.xml
@@ -40,7 +40,7 @@
 					<posy>10</posy>
 					<width>70</width>
 					<height>70</height>
-					<texture background="true">$VAR[PosterThumb]</texture>
+					<texture>$VAR[PosterThumb]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
 				<control type="label">
@@ -110,7 +110,7 @@
 					<posy>10</posy>
 					<width>70</width>
 					<height>70</height>
-					<texture background="true">$VAR[PosterThumb]</texture>
+					<texture>$VAR[PosterThumb]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
 				<control type="label">
@@ -234,7 +234,7 @@
 					<posy>10</posy>
 					<width>45</width>
 					<height>45</height>
-					<texture background="true">$INFO[ListItem.Icon]</texture>
+					<texture>$INFO[ListItem.Icon]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
 				<control type="label" id="1">
@@ -270,7 +270,7 @@
 					<posy>10</posy>
 					<width>45</width>
 					<height>45</height>
-					<texture background="true">$INFO[ListItem.Icon]</texture>
+					<texture>$INFO[ListItem.Icon]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
 				<control type="label" id="1">

--- a/addons/skin.estouchy/xml/ViewsThumbnail.xml
+++ b/addons/skin.estouchy/xml/ViewsThumbnail.xml
@@ -32,7 +32,7 @@
 					<posy>5</posy>
 					<width>200</width>
 					<height>200</height>
-					<texture background="true">$INFO[Listitem.Icon]</texture>
+					<texture>$INFO[Listitem.Icon]</texture>
 					<aspectratio>scale</aspectratio>
 					<visible>Container.Content(Artists) | Container.Content(Albums) | Container.Content(Songs) | Container.Content(Addons) | Container.Content(Games) | Container.Content(Images) | Container.Content(Actors) | Container.Content(Sets)</visible>
 				</control>
@@ -41,7 +41,7 @@
 					<posy>62</posy>
 					<width>86</width>
 					<height>86</height>
-					<texture background="true">$INFO[Listitem.Icon]</texture>
+					<texture>$INFO[Listitem.Icon]</texture>
 					<aspectratio>keep</aspectratio>
 					<visible>Container.Content() | Container.Content(Files) | Container.Content(Games) | Container.Content(Genres) | Container.Content(Years) | Container.Content(Directors) | Container.Content(Studios) | Container.Content(Countries) | Container.Content(Tags) | Container.Content(Playlists)</visible>
 				</control>
@@ -104,7 +104,7 @@
 					<posy>5</posy>
 					<width>200</width>
 					<height>200</height>
-					<texture background="true">$INFO[Listitem.Icon]</texture>
+					<texture>$INFO[Listitem.Icon]</texture>
 					<aspectratio>scale</aspectratio>
 					<visible>Container.Content(Artists) | Container.Content(Albums) | Container.Content(Songs) | Container.Content(Addons) | Container.Content(Games) | Container.Content(Images) | Container.Content(Actors) | Container.Content(Sets)</visible>
 				</control>
@@ -113,7 +113,7 @@
 					<posy>62</posy>
 					<width>86</width>
 					<height>86</height>
-					<texture background="true">$INFO[Listitem.Icon]</texture>
+					<texture>$INFO[Listitem.Icon]</texture>
 					<aspectratio>keep</aspectratio>
 					<visible>Container.Content() | Container.Content(Files) | Container.Content(Genres) | Container.Content(Years) | Container.Content(Directors) | Container.Content(Studios) | Container.Content(Countries) | Container.Content(Tags) | Container.Content(Playlists)</visible>
 				</control>
@@ -177,7 +177,7 @@
 					<posy>5</posy>
 					<width>200</width>
 					<height>300</height>
-					<texture background="true">$VAR[PosterThumb]</texture>
+					<texture>$VAR[PosterThumb]</texture>
 					<aspectratio>stretch</aspectratio>
 				</control>
 				<control type="image">
@@ -246,7 +246,7 @@
 					<posy>5</posy>
 					<width>200</width>
 					<height>300</height>
-					<texture background="true">$VAR[PosterThumb]</texture>
+					<texture>$VAR[PosterThumb]</texture>
 					<aspectratio>stretch</aspectratio>
 				</control>
 				<control type="image">
@@ -316,7 +316,7 @@
 					<width>298</width>
 					<height>168</height>
 					<aspectratio>scale</aspectratio>
-					<texture background="true">$INFO[Listitem.Icon]</texture>
+					<texture>$INFO[Listitem.Icon]</texture>
 				</control>
 				<control type="image">
 					<posx>5</posx>
@@ -377,7 +377,7 @@
 					<width>298</width>
 					<height>168</height>
 					<aspectratio>scale</aspectratio>
-					<texture background="true">$INFO[Listitem.Icon]</texture>
+					<texture>$INFO[Listitem.Icon]</texture>
 				</control>
 				<control type="image">
 					<posx>5</posx>

--- a/addons/skin.estouchy/xml/ViewsWide.xml
+++ b/addons/skin.estouchy/xml/ViewsWide.xml
@@ -41,7 +41,7 @@
 					<posy>10</posy>
 					<width>150</width>
 					<height>220</height>
-					<texture background="true">$VAR[PosterThumb]</texture>
+					<texture>$VAR[PosterThumb]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
 				<control type="label">
@@ -147,7 +147,7 @@
 					<posy>10</posy>
 					<width>150</width>
 					<height>220</height>
-					<texture background="true">$VAR[PosterThumb]</texture>
+					<texture>$VAR[PosterThumb]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
 				<control type="label">
@@ -247,7 +247,7 @@
 					<width>250</width>
 					<height>160</height>
 					<aspectratio>scale</aspectratio>
-					<texture background="true">$INFO[ListItem.Icon]</texture>
+					<texture>$INFO[ListItem.Icon]</texture>
 				</control>
 				<control type="label">
 					<posx>10</posx>
@@ -357,7 +357,7 @@
 					<width>250</width>
 					<height>160</height>
 					<aspectratio>scale</aspectratio>
-					<texture background="true">$INFO[ListItem.Icon]</texture>
+					<texture>$INFO[ListItem.Icon]</texture>
 				</control>
 				<control type="label">
 					<posx>10</posx>
@@ -460,7 +460,7 @@
 					<width>230</width>
 					<height>230</height>
 					<aspectratio>scale</aspectratio>
-					<texture background="true">$INFO[ListItem.Icon]</texture>
+					<texture>$INFO[ListItem.Icon]</texture>
 				</control>
 				<control type="label">
 					<posx>250</posx>
@@ -590,7 +590,7 @@
 					<width>230</width>
 					<height>230</height>
 					<aspectratio>scale</aspectratio>
-					<texture background="true">$INFO[ListItem.Icon]</texture>
+					<texture>$INFO[ListItem.Icon]</texture>
 				</control>
 				<control type="label">
 					<posx>250</posx>
@@ -712,7 +712,7 @@
 					<width>230</width>
 					<height>230</height>
 					<aspectratio>scale</aspectratio>
-					<texture background="true">$INFO[ListItem.Icon]</texture>
+					<texture>$INFO[ListItem.Icon]</texture>
 				</control>
 				<control type="label">
 					<posx>250</posx>
@@ -771,7 +771,7 @@
 					<width>230</width>
 					<height>230</height>
 					<aspectratio>scale</aspectratio>
-					<texture background="true">$INFO[ListItem.Icon]</texture>
+					<texture>$INFO[ListItem.Icon]</texture>
 				</control>
 				<control type="label">
 					<posx>250</posx>

--- a/addons/skin.estuary/xml/Custom_1100_AddonLauncher.xml
+++ b/addons/skin.estuary/xml/Custom_1100_AddonLauncher.xml
@@ -13,7 +13,7 @@
 			<animation effect="fade" start="0" end="100" time="400">WindowOpen</animation>
 			<animation effect="fade" start="100" end="0" time="300">WindowClose</animation>
 			<animation effect="fade" time="400">VisibleChange</animation>
-			<imagepath background="true" colordiffuse="bg_overlay">$VAR[AddonsFanartVar]</imagepath>
+			<imagepath colordiffuse="bg_overlay">$VAR[AddonsFanartVar]</imagepath>
 			<visible>!Player.HasMedia</visible>
 		</control>
 		<control type="group">

--- a/addons/skin.estuary/xml/DialogAddonInfo.xml
+++ b/addons/skin.estuary/xml/DialogAddonInfo.xml
@@ -41,7 +41,7 @@
 					<control type="image">
 						<width>425</width>
 						<height>260</height>
-						<texture background="true">DefaultNoPreview.png</texture>
+						<texture>DefaultNoPreview.png</texture>
 						<aspectratio>scale</aspectratio>
 						<bordertexture border="21" infill="false">overlays/shadow.png</bordertexture>
 						<bordersize>20</bordersize>
@@ -50,7 +50,7 @@
 						<left>405</left>
 						<width>425</width>
 						<height>260</height>
-						<texture background="true">DefaultNoPreview.png</texture>
+						<texture>DefaultNoPreview.png</texture>
 						<aspectratio>scale</aspectratio>
 						<bordertexture border="21" infill="false">overlays/shadow.png</bordertexture>
 						<bordersize>20</bordersize>
@@ -59,7 +59,7 @@
 						<left>810</left>
 						<width>425</width>
 						<height>260</height>
-						<texture background="true">DefaultNoPreview.png</texture>
+						<texture>DefaultNoPreview.png</texture>
 						<aspectratio>scale</aspectratio>
 						<bordertexture border="21" infill="false">overlays/shadow.png</bordertexture>
 						<bordersize>20</bordersize>
@@ -78,7 +78,7 @@
 							<left>-12</left>
 							<width>425</width>
 							<height>260</height>
-							<texture background="true">DefaultNoPreview.png</texture>
+							<texture>DefaultNoPreview.png</texture>
 							<aspectratio>scale</aspectratio>
 							<bordertexture border="21" infill="false">overlays/shadow.png</bordertexture>
 							<bordersize>20</bordersize>
@@ -87,7 +87,7 @@
 							<left>-12</left>
 							<width>425</width>
 							<height>260</height>
-							<texture background="true">$INFO[ListItem.Icon]</texture>
+							<texture>$INFO[ListItem.Icon]</texture>
 							<aspectratio>scale</aspectratio>
 							<bordertexture border="21" infill="false">overlays/shadow.png</bordertexture>
 							<bordersize>20</bordersize>
@@ -98,7 +98,7 @@
 							<left>-12</left>
 							<width>425</width>
 							<height>260</height>
-							<texture background="true">DefaultNoPreview.png</texture>
+							<texture>DefaultNoPreview.png</texture>
 							<aspectratio>scale</aspectratio>
 							<bordertexture border="21" infill="false">overlays/shadow.png</bordertexture>
 							<bordersize>20</bordersize>
@@ -107,7 +107,7 @@
 							<left>-12</left>
 							<width>425</width>
 							<height>260</height>
-							<texture background="true">$INFO[ListItem.Icon]</texture>
+							<texture>$INFO[ListItem.Icon]</texture>
 							<aspectratio>scale</aspectratio>
 							<bordertexture border="21" infill="false">overlays/shadow.png</bordertexture>
 							<bordersize>20</bordersize>
@@ -316,7 +316,7 @@
 					<height>500</height>
 					<aspectratio aligny="top">scale</aspectratio>
 					<fadetime>300</fadetime>
-					<texture fallback="DefaultAddon.png" background="true">$INFO[ListItem.Art(thumb)]</texture>
+					<texture fallback="DefaultAddon.png">$INFO[ListItem.Art(thumb)]</texture>
 				</control>
 				<control type="group">
 					<visible>String.IsEqual(ListItem.AddonLifecycleType,$LOCALIZE[24170]) | String.IsEqual(ListItem.AddonLifecycleType,$LOCALIZE[24171])</visible>

--- a/addons/skin.estuary/xml/DialogMusicInfo.xml
+++ b/addons/skin.estuary/xml/DialogMusicInfo.xml
@@ -29,7 +29,7 @@
 					<height>570</height>
 					<aspectratio aligny="top">scale</aspectratio>
 					<fadetime>300</fadetime>
-					<texture background="true">$VAR[MusicInfoThumbVar]</texture>
+					<texture>$VAR[MusicInfoThumbVar]</texture>
 				</control>
 			</control>
 			<control type="group">
@@ -280,7 +280,7 @@
 							<top>21</top>
 							<width>190</width>
 							<height>190</height>
-							<texture border="2" fallback="DefaultAudio.png" background="true">$INFO[ListItem.Thumb]</texture>
+							<texture border="2" fallback="DefaultAudio.png">$INFO[ListItem.Thumb]</texture>
 							<aspectratio>keep</aspectratio>
 							<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
 							<bordersize>4</bordersize>
@@ -316,7 +316,7 @@
 								<top>21</top>
 								<width>190</width>
 								<height>190</height>
-								<texture border="2" fallback="DefaultAudio.png" background="true">$INFO[ListItem.Thumb]</texture>
+								<texture border="2" fallback="DefaultAudio.png">$INFO[ListItem.Thumb]</texture>
 								<aspectratio>keep</aspectratio>
 								<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
 								<bordersize>4</bordersize>

--- a/addons/skin.estuary/xml/DialogPVRChannelManager.xml
+++ b/addons/skin.estuary/xml/DialogPVRChannelManager.xml
@@ -198,7 +198,7 @@
 					<width>70</width>
 					<height>50</height>
 					<aspectratio>keep</aspectratio>
-					<texture background="true">$INFO[Container(20).ListItem.Property(icon)]</texture>
+					<texture>$INFO[Container(20).ListItem.Property(icon)]</texture>
 				</control>
 				<control type="grouplist">
 					<top>590</top>

--- a/addons/skin.estuary/xml/DialogPictureInfo.xml
+++ b/addons/skin.estuary/xml/DialogPictureInfo.xml
@@ -28,7 +28,7 @@
 					<aspectratio aligny="center">keep</aspectratio>
 					<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
 					<bordersize>4</bordersize>
-					<texture border="4" background="true" fallback="colors/black.png">$INFO[ListItem.FolderPath]</texture>
+					<texture border="4" fallback="colors/black.png">$INFO[ListItem.FolderPath]</texture>
 				</control>
 			</control>
 			<control type="group">

--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -395,7 +395,7 @@
 				<width>400</width>
 				<height>600</height>
 				<aspectratio aligny="bottom">keep</aspectratio>
-				<texture fallback="DefaultVideo.png" background="true">$VAR[NowPlayingPosterVar]</texture>
+				<texture fallback="DefaultVideo.png">$VAR[NowPlayingPosterVar]</texture>
 				<bordertexture border="21" infill="false">overlays/shadow.png</bordertexture>
 				<bordersize>20</bordersize>
 				<include>OpenClose_Left</include>

--- a/addons/skin.estuary/xml/DialogVideoInfo.xml
+++ b/addons/skin.estuary/xml/DialogVideoInfo.xml
@@ -30,7 +30,7 @@
 					<width>526</width>
 					<height>801</height>
 					<aspectratio>scale</aspectratio>
-					<texture fallback="DefaultVideo.png" background="true">$VAR[InfoDialogPosterVar]</texture>
+					<texture fallback="DefaultVideo.png">$VAR[InfoDialogPosterVar]</texture>
 				</control>
 				<control type="group">
 					<visible>String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,video)</visible>
@@ -317,7 +317,7 @@
 								<left>20</left>
 								<width>224</width>
 								<height>277</height>
-								<texture background="true">$INFO[ListItem.Thumb]</texture>
+								<texture>$INFO[ListItem.Thumb]</texture>
 								<aspectratio aligny="center">scale</aspectratio>
 							</control>
 							<control type="image">
@@ -369,7 +369,7 @@
 								<left>20</left>
 								<width>224</width>
 								<height>277</height>
-								<texture background="true">$INFO[ListItem.Thumb]</texture>
+								<texture>$INFO[ListItem.Thumb]</texture>
 								<aspectratio aligny="center">scale</aspectratio>
 							</control>
 							<control type="image">
@@ -430,7 +430,7 @@
 								<left>20</left>
 								<width>204</width>
 								<height>277</height>
-								<texture background="true">$INFO[ListItem.Art(poster)]</texture>
+								<texture>$INFO[ListItem.Art(poster)]</texture>
 								<aspectratio aligny="center">keep</aspectratio>
 							</control>
 							<control type="image">
@@ -472,7 +472,7 @@
 								<left>20</left>
 								<width>204</width>
 								<height>277</height>
-								<texture background="true">$INFO[ListItem.Art(poster)]</texture>
+								<texture>$INFO[ListItem.Art(poster)]</texture>
 								<aspectratio aligny="center">keep</aspectratio>
 							</control>
 							<control type="image">

--- a/addons/skin.estuary/xml/FileBrowser.xml
+++ b/addons/skin.estuary/xml/FileBrowser.xml
@@ -52,7 +52,7 @@
 				<aspectratio aligny="bottom">keep</aspectratio>
 				<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
 				<bordersize>4</bordersize>
-				<texture border="4" background="true">$INFO[ListItem.Icon]</texture>
+				<texture border="4">$INFO[ListItem.Icon]</texture>
 			</control>
 			<control type="image">
 				<left>0</left>

--- a/addons/skin.estuary/xml/Home.xml
+++ b/addons/skin.estuary/xml/Home.xml
@@ -27,7 +27,7 @@
 			<animation effect="fade" start="0" end="100" time="400">WindowOpen</animation>
 			<animation effect="fade" start="100" end="0" time="300">WindowClose</animation>
 			<animation effect="fade" time="400">VisibleChange</animation>
-			<imagepath background="true" colordiffuse="bg_overlay">$VAR[HomeFanartVar]</imagepath>
+			<imagepath colordiffuse="bg_overlay">$VAR[HomeFanartVar]</imagepath>
 			<visible>!Player.HasMedia</visible>
 		</control>
 		<control type="group">

--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -1170,7 +1170,7 @@
 						<aspectratio>scale</aspectratio>
 						<fadetime>400</fadetime>
 						<animation effect="fade" time="400">VisibleChange</animation>
-						<texture background="true" colordiffuse="37FFFFFF">$VAR[MediaFanartVar]</texture>
+						<texture colordiffuse="37FFFFFF">$VAR[MediaFanartVar]</texture>
 						<visible>!Control.IsVisible(502) | $EXP[infodialog_active]</visible>
 					</control>
 					<control type="image">
@@ -1182,7 +1182,7 @@
 						<fadetime>400</fadetime>
 						<include>OpenClose_Left</include>
 						<animation effect="fade" time="400">VisibleChange</animation>
-						<texture background="true" colordiffuse="37FFFFFF">$VAR[PosterVar]</texture>
+						<texture colordiffuse="37FFFFFF">$VAR[PosterVar]</texture>
 						<visible>!Control.IsVisible(32111)</visible>
 					</control>
 				</control>

--- a/addons/skin.estuary/xml/MusicVisualisation.xml
+++ b/addons/skin.estuary/xml/MusicVisualisation.xml
@@ -20,7 +20,7 @@
 				<animation effect="fade" start="0" end="100" time="400">WindowOpen</animation>
 				<animation effect="fade" start="100" end="0" time="300">WindowClose</animation>
 				<animation effect="fade" start="100" end="50" time="0" condition="Visualisation.Enabled">Conditional</animation>
-				<texture background="true">$INFO[Player.Art(fanart)]</texture>
+				<texture>$INFO[Player.Art(fanart)]</texture>
 				<visible>String.IsEmpty(Window(Visualisation).Property(ArtistSlideshow.Image))</visible>
 			</control>
 			<control type="image">
@@ -29,7 +29,7 @@
 				<animation effect="fade" start="0" end="100" time="400">WindowOpen</animation>
 				<animation effect="fade" start="100" end="0" time="300">WindowClose</animation>
 				<animation effect="fade" start="100" end="50" time="0" condition="Visualisation.Enabled">Conditional</animation>
-				<texture background="true">$INFO[Window(Visualisation).Property(ArtistSlideshow.Image)]</texture>
+				<texture>$INFO[Window(Visualisation).Property(ArtistSlideshow.Image)]</texture>
 			</control>
 		</control>
 		<control type="group">

--- a/addons/skin.estuary/xml/MyWeather.xml
+++ b/addons/skin.estuary/xml/MyWeather.xml
@@ -47,7 +47,7 @@
 			<animation effect="fade" start="0" end="100" time="400">WindowOpen</animation>
 			<animation effect="fade" start="100" end="0" time="300">WindowClose</animation>
 			<animation effect="fade" time="400">VisibleChange</animation>
-			<imagepath background="true" colordiffuse="bg_overlay">$VAR[WeatherFanartVar]</imagepath>
+			<imagepath colordiffuse="bg_overlay">$VAR[WeatherFanartVar]</imagepath>
 			<visible>!Player.HasMedia</visible>
 		</control>
 		<control type="grouplist" id="2000">

--- a/addons/skin.estuary/xml/SettingsProfile.xml
+++ b/addons/skin.estuary/xml/SettingsProfile.xml
@@ -13,7 +13,7 @@
 			<animation effect="fade" start="0" end="100" time="400">WindowOpen</animation>
 			<animation effect="fade" start="100" end="0" time="300">WindowClose</animation>
 			<animation effect="fade" time="400">VisibleChange</animation>
-			<imagepath background="true" colordiffuse="bg_overlay">$INFO[Skin.String(HomeFanart.path)]settings$INFO[Skin.String(HomeFanart.ext)]</imagepath>
+			<imagepath colordiffuse="bg_overlay">$INFO[Skin.String(HomeFanart.path)]settings$INFO[Skin.String(HomeFanart.ext)]</imagepath>
 			<visible>!Player.HasMedia + !String.IsEmpty(Skin.String(HomeFanart.path))</visible>
 		</control>
 		<control type="group" id="9100">

--- a/addons/skin.estuary/xml/SettingsSystemInfo.xml
+++ b/addons/skin.estuary/xml/SettingsSystemInfo.xml
@@ -12,7 +12,7 @@
 			<animation effect="fade" start="0" end="100" time="400">WindowOpen</animation>
 			<animation effect="fade" start="100" end="0" time="300">WindowClose</animation>
 			<animation effect="fade" time="400">VisibleChange</animation>
-			<imagepath background="true" colordiffuse="bg_overlay">$INFO[Skin.String(HomeFanart.path)]settings$INFO[Skin.String(HomeFanart.ext)]</imagepath>
+			<imagepath colordiffuse="bg_overlay">$INFO[Skin.String(HomeFanart.path)]settings$INFO[Skin.String(HomeFanart.ext)]</imagepath>
 			<visible>!Player.HasMedia + !String.IsEmpty(Skin.String(HomeFanart.path))</visible>
 		</control>
 		<control type="group">

--- a/addons/skin.estuary/xml/SkinSettings.xml
+++ b/addons/skin.estuary/xml/SkinSettings.xml
@@ -14,7 +14,7 @@
 			<animation effect="fade" start="0" end="100" time="400">WindowOpen</animation>
 			<animation effect="fade" start="100" end="0" time="300">WindowClose</animation>
 			<animation effect="fade" time="400">VisibleChange</animation>
-			<imagepath background="true" colordiffuse="bg_overlay">$INFO[Skin.String(HomeFanart.path)]settings$INFO[Skin.String(HomeFanart.ext)]</imagepath>
+			<imagepath colordiffuse="bg_overlay">$INFO[Skin.String(HomeFanart.path)]settings$INFO[Skin.String(HomeFanart.ext)]</imagepath>
 			<visible>!Player.HasMedia + !String.IsEmpty(Skin.String(HomeFanart.path))</visible>
 		</control>
 		<control type="group" id="10000">

--- a/addons/skin.estuary/xml/View_501_Banner.xml
+++ b/addons/skin.estuary/xml/View_501_Banner.xml
@@ -29,7 +29,7 @@
 							<top>0</top>
 							<width>860</width>
 							<height>195</height>
-							<texture fallback="dialogs/dialog-bg-nobo.png" background="true">$VAR[BannerArtVar]</texture>
+							<texture fallback="dialogs/dialog-bg-nobo.png">$VAR[BannerArtVar]</texture>
 							<aspectratio aligny="center">scale</aspectratio>
 							<bordertexture border="21" infill="false">overlays/shadow.png</bordertexture>
 							<bordersize>20</bordersize>
@@ -66,7 +66,7 @@
 							<top>0</top>
 							<width>860</width>
 							<height>195</height>
-							<texture fallback="dialogs/dialog-bg-nobo.png" background="true">$VAR[BannerArtVar]</texture>
+							<texture fallback="dialogs/dialog-bg-nobo.png">$VAR[BannerArtVar]</texture>
 							<aspectratio aligny="center">scale</aspectratio>
 							<bordertexture border="21" infill="false">overlays/shadow.png</bordertexture>
 							<bordersize>20</bordersize>

--- a/addons/skin.estuary/xml/View_502_FanArt.xml
+++ b/addons/skin.estuary/xml/View_502_FanArt.xml
@@ -32,7 +32,7 @@
 					<top>115</top>
 					<height>644</height>
 					<fadetime>300</fadetime>
-					<texture border="2" fallback="special://skin/extras/home-images/movie.jpg" background="true">$VAR[FanartImageVar]</texture>
+					<texture border="2" fallback="special://skin/extras/home-images/movie.jpg">$VAR[FanartImageVar]</texture>
 					<aspectratio align="center" aligny="bottom">scale</aspectratio>
 				</control>
 				<control type="group">

--- a/addons/skin.estuary/xml/View_50_List.xml
+++ b/addons/skin.estuary/xml/View_50_List.xml
@@ -61,7 +61,7 @@
 						<bottom>124</bottom>
 						<fadetime>200</fadetime>
 						<aspectratio aligny="bottom">keep</aspectratio>
-						<texture fallback="DefaultVideo.png" background="true">$VAR[InfoWallThumbVar]</texture>
+						<texture fallback="DefaultVideo.png">$VAR[InfoWallThumbVar]</texture>
 					</control>
 					<control type="group">
 						<left>291</left>
@@ -80,7 +80,7 @@
 						<height>470</height>
 						<aspectratio aligny="bottom">keep</aspectratio>
 						<fadetime>300</fadetime>
-						<texture fallback="DefaultAudio.png" background="true">$INFO[Player.Icon]</texture>
+						<texture fallback="DefaultAudio.png">$INFO[Player.Icon]</texture>
 					</control>
 					<control type="group">
 						<left>301</left>
@@ -239,7 +239,7 @@
 					<height>470</height>
 					<aspectratio aligny="bottom">keep</aspectratio>
 					<fadetime>300</fadetime>
-					<texture fallback="$PARAM[fallback_image]" background="true">$VAR[IconWallThumbVar]</texture>
+					<texture fallback="$PARAM[fallback_image]">$VAR[IconWallThumbVar]</texture>
 					<visible>!String.IsEqual(ListItem.DbType,episode) + !String.IsEqual(ListItem.DBType,song)</visible>
 				</control>
 				<control type="image">
@@ -249,7 +249,7 @@
 					<height>330</height>
 					<aspectratio aligny="bottom">keep</aspectratio>
 					<fadetime>300</fadetime>
-					<texture background="true">$VAR[ShiftThumbVar]</texture>
+					<texture>$VAR[ShiftThumbVar]</texture>
 					<visible>String.IsEqual(ListItem.DbType,episode)</visible>
 				</control>
 				<control type="image">
@@ -259,7 +259,7 @@
 					<height>470</height>
 					<aspectratio aligny="bottom">keep</aspectratio>
 					<fadetime>300</fadetime>
-					<texture fallback="DefaultAudio.png" background="true">$VAR[IconWallThumbVar]</texture>
+					<texture fallback="DefaultAudio.png">$VAR[IconWallThumbVar]</texture>
 					<visible>String.IsEqual(ListItem.DBType,song)</visible>
 				</control>
 				<control type="group">

--- a/addons/skin.estuary/xml/View_51_Poster.xml
+++ b/addons/skin.estuary/xml/View_51_Poster.xml
@@ -141,7 +141,7 @@
 				<height>716</height>
 				<fadetime>200</fadetime>
 				<aspectratio>scale</aspectratio>
-				<texture fallback="DefaultMovies.png" background="true">$VAR[PosterThumbVar]</texture>
+				<texture fallback="DefaultMovies.png">$VAR[PosterThumbVar]</texture>
 			</control>
 			<control type="group">
 				<visible>String.IsEqual(ListItem.DBtype,tvshow)</visible>

--- a/addons/skin.estuary/xml/View_53_Shift.xml
+++ b/addons/skin.estuary/xml/View_53_Shift.xml
@@ -79,7 +79,7 @@
 							<width>370</width>
 							<height>480</height>
 							<aspectratio aligny="center">keep</aspectratio>
-							<texture fallback="DefaultVideo.png" background="true">$VAR[ShiftThumbVar]</texture>
+							<texture fallback="DefaultVideo.png">$VAR[ShiftThumbVar]</texture>
 							<bordertexture border="21" infill="false">overlays/shadow.png</bordertexture>
 							<bordersize>20</bordersize>
 						</control>
@@ -166,7 +166,7 @@
 							<width>370</width>
 							<height>480</height>
 							<aspectratio aligny="center">keep</aspectratio>
-							<texture fallback="DefaultVideo.png" background="true">$VAR[ShiftThumbVar]</texture>
+							<texture fallback="DefaultVideo.png">$VAR[ShiftThumbVar]</texture>
 							<bordertexture border="21" infill="false">overlays/shadow.png</bordertexture>
 							<bordersize>20</bordersize>
 						</control>

--- a/addons/skin.estuary/xml/View_54_InfoWall.xml
+++ b/addons/skin.estuary/xml/View_54_InfoWall.xml
@@ -27,7 +27,7 @@
 				<top>10</top>
 				<width>336</width>
 				<height>300</height>
-				<texture border="2" background="true">$VAR[InfoWallThumbVar]</texture>
+				<texture border="2">$VAR[InfoWallThumbVar]</texture>
 				<aspectratio>keep</aspectratio>
 			</control>
 			<control type="label">
@@ -74,7 +74,7 @@
 				<top>0</top>
 				<width>316</width>
 				<height>316</height>
-				<texture fallback="$PARAM[fallback_image]" background="true">$VAR[InfoWallThumbVar]</texture>
+				<texture fallback="$PARAM[fallback_image]">$VAR[InfoWallThumbVar]</texture>
 				<aspectratio>keep</aspectratio>
 				<bordersize>20</bordersize>
 			</control>
@@ -150,7 +150,7 @@
 				<top>10</top>
 				<width>316</width>
 				<height>218</height>
-				<texture fallback="$PARAM[fallback_image]" background="true">$VAR[InfoWallThumbVar]</texture>
+				<texture fallback="$PARAM[fallback_image]">$VAR[InfoWallThumbVar]</texture>
 				<aspectratio>scale</aspectratio>
 				<bordersize>20</bordersize>
 			</control>
@@ -270,7 +270,7 @@
 					<top>-1</top>
 					<width>272</width>
 					<height>270</height>
-					<texture fallback="DefaultMovies.png" background="true">$INFO[ListItem.Icon]</texture>
+					<texture fallback="DefaultMovies.png">$INFO[ListItem.Icon]</texture>
 					<aspectratio>scale</aspectratio>
 					<bordersize>20</bordersize>
 				</control>
@@ -293,7 +293,7 @@
 					<top>-10</top>
 					<width>290</width>
 					<height>400</height>
-					<texture background="true">$INFO[ListItem.Art(poster)]</texture>
+					<texture>$INFO[ListItem.Art(poster)]</texture>
 					<aspectratio>scale</aspectratio>
 					<bordertexture border="21" infill="false">overlays/shadow.png</bordertexture>
 					<bordersize>20</bordersize>

--- a/xbmc/GUILargeTextureManager.cpp
+++ b/xbmc/GUILargeTextureManager.cpp
@@ -37,14 +37,14 @@ bool CImageLoader::DoWork()
   bool needsChecking = false;
   std::string loadPath;
 
-  std::string texturePath = CServiceBroker::GetGUI()->GetTextureManager().GetTexturePath(m_path);
-  if (texturePath.empty())
+  if (m_path.empty())
     return false;
 
-  if (m_use_cache)
-    loadPath = CServiceBroker::GetTextureCache()->CheckCachedImage(texturePath, needsChecking);
+  bool useCache = m_use_cache && CTextureCache::CanCacheImage(m_path);
+  if (useCache)
+    loadPath = CServiceBroker::GetTextureCache()->CheckCachedImage(m_path, needsChecking);
   else
-    loadPath = texturePath;
+    loadPath = m_path;
 
   if (!loadPath.empty())
   {
@@ -63,7 +63,7 @@ bool CImageLoader::DoWork()
     if (m_texture)
     {
       if (needsChecking)
-        CServiceBroker::GetTextureCache()->BackgroundCacheImage(texturePath);
+        CServiceBroker::GetTextureCache()->BackgroundCacheImage(m_path);
 
       return true;
     }
@@ -72,11 +72,11 @@ bool CImageLoader::DoWork()
     CLog::Log(LOGERROR, "{} - Direct texture file loading failed for {}", __FUNCTION__, loadPath);
   }
 
-  if (!m_use_cache)
+  if (!useCache)
     return false; // We're done
 
   // not in our texture cache or it failed to load from it, so try and load directly and then cache the result
-  CServiceBroker::GetTextureCache()->CacheImage(texturePath, &m_texture);
+  CServiceBroker::GetTextureCache()->CacheImage(m_path, &m_texture);
   return (m_texture != NULL);
 }
 

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -54,24 +54,25 @@ void CTextureCache::Deinitialize()
 
 bool CTextureCache::CanCacheImage(const std::string& url)
 {
-  if (url.empty())
+  const std::string checkurl = CTextureUtils::UnwrapImageURL(url);
+  if (checkurl.empty())
     return false;
 
-  if (!CURL::IsFullPath(url))
+  if (!CURL::IsFullPath(checkurl))
     return false;
 
   bool fastLoadingPath =
       // install directory and home directory are likely to be as fast or faster than texture cache
-      URIUtils::PathHasParent(url, "special://xbmc", true) ||
-      URIUtils::PathHasParent(url, "special://home", true) ||
+      URIUtils::PathHasParent(checkurl, "special://xbmc", true) ||
+      URIUtils::PathHasParent(checkurl, "special://home", true) ||
       // these are often located in 'home' or 'xbmc', but let's be clear
-      URIUtils::PathHasParent(url, "special://thumbnails", true) ||
-      URIUtils::PathHasParent(url, "special://skin", true) ||
-      URIUtils::PathHasParent(url, "special://temp", true) ||
+      URIUtils::PathHasParent(checkurl, "special://thumbnails", true) ||
+      URIUtils::PathHasParent(checkurl, "special://skin", true) ||
+      URIUtils::PathHasParent(checkurl, "special://temp", true) ||
       // image resources are often located in home, likely to be packed in xbt
-      URIUtils::PathHasParent(url, "resource://", true) ||
+      URIUtils::PathHasParent(checkurl, "resource://", true) ||
       // app icons loaded from Android system something
-      URIUtils::PathHasParent(url, "androidapp://", true);
+      URIUtils::PathHasParent(checkurl, "androidapp://", true);
   return !fastLoadingPath;
 }
 

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -142,6 +142,10 @@ public:
    */
   static bool CanCacheImageURL(const CURL &url);
 
+  /*! \brief Check if the texture cache can be used for the image at the given url.
+  */
+  static bool CanCacheImage(const std::string& url);
+
   /*! \brief Add this image to the database
    Thread-safe wrapper of CTextureDatabase::AddCachedTexture
    \param image url of the original image
@@ -162,12 +166,6 @@ private:
   // private construction, and no assignments; use the provided singleton methods
   CTextureCache(const CTextureCache&) = delete;
   CTextureCache const& operator=(CTextureCache const&) = delete;
-
-  /*! \brief Check if the given image is a cached image
-   \param image url of the image
-   \return true if this is a cached image, false otherwise.
-   */
-  bool IsCachedImage(const std::string &image) const;
 
   /*! \brief retrieve the cached version of the given image (if it exists)
    \param image url of the image

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -357,9 +357,6 @@ bool CGUIControlFactory::GetTexture(const TiXmlNode* pRootNode, const char* strT
     image.orientation = 3 - image.orientation; // either 3 or 2
   image.diffuse = XMLUtils::GetAttribute(pNode, "diffuse");
   image.diffuseColor.Parse(XMLUtils::GetAttribute(pNode, "colordiffuse"), 0);
-  const char *background = pNode->Attribute("background");
-  if (background && StringUtils::CompareNoCase(background, "true", 4) == 0)
-    image.useLarge = true;
   image.filename = pNode->FirstChild() ? pNode->FirstChild()->Value() : "";
   return true;
 }

--- a/xbmc/guilib/GUITexture.cpp
+++ b/xbmc/guilib/GUITexture.cpp
@@ -93,6 +93,7 @@ CGUITexture::CGUITexture(
   m_isAllocated = NO;
   m_invalid = true;
   m_use_cache = true;
+  m_info.useLarge = !CServiceBroker::GetGUI()->GetTextureManager().ShouldLoadImage(m_info.filename);
 }
 
 CGUITexture::CGUITexture(const CGUITexture& right)
@@ -313,12 +314,8 @@ bool CGUITexture::AllocResources()
 
   // reset our animstate
   ResetAnimState();
-
-  bool useLargeLoader =
-      !CServiceBroker::GetGUI()->GetTextureManager().ShouldLoadImage(m_info.filename);
-
   bool changed = false;
-  if (useLargeLoader)
+  if (m_info.useLarge)
   {
     if (m_isAllocated != NORMAL)
     { // use our large image background loader
@@ -673,6 +670,7 @@ bool CGUITexture::SetFileName(const std::string& filename)
   // filenames mid-animation
   FreeResources();
   m_info.filename = filename;
+  m_info.useLarge = !CServiceBroker::GetGUI()->GetTextureManager().ShouldLoadImage(m_info.filename);
 
   // Don't allocate resources here as this is done at render time
   return true;

--- a/xbmc/guilib/GUITexture.cpp
+++ b/xbmc/guilib/GUITexture.cpp
@@ -314,21 +314,12 @@ bool CGUITexture::AllocResources()
   // reset our animstate
   ResetAnimState();
 
+  bool useLargeLoader =
+      !CServiceBroker::GetGUI()->GetTextureManager().ShouldLoadImage(m_info.filename);
+
   bool changed = false;
-  bool useLarge = m_info.useLarge || !CServiceBroker::GetGUI()->GetTextureManager().CanLoad(m_info.filename);
-  if (useLarge)
-  { // we want to use the large image loader, but we first check for bundled textures
-    if (!IsAllocated())
-    {
-      CTextureArray texture;
-      texture = CServiceBroker::GetGUI()->GetTextureManager().Load(m_info.filename, true);
-      if (texture.size())
-      {
-        m_isAllocated = NORMAL;
-        m_texture = texture;
-        changed = true;
-      }
-    }
+  if (useLargeLoader)
+  {
     if (m_isAllocated != NORMAL)
     { // use our large image background loader
       CTextureArray texture;
@@ -682,13 +673,6 @@ bool CGUITexture::SetFileName(const std::string& filename)
   // filenames mid-animation
   FreeResources();
   m_info.filename = filename;
-
-  // disable large loader and cache for gifs
-  if (StringUtils::EndsWithNoCase(m_info.filename, ".gif"))
-  {
-    m_info.useLarge = false;
-    SetUseCache(false);
-  }
 
   // Don't allocate resources here as this is done at render time
   return true;

--- a/xbmc/guilib/TextureManager.cpp
+++ b/xbmc/guilib/TextureManager.cpp
@@ -241,6 +241,25 @@ bool CGUITextureManager::CanLoad(const std::string &texturePath)
   return URIUtils::IsHD(texturePath);
 }
 
+bool CGUITextureManager::ShouldLoadImage(const std::string& url)
+{
+  if (url.empty())
+    return false;
+
+  // assume this is a relative path to a skin image
+  if (!CURL::IsFullPath(url))
+    return true;
+
+  // this is an absolute path to a skin image
+  if (URIUtils::PathHasParent(url, "special://skin/media", true))
+    return true;
+
+  // this is the only loader built to handle animated .gif and .apng,
+  // but this loader only supports 'local' paths. Otherwise they go through
+  // the LargeTextureManager / async loader, which displays a static image
+  return URIUtils::HasExtension(url, ".gif|.apng") && URIUtils::IsHD(url);
+}
+
 bool CGUITextureManager::HasTexture(const std::string &textureName, std::string *path, int *bundle, int *size)
 {
   std::unique_lock<CCriticalSection> lock(m_section);

--- a/xbmc/guilib/TextureManager.cpp
+++ b/xbmc/guilib/TextureManager.cpp
@@ -250,10 +250,6 @@ bool CGUITextureManager::ShouldLoadImage(const std::string& url)
   if (!CURL::IsFullPath(url))
     return true;
 
-  // this is an absolute path to a skin image
-  if (URIUtils::PathHasParent(url, "special://skin/media", true))
-    return true;
-
   // this is the only loader built to handle animated .gif and .apng,
   // but this loader only supports 'local' paths. Otherwise they go through
   // the LargeTextureManager / async loader, which displays a static image

--- a/xbmc/guilib/TextureManager.h
+++ b/xbmc/guilib/TextureManager.h
@@ -101,6 +101,12 @@ public:
 
   bool HasTexture(const std::string &textureName, std::string *path = NULL, int *bundle = NULL, int *size = NULL);
   static bool CanLoad(const std::string &texturePath); ///< Returns true if the texture manager can load this texture
+  /*!
+   * @brief Should this Texture Manager be used to load the given image.
+   *
+   * Basically, this is for skin textures. And local gif files, that was built into this.
+  */
+  static bool ShouldLoadImage(const std::string& url);
   const CTextureArray& Load(const std::string& strTextureName, bool checkBundleOnly = false);
   void ReleaseTexture(const std::string& strTextureName, bool immediately = false);
   void Cleanup();


### PR DESCRIPTION
## Description
Only use the blocking image loader for skin textures, otherwise use the background / asynchronous texture loader (`CGUILargeTextureManager`) for all images. This includes media artwork viewed in the library, file browsers, and plugins; backgrounds, image resources, PVR channel logos, and video, picture, and game thumbnails. Surely others.

The only images loaded by the blocking / synchronous image loader (`CGUITextureManager`) are skin textures - **images in the skin's _media/_ directory that are or should be in an xbt**. And animated gif / apng, the functionality to load animated textures still only exists in the sync loader.

This also tightens up the selection of images that will be saved in the Thumbnail / Texture Cache, as the default behavior of the background loader is to cache images.

Removed `background="true"` from all skin files - that is the majority of "Files changed".

[Call to action forum post](https://forum.kodi.tv/showthread.php?tid=372647) for skin designers to test for edge cases. Skins may see a difference in texture loading if they intentionally used the sync loader for images not in their _media/_ folder, like _special://skin/extras/_.

## Motivation and context
Ensure images that need to be cached before display do so correctly in all cases. Potentially less jank with fewer images loaded from a file system on the main thread. Fix #21744 permanently for all images displayed in all skins. Remove one fiddly little thing (should this image control use `background="true"`?) that skinners have to deal with.

## How has this been tested?
Manually, I've been using this regularly for a couple months; basic video and music library usage and a bit of plugins. Rarely with Estuary.

## What is the effect on users?
Little notable effect on end-users.

📰🥸 Remove one texture xml attribute for skin designers to deal with - `background="true"`.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
