### PR TITLE
[windows] use curl instead of wget to download dependencies 

### DIFF
--- a/project/BuildDependencies/bin/wget.exe.sha256
+++ b/project/BuildDependencies/bin/wget.exe.sha256
@@ -1,1 +1,0 @@
-bc8a2eabcb5598b66ea8c4a385a8135887a5688d9ad5dd33d2d3d6716c9332e7  project/BuildDependencies/bin/wget.exe

--- a/project/BuildDependencies/bin/wget.exe.url
+++ b/project/BuildDependencies/bin/wget.exe.url
@@ -1,1 +1,0 @@
-https://eternallybored.org/misc/wget/1.21.1/64/wget.exe

--- a/project/BuildDependencies/scripts/get_formed.cmd
+++ b/project/BuildDependencies/scripts/get_formed.cmd
@@ -64,7 +64,7 @@ IF EXIST %1 (
 ) ELSE (
   CALL :setSubStageName Downloading %1...
   SET DOWNLOAD_URL=%KODI_MIRROR%/build-deps/win32/%1
-  %WGET% --tries=5 --retry-connrefused --waitretry=2 --show-progress "!DOWNLOAD_URL!" 2>&1
+  curl --retry 5 --retry-all-errors --retry-connrefused --retry-delay 5 --location --remote-name "!DOWNLOAD_URL!" 2>&1
   REM Apparently there's a quirk in cmd so this means if error level => 1
   IF ERRORLEVEL 1 (
     ECHO %1^|Download of !DOWNLOAD_URL! failed >> %FORMED_FAILED_LIST%

--- a/project/Win32BuildSetup/getdeploydependencies.bat
+++ b/project/Win32BuildSetup/getdeploydependencies.bat
@@ -11,7 +11,7 @@ if not exist %DOWNLOAD_FOLDER% mkdir %DOWNLOAD_FOLDER%
 
 if not exist %DOWNLOAD_FOLDER%\%DOWNLOAD_FILE% (
   echo Downloading vc143 redist...
-  ..\BuildDependencies\bin\wget --tries=5 --retry-connrefused --waitretry=2 -nv -O %DOWNLOAD_FOLDER%\%DOWNLOAD_FILE% %DOWNLOAD_URL%
+  curl --retry 5 --retry-all-errors --retry-connrefused --retry-delay 5 --location --output %DOWNLOAD_FOLDER%\%DOWNLOAD_FILE% %DOWNLOAD_URL%
 )
 :: Restore the previous current directory
 POPD

--- a/tools/buildsteps/windows/buildhelpers.sh
+++ b/tools/buildsteps/windows/buildhelpers.sh
@@ -37,9 +37,9 @@ do_wget() {
   local archive="$2"
 
   if [[ -z $archive ]]; then
-    wget --tries=5 --retry-connrefused --waitretry=2 --no-check-certificate -c -P /downloads/ $URL
+    curl --retry 5 --retry-all-errors --retry-connrefused --retry-delay 5 --location --output-dir /downloads/ --remote-name $URL
   else
-    wget --tries=5 --retry-connrefused --waitretry=2 --no-check-certificate -c $URL -O /downloads/$archive
+    curl --retry 5 --retry-all-errors --retry-connrefused --retry-delay 5 --location --output-dir /downloads/ --output $archive $URL
   fi
 }
 

--- a/tools/buildsteps/windows/buildhelpers.sh
+++ b/tools/buildsteps/windows/buildhelpers.sh
@@ -121,7 +121,7 @@ do_download() {
 
     do_print_status "$LIBNAME-$VERSION" "$blue_color" "Extracting"
     mkdir $LOCALSRCDIR && cd $LOCALSRCDIR
-    tar -xaf /downloads/$ARCHIVE --strip 1
+    tar -xf /downloads/$ARCHIVE --strip 1
   fi
   # applying patches
   local patches=(/xbmc/tools/buildsteps/windows/patches/*-$LIBNAME-*.patch)

--- a/tools/buildsteps/windows/download-dependencies.bat
+++ b/tools/buildsteps/windows/download-dependencies.bat
@@ -31,7 +31,6 @@ REM Can't run rmdir and md back to back. access denied error otherwise.
 IF EXIST %TMP_PATH% rmdir %TMP_PATH% /S /Q
 
 SET DL_PATH="%BUILD_DEPS_PATH%\downloads"
-SET WGET=%BUILD_DEPS_PATH%\bin\wget
 SET ZIP=%BUILD_DEPS_PATH%\..\Win32BuildSetup\tools\7z\7za
 
 IF NOT EXIST %DL_PATH% md %DL_PATH%

--- a/tools/buildsteps/windows/download-msys2.bat
+++ b/tools/buildsteps/windows/download-msys2.bat
@@ -84,7 +84,7 @@ if exist "%downloaddir%\%msysfile%" GOTO unpack
         ::download msys2 from our mirror
         set msysurl=%MSYS_MIRROR%/%msysfile%
     )
-    %instdir%\bin\wget --tries=20 --retry-connrefused --waitretry=2 --no-check-certificate -c -O %downloaddir%\%msysfile% %msysurl%
+    curl --retry 5 --retry-all-errors --retry-connrefused --retry-delay 5 --location --output %downloaddir%\%msysfile% %msysurl%
     if errorlevel == 1 (
         if exist "%downloaddir%\%msysfile%" del %downloaddir%\%msysfile%
         if %usemirror%==yes (
@@ -383,7 +383,7 @@ if exist %downloaddir%\%gaspreprocfile% goto extractGasPreproc
     echo -------------------------------------------------------------------------------
     echo.- Downloading gas-preprocessor.pl
     echo -------------------------------------------------------------------------------
-    %instdir%\bin\wget --tries=20 --retry-connrefused --waitretry=2 --no-check-certificate -c -O %downloaddir%\%gaspreprocfile% %gaspreprocurl%
+    curl --retry 5 --retry-all-errors --retry-connrefused --retry-delay 5 --location --output %downloaddir%\%gaspreprocfile% %gaspreprocurl%
 
 :extractGasPreproc
 if exist %instdir%\%msys2%\usr\bin\gas-preprocessor.pl goto end


### PR DESCRIPTION
This is intended to help our downloading issues on our windows builders.

Windows has had native curl support for a while now, let's use it instead of our custom wget binary.

We'll see what jenkins says. We may have to test this with clean workspaces. I'm also not sure if we need the `--verbose` switch but I wanted to leave it in to help diagnose any issues.

I also added a commit to fix the warning with `tar.exe`