### PR TITLE
[Android] improve Dolby Vision compatibility

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -546,7 +546,13 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
                   "Display: {}, MediaCodec: {}",
                   displaySupportsDovi, mediaCodecSupportsDovi);
 
-        if (mediaCodecSupportsDovi)
+        // For Dolby Vision profiles that don't have HDR10 fallback, always use
+        // the dvhe decoder even if the display not supports Dolby Vision.
+        // For profiles that has HDR10 fallback (7, 8) is better use HEVC decoder to
+        // ensure HDR10 output if display is not DV capable.
+        bool notHasHDR10fallback = (m_hints.dovi.dv_profile == 4 || m_hints.dovi.dv_profile == 5);
+
+        if (mediaCodecSupportsDovi && (displaySupportsDovi || notHasHDR10fallback))
         {
           m_mime = "video/dolby-vision";
           m_formatname = isDvhe ? "amc-dvhe" : "amc-dvh1";

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
@@ -32,6 +32,7 @@ class IAddonProvider;
 extern "C"
 {
 #include <libavcodec/avcodec.h>
+#include <libavutil/dovi_meta.h>
 #include <libavutil/mastering_display_metadata.h>
 }
 
@@ -150,6 +151,7 @@ public:
 
   std::string stereo_mode; // expected stereo mode
   StreamHdrType hdr_type = StreamHdrType::HDR_TYPE_NONE; // type of HDR for this stream (hdr10, etc)
+  AVDOVIDecoderConfigurationRecord dovi{};
 };
 
 class CDemuxStreamAudio : public CDemuxStream

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -56,8 +56,10 @@ extern "C"
 #include <stdint.h>
 #endif
 
-extern "C" {
+extern "C"
+{
 #include <libavutil/dict.h>
+#include <libavutil/dovi_meta.h>
 #include <libavutil/opt.h>
 }
 
@@ -1688,6 +1690,15 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
         // https://github.com/FFmpeg/FFmpeg/blob/release/5.0/doc/APIchanges
         size_t size = 0;
         uint8_t* side_data = nullptr;
+
+        if (st->hdr_type == StreamHdrType::HDR_TYPE_DOLBYVISION)
+        {
+          side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_DOVI_CONF, &size);
+          if (side_data && size)
+          {
+            st->dovi = *reinterpret_cast<AVDOVIDecoderConfigurationRecord*>(side_data);
+          }
+        }
 
         side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_MASTERING_DISPLAY_METADATA, &size);
         if (side_data && size)

--- a/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.cpp
@@ -11,6 +11,8 @@
 #include "DVDDemuxers/DVDDemux.h"
 #include "cores/VideoPlayer/Interface/DemuxCrypto.h"
 
+#include <cstring>
+
 CDVDStreamInfo::CDVDStreamInfo()                                                     { extradata = NULL; Clear(); }
 CDVDStreamInfo::CDVDStreamInfo(const CDVDStreamInfo &right, bool withextradata )     { extradata = NULL; Clear(); Assign(right, withextradata); }
 CDVDStreamInfo::CDVDStreamInfo(const CDemuxStream &right, bool withextradata )       { extradata = NULL; Clear(); Assign(right, withextradata); }
@@ -64,6 +66,7 @@ void CDVDStreamInfo::Clear()
   masteringMetadata = nullptr;
   contentLightMetadata = nullptr;
   stereo_mode.clear();
+  dovi = {};
 
   channels   = 0;
   samplerate = 0;
@@ -152,6 +155,9 @@ bool CDVDStreamInfo::Equal(const CDVDStreamInfo& right, int compare)
   else if (contentLightMetadata || right.contentLightMetadata)
     return false;
 
+  if (0 != std::memcmp(&dovi, &right.dovi, sizeof(AVDOVIDecoderConfigurationRecord)))
+    return false;
+
   // AUDIO
   if( channels      != right.channels
   ||  samplerate    != right.samplerate
@@ -237,6 +243,7 @@ void CDVDStreamInfo::Assign(const CDVDStreamInfo& right, bool withextradata)
   masteringMetadata = right.masteringMetadata;
   contentLightMetadata = right.contentLightMetadata;
   stereo_mode = right.stereo_mode;
+  dovi = right.dovi;
 
   // AUDIO
   channels      = right.channels;
@@ -307,6 +314,7 @@ void CDVDStreamInfo::Assign(const CDemuxStream& right, bool withextradata)
     masteringMetadata = stream->masteringMetaData;
     contentLightMetadata = stream->contentLightMetaData;
     stereo_mode = stream->stereo_mode;
+    dovi = stream->dovi;
   }
   else if (right.type == STREAM_SUBTITLE)
   {

--- a/xbmc/cores/VideoPlayer/DVDStreamInfo.h
+++ b/xbmc/cores/VideoPlayer/DVDStreamInfo.h
@@ -10,8 +10,10 @@
 
 #include "DVDDemuxers/DVDDemux.h"
 
-extern "C" {
+extern "C"
+{
 #include <libavcodec/avcodec.h>
+#include <libavutil/dovi_meta.h>
 }
 
 #define CODEC_FORCE_SOFTWARE 0x01
@@ -76,6 +78,7 @@ public:
   std::shared_ptr<AVMasteringDisplayMetadata> masteringMetadata;
   std::shared_ptr<AVContentLightMetadata> contentLightMetadata;
   std::string stereo_mode; // stereoscopic 3d mode
+  AVDOVIDecoderConfigurationRecord dovi{};
 
   // AUDIO
   int channels;


### PR DESCRIPTION
## Description
Improve Dolby Vision compatibility

## Motivation and context
Follow up of https://github.com/xbmc/xbmc/pull/22950

While the previous PR improved the compatibility of profiles 4 and 5 with devices that do not have a DV display, it has also caused regressions with Dolby Vision profiles 7, 8 and devices that normally work well with HDR10 fallback.

This is very important use case as all BD remuxes that come from commercial UHD Blu-Ray's has DV profile 7 with HDR10 fallback (or profile 8 if it has been converted with some tool).

See https://github.com/xbmc/xbmc/pull/22950#issuecomment-1487557156 and https://github.com/xbmc/xbmc/pull/22950#issuecomment-1489127003

## How has this been tested?
Tested Shield Pro 2019 with Dolby Vision Shield setting disabled.
Tested various BDremux (DV profile 7) and demo clips (DV profile 8) mkv and mp4.
Confirmed output picture is HDR10 on TV and in Kodi Player Info video decoder used is amc-hevc(s) HW

## What is the effect on users?
Improve Dolby Vision compatibility with devices that are not DV capable but has HDR10 capabilities.
At same time maintains the improvements of the previous PR for devices that are capable of HW tone mapping Dolby Vision profile 4, 5 to SDR. 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
