### PR TITLE
CTextureBundleXBT: return std::optional 

### DIFF
--- a/xbmc/guilib/TextureBundle.cpp
+++ b/xbmc/guilib/TextureBundle.cpp
@@ -44,15 +44,12 @@ std::vector<std::string> CTextureBundle::GetTexturesFromPath(const std::string& 
     return {};
 }
 
-bool CTextureBundle::LoadTexture(const std::string& filename,
-                                 std::unique_ptr<CTexture>& texture,
-                                 int& width,
-                                 int& height)
+std::optional<CTextureBundleXBT::Texture> CTextureBundle::LoadTexture(const std::string& filename)
 {
   if (m_useXBT)
-    return m_tbXBT.LoadTexture(filename, texture, width, height);
+    return m_tbXBT.LoadTexture(filename);
   else
-    return false;
+    return {};
 }
 
 bool CTextureBundle::LoadAnim(const std::string& filename,

--- a/xbmc/guilib/TextureBundle.cpp
+++ b/xbmc/guilib/TextureBundle.cpp
@@ -52,16 +52,12 @@ std::optional<CTextureBundleXBT::Texture> CTextureBundle::LoadTexture(const std:
     return {};
 }
 
-bool CTextureBundle::LoadAnim(const std::string& filename,
-                              std::vector<std::pair<std::unique_ptr<CTexture>, int>>& textures,
-                              int& width,
-                              int& height,
-                              int& nLoops)
+std::optional<CTextureBundleXBT::Animation> CTextureBundle::LoadAnim(const std::string& filename)
 {
   if (m_useXBT)
-    return m_tbXBT.LoadAnim(filename, textures, width, height, nLoops);
+    return m_tbXBT.LoadAnim(filename);
   else
-    return false;
+    return {};
 }
 
 void CTextureBundle::Close()

--- a/xbmc/guilib/TextureBundle.h
+++ b/xbmc/guilib/TextureBundle.h
@@ -33,19 +33,9 @@ public:
    * \brief Load texture from bundle
    *
    * \param[in] filename name of the texture to load
-   * \param[out] texture holds the pointer to the texture after successful loading
-   * \param[out] width width of the loaded texture
-   * \param[out] height height of the loaded texture
-   * \return true if texture was loaded
-   *
-   * \todo With c++17 this should be changed to return a std::optional that's
-   *       wrapping a struct containing the output values. Same for
-   *       CTextureBundleXBT::LoadTexture.
+   * \return std::optional<CTextureBundleXBT::Texture> if texture was loaded
    */
-  bool LoadTexture(const std::string& filename,
-                   std::unique_ptr<CTexture>& texture,
-                   int& width,
-                   int& height);
+  std::optional<CTextureBundleXBT::Texture> LoadTexture(const std::string& filename);
 
   /*!
    * \brief Load animation from bundle

--- a/xbmc/guilib/TextureBundle.h
+++ b/xbmc/guilib/TextureBundle.h
@@ -41,21 +41,10 @@ public:
    * \brief Load animation from bundle
    *
    * \param[in] filename name of the animation to load
-   * \param[out] texture vector of frames. Each frame is pair of a texture and
-   *                     the duration the frame
-   * \param[out] width width of the loaded textures
-   * \param[out] height height of the loaded textures
-   * \return true if animation was loaded
-   *
-   * \todo With c++17 this should be changed to return a std::optional that's
-   *       wrapping a struct containing the output values. Same for
-   *       CTextureBundleXBT::LoadAnim.
+   * \return std::optional<CTextureBundleXBT::Animation> if animation was loaded
    */
-  bool LoadAnim(const std::string& filename,
-                std::vector<std::pair<std::unique_ptr<CTexture>, int>>& textures,
-                int& width,
-                int& height,
-                int& nLoops);
+  std::optional<CTextureBundleXBT::Animation> LoadAnim(const std::string& filename);
+
   void Close();
 private:
   CTextureBundleXBT m_tbXBT;

--- a/xbmc/guilib/TextureBundleXBT.cpp
+++ b/xbmc/guilib/TextureBundleXBT.cpp
@@ -148,31 +148,29 @@ std::vector<std::string> CTextureBundleXBT::GetTexturesFromPath(const std::strin
   return textures;
 }
 
-bool CTextureBundleXBT::LoadTexture(const std::string& filename,
-                                    std::unique_ptr<CTexture>& texture,
-                                    int& width,
-                                    int& height)
+std::optional<CTextureBundleXBT::Texture> CTextureBundleXBT::LoadTexture(
+    const std::string& filename)
 {
   std::string name = Normalize(filename);
 
   CXBTFFile file;
   if (!m_XBTFReader->Get(name, file))
-    return false;
+    return {};
 
   if (file.GetFrames().empty())
-    return false;
+    return {};
 
   const CXBTFFrame& frame = file.GetFrames().at(0);
-  texture = ConvertFrameToTexture(filename, frame);
-  if (!texture)
-  {
-    return false;
-  }
 
-  width = frame.GetWidth();
-  height = frame.GetHeight();
+  Texture texture;
+  texture.width = frame.GetWidth();
+  texture.height = frame.GetHeight();
 
-  return true;
+  texture.texture = ConvertFrameToTexture(filename, frame);
+  if (!texture.texture)
+    return {};
+
+  return std::make_optional<CTextureBundleXBT::Texture>(std::move(texture));
 }
 
 bool CTextureBundleXBT::LoadAnim(const std::string& filename,

--- a/xbmc/guilib/TextureBundleXBT.cpp
+++ b/xbmc/guilib/TextureBundleXBT.cpp
@@ -170,26 +170,24 @@ std::optional<CTextureBundleXBT::Texture> CTextureBundleXBT::LoadTexture(
   if (!texture.texture)
     return {};
 
-  return std::make_optional<CTextureBundleXBT::Texture>(std::move(texture));
+  return std::make_optional<Texture>(std::move(texture));
 }
 
-bool CTextureBundleXBT::LoadAnim(const std::string& filename,
-                                 std::vector<std::pair<std::unique_ptr<CTexture>, int>>& textures,
-                                 int& width,
-                                 int& height,
-                                 int& nLoops)
+std::optional<CTextureBundleXBT::Animation> CTextureBundleXBT::LoadAnim(const std::string& filename)
 {
   std::string name = Normalize(filename);
 
   CXBTFFile file;
   if (!m_XBTFReader->Get(name, file))
-    return false;
+    return {};
 
   if (file.GetFrames().empty())
-    return false;
+    return {};
 
   size_t nTextures = file.GetFrames().size();
-  textures.reserve(nTextures);
+
+  Animation animation;
+  animation.textures.reserve(nTextures);
 
   for (size_t i = 0; i < nTextures; i++)
   {
@@ -197,16 +195,16 @@ bool CTextureBundleXBT::LoadAnim(const std::string& filename,
 
     std::unique_ptr<CTexture> texture = ConvertFrameToTexture(filename, frame);
     if (!texture)
-      return false;
+      return {};
 
-    textures.emplace_back(std::move(texture), frame.GetDuration());
+    animation.textures.emplace_back(std::move(texture), frame.GetDuration());
   }
 
-  width = file.GetFrames().at(0).GetWidth();
-  height = file.GetFrames().at(0).GetHeight();
-  nLoops = file.GetLoop();
+  animation.width = file.GetFrames().at(0).GetWidth();
+  animation.height = file.GetFrames().at(0).GetHeight();
+  animation.loops = file.GetLoop();
 
-  return true;
+  return std::make_optional<Animation>(std::move(animation));
 }
 
 std::unique_ptr<CTexture> CTextureBundleXBT::ConvertFrameToTexture(const std::string& name,

--- a/xbmc/guilib/TextureBundleXBT.h
+++ b/xbmc/guilib/TextureBundleXBT.h
@@ -45,14 +45,18 @@ public:
    */
   std::optional<Texture> LoadTexture(const std::string& filename);
 
+  struct Animation
+  {
+    std::vector<std::pair<std::unique_ptr<CTexture>, int>> textures;
+    int width;
+    int height;
+    int loops;
+  };
+
   /*!
    * \brief See CTextureBundle::LoadAnim
    */
-  bool LoadAnim(const std::string& filename,
-                std::vector<std::pair<std::unique_ptr<CTexture>, int>>& textures,
-                int& width,
-                int& height,
-                int& nLoops);
+  std::optional<Animation> LoadAnim(const std::string& filename);
 
   //! @todo Change return to std::optional<std::vector<uint8_t>>> when c++17 is allowed
   static std::vector<uint8_t> UnpackFrame(const CXBTFReader& reader, const CXBTFFrame& frame);

--- a/xbmc/guilib/TextureBundleXBT.h
+++ b/xbmc/guilib/TextureBundleXBT.h
@@ -8,14 +8,16 @@
 
 #pragma once
 
+#include "Texture.h"
+
 #include <cstdint>
 #include <ctime>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
 
-class CTexture;
 class CXBTFReader;
 class CXBTFFrame;
 
@@ -31,13 +33,17 @@ public:
   std::vector<std::string> GetTexturesFromPath(const std::string& path);
   static std::string Normalize(std::string name);
 
+  struct Texture
+  {
+    std::unique_ptr<CTexture> texture;
+    int width;
+    int height;
+  };
+
   /*!
    * \brief See CTextureBundle::LoadTexture
    */
-  bool LoadTexture(const std::string& filename,
-                   std::unique_ptr<CTexture>& texture,
-                   int& width,
-                   int& height);
+  std::optional<Texture> LoadTexture(const std::string& filename);
 
   /*!
    * \brief See CTextureBundle::LoadAnim

--- a/xbmc/guilib/TextureBundleXBT.h
+++ b/xbmc/guilib/TextureBundleXBT.h
@@ -55,9 +55,7 @@ public:
 
 private:
   bool OpenBundle();
-  bool ConvertFrameToTexture(const std::string& name,
-                             const CXBTFFrame& frame,
-                             std::unique_ptr<CTexture>& texture);
+  std::unique_ptr<CTexture> ConvertFrameToTexture(const std::string& name, const CXBTFFrame& frame);
 
   time_t m_TimeStamp;
 

--- a/xbmc/guilib/TextureManager.cpp
+++ b/xbmc/guilib/TextureManager.cpp
@@ -340,19 +340,22 @@ const CTextureArray& CGUITextureManager::Load(const std::string& strTextureName,
   if (bundle >= 0 && StringUtils::EndsWithNoCase(strPath, ".gif"))
   {
     CTextureMap* pMap = nullptr;
-    std::vector<std::pair<std::unique_ptr<CTexture>, int>> textures;
-    int nLoops = 0, width = 0, height = 0;
-    bool success = m_TexBundle[bundle].LoadAnim(strTextureName, textures, width, height, nLoops);
-    if (!success)
+    std::optional<CTextureBundleXBT::Animation> animation =
+        m_TexBundle[bundle].LoadAnim(strTextureName);
+    if (!animation)
     {
       CLog::Log(LOGERROR, "Texture manager unable to load bundled file: {}", strTextureName);
       return emptyTexture;
     }
 
+    int nLoops = animation.value().loops;
+    int width = animation.value().width;
+    int height = animation.value().height;
+
     unsigned int maxWidth = 0;
     unsigned int maxHeight = 0;
     pMap = new CTextureMap(strTextureName, width, height, nLoops);
-    for (auto& texture : textures)
+    for (auto& texture : animation.value().textures)
     {
       maxWidth = std::max(maxWidth, texture.first->GetWidth());
       maxHeight = std::max(maxHeight, texture.first->GetHeight());

--- a/xbmc/guilib/TextureManager.cpp
+++ b/xbmc/guilib/TextureManager.cpp
@@ -428,11 +428,17 @@ const CTextureArray& CGUITextureManager::Load(const std::string& strTextureName,
   int width = 0, height = 0;
   if (bundle >= 0)
   {
-    if (!m_TexBundle[bundle].LoadTexture(strTextureName, pTexture, width, height))
+    std::optional<CTextureBundleXBT::Texture> texture =
+        m_TexBundle[bundle].LoadTexture(strTextureName);
+    if (!texture)
     {
       CLog::Log(LOGERROR, "Texture manager unable to load bundled file: {}", strTextureName);
       return emptyTexture;
     }
+
+    pTexture = std::move(texture.value().texture);
+    width = texture.value().width;
+    height = texture.value().height;
   }
   else
   {


### PR DESCRIPTION
This updates `CTextureBundleXBT::LoadTexture` and `CTextureBundleXBT::LoadAnim` to return `std::optional`.

This is nice because it removes the out parameters from the methods. It also make it more readable (IMO).

## What is the effect on users?

none, just code updates