### PR TITLE
Revert "[cmake] glx: find glx library instead of gl"

### DIFF
--- a/cmake/modules/FindGLX.cmake
+++ b/cmake/modules/FindGLX.cmake
@@ -20,7 +20,7 @@ endif()
 
 find_path(GLX_INCLUDE_DIR NAMES GL/glx.h
                           PATHS ${PC_GLX_INCLUDEDIR})
-find_library(GLX_LIBRARY NAMES GLX
+find_library(GLX_LIBRARY NAMES GL
                          PATHS ${PC_GLX_LIBDIR})
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
This reverts commit 26fe222b503a89b973c537bea37b140a40e8359e.

This should partially fix #22491

There seems to be no need to link GLX in and it will be dynamically looked up via the GL lib.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Fixes running on some platforms.

