### PR TITLE
[Windows] Remove workaround for Video Super Resolution

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -753,11 +753,7 @@ bool CProcessorHD::Render(CRect src, CRect dst, ID3D11Resource* target, CRenderB
   // Stream dest rect
   m_pVideoContext->VideoProcessorSetStreamDestRect(m_pVideoProcessor.Get(), DEFAULT_STREAM_INDEX, TRUE, &dstRECT);
   // Output rect
-  // Disabled when using Video Super Resolution because it causes vertical shift of a few pixels.
-  // Tested with RTX 4070 and NVIDIA driver 535.98. It doesn't seem to happen with Intel i7-13700K.
-  // ToDo: retest with future NVIDIA drivers and eventually remove this workaround.
-  m_pVideoContext->VideoProcessorSetOutputTargetRect(
-      m_pVideoProcessor.Get(), m_superResolutionEnabled ? FALSE : TRUE, &dstRECT);
+  m_pVideoContext->VideoProcessorSetOutputTargetRect(m_pVideoProcessor.Get(), TRUE, &dstRECT);
 
   ComPtr<ID3D11VideoContext1> videoCtx1;
   if (SUCCEEDED(m_pVideoContext.As(&videoCtx1)))
@@ -1280,7 +1276,7 @@ void CProcessorHD::EnableIntelVideoSuperResolution()
     return;
   }
 
-  CLog::LogF(LOGINFO, "Intel Video Super Resolution enabled successfully");
+  CLog::LogF(LOGINFO, "Intel Video Super Resolution request enable successfully");
   m_superResolutionEnabled = true;
 }
 
@@ -1304,6 +1300,6 @@ void CProcessorHD::EnableNvidiaRTXVideoSuperResolution()
     return;
   }
 
-  CLog::LogF(LOGINFO, "RTX Video Super Resolution enabled successfully");
+  CLog::LogF(LOGINFO, "RTX Video Super Resolution request enable successfully");
   m_superResolutionEnabled = true;
 }


### PR DESCRIPTION
## Description
[Windows] Remove workaround for Video Super Resolution

## Motivation and context
Seems vertical shift is fixed with NVIDIA driver 536.23.
Also changed logs wording "enabled" to "request enable" to reflect better the reality.

## How has this been tested?
Runtime NVIDIA RTX 4070, driver 536.23, Windows 11 22H2

## What is the effect on users?
none

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
