### PR TITLE
[Windows] remove unnecessary log for Intel without super resolution scaler support

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
@@ -139,18 +139,19 @@ bool CRendererDXVA::Configure(const VideoPicture& picture, float fps, unsigned o
 
       if (m_processor->IsFormatConversionSupported(dxgi_format, dest_format, picture))
       {
-        const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-
-        if (!settings)
-          return true;
-
-        if (settings->GetBool(CSettings::SETTING_VIDEOPLAYER_USESUPERRESOLUTION) &&
-            DXVA::CProcessorHD::IsSuperResolutionSuitable(picture) &&
-            DX::Windowing()->SupportsVideoSuperResolution())
+        if (DX::Windowing()->SupportsVideoSuperResolution())
         {
-          m_processor->TryEnableVideoSuperResolution();
-        }
+          const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
 
+          if (!settings)
+            return true;
+
+          if (settings->GetBool(CSettings::SETTING_VIDEOPLAYER_USESUPERRESOLUTION) &&
+              CProcessorHD::IsSuperResolutionSuitable(picture))
+          {
+            m_processor->TryEnableVideoSuperResolution();
+          }
+        }
         return true;
       }
     }


### PR DESCRIPTION

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Align test order with the setting visibility condition to avoid logging errors for an unsupported / inexistent setting.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Unnecessary logging when starting playback on a computer that doesn't support super resolution.

>2023-06-06 20:18:44.918 T:20848 debug : requested setting (videoplayer.usesuperresolution) was not found.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Playback with dxva render method on Intel Gen 8 where this used to trigger.
Wasn't happening on AMD > still doesn't

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
none

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
