### PR TITLE
[CVariant] Fix empty() for Null-CVariant

### DIFF
--- a/xbmc/utils/Variant.cpp
+++ b/xbmc/utils/Variant.cpp
@@ -673,6 +673,7 @@ bool CVariant::empty() const
                                [](const VariantArray& a) { return a.empty(); },
                                [](const std::string& s) { return s.empty(); },
                                [](const std::wstring& w) { return w.empty(); },
+                               [](const Null& n) { return true; },
                                [](const auto&) { return false; }},
                     m_data);
 }

--- a/xbmc/utils/test/TestVariant.cpp
+++ b/xbmc/utils/test/TestVariant.cpp
@@ -8,6 +8,10 @@
 
 #include "utils/Variant.h"
 
+#include <map>
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 TEST(TestVariant, VariantTypeInteger)
@@ -284,9 +288,32 @@ TEST(TestVariant, size)
 TEST(TestVariant, empty)
 {
   std::vector<std::string> strarray;
-  CVariant a(strarray);
+  EXPECT_TRUE(CVariant(strarray).empty());
+  strarray.emplace_back("abc");
+  EXPECT_FALSE(CVariant(strarray).empty());
 
-  EXPECT_TRUE(a.empty());
+  std::map<std::string, std::string> strmap;
+  EXPECT_TRUE(CVariant(strmap).empty());
+  strmap.emplace(std::make_pair(std::string("key"), std::string("value")));
+  EXPECT_FALSE(CVariant(strmap).empty());
+
+  std::string str;
+  EXPECT_TRUE(CVariant(str).empty());
+  str = "abc";
+  EXPECT_FALSE(CVariant(str).empty());
+
+  std::wstring wstr;
+  EXPECT_TRUE(CVariant(wstr).empty());
+  wstr = L"abc";
+  EXPECT_FALSE(CVariant(wstr).empty());
+
+  EXPECT_TRUE(CVariant().empty());
+
+  EXPECT_FALSE(CVariant(CVariant::VariantTypeConstNull).empty());
+  EXPECT_FALSE(CVariant(CVariant::VariantTypeInteger).empty());
+  EXPECT_FALSE(CVariant(CVariant::VariantTypeUnsignedInteger).empty());
+  EXPECT_FALSE(CVariant(CVariant::VariantTypeBoolean).empty());
+  EXPECT_FALSE(CVariant(CVariant::VariantTypeDouble).empty());
 }
 
 TEST(TestVariant, clear)


### PR DESCRIPTION
## Description
`CVariant::empty()` has to return `true` for a Null-CVariant. This accidentally broke in #23114 728b396dad3a40f9cba5d679bedfab4f76a97125. This PR restores the correct bahaviour and extends the unit test for that case.

The problem was first observed in https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/877.

## Motivation and context
Restore the correct behaviour.

## How has this been tested?
The curl request in https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/877#issuecomment-1517713150 creates the expected output. Also there is a better unit test now.

## What is the effect on users?
This could cause issues in many places.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
