### PR TITLE
webos: Cleanup after #23092

### DIFF
--- a/cmake/modules/FindPlayerAPIs.cmake
+++ b/cmake/modules/FindPlayerAPIs.cmake
@@ -23,7 +23,7 @@ find_path(PLAYERAPIS_INCLUDE_DIR NAMES starfish-media-pipeline/StarfishMediaAPIs
 find_library(PLAYERAPIS_LIBRARY NAMES playerAPIs
         PATHS ${PC_PLAYERAPIS_LIBDIR})
 
-set(PLAYERAPIS_VERSION 1.0.0)
+set(PLAYERAPIS_VERSION ${PC_PLAYERAPIS_VERSION})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(PlayerAPIs

--- a/xbmc/cores/AudioEngine/Sinks/AESinkStarfish.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkStarfish.cpp
@@ -13,8 +13,21 @@
 #include "utils/log.h"
 #include "xbmc/cores/AudioEngine/AESinkFactory.h"
 
-#include <chrono>
 #include <thread>
+
+using namespace std::chrono_literals;
+
+namespace
+{
+constexpr unsigned int STARFISH_AUDIO_BUFFERS = 8;
+constexpr unsigned int AC3_SYNCFRAME_SIZE = 2560;
+
+static constexpr auto ms_audioCodecMap = make_map<CAEStreamInfo::DataType, std::string_view>({
+    {CAEStreamInfo::STREAM_TYPE_AC3, "AC3"},
+    {CAEStreamInfo::STREAM_TYPE_EAC3, "AC3 PLUS"},
+});
+
+} // namespace
 
 void CAESinkStarfish::Register()
 {
@@ -44,53 +57,32 @@ void CAESinkStarfish::EnumerateDevicesEx(AEDeviceInfoList& list, bool force)
 
   // PCM disabled for now as the latency is just too high, needs more research
   // Thankfully, ALSA or PulseAudio do work as an alternative for PCM content
-  /*info.m_dataFormats.push_back(AE_FMT_U8);
-  info.m_dataFormats.push_back(AE_FMT_S16NE);
-  info.m_dataFormats.push_back(AE_FMT_S16LE);
-  info.m_dataFormats.push_back(AE_FMT_S16BE);
-  info.m_dataFormats.push_back(AE_FMT_S32NE);
-  info.m_dataFormats.push_back(AE_FMT_S32LE);
-  info.m_dataFormats.push_back(AE_FMT_S32BE);
-  info.m_dataFormats.push_back(AE_FMT_FLOAT);
-  info.m_dataFormats.push_back(AE_FMT_DOUBLE);*/
-  info.m_dataFormats.push_back(AE_FMT_RAW);
+  info.m_dataFormats.emplace_back(AE_FMT_RAW);
 
   info.m_deviceType = AE_DEVTYPE_IEC958;
-  info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_AC3);
-  //info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_EAC3);
-  //info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_TRUEHD);
+  info.m_streamTypes.emplace_back(CAEStreamInfo::STREAM_TYPE_AC3);
+  info.m_streamTypes.emplace_back(CAEStreamInfo::STREAM_TYPE_EAC3);
 
-  info.m_sampleRates.push_back(48000);
-  info.m_sampleRates.push_back(44100);
-  info.m_sampleRates.push_back(32000);
-  info.m_sampleRates.push_back(24000);
-  info.m_sampleRates.push_back(22050);
-  info.m_sampleRates.push_back(16000);
-  info.m_sampleRates.push_back(12000);
-  info.m_sampleRates.push_back(8000);
-
-  list.push_back(info);
+  list.emplace_back(info);
 }
 
 CAESinkStarfish::CAESinkStarfish() : m_starfishMediaAPI(std::make_unique<StarfishMediaAPIs>())
 {
 }
 
-CAESinkStarfish::~CAESinkStarfish()
-{
-}
+CAESinkStarfish::~CAESinkStarfish() = default;
 
 bool CAESinkStarfish::Initialize(AEAudioFormat& format, std::string& device)
 {
   m_format = format;
-  m_pts = 0;
+  m_pts = 0ns;
 
   if (m_format.m_dataFormat != AE_FMT_RAW)
+  {
+    CLog::LogF(LOGERROR, "CAESinkStarfish: Unsupported format PCM");
     return false;
+  }
   m_format.m_frameSize = 1;
-
-  CLog::Log(LOGDEBUG, "CAESinkStarfish::Initialize Channel count is {}",
-            m_format.m_channelLayout.Count());
 
   format = m_format;
 
@@ -106,77 +98,36 @@ bool CAESinkStarfish::Initialize(AEAudioFormat& format, std::string& device)
   payload["option"]["transmission"]["contentsType"] = "LIVE"; // "LIVE", "WEBRTC"
 
   payload["option"]["lowDelayMode"] = true;
-  /*payload["option"]["bufferControl"]["preBufferTime"] = 0;
-  payload["option"]["bufferControl"]["userBufferCtrl"] = true;
-  payload["option"]["bufferControl"]["bufferingMinTime"] = 0;
-  payload["option"]["bufferControl"]["bufferingMaxTime"] = 100;*/
 
-  m_bufferSize = 12288;
-  if (m_format.m_dataFormat == AE_FMT_RAW)
+  switch (m_format.m_streamInfo.m_type)
   {
-    switch (m_format.m_streamInfo.m_type)
+    case CAEStreamInfo::STREAM_TYPE_AC3:
     {
-      case CAEStreamInfo::STREAM_TYPE_AC3:
-        payload["option"]["externalStreamingInfo"]["contents"]["codec"]["audio"] = "AC3";
-        if (!format.m_streamInfo.m_ac3FrameSize)
-          format.m_streamInfo.m_ac3FrameSize = 2560;
-        format.m_frames = format.m_streamInfo.m_ac3FrameSize;
-        m_bufferSize = format.m_frames * 8;
-        break;
-      case CAEStreamInfo::STREAM_TYPE_EAC3:
-        payload["option"]["externalStreamingInfo"]["contents"]["codec"]["audio"] = "AC3 PLUS";
-        payload["option"]["externalStreamingInfo"]["contents"]["ac3PlusInfo"]["channels"] =
-            m_format.m_streamInfo.m_channels;
-        payload["option"]["externalStreamingInfo"]["contents"]["ac3PlusInfo"]["frequency"] =
-            static_cast<double>(m_format.m_streamInfo.m_sampleRate) / 1000;
-
-        if (!format.m_streamInfo.m_ac3FrameSize)
-          format.m_streamInfo.m_ac3FrameSize = 2560;
-        format.m_frames = format.m_streamInfo.m_ac3FrameSize;
-        m_bufferSize = format.m_frames * 8;
-        break;
-      default:
-        CLog::Log(LOGDEBUG, "CAESinkStarfish::Initialize Unsupported format {}",
-                  m_format.m_streamInfo.m_type);
-        return false;
+      if (!format.m_streamInfo.m_ac3FrameSize)
+        format.m_streamInfo.m_ac3FrameSize = AC3_SYNCFRAME_SIZE;
+      format.m_frames = format.m_streamInfo.m_ac3FrameSize;
+      m_bufferSize = format.m_frames * STARFISH_AUDIO_BUFFERS;
+      break;
     }
-  }
-  else
-  {
-    payload["option"]["externalStreamingInfo"]["contents"]["pcmInfo"]["bitsPerSample"] =
-        CAEUtil::DataFormatToBits(m_format.m_dataFormat);
-    payload["option"]["externalStreamingInfo"]["contents"]["pcmInfo"]["sampleRate"] =
-        m_format.m_sampleRate;
-    payload["option"]["externalStreamingInfo"]["contents"]["pcmInfo"]["layout"] =
-        AE_IS_PLANAR(m_format.m_dataFormat) ? "non-interleaved" : "interleaved";
+    case CAEStreamInfo::STREAM_TYPE_EAC3:
+    {
+      payload["option"]["externalStreamingInfo"]["contents"]["ac3PlusInfo"]["channels"] =
+          m_format.m_streamInfo.m_channels;
+      payload["option"]["externalStreamingInfo"]["contents"]["ac3PlusInfo"]["frequency"] =
+          static_cast<double>(m_format.m_streamInfo.m_sampleRate) / 1000;
 
-    std::string channel;
-    switch (m_format.m_channelLayout.Count())
-    {
-      case 1:
-        channel = "mono";
-        break;
-      case 2:
-        channel = "stereo";
-        break;
-      case 6:
-        channel = "6-channel";
-        break;
-      default:
-        CLog::Log(LOGDEBUG, "CAESinkStarfish::Initialize Unsupported channel count {}",
-                  m_format.m_channelLayout.Count());
-        return false;
+      if (!format.m_streamInfo.m_ac3FrameSize)
+        format.m_streamInfo.m_ac3FrameSize = AC3_SYNCFRAME_SIZE;
+      format.m_frames = format.m_streamInfo.m_ac3FrameSize;
+      m_bufferSize = format.m_frames * STARFISH_AUDIO_BUFFERS;
+      break;
     }
-    payload["option"]["externalStreamingInfo"]["contents"]["pcmInfo"]["channelMode"] = channel;
-    auto pcmFormat = AEFormatToStarfishFormat(m_format.m_dataFormat);
-    if (pcmFormat.empty())
-    {
-      CLog::Log(LOGWARNING, "CAESinkStarfish::Initialize PCM format is empty");
+    default:
+      CLog::LogF(LOGDEBUG, "CAESinkStarfish: Unsupported format {}", m_format.m_streamInfo.m_type);
       return false;
-    }
-    payload["option"]["externalStreamingInfo"]["contents"]["pcmInfo"]["format"] = pcmFormat.data();
-    payload["option"]["externalStreamingInfo"]["contents"]["codec"]["audio"] = "PCM";
   }
+  payload["option"]["externalStreamingInfo"]["contents"]["codec"]["audio"] =
+      ms_audioCodecMap.at(m_format.m_streamInfo.m_type).data();
 
   payload["option"]["externalStreamingInfo"]["bufferingCtrInfo"]["preBufferByte"] = 0;
   payload["option"]["externalStreamingInfo"]["bufferingCtrInfo"]["bufferMinLevel"] = 0;
@@ -198,10 +149,10 @@ bool CAESinkStarfish::Initialize(AEAudioFormat& format, std::string& device)
   CJSONVariantWriter::Write(payloadArgs, json, true);
 
   m_starfishMediaAPI->notifyForeground();
-  CLog::Log(LOGDEBUG, "CAESinkStarfish: Sending Load payload {}", json);
+  CLog::LogFC(LOGDEBUG, LOGAUDIO, "CAESinkStarfish: Sending Load payload {}", json);
   if (!m_starfishMediaAPI->Load(json.c_str(), &CAESinkStarfish::PlayerCallback, this))
   {
-    CLog::Log(LOGERROR, "CAESinkStarfish::Initialize Load failed");
+    CLog::LogF(LOGERROR, "CAESinkStarfish: Load failed");
     return false;
   }
 
@@ -216,7 +167,11 @@ void CAESinkStarfish::Deinitialize()
 double CAESinkStarfish::GetCacheTotal()
 {
   if (m_format.m_dataFormat == AE_FMT_RAW)
-    return 8 * m_format.m_streamInfo.GetDuration();
+  {
+    auto frameTimeSeconds = std::chrono::duration_cast<std::chrono::duration<double>>(
+        std::chrono::duration<double, std::milli>(m_format.m_streamInfo.GetDuration()));
+    return STARFISH_AUDIO_BUFFERS * frameTimeSeconds.count();
+  }
   else
     return 0.0;
 }
@@ -229,24 +184,21 @@ double CAESinkStarfish::GetLatency()
 unsigned int CAESinkStarfish::AddPackets(uint8_t** data, unsigned int frames, unsigned int offset)
 {
   CVariant payload;
-  auto buffer = data[0] + offset * m_format.m_frameSize;
+  uint8_t* buffer = data[0] + offset * m_format.m_frameSize;
   payload["bufferAddr"] = fmt::format("{:#x}", reinterpret_cast<std::uintptr_t>(buffer));
   payload["bufferSize"] = frames * m_format.m_frameSize;
-  payload["pts"] = m_pts;
+  payload["pts"] = m_pts.count();
   payload["esData"] = 2;
 
-  int64_t frameTime;
-  if (m_format.m_dataFormat == AE_FMT_RAW)
-    frameTime = static_cast<int64_t>(m_format.m_streamInfo.GetDuration() * 1000000.0);
-  else
-    frameTime = 1000000000 * frames / m_format.m_sampleRate;
+  auto frameTime = std::chrono::duration_cast<std::chrono::nanoseconds>(
+      std::chrono::duration<double, std::milli>(m_format.m_streamInfo.GetDuration()));
 
   m_pts += frameTime;
 
   std::string json;
   CJSONVariantWriter::Write(payload, json, true);
 
-  auto result = m_starfishMediaAPI->Feed(json.c_str());
+  std::string result = m_starfishMediaAPI->Feed(json.c_str());
   while (result.find("BufferFull") != std::string::npos)
   {
     std::this_thread::sleep_for(std::chrono::nanoseconds(frameTime));
@@ -256,14 +208,12 @@ unsigned int CAESinkStarfish::AddPackets(uint8_t** data, unsigned int frames, un
   if (result.find("Ok") != std::string::npos)
     return frames;
 
-  CLog::Log(LOGWARNING, "CAESinkStarfish::AddPackets Buffer submit returned error: {}", result);
+  CLog::LogF(LOGWARNING, "CAESinkStarfish: Buffer submit returned error: {}", result);
   return 0;
 }
 
 void CAESinkStarfish::AddPause(unsigned int millis)
 {
-  //m_starfishMediaAPI->pushAudioDiscontinuityGap(m_playtime, m_playtime + millis * 1000000);
-  //m_pts += millis * 1000000;
   m_starfishMediaAPI->Pause();
   std::this_thread::sleep_for(std::chrono::milliseconds(millis));
   m_starfishMediaAPI->Play();
@@ -271,23 +221,14 @@ void CAESinkStarfish::AddPause(unsigned int millis)
 
 void CAESinkStarfish::GetDelay(AEDelayStatus& status)
 {
-  constexpr double hwLatency = 0.25;
-  status.SetDelay(hwLatency + static_cast<double>(m_delay) / 1000000000.0);
+  constexpr auto hwLatency = 250ms;
+  status.SetDelay(
+      std::chrono::duration_cast<std::chrono::duration<double>>(m_delay + hwLatency).count());
 }
 
 void CAESinkStarfish::Drain()
 {
   m_starfishMediaAPI->flush();
-}
-
-bool CAESinkStarfish::HasVolume()
-{
-  return false;
-}
-
-void CAESinkStarfish::SetVolume(float volume)
-{
-  //m_starfishMediaAPI->SetVolume(volume * 100);
 }
 
 void CAESinkStarfish::PlayerCallback(const int32_t type,
@@ -297,20 +238,15 @@ void CAESinkStarfish::PlayerCallback(const int32_t type,
   switch (type)
   {
     case PF_EVENT_TYPE_FRAMEREADY:
-      m_playtime = numValue;
-      m_delay = m_pts - numValue;
+      m_delay = m_pts - std::chrono::nanoseconds(numValue);
       break;
     case PF_EVENT_TYPE_STR_STATE_UPDATE__LOADCOMPLETED:
       m_starfishMediaAPI->Play();
       break;
     default:
-      std::string logstr;
-      if (strValue)
-      {
-        logstr = strValue;
-      }
-      CLog::Log(LOGDEBUG, "CAESinkStarfish::PlayerCallback type: {}, numValue: {}, strValue: {}",
-                type, numValue, logstr);
+      std::string logstr = strValue != nullptr ? strValue : "";
+      CLog::LogF(LOGDEBUG, "CAESinkStarfish: type: {}, numValue: {}, strValue: {}", type, numValue,
+                 logstr);
   }
 }
 
@@ -320,31 +256,4 @@ void CAESinkStarfish::PlayerCallback(const int32_t type,
                                      void* data)
 {
   static_cast<CAESinkStarfish*>(data)->PlayerCallback(type, numValue, strValue);
-}
-
-std::string_view CAESinkStarfish::AEFormatToStarfishFormat(AEDataFormat format)
-{
-  switch (format)
-  {
-    case AE_FMT_U8:
-      return "U8";
-    case AE_FMT_S16NE:
-      return "S16LE";
-    case AE_FMT_S16LE:
-      return "S16LE";
-    case AE_FMT_S16BE:
-      return "S16BE";
-    case AE_FMT_S32NE:
-      return "S32LE";
-    case AE_FMT_S32LE:
-      return "S32LE";
-    case AE_FMT_S32BE:
-      return "S32BE";
-    case AE_FMT_FLOAT:
-      return "F32LE";
-    case AE_FMT_DOUBLE:
-      return "F64LE";
-    default:
-      return "";
-  }
 }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkStarfish.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkStarfish.h
@@ -11,6 +11,9 @@
 #include "cores/AudioEngine/Interfaces/AESink.h"
 #include "cores/AudioEngine/Utils/AEDeviceInfo.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
+#include "utils/Map.h"
+
+#include <chrono>
 
 #include <starfish-media-pipeline/StarfishMediaAPIs.h>
 
@@ -33,8 +36,6 @@ public:
   void AddPause(unsigned int millis) override;
   void GetDelay(AEDelayStatus& status) override;
   void Drain() override;
-  bool HasVolume() override;
-  void SetVolume(float volume) override;
 
 private:
   void PlayerCallback(const int32_t type, const int64_t numValue, const char* strValue);
@@ -43,12 +44,9 @@ private:
                              const char* strValue,
                              void* data);
 
-  std::string_view AEFormatToStarfishFormat(AEDataFormat format);
-
   std::unique_ptr<StarfishMediaAPIs> m_starfishMediaAPI;
   AEAudioFormat m_format;
-  int64_t m_pts{0};
+  std::chrono::nanoseconds m_pts{0};
   int64_t m_bufferSize{0};
-  int64_t m_delay{0};
-  int64_t m_playtime{0};
+  std::chrono::nanoseconds m_delay{0};
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererStarfish.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererStarfish.cpp
@@ -18,12 +18,10 @@
 
 CRendererStarfish::CRendererStarfish()
 {
-  CLog::Log(LOGINFO, "Instancing CRendererStarfish");
+  CLog::LogF(LOGINFO, "CRendererStarfish: Instanced");
 }
 
-CRendererStarfish::~CRendererStarfish()
-{
-}
+CRendererStarfish::~CRendererStarfish() = default;
 
 CBaseRenderer* CRendererStarfish::Create(CVideoBuffer* buffer)
 {
@@ -57,8 +55,10 @@ void CRendererStarfish::ManageRenderArea()
   {
     auto origRect =
         CRect{0, 0, static_cast<float>(m_sourceWidth), static_cast<float>(m_sourceHeight)};
-    static_cast<KODI::WINDOWING::WAYLAND::CWinSystemWaylandWebOS*>(CServiceBroker::GetWinSystem())
-        ->SetExportedWindow(origRect, m_sourceRect, m_destRect);
+    using namespace KODI::WINDOWING::WAYLAND;
+    auto winSystem = static_cast<CWinSystemWaylandWebOS*>(CServiceBroker::GetWinSystem());
+
+    winSystem->SetExportedWindow(origRect, m_sourceRect, m_destRect);
     m_exportedSourceRect = m_sourceRect;
     m_exportedDestRect = m_destRect;
   }

--- a/xbmc/windowing/wayland/WinSystemWaylandWebOS.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandWebOS.cpp
@@ -23,7 +23,8 @@ namespace KODI::WINDOWING::WAYLAND
 
 bool CWinSystemWaylandWebOS::InitWindowSystem()
 {
-  auto ok = CWinSystemWayland::InitWindowSystem();
+  if (!CWinSystemWayland::InitWindowSystem())
+    return false;
 
   CDVDVideoCodecStarfish::Register();
   CRendererStarfish::Register();
@@ -35,14 +36,15 @@ bool CWinSystemWaylandWebOS::InitWindowSystem()
   m_webosRegistry->RequestSingleton(m_webosForeign, 1, 2, false);
   m_webosRegistry->Bind();
 
-  return ok;
+  return true;
 }
 
 bool CWinSystemWaylandWebOS::CreateNewWindow(const std::string& name,
                                              bool fullScreen,
                                              RESOLUTION_INFO& res)
 {
-  auto ok = CWinSystemWayland::CreateNewWindow(name, fullScreen, res);
+  if (!CWinSystemWayland::CreateNewWindow(name, fullScreen, res))
+    return false;
 
   if (m_webosForeign)
   {
@@ -51,12 +53,14 @@ bool CWinSystemWaylandWebOS::CreateNewWindow(const std::string& name,
         static_cast<uint32_t>(wayland::webos_foreign_webos_exported_type::video_object));
     m_exportedSurface.on_window_id_assigned() = [this](std::string window_id,
                                                        uint32_t exported_type) {
-      CLog::Log(LOGDEBUG, "Wayland foreign video surface exported {}", window_id);
+      CLog::Log(LOGDEBUG,
+                "CreateNewWindow:CDVDVideoCodecStarfish: Foreign video surface exported {}",
+                window_id);
       this->m_exportedWindowName = window_id;
     };
   }
 
-  return ok;
+  return true;
 }
 
 CWinSystemWaylandWebOS::~CWinSystemWaylandWebOS() noexcept
@@ -85,14 +89,13 @@ bool CWinSystemWaylandWebOS::SetExportedWindow(CRect orig, CRect src, CRect dest
 {
   if (m_webosForeign)
   {
-    CLog::Log(LOGINFO,
-              "CWinSystemWaylandWebOS::SetExportedWindow orig {} {} {} {} src {} {} {} {} -> dest "
-              "{} {} {} {}",
-              orig.x1, orig.y1, orig.x2, orig.y2, src.x1, src.y1, src.x2, src.y2, dest.x1, dest.y1,
-              dest.x2, dest.y2);
-    auto origRegion = m_compositor.create_region();
-    auto srcRegion = m_compositor.create_region();
-    auto dstRegion = m_compositor.create_region();
+    CLog::LogF(LOGINFO,
+               "CWinSystemWaylandWebOS: orig {} {} {} {} src {} {} {} {} -> dest {} {} {} {}",
+               orig.x1, orig.y1, orig.x2, orig.y2, src.x1, src.y1, src.x2, src.y2, dest.x1, dest.y1,
+               dest.x2, dest.y2);
+    wayland::region_t origRegion = m_compositor.create_region();
+    wayland::region_t srcRegion = m_compositor.create_region();
+    wayland::region_t dstRegion = m_compositor.create_region();
     origRegion.add(static_cast<int>(orig.x1), static_cast<int>(orig.y1),
                    static_cast<int>(orig.Width()), static_cast<int>(orig.Height()));
     srcRegion.add(static_cast<int>(src.x1), static_cast<int>(src.y1), static_cast<int>(src.Width()),


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Addresses the review feedback from @lrusak in #23092 

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Citing @lrusak review comment here:

>     It seems logging could use some uniformity (this is lacking elsewhere in the codebase but for new code it would be nice if the log style was consistent).
I'm now using LogF everywhere to make logging more consistent
>     There seems to be an overuse (abuse) of auto, see the code guidelines for help here -> https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md#124-auto
I've removed auto in a couple of places to make typing more explicit
>     The use of json is interesting and I would recommend looking into a way to set the json structures in a more readable manner (using a json template possibly and just setting the specific key/values through helpers (future TODO).
I think this is something we can improve on in `webos-userland`
>     There seems to be a lot of ifdeffing being added. I hope in the future we can find better ways to abstract this otherwise it's going to become a plague.
Probably once we get some integration with the luna bus to query the webOS version at runtime properly.
>     Take a look at using std::map (or utils/Map.h) for 1:1 mapping. This IMO improve readability and keeps definitions and maps together.
I'm using constexpr maps all over now
>     The API uses a lot of strings. It might be worth adding all the required strings as constant defines to group them together for readability.
Probably also something that can be added in `webos-userland`. I was thinking about implementing a helper function to set json values like so `very.nested.json.object`. Those strings could then be defined in the headers.
>     Please avoid adding dead code. You can always factor that in later. It's easier to change new code rather than changing it later.
I've removed the whole PCM stuff from AESinkStarfis and also the buffer limits from the video codec.
>     Our API's aren't quite setup yet to leverage std::chrono but I would recommend using it when dealing with time and changing units. It increases readability and avoids the need for macros to change units.
We now use std::chrono everywhere which is actually a very reasonable change because time units in DVDPlayer are not very consistent (use of micro, milli and second units) 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
LG OLED77C28 (webOS 7)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
