### PR TITLE
Python API: Fix setting picture/game info via InfoTags

### DIFF
--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -901,17 +901,13 @@ namespace XBMCAddon
     xbmc::InfoTagPicture* ListItem::getPictureInfoTag()
     {
       XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
-      if (item->HasPictureInfoTag())
-        return new xbmc::InfoTagPicture(item->GetPictureInfoTag(), m_offscreen);
-      return new xbmc::InfoTagPicture();
+      return new xbmc::InfoTagPicture(item->GetPictureInfoTag(), m_offscreen);
     }
 
     xbmc::InfoTagGame* ListItem::getGameInfoTag()
     {
       XBMCAddonUtils::GuiLock lock(languageHook, m_offscreen);
-      if (item->HasGameInfoTag())
-        return new xbmc::InfoTagGame(item->GetGameInfoTag(), m_offscreen);
-      return new xbmc::InfoTagGame();
+      return new xbmc::InfoTagGame(item->GetGameInfoTag(), m_offscreen);
     }
 
     std::vector<std::string> ListItem::getStringArray(const InfoLabelValue& alt,


### PR DESCRIPTION
## Description

This PR attempts to fix the issue reported in https://github.com/xbmc/xbmc/issues/23042. In the code I noticed that the behavior of picture/game infotags differed from video/music, which is likely the source of the bug.

If you scroll up in the diff, you can see how video/music infotags are retrieved. The picture/game approach, calling HasGameInfoTag(), is incorrect because a game info tag is never created and linked to the listitem.

## Motivation and context

Fixes https://github.com/xbmc/xbmc/issues/23042

Replaces https://github.com/xbmc/xbmc/pull/23055

## How has this been tested?

Test builds coming soon.

Confirmed working in https://github.com/xbmc/xbmc/issues/23042

## What is the effect on users?

Fixed setting picture/game infotags in Python

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
