### PR TITLE
[Windows] DXVA: check if BT.2020 color space is supported by video processor

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -110,6 +110,8 @@ public:
     UnInit();
   }
 
+  static bool IsBT2020Supported();
+
 protected:
   bool ReInit();
   bool InitProcessor();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -127,7 +127,8 @@ protected:
   ProcColorSpaces CalculateDXGIColorSpaces(const DXGIColorSpaceArgs& csArgs) const;
   static DXGI_COLOR_SPACE_TYPE GetDXGIColorSpaceSource(const DXGIColorSpaceArgs& csArgs,
                                                        bool supportHDR,
-                                                       bool supportHLG);
+                                                       bool supportHLG,
+                                                       bool topLeft);
   DXGI_COLOR_SPACE_TYPE GetDXGIColorSpaceTarget(const DXGIColorSpaceArgs& csArgs,
                                                 bool supportHDR,
                                                 bool limitedRange) const;
@@ -143,6 +144,7 @@ protected:
   D3D11_VIDEO_PROCESSOR_RATE_CONVERSION_CAPS m_rateCaps = {};
   bool m_bSupportHLG = false;
   bool m_bSupportHDR10Limited = false;
+  bool m_BT2020TopLeft = false;
 
   struct ProcAmpInfo
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
@@ -31,7 +31,13 @@ void CRendererDXVA::GetWeight(std::map<RenderMethod, int>& weights, const VideoP
   const AVPixelFormat av_pixel_format = picture.videoBuffer->GetFormat();
 
   if (av_pixel_format == AV_PIX_FMT_D3D11VA_VLD)
+  {
+    // Check if BT.2020 color space is supported by DXVA video processor
+    if (picture.color_primaries == AVCOL_PRI_BT2020 && !DXVA::CProcessorHD::IsBT2020Supported())
+      return;
+
     weight += 1000;
+  }
   else
   {
     // check format for buffer
@@ -56,6 +62,10 @@ void CRendererDXVA::GetWeight(std::map<RenderMethod, int>& weights, const VideoP
                  DX::DXGIFormatToString(dxgi_format));
       return;
     }
+
+    // Check if BT.2020 color space is supported by DXVA video processor
+    if (picture.color_primaries == AVCOL_PRI_BT2020 && !DXVA::CProcessorHD::IsBT2020Supported())
+      return;
 
     if (av_pixel_format == AV_PIX_FMT_NV12 ||
         av_pixel_format == AV_PIX_FMT_P010 ||


### PR DESCRIPTION
## Description
[Windows] DXVA: check if BT.2020 color space is supported by video processor

## Motivation and context
With HDR10 files is used input color space `DXGI_COLOR_SPACE_YCBCR_STUDIO_G2084_LEFT_P2020` and when HDR is not supported on system is used `DXGI_COLOR_SPACE_YCBCR_STUDIO_G22_LEFT_P2020` and transfer is converted from PQ to gamma G22 using shaders and tonemap algos (Reinhard, Hable...) but if render method is DXVA, color space BT.2020 still needs to be supported by video processor.

There are two use cases where there can be problems: old HW and old Windows.

Seems BT.2020 input color space is not supported on Intel gen 4th or older. See: https://github.com/xbmc/xbmc/pull/23074#issuecomment-1495376426

Also `ID3D11VideoContext1` is only supported from Windows 10 and fallback code only supports BT.709 & BT.601 color spaces:

https://github.com/xbmc/xbmc/blob/00d9e079941ea00e194129782ddc6ac7abffea51/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp#L667-L687

Then in Windows 8 surely is not obtained correct color conversion using this code.

This PR fixes the two use cases with fallback to Pixel Shaders when render method setting is Auto or even DXVA and BT.2020 is not supported on DXVA.

The check is implemented in a static method (self contained) to able to call it before initialization of video processor, when is evaluated render method to use in `CRendererDXVA::GetWeight`


## How has this been tested?
Runtime tested Windows x64 with HDR10 media files and simulated case when BT.2020 check returns false.
Tested with 8 bit and 10 bit swap chain and limited/full range output (all combinations).


## What is the effect on users?
Fixes black screen with old HW when BT.2020 color space is not supported using DXVA.
Fixes inaccurate BT.2020 color conversion probably in Windows 8 using DXVA.


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
