### PR TITLE
[Windows] Add render method information to the debug OSD

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugInfo.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugInfo.h
@@ -24,6 +24,7 @@ struct DEBUG_INFO_VIDEO
   std::string metaPrim;
   std::string metaLight;
   std::string shader;
+  std::string render;
 };
 
 struct DEBUG_INFO_RENDER

--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
@@ -90,6 +90,7 @@ void CDebugRenderer::SetInfo(DEBUG_INFO_VIDEO& video, DEBUG_INFO_RENDER& render)
   m_adapter->AddSubtitle(video.metaPrim, 0., 5000000.);
   m_adapter->AddSubtitle(video.metaLight, 0., 5000000.);
   m_adapter->AddSubtitle(video.shader, 0., 5000000.);
+  m_adapter->AddSubtitle(video.render, 0., 5000000.);
   m_adapter->AddSubtitle(render.renderFlags, 0., 5000000.);
   m_adapter->AddSubtitle(render.videoOutput, 0., 5000000.);
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -123,6 +123,7 @@ public:
   static bool IsPQ10PassthroughSupported(const DXGI_FORMAT dxgi_format);
   static bool IsSuperResolutionSuitable(const VideoPicture& picture);
   void TryEnableVideoSuperResolution();
+  bool IsVideoSuperResolutionEnabled() const { return m_superResolutionEnabled; }
 
 protected:
   bool ReInit();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
@@ -723,5 +723,14 @@ DEBUG_INFO_VIDEO CRendererBase::GetDebugInfo(int idx)
   if (m_outputShader)
     info.shader = m_outputShader->GetDebugInfo();
 
+  info.render = StringUtils::Format("Render method: {}", m_renderMethodName);
+
+  std::string rmInfo = GetRenderMethodDebugInfo();
+  if (!rmInfo.empty())
+  {
+    info.render.append(", ");
+    info.render.append(rmInfo);
+  }
+
   return info;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
@@ -155,6 +155,7 @@ protected:
   virtual void CheckVideoParameters();
   virtual void OnViewSizeChanged() {}
   virtual void OnOutputReset() {}
+  virtual std::string GetRenderMethodDebugInfo() const { return {}; }
 
   bool m_toneMapping = false;
   bool m_useDithering = false;
@@ -188,4 +189,5 @@ protected:
   DXGI_HDR_METADATA_HDR10 m_lastHdr10 = {};
   HDR_TYPE m_HdrType = HDR_TYPE::HDR_NONE_SDR;
   bool m_AutoSwitchHDR = false;
+  std::string m_renderMethodName;
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
@@ -110,6 +110,11 @@ void CRendererDXVA::GetWeight(std::map<RenderMethod, int>& weights, const VideoP
     weights[RENDER_DXVA] = weight;
 }
 
+CRendererDXVA::CRendererDXVA(CVideoSettings& videoSettings) : CRendererHQ(videoSettings)
+{
+  m_renderMethodName = "DXVA";
+}
+
 CRenderInfo CRendererDXVA::GetRenderInfo()
 {
   auto info = __super::GetRenderInfo();
@@ -293,6 +298,16 @@ bool CRendererDXVA::Supports(ESCALINGMETHOD method) const
 CRenderBuffer* CRendererDXVA::CreateBuffer()
 {
   return new CRenderBufferImpl(m_format, m_sourceWidth, m_sourceHeight);
+}
+
+std::string CRendererDXVA::GetRenderMethodDebugInfo() const
+{
+  if (m_processor && DX::Windowing()->SupportsVideoSuperResolution())
+  {
+    return StringUtils::Format("Video Super Resolution: {}",
+                               m_processor->IsVideoSuperResolutionEnabled() ? "requested" : "OFF");
+  }
+  return {};
 }
 
 CRendererDXVA::CRenderBufferImpl::CRenderBufferImpl(AVPixelFormat av_pix_format, unsigned width, unsigned height)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
@@ -37,11 +37,12 @@ public:
   static void GetWeight(std::map<RenderMethod, int>& weights, const VideoPicture& picture);
 
 protected:
-  explicit CRendererDXVA(CVideoSettings& videoSettings) : CRendererHQ(videoSettings) {}
+  explicit CRendererDXVA(CVideoSettings& videoSettings);
 
   void CheckVideoParameters() override;
   void RenderImpl(CD3DTexture& target, CRect& sourceRect, CPoint(&destPoints)[4], uint32_t flags) override;
   CRenderBuffer* CreateBuffer() override;
+  virtual std::string GetRenderMethodDebugInfo() const;
 
 private:
   void FillBuffersSet(CRenderBuffer* (&buffers)[8]);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererShaders.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererShaders.cpp
@@ -71,6 +71,11 @@ void CRendererShaders::GetWeight(std::map<RenderMethod, int>& weights, const Vid
     weights[RENDER_PS] = weight;
 }
 
+CRendererShaders::CRendererShaders(CVideoSettings& videoSettings) : CRendererHQ(videoSettings)
+{
+  m_renderMethodName = "Pixel Shaders";
+}
+
 bool CRendererShaders::Supports(ESCALINGMETHOD method) const
 {
   if (method == VS_SCALINGMETHOD_LINEAR)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererShaders.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererShaders.h
@@ -39,7 +39,7 @@ public:
   static void GetWeight(std::map<RenderMethod, int>& weights, const VideoPicture& picture);
 
 protected:
-  explicit CRendererShaders(CVideoSettings& videoSettings) : CRendererHQ(videoSettings) {}
+  explicit CRendererShaders(CVideoSettings& videoSettings);
   void RenderImpl(CD3DTexture& target, CRect& sourceRect, CPoint(&destPoints)[4], uint32_t flags) override;
   void CheckVideoParameters() override;
   void UpdateVideoFilters() override;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererSoftware.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererSoftware.cpp
@@ -39,6 +39,11 @@ void CRendererSoftware::GetWeight(std::map<RenderMethod, int>& weights, const Vi
     weights[RENDER_SW] = weight;
 }
 
+CRendererSoftware::CRendererSoftware(CVideoSettings& videoSettings) : CRendererBase(videoSettings)
+{
+  m_renderMethodName = "Software";
+}
+
 CRendererSoftware::~CRendererSoftware()
 {
   if (m_sw_scale_ctx)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererSoftware.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererSoftware.h
@@ -28,7 +28,7 @@ public:
   static void GetWeight(std::map<RenderMethod, int>& weights, const VideoPicture& picture);
 
 protected:
-  explicit CRendererSoftware(CVideoSettings& videoSettings) : CRendererBase(videoSettings) {}
+  explicit CRendererSoftware(CVideoSettings& videoSettings);
   CRenderBuffer* CreateBuffer() override;
   void RenderImpl(CD3DTexture& target, CRect& sourceRect, CPoint(&destPoints)[4], uint32_t flags) override;
   void FinalOutput(CD3DTexture& source, CD3DTexture& target, const CRect& src, const CPoint(&destPoints)[4]) override;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Added line to the debug OSD for Windows render method information.

For now, name and optional render method provided string.
With PR#23359 the intermediate target format will be added.

The DXVA render method returns the status of the Video Super Resolution feature.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The render method changes depending on dxva support for input/output conversions and it's convenient to have the information on screen rather than in debug log only.
Same for the new dxva super video resolution scalers activation status.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows and auto/dxva/pixel shaders/software renderer render method settings, including situations with fallback from dxva to ps.

Unable to test super resolution, no suitable hardware on hand.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Helpful for devs.

## Screenshots (if appropriate):
![image](https://github.com/xbmc/xbmc/assets/489377/60f65ac4-2a8d-4cf6-9e8b-01de906898b2)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
