### PR TITLE
[Windows] Add DXVA Video Super Resolution upscaler

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7205,7 +7205,13 @@ msgctxt "#13416"
 msgid "Auto detect"
 msgstr ""
 
-#empty strings from id 13417 to 13418
+#: system/settings/settings.xml
+#: xbmc/cores/VideoPlayer/VideoRenderers/windows/RenderedDXVA.cpp
+msgctxt "#13417"
+msgid "Allow use DXVA Video Super Resolution"
+msgstr ""
+
+#empty string 13418
 
 #: system/settings/settings.xml
 #: xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
@@ -23440,4 +23446,10 @@ msgstr ""
 #: system/settings/settings.xml
 msgctxt "#39193"
 msgid "If music is being played, the screensaver will never be activated"
+msgstr ""
+
+#. Help text of setting "Allow use DXVA Video Super Resolution" with label #13417
+#: system/settings/settings.xml
+msgctxt "#39194"
+msgid "Enables advanced DXVA upscaler using NVIDIA \"RTX Video Super Resolution\" or \"Intel Video Super Resolution\".[CR]Used when video source is 1080p or less (progressive only) and source resolution is lower than display resolution.[CR]It's only available on specific hardware: NVIDIA RTX 40x, RTX 30x and Intel Arc A770, A750."
 msgstr ""

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -113,6 +113,26 @@
             <formatlabel>14047</formatlabel>
           </control>
         </setting>
+        <setting id="videoplayer.usesuperresolution" type="boolean" label="13417" help="39194">
+          <requirement>HAS_DX</requirement>
+          <dependencies>
+            <dependency type="visible">
+              <condition on="property" name="supportsvideosuperresolution" />
+            </dependency>
+            <dependency type="enable">
+              <or>
+                <condition setting="videoplayer.rendermethod" operator="is">0</condition> <!-- RENDER_METHOD_AUTO -->
+                <condition setting="videoplayer.rendermethod" operator="is">4</condition> <!-- RENDER_METHOD_DXVA -->
+              </or>
+            </dependency>
+          </dependencies>
+          <level>2</level>
+          <default>false</default>
+          <updates>
+            <update type="change" />
+          </updates>
+          <control type="toggle" />
+        </setting>
         <setting id="videoplayer.usemediacodecsurface" type="boolean" label="13440" help="36544">
           <requirement>HAS_MEDIACODEC</requirement>
           <level>2</level>

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -120,6 +120,8 @@ public:
   }
 
   static bool IsBT2020Supported();
+  static bool IsSuperResolutionSuitable(const VideoPicture& picture);
+  void TryEnableVideoSuperResolution();
 
 protected:
   bool ReInit();
@@ -153,6 +155,9 @@ protected:
    */
   std::vector<DXGI_FORMAT> GetProcessorOutputFormats() const;
 
+  void EnableIntelVideoSuperResolution();
+  void EnableNvidiaRTXVideoSuperResolution();
+
   CCriticalSection m_section;
 
   uint32_t m_width = 0;
@@ -177,6 +182,9 @@ protected:
   Microsoft::WRL::ComPtr<ID3D11VideoProcessorEnumerator> m_pEnumerator;
   Microsoft::WRL::ComPtr<ID3D11VideoProcessorEnumerator1> m_pEnumerator1;
   Microsoft::WRL::ComPtr<ID3D11VideoProcessor> m_pVideoProcessor;
+
+  bool m_forced8bit{false};
+  bool m_superResolutionEnabled{false};
 };
 
 };

--- a/xbmc/rendering/dx/DeviceResources.h
+++ b/xbmc/rendering/dx/DeviceResources.h
@@ -81,7 +81,7 @@ namespace DX
     bool SetFullScreen(bool fullscreen, RESOLUTION_INFO& res);
 
     // Apply display settings changes
-    void ApplyDisplaySettings();
+    void ApplyDisplaySettings(bool force8bit = false);
 
     // HDR display support
     HDR_STATUS ToggleHDR();
@@ -114,6 +114,7 @@ namespace DX
 #endif // TARGET_WINDOWS_STORE
     bool IsNV12SharedTexturesSupported() const { return m_NV12SharedTexturesSupport; }
     bool IsDXVA2SharedDecoderSurfaces() const { return m_DXVA2SharedDecoderSurfaces; }
+    bool IsSuperResolutionSupported() const { return m_DXVASuperResolutionSupport; }
 
     // Gets debug info from swapchain
     DEBUG_INFO_RENDER GetDebugInfo() const;
@@ -185,6 +186,8 @@ namespace DX
     bool m_IsTransferPQ;
     bool m_NV12SharedTexturesSupport{false};
     bool m_DXVA2SharedDecoderSurfaces{false};
+    bool m_DXVASuperResolutionSupport{false};
     bool m_usedSwapChain{false};
+    bool m_force8bit{false};
   };
 }

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -110,6 +110,14 @@ bool HasSystemSdrPeakLuminance(const std::string& condition,
   return CServiceBroker::GetWinSystem()->HasSystemSdrPeakLuminance();
 }
 
+bool SupportsVideoSuperResolution(const std::string& condition,
+                                  const std::string& value,
+                                  const SettingConstPtr& setting,
+                                  void* data)
+{
+  return CServiceBroker::GetWinSystem()->SupportsVideoSuperResolution();
+}
+
 bool SupportsScreenMove(const std::string& condition,
                         const std::string& value,
                         const SettingConstPtr& setting,
@@ -457,6 +465,7 @@ void CSettingConditions::Initialize()
   m_complexConditions.emplace("haspowerofffeature", HasPowerOffFeature);
   m_complexConditions.emplace("hassystemsdrpeakluminance", HasSystemSdrPeakLuminance);
   m_complexConditions.emplace("supportsscreenmove", SupportsScreenMove);
+  m_complexConditions.emplace("supportsvideosuperresolution", SupportsVideoSuperResolution);
   m_complexConditions.emplace("ishdrdisplay", IsHDRDisplay);
   m_complexConditions.emplace("ismasteruser", IsMasterUser);
   m_complexConditions.emplace("hassubtitlesfontextensions", HasSubtitlesFontExtensions);

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -113,6 +113,7 @@ public:
       "videoplayer.quitstereomodeonstop";
   static constexpr auto SETTING_VIDEOPLAYER_RENDERMETHOD = "videoplayer.rendermethod";
   static constexpr auto SETTING_VIDEOPLAYER_HQSCALERS = "videoplayer.hqscalers";
+  static constexpr auto SETTING_VIDEOPLAYER_USESUPERRESOLUTION = "videoplayer.usesuperresolution";
   static constexpr auto SETTING_VIDEOPLAYER_USEMEDIACODEC = "videoplayer.usemediacodec";
   static constexpr auto SETTING_VIDEOPLAYER_USEMEDIACODECSURFACE =
       "videoplayer.usemediacodecsurface";

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -192,6 +192,13 @@ public:
   static const char* SETTING_WINSYSTEM_IS_HDR_DISPLAY;
   virtual bool HasSystemSdrPeakLuminance() { return false; }
 
+  /**
+   * @brief System supports Video Super Resolution HW upscaler i.e.:
+   * "NVIDIA RTX Video Super Resolution" or "Intel Video Super Resolution"
+   *
+   */
+  virtual bool SupportsVideoSuperResolution() { return false; }
+
   // Gets debug info from video renderer
   virtual DEBUG_INFO_RENDER GetDebugInfo() { return {}; }
 

--- a/xbmc/windowing/windows/WinSystemWin32DX.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32DX.cpp
@@ -445,3 +445,8 @@ DEBUG_INFO_RENDER CWinSystemWin32DX::GetDebugInfo()
 {
   return m_deviceResources->GetDebugInfo();
 }
+
+bool CWinSystemWin32DX::SupportsVideoSuperResolution()
+{
+  return m_deviceResources->IsSuperResolutionSupported();
+}

--- a/xbmc/windowing/windows/WinSystemWin32DX.h
+++ b/xbmc/windowing/windows/WinSystemWin32DX.h
@@ -82,6 +82,8 @@ public:
   // Get debug info from swapchain
   DEBUG_INFO_RENDER GetDebugInfo() override;
 
+  bool SupportsVideoSuperResolution() override;
+
 protected:
   void SetDeviceFullScreen(bool fullScreen, RESOLUTION_INFO& res) override;
   void ReleaseBackBuffer() override;


### PR DESCRIPTION
## Description
Add DXVA Video Super Resolution upscaler.
It's supported NVIDIA "RTX Video Super Resolution" and "Intel Video Super Resolution".

Is not implemented as new upscaler method but a extension of DXVA upscaler with a new setting default disabled for now.

## Motivation and context
See: https://blogs.nvidia.com/blog/2023/02/28/rtx-video-super-resolution/

I don't find it as incredible as advertised, but it certainly reduces video compressing artifacts and somewhat increases the sensation of sharpness, seems more noticeable in lower quality videos.

Something that must be taken into account is the increase in power consumption and NVIDIA allows us configure 4 levels:

![4levels](https://github.com/xbmc/xbmc/assets/58434170/c5bcb5bb-9058-430f-9e43-cf1342d0c669)

This is power used in RTX 4070 upscaling 1080p to 4K:

Disabled ---> 15 W
Level 1 ---> ~60 W
Level 4 ---> ~160 W

## How has this been tested?
Runtime tested in RTX 4070. Tested in a PC screen (1920x1200) upscaling SD videos. Also tested in a 4K TV upscaling 1080p to 4K. Intel code not full tested but should work in Arc A750 and A770.

## What is the effect on users?
Improves video quality when video source resolution is lower that display resolution and render method used is DXVA.
Cons is notable increase in power consumption and only available in very limited hardware.

## Screenshots (if appropriate):
**New setting**
![screenshot00010](https://github.com/xbmc/xbmc/assets/58434170/04a62583-0ac0-4869-8304-d5d145507877)

**SD upscaled to 1080p (RTX Super Resolution disabled)**
![screenshot00002](https://github.com/xbmc/xbmc/assets/58434170/07c43c46-7443-4f13-9f91-4954e6e82a44)

**SD upscaled to 1080p (RTX Super Resolution enabled)**
![screenshot00003](https://github.com/xbmc/xbmc/assets/58434170/e3bcd41b-4d84-45be-8211-d896d1e8c59f)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
