### PR TITLE
[macOS][NativeWindowing] Ignore mouse locationInWindow if...no window

### DIFF
--- a/xbmc/windowing/osx/WinEventsOSXImpl.mm
+++ b/xbmc/windowing/osx/WinEventsOSXImpl.mm
@@ -208,7 +208,7 @@
 
   // The incoming mouse position.
   NSPoint location = nsevent.locationInWindow;
-  if (location.x < 0 || location.y < 0)
+  if (!nsevent.window || location.x < 0 || location.y < 0)
     return nsevent;
 
   // cocoa world is upside down ...


### PR DESCRIPTION
## Description
This is a simple fix/improvement for mouse behaviour under macOS (native windowing). We use `locationInWindow` (window coordinates) to broadcast the mouse position. Problem is, if we're running windowed and the cursor is outside of the window, the event will be reported with the screen coordinates instead, positioning our "custom cursor" inside the window as we move.
Hence ignore the event if no window is associated to the the event.

## Motivation

Improve UX for macOS native windowing

