### PR TITLE
[backport] Revert "[cmake] glx: find glx library instead of gl"

### DIFF
--- a/cmake/modules/FindGLX.cmake
+++ b/cmake/modules/FindGLX.cmake
@@ -20,7 +20,7 @@ endif()
 
 find_path(GLX_INCLUDE_DIR NAMES GL/glx.h
                           PATHS ${PC_GLX_INCLUDEDIR})
-find_library(GLX_LIBRARY NAMES GLX
+find_library(GLX_LIBRARY NAMES GL
                          PATHS ${PC_GLX_LIBDIR})
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
backport of #23226 