### PR TITLE
TextureFormats.h: use XB_FMT as an enum

### DIFF
--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -197,7 +197,7 @@ CXBTFFrame TexturePacker::CreateXBTFFrame(DecodedFrame& decodedFrame, CXBTFWrite
   const unsigned int width = decodedFrame.rgbaImage.width;
   const unsigned int height = decodedFrame.rgbaImage.height;
   const unsigned int size = width * height * 4;
-  const unsigned int format = XB_FMT_A8R8G8B8;
+  const XB_FMT format = XB_FMT_A8R8G8B8;
   unsigned char* data = (unsigned char*)decodedFrame.rgbaImage.pixels.data();
 
   const bool hasAlpha = HasAlpha(data, width, height);
@@ -246,7 +246,7 @@ CXBTFFrame TexturePacker::CreateXBTFFrame(DecodedFrame& decodedFrame, CXBTFWrite
   frame.SetUnpackedSize(size);
   frame.SetWidth(width);
   frame.SetHeight(height);
-  frame.SetFormat(hasAlpha ? format : format | XB_FMT_OPAQUE);
+  frame.SetFormat(hasAlpha ? format : static_cast<XB_FMT>(format | XB_FMT_OPAQUE));
   frame.SetDuration(delay);
   return frame;
 }

--- a/xbmc/cores/RetroPlayer/buffers/video/RenderBufferGuiTexture.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/video/RenderBufferGuiTexture.cpp
@@ -75,7 +75,7 @@ void CRenderBufferGuiTexture::BindToUnit(unsigned int unit)
     m_texture->BindToUnit(unit);
 }
 
-AVPixelFormat CRenderBufferGuiTexture::TranslateFormat(unsigned int textureFormat)
+AVPixelFormat CRenderBufferGuiTexture::TranslateFormat(XB_FMT textureFormat)
 {
   switch (textureFormat)
   {

--- a/xbmc/cores/RetroPlayer/buffers/video/RenderBufferGuiTexture.h
+++ b/xbmc/cores/RetroPlayer/buffers/video/RenderBufferGuiTexture.h
@@ -37,12 +37,12 @@ public:
   CTexture* GetTexture() { return m_texture.get(); }
 
 protected:
-  AVPixelFormat TranslateFormat(unsigned int textureFormat);
+  AVPixelFormat TranslateFormat(XB_FMT textureFormat);
   TEXTURE_SCALING TranslateScalingMethod(SCALINGMETHOD scalingMethod);
 
   // Texture parameters
   SCALINGMETHOD m_scalingMethod;
-  unsigned int m_textureFormat = XB_FMT_UNKNOWN;
+  XB_FMT m_textureFormat = XB_FMT_UNKNOWN;
   std::unique_ptr<CTexture> m_texture;
 };
 

--- a/xbmc/filesystem/XbtFile.cpp
+++ b/xbmc/filesystem/XbtFile.cpp
@@ -305,11 +305,11 @@ uint32_t CXbtFile::GetImageHeight() const
   return frame.GetHeight();
 }
 
-uint32_t CXbtFile::GetImageFormat() const
+XB_FMT CXbtFile::GetImageFormat() const
 {
   CXBTFFrame frame;
   if (!GetFirstFrame(frame))
-    return false;
+    return XB_FMT_UNKNOWN;
 
   return frame.GetFormat();
 }

--- a/xbmc/filesystem/XbtFile.h
+++ b/xbmc/filesystem/XbtFile.h
@@ -42,7 +42,7 @@ public:
 
   uint32_t GetImageWidth() const;
   uint32_t GetImageHeight() const;
-  uint32_t GetImageFormat() const;
+  XB_FMT GetImageFormat() const;
   bool HasImageAlpha() const;
 
 private:

--- a/xbmc/guilib/DDSImage.cpp
+++ b/xbmc/guilib/DDSImage.cpp
@@ -22,7 +22,7 @@ CDDSImage::CDDSImage()
   memset(&m_desc, 0, sizeof(m_desc));
 }
 
-CDDSImage::CDDSImage(unsigned int width, unsigned int height, unsigned int format)
+CDDSImage::CDDSImage(unsigned int width, unsigned int height, XB_FMT format)
 {
   m_data = NULL;
   Allocate(width, height, format);
@@ -43,10 +43,10 @@ unsigned int CDDSImage::GetHeight() const
   return m_desc.height;
 }
 
-unsigned int CDDSImage::GetFormat() const
+XB_FMT CDDSImage::GetFormat() const
 {
   if (m_desc.pixelFormat.flags & DDPF_RGB)
-    return 0; // Not supported
+    return XB_FMT_UNKNOWN; // Not supported
   if (m_desc.pixelFormat.flags & DDPF_FOURCC)
   {
     if (strncmp((const char *)&m_desc.pixelFormat.fourcc, "DXT1", 4) == 0)
@@ -58,7 +58,7 @@ unsigned int CDDSImage::GetFormat() const
     if (strncmp((const char *)&m_desc.pixelFormat.fourcc, "ARGB", 4) == 0)
       return XB_FMT_A8R8G8B8;
   }
-  return 0;
+  return XB_FMT_UNKNOWN;
 }
 
 unsigned int CDDSImage::GetSize() const
@@ -100,7 +100,9 @@ bool CDDSImage::ReadFile(const std::string &inputFile)
   return true;
 }
 
-unsigned int CDDSImage::GetStorageRequirements(unsigned int width, unsigned int height, unsigned int format)
+unsigned int CDDSImage::GetStorageRequirements(unsigned int width,
+                                               unsigned int height,
+                                               XB_FMT format)
 {
   switch (format)
   {
@@ -115,7 +117,7 @@ unsigned int CDDSImage::GetStorageRequirements(unsigned int width, unsigned int 
   }
 }
 
-void CDDSImage::Allocate(unsigned int width, unsigned int height, unsigned int format)
+void CDDSImage::Allocate(unsigned int width, unsigned int height, XB_FMT format)
 {
   memset(&m_desc, 0, sizeof(m_desc));
   m_desc.size = sizeof(m_desc);
@@ -131,7 +133,7 @@ void CDDSImage::Allocate(unsigned int width, unsigned int height, unsigned int f
   m_data = new unsigned char[m_desc.linearSize];
 }
 
-const char *CDDSImage::GetFourCC(unsigned int format)
+const char* CDDSImage::GetFourCC(XB_FMT format)
 {
   switch (format)
   {

--- a/xbmc/guilib/DDSImage.h
+++ b/xbmc/guilib/DDSImage.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "TextureFormats.h"
+
 #include <stdint.h>
 #include <string>
 
@@ -15,22 +17,24 @@ class CDDSImage
 {
 public:
   CDDSImage();
-  CDDSImage(unsigned int width, unsigned int height, unsigned int format);
+  CDDSImage(unsigned int width, unsigned int height, XB_FMT format);
   ~CDDSImage();
 
   unsigned int GetWidth() const;
   unsigned int GetHeight() const;
-  unsigned int GetFormat() const;
+  XB_FMT GetFormat() const;
   unsigned int GetSize() const;
   unsigned char *GetData() const;
 
   bool ReadFile(const std::string &file);
 
 private:
-  void Allocate(unsigned int width, unsigned int height, unsigned int format);
-  static const char *GetFourCC(unsigned int format);
+  void Allocate(unsigned int width, unsigned int height, XB_FMT format);
+  static const char* GetFourCC(XB_FMT format);
 
-  static unsigned int GetStorageRequirements(unsigned int width, unsigned int height, unsigned int format);
+  static unsigned int GetStorageRequirements(unsigned int width,
+                                             unsigned int height,
+                                             XB_FMT format);
   enum {
     ddsd_caps        = 0x00000001,
     ddsd_height      = 0x00000002,

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -37,7 +37,7 @@
 /************************************************************************/
 /*                                                                      */
 /************************************************************************/
-CTexture::CTexture(unsigned int width, unsigned int height, unsigned int format)
+CTexture::CTexture(unsigned int width, unsigned int height, XB_FMT format)
 {
   m_pixels = NULL;
   m_loadedToGPU = false;
@@ -50,7 +50,7 @@ CTexture::~CTexture()
   m_pixels = NULL;
 }
 
-void CTexture::Allocate(unsigned int width, unsigned int height, unsigned int format)
+void CTexture::Allocate(unsigned int width, unsigned int height, XB_FMT format)
 {
   m_imageWidth = m_originalWidth = width;
   m_imageHeight = m_originalHeight = height;
@@ -117,7 +117,7 @@ void CTexture::Allocate(unsigned int width, unsigned int height, unsigned int fo
 void CTexture::Update(unsigned int width,
                       unsigned int height,
                       unsigned int pitch,
-                      unsigned int format,
+                      XB_FMT format,
                       const unsigned char* pixels,
                       bool loadToGPU)
 {
@@ -357,7 +357,7 @@ bool CTexture::LoadIImage(IImage* pImage,
 bool CTexture::LoadFromMemory(unsigned int width,
                               unsigned int height,
                               unsigned int pitch,
-                              unsigned int format,
+                              XB_FMT format,
                               bool hasAlpha,
                               const unsigned char* pixels)
 {
@@ -372,7 +372,7 @@ bool CTexture::LoadFromMemory(unsigned int width,
 bool CTexture::LoadPaletted(unsigned int width,
                             unsigned int height,
                             unsigned int pitch,
-                            unsigned int format,
+                            XB_FMT format,
                             const unsigned char* pixels,
                             const COLOR* palette)
 {

--- a/xbmc/guilib/Texture.h
+++ b/xbmc/guilib/Texture.h
@@ -35,12 +35,12 @@ class CTexture
 {
 
 public:
-  CTexture(unsigned int width = 0, unsigned int height = 0, unsigned int format = XB_FMT_A8R8G8B8);
+  CTexture(unsigned int width = 0, unsigned int height = 0, XB_FMT format = XB_FMT_A8R8G8B8);
   virtual ~CTexture();
 
   static std::unique_ptr<CTexture> CreateTexture(unsigned int width = 0,
                                                  unsigned int height = 0,
-                                                 unsigned int format = XB_FMT_A8R8G8B8);
+                                                 XB_FMT format = XB_FMT_A8R8G8B8);
 
   /*! \brief Load a texture from a file
    Loads a texture from a file, restricting in size if needed based on maxHeight and maxWidth.
@@ -73,8 +73,18 @@ public:
                                                         unsigned int idealWidth = 0,
                                                         unsigned int idealHeight = 0);
 
-  bool LoadFromMemory(unsigned int width, unsigned int height, unsigned int pitch, unsigned int format, bool hasAlpha, const unsigned char* pixels);
-  bool LoadPaletted(unsigned int width, unsigned int height, unsigned int pitch, unsigned int format, const unsigned char *pixels, const COLOR *palette);
+  bool LoadFromMemory(unsigned int width,
+                      unsigned int height,
+                      unsigned int pitch,
+                      XB_FMT format,
+                      bool hasAlpha,
+                      const unsigned char* pixels);
+  bool LoadPaletted(unsigned int width,
+                    unsigned int height,
+                    unsigned int pitch,
+                    XB_FMT format,
+                    const unsigned char* pixels,
+                    const COLOR* palette);
 
   bool HasAlpha() const;
 
@@ -105,8 +115,13 @@ public:
   int GetOrientation() const { return m_orientation; }
   void SetOrientation(int orientation) { m_orientation = orientation; }
 
-  void Update(unsigned int width, unsigned int height, unsigned int pitch, unsigned int format, const unsigned char *pixels, bool loadToGPU);
-  void Allocate(unsigned int width, unsigned int height, unsigned int format);
+  void Update(unsigned int width,
+              unsigned int height,
+              unsigned int pitch,
+              XB_FMT format,
+              const unsigned char* pixels,
+              bool loadToGPU);
+  void Allocate(unsigned int width, unsigned int height, XB_FMT format);
   void ClampToEdge();
 
   static unsigned int PadPow2(unsigned int x);
@@ -135,7 +150,7 @@ protected:
 
   unsigned char* m_pixels;
   bool m_loadedToGPU;
-  unsigned int m_format;
+  XB_FMT m_format;
   int m_orientation;
   bool m_hasAlpha =  true ;
   bool m_mipmapping =  false ;

--- a/xbmc/guilib/TextureDX.cpp
+++ b/xbmc/guilib/TextureDX.cpp
@@ -15,12 +15,12 @@
 
 std::unique_ptr<CTexture> CTexture::CreateTexture(unsigned int width,
                                                   unsigned int height,
-                                                  unsigned int format)
+                                                  XB_FMT format)
 {
   return std::make_unique<CDXTexture>(width, height, format);
 }
 
-CDXTexture::CDXTexture(unsigned int width, unsigned int height, unsigned int format)
+CDXTexture::CDXTexture(unsigned int width, unsigned int height, XB_FMT format)
   : CTexture(width, height, format)
 {
 }

--- a/xbmc/guilib/TextureDX.h
+++ b/xbmc/guilib/TextureDX.h
@@ -17,7 +17,7 @@
 class CDXTexture : public CTexture
 {
 public:
-  CDXTexture(unsigned int width = 0, unsigned int height = 0, unsigned int format = XB_FMT_UNKNOWN);
+  CDXTexture(unsigned int width = 0, unsigned int height = 0, XB_FMT format = XB_FMT_UNKNOWN);
   virtual ~CDXTexture();
 
   void CreateTextureObject();

--- a/xbmc/guilib/TextureFormats.h
+++ b/xbmc/guilib/TextureFormats.h
@@ -8,15 +8,21 @@
 
 #pragma once
 
-#define XB_FMT_MASK   0xffff ///< mask for format info - other flags are outside this
-#define XB_FMT_DXT_MASK   15
-#define XB_FMT_UNKNOWN     0
-#define XB_FMT_DXT1        1
-#define XB_FMT_DXT3        2
-#define XB_FMT_DXT5        4
-#define XB_FMT_DXT5_YCoCg  8
-#define XB_FMT_A8R8G8B8   16 // texture.xbt byte order (matches BGRA8)
-#define XB_FMT_A8         32
-#define XB_FMT_RGBA8      64
-#define XB_FMT_RGB8      128
-#define XB_FMT_OPAQUE  65536
+// clang-format off
+enum XB_FMT
+{
+  XB_FMT_UNKNOWN     = 0x0,
+  XB_FMT_DXT1        = 0x1,
+  XB_FMT_DXT3        = 0x2,
+  XB_FMT_DXT5        = 0x4,
+  XB_FMT_DXT5_YCoCg  = 0x8,
+  XB_FMT_DXT_MASK    = 0xF,
+
+  XB_FMT_A8R8G8B8    = 0x10, // texture.xbt byte order (matches BGRA8)
+  XB_FMT_A8          = 0x20,
+  XB_FMT_RGBA8       = 0x40,
+  XB_FMT_RGB8        = 0x80,
+  XB_FMT_MASK        = 0xFFFF,
+  XB_FMT_OPAQUE      = 0x10000,
+};
+// clang-format on

--- a/xbmc/guilib/TextureGL.cpp
+++ b/xbmc/guilib/TextureGL.cpp
@@ -20,12 +20,12 @@
 
 std::unique_ptr<CTexture> CTexture::CreateTexture(unsigned int width,
                                                   unsigned int height,
-                                                  unsigned int format)
+                                                  XB_FMT format)
 {
   return std::make_unique<CGLTexture>(width, height, format);
 }
 
-CGLTexture::CGLTexture(unsigned int width, unsigned int height, unsigned int format)
+CGLTexture::CGLTexture(unsigned int width, unsigned int height, XB_FMT format)
   : CTexture(width, height, format)
 {
   unsigned int major, minor;

--- a/xbmc/guilib/TextureGL.h
+++ b/xbmc/guilib/TextureGL.h
@@ -18,7 +18,7 @@
 class CGLTexture : public CTexture
 {
 public:
-  CGLTexture(unsigned int width = 0, unsigned int height = 0, unsigned int format = XB_FMT_A8R8G8B8);
+  CGLTexture(unsigned int width = 0, unsigned int height = 0, XB_FMT format = XB_FMT_A8R8G8B8);
   ~CGLTexture() override;
 
   void CreateTextureObject() override;

--- a/xbmc/guilib/XBTF.cpp
+++ b/xbmc/guilib/XBTF.cpp
@@ -72,14 +72,14 @@ void CXBTFFrame::SetUnpackedSize(uint64_t size)
   m_unpackedSize = size;
 }
 
-void CXBTFFrame::SetFormat(uint32_t format)
+void CXBTFFrame::SetFormat(XB_FMT format)
 {
   m_format = format;
 }
 
-uint32_t CXBTFFrame::GetFormat(bool raw) const
+XB_FMT CXBTFFrame::GetFormat(bool raw) const
 {
-  return raw ? m_format : (m_format & XB_FMT_MASK);
+  return raw ? m_format : static_cast<XB_FMT>(m_format & XB_FMT_MASK);
 }
 
 uint64_t CXBTFFrame::GetOffset() const

--- a/xbmc/guilib/XBTF.h
+++ b/xbmc/guilib/XBTF.h
@@ -28,8 +28,8 @@ public:
   uint32_t GetWidth() const;
   void SetWidth(uint32_t width);
 
-  uint32_t GetFormat(bool raw = false) const;
-  void SetFormat(uint32_t format);
+  XB_FMT GetFormat(bool raw = false) const;
+  void SetFormat(XB_FMT format);
 
   uint32_t GetHeight() const;
   void SetHeight(uint32_t height);
@@ -54,7 +54,7 @@ public:
 private:
   uint32_t m_width;
   uint32_t m_height;
-  uint32_t m_format;
+  XB_FMT m_format;
   uint64_t m_packedSize;
   uint64_t m_unpackedSize;
   uint64_t m_offset;

--- a/xbmc/guilib/XBTFReader.cpp
+++ b/xbmc/guilib/XBTFReader.cpp
@@ -134,7 +134,7 @@ bool CXBTFReader::Open(const std::string& path)
 
       if (!ReadUInt32(m_file, u32))
         return false;
-      frame.SetFormat(u32);
+      frame.SetFormat(static_cast<XB_FMT>(u32));
 
       if (!ReadUInt64(m_file, u64))
         return false;


### PR DESCRIPTION
This makes the `XB_FMT` related definition to an enum. This is just a code improvement as we can use the `XB_FMT` type
 rather than an unsigned int.

Pretty straightforward and shouldn't be any functional changes.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

None
