### PR TITLE
[macOS][nativewindowing] Make mouse hide/unhide safer

### DIFF
--- a/xbmc/windowing/osx/OpenGL/OSXGLView.mm
+++ b/xbmc/windowing/osx/OpenGL/OSXGLView.mm
@@ -16,6 +16,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/log.h"
+#import "windowing/osx/WinSystemOSX.h"
 
 #include "system_gl.h"
 
@@ -90,18 +91,22 @@
   [self addTrackingArea:m_trackingArea];
 }
 
-- (void)mouseEntered:(NSEvent*)theEvent
+- (void)mouseEntered:(NSEvent*)nsEvent
 {
-  [NSCursor hide];
+  CWinSystemOSX* winSystem = dynamic_cast<CWinSystemOSX*>(CServiceBroker::GetWinSystem());
+  if (winSystem)
+    winSystem->signalMouseEntered();
 }
 
-- (void)mouseMoved:(NSEvent*)theEvent
+- (void)mouseMoved:(NSEvent*)nsEvent
 {
 }
 
-- (void)mouseExited:(NSEvent*)theEvent
+- (void)mouseExited:(NSEvent*)nsEvent
 {
-  [NSCursor unhide];
+  CWinSystemOSX* winSystem = dynamic_cast<CWinSystemOSX*>(CServiceBroker::GetWinSystem());
+  if (winSystem)
+    winSystem->signalMouseExited();
 }
 
 - (NSOpenGLContext*)getGLContext

--- a/xbmc/windowing/osx/WinEventsOSX.h
+++ b/xbmc/windowing/osx/WinEventsOSX.h
@@ -29,6 +29,9 @@ public:
   void enableInputEvents();
   void disableInputEvents();
 
+  void signalMouseEntered();
+  void signalMouseExited();
+
 private:
   std::unique_ptr<CWinEventsOSXImplWrapper> m_eventsImplWrapper;
 };

--- a/xbmc/windowing/osx/WinEventsOSX.mm
+++ b/xbmc/windowing/osx/WinEventsOSX.mm
@@ -52,3 +52,13 @@ void CWinEventsOSX::disableInputEvents()
 {
   return [m_eventsImplWrapper->callbackClass disableInputEvents];
 }
+
+void CWinEventsOSX::signalMouseEntered()
+{
+  return [m_eventsImplWrapper->callbackClass signalMouseEntered];
+}
+
+void CWinEventsOSX::signalMouseExited()
+{
+  return [m_eventsImplWrapper->callbackClass signalMouseExited];
+}

--- a/xbmc/windowing/osx/WinEventsOSXImpl.h
+++ b/xbmc/windowing/osx/WinEventsOSXImpl.h
@@ -22,4 +22,7 @@
 - (void)disableInputEvents;
 - (XBMC_Event)keyPressEvent:(CGEventRef*)event;
 
+- (void)signalMouseEntered;
+- (void)signalMouseExited;
+
 @end

--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -47,7 +47,6 @@ public:
   bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
   bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
   void UpdateResolutions() override;
-  void ShowOSMouse(bool show) override;
   bool Minimize() override;
   bool Restore() override;
   bool Hide() override;
@@ -83,6 +82,9 @@ public:
   NSRect GetWindowDimensions();
   void enableInputEvents();
   void disableInputEvents();
+
+  void signalMouseEntered();
+  void signalMouseExited();
 
 protected:
   std::unique_ptr<KODI::WINDOWING::IOSScreenSaver> GetOSScreenSaverImpl() override;

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1279,7 +1279,12 @@ std::string CWinSystemOSX::GetClipboardText()
   return utf8_text;
 }
 
-void CWinSystemOSX::ShowOSMouse(bool show)
+void CWinSystemOSX::signalMouseEntered()
 {
-  // do nothing (this is already handled by OSXGLView on mouseEntered and mouseExited)
+  m_winEvents->signalMouseEntered();
+}
+
+void CWinSystemOSX::signalMouseExited()
+{
+  m_winEvents->signalMouseExited();
 }


### PR DESCRIPTION
## Description
According to the [documentation](https://developer.apple.com/documentation/appkit/nscursor/1527345-hide):

> Each invocation of hide must be balanced by an invocation of [unhide()](https://developer.apple.com/documentation/appkit/nscursor/1532996-unhide) in order for the cursor to be displayed.

Since we react to `NSView`events it might happen that we toggle hide without the cursor being hidden and the same for unhide - this causes all sorts of issues with the mouse being occluded when moving out of the window (or trying to focus the app bar when in fullscreen).

There used to be a `CGCursorIsVisible` but has been deprecated/removed, applications must track the state instead.

Not the last issue regarding mouse behaviour but we are getting close :)

