### PR TITLE
[Estuary] Also start timer (with reset) on seeks

### DIFF
--- a/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
+++ b/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <window type="dialog" id="1109">
-	<onload>Skin.TimerStart(1110_topbaroverlay)</onload>
+	<onload>Skin.TimerStart(1109_topbaroverlay)</onload>
 	<visible>Window.IsActive(fullscreenvideo) | Window.IsActive(visualisation)</visible>
 	<visible>Window.IsActive(seekbar) | Window.IsActive(pvrosdchannels) | Window.IsActive(pvrchannelguide)</visible>
 	<depth>DepthOSD</depth>
@@ -10,7 +10,7 @@
 		<control type="group">
 			<visible>![Player.ShowInfo | Window.IsActive(fullscreeninfo) | Player.ShowTime | Window.IsActive(videoosd) | Window.IsActive(musicosd) | Window.IsActive(playerprocessinfo) | Window.IsActive(pvrosdchannels) | Window.IsActive(pvrchannelguide)] + [!String.IsEmpty(Player.SeekNumeric) | Player.Seeking | Player.HasPerformedSeek(3) | Player.Forwarding | Player.Rewinding | Player.Paused] | !String.IsEmpty(PVR.ChannelNumberInput)</visible>
 			<animation effect="fade" start="0" end="100" time="300">VisibleChange</animation>
-			<animation effect="slide" start="0,0" end="0,-80" time="300" condition="Player.Paused + Integer.IsGreaterOrEqual(Skin.TimerElapsedSecs(1110_topbaroverlay),5)">Conditional</animation>
+			<animation effect="slide" start="0,0" end="0,-80" time="300" condition="Player.Paused + Integer.IsGreaterOrEqual(Skin.TimerElapsedSecs(1109_topbaroverlay),5)">Conditional</animation>
 			<control type="image">
 				<left>0</left>
 				<top>0</top>

--- a/addons/skin.estuary/xml/Timers.xml
+++ b/addons/skin.estuary/xml/Timers.xml
@@ -9,10 +9,10 @@
         <onstop>Dialog.Close(videoosd)</onstop>
     </timer>
     <timer>
-        <name>1110_topbaroverlay</name>
+        <name>1109_topbaroverlay</name>
         <description>A timer that is activated when the topbaroverlay is loaded and stops automatically after 5 seconds (or playback is resumed)</description>
         <start reset="true">Window.IsActive(1109) + [Player.Seeking | Player.Forwarding | Player.Rewinding | Player.HasPerformedSeek(1)]</start>
         <reset>Player.Seeking | Player.Forwarding | Player.Rewinding | Player.HasPerformedSeek(1)</reset>
-        <stop>Integer.IsGreaterOrEqual(Skin.TimerElapsedSecs(1110_topbaroverlay),5) | Player.Playing</stop>
+        <stop>Integer.IsGreaterOrEqual(Skin.TimerElapsedSecs(1109_topbaroverlay),5) | Player.Playing</stop>
     </timer>
 </timers>

--- a/addons/skin.estuary/xml/Timers.xml
+++ b/addons/skin.estuary/xml/Timers.xml
@@ -11,6 +11,7 @@
     <timer>
         <name>1110_topbaroverlay</name>
         <description>A timer that is activated when the topbaroverlay is loaded and stops automatically after 5 seconds (or playback is resumed)</description>
+        <start reset="true">Window.IsActive(1109) + [Player.Seeking | Player.Forwarding | Player.Rewinding | Player.HasPerformedSeek(1)]</start>
         <reset>[Player.Seeking | Player.Forwarding | Player.Rewinding | Player.HasPerformedSeek(1)]</reset>
         <stop>Integer.IsGreaterOrEqual(Skin.TimerElapsedSecs(1110_topbaroverlay),5)</stop>
     </timer>

--- a/addons/skin.estuary/xml/Timers.xml
+++ b/addons/skin.estuary/xml/Timers.xml
@@ -12,7 +12,7 @@
         <name>1110_topbaroverlay</name>
         <description>A timer that is activated when the topbaroverlay is loaded and stops automatically after 5 seconds (or playback is resumed)</description>
         <start reset="true">Window.IsActive(1109) + [Player.Seeking | Player.Forwarding | Player.Rewinding | Player.HasPerformedSeek(1)]</start>
-        <reset>[Player.Seeking | Player.Forwarding | Player.Rewinding | Player.HasPerformedSeek(1)]</reset>
-        <stop>Integer.IsGreaterOrEqual(Skin.TimerElapsedSecs(1110_topbaroverlay),5)</stop>
+        <reset>Player.Seeking | Player.Forwarding | Player.Rewinding | Player.HasPerformedSeek(1)</reset>
+        <stop>Integer.IsGreaterOrEqual(Skin.TimerElapsedSecs(1110_topbaroverlay),5) | Player.Playing</stop>
     </timer>
 </timers>

--- a/xbmc/addons/gui/skin/SkinTimerManager.cpp
+++ b/xbmc/addons/gui/skin/SkinTimerManager.cpp
@@ -73,7 +73,8 @@ void CSkinTimerManager::LoadTimerInternal(const TiXmlElement* node)
     startInfo = CServiceBroker::GetGUI()->GetInfoManager().Register(
         node->FirstChild("start")->FirstChild()->ValueStr());
     // check if timer needs to be reset after start
-    if (node->Attribute("reset") && StringUtils::EqualsNoCase(node->Attribute("reset"), "true"))
+    if (node->FirstChildElement("start")->Attribute("reset") &&
+        StringUtils::EqualsNoCase(node->FirstChildElement("start")->Attribute("reset"), "true"))
     {
       resetOnStart = true;
     }


### PR DESCRIPTION
## Description
Another one, this time found by @CrystalP. It seems Kodi does not unload the custom window (and load it again) when we perform seeks since it depends on dialog seekbar visibility. Since the timer is only started on window load, we might get to a situation where the control group is visible again (with the window already loaded) but the timer is not running. Hence, this make sure we start the timer (with reset) on the same condition we already do for reset (seeks, rewind, etc).

Ref: https://github.com/xbmc/xbmc/pull/23380#issuecomment-1589821366