### PR TITLE
[macos][nativewindowing] Improve app bar visual appearance 

### DIFF
--- a/xbmc/windowing/osx/OpenGL/OSXGLWindow.h
+++ b/xbmc/windowing/osx/OpenGL/OSXGLWindow.h
@@ -12,6 +12,6 @@
 
 @interface OSXGLWindow : NSWindow <NSWindowDelegate>
 
-- (id)initWithContentRect:(NSRect)box styleMask:(uint)style;
+- (nullable instancetype)initWithContentRect:(NSRect)box styleMask:(uint)style;
 
 @end

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -656,6 +656,8 @@ bool CWinSystemOSX::CreateNewWindow(const std::string& name, bool fullScreen, RE
       NSString* title = [NSString stringWithUTF8String:m_name.c_str()];
       appWindow.backgroundColor = NSColor.blackColor;
       appWindow.title = title;
+      appWindow.titlebarAppearsTransparent = YES;
+      appWindow.titleVisibility = NSWindowTitleHidden;
 
       NSWindowCollectionBehavior behavior = appWindow.collectionBehavior;
       //! @todo actually implement fullscreen tilling and remove NSWindowCollectionBehaviorFullScreenDisallowsTiling


### PR DESCRIPTION
## Description
Trivial change to make the app bar look way prettier (transparent background and no title).
Kindly stolen from @stevehartwell while looking into the NSWindowController stuff (credits given) :)

**Before:**
<img width="1217" alt="image" src="https://user-images.githubusercontent.com/7375276/230054473-e649bd1f-99d0-46ac-ae6c-7078fbba89be.png">


**Now:**
<img width="1227" alt="image" src="https://user-images.githubusercontent.com/7375276/230054123-6b57fe04-98a6-47b8-9431-878a0a06986a.png">
