### PR TITLE
[subtitles] Avoid calls to virtual methods on destructor

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParser.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParser.h
@@ -22,8 +22,7 @@ class CDVDSubtitleParser
 {
 public:
   virtual ~CDVDSubtitleParser() = default;
-  virtual bool Open(CDVDStreamInfo &hints) = 0;
-  virtual void Dispose() = 0;
+  virtual bool Open(CDVDStreamInfo& hints) = 0;
   virtual void Reset() = 0;
   virtual std::shared_ptr<CDVDOverlay> Parse(double iPts) = 0;
   virtual const std::string& GetName() const = 0;
@@ -43,7 +42,6 @@ public:
     return o->Clone();
   }
   void Reset() override { m_collection.Reset(); }
-  void Dispose() override { m_collection.Clear(); }
 
 protected:
   CDVDSubtitleLineCollection m_collection;

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserMPL2.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserMPL2.cpp
@@ -22,11 +22,6 @@ CDVDSubtitleParserMPL2::CDVDSubtitleParserMPL2(std::unique_ptr<CDVDSubtitleStrea
 {
 }
 
-CDVDSubtitleParserMPL2::~CDVDSubtitleParserMPL2()
-{
-  Dispose();
-}
-
 bool CDVDSubtitleParserMPL2::Open(CDVDStreamInfo& hints)
 {
   if (!CDVDSubtitleParserText::Open())
@@ -64,9 +59,4 @@ bool CDVDSubtitleParserMPL2::Open(CDVDStreamInfo& hints)
   m_collection.Add(CreateOverlay());
 
   return true;
-}
-
-void CDVDSubtitleParserMPL2::Dispose()
-{
-  CDVDSubtitleParserCollection::Dispose();
 }

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserMPL2.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserMPL2.h
@@ -17,10 +17,9 @@ class CDVDSubtitleParserMPL2 : public CDVDSubtitleParserText, private CSubtitles
 {
 public:
   CDVDSubtitleParserMPL2(std::unique_ptr<CDVDSubtitleStream>&& stream, const std::string& strFile);
-  ~CDVDSubtitleParserMPL2() override;
+  ~CDVDSubtitleParserMPL2() = default;
 
   bool Open(CDVDStreamInfo& hints) override;
-  void Dispose() override;
 
 private:
   double m_framerate;

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserMicroDVD.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserMicroDVD.cpp
@@ -23,11 +23,6 @@ CDVDSubtitleParserMicroDVD::CDVDSubtitleParserMicroDVD(std::unique_ptr<CDVDSubti
 {
 }
 
-CDVDSubtitleParserMicroDVD::~CDVDSubtitleParserMicroDVD()
-{
-  Dispose();
-}
-
 bool CDVDSubtitleParserMicroDVD::Open(CDVDStreamInfo& hints)
 {
   if (!CDVDSubtitleParserText::Open())
@@ -71,9 +66,4 @@ bool CDVDSubtitleParserMicroDVD::Open(CDVDStreamInfo& hints)
   m_collection.Add(CreateOverlay());
 
   return true;
-}
-
-void CDVDSubtitleParserMicroDVD::Dispose()
-{
-  CDVDSubtitleParserCollection::Dispose();
 }

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserMicroDVD.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserMicroDVD.h
@@ -18,10 +18,9 @@ class CDVDSubtitleParserMicroDVD : public CDVDSubtitleParserText, private CSubti
 public:
   CDVDSubtitleParserMicroDVD(std::unique_ptr<CDVDSubtitleStream>&& stream,
                              const std::string& strFile);
-  ~CDVDSubtitleParserMicroDVD() override;
+  ~CDVDSubtitleParserMicroDVD() = default;
 
   bool Open(CDVDStreamInfo& hints) override;
-  void Dispose() override;
 
 private:
   double m_framerate;

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSSA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSSA.cpp
@@ -24,11 +24,6 @@ CDVDSubtitleParserSSA::CDVDSubtitleParserSSA(std::unique_ptr<CDVDSubtitleStream>
   m_libass->Configure();
 }
 
-CDVDSubtitleParserSSA::~CDVDSubtitleParserSSA()
-{
-  Dispose();
-}
-
 bool CDVDSubtitleParserSSA::Open(CDVDStreamInfo& hints)
 {
 
@@ -49,9 +44,4 @@ bool CDVDSubtitleParserSSA::Open(CDVDStreamInfo& hints)
   m_collection.Add(overlay);
 
   return true;
-}
-
-void CDVDSubtitleParserSSA::Dispose()
-{
-  CDVDSubtitleParserCollection::Dispose();
 }

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSSA.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSSA.h
@@ -17,10 +17,9 @@ class CDVDSubtitleParserSSA : public CDVDSubtitleParserText
 {
 public:
   CDVDSubtitleParserSSA(std::unique_ptr<CDVDSubtitleStream>&& pStream, const std::string& strFile);
-  ~CDVDSubtitleParserSSA() override;
+  ~CDVDSubtitleParserSSA() = default;
 
   bool Open(CDVDStreamInfo& hints) override;
-  void Dispose() override;
 
 private:
   std::shared_ptr<CDVDSubtitlesLibass> m_libass;

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSami.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSami.cpp
@@ -21,11 +21,6 @@ CDVDSubtitleParserSami::CDVDSubtitleParserSami(std::unique_ptr<CDVDSubtitleStrea
 {
 }
 
-CDVDSubtitleParserSami::~CDVDSubtitleParserSami()
-{
-  Dispose();
-}
-
 bool CDVDSubtitleParserSami::Open(CDVDStreamInfo& hints)
 {
   if (!CDVDSubtitleParserText::Open())
@@ -149,9 +144,4 @@ bool CDVDSubtitleParserSami::Open(CDVDStreamInfo& hints)
   m_collection.Add(CreateOverlay());
 
   return true;
-}
-
-void CDVDSubtitleParserSami::Dispose()
-{
-  CDVDSubtitleParserCollection::Dispose();
 }

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSami.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSami.h
@@ -19,8 +19,7 @@ class CDVDSubtitleParserSami : public CDVDSubtitleParserText, private CSubtitles
 {
 public:
   CDVDSubtitleParserSami(std::unique_ptr<CDVDSubtitleStream>&& pStream, const std::string& strFile);
-  ~CDVDSubtitleParserSami() override;
+  ~CDVDSubtitleParserSami() = default;
 
   bool Open(CDVDStreamInfo& hints) override;
-  void Dispose() override;
 };

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSubrip.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSubrip.cpp
@@ -18,11 +18,6 @@ CDVDSubtitleParserSubrip::CDVDSubtitleParserSubrip(std::unique_ptr<CDVDSubtitleS
 {
 }
 
-CDVDSubtitleParserSubrip::~CDVDSubtitleParserSubrip()
-{
-  Dispose();
-}
-
 bool CDVDSubtitleParserSubrip::Open(CDVDStreamInfo& hints)
 {
   if (!CDVDSubtitleParserText::Open())
@@ -86,9 +81,4 @@ bool CDVDSubtitleParserSubrip::Open(CDVDStreamInfo& hints)
   m_collection.Add(CreateOverlay());
 
   return true;
-}
-
-void CDVDSubtitleParserSubrip::Dispose()
-{
-  CDVDSubtitleParserCollection::Dispose();
 }

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSubrip.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserSubrip.h
@@ -18,8 +18,7 @@ class CDVDSubtitleParserSubrip : public CDVDSubtitleParserText, private CSubtitl
 public:
   CDVDSubtitleParserSubrip(std::unique_ptr<CDVDSubtitleStream>&& pStream,
                            const std::string& strFile);
-  ~CDVDSubtitleParserSubrip() override;
+  ~CDVDSubtitleParserSubrip() = default;
 
   bool Open(CDVDStreamInfo& hints) override;
-  void Dispose() override;
 };

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserVplayer.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserVplayer.cpp
@@ -21,11 +21,6 @@ CDVDSubtitleParserVplayer::CDVDSubtitleParserVplayer(std::unique_ptr<CDVDSubtitl
 {
 }
 
-CDVDSubtitleParserVplayer::~CDVDSubtitleParserVplayer()
-{
-  Dispose();
-}
-
 bool CDVDSubtitleParserVplayer::Open(CDVDStreamInfo& hints)
 {
   if (!CDVDSubtitleParserText::Open())
@@ -81,9 +76,4 @@ bool CDVDSubtitleParserVplayer::Open(CDVDStreamInfo& hints)
   m_collection.Add(CreateOverlay());
 
   return true;
-}
-
-void CDVDSubtitleParserVplayer::Dispose()
-{
-  CDVDSubtitleParserCollection::Dispose();
 }

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserVplayer.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParserVplayer.h
@@ -18,10 +18,9 @@ class CDVDSubtitleParserVplayer : public CDVDSubtitleParserText, private CSubtit
 public:
   CDVDSubtitleParserVplayer(std::unique_ptr<CDVDSubtitleStream>&& pStream,
                             const std::string& strFile);
-  ~CDVDSubtitleParserVplayer() override;
+  ~CDVDSubtitleParserVplayer() = default;
 
   bool Open(CDVDStreamInfo& hints) override;
-  void Dispose() override;
 
 private:
   double m_framerate;

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitleParserWebVTT.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitleParserWebVTT.cpp
@@ -24,11 +24,6 @@ CSubtitleParserWebVTT::CSubtitleParserWebVTT(std::unique_ptr<CDVDSubtitleStream>
 {
 }
 
-CSubtitleParserWebVTT::~CSubtitleParserWebVTT()
-{
-  Dispose();
-}
-
 bool CSubtitleParserWebVTT::Open(CDVDStreamInfo& hints)
 {
   if (!CDVDSubtitleParserText::Open())
@@ -76,9 +71,4 @@ bool CSubtitleParserWebVTT::Open(CDVDStreamInfo& hints)
   m_collection.Add(overlay);
 
   return true;
-}
-
-void CSubtitleParserWebVTT::Dispose()
-{
-  CDVDSubtitleParserCollection::Dispose();
 }

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitleParserWebVTT.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitleParserWebVTT.h
@@ -17,8 +17,7 @@ class CSubtitleParserWebVTT : public CDVDSubtitleParserText, public CSubtitlesAd
 {
 public:
   CSubtitleParserWebVTT(std::unique_ptr<CDVDSubtitleStream>&& pStream, const std::string& strFile);
-  ~CSubtitleParserWebVTT() override;
+  ~CSubtitleParserWebVTT() = default;
 
   bool Open(CDVDStreamInfo& hints) override;
-  void Dispose() override;
 };


### PR DESCRIPTION
## Description

Calling virtual functions from a constructor or destructor is considered dangerous most of the times and must be avoided whenever possible. All the C++ implementations need to call the version of the function defined at the level of the hierarchy in the current constructor and not further.

Since all parsers derive from `CDVDSubtitleParserText` and this derives from `CDVDSubtitleParserCollection` there is no reason to be redefining the destructor as all the parsers do is to call the base class dispose (`CDVDSubtitleParserCollection::Dispose`) anyway. Just move the dispose logic to the base class destructor.

@CastagnaIT for review

## Motivation and context
Fix a few clang-tidy warnings

## How has this been tested?
Runtime tested, breakpoint on `~CDVDSubtitleParserCollection()` to make sure the list is cleared on playback stop.

## What is the effect on users?
None, simple internal cleanup

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
