### PR TITLE
android_main: move the native method register to the owner classes

### DIFF
--- a/xbmc/platform/android/activity/CMakeLists.txt
+++ b/xbmc/platform/android/activity/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SOURCES android_main.cpp
             JNIXBMCDisplayManagerDisplayListener.cpp
             JNIXBMCSpeechRecognitionListener.cpp
             JNIXBMCConnectivityManagerNetworkCallback.cpp
+            JNIXBMCBroadcastReceiver.cpp
             ${NDKROOT}/sources/android/native_app_glue/android_native_app_glue.c
             ${NDKROOT}/sources/android/cpufeatures/cpu-features.c)
 
@@ -45,6 +46,7 @@ set(HEADERS AndroidFeatures.h
             JNIXBMCDisplayManagerDisplayListener.h
             JNIXBMCSpeechRecognitionListener.h
             JNIXBMCConnectivityManagerNetworkCallback.h
+            JNIXBMCBroadcastReceiver.h
             XBMCApp.h)
 
 core_add_library(platform_android_activity)

--- a/xbmc/platform/android/activity/JNIMainActivity.cpp
+++ b/xbmc/platform/android/activity/JNIMainActivity.cpp
@@ -8,6 +8,8 @@
 
 #include "JNIMainActivity.h"
 
+#include "CompileInfo.h"
+
 #include <androidjni/Activity.h>
 #include <androidjni/Intent.h>
 #include <androidjni/jutils-details.hpp>
@@ -25,6 +27,53 @@ CJNIMainActivity::CJNIMainActivity(const ANativeActivity *nativeActivity)
 CJNIMainActivity::~CJNIMainActivity()
 {
   m_appInstance = NULL;
+}
+
+void CJNIMainActivity::RegisterNatives(JNIEnv* env)
+{
+  std::string pkgRoot = CCompileInfo::GetClass();
+
+  const std::string mainClass = pkgRoot + "/Main";
+  const std::string settingsObserver = pkgRoot + "/XBMCSettingsContentObserver";
+  const std::string inputDeviceListener = pkgRoot + "/XBMCInputDeviceListener";
+
+  jclass cMain = env->FindClass(mainClass.c_str());
+  if (cMain)
+  {
+    JNINativeMethod methods[] = {
+        {"_onNewIntent", "(Landroid/content/Intent;)V",
+         reinterpret_cast<void*>(&CJNIMainActivity::_onNewIntent)},
+        {"_onActivityResult", "(IILandroid/content/Intent;)V",
+         reinterpret_cast<void*>(&CJNIMainActivity::_onActivityResult)},
+        {"_doFrame", "(J)V", reinterpret_cast<void*>(&CJNIMainActivity::_doFrame)},
+        {"_callNative", "(JJ)V", reinterpret_cast<void*>(&CJNIMainActivity::_callNative)},
+        {"_onVisibleBehindCanceled", "()V",
+         reinterpret_cast<void*>(&CJNIMainActivity::_onVisibleBehindCanceled)},
+    };
+    env->RegisterNatives(cMain, methods, sizeof(methods) / sizeof(methods[0]));
+  }
+
+  jclass cSettingsObserver = env->FindClass(settingsObserver.c_str());
+  if (cSettingsObserver)
+  {
+    JNINativeMethod methods[] = {
+        {"_onVolumeChanged", "(I)V", reinterpret_cast<void*>(&CJNIMainActivity::_onVolumeChanged)},
+    };
+    env->RegisterNatives(cSettingsObserver, methods, sizeof(methods) / sizeof(methods[0]));
+  }
+
+  jclass cInputDeviceListener = env->FindClass(inputDeviceListener.c_str());
+  if (cInputDeviceListener)
+  {
+    JNINativeMethod methods[] = {
+        {"_onInputDeviceAdded", "(I)V",
+         reinterpret_cast<void*>(&CJNIMainActivity::_onInputDeviceAdded)},
+        {"_onInputDeviceChanged", "(I)V",
+         reinterpret_cast<void*>(&CJNIMainActivity::_onInputDeviceChanged)},
+        {"_onInputDeviceRemoved", "(I)V",
+         reinterpret_cast<void*>(&CJNIMainActivity::_onInputDeviceRemoved)}};
+    env->RegisterNatives(cInputDeviceListener, methods, sizeof(methods) / sizeof(methods[0]));
+  }
 }
 
 void CJNIMainActivity::_onNewIntent(JNIEnv *env, jobject context, jobject intent)

--- a/xbmc/platform/android/activity/JNIMainActivity.h
+++ b/xbmc/platform/android/activity/JNIMainActivity.h
@@ -20,6 +20,8 @@ public:
 
   static CJNIMainActivity* GetAppInstance() { return m_appInstance; }
 
+  static void RegisterNatives(JNIEnv* env);
+
   static void _onNewIntent(JNIEnv *env, jobject context, jobject intent);
   static void _onActivityResult(JNIEnv *env, jobject context, jint requestCode, jint resultCode, jobject resultData);
   static void _onVolumeChanged(JNIEnv *env, jobject context, jint volume);

--- a/xbmc/platform/android/activity/JNIXBMCBroadcastReceiver.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCBroadcastReceiver.cpp
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (C) 2012-2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "JNIXBMCBroadcastReceiver.h"
+
+#include "CompileInfo.h"
+
+#include <androidjni/BroadcastReceiver.h>
+
+using namespace jni;
+
+namespace
+{
+
+static std::string className = std::string(CCompileInfo::GetClass()) + "/XBMCBroadcastReceiver";
+
+} // namespace
+
+void CJNIXBMCBroadcastReceiver::RegisterNatives(JNIEnv* env)
+{
+  jclass cClass = env->FindClass(className.c_str());
+  if (cClass)
+  {
+    JNINativeMethod methods[] = {
+        {"_onReceive", "(Landroid/content/Intent;)V",
+         reinterpret_cast<void*>(&CJNIBroadcastReceiver::_onReceive)},
+    };
+
+    env->RegisterNatives(cClass, methods, sizeof(methods) / sizeof(methods[0]));
+  }
+}

--- a/xbmc/platform/android/activity/JNIXBMCBroadcastReceiver.h
+++ b/xbmc/platform/android/activity/JNIXBMCBroadcastReceiver.h
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (C) 2012-2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <androidjni/JNIBase.h>
+
+namespace jni
+{
+
+class CJNIXBMCBroadcastReceiver
+{
+public:
+  static void RegisterNatives(JNIEnv* env);
+};
+
+} // namespace jni

--- a/xbmc/platform/android/activity/android_main.cpp
+++ b/xbmc/platform/android/activity/android_main.cpp
@@ -6,7 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-#include "CompileInfo.h"
 #include "EventLoop.h"
 #include "XBMCApp.h"
 
@@ -112,12 +111,7 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved)
   if (vm->GetEnv(reinterpret_cast<void**>(&env), version) != JNI_OK)
     return -1;
 
-  std::string pkgRoot = CCompileInfo::GetClass();
-
-  const std::string mainClass = pkgRoot + "/Main";
-  const std::string settingsObserver = pkgRoot + "/XBMCSettingsContentObserver";
-  const std::string inputDeviceListener = pkgRoot + "/XBMCInputDeviceListener";
-
+  CJNIMainActivity::RegisterNatives(env);
   CJNIXBMCAudioManagerOnAudioFocusChangeListener::RegisterNatives(env);
   CJNIXBMCSurfaceTextureOnFrameAvailableListener::RegisterNatives(env);
   CJNIXBMCMainView::RegisterNatives(env);
@@ -134,42 +128,6 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved)
   jni::CJNIXBMCSpeechRecognitionListener::RegisterNatives(env);
   jni::CJNIXBMCConnectivityManagerNetworkCallback::RegisterNatives(env);
   jni::CJNIXBMCBroadcastReceiver::RegisterNatives(env);
-
-  jclass cMain = env->FindClass(mainClass.c_str());
-  if(cMain)
-  {
-    JNINativeMethod methods[] =
-    {
-      {"_onNewIntent", "(Landroid/content/Intent;)V", (void*)&CJNIMainActivity::_onNewIntent},
-      {"_onActivityResult", "(IILandroid/content/Intent;)V", (void*)&CJNIMainActivity::_onActivityResult},
-      {"_doFrame", "(J)V", (void*)&CJNIMainActivity::_doFrame},
-      {"_callNative", "(JJ)V", (void*)&CJNIMainActivity::_callNative},
-      {"_onVisibleBehindCanceled", "()V", (void*)&CJNIMainActivity::_onVisibleBehindCanceled},
-    };
-    env->RegisterNatives(cMain, methods, sizeof(methods)/sizeof(methods[0]));
-  }
-
-  jclass cSettingsObserver = env->FindClass(settingsObserver.c_str());
-  if(cSettingsObserver)
-  {
-    JNINativeMethod methods[] =
-    {
-      {"_onVolumeChanged", "(I)V", (void*)&CJNIMainActivity::_onVolumeChanged},
-    };
-    env->RegisterNatives(cSettingsObserver, methods, sizeof(methods)/sizeof(methods[0]));
-  }
-
-  jclass cInputDeviceListener = env->FindClass(inputDeviceListener.c_str());
-  if(cInputDeviceListener)
-  {
-    JNINativeMethod methods[] =
-    {
-      { "_onInputDeviceAdded", "(I)V", (void*)&CJNIMainActivity::_onInputDeviceAdded },
-      { "_onInputDeviceChanged", "(I)V", (void*)&CJNIMainActivity::_onInputDeviceChanged },
-      { "_onInputDeviceRemoved", "(I)V", (void*)&CJNIMainActivity::_onInputDeviceRemoved }
-    };
-    env->RegisterNatives(cInputDeviceListener, methods, sizeof(methods)/sizeof(methods[0]));
-  }
 
   return version;
 }

--- a/xbmc/platform/android/activity/android_main.cpp
+++ b/xbmc/platform/android/activity/android_main.cpp
@@ -12,6 +12,7 @@
 
 #include "platform/android/activity/JNIMainActivity.h"
 #include "platform/android/activity/JNIXBMCAudioManagerOnAudioFocusChangeListener.h"
+#include "platform/android/activity/JNIXBMCBroadcastReceiver.h"
 #include "platform/android/activity/JNIXBMCConnectivityManagerNetworkCallback.h"
 #include "platform/android/activity/JNIXBMCDisplayManagerDisplayListener.h"
 #include "platform/android/activity/JNIXBMCFile.h"
@@ -114,7 +115,6 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved)
   std::string pkgRoot = CCompileInfo::GetClass();
 
   const std::string mainClass = pkgRoot + "/Main";
-  const std::string bcReceiver = pkgRoot + "/XBMCBroadcastReceiver";
   const std::string settingsObserver = pkgRoot + "/XBMCSettingsContentObserver";
   const std::string inputDeviceListener = pkgRoot + "/XBMCInputDeviceListener";
 
@@ -133,6 +133,7 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved)
   jni::CJNIXBMCURIUtils::RegisterNatives(env);
   jni::CJNIXBMCSpeechRecognitionListener::RegisterNatives(env);
   jni::CJNIXBMCConnectivityManagerNetworkCallback::RegisterNatives(env);
+  jni::CJNIXBMCBroadcastReceiver::RegisterNatives(env);
 
   jclass cMain = env->FindClass(mainClass.c_str());
   if(cMain)
@@ -146,16 +147,6 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved)
       {"_onVisibleBehindCanceled", "()V", (void*)&CJNIMainActivity::_onVisibleBehindCanceled},
     };
     env->RegisterNatives(cMain, methods, sizeof(methods)/sizeof(methods[0]));
-  }
-
-  jclass cBroadcastReceiver = env->FindClass(bcReceiver.c_str());
-  if(cBroadcastReceiver)
-  {
-    JNINativeMethod methods[] =
-    {
-      {"_onReceive", "(Landroid/content/Intent;)V", (void*)&CJNIBroadcastReceiver::_onReceive},
-    };
-    env->RegisterNatives(cBroadcastReceiver, methods, sizeof(methods)/sizeof(methods[0]));
   }
 
   jclass cSettingsObserver = env->FindClass(settingsObserver.c_str());


### PR DESCRIPTION
## Description
Move the code of the `androin_main` class that registers some native JNI methods to the related classes: `CJNIMainActivity` and `CJNIXBMCBroadcastReceiver`.

## Motivation and context
The aim is to use the same criteria as for the other classes and interfaces, and simplify the `android_main` code.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
