### PR TITLE
TexturePacker: second pass at modernization

### DIFF
--- a/tools/depends/native/TexturePacker/src/DecoderManager.cpp
+++ b/tools/depends/native/TexturePacker/src/DecoderManager.cpp
@@ -41,7 +41,7 @@ bool DecoderManager::IsSupportedGraphicsFile(std::string_view filename)
 
   for (const auto& decoder : m_decoders)
   {
-    const std::vector<std::string> extensions = decoder->GetSupportedExtensions();
+    const std::vector<std::string>& extensions = decoder->GetSupportedExtensions();
     for (const auto& extension : extensions)
     {
       if (std::string::npos != filename.rfind(extension, filename.length() - extension.length()))

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -51,8 +51,6 @@
 
 #define DIR_SEPARATOR '/'
 
-static DecoderManager decoderManager;
-
 const char *GetFormatString(unsigned int format)
 {
   switch (format)
@@ -74,9 +72,29 @@ const char *GetFormatString(unsigned int format)
   }
 }
 
-void CreateSkeletonHeader(CXBTFWriter& xbtfWriter,
-                          const std::string& fullPath,
-                          const std::string& relativePath = "")
+class TexturePacker
+{
+public:
+  TexturePacker() = default;
+  ~TexturePacker() = default;
+
+  int createBundle(const std::string& InputDir,
+                   const std::string& OutputFile,
+                   double maxMSE,
+                   unsigned int flags,
+                   bool dupecheck);
+
+  DecoderManager decoderManager;
+
+private:
+  void CreateSkeletonHeader(CXBTFWriter& xbtfWriter,
+                            const std::string& fullPath,
+                            const std::string& relativePath = "");
+};
+
+void TexturePacker::CreateSkeletonHeader(CXBTFWriter& xbtfWriter,
+                                         const std::string& fullPath,
+                                         const std::string& relativePath)
 {
   struct dirent* dp;
   struct stat stat_p;
@@ -248,7 +266,11 @@ static bool checkDupe(struct MD5Context* ctx,
   return false;
 }
 
-int createBundle(const std::string& InputDir, const std::string& OutputFile, double maxMSE, unsigned int flags, bool dupecheck)
+int TexturePacker::createBundle(const std::string& InputDir,
+                                const std::string& OutputFile,
+                                double maxMSE,
+                                unsigned int flags,
+                                bool dupecheck)
 {
   CXBTFWriter writer(OutputFile);
   if (!writer.Create())
@@ -363,6 +385,8 @@ int main(int argc, char* argv[])
   std::string InputDir;
   std::string OutputFilename = "Textures.xbt";
 
+  TexturePacker texturePacker;
+
   for (unsigned int i = 1; i < args.size(); ++i)
   {
     if (!platform_stricmp(args[i], "-help") || !platform_stricmp(args[i], "-h") || !platform_stricmp(args[i], "-?"))
@@ -381,7 +405,7 @@ int main(int argc, char* argv[])
     }
     else if (!strcmp(args[i], "-verbose"))
     {
-      decoderManager.verbose = true;
+      texturePacker.decoderManager.verbose = true;
     }
     else if (!platform_stricmp(args[i], "-output") || !platform_stricmp(args[i], "-o"))
     {
@@ -409,5 +433,6 @@ int main(int argc, char* argv[])
     InputDir += DIR_SEPARATOR;
 
   double maxMSE = 1.5; // HQ only please
-  createBundle(InputDir, OutputFilename, maxMSE, flags, dupecheck);
+
+  texturePacker.createBundle(InputDir, OutputFilename, maxMSE, flags, dupecheck);
 }

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -80,7 +80,6 @@ public:
 
   int createBundle(const std::string& InputDir,
                    const std::string& OutputFile,
-                   double maxMSE,
                    unsigned int flags,
                    bool dupecheck);
 
@@ -212,7 +211,7 @@ bool HasAlpha(unsigned char *argb, unsigned int width, unsigned int height)
   return false;
 }
 
-CXBTFFrame createXBTFFrame(RGBAImage &image, CXBTFWriter& writer, double maxMSE, unsigned int flags)
+CXBTFFrame createXBTFFrame(RGBAImage& image, CXBTFWriter& writer, unsigned int flags)
 {
 
   int width, height;
@@ -268,7 +267,6 @@ static bool checkDupe(struct MD5Context* ctx,
 
 int TexturePacker::createBundle(const std::string& InputDir,
                                 const std::string& OutputFile,
-                                double maxMSE,
                                 unsigned int flags,
                                 bool dupecheck)
 {
@@ -337,7 +335,7 @@ int TexturePacker::createBundle(const std::string& InputDir,
       for (unsigned int j = 0; j < frames.frameList.size(); j++)
       {
         printf("    frame %4i (delay:%4i)                         ", j, frames.frameList[j].delay);
-        CXBTFFrame frame = createXBTFFrame(frames.frameList[j].rgbaImage, writer, maxMSE, flags);
+        CXBTFFrame frame = createXBTFFrame(frames.frameList[j].rgbaImage, writer, flags);
         frame.SetDuration(frames.frameList[j].delay);
         file.GetFrames().push_back(frame);
         printf("%s%c (%d,%d @ %" PRIu64 " bytes)\n", GetFormatString(frame.GetFormat()), frame.HasAlpha() ? ' ' : '*',
@@ -432,7 +430,5 @@ int main(int argc, char* argv[])
   if (pos != InputDir.length() - 1)
     InputDir += DIR_SEPARATOR;
 
-  double maxMSE = 1.5; // HQ only please
-
-  texturePacker.createBundle(InputDir, OutputFilename, maxMSE, flags, dupecheck);
+  texturePacker.createBundle(InputDir, OutputFilename, flags, dupecheck);
 }

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -74,9 +74,9 @@ const char *GetFormatString(unsigned int format)
   }
 }
 
-void CreateSkeletonHeaderImpl(CXBTFWriter& xbtfWriter,
-                              const std::string& fullPath,
-                              const std::string& relativePath)
+void CreateSkeletonHeader(CXBTFWriter& xbtfWriter,
+                          const std::string& fullPath,
+                          const std::string& relativePath = "")
 {
   struct dirent* dp;
   struct stat stat_p;
@@ -103,7 +103,8 @@ void CreateSkeletonHeaderImpl(CXBTFWriter& xbtfWriter,
             tmpPath += "/";
           }
 
-          CreateSkeletonHeaderImpl(xbtfWriter, fullPath + DIR_SEPARATOR + dp->d_name, tmpPath + dp->d_name);
+          CreateSkeletonHeader(xbtfWriter, fullPath + DIR_SEPARATOR + dp->d_name,
+                               tmpPath + dp->d_name);
         }
         else if (decoderManager.IsSupportedGraphicsFile(dp->d_name))
         {
@@ -131,12 +132,6 @@ void CreateSkeletonHeaderImpl(CXBTFWriter& xbtfWriter,
   {
     fprintf(stderr, "Error opening %s (%s)\n", fullPath.c_str(), strerror(errno));
   }
-}
-
-void CreateSkeletonHeader(CXBTFWriter& xbtfWriter, const std::string& fullPath)
-{
-  std::string temp;
-  CreateSkeletonHeaderImpl(xbtfWriter, fullPath, temp);
 }
 
 CXBTFFrame appendContent(CXBTFWriter &writer, int width, int height, unsigned char *data, unsigned int size, unsigned int format, bool hasAlpha, unsigned int flags)

--- a/tools/depends/native/TexturePacker/src/XBTFWriter.cpp
+++ b/tools/depends/native/TexturePacker/src/XBTFWriter.cpp
@@ -37,11 +37,7 @@
 #define WRITE_U32(i, file) { uint32_t _n = Endian_SwapLE32(i); fwrite(&_n, 4, 1, file); }
 #define WRITE_U64(i, file) { uint64_t _n = i; _n = Endian_SwapLE64(i); fwrite(&_n, 8, 1, file); }
 
-CXBTFWriter::CXBTFWriter(const std::string& outputFile)
-  : m_outputFile(outputFile),
-    m_file(nullptr),
-    m_data(nullptr),
-    m_size(0)
+CXBTFWriter::CXBTFWriter(const std::string& outputFile) : m_outputFile(outputFile), m_file(nullptr)
 { }
 
 CXBTFWriter::~CXBTFWriter()
@@ -60,10 +56,10 @@ bool CXBTFWriter::Create()
 
 bool CXBTFWriter::Close()
 {
-  if (m_file == nullptr || m_data == nullptr)
+  if (m_file == nullptr)
     return false;
 
-  fwrite(m_data, 1, m_size, m_file);
+  fwrite(m_data.data(), 1, m_data.size(), m_file);
 
   Cleanup();
 
@@ -72,9 +68,6 @@ bool CXBTFWriter::Close()
 
 void CXBTFWriter::Cleanup()
 {
-  free(m_data);
-  m_data = nullptr;
-  m_size = 0;
   if (m_file)
   {
     fclose(m_file);
@@ -84,18 +77,7 @@ void CXBTFWriter::Cleanup()
 
 bool CXBTFWriter::AppendContent(unsigned char const* data, size_t length)
 {
-  unsigned char *new_data = (unsigned char *)realloc(m_data, m_size + length);
-
-  if (new_data == nullptr)
-  { // OOM - cleanup and fail
-    Cleanup();
-    return false;
-  }
-
-  m_data = new_data;
-
-  memcpy(m_data + m_size, data, length);
-  m_size += length;
+  m_data.insert(m_data.end(), data, data + length);
 
   return true;
 }

--- a/tools/depends/native/TexturePacker/src/XBTFWriter.h
+++ b/tools/depends/native/TexturePacker/src/XBTFWriter.h
@@ -42,7 +42,6 @@ private:
 
   std::string m_outputFile;
   FILE* m_file;
-  unsigned char *m_data;
-  size_t         m_size;
+  std::vector<uint8_t> m_data;
 };
 

--- a/tools/depends/native/TexturePacker/src/decoder/GIFDecoder.cpp
+++ b/tools/depends/native/TexturePacker/src/decoder/GIFDecoder.cpp
@@ -45,13 +45,12 @@ bool GIFDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
       unsigned int height = gifImage.GetHeight();
       unsigned int width = gifImage.GetWidth();
       unsigned int pitch = gifImage.GetPitch();
-      unsigned int frameSize = pitch * height;
+
       for (unsigned int i = 0; i < extractedFrames.size(); i++)
       {
         DecodedFrame frame;
 
-        frame.rgbaImage.pixels.resize(frameSize);
-        memcpy(frame.rgbaImage.pixels.data(), extractedFrames[i]->m_pImage, frameSize);
+        frame.rgbaImage.pixels = extractedFrames[i]->m_pImage;
         frame.rgbaImage.height = height;
         frame.rgbaImage.width = width;
         frame.rgbaImage.bbp = 32;

--- a/tools/depends/native/TexturePacker/src/decoder/GIFDecoder.cpp
+++ b/tools/depends/native/TexturePacker/src/decoder/GIFDecoder.cpp
@@ -36,7 +36,7 @@ bool GIFDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
   bool result = false;
 
   GifHelper gifImage;
-  if (gifImage.LoadGif(filename.c_str()))
+  if (gifImage.LoadGif(filename))
   {
     auto extractedFrames = gifImage.GetFrames();
     n = extractedFrames.size();

--- a/tools/depends/native/TexturePacker/src/decoder/GIFDecoder.cpp
+++ b/tools/depends/native/TexturePacker/src/decoder/GIFDecoder.cpp
@@ -24,6 +24,11 @@
 
 #include <cstring>
 
+GIFDecoder::GIFDecoder()
+{
+  m_extensions.emplace_back(".gif");
+}
+
 // returns true for gif files, otherwise returns false
 bool GIFDecoder::CanDecode(const std::string &filename)
 {
@@ -64,9 +69,4 @@ bool GIFDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
   }
 
   return result;
-}
-
-void GIFDecoder::FillSupportedExtensions()
-{
-  m_supportedExtensions.emplace_back(".gif");
 }

--- a/tools/depends/native/TexturePacker/src/decoder/GIFDecoder.cpp
+++ b/tools/depends/native/TexturePacker/src/decoder/GIFDecoder.cpp
@@ -35,16 +35,16 @@ bool GIFDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
   int n = 0;
   bool result = false;
 
-  GifHelper *gifImage = new GifHelper();
-  if (gifImage->LoadGif(filename.c_str()))
+  GifHelper gifImage;
+  if (gifImage.LoadGif(filename.c_str()))
   {
-    auto extractedFrames = gifImage->GetFrames();
+    auto extractedFrames = gifImage.GetFrames();
     n = extractedFrames.size();
     if (n > 0)
     {
-      unsigned int height = gifImage->GetHeight();
-      unsigned int width = gifImage->GetWidth();
-      unsigned int pitch = gifImage->GetPitch();
+      unsigned int height = gifImage.GetHeight();
+      unsigned int width = gifImage.GetWidth();
+      unsigned int pitch = gifImage.GetPitch();
       unsigned int frameSize = pitch * height;
       for (unsigned int i = 0; i < extractedFrames.size(); i++)
       {
@@ -63,7 +63,7 @@ bool GIFDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
     }
     result = true;
   }
-  delete gifImage;
+
   return result;
 }
 

--- a/tools/depends/native/TexturePacker/src/decoder/GIFDecoder.h
+++ b/tools/depends/native/TexturePacker/src/decoder/GIFDecoder.h
@@ -25,11 +25,10 @@
 class GIFDecoder : public IDecoder
 {
   public:
+    GIFDecoder();
     ~GIFDecoder() override = default;
     bool CanDecode(const std::string &filename) override;
     bool LoadFile(const std::string& filename, DecodedFrames& frames) override;
     const char* GetImageFormatName() override { return "GIF"; }
     const char* GetDecoderName() override { return "libgif"; }
-  protected:
-    void FillSupportedExtensions() override;
 };

--- a/tools/depends/native/TexturePacker/src/decoder/GifHelper.cpp
+++ b/tools/depends/native/TexturePacker/src/decoder/GifHelper.cpp
@@ -43,16 +43,10 @@ int ReadFromVfs(GifFileType* gif, GifByteType* gifbyte, int len)
   return gifFile->Read(gifbyte, len);
 }
 
-GifHelper::GifHelper()
-{
-  m_gifFile = new CFile();
-}
-
 GifHelper::~GifHelper()
 {
     Close(m_gif);
     Release();
-    delete m_gifFile;
 }
 
 bool GifHelper::Open(GifFileType*& gif, void *dataPtr, InputFunc readFunc)
@@ -176,8 +170,8 @@ bool GifHelper::LoadGifMetaData(GifFileType* gif)
 
 bool GifHelper::LoadGifMetaData(const std::string& file)
 {
-  m_gifFile->Close();
-  if (!m_gifFile->Open(file) || !Open(m_gif, m_gifFile, ReadFromVfs))
+  m_gifFile.Close();
+  if (!m_gifFile.Open(file) || !Open(m_gif, &m_gifFile, ReadFromVfs))
     return false;
 
   return LoadGifMetaData(m_gif);

--- a/tools/depends/native/TexturePacker/src/decoder/GifHelper.cpp
+++ b/tools/depends/native/TexturePacker/src/decoder/GifHelper.cpp
@@ -174,7 +174,7 @@ bool GifHelper::LoadGifMetaData(GifFileType* gif)
   return true;
 }
 
-bool GifHelper::LoadGifMetaData(const char* file)
+bool GifHelper::LoadGifMetaData(const std::string& file)
 {
   m_gifFile->Close();
   if (!m_gifFile->Open(file) || !Open(m_gif, m_gifFile, ReadFromVfs))
@@ -200,10 +200,10 @@ bool GifHelper::Slurp(GifFileType* gif)
   return true;
 }
 
-bool GifHelper::LoadGif(const char* file)
+bool GifHelper::LoadGif(const std::string& file)
 {
   m_filename = file;
-  if (!LoadGifMetaData(m_filename.c_str()))
+  if (!LoadGifMetaData(m_filename))
     return false;
 
   try

--- a/tools/depends/native/TexturePacker/src/decoder/GifHelper.cpp
+++ b/tools/depends/native/TexturePacker/src/decoder/GifHelper.cpp
@@ -449,22 +449,3 @@ void GifHelper::ClearFrameAreaToTransparency(unsigned char* dest, const GifFrame
     }
   }
 }
-
-GifFrame::GifFrame(const GifFrame& src)
-  : m_delay(src.m_delay),
-    m_top(src.m_top),
-    m_left(src.m_left),
-    m_disposal(src.m_disposal),
-    m_height(src.m_height),
-    m_width(src.m_width)
-{
-  if (src.m_pImage.size())
-  {
-    m_pImage = src.m_pImage;
-  }
-
-  if (src.m_palette.size())
-  {
-    m_palette = src.m_palette;
-  }
-}

--- a/tools/depends/native/TexturePacker/src/decoder/GifHelper.h
+++ b/tools/depends/native/TexturePacker/src/decoder/GifHelper.h
@@ -108,7 +108,7 @@ private:
   std::string     m_filename;
   GifFileType* m_gif = nullptr;
   std::vector<GifColor> m_globalPalette;
-  unsigned char* m_pTemplate = nullptr;
+  std::vector<uint8_t> m_pTemplate;
   CFile m_gifFile;
 
   unsigned int m_width;

--- a/tools/depends/native/TexturePacker/src/decoder/GifHelper.h
+++ b/tools/depends/native/TexturePacker/src/decoder/GifHelper.h
@@ -61,9 +61,9 @@ class GifFrame
 public:
 
   GifFrame() = default;
-  virtual ~GifFrame();
+  virtual ~GifFrame() = default;
 
-  unsigned char* m_pImage = nullptr;
+  std::vector<uint8_t> m_pImage;
   unsigned int m_delay = 0;
 
 private:
@@ -74,7 +74,6 @@ private:
   unsigned int m_disposal = 0;
   unsigned int m_height = 0;
   unsigned int m_width = 0;
-  unsigned int m_imageSize = 0;
   std::vector<GifColor>   m_palette;
 };
 

--- a/tools/depends/native/TexturePacker/src/decoder/GifHelper.h
+++ b/tools/depends/native/TexturePacker/src/decoder/GifHelper.h
@@ -67,8 +67,6 @@ public:
   unsigned int m_delay = 0;
 
 private:
-  GifFrame(const GifFrame& src);
-
   unsigned int m_top = 0;
   unsigned int m_left = 0;
   unsigned int m_disposal = 0;

--- a/tools/depends/native/TexturePacker/src/decoder/GifHelper.h
+++ b/tools/depends/native/TexturePacker/src/decoder/GifHelper.h
@@ -87,7 +87,7 @@ class GifHelper
   typedef std::shared_ptr<GifFrame> FramePtr;
 
 public:
-  GifHelper();
+  GifHelper() = default;
   virtual ~GifHelper();
 
   bool LoadGif(const std::string& file);
@@ -109,7 +109,7 @@ private:
   GifFileType* m_gif = nullptr;
   std::vector<GifColor> m_globalPalette;
   unsigned char* m_pTemplate = nullptr;
-  CFile*          m_gifFile;
+  CFile m_gifFile;
 
   unsigned int m_width;
   unsigned int m_height;

--- a/tools/depends/native/TexturePacker/src/decoder/GifHelper.h
+++ b/tools/depends/native/TexturePacker/src/decoder/GifHelper.h
@@ -90,8 +90,7 @@ public:
   GifHelper();
   virtual ~GifHelper();
 
-
-  bool LoadGif(const char* file);
+  bool LoadGif(const std::string& file);
 
   std::vector<FramePtr>& GetFrames() { return m_frames; }
   unsigned int GetPitch() const { return m_pitch; }
@@ -120,7 +119,7 @@ private:
 
   const char* Reason(int reason);
 
-  bool LoadGifMetaData(const char* file);
+  bool LoadGifMetaData(const std::string& file);
   bool Slurp(GifFileType* gif);
   void InitTemplateAndColormap();
   bool LoadGifMetaData(GifFileType* gif);

--- a/tools/depends/native/TexturePacker/src/decoder/IDecoder.h
+++ b/tools/depends/native/TexturePacker/src/decoder/IDecoder.h
@@ -37,17 +37,10 @@ class IDecoder
     virtual const char* GetImageFormatName() = 0;
     virtual const char* GetDecoderName() = 0;
 
-    const std::vector<std::string>& GetSupportedExtensions()
-    {
-      m_supportedExtensions.clear();
-      FillSupportedExtensions();
-      return m_supportedExtensions;
-    }
+    const std::vector<std::string>& GetSupportedExtensions() const { return m_extensions; }
 
   protected:
-    virtual void FillSupportedExtensions() = 0;
-    //fill this with extensions in FillSupportedExtensions like ".png"
-    std::vector<std::string> m_supportedExtensions;
+    std::vector<std::string> m_extensions;
 };
 
 class RGBAImage

--- a/tools/depends/native/TexturePacker/src/decoder/JPGDecoder.cpp
+++ b/tools/depends/native/TexturePacker/src/decoder/JPGDecoder.cpp
@@ -90,13 +90,16 @@ bool JPGDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
 
   frame.rgbaImage.pixels.resize(ImageSize);
 
-  unsigned char *scanlinebuff = new unsigned char[3 * cinfo.image_width];
+  std::vector<unsigned char> scanlinebuff;
+  scanlinebuff.resize(3 * cinfo.image_width);
+
   unsigned char* dst = (unsigned char*)frame.rgbaImage.pixels.data();
   while (cinfo.output_scanline < cinfo.output_height)
   {
-    jpeg_read_scanlines(&cinfo,&scanlinebuff,1);
+    unsigned char* src2 = scanlinebuff.data();
 
-    unsigned char *src2 = scanlinebuff;
+    jpeg_read_scanlines(&cinfo, &src2, 1);
+
     unsigned char *dst2 = dst;
     for (unsigned int x = 0; x < cinfo.image_width; x++, src2 += 3)
     {
@@ -107,7 +110,6 @@ bool JPGDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
     }
     dst += cinfo.image_width * 4;
   }
-  delete [] scanlinebuff;
 
   jpeg_finish_decompress(&cinfo);
   jpeg_destroy_decompress(&cinfo);

--- a/tools/depends/native/TexturePacker/src/decoder/JPGDecoder.cpp
+++ b/tools/depends/native/TexturePacker/src/decoder/JPGDecoder.cpp
@@ -26,6 +26,12 @@
 
 #include <jpeglib.h>
 
+JPGDecoder::JPGDecoder()
+{
+  m_extensions.emplace_back(".jpg");
+  m_extensions.emplace_back(".jpeg");
+}
+
 bool JPGDecoder::CanDecode(const std::string &filename)
 {
   CFile fp;
@@ -122,10 +128,4 @@ bool JPGDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
   frames.frameList.push_back(frame);
 
   return true;
-}
-
-void JPGDecoder::FillSupportedExtensions()
-{
-  m_supportedExtensions.emplace_back(".jpg");
-  m_supportedExtensions.emplace_back(".jpeg");
 }

--- a/tools/depends/native/TexturePacker/src/decoder/JPGDecoder.h
+++ b/tools/depends/native/TexturePacker/src/decoder/JPGDecoder.h
@@ -25,11 +25,10 @@
 class JPGDecoder : public IDecoder
 {
   public:
+    JPGDecoder();
     ~JPGDecoder() override = default;
     bool CanDecode(const std::string &filename) override;
     bool LoadFile(const std::string& filename, DecodedFrames& frames) override;
     const char* GetImageFormatName() override { return "JPG"; }
     const char* GetDecoderName() override { return "libjpeg"; }
-  protected:
-    void FillSupportedExtensions() override;
 };

--- a/tools/depends/native/TexturePacker/src/decoder/PNGDecoder.cpp
+++ b/tools/depends/native/TexturePacker/src/decoder/PNGDecoder.cpp
@@ -28,6 +28,11 @@
 #  define png_jmpbuf(png_ptr) ((png_ptr)->jmpbuf)
 #endif
 
+PNGDecoder::PNGDecoder()
+{
+  m_extensions.emplace_back(".png");
+}
+
 /* Check to see if a file is a PNG file using png_sig_cmp().  png_sig_cmp()
  * returns zero if the image is a PNG and nonzero if it isn't a PNG.
  *
@@ -215,9 +220,4 @@ bool PNGDecoder::LoadFile(const std::string &filename, DecodedFrames &frames)
   png_destroy_read_struct(&png_ptr, &info_ptr, &end_info);
 
   return true;
-}
-
-void PNGDecoder::FillSupportedExtensions()
-{
-  m_supportedExtensions.emplace_back(".png");
 }

--- a/tools/depends/native/TexturePacker/src/decoder/PNGDecoder.h
+++ b/tools/depends/native/TexturePacker/src/decoder/PNGDecoder.h
@@ -25,11 +25,10 @@
 class PNGDecoder : public IDecoder
 {
   public:
+    PNGDecoder();
     ~PNGDecoder() override = default;
     bool CanDecode(const std::string &filename) override;
     bool LoadFile(const std::string& filename, DecodedFrames& frames) override;
     const char* GetImageFormatName() override { return "PNG"; }
     const char* GetDecoderName() override { return "libpng"; }
-  protected:
-    void FillSupportedExtensions() override;
 };


### PR DESCRIPTION
This is a follow up to #23150 

This removes the uses of some memcpy, adds a basic class implementation to TexturePacker and simplifies some interfaces.

When reviewing look at the individual commits as the overall diff looks a bit messy.


## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

none