### PR TITLE
Revert "CWinSystemGbm: don't require a modeset when setting HDR metadata"

### DIFF
--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -349,6 +349,7 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
     if (connector->SupportsProperty("HDR_OUTPUT_METADATA"))
     {
       drm->AddProperty(connector, "HDR_OUTPUT_METADATA", 0);
+      drm->SetActive(true);
 
       if (m_hdr_blob_id)
         drmModeDestroyPropertyBlob(drm->GetFileDescriptor(), m_hdr_blob_id);
@@ -438,6 +439,7 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
     }
 
     drm->AddProperty(connector, "HDR_OUTPUT_METADATA", m_hdr_blob_id);
+    drm->SetActive(true);
   }
 
   return true;


### PR DESCRIPTION
This reverts #23116 

The original PR wasn't tested properly and actually breaks HDR activation. Let's revert it for now.