### PR TITLE
[guilib][vfs][imagecache] Load special images into texture cache when viewed, like standard images

### DIFF
--- a/cmake/treedata/common/subdirs.txt
+++ b/cmake/treedata/common/subdirs.txt
@@ -16,6 +16,7 @@ xbmc/dialogs                                    dialogs
 xbmc/favourites                                 favourites
 xbmc/guilib                                     guilib
 xbmc/guilib/guiinfo                             guilib_guiinfo
+xbmc/imagefiles                                 imagefiles
 xbmc/input                                      input
 xbmc/input/actions                              input/actions
 xbmc/input/button                               input/button

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -26,7 +26,6 @@
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
-#include "video/VideoThumbLoader.h"
 
 #include <cstdlib>
 #include <cstring>
@@ -200,14 +199,6 @@ std::unique_ptr<CTexture> CTextureCacheJob::LoadImage(const std::string& image,
   { // special case for embedded music images
     EmbeddedArt art;
     if (CMusicThumbLoader::GetEmbeddedThumb(image, art))
-      return CTexture::LoadFromFileInMemory(art.m_data.data(), art.m_size, art.m_mime, width,
-                                            height);
-  }
-
-  if (StringUtils::StartsWith(additional_info, "video_"))
-  {
-    EmbeddedArt art;
-    if (CVideoThumbLoader::GetEmbeddedThumb(image, additional_info.substr(6), art))
       return CTexture::LoadFromFileInMemory(art.m_data.data(), art.m_size, art.m_mime, width,
                                             height);
   }

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -17,6 +17,7 @@
 #include "commons/ilog.h"
 #include "filesystem/File.h"
 #include "guilib/Texture.h"
+#include "imagefiles/SpecialImageLoaderFactory.h"
 #include "music/MusicThumbLoader.h"
 #include "pictures/Picture.h"
 #include "settings/AdvancedSettings.h"
@@ -209,6 +210,14 @@ std::unique_ptr<CTexture> CTextureCacheJob::LoadImage(const std::string& image,
     if (CVideoThumbLoader::GetEmbeddedThumb(image, additional_info.substr(6), art))
       return CTexture::LoadFromFileInMemory(art.m_data.data(), art.m_size, art.m_mime, width,
                                             height);
+  }
+
+  if (!additional_info.empty())
+  {
+    IMAGE_FILES::CSpecialImageLoaderFactory specialImageLoader{};
+    auto texture = specialImageLoader.Load(additional_info, image, width, height);
+    if (texture)
+      return texture;
   }
 
   // Validate file URL to see if it is an image

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -18,11 +18,9 @@
 #include "filesystem/File.h"
 #include "guilib/Texture.h"
 #include "imagefiles/SpecialImageLoaderFactory.h"
-#include "music/MusicThumbLoader.h"
 #include "pictures/Picture.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
-#include "utils/EmbeddedArt.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -195,14 +193,6 @@ std::unique_ptr<CTexture> CTextureCacheJob::LoadImage(const std::string& image,
                                                       const std::string& additional_info,
                                                       bool requirePixels)
 {
-  if (additional_info == "music")
-  { // special case for embedded music images
-    EmbeddedArt art;
-    if (CMusicThumbLoader::GetEmbeddedThumb(image, art))
-      return CTexture::LoadFromFileInMemory(art.m_data.data(), art.m_size, art.m_mime, width,
-                                            height);
-  }
-
   if (!additional_info.empty())
   {
     IMAGE_FILES::CSpecialImageLoaderFactory specialImageLoader{};

--- a/xbmc/imagefiles/CMakeLists.txt
+++ b/xbmc/imagefiles/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(SOURCES SpecialImageLoaderFactory.cpp)
+
+set(HEADERS SpecialImageFileLoader.h
+            SpecialImageLoaderFactory.h)
+
+core_add_library(imagefiles)

--- a/xbmc/imagefiles/SpecialImageFileLoader.h
+++ b/xbmc/imagefiles/SpecialImageFileLoader.h
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+class CTexture;
+
+namespace IMAGE_FILES
+{
+
+/*!
+ * @brief An interface to load special image files into a texture for the cache.
+ *
+ * Special image files are generated or embedded images, like album covers embedded
+ * in music files or thumbnails generated from video files.
+*/
+class ISpecialImageFileLoader
+{
+public:
+  virtual bool CanLoad(std::string specialType) const = 0;
+  virtual std::unique_ptr<CTexture> Load(std::string specialType,
+                                         std::string filePath,
+                                         unsigned int preferredWidth,
+                                         unsigned int preferredHeight) const = 0;
+  virtual ~ISpecialImageFileLoader() = default;
+};
+
+} // namespace IMAGE_FILES

--- a/xbmc/imagefiles/SpecialImageLoaderFactory.cpp
+++ b/xbmc/imagefiles/SpecialImageLoaderFactory.cpp
@@ -9,6 +9,7 @@
 #include "SpecialImageLoaderFactory.h"
 
 #include "guilib/Texture.h"
+#include "music/MusicEmbeddedImageFileLoader.h"
 #include "video/VideoEmbeddedImageFileLoader.h"
 
 using namespace IMAGE_FILES;
@@ -16,6 +17,7 @@ using namespace IMAGE_FILES;
 CSpecialImageLoaderFactory::CSpecialImageLoaderFactory()
 {
   m_specialImageLoaders[0] = std::make_unique<VIDEO::CVideoEmbeddedImageFileLoader>();
+  m_specialImageLoaders[1] = std::make_unique<MUSIC_INFO::CMusicEmbeddedImageFileLoader>();
 }
 
 std::unique_ptr<CTexture> CSpecialImageLoaderFactory::Load(std::string specialType,

--- a/xbmc/imagefiles/SpecialImageLoaderFactory.cpp
+++ b/xbmc/imagefiles/SpecialImageLoaderFactory.cpp
@@ -9,11 +9,13 @@
 #include "SpecialImageLoaderFactory.h"
 
 #include "guilib/Texture.h"
+#include "video/VideoEmbeddedImageFileLoader.h"
 
 using namespace IMAGE_FILES;
 
 CSpecialImageLoaderFactory::CSpecialImageLoaderFactory()
 {
+  m_specialImageLoaders[0] = std::make_unique<VIDEO::CVideoEmbeddedImageFileLoader>();
 }
 
 std::unique_ptr<CTexture> CSpecialImageLoaderFactory::Load(std::string specialType,

--- a/xbmc/imagefiles/SpecialImageLoaderFactory.cpp
+++ b/xbmc/imagefiles/SpecialImageLoaderFactory.cpp
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "SpecialImageLoaderFactory.h"
+
+#include "guilib/Texture.h"
+
+using namespace IMAGE_FILES;
+
+CSpecialImageLoaderFactory::CSpecialImageLoaderFactory()
+{
+}
+
+std::unique_ptr<CTexture> CSpecialImageLoaderFactory::Load(std::string specialType,
+                                                           std::string filePath,
+                                                           unsigned int preferredWidth,
+                                                           unsigned int preferredHeight) const
+{
+  if (specialType.empty())
+    return {};
+  for (auto& loader : m_specialImageLoaders)
+  {
+    if (loader->CanLoad(specialType))
+    {
+      auto val = loader->Load(specialType, filePath, preferredWidth, preferredHeight);
+      if (val)
+        return val;
+    }
+  }
+  return {};
+}

--- a/xbmc/imagefiles/SpecialImageLoaderFactory.h
+++ b/xbmc/imagefiles/SpecialImageLoaderFactory.h
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "imagefiles/SpecialImageFileLoader.h"
+
+#include <array>
+#include <memory>
+#include <string>
+
+class CTexture;
+
+namespace IMAGE_FILES
+{
+class CSpecialImageLoaderFactory
+{
+public:
+  CSpecialImageLoaderFactory();
+
+  std::unique_ptr<CTexture> Load(std::string specialType,
+                                 std::string filePath,
+                                 unsigned int preferredWidth,
+                                 unsigned int preferredHeight) const;
+
+private:
+  std::array<std::unique_ptr<ISpecialImageFileLoader>, 2> m_specialImageLoaders{};
+};
+} // namespace IMAGE_FILES

--- a/xbmc/music/CMakeLists.txt
+++ b/xbmc/music/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES Album.cpp
             GUIViewStateMusic.cpp
             MusicDatabase.cpp
             MusicDbUrl.cpp
+            MusicEmbeddedImageFileLoader.cpp
             MusicInfoLoader.cpp
             MusicLibraryQueue.cpp
             MusicThumbLoader.cpp
@@ -16,6 +17,7 @@ set(HEADERS Album.h
             GUIViewStateMusic.h
             MusicDatabase.h
             MusicDbUrl.h
+            MusicEmbeddedImageFileLoader.h
             MusicInfoLoader.h
             MusicLibraryQueue.h
             MusicThumbLoader.h

--- a/xbmc/music/MusicEmbeddedImageFileLoader.cpp
+++ b/xbmc/music/MusicEmbeddedImageFileLoader.cpp
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "MusicEmbeddedImageFileLoader.h"
+
+#include "FileItem.h"
+#include "guilib/Texture.h"
+#include "music/tags/ImusicInfoTagLoader.h"
+#include "music/tags/MusicInfoTag.h"
+#include "music/tags/MusicInfoTagLoaderFactory.h"
+#include "utils/EmbeddedArt.h"
+
+using namespace MUSIC_INFO;
+
+bool CMusicEmbeddedImageFileLoader::CanLoad(std::string specialType) const
+{
+  return specialType == "music";
+}
+
+namespace
+{
+bool GetEmbeddedThumb(const std::string& path, EmbeddedArt& art)
+{
+  CFileItem item(path, false);
+  std::unique_ptr<IMusicInfoTagLoader> loader(CMusicInfoTagLoaderFactory::CreateLoader(item));
+  CMusicInfoTag tag;
+  if (loader)
+    loader->Load(path, tag, &art);
+
+  return !art.Empty();
+}
+} // namespace
+
+std::unique_ptr<CTexture> CMusicEmbeddedImageFileLoader::Load(std::string specialType,
+                                                              std::string filePath,
+                                                              unsigned int preferredWidth,
+                                                              unsigned int preferredHeight) const
+{
+  EmbeddedArt art;
+  if (GetEmbeddedThumb(filePath, art))
+    return CTexture::LoadFromFileInMemory(art.m_data.data(), art.m_size, art.m_mime, preferredWidth,
+                                          preferredHeight);
+  return nullptr;
+}

--- a/xbmc/music/MusicEmbeddedImageFileLoader.h
+++ b/xbmc/music/MusicEmbeddedImageFileLoader.h
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "imagefiles/SpecialImageFileLoader.h"
+
+namespace MUSIC_INFO
+{
+
+class CMusicEmbeddedImageFileLoader : public IMAGE_FILES::ISpecialImageFileLoader
+{
+public:
+  CMusicEmbeddedImageFileLoader() = default;
+  ~CMusicEmbeddedImageFileLoader() override = default;
+
+  bool CanLoad(std::string specialType) const override;
+  std::unique_ptr<CTexture> Load(std::string specialType,
+                                 std::string filePath,
+                                 unsigned int preferredWidth,
+                                 unsigned int preferredHeight) const override;
+};
+} // namespace MUSIC_INFO

--- a/xbmc/music/MusicThumbLoader.cpp
+++ b/xbmc/music/MusicThumbLoader.cpp
@@ -12,7 +12,6 @@
 #include "TextureDatabase.h"
 #include "music/infoscanner/MusicInfoScanner.h"
 #include "music/tags/MusicInfoTag.h"
-#include "music/tags/MusicInfoTagLoaderFactory.h"
 #include "utils/StringUtils.h"
 #include "video/VideoThumbLoader.h"
 
@@ -371,15 +370,4 @@ bool CMusicThumbLoader::FillLibraryArt(CFileItem &item)
 
   item.SetProperty("libraryartfilled", true);
   return artfound;
-}
-
-bool CMusicThumbLoader::GetEmbeddedThumb(const std::string &path, EmbeddedArt &art)
-{
-  CFileItem item(path, false);
-  std::unique_ptr<IMusicInfoTagLoader> pLoader (CMusicInfoTagLoaderFactory::CreateLoader(item));
-  CMusicInfoTag tag;
-  if (nullptr != pLoader)
-    pLoader->Load(path, tag, &art);
-
-  return !art.Empty();
 }

--- a/xbmc/music/MusicThumbLoader.h
+++ b/xbmc/music/MusicThumbLoader.h
@@ -51,8 +51,6 @@ public:
    */
   virtual bool FillThumb(CFileItem &item, bool folderThumbs = true);
 
-  static bool GetEmbeddedThumb(const std::string &path, EmbeddedArt &art);
-
 protected:
   CMusicDatabase *m_musicDatabase;
   typedef std::map<int, std::map<std::string, std::string> > ArtCache;

--- a/xbmc/video/CMakeLists.txt
+++ b/xbmc/video/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES Bookmark.cpp
             Teletext.cpp
             VideoDatabase.cpp
             VideoDbUrl.cpp
+            VideoEmbeddedImageFileLoader.cpp
             VideoInfoDownloader.cpp
             VideoInfoScanner.cpp
             VideoInfoTag.cpp
@@ -22,6 +23,7 @@ set(HEADERS Bookmark.h
             TeletextDefines.h
             VideoDatabase.h
             VideoDbUrl.h
+            VideoEmbeddedImageFileLoader.h
             VideoInfoDownloader.h
             VideoInfoScanner.h
             VideoInfoTag.h

--- a/xbmc/video/VideoEmbeddedImageFileLoader.cpp
+++ b/xbmc/video/VideoEmbeddedImageFileLoader.cpp
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "VideoEmbeddedImageFileLoader.h"
+
+#include "FileItem.h"
+#include "guilib/Texture.h"
+#include "utils/EmbeddedArt.h"
+#include "utils/StringUtils.h"
+#include "video/VideoInfoTag.h"
+#include "video/tags/IVideoInfoTagLoader.h"
+#include "video/tags/VideoInfoTagLoaderFactory.h"
+
+using namespace VIDEO;
+
+bool CVideoEmbeddedImageFileLoader::CanLoad(std::string specialType) const
+{
+  return StringUtils::StartsWith(specialType, "video_");
+}
+
+namespace
+{
+bool GetEmbeddedThumb(const std::string& path, const std::string& type, EmbeddedArt& art)
+{
+  CFileItem item(path, false);
+  std::unique_ptr<IVideoInfoTagLoader> loader(
+      CVideoInfoTagLoaderFactory::CreateLoader(item, ADDON::ScraperPtr(), false));
+  CVideoInfoTag tag;
+  std::vector<EmbeddedArt> artv;
+  if (loader)
+    loader->Load(tag, false, &artv);
+
+  for (const auto& it : artv)
+  {
+    if (it.m_type == type)
+    {
+      art = it;
+      break;
+    }
+  }
+  return !art.Empty();
+}
+} // namespace
+
+std::unique_ptr<CTexture> CVideoEmbeddedImageFileLoader::Load(std::string specialType,
+                                                              std::string filePath,
+                                                              unsigned int preferredWidth,
+                                                              unsigned int preferredHeight) const
+{
+  EmbeddedArt art;
+  if (GetEmbeddedThumb(filePath, specialType.substr(6), art))
+    return CTexture::LoadFromFileInMemory(art.m_data.data(), art.m_size, art.m_mime, preferredWidth,
+                                          preferredHeight);
+  return {};
+}

--- a/xbmc/video/VideoEmbeddedImageFileLoader.h
+++ b/xbmc/video/VideoEmbeddedImageFileLoader.h
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "imagefiles/SpecialImageFileLoader.h"
+
+namespace VIDEO
+{
+
+class CVideoEmbeddedImageFileLoader : public IMAGE_FILES::ISpecialImageFileLoader
+{
+public:
+  CVideoEmbeddedImageFileLoader() = default;
+  ~CVideoEmbeddedImageFileLoader() override = default;
+
+  bool CanLoad(std::string specialType) const override;
+  std::unique_ptr<CTexture> Load(std::string specialType,
+                                 std::string filePath,
+                                 unsigned int preferredWidth,
+                                 unsigned int preferredHeight) const override;
+};
+
+} // namespace VIDEO

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -27,13 +27,11 @@
 #include "settings/SettingUtils.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "utils/EmbeddedArt.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
 #include "video/VideoInfoTag.h"
-#include "video/tags/VideoInfoTagLoaderFactory.h"
 
 #include <algorithm>
 #include <cstdlib>
@@ -690,29 +688,6 @@ std::string CVideoThumbLoader::GetEmbeddedThumbURL(const CFileItem &item)
     path = CStackDirectory::GetFirstStackedFile(path);
 
   return CTextureUtils::GetWrappedImageURL(path, "video");
-}
-
-bool CVideoThumbLoader::GetEmbeddedThumb(const std::string& path,
-                                         const std::string& type, EmbeddedArt& art)
-{
-  CFileItem item(path, false);
-  std::unique_ptr<IVideoInfoTagLoader> pLoader;
-  pLoader.reset(CVideoInfoTagLoaderFactory::CreateLoader(item,ADDON::ScraperPtr(),false));
-  CVideoInfoTag tag;
-  std::vector<EmbeddedArt> artv;
-  if (pLoader)
-    pLoader->Load(tag, false, &artv);
-
-  for (const EmbeddedArt& it : artv)
-  {
-    if (it.m_type == type)
-    {
-      art = it;
-      break;
-    }
-  }
-
-  return !art.Empty();
 }
 
 void CVideoThumbLoader::OnJobComplete(unsigned int jobID, bool success, CJob* job)

--- a/xbmc/video/VideoThumbLoader.h
+++ b/xbmc/video/VideoThumbLoader.h
@@ -117,10 +117,6 @@ public:
    */
   void OnJobComplete(unsigned int jobID, bool success, CJob *job) override;
 
-  static bool GetEmbeddedThumb(const std::string& path,
-                               const std::string& type,
-                               EmbeddedArt& art);
-
 protected:
   CVideoDatabase *m_videoDatabase;
   ArtCache m_artCache;


### PR DESCRIPTION
## Description
Build a new interface to "pull" special images, like generated video thumbs `image://video@nfs....`, into the texture cache when displayed, like regular images and embedded music covers.

I moved the embedded music and video images that already behave like this to the new interface.

Adds a new top-level folder **imagefiles** and namespace **IMAGE_FILES**, that I hope to populate with a lot of the TextureCache stuff that exists now as I push and pull it around. I chose not to use the term _texture_ because that seems more useful as a skin / GUI / rendering term, while this is more general. This is also used heavily for remote interfaces - web like Chorus2 and remote apps like Kore. Name borrowed from `CImageFile`, the handler for `image://...` VFS file paths - I tried _imagecache_ for awhile, but this is also more than just caching.

The special images this is meant for are **video**, still image thumbnails generated from videos; **picturefolder**, which are generated grid images for folders viewed in the picture browser; **pvr**, which are generated grid images for channel groups in PVR; and **video chapter thumbnails**. They each have some specific behavior to deal with so I'll work with them in separate PRs. I've also seen hints of _epg_ but I don't know where that is generated yet.

This is a trimmed down and commit-organized version of #23134 to be more reviewable, as requested by lrusak.

## Motivation and context
Consistent behavior: all images load the same way, whether they are already cached or not. Remote interfaces can show these images even if they haven't been viewed in Kodi yet. Kodi doesn't have to pre-cache a potentially massive list of images when browsing folders, _just in case_ they are viewed, saving both storage size in the cache and taking queue time for images actually displayed in the GUI. These special images can now be _preloaded_ the same as other images.

Easier maintenance and development: this provides a clear interface to load more special images, avoids the complication of preloading a big list for this pull-based functionality, loading for view and preloading work just like other images.

## How has this been tested?
I've been dogfooding this as part of #23134 for a month.

## What is the effect on users?
None, this is trimmed down to just a new interface and moving code that already functioned exactly like it.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
