### PR TITLE
[CEncoderFFmpeg] Fix cleanup of buffer managed by AVIOContext

### DIFF
--- a/xbmc/cdrip/EncoderFFmpeg.h
+++ b/xbmc/cdrip/EncoderFFmpeg.h
@@ -54,7 +54,6 @@ private:
    * For others a typical size is a cache page, e.g. 4kb.
    */
   static constexpr size_t BUFFER_SIZE = 4096;
-  uint8_t* m_bcBuffer{nullptr};
 
   unsigned int m_neededFrames{0};
   size_t m_neededBytes{0};


### PR DESCRIPTION
## Description
From the [documentation](https://ffmpeg.org/doxygen/trunk/aviobuf_8c.html#a853f5149136a27ffba3207d8520172a5) regarding the buffer passed to avio_alloc_context():

Memory block for input/output operations via AVIOContext. The buffer must be allocated with av_malloc() and friends. It may be freed and replaced with a new buffer by libavformat. AVIOContext.buffer holds the buffer currently in use, which must be later freed with av_free().

## Motivation and context
Manage memory as described in the documentation.

## How has this been tested?
**Hasn't been tested!**

## What is the effect on users?
Unknown, maybe could have caused crashes in the past.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
