### PR TITLE
[database][mysql][video] MySQL: Change Charset/Collation to utf8mb4_general_ci

### DIFF
--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -221,11 +221,11 @@ int MysqlDatabase::connect(bool create_new)
       // disable mysql autocommit since we handle it
       //mysql_autocommit(conn, false);
 
-      // enforce utf8 charset usage
+      // enforce utf8mb4 charset usage
       default_charset = mysql_character_set_name(conn);
-      if (mysql_set_character_set(conn, "utf8")) // returns 0 on success
+      if (mysql_set_character_set(conn, "utf8mb4")) // returns 0 on success
       {
-        CLog::Log(LOGERROR, "Unable to set utf8 charset: {} [{}]({})", db, mysql_errno(conn),
+        CLog::Log(LOGERROR, "Unable to set utf8mb4 charset: {} [{}]({})", db, mysql_errno(conn),
                   mysql_error(conn));
       }
 
@@ -239,7 +239,7 @@ int MysqlDatabase::connect(bool create_new)
       else if (create_new)
       {
         const std::string sqlcmd{StringUtils::Format(
-            "CREATE DATABASE `{}` CHARACTER SET utf8 COLLATE utf8_general_ci", db)};
+            "CREATE DATABASE `{}` CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci", db)};
         const int ret = query_with_reconnect(sqlcmd.c_str());
         if (ret != MYSQL_OK)
         {
@@ -340,7 +340,7 @@ int MysqlDatabase::copy(const char* backup_name)
     }
 
     // create the new database
-    sqlcmd = StringUtils::Format("CREATE DATABASE `{}` CHARACTER SET utf8 COLLATE utf8_general_ci",
+    sqlcmd = StringUtils::Format("CREATE DATABASE `{}` CHARACTER SET utfmb48 COLLATE utf8mb4_general_ci",
                                  backup_name);
     ret = query_with_reconnect(sqlcmd.c_str());
     if (ret != MYSQL_OK)
@@ -692,7 +692,7 @@ std::string MysqlDatabase::vprepare(const char* format, va_list args)
   }
 
   // Remove COLLATE NOCASE the SQLite case insensitive collation.
-  // In MySQL all tables are defined with case insensitive collation utf8_general_ci
+  // In MySQL all tables are defined with case insensitive collation utf8mb4_general_ci
   pos = 0;
   while ((pos = strResult.find(" COLLATE NOCASE", pos)) != std::string::npos)
   {
@@ -1816,7 +1816,7 @@ int MysqlDataset::exec(const std::string& sql)
       ci_find(qry, "CREATE TEMPORARY TABLE") != std::string::npos)
   {
     // If CREATE TABLE ... SELECT Syntax is used we need to add the encoding after the table before the select
-    // e.g. CREATE TABLE x CHARACTER SET utf8 COLLATE utf8_general_ci [AS] SELECT * FROM y
+    // e.g. CREATE TABLE x CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci [AS] SELECT * FROM y
     loc = qry.find(" AS SELECT ");
     if (loc == std::string::npos)
     {
@@ -1824,10 +1824,10 @@ int MysqlDataset::exec(const std::string& sql)
     }
     if (loc != std::string::npos)
     {
-      qry = qry.insert(loc, " CHARACTER SET utf8 COLLATE utf8_general_ci");
+      qry = qry.insert(loc, " CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci");
     }
     else
-      qry += " CHARACTER SET utf8 COLLATE utf8_general_ci";
+      qry += " CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
   }
 
   const auto start = std::chrono::steady_clock::now();


### PR DESCRIPTION
MySQL_set_charset_utf8mbr4
Update Videodb schema to 122 to create new MySQL database with utfmb4 charset
Add additional reference to utfmb4_general_ci

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Current video database implementation for MySQL/Mariadb uses utf8 character set and utf8_general_ci collation.  As a result, unable to add text data to text fields where characters fall outside of the unicode BMP.  When these characters exist in video file names, the files are not scanned into the database.  SQLite databases do not have this limitation.

This changes the database definition for MySQL/Mariadb to specify character set utf8mb4 (4-byte) and collation utf8mb4_general_ci by updating the video database schema to version 122.

Note that there would be advantages to changing to a more unicode compliant collation but that is outside the scope of this change.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR fixes issues https://github.com/xbmc/xbmc/issues/23312 and https://github.com/xbmc/xbmc/issues/16328 by allowing characters above the unicode BMP to be entered into both SQLite and MySQL/MariaDB video database.

Note also [MySQL Ref Man 8.0](https://dev.mysql.com/doc/refman/8.0/en/charset-unicode-utf8.html) indicates utf8 (alias to utf8mb3) is deprecated and may be removed at a later date.  I believe utf8mb4 is supported in MySQL since ver 5.6 but am uncertain if older MySQL/Mariadb installs need some server-side maintenance to accept utf8mb4.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Created a local mariadb 11.1.0 installation on windows 10 x64.  Built Kodi from master in VS2022 as debug and ran from desktop.  Tested with no videodb in Mariadb and also with myvideos121 created by Kodi 20.1.  In both instances new myvideos122 database was created with tables and columns text set to utf8mb4 collation utf8mb4_general_ci.  Successfully added video files with unicode above BMP to myvideos122.  Performed regression test on SQLite and myvideos122.db correctly migrated from myvideos121.db

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Users who use MySQL/Mariadb database to manage Kodi databases can now use unicode characters outside of the BMP, to give same performance as SQLite database.  This will also reduce errors when users move from SQLite to MySQL/Mariadb with existing SQLite library. 

This may require maintenance action by users with older installs of MySQL/Mariadb on the server side.  Need assistance of a database dev to verify. 

Note: it doesn't appear existing Doxygen/Wiki covers this topic.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
