### PR TITLE
[macos][nativewindowing] Fix label for fullscreen toggle

### DIFF
--- a/xbmc/platform/darwin/osx/XBMCApplication.mm
+++ b/xbmc/platform/darwin/osx/XBMCApplication.mm
@@ -57,7 +57,7 @@ static NSDictionary* _windowMenu = @{
     },
     @{@"title" : @"-"},
     @{
-      @"title" : @"Enter Full Screen",
+      @"title" : @"Toggle Full Screen",
       @"sel" : @"fullScreenToggle:",
       @"mod" : @(NSEventModifierFlagControl),
       @"key" : @"f"


### PR DESCRIPTION
## Description
Just something rather insignificant I've noticed while working on other stuff. The menu item for fullscreen toggle is actually called "Enter Full Screen" regardless of the fullscreen state. Means that if Kodi is running fullscreen the item is still called "Enter Full Screen". Just rename it to "Toggle Full Screen".

<img width="403" alt="image" src="https://user-images.githubusercontent.com/7375276/236797590-d9236125-0131-4f82-b7b1-a6396c7b286d.png">



