### PR TITLE
[rendering] use default luminance for tone mapping of streams with bad metadata

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/CMakeLists.txt
@@ -6,15 +6,19 @@ set(HEADERS ConvolutionKernels.h
 
 if(CORE_SYSTEM_NAME STREQUAL windows OR CORE_SYSTEM_NAME STREQUAL windowsstore)
   list(APPEND SOURCES ConversionMatrix.cpp
+                      ToneMappers.cpp
                       WinVideoFilter.cpp)
   list(APPEND HEADERS ConversionMatrix.h
+                      ToneMappers.h
                       WinVideoFilter.h)
 endif()
 
 
 if(TARGET OpenGL::GL OR TARGET OpenGL::GLES)
-  list(APPEND SOURCES ConversionMatrix.cpp)
-  list(APPEND HEADERS ConversionMatrix.h)
+  list(APPEND SOURCES ConversionMatrix.cpp
+                      ToneMappers.cpp)
+  list(APPEND HEADERS ConversionMatrix.h
+                      ToneMappers.h)
 endif()
 
 if(TARGET OpenGL::GL)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ToneMappers.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ToneMappers.cpp
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ToneMappers.h"
+
+float CToneMappers::GetLuminanceValue(bool hasDisplayMetadata,
+                                      const AVMasteringDisplayMetadata& displayMetadata,
+                                      bool hasLightMetadata,
+                                      const AVContentLightMetadata& lightMetadata)
+{
+  // default for bad quality HDR-PQ sources (missing or invalid metadata)
+  const float defaultLuminance = 400.0f;
+  float lum1 = defaultLuminance;
+
+  unsigned int maxLuminance = static_cast<unsigned int>(defaultLuminance);
+
+  if (hasDisplayMetadata && displayMetadata.has_luminance && displayMetadata.max_luminance.den)
+  {
+    const uint16_t lum = displayMetadata.max_luminance.num / displayMetadata.max_luminance.den;
+
+    if (lum > 0)
+      maxLuminance = lum;
+  }
+
+  if (hasLightMetadata)
+  {
+    float lum2;
+
+    if (lightMetadata.MaxCLL >= maxLuminance)
+    {
+      lum1 = static_cast<float>(maxLuminance);
+      lum2 = static_cast<float>(lightMetadata.MaxCLL);
+    }
+    else
+    {
+      lum1 = static_cast<float>(lightMetadata.MaxCLL);
+      lum2 = static_cast<float>(maxLuminance);
+    }
+    const float lum3 = static_cast<float>(lightMetadata.MaxFALL);
+
+    lum1 = (lum1 * 0.5f) + (lum2 * 0.2f) + (lum3 * 0.3f);
+  }
+  else if (hasDisplayMetadata && displayMetadata.has_luminance)
+  {
+    lum1 = static_cast<float>(maxLuminance);
+  }
+
+  return lum1;
+}

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ToneMappers.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ToneMappers.h
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: LGPL-2.1-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+extern "C"
+{
+#include <libavutil/mastering_display_metadata.h>
+}
+
+class CToneMappers
+{
+public:
+  static float GetLuminanceValue(bool hasDisplayMetadata,
+                                 const AVMasteringDisplayMetadata& displayMetadata,
+                                 bool hasLightMetadata,
+                                 const AVContentLightMetadata& lightMetadata);
+};

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h
@@ -91,7 +91,6 @@ private:
   void PrepareParameters(unsigned sourceWidth, unsigned sourceHeight, CRect sourceRect, const CPoint points[4]);
   void SetShaderParameters(CD3DTexture &sourceTexture, unsigned range, float contrast, float brightness);
   void CreateDitherView();
-  float GetLuminanceValue() const;
 
   bool m_useLut = false;
   bool m_useDithering = false;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.cpp
@@ -12,6 +12,7 @@
 #include "../RenderFlags.h"
 #include "ConvolutionKernels.h"
 #include "ServiceBroker.h"
+#include "ToneMappers.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/GLUtils.h"
@@ -192,13 +193,16 @@ bool BaseYUV2RGBGLSLShader::OnEnabled()
     }
     else if (m_toneMappingMethod == VS_TONEMAPMETHOD_ACES)
     {
-      glUniform1f(m_hLuminance, GetLuminanceValue());
+      const float lumin = CToneMappers::GetLuminanceValue(m_hasDisplayMetadata, m_displayMetadata,
+                                                          m_hasLightMetadata, m_lightMetadata);
+      glUniform1f(m_hLuminance, lumin);
       glUniform1f(m_hToneP1, m_toneMappingParam);
     }
     else if (m_toneMappingMethod == VS_TONEMAPMETHOD_HABLE)
     {
-      float lumin = GetLuminanceValue();
-      float param = (10000.0f / lumin) * (2.0f / m_toneMappingParam);
+      const float lumin = CToneMappers::GetLuminanceValue(m_hasDisplayMetadata, m_displayMetadata,
+                                                          m_hasLightMetadata, m_lightMetadata);
+      const float param = (10000.0f / lumin) * (2.0f / m_toneMappingParam);
       glUniform1f(m_hLuminance, lumin);
       glUniform1f(m_hToneP1, param);
     }
@@ -254,38 +258,6 @@ void BaseYUV2RGBGLSLShader::SetToneMapParam(ETONEMAPMETHOD method, float param)
 {
   m_toneMappingMethod = method;
   m_toneMappingParam = param;
-}
-
-float BaseYUV2RGBGLSLShader::GetLuminanceValue() const //Maybe move this to linuxrenderer?! same as in baserenderer
-{
-  float lum1 = 400.0f; // default for bad quality HDR-PQ sources (with no metadata)
-  float lum2 = lum1;
-  float lum3 = lum1;
-
-  if (m_hasLightMetadata)
-  {
-    uint16_t lum = m_displayMetadata.max_luminance.num / m_displayMetadata.max_luminance.den;
-    if (m_lightMetadata.MaxCLL >= lum)
-    {
-      lum1 = static_cast<float>(lum);
-      lum2 = static_cast<float>(m_lightMetadata.MaxCLL);
-    }
-    else
-    {
-      lum1 = static_cast<float>(m_lightMetadata.MaxCLL);
-      lum2 = static_cast<float>(lum);
-    }
-    lum3 = static_cast<float>(m_lightMetadata.MaxFALL);
-    lum1 = (lum1 * 0.5f) + (lum2 * 0.2f) + (lum3 * 0.3f);
-  }
-  else if (m_hasDisplayMetadata && m_displayMetadata.has_luminance &&
-           m_displayMetadata.max_luminance.num)
-  {
-    uint16_t lum = m_displayMetadata.max_luminance.num / m_displayMetadata.max_luminance.den;
-    lum1 = static_cast<float>(lum);
-  }
-
-  return lum1;
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.h
@@ -54,7 +54,6 @@ public:
                           bool hasLightMetadata,
                           AVContentLightMetadata lightMetadata);
   void SetToneMapParam(ETONEMAPMETHOD method, float param);
-  float GetLuminanceValue() const;
 
   void SetConvertFullColorRange(bool convertFullRange) { m_convertFullRange = convertFullRange; }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.h
@@ -45,7 +45,6 @@ class BaseYUV2RGBGLSLShader : public CGLSLShaderProgram
                             bool hasLightMetadata,
                             AVContentLightMetadata lightMetadata);
     void SetToneMapParam(float param) { m_toneMappingParam = param; }
-    float GetLuminanceValue() const;
 
     GLint GetVertexLoc() { return m_hVertex; }
     GLint GetYcoordLoc() { return m_hYcoord; }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Modification of the GetLuminanceValue() function:
- 600 nits for missing metadata (consistency with default for Reinhard that yields the hardcoded 0.7 value - instead of 400)
- 600 nits if the mastering display metadata is bad (.5 nits in sample linked in context, rounded to 0 because of integer calculations of the function)

I can only build/test Windows but noticed that GL/GLES have identical functions and made the change there as well.

Open questions, since I'm only aware of the one sample file:
* what's the max value that can be considered bad metadata? 0 is obviously bad metadata, but we could use something like 80 nits (SDR level) as the valid minimum, or some other value.
* what should the default value be? Reinhard defaults to 600, which worked better for the sample than the 400 already present in GetLuminanceValue(). For that sample, much higher values work even better to avoid blowing out brighter areas, but that is a sample and they may  have cranked everything to 11. 1000 nits is common in valid metadata.
* test for a max valid value of 10000?

Since there is code duplication between the platforms (identical GetLuminanceValue() functions, identical default for Reinhard), I don't mind creating a common function / const default but don't know where to locate it. Please suggest.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Black screen with tone mappers ACES Filmic and Hable for the sample [here ](https://4kmedia.org/sony-bravia-uhd-hdr-4k-demo/).
It has bad mastering display metadata (min 0.1 max 0.5) and no light metadata.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 10, now plays the sample ok with tone mapping ACES Filmic or Hable on SDR screen or HDR screen with option "Use diaplay HDR capabilities" set to off.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
All tone mapping algorithms provide an output for files with bad metadata.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
