### PR TITLE
[PVR] Logging improvements.

### DIFF
--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -378,7 +378,7 @@ bool CPVRDatabase::Persist(const CPVRClient& client)
   if (client.GetID() == PVR_INVALID_CLIENT_ID)
     return false;
 
-  CLog::LogFC(LOGDEBUG, LOGPVR, "Persisting client '{}' to database", client.ID());
+  CLog::LogFC(LOGDEBUG, LOGPVR, "Persisting client {} to database", client.GetID());
 
   std::unique_lock<CCriticalSection> lock(m_critSection);
 
@@ -393,7 +393,7 @@ bool CPVRDatabase::Delete(const CPVRClient& client)
   if (client.GetID() == PVR_INVALID_CLIENT_ID)
     return false;
 
-  CLog::LogFC(LOGDEBUG, LOGPVR, "Deleting client '{}' from the database", client.ID());
+  CLog::LogFC(LOGDEBUG, LOGPVR, "Deleting client {} from the database", client.GetID());
 
   std::unique_lock<CCriticalSection> lock(m_critSection);
 
@@ -408,7 +408,7 @@ int CPVRDatabase::GetPriority(const CPVRClient& client)
   if (client.GetID() == PVR_INVALID_CLIENT_ID)
     return 0;
 
-  CLog::LogFC(LOGDEBUG, LOGPVR, "Getting priority for client '{}' from the database", client.ID());
+  CLog::LogFC(LOGDEBUG, LOGPVR, "Getting priority for client {} from the database", client.GetID());
 
   std::unique_lock<CCriticalSection> lock(m_critSection);
 

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -694,8 +694,8 @@ bool CPVRManager::UpdateComponents(ManagerState stateToCheck,
     // skip not (yet) connected clients
     if (entry.second->IgnoreClient())
     {
-      CLog::LogFC(LOGDEBUG, LOGPVR, "Skipping not (yet) connected PVR client '{}'",
-                  entry.second->ID());
+      CLog::LogFC(LOGDEBUG, LOGPVR, "Skipping not (yet) connected PVR client {}",
+                  entry.second->GetID());
       continue;
     }
 
@@ -704,8 +704,8 @@ bool CPVRManager::UpdateComponents(ManagerState stateToCheck,
       m_knownClients.emplace_back(entry.second);
       newClients.emplace_back(entry.second);
 
-      CLog::LogFC(LOGDEBUG, LOGPVR, "Adding new PVR client '{}' to list of known clients",
-                  entry.second->ID());
+      CLog::LogFC(LOGDEBUG, LOGPVR, "Adding new PVR client {} to list of known clients",
+                  entry.second->GetID());
     }
   }
 

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -166,7 +166,6 @@ void CPVRClients::UpdateClients(
 
       if (status != ADDON_STATUS_OK)
       {
-        CLog::LogF(LOGERROR, "Failed to create add-on {}, status = {}", client->ID(), status);
         if (status == ADDON_STATUS_PERMANENT_FAILURE)
         {
           CServiceBroker::GetAddonMgr().DisableAddon(client->ID(),
@@ -916,12 +915,23 @@ PVR_ERROR CPVRClients::ForCreatedClients(const char* strFunctionName,
 
   for (const auto& clientEntry : clients)
   {
+    //    CLog::LogFC(LOGDEBUG, LOGPVR, "Calling add-on function '{}' on client {}.", strFunctionName,
+    //                clientEntry.second->GetID());
+
     PVR_ERROR currentError = function(clientEntry.second);
+
+    //    CLog::LogFC(LOGDEBUG, LOGPVR, "Called add-on function '{}' on client {}. return={}",
+    //                strFunctionName, clientEntry.second->GetID(), currentError);
 
     if (currentError != PVR_ERROR_NO_ERROR && currentError != PVR_ERROR_NOT_IMPLEMENTED)
     {
       lastError = currentError;
       failedClients.emplace_back(clientEntry.first);
+
+      CLog::LogFC(LOGDEBUG, LOGPVR,
+                  "Added client {} to failed clients list after call to "
+                  "function '{}‘ returned error {}.",
+                  clientEntry.second->GetID(), strFunctionName, currentError);
     }
   }
   return lastError;
@@ -960,12 +970,23 @@ PVR_ERROR CPVRClients::ForClients(const char* strFunctionName,
     if (std::none_of(failedClients.cbegin(), failedClients.cend(),
                      [&client](int failedClientId) { return failedClientId == client->GetID(); }))
     {
+      //      CLog::LogFC(LOGDEBUG, LOGPVR, "Calling add-on function '{}' on client {}.", strFunctionName,
+      //                  client->GetID());
+
       PVR_ERROR currentError = function(client);
+
+      //      CLog::LogFC(LOGDEBUG, LOGPVR, "Called add-on function '{}' on client {}. return={}",
+      //                  strFunctionName, client->GetID(), currentError);
 
       if (currentError != PVR_ERROR_NO_ERROR && currentError != PVR_ERROR_NOT_IMPLEMENTED)
       {
         lastError = currentError;
         failedClients.emplace_back(client->GetID());
+
+        CLog::LogFC(LOGDEBUG, LOGPVR,
+                    "Added client {} to failed clients list after call to "
+                    "function '{}‘ returned error {}.",
+                    client->GetID(), strFunctionName, currentError);
       }
     }
     else

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -734,8 +734,9 @@ std::vector<std::shared_ptr<CPVRChannelGroupMember>> CPVRChannelGroup::RemoveDel
     {
       if (HasValidDataForClient(channel->ClientID()))
       {
-        CLog::Log(LOGINFO, "Removed stale {} channel '{}' from group '{}'",
-                  IsRadio() ? "radio" : "TV", channel->ChannelName(), GroupName());
+        CLog::LogFC(LOGDEBUG, LOGPVR, "Removed stale {} channel '{}' from group '{}'. clientId={}",
+                    IsRadio() ? "radio" : "TV", channel->ChannelName(), GroupName(),
+                    channel->ClientID());
         membersToRemove.emplace_back(*it);
 
         m_members.erase(channel->StorageId());

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -82,6 +82,9 @@ void CPVRChannelGroups::Unload()
 
 bool CPVRChannelGroups::UpdateFromClient(const std::shared_ptr<CPVRChannelGroup>& group)
 {
+  CLog::LogFC(LOGDEBUG, LOGPVR, "Got channel group '{}' from client {}.", group->GroupName(),
+              group->GetClientID());
+
   if (!Update(group, true))
     return false;
 
@@ -300,14 +303,11 @@ bool CPVRChannelGroups::UpdateFromClients(const std::vector<std::shared_ptr<CPVR
   bool bReturn = true;
 
   // sync groups
-  const int iSize = static_cast<int>(m_groups.size());
   if (!bChannelsOnly)
   {
     // get channel groups from the clients
     CServiceBroker::GetPVRManager().Clients()->GetChannelGroups(clients, this,
                                                                 m_failedClientsForChannelGroups);
-    CLog::LogFC(LOGDEBUG, LOGPVR, "{} new {} channel groups fetched from clients",
-                (m_groups.size() - iSize), m_bRadio ? "radio" : "TV");
   }
 
   // sync channels in groups
@@ -323,28 +323,10 @@ bool CPVRChannelGroups::UpdateFromClients(const std::vector<std::shared_ptr<CPVR
   {
     if (!bChannelsOnly || group->IsInternalGroup())
     {
-      const int iMemberCount = static_cast<int>(group->Size());
       if (!group->UpdateFromClients(clients))
       {
         CLog::LogFC(LOGERROR, LOGPVR, "Failed to update channel group '{}'", group->GroupName());
         bReturn = false;
-      }
-
-      const int iChangedMembersCount = static_cast<int>(group->Size()) - iMemberCount;
-      if (iChangedMembersCount > 0)
-      {
-        CLog::LogFC(LOGDEBUG, LOGPVR, "{} channel group members added to group '{}'",
-                    iChangedMembersCount, group->GroupName());
-      }
-      else if (iChangedMembersCount < 0)
-      {
-        CLog::LogFC(LOGDEBUG, LOGPVR, "{} channel group members removed from group '{}'",
-                    -iChangedMembersCount, group->GroupName());
-      }
-      else
-      {
-        // could still be changed if same amount of members was removed as was added, but too
-        // complicated to calculate just for debug logging
       }
     }
 

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -90,7 +90,6 @@ void CPVRRecordings::UpdateInProgressSize()
     return;
   m_bIsUpdating = true;
 
-  CLog::LogFC(LOGDEBUG, LOGPVR, "Updating recordings size");
   bool bHaveUpdatedInProgessRecording = false;
   for (auto& recording : m_recordings)
   {


### PR DESCRIPTION
As subject says, logging improvements - mainly for better tracking of client ids.

I intentionally left in the commented lines to log every add-on call, because they could be quite useful to debug certain cases. However, this should not be enabled by default, because of potential runtime performance issues (think of the performance critical  "DemuxRead" calls for example.)

@phunkyfish whenever you find some time for a review.