### PR TITLE
ViderPlayerAudio: fix setting of resample mode on stream change

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -526,6 +526,8 @@ bool CVideoPlayerAudio::ProcessDecoderOutput(DVDAudioFrame &audioframe)
       if (!m_audioSink.Create(audioframe, m_streaminfo.codec, m_synctype == SYNC_RESAMPLE))
         CLog::Log(LOGERROR, "{} - failed to create audio renderer", __FUNCTION__);
 
+      m_prevsynctype = -1;
+
       if (m_syncState == IDVDStreamPlayer::SYNC_INSYNC)
         m_audioSink.Resume();
     }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Race: CAudioSinkAE::SetResampleMode() may be called before CAudioSinkAE::Create() and the mode set is lost.

That is no issue if m_synctype == SYNC_DISCON in CVideoPlayerAudio::SetSyncType() because it defaults to 0 but m_synctype == SYNC_RESAMPLE is lost.

~~This PR is saving the mode in CAudioSinkAE::SetResampleMode() and apply it at end of CAudioSinkAE::Create(). Using mode 0 by default seem not to cause any restriction.~~

This PR is invalidating the previous sync type after new Sink was created. Sync type will be set again.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While watching live TV I've noticed audio distortion from time to time. In PlayerDebug the rr value stuck to 1.000000.

The distortion occur when the audio stream change from 2.0 to DD 5.1. Finally the issue could be reproduced without live TV using a recording with setting "Sync playback to display" enabled.

Debug log: [kodi.omega.dd.race.log](https://github.com/xbmc/xbmc/files/11240247/kodi.omega.dd.race.log)

In the log the audio stream of the recording is created three times: 

```
# 1. Opened:
2023-04-15 12:00:14.768 T:10022    info <general>: Creating audio stream (codec id: 86016, channels: 2, sample rate: 48000, no pass-through)
2023-04-15 12:00:14.768 T:10022   debug <general>: CVideoPlayerAudio:: synctype set to 1: resample

# 2. Seek before stream change:
2023-04-15 12:00:14.768 T:10022    info <general>: Creating audio stream (codec id: 86016, channels: 2, sample rate: 48000, no pass-through)
2023-04-15 12:00:14.768 T:10022   debug <general>: CVideoPlayerAudio:: synctype set to 1: resample

# 3. Change from DD 2.0 to DD 5.1:
2023-04-15 12:00:21.487 T:10022   debug <general>: CVideoPlayerAudio:: synctype set to 1: resample
2023-04-15 12:00:22.063 T:10022    info <general>: Creating audio stream (codec id: 86019, channels: 6, sample rate: 48000, no pass-through)
```
The third time the order of calls is reversed.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Some weeks on my LibreELEC installation in the living room.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Less audio issues.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
