### PR TITLE
[cmake][webos] Reduce footprint of WINDOWSYSTEM

### DIFF
--- a/tools/depends/target/cmakebuildsys/Makefile
+++ b/tools/depends/target/cmakebuildsys/Makefile
@@ -36,10 +36,6 @@ ifeq ($(OS),osx)
   endif
 endif
 
-ifeq ($(TARGET_PLATFORM),webos)
-  WINDOWSYSTEM=-DCORE_PLATFORM_NAME=webos
-endif
-
 ifeq ($(BUILD_DIR),)
   BUILD_DIR=$(CMAKE_SOURCE_DIR)/build
 endif


### PR DESCRIPTION
## Description
Found while rebasing https://github.com/xbmc/xbmc/pull/22990. Using `WINDOWSYSTEM` to propagate `CORE_PLATFORM_NAME` doesn't seem correct to me. This moves it to `CMAKE_EXTRA_ARGUMENTS` allowing to reduce the footprint of `WINDOWSYSTEM` (hopefully easier to rebase for me).
