### PR TITLE
CURL: Take advantage of std::string move semantic

### DIFF
--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -49,11 +49,11 @@ void CURL::Reset()
   m_iPort = 0;
 }
 
-void CURL::Parse(const std::string& strURL1)
+void CURL::Parse(std::string strURL1)
 {
   Reset();
   // start by validating the path
-  std::string strURL = CUtil::ValidatePath(strURL1);
+  std::string strURL = CUtil::ValidatePath(std::move(strURL1));
 
   // strURL can be one of the following:
   // format 1: protocol://[username:password]@hostname[:port]/directoryandfile
@@ -88,7 +88,7 @@ void CURL::Parse(const std::string& strURL1)
       if (iPos == std::string::npos)
       {
         /* set filename and update extension*/
-        SetFileName(strURL);
+        SetFileName(std::move(strURL));
         return ;
       }
       iPos += extLen + 1;
@@ -105,12 +105,12 @@ void CURL::Parse(const std::string& strURL1)
           archiveName = Encode(archiveName);
           if (is_apk)
           {
-            CURL c("apk://" + archiveName + "/" + strURL.substr(iPos + 1));
+            CURL c("apk://" + archiveName + "/" + std::move(strURL).substr(iPos + 1));
             *this = c;
           }
           else
           {
-            CURL c("zip://" + archiveName + "/" + strURL.substr(iPos + 1));
+            CURL c("zip://" + archiveName + "/" + std::move(strURL).substr(iPos + 1));
             *this = c;
           }
           return;
@@ -137,7 +137,7 @@ void CURL::Parse(const std::string& strURL1)
     IsProtocol("resource")
     )
   {
-    SetFileName(strURL.substr(iPos));
+    SetFileName(std::move(strURL).substr(iPos));
     return;
   }
 
@@ -150,7 +150,7 @@ void CURL::Parse(const std::string& strURL1)
       isoPos = lower.find(".udf\\", iPos);
     if (isoPos != std::string::npos)
     {
-      strURL = strURL.replace(isoPos + 4, 1, "/");
+      strURL.replace(isoPos + 4, 1, "/");
     }
   }
 
@@ -242,7 +242,7 @@ void CURL::Parse(const std::string& strURL1)
     // username
     else
     {
-      m_strUserName = strUserNamePassword;
+      m_strUserName = std::move(strUserNamePassword);
     }
 
     iPos = iAlphaSign + 1;
@@ -275,7 +275,7 @@ void CURL::Parse(const std::string& strURL1)
   // if we still don't have hostname, the strHostNameAndPort substring
   // is 'just' hostname without :port specification - so use it as is.
   if (m_strHostName.empty())
-    m_strHostName = strHostNameAndPort;
+    m_strHostName = std::move(strHostNameAndPort);
 
   if (iSlash != std::string::npos)
   {
@@ -317,9 +317,9 @@ void CURL::Parse(const std::string& strURL1)
   m_strPassword = Decode(m_strPassword);
 }
 
-void CURL::SetFileName(const std::string& strFileName)
+void CURL::SetFileName(std::string strFileName)
 {
-  m_strFileName = strFileName;
+  m_strFileName = std::move(strFileName);
 
   size_t slash = m_strFileName.find_last_of(GetDirectorySeparator());
   size_t period = m_strFileName.find_last_of('.');
@@ -338,13 +338,13 @@ void CURL::SetFileName(const std::string& strFileName)
   StringUtils::ToLower(m_strFileType);
 }
 
-void CURL::SetProtocol(const std::string& strProtocol)
+void CURL::SetProtocol(std::string strProtocol)
 {
-  m_strProtocol = strProtocol;
+  m_strProtocol = std::move(strProtocol);
   StringUtils::ToLower(m_strProtocol);
 }
 
-void CURL::SetOptions(const std::string& strOptions)
+void CURL::SetOptions(std::string strOptions)
 {
   m_strOptions.clear();
   m_options.Clear();
@@ -355,7 +355,7 @@ void CURL::SetOptions(const std::string& strOptions)
        strOptions[0] == ';' ||
        strOptions.find("xml") != std::string::npos)
     {
-      m_strOptions = strOptions;
+      m_strOptions = std::move(strOptions);
       m_options.AddOptions(m_strOptions);
     }
     else
@@ -363,21 +363,21 @@ void CURL::SetOptions(const std::string& strOptions)
   }
 }
 
-void CURL::SetProtocolOptions(const std::string& strOptions)
+void CURL::SetProtocolOptions(std::string strOptions)
 {
   m_strProtocolOptions.clear();
   m_protocolOptions.Clear();
   if (strOptions.length() > 0)
   {
     if (strOptions[0] == '|')
-      m_strProtocolOptions = strOptions.substr(1);
+      m_strProtocolOptions = std::move(strOptions).substr(1);
     else
-      m_strProtocolOptions = strOptions;
+      m_strProtocolOptions = std::move(strOptions);
     m_protocolOptions.AddOptions(m_strProtocolOptions);
   }
 }
 
-const std::string CURL::GetTranslatedProtocol() const
+std::string CURL::GetTranslatedProtocol() const
 {
   if (IsProtocol("shout")
    || IsProtocol("dav")
@@ -391,7 +391,7 @@ const std::string CURL::GetTranslatedProtocol() const
   return GetProtocol();
 }
 
-const std::string CURL::GetFileNameWithoutPath() const
+std::string CURL::GetFileNameWithoutPath() const
 {
   // *.zip and *.rar store the actual zip/rar path in the hostname of the url
   if ((IsProtocol("rar")  ||
@@ -620,9 +620,9 @@ std::string CURL::GetRedacted() const
   return GetWithoutUserDetails(true);
 }
 
-std::string CURL::GetRedacted(const std::string& path)
+std::string CURL::GetRedacted(std::string path)
 {
-  return CURL(path).GetRedacted();
+  return CURL(std::move(path)).GetRedacted();
 }
 
 bool CURL::IsLocal() const

--- a/xbmc/URL.h
+++ b/xbmc/URL.h
@@ -21,10 +21,7 @@
 class CURL
 {
 public:
-  explicit CURL(const std::string& strURL)
-  {
-    Parse(strURL);
-  }
+  explicit CURL(std::string strURL) { Parse(std::move(strURL)); }
 
   CURL() = default;
   virtual ~CURL(void);
@@ -33,31 +30,19 @@ public:
   bool operator==(const std::string &url) const { return Get() == url; }
 
   void Reset();
-  void Parse(const std::string& strURL);
-  void SetFileName(const std::string& strFileName);
-  void SetHostName(const std::string& strHostName)
-  {
-    m_strHostName = strHostName;
-  }
+  void Parse(std::string strURL);
+  void SetFileName(std::string strFileName);
+  void SetHostName(std::string strHostName) { m_strHostName = std::move(strHostName); }
 
-  void SetUserName(const std::string& strUserName)
-  {
-    m_strUserName = strUserName;
-  }
+  void SetUserName(std::string strUserName) { m_strUserName = std::move(strUserName); }
 
-  void SetDomain(const std::string& strDomain)
-  {
-    m_strDomain = strDomain;
-  }
+  void SetDomain(std::string strDomain) { m_strDomain = std::move(strDomain); }
 
-  void SetPassword(const std::string& strPassword)
-  {
-    m_strPassword = strPassword;
-  }
+  void SetPassword(std::string strPassword) { m_strPassword = std::move(strPassword); }
 
-  void SetProtocol(const std::string& strProtocol);
-  void SetOptions(const std::string& strOptions);
-  void SetProtocolOptions(const std::string& strOptions);
+  void SetProtocol(std::string strProtocol);
+  void SetOptions(std::string strOptions);
+  void SetProtocolOptions(std::string strOptions);
   void SetPort(int port)
   {
     m_iPort = port;
@@ -103,7 +88,7 @@ public:
     return m_strProtocol;
   }
 
-  const std::string GetTranslatedProtocol() const;
+  std::string GetTranslatedProtocol() const;
 
   const std::string& GetFileType() const
   {
@@ -125,7 +110,7 @@ public:
     return m_strProtocolOptions;
   }
 
-  const std::string GetFileNameWithoutPath() const; /* return the filename excluding path */
+  std::string GetFileNameWithoutPath() const; /* return the filename excluding path */
 
   char GetDirectorySeparator() const;
 
@@ -134,7 +119,7 @@ public:
   std::string GetWithoutUserDetails(bool redact = false) const;
   std::string GetWithoutFilename() const;
   std::string GetRedacted() const;
-  static std::string GetRedacted(const std::string& path);
+  static std::string GetRedacted(std::string path);
   bool IsLocal() const;
   bool IsLocalHost() const;
   static bool IsFileOnly(const std::string &url); ///< return true if there are no directories in the url.

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -898,31 +898,29 @@ bool CUtil::CreateDirectoryEx(const std::string& strPath)
   return CDirectory::Exists(strPath);
 }
 
-std::string CUtil::MakeLegalFileName(const std::string &strFile, int LegalType)
+std::string CUtil::MakeLegalFileName(std::string strFile, int LegalType)
 {
-  std::string result = strFile;
-
-  StringUtils::Replace(result, '/', '_');
-  StringUtils::Replace(result, '\\', '_');
-  StringUtils::Replace(result, '?', '_');
+  StringUtils::Replace(strFile, '/', '_');
+  StringUtils::Replace(strFile, '\\', '_');
+  StringUtils::Replace(strFile, '?', '_');
 
   if (LegalType == LEGAL_WIN32_COMPAT)
   {
     // just filter out some illegal characters on windows
-    StringUtils::Replace(result, ':', '_');
-    StringUtils::Replace(result, '*', '_');
-    StringUtils::Replace(result, '?', '_');
-    StringUtils::Replace(result, '\"', '_');
-    StringUtils::Replace(result, '<', '_');
-    StringUtils::Replace(result, '>', '_');
-    StringUtils::Replace(result, '|', '_');
-    StringUtils::TrimRight(result, ". ");
+    StringUtils::Replace(strFile, ':', '_');
+    StringUtils::Replace(strFile, '*', '_');
+    StringUtils::Replace(strFile, '?', '_');
+    StringUtils::Replace(strFile, '\"', '_');
+    StringUtils::Replace(strFile, '<', '_');
+    StringUtils::Replace(strFile, '>', '_');
+    StringUtils::Replace(strFile, '|', '_');
+    StringUtils::TrimRight(strFile, ". ");
   }
-  return result;
+  return strFile;
 }
 
 // legalize entire path
-std::string CUtil::MakeLegalPath(const std::string &strPathAndFile, int LegalType)
+std::string CUtil::MakeLegalPath(std::string strPathAndFile, int LegalType)
 {
   if (URIUtils::IsStack(strPathAndFile))
     return MakeLegalPath(CStackDirectory::GetFirstStackedFile(strPathAndFile));
@@ -946,9 +944,8 @@ std::string CUtil::MakeLegalPath(const std::string &strPathAndFile, int LegalTyp
   return dir;
 }
 
-std::string CUtil::ValidatePath(const std::string &path, bool bFixDoubleSlashes /* = false */)
+std::string CUtil::ValidatePath(std::string path, bool bFixDoubleSlashes /* = false */)
 {
-  std::string result = path;
 
   // Don't do any stuff on URLs containing %-characters or protocols that embed
   // filenames. NOTE: Don't use IsInZip or IsInRar here since it will infinitely
@@ -961,46 +958,47 @@ std::string CUtil::ValidatePath(const std::string &path, bool bFixDoubleSlashes 
       StringUtils::StartsWithNoCase(path, "stack:") ||
       StringUtils::StartsWithNoCase(path, "bluray:") ||
       StringUtils::StartsWithNoCase(path, "multipath:") ))
-    return result;
+    return path;
 
-  // check the path for incorrect slashes
+    // check the path for incorrect slashes
 #ifdef TARGET_WINDOWS
   if (URIUtils::IsDOSPath(path))
   {
-    StringUtils::Replace(result, '/', '\\');
+    StringUtils::Replace(path, '/', '\\');
     /* The double slash correction should only be used when *absolutely*
        necessary! This applies to certain DLLs or use from Python DLLs/scripts
        that incorrectly generate double (back) slashes.
     */
-    if (bFixDoubleSlashes && !result.empty())
+    if (bFixDoubleSlashes && !path.empty())
     {
       // Fixup for double back slashes (but ignore the \\ of unc-paths)
-      for (size_t x = 1; x < result.size() - 1; x++)
+      for (size_t x = 1; x < path.size() - 1; x++)
       {
-        if (result[x] == '\\' && result[x+1] == '\\')
-          result.erase(x, 1);
+        if (path[x] == '\\' && path[x + 1] == '\\')
+          path.erase(x, 1);
       }
     }
   }
   else if (path.find("://") != std::string::npos || path.find(":\\\\") != std::string::npos)
 #endif
   {
-    StringUtils::Replace(result, '\\', '/');
+    StringUtils::Replace(path, '\\', '/');
     /* The double slash correction should only be used when *absolutely*
        necessary! This applies to certain DLLs or use from Python DLLs/scripts
        that incorrectly generate double (back) slashes.
     */
-    if (bFixDoubleSlashes && !result.empty())
+    if (bFixDoubleSlashes && !path.empty())
     {
       // Fixup for double forward slashes(/) but don't touch the :// of URLs
-      for (size_t x = 2; x < result.size() - 1; x++)
+      for (size_t x = 2; x < path.size() - 1; x++)
       {
-        if ( result[x] == '/' && result[x + 1] == '/' && !(result[x - 1] == ':' || (result[x - 1] == '/' && result[x - 2] == ':')) )
-          result.erase(x, 1);
+        if (path[x] == '/' && path[x + 1] == '/' &&
+            !(path[x - 1] == ':' || (path[x - 1] == '/' && path[x - 2] == ':')))
+          path.erase(x, 1);
       }
     }
   }
-  return result;
+  return path;
 }
 
 void CUtil::SplitParams(const std::string &paramString, std::vector<std::string> &parameters)

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -99,13 +99,16 @@ public:
   static bool CreateDirectoryEx(const std::string& strPath);
 
 #ifdef TARGET_WINDOWS
-  static std::string MakeLegalFileName(const std::string &strFile, int LegalType=LEGAL_WIN32_COMPAT);
-  static std::string MakeLegalPath(const std::string &strPath, int LegalType=LEGAL_WIN32_COMPAT);
+  static std::string MakeLegalFileName(std::string strFile, int LegalType = LEGAL_WIN32_COMPAT);
+  static std::string MakeLegalPath(std::string strPath, int LegalType = LEGAL_WIN32_COMPAT);
 #else
-  static std::string MakeLegalFileName(const std::string &strFile, int LegalType=LEGAL_NONE);
-  static std::string MakeLegalPath(const std::string &strPath, int LegalType=LEGAL_NONE);
+  static std::string MakeLegalFileName(std::string strFile, int LegalType = LEGAL_NONE);
+  static std::string MakeLegalPath(std::string strPath, int LegalType = LEGAL_NONE);
 #endif
-  static std::string ValidatePath(const std::string &path, bool bFixDoubleSlashes = false); ///< return a validated path, with correct directory separators.
+  static std::string ValidatePath(
+      std::string path,
+      bool bFixDoubleSlashes =
+          false); ///< return a validated path, with correct directory separators.
 
   /*!
    * \brief Check if a filename contains a supported font extension.

--- a/xbmc/cdrip/CDDARipper.cpp
+++ b/xbmc/cdrip/CDDARipper.cpp
@@ -184,7 +184,7 @@ bool CCDDARipper::CreateAlbumDir(const MUSIC_INFO::CMusicInfoTag& infoTag,
     URIUtils::AddSlashAtEnd(strDirectory);
   }
 
-  strDirectory = CUtil::MakeLegalPath(strDirectory, legalType);
+  strDirectory = CUtil::MakeLegalPath(std::move(strDirectory), legalType);
 
   // Create directory if it doesn't exist
   if (!CUtil::CreateDirectoryEx(strDirectory))

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -226,7 +226,7 @@ void CGUIDialogSmartPlaylistEditor::OnOK()
     if (CGUIKeyboardFactory::ShowAndGetInput(filename, CVariant{g_localizeStrings.Get(16013)}, false))
     {
       path = URIUtils::AddFileToFolder(systemPlaylistsPath, m_playlist.GetSaveLocation(),
-                                        CUtil::MakeLegalFileName(filename));
+                                       CUtil::MakeLegalFileName(std::move(filename)));
     }
     else
       return;

--- a/xbmc/filesystem/SpecialProtocol.cpp
+++ b/xbmc/filesystem/SpecialProtocol.cpp
@@ -202,7 +202,7 @@ std::string CSpecialProtocol::TranslatePath(const CURL &url)
   }
 
   // Validate the final path, just in case
-  return CUtil::ValidatePath(translatedPath);
+  return CUtil::ValidatePath(std::move(translatedPath));
 }
 
 std::string CSpecialProtocol::TranslatePathConvertCase(const std::string& path)

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -305,7 +305,7 @@ void CGUIWindowMusicPlayList::SavePlayList()
   std::string strNewFileName;
   if (CGUIKeyboardFactory::ShowAndGetInput(strNewFileName, CVariant{g_localizeStrings.Get(16012)}, false))
   {
-    strNewFileName = CUtil::MakeLegalFileName(strNewFileName);
+    strNewFileName = CUtil::MakeLegalFileName(std::move(strNewFileName));
     strNewFileName += ".m3u8";
     std::string strPath = URIUtils::AddFileToFolder(
       CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_SYSTEM_PLAYLISTSPATH),

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -151,10 +151,10 @@ bool CPeripheral::Initialise(void)
 
   if (m_iVendorId == 0x0000 && m_iProductId == 0x0000)
   {
-    m_strSettingsFile =
-        StringUtils::Format("special://profile/peripheral_data/{}_{}.xml",
-                            PeripheralTypeTranslator::BusTypeToString(m_mappedBusType),
-                            CUtil::MakeLegalFileName(safeDeviceName, LEGAL_WIN32_COMPAT));
+    m_strSettingsFile = StringUtils::Format(
+        "special://profile/peripheral_data/{}_{}.xml",
+        PeripheralTypeTranslator::BusTypeToString(m_mappedBusType),
+        CUtil::MakeLegalFileName(std::move(safeDeviceName), LEGAL_WIN32_COMPAT));
   }
   else
   {
@@ -167,7 +167,7 @@ bool CPeripheral::Initialise(void)
       m_strSettingsFile = StringUtils::Format(
           "special://profile/peripheral_data/{}_{}_{}_{}.xml",
           PeripheralTypeTranslator::BusTypeToString(m_mappedBusType), m_strVendorId, m_strProductId,
-          CUtil::MakeLegalFileName(safeDeviceName, LEGAL_WIN32_COMPAT));
+          CUtil::MakeLegalFileName(std::move(safeDeviceName), LEGAL_WIN32_COMPAT));
   }
 
   LoadPersistedSettings();

--- a/xbmc/platform/win32/threads/Win32Exception.cpp
+++ b/xbmc/platform/win32/threads/Win32Exception.cpp
@@ -73,8 +73,9 @@ bool win32_exception::write_minidump(EXCEPTION_POINTERS* pEp)
                                      mVersion, stLocalTime.year, stLocalTime.month, stLocalTime.day,
                                      stLocalTime.hour, stLocalTime.minute, stLocalTime.second);
 
-  dumpFileName = CWIN32Util::SmbToUnc(URIUtils::AddFileToFolder(
-      CWIN32Util::GetProfilePath(m_platformDir), CUtil::MakeLegalFileName(dumpFileName)));
+  dumpFileName = CWIN32Util::SmbToUnc(
+      URIUtils::AddFileToFolder(CWIN32Util::GetProfilePath(m_platformDir),
+                                CUtil::MakeLegalFileName(std::move(dumpFileName))));
 
   dumpFileNameW = KODI::PLATFORM::WINDOWS::ToW(dumpFileName);
   HANDLE hDumpFile = CreateFileW(dumpFileNameW.c_str(), GENERIC_WRITE, 0, 0, CREATE_ALWAYS, 0, 0);
@@ -189,8 +190,9 @@ bool win32_exception::write_stacktrace(EXCEPTION_POINTERS* pEp)
                                      mVersion, stLocalTime.year, stLocalTime.month, stLocalTime.day,
                                      stLocalTime.hour, stLocalTime.minute, stLocalTime.second);
 
-  dumpFileName = CWIN32Util::SmbToUnc(URIUtils::AddFileToFolder(
-      CWIN32Util::GetProfilePath(m_platformDir), CUtil::MakeLegalFileName(dumpFileName)));
+  dumpFileName = CWIN32Util::SmbToUnc(
+      URIUtils::AddFileToFolder(CWIN32Util::GetProfilePath(m_platformDir),
+                                CUtil::MakeLegalFileName(std::move(dumpFileName))));
 
   dumpFileNameW = KODI::PLATFORM::WINDOWS::ToW(dumpFileName);
   hDumpFile = CreateFileW(dumpFileNameW.c_str(), GENERIC_WRITE, 0, 0, CREATE_ALWAYS, 0, 0);

--- a/xbmc/playlists/PlayListB4S.cpp
+++ b/xbmc/playlists/PlayListB4S.cpp
@@ -105,7 +105,7 @@ void CPlayListB4S::Save(const std::string& strFileName) const
 {
   if (!m_vecItems.size()) return ;
   std::string strPlaylist = strFileName;
-  strPlaylist = CUtil::MakeLegalPath(strPlaylist);
+  strPlaylist = CUtil::MakeLegalPath(std::move(strPlaylist));
   CFile file;
   if (!file.OpenForWrite(strPlaylist, true))
   {

--- a/xbmc/utils/FileOperationJob.cpp
+++ b/xbmc/utils/FileOperationJob.cpp
@@ -168,7 +168,7 @@ bool CFileOperationJob::DoProcess(FileAction action,
           strFileName += URIUtils::GetExtension(pItem->GetPath());
         }
 
-        strFileName = CUtil::MakeLegalFileName(strFileName);
+        strFileName = CUtil::MakeLegalFileName(std::move(strFileName));
       }
 
       std::string strnewDestFile;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -10927,7 +10927,7 @@ std::string CVideoDatabase::GetSafeFile(const std::string &dir, const std::strin
 {
   std::string safeThumb(name);
   StringUtils::Replace(safeThumb, ' ', '_');
-  return URIUtils::AddFileToFolder(dir, CUtil::MakeLegalFileName(safeThumb));
+  return URIUtils::AddFileToFolder(dir, CUtil::MakeLegalFileName(std::move(safeThumb)));
 }
 
 void CVideoDatabase::AnnounceRemove(const std::string& content, int id, bool scanning /* = false */)

--- a/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
+++ b/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
@@ -418,7 +418,7 @@ void CGUIWindowVideoPlaylist::SavePlayList()
   if (CGUIKeyboardFactory::ShowAndGetInput(strNewFileName, CVariant{g_localizeStrings.Get(16012)}, false))
   {
     // need 2 rename it
-    strNewFileName = CUtil::MakeLegalFileName(strNewFileName);
+    strNewFileName = CUtil::MakeLegalFileName(std::move(strNewFileName));
     strNewFileName += ".m3u8";
     std::string strPath = URIUtils::AddFileToFolder(
       CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_SYSTEM_PLAYLISTSPATH),


### PR DESCRIPTION
## Description
Optimize `std::string` handling to allow for move semantic. The `CUtil` commit is part of this PR because I need the move friendly `CUtil::ValidatePath` in `CURL::Parse`.

## Motivation and context
Improve efficiency. In my case it saves around 100,000 allocations when re-scanning my already up-to-date TV library.

## How has this been tested?
Refreshing the library and general Kodi usage with an address sanitizer enabled build.

## What is the effect on users?
None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
