### PR TITLE
Maintain the selection position after end of playback / watched status change

### DIFF
--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -345,7 +345,9 @@ void CGUIDialogFileBrowser::Update(const std::string &strDirectory)
     {
       strSelectedItem = pItem->GetPath();
       URIUtils::RemoveSlashAtEnd(strSelectedItem);
-      m_history.SetSelectedItem(strSelectedItem, m_Directory->GetPath().empty()?"empty":m_Directory->GetPath());
+      m_history.SetSelectedItem(strSelectedItem,
+                                m_Directory->GetPath().empty() ? "empty" : m_Directory->GetPath(),
+                                iItem);
     }
   }
 

--- a/xbmc/filesystem/DirectoryHistory.cpp
+++ b/xbmc/filesystem/DirectoryHistory.cpp
@@ -35,7 +35,9 @@ void CDirectoryHistory::RemoveSelectedItem(const std::string& strDirectory)
     m_vecHistory.erase(iter);
 }
 
-void CDirectoryHistory::SetSelectedItem(const std::string& strSelectedItem, const std::string& strDirectory)
+void CDirectoryHistory::SetSelectedItem(const std::string& strSelectedItem,
+                                        const std::string& strDirectory,
+                                        const int indexItem)
 {
   if (strSelectedItem.empty())
     return;
@@ -47,12 +49,14 @@ void CDirectoryHistory::SetSelectedItem(const std::string& strSelectedItem, cons
   if (iter != m_vecHistory.end())
   {
     iter->second.m_strItem = strItem;
+    iter->second.m_indexItem = indexItem;
     return;
   }
 
   CHistoryItem item;
   item.m_strItem = strItem;
   item.m_strDirectory = strDir;
+  item.m_indexItem = indexItem;
   m_vecHistory[strDir] = item;
 }
 
@@ -63,6 +67,15 @@ const std::string& CDirectoryHistory::GetSelectedItem(const std::string& strDire
     return iter->second.m_strItem;
 
   return StringUtils::Empty;
+}
+
+int CDirectoryHistory::GetSelectedItemIndex(const std::string& strDirectory) const
+{
+  HistoryMap::const_iterator iter = m_vecHistory.find(preparePath(strDirectory));
+  if (iter != m_vecHistory.end())
+    return iter->second.m_indexItem;
+
+  return -1;
 }
 
 void CDirectoryHistory::AddPath(const std::string& strPath, const std::string &strFilterPath /* = "" */)

--- a/xbmc/filesystem/DirectoryHistory.cpp
+++ b/xbmc/filesystem/DirectoryHistory.cpp
@@ -55,7 +55,6 @@ void CDirectoryHistory::SetSelectedItem(const std::string& strSelectedItem,
 
   CHistoryItem item;
   item.m_strItem = strItem;
-  item.m_strDirectory = strDir;
   item.m_indexItem = indexItem;
   m_vecHistory[strDir] = item;
 }

--- a/xbmc/filesystem/DirectoryHistory.h
+++ b/xbmc/filesystem/DirectoryHistory.h
@@ -21,7 +21,6 @@ public:
     CHistoryItem() = default;
     virtual ~CHistoryItem() = default;
     std::string m_strItem;
-    std::string m_strDirectory;
     int m_indexItem{-1};
   };
 

--- a/xbmc/filesystem/DirectoryHistory.h
+++ b/xbmc/filesystem/DirectoryHistory.h
@@ -22,6 +22,7 @@ public:
     virtual ~CHistoryItem() = default;
     std::string m_strItem;
     std::string m_strDirectory;
+    int m_indexItem{-1};
   };
 
   class CPathHistoryItem
@@ -39,8 +40,18 @@ public:
   CDirectoryHistory() = default;
   virtual ~CDirectoryHistory();
 
-  void SetSelectedItem(const std::string& strSelectedItem, const std::string& strDirectory);
+  /*!
+   * \brief Store the currently selected item for the navigation path
+   * \param strSelectedItem Selected item
+   * \param strDirectory Path
+   * \param indexItem Index of the selected item (in list, after filtering/sorting).
+   * -1 when the index information is not available.
+  */
+  void SetSelectedItem(const std::string& strSelectedItem,
+                       const std::string& strDirectory,
+                       const int indexItem = -1);
   const std::string& GetSelectedItem(const std::string& strDirectory) const;
+  int GetSelectedItemIndex(const std::string& strDirectory) const;
   void RemoveSelectedItem(const std::string& strDirectory);
 
   void AddPath(const std::string& strPath, const std::string &m_strFilterPath = "");

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -325,7 +325,7 @@ void CGUIWindowMusicPlayList::SavePlayList()
     }
 
     std::string strOldDirectory = m_vecItems->GetPath();
-    m_history.SetSelectedItem(strSelectedItem, strOldDirectory);
+    m_history.SetSelectedItem(strSelectedItem, strOldDirectory, iItem);
 
     PLAYLIST::CPlayListM3U playlist;
     for (int i = 0; i < m_vecItems->Size(); ++i)

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1310,7 +1310,7 @@ void CGUIMediaWindow::SaveSelectedItemInHistory()
     GetDirectoryHistoryString(pItem.get(), strSelectedItem);
   }
 
-  m_history.SetSelectedItem(strSelectedItem, m_vecItems->GetPath());
+  m_history.SetSelectedItem(strSelectedItem, m_vecItems->GetPath(), iItem);
 }
 
 void CGUIMediaWindow::RestoreSelectedItemFromHistory()
@@ -1333,7 +1333,17 @@ void CGUIMediaWindow::RestoreSelectedItemFromHistory()
     }
   }
 
-  // if we haven't found the selected item, select the first item
+  // Exact item not found - maybe deleted, watched status change, filtered out, ...
+  // Attempt to restore the position of the selection
+  int selectedItemIndex = m_history.GetSelectedItemIndex(m_vecItems->GetPath());
+  if (selectedItemIndex >= 0 && m_vecItems->Size() > 0)
+  {
+    int newIndex = std::min(selectedItemIndex, m_vecItems->Size() - 1);
+    m_viewControl.SetSelectedItem(newIndex);
+    return;
+  }
+
+  // Fallback: select the first item
   m_viewControl.SetSelectedItem(0);
 }
 

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -460,7 +460,7 @@ bool CGUIWindowFileManager::Update(int iList, const std::string &strDirectory)
     if (!pItem->IsParentFolder())
     {
       GetDirectoryHistoryString(pItem.get(), strSelectedItem);
-      m_history[iList].SetSelectedItem(strSelectedItem, m_Directory[iList]->GetPath());
+      m_history[iList].SetSelectedItem(strSelectedItem, m_Directory[iList]->GetPath(), iItem);
     }
   }
 


### PR DESCRIPTION
## Description

Extended the navigation history to track the line number of the  selected item so that it can be restored when the item disappears from the list, instead of resetting the selection to the top of the list (usually the ..)

* Added member to CHistoryItem and new accessor GetSelectedItemIndex. 

* Modified CGUIMediaWindow so that it uses the last known selected line when the last selected item is not available anymore due to a refresh, filter, watch status change, ...

* A couple other screens use the same history mechanism (CGUIWindowFileManager, CGUIDialogFileBrowser, GUIWindowMusicPlaylist ) but I made minimal changes only, they either don't attempt to restore the selected item or it didn't look like they could lose the selection and benefit.

* Second commit to remove unused member m_strDirectory - was probably created at a time when the history was not stored as a map.

I tried other ways to do this, but ended up going down deep rabbit holes and that was the best / easiest solution.

## Motivation and context

With the "unwatched" filter active in Movies / TV Shows library, losing your place after playback ends or when marking a movie/show/season/ep watched is pretty annoying and the more pages of movies/etc there are, the worse it gets.
You have to scroll down back to the same place, and repeat many times if there is more than one item to play / mark watched / ... This is a pointless scrolling and loss of time.

It looks like I'm not alone https://forum.kodi.tv/showthread.php?tid=373160

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
The change is for all platforms, but tested on Windows 10.

Unwatched filter turned on for Movies and TV Shows. Navigate to first / last / middle item, play. After playback ends, position hasn't changed (instead of resetting to the top)

Navigated through Movies, Movie Sets, TV Shows (Series, Seasons, Episodes List), Photos, Videos and toggled watched status of items > OK

Changed watched status of last item in a list > no out of bounds problem

For Photos and Videos, navigated in a hierarchy of folders backwards and forwards to verify there was no change
Jumped to Settings while navigating media, moved/deleted folders or items, returned to media navigation > OK new selection is made. Selection doesn't change if no change to folders/items is made while in Settings, as expected.

<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
Better experience when marking items watched or unwatched, with the selection remaining in the same place instead of resetting to the top of the list.
## Screenshots (if appropriate):
Example with a small number of items

Initial state:
![image](https://github.com/xbmc/xbmc/assets/489377/5108681d-d3a3-41a7-8746-ee89a2ce7806)

Before PR, after changing item status to Watched (context menu or by playing the movie), the selection is reset to the top of the list:
![image](https://github.com/xbmc/xbmc/assets/489377/452beb8c-a9d4-40f7-b60a-d82096476dd4)

After PR, after changing item status to Watched (context menu or play the movie) the selection remains at the same position:
![image](https://github.com/xbmc/xbmc/assets/489377/c722c044-d2bb-4417-856d-725ca103490c)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
