### PR TITLE
[macOS][NativeWindowing] Simplify application menus

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -1607,10 +1607,6 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
     appPlayer->TriggerUpdateResolution();
     break;
 
-  case TMSG_TOGGLEFLOATONTOP:
-    CServiceBroker::GetWinSystem()->ToggleFloatOnTop();
-    break;
-
   case TMSG_MINIMIZE:
     CServiceBroker::GetWinSystem()->Minimize();
     break;

--- a/xbmc/messaging/ApplicationMessenger.h
+++ b/xbmc/messaging/ApplicationMessenger.h
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 
+// clang-format off
 #define TMSG_MASK_MESSAGE                 0xFFFF0000 // only keep the high bits to route messages
 #define TMSG_MASK_APPLICATION             (1<<30) //Don't use bit 31 as it'll fail to build, using unsigned variable to hold the message.
 #define TMSG_MASK_PLAYLISTPLAYER          (1<<29)
@@ -82,7 +83,6 @@
 #define TMSG_RENDERER_PREINIT             TMSG_MASK_APPLICATION + 31
 #define TMSG_RENDERER_UNINIT              TMSG_MASK_APPLICATION + 32
 #define TMSG_EVENT                        TMSG_MASK_APPLICATION + 33
-#define TMSG_TOGGLEFLOATONTOP TMSG_MASK_APPLICATION + 34
 
 /// @brief Called from the player when its current item is updated
 #define TMSG_UPDATE_PLAYER_ITEM TMSG_MASK_APPLICATION + 35
@@ -137,8 +137,7 @@
 
 
 #define TMSG_CALLBACK                     800
-
-
+// clang-format on
 
 class CGUIMessage;
 

--- a/xbmc/platform/darwin/osx/XBMCApplication.mm
+++ b/xbmc/platform/darwin/osx/XBMCApplication.mm
@@ -120,6 +120,12 @@ static NSMenu* setupWindowMenu()
   [windowMenu addItemWithTitle:@"Minimize"
                         action:@selector(performMiniaturize:)
                  keyEquivalent:@"m"];
+
+  // "Zoom" item
+  NSMenuItem* zoomMenuItem = [[NSMenuItem alloc] initWithTitle:@"Zoom"
+                                                        action:@selector(performZoom:)
+                                                 keyEquivalent:@""];
+  [windowMenu addItem:zoomMenuItem];
 }
 
 // Called after the internal event loop has started running.

--- a/xbmc/platform/darwin/osx/XBMCApplication.mm
+++ b/xbmc/platform/darwin/osx/XBMCApplication.mm
@@ -299,10 +299,22 @@ static NSMenu* setupWindowMenu()
 
 - (void)floatOnTopToggle:(id)sender
 {
-  [sender setState:([NSApplication sharedApplication].mainWindow.level == NSNormalWindowLevel
-                        ? NSControlStateValueOn
-                        : NSControlStateValueOff)];
-  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_TOGGLEFLOATONTOP);
+  auto mainWindow = [NSApplication sharedApplication].mainWindow;
+  if (!mainWindow)
+  {
+    return;
+  }
+
+  if (mainWindow.level == NSNormalWindowLevel)
+  {
+    [mainWindow setLevel:NSFloatingWindowLevel];
+    [sender setState:NSControlStateValueOn];
+  }
+  else
+  {
+    [mainWindow setLevel:NSNormalWindowLevel];
+    [sender setState:NSControlStateValueOff];
+  }
 }
 
 - (void)hideAppToggle:(id)sender

--- a/xbmc/platform/darwin/osx/XBMCApplication.mm
+++ b/xbmc/platform/darwin/osx/XBMCApplication.mm
@@ -45,13 +45,6 @@ static NSMenu* setupWindowMenu()
   menuItem.keyEquivalentModifierMask = NSEventModifierFlagCommand;
   [windowMenu addItem:menuItem];
 
-  // "Hide" item
-  menuItem = [[NSMenuItem alloc] initWithTitle:@"Hide"
-                                        action:@selector(hideAppToggle:)
-                                 keyEquivalent:@"h"];
-  menuItem.keyEquivalentModifierMask = NSEventModifierFlagCommand;
-  [windowMenu addItem:menuItem];
-
   // "Minimize" item
   menuItem = [[NSMenuItem alloc] initWithTitle:@"Minimize"
                                         action:@selector(performMiniaturize:)
@@ -84,7 +77,7 @@ static NSMenu* setupWindowMenu()
   // Main menu
   NSMenu* appMenu = [NSMenu new];
   NSMenuItem* hideMenuItem = [[NSMenuItem alloc] initWithTitle:@"Hide"
-                                                        action:@selector(hideAppToggle:)
+                                                        action:@selector(hide:)
                                                  keyEquivalent:@"h"];
   hideMenuItem.keyEquivalentModifierMask = NSEventModifierFlagCommand;
   [appMenu addItem:hideMenuItem];
@@ -113,20 +106,6 @@ static NSMenu* setupWindowMenu()
   [windowMenu addItemWithTitle:@"Minimize"
                         action:@selector(performMiniaturize:)
                  keyEquivalent:@"m"];
-}
-
-- (BOOL)validateMenuItem:(NSMenuItem*)item
-{
-  // validate how the hide menu item should be shown (hide or show)
-  if ([item.title isEqual:@"Hide"] && [[NSApplication sharedApplication] isHidden])
-  {
-    [item setTitle:@"Show"];
-  }
-  else if (([item.title isEqual:@"Show"] && ![[NSApplication sharedApplication] isHidden]))
-  {
-    [item setTitle:@"Hide"];
-  }
-  return YES;
 }
 
 // Called after the internal event loop has started running.
@@ -314,18 +293,6 @@ static NSMenu* setupWindowMenu()
   {
     [mainWindow setLevel:NSNormalWindowLevel];
     [sender setState:NSControlStateValueOff];
-  }
-}
-
-- (void)hideAppToggle:(id)sender
-{
-  if (![[NSApplication sharedApplication] isHidden])
-  {
-    [[NSApplication sharedApplication] hide:sender];
-  }
-  else
-  {
-    [[NSApplication sharedApplication] unhide:sender];
   }
 }
 

--- a/xbmc/platform/darwin/osx/XBMCApplication.mm
+++ b/xbmc/platform/darwin/osx/XBMCApplication.mm
@@ -81,6 +81,20 @@ static NSMenu* setupWindowMenu()
                                                  keyEquivalent:@"h"];
   hideMenuItem.keyEquivalentModifierMask = NSEventModifierFlagCommand;
   [appMenu addItem:hideMenuItem];
+
+  NSMenuItem* hideOthersMenuItem =
+      [[NSMenuItem alloc] initWithTitle:@"Hide Others"
+                                 action:@selector(hideOtherApplications:)
+                          keyEquivalent:@"h"];
+  hideOthersMenuItem.keyEquivalentModifierMask =
+      NSEventModifierFlagOption | NSEventModifierFlagCommand;
+  [appMenu addItem:hideOthersMenuItem];
+
+  NSMenuItem* showAllMenuItem = [[NSMenuItem alloc] initWithTitle:@"Show All"
+                                                           action:@selector(unhideAllApplications:)
+                                                    keyEquivalent:@""];
+  [appMenu addItem:showAllMenuItem];
+
   NSMenuItem* quitMenuItem = [[NSMenuItem alloc] initWithTitle:@"Quit"
                                                         action:@selector(terminate:)
                                                  keyEquivalent:@"q"];

--- a/xbmc/platform/darwin/osx/XBMCApplication.mm
+++ b/xbmc/platform/darwin/osx/XBMCApplication.mm
@@ -25,35 +25,45 @@ static int gArgc;
 static const char** gArgv;
 static BOOL gCalledAppMainline = FALSE;
 
-// Create a window menu
-static NSMenu* setupWindowMenu()
-{
-  NSMenu* windowMenu = [[NSMenu alloc] initWithTitle:@"Window"];
+//! @TODO We should use standard XIB files for better management of the menubar.
+static NSDictionary* _appMenu = @{
+  @"title" : @"Kodi",
+  @"items" : @[
+    @{@"title" : @"About", @"sel" : @"orderFrontStandardAboutPanel:"},
+    @{@"title" : @"-"},
+    @{@"title" : @"Hide", @"sel" : @"hide:", @"key" : @"h"},
+    @{
+      @"title" : @"Hide Others",
+      @"sel" : @"hideOtherApplications:",
+      @"mod" : @(NSEventModifierFlagOption),
+      @"key" : @"h"
+    },
+    @{@"title" : @"Show All", @"sel" : @"unhideAllApplications:"},
+    @{@"title" : @"-"},
+    @{@"title" : @"Quit", @"sel" : @"terminate:", @"key" : @"q"},
+  ]
+};
 
-  // "Full/Windowed Toggle" item
-  NSMenuItem* menuItem = [[NSMenuItem alloc] initWithTitle:@"Full/Windowed Toggle"
-                                                    action:@selector(fullScreenToggle:)
-                                             keyEquivalent:@"f"];
-  // this is just for display purposes, key handling is in CWinEventsOSX::ProcessOSXShortcuts()
-  menuItem.keyEquivalentModifierMask = NSEventModifierFlagCommand | NSEventModifierFlagControl;
-  [windowMenu addItem:menuItem];
-
-  // "Float on top" item
-  menuItem = [[NSMenuItem alloc] initWithTitle:@"Float on Top"
-                                        action:@selector(floatOnTopToggle:)
-                                 keyEquivalent:@"t"];
-  menuItem.keyEquivalentModifierMask = NSEventModifierFlagCommand;
-  [windowMenu addItem:menuItem];
-
-  // "Minimize" item
-  menuItem = [[NSMenuItem alloc] initWithTitle:@"Minimize"
-                                        action:@selector(performMiniaturize:)
-                                 keyEquivalent:@"m"];
-  menuItem.keyEquivalentModifierMask = NSEventModifierFlagCommand;
-  [windowMenu addItem:menuItem];
-
-  return windowMenu;
-}
+static NSDictionary* _windowMenu = @{
+  @"title" : @"Window",
+  @"items" : @[
+    @{@"title" : @"Minimize", @"sel" : @"performMiniaturize:", @"key" : @"m"},
+    @{@"title" : @"Zoom", @"sel" : @"performZoom:"},
+    @{
+      @"title" : @"Float on Top",
+      @"sel" : @"floatOnTopToggle:",
+      @"mod" : @(NSEventModifierFlagOption),
+      @"key" : @"t"
+    },
+    @{@"title" : @"-"},
+    @{
+      @"title" : @"Enter Full Screen",
+      @"sel" : @"fullScreenToggle:",
+      @"mod" : @(NSEventModifierFlagControl),
+      @"key" : @"f"
+    },
+  ]
+};
 
 // The main class of the application, the application's delegate
 @implementation XBMCDelegate
@@ -67,70 +77,47 @@ static NSMenu* setupWindowMenu()
            @"SetupWorkingDirectory Failed to cwd");
 }
 
-- (void)applicationWillFinishLaunching:(NSNotification*)notification
+- (void)setupMenuBar
 {
   NSMenu* menubar = [NSMenu new];
-  NSMenuItem* menuBarItem = [NSMenuItem new];
-  [menubar addItem:menuBarItem];
-  [NSApp setMainMenu:menubar];
+  NSMenu* windowsMenu = nil;
 
-  // Main menu
-  NSMenu* appMenu = [NSMenu new];
-  NSMenuItem* aboutMenuItem =
-      [[NSMenuItem alloc] initWithTitle:@"About"
-                                 action:@selector(orderFrontStandardAboutPanel:)
-                          keyEquivalent:@""];
-  [appMenu addItem:aboutMenuItem];
-  NSMenuItem* hideMenuItem = [[NSMenuItem alloc] initWithTitle:@"Hide"
-                                                        action:@selector(hide:)
-                                                 keyEquivalent:@"h"];
-  hideMenuItem.keyEquivalentModifierMask = NSEventModifierFlagCommand;
-  [appMenu addItem:hideMenuItem];
+  for (NSDictionary* menuDict in @[ _appMenu, _windowMenu ])
+  {
+    auto item = [menubar addItemWithTitle:@"" action:nil keyEquivalent:@""];
+    auto submenu = [self makeMenu:menuDict];
+    [menubar setSubmenu:submenu forItem:item];
+  }
+  NSApp.mainMenu = menubar;
+  NSApp.windowsMenu = windowsMenu;
+}
 
-  NSMenuItem* hideOthersMenuItem =
-      [[NSMenuItem alloc] initWithTitle:@"Hide Others"
-                                 action:@selector(hideOtherApplications:)
-                          keyEquivalent:@"h"];
-  hideOthersMenuItem.keyEquivalentModifierMask =
-      NSEventModifierFlagOption | NSEventModifierFlagCommand;
-  [appMenu addItem:hideOthersMenuItem];
+- (NSMenu*)makeMenu:(NSDictionary*)menuDict
+{
+  auto menu = [[NSMenu alloc] initWithTitle:menuDict[@"title"]];
+  for (NSDictionary* items in menuDict[@"items"])
+  {
+    NSString* title = items[@"title"];
+    if ([title isEqualToString:@"-"])
+    {
+      [menu addItem:[NSMenuItem separatorItem]];
+      continue;
+    }
+    auto item = [[NSMenuItem alloc] initWithTitle:title action:nil keyEquivalent:@""];
+    if (NSString* sel = items[@"sel"])
+      item.action = NSSelectorFromString(sel);
+    if (NSString* key = items[@"key"])
+      item.keyEquivalent = key;
+    if (NSNumber* mask = items[@"mod"])
+      item.keyEquivalentModifierMask |= [mask intValue];
+    [menu addItem:item];
+  }
+  return menu;
+}
 
-  NSMenuItem* showAllMenuItem = [[NSMenuItem alloc] initWithTitle:@"Show All"
-                                                           action:@selector(unhideAllApplications:)
-                                                    keyEquivalent:@""];
-  [appMenu addItem:showAllMenuItem];
-
-  NSMenuItem* quitMenuItem = [[NSMenuItem alloc] initWithTitle:@"Quit"
-                                                        action:@selector(terminate:)
-                                                 keyEquivalent:@"q"];
-  [appMenu addItem:quitMenuItem];
-  [menuBarItem setSubmenu:appMenu];
-
-  // Window Menu
-  NSMenuItem* windowMenuItem = [menubar addItemWithTitle:@"" action:nil keyEquivalent:@""];
-  NSMenu* windowMenu = [[NSMenu alloc] initWithTitle:@"Window"];
-  [menubar setSubmenu:windowMenu forItem:windowMenuItem];
-  NSMenuItem* fullscreenMenuItem = [[NSMenuItem alloc] initWithTitle:@"Full/Windowed Toggle"
-                                                              action:@selector(fullScreenToggle:)
-                                                       keyEquivalent:@"f"];
-  fullscreenMenuItem.keyEquivalentModifierMask =
-      NSEventModifierFlagCommand | NSEventModifierFlagControl;
-  [windowMenu addItem:fullscreenMenuItem];
-  NSMenuItem* floatOnTopMenuItem = [[NSMenuItem alloc] initWithTitle:@"Float on Top"
-                                                              action:@selector(floatOnTopToggle:)
-                                                       keyEquivalent:@"t"];
-  floatOnTopMenuItem.keyEquivalentModifierMask = NSEventModifierFlagCommand;
-  [windowMenu addItem:floatOnTopMenuItem];
-
-  [windowMenu addItemWithTitle:@"Minimize"
-                        action:@selector(performMiniaturize:)
-                 keyEquivalent:@"m"];
-
-  // "Zoom" item
-  NSMenuItem* zoomMenuItem = [[NSMenuItem alloc] initWithTitle:@"Zoom"
-                                                        action:@selector(performZoom:)
-                                                 keyEquivalent:@""];
-  [windowMenu addItem:zoomMenuItem];
+- (void)applicationWillFinishLaunching:(NSNotification*)notification
+{
+  [self setupMenuBar];
 }
 
 // Called after the internal event loop has started running.
@@ -323,7 +310,7 @@ static NSMenu* setupWindowMenu()
 
 - (NSMenu*)applicationDockMenu:(NSApplication*)sender
 {
-  return setupWindowMenu();
+  return [self makeMenu:_windowMenu];
 }
 
 @end

--- a/xbmc/platform/darwin/osx/XBMCApplication.mm
+++ b/xbmc/platform/darwin/osx/XBMCApplication.mm
@@ -76,6 +76,11 @@ static NSMenu* setupWindowMenu()
 
   // Main menu
   NSMenu* appMenu = [NSMenu new];
+  NSMenuItem* aboutMenuItem =
+      [[NSMenuItem alloc] initWithTitle:@"About"
+                                 action:@selector(orderFrontStandardAboutPanel:)
+                          keyEquivalent:@""];
+  [appMenu addItem:aboutMenuItem];
   NSMenuItem* hideMenuItem = [[NSMenuItem alloc] initWithTitle:@"Hide"
                                                         action:@selector(hide:)
                                                  keyEquivalent:@"h"];

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -79,13 +79,6 @@ public:
   //the number of presentation buffers
   virtual int NoOfBuffers();
 
-  /*!
-   * @brief Toggle Float on Top
-   *
-   * @details Used to keep the application window on top of all other windows regardless of being the one
-   * receiving input (or focused).
-  */
-  virtual void ToggleFloatOnTop(){};
   /**
    * Get average display latency
    *

--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -76,8 +76,6 @@ public:
   void Register(IDispResource* resource) override;
   void Unregister(IDispResource* resource) override;
 
-  void ToggleFloatOnTop() override;
-
   std::unique_ptr<CVideoSync> GetVideoSync(void* clock) override;
 
   void WindowChangedScreen();

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -751,25 +751,6 @@ NSRect CWinSystemOSX::GetWindowDimensions()
   return frame;
 }
 
-#pragma mark - Window level
-
-void CWinSystemOSX::ToggleFloatOnTop()
-{
-  dispatch_sync(dispatch_get_main_queue(), ^{
-    if (!m_appWindow)
-      return;
-
-    if (m_appWindow.level == NSFloatingWindowLevel)
-    {
-      [m_appWindow setLevel:NSNormalWindowLevel];
-    }
-    else
-    {
-      [m_appWindow setLevel:NSFloatingWindowLevel];
-    }
-  });
-}
-
 #pragma mark - Resize Window
 
 bool CWinSystemOSX::ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop)


### PR DESCRIPTION
## Description
Another one kindly stolen/adapted from @stevehartwell work (credits given), it simplifies the application menus, drops the dependency on the application for "float on top" (no longer needed since the input code was re-written), removes our custom logic for show/hide (this is guaranteed automatically by the default selector), adds other standard menu items like the about item (and other window items).

## Screenshots (if appropriate):

<img width="330" alt="image" src="https://user-images.githubusercontent.com/7375276/233833493-a43c2d39-c9d5-490f-b1a3-03001cd4e504.png">

<img width="396" alt="image" src="https://user-images.githubusercontent.com/7375276/233833519-1a945043-616a-4b7c-8119-af38131eced4.png">

<img width="192" alt="image" src="https://user-images.githubusercontent.com/7375276/233833525-5b5875e3-99fd-4141-8633-6007b963b3a1.png">

<img width="356" alt="image" src="https://user-images.githubusercontent.com/7375276/233833564-6a77b5ab-c342-4f6b-b0c9-1a6f54f1851a.png">


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
