### PR TITLE
[Windows] fix thread names in debugger / crash dumps

### DIFF
--- a/xbmc/platform/win32/WIN32Util.h
+++ b/xbmc/platform/win32/WIN32Util.h
@@ -84,4 +84,11 @@ public:
 
   static VideoDriverInfo GetVideoDriverInfo(const UINT vendorId, const std::wstring& driverDesc);
   static std::wstring GetDisplayFriendlyName(const std::wstring& GdiDeviceName);
+  /*!
+   * \brief Set the thread name using SetThreadDescription when available
+   * \param handle handle of the thread
+   * \param name name of the thread
+   * \return true if the name was successfully set, false otherwise (API not supported or API failure)
+   */
+  static bool SetThreadName(const HANDLE handle, const std::string& name);
 };

--- a/xbmc/platform/win32/threads/ThreadImplWin.cpp
+++ b/xbmc/platform/win32/threads/ThreadImplWin.cpp
@@ -67,14 +67,14 @@ void CThreadImplWin::SetThreadInfo(const std::string& name)
   {
     DWORD dwType; // must be 0x1000
     LPCSTR szName; // pointer to name (in same addr space)
-    DWORD dwThreadID; // thread ID (-1 caller thread)
-    DWORD dwFlags; // reserved for future use, most be zero
+    DWORD dwThreadID; // thread ID (-1 = caller thread)
+    DWORD dwFlags; // reserved for future use, must be zero
   } info;
 #pragma pack(pop)
 
   info.dwType = 0x1000;
   info.szName = name.c_str();
-  info.dwThreadID = reinterpret_cast<std::uintptr_t>(m_handle);
+  info.dwThreadID = GetThreadId(static_cast<HANDLE>(m_handle));
   info.dwFlags = 0;
 
   __try

--- a/xbmc/platform/win32/threads/ThreadImplWin.cpp
+++ b/xbmc/platform/win32/threads/ThreadImplWin.cpp
@@ -60,29 +60,34 @@ CThreadImplWin::CThreadImplWin(std::thread::native_handle_type handle) : IThread
 
 void CThreadImplWin::SetThreadInfo(const std::string& name)
 {
-  const unsigned int MS_VC_EXCEPTION = 0x406d1388;
-
-#pragma pack(push,8)
-  struct THREADNAME_INFO
+  // Modern way to name threads first (Windows 10 1607 and above)
+  if (!CWIN32Util::SetThreadName(static_cast<HANDLE>(m_handle), name))
   {
-    DWORD dwType; // must be 0x1000
-    LPCSTR szName; // pointer to name (in same addr space)
-    DWORD dwThreadID; // thread ID (-1 = caller thread)
-    DWORD dwFlags; // reserved for future use, must be zero
-  } info;
+    // Fallback on legacy method - specially configured exception
+    const unsigned int MS_VC_EXCEPTION = 0x406d1388;
+
+#pragma pack(push, 8)
+    struct THREADNAME_INFO
+    {
+      DWORD dwType; // must be 0x1000
+      LPCSTR szName; // pointer to name (in same addr space)
+      DWORD dwThreadID; // thread ID (-1 = caller thread)
+      DWORD dwFlags; // reserved for future use, must be zero
+    } info;
 #pragma pack(pop)
 
-  info.dwType = 0x1000;
-  info.szName = name.c_str();
-  info.dwThreadID = GetThreadId(static_cast<HANDLE>(m_handle));
-  info.dwFlags = 0;
+    info.dwType = 0x1000;
+    info.szName = name.c_str();
+    info.dwThreadID = GetThreadId(static_cast<HANDLE>(m_handle));
+    info.dwFlags = 0;
 
-  __try
-  {
-    RaiseException(MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(ULONG_PTR), (ULONG_PTR *)&info);
-  }
-  __except(EXCEPTION_EXECUTE_HANDLER)
-  {
+    __try
+    {
+      RaiseException(MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(ULONG_PTR), (ULONG_PTR*)&info);
+    }
+    __except (EXCEPTION_EXECUTE_HANDLER)
+    {
+    }
   }
 
   CWIN32Util::SetThreadLocalLocale(true); // avoid crashing with setlocale(), see https://connect.microsoft.com/VisualStudio/feedback/details/794122

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -682,17 +682,25 @@ std::string CSysInfo::GetOsPrettyNameWithVersion(void)
         osNameVer.append("Server 2012 R2");
       break;
     case WindowsVersionWin10:
+    case WindowsVersionWin10_1607:
     case WindowsVersionWin10_1709:
     case WindowsVersionWin10_1803:
     case WindowsVersionWin10_1809:
     case WindowsVersionWin10_1903:
     case WindowsVersionWin10_1909:
     case WindowsVersionWin10_2004:
+    case WindowsVersionWin10_20H2:
+    case WindowsVersionWin10_21H1:
+    case WindowsVersionWin10_21H2:
+    case WindowsVersionWin10_22H2:
+
     case WindowsVersionWin10_Future:
       osNameVer.append("10");
       appendWindows10NameVersion(osNameVer);
       break;
-    case WindowsVersionWin11:
+    case WindowsVersionWin11_21H2:
+    case WindowsVersionWin11_22H2:
+    case WindowsVersionWin11_Future:
       osNameVer.append("11");
       appendWindows10NameVersion(osNameVer);
       break;
@@ -855,8 +863,10 @@ CSysInfo::WindowsVersion CSysInfo::GetWindowsVersion()
     {
       if (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion == 3)
         m_WinVer = WindowsVersionWin8_1;
-      else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber < 16299)
+      else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber < 14393)
         m_WinVer = WindowsVersionWin10;
+      else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber == 14393)
+        m_WinVer = WindowsVersionWin10_1607;
       else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber == 16299)
         m_WinVer = WindowsVersionWin10_1709;
       else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber == 17134)
@@ -869,9 +879,21 @@ CSysInfo::WindowsVersion CSysInfo::GetWindowsVersion()
         m_WinVer = WindowsVersionWin10_1909;
       else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber == 19041)
         m_WinVer = WindowsVersionWin10_2004;
-      else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber >= 22000)
-        m_WinVer = WindowsVersionWin11;
-      else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber > 19041)
+      else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber == 19042)
+        m_WinVer = WindowsVersionWin10_20H2;
+      else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber == 19043)
+        m_WinVer = WindowsVersionWin10_21H1;
+      else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber == 19044)
+        m_WinVer = WindowsVersionWin10_21H2;
+      else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber == 19045)
+        m_WinVer = WindowsVersionWin10_22H2;
+      else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber == 22000)
+        m_WinVer = WindowsVersionWin11_21H2;
+      else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber == 22621)
+        m_WinVer = WindowsVersionWin11_22H2;
+      else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber > 22621)
+        m_WinVer = WindowsVersionWin11_Future;
+      else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber > 19045)
         m_WinVer = WindowsVersionWin10_Future;
       /* Insert checks for new Windows versions here */
       else if ( (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion > 3) || osvi.dwMajorVersion > 10)

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -71,19 +71,28 @@ class CSysInfo : public CInfoLoader, public ISubSettings
 public:
   enum WindowsVersion
   {
+    // clang-format off
     WindowsVersionUnknown = -1, // Undetected, unsupported Windows version or OS in not Windows
-    WindowsVersionWin8_1, // Windows 8.1, Windows Server 2012 R2
+    WindowsVersionWin8_1,       // Windows 8.1, Windows Server 2012 R2
     WindowsVersionWin10,        // Windows 10
+    WindowsVersionWin10_1607,   // Windows 10 1607
     WindowsVersionWin10_1709,   // Windows 10 1709 (FCU)
     WindowsVersionWin10_1803,   // Windows 10 1803
     WindowsVersionWin10_1809,   // Windows 10 1809
     WindowsVersionWin10_1903,   // Windows 10 1903
     WindowsVersionWin10_1909,   // Windows 10 1909
     WindowsVersionWin10_2004,   // Windows 10 2004
+    WindowsVersionWin10_20H2,   // Windows 10 20H2
+    WindowsVersionWin10_21H1,   // Windows 10 21H1
+    WindowsVersionWin10_21H2,   // Windows 10 21H2
+    WindowsVersionWin10_22H2,   // Windows 10 22H2
     WindowsVersionWin10_Future, // Windows 10 future build
-    WindowsVersionWin11,        // Windows 11
+    WindowsVersionWin11_21H2,   // Windows 11 21H2 - Sun Valley
+    WindowsVersionWin11_22H2,   // Windows 11 22H2 - Sun Valley 2
+    WindowsVersionWin11_Future, // Windows 11 future build
     /* Insert new Windows versions here, when they'll be known */
     WindowsVersionFuture = 100  // Future Windows version, not known to code
+    // clang-format on
   };
   enum WindowsDeviceFamily
   {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Fixed up / updated the way thread names are set so they can be seen in the debugger.

* The legacy method used by Kodi so far needed a thread id instead of a thread handle (all Windows platforms)

* Added the modern method SetThreadDescription available with Windows 10 1607 and above. The new method adds a few niceties, see https://learn.microsoft.com/en-us/visualstudio/debugger/how-to-set-a-thread-name-in-native-code?view=vs-2022
  * Both method can coexist, but might as well use only the new one when available, with fallback to the legacy method.
  * The new method requires dynamic loading as the function does not exist in older versions of Windows
To avoid impacting performance, LoadLibrary/GetProcAddress is done once and a cached pointer is used for every new thread. Could be simplified if thread creation time is a non-issue.

  * No support added for UWP (covered by legacy method). I'm not familiar with Win RT and didn't find an equivalent that didn't require bundling KernelBase.dll with the app, most likely not a good idea.

* Had to define new Windows builds in order to detect Windows 10 1607 properly

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Generic thread names in the debugger make debugging more difficult.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 10 22H2 x64 and UWP x64. With old method and new method enabled selectively by special code not included in PR.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
none
## Screenshots (if appropriate):
Before, generic names assigned by Visual Studio:
![image](https://user-images.githubusercontent.com/489377/234442213-a3f3bca6-17e1-4ab6-84dd-d717e05eef33.png)

After, Kodi specified names:
![image](https://user-images.githubusercontent.com/489377/234436379-b8546118-bc5b-4778-bed1-e389e0b56e81.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
