### PR TITLE
[Windows][build ffmpeg] more robust build scripts

### DIFF
--- a/tools/buildsteps/windows/make-mingwlibs.bat
+++ b/tools/buildsteps/windows/make-mingwlibs.bat
@@ -5,8 +5,9 @@ PUSHD %~dp0\..\..\..
 SET WORKDIR=%CD%
 POPD
 
-REM recreates ffmpeg build dir in case it does not exist
+REM recreates clean ffmpeg build dir
 SET BUILD_DIR=%WORKDIR%\project\BuildDependencies\build
+IF EXIST %BUILD_DIR% rmdir %BUILD_DIR% /S /Q
 IF NOT EXIST %BUILD_DIR% mkdir %BUILD_DIR%
 
 SET PROMPTLEVEL=prompt

--- a/tools/buildsteps/windows/prepare-env.bat
+++ b/tools/buildsteps/windows/prepare-env.bat
@@ -10,6 +10,9 @@ cd %WORKSPACE%
 rem clean the BUILD_WIN32 at first to avoid problems with possible git files in there
 IF EXIST %WORKSPACE%\project\Win32BuildSetup\BUILD_WIN32 rmdir %WORKSPACE%\project\Win32BuildSetup\BUILD_WIN32 /S /Q
 
+rem also clean 'build' dir used to build ffmpeg as git clean has trouble to remove some times
+IF EXIST %WORKSPACE%\project\BuildDependencies\build rmdir %WORKSPACE%\project\BuildDependencies\build /S /Q
+
 rem we assume git in path as this is a requirement
 rem git clean the untracked files and directories
 rem but keep the downloaded dependencies
@@ -18,8 +21,3 @@ SET GIT_CLEAN_CMD=git clean -xffd -e "project/BuildDependencies/downloads" -e "p
 
 ECHO running %GIT_CLEAN_CMD%
 %GIT_CLEAN_CMD%
-
-REM 'build' dir is necessary to extract ffmpeg code
-REM we prevents missing under certain circumstances (early creation)
-SET BUILD_FFMPEG=%WORKSPACE%\project\BuildDependencies\build
-IF NOT EXIST %BUILD_FFMPEG% mkdir %BUILD_FFMPEG%


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/22964

## Motivation and context
This change has working fine in master branch, I am not aware that Jenkins builds have failed again due to this. But yesterday the same failure occurred on Nexus, so let's do the same here...

```
19:48:44 Workspace is c:\jenkins-workspace\workspace\WIN-64
19:48:44 running git clean -xffd -e "project/BuildDependencies/downloads" -e "project/BuildDependencies/downloads2" -e "project/BuildDependencies/mingwlibs" -e "project/BuildDependencies/msys64" -e "project/BuildDependencies/tools"
19:48:45 warning: failed to remove project/BuildDependencies/build/ffmpeg-x64: Permission denied
```


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
