### PR TITLE
[FFmpegImage] Switch back to jpeg_pipe for FFmpeg>=6.0

### DIFF
--- a/xbmc/guilib/FFmpegImage.cpp
+++ b/xbmc/guilib/FFmpegImage.cpp
@@ -198,9 +198,16 @@ bool CFFmpegImage::Initialize(unsigned char* buffer, size_t bufSize)
   bool is_png = (bufSize > 3 && buffer[1] == 'P' && buffer[2] == 'N' && buffer[3] == 'G');
   bool is_tiff = (bufSize > 2 && buffer[0] == 'I' && buffer[1] == 'I' && buffer[2] == '*');
 
+  // See Github #19113
+#if LIBAVCODEC_VERSION_MAJOR < 60
+  constexpr char jpegFormat[] = "image2";
+#else
+  constexpr char jpegFormat[] = "jpeg_pipe";
+#endif
+
   const AVInputFormat* inp = nullptr;
   if (is_jpeg)
-    inp = av_find_input_format("image2");
+    inp = av_find_input_format(jpegFormat);
   else if (m_strMimeType == "image/apng")
     inp = av_find_input_format("apng");
   else if (is_png)
@@ -213,7 +220,7 @@ bool CFFmpegImage::Initialize(unsigned char* buffer, size_t bufSize)
     inp = av_find_input_format("webp_pipe");
   // brute force parse if above check already failed
   else if (m_strMimeType == "image/jpeg" || m_strMimeType == "image/jpg")
-    inp = av_find_input_format("image2");
+    inp = av_find_input_format(jpegFormat);
   else if (m_strMimeType == "image/png")
     inp = av_find_input_format("png_pipe");
   else if (m_strMimeType == "image/tiff")


### PR DESCRIPTION
## Description
FFmpeg 6.0 seems to be able to decode the problematic images from #18744 and #19103 just fine. In the debug log it shows these messages when opening the problematic pictures but I guess that's fine:
```
ffmpeg[0x617000049f80]: [mjpeg] unable to decode APP fields: Invalid data found when processing input
```
This effectively reverts #19113.

## Motivation and context
Main motivation was to get rid of these messages in the debug log :sweat_smile: :

```
ffmpeg[0x2a82e45180X]: [image2] Custom AVIOContext makes no sense and will be ignored with AVFMT_NOFILE format.
```

## How has this been tested?
Test images are showing up in Kodi.

## What is the effect on users?
None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [X] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
