### PR TITLE
[subtitles] Fix mkv subtitles without duration

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecText.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecText.cpp
@@ -18,6 +18,15 @@
 
 #include <memory>
 
+namespace
+{
+// Subtitle packets reaching the decoder may not have the stop PTS value,
+// the stop value can be taken from the start PTS of the next subtitle.
+// Otherwise we fallback to a default of 20 secs duration. This is only
+// applied if the subtitle packets have 0 duration (stop > start).
+constexpr double DEFAULT_DURATION = 20.0 * static_cast<double>(DVD_TIME_BASE);
+} // namespace
+
 CDVDOverlayCodecText::CDVDOverlayCodecText() : CDVDOverlayCodec("Text Subtitle Decoder")
 {
   m_pOverlay = nullptr;
@@ -69,7 +78,23 @@ OverlayMessage CDVDOverlayCodecText::Decode(DemuxPacket* pPacket)
   {
     TagConv.ConvertLine(text);
     TagConv.CloseTag(text);
-    AddSubtitle(text, PTSStartTime, PTSStopTime);
+
+    // similar to CC text, if the subtitle duration is invalid (stop > start)
+    // we might want to assume the stop time will be set by the next received
+    // packet
+    if (PTSStopTime < PTSStartTime)
+    {
+      if (m_changePrevStopTime)
+      {
+        ChangeSubtitleStopTime(m_prevSubId, PTSStartTime);
+        m_changePrevStopTime = false;
+      }
+
+      PTSStopTime = PTSStartTime + DEFAULT_DURATION;
+      m_changePrevStopTime = true;
+    }
+
+    m_prevSubId = AddSubtitle(text, PTSStartTime, PTSStopTime);
   }
   else
     CLog::Log(LOGERROR, "{} - Failed to initialize tag converter", __FUNCTION__);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecText.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecText.h
@@ -36,5 +36,7 @@ public:
 private:
   std::shared_ptr<CDVDOverlay> m_pOverlay;
   CDVDStreamInfo m_hints;
+  int m_prevSubId{-1};
+  bool m_changePrevStopTime{false};
   AVCodecID m_codecId{AV_CODEC_ID_NONE};
 };


### PR DESCRIPTION
## Description
This fixes a regression with muxed srt subtitles that has been raised by @Leatherface75 in https://github.com/xbmc/xbmc/issues/23038. User has provided the sample https://easyupload.io/viv77l and I've confirmed this used to work in Kodi 19.5.

@CastagnaIT I am really unsure about this. According to matroska specification each subtitle packet (even srt) should have the proper duration of the block set (https://www.matroska.org/technical/subtitles.html). However, all subtitles from this file have duration 0 (from ffmpeg). This is some kind of auto-conversion done by tvheadend for teletext so I assume they probably don't know the pts of the next packet to fill the block duration correctly.  Strangely enough, mkvextract extracts the subtitle file properly with start and end timestamps correctly (maybe they have code to do this).
This all sounds like a big hack (or maybe I am reading the wrong specs) but since it used to work and the change is pretty well localised probably won't hurt much to keep it and make users happy.

More info about this: https://tvheadend.org/issues/756 : 

> tvheadend writes converted teletext subtitles as simple ascii subtitles. And in the teletext specification there is no concept of "duration" so that is why tvheadend does not write a duration in the subtitle track. And the mkv specifications does not mandate a duration for these kinds of subtitle track.

Not sure where the "does not mandate" is written but well... 🤷‍♂️ 

## Motivation and context
Fix the issue reported by the user, restore 19.5 functionality.

## How has this been tested?
Playing the sample in macOS

## What is the effect on users?
Tvheadend users might have the subtitle 

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [x] **None of the above** (please explain below)

It's explained above. So

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
