### PR TITLE
[webos] Patch Samba to stop it from pulling in extra dependencies (readline, ncurses)

### DIFF
--- a/tools/depends/target/samba-gplv3/Makefile
+++ b/tools/depends/target/samba-gplv3/Makefile
@@ -83,6 +83,9 @@ ifeq ($(findstring apple-darwin, $(HOST)), apple-darwin)
 	cd $(PLATFORM); patch -p1 -i ../05-apple-disable-zlib-pkgconfig.patch
 	cd $(PLATFORM); patch -p1 -i ../06-apple-fix-st_atim.patch
 endif
+ifeq ($(TARGET_PLATFORM),webos)
+	cd $(PLATFORM); patch -p1 -i ../webos-no-readline.patch
+endif
 	cd $(PLATFORM); $(CONFIGURE)
 
 $(LIBDYLIB): $(PLATFORM)

--- a/tools/depends/target/samba-gplv3/webos-no-readline.patch
+++ b/tools/depends/target/samba-gplv3/webos-no-readline.patch
@@ -1,0 +1,111 @@
+--- a/lib/replace/wscript
++++ b/lib/replace/wscript
+@@ -663,8 +663,6 @@
+     conf.CHECK_FUNCS_IN('crypt_r', 'crypt', checklibc=True)
+     conf.CHECK_FUNCS_IN('crypt_rn', 'crypt', checklibc=True)
+ 
+-    conf.CHECK_VARIABLE('rl_event_hook', define='HAVE_DECL_RL_EVENT_HOOK', always=True,
+-                        headers='readline.h readline/readline.h readline/history.h')
+     conf.CHECK_VARIABLE('program_invocation_short_name', headers='errno.h')
+ 
+     conf.CHECK_DECLS('snprintf vsnprintf asprintf vasprintf')
+--- a/libcli/smbreadline/wscript_build
++++ b/libcli/smbreadline/wscript_build
+@@ -1,8 +1,6 @@
+ #!/usr/bin/env python
+ 
+ 
+-termlib=bld.env.READLINE_TERMLIB or ''
+-
+ bld.SAMBA_SUBSYSTEM('SMBREADLINE',
+                     source='smbreadline.c',
+-                    deps=termlib + ' readline talloc')
++                    deps='talloc')
+--- a/libcli/smbreadline/wscript_configure
++++ b/libcli/smbreadline/wscript_configure
+@@ -1,85 +1,3 @@
+ #!/usr/bin/env python
+ 
+ 
+-conf.CHECK_HEADERS('readline.h history.h readline/readline.h readline/history.h')
+-for termlib in ['ncurses', 'curses', 'termcap', 'terminfo', 'termlib', 'tinfo']:
+-    if conf.CHECK_FUNCS_IN('tgetent', termlib):
+-        conf.env['READLINE_TERMLIB'] = termlib
+-        break
+-
+-#
+-# Check if we need to work around readline/readline.h
+-# deprecated declarations
+-#
+-if conf.CONFIG_SET('HAVE_READLINE_READLINE_H'):
+-    if not conf.CHECK_CODE('''
+-                    #include <readline/readline.h>
+-                    int main() {return 0;}
+-                    ''',
+-                    define='HAVE_WORKING_READLINE_READLINE_WITH_STRICT_PROTO',
+-                    cflags=conf.env['WERROR_CFLAGS'] +
+-                           ['-Wstrict-prototypes',
+-                            '-Werror=strict-prototypes'],
+-                    msg='for compiling <readline/readline.h> with strict prototypes',
+-                    addmain=False):
+-                conf.CHECK_CODE('''
+-                    #define _FUNCTION_DEF
+-                    #include <readline/readline.h>
+-                    int main() {return 0;}
+-                    ''',
+-                    cflags=conf.env['WERROR_CFLAGS'] +
+-                           ['-Wstrict-prototypes',
+-                            '-Werror=strict-prototypes'],
+-                    msg='for workaround to <readline/readline.h> strict prototypes issue',
+-                    define='HAVE_READLINE_READLINE_WORKAROUND',
+-                    addmain=False)
+-
+-conf.CHECK_CODE('''
+-#ifdef HAVE_READLINE_READLINE_H
+-#  ifdef HAVE_READLINE_READLINE_WORKAROUND
+-#    define _FUNCTION_DEF
+-#  endif
+-#  include <readline/readline.h>
+-#  ifdef HAVE_READLINE_HISTORY_H
+-#    include <readline/history.h>
+-#  endif
+-#else
+-#  ifdef HAVE_READLINE_H
+-#    include <readline.h>
+-#    ifdef HAVE_HISTORY_H
+-#      include <history.h>
+-#    endif
+-#  endif
+-#endif
+-int main(void) {rl_completion_t f; return 0;}
+-''',
+-'HAVE_RL_COMPLETION_FUNC_T', execute=False, addmain=False,
+-msg='Checking for rl_completion_t')
+-
+-conf.CHECK_CODE('''
+-#ifdef HAVE_READLINE_READLINE_H
+-#  ifdef HAVE_READLINE_READLINE_WORKAROUND
+-#    define _FUNCTION_DEF
+-#  endif
+-#  include <readline/readline.h>
+-#  ifdef HAVE_READLINE_HISTORY_H
+-#    include <readline/history.h>
+-#  endif
+-#else
+-#  ifdef HAVE_READLINE_H
+-#    include <readline.h>
+-#    ifdef HAVE_HISTORY_H
+-#      include <history.h>
+-#    endif
+-#  endif
+-#endif
+-int main(void) {CPPFunction f; return 0;}
+-''',
+-'HAVE_CPPFUNCTION', execute=False, addmain=False,
+-msg='Checking for CPPFunction')
+-
+-if conf.CHECK_FUNCS_IN('rl_completion_matches', 'readline'):
+-    conf.DEFINE('HAVE_NEW_LIBREADLINE', 1)
+-
+-if conf.CHECK_FUNCS_IN('history_list', 'readline'):
+-    conf.DEFINE('HAVE_HISTORY_LIST', 1)


### PR DESCRIPTION
## Description
Samba (`tools/depends/target/samba-gplv3`) is causing Kodi to link against readline and ncurses (libtinfo) whenever its configure script detects them. I couldn't find an option to disable this, so I patched out the checks themselves. The patch is only applied when targeting webOS.

## Motivation and context
This change prevents unnecessary dependencies from being added to Kodi on webOS. Depending on readline would mean including an extra library in the package in exchange for no difference in functionality, as far as I can tell. Most webOS development so far has been done with a buildroot-nc4 toolchain from before readline/ncurses were [enabled](https://github.com/openlgtv/buildroot-nc4/commit/bf515fde625a22333184801513d62ae38b07ded3), and this patch just produces the same result even when they are present.

## How has this been tested?
I built Kodi with a toolchain that provides readline and ncurses. The binary produced doesn't have dependencies on readline (`libreadline.so.8`) or ncurses (`libtinfo.so.5`). I tested it on webOS 6 and didn't see any issues.

## What is the effect on users?
Should be none.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
