### PR TITLE
[docs] Add webOS and fix typos in cmake README.md

### DIFF
--- a/cmake/README.md
+++ b/cmake/README.md
@@ -8,11 +8,12 @@ Welcome to Kodi's CMake Based Build System. CMake is a cross-platform tool for g
 * macOS, iOS and tvOS
 * Android
 * FreeBSD
+* webOS
 
 While the legacy build systems typically used in-source builds, it's recommended to use out-of-source builds with CMake. The necessary runtime dependencies such as dlls, skins and configuration files are copied over to the build directory automatically. Instructions are highly dependent on your operating system and target platform but we prepared a set of **[build guides](../docs/README.md)** for your convenience.
 
 ## Build options
-Kodi supports a number of build options that can enable or disable functionality. These options must be set when running CMake with `-DENABLE_<OPTION>=<ON|OFF|AUTO`. The default is `AUTO` which enables the option if a certain dependency is found. For example CEC support is enabled if `libCEC` is available. `ON` forcefully enables the dependency and the CMake run will **fail** if the related dependency is not available. `OFF` will disable the feature.
+Kodi supports a number of build options that can enable or disable functionality. These options must be set when running CMake with `-DENABLE_<OPTION>=<ON|OFF|AUTO>`. The default is `AUTO` which enables the option if a certain dependency is found. For example CEC support is enabled if `libCEC` is available. `ON` forcefully enables the dependency and the CMake run will **fail** if the related dependency is not available. `OFF` will disable the feature.
 
 Example for forcefully enabling VAAPI and disabling VDPAU:
 ```
@@ -32,14 +33,14 @@ To trigger the cmake-based buildsystem the following command must be executed wi
 
 `cmake <path> -G <generator>`
 
-CMake supports multiple generators. See [here] (https://cmake.org/cmake/help/v3.1/manual/cmake-generators.7.html) for a list.
+CMake supports multiple generators. See [here](https://cmake.org/cmake/help/v3.1/manual/cmake-generators.7.html) for a list.
 
 In case of additional options the call might look like this:
 
 cmake `<path>` [-G `<generator>`] \  
       -DCMAKE_BUILD_TYPE=Release \  
       -DARCH_DEFINES="-DTARGET_LINUX" \  
-      -DCMAKE_INSTALL_PREFIX="`<path-to-install-directory`"
+      -DCMAKE_INSTALL_PREFIX="`<path-to-install-directory>`"
 
 ## Tests
 Kodi uses Google Test as its testing framework. Each test file is scanned for tests and these are added to CTest, which is the native test driver for CMake.
@@ -86,7 +87,7 @@ Both methods work only for already existing add-ons. See this **[forum thread](h
 for add-on development and detailed documentation about the add-on build system.
 
 ## Sanitizers
-Clang and GCC support different kinds of sanitizers. To enable a sanitizer, call CMake with the option `-DECM_ENABLE_SANITIZERS=’san1;san2;...'`. For more information about enabling the
+Clang and GCC support different kinds of sanitizers. To enable a sanitizer, call CMake with the option `-DECM_ENABLE_SANITIZERS='san1;san2;...'`. For more information about enabling the
 sanitizers, read the module **[documentation](modules/extra/ECMEnableSanitizers.cmake)**.
 
 It is also recommended to read the sections about sanitizers in the [Clang documentation](http://clang.llvm.org/docs/).


### PR DESCRIPTION
## Description
This adds webOS to the list of supported platforms in `cmake/README.md` and fixes a few minor punctuation-related typos. Specifically, I added two closing `>`s, replaced a right single quote (U+2019) with a straight single quote/apostrophe, and removed a space that was breaking a link.

## Motivation and context
Improving documentation

## How has this been tested?
N/A

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
