### PR TITLE
[CRenderManager] Add missing member initialization

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -196,7 +196,7 @@ protected:
     double         pts;
     EFIELDSYNC     presentfield;
     EPRESENTMETHOD presentmethod;
-  } m_Queue[NUM_BUFFERS];
+  } m_Queue[NUM_BUFFERS]{};
 
   std::deque<int> m_free;
   std::deque<int> m_queued;


### PR DESCRIPTION
## Description
The `m_Queue` member could be used without initialization, see Valgrind output.

<details>
<summary>Valgrind output</summary>

```
==182053==    at 0x150352C: CRenderManager::Render(bool, unsigned int, unsigned int, bool) (RenderManager.cpp:718)
==182053==    by 0x1CD3721: CApplicationPlayer::Render(bool, unsigned int, bool) (ApplicationPlayer.cpp:849)
==182053==    by 0x1BC7FFC: CGUIVideoControl::Render() (GUIVideoControl.cpp:68)
==182053==    by 0x1B36FCC: DoRender (GUIControl.cpp:203)
==182053==    by 0x1B36FCC: CGUIControl::DoRender() (GUIControl.cpp:178)
==182053==    by 0x1B4C59D: CGUIControlGroup::Render() (GUIControlGroup.cpp:113)
==182053==    by 0x1B36FCC: DoRender (GUIControl.cpp:203)
==182053==    by 0x1B36FCC: CGUIControl::DoRender() (GUIControl.cpp:178)
==182053==    by 0x1BD1A63: CGUIWindow::DoRender() (GUIWindow.cpp:351)
==182053==    by 0x1BD908B: CGUIWindowManager::RenderPass() const (GUIWindowManager.cpp:1246)
==182053==    by 0x1BD9948: CGUIWindowManager::Render() (GUIWindowManager.cpp:1296)
==182053==    by 0x1CB8344: CApplication::Render() (Application.cpp:909)
==182053==    by 0x1BD71DF: CGUIWindowManager::ProcessRenderLoop(bool) (GUIWindowManager.cpp:1412)
==182053==    by 0x1C21799: CGUIDialogBusy::WaitOnEvent(CEvent&, unsigned int, bool) (GUIDialogBusy.cpp:94)
==182053==  Uninitialised value was created by a heap allocation
==182053==    at 0x48CCFC3: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==182053==    by 0x276307C: allocate (new_allocator.h:137)
==182053==    by 0x276307C: allocate (alloc_traits.h:464)
==182053==    by 0x276307C: __allocate_guarded<std::allocator<std::_Sp_counted_ptr_inplace<CVideoPlayer, std::allocator<void>, (__gnu_cxx::_Lock_policy)2> > > (allocated_ptr.h:98)
==182053==    by 0x276307C: __shared_count<CVideoPlayer, std::allocator<void>, IPlayerCallback&> (shared_ptr_base.h:969)
==182053==    by 0x276307C: __shared_ptr<std::allocator<void>, IPlayerCallback&> (shared_ptr_base.h:1712)
==182053==    by 0x276307C: shared_ptr<std::allocator<void>, IPlayerCallback&> (shared_ptr.h:464)
==182053==    by 0x276307C: make_shared<CVideoPlayer, IPlayerCallback&> (shared_ptr.h:1010)
==182053==    by 0x276307C: CPlayerCoreConfig::CreatePlayer(IPlayerCallback&) const (PlayerCoreConfig.cpp:49)
==182053==    by 0x27643D3: CPlayerCoreFactory::CreatePlayer(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, IPlayerCallback&) const (PlayerCoreFactory.cpp:64)
==182053==    by 0x1CD873D: CApplicationPlayer::CreatePlayer(CPlayerCoreFactory const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, IPlayerCallback&) (ApplicationPlayer.cpp:70)
==182053==    by 0x1CD9891: CApplicationPlayer::OpenFile(CFileItem const&, CPlayerOptions const&, CPlayerCoreFactory const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, IPlayerCallback&) (ApplicationPlayer.cpp:139)
==182053==    by 0x1CBD999: CApplication::PlayFile(CFileItem, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) (Application.cpp:2544)
==182053==    by 0x1F30FF2: PLAYLIST::CPlayListPlayer::Play(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, bool) (PlayListPlayer.cpp:337)
==182053==    by 0x166370F: CGUIWindowVideoBase::PlayMovie(CFileItem const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (GUIWindowVideoBase.cpp:1118)
==182053==    by 0x1668B42: CGUIWindowVideoBase::OnPlayMedia(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (GUIWindowVideoBase.cpp:1091)
==182053==    by 0x182CBE1: CGUIMediaWindow::OnClick(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (GUIMediaWindow.cpp:1179)
==182053==    by 0x167EDB2: CGUIWindowVideoNav::OnClick(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (GUIWindowVideoNav.cpp:1042)
==182053==    by 0x166E4F1: CGUIWindowVideoBase::OnFileAction(int, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (GUIWindowVideoBase.cpp:561)
==182053== 
==182053== Conditional jump or move depends on uninitialised value(s)
==182053==    at 0x1503540: CRenderManager::Render(bool, unsigned int, unsigned int, bool) (RenderManager.cpp:720)
==182053==    by 0x1CD3721: CApplicationPlayer::Render(bool, unsigned int, bool) (ApplicationPlayer.cpp:849)
==182053==    by 0x1BC7FFC: CGUIVideoControl::Render() (GUIVideoControl.cpp:68)
==182053==    by 0x1B36FCC: DoRender (GUIControl.cpp:203)
==182053==    by 0x1B36FCC: CGUIControl::DoRender() (GUIControl.cpp:178)
==182053==    by 0x1B4C59D: CGUIControlGroup::Render() (GUIControlGroup.cpp:113)
==182053==    by 0x1B36FCC: DoRender (GUIControl.cpp:203)
==182053==    by 0x1B36FCC: CGUIControl::DoRender() (GUIControl.cpp:178)
==182053==    by 0x1BD1A63: CGUIWindow::DoRender() (GUIWindow.cpp:351)
==182053==    by 0x1BD908B: CGUIWindowManager::RenderPass() const (GUIWindowManager.cpp:1246)
==182053==    by 0x1BD9948: CGUIWindowManager::Render() (GUIWindowManager.cpp:1296)
==182053==    by 0x1CB8344: CApplication::Render() (Application.cpp:909)
==182053==    by 0x1BD71DF: CGUIWindowManager::ProcessRenderLoop(bool) (GUIWindowManager.cpp:1412)
==182053==    by 0x1C21799: CGUIDialogBusy::WaitOnEvent(CEvent&, unsigned int, bool) (GUIDialogBusy.cpp:94)
==182053==  Uninitialised value was created by a heap allocation
==182053==    at 0x48CCFC3: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==182053==    by 0x276307C: allocate (new_allocator.h:137)
==182053==    by 0x276307C: allocate (alloc_traits.h:464)
==182053==    by 0x276307C: __allocate_guarded<std::allocator<std::_Sp_counted_ptr_inplace<CVideoPlayer, std::allocator<void>, (__gnu_cxx::_Lock_policy)2> > > (allocated_ptr.h:98)
==182053==    by 0x276307C: __shared_count<CVideoPlayer, std::allocator<void>, IPlayerCallback&> (shared_ptr_base.h:969)
==182053==    by 0x276307C: __shared_ptr<std::allocator<void>, IPlayerCallback&> (shared_ptr_base.h:1712)
==182053==    by 0x276307C: shared_ptr<std::allocator<void>, IPlayerCallback&> (shared_ptr.h:464)
==182053==    by 0x276307C: make_shared<CVideoPlayer, IPlayerCallback&> (shared_ptr.h:1010)
==182053==    by 0x276307C: CPlayerCoreConfig::CreatePlayer(IPlayerCallback&) const (PlayerCoreConfig.cpp:49)
==182053==    by 0x27643D3: CPlayerCoreFactory::CreatePlayer(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, IPlayerCallback&) const (PlayerCoreFactory.cpp:64)
==182053==    by 0x1CD873D: CApplicationPlayer::CreatePlayer(CPlayerCoreFactory const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, IPlayerCallback&) (ApplicationPlayer.cpp:70)
==182053==    by 0x1CD9891: CApplicationPlayer::OpenFile(CFileItem const&, CPlayerOptions const&, CPlayerCoreFactory const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, IPlayerCallback&) (ApplicationPlayer.cpp:139)
==182053==    by 0x1CBD999: CApplication::PlayFile(CFileItem, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) (Application.cpp:2544)
==182053==    by 0x1F30FF2: PLAYLIST::CPlayListPlayer::Play(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, bool) (PlayListPlayer.cpp:337)
==182053==    by 0x166370F: CGUIWindowVideoBase::PlayMovie(CFileItem const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (GUIWindowVideoBase.cpp:1118)
==182053==    by 0x1668B42: CGUIWindowVideoBase::OnPlayMedia(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (GUIWindowVideoBase.cpp:1091)
==182053==    by 0x182CBE1: CGUIMediaWindow::OnClick(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (GUIMediaWindow.cpp:1179)
==182053==    by 0x167EDB2: CGUIWindowVideoNav::OnClick(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (GUIWindowVideoNav.cpp:1042)
==182053==    by 0x166E4F1: CGUIWindowVideoBase::OnFileAction(int, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (GUIWindowVideoBase.cpp:561)
==182053== 
==182053== Conditional jump or move depends on uninitialised value(s)
==182053==    at 0x14FBF56: CRenderManager::PresentSingle(bool, unsigned int, unsigned int) (RenderManager.cpp:835)
==182053==    by 0x150354A: CRenderManager::Render(bool, unsigned int, unsigned int, bool) (RenderManager.cpp:723)
==182053==    by 0x1CD3721: CApplicationPlayer::Render(bool, unsigned int, bool) (ApplicationPlayer.cpp:849)
==182053==    by 0x1BC7FFC: CGUIVideoControl::Render() (GUIVideoControl.cpp:68)
==182053==    by 0x1B36FCC: DoRender (GUIControl.cpp:203)
==182053==    by 0x1B36FCC: CGUIControl::DoRender() (GUIControl.cpp:178)
==182053==    by 0x1B4C59D: CGUIControlGroup::Render() (GUIControlGroup.cpp:113)
==182053==    by 0x1B36FCC: DoRender (GUIControl.cpp:203)
==182053==    by 0x1B36FCC: CGUIControl::DoRender() (GUIControl.cpp:178)
==182053==    by 0x1BD1A63: CGUIWindow::DoRender() (GUIWindow.cpp:351)
==182053==    by 0x1BD908B: CGUIWindowManager::RenderPass() const (GUIWindowManager.cpp:1246)
==182053==    by 0x1BD9948: CGUIWindowManager::Render() (GUIWindowManager.cpp:1296)
==182053==    by 0x1CB8344: CApplication::Render() (Application.cpp:909)
==182053==    by 0x1BD71DF: CGUIWindowManager::ProcessRenderLoop(bool) (GUIWindowManager.cpp:1412)
==182053==  Uninitialised value was created by a heap allocation
==182053==    at 0x48CCFC3: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==182053==    by 0x276307C: allocate (new_allocator.h:137)
==182053==    by 0x276307C: allocate (alloc_traits.h:464)
==182053==    by 0x276307C: __allocate_guarded<std::allocator<std::_Sp_counted_ptr_inplace<CVideoPlayer, std::allocator<void>, (__gnu_cxx::_Lock_policy)2> > > (allocated_ptr.h:98)
==182053==    by 0x276307C: __shared_count<CVideoPlayer, std::allocator<void>, IPlayerCallback&> (shared_ptr_base.h:969)
==182053==    by 0x276307C: __shared_ptr<std::allocator<void>, IPlayerCallback&> (shared_ptr_base.h:1712)
==182053==    by 0x276307C: shared_ptr<std::allocator<void>, IPlayerCallback&> (shared_ptr.h:464)
==182053==    by 0x276307C: make_shared<CVideoPlayer, IPlayerCallback&> (shared_ptr.h:1010)
==182053==    by 0x276307C: CPlayerCoreConfig::CreatePlayer(IPlayerCallback&) const (PlayerCoreConfig.cpp:49)
==182053==    by 0x27643D3: CPlayerCoreFactory::CreatePlayer(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, IPlayerCallback&) const (PlayerCoreFactory.cpp:64)
==182053==    by 0x1CD873D: CApplicationPlayer::CreatePlayer(CPlayerCoreFactory const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, IPlayerCallback&) (ApplicationPlayer.cpp:70)
==182053==    by 0x1CD9891: CApplicationPlayer::OpenFile(CFileItem const&, CPlayerOptions const&, CPlayerCoreFactory const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, IPlayerCallback&) (ApplicationPlayer.cpp:139)
==182053==    by 0x1CBD999: CApplication::PlayFile(CFileItem, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) (Application.cpp:2544)
==182053==    by 0x1F30FF2: PLAYLIST::CPlayListPlayer::Play(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, bool) (PlayListPlayer.cpp:337)
==182053==    by 0x166370F: CGUIWindowVideoBase::PlayMovie(CFileItem const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (GUIWindowVideoBase.cpp:1118)
==182053==    by 0x1668B42: CGUIWindowVideoBase::OnPlayMedia(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (GUIWindowVideoBase.cpp:1091)
==182053==    by 0x182CBE1: CGUIMediaWindow::OnClick(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (GUIMediaWindow.cpp:1179)
==182053==    by 0x167EDB2: CGUIWindowVideoNav::OnClick(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (GUIWindowVideoNav.cpp:1042)
==182053==    by 0x166E4F1: CGUIWindowVideoBase::OnFileAction(int, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (GUIWindowVideoBase.cpp:561)
==182053== 
==182053== Conditional jump or move depends on uninitialised value(s)
==182053==    at 0x14FBF5B: CRenderManager::PresentSingle(bool, unsigned int, unsigned int) (RenderManager.cpp:837)
==182053==    by 0x150354A: CRenderManager::Render(bool, unsigned int, unsigned int, bool) (RenderManager.cpp:723)
==182053==    by 0x1CD3721: CApplicationPlayer::Render(bool, unsigned int, bool) (ApplicationPlayer.cpp:849)
==182053==    by 0x1BC7FFC: CGUIVideoControl::Render() (GUIVideoControl.cpp:68)
==182053==    by 0x1B36FCC: DoRender (GUIControl.cpp:203)
==182053==    by 0x1B36FCC: CGUIControl::DoRender() (GUIControl.cpp:178)
==182053==    by 0x1B4C59D: CGUIControlGroup::Render() (GUIControlGroup.cpp:113)
==182053==    by 0x1B36FCC: DoRender (GUIControl.cpp:203)
==182053==    by 0x1B36FCC: CGUIControl::DoRender() (GUIControl.cpp:178)
==182053==    by 0x1BD1A63: CGUIWindow::DoRender() (GUIWindow.cpp:351)
==182053==    by 0x1BD908B: CGUIWindowManager::RenderPass() const (GUIWindowManager.cpp:1246)
==182053==    by 0x1BD9948: CGUIWindowManager::Render() (GUIWindowManager.cpp:1296)
==182053==    by 0x1CB8344: CApplication::Render() (Application.cpp:909)
==182053==    by 0x1BD71DF: CGUIWindowManager::ProcessRenderLoop(bool) (GUIWindowManager.cpp:1412)
==182053==  Uninitialised value was created by a heap allocation
==182053==    at 0x48CCFC3: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==182053==    by 0x276307C: allocate (new_allocator.h:137)
==182053==    by 0x276307C: allocate (alloc_traits.h:464)
==182053==    by 0x276307C: __allocate_guarded<std::allocator<std::_Sp_counted_ptr_inplace<CVideoPlayer, std::allocator<void>, (__gnu_cxx::_Lock_policy)2> > > (allocated_ptr.h:98)
==182053==    by 0x276307C: __shared_count<CVideoPlayer, std::allocator<void>, IPlayerCallback&> (shared_ptr_base.h:969)
==182053==    by 0x276307C: __shared_ptr<std::allocator<void>, IPlayerCallback&> (shared_ptr_base.h:1712)
==182053==    by 0x276307C: shared_ptr<std::allocator<void>, IPlayerCallback&> (shared_ptr.h:464)
==182053==    by 0x276307C: make_shared<CVideoPlayer, IPlayerCallback&> (shared_ptr.h:1010)
==182053==    by 0x276307C: CPlayerCoreConfig::CreatePlayer(IPlayerCallback&) const (PlayerCoreConfig.cpp:49)
==182053==    by 0x27643D3: CPlayerCoreFactory::CreatePlayer(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, IPlayerCallback&) const (PlayerCoreFactory.cpp:64)
==182053==    by 0x1CD873D: CApplicationPlayer::CreatePlayer(CPlayerCoreFactory const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, IPlayerCallback&) (ApplicationPlayer.cpp:70)
==182053==    by 0x1CD9891: CApplicationPlayer::OpenFile(CFileItem const&, CPlayerOptions const&, CPlayerCoreFactory const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, IPlayerCallback&) (ApplicationPlayer.cpp:139)
==182053==    by 0x1CBD999: CApplication::PlayFile(CFileItem, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) (Application.cpp:2544)
==182053==    by 0x1F30FF2: PLAYLIST::CPlayListPlayer::Play(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, bool) (PlayListPlayer.cpp:337)
==182053==    by 0x166370F: CGUIWindowVideoBase::PlayMovie(CFileItem const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (GUIWindowVideoBase.cpp:1118)
==182053==    by 0x1668B42: CGUIWindowVideoBase::OnPlayMedia(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (GUIWindowVideoBase.cpp:1091)
==182053==    by 0x182CBE1: CGUIMediaWindow::OnClick(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (GUIMediaWindow.cpp:1179)
==182053==    by 0x167EDB2: CGUIWindowVideoNav::OnClick(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (GUIWindowVideoNav.cpp:1042)
==182053==    by 0x166E4F1: CGUIWindowVideoBase::OnFileAction(int, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (GUIWindowVideoBase.cpp:561)
==182053== 
```
</details>

## Motivation and context
Using unitialized memory can result in random behaviour or crashes.

## How has this been tested?
Run Kodi under Valgrind, the error doesn't appear anymore.

## What is the effect on users?
None.

## Screenshots (if appropriate):
None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
