### PR TITLE
Remove surround40 from ALSA pcm blacklist

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -1189,7 +1189,6 @@ void CAESinkALSA::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
        * "plughw", "dsnoop"). */
 
       else if (baseName != "default"
-            && baseName != "surround40"
             && baseName != "surround41"
             && baseName != "surround50"
             && baseName != "surround51"
@@ -1261,6 +1260,8 @@ void CAESinkALSA::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
 
   for (AEDeviceInfoList::iterator it1 = list.begin(); it1 != list.end(); ++it1)
   {
+    std::string replacementName = "";
+
     for (AEDeviceInfoList::iterator it2 = it1+1; it2 != list.end(); ++it2)
     {
       if (it1->m_displayName == it2->m_displayName
@@ -1290,9 +1291,13 @@ void CAESinkALSA::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
         }
 
         /* if we got here, the configuration is really weird, just append the whole device string */
-        it1->m_displayName += " (" + it1->m_deviceName + ")";
+        replacementName = it1->m_displayName + " (" + it1->m_deviceName + ")";
         it2->m_displayName += " (" + it2->m_deviceName + ")";
       }
+    }
+
+    if (!replacementName.empty()) {
+      it1->m_displayName = replacementName;
     }
   }
 


### PR DESCRIPTION
There is a real-world need to be able to force downmixing to 4.0 even if Kodi is configured for more channels and more channels are available.

For instance, a Klipsch ProMedia v.2-400 system has 4 speakers and a subwoofer, but the subwoofer is addressed with an internal crossover rather than a dedicated LFE connection.  It is connected via a C-Media 7.1 USB sound card which has 4 pairs of analog outputs, so the surroundXX detection performed on the '@' device falls through to 8 channels and sound is then output to center/LFE and rear speaker jacks instead of downmixed.  Those jacks are impossible to connect to the Klipsch system since it only has 2 inputs: front stereo and rear (surround) stereo 3.5mm.

Other late 1990s and early 2000s PC speaker systems designed for use with sound cards supporting positional audio will be similar.  These sound cards typically only had front and rear analog 3.5mm jacks and no center/LFE jack, so the speaker systems have two 3.5mm jacks for inputs and use a crossover to isolate LFE.

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
