### PR TITLE
[RFC] TexturePacker: add zstd compression support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ if(NOT VERBOSE)
   set(CMAKE_REQUIRED_QUIET ON)
 endif()
 
+set(TEXTUREPACKER_COMPRESSION_METHOD "zstd" CACHE STRING "TexturePacker compression method [none|lzo|zstd]")
+
 # Includes
 include(cmake/modules/extra/ECMEnableSanitizers.cmake)
 include(cmake/scripts/common/GeneratorSetup.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,7 @@ set(required_deps ASS
                   TagLib
                   TinyXML
                   ZLIB
+                  ZSTD
                   ${PLATFORM_REQUIRED_DEPS})
 
 # Optional dependencies. Keep in alphabetical order please

--- a/cmake/modules/FindZSTD.cmake
+++ b/cmake/modules/FindZSTD.cmake
@@ -1,0 +1,35 @@
+#.rst:
+# FindZSTD
+# --------
+# Finds the ZSTD library
+#
+# This will define the following variables::
+#
+# ZSTD_FOUND - system has ZSTD
+# ZSTD_INCLUDE_DIRS - the ZSTD include directory
+# ZSTD_LIBRARIES - the ZSTD libraries
+#
+
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(PC_LIBZSTD libzstd QUIET)
+endif()
+
+find_path(ZSTD_INCLUDE_DIR NAMES zstd.h
+                           PATHS ${PC_LIBZSTD_INCLUDEDIR})
+
+find_library(ZSTD_LIBRARY NAMES zstd libzstd
+                          PATHS ${PC_LIBZSTD_LIBDIR})
+
+set(ZSTD_VERSION ${PC_LIBZSTD_VERSION})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(ZSTD
+                                  REQUIRED_VARS ZSTD_LIBRARY ZSTD_INCLUDE_DIR
+                                  VERSION_VAR ZSTD_VERSION)
+
+if(ZSTD_FOUND)
+  set(ZSTD_LIBRARIES ${ZSTD_LIBRARY})
+  set(ZSTD_INCLUDE_DIRS ${ZSTD_INCLUDE_DIR})
+endif()
+
+mark_as_advanced(ZSTD_INCLUDE_DIR ZSTD_LIBRARY)

--- a/cmake/scripts/common/ProjectMacros.cmake
+++ b/cmake/scripts/common/ProjectMacros.cmake
@@ -15,6 +15,7 @@ function(pack_xbt input output)
                      ARGS    -input ${input}
                              -output ${output}
                              -dupecheck
+                             -compression-method ${TEXTUREPACKER_COMPRESSION_METHOD}
                      DEPENDS ${MEDIA_FILES})
   list(APPEND XBT_FILES ${output})
   set(XBT_FILES ${XBT_FILES} PARENT_SCOPE)

--- a/tools/depends/native/Makefile
+++ b/tools/depends/native/Makefile
@@ -30,7 +30,8 @@ NATIVE= \
   python3 \
   swig \
   TexturePacker \
-  zlib
+  zlib \
+  zstd
 
 ifneq ($(NATIVE_OS),osx)
   NATIVE += libffi

--- a/tools/depends/native/Makefile
+++ b/tools/depends/native/Makefile
@@ -81,7 +81,7 @@ pugixml: cmake
 python3: $(EXPAT) $(LIBFFI) pkg-config zlib openssl autoconf-archive
 swig: pcre
 tar: xz automake
-TexturePacker: automake pkg-config libpng liblzo2 giflib libjpeg-turbo
+TexturePacker: automake pkg-config libpng liblzo2 giflib libjpeg-turbo zstd
 wayland-scanner: expat pkg-config
 waylandpp-scanner: cmake pugixml
 

--- a/tools/depends/native/TexturePacker/CMakeLists.txt
+++ b/tools/depends/native/TexturePacker/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(Lzo2 REQUIRED)
 find_package(PNG REQUIRED)
 find_package(GIF REQUIRED)
 find_package(JPEG REQUIRED)
+find_package(ZSTD REQUIRED)
 
 if(GIF_VERSION LESS 4)
   message(FATAL_ERROR "giflib < 4 not supported")
@@ -42,6 +43,7 @@ target_include_directories(TexturePacker
                            PRIVATE ${PNG_INCLUDE_DIRS}
                                     ${JPEG_INCLUDE_DIR}
                                     ${GIF_INCLUDE_DIR}
+                                    ${ZSTD_INCLUDE_DIRS}
                                     ${CMAKE_SOURCE_DIR}/xbmc
                                     ${CMAKE_CURRENT_SOURCE_DIR}/src
                                     ${CMAKE_CURRENT_SOURCE_DIR}/src/decoder)
@@ -50,5 +52,6 @@ target_link_libraries(TexturePacker
                               ${GIF_LIBRARIES}
                               ${PNG_LIBRARIES}
                               ${JPEG_LIBRARIES}
+                              ${ZSTD_LIBRARIES}
                               ${LZO2_LIBRARIES})
 target_compile_options(TexturePacker PRIVATE ${ARCH_DEFINES} ${SYSTEM_DEFINES})

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -224,6 +224,8 @@ CXBTFFrame TexturePacker::CreateXBTFFrame(DecodedFrame& decodedFrame, CXBTFWrite
       // compression failed, or compressed size is bigger than uncompressed, so store as uncompressed
       packedSize = size;
       writer.AppendContent(data, size);
+
+      frame.SetCompressionMethod(XBTFCompressionMethod::NONE);
     }
     else
     { // success
@@ -233,16 +235,22 @@ CXBTFFrame TexturePacker::CreateXBTFFrame(DecodedFrame& decodedFrame, CXBTFWrite
       { //optimisation failed
         packedSize = size;
         writer.AppendContent(data, size);
+
+        frame.SetCompressionMethod(XBTFCompressionMethod::NONE);
       }
       else
       { // success
         writer.AppendContent(packed.data(), packedSize);
+
+        frame.SetCompressionMethod(XBTFCompressionMethod::LZO);
       }
     }
   }
   else
   {
     writer.AppendContent(data, size);
+
+    frame.SetCompressionMethod(XBTFCompressionMethod::NONE);
   }
   frame.SetPackedSize(packedSize);
   frame.SetUnpackedSize(size);

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -44,6 +44,7 @@
 #define strncasecmp _strnicmp
 #endif
 
+#include <chrono>
 #include <vector>
 
 #include <lzo/lzo1x.h>
@@ -326,6 +327,8 @@ int TexturePacker::createBundle(const std::string& InputDir, const std::string& 
   std::vector<CXBTFFile> files = writer.GetFiles();
   m_dupes.resize(files.size());
 
+  const auto start = std::chrono::steady_clock::now();
+
   for (size_t i = 0; i < files.size(); i++)
   {
     struct MD5Context ctx;
@@ -386,6 +389,15 @@ int TexturePacker::createBundle(const std::string& InputDir, const std::string& 
 
     writer.UpdateFile(file);
   }
+
+  const auto end = std::chrono::steady_clock::now();
+
+  const auto diff =
+      std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(end - start);
+
+  printf(
+      "TexturePacker: processed %lu files in %.3f ms using %s\n", files.size(), diff.count(),
+      XBTFCompressionMethodMap.at(files.front().GetFrames().front().GetCompressionMethod()).data());
 
   if (!writer.UpdateHeader(m_dupes))
   {

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -350,10 +350,11 @@ int TexturePacker::createBundle(const std::string& InputDir, const std::string& 
         CXBTFFrame frame = CreateXBTFFrame(frames.frameList[j], writer);
         file.GetFrames().push_back(frame);
         printf("    frame %4i (delay:%4i)                         %s%c (%d,%d @ %" PRIu64
-               " -> %" PRIu64 " bytes)\n",
+               " -> %" PRIu64 " bytes, compression: %s)\n",
                j, frame.GetDuration(), GetFormatString(frame.GetFormat()),
                frame.HasAlpha() ? ' ' : '*', frame.GetWidth(), frame.GetHeight(),
-               frame.GetUnpackedSize(), frame.GetPackedSize());
+               frame.GetUnpackedSize(), frame.GetPackedSize(),
+               XBTFCompressionMethodMap.at(frame.GetCompressionMethod()).data());
       }
     }
     file.SetLoop(0);

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -89,10 +89,11 @@ bool HasAlpha(unsigned char* argb, unsigned int width, unsigned int height)
 void Usage()
 {
   puts("Usage:");
-  puts("  -help            Show this screen.");
-  puts("  -input <dir>     Input directory. Default: current dir");
-  puts("  -output <dir>    Output directory/filename. Default: Textures.xbt");
-  puts("  -dupecheck       Enable duplicate file detection. Reduces output file size. Default: off");
+  puts("  -help               Show this screen.");
+  puts("  -input <dir>        Input directory. Default: current dir");
+  puts("  -output <dir>       Output directory/filename. Default: Textures.xbt");
+  puts("  -dupecheck          Enable duplicate file detection. Reduces output file size. Default: off");
+  puts("  -compression-method Compression method to use. [lzo|none] Default: lzo");
 }
 
 } // namespace
@@ -407,6 +408,20 @@ int main(int argc, char* argv[])
     else if (!strcmp(args[i], "-verbose"))
     {
       texturePacker.EnableVerboseOutput();
+    }
+    else if (!strcmp(args[i], "-compression-method"))
+    {
+      std::string compressionMethod = args[++i];
+
+      if (compressionMethod == "lzo")
+      {
+        texturePacker.SetCompressionMethod(XBTFCompressionMethod::LZO);
+      }
+
+      if (compressionMethod == "none")
+      {
+        texturePacker.SetCompressionMethod(XBTFCompressionMethod::NONE);
+      }
     }
     else if (!platform_stricmp(args[i], "-output") || !platform_stricmp(args[i], "-o"))
     {

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -49,8 +49,6 @@
 #include <lzo/lzo1x.h>
 #include <sys/stat.h>
 
-#define FLAGS_USE_LZO     1
-
 #define DIR_SEPARATOR '/'
 
 namespace
@@ -111,7 +109,10 @@ public:
 
   int createBundle(const std::string& InputDir, const std::string& OutputFile);
 
-  void SetFlags(unsigned int flags) { m_flags = flags; }
+  void SetCompressionMethod(XBTFCompressionMethod compressionMethod)
+  {
+    m_compressionMethod = compressionMethod;
+  }
 
 private:
   void CreateSkeletonHeader(CXBTFWriter& xbtfWriter,
@@ -128,7 +129,7 @@ private:
   std::vector<unsigned int> m_dupes;
 
   bool m_dupecheck{false};
-  unsigned int m_flags{0};
+  XBTFCompressionMethod m_compressionMethod = XBTFCompressionMethod::NONE;
 };
 
 void TexturePacker::CreateSkeletonHeader(CXBTFWriter& xbtfWriter,
@@ -205,7 +206,7 @@ CXBTFFrame TexturePacker::CreateXBTFFrame(DecodedFrame& decodedFrame, CXBTFWrite
   CXBTFFrame frame;
   lzo_uint packedSize = size;
 
-  if ((m_flags & FLAGS_USE_LZO) == FLAGS_USE_LZO)
+  if (m_compressionMethod == XBTFCompressionMethod::LZO)
   {
     // grab a temporary buffer for unpacking into
     packedSize = size + size / 16 + 64 + 3; // see simple.c in lzo
@@ -385,7 +386,7 @@ int main(int argc, char* argv[])
 
   TexturePacker texturePacker;
 
-  texturePacker.SetFlags(FLAGS_USE_LZO);
+  texturePacker.SetCompressionMethod(XBTFCompressionMethod::LZO);
 
   for (unsigned int i = 1; i < args.size(); ++i)
   {

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -342,10 +342,10 @@ int TexturePacker::createBundle(const std::string& InputDir, const std::string& 
         CXBTFFrame frame = CreateXBTFFrame(frames.frameList[j], writer);
         file.GetFrames().push_back(frame);
         printf("    frame %4i (delay:%4i)                         %s%c (%d,%d @ %" PRIu64
-               " bytes)\n",
+               " -> %" PRIu64 " bytes)\n",
                j, frame.GetDuration(), GetFormatString(frame.GetFormat()),
                frame.HasAlpha() ? ' ' : '*', frame.GetWidth(), frame.GetHeight(),
-               frame.GetUnpackedSize());
+               frame.GetUnpackedSize(), frame.GetPackedSize());
       }
     }
     file.SetLoop(0);

--- a/tools/depends/native/TexturePacker/src/XBTFWriter.cpp
+++ b/tools/depends/native/TexturePacker/src/XBTFWriter.cpp
@@ -131,6 +131,7 @@ bool CXBTFWriter::UpdateHeader(const std::vector<unsigned int>& dupes)
       WRITE_U64(frame.GetUnpackedSize(), m_file);
       WRITE_U32(frame.GetDuration(), m_file);
       WRITE_U64(frame.GetOffset(), m_file);
+      WRITE_U32(static_cast<uint32_t>(frame.GetCompressionMethod()), m_file);
     }
   }
 

--- a/tools/depends/native/TexturePacker/src/cmdlineargs.h
+++ b/tools/depends/native/TexturePacker/src/cmdlineargs.h
@@ -26,8 +26,9 @@ char* GetCommandLine();
 #else
 #include <windows.h>
 #endif
-#include <vector>
+#include <cstring>
 #include <string>
+#include <vector>
 
 class CmdLineArgs : public std::vector<char*>
 {

--- a/tools/depends/native/TexturePacker/src/configure.ac
+++ b/tools/depends/native/TexturePacker/src/configure.ac
@@ -33,6 +33,9 @@ AC_CHECK_HEADER([jpeglib.h],, AC_MSG_ERROR("jpeglib.h not found"))
 AC_CHECK_LIB([jpeg],[main],, AC_MSG_ERROR("libjpeg not found"))
 AC_CHECK_HEADER([lzo/lzo1x.h],, AC_MSG_ERROR("lzo/lzo1x.h not found"))
 AC_CHECK_LIB([lzo2],[main],, AC_MSG_ERROR("liblzo2 not found"))
+AC_CHECK_HEADER([zstd.h],, AC_MSG_ERROR("zstd.h not found"))
+AC_CHECK_LIB([zstd],[main],, AC_MSG_ERROR("libzstd not found"))
+
 
 AC_SUBST(KODI_SRC_DIR)
 AC_SUBST(STATIC_FLAG)

--- a/tools/depends/native/zstd/Makefile
+++ b/tools/depends/native/zstd/Makefile
@@ -1,0 +1,30 @@
+include ../../Makefile.include
+PREFIX=$(NATIVEPREFIX)
+PLATFORM=$(NATIVEPLATFORM)
+DEPS = ../../Makefile.include Makefile ../../download-files.include
+
+LIBNAME=zstd
+VERSION=1.5.5
+SOURCE=$(LIBNAME)-$(VERSION)
+ARCHIVE=$(SOURCE).tar.gz
+SHA512=99109ec0e07fa65c2101c9cb36be56b672bbd0ee69d265f924718e61f9192ae8385c8d9e4d0c318be9edfa6d849fd3d60e5f164fa120961449429ea3c5dab6b6
+include ../../download-files.include
+
+all: .installed-$(PLATFORM)
+
+$(PLATFORM): $(DEPS) | $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE)
+	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
+	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+
+.installed-$(PLATFORM): $(PLATFORM)
+	$(MAKE) -C $(PLATFORM)/lib libzstd.a PREFIX=$(PREFIX)
+	$(MAKE) -C $(PLATFORM)/lib install-pc install-static install-includes PREFIX=$(PREFIX)
+	touch $@
+
+clean:
+	$(MAKE) -C $(PLATFORM) clean
+	rm -f .installed-$(PLATFORM)
+
+distclean::
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)
+

--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -48,7 +48,8 @@ DEPENDS = \
   sqlite3 \
   tinyxml \
   udfread \
-  xz
+  xz \
+  zstd
 
 ifeq ($(ENABLE_GPLV3),yes)
   DEPENDS+=samba-gplv3 libcdio-gplv3

--- a/tools/depends/target/gnutls/Makefile
+++ b/tools/depends/target/gnutls/Makefile
@@ -23,6 +23,7 @@ CONFIGURE_OPTIONS+= ac_cv_func_malloc_0_nonnull=yes \
 CONFIGURE=./configure --prefix=$(PREFIX) \
                       --disable-shared \
                       --without-p11-kit \
+                      --without-zstd \
                       --disable-nls \
                       --with-included-unistring \
                       --with-included-libtasn1 \

--- a/tools/depends/target/zstd/Makefile
+++ b/tools/depends/target/zstd/Makefile
@@ -1,0 +1,28 @@
+include ../../Makefile.include
+DEPS = ../../Makefile.include Makefile ../../download-files.include
+
+LIBNAME=zstd
+VERSION=1.5.5
+SOURCE=$(LIBNAME)-$(VERSION)
+ARCHIVE=$(SOURCE).tar.gz
+SHA512=99109ec0e07fa65c2101c9cb36be56b672bbd0ee69d265f924718e61f9192ae8385c8d9e4d0c318be9edfa6d849fd3d60e5f164fa120961449429ea3c5dab6b6
+include ../../download-files.include
+
+all: .installed-$(PLATFORM)
+
+$(PLATFORM): $(DEPS) | $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE)
+	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
+	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+
+.installed-$(PLATFORM): $(PLATFORM)
+	$(MAKE) -C $(PLATFORM)/lib libzstd.a PREFIX=$(PREFIX)
+	$(MAKE) -C $(PLATFORM)/lib install-pc install-static install-includes PREFIX=$(PREFIX)
+	touch $@
+
+clean:
+	$(MAKE) -C $(PLATFORM) clean
+	rm -f .installed-$(PLATFORM)
+
+distclean::
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)
+

--- a/tools/depends/target/zstd/Makefile
+++ b/tools/depends/target/zstd/Makefile
@@ -15,7 +15,7 @@ $(PLATFORM): $(DEPS) | $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 
 .installed-$(PLATFORM): $(PLATFORM)
-	$(MAKE) -C $(PLATFORM)/lib libzstd.a PREFIX=$(PREFIX)
+	$(MAKE) -C $(PLATFORM)/lib libzstd.a PREFIX=$(PREFIX) CFLAGS="$(CFLAGS)" CPPFLAGS="$(CPPFLAGS)"
 	$(MAKE) -C $(PLATFORM)/lib install-pc install-static install-includes PREFIX=$(PREFIX)
 	touch $@
 

--- a/xbmc/guilib/TextureBundleXBT.cpp
+++ b/xbmc/guilib/TextureBundleXBT.cpp
@@ -225,7 +225,7 @@ bool CTextureBundleXBT::ConvertFrameToTexture(const std::string& name,
   }
 
   // check if it's packed with lzo
-  if (frame.IsPacked())
+  if (frame.GetCompressionMethod() == XBTFCompressionMethod::LZO)
   { // unpack
     std::vector<unsigned char> unpacked(static_cast<size_t>(frame.GetUnpackedSize()));
     lzo_uint s = (lzo_uint)frame.GetUnpackedSize();
@@ -275,7 +275,7 @@ std::vector<uint8_t> CTextureBundleXBT::UnpackFrame(const CXBTFReader& reader,
   }
 
   // if the frame isn't packed there's nothing else to be done
-  if (!frame.IsPacked())
+  if (frame.GetCompressionMethod() == XBTFCompressionMethod::NONE)
     return packedBuffer;
 
   // make sure lzo is initialized

--- a/xbmc/guilib/TextureManager.cpp
+++ b/xbmc/guilib/TextureManager.cpp
@@ -24,6 +24,8 @@
 
 #include <mutex>
 
+#define _DEBUG_TEXTURES
+
 #ifdef _DEBUG_TEXTURES
 #include "utils/TimeUtils.h"
 #endif

--- a/xbmc/guilib/XBTF.cpp
+++ b/xbmc/guilib/XBTF.cpp
@@ -52,9 +52,14 @@ void CXBTFFrame::SetPackedSize(uint64_t size)
   m_packedSize = size;
 }
 
-bool CXBTFFrame::IsPacked() const
+XBTFCompressionMethod CXBTFFrame::GetCompressionMethod() const
 {
-  return m_unpackedSize != m_packedSize;
+  return m_compressionMethod;
+}
+
+void CXBTFFrame::SetCompressionMethod(XBTFCompressionMethod compressionMethod)
+{
+  m_compressionMethod = compressionMethod;
 }
 
 bool CXBTFFrame::HasAlpha() const
@@ -111,7 +116,8 @@ uint64_t CXBTFFrame::GetHeaderSize() const
     sizeof(m_packedSize) +
     sizeof(m_unpackedSize) +
     sizeof(m_offset) +
-    sizeof(m_duration);
+    sizeof(m_duration) +
+    sizeof(m_compressionMethod);
 
   return result;
 }

--- a/xbmc/guilib/XBTF.h
+++ b/xbmc/guilib/XBTF.h
@@ -8,12 +8,13 @@
 
 #pragma once
 
+#include "utils/Map.h"
+
 #include <ctime>
 #include <map>
+#include <stdint.h>
 #include <string>
 #include <vector>
-
-#include <stdint.h>
 
 static const std::string XBTF_MAGIC = "XBTF";
 static const std::string XBTF_VERSION = "3";
@@ -25,6 +26,11 @@ enum class XBTFCompressionMethod : uint32_t
   NONE,
   LZO,
 };
+
+constexpr auto XBTFCompressionMethodMap = make_map<XBTFCompressionMethod, std::string_view>({
+    {XBTFCompressionMethod::NONE, "none"},
+    {XBTFCompressionMethod::LZO, "lzo"},
+});
 
 class CXBTFFrame
 {

--- a/xbmc/guilib/XBTF.h
+++ b/xbmc/guilib/XBTF.h
@@ -25,11 +25,13 @@ enum class XBTFCompressionMethod : uint32_t
 {
   NONE,
   LZO,
+  ZSTD,
 };
 
 constexpr auto XBTFCompressionMethodMap = make_map<XBTFCompressionMethod, std::string_view>({
     {XBTFCompressionMethod::NONE, "none"},
     {XBTFCompressionMethod::LZO, "lzo"},
+    {XBTFCompressionMethod::ZSTD, "zstd"},
 });
 
 class CXBTFFrame

--- a/xbmc/guilib/XBTF.h
+++ b/xbmc/guilib/XBTF.h
@@ -20,6 +20,12 @@ static const std::string XBTF_VERSION = "2";
 
 #include "TextureFormats.h"
 
+enum class XBTFCompressionMethod
+{
+  NONE,
+  LZO,
+};
+
 class CXBTFFrame
 {
 public:

--- a/xbmc/guilib/XBTF.h
+++ b/xbmc/guilib/XBTF.h
@@ -16,11 +16,11 @@
 #include <stdint.h>
 
 static const std::string XBTF_MAGIC = "XBTF";
-static const std::string XBTF_VERSION = "2";
+static const std::string XBTF_VERSION = "3";
 
 #include "TextureFormats.h"
 
-enum class XBTFCompressionMethod
+enum class XBTFCompressionMethod : uint32_t
 {
   NONE,
   LZO,
@@ -54,7 +54,9 @@ public:
   uint32_t GetDuration() const;
   void SetDuration(uint32_t duration);
 
-  bool IsPacked() const;
+  XBTFCompressionMethod GetCompressionMethod() const;
+  void SetCompressionMethod(XBTFCompressionMethod compressionMethod);
+
   bool HasAlpha() const;
 
 private:
@@ -65,6 +67,7 @@ private:
   uint64_t m_unpackedSize;
   uint64_t m_offset;
   uint32_t m_duration;
+  XBTFCompressionMethod m_compressionMethod = XBTFCompressionMethod::NONE;
 };
 
 class CXBTFFile

--- a/xbmc/guilib/XBTFReader.cpp
+++ b/xbmc/guilib/XBTFReader.cpp
@@ -152,6 +152,10 @@ bool CXBTFReader::Open(const std::string& path)
         return false;
       frame.SetOffset(u64);
 
+      if (!ReadUInt32(m_file, u32))
+        return false;
+      frame.SetCompressionMethod(static_cast<XBTFCompressionMethod>(u32));
+
       xbtfFile.GetFrames().push_back(frame);
     }
 


### PR DESCRIPTION
This is something I've been playing with after doing the TexturePacker modernization.

This add zstd compression/decompression support.

I originally had this in two parts but the changes in the first part wouldn't really make sense without the second part. The first branch was here -> https://github.com/lrusak/xbmc/commits/TexturePacker-PR-4

Compression support to `TexturePacker` and decompression to Kodi via `CTextureBundleXBT`.

I've added a switch to TexturePacker (`-compression-method`) to allow selecting the compression method method. If we want to allow the use of zstd compression we may look at deprecating lzo (though it's harmless to keep both) other than dependencies.

This also bumps the `XBTF_VERSION` because of the new `m_compressionMethod` member that is added to the serialization in the xbt file.

I've also added the cmake option `-DTEXTUREPACKER_COMPRESSION_METHOD=[zstd|lzo|none]` that can be used to select the compression method used to create the `Texture.xbt` bundle at build time.

I plan to add some more metrics that measure the speeds in the future but this is what I have for now. This is all on my i7 so it would be interesting to see on a low power arm device

TexturePacker:
```
TexturePacker: processed 681 files in 466.403 ms using zstd
```
vs
```
TexturePacker: processed 681 files in 2343.757 ms using lzo
```

Decompressions time is similar (zstd | lzo):
```
colors/white50.png: 0.027 ms (bundled)			   |	colors/white50.png: 0.016 ms (bundled)
colors/white.png: 0.007 ms (bundled)			   |	colors/white.png: 0.006 ms (bundled)
colors/white70.png: 0.031 ms (bundled)			   |	colors/white70.png: 0.005 ms (bundled)
osd/progress/nub_bar.png: 0.007 ms (bundled)			osd/progress/nub_bar.png: 0.007 ms (bundled)
buttons/slider-back.png: 0.022 ms (bundled)		   |	buttons/slider-back.png: 0.016 ms (bundled)
buttons/slider-nib.png: 0.011 ms (bundled)		   |	buttons/slider-nib.png: 0.009 ms (bundled)
colors/red50.png: 0.007 ms (bundled)			   |	colors/red50.png: 0.006 ms (bundled)
progress/texturebg_border_white.png: 0.015 ms (bundled)	   |	progress/texturebg_border_white.png: 0.013 ms (bundled)
progress/texturebg_white.png: 0.008 ms (bundled)	   |	progress/texturebg_white.png: 0.009 ms (bundled)
pointer_arrow.png: 0.027 ms (bundled)			   |	pointer_arrow.png: 0.050 ms (bundled)
pointer_click.png: 0.020 ms (bundled)			   |	pointer_click.png: 0.034 ms (bundled)
buttons/dialogbutton-fo.png: 0.258 ms (bundled)		   |	buttons/dialogbutton-fo.png: 0.268 ms (bundled)
buttons/dialogbutton-nofo.png: 0.011 ms (bundled)	   |	buttons/dialogbutton-nofo.png: 0.014 ms (bundled)
buttons/roundbutton-fo.png: 0.034 ms (bundled)		   |	buttons/roundbutton-fo.png: 0.036 ms (bundled)
icons/power.png: 0.032 ms (bundled)			   |	icons/power.png: 0.023 ms (bundled)
buttons/radio-button-on.png: 0.030 ms (bundled)			buttons/radio-button-on.png: 0.030 ms (bundled)
buttons/radio-button-off.png: 0.026 ms (bundled)	   |	buttons/radio-button-off.png: 0.029 ms (bundled)
icons/settings.png: 0.023 ms (bundled)			   |	icons/settings.png: 0.021 ms (bundled)
icons/search.png: 0.022 ms (bundled)			   |	icons/search.png: 0.018 ms (bundled)
icons/now-playing/fullscreen.png: 0.018 ms (bundled)	   |	icons/now-playing/fullscreen.png: 0.016 ms (bundled)
frame/menu-nofo.png: 0.017 ms (bundled)			   |	frame/menu-nofo.png: 0.013 ms (bundled)
icons/menu.png: 0.009 ms (bundled)			   |	icons/menu.png: 0.008 ms (bundled)
icons/favourites.png: 0.020 ms (bundled)		   |	icons/favourites.png: 0.016 ms (bundled)
overlays/shadow.png: 0.028 ms (bundled)			   |	overlays/shadow.png: 0.023 ms (bundled)
lists/panel.png: 0.011 ms (bundled)			   |	lists/panel.png: 0.012 ms (bundled)
lists/focus.png: 0.048 ms (bundled)			   |	lists/focus.png: 0.103 ms (bundled)
colors/black.png: 0.008 ms (bundled)			   |	colors/black.png: 0.007 ms (bundled)
icons/sidemenu/movies.png: 0.022 ms (bundled)		   |	icons/sidemenu/movies.png: 0.027 ms (bundled)
icons/sidemenu/tv.png: 0.023 ms (bundled)		   |	icons/sidemenu/tv.png: 0.039 ms (bundled)
icons/sidemenu/music.png: 0.024 ms (bundled)		   |	icons/sidemenu/music.png: 0.038 ms (bundled)
icons/sidemenu/games.png: 0.053 ms (bundled)		   |	icons/sidemenu/games.png: 0.033 ms (bundled)
icons/sidemenu/addons.png: 0.028 ms (bundled)		   |	icons/sidemenu/addons.png: 0.044 ms (bundled)
icons/sidemenu/pictures.png: 0.054 ms (bundled)		   |	icons/sidemenu/pictures.png: 0.045 ms (bundled)
icons/sidemenu/videos.png: 0.018 ms (bundled)		   |	icons/sidemenu/videos.png: 0.027 ms (bundled)
icons/sidemenu/favourites.png: 0.025 ms (bundled)	   |	icons/sidemenu/favourites.png: 0.040 ms (bundled)
icons/sidemenu/weather.png: 0.025 ms (bundled)		   |	icons/sidemenu/weather.png: 0.030 ms (bundled)
frame/InfoBar.png: 0.021 ms (bundled)			   |	frame/InfoBar.png: 0.030 ms (bundled)
```

File size is similar:
```
zstd:

-rw-r--r--. 1 lukas lukas 1012K May 19 19:59 addons/skin.estuary/media/Textures.xbt
-rw-r--r--. 1 lukas lukas 1035686 May 19 19:59 addons/skin.estuary/media/Textures.xbt
```

vs

```
lzo

-rw-r--r--. 1 lukas lukas 1.3M May 19 20:01 addons/skin.estuary/media/Textures.xbt
-rw-r--r--. 1 lukas lukas 1269532 May 19 20:01 addons/skin.estuary/media/Textures.xbt
```

This is just with the default zstd compression level (3).

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Faster Textures.xbt bundle decompression? Smaller Textures.xbt bundle size?