### PR TITLE
[Windows][dxva] Validate the format conversion of the DXVA processor

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -396,6 +396,8 @@ void CContext::DestroyContext()
   {
     m_d3d11Debug->ReportLiveDeviceObjects(D3D11_RLDO_SUMMARY | D3D11_RLDO_DETAIL);
     m_d3d11Debug = nullptr;
+    // References in the report to ID3D11VideoDecoderOutputView are normal at this point
+    // They are held for VideoPlayer and should be freed later.
   }
 #endif
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
@@ -96,11 +96,13 @@ bool CRendererDXVA::Configure(const VideoPicture& picture, float fps, unsigned o
   {
     m_format = picture.videoBuffer->GetFormat();
     const DXGI_FORMAT dxgi_format = CRenderBufferImpl::GetDXGIFormat(m_format, GetDXGIFormat(picture));
+    const DXGI_FORMAT dest_format = DX::Windowing()->GetBackBuffer().GetFormat();
 
     // create processor
     m_processor = std::make_unique<DXVA::CProcessorHD>();
     if (m_processor->PreInit() && m_processor->Open(m_sourceWidth, m_sourceHeight) &&
-        m_processor->IsFormatSupported(dxgi_format, support_type))
+        m_processor->IsFormatSupported(dxgi_format, support_type) &&
+        m_processor->IsFormatConversionSupported(dxgi_format, dest_format, picture))
     {
       return true;
     }

--- a/xbmc/rendering/dx/DirectXHelper.cpp
+++ b/xbmc/rendering/dx/DirectXHelper.cpp
@@ -6,6 +6,7 @@
  *  See LICENSES/README.md for more information.
  */
 
+#include <d3d11_4.h>
 #include <dxgicommon.h>
 #include <dxgiformat.h>
 
@@ -180,5 +181,19 @@ const std::string DXGIColorSpaceTypeToString(DXGI_COLOR_SPACE_TYPE type)
       return std::to_string(type);
   }
 #undef CASEDXGICOLORSPACETYPE
+}
+
+const std::string D3D11VideoProcessorFormatSupportToString(
+    D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT value)
+{
+  switch (value)
+  {
+    case D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT_INPUT:
+      return "input";
+    case D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT_OUTPUT:
+      return "output";
+    default:
+      return std::to_string(value);
+  }
 }
 } // namespace DX

--- a/xbmc/rendering/dx/DirectXHelper.h
+++ b/xbmc/rendering/dx/DirectXHelper.h
@@ -188,6 +188,8 @@ namespace DX
 
   const std::string DXGIFormatToString(const DXGI_FORMAT format);
   const std::string DXGIColorSpaceTypeToString(DXGI_COLOR_SPACE_TYPE type);
+  const std::string D3D11VideoProcessorFormatSupportToString(
+      D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT value);
 }
 
 #ifdef TARGET_WINDOWS_DESKTOP


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Added a function and plumbing to use ID3D11VideoProcessorEnumerator1::CheckVideoProcessorFormatConversion, available since Windows 10. Color space and format selection were moved around but not changed.

This is a first step, the new validation is called from RendererDVXA::Configure and logs the problem but playback still fails when a conversion is not supported.

To move forward with the next step (automatic fallback to pixel shaders or software), I'd like some information:
* Can the source's format or color space change mid-stream? That would have to be detected in CProcessorHD::Render I guess. 
* I'm undecided about the approach, I can think of two main ways  that have plus and minus, any input?
    * Test remains in RendererDXVA::Configure, modify CWinRenderer::Configure to loop over a list of render methods sorted with user preference and render method's weights, until Configure() succeeds for one of them. Pro: rather easy to do. Con: HDR switching would have to be moved a little later in the configuration process to avoid unnecessary switches when a renderer fails to configure. That approach also provides fallback for other renderers at the same time, but not super useful as dvxa is the only one that's likely to fail as it cannot probe for all support during GetWeight
    * extend CRendererDXVA::GetWeight  so that it doesn't create a weight if the conversion is not possible and is not seen as a candidate by WinRenderer. Pro: seems like the best place to probe for conversion capabilities and later whether some post processing is needed in the output shader (HLG / tonemapping). Con: GetWeight is currently static, everything else in RendererDXVA and ProcessorHD is not. Duplicating part of the code as static would not be good, so some lifecycle changes would be necessary that may also impact the other render methods.

Ideally both should be done I guess as they provide other benefits...


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Take advantage of OS provided checking to detect DVXA processor conversions that will fail and cause black screens.

Leak of decoder output views detected after activating the debug layers on the decoder d3d device (previous PR)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 10 and recent AMD Cezanne igfx: the GPU and driver are fully featured and handle every type of file I had so I had to fake invalid information to confirm that the API returns failures and the function returns them to the caller.

With an old-ish 4th generation Intel it was possible to confirm that HDR->SDR conversions are correctly detected and rejected (trying to use them anyway yields "not available"  errors from VideoProcessorBlt).

No Windows 8 on hand to test degraded behavior.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Additional log information for easier troubleshooting of black screens with the dxva renderer.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
