### PR TITLE
CVariant: Fix negated logic in asBoolean() for strings

### DIFF
--- a/xbmc/utils/Variant.cpp
+++ b/xbmc/utils/Variant.cpp
@@ -419,11 +419,12 @@ float CVariant::asFloat(float fallback) const
 bool CVariant::asBoolean(bool fallback) const
 {
   return std::visit(
-      overloaded{[](bool b) { return b; }, [](int64_t i) { return i != 0; },
-                 [](uint64_t u) { return u != 0; }, [](double d) { return d != 0; },
-                 [](const std::string& s) { return s.empty() || s == "0" || s == "false"; },
-                 [](const std::wstring& ws) { return ws.empty() || ws == L"0" || ws == L"false"; },
-                 [=](const auto&) { return fallback; }},
+      overloaded{
+          [](bool b) { return b; }, [](int64_t i) { return i != 0; },
+          [](uint64_t u) { return u != 0; }, [](double d) { return d != 0; },
+          [](const std::string& s) { return !(s.empty() || s == "0" || s == "false"); },
+          [](const std::wstring& ws) { return !(ws.empty() || ws == L"0" || ws == L"false"); },
+          [=](const auto&) { return fallback; }},
       m_data);
 }
 

--- a/xbmc/utils/test/TestVariant.cpp
+++ b/xbmc/utils/test/TestVariant.cpp
@@ -359,3 +359,40 @@ TEST(TestVariant, isMember)
   EXPECT_TRUE(a.isMember("key1"));
   EXPECT_FALSE(a.isMember("key2"));
 }
+
+TEST(TestVariant, asBoolean)
+{
+  EXPECT_TRUE(CVariant("true").asBoolean());
+  EXPECT_FALSE(CVariant("false").asBoolean());
+  EXPECT_TRUE(CVariant("1").asBoolean());
+  EXPECT_FALSE(CVariant("0").asBoolean());
+  EXPECT_FALSE(CVariant("").asBoolean());
+
+  EXPECT_TRUE(CVariant(L"true").asBoolean());
+  EXPECT_FALSE(CVariant(L"false").asBoolean());
+  EXPECT_TRUE(CVariant(L"1").asBoolean());
+  EXPECT_FALSE(CVariant(L"0").asBoolean());
+  EXPECT_FALSE(CVariant(L"").asBoolean());
+
+  EXPECT_TRUE(CVariant(uint64_t{1}).asBoolean());
+  EXPECT_TRUE(CVariant(uint64_t{999999999}).asBoolean());
+  EXPECT_FALSE(CVariant(uint64_t{0}).asBoolean());
+
+  EXPECT_TRUE(CVariant(int64_t{1}).asBoolean());
+  EXPECT_TRUE(CVariant(int64_t{999999999}).asBoolean());
+  EXPECT_TRUE(CVariant(int64_t{-999999999}).asBoolean());
+  EXPECT_FALSE(CVariant(int64_t{0}).asBoolean());
+
+  EXPECT_TRUE(CVariant(double{1}).asBoolean());
+  EXPECT_TRUE(CVariant(double{999999999}).asBoolean());
+  EXPECT_TRUE(CVariant(double{-999999999}).asBoolean());
+  EXPECT_FALSE(CVariant(double{0}).asBoolean());
+
+  EXPECT_TRUE(CVariant(true).asBoolean());
+  EXPECT_FALSE(CVariant(false).asBoolean());
+
+  EXPECT_FALSE(CVariant(CVariant::VariantTypeNull).asBoolean());
+  EXPECT_FALSE(CVariant(CVariant::VariantTypeConstNull).asBoolean());
+  EXPECT_FALSE(CVariant(CVariant::VariantTypeArray).asBoolean());
+  EXPECT_FALSE(CVariant(CVariant::VariantTypeObject).asBoolean());
+}


### PR DESCRIPTION
## Description
See title. Issue was observed in #23186.

## Motivation and context
Restore correct behaviour.

## How has this been tested?
Addons work again (see #23186) + new unit tests.

## What is the effect on users?
Addons work again.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
