### PR TITLE
[PVR] Change default timer "priority" when priority not supported

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -133,6 +133,10 @@ void CGUIDialogPVRTimerSettings::SetTimer(const std::shared_ptr<CPVRTimerInfoTag
   m_iMarginStart = m_timerInfoTag->m_iMarginStart;
   m_iMarginEnd = m_timerInfoTag->m_iMarginEnd;
   m_iPriority = m_timerInfoTag->m_iPriority;
+  if (m_timerType->SupportsPriority())
+    m_pPriority = &m_iPriority;
+  else
+    m_pPriority = nullptr;
   m_iLifetime = m_timerInfoTag->m_iLifetime;
   m_iMaxRecordings = m_timerInfoTag->m_iMaxRecordings;
 
@@ -1082,7 +1086,10 @@ void CGUIDialogPVRTimerSettings::PrioritiesFiller(const SettingConstPtr& setting
       return IntegerSettingOption(value.first, value.second);
     });
 
-    current = pThis->m_iPriority;
+    if (pThis->m_pPriority == nullptr)
+      current = pThis->m_timerType->GetPriorityDefault();
+    else
+      current = pThis->m_iPriority;
 
     auto it = list.begin();
     while (it != list.end())

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.h
@@ -188,6 +188,7 @@ private:
   unsigned int m_iMarginStart = 0;
   unsigned int m_iMarginEnd = 0;
   int m_iPriority = 0;
+  int* m_pPriority = nullptr;
   int m_iLifetime = 0;
   int m_iMaxRecordings = 0;
   std::string m_strDirectory;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
When a PVR timer type does not support priorities it is being assigned the same value as a timer that supports priorities.  This adds a new default value.
<!--- Describe your change in detail here. -->

This change initializes to a new value that is checked and if found it can be overwritten with a valid default for the type.   The "magic" value used  -50 after reviewing PVR that support priority but other values could be used.

If the m_iPriority value cannot be overloaded a new flag might be a safer option.   MythTV does allow negative priorities.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->

This is change is required because with the current logic if a user changes the initialized timer type from a type that doesn't support priorities to one that does, instead of re-initializing the priority the default (50) is added as the current priority even if it is not a valid priority.  

<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->

Tested changing types under "Add timer ..." and modifying  existing timers.   It does not address or test the potential issue changing from timer types with different priority value lists and defaults which might also be a problem currently.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested in WIndows 11

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->

Users are presented with a valid default which may be sent to the backend generating an error or unwanted actions.

<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
