### PR TITLE
webos: Support E-AC3 passthrough mode

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkStarfish.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkStarfish.cpp
@@ -19,6 +19,14 @@ using namespace std::chrono_literals;
 
 namespace
 {
+// clang-format off
+constexpr std::array<unsigned int, 3> defaultSampleRates = {
+  32000,
+  44100,
+  48000
+};
+// clang-format on
+
 constexpr unsigned int STARFISH_AUDIO_BUFFERS = 8;
 constexpr unsigned int AC3_SYNCFRAME_SIZE = 2560;
 
@@ -52,7 +60,8 @@ void CAESinkStarfish::EnumerateDevicesEx(AEDeviceInfoList& list, bool force)
   CAEDeviceInfo info;
   info.m_deviceName = "Starfish";
   info.m_displayName = "Starfish (Passthrough only)";
-  info.m_channels = AE_CH_LAYOUT_5_1;
+  info.m_channels = AE_CH_LAYOUT_2_0;
+  info.m_sampleRates.assign(defaultSampleRates.begin(), defaultSampleRates.end());
   info.m_wantsIECPassthrough = false;
 
   // PCM disabled for now as the latency is just too high, needs more research


### PR DESCRIPTION
## Description
This PR adds necessary sample rates to webOS to allow E-AC3 (Dolby Digital Plus) to passthrough correctly. Without this patch only PCM (2.0) is offered.

Fixes: https://github.com/xbmc/xbmc/issues/23288

Thanks @fritsch

Note: even though AE_CH_LAYOUT_2_0 is specified, 5.1 audio is output. This is mentioned in PulseAudio also in kodi source code.

## Motivation and context
To support playback of DD+ audio.

## How has this been tested?
TV has been tested in TV Speaker as well as eARC mode to a Denon 2700H A/V receiver.

Dolby Digital 5.1 Plus test file activates Dolby Digital Plus:
https://ott.dolby.com/OnDelKits/DDP/Dolby_Digital_Plus_Online_Delivery_Kit_v1.4.1/Test_Signals/muxed_streams/MP4/Example/ChID_voices_1920x1080p_25fps_h265_6ch_256kbps_ddp.mp4

Dolby Atmos test file activates Dolby Digital Plus (ATMOS is **not** supported):
https://ott.dolby.com/OnDelKits/DDP/Dolby_Digital_Plus_Online_Delivery_Kit_v1.4.1/Test_Signals/muxed_streams/MP4/Example/ChID_voices_1920x1080p_25fps_h265_6ch_640kbps_ddp_joc.mp4

Dolby Digital 5.1 (not plus) test file activates Dolby Digital:
https://www.paolofiorani.it/TEST%20Audio/Ac3%20Dolby%20Digital%205.1Ch%20Sound%20Test.avi

Sample rates taken off: https://en.wikipedia.org/wiki/Dolby_Digital_Plus

## What is the effect on users?
Enjoy better quality audio on webOS

## Screenshots (if appropriate):
https://imgur.com/gHDXKgm
https://imgur.com/a/YdU1sFn

## Types of change
- [x] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
