### PR TITLE
[Estuary] MyPVRTimers: Fix visibility of 'next recording' label.

### DIFF
--- a/addons/skin.estuary/xml/MyPVRTimers.xml
+++ b/addons/skin.estuary/xml/MyPVRTimers.xml
@@ -57,29 +57,29 @@
 					<param name="folder_sortorder" value="ascending" />
 				</include>
 			</control>
-		</control>
-		<include content="TopBar">
-			<param name="breadcrumbs_label" value="$VAR[BreadcrumbsPVRTimersVar]" />
-		</include>
-		<include content="BottomBar">
-			<param name="info_visible" value="true" />
-		</include>
-		<control type="label">
-			<right>20</right>
-			<include>OpenClose_Right</include>
-			<bottom>10</bottom>
-			<width>850</width>
-			<height>60</height>
-			<label>$INFO[PVR.NextTimer]</label>
-			<shadowcolor>black</shadowcolor>
-			<align>right</align>
-			<aligny>center</aligny>
-			<wrapmultiline>true</wrapmultiline>
-			<font>font27</font>
-		</control>
-		<control type="group">
-			<include>MediaMenuCommon</include>
-			<include>PVRSideBar</include>
+			<include content="TopBar">
+				<param name="breadcrumbs_label" value="$VAR[BreadcrumbsPVRTimersVar]" />
+			</include>
+			<include content="BottomBar">
+				<param name="info_visible" value="true" />
+			</include>
+			<control type="label">
+				<right>20</right>
+				<include>OpenClose_Right</include>
+				<bottom>10</bottom>
+				<width>850</width>
+				<height>60</height>
+				<label>$INFO[PVR.NextTimer]</label>
+				<shadowcolor>black</shadowcolor>
+				<align>right</align>
+				<aligny>center</aligny>
+				<wrapmultiline>true</wrapmultiline>
+				<font>font27</font>
+			</control>
+			<control type="group">
+				<include>MediaMenuCommon</include>
+				<include>PVRSideBar</include>
+			</control>
 		</control>
 		<control type="label" id="29">
 			<font></font>


### PR DESCRIPTION
"Next recording on" label should only appear in the "Timers" window and not in any dialog put on top of it.

***Timers window***

![screenshot00003](https://user-images.githubusercontent.com/3226626/234192263-7116e2ec-246d-4436-9228-e5c91a1c013a.png)

***Before: Programme info dialog on top of Timers window***

![screenshot00002](https://user-images.githubusercontent.com/3226626/234192284-86e8b873-00ce-4717-84a5-5a5f430643b3.png)

***After: Programme info dialog on top of Timers window***

![screenshot00004](https://user-images.githubusercontent.com/3226626/234192254-b0ae29d1-df83-40aa-b8a6-5b70b60431cd.png)

How to reproduce:
1) Open Timers window
2) Open the context menu of any timer
3) Select "Programme informatiom" context menu item

@jjd-uk can you please review.