### PR TITLE
[FFmpegExtraData] Cleanups + fix a crash

### DIFF
--- a/xbmc/cores/FFmpeg.cpp
+++ b/xbmc/cores/FFmpeg.cpp
@@ -144,7 +144,8 @@ FFmpegExtraData::FFmpegExtraData(size_t size)
 
 FFmpegExtraData::FFmpegExtraData(const uint8_t* data, size_t size) : FFmpegExtraData(size)
 {
-  std::memcpy(m_data, data, size);
+  if (size > 0)
+    std::memcpy(m_data, data, size);
 }
 
 FFmpegExtraData::~FFmpegExtraData()
@@ -154,7 +155,8 @@ FFmpegExtraData::~FFmpegExtraData()
 
 FFmpegExtraData::FFmpegExtraData(const FFmpegExtraData& e) : FFmpegExtraData(e.m_size)
 {
-  std::memcpy(m_data, e.m_data, m_size);
+  if (m_size > 0)
+    std::memcpy(m_data, e.m_data, m_size);
 }
 
 FFmpegExtraData::FFmpegExtraData(FFmpegExtraData&& other) noexcept : FFmpegExtraData()
@@ -167,7 +169,7 @@ FFmpegExtraData& FFmpegExtraData::operator=(const FFmpegExtraData& other)
 {
   if (this != &other)
   {
-    if (m_size >= other.m_size) // reuse current buffer if large enough
+    if (m_size >= other.m_size && other.m_size > 0) // reuse current buffer if large enough
     {
       std::memcpy(m_data, other.m_data, other.m_size);
       m_size = other.m_size;
@@ -193,7 +195,7 @@ FFmpegExtraData& FFmpegExtraData::operator=(FFmpegExtraData&& other) noexcept
 
 bool FFmpegExtraData::operator==(const FFmpegExtraData& other) const
 {
-  return m_size == other.m_size && std::memcmp(m_data, other.m_data, m_size) == 0;
+  return m_size == other.m_size && (m_size == 0 || std::memcmp(m_data, other.m_data, m_size) == 0);
 }
 
 bool FFmpegExtraData::operator!=(const FFmpegExtraData& other) const

--- a/xbmc/cores/FFmpeg.cpp
+++ b/xbmc/cores/FFmpeg.cpp
@@ -203,6 +203,14 @@ bool FFmpegExtraData::operator!=(const FFmpegExtraData& other) const
   return !(*this == other);
 }
 
+uint8_t* FFmpegExtraData::TakeData()
+{
+  auto tmp = m_data;
+  m_data = nullptr;
+  m_size = 0;
+  return tmp;
+}
+
 FFmpegExtraData GetPacketExtradata(const AVPacket* pkt, const AVCodecParameters* codecPar)
 {
   constexpr int FF_MAX_EXTRADATA_SIZE = ((1 << 28) - AV_INPUT_BUFFER_PADDING_SIZE);

--- a/xbmc/cores/FFmpeg.cpp
+++ b/xbmc/cores/FFmpeg.cpp
@@ -136,8 +136,10 @@ void ff_avutil_log(void* ptr, int level, const char* format, va_list va)
 }
 
 FFmpegExtraData::FFmpegExtraData(size_t size)
-  : m_data(reinterpret_cast<uint8_t*>(av_malloc(size + AV_INPUT_BUFFER_PADDING_SIZE))), m_size(size)
+  : m_data(reinterpret_cast<uint8_t*>(av_mallocz(size + AV_INPUT_BUFFER_PADDING_SIZE))),
+    m_size(size)
 {
+  // using av_mallocz because some APIs require at least the padding to be zeroed, e.g. AVCodecParameters
   if (!m_data)
     throw std::bad_alloc();
 }

--- a/xbmc/cores/FFmpeg.h
+++ b/xbmc/cores/FFmpeg.h
@@ -93,6 +93,15 @@ public:
   uint8_t* GetData() { return m_data; }
   const uint8_t* GetData() const { return m_data; }
   size_t GetSize() const { return m_size; }
+  /*!
+   * \brief Take ownership over the extra data buffer
+   *
+   * It's in the responsibility of the caller to free the buffer with av_free. After the call
+   * FFmpegExtraData is empty.
+   *
+   * \return The extra data buffer or nullptr if FFmpegExtraData is empty.
+   */
+  uint8_t* TakeData();
 
 private:
   uint8_t* m_data{nullptr};

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -2302,7 +2302,7 @@ void CDVDDemuxFFmpeg::ParsePacket(AVPacket* pkt)
       if (retExtraData)
       {
         st->codecpar->extradata_size = retExtraData.GetSize();
-        st->codecpar->extradata = retExtraData.GetData();
+        st->codecpar->extradata = retExtraData.TakeData();
 
         if (parser->second->m_parserCtx->parser->parser_parse)
         {


### PR DESCRIPTION
## Description
Fixes some oversights from the initial implementation and a crash caused by a heap-use-after-free.

## Motivation and context
Fix #23285.

## How has this been tested?
File from #23285 is played and address sanitizer is happy.

## What is the effect on users?
No crashes when playing videos.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
