### PR TITLE
[macos][nativewindowing] Check keywindow before hiding/showing OS Cursor

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1272,14 +1272,20 @@ bool CWinSystemOSX::HasCursor()
 
 void CWinSystemOSX::signalMouseEntered()
 {
-  m_hasCursor = true;
-  m_winEvents->signalMouseEntered();
+  if (m_appWindow.keyWindow)
+  {
+    m_hasCursor = true;
+    m_winEvents->signalMouseEntered();
+  }
 }
 
 void CWinSystemOSX::signalMouseExited()
 {
-  m_hasCursor = false;
-  m_winEvents->signalMouseExited();
+  if (m_appWindow.keyWindow)
+  {
+    m_hasCursor = false;
+    m_winEvents->signalMouseExited();
+  }
 }
 
 void CWinSystemOSX::SendInputEvent(NSEvent* nsEvent)


### PR DESCRIPTION
## Description
Currently we signal mouseentered and mouseexited anytime the cursor enters/exits the tracking area. The problem is that we assume the Kodi window is the current key window. If we open some other window (e.g. the application credits) we loose the cursor while navigating with the mouse between the main kodi window boundary and the credits (current keywindow) area.
This PR guarantees we only signal such events if the Kodi window is the current key window. 