### PR TITLE
Replace calls to CLog::Log that use __FUNCTION__ with LogF

### DIFF
--- a/logf-replacement.sh
+++ b/logf-replacement.sh
@@ -5,7 +5,8 @@ find xbmc -type f | xargs sed -i \
     /CLog::Log(/{
       :line
       s/,\n[ ]*/, /g
-      s/[^,]\n[ ]*//g
+      s/(\n[ ]*/(/g
+      s/"\s*\n\s*"/" "/g
       /);/!{
         N
         bline
@@ -133,3 +134,8 @@ git commit --no-verify -m "CLog: update logging calls that use __FUNCTION__ and 
 find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), __FUNCTION__": /CLog::LogF(\1, "/g' -i
 git add xbmc
 git commit --no-verify -m "CLog: update logging calls that use __FUNCTION__ as macro"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), __FUNCTION__\s*"\s*[:,-]\s*(.*)"/CLog::LogF(\1, "\2"/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update loggings calls that only use __FUNCTION__ to use LogF (with C string literal concat)"
+

--- a/logf-replacement.sh
+++ b/logf-replacement.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+
+find xbmc -type f | xargs sed -i \
+-e ':a
+    /CLog::Log(/{
+      :line
+      s/,\n[ ]*/, /g
+      s/[^,]\n[ ]*//g
+      /);/!{
+        N
+        bline
+      }
+      N
+    }'
+
+git add xbmc
+git commit --no-verify -m "[temp] convert clog calls from multiline to single line"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), "\{\}: (.*)", __FUNCTION__\);/CLog::LogF(\1, "\2");/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update loggings calls that only use __FUNCTION__ to use LogF"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), "\{\}, (.*)", __FUNCTION__\);/CLog::LogF(\1, "\2");/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update loggings calls that only use __FUNCTION__ and comma to use LogF"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), "\{\} - (.*)", __FUNCTION__\);/CLog::LogF(\1, "\2");/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update loggings calls that only use __FUNCTION__ and dash to use LogF"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), "\{\} (.*)", __FUNCTION__\);/CLog::LogF(\1, "\2");/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update loggings calls that only use __FUNCTION__ without colon to use LogF"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), (LOG[A-Z]+), "\{\}: (.*)", __FUNCTION__\);/CLog::LogFC(\1, \2, "\3");/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update component loggings calls that only use __FUNCTION__ to use LogF"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), "\{0\} (.*)", __FUNCTION__\);/CLog::LogF(\1, "\2");/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update logging calls that only use __FUNCTION__ to use LogF (special case)"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), "(.*)::\{\}: (.*)", __FUNCTION__\);/CLog::LogF(\1, "\2: \3");/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update logging calls that only use __FUNCTION__ to use LogF (with class)"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), "(.*)::\{\} - (.*)", __FUNCTION__\);/CLog::LogF(\1, "\2: \3");/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update logging calls that only use __FUNCTION__ to use LogF (with class and dash)"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), "(.*)::\{\} (.*)", __FUNCTION__\);/CLog::LogF(\1, "\2: \3");/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update logging calls that only use __FUNCTION__ to use LogF (with class and no dash or colon)"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), "(.*)::\{\}", __FUNCTION__\);/CLog::LogF(\1, "\2");/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update logging calls that only use __FUNCTION__ to use LogF (with class and no message)"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), "\{\}: (.*)", __FUNCTION__, ([^,]+)\);/CLog::LogF(\1, "\2", \3);/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update logging calls that use __FUNCTION__ and one extra arg to use LogF"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), "\{\} - (.*)", __FUNCTION__, ([^,]+)\);/CLog::LogF(\1, "\2", \3);/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update logging calls that use __FUNCTION__ and one extra arg to use LogF (with dash)"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), "\{\} (.*)", __FUNCTION__, ([^,]+)\);/CLog::LogF(\1, "\2", \3);/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update logging calls that use __FUNCTION__ and one extra arg to use LogF (no dash or colon)"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), "\{\}, (.*)", __FUNCTION__, ([^,]+)\);/CLog::LogF(\1, "\2", \3);/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update logging calls that use __FUNCTION__ and one extra arg to use LogF (with comma)"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), "\{\}(.*)", __FUNCTION__, ([^,]+)\);/CLog::LogF(\1, "\2", \3);/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update logging calls that use __FUNCTION__ and one extra arg to use LogF (no space)"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), "\{\}: (.*)", __FUNCTION__, (.*)\);/CLog::LogF(\1, "\2", \3);/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update logging calls that use __FUNCTION__ and multiple args to use LogF"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), "\{\} - (.*)", __FUNCTION__, (.*)\);/CLog::LogF(\1, "\2", \3);/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update logging calls that use __FUNCTION__ and multiple args to use LogF (with dash)"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), "\{\} (.*)", __FUNCTION__, (.*)\);/CLog::LogF(\1, "\2", \3);/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update logging calls that use __FUNCTION__ and multiple args to use LogF (no dash or colon)"
+
+# find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), "\{\}, (.*)", __FUNCTION__, (.*)\);/CLog::LogF(\1, "\2", \3);/g' -i
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), "\{\}(.*)", __FUNCTION__, (.*)\);/CLog::LogF(\1, "\2", \3);/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update logging calls that use __FUNCTION__ and multiple args to use LogF (no space)"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), "(.*)::\{\}: (.*)", __FUNCTION__,$/CLog::LogF(\1, "\2: \3",/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update logging calls that use __FUNCTION__ and continue on newline to use LogF (with class)"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), "(.*)::\{\} - (.*)", __FUNCTION__,$/CLog::LogF(\1, "\2: \3",/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update logging calls that use __FUNCTION__ and continue on newline to use LogF (with class and dash)"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), "\{\}: (.*)", __FUNCTION__,$/CLog::LogF(\1, "\2",/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update logging calls that use __FUNCTION__ and continue on newline"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), "\{\} - (.*)", __FUNCTION__,$/CLog::LogF(\1, "\2",/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update logging calls that use __FUNCTION__ and continue on newline (with dash)"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), "\{\}, (.*)", __FUNCTION__,$/CLog::LogF(\1, "\2",/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update logging calls that use __FUNCTION__ and continue on newline (with comma)"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), "\{\} (.*)", __FUNCTION__,$/CLog::LogF(\1, "\2",/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update logging calls that use __FUNCTION__ and continue on newline (no dash or colon)"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), "(.*)::\{\}: (.*)", __FUNCTION__, (.*)/CLog::LogF(\1, "\2: \3", \4/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update logging calls that use __FUNCTION__ and multiple args to use LogF (with class)"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), "(.*)::\{\} - (.*)", __FUNCTION__, (.*)/CLog::LogF(\1, "\2: \3", \4/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update logging calls that use __FUNCTION__ and multiple args to use LogF (with class and dash)"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), "(.*)::\{\} (.*)", __FUNCTION__, (.*)/CLog::LogF(\1, "\2: \3", \4/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update logging calls that use __FUNCTION__ and multiple args to use LogF (with class and no dash or colon)"
+
+find xbmc -type f | xargs sed -E -e 's/CLog::Log\((LOG[A-Z]+), __FUNCTION__": /CLog::LogF(\1, "/g' -i
+git add xbmc
+git commit --no-verify -m "CLog: update logging calls that use __FUNCTION__ as macro"

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -141,7 +141,7 @@ bool CAutorun::RunDisc(IDirectory* pDir, const std::string& strDrive, int& nAdde
 {
   if (!pDir)
   {
-    CLog::Log(LOGDEBUG, "CAutorun::{}: cannot run disc. is it properly mounted?", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "CAutorun: cannot run disc. is it properly mounted?");
     return false;
   }
 

--- a/xbmc/BackgroundInfoLoader.cpp
+++ b/xbmc/BackgroundInfoLoader.cpp
@@ -88,7 +88,7 @@ void CBackgroundInfoLoader::Run()
   catch (...)
   {
     m_bIsLoading = false;
-    CLog::Log(LOGERROR, "{} - Unhandled exception", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Unhandled exception");
   }
 }
 

--- a/xbmc/DatabaseManager.cpp
+++ b/xbmc/DatabaseManager.cpp
@@ -40,7 +40,7 @@ void CDatabaseManager::Initialize()
 
   m_dbStatus.clear();
 
-  CLog::Log(LOGDEBUG, "{}, updating databases...", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "updating databases...");
 
   const std::shared_ptr<CAdvancedSettings> advancedSettings = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
 
@@ -57,7 +57,7 @@ void CDatabaseManager::Initialize()
   { CPVRDatabase db; UpdateDatabase(db, &advancedSettings->m_databaseTV); }
   { CPVREpgDatabase db; UpdateDatabase(db, &advancedSettings->m_databaseEpg); }
 
-  CLog::Log(LOGDEBUG, "{}, updating databases... DONE", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "updating databases... DONE");
 
   m_bIsUpgrading = false;
 }

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2809,8 +2809,7 @@ void CFileItemList::StackFolders()
   while (strExpression != strFolderRegExps.end())
   {
     if (!folderRegExp.RegComp(*strExpression))
-      CLog::Log(LOGERROR, "{}: Invalid folder stack RegExp:'{}'", __FUNCTION__,
-                strExpression->c_str());
+      CLog::LogF(LOGERROR, "Invalid folder stack RegExp:'{}'", strExpression->c_str());
     else
       folderRegExps.push_back(folderRegExp);
 
@@ -2819,8 +2818,7 @@ void CFileItemList::StackFolders()
 
   if (!folderRegExp.IsCompiled())
   {
-    CLog::Log(LOGDEBUG, "{}: No stack expressions available. Skipping folder stacking",
-              __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "No stack expressions available. Skipping folder stacking");
     return;
   }
 
@@ -3634,7 +3632,7 @@ bool CFileItem::LoadMusicTag()
     musicDatabase.Close();
   }
   // load tag from file
-  CLog::Log(LOGDEBUG, "{}: loading tag information for file: {}", __FUNCTION__, m_strPath);
+  CLog::LogF(LOGDEBUG, "loading tag information for file: {}", m_strPath);
   CMusicInfoTagLoaderFactory factory;
   std::unique_ptr<IMusicInfoTagLoader> pLoader (factory.CreateLoader(*this));
   if (pLoader)

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -11079,7 +11079,7 @@ int CGUIInfoManager::AddMultiInfo(const CGUIInfo &info)
   m_multiInfo.emplace_back(info);
   int id = static_cast<int>(m_multiInfo.size()) + MULTI_INFO_START - 1;
   if (id > MULTI_INFO_END)
-    CLog::Log(LOGERROR, "{} - too many multiinfo bool/labels in this skin", __FUNCTION__);
+    CLog::LogF(LOGERROR, "too many multiinfo bool/labels in this skin");
   return id;
 }
 

--- a/xbmc/GUILargeTextureManager.cpp
+++ b/xbmc/GUILargeTextureManager.cpp
@@ -58,7 +58,7 @@ bool CImageLoader::DoWork()
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 
     if (duration.count() > 100)
-      CLog::Log(LOGDEBUG, "{} - took {} ms to load {}", __FUNCTION__, duration.count(), loadPath);
+      CLog::LogF(LOGDEBUG, "took {} ms to load {}", duration.count(), loadPath);
 
     if (m_texture)
     {
@@ -69,7 +69,7 @@ bool CImageLoader::DoWork()
     }
 
     // Fallthrough on failure:
-    CLog::Log(LOGERROR, "{} - Direct texture file loading failed for {}", __FUNCTION__, loadPath);
+    CLog::LogF(LOGERROR, "Direct texture file loading failed for {}", loadPath);
   }
 
   if (!m_use_cache)

--- a/xbmc/PartyModeManager.cpp
+++ b/xbmc/PartyModeManager.cpp
@@ -189,7 +189,7 @@ bool CPartyModeManager::Enable(PartyModeContext context /*= PARTYMODECONTEXT_MUS
 
   auto end = std::chrono::steady_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-  CLog::Log(LOGDEBUG, "{} time for song fetch: {} ms", __FUNCTION__, duration.count());
+  CLog::LogF(LOGDEBUG, "time for song fetch: {} ms", duration.count());
 
   // start playing
   CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(playlistId);

--- a/xbmc/PasswordManager.cpp
+++ b/xbmc/PasswordManager.cpp
@@ -148,8 +148,8 @@ void CPasswordManager::Load()
     CXBMCTinyXML doc;
     if (!doc.LoadFile(passwordsFile))
     {
-      CLog::Log(LOGERROR, "{} - Unable to load: {}, Line {}\n{}", __FUNCTION__, passwordsFile,
-                doc.ErrorRow(), doc.ErrorDesc());
+      CLog::LogF(LOGERROR, "Unable to load: {}, Line {}\n{}", passwordsFile, doc.ErrorRow(),
+                 doc.ErrorDesc());
       return;
     }
     const TiXmlElement *root = doc.RootElement();

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -72,7 +72,7 @@ bool CServiceManager::InitForTesting()
   m_addonMgr.reset(new ADDON::CAddonMgr());
   if (!m_addonMgr->Init())
   {
-    CLog::Log(LOGFATAL, "CServiceManager::{}: Unable to start CAddonMgr", __FUNCTION__);
+    CLog::LogF(LOGFATAL, "CServiceManager: Unable to start CAddonMgr");
     return false;
   }
 
@@ -125,7 +125,7 @@ bool CServiceManager::InitStageTwo(const std::string& profilesUserDataFolder)
   m_addonMgr.reset(new ADDON::CAddonMgr());
   if (!m_addonMgr->Init())
   {
-    CLog::Log(LOGFATAL, "CServiceManager::{}: Unable to start CAddonMgr", __FUNCTION__);
+    CLog::LogF(LOGFATAL, "CServiceManager: Unable to start CAddonMgr");
     return false;
   }
 

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -187,8 +187,7 @@ std::string CTextureCache::CacheImage(const std::string& image,
   }
   else
   {
-    CLog::Log(LOGDEBUG, "CTextureCache::{} - Return NULL texture because cache is not ready",
-              __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "CTextureCache: Return NULL texture because cache is not ready");
   }
 
   return cachedpath;
@@ -329,7 +328,7 @@ bool CTextureCache::Export(const std::string &image, const std::string &destinat
     {
       if (CFile::Copy(cachedImage, dest))
         return true;
-      CLog::Log(LOGERROR, "{} failed exporting '{}' to '{}'", __FUNCTION__, cachedImage, dest);
+      CLog::LogF(LOGERROR, "failed exporting '{}' to '{}'", cachedImage, dest);
     }
   }
   return false;
@@ -343,7 +342,7 @@ bool CTextureCache::Export(const std::string &image, const std::string &destinat
   {
     if (CFile::Copy(cachedImage, destination))
       return true;
-    CLog::Log(LOGERROR, "{} failed exporting '{}' to '{}'", __FUNCTION__, cachedImage, destination);
+    CLog::LogF(LOGERROR, "failed exporting '{}' to '{}'", cachedImage, destination);
   }
   return false;
 }

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -260,7 +260,7 @@ std::string CTextureCacheJob::GetImageHash(const std::string &url)
     return "BADHASH";
   }
 
-  CLog::Log(LOGDEBUG, "{} - unable to stat url {}", __FUNCTION__, CURL::GetRedacted(url));
+  CLog::LogF(LOGDEBUG, "unable to stat url {}", CURL::GetRedacted(url));
   return "";
 }
 

--- a/xbmc/TextureDatabase.cpp
+++ b/xbmc/TextureDatabase.cpp
@@ -162,14 +162,14 @@ void CTextureDatabase::CreateTables()
 
 void CTextureDatabase::CreateAnalytics()
 {
-  CLog::Log(LOGINFO, "{} creating indices", __FUNCTION__);
+  CLog::LogF(LOGINFO, "creating indices");
   m_pDS->exec("CREATE INDEX idxTexture ON texture(url)");
   m_pDS->exec("CREATE INDEX idxSize ON sizes(idtexture, size)");
   m_pDS->exec("CREATE INDEX idxSize2 ON sizes(idtexture, width, height)");
   //! @todo Should the path index be a covering index? (we need only retrieve texture)
   m_pDS->exec("CREATE INDEX idxPath ON path(url, type)");
 
-  CLog::Log(LOGINFO, "{} creating triggers", __FUNCTION__);
+  CLog::LogF(LOGINFO, "creating triggers");
   m_pDS->exec("CREATE TRIGGER textureDelete AFTER delete ON texture FOR EACH ROW BEGIN delete from sizes where sizes.idtexture=old.id; END");
 }
 
@@ -262,7 +262,7 @@ bool CTextureDatabase::GetCachedTexture(const std::string &url, CTextureDetails 
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}, failed on url '{}'", __FUNCTION__, url);
+    CLog::LogF(LOGERROR, "failed on url '{}'", url);
   }
   return false;
 }
@@ -310,7 +310,7 @@ bool CTextureDatabase::GetTextures(CVariant &items, const Filter &filter)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}, failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -345,7 +345,7 @@ bool CTextureDatabase::AddCachedTexture(const std::string &url, const CTextureDe
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed on url '{}'", __FUNCTION__, url);
+    CLog::LogF(LOGERROR, "failed on url '{}'", url);
   }
   return true;
 }
@@ -381,7 +381,7 @@ bool CTextureDatabase::ClearCachedTexture(int id, std::string &cacheFile)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}, failed on texture id {}", __FUNCTION__, id);
+    CLog::LogF(LOGERROR, "failed on texture id {}", id);
   }
   return false;
 }
@@ -418,7 +418,7 @@ std::string CTextureDatabase::GetTextureForPath(const std::string &url, const st
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}, failed on url '{}'", __FUNCTION__, url);
+    CLog::LogF(LOGERROR, "failed on url '{}'", url);
   }
   return "";
 }
@@ -453,7 +453,7 @@ void CTextureDatabase::SetTextureForPath(const std::string &url, const std::stri
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed on url '{}'", __FUNCTION__, url);
+    CLog::LogF(LOGERROR, "failed on url '{}'", url);
   }
 }
 
@@ -471,7 +471,7 @@ void CTextureDatabase::ClearTextureForPath(const std::string &url, const std::st
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed on url '{}'", __FUNCTION__, url);
+    CLog::LogF(LOGERROR, "failed on url '{}'", url);
   }
 }
 

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -354,7 +354,7 @@ void CURL::SetOptions(const std::string& strOptions)
       m_options.AddOptions(m_strOptions);
     }
     else
-      CLog::Log(LOGWARNING, "{} - Invalid options specified for url {}", __FUNCTION__, strOptions);
+      CLog::LogF(LOGWARNING, "Invalid options specified for url {}", strOptions);
   }
 }
 

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -395,8 +395,8 @@ void CUtil::CleanString(const std::string& strFileName,
 
   if (!reYear.RegComp(advancedSettings->m_videoCleanDateTimeRegExp))
   {
-    CLog::Log(LOGERROR, "{}: Invalid datetime clean RegExp:'{}'", __FUNCTION__,
-              advancedSettings->m_videoCleanDateTimeRegExp);
+    CLog::LogF(LOGERROR, "Invalid datetime clean RegExp:'{}'",
+               advancedSettings->m_videoCleanDateTimeRegExp);
   }
   else
   {
@@ -413,7 +413,7 @@ void CUtil::CleanString(const std::string& strFileName,
   {
     if (!reTags.RegComp(regexp.c_str()))
     { // invalid regexp - complain in logs
-      CLog::Log(LOGERROR, "{}: Invalid string clean RegExp:'{}'", __FUNCTION__, regexp);
+      CLog::LogF(LOGERROR, "Invalid string clean RegExp:'{}'", regexp);
       continue;
     }
     int j=0;
@@ -533,7 +533,7 @@ bool CUtil::ExcludeFileOrFolder(const std::string& strFileOrFolder, const std::v
   {
     if (!regExExcludes.RegComp(regexp.c_str()))
     { // invalid regexp - complain in logs
-      CLog::Log(LOGERROR, "{}: Invalid exclude RegExp:'{}'", __FUNCTION__, regexp);
+      CLog::LogF(LOGERROR, "Invalid exclude RegExp:'{}'", regexp);
       continue;
     }
     if (regExExcludes.RegFind(strFileOrFolder) > -1)
@@ -671,7 +671,7 @@ void CUtil::ClearSubtitles()
       if (item->GetPath().find("subtitle") != std::string::npos ||
           item->GetPath().find("vobsub_queue") != std::string::npos)
       {
-        CLog::Log(LOGDEBUG, "{} - Deleting temporary subtitle {}", __FUNCTION__, item->GetPath());
+        CLog::LogF(LOGDEBUG, "Deleting temporary subtitle {}", item->GetPath());
         CFile::Delete(item->GetPath());
       }
     }
@@ -880,7 +880,7 @@ bool CUtil::CreateDirectoryEx(const std::string& strPath)
   // we currently only allow HD and smb and nfs paths
   if (!URIUtils::IsHD(strPath) && !URIUtils::IsSmb(strPath) && !URIUtils::IsNfs(strPath))
   {
-    CLog::Log(LOGERROR, "{} called with an unsupported path: {}", __FUNCTION__, strPath);
+    CLog::LogF(LOGERROR, "called with an unsupported path: {}", strPath);
     return false;
   }
 
@@ -1079,8 +1079,7 @@ void CUtil::SplitParams(const std::string &paramString, std::vector<std::string>
     parameter += ch;
   }
   if (inFunction || inQuotes)
-    CLog::Log(LOGWARNING, "{}({}) - end of string while searching for ) or \"", __FUNCTION__,
-              paramString);
+    CLog::LogF(LOGWARNING, "({}) - end of string while searching for ) or \"", paramString);
   if (whiteSpacePos)
     parameter.erase(whiteSpacePos);
   // trim off start and end quotes
@@ -1865,8 +1864,7 @@ void CUtil::ScanPathsForAssociatedItems(const std::string& videoName,
       else
       {
         associatedFiles.push_back(pItem->GetPath());
-        CLog::Log(LOGINFO, "{}: found associated file {}", __FUNCTION__,
-                  CURL::GetRedacted(pItem->GetPath()));
+        CLog::LogF(LOGINFO, "found associated file {}", CURL::GetRedacted(pItem->GetPath()));
       }
     }
     else
@@ -1926,8 +1924,7 @@ int CUtil::ScanArchiveForAssociatedItems(const std::string& strArchivePath,
     {
       if (StringUtils::EqualsNoCase(strExt, ext))
       {
-        CLog::Log(LOGINFO, "{}: found associated file {}", __FUNCTION__,
-                  CURL::GetRedacted(strPathInRar));
+        CLog::LogF(LOGINFO, "found associated file {}", CURL::GetRedacted(strPathInRar));
         associatedFiles.push_back(strPathInRar);
         nItemsAdded++;
         break;
@@ -1949,7 +1946,7 @@ void CUtil::ScanForExternalSubtitles(const std::string& strMovie, std::vector<st
     || !item.IsVideo())
     return;
 
-  CLog::Log(LOGDEBUG, "{}: Searching for subtitles...", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "Searching for subtitles...");
 
   std::string strBasePath;
   std::string strSubtitle;
@@ -2033,7 +2030,7 @@ void CUtil::ScanForExternalSubtitles(const std::string& strMovie, std::vector<st
 
   auto end = std::chrono::steady_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-  CLog::Log(LOGDEBUG, "{}: END (total time: {} ms)", __FUNCTION__, duration.count());
+  CLog::LogF(LOGDEBUG, "END (total time: {} ms)", duration.count());
 }
 
 ExternalStreamInfo CUtil::GetExternalStreamDetailsFromFilename(const std::string& videoPath, const std::string& associatedFile)
@@ -2052,8 +2049,8 @@ ExternalStreamInfo CUtil::GetExternalStreamDetailsFromFilename(const std::string
   else if (URIUtils::GetExtension(associatedFile) == ".sub" && URIUtils::IsInArchive(associatedFile))
   {
     // exclude parsing of vobsub file names that are embedded in an archive
-    CLog::Log(LOGDEBUG, "{} - skipping archived vobsub filename parsing: {}", __FUNCTION__,
-              CURL::GetRedacted(associatedFile));
+    CLog::LogF(LOGDEBUG, "skipping archived vobsub filename parsing: {}",
+               CURL::GetRedacted(associatedFile));
     toParse.clear();
   }
 
@@ -2110,8 +2107,8 @@ ExternalStreamInfo CUtil::GetExternalStreamDetailsFromFilename(const std::string
   if (info.flag == 0)
     info.flag = StreamFlags::FLAG_NONE;
 
-  CLog::Log(LOGDEBUG, "{} - Language = '{}' / Name = '{}' / Flag = '{}' from {}", __FUNCTION__,
-            info.language, info.name, info.flag, CURL::GetRedacted(associatedFile));
+  CLog::LogF(LOGDEBUG, "Language = '{}' / Name = '{}' / Flag = '{}' from {}", info.language,
+             info.name, info.flag, CURL::GetRedacted(associatedFile));
 
   return info;
 }

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -242,7 +242,7 @@ void CAddonDatabase::CreateTables()
 
 void CAddonDatabase::CreateAnalytics()
 {
-  CLog::Log(LOGINFO, "{} creating indices", __FUNCTION__);
+  CLog::LogF(LOGINFO, "creating indices");
   m_pDS->exec("CREATE INDEX idxAddons ON addons(addonID)");
   m_pDS->exec("CREATE UNIQUE INDEX ix_addonlinkrepo_1 ON addonlinkrepo ( idAddon, idRepo )\n");
   m_pDS->exec("CREATE UNIQUE INDEX ix_addonlinkrepo_2 ON addonlinkrepo ( idRepo, idAddon )\n");
@@ -452,7 +452,7 @@ void CAddonDatabase::SyncInstalled(const std::set<std::string>& ids,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
     RollbackTransaction();
   }
 }
@@ -472,7 +472,7 @@ bool CAddonDatabase::SetLastUpdated(const std::string& addonId, const CDateTime&
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed on addon '{}'", __FUNCTION__, addonId);
+    CLog::LogF(LOGERROR, "failed on addon '{}'", addonId);
   }
   return false;
 }
@@ -491,7 +491,7 @@ bool CAddonDatabase::SetOrigin(const std::string& addonId, const std::string& or
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed on addon '{}'", __FUNCTION__, addonId);
+    CLog::LogF(LOGERROR, "failed on addon '{}'", addonId);
   }
   return false;
 }
@@ -516,7 +516,7 @@ bool CAddonDatabase::SetLastUsed(const std::string& addonId, const CDateTime& da
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed on addon '{}'", __FUNCTION__, addonId);
+    CLog::LogF(LOGERROR, "failed on addon '{}'", addonId);
   }
   return false;
 }
@@ -570,7 +570,7 @@ bool CAddonDatabase::FindByAddonId(const std::string& addonId, ADDON::VECADDONS&
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed on addon {}", __FUNCTION__, addonId);
+    CLog::LogF(LOGERROR, "failed on addon {}", addonId);
   }
   return false;
 }
@@ -602,7 +602,7 @@ bool CAddonDatabase::GetAddon(const std::string& addonID,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed on addon {}", __FUNCTION__, addonID);
+    CLog::LogF(LOGERROR, "failed on addon {}", addonID);
   }
   return false;
 
@@ -640,7 +640,7 @@ bool CAddonDatabase::GetAddon(int id, AddonPtr &addon)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed on addon {}", __FUNCTION__, id);
+    CLog::LogF(LOGERROR, "failed on addon {}", id);
   }
   return false;
 }
@@ -752,7 +752,7 @@ bool CAddonDatabase::GetRepositoryContent(const std::string& id, VECADDONS& addo
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -774,7 +774,7 @@ void CAddonDatabase::DeleteRepository(const std::string& id)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed on repo '{}'", __FUNCTION__, id);
+    CLog::LogF(LOGERROR, "failed on repo '{}'", id);
   }
 }
 
@@ -796,7 +796,7 @@ void CAddonDatabase::DeleteRepositoryContents(const std::string& id)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed on repo '{}'", __FUNCTION__, id);
+    CLog::LogF(LOGERROR, "failed on repo '{}'", id);
   }
 }
 
@@ -848,7 +848,7 @@ bool CAddonDatabase::UpdateRepositoryContent(const std::string& repository,
       int idAddon = static_cast<int>(m_pDS->lastinsertid());
       if (idAddon <= 0)
       {
-        CLog::Log(LOGERROR, "{} insert failed on addon '{}'", __FUNCTION__, addon->ID());
+        CLog::LogF(LOGERROR, "insert failed on addon '{}'", addon->ID());
         RollbackTransaction();
         return false;
       }
@@ -861,7 +861,7 @@ bool CAddonDatabase::UpdateRepositoryContent(const std::string& repository,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed on repo '{}'", __FUNCTION__, repository);
+    CLog::LogF(LOGERROR, "failed on repo '{}'", repository);
     RollbackTransaction();
   }
   return false;
@@ -886,7 +886,7 @@ int CAddonDatabase::GetRepoChecksum(const std::string& id, std::string& checksum
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed on repo '{}'", __FUNCTION__, id);
+    CLog::LogF(LOGERROR, "failed on repo '{}'", id);
   }
   checksum.clear();
   return -1;
@@ -911,7 +911,7 @@ CAddonDatabase::RepoUpdateData CAddonDatabase::GetRepoUpdateData(const std::stri
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed on repo '{}'", __FUNCTION__, id);
+    CLog::LogF(LOGERROR, "failed on repo '{}'", id);
   }
   return result;
 }
@@ -954,7 +954,7 @@ int CAddonDatabase::SetRepoUpdateData(const std::string& id, const RepoUpdateDat
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed on repo '{}'", __FUNCTION__, id);
+    CLog::LogF(LOGERROR, "failed on repo '{}'", id);
   }
   return -1;
 }
@@ -972,7 +972,7 @@ bool CAddonDatabase::Search(const std::string& search, VECADDONS& addons)
     strSQL = PrepareSQL("SELECT id FROM addons WHERE name LIKE '%%%s%%' OR summary LIKE '%%%s%%' "
                   "OR description LIKE '%%%s%%'", search.c_str(), search.c_str(), search.c_str());
 
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
 
     if (!m_pDS->query(strSQL)) return false;
     if (m_pDS->num_rows() == 0) return false;
@@ -991,7 +991,7 @@ bool CAddonDatabase::Search(const std::string& search, VECADDONS& addons)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -1013,7 +1013,7 @@ bool CAddonDatabase::DisableAddon(const std::string& addonID, AddonDisabledReaso
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed on addon '{}'", __FUNCTION__, addonID);
+    CLog::LogF(LOGERROR, "failed on addon '{}'", addonID);
   }
   return false;
 }
@@ -1034,7 +1034,7 @@ bool CAddonDatabase::EnableAddon(const std::string& addonID)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed on addon '{}'", __FUNCTION__, addonID);
+    CLog::LogF(LOGERROR, "failed on addon '{}'", addonID);
   }
   return false;
 }
@@ -1062,7 +1062,7 @@ bool CAddonDatabase::GetDisabled(std::map<std::string, AddonDisabledReason>& add
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -1090,7 +1090,7 @@ bool CAddonDatabase::GetAddonUpdateRules(
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -1112,7 +1112,7 @@ bool CAddonDatabase::AddUpdateRuleForAddon(const std::string& addonID, AddonUpda
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed on addon '{}'", __FUNCTION__, addonID);
+    CLog::LogF(LOGERROR, "failed on addon '{}'", addonID);
   }
   return false;
 }
@@ -1144,7 +1144,7 @@ bool CAddonDatabase::RemoveUpdateRuleForAddon(const std::string& addonID,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed on addon '{}'", __FUNCTION__, addonID);
+    CLog::LogF(LOGERROR, "failed on addon '{}'", addonID);
   }
   return false;
 }
@@ -1191,7 +1191,7 @@ void CAddonDatabase::OnPostUnInstall(const std::string& addonId)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed on addon {}", __FUNCTION__, addonId);
+    CLog::LogF(LOGERROR, "failed on addon {}", addonId);
   }
 }
 
@@ -1219,7 +1219,7 @@ void CAddonDatabase::GetInstallData(const AddonInfoPtr& addon)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "CAddonDatabase::{}: failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "CAddonDatabase: failed");
   }
 }
 
@@ -1246,7 +1246,7 @@ bool CAddonDatabase::AddInstalledAddon(const std::shared_ptr<CAddonInfo>& addon,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
     return false;
   }
 

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -761,8 +761,9 @@ bool CAddonInstallJob::DoWork()
         {
           CFile::Delete(package);
 
-          CLog::Log(LOGERROR, "CAddonInstallJob[{}]: Hash mismatch after download. Expected {}, was {}",
-              m_addon->ID(), hash.value, actualHash.value);
+          CLog::Log(LOGERROR,
+                    "CAddonInstallJob[{}]: Hash mismatch after download. Expected {}, was {}",
+                    m_addon->ID(), hash.value, actualHash.value);
           ReportInstallError(m_addon->ID(), URIUtils::GetFileName(package));
           return false;
         }

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -180,18 +180,18 @@ bool CAddonMgr::HasInstalledAddons(AddonType type)
   return false;
 }
 
-void CAddonMgr::AddToUpdateableAddons(AddonPtr &pAddon)
+void CAddonMgr::AddToUpdateableAddons(AddonPtr& pAddon)
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   m_updateableAddons.push_back(pAddon);
 }
 
-void CAddonMgr::RemoveFromUpdateableAddons(AddonPtr &pAddon)
+void CAddonMgr::RemoveFromUpdateableAddons(AddonPtr& pAddon)
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   VECADDONS::iterator it = std::find(m_updateableAddons.begin(), m_updateableAddons.end(), pAddon);
 
-  if(it != m_updateableAddons.end())
+  if (it != m_updateableAddons.end())
   {
     m_updateableAddons.erase(it);
   }
@@ -199,16 +199,12 @@ void CAddonMgr::RemoveFromUpdateableAddons(AddonPtr &pAddon)
 
 struct AddonIdFinder
 {
-    explicit AddonIdFinder(const std::string& id)
-      : m_id(id)
-    {}
+  explicit AddonIdFinder(const std::string& id) : m_id(id) {}
 
-    bool operator()(const AddonPtr& addon)
-    {
-      return m_id == addon->ID();
-    }
-    private:
-    std::string m_id;
+  bool operator()(const AddonPtr& addon) { return m_id == addon->ID(); }
+
+private:
+  std::string m_id;
 };
 
 bool CAddonMgr::ReloadSettings(const std::string& addonId, AddonInstanceId instanceId)
@@ -217,7 +213,7 @@ bool CAddonMgr::ReloadSettings(const std::string& addonId, AddonInstanceId insta
   VECADDONS::iterator it =
       std::find_if(m_updateableAddons.begin(), m_updateableAddons.end(), AddonIdFinder(addonId));
 
-  if( it != m_updateableAddons.end())
+  if (it != m_updateableAddons.end())
   {
     return (*it)->ReloadSettings(instanceId);
   }
@@ -341,7 +337,8 @@ bool CAddonMgr::IsOrphaned(const std::shared_ptr<IAddon>& addon,
       !CAddonType::IsDependencyType(addon->MainType()))
     return false;
 
-  auto dependsOnCapturedAddon = [&addon](const std::shared_ptr<IAddon>& _) {
+  auto dependsOnCapturedAddon = [&addon](const std::shared_ptr<IAddon>& _)
+  {
     const auto& deps = _->GetDependencies();
     return std::any_of(deps.begin(), deps.end(),
                        [&addon](const DependencyInfo& dep) { return dep.id == addon->ID(); });
@@ -389,7 +386,7 @@ bool CAddonMgr::GetDisabledAddons(VECADDONS& addons, AddonType type)
   if (GetInstalledAddons(all, type))
   {
     std::copy_if(all.begin(), all.end(), std::back_inserter(addons),
-        [this](const AddonPtr& addon){ return IsAddonDisabled(addon->ID()); });
+                 [this](const AddonPtr& addon) { return IsAddonDisabled(addon->ID()); });
     return true;
   }
   return false;
@@ -414,19 +411,21 @@ bool CAddonMgr::GetInstallableAddons(VECADDONS& addons, AddonType type)
   // go through all addons and remove all that are already installed
 
   addons.erase(std::remove_if(addons.begin(), addons.end(),
-    [this, type](const AddonPtr& addon)
-    {
-      bool bErase = false;
+                              [this, type](const AddonPtr& addon)
+                              {
+                                bool bErase = false;
 
-      // check if the addon matches the provided addon type
-      if (type != AddonType::UNKNOWN && addon->Type() != type && !addon->HasType(type))
-        bErase = true;
+                                // check if the addon matches the provided addon type
+                                if (type != AddonType::UNKNOWN && addon->Type() != type &&
+                                    !addon->HasType(type))
+                                  bErase = true;
 
-      if (!this->CanAddonBeInstalled(addon))
-        bErase = true;
+                                if (!this->CanAddonBeInstalled(addon))
+                                  bErase = true;
 
-      return bErase;
-    }), addons.end());
+                                return bErase;
+                              }),
+               addons.end());
 
   return true;
 }
@@ -567,10 +566,10 @@ bool CAddonMgr::GetAddonUpdateCandidates(VECADDONS& updates) const
 {
   // Get Addons in need of an update and remove all the blacklisted ones
   updates = GetAvailableUpdates();
-  updates.erase(
-      std::remove_if(updates.begin(), updates.end(),
-                     [this](const AddonPtr& addon) { return !IsAutoUpdateable(addon->ID()); }),
-      updates.end());
+  updates.erase(std::remove_if(updates.begin(), updates.end(),
+                               [this](const AddonPtr& addon)
+                               { return !IsAutoUpdateable(addon->ID()); }),
+                updates.end());
   return updates.empty();
 }
 
@@ -592,9 +591,8 @@ void CAddonMgr::SortByDependencies(VECADDONS& updates) const
       // the end of the sorted vector of addon updates)
       for (const auto& dep : dependencies)
       {
-        auto comparator = [&dep](const std::shared_ptr<ADDON::IAddon>& addon) {
-          return addon->ID() == dep.id;
-        };
+        auto comparator = [&dep](const std::shared_ptr<ADDON::IAddon>& addon)
+        { return addon->ID() == dep.id; };
 
         if ((std::any_of(updates.begin(), updates.end(), comparator)) &&
             (!std::any_of(sorted.begin(), sorted.end(), comparator)))
@@ -685,8 +683,7 @@ bool CAddonMgr::FindAddon(const std::string& addonId,
   std::unique_lock<CCriticalSection> lock(m_critSection);
 
   m_database->GetInstallData(it->second);
-  CLog::Log(LOGINFO, "CAddonMgr::{}: {} v{} installed", __FUNCTION__, addonId,
-            addonVersion.asString());
+  CLog::LogF(LOGINFO, "CAddonMgr: {} v{} installed", addonId, addonVersion.asString());
 
   m_installedAddons[addonId] = it->second; // insert/replace entry
   m_database->AddInstalledAddon(it->second, origin);
@@ -721,8 +718,8 @@ bool CAddonMgr::FindAddons()
   for (const auto& addon : installedAddons)
   {
     m_database->GetInstallData(addon.second);
-    CLog::Log(LOGINFO, "CAddonMgr::{}: {} v{} installed", __FUNCTION__, addon.second->ID(),
-              addon.second->Version().asString());
+    CLog::LogF(LOGINFO, "CAddonMgr: {} v{} installed", addon.second->ID(),
+               addon.second->Version().asString());
   }
 
   m_installedAddons = std::move(installedAddons);
@@ -816,19 +813,23 @@ void CAddonMgr::OnPostUnInstall(const std::string& id)
 void CAddonMgr::UpdateLastUsed(const std::string& id)
 {
   auto time = CDateTime::GetCurrentDateTime();
-  CServiceBroker::GetJobManager()->Submit([this, id, time]() {
-    {
-      std::unique_lock<CCriticalSection> lock(m_critSection);
-      m_database->SetLastUsed(id, time);
-      auto addonInfo = GetAddonInfo(id, AddonType::UNKNOWN);
-      if (addonInfo)
-        addonInfo->SetLastUsed(time);
-    }
-    m_events.Publish(AddonEvents::MetadataChanged(id));
-  });
+  CServiceBroker::GetJobManager()->Submit(
+      [this, id, time]()
+      {
+        {
+          std::unique_lock<CCriticalSection> lock(m_critSection);
+          m_database->SetLastUsed(id, time);
+          auto addonInfo = GetAddonInfo(id, AddonType::UNKNOWN);
+          if (addonInfo)
+            addonInfo->SetLastUsed(time);
+        }
+        m_events.Publish(AddonEvents::MetadataChanged(id));
+      });
 }
 
-static void ResolveDependencies(const std::string& addonId, std::vector<std::string>& needed, std::vector<std::string>& missing)
+static void ResolveDependencies(const std::string& addonId,
+                                std::vector<std::string>& needed,
+                                std::vector<std::string>& missing)
 {
   if (std::find(needed.begin(), needed.end(), addonId) != needed.end())
     return;
@@ -1067,7 +1068,7 @@ bool CAddonMgr::IsOptionalSystemAddon(const std::string& id)
          m_optionalSystemAddons.end();
 }
 
-bool CAddonMgr::LoadAddonDescription(const std::string &directory, AddonPtr &addon)
+bool CAddonMgr::LoadAddonDescription(const std::string& directory, AddonPtr& addon)
 {
   auto addonInfo = CAddonInfoBuilder::Generate(directory);
   if (addonInfo)
@@ -1176,7 +1177,8 @@ std::vector<DependencyInfo> CAddonMgr::GetDepsRecursive(const std::string& id,
         StringUtils::StartsWith(current_dep.id, "kodi."))
       continue;
 
-    auto added_it = std::find_if(added.begin(), added.end(), [&](const DependencyInfo& d){ return d.id == current_dep.id;});
+    auto added_it = std::find_if(added.begin(), added.end(),
+                                 [&](const DependencyInfo& d) { return d.id == current_dep.id; });
     if (added_it != added.end())
     {
       if (current_dep.version < added_it->version)
@@ -1302,12 +1304,18 @@ void CAddonMgr::FindAddons(ADDON_INFO_LIST& addonmap, const std::string& path)
           {
             if (it->second->Version() > addonInfo->Version())
             {
-              CLog::Log(LOGWARNING, "CAddonMgr::{}: Addon '{}' already present with higher version {} at '{}' - other version {} at '{}' will be ignored",
-                           __FUNCTION__, addonInfo->ID(), it->second->Version().asString(), it->second->Path(), addonInfo->Version().asString(), addonInfo->Path());
+              CLog::LogF(LOGWARNING,
+                         "CAddonMgr: Addon '{}' already present with higher version {} at '{}' - "
+                         "other version {} at '{}' will be ignored",
+                         addonInfo->ID(), it->second->Version().asString(), it->second->Path(),
+                         addonInfo->Version().asString(), addonInfo->Path());
               continue;
             }
-            CLog::Log(LOGDEBUG, "CAddonMgr::{}: Addon '{}' already present with version {} at '{}' replaced with version {} at '{}'",
-                         __FUNCTION__, addonInfo->ID(), it->second->Version().asString(), it->second->Path(), addonInfo->Version().asString(), addonInfo->Path());
+            CLog::LogF(LOGDEBUG,
+                       "CAddonMgr: Addon '{}' already present with version {} at '{}' replaced "
+                       "with version {} at '{}'",
+                       addonInfo->ID(), it->second->Version().asString(), it->second->Path(),
+                       addonInfo->Version().asString(), addonInfo->Path());
           }
 
           addonmap[addonInfo->ID()] = addonInfo;
@@ -1340,7 +1348,9 @@ bool CAddonMgr::IsAddonDisabledWithReason(const std::string& ID,
  */
 /*@{{{*/
 
-bool CAddonMgr::SetAddonOrigin(const std::string& addonId, const std::string& repoAddonId, bool isUpdate)
+bool CAddonMgr::SetAddonOrigin(const std::string& addonId,
+                               const std::string& repoAddonId,
+                               bool isUpdate)
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
 

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -315,7 +315,8 @@ RepositoryDirInfo CRepository::ParseDirConfiguration(const CAddonExtensions& con
     dir.hashType = CDigest::TypeFromString(hashStr);
     if (dir.hashType == CDigest::Type::MD5)
     {
-      CLog::Log(LOGWARNING, "CRepository::{}: Repository has MD5 hashes enabled - this hash function is broken and will only guard against unintentional data corruption", __FUNCTION__);
+      CLog::LogF(LOGWARNING, "CRepository: Repository has MD5 hashes enabled - this hash function "
+                             "is broken and will only guard against unintentional data corruption");
     }
   }
 

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -233,7 +233,7 @@ std::vector<std::string> CScraper::Run(const std::string &function,
   if (strXML.empty())
   {
     if (function != "NfoUrl" && function != "ResolveIDToUrl")
-      CLog::Log(LOGERROR, "{}: Unable to parse web site", __FUNCTION__);
+      CLog::LogF(LOGERROR, "Unable to parse web site");
     throw CScraperError();
   }
 
@@ -244,7 +244,7 @@ std::vector<std::string> CScraper::Run(const std::string &function,
   doc.Parse(strXML, TIXML_ENCODING_UTF8);
   if (!doc.RootElement())
   {
-    CLog::Log(LOGERROR, "{}: Unable to parse XML", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Unable to parse XML");
     throw CScraperError();
   }
 
@@ -440,7 +440,7 @@ CScraperUrl CScraper::NfoUrl(const std::string &sNfoContent)
     if (items.Size() == 0)
       return scurlRet;
     if (items.Size() > 1)
-      CLog::Log(LOGWARNING, "{}: scraper returned multiple results; using first", __FUNCTION__);
+      CLog::LogF(LOGWARNING, "scraper returned multiple results; using first");
 
     CScraperUrl::SUrlEntry surl;
     surl.m_type = CScraperUrl::UrlType::General;
@@ -458,7 +458,7 @@ CScraperUrl CScraper::NfoUrl(const std::string &sNfoContent)
   if (vcsOut.empty() || vcsOut[0].empty())
     return scurlRet;
   if (vcsOut.size() > 1)
-    CLog::Log(LOGWARNING, "{}: scraper returned multiple results; using first", __FUNCTION__);
+    CLog::LogF(LOGWARNING, "scraper returned multiple results; using first");
 
   // parse returned XML: either <error> element on error, blank on failure,
   // or <url>...</url> or <url>...</url><id>...</id> on success
@@ -534,7 +534,7 @@ CScraperUrl CScraper::ResolveIDToUrl(const std::string &externalID)
   if (vcsOut.empty() || vcsOut[0].empty())
     return scurlRet;
   if (vcsOut.size() > 1)
-    CLog::Log(LOGWARNING, "{}: scraper returned multiple results; using first", __FUNCTION__);
+    CLog::LogF(LOGWARNING, "scraper returned multiple results; using first");
 
   // parse returned XML: either <error> element on error, blank on failure,
   // or <url>...</url> or <url>...</url><id>...</id> on success
@@ -881,11 +881,10 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl,
     sYear = std::to_string( movieYear );
   }
 
-  CLog::Log(LOGDEBUG,
-            "{}: Searching for '{}' using {} scraper "
-            "(path: '{}', content: '{}', version: '{}')",
-            __FUNCTION__, sTitle, Name(), Path(), ADDON::TranslateContent(Content()),
-            Version().asString());
+  CLog::LogF(LOGDEBUG,
+             "Searching for '{}' using {} scraper "
+             "(path: '{}', content: '{}', version: '{}')",
+             sTitle, Name(), Path(), ADDON::TranslateContent(Content()), Version().asString());
 
   std::vector<CScraperUrl> vcscurl;
   if (IsNoop())
@@ -914,7 +913,7 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl,
   std::vector<std::string> vcsOut = Run("CreateSearchUrl", scurl, fcurl, &vcsIn);
   if (vcsOut.empty())
   {
-    CLog::Log(LOGDEBUG, "{}: CreateSearchUrl failed", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "CreateSearchUrl failed");
     throw CScraperError();
   }
   scurl.ParseFromData(vcsOut[0]);
@@ -933,7 +932,7 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::CCurlFile &fcurl,
     doc.Parse(*i, TIXML_ENCODING_UTF8);
     if (!doc.RootElement())
     {
-      CLog::Log(LOGERROR, "{}: Unable to parse XML", __FUNCTION__);
+      CLog::LogF(LOGERROR, "Unable to parse XML");
       continue; // might have more valid results later
     }
 
@@ -1024,11 +1023,11 @@ std::vector<CMusicAlbumInfo> CScraper::FindAlbum(CCurlFile &fcurl,
                                                  const std::string &sAlbum,
                                                  const std::string &sArtist)
 {
-  CLog::Log(LOGDEBUG,
-            "{}: Searching for '{} - {}' using {} scraper "
-            "(path: '{}', content: '{}', version: '{}')",
-            __FUNCTION__, sArtist, sAlbum, Name(), Path(), ADDON::TranslateContent(Content()),
-            Version().asString());
+  CLog::LogF(LOGDEBUG,
+             "Searching for '{} - {}' using {} scraper "
+             "(path: '{}', content: '{}', version: '{}')",
+             sArtist, sAlbum, Name(), Path(), ADDON::TranslateContent(Content()),
+             Version().asString());
 
   std::vector<CMusicAlbumInfo> vcali;
   if (IsNoop())
@@ -1048,7 +1047,7 @@ std::vector<CMusicAlbumInfo> CScraper::FindAlbum(CCurlFile &fcurl,
   CScraperUrl scurl;
   std::vector<std::string> vcsOut = RunNoThrow("CreateAlbumSearchUrl", scurl, fcurl, &extras);
   if (vcsOut.size() > 1)
-    CLog::Log(LOGWARNING, "{}: scraper returned multiple results; using first", __FUNCTION__);
+    CLog::LogF(LOGWARNING, "scraper returned multiple results; using first");
 
   if (vcsOut.empty() || vcsOut[0].empty())
     return vcali;
@@ -1125,11 +1124,10 @@ std::vector<CMusicAlbumInfo> CScraper::FindAlbum(CCurlFile &fcurl,
 // returns a list of artists (empty if no match or failure)
 std::vector<CMusicArtistInfo> CScraper::FindArtist(CCurlFile &fcurl, const std::string &sArtist)
 {
-  CLog::Log(LOGDEBUG,
-            "{}: Searching for '{}' using {} scraper "
-            "(file: '{}', content: '{}', version: '{}')",
-            __FUNCTION__, sArtist, Name(), Path(), ADDON::TranslateContent(Content()),
-            Version().asString());
+  CLog::LogF(LOGDEBUG,
+             "Searching for '{}' using {} scraper "
+             "(file: '{}', content: '{}', version: '{}')",
+             sArtist, Name(), Path(), ADDON::TranslateContent(Content()), Version().asString());
 
   std::vector<CMusicArtistInfo> vcari;
   if (IsNoop())
@@ -1172,7 +1170,7 @@ std::vector<CMusicArtistInfo> CScraper::FindArtist(CCurlFile &fcurl, const std::
     doc.Parse(*i, TIXML_ENCODING_UTF8);
     if (!doc.RootElement())
     {
-      CLog::Log(LOGERROR, "{}: Unable to parse XML", __FUNCTION__);
+      CLog::LogF(LOGERROR, "Unable to parse XML");
       return vcari;
     }
     TiXmlHandle xhDoc(&doc);
@@ -1216,11 +1214,11 @@ EPISODELIST CScraper::GetEpisodeList(XFILE::CCurlFile &fcurl, const CScraperUrl 
   if (!scurl.HasUrls())
     return vcep;
 
-  CLog::Log(LOGDEBUG,
-            "{}: Searching '{}' using {} scraper "
-            "(file: '{}', content: '{}', version: '{}')",
-            __FUNCTION__, scurl.GetFirstThumbUrl(), Name(), Path(),
-            ADDON::TranslateContent(Content()), Version().asString());
+  CLog::LogF(LOGDEBUG,
+             "Searching '{}' using {} scraper "
+             "(file: '{}', content: '{}', version: '{}')",
+             scurl.GetFirstThumbUrl(), Name(), Path(), ADDON::TranslateContent(Content()),
+             Version().asString());
 
   if (m_isPython)
   {
@@ -1263,7 +1261,7 @@ EPISODELIST CScraper::GetEpisodeList(XFILE::CCurlFile &fcurl, const CScraperUrl 
     doc.Parse(*i);
     if (!doc.RootElement())
     {
-      CLog::Log(LOGERROR, "{}: Unable to parse XML", __FUNCTION__);
+      CLog::LogF(LOGERROR, "Unable to parse XML");
       continue;
     }
 
@@ -1315,11 +1313,11 @@ bool CScraper::GetVideoDetails(XFILE::CCurlFile &fcurl,
                                bool fMovie /*else episode*/,
                                CVideoInfoTag &video)
 {
-  CLog::Log(LOGDEBUG,
-            "{}: Reading {} '{}' using {} scraper "
-            "(file: '{}', content: '{}', version: '{}')",
-            __FUNCTION__, fMovie ? MediaTypeMovie : MediaTypeEpisode, scurl.GetFirstThumbUrl(),
-            Name(), Path(), ADDON::TranslateContent(Content()), Version().asString());
+  CLog::LogF(LOGDEBUG,
+             "Reading {} '{}' using {} scraper "
+             "(file: '{}', content: '{}', version: '{}')",
+             fMovie ? MediaTypeMovie : MediaTypeEpisode, scurl.GetFirstThumbUrl(), Name(), Path(),
+             ADDON::TranslateContent(Content()), Version().asString());
 
   video.Reset();
 
@@ -1341,7 +1339,7 @@ bool CScraper::GetVideoDetails(XFILE::CCurlFile &fcurl,
     doc.Parse(*i, TIXML_ENCODING_UTF8);
     if (!doc.RootElement())
     {
-      CLog::Log(LOGERROR, "{}: Unable to parse XML", __FUNCTION__);
+      CLog::LogF(LOGERROR, "Unable to parse XML");
       continue;
     }
 
@@ -1349,7 +1347,7 @@ bool CScraper::GetVideoDetails(XFILE::CCurlFile &fcurl,
     TiXmlElement *pxeDetails = xhDoc.FirstChild("details").Element();
     if (!pxeDetails)
     {
-      CLog::Log(LOGERROR, "{}: Invalid XML file (want <details>)", __FUNCTION__);
+      CLog::LogF(LOGERROR, "Invalid XML file (want <details>)");
       continue;
     }
     video.Load(pxeDetails, true /*fChain*/);
@@ -1361,11 +1359,11 @@ bool CScraper::GetVideoDetails(XFILE::CCurlFile &fcurl,
 // takes a URL; returns true and populates album on success, false otherwise
 bool CScraper::GetAlbumDetails(CCurlFile &fcurl, const CScraperUrl &scurl, CAlbum &album)
 {
-  CLog::Log(LOGDEBUG,
-            "{}: Reading '{}' using {} scraper "
-            "(file: '{}', content: '{}', version: '{}')",
-            __FUNCTION__, scurl.GetFirstThumbUrl(), Name(), Path(),
-            ADDON::TranslateContent(Content()), Version().asString());
+  CLog::LogF(LOGDEBUG,
+             "Reading '{}' using {} scraper "
+             "(file: '{}', content: '{}', version: '{}')",
+             scurl.GetFirstThumbUrl(), Name(), Path(), ADDON::TranslateContent(Content()),
+             Version().asString());
 
   if (m_isPython)
     return PythonDetails(ID(), "url", scurl.GetFirstThumbUrl(),
@@ -1381,7 +1379,7 @@ bool CScraper::GetAlbumDetails(CCurlFile &fcurl, const CScraperUrl &scurl, CAlbu
     doc.Parse(*i, TIXML_ENCODING_UTF8);
     if (!doc.RootElement())
     {
-      CLog::Log(LOGERROR, "{}: Unable to parse XML", __FUNCTION__);
+      CLog::LogF(LOGERROR, "Unable to parse XML");
       return false;
     }
     fRet = album.Load(doc.RootElement(), i != vcsOut.begin());
@@ -1399,11 +1397,11 @@ bool CScraper::GetArtistDetails(CCurlFile &fcurl,
   if (!scurl.HasUrls())
     return false;
 
-  CLog::Log(LOGDEBUG,
-            "{}: Reading '{}' ('{}') using {} scraper "
-            "(file: '{}', content: '{}', version: '{}')",
-            __FUNCTION__, scurl.GetFirstThumbUrl(), sSearch, Name(), Path(),
-            ADDON::TranslateContent(Content()), Version().asString());
+  CLog::LogF(LOGDEBUG,
+             "Reading '{}' ('{}') using {} scraper "
+             "(file: '{}', content: '{}', version: '{}')",
+             scurl.GetFirstThumbUrl(), sSearch, Name(), Path(), ADDON::TranslateContent(Content()),
+             Version().asString());
 
   if (m_isPython)
     return PythonDetails(ID(), "url", scurl.GetFirstThumbUrl(),
@@ -1424,7 +1422,7 @@ bool CScraper::GetArtistDetails(CCurlFile &fcurl,
     doc.Parse(*i, TIXML_ENCODING_UTF8);
     if (!doc.RootElement())
     {
-      CLog::Log(LOGERROR, "{}: Unable to parse XML", __FUNCTION__);
+      CLog::LogF(LOGERROR, "Unable to parse XML");
       return false;
     }
 
@@ -1438,11 +1436,11 @@ bool CScraper::GetArtwork(XFILE::CCurlFile &fcurl, CVideoInfoTag &details)
   if (!details.HasUniqueID())
     return false;
 
-  CLog::Log(LOGDEBUG,
-            "{}: Reading artwork for '{}' using {} scraper "
-            "(file: '{}', content: '{}', version: '{}')",
-            __FUNCTION__, details.GetUniqueID(), Name(), Path(), ADDON::TranslateContent(Content()),
-            Version().asString());
+  CLog::LogF(LOGDEBUG,
+             "Reading artwork for '{}' using {} scraper "
+             "(file: '{}', content: '{}', version: '{}')",
+             details.GetUniqueID(), Name(), Path(), ADDON::TranslateContent(Content()),
+             Version().asString());
 
   if (m_isPython)
     return PythonDetails(ID(), "id", details.GetUniqueID(),
@@ -1460,7 +1458,7 @@ bool CScraper::GetArtwork(XFILE::CCurlFile &fcurl, CVideoInfoTag &details)
     doc.Parse(*it, TIXML_ENCODING_UTF8);
     if (!doc.RootElement())
     {
-      CLog::Log(LOGERROR, "{}: Unable to parse XML", __FUNCTION__);
+      CLog::LogF(LOGERROR, "Unable to parse XML");
       return false;
     }
     fRet = details.Load(doc.RootElement(), it != vcsOut.begin());

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -661,7 +661,7 @@ void CSkinInfo::SetString(int setting, const std::string &label)
     return;
   }
 
-  CLog::Log(LOGFATAL, "{}: unknown setting ({}) requested", __FUNCTION__, setting);
+  CLog::LogF(LOGFATAL, "unknown setting ({}) requested", setting);
   assert(false);
 }
 
@@ -705,7 +705,7 @@ void CSkinInfo::SetBool(int setting, bool set)
     return;
   }
 
-  CLog::Log(LOGFATAL, "{}: unknown setting ({}) requested", __FUNCTION__, setting);
+  CLog::LogF(LOGFATAL, "unknown setting ({}) requested", setting);
   assert(false);
 }
 

--- a/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
+++ b/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
@@ -194,7 +194,7 @@ AddonInfoPtr CAddonInfoBuilder::Generate(const std::string& id, AddonType type)
   // any character to go through.
   if (id.empty() || id.find_first_not_of(VALID_ADDON_IDENTIFIER_CHARACTERS) != std::string::npos)
   {
-    CLog::Log(LOGERROR, "CAddonInfoBuilder::{}: identifier '{}' is invalid", __FUNCTION__, id);
+    CLog::LogF(LOGERROR, "CAddonInfoBuilder: identifier '{}' is invalid", id);
     return nullptr;
   }
 
@@ -211,11 +211,9 @@ AddonInfoPtr CAddonInfoBuilder::Generate(const std::string& addonPath, bool plat
   CXBMCTinyXML xmlDoc;
   if (!xmlDoc.LoadFile(URIUtils::AddFileToFolder(addonRealPath, "addon.xml")))
   {
-    CLog::Log(LOGERROR, "CAddonInfoBuilder::{}: Unable to load '{}', Line {}\n{}",
-                                               __FUNCTION__,
-                                               URIUtils::AddFileToFolder(addonRealPath, "addon.xml"),
-                                               xmlDoc.ErrorRow(),
-                                               xmlDoc.ErrorDesc());
+    CLog::LogF(LOGERROR, "CAddonInfoBuilder: Unable to load '{}', Line {}\n{}",
+               URIUtils::AddFileToFolder(addonRealPath, "addon.xml"), xmlDoc.ErrorRow(),
+               xmlDoc.ErrorDesc());
     return nullptr;
   }
 
@@ -277,7 +275,7 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon,
 
   if (!StringUtils::EqualsNoCase(element->Value(), "addon"))
   {
-    CLog::Log(LOGERROR, "CAddonInfoBuilder::{}: file from '{}' doesn't contain <addon>", __FUNCTION__, addonPath);
+    CLog::LogF(LOGERROR, "CAddonInfoBuilder: file from '{}' doesn't contain <addon>", addonPath);
     return false;
   }
 
@@ -303,11 +301,11 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon,
 
   if (addon->m_id.empty() || addon->m_version.empty())
   {
-    CLog::Log(LOGERROR, "CAddonInfoBuilder::{}: file '{}' doesn't contain required values on <addon ... > id='{}', version='{}'",
-              __FUNCTION__,
-              addonPath,
-              addon->m_id.empty() ? "missing" : addon->m_id,
-              addon->m_version.empty() ? "missing" : addon->m_version.asString());
+    CLog::LogF(LOGERROR,
+               "CAddonInfoBuilder: file '{}' doesn't contain required values on <addon ... > "
+               "id='{}', version='{}'",
+               addonPath, addon->m_id.empty() ? "missing" : addon->m_id,
+               addon->m_version.empty() ? "missing" : addon->m_version.asString());
     return false;
   }
 
@@ -316,7 +314,7 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon,
   // any character to go through.
   if (addon->m_id.find_first_not_of(VALID_ADDON_IDENTIFIER_CHARACTERS) != std::string::npos)
   {
-    CLog::Log(LOGERROR, "CAddonInfoBuilder::{}: identifier {} is invalid", __FUNCTION__, addon->m_id);
+    CLog::LogF(LOGERROR, "CAddonInfoBuilder: identifier {} is invalid", addon->m_id);
     return false;
   }
 
@@ -561,7 +559,9 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon,
       AddonType type = CAddonInfo::TranslateType(point);
       if (type == AddonType::UNKNOWN || type >= AddonType::MAX_TYPES)
       {
-        CLog::Log(LOGERROR, "CAddonInfoBuilder::{}: file '{}' doesn't contain a valid add-on type name ({})", __FUNCTION__, addon->m_path, point);
+        CLog::LogF(LOGERROR,
+                   "CAddonInfoBuilder: file '{}' doesn't contain a valid add-on type name ({})",
+                   addon->m_path, point);
         return false;
       }
 
@@ -599,8 +599,10 @@ bool CAddonInfoBuilder::ParseXML(const AddonInfoPtr& addon,
       // Prevent log file entry if data is from repository, there normal on
       // addons for other OS's
       if (!isRepoXMLContent)
-        CLog::Log(LOGERROR, "CAddonInfoBuilder::{}: addon.xml from '{}' for binary type '{}' doesn't contain library and addon becomes ignored",
-                      __FUNCTION__, addon->ID(), CAddonInfo::TranslateType(addon->m_mainType));
+        CLog::LogF(LOGERROR,
+                   "CAddonInfoBuilder: addon.xml from '{}' for binary type '{}' doesn't contain "
+                   "library and addon becomes ignored",
+                   addon->ID(), CAddonInfo::TranslateType(addon->m_mainType));
       return false;
     }
   }
@@ -650,14 +652,15 @@ bool CAddonInfoBuilder::ParseXMLTypes(CAddonType& addonType,
       }
       catch (const std::regex_error& e)
       {
-        CLog::Log(LOGERROR, "CAddonInfoBuilder::{}: Regex error caught: {}", __func__,
-                  e.what());
+        CLog::Log(LOGERROR, "CAddonInfoBuilder::{}: Regex error caught: {}", __func__, e.what());
       }
     }
 
     if (!ParseXMLExtension(addonType, child))
     {
-      CLog::Log(LOGERROR, "CAddonInfoBuilder::{}: addon.xml file doesn't contain a valid add-on extensions ({})", __FUNCTION__, info->ID());
+      CLog::LogF(LOGERROR,
+                 "CAddonInfoBuilder: addon.xml file doesn't contain a valid add-on extensions ({})",
+                 info->ID());
       return false;
     }
     if (!addonType.GetValue("provides").empty())

--- a/xbmc/addons/binary-addons/BinaryAddonBase.cpp
+++ b/xbmc/addons/binary-addons/BinaryAddonBase.cpp
@@ -26,8 +26,7 @@ AddonDllPtr CBinaryAddonBase::GetAddon(IAddonInstanceHandler* handler)
 {
   if (handler == nullptr)
   {
-    CLog::Log(LOGERROR, "CBinaryAddonBase::{}: for Id '{}' called with empty instance handler",
-              __FUNCTION__, ID());
+    CLog::LogF(LOGERROR, "CBinaryAddonBase: for Id '{}' called with empty instance handler", ID());
     return nullptr;
   }
 
@@ -47,8 +46,7 @@ void CBinaryAddonBase::ReleaseAddon(IAddonInstanceHandler* handler)
 {
   if (handler == nullptr)
   {
-    CLog::Log(LOGERROR, "CBinaryAddonBase::{}: for Id '{}' called with empty instance handler",
-              __FUNCTION__, ID());
+    CLog::LogF(LOGERROR, "CBinaryAddonBase: for Id '{}' called with empty instance handler", ID());
     return;
   }
 

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -817,8 +817,7 @@ bool CGUIDialogAddonInfo::SetItem(const CFileItemPtr& item)
   if (CServiceBroker::GetAddonMgr().GetAddon(item->GetAddonInfo()->ID(), m_localAddon,
                                              OnlyEnabled::CHOICE_NO))
   {
-    CLog::Log(LOGDEBUG, "{} - Addon with id {} not found locally.", __FUNCTION__,
-              item->GetAddonInfo()->ID());
+    CLog::LogF(LOGDEBUG, "Addon with id {} not found locally.", item->GetAddonInfo()->ID());
   }
   return true;
 }

--- a/xbmc/addons/interfaces/AudioEngine.cpp
+++ b/xbmc/addons/interfaces/AudioEngine.cpp
@@ -304,9 +304,9 @@ AEStreamHandle* Interface_AudioEngine::audioengine_make_stream(void* kodiBase,
 {
   if (!kodiBase || !streamFormat)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamFormat='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamFormat));
+    CLog::LogF(LOGERROR,
+               "Interface_AudioEngine: invalid stream data (kodiBase='{}', streamFormat='{}')",
+               kodiBase, static_cast<void*>(streamFormat));
     return nullptr;
   }
 
@@ -343,9 +343,9 @@ void Interface_AudioEngine::audioengine_free_stream(void* kodiBase, AEStreamHand
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR,
+               "Interface_AudioEngine: invalid stream data (kodiBase='{}', streamHandle='{}')",
+               kodiBase, static_cast<void*>(streamHandle));
     return;
   }
 
@@ -358,9 +358,8 @@ bool Interface_AudioEngine::get_current_sink_format(void* kodiBase, AUDIO_ENGINE
 {
   if (!kodiBase || !format)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', format='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(format));
+    CLog::LogF(LOGERROR, "Interface_AudioEngine: invalid stream data (kodiBase='{}', format='{}')",
+               kodiBase, static_cast<void*>(format));
     return false;
   }
 
@@ -371,8 +370,7 @@ bool Interface_AudioEngine::get_current_sink_format(void* kodiBase, AUDIO_ENGINE
   AEAudioFormat sinkFormat;
   if (!engine->GetCurrentSinkFormat(sinkFormat))
   {
-    CLog::Log(LOGERROR, "Interface_AudioEngine::{} - failed to get current sink format from AE!",
-              __FUNCTION__);
+    CLog::LogF(LOGERROR, "Interface_AudioEngine: failed to get current sink format from AE!");
     return false;
   }
 
@@ -393,9 +391,9 @@ unsigned int Interface_AudioEngine::aestream_get_space(void* kodiBase, AEStreamH
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR,
+               "Interface_AudioEngine: invalid stream data (kodiBase='{}', streamHandle='{}')",
+               kodiBase, static_cast<void*>(streamHandle));
     return 0;
   }
 
@@ -413,9 +411,9 @@ unsigned int Interface_AudioEngine::aestream_add_data(void* kodiBase,
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR,
+               "Interface_AudioEngine: invalid stream data (kodiBase='{}', streamHandle='{}')",
+               kodiBase, static_cast<void*>(streamHandle));
     return 0;
   }
 
@@ -433,9 +431,9 @@ double Interface_AudioEngine::aestream_get_delay(void* kodiBase, AEStreamHandle*
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR,
+               "Interface_AudioEngine: invalid stream data (kodiBase='{}', streamHandle='{}')",
+               kodiBase, static_cast<void*>(streamHandle));
     return -1.0;
   }
 
@@ -449,9 +447,9 @@ bool Interface_AudioEngine::aestream_is_buffering(void* kodiBase, AEStreamHandle
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR,
+               "Interface_AudioEngine: invalid stream data (kodiBase='{}', streamHandle='{}')",
+               kodiBase, static_cast<void*>(streamHandle));
     return false;
   }
 
@@ -465,9 +463,9 @@ double Interface_AudioEngine::aestream_get_cache_time(void* kodiBase, AEStreamHa
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR,
+               "Interface_AudioEngine: invalid stream data (kodiBase='{}', streamHandle='{}')",
+               kodiBase, static_cast<void*>(streamHandle));
     return -1.0;
   }
 
@@ -481,9 +479,9 @@ double Interface_AudioEngine::aestream_get_cache_total(void* kodiBase, AEStreamH
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR,
+               "Interface_AudioEngine: invalid stream data (kodiBase='{}', streamHandle='{}')",
+               kodiBase, static_cast<void*>(streamHandle));
     return -1.0;
   }
 
@@ -497,9 +495,9 @@ void Interface_AudioEngine::aestream_pause(void* kodiBase, AEStreamHandle* strea
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR,
+               "Interface_AudioEngine: invalid stream data (kodiBase='{}', streamHandle='{}')",
+               kodiBase, static_cast<void*>(streamHandle));
     return;
   }
 
@@ -513,9 +511,9 @@ void Interface_AudioEngine::aestream_resume(void* kodiBase, AEStreamHandle* stre
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR,
+               "Interface_AudioEngine: invalid stream data (kodiBase='{}', streamHandle='{}')",
+               kodiBase, static_cast<void*>(streamHandle));
     return;
   }
 
@@ -526,9 +524,9 @@ void Interface_AudioEngine::aestream_drain(void* kodiBase, AEStreamHandle* strea
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR,
+               "Interface_AudioEngine: invalid stream data (kodiBase='{}', streamHandle='{}')",
+               kodiBase, static_cast<void*>(streamHandle));
     return;
   }
 
@@ -542,9 +540,9 @@ bool Interface_AudioEngine::aestream_is_draining(void* kodiBase, AEStreamHandle*
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR,
+               "Interface_AudioEngine: invalid stream data (kodiBase='{}', streamHandle='{}')",
+               kodiBase, static_cast<void*>(streamHandle));
     return false;
   }
 
@@ -558,9 +556,9 @@ bool Interface_AudioEngine::aestream_is_drained(void* kodiBase, AEStreamHandle* 
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR,
+               "Interface_AudioEngine: invalid stream data (kodiBase='{}', streamHandle='{}')",
+               kodiBase, static_cast<void*>(streamHandle));
     return false;
   }
 
@@ -574,9 +572,9 @@ void Interface_AudioEngine::aestream_flush(void* kodiBase, AEStreamHandle* strea
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR,
+               "Interface_AudioEngine: invalid stream data (kodiBase='{}', streamHandle='{}')",
+               kodiBase, static_cast<void*>(streamHandle));
     return;
   }
 
@@ -590,9 +588,9 @@ float Interface_AudioEngine::aestream_get_volume(void* kodiBase, AEStreamHandle*
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR,
+               "Interface_AudioEngine: invalid stream data (kodiBase='{}', streamHandle='{}')",
+               kodiBase, static_cast<void*>(streamHandle));
     return -1.0f;
   }
 
@@ -608,9 +606,9 @@ void Interface_AudioEngine::aestream_set_volume(void* kodiBase,
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR,
+               "Interface_AudioEngine: invalid stream data (kodiBase='{}', streamHandle='{}')",
+               kodiBase, static_cast<void*>(streamHandle));
     return;
   }
 
@@ -625,9 +623,9 @@ float Interface_AudioEngine::aestream_get_amplification(void* kodiBase,
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR,
+               "Interface_AudioEngine: invalid stream data (kodiBase='{}', streamHandle='{}')",
+               kodiBase, static_cast<void*>(streamHandle));
     return -1.0f;
   }
 
@@ -643,9 +641,9 @@ void Interface_AudioEngine::aestream_set_amplification(void* kodiBase,
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR,
+               "Interface_AudioEngine: invalid stream data (kodiBase='{}', streamHandle='{}')",
+               kodiBase, static_cast<void*>(streamHandle));
     return;
   }
 
@@ -660,9 +658,9 @@ unsigned int Interface_AudioEngine::aestream_get_frame_size(void* kodiBase,
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR,
+               "Interface_AudioEngine: invalid stream data (kodiBase='{}', streamHandle='{}')",
+               kodiBase, static_cast<void*>(streamHandle));
     return 0;
   }
 
@@ -677,9 +675,9 @@ unsigned int Interface_AudioEngine::aestream_get_channel_count(void* kodiBase,
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR,
+               "Interface_AudioEngine: invalid stream data (kodiBase='{}', streamHandle='{}')",
+               kodiBase, static_cast<void*>(streamHandle));
     return 0;
   }
 
@@ -694,9 +692,9 @@ unsigned int Interface_AudioEngine::aestream_get_sample_rate(void* kodiBase,
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR,
+               "Interface_AudioEngine: invalid stream data (kodiBase='{}', streamHandle='{}')",
+               kodiBase, static_cast<void*>(streamHandle));
     return 0;
   }
 
@@ -711,9 +709,9 @@ AudioEngineDataFormat Interface_AudioEngine::aestream_get_data_format(void* kodi
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR,
+               "Interface_AudioEngine: invalid stream data (kodiBase='{}', streamHandle='{}')",
+               kodiBase, static_cast<void*>(streamHandle));
     return AUDIOENGINE_FMT_INVALID;
   }
 
@@ -728,9 +726,9 @@ double Interface_AudioEngine::aestream_get_resample_ratio(void* kodiBase,
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR,
+               "Interface_AudioEngine: invalid stream data (kodiBase='{}', streamHandle='{}')",
+               kodiBase, static_cast<void*>(streamHandle));
     return -1.0;
   }
 
@@ -746,9 +744,9 @@ void Interface_AudioEngine::aestream_set_resample_ratio(void* kodiBase,
 {
   if (!kodiBase || !streamHandle)
   {
-    CLog::Log(LOGERROR,
-              "Interface_AudioEngine::{} - invalid stream data (kodiBase='{}', streamHandle='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(streamHandle));
+    CLog::LogF(LOGERROR,
+               "Interface_AudioEngine: invalid stream data (kodiBase='{}', streamHandle='{}')",
+               kodiBase, static_cast<void*>(streamHandle));
     return;
   }
 

--- a/xbmc/addons/interfaces/Filesystem.cpp
+++ b/xbmc/addons/interfaces/Filesystem.cpp
@@ -161,8 +161,8 @@ bool Interface_Filesystem::can_open_directory(void* kodiBase, const char* url)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || url == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', url='{}')",
-              __FUNCTION__, kodiBase, static_cast<const void*>(url));
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', url='{}')", kodiBase,
+               static_cast<const void*>(url));
     return false;
   }
 
@@ -175,8 +175,8 @@ bool Interface_Filesystem::create_directory(void* kodiBase, const char* path)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || path == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', path='{}')",
-              __FUNCTION__, kodiBase, static_cast<const void*>(path));
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', path='{}')", kodiBase,
+               static_cast<const void*>(path));
     return false;
   }
 
@@ -188,8 +188,8 @@ bool Interface_Filesystem::directory_exists(void* kodiBase, const char* path)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || path == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', path='{}')",
-              __FUNCTION__, kodiBase, static_cast<const void*>(path));
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', path='{}')", kodiBase,
+               static_cast<const void*>(path));
     return false;
   }
 
@@ -201,8 +201,8 @@ bool Interface_Filesystem::remove_directory(void* kodiBase, const char* path)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || path == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', path='{}')",
-              __FUNCTION__, kodiBase, static_cast<const void*>(path));
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', path='{}')", kodiBase,
+               static_cast<const void*>(path));
     return false;
   }
 
@@ -220,8 +220,8 @@ bool Interface_Filesystem::remove_directory_recursive(void* kodiBase, const char
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || path == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', path='{}')",
-              __FUNCTION__, kodiBase, static_cast<const void*>(path));
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', path='{}')", kodiBase,
+               static_cast<const void*>(path));
     return false;
   }
 
@@ -250,12 +250,11 @@ bool Interface_Filesystem::get_directory(void* kodiBase,
   if (addon == nullptr || path == nullptr || mask == nullptr || items == nullptr ||
       num_items == nullptr)
   {
-    CLog::Log(LOGERROR,
-              "Interface_Filesystem::{} - invalid data (addon='{}', path='{}', mask='{}', "
-              "items='{}', num_items='{}'",
-              __FUNCTION__, kodiBase, static_cast<const void*>(path),
-              static_cast<const void*>(mask), static_cast<void*>(items),
-              static_cast<void*>(num_items));
+    CLog::LogF(LOGERROR,
+               "Interface_Filesystem: invalid data (addon='{}', path='{}', mask='{}', "
+               "items='{}', num_items='{}'",
+               kodiBase, static_cast<const void*>(path), static_cast<const void*>(mask),
+               static_cast<void*>(items), static_cast<void*>(num_items));
     return false;
   }
 
@@ -285,8 +284,8 @@ void Interface_Filesystem::free_directory(void* kodiBase,
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || items == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', items='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(items));
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', items='{}')", kodiBase,
+               static_cast<void*>(items));
     return;
   }
 
@@ -305,8 +304,8 @@ bool Interface_Filesystem::file_exists(void* kodiBase, const char* filename, boo
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || filename == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', filename='{}')",
-              __FUNCTION__, kodiBase, static_cast<const void*>(filename));
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', filename='{}')", kodiBase,
+               static_cast<const void*>(filename));
     return false;
   }
 
@@ -320,10 +319,9 @@ bool Interface_Filesystem::stat_file(void* kodiBase,
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || filename == nullptr || buffer == nullptr)
   {
-    CLog::Log(LOGERROR,
-              "Interface_Filesystem::{} - invalid data (addon='{}', filename='{}', buffer='{}')",
-              __FUNCTION__, kodiBase, static_cast<const void*>(filename),
-              static_cast<void*>(buffer));
+    CLog::LogF(LOGERROR,
+               "Interface_Filesystem: invalid data (addon='{}', filename='{}', buffer='{}')",
+               kodiBase, static_cast<const void*>(filename), static_cast<void*>(buffer));
     return false;
   }
 
@@ -353,8 +351,8 @@ bool Interface_Filesystem::delete_file(void* kodiBase, const char* filename)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || filename == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', filename='{}')",
-              __FUNCTION__, kodiBase, static_cast<const void*>(filename));
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', filename='{}')", kodiBase,
+               static_cast<const void*>(filename));
     return false;
   }
 
@@ -368,11 +366,9 @@ bool Interface_Filesystem::rename_file(void* kodiBase,
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || filename == nullptr || newFileName == nullptr)
   {
-    CLog::Log(
-        LOGERROR,
-        "Interface_Filesystem::{} - invalid data (addon='{}', filename='{}', newFileName='{}')",
-        __FUNCTION__, kodiBase, static_cast<const void*>(filename),
-        static_cast<const void*>(newFileName));
+    CLog::LogF(LOGERROR,
+               "Interface_Filesystem: invalid data (addon='{}', filename='{}', newFileName='{}')",
+               kodiBase, static_cast<const void*>(filename), static_cast<const void*>(newFileName));
     return false;
   }
 
@@ -384,9 +380,9 @@ bool Interface_Filesystem::copy_file(void* kodiBase, const char* filename, const
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || filename == nullptr || dest == nullptr)
   {
-    CLog::Log(
-        LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', filename='{}', dest='{}')",
-        __FUNCTION__, kodiBase, static_cast<const void*>(filename), static_cast<const void*>(dest));
+    CLog::LogF(LOGERROR,
+               "Interface_Filesystem: invalid data (addon='{}', filename='{}', dest='{}')",
+               kodiBase, static_cast<const void*>(filename), static_cast<const void*>(dest));
     return false;
   }
 
@@ -398,8 +394,8 @@ char* Interface_Filesystem::get_file_md5(void* kodiBase, const char* filename)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || filename == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', filename='{})",
-              __FUNCTION__, kodiBase, static_cast<const void*>(filename));
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', filename='{})", kodiBase,
+               static_cast<const void*>(filename));
     return nullptr;
   }
 
@@ -413,8 +409,8 @@ char* Interface_Filesystem::get_cache_thumb_name(void* kodiBase, const char* fil
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || filename == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', filename='{})",
-              __FUNCTION__, kodiBase, static_cast<const void*>(filename));
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', filename='{})", kodiBase,
+               static_cast<const void*>(filename));
     return nullptr;
   }
 
@@ -429,8 +425,8 @@ char* Interface_Filesystem::make_legal_filename(void* kodiBase, const char* file
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || filename == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', filename='{})",
-              __FUNCTION__, kodiBase, static_cast<const void*>(filename));
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', filename='{})", kodiBase,
+               static_cast<const void*>(filename));
     return nullptr;
   }
 
@@ -444,8 +440,8 @@ char* Interface_Filesystem::make_legal_path(void* kodiBase, const char* path)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || path == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', path='{})",
-              __FUNCTION__, kodiBase, static_cast<const void*>(path));
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', path='{})", kodiBase,
+               static_cast<const void*>(path));
     return nullptr;
   }
 
@@ -459,8 +455,8 @@ char* Interface_Filesystem::translate_special_protocol(void* kodiBase, const cha
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || strSource == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', strSource='{})",
-              __FUNCTION__, kodiBase, static_cast<const void*>(strSource));
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', strSource='{})", kodiBase,
+               static_cast<const void*>(strSource));
     return nullptr;
   }
 
@@ -476,12 +472,11 @@ bool Interface_Filesystem::get_disk_space(
   if (addon == nullptr || path == nullptr || capacity == nullptr || free == nullptr ||
       available == nullptr)
   {
-    CLog::Log(
-        LOGERROR,
-        "Interface_Filesystem::{} - invalid data (addon='{}', path='{}, capacity='{}, free='{}, "
-        "available='{})",
-        __FUNCTION__, kodiBase, static_cast<const void*>(path), static_cast<void*>(capacity),
-        static_cast<void*>(free), static_cast<void*>(available));
+    CLog::LogF(LOGERROR,
+               "Interface_Filesystem: invalid data (addon='{}', path='{}, capacity='{}, free='{}, "
+               "available='{})",
+               kodiBase, static_cast<const void*>(path), static_cast<void*>(capacity),
+               static_cast<void*>(free), static_cast<void*>(available));
     return false;
   }
 
@@ -501,8 +496,8 @@ bool Interface_Filesystem::is_internet_stream(void* kodiBase, const char* path, 
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || path == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', path='{})",
-              __FUNCTION__, kodiBase, static_cast<const void*>(path));
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', path='{})", kodiBase,
+               static_cast<const void*>(path));
     return false;
   }
 
@@ -514,8 +509,8 @@ bool Interface_Filesystem::is_on_lan(void* kodiBase, const char* path)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || path == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', path='{})",
-              __FUNCTION__, kodiBase, static_cast<const void*>(path));
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', path='{})", kodiBase,
+               static_cast<const void*>(path));
     return false;
   }
 
@@ -527,8 +522,8 @@ bool Interface_Filesystem::is_remote(void* kodiBase, const char* path)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || path == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', path='{})",
-              __FUNCTION__, kodiBase, static_cast<const void*>(path));
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', path='{})", kodiBase,
+               static_cast<const void*>(path));
     return false;
   }
 
@@ -540,8 +535,8 @@ bool Interface_Filesystem::is_local(void* kodiBase, const char* path)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || path == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', path='{})",
-              __FUNCTION__, kodiBase, static_cast<const void*>(path));
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', path='{})", kodiBase,
+               static_cast<const void*>(path));
     return false;
   }
 
@@ -553,8 +548,8 @@ bool Interface_Filesystem::is_url(void* kodiBase, const char* path)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || path == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', path='{})",
-              __FUNCTION__, kodiBase, static_cast<const void*>(path));
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', path='{})", kodiBase,
+               static_cast<const void*>(path));
     return false;
   }
 
@@ -569,11 +564,11 @@ bool Interface_Filesystem::get_mime_type(void* kodiBase,
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || url == nullptr || content == nullptr || useragent == nullptr)
   {
-    CLog::Log(LOGERROR,
-              "Interface_Filesystem::{} - invalid data (addon='{}', url='{}', content='{}', "
-              "useragent='{}')",
-              __FUNCTION__, kodiBase, static_cast<const void*>(url),
-              static_cast<const void*>(content), static_cast<const void*>(useragent));
+    CLog::LogF(LOGERROR,
+               "Interface_Filesystem: invalid data (addon='{}', url='{}', content='{}', "
+               "useragent='{}')",
+               kodiBase, static_cast<const void*>(url), static_cast<const void*>(content),
+               static_cast<const void*>(useragent));
     return false;
   }
 
@@ -594,11 +589,11 @@ bool Interface_Filesystem::get_content_type(void* kodiBase,
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || url == nullptr || content == nullptr || useragent == nullptr)
   {
-    CLog::Log(LOGERROR,
-              "Interface_Filesystem::{} - invalid data (addon='{}', url='{}', content='{}', "
-              "useragent='{}')",
-              __FUNCTION__, kodiBase, static_cast<const void*>(url),
-              static_cast<const void*>(content), static_cast<const void*>(useragent));
+    CLog::LogF(LOGERROR,
+               "Interface_Filesystem: invalid data (addon='{}', url='{}', content='{}', "
+               "useragent='{}')",
+               kodiBase, static_cast<const void*>(url), static_cast<const void*>(content),
+               static_cast<const void*>(useragent));
     return false;
   }
 
@@ -616,9 +611,8 @@ bool Interface_Filesystem::get_cookies(void* kodiBase, const char* url, char** c
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || url == nullptr || cookies == nullptr)
   {
-    CLog::Log(
-        LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', url='{}', cookies='{}')",
-        __FUNCTION__, kodiBase, static_cast<const void*>(url), static_cast<const void*>(cookies));
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', url='{}', cookies='{}')",
+               kodiBase, static_cast<const void*>(url), static_cast<const void*>(cookies));
     return false;
   }
 
@@ -653,8 +647,8 @@ bool Interface_Filesystem::http_header_create(void* kodiBase, struct KODI_HTTP_H
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || headers == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', headers='{}')",
-              __FUNCTION__, kodiBase, static_cast<const void*>(headers));
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', headers='{}')", kodiBase,
+               static_cast<const void*>(headers));
     return false;
   }
 
@@ -674,8 +668,8 @@ void Interface_Filesystem::http_header_free(void* kodiBase, struct KODI_HTTP_HEA
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || headers == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', headers='{}')",
-              __FUNCTION__, kodiBase, static_cast<const void*>(headers));
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', headers='{}')", kodiBase,
+               static_cast<const void*>(headers));
     return;
   }
 
@@ -688,9 +682,8 @@ char* Interface_Filesystem::http_header_get_value(void* kodiBase, void* handle, 
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || handle == nullptr || param == nullptr)
   {
-    CLog::Log(LOGERROR,
-              "Interface_Filesystem::{} - invalid data (addon='{}', handle='{}', param='{}')",
-              __FUNCTION__, kodiBase, handle, static_cast<const void*>(param));
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', handle='{}', param='{}')",
+               kodiBase, handle, static_cast<const void*>(param));
     return nullptr;
   }
 
@@ -710,11 +703,10 @@ char** Interface_Filesystem::http_header_get_values(void* kodiBase,
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || handle == nullptr || param == nullptr || length == nullptr)
   {
-    CLog::Log(LOGERROR,
-              "Interface_Filesystem::{} - invalid data (addon='{}', handle='{}', param='{}', "
-              "length='{}')",
-              __FUNCTION__, kodiBase, handle, static_cast<const void*>(param),
-              static_cast<const void*>(length));
+    CLog::LogF(LOGERROR,
+               "Interface_Filesystem: invalid data (addon='{}', handle='{}', param='{}', "
+               "length='{}')",
+               kodiBase, handle, static_cast<const void*>(param), static_cast<const void*>(length));
     return nullptr;
   }
 
@@ -734,8 +726,8 @@ char* Interface_Filesystem::http_header_get_header(void* kodiBase, void* handle)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || handle == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', handle='{}')",
-              __FUNCTION__, kodiBase, handle);
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', handle='{}')", kodiBase,
+               handle);
     return nullptr;
   }
 
@@ -752,8 +744,8 @@ char* Interface_Filesystem::http_header_get_mime_type(void* kodiBase, void* hand
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || handle == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', handle='{}')",
-              __FUNCTION__, kodiBase, handle);
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', handle='{}')", kodiBase,
+               handle);
     return nullptr;
   }
 
@@ -770,8 +762,8 @@ char* Interface_Filesystem::http_header_get_charset(void* kodiBase, void* handle
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || handle == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', handle='{}')",
-              __FUNCTION__, kodiBase, handle);
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', handle='{}')", kodiBase,
+               handle);
     return nullptr;
   }
 
@@ -788,8 +780,8 @@ char* Interface_Filesystem::http_header_get_proto_line(void* kodiBase, void* han
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || handle == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', handle='{}')",
-              __FUNCTION__, kodiBase, handle);
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', handle='{}')", kodiBase,
+               handle);
     return nullptr;
   }
 
@@ -808,8 +800,8 @@ void* Interface_Filesystem::open_file(void* kodiBase, const char* filename, unsi
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || filename == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', filename='{}')",
-              __FUNCTION__, kodiBase, static_cast<const void*>(filename));
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', filename='{}')", kodiBase,
+               static_cast<const void*>(filename));
     return nullptr;
   }
 
@@ -828,8 +820,8 @@ void* Interface_Filesystem::open_file_for_write(void* kodiBase,
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || filename == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', filename='{}')",
-              __FUNCTION__, kodiBase, static_cast<const void*>(filename));
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', filename='{}')", kodiBase,
+               static_cast<const void*>(filename));
     return nullptr;
   }
 
@@ -846,8 +838,8 @@ ssize_t Interface_Filesystem::read_file(void* kodiBase, void* file, void* ptr, s
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || file == nullptr || ptr == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', file='{}', ptr='{}')",
-              __FUNCTION__, kodiBase, file, ptr);
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', file='{}', ptr='{}')",
+               kodiBase, file, ptr);
     return -1;
   }
 
@@ -862,9 +854,8 @@ bool Interface_Filesystem::read_file_string(void* kodiBase,
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || file == nullptr || szLine == nullptr)
   {
-    CLog::Log(LOGERROR,
-              "Interface_Filesystem::{} - invalid data (addon='{}', file='{}', szLine=='{}')",
-              __FUNCTION__, kodiBase, file, static_cast<void*>(szLine));
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', file='{}', szLine=='{}')",
+               kodiBase, file, static_cast<void*>(szLine));
     return false;
   }
 
@@ -876,8 +867,8 @@ ssize_t Interface_Filesystem::write_file(void* kodiBase, void* file, const void*
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || file == nullptr || ptr == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', file='{}', ptr='{}')",
-              __FUNCTION__, kodiBase, file, ptr);
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', file='{}', ptr='{}')",
+               kodiBase, file, ptr);
     return -1;
   }
 
@@ -889,8 +880,8 @@ void Interface_Filesystem::flush_file(void* kodiBase, void* file)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || file == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', file='{}')",
-              __FUNCTION__, kodiBase, file);
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', file='{}')", kodiBase,
+               file);
     return;
   }
 
@@ -902,8 +893,8 @@ int64_t Interface_Filesystem::seek_file(void* kodiBase, void* file, int64_t posi
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || file == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', file='{}')",
-              __FUNCTION__, kodiBase, file);
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', file='{}')", kodiBase,
+               file);
     return -1;
   }
 
@@ -915,8 +906,8 @@ int Interface_Filesystem::truncate_file(void* kodiBase, void* file, int64_t size
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || file == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', file='{}')",
-              __FUNCTION__, kodiBase, file);
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', file='{}')", kodiBase,
+               file);
     return -1;
   }
 
@@ -928,8 +919,8 @@ int64_t Interface_Filesystem::get_file_position(void* kodiBase, void* file)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || file == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', file='{}')",
-              __FUNCTION__, kodiBase, file);
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', file='{}')", kodiBase,
+               file);
     return -1;
   }
 
@@ -941,8 +932,8 @@ int64_t Interface_Filesystem::get_file_length(void* kodiBase, void* file)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || file == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', file='{}')",
-              __FUNCTION__, kodiBase, file);
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', file='{}')", kodiBase,
+               file);
     return -1;
   }
 
@@ -954,8 +945,8 @@ double Interface_Filesystem::get_file_download_speed(void* kodiBase, void* file)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || file == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', file='{}')",
-              __FUNCTION__, kodiBase, file);
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', file='{}')", kodiBase,
+               file);
     return 0.0;
   }
 
@@ -967,8 +958,8 @@ void Interface_Filesystem::close_file(void* kodiBase, void* file)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || file == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', file='{}')",
-              __FUNCTION__, kodiBase, file);
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', file='{}')", kodiBase,
+               file);
     return;
   }
 
@@ -981,8 +972,7 @@ int Interface_Filesystem::get_file_chunk_size(void* kodiBase, void* file)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || file == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_VFS::{} - invalid data (addon='{}', file='{}')", __FUNCTION__,
-              kodiBase, file);
+    CLog::LogF(LOGERROR, "Interface_VFS: invalid data (addon='{}', file='{}')", kodiBase, file);
     return -1;
   }
 
@@ -994,8 +984,7 @@ bool Interface_Filesystem::io_control_get_seek_possible(void* kodiBase, void* fi
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || file == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_VFS::{} - invalid data (addon='{}', file='{}')", __FUNCTION__,
-              kodiBase, file);
+    CLog::LogF(LOGERROR, "Interface_VFS: invalid data (addon='{}', file='{}')", kodiBase, file);
     return false;
   }
 
@@ -1011,8 +1000,8 @@ bool Interface_Filesystem::io_control_get_cache_status(void* kodiBase,
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || file == nullptr || status == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_VFS::{} - invalid data (addon='{}', file='{}, status='{}')",
-              __FUNCTION__, kodiBase, file, static_cast<const void*>(status));
+    CLog::LogF(LOGERROR, "Interface_VFS: invalid data (addon='{}', file='{}, status='{}')",
+               kodiBase, file, static_cast<const void*>(status));
     return false;
   }
 
@@ -1034,8 +1023,7 @@ bool Interface_Filesystem::io_control_set_cache_rate(void* kodiBase, void* file,
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || file == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_VFS::{} - invalid data (addon='{}', file='{}')", __FUNCTION__,
-              kodiBase, file);
+    CLog::LogF(LOGERROR, "Interface_VFS: invalid data (addon='{}', file='{}')", kodiBase, file);
     return false;
   }
 
@@ -1048,8 +1036,7 @@ bool Interface_Filesystem::io_control_set_retry(void* kodiBase, void* file, bool
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || file == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_VFS::{} - invalid data (addon='{}', file='{}')", __FUNCTION__,
-              kodiBase, file);
+    CLog::LogF(LOGERROR, "Interface_VFS: invalid data (addon='{}', file='{}')", kodiBase, file);
     return false;
   }
 
@@ -1063,11 +1050,10 @@ char** Interface_Filesystem::get_property_values(
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || file == nullptr || name == nullptr || numValues == nullptr)
   {
-    CLog::Log(LOGERROR,
-              "Interface_Filesystem::{} - invalid data (addon='{}', file='{}', name='{}', "
-              "numValues='{}')",
-              __FUNCTION__, kodiBase, file, static_cast<const void*>(name),
-              static_cast<void*>(numValues));
+    CLog::LogF(LOGERROR,
+               "Interface_Filesystem: invalid data (addon='{}', file='{}', name='{}', "
+               "numValues='{}')",
+               kodiBase, file, static_cast<const void*>(name), static_cast<void*>(numValues));
     return nullptr;
   }
 
@@ -1093,8 +1079,8 @@ char** Interface_Filesystem::get_property_values(
       internalType = XFILE::FILE_PROPERTY_EFFECTIVE_URL;
       break;
     default:
-      CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', file='{}')",
-                __FUNCTION__, kodiBase, file);
+      CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', file='{}')", kodiBase,
+                 file);
       return nullptr;
   };
   std::vector<std::string> values =
@@ -1113,8 +1099,8 @@ void* Interface_Filesystem::curl_create(void* kodiBase, const char* url)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || url == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', url='{}')",
-              __FUNCTION__, kodiBase, static_cast<const void*>(url));
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', url='{}')", kodiBase,
+               static_cast<const void*>(url));
     return nullptr;
   }
 
@@ -1132,11 +1118,9 @@ bool Interface_Filesystem::curl_add_option(
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || file == nullptr || name == nullptr || value == nullptr)
   {
-    CLog::Log(
-        LOGERROR,
-        "Interface_Filesystem::{} - invalid data (addon='{}', file='{}', name='{}', value='{}')",
-        __FUNCTION__, kodiBase, file, static_cast<const void*>(name),
-        static_cast<const void*>(value));
+    CLog::LogF(LOGERROR,
+               "Interface_Filesystem: invalid data (addon='{}', file='{}', name='{}', value='{}')",
+               kodiBase, file, static_cast<const void*>(name), static_cast<const void*>(value));
     return false;
   }
 
@@ -1168,8 +1152,8 @@ bool Interface_Filesystem::curl_open(void* kodiBase, void* file, unsigned int fl
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || file == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Filesystem::{} - invalid data (addon='{}', file='{}')",
-              __FUNCTION__, kodiBase, file);
+    CLog::LogF(LOGERROR, "Interface_Filesystem: invalid data (addon='{}', file='{}')", kodiBase,
+               file);
     return false;
   }
 

--- a/xbmc/addons/interfaces/General.cpp
+++ b/xbmc/addons/interfaces/General.cpp
@@ -70,8 +70,8 @@ char* Interface_General::unknown_to_utf8(void* kodiBase, const char* source, boo
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (!addon || !source || !ret)
   {
-    CLog::Log(LOGERROR, "Interface_General::{} - invalid data (addon='{}', source='{}', ret='{}')",
-              __FUNCTION__, kodiBase, static_cast<const void*>(source), static_cast<void*>(ret));
+    CLog::LogF(LOGERROR, "Interface_General: invalid data (addon='{}', source='{}', ret='{}')",
+               kodiBase, static_cast<const void*>(source), static_cast<void*>(ret));
     return nullptr;
   }
 
@@ -86,8 +86,7 @@ char* Interface_General::get_language(void* kodiBase, int format, bool region)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (!addon)
   {
-    CLog::Log(LOGERROR, "Interface_General::{} - invalid data (addon='{}')", __FUNCTION__,
-              kodiBase);
+    CLog::LogF(LOGERROR, "Interface_General: invalid data (addon='{}')", kodiBase);
     return nullptr;
   }
 
@@ -143,8 +142,8 @@ bool Interface_General::queue_notification(void* kodiBase, int type, const char*
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || message == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_General::{} - invalid data (addon='{}', message='{}')",
-              __FUNCTION__, kodiBase, static_cast<const void*>(message));
+    CLog::LogF(LOGERROR, "Interface_General: invalid data (addon='{}', message='{}')", kodiBase,
+               static_cast<const void*>(message));
     return false;
   }
 
@@ -164,30 +163,27 @@ bool Interface_General::queue_notification(void* kodiBase, int type, const char*
     case QueueMsg::QUEUE_WARNING:
       usedType = CGUIDialogKaiToast::Warning;
       withSound = true;
-      CLog::Log(LOGDEBUG, "Interface_General::{} - {} - Warning Message: '{}'", __FUNCTION__,
-                addon->Name(), message);
+      CLog::LogF(LOGDEBUG, "Interface_General: {} - Warning Message: '{}'", addon->Name(), message);
       break;
     case QueueMsg::QUEUE_ERROR:
       usedType = CGUIDialogKaiToast::Error;
       withSound = true;
-      CLog::Log(LOGDEBUG, "Interface_General::{} - {} - Error Message : '{}'", __FUNCTION__,
-                addon->Name(), message);
+      CLog::LogF(LOGDEBUG, "Interface_General: {} - Error Message : '{}'", addon->Name(), message);
       break;
     case QueueMsg::QUEUE_INFO:
     default:
       usedType = CGUIDialogKaiToast::Info;
       withSound = false;
-      CLog::Log(LOGDEBUG, "Interface_General::{} - {} - Info Message : '{}'", __FUNCTION__,
-                addon->Name(), message);
+      CLog::LogF(LOGDEBUG, "Interface_General: {} - Info Message : '{}'", addon->Name(), message);
       break;
     }
 
     if (imageFile && strlen(imageFile) > 0)
     {
-      CLog::Log(LOGERROR,
-                "Interface_General::{} - To use given image file '{}' must be type value set to "
-                "'QUEUE_OWN_STYLE'",
-                __FUNCTION__, imageFile);
+    CLog::LogF(LOGERROR,
+               "Interface_General: To use given image file '{}' must be type value set to "
+               "'QUEUE_OWN_STYLE'",
+               imageFile);
     }
 
     CGUIDialogKaiToast::QueueNotification(usedType, usedHeader, message, 3000, withSound);
@@ -204,8 +200,8 @@ void Interface_General::get_md5(void* kodiBase, const char* text, char* md5)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || text == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_General::{} - invalid data (addon='{}', text='{}')",
-              __FUNCTION__, kodiBase, static_cast<const void*>(text));
+    CLog::LogF(LOGERROR, "Interface_General: invalid data (addon='{}', text='{}')", kodiBase,
+               static_cast<const void*>(text));
     return;
   }
 
@@ -218,8 +214,8 @@ char* Interface_General::get_region(void* kodiBase, const char* id)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || id == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_General::{} - invalid data (addon='{}', id='{}')", __FUNCTION__,
-              kodiBase, static_cast<const void*>(id));
+    CLog::LogF(LOGERROR, "Interface_General: invalid data (addon='{}', id='{}')", kodiBase,
+               static_cast<const void*>(id));
     return nullptr;
   }
 
@@ -264,8 +260,8 @@ char* Interface_General::get_region(void* kodiBase, const char* id)
                                  g_langInfo.GetMeridiemSymbol(MeridiemSymbolPM));
   else
   {
-    CLog::Log(LOGERROR, "Interface_General::{} -  add-on '{}' requests invalid id '{}'",
-              __FUNCTION__, addon->Name(), id);
+    CLog::LogF(LOGERROR, "Interface_General:  add-on '{}' requests invalid id '{}'", addon->Name(),
+               id);
     return nullptr;
   }
 
@@ -278,8 +274,8 @@ void Interface_General::get_free_mem(void* kodiBase, long* free, long* total, bo
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || free == nullptr || total == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_General::{} - invalid data (addon='{}', free='{}', total='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(free), static_cast<void*>(total));
+    CLog::LogF(LOGERROR, "Interface_General: invalid data (addon='{}', free='{}', total='{}')",
+               kodiBase, static_cast<void*>(free), static_cast<void*>(total));
     return;
   }
 
@@ -299,8 +295,7 @@ int Interface_General::get_global_idle_time(void* kodiBase)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_General::{} - invalid data (addon='{}')", __FUNCTION__,
-              kodiBase);
+    CLog::LogF(LOGERROR, "Interface_General: invalid data (addon='{}')", kodiBase);
     return -1;
   }
 
@@ -317,11 +312,10 @@ bool Interface_General::is_addon_avilable(void* kodiBase,
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || id == nullptr || version == nullptr || enabled == nullptr)
   {
-    CLog::Log(
-        LOGERROR,
-        "Interface_General::{} - invalid data (addon='{}', id='{}', version='{}', enabled='{}')",
-        __FUNCTION__, kodiBase, static_cast<const void*>(id), static_cast<void*>(version),
-        static_cast<void*>(enabled));
+    CLog::LogF(LOGERROR,
+               "Interface_General: invalid data (addon='{}', id='{}', version='{}', enabled='{}')",
+               kodiBase, static_cast<const void*>(id), static_cast<void*>(version),
+               static_cast<void*>(enabled));
     return false;
   }
 
@@ -340,12 +334,12 @@ void Interface_General::kodi_version(void* kodiBase, char** compile_name, int* m
   if (addon == nullptr || compile_name == nullptr || major == nullptr || minor == nullptr ||
      revision == nullptr || tag == nullptr || tagversion == nullptr)
   {
-    CLog::Log(LOGERROR,
-              "Interface_General::{} - invalid data (addon='{}', compile_name='{}', major='{}', "
-              "minor='{}', revision='{}', tag='{}', tagversion='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(compile_name), static_cast<void*>(major),
-              static_cast<void*>(minor), static_cast<void*>(revision), static_cast<void*>(tag),
-              static_cast<void*>(tagversion));
+    CLog::LogF(LOGERROR,
+               "Interface_General: invalid data (addon='{}', compile_name='{}', major='{}', "
+               "minor='{}', revision='{}', tag='{}', tagversion='{}')",
+               kodiBase, static_cast<void*>(compile_name), static_cast<void*>(major),
+               static_cast<void*>(minor), static_cast<void*>(revision), static_cast<void*>(tag),
+               static_cast<void*>(tagversion));
     return;
   }
 
@@ -380,8 +374,7 @@ char* Interface_General::get_current_skin_id(void* kodiBase)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_General::{} - invalid data (addon='{}')", __FUNCTION__,
-              kodiBase);
+    CLog::LogF(LOGERROR, "Interface_General: invalid data (addon='{}')", kodiBase);
     return nullptr;
   }
 
@@ -393,10 +386,9 @@ bool Interface_General::get_keyboard_layout(void* kodiBase, char** layout_name, 
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || c_layout == nullptr || layout_name == nullptr)
   {
-    CLog::Log(LOGERROR,
-              "Interface_General::{} - invalid data (addon='{}', c_layout='{}', layout_name='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(c_layout),
-              static_cast<void*>(layout_name));
+    CLog::LogF(LOGERROR,
+               "Interface_General: invalid data (addon='{}', c_layout='{}', layout_name='{}')",
+               kodiBase, static_cast<void*>(c_layout), static_cast<void*>(layout_name));
     return false;
   }
 
@@ -431,8 +423,8 @@ bool Interface_General::change_keyboard_layout(void* kodiBase, char** layout_nam
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || layout_name == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_General::{} - invalid data (addon='{}', layout_name='{}')",
-              __FUNCTION__, kodiBase, static_cast<void*>(layout_name));
+    CLog::LogF(LOGERROR, "Interface_General: invalid data (addon='{}', layout_name='{}')", kodiBase,
+               static_cast<void*>(layout_name));
     return false;
   }
 

--- a/xbmc/addons/interfaces/Network.cpp
+++ b/xbmc/addons/interfaces/Network.cpp
@@ -49,8 +49,8 @@ bool Interface_Network::wake_on_lan(void* kodiBase, const char* mac)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || mac == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Network::{} - invalid data (addon='{}', mac='{}')", __FUNCTION__,
-              kodiBase, static_cast<const void*>(mac));
+    CLog::LogF(LOGERROR, "Interface_Network: invalid data (addon='{}', mac='{}')", kodiBase,
+               static_cast<const void*>(mac));
     return false;
   }
 
@@ -62,8 +62,7 @@ char* Interface_Network::get_ip_address(void* kodiBase)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Network::{} - invalid data (addon='{}')", __FUNCTION__,
-              kodiBase);
+    CLog::LogF(LOGERROR, "Interface_Network: invalid data (addon='{}')", kodiBase);
     return nullptr;
   }
 
@@ -85,8 +84,7 @@ char* Interface_Network::get_hostname(void* kodiBase)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Network::{} - invalid data (addon='{}')", __FUNCTION__,
-              kodiBase);
+    CLog::LogF(LOGERROR, "Interface_Network: invalid data (addon='{}')", kodiBase);
     return nullptr;
   }
 
@@ -105,8 +103,7 @@ char* Interface_Network::get_user_agent(void* kodiBase)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Network::{} - invalid data (addon='{}')", __FUNCTION__,
-              kodiBase);
+    CLog::LogF(LOGERROR, "Interface_Network: invalid data (addon='{}')", kodiBase);
     return nullptr;
   }
 
@@ -122,8 +119,8 @@ bool Interface_Network::is_local_host(void* kodiBase, const char* hostname)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || hostname == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Network::{} - invalid data (addon='{}', hostname='{}')",
-              __FUNCTION__, kodiBase, static_cast<const void*>(hostname));
+    CLog::LogF(LOGERROR, "Interface_Network: invalid data (addon='{}', hostname='{}')", kodiBase,
+               static_cast<const void*>(hostname));
     return false;
   }
 
@@ -135,8 +132,8 @@ bool Interface_Network::is_host_on_lan(void* kodiBase, const char* hostname, boo
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || hostname == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Network::{} - invalid data (addon='{}', hostname='{}')",
-              __FUNCTION__, kodiBase, static_cast<const void*>(hostname));
+    CLog::LogF(LOGERROR, "Interface_Network: invalid data (addon='{}', hostname='{}')", kodiBase,
+               static_cast<const void*>(hostname));
     return false;
   }
 
@@ -148,8 +145,8 @@ char* Interface_Network::dns_lookup(void* kodiBase, const char* url, bool* ret)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || url == nullptr || ret == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Network::{} - invalid data (addon='{}', url='{}', ret='{}')",
-              __FUNCTION__, kodiBase, static_cast<const void*>(url), static_cast<void*>(ret));
+    CLog::LogF(LOGERROR, "Interface_Network: invalid data (addon='{}', url='{}', ret='{}')",
+               kodiBase, static_cast<const void*>(url), static_cast<void*>(ret));
     return nullptr;
   }
 
@@ -166,8 +163,8 @@ char* Interface_Network::url_encode(void* kodiBase, const char* url)
   CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
   if (addon == nullptr || url == nullptr)
   {
-    CLog::Log(LOGERROR, "Interface_Network::{} - invalid data (addon='{}', url='{}')", __FUNCTION__,
-              kodiBase, static_cast<const void*>(url));
+    CLog::LogF(LOGERROR, "Interface_Network: invalid data (addon='{}', url='{}')", kodiBase,
+               static_cast<const void*>(url));
     return nullptr;
   }
 

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -486,8 +486,7 @@ bool CApplication::CreateGUI()
 
   for (auto& windowSystem : windowSystems)
   {
-    CLog::Log(LOGDEBUG, "CApplication::{} - trying to init {} windowing system", __FUNCTION__,
-              windowSystem);
+    CLog::LogF(LOGDEBUG, "CApplication: trying to init {} windowing system", windowSystem);
     m_pWinSystem = KODI::WINDOWING::CWindowSystemFactory::CreateWindowSystem(windowSystem);
 
     if (!m_pWinSystem)
@@ -500,8 +499,7 @@ bool CApplication::CreateGUI()
 
     if (!m_pWinSystem->InitWindowSystem())
     {
-      CLog::Log(LOGDEBUG, "CApplication::{} - unable to init {} windowing system", __FUNCTION__,
-                windowSystem);
+      CLog::LogF(LOGDEBUG, "CApplication: unable to init {} windowing system", windowSystem);
       m_pWinSystem->DestroyWindowSystem();
       m_pWinSystem.reset();
       CServiceBroker::UnregisterWinSystem();
@@ -509,15 +507,14 @@ bool CApplication::CreateGUI()
     }
     else
     {
-      CLog::Log(LOGINFO, "CApplication::{} - using the {} windowing system", __FUNCTION__,
-                windowSystem);
+      CLog::LogF(LOGINFO, "CApplication: using the {} windowing system", windowSystem);
       break;
     }
   }
 
   if (!m_pWinSystem)
   {
-    CLog::Log(LOGFATAL, "CApplication::{} - unable to init windowing system", __FUNCTION__);
+    CLog::LogF(LOGFATAL, "CApplication: unable to init windowing system");
     CServiceBroker::UnregisterWinSystem();
     return false;
   }
@@ -1624,8 +1621,7 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
     {
       if (!audioengine->Suspend())
       {
-        CLog::Log(LOGINFO, "{}: Failed to suspend AudioEngine before launching external program",
-                  __FUNCTION__);
+          CLog::LogF(LOGINFO, "Failed to suspend AudioEngine before launching external program");
       }
     }
 #if defined(TARGET_DARWIN)
@@ -1640,8 +1636,7 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
     {
       if (!audioengine->Resume())
       {
-        CLog::Log(LOGFATAL, "{}: Failed to restart AudioEngine after return from external player",
-                  __FUNCTION__);
+          CLog::LogF(LOGFATAL, "Failed to restart AudioEngine after return from external player");
       }
     }
     break;
@@ -1761,7 +1756,7 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
   break;
 
   default:
-    CLog::Log(LOGERROR, "{}: Unhandled threadmessage sent, {}", __FUNCTION__, msg);
+    CLog::LogF(LOGERROR, "Unhandled threadmessage sent, {}", msg);
     break;
   }
 }
@@ -3054,8 +3049,8 @@ void CApplication::ConfigureAndEnableAddons()
         auto addonInfo = addonMgr.GetAddonInfo(addon->ID(), AddonType::UNKNOWN);
         if (addonInfo && addonMgr.IsCompatible(addonInfo))
         {
-          CLog::Log(LOGDEBUG, "CApplication::{}: enabling the compatible version of [{}].",
-                    __FUNCTION__, addon->ID());
+          CLog::LogF(LOGDEBUG, "CApplication: enabling the compatible version of [{}].",
+                     addon->ID());
           addonMgr.EnableAddon(addon->ID());
         }
         continue;

--- a/xbmc/application/ApplicationPowerHandling.cpp
+++ b/xbmc/application/ApplicationPowerHandling.cpp
@@ -503,7 +503,7 @@ void CApplicationPowerHandling::HandleShutdownMessage()
       break;
 
     default:
-      CLog::Log(LOGERROR, "{}: No valid shutdownstate matched", __FUNCTION__);
+      CLog::LogF(LOGERROR, "No valid shutdownstate matched");
       break;
   }
 }

--- a/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
+++ b/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
@@ -324,7 +324,7 @@ int CAEEncoderFFmpeg::Encode(uint8_t *in, int in_size, uint8_t *out, int out_siz
   }
   catch (const FFMpegException& caught)
   {
-    CLog::Log(LOGERROR, "CAEEncoderFFmpeg::{} - {}", __func__, caught.what());
+    CLog::LogF(LOGERROR, "CAEEncoderFFmpeg: {}", caught.what());
   }
 
   av_channel_layout_uninit(&frame->ch_layout);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -442,8 +442,8 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
       }
       {
         std::string portName = port == NULL ? "timer" : port->portName;
-        CLog::Log(LOGWARNING, "CActiveAE::{} - signal: {} from port: {} not handled for state: {}",
-                  __FUNCTION__, signal, portName, m_state);
+        CLog::LogF(LOGWARNING, "CActiveAE: signal: {} from port: {} not handled for state: {}",
+                   signal, portName, m_state);
       }
       return;
 
@@ -1035,7 +1035,7 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
       break;
 
     default: // we are in no state, should not happen
-      CLog::Log(LOGERROR, "CActiveAE::{} - no valid state: {}", __FUNCTION__, m_state);
+      CLog::LogF(LOGERROR, "CActiveAE: no valid state: {}", m_state);
       return;
     }
   } // for
@@ -1212,9 +1212,9 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
       double buffertime = (double)m_sinkFormat.m_frames / m_sinkFormat.m_sampleRate;
       if (buffertime > MAX_BUFFER_TIME)
       {
-        CLog::Log(LOGWARNING,
-                  "ActiveAE::{} - sink returned large period time of {} ms, reducing to {} ms",
-                  __FUNCTION__, (int)(buffertime * 1000), (int)(MAX_BUFFER_TIME * 1000));
+        CLog::LogF(LOGWARNING,
+                   "ActiveAE: sink returned large period time of {} ms, reducing to {} ms",
+                   (int)(buffertime * 1000), (int)(MAX_BUFFER_TIME * 1000));
         m_sinkFormat.m_frames = MAX_BUFFER_TIME * m_sinkFormat.m_sampleRate;
       }
     }
@@ -1578,14 +1578,14 @@ void CActiveAE::FlushEngine()
     bool success = reply->signal == CSinkControlProtocol::ACC;
     if (!success)
     {
-      CLog::Log(LOGERROR, "ActiveAE::{} - returned error on flush", __FUNCTION__);
+      CLog::LogF(LOGERROR, "ActiveAE: returned error on flush");
       m_extError = true;
     }
     reply->Release();
   }
   else
   {
-    CLog::Log(LOGERROR, "ActiveAE::{} - failed to flush", __FUNCTION__);
+    CLog::LogF(LOGERROR, "ActiveAE: failed to flush");
     m_extError = true;
   }
   m_stats.Reset(m_sinkFormat.m_sampleRate, m_mode == MODE_PCM);
@@ -1810,7 +1810,7 @@ bool CActiveAE::InitSink()
     if (!success)
     {
       reply->Release();
-      CLog::Log(LOGERROR, "ActiveAE::{} - returned error", __FUNCTION__);
+      CLog::LogF(LOGERROR, "ActiveAE: returned error");
       m_extError = true;
       return false;
     }
@@ -1829,7 +1829,7 @@ bool CActiveAE::InitSink()
   }
   else
   {
-    CLog::Log(LOGERROR, "ActiveAE::{} - failed to init", __FUNCTION__);
+    CLog::LogF(LOGERROR, "ActiveAE: failed to init");
     m_stats.SetSinkCacheTotal(0);
     m_stats.SetSinkLatency(0);
     AEAudioFormat invalidFormat;
@@ -1853,7 +1853,7 @@ void CActiveAE::DrainSink()
     if (!success)
     {
       reply->Release();
-      CLog::Log(LOGERROR, "ActiveAE::{} - returned error on drain", __FUNCTION__);
+      CLog::LogF(LOGERROR, "ActiveAE: returned error on drain");
       m_extError = true;
       return;
     }
@@ -1861,7 +1861,7 @@ void CActiveAE::DrainSink()
   }
   else
   {
-    CLog::Log(LOGERROR, "ActiveAE::{} - failed to drain", __FUNCTION__);
+    CLog::LogF(LOGERROR, "ActiveAE: failed to drain");
     m_extError = true;
     return;
   }
@@ -1876,14 +1876,14 @@ void CActiveAE::UnconfigureSink()
     bool success = reply->signal == CSinkControlProtocol::ACC;
     if (!success)
     {
-      CLog::Log(LOGERROR, "ActiveAE::{} - returned error", __FUNCTION__);
+      CLog::LogF(LOGERROR, "ActiveAE: returned error");
       m_extError = true;
     }
     reply->Release();
   }
   else
   {
-    CLog::Log(LOGERROR, "ActiveAE::{} - failed to unconfigure", __FUNCTION__);
+    CLog::LogF(LOGERROR, "ActiveAE: failed to unconfigure");
     m_extError = true;
   }
 
@@ -2252,7 +2252,7 @@ bool CActiveAE::RunStages()
               m_vizBuffers->m_inputSamples.push_back(viz);
             }
             else
-              CLog::Log(LOGWARNING, "ActiveAE::{} - viz ran out of free buffers", __FUNCTION__);
+              CLog::LogF(LOGWARNING, "ActiveAE: viz ran out of free buffers");
             AEDelayStatus status;
             m_stats.GetDelay(status);
             int64_t now = std::chrono::steady_clock::now().time_since_epoch().count();
@@ -2680,12 +2680,12 @@ void CActiveAE::Start()
     reply->Release();
     if (!success)
     {
-      CLog::Log(LOGERROR, "ActiveAE::{} - returned error", __FUNCTION__);
+      CLog::LogF(LOGERROR, "ActiveAE: returned error");
     }
   }
   else
   {
-    CLog::Log(LOGERROR, "ActiveAE::{} - failed to init", __FUNCTION__);
+    CLog::LogF(LOGERROR, "ActiveAE: failed to init");
   }
 
   m_inMsgEvent.Reset();
@@ -2871,13 +2871,13 @@ bool CActiveAE::Resume()
     reply->Release();
     if (!success)
     {
-      CLog::Log(LOGERROR, "ActiveAE::{} - returned error", __FUNCTION__);
+      CLog::LogF(LOGERROR, "ActiveAE: returned error");
       return false;
     }
   }
   else
   {
-    CLog::Log(LOGERROR, "ActiveAE::{} - failed to init", __FUNCTION__);
+    CLog::LogF(LOGERROR, "ActiveAE: failed to init");
     return false;
   }
 
@@ -2945,12 +2945,12 @@ void CActiveAE::OnLostDisplay()
     reply->Release();
     if (!success)
     {
-      CLog::Log(LOGERROR, "ActiveAE::{} - returned error", __FUNCTION__);
+      CLog::LogF(LOGERROR, "ActiveAE: returned error");
     }
   }
   else
   {
-    CLog::Log(LOGERROR, "ActiveAE::{} - timed out", __FUNCTION__);
+    CLog::LogF(LOGERROR, "ActiveAE: timed out");
   }
 }
 
@@ -3096,12 +3096,11 @@ IAE::SoundPtr CActiveAE::MakeSound(const std::string& file)
 
   AVPacket* avpkt = av_packet_alloc();
   if (!avpkt)
-    CLog::Log(LOGERROR, "CActiveAE::{} - av_packet_alloc failed: {}", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CActiveAE: av_packet_alloc failed: {}", strerror(errno));
 
   AVFrame* decoded_frame = av_frame_alloc();
   if (!decoded_frame)
-    CLog::Log(LOGERROR, "CActiveAE::{} - av_frame_alloc failed: {}", __FUNCTION__, strerror(errno));
+    CLog::LogF(LOGERROR, "CActiveAE: av_frame_alloc failed: {}", strerror(errno));
 
   bool error = false;
 
@@ -3336,7 +3335,7 @@ IAE::StreamPtr CActiveAE::MakeStream(AEAudioFormat& audioFormat,
     reply->Release();
   }
 
-  CLog::Log(LOGERROR, "ActiveAE::{} - could not create stream", __FUNCTION__);
+  CLog::LogF(LOGERROR, "ActiveAE: could not create stream");
   return NULL;
 }
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -352,9 +352,8 @@ void CActiveAESink::StateMachine(int signal, Protocol *port, Message *msg)
       }
       {
         std::string portName = port == nullptr ? "timer" : port->portName;
-        CLog::Log(LOGWARNING,
-                  "CActiveAESink::{} - signal: {} form port: {} not handled for state: {}",
-                  __FUNCTION__, signal, portName, m_state);
+        CLog::LogF(LOGWARNING, "CActiveAESink: signal: {} form port: {} not handled for state: {}",
+                   signal, portName, m_state);
       }
       return;
 
@@ -595,7 +594,7 @@ void CActiveAESink::StateMachine(int signal, Protocol *port, Message *msg)
       break;
 
     default: // we are in no state, should not happen
-      CLog::Log(LOGERROR, "CActiveAESink::{} - no valid state: {}", __FUNCTION__, m_state);
+      CLog::LogF(LOGERROR, "CActiveAESink: no valid state: {}", m_state);
       return;
     }
   } // for

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -88,7 +88,7 @@ void CActiveAEStream::InitRemapper()
 
   if(needRemap)
   {
-    CLog::Log(LOGDEBUG, "CActiveAEStream::{} - initialize remapper", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "CActiveAEStream: initialize remapper");
 
     m_remapper = CAEResampleFactory::Create();
     uint64_t avLayout = CAEUtil::GetAVChannelLayout(m_format.m_channelLayout);
@@ -168,7 +168,7 @@ void CActiveAEStream::RemapBuffer()
 
     if (samples != m_currentBuffer->pkt->nb_samples)
     {
-      CLog::Log(LOGERROR, "CActiveAEStream::{} - error remapping", __FUNCTION__);
+      CLog::LogF(LOGERROR, "CActiveAEStream: error remapping");
     }
 
     // swap sound packets

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINIOS.mm
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINIOS.mm
@@ -236,7 +236,7 @@ unsigned int CAAudioUnitSink::write(uint8_t *data, unsigned int frames)
     condVar.wait(mutex, timeout);
     if (!m_started && timer.IsTimePast())
     {
-      CLog::Log(LOGERROR, "{} engine didn't start in {} ms!", __FUNCTION__, timeout.count());
+      CLog::LogF(LOGERROR, "engine didn't start in {} ms!", timeout.count());
       return INT_MAX;
     }
   }
@@ -317,7 +317,7 @@ Float64 CAAudioUnitSink::getCoreAudioRealisedSampleRate()
   UInt32 ioDataSize = sizeof(outputSampleRate);
   if (AudioSessionGetProperty(kAudioSessionProperty_CurrentHardwareSampleRate,
                               &ioDataSize, &outputSampleRate) != noErr)
-    CLog::Log(LOGERROR, "{}: error getting CurrentHardwareSampleRate", __FUNCTION__);
+    CLog::LogF(LOGERROR, "error getting CurrentHardwareSampleRate");
   return outputSampleRate;
 }
 
@@ -423,20 +423,20 @@ bool CAAudioUnitSink::checkSessionProperties()
   ioDataSize = sizeof(m_outputVolume);
   if (AudioSessionGetProperty(kAudioSessionProperty_CurrentHardwareOutputVolume,
     &ioDataSize, &m_outputVolume) != noErr)
-    CLog::Log(LOGERROR, "{}: error getting CurrentHardwareOutputVolume", __FUNCTION__);
+    CLog::LogF(LOGERROR, "error getting CurrentHardwareOutputVolume");
 
   ioDataSize = sizeof(m_outputLatency);
   if (AudioSessionGetProperty(kAudioSessionProperty_CurrentHardwareOutputLatency,
     &ioDataSize, &m_outputLatency) != noErr)
-    CLog::Log(LOGERROR, "{}: error getting CurrentHardwareOutputLatency", __FUNCTION__);
+    CLog::LogF(LOGERROR, "error getting CurrentHardwareOutputLatency");
 
   ioDataSize = sizeof(m_bufferDuration);
   if (AudioSessionGetProperty(kAudioSessionProperty_CurrentHardwareIOBufferDuration,
     &ioDataSize, &m_bufferDuration) != noErr)
-    CLog::Log(LOGERROR, "{}: error getting CurrentHardwareIOBufferDuration", __FUNCTION__);
+    CLog::LogF(LOGERROR, "error getting CurrentHardwareIOBufferDuration");
 
-  CLog::Log(LOGDEBUG, "{}: volume = {:f}, latency = {:f}, buffer = {:f}", __FUNCTION__,
-            m_outputVolume, m_outputLatency, m_bufferDuration);
+  CLog::LogF(LOGDEBUG, "volume = {:f}, latency = {:f}, buffer = {:f}", m_outputVolume,
+             m_outputLatency, m_bufferDuration);
   return true;
 }
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINOSX.cpp
@@ -210,11 +210,11 @@ bool CAESinkDARWINOSX::Initialize(AEAudioFormat &format, std::string &device)
         requestedStreamIndex = deviceInstance.streamIndex;
         requestedSourceId = deviceInstance.sourceId;
         if (requestedStreamIndex != INT_MAX)
-          CLog::Log(LOGINFO, "{} pseudo device - requesting stream {}", __FUNCTION__,
-                    (unsigned int)requestedStreamIndex);
+          CLog::LogF(LOGINFO, "pseudo device - requesting stream {}",
+                     (unsigned int)requestedStreamIndex);
         if (requestedSourceId != INT_MAX)
-          CLog::Log(LOGINFO, "{} device - requesting audiosource {}", __FUNCTION__,
-                    (unsigned int)requestedSourceId);
+          CLog::LogF(LOGINFO, "device - requesting audiosource {}",
+                     (unsigned int)requestedSourceId);
         break;
       }
     }
@@ -222,7 +222,7 @@ bool CAESinkDARWINOSX::Initialize(AEAudioFormat &format, std::string &device)
 
   if (!deviceID)
   {
-    CLog::Log(LOGERROR, "{}: Unable to find device {}", __FUNCTION__, device);
+    CLog::LogF(LOGERROR, "Unable to find device {}", device);
     return false;
   }
 
@@ -240,13 +240,13 @@ bool CAESinkDARWINOSX::Initialize(AEAudioFormat &format, std::string &device)
     {
       numOutputChannels = std::min((size_t)format.m_channelLayout.Count(), (size_t)devEnum.GetNumPlanes());
       m_planes = numOutputChannels;
-      CLog::Log(LOGDEBUG, "{} Found planar audio with {} channels using {} of them.", __FUNCTION__,
-                (unsigned int)devEnum.GetNumPlanes(), (unsigned int)numOutputChannels);
+      CLog::LogF(LOGDEBUG, "Found planar audio with {} channels using {} of them.",
+                 (unsigned int)devEnum.GetNumPlanes(), (unsigned int)numOutputChannels);
     }
   }
   else
   {
-    CLog::Log(LOGERROR, "{}, Unable to find suitable stream", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Unable to find suitable stream");
     return false;
   }
 
@@ -261,7 +261,7 @@ bool CAESinkDARWINOSX::Initialize(AEAudioFormat &format, std::string &device)
     }
     else
     {
-      CLog::Log(LOGERROR, "{}, Unable to find suitable virtual stream", __FUNCTION__);
+      CLog::LogF(LOGERROR, "Unable to find suitable virtual stream");
       //return false;
       numOutputChannelsVirt = 0;
     }
@@ -278,15 +278,14 @@ bool CAESinkDARWINOSX::Initialize(AEAudioFormat &format, std::string &device)
   if (passthrough && numOutputChannelsVirt == 0)
   {
     m_outputBitstream = true;
-    CLog::Log(LOGDEBUG, "{}: Bitstream passthrough with float -> int16 conversion enabled",
-              __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "Bitstream passthrough with float -> int16 conversion enabled");
   }
 
   std::string formatString;
-  CLog::Log(LOGDEBUG, "{}: Selected stream[{}] - id: {:#04X}, Physical Format: {} {}", __FUNCTION__,
-            (unsigned int)m_outputBufferIndex, (unsigned int)outputStream,
-            StreamDescriptionToString(outputFormat, formatString),
-            passthrough ? "passthrough" : "");
+  CLog::LogF(LOGDEBUG, "Selected stream[{}] - id: {:#04X}, Physical Format: {} {}",
+             (unsigned int)m_outputBufferIndex, (unsigned int)outputStream,
+             StreamDescriptionToString(outputFormat, formatString),
+             passthrough ? "passthrough" : "");
 
   m_device.Open(deviceID);
   SetHogMode(passthrough);
@@ -297,23 +296,23 @@ bool CAESinkDARWINOSX::Initialize(AEAudioFormat &format, std::string &device)
   AudioStreamBasicDescription virtualFormat, previousPhysicalFormat;
   m_outputStream.GetVirtualFormat(&virtualFormat);
   m_outputStream.GetPhysicalFormat(&previousPhysicalFormat);
-  CLog::Log(LOGDEBUG, "{}: Previous Virtual Format: {}", __FUNCTION__,
-            StreamDescriptionToString(virtualFormat, formatString));
-  CLog::Log(LOGDEBUG, "{}: Previous Physical Format: {}", __FUNCTION__,
-            StreamDescriptionToString(previousPhysicalFormat, formatString));
+  CLog::LogF(LOGDEBUG, "Previous Virtual Format: {}",
+             StreamDescriptionToString(virtualFormat, formatString));
+  CLog::LogF(LOGDEBUG, "Previous Physical Format: {}",
+             StreamDescriptionToString(previousPhysicalFormat, formatString));
 
   m_outputStream.SetPhysicalFormat(&outputFormat); // Set the active format (the old one will be reverted when we close)
   if (passthrough && numOutputChannelsVirt > 0)
     m_outputStream.SetVirtualFormat(&outputFormatVirt);
 
   m_outputStream.GetVirtualFormat(&virtualFormat);
-  CLog::Log(LOGDEBUG, "{}: New Virtual Format: {}", __FUNCTION__,
-            StreamDescriptionToString(virtualFormat, formatString));
-  CLog::Log(LOGDEBUG, "{}: New Physical Format: {}", __FUNCTION__,
-            StreamDescriptionToString(outputFormat, formatString));
+  CLog::LogF(LOGDEBUG, "New Virtual Format: {}",
+             StreamDescriptionToString(virtualFormat, formatString));
+  CLog::LogF(LOGDEBUG, "New Physical Format: {}",
+             StreamDescriptionToString(outputFormat, formatString));
 
   if (requestedSourceId != INT_MAX && !m_device.SetDataSource(requestedSourceId))
-    CLog::Log(LOGERROR, "{}: Error setting requested audio source.", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Error setting requested audio source.");
 
   m_latentFrames = m_device.GetNumLatencyFrames();
   m_latentFrames += m_outputStream.GetNumLatencyFrames();
@@ -330,8 +329,8 @@ bool CAESinkDARWINOSX::Initialize(AEAudioFormat &format, std::string &device)
 
   unsigned int num_buffers = 4;
   m_buffer = new AERingBuffer(num_buffers * format.m_frames * m_frameSizePerPlane, m_planes);
-  CLog::Log(LOGDEBUG, "{}: using buffer size: {} ({:f} ms)", __FUNCTION__, m_buffer->GetMaxSize(),
-            (float)m_buffer->GetMaxSize() / (m_framesPerSecond * m_frameSizePerPlane));
+  CLog::LogF(LOGDEBUG, "using buffer size: {} ({:f} ms)", m_buffer->GetMaxSize(),
+             (float)m_buffer->GetMaxSize() / (m_framesPerSecond * m_frameSizePerPlane));
 
   if (!passthrough)
     format.m_dataFormat = (m_planes > 1) ? AE_FMT_FLOATP : AE_FMT_FLOAT;
@@ -434,7 +433,7 @@ unsigned int CAESinkDARWINOSX::AddPackets(uint8_t **data, unsigned int frames, u
     condVar.wait(mutex, timeout);
     if (!m_started && timer.IsTimePast())
     {
-      CLog::Log(LOGERROR, "{} engine didn't start in {} ms!", __FUNCTION__, timeout.count());
+      CLog::LogF(LOGERROR, "engine didn't start in {} ms!", timeout.count());
       return INT_MAX;
     }
   }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINTVOS.mm
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINTVOS.mm
@@ -373,7 +373,7 @@ unsigned int CAAudioUnitSink::write(uint8_t* data, unsigned int frames, unsigned
     condVar.wait(mutex, timeout);
     if (!m_started && timer.IsTimePast())
     {
-      CLog::Log(LOGERROR, "{} engine didn't start in {} ms!", __FUNCTION__, timeout.count());
+      CLog::LogF(LOGERROR, "engine didn't start in {} ms!", timeout.count());
       return INT_MAX;
     }
   }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
@@ -134,7 +134,7 @@ bool CAESinkXAudio::Initialize(AEAudioFormat &format, std::string &device)
 
   if (!InitializeInternal(device, format))
   {
-    CLog::Log(LOGINFO, __FUNCTION__": Could not Initialize voices with that format");
+    CLog::LogF(LOGINFO, "Could not Initialize voices with that format");
     goto failed;
   }
 
@@ -148,7 +148,7 @@ bool CAESinkXAudio::Initialize(AEAudioFormat &format, std::string &device)
   return true;
 
 failed:
-  CLog::Log(LOGERROR, __FUNCTION__": XAudio initialization failed.");
+  CLog::LogF(LOGERROR, "XAudio initialization failed.");
   return true;
 }
 
@@ -168,7 +168,7 @@ void CAESinkXAudio::Deinitialize()
     }
     catch (...)
     {
-      CLog::Log(LOGDEBUG, "{}: Invalidated source voice - Releasing", __FUNCTION__);
+      CLog::LogF(LOGDEBUG, "Invalidated source voice - Releasing");
     }
   }
   m_running = false;
@@ -345,7 +345,7 @@ void CAESinkXAudio::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
   hr = XAudio2Create(xaudio2.ReleaseAndGetAddressOf(), eflags);
   if (FAILED(hr))
   {
-    CLog::Log(LOGDEBUG, __FUNCTION__": Failed to activate XAudio for capability testing.");
+    CLog::LogF(LOGDEBUG, "Failed to activate XAudio for capability testing.");
     goto failed;
   }
 
@@ -375,9 +375,9 @@ void CAESinkXAudio::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
 
     if (FAILED(hr))
     {
-      CLog::Log(
-          LOGINFO, __FUNCTION__ ": stream type \"{}\" on device \"{}\" seems to be not supported.",
-          CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_DTSHD_MA), details.strDescription);
+      CLog::LogF(LOGINFO, "stream type \"{}\" on device \"{}\" seems to be not supported.",
+                 CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_DTSHD_MA),
+                 details.strDescription);
     }
     else
     {
@@ -404,9 +404,9 @@ void CAESinkXAudio::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
 
     if (FAILED(hr))
     {
-      CLog::Log(LOGINFO,
-                __FUNCTION__ ": stream type \"{}\" on device \"{}\" seems to be not supported.",
-                CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_DTSHD), details.strDescription);
+      CLog::LogF(LOGINFO, "stream type \"{}\" on device \"{}\" seems to be not supported.",
+                 CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_DTSHD),
+                 details.strDescription);
     }
     else
     {
@@ -423,9 +423,9 @@ void CAESinkXAudio::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
     hr = xaudio2->CreateSourceVoice(&mSourceVoice, &wfxex.Format);
     if (FAILED(hr))
     {
-      CLog::Log(
-          LOGINFO, __FUNCTION__ ": stream type \"{}\" on device \"{}\" seems to be not supported.",
-          CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_TRUEHD), details.strDescription);
+      CLog::LogF(LOGINFO, "stream type \"{}\" on device \"{}\" seems to be not supported.",
+                 CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_TRUEHD),
+                 details.strDescription);
     }
     else
     {
@@ -447,9 +447,8 @@ void CAESinkXAudio::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
 
     if (FAILED(hr))
     {
-      CLog::Log(LOGINFO,
-                __FUNCTION__ ": stream type \"{}\" on device \"{}\" seems to be not supported.",
-                CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_EAC3), details.strDescription);
+      CLog::LogF(LOGINFO, "stream type \"{}\" on device \"{}\" seems to be not supported.",
+                 CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_EAC3), details.strDescription);
     }
     else
     {
@@ -471,9 +470,8 @@ void CAESinkXAudio::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
     hr = xaudio2->CreateSourceVoice(&mSourceVoice, &wfxex.Format);
     if (FAILED(hr))
     {
-      CLog::Log(LOGINFO,
-                __FUNCTION__ ": stream type \"{}\" on device \"{}\" seems to be not supported.",
-                "STREAM_TYPE_DTS", details.strDescription);
+      CLog::LogF(LOGINFO, "stream type \"{}\" on device \"{}\" seems to be not supported.",
+                 "STREAM_TYPE_DTS", details.strDescription);
     }
     else
     {
@@ -490,9 +488,8 @@ void CAESinkXAudio::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
     hr = xaudio2->CreateSourceVoice(&mSourceVoice, &wfxex.Format);
     if (FAILED(hr))
     {
-      CLog::Log(LOGINFO,
-                __FUNCTION__ ": stream type \"{}\" on device \"{}\" seems to be not supported.",
-                CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_AC3), details.strDescription);
+      CLog::LogF(LOGINFO, "stream type \"{}\" on device \"{}\" seems to be not supported.",
+                 CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_AC3), details.strDescription);
     }
     else
     {
@@ -560,9 +557,8 @@ void CAESinkXAudio::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
       else if (wfxex.Format.nSamplesPerSec == 192000 && add192)
       {
         deviceInfo.m_sampleRates.push_back(WASAPISampleRates[j]);
-        CLog::Log(LOGINFO,
-                  __FUNCTION__ ": sample rate 192khz on device \"{}\" seems to be not supported.",
-                  details.strDescription);
+        CLog::LogF(LOGINFO, "sample rate 192khz on device \"{}\" seems to be not supported.",
+                   details.strDescription);
       }
     }
     SafeDestroyVoice(&mSourceVoice);
@@ -597,8 +593,7 @@ void CAESinkXAudio::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
 failed:
 
   if (FAILED(hr))
-    CLog::Log(LOGERROR, __FUNCTION__ ": Failed to enumerate XAudio endpoint devices ({}).",
-              WASAPIErrToStr(hr));
+    CLog::LogF(LOGERROR, "Failed to enumerate XAudio endpoint devices ({}).", WASAPIErrToStr(hr));
 }
 
 /// ------------------- Private utility functions -----------------------------------
@@ -652,10 +647,10 @@ bool CAESinkXAudio::InitializeInternal(std::string deviceId, AEAudioFormat &form
   {
     if (!bdefault)
     {
-      CLog::Log(LOGINFO,
-                __FUNCTION__ ": Could not locate the device named \"{}\" in the list of Xaudio "
-                             "endpoint devices. Trying the default device...",
-                KODI::PLATFORM::WINDOWS::FromW(device));
+      CLog::LogF(LOGINFO,
+                 "Could not locate the device named \"{}\" in the list of Xaudio "
+                 "endpoint devices. Trying the default device...",
+                 KODI::PLATFORM::WINDOWS::FromW(device));
     }
 
     // smartphone issue: providing device ID (even default ID) causes E_NOINTERFACE result
@@ -664,9 +659,8 @@ bool CAESinkXAudio::InitializeInternal(std::string deviceId, AEAudioFormat &form
                                           0, 0, nullptr, AudioCategory_Media);
     if (FAILED(hr) || !pMasterVoice)
     {
-      CLog::Log(LOGINFO,
-                __FUNCTION__ ": Could not retrieve the default XAudio audio endpoint ({}).",
-                WASAPIErrToStr(hr));
+      CLog::LogF(LOGINFO, "Could not retrieve the default XAudio audio endpoint ({}).",
+                 WASAPIErrToStr(hr));
       return false;
     }
   }
@@ -680,7 +674,7 @@ bool CAESinkXAudio::InitializeInternal(std::string deviceId, AEAudioFormat &form
   hr = m_xAudio2->CreateSourceVoice(&m_sourceVoice, &wfxex.Format, 0, XAUDIO2_DEFAULT_FREQ_RATIO, &m_voiceCallback);
   if (SUCCEEDED(hr))
   {
-    CLog::Log(LOGINFO, __FUNCTION__": Format is Supported - will attempt to Initialize");
+    CLog::LogF(LOGINFO, "Format is Supported - will attempt to Initialize");
     goto initialize;
   }
 
@@ -688,9 +682,8 @@ bool CAESinkXAudio::InitializeInternal(std::string deviceId, AEAudioFormat &form
     return false;
 
   if (CServiceBroker::GetLogging().CanLogComponent(LOGAUDIO))
-    CLog::Log(LOGDEBUG,
-              __FUNCTION__ ": CreateSourceVoice failed ({}) - trying to find a compatible format",
-              WASAPIErrToStr(hr));
+    CLog::LogF(LOGDEBUG, "CreateSourceVoice failed ({}) - trying to find a compatible format",
+               WASAPIErrToStr(hr));
 
   requestedChannels = wfxex.Format.nChannels;
 
@@ -745,7 +738,7 @@ bool CAESinkXAudio::InitializeInternal(std::string deviceId, AEAudioFormat &form
         }
 
         if (FAILED(hr))
-          CLog::Log(LOGERROR, __FUNCTION__ ": creating voices failed ({})", WASAPIErrToStr(hr));
+          CLog::LogF(LOGERROR, "creating voices failed ({})", WASAPIErrToStr(hr));
       }
 
       if (closestMatch >= 0)
@@ -757,7 +750,8 @@ bool CAESinkXAudio::InitializeInternal(std::string deviceId, AEAudioFormat &form
     }
   }
 
-  CLog::Log(LOGERROR, __FUNCTION__": Unable to locate a supported output format for the device.  Check the speaker settings in the control panel.");
+  CLog::LogF(LOGERROR, "Unable to locate a supported output format for the device.  Check the "
+                       "speaker settings in the control panel.");
 
   /* We couldn't find anything supported. This should never happen      */
   /* unless the user set the wrong speaker setting in the control panel */
@@ -800,7 +794,7 @@ initialize:
   hr = m_sourceVoice->Start(0, XAUDIO2_COMMIT_NOW);
   if (FAILED(hr))
   {
-    CLog::Log(LOGERROR, __FUNCTION__ ": Voice start failed : {}", WASAPIErrToStr(hr));
+    CLog::LogF(LOGERROR, "Voice start failed : {}", WASAPIErrToStr(hr));
     CLog::Log(LOGDEBUG, "  Sample Rate     : {}", wfxex.Format.nSamplesPerSec);
     CLog::Log(LOGDEBUG, "  Sample Format   : {}", CAEUtil::DataFormatToStr(format.m_dataFormat));
     CLog::Log(LOGDEBUG, "  Bits Per Sample : {}", wfxex.Format.wBitsPerSample);
@@ -819,7 +813,7 @@ initialize:
   m_xAudio2->GetPerformanceData(&perfData);
   if (!perfData.TotalSourceVoiceCount)
   {
-    CLog::Log(LOGERROR, __FUNCTION__ ": GetPerformanceData Failed : {}", WASAPIErrToStr(hr));
+    CLog::LogF(LOGERROR, "GetPerformanceData Failed : {}", WASAPIErrToStr(hr));
     return false;
   }
 
@@ -829,9 +823,9 @@ initialize:
   m_dwBufferLen = m_dwChunkSize * 4;
   m_AvgBytesPerSec = wfxex.Format.nAvgBytesPerSec;
 
-  CLog::Log(LOGINFO, __FUNCTION__ ": XAudio Sink Initialized using: {}, {}, {}",
-            CAEUtil::DataFormatToStr(format.m_dataFormat), wfxex.Format.nSamplesPerSec,
-            wfxex.Format.nChannels);
+  CLog::LogF(LOGINFO, "XAudio Sink Initialized using: {}, {}, {}",
+             CAEUtil::DataFormatToStr(format.m_dataFormat), wfxex.Format.nSamplesPerSec,
+             wfxex.Format.nChannels);
 
   m_sourceVoice->Stop();
 
@@ -859,7 +853,7 @@ void CAESinkXAudio::Drain()
     }
     catch (...)
     {
-      CLog::Log(LOGDEBUG, "{}: Invalidated source voice - Releasing", __FUNCTION__);
+      CLog::LogF(LOGDEBUG, "Invalidated source voice - Releasing");
     }
   }
   m_running = false;

--- a/xbmc/cores/AudioEngine/Sinks/osx/AEDeviceEnumerationOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/osx/AEDeviceEnumerationOSX.cpp
@@ -451,8 +451,7 @@ AESampleRateList AEDeviceEnumerationOSX::getSampleRateListForStream(UInt32 strea
     // the "fixed" audio config to force one of them
     if (formatDesc.mSampleRate == kAudioStreamAnyRate)
     {
-      CLog::Log(LOGINFO, "{} reported samplerate is kAudioStreamAnyRate adding 44.1khz and 48khz",
-                __FUNCTION__);
+      CLog::LogF(LOGINFO, "reported samplerate is kAudioStreamAnyRate adding 44.1khz and 48khz");
       formatDesc.mSampleRate = 44100;
       if (!hasSampleRate(returnSampleRateList, formatDesc.mSampleRate))
         returnSampleRateList.push_back(formatDesc.mSampleRate);
@@ -505,10 +504,9 @@ std::string AEDeviceEnumerationOSX::getExtraDisplayNameForStream(UInt32 streamId
     extraName << startChannel;
     extraName << " - ";
     extraName << startChannel + numChannels - 1;
-    CLog::Log(LOGINFO,
-              "{} adding stream {} as pseudo device with start channel {} and {} channels total",
-              __FUNCTION__, (unsigned int)streamIdx, (unsigned int)startChannel,
-              (unsigned int)numChannels);
+    CLog::LogF(LOGINFO,
+               "adding stream {} as pseudo device with start channel {} and {} channels total",
+               (unsigned int)streamIdx, (unsigned int)startChannel, (unsigned int)numChannels);
     return extraName.str();
   }
 
@@ -578,8 +576,8 @@ float AEDeviceEnumerationOSX::ScoreFormat(const AudioStreamBasicDescription &for
 
 bool AEDeviceEnumerationOSX::FindSuitableFormatForStream(UInt32 &streamIdx, const AEAudioFormat &format, bool virt, AudioStreamBasicDescription &outputFormat, AudioStreamID &outputStream) const
 {
-  CLog::Log(LOGDEBUG, "{}: Finding stream for format {}", __FUNCTION__,
-            CAEUtil::DataFormatToStr(format.m_dataFormat));
+  CLog::LogF(LOGDEBUG, "Finding stream for format {}",
+             CAEUtil::DataFormatToStr(format.m_dataFormat));
 
   bool                        formatFound  = false;
   float                       outputScore  = 0;
@@ -621,11 +619,11 @@ bool AEDeviceEnumerationOSX::FindSuitableFormatForStream(UInt32 &streamIdx, cons
 
       std::string formatString;
       if (!virt)
-        CLog::Log(LOGDEBUG, "{}: Physical Format: {} rated {:f}", __FUNCTION__,
-                  StreamDescriptionToString(formatDesc, formatString), score);
+        CLog::LogF(LOGDEBUG, "Physical Format: {} rated {:f}",
+                   StreamDescriptionToString(formatDesc, formatString), score);
       else
-        CLog::Log(LOGDEBUG, "{}: Virtual Format: {} rated {:f}", __FUNCTION__,
-                  StreamDescriptionToString(formatDesc, formatString), score);
+        CLog::LogF(LOGDEBUG, "Virtual Format: {} rated {:f}",
+                   StreamDescriptionToString(formatDesc, formatString), score);
 
       if (score > outputScore)
       {
@@ -799,15 +797,14 @@ void AEDeviceEnumerationOSX::GetAEChannelMap(CAEChannelInfo &channelMap, unsigne
 
   if (logMapping)
   {
-    CLog::Log(LOGDEBUG, "{} Engine requests layout {}", __FUNCTION__, ((std::string)channelMap));
+    CLog::LogF(LOGDEBUG, "Engine requests layout {}", ((std::string)channelMap));
 
     if (mapAvailable)
-      CLog::Log(LOGDEBUG, "{} trying to map to {} layout: {}", __FUNCTION__,
-                channelsPerFrame == 2 ? "stereo" : "multichannel",
-                calayout.ChannelLayoutToString(*layout, layoutStr));
+      CLog::LogF(LOGDEBUG, "trying to map to {} layout: {}",
+                 channelsPerFrame == 2 ? "stereo" : "multichannel",
+                 calayout.ChannelLayoutToString(*layout, layoutStr));
     else
-      CLog::Log(LOGDEBUG, "{} no map available - using static multichannel map layout",
-                __FUNCTION__);
+      CLog::LogF(LOGDEBUG, "no map available - using static multichannel map layout");
   }
 
   channelMap.Reset();// start with an empty map
@@ -833,5 +830,5 @@ void AEDeviceEnumerationOSX::GetAEChannelMap(CAEChannelInfo &channelMap, unsigne
   }
 
   if (logMapping)
-    CLog::Log(LOGDEBUG, "{} mapped channels to layout {}", __FUNCTION__, ((std::string)channelMap));
+    CLog::LogF(LOGDEBUG, "mapped channels to layout {}", ((std::string)channelMap));
 }

--- a/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/osx/CoreAudioDevice.cpp
@@ -895,9 +895,9 @@ void CCoreAudioDevice::RegisterDeviceChangedCB(bool bRegister, AudioObjectProper
         ret = AudioObjectRemovePropertyListener(kAudioObjectSystemObject, &inAdr, callback, ref);
 
     if (ret != noErr)
-      CLog::Log(LOGERROR,
-                "CCoreAudioAE::Deinitialize - error {} a listener callback for device changes!",
-                bRegister ? "attaching" : "removing");
+        CLog::Log(LOGERROR,
+                  "CCoreAudioAE::Deinitialize - error {} a listener callback for device changes!",
+                  bRegister ? "attaching" : "removing");
 }
 
 void CCoreAudioDevice::RegisterDefaultOutputDeviceChangedCB(bool bRegister, AudioObjectPropertyListenerProc callback, void *ref)
@@ -928,10 +928,10 @@ void CCoreAudioDevice::RegisterDefaultOutputDeviceChangedCB(bool bRegister, Audi
     }
 
     if (ret != noErr)
-      CLog::Log(LOGERROR,
-                "CCoreAudioAE::Deinitialize - error {} a listener callback for default output "
-                "device changes!",
-                bRegister ? "attaching" : "removing");
+        CLog::Log(LOGERROR,
+                  "CCoreAudioAE::Deinitialize - error {} a listener callback for default output "
+                  "device changes!",
+                  bRegister ? "attaching" : "removing");
     else
         registered = bRegister ? 1 : 0;
 }

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -324,9 +324,7 @@ void CAESinkPipewire::EnumerateDevicesEx(AEDeviceInfoList& list, bool force)
     int ret = loop.Wait(5s);
     if (ret == -ETIMEDOUT)
     {
-      CLog::Log(LOGDEBUG,
-                "CAESinkPipewire::{} - timed out out waiting for formats to be enumerated",
-                __FUNCTION__);
+      CLog::LogF(LOGDEBUG, "CAESinkPipewire: timed out out waiting for formats to be enumerated");
       continue;
     }
 
@@ -475,16 +473,14 @@ bool CAESinkPipewire::Initialize(AEAudioFormat& format, std::string& device)
   if (!m_stream->Connect(id, PW_DIRECTION_OUTPUT, params, flags))
     return false;
 
-  CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - rate: {}", __FUNCTION__, format.m_sampleRate);
-  CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - channels: {}", __FUNCTION__, pwChannels.size());
-  CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - format: {}", __FUNCTION__, PWFormatToString(pwFormat));
-  CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - samplesize: {}", __FUNCTION__,
-            PWFormatToSampleSize(pwFormat));
-  CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - framesize: {}", __FUNCTION__,
-            pwChannels.size() * PWFormatToSampleSize(pwFormat));
-  CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - latency: {}/{} ({:.3f}s)", __FUNCTION__, frames,
-            format.m_sampleRate,
-            static_cast<double>(frames) / DEFAULT_LATENCY_DIVIDER / format.m_sampleRate);
+  CLog::LogF(LOGDEBUG, "CAESinkPipewire: rate: {}", format.m_sampleRate);
+  CLog::LogF(LOGDEBUG, "CAESinkPipewire: channels: {}", pwChannels.size());
+  CLog::LogF(LOGDEBUG, "CAESinkPipewire: format: {}", PWFormatToString(pwFormat));
+  CLog::LogF(LOGDEBUG, "CAESinkPipewire: samplesize: {}", PWFormatToSampleSize(pwFormat));
+  CLog::LogF(LOGDEBUG, "CAESinkPipewire: framesize: {}",
+             pwChannels.size() * PWFormatToSampleSize(pwFormat));
+  CLog::LogF(LOGDEBUG, "CAESinkPipewire: latency: {}/{} ({:.3f}s)", frames, format.m_sampleRate,
+             static_cast<double>(frames) / format.m_sampleRate);
 
   pw_stream_state state;
   do
@@ -493,18 +489,17 @@ bool CAESinkPipewire::Initialize(AEAudioFormat& format, std::string& device)
     if (state == PW_STREAM_STATE_PAUSED)
       break;
 
-    CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - waiting", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "CAESinkPipewire: waiting");
 
     int ret = loop.Wait(5s);
     if (ret == -ETIMEDOUT)
     {
-      CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - timed out waiting for stream to be paused",
-                __FUNCTION__);
+      CLog::LogF(LOGDEBUG, "CAESinkPipewire: timed out waiting for stream to be paused");
       return false;
     }
   } while (state != PW_STREAM_STATE_PAUSED);
 
-  CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - initialized", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CAESinkPipewire: initialized");
 
   format.m_frameSize = pwChannels.size() * PWFormatToSampleSize(pwFormat);
   format.m_frames = frames;
@@ -624,6 +619,6 @@ void CAESinkPipewire::Drain()
   int ret = loop.Wait(1s);
   if (ret == -ETIMEDOUT)
   {
-    CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - wait timed out, already drained?", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "CAESinkPipewire: wait timed out, already drained?");
   }
 }

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireNode.cpp
@@ -50,7 +50,7 @@ void CPipewireNode::Info(void* userdata, const struct pw_node_info* info)
 
   if (node.m_info)
   {
-    CLog::Log(LOGDEBUG, "CPipewireNode::{} - node {} changed", __FUNCTION__, info->id);
+    CLog::LogF(LOGDEBUG, "CPipewireNode: node {} changed", info->id);
     pw_node_info* m_info = node.m_info.get();
     m_info = pw_node_info_update(m_info, info);
   }

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireProxy.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireProxy.cpp
@@ -42,7 +42,7 @@ CPipewireProxy::~CPipewireProxy()
 
 void CPipewireProxy::Bound(void* userdata, uint32_t id)
 {
-  CLog::Log(LOGDEBUG, "CPipewireProxy::{} - id={}", __FUNCTION__, id);
+  CLog::LogF(LOGDEBUG, "CPipewireProxy: id={}", id);
 
   auto AE = CServiceBroker::GetActiveAE();
   if (AE)
@@ -51,7 +51,7 @@ void CPipewireProxy::Bound(void* userdata, uint32_t id)
 
 void CPipewireProxy::Removed(void* userdata)
 {
-  CLog::Log(LOGDEBUG, "CPipewireProxy::{}", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CPipewireProxy");
 
   auto AE = CServiceBroker::GetActiveAE();
   if (AE)

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireRegistry.cpp
@@ -92,8 +92,7 @@ void CPipewireRegistry::OnGlobalRemoved(void* userdata, uint32_t id)
   if (it != globals.end())
   {
     const auto& [globalId, global] = *it;
-    CLog::Log(LOGDEBUG, "CPipewireRegistry::{} - id={} type={}", __FUNCTION__, id,
-              global->GetType());
+    CLog::LogF(LOGDEBUG, "CPipewireRegistry: id={} type={}", id, global->GetType());
 
     globals.erase(it);
   }

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
@@ -116,15 +116,14 @@ void CPipewireStream::StateChanged(void* userdata,
   auto& stream = *reinterpret_cast<CPipewireStream*>(userdata);
   auto& loop = stream.GetCore().GetContext().GetThreadLoop();
 
-  CLog::Log(LOGDEBUG, "CPipewireStream::{} - stream state changed {} -> {}", __FUNCTION__,
-            pw_stream_state_as_string(old), pw_stream_state_as_string(state));
+  CLog::LogF(LOGDEBUG, "CPipewireStream: stream state changed {} -> {}",
+             pw_stream_state_as_string(old), pw_stream_state_as_string(state));
 
   if (state == PW_STREAM_STATE_STREAMING)
-    CLog::Log(LOGDEBUG, "CPipewireStream::{} - stream node {}", __FUNCTION__, stream.GetNodeId());
+    CLog::LogF(LOGDEBUG, "CPipewireStream: stream node {}", stream.GetNodeId());
 
   if (state == PW_STREAM_STATE_ERROR)
-    CLog::Log(LOGDEBUG, "CPipewireStream::{} - stream node {} error: {}", __FUNCTION__,
-              stream.GetNodeId(), error);
+    CLog::LogF(LOGDEBUG, "CPipewireStream: stream node {} error: {}", stream.GetNodeId(), error);
 
   loop.Signal(false);
 }
@@ -144,7 +143,7 @@ void CPipewireStream::Drained(void* userdata)
 
   stream.SetActive(false);
 
-  CLog::Log(LOGDEBUG, "CPipewireStream::{}", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CPipewireStream");
 
   loop.Signal(false);
 }

--- a/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin10.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin10.cpp
@@ -112,7 +112,7 @@ std::vector<RendererDetail> CAESinkFactoryWin::GetRendererDetails()
   }
 
 failed:
-  CLog::Log(LOGERROR, __FUNCTION__": Failed to enumerate audio renderer devices.");
+  CLog::LogF(LOGERROR, "Failed to enumerate audio renderer devices.");
   return list;
 }
 

--- a/xbmc/cores/AudioEngine/Utils/AEUtil.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEUtil.cpp
@@ -39,8 +39,9 @@ double AEDelayStatus::GetDelay() const
 
 CAEChannelInfo CAEUtil::GuessChLayout(const unsigned int channels)
 {
-  CLog::Log(LOGWARNING, "CAEUtil::GuessChLayout - "
-    "This method should really never be used, please fix the code that called this");
+  CLog::Log(LOGWARNING,
+            "CAEUtil::GuessChLayout - "
+            "This method should really never be used, please fix the code that called this");
 
   CAEChannelInfo result;
   if (channels < 1 || channels > 8)

--- a/xbmc/cores/DllLoader/DllLoader.cpp
+++ b/xbmc/cores/DllLoader/DllLoader.cpp
@@ -615,7 +615,7 @@ bool DllLoader::Load()
     XBMCCOMMONS_HANDLE_UNCHECKED
     catch(...)
     {
-      CLog::Log(LOGERROR, "{} - Unhandled exception during DLL_PROCESS_ATTACH", __FUNCTION__);
+      CLog::LogF(LOGERROR, "Unhandled exception during DLL_PROCESS_ATTACH");
 
       // vp7vfw.dll throws a CUserException due to a missing export
       // but the export isn't really needed for normal operation
@@ -624,8 +624,7 @@ bool DllLoader::Load()
       if (StringUtils::CompareNoCase(GetName(), "vp7vfw.dll") != 0)
         return false;
 
-
-      CLog::Log(LOGDEBUG, "{} - Ignoring exception during DLL_PROCESS_ATTACH", __FUNCTION__);
+      CLog::LogF(LOGDEBUG, "Ignoring exception during DLL_PROCESS_ATTACH");
     }
 
     // init function may have fixed up the export table

--- a/xbmc/cores/DllLoader/LibraryLoader.cpp
+++ b/xbmc/cores/DllLoader/LibraryLoader.cpp
@@ -57,6 +57,6 @@ int LibraryLoader::DecrRef()
 
 int LibraryLoader::ResolveOrdinal(unsigned long ordinal, void** ptr)
 {
-  CLog::Log(LOGWARNING, "{} - Unable to resolve {} in dll {}", __FUNCTION__, ordinal, GetName());
+  CLog::LogF(LOGWARNING, "Unable to resolve {} in dll {}", ordinal, GetName());
   return 0;
 }

--- a/xbmc/cores/DllLoader/Win32DllLoader.cpp
+++ b/xbmc/cores/DllLoader/Win32DllLoader.cpp
@@ -156,12 +156,12 @@ bool Win32DllLoader::Load()
     if (strLen != 0)
     {
       auto strMessage = FromW(lpMsgBuf, strLen);
-      CLog::Log(LOGERROR, "{}: Failed to load \"{}\" with error {}: \"{}\"", __FUNCTION__,
-                CSpecialProtocol::TranslatePath(strFileName), dw, strMessage);
+      CLog::LogF(LOGERROR, "Failed to load \"{}\" with error {}: \"{}\"",
+                 CSpecialProtocol::TranslatePath(strFileName), dw, strMessage);
     }
     else
-      CLog::Log(LOGERROR, "{}: Failed to load \"{}\" with error {}", __FUNCTION__,
-                CSpecialProtocol::TranslatePath(strFileName), dw);
+      CLog::LogF(LOGERROR, "Failed to load \"{}\" with error {}",
+                 CSpecialProtocol::TranslatePath(strFileName), dw);
 
     LocalFree(lpMsgBuf);
     return false;
@@ -182,7 +182,7 @@ void Win32DllLoader::Unload()
   if (m_dllHandle)
   {
     if (!FreeLibrary(m_dllHandle))
-      CLog::Log(LOGERROR, "{} Unable to unload {}", __FUNCTION__, GetName());
+      CLog::LogF(LOGERROR, "Unable to unload {}", GetName());
   }
 
   m_dllHandle = NULL;
@@ -193,8 +193,7 @@ int Win32DllLoader::ResolveExport(const char* symbol, void** f, bool logging)
   if (!m_dllHandle && !Load())
   {
     if (logging)
-      CLog::Log(LOGWARNING, "{} - Unable to resolve: {} {}, reason: DLL not loaded", __FUNCTION__,
-                GetName(), symbol);
+      CLog::LogF(LOGWARNING, "Unable to resolve: {} {}, reason: DLL not loaded", GetName(), symbol);
     return 0;
   }
 
@@ -203,7 +202,7 @@ int Win32DllLoader::ResolveExport(const char* symbol, void** f, bool logging)
   if (!s)
   {
     if (logging)
-      CLog::Log(LOGWARNING, "{} - Unable to resolve: {} {}", __FUNCTION__, GetName(), symbol);
+      CLog::LogF(LOGWARNING, "Unable to resolve: {} {}", GetName(), symbol);
     return 0;
   }
 
@@ -234,7 +233,7 @@ void Win32DllLoader::OverrideImports(const std::string &dll)
 
   if (!image_base)
   {
-    CLog::Log(LOGERROR, "{} - unable to GetModuleHandle for dll {}", __FUNCTION__, dll);
+    CLog::LogF(LOGERROR, "unable to GetModuleHandle for dll {}", dll);
     return;
   }
 
@@ -246,7 +245,7 @@ void Win32DllLoader::OverrideImports(const std::string &dll)
 
   if (!imp_desc)
   {
-    CLog::Log(LOGERROR, "{} - unable to get import directory for dll {}", __FUNCTION__, dll);
+    CLog::LogF(LOGERROR, "unable to get import directory for dll {}", dll);
     return;
   }
 

--- a/xbmc/cores/DllLoader/dll.cpp
+++ b/xbmc/cores/DllLoader/dll.cpp
@@ -131,7 +131,7 @@ extern "C" int __stdcall dllFreeLibrary(HINSTANCE hLibModule)
 
   if( !dllhandle )
   {
-    CLog::Log(LOGERROR, "{} - Invalid hModule specified", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Invalid hModule specified");
     return 1;
   }
 
@@ -152,7 +152,7 @@ extern "C" intptr_t (*__stdcall dllGetProcAddress(HMODULE hModule, const char* f
 
   if( !dll )
   {
-    CLog::Log(LOGERROR, "{} - Invalid hModule specified", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Invalid hModule specified");
     return NULL;
   }
 
@@ -162,8 +162,8 @@ extern "C" intptr_t (*__stdcall dllGetProcAddress(HMODULE hModule, const char* f
   {
     if( dll->ResolveOrdinal(LOW_WORD(function), &address) )
     {
-      CLog::Log(LOGDEBUG, "{}({}({}), {}) => {}", __FUNCTION__, fmt::ptr(hModule), dll->GetName(),
-                LOW_WORD(function), fmt::ptr(address));
+      CLog::LogF(LOGDEBUG, "({}({}), {}) => {}", fmt::ptr(hModule), dll->GetName(),
+                 LOW_WORD(function), fmt::ptr(address));
     }
     else if( dll->IsSystemDll() )
     {
@@ -176,22 +176,21 @@ extern "C" intptr_t (*__stdcall dllGetProcAddress(HMODULE hModule, const char* f
       if( track )
         tracker_dll_data_track(track->pDll, (uintptr_t)address);
 
-      CLog::Log(LOGDEBUG, "{} - created dummy function {}!{}", __FUNCTION__, dll->GetName(),
-                ordinal);
+      CLog::LogF(LOGDEBUG, "created dummy function {}!{}", dll->GetName(), ordinal);
     }
     else
     {
       address = NULL;
-      CLog::Log(LOGDEBUG, "{}({}({}), '{}') => {}", __FUNCTION__, fmt::ptr(hModule), dll->GetName(),
-                function, fmt::ptr(address));
+      CLog::LogF(LOGDEBUG, "({}({}), '{}') => {}", fmt::ptr(hModule), dll->GetName(), function,
+                 fmt::ptr(address));
     }
   }
   else
   {
     if( dll->ResolveExport(function, &address) )
     {
-      CLog::Log(LOGDEBUG, "{}({}({}), '{}') => {}", __FUNCTION__, fmt::ptr(hModule), dll->GetName(),
-                function, fmt::ptr(address));
+      CLog::LogF(LOGDEBUG, "({}({}), '{}') => {}", fmt::ptr(hModule), dll->GetName(), function,
+                 fmt::ptr(address));
     }
     else
     {
@@ -203,14 +202,13 @@ extern "C" intptr_t (*__stdcall dllGetProcAddress(HMODULE hModule, const char* f
       {
         address = (void*)create_dummy_function(dll->GetName(), function);
         tracker_dll_data_track(track->pDll, (uintptr_t)address);
-        CLog::Log(LOGDEBUG, "{} - created dummy function {}!{}", __FUNCTION__, dll->GetName(),
-                  function);
+        CLog::LogF(LOGDEBUG, "created dummy function {}!{}", dll->GetName(), function);
       }
       else
       {
         address = NULL;
-        CLog::Log(LOGDEBUG, "{}({}({}), '{}') => {}", __FUNCTION__, fmt::ptr(hModule),
-                  dll->GetName(), function, fmt::ptr(address));
+        CLog::LogF(LOGDEBUG, "({}({}), '{}') => {}", fmt::ptr(hModule), dll->GetName(), function,
+                   fmt::ptr(address));
       }
     }
   }

--- a/xbmc/cores/DllLoader/dll_tracker_library.cpp
+++ b/xbmc/cores/DllLoader/dll_tracker_library.cpp
@@ -55,7 +55,7 @@ extern "C" void tracker_library_free_all(DllTrackInfo* pInfo)
       LibraryLoader* pDll = DllLoaderContainer::GetModule((HMODULE)*it);
       if( !pDll)
       {
-        CLog::Log(LOGERROR, "{} - Invalid module in tracker", __FUNCTION__);
+        CLog::LogF(LOGERROR, "Invalid module in tracker");
         return;
       }
 
@@ -72,7 +72,7 @@ extern "C" void tracker_library_free_all(DllTrackInfo* pInfo)
       LibraryLoader* pDll = DllLoaderContainer::GetModule((HMODULE)*it);
       if( !pDll)
       {
-        CLog::Log(LOGERROR, "{} - Invalid module in tracker", __FUNCTION__);
+        CLog::LogF(LOGERROR, "Invalid module in tracker");
         return;
       }
 

--- a/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
+++ b/xbmc/cores/DllLoader/exports/emu_msvcrt.cpp
@@ -580,7 +580,7 @@ extern "C"
       // let the operating system handle it
       return read(fd, buffer, uiSize);
     }
-    CLog::Log(LOGERROR, "{} emulated function failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "emulated function failed");
     errno = EBADF;
     return -1;
   }
@@ -612,7 +612,7 @@ extern "C"
       // let the operating system handle it
       return write(fd, buffer, uiSize);
     }
-    CLog::Log(LOGERROR, "{} emulated function failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "emulated function failed");
     errno = EBADF;
     return -1;
   }
@@ -628,7 +628,7 @@ extern "C"
 #else
       return fstat64(fd, buf);
 #endif
-    CLog::Log(LOGERROR, "{} emulated function failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "emulated function failed");
     return -1;
   }
 
@@ -649,7 +649,7 @@ extern "C"
       // let the operating system handle it
       return close(fd);
     }
-    CLog::Log(LOGERROR, "{} emulated function failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "emulated function failed");
     return -1;
   }
 
@@ -669,7 +669,7 @@ extern "C"
       CLog::Log(LOGWARNING, "msvcrt.dll: dll_lseeki64 called, TODO: add 'int64 -> long' type checking");      //warning
       return static_cast<long long>(lseek(fd, (long)lPos, iWhence));
     }
-    CLog::Log(LOGERROR, "{} emulated function failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "emulated function failed");
     return -1ll;
   }
 
@@ -685,7 +685,7 @@ extern "C"
       // let the operating system handle it
       return lseek(fd, lPos, iWhence);
     }
-    CLog::Log(LOGERROR, "{} emulated function failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "emulated function failed");
     return -1;
   }
 
@@ -698,7 +698,7 @@ extern "C"
     }
     else
     {
-      CLog::Log(LOGERROR, "{} emulated function failed", __FUNCTION__);
+      CLog::LogF(LOGERROR, "emulated function failed");
     }
   }
 
@@ -711,7 +711,7 @@ extern "C"
       g_emuFileWrapper.LockFileObjectByDescriptor(fd);
       return;
     }
-    CLog::Log(LOGERROR, "{} emulated function failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "emulated function failed");
   }
 
   int dll_ftrylockfile(FILE *stream)
@@ -723,7 +723,7 @@ extern "C"
         return 0;
       return -1;
     }
-    CLog::Log(LOGERROR, "{} emulated function failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "emulated function failed");
     return -1;
   }
 
@@ -735,7 +735,7 @@ extern "C"
       g_emuFileWrapper.UnlockFileObjectByDescriptor(fd);
       return;
     }
-    CLog::Log(LOGERROR, "{} emulated function failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "emulated function failed");
   }
 
   int dll_fclose(FILE * stream)
@@ -745,7 +745,7 @@ extern "C"
     {
       return dll_close(fd) == 0 ? 0 : EOF;
     }
-    CLog::Log(LOGERROR, "{} emulated function failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "emulated function failed");
     return EOF;
   }
 
@@ -1064,7 +1064,7 @@ extern "C"
       }
       else return NULL; //eof
     }
-    CLog::Log(LOGERROR, "{} emulated function failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "emulated function failed");
     return NULL;
   }
 
@@ -1076,7 +1076,7 @@ extern "C"
       if (pFile->GetPosition() < pFile->GetLength()) return 0;
       else return 1;
     }
-    CLog::Log(LOGERROR, "{} emulated function failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "emulated function failed");
     return 1; // eof by default
   }
 
@@ -1099,7 +1099,7 @@ extern "C"
       } while (bufSize > read);
       return read / size;
     }
-    CLog::Log(LOGERROR, "{} emulated function failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "emulated function failed");
     return 0;
   }
 
@@ -1115,7 +1115,7 @@ extern "C"
 
       return (int)buf;
     }
-    CLog::Log(LOGERROR, "{} emulated function failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "emulated function failed");
     return EOF;
   }
 
@@ -1126,7 +1126,7 @@ extern "C"
       // This routine is normally implemented as a macro with the same result as fgetc().
       return dll_fgetc(stream);
     }
-    CLog::Log(LOGERROR, "{} emulated function failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "emulated function failed");
     return EOF;
   }
 
@@ -1137,9 +1137,7 @@ extern "C"
     if (strcmp(filename, _PATH_MOUNTED) == 0
     ||  strcmp(filename, _PATH_MNTTAB) == 0)
     {
-      CLog::Log(LOGINFO,
-                "{} - something opened the mount file, let's hope it knows what it's doing",
-                __FUNCTION__);
+      CLog::LogF(LOGINFO, "something opened the mount file, let's hope it knows what it's doing");
       return fopen(filename, mode);
     }
 #endif
@@ -1200,7 +1198,7 @@ extern "C"
         }
       }
     }
-    CLog::Log(LOGERROR, "{} emulated function failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "emulated function failed");
     return EOF;
   }
 
@@ -1220,7 +1218,7 @@ extern "C"
       }
     }
 
-    CLog::Log(LOGERROR, "{} emulated function failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "emulated function failed");
     return EOF;
   }
 
@@ -1235,7 +1233,7 @@ extern "C"
       }
       else return -1;
     }
-    CLog::Log(LOGERROR, "{} emulated function failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "emulated function failed");
     return -1;
   }
 
@@ -1259,16 +1257,16 @@ extern "C"
       dll_fseek(stream, -1, SEEK_CUR);
       if (c != d)
       {
-        CLog::Log(LOGWARNING, "{}: c != d", __FUNCTION__);
+        CLog::LogF(LOGWARNING, "c != d");
         d = fputc(c, stream);
         if (d != c)
-          CLog::Log(LOGERROR, "{}: Write failed!", __FUNCTION__);
+          CLog::LogF(LOGERROR, "Write failed!");
         else
           dll_fseek(stream, -1, SEEK_CUR);
       }
       return d;
     }
-    CLog::Log(LOGERROR, "{} emulated function failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "emulated function failed");
     return EOF;
   }
 
@@ -1284,7 +1282,7 @@ extern "C"
     {
        return (off64_t)pFile->GetPosition();
     }
-    CLog::Log(LOGERROR, "{} emulated function failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "emulated function failed");
     return -1;
   }
 
@@ -1305,7 +1303,7 @@ extern "C"
       return lseek(fd, 0, SEEK_CUR);
 #endif
     }
-    CLog::Log(LOGERROR, "{} emulated function failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "emulated function failed");
     return -1;
   }
 
@@ -1330,7 +1328,7 @@ extern "C"
       return lseek64(fd, 0, SEEK_CUR);
 #endif
     }
-    CLog::Log(LOGERROR, "{} emulated function failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "emulated function failed");
     return -1;
   }
 
@@ -1370,7 +1368,7 @@ extern "C"
         return written / size;
       }
     }
-    CLog::Log(LOGERROR, "{} emulated function failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "emulated function failed");
     return 0;
   }
 
@@ -1458,13 +1456,13 @@ extern "C"
       }
     }
 
-    CLog::Log(LOGERROR, "{} emulated function failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "emulated function failed");
     return strlen(tmp);
   }
 
   int dll_fscanf(FILE* stream, const char* format, ...)
   {
-    CLog::Log(LOGERROR, "{} is not implemented", __FUNCTION__);
+    CLog::LogF(LOGERROR, "is not implemented");
     return -1;
   }
 
@@ -1504,7 +1502,7 @@ extern "C"
 #endif
       return 0;
     }
-    CLog::Log(LOGERROR, "{} emulated function failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "emulated function failed");
     return EINVAL;
   }
 
@@ -1526,7 +1524,7 @@ extern "C"
         return EINVAL;
       }
     }
-    CLog::Log(LOGERROR, "{} emulated function failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "emulated function failed");
     return EINVAL;
   }
 
@@ -1543,7 +1541,7 @@ extern "C"
 #endif
       return dll_fsetpos64(stream, &tmpPos);
     }
-    CLog::Log(LOGERROR, "{} emulated function failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "emulated function failed");
     return EINVAL;
   }
 
@@ -2005,13 +2003,13 @@ extern "C"
       d.param   = p1;
       ret = pFile->IoControl(IOCTRL_NATIVE, &d);
       if(ret<0)
-        CLog::Log(LOGWARNING, "{} - {} request failed with error [{}] {}", __FUNCTION__, request,
-                  errno, strerror(errno));
+        CLog::LogF(LOGWARNING, "{} request failed with error [{}] {}", request, errno,
+                   strerror(errno));
     }
     else
 #endif
     {
-      CLog::Log(LOGWARNING, "{} - Unknown request type {}", __FUNCTION__, request);
+      CLog::LogF(LOGWARNING, "Unknown request type {}", request);
       ret = -1;
     }
     return ret;
@@ -2020,7 +2018,7 @@ extern "C"
 
   int dll_setvbuf(FILE *stream, char *buf, int type, size_t size)
   {
-    CLog::Log(LOGWARNING, "{} - May not be implemented correctly", __FUNCTION__);
+    CLog::LogF(LOGWARNING, "May not be implemented correctly");
     return 0;
   }
 

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -93,7 +93,7 @@ bool CExternalPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &opti
     m_time = 0;
     m_playbackStartTime = std::chrono::steady_clock::now();
     m_launchFilename = file.GetDynPath();
-    CLog::Log(LOGINFO, "{}: {}", __FUNCTION__, m_launchFilename);
+    CLog::LogF(LOGINFO, "{}", m_launchFilename);
     Create();
 
     return true;
@@ -101,7 +101,7 @@ bool CExternalPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &opti
   catch(...)
   {
     m_bIsPlaying = false;
-    CLog::Log(LOGERROR, "{} - Exception thrown", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Exception thrown");
     return false;
   }
 }
@@ -173,7 +173,7 @@ void CExternalPlayer::Process()
 
       if (!regExp.RegComp(strMatch.c_str()))
       { // invalid regexp - complain in logs
-        CLog::Log(LOGERROR, "{}: Invalid RegExp:'{}'", __FUNCTION__, strMatch);
+        CLog::LogF(LOGERROR, "Invalid RegExp:'{}'", strMatch);
         continue;
       }
 
@@ -184,7 +184,7 @@ void CExternalPlayer::Process()
 
         if (!regExp.RegComp(strPat.c_str()))
         { // invalid regexp - complain in logs
-          CLog::Log(LOGERROR, "{}: Invalid RegExp:'{}'", __FUNCTION__, strPat);
+          CLog::LogF(LOGERROR, "Invalid RegExp:'{}'", strPat);
           continue;
         }
 
@@ -200,18 +200,18 @@ void CExternalPlayer::Process()
           if (!bGlobal)
             break;
         }
-        CLog::Log(LOGINFO, "{}: File matched:'{}' (RE='{}',Rep='{}') new filename:'{}'.",
-                  __FUNCTION__, strMatch, strPat, strRep, mainFile);
+        CLog::LogF(LOGINFO, "File matched:'{}' (RE='{}',Rep='{}') new filename:'{}'.", strMatch,
+                   strPat, strRep, mainFile);
         if (bStop) break;
       }
     }
   }
 
-  CLog::Log(LOGINFO, "{}: Player : {}", __FUNCTION__, m_filename);
-  CLog::Log(LOGINFO, "{}: File   : {}", __FUNCTION__, mainFile);
-  CLog::Log(LOGINFO, "{}: Content: {}", __FUNCTION__, archiveContent);
-  CLog::Log(LOGINFO, "{}: Args   : {}", __FUNCTION__, m_args);
-  CLog::Log(LOGINFO, "{}: Start", __FUNCTION__);
+  CLog::LogF(LOGINFO, "Player : {}", m_filename);
+  CLog::LogF(LOGINFO, "File   : {}", mainFile);
+  CLog::LogF(LOGINFO, "Content: {}", archiveContent);
+  CLog::LogF(LOGINFO, "Args   : {}", m_args);
+  CLog::LogF(LOGINFO, "Start");
 
   // make sure we surround the arguments with quotes where necessary
   std::string strFName;
@@ -268,7 +268,7 @@ void CExternalPlayer::Process()
         y = GetSystemMetrics(SM_CYSCREEN) / 2;
         break;
     }
-    CLog::Log(LOGINFO, "{}: Warping cursor to ({},{})", __FUNCTION__, x, y);
+    CLog::LogF(LOGINFO, "Warping cursor to ({},{})", x, y);
     SetCursorPos(x,y);
   }
 
@@ -277,17 +277,17 @@ void CExternalPlayer::Process()
 
   if (m_hidexbmc && !m_islauncher)
   {
-    CLog::Log(LOGINFO, "{}: Hiding {} window", __FUNCTION__, CCompileInfo::GetAppName());
+    CLog::LogF(LOGINFO, "Hiding {} window", CCompileInfo::GetAppName());
     CServiceBroker::GetWinSystem()->Hide();
   }
 #if defined(TARGET_WINDOWS_DESKTOP)
   else if (currentStyle & WS_EX_TOPMOST)
   {
-    CLog::Log(LOGINFO, "{}: Lowering {} window", __FUNCTION__, CCompileInfo::GetAppName());
+    CLog::LogF(LOGINFO, "Lowering {} window", CCompileInfo::GetAppName());
     SetWindowPos(g_hWnd, HWND_BOTTOM, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOREDRAW | SWP_ASYNCWINDOWPOS);
   }
 
-  CLog::Log(LOGDEBUG, "{}: Unlocking foreground window", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "Unlocking foreground window");
   LockSetForegroundWindow(LSFW_UNLOCK);
 #endif
 
@@ -304,8 +304,7 @@ void CExternalPlayer::Process()
   }
   if (timer.IsTimePast())
   {
-    CLog::Log(LOGERROR, "{}: AudioEngine did not suspend before launching external player",
-              __FUNCTION__);
+    CLog::LogF(LOGERROR, "AudioEngine did not suspend before launching external player");
   }
 
   m_callback.OnPlayBackStarted(m_file);
@@ -326,8 +325,8 @@ void CExternalPlayer::Process()
   {
     if (m_hidexbmc)
     {
-      CLog::Log(LOGINFO, "{}: {} cannot stay hidden for a launcher process", __FUNCTION__,
-                CCompileInfo::GetAppName());
+      CLog::LogF(LOGINFO, "{} cannot stay hidden for a launcher process",
+                 CCompileInfo::GetAppName());
       CServiceBroker::GetWinSystem()->Show(false);
     }
 
@@ -344,21 +343,21 @@ void CExternalPlayer::Process()
   }
 
   m_bIsPlaying = false;
-  CLog::Log(LOGINFO, "{}: Stop", __FUNCTION__);
+  CLog::LogF(LOGINFO, "Stop");
 
 #if defined(TARGET_WINDOWS_DESKTOP)
   CServiceBroker::GetWinSystem()->Restore();
 
   if (currentStyle & WS_EX_TOPMOST)
   {
-    CLog::Log(LOGINFO, "{}: Showing {} window TOPMOST", __FUNCTION__, CCompileInfo::GetAppName());
+    CLog::LogF(LOGINFO, "Showing {} window TOPMOST", CCompileInfo::GetAppName());
     SetWindowPos(g_hWnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW | SWP_ASYNCWINDOWPOS);
     SetForegroundWindow(g_hWnd);
   }
   else
 #endif
   {
-    CLog::Log(LOGINFO, "{}: Showing {} window", __FUNCTION__, CCompileInfo::GetAppName());
+    CLog::LogF(LOGINFO, "Showing {} window", CCompileInfo::GetAppName());
     CServiceBroker::GetWinSystem()->Show();
   }
 
@@ -372,7 +371,7 @@ void CExternalPlayer::Process()
       m_xPos = (m_ptCursorpos.x);
       m_yPos = (m_ptCursorpos.y);
     }
-    CLog::Log(LOGINFO, "{}: Restoring cursor to ({},{})", __FUNCTION__, m_xPos, m_yPos);
+    CLog::LogF(LOGINFO, "Restoring cursor to ({},{})", m_xPos, m_yPos);
     SetCursorPos(m_xPos,m_yPos);
   }
 #endif
@@ -386,8 +385,7 @@ void CExternalPlayer::Process()
   /* Resume AE processing of XBMC native audio */
   if (!CServiceBroker::GetActiveAE()->Resume())
   {
-    CLog::Log(LOGFATAL, "{}: Failed to restart AudioEngine after return from external player",
-              __FUNCTION__);
+    CLog::LogF(LOGFATAL, "Failed to restart AudioEngine after return from external player");
   }
 
   // We don't want to come back to an active screensaver
@@ -405,7 +403,7 @@ void CExternalPlayer::Process()
 #if defined(TARGET_WINDOWS_DESKTOP)
 bool CExternalPlayer::ExecuteAppW32(const char* strPath, const char* strSwitches)
 {
-  CLog::Log(LOGINFO, "{}: {} {}", __FUNCTION__, strPath, strSwitches);
+  CLog::LogF(LOGINFO, "{} {}", strPath, strSwitches);
 
   STARTUPINFOW si = {};
   si.cb = sizeof(si);
@@ -425,7 +423,7 @@ bool CExternalPlayer::ExecuteAppW32(const char* strPath, const char* strSwitches
   if (ret == FALSE)
   {
     DWORD lastError = GetLastError();
-    CLog::Log(LOGINFO, "{} - Failure: {}", __FUNCTION__, lastError);
+    CLog::LogF(LOGINFO, "Failure: {}", lastError);
   }
   else
   {
@@ -434,16 +432,16 @@ bool CExternalPlayer::ExecuteAppW32(const char* strPath, const char* strSwitches
     switch (res)
     {
       case WAIT_OBJECT_0:
-        CLog::Log(LOGINFO, "{}: WAIT_OBJECT_0", __FUNCTION__);
+        CLog::LogF(LOGINFO, "WAIT_OBJECT_0");
         break;
       case WAIT_ABANDONED:
-        CLog::Log(LOGINFO, "{}: WAIT_ABANDONED", __FUNCTION__);
+        CLog::LogF(LOGINFO, "WAIT_ABANDONED");
         break;
       case WAIT_TIMEOUT:
-        CLog::Log(LOGINFO, "{}: WAIT_TIMEOUT", __FUNCTION__);
+        CLog::LogF(LOGINFO, "WAIT_TIMEOUT");
         break;
       case WAIT_FAILED:
-        CLog::Log(LOGINFO, "{}: WAIT_FAILED ({})", __FUNCTION__, GetLastError());
+        CLog::LogF(LOGINFO, "WAIT_FAILED ({})", GetLastError());
         ret = FALSE;
         break;
     }
@@ -460,12 +458,12 @@ bool CExternalPlayer::ExecuteAppW32(const char* strPath, const char* strSwitches
 #if !defined(TARGET_ANDROID) && !defined(TARGET_DARWIN_EMBEDDED) && defined(TARGET_POSIX)
 bool CExternalPlayer::ExecuteAppLinux(const char* strSwitches)
 {
-  CLog::Log(LOGINFO, "{}: {}", __FUNCTION__, strSwitches);
+  CLog::LogF(LOGINFO, "{}", strSwitches);
 
   int ret = system(strSwitches);
   if (ret != 0)
   {
-    CLog::Log(LOGINFO, "{}: Failure: {}", __FUNCTION__, ret);
+    CLog::LogF(LOGINFO, "Failure: {}", ret);
   }
 
   return (ret == 0);
@@ -475,13 +473,13 @@ bool CExternalPlayer::ExecuteAppLinux(const char* strSwitches)
 #if defined(TARGET_ANDROID)
 bool CExternalPlayer::ExecuteAppAndroid(const char* strSwitches,const char* strPath)
 {
-  CLog::Log(LOGINFO, "{}: {}", __FUNCTION__, strSwitches);
+  CLog::LogF(LOGINFO, "{}", strSwitches);
 
   bool ret = CXBMCApp::StartActivity(strSwitches, "android.intent.action.VIEW", "video/*", strPath);
 
   if (!ret)
   {
-    CLog::Log(LOGINFO, "{}: Failure", __FUNCTION__);
+    CLog::LogF(LOGINFO, "Failure");
   }
 
   return (ret == 0);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.cpp
@@ -150,8 +150,7 @@ bool CDVDAudioCodecFFmpeg::AddData(const DemuxPacket &packet)
   AVPacket* avpkt = av_packet_alloc();
   if (!avpkt)
   {
-    CLog::Log(LOGERROR, "CDVDAudioCodecFFmpeg::{} - av_packet_alloc failed: {}", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CDVDAudioCodecFFmpeg: av_packet_alloc failed: {}", strerror(errno));
     return false;
   }
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecCCText.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecCCText.cpp
@@ -104,7 +104,7 @@ OverlayMessage CDVDOverlayCodecCCText::Decode(DemuxPacket* pPacket)
     m_prevPTSStart = PTSStartTime;
   }
   else
-    CLog::Log(LOGERROR, "{} - Failed to initialize tag converter", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Failed to initialize tag converter");
 
   return m_pOverlay ? OverlayMessage::OC_DONE : OverlayMessage::OC_OVERLAY;
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
@@ -44,7 +44,7 @@ bool CDVDOverlayCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &optio
   const AVCodec* pCodec = avcodec_find_decoder(hints.codec);
   if (!pCodec)
   {
-    CLog::Log(LOGDEBUG, "{} - Unable to find codec {}", __FUNCTION__, hints.codec);
+    CLog::LogF(LOGDEBUG, "Unable to find codec {}", hints.codec);
     return false;
   }
 
@@ -84,7 +84,7 @@ bool CDVDOverlayCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &optio
         {
           m_pCodecContext->width = width;
           m_pCodecContext->height = height;
-          CLog::Log(LOGDEBUG, "{} - parsed extradata: size: {} x {}", __FUNCTION__, width, height);
+          CLog::LogF(LOGDEBUG, "parsed extradata: size: {} x {}", width, height);
         }
       }
       /*
@@ -126,8 +126,7 @@ OverlayMessage CDVDOverlayCodecFFmpeg::Decode(DemuxPacket* pPacket)
   AVPacket* avpkt = av_packet_alloc();
   if (!avpkt)
   {
-    CLog::Log(LOGERROR, "CDVDOverlayCodecFFmpeg::{} - av_packet_alloc failed: {}", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CDVDOverlayCodecFFmpeg: av_packet_alloc failed: {}", strerror(errno));
     return OverlayMessage::OC_ERROR;
   }
 
@@ -144,14 +143,13 @@ OverlayMessage CDVDOverlayCodecFFmpeg::Decode(DemuxPacket* pPacket)
 
   if (len < 0)
   {
-    CLog::Log(LOGERROR, "{} - avcodec_decode_subtitle returned failure", __FUNCTION__);
+    CLog::LogF(LOGERROR, "avcodec_decode_subtitle returned failure");
     Flush();
     return OverlayMessage::OC_ERROR;
   }
 
   if (len != size)
-    CLog::Log(LOGWARNING, "{} - avcodec_decode_subtitle didn't consume the full packet",
-              __FUNCTION__);
+    CLog::LogF(LOGWARNING, "avcodec_decode_subtitle didn't consume the full packet");
 
   if (!gotsub)
     return OverlayMessage::OC_BUFFER;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecTX3G.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecTX3G.cpp
@@ -123,7 +123,7 @@ OverlayMessage CDVDOverlayCodecTX3G::Decode(DemuxPacket* pPacket)
   {
     if (sampleData.CharsLeft() < MP4_BOX_HEADER_SIZE)
     {
-      CLog::Log(LOGWARNING, "{} - Incomplete box header found", __FUNCTION__);
+      CLog::LogF(LOGWARNING, "Incomplete box header found");
       break;
     }
 
@@ -132,21 +132,21 @@ OverlayMessage CDVDOverlayCodecTX3G::Decode(DemuxPacket* pPacket)
 
     if (boxType == BOX_TYPE_UUID)
     {
-      CLog::Log(LOGDEBUG, "{} - Sample data has unsupported extended type 'uuid'", __FUNCTION__);
+      CLog::LogF(LOGDEBUG, "Sample data has unsupported extended type 'uuid'");
     }
     else if (boxType == BOX_TYPE_STYL)
     {
       // Parse the contained StyleRecords
       if (styleRecords.size() != 0)
       {
-        CLog::Log(LOGDEBUG, "{} - Found additional TextStyleBox, skipping", __FUNCTION__);
+        CLog::LogF(LOGDEBUG, "Found additional TextStyleBox, skipping");
         sampleData.SkipChars(boxSize - MP4_BOX_HEADER_SIZE);
         continue;
       }
 
       if (sampleData.CharsLeft() < 2)
       {
-        CLog::Log(LOGWARNING, "{} - Incomplete TextStyleBox header found", __FUNCTION__);
+        CLog::LogF(LOGWARNING, "Incomplete TextStyleBox header found");
         return OverlayMessage::OC_ERROR;
       }
       uint16_t styleCount = sampleData.ReadNextUnsignedShort();
@@ -160,7 +160,7 @@ OverlayMessage CDVDOverlayCodecTX3G::Decode(DemuxPacket* pPacket)
       {
         if (sampleData.CharsLeft() < 12)
         {
-          CLog::Log(LOGWARNING, "{} - Incomplete StyleRecord found, skipping", __FUNCTION__);
+          CLog::LogF(LOGWARNING, "Incomplete StyleRecord found, skipping");
           sampleData.SkipChars(sampleData.CharsLeft());
           continue;
         }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecText.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecText.cpp
@@ -72,7 +72,7 @@ OverlayMessage CDVDOverlayCodecText::Decode(DemuxPacket* pPacket)
     AddSubtitle(text, PTSStartTime, PTSStopTime);
   }
   else
-    CLog::Log(LOGERROR, "{} - Failed to initialize tag converter", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Failed to initialize tag converter");
 
   return m_pOverlay ? OverlayMessage::OC_DONE : OverlayMessage::OC_OVERLAY;
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/contrib/cc_decoder708.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/contrib/cc_decoder708.cpp
@@ -345,7 +345,7 @@ int handle_708_C2 (cc708_service_decoder *decoder, unsigned char *data, int data
 int handle_708_C3 (cc708_service_decoder *decoder, unsigned char *data, int data_length)
 {
   if (data[0] < 0x80 || data[0] > 0x9F)
-    CLog::Log(LOGERROR, "{} - Entry in handle_708_C3 with an out of range value", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Entry in handle_708_C3 with an out of range value");
   if (data[0]<=0x87) // 80-87...
     return 5; // ... Five-byte control bytes (4 additional bytes)
   else if (data[0]<=0x8F) // 88-8F ...

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -208,8 +208,8 @@ enum AVPixelFormat CDVDVideoCodecDRMPRIME::GetFormat(struct AVCodecContext* avct
   {
     formats.emplace_back(av_get_pix_fmt_name(fmt[n]));
   }
-  CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - no supported pixel formats: {}", __FUNCTION__,
-            StringUtils::Join(formats, ", "));
+  CLog::LogF(LOGERROR, "CDVDVideoCodecDRMPRIME: supported pixel formats: {}",
+             StringUtils::Join(formats, ", "));
 
   return AV_PIX_FMT_NONE;
 }
@@ -266,13 +266,12 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
   const AVCodec* pCodec = FindDecoder(hints);
   if (!pCodec)
   {
-    CLog::Log(LOGDEBUG, "CDVDVideoCodecDRMPRIME::{} - unable to find decoder for codec {}",
-              __FUNCTION__, hints.codec);
+    CLog::LogF(LOGDEBUG, "CDVDVideoCodecDRMPRIME: unable to find decoder for codec {}",
+               hints.codec);
     return false;
   }
 
-  CLog::Log(LOGINFO, "CDVDVideoCodecDRMPRIME::{} - using decoder {}", __FUNCTION__,
-            pCodec->long_name ? pCodec->long_name : pCodec->name);
+  CLog::LogF(LOGINFO, "CDVDVideoCodecDRMPRIME: using decoder {}");
 
   m_pCodecContext = avcodec_alloc_context3(pCodec);
   if (!m_pCodecContext)
@@ -308,14 +307,15 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
     if (!device)
       device = "/dev/dri/renderD128";
 
-    CLog::Log(LOGDEBUG, "CDVDVideoCodecDRMPRIME::{} - using drm device for av_hwdevice_ctx: {}", __FUNCTION__, device);
+    CLog::LogF(LOGDEBUG, "CDVDVideoCodecDRMPRIME: using drm device for av_hwdevice_ctx: {}",
+               device);
 
     if (av_hwdevice_ctx_create(&m_pCodecContext->hw_device_ctx, pConfig->device_type,
                                device, nullptr, 0) < 0)
     {
-      CLog::Log(LOGERROR,
-                "CDVDVideoCodecDRMPRIME::{} - unable to create hwdevice context using device: {}",
-                __FUNCTION__, device);
+      CLog::LogF(LOGERROR,
+                 "CDVDVideoCodecDRMPRIME: unable to create hwdevice context using device: {}",
+                 device);
       avcodec_free_context(&m_pCodecContext);
       return false;
     }
@@ -346,7 +346,7 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
 
   if (avcodec_open2(m_pCodecContext, pCodec, nullptr) < 0)
   {
-    CLog::Log(LOGINFO, "CDVDVideoCodecDRMPRIME::{} - unable to open codec", __FUNCTION__);
+    CLog::LogF(LOGINFO, "CDVDVideoCodecDRMPRIME: unable to open codec");
     avcodec_free_context(&m_pCodecContext);
     if (hints.codecOptions & CODEC_FORCE_SOFTWARE)
       return false;
@@ -388,8 +388,7 @@ bool CDVDVideoCodecDRMPRIME::AddData(const DemuxPacket& packet)
   AVPacket* avpkt = av_packet_alloc();
   if (!avpkt)
   {
-    CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - av_packet_alloc failed: {}", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CDVDVideoCodecDRMPRIME: av_packet_alloc failed: {}", strerror(errno));
     return false;
   }
 
@@ -418,8 +417,7 @@ bool CDVDVideoCodecDRMPRIME::AddData(const DemuxPacket& packet)
   {
     char err[AV_ERROR_MAX_STRING_SIZE] = {};
     av_strerror(ret, err, AV_ERROR_MAX_STRING_SIZE);
-    CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - send packet failed: {} ({})", __FUNCTION__,
-              err, ret);
+    CLog::LogF(LOGERROR, "CDVDVideoCodecDRMPRIME: send packet failed: {} ({})", err, ret);
     if (ret != AVERROR_EOF && ret != AVERROR_INVALIDDATA)
       return false;
   }
@@ -443,15 +441,14 @@ void CDVDVideoCodecDRMPRIME::Reset()
     {
       char err[AV_ERROR_MAX_STRING_SIZE] = {};
       av_strerror(ret, err, AV_ERROR_MAX_STRING_SIZE);
-      CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - receive frame failed: {} ({})",
-                __FUNCTION__, err, ret);
+      CLog::LogF(LOGERROR, "CDVDVideoCodecDRMPRIME: receive frame failed: {} ({})", err, ret);
       break;
     }
     else
       av_frame_unref(m_pFrame);
   } while (true);
 
-  CLog::Log(LOGDEBUG, "CDVDVideoCodecDRMPRIME::{} - flush buffers", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CDVDVideoCodecDRMPRIME: flush buffers");
   avcodec_flush_buffers(m_pCodecContext);
 }
 
@@ -460,8 +457,7 @@ void CDVDVideoCodecDRMPRIME::Drain()
   AVPacket* avpkt = av_packet_alloc();
   if (!avpkt)
   {
-    CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - av_packet_alloc failed: {}", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CDVDVideoCodecDRMPRIME: av_packet_alloc failed: {}", strerror(errno));
     return;
   }
 
@@ -473,8 +469,7 @@ void CDVDVideoCodecDRMPRIME::Drain()
   {
     char err[AV_ERROR_MAX_STRING_SIZE] = {};
     av_strerror(ret, err, AV_ERROR_MAX_STRING_SIZE);
-    CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - send packet failed: {} ({})", __FUNCTION__,
-              err, ret);
+    CLog::LogF(LOGERROR, "CDVDVideoCodecDRMPRIME: send packet failed: {} ({})", err, ret);
   }
 
   av_packet_free(&avpkt);
@@ -589,7 +584,7 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::GetPicture(VideoPicture* pVideo
   {
     if (m_codecControlFlags & DVD_CODEC_CTRL_DRAIN)
     {
-      CLog::Log(LOGDEBUG, "CDVDVideoCodecDRMPRIME::{} - flush buffers", __FUNCTION__);
+      CLog::LogF(LOGDEBUG, "CDVDVideoCodecDRMPRIME: flush buffers");
       avcodec_flush_buffers(m_pCodecContext);
       SetCodecControl(m_codecControlFlags & ~DVD_CODEC_CTRL_DRAIN);
     }
@@ -599,8 +594,7 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::GetPicture(VideoPicture* pVideo
   {
     char err[AV_ERROR_MAX_STRING_SIZE] = {};
     av_strerror(ret, err, AV_ERROR_MAX_STRING_SIZE);
-    CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - receive frame failed: {} ({})", __FUNCTION__,
-              err, ret);
+    CLog::LogF(LOGERROR, "CDVDVideoCodecDRMPRIME: receive frame failed: {} ({})", err, ret);
     return VC_ERROR;
   }
 
@@ -634,8 +628,8 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::GetPicture(VideoPicture* pVideo
 
   if (!pVideoPicture->videoBuffer)
   {
-    CLog::Log(LOGERROR, "CDVDVideoCodecDRMPRIME::{} - videoBuffer:nullptr format:{}", __FUNCTION__,
-              av_get_pix_fmt_name(static_cast<AVPixelFormat>(m_pFrame->format)));
+    CLog::LogF(LOGERROR, "CDVDVideoCodecDRMPRIME: videoBuffer:nullptr format:{}",
+               av_get_pix_fmt_name(static_cast<AVPixelFormat>(m_pFrame->format)));
     av_frame_unref(m_pFrame);
     return VC_ERROR;
   }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -580,8 +580,7 @@ bool CDVDVideoCodecFFmpeg::AddData(const DemuxPacket &packet)
   AVPacket* avpkt = av_packet_alloc();
   if (!avpkt)
   {
-    CLog::Log(LOGERROR, "CDVDVideoCodecFFmpeg::{} - av_packet_alloc failed: {}", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CDVDVideoCodecFFmpeg: av_packet_alloc failed: {}", strerror(errno));
     return false;
   }
 
@@ -684,8 +683,7 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecFFmpeg::GetPicture(VideoPicture* pVideoPi
     AVPacket* avpkt = av_packet_alloc();
     if (!avpkt)
     {
-      CLog::Log(LOGERROR, "CDVDVideoCodecFFmpeg::{} - av_packet_alloc failed: {}", __FUNCTION__,
-                strerror(errno));
+      CLog::LogF(LOGERROR, "CDVDVideoCodecFFmpeg: av_packet_alloc failed: {}", strerror(errno));
       return VC_ERROR;
     }
     avpkt->data = nullptr;
@@ -758,7 +756,7 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecFFmpeg::GetPicture(VideoPicture* pVideoPi
   }
   else if (ret)
   {
-    CLog::Log(LOGERROR, "{} - avcodec_receive_frame returned failure", __FUNCTION__);
+    CLog::LogF(LOGERROR, "avcodec_receive_frame returned failure");
     return VC_ERROR;
   }
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -759,7 +759,7 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum A
 
 void CDecoder::Close()
 {
-  CLog::Log(LOGINFO, "VAAPI::{}", __FUNCTION__);
+  CLog::LogF(LOGINFO, "VAAPI");
 
   std::unique_lock<CCriticalSection> lock(m_DecoderSection);
 
@@ -801,13 +801,13 @@ long CDecoder::Release()
       reply->Release();
       if (!success)
       {
-        CLog::Log(LOGERROR, "VAAPI::{} - pre-cleanup returned error", __FUNCTION__);
+        CLog::LogF(LOGERROR, "VAAPI: pre-cleanup returned error");
         m_DisplayState = VAAPI_ERROR;
       }
     }
     else
     {
-      CLog::Log(LOGERROR, "VAAPI::{} - pre-cleanup timed out", __FUNCTION__);
+      CLog::LogF(LOGERROR, "VAAPI: pre-cleanup timed out");
       m_DisplayState = VAAPI_ERROR;
     }
 
@@ -862,7 +862,7 @@ int CDecoder::FFGetBuffer(AVCodecContext *avctx, AVFrame *pic, int flags)
   AVBufferRef *buffer = av_buffer_create(pic->data[3], 0, CVAAPIContext::FFReleaseBuffer, va, 0);
   if (!buffer)
   {
-    CLog::Log(LOGERROR, "VAAPI::{} - error creating buffer", __FUNCTION__);
+    CLog::LogF(LOGERROR, "VAAPI: error creating buffer");
     return -1;
   }
   pic->buf[0] = buffer;
@@ -993,10 +993,10 @@ CDVDVideoCodec::VCReturn CDecoder::Decode(AVCodecContext* avctx, AVFrame* pFrame
       break;
   }
 
-  CLog::Log(LOGERROR,
-            "VAAPI::{} - timed out waiting for output message - decoded: {}, proc: {}, has free "
-            "surface: {}",
-            __FUNCTION__, decoded, processed, m_videoSurfaces.HasFree() ? "yes" : "no");
+  CLog::LogF(LOGERROR,
+             "VAAPI: timed out waiting for output message - decoded: {}, proc: {}, has free "
+             "surface: {}",
+             decoded, processed, m_videoSurfaces.HasFree() ? "yes" : "no");
   m_DisplayState = VAAPI_ERROR;
 
   return CDVDVideoCodec::VC_ERROR;
@@ -1098,7 +1098,7 @@ void CDecoder::Reset()
     reply->Release();
     if (!success)
     {
-      CLog::Log(LOGERROR, "VAAPI::{} - flush returned error", __FUNCTION__);
+      CLog::LogF(LOGERROR, "VAAPI: flush returned error");
       m_DisplayState = VAAPI_ERROR;
     }
     else
@@ -1109,7 +1109,7 @@ void CDecoder::Reset()
   }
   else
   {
-    CLog::Log(LOGERROR, "VAAPI::{} - flush timed out", __FUNCTION__);
+    CLog::LogF(LOGERROR, "VAAPI: flush timed out");
     m_DisplayState = VAAPI_ERROR;
   }
 }
@@ -1201,7 +1201,7 @@ bool CDecoder::ConfigVAAPI()
     if (!success)
     {
       reply->Release();
-      CLog::Log(LOGERROR, "VAAPI::{} - vaapi output returned error", __FUNCTION__);
+      CLog::LogF(LOGERROR, "VAAPI: vaapi output returned error");
       m_vaapiOutput.Dispose();
       return false;
     }
@@ -1209,7 +1209,7 @@ bool CDecoder::ConfigVAAPI()
   }
   else
   {
-    CLog::Log(LOGERROR, "VAAPI::{} - failed to init output", __FUNCTION__);
+    CLog::LogF(LOGERROR, "VAAPI: failed to init output");
     m_vaapiOutput.Dispose();
     return false;
   }
@@ -1603,8 +1603,8 @@ void COutput::StateMachine(int signal, Protocol *port, Message *msg)
       }
       {
         std::string portName = port == NULL ? "timer" : port->portName;
-        CLog::Log(LOGWARNING, "COutput::{} - signal: {} form port: {} not handled for state: {}",
-                  __FUNCTION__, signal, portName, m_state);
+        CLog::LogF(LOGWARNING, "COutput: signal: {} form port: {} not handled for state: {}",
+                   signal, portName, m_state);
       }
       return;
 
@@ -1830,7 +1830,7 @@ void COutput::StateMachine(int signal, Protocol *port, Message *msg)
       break;
 
     default: // we are in no state, should not happen
-      CLog::Log(LOGERROR, "COutput::{} - no valid state: {}", __FUNCTION__, m_state);
+      CLog::LogF(LOGERROR, "COutput: no valid state: {}", m_state);
       return;
     }
   } // for

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
@@ -677,13 +677,13 @@ long CDecoder::Release()
       reply->Release();
       if (!success)
       {
-        CLog::Log(LOGERROR, "VDPAU::{} - pre-cleanup returned error", __FUNCTION__);
+        CLog::LogF(LOGERROR, "VDPAU: pre-cleanup returned error");
         m_DisplayState = VDPAU_ERROR;
       }
     }
     else
     {
-      CLog::Log(LOGERROR, "VDPAU::{} - pre-cleanup timed out", __FUNCTION__);
+      CLog::LogF(LOGERROR, "VDPAU: pre-cleanup timed out");
       m_DisplayState = VDPAU_ERROR;
     }
 
@@ -972,14 +972,14 @@ bool CDecoder::ConfigVDPAU(AVCodecContext* avctx, int ref_frames)
     reply->Release();
     if (!success)
     {
-      CLog::Log(LOGERROR, "VDPAU::{} - vdpau output returned error", __FUNCTION__);
+      CLog::LogF(LOGERROR, "VDPAU: vdpau output returned error");
       m_vdpauOutput.Dispose();
       return false;
     }
   }
   else
   {
-    CLog::Log(LOGERROR, "VDPAU::{} - failed to init output", __FUNCTION__);
+    CLog::LogF(LOGERROR, "VDPAU: failed to init output");
     m_vdpauOutput.Dispose();
     return false;
   }
@@ -1036,7 +1036,7 @@ int CDecoder::FFGetBuffer(AVCodecContext *avctx, AVFrame *pic, int flags)
   AVBufferRef *buffer = av_buffer_create(pic->data[3], 0, FFReleaseBuffer, vdp, 0);
   if (!buffer)
   {
-    CLog::Log(LOGERROR, "CVDPAU::{} - error creating buffer", __FUNCTION__);
+    CLog::LogF(LOGERROR, "CVDPAU: error creating buffer");
     return -1;
   }
   pic->buf[0] = buffer;
@@ -1232,7 +1232,7 @@ CDVDVideoCodec::VCReturn CDecoder::Decode(AVCodecContext *avctx, AVFrame *pFrame
       break;
   }
 
-  CLog::Log(LOGERROR, "VDPAU::{} - timed out waiting for output message", __FUNCTION__);
+  CLog::LogF(LOGERROR, "VDPAU: timed out waiting for output message");
   m_DisplayState = VDPAU_ERROR;
 
   return CDVDVideoCodec::VC_ERROR;
@@ -1278,7 +1278,7 @@ void CDecoder::Reset()
     reply->Release();
     if (!success)
     {
-      CLog::Log(LOGERROR, "VDPAU::{} - flush returned error", __FUNCTION__);
+      CLog::LogF(LOGERROR, "VDPAU: flush returned error");
       m_DisplayState = VDPAU_ERROR;
     }
     else
@@ -1286,7 +1286,7 @@ void CDecoder::Reset()
   }
   else
   {
-    CLog::Log(LOGERROR, "VDPAU::{} - flush timed out", __FUNCTION__);
+    CLog::LogF(LOGERROR, "VDPAU: flush timed out");
     m_DisplayState = VDPAU_ERROR;
   }
 }
@@ -1633,8 +1633,8 @@ void CMixer::StateMachine(int signal, Protocol *port, Message *msg)
       }
       {
         std::string portName = port == NULL ? "timer" : port->portName;
-        CLog::Log(LOGWARNING, "CMixer::{} - signal: {} form port: {} not handled for state: {}",
-                  __FUNCTION__, signal, portName, m_state);
+        CLog::LogF(LOGWARNING, "CMixer: signal: {} form port: {} not handled for state: {}", signal,
+                   portName, m_state);
       }
       return;
 
@@ -1842,8 +1842,8 @@ void CMixer::StateMachine(int signal, Protocol *port, Message *msg)
        break;
 
     default: // we are in no state, should not happen
-      CLog::Log(LOGERROR, "CMixer::{} - no valid state: {}", __FUNCTION__, m_state);
-      return;
+       CLog::LogF(LOGERROR, "CMixer: no valid state: {}", m_state);
+       return;
     }
   } // for
 }
@@ -2920,8 +2920,8 @@ void COutput::StateMachine(int signal, Protocol *port, Message *msg)
       }
       {
         std::string portName = port == NULL ? "timer" : port->portName;
-        CLog::Log(LOGWARNING, "COutput::{} - signal: {} form port: {} not handled for state: {}",
-                  __FUNCTION__, signal, portName, m_state);
+        CLog::LogF(LOGWARNING, "COutput: signal: {} form port: {} not handled for state: {}",
+                   signal, portName, m_state);
       }
       return;
 
@@ -3079,7 +3079,7 @@ void COutput::StateMachine(int signal, Protocol *port, Message *msg)
       break;
 
     default: // we are in no state, should not happen
-      CLog::Log(LOGERROR, "COutput::{} - no valid state: {}", __FUNCTION__, m_state);
+      CLog::LogF(LOGERROR, "COutput: no valid state: {}", m_state);
       return;
     }
   } // for
@@ -3190,7 +3190,7 @@ void COutput::Flush()
       reply->Release();
     }
     else
-      CLog::Log(LOGERROR, "Coutput::{} - failed to flush mixer", __FUNCTION__);
+      CLog::LogF(LOGERROR, "Coutput: failed to flush mixer");
   }
 
   Message *msg;

--- a/xbmc/cores/VideoPlayer/DVDDemuxSPU.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxSPU.cpp
@@ -496,7 +496,7 @@ std::shared_ptr<CDVDOverlaySpu> CDVDDemuxSPU::ParseRLE(std::shared_ptr<CDVDOverl
     // we only set it if there is a valid i_border color
     if (!pSPU->bHasColor)
     {
-      CLog::Log(LOGINFO, "{} - no color palette found, using default", __FUNCTION__);
+      CLog::LogF(LOGINFO, "no color palette found, using default");
       FindSubtitleColor(i_border, stats, *pSPU);
     }
 
@@ -508,8 +508,7 @@ std::shared_ptr<CDVDOverlaySpu> CDVDDemuxSPU::ParseRLE(std::shared_ptr<CDVDOverl
       // thus if there are no pixels to display, we assume the alphas are incorrect.
       if (!CanDisplayWithAlphas(pSPU->alpha, stats))
       {
-        CLog::Log(LOGINFO, "{} - no  matching color and alpha found, resetting alpha",
-                  __FUNCTION__);
+        CLog::LogF(LOGINFO, "no  matching color and alpha found, resetting alpha");
 
         pSPU->alpha[0] = 0x00; // back ground
         pSPU->alpha[1] = 0x0f;
@@ -519,7 +518,7 @@ std::shared_ptr<CDVDOverlaySpu> CDVDDemuxSPU::ParseRLE(std::shared_ptr<CDVDOverl
     }
     else
     {
-      CLog::Log(LOGINFO, "{} - ignoring blank alpha palette, using default", __FUNCTION__);
+      CLog::LogF(LOGINFO, "ignoring blank alpha palette, using default");
 
       pSPU->alpha[0] = 0x00; // back ground
       pSPU->alpha[1] = 0x0f;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -404,8 +404,7 @@ bool CDVDDemuxFFmpeg::Open(const std::shared_ptr<CDVDInputStream>& pInput, bool 
         pd.buf_size = avio_read(m_ioContext, pd.buf, probeBufferSize);
         if (pd.buf_size <= 0)
         {
-          CLog::Log(LOGERROR, "{} - error reading from input stream, {}", __FUNCTION__,
-                    CURL::GetRedacted(strFile));
+          CLog::LogF(LOGERROR, "error reading from input stream, {}", CURL::GetRedacted(strFile));
           return false;
         }
         memset(pd.buf + pd.buf_size, 0, AVPROBE_PADDING_SIZE);
@@ -442,7 +441,7 @@ bool CDVDDemuxFFmpeg::Open(const std::shared_ptr<CDVDInputStream>& pInput, bool 
             {
               // not dts either, return false in case we were explicitly
               // requested to only check for S/PDIF padded compressed audio
-              CLog::Log(LOGDEBUG, "{} - not spdif or dts file, falling back", __FUNCTION__);
+              CLog::LogF(LOGDEBUG, "not spdif or dts file, falling back");
               return false;
             }
           }
@@ -466,16 +465,15 @@ bool CDVDDemuxFFmpeg::Open(const std::shared_ptr<CDVDInputStream>& pInput, bool 
 
       if (!iformat)
       {
-        CLog::Log(LOGERROR, "{} - error probing input format, {}", __FUNCTION__,
-                  CURL::GetRedacted(strFile));
+        CLog::LogF(LOGERROR, "error probing input format, {}", CURL::GetRedacted(strFile));
         return false;
       }
       else
       {
         if (iformat->name)
-          CLog::Log(LOGDEBUG, "{} - probing detected format [{}]", __FUNCTION__, iformat->name);
+          CLog::LogF(LOGDEBUG, "probing detected format [{}]", iformat->name);
         else
-          CLog::Log(LOGDEBUG, "{} - probing detected unnamed format", __FUNCTION__);
+          CLog::LogF(LOGDEBUG, "probing detected unnamed format");
       }
     }
 
@@ -485,7 +483,7 @@ bool CDVDDemuxFFmpeg::Open(const std::shared_ptr<CDVDInputStream>& pInput, bool 
     AVDictionary* options = NULL;
     if (iformat->name && (strcmp(iformat->name, "mp3") == 0 || strcmp(iformat->name, "mp2") == 0))
     {
-      CLog::Log(LOGDEBUG, "{} - setting usetoc to 0 for accurate VBR MP3 seek", __FUNCTION__);
+      CLog::LogF(LOGDEBUG, "setting usetoc to 0 for accurate VBR MP3 seek");
       av_dict_set(&options, "usetoc", "0", 0);
     }
 
@@ -500,8 +498,7 @@ bool CDVDDemuxFFmpeg::Open(const std::shared_ptr<CDVDInputStream>& pInput, bool 
 
     if (avformat_open_input(&m_pFormatContext, strFile.c_str(), iformat, &options) < 0)
     {
-      CLog::Log(LOGERROR, "{} - Error, could not open file {}", __FUNCTION__,
-                CURL::GetRedacted(strFile));
+      CLog::LogF(LOGERROR, "Error, could not open file {}", CURL::GetRedacted(strFile));
       Dispose();
       av_dict_free(&options);
       return false;
@@ -555,7 +552,7 @@ bool CDVDDemuxFFmpeg::Open(const std::shared_ptr<CDVDInputStream>& pInput, bool 
     if (m_pInput->IsStreamType(DVDSTREAM_TYPE_DVD))
       av_opt_set_int(m_pFormatContext, "analyzeduration", 500000, 0);
 
-    CLog::Log(LOGDEBUG, "{} - avformat_find_stream_info starting", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "avformat_find_stream_info starting");
     int iErr = avformat_find_stream_info(m_pFormatContext, NULL);
     if (iErr < 0)
     {
@@ -574,7 +571,7 @@ bool CDVDDemuxFFmpeg::Open(const std::shared_ptr<CDVDInputStream>& pInput, bool 
         return false;
       }
     }
-    CLog::Log(LOGDEBUG, "{} - av_find_stream_info finished", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "av_find_stream_info finished");
 
     // print some extra information
     av_dump_format(m_pFormatContext, 0, CURL::GetRedacted(strFile).c_str(), 0);
@@ -1280,7 +1277,7 @@ bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double* startpts)
   if (!m_pInput->Seek(0, SEEK_POSSIBLE) &&
       !m_pInput->IsStreamType(DVDSTREAM_TYPE_FFMPEG))
   {
-    CLog::Log(LOGDEBUG, "{} - input stream reports it is not seekable", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "input stream reports it is not seekable");
     return false;
   }
 
@@ -1303,8 +1300,7 @@ bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double* startpts)
 
       if (timer.IsTimePast())
       {
-        CLog::Log(LOGERROR, "CDVDDemuxFFmpeg::{} - Timed out waiting for video to be ready",
-                  __FUNCTION__);
+        CLog::LogF(LOGERROR, "CDVDDemuxFFmpeg: Timed out waiting for video to be ready");
         return false;
       }
     }
@@ -1356,10 +1352,9 @@ bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double* startpts)
   }
 
   if (m_currentPts == DVD_NOPTS_VALUE)
-    CLog::Log(LOGDEBUG, "{} - unknown position after seek", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "unknown position after seek");
   else
-    CLog::Log(LOGDEBUG, "{} - seek ended up on time {}", __FUNCTION__,
-              (int)(m_currentPts / DVD_TIME_BASE * 1000));
+    CLog::LogF(LOGDEBUG, "seek ended up on time {}", (int)(m_currentPts / DVD_TIME_BASE * 1000));
 
   // in this case the start time is requested time
   if (startpts)
@@ -1737,8 +1732,7 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
             {
               pStream->codecpar->codec_id = AV_CODEC_ID_MPEG2VIDEO;
               pStream->codecpar->codec_tag = MKTAG('M','P','2','V');
-              CLog::Log(LOGERROR, "{} - AV_CODEC_ID_PROBE detected, forcing AV_CODEC_ID_MPEG2VIDEO",
-                        __FUNCTION__);
+              CLog::LogF(LOGERROR, "AV_CODEC_ID_PROBE detected, forcing AV_CODEC_ID_MPEG2VIDEO");
             }
           }
         }
@@ -2064,7 +2058,7 @@ bool CDVDDemuxFFmpeg::SeekChapter(int chapter, double* startpts)
   std::shared_ptr<CDVDInputStream::IChapter> ich = std::dynamic_pointer_cast<CDVDInputStream::IChapter>(m_pInput);
   if (ich)
   {
-    CLog::Log(LOGDEBUG, "{} - chapter seeking using input stream", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "chapter seeking using input stream");
     if (!ich->SeekChapter(chapter))
       return false;
 
@@ -2286,7 +2280,7 @@ void CDVDDemuxFFmpeg::ParsePacket(AVPacket* pkt)
       const AVCodec* codec = avcodec_find_decoder(st->codecpar->codec_id);
       if (codec == nullptr)
       {
-        CLog::Log(LOGERROR, "{} - can't find decoder", __FUNCTION__);
+        CLog::LogF(LOGERROR, "can't find decoder");
         m_parsers.erase(parser);
         return;
       }
@@ -2501,7 +2495,7 @@ void CDVDDemuxFFmpeg::GetL16Parameters(int &channels, int &samplerate)
             if (val > 0)
               channels = val;
             else
-              CLog::Log(LOGDEBUG, "CDVDDemuxFFmpeg::{} - no parameter for channels", __FUNCTION__);
+              CLog::LogF(LOGDEBUG, "CDVDDemuxFFmpeg: no parameter for channels");
           }
         }
         else if (content.compare(pos, 5, "rate=", 5) == 0)
@@ -2519,8 +2513,7 @@ void CDVDDemuxFFmpeg::GetL16Parameters(int &channels, int &samplerate)
             if (val > 0)
               samplerate = val;
             else
-              CLog::Log(LOGDEBUG, "CDVDDemuxFFmpeg::{} - no parameter for samplerate",
-                        __FUNCTION__);
+              CLog::LogF(LOGDEBUG, "CDVDDemuxFFmpeg: no parameter for samplerate");
           }
         }
         pos = content.find(';', pos); // find next parameter

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp
@@ -27,8 +27,7 @@ void CDVDDemuxUtils::FreeDemuxPacket(DemuxPacket* pPacket)
       AVPacket* avPkt = av_packet_alloc();
       if (!avPkt)
       {
-        CLog::Log(LOGERROR, "CDVDDemuxUtils::{} - av_packet_alloc failed: {}", __FUNCTION__,
-                  strerror(errno));
+        CLog::LogF(LOGERROR, "CDVDDemuxUtils: av_packet_alloc failed: {}", strerror(errno));
       }
       else
       {
@@ -91,8 +90,7 @@ void CDVDDemuxUtils::StoreSideData(DemuxPacket *pkt, AVPacket *src)
   AVPacket* avPkt = av_packet_alloc();
   if (!avPkt)
   {
-    CLog::Log(LOGERROR, "CDVDDemuxUtils::{} - av_packet_alloc failed: {}", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CDVDDemuxUtils: av_packet_alloc failed: {}", strerror(errno));
     return;
   }
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxMultiSource.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxMultiSource.cpp
@@ -184,8 +184,8 @@ DemuxPacket* CDemuxMultiSource::Read()
     {
       if (input->second->IsEOF())
       {
-        CLog::Log(LOGDEBUG, "{} - Demuxer for file {} is at eof, removed it from the queue",
-                  __FUNCTION__, CURL::GetRedacted(currentDemuxer->GetFileName()));
+        CLog::LogF(LOGDEBUG, "Demuxer for file {} is at eof, removed it from the queue",
+                   CURL::GetRedacted(currentDemuxer->GetFileName()));
       }
       else    //maybe add an error counter?
         m_demuxerQueue.push(std::make_pair(-1.0, currentDemuxer));
@@ -204,12 +204,12 @@ bool CDemuxMultiSource::SeekTime(double time, bool backwards, double* startpts)
     if (iter.second->SeekTime(time, false, startpts))
     {
       demuxerQueue.push(std::make_pair(*startpts, iter.second));
-      CLog::Log(LOGDEBUG, "{} - starting demuxer from: {:f}", __FUNCTION__, time);
+      CLog::LogF(LOGDEBUG, "starting demuxer from: {:f}", time);
       ret = true;
     }
     else
     {
-      CLog::Log(LOGDEBUG, "{} - failed to start demuxing from: {:f}", __FUNCTION__, time);
+      CLog::LogF(LOGDEBUG, "failed to start demuxing from: {:f}", time);
     }
   }
   m_demuxerQueue = demuxerQueue;

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -115,13 +115,13 @@ bool CDVDFileInfo::ExtractThumb(const CFileItem& fileItem,
     pDemuxer = CDVDFactoryDemuxer::CreateDemuxer(pInputStream, true);
     if(!pDemuxer)
     {
-      CLog::Log(LOGERROR, "{} - Error creating demuxer", __FUNCTION__);
+      CLog::LogF(LOGERROR, "Error creating demuxer");
       return false;
     }
   }
   catch(...)
   {
-    CLog::Log(LOGERROR, "{} - Exception thrown when opening demuxer", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Exception thrown when opening demuxer");
     if (pDemuxer)
       delete pDemuxer;
 
@@ -201,8 +201,8 @@ bool CDVDFileInfo::ExtractThumb(const CFileItem& fileItem,
       int nTotalLen = pDemuxer->GetStreamLength();
       int64_t nSeekTo = (pos == -1) ? nTotalLen / 3 : pos;
 
-      CLog::Log(LOGDEBUG, "{} - seeking to pos {}ms (total: {}ms) in {}", __FUNCTION__, nSeekTo,
-                nTotalLen, redactPath);
+      CLog::LogF(LOGDEBUG, "seeking to pos {}ms (total: {}ms) in {}", nSeekTo, nTotalLen,
+                 redactPath);
 
       if (pDemuxer->SeekTime(static_cast<double>(nSeekTo), true))
       {
@@ -281,8 +281,7 @@ bool CDVDFileInfo::ExtractThumb(const CFileItem& fileItem,
         }
         else
         {
-          CLog::Log(LOGDEBUG, "{} - decode failed in {} after {} packets.", __FUNCTION__,
-                    redactPath, packetsTried);
+          CLog::LogF(LOGDEBUG, "decode failed in {} after {} packets.", redactPath, packetsTried);
         }
       }
     }
@@ -300,8 +299,8 @@ bool CDVDFileInfo::ExtractThumb(const CFileItem& fileItem,
 
   auto end = std::chrono::steady_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-  CLog::Log(LOGDEBUG, "{} - measured {} ms to extract thumb from file <{}> in {} packets. ",
-            __FUNCTION__, duration.count(), redactPath, packetsTried);
+  CLog::LogF(LOGDEBUG, "measured {} ms to extract thumb from file <{}> in {} packets. ",
+             duration.count(), redactPath, packetsTried);
 
   return bOk;
 }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -184,7 +184,7 @@ bool CDVDInputStreamNavigator::Open()
     }
   }
 
-  CLog::Log(LOGDEBUG, "{} - Setting region mask {:02x}", __FUNCTION__, mask);
+  CLog::LogF(LOGDEBUG, "Setting region mask {:02x}", mask);
   m_dll.dvdnav_set_region_mask(m_dvdnav, mask);
 
   // get default language settings
@@ -525,9 +525,8 @@ int CDVDInputStreamNavigator::ProcessBlock(uint8_t* dest_buffer, int* read)
           int entries = m_dll.dvdnav_describe_title_chapters(m_dvdnav, m_iTitle, &times, &duration);
 
           if (entries != m_iPartCount)
-            CLog::Log(LOGDEBUG,
-                      "{} - Number of chapters/positions differ: Chapters {}, positions {}",
-                      __FUNCTION__, m_iPartCount, entries);
+          CLog::LogF(LOGDEBUG, "Number of chapters/positions differ: Chapters {}, positions {}",
+                     m_iPartCount, entries);
 
           if (times)
           {
@@ -540,10 +539,9 @@ int CDVDInputStreamNavigator::ProcessBlock(uint8_t* dest_buffer, int* read)
             free(times);
           }
         }
-        CLog::Log(LOGDEBUG, "{} - Cell change: Title {}, Chapter {}", __FUNCTION__, m_iTitle,
-                  m_iPart);
-        CLog::Log(LOGDEBUG, "{} - At position {:.0f}% inside the feature", __FUNCTION__,
-                  100 * (double)pos / (double)len);
+        CLog::LogF(LOGDEBUG, "Cell change: Title {}, Chapter {}", m_iTitle, m_iPart);
+        CLog::LogF(LOGDEBUG, "At position {:.0f}% inside the feature",
+                   100 * (double)pos / (double)len);
         //Get total segment time
 
         dvdnav_cell_change_event_t* cell_change_event = reinterpret_cast<dvdnav_cell_change_event_t*>(buf);
@@ -1234,8 +1232,7 @@ bool CDVDInputStreamNavigator::SeekChapter(int iChapter)
   // therefore we just skip the request in case there are buttons and return false
   if (IsInMenu() && GetTotalButtons() > 0)
   {
-    CLog::Log(LOGDEBUG, "{} - Seeking chapter is not allowed in menu set with buttons",
-              __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "Seeking chapter is not allowed in menu set with buttons");
     return false;
   }
 
@@ -1283,7 +1280,7 @@ float CDVDInputStreamNavigator::GetVideoAspectRatio()
   //and such. should be able to give us info that we can zoom in automatically
   //not sure what to do with it currently
 
-  CLog::Log(LOGINFO, "{} - Aspect wanted: {}, Scale permissions: {}", __FUNCTION__, iAspect, iPerm);
+  CLog::LogF(LOGINFO, "Aspect wanted: {}, Scale permissions: {}", iAspect, iPerm);
   switch(iAspect)
   {
     case 0: //4:3

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserMicroDVD.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserMicroDVD.cpp
@@ -36,7 +36,7 @@ bool CDVDSubtitleParserMicroDVD::Open(CDVDStreamInfo& hints)
   if (!Initialize())
     return false;
 
-  CLog::Log(LOGDEBUG, "{} - framerate {}:{}", __FUNCTION__, hints.fpsrate, hints.fpsscale);
+  CLog::LogF(LOGDEBUG, "framerate {}:{}", hints.fpsrate, hints.fpsscale);
   if (hints.fpsscale > 0 && hints.fpsrate > 0)
   {
     m_framerate = (double)hints.fpsscale / (double)hints.fpsrate;

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleStream.cpp
@@ -37,10 +37,10 @@ bool CDVDSubtitleStream::Open(const std::string& strFile)
 
     if (URIUtils::HasExtension(strFile, ".sub") && IsIncompatible(pInputStream.get(), buf, &totalread))
     {
-      CLog::Log(LOGDEBUG,
-                "{}: file {} seems to be a vob sub"
-                "file without an idx file, skipping it",
-                __FUNCTION__, CURL::GetRedacted(pInputStream->GetFileName()));
+      CLog::LogF(LOGDEBUG,
+                 "file {} seems to be a vob sub"
+                 "file without an idx file, skipping it",
+                 CURL::GetRedacted(pInputStream->GetFileName()));
       buf.clear();
       return false;
     }

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitlesLibass.cpp
@@ -174,7 +174,7 @@ bool CDVDSubtitlesLibass::DecodeDemuxPkt(const char* data, int size, double star
   std::unique_lock<CCriticalSection> lock(m_section);
   if (!m_track)
   {
-    CLog::Log(LOGERROR, "{} - No SSA header found.", __FUNCTION__);
+    CLog::LogF(LOGERROR, "No SSA header found.");
     return false;
   }
 
@@ -189,7 +189,7 @@ bool CDVDSubtitlesLibass::CreateTrack()
   std::unique_lock<CCriticalSection> lock(m_section);
   if (!m_library)
   {
-    CLog::Log(LOGERROR, "{} - Failed to create ASS track, library not initialized.", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Failed to create ASS track, library not initialized.");
     return false;
   }
 
@@ -197,7 +197,7 @@ bool CDVDSubtitlesLibass::CreateTrack()
   m_track = ass_new_track(m_library);
   if (m_track == NULL)
   {
-    CLog::Log(LOGERROR, "{} - Failed to allocate ASS track.", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Failed to allocate ASS track.");
     return false;
   }
 
@@ -217,13 +217,13 @@ bool CDVDSubtitlesLibass::CreateStyle()
   std::unique_lock<CCriticalSection> lock(m_section);
   if (!m_library)
   {
-    CLog::Log(LOGERROR, "{} - Failed to create ASS style, library not initialized.", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Failed to create ASS style, library not initialized.");
     return false;
   }
 
   if (!m_track)
   {
-    CLog::Log(LOGERROR, "{} - Failed to create ASS style, track not initialized.", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Failed to create ASS style, track not initialized.");
     return false;
   }
 
@@ -236,7 +236,7 @@ bool CDVDSubtitlesLibass::CreateTrack(char* buf, size_t size)
   std::unique_lock<CCriticalSection> lock(m_section);
   if (!m_library)
   {
-    CLog::Log(LOGERROR, "{} - No ASS library struct (m_library)", __FUNCTION__);
+    CLog::LogF(LOGERROR, "No ASS library struct (m_library)");
     return false;
   }
 
@@ -258,13 +258,13 @@ ASS_Image* CDVDSubtitlesLibass::RenderImage(double pts,
   std::unique_lock<CCriticalSection> lock(m_section);
   if (!m_renderer || !m_track)
   {
-    CLog::Log(LOGERROR, "{} - ASS renderer/ASS track not initialized.", __FUNCTION__);
+    CLog::LogF(LOGERROR, "ASS renderer/ASS track not initialized.");
     return nullptr;
   }
 
   if (!subStyle)
   {
-    CLog::Log(LOGERROR, "{} - The subtitle overlay style is not set.", __FUNCTION__);
+    CLog::LogF(LOGERROR, "The subtitle overlay style is not set.");
     return nullptr;
   }
 
@@ -334,11 +334,11 @@ ASS_Image* CDVDSubtitlesLibass::RenderImage(double pts,
 
 void CDVDSubtitlesLibass::ApplyStyle(const std::shared_ptr<struct style>& subStyle, renderOpts opts)
 {
-  CLog::Log(LOGDEBUG, "{} - Start setting up the LibAss style", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "Start setting up the LibAss style");
 
   if (!subStyle)
   {
-    CLog::Log(LOGERROR, "{} - The subtitle overlay style is not set.", __FUNCTION__);
+    CLog::LogF(LOGERROR, "The subtitle overlay style is not set.");
     return;
   }
 
@@ -534,7 +534,7 @@ int CDVDSubtitlesLibass::GetPlayResY()
 {
   if (!m_track)
   {
-    CLog::Log(LOGERROR, "{} - ASS renderer/ASS track not initialized.", __FUNCTION__);
+    CLog::LogF(LOGERROR, "ASS renderer/ASS track not initialized.");
     return VIEWPORT_HEIGHT;
   }
   return m_track->PlayResY;
@@ -545,7 +545,7 @@ void CDVDSubtitlesLibass::ConfigureAssOverride(const std::shared_ptr<struct styl
 {
   if (!subStyle)
   {
-    CLog::Log(LOGERROR, "{} - The subtitle overlay style is not set.", __FUNCTION__);
+    CLog::LogF(LOGERROR, "The subtitle overlay style is not set.");
     return;
   }
 
@@ -583,7 +583,7 @@ ASS_Event* CDVDSubtitlesLibass::GetEvents()
   std::unique_lock<CCriticalSection> lock(m_section);
   if (!m_track)
   {
-    CLog::Log(LOGERROR, "{} -  Missing ASS structs (m_track)", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Missing ASS structs (m_track)");
     return NULL;
   }
   return m_track->events;
@@ -609,16 +609,15 @@ int CDVDSubtitlesLibass::AddEvent(const char* text,
 {
   if (text == NULL || text[0] == '\0')
   {
-    CLog::Log(LOGDEBUG,
-              "{} - Add event skipped due to empty text (with start time: {}, stop time {})",
-              __FUNCTION__, startTime, stopTime);
+    CLog::LogF(LOGDEBUG, "Add event skipped due to empty text (with start time: {}, stop time {})",
+               startTime, stopTime);
     return ASS_NO_ID;
   }
 
   std::unique_lock<CCriticalSection> lock(m_section);
   if (!m_library || !m_track)
   {
-    CLog::Log(LOGERROR, "{} - Missing ASS structs (m_library or m_track)", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Missing ASS structs (m_library or m_track)");
     return ASS_NO_ID;
   }
 
@@ -640,7 +639,7 @@ int CDVDSubtitlesLibass::AddEvent(const char* text,
     return eventId;
   }
   else
-    CLog::Log(LOGERROR, "{} - Cannot allocate a new event", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Cannot allocate a new event");
   return ASS_NO_ID;
 }
 
@@ -651,15 +650,14 @@ void CDVDSubtitlesLibass::AppendTextToEvent(int eventId, const char* text)
     return;
   if (!m_track)
   {
-    CLog::Log(LOGERROR, "{} -  Missing ASS structs (m_track)", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Missing ASS structs (m_track)");
     return;
   }
 
   ASS_Event* assEvents = m_track->events;
   if (!assEvents)
   {
-    CLog::Log(LOGERROR, "{} -  Failed append text to Event ID {}, there are no Events",
-              __FUNCTION__, eventId);
+    CLog::LogF(LOGERROR, "Failed append text to Event ID {}, there are no Events", eventId);
     return;
   }
 
@@ -683,15 +681,14 @@ void CDVDSubtitlesLibass::ChangeEventStopTime(int eventId, double stopTime)
     return;
   if (!m_track)
   {
-    CLog::Log(LOGERROR, "{} -  Missing ASS structs (m_track)", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Missing ASS structs (m_track)");
     return;
   }
 
   ASS_Event* assEvents = m_track->events;
   if (!assEvents)
   {
-    CLog::Log(LOGERROR, "{} -  Failed change stop time to Event ID {}, there are no Events",
-              __FUNCTION__, eventId);
+    CLog::LogF(LOGERROR, "Failed change stop time to Event ID {}, there are no Events", eventId);
     return;
   }
 
@@ -705,7 +702,7 @@ void CDVDSubtitlesLibass::FlushEvents()
   std::unique_lock<CCriticalSection> lock(m_section);
   if (!m_library || !m_track)
   {
-    CLog::Log(LOGERROR, "{} - Missing ASS structs (m_library or m_track)", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Missing ASS structs (m_library or m_track)");
     return;
   }
 
@@ -717,7 +714,7 @@ int CDVDSubtitlesLibass::DeleteEvents(int nEvents, int threshold)
   std::unique_lock<CCriticalSection> lock(m_section);
   if (!m_library || !m_track)
   {
-    CLog::Log(LOGERROR, "{} - Missing ASS structs (m_library or m_track)", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Missing ASS structs (m_library or m_track)");
     return ASS_NO_ID;
   }
 

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTISOHandler.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTISOHandler.cpp
@@ -62,7 +62,7 @@ void CWebVTTISOHandler::DecodeStream(const char* buffer,
   {
     if (sampleData.CharsLeft() < MP4_BOX_HEADER_SIZE)
     {
-      CLog::Log(LOGWARNING, "{} - Incomplete box header found", __FUNCTION__);
+      CLog::LogF(LOGWARNING, "Incomplete box header found");
       break;
     }
 
@@ -116,7 +116,7 @@ bool CWebVTTISOHandler::ParseVTTCueBox(CCharArrayParser& sampleData,
   {
     if (remainingCueBoxChars < MP4_BOX_HEADER_SIZE)
     {
-      CLog::Log(LOGWARNING, "{} - Incomplete VTT Cue box header found", __FUNCTION__);
+      CLog::LogF(LOGWARNING, "Incomplete VTT Cue box header found");
       return false;
     }
     uint32_t boxSize = sampleData.ReadNextUnsignedInt();

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -55,9 +55,9 @@ bool CEdl::ReadEditDecisionLists(const CFileItem& fileItem, const float fFramesP
   if ((URIUtils::IsHD(strMovie) || URIUtils::IsOnLAN(strMovie)) &&
       !URIUtils::IsInternetStream(strMovie))
   {
-    CLog::Log(LOGDEBUG,
-              "{} - Checking for edit decision lists (EDL) on local drive or remote share for: {}",
-              __FUNCTION__, CURL::GetRedacted(strMovie));
+    CLog::LogF(LOGDEBUG,
+               "Checking for edit decision lists (EDL) on local drive or remote share for: {}",
+               CURL::GetRedacted(strMovie));
 
     /*
      * Read any available file format until a valid EDL related file is found.
@@ -99,8 +99,7 @@ bool CEdl::ReadEdl(const std::string& strMovie, const float fFramesPerSecond)
   CFile edlFile;
   if (!edlFile.Open(edlFilename))
   {
-    CLog::Log(LOGERROR, "{} - Could not open EDL file: {}", __FUNCTION__,
-              CURL::GetRedacted(edlFilename));
+    CLog::LogF(LOGERROR, "Could not open EDL file: {}", CURL::GetRedacted(edlFilename));
     return false;
   }
 
@@ -112,8 +111,8 @@ bool CEdl::ReadEdl(const std::string& strMovie, const float fFramesPerSecond)
   {
     // Log any errors from previous run in the loop
     if (bError)
-      CLog::Log(LOGWARNING, "{} - Error on line {} in EDL file: {}", __FUNCTION__, iLine,
-                CURL::GetRedacted(edlFilename));
+      CLog::LogF(LOGWARNING, "Error on line {} in EDL file: {}", iLine,
+                 CURL::GetRedacted(edlFilename));
 
     bError = false;
 
@@ -223,47 +222,47 @@ bool CEdl::ReadEdl(const std::string& strMovie, const float fFramesPerSecond)
       edit.action = Action::CUT;
       if (!AddEdit(edit))
       {
-        CLog::Log(LOGWARNING, "{} - Error adding cut from line {} in EDL file: {}", __FUNCTION__,
-                  iLine, CURL::GetRedacted(edlFilename));
-        continue;
+          CLog::LogF(LOGWARNING, "Error adding cut from line {} in EDL file: {}", iLine,
+                     CURL::GetRedacted(edlFilename));
+          continue;
       }
       break;
     case 1:
       edit.action = Action::MUTE;
       if (!AddEdit(edit))
       {
-        CLog::Log(LOGWARNING, "{} - Error adding mute from line {} in EDL file: {}", __FUNCTION__,
-                  iLine, CURL::GetRedacted(edlFilename));
-        continue;
+          CLog::LogF(LOGWARNING, "Error adding mute from line {} in EDL file: {}", iLine,
+                     CURL::GetRedacted(edlFilename));
+          continue;
       }
       break;
     case 2:
       if (!AddSceneMarker(edit.end))
       {
-        CLog::Log(LOGWARNING, "{} - Error adding scene marker from line {} in EDL file: {}",
-                  __FUNCTION__, iLine, CURL::GetRedacted(edlFilename));
-        continue;
+          CLog::LogF(LOGWARNING, "Error adding scene marker from line {} in EDL file: {}", iLine,
+                     CURL::GetRedacted(edlFilename));
+          continue;
       }
       break;
     case 3:
       edit.action = Action::COMM_BREAK;
       if (!AddEdit(edit))
       {
-        CLog::Log(LOGWARNING, "{} - Error adding commercial break from line {} in EDL file: {}",
-                  __FUNCTION__, iLine, CURL::GetRedacted(edlFilename));
-        continue;
+          CLog::LogF(LOGWARNING, "Error adding commercial break from line {} in EDL file: {}",
+                     iLine, CURL::GetRedacted(edlFilename));
+          continue;
       }
       break;
     default:
-      CLog::Log(LOGWARNING, "{} - Invalid action on line {} in EDL file: {}", __FUNCTION__, iLine,
-                CURL::GetRedacted(edlFilename));
+      CLog::LogF(LOGWARNING, "Invalid action on line {} in EDL file: {}", iLine,
+                 CURL::GetRedacted(edlFilename));
       continue;
     }
   }
 
   if (bError) // Log last line warning, if there was one, since while loop will have terminated.
-    CLog::Log(LOGWARNING, "{} - Error on line {} in EDL file: {}", __FUNCTION__, iLine,
-              CURL::GetRedacted(edlFilename));
+    CLog::LogF(LOGWARNING, "Error on line {} in EDL file: {}", iLine,
+               CURL::GetRedacted(edlFilename));
 
   edlFile.Close();
 
@@ -275,8 +274,8 @@ bool CEdl::ReadEdl(const std::string& strMovie, const float fFramesPerSecond)
   }
   else
   {
-    CLog::Log(LOGDEBUG, "{} - No edits or scene markers found in EDL file: {}", __FUNCTION__,
-              CURL::GetRedacted(edlFilename));
+    CLog::LogF(LOGDEBUG, "No edits or scene markers found in EDL file: {}",
+               CURL::GetRedacted(edlFilename));
     return false;
   }
 }
@@ -292,8 +291,7 @@ bool CEdl::ReadComskip(const std::string& strMovie, const float fFramesPerSecond
   CFile comskipFile;
   if (!comskipFile.Open(comskipFilename))
   {
-    CLog::Log(LOGERROR, "{} - Could not open Comskip file: {}", __FUNCTION__,
-              CURL::GetRedacted(comskipFilename));
+    CLog::LogF(LOGERROR, "Could not open Comskip file: {}", CURL::GetRedacted(comskipFilename));
     return false;
   }
 
@@ -301,9 +299,8 @@ bool CEdl::ReadComskip(const std::string& strMovie, const float fFramesPerSecond
   if (comskipFile.ReadString(szBuffer, 1023)
   &&  strncmp(szBuffer, COMSKIP_HEADER, strlen(COMSKIP_HEADER)) != 0) // Line 1.
   {
-    CLog::Log(LOGERROR,
-              "{} - Invalid Comskip file: {}. Error reading line 1 - expected '{}' at start.",
-              __FUNCTION__, CURL::GetRedacted(comskipFilename), COMSKIP_HEADER);
+    CLog::LogF(LOGERROR, "Invalid Comskip file: {}. Error reading line 1 - expected '{}' at start.",
+               CURL::GetRedacted(comskipFilename), COMSKIP_HEADER);
     comskipFile.Close();
     return false;
   }
@@ -355,10 +352,10 @@ bool CEdl::ReadComskip(const std::string& strMovie, const float fFramesPerSecond
 
   if (!bValid)
   {
-    CLog::Log(LOGERROR,
-              "{} - Invalid Comskip file: {}. Error on line {}. Clearing any valid commercial "
-              "breaks found.",
-              __FUNCTION__, CURL::GetRedacted(comskipFilename), iLine);
+    CLog::LogF(LOGERROR,
+               "Invalid Comskip file: {}. Error on line {}. Clearing any valid commercial "
+               "breaks found.",
+               CURL::GetRedacted(comskipFilename), iLine);
     Clear();
     return false;
   }
@@ -370,8 +367,8 @@ bool CEdl::ReadComskip(const std::string& strMovie, const float fFramesPerSecond
   }
   else
   {
-    CLog::Log(LOGDEBUG, "{} - No commercial breaks found in Comskip file: {}", __FUNCTION__,
-              CURL::GetRedacted(comskipFilename));
+    CLog::LogF(LOGDEBUG, "No commercial breaks found in Comskip file: {}",
+               CURL::GetRedacted(comskipFilename));
     return false;
   }
 }
@@ -392,8 +389,7 @@ bool CEdl::ReadVideoReDo(const std::string& strMovie)
   CFile videoReDoFile;
   if (!videoReDoFile.Open(videoReDoFilename))
   {
-    CLog::Log(LOGERROR, "{} - Could not open VideoReDo file: {}", __FUNCTION__,
-              CURL::GetRedacted(videoReDoFilename));
+    CLog::LogF(LOGERROR, "Could not open VideoReDo file: {}", CURL::GetRedacted(videoReDoFilename));
     return false;
   }
 
@@ -401,10 +397,10 @@ bool CEdl::ReadVideoReDo(const std::string& strMovie)
   if (videoReDoFile.ReadString(szBuffer, 1023)
   &&  strncmp(szBuffer, VIDEOREDO_HEADER, strlen(VIDEOREDO_HEADER)) != 0)
   {
-    CLog::Log(LOGERROR,
-              "{} - Invalid VideoReDo file: {}. Error reading line 1 - expected {}. Only version 2 "
-              "files are supported.",
-              __FUNCTION__, CURL::GetRedacted(videoReDoFilename), VIDEOREDO_HEADER);
+    CLog::LogF(LOGERROR,
+               "Invalid VideoReDo file: {}. Error reading line 1 - expected {}. Only version 2 "
+               "files are supported.",
+               CURL::GetRedacted(videoReDoFilename), VIDEOREDO_HEADER);
     videoReDoFile.Close();
     return false;
   }
@@ -452,10 +448,10 @@ bool CEdl::ReadVideoReDo(const std::string& strMovie)
 
   if (!bValid)
   {
-    CLog::Log(LOGERROR,
-              "{} - Invalid VideoReDo file: {}. Error in line {}. Clearing any valid edits or "
-              "scenes found.",
-              __FUNCTION__, CURL::GetRedacted(videoReDoFilename), iLine);
+    CLog::LogF(LOGERROR,
+               "Invalid VideoReDo file: {}. Error in line {}. Clearing any valid edits or "
+               "scenes found.",
+               CURL::GetRedacted(videoReDoFilename), iLine);
     Clear();
     return false;
   }
@@ -468,8 +464,8 @@ bool CEdl::ReadVideoReDo(const std::string& strMovie)
   }
   else
   {
-    CLog::Log(LOGDEBUG, "{} - No edits or scene markers found in VideoReDo file: {}", __FUNCTION__,
-              CURL::GetRedacted(videoReDoFilename));
+    CLog::LogF(LOGDEBUG, "No edits or scene markers found in VideoReDo file: {}",
+               CURL::GetRedacted(videoReDoFilename));
     return false;
   }
 }
@@ -485,23 +481,23 @@ bool CEdl::ReadBeyondTV(const std::string& strMovie)
   CXBMCTinyXML xmlDoc;
   if (!xmlDoc.LoadFile(beyondTVFilename))
   {
-    CLog::Log(LOGERROR, "{} - Could not load Beyond TV file: {}. {}", __FUNCTION__,
-              CURL::GetRedacted(beyondTVFilename), xmlDoc.ErrorDesc());
+    CLog::LogF(LOGERROR, "Could not load Beyond TV file: {}. {}",
+               CURL::GetRedacted(beyondTVFilename), xmlDoc.ErrorDesc());
     return false;
   }
 
   if (xmlDoc.Error())
   {
-    CLog::Log(LOGERROR, "{} - Could not parse Beyond TV file: {}. {}", __FUNCTION__,
-              CURL::GetRedacted(beyondTVFilename), xmlDoc.ErrorDesc());
+    CLog::LogF(LOGERROR, "Could not parse Beyond TV file: {}. {}",
+               CURL::GetRedacted(beyondTVFilename), xmlDoc.ErrorDesc());
     return false;
   }
 
   TiXmlElement *pRoot = xmlDoc.RootElement();
   if (!pRoot || strcmp(pRoot->Value(), "cutlist"))
   {
-    CLog::Log(LOGERROR, "{} - Invalid Beyond TV file: {}. Expected root node to be <cutlist>",
-              __FUNCTION__, CURL::GetRedacted(beyondTVFilename));
+    CLog::LogF(LOGERROR, "Invalid Beyond TV file: {}. Expected root node to be <cutlist>",
+               CURL::GetRedacted(beyondTVFilename));
     return false;
   }
 
@@ -538,9 +534,8 @@ bool CEdl::ReadBeyondTV(const std::string& strMovie)
   }
   if (!bValid)
   {
-    CLog::Log(LOGERROR,
-              "{} - Invalid Beyond TV file: {}. Clearing any valid commercial breaks found.",
-              __FUNCTION__, CURL::GetRedacted(beyondTVFilename));
+    CLog::LogF(LOGERROR, "Invalid Beyond TV file: {}. Clearing any valid commercial breaks found.",
+               CURL::GetRedacted(beyondTVFilename));
     Clear();
     return false;
   }
@@ -552,8 +547,8 @@ bool CEdl::ReadBeyondTV(const std::string& strMovie)
   }
   else
   {
-    CLog::Log(LOGDEBUG, "{} - No commercial breaks found in Beyond TV file: {}", __FUNCTION__,
-              CURL::GetRedacted(beyondTVFilename));
+    CLog::LogF(LOGDEBUG, "No commercial breaks found in Beyond TV file: {}",
+               CURL::GetRedacted(beyondTVFilename));
     return false;
   }
 }
@@ -570,29 +565,29 @@ bool CEdl::ReadPvr(const CFileItem &fileItem)
       case Action::COMM_BREAK:
         if (AddEdit(edit))
         {
-          CLog::Log(LOGDEBUG, "{} - Added break [{} - {}] found in PVR item for: {}.", __FUNCTION__,
-                    MillisecondsToTimeString(edit.start), MillisecondsToTimeString(edit.end),
-                    CURL::GetRedacted(fileItem.GetDynPath()));
+          CLog::LogF(LOGDEBUG, "Added break [{} - {}] found in PVR item for: {}.",
+                     MillisecondsToTimeString(edit.start), MillisecondsToTimeString(edit.end),
+                     CURL::GetRedacted(fileItem.GetDynPath()));
         }
         else
         {
-          CLog::Log(LOGERROR,
-                    "{} - Invalid break [{} - {}] found in PVR item for: {}. Continuing anyway.",
-                    __FUNCTION__, MillisecondsToTimeString(edit.start),
-                    MillisecondsToTimeString(edit.end), CURL::GetRedacted(fileItem.GetDynPath()));
+          CLog::LogF(LOGERROR,
+                     "Invalid break [{} - {}] found in PVR item for: {}. Continuing anyway.",
+                     MillisecondsToTimeString(edit.start), MillisecondsToTimeString(edit.end),
+                     CURL::GetRedacted(fileItem.GetDynPath()));
         }
         break;
 
       case Action::SCENE:
         if (!AddSceneMarker(edit.end))
         {
-          CLog::Log(LOGWARNING, "{} - Error adding scene marker for PVR item", __FUNCTION__);
+          CLog::LogF(LOGWARNING, "Error adding scene marker for PVR item");
         }
         break;
 
       default:
-        CLog::Log(LOGINFO, "{} - Ignoring entry of unknown edit action: {}", __FUNCTION__,
-                  static_cast<int>(edit.action));
+        CLog::LogF(LOGINFO, "Ignoring entry of unknown edit action: {}",
+                   static_cast<int>(edit.action));
         break;
     }
   }
@@ -607,34 +602,32 @@ bool CEdl::AddEdit(const Edit& newEdit)
   if (edit.action != Action::CUT && edit.action != Action::MUTE &&
       edit.action != Action::COMM_BREAK)
   {
-    CLog::Log(LOGERROR,
-              "{} - Not an Action::CUT, Action::MUTE, or Action::COMM_BREAK! [{} - {}], {}",
-              __FUNCTION__, MillisecondsToTimeString(edit.start),
-              MillisecondsToTimeString(edit.end), static_cast<int>(edit.action));
+    CLog::LogF(LOGERROR, "Not an Action::CUT, Action::MUTE, or Action::COMM_BREAK! [{} - {}], {}",
+               MillisecondsToTimeString(edit.start), MillisecondsToTimeString(edit.end),
+               static_cast<int>(edit.action));
     return false;
   }
 
   if (edit.start < 0)
   {
-    CLog::Log(LOGERROR, "{} - Before start! [{} - {}], {}", __FUNCTION__,
-              MillisecondsToTimeString(edit.start), MillisecondsToTimeString(edit.end),
-              static_cast<int>(edit.action));
+    CLog::LogF(LOGERROR, "Before start! [{} - {}], {}", MillisecondsToTimeString(edit.start),
+               MillisecondsToTimeString(edit.end), static_cast<int>(edit.action));
     return false;
   }
 
   if (edit.start >= edit.end)
   {
-    CLog::Log(LOGERROR, "{} - Times are around the wrong way or the same! [{} - {}], {}",
-              __FUNCTION__, MillisecondsToTimeString(edit.start),
-              MillisecondsToTimeString(edit.end), static_cast<int>(edit.action));
+    CLog::LogF(LOGERROR, "Times are around the wrong way or the same! [{} - {}], {}",
+               MillisecondsToTimeString(edit.start), MillisecondsToTimeString(edit.end),
+               static_cast<int>(edit.action));
     return false;
   }
 
   if (InEdit(edit.start) || InEdit(edit.end))
   {
-    CLog::Log(LOGERROR, "{} - Start or end is in an existing edit! [{} - {}], {}", __FUNCTION__,
-              MillisecondsToTimeString(edit.start), MillisecondsToTimeString(edit.end),
-              static_cast<int>(edit.action));
+    CLog::LogF(LOGERROR, "Start or end is in an existing edit! [{} - {}], {}",
+               MillisecondsToTimeString(edit.start), MillisecondsToTimeString(edit.end),
+               static_cast<int>(edit.action));
     return false;
   }
 
@@ -642,9 +635,9 @@ bool CEdl::AddEdit(const Edit& newEdit)
   {
     if (edit.start < m_vecEdits[i].start && edit.end > m_vecEdits[i].end)
     {
-      CLog::Log(LOGERROR, "{} - Edit surrounds an existing edit! [{} - {}], {}", __FUNCTION__,
-                MillisecondsToTimeString(edit.start), MillisecondsToTimeString(edit.end),
-                static_cast<int>(edit.action));
+      CLog::LogF(LOGERROR, "Edit surrounds an existing edit! [{} - {}], {}",
+                 MillisecondsToTimeString(edit.start), MillisecondsToTimeString(edit.end),
+                 static_cast<int>(edit.action));
       return false;
     }
   }
@@ -680,9 +673,9 @@ bool CEdl::AddEdit(const Edit& newEdit)
    */
   if (m_vecEdits.empty() || edit.start > m_vecEdits.back().start)
   {
-    CLog::Log(LOGDEBUG, "{} - Pushing new edit to back [{} - {}], {}", __FUNCTION__,
-              MillisecondsToTimeString(edit.start), MillisecondsToTimeString(edit.end),
-              static_cast<int>(edit.action));
+    CLog::LogF(LOGDEBUG, "Pushing new edit to back [{} - {}], {}",
+               MillisecondsToTimeString(edit.start), MillisecondsToTimeString(edit.end),
+               static_cast<int>(edit.action));
     m_vecEdits.emplace_back(edit);
   }
   else
@@ -692,9 +685,9 @@ bool CEdl::AddEdit(const Edit& newEdit)
     {
       if (edit.start < pCurrentEdit->start)
       {
-        CLog::Log(LOGDEBUG, "{} - Inserting new edit [{} - {}], {}", __FUNCTION__,
-                  MillisecondsToTimeString(edit.start), MillisecondsToTimeString(edit.end),
-                  static_cast<int>(edit.action));
+        CLog::LogF(LOGDEBUG, "Inserting new edit [{} - {}], {}",
+                   MillisecondsToTimeString(edit.start), MillisecondsToTimeString(edit.end),
+                   static_cast<int>(edit.action));
         m_vecEdits.insert(pCurrentEdit, edit);
         break;
       }
@@ -714,8 +707,7 @@ bool CEdl::AddSceneMarker(const int iSceneMarker)
   if (InEdit(iSceneMarker, &edit) && edit.action == Action::CUT) // Only works for current cuts.
     return false;
 
-  CLog::Log(LOGDEBUG, "{} - Inserting new scene marker: {}", __FUNCTION__,
-            MillisecondsToTimeString(iSceneMarker));
+  CLog::LogF(LOGDEBUG, "Inserting new scene marker: {}", MillisecondsToTimeString(iSceneMarker));
   m_vecSceneMarkers.push_back(iSceneMarker); // Unsorted
 
   return true;
@@ -946,9 +938,9 @@ void CEdl::MergeShortCommBreaks()
   if (!m_vecEdits.empty() && m_vecEdits[0].action == Action::COMM_BREAK &&
       (m_vecEdits[0].end - m_vecEdits[0].start) < 5 * 1000) // 5 seconds
   {
-    CLog::Log(LOGDEBUG, "{} - Removing short commercial break at start [{} - {}]. <5 seconds",
-              __FUNCTION__, MillisecondsToTimeString(m_vecEdits[0].start),
-              MillisecondsToTimeString(m_vecEdits[0].end));
+    CLog::LogF(LOGDEBUG, "Removing short commercial break at start [{} - {}]. <5 seconds",
+               MillisecondsToTimeString(m_vecEdits[0].start),
+               MillisecondsToTimeString(m_vecEdits[0].end));
     m_vecEdits.erase(m_vecEdits.begin());
   }
 
@@ -969,13 +961,13 @@ void CEdl::MergeShortCommBreaks()
         commBreak.start = m_vecEdits[i].start;
         commBreak.end = m_vecEdits[i + 1].end;
 
-        CLog::Log(
-            LOGDEBUG, "{} - Consolidating commercial break [{} - {}] and [{} - {}] to: [{} - {}]",
-            __FUNCTION__, MillisecondsToTimeString(m_vecEdits[i].start),
-            MillisecondsToTimeString(m_vecEdits[i].end),
-            MillisecondsToTimeString(m_vecEdits[i + 1].start),
-            MillisecondsToTimeString(m_vecEdits[i + 1].end),
-            MillisecondsToTimeString(commBreak.start), MillisecondsToTimeString(commBreak.end));
+        CLog::LogF(LOGDEBUG, "Consolidating commercial break [{} - {}] and [{} - {}] to: [{} - {}]",
+                   MillisecondsToTimeString(m_vecEdits[i].start),
+                   MillisecondsToTimeString(m_vecEdits[i].end),
+                   MillisecondsToTimeString(m_vecEdits[i + 1].start),
+                   MillisecondsToTimeString(m_vecEdits[i + 1].end),
+                   MillisecondsToTimeString(commBreak.start),
+                   MillisecondsToTimeString(commBreak.end));
 
         /*
          * Erase old edits and insert the new merged one.
@@ -996,9 +988,9 @@ void CEdl::MergeShortCommBreaks()
     if (!m_vecEdits.empty() && m_vecEdits[0].action == Action::COMM_BREAK &&
         m_vecEdits[0].start < advancedSettings->m_iEdlMaxStartGap * 1000)
     {
-      CLog::Log(LOGDEBUG, "{} - Expanding first commercial break back to start [{} - {}].",
-                __FUNCTION__, MillisecondsToTimeString(m_vecEdits[0].start),
-                MillisecondsToTimeString(m_vecEdits[0].end));
+      CLog::LogF(LOGDEBUG, "Expanding first commercial break back to start [{} - {}].",
+                 MillisecondsToTimeString(m_vecEdits[0].start),
+                 MillisecondsToTimeString(m_vecEdits[0].end));
       m_vecEdits[0].start = 0;
     }
 
@@ -1011,11 +1003,11 @@ void CEdl::MergeShortCommBreaks()
           (m_vecEdits[i].end - m_vecEdits[i].start) <
               advancedSettings->m_iEdlMinCommBreakLength * 1000)
       {
-        CLog::Log(LOGDEBUG,
-                  "{} - Removing short commercial break [{} - {}]. Minimum length: {} seconds",
-                  __FUNCTION__, MillisecondsToTimeString(m_vecEdits[i].start),
-                  MillisecondsToTimeString(m_vecEdits[i].end),
-                  advancedSettings->m_iEdlMinCommBreakLength);
+        CLog::LogF(LOGDEBUG,
+                   "Removing short commercial break [{} - {}]. Minimum length: {} seconds",
+                   MillisecondsToTimeString(m_vecEdits[i].start),
+                   MillisecondsToTimeString(m_vecEdits[i].end),
+                   advancedSettings->m_iEdlMinCommBreakLength);
         m_vecEdits.erase(m_vecEdits.begin() + i);
 
         i--;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -843,7 +843,7 @@ bool CVideoPlayer::OpenDemuxStream()
     }
     else if(!m_pDemuxer && m_pInputStream->NextStream() != CDVDInputStream::NEXTSTREAM_NONE)
     {
-      CLog::Log(LOGDEBUG, "{} - New stream available from input, retry open", __FUNCTION__);
+      CLog::LogF(LOGDEBUG, "New stream available from input, retry open");
       continue;
     }
     break;
@@ -851,7 +851,7 @@ bool CVideoPlayer::OpenDemuxStream()
 
   if (!m_pDemuxer)
   {
-    CLog::Log(LOGERROR, "{} - Error creating demuxer", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Error creating demuxer");
     return false;
   }
 
@@ -1036,8 +1036,7 @@ bool CVideoPlayer::ReadPacket(DemuxPacket*& packet, CDemuxStream*& stream)
       stream = m_pSubtitleDemuxer->GetStream(packet->demuxerId, packet->iStreamId);
       if (!stream)
       {
-        CLog::Log(LOGERROR, "{} - Error demux packet doesn't belong to a valid stream",
-                  __FUNCTION__);
+        CLog::LogF(LOGERROR, "Error demux packet doesn't belong to a valid stream");
         return false;
       }
       if (stream->source == STREAM_SOURCE_NONE)
@@ -1084,8 +1083,7 @@ bool CVideoPlayer::ReadPacket(DemuxPacket*& packet, CDemuxStream*& stream)
       stream = m_pDemuxer->GetStream(packet->demuxerId, packet->iStreamId);
       if (!stream)
       {
-        CLog::Log(LOGERROR, "{} - Error demux packet doesn't belong to a valid stream",
-                  __FUNCTION__);
+        CLog::LogF(LOGERROR, "Error demux packet doesn't belong to a valid stream");
         return false;
       }
       if(stream->source == STREAM_SOURCE_NONE)
@@ -1288,8 +1286,7 @@ void CVideoPlayer::Prepare()
       starttime = m_Edl.GetTimeAfterRestoringCuts(
           static_cast<int>(m_playerOptions.starttime * 1000)); // s to ms
     }
-    CLog::Log(LOGDEBUG, "{} - Start position set to last stopped position: {}", __FUNCTION__,
-              starttime);
+    CLog::LogF(LOGDEBUG, "Start position set to last stopped position: {}", starttime);
   }
   else if (m_Edl.InEdit(starttime, &edit))
   {
@@ -1300,16 +1297,14 @@ void CVideoPlayer::Prepare()
     if (edit.action == EDL::Action::CUT)
     {
       starttime = edit.end;
-      CLog::Log(LOGDEBUG, "{} - Start position set to end of first cut: {}", __FUNCTION__,
-                starttime);
+      CLog::LogF(LOGDEBUG, "Start position set to end of first cut: {}", starttime);
     }
     else if (edit.action == EDL::Action::COMM_BREAK)
     {
       if (m_SkipCommercials)
       {
         starttime = edit.end;
-        CLog::Log(LOGDEBUG, "{} - Start position set to end of first commercial break: {}",
-                  __FUNCTION__, starttime);
+        CLog::LogF(LOGDEBUG, "Start position set to end of first commercial break: {}", starttime);
       }
 
       const std::shared_ptr<CAdvancedSettings> advancedSettings =
@@ -1331,19 +1326,18 @@ void CVideoPlayer::Prepare()
       if (m_pDemuxer->SeekTime(starttime, true, &startpts))
       {
         FlushBuffers(starttime / 1000 * AV_TIME_BASE, true, true);
-        CLog::Log(LOGDEBUG, "{} - starting demuxer from: {}", __FUNCTION__, starttime);
+        CLog::LogF(LOGDEBUG, "starting demuxer from: {}", starttime);
       }
       else
-        CLog::Log(LOGDEBUG, "{} - failed to start demuxing from: {}", __FUNCTION__, starttime);
+        CLog::LogF(LOGDEBUG, "failed to start demuxing from: {}", starttime);
     }
 
     if (m_pSubtitleDemuxer)
     {
       if(m_pSubtitleDemuxer->SeekTime(starttime, true, &startpts))
-        CLog::Log(LOGDEBUG, "{} - starting subtitle demuxer from: {}", __FUNCTION__, starttime);
+        CLog::LogF(LOGDEBUG, "starting subtitle demuxer from: {}", starttime);
       else
-        CLog::Log(LOGDEBUG, "{} - failed to start subtitle demuxing from: {}", __FUNCTION__,
-                  starttime);
+        CLog::LogF(LOGDEBUG, "failed to start subtitle demuxing from: {}", starttime);
     }
 
     m_clock.Discontinuity(DVD_MSEC_TO_TIME(starttime));
@@ -1556,7 +1550,7 @@ void CVideoPlayer::Process()
       }
 
       if (!m_pInputStream->IsEOF())
-        CLog::Log(LOGINFO, "{} - eof reading from demuxer", __FUNCTION__);
+        CLog::LogF(LOGINFO, "eof reading from demuxer");
 
       break;
     }
@@ -2220,14 +2214,14 @@ bool CVideoPlayer::CheckPlayerInit(CCurrentStream& current)
   {
     if(current.dts == DVD_NOPTS_VALUE)
     {
-      CLog::Log(LOGDEBUG, "{} - dropping packet type:{} dts:{:f} to get to start point at {:f}",
-                __FUNCTION__, current.player, current.dts, current.startpts);
+      CLog::LogF(LOGDEBUG, "dropping packet type:{} dts:{:f} to get to start point at {:f}",
+                 current.player, current.dts, current.startpts);
       return true;
     }
 
     if ((current.startpts - current.dts) > DVD_SEC_TO_TIME(20))
     {
-      CLog::Log(LOGDEBUG, "{} - too far to decode before finishing seek", __FUNCTION__);
+      CLog::LogF(LOGDEBUG, "too far to decode before finishing seek");
       if(m_CurrentAudio.startpts != DVD_NOPTS_VALUE)
         m_CurrentAudio.startpts = current.dts;
       if(m_CurrentVideo.startpts != DVD_NOPTS_VALUE)
@@ -2244,8 +2238,8 @@ bool CVideoPlayer::CheckPlayerInit(CCurrentStream& current)
 
     if(current.dts < current.startpts)
     {
-      CLog::Log(LOGDEBUG, "{} - dropping packet type:{} dts:{:f} to get to start point at {:f}",
-                __FUNCTION__, current.player, current.dts, current.startpts);
+      CLog::LogF(LOGDEBUG, "dropping packet type:{} dts:{:f} to get to start point at {:f}",
+                 current.player, current.dts, current.startpts);
       return true;
     }
   }
@@ -2425,9 +2419,9 @@ void CVideoPlayer::CheckAutoSceneSkip()
     if ((m_playSpeed > 0 && correctClock < (edit.start + 1000)) ||
         (m_playSpeed < 0 && correctClock < (edit.end - 1000)))
     {
-      CLog::Log(LOGDEBUG, "{} - Clock in EDL cut [{} - {}]: {}. Automatically skipping over.",
-                __FUNCTION__, CEdl::MillisecondsToTimeString(edit.start),
-                CEdl::MillisecondsToTimeString(edit.end), CEdl::MillisecondsToTimeString(clock));
+      CLog::LogF(LOGDEBUG, "Clock in EDL cut [{} - {}]: {}. Automatically skipping over.",
+                 CEdl::MillisecondsToTimeString(edit.start),
+                 CEdl::MillisecondsToTimeString(edit.end), CEdl::MillisecondsToTimeString(clock));
 
       // Seeking either goes to the start or the end of the cut depending on the play direction.
       int seek = m_playSpeed >= 0 ? edit.end : edit.start;
@@ -2466,11 +2460,11 @@ void CVideoPlayer::CheckAutoSceneSkip()
 
       if (m_SkipCommercials)
       {
-        CLog::Log(LOGDEBUG,
-                  "{} - Clock in commercial break [{} - {}]: {}. Automatically skipping to end of "
-                  "commercial break",
-                  __FUNCTION__, CEdl::MillisecondsToTimeString(edit.start),
-                  CEdl::MillisecondsToTimeString(edit.end), CEdl::MillisecondsToTimeString(clock));
+        CLog::LogF(LOGDEBUG,
+                   "Clock in commercial break [{} - {}]: {}. Automatically skipping to end of "
+                   "commercial break",
+                   CEdl::MillisecondsToTimeString(edit.start),
+                   CEdl::MillisecondsToTimeString(edit.end), CEdl::MillisecondsToTimeString(clock));
 
         CDVDMsgPlayerSeek::CMode mode;
         mode.time = edit.end;
@@ -3567,7 +3561,7 @@ bool CVideoPlayer::OpenStream(CCurrentStream& current, int64_t demuxerId, int iS
       pts = 0;
     pts += m_offset_pts;
     if (!m_pSubtitleDemuxer->SeekTime((int)(1000.0 * pts / (double)DVD_TIME_BASE)))
-      CLog::Log(LOGDEBUG, "{} - failed to start subtitle demuxing from: {:f}", __FUNCTION__, pts);
+      CLog::LogF(LOGDEBUG, "failed to start subtitle demuxing from: {:f}", pts);
     stream = m_pSubtitleDemuxer->GetStream(demuxerId, iStream);
     if(!stream || stream->disabled)
       return false;
@@ -3660,8 +3654,7 @@ bool CVideoPlayer::OpenStream(CCurrentStream& current, int64_t demuxerId, int iS
     if(stream)
     {
       /* mark stream as disabled, to disallow further attempts*/
-      CLog::Log(LOGWARNING, "{} - Unsupported stream {}. Stream disabled.", __FUNCTION__,
-                stream->uniqueId);
+      CLog::LogF(LOGWARNING, "Unsupported stream {}. Stream disabled.", stream->uniqueId);
       stream->disabled = true;
     }
   }
@@ -4321,7 +4314,7 @@ bool CVideoPlayer::OnAction(const CAction &action)
           {
             THREAD_ACTION(action);
             /* this will force us out of the stillframe */
-            CLog::Log(LOGDEBUG, "{} - User asked to exit stillframe", __FUNCTION__);
+            CLog::LogF(LOGDEBUG, "User asked to exit stillframe");
             m_dvd.iDVDStillStartTime = {};
             m_dvd.iDVDStillTime = 1ms;
           }

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -524,7 +524,7 @@ bool CVideoPlayerAudio::ProcessDecoderOutput(DVDAudioFrame &audioframe)
       m_audioSink.Destroy(false);
 
       if (!m_audioSink.Create(audioframe, m_streaminfo.codec, m_synctype == SYNC_RESAMPLE))
-        CLog::Log(LOGERROR, "{} - failed to create audio renderer", __FUNCTION__);
+        CLog::LogF(LOGERROR, "failed to create audio renderer");
 
       if (m_syncState == IDVDStreamPlayer::SYNC_INSYNC)
         m_audioSink.Resume();

--- a/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.cpp
@@ -126,7 +126,7 @@ bool CVideoPlayerSubtitle::OpenStream(CDVDStreamInfo &hints, std::string &filena
     m_pSubtitleFileParser.reset(CDVDFactorySubtitle::CreateParser(filename));
     if (!m_pSubtitleFileParser)
     {
-      CLog::Log(LOGERROR, "{} - Unable to create subtitle parser", __FUNCTION__);
+      CLog::LogF(LOGERROR, "Unable to create subtitle parser");
       CloseStream(true);
       return false;
     }
@@ -135,7 +135,7 @@ bool CVideoPlayerSubtitle::OpenStream(CDVDStreamInfo &hints, std::string &filena
 
     if (!m_pSubtitleFileParser->Open(hints))
     {
-      CLog::Log(LOGERROR, "{} - Unable to init subtitle parser", __FUNCTION__);
+      CLog::LogF(LOGERROR, "Unable to init subtitle parser");
       CloseStream(true);
       return false;
     }
@@ -154,7 +154,7 @@ bool CVideoPlayerSubtitle::OpenStream(CDVDStreamInfo &hints, std::string &filena
     return true;
   }
 
-  CLog::Log(LOGERROR, "{} - Unable to init overlay codec", __FUNCTION__);
+  CLog::LogF(LOGERROR, "Unable to init overlay codec");
   return false;
 }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -868,7 +868,7 @@ CVideoPlayerVideo::EOutputState CVideoPlayerVideo::OutputPicture(const VideoPict
                                 orientation,
                                 m_pVideoCodec->GetAllowedReferences()))
   {
-    CLog::Log(LOGERROR, "{} - failed to configure renderer", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed to configure renderer");
     return OUTPUT_ABORT;
   }
 
@@ -911,7 +911,7 @@ CVideoPlayerVideo::EOutputState CVideoPlayerVideo::OutputPicture(const VideoPict
   if ((pPicture->iFlags & DVP_FLAG_DROPPED))
   {
     m_droppingStats.AddOutputDropGain(pPicture->pts, 1);
-    CLog::Log(LOGDEBUG, "{} - dropped in output", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "dropped in output");
     return OUTPUT_DROPPED;
   }
 
@@ -926,7 +926,7 @@ CVideoPlayerVideo::EOutputState CVideoPlayerVideo::OutputPicture(const VideoPict
   if (buffer < 0)
   {
     if (m_speed != DVD_PLAYSPEED_PAUSE)
-      CLog::Log(LOGWARNING, "{} - timeout waiting for buffer", __FUNCTION__);
+      CLog::LogF(LOGWARNING, "timeout waiting for buffer");
     return OUTPUT_AGAIN;
   }
 
@@ -1026,9 +1026,9 @@ void CVideoPlayerVideo::CalcFrameRate()
 
     if (m_iFrameRateErr == MAXFRAMESERR && m_iFrameRateLength == 1)
     {
-      CLog::Log(LOGDEBUG,
-                "{} counted {} frames without being able to calculate the framerate, giving up",
-                __FUNCTION__, m_iFrameRateErr);
+      CLog::LogF(LOGDEBUG,
+                 "counted {} frames without being able to calculate the framerate, giving up",
+                 m_iFrameRateErr);
       m_bAllowDrop = true;
       m_iFrameRateLength = 128;
     }
@@ -1055,8 +1055,8 @@ void CVideoPlayerVideo::CalcFrameRate()
       //store the calculated framerate if it differs too much from m_fFrameRate
       if (fabs(m_fFrameRate - (m_fStableFrameRate / m_iFrameRateCount)) > MAXFRAMERATEDIFF || m_bFpsInvalid)
       {
-        CLog::Log(LOGDEBUG, "{} framerate was:{:f} calculated:{:f}", __FUNCTION__, m_fFrameRate,
-                  m_fStableFrameRate / m_iFrameRateCount);
+        CLog::LogF(LOGDEBUG, "framerate was:{:f} calculated:{:f}", m_fFrameRate,
+                   m_fStableFrameRate / m_iFrameRateCount);
         m_fFrameRate = m_fStableFrameRate / m_iFrameRateCount;
         m_bFpsInvalid = false;
         m_processInfo.SetVideoFps(static_cast<float>(m_fFrameRate));

--- a/xbmc/cores/VideoPlayer/VideoRenderers/ColorManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/ColorManager.cpp
@@ -313,13 +313,13 @@ bool CColorManager::Probe3dLut(const std::string& filename, int* clutSize)
 
   if (!lutFile.Open(filename))
   {
-    CLog::Log(LOGERROR, "{}: Could not open 3DLUT file: {}", __FUNCTION__, filename);
+    CLog::LogF(LOGERROR, "Could not open 3DLUT file: {}", filename);
     return false;
   }
 
   if (lutFile.Read(&header, sizeof(header)) < static_cast<ssize_t>(sizeof(header)))
   {
-    CLog::Log(LOGERROR, "{}: Could not read 3DLUT header: {}", __FUNCTION__, filename);
+    CLog::LogF(LOGERROR, "Could not read 3DLUT header: {}", filename);
     return false;
   }
 
@@ -328,7 +328,7 @@ bool CColorManager::Probe3dLut(const std::string& filename, int* clutSize)
         && header.signature[2]=='L'
         && header.signature[3]=='T') )
   {
-    CLog::Log(LOGERROR, "{}: Not a 3DLUT file: {}", __FUNCTION__, filename);
+    CLog::LogF(LOGERROR, "Not a 3DLUT file: {}", filename);
     return false;
   }
 
@@ -337,7 +337,7 @@ bool CColorManager::Probe3dLut(const std::string& filename, int* clutSize)
       || header.inputColorEncoding != 0
       || header.outputColorEncoding != 0 )
   {
-    CLog::Log(LOGERROR, "{}: Unsupported 3DLUT file: {}", __FUNCTION__, filename);
+    CLog::LogF(LOGERROR, "Unsupported 3DLUT file: {}", filename);
     return false;
   }
 
@@ -346,8 +346,7 @@ bool CColorManager::Probe3dLut(const std::string& filename, int* clutSize)
   int bSize = 1 << header.inputBitDepth[2];
   if (rSize != gSize || rSize != bSize)
   {
-    CLog::Log(LOGERROR, "{}: Different channel resolutions unsupported: {}", __FUNCTION__,
-              filename);
+    CLog::LogF(LOGERROR, "Different channel resolutions unsupported: {}", filename);
     return false;
   }
 
@@ -368,13 +367,13 @@ bool CColorManager::Load3dLut(const std::string& filename,
 
   if (!lutFile.Open(filename))
   {
-    CLog::Log(LOGERROR, "{}: Could not open 3DLUT file: {}", __FUNCTION__, filename);
+    CLog::LogF(LOGERROR, "Could not open 3DLUT file: {}", filename);
     return false;
   }
 
   if (lutFile.Read(&header, sizeof(header)) < static_cast<ssize_t>(sizeof(header)))
   {
-    CLog::Log(LOGERROR, "{}: Could not read 3DLUT header: {}", __FUNCTION__, filename);
+    CLog::LogF(LOGERROR, "Could not read 3DLUT header: {}", filename);
     return false;
   }
 
@@ -384,8 +383,7 @@ bool CColorManager::Load3dLut(const std::string& filename,
 
   if ( rSize != CLUTsize || rSize != gSize || rSize != bSize)
   {
-    CLog::Log(LOGERROR, "{}: Different channel resolutions unsupported: {}", __FUNCTION__,
-              filename);
+    CLog::LogF(LOGERROR, "Different channel resolutions unsupported: {}", filename);
     return false;
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
@@ -35,7 +35,7 @@ void CDebugRenderer::Initialize()
   m_isInitialized = m_adapter->Initialize();
   if (!m_isInitialized)
   {
-    CLog::Log(LOGERROR, "{} - Failed to configure OSD info debug renderer", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Failed to configure OSD info debug renderer");
     delete m_adapter;
     m_adapter = nullptr;
     return;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
@@ -65,7 +65,7 @@ bool CDRMPRIMETexture::Map(CVideoBufferDRMPRIME* buffer)
 
   if (!buffer->AcquireDescriptor())
   {
-    CLog::Log(LOGERROR, "CDRMPRIMETexture::{} - failed to acquire descriptor", __FUNCTION__);
+    CLog::LogF(LOGERROR, "CDRMPRIMETexture: failed to acquire descriptor");
     return false;
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
@@ -36,8 +36,7 @@ bool CVaapi1Texture::Map(CVaapiRenderPicture *pic)
   status = vaDeriveImage(pic->vadsp, pic->procPic.videoSurface, &m_glSurface.vaImage);
   if (status != VA_STATUS_SUCCESS)
   {
-    CLog::Log(LOGERROR, "CVaapiTexture::{} - Error: {}({})", __FUNCTION__, vaErrorStr(status),
-              status);
+    CLog::LogF(LOGERROR, "CVaapiTexture: Error: {}({})", vaErrorStr(status), status);
     return false;
   }
   memset(&m_glSurface.vBufInfo, 0, sizeof(m_glSurface.vBufInfo));
@@ -45,8 +44,7 @@ bool CVaapi1Texture::Map(CVaapiRenderPicture *pic)
   status = vaAcquireBufferHandle(pic->vadsp, m_glSurface.vaImage.buf, &m_glSurface.vBufInfo);
   if (status != VA_STATUS_SUCCESS)
   {
-    CLog::Log(LOGERROR, "CVaapiTexture::{} - Error: {}({})", __FUNCTION__, vaErrorStr(status),
-              status);
+    CLog::LogF(LOGERROR, "CVaapiTexture: Error: {}({})", vaErrorStr(status), status);
     return false;
   }
 
@@ -257,13 +255,13 @@ void CVaapi1Texture::Unmap()
   status = vaReleaseBufferHandle(m_vaapiPic->vadsp, m_glSurface.vaImage.buf);
   if (status != VA_STATUS_SUCCESS)
   {
-    CLog::Log(LOGERROR, "VAAPI::{} - Error: {}({})", __FUNCTION__, vaErrorStr(status), status);
+    CLog::LogF(LOGERROR, "VAAPI: Error: {}({})", vaErrorStr(status), status);
   }
 
   status = vaDestroyImage(m_vaapiPic->vadsp, m_glSurface.vaImage.image_id);
   if (status != VA_STATUS_SUCCESS)
   {
-    CLog::Log(LOGERROR, "VAAPI::{} - Error: {}({})", __FUNCTION__, vaErrorStr(status), status);
+    CLog::LogF(LOGERROR, "VAAPI: Error: {}({})", vaErrorStr(status), status);
   }
 
   m_glSurface.vaImage.image_id = VA_INVALID_ID;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -74,8 +74,7 @@ bool CVideoLayerBridgeDRMPRIME::Map(CVideoBufferDRMPRIME* buffer)
 
   if (!buffer->AcquireDescriptor())
   {
-    CLog::Log(LOGERROR, "CVideoLayerBridgeDRMPRIME::{} - failed to acquire descriptor",
-              __FUNCTION__);
+    CLog::LogF(LOGERROR, "CVideoLayerBridgeDRMPRIME: failed to acquire descriptor");
     return false;
   }
 
@@ -91,10 +90,10 @@ bool CVideoLayerBridgeDRMPRIME::Map(CVideoBufferDRMPRIME* buffer)
                              &buffer->m_handles[object]);
     if (ret < 0)
     {
-      CLog::Log(LOGERROR,
-                "CVideoLayerBridgeDRMPRIME::{} - failed to convert prime fd {} to gem handle {}, "
-                "ret = {}",
-                __FUNCTION__, descriptor->objects[object].fd, buffer->m_handles[object], ret);
+      CLog::LogF(LOGERROR,
+                 "CVideoLayerBridgeDRMPRIME: failed to convert prime fd {} to gem handle {}, "
+                 "ret = {}",
+                 descriptor->objects[object].fd, buffer->m_handles[object], ret);
       return false;
     }
   }
@@ -123,8 +122,8 @@ bool CVideoLayerBridgeDRMPRIME::Map(CVideoBufferDRMPRIME* buffer)
                                    modifier, &buffer->m_fb_id, flags);
   if (ret < 0)
   {
-    CLog::Log(LOGERROR, "CVideoLayerBridgeDRMPRIME::{} - failed to add fb {}, ret = {}",
-              __FUNCTION__, buffer->m_fb_id, ret);
+    CLog::LogF(LOGERROR, "CVideoLayerBridgeDRMPRIME: failed to add fb {}, ret = {}",
+               buffer->m_fb_id, ret);
     return false;
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
@@ -42,14 +42,14 @@ static bool LoadTexture(int width, int height, int stride
 {
   if (!texture->Create(width, height, 1, D3D11_USAGE_IMMUTABLE, format, pixels, stride))
   {
-    CLog::Log(LOGERROR, "{} - failed to allocate texture.", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed to allocate texture.");
     return false;
   }
 
   D3D11_TEXTURE2D_DESC desc = {};
   if (!texture->GetDesc(&desc))
   {
-    CLog::Log(LOGERROR, "{} - failed to get texture description.", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed to get texture description.");
     texture->Release();
     return false;
   }
@@ -141,7 +141,7 @@ COverlayQuadsDX::COverlayQuadsDX(ASS_Image* images, float width, float height)
   if (!m_vertex.Create(D3D11_BIND_VERTEX_BUFFER, 6 * m_count, sizeof(Vertex), DXGI_FORMAT_UNKNOWN,
                        D3D11_USAGE_IMMUTABLE, vt))
   {
-    CLog::Log(LOGERROR, "{} - failed to create vertex buffer", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed to create vertex buffer");
     m_texture.Release();
   }
 
@@ -316,7 +316,7 @@ void COverlayImageDX::Load(const uint32_t* rgba, int width, int height, int stri
 
   if (!m_vertex.Create(D3D11_BIND_VERTEX_BUFFER, 4, sizeof(Vertex), DXGI_FORMAT_UNKNOWN, D3D11_USAGE_IMMUTABLE, vt))
   {
-    CLog::Log(LOGERROR, "{} - failed to create vertex buffer", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed to create vertex buffer");
     m_texture.Release();
   }
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderCaptureDX.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderCaptureDX.cpp
@@ -43,11 +43,9 @@ void CRenderCaptureDX::BeginRender()
     if (m_flags & CAPTUREFLAG_CONTINUOUS)
     {
       if (!m_asyncSupported)
-        CLog::Log(LOGWARNING, "{}: D3D11_QUERY_OCCLUSION not supported, performance might suffer.",
-                  __FUNCTION__);
+        CLog::LogF(LOGWARNING, "D3D11_QUERY_OCCLUSION not supported, performance might suffer.");
       if (!UseOcclusionQuery())
-        CLog::Log(LOGWARNING, "{}: D3D11_QUERY_OCCLUSION disabled, performance might suffer.",
-                  __FUNCTION__);
+        CLog::LogF(LOGWARNING, "D3D11_QUERY_OCCLUSION disabled, performance might suffer.");
     }
     m_asyncChecked = true;
   }
@@ -139,7 +137,7 @@ void CRenderCaptureDX::ReadOut()
     }
     else
     {
-      CLog::Log(LOGERROR, "{}: GetData failed.", __FUNCTION__);
+      CLog::LogF(LOGERROR, "GetData failed.");
       SurfaceToBuffer();
     }
   }
@@ -170,7 +168,7 @@ void CRenderCaptureDX::SurfaceToBuffer()
   }
   else
   {
-    CLog::Log(LOGERROR, "{}: locking m_copySurface failed.", __FUNCTION__);
+    CLog::LogF(LOGERROR, "locking m_copySurface failed.");
     SetState(CAPTURESTATE_FAILED);
   }
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -361,7 +361,7 @@ void CRenderManager::PreInit()
     CServiceBroker::GetAppMessenger()->PostMsg(TMSG_RENDERER_PREINIT);
     if (!m_initEvent.Wait(2000ms))
     {
-      CLog::Log(LOGERROR, "{} - timed out waiting for renderer to preinit", __FUNCTION__);
+      CLog::LogF(LOGERROR, "timed out waiting for renderer to preinit");
     }
   }
 
@@ -390,7 +390,7 @@ void CRenderManager::UnInit()
     CServiceBroker::GetAppMessenger()->PostMsg(TMSG_RENDERER_UNINIT);
     if (!m_initEvent.Wait(2000ms))
     {
-      CLog::Log(LOGERROR, "{} - timed out waiting for renderer to uninit", __FUNCTION__);
+      CLog::LogF(LOGERROR, "timed out waiting for renderer to uninit");
     }
   }
 
@@ -417,7 +417,7 @@ bool CRenderManager::Flush(bool wait, bool saveBuffers)
 
   if (CServiceBroker::GetAppMessenger()->IsProcessThread())
   {
-    CLog::Log(LOGDEBUG, "{} - flushing renderer", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "flushing renderer");
 
 // fix deadlock on Windows only when is enabled 'Sync playback to display'
 #ifndef TARGET_WINDOWS
@@ -456,7 +456,7 @@ bool CRenderManager::Flush(bool wait, bool saveBuffers)
     {
       if (!m_flushEvent.Wait(1000ms))
       {
-        CLog::Log(LOGERROR, "{} - timed out waiting for renderer to flush", __FUNCTION__);
+        CLog::LogF(LOGERROR, "timed out waiting for renderer to flush");
         return false;
       }
       else
@@ -494,7 +494,7 @@ void CRenderManager::DeleteRenderer()
 {
   if (m_pRenderer)
   {
-    CLog::Log(LOGDEBUG, "{} - deleting renderer", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "deleting renderer");
 
     delete m_pRenderer;
     m_pRenderer = NULL;

--- a/xbmc/cores/paplayer/VideoPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.cpp
@@ -74,7 +74,7 @@ bool VideoPlayerCodec::Init(const CFileItem &file, unsigned int filecache)
   m_pInputStream = CDVDFactoryInputStream::CreateInputStream(NULL, fileitem);
   if (!m_pInputStream)
   {
-    CLog::Log(LOGERROR, "{}: Error creating input stream for {}", __FUNCTION__, file.GetDynPath());
+    CLog::LogF(LOGERROR, "Error creating input stream for {}", file.GetDynPath());
     return false;
   }
 
@@ -82,7 +82,7 @@ bool VideoPlayerCodec::Init(const CFileItem &file, unsigned int filecache)
   //! convey CFileItem::ContentLookup() into Open()
   if (!m_pInputStream->Open())
   {
-    CLog::Log(LOGERROR, "{}: Error opening file {}", __FUNCTION__, file.GetDynPath());
+    CLog::LogF(LOGERROR, "Error opening file {}", file.GetDynPath());
     if (m_pInputStream.use_count() > 1)
       throw std::runtime_error("m_pInputStream reference count is greater than 1");
     m_pInputStream.reset();
@@ -99,13 +99,13 @@ bool VideoPlayerCodec::Init(const CFileItem &file, unsigned int filecache)
       if (m_pInputStream.use_count() > 1)
         throw std::runtime_error("m_pInputStream reference count is greater than 1");
       m_pInputStream.reset();
-      CLog::Log(LOGERROR, "{}: Error creating demuxer", __FUNCTION__);
+      CLog::LogF(LOGERROR, "Error creating demuxer");
       return false;
     }
   }
   catch(...)
   {
-    CLog::Log(LOGERROR, "{}: Exception thrown when opening demuxer", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Exception thrown when opening demuxer");
     if (m_pDemuxer)
     {
       delete m_pDemuxer;
@@ -130,7 +130,7 @@ bool VideoPlayerCodec::Init(const CFileItem &file, unsigned int filecache)
 
   if (m_nAudioStream == -1)
   {
-    CLog::Log(LOGERROR, "{}: Could not find audio stream", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Could not find audio stream");
     delete m_pDemuxer;
     m_pDemuxer = NULL;
     if (m_pInputStream.use_count() > 1)
@@ -146,7 +146,7 @@ bool VideoPlayerCodec::Init(const CFileItem &file, unsigned int filecache)
   m_pAudioCodec = CDVDFactoryCodec::CreateAudioCodec(hint, *m_processInfo, true, true, ptStreamTye);
   if (!m_pAudioCodec)
   {
-    CLog::Log(LOGERROR, "{}: Could not create audio codec", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Could not create audio codec");
     delete m_pDemuxer;
     m_pDemuxer = NULL;
     if (m_pInputStream.use_count() > 1)
@@ -189,7 +189,7 @@ bool VideoPlayerCodec::Init(const CFileItem &file, unsigned int filecache)
   }
   if (nErrors >= 10)
   {
-    CLog::Log(LOGDEBUG, "{}: Could not decode data", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "Could not decode data");
     return false;
   }
 

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -286,7 +286,7 @@ std::string CDatabase::GetSingleValue(const std::string& query, std::unique_ptr<
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} - failed on query '{}'", __FUNCTION__, query);
+    CLog::LogF(LOGERROR, "failed on query '{}'", query);
   }
   return ret;
 }
@@ -325,7 +325,7 @@ int CDatabase::GetSingleValueInt(const std::string& query, std::unique_ptr<Datas
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} - failed on query '{}'", __FUNCTION__, query);
+    CLog::LogF(LOGERROR, "failed on query '{}'", query);
   }
   return ret;
 }
@@ -395,7 +395,7 @@ bool CDatabase::ExecuteQuery(const std::string& strQuery)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} - failed to execute query '{}'", __FUNCTION__, strQuery);
+    CLog::LogF(LOGERROR, "failed to execute query '{}'", strQuery);
   }
 
   return bReturn;
@@ -418,7 +418,7 @@ bool CDatabase::ResultQuery(const std::string& strQuery) const
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} - failed to execute query '{}'", __FUNCTION__, strQuery);
+    CLog::LogF(LOGERROR, "failed to execute query '{}'", strQuery);
   }
 
   return bReturn;
@@ -460,7 +460,7 @@ bool CDatabase::CommitInsertQueries()
     catch (...)
     {
       bReturn = false;
-      CLog::Log(LOGERROR, "{} - failed to execute queries", __FUNCTION__);
+      CLog::LogF(LOGERROR, "failed to execute queries");
     }
   }
 
@@ -498,7 +498,7 @@ bool CDatabase::CommitDeleteQueries()
     catch (...)
     {
       bReturn = false;
-      CLog::Log(LOGERROR, "{} - failed to execute queries", __FUNCTION__);
+      CLog::LogF(LOGERROR, "failed to execute queries");
     }
   }
 
@@ -653,7 +653,7 @@ bool CDatabase::Connect(const std::string& dbName, const DatabaseSettings& dbSet
   }
   catch (DbErrors& error)
   {
-    CLog::Log(LOGERROR, "{} failed with '{}'", __FUNCTION__, error.getMsg());
+    CLog::LogF(LOGERROR, "failed with '{}'", error.getMsg());
     m_openCount = 1; // set to open so we can execute Close()
     Close();
     return false;
@@ -732,7 +732,7 @@ bool CDatabase::Compress(bool bForce /* =true */)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} - Compressing the database failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Compressing the database failed");
     return false;
   }
   return true;
@@ -800,7 +800,7 @@ bool CDatabase::CreateDatabase()
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} unable to create database:{}", __FUNCTION__, (int)GetLastError());
+    CLog::LogF(LOGERROR, "unable to create database:{}", (int)GetLastError());
     RollbackTransaction();
     return false;
   }

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -161,8 +161,7 @@ int MysqlDatabase::connect(bool create_new)
   std::string resolvedHost;
   if (!StringUtils::EqualsNoCase(host, "localhost") && CDNSNameCache::Lookup(host, resolvedHost))
   {
-    CLog::Log(LOGDEBUG, "{} replacing configured host {} with resolved host {}", __FUNCTION__, host,
-              resolvedHost);
+    CLog::LogF(LOGDEBUG, "replacing configured host {} with resolved host {}", host, resolvedHost);
     host = resolvedHost;
   }
 

--- a/xbmc/dialogs/GUIDialogColorPicker.cpp
+++ b/xbmc/dialogs/GUIDialogColorPicker.cpp
@@ -173,8 +173,7 @@ void CGUIDialogColorPicker::LoadColors(const std::string& filePath)
     }
   }
   else
-    CLog::Log(LOGERROR, "{} - An error occurred when loading colours from the xml file.",
-              __FUNCTION__);
+    CLog::LogF(LOGERROR, "An error occurred when loading colours from the xml file.");
 }
 
 std::string CGUIDialogColorPicker::GetSelectedColor() const
@@ -224,7 +223,7 @@ void CGUIDialogColorPicker::OnWindowLoaded()
 void CGUIDialogColorPicker::OnInitWindow()
 {
   if (!m_vecList || m_vecList->IsEmpty())
-    CLog::Log(LOGERROR, "{} - No colours have been added in the list.", __FUNCTION__);
+    CLog::LogF(LOGERROR, "No colours have been added in the list.");
 
   m_viewControl.SetItems(*m_vecList);
   m_viewControl.SetCurrentView(CONTROL_ICON_LIST);

--- a/xbmc/filesystem/CacheStrategy.cpp
+++ b/xbmc/filesystem/CacheStrategy.cpp
@@ -72,7 +72,7 @@ int CSimpleFileCache::Open()
       CUtil::GetNextFilename("special://temp/filecache{:03}.cache", 999));
   if (m_filename.empty())
   {
-    CLog::Log(LOGERROR, "CSimpleFileCache::{} - Unable to generate a new filename", __FUNCTION__);
+    CLog::LogF(LOGERROR, "CSimpleFileCache: Unable to generate a new filename");
     Close();
     return CACHE_RC_ERROR;
   }
@@ -81,16 +81,14 @@ int CSimpleFileCache::Open()
 
   if (!m_cacheFileWrite->OpenForWrite(fileURL, false))
   {
-    CLog::Log(LOGERROR, "CSimpleFileCache::{} - Failed to create file \"{}\" for writing",
-              __FUNCTION__, m_filename);
+    CLog::LogF(LOGERROR, "CSimpleFileCache: Failed to create file \"{}\" for writing", m_filename);
     Close();
     return CACHE_RC_ERROR;
   }
 
   if (!m_cacheFileRead->Open(fileURL))
   {
-    CLog::Log(LOGERROR, "CSimpleFileCache::{} - Failed to open file \"{}\" for reading",
-              __FUNCTION__, m_filename);
+    CLog::LogF(LOGERROR, "CSimpleFileCache: Failed to open file \"{}\" for reading", m_filename);
     Close();
     return CACHE_RC_ERROR;
   }
@@ -109,8 +107,7 @@ void CSimpleFileCache::Close()
   m_cacheFileRead->Close();
 
   if (!m_filename.empty() && !m_cacheFileRead->Delete(CURL(m_filename)))
-    CLog::Log(LOGWARNING, "SimpleFileCache::{} - Failed to delete cache file \"{}\"", __FUNCTION__,
-              m_filename);
+    CLog::LogF(LOGWARNING, "SimpleFileCache: Failed to delete cache file \"{}\"", m_filename);
 
   m_filename.clear();
 }
@@ -129,8 +126,7 @@ int CSimpleFileCache::WriteToCache(const char *pBuffer, size_t iSize)
         m_cacheFileWrite->Write(pBuffer, std::min(iSize, static_cast<size_t>(SSIZE_MAX)));
     if (lastWritten <= 0)
     {
-      CLog::Log(LOGERROR, "SimpleFileCache::{} - <{}> Failed to write to cache", __FUNCTION__,
-                m_filename);
+      CLog::LogF(LOGERROR, "SimpleFileCache: <{}> Failed to write to cache", m_filename);
       return CACHE_RC_ERROR;
     }
     m_nWritePosition += lastWritten;
@@ -167,8 +163,7 @@ int CSimpleFileCache::ReadFromCache(char *pBuffer, size_t iMaxSize)
       break;
     if (lastRead < 0)
     {
-      CLog::Log(LOGERROR, "CSimpleFileCache::{} - <{}> Failed to read from cache", __FUNCTION__,
-                m_filename);
+      CLog::LogF(LOGERROR, "CSimpleFileCache: <{}> Failed to read from cache", m_filename);
       return CACHE_RC_ERROR;
     }
     m_nReadPosition += lastRead;
@@ -206,33 +201,32 @@ int64_t CSimpleFileCache::Seek(int64_t iFilePosition)
 
   if (iTarget < 0)
   {
-    CLog::Log(LOGDEBUG, "CSimpleFileCache::{} - <{}> Request seek to {} before start of cache",
-              __FUNCTION__, iFilePosition, m_filename);
+    CLog::LogF(LOGDEBUG, "CSimpleFileCache: <{}> Request seek to {} before start of cache",
+               iFilePosition, m_filename);
     return CACHE_RC_ERROR;
   }
 
   int64_t nDiff = iTarget - m_nWritePosition;
   if (nDiff > 500000)
   {
-    CLog::Log(LOGDEBUG,
-              "CSimpleFileCache::{} - <{}> Requested position {} is beyond cached data ({})",
-              __FUNCTION__, m_filename, iFilePosition, m_nWritePosition);
+    CLog::LogF(LOGDEBUG, "CSimpleFileCache: <{}> Requested position {} is beyond cached data ({})",
+               m_filename, iFilePosition, m_nWritePosition);
     return CACHE_RC_ERROR;
   }
 
   if (nDiff > 0 &&
       WaitForData(static_cast<uint32_t>(iTarget - m_nReadPosition), 5s) == CACHE_RC_TIMEOUT)
   {
-    CLog::Log(LOGDEBUG, "CSimpleFileCache::{} - <{}> Wait for position {} failed. Ended up at {}",
-              __FUNCTION__, m_filename, iFilePosition, m_nWritePosition);
+    CLog::LogF(LOGDEBUG, "CSimpleFileCache: <{}> Wait for position {} failed. Ended up at {}",
+               m_filename, iFilePosition, m_nWritePosition);
     return CACHE_RC_ERROR;
   }
 
   m_nReadPosition = m_cacheFileRead->Seek(iTarget, SEEK_SET);
   if (m_nReadPosition != iTarget)
   {
-    CLog::Log(LOGERROR, "CSimpleFileCache::{} - <{}> Can't seek cache file for position {}",
-              __FUNCTION__, iFilePosition, m_filename);
+    CLog::LogF(LOGERROR, "CSimpleFileCache: <{}> Can't seek cache file for position {}",
+               iFilePosition, m_filename);
     return CACHE_RC_ERROR;
   }
 
@@ -389,10 +383,10 @@ bool CDoubleCache::Reset(int64_t iSourcePosition)
   // If new active cache still doesn't have this position, log it
   if (!m_pCache->IsCachedPosition(iSourcePosition))
   {
-    CLog::Log(LOGDEBUG, "CDoubleCache::{} - ({}) Cache miss for {} with new={}-{} and old={}-{}",
-              __FUNCTION__, fmt::ptr(this), iSourcePosition, m_pCache->CachedDataStartPos(),
-              m_pCache->CachedDataEndPos(), m_pCacheOld->CachedDataStartPos(),
-              m_pCacheOld->CachedDataEndPos());
+    CLog::LogF(LOGDEBUG, "CDoubleCache: ({}) Cache miss for {} with new={}-{} and old={}-{}",
+               fmt::ptr(this), iSourcePosition, m_pCache->CachedDataStartPos(),
+               m_pCache->CachedDataEndPos(), m_pCacheOld->CachedDataStartPos(),
+               m_pCacheOld->CachedDataEndPos());
   }
 
   return m_pCache->Reset(iSourcePosition);

--- a/xbmc/filesystem/CircularCache.cpp
+++ b/xbmc/filesystem/CircularCache.cpp
@@ -223,9 +223,8 @@ int64_t CCircularCache::Seek(int64_t pos)
     lock.lock();
 
     if (pos < m_beg || pos > m_end)
-      CLog::Log(LOGDEBUG,
-                "CCircularCache::{} - ({}) Wait for data failed for pos {}, ended up at {}",
-                __FUNCTION__, fmt::ptr(this), pos, m_cur);
+      CLog::LogF(LOGDEBUG, "CCircularCache: ({}) Wait for data failed for pos {}, ended up at {}",
+                 fmt::ptr(this), pos, m_cur);
   }
 
   if (pos >= m_beg && pos <= m_end)

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -191,8 +191,8 @@ size_t CCurlFile::CReadState::WriteCallback(char *buffer, size_t size, size_t ni
     {
       if (!m_buffer.WriteData(m_overflowBuffer, maxWriteable))
       {
-        CLog::Log(LOGERROR, "CCurlFile::CReadState::{} - ({}) Unable to write to buffer",
-                  __FUNCTION__, fmt::ptr(this));
+        CLog::LogF(LOGERROR, "CCurlFile::CReadState: ({}) Unable to write to buffer",
+                   fmt::ptr(this));
         return 0;
       }
 
@@ -213,9 +213,8 @@ size_t CCurlFile::CReadState::WriteCallback(char *buffer, size_t size, size_t ni
   {
     if (!m_buffer.WriteData(buffer, maxWriteable))
     {
-      CLog::Log(LOGERROR,
-                "CCurlFile::CReadState::{} - ({}) Unable to write to buffer with {} bytes",
-                __FUNCTION__, fmt::ptr(this), maxWriteable);
+      CLog::LogF(LOGERROR, "CCurlFile::CReadState: ({}) Unable to write to buffer with {} bytes",
+                 fmt::ptr(this), maxWriteable);
       return 0;
     }
     else
@@ -230,10 +229,10 @@ size_t CCurlFile::CReadState::WriteCallback(char *buffer, size_t size, size_t ni
     m_overflowBuffer = (char*)realloc_simple(m_overflowBuffer, amount + m_overflowSize);
     if(m_overflowBuffer == NULL)
     {
-      CLog::Log(LOGWARNING,
-                "CCurlFile::CReadState::{} - ({}) Failed to grow overflow buffer from {} bytes to "
-                "{} bytes",
-                __FUNCTION__, fmt::ptr(this), m_overflowSize, amount + m_overflowSize);
+      CLog::LogF(LOGWARNING,
+                 "CCurlFile::CReadState: ({}) Failed to grow overflow buffer from {} bytes to "
+                 "{} bytes",
+                 fmt::ptr(this), m_overflowSize, amount + m_overflowSize);
       return 0;
     }
     memcpy(m_overflowBuffer + m_overflowSize, buffer, amount);
@@ -290,9 +289,9 @@ bool CCurlFile::CReadState::Seek(int64_t pos)
     if (FillBuffer(m_bufferSize) != FILLBUFFER_OK)
     {
       if(!m_buffer.SkipBytes(-len))
-        CLog::Log(LOGERROR,
-                  "CCurlFile::CReadState::{} - ({}) Failed to restore position after failed fill",
-                  __FUNCTION__, fmt::ptr(this));
+        CLog::LogF(LOGERROR,
+                   "CCurlFile::CReadState: ({}) Failed to restore position after failed fill",
+                   fmt::ptr(this));
       else
         m_filePos -= len;
       return false;
@@ -300,14 +299,14 @@ bool CCurlFile::CReadState::Seek(int64_t pos)
 
     if(!FITS_INT(pos - m_filePos) || !m_buffer.SkipBytes((int)(pos - m_filePos)))
     {
-      CLog::Log(
+      CLog::LogF(
           LOGERROR,
-          "CCurlFile::CReadState::{} - ({}) Failed to skip to position after having filled buffer",
-          __FUNCTION__, fmt::ptr(this));
+          "CCurlFile::CReadState: ({}) Failed to skip to position after having filled buffer",
+          fmt::ptr(this));
       if(!m_buffer.SkipBytes(-len))
-        CLog::Log(LOGERROR,
-                  "CCurlFile::CReadState::{} - ({}) Failed to restore position after failed seek",
-                  __FUNCTION__, fmt::ptr(this));
+        CLog::LogF(LOGERROR,
+                   "CCurlFile::CReadState: ({}) Failed to restore position after failed seek",
+                   fmt::ptr(this));
       else
         m_filePos -= len;
       return false;
@@ -339,8 +338,8 @@ void CCurlFile::CReadState::SetResume(void)
 long CCurlFile::CReadState::Connect(unsigned int size)
 {
   if (m_filePos != 0)
-    CLog::Log(LOGDEBUG, "CurlFile::CReadState::{} - ({}) Resume from position {}", __FUNCTION__,
-              fmt::ptr(this), m_filePos);
+    CLog::LogF(LOGDEBUG, "CurlFile::CReadState: ({}) Resume from position {}", fmt::ptr(this),
+               m_filePos);
 
   SetResume();
   g_curlInterface.multi_add_handle(m_multiHandle, m_easyHandle);
@@ -768,11 +767,11 @@ void CCurlFile::ParseAndCorrectUrl(CURL &url2)
     // we was using url options for urls, keep the old code work and warning
     if (!url2.GetOptions().empty())
     {
-      CLog::Log(LOGWARNING,
-                "CCurlFile::{} - <{}> FTP url option is deprecated, please switch to use protocol "
-                "option (change "
-                "'?' to '|')",
-                __FUNCTION__, url2.GetRedacted());
+      CLog::LogF(LOGWARNING,
+                 "CCurlFile: <{}> FTP url option is deprecated, please switch to use protocol "
+                 "option (change "
+                 "'?' to '|')",
+                 url2.GetRedacted());
       url2.SetProtocolOptions(url2.GetOptions().substr(1));
       /* ftp has no options */
       url2.SetOptions("");
@@ -992,8 +991,7 @@ bool CCurlFile::ReadData(std::string& strHTML)
 
 bool CCurlFile::Download(const std::string& strURL, const std::string& strFileName, unsigned int* pdwSize)
 {
-  CLog::Log(LOGINFO, "CCurlFile::{} - {}->{}", __FUNCTION__, CURL::GetRedacted(strURL),
-            strFileName);
+  CLog::LogF(LOGINFO, "CCurlFile: {}->{}", CURL::GetRedacted(strURL), strFileName);
 
   std::string strData;
   if (!Get(strURL, strData))
@@ -1002,8 +1000,8 @@ bool CCurlFile::Download(const std::string& strURL, const std::string& strFileNa
   XFILE::CFile file;
   if (!file.OpenForWrite(strFileName, true))
   {
-    CLog::Log(LOGERROR, "CCurlFile::{} - <{}> Unable to open file for write: {} ({})", __FUNCTION__,
-              CURL::GetRedacted(strURL), strFileName, GetLastError());
+    CLog::LogF(LOGERROR, "CCurlFile: <{}> Unable to open file for write: {} ({})",
+               CURL::GetRedacted(strURL), strFileName, GetLastError());
     return false;
   }
   ssize_t written = 0;
@@ -1062,8 +1060,8 @@ void CCurlFile::SetProxy(const std::string &type, const std::string &host,
   else if (type == "socks5-remote")
     m_proxytype = CCurlFile::PROXY_SOCKS5_REMOTE;
   else
-    CLog::Log(LOGERROR, "CCurFile::{} - <{}> Invalid proxy type \"{}\"", __FUNCTION__,
-              CURL::GetRedacted(m_url), type);
+    CLog::LogF(LOGERROR, "CCurFile: <{}> Invalid proxy type \"{}\"", CURL::GetRedacted(m_url),
+               type);
   m_proxyhost = host;
   m_proxyport = port;
   m_proxyuser = user;
@@ -1079,7 +1077,7 @@ bool CCurlFile::Open(const CURL& url)
   ParseAndCorrectUrl(url2);
 
   std::string redactPath = CURL::GetRedacted(m_url);
-  CLog::Log(LOGDEBUG, "CurlFile::{} - <{}>", __FUNCTION__, redactPath);
+  CLog::LogF(LOGDEBUG, "CurlFile: <{}>", redactPath);
 
   assert(!(!m_state->m_easyHandle ^ !m_state->m_multiHandle));
   if( m_state->m_easyHandle == NULL )
@@ -1106,8 +1104,8 @@ bool CCurlFile::Open(const CURL& url)
       ReadString(&error[0], 4095);
     }
 
-    CLog::Log(LOGERROR, "CCurlFile::{} - <{}> Failed with code {}:\n{}", __FUNCTION__,
-              redactPath, m_httpresponse, error);
+    CLog::LogF(LOGERROR, "CCurlFile: <{}> Failed with code {}:\n{}", redactPath, m_httpresponse,
+               error);
 
     return false;
   }
@@ -1126,8 +1124,7 @@ bool CCurlFile::Open(const CURL& url)
      || !m_state->m_httpheader.GetValue("icy-name").empty()
      || !m_state->m_httpheader.GetValue("icy-br").empty()) && !m_skipshout)
   {
-    CLog::Log(LOGDEBUG, "CCurlFile::{} - <{}> File is a shoutcast stream. Re-opening", __FUNCTION__,
-              redactPath);
+    CLog::LogF(LOGDEBUG, "CCurlFile: <{}> File is a shoutcast stream. Re-opening", redactPath);
     throw new CRedirectException(new CShoutcastFile);
   }
 
@@ -1137,9 +1134,8 @@ bool CCurlFile::Open(const CURL& url)
     m_multisession = true;
     if(m_state->m_httpheader.GetValue("Server").find("Portable SDK for UPnP devices") != std::string::npos)
     {
-      CLog::Log(LOGWARNING,
-                "CCurlFile::{} - <{}> Disabling multi session due to broken libupnp server",
-                __FUNCTION__, redactPath);
+      CLog::LogF(LOGWARNING, "CCurlFile: <{}> Disabling multi session due to broken libupnp server",
+                 redactPath);
       m_multisession = false;
     }
   }
@@ -1166,8 +1162,7 @@ bool CCurlFile::Open(const CURL& url)
     if (m_url != efurl)
     {
       std::string redactEfpath = CURL::GetRedacted(efurl);
-      CLog::Log(LOGDEBUG, "CCurlFile::{} - <{}> Effective URL is {}", __FUNCTION__, redactPath,
-                redactEfpath);
+      CLog::LogF(LOGDEBUG, "CCurlFile: <{}> Effective URL is {}", redactPath, redactEfpath);
     }
     m_url = efurl;
   }
@@ -1186,7 +1181,7 @@ bool CCurlFile::OpenForWrite(const CURL& url, bool bOverWrite)
   CURL url2(url);
   ParseAndCorrectUrl(url2);
 
-  CLog::Log(LOGDEBUG, "CCurlFile::{} - Opening {}", __FUNCTION__, CURL::GetRedacted(m_url));
+  CLog::LogF(LOGDEBUG, "CCurlFile: Opening {}", CURL::GetRedacted(m_url));
 
   assert(m_state->m_easyHandle == NULL);
   g_curlInterface.easy_acquire(url2.GetProtocol().c_str(),
@@ -1243,8 +1238,8 @@ ssize_t CCurlFile::Write(const void* lpBuf, size_t uiBufSize)
     {
       long code;
       if(g_curlInterface.easy_getinfo(m_state->m_easyHandle, CURLINFO_RESPONSE_CODE, &code) == CURLE_OK )
-        CLog::Log(LOGERROR, "CCurlFile::{} - <{}> Unable to write curl resource with code {}",
-                  __FUNCTION__, CURL::GetRedacted(m_url), code);
+        CLog::LogF(LOGERROR, "CCurlFile: <{}> Unable to write curl resource with code {}",
+                   CURL::GetRedacted(m_url), code);
       m_inError = true;
       return -1;
     }
@@ -1268,10 +1263,9 @@ bool CCurlFile::CReadState::ReadString(char *szLine, int iLineLength)
   if (!m_stillRunning && (m_fileSize == 0 || m_filePos != m_fileSize) && !want)
   {
     if (m_fileSize != 0)
-      CLog::Log(
-          LOGWARNING,
-          "CCurlFile::{} - ({}) Transfer ended before entire file was retrieved pos {}, size {}",
-          __FUNCTION__, fmt::ptr(this), m_filePos, m_fileSize);
+      CLog::LogF(LOGWARNING,
+                 "CCurlFile: ({}) Transfer ended before entire file was retrieved pos {}, size {}",
+                 fmt::ptr(this), m_filePos, m_fileSize);
 
     return false;
   }
@@ -1300,8 +1294,7 @@ bool CCurlFile::Exists(const CURL& url)
   // if file is already running, get info from it
   if( m_opened )
   {
-    CLog::Log(LOGWARNING, "CCurlFile::{} - <{}> Exist called on open file", __FUNCTION__,
-              url.GetRedacted());
+    CLog::LogF(LOGWARNING, "CCurlFile: <{}> Exist called on open file", url.GetRedacted());
     return true;
   }
 
@@ -1367,19 +1360,19 @@ bool CCurlFile::Exists(const CURL& url)
         if (result == CURLE_HTTP_RETURNED_ERROR)
         {
           if (g_curlInterface.easy_getinfo(m_state->m_easyHandle, CURLINFO_RESPONSE_CODE, &code) == CURLE_OK && code != 404 )
-            CLog::Log(LOGERROR, "CCurlFile::{} - <{}> Failed: HTTP returned error {}", __FUNCTION__,
-                      url.GetRedacted(), code);
+            CLog::LogF(LOGERROR, "CCurlFile: <{}> Failed: HTTP returned error {}",
+                       url.GetRedacted(), code);
         }
       }
       else
-        CLog::Log(LOGERROR, "CCurlFile::{} - <{}> Failed: HTTP returned error {}", __FUNCTION__,
-                  url.GetRedacted(), code);
+        CLog::LogF(LOGERROR, "CCurlFile: <{}> Failed: HTTP returned error {}", url.GetRedacted(),
+                   code);
     }
   }
   else if (result != CURLE_REMOTE_FILE_NOT_FOUND && result != CURLE_FTP_COULDNT_RETR_FILE)
   {
-    CLog::Log(LOGERROR, "CCurlFile::{} - <{}> Failed: {}({})", __FUNCTION__, url.GetRedacted(),
-              g_curlInterface.easy_strerror(result), result);
+    CLog::LogF(LOGERROR, "CCurlFile: <{}> Failed: {}({})", url.GetRedacted(),
+               g_curlInterface.easy_strerror(result), result);
   }
 
   errno = ENOENT;
@@ -1502,8 +1495,7 @@ int CCurlFile::Stat(const CURL& url, struct __stat64* buffer)
   // if file is already running, get info from it
   if( m_opened )
   {
-    CLog::Log(LOGWARNING, "CCurlFile::{} - <{}> Stat called on open file", __FUNCTION__,
-              url.GetRedacted());
+    CLog::LogF(LOGWARNING, "CCurlFile: <{}> Stat called on open file", url.GetRedacted());
     if (buffer)
     {
       *buffer = {};
@@ -1575,8 +1567,8 @@ int CCurlFile::Stat(const CURL& url, struct __stat64* buffer)
   {
     g_curlInterface.easy_release(&m_state->m_easyHandle, NULL);
     errno = ENOENT;
-    CLog::Log(LOGERROR, "CCurlFile::{} - <{}> Failed: {}({})", __FUNCTION__, url.GetRedacted(),
-              g_curlInterface.easy_strerror(result), result);
+    CLog::LogF(LOGERROR, "CCurlFile: <{}> Failed: {}({})", url.GetRedacted(),
+               g_curlInterface.easy_strerror(result), result);
     return -1;
   }
 
@@ -1593,8 +1585,8 @@ int CCurlFile::Stat(const CURL& url, struct __stat64* buffer)
     if (url.IsProtocol("ftp"))
     {
       g_curlInterface.easy_release(&m_state->m_easyHandle, NULL);
-      CLog::Log(LOGINFO, "CCurlFile::{} - <{}> Content length failed: {}({})", __FUNCTION__,
-                url.GetRedacted(), g_curlInterface.easy_strerror(result), result);
+      CLog::LogF(LOGINFO, "CCurlFile: <{}> Content length failed: {}({})", url.GetRedacted(),
+                 g_curlInterface.easy_strerror(result), result);
       errno = ENOENT;
       return -1;
     }
@@ -1625,8 +1617,8 @@ int CCurlFile::Stat(const CURL& url, struct __stat64* buffer)
     result = g_curlInterface.easy_getinfo(m_state->m_easyHandle, CURLINFO_FILETIME, &filetime);
     if (result != CURLE_OK)
     {
-      CLog::Log(LOGINFO, "CCurlFile::{} - <{}> Filetime failed: {}({})", __FUNCTION__,
-                url.GetRedacted(), g_curlInterface.easy_strerror(result), result);
+      CLog::LogF(LOGINFO, "CCurlFile: <{}> Filetime failed: {}({})", url.GetRedacted(),
+                 g_curlInterface.easy_strerror(result), result);
     }
     else
     {
@@ -1664,10 +1656,10 @@ ssize_t CCurlFile::CReadState::Read(void* lpBuf, size_t uiBufSize)
   /* check if we finished prematurely */
   if (!m_stillRunning && (m_fileSize == 0 || m_filePos != m_fileSize))
   {
-    CLog::Log(LOGWARNING,
-              "CCurlFile::CReadState::{} - ({}) Transfer ended before entire file was retrieved "
-              "pos {}, size {}",
-              __FUNCTION__, fmt::ptr(this), m_filePos, m_fileSize);
+    CLog::LogF(LOGWARNING,
+               "CCurlFile::CReadState: ({}) Transfer ended before entire file was retrieved "
+               "pos {}, size {}",
+               fmt::ptr(this), m_filePos, m_fileSize);
     return -1;
   }
 
@@ -1732,15 +1724,13 @@ int8_t CCurlFile::CReadState::FillBuffer(unsigned int want)
 
               // Don't log 404 not-found errors to prevent log-spam
               if (httpCode != 404)
-                CLog::Log(LOGERROR,
-                          "CCurlFile::CReadState::{} - ({}) Failed: HTTP returned code {}",
-                          __FUNCTION__, fmt::ptr(this), httpCode);
+                CLog::LogF(LOGERROR, "CCurlFile::CReadState: ({}) Failed: HTTP returned code {}",
+                           fmt::ptr(this), httpCode);
             }
             else
             {
-              CLog::Log(LOGERROR, "CCurlFile::CReadState::{} - ({}) Failed: {}({})", __FUNCTION__,
-                        fmt::ptr(this), g_curlInterface.easy_strerror(msg->data.result),
-                        msg->data.result);
+              CLog::LogF(LOGERROR, "CCurlFile::CReadState: ({}) Failed: {}({})", fmt::ptr(this),
+                         g_curlInterface.easy_strerror(msg->data.result), msg->data.result);
             }
 
             if ( (msg->data.result == CURLE_OPERATION_TIMEDOUT ||
@@ -1796,8 +1786,8 @@ int8_t CCurlFile::CReadState::FillBuffer(unsigned int want)
           SetResume();
           g_curlInterface.multi_add_handle(m_multiHandle, m_easyHandle);
 
-          CLog::Log(LOGWARNING, "CCurlFile::CReadState::{} - ({}) Reconnect, (re)try {}",
-                    __FUNCTION__, fmt::ptr(this), retry);
+          CLog::LogF(LOGWARNING, "CCurlFile::CReadState: ({}) Reconnect, (re)try {}",
+                     fmt::ptr(this), retry);
 
           // Return to the beginning of the loop:
           continue;
@@ -1874,12 +1864,12 @@ int8_t CCurlFile::CReadState::FillBuffer(unsigned int want)
 #ifdef TARGET_WINDOWS
           char buf[256];
           strerror_s(buf, 256, WSAGetLastError());
-          CLog::Log(LOGERROR, "CCurlFile::CReadState::{} - ({}) Failed with socket error:{}",
-                    __FUNCTION__, fmt::ptr(this), buf);
+          CLog::LogF(LOGERROR, "CCurlFile::CReadState: ({}) Failed with socket error:{}",
+                     fmt::ptr(this), buf);
 #else
           char const * str = strerror(errno);
-          CLog::Log(LOGERROR, "CCurlFile::CReadState::{} - ({}) Failed with socket error:{}",
-                    __FUNCTION__, fmt::ptr(this), str);
+          CLog::LogF(LOGERROR, "CCurlFile::CReadState: ({}) Failed with socket error:{}",
+                     fmt::ptr(this), str);
 #endif
 
           return FILLBUFFER_FAIL;
@@ -1896,9 +1886,9 @@ int8_t CCurlFile::CReadState::FillBuffer(unsigned int want)
       break;
       default:
       {
-        CLog::Log(LOGERROR,
-                  "CCurlFile::CReadState::{} - ({}) Multi perform failed with code {}, aborting",
-                  __FUNCTION__, fmt::ptr(this), result);
+        CLog::LogF(LOGERROR,
+                   "CCurlFile::CReadState: ({}) Multi perform failed with code {}, aborting",
+                   fmt::ptr(this), result);
         return FILLBUFFER_FAIL;
       }
       break;
@@ -1945,9 +1935,9 @@ std::string CCurlFile::GetInfoString(int infoType)
   CURLcode result = g_curlInterface.easy_getinfo(m_state->m_easyHandle, static_cast<CURLINFO> (infoType), &info);
   if (result != CURLE_OK)
   {
-    CLog::Log(LOGERROR,
-              "CCurlFile::{} - <{}> Info string request for type {} failed with result code {}",
-              __FUNCTION__, CURL::GetRedacted(m_url), infoType, result);
+    CLog::LogF(LOGERROR,
+               "CCurlFile: <{}> Info string request for type {} failed with result code {}",
+               CURL::GetRedacted(m_url), infoType, result);
     return "";
   }
   return (info ? info : "");
@@ -1968,8 +1958,8 @@ bool CCurlFile::GetHttpHeader(const CURL &url, CHttpHeader &headers)
   }
   catch(...)
   {
-    CLog::Log(LOGERROR, "CCurlFile::{} - <{}> Exception thrown while trying to retrieve header",
-              __FUNCTION__, url.GetRedacted());
+    CLog::LogF(LOGERROR, "CCurlFile: <{}> Exception thrown while trying to retrieve header",
+               url.GetRedacted());
     return false;
   }
 }
@@ -1988,10 +1978,10 @@ bool CCurlFile::GetMimeType(const CURL &url, std::string &content, const std::st
       content = "x-directory/normal";
     else
       content = file.GetProperty(XFILE::FILE_PROPERTY_MIME_TYPE);
-    CLog::Log(LOGDEBUG, "CCurlFile::{} - <{}> -> {}", __FUNCTION__, redactUrl, content);
+    CLog::LogF(LOGDEBUG, "CCurlFile: <{}> -> {}", redactUrl, content);
     return true;
   }
-  CLog::Log(LOGDEBUG, "CCurlFile::{} - <{}> -> failed", __FUNCTION__, redactUrl);
+  CLog::LogF(LOGDEBUG, "CCurlFile: <{}> -> failed", redactUrl);
   content.clear();
   return false;
 }
@@ -2010,10 +2000,10 @@ bool CCurlFile::GetContentType(const CURL &url, std::string &content, const std:
       content = "x-directory/normal";
     else
       content = file.GetProperty(XFILE::FILE_PROPERTY_CONTENT_TYPE, "");
-    CLog::Log(LOGDEBUG, "CCurlFile::{} - <{}> -> {}", __FUNCTION__, redactUrl, content);
+    CLog::LogF(LOGDEBUG, "CCurlFile: <{}> -> {}", redactUrl, content);
     return true;
   }
-  CLog::Log(LOGDEBUG, "CCurlFile::{} - <{}> -> failed", __FUNCTION__, redactUrl);
+  CLog::LogF(LOGDEBUG, "CCurlFile: <{}> -> failed", redactUrl);
   content.clear();
   return false;
 }
@@ -2042,8 +2032,8 @@ bool CCurlFile::GetCookies(const CURL &url, std::string &cookies)
       // ensure the length is valid
       if (valuesVec.size() < 7)
       {
-        CLog::Log(LOGERROR, "CCurlFile::{} - <{}> Invalid cookie: '{}'", __FUNCTION__,
-                  url.GetRedacted(), curlCookieIter->data);
+        CLog::LogF(LOGERROR, "CCurlFile: <{}> Invalid cookie: '{}'", url.GetRedacted(),
+                   curlCookieIter->data);
         curlCookieIter = curlCookieIter->next;
         continue;
       }

--- a/xbmc/filesystem/DAVCommon.cpp
+++ b/xbmc/filesystem/DAVCommon.cpp
@@ -46,8 +46,8 @@ bool CDAVCommon::ValueWithoutNamespace(const TiXmlNode *pNode, const std::string
   }
   else if (tag.size() > 2)
   {
-    CLog::Log(LOGERROR, "{} - Splitting {} failed, size(): {}, value: {}", __FUNCTION__,
-              pElement->Value(), (unsigned long int)tag.size(), value);
+    CLog::LogF(LOGERROR, "Splitting {} failed, size(): {}, value: {}", pElement->Value(),
+               (unsigned long int)tag.size(), value);
   }
 
   return false;

--- a/xbmc/filesystem/DAVDirectory.cpp
+++ b/xbmc/filesystem/DAVDirectory.cpp
@@ -118,7 +118,7 @@ bool CDAVDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
   if (!dav.Open(url))
   {
-    CLog::Log(LOGERROR, "{} - Unable to get dav directory ({})", __FUNCTION__, url.GetRedacted());
+    CLog::LogF(LOGERROR, "Unable to get dav directory ({})", url.GetRedacted());
     return false;
   }
 
@@ -131,8 +131,7 @@ bool CDAVDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
   if (!davResponse.Parse(strResponse))
   {
-    CLog::Log(LOGERROR, "{} - Unable to process dav directory ({})", __FUNCTION__,
-              url.GetRedacted());
+    CLog::LogF(LOGERROR, "Unable to process dav directory ({})", url.GetRedacted());
     dav.Close();
     return false;
   }
@@ -187,8 +186,8 @@ bool CDAVDirectory::Create(const CURL& url)
 
   if (!dav.Execute(url))
   {
-    CLog::Log(LOGERROR, "{} - Unable to create dav directory ({}) - {}", __FUNCTION__,
-              url.GetRedacted(), dav.GetLastResponseCode());
+    CLog::LogF(LOGERROR, "Unable to create dav directory ({}) - {}", url.GetRedacted(),
+               dav.GetLastResponseCode());
     return false;
   }
 
@@ -219,8 +218,8 @@ bool CDAVDirectory::Remove(const CURL& url)
 
   if (!dav.Execute(url))
   {
-    CLog::Log(LOGERROR, "{} - Unable to delete dav directory ({}) - {}", __FUNCTION__,
-              url.GetRedacted(), dav.GetLastResponseCode());
+    CLog::LogF(LOGERROR, "Unable to delete dav directory ({}) - {}", url.GetRedacted(),
+               dav.GetLastResponseCode());
     return false;
   }
 

--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -205,7 +205,7 @@ bool CDirectory::GetDirectory(const CURL& url,
             continue;
           }
 
-          CLog::Log(LOGERROR, "{} - Error getting {}", __FUNCTION__, url.GetRedacted());
+          CLog::LogF(LOGERROR, "Error getting {}", url.GetRedacted());
           return false;
         }
       }
@@ -300,8 +300,11 @@ bool CDirectory::GetDirectory(const CURL& url,
     return true;
   }
   XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...) { CLog::Log(LOGERROR, "{} - Unhandled exception", __FUNCTION__); }
-  CLog::Log(LOGERROR, "{} - Error getting {}", __FUNCTION__, url.GetRedacted());
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "Unhandled exception");
+  }
+  CLog::LogF(LOGERROR, "Error getting {}", url.GetRedacted());
   return false;
 }
 
@@ -326,8 +329,11 @@ bool CDirectory::Create(const CURL& url)
         return true;
   }
   XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...) { CLog::Log(LOGERROR, "{} - Unhandled exception", __FUNCTION__); }
-  CLog::Log(LOGERROR, "{} - Error creating {}", __FUNCTION__, url.GetRedacted());
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "Unhandled exception");
+  }
+  CLog::LogF(LOGERROR, "Error creating {}", url.GetRedacted());
   return false;
 }
 
@@ -361,8 +367,11 @@ bool CDirectory::Exists(const CURL& url, bool bUseCache /* = true */)
       return pDirectory->Exists(realURL);
   }
   XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...) { CLog::Log(LOGERROR, "{} - Unhandled exception", __FUNCTION__); }
-  CLog::Log(LOGERROR, "{} - Error checking for {}", __FUNCTION__, url.GetRedacted());
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "Unhandled exception");
+  }
+  CLog::LogF(LOGERROR, "Error checking for {}", url.GetRedacted());
   return false;
 }
 
@@ -395,8 +404,11 @@ bool CDirectory::Remove(const CURL& url)
       }
   }
   XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...) { CLog::Log(LOGERROR, "{} - Unhandled exception", __FUNCTION__); }
-  CLog::Log(LOGERROR, "{} - Error removing {}", __FUNCTION__, url.GetRedacted());
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "Unhandled exception");
+  }
+  CLog::LogF(LOGERROR, "Error removing {}", url.GetRedacted());
   return false;
 }
 
@@ -418,8 +430,11 @@ bool CDirectory::RemoveRecursive(const CURL& url)
       }
   }
   XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...) { CLog::Log(LOGERROR, "{} - Unhandled exception", __FUNCTION__); }
-  CLog::Log(LOGERROR, "{} - Error removing {}", __FUNCTION__, url.GetRedacted());
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "Unhandled exception");
+  }
+  CLog::LogF(LOGERROR, "Error removing {}", url.GetRedacted());
   return false;
 }
 

--- a/xbmc/filesystem/DirectoryCache.cpp
+++ b/xbmc/filesystem/DirectoryCache.cpp
@@ -247,8 +247,7 @@ void CDirectoryCache::CheckIfFull()
 void CDirectoryCache::PrintStats() const
 {
   std::unique_lock<CCriticalSection> lock(m_cs);
-  CLog::Log(LOGDEBUG, "{} - total of {} cache hits, and {} cache misses", __FUNCTION__, m_cacheHits,
-            m_cacheMisses);
+  CLog::LogF(LOGDEBUG, "total of {} cache hits, and {} cache misses", m_cacheHits, m_cacheMisses);
   // run through and find the oldest and the number of items cached
   unsigned int oldest = UINT_MAX;
   unsigned int numItems = 0;
@@ -260,7 +259,7 @@ void CDirectoryCache::PrintStats() const
     numItems += dir.m_Items->Size();
     numDirs++;
   }
-  CLog::Log(LOGDEBUG, "{} - {} folders cached, with {} items total.  Oldest is {}, current is {}",
-            __FUNCTION__, numDirs, numItems, oldest, m_accessCounter);
+  CLog::LogF(LOGDEBUG, "{} folders cached, with {} items total.  Oldest is {}, current is {}",
+             numDirs, numItems, oldest, m_accessCounter);
 }
 #endif

--- a/xbmc/filesystem/DirectoryFactory.cpp
+++ b/xbmc/filesystem/DirectoryFactory.cpp
@@ -190,8 +190,7 @@ IDirectory* CDirectoryFactory::Create(const CURL& url)
   if (url.IsProtocol("pvr"))
     return new CPVRDirectory();
 
-  CLog::Log(LOGWARNING, "{} - unsupported protocol({}) in {}", __FUNCTION__, url.GetProtocol(),
-            url.GetRedacted());
+  CLog::LogF(LOGWARNING, "unsupported protocol({}) in {}", url.GetProtocol(), url.GetRedacted());
   return NULL;
 }
 

--- a/xbmc/filesystem/DllLibCurl.cpp
+++ b/xbmc/filesystem/DllLibCurl.cpp
@@ -142,8 +142,8 @@ void DllLibCurlGlobal::CheckIdle()
 
     if (!it->m_busy && duration.count() > idletime)
     {
-      CLog::Log(LOGDEBUG, "{} - Closing session to {}://{} (easy={}, multi={})", __FUNCTION__,
-                it->m_protocol, it->m_hostname, fmt::ptr(it->m_easy), fmt::ptr(it->m_multi));
+      CLog::LogF(LOGDEBUG, "Closing session to {}://{} (easy={}, multi={})", it->m_protocol,
+                 it->m_hostname, fmt::ptr(it->m_easy), fmt::ptr(it->m_multi));
 
       if (it->m_multi && it->m_easy)
         multi_remove_handle(it->m_multi, it->m_easy);
@@ -217,7 +217,7 @@ void DllLibCurlGlobal::easy_acquire(const char* protocol,
 
   m_sessions.push_back(session);
 
-  CLog::Log(LOGDEBUG, "{} - Created session to {}://{}", __FUNCTION__, protocol, hostname);
+  CLog::LogF(LOGDEBUG, "Created session to {}://{}", protocol, hostname);
 }
 
 void DllLibCurlGlobal::easy_release(CURL_HANDLE** easy_handle, CURLM** multi_handle)

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -137,7 +137,7 @@ bool CFile::Copy(const CURL& url2, const CURL& dest, XFILE::IFileCallback* pCall
       if (iRead == 0) break;
       else if (iRead < 0)
       {
-        CLog::Log(LOGERROR, "{} - Failed read from file {}", __FUNCTION__, url.GetRedacted());
+        CLog::LogF(LOGERROR, "Failed read from file {}", url.GetRedacted());
         llFileSize = (uint64_t)-1;
         break;
       }
@@ -154,7 +154,7 @@ bool CFile::Copy(const CURL& url2, const CURL& dest, XFILE::IFileCallback* pCall
 
       if (iWrite != iRead)
       {
-        CLog::Log(LOGERROR, "{} - Failed write to file {}", __FUNCTION__, dest.GetRedacted());
+        CLog::LogF(LOGERROR, "Failed write to file {}", dest.GetRedacted());
         llFileSize = (uint64_t)-1;
         break;
       }
@@ -175,7 +175,7 @@ bool CFile::Copy(const CURL& url2, const CURL& dest, XFILE::IFileCallback* pCall
 
         if(!pCallback->OnFileCallback(pContext, ipercent, averageSpeed))
         {
-          CLog::Log(LOGERROR, "{} - User aborted copy", __FUNCTION__);
+          CLog::LogF(LOGERROR, "User aborted copy");
           llFileSize = (uint64_t)-1;
           break;
         }
@@ -375,8 +375,11 @@ bool CFile::Open(const CURL& file, const unsigned int flags)
     return true;
   }
   XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...) { CLog::Log(LOGERROR, "{} - Unhandled exception", __FUNCTION__); }
-  CLog::Log(LOGERROR, "{} - Error opening {}", __FUNCTION__, file.GetRedacted());
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "Unhandled exception");
+  }
+  CLog::LogF(LOGERROR, "Error opening {}", file.GetRedacted());
   return false;
 }
 
@@ -408,9 +411,9 @@ bool CFile::OpenForWrite(const CURL& file, bool bOverWrite)
   XBMCCOMMONS_HANDLE_UNCHECKED
   catch(...)
   {
-    CLog::Log(LOGERROR, "{} - Unhandled exception opening {}", __FUNCTION__, file.GetRedacted());
+    CLog::LogF(LOGERROR, "Unhandled exception opening {}", file.GetRedacted());
   }
-  CLog::Log(LOGERROR, "{} - Error opening {}", __FUNCTION__, file.GetRedacted());
+  CLog::LogF(LOGERROR, "Error opening {}", file.GetRedacted());
   return false;
 }
 
@@ -488,8 +491,11 @@ bool CFile::Exists(const CURL& file, bool bUseCache /* = true */)
       }
     }
   }
-  catch (...) { CLog::Log(LOGERROR, "{} - Unhandled exception", __FUNCTION__); }
-  CLog::Log(LOGERROR, "{} - Error checking for {}", __FUNCTION__, file.GetRedacted());
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "Unhandled exception");
+  }
+  CLog::LogF(LOGERROR, "Error checking for {}", file.GetRedacted());
   return false;
 }
 
@@ -566,8 +572,11 @@ int CFile::Stat(const CURL& file, struct __stat64* buffer)
       }
     }
   }
-  catch (...) { CLog::Log(LOGERROR, "{} - Unhandled exception", __FUNCTION__); }
-  CLog::Log(LOGERROR, "{} - Error statting {}", __FUNCTION__, file.GetRedacted());
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "Unhandled exception");
+  }
+  CLog::LogF(LOGERROR, "Error statting {}", file.GetRedacted());
   return -1;
 }
 
@@ -642,7 +651,7 @@ ssize_t CFile::Read(void *lpBuf, size_t uiBufSize)
   XBMCCOMMONS_HANDLE_UNCHECKED
   catch(...)
   {
-    CLog::Log(LOGERROR, "{} - Unhandled exception", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Unhandled exception");
     return -1;
   }
   return 0;
@@ -660,7 +669,10 @@ void CFile::Close()
     m_pFile.reset();
   }
   XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...) { CLog::Log(LOGERROR, "{} - Unhandled exception", __FUNCTION__); }
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "Unhandled exception");
+  }
 }
 
 void CFile::Flush()
@@ -671,7 +683,10 @@ void CFile::Flush()
       m_pFile->Flush();
   }
   XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...) { CLog::Log(LOGERROR, "{} - Unhandled exception", __FUNCTION__); }
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "Unhandled exception");
+  }
 }
 
 //*********************************************************************************************
@@ -695,7 +710,10 @@ int64_t CFile::Seek(int64_t iFilePosition, int iWhence)
     return m_pFile->Seek(iFilePosition, iWhence);
   }
   XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...) { CLog::Log(LOGERROR, "{} - Unhandled exception", __FUNCTION__); }
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "Unhandled exception");
+  }
   return -1;
 }
 
@@ -710,7 +728,10 @@ int CFile::Truncate(int64_t iSize)
     return m_pFile->Truncate(iSize);
   }
   XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...) { CLog::Log(LOGERROR, "{} - Unhandled exception", __FUNCTION__); }
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "Unhandled exception");
+  }
   return -1;
 }
 
@@ -724,7 +745,10 @@ int64_t CFile::GetLength()
     return 0;
   }
   XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...) { CLog::Log(LOGERROR, "{} - Unhandled exception", __FUNCTION__); }
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "Unhandled exception");
+  }
   return 0;
 }
 
@@ -742,7 +766,10 @@ int64_t CFile::GetPosition() const
     return m_pFile->GetPosition();
   }
   XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...) { CLog::Log(LOGERROR, "{} - Unhandled exception", __FUNCTION__); }
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "Unhandled exception");
+  }
   return -1;
 }
 
@@ -801,7 +828,10 @@ bool CFile::ReadString(char *szLine, int iLineLength)
     return m_pFile->ReadString(szLine, iLineLength);
   }
   XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...) { CLog::Log(LOGERROR, "{} - Unhandled exception", __FUNCTION__); }
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "Unhandled exception");
+  }
   return false;
 }
 
@@ -825,7 +855,10 @@ ssize_t CFile::Write(const void* lpBuf, size_t uiBufSize)
     return m_pFile->Write(lpBuf, uiBufSize);
   }
   XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...) { CLog::Log(LOGERROR, "{} - Unhandled exception", __FUNCTION__); }
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "Unhandled exception");
+  }
   return -1;
 }
 
@@ -855,9 +888,12 @@ bool CFile::Delete(const CURL& file)
     }
   }
   XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...) { CLog::Log(LOGERROR, "{} - Unhandled exception", __FUNCTION__); }
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "Unhandled exception");
+  }
   if (Exists(file))
-    CLog::Log(LOGERROR, "{} - Error deleting file {}", __FUNCTION__, file.GetRedacted());
+    CLog::LogF(LOGERROR, "Error deleting file {}", file.GetRedacted());
   return false;
 }
 
@@ -894,8 +930,11 @@ bool CFile::Rename(const CURL& file, const CURL& newFile)
     }
   }
   XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...) { CLog::Log(LOGERROR, "{} - Unhandled exception ", __FUNCTION__); }
-  CLog::Log(LOGERROR, "{} - Error renaming file {}", __FUNCTION__, file.GetRedacted());
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "Unhandled exception ");
+  }
+  CLog::LogF(LOGERROR, "Error renaming file {}", file.GetRedacted());
   return false;
 }
 
@@ -922,7 +961,7 @@ bool CFile::SetHidden(const CURL& file, bool hidden)
   }
   catch(...)
   {
-    CLog::Log(LOGERROR, "{}({}) - Unhandled exception", __FUNCTION__, file.GetRedacted());
+    CLog::LogF(LOGERROR, "({}) - Unhandled exception", file.GetRedacted());
   }
   return false;
 }

--- a/xbmc/filesystem/FileFactory.cpp
+++ b/xbmc/filesystem/FileFactory.cpp
@@ -174,7 +174,6 @@ IFile* CFileFactory::CreateLoader(const CURL& url)
   else if (url.IsProtocol("upnp")) return new CUPnPFile();
 #endif
 
-  CLog::Log(LOGWARNING, "{} - unsupported protocol({}) in {}", __FUNCTION__, url.GetProtocol(),
-            url.GetRedacted());
+  CLog::LogF(LOGWARNING, "unsupported protocol({}) in {}", url.GetProtocol(), url.GetRedacted());
   return NULL;
 }

--- a/xbmc/filesystem/HTTPDirectory.cpp
+++ b/xbmc/filesystem/HTTPDirectory.cpp
@@ -36,7 +36,7 @@ bool CHTTPDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
   if(!http.Open(url))
   {
-    CLog::Log(LOGERROR, "{} - Unable to get http directory ({})", __FUNCTION__, url.GetRedacted());
+    CLog::LogF(LOGERROR, "Unable to get http directory ({})", url.GetRedacted());
     return false;
   }
 

--- a/xbmc/filesystem/MusicSearchDirectory.cpp
+++ b/xbmc/filesystem/MusicSearchDirectory.cpp
@@ -40,7 +40,7 @@ bool CMusicSearchDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   auto end = std::chrono::steady_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 
-  CLog::Log(LOGDEBUG, "{} ({}) took {} ms", __FUNCTION__, url.GetRedacted(), duration.count());
+  CLog::LogF(LOGDEBUG, "({}) took {} ms", url.GetRedacted(), duration.count());
 
   items.SetLabel(g_localizeStrings.Get(137)); // Search
   return true;

--- a/xbmc/filesystem/NFSDirectory.cpp
+++ b/xbmc/filesystem/NFSDirectory.cpp
@@ -351,8 +351,7 @@ bool CNFSDirectory::Remove(const CURL& url2)
 
   if(ret != 0 && errno != ENOENT)
   {
-    CLog::Log(LOGERROR, "{} - Error( {} )", __FUNCTION__,
-              nfs_get_error(gNfsConnection.GetNfsContext()));
+    CLog::LogF(LOGERROR, "Error( {} )", nfs_get_error(gNfsConnection.GetNfsContext()));
     return false;
   }
   return true;

--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -319,10 +319,10 @@ bool CNfsConnection::Connect(const CURL& url, std::string &relativePath)
 
       if(nfsRet != 0)
       {
-        CLog::Log(LOGERROR, "NFS: Failed to mount nfs share: {} ({})", exportPath,
-                  nfs_get_error(m_pNfsContext));
-        destroyContext(url.GetHostName() + exportPath);
-        return false;
+          CLog::Log(LOGERROR, "NFS: Failed to mount nfs share: {} ({})", exportPath,
+                    nfs_get_error(m_pNfsContext));
+          destroyContext(url.GetHostName() + exportPath);
+          return false;
       }
       CLog::Log(LOGDEBUG, "NFS: Connected to server {} and export {}", url.GetHostName(),
                 exportPath);
@@ -726,8 +726,8 @@ ssize_t CNFSFile::Read(void *lpBuf, size_t uiBufSize)
 
   //something went wrong ...
   if (numberOfBytesRead < 0)
-    CLog::Log(LOGERROR, "{} - Error( {}, {} )", __FUNCTION__, (int64_t)numberOfBytesRead,
-              nfs_get_error(m_pNfsContext));
+    CLog::LogF(LOGERROR, "Error( {}, {} )", (int64_t)numberOfBytesRead,
+               nfs_get_error(m_pNfsContext));
 
   return numberOfBytesRead;
 }
@@ -744,8 +744,8 @@ int64_t CNFSFile::Seek(int64_t iFilePosition, int iWhence)
   ret = nfs_lseek(m_pNfsContext, m_pFileHandle, iFilePosition, iWhence, &offset);
   if (ret < 0)
   {
-    CLog::Log(LOGERROR, "{} - Error( seekpos: {}, whence: {}, fsize: {}, {})", __FUNCTION__,
-              iFilePosition, iWhence, m_fileSize, nfs_get_error(m_pNfsContext));
+    CLog::LogF(LOGERROR, "Error( seekpos: {}, whence: {}, fsize: {}, {})", iFilePosition, iWhence,
+               m_fileSize, nfs_get_error(m_pNfsContext));
     return -1;
   }
   return (int64_t)offset;
@@ -762,8 +762,8 @@ int CNFSFile::Truncate(int64_t iSize)
   ret = nfs_ftruncate(m_pNfsContext, m_pFileHandle, iSize);
   if (ret < 0)
   {
-    CLog::Log(LOGERROR, "{} - Error( ftruncate: {}, fsize: {}, {})", __FUNCTION__, iSize,
-              m_fileSize, nfs_get_error(m_pNfsContext));
+    CLog::LogF(LOGERROR, "Error( ftruncate: {}, fsize: {}, {})", iSize, m_fileSize,
+               nfs_get_error(m_pNfsContext));
     return -1;
   }
   return ret;
@@ -857,8 +857,7 @@ bool CNFSFile::Delete(const CURL& url)
 
   if(ret != 0)
   {
-    CLog::Log(LOGERROR, "{} - Error( {} )", __FUNCTION__,
-              nfs_get_error(gNfsConnection.GetNfsContext()));
+    CLog::LogF(LOGERROR, "Error( {} )", nfs_get_error(gNfsConnection.GetNfsContext()));
   }
   return (ret == 0);
 }
@@ -880,8 +879,7 @@ bool CNFSFile::Rename(const CURL& url, const CURL& urlnew)
 
   if(ret != 0)
   {
-    CLog::Log(LOGERROR, "{} - Error( {} )", __FUNCTION__,
-              nfs_get_error(gNfsConnection.GetNfsContext()));
+    CLog::LogF(LOGERROR, "Error( {} )", nfs_get_error(gNfsConnection.GetNfsContext()));
   }
   return (ret == 0);
 }

--- a/xbmc/guilib/FFmpegImage.cpp
+++ b/xbmc/guilib/FFmpegImage.cpp
@@ -357,7 +357,7 @@ bool CFFmpegImage::Decode(unsigned char * const pixels, unsigned int width, unsi
 
   if (pixels == nullptr)
   {
-    CLog::Log(LOGERROR, "{} - No valid buffer pointer (nullptr) passed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "No valid buffer pointer (nullptr) passed");
     return false;
   }
 
@@ -418,8 +418,8 @@ bool CFFmpegImage::DecodeFrame(AVFrame* frame, unsigned int width, unsigned int 
 {
   if (pixels == nullptr)
   {
-    CLog::Log(LOGERROR, "{} - No valid buffer pointer (nullptr) passed", __FUNCTION__);
-    return false;
+   CLog::LogF(LOGERROR, "No valid buffer pointer (nullptr) passed");
+   return false;
   }
 
   AVFrame* pictureRGB = av_frame_alloc();

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -1311,7 +1311,7 @@ bool CGUIBaseContainer::InsideLayout(const CGUIListItemLayout *layout, const CPo
 #ifdef _DEBUG
 void CGUIBaseContainer::DumpTextureUse()
 {
-  CLog::Log(LOGDEBUG, "{} for container {}", __FUNCTION__, GetID());
+  CLog::LogF(LOGDEBUG, "for container {}", GetID());
   for (unsigned int i = 0; i < m_items.size(); ++i)
   {
     CGUIListItemPtr item = m_items[i];

--- a/xbmc/guilib/GUIColorManager.cpp
+++ b/xbmc/guilib/GUIColorManager.cpp
@@ -113,7 +113,7 @@ bool CGUIColorManager::LoadColorsListFromXML(
   CXBMCTinyXML xmlDoc;
   if (!xmlDoc.LoadFile(filePath))
   {
-    CLog::Log(LOGERROR, "{} - Failed to load colors from file {}", __FUNCTION__, filePath);
+    CLog::LogF(LOGERROR, "Failed to load colors from file {}", filePath);
     return false;
   }
 
@@ -121,7 +121,7 @@ bool CGUIColorManager::LoadColorsListFromXML(
   std::string strValue = pRootElement->Value();
   if (strValue != std::string("colors"))
   {
-    CLog::Log(LOGERROR, "{} - Color file doesn't start with <colors>", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Color file doesn't start with <colors>");
     return false;
   }
 

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -1021,7 +1021,7 @@ bool CGUIWindow::SendMessage(int message, int id, int param1 /* = 0*/, int param
 #ifdef _DEBUG
 void CGUIWindow::DumpTextureUse()
 {
-  CLog::Log(LOGDEBUG, "{} for window {}", __FUNCTION__, GetID());
+  CLog::LogF(LOGDEBUG, "for window {}", GetID());
   CGUIControlGroup::DumpTextureUse();
 }
 #endif

--- a/xbmc/guilib/StereoscopicsManager.cpp
+++ b/xbmc/guilib/StereoscopicsManager.cpp
@@ -164,8 +164,8 @@ std::string CStereoscopicsManager::DetectStereoModeByString(const std::string &n
 
   if (!re.RegComp(CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_stereoscopicregex_3d.c_str()))
   {
-    CLog::Log(
-        LOGERROR, "{}: Invalid RegExp for matching 3d content:'{}'", __FUNCTION__,
+    CLog::LogF(
+        LOGERROR, "Invalid RegExp for matching 3d content:'{}'",
         CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_stereoscopicregex_3d);
     return stereoMode;
   }
@@ -175,8 +175,8 @@ std::string CStereoscopicsManager::DetectStereoModeByString(const std::string &n
 
   if (!re.RegComp(CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_stereoscopicregex_sbs.c_str()))
   {
-    CLog::Log(
-        LOGERROR, "{}: Invalid RegExp for matching 3d SBS content:'{}'", __FUNCTION__,
+    CLog::LogF(
+        LOGERROR, "Invalid RegExp for matching 3d SBS content:'{}'",
         CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_stereoscopicregex_sbs);
     return stereoMode;
   }
@@ -189,8 +189,8 @@ std::string CStereoscopicsManager::DetectStereoModeByString(const std::string &n
 
   if (!re.RegComp(CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_stereoscopicregex_tab.c_str()))
   {
-    CLog::Log(
-        LOGERROR, "{}: Invalid RegExp for matching 3d TAB content:'{}'", __FUNCTION__,
+    CLog::LogF(
+        LOGERROR, "Invalid RegExp for matching 3d TAB content:'{}'",
         CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_stereoscopicregex_tab);
     return stereoMode;
   }

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -109,7 +109,7 @@ void CTexture::Allocate(unsigned int width, unsigned int height, unsigned int fo
 
     if (m_pixels == nullptr)
     {
-      CLog::Log(LOGERROR, "{} - Could not allocate {} bytes. Out of memory.", __FUNCTION__, size);
+      CLog::LogF(LOGERROR, "Could not allocate {} bytes. Out of memory.", size);
     }
   }
 }
@@ -293,7 +293,7 @@ bool CTexture::LoadFromFileInternal(const std::string& texturePath,
 
   if (!LoadIImage(pImage, buf.data(), buf.size(), width, height))
   {
-    CLog::Log(LOGDEBUG, "{} - Load of {} failed.", __FUNCTION__, CURL::GetRedacted(texturePath));
+    CLog::LogF(LOGDEBUG, "Load of {} failed.", CURL::GetRedacted(texturePath));
     delete pImage;
     return false;
   }

--- a/xbmc/guilib/TextureBundleXBT.cpp
+++ b/xbmc/guilib/TextureBundleXBT.cpp
@@ -62,7 +62,7 @@ void CTextureBundleXBT::CloseBundle()
   if (m_XBTFReader != nullptr && m_XBTFReader->IsOpen())
   {
     XFILE::CXbtManager::GetInstance().Release(CURL(m_path));
-    CLog::Log(LOGDEBUG, "{} - Closed {}bundle", __FUNCTION__, m_themeBundle ? "theme " : "");
+    CLog::LogF(LOGDEBUG, "Closed {}bundle", m_themeBundle ? "theme " : "");
   }
 }
 
@@ -97,7 +97,7 @@ bool CTextureBundleXBT::OpenBundle()
     return false;
   }
 
-  CLog::Log(LOGDEBUG, "{} - Opened bundle {}", __FUNCTION__, m_path);
+  CLog::LogF(LOGDEBUG, "Opened bundle {}", m_path);
 
   m_TimeStamp = m_XBTFReader->GetLastModificationTimestamp();
 

--- a/xbmc/guilib/TextureManager.cpp
+++ b/xbmc/guilib/TextureManager.cpp
@@ -487,7 +487,7 @@ void CGUITextureManager::ReleaseTexture(const std::string& strTextureName, bool 
     }
     ++i;
   }
-  CLog::Log(LOGWARNING, "{}: Unable to release texture {}", __FUNCTION__, strTextureName);
+  CLog::LogF(LOGWARNING, "Unable to release texture {}", strTextureName);
 }
 
 void CGUITextureManager::FreeUnusedTextures(unsigned int timeDelay)
@@ -538,7 +538,7 @@ void CGUITextureManager::Cleanup()
   while (i != m_vecTextures.end())
   {
     CTextureMap* pMap = *i;
-    CLog::Log(LOGWARNING, "{}: Having to cleanup texture {}", __FUNCTION__, pMap->GetName());
+    CLog::LogF(LOGWARNING, "Having to cleanup texture {}", pMap->GetName());
     delete pMap;
     i = m_vecTextures.erase(i);
   }

--- a/xbmc/input/AppTranslator.cpp
+++ b/xbmc/input/AppTranslator.cpp
@@ -60,7 +60,7 @@ uint32_t CAppTranslator::TranslateAppCommand(const std::string& szButton)
   if (it != AppCommands.end())
     return it->second | KEY_APPCOMMAND;
 
-  CLog::Log(LOGERROR, "{}: Can't find appcommand {}", __FUNCTION__, szButton);
+  CLog::LogF(LOGERROR, "Can't find appcommand {}", szButton);
 #endif
 
   return 0;

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -270,7 +270,7 @@ unsigned int CButtonTranslator::GetActionCode(int window,
   // Some buttoncodes changed in Hardy
   if (action == ACTION_NONE && (code & KEY_VKEY) == KEY_VKEY && (code & 0x0F00))
   {
-    CLog::Log(LOGDEBUG, "{}: Trying Hardy keycode for {:#04x}", __FUNCTION__, code);
+    CLog::LogF(LOGDEBUG, "Trying Hardy keycode for {:#04x}", code);
     code &= ~0x0F00;
     it2 = (*it).second.find(code);
     if (it2 != (*it).second.end())

--- a/xbmc/input/KeyboardStat.cpp
+++ b/xbmc/input/KeyboardStat.cpp
@@ -106,7 +106,7 @@ CKey CKeyboardStat::TranslateKey(XBMC_keysym& keysym) const
   // Start by check whether any of the HID peripherals wants to translate this keypress
   if (LookupSymAndUnicodePeripherals(keysym, &vkey, &ascii))
   {
-    CLog::Log(LOGDEBUG, "{} - keypress translated by a HID peripheral", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "keypress translated by a HID peripheral");
   }
 
   // Continue by trying to match both the sym and unicode. This will identify

--- a/xbmc/input/KeyboardTranslator.cpp
+++ b/xbmc/input/KeyboardTranslator.cpp
@@ -35,7 +35,7 @@ uint32_t CKeyboardTranslator::TranslateButton(const TiXmlElement* pButton)
       char* endptr;
       long int id = strtol(str, &endptr, 0);
       if (endptr - str != (int)strlen(str) || id <= 0 || id > 0x00FFFFFF)
-        CLog::Log(LOGDEBUG, "{} - invalid key id {}", __FUNCTION__, strID);
+        CLog::LogF(LOGDEBUG, "invalid key id {}", strID);
       else
         button_id = (uint32_t)id;
     }

--- a/xbmc/input/TouchTranslator.cpp
+++ b/xbmc/input/TouchTranslator.cpp
@@ -164,7 +164,7 @@ unsigned int CTouchTranslator::TranslateTouchCommand(const TiXmlElement* pButton
 
   if (touchCommandId == TOUCH_COMMAND_NONE)
   {
-    CLog::Log(LOGERROR, "{}: Can't find touch command {}", __FUNCTION__, szButton);
+    CLog::LogF(LOGERROR, "Can't find touch command {}", szButton);
     return ACTION_NONE;
   }
 

--- a/xbmc/interfaces/builtins/AddonBuiltins.cpp
+++ b/xbmc/interfaces/builtins/AddonBuiltins.cpp
@@ -265,7 +265,7 @@ static int RunScript(const std::vector<std::string>& params)
         }
         else
         {
-          CLog::Log(LOGERROR, "{} - Could not get addon: {}", __FUNCTION__, params[0]);
+          CLog::LogF(LOGERROR, "Could not get addon: {}", params[0]);
         }
       }
     }

--- a/xbmc/interfaces/generic/ScriptInvocationManager.cpp
+++ b/xbmc/interfaces/generic/ScriptInvocationManager.cpp
@@ -197,8 +197,8 @@ LanguageInvokerPtr CScriptInvocationManager::GetLanguageInvoker(const std::strin
   {
     if (m_lastInvokerThread->Reuseable(script))
     {
-      CLog::Log(LOGDEBUG, "{} - Reusing LanguageInvokerThread {} for script {}", __FUNCTION__,
-                m_lastInvokerThread->GetId(), script);
+      CLog::LogF(LOGDEBUG, "Reusing LanguageInvokerThread {} for script {}",
+                 m_lastInvokerThread->GetId(), script);
       m_lastInvokerThread->GetInvoker()->Reset();
       return m_lastInvokerThread->GetInvoker();
     }
@@ -228,7 +228,7 @@ int CScriptInvocationManager::ExecuteAsync(
 
   if (!CFileUtils::Exists(script, false))
   {
-    CLog::Log(LOGERROR, "{} - Not executing non-existing script {}", __FUNCTION__, script);
+    CLog::LogF(LOGERROR, "Not executing non-existing script {}", script);
     return -1;
   }
 
@@ -249,7 +249,7 @@ int CScriptInvocationManager::ExecuteAsync(
 
   if (!CFileUtils::Exists(script, false))
   {
-    CLog::Log(LOGERROR, "{} - Not executing non-existing script {}", __FUNCTION__, script);
+    CLog::LogF(LOGERROR, "Not executing non-existing script {}", script);
     return -1;
   }
 
@@ -302,7 +302,7 @@ int CScriptInvocationManager::ExecuteSync(
 
   if (!CFileUtils::Exists(script, false))
   {
-    CLog::Log(LOGERROR, "{} - Not executing non-existing script {}", __FUNCTION__, script);
+    CLog::LogF(LOGERROR, "Not executing non-existing script {}", script);
     return -1;
   }
 

--- a/xbmc/interfaces/python/LanguageHook.cpp
+++ b/xbmc/interfaces/python/LanguageHook.cpp
@@ -125,7 +125,7 @@ namespace XBMCAddon
       PyObject* main_module = PyImport_AddModule("__main__");
       if (!main_module)
       {
-        CLog::Log(LOGDEBUG, "PythonLanguageHook::{}: __main__ returns null", __FUNCTION__);
+        CLog::LogF(LOGDEBUG, "PythonLanguageHook: __main__ returns null");
         return "";
       }
       PyObject* global_dict = PyModule_GetDict(main_module);
@@ -145,7 +145,7 @@ namespace XBMCAddon
       PyObject* main_module = PyImport_AddModule("__main__");
       if (!main_module)
       {
-        CLog::Log(LOGDEBUG, "PythonLanguageHook::{}: __main__ returns null", __FUNCTION__);
+        CLog::LogF(LOGDEBUG, "PythonLanguageHook: __main__ returns null");
         return "";
       }
       PyObject* global_dict = PyModule_GetDict(main_module);
@@ -166,7 +166,7 @@ namespace XBMCAddon
       PyObject* main_module = PyImport_AddModule("__main__");
       if (!main_module)
       {
-        CLog::Log(LOGDEBUG, "PythonLanguageHook::{}: __main__ returns null", __FUNCTION__);
+        CLog::LogF(LOGDEBUG, "PythonLanguageHook: __main__ returns null");
         return -1;
       }
       PyObject* global_dict = PyModule_GetDict(main_module);

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -547,7 +547,7 @@ void CPythonInvoker::onExecutionDone()
   std::unique_lock<CCriticalSection> lock(m_critical);
   if (m_threadState != NULL)
   {
-    CLog::Log(LOGDEBUG, "{}({}, {})", __FUNCTION__, GetId(), m_sourceFile);
+    CLog::LogF(LOGDEBUG, "({}, {})", GetId(), m_sourceFile);
 
     PyEval_RestoreThread(m_threadState);
 

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -243,7 +243,7 @@ void CMusicDatabase::CreateTables()
 
 void CMusicDatabase::CreateAnalytics()
 {
-  CLog::Log(LOGINFO, "{} - creating indices", __FUNCTION__);
+  CLog::LogF(LOGINFO, "creating indices");
   m_pDS->exec("CREATE INDEX idxAlbum ON album(strAlbum(255))");
   m_pDS->exec("CREATE INDEX idxAlbum_1 ON album(bCompilation)");
   m_pDS->exec("CREATE UNIQUE INDEX idxAlbum_2 ON album(strMusicBrainzAlbumID(36))");
@@ -901,8 +901,8 @@ bool CMusicDatabase::UpdateAlbum(CAlbum& album)
       }
       if (!canBeBoxset && album.bBoxedSet)
       {
-        CLog::Log(LOGINFO, "{} : Album with id [{}] does not meet the requirements for a boxset.",
-                  __FUNCTION__, album.idAlbum);
+        CLog::LogF(LOGINFO, ": Album with id [{}] does not meet the requirements for a boxset.",
+                   album.idAlbum);
         album.bBoxedSet = false;
       }
     }
@@ -1210,7 +1210,7 @@ bool CMusicDatabase::GetSong(int idSong, CSong& song)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idSong);
+    CLog::LogF(LOGERROR, "({}) failed", idSong);
   }
 
   return false;
@@ -1473,7 +1473,7 @@ int CMusicDatabase::AddAlbum(const std::string& strAlbum,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed with query ({})", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "failed with query ({})", strSQL);
   }
 
   return -1;
@@ -1651,7 +1651,7 @@ bool CMusicDatabase::GetAlbum(int idAlbum, CAlbum& album, bool getSongs /* = tru
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idAlbum);
+    CLog::LogF(LOGERROR, "({}) failed", idAlbum);
   }
 
   return false;
@@ -2087,7 +2087,7 @@ bool CMusicDatabase::GetArtist(int idArtist, CArtist& artist, bool fetchAll /* =
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idArtist);
+    CLog::LogF(LOGERROR, "({}) failed", idArtist);
   }
 
   return false;
@@ -2117,7 +2117,7 @@ bool CMusicDatabase::GetArtistExists(int idArtist)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idArtist);
+    CLog::LogF(LOGERROR, "({}) failed", idArtist);
   }
 
   return false;
@@ -2309,7 +2309,7 @@ bool CMusicDatabase::GetArtistDiscography(int idArtist, CFileItemList& items)
   {
     m_pDS->exec("DROP TABLE tempDisco");
     m_pDS->exec("DROP TABLE tempAlbum");
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -2459,7 +2459,7 @@ int CMusicDatabase::GetRoleByName(const std::string& strRole)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return -1;
 }
@@ -2498,7 +2498,7 @@ bool CMusicDatabase::GetRolesByArtist(int idArtist, CFileItem* item)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idArtist);
+    CLog::LogF(LOGERROR, "({}) failed", idArtist);
   }
   return false;
 }
@@ -2560,7 +2560,7 @@ bool CMusicDatabase::AddSongGenres(int idSong, const std::vector<std::string>& g
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) {} failed", __FUNCTION__, idSong, strSQL);
+    CLog::LogF(LOGERROR, "({}) {} failed", idSong, strSQL);
   }
   return false;
 }
@@ -2589,7 +2589,7 @@ bool CMusicDatabase::GetAlbumsByArtist(int idArtist, std::vector<int>& albums)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idArtist);
+    CLog::LogF(LOGERROR, "({}) failed", idArtist);
   }
   return false;
 }
@@ -2639,7 +2639,7 @@ bool CMusicDatabase::GetArtistsByAlbum(int idAlbum, CFileItem* item)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idAlbum);
+    CLog::LogF(LOGERROR, "({}) failed", idAlbum);
   }
   return false;
 }
@@ -2676,7 +2676,7 @@ bool CMusicDatabase::GetArtistsByAlbum(int idAlbum, std::vector<std::string>& ar
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idAlbum);
+    CLog::LogF(LOGERROR, "({}) failed", idAlbum);
   }
   return false;
 };
@@ -2707,7 +2707,7 @@ bool CMusicDatabase::GetSongsByArtist(int idArtist, std::vector<int>& songs)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idArtist);
+    CLog::LogF(LOGERROR, "({}) failed", idArtist);
   }
   return false;
 };
@@ -2738,7 +2738,7 @@ bool CMusicDatabase::GetArtistsBySong(int idSong, std::vector<int>& artists)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idSong);
+    CLog::LogF(LOGERROR, "({}) failed", idSong);
   }
   return false;
 }
@@ -2797,7 +2797,7 @@ bool CMusicDatabase::GetGenresByArtist(int idArtist, CFileItem* item)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idArtist);
+    CLog::LogF(LOGERROR, "({}) failed", idArtist);
   }
   return false;
 }
@@ -2839,7 +2839,7 @@ bool CMusicDatabase::GetGenresByAlbum(int idAlbum, CFileItem* item)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idAlbum);
+    CLog::LogF(LOGERROR, "({}) failed", idAlbum);
   }
   return false;
 }
@@ -2870,7 +2870,7 @@ bool CMusicDatabase::GetGenresBySong(int idSong, std::vector<int>& genres)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idSong);
+    CLog::LogF(LOGERROR, "({}) failed", idSong);
   }
   return false;
 }
@@ -2888,7 +2888,7 @@ bool CMusicDatabase::GetIsAlbumArtist(int idArtist, CFileItem* item)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idArtist);
+    CLog::LogF(LOGERROR, "({}) failed", idArtist);
   }
   return false;
 }
@@ -3304,7 +3304,7 @@ int CMusicDatabase::GetAlbumIdByPath(const std::string& strPath)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, strPath);
+    CLog::LogF(LOGERROR, "({}) failed", strPath);
   }
 
   return -1;
@@ -3335,7 +3335,7 @@ int CMusicDatabase::GetSongByArtistAndAlbumAndTitle(const std::string& strArtist
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({},{},{}) failed", __FUNCTION__, strArtist, strAlbum, strTitle);
+    CLog::LogF(LOGERROR, "({},{},{}) failed", strArtist, strAlbum, strTitle);
   }
 
   return -1;
@@ -3390,7 +3390,7 @@ bool CMusicDatabase::SearchArtists(const std::string& search, CFileItemList& art
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
 
   return false;
@@ -3414,7 +3414,7 @@ bool CMusicDatabase::GetTop100(const std::string& strBaseDir, CFileItemList& ite
                          "ORDER BY iTimesPlayed DESC "
                          "LIMIT 100";
 
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
     if (!m_pDS->query(strSQL))
       return false;
     int iRowsFound = m_pDS->num_rows();
@@ -3437,7 +3437,7 @@ bool CMusicDatabase::GetTop100(const std::string& strBaseDir, CFileItemList& ite
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
 
   return false;
@@ -3462,7 +3462,7 @@ bool CMusicDatabase::GetTop100Albums(VECALBUMS& albums)
                          "ORDER BY albumview.iTimesPlayed DESC LIMIT 100) "
                          "ORDER BY albumview.iTimesPlayed DESC, albumartistview.iOrder";
 
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
     if (!m_pDS->query(strSQL))
       return false;
     int iRowsFound = m_pDS->num_rows();
@@ -3494,7 +3494,7 @@ bool CMusicDatabase::GetTop100Albums(VECALBUMS& albums)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
 
   return false;
@@ -3549,7 +3549,7 @@ bool CMusicDatabase::GetTop100AlbumSongs(const std::string& strBaseDir, CFileIte
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -3578,7 +3578,7 @@ bool CMusicDatabase::GetRecentlyPlayedAlbums(VECALBUMS& albums)
                    CAlbum::ReleaseTypeToString(CAlbum::Album).c_str(), RECENTLY_PLAYED_LIMIT);
 
     auto queryStart = std::chrono::steady_clock::now();
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
     if (!m_pDS->query(strSQL))
       return false;
 
@@ -3621,7 +3621,7 @@ bool CMusicDatabase::GetRecentlyPlayedAlbums(VECALBUMS& albums)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
 
   return false;
@@ -3710,7 +3710,7 @@ bool CMusicDatabase::GetRecentlyPlayedAlbumSongs(const std::string& strBaseDir,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -3740,7 +3740,7 @@ bool CMusicDatabase::GetRecentlyAddedAlbums(VECALBUMS& albums, unsigned int limi
                                ->GetAdvancedSettings()
                                ->m_iMusicLibraryRecentlyAddedItems);
 
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
     if (!m_pDS->query(strSQL))
       return false;
     int iRowsFound = m_pDS->num_rows();
@@ -3771,7 +3771,7 @@ bool CMusicDatabase::GetRecentlyAddedAlbums(VECALBUMS& albums, unsigned int limi
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
 
   return false;
@@ -3863,7 +3863,7 @@ bool CMusicDatabase::GetRecentlyAddedAlbumSongs(const std::string& strBaseDir,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -3886,7 +3886,7 @@ void CMusicDatabase::IncrementPlayCount(const CFileItem& item)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, item.GetPath());
+    CLog::LogF(LOGERROR, "({}) failed", item.GetPath());
   }
 }
 
@@ -3917,7 +3917,7 @@ bool CMusicDatabase::GetSongsByPath(const std::string& strPath1,
                                     strPath.c_str());
     if (!m_pDS->query(strSQL))
       return false;
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
     {
@@ -3947,7 +3947,7 @@ bool CMusicDatabase::GetSongsByPath(const std::string& strPath1,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, strPath);
+    CLog::LogF(LOGERROR, "({}) failed", strPath);
   }
 
   return false;
@@ -3966,21 +3966,21 @@ bool CMusicDatabase::Search(const std::string& search, CFileItemList& items)
   SearchArtists(search, items);
   auto end = std::chrono::steady_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-  CLog::Log(LOGDEBUG, "{} Artist search in {} ms", __FUNCTION__, duration.count());
+  CLog::LogF(LOGDEBUG, "Artist search in {} ms", duration.count());
 
   start = std::chrono::steady_clock::now();
   // then albums that match
   SearchAlbums(search, items);
   end = std::chrono::steady_clock::now();
   duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-  CLog::Log(LOGDEBUG, "{} Album search in {} ms", __FUNCTION__, duration.count());
+  CLog::LogF(LOGDEBUG, "Album search in {} ms", duration.count());
 
   start = std::chrono::steady_clock::now();
   // and finally songs
   SearchSongs(search, items);
   end = std::chrono::steady_clock::now();
   duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-  CLog::Log(LOGDEBUG, "{} Songs search in {} ms", __FUNCTION__, duration.count());
+  CLog::LogF(LOGDEBUG, "Songs search in {} ms", duration.count());
 
   return true;
 }
@@ -4026,7 +4026,7 @@ bool CMusicDatabase::SearchSongs(const std::string& search, CFileItemList& items
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
 
   return false;
@@ -4073,7 +4073,7 @@ bool CMusicDatabase::SearchAlbums(const std::string& search, CFileItemList& albu
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -4438,7 +4438,7 @@ int CMusicDatabase::Cleanup(CGUIDialogProgress* progressDialog /*= nullptr*/)
   int ret;
   std::chrono::seconds duration;
   auto time = std::chrono::steady_clock::now();
-  CLog::Log(LOGINFO, "{}: Starting musicdatabase cleanup ..", __FUNCTION__);
+  CLog::LogF(LOGINFO, "Starting musicdatabase cleanup ..");
   CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary, "OnCleanStarted");
 
   SetLibraryLastCleaned();
@@ -4575,8 +4575,7 @@ int CMusicDatabase::Cleanup(CGUIDialogProgress* progressDialog /*= nullptr*/)
 
   duration =
       std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - time);
-  CLog::Log(LOGINFO, "{}: Cleaning musicdatabase done. Operation took {}s", __FUNCTION__,
-            duration.count());
+  CLog::LogF(LOGINFO, "Cleaning musicdatabase done. Operation took {}s", duration.count());
   CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary, "OnCleanFinished");
 
   if (!Compress(false))
@@ -4891,7 +4890,7 @@ bool CMusicDatabase::GetGenresNav(const std::string& strBaseDir,
              strSQLExtra;
 
     // run query
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
 
     if (!m_pDS->query(strSQL))
       return false;
@@ -4937,7 +4936,7 @@ bool CMusicDatabase::GetGenresNav(const std::string& strBaseDir,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -5008,7 +5007,7 @@ bool CMusicDatabase::GetSourcesNav(const std::string& strBaseDir,
              strSQLExtra;
 
     // run query
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
 
     if (!m_pDS->query(strSQL))
       return false;
@@ -5055,7 +5054,7 @@ bool CMusicDatabase::GetSourcesNav(const std::string& strBaseDir,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -5098,7 +5097,7 @@ bool CMusicDatabase::GetYearsNav(const std::string& strBaseDir,
       return false;
 
     // run query
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
     if (!m_pDS->query(strSQL))
       return false;
     int iRowsFound = m_pDS->num_rows();
@@ -5138,7 +5137,7 @@ bool CMusicDatabase::GetYearsNav(const std::string& strBaseDir,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -5168,7 +5167,7 @@ bool CMusicDatabase::GetRolesNav(const std::string& strBaseDir,
       return false;
 
     // run query
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
     if (!m_pDS->query(strSQL))
       return false;
     int iRowsFound = m_pDS->num_rows();
@@ -5204,7 +5203,7 @@ bool CMusicDatabase::GetRolesNav(const std::string& strBaseDir,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -5261,7 +5260,7 @@ bool CMusicDatabase::GetCommonNav(const std::string& strBaseDir,
       return false;
 
     // run query
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
     if (!m_pDS->query(strSQL))
       return false;
 
@@ -5307,7 +5306,7 @@ bool CMusicDatabase::GetCommonNav(const std::string& strBaseDir,
   catch (...)
   {
     m_pDS->close();
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
 
   return false;
@@ -5368,7 +5367,7 @@ bool CMusicDatabase::GetArtistsNav(const std::string& strBaseDir,
   catch (...)
   {
     m_pDS->close();
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -5477,7 +5476,7 @@ bool CMusicDatabase::GetArtistsByWhere(
     strSQL = "SELECT " + strFields + " FROM artistview " + strSQLExtra;
 
     // run query
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
     auto queryStart = std::chrono::steady_clock::now();
     if (!m_pDS->query(strSQL))
       return false;
@@ -5536,8 +5535,7 @@ bool CMusicDatabase::GetArtistsByWhere(
       catch (...)
       {
         m_pDS->close();
-        CLog::Log(LOGERROR, "{} - out of memory getting listing (got {})", __FUNCTION__,
-                  items.Size());
+        CLog::LogF(LOGERROR, "out of memory getting listing (got {})", items.Size());
       }
     }
     // cleanup
@@ -5554,7 +5552,7 @@ bool CMusicDatabase::GetArtistsByWhere(
   catch (...)
   {
     m_pDS->close();
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -5588,7 +5586,7 @@ bool CMusicDatabase::GetAlbumFromSong(int idSong, CAlbum& album)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -5712,7 +5710,7 @@ bool CMusicDatabase::GetAlbumsByWhere(
     strSQL = "SELECT " + strFields + " FROM albumview " + strSQLExtra;
 
     // run query
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
     auto querytime = std::chrono::steady_clock::now();
     if (!m_pDS->query(strSQL))
       return false;
@@ -5765,8 +5763,7 @@ bool CMusicDatabase::GetAlbumsByWhere(
       catch (...)
       {
         m_pDS->close();
-        CLog::Log(LOGERROR, "{} - out of memory getting listing (got {})", __FUNCTION__,
-                  items.Size());
+        CLog::LogF(LOGERROR, "out of memory getting listing (got {})", items.Size());
       }
     }
     // cleanup
@@ -5783,7 +5780,7 @@ bool CMusicDatabase::GetAlbumsByWhere(
   catch (...)
   {
     m_pDS->close();
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, filter.where);
+    CLog::LogF(LOGERROR, "({}) failed", filter.where);
   }
   return false;
 }
@@ -5890,7 +5887,7 @@ bool CMusicDatabase::GetDiscsByWhere(CMusicDbUrl& musicUrl,
              strSQLExtra;
 
     // run query
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
     auto queryStart = std::chrono::steady_clock::now();
     if (!m_pDS->query(strSQL))
       return false;
@@ -5976,8 +5973,7 @@ bool CMusicDatabase::GetDiscsByWhere(CMusicDbUrl& musicUrl,
       catch (...)
       {
         m_pDS->close();
-        CLog::Log(LOGERROR, "{} - out of memory getting listing (got {})", __FUNCTION__,
-                  items.Size());
+        CLog::LogF(LOGERROR, "out of memory getting listing (got {})", items.Size());
       }
     }
 
@@ -6000,7 +5996,7 @@ bool CMusicDatabase::GetDiscsByWhere(CMusicDbUrl& musicUrl,
   catch (...)
   {
     m_pDS->close();
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, filter.where);
+    CLog::LogF(LOGERROR, "({}) failed", filter.where);
   }
 
   return false;
@@ -6146,7 +6142,7 @@ bool CMusicDatabase::GetSongsFullByWhere(
     else
       strSQL = "SELECT " + strFields + " FROM songview " + strSQLExtra;
 
-    CLog::Log(LOGDEBUG, "{} query = {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query = {}", strSQL);
     auto queryStart = std::chrono::steady_clock::now();
     // run query
     if (!m_pDS->query(strSQL))
@@ -6222,7 +6218,7 @@ bool CMusicDatabase::GetSongsFullByWhere(
       catch (...)
       {
         m_pDS->close();
-        CLog::Log(LOGERROR, "{}: out of memory loading query: {}", __FUNCTION__, filter.where);
+        CLog::LogF(LOGERROR, "out of memory loading query: {}", filter.where);
         return (items.Size() > 0);
       }
     }
@@ -6256,7 +6252,7 @@ bool CMusicDatabase::GetSongsFullByWhere(
   {
     // cleanup
     m_pDS->close();
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, filter.where);
+    CLog::LogF(LOGERROR, "({}) failed", filter.where);
   }
   return false;
 }
@@ -6307,7 +6303,7 @@ bool CMusicDatabase::GetSongsByWhere(
                                     : "songview.*") +
              strSQLExtra;
 
-    CLog::Log(LOGDEBUG, "{} query = {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query = {}", strSQL);
     // run query
     if (!m_pDS->query(strSQL))
       return false;
@@ -6349,7 +6345,7 @@ bool CMusicDatabase::GetSongsByWhere(
       catch (...)
       {
         m_pDS->close();
-        CLog::Log(LOGERROR, "{}: out of memory loading query: {}", __FUNCTION__, filter.where);
+        CLog::LogF(LOGERROR, "out of memory loading query: {}", filter.where);
         return (items.Size() > 0);
       }
     }
@@ -6362,7 +6358,7 @@ bool CMusicDatabase::GetSongsByWhere(
   {
     // cleanup
     m_pDS->close();
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, filter.where);
+    CLog::LogF(LOGERROR, "({}) failed", filter.where);
   }
   return false;
 }
@@ -6844,7 +6840,7 @@ bool CMusicDatabase::GetArtistsByWhereJSON(
       strSQL = "SELECT a1.*, " + joinLayout.GetFields() + " FROM " + strSQL + strSQLJoin;
     }
 
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
     // run query
     auto start = std::chrono::steady_clock::now();
 
@@ -6854,7 +6850,7 @@ bool CMusicDatabase::GetArtistsByWhereJSON(
     auto end = std::chrono::steady_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 
-    CLog::Log(LOGDEBUG, "{} - query took {} ms", __FUNCTION__, duration.count());
+    CLog::LogF(LOGDEBUG, "query took {} ms", duration.count());
 
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound <= 0)
@@ -7137,7 +7133,7 @@ bool CMusicDatabase::GetArtistsByWhereJSON(
   catch (...)
   {
     m_pDS->close();
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -7394,7 +7390,7 @@ bool CMusicDatabase::GetAlbumsByWhereJSON(
     else
       StringUtils::Replace(strSQL, "<datefield>", "strOrigReleaseDate");
 
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
     // run query
     auto start = std::chrono::steady_clock::now();
 
@@ -7404,7 +7400,7 @@ bool CMusicDatabase::GetAlbumsByWhereJSON(
     auto end = std::chrono::steady_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 
-    CLog::Log(LOGDEBUG, "{} - query took {} ms", __FUNCTION__, duration.count());
+    CLog::LogF(LOGDEBUG, "query took {} ms", duration.count());
 
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound <= 0)
@@ -7539,7 +7535,7 @@ bool CMusicDatabase::GetAlbumsByWhereJSON(
   catch (...)
   {
     m_pDS->close();
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -7977,7 +7973,7 @@ bool CMusicDatabase::GetSongsByWhereJSON(
     else
       StringUtils::Replace(strSQL, "<datefield>", "song.strOrigReleaseDate");
 
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
 
     // Run query
     auto start = std::chrono::steady_clock::now();
@@ -7988,7 +7984,7 @@ bool CMusicDatabase::GetSongsByWhereJSON(
     auto end = std::chrono::steady_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 
-    CLog::Log(LOGDEBUG, "{} - query took {} ms", __FUNCTION__, duration.count());
+    CLog::LogF(LOGDEBUG, "query took {} ms", duration.count());
 
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound <= 0)
@@ -8214,7 +8210,7 @@ bool CMusicDatabase::GetSongsByWhereJSON(
   catch (...)
   {
     m_pDS->close();
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -8334,7 +8330,7 @@ std::string CMusicDatabase::AlphanumericSortSQL(const std::string& strField,
 
 void CMusicDatabase::UpdateTables(int version)
 {
-  CLog::Log(LOGINFO, "{} - updating tables", __FUNCTION__);
+  CLog::LogF(LOGINFO, "updating tables");
   if (version < 34)
   {
     m_pDS->exec("ALTER TABLE artist ADD strMusicBrainzArtistID text\n");
@@ -9340,7 +9336,7 @@ int CMusicDatabase::GetMusicNeedsTagScan()
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return -1;
 }
@@ -9462,7 +9458,7 @@ unsigned int CMusicDatabase::GetRandomSongIDs(const Filter& filter,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, filter.where);
+    CLog::LogF(LOGERROR, "({}) failed", filter.where);
   }
   return 0;
 }
@@ -9495,7 +9491,7 @@ int CMusicDatabase::GetSongsCount(const Filter& filter)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, filter.where);
+    CLog::LogF(LOGERROR, "({}) failed", filter.where);
   }
   return 0;
 }
@@ -9563,7 +9559,7 @@ bool CMusicDatabase::GetAlbumPaths(int idAlbum, std::vector<std::pair<std::strin
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "CMusicDatabase::{} - failed to execute {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "CMusicDatabase: failed to execute {}", strSQL);
   }
 
   return false;
@@ -9595,7 +9591,7 @@ int CMusicDatabase::GetDiscnumberForPathID(int idPath)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "CMusicDatabase::{} - failed to execute {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "CMusicDatabase: failed to execute {}", strSQL);
   }
   return result;
 }
@@ -9678,7 +9674,7 @@ bool CMusicDatabase::GetOldArtistPath(int idArtist, std::string& basePath)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   basePath.clear();
   return false;
@@ -9876,7 +9872,7 @@ int CMusicDatabase::AddSource(const std::string& strName,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed with query ({})", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "failed with query ({})", strSQL);
     RollbackTransaction();
   }
 
@@ -9945,7 +9941,7 @@ int CMusicDatabase::UpdateSource(const std::string& strOldName,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed with query ({})", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "failed with query ({})", strSQL);
     RollbackTransaction();
   }
 
@@ -9997,7 +9993,7 @@ int CMusicDatabase::GetSourceFromPath(const std::string& strPath1)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} path: {} ({}) failed", __FUNCTION__, strSQL, strPath1);
+    CLog::LogF(LOGERROR, "path: {} ({}) failed", strSQL, strPath1);
   }
 
   return -1;
@@ -10074,7 +10070,7 @@ bool CMusicDatabase::AddAlbumSources(int idAlbum, const std::string& strPath)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} path: {} ({}) failed", __FUNCTION__, strSQL, strPath);
+    CLog::LogF(LOGERROR, "path: {} ({}) failed", strSQL, strPath);
   }
 
   return false;
@@ -10139,7 +10135,7 @@ bool CMusicDatabase::CheckSources(VECSOURCES& sources)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -10179,7 +10175,7 @@ bool CMusicDatabase::MigrateSources()
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "({}) failed", strSQL);
   }
   return false;
 }
@@ -10204,7 +10200,7 @@ bool CMusicDatabase::UpdateSources()
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -10224,7 +10220,7 @@ bool CMusicDatabase::GetSources(CFileItemList& items)
         "FROM source JOIN source_path ON source.idSource = source_path.idSource "
         "ORDER BY source.idSource, source_path.idPath";
 
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
     if (!m_pDS->query(strSQL))
       return false;
     int iRowsFound = m_pDS->num_rows();
@@ -10278,7 +10274,7 @@ bool CMusicDatabase::GetSources(CFileItemList& items)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -10335,7 +10331,7 @@ bool CMusicDatabase::GetSourcesByArtist(int idArtist, CFileItem* item)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idArtist);
+    CLog::LogF(LOGERROR, "({}) failed", idArtist);
   }
   return false;
 }
@@ -10403,7 +10399,7 @@ bool CMusicDatabase::GetSourcesByAlbum(int idAlbum, CFileItem* item)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idAlbum);
+    CLog::LogF(LOGERROR, "({}) failed", idAlbum);
   }
   return false;
 }
@@ -10452,7 +10448,7 @@ bool CMusicDatabase::GetSourcesBySong(int idSong, const std::string& strPath1, C
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, idSong);
+    CLog::LogF(LOGERROR, "({}) failed", idSong);
   }
   return false;
 }
@@ -10481,7 +10477,7 @@ int CMusicDatabase::GetSourceByName(const std::string& strSource)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return -1;
 }
@@ -10518,7 +10514,7 @@ int CMusicDatabase::GetArtistByName(const std::string& strArtist)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return -1;
 }
@@ -10555,7 +10551,7 @@ int CMusicDatabase::GetArtistByMatch(const CArtist& artist)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "CMusicDatabase::{} - failed to execute {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "CMusicDatabase: failed to execute {}", strSQL);
   }
   return -1;
 }
@@ -10590,7 +10586,7 @@ bool CMusicDatabase::GetArtistFromSong(int idSong, CArtist& artist)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -10650,7 +10646,7 @@ int CMusicDatabase::GetAlbumByName(const std::string& strAlbum, const std::strin
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return -1;
 }
@@ -10694,7 +10690,7 @@ bool CMusicDatabase::GetMatchingMusicVideoAlbum(const std::string& strAlbum,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -10733,7 +10729,7 @@ bool CMusicDatabase::SearchAlbumsByArtistName(const std::string& strArtist, CFil
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -10781,7 +10777,7 @@ int CMusicDatabase::GetAlbumByMatch(const CAlbum& album)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "CMusicDatabase::{} - failed to execute {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "CMusicDatabase: failed to execute {}", strSQL);
   }
   return -1;
 }
@@ -10840,7 +10836,7 @@ bool CMusicDatabase::UpdateArtistSortNames(int idArtist /*=-1*/)
                    "AND album_artist.idAlbum = album.idAlbum)",
                    idArtist);
   ExecuteQuery(strSQL);
-  CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+  CLog::LogF(LOGDEBUG, "query: {}", strSQL);
 
   if (bisMySQL)
     strSQL = "(SELECT GROUP_CONCAT("
@@ -10868,12 +10864,12 @@ bool CMusicDatabase::UpdateArtistSortNames(int idArtist /*=-1*/)
                          "AND song_artist.idSong = song.idSong AND song_artist.idRole = 1)",
                          idArtist);
   ExecuteQuery(strSQL);
-  CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+  CLog::LogF(LOGDEBUG, "query: {}", strSQL);
 
   if (CommitMultipleExecute())
     return true;
   else
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   return false;
 }
 
@@ -10908,7 +10904,7 @@ int CMusicDatabase::GetGenreByName(const std::string& strGenre)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return -1;
 }
@@ -10947,7 +10943,7 @@ bool CMusicDatabase::GetGenresJSON(CFileItemList& items, bool bSources)
     strSQL = PrepareSQL(strSQL, extFilter.fields.c_str()) + strSQLExtra;
 
     // run query
-    CLog::Log(LOGDEBUG, "{} query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGDEBUG, "query: {}", strSQL);
 
     if (!m_pDS->query(strSQL))
       return false;
@@ -11007,7 +11003,7 @@ bool CMusicDatabase::GetGenresJSON(CFileItemList& items, bool bSources)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "({}) failed", strSQL);
   }
   return false;
 }
@@ -11100,7 +11096,7 @@ bool CMusicDatabase::SetPathHash(const std::string& path, const std::string& has
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}, {}) failed", __FUNCTION__, path, hash);
+    CLog::LogF(LOGERROR, "({}, {}) failed", path, hash);
   }
 
   return false;
@@ -11124,7 +11120,7 @@ bool CMusicDatabase::GetPathHash(const std::string& path, std::string& hash)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, path);
+    CLog::LogF(LOGERROR, "({}) failed", path);
   }
 
   return false;
@@ -11225,7 +11221,7 @@ bool CMusicDatabase::RemoveSongsFromPath(const std::string& path1, MAPSONGS& son
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, path);
+    CLog::LogF(LOGERROR, "({}) failed", path);
   }
   return false;
 }
@@ -11271,7 +11267,7 @@ bool CMusicDatabase::GetPaths(std::set<std::string>& paths)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -11295,7 +11291,7 @@ bool CMusicDatabase::SetSongUserrating(const std::string& filePath, int userrati
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({},{}) failed", __FUNCTION__, filePath, userrating);
+    CLog::LogF(LOGERROR, "({},{}) failed", filePath, userrating);
   }
   return false;
 }
@@ -11316,7 +11312,7 @@ bool CMusicDatabase::SetSongUserrating(int idSong, int userrating)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({},{}) failed", __FUNCTION__, idSong, userrating);
+    CLog::LogF(LOGERROR, "({},{}) failed", idSong, userrating);
   }
   return false;
 }
@@ -11339,7 +11335,7 @@ bool CMusicDatabase::SetAlbumUserrating(const int idAlbum, int userrating)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({},{}) failed", __FUNCTION__, idAlbum, userrating);
+    CLog::LogF(LOGERROR, "({},{}) failed", idAlbum, userrating);
   }
   return false;
 }
@@ -11366,7 +11362,7 @@ bool CMusicDatabase::SetSongVotes(const std::string& filePath, int votes)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({},{}) failed", __FUNCTION__, filePath, votes);
+    CLog::LogF(LOGERROR, "({},{}) failed", filePath, votes);
   }
   return false;
 }
@@ -11411,7 +11407,7 @@ int CMusicDatabase::GetSongIDFromPath(const std::string& filePath)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, filePath);
+    CLog::LogF(LOGERROR, "({}) failed", filePath);
   }
   return -1;
 }
@@ -11503,7 +11499,7 @@ bool CMusicDatabase::SetScraperAll(const std::string& strBaseDir, const ADDON::S
   catch (...)
   {
     RollbackTransaction();
-    CLog::Log(LOGERROR, "{} - ({}, {}) failed", __FUNCTION__, strBaseDir, strSQL);
+    CLog::LogF(LOGERROR, "({}, {}) failed", strBaseDir, strSQL);
   }
   return false;
 }
@@ -11560,7 +11556,7 @@ bool CMusicDatabase::SetScraper(int id,
   catch (...)
   {
     RollbackTransaction();
-    CLog::Log(LOGERROR, "{} - ({}, {}) failed", __FUNCTION__, id, strSQL);
+    CLog::LogF(LOGERROR, "({}, {}) failed", id, strSQL);
   }
   return false;
 }
@@ -11623,7 +11619,7 @@ bool CMusicDatabase::GetScraper(int id, const CONTENT_TYPE& content, ADDON::Scra
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} -({}, {} {}) failed", __FUNCTION__, id, scraperUUID, strSettings);
+    CLog::LogF(LOGERROR, "-({}, {} {}) failed", id, scraperUUID, strSettings);
   }
   return false;
 }
@@ -11650,7 +11646,7 @@ bool CMusicDatabase::ScraperInUse(const std::string& scraperID) const
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, scraperID);
+    CLog::LogF(LOGERROR, "({}) failed", scraperID);
   }
   return false;
 }
@@ -11790,7 +11786,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
                                       CAlbum::ReleaseTypeToString(CAlbum::Album).c_str());
       if (!settings.m_unscraped)
         strSQL += "AND lastScraped IS NOT NULL";
-      CLog::Log(LOGDEBUG, "CMusicDatabase::{} - {}", __FUNCTION__, strSQL);
+      CLog::LogF(LOGDEBUG, "CMusicDatabase: {}", strSQL);
       m_pDS->query(strSQL);
 
       int total = m_pDS->num_rows();
@@ -11827,14 +11823,13 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
             // Most albums are under a unique folder, but if songs from various albums are mixed then
             // avoid overwriting by not allow NFO and art to be exported
             if (strAlbumPath.empty())
-              CLog::Log(LOGDEBUG,
-                        "CMusicDatabase::{} - Not exporting album {} as unique path not found",
-                        __FUNCTION__, album.strAlbum);
+              CLog::LogF(LOGDEBUG,
+                         "CMusicDatabase: Not exporting album {} as unique path not found",
+                         album.strAlbum);
             else if (!CDirectory::Exists(strAlbumPath))
-              CLog::Log(
-                  LOGDEBUG,
-                  "CMusicDatabase::{} - Not exporting album {} as found path {} does not exist",
-                  __FUNCTION__, album.strAlbum, strAlbumPath);
+              CLog::LogF(LOGDEBUG,
+                         "CMusicDatabase: Not exporting album {} as found path {} does not exist",
+                         album.strAlbum, strAlbumPath);
             else
             {
               strPath = strAlbumPath;
@@ -11857,9 +11852,8 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
                 pathfound = CDirectory::Create(strPath);
             }
             if (!pathfound)
-              CLog::Log(LOGDEBUG,
-                        "CMusicDatabase::{} - Not exporting album {} as could not create {}",
-                        __FUNCTION__, album.strAlbum, strPath);
+              CLog::LogF(LOGDEBUG, "CMusicDatabase: Not exporting album {} as could not create {}",
+                         album.strAlbum, strPath);
             else
             {
               std::string strAlbumFolder;
@@ -11872,9 +11866,9 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
                   pathfound = CDirectory::Create(strPath);
               }
               if (!pathfound)
-                CLog::Log(LOGDEBUG,
-                          "CMusicDatabase::{} - Not exporting album {} as could not create {}",
-                          __FUNCTION__, album.strAlbum, strPath);
+                CLog::LogF(LOGDEBUG,
+                           "CMusicDatabase: Not exporting album {} as could not create {}",
+                           album.strAlbum, strPath);
             }
           }
           if (pathfound)
@@ -11888,8 +11882,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
               {
                 if (!xmlDoc.SaveFile(nfoFile))
                 {
-                  CLog::Log(LOGERROR, "CMusicDatabase::{}: Album nfo export failed! ('{}')",
-                            __FUNCTION__, nfoFile);
+                  CLog::LogF(LOGERROR, "CMusicDatabase: Album nfo export failed! ('{}')", nfoFile);
                   CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error,
                                                         g_localizeStrings.Get(20302), nfoFile);
                   iFailCount++;
@@ -11971,7 +11964,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
 
       std::string strSQL = "SELECT idArtist FROM artist";
       BuildSQL(strSQL, filter, strSQL);
-      CLog::Log(LOGDEBUG, "CMusicDatabase::{} - {}", __FUNCTION__, strSQL);
+      CLog::LogF(LOGDEBUG, "CMusicDatabase: {}", strSQL);
 
       m_pDS->query(strSQL);
       int total = m_pDS->num_rows();
@@ -12017,9 +12010,8 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
               pathfound = CDirectory::Create(strPath);
           }
           if (!pathfound)
-            CLog::Log(LOGDEBUG,
-                      "CMusicDatabase::{} - Not exporting artist {} as could not create {}",
-                      __FUNCTION__, artist.strArtist, strPath);
+            CLog::LogF(LOGDEBUG, "CMusicDatabase: Not exporting artist {} as could not create {}",
+                       artist.strArtist, strPath);
           else
           {
             if (!artistfoldersonly)
@@ -12032,8 +12024,8 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
                 {
                   if (!xmlDoc.SaveFile(nfoFile))
                   {
-                    CLog::Log(LOGERROR, "CMusicDatabase::{}: Artist nfo export failed! ('{}')",
-                              __FUNCTION__, nfoFile);
+                    CLog::LogF(LOGERROR, "CMusicDatabase: Artist nfo export failed! ('{}')",
+                               nfoFile);
                     CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error,
                                                           g_localizeStrings.Get(20302), nfoFile);
                     iFailCount++;
@@ -12091,7 +12083,7 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "CMusicDatabase::{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "CMusicDatabase: failed");
     iFailCount++;
   }
 
@@ -12168,7 +12160,7 @@ bool CMusicDatabase::ExportSongHistory(TiXmlNode* pNode, CGUIDialogProgress* pro
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{0} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -12230,8 +12222,8 @@ void CMusicDatabase::ImportFromXML(const std::string& xmlFile, CGUIDialogProgres
           UpdateArtist(artist);
         }
         else
-          CLog::Log(LOGDEBUG, "{} - Not import additional artist data as {} not found",
-                    __FUNCTION__, importedArtist.strArtist);
+          CLog::LogF(LOGDEBUG, "Not import additional artist data as {} not found",
+                     importedArtist.strArtist);
         current++;
       }
       else if (StringUtils::CompareNoCase(entry->Value(), "album", 5) == 0)
@@ -12249,8 +12241,8 @@ void CMusicDatabase::ImportFromXML(const std::string& xmlFile, CGUIDialogProgres
           UpdateAlbum(album); //Will replace song artists if present in xml
         }
         else
-          CLog::Log(LOGDEBUG, "{} - Not import additional album data as {} not found", __FUNCTION__,
-                    importedAlbum.strAlbum);
+          CLog::LogF(LOGDEBUG, "Not import additional album data as {} not found",
+                     importedAlbum.strAlbum);
 
         current++;
       }
@@ -12280,7 +12272,7 @@ void CMusicDatabase::ImportFromXML(const std::string& xmlFile, CGUIDialogProgres
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
     RollbackTransaction();
   }
   if (progressDialog)
@@ -12616,7 +12608,7 @@ bool CMusicDatabase::ImportSongHistory(const std::string& xmlFile,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
     RollbackTransaction();
     if (bHistSongExists)
       m_pDS->exec("DROP TABLE HistSong");
@@ -12793,8 +12785,7 @@ void CMusicDatabase::SetArtForItem(int mediaId,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}, '{}', '{}', '{}') failed", __FUNCTION__, mediaId, mediaType,
-              artType, url);
+    CLog::LogF(LOGERROR, "({}, '{}', '{}', '{}') failed", mediaId, mediaType, artType, url);
   }
 }
 
@@ -12908,7 +12899,7 @@ bool CMusicDatabase::GetArtForItem(
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "({}) failed", strSQL);
   }
   return false;
 }
@@ -12937,7 +12928,7 @@ bool CMusicDatabase::GetArtForItem(int mediaId,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, mediaId);
+    CLog::LogF(LOGERROR, "({}) failed", mediaId);
   }
   return false;
 }
@@ -13003,7 +12994,7 @@ bool CMusicDatabase::GetArtTypes(const MediaType& mediaType, std::vector<std::st
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, mediaType);
+    CLog::LogF(LOGERROR, "({}) failed", mediaType);
   }
   return false;
 }

--- a/xbmc/music/dialogs/GUIDialogInfoProviderSettings.cpp
+++ b/xbmc/music/dialogs/GUIDialogInfoProviderSettings.cpp
@@ -193,8 +193,7 @@ void CGUIDialogInfoProviderSettings::OnSettingAction(const std::shared_ptr<const
       }
       else
       {
-        CLog::Log(LOGERROR, "{} - Could not get settings for addon: {}", __FUNCTION__,
-                  selectedAddonId);
+        CLog::LogF(LOGERROR, "Could not get settings for addon: {}", selectedAddonId);
       }
     }
   }
@@ -219,7 +218,7 @@ void CGUIDialogInfoProviderSettings::OnSettingAction(const std::shared_ptr<const
       }
       else
       {
-        CLog::Log(LOGERROR, "{} - Could not get addon: {}", __FUNCTION__, selectedAddonId);
+        CLog::LogF(LOGERROR, "Could not get addon: {}", selectedAddonId);
       }
     }
   }
@@ -267,7 +266,7 @@ bool CGUIDialogInfoProviderSettings::Save()
     return true; //Save done by caller of ::Show
 
   // Save default settings for fetching additional information and art
-  CLog::Log(LOGINFO, "{} called", __FUNCTION__);
+  CLog::LogF(LOGINFO, "called");
   // Save Fetch addiitional info during update
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
   settings->SetBool(CSettings::SETTING_MUSICLIBRARY_DOWNLOADINFO, m_fetchInfo);
@@ -388,13 +387,13 @@ void CGUIDialogInfoProviderSettings::InitializeSettings()
   std::shared_ptr<CSettingCategory> category = AddCategory("infoprovidersettings", -1);
   if (category == nullptr)
   {
-    CLog::Log(LOGERROR, "{}: unable to setup settings", __FUNCTION__);
+    CLog::LogF(LOGERROR, "unable to setup settings");
     return;
   }
   std::shared_ptr<CSettingGroup> group1 = AddGroup(category);
   if (group1 == nullptr)
   {
-    CLog::Log(LOGERROR, "{}: unable to setup settings", __FUNCTION__);
+    CLog::LogF(LOGERROR, "unable to setup settings");
     return;
   }
 
@@ -423,7 +422,7 @@ void CGUIDialogInfoProviderSettings::InitializeSettings()
   std::shared_ptr<CSettingGroup> group = AddGroup(category, 38337);
   if (group == nullptr)
   {
-    CLog::Log(LOGERROR, "{}: unable to setup settings", __FUNCTION__);
+    CLog::LogF(LOGERROR, "unable to setup settings");
     return;
   }
   std::shared_ptr<CSettingAction> subsetting;

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -103,7 +103,7 @@ void CMusicInfoScanner::Process()
 
     if (m_scanType == 0) // load info from files
     {
-      CLog::Log(LOGDEBUG, "{} - Starting scan", __FUNCTION__);
+      CLog::LogF(LOGDEBUG, "Starting scan");
 
       if (m_handle)
         m_handle->SetTitle(g_localizeStrings.Get(505));
@@ -133,8 +133,7 @@ void CMusicInfoScanner::Process()
            * and cleans out all songs under that path as its first step before re-adding files, if
            * the entire source is offline we totally empty the music database in one go.
            */
-          CLog::Log(LOGWARNING, "{} directory '{}' does not exist - skipping scan.", __FUNCTION__,
-                    it);
+          CLog::LogF(LOGWARNING, "directory '{}' does not exist - skipping scan.", it);
           m_seenPaths.insert(it);
           continue;
         }
@@ -271,7 +270,7 @@ void CMusicInfoScanner::Process()
     CLog::Log(LOGERROR, "MusicInfoScanner: Exception while scanning.");
   }
   m_musicDatabase.Close();
-  CLog::Log(LOGDEBUG, "{} - Finished scan", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "Finished scan");
 
   m_bRunning = false;
   CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary, "OnScanFinished");
@@ -504,11 +503,10 @@ bool CMusicInfoScanner::DoScan(const std::string& strDirectory)
   if ((m_flags & SCAN_RESCAN) || !m_musicDatabase.GetPathHash(strDirectory, dbHash) || !StringUtils::EqualsNoCase(dbHash, hash))
   { // path has changed - rescan
     if (dbHash.empty())
-      CLog::Log(LOGDEBUG, "{} Scanning dir '{}' as not in the database", __FUNCTION__,
-                CURL::GetRedacted(strDirectory));
+      CLog::LogF(LOGDEBUG, "Scanning dir '{}' as not in the database",
+                 CURL::GetRedacted(strDirectory));
     else
-      CLog::Log(LOGDEBUG, "{} Rescanning dir '{}' due to change", __FUNCTION__,
-                CURL::GetRedacted(strDirectory));
+      CLog::LogF(LOGDEBUG, "Rescanning dir '{}' due to change", CURL::GetRedacted(strDirectory));
 
     if (m_handle)
       m_handle->SetTitle(g_localizeStrings.Get(505)); //"Loading media information from files..."
@@ -529,8 +527,7 @@ bool CMusicInfoScanner::DoScan(const std::string& strDirectory)
   }
   else
   { // path is the same - no need to rescan
-    CLog::Log(LOGDEBUG, "{} Skipping dir '{}' due to no change", __FUNCTION__,
-              CURL::GetRedacted(strDirectory));
+    CLog::LogF(LOGDEBUG, "Skipping dir '{}' due to no change", CURL::GetRedacted(strDirectory));
     m_currentItem += CountFiles(items, false);  // false for non-recursive
 
     // updated the dialog with our progress
@@ -595,7 +592,7 @@ CInfoScanner::INFO_RET CMusicInfoScanner::ScanTags(const CFileItemList& items,
 
     if (!tag.Loaded() && !pItem->HasCueDocument())
     {
-      CLog::Log(LOGDEBUG, "{} - No tag found for: {}", __FUNCTION__, pItem->GetPath());
+      CLog::LogF(LOGDEBUG, "No tag found for: {}", pItem->GetPath());
       continue;
     }
     else
@@ -1296,7 +1293,7 @@ CMusicInfoScanner::UpdateDatabaseAlbumInfo(CAlbum& album,
   while (!stop)
   {
     stop = true;
-    CLog::Log(LOGDEBUG, "{} downloading info for: {}", __FUNCTION__, album.strAlbum);
+    CLog::LogF(LOGDEBUG, "downloading info for: {}", album.strAlbum);
     albumDownloadStatus = DownloadAlbumInfo(album, scraper, albumInfo, !bAllowSelection, pDialog);
     if (albumDownloadStatus == INFO_NOT_FOUND)
     {
@@ -1377,7 +1374,7 @@ CMusicInfoScanner::UpdateDatabaseArtistInfo(CArtist& artist,
   while (!stop)
   {
     stop = true;
-    CLog::Log(LOGDEBUG, "{} downloading info for: {}", __FUNCTION__, artist.strArtist);
+    CLog::LogF(LOGDEBUG, "downloading info for: {}", artist.strArtist);
     artistDownloadStatus = DownloadArtistInfo(artist, scraper, artistInfo, !bAllowSelection, pDialog);
     if (artistDownloadStatus == INFO_NOT_FOUND)
     {
@@ -1502,7 +1499,7 @@ CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album,
     result = nfoReader.Create(strNfo, info);
     if (result == CInfoScanner::FULL_NFO)
     {
-      CLog::Log(LOGDEBUG, "{} Got details from nfo", __FUNCTION__);
+      CLog::LogF(LOGDEBUG, "Got details from nfo");
       nfoReader.GetDetails(albumInfo.GetAlbum());
       return INFO_ADDED;
     }
@@ -1524,8 +1521,7 @@ CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album,
 
   if (!scraper.CheckValidOrFallback(CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_MUSICLIBRARY_ALBUMSSCRAPER)))
   { // the current scraper is invalid, as is the default - bail
-    CLog::Log(LOGERROR, "{} - current and default scrapers are invalid.  Pick another one",
-              __FUNCTION__);
+    CLog::LogF(LOGERROR, "current and default scrapers are invalid.  Pick another one");
     return INFO_ERROR;
   }
 
@@ -1785,7 +1781,7 @@ CMusicInfoScanner::DownloadArtistInfo(const CArtist& artist,
     result = nfoReader.Create(strNfo, info);
     if (result == CInfoScanner::FULL_NFO)
     {
-      CLog::Log(LOGDEBUG, "{} Got details from nfo", __FUNCTION__);
+      CLog::LogF(LOGDEBUG, "Got details from nfo");
       nfoReader.GetDetails(artistInfo.GetArtist());
       return INFO_ADDED;
     }

--- a/xbmc/music/infoscanner/MusicInfoScraper.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScraper.cpp
@@ -188,7 +188,7 @@ bool CMusicInfoScraper::CheckValidOrFallback(const std::string &fallbackScraper)
   if (m_scraper->Path() != fallbackScraper &&
       parser.Load("special://xbmc/system/scrapers/music/" + fallbackScraper))
   {
-    CLog::Log(LOGWARNING, "{} - scraper {} fails to load, falling back to {}", __FUNCTION__, m_info.strPath, fallbackScraper);
+    CLog::LogF(LOGWARNING, "scraper {} fails to load, falling back to {}", m_info.strPath, fallbackScraper);
     m_info.strPath = fallbackScraper;
     m_info.strContent = "albums";
     m_info.strTitle = parser.GetName();

--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -212,14 +212,14 @@ void CNetworkBase::NetworkMessage(EMESSAGE message, int param)
   switch( message )
   {
     case SERVICES_UP:
-      CLog::Log(LOGDEBUG, "{} - Starting network services", __FUNCTION__);
+      CLog::LogF(LOGDEBUG, "Starting network services");
       m_services->Start();
       break;
 
     case SERVICES_DOWN:
-      CLog::Log(LOGDEBUG, "{} - Signaling network services to stop", __FUNCTION__);
+      CLog::LogF(LOGDEBUG, "Signaling network services to stop");
       m_services->Stop(false); // tell network services to stop, but don't wait for them yet
-      CLog::Log(LOGDEBUG, "{} - Waiting for network services to stop", __FUNCTION__);
+      CLog::LogF(LOGDEBUG, "Waiting for network services to stop");
       m_services->Stop(true); // wait for network services to stop
       break;
   }
@@ -235,14 +235,14 @@ bool CNetworkBase::WakeOnLan(const char* mac)
   // Fetch the hardware address
   if (!in_ether(mac, ethaddr))
   {
-    CLog::Log(LOGERROR, "{} - Invalid hardware address specified ({})", __FUNCTION__, mac);
+    CLog::LogF(LOGERROR, "Invalid hardware address specified ({})", mac);
     return false;
   }
 
   // Setup the socket
   if ((packet = socket (AF_INET, SOCK_DGRAM, IPPROTO_UDP)) < 0)
   {
-    CLog::Log(LOGERROR, "{} - Unable to create socket ({})", __FUNCTION__, strerror(errno));
+    CLog::LogF(LOGERROR, "Unable to create socket ({})", strerror(errno));
     return false;
   }
 
@@ -255,7 +255,7 @@ bool CNetworkBase::WakeOnLan(const char* mac)
   unsigned int value = 1;
   if (setsockopt (packet, SOL_SOCKET, SO_BROADCAST, (char*) &value, sizeof( unsigned int ) ) == SOCKET_ERROR)
   {
-    CLog::Log(LOGERROR, "{} - Unable to set socket options ({})", __FUNCTION__, strerror(errno));
+    CLog::LogF(LOGERROR, "Unable to set socket options ({})", strerror(errno));
     closesocket(packet);
     return false;
   }
@@ -272,13 +272,13 @@ bool CNetworkBase::WakeOnLan(const char* mac)
   // Send the magic packet
   if (sendto (packet, (char *)buf, 102, 0, (struct sockaddr *)&saddr, sizeof (saddr)) < 0)
   {
-    CLog::Log(LOGERROR, "{} - Unable to send magic packet ({})", __FUNCTION__, strerror(errno));
+    CLog::LogF(LOGERROR, "Unable to send magic packet ({})", strerror(errno));
     closesocket(packet);
     return false;
   }
 
   closesocket(packet);
-  CLog::Log(LOGINFO, "{} - Magic packet send to '{}'", __FUNCTION__, mac);
+  CLog::LogF(LOGINFO, "Magic packet send to '{}'", mac);
   return true;
 }
 
@@ -393,8 +393,7 @@ bool CNetworkBase::PingHost(unsigned long ipaddr, unsigned short port, unsigned 
     std::string sock_err = strerror(errno);
 #endif
 
-    CLog::Log(LOGERROR, "{}({}:{}) - {} ({})", __FUNCTION__, inet_ntoa(addr.sin_addr), port,
-              err_msg, sock_err);
+    CLog::LogF(LOGERROR, "({}:{}) - {} ({})", inet_ntoa(addr.sin_addr), port, err_msg, sock_err);
   }
 
   return err_msg == 0;
@@ -467,8 +466,7 @@ void CNetworkBase::WaitForNet()
   if (!IsAvailable())
     return;
 
-  CLog::Log(LOGINFO, "{}: Waiting for a network interface to come up (Timeout: {} s)", __FUNCTION__,
-            timeout);
+  CLog::LogF(LOGINFO, "Waiting for a network interface to come up (Timeout: {} s)", timeout);
 
   const static int intervalMs = 200;
   const int numMaxTries = (timeout * 1000) / intervalMs;
@@ -480,14 +478,12 @@ void CNetworkBase::WaitForNet()
 
     if (IsConnected())
     {
-      CLog::Log(LOGINFO, "{}: A network interface is up after waiting {} ms", __FUNCTION__,
-                i * intervalMs);
+      CLog::LogF(LOGINFO, "A network interface is up after waiting {} ms", i * intervalMs);
       return;
     }
   }
 
-  CLog::Log(LOGINFO, "{}: No network interface did come up within {} s... Giving up...",
-            __FUNCTION__, timeout);
+  CLog::LogF(LOGINFO, "No network interface did come up within {} s... Giving up...", timeout);
 }
 
 std::string CNetworkBase::GetIpStr(const struct sockaddr* sa)

--- a/xbmc/network/TCPServer.cpp
+++ b/xbmc/network/TCPServer.cpp
@@ -275,7 +275,7 @@ bool CTCPServer::Initialize()
 #ifdef TARGET_WINDOWS_STORE
 bool CTCPServer::InitializeBlue()
 {
-  CLog::Log(LOGDEBUG, "{} is not implemented", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "is not implemented");
   return true; // need to fake it for now
 }
 

--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -210,7 +210,7 @@ bool CMACDiscoveryJob::DoWork()
 
   if (ipAddress == INADDR_NONE)
   {
-    CLog::Log(LOGERROR, "{} - can't determine ip of '{}'", __FUNCTION__, m_host);
+    CLog::LogF(LOGERROR, "can't determine ip of '{}'", m_host);
     return false;
   }
 
@@ -644,7 +644,7 @@ void CWakeOnAccess::QueueMACDiscoveryForHost(const std::string& host)
     if (URIUtils::IsHostOnLAN(host, true))
       CServiceBroker::GetJobManager()->AddJob(new CMACDiscoveryJob(host), this);
     else
-      CLog::Log(LOGINFO, "{} - skip Mac discovery for non-local host '{}'", __FUNCTION__, host);
+      CLog::LogF(LOGINFO, "skip Mac discovery for non-local host '{}'", host);
   }
 }
 
@@ -709,7 +709,7 @@ void CWakeOnAccess::QueueMACDiscoveryForAllRemotes()
 
 void CWakeOnAccess::SaveMACDiscoveryResult(const std::string& host, const std::string& mac)
 {
-  CLog::Log(LOGINFO, "{} - Mac discovered for host '{}' -> '{}'", __FUNCTION__, host, mac);
+  CLog::LogF(LOGINFO, "Mac discovered for host '{}' -> '{}'", host, mac);
 
   for (auto& i : m_entries)
   {
@@ -750,7 +750,7 @@ void CWakeOnAccess::OnJobComplete(unsigned int jobID, bool success, CJob *job)
   }
   else
   {
-    CLog::Log(LOGERROR, "{} - Mac discovery failed for host '{}'", __FUNCTION__, host);
+    CLog::LogF(LOGERROR, "Mac discovery failed for host '{}'", host);
 
     if (IsEnabled())
     {
@@ -805,15 +805,14 @@ void CWakeOnAccess::LoadFromXML()
   if (!xmlDoc.LoadFile(GetSettingFile()))
   {
     if (enabled)
-      CLog::Log(LOGINFO, "{} - unable to load:{}", __FUNCTION__, GetSettingFile());
+      CLog::LogF(LOGINFO, "unable to load:{}", GetSettingFile());
     return;
   }
 
   TiXmlElement* pRootElement = xmlDoc.RootElement();
   if (StringUtils::CompareNoCase(pRootElement->Value(), "onaccesswakeup"))
   {
-    CLog::Log(LOGERROR, "{} - XML file {} doesn't contain <onaccesswakeup>", __FUNCTION__,
-              GetSettingFile());
+    CLog::LogF(LOGERROR, "XML file {} doesn't contain <onaccesswakeup>", GetSettingFile());
     return;
   }
 
@@ -845,9 +844,9 @@ void CWakeOnAccess::LoadFromXML()
       entry.mac = strtmp;
 
     if (entry.host.empty())
-      CLog::Log(LOGERROR, "{} - Missing <host> tag or it's empty", __FUNCTION__);
+      CLog::LogF(LOGERROR, "Missing <host> tag or it's empty");
     else if (entry.mac.empty())
-      CLog::Log(LOGERROR, "{} - Missing <mac> tag or it's empty", __FUNCTION__);
+      CLog::LogF(LOGERROR, "Missing <mac> tag or it's empty");
     else
     {
       if (XMLUtils::GetInt(pWakeUp, "pingport", tmp, 0, USHRT_MAX))
@@ -900,7 +899,7 @@ void CWakeOnAccess::LoadFromXML()
       server.m_name = server.m_uuid;
 
     if (server.m_uuid.empty() || server.m_mac.empty())
-      CLog::Log(LOGERROR, "{} - Missing or empty <upnp_map> entry", __FUNCTION__);
+      CLog::LogF(LOGERROR, "Missing or empty <upnp_map> entry");
     else
     {
       CLog::Log(LOGINFO, "  Registering upnp_map entry [{} : {}] -> [{}]", server.m_name,

--- a/xbmc/network/mdns/ZeroconfBrowserMDNS.cpp
+++ b/xbmc/network/mdns/ZeroconfBrowserMDNS.cpp
@@ -45,7 +45,7 @@ CZeroconfBrowserMDNS::~CZeroconfBrowserMDNS()
   WSAAsyncSelect( (SOCKET) DNSServiceRefSockFD( m_browser ), g_hWnd, BONJOUR_BROWSER_EVENT, 0 );
 #elif  defined(TARGET_WINDOWS_STORE)
   // need to modify this code to use WSAEventSelect since WSAAsyncSelect is not supported
-  CLog::Log(LOGDEBUG, "{} is not implemented for TARGET_WINDOWS_STORE", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "is not implemented for TARGET_WINDOWS_STORE");
 #endif //TARGET_WINDOWS
 
   if (m_browser)
@@ -247,7 +247,7 @@ bool CZeroconfBrowserMDNS::doAddServiceType(const std::string& fcr_service_type)
       CLog::Log(LOGERROR, "ZeroconfBrowserMDNS: WSAAsyncSelect failed with error = {}", (int)err);
 #elif defined(TARGET_WINDOWS_STORE)
     // need to modify this code to use WSAEventSelect since WSAAsyncSelect is not supported
-    CLog::Log(LOGERROR, "{} is not implemented for TARGET_WINDOWS_STORE", __FUNCTION__);
+    CLog::LogF(LOGERROR, "is not implemented for TARGET_WINDOWS_STORE");
 #endif // TARGET_WINDOWS_STORE
   }
 #endif //!HAS_MDNS_EMBEDDED

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -341,10 +341,8 @@ void CPeripherals::CreatePeripheral(CPeripheralBus& bus, const PeripheralScanRes
       if (!m_bMissingLibCecWarningDisplayed)
       {
         m_bMissingLibCecWarningDisplayed = true;
-        CLog::Log(
-            LOGWARNING,
-            "{} - libCEC support has not been compiled in, so the CEC adapter cannot be used.",
-            __FUNCTION__);
+        CLog::LogF(LOGWARNING,
+                   "libCEC support has not been compiled in, so the CEC adapter cannot be used.");
         CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning,
                                               g_localizeStrings.Get(36000),
                                               g_localizeStrings.Get(36017));
@@ -380,8 +378,7 @@ void CPeripherals::CreatePeripheral(CPeripheralBus& bus, const PeripheralScanRes
       bus.Register(peripheral);
     else
     {
-      CLog::Log(LOGDEBUG, "{} - failed to initialise peripheral on '{}'", __FUNCTION__,
-                mappedResult.m_strLocation);
+      CLog::LogF(LOGDEBUG, "failed to initialise peripheral on '{}'", mappedResult.m_strLocation);
     }
   }
 }
@@ -454,9 +451,9 @@ bool CPeripherals::GetMappingForDevice(const CPeripheralBus& bus,
       std::string strVendorId, strProductId;
       PeripheralTypeTranslator::FormatHexString(result.m_iVendorId, strVendorId);
       PeripheralTypeTranslator::FormatHexString(result.m_iProductId, strProductId);
-      CLog::Log(LOGDEBUG, "{} - device ({}:{}) mapped to {} (type = {})", __FUNCTION__, strVendorId,
-                strProductId, mapping.m_strDeviceName,
-                PeripheralTypeTranslator::TypeToString(mapping.m_mappedTo));
+      CLog::LogF(LOGDEBUG, "device ({}:{}) mapped to {} (type = {})", strVendorId, strProductId,
+                 mapping.m_strDeviceName,
+                 PeripheralTypeTranslator::TypeToString(mapping.m_mappedTo));
       result.m_mappedType = mapping.m_mappedTo;
       if (result.m_strDeviceName.empty() && !mapping.m_strDeviceName.empty())
         result.m_strDeviceName = mapping.m_strDeviceName;
@@ -506,14 +503,14 @@ bool CPeripherals::LoadMappings()
   CXBMCTinyXML xmlDoc;
   if (!xmlDoc.LoadFile("special://xbmc/system/peripherals.xml"))
   {
-    CLog::Log(LOGWARNING, "{} - peripherals.xml does not exist", __FUNCTION__);
+    CLog::LogF(LOGWARNING, "peripherals.xml does not exist");
     return true;
   }
 
   TiXmlElement* pRootElement = xmlDoc.RootElement();
   if (!pRootElement || StringUtils::CompareNoCase(pRootElement->Value(), "peripherals") != 0)
   {
-    CLog::Log(LOGERROR, "{} - peripherals.xml does not contain <peripherals>", __FUNCTION__);
+    CLog::LogF(LOGERROR, "peripherals.xml does not contain <peripherals>");
     return false;
   }
 
@@ -536,8 +533,8 @@ bool CPeripherals::LoadMappings()
         std::vector<std::string> idArray = StringUtils::Split(i, ":");
         if (idArray.size() != 2)
         {
-          CLog::Log(LOGERROR, "{} - ignoring node \"{}\" with invalid vendor_product attribute",
-                    __FUNCTION__, mapping.m_strDeviceName);
+          CLog::LogF(LOGERROR, "ignoring node \"{}\" with invalid vendor_product attribute",
+                     mapping.m_strDeviceName);
           continue;
         }
 
@@ -556,7 +553,7 @@ bool CPeripherals::LoadMappings()
     GetSettingsFromMappingsFile(currentNode, mapping.m_settings);
 
     m_mappings.push_back(mapping);
-    CLog::Log(LOGDEBUG, "{} - loaded node \"{}\"", __FUNCTION__, mapping.m_strDeviceName);
+    CLog::LogF(LOGDEBUG, "loaded node \"{}\"", mapping.m_strDeviceName);
   }
 
   return true;

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -197,10 +197,10 @@ bool CPeripheralAddon::Register(unsigned int peripheralIndex, const PeripheralPt
     {
       m_peripherals[peripheralIndex] = std::static_pointer_cast<CPeripheralJoystick>(peripheral);
 
-      CLog::Log(LOGINFO, "{} - new {} device registered on {}->{}: {}", __FUNCTION__,
-                PeripheralTypeTranslator::TypeToString(peripheral->Type()),
-                PeripheralTypeTranslator::BusTypeToString(PERIPHERAL_BUS_ADDON),
-                peripheral->Location(), peripheral->DeviceName());
+      CLog::LogF(LOGINFO, "new {} device registered on {}->{}: {}",
+                 PeripheralTypeTranslator::TypeToString(peripheral->Type()),
+                 PeripheralTypeTranslator::BusTypeToString(PERIPHERAL_BUS_ADDON),
+                 peripheral->Location(), peripheral->DeviceName());
 
       return true;
     }
@@ -232,10 +232,10 @@ void CPeripheralAddon::UnregisterRemovedDevices(const PeripheralScanResults& res
   {
     auto it = m_peripherals.find(index);
     const PeripheralPtr& peripheral = it->second;
-    CLog::Log(LOGINFO, "{} - device removed from {}/{}: {} ({}:{})", __FUNCTION__,
-              PeripheralTypeTranslator::TypeToString(peripheral->Type()), peripheral->Location(),
-              peripheral->DeviceName(), peripheral->VendorIdAsString(),
-              peripheral->ProductIdAsString());
+    CLog::LogF(LOGINFO, "device removed from {}/{}: {} ({}:{})",
+               PeripheralTypeTranslator::TypeToString(peripheral->Type()), peripheral->Location(),
+               peripheral->DeviceName(), peripheral->VendorIdAsString(),
+               peripheral->ProductIdAsString());
     UnregisterButtonMap(peripheral.get());
     peripheral->OnDeviceRemoved();
     removedPeripherals.push_back(peripheral);

--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -100,10 +100,10 @@ void CPeripheralBus::UnregisterRemovedDevices(const PeripheralScanResults& resul
         features.size() > 1 || (features.size() == 1 && features.at(0) != FEATURE_UNKNOWN);
     if (peripheral->Type() != PERIPHERAL_UNKNOWN || peripheralHasFeatures)
     {
-      CLog::Log(LOGINFO, "{} - device removed from {}/{}: {} ({}:{})", __FUNCTION__,
-                PeripheralTypeTranslator::TypeToString(peripheral->Type()), peripheral->Location(),
-                peripheral->DeviceName(), peripheral->VendorIdAsString(),
-                peripheral->ProductIdAsString());
+      CLog::LogF(LOGINFO, "device removed from {}/{}: {} ({}:{})",
+                 PeripheralTypeTranslator::TypeToString(peripheral->Type()), peripheral->Location(),
+                 peripheral->DeviceName(), peripheral->VendorIdAsString(),
+                 peripheral->ProductIdAsString());
       peripheral->OnDeviceRemoved();
     }
 
@@ -264,11 +264,11 @@ void CPeripheralBus::Register(const PeripheralPtr& peripheral)
 
   if (bPeripheralAdded)
   {
-    CLog::Log(LOGINFO, "{} - new {} device registered on {}->{}: {} ({}:{})", __FUNCTION__,
-              PeripheralTypeTranslator::TypeToString(peripheral->Type()),
-              PeripheralTypeTranslator::BusTypeToString(m_type), peripheral->Location(),
-              peripheral->DeviceName(), peripheral->VendorIdAsString(),
-              peripheral->ProductIdAsString());
+    CLog::LogF(LOGINFO, "new {} device registered on {}->{}: {} ({}:{})",
+               PeripheralTypeTranslator::TypeToString(peripheral->Type()),
+               PeripheralTypeTranslator::BusTypeToString(m_type), peripheral->Location(),
+               peripheral->DeviceName(), peripheral->VendorIdAsString(),
+               peripheral->ProductIdAsString());
     m_manager.OnDeviceAdded(*this, *peripheral);
   }
 }

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -183,8 +183,8 @@ bool CPeripheral::Initialise(void)
 
   if (bReturn)
   {
-    CLog::Log(LOGDEBUG, "{} - initialised peripheral on '{}' with {} features and {} sub devices",
-              __FUNCTION__, m_strLocation, (int)m_features.size(), (int)m_subDevices.size());
+    CLog::LogF(LOGDEBUG, "initialised peripheral on '{}' with {} features and {} sub devices",
+               m_strLocation, (int)m_features.size(), (int)m_subDevices.size());
     m_bInitialised = true;
   }
 
@@ -220,7 +220,7 @@ void CPeripheral::AddSetting(const std::string& strKey, const SettingConstPtr& s
 {
   if (!setting)
   {
-    CLog::Log(LOGERROR, "{} - invalid setting", __FUNCTION__);
+    CLog::LogF(LOGERROR, "invalid setting");
     return;
   }
 

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -155,8 +155,7 @@ void CPeripheralCecAdapter::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
       // may not action the standby command.
       bIgnoreDeactivate = data["shuttingdown"].asBoolean();
       if (bIgnoreDeactivate)
-        CLog::Log(LOGDEBUG, "{} - ignoring OnScreensaverDeactivated for power action",
-                  __FUNCTION__);
+        CLog::LogF(LOGDEBUG, "ignoring OnScreensaverDeactivated for power action");
     }
     if (m_bPowerOnScreensaver && !bIgnoreDeactivate && m_configuration.bActivateSource)
     {
@@ -189,7 +188,7 @@ void CPeripheralCecAdapter::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
   else if (flag == ANNOUNCEMENT::System && sender == CAnnouncementManager::ANNOUNCEMENT_SENDER &&
            message == "OnWake")
   {
-    CLog::Log(LOGDEBUG, "{} - reconnecting to the CEC adapter after standby mode", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "reconnecting to the CEC adapter after standby mode");
     if (ReopenConnection())
     {
       bool bActivate(false);
@@ -275,8 +274,8 @@ bool CPeripheralCecAdapter::InitialiseFeature(const PeripheralFeature feature)
     }
     else
     {
-      CLog::Log(LOGDEBUG, "{} - using libCEC v{}", __FUNCTION__,
-                m_cecAdapter->VersionToString(m_configuration.serverVersion));
+      CLog::LogF(LOGDEBUG, "using libCEC v{}",
+                 m_cecAdapter->VersionToString(m_configuration.serverVersion));
       SetVersionInfo(m_configuration);
     }
 
@@ -307,14 +306,13 @@ bool CPeripheralCecAdapter::OpenConnection(void)
 
   if (!GetSettingBool("enabled"))
   {
-    CLog::Log(LOGDEBUG, "{} - CEC adapter is disabled in peripheral settings", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "CEC adapter is disabled in peripheral settings");
     m_bStarted = false;
     return bIsOpen;
   }
 
   // open the CEC adapter
-  CLog::Log(LOGDEBUG, "{} - opening a connection to the CEC adapter: {}", __FUNCTION__,
-            m_strComPort);
+  CLog::LogF(LOGDEBUG, "opening a connection to the CEC adapter: {}", m_strComPort);
 
   // scanning the CEC bus takes about 5 seconds, so display a notification to inform users that
   // we're busy
@@ -330,7 +328,7 @@ bool CPeripheralCecAdapter::OpenConnection(void)
     if ((bIsOpen = m_cecAdapter->Open(m_strComPort.c_str(), 10000)) == false)
     {
       // display warning: couldn't initialise libCEC
-      CLog::Log(LOGERROR, "{} - could not opening a connection to the CEC adapter", __FUNCTION__);
+      CLog::LogF(LOGERROR, "could not opening a connection to the CEC adapter");
       if (!bConnectionFailedDisplayed)
         CGUIDialogKaiToast::QueueNotification(
             CGUIDialogKaiToast::Error, g_localizeStrings.Get(36000), g_localizeStrings.Get(36012));
@@ -342,7 +340,7 @@ bool CPeripheralCecAdapter::OpenConnection(void)
 
   if (bIsOpen)
   {
-    CLog::Log(LOGDEBUG, "{} - connection to the CEC adapter opened", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "connection to the CEC adapter opened");
 
     // read the configuration
     libcec_configuration config;
@@ -410,26 +408,25 @@ void CPeripheralCecAdapter::Process(void)
     {
       if (!m_configuration.powerOffDevices.IsEmpty())
       {
-        CLog::Log(LOGDEBUG, "{} - sending standby commands", __FUNCTION__);
+        CLog::LogF(LOGDEBUG, "sending standby commands");
         m_standbySent = CDateTime::GetCurrentDateTime();
         m_cecAdapter->StandbyDevices();
       }
       else if (m_bSendInactiveSource)
       {
-        CLog::Log(LOGDEBUG, "{} - sending inactive source commands", __FUNCTION__);
+        CLog::LogF(LOGDEBUG, "sending inactive source commands");
         m_cecAdapter->SetInactiveView();
       }
     }
     else
     {
-      CLog::Log(LOGDEBUG, "{} - XBMC is not the active source, not sending any standby commands",
-                __FUNCTION__);
+      CLog::LogF(LOGDEBUG, "XBMC is not the active source, not sending any standby commands");
     }
   }
 
   m_cecAdapter->Close();
 
-  CLog::Log(LOGDEBUG, "{} - CEC adapter processor thread ended", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CEC adapter processor thread ended");
 
   {
     std::unique_lock<CCriticalSection> lock(m_critSection);
@@ -615,11 +612,10 @@ void CPeripheralCecAdapter::SetMenuLanguage(const char* strLanguage)
   {
     strGuiLanguage = "resource.language." + strGuiLanguage;
     CServiceBroker::GetAppMessenger()->PostMsg(TMSG_SETLANGUAGE, -1, -1, nullptr, strGuiLanguage);
-    CLog::Log(LOGDEBUG, "{} - language set to '{}'", __FUNCTION__, strGuiLanguage);
+    CLog::LogF(LOGDEBUG, "language set to '{}'", strGuiLanguage);
   }
   else
-    CLog::Log(LOGWARNING, "{} - TV menu language set to unknown value '{}'", __FUNCTION__,
-              strLanguage);
+    CLog::LogF(LOGWARNING, "TV menu language set to unknown value '{}'", strLanguage);
 }
 
 void CPeripheralCecAdapter::OnTvStandby(void)
@@ -657,7 +653,7 @@ void CPeripheralCecAdapter::OnTvStandby(void)
     case LOCALISED_ID_IGNORE:
       break;
     default:
-      CLog::Log(LOGERROR, "{} - Unexpected [standby_pc_on_tv_standby] setting value", __FUNCTION__);
+      CLog::LogF(LOGERROR, "Unexpected [standby_pc_on_tv_standby] setting value");
       break;
   }
 }
@@ -814,8 +810,7 @@ void CPeripheralCecAdapter::GetNextKey(void)
 
 void CPeripheralCecAdapter::PushCecKeypress(const CecButtonPress& key)
 {
-  CLog::Log(LOGDEBUG, "{} - received key {:2x} duration {}", __FUNCTION__, key.iButton,
-            key.iDuration);
+  CLog::LogF(LOGDEBUG, "received key {:2x} duration {}", key.iButton, key.iDuration);
 
   std::unique_lock<CCriticalSection> lock(m_critSection);
   // avoid the queue getting too long
@@ -1170,12 +1165,12 @@ void CPeripheralCecAdapter::OnSettingChanged(const std::string& strChangedSettin
     bool bEnabled(GetSettingBool("enabled"));
     if (!bEnabled && IsRunning())
     {
-      CLog::Log(LOGDEBUG, "{} - closing the CEC connection", __FUNCTION__);
+      CLog::LogF(LOGDEBUG, "closing the CEC connection");
       StopThread(true);
     }
     else if (bEnabled && !IsRunning())
     {
-      CLog::Log(LOGDEBUG, "{} - starting the CEC connection", __FUNCTION__);
+      CLog::LogF(LOGDEBUG, "starting the CEC connection");
       SetConfigurationFromSettings();
       InitialiseFeature(FEATURE_CEC);
     }
@@ -1184,14 +1179,14 @@ void CPeripheralCecAdapter::OnSettingChanged(const std::string& strChangedSettin
   {
     if (m_queryThread->IsRunning())
     {
-      CLog::Log(LOGDEBUG, "{} - sending the updated configuration to libCEC", __FUNCTION__);
+      CLog::LogF(LOGDEBUG, "sending the updated configuration to libCEC");
       SetConfigurationFromSettings();
       m_queryThread->UpdateConfiguration(&m_configuration);
     }
   }
   else
   {
-    CLog::Log(LOGDEBUG, "{} - restarting the CEC connection", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "restarting the CEC connection");
     SetConfigurationFromSettings();
     InitialiseFeature(FEATURE_CEC);
   }
@@ -1593,13 +1588,13 @@ void CPeripheralCecAdapterUpdateThread::UpdateMenuLanguage(void)
   // request the menu language of the TV
   if (m_adapter->m_bUseTVMenuLanguage == 1)
   {
-    CLog::Log(LOGDEBUG, "{} - requesting the menu language of the TV", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "requesting the menu language of the TV");
     std::string language(m_adapter->m_cecAdapter->GetDeviceMenuLanguage(CECDEVICE_TV));
     m_adapter->SetMenuLanguage(language.c_str());
   }
   else
   {
-    CLog::Log(LOGDEBUG, "{} - using TV menu language is disabled", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "using TV menu language is disabled");
   }
 }
 
@@ -1613,9 +1608,8 @@ std::string CPeripheralCecAdapterUpdateThread::UpdateAudioSystemStatus(void)
   {
     // request the OSD name of the amp
     std::string ampName(m_adapter->m_cecAdapter->GetDeviceOSDName(CECDEVICE_AUDIOSYSTEM));
-    CLog::Log(LOGDEBUG,
-              "{} - CEC capable amplifier found ({}). volume will be controlled on the amp",
-              __FUNCTION__, ampName);
+    CLog::LogF(LOGDEBUG, "CEC capable amplifier found ({}). volume will be controlled on the amp",
+               ampName);
     strAmpName += ampName;
 
     // set amp present
@@ -1628,7 +1622,7 @@ std::string CPeripheralCecAdapterUpdateThread::UpdateAudioSystemStatus(void)
   else
   {
     // set amp present
-    CLog::Log(LOGDEBUG, "{} - no CEC capable amplifier found", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "no CEC capable amplifier found");
     m_adapter->SetAudioSystemConnected(false);
   }
 
@@ -1704,11 +1698,11 @@ void CPeripheralCecAdapterUpdateThread::Process(void)
         m_bIsUpdating = false;
       }
 
-      CLog::Log(LOGDEBUG, "{} - updating the configuration", __FUNCTION__);
+      CLog::LogF(LOGDEBUG, "updating the configuration");
       bool bConfigSet(m_adapter->m_cecAdapter->SetConfiguration(&configuration));
       // display message: config updated / failed to update
       if (!bConfigSet)
-        CLog::Log(LOGERROR, "{} - libCEC couldn't set the new configuration", __FUNCTION__);
+        CLog::LogF(LOGERROR, "libCEC couldn't set the new configuration");
       else
       {
         UpdateMenuLanguage();
@@ -1832,7 +1826,7 @@ void CPeripheralCecAdapter::ProcessStandbyDevices(void)
     }
     else if (m_bSendInactiveSource == 1)
     {
-      CLog::Log(LOGDEBUG, "{} - sending inactive source commands", __FUNCTION__);
+      CLog::LogF(LOGDEBUG, "sending inactive source commands");
       m_cecAdapter->SetInactiveView();
     }
   }
@@ -1846,13 +1840,13 @@ bool CPeripheralCecAdapter::ToggleDeviceState(CecStateChange mode /*= STATE_SWIT
   if (m_cecAdapter->IsLibCECActiveSource() &&
       (mode == STATE_SWITCH_TOGGLE || mode == STATE_STANDBY))
   {
-    CLog::Log(LOGDEBUG, "{} - putting CEC device on standby...", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "putting CEC device on standby...");
     StandbyDevices();
     return false;
   }
   else if (mode == STATE_SWITCH_TOGGLE || mode == STATE_ACTIVATE_SOURCE)
   {
-    CLog::Log(LOGDEBUG, "{} - waking up CEC device...", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "waking up CEC device...");
     ActivateSource();
     return true;
   }

--- a/xbmc/peripherals/devices/PeripheralHID.cpp
+++ b/xbmc/peripherals/devices/PeripheralHID.cpp
@@ -29,7 +29,7 @@ CPeripheralHID::~CPeripheralHID(void)
 {
   if (!m_strKeymap.empty() && !GetSettingBool("do_not_use_custom_keymap"))
   {
-    CLog::Log(LOGDEBUG, "{} - switching active keymapping to: default", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "switching active keymapping to: default");
     m_manager.GetInputManager().RemoveKeymap(m_strKeymap);
   }
 }
@@ -57,18 +57,17 @@ bool CPeripheralHID::InitialiseFeature(const PeripheralFeature feature)
       bool bKeymapEnabled(!GetSettingBool("do_not_use_custom_keymap"));
       if (bKeymapEnabled)
       {
-        CLog::Log(LOGDEBUG, "{} - adding keymapping for: {}", __FUNCTION__, m_strKeymap);
+        CLog::LogF(LOGDEBUG, "adding keymapping for: {}", m_strKeymap);
         m_manager.GetInputManager().AddKeymap(m_strKeymap);
       }
       else
       {
-        CLog::Log(LOGDEBUG, "{} - removing keymapping for: {}", __FUNCTION__, m_strKeymap);
+        CLog::LogF(LOGDEBUG, "removing keymapping for: {}", m_strKeymap);
         m_manager.GetInputManager().RemoveKeymap(m_strKeymap);
       }
     }
 
-    CLog::Log(LOGDEBUG, "{} - initialised HID device ({}:{})", __FUNCTION__, m_strVendorId,
-              m_strProductId);
+    CLog::LogF(LOGDEBUG, "initialised HID device ({}:{})", m_strVendorId, m_strProductId);
   }
 
   return CPeripheral::InitialiseFeature(feature);

--- a/xbmc/peripherals/devices/PeripheralNyxboard.cpp
+++ b/xbmc/peripherals/devices/PeripheralNyxboard.cpp
@@ -29,20 +29,20 @@ bool CPeripheralNyxboard::LookupSymAndUnicode(XBMC_keysym& keysym, uint8_t* key,
       GetSettingBool("enable_flip_commands"))
   {
     /* switched to keyboard side */
-    CLog::Log(LOGDEBUG, "{} - switched to keyboard side", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "switched to keyboard side");
     strCommand = GetSettingString("flip_keyboard");
   }
   else if (keysym.sym == XBMCK_F7 && keysym.mod == XBMCKMOD_LCTRL &&
            GetSettingBool("enable_flip_commands"))
   {
     /* switched to remote side */
-    CLog::Log(LOGDEBUG, "{} - switched to remote side", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "switched to remote side");
     strCommand = GetSettingString("flip_remote");
   }
 
   if (!strCommand.empty())
   {
-    CLog::Log(LOGDEBUG, "{} - executing command '{}'", __FUNCTION__, strCommand);
+    CLog::LogF(LOGDEBUG, "executing command '{}'", strCommand);
     if (g_application.ExecuteXBMCAction(strCommand))
     {
       *key = 0;

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
@@ -181,7 +181,7 @@ void CGUIDialogPeripheralSettings::InitializeSettings()
   PeripheralPtr peripheral = CServiceBroker::GetPeripherals().GetByPath(m_item->GetPath());
   if (!peripheral)
   {
-    CLog::Log(LOGDEBUG, "{} - no peripheral", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "no peripheral");
     m_initialising = false;
     return;
   }
@@ -211,7 +211,7 @@ void CGUIDialogPeripheralSettings::InitializeSettings()
 
     if (!setting->IsVisible())
     {
-      CLog::Log(LOGDEBUG, "{} - invisible", __FUNCTION__);
+      CLog::LogF(LOGDEBUG, "invisible");
       continue;
     }
 
@@ -292,7 +292,7 @@ void CGUIDialogPeripheralSettings::InitializeSettings()
 
       default:
         //! @todo add more types if needed
-        CLog::Log(LOGDEBUG, "{} - unknown type", __FUNCTION__);
+        CLog::LogF(LOGDEBUG, "unknown type");
         break;
     }
 

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -1718,7 +1718,7 @@ void CXBMCApp::onDisplayAdded(int displayId)
 
 void CXBMCApp::onDisplayChanged(int displayId)
 {
-  CLog::Log(LOGDEBUG, "CXBMCApp::{}: id: {}", __FUNCTION__, displayId);
+  CLog::LogF(LOGDEBUG, "CXBMCApp: id: {}", displayId);
 
   // Update display modes
   CWinSystemAndroid* winSystemAndroid = dynamic_cast<CWinSystemAndroid*>(CServiceBroker::GetWinSystem());

--- a/xbmc/platform/android/network/NetworkAndroid.cpp
+++ b/xbmc/platform/android/network/NetworkAndroid.cpp
@@ -126,7 +126,7 @@ bool CNetworkInterfaceAndroid::GetHostMacAddress(unsigned long host_ip, std::str
 
     if (result != 0)
     {
-      //  CLog::Log(LOGERROR, "{} - GetHostMacAddress/ioctl failed with errno ({})", __FUNCTION__, errno);
+      //  CLog::LogF(LOGERROR, "GetHostMacAddress/ioctl failed with errno ({})", errno);
       return false;
     }
   }

--- a/xbmc/platform/android/powermanagement/AndroidPowerSyscall.cpp
+++ b/xbmc/platform/android/powermanagement/AndroidPowerSyscall.cpp
@@ -33,11 +33,11 @@ bool CAndroidPowerSyscall::PumpPowerEvents(IPowerEventsCallback *callback)
   {
     case SUSPENDED:
       callback->OnSleep();
-      CLog::Log(LOGINFO, "{}: OnSleep called", __FUNCTION__);
+      CLog::LogF(LOGINFO, "OnSleep called");
       break;
     case RESUMED:
       callback->OnWake();
-      CLog::Log(LOGINFO, "{}: OnWake called", __FUNCTION__);
+      CLog::LogF(LOGINFO, "OnWake called");
       break;
     default:
       return false;

--- a/xbmc/platform/darwin/ios/IOSScreenManager.mm
+++ b/xbmc/platform/darwin/ios/IOSScreenManager.mm
@@ -167,7 +167,6 @@ static CEvent screenChangeEvent;
   NSDictionary *dict = [NSDictionary dictionaryWithObjectsAndKeys:mode, @"screenMode",
                                                                   idx,  @"screenIdx", nil];
 
-
   CLog::Log(LOGINFO, "Changing screen to {} with {:f} x {:f}", screenIdx, [mode size].width,
             [mode size].height);
   //ensure that the screen change is done in the mainthread

--- a/xbmc/platform/darwin/osx/powermanagement/CocoaPowerSyscall.cpp
+++ b/xbmc/platform/darwin/osx/powermanagement/CocoaPowerSyscall.cpp
@@ -244,7 +244,7 @@ void CCocoaPowerSyscall::CreateOSPowerCallBacks(void)
   }
   else
   {
-    CLog::Log(LOGERROR, "{} - IORegisterForSystemPower failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "IORegisterForSystemPower failed");
   }
 
   // if we have a battery, we want power source change notifications (on AC, on Battery, etc)
@@ -254,7 +254,7 @@ void CCocoaPowerSyscall::CreateOSPowerCallBacks(void)
     if (m_power_source)
       CFRunLoopAddSource(CFRunLoopGetCurrent(), m_power_source, kCFRunLoopDefaultMode);
     else
-      CLog::Log(LOGERROR, "{} - IOPSNotificationCreateRunLoopSource failed", __FUNCTION__);
+      CLog::LogF(LOGERROR, "IOPSNotificationCreateRunLoopSource failed");
   }
 }
 
@@ -295,7 +295,7 @@ void CCocoaPowerSyscall::OSPowerCallBack(void *refcon, io_service_t service, nat
       // if we don't respond, OS will sleep in 30 second.
       ctx->m_OnSuspend = true;
       IOAllowPowerChange(ctx->m_root_port, (long)msg_arg);
-      //CLog::Log(LOGDEBUG, "{} - kIOMessageCanSystemSleep", __FUNCTION__);
+      //CLog::LogF(LOGDEBUG, "kIOMessageCanSystemSleep");
       break;
     case kIOMessageSystemWillSleep:
       // System demanded sleep from:
@@ -307,7 +307,7 @@ void CCocoaPowerSyscall::OSPowerCallBack(void *refcon, io_service_t service, nat
       // in main thread so we can do this.
       CServiceBroker::GetPowerManager().ProcessEvents();
       IOAllowPowerChange(ctx->m_root_port, (long)msg_arg);
-      //CLog::Log(LOGDEBUG, "{} - kIOMessageSystemWillSleep", __FUNCTION__);
+      //CLog::LogF(LOGDEBUG, "kIOMessageSystemWillSleep");
       // let XBMC know system will sleep
       //! @todo implement
       break;
@@ -316,7 +316,7 @@ void CCocoaPowerSyscall::OSPowerCallBack(void *refcon, io_service_t service, nat
       // let XBMC know system has woke
       //! @todo implement
       ctx->m_OnResume = true;
-      //CLog::Log(LOGDEBUG, "{} - kIOMessageSystemHasPoweredOn", __FUNCTION__);
+      //CLog::LogF(LOGDEBUG, "kIOMessageSystemHasPoweredOn");
       break;
   }
 }

--- a/xbmc/platform/darwin/tvos/powermanagement/TVOSPowerSyscall.cpp
+++ b/xbmc/platform/darwin/tvos/powermanagement/TVOSPowerSyscall.cpp
@@ -71,11 +71,11 @@ bool CTVOSPowerSyscall::PumpPowerEvents(IPowerEventsCallback* callback)
   {
     case SUSPENDED:
       callback->OnSleep();
-      CLog::Log(LOGDEBUG, "{}: OnSleep called", __FUNCTION__);
+      CLog::LogF(LOGDEBUG, "OnSleep called");
       break;
     case RESUMED:
       callback->OnWake();
-      CLog::Log(LOGDEBUG, "{}: OnWake called", __FUNCTION__);
+      CLog::LogF(LOGDEBUG, "OnWake called");
       break;
     default:
       return false;

--- a/xbmc/platform/linux/input/LibInputHandler.cpp
+++ b/xbmc/platform/linux/input/LibInputHandler.cpp
@@ -31,15 +31,14 @@ static int open_restricted(const char *path, int flags, void __attribute__((unus
 
   if (fd < 0)
   {
-    CLog::Log(LOGERROR, "{} - failed to open {} ({})", __FUNCTION__, path, strerror(errno));
+    CLog::LogF(LOGERROR, "failed to open {} ({})", path, strerror(errno));
     return -errno;
   }
 
   auto ret = ioctl(fd, EVIOCGRAB, (void*)1);
   if (ret < 0)
   {
-    CLog::Log(LOGDEBUG, "{} - grab requested, but failed for {} ({})", __FUNCTION__, path,
-              strerror(errno));
+    CLog::LogF(LOGDEBUG, "grab requested, but failed for {} ({})", path, strerror(errno));
   }
 
   return fd;
@@ -72,15 +71,14 @@ CLibInputHandler::CLibInputHandler() : CThread("libinput")
   m_udev = udev_new();
   if (!m_udev)
   {
-    CLog::Log(LOGERROR, "CLibInputHandler::{} - failed to get udev context for libinput",
-              __FUNCTION__);
+    CLog::LogF(LOGERROR, "CLibInputHandler: failed to get udev context for libinput");
     return;
   }
 
   m_li = libinput_udev_create_context(&m_interface, nullptr, m_udev);
   if (!m_li)
   {
-    CLog::Log(LOGERROR, "CLibInputHandler::{} - failed to get libinput context", __FUNCTION__);
+    CLog::LogF(LOGERROR, "CLibInputHandler: failed to get libinput context");
     return;
   }
 
@@ -89,7 +87,7 @@ CLibInputHandler::CLibInputHandler() : CThread("libinput")
 
   auto ret = libinput_udev_assign_seat(m_li, "seat0");
   if (ret < 0)
-    CLog::Log(LOGERROR, "CLibInputHandler::{} - failed to assign seat", __FUNCTION__);
+    CLog::LogF(LOGERROR, "CLibInputHandler: failed to assign seat");
 
   m_liFd = libinput_get_fd(m_li);
 
@@ -123,7 +121,7 @@ void CLibInputHandler::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
     {
       auto ret = libinput_resume(m_li);
       if (ret < 0)
-        CLog::Log(LOGERROR, "CLibInputHandler::{} - failed to resume monitoring", __FUNCTION__);
+        CLog::LogF(LOGERROR, "CLibInputHandler: failed to resume monitoring");
     }
   }
 }
@@ -144,8 +142,8 @@ void CLibInputHandler::Process()
   int epollFd = epoll_create1(EPOLL_CLOEXEC);
   if (epollFd < 0)
   {
-    CLog::Log(LOGERROR, "CLibInputHandler::{} - failed to create epoll file descriptor: {}",
-              __FUNCTION__, strerror(-errno));
+    CLog::LogF(LOGERROR, "CLibInputHandler: failed to create epoll file descriptor: {}",
+               strerror(-errno));
     return;
   }
 
@@ -156,8 +154,8 @@ void CLibInputHandler::Process()
   auto ret = epoll_ctl(epollFd, EPOLL_CTL_ADD, m_liFd, &event);
   if (ret < 0)
   {
-    CLog::Log(LOGERROR, "CLibInputHandler::{} - failed to add file descriptor to epoll: {}",
-              __FUNCTION__, strerror(-errno));
+    CLog::LogF(LOGERROR, "CLibInputHandler: failed to add file descriptor to epoll: {}",
+               strerror(-errno));
     close(epollFd);
     return;
   }
@@ -169,8 +167,7 @@ void CLibInputHandler::Process()
     ret = libinput_dispatch(m_li);
     if (ret < 0)
     {
-      CLog::Log(LOGERROR, "CLibInputHandler::{} - libinput_dispatch failed: {}", __FUNCTION__,
-                strerror(-errno));
+      CLog::LogF(LOGERROR, "CLibInputHandler: libinput_dispatch failed: {}", strerror(-errno));
       close(epollFd);
       return;
     }
@@ -186,8 +183,8 @@ void CLibInputHandler::Process()
   ret = close(epollFd);
   if (ret < 0)
   {
-    CLog::Log(LOGERROR, "CLibInputHandler::{} - failed to close epoll file descriptor: {}",
-              __FUNCTION__, strerror(-errno));
+    CLog::LogF(LOGERROR, "CLibInputHandler: failed to close epoll file descriptor: {}",
+               strerror(-errno));
     return;
   }
 }
@@ -249,22 +246,19 @@ void CLibInputHandler::DeviceAdded(libinput_device *dev)
 
   if (libinput_device_has_capability(dev, LIBINPUT_DEVICE_CAP_TOUCH))
   {
-    CLog::Log(LOGDEBUG, "CLibInputHandler::{} - touch type device added: {} ({})", __FUNCTION__,
-              name, sysname);
+    CLog::LogF(LOGDEBUG, "CLibInputHandler: touch type device added: {} ({})", name, sysname);
     m_devices.push_back(libinput_device_ref(dev));
   }
 
   if (libinput_device_has_capability(dev, LIBINPUT_DEVICE_CAP_POINTER))
   {
-    CLog::Log(LOGDEBUG, "CLibInputHandler::{} - pointer type device added: {} ({})", __FUNCTION__,
-              name, sysname);
+    CLog::LogF(LOGDEBUG, "CLibInputHandler: pointer type device added: {} ({})", name, sysname);
     m_devices.push_back(libinput_device_ref(dev));
   }
 
   if (libinput_device_has_capability(dev, LIBINPUT_DEVICE_CAP_KEYBOARD))
   {
-    CLog::Log(LOGDEBUG, "CLibInputHandler::{} - keyboard type device added: {} ({})", __FUNCTION__,
-              name, sysname);
+    CLog::LogF(LOGDEBUG, "CLibInputHandler: keyboard type device added: {} ({})", name, sysname);
     m_devices.push_back(libinput_device_ref(dev));
     m_keyboard->GetRepeat(dev);
   }
@@ -277,24 +271,21 @@ void CLibInputHandler::DeviceRemoved(libinput_device *dev)
 
   if (libinput_device_has_capability(dev, LIBINPUT_DEVICE_CAP_TOUCH))
   {
-    CLog::Log(LOGDEBUG, "CLibInputHandler::{} - touch type device removed: {} ({})", __FUNCTION__,
-              name, sysname);
+    CLog::LogF(LOGDEBUG, "CLibInputHandler: touch type device removed: {} ({})", name, sysname);
     auto device = std::find(m_devices.begin(), m_devices.end(), libinput_device_unref(dev));
     m_devices.erase(device);
   }
 
   if (libinput_device_has_capability(dev, LIBINPUT_DEVICE_CAP_POINTER))
   {
-    CLog::Log(LOGDEBUG, "CLibInputHandler::{} - pointer type device removed: {} ({})", __FUNCTION__,
-              name, sysname);
+    CLog::LogF(LOGDEBUG, "CLibInputHandler: pointer type device removed: {} ({})", name, sysname);
     auto device = std::find(m_devices.begin(), m_devices.end(), libinput_device_unref(dev));
     m_devices.erase(device);
   }
 
   if (libinput_device_has_capability(dev, LIBINPUT_DEVICE_CAP_KEYBOARD))
   {
-    CLog::Log(LOGDEBUG, "CLibInputHandler::{} - keyboard type device removed: {} ({})",
-              __FUNCTION__, name, sysname);
+    CLog::LogF(LOGDEBUG, "CLibInputHandler: keyboard type device removed: {} ({})", name, sysname);
     auto device = std::find(m_devices.begin(), m_devices.end(), libinput_device_unref(dev));
     m_devices.erase(device);
   }

--- a/xbmc/platform/linux/input/LibInputKeyboard.cpp
+++ b/xbmc/platform/linux/input/LibInputKeyboard.cpp
@@ -156,7 +156,7 @@ CLibInputKeyboard::CLibInputKeyboard()
   m_ctx = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
   if (!m_ctx)
   {
-    CLog::Log(LOGERROR, "CLibInputKeyboard::{} - failed to create xkb context", __FUNCTION__);
+    CLog::LogF(LOGERROR, "CLibInputKeyboard: failed to create xkb context");
     return;
   }
 
@@ -164,7 +164,7 @@ CLibInputKeyboard::CLibInputKeyboard()
 
   if (!SetKeymap(layout))
   {
-    CLog::Log(LOGERROR, "CLibInputKeyboard::{} - failed set default keymap", __FUNCTION__);
+    CLog::LogF(LOGERROR, "CLibInputKeyboard: failed set default keymap");
     return;
   }
 }
@@ -192,14 +192,14 @@ bool CLibInputKeyboard::SetKeymap(const std::string& layout)
   m_keymap = xkb_keymap_new_from_names(m_ctx, &names, XKB_KEYMAP_COMPILE_NO_FLAGS);
   if (!m_keymap)
   {
-    CLog::Log(LOGERROR, "CLibInputKeyboard::{} - failed to compile keymap", __FUNCTION__);
+    CLog::LogF(LOGERROR, "CLibInputKeyboard: failed to compile keymap");
     return false;
   }
 
   m_state = xkb_state_new(m_keymap);
   if (!m_state)
   {
-    CLog::Log(LOGERROR, "CLibInputKeyboard::{} - failed to create xkb state", __FUNCTION__);
+    CLog::LogF(LOGERROR, "CLibInputKeyboard: failed to create xkb state");
     return false;
   }
 
@@ -300,8 +300,8 @@ void CLibInputKeyboard::ProcessKey(libinput_event_keyboard *e)
     auto data = m_repeatData.find(dev);
     if (data != m_repeatData.end())
     {
-      CLog::Log(LOGDEBUG, "CLibInputKeyboard::{} - using delay: {}ms repeat: {}ms", __FUNCTION__,
-                data->second.at(0), data->second.at(1));
+      CLog::LogF(LOGDEBUG, "CLibInputKeyboard: using delay: {}ms repeat: {}ms", data->second.at(0),
+                 data->second.at(1));
 
       m_repeatRate = data->second.at(1);
       m_repeatTimer.Stop(true);
@@ -362,18 +362,17 @@ void CLibInputKeyboard::GetRepeat(libinput_device *dev)
 
   if (fd < 0)
   {
-    CLog::Log(LOGERROR, "CLibInputKeyboard::{} - failed to open {} ({})", __FUNCTION__, sysname,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CLibInputKeyboard: failed to open {} ({})", sysname, strerror(errno));
   }
   else
   {
     auto ret = ioctl(fd, EVIOCGREP, &kbdrep);
     if (ret < 0)
-      CLog::Log(LOGDEBUG, "CLibInputKeyboard::{} - could not get key repeat for {} ({})",
-                __FUNCTION__, sysname, strerror(errno));
+      CLog::LogF(LOGDEBUG, "CLibInputKeyboard: could not get key repeat for {} ({})", sysname,
+                 strerror(errno));
 
-    CLog::Log(LOGDEBUG, "CLibInputKeyboard::{} - delay: {}ms repeat: {}ms for {} ({})",
-              __FUNCTION__, kbdrep[0], kbdrep[1], name, sysname);
+    CLog::LogF(LOGDEBUG, "CLibInputKeyboard: delay: {}ms repeat: {}ms for {} ({})", kbdrep[0],
+               kbdrep[1], name, sysname);
     close(fd);
   }
 

--- a/xbmc/platform/linux/input/LibInputPointer.cpp
+++ b/xbmc/platform/linux/input/LibInputPointer.cpp
@@ -59,10 +59,10 @@ void CLibInputPointer::ProcessButton(libinput_event_pointer *e)
   event.button.x = static_cast<uint16_t>(m_pos.X);
   event.button.y = static_cast<uint16_t>(m_pos.Y);
 
-  CLog::Log(LOGDEBUG,
-            "CLibInputPointer::{} - event.type: {}, event.button.button: {}, event.button.x: {}, "
-            "event.button.y: {}",
-            __FUNCTION__, event.type, event.button.button, event.button.x, event.button.y);
+  CLog::LogF(LOGDEBUG,
+             "CLibInputPointer: event.type: {}, event.button.button: {}, event.button.x: {}, "
+             "event.button.y: {}",
+             event.type, event.button.button, event.button.x, event.button.y);
 
   std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
   if (appPort)
@@ -91,9 +91,8 @@ void CLibInputPointer::ProcessMotion(libinput_event_pointer *e)
   event.motion.x = static_cast<uint16_t>(m_pos.X);
   event.motion.y = static_cast<uint16_t>(m_pos.Y);
 
-  CLog::Log(LOGDEBUG,
-            "CLibInputPointer::{} - event.type: {}, event.motion.x: {}, event.motion.y: {}",
-            __FUNCTION__, event.type, event.motion.x, event.motion.y);
+  CLog::LogF(LOGDEBUG, "CLibInputPointer: event.type: {}, event.motion.x: {}, event.motion.y: {}",
+             event.type, event.motion.x, event.motion.y);
 
   std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
   if (appPort)
@@ -110,9 +109,8 @@ void CLibInputPointer::ProcessMotionAbsolute(libinput_event_pointer *e)
   event.motion.x = static_cast<uint16_t>(m_pos.X);
   event.motion.y = static_cast<uint16_t>(m_pos.Y);
 
-  CLog::Log(LOGDEBUG,
-            "CLibInputPointer::{} - event.type: {}, event.motion.x: {}, event.motion.y: {}",
-            __FUNCTION__, event.type, event.motion.x, event.motion.y);
+  CLog::LogF(LOGDEBUG, "CLibInputPointer: event.type: {}, event.motion.x: {}, event.motion.y: {}",
+             event.type, event.motion.x, event.motion.y);
 
   std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
   if (appPort)
@@ -138,9 +136,8 @@ void CLibInputPointer::ProcessAxis(libinput_event_pointer *e)
   event.button.x = static_cast<uint16_t>(m_pos.X);
   event.button.y = static_cast<uint16_t>(m_pos.Y);
 
-  CLog::Log(LOGDEBUG, "CLibInputPointer::{} - scroll: {}, event.button.x: {}, event.button.y: {}",
-            __FUNCTION__, scroll == XBMC_BUTTON_WHEELUP ? "up" : "down", event.button.x,
-            event.button.y);
+  CLog::LogF(LOGDEBUG, "CLibInputPointer: scroll: {}, event.button.x: {}, event.button.y: {}",
+             scroll == XBMC_BUTTON_WHEELUP ? "up" : "down", event.button.x, event.button.y);
 
   std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
   if (appPort)

--- a/xbmc/platform/linux/input/LibInputTouch.cpp
+++ b/xbmc/platform/linux/input/LibInputTouch.cpp
@@ -18,7 +18,7 @@ static inline CPoint GetPos(libinput_event_touch *e)
   const double x = libinput_event_touch_get_x_transformed(e, CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth());
   const double y = libinput_event_touch_get_y_transformed(e, CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight());
 
-  CLog::Log(LOGDEBUG, "CLibInputTouch::{} - x: {:f} y: {:f}", __FUNCTION__, x, y);
+  CLog::LogF(LOGDEBUG, "CLibInputTouch: x: {:f} y: {:f}", x, y);
 
   return CPoint(x, y);
 }
@@ -59,7 +59,7 @@ void CLibInputTouch::ProcessTouchDown(libinput_event_touch *e)
 
   SetPosition(slot, GetPos(e));
   SetEvent(slot, TouchInputDown);
-  CLog::Log(LOGDEBUG, "CLibInputTouch::{} - touch input down", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CLibInputTouch: touch input down");
 }
 
 void CLibInputTouch::ProcessTouchMotion(libinput_event_touch *e)
@@ -71,7 +71,7 @@ void CLibInputTouch::ProcessTouchMotion(libinput_event_touch *e)
 
   if (GetEvent(slot) != TouchInputDown)
     SetEvent(slot, TouchInputMove);
-  CLog::Log(LOGDEBUG, "CLibInputTouch::{} - touch input move", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CLibInputTouch: touch input move");
 
   CGenericTouchInputHandler::GetInstance().UpdateTouchPointer(slot, GetX(slot), GetY(slot), nanotime);
 }
@@ -81,7 +81,7 @@ void CLibInputTouch::ProcessTouchUp(libinput_event_touch *e)
   int slot = libinput_event_touch_get_seat_slot(e);
 
   SetEvent(slot, TouchInputUp);
-  CLog::Log(LOGDEBUG, "CLibInputTouch::{} - touch input up", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CLibInputTouch: touch input up");
 }
 
 void CLibInputTouch::ProcessTouchCancel(libinput_event_touch *e)
@@ -89,7 +89,7 @@ void CLibInputTouch::ProcessTouchCancel(libinput_event_touch *e)
   int slot = libinput_event_touch_get_seat_slot(e);
   uint64_t nanotime = libinput_event_touch_get_time_usec(e) * 1000LL;
 
-  CLog::Log(LOGDEBUG, "CLibInputTouch::{} - touch input cancel", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CLibInputTouch: touch input cancel");
   CGenericTouchInputHandler::GetInstance().HandleTouchInput(TouchInputAbort, GetX(slot), GetY(slot), nanotime, slot);
 }
 
@@ -99,9 +99,8 @@ void CLibInputTouch::ProcessTouchFrame(libinput_event_touch *e)
 
   for (size_t slot = 0; slot < m_points.size(); ++slot)
   {
-    CLog::Log(LOGDEBUG, "CLibInputTouch::{} - touch input frame: event {}", __FUNCTION__,
-              GetEvent(slot));
-    CLog::Log(LOGDEBUG, "CLibInputTouch::{} - touch input frame: slot {}", __FUNCTION__, slot);
+    CLog::LogF(LOGDEBUG, "CLibInputTouch: touch input frame: event {}", GetEvent(slot));
+    CLog::LogF(LOGDEBUG, "CLibInputTouch: touch input frame: slot {}", slot);
     CGenericTouchInputHandler::GetInstance().HandleTouchInput(GetEvent(slot), GetX(slot), GetY(slot), nanotime, slot);
     SetEvent(slot, TouchInputUnchanged);
   }

--- a/xbmc/platform/linux/network/NetworkLinux.cpp
+++ b/xbmc/platform/linux/network/NetworkLinux.cpp
@@ -99,7 +99,7 @@ bool CNetworkInterfaceLinux::GetHostMacAddress(unsigned long host_ip, std::strin
 
   if (result != 0)
   {
-    //  CLog::Log(LOGERROR, "{} - GetHostMacAddress/ioctl failed with errno ({})", __FUNCTION__, errno);
+    //  CLog::LogF(LOGERROR, "GetHostMacAddress/ioctl failed with errno ({})", errno);
     return false;
   }
 

--- a/xbmc/platform/linux/peripherals/PeripheralBusUSBLibUSB.cpp
+++ b/xbmc/platform/linux/peripherals/PeripheralBusUSBLibUSB.cpp
@@ -22,7 +22,7 @@ CPeripheralBusUSB::CPeripheralBusUSB(CPeripherals& manager) :
   usb_init();
   usb_find_busses();
   m_busses = usb_get_busses();
-  CLog::Log(LOGDEBUG, "{} - using libusb peripheral scanning", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "using libusb peripheral scanning");
 }
 
 bool CPeripheralBusUSB::PerformDeviceScan(PeripheralScanResults &results)

--- a/xbmc/platform/linux/peripherals/PeripheralBusUSBLibUdev.cpp
+++ b/xbmc/platform/linux/peripherals/PeripheralBusUSBLibUdev.cpp
@@ -180,8 +180,8 @@ void CPeripheralBusUSB::Process(void)
 {
   if (!(m_udev = udev_new()))
   {
-    CLog::Log(LOGERROR, "{} - failed to allocate udev context", __FUNCTION__);
-    return;
+  CLog::LogF(LOGERROR, "failed to allocate udev context");
+  return;
   }
 
   /* set up a devices monitor that listen for any device change */
@@ -193,7 +193,7 @@ void CPeripheralBusUSB::Process(void)
     CLog::Log(LOGERROR, "Could not limit filter on USB only");
   }
 
-  CLog::Log(LOGDEBUG, "{} - initialised udev monitor", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "initialised udev monitor");
 
   udev_monitor_enable_receiving(m_udevMon);
   bool bUpdated(false);
@@ -221,7 +221,7 @@ bool CPeripheralBusUSB::WaitForUpdate()
 
   if (udevFd < 0)
   {
-    CLog::Log(LOGERROR, "{} - get udev monitor", __FUNCTION__);
+    CLog::LogF(LOGERROR, "get udev monitor");
     return false;
   }
 
@@ -244,8 +244,7 @@ bool CPeripheralBusUSB::WaitForUpdate()
     udev_device_unref(dev);
   else
   {
-    CLog::Log(LOGERROR, "{} - failed to get device from udev_monitor_receive_device()",
-              __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed to get device from udev_monitor_receive_device()");
     Clear();
     return false;
   }

--- a/xbmc/platform/linux/storage/UDevProvider.cpp
+++ b/xbmc/platform/linux/storage/UDevProvider.cpp
@@ -73,7 +73,7 @@ void CUDevProvider::Initialize()
   m_udev = udev_new();
   if (!m_udev)
   {
-    CLog::Log(LOGERROR, "{} - failed to allocate udev context", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed to allocate udev context");
     return;
   }
   /* set up a devices monitor that listen for any device change */

--- a/xbmc/platform/posix/XHandle.cpp
+++ b/xbmc/platform/posix/XHandle.cpp
@@ -36,7 +36,7 @@ CXHandle::CXHandle(const CXHandle &src)
 {
   // we shouldn't get here EVER. however, if we do - try to make the best. copy what we can
   // and most importantly - not share any pointer.
-  CLog::Log(LOGWARNING, "{}, copy handle.", __FUNCTION__);
+  CLog::LogF(LOGWARNING, "copy handle.");
 
   Init();
 
@@ -60,13 +60,12 @@ CXHandle::~CXHandle()
   m_objectTracker[m_type]--;
 
   if (RecursionCount > 0) {
-    CLog::Log(LOGERROR, "{}, destroying handle with recursion count {}", __FUNCTION__,
-              RecursionCount);
+    CLog::LogF(LOGERROR, "destroying handle with recursion count {}", RecursionCount);
     assert(false);
   }
 
   if (m_nRefCount > 1) {
-    CLog::Log(LOGERROR, "{}, destroying handle with ref count {}", __FUNCTION__, m_nRefCount);
+    CLog::LogF(LOGERROR, "destroying handle with ref count {}", m_nRefCount);
     assert(false);
   }
 

--- a/xbmc/platform/posix/filesystem/SMBDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/SMBDirectory.cpp
@@ -193,8 +193,7 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
             iSize = info.st_size;
           }
           else
-            CLog::Log(LOGERROR, "{} - Failed to stat file {}", __FUNCTION__,
-                      CURL::GetRedacted(strFullName));
+            CLog::LogF(LOGERROR, "Failed to stat file {}", CURL::GetRedacted(strFullName));
 
           lock.unlock();
         }
@@ -329,7 +328,7 @@ bool CSMBDirectory::Create(const CURL& url2)
   int result = smbc_mkdir(strFileName.c_str(), 0);
   bool success = (result == 0 || EEXIST == errno);
   if(!success)
-    CLog::Log(LOGERROR, "{} - Error( {} )", __FUNCTION__, strerror(errno));
+    CLog::LogF(LOGERROR, "Error( {} )", strerror(errno));
 
   return success;
 }
@@ -347,7 +346,7 @@ bool CSMBDirectory::Remove(const CURL& url2)
 
   if(result != 0 && errno != ENOENT)
   {
-    CLog::Log(LOGERROR, "{} - Error( {} )", __FUNCTION__, strerror(errno));
+    CLog::LogF(LOGERROR, "Error( {} )", strerror(errno));
     return false;
   }
 

--- a/xbmc/platform/posix/filesystem/SMBFile.cpp
+++ b/xbmc/platform/posix/filesystem/SMBFile.cpp
@@ -530,7 +530,7 @@ int CSMBFile::Truncate(int64_t size)
   int iResult = smbc_ftruncate(m_fd, size);
 #endif
 */
-  CLog::Log(LOGWARNING, "{} - Warning(smbc_ftruncate called and not implemented)", __FUNCTION__);
+  CLog::LogF(LOGWARNING, "Warning(smbc_ftruncate called and not implemented)");
   return 0;
 }
 
@@ -560,14 +560,12 @@ ssize_t CSMBFile::Read(void *lpBuf, size_t uiBufSize)
 
   if (m_allowRetry && bytesRead < 0 && errno == EINVAL )
   {
-    CLog::Log(LOGERROR, "{} - Error( {}, {}, {} ) - Retrying", __FUNCTION__, bytesRead, errno,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "Error( {}, {}, {} ) - Retrying", bytesRead, errno, strerror(errno));
     bytesRead = smbc_read(m_fd, lpBuf, (int)uiBufSize);
   }
 
   if ( bytesRead < 0 )
-    CLog::Log(LOGERROR, "{} - Error( {}, {}, {} )", __FUNCTION__, bytesRead, errno,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "Error( {}, {}, {} )", bytesRead, errno, strerror(errno));
 
   return bytesRead;
 }
@@ -585,7 +583,7 @@ int64_t CSMBFile::Seek(int64_t iFilePosition, int iWhence)
 
   if ( pos < 0 )
   {
-    CLog::Log(LOGERROR, "{} - Error( {}, {}, {} )", __FUNCTION__, pos, errno, strerror(errno));
+    CLog::LogF(LOGERROR, "Error( {}, {}, {} )", pos, errno, strerror(errno));
     return -1;
   }
 
@@ -629,7 +627,7 @@ bool CSMBFile::Delete(const CURL& url)
   int result = smbc_unlink(strFile.c_str());
 
   if(result != 0)
-    CLog::Log(LOGERROR, "{} - Error( {} )", __FUNCTION__, strerror(errno));
+    CLog::LogF(LOGERROR, "Error( {} )", strerror(errno));
 
   return (result == 0);
 }
@@ -646,7 +644,7 @@ bool CSMBFile::Rename(const CURL& url, const CURL& urlnew)
   int result = smbc_rename(strFile.c_str(), strFileNew.c_str());
 
   if(result != 0)
-    CLog::Log(LOGERROR, "{} - Error( {} )", __FUNCTION__, strerror(errno));
+    CLog::LogF(LOGERROR, "Error( {} )", strerror(errno));
 
   return (result == 0);
 }

--- a/xbmc/platform/posix/network/NetworkPosix.cpp
+++ b/xbmc/platform/posix/network/NetworkPosix.cpp
@@ -140,7 +140,7 @@ CNetworkInterface* CNetworkPosix::GetFirstConnectedInterface()
   // no connected Interfaces found? - requeryInterfaceList
   if (!pNetIf)
   {
-    CLog::Log(LOGDEBUG, "{} no connected interface found - requery list", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "no connected interface found - requery list");
     queryInterfaceList();
     //retry finding a connected if
     pNetIf = CNetworkBase::GetFirstConnectedInterface();

--- a/xbmc/platform/win10/peripherals/PeripheralBusUSB.cpp
+++ b/xbmc/platform/win10/peripherals/PeripheralBusUSB.cpp
@@ -42,14 +42,14 @@ bool CPeripheralBusUSB::PerformDeviceScan(const GUID *guid, const PeripheralType
 {
   bool bReturn(false);
 
-  CLog::Log(LOGDEBUG, "{} is not implemented", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "is not implemented");
 
   return bReturn;
 }
 
 bool GetProductAndVendorId(const PeripheralType type, const std::string &strDeviceLocation, int *iVendorId, int *iProductId)
 {
-  CLog::Log(LOGDEBUG, "{} is not implemented", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "is not implemented");
 
   return false;
 }

--- a/xbmc/platform/win10/storage/Win10StorageProvider.cpp
+++ b/xbmc/platform/win10/storage/Win10StorageProvider.cpp
@@ -49,7 +49,7 @@ void CStorageProvider::Initialize()
   if (!vShare.empty())
     CServiceBroker::GetMediaManager().SetHasOpticalDrive(true);
   else
-    CLog::Log(LOGDEBUG, "{}: No optical drive found.", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "No optical drive found.");
 
   m_watcher = DeviceInformation::CreateWatcher(DeviceClass::PortableStorageDevice);
   m_watcher.Added([this](auto&&, auto&&)

--- a/xbmc/platform/win32/IMMNotificationClient.h
+++ b/xbmc/platform/win32/IMMNotificationClient.h
@@ -103,21 +103,20 @@ public:
       break;
     }
 
-    CLog::Log(LOGDEBUG, "{}: New default device: flow = {}, role = {}", __FUNCTION__, pszFlow,
-              pszRole);
+    CLog::LogF(LOGDEBUG, "New default device: flow = {}, role = {}", pszFlow, pszRole);
     return S_OK;
   }
 
   HRESULT STDMETHODCALLTYPE OnDeviceAdded(LPCWSTR pwstrDeviceId)
   {
-    CLog::Log(LOGDEBUG, "{}: Added device: {}", __FUNCTION__, FromW(pwstrDeviceId));
+    CLog::LogF(LOGDEBUG, "Added device: {}", FromW(pwstrDeviceId));
     NotifyAE();
     return S_OK;
   }
 
   HRESULT STDMETHODCALLTYPE OnDeviceRemoved(LPCWSTR pwstrDeviceId)
   {
-    CLog::Log(LOGDEBUG, "{}: Removed device: {}", __FUNCTION__, FromW(pwstrDeviceId));
+    CLog::LogF(LOGDEBUG, "Removed device: {}", FromW(pwstrDeviceId));
     NotifyAE();
     return S_OK;
   }
@@ -141,20 +140,20 @@ public:
       pszState = "UNPLUGGED";
       break;
     }
-    CLog::Log(LOGDEBUG, "{}: New device state is DEVICE_STATE_{}", __FUNCTION__, pszState);
+    CLog::LogF(LOGDEBUG, "New device state is DEVICE_STATE_{}", pszState);
     NotifyAE();
     return S_OK;
   }
 
   HRESULT STDMETHODCALLTYPE OnPropertyValueChanged(LPCWSTR pwstrDeviceId, const PROPERTYKEY key)
   {
-    CLog::Log(LOGDEBUG,
-              "{}: Changed device property of {} is "
-              "({:08x}-{:04x}-{:04x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x})#{}",
-              __FUNCTION__, FromW(pwstrDeviceId), key.fmtid.Data1, key.fmtid.Data2, key.fmtid.Data3,
-              key.fmtid.Data4[0], key.fmtid.Data4[1], key.fmtid.Data4[2], key.fmtid.Data4[3],
-              key.fmtid.Data4[4], key.fmtid.Data4[5], key.fmtid.Data4[6], key.fmtid.Data4[7],
-              key.pid);
+    CLog::LogF(LOGDEBUG,
+               "Changed device property of {} is "
+               "({:08x}-{:04x}-{:04x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x})#{}",
+               FromW(pwstrDeviceId), key.fmtid.Data1, key.fmtid.Data2, key.fmtid.Data3,
+               key.fmtid.Data4[0], key.fmtid.Data4[1], key.fmtid.Data4[2], key.fmtid.Data4[3],
+               key.fmtid.Data4[4], key.fmtid.Data4[5], key.fmtid.Data4[6], key.fmtid.Data4[7],
+               key.pid);
     return S_OK;
   }
 

--- a/xbmc/platform/win32/filesystem/Win32Directory.cpp
+++ b/xbmc/platform/win32/filesystem/Win32Directory.cpp
@@ -74,7 +74,7 @@ bool CWin32Directory::GetDirectory(const CURL& url, CFileItemList &items)
     std::string itemName;
     if (!g_charsetConverter.wToUTF8(itemNameW, itemName, true) || itemName.empty())
     {
-      CLog::Log(LOGERROR, "{}: Can't convert wide string name to UTF-8 encoding", __FUNCTION__);
+      CLog::LogF(LOGERROR, "Can't convert wide string name to UTF-8 encoding");
       continue;
     }
 
@@ -183,7 +183,7 @@ bool CWin32Directory::RemoveRecursive(const CURL& url)
       std::string path;
       if (!g_charsetConverter.wToUTF8(pathW, path, true))
       {
-        CLog::Log(LOGERROR, "{}: Can't convert wide string name to UTF-8 encoding", __FUNCTION__);
+        CLog::LogF(LOGERROR, "Can't convert wide string name to UTF-8 encoding");
         continue;
       }
 

--- a/xbmc/platform/win32/filesystem/Win32SMBDirectory.cpp
+++ b/xbmc/platform/win32/filesystem/Win32SMBDirectory.cpp
@@ -544,7 +544,7 @@ static bool localGetNetworkResources(struct _NETRESOURCEW* basePathToScanPtr, co
             }
           }
           else
-            CLog::Log(LOGERROR, "{}: Skipping container with empty remote name", __FUNCTION__);
+            CLog::LogF(LOGERROR, "Skipping container with empty remote name");
         }
       }
     }

--- a/xbmc/platform/win32/network/NetworkWin32.cpp
+++ b/xbmc/platform/win32/network/NetworkWin32.cpp
@@ -159,7 +159,7 @@ void CNetworkWin32::queryInterfaceList()
     }
   }
   else
-    CLog::Log(LOGDEBUG, "{} - GetAdaptersAddresses() failed ...", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "GetAdaptersAddresses() failed ...");
 }
 
 std::vector<std::string> CNetworkWin32::GetNameServers(void)
@@ -232,9 +232,9 @@ bool CNetworkWin32::PingHost(const struct sockaddr& host, unsigned int timeout_m
 
   DWORD lastErr = GetLastError();
   if (lastErr != ERROR_SUCCESS && lastErr != IP_REQ_TIMED_OUT)
-    CLog::Log(LOGERROR, "{} - {} failed - {}", __FUNCTION__,
-              host.sa_family == AF_INET ? "IcmpSendEcho2" : "Icmp6SendEcho2",
-              CWIN32Util::WUSysMsg(lastErr));
+    CLog::LogF(LOGERROR, "{} failed - {}",
+               host.sa_family == AF_INET ? "IcmpSendEcho2" : "Icmp6SendEcho2",
+               CWIN32Util::WUSysMsg(lastErr));
 
   IcmpCloseHandle (hIcmpFile);
 

--- a/xbmc/platform/win32/peripherals/PeripheralBusUSB.cpp
+++ b/xbmc/platform/win32/peripherals/PeripheralBusUSB.cpp
@@ -57,7 +57,7 @@ bool CPeripheralBusUSB::PerformDeviceScan(const GUID *guid, const PeripheralType
   HDEVINFO const hDevHandle = SetupDiGetClassDevs(guid, 0, 0, DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
   if (hDevHandle == INVALID_HANDLE_VALUE)
   {
-    CLog::Log(LOGWARNING, "{} - cannot query USB devices: invalid handle", __FUNCTION__);
+    CLog::LogF(LOGWARNING, "cannot query USB devices: invalid handle");
     return bReturn;
   }
 
@@ -68,7 +68,7 @@ bool CPeripheralBusUSB::PerformDeviceScan(const GUID *guid, const PeripheralType
   {
     free(devicedetailData);
     free(deviceProperty);
-    CLog::Log(LOGFATAL, "{}: memory allocation failed", __FUNCTION__);
+    CLog::LogF(LOGFATAL, "memory allocation failed");
     return false;
   }
 
@@ -102,7 +102,7 @@ bool CPeripheralBusUSB::PerformDeviceScan(const GUID *guid, const PeripheralType
         if (!devicedetailData)
         {
           free(deviceProperty);
-          CLog::Log(LOGFATAL, "{}: memory allocation failed", __FUNCTION__);
+          CLog::LogF(LOGFATAL, "memory allocation failed");
           return false;
         }
         devicedetailData->cbSize = sizeof(SP_INTERFACE_DEVICE_DETAIL_DATA);
@@ -120,7 +120,7 @@ bool CPeripheralBusUSB::PerformDeviceScan(const GUID *guid, const PeripheralType
           if (!deviceProperty)
           {
             free(devicedetailData);
-            CLog::Log(LOGFATAL, "{}: memory allocation failed", __FUNCTION__);
+            CLog::LogF(LOGFATAL, "memory allocation failed");
             return false;
           }
           nPropertyBufferSize = required;

--- a/xbmc/platform/win32/storage/Win32StorageProvider.cpp
+++ b/xbmc/platform/win32/storage/Win32StorageProvider.cpp
@@ -36,7 +36,7 @@ void CWin32StorageProvider::Initialize()
   if(!vShare.empty())
     CServiceBroker::GetMediaManager().SetHasOpticalDrive(true);
   else
-    CLog::Log(LOGDEBUG, "{}: No optical drive found.", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "No optical drive found.");
 
 #ifdef HAS_DVD_DRIVE
   // Can be removed once the StorageHandler supports optical media
@@ -381,7 +381,7 @@ CDetectDisc::CDetectDisc(const std::string &strPath, const bool bautorun)
 bool CDetectDisc::DoWork()
 {
 #ifdef HAS_DVD_DRIVE
-  CLog::Log(LOGDEBUG, "{}: Optical media found in drive {}", __FUNCTION__, m_strPath);
+  CLog::LogF(LOGDEBUG, "Optical media found in drive {}", m_strPath);
   CMediaSource share;
   share.strPath = m_strPath;
   share.strStatus = CServiceBroker::GetMediaManager().GetDiskLabel(share.strPath);

--- a/xbmc/playlists/PlayList.cpp
+++ b/xbmc/playlists/PlayList.cpp
@@ -261,7 +261,7 @@ void CPlayList::Shuffle(int iPosition)
       return;
     if (iPosition < 0)
       iPosition = 0;
-    CLog::Log(LOGDEBUG, "{} shuffling at pos:{}", __FUNCTION__, iPosition);
+    CLog::LogF(LOGDEBUG, "shuffling at pos:{}", iPosition);
 
     ivecItems it = m_vecItems.begin() + iPosition;
     KODI::UTILS::RandomShuffle(it, m_vecItems.end());
@@ -426,8 +426,7 @@ bool CPlayList::Load(const std::string& strFileName)
 
   if (file.GetLength() > 1024*1024)
   {
-    CLog::Log(LOGWARNING, "{} - File is larger than 1 MB, most likely not a playlist",
-              __FUNCTION__);
+    CLog::LogF(LOGWARNING, "File is larger than 1 MB, most likely not a playlist");
     return false;
   }
 

--- a/xbmc/playlists/PlayListPLS.cpp
+++ b/xbmc/playlists/PlayListPLS.cpp
@@ -75,8 +75,7 @@ bool CPlayListPLS::Load(const std::string &strFile)
 
   if (file.GetLength() > 1024*1024)
   {
-    CLog::Log(LOGWARNING, "{} - File is larger than 1 MB, most likely not a playlist",
-              __FUNCTION__);
+    CLog::LogF(LOGWARNING, "File is larger than 1 MB, most likely not a playlist");
     return false;
   }
 

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -192,7 +192,7 @@ void CPowerManager::OnSleep()
   if (dialog)
     dialog->Open();
 
-  CLog::Log(LOGINFO, "{}: Running sleep jobs", __FUNCTION__);
+  CLog::LogF(LOGINFO, "Running sleep jobs");
 
   StorePlayerState();
 
@@ -208,7 +208,7 @@ void CPowerManager::OnSleep()
 
 void CPowerManager::OnWake()
 {
-  CLog::Log(LOGINFO, "{}: Running resume jobs", __FUNCTION__);
+  CLog::LogF(LOGINFO, "Running resume jobs");
 
   CServiceBroker::GetNetwork().WaitForNet();
 
@@ -245,7 +245,7 @@ void CPowerManager::OnWake()
 
 void CPowerManager::OnLowBattery()
 {
-  CLog::Log(LOGINFO, "{}: Running low battery jobs", __FUNCTION__);
+  CLog::LogF(LOGINFO, "Running low battery jobs");
 
   CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(13050), "");
 

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -543,7 +543,7 @@ const CProfile& CProfileManager::GetMasterProfile() const
   if (!m_profiles.empty())
     return m_profiles[0];
 
-  CLog::Log(LOGERROR, "{}: master profile doesn't exist", __FUNCTION__);
+  CLog::LogF(LOGERROR, "master profile doesn't exist");
   return EmptyProfile;
 }
 

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -254,9 +254,8 @@ bool DX::DeviceResources::SetFullScreen(bool fullscreen, RESOLUTION_INFO& res)
         // some drivers unable to create stereo swapchain if mode does not match @23.976
         || CServiceBroker::GetWinSystem()->GetGfxContext().GetStereoMode() == RENDER_STEREO_MODE_HARDWAREBASED)
       {
-        CLog::Log(LOGDEBUG, __FUNCTION__ ": changing display mode to {}x{}@{:0.3f}", res.iWidth,
-                  res.iHeight, res.fRefreshRate,
-                  res.dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "");
+        CLog::LogF(LOGDEBUG, "changing display mode to {}x{}@{:0.3f}", res.iWidth, res.iHeight,
+                   res.fRefreshRate, res.dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "");
 
         int refresh = static_cast<int>(res.fRefreshRate);
         int i = (refresh + 1) % 24 == 0 || (refresh + 1) % 30 == 0 ? 1 : 0;

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -163,7 +163,7 @@ void CRenderSystemDX::CheckInterlacedStereoView()
     DXGI_FORMAT texFormat = m_deviceResources->GetBackBuffer().GetFormat();
     if (!m_rightEyeTex.Create(outputSize.Width, outputSize.Height, 1, D3D11_USAGE_DEFAULT, texFormat))
     {
-      CLog::Log(LOGERROR, "{} - Failed to create right eye buffer.", __FUNCTION__);
+      CLog::LogF(LOGERROR, "Failed to create right eye buffer.");
       CServiceBroker::GetWinSystem()->GetGfxContext().SetStereoMode(RENDER_STEREO_MODE_SPLIT_HORIZONTAL); // try fallback to split horizontal
     }
     else

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -49,8 +49,8 @@ bool CRenderSystemGL::InitRenderSystem()
     m_RenderVersion = ver;
   }
 
-  CLog::Log(LOGINFO, "CRenderSystemGL::{} - Version: {}, Major: {}, Minor: {}", __FUNCTION__, ver,
-            m_RenderVersionMajor, m_RenderVersionMinor);
+  CLog::LogF(LOGINFO, "CRenderSystemGL: Version: {}, Major: {}, Minor: {}", ver,
+             m_RenderVersionMajor, m_RenderVersionMinor);
 
   m_RenderExtensions  = " ";
   if (m_RenderVersionMajor > 3 ||

--- a/xbmc/settings/SettingsValueFlatJsonSerializer.cpp
+++ b/xbmc/settings/SettingsValueFlatJsonSerializer.cpp
@@ -36,7 +36,7 @@ std::string CSettingsValueFlatJsonSerializer::SerializeValues(
   if (!CJSONVariantWriter::Write(root, result, m_compact))
   {
     CLog::Log(LOGWARNING,
-      "CSettingsValueFlatJsonSerializer: failed to serialize settings into JSON");
+              "CSettingsValueFlatJsonSerializer: failed to serialize settings into JSON");
     return "";
   }
 
@@ -131,9 +131,11 @@ CVariant CSettingsValueFlatJsonSerializer::SerializeSettingValue(
 
     case SettingType::Unknown:
     default:
-      CLog::Log(LOGWARNING,
-        "CSettingsValueFlatJsonSerializer: failed to serialize setting \"{}\" with value \"{}\" " \
-        "of unknown type", setting->GetId(), setting->ToString());
+      CLog::Log(
+          LOGWARNING,
+          "CSettingsValueFlatJsonSerializer: failed to serialize setting \"{}\" with value \"{}\" "
+          "of unknown type",
+          setting->GetId(), setting->ToString());
       return CVariant::ConstNullVariant;
   }
 }

--- a/xbmc/settings/SettingsValueXmlSerializer.cpp
+++ b/xbmc/settings/SettingsValueXmlSerializer.cpp
@@ -96,6 +96,7 @@ void CSettingsValueXmlSerializer::SerializeSetting(TiXmlNode* parent,
 
   if (parent->InsertEndChild(settingElement) == nullptr)
     CLog::Log(LOGWARNING,
-      "CSettingsValueXmlSerializer: unable to write <" SETTING_XML_ELM_SETTING " id=\"{}\"> tag",
-      setting->GetId());
+              "CSettingsValueXmlSerializer: unable to write <" SETTING_XML_ELM_SETTING
+              " id=\"{}\"> tag",
+              setting->GetId());
 }

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
@@ -258,8 +258,7 @@ void CGUIDialogContentSettings::OnSettingAction(const std::shared_ptr<const CSet
       }
       else
       {
-        CLog::Log(LOGERROR, "{} - Could not get settings for addon: {}", __FUNCTION__,
-                  selectedAddonId);
+        CLog::LogF(LOGERROR, "Could not get settings for addon: {}", selectedAddonId);
       }
     }
   }

--- a/xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
@@ -434,7 +434,7 @@ int CGUIDialogLibExportSettings::GetExportItemsFromSetting(const SettingConstPtr
   std::shared_ptr<const CSettingList> settingList = std::static_pointer_cast<const CSettingList>(setting);
   if (settingList->GetElementType() != SettingType::Integer)
   {
-    CLog::Log(LOGERROR, "CGUIDialogLibExportSettings::{} - wrong items element type", __FUNCTION__);
+    CLog::LogF(LOGERROR, "CGUIDialogLibExportSettings: wrong items element type");
     return 0;
   }
   int exportitems = 0;
@@ -443,7 +443,7 @@ int CGUIDialogLibExportSettings::GetExportItemsFromSetting(const SettingConstPtr
   {
     if (!value.isInteger())
     {
-      CLog::Log(LOGERROR, "CGUIDialogLibExportSettings::{} - wrong items value type", __FUNCTION__);
+      CLog::LogF(LOGERROR, "CGUIDialogLibExportSettings: wrong items value type");
       return 0;
     }
     exportitems += static_cast<int>(value.asInteger());

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -712,8 +712,8 @@ void CMediaManager::OnStorageAdded(const MEDIA_DETECT::STORAGE::StorageDevice& d
         {
           return;
         }
-        CLog::Log(LOGDEBUG, "{}: Could not execute autorun for optical disc with path {}",
-                  __FUNCTION__, device.path);
+        CLog::LogF(LOGDEBUG, "Could not execute autorun for optical disc with path {}",
+                   device.path);
       }
       CServiceBroker::GetJobManager()->AddJob(new CAutorunMediaJob(device.label, device.path), this,
                                               CJob::PRIORITY_HIGH);

--- a/xbmc/storage/cdioSupport.cpp
+++ b/xbmc/storage/cdioSupport.cpp
@@ -686,7 +686,7 @@ CCdInfo* CCdIoSupport::GetCdInfo(char* cDeviceFileName)
   cdio = ::cdio_open(source_name, DRIVER_UNKNOWN);
   if (cdio == NULL)
   {
-    CLog::Log(LOGERROR, "{}: Error in automatically selecting driver with input", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Error in automatically selecting driver with input");
     return NULL;
   }
 

--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -67,8 +67,7 @@ void CThread::Create(bool bAutoDelete)
       StopThread(true);  // so let's just clean up
     else
     { // otherwise we have a problem.
-      CLog::Log(LOGERROR, "{} - fatal error creating thread {} - old thread id not null",
-                __FUNCTION__, m_ThreadName);
+      CLog::LogF(LOGERROR, "fatal error creating thread {} - old thread id not null", m_ThreadName);
       exit(1);
     }
   }
@@ -115,7 +114,7 @@ void CThread::Create(bool bAutoDelete)
 
         if (pThread == nullptr)
         {
-          CLog::Log(LOGERROR, "{}, sanity failed. thread is NULL.", __FUNCTION__);
+          CLog::LogF(LOGERROR, "sanity failed. thread is NULL.");
           promise.set_value(false);
           return;
         }

--- a/xbmc/utils/AliasShortcutUtils.cpp
+++ b/xbmc/utils/AliasShortcutUtils.cpp
@@ -48,7 +48,7 @@ void TranslateAliasShortcut(std::string& path)
   // Linux does not use alias or shortcut methods
 #elif defined(TARGET_WINDOWS_STORE)
   // Win10 does not use alias or shortcut methods
-  CLog::Log(LOGDEBUG, "{} is not implemented", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "is not implemented");
 #elif defined(TARGET_WINDOWS)
 /* Needs testing under Windows platform so ignore shortcuts for now
   CComPtr<IShellLink> ipShellLink;

--- a/xbmc/utils/Archive.cpp
+++ b/xbmc/utils/Archive.cpp
@@ -397,7 +397,7 @@ void CArchive::FlushBuffer()
   if (m_iMode == store && m_BufferPos != m_pBuffer.get())
   {
     if (m_pFile->Write(m_pBuffer.get(), m_BufferPos - m_pBuffer.get()) != m_BufferPos - m_pBuffer.get())
-      CLog::Log(LOGERROR, "{}: Error flushing buffer", __FUNCTION__);
+      CLog::LogF(LOGERROR, "Error flushing buffer");
     else
     {
       m_BufferPos = m_pBuffer.get();
@@ -445,9 +445,9 @@ CArchive &CArchive::streamin_bufferwrap(uint8_t *ptr, size_t size)
       FillBuffer();
       if (m_BufferRemain < CARCHIVE_BUFFER_MAX && m_BufferRemain < size)
       {
-        CLog::Log(LOGERROR, "{}: can't stream in: requested {} bytes, was read {} bytes",
-                  __FUNCTION__, static_cast<unsigned long>(orig_size),
-                  static_cast<unsigned long>(ptr - orig_ptr + m_BufferRemain));
+        CLog::LogF(LOGERROR, "can't stream in: requested {} bytes, was read {} bytes",
+                   static_cast<unsigned long>(orig_size),
+                   static_cast<unsigned long>(ptr - orig_ptr + m_BufferRemain));
 
         memset(orig_ptr, 0, orig_size);
         return *this;

--- a/xbmc/utils/CharArrayParser.cpp
+++ b/xbmc/utils/CharArrayParser.cpp
@@ -42,7 +42,7 @@ bool CCharArrayParser::SetPosition(int position)
     m_position = position;
   else
   {
-    CLog::Log(LOGERROR, "{} - Position out of range", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Position out of range");
     return false;
   }
   return true;
@@ -58,11 +58,11 @@ uint8_t CCharArrayParser::ReadNextUnsignedChar()
   m_position++;
   if (!m_data)
   {
-    CLog::Log(LOGERROR, "{} - No data to read", __FUNCTION__);
+    CLog::LogF(LOGERROR, "No data to read");
     return 0;
   }
   if (m_position > m_limit)
-    CLog::Log(LOGERROR, "{} - Position out of range", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Position out of range");
   return static_cast<uint8_t>(m_data[m_position - 1]) & 0xFF;
 }
 
@@ -70,12 +70,12 @@ uint16_t CCharArrayParser::ReadNextUnsignedShort()
 {
   if (!m_data)
   {
-    CLog::Log(LOGERROR, "{} - No data to read", __FUNCTION__);
+    CLog::LogF(LOGERROR, "No data to read");
     return 0;
   }
   m_position += 2;
   if (m_position > m_limit)
-    CLog::Log(LOGERROR, "{} - Position out of range", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Position out of range");
   return (static_cast<uint16_t>(m_data[m_position - 2]) & 0xFF) << 8 |
          (static_cast<uint16_t>(m_data[m_position - 1]) & 0xFF);
 }
@@ -84,12 +84,12 @@ uint32_t CCharArrayParser::ReadNextUnsignedInt()
 {
   if (!m_data)
   {
-    CLog::Log(LOGERROR, "{} - No data to read", __FUNCTION__);
+    CLog::LogF(LOGERROR, "No data to read");
     return 0;
   }
   m_position += 4;
   if (m_position > m_limit)
-    CLog::Log(LOGERROR, "{} - Position out of range", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Position out of range");
   return (static_cast<uint32_t>(m_data[m_position - 4]) & 0xFF) << 24 |
          (static_cast<uint32_t>(m_data[m_position - 3]) & 0xFF) << 16 |
          (static_cast<uint32_t>(m_data[m_position - 2]) & 0xFF) << 8 |
@@ -100,13 +100,13 @@ std::string CCharArrayParser::ReadNextString(int length)
 {
   if (!m_data)
   {
-    CLog::Log(LOGERROR, "{} - No data to read", __FUNCTION__);
+    CLog::LogF(LOGERROR, "No data to read");
     return "";
   }
   std::string str(m_data + m_position, length);
   m_position += length;
   if (m_position > m_limit)
-    CLog::Log(LOGERROR, "{} - Position out of range", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Position out of range");
   return str;
 }
 
@@ -114,12 +114,12 @@ bool CCharArrayParser::ReadNextArray(int length, char* data)
 {
   if (!m_data)
   {
-    CLog::Log(LOGERROR, "{} - No data to read", __FUNCTION__);
+    CLog::LogF(LOGERROR, "No data to read");
     return false;
   }
   if (m_position + length > m_limit)
   {
-    CLog::Log(LOGERROR, "{} - Position out of range", __FUNCTION__);
+    CLog::LogF(LOGERROR, "Position out of range");
     return false;
   }
   std::strncpy(data, m_data + m_position, length);
@@ -131,7 +131,7 @@ bool CCharArrayParser::ReadNextLine(std::string& line)
 {
   if (!m_data)
   {
-    CLog::Log(LOGERROR, "{} - No data to read", __FUNCTION__);
+    CLog::LogF(LOGERROR, "No data to read");
     return false;
   }
   if (CharsLeft() == 0)

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -182,8 +182,8 @@ iconv_t CConverterType::GetConverter(std::unique_lock<CCriticalSection>& convert
     m_iconv = iconv_open(m_targetCharset.c_str(), m_sourceCharset.c_str());
 
     if (m_iconv == NO_ICONV)
-      CLog::Log(LOGERROR, "{}: iconv_open() for \"{}\" -> \"{}\" failed, errno = {} ({})",
-                __FUNCTION__, m_sourceCharset, m_targetCharset, errno, strerror(errno));
+      CLog::LogF(LOGERROR, "iconv_open() for \"{}\" -> \"{}\" failed, errno = {} ({})",
+                 m_sourceCharset, m_targetCharset, errno, strerror(errno));
   }
 
   return m_iconv;
@@ -342,8 +342,8 @@ bool CCharsetConverter::CInnerConverter::customConvert(const std::string& source
   iconv_t conv = iconv_open(targetCharset.c_str(), sourceCharset.c_str());
   if (conv == NO_ICONV)
   {
-    CLog::Log(LOGERROR, "{}: iconv_open() for \"{}\" -> \"{}\" failed, errno = {} ({})",
-              __FUNCTION__, sourceCharset, targetCharset, errno, strerror(errno));
+    CLog::LogF(LOGERROR, "iconv_open() for \"{}\" -> \"{}\" failed, errno = {} ({})", sourceCharset,
+               targetCharset, errno, strerror(errno));
     return false;
   }
   const int dstMultp = (targetCharset.compare(0, 5, "UTF-8") == 0) ? CCharsetConverter::m_Utf8CharMaxSize : 1;
@@ -381,7 +381,7 @@ bool CCharsetConverter::CInnerConverter::convert(iconv_t type, int multiplier, c
   char*       outBuf     = (char*)malloc(outBufSize);
   if (outBuf == NULL)
   {
-    CLog::Log(LOGFATAL, "{}: malloc failed", __FUNCTION__);
+    CLog::LogF(LOGFATAL, "malloc failed");
     return false;
   }
 
@@ -408,8 +408,7 @@ bool CCharsetConverter::CInnerConverter::convert(iconv_t type, int multiplier, c
         char* newBuf  = (char*)realloc(outBuf, outBufSize);
         if (!newBuf)
         {
-          CLog::Log(LOGFATAL, "{} realloc failed with errno={}({})", __FUNCTION__, errno,
-                    strerror(errno));
+          CLog::LogF(LOGFATAL, "realloc failed with errno={}({})", errno, strerror(errno));
           break;
         }
         outBuf = newBuf;
@@ -441,8 +440,7 @@ bool CCharsetConverter::CInnerConverter::convert(iconv_t type, int multiplier, c
       }
       else //iconv() had some other error
       {
-        CLog::Log(LOGERROR, "{}: iconv() failed, errno={} ({})", __FUNCTION__, errno,
-                  strerror(errno));
+        CLog::LogF(LOGERROR, "iconv() failed, errno={} ({})", errno, strerror(errno));
       }
     }
     break;
@@ -450,7 +448,7 @@ bool CCharsetConverter::CInnerConverter::convert(iconv_t type, int multiplier, c
 
   //complete the conversion (reset buffers), otherwise the current data will prefix the data on the next call
   if (iconv(type, NULL, NULL, &outBufStart, &outBytesAvail) == (size_t)-1)
-    CLog::Log(LOGERROR, "{} failed cleanup errno={}({})", __FUNCTION__, errno, strerror(errno));
+    CLog::LogF(LOGERROR, "failed cleanup errno={}({})", errno, strerror(errno));
 
   if (returnV == (size_t)-1)
   {
@@ -504,7 +502,7 @@ bool CCharsetConverter::CInnerConverter::logicalToVisualBiDi(
     if (visual == NULL)
     {
       free(visual);
-      CLog::Log(LOGFATAL, "{}: can't allocate memory", __FUNCTION__);
+      CLog::LogF(LOGFATAL, "can't allocate memory");
       return false;
     }
 

--- a/xbmc/utils/CharsetDetection.cpp
+++ b/xbmc/utils/CharsetDetection.cpp
@@ -339,8 +339,8 @@ bool CCharsetDetection::ConvertHtmlToUtf8(const std::string& htmlContent, std::s
   else
     usedHtmlCharset = "WINDOWS-1252";
 
-  CLog::Log(LOGWARNING, "{}: Can't correctly convert to UTF-8 charset, converting as \"{}\"",
-            __FUNCTION__, usedHtmlCharset);
+  CLog::LogF(LOGWARNING, "Can't correctly convert to UTF-8 charset, converting as \"{}\"",
+             usedHtmlCharset);
   g_charsetConverter.ToUtf8(usedHtmlCharset, htmlContent, converted, false);
 
   return false;
@@ -411,8 +411,8 @@ bool CCharsetDetection::ConvertPlainTextToUtf8(const std::string& textContent, s
   else
     usedCharset = "WINDOWS-1252";
 
-  CLog::Log(LOGWARNING, "{}: Can't correctly convert to UTF-8 charset, converting as \"{}\"",
-            __FUNCTION__, usedCharset);
+  CLog::LogF(LOGWARNING, "Can't correctly convert to UTF-8 charset, converting as \"{}\"",
+             usedCharset);
   g_charsetConverter.ToUtf8(usedCharset, textContent, converted, false);
 
   return false;

--- a/xbmc/utils/DMAHeapBufferObject.cpp
+++ b/xbmc/utils/DMAHeapBufferObject.cpp
@@ -46,8 +46,7 @@ void CDMAHeapBufferObject::Register()
     int fd = open(path, O_RDWR);
     if (fd < 0)
     {
-      CLog::Log(LOGDEBUG, "CDMAHeapBufferObject::{} unable to open {}: {}", __FUNCTION__, path,
-                strerror(errno));
+      CLog::LogF(LOGDEBUG, "CDMAHeapBufferObject: unable to open {}: {}", path, strerror(errno));
       continue;
     }
 
@@ -59,7 +58,7 @@ void CDMAHeapBufferObject::Register()
   if (!DMA_HEAP_PATH)
     return;
 
-  CLog::Log(LOGDEBUG, "CDMAHeapBufferObject::{} - using {}", __FUNCTION__, DMA_HEAP_PATH);
+  CLog::LogF(LOGDEBUG, "CDMAHeapBufferObject: using {}", DMA_HEAP_PATH);
 
   CBufferObjectFactory::RegisterBufferObject(CDMAHeapBufferObject::Create);
 }
@@ -120,8 +119,8 @@ bool CDMAHeapBufferObject::CreateBufferObject(uint64_t size)
   int ret = ioctl(m_dmaheapfd, DMA_HEAP_IOCTL_ALLOC, &allocData);
   if (ret < 0)
   {
-    CLog::Log(LOGERROR, "CDMAHeapBufferObject::{} - ioctl DMA_HEAP_IOCTL_ALLOC failed, errno={}",
-              __FUNCTION__, strerror(errno));
+    CLog::LogF(LOGERROR, "CDMAHeapBufferObject: ioctl DMA_HEAP_IOCTL_ALLOC failed, errno={}",
+               strerror(errno));
     return false;
   }
 
@@ -130,8 +129,8 @@ bool CDMAHeapBufferObject::CreateBufferObject(uint64_t size)
 
   if (m_fd < 0 || m_size <= 0)
   {
-    CLog::Log(LOGERROR, "CDMAHeapBufferObject::{} - invalid allocation data: fd={} len={}",
-              __FUNCTION__, m_fd, m_size);
+    CLog::LogF(LOGERROR, "CDMAHeapBufferObject: invalid allocation data: fd={} len={}", m_fd,
+               m_size);
     return false;
   }
 
@@ -145,8 +144,7 @@ void CDMAHeapBufferObject::DestroyBufferObject()
 
   int ret = close(m_fd);
   if (ret < 0)
-    CLog::Log(LOGERROR, "CDMAHeapBufferObject::{} - close failed, errno={}", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CDMAHeapBufferObject: close failed, errno={}", strerror(errno));
 
   m_fd = -1;
   m_stride = 0;
@@ -160,16 +158,15 @@ uint8_t* CDMAHeapBufferObject::GetMemory()
 
   if (m_map)
   {
-    CLog::Log(LOGDEBUG, "CDMAHeapBufferObject::{} - already mapped fd={} map={}", __FUNCTION__,
-              m_fd, fmt::ptr(m_map));
+    CLog::LogF(LOGDEBUG, "CDMAHeapBufferObject: already mapped fd={} map={}", m_fd,
+               fmt::ptr(m_map));
     return m_map;
   }
 
   m_map = static_cast<uint8_t*>(mmap(nullptr, m_size, PROT_WRITE, MAP_SHARED, m_fd, 0));
   if (m_map == MAP_FAILED)
   {
-    CLog::Log(LOGERROR, "CDMAHeapBufferObject::{} - mmap failed, errno={}", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CDMAHeapBufferObject: mmap failed, errno={}", strerror(errno));
     return nullptr;
   }
 
@@ -183,8 +180,7 @@ void CDMAHeapBufferObject::ReleaseMemory()
 
   int ret = munmap(m_map, m_size);
   if (ret < 0)
-    CLog::Log(LOGERROR, "CDMAHeapBufferObject::{} - munmap failed, errno={}", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CDMAHeapBufferObject: munmap failed, errno={}", strerror(errno));
 
   m_map = nullptr;
 }

--- a/xbmc/utils/DumbBufferObject.cpp
+++ b/xbmc/utils/DumbBufferObject.cpp
@@ -74,8 +74,8 @@ bool CDumbBufferObject::CreateBufferObject(uint32_t format, uint32_t width, uint
   int ret = drmIoctl(m_device, DRM_IOCTL_MODE_CREATE_DUMB, &create_dumb);
   if (ret < 0)
   {
-    CLog::Log(LOGERROR, "CDumbBufferObject::{} - ioctl DRM_IOCTL_MODE_CREATE_DUMB failed, errno={}",
-              __FUNCTION__, strerror(errno));
+    CLog::LogF(LOGERROR, "CDumbBufferObject: ioctl DRM_IOCTL_MODE_CREATE_DUMB failed, errno={}",
+               strerror(errno));
     return false;
   }
 
@@ -85,8 +85,8 @@ bool CDumbBufferObject::CreateBufferObject(uint32_t format, uint32_t width, uint
   ret = drmPrimeHandleToFD(m_device, create_dumb.handle, 0, &m_fd);
   if (ret < 0)
   {
-    CLog::Log(LOGERROR, "CDumbBufferObject::{} - failed to get fd from prime handle, errno={}",
-              __FUNCTION__, strerror(errno));
+    CLog::LogF(LOGERROR, "CDumbBufferObject: failed to get fd from prime handle, errno={}",
+               strerror(errno));
     return false;
   }
 
@@ -100,8 +100,7 @@ void CDumbBufferObject::DestroyBufferObject()
 
   int ret = close(m_fd);
   if (ret < 0)
-    CLog::Log(LOGERROR, "CDumbBufferObject::{} - close failed, errno={}", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CDumbBufferObject: close failed, errno={}", strerror(errno));
 
   m_fd = -1;
   m_stride = 0;
@@ -115,8 +114,7 @@ uint8_t* CDumbBufferObject::GetMemory()
 
   if (m_map)
   {
-    CLog::Log(LOGDEBUG, "CDumbBufferObject::{} - already mapped fd={} map={}", __FUNCTION__, m_fd,
-              fmt::ptr(m_map));
+    CLog::LogF(LOGDEBUG, "CDumbBufferObject: already mapped fd={} map={}", m_fd, fmt::ptr(m_map));
     return m_map;
   }
 
@@ -124,8 +122,8 @@ uint8_t* CDumbBufferObject::GetMemory()
   int ret = drmPrimeFDToHandle(m_device, m_fd, &handle);
   if (ret < 0)
   {
-    CLog::Log(LOGERROR, "CDumbBufferObject::{} - failed to get handle from prime fd, errno={}",
-              __FUNCTION__, strerror(errno));
+    CLog::LogF(LOGERROR, "CDumbBufferObject: failed to get handle from prime fd, errno={}",
+               strerror(errno));
     return nullptr;
   }
 
@@ -135,8 +133,8 @@ uint8_t* CDumbBufferObject::GetMemory()
   ret = drmIoctl(m_device, DRM_IOCTL_MODE_MAP_DUMB, &map_dumb);
   if (ret < 0)
   {
-    CLog::Log(LOGERROR, "CDumbBufferObject::{} - ioctl DRM_IOCTL_MODE_MAP_DUMB failed, errno={}",
-              __FUNCTION__, strerror(errno));
+    CLog::LogF(LOGERROR, "CDumbBufferObject: ioctl DRM_IOCTL_MODE_MAP_DUMB failed, errno={}",
+               strerror(errno));
     return nullptr;
   }
 
@@ -145,8 +143,7 @@ uint8_t* CDumbBufferObject::GetMemory()
   m_map = static_cast<uint8_t*>(mmap(nullptr, m_size, PROT_WRITE, MAP_SHARED, m_device, m_offset));
   if (m_map == MAP_FAILED)
   {
-    CLog::Log(LOGERROR, "CDumbBufferObject::{} - mmap failed, errno={}", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CDumbBufferObject: mmap failed, errno={}", strerror(errno));
     return nullptr;
   }
 
@@ -160,8 +157,7 @@ void CDumbBufferObject::ReleaseMemory()
 
   int ret = munmap(m_map, m_size);
   if (ret < 0)
-    CLog::Log(LOGERROR, "CDumbBufferObject::{} - munmap failed, errno={}", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CDumbBufferObject: munmap failed, errno={}", strerror(errno));
 
   m_map = nullptr;
   m_offset = 0;

--- a/xbmc/utils/EGLImage.cpp
+++ b/xbmc/utils/EGLImage.cpp
@@ -182,13 +182,13 @@ bool CEGLImage::CreateImage(EglAttrs imageAttrs)
       eglString.append(StringUtils::Format("{}: {}\n", keyStr, valueStr));
     }
 
-    CLog::Log(LOGDEBUG, "CEGLImage::{} - attributes:\n{}", __FUNCTION__, eglString);
+    CLog::LogF(LOGDEBUG, "CEGLImage: attributes:\n{}", eglString);
   }
 
   if (!m_image)
   {
-    CLog::Log(LOGERROR, "CEGLImage::{} - failed to import buffer into EGL image: {:#4x}",
-              __FUNCTION__, eglGetError());
+    CLog::LogF(LOGERROR, "CEGLImage: failed to import buffer into EGL image: {:#4x}",
+               eglGetError());
     return false;
   }
 
@@ -215,17 +215,15 @@ bool CEGLImage::SupportsFormat(uint32_t format)
   EGLint numFormats;
   if (eglQueryDmaBufFormatsEXT(m_display, 0, nullptr, &numFormats) != EGL_TRUE)
   {
-    CLog::Log(LOGERROR,
-              "CEGLImage::{} - failed to query the max number of EGL dma-buf formats: {:#4x}",
-              __FUNCTION__, eglGetError());
+    CLog::LogF(LOGERROR, "CEGLImage: failed to query the max number of EGL dma-buf formats: {:#4x}",
+               eglGetError());
     return false;
   }
 
   std::vector<EGLint> formats(numFormats);
   if (eglQueryDmaBufFormatsEXT(m_display, numFormats, formats.data(), &numFormats) != EGL_TRUE)
   {
-    CLog::Log(LOGERROR, "CEGLImage::{} - failed to query EGL dma-buf formats: {:#4x}", __FUNCTION__,
-              eglGetError());
+    CLog::LogF(LOGERROR, "CEGLImage: failed to query EGL dma-buf formats: {:#4x}", eglGetError());
     return false;
   }
 
@@ -236,7 +234,7 @@ bool CEGLImage::SupportsFormat(uint32_t format)
     for (const auto& supportedFormat : formats)
       formatStr.append("\n" + DRMHELPERS::FourCCToString(supportedFormat));
 
-    CLog::Log(LOGDEBUG, "CEGLImage::{} - supported formats:{}", __FUNCTION__, formatStr);
+    CLog::LogF(LOGDEBUG, "CEGLImage: supported formats:{}", formatStr);
   }
 
   if (foundFormat != formats.end())
@@ -246,8 +244,7 @@ bool CEGLImage::SupportsFormat(uint32_t format)
     return true;
   }
 
-  CLog::Log(LOGERROR, "CEGLImage::{} - format not supported: {}", __FUNCTION__,
-            DRMHELPERS::FourCCToString(format));
+  CLog::LogF(LOGERROR, "CEGLImage: format not supported: {}", DRMHELPERS::FourCCToString(format));
 
   return false;
 }
@@ -274,10 +271,10 @@ bool CEGLImage::SupportsFormatAndModifier(uint32_t format, uint64_t modifier)
   EGLint numFormats;
   if (eglQueryDmaBufModifiersEXT(m_display, format, 0, nullptr, nullptr, &numFormats) != EGL_TRUE)
   {
-    CLog::Log(LOGERROR,
-              "CEGLImage::{} - failed to query the max number of EGL dma-buf format modifiers for "
-              "format: {} - {:#4x}",
-              __FUNCTION__, DRMHELPERS::FourCCToString(format), eglGetError());
+    CLog::LogF(LOGERROR,
+               "CEGLImage: failed to query the max number of EGL dma-buf format modifiers for "
+               "format: {} - {:#4x}",
+               DRMHELPERS::FourCCToString(format), eglGetError());
     return false;
   }
 
@@ -286,10 +283,9 @@ bool CEGLImage::SupportsFormatAndModifier(uint32_t format, uint64_t modifier)
   if (eglQueryDmaBufModifiersEXT(m_display, format, numFormats, modifiers.data(), nullptr,
                                  &numFormats) != EGL_TRUE)
   {
-    CLog::Log(
-        LOGERROR,
-        "CEGLImage::{} - failed to query EGL dma-buf format modifiers for format: {} - {:#4x}",
-        __FUNCTION__, DRMHELPERS::FourCCToString(format), eglGetError());
+    CLog::LogF(LOGERROR,
+               "CEGLImage: failed to query EGL dma-buf format modifiers for format: {} - {:#4x}",
+               DRMHELPERS::FourCCToString(format), eglGetError());
     return false;
   }
 
@@ -300,7 +296,7 @@ bool CEGLImage::SupportsFormatAndModifier(uint32_t format, uint64_t modifier)
     for (const auto& supportedModifier : modifiers)
       modifierStr.append("\n" + DRMHELPERS::ModifierToString(supportedModifier));
 
-    CLog::Log(LOGDEBUG, "CEGLImage::{} - supported modifiers:{}", __FUNCTION__, modifierStr);
+    CLog::LogF(LOGDEBUG, "CEGLImage: supported modifiers:{}", modifierStr);
   }
 
   if (foundModifier != modifiers.end())
@@ -310,8 +306,8 @@ bool CEGLImage::SupportsFormatAndModifier(uint32_t format, uint64_t modifier)
     return true;
   }
 
-  CLog::Log(LOGERROR, "CEGLImage::{} - modifier ({}) not supported for format ({})", __FUNCTION__,
-            DRMHELPERS::ModifierToString(modifier), DRMHELPERS::FourCCToString(format));
+  CLog::LogF(LOGERROR, "CEGLImage: modifier ({}) not supported for format ({})",
+             DRMHELPERS::ModifierToString(modifier), DRMHELPERS::FourCCToString(format));
 
   return false;
 }

--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -179,7 +179,7 @@ CDateTime CFileUtils::GetModificationDate(const int& code, const std::string& st
   CDateTime dateAdded;
   if (strFileNameAndPath.empty())
   {
-    CLog::Log(LOGDEBUG, "{} empty strFileNameAndPath variable", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "empty strFileNameAndPath variable");
     return dateAdded;
   }
 
@@ -245,8 +245,7 @@ CDateTime CFileUtils::GetModificationDate(const int& code, const std::string& st
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} unable to extract modification date for file ({})", __FUNCTION__,
-              strFileNameAndPath);
+    CLog::LogF(LOGERROR, "unable to extract modification date for file ({})", strFileNameAndPath);
   }
   return dateAdded;
 }
@@ -292,7 +291,7 @@ bool CFileUtils::CheckFileAccessAllowed(const std::string &filePath)
   {
     if (decodePath.find(b) != std::string::npos)
     {
-      CLog::Log(LOGERROR, "{} denied access to {}", __FUNCTION__, decodePath);
+      CLog::LogF(LOGERROR, "denied access to {}", decodePath);
       return false;
     }
   }

--- a/xbmc/utils/GLUtils.cpp
+++ b/xbmc/utils/GLUtils.cpp
@@ -129,12 +129,13 @@ void KODI::UTILS::GL::GlErrorCallback(GLenum source, GLenum type, GLuint id, GLe
 
 static void PrintMatrix(const GLfloat* matrix, const std::string& matrixName)
 {
-  CLog::Log(LOGDEBUG, "{}:\n{:> 10.3f} {:> 10.3f} {:> 10.3f} {:> 10.3f}\n{:> 10.3f} {:> 10.3f} {:> 10.3f} {:> 10.3f}\n{:> 10.3f} {:> 10.3f} {:> 10.3f} {:> 10.3f}\n{:> 10.3f} {:> 10.3f} {:> 10.3f} {:> 10.3f}",
-                      matrixName,
-                      matrix[0], matrix[1], matrix[2], matrix[3],
-                      matrix[4], matrix[5], matrix[6], matrix[7],
-                      matrix[8], matrix[9], matrix[10], matrix[11],
-                      matrix[12], matrix[13], matrix[14], matrix[15]);
+  CLog::Log(LOGDEBUG,
+            "{}:\n{:> 10.3f} {:> 10.3f} {:> 10.3f} {:> 10.3f}\n{:> 10.3f} {:> 10.3f} {:> 10.3f} "
+            "{:> 10.3f}\n{:> 10.3f} {:> 10.3f} {:> 10.3f} {:> 10.3f}\n{:> 10.3f} {:> 10.3f} {:> "
+            "10.3f} {:> 10.3f}",
+            matrixName, matrix[0], matrix[1], matrix[2], matrix[3], matrix[4], matrix[5], matrix[6],
+            matrix[7], matrix[8], matrix[9], matrix[10], matrix[11], matrix[12], matrix[13],
+            matrix[14], matrix[15]);
 }
 
 void _VerifyGLState(const char* szfile, const char* szfunction, int lineno)

--- a/xbmc/utils/JobManager.cpp
+++ b/xbmc/utils/JobManager.cpp
@@ -56,7 +56,7 @@ void CJobWorker::Process()
     }
     catch (...)
     {
-      CLog::Log(LOGERROR, "{} error processing job {}", __FUNCTION__, job->GetType());
+      CLog::LogF(LOGERROR, "error processing job {}", job->GetType());
     }
     m_jobManager->OnJobComplete(success, job);
   }
@@ -411,7 +411,7 @@ void CJobManager::OnJobComplete(bool success, CJob *job)
     }
     catch (...)
     {
-      CLog::Log(LOGERROR, "{} error processing job {}", __FUNCTION__, item.m_job->GetType());
+      CLog::LogF(LOGERROR, "error processing job {}", item.m_job->GetType());
     }
     lock.lock();
     Processing::iterator j = find(m_processing.begin(), m_processing.end(), job);

--- a/xbmc/utils/POUtils.cpp
+++ b/xbmc/utils/POUtils.cpp
@@ -35,8 +35,7 @@ bool CPODocument::LoadFile(const std::string &pofilename)
   std::vector<uint8_t> buf;
   if (file.LoadFile(poFileUrl, buf) < 18) // at least a size of a minimalistic header
   {
-    CLog::Log(LOGERROR, "{}: can't load file \"{}\" or file is too small", __FUNCTION__,
-              pofilename);
+    CLog::LogF(LOGERROR, "can't load file \"{}\" or file is too small", pofilename);
     return false;
   }
 

--- a/xbmc/utils/RegExp.cpp
+++ b/xbmc/utils/RegExp.cpp
@@ -253,7 +253,7 @@ CRegExp& CRegExp::operator=(const CRegExp& re)
         m_iOptions = re.m_iOptions;
       }
       else
-        CLog::Log(LOGFATAL, "{}: Failed to allocate memory", __FUNCTION__);
+        CLog::LogF(LOGFATAL, "Failed to allocate memory");
     }
   }
   return *this;
@@ -300,8 +300,7 @@ bool CRegExp::RegComp(const char *re, studyMode study /*= NoStudy*/)
     m_sd = pcre_study(m_re, studyOptions, &errMsg);
     if (errMsg != NULL)
     {
-      CLog::Log(LOGWARNING, "{}: PCRE error \"{}\" while studying expression", __FUNCTION__,
-                errMsg);
+      CLog::LogF(LOGWARNING, "PCRE error \"{}\" while studying expression", errMsg);
       if (m_sd != NULL)
       {
         pcre_free_study(m_sd);
@@ -343,7 +342,7 @@ int CRegExp::PrivateRegFind(size_t bufferLen, const char *str, unsigned int star
 
   if (startoffset > bufferLen)
   {
-    CLog::Log(LOGERROR, "{}: startoffset is beyond end of string to match", __FUNCTION__);
+    CLog::LogF(LOGERROR, "startoffset is beyond end of string to match");
     return -1;
   }
 
@@ -352,7 +351,7 @@ int CRegExp::PrivateRegFind(size_t bufferLen, const char *str, unsigned int star
   {
     m_jitStack = pcre_jit_stack_alloc(32*1024, 512*1024);
     if (m_jitStack == NULL)
-      CLog::Log(LOGWARNING, "{}: can't allocate address space for JIT stack", __FUNCTION__);
+      CLog::LogF(LOGWARNING, "can't allocate address space for JIT stack");
 
     pcre_assign_jit_stack(m_sd, NULL, m_jitStack);
   }

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -60,13 +60,12 @@ void CSaveFileState::DoWork(CFileItem& item,
     if (item.IsVideo())
     {
       std::string redactPath = CURL::GetRedacted(progressTrackingFile);
-      CLog::Log(LOGDEBUG, "{} - Saving file state for video item {}", __FUNCTION__, redactPath);
+      CLog::LogF(LOGDEBUG, "Saving file state for video item {}", redactPath);
 
       CVideoDatabase videodatabase;
       if (!videodatabase.Open())
       {
-        CLog::Log(LOGWARNING, "{} - Unable to open video database. Can not save file state!",
-                  __FUNCTION__);
+        CLog::LogF(LOGWARNING, "Unable to open video database. Can not save file state!");
       }
       else
       {
@@ -94,8 +93,7 @@ void CSaveFileState::DoWork(CFileItem& item,
             // no watched for not yet finished pvr recordings
             if (!item.IsInProgressPVRRecording())
             {
-              CLog::Log(LOGDEBUG, "{} - Marking video item {} as watched", __FUNCTION__,
-                        redactPath);
+              CLog::LogF(LOGDEBUG, "Marking video item {} as watched", redactPath);
 
               // consider this item as played
               const CDateTime newLastPlayed = videodatabase.IncrementPlayCount(item);
@@ -192,20 +190,19 @@ void CSaveFileState::DoWork(CFileItem& item,
     if (item.IsAudio())
     {
       std::string redactPath = CURL::GetRedacted(progressTrackingFile);
-      CLog::Log(LOGDEBUG, "{} - Saving file state for audio item {}", __FUNCTION__, redactPath);
+      CLog::LogF(LOGDEBUG, "Saving file state for audio item {}", redactPath);
 
       CMusicDatabase musicdatabase;
       if (updatePlayCount)
       {
         if (!musicdatabase.Open())
         {
-          CLog::Log(LOGWARNING, "{} - Unable to open music database. Can not save file state!",
-                    __FUNCTION__);
+          CLog::LogF(LOGWARNING, "Unable to open music database. Can not save file state!");
         }
         else
         {
           // consider this item as played
-          CLog::Log(LOGDEBUG, "{} - Marking audio item {} as listened", __FUNCTION__, redactPath);
+          CLog::LogF(LOGDEBUG, "Marking audio item {} as listened", redactPath);
 
           musicdatabase.IncrementPlayCount(item);
           musicdatabase.Close();

--- a/xbmc/utils/ScraperParser.cpp
+++ b/xbmc/utils/ScraperParser.cpp
@@ -440,8 +440,8 @@ void CScraperParser::ParseNext(TiXmlElement* element)
           ParseExpression(strInput, m_param[iDest - 1],pReg,bAppend);
       }
       else
-        CLog::Log(LOGERROR,"CScraperParser::ParseNext: destination buffer "
-                           "out of bounds, skipping expression");
+        CLog::Log(LOGERROR, "CScraperParser::ParseNext: destination buffer "
+                            "out of bounds, skipping expression");
     }
     pReg = NextSiblingScraperElement(pReg);
   }
@@ -453,7 +453,7 @@ const std::string CScraperParser::Parse(const std::string& strTag,
   TiXmlElement* pChildElement = m_pRootElement->FirstChildElement(strTag.c_str());
   if(pChildElement == NULL)
   {
-    CLog::Log(LOGERROR, "{}: Could not find scraper function {}", __FUNCTION__, strTag);
+    CLog::LogF(LOGERROR, "Could not find scraper function {}", strTag);
     return "";
   }
   int iResult = 1; // default to param 1

--- a/xbmc/utils/ScraperUrl.cpp
+++ b/xbmc/utils/ScraperUrl.cpp
@@ -353,11 +353,10 @@ bool CScraperUrl::Get(const SUrlEntry& scrURL,
     if (iSize > 0)
     {
       strHTML = strBuffer;
-      CLog::Log(LOGDEBUG, "{}: Archive \"{}\" was unpacked in memory", __FUNCTION__, scrURL.m_url);
+      CLog::LogF(LOGDEBUG, "Archive \"{}\" was unpacked in memory", scrURL.m_url);
     }
     else
-      CLog::Log(LOGWARNING, "{}: \"{}\" looks like archive but cannot be unpacked", __FUNCTION__,
-                scrURL.m_url);
+      CLog::LogF(LOGWARNING, "\"{}\" looks like archive but cannot be unpacked", scrURL.m_url);
   }
 
   const auto reportedCharset = http.GetProperty(XFILE::FILE_PROPERTY_CONTENT_CHARSET);
@@ -365,12 +364,10 @@ bool CScraperUrl::Get(const SUrlEntry& scrURL,
   {
     std::string realHtmlCharset, converted;
     if (!CCharsetDetection::ConvertHtmlToUtf8(strHTML, converted, reportedCharset, realHtmlCharset))
-      CLog::Log(LOGWARNING,
-                "{}: Can't find precise charset for HTML \"{}\", using \"{}\" as fallback",
-                __FUNCTION__, scrURL.m_url, realHtmlCharset);
+      CLog::LogF(LOGWARNING, "Can't find precise charset for HTML \"{}\", using \"{}\" as fallback",
+                 scrURL.m_url, realHtmlCharset);
     else
-      CLog::Log(LOGDEBUG, "{}: Using \"{}\" charset for HTML \"{}\"", __FUNCTION__, realHtmlCharset,
-                scrURL.m_url);
+      CLog::LogF(LOGDEBUG, "Using \"{}\" charset for HTML \"{}\"", realHtmlCharset, scrURL.m_url);
 
     strHTML = converted;
   }
@@ -382,8 +379,7 @@ bool CScraperUrl::Get(const SUrlEntry& scrURL,
     const auto realXmlCharset = xmlDoc.GetUsedCharset();
     if (!realXmlCharset.empty())
     {
-      CLog::Log(LOGDEBUG, "{}: Using \"{}\" charset for XML \"{}\"", __FUNCTION__, realXmlCharset,
-                scrURL.m_url);
+      CLog::LogF(LOGDEBUG, "Using \"{}\" charset for XML \"{}\"", realXmlCharset, scrURL.m_url);
       std::string converted;
       g_charsetConverter.ToUtf8(realXmlCharset, strHTML, converted);
       strHTML = converted;
@@ -397,18 +393,17 @@ bool CScraperUrl::Get(const SUrlEntry& scrURL,
     CCharsetDetection::ConvertPlainTextToUtf8(strHTML, converted, reportedCharset, realTextCharset);
     strHTML = converted;
     if (reportedCharset != realTextCharset)
-      CLog::Log(LOGWARNING,
-                "{}: Using \"{}\" charset for plain text \"{}\" instead of server reported \"{}\" "
-                "charset",
-                __FUNCTION__, realTextCharset, scrURL.m_url, reportedCharset);
+      CLog::LogF(LOGWARNING,
+                 "Using \"{}\" charset for plain text \"{}\" instead of server reported \"{}\" "
+                 "charset",
+                 realTextCharset, scrURL.m_url, reportedCharset);
     else
-      CLog::Log(LOGDEBUG, "{}: Using \"{}\" charset for plain text \"{}\"", __FUNCTION__,
-                realTextCharset, scrURL.m_url);
+      CLog::LogF(LOGDEBUG, "Using \"{}\" charset for plain text \"{}\"", realTextCharset,
+                 scrURL.m_url);
   }
   else if (!reportedCharset.empty())
   {
-    CLog::Log(LOGDEBUG, "{}: Using \"{}\" charset for \"{}\"", __FUNCTION__, reportedCharset,
-              scrURL.m_url);
+    CLog::LogF(LOGDEBUG, "Using \"{}\" charset for \"{}\"", reportedCharset, scrURL.m_url);
     if (reportedCharset != "UTF-8")
     {
       std::string converted;
@@ -417,8 +412,8 @@ bool CScraperUrl::Get(const SUrlEntry& scrURL,
     }
   }
   else
-    CLog::Log(LOGDEBUG, "{}: Using content of \"{}\" as binary or text with \"UTF-8\" charset",
-              __FUNCTION__, scrURL.m_url);
+    CLog::LogF(LOGDEBUG, "Using content of \"{}\" as binary or text with \"UTF-8\" charset",
+               scrURL.m_url);
 
   if (!scrURL.m_cache.empty())
   {

--- a/xbmc/utils/UDMABufferObject.cpp
+++ b/xbmc/utils/UDMABufferObject.cpp
@@ -42,8 +42,7 @@ void CUDMABufferObject::Register()
   int fd = open("/dev/udmabuf", O_RDWR);
   if (fd < 0)
   {
-    CLog::Log(LOGDEBUG, "CUDMABufferObject::{} - unable to open /dev/udmabuf: {}", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGDEBUG, "CUDMABufferObject: unable to open /dev/udmabuf: {}", strerror(errno));
     return;
   }
 
@@ -59,8 +58,7 @@ CUDMABufferObject::~CUDMABufferObject()
 
   int ret = close(m_udmafd);
   if (ret < 0)
-    CLog::Log(LOGERROR, "CUDMABufferObject::{} - close /dev/udmabuf failed, errno={}", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CUDMABufferObject: close /dev/udmabuf failed, errno={}", strerror(errno));
 
   m_udmafd = -1;
 }
@@ -98,21 +96,19 @@ bool CUDMABufferObject::CreateBufferObject(uint64_t size)
   m_memfd = memfd_create("kodi", MFD_CLOEXEC | MFD_ALLOW_SEALING);
   if (m_memfd < 0)
   {
-    CLog::Log(LOGERROR, "CUDMABufferObject::{} - memfd_create failed: {}", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CUDMABufferObject: memfd_create failed: {}", strerror(errno));
     return false;
   }
 
   if (ftruncate(m_memfd, m_size) < 0)
   {
-    CLog::Log(LOGERROR, "CUDMABufferObject::{} - ftruncate failed: {}", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CUDMABufferObject: ftruncate failed: {}", strerror(errno));
     return false;
   }
 
   if (fcntl(m_memfd, F_ADD_SEALS, F_SEAL_SHRINK) < 0)
   {
-    CLog::Log(LOGERROR, "CUDMABufferObject::{} - fcntl failed: {}", __FUNCTION__, strerror(errno));
+    CLog::LogF(LOGERROR, "CUDMABufferObject: fcntl failed: {}", strerror(errno));
     close(m_memfd);
     return false;
   }
@@ -122,8 +118,7 @@ bool CUDMABufferObject::CreateBufferObject(uint64_t size)
     m_udmafd = open("/dev/udmabuf", O_RDWR);
     if (m_udmafd < 0)
     {
-      CLog::Log(LOGERROR, "CUDMABufferObject::{} - unable to open /dev/udmabuf: {}", __FUNCTION__,
-                strerror(errno));
+      CLog::LogF(LOGERROR, "CUDMABufferObject: unable to open /dev/udmabuf: {}", strerror(errno));
       close(m_memfd);
       return false;
     }
@@ -137,8 +132,7 @@ bool CUDMABufferObject::CreateBufferObject(uint64_t size)
   m_fd = ioctl(m_udmafd, UDMABUF_CREATE, &create);
   if (m_fd < 0)
   {
-    CLog::Log(LOGERROR, "CUDMABufferObject::{} - ioctl UDMABUF_CREATE failed: {}", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CUDMABufferObject: ioctl UDMABUF_CREATE failed: {}", strerror(errno));
     close(m_memfd);
     return false;
   }
@@ -153,13 +147,11 @@ void CUDMABufferObject::DestroyBufferObject()
 
   int ret = close(m_fd);
   if (ret < 0)
-    CLog::Log(LOGERROR, "CUDMABufferObject::{} - close fd failed, errno={}", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CUDMABufferObject: close fd failed, errno={}", strerror(errno));
 
   ret = close(m_memfd);
   if (ret < 0)
-    CLog::Log(LOGERROR, "CUDMABufferObject::{} - close memfd failed, errno={}", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CUDMABufferObject: close memfd failed, errno={}", strerror(errno));
 
   m_memfd = -1;
   m_fd = -1;
@@ -174,16 +166,14 @@ uint8_t* CUDMABufferObject::GetMemory()
 
   if (m_map)
   {
-    CLog::Log(LOGDEBUG, "CUDMABufferObject::{} - already mapped fd={} map={}", __FUNCTION__, m_fd,
-              fmt::ptr(m_map));
+    CLog::LogF(LOGDEBUG, "CUDMABufferObject: already mapped fd={} map={}", m_fd, fmt::ptr(m_map));
     return m_map;
   }
 
   m_map = static_cast<uint8_t*>(mmap(nullptr, m_size, PROT_WRITE, MAP_SHARED, m_memfd, 0));
   if (m_map == MAP_FAILED)
   {
-    CLog::Log(LOGERROR, "CUDMABufferObject::{} - mmap failed, errno={}", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CUDMABufferObject: mmap failed, errno={}", strerror(errno));
     return nullptr;
   }
 
@@ -197,8 +187,7 @@ void CUDMABufferObject::ReleaseMemory()
 
   int ret = munmap(m_map, m_size);
   if (ret < 0)
-    CLog::Log(LOGERROR, "CUDMABufferObject::{} - munmap failed, errno={}", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CUDMABufferObject: munmap failed, errno={}", strerror(errno));
 
   m_map = nullptr;
 }

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -630,7 +630,7 @@ bool URIUtils::IsOnDVD(const std::string& strFile)
     return true;
 
 #if defined(TARGET_WINDOWS_STORE)
-  CLog::Log(LOGDEBUG, "{} is not implemented", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "is not implemented");
 #elif defined(TARGET_WINDOWS_DESKTOP)
   using KODI::PLATFORM::WINDOWS::ToW;
   if (strFile.size() >= 2 && strFile.substr(1, 1) == ":")

--- a/xbmc/utils/UrlOptions.cpp
+++ b/xbmc/utils/UrlOptions.cpp
@@ -108,8 +108,8 @@ void CUrlOptions::AddOptions(const std::string &options)
   {
     // remove leading ?, #, ; or | if present
     if (!m_strLead.empty())
-      CLog::Log(LOGWARNING, "{}: original leading str {} overridden by {}", __FUNCTION__, m_strLead,
-                strOptions.at(0));
+      CLog::LogF(LOGWARNING, "original leading str {} overridden by {}", m_strLead,
+                 strOptions.at(0));
     m_strLead = strOptions.at(0);
     strOptions.erase(0, 1);
   }

--- a/xbmc/utils/XBMCTinyXML.cpp
+++ b/xbmc/utils/XBMCTinyXML.cpp
@@ -145,10 +145,9 @@ bool CXBMCTinyXML::Parse(const std::string& data, TiXmlEncoding encoding /*= TIX
   if (CCharsetDetection::DetectXmlEncoding(data, detectedCharset) && TryParse(data, detectedCharset))
   {
     if (!m_SuggestedCharset.empty())
-      CLog::Log(LOGWARNING,
-                "{}: \"{}\" charset was used instead of suggested charset \"{}\" for {}",
-                __FUNCTION__, m_UsedCharset, m_SuggestedCharset,
-                (value.empty() ? "XML data" : ("file \"" + value + "\"")));
+      CLog::LogF(LOGWARNING, "\"{}\" charset was used instead of suggested charset \"{}\" for {}",
+                 m_UsedCharset, m_SuggestedCharset,
+                 (value.empty() ? "XML data" : ("file \"" + value + "\"")));
 
     return true;
   }
@@ -158,14 +157,13 @@ bool CXBMCTinyXML::Parse(const std::string& data, TiXmlEncoding encoding /*= TIX
       TryParse(data, "UTF-8"))
   {
     if (!m_SuggestedCharset.empty())
-      CLog::Log(LOGWARNING,
-                "{}: \"{}\" charset was used instead of suggested charset \"{}\" for {}",
-                __FUNCTION__, m_UsedCharset, m_SuggestedCharset,
-                (value.empty() ? "XML data" : ("file \"" + value + "\"")));
+      CLog::LogF(LOGWARNING, "\"{}\" charset was used instead of suggested charset \"{}\" for {}",
+                 m_UsedCharset, m_SuggestedCharset,
+                 (value.empty() ? "XML data" : ("file \"" + value + "\"")));
     else if (!detectedCharset.empty())
-      CLog::Log(LOGWARNING, "{}: \"{}\" charset was used instead of detected charset \"{}\" for {}",
-                __FUNCTION__, m_UsedCharset, detectedCharset,
-                (value.empty() ? "XML data" : ("file \"" + value + "\"")));
+      CLog::LogF(LOGWARNING, "\"{}\" charset was used instead of detected charset \"{}\" for {}",
+                 m_UsedCharset, detectedCharset,
+                 (value.empty() ? "XML data" : ("file \"" + value + "\"")));
     return true;
   }
 
@@ -173,14 +171,13 @@ bool CXBMCTinyXML::Parse(const std::string& data, TiXmlEncoding encoding /*= TIX
   if (TryParse(data, g_langInfo.GetGuiCharSet()))
   {
     if (!m_SuggestedCharset.empty())
-      CLog::Log(LOGWARNING,
-                "{}: \"{}\" charset was used instead of suggested charset \"{}\" for {}",
-                __FUNCTION__, m_UsedCharset, m_SuggestedCharset,
-                (value.empty() ? "XML data" : ("file \"" + value + "\"")));
+      CLog::LogF(LOGWARNING, "\"{}\" charset was used instead of suggested charset \"{}\" for {}",
+                 m_UsedCharset, m_SuggestedCharset,
+                 (value.empty() ? "XML data" : ("file \"" + value + "\"")));
     else if (!detectedCharset.empty())
-      CLog::Log(LOGWARNING, "{}: \"{}\" charset was used instead of detected charset \"{}\" for {}",
-                __FUNCTION__, m_UsedCharset, detectedCharset,
-                (value.empty() ? "XML data" : ("file \"" + value + "\"")));
+      CLog::LogF(LOGWARNING, "\"{}\" charset was used instead of detected charset \"{}\" for {}",
+                 m_UsedCharset, detectedCharset,
+                 (value.empty() ? "XML data" : ("file \"" + value + "\"")));
     return true;
   }
 
@@ -188,13 +185,11 @@ bool CXBMCTinyXML::Parse(const std::string& data, TiXmlEncoding encoding /*= TIX
   if (InternalParse(data, TIXML_ENCODING_UNKNOWN))
   {
     if (!m_SuggestedCharset.empty())
-      CLog::Log(LOGWARNING, "{}: Processed {} as unknown encoding instead of suggested \"{}\"",
-                __FUNCTION__, (value.empty() ? "XML data" : ("file \"" + value + "\"")),
-                m_SuggestedCharset);
+      CLog::LogF(LOGWARNING, "Processed {} as unknown encoding instead of suggested \"{}\"",
+                 (value.empty() ? "XML data" : ("file \"" + value + "\"")), m_SuggestedCharset);
     else if (!detectedCharset.empty())
-      CLog::Log(LOGWARNING, "{}: Processed {} as unknown encoding instead of detected \"{}\"",
-                __FUNCTION__, (value.empty() ? "XML data" : ("file \"" + value + "\"")),
-                detectedCharset);
+      CLog::LogF(LOGWARNING, "Processed {} as unknown encoding instead of detected \"{}\"",
+                 (value.empty() ? "XML data" : ("file \"" + value + "\"")), detectedCharset);
     return true;
   }
 

--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -112,9 +112,9 @@ public:
     Log(level, format, std::forward<Args>(args)...);
   }
 
-#define LogF(level, format, ...) Log((level), ("{}: " format), __FUNCTION__, ##__VA_ARGS__)
+#define LogF(level, format, ...) Log((level), ("{}: " format), __func__, ##__VA_ARGS__)
 #define LogFC(level, component, format, ...) \
-  Log((level), (component), ("{}: " format), __FUNCTION__, ##__VA_ARGS__)
+  Log((level), (component), ("{}: " format), __func__, ##__VA_ARGS__)
 
 private:
   static CLog& GetInstance();

--- a/xbmc/video/Teletext.cpp
+++ b/xbmc/video/Teletext.cpp
@@ -602,14 +602,14 @@ bool CTeletextDecoder::InitDecoder()
   m_txtCache = appPlayer->GetTeletextCache();
   if (m_txtCache == nullptr)
   {
-    CLog::Log(LOGERROR, "{}: called without teletext cache", __FUNCTION__);
+    CLog::LogF(LOGERROR, "called without teletext cache");
     return false;
   }
 
   /* init fontlibrary */
   if ((error = FT_Init_FreeType(&m_Library)))
   {
-    CLog::Log(LOGERROR, "{}: <FT_Init_FreeType: {:#2X}>", __FUNCTION__, error);
+    CLog::LogF(LOGERROR, "<FT_Init_FreeType: {:#2X}>", error);
     m_Library = NULL;
     return false;
   }
@@ -619,7 +619,7 @@ bool CTeletextDecoder::InitDecoder()
     FT_Done_FreeType(m_Library);
     m_Library = NULL;
     m_Manager = NULL;
-    CLog::Log(LOGERROR, "{}: <FTC_Manager_New: {:#2X}>", __FUNCTION__, error);
+    CLog::LogF(LOGERROR, "<FTC_Manager_New: {:#2X}>", error);
     return false;
   }
 
@@ -629,7 +629,7 @@ bool CTeletextDecoder::InitDecoder()
     FT_Done_FreeType(m_Library);
     m_Manager = NULL;
     m_Library = NULL;
-    CLog::Log(LOGERROR, "{}: <FTC_SBit_Cache_New: {:#2X}>", __FUNCTION__, error);
+    CLog::LogF(LOGERROR, "<FTC_SBit_Cache_New: {:#2X}>", error);
     return false;
   }
 
@@ -651,8 +651,7 @@ bool CTeletextDecoder::InitDecoder()
     m_TypeTTF.face_id = (FTC_FaceID) const_cast<char*>(m_teletextFont.c_str());
     if ((error = FTC_Manager_LookupFace(m_Manager, m_TypeTTF.face_id, &m_Face)))
     {
-      CLog::Log(LOGERROR, "{}: <FTC_Manager_Lookup_Face failed with Errorcode {:#2X}>",
-                __FUNCTION__, error);
+      CLog::LogF(LOGERROR, "<FTC_Manager_Lookup_Face failed with Errorcode {:#2X}>", error);
       FTC_Manager_Done(m_Manager);
       FT_Done_FreeType(m_Library);
       m_Manager = NULL;
@@ -722,7 +721,7 @@ void CTeletextDecoder::EndDecoder()
 
   if (!m_txtCache)
   {
-    CLog::Log(LOGINFO, "{}: called without cache", __FUNCTION__);
+    CLog::LogF(LOGINFO, "called without cache");
   }
   else
   {
@@ -2376,8 +2375,7 @@ void CTeletextDecoder::RenderCharIntern(TextRenderInfo_t* RenderInfo, int Char, 
   /* render char */
   if (!(glyph = FT_Get_Char_Index(m_Face, Char)))
   {
-    CLog::Log(LOGERROR, "{}:  <FT_Get_Char_Index for Char {:x} \"{}\" failed", __FUNCTION__,
-              alphachar, alphachar);
+    CLog::LogF(LOGERROR, "<FT_Get_Char_Index for Char {:x} \"{}\" failed", alphachar, alphachar);
 
     FillRect(m_TextureBuffer, m_RenderInfo.Width, m_RenderInfo.PosX, m_RenderInfo.PosY + yoffset, curfontwidth, factor*m_RenderInfo.FontHeight, bgcolor);
     m_RenderInfo.PosX += curfontwidth;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -228,7 +228,7 @@ void CVideoDatabase::CreateAnalytics()
   /* advantage of a index that has been created on ( bar_id, foo_id )   */
   /* however an index on ( foo_id, bar_id ) will be considered for use  */
 
-  CLog::Log(LOGINFO, "{} - creating indices", __FUNCTION__);
+  CLog::LogF(LOGINFO, "creating indices");
   m_pDS->exec("CREATE INDEX ix_bookmark ON bookmark (idFile, type)");
   m_pDS->exec("CREATE UNIQUE INDEX ix_settings ON settings ( idFile )\n");
   m_pDS->exec("CREATE UNIQUE INDEX ix_stacktimes ON stacktimes ( idFile )\n");
@@ -286,7 +286,7 @@ void CVideoDatabase::CreateAnalytics()
   CreateLinkIndex("genre");
   CreateLinkIndex("country");
 
-  CLog::Log(LOGINFO, "{} - creating triggers", __FUNCTION__);
+  CLog::LogF(LOGINFO, "creating triggers");
   m_pDS->exec("CREATE TRIGGER delete_movie AFTER DELETE ON movie FOR EACH ROW BEGIN "
               "DELETE FROM genre_link WHERE media_id=old.idMovie AND media_type='movie'; "
               "DELETE FROM actor_link WHERE media_id=old.idMovie AND media_type='movie'; "
@@ -584,7 +584,7 @@ int CVideoDatabase::GetPathId(const std::string& strPath)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} unable to getpath ({})", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "unable to getpath ({})", strSQL);
   }
   return -1;
 }
@@ -656,7 +656,7 @@ bool CVideoDatabase::GetPaths(std::set<std::string> &paths)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -677,7 +677,7 @@ bool CVideoDatabase::GetPathsLinkedToTvShow(int idShow, std::vector<std::string>
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} error during query: {}", __FUNCTION__, sql);
+    CLog::LogF(LOGERROR, "error during query: {}", sql);
   }
   return false;
 }
@@ -710,7 +710,7 @@ bool CVideoDatabase::GetPathsForTvShow(int idShow, std::set<int>& paths)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} error during query: {}", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "error during query: {}", strSQL);
   }
   return false;
 }
@@ -762,7 +762,7 @@ bool CVideoDatabase::GetSubPaths(const std::string &basepath, std::vector<std::p
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} error during query: {}", __FUNCTION__, sql);
+    CLog::LogF(LOGERROR, "error during query: {}", sql);
   }
   return false;
 }
@@ -810,7 +810,7 @@ int CVideoDatabase::AddPath(const std::string& strPath, const std::string &paren
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} unable to addpath ({})", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "unable to addpath ({})", strSQL);
   }
   return -1;
 }
@@ -833,7 +833,7 @@ bool CVideoDatabase::GetPathHash(const std::string &path, std::string &hash)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, path);
+    CLog::LogF(LOGERROR, "({}) failed", path);
   }
 
   return false;
@@ -915,7 +915,7 @@ bool CVideoDatabase::GetSourcePath(const std::string &path, std::string &sourceP
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -972,7 +972,7 @@ int CVideoDatabase::AddFile(const std::string& strFileNameAndPath,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} unable to addfile ({})", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "unable to addfile ({})", strSQL);
   }
   return -1;
 }
@@ -1016,8 +1016,8 @@ void CVideoDatabase::UpdateFileDateAdded(CVideoInfoTag& details)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}, {}) failed", __FUNCTION__, CURL::GetRedacted(details.GetPath()),
-              finalDateAdded.GetAsDBDateTime());
+    CLog::LogF(LOGERROR, "({}, {}) failed", CURL::GetRedacted(details.GetPath()),
+               finalDateAdded.GetAsDBDateTime());
   }
 }
 
@@ -1040,7 +1040,7 @@ bool CVideoDatabase::SetPathHash(const std::string &path, const std::string &has
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}, {}) failed", __FUNCTION__, path, hash);
+    CLog::LogF(LOGERROR, "({}, {}) failed", path, hash);
   }
 
   return false;
@@ -1069,7 +1069,7 @@ bool CVideoDatabase::LinkMovieToTvshow(int idMovie, int idShow, bool bRemove)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}, {}) failed", __FUNCTION__, idMovie, idShow);
+    CLog::LogF(LOGERROR, "({}, {}) failed", idMovie, idShow);
   }
 
   return false;
@@ -1097,7 +1097,7 @@ bool CVideoDatabase::IsLinkedToTvshow(int idMovie)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, idMovie);
+    CLog::LogF(LOGERROR, "({}) failed", idMovie);
   }
 
   return false;
@@ -1125,7 +1125,7 @@ bool CVideoDatabase::GetLinksToTvShow(int idMovie, std::vector<int>& ids)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, idMovie);
+    CLog::LogF(LOGERROR, "({}) failed", idMovie);
   }
 
   return false;
@@ -1160,7 +1160,7 @@ int CVideoDatabase::GetFileId(const std::string& strFilenameAndPath)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strFilenameAndPath);
+    CLog::LogF(LOGERROR, "({}) failed", strFilenameAndPath);
   }
   return -1;
 }
@@ -1241,7 +1241,7 @@ int CVideoDatabase::GetMovieId(const std::string& strFilenameAndPath)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strFilenameAndPath);
+    CLog::LogF(LOGERROR, "({}) failed", strFilenameAndPath);
   }
   return -1;
 }
@@ -1292,7 +1292,7 @@ int CVideoDatabase::GetTvShowId(const std::string& strPath)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strPath);
+    CLog::LogF(LOGERROR, "({}) failed", strPath);
   }
   return -1;
 }
@@ -1352,7 +1352,7 @@ int CVideoDatabase::GetEpisodeId(const std::string& strFilenameAndPath, int idEp
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strFilenameAndPath);
+    CLog::LogF(LOGERROR, "({}) failed", strFilenameAndPath);
   }
   return -1;
 }
@@ -1384,7 +1384,7 @@ int CVideoDatabase::GetMusicVideoId(const std::string& strFilenameAndPath)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strFilenameAndPath);
+    CLog::LogF(LOGERROR, "({}) failed", strFilenameAndPath);
   }
   return -1;
 }
@@ -1417,7 +1417,7 @@ int CVideoDatabase::AddNewMovie(CVideoInfoTag& details)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, filePath);
+    CLog::LogF(LOGERROR, "({}) failed", filePath);
   }
   return -1;
 }
@@ -1466,7 +1466,7 @@ int CVideoDatabase::AddNewEpisode(int idShow, CVideoInfoTag& details)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, filePath);
+    CLog::LogF(LOGERROR, "({}) failed", filePath);
   }
   return -1;
 }
@@ -1498,7 +1498,7 @@ int CVideoDatabase::AddNewMusicVideo(CVideoInfoTag& details)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, filePath);
+    CLog::LogF(LOGERROR, "({}) failed", filePath);
   }
   return -1;
 }
@@ -1533,7 +1533,7 @@ int CVideoDatabase::AddToTable(const std::string& table, const std::string& firs
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, value);
+    CLog::LogF(LOGERROR, "({}) failed", value);
   }
 
   return -1;
@@ -1555,7 +1555,7 @@ int CVideoDatabase::UpdateRatings(int mediaId, const char *mediaType, const Rati
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} unable to update ratings of  ({})", __FUNCTION__, mediaType);
+    CLog::LogF(LOGERROR, "unable to update ratings of  ({})", mediaType);
   }
   return -1;
 }
@@ -1602,7 +1602,7 @@ int CVideoDatabase::AddRatings(int mediaId, const char *mediaType, const RatingM
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({} - {}) failed", __FUNCTION__, mediaId, mediaType);
+    CLog::LogF(LOGERROR, "({} - {}) failed", mediaId, mediaType);
   }
 
   return ratingid;
@@ -1624,7 +1624,7 @@ int CVideoDatabase::UpdateUniqueIDs(int mediaId, const char *mediaType, const CV
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} unable to update unique ids of ({})", __FUNCTION__, mediaType);
+    CLog::LogF(LOGERROR, "unable to update unique ids of ({})", mediaType);
   }
   return -1;
 }
@@ -1667,7 +1667,7 @@ int CVideoDatabase::AddUniqueIDs(int mediaId, const char *mediaType, const CVide
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({} - {}) failed", __FUNCTION__, mediaId, mediaType);
+    CLog::LogF(LOGERROR, "({} - {}) failed", mediaId, mediaType);
   }
 
   return uniqueid;
@@ -1702,7 +1702,7 @@ int CVideoDatabase::AddSet(const std::string& strSet, const std::string& strOver
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strSet);
+    CLog::LogF(LOGERROR, "({}) failed", strSet);
   }
 
   return -1;
@@ -1758,7 +1758,7 @@ int CVideoDatabase::AddActor(const std::string& name, const std::string& thumbUR
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, name);
+    CLog::LogF(LOGERROR, "({}) failed", name);
   }
   return -1;
 }
@@ -1907,7 +1907,7 @@ bool CVideoDatabase::HasMovieInfo(const std::string& strFilenameAndPath)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strFilenameAndPath);
+    CLog::LogF(LOGERROR, "({}) failed", strFilenameAndPath);
   }
   return false;
 }
@@ -1925,7 +1925,7 @@ bool CVideoDatabase::HasTvShowInfo(const std::string& strPath)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strPath);
+    CLog::LogF(LOGERROR, "({}) failed", strPath);
   }
   return false;
 }
@@ -1943,7 +1943,7 @@ bool CVideoDatabase::HasEpisodeInfo(const std::string& strFilenameAndPath)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strFilenameAndPath);
+    CLog::LogF(LOGERROR, "({}) failed", strFilenameAndPath);
   }
   return false;
 }
@@ -1961,7 +1961,7 @@ bool CVideoDatabase::HasMusicVideoInfo(const std::string& strFilenameAndPath)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strFilenameAndPath);
+    CLog::LogF(LOGERROR, "({}) failed", strFilenameAndPath);
   }
   return false;
 }
@@ -2008,7 +2008,7 @@ void CVideoDatabase::DeleteDetailsForTvShow(int idTvShow)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, idTvShow);
+    CLog::LogF(LOGERROR, "({}) failed", idTvShow);
   }
 }
 
@@ -2082,7 +2082,7 @@ void CVideoDatabase::GetMusicVideosByArtist(const std::string& strArtist, CFileI
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strArtist);
+    CLog::LogF(LOGERROR, "({}) failed", strArtist);
   }
 }
 
@@ -2106,7 +2106,7 @@ bool CVideoDatabase::GetMovieInfo(const std::string& strFilenameAndPath, CVideoI
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strFilenameAndPath);
+    CLog::LogF(LOGERROR, "({}) failed", strFilenameAndPath);
   }
   return false;
 }
@@ -2131,7 +2131,7 @@ bool CVideoDatabase::GetTvShowInfo(const std::string& strPath, CVideoInfoTag& de
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strPath);
+    CLog::LogF(LOGERROR, "({}) failed", strPath);
   }
   return false;
 }
@@ -2222,7 +2222,7 @@ bool CVideoDatabase::GetSeasonInfo(int idSeason,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, idSeason);
+    CLog::LogF(LOGERROR, "({}) failed", idSeason);
   }
   return false;
 }
@@ -2245,7 +2245,7 @@ bool CVideoDatabase::GetEpisodeBasicInfo(const std::string& strFilenameAndPath, 
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strFilenameAndPath);
+    CLog::LogF(LOGERROR, "({}) failed", strFilenameAndPath);
   }
   return false;
 }
@@ -2269,7 +2269,7 @@ bool CVideoDatabase::GetEpisodeInfo(const std::string& strFilenameAndPath, CVide
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strFilenameAndPath);
+    CLog::LogF(LOGERROR, "({}) failed", strFilenameAndPath);
   }
   return false;
 }
@@ -2293,7 +2293,7 @@ bool CVideoDatabase::GetMusicVideoInfo(const std::string& strFilenameAndPath, CV
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strFilenameAndPath);
+    CLog::LogF(LOGERROR, "({}) failed", strFilenameAndPath);
   }
   return false;
 }
@@ -2320,7 +2320,7 @@ bool CVideoDatabase::GetSetInfo(int idSet, CVideoInfoTag& details, CFileItem* it
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, idSet);
+    CLog::LogF(LOGERROR, "({}) failed", idSet);
   }
   return false;
 }
@@ -2366,7 +2366,7 @@ bool CVideoDatabase::GetFileInfo(const std::string& strFilenameAndPath, CVideoIn
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strFilenameAndPath);
+    CLog::LogF(LOGERROR, "({}) failed", strFilenameAndPath);
   }
   return false;
 }
@@ -2568,7 +2568,7 @@ int CVideoDatabase::SetDetailsForMovie(CVideoInfoTag& details,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, filePath);
+    CLog::LogF(LOGERROR, "({}) failed", filePath);
   }
   RollbackTransaction();
   return -1;
@@ -2581,7 +2581,7 @@ int CVideoDatabase::UpdateDetailsForMovie(int idMovie, CVideoInfoTag& details, c
 
   try
   {
-    CLog::Log(LOGINFO, "{}: Starting updates for movie {}", __FUNCTION__, idMovie);
+    CLog::LogF(LOGINFO, "Starting updates for movie {}", idMovie);
 
     BeginTransaction();
 
@@ -2634,8 +2634,8 @@ int CVideoDatabase::UpdateDetailsForMovie(int idMovie, CVideoInfoTag& details, c
         if (!items.IsEmpty())
           LinkMovieToTvshow(idMovie, items[0]->GetVideoInfoTag()->m_iDbId, false);
         else
-          CLog::Log(LOGWARNING, "{}: Failed to link movie {} to show {}", __FUNCTION__,
-                    details.m_strTitle, showLink);
+          CLog::LogF(LOGWARNING, "Failed to link movie {} to show {}", details.m_strTitle,
+                     showLink);
       }
     }
 
@@ -2658,13 +2658,13 @@ int CVideoDatabase::UpdateDetailsForMovie(int idMovie, CVideoInfoTag& details, c
 
     CommitTransaction();
 
-    CLog::Log(LOGINFO, "{}: Finished updates for movie {}", __FUNCTION__, idMovie);
+    CLog::LogF(LOGINFO, "Finished updates for movie {}", idMovie);
 
     return idMovie;
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, idMovie);
+    CLog::LogF(LOGERROR, "({}) failed", idMovie);
   }
   RollbackTransaction();
   return -1;
@@ -2699,7 +2699,7 @@ int CVideoDatabase::SetDetailsForMovieSet(const CVideoInfoTag& details, const st
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, idSet);
+    CLog::LogF(LOGERROR, "({}) failed", idSet);
   }
   RollbackTransaction();
   return -1;
@@ -2859,7 +2859,7 @@ int CVideoDatabase::SetDetailsForSeason(const CVideoInfoTag& details, const std:
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, idSeason);
+    CLog::LogF(LOGERROR, "({}) failed", idSeason);
   }
   RollbackTransaction();
   return -1;
@@ -2956,7 +2956,7 @@ int CVideoDatabase::SetDetailsForEpisode(CVideoInfoTag& details,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, filePath);
+    CLog::LogF(LOGERROR, "({}) failed", filePath);
   }
   RollbackTransaction();
   return -1;
@@ -3048,7 +3048,7 @@ int CVideoDatabase::SetDetailsForMusicVideo(CVideoInfoTag& details,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, filePath);
+    CLog::LogF(LOGERROR, "({}) failed", filePath);
   }
   RollbackTransaction();
   return -1;
@@ -3121,7 +3121,7 @@ void CVideoDatabase::SetStreamDetailsForFileId(const CStreamDetails& details, in
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, idFile);
+    CLog::LogF(LOGERROR, "({}) failed", idFile);
   }
 }
 
@@ -3162,7 +3162,7 @@ void CVideoDatabase::GetFilePathById(int idMovie, std::string& filePath, VideoDb
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
 }
 
@@ -3222,7 +3222,7 @@ void CVideoDatabase::GetBookMarksForFile(const std::string& strFilenameAndPath, 
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strFilenameAndPath);
+    CLog::LogF(LOGERROR, "({}) failed", strFilenameAndPath);
   }
 }
 
@@ -3284,8 +3284,7 @@ void CVideoDatabase::DeleteResumeBookMark(const CFileItem& item)
   }
   catch(...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__,
-              item.GetVideoInfoTag()->m_strFileNameAndPath);
+    CLog::LogF(LOGERROR, "({}) failed", item.GetVideoInfoTag()->m_strFileNameAndPath);
   }
 }
 
@@ -3304,7 +3303,7 @@ void CVideoDatabase::GetEpisodesByFile(const std::string& strFilenameAndPath, st
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strFilenameAndPath);
+    CLog::LogF(LOGERROR, "({}) failed", strFilenameAndPath);
   }
 }
 
@@ -3353,7 +3352,7 @@ void CVideoDatabase::AddBookMarkToFile(const std::string& strFilenameAndPath, co
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strFilenameAndPath);
+    CLog::LogF(LOGERROR, "({}) failed", strFilenameAndPath);
   }
 }
 
@@ -3391,7 +3390,7 @@ void CVideoDatabase::ClearBookMarkOfFile(const std::string& strFilenameAndPath, 
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strFilenameAndPath);
+    CLog::LogF(LOGERROR, "({}) failed", strFilenameAndPath);
   }
 }
 
@@ -3425,7 +3424,7 @@ void CVideoDatabase::ClearBookMarksOfFile(int idFile, CBookmark::EType type /*= 
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, idFile);
+    CLog::LogF(LOGERROR, "({}) failed", idFile);
   }
 }
 
@@ -3454,7 +3453,7 @@ bool CVideoDatabase::GetBookMarkForEpisode(const CVideoInfoTag& tag, CBookmark& 
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
     return false;
   }
   return true;
@@ -3476,7 +3475,7 @@ void CVideoDatabase::AddBookMarkForEpisode(const CVideoInfoTag& tag, const CBook
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, tag.m_iDbId);
+    CLog::LogF(LOGERROR, "({}) failed", tag.m_iDbId);
   }
 }
 
@@ -3491,7 +3490,7 @@ void CVideoDatabase::DeleteBookMarkForEpisode(const CVideoInfoTag& tag)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, tag.m_iDbId);
+    CLog::LogF(LOGERROR, "({}) failed", tag.m_iDbId);
   }
 }
 
@@ -3535,7 +3534,7 @@ void CVideoDatabase::DeleteMovie(int idMovie, bool bKeepId /* = false */)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
     RollbackTransaction();
   }
 }
@@ -3600,7 +3599,7 @@ void CVideoDatabase::DeleteTvShow(int idTvShow, bool bKeepId /* = false */)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, idTvShow);
+    CLog::LogF(LOGERROR, "({}) failed", idTvShow);
     RollbackTransaction();
   }
 }
@@ -3633,7 +3632,7 @@ void CVideoDatabase::DeleteSeason(int idSeason, bool bKeepId /* = false */)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, idSeason);
+    CLog::LogF(LOGERROR, "({}) failed", idSeason);
     RollbackTransaction();
   }
 }
@@ -3672,7 +3671,7 @@ void CVideoDatabase::DeleteEpisode(int idEpisode, bool bKeepId /* = false */)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, idEpisode);
+    CLog::LogF(LOGERROR, "({}) failed", idEpisode);
   }
 }
 
@@ -3714,7 +3713,7 @@ void CVideoDatabase::DeleteMusicVideo(int idMVideo, bool bKeepId /* = false */)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
     RollbackTransaction();
   }
 }
@@ -3753,7 +3752,7 @@ void CVideoDatabase::DeleteSet(int idSet)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, idSet);
+    CLog::LogF(LOGERROR, "({}) failed", idSet);
   }
 }
 
@@ -3792,7 +3791,7 @@ void CVideoDatabase::DeleteTag(int idTag, VideoDbContentType mediaType)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, idTag);
+    CLog::LogF(LOGERROR, "({}) failed", idTag);
   }
 }
 
@@ -3960,7 +3959,7 @@ bool CVideoDatabase::GetStreamDetails(CVideoInfoTag& tag) const
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, tag.m_iFileId);
+    CLog::LogF(LOGERROR, "({}) failed", tag.m_iFileId);
   }
   details.DetermineBestStreams();
 
@@ -4012,7 +4011,7 @@ bool CVideoDatabase::GetResumePoint(CVideoInfoTag& tag)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, tag.m_strFileNameAndPath);
+    CLog::LogF(LOGERROR, "({}) failed", tag.m_strFileNameAndPath);
   }
 
   return match;
@@ -4357,7 +4356,7 @@ void CVideoDatabase::GetCast(int media_id, const std::string &media_type, std::v
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({},{}) failed", __FUNCTION__, media_id, media_type);
+    CLog::LogF(LOGERROR, "({},{}) failed", media_id, media_type);
   }
 }
 
@@ -4381,7 +4380,7 @@ void CVideoDatabase::GetTags(int media_id, const std::string &media_type, std::v
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({},{}) failed", __FUNCTION__, media_id, media_type);
+    CLog::LogF(LOGERROR, "({},{}) failed", media_id, media_type);
   }
 }
 
@@ -4405,7 +4404,7 @@ void CVideoDatabase::GetRatings(int media_id, const std::string &media_type, Rat
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({},{}) failed", __FUNCTION__, media_id, media_type);
+    CLog::LogF(LOGERROR, "({},{}) failed", media_id, media_type);
   }
 }
 
@@ -4429,7 +4428,7 @@ void CVideoDatabase::GetUniqueIDs(int media_id, const std::string &media_type, C
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({},{}) failed", __FUNCTION__, media_id, media_type);
+    CLog::LogF(LOGERROR, "({},{}) failed", media_id, media_type);
   }
 }
 
@@ -4495,7 +4494,7 @@ bool CVideoDatabase::GetVideoSettings(int idFile, CVideoSettings &settings)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -4582,7 +4581,7 @@ void CVideoDatabase::SetVideoSettings(int idFile, const CVideoSettings &setting)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, idFile);
+    CLog::LogF(LOGERROR, "({}) failed", idFile);
   }
 }
 
@@ -4627,8 +4626,7 @@ void CVideoDatabase::SetArtForItem(int mediaId, const MediaType &mediaType, cons
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}, '{}', '{}', '{}') failed", __FUNCTION__, mediaId, mediaType,
-              artType, url);
+    CLog::LogF(LOGERROR, "({}, '{}', '{}', '{}') failed", mediaId, mediaType, artType, url);
   }
 }
 
@@ -4653,7 +4651,7 @@ bool CVideoDatabase::GetArtForItem(int mediaId, const MediaType &mediaType, std:
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, mediaId);
+    CLog::LogF(LOGERROR, "({}) failed", mediaId);
   }
   return false;
 }
@@ -4695,7 +4693,7 @@ bool CVideoDatabase::HasArtForItem(int mediaId, const MediaType &mediaType)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, mediaId);
+    CLog::LogF(LOGERROR, "({}) failed", mediaId);
   }
   return false;
 }
@@ -4724,7 +4722,7 @@ bool CVideoDatabase::GetTvShowSeasons(int showId, std::map<int, int> &seasons)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, showId);
+    CLog::LogF(LOGERROR, "({}) failed", showId);
   }
   return false;
 }
@@ -4753,7 +4751,7 @@ bool CVideoDatabase::GetTvShowNamedSeasons(int showId, std::map<int, std::string
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, showId);
+    CLog::LogF(LOGERROR, "({}) failed", showId);
   }
   return false;
 }
@@ -4786,7 +4784,7 @@ bool CVideoDatabase::GetTvShowSeasonArt(int showId, std::map<int, std::map<std::
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, showId);
+    CLog::LogF(LOGERROR, "({}) failed", showId);
   }
   return false;
 }
@@ -4815,7 +4813,7 @@ bool CVideoDatabase::GetArtTypes(const MediaType &mediaType, std::vector<std::st
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, mediaType);
+    CLog::LogF(LOGERROR, "({}) failed", mediaType);
   }
   return false;
 }
@@ -5068,7 +5066,7 @@ bool CVideoDatabase::GetStackTimes(const std::string &filePath, std::vector<uint
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -5098,7 +5096,7 @@ void CVideoDatabase::SetStackTimes(const std::string& filePath, const std::vecto
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, filePath);
+    CLog::LogF(LOGERROR, "({}) failed", filePath);
   }
 }
 
@@ -5184,7 +5182,7 @@ void CVideoDatabase::RemoveContentForPath(const std::string& strPath, CGUIDialog
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strPath);
+    CLog::LogF(LOGERROR, "({}) failed", strPath);
   }
   if (progress)
     progress->Close();
@@ -5244,7 +5242,7 @@ void CVideoDatabase::SetScraperForPath(const std::string& filePath, const Scrape
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, filePath);
+    CLog::LogF(LOGERROR, "({}) failed", filePath);
   }
 }
 
@@ -5266,7 +5264,7 @@ bool CVideoDatabase::ScraperInUse(const std::string &scraperID) const
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}({}) failed", __FUNCTION__, scraperID);
+    CLog::LogF(LOGERROR, "({}) failed", scraperID);
   }
   return false;
 }
@@ -6012,7 +6010,7 @@ bool CVideoDatabase::GetPlayCounts(const std::string &strPath, CFileItemList &it
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -6043,7 +6041,7 @@ int CVideoDatabase::GetPlayCount(int iFileId)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return -1;
 }
@@ -6119,7 +6117,7 @@ void CVideoDatabase::UpdateFanart(const CFileItem& item, VideoDbContentType type
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} - error updating fanart for {}", __FUNCTION__, item.GetPath());
+    CLog::LogF(LOGERROR, "error updating fanart for {}", item.GetPath());
   }
 }
 
@@ -6182,7 +6180,7 @@ CDateTime CVideoDatabase::SetPlayCount(const CFileItem& item, int count, const C
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
 
   return {};
@@ -6244,10 +6242,10 @@ void CVideoDatabase::UpdateMovieTitle(int idMovie,
   }
   catch (...)
   {
-    CLog::Log(
+    CLog::LogF(
         LOGERROR,
-        "{} (int idMovie, const std::string& strNewMovieTitle) failed on MovieID:{} and Title:{}",
-        __FUNCTION__, idMovie, strNewMovieTitle);
+        "(int idMovie, const std::string& strNewMovieTitle) failed on MovieID:{} and Title:{}",
+        idMovie, strNewMovieTitle);
   }
 }
 
@@ -6274,10 +6272,10 @@ bool CVideoDatabase::UpdateVideoSortTitle(int idDb,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR,
-              "{} (int idDb, const std::string& strNewSortTitle, VIDEODB_CONTENT_TYPE iType) "
-              "failed on ID: {} and Sort Title: {}",
-              __FUNCTION__, idDb, strNewSortTitle);
+    CLog::LogF(LOGERROR,
+               "(int idDb, const std::string& strNewSortTitle, VIDEODB_CONTENT_TYPE iType) "
+               "failed on ID: {} and Sort Title: {}",
+               idDb, strNewSortTitle);
   }
 
   return false;
@@ -6300,7 +6298,7 @@ void CVideoDatabase::EraseVideoSettings(const CFileItem &item)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
 }
 
@@ -6315,7 +6313,7 @@ void CVideoDatabase::EraseAllVideoSettings()
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
 }
 
@@ -6345,7 +6343,7 @@ void CVideoDatabase::EraseAllVideoSettings(const std::string& path)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
 }
 
@@ -6570,7 +6568,7 @@ bool CVideoDatabase::GetNavCommon(const std::string& strBaseDir,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -6644,7 +6642,7 @@ bool CVideoDatabase::GetSetsByWhere(const std::string& strBaseDir, const Filter 
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -6810,7 +6808,7 @@ bool CVideoDatabase::GetMusicVideoAlbumsNav(const std::string& strBaseDir, CFile
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -7122,7 +7120,7 @@ bool CVideoDatabase::GetPeopleNav(const std::string& strBaseDir,
         catch (...)
         {
           m_pDS->close();
-          CLog::Log(LOGERROR, "{}: out of memory - retrieved {} items", __FUNCTION__, items.Size());
+          CLog::LogF(LOGERROR, "out of memory - retrieved {} items", items.Size());
           return items.Size() > 0;
         }
       }
@@ -7140,7 +7138,7 @@ bool CVideoDatabase::GetPeopleNav(const std::string& strBaseDir,
   catch (...)
   {
     m_pDS->close();
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -7313,7 +7311,7 @@ bool CVideoDatabase::GetYearsNav(const std::string& strBaseDir,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -7480,7 +7478,7 @@ bool CVideoDatabase::GetSeasonsByWhere(const std::string& strBaseDir, const Filt
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -7739,7 +7737,7 @@ bool CVideoDatabase::GetMoviesByWhere(const std::string& strBaseDir, const Filte
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -7848,7 +7846,7 @@ bool CVideoDatabase::GetTvShowsByWhere(const std::string& strBaseDir, const Filt
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -7985,7 +7983,7 @@ bool CVideoDatabase::GetEpisodesByWhere(const std::string& strBaseDir, const Fil
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -8106,7 +8104,7 @@ bool CVideoDatabase::HasSets() const
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -8133,7 +8131,7 @@ int CVideoDatabase::GetTvShowForEpisode(int idEpisode)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, idEpisode);
+    CLog::LogF(LOGERROR, "({}) failed", idEpisode);
   }
   return false;
 }
@@ -8180,7 +8178,7 @@ bool CVideoDatabase::HasContent(VideoDbContentType type)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return result;
 }
@@ -8350,7 +8348,7 @@ ScraperPtr CVideoDatabase::GetScraperForPath(const std::string& strPath, SScanSe
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return ScraperPtr();
 }
@@ -8437,7 +8435,7 @@ void CVideoDatabase::GetMovieGenresByName(const std::string& strSearch, CFileIte
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "({}) failed", strSQL);
   }
 }
 
@@ -8479,7 +8477,7 @@ void CVideoDatabase::GetMovieCountriesByName(const std::string& strSearch, CFile
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "({}) failed", strSQL);
   }
 }
 
@@ -8520,7 +8518,7 @@ void CVideoDatabase::GetTvShowGenresByName(const std::string& strSearch, CFileIt
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "({}) failed", strSQL);
   }
 }
 
@@ -8561,7 +8559,7 @@ void CVideoDatabase::GetMovieActorsByName(const std::string& strSearch, CFileIte
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "({}) failed", strSQL);
   }
 }
 
@@ -8602,7 +8600,7 @@ void CVideoDatabase::GetTvShowsActorsByName(const std::string& strSearch, CFileI
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "({}) failed", strSQL);
   }
 }
 
@@ -8646,7 +8644,7 @@ void CVideoDatabase::GetMusicVideoArtistsByName(const std::string& strSearch, CF
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "({}) failed", strSQL);
   }
 }
 
@@ -8687,7 +8685,7 @@ void CVideoDatabase::GetMusicVideoGenresByName(const std::string& strSearch, CFi
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "({}) failed", strSQL);
   }
 }
 
@@ -8744,7 +8742,7 @@ void CVideoDatabase::GetMusicVideoAlbumsByName(const std::string& strSearch, CFi
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "({}) failed", strSQL);
   }
 }
 
@@ -8787,7 +8785,7 @@ void CVideoDatabase::GetMusicVideosByAlbum(const std::string& strSearch, CFileIt
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "({}) failed", strSQL);
   }
 }
 
@@ -8886,7 +8884,7 @@ bool CVideoDatabase::GetMusicVideosByWhere(const std::string &baseDir, const Fil
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return false;
 }
@@ -8923,7 +8921,7 @@ unsigned int CVideoDatabase::GetRandomMusicVideoIDs(const std::string& strWhere,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strWhere);
+    CLog::LogF(LOGERROR, "({}) failed", strWhere);
   }
   return 0;
 }
@@ -8970,7 +8968,7 @@ int CVideoDatabase::GetMatchingMusicVideo(const std::string& strArtist, const st
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   return -1;
 }
@@ -9026,7 +9024,7 @@ void CVideoDatabase::GetMoviesByName(const std::string& strSearch, CFileItemList
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "({}) failed", strSQL);
   }
 }
 
@@ -9070,7 +9068,7 @@ void CVideoDatabase::GetTvShowsByName(const std::string& strSearch, CFileItemLis
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "({}) failed", strSQL);
   }
 }
 
@@ -9113,7 +9111,7 @@ void CVideoDatabase::GetEpisodesByName(const std::string& strSearch, CFileItemLi
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "({}) failed", strSQL);
   }
 }
 
@@ -9160,7 +9158,7 @@ void CVideoDatabase::GetMusicVideosByName(const std::string& strSearch, CFileIte
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "({}) failed", strSQL);
   }
 }
 
@@ -9210,7 +9208,7 @@ void CVideoDatabase::GetEpisodesByPlot(const std::string& strSearch, CFileItemLi
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "({}) failed", strSQL);
   }
 }
 
@@ -9255,7 +9253,7 @@ void CVideoDatabase::GetMoviesByPlot(const std::string& strSearch, CFileItemList
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "({}) failed", strSQL);
   }
 }
 
@@ -9298,7 +9296,7 @@ void CVideoDatabase::GetMovieDirectorsByName(const std::string& strSearch, CFile
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "({}) failed", strSQL);
   }
 }
 
@@ -9341,7 +9339,7 @@ void CVideoDatabase::GetTvShowsDirectorsByName(const std::string& strSearch, CFi
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "({}) failed", strSQL);
   }
 }
 
@@ -9384,7 +9382,7 @@ void CVideoDatabase::GetMusicVideoDirectorsByName(const std::string& strSearch, 
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "({}) failed", strSQL);
   }
 }
 
@@ -9403,7 +9401,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle,
       return;
 
     auto start = std::chrono::steady_clock::now();
-    CLog::Log(LOGINFO, "{}: Starting videodatabase cleanup ..", __FUNCTION__);
+    CLog::LogF(LOGINFO, "Starting videodatabase cleanup ..");
     CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary,
                                                        "OnCleanStarted");
 
@@ -9591,7 +9589,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle,
         }
         CLog::LogFC(LOGDEBUG, LOGDATABASE, "Cleaned {} path hashes", pathHashCount);
 
-        CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning files table", __FUNCTION__);
+        CLog::LogFC(LOGDEBUG, LOGDATABASE, "Cleaning files table");
         sql = "DELETE FROM files WHERE idFile IN " + filesToDelete;
         m_pDS->exec(sql);
       }
@@ -9603,7 +9601,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle,
           moviesToDelete += StringUtils::Format("{},", i);
         moviesToDelete = "(" + StringUtils::TrimRight(moviesToDelete, ",") + ")";
 
-        CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning movie table", __FUNCTION__);
+        CLog::LogFC(LOGDEBUG, LOGDATABASE, "Cleaning movie table");
         sql = "DELETE FROM movie WHERE idMovie IN " + moviesToDelete;
         m_pDS->exec(sql);
       }
@@ -9615,13 +9613,12 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle,
           episodesToDelete += StringUtils::Format("{},", i);
         episodesToDelete = "(" + StringUtils::TrimRight(episodesToDelete, ",") + ")";
 
-        CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning episode table", __FUNCTION__);
+        CLog::LogFC(LOGDEBUG, LOGDATABASE, "Cleaning episode table");
         sql = "DELETE FROM episode WHERE idEpisode IN " + episodesToDelete;
         m_pDS->exec(sql);
       }
 
-      CLog::Log(LOGDEBUG, LOGDATABASE,
-                "{}: Cleaning paths that don't exist and have content set...", __FUNCTION__);
+      CLog::LogFC(LOGDEBUG, LOGDATABASE, "Cleaning paths that don't exist and have content set...");
       sql = "SELECT path.idPath, path.strPath, path.idParentPath FROM path "
             "WHERE NOT ((strContent IS NULL OR strContent = '') "
             "AND (strSettings IS NULL OR strSettings = '') "
@@ -9669,7 +9666,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle,
         m_pDS->exec(sql);
       }
 
-      CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning tvshow table", __FUNCTION__);
+      CLog::LogFC(LOGDEBUG, LOGDATABASE, "Cleaning tvshow table");
 
       std::string tvshowsToDelete;
       sql = "SELECT idShow FROM tvshow "
@@ -9697,12 +9694,12 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle,
           musicVideosToDelete += StringUtils::Format("{},", i);
         musicVideosToDelete = "(" + StringUtils::TrimRight(musicVideosToDelete, ",") + ")";
 
-        CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning musicvideo table", __FUNCTION__);
+        CLog::LogFC(LOGDEBUG, LOGDATABASE, "Cleaning musicvideo table");
         sql = "DELETE FROM musicvideo WHERE idMVideo IN " + musicVideosToDelete;
         m_pDS->exec(sql);
       }
 
-      CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning path table", __FUNCTION__);
+      CLog::LogFC(LOGDEBUG, LOGDATABASE, "Cleaning path table");
       sql = StringUtils::Format(
           "DELETE FROM path "
           "WHERE (strContent IS NULL OR strContent = '') "
@@ -9720,19 +9717,18 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle,
           VIDEODB_ID_MUSICVIDEO_PARENTPATHID);
       m_pDS->exec(sql);
 
-      CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning genre table", __FUNCTION__);
+      CLog::LogFC(LOGDEBUG, LOGDATABASE, "Cleaning genre table");
       sql =
           "DELETE FROM genre "
           "WHERE NOT EXISTS (SELECT 1 FROM genre_link WHERE genre_link.genre_id = genre.genre_id)";
       m_pDS->exec(sql);
 
-      CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning country table", __FUNCTION__);
+      CLog::LogFC(LOGDEBUG, LOGDATABASE, "Cleaning country table");
       sql = "DELETE FROM country WHERE NOT EXISTS (SELECT 1 FROM country_link WHERE "
             "country_link.country_id = country.country_id)";
       m_pDS->exec(sql);
 
-      CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning actor table of actors, directors and writers",
-                __FUNCTION__);
+      CLog::LogFC(LOGDEBUG, LOGDATABASE, "Cleaning actor table of actors, directors and writers");
       sql =
           "DELETE FROM actor "
           "WHERE NOT EXISTS (SELECT 1 FROM actor_link WHERE actor_link.actor_id = actor.actor_id) "
@@ -9741,13 +9737,13 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle,
           "AND NOT EXISTS (SELECT 1 FROM writer_link WHERE writer_link.actor_id = actor.actor_id)";
       m_pDS->exec(sql);
 
-      CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning studio table", __FUNCTION__);
+      CLog::LogFC(LOGDEBUG, LOGDATABASE, "Cleaning studio table");
       sql = "DELETE FROM studio "
             "WHERE NOT EXISTS (SELECT 1 FROM studio_link WHERE studio_link.studio_id = "
             "studio.studio_id)";
       m_pDS->exec(sql);
 
-      CLog::Log(LOGDEBUG, LOGDATABASE, "{}: Cleaning set table", __FUNCTION__);
+      CLog::LogFC(LOGDEBUG, LOGDATABASE, "Cleaning set table");
       sql = "DELETE FROM sets "
             "WHERE NOT EXISTS (SELECT 1 FROM movie WHERE movie.idSet = sets.idSet)";
       m_pDS->exec(sql);
@@ -9764,8 +9760,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle,
       auto end = std::chrono::steady_clock::now();
       auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 
-      CLog::Log(LOGINFO, "{}: Cleaning videodatabase done. Operation took {} ms", __FUNCTION__,
-                duration.count());
+      CLog::LogF(LOGINFO, "Cleaning videodatabase done. Operation took {} ms", duration.count());
 
       for (const auto& i : movieIDs)
         AnnounceRemove(MediaTypeMovie, i, true);
@@ -9782,7 +9777,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
     RollbackTransaction();
   }
   if (progress)
@@ -10080,8 +10075,8 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
       {
         if (!item.Exists(false))
         {
-          CLog::Log(LOGINFO, "{} - Not exporting item {} as it does not exist", __FUNCTION__,
-                    movie.m_strFileNameAndPath);
+          CLog::LogF(LOGINFO, "Not exporting item {} as it does not exist",
+                     movie.m_strFileNameAndPath);
           bSkip = true;
         }
         else
@@ -10099,7 +10094,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
           {
             if(!xmlDoc.SaveFile(nfoFile))
             {
-              CLog::Log(LOGERROR, "{}: Movie nfo export failed! ('{}')", __FUNCTION__, nfoFile);
+              CLog::LogF(LOGERROR, "Movie nfo export failed! ('{}')", nfoFile);
               CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(20302), nfoFile);
               iFailCount++;
             }
@@ -10178,10 +10173,9 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
           }
         }
         else
-          CLog::Log(
-              LOGDEBUG,
-              "CVideoDatabase::{} - Not exporting movie set '{}' as could not create folder '{}'",
-              __FUNCTION__, title, itemPath);
+          CLog::LogF(LOGDEBUG,
+                     "CVideoDatabase: Not exporting movie set '{}' as could not create folder '{}'",
+                     title, itemPath);
         m_pDS->next();
         current++;
       }
@@ -10231,8 +10225,8 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
       {
         if (!item.Exists(false))
         {
-          CLog::Log(LOGINFO, "{} - Not exporting item {} as it does not exist", __FUNCTION__,
-                    movie.m_strFileNameAndPath);
+          CLog::LogF(LOGINFO, "Not exporting item {} as it does not exist",
+                     movie.m_strFileNameAndPath);
           bSkip = true;
         }
         else
@@ -10243,8 +10237,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
           {
             if(!xmlDoc.SaveFile(nfoFile))
             {
-              CLog::Log(LOGERROR, "{}: Musicvideo nfo export failed! ('{}')", __FUNCTION__,
-                        nfoFile);
+              CLog::LogF(LOGERROR, "Musicvideo nfo export failed! ('{}')", nfoFile);
               CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(20302), nfoFile);
               iFailCount++;
             }
@@ -10332,8 +10325,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
       {
         if (!item.Exists(false))
         {
-          CLog::Log(LOGINFO, "{} - Not exporting item {} as it does not exist", __FUNCTION__,
-                    tvshow.m_strPath);
+          CLog::LogF(LOGINFO, "Not exporting item {} as it does not exist", tvshow.m_strPath);
           bSkip = true;
         }
         else
@@ -10344,7 +10336,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
           {
             if(!xmlDoc.SaveFile(nfoFile))
             {
-              CLog::Log(LOGERROR, "{}: TVShow nfo export failed! ('{}')", __FUNCTION__, nfoFile);
+              CLog::LogF(LOGERROR, "TVShow nfo export failed! ('{}')", nfoFile);
               CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(20302), nfoFile);
               iFailCount++;
             }
@@ -10428,8 +10420,8 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
         {
           if (!item.Exists(false))
           {
-            CLog::Log(LOGINFO, "{} - Not exporting item {} as it does not exist", __FUNCTION__,
-                      episode.m_strFileNameAndPath);
+            CLog::LogF(LOGINFO, "Not exporting item {} as it does not exist",
+                       episode.m_strFileNameAndPath);
             bSkip = true;
           }
           else
@@ -10440,7 +10432,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
             {
               if(!xmlDoc.SaveFile(nfoFile))
               {
-                CLog::Log(LOGERROR, "{}: Episode nfo export failed! ('{}')", __FUNCTION__, nfoFile);
+                CLog::LogF(LOGERROR, "Episode nfo export failed! ('{}')", nfoFile);
                 CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(20302), nfoFile);
                 iFailCount++;
               }
@@ -10521,7 +10513,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
     iFailCount++;
   }
 
@@ -10590,7 +10582,7 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
     int iVersion = 0;
     XMLUtils::GetInt(root, "version", iVersion);
 
-    CLog::Log(LOGINFO, "{}: Starting import (export version = {})", __FUNCTION__, iVersion);
+    CLog::LogF(LOGINFO, "Starting import (export version = {})", iVersion);
 
     TiXmlElement *movie = root->FirstChildElement();
     int current = 0;
@@ -10751,7 +10743,7 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
   if (progress)
     progress->Close();
@@ -10877,7 +10869,7 @@ bool CVideoDatabase::SetSingleValue(VideoDbContentType type,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, strSQL);
+    CLog::LogF(LOGERROR, "({}) failed", strSQL);
   }
   return false;
 }
@@ -10918,7 +10910,7 @@ bool CVideoDatabase::SetSingleValue(const std::string &table, const std::string 
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, sql);
+    CLog::LogF(LOGERROR, "({}) failed", sql);
   }
   return false;
 }
@@ -11269,7 +11261,7 @@ bool CVideoDatabase::SetVideoUserRating(int dbId, int rating, const MediaType& m
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}, {}, {}) failed", __FUNCTION__, dbId, mediaType, rating);
+    CLog::LogF(LOGERROR, "({}, {}, {}) failed", dbId, mediaType, rating);
   }
   return false;
 }
@@ -11343,6 +11335,6 @@ void CVideoDatabase::EraseAllForPath(const std::string& path)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
   }
 }

--- a/xbmc/video/VideoInfoDownloader.cpp
+++ b/xbmc/video/VideoInfoDownloader.cpp
@@ -65,8 +65,7 @@ void CVideoInfoDownloader::Process()
   if (m_state == FIND_MOVIE)
   {
     if (!(m_found=FindMovie(m_movieTitle, m_movieYear, m_movieList)))
-      CLog::Log(LOGERROR, "{}: Error looking up item {} ({})", __FUNCTION__, m_movieTitle,
-                m_movieYear);
+      CLog::LogF(LOGERROR, "Error looking up item {} ({})", m_movieTitle, m_movieYear);
     m_state = DO_NOTHING;
     return;
   }
@@ -75,26 +74,23 @@ void CVideoInfoDownloader::Process()
   {
     // empty url when it's not supposed to be..
     // this might happen if the previously scraped item was removed from the site (see ticket #10537)
-    CLog::Log(LOGERROR, "{}: Error getting details for {} ({}) due to an empty url", __FUNCTION__,
-              m_movieTitle, m_movieYear);
+    CLog::LogF(LOGERROR, "Error getting details for {} ({}) due to an empty url", m_movieTitle,
+               m_movieYear);
   }
   else if (m_state == GET_DETAILS)
   {
     if (!GetDetails(m_url, m_movieDetails))
-      CLog::Log(LOGERROR, "{}: Error getting details from {}", __FUNCTION__,
-                m_url.GetFirstThumbUrl());
+      CLog::LogF(LOGERROR, "Error getting details from {}", m_url.GetFirstThumbUrl());
   }
   else if (m_state == GET_EPISODE_DETAILS)
   {
     if (!GetEpisodeDetails(m_url, m_movieDetails))
-      CLog::Log(LOGERROR, "{}: Error getting episode details from {}", __FUNCTION__,
-                m_url.GetFirstThumbUrl());
+      CLog::LogF(LOGERROR, "Error getting episode details from {}", m_url.GetFirstThumbUrl());
   }
   else if (m_state == GET_EPISODE_LIST)
   {
     if (!GetEpisodeList(m_url, m_episode))
-      CLog::Log(LOGERROR, "{}: Error getting episode list from {}", __FUNCTION__,
-                m_url.GetFirstThumbUrl());
+      CLog::LogF(LOGERROR, "Error getting episode list from {}", m_url.GetFirstThumbUrl());
   }
   m_found = 1;
   m_state = DO_NOTHING;

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -133,8 +133,8 @@ namespace VIDEO
            * doesn't exist rather than a NAS being switched off.  A manual clean from settings
            * will still pick up and remove it though.
            */
-          CLog::Log(LOGWARNING, "{} directory '{}' does not exist - skipping scan{}.", __FUNCTION__,
-                    CURL::GetRedacted(directory), m_bClean ? " and clean" : "");
+          CLog::LogF(LOGWARNING, "directory '{}' does not exist - skipping scan{}.",
+                     CURL::GetRedacted(directory), m_bClean ? " and clean" : "");
           m_pathsToScan.erase(m_pathsToScan.begin());
         }
         else if (!DoScan(directory))
@@ -1048,8 +1048,8 @@ namespace VIDEO
       if (item->IsPlugin())
         episode.item = std::make_shared<CFileItem>(*item);
       episodeList.push_back(episode);
-      CLog::Log(LOGDEBUG, "{} - found match for: {}. Season {}, Episode {}", __FUNCTION__,
-                CURL::GetRedacted(episode.strPath), episode.iSeason, episode.iEpisode);
+      CLog::LogF(LOGDEBUG, "found match for: {}. Season {}, Episode {}",
+                 CURL::GetRedacted(episode.strPath), episode.iSeason, episode.iEpisode);
       return true;
     }
 
@@ -1073,10 +1073,9 @@ namespace VIDEO
        */
       episode.cDate = item->GetVideoInfoTag()->m_firstAired;
       episodeList.push_back(episode);
-      CLog::Log(LOGDEBUG, "{} - found match for: '{}', firstAired: '{}' = '{}', title: '{}'",
-                __FUNCTION__, CURL::GetRedacted(episode.strPath),
-                tag->m_firstAired.GetAsDBDateTime(), episode.cDate.GetAsLocalizedDate(),
-                episode.strTitle);
+      CLog::LogF(LOGDEBUG, "found match for: '{}', firstAired: '{}' = '{}', title: '{}'",
+                 CURL::GetRedacted(episode.strPath), tag->m_firstAired.GetAsDBDateTime(),
+                 episode.cDate.GetAsLocalizedDate(), episode.strTitle);
       return true;
     }
 
@@ -1096,8 +1095,8 @@ namespace VIDEO
       episode.iSeason = -1;
       episode.iEpisode = -1;
       episodeList.push_back(episode);
-      CLog::Log(LOGDEBUG, "{} - found match for: '{}', title: '{}'", __FUNCTION__,
-                CURL::GetRedacted(episode.strPath), episode.strTitle);
+      CLog::LogF(LOGDEBUG, "found match for: '{}', title: '{}'", CURL::GetRedacted(episode.strPath),
+                 episode.strTitle);
       return true;
     }
 
@@ -1108,10 +1107,10 @@ namespace VIDEO
      */
     if (tag->m_iSeason == 0 && tag->m_iEpisode == 0)
     {
-      CLog::Log(LOGDEBUG,
-                "{} - found exclusion match for: {}. Both Season and Episode are 0. Item will be "
-                "ignored for scanning.",
-                __FUNCTION__, CURL::GetRedacted(item->GetPath()));
+      CLog::LogF(LOGDEBUG,
+                 "found exclusion match for: {}. Both Season and Episode are 0. Item will be "
+                 "ignored for scanning.",
+                 CURL::GetRedacted(item->GetPath()));
       return true;
     }
 
@@ -1510,9 +1509,8 @@ namespace VIDEO
     path = URIUtils::AddFileToFolder(path, CUtil::MakeLegalFileName(setTitle, LEGAL_WIN32_COMPAT));
     URIUtils::AddSlashAtEnd(path);
     CLog::Log(LOGDEBUG,
-        "VideoInfoScanner: Looking for local artwork for movie set '{}' in folder '{}'",
-        setTitle,
-        CURL::GetRedacted(path));
+              "VideoInfoScanner: Looking for local artwork for movie set '{}' in folder '{}'",
+              setTitle, CURL::GetRedacted(path));
     return CDirectory::Exists(path) ? path : "";
   }
 
@@ -1897,11 +1895,10 @@ namespace VIDEO
           {
             guide = candidates->begin() + index;
             bFound = true;
-            CLog::Log(LOGDEBUG,
-                      "{} fuzzy title match for show: '{}', title: '{}', match: '{}', score: {:f} "
-                      ">= {:f}",
-                      __FUNCTION__, showInfo.m_strTitle, file->strTitle, titles[index], matchscore,
-                      minscore);
+            CLog::LogF(LOGDEBUG,
+                       "fuzzy title match for show: '{}', title: '{}', match: '{}', score: {:f} "
+                       ">= {:f}",
+                       showInfo.m_strTitle, file->strTitle, titles[index], matchscore, minscore);
           }
         }
       }
@@ -1925,10 +1922,10 @@ namespace VIDEO
       }
       else
       {
-        CLog::Log(
+        CLog::LogF(
             LOGDEBUG,
-            "{} - no match for show: '{}', season: {}, episode: {}.{}, airdate: '{}', title: '{}'",
-            __FUNCTION__, showInfo.m_strTitle, file->iSeason, file->iEpisode, file->iSubepisode,
+            "no match for show: '{}', season: {}, episode: {}.{}, airdate: '{}', title: '{}'",
+            showInfo.m_strTitle, file->iSeason, file->iEpisode, file->iSubepisode,
             file->cDate.GetAsLocalizedDate(), file->strTitle);
       }
     }

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -1436,8 +1436,8 @@ unsigned int CVideoInfoTag::GetDurationFromMinuteString(const std::string &runti
   if (!duration)
   { // failed for some reason, or zero
     duration = strtoul(runtime.c_str(), NULL, 10);
-    CLog::Log(LOGWARNING, "{} <runtime> should be in minutes. Interpreting '{}' as {} minutes",
-              __FUNCTION__, runtime, duration);
+    CLog::LogF(LOGWARNING, "<runtime> should be in minutes. Interpreting '{}' as {} minutes",
+               runtime, duration);
   }
   return duration*60;
 }

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -103,8 +103,8 @@ bool CThumbExtractor::DoWork()
   bool result=false;
   if (m_thumb)
   {
-    CLog::Log(LOGDEBUG, "{} - trying to extract thumb from video file {}", __FUNCTION__,
-              CURL::GetRedacted(m_item.GetPath()));
+    CLog::LogF(LOGDEBUG, "trying to extract thumb from video file {}",
+               CURL::GetRedacted(m_item.GetPath()));
     // construct the thumb cache file
     CTextureDetails details;
     details.file = CTextureCache::GetCacheFile(m_target) + ".jpg";
@@ -133,8 +133,8 @@ bool CThumbExtractor::DoWork()
            !m_item.GetVideoInfoTag()->HasStreamDetails()))
   {
     // No tag or no details set, so extract them
-    CLog::Log(LOGDEBUG, "{} - trying to extract filestream details from video file {}",
-              __FUNCTION__, CURL::GetRedacted(m_item.GetPath()));
+    CLog::LogF(LOGDEBUG, "trying to extract filestream details from video file {}",
+               CURL::GetRedacted(m_item.GetPath()));
     result = CDVDFileInfo::GetFileStreamDetails(&m_item);
   }
 

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -419,8 +419,7 @@ void CGUIDialogSubtitles::OnSearchComplete(const CFileItemList *items)
           CSettings::SETTING_SUBTITLES_DOWNLOADFIRST))
   {
     CFileItemPtr item = items->Get(0);
-    CLog::Log(LOGDEBUG, "{} - Automatically download first subtitle: {}", __FUNCTION__,
-              item->GetLabel2());
+    CLog::LogF(LOGDEBUG, "Automatically download first subtitle: {}", item->GetLabel2());
     m_LastAutoDownloaded = g_application.CurrentFile();
     Download(*item);
   }
@@ -454,8 +453,8 @@ void CGUIDialogSubtitles::OnSubtitleServiceContextMenu(int itemIdx)
       }
       else
       {
-        CLog::Log(LOGERROR, "{} - Could not open settings for addon: {}", __FUNCTION__,
-                  service->GetProperty("Addon.ID").asString());
+        CLog::LogF(LOGERROR, "Could not open settings for addon: {}",
+                   service->GetProperty("Addon.ID").asString());
       }
       break;
     }
@@ -617,8 +616,7 @@ void CGUIDialogSubtitles::OnDownloadComplete(const CFileItemList *items, const s
     if (!CFile::Copy(strUrl, strDownloadFile))
     {
       CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, strSubName, g_localizeStrings.Get(24113));
-      CLog::Log(LOGERROR, "{} - Saving of subtitle {} to {} failed", __FUNCTION__, strUrl,
-                strDownloadFile);
+      CLog::LogF(LOGERROR, "Saving of subtitle {} to {} failed", strUrl, strDownloadFile);
     }
     else
     {
@@ -632,8 +630,7 @@ void CGUIDialogSubtitles::OnDownloadComplete(const CFileItemList *items, const s
          * so that all remaining items (including the .idx below) are copied directly to their final destination and thus all
          * items end up in the same folder
          */
-        CLog::Log(LOGDEBUG, "{} - Saving subtitle {} to {}", __FUNCTION__, strDownloadFile,
-                  strTryDestFile);
+        CLog::LogF(LOGDEBUG, "Saving subtitle {} to {}", strDownloadFile, strTryDestFile);
         if (CFile::Copy(strDownloadFile, strTryDestFile))
         {
           CFile::Delete(strDownloadFile);
@@ -642,14 +639,14 @@ void CGUIDialogSubtitles::OnDownloadComplete(const CFileItemList *items, const s
         }
         else
         {
-          CLog::Log(LOGWARNING, "{} - Saving of subtitle {} to {} failed. Falling back to {}",
-                    __FUNCTION__, strDownloadFile, strTryDestFile, strDownloadPath);
+          CLog::LogF(LOGWARNING, "Saving of subtitle {} to {} failed. Falling back to {}",
+                     strDownloadFile, strTryDestFile, strDownloadPath);
           strDestPath = strDownloadPath; // Copy failed, use fallback for the rest of the items
         }
       }
       else
       {
-        CLog::Log(LOGDEBUG, "{} - Saved subtitle {} to {}", __FUNCTION__, strUrl, strDownloadFile);
+        CLog::LogF(LOGDEBUG, "Saved subtitle {} to {}", strUrl, strDownloadFile);
       }
 
       // for ".sub" subtitles we check if ".idx" counterpart exists and copy that as well

--- a/xbmc/video/dialogs/GUIDialogTeletext.cpp
+++ b/xbmc/video/dialogs/GUIDialogTeletext.cpp
@@ -135,7 +135,7 @@ void CGUIDialogTeletext::OnInitWindow()
 
   if (!m_TextDecoder.InitDecoder())
   {
-    CLog::Log(LOGERROR, "{}: failed to init teletext decoder", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed to init teletext decoder");
     Close();
   }
 
@@ -143,7 +143,7 @@ void CGUIDialogTeletext::OnInitWindow()
       CTexture::CreateTexture(m_TextDecoder.GetWidth(), m_TextDecoder.GetHeight(), XB_FMT_A8R8G8B8);
   if (!m_pTxtTexture)
   {
-    CLog::Log(LOGERROR, "{}: failed to create texture", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed to create texture");
     Close();
   }
 

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -356,8 +356,8 @@ bool CGUIWindowVideoBase::ShowIMDB(CFileItemPtr item, const ScraperPtr &info2, b
           URIUtils::GetParentPath(item->GetPath(), strParentDirectory);
           if (m_database.GetTvShowId(strParentDirectory) < 0)
           {
-            CLog::Log(LOGERROR, "{}: could not add episode [{}]. tvshow does not exist yet..",
-                      __FUNCTION__, item->GetPath());
+            CLog::LogF(LOGERROR, "could not add episode [{}]. tvshow does not exist yet..",
+                       item->GetPath());
             return false;
           }
         }
@@ -1084,7 +1084,7 @@ bool CGUIWindowVideoBase::OnPlayMedia(int iItem, const std::string &player)
     item.SetPath(pItem->GetVideoInfoTag()->m_strFileNameAndPath);
     item.SetProperty("original_listitem_url", pItem->GetPath());
   }
-  CLog::Log(LOGDEBUG, "{} {}", __FUNCTION__, CURL::GetRedacted(item.GetPath()));
+  CLog::LogF(LOGDEBUG, "{}", CURL::GetRedacted(item.GetPath()));
 
   item.SetProperty("playlist_type_hint", m_guiState->GetPlaylist());
 

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -969,7 +969,7 @@ bool CGUIWindowVideoNav::OnClick(int iItem, const std::string &player)
   CFileItemPtr item = m_vecItems->Get(iItem);
   if (!item->m_bIsFolder && item->IsVideoDb() && !item->Exists())
   {
-    CLog::Log(LOGDEBUG, "{} called on '{}' but file doesn't exist", __FUNCTION__, item->GetPath());
+    CLog::LogF(LOGDEBUG, "called on '{}' but file doesn't exist", item->GetPath());
 
     const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 

--- a/xbmc/view/ViewDatabase.cpp
+++ b/xbmc/view/ViewDatabase.cpp
@@ -47,7 +47,7 @@ void CViewDatabase::CreateTables()
 
 void CViewDatabase::CreateAnalytics()
 {
-  CLog::Log(LOGINFO, "{} - creating indices", __FUNCTION__);
+  CLog::LogF(LOGINFO, "creating indices");
   m_pDS->exec("CREATE INDEX idxViews ON view(path)");
   m_pDS->exec("CREATE INDEX idxViewsWindow ON view(window)");
 }
@@ -145,7 +145,7 @@ bool CViewDatabase::GetViewState(const std::string &path, int window, CViewState
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{}, failed on path '{}'", __FUNCTION__, path);
+    CLog::LogF(LOGERROR, "failed on path '{}'", path);
   }
   return false;
 }
@@ -183,7 +183,7 @@ bool CViewDatabase::SetViewState(const std::string &path, int window, const CVie
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed on path '{}'", __FUNCTION__, path);
+    CLog::LogF(LOGERROR, "failed on path '{}'", path);
   }
   return true;
 }
@@ -202,7 +202,7 @@ bool CViewDatabase::ClearViewStates(int windowID)
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed on window '{}'", __FUNCTION__, windowID);
+    CLog::LogF(LOGERROR, "failed on window '{}'", windowID);
   }
   return true;
 }

--- a/xbmc/windowing/X11/GLContextGLX.cpp
+++ b/xbmc/windowing/X11/GLContextGLX.cpp
@@ -174,7 +174,7 @@ void CGLContextGLX::SetVSync(bool enable)
     if(m_glXSwapIntervalMESA(1) == 0)
       m_vsyncMode = 2;
     else
-      CLog::Log(LOGWARNING, "{} - glXSwapIntervalMESA failed", __FUNCTION__);
+      CLog::LogF(LOGWARNING, "glXSwapIntervalMESA failed");
   }
   if (m_glXWaitVideoSyncSGI && m_glXGetVideoSyncSGI && !m_vsyncMode)
   {
@@ -182,8 +182,7 @@ void CGLContextGLX::SetVSync(bool enable)
     if(m_glXGetVideoSyncSGI(&count) == 0)
       m_vsyncMode = 3;
     else
-      CLog::Log(LOGWARNING, "{} - glXGetVideoSyncSGI failed, glcontext probably not direct",
-                __FUNCTION__);
+      CLog::LogF(LOGWARNING, "glXGetVideoSyncSGI failed, glcontext probably not direct");
   }
 }
 
@@ -194,15 +193,13 @@ void CGLContextGLX::SwapBuffers()
     glFinish();
     unsigned int before = 0, after = 0;
     if (m_glXGetVideoSyncSGI(&before) != 0)
-      CLog::Log(LOGERROR, "{} - glXGetVideoSyncSGI - Failed to get current retrace count",
-                __FUNCTION__);
+      CLog::LogF(LOGERROR, "glXGetVideoSyncSGI - Failed to get current retrace count");
 
     glXSwapBuffers(m_dpy, m_glxWindow);
     glFinish();
 
     if(m_glXGetVideoSyncSGI(&after) != 0)
-      CLog::Log(LOGERROR, "{} - glXGetVideoSyncSGI - Failed to get current retrace count",
-                __FUNCTION__);
+      CLog::LogF(LOGERROR, "glXGetVideoSyncSGI - Failed to get current retrace count");
 
     if (after == before)
       m_iVSyncErrors = 1;
@@ -231,21 +228,19 @@ void CGLContextGLX::SwapBuffers()
     glFinish();
     unsigned int before = 0, swap = 0, after = 0;
     if (m_glXGetVideoSyncSGI(&before) != 0)
-      CLog::Log(LOGERROR, "{} - glXGetVideoSyncSGI - Failed to get current retrace count",
-                __FUNCTION__);
+      CLog::LogF(LOGERROR, "glXGetVideoSyncSGI - Failed to get current retrace count");
 
     if(m_glXWaitVideoSyncSGI(2, (before+1)%2, &swap) != 0)
-      CLog::Log(LOGERROR, "{} - glXWaitVideoSyncSGI - Returned error", __FUNCTION__);
+      CLog::LogF(LOGERROR, "glXWaitVideoSyncSGI - Returned error");
 
     glXSwapBuffers(m_dpy, m_glxWindow);
     glFinish();
 
     if (m_glXGetVideoSyncSGI(&after) != 0)
-      CLog::Log(LOGERROR, "{} - glXGetVideoSyncSGI - Failed to get current retrace count",
-                __FUNCTION__);
+      CLog::LogF(LOGERROR, "glXGetVideoSyncSGI - Failed to get current retrace count");
 
     if (after == before)
-      CLog::Log(LOGERROR, "{} - glXWaitVideoSyncSGI - Woke up early", __FUNCTION__);
+      CLog::LogF(LOGERROR, "glXWaitVideoSyncSGI - Woke up early");
 
     if (after > before + 1)
       m_iVSyncErrors++;

--- a/xbmc/windowing/X11/VideoSyncOML.cpp
+++ b/xbmc/windowing/X11/VideoSyncOML.cpp
@@ -19,7 +19,7 @@ using namespace KODI::WINDOWING::X11;
 
 bool CVideoSyncOML::Setup(PUPDATECLOCK func)
 {
-  CLog::Log(LOGDEBUG, "CVideoSyncOML::{} - setting up OML", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CVideoSyncOML: setting up OML");
 
   UpdateClock = func;
 

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -61,7 +61,7 @@ bool CWinSystemX11::InitWindowSystem()
   const char* env = getenv("DISPLAY");
   if (!env)
   {
-    CLog::Log(LOGDEBUG, "CWinSystemX11::{} - DISPLAY env not set", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "CWinSystemX11: DISPLAY env not set");
     return false;
   }
 
@@ -559,7 +559,7 @@ bool CWinSystemX11::Show(bool raise)
 
 void CWinSystemX11::NotifyXRREvent()
 {
-  CLog::Log(LOGDEBUG, "{} - notify display reset event", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "notify display reset event");
 
   std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
 
@@ -588,10 +588,10 @@ void CWinSystemX11::RecreateWindow()
   XMode   mode = g_xrandr.GetCurrentMode(m_userOutput);
 
   if (out)
-    CLog::Log(LOGDEBUG, "{} - current output: {}, mode: {}, refresh: {:.3f}", __FUNCTION__,
-              out->name, mode.id, mode.hz);
+    CLog::LogF(LOGDEBUG, "current output: {}, mode: {}, refresh: {:.3f}", out->name, mode.id,
+               mode.hz);
   else
-    CLog::Log(LOGWARNING, "{} - output name not set", __FUNCTION__);
+    CLog::LogF(LOGWARNING, "output name not set");
 
   RESOLUTION_INFO res;
   unsigned int i;
@@ -620,7 +620,7 @@ void CWinSystemX11::RecreateWindow()
 
 void CWinSystemX11::OnLostDevice()
 {
-  CLog::Log(LOGDEBUG, "{} - notify display change event", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "notify display change event");
 
   {
     std::unique_lock<CCriticalSection> lock(m_resourceSection);

--- a/xbmc/windowing/android/VideoSyncAndroid.cpp
+++ b/xbmc/windowing/android/VideoSyncAndroid.cpp
@@ -22,7 +22,7 @@
 
 bool CVideoSyncAndroid::Setup(PUPDATECLOCK func)
 {
-  CLog::Log(LOGDEBUG, "CVideoSyncAndroid::{} setting up", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CVideoSyncAndroid: setting up");
 
   //init the vblank timestamp
   m_LastVBlankTime = CurrentHostCounter();
@@ -43,7 +43,7 @@ void CVideoSyncAndroid::Run(CEvent& stopEvent)
 
 void CVideoSyncAndroid::Cleanup()
 {
-  CLog::Log(LOGDEBUG, "CVideoSyncAndroid::{} cleaning up", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CVideoSyncAndroid: cleaning up");
   CXBMCApp::Get().DeinitFrameCallback();
   CServiceBroker::GetWinSystem()->Unregister(this);
 }
@@ -51,8 +51,7 @@ void CVideoSyncAndroid::Cleanup()
 float CVideoSyncAndroid::GetFps()
 {
   m_fps = CServiceBroker::GetWinSystem()->GetGfxContext().GetFPS();
-  CLog::Log(LOGDEBUG, "CVideoSyncAndroid::{} Detected refreshrate: {:f} hertz", __FUNCTION__,
-            m_fps);
+  CLog::LogF(LOGDEBUG, "CVideoSyncAndroid: Detected refreshrate: {:f} hertz", m_fps);
   return m_fps;
 }
 

--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -90,7 +90,7 @@ bool CWinSystemAndroid::InitWindowSystem()
 
 bool CWinSystemAndroid::DestroyWindowSystem()
 {
-  CLog::Log(LOGINFO, "CWinSystemAndroid::{}", __FUNCTION__);
+  CLog::LogF(LOGINFO, "CWinSystemAndroid");
 
   delete m_android;
   m_android = nullptr;
@@ -147,7 +147,7 @@ bool CWinSystemAndroid::CreateNewWindow(const std::string& name,
 
 bool CWinSystemAndroid::DestroyWindow()
 {
-  CLog::Log(LOGINFO, "CWinSystemAndroid::{}", __FUNCTION__);
+  CLog::LogF(LOGINFO, "CWinSystemAndroid");
   m_nativeWindow.reset();
   m_bWindowCreated = false;
   return true;
@@ -165,7 +165,7 @@ void CWinSystemAndroid::UpdateResolutions(bool bUpdateDesktopRes)
   std::vector<RESOLUTION_INFO> resolutions;
   if (!m_android->ProbeResolutions(resolutions) || resolutions.empty())
   {
-    CLog::Log(LOGWARNING, "CWinSystemAndroid::{} failed.", __FUNCTION__);
+    CLog::LogF(LOGWARNING, "CWinSystemAndroid: failed.");
   }
 
   const RESOLUTION_INFO resWindow = CDisplaySettings::GetInstance().GetResolutionInfo(RES_WINDOW);

--- a/xbmc/windowing/gbm/GBMUtils.cpp
+++ b/xbmc/windowing/gbm/GBMUtils.cpp
@@ -24,8 +24,7 @@ bool CGBMUtils::CreateDevice(int fd)
   auto device = gbm_create_device(fd);
   if (!device)
   {
-    CLog::Log(LOGERROR, "CGBMUtils::{} - failed to create device: {}", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CGBMUtils: failed to create device: {}", strerror(errno));
     return false;
   }
 
@@ -57,13 +56,11 @@ bool CGBMUtils::CGBMDevice::CreateSurface(
 
   if (!surface)
   {
-    CLog::Log(LOGERROR, "CGBMUtils::{} - failed to create surface: {}", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CGBMUtils: failed to create surface: {}", strerror(errno));
     return false;
   }
 
-  CLog::Log(LOGDEBUG, "CGBMUtils::{} - created surface with size {}x{}", __FUNCTION__, width,
-            height);
+  CLog::LogF(LOGDEBUG, "CGBMUtils: created surface with size {}x{}", width, height);
 
   m_surface.reset(new CGBMSurface(surface));
 

--- a/xbmc/windowing/gbm/VideoSyncGbm.cpp
+++ b/xbmc/windowing/gbm/VideoSyncGbm.cpp
@@ -36,26 +36,26 @@ bool CVideoSyncGbm::Setup(PUPDATECLOCK func)
   UpdateClock = func;
   m_abort = false;
   m_winSystem->Register(this);
-  CLog::Log(LOGDEBUG, "CVideoSyncGbm::{} setting up", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CVideoSyncGbm: setting up");
 
   auto winSystemGbm = dynamic_cast<KODI::WINDOWING::GBM::CWinSystemGbm*>(m_winSystem);
   if (!winSystemGbm)
   {
-    CLog::Log(LOGWARNING, "CVideoSyncGbm::{}: failed to get winSystem", __FUNCTION__);
+    CLog::LogF(LOGWARNING, "CVideoSyncGbm: failed to get winSystem");
     return false;
   }
 
   auto drm = winSystemGbm->GetDrm();
   if (!drm)
   {
-    CLog::Log(LOGWARNING, "CVideoSyncGbm::{}: failed to get drm", __FUNCTION__);
+    CLog::LogF(LOGWARNING, "CVideoSyncGbm: failed to get drm");
     return false;
   }
 
   auto crtc = drm->GetCrtc();
   if (!crtc)
   {
-    CLog::Log(LOGWARNING, "CVideoSyncGbm::{}: failed to get crtc", __FUNCTION__);
+    CLog::LogF(LOGWARNING, "CVideoSyncGbm: failed to get crtc");
     return false;
   }
 
@@ -66,12 +66,12 @@ bool CVideoSyncGbm::Setup(PUPDATECLOCK func)
   m_offset = CurrentHostCounter() - ns;
   if (s != 0)
   {
-    CLog::Log(LOGWARNING, "CVideoSyncGbm::{}: drmCrtcGetSequence failed ({})", __FUNCTION__, s);
+    CLog::LogF(LOGWARNING, "CVideoSyncGbm: drmCrtcGetSequence failed ({})", s);
     return false;
   }
 
-  CLog::Log(LOGINFO, "CVideoSyncGbm::{}: opened (fd:{} crtc:{} seq:{} ns:{}:{})", __FUNCTION__,
-            m_fd, m_crtcId, m_sequence, ns, m_offset + ns);
+  CLog::LogF(LOGINFO, "CVideoSyncGbm: opened (fd:{} crtc:{} seq:{} ns:{}:{})", m_fd, m_crtcId,
+             m_sequence, ns, m_offset + ns);
   return true;
 }
 
@@ -82,10 +82,10 @@ void CVideoSyncGbm::Run(CEvent& stopEvent)
 
   if (m_fd < 0)
   {
-    CLog::Log(LOGWARNING, "CVideoSyncGbm::{}: failed to open device ({})", __FUNCTION__, m_fd);
+    CLog::LogF(LOGWARNING, "CVideoSyncGbm: failed to open device ({})", m_fd);
     return;
   }
-  CLog::Log(LOGDEBUG, "CVideoSyncGbm::{}: started {}", __FUNCTION__, m_fd);
+  CLog::LogF(LOGDEBUG, "CVideoSyncGbm: started {}", m_fd);
 
   while (!stopEvent.Signaled() && !m_abort)
   {
@@ -94,7 +94,7 @@ void CVideoSyncGbm::Run(CEvent& stopEvent)
     int s = drmCrtcGetSequence(m_fd, m_crtcId, &sequence, &ns);
     if (s != 0)
     {
-      CLog::Log(LOGWARNING, "CVideoSyncGbm::{}: drmCrtcGetSequence failed ({})", __FUNCTION__, s);
+      CLog::LogF(LOGWARNING, "CVideoSyncGbm: drmCrtcGetSequence failed ({})", s);
       break;
     }
 
@@ -108,14 +108,14 @@ void CVideoSyncGbm::Run(CEvent& stopEvent)
 
 void CVideoSyncGbm::Cleanup()
 {
-  CLog::Log(LOGDEBUG, "CVideoSyncGbm::{}: cleaning up", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CVideoSyncGbm: cleaning up");
   m_winSystem->Unregister(this);
 }
 
 float CVideoSyncGbm::GetFps()
 {
   m_fps = m_winSystem->GetGfxContext().GetFPS();
-  CLog::Log(LOGDEBUG, "CVideoSyncGbm::{}: fps:{}", __FUNCTION__, m_fps);
+  CLog::LogF(LOGDEBUG, "CVideoSyncGbm: fps:{}", m_fps);
   return m_fps;
 }
 

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -76,8 +76,7 @@ bool CWinSystemGbm::InitWindowSystem()
   const char* wayland = getenv("WAYLAND_DISPLAY");
   if (x11 || wayland)
   {
-    CLog::Log(LOGDEBUG, "CWinSystemGbm::{} - not allowed to run GBM under a window manager",
-              __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "CWinSystemGbm: not allowed to run GBM under a window manager");
     return false;
   }
 
@@ -85,21 +84,20 @@ bool CWinSystemGbm::InitWindowSystem()
 
   if (!m_DRM->InitDrm())
   {
-    CLog::Log(LOGERROR, "CWinSystemGbm::{} - failed to initialize Atomic DRM", __FUNCTION__);
+    CLog::LogF(LOGERROR, "CWinSystemGbm: failed to initialize Atomic DRM");
     m_DRM.reset();
 
     m_DRM = std::make_shared<CDRMLegacy>();
 
     if (!m_DRM->InitDrm())
     {
-      CLog::Log(LOGERROR, "CWinSystemGbm::{} - failed to initialize Legacy DRM", __FUNCTION__);
+      CLog::LogF(LOGERROR, "CWinSystemGbm: failed to initialize Legacy DRM");
       m_DRM.reset();
 
       m_DRM = std::make_shared<COffScreenModeSetting>();
       if (!m_DRM->InitDrm())
       {
-        CLog::Log(LOGERROR, "CWinSystemGbm::{} - failed to initialize off screen DRM",
-                  __FUNCTION__);
+        CLog::LogF(LOGERROR, "CWinSystemGbm: failed to initialize off screen DRM");
         m_DRM.reset();
         return false;
       }
@@ -128,13 +126,13 @@ bool CWinSystemGbm::InitWindowSystem()
   if (setting)
     setting->SetVisible(true);
 
-  CLog::Log(LOGDEBUG, "CWinSystemGbm::{} - initialized DRM", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CWinSystemGbm: initialized DRM");
   return CWinSystemBase::InitWindowSystem();
 }
 
 bool CWinSystemGbm::DestroyWindowSystem()
 {
-  CLog::Log(LOGDEBUG, "CWinSystemGbm::{} - deinitialized DRM", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CWinSystemGbm: deinitialized DRM");
 
   m_libinput.reset();
 
@@ -148,7 +146,7 @@ void CWinSystemGbm::UpdateResolutions()
   auto resolutions = m_DRM->GetModes();
   if (resolutions.empty())
   {
-    CLog::Log(LOGWARNING, "CWinSystemGbm::{} - Failed to get resolutions", __FUNCTION__);
+    CLog::LogF(LOGWARNING, "CWinSystemGbm: Failed to get resolutions");
   }
   else
   {
@@ -190,7 +188,7 @@ bool CWinSystemGbm::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
 
   if(!m_DRM->SetMode(res))
   {
-    CLog::Log(LOGERROR, "CWinSystemGbm::{} - failed to set DRM mode", __FUNCTION__);
+    CLog::LogF(LOGERROR, "CWinSystemGbm: failed to set DRM mode");
     return false;
   }
 
@@ -295,7 +293,7 @@ void CWinSystemGbm::Unregister(IDispResource *resource)
 
 void CWinSystemGbm::OnLostDevice()
 {
-  CLog::Log(LOGDEBUG, "{} - notify display change event", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "notify display change event");
   m_dispReset = true;
 
   std::unique_lock<CCriticalSection> lock(m_resourceSection);

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -75,7 +75,7 @@ bool CWinSystemGbmEGLContext::CreateNewWindow(const std::string& name,
 
   if (!m_DRM->SetMode(res))
   {
-    CLog::Log(LOGERROR, "CWinSystemGbmEGLContext::{} - failed to set DRM mode", __FUNCTION__);
+    CLog::LogF(LOGERROR, "CWinSystemGbmEGLContext: failed to set DRM mode");
     return false;
   }
 
@@ -90,7 +90,7 @@ bool CWinSystemGbmEGLContext::CreateNewWindow(const std::string& name,
   if (!m_GBM->GetDevice()->CreateSurface(res.iWidth, res.iHeight, format, modifiers.data(),
                                          modifiers.size()))
   {
-    CLog::Log(LOGERROR, "CWinSystemGbmEGLContext::{} - failed to initialize GBM", __FUNCTION__);
+    CLog::LogF(LOGERROR, "CWinSystemGbmEGLContext: failed to initialize GBM");
     return false;
   }
 
@@ -114,7 +114,7 @@ bool CWinSystemGbmEGLContext::CreateNewWindow(const std::string& name,
   m_nHeight = res.iHeight;
   m_fRefreshRate = res.fRefreshRate;
 
-  CLog::Log(LOGDEBUG, "CWinSystemGbmEGLContext::{} - initialized GBM", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CWinSystemGbmEGLContext: initialized GBM");
   return true;
 }
 
@@ -122,7 +122,7 @@ bool CWinSystemGbmEGLContext::DestroyWindow()
 {
   m_eglContext.DestroySurface();
 
-  CLog::Log(LOGDEBUG, "CWinSystemGbmEGLContext::{} - deinitialized GBM", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CWinSystemGbmEGLContext: deinitialized GBM");
   return true;
 }
 

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -93,8 +93,7 @@ bool CWinSystemGbmGLContext::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res
   if (res.iWidth != m_nWidth ||
       res.iHeight != m_nHeight)
   {
-    CLog::Log(LOGDEBUG, "CWinSystemGbmGLContext::{} - resolution changed, creating a new window",
-              __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "CWinSystemGbmGLContext: resolution changed, creating a new window");
     CreateNewWindow("", fullScreen, res);
   }
 
@@ -129,8 +128,7 @@ void CWinSystemGbmGLContext::PresentRender(bool rendered, bool videoLayer)
 
     if (m_dispReset && m_dispResetTimer.IsTimePast())
     {
-      CLog::Log(LOGDEBUG, "CWinSystemGbmGLContext::{} - Sending display reset to all clients",
-                __FUNCTION__);
+      CLog::LogF(LOGDEBUG, "CWinSystemGbmGLContext: Sending display reset to all clients");
       m_dispReset = false;
       std::unique_lock<CCriticalSection> lock(m_resourceSection);
 

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -102,8 +102,7 @@ bool CWinSystemGbmGLESContext::SetFullScreen(bool fullScreen, RESOLUTION_INFO& r
   if (res.iWidth != m_nWidth ||
       res.iHeight != m_nHeight)
   {
-    CLog::Log(LOGDEBUG, "CWinSystemGbmGLESContext::{} - resolution changed, creating a new window",
-              __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "CWinSystemGbmGLESContext: resolution changed, creating a new window");
     CreateNewWindow("", fullScreen, res);
   }
 
@@ -138,8 +137,7 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
 
     if (m_dispReset && m_dispResetTimer.IsTimePast())
     {
-      CLog::Log(LOGDEBUG, "CWinSystemGbmGLESContext::{} - Sending display reset to all clients",
-                __FUNCTION__);
+      CLog::LogF(LOGDEBUG, "CWinSystemGbmGLESContext: Sending display reset to all clients");
       m_dispReset = false;
       std::unique_lock<CCriticalSection> lock(m_resourceSection);
 

--- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
@@ -127,10 +127,10 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
   auto ret = drmModeAtomicCommit(m_fd, m_req->Get(), flags | DRM_MODE_ATOMIC_TEST_ONLY, nullptr);
   if (ret < 0)
   {
-    CLog::Log(LOGERROR,
-              "CDRMAtomic::{} - test commit failed: ({}) - falling back to last successful atomic "
-              "request",
-              __FUNCTION__, strerror(errno));
+    CLog::LogF(LOGERROR,
+               "CDRMAtomic: test commit failed: ({}) - falling back to last successful atomic "
+               "request",
+               strerror(errno));
 
     auto oldRequest = m_atomicRequestQueue.front().get();
     CDRMAtomicRequest::LogAtomicDiff(m_req, oldRequest);
@@ -144,15 +144,13 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
   ret = drmModeAtomicCommit(m_fd, m_req->Get(), flags, nullptr);
   if (ret < 0)
   {
-    CLog::Log(LOGERROR, "CDRMAtomic::{} - atomic commit failed: {}", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CDRMAtomic: atomic commit failed: {}", strerror(errno));
   }
 
   if (flags & DRM_MODE_ATOMIC_ALLOW_MODESET)
   {
     if (drmModeDestroyPropertyBlob(m_fd, blob_id) != 0)
-      CLog::Log(LOGERROR, "CDRMAtomic::{} - failed to destroy property blob: {}", __FUNCTION__,
-                strerror(errno));
+      CLog::LogF(LOGERROR, "CDRMAtomic: failed to destroy property blob: {}", strerror(errno));
   }
 
   if (m_atomicRequestQueue.size() > 1)
@@ -176,7 +174,7 @@ void CDRMAtomic::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
     drm_fb = CDRMUtils::DrmFbGetFromBo(bo);
     if (!drm_fb)
     {
-      CLog::Log(LOGERROR, "CDRMAtomic::{} - Failed to get a new FBO", __FUNCTION__);
+      CLog::LogF(LOGERROR, "CDRMAtomic: Failed to get a new FBO");
       return;
     }
   }
@@ -187,7 +185,7 @@ void CDRMAtomic::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
   {
     flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
     m_need_modeset = false;
-    CLog::Log(LOGDEBUG, "CDRMAtomic::{} - Execute modeset at next commit", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "CDRMAtomic: Execute modeset at next commit");
   }
 
   DrmAtomicCommit(!drm_fb ? 0 : drm_fb->fb_id, flags, rendered, videoLayer);
@@ -201,8 +199,7 @@ bool CDRMAtomic::InitDrm()
   auto ret = drmSetClientCap(m_fd, DRM_CLIENT_CAP_ATOMIC, 1);
   if (ret)
   {
-    CLog::Log(LOGERROR, "CDRMAtomic::{} - no atomic modesetting support: {}", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CDRMAtomic: no atomic modesetting support: {}", strerror(errno));
     return false;
   }
 
@@ -218,7 +215,7 @@ bool CDRMAtomic::InitDrm()
     AddProperty(plane.get(), "CRTC_ID", 0);
   }
 
-  CLog::Log(LOGDEBUG, "CDRMAtomic::{} - initialized atomic DRM", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CDRMAtomic: initialized atomic DRM");
 
   //! @todo: disabled until upstream kernel changes are merged
   // if (m_gui_plane->SupportsProperty("SCALING_FILTER"))
@@ -310,14 +307,14 @@ void CDRMAtomic::CDRMAtomicRequest::LogAtomicDiff(CDRMAtomicRequest* current,
     }
   }
 
-  CLog::Log(LOGDEBUG, "CDRMAtomicRequest::{} - DRM Atomic Request Diff:", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CDRMAtomicRequest: DRM Atomic Request Diff:");
 
   LogAtomicRequest(LOGERROR, atomicDiff);
 }
 
 void CDRMAtomic::CDRMAtomicRequest::LogAtomicRequest()
 {
-  CLog::Log(LOGDEBUG, "CDRMAtomicRequest::{} - DRM Atomic Request:", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CDRMAtomicRequest: DRM Atomic Request:");
   LogAtomicRequest(LOGDEBUG, m_atomicRequestItems);
 }
 

--- a/xbmc/windowing/gbm/drm/DRMConnector.cpp
+++ b/xbmc/windowing/gbm/drm/DRMConnector.cpp
@@ -65,7 +65,7 @@ bool CDRMConnector::CheckConnector()
   unsigned retryCnt = 7;
   while (!IsConnected() && retryCnt > 0)
   {
-    CLog::Log(LOGDEBUG, "CDRMConnector::{} - connector is disconnected", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "CDRMConnector: connector is disconnected");
     retryCnt--;
     KODI::TIME::Sleep(1s);
 

--- a/xbmc/windowing/gbm/drm/DRMLegacy.cpp
+++ b/xbmc/windowing/gbm/drm/DRMLegacy.cpp
@@ -36,16 +36,16 @@ bool CDRMLegacy::SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo *bo)
 
   if(ret < 0)
   {
-    CLog::Log(LOGERROR, "CDRMLegacy::{} - failed to set crtc mode: {}x{}{} @ {} Hz", __FUNCTION__,
-              m_mode->hdisplay, m_mode->vdisplay,
-              m_mode->flags & DRM_MODE_FLAG_INTERLACE ? "i" : "", m_mode->vrefresh);
+    CLog::LogF(LOGERROR, "CDRMLegacy: failed to set crtc mode: {}x{}{} @ {} Hz", m_mode->hdisplay,
+               m_mode->vdisplay, m_mode->flags & DRM_MODE_FLAG_INTERLACE ? "i" : "",
+               m_mode->vrefresh);
 
     return false;
   }
 
-  CLog::Log(LOGDEBUG, "CDRMLegacy::{} - set crtc mode: {}x{}{} @ {} Hz", __FUNCTION__,
-            m_mode->hdisplay, m_mode->vdisplay, m_mode->flags & DRM_MODE_FLAG_INTERLACE ? "i" : "",
-            m_mode->vrefresh);
+  CLog::LogF(LOGDEBUG, "CDRMLegacy: set crtc mode: {}x{}{} @ {} Hz", m_mode->hdisplay,
+             m_mode->vdisplay, m_mode->flags & DRM_MODE_FLAG_INTERLACE ? "i" : "",
+             m_mode->vrefresh);
 
   return true;
 }
@@ -101,7 +101,7 @@ bool CDRMLegacy::QueueFlip(struct gbm_bo *bo)
 
   if(ret)
   {
-    CLog::Log(LOGDEBUG, "CDRMLegacy::{} - failed to queue DRM page flip", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "CDRMLegacy: failed to queue DRM page flip");
     return false;
   }
 
@@ -125,7 +125,7 @@ bool CDRMLegacy::InitDrm()
   if (!CDRMUtils::InitDrm())
     return false;
 
-  CLog::Log(LOGDEBUG, "CDRMLegacy::{} - initialized legacy DRM", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CDRMLegacy: initialized legacy DRM");
   return true;
 }
 
@@ -133,7 +133,7 @@ bool CDRMLegacy::SetActive(bool active)
 {
   if (!m_connector->SetProperty("DPMS", active ? DRM_MODE_DPMS_ON : DRM_MODE_DPMS_OFF))
   {
-    CLog::Log(LOGDEBUG, "CDRMLegacy::{} - failed to set DPMS property", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "CDRMLegacy: failed to set DPMS property");
     return false;
   }
 

--- a/xbmc/windowing/gbm/drm/DRMPlane.cpp
+++ b/xbmc/windowing/gbm/drm/DRMPlane.cpp
@@ -47,8 +47,8 @@ bool CDRMPlane::SupportsFormatAndModifier(uint32_t format, uint64_t modifier)
   {
     if (!SupportsFormat(format))
     {
-      CLog::Log(LOGDEBUG, "CDRMPlane::{} - format not supported: {}", __FUNCTION__,
-                DRMHELPERS::FourCCToString(format));
+      CLog::LogF(LOGDEBUG, "CDRMPlane: format not supported: {}",
+                 DRMHELPERS::FourCCToString(format));
       return false;
     }
   }
@@ -57,23 +57,22 @@ bool CDRMPlane::SupportsFormatAndModifier(uint32_t format, uint64_t modifier)
     auto formatModifiers = &m_modifiers_map[format];
     if (formatModifiers->empty())
     {
-      CLog::Log(LOGDEBUG, "CDRMPlane::{} - format not supported: {}", __FUNCTION__,
-                DRMHELPERS::FourCCToString(format));
+      CLog::LogF(LOGDEBUG, "CDRMPlane: format not supported: {}",
+                 DRMHELPERS::FourCCToString(format));
       return false;
     }
 
     auto formatModifier = std::find(formatModifiers->begin(), formatModifiers->end(), modifier);
     if (formatModifier == formatModifiers->end())
     {
-      CLog::Log(LOGDEBUG, "CDRMPlane::{} - modifier ({}) not supported for format ({})",
-                __FUNCTION__, DRMHELPERS::ModifierToString(modifier),
-                DRMHELPERS::FourCCToString(format));
+      CLog::LogF(LOGDEBUG, "CDRMPlane: modifier ({}) not supported for format ({})",
+                 DRMHELPERS::ModifierToString(modifier), DRMHELPERS::FourCCToString(format));
       return false;
     }
   }
 
-  CLog::Log(LOGDEBUG, "CDRMPlane::{} - found plane format ({}) and modifier ({})", __FUNCTION__,
-            DRMHELPERS::FourCCToString(format), DRMHELPERS::ModifierToString(modifier));
+  CLog::LogF(LOGDEBUG, "CDRMPlane: found plane format ({}) and modifier ({})",
+             DRMHELPERS::FourCCToString(format), DRMHELPERS::ModifierToString(modifier));
 
   return true;
 }

--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -29,7 +29,7 @@ void DrmFbDestroyCallback(gbm_bo* bo, void* data)
 
   if (fb->fb_id > 0)
   {
-    CLog::Log(LOGDEBUG, "CDRMUtils::{} - removing framebuffer: {}", __FUNCTION__, fb->fb_id);
+    CLog::LogF(LOGDEBUG, "CDRMUtils: removing framebuffer: {}", fb->fb_id);
     int drm_fd = gbm_device_get_fd(gbm_bo_get_device(bo));
     drmModeRmFB(drm_fd, fb->fb_id);
   }
@@ -52,9 +52,9 @@ bool CDRMUtils::SetMode(const RESOLUTION_INFO& res)
   m_width = res.iWidth;
   m_height = res.iHeight;
 
-  CLog::Log(LOGDEBUG, "CDRMUtils::{} - found crtc mode: {}x{}{} @ {} Hz", __FUNCTION__,
-            m_mode->hdisplay, m_mode->vdisplay, m_mode->flags & DRM_MODE_FLAG_INTERLACE ? "i" : "",
-            m_mode->vrefresh);
+  CLog::LogF(LOGDEBUG, "CDRMUtils: found crtc mode: {}x{}{} @ {} Hz", m_mode->hdisplay,
+             m_mode->vdisplay, m_mode->flags & DRM_MODE_FLAG_INTERLACE ? "i" : "",
+             m_mode->vrefresh);
 
   return true;
 }
@@ -106,8 +106,8 @@ drm_fb * CDRMUtils::DrmFbGetFromBo(struct gbm_bo *bo)
   if (modifiers[0] && modifiers[0] != DRM_FORMAT_MOD_INVALID)
   {
     flags |= DRM_MODE_FB_MODIFIERS;
-    CLog::Log(LOGDEBUG, "CDRMUtils::{} - using modifier: {}", __FUNCTION__,
-              DRMHELPERS::ModifierToString(modifiers[0]));
+    CLog::LogF(LOGDEBUG, "CDRMUtils: using modifier: {}",
+               DRMHELPERS::ModifierToString(modifiers[0]));
   }
 
   int ret = drmModeAddFB2WithModifiers(m_fd,
@@ -136,7 +136,7 @@ drm_fb * CDRMUtils::DrmFbGetFromBo(struct gbm_bo *bo)
     if (ret < 0)
     {
       delete (fb);
-      CLog::Log(LOGDEBUG, "CDRMUtils::{} - failed to add framebuffer: {} ({})", __FUNCTION__, strerror(errno), errno);
+      CLog::LogF(LOGDEBUG, "CDRMUtils: failed to add framebuffer: {} ({})", strerror(errno), errno);
       return nullptr;
     }
   }
@@ -158,9 +158,9 @@ bool CDRMUtils::FindPreferredMode()
     if(current_mode->type & DRM_MODE_TYPE_PREFERRED)
     {
       m_mode = current_mode;
-      CLog::Log(LOGDEBUG, "CDRMUtils::{} - found preferred mode: {}x{}{} @ {} Hz", __FUNCTION__,
-                m_mode->hdisplay, m_mode->vdisplay,
-                m_mode->flags & DRM_MODE_FLAG_INTERLACE ? "i" : "", m_mode->vrefresh);
+      CLog::LogF(LOGDEBUG, "CDRMUtils: found preferred mode: {}x{}{} @ {} Hz", m_mode->hdisplay,
+                 m_mode->vdisplay, m_mode->flags & DRM_MODE_FLAG_INTERLACE ? "i" : "",
+                 m_mode->vrefresh);
       break;
     }
 
@@ -174,7 +174,7 @@ bool CDRMUtils::FindPreferredMode()
 
   if(!m_mode)
   {
-    CLog::Log(LOGDEBUG, "CDRMUtils::{} - failed to find preferred mode", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "CDRMUtils: failed to find preferred mode");
     return false;
   }
 
@@ -232,24 +232,21 @@ bool CDRMUtils::FindPlanes()
     }
   }
 
-  CLog::Log(LOGINFO, "CDRMUtils::{} - using crtc: {}", __FUNCTION__, m_crtc->GetCrtcId());
+  CLog::LogF(LOGINFO, "CDRMUtils: using crtc: {}", m_crtc->GetCrtcId());
 
   // video plane may not be available
   if (m_video_plane)
-    CLog::Log(LOGDEBUG, "CDRMUtils::{} - using video plane {}", __FUNCTION__,
-              m_video_plane->GetPlaneId());
+    CLog::LogF(LOGDEBUG, "CDRMUtils: using video plane {}", m_video_plane->GetPlaneId());
 
   if (m_gui_plane->SupportsFormat(DRM_FORMAT_XRGB2101010))
   {
     m_gui_plane->SetFormat(DRM_FORMAT_XRGB2101010);
-    CLog::Log(LOGDEBUG, "CDRMUtils::{} - using 10bit gui plane {}", __FUNCTION__,
-              m_gui_plane->GetPlaneId());
+    CLog::LogF(LOGDEBUG, "CDRMUtils: using 10bit gui plane {}", m_gui_plane->GetPlaneId());
   }
   else
   {
     m_gui_plane->SetFormat(DRM_FORMAT_XRGB8888);
-    CLog::Log(LOGDEBUG, "CDRMUtils::{} - using gui plane {}", __FUNCTION__,
-              m_gui_plane->GetPlaneId());
+    CLog::LogF(LOGDEBUG, "CDRMUtils: using gui plane {}", m_gui_plane->GetPlaneId());
   }
 
   return true;
@@ -320,20 +317,18 @@ bool CDRMUtils::OpenDrm(bool needConnector)
   int numDevices = drmGetDevices2(0, nullptr, 0);
   if (numDevices <= 0)
   {
-    CLog::Log(LOGERROR, "CDRMUtils::{} - no drm devices found: ({})", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CDRMUtils: no drm devices found: ({})", strerror(errno));
     return false;
   }
 
-  CLog::Log(LOGDEBUG, "CDRMUtils::{} - drm devices found: {}", __FUNCTION__, numDevices);
+  CLog::LogF(LOGDEBUG, "CDRMUtils: drm devices found: {}", numDevices);
 
   std::vector<drmDevicePtr> devices(numDevices);
 
   int ret = drmGetDevices2(0, devices.data(), devices.size());
   if (ret < 0)
   {
-    CLog::Log(LOGERROR, "CDRMUtils::{} - drmGetDevices2 return an error: ({})", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CDRMUtils: drmGetDevices2 return an error: ({})", strerror(errno));
     return false;
   }
 
@@ -363,8 +358,7 @@ bool CDRMUtils::OpenDrm(bool needConnector)
         continue;
     }
 
-    CLog::Log(LOGDEBUG, "CDRMUtils::{} - opened device: {}", __FUNCTION__,
-              device->nodes[DRM_NODE_PRIMARY]);
+    CLog::LogF(LOGDEBUG, "CDRMUtils: opened device: {}", device->nodes[DRM_NODE_PRIMARY]);
 
     PrintDrmDeviceInfo(device);
 
@@ -381,7 +375,7 @@ bool CDRMUtils::OpenDrm(bool needConnector)
       m_renderDevicePath = renderPath;
       m_renderFd = open(renderPath, O_RDWR | O_CLOEXEC);
       if (m_renderFd != 0)
-        CLog::Log(LOGDEBUG, "CDRMUtils::{} - opened render node: {}", __FUNCTION__, renderPath);
+        CLog::LogF(LOGDEBUG, "CDRMUtils: opened render node: {}", renderPath);
     }
 
     drmFreeDevices(devices.data(), devices.size());
@@ -401,30 +395,29 @@ bool CDRMUtils::InitDrm()
   int ret = drmSetClientCap(m_fd, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1);
   if (ret)
   {
-    CLog::Log(LOGERROR, "CDRMUtils::{} - failed to set universal planes capability: {}",
-              __FUNCTION__, strerror(errno));
+    CLog::LogF(LOGERROR, "CDRMUtils: failed to set universal planes capability: {}",
+               strerror(errno));
     return false;
   }
 
   ret = drmSetClientCap(m_fd, DRM_CLIENT_CAP_STEREO_3D, 1);
   if (ret)
   {
-    CLog::Log(LOGERROR, "CDRMUtils::{} - failed to set stereo 3d capability: {}", __FUNCTION__,
-              strerror(errno));
+    CLog::LogF(LOGERROR, "CDRMUtils: failed to set stereo 3d capability: {}", strerror(errno));
     return false;
   }
 
 #if defined(DRM_CLIENT_CAP_ASPECT_RATIO)
   ret = drmSetClientCap(m_fd, DRM_CLIENT_CAP_ASPECT_RATIO, 0);
   if (ret != 0)
-    CLog::Log(LOGERROR, "CDRMUtils::{} - aspect ratio capability is not supported: {}",
-              __FUNCTION__, strerror(errno));
+    CLog::LogF(LOGERROR, "CDRMUtils: aspect ratio capability is not supported: {}",
+               strerror(errno));
 #endif
 
   auto resources = drmModeGetResources(m_fd);
   if (!resources)
   {
-    CLog::Log(LOGERROR, "CDRMUtils::{} - failed to get drm resources: {}", __FUNCTION__, strerror(errno));
+    CLog::LogF(LOGERROR, "CDRMUtils: failed to get drm resources: {}", strerror(errno));
     return false;
   }
 
@@ -445,7 +438,7 @@ bool CDRMUtils::InitDrm()
   auto planeResources = drmModeGetPlaneResources(m_fd);
   if (!planeResources)
   {
-    CLog::Log(LOGERROR, "CDRMUtils::{} - failed to get drm plane resources: {}", __FUNCTION__, strerror(errno));
+    CLog::LogF(LOGERROR, "CDRMUtils: failed to get drm plane resources: {}", strerror(errno));
     return false;
   }
 
@@ -476,29 +469,26 @@ bool CDRMUtils::InitDrm()
   ret = drmSetMaster(m_fd);
   if (ret < 0)
   {
-    CLog::Log(LOGDEBUG,
-              "CDRMUtils::{} - failed to set drm master, will try to authorize instead: {}",
-              __FUNCTION__, strerror(errno));
+    CLog::LogF(LOGDEBUG, "CDRMUtils: failed to set drm master, will try to authorize instead: {}",
+               strerror(errno));
 
     drm_magic_t magic;
 
     ret = drmGetMagic(m_fd, &magic);
     if (ret < 0)
     {
-      CLog::Log(LOGERROR, "CDRMUtils::{} - failed to get drm magic: {}", __FUNCTION__,
-                strerror(errno));
+      CLog::LogF(LOGERROR, "CDRMUtils: failed to get drm magic: {}", strerror(errno));
       return false;
     }
 
     ret = drmAuthMagic(m_fd, magic);
     if (ret < 0)
     {
-      CLog::Log(LOGERROR, "CDRMUtils::{} - failed to authorize drm magic: {}", __FUNCTION__,
-                strerror(errno));
+      CLog::LogF(LOGERROR, "CDRMUtils: failed to authorize drm magic: {}", strerror(errno));
       return false;
     }
 
-    CLog::Log(LOGINFO, "CDRMUtils::{} - successfully authorized drm magic", __FUNCTION__);
+    CLog::LogF(LOGINFO, "CDRMUtils: successfully authorized drm magic");
   }
 
   return true;
@@ -528,8 +518,8 @@ bool CDRMUtils::FindConnector()
 
     if (connector == m_connectors.end())
     {
-      CLog::Log(LOGDEBUG, "CDRMUtils::{} - failed to find specified connector: {}, trying default",
-                __FUNCTION__, connectorName);
+      CLog::LogF(LOGDEBUG, "CDRMUtils: failed to find specified connector: {}, trying default",
+                 connectorName);
       connectorName = "Default";
     }
   }
@@ -543,12 +533,11 @@ bool CDRMUtils::FindConnector()
 
   if (connector == m_connectors.end())
   {
-    CLog::Log(LOGDEBUG, "CDRMUtils::{} - failed to find connected connector", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "CDRMUtils: failed to find connected connector");
     return false;
   }
 
-  CLog::Log(LOGINFO, "CDRMUtils::{} - using connector: {}", __FUNCTION__,
-            connector->get()->GetName());
+  CLog::LogF(LOGINFO, "CDRMUtils: using connector: {}", connector->get()->GetName());
 
   m_connector = connector->get();
   return true;
@@ -562,13 +551,12 @@ bool CDRMUtils::FindEncoder()
 
   if (encoder == m_encoders.end())
   {
-    CLog::Log(LOGDEBUG, "CDRMUtils::{} - failed to find encoder for connector id: {}", __FUNCTION__,
-              *m_connector->GetConnectorId());
+    CLog::LogF(LOGDEBUG, "CDRMUtils: failed to find encoder for connector id: {}",
+               *m_connector->GetConnectorId());
     return false;
   }
 
-  CLog::Log(LOGINFO, "CDRMUtils::{} - using encoder: {}", __FUNCTION__,
-            encoder->get()->GetEncoderId());
+  CLog::LogF(LOGINFO, "CDRMUtils: using encoder: {}", encoder->get()->GetEncoderId());
 
   m_encoder = encoder->get();
   return true;
@@ -586,9 +574,9 @@ bool CDRMUtils::FindCrtc()
         if (m_orig_crtc->GetModeValid())
         {
           m_mode = m_orig_crtc->GetMode();
-          CLog::Log(LOGDEBUG, "CDRMUtils::{} - original crtc mode: {}x{}{} @ {} Hz", __FUNCTION__,
-                    m_mode->hdisplay, m_mode->vdisplay,
-                    m_mode->flags & DRM_MODE_FLAG_INTERLACE ? "i" : "", m_mode->vrefresh);
+          CLog::LogF(LOGDEBUG, "CDRMUtils: original crtc mode: {}x{}{} @ {} Hz", m_mode->hdisplay,
+                     m_mode->vdisplay, m_mode->flags & DRM_MODE_FLAG_INTERLACE ? "i" : "",
+                     m_mode->vrefresh);
         }
         return true;
       }
@@ -611,11 +599,11 @@ bool CDRMUtils::RestoreOriginalMode()
 
   if(ret)
   {
-    CLog::Log(LOGERROR, "CDRMUtils::{} - failed to set original crtc mode", __FUNCTION__);
+    CLog::LogF(LOGERROR, "CDRMUtils: failed to set original crtc mode");
     return false;
   }
 
-  CLog::Log(LOGDEBUG, "CDRMUtils::{} - set original crtc mode", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CDRMUtils: set original crtc mode");
 
   return true;
 }

--- a/xbmc/windowing/gbm/drm/OffScreenModeSetting.cpp
+++ b/xbmc/windowing/gbm/drm/OffScreenModeSetting.cpp
@@ -24,7 +24,7 @@ bool COffScreenModeSetting::InitDrm()
   if (!CDRMUtils::OpenDrm(false))
     return false;
 
-  CLog::Log(LOGDEBUG, "COffScreenModeSetting::{} - initialized offscreen DRM", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "COffScreenModeSetting: initialized offscreen DRM");
   return true;
 }
 

--- a/xbmc/windowing/ios/VideoSyncIos.cpp
+++ b/xbmc/windowing/ios/VideoSyncIos.cpp
@@ -17,7 +17,7 @@
 
 bool CVideoSyncIos::Setup(PUPDATECLOCK func)
 {
-  CLog::Log(LOGDEBUG, "CVideoSyncIos::{} setting up OSX", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CVideoSyncIos: setting up OSX");
 
   //init the vblank timestamp
   m_LastVBlankTime = CurrentHostCounter();
@@ -42,7 +42,7 @@ void CVideoSyncIos::Run(CEvent& stopEvent)
 
 void CVideoSyncIos::Cleanup()
 {
-  CLog::Log(LOGDEBUG, "CVideoSyncIos::{} cleaning up OSX", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CVideoSyncIos: cleaning up OSX");
   DeinitDisplayLink();
   m_winSystem.Unregister(this);
 }
@@ -50,7 +50,7 @@ void CVideoSyncIos::Cleanup()
 float CVideoSyncIos::GetFps()
 {
   m_fps = CServiceBroker::GetWinSystem()->GetGfxContext().GetFPS();
-  CLog::Log(LOGDEBUG, "CVideoSyncIos::{} Detected refreshrate: {:f} hertz", __FUNCTION__, m_fps);
+  CLog::LogF(LOGDEBUG, "CVideoSyncIos: Detected refreshrate: {:f} hertz", m_fps);
   return m_fps;
 }
 

--- a/xbmc/windowing/osx/VideoSyncOsx.mm
+++ b/xbmc/windowing/osx/VideoSyncOsx.mm
@@ -25,7 +25,7 @@ using namespace std::chrono_literals;
 
 bool CVideoSyncOsx::Setup(PUPDATECLOCK func)
 {
-  CLog::Log(LOGDEBUG, "CVideoSyncOsx::{} setting up OSX", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CVideoSyncOsx: setting up OSX");
 
   //init the vblank timestamp
   m_LastVBlankTime = 0;
@@ -61,7 +61,7 @@ void CVideoSyncOsx::Run(CEvent& stopEvent)
 
 void CVideoSyncOsx::Cleanup()
 {
-  CLog::Log(LOGDEBUG, "CVideoSyncOsx::{} cleaning up OSX", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CVideoSyncOsx: cleaning up OSX");
   m_lostEvent.Set();
   m_LastVBlankTime = 0;
   CServiceBroker::GetWinSystem()->Unregister(this);
@@ -70,7 +70,7 @@ void CVideoSyncOsx::Cleanup()
 float CVideoSyncOsx::GetFps()
 {
   m_fps = CServiceBroker::GetWinSystem()->GetGfxContext().GetFPS();
-  CLog::Log(LOGDEBUG, "CVideoSyncOsx::{} Detected refreshrate: {:f} hertz", __FUNCTION__, m_fps);
+  CLog::LogF(LOGDEBUG, "CVideoSyncOsx: Detected refreshrate: {:f} hertz", m_fps);
   return m_fps;
 }
 
@@ -131,11 +131,11 @@ static CVReturn DisplayLinkCallBack(CVDisplayLinkRef displayLink, const CVTimeSt
 bool CVideoSyncOsx::InitDisplayLink()
 {
   bool ret = true;
-  CLog::Log(LOGDEBUG, "CVideoSyncOsx::{} setting up displaylink", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CVideoSyncOsx: setting up displaylink");
 
   if (!Cocoa_CVDisplayLinkCreate((void*)DisplayLinkCallBack, reinterpret_cast<void*>(this)))
   {
-    CLog::Log(LOGDEBUG, "CVideoSyncOsx::{} Cocoa_CVDisplayLinkCreate failed", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "CVideoSyncOsx: Cocoa_CVDisplayLinkCreate failed");
     ret = false;
   }
   return ret;

--- a/xbmc/windowing/tvos/VideoSyncTVos.cpp
+++ b/xbmc/windowing/tvos/VideoSyncTVos.cpp
@@ -17,7 +17,7 @@
 
 bool CVideoSyncTVos::Setup(PUPDATECLOCK func)
 {
-  CLog::Log(LOGDEBUG, "CVideoSyncTVos::{} setting up TVOS", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CVideoSyncTVos: setting up TVOS");
 
   //init the vblank timestamp
   m_LastVBlankTime = CurrentHostCounter();
@@ -42,7 +42,7 @@ void CVideoSyncTVos::Run(CEvent& stopEvent)
 
 void CVideoSyncTVos::Cleanup()
 {
-  CLog::Log(LOGDEBUG, "CVideoSyncTVos::{} cleaning up TVOS", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "CVideoSyncTVos: cleaning up TVOS");
   DeinitDisplayLink();
   m_winSystem.Unregister(this);
 }
@@ -50,7 +50,7 @@ void CVideoSyncTVos::Cleanup()
 float CVideoSyncTVos::GetFps()
 {
   m_fps = CServiceBroker::GetWinSystem()->GetGfxContext().GetFPS();
-  CLog::Log(LOGDEBUG, "CVideoSyncTVos::{} Detected refreshrate: {} hertz", __FUNCTION__, m_fps);
+  CLog::LogF(LOGDEBUG, "CVideoSyncTVos: Detected refreshrate: {} hertz", m_fps);
   return m_fps;
 }
 

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -155,7 +155,7 @@ bool CWinSystemWayland::InitWindowSystem()
   const char* env = getenv("WAYLAND_DISPLAY");
   if (!env)
   {
-    CLog::Log(LOGDEBUG, "CWinSystemWayland::{} - WAYLAND_DISPLAY env not set", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "CWinSystemWayland: WAYLAND_DISPLAY env not set");
     return false;
   }
 

--- a/xbmc/windowing/win10/WinEventsWin10.cpp
+++ b/xbmc/windowing/win10/WinEventsWin10.cpp
@@ -170,10 +170,9 @@ void CWinEventsWin10::UpdateWindowSize()
 {
   auto size = DX::DeviceResources::Get()->GetOutputSize();
 
-  CLog::Log(LOGDEBUG, __FUNCTION__ ": window resize event {:f} x {:f} (as:{})", size.Width,
-            size.Height,
-            CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_fullScreen ? "true"
-                                                                                        : "false");
+  CLog::LogF(LOGDEBUG, "window resize event {:f} x {:f} (as:{})", size.Width, size.Height,
+             CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_fullScreen ? "true"
+                                                                                         : "false");
 
   auto appView = ApplicationView::GetForCurrentView();
   appView.SetDesiredBoundsMode(ApplicationViewBoundsMode::UseCoreWindow);
@@ -192,7 +191,7 @@ void CWinEventsWin10::UpdateWindowSize()
 
 void CWinEventsWin10::OnResize(float width, float height)
 {
-  CLog::Log(LOGDEBUG, __FUNCTION__": window size changed.");
+  CLog::LogF(LOGDEBUG, "window size changed.");
   m_logicalWidth = width;
   m_logicalHeight = height;
   m_bResized = true;
@@ -211,7 +210,7 @@ void CWinEventsWin10::OnWindowSizeChanged(const CoreWindow&, const WindowSizeCha
 
 void CWinEventsWin10::OnWindowResizeStarted(const CoreWindow& sender, const winrt::IInspectable&)
 {
-  CLog::Log(LOGDEBUG, __FUNCTION__": window resize started.");
+  CLog::LogF(LOGDEBUG, "window resize started.");
   m_logicalPosX = sender.Bounds().X;
   m_logicalPosY = sender.Bounds().Y;
   m_sizeChanging = true;
@@ -219,7 +218,7 @@ void CWinEventsWin10::OnWindowResizeStarted(const CoreWindow& sender, const winr
 
 void CWinEventsWin10::OnWindowResizeCompleted(const CoreWindow& sender, const winrt::IInspectable&)
 {
-  CLog::Log(LOGDEBUG, __FUNCTION__": window resize completed.");
+  CLog::LogF(LOGDEBUG, "window resize completed.");
   m_sizeChanging = false;
 
   if (m_logicalPosX != sender.Bounds().X || m_logicalPosY != sender.Bounds().Y)
@@ -230,7 +229,7 @@ void CWinEventsWin10::OnWindowResizeCompleted(const CoreWindow& sender, const wi
 
 void CWinEventsWin10::HandleWindowSizeChanged()
 {
-  CLog::Log(LOGDEBUG, __FUNCTION__": window size/move handled.");
+  CLog::LogF(LOGDEBUG, "window size/move handled.");
   if (m_bMoved)
   {
     // it will get position from CoreWindow
@@ -254,8 +253,7 @@ void CWinEventsWin10::OnVisibilityChanged(const CoreWindow& sender, const Visibi
 
   if (g_application.GetRenderGUI() != active)
     DX::Windowing()->NotifyAppActiveChange(g_application.GetRenderGUI());
-  CLog::Log(LOGDEBUG, __FUNCTION__ ": window is {}",
-            g_application.GetRenderGUI() ? "shown" : "hidden");
+  CLog::LogF(LOGDEBUG, "window is {}", g_application.GetRenderGUI() ? "shown" : "hidden");
 }
 
 void CWinEventsWin10::OnWindowActivationChanged(const CoreWindow& sender, const WindowActivatedEventArgs& args)
@@ -276,8 +274,7 @@ void CWinEventsWin10::OnWindowActivationChanged(const CoreWindow& sender, const 
   }
   if (g_application.GetRenderGUI() != active)
     DX::Windowing()->NotifyAppActiveChange(g_application.GetRenderGUI());
-  CLog::Log(LOGDEBUG, __FUNCTION__ ": window is {}",
-            g_application.GetRenderGUI() ? "active" : "inactive");
+  CLog::LogF(LOGDEBUG, "window is {}", g_application.GetRenderGUI() ? "active" : "inactive");
 }
 
 void CWinEventsWin10::OnWindowClosed(const CoreWindow& sender, const CoreWindowEventArgs& args)
@@ -539,7 +536,7 @@ void CWinEventsWin10::OnOrientationChanged(const DisplayInformation&, const winr
 
 void CWinEventsWin10::OnDisplayContentsInvalidated(const DisplayInformation&, const winrt::IInspectable&)
 {
-  CLog::Log(LOGDEBUG, __FUNCTION__": onevent.");
+  CLog::LogF(LOGDEBUG, "onevent.");
   DX::DeviceResources::Get()->ValidateDevice();
 }
 

--- a/xbmc/windowing/win10/WinSystemWin10.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10.cpp
@@ -83,7 +83,7 @@ bool CWinSystemWin10::InitWindowSystem()
 
   if (m_displays.empty())
   {
-    CLog::Log(LOGERROR, "{} - no suitable monitor found, aborting...", __FUNCTION__);
+    CLog::LogF(LOGERROR, "no suitable monitor found, aborting...");
     return false;
   }
 
@@ -157,7 +157,7 @@ void CWinSystemWin10::FinishWindowResize(int newWidth, int newHeight)
 
 void CWinSystemWin10::AdjustWindow()
 {
-  CLog::Log(LOGDEBUG, __FUNCTION__": adjusting window if required.");
+  CLog::LogF(LOGDEBUG, "adjusting window if required.");
 
   auto appView = ApplicationView::GetForCurrentView();
   bool isInFullscreen = appView.IsFullScreenMode();
@@ -202,9 +202,9 @@ bool CWinSystemWin10::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool 
   CWinSystemWin10::UpdateStates(fullScreen);
   WINDOW_STATE state = GetState(fullScreen);
 
-  CLog::Log(LOGDEBUG, "{} ({}) with size {}x{}, refresh {:f}{}", __FUNCTION__,
-            window_state_names[state], res.iWidth, res.iHeight, res.fRefreshRate,
-            (res.dwFlags & D3DPRESENTFLAG_INTERLACED) ? "i" : "");
+  CLog::LogF(LOGDEBUG, "({}) with size {}x{}, refresh {:f}{}", window_state_names[state],
+             res.iWidth, res.iHeight, res.fRefreshRate,
+             (res.dwFlags & D3DPRESENTFLAG_INTERLACED) ? "i" : "");
 
   bool forceChange = false;    // resolution/display is changed but window state isn't changed
   bool stereoChange = IsStereoEnabled() != (CServiceBroker::GetWinSystem()->GetGfxContext().GetStereoMode() == RENDER_STEREO_MODE_HARDWAREBASED);
@@ -288,7 +288,7 @@ bool CWinSystemWin10::DPIChanged(WORD dpi, RECT windowRect) const
 
 void CWinSystemWin10::RestoreDesktopResolution()
 {
-  CLog::Log(LOGDEBUG, __FUNCTION__": restoring default desktop resolution");
+  CLog::LogF(LOGDEBUG, "restoring default desktop resolution");
   ChangeResolution(CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP));
 }
 
@@ -531,22 +531,22 @@ void CWinSystemWin10::ShowOSMouse(bool show)
 
 bool CWinSystemWin10::Minimize()
 {
-  CLog::Log(LOGDEBUG, "{} is not implemented", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "is not implemented");
   return true;
 }
 bool CWinSystemWin10::Restore()
 {
-  CLog::Log(LOGDEBUG, "{} is not implemented", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "is not implemented");
   return true;
 }
 bool CWinSystemWin10::Hide()
 {
-  CLog::Log(LOGDEBUG, "{} is not implemented", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "is not implemented");
   return true;
 }
 bool CWinSystemWin10::Show(bool raise)
 {
-  CLog::Log(LOGDEBUG, "{} is not implemented", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "is not implemented");
   return true;
 }
 
@@ -566,7 +566,7 @@ void CWinSystemWin10::Unregister(IDispResource* resource)
 
 void CWinSystemWin10::OnDisplayLost()
 {
-  CLog::Log(LOGDEBUG, "{} - notify display lost event", __FUNCTION__);
+  CLog::LogF(LOGDEBUG, "notify display lost event");
 
   {
     std::unique_lock<CCriticalSection> lock(m_resourceSection);
@@ -579,7 +579,7 @@ void CWinSystemWin10::OnDisplayReset()
 {
   if (!m_delayDispReset)
   {
-    CLog::Log(LOGDEBUG, "{} - notify display reset event", __FUNCTION__);
+    CLog::LogF(LOGDEBUG, "notify display reset event");
     std::unique_lock<CCriticalSection> lock(m_resourceSection);
     for (std::vector<IDispResource *>::iterator i = m_resources.begin(); i != m_resources.end(); ++i)
       (*i)->OnResetDisplay();

--- a/xbmc/windowing/windows/WinSystemWin32DX.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32DX.cpp
@@ -325,7 +325,7 @@ void CWinSystemWin32DX::InitHooks(IDXGIOutput* pOutput)
           }
           else
           {
-            CLog::Log(LOGDEBUG, __FUNCTION__": Unable to install and activate D3D11 hook.");
+            CLog::LogF(LOGDEBUG, "Unable to install and activate D3D11 hook.");
             s_fnOpenAdapter10_2 = nullptr;
             FreeLibrary(m_hDriverModule);
             m_hDriverModule = nullptr;

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1487,7 +1487,7 @@ bool CGUIMediaWindow::OnPlayMedia(int iItem, const std::string &player)
   CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST::TYPE_NONE);
   CFileItemPtr pItem=m_vecItems->Get(iItem);
 
-  CLog::Log(LOGDEBUG, "{} {}", __FUNCTION__, CURL::GetRedacted(pItem->GetPath()));
+  CLog::LogF(LOGDEBUG, "{}", CURL::GetRedacted(pItem->GetPath()));
 
   bool bResult = false;
   if (pItem->IsInternetStream() || pItem->IsPlayList())


### PR DESCRIPTION
## Description
There are a lot of calls to CLog::Log that use __FUNCTION__, which there should not be because there is CLog::LogF that does this. Also, it should use __func__ instead because that is actually portable. There are some calls left, but that is a tale for another day.

Before merging, the script should be removed again @lrusak

## Motivation and context
Devcon Hackathon

## How has this been tested?
Build on Linux x64

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [*] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [*] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [*] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [*] All new and existing tests passed
