### PR TITLE
[macos][nativewindow] Support fullscreen move / Fix display lost

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -1609,6 +1609,10 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
     appPlayer->TriggerUpdateResolution();
     break;
 
+  case TMSG_MOVETOSCREEN:
+    CServiceBroker::GetWinSystem()->MoveToScreen(static_cast<int>(pMsg->param1));
+    break;
+
   case TMSG_MINIMIZE:
     CServiceBroker::GetWinSystem()->Minimize();
     break;

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -318,6 +318,9 @@ void CApplication::HandlePortEvents()
       case XBMC_MODECHANGE:
         CServiceBroker::GetWinSystem()->GetGfxContext().ApplyModeChange(newEvent.mode.res);
         break;
+      case XBMC_SCREENCHANGE:
+        CServiceBroker::GetWinSystem()->OnChangeScreen(newEvent.screen.screenIdx);
+        break;
       case XBMC_USEREVENT:
         CServiceBroker::GetAppMessenger()->PostMsg(static_cast<uint32_t>(newEvent.user.code));
         break;

--- a/xbmc/messaging/ApplicationMessenger.h
+++ b/xbmc/messaging/ApplicationMessenger.h
@@ -83,6 +83,7 @@
 #define TMSG_RENDERER_PREINIT             TMSG_MASK_APPLICATION + 31
 #define TMSG_RENDERER_UNINIT              TMSG_MASK_APPLICATION + 32
 #define TMSG_EVENT                        TMSG_MASK_APPLICATION + 33
+#define TMSG_MOVETOSCREEN                 TMSG_MASK_APPLICATION + 34
 
 /// @brief Called from the player when its current item is updated
 #define TMSG_UPDATE_PLAYER_ITEM TMSG_MASK_APPLICATION + 35

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -308,7 +308,9 @@ bool CDisplaySettings::OnSettingChanging(const std::shared_ptr<const CSetting>& 
     {
       const std::string screen =
           std::static_pointer_cast<const CSettingString>(setting)->GetValue();
-      winSystem->MoveToScreen(screen);
+      const unsigned int screenIdx = winSystem->GetScreenId(screen);
+      winSystem->MoveToScreen(screenIdx);
+      m_resolutionChangeAborted = true;
     }
     winSystem->UpdateResolutions();
     RESOLUTION newRes = GetResolutionForScreen();

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -303,12 +303,18 @@ bool CDisplaySettings::OnSettingChanging(const std::shared_ptr<const CSetting>& 
   }
   else if (settingId == CSettings::SETTING_VIDEOSCREEN_MONITOR)
   {
-    CServiceBroker::GetWinSystem()->NotifyScreenChangeIntention();
-    CServiceBroker::GetWinSystem()->UpdateResolutions();
+    auto winSystem = CServiceBroker::GetWinSystem();
+    if (winSystem->SupportsScreenMove())
+    {
+      const std::string screen =
+          std::static_pointer_cast<const CSettingString>(setting)->GetValue();
+      winSystem->MoveToScreen(screen);
+    }
+    winSystem->UpdateResolutions();
     RESOLUTION newRes = GetResolutionForScreen();
 
     SetCurrentResolution(newRes, false);
-    CServiceBroker::GetWinSystem()->GetGfxContext().SetVideoResolution(newRes, true);
+    winSystem->GetGfxContext().SetVideoResolution(newRes, true);
 
     if (!m_resolutionChangeAborted)
     {

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -107,20 +107,26 @@ public:
   virtual bool Hide() { return false; }
   virtual bool Show(bool raise = true) { return false; }
 
-  /*! \brief Window was requested to move to the given screen
-      \param screen the screen name (as shown in the application settings)
-  */
-  virtual void MoveToScreen(const std::string& screen) {}
-
   // videosync
   virtual std::unique_ptr<CVideoSync> GetVideoSync(CVideoReferenceClock* clock) { return nullptr; }
 
   // notifications
   virtual void OnMove(int x, int y) {}
 
+  /*! \brief Get the screen ID provided the screen name
+   *  \param screen the name of the screen as presented on the application display settings
+   *  \return the screen index as known by the windowing system implementation (or the default screen by default)
+  */
+  virtual unsigned int GetScreenId(const std::string& screen) { return 0; }
+
+  /*! \brief Window was requested to move to the given screen
+   *  \param screenIdx the screen index as known by the windowing system implementation
+  */
+  virtual void MoveToScreen(unsigned int screenIdx) {}
+
   /**
    * \brief Used to signal the windowing system about the change of the current screen
-   * \param screenIdx the screen index as know by the windowing system implementation
+   * \param screenIdx the screen index as known by the windowing system implementation
   */
   virtual void OnChangeScreen(unsigned int screenIdx) {}
 

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -107,6 +107,11 @@ public:
   virtual bool Hide() { return false; }
   virtual bool Show(bool raise = true) { return false; }
 
+  /*! \brief Window was requested to move to the given screen
+      \param screen the screen name (as shown in the application settings)
+  */
+  virtual void MoveToScreen(const std::string& screen) {}
+
   // videosync
   virtual std::unique_ptr<CVideoSync> GetVideoSync(CVideoReferenceClock* clock) { return nullptr; }
 
@@ -114,10 +119,10 @@ public:
   virtual void OnMove(int x, int y) {}
 
   /**
-   * \brief Used to signal the windowing system about the intention of the user to change the main display
-   * \details triggered, for example, when the user manually changes the monitor setting
+   * \brief Used to signal the windowing system about the change of the current screen
+   * \param screenIdx the screen index as know by the windowing system implementation
   */
-  virtual void NotifyScreenChangeIntention() {}
+  virtual void OnChangeScreen(unsigned int screenIdx) {}
 
   // OS System screensaver
   /**

--- a/xbmc/windowing/XBMC_events.h
+++ b/xbmc/windowing/XBMC_events.h
@@ -23,6 +23,7 @@ typedef enum
   XBMC_QUIT, /* User-requested quit */
   XBMC_VIDEORESIZE, /* User resized video mode */
   XBMC_FULLSCREEN_UPDATE, /* Triggered by an OS event when Kodi is running in fullscreen, rescale and repositioning is required  */
+  XBMC_SCREENCHANGE, /* Window moved to a different screen */
   XBMC_VIDEOMOVE, /* User moved the window */
   XBMC_MODECHANGE, /* Video mode must be changed */
   XBMC_TOUCH,
@@ -62,6 +63,11 @@ typedef struct XBMC_MoveEvent {
 	int x;		/* New x position */
 	int y;		/* New y position */
 } XBMC_MoveEvent;
+
+typedef struct XBMC_ScreenChangeEvent
+{
+  unsigned int screenIdx; /* The screen index */
+} XBMC_ScreenChangeEvent;
 
 struct XBMC_ModeChangeEvent
 {
@@ -122,6 +128,7 @@ typedef struct XBMC_Event {
     XBMC_TouchEvent touch;
     XBMC_ButtonEvent keybutton;
     XBMC_SetFocusEvent focus;
+    XBMC_ScreenChangeEvent screen;
   };
 } XBMC_Event;
 

--- a/xbmc/windowing/osx/OpenGL/WindowControllerMacOS.mm
+++ b/xbmc/windowing/osx/OpenGL/WindowControllerMacOS.mm
@@ -156,11 +156,19 @@
 
 - (void)windowDidChangeScreen:(NSNotification*)notification
 {
-  // user has moved the window to a different screen
-  CWinSystemOSX* winSystem = dynamic_cast<CWinSystemOSX*>(CServiceBroker::GetWinSystem());
-  if (!winSystem)
-    return;
-  winSystem->WindowChangedScreen();
+  // window has moved to a different screen
+  if (self.window)
+  {
+    XBMC_Event newEvent = {};
+    newEvent.type = XBMC_SCREENCHANGE;
+    newEvent.screen.screenIdx =
+        static_cast<unsigned int>([NSScreen.screens indexOfObject:self.window.screen]);
+    std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+    if (appPort)
+    {
+      appPort->OnEvent(newEvent);
+    }
+  }
 }
 
 - (void)windowDidChangeBackingProperties:(NSNotification*)notification

--- a/xbmc/windowing/osx/OpenGL/WindowControllerMacOS.mm
+++ b/xbmc/windowing/osx/OpenGL/WindowControllerMacOS.mm
@@ -243,5 +243,14 @@
     // we don't need to do anything else
     winSystem->SetFullscreenWillToggle(false);
   }
+  winSystem->SignalFullScreenStateChanged(false);
+}
+
+- (void)windowDidEnterFullScreen:(NSNotification*)notification
+{
+  auto winSystem = dynamic_cast<CWinSystemOSX*>(CServiceBroker::GetWinSystem());
+  if (!winSystem)
+    return;
+  winSystem->SignalFullScreenStateChanged(true);
 }
 @end

--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -66,7 +66,9 @@ public:
   bool Hide() override;
   bool HasCursor() override;
   bool Show(bool raise = true) override;
+  void MoveToScreen(const std::string& screen) override;
   void OnMove(int x, int y) override;
+  void OnChangeScreen(unsigned int screenIdx) override;
   CGraphicContext& GetGfxContext() const override;
   bool HasValidResolution() const;
 
@@ -76,12 +78,6 @@ public:
    *  \return true if the windowing system supports moving windows across screens, false otherwise
   */
   bool SupportsScreenMove() override;
-
-  /**
-   * \brief Used to signal the windowing system about the intention of the user to change the main display
-   * \details triggered, for example, when the user manually changes the monitor setting
-  */
-  void NotifyScreenChangeIntention() override;
 
   void Register(IDispResource* resource) override;
   void Unregister(IDispResource* resource) override;

--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -14,6 +14,7 @@
 #include "windowing/WinSystem.h"
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -66,18 +67,14 @@ public:
   bool Hide() override;
   bool HasCursor() override;
   bool Show(bool raise = true) override;
-  void MoveToScreen(const std::string& screen) override;
+  unsigned int GetScreenId(const std::string& screen) override;
+  void MoveToScreen(unsigned int screenIdx) override;
   void OnMove(int x, int y) override;
   void OnChangeScreen(unsigned int screenIdx) override;
   CGraphicContext& GetGfxContext() const override;
   bool HasValidResolution() const;
 
   std::string GetClipboardText() override;
-
-  /*! \brief Check if the windowing system supports moving windows across screens
-   *  \return true if the windowing system supports moving windows across screens, false otherwise
-  */
-  bool SupportsScreenMove() override;
 
   void Register(IDispResource* resource) override;
   void Unregister(IDispResource* resource) override;
@@ -95,6 +92,7 @@ public:
   int CheckDisplayChanging(uint32_t flags);
   void SetFullscreenWillToggle(bool toggle) { m_fullscreenWillToggle = toggle; }
   bool GetFullscreenWillToggle() { return m_fullscreenWillToggle; }
+  void SignalFullScreenStateChanged(bool fullscreenState);
 
   CGLContextObj GetCGLContextObj();
 
@@ -137,6 +135,8 @@ protected:
   XbmcThreads::EndTime<> m_dispResetTimer;
   bool m_fullscreenWillToggle;
   bool m_hasCursor{false};
+  //! Set while moving the fullscreen window to another screen. Stores the target screen id.
+  std::optional<unsigned long> m_fullScreenMovingToScreen;
   CCriticalSection m_critSection;
 
 private:


### PR DESCRIPTION
## Description
This PR essentially brings two different (although related) functionalities:

https://github.com/xbmc/xbmc/commit/e93faeb2814dde7cab57d757977731fad4934f5a -> When Kodi is on a display that is removed/lost the window was not being resized. This is even worse if it was fullscreen. We need to react to OnMove events to update the current display

https://github.com/xbmc/xbmc/commit/e93faeb2814dde7cab57d757977731fad4934f5a -> Implements fullscreen move (changing monitor within the Kodi settings). Since MacOS does not support any other way of doing this, we toggle fullscreen back to window mode, move it to the target display and set it fullscreen again.


## Motivation and context
I think this is the last PR before considering asking for generic feedback about an hypothetical switch to native-windowing while dropping SDL.

## How has this been tested?
Removing displays, moving the window in fullscreen between displays

## What is the effect on users?
Feature parity with SDL by now.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
