### PR TITLE
[Nexus][PVR] Fix last opened group not always restored on Kodi startup.

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -754,6 +754,9 @@ bool CPVRManager::UpdateComponents(ManagerState stateToCheck,
     return false;
   }
 
+  // reinit playbackstate as new client may provide new last opened group / last played channel
+  m_playbackState->ReInit();
+
   PublishEvent(PVREvent::ClientsInvalidated);
   return true;
 }


### PR DESCRIPTION
Backport of #23164 

@phunkyfish please review.