### PR TITLE
[Windowing] Fix regression for resolution label

### DIFF
--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -797,8 +797,8 @@ void CDisplaySettings::SettingOptionsResolutionsFiller(const SettingConstPtr& se
     for (std::vector<RESOLUTION_WHR>::const_iterator resolution = resolutions.begin(); resolution != resolutions.end(); ++resolution)
     {
       std::string resLabel =
-          !resolution->id.empty()
-              ? resolution->id
+          !resolution->label.empty()
+              ? resolution->label
               : StringUtils::Format("{}x{}{}", resolution->width, resolution->height,
                                     ModeFlagsToString(resolution->flags, false));
       list.emplace_back(resLabel, resolution->ResInfo_Index);

--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -53,7 +53,8 @@ RESOLUTION_INFO::RESOLUTION_INFO(const RESOLUTION_INFO& res)
     guiInsets(res.guiInsets),
     strMode(res.strMode),
     strOutput(res.strOutput),
-    strId(res.strId)
+    strId(res.strId),
+    label(res.label)
 {
   bFullScreen = res.bFullScreen;
   iWidth = res.iWidth; iHeight = res.iHeight;

--- a/xbmc/windowing/Resolution.h
+++ b/xbmc/windowing/Resolution.h
@@ -110,6 +110,12 @@ struct RESOLUTION_INFO
   //!< Resolution ID
   std::string strId;
 
+  //! @brief Resolution label
+  //! @note This label is shown to the user (display settings) and takes precedence over the computation of the label based on the internal properties.
+  //! e.g. sometimes, as the example of HiDPI resolutions, it is preferable to show a custom label/string instead of the one computed using the width/height
+  //! of the resolution
+  std::string label;
+
 public:
   RESOLUTION_INFO(int width = 1280, int height = 720, float aspect = 0, const std::string &mode = "");
   float DisplayRatio() const;

--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -111,23 +111,24 @@ static void AddResolution(std::vector<RESOLUTION_WHR> &resolutions, unsigned int
   float refreshrate = resInfo.fRefreshRate;
 
   // don't touch RES_DESKTOP
-  for (unsigned int idx = 1; idx < resolutions.size(); idx++)
-    if (resolutions[idx].width == width && resolutions[idx].height == height &&
-        (resolutions[idx].flags & D3DPRESENTFLAG_MODEMASK) == flags &&
-        resolutions[idx].label == label)
+  for (auto& resolution : resolutions)
+  {
+    if (resolution.width == width && resolution.height == height &&
+        (resolution.flags & D3DPRESENTFLAG_MODEMASK) == flags && resolution.label == label)
     {
       // check if the refresh rate of this resolution is better suited than
       // the refresh rate of the resolution with the same width/height/interlaced
       // property and if so replace it
       if (bestRefreshrate > 0.0f && refreshrate == bestRefreshrate)
-        resolutions[idx].ResInfo_Index = addindex;
+        resolution.ResInfo_Index = addindex;
 
       // no need to add the resolution again
       return;
     }
+  }
 
   RESOLUTION_WHR res = {width, height, flags, static_cast<int>(addindex), id, label};
-  resolutions.push_back(res);
+  resolutions.emplace_back(res);
 }
 
 static bool resSortPredicate(RESOLUTION_WHR i, RESOLUTION_WHR j)

--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -106,13 +106,15 @@ static void AddResolution(std::vector<RESOLUTION_WHR> &resolutions, unsigned int
   int width  = resInfo.iScreenWidth;
   int height = resInfo.iScreenHeight;
   int flags  = resInfo.dwFlags & D3DPRESENTFLAG_MODEMASK;
-  std::string id = resInfo.strId;
+  const std::string id = resInfo.strId;
+  const std::string label = resInfo.label;
   float refreshrate = resInfo.fRefreshRate;
 
   // don't touch RES_DESKTOP
   for (unsigned int idx = 1; idx < resolutions.size(); idx++)
     if (resolutions[idx].width == width && resolutions[idx].height == height &&
-        (resolutions[idx].flags & D3DPRESENTFLAG_MODEMASK) == flags && resolutions[idx].id == id)
+        (resolutions[idx].flags & D3DPRESENTFLAG_MODEMASK) == flags &&
+        resolutions[idx].label == label)
     {
       // check if the refresh rate of this resolution is better suited than
       // the refresh rate of the resolution with the same width/height/interlaced
@@ -124,7 +126,7 @@ static void AddResolution(std::vector<RESOLUTION_WHR> &resolutions, unsigned int
       return;
     }
 
-  RESOLUTION_WHR res = {width, height, flags, static_cast<int>(addindex), id};
+  RESOLUTION_WHR res = {width, height, flags, static_cast<int>(addindex), id, label};
   resolutions.push_back(res);
 }
 

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -28,6 +28,7 @@ struct RESOLUTION_WHR
   int flags; //< only D3DPRESENTFLAG_MODEMASK flags
   int ResInfo_Index;
   std::string id;
+  std::string label;
 };
 
 struct REFRESHRATE

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1111,6 +1111,7 @@ void CWinSystemOSX::FillInVideoModes()
         if (disp == dispIdx)
         {
           res.strId = ComputeVideoModeId(resWidth, resHeight, pixelWidth, pixelHeight, interlaced);
+          res.label = res.strId;
           UpdateDesktopResolution(res, (dispName != nil) ? dispName.UTF8String : "Unknown",
                                   static_cast<int>(pixelWidth), static_cast<int>(pixelHeight),
                                   refreshrate, 0);
@@ -1139,6 +1140,7 @@ void CWinSystemOSX::UpdateResolutions()
   resInfo.strId = ComputeVideoModeId(screenResolution.resWidth, screenResolution.resHeight,
                                      screenResolution.pixelWidth, screenResolution.pixelHeight,
                                      screenResolution.interlaced);
+  resInfo.label = resInfo.strId;
   UpdateDesktopResolution(
       resInfo, dispName.UTF8String, static_cast<int>(screenResolution.pixelWidth),
       static_cast<int>(screenResolution.pixelHeight), screenResolution.refreshrate, 0);


### PR DESCRIPTION
## Description
This fixes a regression caused by https://github.com/xbmc/xbmc/pull/23259 on platforms such as Linux and Android. We were using the resolution id as the label but it turns out on those platforms the id is already being used for other purposes, see https://github.com/xbmc/xbmc/pull/23259#issuecomment-1575623169

Hence in this PR we introduce a label property we are free to set from the windowing system for UI display purposes (e.g. when we select the resolution in the display settings) that takes precedence over the label that is created with the resolution internal properties (width, height, etc). We still match setting selection by ID but decouple the label from the id. 

## Motivation and context
Regression fix, restore same functionality as before.

## How has this been tested?
Runtime tested in MacOS (source of the feature) and tested by @joseluismarti  on other platforms

## What is the effect on users?
Restore previous functionality


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
