### PR TITLE
CWinSystemGbm: don't require a modeset when setting HDR metadata

### DIFF
--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -336,7 +336,6 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
     if (connector->SupportsProperty("HDR_OUTPUT_METADATA"))
     {
       drm->AddProperty(connector, "HDR_OUTPUT_METADATA", 0);
-      drm->SetActive(true);
 
       if (m_hdr_blob_id)
         drmModeDestroyPropertyBlob(drm->GetFileDescriptor(), m_hdr_blob_id);
@@ -423,7 +422,6 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
     }
 
     drm->AddProperty(connector, "HDR_OUTPUT_METADATA", m_hdr_blob_id);
-    drm->SetActive(true);
   }
 
   return true;


### PR DESCRIPTION
This removes the forced modeset when setting HDR metadata. 

This was added in the original HDR commit https://github.com/xbmc/xbmc/commit/9124e687c79807ae1cafb6448b659317cf49a8ca

It seems that either it is no longer needed, it was never needed, or that it was only needed for specific hardware.

I've tested this on my intel nuc.
