### PR TITLE
Cull GUI elements not in scissor bounds

### DIFF
--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -177,6 +177,10 @@ void CGUIControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregio
 // 3. reset the animation transform
 void CGUIControl::DoRender()
 {
+  if (IsControlRenderable() &&
+      !m_renderRegion.Intersects(CServiceBroker::GetWinSystem()->GetGfxContext().GetScissors()))
+    return;
+
   if (IsVisible() && !m_isCulled)
   {
     bool hasStereo =
@@ -948,6 +952,24 @@ void CGUIControl::UpdateControlStats()
     ++m_controlStats->nCountTotal;
     if (IsVisible() && IsVisibleFromSkin())
       ++m_controlStats->nCountVisible;
+  }
+}
+
+bool CGUIControl::IsControlRenderable()
+{
+  switch (ControlType)
+  {
+    case GUICONTAINER_EPGGRID:
+    case GUICONTAINER_FIXEDLIST:
+    case GUICONTAINER_LIST:
+    case GUICONTAINER_PANEL:
+    case GUICONTAINER_WRAPLIST:
+    case GUICONTROL_GROUP:
+    case GUICONTROL_GROUPLIST:
+    case GUICONTROL_LISTGROUP:
+      return false;
+    default:
+      return true;
   }
 }
 

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -297,6 +297,11 @@ public:
   };
   GUICONTROLTYPES GetControlType() const { return ControlType; }
 
+  /*! \brief Test whether the control is "drawable" (not a group or similar)
+   \return true if the control has textures/labels it wants to render
+   */
+  bool IsControlRenderable();
+
   enum GUIVISIBLE { HIDDEN = 0, DELAYED, VISIBLE };
 
   enum GUISCROLLVALUE { FOCUS = 0, NEVER, ALWAYS };

--- a/xbmc/utils/Geometry.h
+++ b/xbmc/utils/Geometry.h
@@ -281,6 +281,11 @@ public:
     return (x1 <= point.x && point.x <= x2 && y1 <= point.y && point.y <= y2);
   };
 
+  constexpr bool Intersects(const this_type& rect) const
+  {
+    return (x1 < rect.x2 && x2 > rect.x1 && y1 < rect.y2 && y2 > rect.y1);
+  };
+
   this_type& operator-=(const point_type &point) XBMC_FORCE_INLINE
   {
     x1 -= point.x;


### PR DESCRIPTION
## Description
With the PR, we check if the GUI element we want to render is in bounds of the current scissor region. If not, we can avoid the related geometry setup and drawcall(s).

## Motivation and context
Drawcalls are expensive. Our current geometry processing is expensive. Both can be avoided for elements outside of the scissor box we want to render to. This is especially important if we apply our "Cost Reduction" (2) dirty region algorithm. But also our "Union" algorithm, as well as full screen rendering will profit from out-of-bounds culling.

Without it, the cost reduction option is absolutely not viable, as it submits all drawcalls for each region, instead of only the ones needed for each region.

I'm guesstimating that the cost of it will be amortized by avoiding one drawcall. 

## How has this been tested?
Running various skins, I couldn't see any missing UI elements.

## What is the effect on users?
Less CPU and GPU utilization. How much depends on the system, skin, and DR scheme.

## Screenshots (if appropriate):
In this example, the "Cost Reduction" algorithm is active. You can see a "2" being rendered in a region (marked by the black/white scissor outline). For this region, only a glClear() and one glDrawElements() is submitted. Without the patch, all drawcalls (>30) would be submitted for each region rendered.
![image](https://user-images.githubusercontent.com/30039775/226221450-d0d37bac-8c16-45d0-a413-9eeaeb4af8d4.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
