### PR TITLE
CVideoSync: rework setup interface

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoReferenceClock.h
+++ b/xbmc/cores/VideoPlayer/VideoReferenceClock.h
@@ -28,14 +28,15 @@ class CVideoReferenceClock : CThread
     double  GetRefreshRate(double* interval = nullptr);
     bool    GetClockInfo(int& MissedVblanks, double& ClockSpeed, double& RefreshRate) const;
 
+    void UpdateClock(int NrVBlanks, uint64_t time);
+
   private:
     void    Process() override;
     void Start();
     void    UpdateRefreshrate();
-    void    UpdateClock(int NrVBlanks, bool CheckMissed);
+    void UpdateClockInternal(int NrVBlanks, bool CheckMissed);
     double  UpdateInterval() const;
     int64_t TimeOfNextVblank() const;
-    static void CBUpdateClock(int NrVBlanks, uint64_t time, void *clock);
 
     int64_t m_CurrTime;          //the current time of the clock when using vblank as clock source
     int64_t m_LastIntTime;       //last interpolated clock value, to make sure the clock doesn't go backwards

--- a/xbmc/windowing/VideoSync.h
+++ b/xbmc/windowing/VideoSync.h
@@ -11,21 +11,19 @@
 #include "threads/Event.h"
 
 class CVideoReferenceClock;
-typedef void (*PUPDATECLOCK)(int NrVBlanks, uint64_t time, void *clock);
 
 class CVideoSync
 {
 public:
-  explicit CVideoSync(void* clock) { m_refClock = clock; }
+  explicit CVideoSync(CVideoReferenceClock* clock) { m_refClock = clock; }
   virtual ~CVideoSync() = default;
-  virtual bool Setup(PUPDATECLOCK func) = 0;
+  virtual bool Setup() = 0;
   virtual void Run(CEvent& stop) = 0;
   virtual void Cleanup() = 0;
   virtual float GetFps() = 0;
   virtual void RefreshChanged() {}
 
 protected:
-  PUPDATECLOCK UpdateClock;
   float m_fps;
-  void *m_refClock;
+  CVideoReferenceClock* m_refClock;
 };

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -38,6 +38,7 @@ class CDPMSSupport;
 class CGraphicContext;
 class CRenderSystemBase;
 class IRenderLoop;
+class CVideoReferenceClock;
 
 struct VideoPicture;
 
@@ -105,7 +106,7 @@ public:
   virtual bool Show(bool raise = true) { return false; }
 
   // videosync
-  virtual std::unique_ptr<CVideoSync> GetVideoSync(void *clock) { return nullptr; }
+  virtual std::unique_ptr<CVideoSync> GetVideoSync(CVideoReferenceClock* clock) { return nullptr; }
 
   // notifications
   virtual void OnMove(int x, int y) {}

--- a/xbmc/windowing/X11/OptionalsReg.cpp
+++ b/xbmc/windowing/X11/OptionalsReg.cpp
@@ -8,6 +8,8 @@
 
 #include "OptionalsReg.h"
 
+#include "cores/VideoPlayer/VideoReferenceClock.h"
+
 //-----------------------------------------------------------------------------
 // VAAPI
 //-----------------------------------------------------------------------------
@@ -159,8 +161,7 @@ CGLContext* GLXContextCreate(Display *dpy)
   return new CGLContextGLX(dpy);
 }
 
-
-CVideoSync* GLXVideoSyncCreate(void* clock, CWinSystemX11GLContext& winSystem)
+CVideoSync* GLXVideoSyncCreate(CVideoReferenceClock* clock, CWinSystemX11GLContext& winSystem)
 {
   return new  CVideoSyncGLX(clock, winSystem);
 }
@@ -192,7 +193,7 @@ CGLContext* GLXContextCreate(Display *dpy)
   return nullptr;
 }
 
-CVideoSync* GLXVideoSyncCreate(void* clock, CWinSystemX11GLContext& winSystem)
+CVideoSync* GLXVideoSyncCreate(CVideoReferenceClock* clock, CWinSystemX11GLContext& winSystem)
 {
   return nullptr;
 }

--- a/xbmc/windowing/X11/OptionalsReg.h
+++ b/xbmc/windowing/X11/OptionalsReg.h
@@ -43,6 +43,7 @@ void VAAPIRegisterRenderGLES(CVaapiProxy* winSystem, bool& general, bool& deepCo
 
 class CVideoSync;
 class CGLContext;
+class CVideoReferenceClock;
 
 namespace KODI
 {
@@ -56,7 +57,7 @@ class CWinSystemX11GLContext;
 XID GLXGetWindow(void* context);
 void* GLXGetContext(void* context);
 CGLContext* GLXContextCreate(Display *dpy);
-CVideoSync* GLXVideoSyncCreate(void *clock, CWinSystemX11GLContext& winSystem);
+CVideoSync* GLXVideoSyncCreate(CVideoReferenceClock* clock, CWinSystemX11GLContext& winSystem);
 }
 }
 }

--- a/xbmc/windowing/X11/VideoSyncGLX.cpp
+++ b/xbmc/windowing/X11/VideoSyncGLX.cpp
@@ -8,6 +8,7 @@
 
 #include "VideoSyncGLX.h"
 
+#include "cores/VideoPlayer/VideoReferenceClock.h"
 #include "utils/TimeUtils.h"
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
@@ -39,7 +40,7 @@ void CVideoSyncGLX::OnResetDisplay()
   m_displayReset = true;
 }
 
-bool CVideoSyncGLX::Setup(PUPDATECLOCK func)
+bool CVideoSyncGLX::Setup()
 {
   std::unique_lock<CCriticalSection> lock(m_winSystem.GetGfxContext());
 
@@ -48,7 +49,6 @@ bool CVideoSyncGLX::Setup(PUPDATECLOCK func)
   m_vInfo = NULL;
   m_Window = 0;
   m_Context = NULL;
-  UpdateClock = func;
 
   int singleBufferAttributes[] = {
     GLX_RGBA,
@@ -197,7 +197,7 @@ void CVideoSyncGLX::Run(CEvent& stopEvent)
 
     if (VblankCount > PrevVblankCount)
     {
-      UpdateClock((int)(VblankCount - PrevVblankCount), Now, m_refClock);
+      m_refClock->UpdateClock((int)(VblankCount - PrevVblankCount), Now);
       IsReset = false;
     }
     else

--- a/xbmc/windowing/X11/VideoSyncGLX.h
+++ b/xbmc/windowing/X11/VideoSyncGLX.h
@@ -32,11 +32,11 @@ class CWinSystemX11GLContext;
 class CVideoSyncGLX : public CVideoSync, IDispResource
 {
 public:
-  explicit CVideoSyncGLX(void* clock, CWinSystemX11GLContext& winSystem)
+  explicit CVideoSyncGLX(CVideoReferenceClock* clock, CWinSystemX11GLContext& winSystem)
     : CVideoSync(clock), m_winSystem(winSystem)
   {
   }
-  bool Setup(PUPDATECLOCK func) override;
+  bool Setup() override;
   void Run(CEvent& stopEvent) override;
   void Cleanup() override;
   float GetFps() override;

--- a/xbmc/windowing/X11/VideoSyncOML.cpp
+++ b/xbmc/windowing/X11/VideoSyncOML.cpp
@@ -8,6 +8,7 @@
 
 #include "VideoSyncOML.h"
 
+#include "cores/VideoPlayer/VideoReferenceClock.h"
 #include "utils/TimeUtils.h"
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
@@ -17,11 +18,9 @@
 
 using namespace KODI::WINDOWING::X11;
 
-bool CVideoSyncOML::Setup(PUPDATECLOCK func)
+bool CVideoSyncOML::Setup()
 {
   CLog::Log(LOGDEBUG, "CVideoSyncOML::{} - setting up OML", __FUNCTION__);
-
-  UpdateClock = func;
 
   m_abort = false;
 
@@ -60,7 +59,7 @@ void CVideoSyncOML::Run(CEvent& stopEvent)
     }
 
     uint64_t now = CurrentHostCounter();
-    UpdateClock(newMsc - msc, now, m_refClock);
+    m_refClock->UpdateClock(newMsc - msc, now);
     msc = newMsc;
   }
 }

--- a/xbmc/windowing/X11/VideoSyncOML.h
+++ b/xbmc/windowing/X11/VideoSyncOML.h
@@ -26,11 +26,11 @@ class CWinSystemX11GLContext;
 class CVideoSyncOML : public CVideoSync, IDispResource
 {
 public:
-  explicit CVideoSyncOML(void* clock, CWinSystemX11GLContext& winSystem)
+  explicit CVideoSyncOML(CVideoReferenceClock* clock, CWinSystemX11GLContext& winSystem)
     : CVideoSync(clock), m_winSystem(winSystem)
   {
   }
-  bool Setup(PUPDATECLOCK func) override;
+  bool Setup() override;
   void Run(CEvent& stopEvent) override;
   void Cleanup() override;
   float GetFps() override;

--- a/xbmc/windowing/X11/WinSystemX11GLContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
@@ -18,6 +18,7 @@
 #include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h"
 #include "cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h"
 #include "cores/VideoPlayer/Process/X11/ProcessInfoX11.h"
+#include "cores/VideoPlayer/VideoReferenceClock.h"
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
 #include "guilib/DispResource.h"
@@ -313,7 +314,7 @@ bool CWinSystemX11GLContext::RefreshGLContext(bool force)
   return success;
 }
 
-std::unique_ptr<CVideoSync> CWinSystemX11GLContext::GetVideoSync(void *clock)
+std::unique_ptr<CVideoSync> CWinSystemX11GLContext::GetVideoSync(CVideoReferenceClock* clock)
 {
   std::unique_ptr<CVideoSync> pVSync;
 

--- a/xbmc/windowing/X11/WinSystemX11GLContext.h
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.h
@@ -15,6 +15,7 @@
 #include <memory>
 
 class CGLContext;
+class CVideoReferenceClock;
 
 namespace KODI
 {
@@ -46,7 +47,7 @@ public:
   bool IsExtSupported(const char* extension) const override;
 
   // videosync
-  std::unique_ptr<CVideoSync> GetVideoSync(void *clock) override;
+  std::unique_ptr<CVideoSync> GetVideoSync(CVideoReferenceClock* clock) override;
   float GetFrameLatencyAdjustment() override;
   uint64_t GetVblankTiming(uint64_t &msc, uint64_t &interval);
 

--- a/xbmc/windowing/android/VideoSyncAndroid.cpp
+++ b/xbmc/windowing/android/VideoSyncAndroid.cpp
@@ -19,14 +19,12 @@
 
 #include "platform/android/activity/XBMCApp.h"
 
-
-bool CVideoSyncAndroid::Setup(PUPDATECLOCK func)
+bool CVideoSyncAndroid::Setup()
 {
   CLog::Log(LOGDEBUG, "CVideoSyncAndroid::{} setting up", __FUNCTION__);
 
   //init the vblank timestamp
   m_LastVBlankTime = CurrentHostCounter();
-  UpdateClock = func;
   m_abortEvent.Reset();
 
   CXBMCApp::Get().InitFrameCallback(this);
@@ -74,5 +72,5 @@ void CVideoSyncAndroid::FrameCallback(int64_t frameTimeNanos)
   m_LastVBlankTime = frameTimeNanos;
 
   //update the vblank timestamp, update the clock and send a signal that we got a vblank
-  UpdateClock(NrVBlanks, frameTimeNanos, m_refClock);
+  m_refClock->UpdateClock(NrVBlanks, frameTimeNanos);
 }

--- a/xbmc/windowing/android/VideoSyncAndroid.h
+++ b/xbmc/windowing/android/VideoSyncAndroid.h
@@ -14,10 +14,10 @@
 class CVideoSyncAndroid : public CVideoSync, IDispResource
 {
 public:
-  CVideoSyncAndroid(void *clock) : CVideoSync(clock), m_LastVBlankTime(0) {}
+  CVideoSyncAndroid(CVideoReferenceClock* clock) : CVideoSync(clock), m_LastVBlankTime(0) {}
 
   // CVideoSync interface
-  bool Setup(PUPDATECLOCK func) override;
+  bool Setup() override;
   void Run(CEvent& stop) override;
   void Cleanup() override;
   float GetFps() override;

--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
@@ -168,7 +168,7 @@ EGLConfig  CWinSystemAndroidGLESContext::GetEGLConfig() const
   return m_pGLContext.GetEGLConfig();
 }
 
-std::unique_ptr<CVideoSync> CWinSystemAndroidGLESContext::GetVideoSync(void *clock)
+std::unique_ptr<CVideoSync> CWinSystemAndroidGLESContext::GetVideoSync(CVideoReferenceClock* clock)
 {
   std::unique_ptr<CVideoSync> pVSync(new CVideoSyncAndroid(clock));
   return pVSync;

--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.h
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.h
@@ -35,7 +35,7 @@ public:
   bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
   bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
 
-  std::unique_ptr<CVideoSync> GetVideoSync(void* clock) override;
+  std::unique_ptr<CVideoSync> GetVideoSync(CVideoReferenceClock* clock) override;
 
   float GetFrameLatencyAdjustment() override;
   bool IsHDRDisplay() override;

--- a/xbmc/windowing/gbm/VideoSyncGbm.cpp
+++ b/xbmc/windowing/gbm/VideoSyncGbm.cpp
@@ -9,6 +9,7 @@
 #include "VideoSyncGbm.h"
 
 #include "ServiceBroker.h"
+#include "cores/VideoPlayer/VideoReferenceClock.h"
 #include "threads/Thread.h"
 #include "utils/TimeUtils.h"
 #include "utils/log.h"
@@ -24,16 +25,15 @@
 
 #include <unistd.h>
 
-CVideoSyncGbm::CVideoSyncGbm(void* clock)
+CVideoSyncGbm::CVideoSyncGbm(CVideoReferenceClock* clock)
   : CVideoSync(clock), m_winSystem(CServiceBroker::GetWinSystem())
 {
   if (!m_winSystem)
     throw std::runtime_error("window system not available");
 }
 
-bool CVideoSyncGbm::Setup(PUPDATECLOCK func)
+bool CVideoSyncGbm::Setup()
 {
-  UpdateClock = func;
   m_abort = false;
   m_winSystem->Register(this);
   CLog::Log(LOGDEBUG, "CVideoSyncGbm::{} setting up", __FUNCTION__);
@@ -101,7 +101,7 @@ void CVideoSyncGbm::Run(CEvent& stopEvent)
     if (sequence == m_sequence)
       continue;
 
-    UpdateClock(sequence - m_sequence, m_offset + ns, m_refClock);
+    m_refClock->UpdateClock(sequence - m_sequence, m_offset + ns);
     m_sequence = sequence;
   }
 }

--- a/xbmc/windowing/gbm/VideoSyncGbm.h
+++ b/xbmc/windowing/gbm/VideoSyncGbm.h
@@ -18,12 +18,12 @@ class CWinSystemBase;
 class CVideoSyncGbm : public CVideoSync, IDispResource
 {
 public:
-  explicit CVideoSyncGbm(void* clock);
+  explicit CVideoSyncGbm(CVideoReferenceClock* clock);
   CVideoSyncGbm() = delete;
   ~CVideoSyncGbm() override = default;
 
   // CVideoSync overrides
-  bool Setup(PUPDATECLOCK func) override;
+  bool Setup() override;
   void Run(CEvent& stopEvent) override;
   void Cleanup() override;
   float GetFps() override;

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -13,6 +13,7 @@
 #include "ServiceBroker.h"
 #include "VideoSyncGbm.h"
 #include "cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h"
+#include "cores/VideoPlayer/VideoReferenceClock.h"
 #include "drm/DRMAtomic.h"
 #include "drm/DRMLegacy.h"
 #include "drm/OffScreenModeSetting.h"
@@ -316,7 +317,7 @@ void CWinSystemGbm::OnLostDevice()
     resource->OnLostDisplay();
 }
 
-std::unique_ptr<CVideoSync> CWinSystemGbm::GetVideoSync(void* clock)
+std::unique_ptr<CVideoSync> CWinSystemGbm::GetVideoSync(CVideoReferenceClock* clock)
 {
   return std::make_unique<CVideoSyncGbm>(clock);
 }

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -79,7 +79,7 @@ public:
 protected:
   void OnLostDevice();
 
-  std::unique_ptr<CVideoSync> GetVideoSync(void* clock) override;
+  std::unique_ptr<CVideoSync> GetVideoSync(CVideoReferenceClock* clock) override;
 
   std::shared_ptr<CDRMUtils> m_DRM;
   std::unique_ptr<CGBMUtils> m_GBM;

--- a/xbmc/windowing/ios/VideoSyncIos.cpp
+++ b/xbmc/windowing/ios/VideoSyncIos.cpp
@@ -15,13 +15,12 @@
 #include "windowing/GraphicContext.h"
 #include "windowing/ios/WinSystemIOS.h"
 
-bool CVideoSyncIos::Setup(PUPDATECLOCK func)
+bool CVideoSyncIos::Setup()
 {
   CLog::Log(LOGDEBUG, "CVideoSyncIos::{} setting up OSX", __FUNCTION__);
 
   //init the vblank timestamp
   m_LastVBlankTime = CurrentHostCounter();
-  UpdateClock = func;
   m_abortEvent.Reset();
 
   bool setupOk = InitDisplayLink();
@@ -73,7 +72,7 @@ void CVideoSyncIos::IosVblankHandler()
   m_LastVBlankTime = nowtime;
 
   //update the vblank timestamp, update the clock and send a signal that we got a vblank
-  UpdateClock(NrVBlanks, nowtime, m_refClock);
+  m_refClock->UpdateClock(NrVBlanks, nowtime);
 }
 
 bool CVideoSyncIos::InitDisplayLink()

--- a/xbmc/windowing/ios/VideoSyncIos.h
+++ b/xbmc/windowing/ios/VideoSyncIos.h
@@ -16,11 +16,13 @@ class CWinSystemIOS;
 class CVideoSyncIos : public CVideoSync, IDispResource
 {
 public:
-  CVideoSyncIos(void *clock, CWinSystemIOS &winSystem) :
-    CVideoSync(clock), m_winSystem(winSystem) {}
+  CVideoSyncIos(CVideoReferenceClock* clock, CWinSystemIOS& winSystem)
+    : CVideoSync(clock), m_winSystem(winSystem)
+  {
+  }
 
   // CVideoSync interface
-  bool Setup(PUPDATECLOCK func) override;
+  bool Setup() override;
   void Run(CEvent& stopEvent) override;
   void Cleanup() override;
   float GetFps() override;

--- a/xbmc/windowing/ios/WinSystemIOS.h
+++ b/xbmc/windowing/ios/WinSystemIOS.h
@@ -60,7 +60,7 @@ public:
   void Register(IDispResource *resource) override;
   void Unregister(IDispResource *resource) override;
 
-  std::unique_ptr<CVideoSync> GetVideoSync(void* clock) override;
+  std::unique_ptr<CVideoSync> GetVideoSync(CVideoReferenceClock* clock) override;
 
   std::vector<std::string> GetConnectedOutputs() override;
 

--- a/xbmc/windowing/ios/WinSystemIOS.mm
+++ b/xbmc/windowing/ios/WinSystemIOS.mm
@@ -489,7 +489,7 @@ void CWinSystemIOS::MoveToTouchscreen()
   CDisplaySettings::GetInstance().SetMonitor(CONST_TOUCHSCREEN);
 }
 
-std::unique_ptr<CVideoSync> CWinSystemIOS::GetVideoSync(void *clock)
+std::unique_ptr<CVideoSync> CWinSystemIOS::GetVideoSync(CVideoReferenceClock* clock)
 {
   std::unique_ptr<CVideoSync> pVSync(new CVideoSyncIos(clock, *this));
   return pVSync;

--- a/xbmc/windowing/osx/SDL/WinSystemOSXSDL.h
+++ b/xbmc/windowing/osx/SDL/WinSystemOSXSDL.h
@@ -57,7 +57,7 @@ public:
   void Register(IDispResource *resource) override;
   void Unregister(IDispResource *resource) override;
 
-  std::unique_ptr<CVideoSync> GetVideoSync(void* clock) override;
+  std::unique_ptr<CVideoSync> GetVideoSync(CVideoReferenceClock* clock) override;
 
   std::vector<std::string> GetConnectedOutputs() override;
 

--- a/xbmc/windowing/osx/SDL/WinSystemOSXSDL.mm
+++ b/xbmc/windowing/osx/SDL/WinSystemOSXSDL.mm
@@ -1820,7 +1820,7 @@ std::string CWinSystemOSX::GetClipboardText(void)
   return utf8_text;
 }
 
-std::unique_ptr<CVideoSync> CWinSystemOSX::GetVideoSync(void *clock)
+std::unique_ptr<CVideoSync> CWinSystemOSX::GetVideoSync(CVideoReferenceClock* clock)
 {
   std::unique_ptr<CVideoSync> pVSync(new CVideoSyncOsx(clock));
   return pVSync;

--- a/xbmc/windowing/osx/VideoSyncOsx.h
+++ b/xbmc/windowing/osx/VideoSyncOsx.h
@@ -15,13 +15,13 @@
 class CVideoSyncOsx : public CVideoSync, IDispResource
 {
 public:
-  CVideoSyncOsx(void* clock)
+  CVideoSyncOsx(CVideoReferenceClock* clock)
     : CVideoSync(clock), m_LastVBlankTime(0), m_displayLost(false), m_displayReset(false)
   {
   }
 
   // CVideoSync interface
-  bool Setup(PUPDATECLOCK func) override;
+  bool Setup() override;
   void Run(CEvent& stopEvent) override;
   void Cleanup() override;
   float GetFps() override;

--- a/xbmc/windowing/osx/VideoSyncOsx.mm
+++ b/xbmc/windowing/osx/VideoSyncOsx.mm
@@ -9,6 +9,7 @@
 #include "VideoSyncOsx.h"
 
 #include "ServiceBroker.h"
+#include "cores/VideoPlayer/VideoReferenceClock.h"
 #include "utils/MathUtils.h"
 #include "utils/TimeUtils.h"
 #include "utils/log.h"
@@ -23,13 +24,12 @@
 
 using namespace std::chrono_literals;
 
-bool CVideoSyncOsx::Setup(PUPDATECLOCK func)
+bool CVideoSyncOsx::Setup()
 {
   CLog::Log(LOGDEBUG, "CVideoSyncOsx::{} setting up OSX", __FUNCTION__);
 
   //init the vblank timestamp
   m_LastVBlankTime = 0;
-  UpdateClock = func;
   m_displayLost = false;
   m_displayReset = false;
   m_lostEvent.Reset();
@@ -105,7 +105,7 @@ void CVideoSyncOsx::VblankHandler(int64_t nowtime, uint32_t timebase)
     NrVBlanks = MathUtils::round_int(VBlankTime * static_cast<double>(m_fps));
 
     //update the vblank timestamp, update the clock and send a signal that we got a vblank
-    UpdateClock(NrVBlanks, Now, m_refClock);
+    m_refClock->UpdateClock(NrVBlanks, Now);
   }
 
   //save the timestamp of this vblank so we can calculate how many happened next time

--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -76,7 +76,7 @@ public:
   void Register(IDispResource* resource) override;
   void Unregister(IDispResource* resource) override;
 
-  std::unique_ptr<CVideoSync> GetVideoSync(void* clock) override;
+  std::unique_ptr<CVideoSync> GetVideoSync(CVideoReferenceClock* clock) override;
 
   void WindowChangedScreen();
 

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1194,7 +1194,7 @@ void CWinSystemOSX::EnableVSync(bool enable)
                                forParameter:NSOpenGLContextParameterSwapInterval];
 }
 
-std::unique_ptr<CVideoSync> CWinSystemOSX::GetVideoSync(void* clock)
+std::unique_ptr<CVideoSync> CWinSystemOSX::GetVideoSync(CVideoReferenceClock* clock)
 {
   return std::make_unique<CVideoSyncOsx>(clock);
 }

--- a/xbmc/windowing/tvos/VideoSyncTVos.cpp
+++ b/xbmc/windowing/tvos/VideoSyncTVos.cpp
@@ -15,13 +15,12 @@
 #include "windowing/GraphicContext.h"
 #import "windowing/tvos/WinSystemTVOS.h"
 
-bool CVideoSyncTVos::Setup(PUPDATECLOCK func)
+bool CVideoSyncTVos::Setup()
 {
   CLog::Log(LOGDEBUG, "CVideoSyncTVos::{} setting up TVOS", __FUNCTION__);
 
   //init the vblank timestamp
   m_LastVBlankTime = CurrentHostCounter();
-  UpdateClock = func;
   m_abortEvent.Reset();
 
   bool setupOk = InitDisplayLink();
@@ -72,7 +71,7 @@ void CVideoSyncTVos::TVosVblankHandler()
   m_LastVBlankTime = nowtime;
 
   //update the vblank timestamp, update the clock and send a signal that we got a vblank
-  UpdateClock(NrVBlanks, nowtime, m_refClock);
+  m_refClock->UpdateClock(NrVBlanks, nowtime);
 }
 
 bool CVideoSyncTVos::InitDisplayLink()

--- a/xbmc/windowing/tvos/VideoSyncTVos.h
+++ b/xbmc/windowing/tvos/VideoSyncTVos.h
@@ -16,12 +16,13 @@ class CWinSystemTVOS;
 class CVideoSyncTVos : public CVideoSync, IDispResource
 {
 public:
-  CVideoSyncTVos(void* clock, CWinSystemTVOS& winSystem) : CVideoSync(clock), m_winSystem(winSystem)
+  CVideoSyncTVos(CVideoReferenceClock* clock, CWinSystemTVOS& winSystem)
+    : CVideoSync(clock), m_winSystem(winSystem)
   {
   }
 
   // CVideoSync interface
-  bool Setup(PUPDATECLOCK func) override;
+  bool Setup() override;
   void Run(CEvent& stopEvent) override;
   void Cleanup() override;
   float GetFps() override;

--- a/xbmc/windowing/tvos/WinSystemTVOS.h
+++ b/xbmc/windowing/tvos/WinSystemTVOS.h
@@ -72,7 +72,7 @@ public:
   void Register(IDispResource* resource) override;
   void Unregister(IDispResource* resource) override;
 
-  //virtual std::unique_ptr<CVideoSync> GetVideoSync(void* clock) override;
+  //virtual std::unique_ptr<CVideoSync> GetVideoSync(CVideoReferenceClock* clock) override;
 
   std::vector<std::string> GetConnectedOutputs() override;
 

--- a/xbmc/windowing/wayland/VideoSyncWpPresentation.cpp
+++ b/xbmc/windowing/wayland/VideoSyncWpPresentation.cpp
@@ -8,6 +8,7 @@
 
 #include "VideoSyncWpPresentation.h"
 
+#include "cores/VideoPlayer/VideoReferenceClock.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/TimeUtils.h"
 #include "utils/log.h"
@@ -19,14 +20,14 @@
 using namespace KODI::WINDOWING::WAYLAND;
 using namespace std::placeholders;
 
-CVideoSyncWpPresentation::CVideoSyncWpPresentation(void* clock, CWinSystemWayland& winSystem)
-: CVideoSync(clock), m_winSystem(winSystem)
+CVideoSyncWpPresentation::CVideoSyncWpPresentation(CVideoReferenceClock* clock,
+                                                   CWinSystemWayland& winSystem)
+  : CVideoSync(clock), m_winSystem(winSystem)
 {
 }
 
-bool CVideoSyncWpPresentation::Setup(PUPDATECLOCK func)
+bool CVideoSyncWpPresentation::Setup()
 {
-  UpdateClock = func;
   m_stopEvent.Reset();
   m_fps = m_winSystem.GetSyncOutputRefreshRate();
 
@@ -79,5 +80,5 @@ void CVideoSyncWpPresentation::HandlePresentation(timespec tv, std::uint32_t ref
 
   // FIXME use timespec instead of currenthostcounter()? Possibly difficult
   // due to different clock base
-  UpdateClock(mscDiff, CurrentHostCounter(), m_refClock);
+  m_refClock->UpdateClock(mscDiff, CurrentHostCounter());
 }

--- a/xbmc/windowing/wayland/VideoSyncWpPresentation.h
+++ b/xbmc/windowing/wayland/VideoSyncWpPresentation.h
@@ -25,10 +25,10 @@ class CWinSystemWayland;
 class CVideoSyncWpPresentation : public CVideoSync
 {
 public:
-  explicit CVideoSyncWpPresentation(void* clock, CWinSystemWayland& winSystem);
+  explicit CVideoSyncWpPresentation(CVideoReferenceClock* clock, CWinSystemWayland& winSystem);
 
   float GetFps() override;
-  bool Setup(PUPDATECLOCK func) override;
+  bool Setup() override;
   void Run(CEvent& stop) override;
   void Cleanup() override;
 

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -24,6 +24,7 @@
 #include "application/Application.h"
 #include "cores/RetroPlayer/process/wayland/RPProcessInfoWayland.h"
 #include "cores/VideoPlayer/Process/wayland/ProcessInfoWayland.h"
+#include "cores/VideoPlayer/VideoReferenceClock.h"
 #include "guilib/DispResource.h"
 #include "guilib/LocalizeStrings.h"
 #include "input/InputManager.h"
@@ -1471,7 +1472,7 @@ KODI::CSignalRegistration CWinSystemWayland::RegisterOnPresentationFeedback(
   return m_presentationFeedbackHandlers.Register(handler);
 }
 
-std::unique_ptr<CVideoSync> CWinSystemWayland::GetVideoSync(void* clock)
+std::unique_ptr<CVideoSync> CWinSystemWayland::GetVideoSync(CVideoReferenceClock* clock)
 {
   if (m_surface && m_presentation)
   {

--- a/xbmc/windowing/wayland/WinSystemWayland.h
+++ b/xbmc/windowing/wayland/WinSystemWayland.h
@@ -84,7 +84,7 @@ public:
   float GetSyncOutputRefreshRate();
   float GetDisplayLatency() override;
   float GetFrameLatencyAdjustment() override;
-  std::unique_ptr<CVideoSync> GetVideoSync(void* clock) override;
+  std::unique_ptr<CVideoSync> GetVideoSync(CVideoReferenceClock* clock) override;
 
   void Register(IDispResource* resource) override;
   void Unregister(IDispResource* resource) override;

--- a/xbmc/windowing/win10/WinSystemWin10.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10.cpp
@@ -606,7 +606,7 @@ void CWinSystemWin10::ResolutionChanged()
   OnDisplayBack();
 }
 
-std::unique_ptr<CVideoSync> CWinSystemWin10::GetVideoSync(void *clock)
+std::unique_ptr<CVideoSync> CWinSystemWin10::GetVideoSync(CVideoReferenceClock* clock)
 {
   std::unique_ptr<CVideoSync> pVSync(new CVideoSyncD3D(clock));
   return pVSync;

--- a/xbmc/windowing/win10/WinSystemWin10.h
+++ b/xbmc/windowing/win10/WinSystemWin10.h
@@ -84,7 +84,7 @@ public:
   bool HasSystemSdrPeakLuminance() override;
 
   // videosync
-  std::unique_ptr<CVideoSync> GetVideoSync(void *clock) override;
+  std::unique_ptr<CVideoSync> GetVideoSync(CVideoReferenceClock* clock) override;
 
   bool WindowedMode() const { return m_state != WINDOW_STATE_FULLSCREEN; }
   bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;

--- a/xbmc/windowing/windows/VideoSyncD3D.cpp
+++ b/xbmc/windowing/windows/VideoSyncD3D.cpp
@@ -10,6 +10,7 @@
 
 #include "Utils/MathUtils.h"
 #include "Utils/TimeUtils.h"
+#include "cores/VideoPlayer/VideoReferenceClock.h"
 #include "rendering/dx/DeviceResources.h"
 #include "rendering/dx/RenderContext.h"
 #include "utils/StringUtils.h"
@@ -40,7 +41,7 @@ void CVideoSyncD3D::RefreshChanged()
   m_displayReset = true;
 }
 
-bool CVideoSyncD3D::Setup(PUPDATECLOCK func)
+bool CVideoSyncD3D::Setup()
 {
   CLog::Log(LOGDEBUG, "CVideoSyncD3D: Setting up Direct3d");
   std::unique_lock<CCriticalSection> lock(CServiceBroker::GetWinSystem()->GetGfxContext());
@@ -48,7 +49,6 @@ bool CVideoSyncD3D::Setup(PUPDATECLOCK func)
   m_displayLost = false;
   m_displayReset = false;
   m_lostEvent.Reset();
-  UpdateClock = func;
 
   // we need a high priority thread to get accurate timing
   if (!SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL))
@@ -82,7 +82,7 @@ void CVideoSyncD3D::Run(CEvent& stopEvent)
     NrVBlanks = MathUtils::round_int(VBlankTime * m_fps);
 
     // update the vblank timestamp, update the clock and send a signal that we got a vblank
-    UpdateClock(NrVBlanks, Now, m_refClock);
+    m_refClock->UpdateClock(NrVBlanks, Now);
 
     // save the timestamp of this vblank so we can calculate how many vblanks happened next time
     LastVBlankTime = Now;

--- a/xbmc/windowing/windows/VideoSyncD3D.h
+++ b/xbmc/windowing/windows/VideoSyncD3D.h
@@ -15,11 +15,11 @@
 class CVideoSyncD3D : public CVideoSync, IDispResource
 {
 public:
-  CVideoSyncD3D(void* clock)
+  CVideoSyncD3D(CVideoReferenceClock* clock)
     : CVideoSync(clock), m_displayLost(false), m_displayReset(false), m_lastUpdateTime(0)
   {
   }
-  bool Setup(PUPDATECLOCK func) override;
+  bool Setup() override;
   void Run(CEvent& stopEvent) override;
   void Cleanup() override;
   float GetFps() override;

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -1239,7 +1239,7 @@ void CWinSystemWin32::SetForegroundWindowInternal(HWND hWnd)
   }
 }
 
-std::unique_ptr<CVideoSync> CWinSystemWin32::GetVideoSync(void *clock)
+std::unique_ptr<CVideoSync> CWinSystemWin32::GetVideoSync(CVideoReferenceClock* clock)
 {
   std::unique_ptr<CVideoSync> pVSync(new CVideoSyncD3D(clock));
   return pVSync;

--- a/xbmc/windowing/windows/WinSystemWin32.h
+++ b/xbmc/windowing/windows/WinSystemWin32.h
@@ -98,7 +98,7 @@ public:
   bool HasSystemSdrPeakLuminance() override;
 
   // videosync
-  std::unique_ptr<CVideoSync> GetVideoSync(void *clock) override;
+  std::unique_ptr<CVideoSync> GetVideoSync(CVideoReferenceClock* clock) override;
 
   bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
 


### PR DESCRIPTION
This improves the interface for CVideoSync. There is no reason to use a static method for `UpdateClock` when `CVideoSync` holds a pointer to `CVideoReferenceClock`. We can just call the object method instead.


## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

None, purely for API enhancement.
