### PR TITLE
[docs][android] remove unneccessary macos specific build instructions

### DIFF
--- a/docs/README.Android.md
+++ b/docs/README.Android.md
@@ -11,8 +11,7 @@ It should work if you're using macOS. If that is the case, read **[macOS specifi
 3. **[Prerequisites](#3-prerequisites)**  
   3.1. **[Extract Android SDK and NDK](#31-extract-android-sdk-and-ndk)**  
   3.2. **[Configure Android SDK](#32-configure-android-sdk)**   
-  3.3. **[Create a key to sign debug APKs](#33-create-a-key-to-sign-debug-apks)**  
-  3.4. **[macOS specific prerequisites](#34-macos-specific-prerequisites)**
+  3.3. **[Create a key to sign debug APKs](#33-create-a-key-to-sign-debug-apks)**
 4. **[Get the source code](#4-get-the-source-code)**
 5. **[Build tools and dependencies](#5-build-tools-and-dependencies)**  
   5.1. **[Advanced Configure Options](#51-advanced-configure-options)**  
@@ -107,15 +106,6 @@ All packages must be signed. The following command will generate a self-signed d
 ```
 keytool -genkey -keystore ~/.android/debug.keystore -v -alias androiddebugkey -dname "CN=Android Debug,O=Android,C=US" -keypass android -storepass android -keyalg RSA -keysize 2048 -validity 10000
 ```
-
-### 3.4. macOS specific prerequisites
-* **[Java Development Kit 11+ (JDK)](http://www.oracle.com/technetwork/java/javase/downloads/index.html)** installed.
-* Normal macOS installations filesystem is case insensitive but compiling for Android requires a case sensitive filesystem. Generate a writeable hdd image and format it with hfs+ (case sensitive) issuing
-  * `hdiutil create -type UDIF -fs 'Case-sensitive Journaled HFS+' -size 20g -volname android-dev $HOME/android-dev.dmg`
-* Whenever you want to compile/develop you need to mount the image
-  * `open ~/android-dev.dmg`
-* Once you have your hdd image with case sensitive hfs+ file system execute all the steps inside of this filesystem. You need to adapt all paths in this guide so that they match your local environment. As an example here is a configure line that demonstrates possible paths:
-  * `./configure --with-tarballs=/Users/Shared/xbmc-depends/tarballs --host=arm-linux-androideabi --with-sdk-path=/Volumes/android-dev/android/android-sdk-macosx --with-ndk-path=/Volumes/android-dev/android/android-ndk-r21e --prefix=/Volumes/android-dev/android/xbmc-depends`
   
 **[back to top](#table-of-contents)** | **[back to section top](#3-prerequisites)**
 


### PR DESCRIPTION
## Description
Update android build docs to reflect the changes that have been made to building android on macos

## Motivation and context
@gusandrianos had some issues when trying to follow the docs. This just removes a section thats no longer relevant on macos

## How has this been tested?
N/A

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
