### PR TITLE
[Backport] RetroPlayer: Fix memory exhaustion with zero-copy emulators

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -126,6 +126,11 @@ bool CRPRenderManager::Configure(AVPixelFormat format,
 std::vector<VideoStreamBuffer> CRPRenderManager::GetVideoBuffers(unsigned int width,
                                                                  unsigned int height)
 {
+  // Clear any previous pending buffers
+  for (IRenderBuffer* buffer : m_pendingBuffers)
+    buffer->Release();
+  m_pendingBuffers.clear();
+
   std::vector<VideoStreamBuffer> buffers;
 
   if (m_bFlush || m_state != RENDER_STATE::CONFIGURED)

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
@@ -93,7 +93,7 @@ public:
                  unsigned int maxWidth,
                  unsigned int maxHeight,
                  float pixelAspectRatio);
-  std::vector<VideoStreamBuffer> GetVideoBuffers(unsigned int width, unsigned int height);
+  bool GetVideoBuffer(unsigned int width, unsigned int height, VideoStreamBuffer& buffer);
   void AddFrame(const uint8_t* data,
                 size_t size,
                 unsigned int width,

--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerVideo.cpp
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerVideo.cpp
@@ -13,8 +13,6 @@
 #include "cores/RetroPlayer/rendering/RenderTranslator.h"
 #include "utils/log.h"
 
-#include <algorithm>
-
 using namespace KODI;
 using namespace RETRO;
 
@@ -74,33 +72,7 @@ bool CRetroPlayerVideo::GetStreamBuffer(unsigned int width,
   VideoStreamBuffer& videoBuffer = static_cast<VideoStreamBuffer&>(buffer);
 
   if (m_bOpen)
-  {
-    m_buffers = m_renderManager.GetVideoBuffers(width, height);
-
-    std::sort(m_buffers.begin(), m_buffers.end(),
-              [](const VideoStreamBuffer& lhs, const VideoStreamBuffer& rhs) {
-                // Prefer read-write over write only
-                if (lhs.access == DataAccess::READ_WRITE && rhs.access != DataAccess::READ_WRITE)
-                  return true;
-                if (lhs.access != DataAccess::READ_WRITE && rhs.access == DataAccess::READ_WRITE)
-                  return false;
-
-                // Prefer aligned over unaligned
-                if (lhs.alignment == DataAlignment::DATA_ALIGNED &&
-                    rhs.alignment != DataAlignment::DATA_ALIGNED)
-                  return true;
-                if (lhs.alignment != DataAlignment::DATA_ALIGNED &&
-                    rhs.alignment == DataAlignment::DATA_ALIGNED)
-                  return false;
-
-                return false;
-              });
-
-    //! @todo This comment was in the original code
-    //! @todo Handle multiple buffers
-    if (!m_buffers.empty())
-      videoBuffer = m_buffers.at(0);
-  }
+    return m_renderManager.GetVideoBuffer(width, height, videoBuffer);
 
   return false;
 }
@@ -130,8 +102,6 @@ void CRetroPlayerVideo::AddStreamData(const StreamPacket& packet)
     m_renderManager.AddFrame(videoPacket.data, videoPacket.size, videoPacket.width,
                              videoPacket.height, orientationDegCCW);
   }
-
-  m_buffers.clear();
 }
 
 void CRetroPlayerVideo::CloseStream()

--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerVideo.h
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerVideo.h
@@ -107,7 +107,6 @@ private:
 
   // Stream properties
   bool m_bOpen = false;
-  std::vector<VideoStreamBuffer> m_buffers;
 };
 } // namespace RETRO
 } // namespace KODI


### PR DESCRIPTION
## Description

Backport of https://github.com/xbmc/xbmc/pull/23098

## How has this been tested?

Tested in my latest round of builds: https://github.com/garbear/xbmc/releases

## What is the effect on users?

* Fixed memory exhaustion bug introduced in v20.1 with certain emulators

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
