### PR TITLE
[macos][nativewindowing] Fix fullscreen inconsistencies

### DIFF
--- a/xbmc/windowing/osx/OpenGL/WindowControllerMacOS.mm
+++ b/xbmc/windowing/osx/OpenGL/WindowControllerMacOS.mm
@@ -54,17 +54,13 @@
 
 - (void)windowDidResize:(NSNotification*)aNotification
 {
-  auto winSystem = dynamic_cast<CWinSystemOSX*>(CServiceBroker::GetWinSystem());
-  if (!winSystem)
-    return;
-
   NSRect rect = [self.window contentRectForFrameRect:self.window.frame];
   int width = static_cast<int>(rect.size.width);
   int height = static_cast<int>(rect.size.height);
 
   XBMC_Event newEvent = {};
 
-  if (!winSystem->IsFullScreen() && !winSystem->GetFullscreenWillToggle())
+  if ((self.window.styleMask & NSWindowStyleMaskFullScreen) != NSWindowStyleMaskFullScreen)
   {
     RESOLUTION res_index = RES_DESKTOP;
     if ((width == CDisplaySettings::GetInstance().GetResolutionInfo(res_index).iWidth) &&

--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -115,6 +115,7 @@ protected:
   bool SwitchToVideoMode(int width, int height, double refreshrate);
   void FillInVideoModes();
   bool FlushBuffer();
+  void UpdateSafeAreaInsets();
 
   bool DestroyWindowInternal();
 


### PR DESCRIPTION
## Description
This fixes a few inconsistencies that I've found while using Kodi on macOS and toggling fullscreen state via different paths: `\` shortcut (kodi builtin) vs hitting macos controls (like the window builtin maximize button or window shortcuts). SafeAreaInsets was not being calculated (and updated) if we started Kodi windowed and used the macOS "path" to put the window into the fullscreen state. Safe area insets must be calculated regardless of the chosen path, as long as we are moving from windowed to fullscreen.

Another commit fixes some inconsistencies regarding event broadcasting (`FULLSCREEN_UPDATE` vs `VIDEORESIZE`). The condition was a bit confusing and could not always provide the result we were expecting (fullscreen state in windowing system is not atomic). Since we are only interested in knowing if the windowed is fullscreen or not, and the actual notification is an `NSWindow` just check its flags instead. Bonus points since it removes the dependency on the window system too.

@kambala-decapitator should be quick to review
