### PR TITLE
[macOS][nativewindowing] Implement NotifyAppFocusChange callbacks and…

### DIFF
--- a/xbmc/windowing/osx/OpenGL/OSXGLWindow.mm
+++ b/xbmc/windowing/osx/OpenGL/OSXGLWindow.mm
@@ -225,6 +225,7 @@
   auto winSystem = dynamic_cast<CWinSystemOSX*>(CServiceBroker::GetWinSystem());
   if (winSystem)
   {
+    winSystem->NotifyAppFocusChange(true);
     winSystem->enableInputEvents();
   }
 }
@@ -236,6 +237,7 @@
   auto winSystem = dynamic_cast<CWinSystemOSX*>(CServiceBroker::GetWinSystem());
   if (winSystem)
   {
+    winSystem->NotifyAppFocusChange(false);
     winSystem->disableInputEvents();
   }
 }

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1148,28 +1148,10 @@ void CWinSystemOSX::SetOcclusionState(bool occluded)
 
 void CWinSystemOSX::NotifyAppFocusChange(bool bGaining)
 {
-  if (!(m_bFullScreen && bGaining))
+  if (!(m_bFullScreen && bGaining) || !m_appWindow)
     return;
-  @autoreleasepool
-  {
-    // find the window
-    NSOpenGLContext* context = NSOpenGLContext.currentContext;
-    if (context)
-    {
-      NSView* view;
 
-      view = context.view;
-      if (view)
-      {
-        NSWindow* window;
-        window = view.window;
-        if (window)
-        {
-          [window orderFront:nil];
-        }
-      }
-    }
-  }
+  [static_cast<OSXGLWindow*>(m_appWindow) orderFront:nil];
 }
 
 #pragma mark - Window Move


### PR DESCRIPTION
… fix implementation

## Description
`NotifyAppFocusChange` orders the window to front and was created to be invoked when the app focus change. The callbacks were not implemented for macos native windowing (on `windowDidBecomeKey` and `windowDidResignKey`). Furthermore, the method body was using deprecated functions (`context.view`).
Runtime tested windowed/fullscreen.