### PR TITLE
[CMake][FlatC] Don't use local flatc with ENABLE_INTERNAL_FLATBUFFERS if versions don't match

### DIFF
--- a/cmake/modules/buildtools/FindFlatC.cmake
+++ b/cmake/modules/buildtools/FindFlatC.cmake
@@ -25,14 +25,15 @@ if(NOT TARGET flatbuffers::flatc)
                     OUTPUT_STRIP_TRAILING_WHITESPACE)
     string(REGEX MATCH "[^\n]* version [^\n]*" FLATBUFFERS_FLATC_VERSION "${FLATBUFFERS_FLATC_VERSION}")
     string(REGEX REPLACE ".* version (.*)" "\\1" FLATBUFFERS_FLATC_VERSION "${FLATBUFFERS_FLATC_VERSION}")
+  endif()
 
-  else()
+  set(MODULE_LC flatbuffers)
+  # Duplicate URL may exist from FindFlatbuffers.cmake
+  # unset otherwise it thinks we are providing a local file location and incorrect concatenation happens
+  unset(FLATBUFFERS_URL)
+  SETUP_BUILD_VARS()
 
-    set(MODULE_LC flatbuffers)
-    # Duplicate URL may exist from FindFlatbuffers.cmake
-    # unset otherwise it thinks we are providing a local file location and incorrect concatenation happens
-    unset(FLATBUFFERS_URL)
-    SETUP_BUILD_VARS()
+  if(NOT FLATBUFFERS_FLATC_EXECUTABLE OR (ENABLE_INTERNAL_FLATBUFFERS AND NOT "${FLATBUFFERS_FLATC_VERSION}" VERSION_EQUAL "${FLATBUFFERS_VER}"))
 
     # Override build type detection and always build as release
     set(FLATBUFFERS_BUILD_TYPE Release)


### PR DESCRIPTION
## Description

The internal headers and external flatc may not be compatible as seen at the moment with the Windows build failures on Jenkins. #23239 also contains this commit which rightfully triggered a rebuild of flatc which isn't compatible with the flatbuffers currently used on master.

## Motivation and context
Fix build with ENABLE_INTERNAL_FLATBUFFERS if flatbuffers are already installed system wide or available as an artefact of a prior build.

## How has this been tested?
It builds.

## What is the effect on users?
None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
