### PR TITLE
[Android] Network: fix after "Listen to default network changes"

### DIFF
--- a/xbmc/platform/android/network/NetworkAndroid.cpp
+++ b/xbmc/platform/android/network/NetworkAndroid.cpp
@@ -235,13 +235,13 @@ std::unique_ptr<CNetworkBase> CNetworkBase::GetNetwork()
 
 CNetworkAndroid::CNetworkAndroid() : CNetworkBase(), CJNIXBMCConnectivityManagerNetworkCallback()
 {
+  RetrieveInterfaces();
+
   if (CJNIBase::GetSDKVersion() >= 24)
   {
     CJNIConnectivityManager connman{CXBMCApp::getSystemService(CJNIContext::CONNECTIVITY_SERVICE)};
     connman.registerDefaultNetworkCallback(this->get_raw());
   }
-  else
-    RetrieveInterfaces();
 }
 
 CNetworkAndroid::~CNetworkAndroid()
@@ -279,7 +279,7 @@ CNetworkInterface* CNetworkAndroid::GetFirstConnectedInterface()
 {
   std::unique_lock<CCriticalSection> lock(m_refreshMutex);
 
-  if (CJNIBase::GetSDKVersion() >= 24)
+  if (m_defaultInterface)
     return m_defaultInterface.get();
   else
   {


### PR DESCRIPTION
## Description
Network: fix after "Listen to default network changes"

## Motivation and context
On Shield, at least, https://github.com/xbmc/xbmc/pull/23059 has broken the network because `m_defaultInterface` can be nullptr in some cases:

Callbacks only are received after network changes (lost, recovered, new) but not when app starts. This PR enables fallback to old enumeration method when `m_defaultInterface` is not yet initialized. 


## How has this been tested?
Runtime tested Shield 2019

## What is the effect on users?
Fix network not usable. The first symptom is that the web server for remote control fails to initialize when Kodi starts up.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
