### PR TITLE
[PVR] CPVRChannelGroups::UpdateFromClients : Remove dead code.

### DIFF
--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -317,8 +317,6 @@ bool CPVRChannelGroups::UpdateFromClients(const std::vector<std::shared_ptr<CPVR
     groups = m_groups;
   }
 
-  std::vector<std::shared_ptr<CPVRChannelGroup>> emptyGroups;
-
   for (const auto& group : groups)
   {
     if (!bChannelsOnly || group->IsInternalGroup())
@@ -353,12 +351,6 @@ bool CPVRChannelGroups::UpdateFromClients(const std::vector<std::shared_ptr<CPVR
     {
       CServiceBroker::GetPVRManager().TriggerSearchMissingChannelIcons(group);
     }
-  }
-
-  for (const auto& group : emptyGroups)
-  {
-    CLog::LogFC(LOGDEBUG, LOGPVR, "Deleting empty channel group '{}'", group->GroupName());
-    DeleteGroup(group);
   }
 
   if (bChannelsOnly)


### PR DESCRIPTION
Oversight from 9c1069ea9c76fafbf828f406d89739aaa8f0db47. This code is dead now as `emptyGroups`will always be empty.

@phunkyfish can you please have a look?