### PR TITLE
CDRMObject: return std::optional for GetPropertyValue

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -166,15 +166,15 @@ void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
 
   auto plane = m_DRM->GetVideoPlane();
 
-  bool result;
-  uint64_t value;
-  std::tie(result, value) = plane->GetPropertyValue("COLOR_ENCODING", GetColorEncoding(picture));
-  if (result)
-    m_DRM->AddProperty(plane, "COLOR_ENCODING", value);
+  std::optional<uint64_t> colorEncoding =
+      plane->GetPropertyValue("COLOR_ENCODING", GetColorEncoding(picture));
+  if (colorEncoding)
+    m_DRM->AddProperty(plane, "COLOR_ENCODING", colorEncoding.value());
 
-  std::tie(result, value) = plane->GetPropertyValue("COLOR_RANGE", GetColorRange(picture));
-  if (result)
-    m_DRM->AddProperty(plane, "COLOR_RANGE", value);
+  std::optional<uint64_t> colorRange =
+      plane->GetPropertyValue("COLOR_RANGE", GetColorRange(picture));
+  if (colorRange)
+    m_DRM->AddProperty(plane, "COLOR_RANGE", colorRange.value());
 }
 
 void CVideoLayerBridgeDRMPRIME::SetVideoPlane(CVideoBufferDRMPRIME* buffer, const CRect& destRect)

--- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
@@ -46,13 +46,11 @@ uint32_t GetScalingFactor(uint32_t srcWidth,
 
 bool CDRMAtomic::SetScalingFilter(CDRMObject* object, const char* name, const char* type)
 {
-  bool result;
-  uint64_t value;
-  std::tie(result, value) = m_gui_plane->GetPropertyValue(name, type);
-  if (!result)
+  std::optional<uint64_t> scalingFilter = m_gui_plane->GetPropertyValue(name, type);
+  if (!scalingFilter)
     return false;
 
-  if (!AddProperty(object, name, value))
+  if (!AddProperty(object, name, scalingFilter.value()))
     return false;
 
   uint32_t mar_scale_factor =

--- a/xbmc/windowing/gbm/drm/DRMObject.cpp
+++ b/xbmc/windowing/gbm/drm/DRMObject.cpp
@@ -80,30 +80,29 @@ bool CDRMObject::GetProperties(uint32_t id, uint32_t type)
   return true;
 }
 
-//! @todo: improve with c++17
-std::tuple<bool, uint64_t> CDRMObject::GetPropertyValue(const std::string& name,
-                                                        const std::string& valueName) const
+std::optional<uint64_t> CDRMObject::GetPropertyValue(const std::string& name,
+                                                     const std::string& valueName) const
 {
   auto property = std::find_if(m_propsInfo.begin(), m_propsInfo.end(),
                                [&name](const auto& prop) { return prop->name == name; });
 
   if (property == m_propsInfo.end())
-    return std::make_tuple(false, 0);
+    return {};
 
   auto prop = property->get();
 
   if (!static_cast<bool>(drm_property_type_is(prop, DRM_MODE_PROP_ENUM)))
-    return std::make_tuple(false, 0);
+    return {};
 
   for (int j = 0; j < prop->count_enums; j++)
   {
     if (prop->enums[j].name != valueName)
       continue;
 
-    return std::make_tuple(true, prop->enums[j].value);
+    return std::make_optional<uint64_t>(prop->enums[j].value);
   }
 
-  return std::make_tuple(false, 0);
+  return {};
 }
 
 bool CDRMObject::SetProperty(const std::string& name, uint64_t value)

--- a/xbmc/windowing/gbm/drm/DRMObject.h
+++ b/xbmc/windowing/gbm/drm/DRMObject.h
@@ -11,6 +11,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include <xf86drmMode.h>
@@ -34,8 +35,8 @@ public:
 
   uint32_t GetId() const { return m_id; }
   uint32_t GetPropertyId(const std::string& name) const;
-  std::tuple<bool, uint64_t> GetPropertyValue(const std::string& name,
-                                              const std::string& valueName) const;
+  std::optional<uint64_t> GetPropertyValue(const std::string& name,
+                                           const std::string& valueName) const;
 
   bool SetProperty(const std::string& name, uint64_t value);
   bool SupportsProperty(const std::string& name);


### PR DESCRIPTION
This makes `CDRMObject::GetPropertyValue` return a `std::optional<uint64_t>` instead of `std::tuple<bool, uint64>`.

This makes it more readable (IMO).

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

none
