### PR TITLE
[PVR] Optimize and simplify EPG creation on startup / arrival of new channels

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -341,8 +341,6 @@ void CPVRManager::Clear()
   m_channelGroups.reset();
   m_parentalTimer.reset();
   m_database.reset();
-
-  m_bEpgsCreated = false;
 }
 
 void CPVRManager::ResetProperties()
@@ -658,7 +656,6 @@ void CPVRManager::OnWake()
   TriggerProvidersUpdate();
   TriggerChannelsUpdate();
   TriggerRecordingsUpdate();
-  TriggerEpgsCreate();
   TriggerTimersUpdate();
 }
 
@@ -866,17 +863,6 @@ void CPVRManager::LocalizationChanged()
   }
 }
 
-bool CPVRManager::EpgsCreated() const
-{
-  std::unique_lock<CCriticalSection> lock(m_critSection);
-  return m_bEpgsCreated;
-}
-
-void CPVRManager::TriggerEpgsCreate()
-{
-  m_pendingUpdates->Append("pvr-create-epgs", [this]() { return CreateChannelEpgs(); });
-}
-
 void CPVRManager::TriggerRecordingsSizeInProgressUpdate()
 {
   m_pendingUpdates->Append("pvr-update-recordings-size",
@@ -1017,16 +1003,4 @@ void CPVRManager::ConnectionStateChange(CPVRClient* client,
     Clients()->ConnectionStateChange(client, connectString, state, message);
     return true;
   });
-}
-
-bool CPVRManager::CreateChannelEpgs()
-{
-  if (EpgsCreated())
-    return true;
-
-  bool bEpgsCreated = m_channelGroups->CreateChannelEpgs();
-
-  std::unique_lock<CCriticalSection> lock(m_critSection);
-  m_bEpgsCreated = bEpgsCreated;
-  return m_bEpgsCreated;
 }

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -224,12 +224,6 @@ public:
   bool IsStarted() const { return GetState() == ManagerState::STATE_STARTED; }
 
   /*!
-   * @brief Check whether EPG tags for channels have been created.
-   * @return True if EPG tags have been created, false otherwise.
-   */
-  bool EpgsCreated() const;
-
-  /*!
    * @brief Inform PVR manager that playback of an item just started.
    * @param item The item that started to play.
    */
@@ -246,11 +240,6 @@ public:
    * @param item The item that ended to play.
    */
   void OnPlaybackEnded(const CFileItem& item);
-
-  /*!
-   * @brief Let the background thread create epg tags for all channels.
-   */
-  void TriggerEpgsCreate();
 
   /*!
    * @brief Let the background thread update the recordings list.
@@ -331,12 +320,6 @@ public:
    * @brief Restart the parental timer.
    */
   void RestartParentalTimer();
-
-  /*!
-   * @brief Create EPG tags for all channels in internal channel groups
-   * @return True if EPG tags where created successfully, false otherwise
-   */
-  bool CreateChannelEpgs();
 
   /*!
    * @brief Signal a connection change of a client
@@ -467,7 +450,6 @@ private:
   mutable CCriticalSection
       m_critSection; /*!< critical section for all changes to this class, except for changes to triggers */
   bool m_bFirstStart = true; /*!< true when the PVR manager was started first, false otherwise */
-  bool m_bEpgsCreated = false; /*!< true if epg data for channels has been created */
 
   mutable CCriticalSection m_managerStateMutex;
   ManagerState m_managerState = ManagerState::STATE_STOPPED;

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -164,6 +164,9 @@ bool CPVRChannel::CreateEPG()
         m_iEpgId, m_strEPGScraper, std::make_shared<CPVREpgChannelData>(*this));
     if (m_epg)
     {
+      CLog::LogFC(LOGDEBUG, LOGPVR, "Created EPG for {} channel '{}'", IsRadio() ? "radio" : "TV",
+                  m_strChannelName);
+
       if (m_epg->EpgID() != m_iEpgId)
       {
         m_iEpgId = m_epg->EpgID();

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -653,12 +653,8 @@ bool CPVRChannelGroup::UpdateFromClient(const std::shared_ptr<CPVRChannelGroupMe
     CLog::LogFC(LOGDEBUG, LOGPVR, "Added {} channel group member '{}' to group '{}'",
                 IsRadio() ? "radio" : "TV", channel->ChannelName(), GroupName());
 
-    // create EPG for new channel
-    if (IsInternalGroup() && channel->CreateEPG())
-    {
-      CLog::LogFC(LOGDEBUG, LOGPVR, "Created EPG for {} channel '{}' from PVR client",
-                  IsRadio() ? "radio" : "TV", channel->ChannelName());
-    }
+    // Create EPG for new channel
+    channel->CreateEPG();
 
     bChanged = true;
   }
@@ -1216,12 +1212,6 @@ bool CPVRChannelGroup::HasChannels() const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   return !m_members.empty();
-}
-
-bool CPVRChannelGroup::CreateChannelEpgs(bool bForce /* = false */)
-{
-  /* used only by internal channel groups */
-  return true;
 }
 
 bool CPVRChannelGroup::SetHidden(bool bHidden)

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -402,13 +402,6 @@ public:
   bool IsNew() const;
 
   /*!
-   * @brief Create an EPG table for each channel.
-   * @brief bForce Create the tables, even if they already have been created before.
-   * @return True if all tables were created successfully, false otherwise.
-   */
-  virtual bool CreateChannelEpgs(bool bForce = false);
-
-  /*!
    * @brief Update a channel group member with given data.
    * @param storageId The storage id of the channel.
    * @param strChannelName The channel name to set.

--- a/xbmc/pvr/channels/PVRChannelGroupInternal.h
+++ b/xbmc/pvr/channels/PVRChannelGroupInternal.h
@@ -15,8 +15,6 @@
 
 namespace PVR
 {
-enum class PVREvent;
-
 class CPVRChannel;
 class CPVRChannelNumber;
 
@@ -65,13 +63,6 @@ public:
    */
   void CheckGroupName();
 
-  /*!
-   * @brief Create an EPG table for each channel.
-   * @brief bForce Create the tables, even if they already have been created before.
-   * @return True if all tables were created successfully, false otherwise.
-   */
-  bool CreateChannelEpgs(bool bForce = false) override;
-
 protected:
   /*!
    * @brief Remove deleted group members from this group. Delete stale channels.
@@ -108,10 +99,5 @@ protected:
   void UpdateChannelPaths();
 
   size_t m_iHiddenChannels; /*!< the amount of hidden channels in this container */
-
-private:
-  void OnPVRManagerEvent(const PVREvent& event);
-
-  bool m_isSubscribed{false};
 };
 } // namespace PVR

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -699,20 +699,6 @@ bool CPVRChannelGroups::HideGroup(const std::shared_ptr<CPVRChannelGroup>& group
   return bReturn;
 }
 
-bool CPVRChannelGroups::CreateChannelEpgs()
-{
-  bool bReturn(false);
-
-  std::unique_lock<CCriticalSection> lock(m_critSection);
-  for (const auto& group : m_groups)
-  {
-    /* Only create EPGs for the internal groups */
-    if (group->IsInternalGroup())
-      bReturn = group->CreateChannelEpgs();
-  }
-  return bReturn;
-}
-
 int CPVRChannelGroups::CleanupCachedImages()
 {
   int iCleanedImages = 0;

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -194,12 +194,6 @@ public:
   bool HideGroup(const std::shared_ptr<CPVRChannelGroup>& group, bool bHide);
 
   /*!
-   * @brief Create EPG tags for all channels of the internal group.
-   * @return True if EPG tags where created successfully, false if not.
-   */
-  bool CreateChannelEpgs();
-
-  /*!
    * @brief Persist all changes in channel groups.
    * @return True if everything was persisted, false otherwise.
    */

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
@@ -154,13 +154,6 @@ std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroupsContainer::
   return channelTV;
 }
 
-bool CPVRChannelGroupsContainer::CreateChannelEpgs()
-{
-  bool bReturn = m_groupsTV->CreateChannelEpgs();
-  bReturn &= m_groupsRadio->CreateChannelEpgs();
-  return bReturn;
-}
-
 int CPVRChannelGroupsContainer::CleanupCachedImages()
 {
   return m_groupsTV->CleanupCachedImages() + m_groupsRadio->CleanupCachedImages();

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.h
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.h
@@ -145,12 +145,6 @@ namespace PVR
     std::shared_ptr<CPVRChannelGroupMember> GetLastPlayedChannelGroupMember() const;
 
     /*!
-     * @brief Create EPG tags for channels in all internal channel groups.
-     * @return True if EPG tags were created successfully.
-     */
-    bool CreateChannelEpgs();
-
-    /*!
      * @brief Erase stale texture db entries and image files.
      * @return number of cleaned up images.
      */

--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -392,9 +392,6 @@ bool CPVREpg::UpdateFromScraper(time_t start, time_t end, bool bForceUpdate)
   }
   else if (m_strScraperName == "client")
   {
-    if (!CServiceBroker::GetPVRManager().EpgsCreated())
-      return false;
-
     if (!m_channelData->IsEPGEnabled() || m_channelData->IsHidden())
     {
       // ignore. not interested in any updates.

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -1295,7 +1295,7 @@ void CPVRTimerInfoTag::UpdateEpgInfoTag()
 
 std::shared_ptr<CPVREpgInfoTag> CPVRTimerInfoTag::GetEpgInfoTag(bool bCreate /* = true */) const
 {
-  if (!m_epgTag && !m_bProbedEpgTag && bCreate && CServiceBroker::GetPVRManager().EpgsCreated())
+  if (!m_epgTag && !m_bProbedEpgTag && bCreate)
   {
     std::shared_ptr<CPVRChannel> channel(m_channel);
     if (!channel)


### PR DESCRIPTION
No idea why it was so complicated, maybe this was needed at the early days of PVR. Now, EPG for a channel will be created straight after loading data from database or when new channels are transferred by a client. No need imo for complicated asynchronous bidirectional creation mechanisms like it was before this PR.

Definitely nothing for Nexus I I can see some regression potential here.

@phunkyfish please take a look at the code changes, please.