### PR TITLE
[doc][webos] Remove outdated flatc section

### DIFF
--- a/docs/README.webOS.md
+++ b/docs/README.webOS.md
@@ -9,7 +9,6 @@ This guide has been tested with an adapted buildroot configuration where the Lin
 3. **[Configure the tool chain](#3-Configure-the-tool-chain)**
 4. **[Configure ares-cli tools](#4-Configure-ares-cli-tools)**
 5. **[Get the source code](#5-get-the-source-code)**  
-  5.1. **[5.1. Downgrade flatc binary](#51-Downgrade-flatc-binary)**
 6. **[Configure and build tools and dependencies](#6-configure-and-build-tools-and-dependencies)**  
   6.1. **[Advanced Configure Options](#61-Advanced-Configure-Options)**
 7. **[Generate Kodi Build files](#7-Generate-Kodi-Build-files)**  
@@ -101,19 +100,6 @@ Clone Kodi's current master branch:
 ```
 git clone https://github.com/xbmc/xbmc kodi
 ```
-
-### 5.1. Downgrade flatc binary
-
-The version of FlatBuffers in Kodi is currently locked to v2.0.0, the flatc binary installed onto your Linux system is likely
-to be much newer and therefore incompatible. You can get a version compatible here:
-
-```
-https://github.com/google/flatbuffers/releases/download/v2.0.0/Linux.flatc.binary.clang++-9.zip
-```
-
-Place flatc somewhere in your path, for example `/usr/local/bin`
-
-Alternatively, you may run `make -C native/flatc` when in $HOME/kodi/tools/depends which will compile it for you.
 
 **[back to top](#table-of-contents)**
 


### PR DESCRIPTION
## Description
With #23253 merged this workaround shouldn't be necessary anymore. At least I think so :wink: 

## Motivation and context
Simplify build instructions.

## How has this been tested?
Hasn't been tested at all. @sundermann, could you please verify that this workaround isn't necessary anymore?

## What is the effect on users?
None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [X] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
