### PR TITLE
[macos][nativewindowing] Live react to blank/unblank setting change

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -850,9 +850,15 @@ bool CWinSystemOSX::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
       [window setAllowsConcurrentViewDrawing:YES];
     });
 
-    // Blank other displays if requested.
+    // Blank/Unblank other displays if requested.
     if (blankOtherDisplays)
+    {
       BlankOtherDisplays(m_lastDisplayNr);
+    }
+    else
+    {
+      UnblankDisplays(m_lastDisplayNr);
+    }
   }
   else
   {


### PR DESCRIPTION
## Description
Trivial fix for "live reacting" to the blank/unblank other displays setting. Currently we are only checking if `blanking` is enable . This means that if we disable the setting the other displays will remain blank (black window filling the screen) without being unblanked.