### PR TITLE
[Windows]  restore window position and size up to virtual screen limits

### DIFF
--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -166,8 +166,9 @@ bool CWinSystemWin32::CreateNewWindow(const std::string& name, bool fullScreen, 
     const RECT vsRect = GetVirtualScreenRect();
 
     // we check that window is inside of virtual screen rect (sum of all monitors)
-    if (top != 0 && left != 0 && top > vsRect.top && top + m_nHeight < vsRect.bottom &&
-        left > vsRect.left && left + m_nWidth < vsRect.right)
+    // top 0 left 0 is a special position that centers the window on the screen
+    if ((top != 0 || left != 0) && top >= vsRect.top && top + m_nHeight <= vsRect.bottom &&
+        left >= vsRect.left && left + m_nWidth <= vsRect.right)
     {
       // restore previous window position
       m_nLeft = left;
@@ -186,8 +187,8 @@ bool CWinSystemWin32::CreateNewWindow(const std::string& name, bool fullScreen, 
       int maxClientWidth = (rcWorkArea.right - rcNcArea.right) - (rcWorkArea.left - rcNcArea.left);
       int maxClientHeight = (rcWorkArea.bottom - rcNcArea.bottom) - (rcWorkArea.top - rcNcArea.top);
 
-      m_nWidth = std::min<int>(m_nWidth, maxClientWidth);
-      m_nHeight = std::min<int>(m_nHeight, maxClientHeight);
+      m_nWidth = std::min(m_nWidth, maxClientWidth);
+      m_nHeight = std::min(m_nHeight, maxClientHeight);
       CWinSystemBase::SetWindowResolution(m_nWidth, m_nHeight);
 
       // center window on desktop
@@ -391,8 +392,9 @@ void CWinSystemWin32::AdjustWindow(bool forceResize)
       const RECT vsRect = GetVirtualScreenRect();
 
       // we check that window is inside of virtual screen rect (sum of all monitors)
-      if (top != 0 && left != 0 && top > vsRect.top && top + m_nHeight < vsRect.bottom &&
-          left > vsRect.left && left + m_nWidth < vsRect.right)
+      // top 0 left 0 is a special position that centers the window on the screen
+      if ((top != 0 || left != 0) && top >= vsRect.top && top + m_nHeight <= vsRect.bottom &&
+          left >= vsRect.left && left + m_nWidth <= vsRect.right)
       {
         // restore previous window position
         m_nTop = top;
@@ -413,8 +415,8 @@ void CWinSystemWin32::AdjustWindow(bool forceResize)
         int maxClientHeight =
             (rcWorkArea.bottom - rcNcArea.bottom) - (rcWorkArea.top - rcNcArea.top);
 
-        m_nWidth = std::min<int>(m_nWidth, maxClientWidth);
-        m_nHeight = std::min<int>(m_nHeight, maxClientHeight);
+        m_nWidth = std::min(m_nWidth, maxClientWidth);
+        m_nHeight = std::min(m_nHeight, maxClientHeight);
         CWinSystemBase::SetWindowResolution(m_nWidth, m_nHeight);
 
         // center window on desktop


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This is a minimal change to be safe for Nexus.

1. Modified the position restore check to allow a window at the extremes of the virtual desktop
It previously allowed only width -1, height -1, left + 1, top + 1

2. Modified the check to allow either left = 0 or top = 0 but not both to preserve the special behaviour that centers the window for saved position (0,0).

3. Removed a couple unnecessary type specifications in std::min.


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Restoring a full-width or full-height window was changed by PR #22936.

That PR adjusted the saved position and size when they exceeded the virtual screen dimensions to avoid a crash but it's also triggered in a situation that didn't cause a crash and was useful to some users.

For example 1920x1080 @ (0,31) on a 1920x1200 screen

Technically the borders of the window are slightly offscreen (Windows adds 8 pixels to each side) but it doesn't cause the crash that #22936 was addressing so it could be allowed again. That's how Kodi worked before the PR.


## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 10, single and multiple screens, window positions at the edges of the desktop, window sizes under/equal/beyond the edges


## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Users can save and restore a window that goes up to the edges of the screen, restoring v20 behaviour.
Kodi will still not crash when the window exceeds the bounds of the virtual screen.

## Screenshots (if appropriate):
Both screenshots on a 1920x1200 screen and a saved size of 1920x1080.

Before (window shrunk down on restore to 1908x1080)
![image](https://user-images.githubusercontent.com/489377/226188471-1ea87b3d-97cc-4d65-9525-54cd1627dabc.png)

After (no resize, window is 1920x1080 and goes up to the left and right edges)
![image](https://user-images.githubusercontent.com/489377/226188337-85350b9c-4084-437d-92bc-adb4762523f7.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
