### PR TITLE
[macOS][nativewindowing] Disable fullscreen tilling support

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -655,7 +655,9 @@ bool CWinSystemOSX::CreateNewWindow(const std::string& name, bool fullScreen, RE
       appWindow.title = title;
 
       NSWindowCollectionBehavior behavior = appWindow.collectionBehavior;
-      behavior |= NSWindowCollectionBehaviorFullScreenPrimary;
+      //! @todo actually implement fullscreen tilling and remove NSWindowCollectionBehaviorFullScreenDisallowsTiling
+      behavior |= NSWindowCollectionBehaviorFullScreenPrimary |
+                  NSWindowCollectionBehaviorFullScreenDisallowsTiling;
       [appWindow setCollectionBehavior:behavior];
 
       // associate with current window


### PR DESCRIPTION
## Description
Fullscreen tilling is not supported in any other windowing system and is also not available in the SDL counterpart.
Implementing it is actually not too difficult (got it sort of working although a bit buggy when it comes to synchronise both the fullscreen status in the windowing system class and also the respective kodi setting).
I might have another attempt at it at some point in the future.

Since this is really low priority, completely broken, was not there before, there are more prominent issues to fix and the current main goal is to get feature parity between native and SDL (so that we can drop the later), I suggest to disable it for now.

**Windowed:**
<img width="1470" alt="image" src="https://user-images.githubusercontent.com/7375276/226770392-58508817-2c10-44f8-9c00-e3b8b0d9e8aa.png">
<img width="1470" alt="image" src="https://user-images.githubusercontent.com/7375276/226770433-ad221352-4927-431c-82b6-41490acf1870.png">

**Fullscreen:**
<img width="1470" alt="image" src="https://user-images.githubusercontent.com/7375276/226770518-d45fae8d-5281-4e6f-aea2-2f25c232080c.png">




