### PR TITLE
CDVDDemuxFFmpeg: when adding video streams ignore frame rates which seem to be nonsense

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1588,6 +1588,17 @@ void CDVDDemuxFFmpeg::DisposeStreams()
   m_parsers.clear();
 }
 
+bool CDVDDemuxFFmpeg::isFpsNonsense(const AVRational &frameRate)
+{
+  if (frameRate.num == 0 || frameRate.den == 0)
+  {
+	return true;
+  }
+
+  const double fps = (double) frameRate.num / (double) frameRate.den;
+  return fps > 500.;
+}
+
 CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
 {
   AVStream* pStream = m_pFormatContext->streams[streamIdx];
@@ -1648,6 +1659,18 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
 
         AVRational r_frame_rate = pStream->r_frame_rate;
 
+        if (isFpsNonsense(r_frame_rate))
+        {
+          r_frame_rate.num = 0;
+          r_frame_rate.den = 0;
+        }
+
+        if (isFpsNonsense(pStream->avg_frame_rate))
+        {
+          pStream->avg_frame_rate.num = 0;
+          pStream->avg_frame_rate.den = 0;
+        }
+
         //average fps is more accurate for mkv files
         if (m_bMatroska && pStream->avg_frame_rate.den && pStream->avg_frame_rate.num)
         {
@@ -1658,6 +1681,11 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
         {
           st->iFpsRate = r_frame_rate.num;
           st->iFpsScale = r_frame_rate.den;
+        }
+        else if(pStream->avg_frame_rate.den && pStream->avg_frame_rate.num)
+        {
+          st->iFpsRate = pStream->avg_frame_rate.num;
+          st->iFpsScale = pStream->avg_frame_rate.den;
         }
         else
         {

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -177,5 +177,8 @@ protected:
   double m_dtsAtDisplayTime;
   bool m_seekToKeyFrame = false;
   double m_startTime = 0;
+
+private:
+  bool isFpsNonsense(const AVRational &frameRate);
 };
 


### PR DESCRIPTION
## Description

This commit discards frame rate reporting when they are sporadic. 

## Motivation and context

Saves an additional frame rate fix. 

## How has this been tested?

This has been tested on OSMC Vero 4K / 4K + devices for over a year. 

## What is the effect on users?

If Adjust Refresh Rate is enabled, we save an additional refresh rate switch. 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

