### PR TITLE
[dbiplus] String optimiziations + prevent copies

### DIFF
--- a/xbmc/dbwrappers/dataset.cpp
+++ b/xbmc/dbwrappers/dataset.cpp
@@ -421,14 +421,13 @@ const sql_record* Dataset::get_sql_record()
   return result.records[frecno];
 }
 
-const field_value Dataset::f_old(const char* f_name)
+field_value Dataset::f_old(const char* f_name)
 {
   if (ds_state != dsInactive)
     for (int unsigned i = 0; i < fields_object->size(); i++)
       if ((*fields_object)[i].props.name == f_name)
         return (*fields_object)[i].val;
-  field_value fv;
-  return fv;
+  return {};
 }
 
 void Dataset::setParamList(const ParamList& params)

--- a/xbmc/dbwrappers/dataset.cpp
+++ b/xbmc/dbwrappers/dataset.cpp
@@ -357,7 +357,7 @@ bool Dataset::set_field_value(const char* f_name, const field_value& value)
   //  return false;
 }
 
-const field_value Dataset::get_field_value(const char* f_name)
+const field_value& Dataset::get_field_value(const char* f_name)
 {
   if (ds_state != dsInactive)
   {
@@ -391,7 +391,7 @@ const field_value Dataset::get_field_value(const char* f_name)
   throw DbErrors("Dataset state is Inactive");
 }
 
-const field_value Dataset::get_field_value(int index)
+const field_value& Dataset::get_field_value(int index)
 {
   if (ds_state != dsInactive)
   {

--- a/xbmc/dbwrappers/dataset.h
+++ b/xbmc/dbwrappers/dataset.h
@@ -388,11 +388,11 @@ public:
   //  virtual char *field_name(int f_index) { return field_by_index(f_index)->get_field_name(); }
 
   /* Getting value of field for current record */
-  virtual const field_value get_field_value(const char* f_name);
-  virtual const field_value get_field_value(int index);
+  virtual const field_value& get_field_value(const char* f_name);
+  virtual const field_value& get_field_value(int index);
   /* Alias to get_field_value */
-  const field_value fv(const char* f) { return get_field_value(f); }
-  const field_value fv(int index) { return get_field_value(index); }
+  const field_value& fv(const char* f) { return get_field_value(f); }
+  const field_value& fv(int index) { return get_field_value(index); }
 
   /* ------------ for transaction ------------------- */
   void set_autocommit(bool v) { autocommit = v; }

--- a/xbmc/dbwrappers/dataset.h
+++ b/xbmc/dbwrappers/dataset.h
@@ -266,7 +266,7 @@ protected:
   void parse_sql(std::string& sql);
 
   /* Returns old field value (for :OLD) */
-  virtual const field_value f_old(const char* f);
+  virtual field_value f_old(const char* f);
 
   /* fast string tolower helper */
   char* str_toLower(char* s);

--- a/xbmc/dbwrappers/qry_dat.cpp
+++ b/xbmc/dbwrappers/qry_dat.cpp
@@ -169,7 +169,7 @@ field_value::field_value(const field_value& fv)
 field_value::~field_value() = default;
 
 //Conversations functions
-std::string field_value::get_asString() const
+std::string field_value::get_asString() const&
 {
   switch (field_type)
   {
@@ -232,6 +232,17 @@ std::string field_value::get_asString() const
     }
     default:
       return "";
+  }
+}
+
+std::string field_value::get_asString() &&
+{
+  switch (field_type)
+  {
+    case ft_String:
+      return std::move(str_value);
+    default:
+      return get_asString();
   }
 }
 

--- a/xbmc/dbwrappers/qry_dat.cpp
+++ b/xbmc/dbwrappers/qry_dat.cpp
@@ -830,6 +830,12 @@ void field_value::set_asString(const std::string& s)
   field_type = ft_String;
 }
 
+void field_value::set_asString(std::string&& s)
+{
+  str_value = std::move(s);
+  field_type = ft_String;
+}
+
 void field_value::set_asBool(const bool b)
 {
   bool_value = b;

--- a/xbmc/dbwrappers/qry_dat.cpp
+++ b/xbmc/dbwrappers/qry_dat.cpp
@@ -165,6 +165,11 @@ field_value::field_value(const field_value& fv)
   is_null = fv.get_isNull();
 }
 
+field_value::field_value(field_value&& fv) noexcept
+{
+  *this = std::move(fv);
+}
+
 //empty destructor
 field_value::~field_value() = default;
 
@@ -781,6 +786,23 @@ field_value& field_value::operator=(const field_value& fv)
     }
     default:
       return *this;
+  }
+}
+
+field_value& field_value::operator=(field_value&& fv) noexcept
+{
+  if (this == &fv)
+    return *this;
+
+  is_null = fv.get_isNull();
+
+  switch (fv.get_fType())
+  {
+    case ft_String:
+      set_asString(std::move(fv.str_value));
+      return *this;
+    default:
+      return *this = fv;
   }
 }
 

--- a/xbmc/dbwrappers/qry_dat.cpp
+++ b/xbmc/dbwrappers/qry_dat.cpp
@@ -105,6 +105,11 @@ field_value::field_value(const int64_t i)
   is_null = false;
 }
 
+field_value::field_value(const char* s, std::size_t len)
+  : field_type(ft_String), str_value(s, len), is_null(false)
+{
+}
+
 field_value::field_value(const field_value& fv)
 {
   switch (fv.get_fType())
@@ -810,6 +815,12 @@ field_value& field_value::operator=(field_value&& fv) noexcept
 void field_value::set_asString(const char* s)
 {
   str_value = s;
+  field_type = ft_String;
+}
+
+void field_value::set_asString(const char* s, std::size_t len)
+{
+  str_value = std::string_view(s, len);
   field_type = ft_String;
 }
 

--- a/xbmc/dbwrappers/qry_dat.cpp
+++ b/xbmc/dbwrappers/qry_dat.cpp
@@ -171,69 +171,67 @@ field_value::~field_value() = default;
 //Conversations functions
 std::string field_value::get_asString() const
 {
-  std::string tmp;
   switch (field_type)
   {
     case ft_String:
     {
-      tmp = str_value;
-      return tmp;
+      return str_value;
     }
     case ft_Boolean:
     {
       if (bool_value)
-        return tmp = "True";
+        return "True";
       else
-        return tmp = "False";
+        return "False";
     }
     case ft_Char:
     {
-      return tmp = char_value;
+      return {char_value};
     }
     case ft_Short:
     {
       char t[10];
       snprintf(t, sizeof(t), "%i", short_value);
-      return tmp = t;
+      return t;
     }
     case ft_UShort:
     {
       char t[10];
       snprintf(t, sizeof(t), "%i", ushort_value);
-      return tmp = t;
+      return t;
     }
     case ft_Int:
     {
       char t[12];
       snprintf(t, sizeof(t), "%d", int_value);
-      return tmp = t;
+      return t;
     }
     case ft_UInt:
     {
       char t[12];
       snprintf(t, sizeof(t), "%u", uint_value);
-      return tmp = t;
+      return t;
     }
     case ft_Float:
     {
       char t[16];
       snprintf(t, sizeof(t), "%f", static_cast<double>(float_value));
-      return tmp = t;
+      return t;
     }
     case ft_Double:
     {
       char t[32];
       snprintf(t, sizeof(t), "%f", double_value);
-      return tmp = t;
+      return t;
     }
     case ft_Int64:
     {
       char t[23];
       snprintf(t, sizeof(t), "%" PRId64, int64_value);
-      return tmp = t;
+      return t;
     }
     default:
-      return tmp = "";
+      return "";
   }
 }
 

--- a/xbmc/dbwrappers/qry_dat.h
+++ b/xbmc/dbwrappers/qry_dat.h
@@ -76,6 +76,7 @@ public:
   explicit field_value(const float f);
   explicit field_value(const double d);
   explicit field_value(const int64_t i);
+  field_value(const char* s, std::size_t len);
   field_value(const field_value& fv);
   field_value(field_value&& fv) noexcept;
   ~field_value();
@@ -212,6 +213,7 @@ public:
 
   void set_isNull() { is_null = true; }
   void set_asString(const char* s);
+  void set_asString(const char* s, std::size_t len);
   void set_asString(const std::string& s);
   void set_asBool(const bool b);
   void set_asChar(const char c);

--- a/xbmc/dbwrappers/qry_dat.h
+++ b/xbmc/dbwrappers/qry_dat.h
@@ -105,6 +105,11 @@ public:
     set_asString(s);
     return *this;
   }
+  field_value& operator=(std::string&& s)
+  {
+    set_asString(std::move(s));
+    return *this;
+  }
   field_value& operator=(const bool b)
   {
     set_asBool(b);
@@ -215,6 +220,7 @@ public:
   void set_asString(const char* s);
   void set_asString(const char* s, std::size_t len);
   void set_asString(const std::string& s);
+  void set_asString(std::string&& s);
   void set_asBool(const bool b);
   void set_asChar(const char c);
   void set_asShort(const short s);

--- a/xbmc/dbwrappers/qry_dat.h
+++ b/xbmc/dbwrappers/qry_dat.h
@@ -81,7 +81,8 @@ public:
 
   fType get_fType() const { return field_type; }
   bool get_isNull() const { return is_null; }
-  std::string get_asString() const;
+  std::string get_asString() const&;
+  std::string get_asString() &&;
   bool get_asBool() const;
   char get_asChar() const;
   short get_asShort() const;

--- a/xbmc/dbwrappers/qry_dat.h
+++ b/xbmc/dbwrappers/qry_dat.h
@@ -77,6 +77,7 @@ public:
   explicit field_value(const double d);
   explicit field_value(const int64_t i);
   field_value(const field_value& fv);
+  field_value(field_value&& fv) noexcept;
   ~field_value();
 
   fType get_fType() const { return field_type; }
@@ -144,6 +145,7 @@ public:
     return *this;
   }
   field_value& operator=(const field_value& fv);
+  field_value& operator=(field_value&& fv) noexcept;
 
   //class ostream;
   friend std::ostream& operator<<(std::ostream& os, const field_value& fv)

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -915,10 +915,12 @@ bool SqliteDataset::query(const std::string& query)
           v.set_asDouble(sqlite3_column_double(stmt, i));
           break;
         case SQLITE_TEXT:
-          v.set_asString((const char*)sqlite3_column_text(stmt, i));
+          v.set_asString(reinterpret_cast<const char*>(sqlite3_column_text(stmt, i)),
+                         sqlite3_column_bytes(stmt, i));
           break;
         case SQLITE_BLOB:
-          v.set_asString((const char*)sqlite3_column_text(stmt, i));
+          v.set_asString(reinterpret_cast<const char*>(sqlite3_column_text(stmt, i)),
+                         sqlite3_column_bytes(stmt, i));
           break;
         case SQLITE_NULL:
         default:


### PR DESCRIPTION
## Description
Some minor improvements:

1. Return by reference to prevent copies
2. When returning by value remove the `const` from the return type because it prevents move semantic
3. Take advantage of known string length
4. Make more move friendly in general

## Motivation and context
Improve efficiency.

## How has this been tested?
Primarily running library refresh an browsing the library with an address sanitized build.

## What is the effect on users?
None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
