### PR TITLE
[macOS][nativeWindowing] Delegate input events to NSView

### DIFF
--- a/xbmc/windowing/osx/OpenGL/OSXGLView.mm
+++ b/xbmc/windowing/osx/OpenGL/OSXGLView.mm
@@ -28,6 +28,15 @@
   BOOL pause;
 }
 
+- (void)SendInputEvent:(NSEvent*)nsEvent
+{
+  CWinSystemOSX* winSystem = dynamic_cast<CWinSystemOSX*>(CServiceBroker::GetWinSystem());
+  if (winSystem)
+  {
+    winSystem->SendInputEvent(nsEvent);
+  }
+}
+
 - (id)initWithFrame:(NSRect)frameRect
 {
   NSOpenGLPixelFormatAttribute wattrs[] = {
@@ -58,6 +67,11 @@
 {
   [NSOpenGLContext clearCurrentContext];
   [m_glcontext clearDrawable];
+}
+
+- (BOOL)acceptsFirstResponder
+{
+  return YES;
 }
 
 - (void)drawRect:(NSRect)rect
@@ -98,8 +112,71 @@
     winSystem->signalMouseEntered();
 }
 
+#pragma mark - Input Events
+
 - (void)mouseMoved:(NSEvent*)nsEvent
 {
+  [self SendInputEvent:nsEvent];
+}
+
+- (void)mouseDown:(NSEvent*)nsEvent
+{
+  [self SendInputEvent:nsEvent];
+}
+
+- (void)mouseDragged:(NSEvent*)nsEvent
+{
+  [self SendInputEvent:nsEvent];
+}
+
+- (void)mouseUp:(NSEvent*)nsEvent
+{
+  [self SendInputEvent:nsEvent];
+}
+
+- (void)rightMouseDown:(NSEvent*)nsEvent
+{
+  [self SendInputEvent:nsEvent];
+}
+
+- (void)rightMouseDragged:(NSEvent*)nsEvent
+{
+  [self SendInputEvent:nsEvent];
+}
+
+- (void)rightMouseUp:(NSEvent*)nsEvent
+{
+  [self SendInputEvent:nsEvent];
+}
+
+- (void)otherMouseUp:(NSEvent*)nsEvent
+{
+  [self SendInputEvent:nsEvent];
+}
+
+- (void)otherMouseDown:(NSEvent*)nsEvent
+{
+  [self SendInputEvent:nsEvent];
+}
+
+- (void)scrollWheel:(NSEvent*)nsEvent
+{
+  [self SendInputEvent:nsEvent];
+}
+
+- (void)otherMouseDragged:(NSEvent*)nsEvent
+{
+  [self SendInputEvent:nsEvent];
+}
+
+- (void)keyDown:(NSEvent*)nsEvent
+{
+  [self SendInputEvent:nsEvent];
+}
+
+- (void)keyUp:(NSEvent*)nsEvent
+{
+  [self SendInputEvent:nsEvent];
 }
 
 - (void)mouseExited:(NSEvent*)nsEvent

--- a/xbmc/windowing/osx/WinEventsOSX.h
+++ b/xbmc/windowing/osx/WinEventsOSX.h
@@ -15,6 +15,11 @@
 #include <memory>
 
 struct CWinEventsOSXImplWrapper;
+#ifdef __OBJC__
+@class NSEvent;
+#else
+struct NSEvent;
+#endif
 
 class CWinEventsOSX : public IWinEvents, public CThread
 {
@@ -31,6 +36,7 @@ public:
 
   void signalMouseEntered();
   void signalMouseExited();
+  void SendInputEvent(NSEvent* nsEvent);
 
 private:
   std::unique_ptr<CWinEventsOSXImplWrapper> m_eventsImplWrapper;

--- a/xbmc/windowing/osx/WinEventsOSX.mm
+++ b/xbmc/windowing/osx/WinEventsOSX.mm
@@ -62,3 +62,8 @@ void CWinEventsOSX::signalMouseExited()
 {
   return [m_eventsImplWrapper->callbackClass signalMouseExited];
 }
+
+void CWinEventsOSX::SendInputEvent(NSEvent* nsEvent)
+{
+  [m_eventsImplWrapper->callbackClass ProcessInputEvent:nsEvent];
+}

--- a/xbmc/windowing/osx/WinEventsOSXImpl.h
+++ b/xbmc/windowing/osx/WinEventsOSXImpl.h
@@ -24,5 +24,6 @@
 
 - (void)signalMouseEntered;
 - (void)signalMouseExited;
+- (void)ProcessInputEvent:(NSEvent*)nsEvent;
 
 @end

--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -25,9 +25,11 @@ class CWinEventsOSX;
 #ifdef __OBJC__
 @class NSWindow;
 @class OSXGLView;
+@class NSEvent;
 #else
 struct NSWindow;
 struct OSXGLView;
+struct NSEvent;
 #endif
 
 class CWinSystemOSX : public CWinSystemBase, public ITimerCallback
@@ -98,6 +100,7 @@ public:
 
   void signalMouseEntered();
   void signalMouseExited();
+  void SendInputEvent(NSEvent* nsEvent);
 
 protected:
   std::unique_ptr<KODI::WINDOWING::IOSScreenSaver> GetOSScreenSaverImpl() override;

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1351,6 +1351,11 @@ void CWinSystemOSX::signalMouseExited()
   m_winEvents->signalMouseExited();
 }
 
+void CWinSystemOSX::SendInputEvent(NSEvent* nsEvent)
+{
+  m_winEvents->SendInputEvent(nsEvent);
+}
+
 bool CWinSystemOSX::SupportsScreenMove()
 {
   // macOS doesn't allow programatically moving windows across screens if the window is fullscreen


### PR DESCRIPTION
## Description
This finally fixes macos nativewindowing mouse behaviour by delegating the capture of such events by the `NSTrackingArea` and subsequent piping to the windowing event handler instead of defining a global event monitor for keyboard and mouse. The monitor continues to exist but only requests key up/down events, not mouse.

Trying to focus the app bar while in fullscreen, notice the kodi cursor wrongly positioned on the bottom of the screen.

**Before:**
<img width="1470" alt="image" src="https://user-images.githubusercontent.com/7375276/227925556-7b877c52-fb39-4540-a09f-fb2152ed2625.png">


**Now:**
<img width="1470" alt="image" src="https://user-images.githubusercontent.com/7375276/227925038-02f77c7c-caea-4d1a-a5c8-300a5e593745.png">
