### PR TITLE
[macOS][nativewindowing] Hide XBMC mouse on mouseEntered/mouseExited

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -52,6 +52,7 @@ public:
   bool Minimize() override;
   bool Restore() override;
   bool Hide() override;
+  bool HasCursor() override;
   bool Show(bool raise = true) override;
   void OnMove(int x, int y) override;
 
@@ -127,5 +128,6 @@ protected:
   bool m_delayDispReset;
   XbmcThreads::EndTime<> m_dispResetTimer;
   bool m_fullscreenWillToggle;
+  bool m_hasCursor{false};
   CCriticalSection m_critSection;
 };

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1341,13 +1341,20 @@ std::string CWinSystemOSX::GetClipboardText()
   return utf8_text;
 }
 
+bool CWinSystemOSX::HasCursor()
+{
+  return m_hasCursor;
+}
+
 void CWinSystemOSX::signalMouseEntered()
 {
+  m_hasCursor = true;
   m_winEvents->signalMouseEntered();
 }
 
 void CWinSystemOSX::signalMouseExited()
 {
+  m_hasCursor = false;
   m_winEvents->signalMouseExited();
 }
 

--- a/xbmc/windows/GUIWindowPointer.cpp
+++ b/xbmc/windows/GUIWindowPointer.cpp
@@ -52,6 +52,10 @@ void CGUIWindowPointer::UpdateVisibility()
     else
       Close();
   }
+  else
+  {
+    Close();
+  }
 }
 
 void CGUIWindowPointer::OnWindowLoaded()


### PR DESCRIPTION
## Description
This was discussed a while ago with @fuzzard on slack. Currently when the user moves the mouse out of the window/view (if running windowed) the XBMC cursor pointer is left on the window, near the border. Since the app is no longer the one being focused just make sure it is not shown if the user is not pointing at the window.
This basically implements the default `HasCursor()` method from windowing base class.

In the screenshots below I have the OS cursor in the App Bar (not shown because of the screenshot):

**Before:**
<img width="1470" alt="image" src="https://user-images.githubusercontent.com/7375276/229104676-8855479e-b0eb-492c-9647-0547bee0d544.png">

**Now:** 
<img width="1470" alt="image" src="https://user-images.githubusercontent.com/7375276/229104322-647c8c75-a52f-4200-97c4-400bbbee9d46.png">

