### PR TITLE
[Windows] HLG > PQ HDR Playback Fixes

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
@@ -271,7 +271,8 @@ void CRendererBase::Render(CD3DTexture& target, const CRect& sourceRect, const C
 
 void CRendererBase::FinalOutput(CD3DTexture& source, CD3DTexture& target, const CRect& src, const CPoint(&destPoints)[4])
 {
-  m_outputShader->Render(source, src, destPoints, target);
+  if (m_outputShader)
+    m_outputShader->Render(source, src, destPoints, target);
 }
 
 void CRendererBase::ManageTextures()


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Separate commits for each change, it's easier to review by looking at the individual commits.
In order:

~~* Expressed the MaxMasteringLuminance of the made-up HLG metadata in nits (per MS doc). Value changed to 2000 nits to match the value in the HLG_TO_PQ block of the output shader~~
* Fixed formula problems in OETF^-1 (range [0,12] instead of [0,1]) and OOTF (multiplication by target max nits in wrong place)
* Added to the HLG OOTF formula of the output shader the gamma calculation for target luminance <> 1000 nits (see BT.2100 Annex 1 Table 5, note 5f)
* Set the target max luminance to 1000 nits
* Changed variable names and steps of the formulas so they're easier to map to the BT.2100 spec

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Highlights are blown out for HLG material with HDR output on LG OLED.
With this change, the picture looks exactly like the picture of the TV's internal player and the highlights are preserved

A few problems found:
- ~~the HLG made-up metadata was ignored by the screen because of incorrect scaling factor for MaxMasteringLuminance~~
- ~~After correcting the metadata, the picture quality improved, but highlights were still blow out~~
edit: seems something changed in Windows and metadata is now ignored no matter what.
- While investigating, noticed formula discrepancies compared with BT.2100

I understand some users may want a brighter or a more "contrasty" picture and the OOTF exists for that purpose (Lw constant = screen max luminance), however 1000 nits is more compatible and a better default I think.
Knobs could be added to Kodi for the Lw and Lb parameters in another PR - I'll start an issue to discuss.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 10, HLG sample and actual programs, Pixel Shaders render method

dxva has a pre-existing problem of washed out colors for some reason => no change with this PR
Hopefully that's limited to AMD but very strange because it's the same dxva processor conversion for PQ passthrough, which works fine.

Compared the output levels with levels listed in BT.1702 ~~and the results improved (very close now).~~
=> The results are perfect. Be careful to do the calculations using the 10-bit code values and not the rounded video levels of the table

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
HLG to PQ conversion compliant with BT.2100, slightly better picture quality.

## Screenshots (if appropriate):
It's not possible to capture a screenshot of the picture tone-mapped by the screen with highlights blow out.

However after the change the screen is able to display all red / green / blue / yellow boxes of the sample pattern below (tone mapped to SDR below, looks much better in HDR):
![image](https://github.com/xbmc/xbmc/assets/489377/d4638599-c6e9-4391-9d51-5c62a929157e)

Luminance curve before (orange) and after (blue)
![image](https://github.com/xbmc/xbmc/assets/489377/244d2d93-f809-4ee4-ab16-e94e106154ce)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed