### PR TITLE
[macOS][NativeWindowing] Fix fullscreen window menu item (and shortcuts)

### DIFF
--- a/xbmc/platform/darwin/osx/XBMCApplication.mm
+++ b/xbmc/platform/darwin/osx/XBMCApplication.mm
@@ -13,6 +13,7 @@
 #include "application/AppEnvironment.h"
 #include "application/AppInboundProtocol.h"
 #include "application/AppParamParser.h"
+#include "messaging/ApplicationMessenger.h"
 #include "platform/xbmc.h"
 #include "utils/log.h"
 
@@ -264,6 +265,7 @@ static NSMenu* setupWindowMenu()
 
 - (void)fullScreenToggle:(id)sender
 {
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_TOGGLEFULLSCREEN);
 }
 
 - (void)floatOnTopToggle:(id)sender

--- a/xbmc/windowing/osx/WinEventsOSXImpl.mm
+++ b/xbmc/windowing/osx/WinEventsOSXImpl.mm
@@ -128,6 +128,12 @@
   // left command
   if (appleModifier & kCGEventFlagMaskCommand)
     xbmcModifier |= XBMCKMOD_LMETA;
+  // fn/globe
+  if (appleModifier & kCGEventFlagMaskSecondaryFn && !(appleModifier & kCGEventFlagMaskNumericPad))
+  {
+    xbmcModifier |= XBMCKMOD_LMETA;
+    xbmcModifier |= XBMCKMOD_MODE;
+  }
 
   return static_cast<XBMCMod>(xbmcModifier);
 }
@@ -135,6 +141,7 @@
 - (bool)ProcessOSXShortcuts:(XBMC_Event&)event
 {
   const auto cmd = (event.key.keysym.mod & (XBMCKMOD_LMETA | XBMCKMOD_RMETA)) != 0;
+  const auto isFn = (event.key.keysym.mod & XBMCKMOD_MODE) != 0;
   if (cmd && event.type == XBMC_KEYDOWN)
   {
     switch (event.key.keysym.sym)
@@ -148,6 +155,13 @@
         CServiceBroker::GetAppMessenger()->PostMsg(TMSG_TOGGLEFULLSCREEN);
         return true;
 
+      case XBMCK_f: // FN/Globe-f to toggle fullscreen
+        if (isFn) // avoid cmd-f to toggle fullscreen
+        {
+          CServiceBroker::GetAppMessenger()->PostMsg(TMSG_TOGGLEFULLSCREEN);
+          return true;
+        }
+        break;
       case XBMCK_s: // CMD-s to take a screenshot
       {
         CAction* action = new CAction(ACTION_TAKE_SCREENSHOT);


### PR DESCRIPTION
## Description
This essentially provides two fixes:
- Fixes the toggle fullscreen app bar menu item (was actually unimplemented):
<img width="325" alt="image" src="https://user-images.githubusercontent.com/7375276/226768052-e5f7f9ae-4697-411c-9a3e-42728e60bf2e.png">

- The FN/Globe+f shortcut (displayed in the menu as the `keyEquivalent` for fullscreenToggle as the result of f + `NSEventModifierFlagCommand | NSEventModifierFlagControl` was not being trapped as a shortcut in `ProcessOSXShortcuts`. Since it works on all other apps and may lead to user confusion, it's implemented on a separate commit.