### PR TITLE
[macOS][NativeWindowing] Modernize input code, fix XBMC shortcuts

### DIFF
--- a/xbmc/platform/darwin/osx/XBMCApplication.mm
+++ b/xbmc/platform/darwin/osx/XBMCApplication.mm
@@ -47,7 +47,7 @@ static NSMenu* setupWindowMenu()
 
   // "Hide" item
   menuItem = [[NSMenuItem alloc] initWithTitle:@"Hide"
-                                        action:@selector(hideAppAction:)
+                                        action:@selector(hideAppToggle:)
                                  keyEquivalent:@"h"];
   menuItem.keyEquivalentModifierMask = NSEventModifierFlagCommand;
   [windowMenu addItem:menuItem];
@@ -83,6 +83,11 @@ static NSMenu* setupWindowMenu()
 
   // Main menu
   NSMenu* appMenu = [NSMenu new];
+  NSMenuItem* hideMenuItem = [[NSMenuItem alloc] initWithTitle:@"Hide"
+                                                        action:@selector(hideAppToggle:)
+                                                 keyEquivalent:@"h"];
+  hideMenuItem.keyEquivalentModifierMask = NSEventModifierFlagCommand;
+  [appMenu addItem:hideMenuItem];
   NSMenuItem* quitMenuItem = [[NSMenuItem alloc] initWithTitle:@"Quit"
                                                         action:@selector(terminate:)
                                                  keyEquivalent:@"q"];
@@ -105,12 +110,6 @@ static NSMenu* setupWindowMenu()
   floatOnTopMenuItem.keyEquivalentModifierMask = NSEventModifierFlagCommand;
   [windowMenu addItem:floatOnTopMenuItem];
 
-  NSMenuItem* hideMenuItem = [[NSMenuItem alloc] initWithTitle:@"Hide"
-                                                        action:@selector(hideAppAction:)
-                                                 keyEquivalent:@"h"];
-  hideMenuItem.keyEquivalentModifierMask = NSEventModifierFlagCommand;
-  [windowMenu addItem:hideMenuItem];
-
   [windowMenu addItemWithTitle:@"Minimize"
                         action:@selector(performMiniaturize:)
                  keyEquivalent:@"m"];
@@ -118,10 +117,14 @@ static NSMenu* setupWindowMenu()
 
 - (BOOL)validateMenuItem:(NSMenuItem*)item
 {
-  // validate if the hide menu item should be shown
+  // validate how the hide menu item should be shown (hide or show)
   if ([item.title isEqual:@"Hide"] && [[NSApplication sharedApplication] isHidden])
   {
-    return NO;
+    [item setTitle:@"Show"];
+  }
+  else if (([item.title isEqual:@"Show"] && ![[NSApplication sharedApplication] isHidden]))
+  {
+    [item setTitle:@"Hide"];
   }
   return YES;
 }
@@ -302,9 +305,16 @@ static NSMenu* setupWindowMenu()
   CServiceBroker::GetAppMessenger()->PostMsg(TMSG_TOGGLEFLOATONTOP);
 }
 
-- (void)hideAppAction:(id)sender
+- (void)hideAppToggle:(id)sender
 {
-  [[NSApplication sharedApplication] hide:sender];
+  if (![[NSApplication sharedApplication] isHidden])
+  {
+    [[NSApplication sharedApplication] hide:sender];
+  }
+  else
+  {
+    [[NSApplication sharedApplication] unhide:sender];
+  }
 }
 
 - (NSMenu*)applicationDockMenu:(NSApplication*)sender

--- a/xbmc/platform/darwin/osx/XBMCApplication.mm
+++ b/xbmc/platform/darwin/osx/XBMCApplication.mm
@@ -45,6 +45,13 @@ static NSMenu* setupWindowMenu()
   menuItem.keyEquivalentModifierMask = NSEventModifierFlagCommand;
   [windowMenu addItem:menuItem];
 
+  // "Hide" item
+  menuItem = [[NSMenuItem alloc] initWithTitle:@"Hide"
+                                        action:@selector(hideAppAction:)
+                                 keyEquivalent:@"h"];
+  menuItem.keyEquivalentModifierMask = NSEventModifierFlagCommand;
+  [windowMenu addItem:menuItem];
+
   // "Minimize" item
   menuItem = [[NSMenuItem alloc] initWithTitle:@"Minimize"
                                         action:@selector(performMiniaturize:)
@@ -97,9 +104,26 @@ static NSMenu* setupWindowMenu()
                                                        keyEquivalent:@"t"];
   floatOnTopMenuItem.keyEquivalentModifierMask = NSEventModifierFlagCommand;
   [windowMenu addItem:floatOnTopMenuItem];
+
+  NSMenuItem* hideMenuItem = [[NSMenuItem alloc] initWithTitle:@"Hide"
+                                                        action:@selector(hideAppAction:)
+                                                 keyEquivalent:@"h"];
+  hideMenuItem.keyEquivalentModifierMask = NSEventModifierFlagCommand;
+  [windowMenu addItem:hideMenuItem];
+
   [windowMenu addItemWithTitle:@"Minimize"
                         action:@selector(performMiniaturize:)
                  keyEquivalent:@"m"];
+}
+
+- (BOOL)validateMenuItem:(NSMenuItem*)item
+{
+  // validate if the hide menu item should be shown
+  if ([item.title isEqual:@"Hide"] && [[NSApplication sharedApplication] isHidden])
+  {
+    return NO;
+  }
+  return YES;
 }
 
 // Called after the internal event loop has started running.
@@ -276,6 +300,11 @@ static NSMenu* setupWindowMenu()
                         ? NSControlStateValueOn
                         : NSControlStateValueOff)];
   CServiceBroker::GetAppMessenger()->PostMsg(TMSG_TOGGLEFLOATONTOP);
+}
+
+- (void)hideAppAction:(id)sender
+{
+  [[NSApplication sharedApplication] hide:sender];
 }
 
 - (NSMenu*)applicationDockMenu:(NSApplication*)sender

--- a/xbmc/windowing/osx/WinEventsOSX.h
+++ b/xbmc/windowing/osx/WinEventsOSX.h
@@ -15,11 +15,7 @@
 #include <memory>
 
 struct CWinEventsOSXImplWrapper;
-#ifdef __OBJC__
 @class NSEvent;
-#else
-struct NSEvent;
-#endif
 
 class CWinEventsOSX : public IWinEvents, public CThread
 {

--- a/xbmc/windowing/osx/WinEventsOSXImpl.h
+++ b/xbmc/windowing/osx/WinEventsOSXImpl.h
@@ -12,11 +12,7 @@
 
 #import <Foundation/Foundation.h>
 
-#ifdef __OBJC__
 @class NSEvent;
-#else
-struct NSEvent;
-#endif
 
 @interface CWinEventsOSXImpl : NSObject
 

--- a/xbmc/windowing/osx/WinEventsOSXImpl.h
+++ b/xbmc/windowing/osx/WinEventsOSXImpl.h
@@ -10,8 +10,13 @@
 
 #include "windowing/osx/WinEventsOSX.h"
 
-#import <CoreGraphics/CoreGraphics.h>
 #import <Foundation/Foundation.h>
+
+#ifdef __OBJC__
+@class NSEvent;
+#else
+struct NSEvent;
+#endif
 
 @interface CWinEventsOSXImpl : NSObject
 
@@ -20,7 +25,7 @@
 - (bool)MessagePump;
 - (void)enableInputEvents;
 - (void)disableInputEvents;
-- (XBMC_Event)keyPressEvent:(CGEventRef*)event;
+- (XBMC_Event)keyPressEvent:(NSEvent*)nsEvent;
 
 - (void)signalMouseEntered;
 - (void)signalMouseExited;

--- a/xbmc/windowing/osx/WinEventsOSXImpl.mm
+++ b/xbmc/windowing/osx/WinEventsOSXImpl.mm
@@ -24,8 +24,6 @@
 #include <queue>
 
 #import <AppKit/AppKit.h>
-#import <Carbon/Carbon.h> // kvk_ANSI_ keycodes
-#import <CoreGraphics/CoreGraphics.h>
 #import <Foundation/Foundation.h>
 
 #pragma mark - objc implementation
@@ -101,42 +99,38 @@
 {
   switch (character)
   {
-    case kVK_ANSI_8:
     case NSLeftArrowFunctionKey:
       return XBMCK_LEFT;
-    case kVK_ANSI_0:
     case NSRightArrowFunctionKey:
       return XBMCK_RIGHT;
-    case kVK_ANSI_RightBracket:
     case NSUpArrowFunctionKey:
       return XBMCK_UP;
-    case kVK_ANSI_O:
     case NSDownArrowFunctionKey:
       return XBMCK_DOWN;
+    case NSBackspaceCharacter:
     case NSDeleteCharacter:
       return XBMCK_BACKSPACE;
+    case NSCarriageReturnCharacter:
+      return XBMCK_RETURN;
     default:
       return character;
   }
 }
 
-- (XBMCMod)OsxMod2XbmcMod:(CGEventFlags)appleModifier
+- (XBMCMod)OsxMod2XbmcMod:(NSEventModifierFlags)appleModifier
 {
   unsigned int xbmcModifier = XBMCKMOD_NONE;
-  // shift left
-  if (appleModifier & kCGEventFlagMaskAlphaShift)
-    xbmcModifier |= XBMCKMOD_LSHIFT;
-  // shift right
-  if (appleModifier & kCGEventFlagMaskShift)
-    xbmcModifier |= XBMCKMOD_RSHIFT;
+  // shift
+  if (appleModifier & NSEventModifierFlagShift)
+    xbmcModifier |= XBMCKMOD_SHIFT;
   // left ctrl
-  if (appleModifier & kCGEventFlagMaskControl)
-    xbmcModifier |= XBMCKMOD_LCTRL;
+  if (appleModifier & NSEventModifierFlagControl)
+    xbmcModifier |= XBMCKMOD_CTRL;
   // left alt/option
-  if (appleModifier & kCGEventFlagMaskAlternate)
-    xbmcModifier |= XBMCKMOD_LALT;
+  if (appleModifier & NSEventModifierFlagOption)
+    xbmcModifier |= XBMCKMOD_ALT;
   // left command
-  if (appleModifier & kCGEventFlagMaskCommand)
+  if (appleModifier & NSEventModifierFlagCommand)
     xbmcModifier |= XBMCKMOD_LMETA;
 
   return static_cast<XBMCMod>(xbmcModifier);
@@ -204,93 +198,88 @@
   }
 }
 
-- (NSEvent*)InputEventHandler:(NSEvent*)nsevent
+- (NSEvent*)InputEventHandler:(NSEvent*)nsEvent
 {
   bool passEvent = true;
-  CGEventRef event = nsevent.CGEvent;
-  CGEventType type = CGEventGetType(event);
-
   // The incoming mouse position.
-  NSPoint location = nsevent.locationInWindow;
-  if (!nsevent.window || location.x < 0 || location.y < 0)
-    return nsevent;
+  NSPoint location = nsEvent.locationInWindow;
+  if (!nsEvent.window || location.x < 0 || location.y < 0)
+    return nsEvent;
 
   // cocoa world is upside down ...
   auto winSystem = dynamic_cast<CWinSystemOSX*>(CServiceBroker::GetWinSystem());
   if (!winSystem)
-    return nsevent;
+    return nsEvent;
 
   NSRect frame = winSystem->GetWindowDimensions();
   location.y = frame.size.height - location.y;
 
   XBMC_Event newEvent = {};
 
-  switch (type)
+  switch (nsEvent.type)
   {
     // handle mouse events and transform them into the xbmc event world
-    case kCGEventLeftMouseUp:
+    case NSEventTypeLeftMouseUp:
       newEvent.type = XBMC_MOUSEBUTTONUP;
       newEvent.button.button = XBMC_BUTTON_LEFT;
       newEvent.button.x = location.x;
       newEvent.button.y = location.y;
       [self MessagePush:&newEvent];
       break;
-    case kCGEventLeftMouseDown:
+    case NSEventTypeLeftMouseDown:
       newEvent.type = XBMC_MOUSEBUTTONDOWN;
       newEvent.button.button = XBMC_BUTTON_LEFT;
       newEvent.button.x = location.x;
       newEvent.button.y = location.y;
       [self MessagePush:&newEvent];
       break;
-    case kCGEventRightMouseUp:
+    case NSEventTypeRightMouseUp:
       newEvent.type = XBMC_MOUSEBUTTONUP;
       newEvent.button.button = XBMC_BUTTON_RIGHT;
       newEvent.button.x = location.x;
       newEvent.button.y = location.y;
       [self MessagePush:&newEvent];
       break;
-    case kCGEventRightMouseDown:
+    case NSEventTypeRightMouseDown:
       newEvent.type = XBMC_MOUSEBUTTONDOWN;
       newEvent.button.button = XBMC_BUTTON_RIGHT;
       newEvent.button.x = location.x;
       newEvent.button.y = location.y;
       [self MessagePush:&newEvent];
       break;
-    case kCGEventOtherMouseUp:
+    case NSEventTypeOtherMouseUp:
       newEvent.type = XBMC_MOUSEBUTTONUP;
       newEvent.button.button = XBMC_BUTTON_MIDDLE;
       newEvent.button.x = location.x;
       newEvent.button.y = location.y;
       [self MessagePush:&newEvent];
       break;
-    case kCGEventOtherMouseDown:
+    case NSEventTypeOtherMouseDown:
       newEvent.type = XBMC_MOUSEBUTTONDOWN;
       newEvent.button.button = XBMC_BUTTON_MIDDLE;
       newEvent.button.x = location.x;
       newEvent.button.y = location.y;
       [self MessagePush:&newEvent];
       break;
-    case kCGEventMouseMoved:
-    case kCGEventLeftMouseDragged:
-    case kCGEventRightMouseDragged:
-    case kCGEventOtherMouseDragged:
+    case NSEventTypeMouseMoved:
+    case NSEventTypeLeftMouseDragged:
+    case NSEventTypeRightMouseDragged:
+    case NSEventTypeOtherMouseDragged:
       newEvent.type = XBMC_MOUSEMOTION;
       newEvent.motion.x = location.x;
       newEvent.motion.y = location.y;
       [self MessagePush:&newEvent];
       break;
-    case kCGEventScrollWheel:
+    case NSEventTypeScrollWheel:
       // very strange, real scrolls have non-zero deltaY followed by same number of events
       // with a zero deltaY. This reverses our scroll which is WTF? anoying. Trap them out here.
-      if (nsevent.deltaY != 0.0)
+      if (nsEvent.deltaY != 0.0)
       {
         newEvent.type = XBMC_MOUSEBUTTONDOWN;
         newEvent.button.x = location.x;
         newEvent.button.y = location.y;
         newEvent.button.button =
-            CGEventGetIntegerValueField(event, kCGScrollWheelEventDeltaAxis1) > 0
-                ? XBMC_BUTTON_WHEELUP
-                : XBMC_BUTTON_WHEELDOWN;
+            nsEvent.scrollingDeltaY > 0 ? XBMC_BUTTON_WHEELUP : XBMC_BUTTON_WHEELDOWN;
         [self MessagePush:&newEvent];
 
         newEvent.type = XBMC_MOUSEBUTTONUP;
@@ -299,15 +288,15 @@
       break;
 
     // handle keyboard events and transform them into the xbmc event world
-    case kCGEventKeyUp:
-      newEvent = [self keyPressEvent:&event];
+    case NSEventTypeKeyUp:
+      newEvent = [self keyPressEvent:nsEvent];
       newEvent.type = XBMC_KEYUP;
 
       [self MessagePush:&newEvent];
       passEvent = false;
       break;
-    case kCGEventKeyDown:
-      newEvent = [self keyPressEvent:&event];
+    case NSEventTypeKeyDown:
+      newEvent = [self keyPressEvent:nsEvent];
       newEvent.type = XBMC_KEYDOWN;
 
       if (![self ProcessOSXShortcuts:newEvent])
@@ -316,51 +305,38 @@
 
       break;
     default:
-      return nsevent;
+      return nsEvent;
   }
   // We must return the event for it to be useful if not already handled
   if (passEvent)
-    return nsevent;
+    return nsEvent;
   else
     return nullptr;
 }
 
-- (XBMC_Event)keyPressEvent:(CGEventRef*)event
+- (XBMC_Event)keyPressEvent:(NSEvent*)nsEvent
 {
-  UniCharCount actualStringLength = 0;
-  // Get stringlength of event
-  CGEventKeyboardGetUnicodeString(*event, 0, &actualStringLength, nullptr);
-
-  // Create array with size of event string
-  UniChar unicodeString[actualStringLength];
-  memset(unicodeString, 0, sizeof(unicodeString));
-
-  auto keycode =
-      static_cast<CGKeyCode>(CGEventGetIntegerValueField(*event, kCGKeyboardEventKeycode));
-  CGEventKeyboardGetUnicodeString(*event, sizeof(unicodeString) / sizeof(*unicodeString),
-                                  &actualStringLength, unicodeString);
-
+  NSString* unicodeNSString = nsEvent.characters;
   XBMC_Event newEvent = {};
 
   // May be possible for actualStringLength > 1. Havent been able to replicate anything
   // larger than 1, but keep in mind for any regressions
-  if (actualStringLength == 0)
+  if (!unicodeNSString || unicodeNSString.length == 0)
   {
     return newEvent;
   }
-  else if (actualStringLength > 1)
+  else if (unicodeNSString.length > 1)
   {
     CLog::Log(LOGERROR, "CWinEventsOSXImpl::keyPressEvent - event string > 1 - size: {}",
-              static_cast<int>(actualStringLength));
+              unicodeNSString.length);
     return newEvent;
   }
 
-  unicodeString[0] = [self OsxKey2XbmcKey:unicodeString[0]];
-
-  newEvent.key.keysym.scancode = keycode;
-  newEvent.key.keysym.sym = static_cast<XBMCKey>(unicodeString[0]);
-  newEvent.key.keysym.unicode = unicodeString[0];
-  newEvent.key.keysym.mod = [self OsxMod2XbmcMod:CGEventGetFlags(*event)];
+  newEvent.key.keysym.scancode = nsEvent.keyCode;
+  newEvent.key.keysym.sym =
+      static_cast<XBMCKey>([self OsxKey2XbmcKey:[unicodeNSString characterAtIndex:0]]);
+  newEvent.key.keysym.unicode = [unicodeNSString characterAtIndex:0];
+  newEvent.key.keysym.mod = [self OsxMod2XbmcMod:nsEvent.modifierFlags];
 
   return newEvent;
 }

--- a/xbmc/windowing/osx/WinEventsOSXImpl.mm
+++ b/xbmc/windowing/osx/WinEventsOSXImpl.mm
@@ -150,9 +150,6 @@
                                                    static_cast<void*>(action));
         return true;
       }
-      case XBMCK_h: // CMD-h to hide (but we minimize for now)
-        CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MINIMIZE);
-        return true;
 
       default:
         return false;

--- a/xbmc/windowing/osx/WinEventsOSXImpl.mm
+++ b/xbmc/windowing/osx/WinEventsOSXImpl.mm
@@ -10,7 +10,6 @@
 
 #include "ServiceBroker.h"
 #include "application/AppInboundProtocol.h"
-#include "application/Application.h"
 #include "input/XBMC_keysym.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
@@ -139,12 +138,6 @@
   // left command
   if (appleModifier & kCGEventFlagMaskCommand)
     xbmcModifier |= XBMCKMOD_LMETA;
-  // fn/globe
-  if (appleModifier & kCGEventFlagMaskSecondaryFn && !(appleModifier & kCGEventFlagMaskNumericPad))
-  {
-    xbmcModifier |= XBMCKMOD_LMETA;
-    xbmcModifier |= XBMCKMOD_MODE;
-  }
 
   return static_cast<XBMCMod>(xbmcModifier);
 }
@@ -152,32 +145,10 @@
 - (bool)ProcessOSXShortcuts:(XBMC_Event&)event
 {
   const auto cmd = (event.key.keysym.mod & (XBMCKMOD_LMETA | XBMCKMOD_RMETA)) != 0;
-  const auto isFn = (event.key.keysym.mod & XBMCKMOD_MODE) != 0;
   if (cmd && event.type == XBMC_KEYDOWN)
   {
     switch (event.key.keysym.sym)
     {
-      case XBMCK_q: // CMD-q to quit
-        if (!g_application.m_bStop)
-          CServiceBroker::GetAppMessenger()->PostMsg(TMSG_QUIT);
-        return true;
-
-      case XBMCK_CTRLF: // CMD-CTRL-f to toggle fullscreen
-        CServiceBroker::GetAppMessenger()->PostMsg(TMSG_TOGGLEFULLSCREEN);
-        return true;
-
-      case XBMCK_f: // FN/Globe-f to toggle fullscreen
-        if (isFn) // avoid cmd-f to toggle fullscreen
-        {
-          CServiceBroker::GetAppMessenger()->PostMsg(TMSG_TOGGLEFULLSCREEN);
-          return true;
-        }
-        break;
-
-      case XBMCK_t: // CMD-t to toggle float on top
-        CServiceBroker::GetAppMessenger()->PostMsg(TMSG_TOGGLEFLOATONTOP);
-        return true;
-
       case XBMCK_s: // CMD-s to take a screenshot
       {
         CAction* action = new CAction(ACTION_TAKE_SCREENSHOT);
@@ -186,7 +157,6 @@
         return true;
       }
       case XBMCK_h: // CMD-h to hide (but we minimize for now)
-      case XBMCK_m: // CMD-m to minimize
         CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MINIMIZE);
         return true;
 


### PR DESCRIPTION
## Description
Unfortunately the input code used in the native windowing implementation makes use of deprecated frameworks like Carbon and rely on CoreGraphics when more modern alternatives are available. The code to detect the keypress is a bit ugly, all we need is available as part of the NSEvent itself (plus the constants provided by AppKit).

https://github.com/xbmc/xbmc/commit/36e8cbafcc3a530e3de105dd89ec5a6cf79540db -> removes the global application shortcuts (like globe+f, cmd+ctrl+f, etc). Since we moved the input handling to the `NSView` (as an `NSResponder`) these are all handled by the window itself (as a result of registering them with the `NSMenu`. At this point this code is not called, making it effectively dead code. The previous move also fixed an issue with the inconsistency of state in the app menu "toggle float on top". I've only kept those that shortcuts that are not mapped by the application (like screenshot and hide). Removing CApp dependency is a great side-effect too IMHO :)

https://github.com/xbmc/xbmc/commit/e97523ef9b58cd337fb5fd252be0c47736930acd -> modernizes the input code, dropping Carbon.h and CoreGraphics. No functional changes. 

https://github.com/xbmc/xbmc/commit/992f049b7930df7ef6126f52885f5f3e520cdcff -> actually fixes the kodi shortcuts like ctrl+shift+d by finding the actual key without modifiers.

[f28353a873f82c2c4a88dd4bafa3bff392d1809d ](https://github.com/xbmc/xbmc/pull/23081/commits/f28353a873f82c2c4a88dd4bafa3bff392d1809d) -> implements the application hide shortcut properly (we are using minimize currently which is duplicated)