### PR TITLE
CAndroidKey: remove unnecessary ifs

### DIFF
--- a/xbmc/platform/android/activity/AndroidKey.cpp
+++ b/xbmc/platform/android/activity/AndroidKey.cpp
@@ -261,46 +261,38 @@ bool CAndroidKey::onKeyboardEvent(AInputEvent *event)
   switch (action)
   {
     case AKEY_EVENT_ACTION_DOWN:
-#if 1
-      CXBMCApp::android_printf("CAndroidKey: key down (dev:%d; src:%d; code: %d; repeat: %d; flags: 0x%0X; alt: %s; shift: %s; sym: %s)",
-        deviceId, source, keycode, repeat, flags,
-        (state & AMETA_ALT_ON) ? "yes" : "no",
-        (state & AMETA_SHIFT_ON) ? "yes" : "no",
-        (state & AMETA_SYM_ON) ? "yes" : "no");
-#endif
+      CXBMCApp::android_printf(
+          "CAndroidKey: key down (dev: %d; src: %d; code: %d; repeat: %d; flags: 0x%0X; alt: %s; "
+          "shift: %s; sym: %s)",
+          deviceId, source, keycode, repeat, flags, (state & AMETA_ALT_ON) ? "yes" : "no",
+          (state & AMETA_SHIFT_ON) ? "yes" : "no", (state & AMETA_SYM_ON) ? "yes" : "no");
       XBMC_Key((uint8_t)keycode, sym, modifiers, unicode, false);
       break;
 
     case AKEY_EVENT_ACTION_UP:
-#if 1
-      CXBMCApp::android_printf("CAndroidKey: key up (dev:%d; src:%d; code: %d; repeat: %d; flags: 0x%0X; alt: %s; shift: %s; sym: %s)",
-        deviceId, source, keycode, repeat, flags,
-        (state & AMETA_ALT_ON) ? "yes" : "no",
-        (state & AMETA_SHIFT_ON) ? "yes" : "no",
-        (state & AMETA_SYM_ON) ? "yes" : "no");
-#endif
+      CXBMCApp::android_printf(
+          "CAndroidKey: key up (dev: %d; src: %d; code: %d; repeat: %d; flags: 0x%0X; alt: %s; "
+          "shift: %s; sym: %s)",
+          deviceId, source, keycode, repeat, flags, (state & AMETA_ALT_ON) ? "yes" : "no",
+          (state & AMETA_SHIFT_ON) ? "yes" : "no", (state & AMETA_SYM_ON) ? "yes" : "no");
       XBMC_Key((uint8_t)keycode, sym, modifiers, unicode, true);
       break;
 
     case AKEY_EVENT_ACTION_MULTIPLE:
-#if 1
-      CXBMCApp::android_printf("CAndroidKey: key multiple (dev:%d; src:%d; code: %d; repeat: %d; flags: 0x%0X; alt: %s; shift: %s; sym: %s)",
-        deviceId, source, keycode, repeat, flags,
-        (state & AMETA_ALT_ON) ? "yes" : "no",
-        (state & AMETA_SHIFT_ON) ? "yes" : "no",
-        (state & AMETA_SYM_ON) ? "yes" : "no");
-#endif
+      CXBMCApp::android_printf(
+          "CAndroidKey: key multiple (dev: %d; src: %d; code: %d; repeat: %d; flags: 0x%0X; alt: "
+          "%s; shift: %s; sym: %s)",
+          deviceId, source, keycode, repeat, flags, (state & AMETA_ALT_ON) ? "yes" : "no",
+          (state & AMETA_SHIFT_ON) ? "yes" : "no", (state & AMETA_SYM_ON) ? "yes" : "no");
       return false;
       break;
 
     default:
-#if 1
-      CXBMCApp::android_printf("CAndroidKey: unknown key (dev:%d; src:%d; code: %d; repeat: %d; flags: 0x%0X; alt: %s; shift: %s; sym: %s)",
-        deviceId, source, keycode, repeat, flags,
-        (state & AMETA_ALT_ON) ? "yes" : "no",
-        (state & AMETA_SHIFT_ON) ? "yes" : "no",
-        (state & AMETA_SYM_ON) ? "yes" : "no");
-#endif
+      CXBMCApp::android_printf(
+          "CAndroidKey: unknown key (dev: %d; src: %d; code: %d; repeat: %d; flags: 0x%0X; alt: "
+          "%s; shift: %s; sym: %s)",
+          deviceId, source, keycode, repeat, flags, (state & AMETA_ALT_ON) ? "yes" : "no",
+          (state & AMETA_SHIFT_ON) ? "yes" : "no", (state & AMETA_SYM_ON) ? "yes" : "no");
       return false;
       break;
   }


### PR DESCRIPTION
## Description
Remove unnecessary:
```
#if 1
...
#endif
```

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
