### PR TITLE
[MacOS][NativeWindowing] Improve and simplify live resizing

### DIFF
--- a/xbmc/windowing/osx/OpenGL/OSXGLView.mm
+++ b/xbmc/windowing/osx/OpenGL/OSXGLView.mm
@@ -78,7 +78,7 @@
 {
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    [m_glcontext setView:self];
+    [self setOpenGLContext:m_glcontext];
 
     // clear screen on first render
     glClearColor(0, 0, 0, 0);

--- a/xbmc/windowing/osx/OpenGL/OSXGLWindow.h
+++ b/xbmc/windowing/osx/OpenGL/OSXGLWindow.h
@@ -12,8 +12,6 @@
 
 @interface OSXGLWindow : NSWindow <NSWindowDelegate>
 
-@property(atomic) bool resizeState;
-
 - (id)initWithContentRect:(NSRect)box styleMask:(uint)style;
 
 @end

--- a/xbmc/windowing/osx/OpenGL/OSXGLWindow.mm
+++ b/xbmc/windowing/osx/OpenGL/OSXGLWindow.mm
@@ -27,8 +27,6 @@
 //------------------------------------------------------------------------------------------
 @implementation OSXGLWindow
 
-@synthesize resizeState = m_resizeState;
-
 - (id)initWithContentRect:(NSRect)box styleMask:(uint)style
 {
   self = [super initWithContentRect:box styleMask:style backing:NSBackingStoreBuffered defer:YES];
@@ -79,56 +77,42 @@
   }
 }
 
-- (void)windowWillStartLiveResize:(NSNotification*)notification
-{
-  m_resizeState = true;
-}
-
-- (void)windowDidEndLiveResize:(NSNotification*)notification
-{
-  m_resizeState = false;
-  [self windowDidResize:notification];
-}
-
 - (void)windowDidResize:(NSNotification*)aNotification
 {
-  if (!m_resizeState)
+  NSRect rect = [self contentRectForFrameRect:self.frame];
+  int width = static_cast<int>(rect.size.width);
+  int height = static_cast<int>(rect.size.height);
+
+  XBMC_Event newEvent = {};
+
+  if (!CServiceBroker::GetWinSystem()->IsFullScreen())
   {
-    NSRect rect = [self contentRectForFrameRect:self.frame];
-    int width = static_cast<int>(rect.size.width);
-    int height = static_cast<int>(rect.size.height);
+    RESOLUTION res_index = RES_DESKTOP;
+    if ((width == CDisplaySettings::GetInstance().GetResolutionInfo(res_index).iWidth) &&
+        (height == CDisplaySettings::GetInstance().GetResolutionInfo(res_index).iHeight))
+      return;
 
-    XBMC_Event newEvent = {};
+    newEvent.type = XBMC_VIDEORESIZE;
+  }
+  else
+  {
+    // macos may trigger a resize/rescale event just after Kodi has entered fullscreen
+    // (from windowDidEndLiveResize). Kodi needs to rescale the UI - use a different event
+    // type since XBMC_VIDEORESIZE is supposed to only be used in windowed mode
+    newEvent.type = XBMC_FULLSCREEN_UPDATE;
+  }
 
-    if (!CServiceBroker::GetWinSystem()->IsFullScreen())
-    {
-      RESOLUTION res_index = RES_DESKTOP;
-      if ((width == CDisplaySettings::GetInstance().GetResolutionInfo(res_index).iWidth) &&
-          (height == CDisplaySettings::GetInstance().GetResolutionInfo(res_index).iHeight))
-        return;
+  newEvent.resize.w = width;
+  newEvent.resize.h = height;
 
-      newEvent.type = XBMC_VIDEORESIZE;
-    }
-    else
-    {
-      // macos may trigger a resize/rescale event just after Kodi has entered fullscreen
-      // (from windowDidEndLiveResize). Kodi needs to rescale the UI - use a different event
-      // type since XBMC_VIDEORESIZE is supposed to only be used in windowed mode
-      newEvent.type = XBMC_FULLSCREEN_UPDATE;
-    }
-
-    newEvent.resize.w = width;
-    newEvent.resize.h = height;
-
-    // check for valid sizes cause in some cases
-    // we are hit during fullscreen transition from macos
-    // and might be technically "zero" sized
-    if (newEvent.resize.w != 0 && newEvent.resize.h != 0)
-    {
-      std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
-      if (appPort)
-        appPort->OnEvent(newEvent);
-    }
+  // check for valid sizes cause in some cases
+  // we are hit during fullscreen transition from macos
+  // and might be technically "zero" sized
+  if (newEvent.resize.w != 0 && newEvent.resize.h != 0)
+  {
+    std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+    if (appPort)
+      appPort->OnEvent(newEvent);
   }
 }
 

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -841,8 +841,6 @@ bool CWinSystemOSX::ResizeWindow(int newWidth, int newHeight, int newLeft, int n
   if (!m_appWindow)
     return false;
 
-  [(OSXGLWindow*)m_appWindow setResizeState:true];
-
   __block OSXGLView* view;
   dispatch_sync(dispatch_get_main_queue(), ^{
     view = m_appWindow.contentView;
@@ -870,23 +868,12 @@ bool CWinSystemOSX::ResizeWindow(int newWidth, int newHeight, int newLeft, int n
   if (view)
   {
     dispatch_sync(dispatch_get_main_queue(), ^{
-      NSOpenGLContext* context = [view getGLContext];
-      NSWindow* window = m_appWindow;
-
-      NSRect pos = window.frame;
-
-      NSRect myNewContentFrame = NSMakeRect(pos.origin.x, pos.origin.y, newWidth, newHeight);
-      NSRect myNewWindowRect = [window frameRectForContentRect:myNewContentFrame];
-      [window setFrame:myNewWindowRect display:TRUE];
-
-      [context update];
+      [[view getGLContext] update];
     });
   }
 
   m_nWidth = newWidth;
   m_nHeight = newHeight;
-
-  [(OSXGLWindow*)m_appWindow setResizeState:false];
 
   return true;
 }


### PR DESCRIPTION
## Description
This improves the live resize of the Kodi window in MacOS (native windowing). Currently we're resizing it twice (hence the resizeState guards) which, if removed, would put the window on a deadlock resize state (sort of an infinite shaking state).

Furthermore, currently we are only resizing the window after the the window did end the live resize operation, which basically won't refresh the context until you release the mouse (during the operation the view gets broken). This is not a big deal unless you have OCD :) -  regardless it's much better now.