### PR TITLE
TexturePacker: third pass at modernization

### DIFF
--- a/tools/depends/native/TexturePacker/src/DecoderManager.h
+++ b/tools/depends/native/TexturePacker/src/DecoderManager.h
@@ -33,8 +33,10 @@ class DecoderManager
 
     bool IsSupportedGraphicsFile(std::string_view filename);
     bool LoadFile(const std::string& filename, DecodedFrames& frames);
-    bool verbose;
+    void EnableVerboseOutput() { verbose = true; }
 
   private:
     std::vector<std::unique_ptr<IDecoder>> m_decoders;
+
+    bool verbose{false};
 };

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -105,10 +105,9 @@ public:
   TexturePacker() = default;
   ~TexturePacker() = default;
 
-  int createBundle(const std::string& InputDir,
-                   const std::string& OutputFile,
-                   unsigned int flags,
-                   bool dupecheck);
+  void EnableDupeCheck() { m_dupecheck = true; }
+
+  int createBundle(const std::string& InputDir, const std::string& OutputFile, unsigned int flags);
 
   DecoderManager decoderManager;
 
@@ -123,6 +122,8 @@ private:
                  std::map<std::string, unsigned int>& hashes,
                  std::vector<unsigned int>& dupes,
                  unsigned int pos);
+
+  bool m_dupecheck{false};
 };
 
 void TexturePacker::CreateSkeletonHeader(CXBTFWriter& xbtfWriter,
@@ -277,8 +278,7 @@ bool TexturePacker::CheckDupe(MD5Context* ctx,
 
 int TexturePacker::createBundle(const std::string& InputDir,
                                 const std::string& OutputFile,
-                                unsigned int flags,
-                                bool dupecheck)
+                                unsigned int flags)
 {
   CXBTFWriter writer(OutputFile);
   if (!writer.Create())
@@ -293,7 +293,7 @@ int TexturePacker::createBundle(const std::string& InputDir,
 
   std::vector<CXBTFFile> files = writer.GetFiles();
   dupes.resize(files.size());
-  if (!dupecheck)
+  if (!m_dupecheck)
   {
     for (unsigned int i=0;i<dupes.size();++i)
       dupes[i] = i;
@@ -321,7 +321,7 @@ int TexturePacker::createBundle(const std::string& InputDir,
 
     printf("%s\n", output.c_str());
     bool skip=false;
-    if (dupecheck)
+    if (m_dupecheck)
     {
       for (unsigned int j = 0; j < frames.frameList.size(); j++)
         MD5Update(&ctx, (const uint8_t*)frames.frameList[j].rgbaImage.pixels.data(),
@@ -376,7 +376,6 @@ int main(int argc, char* argv[])
     return 1;
   bool valid = false;
   unsigned int flags = 0;
-  bool dupecheck = false;
   CmdLineArgs args(argc, (const char**)argv);
 
   // setup some defaults, lzo packing,
@@ -407,7 +406,7 @@ int main(int argc, char* argv[])
     }
     else if (!strcmp(args[i], "-dupecheck"))
     {
-      dupecheck = true;
+      texturePacker.EnableDupeCheck();
     }
     else if (!strcmp(args[i], "-verbose"))
     {
@@ -438,5 +437,5 @@ int main(int argc, char* argv[])
   if (pos != InputDir.length() - 1)
     InputDir += DIR_SEPARATOR;
 
-  texturePacker.createBundle(InputDir, OutputFilename, flags, dupecheck);
+  texturePacker.createBundle(InputDir, OutputFilename, flags);
 }

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -333,12 +333,14 @@ int TexturePacker::createBundle(const std::string& InputDir,
     {
       for (unsigned int j = 0; j < frames.frameList.size(); j++)
       {
-        printf("    frame %4i (delay:%4i)                         ", j, frames.frameList[j].delay);
         CXBTFFrame frame = createXBTFFrame(frames.frameList[j].rgbaImage, writer, flags);
         frame.SetDuration(frames.frameList[j].delay);
         file.GetFrames().push_back(frame);
-        printf("%s%c (%d,%d @ %" PRIu64 " bytes)\n", GetFormatString(frame.GetFormat()), frame.HasAlpha() ? ' ' : '*',
-          frame.GetWidth(), frame.GetHeight(), frame.GetUnpackedSize());
+        printf("    frame %4i (delay:%4i)                         %s%c (%d,%d @ %" PRIu64
+               " bytes)\n",
+               j, frames.frameList[j].delay, GetFormatString(frame.GetFormat()),
+               frame.HasAlpha() ? ' ' : '*', frame.GetWidth(), frame.GetHeight(),
+               frame.GetUnpackedSize());
       }
     }
     file.SetLoop(0);

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -271,7 +271,7 @@ bool TexturePacker::CheckDupe(MD5Context* ctx,
     return true;
   }
 
-  m_hashes.insert(std::make_pair(hex, pos));
+  m_hashes[hex] = pos;
   m_dupes[pos] = pos;
 
   return false;

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -109,6 +109,11 @@ private:
                             const std::string& relativePath = "");
 
   CXBTFFrame CreateXBTFFrame(DecodedFrame& decodedFrame, CXBTFWriter& writer, unsigned int flags) const;
+
+  bool CheckDupe(MD5Context* ctx,
+                 std::map<std::string, unsigned int>& hashes,
+                 std::vector<unsigned int>& dupes,
+                 unsigned int pos);
 };
 
 void TexturePacker::CreateSkeletonHeader(CXBTFWriter& xbtfWriter,
@@ -242,9 +247,10 @@ void Usage()
   puts("  -dupecheck       Enable duplicate file detection. Reduces output file size. Default: off");
 }
 
-static bool checkDupe(struct MD5Context* ctx,
-                      std::map<std::string, unsigned int>& hashes,
-                      std::vector<unsigned int>& dupes, unsigned int pos)
+bool TexturePacker::CheckDupe(MD5Context* ctx,
+                              std::map<std::string, unsigned int>& hashes,
+                              std::vector<unsigned int>& dupes,
+                              unsigned int pos)
 {
   unsigned char digest[17];
   MD5Final(digest,ctx);
@@ -321,7 +327,7 @@ int TexturePacker::createBundle(const std::string& InputDir,
         MD5Update(&ctx, (const uint8_t*)frames.frameList[j].rgbaImage.pixels.data(),
                   frames.frameList[j].rgbaImage.height * frames.frameList[j].rgbaImage.pitch);
 
-      if (checkDupe(&ctx,hashes,dupes,i))
+      if (CheckDupe(&ctx, hashes, dupes, i))
       {
         printf("****  duplicate of %s\n", files[dupes[i]].GetPath().c_str());
         file.GetFrames().insert(file.GetFrames().end(),

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -171,6 +171,7 @@ void TexturePacker::CreateSkeletonHeader(CXBTFWriter& xbtfWriter,
 
 CXBTFFrame createXBTFFrame(DecodedFrame& decodedFrame, CXBTFWriter& writer, unsigned int flags)
 {
+  const unsigned int delay = decodedFrame.delay;
   const unsigned int width = decodedFrame.rgbaImage.width;
   const unsigned int height = decodedFrame.rgbaImage.height;
   const unsigned int size = width * height * 4;
@@ -224,7 +225,7 @@ CXBTFFrame createXBTFFrame(DecodedFrame& decodedFrame, CXBTFWriter& writer, unsi
   frame.SetWidth(width);
   frame.SetHeight(height);
   frame.SetFormat(hasAlpha ? format : format | XB_FMT_OPAQUE);
-  frame.SetDuration(0);
+  frame.SetDuration(delay);
   return frame;
 }
 
@@ -331,7 +332,6 @@ int TexturePacker::createBundle(const std::string& InputDir,
       for (unsigned int j = 0; j < frames.frameList.size(); j++)
       {
         CXBTFFrame frame = createXBTFFrame(frames.frameList[j], writer, flags);
-        frame.SetDuration(frames.frameList[j].delay);
         file.GetFrames().push_back(frame);
         printf("    frame %4i (delay:%4i)                         %s%c (%d,%d @ %" PRIu64
                " bytes)\n",

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -169,13 +169,13 @@ void TexturePacker::CreateSkeletonHeader(CXBTFWriter& xbtfWriter,
   }
 }
 
-CXBTFFrame createXBTFFrame(RGBAImage& image, CXBTFWriter& writer, unsigned int flags)
+CXBTFFrame createXBTFFrame(DecodedFrame& decodedFrame, CXBTFWriter& writer, unsigned int flags)
 {
-  const unsigned int width = image.width;
-  const unsigned int height = image.height;
+  const unsigned int width = decodedFrame.rgbaImage.width;
+  const unsigned int height = decodedFrame.rgbaImage.height;
   const unsigned int size = width * height * 4;
   const unsigned int format = XB_FMT_A8R8G8B8;
-  unsigned char* data = (unsigned char*)image.pixels.data();
+  unsigned char* data = (unsigned char*)decodedFrame.rgbaImage.pixels.data();
 
   const bool hasAlpha = HasAlpha(data, width, height);
 
@@ -330,7 +330,7 @@ int TexturePacker::createBundle(const std::string& InputDir,
     {
       for (unsigned int j = 0; j < frames.frameList.size(); j++)
       {
-        CXBTFFrame frame = createXBTFFrame(frames.frameList[j].rgbaImage, writer, flags);
+        CXBTFFrame frame = createXBTFFrame(frames.frameList[j], writer, flags);
         frame.SetDuration(frames.frameList[j].delay);
         file.GetFrames().push_back(frame);
         printf("    frame %4i (delay:%4i)                         %s%c (%d,%d @ %" PRIu64

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -53,6 +53,9 @@
 
 #define DIR_SEPARATOR '/'
 
+namespace
+{
+
 const char *GetFormatString(unsigned int format)
 {
   switch (format)
@@ -73,6 +76,8 @@ const char *GetFormatString(unsigned int format)
     return "?????";
   }
 }
+
+} // namespace
 
 class TexturePacker
 {

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -169,8 +169,16 @@ void TexturePacker::CreateSkeletonHeader(CXBTFWriter& xbtfWriter,
   }
 }
 
-CXBTFFrame appendContent(CXBTFWriter &writer, int width, int height, unsigned char *data, unsigned int size, unsigned int format, bool hasAlpha, unsigned int flags)
+CXBTFFrame createXBTFFrame(RGBAImage& image, CXBTFWriter& writer, unsigned int flags)
 {
+  const unsigned int width = image.width;
+  const unsigned int height = image.height;
+  const unsigned int size = width * height * 4;
+  const unsigned int format = XB_FMT_A8R8G8B8;
+  unsigned char* data = (unsigned char*)image.pixels.data();
+
+  const bool hasAlpha = HasAlpha(data, width, height);
+
   CXBTFFrame frame;
   lzo_uint packedSize = size;
 
@@ -217,24 +225,6 @@ CXBTFFrame appendContent(CXBTFWriter &writer, int width, int height, unsigned ch
   frame.SetHeight(height);
   frame.SetFormat(hasAlpha ? format : format | XB_FMT_OPAQUE);
   frame.SetDuration(0);
-  return frame;
-}
-
-CXBTFFrame createXBTFFrame(RGBAImage& image, CXBTFWriter& writer, unsigned int flags)
-{
-
-  int width, height;
-  unsigned int format = 0;
-  unsigned char* argb = (unsigned char*)image.pixels.data();
-
-  width  = image.width;
-  height = image.height;
-  bool hasAlpha = HasAlpha(argb, width, height);
-
-  CXBTFFrame frame;
-  format = XB_FMT_A8R8G8B8;
-  frame = appendContent(writer, width, height, argb, (width * height * 4), format, hasAlpha, flags);
-
   return frame;
 }
 

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -88,6 +88,15 @@ bool HasAlpha(unsigned char* argb, unsigned int width, unsigned int height)
   return false;
 }
 
+void Usage()
+{
+  puts("Usage:");
+  puts("  -help            Show this screen.");
+  puts("  -input <dir>     Input directory. Default: current dir");
+  puts("  -output <dir>    Output directory/filename. Default: Textures.xbt");
+  puts("  -dupecheck       Enable duplicate file detection. Reduces output file size. Default: off");
+}
+
 } // namespace
 
 class TexturePacker
@@ -236,15 +245,6 @@ CXBTFFrame TexturePacker::CreateXBTFFrame(DecodedFrame& decodedFrame,
   frame.SetFormat(hasAlpha ? format : format | XB_FMT_OPAQUE);
   frame.SetDuration(delay);
   return frame;
-}
-
-void Usage()
-{
-  puts("Usage:");
-  puts("  -help            Show this screen.");
-  puts("  -input <dir>     Input directory. Default: current dir");
-  puts("  -output <dir>    Output directory/filename. Default: Textures.xbt");
-  puts("  -dupecheck       Enable duplicate file detection. Reduces output file size. Default: off");
 }
 
 bool TexturePacker::CheckDupe(MD5Context* ctx,

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -107,6 +107,8 @@ private:
   void CreateSkeletonHeader(CXBTFWriter& xbtfWriter,
                             const std::string& fullPath,
                             const std::string& relativePath = "");
+
+  CXBTFFrame CreateXBTFFrame(DecodedFrame& decodedFrame, CXBTFWriter& writer, unsigned int flags) const;
 };
 
 void TexturePacker::CreateSkeletonHeader(CXBTFWriter& xbtfWriter,
@@ -169,7 +171,9 @@ void TexturePacker::CreateSkeletonHeader(CXBTFWriter& xbtfWriter,
   }
 }
 
-CXBTFFrame createXBTFFrame(DecodedFrame& decodedFrame, CXBTFWriter& writer, unsigned int flags)
+CXBTFFrame TexturePacker::CreateXBTFFrame(DecodedFrame& decodedFrame,
+                                          CXBTFWriter& writer,
+                                          unsigned int flags) const
 {
   const unsigned int delay = decodedFrame.delay;
   const unsigned int width = decodedFrame.rgbaImage.width;
@@ -331,7 +335,7 @@ int TexturePacker::createBundle(const std::string& InputDir,
     {
       for (unsigned int j = 0; j < frames.frameList.size(); j++)
       {
-        CXBTFFrame frame = createXBTFFrame(frames.frameList[j], writer, flags);
+        CXBTFFrame frame = CreateXBTFFrame(frames.frameList[j], writer, flags);
         file.GetFrames().push_back(frame);
         printf("    frame %4i (delay:%4i)                         %s%c (%d,%d @ %" PRIu64
                " bytes)\n",

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -298,9 +298,6 @@ int TexturePacker::createBundle(const std::string& InputDir,
     fullPath += file.GetPath();
 
     std::string output = file.GetPath();
-    output = output.substr(0, 40);
-    while (output.size() < 46)
-      output += ' ';
 
     DecodedFrames frames;
     bool loaded = decoderManager.LoadFile(fullPath, frames);

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -77,6 +77,17 @@ const char *GetFormatString(unsigned int format)
   }
 }
 
+bool HasAlpha(unsigned char* argb, unsigned int width, unsigned int height)
+{
+  unsigned char* p = argb + 3; // offset of alpha
+  for (unsigned int i = 0; i < 4 * width * height; i += 4)
+  {
+    if (p[i] != 0xff)
+      return true;
+  }
+  return false;
+}
+
 } // namespace
 
 class TexturePacker
@@ -207,17 +218,6 @@ CXBTFFrame appendContent(CXBTFWriter &writer, int width, int height, unsigned ch
   frame.SetFormat(hasAlpha ? format : format | XB_FMT_OPAQUE);
   frame.SetDuration(0);
   return frame;
-}
-
-bool HasAlpha(unsigned char *argb, unsigned int width, unsigned int height)
-{
-  unsigned char *p = argb + 3; // offset of alpha
-  for (unsigned int i = 0; i < 4*width*height; i += 4)
-  {
-    if (p[i] != 0xff)
-      return true;
-  }
-  return false;
 }
 
 CXBTFFrame createXBTFFrame(RGBAImage& image, CXBTFWriter& writer, unsigned int flags)

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -335,7 +335,7 @@ int TexturePacker::createBundle(const std::string& InputDir,
         file.GetFrames().push_back(frame);
         printf("    frame %4i (delay:%4i)                         %s%c (%d,%d @ %" PRIu64
                " bytes)\n",
-               j, frames.frameList[j].delay, GetFormatString(frame.GetFormat()),
+               j, frame.GetDuration(), GetFormatString(frame.GetFormat()),
                frame.HasAlpha() ? ' ' : '*', frame.GetWidth(), frame.GetHeight(),
                frame.GetUnpackedSize());
       }

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -290,11 +290,6 @@ int TexturePacker::createBundle(const std::string& InputDir, const std::string& 
 
   std::vector<CXBTFFile> files = writer.GetFiles();
   m_dupes.resize(files.size());
-  if (!m_dupecheck)
-  {
-    for (unsigned int i=0;i<m_dupes.size();++i)
-      m_dupes[i] = i;
-  }
 
   for (size_t i = 0; i < files.size(); i++)
   {
@@ -332,6 +327,10 @@ int TexturePacker::createBundle(const std::string& InputDir, const std::string& 
                                 files[m_dupes[i]].GetFrames().end());
         skip = true;
       }
+    }
+    else
+    {
+      m_dupes[i] = i;
     }
 
     if (!skip)

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -107,9 +107,9 @@ public:
 
   void EnableDupeCheck() { m_dupecheck = true; }
 
-  int createBundle(const std::string& InputDir, const std::string& OutputFile);
+  void EnableVerboseOutput() { decoderManager.EnableVerboseOutput(); }
 
-  DecoderManager decoderManager;
+  int createBundle(const std::string& InputDir, const std::string& OutputFile);
 
   void SetFlags(unsigned int flags) { m_flags = flags; }
 
@@ -124,6 +124,8 @@ private:
                  std::map<std::string, unsigned int>& hashes,
                  std::vector<unsigned int>& dupes,
                  unsigned int pos);
+
+  DecoderManager decoderManager;
 
   bool m_dupecheck{false};
   unsigned int m_flags{0};
@@ -408,7 +410,7 @@ int main(int argc, char* argv[])
     }
     else if (!strcmp(args[i], "-verbose"))
     {
-      texturePacker.decoderManager.verbose = true;
+      texturePacker.EnableVerboseOutput();
     }
     else if (!platform_stricmp(args[i], "-output") || !platform_stricmp(args[i], "-o"))
     {


### PR DESCRIPTION
This is a follow up to https://github.com/xbmc/xbmc/pull/23183

This make TexturePacker more of a proper class with members. This helps cleanup the code and avoids passing variables through multiple function calls.

When reviewing look at the individual commits as the overall diff looks a bit messy.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

produces the same sha256 hash for the Texures.xbt file

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

none, yet.
