### PR TITLE
[PVR] Dynamic timer types: Update timer types from client whenever a …

### DIFF
--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -489,11 +489,16 @@ public:
   PVR_ERROR UpdateTimer(const CPVRTimerInfoTag& timer);
 
   /*!
-   * @brief Get all timer types supported by the backend.
-   * @param results The container to store the result in.
+   * @brief Update all timer types supported by the backend.
    * @return PVR_ERROR_NO_ERROR if the list has been fetched successfully.
    */
-  PVR_ERROR GetTimerTypes(std::vector<std::shared_ptr<CPVRTimerType>>& results) const;
+  PVR_ERROR UpdateTimerTypes();
+
+  /*!
+   * @brief Get the timer types supported by the backend, without updating them from the backend.
+   * @return the types.
+   */
+  const std::vector<std::shared_ptr<CPVRTimerType>>& GetTimerTypes() const;
 
   //@}
   /** @name PVR live stream methods */

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -600,15 +600,31 @@ bool CPVRClients::GetTimers(const std::vector<std::shared_ptr<CPVRClient>>& clie
                     failedClients) == PVR_ERROR_NO_ERROR;
 }
 
-PVR_ERROR CPVRClients::GetTimerTypes(std::vector<std::shared_ptr<CPVRTimerType>>& results) const
+PVR_ERROR CPVRClients::UpdateTimerTypes(const std::vector<std::shared_ptr<CPVRClient>>& clients,
+                                        std::vector<int>& failedClients)
 {
-  return ForCreatedClients(__FUNCTION__, [&results](const std::shared_ptr<CPVRClient>& client) {
-    std::vector<std::shared_ptr<CPVRTimerType>> types;
-    PVR_ERROR ret = client->GetTimerTypes(types);
-    if (ret == PVR_ERROR_NO_ERROR)
-      results.insert(results.end(), types.begin(), types.end());
-    return ret;
-  });
+  return ForClients(
+      __FUNCTION__, clients,
+      [](const std::shared_ptr<CPVRClient>& client) { return client->UpdateTimerTypes(); },
+      failedClients);
+}
+
+const std::vector<std::shared_ptr<CPVRTimerType>> CPVRClients::GetTimerTypes() const
+{
+  std::vector<std::shared_ptr<CPVRTimerType>> types;
+
+  std::unique_lock<CCriticalSection> lock(m_critSection);
+  for (const auto& entry : m_clientMap)
+  {
+    const auto& client = entry.second;
+    if (client->ReadyToUse() && !client->IgnoreClient())
+    {
+      const auto& clientTypes = client->GetTimerTypes();
+      types.insert(types.end(), clientTypes.begin(), clientTypes.end());
+    }
+  }
+
+  return types;
 }
 
 PVR_ERROR CPVRClients::GetRecordings(const std::vector<std::shared_ptr<CPVRClient>>& clients,

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -212,11 +212,19 @@ struct SBackend
                    std::vector<int>& failedClients);
 
     /*!
-     * @brief Get all supported timer types.
-     * @param results The container to store the result in.
+     * @brief Update all timer types from the given clients
+     * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
+     * @param failedClients in case of errors will contain the ids of the clients for which the timer types could not be obtained.
      * @return PVR_ERROR_NO_ERROR if the operation succeeded, the respective PVR_ERROR value otherwise.
      */
-    PVR_ERROR GetTimerTypes(std::vector<std::shared_ptr<CPVRTimerType>>& results) const;
+    PVR_ERROR UpdateTimerTypes(const std::vector<std::shared_ptr<CPVRClient>>& clients,
+                               std::vector<int>& failedClients);
+
+    /*!
+     * @brief Get all timer types supported by the backends, without updating them from the backends.
+     * @return the types.
+     */
+    const std::vector<std::shared_ptr<CPVRTimerType>> GetTimerTypes() const;
 
     //@}
 

--- a/xbmc/pvr/timers/PVRTimerType.cpp
+++ b/xbmc/pvr/timers/PVRTimerType.cpp
@@ -27,8 +27,8 @@ using namespace PVR;
 
 const std::vector<std::shared_ptr<CPVRTimerType>> CPVRTimerType::GetAllTypes()
 {
-  std::vector<std::shared_ptr<CPVRTimerType>> allTypes;
-  CServiceBroker::GetPVRManager().Clients()->GetTimerTypes(allTypes);
+  std::vector<std::shared_ptr<CPVRTimerType>> allTypes =
+      CServiceBroker::GetPVRManager().Clients()->GetTimerTypes();
 
   // Add local reminder timer types. Local reminders are always available.
   int iTypeId = PVR_TIMER_TYPE_NONE;
@@ -107,8 +107,8 @@ const std::shared_ptr<CPVRTimerType> CPVRTimerType::GetFirstAvailableType(const 
 {
   if (client)
   {
-    std::vector<std::shared_ptr<CPVRTimerType>> types;
-    if (client->GetTimerTypes(types) == PVR_ERROR_NO_ERROR && !types.empty())
+    const std::vector<std::shared_ptr<CPVRTimerType>>& types = client->GetTimerTypes();
+    if (!types.empty())
     {
       return *(types.begin());
     }
@@ -212,6 +212,24 @@ bool CPVRTimerType::operator ==(const CPVRTimerType& right) const
 bool CPVRTimerType::operator !=(const CPVRTimerType& right) const
 {
   return !(*this == right);
+}
+
+void CPVRTimerType::Update(const CPVRTimerType& type)
+{
+  m_iClientId = type.m_iClientId;
+  m_iTypeId = type.m_iTypeId;
+  m_iAttributes = type.m_iAttributes;
+  m_strDescription = type.m_strDescription;
+  m_priorityValues = type.m_priorityValues;
+  m_iPriorityDefault = type.m_iPriorityDefault;
+  m_lifetimeValues = type.m_lifetimeValues;
+  m_iLifetimeDefault = type.m_iLifetimeDefault;
+  m_maxRecordingsValues = type.m_maxRecordingsValues;
+  m_iMaxRecordingsDefault = type.m_iMaxRecordingsDefault;
+  m_preventDupEpisodesValues = type.m_preventDupEpisodesValues;
+  m_iPreventDupEpisodesDefault = type.m_iPreventDupEpisodesDefault;
+  m_recordingGroupValues = type.m_recordingGroupValues;
+  m_iRecordingGroupDefault = type.m_iRecordingGroupDefault;
 }
 
 void CPVRTimerType::InitDescription()

--- a/xbmc/pvr/timers/PVRTimerType.h
+++ b/xbmc/pvr/timers/PVRTimerType.h
@@ -75,6 +75,12 @@ namespace PVR
     bool operator !=(const CPVRTimerType& right) const;
 
     /*!
+     * @brief Update the data of this instance with the data given by another type instance.
+     * @param type The instance containing the updated data.
+     */
+    void Update(const CPVRTimerType& type);
+
+    /*!
      * @brief Get the PVR client id for this type.
      * @return The PVR client id.
      */

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -157,9 +157,12 @@ bool CPVRTimers::UpdateFromClients(const std::vector<std::shared_ptr<CPVRClient>
     m_bIsUpdating = true;
   }
 
+  CLog::LogFC(LOGDEBUG, LOGPVR, "Updating timer types");
+  std::vector<int> failedClients;
+  CServiceBroker::GetPVRManager().Clients()->UpdateTimerTypes(clients, failedClients);
+
   CLog::LogFC(LOGDEBUG, LOGPVR, "Updating timers");
   CPVRTimersContainer newTimerList;
-  std::vector<int> failedClients;
   CServiceBroker::GetPVRManager().Clients()->GetTimers(clients, &newTimerList, failedClients);
   return UpdateEntries(newTimerList, failedClients);
 }


### PR DESCRIPTION
…timers update for the client is requested.

This PR introduces dynamic timer types. Currently, timer types will only be fetched once a client is newly created or (re)connects. This PR changes behavior so that timer types get re-fetched from clients whenever an update of timers is requested. First, the types will be fetched, then the timers, which may already use the updated types.

@emveepee can you please test?

@phunkyfish could you do the code review, please?