### PR TITLE
[Windows] Setting for high precision processing / HDR tone mapping

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7211,7 +7211,12 @@ msgctxt "#13417"
 msgid "Allow use DXVA Video Super Resolution"
 msgstr ""
 
-#empty string 13418
+#. Setting Player / Video
+#: system/settings/settings.xml
+#: xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
+msgctxt "#13418"
+msgid "Use high precision processing"
+msgstr ""
 
 #: system/settings/settings.xml
 #: xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
@@ -23452,4 +23457,10 @@ msgstr ""
 #: system/settings/settings.xml
 msgctxt "#39194"
 msgid "Enables advanced DXVA upscaler using NVIDIA \"RTX Video Super Resolution\" or \"Intel Video Super Resolution\".[CR]Used when video source is 1080p or less (progressive only) and source resolution is lower than display resolution.[CR]It's only available on specific hardware: NVIDIA RTX 40x, RTX 30x and Intel Arc A770, A750."
+msgstr ""
+
+#. Description of setting with label #13418 "Use high precision processing"
+#: system/settings/settings.xml
+msgctxt "#39195"
+msgid "Enable this option for the best picture quality. Disabling reduces the load on resource-limited systems."
 msgstr ""

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -173,6 +173,12 @@
           <default>true</default>
           <control type="toggle" />
         </setting>
+        <setting id="videoplayer.highprecision" type="boolean" label="13418" help="39195">
+          <requirement>HAS_DX</requirement>
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
       </group>
       <group id="4" label="14232">
         <setting id="videoplayer.stereoscopicplaybackmode" type="integer" label="36520" help="36537">

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -168,7 +168,7 @@ bool CProcessorHD::IsFormatSupported(DXGI_FORMAT format, D3D11_VIDEO_PROCESSOR_F
 bool CProcessorHD::CheckFormats() const
 {
   // check default output format (as render target)
-  return IsFormatSupported(DX::Windowing()->GetBackBuffer().GetFormat(), D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT_OUTPUT);
+  return IsFormatSupported(m_output_dxgi_format, D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT_OUTPUT);
 }
 
 bool CProcessorHD::IsFormatConversionSupported(DXGI_FORMAT inputFormat,
@@ -219,9 +219,6 @@ bool CProcessorHD::Open(const VideoPicture& picture)
       CRendererDXVA::GetDXGIFormat(av_pixel_format, CRendererBase::GetDXGIFormat(picture));
 
   if (!InitProcessor())
-    return false;
-
-  if (!CheckFormats())
     return false;
 
   return OpenProcessor();
@@ -963,4 +960,14 @@ void CProcessorHD::EnableNvidiaRTXVideoSuperResolution()
 
   CLog::LogF(LOGINFO, "RTX Video Super Resolution request enable successfully");
   m_superResolutionEnabled = true;
+}
+
+bool CProcessorHD::SetOutputFormat(DXGI_FORMAT outputFormat)
+{
+  if (IsFormatSupported(outputFormat, D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT_OUTPUT))
+  {
+    m_output_dxgi_format = outputFormat;
+    return true;
+  }
+  return false;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -84,6 +84,13 @@ public:
                                 const DXGI_FORMAT& outputFormat,
                                 const VideoPicture& picture);
 
+  /*!
+   * \brief Set the output format of the dxva processor. Format compatibility will be verified.
+   * \param format The output format
+   * \return true when the processor supports the format as output and the format is changed.
+   */
+  bool SetOutputFormat(DXGI_FORMAT format);
+
   // ID3DResource overrides
   void OnCreateDevice() override  {}
   void OnDestroyDevice(bool) override
@@ -146,6 +153,7 @@ protected:
   AVColorTransferCharacteristic m_color_transfer{AVCOL_TRC_UNSPECIFIED};
   ProcessorCapabilities m_procCaps{};
   DXGI_FORMAT m_input_dxgi_format{DXGI_FORMAT_UNKNOWN};
+  DXGI_FORMAT m_output_dxgi_format{DXGI_FORMAT_UNKNOWN};
 
   bool m_forced8bit{false};
   bool m_superResolutionEnabled{false};

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
@@ -336,21 +336,28 @@ void CRendererBase::DeleteRenderBuffer(int index)
   }
 }
 
-bool CRendererBase::CreateIntermediateTarget(unsigned width, unsigned height, bool dynamic)
+bool CRendererBase::CreateIntermediateTarget(unsigned width,
+                                             unsigned height,
+                                             bool dynamic,
+                                             DXGI_FORMAT format)
 {
-  DXGI_FORMAT format = DX::Windowing()->GetBackBuffer().GetFormat();
+  // No format specified by renderer > mirror swap chain's backbuffer format
+  if (format == DXGI_FORMAT_UNKNOWN)
+    format = DX::Windowing()->GetBackBuffer().GetFormat();
 
   // don't create new one if it exists with requested size and format
-  if (m_IntermediateTarget.Get() && m_IntermediateTarget.GetFormat() == format
-    && m_IntermediateTarget.GetWidth() == width && m_IntermediateTarget.GetHeight() == height)
+  if (m_IntermediateTarget.Get() && m_IntermediateTarget.GetFormat() == format &&
+      m_IntermediateTarget.GetWidth() == width && m_IntermediateTarget.GetHeight() == height)
     return true;
 
   if (m_IntermediateTarget.Get())
     m_IntermediateTarget.Release();
 
-  CLog::LogF(LOGDEBUG, "intermediate target format {}.", DX::DXGIFormatToString(format));
+  CLog::LogF(LOGDEBUG, "creating intermediate target {}x{} format {}.", width, height,
+             DX::DXGIFormatToString(format));
 
-  if (!m_IntermediateTarget.Create(width, height, 1, dynamic ? D3D11_USAGE_DYNAMIC : D3D11_USAGE_DEFAULT, format))
+  if (!m_IntermediateTarget.Create(width, height, 1,
+                                   dynamic ? D3D11_USAGE_DYNAMIC : D3D11_USAGE_DEFAULT, format))
   {
     CLog::LogF(LOGERROR, "intermediate target creation failed.");
     return false;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
@@ -731,7 +731,27 @@ DEBUG_INFO_VIDEO CRendererBase::GetDebugInfo(int idx)
   if (m_outputShader)
     info.shader = m_outputShader->GetDebugInfo();
 
-  info.render = StringUtils::Format("Render method: {}", m_renderMethodName);
+  std::string itformat;
+  switch (m_IntermediateTarget.GetFormat())
+  {
+    case DXGI_FORMAT_B8G8R8A8_UNORM:
+      itformat = "BGRA8";
+      break;
+    case DXGI_FORMAT_R10G10B10A2_UNORM:
+      itformat = "RGBA10";
+      break;
+    case DXGI_FORMAT_R16G16B16A16_FLOAT:
+      itformat = "FP16";
+      break;
+    case DXGI_FORMAT_R32G32B32A32_FLOAT:
+      itformat = "FP32";
+      break;
+    default:
+      itformat = "unknown";
+  }
+
+  info.render =
+      StringUtils::Format("Render method: {}, IT format: {}", m_renderMethodName, itformat);
 
   std::string rmInfo = GetRenderMethodDebugInfo();
   if (!rmInfo.empty())

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
@@ -341,8 +341,14 @@ bool CRendererBase::CreateIntermediateTarget(unsigned width,
                                              bool dynamic,
                                              DXGI_FORMAT format)
 {
-  // No format specified by renderer > mirror swap chain's backbuffer format
-  if (format == DXGI_FORMAT_UNKNOWN)
+  // No format specified by renderer or high precision disabled > mirror swap chain's backbuffer format
+  const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+
+  if (!settings)
+    return false;
+
+  if (format == DXGI_FORMAT_UNKNOWN ||
+      !settings->GetBool(CSettings::SETTING_VIDEOPLAYER_HIGHPRECISIONPROCESSING))
     format = DX::Windowing()->GetBackBuffer().GetFormat();
 
   // don't create new one if it exists with requested size and format

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
@@ -139,7 +139,10 @@ public:
 protected:
   explicit CRendererBase(CVideoSettings& videoSettings);
 
-  bool CreateIntermediateTarget(unsigned int width, unsigned int height, bool dynamic = false);
+  bool CreateIntermediateTarget(unsigned int width,
+                                unsigned int height,
+                                bool dynamic = false,
+                                DXGI_FORMAT format = DXGI_FORMAT_UNKNOWN);
   void OnCMSConfigChanged(AVColorPrimaries srcPrimaries);
   void ReorderDrawPoints(const CRect& destRect, CPoint(&rotatedPoints)[4]) const;
   bool CreateRenderBuffer(int index);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
@@ -48,8 +48,10 @@ protected:
 private:
   void FillBuffersSet(CRenderBuffer* (&buffers)[8]);
   CRect ApplyTransforms(const CRect& destRect) const;
+  DXGI_FORMAT CalcIntermediateTargetFormat(const VideoPicture& picture) const;
 
   std::unique_ptr<DXVA::CProcessorHD> m_processor;
+  DXGI_FORMAT m_intermediateTargetFormat{DXGI_FORMAT_UNKNOWN};
 };
 
 class CRendererDXVA::CRenderBufferImpl : public CRenderBuffer

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererShaders.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererShaders.cpp
@@ -99,7 +99,8 @@ bool CRendererShaders::Configure(const VideoPicture& picture, float fps, unsigne
         m_format = GetAVFormat(dxgi_format);
     }
 
-    CreateIntermediateTarget(m_sourceWidth, m_sourceHeight);
+    CreateIntermediateTarget(m_sourceWidth, m_sourceHeight, false,
+                             CalcIntermediateTargetFormat(picture));
     return true;
   }
   return false;
@@ -200,6 +201,35 @@ AVColorPrimaries CRendererShaders::GetSrcPrimaries(AVColorPrimaries srcPrimaries
       ret = AVCOL_PRI_BT470BG;
   }
   return ret;
+}
+
+DXGI_FORMAT CRendererShaders::CalcIntermediateTargetFormat(const VideoPicture& picture) const
+{
+  // Default value: same as the back buffer
+  DXGI_FORMAT format{DX::Windowing()->GetBackBuffer().GetFormat()};
+
+  // Preserve HDR precision
+  if (picture.colorBits > 8 && (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
+                                picture.color_transfer == AVCOL_TRC_ARIB_STD_B67))
+  {
+    UINT reqSupport{D3D11_FORMAT_SUPPORT_SHADER_SAMPLE | D3D11_FORMAT_SUPPORT_RENDER_TARGET};
+
+    // Preferred: float16 as the yuv-rgb conversion takes place in float
+    // => avoids a conversion / quantization round-trip, but uses more bandwidth
+    const std::array hdrformats{DXGI_FORMAT_R16G16B16A16_FLOAT, DXGI_FORMAT_R10G10B10A2_UNORM,
+                                DXGI_FORMAT_R32G32B32A32_FLOAT};
+
+    const auto it =
+        std::find_if(hdrformats.cbegin(), hdrformats.cend(), [&](DXGI_FORMAT outputFormat) {
+          return DX::Windowing()->IsFormatSupport(outputFormat, reqSupport);
+        });
+
+    if (it != hdrformats.cend())
+      format = *it;
+    else
+      CLog::LogF(LOGDEBUG, "no compatible high precision format found for HDR.");
+  }
+  return format;
 }
 
 CRenderBuffer* CRendererShaders::CreateBuffer()

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererShaders.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererShaders.h
@@ -48,6 +48,7 @@ protected:
 
 private:
   static AVColorPrimaries GetSrcPrimaries(AVColorPrimaries srcPrimaries, unsigned int width, unsigned int height);
+  DXGI_FORMAT CalcIntermediateTargetFormat(const VideoPicture& picture) const;
 
   AVColorPrimaries m_srcPrimaries = AVCOL_PRI_BT709;
   std::unique_ptr<CYUV2RGBShader> m_colorShader;

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -114,6 +114,7 @@ public:
   static constexpr auto SETTING_VIDEOPLAYER_RENDERMETHOD = "videoplayer.rendermethod";
   static constexpr auto SETTING_VIDEOPLAYER_HQSCALERS = "videoplayer.hqscalers";
   static constexpr auto SETTING_VIDEOPLAYER_USESUPERRESOLUTION = "videoplayer.usesuperresolution";
+  static constexpr auto SETTING_VIDEOPLAYER_HIGHPRECISIONPROCESSING = "videoplayer.highprecision";
   static constexpr auto SETTING_VIDEOPLAYER_USEMEDIACODEC = "videoplayer.usemediacodec";
   static constexpr auto SETTING_VIDEOPLAYER_USEMEDIACODECSURFACE =
       "videoplayer.usemediacodecsurface";


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Decoupled the intermediate target (called IT in the rest of the description) format from the backbuffer format.

The render methods can now choose the IT format, each render method can provide its own logic due to their different constraints. Fallback on backbuffer format when the render method does not choose.

For compatibility with previous behavior, the logic was coded so that it will only "upgrade" the format, the back buffer format will still be used the rest of the time and follow the  "Use 10 bit for SDR" setting.

A setting "High precision processing" was created for constrained system to use the previous behavior and always follow the backbuffer format.

* Pixel shaders format selection: rather straightforward, just check usage compatibility. float16 is preferred due to yuv2rgb shader converting as float16. However that's a small change compared with current usage of RGB10 in HDR situations.

* DVXA is more complicated: the dxva processor and its enumerator are needed for texture format compatibility testing, but opening the dxva processor requires knowledge of the texture format. > catch 22...
  * Resolved by delaying the test of CheckFormats a bit (moved into SetOutputFormat()), so the processor can be Open() without texture format.
  * Test compatibility with both IsFormatSupported (windows 8.1) and IsFormatConversionSupported (Windows 10+)
  * Shouldn't interfere with dxva super resolution scaler, limited to SDR media (no hw to confirm through)

Changes left for later:
* Software renderer has other, bigger problems with HDR (color space...), so not changed here
* Allows refactoring of PR #23336 to directly set the intermediate target format as 8 bits instead of modifying the backbuffer + recreating swap chain, with cascade into the IT format.
* One TODO left in CProcessorHD::IsBT2020Supported() still using backbuffer format - doesn't need to be done now because the results are the same. The static vs member functions in CProcessorHD make things difficult without duplicating large amounts of code. To be taken care of in future refactor.

~~* display IT format in debug OSD (only in log for now). The data available in the renderer but should be displayed in rendersystem section, Not sure what to do.~~ Done

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Users selecting "Auto" with AMD GPU or "Off" value in the "Use 10 bit for SDR" setting get slightly reduced precision on HDR to SDR conversion and tone mapping, with lower resulting SDR picture quality.

The output of the color conversion to RGB is truncated to 8 bits instead of preserving the available 10 bits precision.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 10, AMD GPU, Intel gen 4 and gen 8
Setting "Use 10 bit for SDR" auto/on/off.
Setting "Use limited color range" on/off

PQ and HLG material always get 10 bits (DXVA) or float16 (Pixel Shaders).
SDR media is unchanged (8 or 10 bits precision, following existing logic around "Use 10 bit for SDR")

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Improved quality of tone mapping output for AMD users and users with "Use 10 bit for SDR" off (slightly reduced banding)

## Screenshots (if appropriate):
Not sure how well you'll be able to see, with lossy encoding of screenshots, scaling, etc...
The difference was a little easier to see in the rotating color patterns in movement when playing, for some reason.

There is supposed to be banding in this sample, but tone mapping with 8 bit data adds another level of banding. Zoom into the middle pattern.

Before - tone mapping with 8 bits data 
![image](https://github.com/xbmc/xbmc/assets/489377/30728989-3782-4794-ab59-f35175653ba6)


After - tone mapping with 10 bits data
![image](https://github.com/xbmc/xbmc/assets/489377/019df09c-3a15-4bec-9142-0b866b7c0ab2)
"smoother" banding

Setting:
![image](https://github.com/xbmc/xbmc/assets/489377/081e2452-d41f-46ec-b463-1fd1f505d6e2)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
