### PR TITLE
[xbmc][PlayerController] Added new shortcut to download subtitles

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -371,6 +371,7 @@
       <zoom>AspectRatio</zoom>
       <t>ShowSubtitles</t>
       <t mod="ctrl">SubtitleAlign</t>
+      <t mod="alt">DownloadSubtitles</t>
       <l>DialogSelectSubtitle</l>
       <left>StepBack</left>
       <right>StepForward</right>

--- a/xbmc/input/actions/ActionIDs.h
+++ b/xbmc/input/actions/ActionIDs.h
@@ -442,6 +442,9 @@ constexpr const int ACTION_VIDEO_NEXT_STREAM = 250;
 //! Used to queue an item to the next position in the playlist
 constexpr const int ACTION_QUEUE_ITEM_NEXT = 251;
 
+//! Used to open the Download Subtitles dialog
+constexpr const int ACTION_DOWNLOAD_SUBTITLES = 252;
+
 constexpr const int ACTION_HDR_TOGGLE = 260; //!< Toggle display HDR on/off
 
 constexpr const int ACTION_CYCLE_TONEMAP_METHOD = 261; //!< Switch to next tonemap method

--- a/xbmc/input/actions/ActionTranslator.cpp
+++ b/xbmc/input/actions/ActionTranslator.cpp
@@ -52,6 +52,7 @@ static const std::map<ActionName, ActionID> ActionMappings = {
     {"chapterorbigstepback", ACTION_CHAPTER_OR_BIG_STEP_BACK},
     {"osd", ACTION_SHOW_OSD},
     {"showsubtitles", ACTION_SHOW_SUBTITLES},
+    {"downloadsubtitles", ACTION_DOWNLOAD_SUBTITLES},
     {"nextsubtitle", ACTION_NEXT_SUBTITLE},
     {"previoussubtitle", ACTION_PREV_SUBTITLE},
     {"browsesubtitle", ACTION_BROWSE_SUBTITLE},

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -15,6 +15,7 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "dialogs/GUIDialogSlider.h"
+#include "dialogs/GUIDialogSubtitles.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUISliderControl.h"
 #include "guilib/GUIWindowManager.h"
@@ -93,6 +94,22 @@ bool CPlayerController::OnAction(const CAction &action)
           sub = g_localizeStrings.Get(1223);
         CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info,
                                               g_localizeStrings.Get(287), sub, DisplTime, false, MsgTime);
+        return true;
+      }
+
+      case ACTION_DOWNLOAD_SUBTITLES:
+      {
+        auto* guiComponent = CServiceBroker::GetGUI();
+
+        if (guiComponent != nullptr)
+        {
+          auto& windowManager = guiComponent->GetWindowManager();
+          CGUIDialogSubtitles *dialog = windowManager.GetWindow<CGUIDialogSubtitles>(WINDOW_DIALOG_SUBTITLES);
+
+          if (dialog != nullptr)
+            dialog->Open();
+        }
+
         return true;
       }
 


### PR DESCRIPTION
## Description
Added a new keyboard shortcut to download subtitles
This PR is adding a new keyboard shortcut (ALT+T) to open the download subtitles dialog. Re issuing this PR to target Master branch.

## Motivation and context
To download subtitles one had to use the cursor, to open the subtitles dialog, and select Download subtitles, all the whole the video did not pause. This PR is adding a new keyboard shortcut (ALT+T) to open the download subtitles dialog directly, while pausing the playing video.

## How has this been tested?
The change is highly focused on a single class (PlayerController), addtions of code only (no modifications!).
Tested on Windows 10, both positive and negative tests - new shortcut is working, old shortcuts still works as well.
Because of the narrow focus of the change, no implications observed to other areas of the code.

## What is the effect on users?
A new keyboard shortcut (ALT+T) can now open the download subtitles dialog directly, instead of having to manually open the subtitles dialog first (by keyboard), and then manually selecting the Download subtitles entry.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
