### PR TITLE
Binary Addons/c-api: Make general/gui.h valid C

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/general.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/general.h
@@ -21,13 +21,13 @@ extern "C"
   /// @brief **Adjust refresh rate enum**\n
   /// Used to get the Adjust refresh rate status info.
   ///
-  enum AdjustRefreshRateStatus
+  typedef enum AdjustRefreshRateStatus
   {
     ADJUST_REFRESHRATE_STATUS_OFF = 0,
     ADJUST_REFRESHRATE_STATUS_ALWAYS,
     ADJUST_REFRESHRATE_STATUS_ON_STARTSTOP,
     ADJUST_REFRESHRATE_STATUS_ON_START,
-  };
+  } AdjustRefreshRateStatus;
   //------------------------------------------------------------------------------
 
   typedef struct AddonToKodiFuncTable_kodi_gui_general


### PR DESCRIPTION
## Description

The file refers to `enum AdjustRefreshRateStatus` as `AdjustRefreshRateStatus`. A typedef has been added to make this valid in C, not only in C++. The fix follows the format used in other files in the C API.

## Motivation and context

The file is part of the C API for binary addons, but it was not valid C. Compiling it with a C compiler produced the following error:

```
$ gcc -c general.h 
general.h:43:5: error: expected specifier-qualifier-list before ‘AdjustRefreshRateStatus’
   43 |     AdjustRefreshRateStatus (*get_adjust_refresh_rate_status)(KODI_HANDLE kodiBase);
      |     ^~~~~~~~~~~~~~~~~~~~~~~
```

## How has this been tested?

```
$ gcc -c general.h
````

This doesn't produce errors anymore. (Compiling the header by itself is obviously pointless, but it demonstrates that the problem has been fixed.)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
