### PR TITLE
Allow mapping controllers in the Add-on Browser

### DIFF
--- a/xbmc/addons/gui/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonSettings.cpp
@@ -13,6 +13,7 @@
 #include "GUIUserMessages.h"
 #include "ServiceBroker.h"
 #include "addons/AddonManager.h"
+#include "addons/addoninfo/AddonType.h"
 #include "addons/settings/AddonSettings.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "dialogs/GUIDialogYesNo.h"
@@ -143,6 +144,13 @@ bool CGUIDialogAddonSettings::ShowForAddon(const ADDON::AddonPtr& addon,
   {
     CLog::LogF(LOGERROR, "No addon given!");
     return false;
+  }
+
+  if (addon->Type() == ADDON::AddonType::GAME_CONTROLLER)
+  {
+    CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_DIALOG_GAME_CONTROLLERS,
+                                                                addon->ID());
+    return true;
   }
 
   if (!g_passwordManager.CheckMenuLock(WINDOW_ADDON_BROWSER))

--- a/xbmc/games/controllers/Controller.h
+++ b/xbmc/games/controllers/Controller.h
@@ -36,6 +36,9 @@ public:
 
   static const ControllerPtr EmptyPtr;
 
+  // Implementation of IAddon
+  bool CanHaveAddonOrInstanceSettings() override { return true; }
+
   /*!
    * \brief Get all controller features
    *

--- a/xbmc/games/controllers/windows/GUIControllerList.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerList.cpp
@@ -41,13 +41,15 @@ using namespace GAME;
 
 CGUIControllerList::CGUIControllerList(CGUIWindow* window,
                                        IFeatureList* featureList,
-                                       GameClientPtr gameClient)
+                                       GameClientPtr gameClient,
+                                       std::string controllerId)
   : m_guiWindow(window),
     m_featureList(featureList),
     m_controllerList(nullptr),
     m_controllerButton(nullptr),
     m_focusedController(-1), // Initially unfocused
-    m_gameClient(std::move(gameClient))
+    m_gameClient(std::move(gameClient)),
+    m_controllerId(std::move(controllerId))
 {
   assert(m_featureList != nullptr);
 }
@@ -187,8 +189,17 @@ bool CGUIControllerList::RefreshControllers(void)
   CGameServices& gameServices = CServiceBroker::GetGameServices();
   ControllerVector newControllers = gameServices.GetControllers();
 
+  // Filter by specified controller ID
+  if (!m_controllerId.empty())
+  {
+    newControllers.erase(std::remove_if(newControllers.begin(), newControllers.end(),
+                                        [this](const ControllerPtr& controller) {
+                                          return controller->ID() != m_controllerId;
+                                        }),
+                         newControllers.end());
+  }
   // Filter by current game add-on
-  if (m_gameClient)
+  else if (m_gameClient)
   {
     const CControllerTree& controllers = m_gameClient->Input().GetDefaultControllerTree();
 
@@ -201,6 +212,9 @@ bool CGUIControllerList::RefreshControllers(void)
           std::remove_if(newControllers.begin(), newControllers.end(), ControllerNotAccepted),
           newControllers.end());
   }
+
+  if (newControllers.empty())
+    newControllers.emplace_back(gameServices.GetDefaultController());
 
   // Check for changes
   std::set<std::string> oldControllerIds;

--- a/xbmc/games/controllers/windows/GUIControllerList.h
+++ b/xbmc/games/controllers/windows/GUIControllerList.h
@@ -29,7 +29,20 @@ class CGUIControllerWindow;
 class CGUIControllerList : public IControllerList
 {
 public:
-  CGUIControllerList(CGUIWindow* window, IFeatureList* featureList, GameClientPtr gameClient);
+  /*!
+   * \brief Create a GUI controller list
+   *
+   * \param window The GUI window handle
+   * \param featureList The controller interface for the feature list
+   * \param gameClient A gameclient used to filter controllers
+   * \param controllerId A controller ID used to filter controllers (only the
+   *                     specified controller will be shown, or the default
+   *                     controller if the specified controller isn't installed)
+   */
+  CGUIControllerList(CGUIWindow* window,
+                     IFeatureList* featureList,
+                     GameClientPtr gameClient,
+                     std::string controllerId);
   ~CGUIControllerList() override { Deinitialize(); }
 
   // implementation of IControllerList
@@ -57,6 +70,7 @@ private:
   ControllerVector m_controllers;
   int m_focusedController;
   GameClientPtr m_gameClient;
+  std::string m_controllerId;
 };
 } // namespace GAME
 } // namespace KODI

--- a/xbmc/games/controllers/windows/GUIControllerWindow.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerWindow.cpp
@@ -89,6 +89,11 @@ bool CGUIControllerWindow::OnMessage(CGUIMessage& message)
 
   switch (message.GetMessage())
   {
+    case GUI_MSG_WINDOW_INIT:
+    {
+      m_controllerId = message.GetStringParam();
+      break;
+    }
     case GUI_MSG_CLICKED:
     {
       int controlId = message.GetSenderId();
@@ -245,7 +250,7 @@ void CGUIControllerWindow::OnInitWindow(void)
 
   if (!m_controllerList && m_featureList)
   {
-    m_controllerList = new CGUIControllerList(this, m_featureList, m_gameClient);
+    m_controllerList = new CGUIControllerList(this, m_featureList, m_gameClient, m_controllerId);
     if (!m_controllerList->Initialize())
     {
       delete m_controllerList;

--- a/xbmc/games/controllers/windows/GUIControllerWindow.h
+++ b/xbmc/games/controllers/windows/GUIControllerWindow.h
@@ -60,6 +60,7 @@ private:
 
   // Game parameters
   GameClientPtr m_gameClient;
+  std::string m_controllerId;
 
   // Controller parameters
   std::unique_ptr<CControllerInstaller> m_installer;


### PR DESCRIPTION
## Description

This PR enables the "Configure" option for controller profiles in the add-on browser.

When "Configure" is selected, it opens the controller mapping dialog for the specific add-on being viewed.

## Motivation and context

Minor improvement that adds missing functionality.

## How has this been tested?

Tested on Ubuntu 22.04.

Test builds have been uploaded to: https://github.com/garbear/xbmc/releases

## Screenshots (if appropriate):

The "Configure" button is successfully enabled:

![Screenshot from 2023-03-21 14-34-10](https://user-images.githubusercontent.com/531482/226749859-7f03363a-d8e1-4b28-9db5-2450101d6efe.png)

The controller mapper dialog is opened for only that controller:

![Screenshot from 2023-03-21 14-34-25](https://user-images.githubusercontent.com/531482/226749884-efeee062-f236-4f06-993f-b1e9123d4c2d.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
