### PR TITLE
[macOS][nativewindowing] Do not hide OS mouse when entering fullscreen

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -887,8 +887,6 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
   {
     // switch videomode
     SwitchToVideoMode(res.iWidth, res.iHeight, static_cast<double>(res.fRefreshRate));
-    // hide the OS mouse
-    [NSCursor hide];
   }
 
   dispatch_sync(dispatch_get_main_queue(), ^{
@@ -1325,4 +1323,5 @@ std::string CWinSystemOSX::GetClipboardText()
 
 void CWinSystemOSX::ShowOSMouse(bool show)
 {
+  // do nothing (this is already handled by OSXGLView on mouseEntered and mouseExited)
 }


### PR DESCRIPTION
## Description
When we enter fullscreen we are currently hiding the OS cursor on purpose. This is wrong since if the user has a multi-screen setup the OS mouse is hidden when the user moves the cursor out of the Kodi window.
Show and hide the OS mouse is already handled by OSXGLView when `mouseEntered` and `mouseExited` callbacks are invoked. MouseEntered is triggered when the Kodi window has focus and the cursor position is inside the window (OS mouse hides). MouseExisted is triggered when the user moves the mouse out of the Kodi window.

Ideally requires https://github.com/xbmc/xbmc/pull/23019 since it greatly improves the mouse usage.