### PR TITLE
Add .gradle directory to .gitignore

### DIFF
--- a/tools/android/packaging/.gitignore
+++ b/tools/android/packaging/.gitignore
@@ -1,3 +1,4 @@
+/.gradle/
 /images/*
 xbmc/assets/*
 xbmc/lib/*


### PR DESCRIPTION
## Description
This hidden directory contains the project-specific cache generated by Gradle.

## Motivation and context
Exclude from Git.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [X] **None of the above** (please explain below)

## Checklist:
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
