### PR TITLE
[Settings] Fix setting conditions regressions

### DIFF
--- a/xbmc/settings/lib/SettingSection.cpp
+++ b/xbmc/settings/lib/SettingSection.cpp
@@ -158,11 +158,18 @@ SettingList CSettingGroup::GetSettings(SettingLevel level) const
   SettingList settings;
   for (const auto& setting : m_settings)
   {
-    if (setting->GetLevel() <= level && setting->MeetsRequirements() && setting->IsVisible())
+    if (setting->GetLevel() <= level && setting->MeetsRequirements())
       settings.push_back(setting);
   }
 
   return settings;
+}
+
+bool CSettingGroup::ContainsVisibleSettings(const SettingLevel level) const
+{
+  return std::any_of(m_settings.begin(), m_settings.end(), [&level](const SettingPtr& setting) {
+    return setting->GetLevel() <= level && setting->MeetsRequirements() && setting->IsVisible();
+  });
 }
 
 void CSettingGroup::AddSetting(const SettingPtr& setting)
@@ -256,7 +263,7 @@ SettingGroupList CSettingCategory::GetGroups(SettingLevel level) const
   SettingGroupList groups;
   for (const auto& group : m_groups)
   {
-    if (group->MeetsRequirements() && group->IsVisible() && group->GetSettings(level).size() > 0)
+    if (group->MeetsRequirements() && group->IsVisible() && group->ContainsVisibleSettings(level))
       groups.push_back(group);
   }
 

--- a/xbmc/settings/lib/SettingSection.h
+++ b/xbmc/settings/lib/SettingSection.h
@@ -56,6 +56,14 @@ public:
    */
   SettingList GetSettings(SettingLevel level) const;
 
+  /*
+   * \brief Determine if there are visible settings assigned to the given setting level (or below)
+   *        and that they meet the requirements conditions belonging to the setting group.
+   * \param level Level the settings should be assigned to
+   * \return True if there are visible settings belonging to the setting group, otherwise false
+   */
+  bool ContainsVisibleSettings(const SettingLevel level) const;
+
   void AddSetting(const std::shared_ptr<CSetting>& setting);
   void AddSettings(const SettingList &settings);
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Fix settings conditions regressions that are broken

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
the recent PR #22808 has introduced a regression that have broken settings conditions,
at least on python add-ons conditions dont works anymore correctly
the side effect can be shown here: https://www.dropbox.com/s/nk5g4lgwa8eczuw/Kodi21SettingsMenuBroken.mkv?dl=0

fix #22918

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
i attached two examples in the issue #22918

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Have a working conditions settings

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
