### PR TITLE
[Estuary] Reset 1110_seekbar timer on seeks

### DIFF
--- a/addons/skin.estuary/xml/Timers.xml
+++ b/addons/skin.estuary/xml/Timers.xml
@@ -11,6 +11,7 @@
     <timer>
         <name>1110_topbaroverlay</name>
         <description>A timer that is activated when the topbaroverlay is loaded and stops automatically after 5 seconds (or playback is resumed)</description>
-        <stop>!Player.Paused | Integer.IsGreaterOrEqual(Skin.TimerElapsedSecs(1110_topbaroverlay),5)</stop>
+        <reset>[Player.Seeking | Player.Forwarding | Player.Rewinding | Player.HasPerformedSeek(1)]</reset>
+        <stop>Integer.IsGreaterOrEqual(Skin.TimerElapsedSecs(1110_topbaroverlay),5)</stop>
     </timer>
 </timers>


### PR DESCRIPTION
## Description
This fixes a bug found by @pkscout while using the estuary custom seekbar. Since the timer is not being reset on seeks, the elapsed time is not reset to zero making the condition `Integer.IsGreaterOrEqual(Skin.TimerElapsedSecs(1110_topbaroverlay),5)` to evaluate to true after the dialog is opened for 5 seconds. This means that opening the dialog via a seek and then a pause won't close the dialog. The same happens if we pause and seek afterwards. Note that this timer is started once the 1110_topbaroverlay  custom dialog is loaded (and this already depends on the fact the playback is paused or a seek has been performed).

## Motivation and context
Make sure the dialog is closed after 5 seconds have elapsed, even if we do seeks.

## How has this been tested?
Pausing and waiting 5 seconds
Pausing, seeking and waiting ~ 5 secs
Seeking, pausing and waiting ~ 5 secs

## What is the effect on users?
Make the dialog disappear when it should

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
