### PR TITLE
Adds the ability to set UID/GID used for connection to the NFS server

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -22090,7 +22090,7 @@ msgstr ""
 #. Description of setting #37055 NFS connection User ID (UID)"
 #: xbmc/filesystem/NFSFile.cpp
 msgctxt "#37056"
-msgid "NFS User ID (UID) to be used by NFS connections. This UID must match a UID of the NAS system (/etc/passwd). The value is between 1000 and 60000."
+msgid "NFS User ID (UID) to be used by NFS connections. This UID must match a UID already present on the NFS server. The value is between 1000 and 60000."
 msgstr ""
 
 #. Setting #37055 NFS connection Group ID (GID)"

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -22096,7 +22096,7 @@ msgstr ""
 #. Setting #37055 NFS connection Group ID (GID)"
 #: xbmc/filesystem/NFSFile.cpp
 msgctxt "#37057"
-msgid "NFS connection Goup ID (GID)"
+msgid "NFS connection Group ID (GID)"
 msgstr ""
 
 #. Description of setting #37057 NFS connection Group ID (GID)"

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -22069,7 +22069,43 @@ msgctxt "#37052"
 msgid "NFS protocol version to use when establishing NFS connections"
 msgstr ""
 
-#empty strings from id 37053 to 38010
+#. Setting #37053 NFS UID/GID settings"
+#: xbmc/filesystem/NFSFile.cpp
+msgctxt "#37053"
+msgid "Enable the NFS User ID (UID) and Group ID (GID)"
+msgstr ""
+
+#. Description of setting #37053 NFS UID/GID settings"
+#: xbmc/filesystem/NFSFile.cpp
+msgctxt "#37054"
+msgid "Enables the NFS User ID (UID) and Group ID (GID) settings for NFS connections. These UID/GID are used by NFS servers to match acls on the NAS File system. This avoids the use of squash options on exports."
+msgstr ""
+
+#. Setting #37055 NFS connection User ID (UID)"
+#: xbmc/filesystem/NFSFile.cpp
+msgctxt "#37055"
+msgid "NFS connection User ID (UID)"
+msgstr ""
+
+#. Description of setting #37055 NFS connection User ID (UID)"
+#: xbmc/filesystem/NFSFile.cpp
+msgctxt "#37056"
+msgid "NFS User ID (UID) to be used by NFS connections. This UID must match a UID of the NAS system (/etc/passwd). The value is between 1000 and 60000."
+msgstr ""
+
+#. Setting #37055 NFS connection Group ID (GID)"
+#: xbmc/filesystem/NFSFile.cpp
+msgctxt "#37057"
+msgid "NFS connection Goup ID (GID)"
+msgstr ""
+
+#. Description of setting #37057 NFS connection Group ID (GID)"
+#: xbmc/filesystem/NFSFile.cpp
+msgctxt "#37058"
+msgid "NFS Goup ID (GID) to be used by NFS connections. This GID must match a GID of the NAS system (/etc/group). The value is between 100 and 60000."
+msgstr ""
+
+#empty strings from id 37059 to 38010
 
 #. Setting #38011 "Show All Items entry"
 #: system/settings/settings.xml

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -22102,7 +22102,7 @@ msgstr ""
 #. Description of setting #37057 NFS connection Group ID (GID)"
 #: xbmc/filesystem/NFSFile.cpp
 msgctxt "#37058"
-msgid "NFS Goup ID (GID) to be used by NFS connections. This GID must match a GID of the NAS system (/etc/group). The value is between 100 and 60000."
+msgid "NFS Group ID (GID) to be used by NFS connections. This GID must match a GID already present on the NFS server. The value is between 100 and 60000."
 msgstr ""
 
 #empty strings from id 37059 to 38010

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2383,6 +2383,37 @@
           </constraints>
           <control type="spinner" format="integer" />
         </setting>
+        <setting id="nfs.enableids" type="boolean" label="37053" help="37054">
+          <level>2</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="nfs.uid" type="integer" label="37055" help="37056" parent="nfs.enableids">
+          <level>3</level>
+          <default>1000</default>
+          <constraints>
+            <minimum>1000</minimum>
+            <step>1</step>
+            <maximum>60000</maximum>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="nfs.enableids">true</dependency>
+          </dependencies>
+          <control type="edit" format="integer" />
+        </setting>
+        <setting id="nfs.gid" type="integer" label="37057" help="37058" parent="nfs.enableids">
+          <level>2</level>
+          <default>100</default>
+          <constraints>
+            <minimum>100</minimum>
+            <step>1</step>
+            <maximum>60000</maximum>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="nfs.enableids">true</dependency>
+          </dependencies>
+          <control type="edit" format="integer" />
+        </setting>
       </group>
     </category>
     <category id="weather" label="8" help="36316">

--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -559,7 +559,7 @@ void CNfsConnection::setOptions(struct nfs_context* context)
 
   const bool isNfsIdsEnabled = settings->GetBool(SETTING_NFS_ENABLE_IDS);
 
-  if (isNfsEnableIDs)
+  if (isNfsIdsEnabled)
   {
     const int nfsUid = settings->GetInt(SETTING_NFS_UID);
     const int nfsGid = settings->GetInt(SETTING_NFS_GID);
@@ -568,7 +568,7 @@ void CNfsConnection::setOptions(struct nfs_context* context)
     nfs_set_gid(context, nfsGid);
 
     CLog::Log(LOGDEBUG, "NFS: UID: {}, GID {}", nfsUid, nfsGid);
-  } 
+  }
 }
 
 CNfsConnection gNfsConnection;

--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -557,7 +557,7 @@ void CNfsConnection::setOptions(struct nfs_context* context)
 
   CLog::Log(LOGDEBUG, "NFS: version: {}", nfsVersion);
 
-  const bool isNfsEnableIDs = settings->GetBool(SETTING_NFS_ENABLE_IDS);
+  const bool isNfsIdsEnabled = settings->GetBool(SETTING_NFS_ENABLE_IDS);
 
   if (isNfsEnableIDs)
   {

--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -56,6 +56,9 @@ constexpr auto IDLE_TIMEOUT = 30s; // close fast unused contexts when no active 
 constexpr int NFS4ERR_EXPIRED = -11; // client session expired due idle time greater than lease_time
 
 constexpr auto SETTING_NFS_VERSION = "nfs.version";
+constexpr auto SETTING_NFS_ENABLE_IDS = "nfs.enableids";
+constexpr auto SETTING_NFS_UID = "nfs.uid";
+constexpr auto SETTING_NFS_GID = "nfs.gid";
 } // unnamed namespace
 
 CNfsConnection::CNfsConnection()
@@ -553,6 +556,19 @@ void CNfsConnection::setOptions(struct nfs_context* context)
   }
 
   CLog::Log(LOGDEBUG, "NFS: version: {}", nfsVersion);
+
+  const bool isNfsEnableIDs = settings->GetBool(SETTING_NFS_ENABLE_IDS);
+
+  if (isNfsEnableIDs)
+  {
+    const int nfsUid = settings->GetInt(SETTING_NFS_UID);
+    const int nfsGid = settings->GetInt(SETTING_NFS_GID);
+
+    nfs_set_uid(context, nfsUid);
+    nfs_set_gid(context, nfsGid);
+
+    CLog::Log(LOGDEBUG, "NFS: UID: {}, GID {}", nfsUid, nfsGid);
+  } 
 }
 
 CNfsConnection gNfsConnection;


### PR DESCRIPTION
## Description
Adds the possibility to set the UID/GID used for the connection to the NFS server. These two new parameters are added to the NFS client service: the UID value and the GID value. They are conditioned by a boolean parameter which if disabled leaves the UID/GID defined by the underlying OS.

## Motivation and context
Les UID/GID attribués par Android ne sont pas nécessairement identiques d'une installation à une autre. Ainsi lorsque les librairies et base de données sont partagées entre plusieurs installation de Kodi sur différents OS, il devient complexe voire impossible de même en place des ACLs fonctionnels pour toutes les différentes installations sauf à tout surcharger avec les fonctionnalités de "squash" du serveur NAS. Avec cette capacité, il est désormais possible que toutes les installations utilisent les mêmes UID/GID et ainsi simplfie les ACLs 

## How has this been tested?
The test was done using the settings file widget to create a folder on the NAS (without squash option in the export) and then check that the UID/GID of the folder on the NAS file system are identical with those defined.

## What is the effect on users?
The effect is a simpler procedure to set up a shared library between different kodi's installations.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
