### PR TITLE
Fix Thumbnails of Rotated Pictures

### DIFF
--- a/xbmc/pictures/Picture.cpp
+++ b/xbmc/pictures/Picture.cpp
@@ -257,10 +257,11 @@ bool CPicture::CacheTexture(uint8_t *pixels, uint32_t width, uint32_t height, ui
       if (ScaleImage(pixels, width, height, pitch, AV_PIX_FMT_BGRA, (uint8_t*)buffer, dest_width,
                      dest_height, stride, AV_PIX_FMT_BGRA, scalingAlgorithm))
       {
-        if (!orientation || OrientateImage(buffer, dest_width, dest_height, orientation))
+        if (!orientation ||
+            OrientateImage(buffer, dest_width, dest_height, orientation, dest_width_aligned))
         {
           success = CreateThumbnailFromSurface((unsigned char*)buffer, dest_width, dest_height,
-                                               dest_width * 4, dest);
+                                               dest_width_aligned * 4, dest);
         }
       }
       delete[] buffer;
@@ -312,7 +313,9 @@ bool CPicture::CreateTiledThumb(const std::vector<std::string> &files, const std
                      texture->GetPitch(), AV_PIX_FMT_BGRA, (uint8_t*)scaled, width, height,
                      width * 4, AV_PIX_FMT_BGRA))
       {
-        if (!texture->GetOrientation() || OrientateImage(scaled, width, height, texture->GetOrientation()))
+        unsigned int stridePixels{width};
+        if (!texture->GetOrientation() ||
+            OrientateImage(scaled, width, height, texture->GetOrientation(), stridePixels))
         {
           success = true; // Flag that we at least had one successful image processed
           // drop into the texture
@@ -324,7 +327,7 @@ bool CPicture::CreateTiledThumb(const std::vector<std::string> &files, const std
           {
             memcpy(dest, src, width*4);
             dest += imageRes;
-            src += width;
+            src += stridePixels;
           }
         }
       }
@@ -379,32 +382,36 @@ bool CPicture::ScaleImage(uint8_t* in_pixels,
   return false;
 }
 
-bool CPicture::OrientateImage(uint32_t *&pixels, unsigned int &width, unsigned int &height, int orientation)
+bool CPicture::OrientateImage(uint32_t*& pixels,
+                              unsigned int& width,
+                              unsigned int& height,
+                              int orientation,
+                              unsigned int& stridePixels)
 {
   // ideas for speeding these functions up: http://cgit.freedesktop.org/pixman/tree/pixman/pixman-fast-path.c
   bool out = false;
   switch (orientation)
   {
     case 1:
-      out = FlipHorizontal(pixels, width, height);
+      out = FlipHorizontal(pixels, width, height, stridePixels);
       break;
     case 2:
-      out = Rotate180CCW(pixels, width, height);
+      out = Rotate180CCW(pixels, width, height, stridePixels);
       break;
     case 3:
-      out = FlipVertical(pixels, width, height);
+      out = FlipVertical(pixels, width, height, stridePixels);
       break;
     case 4:
-      out = Transpose(pixels, width, height);
+      out = Transpose(pixels, width, height, stridePixels);
       break;
     case 5:
-      out = Rotate270CCW(pixels, width, height);
+      out = Rotate270CCW(pixels, width, height, stridePixels);
       break;
     case 6:
-      out = TransposeOffAxis(pixels, width, height);
+      out = TransposeOffAxis(pixels, width, height, stridePixels);
       break;
     case 7:
-      out = Rotate90CCW(pixels, width, height);
+      out = Rotate90CCW(pixels, width, height, stridePixels);
       break;
     default:
       CLog::Log(LOGERROR, "Unknown orientation {}", orientation);
@@ -415,12 +422,13 @@ bool CPicture::OrientateImage(uint32_t *&pixels, unsigned int &width, unsigned i
 
 bool CPicture::FlipHorizontal(uint32_t*& pixels,
                               const unsigned int& width,
-                              const unsigned int& height)
+                              const unsigned int& height,
+                              const unsigned int& stridePixels)
 {
   // this can be done in-place easily enough
   for (unsigned int y = 0; y < height; ++y)
   {
-    uint32_t *line = pixels + y * width;
+    uint32_t* line = pixels + y * stridePixels;
     for (unsigned int x = 0; x < width / 2; ++x)
       std::swap(line[x], line[width - 1 - x]);
   }
@@ -429,13 +437,14 @@ bool CPicture::FlipHorizontal(uint32_t*& pixels,
 
 bool CPicture::FlipVertical(uint32_t*& pixels,
                             const unsigned int& width,
-                            const unsigned int& height)
+                            const unsigned int& height,
+                            const unsigned int& stridePixels)
 {
   // this can be done in-place easily enough
   for (unsigned int y = 0; y < height / 2; ++y)
   {
-    uint32_t *line1 = pixels + y * width;
-    uint32_t *line2 = pixels + (height - 1 - y) * width;
+    uint32_t* line1 = pixels + y * stridePixels;
+    uint32_t* line2 = pixels + (height - 1 - y) * stridePixels;
     for (unsigned int x = 0; x < width; ++x)
       std::swap(*line1++, *line2++);
   }
@@ -444,26 +453,30 @@ bool CPicture::FlipVertical(uint32_t*& pixels,
 
 bool CPicture::Rotate180CCW(uint32_t*& pixels,
                             const unsigned int& width,
-                            const unsigned int& height)
+                            const unsigned int& height,
+                            const unsigned int& stridePixels)
 {
   // this can be done in-place easily enough
   for (unsigned int y = 0; y < height / 2; ++y)
   {
-    uint32_t *line1 = pixels + y * width;
-    uint32_t *line2 = pixels + (height - 1 - y) * width + width - 1;
+    uint32_t* line1 = pixels + y * stridePixels;
+    uint32_t* line2 = pixels + (height - 1 - y) * stridePixels + width - 1;
     for (unsigned int x = 0; x < width; ++x)
       std::swap(*line1++, *line2--);
   }
   if (height % 2)
   { // height is odd, so flip the middle row as well
-    uint32_t *line = pixels + (height - 1)/2 * width;
+    uint32_t* line = pixels + (height - 1) / 2 * stridePixels;
     for (unsigned int x = 0; x < width / 2; ++x)
       std::swap(line[x], line[width - 1 - x]);
   }
   return true;
 }
 
-bool CPicture::Rotate90CCW(uint32_t *&pixels, unsigned int &width, unsigned int &height)
+bool CPicture::Rotate90CCW(uint32_t*& pixels,
+                           unsigned int& width,
+                           unsigned int& height,
+                           unsigned int& stridePixels)
 {
   uint32_t *dest = new uint32_t[width * height * 4];
   if (dest)
@@ -476,18 +489,22 @@ bool CPicture::Rotate90CCW(uint32_t *&pixels, unsigned int &width, unsigned int 
       for (unsigned int x = 0; x < d_width; x++)
       {
         *dst++ = *src;
-        src += width;
+        src += stridePixels;
       }
     }
     delete[] pixels;
     pixels = dest;
     std::swap(width, height);
+    stridePixels = width;
     return true;
   }
   return false;
 }
 
-bool CPicture::Rotate270CCW(uint32_t *&pixels, unsigned int &width, unsigned int &height)
+bool CPicture::Rotate270CCW(uint32_t*& pixels,
+                            unsigned int& width,
+                            unsigned int& height,
+                            unsigned int& stridePixels)
 {
   uint32_t *dest = new uint32_t[width * height * 4];
   if (!dest)
@@ -496,22 +513,27 @@ bool CPicture::Rotate270CCW(uint32_t *&pixels, unsigned int &width, unsigned int
   unsigned int d_height = width, d_width = height;
   for (unsigned int y = 0; y < d_height; y++)
   {
-    const uint32_t *src = pixels + width * (d_width - 1) + y; // y-th col from left, starting at bottom
-    uint32_t *dst = dest + d_width * y;                       // y-th row from top, starting at left
+    const uint32_t* src =
+        pixels + stridePixels * (d_width - 1) + y; // y-th col from left, starting at bottom
+    uint32_t* dst = dest + d_width * y; // y-th row from top, starting at left
     for (unsigned int x = 0; x < d_width; x++)
     {
       *dst++ = *src;
-      src -= width;
+      src -= stridePixels;
     }
   }
 
   delete[] pixels;
   pixels = dest;
   std::swap(width, height);
+  stridePixels = width;
   return true;
 }
 
-bool CPicture::Transpose(uint32_t *&pixels, unsigned int &width, unsigned int &height)
+bool CPicture::Transpose(uint32_t*& pixels,
+                         unsigned int& width,
+                         unsigned int& height,
+                         unsigned int& stridePixels)
 {
   uint32_t *dest = new uint32_t[width * height * 4];
   if (!dest)
@@ -525,17 +547,21 @@ bool CPicture::Transpose(uint32_t *&pixels, unsigned int &width, unsigned int &h
     for (unsigned int x = 0; x < d_width; x++)
     {
       *dst++ = *src;
-      src += width;
+      src += stridePixels;
     }
   }
 
   delete[] pixels;
   pixels = dest;
   std::swap(width, height);
+  stridePixels = width;
   return true;
 }
 
-bool CPicture::TransposeOffAxis(uint32_t *&pixels, unsigned int &width, unsigned int &height)
+bool CPicture::TransposeOffAxis(uint32_t*& pixels,
+                                unsigned int& width,
+                                unsigned int& height,
+                                unsigned int& stridePixels)
 {
   uint32_t *dest = new uint32_t[width * height * 4];
   if (!dest)
@@ -544,17 +570,19 @@ bool CPicture::TransposeOffAxis(uint32_t *&pixels, unsigned int &width, unsigned
   unsigned int d_height = width, d_width = height;
   for (unsigned int y = 0; y < d_height; y++)
   {
-    const uint32_t *src = pixels + width * (d_width - 1) + (d_height - 1 - y); // y-th col from right, starting at bottom
+    const uint32_t* src = pixels + stridePixels * (d_width - 1) +
+                          (d_height - 1 - y); // y-th col from right, starting at bottom
     uint32_t *dst = dest + d_width * y;                                        // y-th row, starting at left
     for (unsigned int x = 0; x < d_width; x++)
     {
       *dst++ = *src;
-      src -= width;
+      src -= stridePixels;
     }
   }
 
   delete[] pixels;
   pixels = dest;
   std::swap(width, height);
+  stridePixels = width;
   return true;
 }

--- a/xbmc/pictures/Picture.cpp
+++ b/xbmc/pictures/Picture.cpp
@@ -260,7 +260,7 @@ bool CPicture::CacheTexture(uint8_t *pixels, uint32_t width, uint32_t height, ui
         if (!orientation || OrientateImage(buffer, dest_width, dest_height, orientation))
         {
           success = CreateThumbnailFromSurface((unsigned char*)buffer, dest_width, dest_height,
-                                               stride, dest);
+                                               dest_width * 4, dest);
         }
       }
       delete[] buffer;

--- a/xbmc/pictures/Picture.h
+++ b/xbmc/pictures/Picture.h
@@ -79,21 +79,40 @@ public:
       CPictureScalingAlgorithm::Algorithm scalingAlgorithm = CPictureScalingAlgorithm::NoAlgorithm);
 
 private:
-  static bool OrientateImage(uint32_t *&pixels, unsigned int &width, unsigned int &height, int orientation);
+  static bool OrientateImage(uint32_t*& pixels,
+                             unsigned int& width,
+                             unsigned int& height,
+                             int orientation,
+                             unsigned int& stridePixels);
 
   static bool FlipHorizontal(uint32_t*& pixels,
                              const unsigned int& width,
-                             const unsigned int& height);
+                             const unsigned int& height,
+                             const unsigned int& stridePixels);
   static bool FlipVertical(uint32_t*& pixels,
                            const unsigned int& width,
-                           const unsigned int& height);
-  static bool Rotate90CCW(uint32_t *&pixels, unsigned int &width, unsigned int &height);
-  static bool Rotate270CCW(uint32_t *&pixels, unsigned int &width, unsigned int &height);
+                           const unsigned int& height,
+                           const unsigned int& stridePixels);
+  static bool Rotate90CCW(uint32_t*& pixels,
+                          unsigned int& width,
+                          unsigned int& height,
+                          unsigned int& stridePixels);
+  static bool Rotate270CCW(uint32_t*& pixels,
+                           unsigned int& width,
+                           unsigned int& height,
+                           unsigned int& stridePixels);
   static bool Rotate180CCW(uint32_t*& pixels,
                            const unsigned int& width,
-                           const unsigned int& height);
-  static bool Transpose(uint32_t *&pixels, unsigned int &width, unsigned int &height);
-  static bool TransposeOffAxis(uint32_t *&pixels, unsigned int &width, unsigned int &height);
+                           const unsigned int& height,
+                           const unsigned int& stridePixels);
+  static bool Transpose(uint32_t*& pixels,
+                        unsigned int& width,
+                        unsigned int& height,
+                        unsigned int& width_aligned);
+  static bool TransposeOffAxis(uint32_t*& pixels,
+                               unsigned int& width,
+                               unsigned int& height,
+                               unsigned int& stridePixels);
 };
 
 //this class calls CreateThumbnailFromSurface in a CJob, so a png file can be written without halting the render thread


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

When saving a thumbnail, the function Orientate() switches width and height for the 90, 270, Transpose and TransposeOffAxis transformations and the stride needs to be adjusted to the new width.

commit 1 reverts a part of commit fa93cb0 that introduced dimension alignment to 16 bytes.

commit 2 fixes additional stride and alignment related issues and finishes the change started by fa93cb0:
When the width of the picture is not a multiple of 16, padding is added, which needs to be added to the width of the picture in all orientation algorithms. Otherwise the image looks corrupted. Stride is also recalculated in the transformations that swap width and height.

The two commits could be combined into one. I split in two commits because the first is very small and could be backported without issue, the second one is more complex and most pictures have aligned dimensions, avoiding the issue. Could still be backported IMO.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Noticed corruption in the Pictures and saw it reported recently in the forums (https://forum.kodi.tv/showthread.php?tid=371435)

While fixing the rotation problem I noticed flaws in the code for non-aligned dimensions. Testing confirmed the problem and a corruption similar to the original issue.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 10 x64
Applied all rotation algorithms to a picture, with dimension aligned to 16 and non-aligned.

Unfortunately, already generated thumbnails remain corrupted and the user has to delete them to get them recreated.

The fix probably also applies to thumbs generated from rotated videos but I don't have examples to check.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Correct thumbnails for rotated pictures (pictures taken in portrait mode for example) and pictures with dimensions that are not divisible by 16.

Existing thumbnails have to be deleted in order to be recreated correctly.

## Screenshots (if appropriate):
Example of corrupted picture thumbnail:

![image](https://github.com/xbmc/xbmc/assets/489377/b718a6a6-a642-44aa-98ca-2fe966f058f1)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
