### PR TITLE
[Darwin] Fix and make Credits rebrandable

### DIFF
--- a/cmake/scripts/common/Macros.cmake
+++ b/cmake/scripts/common/Macros.cmake
@@ -646,6 +646,10 @@ endfunction()
 #   APP_PACKAGE - Android full package name
 #   COMPANY_NAME - company name
 #   APP_WEBSITE - site url
+#   ABOUT_WEBSITE - url for the about page of the app
+#   DEV_NAME - name of the developer of the app
+#   DOCS_WEBSITE - url for the documentation of the app
+#   FORUM_WEBSITE - url for the forum/discussion board of the app
 #   APP_VERSION_MAJOR - the app version major
 #   APP_VERSION_MINOR - the app version minor
 #   APP_VERSION_TAG - the app version tag
@@ -676,10 +680,14 @@ macro(core_find_versions)
   set(version_props
     ADDON_API
     ADDON_REPOS
+    ABOUT_WEBSITE
     APP_NAME
     APP_PACKAGE
     COMPANY_NAME
     COPYRIGHT_YEARS
+    DEV_NAME
+    DOCS_WEBSITE
+    FORUM_WEBSITE
     JSONRPC_VERSION
     PACKAGE_DESCRIPTION
     PACKAGE_IDENTITY
@@ -699,6 +707,10 @@ macro(core_find_versions)
   string(TOLOWER ${APP_APP_NAME} APP_NAME_LC)
   string(TOUPPER ${APP_APP_NAME} APP_NAME_UC)
   set(COMPANY_NAME ${APP_COMPANY_NAME})
+  set(ABOUT_WEBSITE ${APP_ABOUT_WEBSITE})
+  set(DEV_NAME ${APP_DEV_NAME})
+  set(DOCS_WEBSITE ${APP_DOCS_WEBSITE})
+  set(FORUM_WEBSITE ${APP_FORUM_WEBSITE})
   set(APP_VERSION ${APP_VERSION_MAJOR}.${APP_VERSION_MINOR})
   # Let Flatpak builders etc override APP_PACKAGE
   # NOTE: We cannot declare an option() in top-level CMakeLists.txt

--- a/cmake/scripts/darwin_embedded/Install.cmake
+++ b/cmake/scripts/darwin_embedded/Install.cmake
@@ -123,6 +123,9 @@ set(DEPENDS_ROOT_FOR_XCODE ${NATIVEPREFIX}/..)
 configure_file(${CMAKE_SOURCE_DIR}/tools/darwin/packaging/darwin_embedded/mkdeb-darwin_embedded.sh.in
                ${CMAKE_BINARY_DIR}/tools/darwin/packaging/darwin_embedded/mkdeb-darwin_embedded.sh @ONLY)
 
+configure_file(${CMAKE_SOURCE_DIR}/xbmc/platform/darwin/Credits.html.in
+               ${CMAKE_BINARY_DIR}/xbmc/platform/darwin/Credits.html @ONLY)
+
 add_custom_target(deb
     COMMAND sh ./mkdeb-darwin_embedded.sh ${CORE_BUILD_CONFIG}
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tools/darwin/packaging/darwin_embedded)

--- a/cmake/scripts/osx/Install.cmake
+++ b/cmake/scripts/osx/Install.cmake
@@ -45,6 +45,9 @@ add_dependencies(bundle ${APP_NAME_LC})
 configure_file(${CMAKE_SOURCE_DIR}/tools/darwin/packaging/osx/mkdmg-osx.sh.in
                ${CMAKE_BINARY_DIR}/tools/darwin/packaging/osx/mkdmg-osx.sh @ONLY)
 
+configure_file(${CMAKE_SOURCE_DIR}/xbmc/platform/darwin/Credits.html.in
+               ${CMAKE_BINARY_DIR}/xbmc/platform/darwin/Credits.html @ONLY)
+
 string(TOLOWER ${CORE_BUILD_CONFIG} CORE_BUILD_CONFIG_LOWERCASED)
 if(${CORE_BUILD_CONFIG_LOWERCASED} STREQUAL "release")
   set(ALLOW_DEBUGGER "false")

--- a/tools/Linux/kodi.metainfo.xml.in
+++ b/tools/Linux/kodi.metainfo.xml.in
@@ -4,13 +4,13 @@
     <name>@APP_NAME@</name>
     <project_license>GPL-2.0-only GPL-2.0-or-later LGPL-2.1-or-later MIT BSD-3-Clause BSD-4-Clause</project_license>
     <metadata_license>CC0-1.0</metadata_license>
-    <developer_name>Team Kodi</developer_name>
+    <developer_name>@DEV_NAME@</developer_name>
     <summary>The ultimate entertainment center</summary>
     <url type="homepage">https://kodi.tv/</url>
     <url type="donation">https://kodi.tv/contribute/donate</url>
     <url type="bugtracker">https://github.com/xbmc/xbmc/issues</url>
     <url type="faq">https://kodi.wiki/view/FAQs</url>
-    <url type="help">https://forum.kodi.tv/</url>
+    <url type="help">@FORUM_WEBSITE@</url>
     <url type="translate">https://kodi.weblate.cloud/</url>
     <url type="contribute">https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md</url>
     <url type="vcs-browser">https://github.com/xbmc/xbmc/</url>

--- a/version.txt
+++ b/version.txt
@@ -1,5 +1,9 @@
 APP_NAME Kodi
 COMPANY_NAME XBMC Foundation
+DEV_NAME Team Kodi
+ABOUT_WEBSITE https://kodi.tv/about/
+FORUM_WEBSITE https://forum.kodi.tv/
+DOCS_WEBSITE https://kodi.wiki/
 COPYRIGHT_YEARS 2005-2021
 WEBSITE http://kodi.tv
 VERSION_MAJOR 21

--- a/xbmc/platform/darwin/Credits.html.in
+++ b/xbmc/platform/darwin/Credits.html.in
@@ -18,23 +18,18 @@ th { text-align: right; }
 </style>
 </head>
 <body>
-<center><a href="http://kodi.tv/about/">Team Kodi</a></center>
+<center><a href="@ABOUT_WEBSITE@">@DEV_NAME@</a></center>
 <br>
 <table style="font-family:Verdana;">
 
 <tr>
 <th>Documentation</th>
-<td><a href="http://kodi.wiki/view/Online_Manual">Kodi online manual</a></td>
+<td><a href="@DOCS_WEBSITE@">@DOCS_WEBSITE@</a></td>
 </tr>
 
 <tr>
 <th width="40%">Need Help?</th>
-<td width="60%"><a href="http://forum.kodi.tv/">Kodi community forums</a></td>
-</tr>
-
-<tr>
-<th>Chat</th>
-<td><a href="irc://freenode.net/%23xbmc-osx">#xbmc-osx</a></td>
+<td width="60%"><a href="@FORUM_WEBSITE@">@FORUM_WEBSITE@</a></td>
 </tr>
 
 </table>


### PR DESCRIPTION
## Description
Makes the credit page refer the properties we define on version.txt, making it easier to rebrand and removing obsolete info (`#xbmc-osx` on freenode)

## How has this been tested?
Using the `:orderFrontStandardAboutPanel` selector on macos:


<img width="308" alt="Screenshot 2023-04-22 at 23 56 59" src="https://user-images.githubusercontent.com/7375276/233811111-7e4ccfa8-288e-4380-ac35-8ae11a7c09c1.png">

