### PR TITLE
[Estuary] Fixes for Shift & InfoWall views

### DIFF
--- a/addons/skin.estuary/xml/View_53_Shift.xml
+++ b/addons/skin.estuary/xml/View_53_Shift.xml
@@ -20,7 +20,7 @@
 				</control>
 				<control type="image">
 					<left>0</left>
-					<top>35</top>
+					<top>10</top>
 					<width>100%</width>
 					<height>190</height>
 					<texture colordiffuse="E6FFFFFF">dialogs/dialog-bg-nobo.png</texture>
@@ -30,11 +30,11 @@
 				<visible>Control.IsVisible(53)</visible>
 				<include>Visible_Right</include>
 				<include>OpenClose_Right</include>
-				<top>160</top>
+				<top>140</top>
 				<control type="image">
-					<left>600</left>
-					<top>600</top>
-					<width>340</width>
+					<left>605</left>
+					<top>620</top>
+					<width>330</width>
 					<height>110</height>
 					<visible>Control.HasFocus(53)</visible>
 					<animation effect="fade" time="200">VisibleChange</animation>
@@ -48,7 +48,7 @@
 					<left>-150</left>
 					<top>0</top>
 					<width>111%</width>
-					<height>695</height>
+					<height>715</height>
 					<focusposition>1</focusposition>
 					<movement>0</movement>
 					<pagecontrol>5199</pagecontrol>
@@ -62,179 +62,10 @@
 					<preloaditems>1</preloaditems>
 					<viewtype label="31100">icon</viewtype>
 					<itemlayout width="370">
-						<control type="image">
-							<left>0</left>
-							<top>90</top>
-							<width>370</width>
-							<height>480</height>
-							<texture>dialogs/dialog-bg-nobo.png</texture>
-							<bordertexture border="21" infill="false">overlays/shadow.png</bordertexture>
-							<bordersize>20</bordersize>
-							<visible>String.IsEmpty(ListItem.Art(poster)) + [Container.Content(movies) | Container.Content(tvshows)]</visible>
-						</control>
-						<control type="image">
-							<depth>DepthContentPopout</depth>
-							<left>0</left>
-							<top>90</top>
-							<width>370</width>
-							<height>480</height>
-							<aspectratio aligny="center">keep</aspectratio>
-							<texture fallback="DefaultVideo.png" background="true">$VAR[ShiftThumbVar]</texture>
-							<bordertexture border="21" infill="false">overlays/shadow.png</bordertexture>
-							<bordersize>20</bordersize>
-						</control>
-						<control type="textbox">
-							<left>20</left>
-							<top>603</top>
-							<width>330</width>
-							<height>105</height>
-							<align>center</align>
-							<aligny>center</aligny>
-							<label>$INFO[ListItem.Label]</label>
-						</control>
-						<control type="group">
-							<visible>String.IsEqual(ListItem.DBtype,tvshow)</visible>
-							<control type="image">
-								<left>35</left>
-								<top>500</top>
-								<width>298</width>
-								<height>50</height>
-								<texture colordiffuse="CCFFFFFF">overlays/overlayfade.png</texture>
-								<visible>!String.IsEmpty(ListItem.Art(poster))</visible>
-							</control>
-							<control type="label">
-								<left>0</left>
-								<top>522</top>
-								<width>292</width>
-								<height>24</height>
-								<label>$INFO[ListItem.Property(WatchedEpisodes)]$INFO[ListItem.Property(TotalEpisodes), / ,]</label>
-								<font>font20_title</font>
-								<shadowcolor>text_shadow</shadowcolor>
-								<align>right</align>
-								<aligny>center</aligny>
-							</control>
-							<control type="image">
-								<left>302</left>
-								<top>522</top>
-								<width>24</width>
-								<height>24</height>
-								<texture>lists/played-total.png</texture>
-								<align>right</align>
-								<aligny>center</aligny>
-							</control>
-						</control>
-						<control type="image">
-							<left>35</left>
-							<top>518</top>
-							<width>32</width>
-							<height>32</height>
-							<align>left</align>
-							<aligny>center</aligny>
-							<texture>$VAR[WallWatchedIconVar]</texture>
-						</control>
-						<control type="group">
-							<left>158</left>
-							<top>92</top>
-							<include condition="Skin.HasSetting(circle_rating) | Skin.HasSetting(circle_userrating)">RatingCircle</include>
-						</control>
-						<control type="progress">
-							<left>32</left>
-							<top>530</top>
-							<width>298</width>
-							<height>1</height>
-							<texturebg></texturebg>
-							<midtexture colordiffuse="button_focus" border="3">progress/texturebg_alt_white.png</midtexture>
-							<info>ListItem.PercentPlayed</info>
-							<visible>!Integer.IsEqual(ListItem.PercentPlayed,0)</visible>
-						</control>
+						<include>ShiftFixedListLayout</include>
 					</itemlayout>
 					<focusedlayout width="370">
-						<control type="image">
-							<left>0</left>
-							<top>90</top>
-							<width>370</width>
-							<height>480</height>
-							<texture>dialogs/dialog-bg-nobo.png</texture>
-							<bordertexture border="21" infill="false">overlays/shadow.png</bordertexture>
-							<bordersize>20</bordersize>
-							<visible>String.IsEmpty(ListItem.Art(poster)) + [Container.Content(movies) | Container.Content(tvshows)]</visible>
-						</control>
-						<control type="image">
-							<depth>DepthContentPopout</depth>
-							<left>0</left>
-							<top>90</top>
-							<width>370</width>
-							<height>480</height>
-							<aspectratio aligny="center">keep</aspectratio>
-							<texture fallback="DefaultVideo.png" background="true">$VAR[ShiftThumbVar]</texture>
-							<bordertexture border="21" infill="false">overlays/shadow.png</bordertexture>
-							<bordersize>20</bordersize>
-						</control>
-						<control type="textbox">
-							<left>20</left>
-							<top>603</top>
-							<width>330</width>
-							<height>105</height>
-							<align>center</align>
-							<aligny>center</aligny>
-							<label>$INFO[ListItem.Label]</label>
-							<autoscroll time="3000" delay="3000" repeat="3000">True</autoscroll>
-						</control>
-						<control type="group">
-							<visible>String.IsEqual(ListItem.DBtype,tvshow)</visible>
-							<control type="image">
-								<left>35</left>
-								<top>500</top>
-								<width>298</width>
-								<height>50</height>
-								<texture colordiffuse="CCFFFFFF">overlays/overlayfade.png</texture>
-								<visible>!String.IsEmpty(ListItem.Art(poster))</visible>
-							</control>
-							<control type="label">
-								<left>0</left>
-								<top>522</top>
-								<width>292</width>
-								<height>24</height>
-								<label>$INFO[ListItem.Property(WatchedEpisodes)]$INFO[ListItem.Property(TotalEpisodes), / ,]</label>
-								<font>font20_title</font>
-								<shadowcolor>text_shadow</shadowcolor>
-								<align>right</align>
-								<aligny>center</aligny>
-							</control>
-							<control type="image">
-								<left>302</left>
-								<top>522</top>
-								<width>24</width>
-								<height>24</height>
-								<texture>lists/played-total.png</texture>
-								<align>right</align>
-								<aligny>center</aligny>
-							</control>
-						</control>
-						<control type="image">
-							<left>35</left>
-							<top>518</top>
-							<width>32</width>
-							<height>32</height>
-							<align>left</align>
-							<aligny>center</aligny>
-							<texture>$VAR[WallWatchedIconVar]</texture>
-						</control>
-						<control type="group">
-							<left>158</left>
-							<top>92</top>
-							<include condition="Skin.HasSetting(circle_rating) | Skin.HasSetting(circle_userrating)">RatingCircle</include>
-						</control>
-						<control type="progress">
-							<left>32</left>
-							<top>530</top>
-							<width>298</width>
-							<height>1</height>
-							<texturebg></texturebg>
-							<midtexture colordiffuse="button_focus" border="3">progress/texturebg_alt_white.png</midtexture>
-							<info>ListItem.PercentPlayed</info>
-							<visible>!Integer.IsEqual(ListItem.PercentPlayed,0)</visible>
-						</control>
+						<include>ShiftFixedListLayout</include>
 					</focusedlayout>
 				</control>
 			</control>
@@ -290,13 +121,126 @@
 			</control>
 		</control>
 	</include>
+	<include name="ShiftFixedListLayout">
+		<definition>
+			<control type="image">
+				<left>0</left>
+				<top>80</top>
+				<width>370</width>
+				<height>515</height>
+				<texture>dialogs/dialog-bg-nobo.png</texture>
+				<bordertexture border="21" infill="false">overlays/shadow.png</bordertexture>
+				<bordersize>20</bordersize>
+				<visible>String.IsEmpty(ListItem.Art(poster)) + [Container.Content(movies) | Container.Content(tvshows)]</visible>
+			</control>
+			<control type="image">
+				<depth>DepthContentPopout</depth>
+				<left>0</left>
+				<top>80</top>
+				<width>370</width>
+				<height>515</height>
+				<aspectratio aligny="center">keep</aspectratio>
+				<texture fallback="DefaultVideo.png" background="true">$VAR[ShiftThumbVar]</texture>
+				<bordertexture border="21" infill="false">overlays/shadow.png</bordertexture>
+				<bordersize>20</bordersize>
+				<visible>String.IsEmpty(ListItem.Art(poster)) + [Container.Content(movies) | Container.Content(tvshows)]</visible>
+			</control>
+			<control type="image">
+				<depth>DepthContentPopout</depth>
+				<left>0</left>
+				<top>80</top>
+				<width>370</width>
+				<height>515</height>
+				<aspectratio aligny="center">scale</aspectratio>
+				<texture fallback="DefaultVideo.png" background="true">$VAR[ShiftThumbVar]</texture>
+				<bordertexture border="21" infill="false">overlays/shadow.png</bordertexture>
+				<bordersize>20</bordersize>
+				<visible>!String.IsEmpty(ListItem.Art(poster)) + [Container.Content(movies) | Container.Content(tvshows)]</visible>
+			</control>
+			<control type="textbox">
+				<left>25</left>
+				<top>630</top>
+				<width>320</width>
+				<height>90</height>
+				<align>center</align>
+				<aligny>center</aligny>
+				<label>$INFO[ListItem.Label]</label>
+			</control>
+			<control type="group">
+				<visible>String.IsEqual(ListItem.DBtype,tvshow)</visible>
+				<control type="image">
+					<left>20</left>
+					<top>525</top>
+					<width>330</width>
+					<height>50</height>
+					<texture colordiffuse="CCFFFFFF">overlays/overlayfade.png</texture>
+					<visible>!String.IsEmpty(ListItem.Art(poster))</visible>
+				</control>
+				<control type="label">
+					<left>0</left>
+					<top>545</top>
+					<width>302</width>
+					<height>24</height>
+					<label>$INFO[ListItem.Property(WatchedEpisodes)]$INFO[ListItem.Property(TotalEpisodes), / ,]</label>
+					<font>font20_title</font>
+					<shadowcolor>text_shadow</shadowcolor>
+					<align>right</align>
+					<aligny>center</aligny>
+				</control>
+				<control type="image">
+					<left>312</left>
+					<top>545</top>
+					<width>24</width>
+					<height>24</height>
+					<texture>lists/played-total.png</texture>
+					<align>right</align>
+					<aligny>center</aligny>
+				</control>
+			</control>
+			<control type="group">
+				<visible>Listitem.IsCollection | ListItem.IsPlaying | Integer.IsGreater(ListItem.Playcount,0) | !Integer.IsEqual(ListItem.PercentPlayed,0)</visible>
+				<control type="image">
+					<left>20</left>
+					<top>495</top>
+					<width>80</width>
+					<height>80</height>
+					<texture>overlays/overlay-bg.png</texture>
+					<visible>!String.IsEqual(ListItem.DBtype,tvshow) + !String.IsEmpty(ListItem.Art(poster))</visible>
+				</control>
+				<control type="image">
+					<left>25</left>
+					<top>541</top>
+					<width>32</width>
+					<height>32</height>
+					<align>left</align>
+					<aligny>center</aligny>
+					<texture>$VAR[WallWatchedIconVar]</texture>
+				</control>
+			</control>	
+			<control type="group">
+				<left>158</left>
+				<top>82</top>
+				<include condition="Skin.HasSetting(circle_rating) | Skin.HasSetting(circle_userrating)">RatingCircle</include>
+			</control>
+			<control type="progress">
+				<left>20</left>
+				<top>555</top>
+				<width>330</width>
+				<height>1</height>
+				<texturebg></texturebg>
+				<midtexture colordiffuse="button_focus" border="3">progress/texturebg_alt_white.png</midtexture>
+				<info>ListItem.PercentPlayed</info>
+				<visible>!Integer.IsEqual(ListItem.PercentPlayed,0)</visible>
+			</control>
+		</definition>
+	</include>
 	<include name="ShiftTextbox">
 		<control type="group">
 			<animation effect="fade" time="200" start="0" end="100" condition="!String.IsEmpty(Control.GetLabel($PARAM[textbox_id]))">Conditional</animation>
 			<animation effect="fade" time="200" start="100" end="0" condition="String.IsEmpty(Control.GetLabel($PARAM[textbox_id]))">Conditional</animation>
 			<control type="textbox" id="$PARAM[textbox_id]">
 				<left>30</left>
-				<top>45</top>
+				<top>20</top>
 				<right>30</right>
 				<height>163</height>
 				<label>$PARAM[textbox_content]</label>

--- a/addons/skin.estuary/xml/View_54_InfoWall.xml
+++ b/addons/skin.estuary/xml/View_54_InfoWall.xml
@@ -254,16 +254,28 @@
 					<include condition="$PARAM[focused]">Animation_FocusTextureFade</include>
 				</control>
 				<control type="textbox">
-					<left>40</left>
+					<left>65</left>
 					<top>244</top>
-					<width>242</width>
+					<width>190</width>
 					<height>120</height>
 					<font>font27</font>
 					<align>center</align>
 					<aligny>center</aligny>
 					<label>$INFO[ListItem.Label]</label>
 					<autoscroll time="2000" delay="3000" repeat="5000">$PARAM[focused]</autoscroll>
-					<visible>!ListItem.IsParentFolder</visible>
+					<visible>!ListItem.IsParentFolder + !String.IsEqual(ListItem.DBtype,tvshow)</visible>
+				</control>
+				<control type="textbox">
+					<left>65</left>
+					<top>220</top>
+					<width>190</width>
+					<height>120</height>
+					<font>font27</font>
+					<align>center</align>
+					<aligny>center</aligny>
+					<label>$INFO[ListItem.Label]</label>
+					<autoscroll time="2000" delay="3000" repeat="5000">$PARAM[focused]</autoscroll>
+					<visible>!ListItem.IsParentFolder + String.IsEqual(ListItem.DBtype,tvshow)</visible>
 				</control>
 				<control type="image">
 					<left>24</left>
@@ -304,7 +316,7 @@
 					<width>80</width>
 					<height>80</height>
 					<texture>overlays/overlay-bg.png</texture>
-					<visible>Listitem.IsCollection | ListItem.IsPlaying | Integer.IsGreater(ListItem.Playcount,0)</visible>
+					<visible>Listitem.IsCollection | ListItem.IsPlaying | Integer.IsGreater(ListItem.Playcount,0) | !Integer.IsEqual(ListItem.PercentPlayed,0)</visible>
 				</control>
 			</control>
 			<control type="group">


### PR DESCRIPTION
## Description

Rework of Shift view and related fixes for InfoWall to better see the icons that overlay posters in Shift and InfoWall.

Supersedes https://github.com/xbmc/xbmc/pull/22901

Fix Shift view is missing the icon background for inprogress & watched.
Fix Infowall view is missing the icon background for inprogress.
Fix Infowall text label overlapping icons

## Motivation and context

Fix https://github.com/xbmc/xbmc/issues/22765
Fix https://github.com/xbmc/xbmc/pull/22901#issuecomment-1455324162

Regarding Shift view rework:

Original fix in https://github.com/xbmc/xbmc/pull/22901 for the Shift view did not work out for all cases due to usage of `<aspectratio aligny="center">keep</aspectratio>` at https://github.com/xbmc/xbmc/blob/master/addons/skin.estuary/xml/View_53_Shift.xml#L81 thanks for reporting @howie-f 

This meant that the poster edges would vary dependant on poster dimensions. To prevent this so poster edges are in a fixed place onto which to apply the overlays then `<aspectratio>scale</aspectratio>` must be used as is done in InfoWall at https://github.com/xbmc/xbmc/blob/master/addons/skin.estuary/xml/View_54_InfoWall.xml#L297

This then had the further knock on effect that the top of poster was being cut off. InfoWall uses 400 x 290 which is a 1.38 ratio. However Shift was using 480 x 370 which is a 1.30 ratio. Making consistant 1.38 ratio would give a height of 511 if a width of 370 is maintained, so I rounded up to 515.

This then had a further knock on requiring other adjustments to maintain the balance of the Shift view.

For the fixed list I moved the layout code for `itemlayout` and `focusedlayout` into an include `ShiftFixedListLayout `as this was duplicated before.

## How has this been tested?
Tested locally with a mix of watched, unwatched, & inprogress items.

@howie-f  can you test again to confirm the issue you saw is fixed.
@scott967 can you test to see if your text overlap issue in InfoWall is fixed.

## What is the effect on users?

Better see the icons that overlay posters in Shift and InfoWall.

## Screenshots (if appropriate):

**InfoWall Inprogress Before**

Iconprogress icon not shown on Italian Job

![image](https://user-images.githubusercontent.com/5781142/229169610-e13fee6c-3130-4085-b7d3-1f503f71b0be.png)

**InfoWall Inprogress After**

Iconprogress icon now shown on Italian Job

![image](https://user-images.githubusercontent.com/5781142/229166310-fe9e0c70-2c0b-4431-b466-09a88e285f9b.png)

**InfoWall Title & Icon & No Poster Before**
Long title label and icon overlap(using fake long title to replicate)

![image](https://user-images.githubusercontent.com/5781142/229344947-073c5960-c219-4ce1-a5e4-e3258d5abcae.png)

**InfoWall Title & Icon & No Poster After**
Long title label and icon no longer overlaps (using fake long title to replicate)

![image](https://user-images.githubusercontent.com/5781142/229345010-05572569-f530-4433-90d2-60533669d3d1.png)

**Shift Watched Before**

Watched icon over Alive poster can't be seen.

![image](https://user-images.githubusercontent.com/5781142/229169316-728e8b8d-70a8-4ea4-a177-f5b75ec6930d.png)

**Shift Watched After**

Corner image added as used in InfoWall so Watched icon can be seen.

![image](https://user-images.githubusercontent.com/5781142/229167654-3b6b1038-cea9-46d2-abcc-a752e49399fc.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
