### PR TITLE
[macos][nativewindowing] Close blanking window on future target displ…

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -390,6 +390,16 @@ void BlankOtherDisplays(NSUInteger screenBeingUsed)
   }
 }
 
+void UnblankDisplay(NSUInteger screenToUnblank)
+{
+  if (screenToUnblank < blankingWindowControllers.size() &&
+      blankingWindowControllers[screenToUnblank])
+  {
+    [[blankingWindowControllers[screenToUnblank] window] close];
+    blankingWindowControllers[screenToUnblank] = nil;
+  }
+}
+
 void UnblankDisplays(NSUInteger screenBeingUsed)
 {
   for (NSUInteger i = 0; i < NSScreen.screens.count; i++)
@@ -399,8 +409,7 @@ void UnblankDisplays(NSUInteger screenBeingUsed)
       // Get rid of the blanking windows we created.
       // Note after closing the window, setting the NSWindowController to nil will dealoc
       dispatch_sync(dispatch_get_main_queue(), ^{
-        [[blankingWindowControllers[i] window] close];
-        blankingWindowControllers[i] = nil;
+        UnblankDisplay(i);
       });
     }
   }
@@ -1113,9 +1122,15 @@ void CWinSystemOSX::WindowChangedScreen()
 {
   // if we are here the user dragged the window to a different
   // screen and we return the screen of the window
+  const NSUInteger lastDisplay = m_lastDisplayNr;
   if (m_appWindow)
   {
     m_lastDisplayNr = GetDisplayIndex(GetDisplayIDFromScreen(m_appWindow.screen));
+  }
+  // force unblank the current display
+  if (lastDisplay != m_lastDisplayNr && m_bFullScreen)
+  {
+    UnblankDisplay(m_lastDisplayNr);
   }
 }
 


### PR DESCRIPTION
…ay after display lost

## Description
If "Blank other displays" is enabled Kodi will create black windows "blanking" all other displays apart from the one being used for the main kodi window. If this screen being used is lost/disconnected macOS will move the window back to the default screen which..was (and still is) fully black. This makes sure the screen is unblanked if the window moves to another screen, the window is fullscreen and the screen to which the window is moving is blanked.