### PR TITLE
[Android] Minimise shutdown function

### DIFF
--- a/xbmc/application/ApplicationPowerHandling.cpp
+++ b/xbmc/application/ApplicationPowerHandling.cpp
@@ -538,6 +538,9 @@ void CApplicationPowerHandling::CheckShutdown()
     m_shutdownTimer.Stop();
 
     // Sleep the box
+    CLog::LogF(LOGDEBUG, "Timer is over (shutdown function: {})",
+               CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+                   CSettings::SETTING_POWERMANAGEMENT_SHUTDOWNSTATE));
     CServiceBroker::GetAppMessenger()->PostMsg(TMSG_SHUTDOWN);
   }
 }

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -22,6 +22,8 @@
 #include "messaging/ApplicationMessenger.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/DisplaySettings.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
 #include "windowing/GraphicContext.h"
 
 #include <mutex>
@@ -291,6 +293,16 @@ void CXBMCApp::onResume()
   if (g_application.IsInitialized() &&
       CServiceBroker::GetWinSystem()->GetOSScreenSaver()->IsInhibited())
     KeepScreenOn(true);
+
+  // Reset shutdown timer on wake up
+  if (g_application.IsInitialized() &&
+      CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+          CSettings::SETTING_POWERMANAGEMENT_SHUTDOWNTIME))
+  {
+    auto& components = CServiceBroker::GetAppComponents();
+    const auto appPower = components.GetComponent<CApplicationPowerHandling>();
+    appPower->ResetShutdownTimers();
+  }
 
   m_headsetPlugged = isHeadsetPlugged();
 

--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -278,6 +278,11 @@ void CWinSystemAndroid::UpdateDisplayModes()
   }
 }
 
+bool CWinSystemAndroid::Minimize()
+{
+  return CXBMCApp::Get().moveTaskToBack(true);
+}
+
 bool CWinSystemAndroid::Hide()
 {
   return false;

--- a/xbmc/windowing/android/WinSystemAndroid.h
+++ b/xbmc/windowing/android/WinSystemAndroid.h
@@ -46,6 +46,7 @@ public:
 
   bool HasCursor() override { return false; }
 
+  bool Minimize() override;
   bool Hide() override;
   bool Show(bool raise = true) override;
   void Register(IDispResource *resource) override;


### PR DESCRIPTION
## Description
As described in #23130, does not work "Minimise" as a shutdown function in the advanced power saving section.

I propose the following behaviour on Android: when the timer is over if the selected shutdown function is "Minimise", move the Kodi app to the background and keep it running, and go to the home screen.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
