### PR TITLE
[Android] Only use recommended channels on Android TV stock

### DIFF
--- a/tools/android/packaging/xbmc/src/Main.java.in
+++ b/tools/android/packaging/xbmc/src/Main.java.in
@@ -2,9 +2,12 @@ package @APP_PACKAGE@;
 
 import @APP_PACKAGE@.channels.util.TvUtil;
 
+import static android.content.pm.PackageManager.FEATURE_LEANBACK;
+
 import android.app.NativeActivity;
 import android.content.ComponentName;
 import android.content.Intent;
+import android.content.pm.ResolveInfo;
 import android.graphics.Color;
 import android.graphics.Rect;
 import android.hardware.input.InputManager;
@@ -134,11 +137,15 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
       getIntent().setData(null);
     }
 
-    if (getPackageManager().hasSystemFeature("android.software.leanback"))
+    if (getPackageManager().hasSystemFeature(FEATURE_LEANBACK))
     {
-      if (Build.VERSION.SDK_INT >= VERSION_CODES.O)
+      if (Build.VERSION.SDK_INT >= VERSION_CODES.O
+          && getLauncherName().equals("com.google.android.tvlauncher"))
+      {
         TvUtil.scheduleSyncingChannel(this);
-      else
+      }
+      else if (Build.VERSION.SDK_INT < VERSION_CODES.O
+               && getLauncherName().equals("com.google.android.leanbacklauncher"))
       {
         // Leanback
         mJsonRPC = new XBMCJsonRPC();
@@ -273,8 +280,11 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
   {
     super.onPause();
 
-    if (getPackageManager().hasSystemFeature("android.software.leanback") && Build.VERSION.SDK_INT >= VERSION_CODES.O)
+    if (getPackageManager().hasSystemFeature(FEATURE_LEANBACK)
+        && Build.VERSION.SDK_INT >= VERSION_CODES.O
+        && getLauncherName().equals("com.google.android.tvlauncher")) {
       TvUtil.scheduleSyncingChannel(this);
+    }
 
     mPaused = true;
   }
@@ -326,5 +336,15 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
         _callNative(funcAddr, variantAddr);
       }
     });
+  }
+
+  /**
+   * Gets the package name of the current system launcher
+   */
+  private String getLauncherName() {
+    final Intent intent = new Intent(Intent.ACTION_MAIN);
+    intent.addCategory(Intent.CATEGORY_HOME);
+    final ResolveInfo res = getPackageManager().resolveActivity(intent, 0);
+    return res.activityInfo.packageName;
   }
 }


### PR DESCRIPTION
## Description
Android TV based operating systems such as Fire OS or Google TV do not use the recommendation channels API that allows displays recommended content on the home screen.

Therefore, we should only create and schedule this content channel if the device is running Android TV stock.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
