### PR TITLE
[Windows][dxva] Disable processor tone mapping for AMD and HDR to HDR

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -85,7 +85,7 @@ public:
 
   bool PreInit() const;
   void UnInit();
-  bool Open(UINT width, UINT height);
+  bool Open(UINT width, UINT height, const VideoPicture& picture);
   void Close();
   bool Render(CRect src, CRect dst, ID3D11Resource* target, CRenderBuffer **views, DWORD flags, UINT frameIdx, UINT rotation, float contrast, float brightness);
   uint8_t PastRefs() const { return m_max_back_refs; }
@@ -172,6 +172,7 @@ protected:
   bool m_bSupportHLG = false;
   bool m_HDR10Left{false};
   bool m_BT2020Left{false};
+  bool m_hasMetadataHDR10Support{false};
 
   struct ProcAmpInfo
   {
@@ -184,6 +185,9 @@ protected:
   Microsoft::WRL::ComPtr<ID3D11VideoProcessorEnumerator> m_pEnumerator;
   Microsoft::WRL::ComPtr<ID3D11VideoProcessorEnumerator1> m_pEnumerator1;
   Microsoft::WRL::ComPtr<ID3D11VideoProcessor> m_pVideoProcessor;
+
+  AVColorPrimaries m_color_primaries{AVCOL_PRI_UNSPECIFIED};
+  AVColorTransferCharacteristic m_color_transfer{AVCOL_TRC_UNSPECIFIED};
 
   bool m_forced8bit{false};
   bool m_superResolutionEnabled{false};

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
@@ -131,7 +131,7 @@ bool CRendererDXVA::Configure(const VideoPicture& picture, float fps, unsigned o
 
     // create processor
     m_processor = std::make_unique<DXVA::CProcessorHD>();
-    if (m_processor->PreInit() && m_processor->Open(m_sourceWidth, m_sourceHeight) &&
+    if (m_processor->PreInit() && m_processor->Open(m_sourceWidth, m_sourceHeight, picture) &&
         m_processor->IsFormatSupported(dxgi_format, support_type))
     {
       if (CServiceBroker::GetLogging().IsLogLevelLogged(LOGDEBUG))


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

**Problem analysis**
The AMD dxva processor automatically applies tone mapping to very bright areas of PQ video, regardless of destination transfer PQ or SDR.

This is not really noticeable with "normal" PQ content and current display technology. However it is very visible with Kodi's special mode using PQ passthrough + HLG to PQ shader for output to HDR screen when the processor doesn't support HLG input.
As display technology progresses it will become more visible for bright PQ content.

* With PQ , normalized values close to 1 are very bright highlights (7000+ nits) that don't exist in most content and that current displays are not able to reproduce without tone-mapping.

* With HLG transfer however, those values are "normal" highlights (sky/clouds for example) easily displayed by typical HDR screens, and alterations that make sense for PQ material are detrimental.

**Solution**
Use the ID3D11VideoContext2 interface to set HDR10 metadata and disable automatic tone mapping of the AMD dxva processor (capability exposed with the feature D3D11_VIDEO_PROCESSOR_FEATURE_CAPS_METADATA_HDR10)

Some experimenting with AMD showed that specifying the max PQ value of 10000 nits as max luminance of the output metadata is enough to disable tone mapping.
Specifying the primaries or not didn't have an effect and the stream metadata has unclear behavior and is optional.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Render method DXVA with AMD GPU yields unsaturated colors on HLG test pattern instead of fully saturated primaries and secondaries.

No such problem with the pixel shaders render method.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with Windows 10 and recent AMD GPU.
Played HLG sample videos and HDR10 test patterns (with temp. code change to always run the HLGtoPQ shader, which makes the problem much more visible, instead of hidden by the display's limits / tone mapping.)
> result is the same as pixel shaders render method

Confirmed no impact on SDR or tone mapped HDR (they don't use a G2084 color space)
PQ video is now passed through without change from decoder to output shader

* Unable to test effect on Intel, I noticed the processor capability in some logs but don't have such a computer with HDR output.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
With AMD GPU:
Normal HDR-looking picture for HLG when the dxva render method is used.
More accurate display of bright highlights in PQ material.

## Screenshots (if appropriate):
Github doesn't accept .jxr HDR screenshots so the screenshots below only give an approximate idea of the effect. 

before:
![Kodi 2023-06-15 01_50_33](https://github.com/xbmc/xbmc/assets/489377/20dab4b1-00f5-44d4-aecc-1d8742f823dc)

after the change:
![Kodi 2023-06-15 01_52_50](https://github.com/xbmc/xbmc/assets/489377/96e58c9c-0181-498e-8428-702b70c9365b)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
