### PR TITLE
SavestateFlatBuffer: Remove forward declararion of FlatBufferBuilder

### DIFF
--- a/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.h
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.h
@@ -14,11 +14,6 @@
 
 #include <flatbuffers/flatbuffers.h>
 
-namespace flatbuffers
-{
-class FlatBufferBuilder;
-}
-
 namespace KODI
 {
 namespace RETRO


### PR DESCRIPTION
## Description
This forward declaration causes a compiler error with recent faltbuffers because the type changed:

```
In file included from xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp:12: xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.h:19:7: error: definition of type 'FlatBufferBuilder' conflicts with type alias of the same name
class FlatBufferBuilder;
      ^
/usr/include/flatbuffers/flatbuffer_builder.h:1414:7: note: 'FlatBufferBuilder' declared here
using FlatBufferBuilder = FlatBufferBuilderImpl<false>;
      ^
1 error generated.
```

## Motivation and context
Fix compilation, see #23331.

## How has this been tested?
It compiles with new flatbuffers 23.5.26 on my machine. If it still builds with old flattbuffers Jenkins will find out.

## What is the effect on users?
None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
