### PR TITLE
Implement subtitle 24/25fps frame rate correction

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23789,6 +23789,17 @@ msgctxt "#39201"
 msgid "HDR10+"
 msgstr ""
 
+#: xbmc/dialogs/GUIDialogSubtitles.cpp
+msgctxt "#39202"
+msgid "Subtitle frame rate correction"
+msgstr ""
+
+#: xbmc/dialogs/GUIDialogSubtitles.cpp
+msgctxt "#39203"
+msgid "Same as video"
+msgstr ""
+
+
 # 40000 to 40800 are reserved for Video Versions feature
 
 #. Generic video versions label (plural)

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23791,12 +23791,7 @@ msgstr ""
 
 #: xbmc/dialogs/GUIDialogSubtitles.cpp
 msgctxt "#39202"
-msgid "Subtitle frame rate correction"
-msgstr ""
-
-#: xbmc/dialogs/GUIDialogSubtitles.cpp
-msgctxt "#39203"
-msgid "Same as video"
+msgid "Fix 24/25 fps mismatch"
 msgstr ""
 
 

--- a/xbmc/application/ApplicationPlayer.cpp
+++ b/xbmc/application/ApplicationPlayer.cpp
@@ -737,11 +737,19 @@ void CApplicationPlayer::SetSubTitleDelay(float fValue)
     player->SetSubTitleDelay(fValue);
 }
 
-void CApplicationPlayer::SetSubtitleFPS(SubtitleFPS value)
+void CApplicationPlayer::SetSubtitleCompensateFPS(bool bValue)
 {
   std::shared_ptr<IPlayer> player = GetInternal();
   if (player)
-    player->SetSubtitleFPS(value);
+    player->SetSubtitleCompensateFPS(bValue);
+}
+
+bool CApplicationPlayer::GetSubtitleCompensateFPS() const
+{
+  std::shared_ptr<const IPlayer> player = GetInternal();
+  if (player)
+    return player->GetSubtitleCompensateFPS();
+  return false;
 }
 
 void CApplicationPlayer::SetAVDelay(float fValue)

--- a/xbmc/application/ApplicationPlayer.cpp
+++ b/xbmc/application/ApplicationPlayer.cpp
@@ -737,6 +737,13 @@ void CApplicationPlayer::SetSubTitleDelay(float fValue)
     player->SetSubTitleDelay(fValue);
 }
 
+void CApplicationPlayer::SetSubtitleFPS(ESUBTITLEFPS value)
+{
+  std::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->SetSubtitleFPS(value);
+}
+
 void CApplicationPlayer::SetAVDelay(float fValue)
 {
   std::shared_ptr<IPlayer> player = GetInternal();
@@ -765,7 +772,8 @@ void CApplicationPlayer::GetAudioCapabilities(std::vector<int>& audioCaps) const
     player->GetAudioCapabilities(audioCaps);
 }
 
-void CApplicationPlayer::GetSubtitleCapabilities(std::vector<int>& subCaps) const
+void CApplicationPlayer::GetSubtitleCapabilities(
+    std::vector<IPlayerSubtitleCapabilities>& subCaps) const
 {
   const std::shared_ptr<const IPlayer> player = GetInternal();
   if (player)

--- a/xbmc/application/ApplicationPlayer.cpp
+++ b/xbmc/application/ApplicationPlayer.cpp
@@ -737,7 +737,7 @@ void CApplicationPlayer::SetSubTitleDelay(float fValue)
     player->SetSubTitleDelay(fValue);
 }
 
-void CApplicationPlayer::SetSubtitleFPS(ESUBTITLEFPS value)
+void CApplicationPlayer::SetSubtitleFPS(SubtitleFPS value)
 {
   std::shared_ptr<IPlayer> player = GetInternal();
   if (player)

--- a/xbmc/application/ApplicationPlayer.h
+++ b/xbmc/application/ApplicationPlayer.h
@@ -95,8 +95,9 @@ public:
   std::string GetPlayerState();
   PLAYLIST::Id GetPreferredPlaylist() const;
   int GetSubtitleDelay() const;
+  ESUBTITLEFPS GetSubtitleFPS() const;
   int GetSubtitle();
-  void GetSubtitleCapabilities(std::vector<int>& subCaps) const;
+  void GetSubtitleCapabilities(std::vector<IPlayerSubtitleCapabilities>& subCaps) const;
   int GetSubtitleCount() const;
   void GetSubtitleStreamInfo(int index, SubtitleStreamInfo& info) const;
   bool GetSubtitleVisible() const;
@@ -152,6 +153,7 @@ public:
   bool SetPlayerState(const std::string& state);
   void SetSubtitle(int iStream);
   void SetSubTitleDelay(float fValue = 0.0f);
+  void SetSubtitleFPS(ESUBTITLEFPS value);
   void SetSubtitleVisible(bool bVisible);
 
   /*!

--- a/xbmc/application/ApplicationPlayer.h
+++ b/xbmc/application/ApplicationPlayer.h
@@ -95,7 +95,7 @@ public:
   std::string GetPlayerState();
   PLAYLIST::Id GetPreferredPlaylist() const;
   int GetSubtitleDelay() const;
-  ESUBTITLEFPS GetSubtitleFPS() const;
+  SubtitleFPS GetSubtitleFPS() const;
   int GetSubtitle();
   void GetSubtitleCapabilities(std::vector<IPlayerSubtitleCapabilities>& subCaps) const;
   int GetSubtitleCount() const;
@@ -153,7 +153,7 @@ public:
   bool SetPlayerState(const std::string& state);
   void SetSubtitle(int iStream);
   void SetSubTitleDelay(float fValue = 0.0f);
-  void SetSubtitleFPS(ESUBTITLEFPS value);
+  void SetSubtitleFPS(SubtitleFPS value);
   void SetSubtitleVisible(bool bVisible);
 
   /*!

--- a/xbmc/application/ApplicationPlayer.h
+++ b/xbmc/application/ApplicationPlayer.h
@@ -95,7 +95,7 @@ public:
   std::string GetPlayerState();
   PLAYLIST::Id GetPreferredPlaylist() const;
   int GetSubtitleDelay() const;
-  SubtitleFPS GetSubtitleFPS() const;
+  bool GetSubtitleCompensateFPS() const;
   int GetSubtitle();
   void GetSubtitleCapabilities(std::vector<IPlayerSubtitleCapabilities>& subCaps) const;
   int GetSubtitleCount() const;
@@ -153,7 +153,7 @@ public:
   bool SetPlayerState(const std::string& state);
   void SetSubtitle(int iStream);
   void SetSubTitleDelay(float fValue = 0.0f);
-  void SetSubtitleFPS(SubtitleFPS value);
+  void SetSubtitleCompensateFPS(bool bDoCompensate = false);
   void SetSubtitleVisible(bool bVisible);
 
   /*!

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -64,7 +64,8 @@ enum IPlayerSubtitleCapabilities
   IPC_SUBS_ALL,
   IPC_SUBS_SELECT,
   IPC_SUBS_EXTERNAL,
-  IPC_SUBS_OFFSET
+  IPC_SUBS_OFFSET,
+  IPC_SUBS_STRETCH
 };
 
 enum ERENDERFEATURE
@@ -117,6 +118,8 @@ public:
 
   virtual void SetSubTitleDelay(float fValue = 0.0f) {}
   virtual float GetSubTitleDelay()    { return 0.0f; }
+  virtual void SetSubtitleFPS(ESUBTITLEFPS value = ST_FPS_SAME) {}
+  virtual ESUBTITLEFPS GetSubtitleFPS() { return ST_FPS_SAME; }
   virtual int GetSubtitleCount() const { return 0; }
   virtual int  GetSubtitle()          { return -1; }
   virtual void GetSubtitleStreamInfo(int index, SubtitleStreamInfo& info) const {}
@@ -217,7 +220,7 @@ public:
   /*!
    \brief define the subtitle capabilities of the player
    */
-  virtual void GetSubtitleCapabilities(std::vector<int>& subCaps) const
+  virtual void GetSubtitleCapabilities(std::vector<IPlayerSubtitleCapabilities>& subCaps) const
   {
     subCaps.assign(1, IPC_SUBS_ALL);
   }

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -118,8 +118,8 @@ public:
 
   virtual void SetSubTitleDelay(float fValue = 0.0f) {}
   virtual float GetSubTitleDelay()    { return 0.0f; }
-  virtual void SetSubtitleFPS(SubtitleFPS value = SubtitleFPS::SAME) {}
-  virtual SubtitleFPS GetSubtitleFPS() { return SubtitleFPS::SAME; }
+  virtual void SetSubtitleCompensateFPS(bool bValue = false) {}
+  virtual bool GetSubtitleCompensateFPS() const { return false; }
   virtual int GetSubtitleCount() const { return 0; }
   virtual int  GetSubtitle()          { return -1; }
   virtual void GetSubtitleStreamInfo(int index, SubtitleStreamInfo& info) const {}

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -118,8 +118,8 @@ public:
 
   virtual void SetSubTitleDelay(float fValue = 0.0f) {}
   virtual float GetSubTitleDelay()    { return 0.0f; }
-  virtual void SetSubtitleFPS(ESUBTITLEFPS value = ST_FPS_SAME) {}
-  virtual ESUBTITLEFPS GetSubtitleFPS() { return ST_FPS_SAME; }
+  virtual void SetSubtitleFPS(SubtitleFPS value = SubtitleFPS::SAME) {}
+  virtual SubtitleFPS GetSubtitleFPS() { return SubtitleFPS::SAME; }
   virtual int GetSubtitleCount() const { return 0; }
   virtual int  GetSubtitle()          { return -1; }
   virtual void GetSubtitleStreamInfo(int index, SubtitleStreamInfo& info) const {}

--- a/xbmc/cores/VideoPlayer/IVideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/IVideoPlayer.h
@@ -88,8 +88,8 @@ public:
   virtual bool IsSubtitleEnabled() = 0;
   virtual double GetSubtitleDelay() = 0;
   virtual void SetSubtitleDelay(double delay) = 0;
-  virtual double GetSubtitleFPS() = 0;
-  virtual void SetSubtitleFPS(double fps) = 0;
+  virtual bool GetSubtitleCompensateFPS() const = 0;
+  virtual void SetSubtitleCompensateFPS(bool bDoCompensate) = 0;
   bool IsStalled() const override = 0;
   virtual bool IsRewindStalled() const { return false; }
   virtual double GetCurrentPts() = 0;

--- a/xbmc/cores/VideoPlayer/IVideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/IVideoPlayer.h
@@ -88,6 +88,8 @@ public:
   virtual bool IsSubtitleEnabled() = 0;
   virtual double GetSubtitleDelay() = 0;
   virtual void SetSubtitleDelay(double delay) = 0;
+  virtual double GetSubtitleFPS() = 0;
+  virtual void SetSubtitleFPS(double fps) = 0;
   bool IsStalled() const override = 0;
   virtual bool IsRewindStalled() const { return false; }
   virtual double GetCurrentPts() = 0;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3347,24 +3347,24 @@ float CVideoPlayer::GetSubTitleDelay()
   return (float) -m_VideoPlayerVideo->GetSubtitleDelay() / DVD_TIME_BASE;
 }
 
-void CVideoPlayer::SetSubtitleFPS(ESUBTITLEFPS value)
+void CVideoPlayer::SetSubtitleFPS(SubtitleFPS value)
 {
-  m_processInfo->GetVideoSettingsLocked().SetSubtitleFPS(value);
   double dValue = 0.0;
-  if (value != ST_FPS_SAME)
+  if (value != SubtitleFPS::SAME)
     dValue = ((int)value) / 1000.0;
+  m_processInfo->GetVideoSettingsLocked().SetSubtitleFPS(dValue);
   m_VideoPlayerVideo->SetSubtitleFPS(dValue);
 }
 
-ESUBTITLEFPS CVideoPlayer::GetSubtitleFPS()
+SubtitleFPS CVideoPlayer::GetSubtitleFPS()
 {
   // return m_processInfo->GetVideoSettings().m_subtitleFPS;
   double dValue = m_VideoPlayerVideo->GetSubtitleFPS();
   // simplistic implementation, could properly have acceptance ranges for each setting or such
   if (dValue == 0.0)
-    return ST_FPS_SAME;
+    return SubtitleFPS::SAME;
   else
-    return static_cast<ESUBTITLEFPS>((int)(dValue * 1000.0));
+    return static_cast<SubtitleFPS>((int)(dValue * 1000.0));
 }
 
 bool CVideoPlayer::GetSubtitleVisible() const

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3347,24 +3347,15 @@ float CVideoPlayer::GetSubTitleDelay()
   return (float) -m_VideoPlayerVideo->GetSubtitleDelay() / DVD_TIME_BASE;
 }
 
-void CVideoPlayer::SetSubtitleFPS(SubtitleFPS value)
+void CVideoPlayer::SetSubtitleCompensateFPS(bool bDoCompensate)
 {
-  double dValue = 0.0;
-  if (value != SubtitleFPS::SAME)
-    dValue = ((int)value) / 1000.0;
-  m_processInfo->GetVideoSettingsLocked().SetSubtitleFPS(dValue);
-  m_VideoPlayerVideo->SetSubtitleFPS(dValue);
+  m_processInfo->GetVideoSettingsLocked().SetSubtitleCompensateFPS(bDoCompensate);
+  m_VideoPlayerVideo->SetSubtitleCompensateFPS(bDoCompensate);
 }
 
-SubtitleFPS CVideoPlayer::GetSubtitleFPS()
+bool CVideoPlayer::GetSubtitleCompensateFPS() const
 {
-  // return m_processInfo->GetVideoSettings().m_subtitleFPS;
-  double dValue = m_VideoPlayerVideo->GetSubtitleFPS();
-  // simplistic implementation, could properly have acceptance ranges for each setting or such
-  if (dValue == 0.0)
-    return SubtitleFPS::SAME;
-  else
-    return static_cast<SubtitleFPS>((int)(dValue * 1000.0));
+  return m_VideoPlayerVideo->GetSubtitleCompensateFPS();
 }
 
 bool CVideoPlayer::GetSubtitleVisible() const

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3347,6 +3347,26 @@ float CVideoPlayer::GetSubTitleDelay()
   return (float) -m_VideoPlayerVideo->GetSubtitleDelay() / DVD_TIME_BASE;
 }
 
+void CVideoPlayer::SetSubtitleFPS(ESUBTITLEFPS value)
+{
+  m_processInfo->GetVideoSettingsLocked().SetSubtitleFPS(value);
+  double dValue = 0.0;
+  if (value != ST_FPS_SAME)
+    dValue = ((int)value) / 1000.0;
+  m_VideoPlayerVideo->SetSubtitleFPS(dValue);
+}
+
+ESUBTITLEFPS CVideoPlayer::GetSubtitleFPS()
+{
+  // return m_processInfo->GetVideoSettings().m_subtitleFPS;
+  double dValue = m_VideoPlayerVideo->GetSubtitleFPS();
+  // simplistic implementation, could properly have acceptance ranges for each setting or such
+  if (dValue == 0.0)
+    return ST_FPS_SAME;
+  else
+    return static_cast<ESUBTITLEFPS>((int)(dValue * 1000.0));
+}
+
 bool CVideoPlayer::GetSubtitleVisible() const
 {
   if (m_pInputStream && m_pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD))

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -282,8 +282,8 @@ public:
 
   void SetSubTitleDelay(float fValue = 0.0f) override;
   float GetSubTitleDelay() override;
-  void SetSubtitleFPS(SubtitleFPS value) override;
-  SubtitleFPS GetSubtitleFPS() override;
+  void SetSubtitleCompensateFPS(bool bValue) override;
+  bool GetSubtitleCompensateFPS() const override;
   int GetSubtitleCount() const override;
   int GetSubtitle() override;
   void GetSubtitleStreamInfo(int index, SubtitleStreamInfo& info) const override;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -282,6 +282,8 @@ public:
 
   void SetSubTitleDelay(float fValue = 0.0f) override;
   float GetSubTitleDelay() override;
+  void SetSubtitleFPS(ESUBTITLEFPS value) override;
+  ESUBTITLEFPS GetSubtitleFPS() override;
   int GetSubtitleCount() const override;
   int GetSubtitle() override;
   void GetSubtitleStreamInfo(int index, SubtitleStreamInfo& info) const override;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -282,8 +282,8 @@ public:
 
   void SetSubTitleDelay(float fValue = 0.0f) override;
   float GetSubTitleDelay() override;
-  void SetSubtitleFPS(ESUBTITLEFPS value) override;
-  ESUBTITLEFPS GetSubtitleFPS() override;
+  void SetSubtitleFPS(SubtitleFPS value) override;
+  SubtitleFPS GetSubtitleFPS() override;
   int GetSubtitleCount() const override;
   int GetSubtitle() override;
   void GetSubtitleStreamInfo(int index, SubtitleStreamInfo& info) const override;

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -804,7 +804,8 @@ void CVideoPlayerVideo::Flush(bool sync)
 void CVideoPlayerVideo::ProcessOverlays(const VideoPicture* pSource, double pts)
 {
   double pts1 = pts;
-  if (m_subtitleCompensateFPS) {
+  if (m_subtitleCompensateFPS)
+  {
     double stFrameRate = m_fFrameRate;
     while (stFrameRate > 44.0)
       stFrameRate /= 2.0;
@@ -814,7 +815,7 @@ void CVideoPlayerVideo::ProcessOverlays(const VideoPicture* pSource, double pts)
       // in the ultra-rare cases of true 24.0 fps, it's still only a 86 frames
       // = ~ 3.6 seconds difference per hour, something I feel one could deal
       // with using the subtitle offset feature if need be.
-      pts1 = pts * (stFrameRate / 23.976); 
+      pts1 = pts * (stFrameRate / 23.976);
     else // 24 fps material, compensate 25fps subtitles
       pts1 = pts * (stFrameRate / 25.0);
   }

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -63,6 +63,7 @@ CVideoPlayerVideo::CVideoPlayerVideo(CDVDClock* pClock
   m_paused = false;
   m_syncState = IDVDStreamPlayer::SYNC_STARTING;
   m_iSubtitleDelay = 0;
+  m_subtitleFPS = 0.0;
   m_iLateFrames = 0;
   m_iDroppedRequest = 0;
   m_fForcedAspectRatio = 0;
@@ -802,9 +803,11 @@ void CVideoPlayerVideo::Flush(bool sync)
 
 void CVideoPlayerVideo::ProcessOverlays(const VideoPicture* pSource, double pts)
 {
+  double pts1 = (m_subtitleFPS == 0.0) ? pts : pts * (m_fFrameRate / m_subtitleFPS);
+
   // remove any overlays that are out of time
   if (m_syncState == IDVDStreamPlayer::SYNC_INSYNC)
-    m_pOverlayContainer->CleanUp(pts - m_iSubtitleDelay);
+    m_pOverlayContainer->CleanUp(pts1 - m_iSubtitleDelay);
 
   VecOverlays overlays;
 
@@ -822,7 +825,7 @@ void CVideoPlayerVideo::ProcessOverlays(const VideoPicture* pSource, double pts)
       if(!pOverlay->bForced && !m_bRenderSubs)
         continue;
 
-      double pts2 = pOverlay->bForced ? pts : pts - m_iSubtitleDelay;
+      double pts2 = pOverlay->bForced ? pts1 : pts1 - m_iSubtitleDelay;
 
       if((pOverlay->iPTSStartTime <= pts2 && (pOverlay->iPTSStopTime > pts2 || pOverlay->iPTSStopTime == 0LL)))
       {
@@ -837,7 +840,7 @@ void CVideoPlayerVideo::ProcessOverlays(const VideoPicture* pSource, double pts)
 
     for(it = overlays.begin(); it != overlays.end(); ++it)
     {
-      double pts2 = (*it)->bForced ? pts : pts - m_iSubtitleDelay;
+      double pts2 = (*it)->bForced ? pts1 : pts1 - m_iSubtitleDelay;
       m_renderManager.AddOverlay(*it, pts2);
     }
   }

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
@@ -65,6 +65,8 @@ public:
   bool IsSubtitleEnabled() override { return m_bRenderSubs; }
   double GetSubtitleDelay() override { return m_iSubtitleDelay; }
   void SetSubtitleDelay(double delay) override { m_iSubtitleDelay = delay; }
+  double GetSubtitleFPS() override { return m_subtitleFPS; }
+  void SetSubtitleFPS(double fps) override { m_subtitleFPS = fps; }
   bool IsStalled() const override { return m_stalled; }
   bool IsRewindStalled() const override { return m_rewindStalled; }
   double GetCurrentPts() override;
@@ -105,6 +107,7 @@ protected:
   int CalcDropRequirement(double pts);
 
   double m_iSubtitleDelay;
+  double m_subtitleFPS;
 
   int m_iLateFrames;
   int m_iDroppedFrames;

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
@@ -66,7 +66,10 @@ public:
   double GetSubtitleDelay() override { return m_iSubtitleDelay; }
   void SetSubtitleDelay(double delay) override { m_iSubtitleDelay = delay; }
   bool GetSubtitleCompensateFPS() const override { return m_subtitleCompensateFPS; }
-  void SetSubtitleCompensateFPS(bool bDoCompensate) override { m_subtitleCompensateFPS = bDoCompensate; }
+  void SetSubtitleCompensateFPS(bool bDoCompensate) override
+  {
+    m_subtitleCompensateFPS = bDoCompensate;
+  }
   bool IsStalled() const override { return m_stalled; }
   bool IsRewindStalled() const override { return m_rewindStalled; }
   double GetCurrentPts() override;

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
@@ -65,8 +65,8 @@ public:
   bool IsSubtitleEnabled() override { return m_bRenderSubs; }
   double GetSubtitleDelay() override { return m_iSubtitleDelay; }
   void SetSubtitleDelay(double delay) override { m_iSubtitleDelay = delay; }
-  double GetSubtitleFPS() override { return m_subtitleFPS; }
-  void SetSubtitleFPS(double fps) override { m_subtitleFPS = fps; }
+  bool GetSubtitleCompensateFPS() const override { return m_subtitleCompensateFPS; }
+  void SetSubtitleCompensateFPS(bool bDoCompensate) override { m_subtitleCompensateFPS = bDoCompensate; }
   bool IsStalled() const override { return m_stalled; }
   bool IsRewindStalled() const override { return m_rewindStalled; }
   double GetCurrentPts() override;
@@ -107,7 +107,7 @@ protected:
   int CalcDropRequirement(double pts);
 
   double m_iSubtitleDelay;
-  double m_subtitleFPS;
+  bool m_subtitleCompensateFPS;
 
   int m_iLateFrames;
   int m_iDroppedFrames;

--- a/xbmc/cores/VideoSettings.cpp
+++ b/xbmc/cores/VideoSettings.cpp
@@ -24,7 +24,7 @@ CVideoSettings::CVideoSettings()
   m_AudioStream = -1;
   m_SubtitleStream = -1;
   m_SubtitleDelay = 0.0f;
-  m_subtitleFPS = 0.0;
+  m_subtitleCompensateFPS = false;
   m_subtitleVerticalPosition = 0;
   m_subtitleVerticalPositionSave = false;
   m_SubtitleOn = true;
@@ -58,7 +58,7 @@ bool CVideoSettings::operator!=(const CVideoSettings &right) const
   if (m_AudioStream != right.m_AudioStream) return true;
   if (m_SubtitleStream != right.m_SubtitleStream) return true;
   if (m_SubtitleDelay != right.m_SubtitleDelay) return true;
-  if (m_subtitleFPS != right.m_subtitleFPS)
+  if (m_subtitleCompensateFPS != right.m_subtitleCompensateFPS)
     return true;
   if (m_subtitleVerticalPosition != right.m_subtitleVerticalPosition)
     return true;
@@ -128,10 +128,10 @@ void CVideoSettingsLocked::SetSubtitleDelay(float delay)
   m_videoSettings.m_SubtitleDelay = delay;
 }
 
-void CVideoSettingsLocked::SetSubtitleFPS(double stretch)
+void CVideoSettingsLocked::SetSubtitleCompensateFPS(bool doCompensate)
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
-  m_videoSettings.m_subtitleFPS = stretch;
+  m_videoSettings.m_subtitleCompensateFPS = doCompensate;
 }
 
 void CVideoSettingsLocked::SetSubtitleVerticalPosition(int value, bool save)

--- a/xbmc/cores/VideoSettings.cpp
+++ b/xbmc/cores/VideoSettings.cpp
@@ -24,7 +24,7 @@ CVideoSettings::CVideoSettings()
   m_AudioStream = -1;
   m_SubtitleStream = -1;
   m_SubtitleDelay = 0.0f;
-  m_subtitleFPS = ST_FPS_SAME;
+  m_subtitleFPS = 0.0;
   m_subtitleVerticalPosition = 0;
   m_subtitleVerticalPositionSave = false;
   m_SubtitleOn = true;

--- a/xbmc/cores/VideoSettings.cpp
+++ b/xbmc/cores/VideoSettings.cpp
@@ -24,6 +24,7 @@ CVideoSettings::CVideoSettings()
   m_AudioStream = -1;
   m_SubtitleStream = -1;
   m_SubtitleDelay = 0.0f;
+  m_subtitleFPS = ST_FPS_SAME;
   m_subtitleVerticalPosition = 0;
   m_subtitleVerticalPositionSave = false;
   m_SubtitleOn = true;
@@ -57,6 +58,8 @@ bool CVideoSettings::operator!=(const CVideoSettings &right) const
   if (m_AudioStream != right.m_AudioStream) return true;
   if (m_SubtitleStream != right.m_SubtitleStream) return true;
   if (m_SubtitleDelay != right.m_SubtitleDelay) return true;
+  if (m_subtitleFPS != right.m_subtitleFPS)
+    return true;
   if (m_subtitleVerticalPosition != right.m_subtitleVerticalPosition)
     return true;
   if (m_subtitleVerticalPositionSave != right.m_subtitleVerticalPositionSave)
@@ -123,6 +126,12 @@ void CVideoSettingsLocked::SetSubtitleDelay(float delay)
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   m_videoSettings.m_SubtitleDelay = delay;
+}
+
+void CVideoSettingsLocked::SetSubtitleFPS(double stretch)
+{
+  std::unique_lock<CCriticalSection> lock(m_critSection);
+  m_videoSettings.m_subtitleFPS = stretch;
 }
 
 void CVideoSettingsLocked::SetSubtitleVerticalPosition(int value, bool save)

--- a/xbmc/cores/VideoSettings.h
+++ b/xbmc/cores/VideoSettings.h
@@ -177,30 +177,11 @@ private:
                 "add/remove a mapping?");
 };
 
-enum ESUBTITLEFPS
+enum class SubtitleFPS
 {
-  ST_FPS_SAME = 0,
-  ST_FPS_24 = 23976,
-  ST_FPS_25 = 25000
-};
-
-template<>
-struct fmt::formatter<ESUBTITLEFPS> : fmt::formatter<std::string_view>
-{
-public:
-  template<typename FormatContext>
-  constexpr auto format(const ESUBTITLEFPS& subtitleFPS, FormatContext& ctx)
-  {
-    const auto it = subtitleFPSMap.find(subtitleFPS);
-    if (it == subtitleFPSMap.cend())
-      throw std::range_error("no subtitle stretch string found");
-
-    return fmt::formatter<string_view>::format(it->second, ctx);
-  }
-
-private:
-  static constexpr auto subtitleFPSMap = make_map<ESUBTITLEFPS, std::string_view>(
-      {{ST_FPS_SAME, "Same as video"}, {ST_FPS_24, "24 fps"}, {ST_FPS_25, "25 fps"}});
+  SAME = 0,
+  FPS_24 = 23976,
+  FPS_25 = 25000
 };
 
 enum ViewMode

--- a/xbmc/cores/VideoSettings.h
+++ b/xbmc/cores/VideoSettings.h
@@ -177,13 +177,6 @@ private:
                 "add/remove a mapping?");
 };
 
-enum class SubtitleFPS
-{
-  SAME = 0,
-  FPS_24 = 23976,
-  FPS_25 = 25000
-};
-
 enum ViewMode
 {
   ViewModeNormal = 0,
@@ -217,7 +210,7 @@ public:
   float m_VolumeAmplification;
   int m_SubtitleStream;
   float m_SubtitleDelay;
-  double m_subtitleFPS;
+  double m_subtitleCompensateFPS;
   int m_subtitleVerticalPosition{0};
   bool m_subtitleVerticalPositionSave{false};
   bool m_SubtitleOn;
@@ -254,7 +247,7 @@ public:
   void SetVideoStream(int stream);
   void SetAudioDelay(float delay);
   void SetSubtitleDelay(float delay);
-  void SetSubtitleFPS(double stretch);
+  void SetSubtitleCompensateFPS(bool doCompensate);
 
   /*!
    * \brief Set the subtitle vertical position,

--- a/xbmc/cores/VideoSettings.h
+++ b/xbmc/cores/VideoSettings.h
@@ -177,6 +177,32 @@ private:
                 "add/remove a mapping?");
 };
 
+enum ESUBTITLEFPS
+{
+  ST_FPS_SAME = 0,
+  ST_FPS_24 = 23976,
+  ST_FPS_25 = 25000
+};
+
+template<>
+struct fmt::formatter<ESUBTITLEFPS> : fmt::formatter<std::string_view>
+{
+public:
+  template<typename FormatContext>
+  constexpr auto format(const ESUBTITLEFPS& subtitleFPS, FormatContext& ctx)
+  {
+    const auto it = subtitleFPSMap.find(subtitleFPS);
+    if (it == subtitleFPSMap.cend())
+      throw std::range_error("no subtitle stretch string found");
+
+    return fmt::formatter<string_view>::format(it->second, ctx);
+  }
+
+private:
+  static constexpr auto subtitleFPSMap = make_map<ESUBTITLEFPS, std::string_view>(
+      {{ST_FPS_SAME, "Same as video"}, {ST_FPS_24, "24 fps"}, {ST_FPS_25, "25 fps"}});
+};
+
 enum ViewMode
 {
   ViewModeNormal = 0,
@@ -210,6 +236,7 @@ public:
   float m_VolumeAmplification;
   int m_SubtitleStream;
   float m_SubtitleDelay;
+  double m_subtitleFPS;
   int m_subtitleVerticalPosition{0};
   bool m_subtitleVerticalPositionSave{false};
   bool m_SubtitleOn;
@@ -246,6 +273,7 @@ public:
   void SetVideoStream(int stream);
   void SetAudioDelay(float delay);
   void SetSubtitleDelay(float delay);
+  void SetSubtitleFPS(double stretch);
 
   /*!
    * \brief Set the subtitle vertical position,

--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
@@ -114,8 +114,8 @@ void CGUIDialogSubtitleSettings::OnSettingChanged(const std::shared_ptr<const CS
   }
   else if (settingId == SETTING_SUBTITLE_FPS)
   {
-    ESUBTITLEFPS value =
-        static_cast<ESUBTITLEFPS>(std::static_pointer_cast<const CSettingInt>(setting)->GetValue());
+    SubtitleFPS value =
+        static_cast<SubtitleFPS>(std::static_pointer_cast<const CSettingInt>(setting)->GetValue());
     appPlayer->SetSubtitleFPS(value);
   }
   else if (settingId == SETTING_SUBTITLE_STREAM)
@@ -315,9 +315,9 @@ void CGUIDialogSubtitleSettings::InitializeSettings()
     IntegerSettingOptions entries;
 
     entries.clear();
-    entries.push_back(IntegerSettingOption(g_localizeStrings.Get(39203), ST_FPS_SAME));
-    entries.push_back(IntegerSettingOption(fmt::format("{}", ST_FPS_24), ST_FPS_24));
-    entries.push_back(IntegerSettingOption(fmt::format("{}", ST_FPS_25), ST_FPS_25));
+    entries.push_back(IntegerSettingOption(g_localizeStrings.Get(39203), (int)SubtitleFPS::SAME));
+    entries.push_back(IntegerSettingOption(fmt::format("{}", ((int)SubtitleFPS::FPS_24)/1000.0), (int)SubtitleFPS::FPS_24));
+    entries.push_back(IntegerSettingOption(fmt::format("{}", ((int)SubtitleFPS::FPS_25)/1000.0), (int)SubtitleFPS::FPS_25));
 
     AddSpinner(groupSubtitles, SETTING_SUBTITLE_FPS, 39202, SettingLevel::Basic,
                videoSettings.m_subtitleFPS, entries);

--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
@@ -312,7 +312,8 @@ void CGUIDialogSubtitleSettings::InitializeSettings()
   if (SupportsSubtitleFeature(IPC_SUBS_STRETCH))
   {
     m_subtitleCompensateFPS = appPlayer->GetSubtitleCompensateFPS();
-    AddToggle(groupSubtitles, SETTING_SUBTITLE_FPS, 39202, SettingLevel::Basic, m_subtitleCompensateFPS);
+    AddToggle(groupSubtitles, SETTING_SUBTITLE_FPS, 39202, SettingLevel::Basic,
+              m_subtitleCompensateFPS);
   }
 
   // subtitle stream setting

--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
@@ -114,9 +114,8 @@ void CGUIDialogSubtitleSettings::OnSettingChanged(const std::shared_ptr<const CS
   }
   else if (settingId == SETTING_SUBTITLE_FPS)
   {
-    SubtitleFPS value =
-        static_cast<SubtitleFPS>(std::static_pointer_cast<const CSettingInt>(setting)->GetValue());
-    appPlayer->SetSubtitleFPS(value);
+    bool value = std::static_pointer_cast<const CSettingBool>(setting)->GetValue();
+    appPlayer->SetSubtitleCompensateFPS(value);
   }
   else if (settingId == SETTING_SUBTITLE_STREAM)
   {
@@ -312,15 +311,8 @@ void CGUIDialogSubtitleSettings::InitializeSettings()
 
   if (SupportsSubtitleFeature(IPC_SUBS_STRETCH))
   {
-    IntegerSettingOptions entries;
-
-    entries.clear();
-    entries.push_back(IntegerSettingOption(g_localizeStrings.Get(39203), (int)SubtitleFPS::SAME));
-    entries.push_back(IntegerSettingOption(fmt::format("{}", ((int)SubtitleFPS::FPS_24)/1000.0), (int)SubtitleFPS::FPS_24));
-    entries.push_back(IntegerSettingOption(fmt::format("{}", ((int)SubtitleFPS::FPS_25)/1000.0), (int)SubtitleFPS::FPS_25));
-
-    AddSpinner(groupSubtitles, SETTING_SUBTITLE_FPS, 39202, SettingLevel::Basic,
-               videoSettings.m_subtitleFPS, entries);
+    m_subtitleCompensateFPS = appPlayer->GetSubtitleCompensateFPS();
+    AddToggle(groupSubtitles, SETTING_SUBTITLE_FPS, 39202, SettingLevel::Basic, m_subtitleCompensateFPS);
   }
 
   // subtitle stream setting

--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
@@ -46,6 +46,7 @@
 
 #define SETTING_SUBTITLE_ENABLE                "subtitles.enable"
 #define SETTING_SUBTITLE_DELAY                 "subtitles.delay"
+#define SETTING_SUBTITLE_FPS                   "subtitles.fps"
 #define SETTING_SUBTITLE_STREAM                "subtitles.stream"
 #define SETTING_SUBTITLE_BROWSER               "subtitles.browser"
 #define SETTING_SUBTITLE_SEARCH                "subtitles.search"
@@ -110,6 +111,12 @@ void CGUIDialogSubtitleSettings::OnSettingChanged(const std::shared_ptr<const CS
   {
     float value = static_cast<float>(std::static_pointer_cast<const CSettingNumber>(setting)->GetValue());
     appPlayer->SetSubTitleDelay(value);
+  }
+  else if (settingId == SETTING_SUBTITLE_FPS)
+  {
+    ESUBTITLEFPS value =
+        static_cast<ESUBTITLEFPS>(std::static_pointer_cast<const CSettingInt>(setting)->GetValue());
+    appPlayer->SetSubtitleFPS(value);
   }
   else if (settingId == SETTING_SUBTITLE_STREAM)
   {
@@ -301,6 +308,19 @@ void CGUIDialogSubtitleSettings::InitializeSettings()
   {
     std::shared_ptr<CSettingNumber> settingSubtitleDelay = AddSlider(groupSubtitles, SETTING_SUBTITLE_DELAY, 22006, SettingLevel::Basic, videoSettings.m_SubtitleDelay, 0, -CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoSubsDelayRange, 0.1f, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoSubsDelayRange, 22006, usePopup);
     std::static_pointer_cast<CSettingControlSlider>(settingSubtitleDelay->GetControl())->SetFormatter(SettingFormatterDelay);
+  }
+
+  if (SupportsSubtitleFeature(IPC_SUBS_STRETCH))
+  {
+    IntegerSettingOptions entries;
+
+    entries.clear();
+    entries.push_back(IntegerSettingOption(g_localizeStrings.Get(39203), ST_FPS_SAME));
+    entries.push_back(IntegerSettingOption(fmt::format("{}", ST_FPS_24), ST_FPS_24));
+    entries.push_back(IntegerSettingOption(fmt::format("{}", ST_FPS_25), ST_FPS_25));
+
+    AddSpinner(groupSubtitles, SETTING_SUBTITLE_FPS, 39202, SettingLevel::Basic,
+               videoSettings.m_subtitleFPS, entries);
   }
 
   // subtitle stream setting

--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.h
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "cores/IPlayer.h"
 #include "cores/VideoPlayer/Interface/StreamInfo.h"
 #include "settings/dialogs/GUIDialogSettingsManualBase.h"
 
@@ -53,7 +54,7 @@ private:
   bool m_subtitleVisible;
   std::shared_ptr<CSettingInt> m_subtitleStreamSetting;
 
-  std::vector<int> m_subtitleCapabilities;
+  std::vector<IPlayerSubtitleCapabilities> m_subtitleCapabilities;
   static std::string FormatFlags(StreamFlags flags);
 
   static void SubtitleStreamsOptionFiller(const std::shared_ptr<const CSetting>& setting,

--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.h
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.h
@@ -52,6 +52,7 @@ private:
 
   int m_subtitleStream;
   bool m_subtitleVisible;
+  bool m_subtitleCompensateFPS;
   std::shared_ptr<CSettingInt> m_subtitleStreamSetting;
 
   std::vector<IPlayerSubtitleCapabilities> m_subtitleCapabilities;


### PR DESCRIPTION
## Description

Add an option to the subtitle dialog in video player to correct subtitle files that are mastered to a different frame rate than the media

## Motivation and context

It's a common nuisance in Europe that 24fps original material is ... "remastered" to our 25fps TV standards - just by speeding it up with or without pitch correction, in essence.

Sometimes, one might only/easily get hold of media that is mastered in a certain way, but all easily accessible subtitle files are timecoded for the "other" mastering. I.e. you might have 25fps media and a subtitle file that assumes 24fps playback or vice versa. This causes subtitles to rapidly drift out of alignment (by one second every 25 seconds, roughly).

With Kodi already providing subtitle offsets, audio offsets etc to provide a better playback experience of non-ideal media, adding a way to correct for this seems sensible.

## How has this been tested?

I've watched a season of a TV series that I only have in 25fps media using 24fps subtitle files. With the correction, those come out to be spot on.

## What is the effect on users?

Pro: Users get easy access to correct subtitle files that assume a different frame rate from the media being played (currently, limited to both directions of the common 24/25fps case).

Con: There's one more option in the subtitle dialog 😉

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

(how do I run the existing tests? ... locally? - or do I just wait for Jenkins to pick this up...?)

## Personal Note

It's been a while since I contributed to Kodi; please let me know how I can improve this / make things go smoother for everyone.

The change of  `std::vector<int> m_subtitleCapabilities` to `std::vector<IPlayerSubtitleCapabilities> m_subtitleCapabilities` (in `xbmc/video/dialogs/GUIDialogSubtitleSettings.h`) is in there because my compiler was complaining about it, and I don't see why it shouldn't be type safe.