### PR TITLE
[macos][nativewindowing] Address a few gl deprecations

### DIFF
--- a/xbmc/windowing/osx/OpenGL/OSXGLView.mm
+++ b/xbmc/windowing/osx/OpenGL/OSXGLView.mm
@@ -47,7 +47,7 @@
   [self updateTrackingAreas];
 
   GLint swapInterval = 1;
-  [m_glcontext setValues:&swapInterval forParameter:NSOpenGLCPSwapInterval];
+  [m_glcontext setValues:&swapInterval forParameter:NSOpenGLContextParameterSwapInterval];
   [m_glcontext makeCurrentContext];
 
   return self;
@@ -63,7 +63,7 @@
 {
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    [m_glcontext setView:self];
+    [self setOpenGLContext:m_glcontext];
 
     // clear screen on first render
     glClearColor(0, 0, 0, 0);


### PR DESCRIPTION
## Description
Both available from 10.0, kills some warnings generated by xcode.