### PR TITLE
Bug fix for xmbc.getRegion() [Replaces PR #22982]

### DIFF
--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -1332,7 +1332,13 @@ std::string CDateTime::GetAsLocalizedDate(bool longDate/*=false*/) const
 
 std::string CDateTime::GetAsLocalizedDate(const std::string &strFormat) const
 {
+  return GetAsLocalizedDate(strFormat, false);
+}
+
+std::string CDateTime::GetAsLocalizedDate(const std::string &strFormat, bool returnFormat) const
+{
   std::string strOut;
+  std::string fmtOut;
 
   KODI::TIME::SystemTime dateTime;
   GetAsSystemTime(dateTime);
@@ -1364,6 +1370,7 @@ std::string CDateTime::GetAsLocalizedDate(const std::string &strFormat) const
       }
       StringUtils::Replace(strPart, "''", "'");
       strOut+=strPart;
+      fmtOut+=strPart;
     }
     else if (c=='D' || c=='d') // parse days
     {
@@ -1386,14 +1393,23 @@ std::string CDateTime::GetAsLocalizedDate(const std::string &strFormat) const
       // Format string with the length of the mask
       std::string str;
       if (partLength==1) // single-digit number
-        str = std::to_string(dateTime.day);
+      {
+          str = std::to_string(dateTime.day);
+          fmtOut+="%-d";
+      }
       else if (partLength==2) // two-digit number
+      {
         str = StringUtils::Format("{:02}", dateTime.day);
+        fmtOut+="%d";
+      }
       else // Day of week string
       {
         int wday = dateTime.dayOfWeek;
         if (wday < 1 || wday > 7) wday = 7;
-        str = g_localizeStrings.Get((c =='d' ? 40 : 10) + wday);
+        {
+          str = g_localizeStrings.Get((c =='d' ? 40 : 10) + wday);
+          fmtOut+=(c =='d' ? "%a" : "%A");
+        }
       }
       strOut+=str;
     }
@@ -1418,14 +1434,23 @@ std::string CDateTime::GetAsLocalizedDate(const std::string &strFormat) const
       // Format string with the length of the mask
       std::string str;
       if (partLength==1) // single-digit number
+      {
         str = std::to_string(dateTime.month);
+        fmtOut+="%-m";
+      }
       else if (partLength==2) // two-digit number
+      {
         str = StringUtils::Format("{:02}", dateTime.month);
+        fmtOut+="%m";
+      }
       else // Month string
       {
         int wmonth = dateTime.month;
         if (wmonth < 1 || wmonth > 12) wmonth = 12;
-        str = g_localizeStrings.Get((c =='m' ? 50 : 20) + wmonth);
+          {
+             str = g_localizeStrings.Get((c =='m' ? 50 : 20) + wmonth);
+             fmtOut+=(c =='m' ? "%b" : "%B");
+          }
       }
       strOut+=str;
     }
@@ -1450,15 +1475,25 @@ std::string CDateTime::GetAsLocalizedDate(const std::string &strFormat) const
       // Format string with the length of the mask
       std::string str = std::to_string(dateTime.year); // four-digit number
       if (partLength <= 2)
+      {
         str.erase(0, 2); // two-digit number
+        fmtOut+="%y";
+      }
+      else
+      {
+          fmtOut+="%Y";
+      }
 
-      strOut+=str;
+        strOut+=str;
     }
     else // everything else pass to output
+    {
       strOut+=c;
+      fmtOut+=c;
+    }
   }
 
-  return strOut;
+  return (returnFormat ? fmtOut : strOut);
 }
 
 std::string CDateTime::GetAsLocalizedDateTime(bool longDate/*=false*/, bool withSeconds/*=true*/) const

--- a/xbmc/XBDateTime.h
+++ b/xbmc/XBDateTime.h
@@ -179,6 +179,7 @@ public:
   std::string GetAsDBTime() const;
   std::string GetAsLocalizedDate(bool longDate=false) const;
   std::string GetAsLocalizedDate(const std::string &strFormat) const;
+  std::string GetAsLocalizedDate(const std::string &strFormat, bool returnFormat) const;
   std::string GetAsLocalizedTime(const std::string &format, bool withSeconds=true) const;
   std::string GetAsLocalizedDateTime(bool longDate=false, bool withSeconds=true) const;
   std::string GetAsLocalizedTime(TIME_FORMAT format, bool withSeconds = false) const;

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -403,50 +403,62 @@ namespace XBMCAddon
     {
       XBMC_TRACE;
       std::string result;
+      CDateTime now = CDateTime::GetCurrentDateTime();
 
       if (StringUtils::CompareNoCase(id, "datelong") == 0)
       {
+        result = now.GetAsLocalizedDate(g_langInfo.GetDateFormat(true), true);
+      }
+      else if (StringUtils::CompareNoCase(id, "dateshort") == 0)
+      {
+        result = now.GetAsLocalizedDate(g_langInfo.GetDateFormat(false), true);
+      }
+      else if (StringUtils::CompareNoCase(id, "tempunit") == 0)
+      {
+        result = g_langInfo.GetTemperatureUnitString();
+      }
+      //TODO - There is a (low) risk that these 'raw' formats could be changed on Windows if they contain a '%-' sequence.
+      else if (StringUtils::CompareNoCase(id, "datelongraw") == 0)
+      {
         result = g_langInfo.GetDateFormat(true);
-        StringUtils::Replace(result, "DDDD", "%A");
-        StringUtils::Replace(result, "MMMM", "%B");
-        StringUtils::Replace(result, "D", "%d");
-        StringUtils::Replace(result, "YYYY", "%Y");
-        }
-        else if (StringUtils::CompareNoCase(id, "dateshort") == 0)
+      }
+      else if (StringUtils::CompareNoCase(id, "dateshortraw") == 0)
+      {
+        result = g_langInfo.GetDateFormat(false);
+      }
+      else if (StringUtils::CompareNoCase(id, "timeraw") == 0)
+      {
+        result = g_langInfo.GetTimeFormat();
+      }
+      else if (StringUtils::CompareNoCase(id, "speedunit") == 0)
+      {
+        result = g_langInfo.GetSpeedUnitString();
+      }
+      else if (StringUtils::CompareNoCase(id, "time") == 0)
+      {
+        result = g_langInfo.GetTimeFormat();
+        if (StringUtils::StartsWith(result, "HH"))
         {
-          result = g_langInfo.GetDateFormat(false);
-          StringUtils::Replace(result, "MM", "%m");
-          StringUtils::Replace(result, "DD", "%d");
-#ifdef TARGET_WINDOWS
-          StringUtils::Replace(result, "M", "%#m");
-          StringUtils::Replace(result, "D", "%#d");
-#else
-          StringUtils::Replace(result, "M", "%-m");
-          StringUtils::Replace(result, "D", "%-d");
-#endif
-          StringUtils::Replace(result, "YYYY", "%Y");
+          StringUtils::Replace(result, "HH", "%H");
         }
-        else if (StringUtils::CompareNoCase(id, "tempunit") == 0)
-          result = g_langInfo.GetTemperatureUnitString();
-        else if (StringUtils::CompareNoCase(id, "speedunit") == 0)
-          result = g_langInfo.GetSpeedUnitString();
-        else if (StringUtils::CompareNoCase(id, "time") == 0)
+        else
         {
-          result = g_langInfo.GetTimeFormat();
-          if (StringUtils::StartsWith(result, "HH"))
-            StringUtils::Replace(result, "HH", "%H");
-          else
-            StringUtils::Replace(result, "H", "%H");
+          StringUtils::Replace(result, "H", "%H");
           StringUtils::Replace(result, "h", "%I");
           StringUtils::Replace(result, "mm", "%M");
           StringUtils::Replace(result, "ss", "%S");
           StringUtils::Replace(result, "xx", "%p");
         }
-        else if (StringUtils::CompareNoCase(id, "meridiem") == 0)
-          result = StringUtils::Format("{}/{}", g_langInfo.GetMeridiemSymbol(MeridiemSymbolAM),
-                                       g_langInfo.GetMeridiemSymbol(MeridiemSymbolPM));
-
-        return result;
+      }
+      else if (StringUtils::CompareNoCase(id, "meridiem") == 0)
+      {
+        result = StringUtils::Format("{}/{}", g_langInfo.GetMeridiemSymbol(MeridiemSymbolAM),
+                                     g_langInfo.GetMeridiemSymbol(MeridiemSymbolPM));
+      }
+#ifdef TARGET_WINDOWS
+      StringUtils::Replace(result, "%-", "%#");  //Convert to Windows format if required.
+#endif
+      return result;
     }
 
     //! @todo Add a mediaType enum

--- a/xbmc/test/TestDateTime.cpp
+++ b/xbmc/test/TestDateTime.cpp
@@ -9,6 +9,7 @@
 #include "LangInfo.h"
 #include "XBDateTime.h"
 #include "guilib/LocalizeStrings.h"
+#include "interfaces/legacy/ModuleXbmc.h" //Needed to test getRegion()
 
 #include <array>
 #include <iostream>
@@ -487,6 +488,38 @@ TEST_F(TestDateTime, GetAsLocalized)
   EXPECT_EQ(dateTime3.GetAsLocalizedDate(false), "09-May-91");
   //Test short day name and single digit day number.
   EXPECT_EQ(dateTime3.GetAsLocalizedDate(true), "Thu, 9 May 1991");
+  //Test that the Python date formatting string is returned instead
+  //of the actual formatted date string.
+
+  CDateTime dateTime4;
+  dateTime4.SetDateTime(1991, 05, 9, 12, 34, 56);  //Need a single digit date
+
+  //Test non zero-padded day and short month name.
+  EXPECT_EQ(dateTime4.GetAsLocalizedDate(std::string("D-mmm-YY"), true), "%-d-%b-%y");
+  //Test NZP day and NZP month.
+  EXPECT_EQ(dateTime4.GetAsLocalizedDate(std::string("D-M-YY"), true), "%-d-%-m-%y");
+
+  g_langInfo.SetShortDateFormat("D/M/YY");
+  g_langInfo.SetLongDateFormat("ddd, D MMMM YYYY");
+
+//Test getRegion() here because it is directly reliant on GetAsLocalizedDate()
+//and the windows-specific formatting happens in getRegion().
+#ifdef TARGET_WINDOWS
+  //Windows is handled differently because that's what ModuleXbmc.cpp does.
+  EXPECT_EQ(XBMCAddon::xbmc::getRegion("dateshort"), "%#d/%#m/%y");
+  EXPECT_EQ(XBMCAddon::xbmc::getRegion("datelong"), "%a, %#d %B %Y");
+#else
+  EXPECT_EQ(XBMCAddon::xbmc::getRegion("dateshort"), "%-d/%-m/%y");
+  EXPECT_EQ(XBMCAddon::xbmc::getRegion("datelong"), "%a, %-d %B %Y");
+#endif
+
+  //Test short day name, short month name and 2 digit year.
+  EXPECT_EQ(dateTime4.GetAsLocalizedDate(std::string("ddd, DD-mmm-YY"), true), "%a, %d-%b-%y");
+  //Test as above but with 4 digit year.
+  EXPECT_EQ(dateTime4.GetAsLocalizedDate(std::string("ddd, DD-mmm-YYYY"), true), "%a, %d-%b-%Y");
+  //Test some 'normal' DMY.
+  EXPECT_EQ(dateTime4.GetAsLocalizedDate(std::string("DD/MM/YYYY"), true), "%d/%m/%Y");
+  EXPECT_EQ(dateTime4.GetAsLocalizedDate(std::string("DD/MM/YY"), true), "%d/%m/%y");
 
   // not possible to use these three
   // EXPECT_EQ(dateTime1.GetAsLocalizedTime(TIME_FORMAT(32)), "");


### PR DESCRIPTION
## Description
With Regional settings 'dateshort' and 'datelong' set to "DD-mmm-YY" and "ddd, D MMMM YYYY" respectively, xbmc.getRegion('dateshort') and xbmc.getRegion('datelong') return "%d-mmm-YY" and "ddd, %d %B %Y" respectively whereas the GUI displays the expected values.  "mmm" (short month name) and "ddd" (short day name) were ignored.

This error is caused because xmbc.getRegion() uses different logic to interpret the regional date settings formatting strings than CDateTime::GetAsLocalizedDate().  getRegion() executes a string search/replace operation for several format strings, whereas, GetAsLocalizedDate() inspects the formating string character-by-character to produce its output.

A Boolean flag was added to GetAsLocalizedDate() to indicate if the returned value should be the formatted date value or the modified formatting string.  Both strings are constructed at the same time, using the same logic, with only the required one returned.  An overload function was also created for backwards compatibility with other calling functions.

The string search/replace operations in xmbc.getRegion() were replaced with a call to GetAsLocalizedDate() with the new flag set.

## Motivation and context
xbmc.getRegion('dateshort') and xbmc.getRegion('datelong') return incorrectly formatted strings under certain circumstances.

## How has this been tested?
langinfo.xml was updated with the required formatting strings.
A test addon was run writing values to the log.  Before and after logs were compared.

Log snippets:
**BEFORE: (Kodi 19.5)**
loadSettings: System 'dateshort' = %d-mmm-YY
loadSettings: System 'datelong' = ddd, %d %B %Y
**AFTER: (Kodi 21.0-APLHA1)**
loadSettings: System 'dateshort' = %d-%b-%y
loadSettings: System 'datelong' = %a, %-d %B %Y

Test suite updated to validate formatting strings as well as formatted dates.

## What is the effect on users?
Addon developers will be able to obtain correct formatting strings for all formats supported by the GUI.

## Screenshots (if appropriate):

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed