### PR TITLE
[Windows][Rendering] Fix HDR toggle off on file close

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
@@ -139,12 +139,9 @@ CRendererBase::CRendererBase(CVideoSettings& videoSettings)
 
 CRendererBase::~CRendererBase()
 {
-  if (DX::Windowing()->IsHDROutput())
+  if (!DX::Windowing()->IsHDROutput() && m_AutoSwitchHDR)
   {
-    CLog::LogF(LOGDEBUG, "Restoring SDR rendering");
-    DX::Windowing()->SetHdrColorSpace(DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709);
-    if (m_AutoSwitchHDR)
-      DX::Windowing()->ToggleHDR(); // Toggle display HDR OFF
+    DX::Windowing()->ToggleHDR(); //Toggle HDR only if supported and stream is SDR      
   }
   Flush(false);
 }


### PR DESCRIPTION
## Description
This small fix will leave HDR enabled on CloseFile() unless SDR content is playing. If SDR content is playing and Autoswitch HDR is enabled in settings, then we will toggle HDR back on after CloseFile(). Kodi GUI looks great on HDR displays and we only want to toggle Windows HDR switch off when necessary (during SDR content playback).

## Motivation and context
I got tired of having to toggle HDR back on manually through Windows every time I exit Kodi.

## How has this been tested?
I played an HDR file and checked toggle afterward. I played an SDR file and checked toggle afterward.

## What is the effect on users?
Users with HDR displays will notice that they do not have to manually toggle HDR back on in Windows after exiting Kodi

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
