### PR TITLE
Python API: Add ability to set infotags

### DIFF
--- a/xbmc/interfaces/legacy/InfoTagGame.cpp
+++ b/xbmc/interfaces/legacy/InfoTagGame.cpp
@@ -40,6 +40,11 @@ InfoTagGame::~InfoTagGame()
     delete infoTag;
 }
 
+void InfoTagGame::SerializeInfo(KODI::GAME::CGameInfoTag& infoTag) const
+{
+  infoTag = *this->infoTag;
+}
+
 String InfoTagGame::getTitle()
 {
   return infoTag->GetTitle();

--- a/xbmc/interfaces/legacy/InfoTagGame.h
+++ b/xbmc/interfaces/legacy/InfoTagGame.h
@@ -93,7 +93,12 @@ public:
 #else
   explicit InfoTagGame(bool offscreen = false);
 #endif
+
   ~InfoTagGame() override;
+
+#ifndef SWIG
+  void SerializeInfo(KODI::GAME::CGameInfoTag& infoTag) const;
+#endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
   ///

--- a/xbmc/interfaces/legacy/InfoTagMusic.cpp
+++ b/xbmc/interfaces/legacy/InfoTagMusic.cpp
@@ -41,6 +41,11 @@ namespace XBMCAddon
         delete infoTag;
     }
 
+    void InfoTagMusic::SerializeInfo(MUSIC_INFO::CMusicInfoTag& infoTag) const
+    {
+      infoTag = *this->infoTag;
+    }
+
     int InfoTagMusic::getDbId()
     {
       return infoTag->GetDatabaseId();

--- a/xbmc/interfaces/legacy/InfoTagMusic.h
+++ b/xbmc/interfaces/legacy/InfoTagMusic.h
@@ -92,7 +92,12 @@ namespace XBMCAddon
 #else
       explicit InfoTagMusic(bool offscreen = false);
 #endif
+
       ~InfoTagMusic() override;
+
+#ifndef SWIG
+      void SerializeInfo(MUSIC_INFO::CMusicInfoTag& infoTag) const;
+#endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///

--- a/xbmc/interfaces/legacy/InfoTagPicture.cpp
+++ b/xbmc/interfaces/legacy/InfoTagPicture.cpp
@@ -42,6 +42,11 @@ InfoTagPicture::~InfoTagPicture()
     delete infoTag;
 }
 
+void InfoTagPicture::SerializeInfo(CPictureInfoTag& infoTag) const
+{
+  infoTag = *this->infoTag;
+}
+
 String InfoTagPicture::getResolution()
 {
   return infoTag->GetInfo(SLIDESHOW_RESOLUTION);

--- a/xbmc/interfaces/legacy/InfoTagPicture.h
+++ b/xbmc/interfaces/legacy/InfoTagPicture.h
@@ -88,7 +88,12 @@ public:
 #else
   explicit InfoTagPicture(bool offscreen = false);
 #endif
+
   ~InfoTagPicture() override;
+
+#ifndef SWIG
+  void SerializeInfo(CPictureInfoTag& infoTag) const;
+#endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
   ///

--- a/xbmc/interfaces/legacy/InfoTagVideo.cpp
+++ b/xbmc/interfaces/legacy/InfoTagVideo.cpp
@@ -130,6 +130,11 @@ namespace XBMCAddon
         delete infoTag;
     }
 
+    void InfoTagVideo::SerializeInfo(CVideoInfoTag& infoTag) const
+    {
+      infoTag = *this->infoTag;
+    }
+
     int InfoTagVideo::getDbId()
     {
       return infoTag->m_iDbId;

--- a/xbmc/interfaces/legacy/InfoTagVideo.h
+++ b/xbmc/interfaces/legacy/InfoTagVideo.h
@@ -903,7 +903,12 @@ namespace XBMCAddon
 #else
       explicit InfoTagVideo(bool offscreen = false);
 #endif
+
       ~InfoTagVideo() override;
+
+#ifndef SWIG
+      void SerializeInfo(CVideoInfoTag& infoTag) const;
+#endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -892,10 +892,22 @@ namespace XBMCAddon
       return new xbmc::InfoTagVideo(GetVideoInfoTag(), m_offscreen);
     }
 
+    void ListItem::setVideoInfoTag(const xbmc::InfoTagVideo* infoTag)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
+      infoTag->SerializeInfo(*GetVideoInfoTag());
+    }
+
     xbmc::InfoTagMusic* ListItem::getMusicInfoTag()
     {
       XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
       return new xbmc::InfoTagMusic(GetMusicInfoTag(), m_offscreen);
+    }
+
+    void ListItem::setMusicInfoTag(const xbmc::InfoTagMusic* infoTag)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
+      infoTag->SerializeInfo(*GetMusicInfoTag());
     }
 
     xbmc::InfoTagPicture* ListItem::getPictureInfoTag()
@@ -906,12 +918,24 @@ namespace XBMCAddon
       return new xbmc::InfoTagPicture();
     }
 
+    void ListItem::setPictureInfoTag(const xbmc::InfoTagPicture* infoTag)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
+      infoTag->SerializeInfo(*GetPictureInfoTag());
+    }
+
     xbmc::InfoTagGame* ListItem::getGameInfoTag()
     {
       XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
       if (item->HasGameInfoTag())
         return new xbmc::InfoTagGame(item->GetGameInfoTag(), m_offscreen);
       return new xbmc::InfoTagGame();
+    }
+
+    void ListItem::setGameInfoTag(const xbmc::InfoTagGame* infoTag)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
+      infoTag->SerializeInfo(*GetGameInfoTag());
     }
 
     std::vector<std::string> ListItem::getStringArray(const InfoLabelValue& alt,
@@ -972,6 +996,26 @@ namespace XBMCAddon
     const MUSIC_INFO::CMusicInfoTag* ListItem::GetMusicInfoTag() const
     {
       return item->GetMusicInfoTag();
+    }
+
+    CPictureInfoTag* ListItem::GetPictureInfoTag()
+    {
+      return item->GetPictureInfoTag();
+    }
+
+    const CPictureInfoTag* ListItem::GetPictureInfoTag() const
+    {
+      return item->GetPictureInfoTag();
+    }
+
+    KODI::GAME::CGameInfoTag* ListItem::GetGameInfoTag()
+    {
+      return item->GetGameInfoTag();
+    }
+
+    const KODI::GAME::CGameInfoTag* ListItem::GetGameInfoTag() const
+    {
+      return item->GetGameInfoTag();
     }
 
     void ListItem::setTitleRaw(std::string title)

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -1203,6 +1203,23 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_xbmcgui_listitem
+      /// @brief \python_func{ setVideoInfoTag() }
+      /// Sets the VideoInfoTag for this item.
+      ///
+      /// @param infoTag The video info tag
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setVideoInfoTag(...);
+#else
+      void setVideoInfoTag(const xbmc::InfoTagVideo* infoTag);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcgui_listitem
       /// @brief \python_func{ getMusicInfoTag() }
       /// Returns the MusicInfoTag for this item.
       ///
@@ -1215,6 +1232,23 @@ namespace XBMCAddon
       getMusicInfoTag();
 #else
       xbmc::InfoTagMusic* getMusicInfoTag();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcgui_listitem
+      /// @brief \python_func{ setMusicInfoTag() }
+      /// Sets the MusicInfoTag for this item.
+      ///
+      /// @param infoTag The music info tag
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setMusicInfoTag(...);
+#else
+      void setMusicInfoTag(const xbmc::InfoTagMusic* infoTag);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -1237,6 +1271,23 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_xbmcgui_listitem
+      /// @brief \python_func{ setPictureInfoTag() }
+      /// Sets the InfoTagPicture for this item.
+      ///
+      /// @param infoTag The picture info tag
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setPictureInfoTag(...);
+#else
+      void setPictureInfoTag(const xbmc::InfoTagPicture* infoTag);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcgui_listitem
       /// @brief \python_func{ getGameInfoTag() }
       /// Returns the InfoTagGame for this item.
       ///
@@ -1251,7 +1302,24 @@ namespace XBMCAddon
       xbmc::InfoTagGame* getGameInfoTag();
 #endif
 
-private:
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcgui_listitem
+      /// @brief \python_func{ getGameInfoTag() }
+      /// Sets the InfoTagGame for this item.
+      ///
+      /// @param infoTag The game info tag
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v20 New function added.
+      ///
+      setGameInfoTag(...);
+#else
+      void setGameInfoTag(const xbmc::InfoTagGame* infoTag);
+#endif
+
+    private:
       std::vector<std::string> getStringArray(const InfoLabelValue& alt,
                                               const std::string& tag,
                                               std::string value,
@@ -1268,6 +1336,12 @@ private:
 
       MUSIC_INFO::CMusicInfoTag* GetMusicInfoTag();
       const MUSIC_INFO::CMusicInfoTag* GetMusicInfoTag() const;
+
+      CPictureInfoTag* GetPictureInfoTag();
+      const CPictureInfoTag* GetPictureInfoTag() const;
+
+      KODI::GAME::CGameInfoTag* GetGameInfoTag();
+      const KODI::GAME::CGameInfoTag* GetGameInfoTag() const;
 
       void setTitleRaw(std::string title);
       void setPathRaw(const std::string& path);


### PR DESCRIPTION
## Description

Since `ListItem.setInfo` was deprecated, we moved to managing metadata via infotags.

However, the memory ownership model of infotags makes things brittle, because you're not guaranteed a reference to the underlying listitem's memory. Therefore, setting metadata on infotags isn't guaranteed to update the underlying listitem, breaking our alternative to `setInfo` in v20.

To work around this, simply add infotag setters.

## Motivation and context

Fixes https://github.com/xbmc/xbmc/issues/23042

## How has this been tested?

Testing in progress. Will upload test builds.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
