### PR TITLE
android_main: process_input() fix is no longer needed

### DIFF
--- a/xbmc/platform/android/activity/android_main.cpp
+++ b/xbmc/platform/android/activity/android_main.cpp
@@ -28,8 +28,6 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <thread>
-
-#include <androidjni/SurfaceTexture.h>
 #include <unistd.h>
 
 namespace


### PR DESCRIPTION
## Description
It's no longer necessary to overwrite this function for events to be read by a while loop, this fix was [merged](https://android-review.googlesource.com/c/platform/development/+/54180/1/ndk/sources/android/native_app_glue/android_native_app_glue.c#187) into the ndk.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
