### PR TITLE
[macOS][nativewindowing] Fix blanking other displays

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -42,6 +42,7 @@
 #include "platform/darwin/osx/CocoaInterface.h"
 #include "platform/darwin/osx/powermanagement/CocoaPowerSyscall.h"
 
+#include <array>
 #include <chrono>
 #include <cstdlib>
 #include <mutex>
@@ -68,7 +69,7 @@ constexpr const char* SETTING_WINDOW_TOP = "window.top";
 constexpr const char* SETTING_WINDOW_LEFT = "window.left";
 } // namespace
 
-static NSWindow* blankingWindows[MAX_DISPLAYS];
+static std::array<NSWindowController*, MAX_DISPLAYS> blankingWindowControllers;
 
 size_t DisplayBitsPerPixelForMode(CGDisplayModeRef mode)
 {
@@ -371,49 +372,51 @@ CGDisplayModeRef BestMatchForMode(CGDirectDisplayID display,
 
 #pragma mark - Blank Displays
 
-void BlankOtherDisplays(NSUInteger screen_index)
+void BlankOtherDisplays(NSUInteger screenBeingUsed)
 {
   const NSUInteger numDisplays = NSScreen.screens.count;
 
-  // zero out blankingWindows for debugging
-  for (NSUInteger i = 0; i < MAX_DISPLAYS; i++)
-  {
-    blankingWindows[i] = 0;
-  }
-
-  // Blank.
+  // Blank all other displays except the current one.
   for (NSUInteger i = 0; i < numDisplays; i++)
   {
-    if (i != screen_index)
+    if (i != screenBeingUsed)
     {
-      // Get the size.
+      // Get the size of the screen
       NSScreen* pScreen = [NSScreen.screens objectAtIndex:i];
       NSRect screenRect = pScreen.frame;
-
-      // Build a blanking window.
       screenRect.origin = NSZeroPoint;
-      blankingWindows[i] = [[NSWindow alloc] initWithContentRect:screenRect
-                                                       styleMask:NSWindowStyleMaskBorderless
-                                                         backing:NSBackingStoreBuffered
-                                                           defer:NO
-                                                          screen:pScreen];
 
-      [blankingWindows[i] setBackgroundColor:NSColor.blackColor];
-      [blankingWindows[i] setLevel:CGShieldingWindowLevel()];
-      [blankingWindows[i] makeKeyAndOrderFront:nil];
+      dispatch_sync(dispatch_get_main_queue(), ^{
+        // Build a blanking (black) window.
+        auto blankingWindow = [[NSWindow alloc] initWithContentRect:screenRect
+                                                          styleMask:NSWindowStyleMaskBorderless
+                                                            backing:NSBackingStoreBuffered
+                                                              defer:NO
+                                                             screen:pScreen];
+        [blankingWindow setBackgroundColor:NSColor.blackColor];
+        [blankingWindow setLevel:CGShieldingWindowLevel()];
+        [blankingWindow makeKeyAndOrderFront:nil];
+
+        // Create a controller and bind the blanking window to it
+        blankingWindowControllers[i] = [[NSWindowController alloc] init];
+        [blankingWindowControllers[i] setWindow:blankingWindow];
+      });
     }
   }
 }
 
-void UnblankDisplays(void)
+void UnblankDisplays(NSUInteger screenBeingUsed)
 {
-  for (auto i = 0; i < static_cast<int>(NSScreen.screens.count); i++)
+  for (NSUInteger i = 0; i < NSScreen.screens.count; i++)
   {
-    if (blankingWindows[i] != 0)
+    if (blankingWindowControllers[i] && i != screenBeingUsed)
     {
       // Get rid of the blanking windows we created.
-      [blankingWindows[i] close];
-      blankingWindows[i] = 0;
+      // Note after closing the window, setting the NSWindowController to nil will dealoc
+      dispatch_sync(dispatch_get_main_queue(), ^{
+        [[blankingWindowControllers[i] window] close];
+        blankingWindowControllers[i] = nil;
+      });
     }
   }
 }
@@ -657,7 +660,7 @@ bool CWinSystemOSX::DestroyWindowSystem()
     m_glView = nullptr;
   }
 
-  UnblankDisplays();
+  UnblankDisplays(m_lastDisplayNr);
   return true;
 }
 
@@ -953,6 +956,17 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
   {
     ResizeWindow(m_nWidth, m_nHeight, -1, -1);
     m_fullscreenWillToggle = false;
+
+    // Blank other displays if requested.
+    if (blankOtherDisplays)
+    {
+      BlankOtherDisplays(m_lastDisplayNr);
+    }
+    else
+    {
+      UnblankDisplays(m_lastDisplayNr);
+    }
+
     return true;
   }
 
@@ -1004,8 +1018,7 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
 
     // Unblank.
     // Force the unblank when returning from fullscreen, we get called with blankOtherDisplays set false.
-    //if (blankOtherDisplays)
-    UnblankDisplays();
+    UnblankDisplays(m_lastDisplayNr);
   }
 
   // toggle cocoa fullscreen mode


### PR DESCRIPTION
## Description
This fixes the `blank other displays` setting (which pretty much creates black fullscreen windows on all other displays except the active one) when running native windowing in MacOS.
There were multiple issues involved:

- windows being accessed out of the main thread
- `UnblankDisplays` was missing the reference to the current screen being used
- The created windows were not bound to a `NSWindowController` which was leading to a crash of `NSApplicationMain` when going out of fullscreen

Runtime tested with multiple displays (toggling fullscreen with the setting on), moving the window between screens and toggling again, etc.