### PR TITLE
[Windows] DXVA: check if HDR10 color spaces are supported by video processor

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -120,6 +120,7 @@ public:
   }
 
   static bool IsBT2020Supported();
+  static bool IsPQ10PassthroughSupported(const DXGI_FORMAT dxgi_format);
   static bool IsSuperResolutionSuitable(const VideoPicture& picture);
   void TryEnableVideoSuperResolution();
 
@@ -139,10 +140,11 @@ protected:
   static DXGI_COLOR_SPACE_TYPE GetDXGIColorSpaceSource(const DXGIColorSpaceArgs& csArgs,
                                                        bool supportHDR,
                                                        bool supportHLG,
-                                                       bool topLeft);
-  DXGI_COLOR_SPACE_TYPE GetDXGIColorSpaceTarget(const DXGIColorSpaceArgs& csArgs,
-                                                bool supportHDR,
-                                                bool limitedRange) const;
+                                                       bool BT2020Left,
+                                                       bool HDRLeft);
+  static DXGI_COLOR_SPACE_TYPE GetDXGIColorSpaceTarget(const DXGIColorSpaceArgs& csArgs,
+                                                       bool supportHDR,
+                                                       bool limitedRange);
   /*!
    * \brief Converts ffmpeg AV parameters to a DXGI color space
    * \param csArgs ffmpeg AV picture parameters
@@ -168,8 +170,8 @@ protected:
   D3D11_VIDEO_PROCESSOR_CAPS m_vcaps = {};
   D3D11_VIDEO_PROCESSOR_RATE_CONVERSION_CAPS m_rateCaps = {};
   bool m_bSupportHLG = false;
-  bool m_bSupportHDR10Limited = false;
-  bool m_BT2020TopLeft = false;
+  bool m_HDR10Left{false};
+  bool m_BT2020Left{false};
 
   struct ProcAmpInfo
   {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
 - In similar way that https://github.com/xbmc/xbmc/pull/23109 implements a static method to check if HDR10 color spaces are supported by video processor before initialize it. Then fallback to Pixel Shaders when DXVA not supports color conversion.
- Added support for use the two existent DXGI HDR10 color spaces with different chroma sitting: `DXGI_COLOR_SPACE_YCBCR_STUDIO_G2084_LEFT_P2020` and `DXGI_COLOR_SPACE_YCBCR_STUDIO_G2084_TOPLEFT_P2020`.
- When the two YCBCR HDR10 color spaces are supported is used TOPLEFT because according Microsoft documentation this is the right one for UHD Blu-Ray https://learn.microsoft.com/en-us/windows/win32/api/dxgicommon/ne-dxgicommon-dxgi_color_space_type#siting
- Removes the workaround for HDR10 in limited range implemented in https://github.com/xbmc/xbmc/pull/19826 because in RTX 4070 is not valid anymore (wrong black level) and even on RTX 20x, 30x is not usable now because  `CheckVideoProcessorFormatConversion` returns is not valid conversion.

## Motivation and context
Found that in NVIDIA RTX 4070 things goes wrong with HDR10 limited range.... The use of only "native" color spaces for HDR10 simplifies things and with more strictly checks and fallback to Pixel Shaders more robust and predictable behavior should result.

Closes https://github.com/xbmc/xbmc/issues/23357

Also should fix other sporadic issues seen in forums as: 
https://forum.kodi.tv/showthread.php?tid=372606&pid=3146966#pid3146966

## How has this been tested?
Runtime tested Intel NUC8i3BEK and NVIDIA RTX 4070. 
On NUC continues working as before supporting DXVA HDR10 passthrough in full and limited range.
On RTX 4070 DXVA HDR10 works only in full range and now is used Pixel Shaders in limited range.

Note that current behavior for RTX 4070 limited range in Nexus is wrong black level and in master execution halts in:
https://github.com/xbmc/xbmc/blob/f84cf8bcff3c22e249d91e676c7a0229547190c1/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp#L137


## What is the effect on users?
Avoids failures or wrong picture/black screen when DXVA HDR10 color conversion is not full supported and improves compatibility in some scenarios.


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
