### PR TITLE
CPythonInvoker: fix python path by inserting custom path before default path

### DIFF
--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -222,29 +222,30 @@ bool CPythonInvoker::execute(const std::string& script, std::vector<std::wstring
     }
 
     PyObject* sysPath = PySys_GetObject("path");
-    Py_ssize_t listSize = PyList_Size(sysPath);
 
-    if (listSize > 0)
-      CLog::Log(LOGDEBUG, "CPythonInvoker({}): default python path:", GetId());
+    std::for_each(pythonPath.crbegin(), pythonPath.crend(),
+                  [&sysPath](const auto& path)
+                  {
+                    PyObject* pyPath = PyUnicode_FromString(path.c_str());
+                    PyList_Insert(sysPath, 0, pyPath);
 
-    for (Py_ssize_t index = 0; index < listSize; index++)
+                    Py_DECREF(pyPath);
+                  });
+
+    CLog::Log(LOGDEBUG, "CPythonInvoker({}): full python path:", GetId());
+
+    Py_ssize_t pathListSize = PyList_Size(sysPath);
+
+    for (Py_ssize_t index = 0; index < pathListSize; index++)
     {
+      if (index == 0 && !pythonPath.empty())
+        CLog::Log(LOGDEBUG, "CPythonInvoker({}):   custom python path:", GetId());
+
+      if (index == static_cast<ssize_t>(pythonPath.size()))
+        CLog::Log(LOGDEBUG, "CPythonInvoker({}):   default python path:", GetId());
+
       PyObject* pyPath = PyList_GetItem(sysPath, index);
-
-      CLog::Log(LOGDEBUG, "CPythonInvoker({}):   {}", GetId(), PyUnicode_AsUTF8(pyPath));
-    }
-
-    if (!pythonPath.empty())
-      CLog::Log(LOGDEBUG, "CPythonInvoker({}): adding path:", GetId());
-
-    for (const auto& path : pythonPath)
-    {
-      PyObject* pyPath = PyUnicode_FromString(path.c_str());
-      PyList_Append(sysPath, pyPath);
-
-      CLog::Log(LOGDEBUG, "CPythonInvoker({}):  {}", GetId(), PyUnicode_AsUTF8(pyPath));
-
-      Py_DECREF(pyPath);
+      CLog::Log(LOGDEBUG, "CPythonInvoker({}):     {}", GetId(), PyUnicode_AsUTF8(pyPath));
     }
 
     { // set the m_threadState to this new interp


### PR DESCRIPTION
This fixes #22985 reported by @matthuisman 

https://github.com/xbmc/xbmc/pull/21704 changed the way the python path order was handled. It put the custom python path after the default python path. This causes an issue where custom python modules are used for a specific add-on and the same module was installed on the system python path. The system python path would be ordered before the custom python path.

This PR inserts the custom python path at the beginning of the python path instead of the end.

I also made a minor change to the way the paths are logged. I'm not sure if that is desired or not.

Before:
```
2023-05-06 21:00:12.613 T:520144   debug <general>: CPythonInvoker(2): default python path:
2023-05-06 21:00:12.613 T:520144   debug <general>: CPythonInvoker(2):   /usr/lib64/python311.zip
2023-05-06 21:00:12.613 T:520144   debug <general>: CPythonInvoker(2):   /usr/lib64/python3.11
2023-05-06 21:00:12.613 T:520144   debug <general>: CPythonInvoker(2):   /usr/lib64/python3.11/lib-dynload
2023-05-06 21:00:12.613 T:520144   debug <general>: CPythonInvoker(2):   /usr/local/lib/python3.11/site-packages
2023-05-06 21:00:12.613 T:520144   debug <general>: CPythonInvoker(2):   /usr/lib64/python3.11/site-packages
2023-05-06 21:00:12.614 T:520144   debug <general>: CPythonInvoker(2):   /usr/lib/python3.11/site-packages
2023-05-06 21:00:12.614 T:520144   debug <general>: CPythonInvoker(2): adding path:
2023-05-06 21:00:12.614 T:520144   debug <general>: CPythonInvoker(2):  /home/lukas/.kodi/addons/plugin.video.youtube/resources/lib
2023-05-06 21:00:12.614 T:520144   debug <general>: CPythonInvoker(2):  /home/lukas/.kodi/addons/script.module.certifi/lib
2023-05-06 21:00:12.614 T:520144   debug <general>: CPythonInvoker(2):  /home/lukas/.kodi/addons/script.module.chardet/lib
2023-05-06 21:00:12.614 T:520144   debug <general>: CPythonInvoker(2):  /home/lukas/.kodi/addons/script.module.idna/lib
2023-05-06 21:00:12.614 T:520144   debug <general>: CPythonInvoker(2):  /home/lukas/.kodi/addons/script.module.infotagger/resources/modules
2023-05-06 21:00:12.614 T:520144   debug <general>: CPythonInvoker(2):  /home/lukas/.kodi/addons/script.module.inputstreamhelper/lib
2023-05-06 21:00:12.614 T:520144   debug <general>: CPythonInvoker(2):  /home/lukas/.kodi/addons/script.module.pysocks/lib
2023-05-06 21:00:12.614 T:520144   debug <general>: CPythonInvoker(2):  /home/lukas/.kodi/addons/script.module.requests/lib
2023-05-06 21:00:12.614 T:520144   debug <general>: CPythonInvoker(2):  /home/lukas/.kodi/addons/script.module.urllib3/lib

```

After:
```
2023-05-06 20:52:26.126 T:517352   debug <general>: CPythonInvoker(2): full python path:
2023-05-06 20:52:26.126 T:517352   debug <general>: CPythonInvoker(2):   custom python path:
2023-05-06 20:52:26.126 T:517352   debug <general>: CPythonInvoker(2):     /home/lukas/.kodi/addons/plugin.video.youtube/resources/lib
2023-05-06 20:52:26.126 T:517352   debug <general>: CPythonInvoker(2):     /home/lukas/.kodi/addons/script.module.certifi/lib
2023-05-06 20:52:26.126 T:517352   debug <general>: CPythonInvoker(2):     /home/lukas/.kodi/addons/script.module.chardet/lib
2023-05-06 20:52:26.126 T:517352   debug <general>: CPythonInvoker(2):     /home/lukas/.kodi/addons/script.module.idna/lib
2023-05-06 20:52:26.126 T:517352   debug <general>: CPythonInvoker(2):     /home/lukas/.kodi/addons/script.module.infotagger/resources/modules
2023-05-06 20:52:26.126 T:517352   debug <general>: CPythonInvoker(2):     /home/lukas/.kodi/addons/script.module.inputstreamhelper/lib
2023-05-06 20:52:26.126 T:517352   debug <general>: CPythonInvoker(2):     /home/lukas/.kodi/addons/script.module.pysocks/lib
2023-05-06 20:52:26.126 T:517352   debug <general>: CPythonInvoker(2):     /home/lukas/.kodi/addons/script.module.requests/lib
2023-05-06 20:52:26.126 T:517352   debug <general>: CPythonInvoker(2):     /home/lukas/.kodi/addons/script.module.urllib3/lib
2023-05-06 20:52:26.126 T:517352   debug <general>: CPythonInvoker(2):   default python path:
2023-05-06 20:52:26.126 T:517352   debug <general>: CPythonInvoker(2):     /usr/lib64/python311.zip
2023-05-06 20:52:26.126 T:517352   debug <general>: CPythonInvoker(2):     /usr/lib64/python3.11
2023-05-06 20:52:26.126 T:517352   debug <general>: CPythonInvoker(2):     /usr/lib64/python3.11/lib-dynload
2023-05-06 20:52:26.126 T:517352   debug <general>: CPythonInvoker(2):     /usr/local/lib/python3.11/site-packages
2023-05-06 20:52:26.126 T:517352   debug <general>: CPythonInvoker(2):     /usr/lib64/python3.11/site-packages
2023-05-06 20:52:26.126 T:517352   debug <general>: CPythonInvoker(2):     /usr/lib/python3.11/site-packages
```

The diff looks messy and is better viewed in the split view -> [link](https://github.com/xbmc/xbmc/pull/23244/files?diff=split&w=0)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

allows add-ons to work properly by allowing custom python modules to be preferred.

