### PR TITLE
[Windowing] Make HiDPI more generic/platform agnostic

### DIFF
--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -796,11 +796,13 @@ void CDisplaySettings::SettingOptionsResolutionsFiller(const SettingConstPtr& se
     std::vector<RESOLUTION_WHR> resolutions = CServiceBroker::GetWinSystem()->ScreenResolutions(info.fRefreshRate);
     for (std::vector<RESOLUTION_WHR>::const_iterator resolution = resolutions.begin(); resolution != resolutions.end(); ++resolution)
     {
-      std::string resLabel =
-          !resolution->label.empty()
-              ? resolution->label
-              : StringUtils::Format("{}x{}{}", resolution->width, resolution->height,
-                                    ModeFlagsToString(resolution->flags, false));
+      const std::string resLabel =
+          StringUtils::Format("{}x{}{}{}", resolution->m_screenWidth, resolution->m_screenHeight,
+                              ModeFlagsToString(resolution->flags, false),
+                              resolution->width > resolution->m_screenWidth &&
+                                      resolution->height > resolution->m_screenHeight
+                                  ? " (HiDPI)"
+                                  : "");
       list.emplace_back(resLabel, resolution->ResInfo_Index);
 
       resolutionInfos.insert(std::make_pair((RESOLUTION)resolution->ResInfo_Index, CDisplaySettings::GetInstance().GetResolutionInfo(resolution->ResInfo_Index)));

--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -53,8 +53,7 @@ RESOLUTION_INFO::RESOLUTION_INFO(const RESOLUTION_INFO& res)
     guiInsets(res.guiInsets),
     strMode(res.strMode),
     strOutput(res.strOutput),
-    strId(res.strId),
-    label(res.label)
+    strId(res.strId)
 {
   bFullScreen = res.bFullScreen;
   iWidth = res.iWidth; iHeight = res.iHeight;

--- a/xbmc/windowing/Resolution.h
+++ b/xbmc/windowing/Resolution.h
@@ -74,19 +74,19 @@ struct RESOLUTION_INFO
   //!< Specify if it is a fullscreen resolution, otherwise windowed
   bool bFullScreen;
 
-  //!< Width GUI resolution, may differ from the screen value if GUI resolution limit or 3D is set
+  //!< Width GUI resolution (pixels), may differ from the screen value if GUI resolution limit, 3D is set or in HiDPI screens
   int iWidth;
 
-  //!< Height GUI resolution, may differ from the screen value if GUI resolution limit or 3D is set
+  //!< Height GUI resolution (pixels), may differ from the screen value if GUI resolution limit, 3D is set or in HiDPI screens
   int iHeight;
 
   //!< Number of pixels of padding between stereoscopic frames
   int iBlanking;
 
-  //!< Screen width
+  //!< Screen width (logical width in pixels)
   int iScreenWidth;
 
-  //!< Screen height
+  //!< Screen height (logical height in pixels)
   int iScreenHeight;
 
   //!< The vertical subtitle baseline position, may be changed by Video calibration
@@ -109,12 +109,6 @@ struct RESOLUTION_INFO
 
   //!< Resolution ID
   std::string strId;
-
-  //! @brief Resolution label
-  //! @note This label is shown to the user (display settings) and takes precedence over the computation of the label based on the internal properties.
-  //! e.g. sometimes, as the example of HiDPI resolutions, it is preferable to show a custom label/string instead of the one computed using the width/height
-  //! of the resolution
-  std::string label;
 
 public:
   RESOLUTION_INFO(int width = 1280, int height = 720, float aspect = 0, const std::string &mode = "");

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -25,10 +25,11 @@ struct RESOLUTION_WHR
 {
   int width;
   int height;
+  int m_screenWidth;
+  int m_screenHeight;
   int flags; //< only D3DPRESENTFLAG_MODEMASK flags
   int ResInfo_Index;
   std::string id;
-  std::string label;
 };
 
 struct REFRESHRATE
@@ -218,6 +219,14 @@ public:
 
 protected:
   void UpdateDesktopResolution(RESOLUTION_INFO& newRes, const std::string &output, int width, int height, float refreshRate, uint32_t dwFlags);
+  void UpdateDesktopResolution(RESOLUTION_INFO& newRes,
+                               const std::string& output,
+                               int width,
+                               int height,
+                               int screenWidth,
+                               int screenHeight,
+                               float refreshRate,
+                               uint32_t dwFlags);
   virtual std::unique_ptr<KODI::WINDOWING::IOSScreenSaver> GetOSScreenSaverImpl() { return nullptr; }
 
   int m_nWidth = 0;


### PR DESCRIPTION
## Description
In https://github.com/xbmc/xbmc/pull/23259 HiDPI support was added to MacOS native windowing, this caused a regression for other platforms that has been fixed (quick hack) in https://github.com/xbmc/xbmc/pull/23371 since we were quite close to the alpha2 release.

However, I really don't like the implementation: It adds additional complexity (definition of labels and ids when there is already a property for the mode `strMode`) and... the HiDPI concept is quite generic (it just means the width and height are higher than the actual screen width and height). Hence, in this PR, targeting alpha 3 I propose another approach, removing part of the complexity of the older fix and making it more generic for any windowing system (it's just a matter of defining all the properties on the resolution info - width, height, screenwidth, screenheight, etc). The label is computed in such cases.
Best matching resolutions are chosen by the unique id (if defined) otherwise it gets it from the resolution unique label just like before.

It should not cause regressions (previously we only used one dimension for all properties) but it'd be nice to confirm.
**It's appreciated if you could give it a spin, check the list of resolutions on the display settings and try to select/choose different resolutions.**

@thexai @CrystalP for windows if possible
@joseluismarti for android
Not sure who can check linux (i might look into it at some point this week when back home)

## Motivation and context
Make HiDPI more generic, remove hacks and increased complexity

## How has this been tested?
On MacOS only. Checking the logs, checking the list of resolutions, selecting different resolutions

## What is the effect on users?
Hopefully none, easier to add support for HiDPI for any platform (at least taking advantage of the common windowing code).

## Screenshots (if appropriate):

<img width="1467" alt="image" src="https://github.com/xbmc/xbmc/assets/7375276/35367a62-6859-438c-9346-7dd669fabb43">

<img width="1470" alt="image" src="https://github.com/xbmc/xbmc/assets/7375276/714432fa-ff56-4da4-8167-1a93e6778e11">


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
