### PR TITLE
[Depends][native] Bump cmake 3.26.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,10 +349,14 @@ get_property(INTERNAL_DEPS GLOBAL PROPERTY INTERNAL_DEPS_PROP)
 set(GLOBAL_TARGET_DEPS ${INTERNAL_DEPS} ${PLATFORM_GLOBAL_TARGET_DEPS})
 
 # main library (used for main binary and tests)
-if(CMAKE_GENERATOR STREQUAL Xcode)
+if(CORE_SYSTEM_NAME STREQUAL "darwin_embedded")
+  # $<TARGET_OBJECTS:> as at 3.26.4 provides incorrect paths for ios/tvos platforms
+  # Even if XCODE_EMIT_EFFECTIVE_PLATFORM_NAME global property is used, the xcode project
+  # still sets int dir paths to $(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME) and the generator
+  # expression only provides a path using $(CONFIGURATION)
   add_library(compileinfo_obj OBJECT IMPORTED)
   set_property(TARGET compileinfo_obj PROPERTY IMPORTED_OBJECTS
-    "${CMAKE_BINARY_DIR}/$(PROJECT_NAME).build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/compileinfo.build/$(OBJECT_FILE_DIR_normal:base)/$(CURRENT_ARCH)/CompileInfo.o"
+    "${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/compileinfo.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/$(OBJECT_FILE_DIR_normal:base)/$(CURRENT_ARCH)/CompileInfo.o"
   )
   add_library(lib${APP_NAME_LC} STATIC)
   add_dependencies(lib${APP_NAME_LC} compileinfo)

--- a/cmake/scripts/darwin_embedded/Install.cmake
+++ b/cmake/scripts/darwin_embedded/Install.cmake
@@ -103,6 +103,7 @@ add_custom_command(TARGET ${APP_NAME_LC} POST_BUILD
     COMMAND "ACTION=build"
             "APP_NAME=${APP_NAME}"
             "XBMC_DEPENDS=${DEPENDS_PATH}"
+            "SRCROOT=${CMAKE_BINARY_DIR}"
             ${CMAKE_SOURCE_DIR}/tools/darwin/Support/CopyRootFiles-darwin_embedded.command
     COMMAND "XBMC_DEPENDS=${DEPENDS_PATH}"
             "PYTHON_VERSION=${PYTHON_VERSION}"

--- a/cmake/scripts/osx/Macros.cmake
+++ b/cmake/scripts/osx/Macros.cmake
@@ -1,23 +1,7 @@
 function(core_link_library lib wraplib)
-  if(CMAKE_GENERATOR MATCHES "Unix Makefiles" OR CMAKE_GENERATOR STREQUAL Ninja)
-    set(wrapper_obj cores/dll-loader/exports/CMakeFiles/wrapper.dir/wrapper.c.o)
-  elseif(CMAKE_GENERATOR MATCHES "Xcode")
-    # CURRENT_VARIANT is an Xcode env var
-    # CPU is a project cmake var
-    # Xcode new build system (CMAKE_XCODE_BUILD_SYSTEM=12) requires the env var CURRENT_VARIANT to be passed WITHOUT brackets
-    # Xcode Legacy build system (CMAKE_XCODE_BUILD_SYSTEM=1) requires the env var CURRENT_VARIANT to be passed WITH brackets
-    if(CMAKE_XCODE_BUILD_SYSTEM STREQUAL 12)
-      set(wrapper_obj cores/dll-loader/exports/kodi.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/wrapper.build/Objects-$CURRENT_VARIANT/${CPU}/wrapper.o)
-    else()
-			set(wrapper_obj cores/dll-loader/exports/kodi.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/wrapper.build/Objects-$(CURRENT_VARIANT)/${CPU}/wrapper.o)
-    endif()
-  else()
-    message(FATAL_ERROR "Unsupported generator in core_link_library")
-  endif()
-
   set(export -bundle -undefined dynamic_lookup -read_only_relocs suppress
              -Wl,-alias_list,${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/cores/dll-loader/exports/wrapper.def
-             ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/${wrapper_obj})
+             $<TARGET_OBJECTS:wrapper>)
   set(extension ${CMAKE_SHARED_MODULE_SUFFIX})
   set(check_arg "")
   if(TARGET ${lib})

--- a/tools/darwin/Support/CopyRootFiles-darwin_embedded.command
+++ b/tools/darwin/Support/CopyRootFiles-darwin_embedded.command
@@ -27,34 +27,34 @@ mkdir -p "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/AppHome/userdata"
 mkdir -p "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/AppHome/media"
 mkdir -p "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/AppHome/tools/darwin/runtime"
 
-${SYNC} "$BUILD_ROOT/LICENSE.md"  "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/"
-${SYNC} "$BUILD_ROOT/privacy-policy.txt"  "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/AppHome"
-${SYNC} "$BUILD_ROOT/xbmc/platform/darwin/Credits.html"  "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/"
-${ADDONSYNC} "$BUILD_ROOT/addons"  "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/AppHome"
-${SYNC} "$BUILD_ROOT/media"    "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/AppHome"
+${SYNC} "$SRCROOT/LICENSE.md"  "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/"
+${SYNC} "$SRCROOT/privacy-policy.txt"  "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/AppHome"
+${SYNC} "$SRCROOT/xbmc/platform/darwin/Credits.html"  "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/"
+${ADDONSYNC} "$SRCROOT/addons"  "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/AppHome"
+${SYNC} "$SRCROOT/media"    "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/AppHome"
 
 # extracted eggs
 ${SYNC} "$XBMC_DEPENDS/share/$APP_NAME/addons" "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/AppHome"
 
 # sync skin.estouchy
 SYNCSKIN_A=${SKINSYNC}
-if [ -f "$BUILD_ROOT/addons/skin.estouchy/media/Textures.xbt" ]; then
+if [ -f "$SRCROOT/addons/skin.estouchy/media/Textures.xbt" ]; then
 SYNCSKIN_A="${SKINSYNC} --exclude *.png --exclude *.jpg"
 fi
-${SYNCSKIN_A} "$BUILD_ROOT/addons/skin.estouchy"    "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/AppHome/addons"
-${SYNC} "$BUILD_ROOT/addons/skin.estouchy/background"   "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/AppHome/addons/skin.estouchy"
-${SYNC} "$BUILD_ROOT/addons/skin.estouchy/resources"   "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/AppHome/addons/skin.estouchy"
+${SYNCSKIN_A} "$SRCROOT/addons/skin.estouchy"    "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/AppHome/addons"
+${SYNC} "$SRCROOT/addons/skin.estouchy/background"   "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/AppHome/addons/skin.estouchy"
+${SYNC} "$SRCROOT/addons/skin.estouchy/resources"   "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/AppHome/addons/skin.estouchy"
 
 # sync skin.estuary
 SYNCSKIN_B=${SKINSYNC}
-if [ -f "$BUILD_ROOT/addons/skin.estuary/media/Textures.xbt" ]; then
+if [ -f "$SRCROOT/addons/skin.estuary/media/Textures.xbt" ]; then
 SYNCSKIN_B="${SKINSYNC} --exclude *.png --exclude *.jpg"
 fi
-${SYNCSKIN_B} "$BUILD_ROOT/addons/skin.estuary"     "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/AppHome/addons"
-${SYNC} "$BUILD_ROOT/addons/skin.estuary/extras"   "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/AppHome/addons/skin.estuary"
-${SYNC} "$BUILD_ROOT/addons/skin.estuary/resources"   "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/AppHome/addons/skin.estuary"
+${SYNCSKIN_B} "$SRCROOT/addons/skin.estuary"     "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/AppHome/addons"
+${SYNC} "$SRCROOT/addons/skin.estuary/extras"   "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/AppHome/addons/skin.estuary"
+${SYNC} "$SRCROOT/addons/skin.estuary/resources"   "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/AppHome/addons/skin.estuary"
 
-${SYNC} "$BUILD_ROOT/system"     "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/AppHome"
-${SYNC} "$BUILD_ROOT/userdata"   "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/AppHome"
+${SYNC} "$SRCROOT/system"     "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/AppHome"
+${SYNC} "$SRCROOT/userdata"   "$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/AppData/AppHome"
 
 fi

--- a/tools/depends/native/cmake/Makefile
+++ b/tools/depends/native/cmake/Makefile
@@ -3,10 +3,10 @@ PLATFORM=$(NATIVEPLATFORM)
 DEPS = ../../Makefile.include Makefile ../../download-files.include
 
 APPNAME=cmake
-VERSION=3.21.3
+VERSION=3.26.4
 SOURCE=$(APPNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
-SHA512=0571b78443906c5ad51fb0fafbd32d565caf628cc150b1190802cb819e8497c108ea6b7ecaa03133df2dbbceb730696d24b4df38468c92088c769ce4076d9e9f
+SHA512=fe817c8d5e247db3f0a9a58ee37c466a47220100d9e90711cd5d06c223cef87e41d1a756e75d1537e5f8cd010dcb8971cbeab4684b1ac12bcecf84bf7b720167
 include ../../download-files.include
 
 # configuration settings


### PR DESCRIPTION
## Description
Bump cmake 3.26.4

## Motivation and context
3.26 had a reasonable speedup on windows a while back, so might as well bump for tools/depends and see if we get any faster configure times. probably only noticeable for multi config generators for large speedups (ie xcode)

## How has this been tested?
Jenkins

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
