### PR TITLE
[Windows] Software Renderer Protection and 10 bit Output

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererSoftware.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererSoftware.cpp
@@ -82,12 +82,13 @@ void CRendererSoftware::RenderImpl(CD3DTexture& target, CRect& sourceRect, CPoin
     return;
 
   CRenderBuffer* buf = m_renderBuffers[m_iBufferIndex];
+  const AVPixelFormat dstFormat =
+      (target.GetFormat() == DXGI_FORMAT_R10G10B10A2_UNORM) ? AV_PIX_FMT_X2BGR10 : AV_PIX_FMT_BGRA;
 
   // 1. convert yuv to rgb
-  m_sw_scale_ctx = sws_getCachedContext(m_sw_scale_ctx,
-    buf->GetWidth(), buf->GetHeight(), buf->av_format,
-    buf->GetWidth(), buf->GetHeight(), AV_PIX_FMT_BGRA,
-    SWS_FAST_BILINEAR, nullptr, nullptr, nullptr);
+  m_sw_scale_ctx = sws_getCachedContext(m_sw_scale_ctx, buf->GetWidth(), buf->GetHeight(),
+                                        buf->av_format, buf->GetWidth(), buf->GetHeight(),
+                                        dstFormat, SWS_FAST_BILINEAR, nullptr, nullptr, nullptr);
 
   if (!m_sw_scale_ctx)
     return;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererSoftware.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererSoftware.cpp
@@ -46,6 +46,8 @@ CRendererSoftware::~CRendererSoftware()
     sws_freeContext(m_sw_scale_ctx);
     m_sw_scale_ctx = nullptr;
   }
+  if (m_restoreMultithreadProtectedOff)
+    DX::DeviceResources::Get()->SetMultithreadProtected(false);
 }
 
 bool CRendererSoftware::Configure(const VideoPicture& picture, float fps, unsigned orientation)
@@ -57,8 +59,11 @@ bool CRendererSoftware::Configure(const VideoPicture& picture, float fps, unsign
 
     m_format = picture.videoBuffer->GetFormat();
     if (m_format == AV_PIX_FMT_D3D11VA_VLD)
+    {
       m_format = GetAVFormat(GetDXGIFormat(picture));
-
+      if (!DX::DeviceResources::Get()->SetMultithreadProtected(true))
+        m_restoreMultithreadProtectedOff = true;
+    }
     return true;
   }
   return false;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererSoftware.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererSoftware.h
@@ -35,6 +35,7 @@ protected:
 
 private:
   SwsContext* m_sw_scale_ctx = nullptr;
+  bool m_restoreMultithreadProtectedOff = false;
 };
 
 class CRendererSoftware::CRenderBufferImpl : public CRenderBuffer

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -1414,3 +1414,14 @@ std::vector<DXGI_COLOR_SPACE_TYPE> DX::DeviceResources::GetSwapChainColorSpaces(
   }
   return result;
 }
+
+bool DX::DeviceResources::SetMultithreadProtected(bool enabled) const
+{
+  BOOL wasEnabled = FALSE;
+  ComPtr<ID3D11Multithread> multithread;
+  HRESULT hr = m_d3dDevice.As(&multithread);
+  if (SUCCEEDED(hr))
+    wasEnabled = multithread->SetMultithreadProtected(enabled ? TRUE : FALSE);
+
+  return (wasEnabled == TRUE ? true : false);
+}

--- a/xbmc/rendering/dx/DeviceResources.h
+++ b/xbmc/rendering/dx/DeviceResources.h
@@ -118,6 +118,7 @@ namespace DX
     // Gets debug info from swapchain
     DEBUG_INFO_RENDER GetDebugInfo() const;
     std::vector<DXGI_COLOR_SPACE_TYPE> GetSwapChainColorSpaces() const;
+    bool SetMultithreadProtected(bool enabled) const;
 
   private:
     class CBackBuffer : public CD3DTexture


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

* Turn on D3D11 multithreading protection for dxva2 decoding + software renderer path because the main thread and the video player video thread sometimes use the non-thread safe D3D immediate context simultaneously
  * protection is disabled when playback ends, unless protection was already on (could happen if separate D3D device could not be created for DXVA decode)
  * a critical section to protect the immediate context would be better and would cover all situations, however that's a lot of changes for a case that's likely not used a lot. So, using the same solution as when a separate D3D device cannot be created for the dxva decoding. 
  * no need to protect the software decode path because all operations happen on the main (=rendering) thread

* Make swscale use the output format AV_PIX_FMT_X2BGR10 when Kodi is using a 10 bit swap chain (HDR screen&media and SDR media with "Use 10 bit for SDR" setting.
  * the rest of the code doesn't need to change as the intermediate texture is already created as DXGI_FORMAT_R10G10B10A2_UNORM in those situations

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The D3D debug layer triggers exceptions when using dxva2 decoding with software renderer. Can take a while, or very quickly when some breakpoints are set that significantly slow down the program and alter the usual timing.

Wrong colors on 10 bit output of software renderer.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 10 x64, debug and release mode, UWP on Windows 10 as well.
Software renderer with DXVA2 decoding on and off. HDR and SDR material with HDR and SDR 10 or 8 bit output.

There are pre-existing unrelated issues with dxva2 decode + software renderer: on UWP decoded frames are presented in wrong order (improves when OSD is displayed), for x64 there are partially updated frames when playing 4k or when the OSD is displayed,

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Software renderer displays correctly HDR and works in SDR 10 bit mode.

Avoids some corruption when using dxva2 with software renderer. I didn't witness it but it would be more likely to happen on slow computers or more intensive loads (4k).

## Screenshots (if appropriate):

Exception for simultaneous usage of immediate context from 2 threads:
![image](https://user-images.githubusercontent.com/489377/235382164-40abb34a-46c2-4efc-abd2-9d1f632d404a.png)

Corrupted 10 bit output:
![image](https://user-images.githubusercontent.com/489377/235381957-a55b0c45-765c-44a8-9c74-45b552cc4097.png)

Fixed output:
![image](https://user-images.githubusercontent.com/489377/235381880-da1ba5c0-075c-458c-952e-87f766591220.png)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
