### PR TITLE
[macOS][nativewindowing] Remove more dead code

### DIFF
--- a/xbmc/platform/darwin/osx/XBMCApplication.mm
+++ b/xbmc/platform/darwin/osx/XBMCApplication.mm
@@ -15,7 +15,6 @@
 #include "application/AppParamParser.h"
 #include "platform/xbmc.h"
 #include "utils/log.h"
-#import "windowing/osx/WinSystemOSX.h"
 
 #import "platform/darwin/osx/storage/OSXStorageProvider.h"
 
@@ -65,17 +64,6 @@ static NSMenu* setupWindowMenu()
   auto parentPath = NSBundle.mainBundle.bundlePath.stringByDeletingLastPathComponent;
   NSAssert([NSFileManager.defaultManager changeCurrentDirectoryPath:parentPath],
            @"SetupWorkingDirectory Failed to cwd");
-}
-
-- (void)applicationDidChangeOcclusionState:(NSNotification*)notification
-{
-  bool occluded = true;
-  if (NSApp.occlusionState & NSApplicationOcclusionStateVisible)
-    occluded = false;
-
-  CWinSystemOSX* winSystem = dynamic_cast<CWinSystemOSX*>(CServiceBroker::GetWinSystem());
-  if (winSystem)
-    winSystem->SetOcclusionState(occluded); // SHH method body is commented out
 }
 
 - (void)applicationWillFinishLaunching:(NSNotification*)notification

--- a/xbmc/windowing/osx/OpenGL/WinSystemOSXGL.mm
+++ b/xbmc/windowing/osx/OpenGL/WinSystemOSXGL.mm
@@ -12,8 +12,6 @@
 #include "rendering/gl/RenderSystemGL.h"
 #include "windowing/WindowSystemFactory.h"
 
-#include <unistd.h>
-
 void CWinSystemOSXGL::Register()
 {
   KODI::WINDOWING::CWindowSystemFactory::RegisterWindowSystem(CreateWinSystem);
@@ -28,11 +26,6 @@ void CWinSystemOSXGL::PresentRenderImpl(bool rendered)
 {
   if (rendered)
     FlushBuffer();
-
-  // FlushBuffer does not block if window is obscured
-  // in this case we need to throttle the render loop
-  if (IsObscured())
-    usleep(10000);
 
   if (m_delayDispReset && m_dispResetTimer.IsTimePast())
   {

--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -55,8 +55,6 @@ public:
   bool Show(bool raise = true) override;
   void OnMove(int x, int y) override;
 
-  void SetOcclusionState(bool occluded);
-
   std::string GetClipboardText() override;
 
   void Register(IDispResource* resource) override;
@@ -95,14 +93,12 @@ protected:
   bool SwitchToVideoMode(int width, int height, double refreshrate);
   void FillInVideoModes();
   bool FlushBuffer();
-  bool IsObscured();
 
   bool DestroyWindowInternal();
 
   std::unique_ptr<CWinEventsOSX> m_winEvents;
 
   std::string m_name;
-  bool m_obscured;
   NSWindow* m_appWindow;
   OSXGLView* m_glView;
   unsigned long m_lastDisplayNr;

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -484,7 +484,6 @@ CWinSystemOSX::CWinSystemOSX() : CWinSystemBase(), m_lostDeviceTimer(this)
 {
   m_appWindow = nullptr;
   m_glView = nullptr;
-  m_obscured = false;
   m_lastDisplayNr = -1;
   m_refreshRate = 0.0;
   m_delayDispReset = false;
@@ -1129,21 +1128,6 @@ void CWinSystemOSX::FillInVideoModes()
     }
     CFRelease(displayModes);
   }
-}
-
-#pragma mark - Occlusion
-
-bool CWinSystemOSX::IsObscured()
-{
-  if (m_obscured)
-    CLog::LogF(LOGDEBUG, "Obscured");
-  return m_obscured;
-}
-
-void CWinSystemOSX::SetOcclusionState(bool occluded)
-{
-  //  m_obscured = occluded;
-  //  CLog::LogF(LOGDEBUG, "{}", occluded ? "true":"false");
 }
 
 void CWinSystemOSX::NotifyAppFocusChange(bool bGaining)


### PR DESCRIPTION
## Description
This removes more dead code in the macOS native windowing code. Method body of `SetOcclusionState` is not implemented, `m_obscured` is always false (so not `IsObscured()`).
I've been running this for a while and did not notice any issues with rendering (as per the comment which I guess led to this implementation). I propose to nuke it and reimplement `applicationDidChangeOcclusionState` later if justified for some other use case.