### PR TITLE
[PVR] Prevent crash on saved search

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -441,7 +441,8 @@ CGUIDialogPVRGuideSearch::Result CGUIWindowPVRSearchBase::OpenDialogSearch(
   else if (result == CGUIDialogPVRGuideSearch::Result::SAVE)
   {
     CServiceBroker::GetPVRManager().EpgContainer().PersistSavedSearch(*tmpSearchFilter);
-    searchFilter->SetDatabaseId(tmpSearchFilter->GetDatabaseId());
+    if (searchFilter)
+      searchFilter->SetDatabaseId(tmpSearchFilter->GetDatabaseId());
 
     const CPVREpgSearchPath path(m_vecItems->GetPath());
     if (path.IsValid() && path.IsSearchRoot())


### PR DESCRIPTION
## Description
When a PVR search is first created it is possible to hit Save which saves to the database and then performs a search.   In this scenario the searchFilter parameter is not instantiated before OpenDialogSearch() is called leading to crash when it is referenced.
<!--- Describe your change in detail here. -->

Check that the searchFilter is not empty before trying to populate it.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
This fixes a hard crash.
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
I could not determine the merit of the code that is causing the crash, but I assume it would handle a future change in the database persistance logic if the row id were to change.  In the case of a new search this would not be an in issue.  

Also for new searches the passed searchField parameter is also a class variable and the  class variable is initialized in SetSearchFilter().


<!--- Include details of your testing environment, and the tests you ran to -->
Tested on Windows 11 with current Omega build.
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
The search is saved but it avoids a crash.  It might be possible to remove save as an option on the first call but for users who repeat known searches on clients this would introduce an extra strep.

<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
