### PR TITLE
CDisplayInfo: fix strict checking of edid

### DIFF
--- a/xbmc/utils/DisplayInfo.cpp
+++ b/xbmc/utils/DisplayInfo.cpp
@@ -8,6 +8,7 @@
 
 #include "DisplayInfo.h"
 
+#include "utils/StringUtils.h"
 #include "utils/log.h"
 
 extern "C"
@@ -53,7 +54,17 @@ bool CDisplayInfo::IsValid() const
   const char* error = di_info_get_failure_msg(m_info.get());
   if (error)
   {
-    CLog::Log(LOGERROR, "[display-info] error: {}", error);
+    CLog::Log(LOGERROR, "[display-info] Error parsing EDID:");
+    CLog::Log(LOGERROR, "[display-info] ----------------------------------------------");
+
+    std::vector<std::string> lines = StringUtils::Split(error, "\n");
+
+    for (const auto& line : lines)
+    {
+      CLog::Log(LOGERROR, "[display-info] {}", line);
+    }
+
+    CLog::Log(LOGERROR, "[display-info] ----------------------------------------------");
   }
 
   return true;

--- a/xbmc/utils/DisplayInfo.cpp
+++ b/xbmc/utils/DisplayInfo.cpp
@@ -54,7 +54,6 @@ bool CDisplayInfo::IsValid() const
   if (error)
   {
     CLog::Log(LOGERROR, "[display-info] error: {}", error);
-    return false;
   }
 
   return true;

--- a/xbmc/utils/DisplayInfo.cpp
+++ b/xbmc/utils/DisplayInfo.cpp
@@ -136,8 +136,8 @@ void CDisplayInfo::LogInfo() const
               m_hdr_static_metadata->eotfs->traditional_sdr);
     CLog::Log(LOGINFO, "[display-info]   traditional hdr: {}",
               m_hdr_static_metadata->eotfs->traditional_hdr);
-    CLog::Log(LOGINFO, "[display-info]   traditional pq:  {}", m_hdr_static_metadata->eotfs->pq);
-    CLog::Log(LOGINFO, "[display-info]   traditional hlg: {}", m_hdr_static_metadata->eotfs->hlg);
+    CLog::Log(LOGINFO, "[display-info]   pq:              {}", m_hdr_static_metadata->eotfs->pq);
+    CLog::Log(LOGINFO, "[display-info]   hlg:             {}", m_hdr_static_metadata->eotfs->hlg);
 
     CLog::Log(LOGINFO, "[display-info] luma min: '{}' avg: '{}' max: '{}'",
               m_hdr_static_metadata->desired_content_min_luminance,


### PR DESCRIPTION
After #19141 there was a couple things that needed fixing.

3db44830c2d0ed39048d924c5426016216b837cd still allows using the display info if the edid isn't valid
d1c25492c4451270e4611c2f3c1492fc782041c9 fixes the libdisplay-info multi line error logging
10bfa019cc3cdc2c0df7e4219a4cceb9cd2d0c59 fixes the logging for static metadata types.

```
2023-04-18 14:38:33.812 T:2329529   error <general>: [display-info] Error parsing EDID:
2023-04-18 14:38:33.812 T:2329529   error <general>: [display-info] ----------------------------------------------
2023-04-18 14:38:33.812 T:2329529   error <general>: [display-info] Block 1, CTA-861 Extension Block:
2023-04-18 14:38:33.812 T:2329529   error <general>: [display-info]   Colorimetry Data Block: Reserved bits MD0-MD3 must be 0.
2023-04-18 14:38:33.812 T:2329529   error <general>: [display-info]
2023-04-18 14:38:33.812 T:2329529   error <general>: [display-info] Block 0, Base EDID:
2023-04-18 14:38:33.812 T:2329529   error <general>: [display-info]   Unknown Extension Block.
2023-04-18 14:38:33.812 T:2329529   error <general>: [display-info]
2023-04-18 14:38:33.812 T:2329529   error <general>: [display-info] ----------------------------------------------
2023-04-18 14:38:33.812 T:2329529    info <general>: [display-info] make: 'Acer Technologies' model: 'XV273K'
2023-04-18 14:38:33.812 T:2329529    info <general>: [display-info] supports hdr static metadata type1: true
2023-04-18 14:38:33.812 T:2329529    info <general>: [display-info] supported eotf:
2023-04-18 14:38:33.812 T:2329529    info <general>: [display-info]   traditional sdr: true
2023-04-18 14:38:33.812 T:2329529    info <general>: [display-info]   traditional hdr: true
2023-04-18 14:38:33.812 T:2329529    info <general>: [display-info]   pq:              true
2023-04-18 14:38:33.812 T:2329529    info <general>: [display-info]   hlg:             false
2023-04-18 14:38:33.812 T:2329529    info <general>: [display-info] luma min: '0.049283653' avg: '322.09805' max: '408.75888'
```

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Allows broken edid's to still allow HDR modes.
