### PR TITLE
[Windows] minor refactor of DXVAHD

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -517,11 +517,10 @@ DXGI_COLOR_SPACE_TYPE CProcessorHD::GetDXGIColorSpaceSource(const DXGIColorSpace
 }
 
 DXGI_COLOR_SPACE_TYPE CProcessorHD::GetDXGIColorSpaceTarget(const DXGIColorSpaceArgs& csArgs,
-                                                            bool supportHDR)
+                                                            bool supportHDR,
+                                                            bool limitedRange) const
 {
-  DXGI_COLOR_SPACE_TYPE color;
-
-  color = DX::Windowing()->UseLimitedColor() ? DXGI_COLOR_SPACE_RGB_STUDIO_G22_NONE_P709
+  DXGI_COLOR_SPACE_TYPE color = limitedRange ? DXGI_COLOR_SPACE_RGB_STUDIO_G22_NONE_P709
                                              : DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
 
   if (!DX::Windowing()->IsHDROutput())
@@ -533,13 +532,13 @@ DXGI_COLOR_SPACE_TYPE CProcessorHD::GetDXGIColorSpaceTarget(const DXGIColorSpace
   {
     if (supportHDR)
     {
-      color = DX::Windowing()->UseLimitedColor() ? DXGI_COLOR_SPACE_RGB_STUDIO_G2084_NONE_P2020
-                                                 : DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020;
+      color = limitedRange ? DXGI_COLOR_SPACE_RGB_STUDIO_G2084_NONE_P2020
+                           : DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020;
     }
     else
     {
-      color = DX::Windowing()->UseLimitedColor() ? DXGI_COLOR_SPACE_RGB_STUDIO_G22_NONE_P2020
-                                                 : DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P2020;
+      color = limitedRange ? DXGI_COLOR_SPACE_RGB_STUDIO_G22_NONE_P2020
+                           : DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P2020;
     }
   }
 
@@ -723,9 +722,9 @@ bool CProcessorHD::Render(CRect src, CRect dst, ID3D11Resource* target, CRenderB
 
 ProcColorSpaces CProcessorHD::CalculateDXGIColorSpaces(const DXGIColorSpaceArgs& csArgs) const
 {
-  bool supportHDR = DX::Windowing()->IsHDROutput() &&
-                    (m_bSupportHDR10Limited || !DX::Windowing()->UseLimitedColor());
+  const bool limited = DX::Windowing()->UseLimitedColor();
+  const bool supportHDR = DX::Windowing()->IsHDROutput() && (m_bSupportHDR10Limited || !limited);
 
   return ProcColorSpaces{GetDXGIColorSpaceSource(csArgs, supportHDR, m_bSupportHLG),
-                         GetDXGIColorSpaceTarget(csArgs, supportHDR)};
+                         GetDXGIColorSpaceTarget(csArgs, supportHDR, limited)};
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -110,12 +110,6 @@ public:
     UnInit();
   }
 
-  static DXGI_COLOR_SPACE_TYPE GetDXGIColorSpaceSource(const DXGIColorSpaceArgs& csArgs,
-                                                       bool supportHDR,
-                                                       bool supportHLG);
-  static DXGI_COLOR_SPACE_TYPE GetDXGIColorSpaceTarget(const DXGIColorSpaceArgs& csArgs,
-                                                       bool supportHDR);
-
 protected:
   bool ReInit();
   bool InitProcessor();
@@ -129,6 +123,12 @@ protected:
    * \return the input and output color spaces
    */
   ProcColorSpaces CalculateDXGIColorSpaces(const DXGIColorSpaceArgs& csArgs) const;
+  static DXGI_COLOR_SPACE_TYPE GetDXGIColorSpaceSource(const DXGIColorSpaceArgs& csArgs,
+                                                       bool supportHDR,
+                                                       bool supportHLG);
+  DXGI_COLOR_SPACE_TYPE GetDXGIColorSpaceTarget(const DXGIColorSpaceArgs& csArgs,
+                                                bool supportHDR,
+                                                bool limitedRange) const;
 
   CCriticalSection m_section;
 


### PR DESCRIPTION
## Description
Minor refactor of DXVAHD

## Motivation and context
 - Avoids many calls to `DX::Windowing()->UseLimitedColor()`
 - No functional changes

## How has this been tested?
Runtime Windows x64

## What is the effect on users?
nothing

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
