### PR TITLE
[platform] macOS,iOS: Add speech recognition and microphone usage des…

### DIFF
--- a/xbmc/platform/darwin/ios/Info.plist.in
+++ b/xbmc/platform/darwin/ios/Info.plist.in
@@ -405,5 +405,9 @@
 			</dict>
 		</dict>
 	</array>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>Translate speech to text in virtual keyboard dialog</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Used for speech recognition</string>
 </dict>
 </plist>

--- a/xbmc/platform/darwin/osx/Info.plist.in
+++ b/xbmc/platform/darwin/osx/Info.plist.in
@@ -34,5 +34,9 @@
 	<string>@APP_NAME@</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>Translate speech to text in virtual keyboard dialog</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Used for speech recognition</string>
 </dict>
 </plist>


### PR DESCRIPTION
…criptions to Info.plist. Fixes crash on speech recognition activation.

Fixes a crash when trying to activate speech recognition in virtual keyboard dialog.

```
2023-05-27 20:27:24.461345+0200 Kodi[42835:747277] 2023-05-27 20:27:24.461 T:747277   debug <general>: HandleKey: long-return (0x100f00d) pressed, trying keyboard action 12c
2023-05-27 20:27:24.527314+0200 Kodi[42835:750439] [access] This app has crashed because it attempted to access privacy-sensitive data without a usage description.  The app's Info.plist must contain an NSSpeechRecognitionUsageDescription key with a string value explaining to the user how the app uses this data.
Message from debugger: Terminated due to signal 9
```

https://developer.apple.com/documentation/bundleresources/information_property_list/nsspeechrecognitionusagedescription

https://developer.apple.com/documentation/bundleresources/information_property_list/nsmicrophoneusagedescription

Runtime-tested on macOS Monterey with latest Kodi master.

@fuzzard can you please review.