### PR TITLE
threads: linux: simplify setting thread priority

### DIFF
--- a/xbmc/platform/linux/threads/ThreadImplLinux.cpp
+++ b/xbmc/platform/linux/threads/ThreadImplLinux.cpp
@@ -13,7 +13,7 @@
 
 #include <algorithm>
 #include <array>
-#include <limits.h>
+#include <mutex>
 
 #include <sys/resource.h>
 #include <unistd.h>
@@ -61,57 +61,11 @@ static pid_t gettid()
 #endif
 #endif
 
+std::once_flag flag;
+
 } // namespace
 
-static int s_maxPriority;
-static bool s_maxPriorityIsSet{false};
-
-// We need to return what the best number than can be passed
-// to SetPriority is. It will basically be relative to the
-// the main thread's nice level, inverted (since "higher" priority
-// nice levels are actually lower numbers).
-static int GetUserMaxPriority(int maxPriority)
-{
-  if (s_maxPriorityIsSet)
-    return s_maxPriority;
-
-  // if we're root, then we can do anything. So we'll allow
-  // max priority.
-  if (geteuid() == 0)
-    return maxPriority;
-
-  // get user max prio
-  struct rlimit limit;
-  if (getrlimit(RLIMIT_NICE, &limit) != 0)
-  {
-    // If we fail getting the limit for nice we just assume we can't raise the priority
-    return 0;
-  }
-
-  const int appNice = getpriority(PRIO_PROCESS, getpid());
-  const int rlimVal = limit.rlim_cur;
-
-  // according to the docs, limit.rlim_cur shouldn't be zero, yet, here we are.
-  // if a user has no entry in limits.conf rlim_cur is zero. In this case the best
-  //   nice value we can hope to achieve is '0' as a regular user
-  const int userBestNiceValue = (rlimVal == 0) ? 0 : (20 - rlimVal);
-
-  //          running the app with nice -n 10 ->
-  // e.g.         +10                 10    -     0   // default non-root user.
-  // e.g.         +30                 10    -     -20 // if root with rlimits set.
-  //          running the app default ->
-  // e.g.          0                  0    -     0   // default non-root user.
-  // e.g.         +20                 0    -     -20 // if root with rlimits set.
-  const int bestUserSetPriority = appNice - userBestNiceValue; // nice is inverted from prio.
-
-  // static because we only need to check this once.
-  // we shouldn't expect a user to change RLIMIT_NICE while running
-  // and it won't work anyway for threads that already set their priority.
-  s_maxPriority = std::min(maxPriority, bestUserSetPriority);
-  s_maxPriorityIsSet = true;
-
-  return s_maxPriority;
-}
+static int s_appPriority = getpriority(PRIO_PROCESS, getpid());
 
 std::unique_ptr<IThreadImpl> IThreadImpl::CreateThreadImpl(std::thread::native_handle_type handle)
 {
@@ -129,43 +83,23 @@ void CThreadImplLinux::SetThreadInfo(const std::string& name)
   pthread_setname_np(m_handle, name.c_str());
 #endif
 
-  // get user max prio
-  const int maxPrio = ThreadPriorityToNativePriority(ThreadPriority::HIGHEST);
-  const int userMaxPrio = GetUserMaxPriority(maxPrio);
-
-  // if the user does not have an entry in limits.conf the following
-  // call will fail
-  if (userMaxPrio > 0)
-  {
-    // start thread with nice level of application
-    const int appNice = getpriority(PRIO_PROCESS, getpid());
-    if (setpriority(PRIO_PROCESS, m_threadID, appNice) != 0)
-      CLog::Log(LOGERROR, "[threads] failed to set priority: {}", strerror(errno));
-  }
+  m_name = name;
 }
 
 bool CThreadImplLinux::SetPriority(const ThreadPriority& priority)
 {
-  // keep priority in bounds
+  std::call_once(flag,
+                 []() { CLog::Log(LOGDEBUG, "[threads] app priority: '{}'", s_appPriority); });
+
   const int prio = ThreadPriorityToNativePriority(priority);
-  const int maxPrio = ThreadPriorityToNativePriority(ThreadPriority::HIGHEST);
-  const int minPrio = ThreadPriorityToNativePriority(ThreadPriority::LOWEST);
 
-  // get user max prio given max prio (will take the min)
-  const int userMaxPrio = GetUserMaxPriority(maxPrio);
+  const int newPriority = s_appPriority - prio;
 
-  // clamp to min and max priorities
-  const int adjustedPrio = std::clamp(prio, minPrio, userMaxPrio);
+  setpriority(PRIO_PROCESS, m_threadID, newPriority);
 
-  // nice level of application
-  const int appNice = getpriority(PRIO_PROCESS, getpid());
-  const int newNice = appNice - adjustedPrio;
+  const int actualPriority = getpriority(PRIO_PROCESS, m_threadID);
 
-  if (setpriority(PRIO_PROCESS, m_threadID, newNice) != 0)
-  {
-    CLog::Log(LOGERROR, "[threads] failed to set priority: {}", strerror(errno));
-    return false;
-  }
+  CLog::Log(LOGDEBUG, "[threads] name: '{}' priority: '{}'", m_name, actualPriority);
 
   return true;
 }

--- a/xbmc/platform/linux/threads/ThreadImplLinux.h
+++ b/xbmc/platform/linux/threads/ThreadImplLinux.h
@@ -23,4 +23,5 @@ public:
 
 private:
   pid_t m_threadID;
+  std::string m_name;
 };


### PR DESCRIPTION
This is my attempt at fixing #22755

Instead of trying to fix the mess of inverted niceness and clamping let's just simplify the entire thing.

This just tries to set a priority level (based on the app priority level). If it works great, if not the app priority will be used (the default).

Some background:

On linux there is a niceness level which sets the priority. It's an inverted property from -20 (highest priority) to 20 (lowest priority). Setting a higher priority than `0` typically requires changing `limits.conf` (not obvious). A root user can set any priority.

Since we don't do anything (read "can't"), there is no point in trying to calculate the maximum allowable priority level. We can just blindly set the priority and then read back the priority of the thread. This simplifies the (very confusing) logic of trying to determine the max priority.

example:
```
$ ./kodi.bin --logging=console | grep 'priority:' 

2023-05-01 21:10:32.200 T:3802957   debug <general>: [threads] app priority: '0'
2023-05-01 21:10:32.200 T:3802957   debug <general>: [threads] name: 'Announce' priority: '1'
2023-05-01 21:10:32.757 T:3802955   debug <general>: [threads] name: 'libinput' priority: '1'
2023-05-01 21:10:33.269 T:3802992   debug <general>: [threads] name: 'AESink' priority: '0'
2023-05-01 21:10:33.300 T:3802994   debug <general>: [threads] name: 'JobWorker' priority: '1'
2023-05-01 21:10:33.524 T:3802995   debug <general>: [threads] name: 'JobWorker' priority: '1'
2023-05-01 21:10:33.524 T:3802996   debug <general>: [threads] name: 'JobWorker' priority: '1'
2023-05-01 21:10:33.604 T:3802955   debug <general>: [threads] name: 'PeripBusUSBUdev' priority: '1'
2023-05-01 21:10:33.604 T:3802955   debug <general>: [threads] name: 'PeripBusAddon' priority: '1'
2023-05-01 21:10:34.668 T:3803039   debug <general>: [threads] name: 'JobWorker' priority: '1'
```

The inverted priority means that, `1` is lower priority than the app `0`. Higher priority (if allowed) would be `-1`.

You can also see this with `top`:
```
$ top -H -b -n1 -p $(pidof kodi.bin) 

    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND                                                                                                                                                                                                                                                                                                                          
3803385 lukas     25   5 3654736 406532 144072 S   0.3   1.2   0:00.81 kodi.bin                                                                                                                                                              
3803517 lukas     25   5 3654736 406532 144072 R   0.3   1.2   0:00.06 AESink                                                                                                                                                                
3803530 lukas     25   5 3654736 406532 144072 S   0.3   1.2   0:00.03 PeripEventScan                                                                                                                                                        
3803535 lukas     25   5 3654736 406532 144072 S   0.3   1.2   0:00.27 LanguageInvoker                                                                                                                                                       
3803434 lukas     26   6 3654736 406532 144072 S   0.0   1.2   0:00.00 Announce                                                                                                                                                              
3803438 lukas     25   5 3654736 406532 144072 S   0.0   1.2   0:00.10 kodi.bin                                                                                                                                                              
3803439 lukas     25   5 3654736 406532 144072 S   0.0   1.2   0:00.00 pipewire                                                                                                                                                              
3803480 lukas     26   6 3654736 406532 144072 S   0.0   1.2   0:00.00 libinput                                                                                                                                                              
3803493 lukas     25   5 3654736 406532 144072 S   0.0   1.2   0:00.00 kodi.bin                                                                                                                                                              
3803494 lukas     25   5 3654736 406532 144072 S   0.0   1.2   0:00.00 kodi.bin                                                                                                                                                              
3803495 lukas     25   5 3654736 406532 144072 S   0.0   1.2   0:00.00 kodi.bin                                                                                                                                                              
3803496 lukas     25   5 3654736 406532 144072 S   0.0   1.2   0:00.00 kodi.bin                                                                                                                                                              
3803497 lukas     25   5 3654736 406532 144072 S   0.0   1.2   0:00.00 kodi.bin                                                                                                                                                              
3803498 lukas     25   5 3654736 406532 144072 S   0.0   1.2   0:00.00 kodi.bin                                                                                                                                                              
3803499 lukas     25   5 3654736 406532 144072 S   0.0   1.2   0:00.00 kodi.bin                                                                                                                                                              
3803500 lukas     25   5 3654736 406532 144072 S   0.0   1.2   0:00.00 kodi.bin                                                                                                                                                              
3803501 lukas     39  19 3654736 406532 144072 S   0.0   1.2   0:00.00 kodi.bi:disk$0                                                                                                                                                        
3803516 lukas     25   5 3654736 406532 144072 S   0.0   1.2   0:00.00 ActiveAE                                                                                                                                                              
3803519 lukas     26   6 3654736 406532 144072 S   0.0   1.2   0:00.24 JobWorker                                                                                                                                                             
3803520 lukas     26   6 3654736 406532 144072 S   0.0   1.2   0:00.21 JobWorker                                                                                                                                                             
3803521 lukas     26   6 3654736 406532 144072 S   0.0   1.2   0:00.19 JobWorker                                                                                                                                                             
3803528 lukas     26   6 3654736 406532 144072 S   0.0   1.2   0:00.41 PeripBusUSBUdev                                                                                                                                                       
3803529 lukas     26   6 3654736 406532 144072 S   0.0   1.2   0:00.00 PeripBusAddon                                                                                                                                                         
3803531 lukas     25   5 3654736 406532 144072 S   0.0   1.2   0:00.00 Timer                                                                                                                                                                 
3803532 lukas     25   5 3654736 406532 144072 S   0.0   1.2   0:01.05 LanguageInvoker                                                                                                                                                       
3803533 lukas     25   5 3654736 406532 144072 S   0.0   1.2   0:00.35 LanguageInvoker                                                                                                                                                       
3803534 lukas     25   5 3654736 406532 144072 S   0.0   1.2   0:00.42 LanguageInvoker                                                                                                                                                       
3803537 lukas     25   5 3654736 406532 144072 S   0.0   1.2   0:00.00 EventServer                                                                                                                                                           
3803538 lukas     25   5 3654736 406532 144072 S   0.0   1.2   0:00.00 TCPServer                                                                                                                                                             
3803541 lukas     26   6 3654736 406532 144072 S   0.0   1.2   0:00.48 JobWorker                                                                                                                                                             
3803547 lukas     25   5 3654736 406532 144072 S   0.0   1.2   0:00.01 LanguageInvoker                                                                                                                                                       
3803552 lukas     25   5 3654736 406532 144072 S   0.0   1.2   0:00.00 LanguageInvoker                                                                                                                                                       
3803553 lukas     25   5 3654736 406532 144072 S   0.0   1.2   0:00.00 LanguageInvoker  
```

Sorry for the large ugly commit. It's probably be to view in the side by side view -> [link](https://github.com/xbmc/xbmc/pull/23227/files?diff=split&w=0)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Fixes crashes on some systems.
