### PR TITLE
[Windows] Implements DXVA2 AV1 HW video decoding 8-bit and 10-bit

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -1028,9 +1028,9 @@ bool CDVDVideoCodecFFmpeg::GetPictureCommon(VideoPicture* pVideoPicture)
            (m_pCodecContext->profile == FF_PROFILE_H264_HIGH_10||
             m_pCodecContext->profile == FF_PROFILE_H264_HIGH_10_INTRA))
     pVideoPicture->colorBits = 10;
-  else if (m_pCodecContext->codec_id == AV_CODEC_ID_VP9 &&
-           (m_pCodecContext->profile == FF_PROFILE_VP9_2 ||
-            m_pCodecContext->profile == FF_PROFILE_VP9_3))
+  else if ((m_pCodecContext->codec_id == AV_CODEC_ID_VP9 ||
+            m_pCodecContext->codec_id == AV_CODEC_ID_AV1) &&
+           m_pCodecContext->sw_pix_fmt == AV_PIX_FMT_YUV420P10)
     pVideoPicture->colorBits = 10;
 
   if (m_pCodecContext->color_range == AVCOL_RANGE_JPEG ||


### PR DESCRIPTION
## Description
[Windows] Implements DXVA2 AV1 HW video decoding 8-bit and 10-bit


## Motivation and context
AV1 support


## How has this been tested?
Tested on Intel UHD Graphics 770 (i7-13700K) that only supports profile 0 (main) anyway this is sufficient for decode all 4K 8-bit and 10-bit videos.


## What is the effect on users?
Added AV1 HW video decoding on Windows.


## Screenshots (if appropriate):
![screenshot00008](https://user-images.githubusercontent.com/58434170/230714848-21a85444-9f13-4da2-bd3f-63c856ecd488.png)

![screenshot00009](https://user-images.githubusercontent.com/58434170/230714866-9e4d84f0-fc97-48cd-8560-6291d6fbbcc2.png)

![GPU](https://user-images.githubusercontent.com/58434170/230714872-09f6d7af-63ae-4adb-9d13-c9087617c16a.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
