### PR TITLE
[Android] Target selection: unneeded explicit definition of __ANDROID_API__

### DIFF
--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -313,7 +313,7 @@ esac
 case $host in
   *-*linux-android*)
     deps_dir="$use_host-$use_ndk_api-$build_type"
-    platform_cflags="-DANDROID -D__ANDROID_API__=$use_ndk_api -fexceptions -funwind-tables -fstack-protector-strong -no-canonical-prefixes -fPIC -DPIC"
+    platform_cflags="-DANDROID -fexceptions -funwind-tables -fstack-protector-strong -no-canonical-prefixes -fPIC -DPIC"
     optimize_flags="-Os"
     platform_ldflags="-Wl,--exclude-libs,libgcc.a -Wl,--exclude-libs,libatomic.a -L$prefix/$deps_dir/lib/android-$use_ndk_api"
 


### PR DESCRIPTION
## Description
Cross-compilation targets are selected in Kodi using target-specific wrapper scripts.

The NDK provides wrapper scripts alongside the `clang` and `clang++` binaries, named `<triple><API-level>-clang` and `<triple><API-level>-clang++`.

For example, to target API 21 32-bit ARM, invoke `armv7a-linux-androideabi21-clang` or `armv7a-linux-androideabi21-clang++` instead of `clang` or `clang++`.

Clang defines `__ANDROID_API__` macro automatically based on the triple, so there is no need to explicitly define it.

## How has this been tested?
Build as usual with API level 21 and also tested with a higher level. In both cases the app works correctly.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
