### PR TITLE
[GUI][Settings] Add formatting string to date format selection preview in region settings.

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -35,6 +35,16 @@
 #include <algorithm>
 #include <stdexcept>
 
+namespace
+{
+std::string GetDateStringWithFormat(const CDateTime& date, const std::string& format)
+{
+  // Return the formatted date together with the format used.
+  // eg: '1/02/2003 (D/MM/YYYY)'
+  return date.GetAsLocalizedDate(format) + " (" + format + ")";
+}
+} // namespace
+
 using namespace PVR;
 
 static std::string shortDateFormats[] = {
@@ -1288,10 +1298,11 @@ void CLangInfo::SettingOptionsShortDateFormatsFiller(const SettingConstPtr& sett
 
   CDateTime now = CDateTime::GetCurrentDateTime();
 
-  list.emplace_back(
-      StringUtils::Format(g_localizeStrings.Get(20035),
-                          now.GetAsLocalizedDate(g_langInfo.m_currentRegion->m_strDateFormatShort)),
-      SETTING_REGIONAL_DEFAULT);
+  list.emplace_back(StringUtils::Format(g_localizeStrings.Get(20035),
+                                        GetDateStringWithFormat(
+                                            now, g_langInfo.m_currentRegion->m_strDateFormatShort)),
+                    SETTING_REGIONAL_DEFAULT);
+
   if (shortDateFormatSetting == SETTING_REGIONAL_DEFAULT)
   {
     match = true;
@@ -1300,7 +1311,7 @@ void CLangInfo::SettingOptionsShortDateFormatsFiller(const SettingConstPtr& sett
 
   for (const std::string& shortDateFormat : shortDateFormats)
   {
-    list.emplace_back(now.GetAsLocalizedDate(shortDateFormat), shortDateFormat);
+    list.emplace_back(GetDateStringWithFormat(now, shortDateFormat), shortDateFormat);
 
     if (!match && shortDateFormatSetting == shortDateFormat)
     {
@@ -1323,10 +1334,11 @@ void CLangInfo::SettingOptionsLongDateFormatsFiller(const SettingConstPtr& setti
 
   CDateTime now = CDateTime::GetCurrentDateTime();
 
-  list.emplace_back(
-      StringUtils::Format(g_localizeStrings.Get(20035),
-                          now.GetAsLocalizedDate(g_langInfo.m_currentRegion->m_strDateFormatLong)),
-      SETTING_REGIONAL_DEFAULT);
+  list.emplace_back(StringUtils::Format(g_localizeStrings.Get(20035),
+                                        GetDateStringWithFormat(
+                                            now, g_langInfo.m_currentRegion->m_strDateFormatLong)),
+                    SETTING_REGIONAL_DEFAULT);
+
   if (longDateFormatSetting == SETTING_REGIONAL_DEFAULT)
   {
     match = true;
@@ -1335,7 +1347,7 @@ void CLangInfo::SettingOptionsLongDateFormatsFiller(const SettingConstPtr& setti
 
   for (const std::string& longDateFormat : longDateFormats)
   {
-    list.emplace_back(now.GetAsLocalizedDate(longDateFormat), longDateFormat);
+    list.emplace_back(GetDateStringWithFormat(now, longDateFormat), longDateFormat);
 
     if (!match && longDateFormatSetting == longDateFormat)
     {


### PR DESCRIPTION
## Description

Append the formatting codes to the regional settings date previews.

For example: '13.3.2023 (DD.M.YYYY)'

## Motivation and context

On days or in months with 2 digits, the date preview in the Regional settings is ambiguous.

https://github.com/xbmc/xbmc/issues/23046

## How has this been tested?

Entered Settings|Interface|Regional, selected various formats and then view the output in areas like video information, etc.  No changes observed, changes appear to be restricted to the settings screen only.

## What is the effect on users?

On days or in months with 2 digits, users will now be able to tell the difference between certain date formats.  For example: 'DD/MM/YYYY' and 'D/MM/YYYY'.

This also brings the date format selection preview format into line with the existing time format selection preview.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/127641886/232187677-1372fdc4-b755-450b-85f2-f0a23c26c73e.png)


## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed