### PR TITLE
[macOS][nativewindowing] Take guiInsets into consideration when reset…

### DIFF
--- a/xbmc/windowing/osx/OpenGL/WinSystemOSXGL.mm
+++ b/xbmc/windowing/osx/OpenGL/WinSystemOSXGL.mm
@@ -60,7 +60,8 @@ bool CWinSystemOSXGL::ResizeWindow(int newWidth, int newHeight, int newLeft, int
 bool CWinSystemOSXGL::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
   CWinSystemOSX::SetFullScreen(fullScreen, res, blankOtherDisplays);
-  CRenderSystemGL::ResetRenderSystem(res.iWidth, res.iHeight);
+  CRenderSystemGL::ResetRenderSystem(res.iWidth - res.guiInsets.right - res.guiInsets.left,
+                                     res.iHeight - res.guiInsets.top - res.guiInsets.bottom);
 
   if (m_bVSync)
   {


### PR DESCRIPTION
…ting render system for a specific resolution

## Description
Trivial change that I forgot to implement when working on the notch/edgeinsets stuff. If you reset the resolution, guiInsets should be taken into account. This is noticeable if you, for example, change any setting that may update the screen resolution (e.g. blank other displays) for the same resolution you might already have set:

**Before:**
<img width="1470" alt="image" src="https://user-images.githubusercontent.com/7375276/230770179-bfb96f8d-ef07-4463-b68a-84791dcf39d2.png">


**Now:**
<img width="1470" alt="image" src="https://user-images.githubusercontent.com/7375276/230770140-486eed7a-73de-4f3e-b116-b690ef5f2a4c.png">
