### PR TITLE
[video][music] Fix auto play next item setting

### DIFF
--- a/xbmc/music/ContextMenus.cpp
+++ b/xbmc/music/ContextMenus.cpp
@@ -15,7 +15,9 @@
 #include "guilib/GUIWindowManager.h"
 #include "music/MusicUtils.h"
 #include "music/dialogs/GUIDialogMusicInfo.h"
+#include "playlists/PlayListTypes.h"
 #include "tags/MusicInfoTag.h"
+#include "utils/Variant.h"
 
 #include <utility>
 
@@ -70,7 +72,12 @@ bool CMusicPlay::IsVisible(const CFileItem& item) const
 
 bool CMusicPlay::Execute(const std::shared_ptr<CFileItem>& item) const
 {
-  MUSIC_UTILS::PlayItem(item);
+  const ContentUtils::PlayMode mode = item->GetProperty("CheckAutoPlayNextItem").asBoolean()
+                                          ? ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM
+                                          : ContentUtils::PlayMode::PLAY_ONLY_THIS;
+  MUSIC_UTILS::PlayItem(item, mode);
+
+  item->SetProperty("playlist_type_hint", PLAYLIST::TYPE_MUSIC);
   return true;
 }
 

--- a/xbmc/music/MusicUtils.h
+++ b/xbmc/music/MusicUtils.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "media/MediaType.h"
+#include "utils/ContentUtils.h"
 
 #include <memory>
 #include <string>
@@ -80,12 +81,20 @@ std::vector<std::string> GetArtTypesToScan(const MediaType& mediaType);
   */
 bool IsValidArtType(const std::string& potentialArtType);
 
+/*! \brief Check whether auto play next item is set for the given item.
+  \param item [in] the item to check
+  \return True if auto play next item is active, false otherwise.
+  */
+bool IsAutoPlayNextItem(const CFileItem& item);
+
 /*! \brief Start playback of the given item. If the item is a folder, build a playlist with
   all items contained in the folder and start playback of the playlist. If item is a single music
   item, start playback directly, without adding it to the music playlist first.
   \param item [in] the item to play
+  \param mode [in] queue all successors and play them after item
   */
-void PlayItem(const std::shared_ptr<CFileItem>& item);
+void PlayItem(const std::shared_ptr<CFileItem>& item,
+              ContentUtils::PlayMode mode = ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM);
 
 enum class QueuePosition
 {

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -672,6 +672,17 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
   CGUIWindowMusicBase::GetNonContextButtons(buttons);
 }
 
+bool CGUIWindowMusicNav::OnPopupMenu(int iItem)
+{
+  if (iItem >= 0 && iItem < m_vecItems->Size())
+  {
+    const auto item = m_vecItems->Get(iItem);
+    item->SetProperty("CheckAutoPlayNextItem", true);
+  }
+
+  return CGUIWindowMusicBase::OnPopupMenu(iItem);
+}
+
 bool CGUIWindowMusicNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 {
   CFileItemPtr item;

--- a/xbmc/music/windows/GUIWindowMusicNav.h
+++ b/xbmc/music/windows/GUIWindowMusicNav.h
@@ -33,6 +33,7 @@ protected:
   void PlayItem(int iItem) override;
   void OnWindowLoaded() override;
   void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
+  bool OnPopupMenu(int iItem) override;
   bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
   bool OnClick(int iItem, const std::string &player = "") override;
   std::string GetStartFolder(const std::string &url) override;

--- a/xbmc/pvr/guilib/PVRGUIActionsPlayback.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsPlayback.h
@@ -58,6 +58,14 @@ public:
   bool PlayRecording(const CFileItem& item, bool bCheckResume) const;
 
   /*!
+   * @brief Play a recording folder.
+   * @param item containing a recording folder.
+   * @param bCheckResume controls resume check.
+   * @return true on success, false otherwise.
+   */
+  bool PlayRecordingFolder(const CFileItem& item, bool bCheckResume) const;
+
+  /*!
    * @brief Play EPG tag.
    * @param item containing an epg tag.
    * @return true on success, false otherwise.

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -28,9 +28,7 @@
 #include "settings/SettingsComponent.h"
 #include "utils/URIUtils.h"
 #include "video/VideoLibraryQueue.h"
-#include "video/VideoUtils.h"
 #include "video/windows/GUIWindowVideoBase.h"
-#include "video/windows/GUIWindowVideoNav.h"
 
 #include <memory>
 #include <mutex>
@@ -121,6 +119,17 @@ bool CGUIWindowPVRRecordingsBase::OnAction(const CAction& action)
   }
 
   return CGUIWindowPVRBase::OnAction(action);
+}
+
+bool CGUIWindowPVRRecordingsBase::OnPopupMenu(int iItem)
+{
+  if (iItem >= 0 && iItem < m_vecItems->Size())
+  {
+    const auto item = m_vecItems->Get(iItem);
+    item->SetProperty("CheckAutoPlayNextItem", true);
+  }
+
+  return CGUIWindowPVRBase::OnPopupMenu(iItem);
 }
 
 bool CGUIWindowPVRRecordingsBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
@@ -241,8 +250,8 @@ bool CGUIWindowPVRRecordingsBase::OnMessage(CGUIMessage& message)
               {
                 if (item->m_bIsFolder)
                 {
-                  if (CGUIWindowVideoNav::ShowResumeMenu(*item))
-                    VIDEO_UTILS::PlayItem(item);
+                  CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayRecordingFolder(
+                      *item, true /* check resume */);
                 }
                 else
                   CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayRecording(

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.h
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.h
@@ -30,6 +30,7 @@ public:
   bool OnMessage(CGUIMessage& message) override;
   bool OnAction(const CAction& action) override;
   void GetContextButtons(int itemNumber, CContextButtons& buttons) override;
+  bool OnPopupMenu(int iItem) override;
   bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
   bool Update(const std::string& strDirectory, bool updateFilterPath = true) override;
   void UpdateButtons() override;

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -473,6 +473,13 @@ public:
   static const int MUSICLIBRARY_ARTWORK_LEVEL_CUSTOM = 2;
   static const int MUSICLIBRARY_ARTWORK_LEVEL_NONE = 3;
 
+  // values for SETTING_VIDEOPLAYER_AUTOPLAYNEXTITEM
+  static constexpr int SETTING_AUTOPLAYNEXT_MUSICVIDEOS = 0;
+  static constexpr int SETTING_AUTOPLAYNEXT_TVSHOWS = 1;
+  static constexpr int SETTING_AUTOPLAYNEXT_EPISODES = 2;
+  static constexpr int SETTING_AUTOPLAYNEXT_MOVIES = 3;
+  static constexpr int SETTING_AUTOPLAYNEXT_UNCATEGORIZED = 4;
+
   /*!
    \brief Creates a new settings wrapper around a new settings manager.
 

--- a/xbmc/utils/ContentUtils.h
+++ b/xbmc/utils/ContentUtils.h
@@ -18,6 +18,16 @@ class CFileItem;
 class ContentUtils
 {
 public:
+  /*! \brief Defines play modes to be used in conjunction with the setting "play next video|song
+   automatically".
+   */
+  enum class PlayMode
+  {
+    CHECK_AUTO_PLAY_NEXT_ITEM, /*! play from here, or play only this, according to settings value */
+    PLAY_FROM_HERE, /*! queue all successors and play them after item, ignoring the settings value */
+    PLAY_ONLY_THIS, /*! play only this item, ignoring the settings value */
+  };
+
   /*! \brief Gets the preferred art image for a given item (depending on its media type). Provided a CFileItem
     with many art types on its art map, this method will return a default preferred image (content dependent) for situations where the
     the client expects a single image to represent the item. For instance, for movies and shows this will return the poster, while for

--- a/xbmc/video/ContextMenus.h
+++ b/xbmc/video/ContextMenus.h
@@ -104,9 +104,9 @@ struct CVideoPlayNext : CStaticContextMenuAction
   bool Execute(const std::shared_ptr<CFileItem>& item) const override;
 };
 
-struct CVideoPlayAndQueue : CStaticContextMenuAction
+struct CVideoPlayAndQueue : IContextMenuItem
 {
-  CVideoPlayAndQueue() : CStaticContextMenuAction(13412) {} // Play from here
+  std::string GetLabel(const CFileItem& item) const override;
   bool IsVisible(const CFileItem& item) const override;
   bool Execute(const std::shared_ptr<CFileItem>& item) const override;
 };

--- a/xbmc/video/VideoUtils.h
+++ b/xbmc/video/VideoUtils.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "utils/ContentUtils.h"
+
 #include <memory>
 
 class CFileItem;
@@ -15,12 +17,26 @@ class CFileItemList;
 
 namespace VIDEO_UTILS
 {
+/*! \brief Check whether auto play next item is set for the media type of the given item.
+  \param item [in] the item to check
+  \return True if auto play next item is active, false otherwise.
+  */
+bool IsAutoPlayNextItem(const CFileItem& item);
+
+/*! \brief Check whether auto play next item is set for the given content type.
+  \param item [in] the content to check
+  \return True if auto play next item is active, false otherwise.
+  */
+bool IsAutoPlayNextItem(const std::string& content);
+
 /*! \brief Start playback of the given item. If the item is a folder, build a playlist with
   all items contained in the folder and start playback of the playlist. If item is a single video
   item, start playback directly, without adding it to the video playlist first.
   \param item [in] the item to play
+  \param mode [in] queue all successors and play them after item
   */
-void PlayItem(const std::shared_ptr<CFileItem>& item);
+void PlayItem(const std::shared_ptr<CFileItem>& item,
+              ContentUtils::PlayMode mode = ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM);
 
 enum class QueuePosition
 {
@@ -36,13 +52,13 @@ enum class QueuePosition
 void QueueItem(const std::shared_ptr<CFileItem>& item, QueuePosition pos);
 
 /*! \brief For a given item, get the items to put in a playlist. If the item is a folder, all
-+  subitems will be added recursively to the returned item list. If the item is a playlist, the
-+  playlist will be loaded and contained items will be added to the returned item list. Shows a
-+  busy dialog if action takes certain amount of time to give the user visual feedback.
-+  \param item [in] the item to add to the playlist
-+  \param queuedItems [out] the items that can be put in a play list
-+  \return true on success, false otherwise
-+  */
+  subitems will be added recursively to the returned item list. If the item is a playlist, the
+  playlist will be loaded and contained items will be added to the returned item list. Shows a
+  busy dialog if action takes certain amount of time to give the user visual feedback.
+  \param item [in] the item to add to the playlist
+  \param queuedItems [out] the items that can be put in a play list
+  \return true on success, false otherwise
+  */
 bool GetItemsForPlayList(const std::shared_ptr<CFileItem>& item, CFileItemList& queuedItems);
 
 /*!

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -41,7 +41,6 @@
 #include "playlists/PlayListFactory.h"
 #include "profiles/ProfileManager.h"
 #include "settings/AdvancedSettings.h"
-#include "settings/SettingUtils.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/dialogs/GUIDialogContentSettings.h"
@@ -76,11 +75,6 @@ using namespace KODI::MESSAGING;
 
 #define PROPERTY_GROUP_BY           "group.by"
 #define PROPERTY_GROUP_MIXED        "group.mixed"
-
-static constexpr int SETTING_AUTOPLAYNEXT_MUSICVIDEOS = 0;
-static constexpr int SETTING_AUTOPLAYNEXT_EPISODES = 2;
-static constexpr int SETTING_AUTOPLAYNEXT_MOVIES = 3;
-static constexpr int SETTING_AUTOPLAYNEXT_UNCATEGORIZED = 4;
 
 CGUIWindowVideoBase::CGUIWindowVideoBase(int id, const std::string &xmlFile)
     : CGUIMediaWindow(id, xmlFile.c_str())
@@ -871,25 +865,7 @@ void CGUIWindowVideoBase::GetContextButtons(int itemNumber, CContextButtons &but
           (!item->HasProperty("IsPlayable") || item->GetProperty("IsPlayable").asBoolean()) &&
           m_vecItems->Size() > 1 && itemNumber < m_vecItems->Size() - 1)
       {
-        int settingValue = SETTING_AUTOPLAYNEXT_UNCATEGORIZED;
-
-        if (item->IsVideoDb() && item->HasVideoInfoTag())
-        {
-          const std::string mediaType = item->GetVideoInfoTag()->m_type;
-
-          if (mediaType == MediaTypeMusicVideo)
-            settingValue = SETTING_AUTOPLAYNEXT_MUSICVIDEOS;
-          else if (mediaType == MediaTypeEpisode)
-            settingValue = SETTING_AUTOPLAYNEXT_EPISODES;
-          else if (mediaType == MediaTypeMovie)
-            settingValue = SETTING_AUTOPLAYNEXT_MOVIES;
-        }
-
-        const auto setting = std::dynamic_pointer_cast<CSettingList>(
-                   CServiceBroker::GetSettingsComponent()->GetSettings()->GetSetting(
-                   CSettings::SETTING_VIDEOPLAYER_AUTOPLAYNEXTITEM));
-
-        if (setting && CSettingUtils::FindIntInList(setting, settingValue))
+        if (VIDEO_UTILS::IsAutoPlayNextItem(*item))
           buttons.Add(CONTEXT_BUTTON_PLAY_ONLY_THIS, 13434);
         else
           buttons.Add(CONTEXT_BUTTON_PLAY_AND_QUEUE, 13412);

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -859,6 +859,17 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
   }
 }
 
+bool CGUIWindowVideoNav::OnPopupMenu(int iItem)
+{
+  if (iItem >= 0 && iItem < m_vecItems->Size())
+  {
+    const auto item = m_vecItems->Get(iItem);
+    item->SetProperty("CheckAutoPlayNextItem", true);
+  }
+
+  return CGUIWindowVideoBase::OnPopupMenu(iItem);
+}
+
 bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
 {
   CFileItemPtr item;

--- a/xbmc/video/windows/GUIWindowVideoNav.h
+++ b/xbmc/video/windows/GUIWindowVideoNav.h
@@ -53,6 +53,7 @@ protected:
   virtual void PlayItem(int iItem);
   void OnDeleteItem(const CFileItemPtr& pItem) override;
   void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
+  bool OnPopupMenu(int iItem) override;
   bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
   bool OnAddMediaSource() override;
   bool OnClick(int iItem, const std::string &player = "") override;

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -34,12 +34,12 @@
 #include "programs/GUIViewStatePrograms.h"
 #include "pvr/windows/GUIViewStatePVR.h"
 #include "settings/MediaSourceSettings.h"
-#include "settings/SettingUtils.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
 #include "utils/URIUtils.h"
 #include "video/GUIViewStateVideo.h"
+#include "video/VideoUtils.h"
 #include "view/ViewState.h"
 
 #define PROPERTY_SORT_ORDER         "sort.order"
@@ -51,12 +51,6 @@ using namespace PVR;
 
 std::string CGUIViewState::m_strPlaylistDirectory;
 VECSOURCES CGUIViewState::m_sources;
-
-static const int SETTING_AUTOPLAYNEXT_MUSICVIDEOS = 0;
-static const int SETTING_AUTOPLAYNEXT_TVSHOWS = 1;
-static const int SETTING_AUTOPLAYNEXT_EPISODES = 2;
-static const int SETTING_AUTOPLAYNEXT_MOVIES = 3;
-static const int SETTING_AUTOPLAYNEXT_UNCATEGORIZED = 4;
 
 CGUIViewState* CGUIViewState::GetViewState(int windowId, const CFileItemList& items)
 {
@@ -500,24 +494,7 @@ bool CGUIViewState::AutoPlayNextVideoItem() const
   if (GetPlaylist() != PLAYLIST::TYPE_VIDEO)
     return false;
 
-  int settingValue(-1);
-  if (m_items.GetContent() == "musicvideos")
-    settingValue = SETTING_AUTOPLAYNEXT_MUSICVIDEOS;
-  else if (m_items.GetContent() == "tvshows")
-    settingValue = SETTING_AUTOPLAYNEXT_TVSHOWS;
-  else if (m_items.GetContent() == "episodes")
-    settingValue = SETTING_AUTOPLAYNEXT_EPISODES;
-  else if (m_items.GetContent() == "movies")
-    settingValue = SETTING_AUTOPLAYNEXT_MOVIES;
-  else
-    settingValue = SETTING_AUTOPLAYNEXT_UNCATEGORIZED;
-
-  const auto setting = std::dynamic_pointer_cast<CSettingList>(
-      CServiceBroker::GetSettingsComponent()->GetSettings()->GetSetting(
-          CSettings::SETTING_VIDEOPLAYER_AUTOPLAYNEXTITEM));
-
-  return settingValue >= 0 && setting != nullptr &&
-         CSettingUtils::FindIntInList(setting, settingValue);
+  return VIDEO_UTILS::IsAutoPlayNextItem(m_items.GetContent());
 }
 
 void CGUIViewState::LoadViewState(const std::string &path, int windowID)

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1746,6 +1746,8 @@ bool CGUIMediaWindow::OnPopupMenu(int itemIdx)
   if (!item)
     return false;
 
+  item->SetProperty("ParentPath", m_vecItems->GetPath());
+
   CContextButtons buttons;
 
   //Add items from plugin


### PR DESCRIPTION
Settings -> "Player" -> "Videos" -> "Play next video automatically" and
Settings -> "Player" -> "Music" -> "Play next song automatically" are broken for a long time, at least partly. There are context menu items missing or they do not what they are supposed to do.

From reading the code, this feature is supposed to dynamically change title and/or behavior of certain context menu items, like this:

1) Settings value is "enabled" (music) or not empty (video): 
* Context menu item "Play" will start playback of currently selected item and queue all subsequent items in the currently displayed list in the order they are listed. Once the first item's playback is finished, playback of next item will be started automatically.
* A context menu item "Play only this" will be added to the context menu. This item will like the name suggests only play the selected item, then playback stops.
* There is no context menu item "Play from here" for this case (see below).

2) Settings value is "disabled" (music) or empty (video):
* Context menu item "Play" behaves like "Play only this" for case 1)
* A context menu item "Play from here" will be added to the context menu, behaving like "Play" for case 1)
* There is no context menu item "Play only this" for this case

Somewhere in the past I (?) broke this. Now I come up with this PR to fix up the mess.

@enen92 this is a larger change, but maybe you find some time to review anytime soon. I know it extends VIDEO_UTILS and MUSIC_UTILS once more, but for now this seems the best place to consolidate all the general functionality which is currently scattered/duplicated across the whole code base. And I cleaned up some related PVR code that was located outside pvr source tree to move to where it actually belongs. :-)