### PR TITLE
[macOS][NativeWindowing] Nuke NotifyAppFocusChange (dead code)

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -47,7 +47,6 @@ public:
   bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
   bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
   void UpdateResolutions() override;
-  void NotifyAppFocusChange(bool bGaining) override;
   void ShowOSMouse(bool show) override;
   bool Minimize() override;
   bool Restore() override;

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1130,32 +1130,6 @@ void CWinSystemOSX::FillInVideoModes()
   }
 }
 
-void CWinSystemOSX::NotifyAppFocusChange(bool bGaining)
-{
-  if (!(m_bFullScreen && bGaining))
-    return;
-  @autoreleasepool
-  {
-    // find the window
-    NSOpenGLContext* context = NSOpenGLContext.currentContext;
-    if (context)
-    {
-      NSView* view;
-
-      view = context.view;
-      if (view)
-      {
-        NSWindow* window;
-        window = view.window;
-        if (window)
-        {
-          [window orderFront:nil];
-        }
-      }
-    }
-  }
-}
-
 #pragma mark - Window Move
 
 void CWinSystemOSX::OnMove(int x, int y)


### PR DESCRIPTION
## Description
Alternative to https://github.com/xbmc/xbmc/pull/23037 but nukes the implementation instead. This is currently not called anywhere (dead code) and the implementation also doesn't make sense (app is already at front)