### PR TITLE
VideoPlayer: ffmpeg change default software deinterlacer from yadif to bwdif

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -55,7 +55,7 @@ enum DecoderState
 
 enum EFilterFlags {
   FILTER_NONE                =  0x0,
-  FILTER_DEINTERLACE_YADIF   =  0x1,  //< use first deinterlace mode
+  FILTER_DEINTERLACE_BWDIF   =  0x1,  //< use first deinterlace mode
   FILTER_DEINTERLACE_ANY     =  0xf,  //< use any deinterlace mode
   FILTER_DEINTERLACE_FLAGGED = 0x10,  //< only deinterlace flagged frames
   FILTER_DEINTERLACE_HALFED  = 0x20,  //< do half rate deinterlacing
@@ -526,12 +526,12 @@ void CDVDVideoCodecFFmpeg::SetFilters()
       }
   }
 
-  if (filters & FILTER_DEINTERLACE_YADIF)
+  if (filters & FILTER_DEINTERLACE_BWDIF)
   {
     if (filters & FILTER_DEINTERLACE_HALFED)
-      m_filters_next = "yadif=0:-1";
+      m_filters_next = "bwdif=0:-1";
     else
-      m_filters_next = "yadif=1:-1";
+      m_filters_next = "bwdif=1:-1";
 
     if (filters & FILTER_DEINTERLACE_FLAGGED)
       m_filters_next += ":1";
@@ -1226,7 +1226,7 @@ int CDVDVideoCodecFFmpeg::FilterOpen(const std::string& filters, bool scale)
       return result;
     }
 
-    if (filters.compare(0,5,"yadif") == 0)
+    if (filters.compare(0,5,"bwdif") == 0)
     {
       m_processInfo.SetVideoDeintMethod(filters);
     }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -3007,7 +3007,7 @@ bool CFFmpegPostproc::Init(EINTERLACEMETHOD method)
   {
     std::string filter;
 
-    filter = "yadif=1:-1";
+    filter = "bwdif=1:-1";
 
     if (avfilter_graph_parse_ptr(m_pFilterGraph, filter.c_str(), &inputs, &outputs, NULL) < 0)
     {
@@ -3026,7 +3026,7 @@ bool CFFmpegPostproc::Init(EINTERLACEMETHOD method)
       return false;
     }
 
-    m_config.processInfo->SetVideoDeintMethod("yadif");
+    m_config.processInfo->SetVideoDeintMethod("bwdif");
   }
   else if (method == VS_INTERLACEMETHOD_RENDER_BOB ||
            method == VS_INTERLACEMETHOD_NONE)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Change default ffmpeg software deinterlacer from yadif to bwdif.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Better deinterlacing. Yadif has had it's time.

Deinterlacing can be subjective and source dependent but a reasonable updated benchmark puts bwdif significantly above yadif; [https://videoprocessing.ai/benchmarks/deinterlacer.html](https://videoprocessing.ai/benchmarks/deinterlacer.html)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have been using this patch for years. You can test this on an existing installation without recompiling by hex editing the kodi binary and replacing all occurrences of "yadif" with "bwdif".

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Better deinterlacing and a smidge less CPU usage (the best anecdotally was 50% quicker but unverified).

Note, ffmpeg has x86 SSE asm for both yadif and bwdif but no arm asm for either.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
