### PR TITLE
[Windows][dxva] refactor video processor code

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/CMakeLists.txt
@@ -1,6 +1,8 @@
 if(CORE_SYSTEM_NAME STREQUAL windows OR CORE_SYSTEM_NAME STREQUAL windowsstore)
   list(APPEND SOURCES DXVAHD.cpp)
+  list(APPEND SOURCES DXVAEnumeratorHD.cpp)
   list(APPEND HEADERS DXVAHD.h)
+  list(APPEND HEADERS DXVAEnumeratorHD.h)
 endif()
 
 if(VAAPI_FOUND)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.cpp
@@ -1,0 +1,397 @@
+/*
+ *  Copyright (C) 2005-2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "DXVAEnumeratorHD.h"
+
+#include "rendering/dx/RenderContext.h"
+#include "utils/log.h"
+
+#include <mutex>
+
+#include <Windows.h>
+#include <d3d11_4.h>
+#include <dxgi1_5.h>
+
+using namespace DXVA;
+using namespace Microsoft::WRL;
+
+CEnumeratorHD::CEnumeratorHD()
+{
+  DX::Windowing()->Register(this);
+}
+
+CEnumeratorHD::~CEnumeratorHD()
+{
+  std::unique_lock<CCriticalSection> lock(m_section);
+  DX::Windowing()->Unregister(this);
+  UnInit();
+}
+
+void CEnumeratorHD::UnInit()
+{
+  Close();
+}
+
+void CEnumeratorHD::Close()
+{
+  std::unique_lock<CCriticalSection> lock(m_section);
+  m_pEnumerator1 = nullptr;
+  m_pEnumerator = nullptr;
+}
+
+bool CEnumeratorHD::Open(unsigned int width, unsigned int height, DXGI_FORMAT input_dxgi_format)
+{
+  Close();
+
+  std::unique_lock<CCriticalSection> lock(m_section);
+
+  HRESULT hr{};
+  ComPtr<ID3D11Device> pD3DDevice = DX::DeviceResources::Get()->GetD3DDevice();
+  ComPtr<ID3D11VideoDevice> pVideoDevice;
+
+  if (FAILED(hr = pD3DDevice.As(&pVideoDevice)))
+  {
+    CLog::LogF(LOGWARNING, "video device initialization is failed. Error {}",
+               DX::GetErrorDescription(hr));
+    return false;
+  }
+
+  CLog::LogF(LOGDEBUG, "initializing video enumerator with params: {}x{}.", width, height);
+
+  D3D11_VIDEO_PROCESSOR_CONTENT_DESC contentDesc = {};
+  contentDesc.InputFrameFormat = D3D11_VIDEO_FRAME_FORMAT_INTERLACED_TOP_FIELD_FIRST;
+  contentDesc.InputWidth = width;
+  contentDesc.InputHeight = height;
+  contentDesc.OutputWidth = width;
+  contentDesc.OutputHeight = height;
+  contentDesc.Usage = D3D11_VIDEO_USAGE_PLAYBACK_NORMAL;
+
+  if (FAILED(hr = pVideoDevice->CreateVideoProcessorEnumerator(
+                 &contentDesc, m_pEnumerator.ReleaseAndGetAddressOf())))
+  {
+    CLog::LogF(LOGWARNING, "failed to init video enumerator with params: {}x{}. Error {}", width,
+               height, DX::GetErrorDescription(hr));
+    return false;
+  }
+
+  if (FAILED(hr = m_pEnumerator.As(&m_pEnumerator1)))
+  {
+    CLog::LogF(LOGDEBUG, "ID3D11VideoProcessorEnumerator1 not available on this system. Message {}",
+               DX::GetErrorDescription(hr));
+  }
+
+  m_input_dxgi_format = input_dxgi_format;
+
+  return true;
+}
+
+ProcessorCapabilities CEnumeratorHD::ProbeProcessorCaps()
+{
+  std::unique_lock<CCriticalSection> lock(m_section);
+
+  if (!m_pEnumerator)
+    return {};
+
+  HRESULT hr{};
+  ProcessorCapabilities result{};
+
+  if (CServiceBroker::GetLogging().IsLogLevelLogged(LOGDEBUG))
+  {
+    std::string inputFormats{};
+    std::string outputFormats{};
+    for (int fmt = DXGI_FORMAT_UNKNOWN; fmt <= DXGI_FORMAT_V408; fmt++)
+    {
+      UINT uiFlags;
+      if (S_OK == m_pEnumerator->CheckVideoProcessorFormat((DXGI_FORMAT)fmt, &uiFlags))
+      {
+        if (uiFlags & D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT_INPUT)
+        {
+          inputFormats.append("\n");
+          inputFormats.append(DX::DXGIFormatToString((DXGI_FORMAT)fmt));
+        }
+        if (uiFlags & D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT_OUTPUT)
+        {
+          outputFormats.append("\n");
+          outputFormats.append(DX::DXGIFormatToString((DXGI_FORMAT)fmt));
+        }
+      }
+    }
+    CLog::LogF(LOGDEBUG, "Supported input formats:{}", inputFormats);
+    CLog::LogF(LOGDEBUG, "Supported output formats:{}", outputFormats);
+  }
+
+  if (FAILED(hr = m_pEnumerator->GetVideoProcessorCaps(&result.m_vcaps)))
+  {
+    CLog::LogF(LOGWARNING, "failed to get processor caps. Error {}", DX::GetErrorDescription(hr));
+    return {};
+  }
+
+  CLog::LogF(LOGDEBUG, "video processor has {} rate conversion.",
+             result.m_vcaps.RateConversionCapsCount);
+  CLog::LogF(LOGDEBUG, "video processor has {:#x} feature caps.", result.m_vcaps.FeatureCaps);
+  CLog::LogF(LOGDEBUG, "video processor has {:#x} device caps.", result.m_vcaps.DeviceCaps);
+  CLog::LogF(LOGDEBUG, "video processor has {:#x} input format caps.",
+             result.m_vcaps.InputFormatCaps);
+  CLog::LogF(LOGDEBUG, "video processor has {:#x} auto stream caps.",
+             result.m_vcaps.AutoStreamCaps);
+  CLog::LogF(LOGDEBUG, "video processor has {:#x} stereo caps.", result.m_vcaps.StereoCaps);
+  CLog::LogF(LOGDEBUG, "video processor has {} max input streams.", result.m_vcaps.MaxInputStreams);
+  CLog::LogF(LOGDEBUG, "video processor has {} max stream states.", result.m_vcaps.MaxStreamStates);
+  if (result.m_vcaps.FeatureCaps & D3D11_VIDEO_PROCESSOR_FEATURE_CAPS_METADATA_HDR10)
+  {
+    CLog::LogF(LOGDEBUG, "video processor supports HDR10 metadata.");
+    result.m_hasMetadataHDR10Support = true;
+  }
+
+  if (0 != (result.m_vcaps.FeatureCaps & D3D11_VIDEO_PROCESSOR_FEATURE_CAPS_LEGACY))
+    CLog::LogF(LOGWARNING, "the video driver does not support full video processing capabilities.");
+
+  if (result.m_vcaps.FeatureCaps & D3D11_VIDEO_PROCESSOR_FEATURE_CAPS_STEREO)
+    CLog::LogF(LOGDEBUG, "video processor supports stereo.");
+
+  if (result.m_vcaps.FeatureCaps & D3D11_VIDEO_PROCESSOR_FEATURE_CAPS_ROTATION)
+    CLog::LogF(LOGDEBUG, "video processor supports rotation.");
+
+  if (result.m_vcaps.FeatureCaps & D3D11_VIDEO_PROCESSOR_FEATURE_CAPS_SHADER_USAGE)
+    CLog::LogF(LOGDEBUG, "video processor supports shader usage.");
+
+  const UINT deinterlacingCaps =
+      D3D11_VIDEO_PROCESSOR_PROCESSOR_CAPS_DEINTERLACE_BLEND |
+      D3D11_VIDEO_PROCESSOR_PROCESSOR_CAPS_DEINTERLACE_BOB |
+      D3D11_VIDEO_PROCESSOR_PROCESSOR_CAPS_DEINTERLACE_ADAPTIVE |
+      D3D11_VIDEO_PROCESSOR_PROCESSOR_CAPS_DEINTERLACE_MOTION_COMPENSATION;
+  unsigned maxProcCaps = 0;
+  // try to find best processor
+  for (unsigned int i = 0; i < result.m_vcaps.RateConversionCapsCount; i++)
+  {
+    D3D11_VIDEO_PROCESSOR_RATE_CONVERSION_CAPS convCaps;
+    if (FAILED(hr = m_pEnumerator->GetVideoProcessorRateConversionCaps(i, &convCaps)))
+    {
+      CLog::LogF(LOGWARNING, "unable to retrieve processor rate conversion caps {}. Error {}", i,
+                 DX::GetErrorDescription(hr));
+      continue;
+    }
+
+    // check only deinterlace caps
+    if ((convCaps.ProcessorCaps & deinterlacingCaps) > maxProcCaps)
+    {
+      result.m_procIndex = i;
+      maxProcCaps = convCaps.ProcessorCaps & deinterlacingCaps;
+    }
+  }
+
+  CLog::LogF(LOGDEBUG, "selected video processor index: {}.", result.m_procIndex);
+
+  if (SUCCEEDED(hr = m_pEnumerator->GetVideoProcessorRateConversionCaps(result.m_procIndex,
+                                                                        &result.m_rateCaps)))
+  {
+    CLog::LogF(LOGINFO, "supported deinterlace methods: blend:{}, bob:{}, adaptive:{}, mocomp:{}.",
+               (result.m_rateCaps.ProcessorCaps & 0x1) != 0 ? "yes" : "no", // BLEND
+               (result.m_rateCaps.ProcessorCaps & 0x2) != 0 ? "yes" : "no", // BOB
+               (result.m_rateCaps.ProcessorCaps & 0x4) != 0 ? "yes" : "no", // ADAPTIVE
+               (result.m_rateCaps.ProcessorCaps & 0x8) != 0 ? "yes" : "no" // MOTION_COMPENSATION
+    );
+  }
+  else
+  {
+    CLog::LogF(LOGWARNING,
+               "unable to retrieve processor rate conversion caps {}, the deinterlacing "
+               "capabilities are unknown. Error {}",
+               result.m_procIndex, DX::GetErrorDescription(hr));
+  }
+
+  CLog::LogF(
+      LOGDEBUG,
+      "selected video processor recommends {} future frames and {} past frames for best results.",
+      result.m_rateCaps.FutureFrames, result.m_rateCaps.PastFrames);
+
+  // Get the image filtering capabilities.
+  for (size_t i = 0; i < NUM_FILTERS; i++)
+  {
+    if (result.m_vcaps.FilterCaps & PROCAMP_FILTERS[i].cap)
+    {
+      result.m_Filters[i].Range = {};
+      result.m_Filters[i].bSupported = SUCCEEDED(m_pEnumerator->GetVideoProcessorFilterRange(
+          PROCAMP_FILTERS[i].filter, &result.m_Filters[i].Range));
+
+      if (result.m_Filters[i].bSupported)
+      {
+        CLog::LogF(LOGDEBUG, "filter {} has following params - max: {}, min: {}, default: {}",
+                   PROCAMP_FILTERS[i].name, result.m_Filters[i].Range.Maximum,
+                   result.m_Filters[i].Range.Minimum, result.m_Filters[i].Range.Default);
+      }
+    }
+    else
+    {
+      CLog::LogF(LOGDEBUG, "filter {} not supported by processor.", PROCAMP_FILTERS[i].name);
+      result.m_Filters[i].bSupported = false;
+    }
+  }
+
+  if (m_pEnumerator1)
+  {
+    DXGI_FORMAT format = DX::Windowing()->GetBackBuffer().GetFormat();
+    BOOL supported = 0;
+    HRESULT hr;
+
+    // Check if HLG color space conversion is supported by driver
+    hr = m_pEnumerator1->CheckVideoProcessorFormatConversion(
+        DXGI_FORMAT_P010, DXGI_COLOR_SPACE_YCBCR_STUDIO_GHLG_TOPLEFT_P2020, format,
+        DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709, &supported);
+    result.m_bSupportHLG = SUCCEEDED(hr) && !!supported;
+
+    CLog::LogF(LOGDEBUG, "HLG color space conversion is{}supported.",
+               result.m_bSupportHLG ? " " : " NOT ");
+
+    result.m_BT2020Left = (QueryHDRtoSDRSupport() == Left);
+    result.m_HDR10Left = (QueryHDRtoHDRSupport() == Left);
+  }
+
+  result.m_valid = true;
+
+  return result;
+}
+
+DXVA::InputFormat CEnumeratorHD::QueryHDRtoHDRSupport() const
+{
+  // Not initialized yet
+  if (!m_pEnumerator)
+    return None;
+
+  if (!m_pEnumerator1)
+  {
+    CLog::LogF(LOGWARNING,
+               "ID3D11VideoProcessorEnumerator1 required to evaluate support is not available.");
+    return None;
+  }
+
+  const DXGI_COLOR_SPACE_TYPE destColor = DX::Windowing()->UseLimitedColor()
+                                              ? DXGI_COLOR_SPACE_RGB_STUDIO_G2084_NONE_P2020
+                                              : DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020;
+  BOOL supported = 0;
+
+  // Check if HDR10 (TOP LEFT) input color space is supported by video driver
+  HRESULT hr = m_pEnumerator1->CheckVideoProcessorFormatConversion(
+      m_input_dxgi_format, DXGI_COLOR_SPACE_YCBCR_STUDIO_G2084_TOPLEFT_P2020,
+      DXGI_FORMAT_R10G10B10A2_UNORM, destColor, &supported);
+  const bool HDRtopLeft = SUCCEEDED(hr) && static_cast<bool>(supported);
+
+  // Check if HDR10 (LEFT) input color space is supported by video driver
+  hr = m_pEnumerator1->CheckVideoProcessorFormatConversion(
+      m_input_dxgi_format, DXGI_COLOR_SPACE_YCBCR_STUDIO_G2084_LEFT_P2020,
+      DXGI_FORMAT_R10G10B10A2_UNORM, destColor, &supported);
+  const bool HDRleft = SUCCEEDED(hr) && static_cast<bool>(supported);
+
+  CLog::LogF(LOGDEBUG,
+             "HDR10 input color spaces support with HDR {} range output: "
+             "YCBCR_STUDIO_G2084_LEFT_P2020: {}, "
+             "YCBCR_STUDIO_G2084_TOPLEFT_P2020: {}",
+             DX::Windowing()->UseLimitedColor() ? "limited" : "full", HDRleft ? "yes" : "no",
+             HDRtopLeft ? "yes" : "no");
+
+  if (HDRtopLeft)
+  {
+    if (HDRleft)
+      CLog::LogF(LOGDEBUG, "Preferred UHD Blu-Ray top left chroma siting will be used");
+
+    return TopLeft;
+  }
+  else if (HDRleft)
+  {
+    return Left;
+  }
+
+  return None;
+}
+
+bool CEnumeratorHD::IsPQ10PassthroughSupported()
+{
+  std::unique_lock<CCriticalSection> lock(m_section);
+  if (QueryHDRtoHDRSupport() == None)
+  {
+    CLog::LogF(
+        LOGWARNING,
+        "Input color space HDR10 is not supported by video processor with HDR {} range output. "
+        "DXVA will not be used.",
+        DX::Windowing()->UseLimitedColor() ? "limited" : "full");
+
+    return false;
+  }
+
+  return true;
+}
+
+InputFormat CEnumeratorHD::QueryHDRtoSDRSupport() const
+{
+  // Not initialized yet
+  if (!m_pEnumerator)
+    return None;
+
+  if (!m_pEnumerator1)
+  {
+    CLog::LogF(LOGWARNING,
+               "ID3D11VideoProcessorEnumerator1 required to evaluate support is not available.");
+    return None;
+  }
+
+  const DXGI_FORMAT destFormat = DX::Windowing()->GetBackBuffer().GetFormat();
+  const DXGI_COLOR_SPACE_TYPE destColor = DX::Windowing()->UseLimitedColor()
+                                              ? DXGI_COLOR_SPACE_RGB_STUDIO_G22_NONE_P709
+                                              : DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
+  BOOL supported = 0;
+
+  // Check if BT.2020 (LEFT) input color space is supported by video driver
+  HRESULT hr = m_pEnumerator1->CheckVideoProcessorFormatConversion(
+      m_input_dxgi_format, DXGI_COLOR_SPACE_YCBCR_STUDIO_G22_LEFT_P2020, destFormat, destColor,
+      &supported);
+  const bool left = SUCCEEDED(hr) && static_cast<bool>(supported);
+
+  // Check if BT.2020 (TOP LEFT) input color space is supported by video driver
+  hr = m_pEnumerator1->CheckVideoProcessorFormatConversion(
+      m_input_dxgi_format, DXGI_COLOR_SPACE_YCBCR_STUDIO_G22_TOPLEFT_P2020, destFormat, destColor,
+      &supported);
+  const bool topLeft = SUCCEEDED(hr) && static_cast<bool>(supported);
+
+  CLog::LogF(LOGDEBUG,
+             "BT.2020 input color spaces supported with SDR {} range output: "
+             "YCBCR_STUDIO_G22_LEFT_P2020: {}, "
+             "YCBCR_STUDIO_G22_TOPLEFT_P2020: {}",
+             DX::Windowing()->UseLimitedColor() ? "limited" : "full", left ? "yes" : "no",
+             topLeft ? "yes" : "no");
+
+  if (topLeft)
+  {
+    if (left)
+      CLog::LogF(LOGDEBUG, "Preferred UHD Blu-Ray top left chroma siting will be used");
+
+    return TopLeft;
+  }
+  else if (left)
+  {
+    return Left;
+  }
+
+  return None;
+}
+
+bool CEnumeratorHD::IsBT2020Supported()
+{
+  std::unique_lock<CCriticalSection> lock(m_section);
+  if (QueryHDRtoSDRSupport() == None)
+  {
+    CLog::LogF(
+        LOGWARNING,
+        "Input color space BT.2020 is not supported by video processor with SDR {} range output. "
+        "DXVA will not be used.",
+        DX::Windowing()->UseLimitedColor() ? "limited" : "full");
+
+    return false;
+  }
+
+  return true;
+}

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
@@ -1,0 +1,115 @@
+/*
+ *  Copyright (C) 2005-2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "VideoRenderers/Windows/RendererBase.h"
+#include "guilib/D3DResource.h"
+
+#include <mutex>
+
+#include <wrl/client.h>
+
+namespace DXVA
+{
+
+using namespace Microsoft::WRL;
+
+// ProcAmp filters d3d11 filters
+struct ProcAmpFilter
+{
+  D3D11_VIDEO_PROCESSOR_FILTER filter;
+  D3D11_VIDEO_PROCESSOR_FILTER_CAPS cap;
+  const char* name;
+};
+
+// clang-format off
+const ProcAmpFilter PROCAMP_FILTERS[] = {
+    {D3D11_VIDEO_PROCESSOR_FILTER_BRIGHTNESS,
+    D3D11_VIDEO_PROCESSOR_FILTER_CAPS_BRIGHTNESS, "Brightness"},
+    {D3D11_VIDEO_PROCESSOR_FILTER_CONTRAST,
+    D3D11_VIDEO_PROCESSOR_FILTER_CAPS_CONTRAST, "Contrast"},
+    {D3D11_VIDEO_PROCESSOR_FILTER_HUE,
+    D3D11_VIDEO_PROCESSOR_FILTER_CAPS_HUE, "Hue"},
+    {D3D11_VIDEO_PROCESSOR_FILTER_SATURATION,
+    D3D11_VIDEO_PROCESSOR_FILTER_CAPS_SATURATION, "Saturation"},
+    {D3D11_VIDEO_PROCESSOR_FILTER_NOISE_REDUCTION,
+    D3D11_VIDEO_PROCESSOR_FILTER_CAPS_NOISE_REDUCTION, "Noise Reduction"},
+    {D3D11_VIDEO_PROCESSOR_FILTER_EDGE_ENHANCEMENT,
+     D3D11_VIDEO_PROCESSOR_FILTER_CAPS_EDGE_ENHANCEMENT, "Edge Enhancement"},
+    {D3D11_VIDEO_PROCESSOR_FILTER_ANAMORPHIC_SCALING,
+     D3D11_VIDEO_PROCESSOR_FILTER_CAPS_ANAMORPHIC_SCALING, "Anamorphic Scaling"},
+    {D3D11_VIDEO_PROCESSOR_FILTER_STEREO_ADJUSTMENT,
+     D3D11_VIDEO_PROCESSOR_FILTER_CAPS_STEREO_ADJUSTMENT, "Stereo Adjustment"}};
+// clang-format on
+
+constexpr size_t NUM_FILTERS = ARRAYSIZE(PROCAMP_FILTERS);
+
+struct ProcAmpInfo
+{
+  bool bSupported;
+  D3D11_VIDEO_PROCESSOR_FILTER_RANGE Range;
+};
+
+struct ProcessorCapabilities
+{
+  bool m_valid{false};
+
+  uint32_t m_procIndex{0};
+  D3D11_VIDEO_PROCESSOR_CAPS m_vcaps{};
+  D3D11_VIDEO_PROCESSOR_RATE_CONVERSION_CAPS m_rateCaps{};
+  ProcAmpInfo m_Filters[NUM_FILTERS]{};
+  bool m_bSupportHLG{false};
+  bool m_HDR10Left{false};
+  bool m_BT2020Left{false};
+  bool m_hasMetadataHDR10Support{false};
+};
+
+enum InputFormat
+{
+  None,
+  TopLeft,
+  Left
+};
+
+class CEnumeratorHD : public ID3DResource
+{
+public:
+  CEnumeratorHD();
+  virtual ~CEnumeratorHD();
+
+  bool Open(unsigned int width, unsigned int height, DXGI_FORMAT input_dxgi_format);
+  void Close();
+
+  // ID3DResource overrides
+  void OnCreateDevice() override {}
+  void OnDestroyDevice(bool) override
+  {
+    std::unique_lock<CCriticalSection> lock(m_section);
+    UnInit();
+  }
+
+  bool IsBT2020Supported();
+  bool IsPQ10PassthroughSupported();
+  ProcessorCapabilities ProbeProcessorCaps();
+
+  ComPtr<ID3D11VideoProcessorEnumerator> Get() { return m_pEnumerator; }
+  ComPtr<ID3D11VideoProcessorEnumerator1> Get1() { return m_pEnumerator1; }
+
+protected:
+  void UnInit();
+  InputFormat QueryHDRtoHDRSupport() const;
+  InputFormat QueryHDRtoSDRSupport() const;
+
+  CCriticalSection m_section;
+
+  ComPtr<ID3D11VideoProcessorEnumerator> m_pEnumerator;
+  ComPtr<ID3D11VideoProcessorEnumerator1> m_pEnumerator1;
+  DXGI_FORMAT m_input_dxgi_format{DXGI_FORMAT_UNKNOWN};
+};
+}; // namespace DXVA

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -10,6 +10,7 @@
 
 #include "DVDCodecs/Video/DVDVideoCodecFFmpeg.h"
 #include "DVDCodecs/Video/DXVA.h"
+#include "VideoRenderers/HwDecRender/DXVAEnumeratorHD.h"
 #include "VideoRenderers/Windows/RendererBase.h"
 #include "guilib/D3DResource.h"
 #include "utils/Geometry.h"
@@ -22,35 +23,7 @@ class CRenderBuffer;
 
 namespace DXVA {
 
-// ProcAmp filters d3d11 filters
-struct ProcAmpFilter
-{
-  D3D11_VIDEO_PROCESSOR_FILTER filter;
-  D3D11_VIDEO_PROCESSOR_FILTER_CAPS cap;
-  const char* name;
-};
-
-// clang-format off
-const ProcAmpFilter PROCAMP_FILTERS[] = {
-    {D3D11_VIDEO_PROCESSOR_FILTER_BRIGHTNESS,
-    D3D11_VIDEO_PROCESSOR_FILTER_CAPS_BRIGHTNESS, "Brightness"},
-    {D3D11_VIDEO_PROCESSOR_FILTER_CONTRAST,
-    D3D11_VIDEO_PROCESSOR_FILTER_CAPS_CONTRAST, "Contrast"},
-    {D3D11_VIDEO_PROCESSOR_FILTER_HUE,
-    D3D11_VIDEO_PROCESSOR_FILTER_CAPS_HUE, "Hue"},
-    {D3D11_VIDEO_PROCESSOR_FILTER_SATURATION,
-    D3D11_VIDEO_PROCESSOR_FILTER_CAPS_SATURATION, "Saturation"},
-    {D3D11_VIDEO_PROCESSOR_FILTER_NOISE_REDUCTION,
-    D3D11_VIDEO_PROCESSOR_FILTER_CAPS_NOISE_REDUCTION, "Noise Reduction"},
-    {D3D11_VIDEO_PROCESSOR_FILTER_EDGE_ENHANCEMENT,
-     D3D11_VIDEO_PROCESSOR_FILTER_CAPS_EDGE_ENHANCEMENT, "Edge Enhancement"},
-    {D3D11_VIDEO_PROCESSOR_FILTER_ANAMORPHIC_SCALING,
-     D3D11_VIDEO_PROCESSOR_FILTER_CAPS_ANAMORPHIC_SCALING, "Anamorphic Scaling"},
-    {D3D11_VIDEO_PROCESSOR_FILTER_STEREO_ADJUSTMENT,
-     D3D11_VIDEO_PROCESSOR_FILTER_CAPS_STEREO_ADJUSTMENT, "Stereo Adjustment"}};
-// clang-format on
-
-const size_t NUM_FILTERS = ARRAYSIZE(PROCAMP_FILTERS);
+using namespace Microsoft::WRL;
 
 struct DXGIColorSpaceArgs
 {
@@ -88,7 +61,7 @@ public:
   bool Open(UINT width, UINT height, const VideoPicture& picture);
   void Close();
   bool Render(CRect src, CRect dst, ID3D11Resource* target, CRenderBuffer **views, DWORD flags, UINT frameIdx, UINT rotation, float contrast, float brightness);
-  uint8_t PastRefs() const { return m_max_back_refs; }
+  uint8_t PastRefs() const { return std::min(m_procCaps.m_rateCaps.PastFrames, 4u); }
   bool IsFormatSupported(DXGI_FORMAT format, D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT support) const;
   /*!
    * \brief Evaluate if the DXVA processor supports converting between two formats and color spaces.
@@ -119,8 +92,6 @@ public:
     UnInit();
   }
 
-  static bool IsBT2020Supported();
-  static bool IsPQ10PassthroughSupported(const DXGI_FORMAT dxgi_format);
   static bool IsSuperResolutionSuitable(const VideoPicture& picture);
   void TryEnableVideoSuperResolution();
   bool IsVideoSuperResolutionEnabled() const { return m_superResolutionEnabled; }
@@ -165,33 +136,18 @@ protected:
 
   uint32_t m_width = 0;
   uint32_t m_height = 0;
-  uint8_t  m_max_back_refs = 0;
-  uint8_t  m_max_fwd_refs = 0;
-  uint32_t m_procIndex = 0;
-  D3D11_VIDEO_PROCESSOR_CAPS m_vcaps = {};
-  D3D11_VIDEO_PROCESSOR_RATE_CONVERSION_CAPS m_rateCaps = {};
-  bool m_bSupportHLG = false;
-  bool m_HDR10Left{false};
-  bool m_BT2020Left{false};
-  bool m_hasMetadataHDR10Support{false};
 
-  struct ProcAmpInfo
-  {
-    bool bSupported;
-    D3D11_VIDEO_PROCESSOR_FILTER_RANGE Range;
-  };
-  ProcAmpInfo m_Filters[NUM_FILTERS]{};
-  Microsoft::WRL::ComPtr<ID3D11VideoDevice> m_pVideoDevice;
-  Microsoft::WRL::ComPtr<ID3D11VideoContext> m_pVideoContext;
-  Microsoft::WRL::ComPtr<ID3D11VideoProcessorEnumerator> m_pEnumerator;
-  Microsoft::WRL::ComPtr<ID3D11VideoProcessorEnumerator1> m_pEnumerator1;
-  Microsoft::WRL::ComPtr<ID3D11VideoProcessor> m_pVideoProcessor;
+  ComPtr<ID3D11VideoDevice> m_pVideoDevice;
+  ComPtr<ID3D11VideoContext> m_pVideoContext;
+  ComPtr<ID3D11VideoProcessor> m_pVideoProcessor;
+  std::unique_ptr<CEnumeratorHD> m_enumerator;
 
   AVColorPrimaries m_color_primaries{AVCOL_PRI_UNSPECIFIED};
   AVColorTransferCharacteristic m_color_transfer{AVCOL_TRC_UNSPECIFIED};
+  ProcessorCapabilities m_procCaps{};
+  DXGI_FORMAT m_input_dxgi_format{DXGI_FORMAT_UNKNOWN};
 
   bool m_forced8bit{false};
   bool m_superResolutionEnabled{false};
 };
-
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
@@ -35,6 +35,7 @@ public:
 
   static CRendererBase* Create(CVideoSettings& videoSettings);
   static void GetWeight(std::map<RenderMethod, int>& weights, const VideoPicture& picture);
+  static DXGI_FORMAT GetDXGIFormat(AVPixelFormat format, DXGI_FORMAT default_fmt);
 
 protected:
   explicit CRendererDXVA(CVideoSettings& videoSettings);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

### Approach

Split the CProcessorHD code interacting with the d3d enumerators into its own new class **CEnumeratorHD** (named similar to CProcessorHD, could be changed to CEnumerator)

CEnumeratorHD contains the functions testing various video processor capabilities and conversion capabilities, and passes the results to its callers / owners.

Instanciation / Lifecycle:
* the static GetWeight now creates an instance CEnumeratorHD for its tests, it is auto-deleted when GetWeight completes.
* when a dxva renderer is created, non-static Configure() creates an instance of CProcessorHD, which creates its own CEnumeratorHD and manages it with the same lifecycle as previously its d3d11 enumerators (ie reconstructed when reopened, when d3d device is lost, freed when the CProcessorHD is closed)
* CEnumeratorHD reacts to d3d device lost events but doesn't recreate its state when the device is back, since its caller already takes care of recreating.


### Goals / Scope

Goals of the change: remove code and logic duplication in the dxva video processor code CProcessorHD, keep functionality changes to a minimum to help with review as this is already a big change.

Out of scope: functionality changes, removal of the capabilities double checking (once with GetWeight once with Configure), or other deep code flow changes. It will be much easier to accomplish with other PRs.

Future: It is possible to take this a lot further, like removing the double-checking of capabilities, making the interface presented by CEnumeratorHD cleaner and more object-like, lazy-loading, ... Those are out of scope here.

### Implementation comments

There are a lot of code changes so the changes are divided in logical steps and there is one commit per step. It would likely be best to review commit by commit, as most are trivial moves of code. Each commit builds and works.

Even if multithreading is not used in rendering, the public functions are guarded by a lock, similar to existing code,

Noteworthy commits:
- initial commit: CEnumeratorHD::Open() is c/p of the beginning of CProcessorHD::InitProcessor()
- commit 4 "modify the processor...": CProcessorHD creates a CEnumeratorHD with the same lifecycle as the d3d enumerators - don't think I missed a construction/destruction
- commit 5 "replace the enumerators...": adds accessors to the internal d3d enumerator objects - not ideal but needed to avoid changing too much in this PR. The const versions were removed in later commit. The rest should eventually be replaced by new CEnumeratorHD member functions for each different use of the accessors.
- commit 7 "move the processor...": this is where most of the testing code of InitProcessor() moves to the CEnumeratorHD (direct c/p). Members of CProcessorHD are replaced with a struct returned by CEnumeratorHD containing the same members. There is room for future improvements to use functions of CEnumeratorHD instead of member variables, and to lazy-load the information as needed rather than load everything upfront.
- commit 10 "combine logic of IsPQ10PassthroughSupported()..": merge two nearly identical pieces of code. Pass the result as an enum useful for GetWeight and ProbeProcessorCaps.
  - there is an odd existing code pattern with GetDXGIFormat and RendererDXVA, likely worth simplifying. Made it available for the processor as is though, the focus of the PR is not to rework the code and possibly open cans of worms...
  - virtual / override doesn't exist for static functions, hence the usage of __super::


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It's becoming difficult to add features to the dxva processor code without increasing duplication of code and logic.
For example PR #23359 became impractical with the current code.

There are two main paths into CProcessorHD class: static functions for RendererDXVA::GetWeight() and non-static member functions for RendererDXVA::Configure(), Render() and everything else.

Over the last months CProcessorHD has been improved to use a new Windows API to check the capabilities of the d3d video processor, but such testing has very similar needs from the static and the non-static paths, leading to duplication.

As an example, testing the processor support for PQ passthrough required very similar code in IsPQ10PassthroughSupported() and InitProcessor() + setup code of a d3d dxva enumerator.

This change unifies the code in one path, keeping the best of each former path.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 10, recent AMD, Intel gen 4

* resource leaks: checked the D3D11Debug info after playing multiple files - clear except for the expected ID3D11VideoDecoderOutputView held by VideoPlayer - all released by the time Kodi exits

* capabiltiies reported by the processor are accurate but slightly changed in log because the input format of the video (NV12, P010) is now taken into account (before P010 was always assumed)

* render method falls back as expected from dxva to pixel shaders for unsupported conversions such as no HDR available, or no support for limited range output

* checked with HDR, SDR, HLG videos that the input and output formats / colorspaces haven't changed with HDR or SDR output.

* tested full / limited range output

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
No change.

## Screenshots (if appropriate):
NA

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [X] **None of the above** (please explain below)
Refactor of existing code. Non-breaking change that does not modify existing functionality.

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
