### PR TITLE
Fix build with GCC>=13

### DIFF
--- a/cmake/modules/FindCrossGUID.cmake
+++ b/cmake/modules/FindCrossGUID.cmake
@@ -29,7 +29,8 @@ if(ENABLE_INTERNAL_CROSSGUID)
   endif()
 
   set(patches "${CMAKE_SOURCE_DIR}/tools/depends/target/crossguid/001-fix-unused-function.patch"
-              "${CMAKE_SOURCE_DIR}/tools/depends/target/crossguid/002-disable-Wall-error.patch")
+              "${CMAKE_SOURCE_DIR}/tools/depends/target/crossguid/002-disable-Wall-error.patch"
+              "${CMAKE_SOURCE_DIR}/tools/depends/target/crossguid/003-add-cstdint-include.patch")
 
   generate_patchcommand("${patches}")
 

--- a/tools/depends/native/TexturePacker/src/decoder/IDecoder.h
+++ b/tools/depends/native/TexturePacker/src/decoder/IDecoder.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/tools/depends/target/crossguid/003-add-cstdint-include.patch
+++ b/tools/depends/target/crossguid/003-add-cstdint-include.patch
@@ -1,0 +1,10 @@
+--- a/include/crossguid/guid.hpp
++++ b/include/crossguid/guid.hpp
+@@ -36,6 +36,7 @@ THE SOFTWARE.
+ #include <string_view>
+ #include <utility>
+ #include <iomanip>
++#include <cstdint>
+ 
+ #define BEGIN_XG_NAMESPACE namespace xg {
+ #define END_XG_NAMESPACE }

--- a/tools/depends/target/crossguid/Makefile
+++ b/tools/depends/target/crossguid/Makefile
@@ -47,6 +47,7 @@ endif
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 	cd $(PLATFORM); patch -p1 -i ../001-fix-unused-function.patch
 	cd $(PLATFORM); patch -p1 -i ../002-disable-Wall-error.patch
+	cd $(PLATFORM); patch -p1 -i ../003-add-cstdint-include.patch
 	cd $(PLATFORM)/build; $(CMAKE) $(CMAKE_OPTIONS) ..
 
 .installed-$(PLATFORM): $(PLATFORM)

--- a/tools/depends/target/waylandpp/001-fix-gcc13-build.patch
+++ b/tools/depends/target/waylandpp/001-fix-gcc13-build.patch
@@ -1,0 +1,28 @@
+--- a/include/wayland-client.hpp
++++ b/include/wayland-client.hpp
+@@ -33,6 +33,7 @@
+ #include <memory>
+ #include <string>
+ #include <vector>
++#include <cstdint>
+ #include <wayland-version.hpp>
+ #include <wayland-client-core.h>
+ #include <wayland-util.hpp>
+
+--- a/scanner/scanner.cpp
++++ b/scanner/scanner.cpp
+@@ -24,6 +24,7 @@
+ #include <cctype>
+ #include <cmath>
+ #include <stdexcept>
++#include <cstdint>
+
+ #include "pugixml.hpp"
+
+@@ -928,6 +929,7 @@
+               << "#include <memory>" << std::endl
+               << "#include <string>" << std::endl
+               << "#include <vector>" << std::endl
++              << "#include <cstdint>" << std::endl
+               << std::endl
+               << "#include <wayland-client.hpp>" << std::endl;

--- a/tools/depends/target/waylandpp/Makefile
+++ b/tools/depends/target/waylandpp/Makefile
@@ -1,5 +1,5 @@
 -include ../../Makefile.include
-DEPS =Makefile ../../download-files.include
+DEPS =Makefile ../../download-files.include 001-fix-gcc13-build.patch
 
 # lib name, version
 LIBNAME=waylandpp
@@ -43,6 +43,7 @@ ifeq ($(PREFIX),)
 endif
 	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); patch -p1 -i ../001-fix-gcc13-build.patch
 	mkdir -p $(BUILDDIR)
 	cd $(BUILDDIR); $(CMAKE) $(CMAKE_OPTIONS) ..
 

--- a/xbmc/utils/Observer.h
+++ b/xbmc/utils/Observer.h
@@ -48,7 +48,7 @@ class Observable
 public:
   Observable() = default;
   virtual ~Observable() = default;
-  virtual Observable &operator=(const Observable &observable);
+  Observable& operator=(const Observable& observable);
 
   /*!
    * @brief Register an observer.


### PR DESCRIPTION
## Description
Changes in the transient header includes with GCC>=13 result in a couple of build problems, see e.g. #23237.

The bump of flatbuffers to version 23.3.3 fo fix its build problems with GCC>=13 will follow in a separate commit. Reason is it needs a little more work and this PR fixes builds at least for people building with system dependencies.

## Motivation and context
See above.

## How has this been tested?
Building with GCC 13.1.

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
