### PR TITLE
webos: Limit maximum feedahead time

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecStarfish.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecStarfish.cpp
@@ -39,6 +39,7 @@ constexpr unsigned int MIN_BUFFER_LEVEL = 0;
 constexpr unsigned int MAX_BUFFER_LEVEL = 0;
 constexpr unsigned int MIN_SRC_BUFFER_LEVEL = 1 * 1024 * 1024; // 1 MB
 constexpr unsigned int MAX_SRC_BUFFER_LEVEL = 8 * 1024 * 1024; // 8 MB
+constexpr std::chrono::nanoseconds MAX_FEED_AHEAD_TIME = 1s;
 } // namespace
 
 CDVDVideoCodecStarfish::CDVDVideoCodecStarfish(CProcessInfo& processInfo)
@@ -328,7 +329,10 @@ bool CDVDVideoCodecStarfish::AddData(const DemuxPacket& packet)
     std::string result = m_starfishMediaAPI->Feed(json.c_str());
 
     if (result.find("Ok") != std::string::npos)
+    {
+      m_fedTimestamp = pts;
       return true;
+    }
 
     if (result.find("BufferFull") != std::string::npos)
       return false;
@@ -346,6 +350,7 @@ void CDVDVideoCodecStarfish::Reset()
 
   CLog::LogF(LOGDEBUG, "CDVDVideoCodecStarfish: Reset");
   m_starfishMediaAPI->flush();
+  m_fedTimestamp = TIMESTAMP_UNSET;
 
   m_state = StarfishState::FLUSHED;
 
@@ -374,7 +379,7 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecStarfish::GetPicture(VideoPicture* pVideo
   if (!m_opened)
     return VC_NONE;
 
-  if (m_state == StarfishState::FLUSHED)
+  if (m_state == StarfishState::FLUSHED || !m_videoReady)
   {
     return VC_BUFFER;
   }
@@ -385,7 +390,12 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecStarfish::GetPicture(VideoPicture* pVideo
 
   // The playtime didn't advance probably we need more data
   if (currentPlaytime == m_currentPlaytime)
-    return VC_BUFFER;
+  {
+    if (m_fedTimestamp == TIMESTAMP_UNSET || m_fedTimestamp - currentPlaytime < MAX_FEED_AHEAD_TIME)
+      return VC_BUFFER;
+    else
+      return VC_NONE;
+  }
 
   m_currentPlaytime = currentPlaytime;
 
@@ -509,6 +519,10 @@ void CDVDVideoCodecStarfish::PlayerCallback(const int32_t type,
     case PF_EVENT_TYPE_STR_STATE_UPDATE__LOADCOMPLETED:
       m_starfishMediaAPI->Play();
       m_state = StarfishState::FLUSHED;
+      break;
+    case PF_EVENT_TYPE_STR_VIDEO_INFO:
+      // getCurrentPlaytime will return correct values now
+      m_videoReady = true;
       break;
   }
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecStarfish.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecStarfish.h
@@ -97,13 +97,17 @@ private:
   std::string m_codecname;
   std::string m_formatname{"starfish"};
   bool m_opened{false};
+  bool m_videoReady{false};
   int m_codecControlFlags;
-  std::chrono::nanoseconds m_currentPlaytime{0};
+  std::chrono::nanoseconds m_currentPlaytime{TIMESTAMP_UNSET};
+  std::chrono::nanoseconds m_fedTimestamp{TIMESTAMP_UNSET};
 
   StarfishState m_state{StarfishState::FLUSHED};
 
   VideoPicture m_videobuffer;
   std::unique_ptr<CBitstreamConverter> m_bitstream;
+
+  static constexpr auto TIMESTAMP_UNSET = std::chrono::nanoseconds(-1);
 
   static constexpr auto ms_codecMap = make_map<AVCodecID, std::string_view>({
       {AV_CODEC_ID_VP8, "VP8"},


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Limit the maximum amount of seconds the pipeline can be fed ahead.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some users still reported excessive buffering after the bufferinfo changes. This enforces a hard limit of 1s maximum feedahead data. This is also implemented similarily in the chromium webOS sourcecode: https://github.com/webosose/chromium84-temp/blob/df04aa361ad493d47003a80ebfa3034dfc9de6e0/src/media/neva/webos/media_platform_api_webos_smp.cc#L513-L517C56

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
OLED77C28LB (webOS 7/22)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
