### PR TITLE
[Windows][dxva] log conversions supported by the processor

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -101,6 +101,15 @@ public:
   bool IsFormatConversionSupported(DXGI_FORMAT inputFormat,
                                    DXGI_FORMAT outputFormat,
                                    const VideoPicture& picture);
+  /*!
+   * \brief Outputs in the log a list of conversions supported by the DXVA processor.
+   * \param inputFormat The source format
+   * \param outputFormat The destination format
+   * \param picture Picture information used to derive the color spaces
+   */
+  void ListSupportedConversions(const DXGI_FORMAT& inputFormat,
+                                const DXGI_FORMAT& outputFormat,
+                                const VideoPicture& picture);
 
   // ID3DResource overrides
   void OnCreateDevice() override  {}
@@ -132,6 +141,17 @@ protected:
   DXGI_COLOR_SPACE_TYPE GetDXGIColorSpaceTarget(const DXGIColorSpaceArgs& csArgs,
                                                 bool supportHDR,
                                                 bool limitedRange) const;
+  /*!
+   * \brief Converts ffmpeg AV parameters to a DXGI color space
+   * \param csArgs ffmpeg AV picture parameters
+   * \return DXGI color space
+   */
+  static DXGI_COLOR_SPACE_TYPE AvToDxgiColorSpace(const DXGIColorSpaceArgs& csArgs);
+  /*!
+   * \brief Retrieve the list of DXGI_FORMAT supported as output by the DXVA processor
+   * \return Vector of formats
+   */
+  std::vector<DXGI_FORMAT> GetProcessorOutputFormats() const;
 
   CCriticalSection m_section;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -95,12 +95,12 @@ public:
    * Always returns true when the Windows 10+ API is not available or cannot be called successfully.
    * \param inputFormat The source format
    * \param outputFormat The destination format
-   * \param picture Picutre information used to derive the color spaces
+   * \param picture Picture information used to derive the color spaces
    * \return true if the conversion is supported, false otherwise
    */
   bool IsFormatConversionSupported(DXGI_FORMAT inputFormat,
                                    DXGI_FORMAT outputFormat,
-                                   const VideoPicture& picture) const;
+                                   const VideoPicture& picture);
 
   // ID3DResource overrides
   void OnCreateDevice() override  {}
@@ -155,6 +155,7 @@ protected:
   Microsoft::WRL::ComPtr<ID3D11VideoDevice> m_pVideoDevice;
   Microsoft::WRL::ComPtr<ID3D11VideoContext> m_pVideoContext;
   Microsoft::WRL::ComPtr<ID3D11VideoProcessorEnumerator> m_pEnumerator;
+  Microsoft::WRL::ComPtr<ID3D11VideoProcessorEnumerator1> m_pEnumerator1;
   Microsoft::WRL::ComPtr<ID3D11VideoProcessor> m_pVideoProcessor;
 };
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
@@ -111,10 +111,13 @@ bool CRendererDXVA::Configure(const VideoPicture& picture, float fps, unsigned o
     // create processor
     m_processor = std::make_unique<DXVA::CProcessorHD>();
     if (m_processor->PreInit() && m_processor->Open(m_sourceWidth, m_sourceHeight) &&
-        m_processor->IsFormatSupported(dxgi_format, support_type) &&
-        m_processor->IsFormatConversionSupported(dxgi_format, dest_format, picture))
+        m_processor->IsFormatSupported(dxgi_format, support_type))
     {
-      return true;
+      if (CServiceBroker::GetLogging().IsLogLevelLogged(LOGDEBUG))
+        m_processor->ListSupportedConversions(dxgi_format, dest_format, picture);
+
+      if (m_processor->IsFormatConversionSupported(dxgi_format, dest_format, picture))
+        return true;
     }
 
     CLog::LogF(LOGERROR, "unable to create DXVA processor");

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -1371,8 +1371,8 @@ DEBUG_INFO_RENDER DX::DeviceResources::GetDebugInfo() const
       "Swapchain: {} buffers, flip {}, {}, EOTF: {} (Windows HDR {})", desc.BufferCount,
       (desc.SwapEffect == DXGI_SWAP_EFFECT_FLIP_DISCARD) ? "discard" : "sequential",
       Windowing()->IsFullScreen()
-          ? ((desc.Flags == DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH) ? "fullscreen exclusive"
-                                                                    : "fullscreen windowed")
+          ? ((desc.Flags & DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH) ? "fullscreen exclusive"
+                                                                   : "fullscreen windowed")
           : "windowed screen",
       m_IsTransferPQ ? "PQ" : "SDR", m_IsHDROutput ? "on" : "off");
 

--- a/xbmc/rendering/dx/DeviceResources.h
+++ b/xbmc/rendering/dx/DeviceResources.h
@@ -117,6 +117,7 @@ namespace DX
 
     // Gets debug info from swapchain
     DEBUG_INFO_RENDER GetDebugInfo() const;
+    std::vector<DXGI_COLOR_SPACE_TYPE> GetSwapChainColorSpaces() const;
 
   private:
     class CBackBuffer : public CD3DTexture


### PR DESCRIPTION
## Description
New function to log the conversion capabilities of a dxva processor, based on the Windows 10 function ID3D11VideoProcessorEnumerator1::CheckVideoProcessorFormatConversion().
On Windows 8 the function exits early and logs nothing.

The input format (NV12, P010, ...) is fixed by the file being played and the function will go over possible combinations of the other 3 parameters of a color conversion:
* input color space (YCbCr only)
* output format (RGB only)
* output color space (RGB only)

In order to make it the logged information more readable the function adds special marks to the values currently chosen by Kodi's algorithms, the values that are a more natural mapping but may be missing processor support,

A few technical points:
* To avoid code duplication, GetDXGIColorSpaceSource() was split in two:
  - color space mapping closest to the description of the media (new function AvToDxgiColorSpace()
  - transform the mappings above to workaround processor limitations and do part of the work in the output stage / shader
* changed the enumerator1 to a class member to avoid creating it in multiple places
* refactored swap chain color spaces enumeration, now also used from outside DeviceResources
* unrelated to PR subject: improve a bit DeviceResources::GetDebugInfo
* also unrelated to PR subject: swapchain3 is enough to call CheckColorSpaceSupport, there was no need for swapchain4,

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Helps with troubleshooting and fixing of dxva processor issues.
A previous PR started testing whether the conversion is supported, this PR lists possible alternatives for a fix.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Window 10: Intel 4th and 8th gen, AMD Cezanne igfx
to help with the testing, put a breakpoint in DXVAHD.cpp on the last line of ListSupportedConversions
No Windows 8 needed because the new code exits early under W8.

The processor of Intel 8th gen is strange and CheckVideoProcessorFormatConversion() rejects some conversions even though the processor is able to output a picture (maybe it falls back on a default conversion, with some visual imperfections - unknown at this time). That testing will continue.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
no direct effect and the code activates only when the log level is debug.

## Screenshots (if appropriate):
Example of a couple lines - not a complete log

![image](https://user-images.githubusercontent.com/489377/231375775-6e9d3e25-3608-4b60-a772-fa80ab974128.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
