### PR TITLE
[guilib][vfs][imagecache] Load video thumbnail images into texture cache when viewed, like standard images

### DIFF
--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -97,7 +97,7 @@ std::string CTextureCache::GetCachedImage(const std::string &image, CTextureDeta
 bool CTextureCache::CanCacheImageURL(const CURL &url)
 {
   return url.GetUserName().empty() || url.GetUserName() == "music" ||
-         StringUtils::StartsWith(url.GetUserName(), "video_") ||
+         url.GetUserName() == "video" || StringUtils::StartsWith(url.GetUserName(), "video_") ||
          StringUtils::StartsWith(url.GetUserName(), "pvr") ||
          StringUtils::StartsWith(url.GetUserName(), "epg");
 }

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -149,8 +149,8 @@ std::string CTextureCacheJob::DecodeImageURL(const std::string &url, unsigned in
 
     if (!CTextureCache::CanCacheImageURL(thumbURL))
       return "";
-    if (thumbURL.GetUserName() == "music")
-      additional_info = "music";
+    if (thumbURL.GetUserName() == "music" || thumbURL.GetUserName() == "video")
+      additional_info = thumbURL.GetUserName();
     if (StringUtils::StartsWith(thumbURL.GetUserName(), "video_") ||
         StringUtils::StartsWith(thumbURL.GetUserName(), "pvr") ||
         StringUtils::StartsWith(thumbURL.GetUserName(), "epg"))

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -87,10 +87,7 @@ int DegreeToOrientation(int degrees)
   }
 }
 
-bool CDVDFileInfo::ExtractThumb(const CFileItem& fileItem,
-                                CTextureDetails &details,
-                                CStreamDetails *pStreamDetails,
-                                int64_t pos)
+bool CDVDFileInfo::ExtractThumb(const CFileItem& fileItem, CTextureDetails& details, int64_t pos)
 {
   const std::string redactPath = CURL::GetRedacted(fileItem.GetPath());
   auto start = std::chrono::steady_clock::now();
@@ -128,41 +125,6 @@ bool CDVDFileInfo::ExtractThumb(const CFileItem& fileItem,
       delete pDemuxer;
 
     return false;
-  }
-
-  if (pStreamDetails)
-  {
-
-    const std::string& strPath = item.GetPath();
-    DemuxerToStreamDetails(pInputStream, pDemuxer, *pStreamDetails, strPath);
-
-    //extern subtitles
-    std::vector<std::string> filenames;
-    std::string video_path;
-    if (strPath.empty())
-      video_path = pInputStream->GetFileName();
-    else
-      video_path = strPath;
-
-    CUtil::ScanForExternalSubtitles(video_path, filenames);
-
-    for(unsigned int i=0;i<filenames.size();i++)
-    {
-      // if vobsub subtitle:
-      if (URIUtils::GetExtension(filenames[i]) == ".idx")
-      {
-        std::string strSubFile;
-        if ( CUtil::FindVobSubPair(filenames, filenames[i], strSubFile) )
-          AddExternalSubtitleToDetails(video_path, *pStreamDetails, filenames[i], strSubFile);
-      }
-      else
-      {
-        if ( !CUtil::IsVobSub(filenames, filenames[i]) )
-        {
-          AddExternalSubtitleToDetails(video_path, *pStreamDetails, filenames[i]);
-        }
-      }
-    }
   }
 
   int nVideoStream = -1;

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -518,6 +518,9 @@ bool CDVDFileInfo::GetFileStreamDetails(CFileItem *pItem)
   if (!pItem)
     return false;
 
+  if (!CanExtract(*pItem))
+    return false;
+
   std::string strFileNameAndPath;
   if (pItem->HasVideoInfoTag())
     strFileNameAndPath = pItem->GetVideoInfoTag()->m_strFileNameAndPath;

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.h
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.h
@@ -23,11 +23,8 @@ class CTextureDetails;
 class CDVDFileInfo
 {
 public:
-  // Extract a thumbnail image from the media referenced by fileItem, optionally populating a streamdetails class with the data
-  static bool ExtractThumb(const CFileItem& fileItem,
-                           CTextureDetails &details,
-                           CStreamDetails *pStreamDetails,
-                           int64_t pos);
+  // Extract a thumbnail image from the media referenced by fileItem
+  static bool ExtractThumb(const CFileItem& fileItem, CTextureDetails& details, int64_t pos);
 
   static std::unique_ptr<CTexture> ExtractThumbToTexture(const CFileItem& fileItem);
 

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.h
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.h
@@ -17,6 +17,7 @@ class CDVDDemux;
 class CStreamDetails;
 class CStreamDetailSubtitle;
 class CDVDInputStream;
+class CTexture;
 class CTextureDetails;
 
 class CDVDFileInfo
@@ -27,6 +28,13 @@ public:
                            CTextureDetails &details,
                            CStreamDetails *pStreamDetails,
                            int64_t pos);
+
+  static std::unique_ptr<CTexture> ExtractThumbToTexture(const CFileItem& fileItem);
+
+  /*!
+   * @brief Can a thumbnail image and file stream details be extracted from this file item?
+  */
+  static bool CanExtract(const CFileItem& fileItem);
 
   // Probe the files streams and store the info in the VideoInfoTag
   static bool GetFileStreamDetails(CFileItem *pItem);

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.h
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.h
@@ -34,7 +34,11 @@ public:
   static bool CanExtract(const CFileItem& fileItem);
 
   // Probe the files streams and store the info in the VideoInfoTag
-  static bool GetFileStreamDetails(CFileItem *pItem);
+  static bool GetFileStreamDetails(CFileItem* pItem);
+
+  static bool GetFileDuration(const std::string& path, int& duration);
+
+private:
   static bool DemuxerToStreamDetails(const std::shared_ptr<CDVDInputStream>& pInputStream,
                                      CDVDDemux* pDemux,
                                      CStreamDetails& details,
@@ -47,8 +51,6 @@ public:
                                      CDVDDemux* pDemuxer,
                                      const std::vector<CStreamDetailSubtitle>& subs,
                                      CStreamDetails& details);
-
-  static bool GetFileDuration(const std::string &path, int &duration);
 
   /** \brief Probe the streams of an external subtitle file and store the info in the StreamDetails parameter.
   *   \param[out] details The external subtitle file's StreamDetails.

--- a/xbmc/guilib/Texture.h
+++ b/xbmc/guilib/Texture.h
@@ -87,6 +87,7 @@ public:
                     const COLOR* palette);
 
   bool HasAlpha() const;
+  void SetAlpha(bool hasAlpha) { m_hasAlpha = hasAlpha; }
 
   void SetMipmapping();
   bool IsMipmapped() const;

--- a/xbmc/imagefiles/SpecialImageLoaderFactory.cpp
+++ b/xbmc/imagefiles/SpecialImageLoaderFactory.cpp
@@ -11,6 +11,7 @@
 #include "guilib/Texture.h"
 #include "music/MusicEmbeddedImageFileLoader.h"
 #include "video/VideoEmbeddedImageFileLoader.h"
+#include "video/VideoGeneratedImageFileLoader.h"
 
 using namespace IMAGE_FILES;
 
@@ -18,6 +19,7 @@ CSpecialImageLoaderFactory::CSpecialImageLoaderFactory()
 {
   m_specialImageLoaders[0] = std::make_unique<VIDEO::CVideoEmbeddedImageFileLoader>();
   m_specialImageLoaders[1] = std::make_unique<MUSIC_INFO::CMusicEmbeddedImageFileLoader>();
+  m_specialImageLoaders[2] = std::make_unique<VIDEO::CVideoGeneratedImageFileLoader>();
 }
 
 std::unique_ptr<CTexture> CSpecialImageLoaderFactory::Load(std::string specialType,

--- a/xbmc/pictures/PictureThumbLoader.h
+++ b/xbmc/pictures/PictureThumbLoader.h
@@ -9,9 +9,8 @@
 #pragma once
 
 #include "ThumbLoader.h"
-#include "utils/JobManager.h"
 
-class CPictureThumbLoader : public CThumbLoader, public CJobQueue
+class CPictureThumbLoader : public CThumbLoader
 {
 public:
   CPictureThumbLoader();
@@ -22,15 +21,6 @@ public:
   bool LoadItemLookup(CFileItem* pItem) override;
   void SetRegenerateThumbs(bool regenerate) { m_regenerateThumbs = regenerate; }
   static void ProcessFoldersAndArchives(CFileItem *pItem);
-
-  /*!
-   \brief Callback from CThumbExtractor on completion of a generated image
-
-   Performs the callbacks and updates the GUI.
-
-   \sa CImageLoader, IJobCallback
-   */
-  void OnJobComplete(unsigned int jobID, bool success, CJob *job) override;
 
 protected:
   void OnLoaderFinish() override;

--- a/xbmc/video/CMakeLists.txt
+++ b/xbmc/video/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES Bookmark.cpp
             VideoDatabase.cpp
             VideoDbUrl.cpp
             VideoEmbeddedImageFileLoader.cpp
+            VideoGeneratedImageFileLoader.cpp
             VideoInfoDownloader.cpp
             VideoInfoScanner.cpp
             VideoInfoTag.cpp
@@ -24,6 +25,7 @@ set(HEADERS Bookmark.h
             VideoDatabase.h
             VideoDbUrl.h
             VideoEmbeddedImageFileLoader.h
+            VideoGeneratedImageFileLoader.h
             VideoInfoDownloader.h
             VideoInfoScanner.h
             VideoInfoTag.h

--- a/xbmc/video/VideoGeneratedImageFileLoader.h
+++ b/xbmc/video/VideoGeneratedImageFileLoader.h
@@ -10,25 +10,19 @@
 
 #include "imagefiles/SpecialImageFileLoader.h"
 
-#include <array>
-#include <memory>
-#include <string>
-
-class CTexture;
-
-namespace IMAGE_FILES
+namespace VIDEO
 {
-class CSpecialImageLoaderFactory
+/*!
+ * @brief Generates a texture for a thumbnail of a video file, from a frame approx 1/3 into the video.
+*/
+class CVideoGeneratedImageFileLoader : public IMAGE_FILES::ISpecialImageFileLoader
 {
 public:
-  CSpecialImageLoaderFactory();
-
+  bool CanLoad(std::string specialType) const override;
   std::unique_ptr<CTexture> Load(std::string specialType,
                                  std::string filePath,
                                  unsigned int preferredWidth,
-                                 unsigned int preferredHeight) const;
-
-private:
-  std::array<std::unique_ptr<ISpecialImageFileLoader>, 3> m_specialImageLoaders{};
+                                 unsigned int preferredHeight) const override;
 };
-} // namespace IMAGE_FILES
+
+} // namespace VIDEO

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1672,6 +1672,14 @@ namespace VIDEO
       }
     }
 
+    if (art.find("thumb") == art.end() &&
+        CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+            CSettings::SETTING_MYVIDEOS_EXTRACTTHUMB) &&
+        CDVDFileInfo::CanExtract(*pItem))
+    {
+      art["thumb"] = CVideoThumbLoader::GetEmbeddedThumbURL(*pItem);
+    }
+
     for (const auto& artType : artTypes)
     {
       if (art.find(artType) != art.end())

--- a/xbmc/video/VideoThumbLoader.h
+++ b/xbmc/video/VideoThumbLoader.h
@@ -56,7 +56,7 @@ public:
   bool m_fillStreamDetails; ///< fill in stream details?
 };
 
-class CVideoThumbLoader : public CThumbLoader, public CJobQueue
+class CVideoThumbLoader : public CThumbLoader
 {
 public:
   CVideoThumbLoader();
@@ -107,15 +107,6 @@ public:
    \return true if we fill art, false otherwise
    */
  bool FillLibraryArt(CFileItem &item) override;
-
-  /*!
-   \brief Callback from CThumbExtractor on completion of a generated image
-
-   Performs the callbacks and updates the GUI.
-
-   \sa CImageLoader, IJobCallback
-   */
-  void OnJobComplete(unsigned int jobID, bool success, CJob *job) override;
 
 protected:
   CVideoDatabase *m_videoDatabase;

--- a/xbmc/video/VideoThumbLoader.h
+++ b/xbmc/video/VideoThumbLoader.h
@@ -26,15 +26,18 @@ using ArtCache = std::map<std::pair<MediaType, int>, ArtMap>;
  \ingroup thumbs,jobs
  \brief Thumb extractor job class
 
- Used by the CVideoThumbLoader to perform asynchronous generation of thumbs
+ Used by the "chapter browser" GUI window to generate chapter thumbs.
 
  \sa CVideoThumbLoader and CJob
  */
-class CThumbExtractor : public CJob
+class CChapterThumbExtractor : public CJob
 {
 public:
-  CThumbExtractor(const CFileItem& item, const std::string& listpath, bool thumb, const std::string& strTarget="", int64_t pos = -1, bool fillStreamDetails = true);
-  ~CThumbExtractor() override;
+  CChapterThumbExtractor(const CFileItem& item,
+                         const std::string& listpath,
+                         const std::string& strTarget = "",
+                         int64_t pos = -1);
+  ~CChapterThumbExtractor() override;
 
   /*!
    \brief Work function that extracts thumb.
@@ -50,10 +53,8 @@ public:
 
   std::string m_target; ///< thumbpath
   std::string m_listpath; ///< path used in fileitem list
-  CFileItem  m_item;
-  bool       m_thumb; ///< extract thumb?
-  int64_t    m_pos; ///< position to extract thumb from
-  bool m_fillStreamDetails; ///< fill in stream details?
+  CFileItem m_item;
+  int64_t m_pos; ///< position to extract thumb from
 };
 
 class CVideoThumbLoader : public CThumbLoader

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -293,7 +293,7 @@ void CGUIDialogVideoBookmarks::OnRefreshList()
     else if (i > m_jobsStarted && CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_MYVIDEOS_EXTRACTCHAPTERTHUMBS))
     {
       CFileItem item(m_filePath, false);
-      CJob* job = new CThumbExtractor(item, m_filePath, true, chapterPath, pos * 1000, false);
+      CJob* job = new CChapterThumbExtractor(item, m_filePath, chapterPath, pos * 1000);
       AddJob(job);
       m_mapJobsChapter[job] = i;
       m_jobsStarted++;


### PR DESCRIPTION
## Description
Use the new interface from #23197 to load generated video thumbs `image://video@nfs....`, into the texture cache when displayed, like regular images and embedded music covers.

The commit history tells a story. Commit 1 adds the new image loader, 2 and 3 remove dependencies on the old extractor, 4 trims extractor to just remaining requirement (the result is clearer than the diff), 5 is a boy scout cleanup.

## Motivation and context
Consistent behavior:
- all images load the same way, whether they are already cached or not.
- Remote interfaces can show these images even if they haven't been viewed in Kodi GUI yet.
- Kodi doesn't have to pre-cache a potentially massive list of images when browsing folders, _just in case_ they are viewed, saving both storage size in the cache and taking queue time for images actually displayed in the GUI.
- These special images can now be _preloaded_ the same as other images.

Easier maintenance and development: this provides a clear interface to load more special images, which avoids the complication of designing and developing a way to preload _some types_ of artwork.

## How has this been tested?
Manually on Windows, barely. A couple months dogfooding these changes with an Odroid N2.

## What is the effect on users?
The home window and web / remote interfaces can display generated thumbnails for episodes, movies, and music videos newly added to the library.

Slight changes to first-time texture loading for generated video thumbnails, maybe hard to describe. If anyone uses the "preload way more generated video thumbnails than visible on screen" behavior of these images on purpose, Kodi no longer works that way.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
