### PR TITLE
[windows] Distinguish between host/native download/tools for windows build

### DIFF
--- a/cmake/modules/buildtools/FindJsonSchemaBuilder.cmake
+++ b/cmake/modules/buildtools/FindJsonSchemaBuilder.cmake
@@ -21,7 +21,7 @@ if(NOT TARGET JsonSchemaBuilder::JsonSchemaBuilder)
     set_target_properties(JsonSchemaBuilder::JsonSchemaBuilder PROPERTIES
                                                        IMPORTED_LOCATION "${JSONSCHEMABUILDER_EXECUTABLE}")
   elseif(CORE_SYSTEM_NAME STREQUAL windowsstore)
-    get_filename_component(_jsbpath "${DEPENDS_PATH}/bin/json-rpc" ABSOLUTE)
+    get_filename_component(_jsbpath "${NATIVEPREFIX}/bin/json-rpc" ABSOLUTE)
     find_program(JSONSCHEMABUILDER_EXECUTABLE NAMES "${APP_NAME_LC}-JsonSchemaBuilder" JsonSchemaBuilder
                                               HINTS ${_jsbpath})
 

--- a/cmake/modules/buildtools/FindSWIG.cmake
+++ b/cmake/modules/buildtools/FindSWIG.cmake
@@ -9,7 +9,8 @@
 # SWIG_EXECUTABLE - the SWIG executable
 
 find_program(SWIG_EXECUTABLE NAMES swig4.0 swig3.0 swig2.0 swig
-                             PATH_SUFFIXES swig)
+                             PATH_SUFFIXES swig
+                             HINTS ${NATIVEPREFIX}/bin)
 if(SWIG_EXECUTABLE)
   execute_process(COMMAND ${SWIG_EXECUTABLE} -swiglib
     OUTPUT_VARIABLE SWIG_DIR

--- a/cmake/modules/buildtools/FindTexturePacker.cmake
+++ b/cmake/modules/buildtools/FindTexturePacker.cmake
@@ -23,7 +23,7 @@ if(NOT TARGET TexturePacker::TexturePacker::Executable)
                                           IMPORTED_LOCATION "${TEXTUREPACKER_EXECUTABLE}")
     message(STATUS "External TexturePacker for KODI_DEPENDSBUILD will be executed during build: ${TEXTUREPACKER_EXECUTABLE}")
   elseif(WIN32)
-    get_filename_component(_tppath "${DEPENDS_PATH}/tools/TexturePacker" ABSOLUTE)
+    get_filename_component(_tppath "${NATIVEPREFIX}/tools/TexturePacker" ABSOLUTE)
     find_program(TEXTUREPACKER_EXECUTABLE NAMES "${APP_NAME_LC}-TexturePacker.exe" TexturePacker.exe
                                           HINTS ${_tppath})
 

--- a/cmake/scripts/windows/ArchSetup.cmake
+++ b/cmake/scripts/windows/ArchSetup.cmake
@@ -35,7 +35,10 @@ set(CORE_MAIN_SOURCE ${CMAKE_SOURCE_DIR}/xbmc/platform/win32/WinMain.cpp)
 set(PRECOMPILEDHEADER_DIR ${PROJECT_BINARY_DIR}/${CORE_BUILD_CONFIG}/objs)
 set(CMAKE_SYSTEM_NAME Windows)
 set(DEPS_FOLDER_RELATIVE project/BuildDependencies)
-set(NATIVEPREFIX ${CMAKE_SOURCE_DIR}/${DEPS_FOLDER_RELATIVE}/tools)
+# ToDo: currently host build tools are hardcoded to win32
+# If we ever allow package.native other than 0_package.native-win32.list we will want to
+# adapt this based on host
+set(NATIVEPREFIX ${CMAKE_SOURCE_DIR}/${DEPS_FOLDER_RELATIVE}/win32)
 set(DEPENDS_PATH ${CMAKE_SOURCE_DIR}/${DEPS_FOLDER_RELATIVE}/${ARCH})
 set(MINGW_LIBS_DIR ${CMAKE_SOURCE_DIR}/${DEPS_FOLDER_RELATIVE}/mingwlibs/${ARCH})
 

--- a/cmake/scripts/windowsstore/ArchSetup.cmake
+++ b/cmake/scripts/windowsstore/ArchSetup.cmake
@@ -51,7 +51,10 @@ set(PACKAGE_GUID "281d668b-5739-4abd-b3c2-ed1cda572ed2")
 set(APP_MANIFEST_NAME package.appxmanifest)
 set(DEPS_FOLDER_RELATIVE project/BuildDependencies)
 
-set(NATIVEPREFIX ${CMAKE_SOURCE_DIR}/${DEPS_FOLDER_RELATIVE}/tools)
+# ToDo: currently host build tools are hardcoded to win32
+# If we ever allow package.native other than 0_package.native-win32.list we will want to
+# adapt this based on host
+set(NATIVEPREFIX ${CMAKE_SOURCE_DIR}/${DEPS_FOLDER_RELATIVE}/win32)
 set(DEPENDS_PATH ${CMAKE_SOURCE_DIR}/${DEPS_FOLDER_RELATIVE}/win10-${ARCH})
 set(MINGW_LIBS_DIR ${CMAKE_SOURCE_DIR}/${DEPS_FOLDER_RELATIVE}/mingwlibs/win10-${ARCH})
 

--- a/tools/buildsteps/windows/download-dependencies.bat
+++ b/tools/buildsteps/windows/download-dependencies.bat
@@ -22,6 +22,7 @@ echo Downloading from mirror %KODI_MIRROR%
 REM Locate the BuildDependencies directory, based on the path of this script
 SET BUILD_DEPS_PATH=%WORKSPACE%\project\BuildDependencies
 SET APP_PATH=%WORKSPACE%\project\BuildDependencies\%TARGETPLATFORM%
+SET NATIVE_PATH=%WORKSPACE%\project\BuildDependencies\%NATIVEPLATFORM%
 SET TMP_PATH=%BUILD_DEPS_PATH%\scripts\tmp
 
 REM Change to the BuildDependencies directory, if we're not there already

--- a/tools/buildsteps/windows/vswhere.bat
+++ b/tools/buildsteps/windows/vswhere.bat
@@ -27,18 +27,12 @@ SET vcvars=no
 SET sdkver=
 
 SET vsver=
-SET toolsdir=%arch%
+REM Current tools are only using x86/win32
+REM ToDo: allow to set NATIVEPLATFORM to allow native tools based on actual native arch (eg x86/x86_64/arm/arm64)
+SET toolsdir=win32
 
 IF "%arch%" NEQ "x64" (
   SET vcarch=%vcarch%_%arch%
-)
-
-IF "%arch%"=="x86" (
-  SET toolsdir=win32
-)
-
-IF "%vcstore%"=="store" (
-  SET toolsdir="win10-%toolsdir%"
 )
 
 SET vswhere="%builddeps%\%toolsdir%\tools\vswhere\vswhere.exe"


### PR DESCRIPTION
## Description
Currently the precompiled tools for windows builds are x86/win32. For now stick with this assumption and instead of putting these tools into the target arch folder, put them into the win32 folder to keep arch libs/exes in correct arch folders.

## Motivation and context
The ability to build a build tool (Texturepacker) for windows. To build a target using win32 libs, we need to be able to add its dependencies to the 0_package.native-win32.list and some of the Texturepacker dependencies overlap with the core Kodi build dependencies. We cant distinguish between arch libs, so we have to keep them in separate locations and use the appropriate lib for the appropriate targets.

Currently we only use win32 build tools, but someday there may be a desire to use x86_64 (or heaven forbid arm/aarch64) as true build tools. I dont want to overcomplicate things for what ifs at this stage, so this is the simplest, but just enforces some assumptions in both the batch scripts and the cmake project

## How has this been tested?
build windows

## What is the effect on users?
N/A
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
