### PR TITLE
[PVR] Fix last opened group not always restored on Kodi startup.

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -756,6 +756,9 @@ bool CPVRManager::UpdateComponents(ManagerState stateToCheck,
     return false;
   }
 
+  // reinit playbackstate as new client may provide new last opened group / last played channel
+  m_playbackState->ReInit();
+
   PublishEvent(PVREvent::ClientsInvalidated);
   return true;
 }


### PR DESCRIPTION
Fixes #22591. 

Last opened channel group must be re-evaluated whenever a new pvr client comes online, because this client may provide the last opened channel group. Only happens in certain (multi-pvr-client) setups.

Runtime-tested on macOS, latest Kodi master, in a multi-pvr-client environment, where this problem could be reproduced reliably.

@phunkyfish whenever you find some time for a review. Should be straight forward. ;-)