### PR TITLE
[Android] Avoid crash when create recommendation channels and schedul…

### DIFF
--- a/tools/android/packaging/xbmc/src/channels/util/TvUtil.java.in
+++ b/tools/android/packaging/xbmc/src/channels/util/TvUtil.java.in
@@ -209,7 +209,12 @@ public class TvUtil
     builder.setMinimumLatency(10000);
 
     Log.d(TAG, "TvUtil: Scheduled channel creation.");
-    scheduler.schedule(builder.build());
+
+    try {
+      scheduler.schedule(builder.build());
+    } catch (IllegalStateException e) {
+      Log.w(TAG, "TvUtil: scheduleSyncingChannel - Exception: " + e.getMessage());
+    }
   }
 
   /**
@@ -241,7 +246,12 @@ public class TvUtil
     builder.setExtras(bundle);
 
     scheduler.cancel(getTriggeredJobIdForChannelId(channelId));
-    scheduler.schedule(builder.build());
+
+    try {
+      scheduler.schedule(builder.build());
+    } catch (IllegalStateException e) {
+      Log.w(TAG, "TvUtil: scheduleTriggeredSyncingProgramsForChannel - Exception: " + e.getMessage());
+    }
   }
 
   /**
@@ -271,7 +281,11 @@ public class TvUtil
     JobInfo job = builder.build();
     Log.d(TAG, "TvUtil: scheduleTimedSyncingProgramsForChannel: minperiod=" + job.getMinPeriodMillis());
 
-    scheduler.schedule(job);
+    try {
+      scheduler.schedule(job);
+    } catch (IllegalStateException e) {
+      Log.w(TAG, "TvUtil: scheduleTimedSyncingProgramsForChannel - Exception: " + e.getMessage());
+    }
   }
 
   public static int getTriggeredJobIdForChannelId(long channelId)


### PR DESCRIPTION
…e more than 100 jobs

## Description
Related issue #20680

Exception:
```
java.lang.IllegalStateException: Apps may not schedule more than 100 distinct jobs
```
This can be fixed by catching the exception that is thrown when scheduling a job, thus avoid the crash.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
