### PR TITLE
Adds UID / GID and permissions features in NFS Connections 

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -22625,7 +22625,90 @@ msgctxt "#37057"
 msgid "Data chunk size used on SMB connections"
 msgstr ""
 
-#empty strings from id 37058 to 37100
+#. Setting #37058 NFS UID/GID settings"
+#: xbmc/filesystem/NFSFile.cpp
+msgctxt "#37058"
+msgid "Enforce the NFS User ID (UID) and Group ID (GID)"
+msgstr ""
+
+
+#. Description of setting #37058 NFS UID/GID settings"
+#: xbmc/filesystem/NFSFile.cpp
+msgctxt "#37059"
+msgid "Enforces a User ID (UID) and Group ID (GID) for NFS connections. These UID/GID are used by NFS servers to match filesystem ACLs. This avoids the use of squash options on exports."
+msgstr ""
+
+#. Setting #37060 NFS connection User ID (UID)"
+#: xbmc/filesystem/NFSFile.cpp
+msgctxt "#37060"
+msgid "NFS connection User ID (UID)"
+msgstr ""
+
+#. Description of setting #37060 NFS connection User ID (UID)"
+#: xbmc/filesystem/NFSFile.cpp
+msgctxt "#37061"
+msgid "NFS User ID (UID) to be used by NFS connections. This UID should match a UID already present on the NFS server."
+msgstr ""
+
+#. Setting #37062 NFS connection Group ID (GID)"
+#: xbmc/filesystem/NFSFile.cpp
+msgctxt "#37062"
+msgid "NFS connection Group ID (GID)"
+msgstr ""
+
+#. Description of setting #37062 NFS connection Group ID (GID)"
+#: xbmc/filesystem/NFSFile.cpp
+msgctxt "#37063"
+msgid "NFS Group ID (GID) to be used by NFS connections. This GID should match a GID already present on the NFS server."
+msgstr ""
+
+#. Setting #37064 NFS Group and Other permissions"
+#: xbmc/filesystem/NFSFile.cpp
+msgctxt "#37064"
+msgid "Permissions used for file and directory creation"
+msgstr ""
+
+#. Setting #37065 NFS Group permissions"
+#: xbmc/filesystem/NFSFile.cpp
+msgctxt "#37065"
+msgid "Group permissons (....???...):"
+msgstr ""
+
+#. Description of setting #37065 NFS Group permissions"
+#: xbmc/filesystem/NFSFile.cpp
+msgctxt "#37066"
+msgid "Sets the permissions of the 'group' applied when creating files or directories"
+msgstr ""
+
+#: xbmc/filesystem/NFSFile.cpp
+msgctxt "#37067"
+msgid "No permisions: ---"
+msgstr ""
+
+#: xbmc/filesystem/NFSFile.cpp
+msgctxt "#37068"
+msgid "Read permissions: r-- (default)"
+msgstr ""
+
+#: xbmc/filesystem/NFSFile.cpp
+msgctxt "#37069"
+msgid "Write permissions: rw-"
+msgstr ""
+
+#. Setting #37070 NFS Other permissions"
+#: xbmc/filesystem/NFSFile.cpp
+msgctxt "#37070"
+msgid "Other permissons (.......???):"
+msgstr ""
+
+#. Description of setting #37070 NFS Other permissions"
+#: xbmc/filesystem/NFSFile.cpp
+msgctxt "#37071"
+msgid "Sets the permissions of 'other' applied when creating files or directories"
+msgstr ""
+
+#empty strings from id 37072 to 37100
+
 
 #. Settings / Services "Caching" category label
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2584,6 +2584,63 @@
           </constraints>
           <control type="spinner" format="integer" />
         </setting>
+       <setting id="nfs.enableids" type="boolean" label="37058" help="37059">
+          <level>2</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="nfs.uid" type="integer" label="37060" help="37061" parent="nfs.enableids">
+          <level>2</level>
+          <default>1000</default>
+          <constraints>
+            <minimum>1000</minimum>
+            <step>1</step>
+            <maximum>60000</maximum>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="nfs.enableids">true</dependency>
+          </dependencies>
+          <control type="edit" format="integer" />
+        </setting>
+        <setting id="nfs.gid" type="integer" label="37062" help="37063" parent="nfs.enableids">
+          <level>2</level>
+          <default>100</default>
+          <constraints>
+            <minimum>100</minimum>
+            <step>1</step>
+            <maximum>60000</maximum>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="nfs.enableids">true</dependency>
+          </dependencies>
+          <control type="edit" format="integer" />
+        </setting>
+      </group>
+      <group id="2" label="37064">
+        <setting id="nfs.grouppermissions" type="integer" label="37065" help="37066">
+          <level>3</level>
+          <default>40</default>
+          <constraints>
+            <options>
+              <option label="37067">0</option>
+              <option label="37068">40</option>
+              <option label="37069">56</option>
+            </options>
+          </constraints>
+          <control type="list" format="integer" />
+        </setting>
+        <setting id="nfs.otherpermissions" type="integer" label="37070" help="37071">
+          <level>3</level>
+          <default>5</default>
+          <constraints>
+            <options>
+              <option label="37067">0</option>
+              <option label="37068">5</option>
+              <option label="37069">7</option>
+            </options>
+          </constraints>
+          <control type="list" format="integer" />
+        </setting>
       </group>
       <group id="2" label="37053">
         <setting id="nfs.chunksize" type="integer" label="37054" help="37055">

--- a/xbmc/filesystem/NFSDirectory.cpp
+++ b/xbmc/filesystem/NFSDirectory.cpp
@@ -326,8 +326,8 @@ bool CNFSDirectory::Create(const CURL& url2)
   if(!gNfsConnection.Connect(url,folderName))
     return false;
 
-  ret = nfs_mkdir(gNfsConnection.GetNfsContext(), folderName.c_str());
-
+  ret = nfs_mkdir2(gNfsConnection.GetNfsContext(), folderName.c_str(),
+                   gNfsConnection.GetDirectoryPermissions());
   success = (ret == 0 || -EEXIST == ret);
   if(!success)
     CLog::Log(LOGERROR, "NFS: Failed to create({}) {}", folderName,

--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -33,10 +33,20 @@
 #endif
 
 #if defined(TARGET_WINDOWS)
-#define S_IRGRP 0
-#define S_IROTH 0
-#define S_IWUSR _S_IWRITE
-#define S_IRUSR _S_IREAD
+#define S_IRWXU 00700
+#define S_IRUSR 00400
+#define S_IWUSR 00200
+#define S_IXUSR 00100
+
+#define S_IRWXG 00070
+#define S_IRGRP 00040
+#define S_IWGRP 00020
+#define S_IXGRP 00010
+
+#define S_IRWXO 00007
+#define S_IROTH 00004
+#define S_IWOTH 00002
+#define S_IXOTH 00001
 #endif
 
 using namespace XFILE;
@@ -56,7 +66,14 @@ constexpr auto IDLE_TIMEOUT = 30s; // close fast unused contexts when no active 
 constexpr int NFS4ERR_EXPIRED = -11; // client session expired due idle time greater than lease_time
 
 constexpr auto SETTING_NFS_VERSION = "nfs.version";
+
 constexpr auto SETTING_NFS_CHUNKSIZE = "nfs.chunksize";
+
+constexpr auto SETTING_NFS_ENABLE_IDS = "nfs.enableids";
+constexpr auto SETTING_NFS_UID = "nfs.uid";
+constexpr auto SETTING_NFS_GID = "nfs.gid";
+constexpr auto SETTING_NFS_GROUP_PERMISSIONS = "nfs.grouppermissions";
+constexpr auto SETTING_NFS_OTHER_PERMISSIONS = "nfs.otherpermissions";
 } // unnamed namespace
 
 CNfsConnection::CNfsConnection()
@@ -64,7 +81,8 @@ CNfsConnection::CNfsConnection()
     m_exportPath(""),
     m_hostName(""),
     m_resolvedHostName(""),
-    m_IdleTimeout(std::chrono::steady_clock::now() + IDLE_TIMEOUT)
+    m_IdleTimeout(std::chrono::steady_clock::now() + IDLE_TIMEOUT),
+    m_protocolVersion(0)
 {
 }
 
@@ -146,7 +164,10 @@ struct nfs_context *CNfsConnection::getContextFromMap(const std::string &exportn
   struct nfs_context *pRet = NULL;
   std::unique_lock<CCriticalSection> lock(openContextLock);
 
+  SetVersionAndPermissions();
+
   tOpenContextMap::iterator it = m_openContextMap.find(exportname.c_str());
+
   if (it != m_openContextMap.end())
   {
     //check if context has timed out already
@@ -217,20 +238,12 @@ CNfsConnection::ContextStatus CNfsConnection::getContextForExport(const std::str
 
 bool CNfsConnection::splitUrlIntoExportAndPath(const CURL& url, std::string &exportPath, std::string &relativePath)
 {
+  SetVersionAndPermissions();
+
   //refresh exportlist if empty or hostname change
   if(m_exportList.empty() || !StringUtils::EqualsNoCase(url.GetHostName(), m_hostName))
   {
-    const auto settingsComponent = CServiceBroker::GetSettingsComponent();
-    if (!settingsComponent)
-      return false;
-
-    const auto settings = settingsComponent->GetSettings();
-    if (!settings)
-      return false;
-
-    const int nfsVersion = settings->GetInt(SETTING_NFS_VERSION);
-
-    if (nfsVersion == 4)
+    if (m_protocolVersion == 4)
       m_exportList = {"/"};
     else
       m_exportList = GetExportList(url);
@@ -577,6 +590,46 @@ void CNfsConnection::setOptions(struct nfs_context* context)
   }
 
   CLog::Log(LOGDEBUG, "NFS: version: {}", nfsVersion);
+
+  const bool isNfsIdsEnabled = settings->GetBool(SETTING_NFS_ENABLE_IDS);
+
+  if (isNfsIdsEnabled)
+  {
+    const int nfsUid = settings->GetInt(SETTING_NFS_UID);
+    const int nfsGid = settings->GetInt(SETTING_NFS_GID);
+
+    nfs_set_uid(context, nfsUid);
+    nfs_set_gid(context, nfsGid);
+
+    CLog::Log(LOGDEBUG, "NFS: UID: {}, GID {}", nfsUid, nfsGid);
+  }
+}
+
+void CNfsConnection::SetVersionAndPermissions()
+{
+  if (m_protocolVersion > 0)
+  {
+    return;
+  }
+
+  const auto settingsComponent = CServiceBroker::GetSettingsComponent();
+  if (!settingsComponent)
+    return;
+
+  const auto settings = settingsComponent->GetSettings();
+  if (!settings)
+    return;
+
+  m_protocolVersion = settings->GetInt(SETTING_NFS_VERSION);
+
+  const int nfsGroupPerms = settings->GetInt(SETTING_NFS_GROUP_PERMISSIONS);
+  const int nfsOtherPerms = settings->GetInt(SETTING_NFS_OTHER_PERMISSIONS);
+
+  m_directoryPermisssions = S_IRWXU | nfsGroupPerms | nfsOtherPerms;
+  m_filePermisssions = m_directoryPermisssions & ~(S_IXUSR | S_IXGRP | S_IXOTH);
+
+  CLog::Log(LOGDEBUG, "NFS: permissions: files {} (decimal), directories {} (decimal)",
+            m_filePermisssions, m_directoryPermisssions);
 }
 
 CNfsConnection gNfsConnection;
@@ -931,9 +984,12 @@ bool CNFSFile::OpenForWrite(const CURL& url, bool bOverWrite)
   {
     CLog::Log(LOGWARNING, "FileNFS::OpenForWrite() called with overwriting enabled! - {}",
               filename);
-    //create file with proper permissions
-    ret = nfs_creat(m_pNfsContext, filename.c_str(), S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH, &m_pFileHandle);
+    //create file with proper permissions.
+    //O_EXCL is required for the nfs V4 implementation of libnfs.
+    ret = nfs_create(m_pNfsContext, filename.c_str(), O_RDWR | O_EXCL,
+                     gNfsConnection.GetFilePermissions(), &m_pFileHandle);
     //if file was created the file handle isn't valid ... so close it and open later
+
     if(ret == 0)
     {
       nfs_close(m_pNfsContext,m_pFileHandle);

--- a/xbmc/filesystem/NFSFile.h
+++ b/xbmc/filesystem/NFSFile.h
@@ -68,6 +68,9 @@ public:
   const std::string& GetConnectedExport() const {return m_exportPath;}
   const std::string GetContextMapId() const {return m_hostName + m_exportPath;}
 
+  int GetDirectoryPermissions() { return m_directoryPermisssions; }
+  int GetFilePermissions() { return m_filePermisssions; }
+
 private:
   enum class ContextStatus
   {
@@ -102,6 +105,11 @@ private:
   void resolveHost(const CURL &url);//resolve hostname by dnslookup
   void keepAlive(const std::string& _exportPath, struct nfsfh* _pFileHandle);
   static void setOptions(struct nfs_context* context);
+  void SetVersionAndPermissions();
+
+  int m_protocolVersion;
+  int m_directoryPermisssions; //creation directory permissions
+  int m_filePermisssions; //creation file permissions
 };
 
 extern CNfsConnection gNfsConnection;


### PR DESCRIPTION
## Description
Adds the ability to set the UID/GID used for the connection to the NFS server. These two new parameters are added to the NFS client service: the UID value and the GID value. They are conditioned by a boolean parameter which if disabled leaves the UID/GID defined by the underlying OS.
Also fixes inappropriate permissions applied when creating files and directories with NFS version 4.
Adds the ability to set desired permissions when creating files and directories. 

## Motivation and context
The UID/GID assigned by Android are not necessarily identical from one installation to another. So when libraries and databases are shared between several Kodi installations on different OS, it becomes complex or even impossible to set up functional ACLs for all the different installations unless you overload everything with the squash features of the NAS server. With this capability, it is now possible for all installations to use the same UID/GID and thus simplify the ACLs.
In addition, the ability to explicitly set permissions finalizes the consistency of ACLs.

## How has this been tested?
The test was done using the settings file widget to create a folder and copy files to the NAS (without squash option in the export) and then check that the UID/GID of the folder on the NAS file system are identical with those defined. The tests were done with Android and Windows.

## What is the effect on users?
The effect is a simpler procedure to set up a shared library between different kodi's installations.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
