### PR TITLE
[guilib] Reduce GPU load for unfocused scrolling labels

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -237,7 +237,7 @@ void CGUIBaseContainer::ProcessItem(float posX, float posY, CGUIListItemPtr& ite
       CGUIListItemLayoutPtr layout = std::make_unique<CGUIListItemLayout>(*m_layout, this);
       item->SetLayout(std::move(layout));
     }
-    if (item->GetFocusedLayout())
+    if (item->GetFocusedLayout() && item->GetFocusedLayout()->IsAnimating(ANIM_TYPE_UNFOCUS))
       item->GetFocusedLayout()->Process(item.get(), m_parentID, currentTime, dirtyregions);
     if (item->GetLayout())
       item->GetLayout()->Process(item.get(), m_parentID, currentTime, dirtyregions);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Stop calling Process() of the focused layout for items without focus, once the "unfocus" animation is finished. (condition aligned with code of RenderItem())

* See RenderItem() lines 322-325, render either the focus layout or the regular layout (OK)
* In ProcessItem() (line 240-241), Process() was called on the focused layout indefinitely for all non focused items of the container, in addition to the expected call to Process() on the non-focused layout (lines 242-243).

When the item contains a label that started scrolling due to text length and elapsed delay before scrolling, the focused layout Process() keeps marking the item dirty as if it was still scrolling, causing a redraw every frame, even though as unfocused item it is not scrolling anymore.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
GPU usage remains high after the focus leaves a label that was auto-scrolling due to text too long for the available space.

1. navigate to video folder that contains files with names too long for the available space (have ... at the end)
2. GPU usage is low (no redraw of the GUI)
3. set focus on a file with name too long to fit, wait for the auto-scrolling to start
4. GPU usage increase (GUI redrawn every frame for the auto-scrolling)
5. move focus to another file that doesn't need the scrolling
6. the GPU usage remains high, the GUI keeps getting drawn for every frame, even though nothing changes on screen.

This is quite noticeable when this causes the fan to spin up on low power systems.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 10 x64 & UWP x64
Went through scenario in "Motivation and context". In step 6 the GPU goes back to idle.
No visual artifacts noticed on the group list items.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Reduced GPU usage for that particular situation.

## Screenshots (if appropriate):
GPU load increases when the label text scrolls (expected as the whole GUI is drawn every frame)
![image](https://user-images.githubusercontent.com/489377/236294155-63559257-8d6e-42ba-b68e-eb4f811ecd0a.png)

Without the PR the GPU load remains high until the user goes to a different folder or screen.

With the PR, the GPU load decreases when the focus goes to an item that doesn't scroll:
![image](https://user-images.githubusercontent.com/489377/236294367-67ac92f5-75f2-41c7-86b4-572f94faf9f6.png)

The additional peaks and valleys are due to the screenshots capture.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
