### PR TITLE
CRenderInfo: remove unused member 'optimal_buffer_size'

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodec.cpp
@@ -96,7 +96,6 @@ CRenderInfo CRendererMediaCodec::GetRenderInfo()
 {
   CRenderInfo info;
   info.max_buffer_size = 4;
-  info.optimal_buffer_size = 3;
   return info;
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
@@ -69,7 +69,7 @@ bool CRendererMediaCodecSurface::Configure(const VideoPicture &picture, float fp
 CRenderInfo CRendererMediaCodecSurface::GetRenderInfo()
 {
   CRenderInfo info;
-  info.max_buffer_size = info.optimal_buffer_size = 4;
+  info.max_buffer_size = 4;
   return info;
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererStarfish.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererStarfish.cpp
@@ -83,7 +83,6 @@ CRenderInfo CRendererStarfish::GetRenderInfo()
 {
   CRenderInfo info;
   info.max_buffer_size = 4;
-  info.optimal_buffer_size = 3;
   return info;
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderInfo.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderInfo.h
@@ -24,13 +24,11 @@ struct CRenderInfo
   }
   void Reset()
   {
-    optimal_buffer_size = 0;
     max_buffer_size = 0;
     opaque_pointer = nullptr;
     m_deintMethods.clear();
     formats.clear();
   }
-  unsigned int optimal_buffer_size;
   unsigned int max_buffer_size;
   // Supported pixel formats, can be called before configure
   std::vector<AVPixelFormat> formats;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
@@ -163,7 +163,6 @@ CRenderInfo CRendererBase::GetRenderInfo()
     AV_PIX_FMT_YUV420P16
   };
   info.max_buffer_size = NUM_BUFFERS;
-  info.optimal_buffer_size = 4;
 
   return info;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
@@ -91,8 +91,6 @@ CRenderInfo CRendererDXVA::GetRenderInfo()
 {
   auto info = __super::GetRenderInfo();
 
-  const int buffers = NUM_BUFFERS + m_processor->PastRefs();
-  info.optimal_buffer_size = std::min(NUM_BUFFERS, buffers);
   info.m_deintMethods.push_back(VS_INTERLACEMETHOD_DXVA_AUTO);
 
   return  info;


### PR DESCRIPTION
## Description
CRenderInfo: remove unused member 'optimal_buffer_size'

## Motivation and context
`optimal_buffer_size` is initialized but never read/used.

## How has this been tested?
Build Windows x64

## What is the effect on users?
none / things more clear for developers

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
