### PR TITLE
[macos][nativewindowing] Suport HiDPI (retina) displays

### DIFF
--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -106,13 +106,13 @@ static void AddResolution(std::vector<RESOLUTION_WHR> &resolutions, unsigned int
   int width  = resInfo.iScreenWidth;
   int height = resInfo.iScreenHeight;
   int flags  = resInfo.dwFlags & D3DPRESENTFLAG_MODEMASK;
+  std::string id = resInfo.strId;
   float refreshrate = resInfo.fRefreshRate;
 
   // don't touch RES_DESKTOP
   for (unsigned int idx = 1; idx < resolutions.size(); idx++)
-    if (   resolutions[idx].width == width
-        && resolutions[idx].height == height
-        &&(resolutions[idx].flags & D3DPRESENTFLAG_MODEMASK) == flags)
+    if (resolutions[idx].width == width && resolutions[idx].height == height &&
+        (resolutions[idx].flags & D3DPRESENTFLAG_MODEMASK) == flags && resolutions[idx].id == id)
     {
       // check if the refresh rate of this resolution is better suited than
       // the refresh rate of the resolution with the same width/height/interlaced
@@ -124,7 +124,7 @@ static void AddResolution(std::vector<RESOLUTION_WHR> &resolutions, unsigned int
       return;
     }
 
-  RESOLUTION_WHR res = {width, height, flags, (int)addindex};
+  RESOLUTION_WHR res = {width, height, flags, static_cast<int>(addindex), id};
   resolutions.push_back(res);
 }
 

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -18,6 +18,7 @@
 #include "utils/HDRCapabilities.h"
 
 #include <memory>
+#include <string>
 #include <vector>
 
 struct RESOLUTION_WHR
@@ -26,6 +27,7 @@ struct RESOLUTION_WHR
   int height;
   int flags; //< only D3DPRESENTFLAG_MODEMASK flags
   int ResInfo_Index;
+  std::string id;
 };
 
 struct REFRESHRATE

--- a/xbmc/windowing/osx/OpenGL/OSXGLView.mm
+++ b/xbmc/windowing/osx/OpenGL/OSXGLView.mm
@@ -46,7 +46,7 @@
     m_pixFmt = [[NSOpenGLPixelFormat alloc] initWithAttributes:wattrs];
     m_glcontext = [[NSOpenGLContext alloc] initWithFormat:m_pixFmt shareContext:nil];
   }
-
+  self.wantsBestResolutionOpenGLSurface = YES;
   [self updateTrackingAreas];
 
   GLint swapInterval = 1;

--- a/xbmc/windowing/osx/OpenGL/WindowControllerMacOS.mm
+++ b/xbmc/windowing/osx/OpenGL/WindowControllerMacOS.mm
@@ -54,7 +54,8 @@
 
 - (void)windowDidResize:(NSNotification*)aNotification
 {
-  NSRect rect = [self.window contentRectForFrameRect:self.window.frame];
+  NSRect rect = [self.window.contentView
+      convertRectToBacking:[self.window contentRectForFrameRect:self.window.frame]];
   int width = static_cast<int>(rect.size.width);
   int height = static_cast<int>(rect.size.height);
 
@@ -160,6 +161,13 @@
   if (!winSystem)
     return;
   winSystem->WindowChangedScreen();
+}
+
+- (void)windowDidChangeBackingProperties:(NSNotification*)notification
+{
+  // if the backing scale changes, we need to force resize the window
+  //! @TODO resize only when the backing scale changes, this can also be triggered when the colorspace changes (e.g. HDR/EDR)
+  [self windowDidResize:notification];
 }
 
 - (NSSize)windowWillResize:(NSWindow*)sender toSize:(NSSize)frameSize

--- a/xbmc/windowing/osx/WinEventsOSXImpl.mm
+++ b/xbmc/windowing/osx/WinEventsOSXImpl.mm
@@ -200,12 +200,14 @@
   if (!nsEvent.window || location.x < 0 || location.y < 0)
     return nsEvent;
 
+  location = [nsEvent.window convertPointToBacking:location];
+
   // cocoa world is upside down ...
   auto winSystem = dynamic_cast<CWinSystemOSX*>(CServiceBroker::GetWinSystem());
   if (!winSystem)
     return nsEvent;
 
-  NSRect frame = winSystem->GetWindowDimensions();
+  NSRect frame = [nsEvent.window convertRectToBacking:winSystem->GetWindowDimensions()];
   location.y = frame.size.height - location.y;
 
   XBMC_Event newEvent = {};

--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -40,6 +40,16 @@ public:
   CWinSystemOSX();
   ~CWinSystemOSX() override;
 
+  struct ScreenResolution
+  {
+    bool interlaced{false};
+    size_t resWidth{0};
+    size_t resHeight{0};
+    size_t pixelWidth{0};
+    size_t pixelHeight{0};
+    double refreshrate{0.0};
+  };
+
   // ITimerCallback interface
   void OnTimeout() override;
 
@@ -108,12 +118,11 @@ public:
 protected:
   std::unique_ptr<KODI::WINDOWING::IOSScreenSaver> GetOSScreenSaverImpl() override;
 
-  void GetScreenResolution(size_t* w, size_t* h, double* fps, unsigned long screenIdx);
+  ScreenResolution GetScreenResolution(unsigned long screenIdx);
   void EnableVSync(bool enable);
-  bool SwitchToVideoMode(int width, int height, double refreshrate);
+  bool SwitchToVideoMode(RESOLUTION_INFO& res);
   void FillInVideoModes();
   bool FlushBuffer();
-  void UpdateSafeAreaInsets();
 
   bool DestroyWindowInternal();
 

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -26,6 +26,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "threads/CriticalSection.h"
+#include "utils/StringUtils.h"
 #include "utils/log.h"
 #include "windowing/osx/CocoaDPMSSupport.h"
 #include "windowing/osx/OSScreenSaverOSX.h"
@@ -142,6 +143,32 @@ NSString* GetScreenName(NSUInteger screenIdx)
   return screenName;
 }
 
+EdgeInsets GetScreenEdgeInsets(NSUInteger screenIdx)
+{
+  EdgeInsets safeAreaInsets;
+  NSScreen* pScreen = NSScreen.screens[screenIdx];
+
+  // Update safeareainsets (display may have a notch)
+  //! @TODO update code block once minimal SDK version is bumped to at least 12.0 (remove NSInvocation and selector)
+  auto safeAreaInsetsSelector = @selector(safeAreaInsets);
+  if ([pScreen respondsToSelector:safeAreaInsetsSelector])
+  {
+    NSEdgeInsets insets;
+    NSMethodSignature* safeAreaSignature =
+        [pScreen methodSignatureForSelector:safeAreaInsetsSelector];
+    NSInvocation* safeAreaInvocation =
+        [NSInvocation invocationWithMethodSignature:safeAreaSignature];
+    [safeAreaInvocation setSelector:safeAreaInsetsSelector];
+    [safeAreaInvocation invokeWithTarget:pScreen];
+    [safeAreaInvocation getReturnValue:&insets];
+    // screen backing factor might be higher than 1 (point size vs pixel size in retina displays)
+    safeAreaInsets = EdgeInsets(
+        insets.right * pScreen.backingScaleFactor, insets.bottom * pScreen.backingScaleFactor,
+        insets.left * pScreen.backingScaleFactor, insets.top * pScreen.backingScaleFactor);
+  }
+  return safeAreaInsets;
+}
+
 NSString* screenNameForDisplay(NSUInteger screenIdx)
 {
   // screen id 0 is always called "Default"
@@ -209,14 +236,22 @@ NSUInteger GetDisplayIndex(const std::string& dispName)
 
 #pragma mark - Display Modes
 
-CFArrayRef GetAllDisplayModes(CGDirectDisplayID display)
+std::string ComputeVideoModeId(
+    size_t resWidth, size_t resHeight, size_t pixelWidth, size_t pixelHeight, bool interlaced)
+{
+  const char* hiDPIdesc = pixelWidth > resWidth && pixelHeight > resHeight ? " (HiDPI)" : "";
+  const char* interlacedDesc = interlaced ? "i" : "p";
+  return StringUtils::Format("{}x{}{}{}", resWidth, resHeight, interlacedDesc, hiDPIdesc);
+}
+
+CFArrayRef CopyAllDisplayModes(CGDirectDisplayID display)
 {
   int value = 1;
 
   CFNumberRef number = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &value);
   if (!number)
   {
-    CLog::Log(LOGERROR, "GetAllDisplayModes - could not create Number!");
+    CLog::LogF(LOGERROR, "Could not create Number!");
     return nullptr;
   }
 
@@ -227,7 +262,7 @@ CFArrayRef GetAllDisplayModes(CGDirectDisplayID display)
 
   if (!options)
   {
-    CLog::Log(LOGERROR, "GetAllDisplayModes - could not create Dictionary!");
+    CLog::LogF(LOGERROR, "Could not create Dictionary!");
     return nullptr;
   }
 
@@ -236,16 +271,66 @@ CFArrayRef GetAllDisplayModes(CGDirectDisplayID display)
 
   if (!displayModes)
   {
-    CLog::Log(LOGERROR, "GetAllDisplayModes - no displaymodes found!");
+    CLog::LogF(LOGERROR, "No displaymodes found!");
     return nullptr;
   }
 
   return displayModes;
 }
 
+CGDisplayModeRef CreateModeById(const std::string& modeId, NSUInteger screenIdx)
+{
+  if (modeId.empty())
+    return nullptr;
+
+  bool stretched;
+  bool interlaced;
+  bool safeForHardware;
+  size_t resWidth;
+  size_t resHeight;
+  size_t pixelWidth;
+  size_t pixelHeight;
+  size_t bitsperpixel;
+  RESOLUTION_INFO res;
+
+  CLog::LogF(LOGDEBUG, "Looking for mode for screen {} with id {}", screenIdx, modeId);
+
+  CFArrayRef allModes = CopyAllDisplayModes(GetDisplayID(screenIdx));
+
+  if (!allModes)
+    return nullptr;
+
+  for (int i = 0; i < CFArrayGetCount(allModes); ++i)
+  {
+    CGDisplayModeRef displayMode = (CGDisplayModeRef)CFArrayGetValueAtIndex(allModes, i);
+    uint32_t flags = CGDisplayModeGetIOFlags(displayMode);
+    stretched = (flags & kDisplayModeStretchedFlag) != 0;
+    bitsperpixel = DisplayBitsPerPixelForMode(displayMode);
+    safeForHardware = (flags & kDisplayModeSafetyFlags) != 0;
+    interlaced = (flags & kDisplayModeInterlacedFlag) != 0;
+    resWidth = CGDisplayModeGetWidth(displayMode);
+    resHeight = CGDisplayModeGetHeight(displayMode);
+    pixelWidth = CGDisplayModeGetPixelWidth(displayMode);
+    pixelHeight = CGDisplayModeGetPixelHeight(displayMode);
+
+    if (bitsperpixel == 32 && safeForHardware && !stretched &&
+        modeId == ComputeVideoModeId(resWidth, resHeight, pixelWidth, pixelHeight, interlaced))
+    {
+      CGDisplayModeRetain(displayMode);
+      CFRelease(allModes);
+      CLog::LogF(LOGDEBUG, "Found a match!");
+      return displayMode;
+    }
+  }
+
+  CFRelease(allModes);
+  CLog::LogF(LOGERROR, "No match found!");
+  return nullptr;
+}
+
 // try to find mode that matches the desired size, refreshrate
 // non interlaced, nonstretched, safe for hardware
-CGDisplayModeRef GetMode(size_t width, size_t height, double refreshrate, NSUInteger screenIdx)
+CGDisplayModeRef CreateMode(size_t width, size_t height, double refreshrate, NSUInteger screenIdx)
 {
   if (screenIdx >= [[NSScreen screens] count])
     return nullptr;
@@ -259,10 +344,10 @@ CGDisplayModeRef GetMode(size_t width, size_t height, double refreshrate, NSUInt
   double rate;
   RESOLUTION_INFO res;
 
-  CLog::Log(LOGDEBUG, "GetMode looking for suitable mode with {} x {} @ {} Hz on display {}", width,
-            height, refreshrate, screenIdx);
+  CLog::LogF(LOGDEBUG, "Looking for suitable mode with {} x {} @ {} Hz on display {}", width,
+             height, refreshrate, screenIdx);
 
-  CFArrayRef allModes = GetAllDisplayModes(GetDisplayID(screenIdx));
+  CFArrayRef allModes = CopyAllDisplayModes(GetDisplayID(screenIdx));
 
   if (!allModes)
     return nullptr;
@@ -275,22 +360,23 @@ CGDisplayModeRef GetMode(size_t width, size_t height, double refreshrate, NSUInt
     interlaced = (flags & kDisplayModeInterlacedFlag) != 0;
     bitsperpixel = DisplayBitsPerPixelForMode(displayMode);
     safeForHardware = (flags & kDisplayModeSafetyFlags) != 0;
-    w = CGDisplayModeGetWidth(displayMode);
-    h = CGDisplayModeGetHeight(displayMode);
+    w = CGDisplayModeGetPixelWidth(displayMode);
+    h = CGDisplayModeGetPixelHeight(displayMode);
+
     rate = CGDisplayModeGetRefreshRate(displayMode);
 
-    if ((bitsperpixel == 32) && (safeForHardware == true) && (stretched == false) &&
-        (interlaced == false) && (w == width) && (h == height) &&
-        (rate == refreshrate || rate == 0))
+    if (bitsperpixel == 32 && safeForHardware && !stretched && !interlaced == false && w == width &&
+        h == height && (rate == refreshrate || rate == 0))
     {
+      CGDisplayModeRetain(displayMode);
       CFRelease(allModes);
-      CLog::Log(LOGDEBUG, "GetMode found a match!");
-      return CGDisplayModeRetain(displayMode);
+      CLog::LogF(LOGDEBUG, "Found a match!");
+      return displayMode;
     }
   }
 
   CFRelease(allModes);
-  CLog::Log(LOGERROR, "GetMode - no match found!");
+  CLog::LogF(LOGERROR, "No match found!");
   return nullptr;
 }
 
@@ -305,7 +391,7 @@ CGDisplayModeRef BestMatchForMode(CGDirectDisplayID display,
   // Try to find a mode with the requested depth and equal or greater dimensions first.
   // If no match is found, try to find a mode with greater depth and same or greater dimensions.
   // If still no match is found, just use the current mode.
-  CFArrayRef allModes = GetAllDisplayModes(display);
+  CFArrayRef allModes = CopyAllDisplayModes(display);
 
   if (!allModes)
     return nullptr;
@@ -325,6 +411,7 @@ CGDisplayModeRef BestMatchForMode(CGDirectDisplayID display,
     if ((CGDisplayModeGetWidth(mode) == width) && (CGDisplayModeGetHeight(mode) == height))
     {
       displayMode = mode;
+      CGDisplayModeRetain(displayMode);
       break;
     }
   }
@@ -345,6 +432,7 @@ CGDisplayModeRef BestMatchForMode(CGDirectDisplayID display,
       if ((CGDisplayModeGetWidth(mode) == width) && (CGDisplayModeGetHeight(mode) == height))
       {
         displayMode = mode;
+        CGDisplayModeRetain(displayMode);
         break;
       }
     }
@@ -536,15 +624,9 @@ void CWinSystemOSX::HandleOnResetDevice()
 
 void CWinSystemOSX::AnnounceOnResetDevice()
 {
-  double currentFps = m_refreshRate;
-  size_t w = 0;
-  size_t h = 0;
-  const NSUInteger currentScreenIdx = m_lastDisplayNr;
-  // ensure that graphics context knows about the current refreshrate before
-  // doing the callbacks
-  GetScreenResolution(&w, &h, &currentFps, currentScreenIdx);
-
-  m_gfxContext->SetFPS(currentFps);
+  // ensure that graphics context knows about the current refreshrate before doing the callbacks
+  auto screenResolution = GetScreenResolution(m_lastDisplayNr);
+  m_gfxContext->SetFPS(screenResolution.refreshrate);
 
   std::unique_lock<CCriticalSection> lock(m_resourceSection);
   // tell any shared resources
@@ -620,14 +702,17 @@ bool CWinSystemOSX::CreateNewWindow(const std::string& name, bool fullScreen, RE
   m_bFullScreen = false;
   m_name = name;
 
+  __block NSRect bounds;
   dispatch_sync(dispatch_get_main_queue(), ^{
     auto title = [NSString stringWithUTF8String:m_name.c_str()];
     auto size = NSMakeSize(m_nWidth, m_nHeight);
+    // propose the window size based on the last stored RES_WINDOW resolution info
     m_appWindowController = [[XBMCWindowControllerMacOS alloc] initWithTitle:title
                                                                  defaultSize:size];
 
     m_appWindow = m_appWindowController.window;
     m_glView = m_appWindow.contentView;
+    bounds = m_appWindow.contentView.bounds;
   });
 
   [m_glView Update];
@@ -657,8 +742,18 @@ bool CWinSystemOSX::CreateNewWindow(const std::string& name, bool fullScreen, RE
 
   // get screen refreshrate - this is needed
   // when we startup in windowed mode and don't run through SetFullScreen
-  size_t dummy;
-  GetScreenResolution(&dummy, &dummy, &m_refreshRate, m_lastDisplayNr);
+  auto screenResolution = GetScreenResolution(m_lastDisplayNr);
+  m_refreshRate = screenResolution.refreshrate;
+
+  // NSWindowController decides what is the best size for the window, so make sure to
+  // update the stored resolution right after the window creation (it's used for example by the splash screen)
+  // with the actual size of the window.
+  // Make sure the window frame rect is converted to backing units ONLY after moving it to the display screen
+  // (as it might be moving to another non-HiDPI screen).
+  dispatch_sync(dispatch_get_main_queue(), ^{
+    bounds = [m_appWindow convertRectToBacking:bounds];
+  });
+  SetWindowResolution(bounds.size.width, bounds.size.height);
 
   // register platform dependent objects
   CDVDFactoryCodec::ClearHWAccels();
@@ -772,15 +867,6 @@ bool CWinSystemOSX::ResizeWindow(int newWidth, int newHeight, int newLeft, int n
     view = m_appWindow.contentView;
   });
 
-  if (view)
-  {
-    // It seems, that in macOS 10.15 this defaults to YES, but we currently do not support
-    // Retina resolutions properly. Ensure that the view uses a 1 pixel per point framebuffer.
-    dispatch_sync(dispatch_get_main_queue(), ^{
-      view.wantsBestResolutionOpenGLSurface = NO;
-    });
-  }
-
   if (newWidth < 0)
   {
     newWidth = [(NSWindow*)m_appWindow minSize].width;
@@ -807,9 +893,6 @@ bool CWinSystemOSX::ResizeWindow(int newWidth, int newHeight, int newLeft, int n
 bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays)
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
-
-  __block NSWindow* window = m_appWindow;
-
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
   m_lastDisplayNr = GetDisplayIndex(settings->GetString(CSettings::SETTING_VIDEOSCREEN_MONITOR));
   m_nWidth = res.iWidth;
@@ -817,21 +900,12 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
   const bool fullScreenState = m_bFullScreen;
   m_bFullScreen = fullScreen;
 
-  if (fullScreen || (!fullScreenState && m_fullscreenWillToggle))
-  {
-    UpdateSafeAreaInsets();
-  }
-
-  //handle resolution/refreshrate switching early here
+  // handle resolution/refreshrate switching early here
   if (m_bFullScreen)
   {
     // switch videomode
-    SwitchToVideoMode(res.iWidth, res.iHeight, static_cast<double>(res.fRefreshRate));
+    SwitchToVideoMode(res);
   }
-
-  dispatch_sync(dispatch_get_main_queue(), ^{
-    [window setAllowsConcurrentViewDrawing:NO];
-  });
 
   if (m_fullscreenWillToggle)
   {
@@ -853,12 +927,6 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
 
   if (m_bFullScreen)
   {
-    dispatch_sync(dispatch_get_main_queue(), ^{
-      [window.contentView setFrameSize:NSMakeSize(m_nWidth, m_nHeight)];
-      window.title = @"";
-      [window setAllowsConcurrentViewDrawing:YES];
-    });
-
     // Blank/Unblank other displays if requested.
     if (blankOtherDisplays)
     {
@@ -895,83 +963,9 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
   return true;
 }
 
-void CWinSystemOSX::UpdateSafeAreaInsets()
-{
-  // This is Cocoa Windowed FullScreen Mode
-  // Get the screen rect of our current display
-  NSScreen* pScreen = [NSScreen.screens objectAtIndex:m_lastDisplayNr];
-
-  // Update safeareainsets (display may have a notch)
-  //! @TODO update code block once minimal SDK version is bumped to at least 12.0 (remove NSInvocation and selector)
-  auto safeAreaInsetsSelector = @selector(safeAreaInsets);
-  if ([pScreen respondsToSelector:safeAreaInsetsSelector])
-  {
-    NSEdgeInsets insets;
-    NSMethodSignature* safeAreaSignature =
-        [pScreen methodSignatureForSelector:safeAreaInsetsSelector];
-    NSInvocation* safeAreaInvocation =
-        [NSInvocation invocationWithMethodSignature:safeAreaSignature];
-    [safeAreaInvocation setSelector:safeAreaInsetsSelector];
-    [safeAreaInvocation invokeWithTarget:pScreen];
-    [safeAreaInvocation getReturnValue:&insets];
-
-    RESOLUTION currentRes = m_gfxContext->GetVideoResolution();
-    RESOLUTION_INFO resInfo = m_gfxContext->GetResInfo(currentRes);
-    resInfo.guiInsets = EdgeInsets(insets.right, insets.bottom, insets.left, insets.top);
-    m_gfxContext->SetResInfo(currentRes, resInfo);
-  }
-}
-
-#pragma mark - Resolution
-
-void CWinSystemOSX::UpdateResolutions()
-{
-  CWinSystemBase::UpdateResolutions();
-
-  // Add desktop resolution
-  size_t w;
-  size_t h;
-  double fps;
-
-  const NSUInteger dispIdx =
-      GetDisplayIndex(CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(
-          CSettings::SETTING_VIDEOSCREEN_MONITOR));
-  GetScreenResolution(&w, &h, &fps, dispIdx);
-  NSString* const dispName = screenNameForDisplay(dispIdx);
-  UpdateDesktopResolution(CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP),
-                          dispName.UTF8String, static_cast<int>(w), static_cast<int>(h), fps, 0);
-
-  CDisplaySettings::GetInstance().ClearCustomResolutions();
-
-  // now just fill in the possible resolutions for the attached screens
-  // and push to the resolution info vector
-  FillInVideoModes();
-  CDisplaySettings::GetInstance().ApplyCalibrations();
-}
-
-void CWinSystemOSX::GetScreenResolution(size_t* w, size_t* h, double* fps, unsigned long screenIdx)
-{
-  CGDirectDisplayID display_id = (CGDirectDisplayID)GetDisplayID(screenIdx);
-  CGDisplayModeRef mode = CGDisplayCopyDisplayMode(display_id);
-  *w = CGDisplayModeGetWidth(mode);
-  *h = CGDisplayModeGetHeight(mode);
-  *fps = CGDisplayModeGetRefreshRate(mode);
-  CGDisplayModeRelease(mode);
-  if (static_cast<int>(*fps) == 0)
-  {
-    // NOTE: The refresh rate will be REPORTED AS 0 for many DVI and notebook displays.
-    *fps = 60.0;
-  }
-}
-
-bool CWinSystemOSX::HasValidResolution() const
-{
-  return m_gfxContext->GetVideoResolution() != RES_INVALID;
-}
-
 #pragma mark - Video Modes
 
-bool CWinSystemOSX::SwitchToVideoMode(int width, int height, double refreshrate)
+bool CWinSystemOSX::SwitchToVideoMode(RESOLUTION_INFO& res)
 {
   CGDisplayModeRef dispMode = nullptr;
 
@@ -982,28 +976,31 @@ bool CWinSystemOSX::SwitchToVideoMode(int width, int height, double refreshrate)
   // Figure out the screen size. (default to main screen)
   const CGDirectDisplayID display_id = GetDisplayID(screenIdx);
 
-  // find mode that matches the desired size, refreshrate
-  // non interlaced, nonstretched, safe for hardware
-  dispMode = GetMode(width, height, refreshrate, screenIdx);
+  // find mode that matches the desired size, refreshrate non interlaced, nonstretched, safe for hardware
 
-  //not found - fallback to bestemdeforparameters
+  // try to find an exact match first (by using the unique ids we assign to resolution infos)
+  dispMode = CreateModeById(res.strId, screenIdx);
   if (!dispMode)
   {
-    dispMode = BestMatchForMode(display_id, 32, width, height);
+    dispMode =
+        CreateMode(res.iWidth, res.iHeight, static_cast<double>(res.fRefreshRate), screenIdx);
+  }
+
+  // not found - fallback to bestmodeforparameters
+  if (!dispMode)
+  {
+    dispMode = BestMatchForMode(display_id, 32, res.iWidth, res.iHeight);
 
     if (!dispMode)
     {
-      dispMode = BestMatchForMode(display_id, 16, width, height);
+      dispMode = BestMatchForMode(display_id, 16, res.iWidth, res.iHeight);
 
       // still no match? fallback to current resolution of the display which HAS to work [tm]
       if (!dispMode)
       {
-        size_t currentWidth;
-        size_t currentHeight;
-        double currentRefresh;
-
-        GetScreenResolution(&currentWidth, &currentHeight, &currentRefresh, screenIdx);
-        dispMode = GetMode(currentWidth, currentHeight, currentRefresh, screenIdx);
+        auto screenResolution = GetScreenResolution(screenIdx);
+        dispMode = CreateMode(screenResolution.pixelWidth, screenResolution.pixelHeight,
+                              screenResolution.refreshrate, screenIdx);
 
         // no way to get a resolution set
         if (!dispMode)
@@ -1022,7 +1019,7 @@ bool CWinSystemOSX::SwitchToVideoMode(int width, int height, double refreshrate)
   m_refreshRate = CGDisplayModeGetRefreshRate(dispMode);
 
   Cocoa_CVDisplayLinkUpdate();
-
+  CFRelease(dispMode);
   return (err == kCGErrorSuccess);
 }
 
@@ -1037,16 +1034,19 @@ void CWinSystemOSX::FillInVideoModes()
     bool stretched;
     bool interlaced;
     bool safeForHardware;
-    size_t w;
-    size_t h;
+    size_t resWidth;
+    size_t resHeight;
+    size_t pixelWidth;
+    size_t pixelHeight;
     size_t bitsperpixel;
     double refreshrate;
     RESOLUTION_INFO res;
 
-    CFArrayRef displayModes = GetAllDisplayModes(GetDisplayID(disp));
+    CFArrayRef displayModes = CopyAllDisplayModes(GetDisplayID(disp));
     NSString* const dispName = screenNameForDisplay(disp);
+    res.guiInsets = GetScreenEdgeInsets(disp);
 
-    CLog::LogF(LOGINFO, "Display {} has name {}", disp, [dispName UTF8String]);
+    CLog::LogF(LOGINFO, "Display {} has name {}", disp, dispName.UTF8String);
 
     if (!displayModes)
       continue;
@@ -1061,26 +1061,32 @@ void CWinSystemOSX::FillInVideoModes()
       bitsperpixel = DisplayBitsPerPixelForMode(displayMode);
       safeForHardware = (flags & kDisplayModeSafetyFlags) != 0;
 
-      if ((bitsperpixel == 32) && (safeForHardware == true) && (stretched == false) &&
-          (interlaced == false))
+      if (bitsperpixel == 32 && safeForHardware && !stretched && !interlaced)
       {
-        w = CGDisplayModeGetWidth(displayMode);
-        h = CGDisplayModeGetHeight(displayMode);
+        resWidth = CGDisplayModeGetWidth(displayMode);
+        resHeight = CGDisplayModeGetHeight(displayMode);
+        pixelWidth = CGDisplayModeGetPixelWidth(displayMode);
+        pixelHeight = CGDisplayModeGetPixelHeight(displayMode);
         refreshrate = CGDisplayModeGetRefreshRate(displayMode);
         if (static_cast<int>(refreshrate) == 0) // LCD display?
         {
           // NOTE: The refresh rate will be REPORTED AS 0 for many DVI and notebook displays.
           refreshrate = 60.0;
         }
-        CLog::Log(LOGINFO, "Found possible resolution for display {} with {} x {} @ {} Hz", disp, w,
-                  h, refreshrate);
+        CLog::LogF(
+            LOGINFO,
+            "Found possible resolution for display {} ({}) with {} x {} @ {} Hz (pixel size: "
+            "{} x {})",
+            disp, dispName.UTF8String, resWidth, resHeight, refreshrate, pixelWidth, pixelHeight);
 
         // only add the resolution if it belongs to "our" screen
         // all others are only logged above...
         if (disp == dispIdx)
         {
-          UpdateDesktopResolution(res, (dispName != nil) ? [dispName UTF8String] : "Unknown",
-                                  static_cast<int>(w), static_cast<int>(h), refreshrate, 0);
+          res.strId = ComputeVideoModeId(resWidth, resHeight, pixelWidth, pixelHeight, interlaced);
+          UpdateDesktopResolution(res, (dispName != nil) ? dispName.UTF8String : "Unknown",
+                                  static_cast<int>(pixelWidth), static_cast<int>(pixelHeight),
+                                  refreshrate, 0);
           m_gfxContext->ResetOverscan(res);
           CDisplaySettings::GetInstance().AddResolutionInfo(res);
         }
@@ -1088,6 +1094,60 @@ void CWinSystemOSX::FillInVideoModes()
     }
     CFRelease(displayModes);
   }
+}
+
+#pragma mark - Resolution
+
+void CWinSystemOSX::UpdateResolutions()
+{
+  CWinSystemBase::UpdateResolutions();
+  const NSUInteger dispIdx =
+      GetDisplayIndex(CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(
+          CSettings::SETTING_VIDEOSCREEN_MONITOR));
+
+  auto screenResolution = GetScreenResolution(dispIdx);
+  NSString* const dispName = screenNameForDisplay(dispIdx);
+  RESOLUTION_INFO& resInfo = CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP);
+  resInfo.guiInsets = GetScreenEdgeInsets(dispIdx);
+  resInfo.strId = ComputeVideoModeId(screenResolution.resWidth, screenResolution.resHeight,
+                                     screenResolution.pixelWidth, screenResolution.pixelHeight,
+                                     screenResolution.interlaced);
+  UpdateDesktopResolution(
+      resInfo, dispName.UTF8String, static_cast<int>(screenResolution.pixelWidth),
+      static_cast<int>(screenResolution.pixelHeight), screenResolution.refreshrate, 0);
+
+  CDisplaySettings::GetInstance().ClearCustomResolutions();
+
+  // now just fill in the possible resolutions for the attached screens
+  // and push to the resolution info vector
+  FillInVideoModes();
+  CDisplaySettings::GetInstance().ApplyCalibrations();
+}
+
+CWinSystemOSX::ScreenResolution CWinSystemOSX::GetScreenResolution(unsigned long screenIdx)
+{
+  ScreenResolution screenResolution;
+  CGDirectDisplayID display_id = (CGDirectDisplayID)GetDisplayID(screenIdx);
+  CGDisplayModeRef mode = CGDisplayCopyDisplayMode(display_id);
+  uint32_t flags = CGDisplayModeGetIOFlags(mode);
+  screenResolution.interlaced = (flags & kDisplayModeInterlacedFlag) != 0;
+  screenResolution.resWidth = CGDisplayModeGetWidth(mode);
+  screenResolution.resHeight = CGDisplayModeGetHeight(mode);
+  screenResolution.pixelWidth = CGDisplayModeGetPixelWidth(mode);
+  screenResolution.pixelHeight = CGDisplayModeGetPixelHeight(mode);
+  screenResolution.refreshrate = CGDisplayModeGetRefreshRate(mode);
+  CGDisplayModeRelease(mode);
+  if (static_cast<int>(screenResolution.refreshrate) == 0)
+  {
+    // NOTE: The refresh rate will be REPORTED AS 0 for many DVI and notebook displays.
+    screenResolution.refreshrate = 60.0;
+  }
+  return screenResolution;
+}
+
+bool CWinSystemOSX::HasValidResolution() const
+{
+  return m_gfxContext->GetVideoResolution() != RES_INVALID;
 }
 
 #pragma mark - Window Move
@@ -1107,8 +1167,8 @@ void CWinSystemOSX::OnMove(int x, int y)
   static double oldRefreshRate = m_refreshRate;
   Cocoa_CVDisplayLinkUpdate();
 
-  size_t dummy = 0;
-  GetScreenResolution(&dummy, &dummy, &m_refreshRate, m_lastDisplayNr);
+  auto screenResolution = GetScreenResolution(m_lastDisplayNr);
+  m_refreshRate = screenResolution.refreshrate;
 
   if (oldRefreshRate != m_refreshRate)
   {
@@ -1151,16 +1211,24 @@ void CWinSystemOSX::NotifyScreenChangeIntention()
   const NSUInteger dispIdx =
       GetDisplayIndex(CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(
           CSettings::SETTING_VIDEOSCREEN_MONITOR));
-  NSScreen* screen = nil;
-  if (dispIdx < NSScreen.screens.count)
+  NSScreen* currentScreen;
+  NSScreen* targetScreen;
+  if (dispIdx < NSScreen.screens.count && m_lastDisplayNr < NSScreen.screens.count)
   {
-    screen = [NSScreen.screens objectAtIndex:dispIdx];
+    currentScreen = NSScreen.screens[m_lastDisplayNr];
+    targetScreen = NSScreen.screens[dispIdx];
   }
   // move the window to the center of the new screen
-  if (dispIdx != m_lastDisplayNr && screen)
+  if (dispIdx != m_lastDisplayNr && targetScreen && currentScreen)
   {
-    NSPoint windowPos =
-        NSMakePoint(NSMidX(screen.frame) - m_nWidth / 2, NSMidY(screen.frame) - m_nHeight / 2);
+    // moving from a HiDPI screen to a non-HiDPI screen requires that we scale the dimensions of
+    // the window properly. m_nWidth and m_nHeight store pixels (not points) after resize callbacks
+    const double backingFactor =
+        currentScreen.backingScaleFactor > targetScreen.backingScaleFactor
+            ? currentScreen.backingScaleFactor / targetScreen.backingScaleFactor
+            : currentScreen.backingScaleFactor;
+    NSPoint windowPos = NSMakePoint(NSMidX(targetScreen.frame) - (m_nWidth / backingFactor) / 2.0,
+                                    NSMidY(targetScreen.frame) - (m_nHeight / backingFactor) / 2.0);
     dispatch_sync(dispatch_get_main_queue(), ^{
       [m_appWindow setFrameOrigin:windowPos];
     });


### PR DESCRIPTION
## Description
This pull request adds support for High DPI (e.g. retina) displays in macOS native windowing. HiDPI displays have an OpenGL backing surface greater than 1 pixel per point, Kodi used to force 1:1 by setting `wantsBestResolutionOpenGLSurface` to `false`.
Adding support for retina displays was far from easy since the whole codebase assumes a pixel per point pretty much everywhere. Apart from the necessary conversions (`convertRectToBacking`, `convertPointToBacking`, etc) in resize and tracking area operations we also need some way to map the resolution to a specific resolution object that doesn't exactly match the actual width/height presented for the resolution. For instance, on my mac the default resolution is 1470x956 but with a backing factor of 2, the actual resolution actually being 2940x1920. 
To solve this, code has been added to the display settings to associate a string id to each found resolution, giving precedence over the computation of the resolution based on its internal properties. When selecting a resolution we try to match the id first, otherwise we fallback to best matching resolution just like before.

## Motivation and context
I have a mac with a builtin retina display. Kodi looked a bit too low res for my taste.

## How has this been tested?
Tested on an apple silicon mac (m2) with a builtin retina display. Also tested on a multiscreen setup with this mac.
Also tested on a x86 old mac air. I think I covered pretty much all use cases (including refresh rate/resolution switching).

Kodi on Windows was also verified to make sure the changes to display settings do not introduce regressions.

## What is the effect on users?
Kodi looks absolutely beautiful on recent macs now :)

## Screenshots (if appropriate):

(note: check the artifacts around the kodi logo, the time or the builtin mouse pointer size)

**Before:**
<img width="1470" alt="image" src="https://github.com/xbmc/xbmc/assets/7375276/cb0a2f6e-0b11-4af6-9b80-79475c126ad0">

<img width="1470" alt="image" src="https://github.com/xbmc/xbmc/assets/7375276/2eecf65c-3ff8-40f8-8eb2-267cfb1a697f">


**Now:**
<img width="1470" alt="image" src="https://github.com/xbmc/xbmc/assets/7375276/7effc0cf-d610-4aea-8d9f-30c44479871f">


<img width="1470" alt="image" src="https://github.com/xbmc/xbmc/assets/7375276/83fe543c-9508-451f-a7bb-3d5f4010361c">

<img width="1470" alt="image" src="https://github.com/xbmc/xbmc/assets/7375276/6b70a580-a55b-4e00-90bd-41d0e2ecb367">

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
