### PR TITLE
Pipewire: Catch exceptions in CPipewire::Create()

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/Pipewire.cpp
@@ -12,6 +12,7 @@
 #include "PipewireCore.h"
 #include "PipewireRegistry.h"
 #include "PipewireThreadLoop.h"
+#include "commons/ilog.h"
 #include "utils/log.h"
 
 #include <pipewire/pipewire.h>
@@ -89,10 +90,18 @@ std::unique_ptr<CPipewire> CPipewire::Create()
     using CPipewire::CPipewire;
   };
 
-  auto pipewire = std::make_unique<PipewireMaker>();
+  try
+  {
+    auto pipewire = std::make_unique<PipewireMaker>();
 
-  if (!pipewire->Start())
+    if (!pipewire->Start())
+      return {};
+
+    return pipewire;
+  }
+  catch (const std::exception& e)
+  {
+    CLog::Log(LOGWARNING, "Pipewire: Exception in 'Create': {}", e.what());
     return {};
-
-  return pipewire;
+  }
 }


### PR DESCRIPTION
## Description
`CPlatformLinux::InitStageOne()` doesn't expect `OPTIONALS::*Register()` methods to throw so exceptions aren't handled, they bubble up the stack and crash the application.

## Motivation and context
An exception from `CAESinkPipewire::Register()` crashed Kodi in #23225 which isn't good behaviour even if the host system is setup in an expected way.

## How has this been tested?
Artificially create an exception in `CAESinkPipewire::Register()`. Kodi doesn't crash and instead initializes the pulseaudio interface.

## What is the effect on users?
Kodi doesn't crash maybe there even is sound.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
