### PR TITLE
xbmc.getLanguage() remediation to provide correct Language & Region information.

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -437,6 +437,9 @@ bool CLangInfo::Load(const std::string& strLanguage)
     return false;
   }
 
+  // Load in the 'Language' information from langinfo.xml
+  // Read the locale code from the language node.
+  // This variable is potentially overwritten at a later stage
   if (pRootElement->Attribute("locale"))
     m_defaultRegion.m_strLangLocaleName = pRootElement->Attribute("locale");
 
@@ -451,6 +454,7 @@ bool CLangInfo::Load(const std::string& strLanguage)
   if (!g_LangCodeExpander.ConvertWindowsLanguageCodeToISO6392B(m_defaultRegion.m_strLangLocaleName, m_languageCodeGeneral))
     m_languageCodeGeneral = "";
 #else
+  // If the language code is not 3 char, 'de' vs 'deu', then try to find the correct 3 char code
   if (m_defaultRegion.m_strLangLocaleName.length() != 3)
   {
     if (!g_LangCodeExpander.ConvertToISO6392B(m_defaultRegion.m_strLangLocaleName, m_languageCodeGeneral))
@@ -460,6 +464,17 @@ bool CLangInfo::Load(const std::string& strLanguage)
     m_languageCodeGeneral = m_defaultRegion.m_strLangLocaleName;
 #endif
 
+  m_languageISO6392 = m_languageCodeGeneral; //This should contain the ISO-639-2 (3 char) code
+  // Try to find the 2 char code.  'fra'/'fre' -> 'fr' if one exists
+  if (!g_LangCodeExpander.ConvertToISO6391(m_languageISO6392, m_languageISO6391))
+  {
+    // If we can't find a ISO-639-1 (2 char), save the ISO-639-2 (3 char).
+    m_languageISO6391 = m_languageISO6392;
+  }
+  // Save the ISO name of the language.  'deu'/'ger' -> 'German'
+  g_LangCodeExpander.Lookup(m_languageISO6392, m_languageISOEnglishName);
+
+  // Load in the 'Region' information
   std::string tmp;
   if (g_LangCodeExpander.ConvertToISO6391(m_defaultRegion.m_strLangLocaleName, tmp))
     m_defaultRegion.m_strLangLocaleCodeTwoChar = tmp;
@@ -475,8 +490,20 @@ bool CLangInfo::Load(const std::string& strLanguage)
       if (region.m_strName.empty())
         region.m_strName=g_localizeStrings.Get(10005); // Not available
 
+      // This is actually the ISO-3166-1 Alpha-2 country code
       if (pRegion->Attribute("locale"))
+      {
         region.m_strRegionLocaleName = pRegion->Attribute("locale");
+        // Use the region locale from the langinfo.xml file,
+        // converted to upper case, to get the ISO 3166-1 Alpha-2,
+        // ISO 3166-1 Alpha-3 and English name for this country.
+        region.m_regionISO31661Alpha2 = g_LangCodeExpander.GetISO31661Alpha2(
+            StringUtils::ToUpper(region.m_strRegionLocaleName.data()));
+        region.m_regionISO31661Alpha3 =
+            g_LangCodeExpander.GetISO31661Alpha3(region.m_regionISO31661Alpha2);
+        region.m_regionISO31661EnglishName =
+            g_LangCodeExpander.GetISO31661Name(region.m_regionISO31661Alpha2);
+      }
 
 #ifdef TARGET_WINDOWS
       // Windows need 3 chars regions code
@@ -1092,6 +1119,21 @@ void CLangInfo::SetCurrentRegion(const std::string& strName)
 const std::string& CLangInfo::GetCurrentRegion() const
 {
   return m_currentRegion->m_strName;
+}
+
+const std::string& CLangInfo::GetCurrentRegionISO31661Alpha2() const
+{
+  return m_currentRegion->m_regionISO31661Alpha2;
+}
+
+const std::string& CLangInfo::GetCurrentRegionISO31661Alpha3() const
+{
+  return m_currentRegion->m_regionISO31661Alpha3;
+}
+
+const std::string& CLangInfo::GetCurrentRegionISO31661EnglishName() const
+{
+  return m_currentRegion->m_regionISO31661EnglishName;
 }
 
 CTemperature::Unit CLangInfo::GetTemperatureUnit() const

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -78,6 +78,12 @@ public:
 
   // three char language code (not win32 specific)
   const std::string& GetLanguageCode() const { return m_languageCodeGeneral; }
+  // The 2 char language code if it exists, else the 3 char code.
+  const std::string& GetLanguageISO6391() const { return m_languageISO6391; }
+  // The 3 char language code.
+  const std::string& GetLanguageISO6392() const { return m_languageISO6392; }
+  // The ISO name of the language (Not the description in the config file).
+  const std::string& GetLanguageISOEnglishName() const { return m_languageISOEnglishName; }
 
   /*!
    * \brief Convert an english language name to an addon locale,
@@ -190,6 +196,9 @@ public:
   void GetRegionNames(std::vector<std::string>& array);
   void SetCurrentRegion(const std::string& strName);
   const std::string& GetCurrentRegion() const;
+  const std::string& GetCurrentRegionISO31661Alpha2() const;
+  const std::string& GetCurrentRegionISO31661Alpha3() const;
+  const std::string& GetCurrentRegionISO31661EnglishName() const;
 
   std::set<std::string> GetSortTokens() const;
 
@@ -306,8 +315,10 @@ protected:
 
     CTemperature::Unit m_tempUnit;
     CSpeed::Unit m_speedUnit;
+    std::string m_regionISO31661Alpha2;
+    std::string m_regionISO31661Alpha3;
+    std::string m_regionISO31661EnglishName;
   };
-
 
   typedef std::map<std::string, CRegion> MAPREGIONS;
   typedef std::map<std::string, CRegion>::iterator ITMAPREGIONS;
@@ -338,6 +349,9 @@ protected:
   std::string m_audioLanguage; // ISO 639-2 three char (not win32 specific)
   std::string m_subtitleLanguage; // ISO 639-2 three char (not win32 specific)
   std::string m_languageCodeGeneral; // ISO 639-2 three char (not win32-specific)
+  std::string m_languageISO6391; // 2 char ISO ISO 639-1 (3 char if no 2 char available)
+  std::string m_languageISO6392; // 3 char ISO ISO 639-2
+  std::string m_languageISOEnglishName; // The ISO english name of this language
 };
 
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/General.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/General.h
@@ -90,6 +90,7 @@ inline bool ATTR_DLL_LOCAL UnknownToUTF8(const std::string& stringSrc,
 ///  | LANG_FMT_ENGLISH_NAME | full language name in English (Default)                    |
 ///  | LANG_FMT_ISO_639_1    | two letter code as defined in ISO 639-1                    |
 ///  | LANG_FMT_ISO_639_2    | three letter code as defined in ISO 639-2/T or ISO 639-2/B |
+///  | LANG_FMT_ISO_NAME     | full language name without qualifiers                      |
 /// @param[in] region [opt] append the region delimited by "-" of the language (setting) to the returned language string <em>(default is <b><c>false</c></b>)</em>
 /// @return active language
 ///

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/general.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/general.h
@@ -65,7 +65,9 @@ extern "C"
     /// three letter code as defined in ISO 639-2/T or ISO 639-2/B
     LANG_FMT_ISO_639_2,
     /// full language name in English
-    LANG_FMT_ENGLISH_NAME
+    LANG_FMT_ENGLISH_NAME,
+    /// full language name in English without qualifiers
+    LANG_FMT_ISO_NAME,
   } LangFormats;
   //----------------------------------------------------------------------------
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -44,8 +44,8 @@
                                                       "addon-instance/" \
                                                       "c-api/addon_base.h"
 
-#define ADDON_GLOBAL_VERSION_GENERAL                  "1.0.5"
-#define ADDON_GLOBAL_VERSION_GENERAL_MIN              "1.0.4"
+#define ADDON_GLOBAL_VERSION_GENERAL                  "1.1.0"
+#define ADDON_GLOBAL_VERSION_GENERAL_MIN              "1.1.0"
 #define ADDON_GLOBAL_VERSION_GENERAL_XML_ID           "kodi.binary.global.general"
 #define ADDON_GLOBAL_VERSION_GENERAL_DEPENDS          "General.h"
 

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -197,34 +197,41 @@ namespace XBMCAddon
           return lang;
         }
       case CLangCodeExpander::ISO_639_1:
+      {
+        if (region)
         {
-          std::string langCode;
-          g_LangCodeExpander.ConvertToISO6391(lang, langCode);
-          if (region)
-          {
-            std::string region = g_langInfo.GetRegionLocale();
-            std::string region2Code;
-            g_LangCodeExpander.ConvertToISO6391(region, region2Code);
-            region2Code = "-" + region2Code;
-            return (langCode += region2Code);
-          }
-          return langCode;
+          return StringUtils::Format("{}-{}", g_langInfo.GetLanguageISO6391(),
+                                     g_langInfo.GetCurrentRegionISO31661Alpha2());
         }
+        else
+        {
+          return g_langInfo.GetLanguageISO6391();
+        }
+      }
       case CLangCodeExpander::ISO_639_2:
+      {
+        if (region)
         {
-          std::string langCode;
-          g_LangCodeExpander.ConvertToISO6392B(lang, langCode);
-          if (region)
-          {
-            std::string region = g_langInfo.GetRegionLocale();
-            std::string region3Code;
-            g_LangCodeExpander.ConvertToISO6392B(region, region3Code);
-            region3Code = "-" + region3Code;
-            return (langCode += region3Code);
-          }
-
-          return langCode;
+          return StringUtils::Format("{}-{}", g_langInfo.GetLanguageISO6392(),
+                                     g_langInfo.GetCurrentRegionISO31661Alpha3());
         }
+        else
+        {
+          return g_langInfo.GetLanguageISO6392();
+        }
+      }
+      case CLangCodeExpander::ISO_NAME:
+      {
+        if (region)
+        {
+          return StringUtils::Format("{}-{}", g_langInfo.GetLanguageISOEnglishName(),
+                                     g_langInfo.GetCurrentRegionISO31661EnglishName());
+        }
+        else
+        {
+          return g_langInfo.GetLanguageISOEnglishName();
+        }
+      }
       default:
         return "";
       }
@@ -611,6 +618,10 @@ namespace XBMCAddon
     int getISO_639_1() { return CLangCodeExpander::ISO_639_1; }
     int getISO_639_2(){ return CLangCodeExpander::ISO_639_2; }
     int getENGLISH_NAME() { return CLangCodeExpander::ENGLISH_NAME; }
+    int getISO_NAME()
+    {
+      return CLangCodeExpander::ISO_NAME;
+    }
 
     const int lLOGDEBUG = LOGDEBUG;
   }

--- a/xbmc/interfaces/legacy/ModuleXbmc.h
+++ b/xbmc/interfaces/legacy/ModuleXbmc.h
@@ -309,6 +309,7 @@ namespace XBMCAddon
     /// | xbmc.ISO_639_1    | Two letter code as defined in ISO 639-1
     /// | xbmc.ISO_639_2    | Three letter code as defined in ISO 639-2/T or ISO 639-2/B
     /// | xbmc.ENGLISH_NAME | Full language name in English (default)
+    /// | xbmc.ISO_NAME     | Full language name without qualifiers 'English' not 'English (Australian)'
     /// @param region               [opt] append the region delimited by "-"
     ///                             of the language (setting) to the
     ///                             returned language string
@@ -317,6 +318,7 @@ namespace XBMCAddon
     ///
     /// ------------------------------------------------------------------------
     /// @python_v13 Added new options **format** and **region**.
+    /// @python_v22 Added new format ISO_NAME.
     ///
     /// **Example:**
     /// ~~~~~~~~~~~~~{.py}
@@ -891,6 +893,7 @@ namespace XBMCAddon
     SWIG_CONSTANT_FROM_GETTER(int, ISO_639_1);
     SWIG_CONSTANT_FROM_GETTER(int, ISO_639_2);
     SWIG_CONSTANT_FROM_GETTER(int, ENGLISH_NAME);
+    SWIG_CONSTANT_FROM_GETTER(int, ISO_NAME);
 #if 0
     void registerMonitor(Monitor* monitor);
     void unregisterMonitor(Monitor* monitor);

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -43,9 +43,22 @@ struct ISO3166_1
   const char* alpha3;
 };
 
+static constexpr unsigned int ISO_3166_1_ALPHA_2_LEN =
+    2; // ISO-3166-1 Alpha 2 is 2 char in length.  eg: "FR"
+static constexpr unsigned int ISO_3166_1_ALPHA_3_LEN =
+    3; // ISO-3166-1 Alpha 3 is 3 char in length.  eg: "FRA"
+
+struct ISO3166_1A2
+{
+  const char* alpha2UC{nullptr};
+  const char* alpha3UC{nullptr};
+  const char* englishname{nullptr};
+};
+
 // declared as extern to allow forward declaration
 extern const std::array<ISO639, 192> LanguageCodes;
 extern const std::array<ISO3166_1, 245> RegionCodes;
+extern const std::array<ISO3166_1A2, 249> RegionNames;
 
 CLangCodeExpander::CLangCodeExpander() = default;
 
@@ -234,6 +247,131 @@ bool CLangCodeExpander::ConvertToISO6392T(const std::string& strCharCode,
   return false;
 }
 
+std::string CLangCodeExpander::GetISO31661Alpha2(std::string_view searchString) const
+{
+  if (searchString.size() ==
+      ISO_3166_1_ALPHA_2_LEN) // Lookup based on ISO-3166-1 Alpha 2 if the search string is 2 char in length.
+  {
+    for (const ISO3166_1A2& codes : RegionNames)
+    {
+      if (searchString == codes.alpha2UC)
+      {
+        return codes.alpha2UC;
+      }
+    }
+  }
+
+  if (searchString.size() ==
+      ISO_3166_1_ALPHA_3_LEN) // Lookup based on ISO-3166-1 Alpha 3 if the search string is 3 char in length.
+  {
+    for (const ISO3166_1A2& codes : RegionNames)
+    {
+      if (searchString == codes.alpha3UC)
+      {
+        return codes.alpha2UC;
+      }
+    }
+  }
+
+  if (searchString.size() >
+      ISO_3166_1_ALPHA_3_LEN) // Lookup based on ISO-3166-1 Name if the search string longer than 3 char.
+  {
+    for (const ISO3166_1A2& codes : RegionNames)
+    {
+      // The name search is case-blind.
+      if (StringUtils::ToLower(searchString.data()) == StringUtils::ToLower(codes.englishname))
+      {
+        return codes.alpha2UC;
+      }
+    }
+  }
+
+  return {}; // The code or name was not found.
+}
+
+std::string CLangCodeExpander::GetISO31661Alpha3(std::string_view searchString) const
+{
+  if (searchString.size() ==
+      ISO_3166_1_ALPHA_2_LEN) // Lookup based on ISO-3166-1 Alpha 2 if the search string is 2 char in length.
+  {
+    for (const ISO3166_1A2& codes : RegionNames)
+    {
+      if (searchString == codes.alpha2UC)
+      {
+        return codes.alpha3UC;
+      }
+    }
+  }
+
+  if (searchString.size() ==
+      ISO_3166_1_ALPHA_3_LEN) // Lookup based on ISO-3166-1 Alpha 3 if the search string is 3 char in length.
+  {
+    for (const ISO3166_1A2& codes : RegionNames)
+    {
+      if (searchString == codes.alpha3UC)
+      {
+        return codes.alpha3UC;
+      }
+    }
+  }
+
+  if (searchString.size() >
+      ISO_3166_1_ALPHA_3_LEN) // Lookup based on ISO-3166-1 Name if the search string longer than 3 char.
+  {
+    for (const ISO3166_1A2& codes : RegionNames)
+    {
+      // The name search is case-blind.
+      if (StringUtils::ToLower(searchString.data()) == StringUtils::ToLower(codes.englishname))
+      {
+        return codes.alpha3UC;
+      }
+    }
+  }
+
+  return {}; // The code or name was not found.
+}
+
+std::string CLangCodeExpander::GetISO31661Name(std::string_view searchString) const
+{
+  if (searchString.size() ==
+      ISO_3166_1_ALPHA_2_LEN) // Lookup based on ISO-3166-1 Alpha 2 if the search string is 2 char in length.
+  {
+    for (const ISO3166_1A2& codes : RegionNames)
+    {
+      if (searchString == codes.alpha2UC)
+      {
+        return codes.englishname;
+      }
+    }
+  }
+
+  if (searchString.size() ==
+      ISO_3166_1_ALPHA_3_LEN) // Lookup based on ISO-3166-1 Alpha 3 if the search string is 3 shar in length.
+  {
+    for (const ISO3166_1A2& codes : RegionNames)
+    {
+      if (searchString == codes.alpha3UC)
+      {
+        return codes.englishname;
+      }
+    }
+  }
+
+  if (searchString.size() >
+      ISO_3166_1_ALPHA_3_LEN) // Lookup based on ISO-3166-1 Name if the search string longer than 3 char.
+  {
+    for (const ISO3166_1A2& codes : RegionNames)
+    {
+      // The name search is case-blind.
+      if (StringUtils::ToLower(searchString.data()) == StringUtils::ToLower(codes.englishname))
+      {
+        return codes.englishname;
+      }
+    }
+  }
+
+  return {}; // The code or name was not found.
+}
 
 bool CLangCodeExpander::LookupUserCode(const std::string& desc, std::string& userCode)
 {
@@ -1796,5 +1934,266 @@ const std::array<ISO3166_1, 245> RegionCodes = {{
     {"ye", "yem"},
     {"zm", "zmb"},
     {"zw", "zwe"}
+}};
+// clang-format on
+
+// clang-format off
+// The ISO3166_1 codes above have fewer entries, are in lower-case
+// and lack the name.  Ideally, these should be merged into a
+// single source of truth and the referring functions updated
+// to account for the differences in case.
+// Source: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+// Source: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3
+// The ISO standard seems to require the codes to be upper case
+const std::array<ISO3166_1A2, 249> RegionNames = {{
+    {"AD", "AND", "Andorra"},
+    {"AE", "ARE", "United Arab Emirates"},
+    {"AF", "AFG", "Afghanistan"},
+    {"AG", "ATG", "Antigua and Barbuda"},
+    {"AI", "AIA", "Anguilla"},
+    {"AL", "ALB", "Albania"},
+    {"AM", "ARM", "Armenia"},
+    {"AO", "AGO", "Angola"},
+    {"AQ", "ATA", "Antarctica"},
+    {"AR", "ARG", "Argentina"},
+    {"AS", "ASM", "American Samoa"},
+    {"AT", "AUT", "Austria"},
+    {"AU", "AUS", "Australia"},
+    {"AW", "ABW", "Aruba"},
+    {"AX", "ALA", "Åland Islands"},
+    {"AZ", "AZE", "Azerbaijan"},
+    {"BA", "BIH", "Bosnia and Herzegovina"},
+    {"BB", "BRB", "Barbados"},
+    {"BD", "BGD", "Bangladesh"},
+    {"BE", "BEL", "Belgium"},
+    {"BF", "BFA", "Burkina Faso"},
+    {"BG", "BGR", "Bulgaria"},
+    {"BH", "BHR", "Bahrain"},
+    {"BI", "BDI", "Burundi"},
+    {"BJ", "BEN", "Benin"},
+    {"BL", "BLM", "Saint Barthélemy"},
+    {"BM", "BMU", "Bermuda"},
+    {"BN", "BRN", "Brunei Darussalam"},
+    {"BO", "BOL", "Bolivia (Plurinational State of)"},
+    {"BQ", "BES", "Bonaire, Sint Eustatius and Saba"},
+    {"BR", "BRA", "Brazil"},
+    {"BS", "BHS", "Bahamas"},
+    {"BT", "BTN", "Bhutan"},
+    {"BV", "BVT", "Bouvet Island"},
+    {"BW", "BWA", "Botswana"},
+    {"BY", "BLR", "Belarus"},
+    {"BZ", "BLZ", "Belize"},
+    {"CA", "CAN", "Canada"},
+    {"CC", "CCK", "Cocos (Keeling) Islands"},
+    {"CD", "COD", "Congo, Democratic Republic of the"},
+    {"CF", "CAF", "Central African Republic"},
+    {"CG", "COG", "Congo"},
+    {"CH", "CHE", "Switzerland"},
+    {"CI", "CIV", "Côte d'Ivoire"},
+    {"CK", "COK", "Cook Islands"},
+    {"CL", "CHL", "Chile"},
+    {"CM", "CMR", "Cameroon"},
+    {"CN", "CHN", "China"},
+    {"CO", "COL", "Colombia"},
+    {"CR", "CRI", "Costa Rica"},
+    {"CU", "CUB", "Cuba"},
+    {"CV", "CPV", "Cabo Verde"},
+    {"CW", "CUW", "Curaçao"},
+    {"CX", "CXR", "Christmas Island"},
+    {"CY", "CYP", "Cyprus"},
+    {"CZ", "CZE", "Czechia"},
+    {"DE", "DEU", "Germany"},
+    {"DJ", "DJI", "Djibouti"},
+    {"DK", "DNK", "Denmark"},
+    {"DM", "DMA", "Dominica"},
+    {"DO", "DOM", "Dominican Republic"},
+    {"DZ", "DZA", "Algeria"},
+    {"EC", "ECU", "Ecuador"},
+    {"EE", "EST", "Estonia"},
+    {"EG", "EGY", "Egypt"},
+    {"EH", "ESH", "Western Sahara"},
+    {"ER", "ERI", "Eritrea"},
+    {"ES", "ESP", "Spain"},
+    {"ET", "ETH", "Ethiopia"},
+    {"FI", "FIN", "Finland"},
+    {"FJ", "FJI", "Fiji"},
+    {"FK", "FLK", "Falkland Islands (Malvinas)"},
+    {"FM", "FSM", "Micronesia (Federated States of)"},
+    {"FO", "FRO", "Faroe Islands"},
+    {"FR", "FRA", "France"},
+    {"GA", "GAB", "Gabon"},
+    {"GB", "GBR", "United Kingdom of Great Britain and Northern Ireland"},
+    {"GD", "GRD", "Grenada"},
+    {"GE", "GEO", "Georgia"},
+    {"GF", "GUF", "French Guiana"},
+    {"GG", "GGY", "Guernsey"},
+    {"GH", "GHA", "Ghana"},
+    {"GI", "GIB", "Gibraltar"},
+    {"GL", "GRL", "Greenland"},
+    {"GM", "GMB", "Gambia"},
+    {"GN", "GIN", "Guinea"},
+    {"GP", "GLP", "Guadeloupe"},
+    {"GQ", "GNQ", "Equatorial Guinea"},
+    {"GR", "GRC", "Greece"},
+    {"GS", "SGS", "South Georgia and the South Sandwich Islands"},
+    {"GT", "GTM", "Guatemala"},
+    {"GU", "GUM", "Guam"},
+    {"GW", "GNB", "Guinea-Bissau"},
+    {"GY", "GUY", "Guyana"},
+    {"HK", "HKG", "Hong Kong"},
+    {"HM", "HMD", "Heard Island and McDonald Islands"},
+    {"HN", "HND", "Honduras"},
+    {"HR", "HRV", "Croatia"},
+    {"HT", "HTI", "Haiti"},
+    {"HU", "HUN", "Hungary"},
+    {"ID", "IDN", "Indonesia"},
+    {"IE", "IRL", "Ireland"},
+    {"IL", "ISR", "Israel"},
+    {"IM", "IMN", "Isle of Man"},
+    {"IN", "IND", "India"},
+    {"IO", "IOT", "British Indian Ocean Territory"},
+    {"IQ", "IRQ", "Iraq"},
+    {"IR", "IRN", "Iran (Islamic Republic of)"},
+    {"IS", "ISL", "Iceland"},
+    {"IT", "ITA", "Italy"},
+    {"JE", "JEY", "Jersey"},
+    {"JM", "JAM", "Jamaica"},
+    {"JO", "JOR", "Jordan"},
+    {"JP", "JPN", "Japan"},
+    {"KE", "KEN", "Kenya"},
+    {"KG", "KGZ", "Kyrgyzstan"},
+    {"KH", "KHM", "Cambodia"},
+    {"KI", "KIR", "Kiribati"},
+    {"KM", "COM", "Comoros"},
+    {"KN", "KNA", "Saint Kitts and Nevis"},
+    {"KP", "PRK", "Korea (Democratic People's Republic of)"},
+    {"KR", "KOR", "Korea, Republic of"},
+    {"KW", "KWT", "Kuwait"},
+    {"KY", "CYM", "Cayman Islands"},
+    {"KZ", "KAZ", "Kazakhstan"},
+    {"LA", "LAO", "Lao People's Democratic Republic"},
+    {"LB", "LBN", "Lebanon"},
+    {"LC", "LCA", "Saint Lucia"},
+    {"LI", "LIE", "Liechtenstein"},
+    {"LK", "LKA", "Sri Lanka"},
+    {"LR", "LBR", "Liberia"},
+    {"LS", "LSO", "Lesotho"},
+    {"LT", "LTU", "Lithuania"},
+    {"LU", "LUX", "Luxembourg"},
+    {"LV", "LVA", "Latvia"},
+    {"LY", "LBY", "Libya"},
+    {"MA", "MAR", "Morocco"},
+    {"MC", "MCO", "Monaco"},
+    {"MD", "MDA", "Moldova, Republic of"},
+    {"ME", "MNE", "Montenegro"},
+    {"MF", "MAF", "Saint Martin (French part)"},
+    {"MG", "MDG", "Madagascar"},
+    {"MH", "MHL", "Marshall Islands"},
+    {"MK", "MKD", "North Macedonia"},
+    {"ML", "MLI", "Mali"},
+    {"MM", "MMR", "Myanmar"},
+    {"MN", "MNG", "Mongolia"},
+    {"MO", "MAC", "Macao"},
+    {"MP", "MNP", "Northern Mariana Islands"},
+    {"MQ", "MTQ", "Martinique"},
+    {"MR", "MRT", "Mauritania"},
+    {"MS", "MSR", "Montserrat"},
+    {"MT", "MLT", "Malta"},
+    {"MU", "MUS", "Mauritius"},
+    {"MV", "MDV", "Maldives"},
+    {"MW", "MWI", "Malawi"},
+    {"MX", "MEX", "Mexico"},
+    {"MY", "MYS", "Malaysia"},
+    {"MZ", "MOZ", "Mozambique"},
+    {"NA", "NAM", "Namibia"},
+    {"NC", "NCL", "New Caledonia"},
+    {"NE", "NER", "Niger"},
+    {"NF", "NFK", "Norfolk Island"},
+    {"NG", "NGA", "Nigeria"},
+    {"NI", "NIC", "Nicaragua"},
+    {"NL", "NLD", "Netherlands"},
+    {"NO", "NOR", "Norway"},
+    {"NP", "NPL", "Nepal"},
+    {"NR", "NRU", "Nauru"},
+    {"NU", "NIU", "Niue"},
+    {"NZ", "NZL", "New Zealand"},
+    {"OM", "OMN", "Oman"},
+    {"PA", "PAN", "Panama"},
+    {"PE", "PER", "Peru"},
+    {"PF", "PYF", "French Polynesia"},
+    {"PG", "PNG", "Papua New Guinea"},
+    {"PH", "PHL", "Philippines"},
+    {"PK", "PAK", "Pakistan"},
+    {"PL", "POL", "Poland"},
+    {"PM", "SPM", "Saint Pierre and Miquelon"},
+    {"PN", "PCN", "Pitcairn"},
+    {"PR", "PRI", "Puerto Rico"},
+    {"PS", "PSE", "Palestine, State of"},
+    {"PT", "PRT", "Portugal"},
+    {"PW", "PLW", "Palau"},
+    {"PY", "PRY", "Paraguay"},
+    {"QA", "QAT", "Qatar"},
+    {"RE", "REU", "Réunion"},
+    {"RO", "ROU", "Romania"},
+    {"RS", "SRB", "Serbia"},
+    {"RU", "RUS", "Russian Federation"},
+    {"RW", "RWA", "Rwanda"},
+    {"SA", "SAU", "Saudi Arabia"},
+    {"SB", "SLB", "Solomon Islands"},
+    {"SC", "SYC", "Seychelles"},
+    {"SD", "SDN", "Sudan"},
+    {"SE", "SWE", "Sweden"},
+    {"SG", "SGP", "Singapore"},
+    {"SH", "SHN", "Saint Helena, Ascension and Tristan da Cunha"},
+    {"SI", "SVN", "Slovenia"},
+    {"SJ", "SJM", "Svalbard and Jan Mayen"},
+    {"SK", "SVK", "Slovakia"},
+    {"SL", "SLE", "Sierra Leone"},
+    {"SM", "SMR", "San Marino"},
+    {"SN", "SEN", "Senegal"},
+    {"SO", "SOM", "Somalia"},
+    {"SR", "SUR", "Suriname"},
+    {"SS", "SSD", "South Sudan"},
+    {"ST", "STP", "Sao Tome and Principe"},
+    {"SV", "SLV", "El Salvador"},
+    {"SX", "SXM", "Sint Maarten (Dutch part)"},
+    {"SY", "SYR", "Syrian Arab Republic"},
+    {"SZ", "SWZ", "Eswatini"},
+    {"TC", "TCA", "Turks and Caicos Islands"},
+    {"TD", "TCD", "Chad"},
+    {"TF", "ATF", "French Southern Territories"},
+    {"TG", "TGO", "Togo"},
+    {"TH", "THA", "Thailand"},
+    {"TJ", "TJK", "Tajikistan"},
+    {"TK", "TKL", "Tokelau"},
+    {"TL", "TLS", "Timor-Leste"},
+    {"TM", "TKM", "Turkmenistan"},
+    {"TN", "TUN", "Tunisia"},
+    {"TO", "TON", "Tonga"},
+    {"TR", "TUR", "Türkiye"},
+    {"TT", "TTO", "Trinidad and Tobago"},
+    {"TV", "TUV", "Tuvalu"},
+    {"TW", "TWN", "Taiwan, Province of China"},
+    {"TZ", "TZA", "Tanzania, United Republic of"},
+    {"UA", "UKR", "Ukraine"},
+    {"UG", "UGA", "Uganda"},
+    {"UM", "UMI", "United States Minor Outlying Islands"},
+    {"US", "USA", "United States of America"},
+    {"UY", "URY", "Uruguay"},
+    {"UZ", "UZB", "Uzbekistan"},
+    {"VA", "VAT", "Holy See"},
+    {"VC", "VCT", "Saint Vincent and the Grenadines"},
+    {"VE", "VEN", "Venezuela (Bolivarian Republic of)"},
+    {"VG", "VGB", "Virgin Islands (British)"},
+    {"VI", "VIR", "Virgin Islands (U.S.)"},
+    {"VN", "VNM", "Viet Nam"},
+    {"VU", "VUT", "Vanuatu"},
+    {"WF", "WLF", "Wallis and Futuna"},
+    {"WS", "WSM", "Samoa"},
+    {"YE", "YEM", "Yemen"},
+    {"YT", "MYT", "Mayotte"},
+    {"ZA", "ZAF", "South Africa"},
+    {"ZM", "ZMB", "Zambia"},
+    {"ZW", "ZWE", "Zimbabwe"}
 }};
 // clang-format on

--- a/xbmc/utils/LangCodeExpander.h
+++ b/xbmc/utils/LangCodeExpander.h
@@ -24,7 +24,8 @@ public:
   {
     ISO_639_1,
     ISO_639_2,
-    ENGLISH_NAME
+    ENGLISH_NAME,
+    ISO_NAME,
   };
 
   enum class LANG_LIST
@@ -139,6 +140,39 @@ public:
    */
   std::vector<std::string> GetLanguageNames(LANGFORMATS format = ISO_639_1,
                                             LANG_LIST list = LANG_LIST::DEFAULT);
+
+  /*!
+   * \brief Get an ISO 3166-1 Alpha-2 code.
+   *          Input can be alpha-2 (eg: "AU"), alpha-3 (eg: "AUS")
+   *          or country name (eg: "Australia").
+   *          If the input is a name, the test is case-blind,
+   *          otherwise the code must be upper case.
+   *   \param[in] searchString The code or name to be found.
+   *   \return The Alpha-2 string if found or empty string if not.
+   */
+  std::string GetISO31661Alpha2(std::string_view searchString) const;
+
+  /*!
+   * \brief Get an ISO 3166-1 Alpha-3 code.
+   *          Input can be alpha-2 (eg: "AU"), alpha-3 (eg: "AUS")
+   *          or country name (eg: "Australia").
+   *          If the input is a name, the test is case-blind,
+   *          otherwise the code must be upper case.
+   *   \param[in] searchString The code or name to be found.
+   *   \return The Alpha-3 string if found or empty string if not.
+   */
+  std::string GetISO31661Alpha3(std::string_view searchString) const;
+
+  /*!
+   * \brief Get an ISO 3166-1 name.
+   *          Input can be alpha-2 (eg: "AU"), alpha-3 (eg: "AUS")
+   *          or country name (eg: "Australia").
+   *          If the input is a name, the test is case-blind,
+   *          otherwise the code must be upper case.
+   *   \param[in] searchString The code or name to be found.
+   *   \return The name string if found or empty string if not.
+   */
+  std::string GetISO31661Name(std::string_view searchString) const;
 
 protected:
   /*

--- a/xbmc/utils/test/TestLangCodeExpander.cpp
+++ b/xbmc/utils/test/TestLangCodeExpander.cpp
@@ -27,3 +27,103 @@ TEST(TestLangCodeExpander, ConvertToISO6392B)
   g_LangCodeExpander.ConvertToISO6392B("en", varstr);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 }
+
+TEST(TestLangCodeExpander, GetISO31661Alpha2)
+{
+  std::string testString, outString;
+
+  // Test getting the ISO 3166-1 alpha-2 from the country name
+  testString = "LB";
+  outString = g_LangCodeExpander.GetISO31661Alpha2("Lebanon");
+  EXPECT_EQ(testString, outString);
+
+  // Test getting the ISO 3166-1 alpha-2 from the alpha-3
+  testString = "NZ";
+  outString = g_LangCodeExpander.GetISO31661Alpha2("NZL");
+  EXPECT_EQ(testString, outString);
+
+  // Test getting the ISO 3166-1 alpha-2 from the alpha-2
+  testString = "CA";
+  outString = g_LangCodeExpander.GetISO31661Alpha2("CA");
+  EXPECT_EQ(testString, outString);
+
+  // Test with mixed-case country name
+  testString = "GF";
+  outString = g_LangCodeExpander.GetISO31661Alpha2("FrEnCh GuIaNa");
+  EXPECT_EQ(testString, outString);
+
+  // Test with invalid country name
+  testString = "";
+  outString = g_LangCodeExpander.GetISO31661Alpha2("No-A-Real-Country");
+  EXPECT_EQ(testString, outString);
+
+  // Test with lower case code input
+  testString = "";
+  outString = g_LangCodeExpander.GetISO31661Alpha2("dnk");
+  EXPECT_EQ(testString, outString);
+}
+
+TEST(TestLangCodeExpander, GetISO31661Alpha3)
+{
+  std::string testString, outString;
+
+  // Test getting the ISO 3166-1 alpha-3 from the country name
+  testString = "CIV";
+  outString = g_LangCodeExpander.GetISO31661Alpha3("Côte d'Ivoire");
+  EXPECT_EQ(testString, outString);
+
+  // Test getting the ISO 3166-1 alpha-3 from the alpha-2
+  testString = "MLI";
+  outString = g_LangCodeExpander.GetISO31661Alpha3("ML");
+  EXPECT_EQ(testString, outString);
+
+  // Test getting the ISO 3166-1 alpha-3 from the alpha-3
+  testString = "MTQ";
+  outString = g_LangCodeExpander.GetISO31661Alpha3("MTQ");
+  EXPECT_EQ(testString, outString);
+
+  // Test with mixed-case country name
+  testString = "LIE";
+  outString = g_LangCodeExpander.GetISO31661Alpha3("LiEChtENsTeiN");
+  EXPECT_EQ(testString, outString);
+
+  // Test with invalid country name
+  testString = "";
+  outString = g_LangCodeExpander.GetISO31661Alpha3("e=mc2");
+  EXPECT_EQ(testString, outString);
+
+  // Test with lower case code input
+  testString = "";
+  outString = g_LangCodeExpander.GetISO31661Alpha2("ch");
+  EXPECT_EQ(testString, outString);
+}
+
+TEST(TestLangCodeExpander, GetISO31661Name)
+{
+  std::string testString, outString;
+
+  // Test getting the ISO 3166-1 name from the country name
+  testString = "Norway";
+  outString = g_LangCodeExpander.GetISO31661Name("Norway");
+  EXPECT_EQ(testString, outString);
+
+  // Test getting the ISO 3166-1 name from the alpha-2
+  testString = "Papua New Guinea";
+  outString = g_LangCodeExpander.GetISO31661Name("PG");
+  EXPECT_EQ(testString, outString);
+
+  // Test getting the ISO 3166-1 name from the alpha-3
+  testString = "South Sudan";
+  outString = g_LangCodeExpander.GetISO31661Name("SSD");
+  EXPECT_EQ(testString, outString);
+
+  // Test with mixed-case country name
+  testString = "Seychelles";
+  outString = g_LangCodeExpander.GetISO31661Name("SeYcHElLEs");
+  EXPECT_EQ(testString, outString);
+
+  // Test with invalid country name
+  testString = "";
+  outString = g_LangCodeExpander.GetISO31661Name("Some-Random-Text");
+  EXPECT_EQ(testString, outString);
+}


### PR DESCRIPTION
## Description

The CLangCodeExpander class has been expanded to include new ISO 3166-1 (Country Code) lookup capabilities for Alpha-2, Alpha-3 and Name.

CLangInfo::Load and CLangInfo::SetCurrentRegion have been modified to perform additional lookups (ISO_639_X [language] and ISO 3166-1 [country]) as the langinfo.xml file is loaded with the results being stored as new properties of their respective objects.  New getter methods were added to obtain these new property values.

GetLanguageConfigCode()
GetLanguageISO6391()
GetLanguageISO6392()
GetLanguageISOEnglishName()
GetCurrentRegionISO31661Alpha2()
GetCurrentRegionISO31661Alpha3()
GetCurrentRegionISO31661EnglishName()

xbmc.getLanguage() has been updated as follows:

xbmc.getLanguage(ENGLISH_NAME) - Remains unchanged for backwards compatibility.

xbmc.getLanguage(ISO_639_1) - Updated to return values based on the 'locale' properties in the langinfo.xml file.  An ISO_639_2 value is returned where an ISO_639_1 does not exist for a language.

xbmc.getLanguage(ISO_639_2) - Updated to return values based on the 'locale' properties in the langinfo.xml file.  The 'locale' properties in the langinfo.xml file are used to return the ISO_639_2 and ISO 3166-1 alpha-3 codes.

xbmc.getLanguage(ISO_NAME) - Added to return the 'clean' names for the language and regions based on a lookup table using the 'locale' properties in the langinfo.xml file.

For example: 'English-Australia' instead of 'English (Australia) - Australia (24h)'

## Motivation and context

Provide correct language information to addons.

https://github.com/xbmc/xbmc/issues/22715

## How has this been tested?

Custom addon used to assess the returned values for a number of language and region combinations.

Log extract BEFORE:

xbmc.getLanguage(xbmc.ENGLISH_NAME, True) = English (Australia)-Australia (24h)
xbmc.getLanguage(xbmc.ENGLISH_NAME, False) = English (Australia)
xbmc.getLanguage(xbmc.ISO_639_2, True) = en-au-
xbmc.getLanguage(xbmc.ISO_639_2, False) = en-au
xbmc.getLanguage(xbmc.ISO_639_1, True) = -
xbmc.getLanguage(xbmc.ISO_639_1, False) =

Log extract AFTER:

xbmc.getLanguage(xbmc.ENGLISH_NAME, True) = English (Australia)-Australia (24h)
xbmc.getLanguage(xbmc.ENGLISH_NAME, False) = English (Australia)
xbmc.getLanguage(xbmc.ISO_639_2, True) = eng-AUS
xbmc.getLanguage(xbmc.ISO_639_2, False) = eng
xbmc.getLanguage(xbmc.ISO_639_1, True) = en-AU
xbmc.getLanguage(xbmc.ISO_639_1, False) = en
xbmc.getLanguage(xbmc.ISO_NAME, False) = English
xbmc.getLanguage(xbmc.ISO_NAME, True) = English-Australia

Language with ISO_639_2 only:

BEFORE:

xbmc.getLanguage(xbmc.ENGLISH_NAME, True) = Filipino (Talagog)-Philippines (12h)
xbmc.getLanguage(xbmc.ENGLISH_NAME, False) = Filipino (Talagog)
xbmc.getLanguage(xbmc.ISO_639_2, True) = fil-
xbmc.getLanguage(xbmc.ISO_639_2, False) = fil
xbmc.getLanguage(xbmc.ISO_639_1, True) = -
xbmc.getLanguage(xbmc.ISO_639_1, False) = 

AFTER:

xbmc.getLanguage(xbmc.ENGLISH_NAME, True) = Filipino (Talagog)-Philippines (12h)
xbmc.getLanguage(xbmc.ENGLISH_NAME, False) = Filipino (Talagog)
xbmc.getLanguage(xbmc.ISO_639_2, True) = fil-PHL
xbmc.getLanguage(xbmc.ISO_639_2, False) = fil
xbmc.getLanguage(xbmc.ISO_639_1, True) = fil-PH
xbmc.getLanguage(xbmc.ISO_639_1, False) = fil
xbmc.getLanguage(xbmc.ISO_NAME, False) = Filipino
xbmc.getLanguage(xbmc.ISO_NAME, True) = Filipino-Philippines

## What is the effect on users?

Standard Kodi users should see no change to the UI.  Python add-on developers will now be able to obtain the correct language and region codes and names.

## Screenshots (if appropriate):

## Types of change

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
