### PR TITLE
[PVR] Timer settings dialog: Refetch timer types from clients on init of types list

### DIFF
--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -305,7 +305,6 @@ bool CPVRClient::GetAddonProperties()
     return false;
 
   PVR_ADDON_CAPABILITIES addonCapabilities = {};
-  std::vector<std::shared_ptr<CPVRTimerType>> timerTypes;
 
   /* get the capabilities */
   PVR_ERROR retVal = DoAddonCall(
@@ -318,96 +317,13 @@ bool CPVRClient::GetAddonProperties()
   if (retVal != PVR_ERROR_NO_ERROR)
     return false;
 
-  /* timer types */
-  retVal = DoAddonCall(
-      __func__,
-      [this, &addonCapabilities, &timerTypes](const AddonInstance* addon) {
-        std::unique_ptr<PVR_TIMER_TYPE[]> types_array(
-            new PVR_TIMER_TYPE[PVR_ADDON_TIMERTYPE_ARRAY_SIZE]);
-        int size = PVR_ADDON_TIMERTYPE_ARRAY_SIZE;
+  {
+    std::unique_lock<CCriticalSection> lock(m_critSection);
+    m_clientCapabilities = addonCapabilities;
+  }
 
-        PVR_ERROR retval = addon->toAddon->GetTimerTypes(addon, types_array.get(), &size);
-
-        if (retval == PVR_ERROR_NOT_IMPLEMENTED)
-        {
-          // begin compat section
-          CLog::LogF(LOGWARNING,
-                     "Add-on {} does not support timer types. It will work, but not benefit from "
-                     "the timer features introduced with PVR Addon API 2.0.0",
-                     GetFriendlyName());
-
-          // Create standard timer types (mostly) matching the timer functionality available in Isengard.
-          // This is for migration only and does not make changes to the addons obsolete. Addons should
-          // work and benefit from some UI changes (e.g. some of the timer settings dialog enhancements),
-          // but all old problems/bugs due to static attributes and values will remain the same as in
-          // Isengard. Also, new features (like epg search) are not available to addons automatically.
-          // This code can be removed once all addons actually support the respective PVR Addon API version.
-
-          size = 0;
-          // manual one time
-          memset(&types_array[size], 0, sizeof(types_array[size]));
-          types_array[size].iId = size + 1;
-          types_array[size].iAttributes =
-              PVR_TIMER_TYPE_IS_MANUAL | PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
-              PVR_TIMER_TYPE_SUPPORTS_CHANNELS | PVR_TIMER_TYPE_SUPPORTS_START_TIME |
-              PVR_TIMER_TYPE_SUPPORTS_END_TIME | PVR_TIMER_TYPE_SUPPORTS_PRIORITY |
-              PVR_TIMER_TYPE_SUPPORTS_LIFETIME | PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS;
-          ++size;
-
-          // manual timer rule
-          memset(&types_array[size], 0, sizeof(types_array[size]));
-          types_array[size].iId = size + 1;
-          types_array[size].iAttributes =
-              PVR_TIMER_TYPE_IS_MANUAL | PVR_TIMER_TYPE_IS_REPEATING |
-              PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE | PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
-              PVR_TIMER_TYPE_SUPPORTS_START_TIME | PVR_TIMER_TYPE_SUPPORTS_END_TIME |
-              PVR_TIMER_TYPE_SUPPORTS_PRIORITY | PVR_TIMER_TYPE_SUPPORTS_LIFETIME |
-              PVR_TIMER_TYPE_SUPPORTS_FIRST_DAY | PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS |
-              PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS;
-          ++size;
-
-          if (addonCapabilities.bSupportsEPG)
-          {
-            // One-shot epg-based
-            memset(&types_array[size], 0, sizeof(types_array[size]));
-            types_array[size].iId = size + 1;
-            types_array[size].iAttributes =
-                PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE | PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE |
-                PVR_TIMER_TYPE_SUPPORTS_CHANNELS | PVR_TIMER_TYPE_SUPPORTS_START_TIME |
-                PVR_TIMER_TYPE_SUPPORTS_END_TIME | PVR_TIMER_TYPE_SUPPORTS_PRIORITY |
-                PVR_TIMER_TYPE_SUPPORTS_LIFETIME | PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS;
-            ++size;
-          }
-
-          retval = PVR_ERROR_NO_ERROR;
-          // end compat section
-        }
-
-        if (retval == PVR_ERROR_NO_ERROR)
-        {
-          timerTypes.reserve(size);
-          for (int i = 0; i < size; ++i)
-          {
-            if (types_array[i].iId == PVR_TIMER_TYPE_NONE)
-            {
-              CLog::LogF(LOGERROR, "Invalid timer type supplied by add-on {}.", GetID());
-              continue;
-            }
-            timerTypes.emplace_back(
-                std::shared_ptr<CPVRTimerType>(new CPVRTimerType(types_array[i], m_iClientId)));
-          }
-        }
-        return retval;
-      },
-      addonCapabilities.bSupportsTimers, false);
-
-  if (retVal == PVR_ERROR_NOT_IMPLEMENTED)
-    retVal = PVR_ERROR_NO_ERROR; // timer support is optional.
-
-  /* update the members */
-  std::unique_lock<CCriticalSection> lock(m_critSection);
-  m_clientCapabilities = addonCapabilities;
-  m_timertypes = timerTypes;
+  /* get the timer types */
+  retVal = RefreshTimerTypesCache();
 
   return retVal == PVR_ERROR_NO_ERROR;
 }
@@ -1083,6 +999,122 @@ PVR_ERROR CPVRClient::GetTimerTypes(std::vector<std::shared_ptr<CPVRTimerType>>&
   std::unique_lock<CCriticalSection> lock(m_critSection);
   results = m_timertypes;
   return PVR_ERROR_NO_ERROR;
+}
+
+PVR_ERROR CPVRClient::RefreshTimerTypesCache()
+{
+  std::vector<std::shared_ptr<CPVRTimerType>> timerTypes;
+
+  PVR_ERROR retVal = DoAddonCall(
+      __func__,
+      [this, &timerTypes](const AddonInstance* addon) {
+        std::unique_ptr<PVR_TIMER_TYPE[]> types_array(
+            new PVR_TIMER_TYPE[PVR_ADDON_TIMERTYPE_ARRAY_SIZE]);
+        int size = PVR_ADDON_TIMERTYPE_ARRAY_SIZE;
+
+        PVR_ERROR retval = addon->toAddon->GetTimerTypes(addon, types_array.get(), &size);
+
+        if (retval == PVR_ERROR_NOT_IMPLEMENTED)
+        {
+          // begin compat section
+          CLog::LogF(LOGWARNING,
+                     "Add-on {} does not support timer types. It will work, but not benefit from "
+                     "the timer features introduced with PVR Addon API 2.0.0",
+                     GetFriendlyName());
+
+          // Create standard timer types (mostly) matching the timer functionality available in Isengard.
+          // This is for migration only and does not make changes to the addons obsolete. Addons should
+          // work and benefit from some UI changes (e.g. some of the timer settings dialog enhancements),
+          // but all old problems/bugs due to static attributes and values will remain the same as in
+          // Isengard. Also, new features (like epg search) are not available to addons automatically.
+          // This code can be removed once all addons actually support the respective PVR Addon API version.
+
+          size = 0;
+          // manual one time
+          memset(&types_array[size], 0, sizeof(types_array[size]));
+          types_array[size].iId = size + 1;
+          types_array[size].iAttributes =
+              PVR_TIMER_TYPE_IS_MANUAL | PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
+              PVR_TIMER_TYPE_SUPPORTS_CHANNELS | PVR_TIMER_TYPE_SUPPORTS_START_TIME |
+              PVR_TIMER_TYPE_SUPPORTS_END_TIME | PVR_TIMER_TYPE_SUPPORTS_PRIORITY |
+              PVR_TIMER_TYPE_SUPPORTS_LIFETIME | PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS;
+          ++size;
+
+          // manual timer rule
+          memset(&types_array[size], 0, sizeof(types_array[size]));
+          types_array[size].iId = size + 1;
+          types_array[size].iAttributes =
+              PVR_TIMER_TYPE_IS_MANUAL | PVR_TIMER_TYPE_IS_REPEATING |
+              PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE | PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
+              PVR_TIMER_TYPE_SUPPORTS_START_TIME | PVR_TIMER_TYPE_SUPPORTS_END_TIME |
+              PVR_TIMER_TYPE_SUPPORTS_PRIORITY | PVR_TIMER_TYPE_SUPPORTS_LIFETIME |
+              PVR_TIMER_TYPE_SUPPORTS_FIRST_DAY | PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS |
+              PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS;
+          ++size;
+
+          if (m_clientCapabilities.SupportsEPG())
+          {
+            // One-shot epg-based
+            memset(&types_array[size], 0, sizeof(types_array[size]));
+            types_array[size].iId = size + 1;
+            types_array[size].iAttributes =
+                PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE | PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE |
+                PVR_TIMER_TYPE_SUPPORTS_CHANNELS | PVR_TIMER_TYPE_SUPPORTS_START_TIME |
+                PVR_TIMER_TYPE_SUPPORTS_END_TIME | PVR_TIMER_TYPE_SUPPORTS_PRIORITY |
+                PVR_TIMER_TYPE_SUPPORTS_LIFETIME | PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS;
+            ++size;
+          }
+
+          retval = PVR_ERROR_NO_ERROR;
+          // end compat section
+        }
+
+        if (retval == PVR_ERROR_NO_ERROR)
+        {
+          timerTypes.reserve(size);
+          for (int i = 0; i < size; ++i)
+          {
+            if (types_array[i].iId == PVR_TIMER_TYPE_NONE)
+            {
+              CLog::LogF(LOGERROR, "Invalid timer type supplied by add-on {}.", GetID());
+              continue;
+            }
+            timerTypes.emplace_back(
+                std::shared_ptr<CPVRTimerType>(new CPVRTimerType(types_array[i], m_iClientId)));
+          }
+        }
+        return retval;
+      },
+      m_clientCapabilities.SupportsTimers(), false);
+
+  if (retVal == PVR_ERROR_NOT_IMPLEMENTED)
+    retVal = PVR_ERROR_NO_ERROR; // timer support is optional.
+
+  std::vector<std::shared_ptr<CPVRTimerType>> newTimerTypes;
+
+  std::unique_lock<CCriticalSection> lock(m_critSection);
+
+  for (const auto& type : timerTypes)
+  {
+    const auto it = std::find_if(m_timertypes.cbegin(), m_timertypes.cend(),
+                                 [&type](const std::shared_ptr<CPVRTimerType>& entry) {
+                                   return entry->GetClientId() == type->GetClientId() &&
+                                          entry->GetTypeId() == type->GetTypeId();
+                                 });
+    if (it == m_timertypes.cend())
+    {
+      newTimerTypes.emplace_back(type);
+    }
+    else
+    {
+      (*it)->Update(*type);
+      newTimerTypes.emplace_back(*it);
+    }
+  }
+
+  m_timertypes = newTimerTypes;
+
+  return retVal;
 }
 
 PVR_ERROR CPVRClient::GetStreamReadChunkSize(int& iChunkSize)

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -495,6 +495,12 @@ public:
    */
   PVR_ERROR GetTimerTypes(std::vector<std::shared_ptr<CPVRTimerType>>& results) const;
 
+  /*!
+   * @brief Refetch all timer types from the backend.
+   * @return PVR_ERROR_NO_ERROR if the types have been refetched successfully.
+   */
+  PVR_ERROR RefreshTimerTypesCache();
+
   //@}
   /** @name PVR live stream methods */
   //@{

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -611,6 +611,13 @@ PVR_ERROR CPVRClients::GetTimerTypes(std::vector<std::shared_ptr<CPVRTimerType>>
   });
 }
 
+PVR_ERROR CPVRClients::RefreshTimerTypesCache()
+{
+  return ForCreatedClients(__FUNCTION__, [](const std::shared_ptr<CPVRClient>& client) {
+    return client->RefreshTimerTypesCache();
+  });
+}
+
 PVR_ERROR CPVRClients::GetRecordings(const std::vector<std::shared_ptr<CPVRClient>>& clients,
                                      CPVRRecordings* recordings,
                                      bool deleted,

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -218,6 +218,12 @@ struct SBackend
      */
     PVR_ERROR GetTimerTypes(std::vector<std::shared_ptr<CPVRTimerType>>& results) const;
 
+    /*!
+     * @brief Refetch all timer types from all backends.
+     * @return PVR_ERROR_NO_ERROR if the types have been refetched successfully.
+     */
+    PVR_ERROR RefreshTimerTypesCache();
+
     //@}
 
     /*! @name Recording methods */

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -819,6 +819,8 @@ void CGUIDialogPVRTimerSettings::InitializeTypesList()
     return;
   }
 
+  CServiceBroker::GetPVRManager().Clients()->RefreshTimerTypesCache();
+
   bool bFoundThisType(false);
   int idx(0);
   const std::vector<std::shared_ptr<CPVRTimerType>> types(CPVRTimerType::GetAllTypes());

--- a/xbmc/pvr/timers/PVRTimerType.cpp
+++ b/xbmc/pvr/timers/PVRTimerType.cpp
@@ -214,6 +214,24 @@ bool CPVRTimerType::operator !=(const CPVRTimerType& right) const
   return !(*this == right);
 }
 
+void CPVRTimerType::Update(const CPVRTimerType& type)
+{
+  m_iClientId = type.m_iClientId;
+  m_iTypeId = type.m_iTypeId;
+  m_iAttributes = type.m_iAttributes;
+  m_strDescription = type.m_strDescription;
+  m_priorityValues = type.m_priorityValues;
+  m_iPriorityDefault = type.m_iPriorityDefault;
+  m_lifetimeValues = type.m_lifetimeValues;
+  m_iLifetimeDefault = type.m_iLifetimeDefault;
+  m_maxRecordingsValues = type.m_maxRecordingsValues;
+  m_iMaxRecordingsDefault = type.m_iMaxRecordingsDefault;
+  m_preventDupEpisodesValues = type.m_preventDupEpisodesValues;
+  m_iPreventDupEpisodesDefault = type.m_iPreventDupEpisodesDefault;
+  m_recordingGroupValues = type.m_recordingGroupValues;
+  m_iRecordingGroupDefault = type.m_iRecordingGroupDefault;
+}
+
 void CPVRTimerType::InitDescription()
 {
   // if no description was given, compile it

--- a/xbmc/pvr/timers/PVRTimerType.h
+++ b/xbmc/pvr/timers/PVRTimerType.h
@@ -75,6 +75,12 @@ namespace PVR
     bool operator !=(const CPVRTimerType& right) const;
 
     /*!
+     * @brief Update the data of this instance with the data given by another type instance.
+     * @param type The instance containing the updated data.
+     */
+    void Update(const CPVRTimerType& type);
+
+    /*!
      * @brief Get the PVR client id for this type.
      * @return The PVR client id.
      */


### PR DESCRIPTION
For performance reasons, timer types are only obtained when clients are created/connected/reconnected. But types might change dynamically and those changes wont be reflected in timer settings dialog's type selection list. This PR fixes this problem by re-fetching the types from the clients on initialization of the types selection list.

@emveepee fyi

@runtime-tested on macOS, latest Kodi master

@phunkyfish please have look at the code change. It's basically factoring out the code that fetches timer types from the clients and to additionally call the new method from timer settings dialog.