### PR TITLE
Python API: Add missing gameinfo to Player class 

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -15,6 +15,8 @@
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPlayer.h"
 #include "cores/DataCacheCore.h"
+#include "filesystem/File.h"
+#include "games/tags/GameInfoTag.h"
 #include "guilib/guiinfo/GUIInfo.h"
 #include "guilib/guiinfo/GUIInfoHelper.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
@@ -11324,6 +11326,14 @@ const CVideoInfoTag* CGUIInfoManager::GetCurrentMovieTag() const
 {
   if (m_currentFile->HasVideoInfoTag())
     return m_currentFile->GetVideoInfoTag();
+
+  return nullptr;
+}
+
+const KODI::GAME::CGameInfoTag* CGUIInfoManager::GetCurrentGameTag() const
+{
+  if (m_currentFile->HasGameInfoTag())
+    return m_currentFile->GetGameInfoTag();
 
   return nullptr;
 }

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -28,6 +28,10 @@ typedef std::shared_ptr<CGUIListItem> CGUIListItemPtr;
 
 namespace KODI
 {
+namespace GAME
+{
+class CGameInfoTag;
+}
 namespace GUILIB
 {
 namespace GUIINFO
@@ -130,6 +134,9 @@ public:
 
   // Current video stuff
   const CVideoInfoTag* GetCurrentMovieTag() const;
+
+  // Current game stuff
+  const KODI::GAME::CGameInfoTag* GetCurrentGameTag() const;
 
   void UpdateAVInfo();
 

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -1760,6 +1760,17 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
   }
   break;
 
+  case TMSG_UPDATE_PLAYER_ITEM:
+  {
+    std::unique_ptr<CFileItem> item{static_cast<CFileItem*>(pMsg->lpVoid)};
+    if (item)
+    {
+      m_itemCurrentFile->UpdateInfo(*item);
+      CServiceBroker::GetGUI()->GetInfoManager().UpdateCurrentItem(*m_itemCurrentFile);
+    }
+  }
+  break;
+
   default:
     CLog::Log(LOGERROR, "{}: Unhandled threadmessage sent, {}", __FUNCTION__, msg);
     break;

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -9,6 +9,7 @@
 #include "RetroPlayer.h"
 
 #include "FileItem.h"
+#include "GUIInfoManager.h"
 #include "RetroPlayerAutoSave.h"
 #include "RetroPlayerInput.h"
 #include "ServiceBroker.h"
@@ -42,6 +43,7 @@
 #include "guilib/WindowIDs.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
+#include "interfaces/AnnouncementManager.h"
 #include "messaging/ApplicationMessenger.h"
 #include "utils/JobManager.h"
 #include "utils/StringUtils.h"

--- a/xbmc/cores/RetroPlayer/cheevos/Cheevos.cpp
+++ b/xbmc/cores/RetroPlayer/cheevos/Cheevos.cpp
@@ -39,7 +39,7 @@ constexpr auto DEVELOPER = "Developer";
 constexpr auto GENRE = "Genre";
 constexpr auto CONSOLE_NAME = "ConsoleName";
 
-constexpr int RESPORNSE_SIZE = 64;
+constexpr int RESPONSE_SIZE = 64;
 } // namespace
 
 CCheevos::CCheevos(GAME::CGameClient* gameClient,
@@ -84,8 +84,8 @@ bool CCheevos::LoadData()
   response.CURLCreate(requestURL);
   response.CURLOpen(0);
 
-  char responseStr[RESPORNSE_SIZE];
-  response.ReadString(responseStr, RESPORNSE_SIZE);
+  char responseStr[RESPONSE_SIZE];
+  response.ReadString(responseStr, RESPONSE_SIZE);
 
   response.Close();
 

--- a/xbmc/cores/RetroPlayer/cheevos/Cheevos.cpp
+++ b/xbmc/cores/RetroPlayer/cheevos/Cheevos.cpp
@@ -8,11 +8,15 @@
 
 #include "Cheevos.h"
 
+#include "FileItem.h"
+#include "ServiceBroker.h"
 #include "URL.h"
 #include "filesystem/CurlFile.h"
 #include "filesystem/File.h"
 #include "games/addons/GameClient.h"
 #include "games/addons/cheevos/GameClientCheevos.h"
+#include "games/tags/GameInfoTag.h"
+#include "messaging/ApplicationMessenger.h"
 #include "utils/JSONVariantParser.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
@@ -29,6 +33,11 @@ constexpr auto SUCCESS = "Success";
 constexpr auto GAME_ID = "GameID";
 constexpr auto PATCH_DATA = "PatchData";
 constexpr auto RICH_PRESENCE = "RichPresencePatch";
+constexpr auto GAME_TITLE = "Title";
+constexpr auto PUBLISHER = "Publisher";
+constexpr auto DEVELOPER = "Developer";
+constexpr auto GENRE = "Genre";
+constexpr auto CONSOLE_NAME = "ConsoleName";
 
 constexpr int RESPORNSE_SIZE = 64;
 } // namespace
@@ -107,6 +116,18 @@ bool CCheevos::LoadData()
 
   m_richPresenceScript = data[PATCH_DATA][RICH_PRESENCE].asString();
   m_richPresenceLoaded = true;
+
+  std::unique_ptr<CFileItem> file{std::make_unique<CFileItem>()};
+
+  GAME::CGameInfoTag& tag = *file->GetGameInfoTag();
+  tag.SetTitle(data[PATCH_DATA][GAME_TITLE].asString());
+  tag.SetPublisher(data[PATCH_DATA][PUBLISHER].asString());
+  tag.SetDeveloper(data[PATCH_DATA][DEVELOPER].asString());
+  tag.SetGenres({data[PATCH_DATA][GENRE].asString()});
+  tag.SetPlatform(data[PATCH_DATA][CONSOLE_NAME].asString());
+
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_UPDATE_PLAYER_ITEM, -1, -1,
+                                             static_cast<void*>(file.release()));
 
   return true;
 }

--- a/xbmc/interfaces/legacy/Player.cpp
+++ b/xbmc/interfaces/legacy/Player.cpp
@@ -356,6 +356,12 @@ namespace XBMCAddon
       return getAppPlayer()->IsPlayingRDS();
     }
 
+    bool Player::isPlayingGame()
+    {
+      XBMC_TRACE;
+      return getAppPlayer()->IsPlayingGame();
+    }
+
     bool Player::isExternalPlayer()
     {
       XBMC_TRACE;
@@ -415,6 +421,20 @@ namespace XBMCAddon
 
       CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_ITEM, 0, item->item);
       CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
+    }
+
+    InfoTagGame* Player::getGameInfoTag()
+    {
+      XBMC_TRACE;
+      if (!getAppPlayer()->IsPlayingGame())
+        throw PlayerException("Kodi is not playing any game file");
+
+      const KODI::GAME::CGameInfoTag* game =
+          CServiceBroker::GetGUI()->GetInfoManager().GetCurrentGameTag();
+      if (game)
+        return new InfoTagGame(game);
+
+      return new InfoTagGame();
     }
 
     InfoTagRadioRDS* Player::getRadioRDSInfoTag()

--- a/xbmc/interfaces/legacy/Player.h
+++ b/xbmc/interfaces/legacy/Player.h
@@ -12,6 +12,7 @@
 #include "AddonString.h"
 #include "Alternative.h"
 #include "Exception.h"
+#include "InfoTagGame.h"
 #include "InfoTagMusic.h"
 #include "InfoTagRadioRDS.h"
 #include "InfoTagVideo.h"
@@ -426,6 +427,22 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_Player
+      /// @brief \python_func{ isPlayingGame() }
+      /// Check for playing game.
+      ///
+      /// @return                    True if kodi is playing a game
+      ///
+      ///------------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      isPlayingGame();
+#else
+      bool isPlayingGame();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_Player
       /// @brief \python_func{ isExternalPlayer() }
       /// Check for external player.
       ///
@@ -623,6 +640,25 @@ namespace XBMCAddon
       void updateInfoTag(const XBMCAddon::xbmcgui::ListItem* item);
 #endif
 
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_Player
+      /// @brief \python_func{ getGameInfoTag() }
+      /// To get game info tag.
+      ///
+      /// Returns the GameInfoTag of the current playing game.
+      ///
+      /// @return                    Game info tag
+      /// @throws Exception          If player is not playing a file or current
+      ///                            file is not a game file.
+      ///
+      ///------------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      getGameInfoTag();
+#else
+      InfoTagGame* getGameInfoTag();
+#endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///

--- a/xbmc/messaging/ApplicationMessenger.h
+++ b/xbmc/messaging/ApplicationMessenger.h
@@ -84,6 +84,9 @@
 #define TMSG_EVENT                        TMSG_MASK_APPLICATION + 33
 #define TMSG_TOGGLEFLOATONTOP TMSG_MASK_APPLICATION + 34
 
+/// @brief Called from the player when its current item is updated
+#define TMSG_UPDATE_PLAYER_ITEM TMSG_MASK_APPLICATION + 35
+
 #define TMSG_GUI_INFOLABEL                TMSG_MASK_GUIINFOMANAGER + 0
 #define TMSG_GUI_INFOBOOL                 TMSG_MASK_GUIINFOMANAGER + 1
 #define TMSG_UPDATE_CURRENT_ITEM          TMSG_MASK_GUIINFOMANAGER + 2


### PR DESCRIPTION
## Description

This PR extends the Python API to support player game metadata, like title, developer and publisher.

It also allows RetroPlayer to update the game metadata as it's retrieved from RetroAchievements.org.

Code is from https://github.com/xbmc/xbmc/pull/21286, but modified to not add captions to the interface.

## Motivation and context

Reported missing here: https://github.com/xbmc/xbmc/issues/23042

## How has this been tested?

Testing in progress.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
