### PR TITLE
[Windows] fix playback of HDR material when Windows is already in HDR mode

### DIFF
--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -730,6 +730,7 @@ void DX::DeviceResources::ResizeBuffers()
     ComPtr<IDXGIDevice1> dxgiDevice;
     hr = m_d3dDevice.As(&dxgiDevice); CHECK_ERR();
     dxgiDevice->SetMaximumFrameLatency(1);
+    m_usedSwapChain = false;
   }
 
   CLog::LogF(LOGDEBUG, "end resize buffers.");
@@ -957,6 +958,7 @@ void DX::DeviceResources::HandleDeviceLost(bool removed)
 bool DX::DeviceResources::Begin()
 {
   HRESULT hr = m_swapChain->Present(0, DXGI_PRESENT_TEST);
+  m_usedSwapChain = true;
 
   // If the device was removed either by a disconnection or a driver upgrade, we
   // must recreate all device resources.
@@ -988,6 +990,7 @@ void DX::DeviceResources::Present()
   // frames that will never be displayed to the screen.
   DXGI_PRESENT_PARAMETERS parameters = {};
   HRESULT hr = m_swapChain->Present1(1, 0, &parameters);
+  m_usedSwapChain = true;
 
   // If the device was removed either by a disconnection or a driver upgrade, we
   // must recreate all device resources.
@@ -1292,6 +1295,18 @@ void DX::DeviceResources::SetHdrColorSpace(const DXGI_COLOR_SPACE_TYPE colorSpac
 
   if (SUCCEEDED(m_swapChain.As(&swapChain3)))
   {
+    // Set the color space on a new swap chain - not mandated by MS documentation but needed
+    // at least for some AMD, at least up to Adrenalin 23.4.3 / Windows driver 31.0.14043.7000
+    if (m_usedSwapChain &&
+        m_IsTransferPQ != (colorSpace == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020))
+    {
+      // Temporary release, can't hold references during swap chain re-creation
+      swapChain3 = nullptr;
+      DestroySwapChain();
+      CreateWindowSizeDependentResources();
+      m_swapChain.As(&swapChain3);
+    }
+
     if (SUCCEEDED(swapChain3->SetColorSpace1(colorSpace)))
     {
       m_IsTransferPQ = (colorSpace == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020);

--- a/xbmc/rendering/dx/DeviceResources.h
+++ b/xbmc/rendering/dx/DeviceResources.h
@@ -185,5 +185,6 @@ namespace DX
     bool m_IsTransferPQ;
     bool m_NV12SharedTexturesSupport{false};
     bool m_DXVA2SharedDecoderSurfaces{false};
+    bool m_usedSwapChain{false};
   };
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The current code sets the color space matching the played media long after the creation of the swap chain, except when Kodi switches the Windows HDR mode, forcing the creation of a new swap chain (the only case that works properly).

After some experiments, it seems that setting a colorspace has no effect on a used swap chain, at least on recent AMD GPU. That is not mentioned in MS documentation.

Made changes to:
* track the used status of a swap chain (was it presented)
* SetHdrColorSpace:
  * recreate the swap chain if it's been used

(untested: this change may also help with the setting of the HDR10 metadata)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Blown out picture for HDR video when the screen is in HDR mode when Kodi starts.

The issue sort of self-corrects when "Use display HDR capabilities" is enabled but it's not ideal. Play HDR 1st time: bad picture, Kodi switches screen to SDR when playback stops, play HDR 2nd time: Kodi switches HDR on, playback ok

The problem is possibly limited to AMD. I don't think it was reported before and I don't have other HDR-capable hardware to check.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 10 x64, AMD GPU
Combinations of:
* Windowed fullscreen and fullscreen exclusive
* "Use display HDR capabilities" on and off
* Kodi started with Windows HDR set to on and off
* SDR and HDR videos

Other than pre-existing problems when Windows HDR is switched while Kodi is running, things worked as expected (good picture).

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Maybe recent AMD only.
Kodi plays HDR correctly when the screen is already in HDR mode.
=> it's possible to set and leave the screen in HDR mode and Kodi will play any media SDR/HDR correctly.

## Screenshots (if appropriate):
Before:
unable to capture, taking a screenshots fixes the problem.

After: normal image
![image](https://user-images.githubusercontent.com/489377/236609174-3ea1b5a8-c80d-4d1a-b4f2-3ac684d045ce.png)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
