### PR TITLE
[macos][nativewindowing] Fix crashes with liveresize

### DIFF
--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -264,7 +264,7 @@ void CWinSystemBase::DriveRenderLoop()
   }
 }
 
-CGraphicContext& CWinSystemBase::GetGfxContext()
+CGraphicContext& CWinSystemBase::GetGfxContext() const
 {
   return *m_gfxContext;
 }

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -168,7 +168,7 @@ public:
   virtual bool MessagePump() { return false; }
 
   // Access render system interface
-  CGraphicContext& GetGfxContext() const;
+  virtual CGraphicContext& GetGfxContext() const;
 
   /**
    * Get OS specific hardware context

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -168,7 +168,7 @@ public:
   virtual bool MessagePump() { return false; }
 
   // Access render system interface
-  CGraphicContext& GetGfxContext();
+  CGraphicContext& GetGfxContext() const;
 
   /**
    * Get OS specific hardware context

--- a/xbmc/windowing/osx/OpenGL/OSXGLView.h
+++ b/xbmc/windowing/osx/OpenGL/OSXGLView.h
@@ -15,7 +15,19 @@
 - (id)initWithFrame:(NSRect)frameRect;
 - (CGLContextObj)getGLContextObj;
 
+/**
+ * @brief Application renders out of the NSOpenGLView drawRect (on a different thread). Hence the current
+ *  NSOpenGLContext needs to be make current so that the view on the context is valid for rendering.
+ *  This should be done whenever gl calls are about to be done.
+ */
+- (void)NotifyContext;
+/**
+ * @brief Update the current OpenGL context (view is set before updating)
+ */
 - (void)Update;
+/**
+ * @brief Copies the back buffer to the front buffer of the OpenGL context.
+ */
 - (void)FlushBuffer;
 
 @end

--- a/xbmc/windowing/osx/OpenGL/OSXGLView.h
+++ b/xbmc/windowing/osx/OpenGL/OSXGLView.h
@@ -13,6 +13,9 @@
 @interface OSXGLView : NSOpenGLView
 
 - (id)initWithFrame:(NSRect)frameRect;
-- (NSOpenGLContext*)getGLContext;
+- (CGLContextObj)getGLContextObj;
+
+- (void)Update;
+- (void)FlushBuffer;
 
 @end

--- a/xbmc/windowing/osx/OpenGL/OSXGLView.mm
+++ b/xbmc/windowing/osx/OpenGL/OSXGLView.mm
@@ -179,8 +179,29 @@
     winSystem->signalMouseExited();
 }
 
-- (NSOpenGLContext*)getGLContext
+- (CGLContextObj)getGLContextObj
 {
-  return m_glcontext;
+  if (!m_glcontext)
+    return nil;
+
+  return [m_glcontext CGLContextObj];
+}
+
+- (void)Update
+{
+  if (!m_glcontext)
+    return;
+
+  // sets current glContext frame (required if we render out of view drawRect)
+  [m_glcontext makeCurrentContext];
+  [m_glcontext update];
+}
+
+- (void)FlushBuffer
+{
+  if (!m_glcontext)
+    return;
+
+  [m_glcontext flushBuffer];
 }
 @end

--- a/xbmc/windowing/osx/OpenGL/OSXGLView.mm
+++ b/xbmc/windowing/osx/OpenGL/OSXGLView.mm
@@ -181,27 +181,28 @@
 
 - (CGLContextObj)getGLContextObj
 {
-  if (!m_glcontext)
-    return nil;
-
+  assert(m_glcontext);
   return [m_glcontext CGLContextObj];
 }
 
 - (void)Update
 {
-  if (!m_glcontext)
-    return;
-
-  // sets current glContext frame (required if we render out of view drawRect)
-  [m_glcontext makeCurrentContext];
+  assert(m_glcontext);
+  [self NotifyContext];
   [m_glcontext update];
+}
+
+- (void)NotifyContext
+{
+  assert(m_glcontext);
+  // signals/notifies the context that this view is current (required if we render out of DrawRect)
+  [m_glcontext makeCurrentContext];
 }
 
 - (void)FlushBuffer
 {
-  if (!m_glcontext)
-    return;
-
+  assert(m_glcontext);
+  [m_glcontext makeCurrentContext];
   [m_glcontext flushBuffer];
 }
 @end

--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -57,6 +57,8 @@ public:
   bool HasCursor() override;
   bool Show(bool raise = true) override;
   void OnMove(int x, int y) override;
+  CGraphicContext& GetGfxContext() const override;
+  bool HasValidResolution() const;
 
   std::string GetClipboardText() override;
 

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -426,8 +426,7 @@ static void DisplayReconfigured(CGDirectDisplayID display,
   if (flags & kCGDisplayBeginConfigurationFlag)
   {
     // pre/post-reconfiguration changes
-    RESOLUTION res = CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution();
-    if (res == RES_INVALID)
+    if (!winsys->HasValidResolution())
       return;
 
     NSScreen* pScreen = nil;
@@ -536,7 +535,7 @@ void CWinSystemOSX::AnnounceOnResetDevice()
   // doing the callbacks
   GetScreenResolution(&w, &h, &currentFps, currentScreenIdx);
 
-  CServiceBroker::GetWinSystem()->GetGfxContext().SetFPS(currentFps);
+  m_gfxContext->SetFPS(currentFps);
 
   std::unique_lock<CCriticalSection> lock(m_resourceSection);
   // tell any shared resources
@@ -961,6 +960,11 @@ void CWinSystemOSX::GetScreenResolution(size_t* w, size_t* h, double* fps, unsig
   }
 }
 
+bool CWinSystemOSX::HasValidResolution() const
+{
+  return m_gfxContext->GetVideoResolution() != RES_INVALID;
+}
+
 #pragma mark - Video Modes
 
 bool CWinSystemOSX::SwitchToVideoMode(int width, int height, double refreshrate)
@@ -1073,7 +1077,7 @@ void CWinSystemOSX::FillInVideoModes()
         {
           UpdateDesktopResolution(res, (dispName != nil) ? [dispName UTF8String] : "Unknown",
                                   static_cast<int>(w), static_cast<int>(h), refreshrate, 0);
-          CServiceBroker::GetWinSystem()->GetGfxContext().ResetOverscan(res);
+          m_gfxContext->ResetOverscan(res);
           CDisplaySettings::GetInstance().AddResolutionInfo(res);
         }
       }
@@ -1165,6 +1169,18 @@ CGLContextObj CWinSystemOSX::GetCGLContextObj()
   }
 
   return cglcontex;
+}
+
+CGraphicContext& CWinSystemOSX::GetGfxContext() const
+{
+  if (m_glView)
+  {
+    dispatch_sync(dispatch_get_main_queue(), ^{
+      [m_glView NotifyContext];
+    });
+  }
+
+  return CWinSystemBase::GetGfxContext();
 }
 
 bool CWinSystemOSX::FlushBuffer()

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -622,8 +622,7 @@ bool CWinSystemOSX::CreateNewWindow(const std::string& name, bool fullScreen, RE
     m_glView = m_appWindow.contentView;
   });
 
-  [m_glView.getGLContext makeCurrentContext];
-  [m_glView.getGLContext update];
+  [m_glView Update];
 
   NSScreen* currentScreen = [NSScreen mainScreen];
   dispatch_sync(dispatch_get_main_queue(), ^{
@@ -806,7 +805,7 @@ bool CWinSystemOSX::ResizeWindow(int newWidth, int newHeight, int newLeft, int n
   if (view)
   {
     dispatch_sync(dispatch_get_main_queue(), ^{
-      [[view getGLContext] update];
+      [view Update];
     });
   }
 
@@ -1161,8 +1160,7 @@ CGLContextObj CWinSystemOSX::GetCGLContextObj()
   if (m_appWindow)
   {
     dispatch_sync(dispatch_get_main_queue(), ^{
-      OSXGLView* contentView = m_appWindow.contentView;
-      cglcontex = contentView.getGLContext.CGLContextObj;
+      cglcontex = [(OSXGLView*)m_appWindow.contentView getGLContextObj];
     });
   }
 
@@ -1174,9 +1172,7 @@ bool CWinSystemOSX::FlushBuffer()
   if (m_appWindow)
   {
     dispatch_sync(dispatch_get_main_queue(), ^{
-      OSXGLView* contentView = m_appWindow.contentView;
-      NSOpenGLContext* glcontex = contentView.getGLContext;
-      [glcontex flushBuffer];
+      [m_appWindow.contentView FlushBuffer];
     });
   }
 


### PR DESCRIPTION
## Description
Kodi renders on the main thread, **out of NSOpenGLView DrawRect**. Whenever applications render outside of DrawRect, the current view must be set to avoid it being nil when rendering. This used to work fine because we were using the deprecated function `setView` (removed in https://github.com/xbmc/xbmc/pull/23045/files).
To adhere to the new implementation and avoid the deprecated call, we need to call `[m_glcontext makeCurrentContext];` whenever we want to execute opengl calls - (will set the view member internally in the gl context object) otherwise the view might be null as a result of a window resize operation (which inherently calls drawRect).