### PR TITLE
[guilib] Enable proper disabled appearance for Slider / Settings Slider controls + Estuary/Estouchy update

### DIFF
--- a/addons/skin.estouchy/xml/Defaults.xml
+++ b/addons/skin.estouchy/xml/Defaults.xml
@@ -113,8 +113,10 @@
 		<controloffsetx>75</controloffsetx>
 		<controloffsety>0</controloffsety>
 		<texturesliderbar>slider.png</texturesliderbar>
+		<texturesliderbardisabled colordiffuse="grey2">slider.png</texturesliderbardisabled>
 		<textureslidernib>slider_nofocus.png</textureslidernib>
 		<textureslidernibfocus>slider_focus.png</textureslidernibfocus>
+		<textureslidernibdisabled colordiffuse="grey2">slider_nofocus.png"</textureslidernibdisabled>
 		<orientation>horizontal</orientation>
 	</default>
 	<default type="sliderex">
@@ -126,8 +128,10 @@
 		<sliderwidth>350</sliderwidth>
 		<sliderheight>40</sliderheight>
 		<texturesliderbar>slider.png</texturesliderbar>
+		<texturesliderbardisabled colordiffuse="grey2">slider.png</texturesliderbardisabled>
 		<textureslidernib>slider_nofocus.png</textureslidernib>
 		<textureslidernibfocus>slider_focus.png</textureslidernibfocus>
+		<textureslidernibdisabled colordiffuse="grey2">slider_nofocus.png"</textureslidernibdisabled>
 		<font>font16</font>
 		<textcolor>white</textcolor>
 		<disabledcolor>grey2</disabledcolor>

--- a/addons/skin.estuary/xml/Defaults.xml
+++ b/addons/skin.estuary/xml/Defaults.xml
@@ -143,8 +143,10 @@
 	</default>
 	<default type="slider">
 		<texturesliderbar border="10">buttons/slider-back.png</texturesliderbar>
+		<texturesliderbardisabled colordiffuse="disabled">buttons/slider-back.png</texturesliderbardisabled>
 		<textureslidernib>buttons/slider-nib.png</textureslidernib>
 		<textureslidernibfocus colordiffuse="button_focus">buttons/slider-nib.png</textureslidernibfocus>
+		<textureslidernibdisabled colordiffuse="disabled">buttons/slider-nib.png</textureslidernibdisabled>
 		<orientation>horizontal</orientation>
 	</default>
 	<default type="sliderex">
@@ -155,8 +157,10 @@
 		<sliderwidth>150</sliderwidth>
 		<sliderheight>28</sliderheight>
 		<texturesliderbar>buttons/slider-back.png</texturesliderbar>
+		<texturesliderbardisabled colordiffuse="disabled">buttons/slider-back.png</texturesliderbardisabled>
 		<textureslidernib>buttons/slider-nib.png</textureslidernib>
 		<textureslidernibfocus colordiffuse="button_focus">buttons/slider-nib.png</textureslidernibfocus>
+		<textureslidernibdisabled colordiffuse="disabled">buttons/slider-nib.png</textureslidernibdisabled>
 		<font>font13</font>
 		<textcolor>white</textcolor>
 		<disabledcolor>disabled</disabledcolor>

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -749,7 +749,8 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   bool bReverse = true;
   bool bReveal = false;
   CTextureInfo textureBackground, textureLeft, textureRight, textureMid, textureOverlay;
-  CTextureInfo textureNib, textureNibFocus, textureBar, textureBarFocus;
+  CTextureInfo textureNib, textureNibFocus, textureNibDisabled, textureBar, textureBarFocus,
+      textureBarDisabled;
   CTextureInfo textureUp, textureDown;
   CTextureInfo textureUpFocus, textureDownFocus;
   CTextureInfo textureUpDisabled, textureDownDisabled;
@@ -974,8 +975,12 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   GetTexture(pControlNode, "texturesliderbackground", textureBackground);
   GetTexture(pControlNode, "texturesliderbar", textureBar);
   GetTexture(pControlNode, "texturesliderbarfocus", textureBarFocus);
+  if (!GetTexture(pControlNode, "texturesliderbardisabled", textureBarDisabled))
+    GetTexture(pControlNode, "texturesliderbar", textureBarDisabled); // backward compatibility
   GetTexture(pControlNode, "textureslidernib", textureNib);
   GetTexture(pControlNode, "textureslidernibfocus", textureNibFocus);
+  if (!GetTexture(pControlNode, "textureslidernibdisabled", textureNibDisabled))
+    GetTexture(pControlNode, "textureslidernib", textureNibDisabled); // backward compatibility
 
   GetTexture(pControlNode, "texturecolormask", textureColorMask);
   GetTexture(pControlNode, "texturecolordisabledmask", textureColorDisabledMask);
@@ -1350,8 +1355,8 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   case CGUIControl::GUICONTROL_SLIDER:
     {
       control = new CGUISliderControl(
-        parentID, id, posX, posY, width, height,
-        textureBar, textureNib, textureNibFocus, SLIDER_CONTROL_TYPE_PERCENTAGE, orientation);
+          parentID, id, posX, posY, width, height, textureBar, textureBarDisabled, textureNib,
+          textureNibFocus, textureNibDisabled, SLIDER_CONTROL_TYPE_PERCENTAGE, orientation);
 
       static_cast<CGUISliderControl*>(control)->SetInfo(singleInfo);
       static_cast<CGUISliderControl*>(control)->SetAction(action);
@@ -1360,8 +1365,9 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   case CGUIControl::GUICONTROL_SETTINGS_SLIDER:
     {
       control = new CGUISettingsSliderControl(
-        parentID, id, posX, posY, width, height, sliderWidth, sliderHeight, textureFocus, textureNoFocus,
-        textureBar, textureNib, textureNibFocus, labelInfo, SLIDER_CONTROL_TYPE_PERCENTAGE);
+          parentID, id, posX, posY, width, height, sliderWidth, sliderHeight, textureFocus,
+          textureNoFocus, textureBar, textureBarDisabled, textureNib, textureNibFocus,
+          textureNibDisabled, labelInfo, SLIDER_CONTROL_TYPE_PERCENTAGE);
 
       static_cast<CGUISettingsSliderControl*>(control)->SetText(strLabel);
       static_cast<CGUISettingsSliderControl*>(control)->SetInfo(singleInfo);

--- a/xbmc/guilib/GUISettingsSliderControl.cpp
+++ b/xbmc/guilib/GUISettingsSliderControl.cpp
@@ -10,10 +10,39 @@
 
 #include "input/Key.h"
 
-CGUISettingsSliderControl::CGUISettingsSliderControl(int parentID, int controlID, float posX, float posY, float width, float height, float sliderWidth, float sliderHeight, const CTextureInfo &textureFocus, const CTextureInfo &textureNoFocus, const CTextureInfo& backGroundTexture, const CTextureInfo& nibTexture, const CTextureInfo& nibTextureFocus, const CLabelInfo &labelInfo, int iType)
-    : CGUISliderControl(parentID, controlID, posX, posY, sliderWidth, sliderHeight, backGroundTexture, nibTexture,nibTextureFocus, iType, HORIZONTAL)
-    , m_buttonControl(parentID, controlID, posX, posY, width, height, textureFocus, textureNoFocus, labelInfo)
-    , m_label(posX, posY, width, height, labelInfo)
+CGUISettingsSliderControl::CGUISettingsSliderControl(int parentID,
+                                                     int controlID,
+                                                     float posX,
+                                                     float posY,
+                                                     float width,
+                                                     float height,
+                                                     float sliderWidth,
+                                                     float sliderHeight,
+                                                     const CTextureInfo& textureFocus,
+                                                     const CTextureInfo& textureNoFocus,
+                                                     const CTextureInfo& backGroundTexture,
+                                                     const CTextureInfo& backGroundTextureDisabled,
+                                                     const CTextureInfo& nibTexture,
+                                                     const CTextureInfo& nibTextureFocus,
+                                                     const CTextureInfo& nibTextureDisabled,
+                                                     const CLabelInfo& labelInfo,
+                                                     int iType)
+  : CGUISliderControl(parentID,
+                      controlID,
+                      posX,
+                      posY,
+                      sliderWidth,
+                      sliderHeight,
+                      backGroundTexture,
+                      backGroundTextureDisabled,
+                      nibTexture,
+                      nibTextureFocus,
+                      nibTextureDisabled,
+                      iType,
+                      HORIZONTAL),
+    m_buttonControl(
+        parentID, controlID, posX, posY, width, height, textureFocus, textureNoFocus, labelInfo),
+    m_label(posX, posY, width, height, labelInfo)
 {
   m_label.SetAlign((labelInfo.align & XBFONT_CENTER_Y) | XBFONT_RIGHT);
   ControlType = GUICONTROL_SETTINGS_SLIDER;

--- a/xbmc/guilib/GUISettingsSliderControl.h
+++ b/xbmc/guilib/GUISettingsSliderControl.h
@@ -24,7 +24,23 @@ class CGUISettingsSliderControl :
       public CGUISliderControl
 {
 public:
-  CGUISettingsSliderControl(int parentID, int controlID, float posX, float posY, float width, float height, float sliderWidth, float sliderHeight, const CTextureInfo &textureFocus, const CTextureInfo &textureNoFocus, const CTextureInfo& backGroundTexture, const CTextureInfo& nibTexture, const CTextureInfo& nibTextureFocus, const CLabelInfo &labelInfo, int iType);
+  CGUISettingsSliderControl(int parentID,
+                            int controlID,
+                            float posX,
+                            float posY,
+                            float width,
+                            float height,
+                            float sliderWidth,
+                            float sliderHeight,
+                            const CTextureInfo& textureFocus,
+                            const CTextureInfo& textureNoFocus,
+                            const CTextureInfo& backGroundTexture,
+                            const CTextureInfo& backGroundTextureDisabled,
+                            const CTextureInfo& nibTexture,
+                            const CTextureInfo& nibTextureFocus,
+                            const CTextureInfo& nibTextureDisabled,
+                            const CLabelInfo& labelInfo,
+                            int iType);
   ~CGUISettingsSliderControl() override = default;
   CGUISettingsSliderControl *Clone() const override { return new CGUISettingsSliderControl(*this); }
 

--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -30,16 +30,24 @@ CGUISliderControl::CGUISliderControl(int parentID,
                                      float width,
                                      float height,
                                      const CTextureInfo& backGroundTexture,
+                                     const CTextureInfo& backGroundTextureDisabled,
                                      const CTextureInfo& nibTexture,
                                      const CTextureInfo& nibTextureFocus,
+                                     const CTextureInfo& nibTextureDisabled,
                                      int iType,
                                      ORIENTATION orientation)
   : CGUIControl(parentID, controlID, posX, posY, width, height),
     m_guiBackground(CGUITexture::CreateTexture(posX, posY, width, height, backGroundTexture)),
+    m_guiBackgroundDisabled(
+        CGUITexture::CreateTexture(posX, posY, width, height, backGroundTextureDisabled)),
     m_guiSelectorLower(CGUITexture::CreateTexture(posX, posY, width, height, nibTexture)),
     m_guiSelectorUpper(CGUITexture::CreateTexture(posX, posY, width, height, nibTexture)),
     m_guiSelectorLowerFocus(CGUITexture::CreateTexture(posX, posY, width, height, nibTextureFocus)),
-    m_guiSelectorUpperFocus(CGUITexture::CreateTexture(posX, posY, width, height, nibTextureFocus))
+    m_guiSelectorUpperFocus(CGUITexture::CreateTexture(posX, posY, width, height, nibTextureFocus)),
+    m_guiSelectorLowerDisabled(
+        CGUITexture::CreateTexture(posX, posY, width, height, nibTextureDisabled)),
+    m_guiSelectorUpperDisabled(
+        CGUITexture::CreateTexture(posX, posY, width, height, nibTextureDisabled))
 {
   m_iType = iType;
   m_rangeSelection = false;
@@ -66,10 +74,13 @@ CGUISliderControl::CGUISliderControl(int parentID,
 CGUISliderControl::CGUISliderControl(const CGUISliderControl& control)
   : CGUIControl(control),
     m_guiBackground(control.m_guiBackground->Clone()),
+    m_guiBackgroundDisabled(control.m_guiBackgroundDisabled->Clone()),
     m_guiSelectorLower(control.m_guiSelectorLower->Clone()),
     m_guiSelectorUpper(control.m_guiSelectorUpper->Clone()),
     m_guiSelectorLowerFocus(control.m_guiSelectorLowerFocus->Clone()),
     m_guiSelectorUpperFocus(control.m_guiSelectorUpperFocus->Clone()),
+    m_guiSelectorLowerDisabled(control.m_guiSelectorLowerDisabled->Clone()),
+    m_guiSelectorUpperDisabled(control.m_guiSelectorUpperDisabled->Clone()),
     m_iType(control.m_iType),
     m_rangeSelection(control.m_rangeSelection),
     m_currentSelector(control.m_currentSelector),
@@ -93,8 +104,10 @@ CGUISliderControl::CGUISliderControl(const CGUISliderControl& control)
 void CGUISliderControl::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
   bool dirty = false;
+  CGUITexture* guiBackground =
+      !IsDisabled() ? m_guiBackground.get() : m_guiBackgroundDisabled.get();
 
-  dirty |= m_guiBackground->SetPosition(m_posX, m_posY);
+  dirty |= guiBackground->SetPosition(m_posX, m_posY);
   int infoCode = m_iInfoCode;
   if (m_action && (!m_dragging || m_action->fireOnDrag))
     infoCode = m_action->infoCode;
@@ -105,35 +118,41 @@ void CGUISliderControl::Process(unsigned int currentTime, CDirtyRegionList &dirt
       SetIntValue(val);
   }
 
-  dirty |= m_guiBackground->SetHeight(m_height);
-  dirty |= m_guiBackground->SetWidth(m_width);
-  dirty |= m_guiBackground->Process(currentTime);
+  dirty |= guiBackground->SetHeight(m_height);
+  dirty |= guiBackground->SetWidth(m_width);
+  dirty |= guiBackground->Process(currentTime);
 
-  CGUITexture* nibLower =
-      (IsActive() && m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorLower)
-          ? m_guiSelectorLowerFocus.get()
-          : m_guiSelectorLower.get();
+  CGUITexture* nibLower = nullptr;
+  if (IsActive() && m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorLower)
+    nibLower = m_guiSelectorLowerFocus.get();
+  else if (!IsDisabled())
+    nibLower = m_guiSelectorLower.get();
+  else
+    nibLower = m_guiSelectorLowerDisabled.get();
 
   float fScale = 1.0f;
 
-  if (m_orientation == HORIZONTAL && m_guiBackground->GetTextureHeight() != 0)
-    fScale = m_height / m_guiBackground->GetTextureHeight();
+  if (m_orientation == HORIZONTAL && guiBackground->GetTextureHeight() != 0)
+    fScale = m_height / guiBackground->GetTextureHeight();
   else if (m_width != 0 && nibLower->GetTextureWidth() != 0)
     fScale = m_width / nibLower->GetTextureWidth();
-  dirty |= ProcessSelector(nibLower, currentTime, fScale, RangeSelectorLower);
+  dirty |= ProcessSelector(guiBackground, nibLower, currentTime, fScale, RangeSelectorLower);
   if (m_rangeSelection)
   {
-    CGUITexture* nibUpper =
-        (IsActive() && m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorUpper)
-            ? m_guiSelectorUpperFocus.get()
-            : m_guiSelectorUpper.get();
+    CGUITexture* nibUpper = nullptr;
+    if (IsActive() && m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorUpper)
+      nibUpper = m_guiSelectorUpperFocus.get();
+    else if (!IsDisabled())
+      nibUpper = m_guiSelectorUpper.get();
+    else
+      nibUpper = m_guiSelectorUpperDisabled.get();
 
-    if (m_orientation == HORIZONTAL && m_guiBackground->GetTextureHeight() != 0)
-      fScale = m_height / m_guiBackground->GetTextureHeight();
+    if (m_orientation == HORIZONTAL && guiBackground->GetTextureHeight() != 0)
+      fScale = m_height / guiBackground->GetTextureHeight();
     else if (m_width != 0 && nibUpper->GetTextureWidth() != 0)
       fScale = m_width / nibUpper->GetTextureWidth();
 
-    dirty |= ProcessSelector(nibUpper, currentTime, fScale, RangeSelectorUpper);
+    dirty |= ProcessSelector(guiBackground, nibUpper, currentTime, fScale, RangeSelectorUpper);
   }
 
   if (dirty)
@@ -142,7 +161,8 @@ void CGUISliderControl::Process(unsigned int currentTime, CDirtyRegionList &dirt
   CGUIControl::Process(currentTime, dirtyregions);
 }
 
-bool CGUISliderControl::ProcessSelector(CGUITexture* nib,
+bool CGUISliderControl::ProcessSelector(CGUITexture* background,
+                                        CGUITexture* nib,
                                         unsigned int currentTime,
                                         float fScale,
                                         RangeSelector selector)
@@ -174,8 +194,7 @@ bool CGUISliderControl::ProcessSelector(CGUITexture* nib,
       offset = m_width - rect.Width();
     if (offset < 0)
       offset = 0;
-    dirty |=
-        nib->SetPosition(m_guiBackground->GetXPosition() + offset, m_guiBackground->GetYPosition());
+    dirty |= nib->SetPosition(background->GetXPosition() + offset, background->GetYPosition());
   }
   else
   {
@@ -184,10 +203,9 @@ bool CGUISliderControl::ProcessSelector(CGUITexture* nib,
       offset = m_height - rect.Height();
     if (offset < 0)
       offset = 0;
-    dirty |=
-        nib->SetPosition(m_guiBackground->GetXPosition(),
-                         m_guiBackground->GetYPosition() + m_guiBackground->GetHeight() - offset -
-                             ((nib->GetHeight() - rect.Height()) / 2 + rect.Height()));
+    dirty |= nib->SetPosition(background->GetXPosition(),
+                              background->GetYPosition() + background->GetHeight() - offset -
+                                  ((nib->GetHeight() - rect.Height()) / 2 + rect.Height()));
   }
   dirty |= nib->Process(currentTime); // need to process again as the position may have changed
 
@@ -196,18 +214,28 @@ bool CGUISliderControl::ProcessSelector(CGUITexture* nib,
 
 void CGUISliderControl::Render()
 {
-  m_guiBackground->Render();
-  CGUITexture* nibLower =
-      (IsActive() && m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorLower)
-          ? m_guiSelectorLowerFocus.get()
-          : m_guiSelectorLower.get();
+  if (!IsDisabled())
+    m_guiBackground->Render();
+  else
+    m_guiBackgroundDisabled->Render();
+
+  CGUITexture* nibLower = nullptr;
+  if (IsActive() && m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorLower)
+    nibLower = m_guiSelectorLowerFocus.get();
+  else if (!IsDisabled())
+    nibLower = m_guiSelectorLower.get();
+  else
+    nibLower = m_guiSelectorLowerDisabled.get();
   nibLower->Render();
   if (m_rangeSelection)
   {
-    CGUITexture* nibUpper =
-        (IsActive() && m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorUpper)
-            ? m_guiSelectorUpperFocus.get()
-            : m_guiSelectorUpper.get();
+    CGUITexture* nibUpper = nullptr;
+    if (IsActive() && m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorUpper)
+      nibUpper = m_guiSelectorUpperFocus.get();
+    else if (!IsDisabled())
+      nibUpper = m_guiSelectorUpper.get();
+    else
+      nibUpper = m_guiSelectorUpperDisabled.get();
     nibUpper->Render();
   }
   CGUIControl::Render();
@@ -541,40 +569,52 @@ void CGUISliderControl::FreeResources(bool immediately)
 {
   CGUIControl::FreeResources(immediately);
   m_guiBackground->FreeResources(immediately);
+  m_guiBackgroundDisabled->FreeResources(immediately);
   m_guiSelectorLower->FreeResources(immediately);
   m_guiSelectorUpper->FreeResources(immediately);
   m_guiSelectorLowerFocus->FreeResources(immediately);
   m_guiSelectorUpperFocus->FreeResources(immediately);
+  m_guiSelectorLowerDisabled->FreeResources(immediately);
+  m_guiSelectorUpperDisabled->FreeResources(immediately);
 }
 
 void CGUISliderControl::DynamicResourceAlloc(bool bOnOff)
 {
   CGUIControl::DynamicResourceAlloc(bOnOff);
   m_guiBackground->DynamicResourceAlloc(bOnOff);
+  m_guiBackgroundDisabled->DynamicResourceAlloc(bOnOff);
   m_guiSelectorLower->DynamicResourceAlloc(bOnOff);
   m_guiSelectorUpper->DynamicResourceAlloc(bOnOff);
   m_guiSelectorLowerFocus->DynamicResourceAlloc(bOnOff);
   m_guiSelectorUpperFocus->DynamicResourceAlloc(bOnOff);
+  m_guiSelectorLowerDisabled->DynamicResourceAlloc(bOnOff);
+  m_guiSelectorUpperDisabled->DynamicResourceAlloc(bOnOff);
 }
 
 void CGUISliderControl::AllocResources()
 {
   CGUIControl::AllocResources();
   m_guiBackground->AllocResources();
+  m_guiBackgroundDisabled->AllocResources();
   m_guiSelectorLower->AllocResources();
   m_guiSelectorUpper->AllocResources();
   m_guiSelectorLowerFocus->AllocResources();
   m_guiSelectorUpperFocus->AllocResources();
+  m_guiSelectorLowerDisabled->AllocResources();
+  m_guiSelectorUpperDisabled->AllocResources();
 }
 
 void CGUISliderControl::SetInvalid()
 {
   CGUIControl::SetInvalid();
   m_guiBackground->SetInvalid();
+  m_guiBackgroundDisabled->SetInvalid();
   m_guiSelectorLower->SetInvalid();
   m_guiSelectorUpper->SetInvalid();
   m_guiSelectorLowerFocus->SetInvalid();
   m_guiSelectorUpperFocus->SetInvalid();
+  m_guiSelectorLowerDisabled->SetInvalid();
+  m_guiSelectorUpperDisabled->SetInvalid();
 }
 
 bool CGUISliderControl::HitTest(const CPoint &point) const
@@ -742,10 +782,13 @@ bool CGUISliderControl::UpdateColors(const CGUIListItem* item)
 {
   bool changed = CGUIControl::UpdateColors(nullptr);
   changed |= m_guiBackground->SetDiffuseColor(m_diffuseColor);
+  changed |= m_guiBackgroundDisabled->SetDiffuseColor(m_diffuseColor);
   changed |= m_guiSelectorLower->SetDiffuseColor(m_diffuseColor);
   changed |= m_guiSelectorUpper->SetDiffuseColor(m_diffuseColor);
   changed |= m_guiSelectorLowerFocus->SetDiffuseColor(m_diffuseColor);
   changed |= m_guiSelectorUpperFocus->SetDiffuseColor(m_diffuseColor);
+  changed |= m_guiSelectorLowerDisabled->SetDiffuseColor(m_diffuseColor);
+  changed |= m_guiSelectorUpperDisabled->SetDiffuseColor(m_diffuseColor);
 
   return changed;
 }

--- a/xbmc/guilib/GUISliderControl.dox
+++ b/xbmc/guilib/GUISliderControl.dox
@@ -22,8 +22,10 @@ the position, size, and look of the slider control.
       <height>30</height>
       <visible>true</visible>
       <texturesliderbar>mybackgroundtexture.png</texturesliderbar>
+      <texturesliderbardisabled>mydisabledbackgroundtexture.png</texturesliderbardisabled>
       <textureslidernib>mydowntexture.png</textureslidernib>
       <textureslidernibfocus>mydownfocustexture.png</textureslidernibfocus>
+      <textureslidernibdisabled>mydisablednibtexture.png</textureslidernibdisabled>
       <info></info>
       <action></action>
       <controloffsetx></controloffsetx>
@@ -45,16 +47,18 @@ In addition to the [Default Control Tags](http://kodi.wiki/view/Default_Control_
 the following tags are available. Note that each tag is lower case only. This is
 important, as xml tags are case-sensitive.
 
-| Tag                   | Description                                                   |
-|----------------------:|:--------------------------------------------------------------|
-| texturesliderbar      | Specifies the image file which should be displayed in the background of the slider control. [See here for additional information about textures](http://kodi.wiki/view/Texture_Attributes).
-| textureslidernib      | Specifies the image file which should be displayed for the slider nib.
-| textureslidernibfocus | Specifies the image file which should be displayed for the slider nib when it has focus.
-| controloffsetx        | Amount to offset the slider background texture from the left edge of the control. Only useful if a value is being rendered as well (ie in int or float mode).
-| controloffsety        | Amount to offset the slider background texture from the top edge of the control.
-| info                  | Specifies the information that the slider controls. [See here for more information](http://kodi.wiki/view/InfoLabels).
-| orientation           | Specifies whether this scrollbar is horizontal or vertical. Defaults to vertical.
-| action                | Can be <b>`volume`</b> to adjust the volume, <b>`seek`</b> to change the seek position, <b>`pvr.seek`</b> for timeshifting in PVR.
+| Tag                      | Description                                                   |
+|-------------------------:|:--------------------------------------------------------------|
+| texturesliderbar         | Specifies the image file which should be displayed in the background of the slider control. [See here for additional information about textures](http://kodi.wiki/view/Texture_Attributes).
+| texturesliderdisabled    | Specifies the image file which should be displayed in the background of the slider control when it is disabled.
+| textureslidernib         | Specifies the image file which should be displayed for the slider nib.
+| textureslidernibfocus    | Specifies the image file which should be displayed for the slider nib when it has focus.
+| textureslidernibdisabled | Specifies the image file which should be displayed for the slider nib when it is disabled.
+| controloffsetx           | Amount to offset the slider background texture from the left edge of the control. Only useful if a value is being rendered as well (ie in int or float mode).
+| controloffsety           | Amount to offset the slider background texture from the top edge of the control.
+| info                     | Specifies the information that the slider controls. [See here for more information](http://kodi.wiki/view/InfoLabels).
+| orientation              | Specifies whether this scrollbar is horizontal or vertical. Defaults to vertical.
+| action                   | Can be <b>`volume`</b> to adjust the volume, <b>`seek`</b> to change the seek position, <b>`pvr.seek`</b> for timeshifting in PVR.
 
 \section Slider_Control_revhistory Revision History
 

--- a/xbmc/guilib/GUISliderControl.h
+++ b/xbmc/guilib/GUISliderControl.h
@@ -43,7 +43,19 @@ public:
     RangeSelectorUpper = 1
   } RangeSelector;
 
-  CGUISliderControl(int parentID, int controlID, float posX, float posY, float width, float height, const CTextureInfo& backGroundTexture, const CTextureInfo& mibTexture, const CTextureInfo& nibTextureFocus, int iType, ORIENTATION orientation);
+  CGUISliderControl(int parentID,
+                    int controlID,
+                    float posX,
+                    float posY,
+                    float width,
+                    float height,
+                    const CTextureInfo& backGroundTexture,
+                    const CTextureInfo& backGroundTextureDisabled,
+                    const CTextureInfo& mibTexture,
+                    const CTextureInfo& nibTextureFocus,
+                    const CTextureInfo& nibTextureDisabled,
+                    int iType,
+                    ORIENTATION orientationconst);
   ~CGUISliderControl() override = default;
   CGUISliderControl* Clone() const override { return new CGUISliderControl(*this); }
 
@@ -58,7 +70,8 @@ public:
   virtual void SetRange(int iStart, int iEnd);
   virtual void SetFloatRange(float fStart, float fEnd);
   bool OnMessage(CGUIMessage& message) override;
-  bool ProcessSelector(CGUITexture* nib,
+  bool ProcessSelector(CGUITexture* background,
+                       CGUITexture* nib,
                        unsigned int currentTime,
                        float fScale,
                        RangeSelector selector);
@@ -99,10 +112,13 @@ protected:
   void SendClick();
 
   std::unique_ptr<CGUITexture> m_guiBackground;
+  std::unique_ptr<CGUITexture> m_guiBackgroundDisabled;
   std::unique_ptr<CGUITexture> m_guiSelectorLower;
   std::unique_ptr<CGUITexture> m_guiSelectorUpper;
   std::unique_ptr<CGUITexture> m_guiSelectorLowerFocus;
   std::unique_ptr<CGUITexture> m_guiSelectorUpperFocus;
+  std::unique_ptr<CGUITexture> m_guiSelectorLowerDisabled;
+  std::unique_ptr<CGUITexture> m_guiSelectorUpperDisabled;
   int m_iType;
 
   bool m_rangeSelection;

--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -447,10 +447,16 @@ namespace XBMCAddon
 
     // ============================================================
     // ============================================================
-    ControlSlider::ControlSlider(long x, long y, long width, long height,
+    ControlSlider::ControlSlider(long x,
+                                 long y,
+                                 long width,
+                                 long height,
                                  const char* textureback,
                                  const char* texture,
-                                 const char* texturefocus, int orientation)
+                                 const char* texturefocus,
+                                 int orientation,
+                                 const char* texturebackdisabled,
+                                 const char* texturedisabled)
     {
       dwPosX = x;
       dwPosY = y;
@@ -461,10 +467,12 @@ namespace XBMCAddon
       // if texture is supplied use it, else get default ones
       strTextureBack = textureback ? textureback :
         XBMCAddonUtils::getDefaultImage("slider", "texturesliderbar");
+      strTextureBackDisabled = texturebackdisabled ? texturebackdisabled : strTextureBack;
       strTexture = texture ? texture :
         XBMCAddonUtils::getDefaultImage("slider", "textureslidernib");
       strTextureFoc = texturefocus ? texturefocus :
         XBMCAddonUtils::getDefaultImage("slider", "textureslidernibfocus");
+      strTextureDisabled = texturedisabled ? texturedisabled : strTexture;
     }
 
     float ControlSlider::getPercent()
@@ -510,12 +518,13 @@ namespace XBMCAddon
       }
     }
 
-    CGUIControl* ControlSlider::Create ()
+    CGUIControl* ControlSlider::Create()
     {
-      pGUIControl = new CGUISliderControl(iParentId, iControlId,(float)dwPosX, (float)dwPosY,
-                                          (float)dwWidth,(float)dwHeight,
-                                          CTextureInfo(strTextureBack),CTextureInfo(strTexture),
-                                          CTextureInfo(strTextureFoc), 0, ORIENTATION(iOrientation));
+      pGUIControl = new CGUISliderControl(
+          iParentId, iControlId, (float)dwPosX, (float)dwPosY, (float)dwWidth, (float)dwHeight,
+          CTextureInfo(strTextureBack), CTextureInfo(strTextureBackDisabled),
+          CTextureInfo(strTexture), CTextureInfo(strTextureFoc), CTextureInfo(strTextureDisabled),
+          0, ORIENTATION(iOrientation));
 
       return pGUIControl;
     }

--- a/xbmc/interfaces/legacy/Control.h
+++ b/xbmc/interfaces/legacy/Control.h
@@ -2753,7 +2753,7 @@ namespace XBMCAddon
     /// @{
     /// @brief **Used for a volume slider.**
     ///
-    /// \python_class{ ControlSlider(x, y, width, height[, textureback, texture, texturefocus, orientation]) }
+    /// \python_class{ ControlSlider(x, y, width, height[, textureback, texture, texturefocus, orientation, texturebackdisabled, texturedisabled]) }
     ///
     /// The slider control is used for things where a sliding bar best represents
     /// the operation at hand (such as a volume control or seek control). You can
@@ -2769,6 +2769,8 @@ namespace XBMCAddon
     /// @param texture              [opt] string - image filename
     /// @param texturefocus         [opt] string - image filename
     /// @param orientation          [opt] integer - orientation of slider (xbmcgui.HORIZONTAL / xbmcgui.VERTICAL (default))
+    /// @param texturebackdisabled  [opt] string - image filename
+    /// @param texturedisabled      [opt] string - image filename
     ///
     ///
     /// @note You can use the above as keywords for arguments and skip certain
@@ -2791,10 +2793,16 @@ namespace XBMCAddon
     class ControlSlider : public Control
     {
     public:
-      ControlSlider(long x, long y, long width, long height,
+      ControlSlider(long x,
+                    long y,
+                    long width,
+                    long height,
                     const char* textureback = NULL,
                     const char* texture = NULL,
-                    const char* texturefocus = NULL, int orientation = 1);
+                    const char* texturefocus = NULL,
+                    int orientation = 1,
+                    const char* texturebackdisabled = NULL,
+                    const char* texturedisabled = NULL);
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
@@ -2946,8 +2954,10 @@ namespace XBMCAddon
 
 #ifndef SWIG
       std::string strTextureBack;
+      std::string strTextureBackDisabled;
       std::string strTexture;
       std::string strTextureFoc;
+      std::string strTextureDisabled;
       int iOrientation;
 
       CGUIControl* Create() override;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Added the ability for the slider and sliderex controls to render properly in a disabled state

* Defined two new control textures, used when the control is in the disabled state.
  * `texturesliderbardisabled` for the "background" 
  * `textureslidernibdisabled` for the "nib"
  For example, modification of Estuary:
```
<texturesliderbardisabled colordiffuse="disabled">buttons/slider-back.png</texturesliderbardisabled>
<textureslidernibdisabled colordiffuse="disabled">buttons/slider-nib.png</textureslidernibdisabled>
```
* The control falls back to before-PR behavior until a skin is updated with the new textures, so no immediate action needed from the skinners. The control reverts to using `textureslidebar` and `textureslidernib` even in disabled state.

* Existing code patterns were followed in `Process` / `ProcessSelector` / `Render` code of the control, and the plumbing to get the texture information extracted and passed around.
  - I'm unsure about dirty regions handling with multiple textures that appear at the same place, guidance appreciated if needed.

- Modified `xbmc/interfaces/legacy/Control.cpp` but I don't really know what it's for and how it is invoked (seems to have to do with legacy Addon / Python stuff?). Added the two new texture as optional last parameters to preserve compatibility, with same fallback on the previous textures.

* I will add the new tags to the Wiki https://kodi.wiki/view/Skinning_Manual#Slider_Control

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See screenshots.
Noticed in previous PR #22756 that a slider control doesn't show properly in disabled state: a part still seems to be enabled and it looks weird.
Same thing was reported in issue #17992
It's possible ppl held back on using the slider because of that issue and it may be used more after this PR.

Explored alternatives:
* It was suggested to try and workaround this with a diffusecolor, but all it does is make the selector look disabled all the time, it's not possible to add conditions with control state in a texture definition to my knowledge. Even if there is, a skin change would still be needed.

* While adding a "disabled colordiffuse" to the texture would be enough for Estuary / Estouchy, assuming that it's also enough for all other skins seemed too much. Hence the PR's approach that adds a couple textures for complete freedom of the skinner.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows, the HDR group in Settings / System / Display has a case of disabled slider - see the screenshots.
Also tested with "InputStream FFmpeg Direct" addon.
Disabling/enabling, selecting the control to change value work.
Tried the different dirty regions algorithms with visualization, no difference before/after.

I don't know how the interface defined in xbmc/interfaces/legacy/Control.cpp gets invoked so that's untested.


## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Nicer appearance / more consistent skinning of the slider

## Screenshots (if appropriate):
Before, the control looks only partially disabled:
![image](https://user-images.githubusercontent.com/489377/232360258-374603fe-1c09-44cc-8e1a-fb8acd3f71f9.png)

After, the entire control has a proper disabled appearance:
![image](https://user-images.githubusercontent.com/489377/232360029-54e9e49f-939e-48a9-b516-a558eedbb5ac.png)

And the screenshot of issue #17992 looks correct:
![image](https://user-images.githubusercontent.com/489377/232373378-00a1dafa-f3e7-415c-92dc-6aae49a6d106.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
