### PR TITLE
Build Texturepacker for all platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,7 +335,7 @@ foreach(skin ${SKINS})
 endforeach()
 
 add_custom_target(pack-skins ALL
-                  DEPENDS TexturePacker::TexturePacker::Executable export-files ${XBT_FILES})
+                  DEPENDS TexturePacker::TexturePacker export-files ${XBT_FILES})
 set_target_properties(pack-skins PROPERTIES FOLDER "Build Utilities")
 
 file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/system/players/VideoPlayer)

--- a/cmake/modules/buildtools/FindTexturePacker.cmake
+++ b/cmake/modules/buildtools/FindTexturePacker.cmake
@@ -1,95 +1,106 @@
 #.rst:
 # FindTexturePacker
 # -----------------
-# Finds the TexturePacker
+# Finds TexturePacker executable
 #
 # If WITH_TEXTUREPACKER is defined and points to a directory,
 # this path will be used to search for the Texturepacker binary
 #
+# This will define the following target:
 #
-# This will define the following (imported) targets::
-#
-#   TexturePacker::TexturePacker::Executable   - The TexturePacker executable participating in build
-#   TexturePacker::TexturePacker::Installable  - The TexturePacker executable shipped in the Kodi package
+#   TexturePacker::TexturePacker - The TexturePacker executable
 
-if(NOT TARGET TexturePacker::TexturePacker::Executable)
-  if(KODI_DEPENDSBUILD)
-    get_filename_component(_tppath "${NATIVEPREFIX}/bin" ABSOLUTE)
+if(NOT TARGET TexturePacker::TexturePacker)
+  if(WITH_TEXTUREPACKER)
+    get_filename_component(_tppath ${WITH_TEXTUREPACKER} ABSOLUTE)
+    get_filename_component(_tppath ${_tppath} DIRECTORY)
     find_program(TEXTUREPACKER_EXECUTABLE NAMES "${APP_NAME_LC}-TexturePacker" TexturePacker
-                                          HINTS ${_tppath})
+                                                "${APP_NAME_LC}-TexturePacker.exe" TexturePacker.exe
+                                          HINTS ${_tppath}
+                                          NO_CACHE)
 
-    add_executable(TexturePacker::TexturePacker::Executable IMPORTED GLOBAL)
-    set_target_properties(TexturePacker::TexturePacker::Executable PROPERTIES
-                                          IMPORTED_LOCATION "${TEXTUREPACKER_EXECUTABLE}")
-    message(STATUS "External TexturePacker for KODI_DEPENDSBUILD will be executed during build: ${TEXTUREPACKER_EXECUTABLE}")
-  elseif(WIN32)
-    get_filename_component(_tppath "${NATIVEPREFIX}/tools/TexturePacker" ABSOLUTE)
-    find_program(TEXTUREPACKER_EXECUTABLE NAMES "${APP_NAME_LC}-TexturePacker.exe" TexturePacker.exe
-                                          HINTS ${_tppath})
-
-    add_executable(TexturePacker::TexturePacker::Executable IMPORTED GLOBAL)
-    set_target_properties(TexturePacker::TexturePacker::Executable PROPERTIES
-                                          IMPORTED_LOCATION "${TEXTUREPACKER_EXECUTABLE}")
-    message(STATUS "External TexturePacker for WIN32 will be executed during build: ${TEXTUREPACKER_EXECUTABLE}")
+    if(NOT TEXTUREPACKER_EXECUTABLE)
+      message(FATAL_ERROR "Could not find 'TexturePacker' executable in ${_tppath} supplied by -DWITH_TEXTUREPACKER")
+    endif()
   else()
-    if(WITH_TEXTUREPACKER)
-      get_filename_component(_tppath ${WITH_TEXTUREPACKER} ABSOLUTE)
-      get_filename_component(_tppath ${_tppath} DIRECTORY)
-      find_program(TEXTUREPACKER_EXECUTABLE NAMES "${APP_NAME_LC}-TexturePacker" TexturePacker
-                                          HINTS ${_tppath})
+    include(cmake/scripts/common/ModuleHelpers.cmake)
 
-      # Use external TexturePacker executable if found
-      if(TEXTUREPACKER_EXECUTABLE)
-        add_executable(TexturePacker::TexturePacker::Executable IMPORTED GLOBAL)
-        set_target_properties(TexturePacker::TexturePacker::Executable PROPERTIES
-                                          IMPORTED_LOCATION "${TEXTUREPACKER_EXECUTABLE}")
-        message(STATUS "Found external TexturePacker: ${TEXTUREPACKER_EXECUTABLE}")
+    # Check for existing TEXTUREPACKER
+    find_program(TEXTUREPACKER_EXECUTABLE NAMES "${APP_NAME_LC}-TexturePacker" TexturePacker
+                                                "${APP_NAME_LC}-TexturePacker.exe" TexturePacker.exe
+                                          HINTS ${NATIVEPREFIX}/bin
+                                          NO_CACHE)
+
+    if(TEXTUREPACKER_EXECUTABLE)
+      execute_process(COMMAND "${TEXTUREPACKER_EXECUTABLE}" -version
+                      OUTPUT_VARIABLE TEXTUREPACKER_EXECUTABLE_VERSION
+                      OUTPUT_STRIP_TRAILING_WHITESPACE)
+      string(REGEX MATCH "[^\n]* version [^\n]*" TEXTUREPACKER_EXECUTABLE_VERSION "${TEXTUREPACKER_EXECUTABLE_VERSION}")
+      string(REGEX REPLACE ".* version (.*)" "\\1" TEXTUREPACKER_EXECUTABLE_VERSION "${TEXTUREPACKER_EXECUTABLE_VERSION}")
+    endif()
+
+    set(MODULE_LC TexturePacker)
+    set(LIB_TYPE native)
+    SETUP_BUILD_VARS()
+
+    if(NOT TEXTUREPACKER_EXECUTABLE OR "${TEXTUREPACKER_EXECUTABLE_VERSION}" VERSION_LESS "${TEXTUREPACKER_VER}")
+
+      # Override build type detection and always build as release
+      set(TEXTUREPACKER_BUILD_TYPE Release)
+
+      set(CMAKE_ARGS -DKODI_SOURCE_DIR=${CMAKE_SOURCE_DIR})
+
+      if(NATIVEPREFIX)
+        set(INSTALL_DIR "${NATIVEPREFIX}/bin")
+        set(TEXTUREPACKER_INSTALL_PREFIX ${NATIVEPREFIX})
+        list(APPEND CMAKE_ARGS "-DNATIVEPREFIX=${NATIVEPREFIX}")
       else()
-        # Warn about external TexturePacker supplied but not fail fatally
-        # because we might have internal TexturePacker executable built
-        # and unset TEXTUREPACKER_EXECUTABLE variable
-        message(WARNING "Could not find '${APP_NAME_LC}-TexturePacker' or 'TexturePacker' executable in ${_tppath} supplied by -DWITH_TEXTUREPACKER. Make sure the executable file name matches these names!")
+        set(INSTALL_DIR "${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/bin")
+        set(TEXTUREPACKER_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR})
       endif()
-    endif()
 
-    # Ship TexturePacker only on Linux and FreeBSD
-    if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "Linux")
-      # But skip shipping it if build architecture can be executed on host
-      # and TEXTUREPACKER_EXECUTABLE is found
-      if(NOT (HOST_CAN_EXECUTE_TARGET AND TEXTUREPACKER_EXECUTABLE))
-        set(INTERNAL_TEXTUREPACKER_INSTALLABLE TRUE CACHE BOOL "" FORCE)
+      # Set host build info for buildtool
+      if(EXISTS "${NATIVEPREFIX}/share/Toolchain-Native.cmake")
+        set(TEXTUREPACKER_TOOLCHAIN_FILE "${NATIVEPREFIX}/share/Toolchain-Native.cmake")
+        list(APPEND CMAKE_ARGS -DENABLE_STATIC=1)
+      else()
+        if(WIN32)
+          # Windows ARCH_DEFINES for store has some things we probably dont want
+          # just provide a simple set of defines for all windows host builds
+          list(APPEND CMAKE_ARGS -DARCH_DEFINES=TARGET_WINDOWS;WIN32;_CONSOLE;_CRT_SECURE_NO_WARNINGS)
+          list(APPEND CMAKE_ARGS -DENABLE_STATIC=1)
+        else()
+          string(REGEX REPLACE "-D" "" STRIPPED_ARCH_DEFINES "${ARCH_DEFINES}")
+          list(APPEND CMAKE_ARGS "-DARCH_DEFINES=${STRIPPED_ARCH_DEFINES}")
+        endif()
       endif()
+
+      if(WIN32 OR WINDOWS_STORE)
+        # Make sure we generate for host arch, not target
+        set(TEXTUREPACKER_GENERATOR_PLATFORM CMAKE_GENERATOR_PLATFORM WIN32)
+        set(WIN_DISABLE_PROJECT_FLAGS 1)
+        set(APP_EXTENSION ".exe")
+      endif()
+
+      set(TEXTUREPACKER_SOURCE_DIR ${CMAKE_SOURCE_DIR}/tools/depends/native/TexturePacker/src)
+      set(TEXTUREPACKER_EXECUTABLE ${INSTALL_DIR}/TexturePacker${APP_EXTENSION})
+      set(TEXTUREPACKER_EXECUTABLE_VERSION ${TEXTUREPACKER_VER})
+
+      set(BUILD_BYPRODUCTS ${TEXTUREPACKER_EXECUTABLE})
+
+      BUILD_DEP_TARGET()
     endif()
+  endif()
 
-    # Use it during build if build architecture can be executed on host
-    # and TEXTUREPACKER_EXECUTABLE is not found
-    if(HOST_CAN_EXECUTE_TARGET AND NOT TEXTUREPACKER_EXECUTABLE)
-      set(INTERNAL_TEXTUREPACKER_EXECUTABLE TRUE)
-    endif()
+  include(FindPackageMessage)
+  find_package_message(TexturePacker "Found TexturePacker: ${TEXTUREPACKER_EXECUTABLE} (found version \"${TEXTUREPACKER_EXECUTABLE_VERSION}\")"
+                                     "[${TEXTUREPACKER_EXECUTABLE}][${TEXTUREPACKER_EXECUTABLE_VERSION}]")
 
-    # Build and install internal TexturePacker if needed
-    if (INTERNAL_TEXTUREPACKER_EXECUTABLE OR INTERNAL_TEXTUREPACKER_INSTALLABLE)
-      set(KODI_SOURCE_DIR ${CMAKE_SOURCE_DIR})
-      add_subdirectory(${CMAKE_SOURCE_DIR}/tools/depends/native/TexturePacker/src build/texturepacker)
-      unset(KODI_SOURCE_DIR)
-      message(STATUS "Building internal TexturePacker")
-    endif()
+  add_executable(TexturePacker::TexturePacker IMPORTED GLOBAL)
+  set_target_properties(TexturePacker::TexturePacker PROPERTIES
+                                                     IMPORTED_LOCATION "${TEXTUREPACKER_EXECUTABLE}")
 
-    if(INTERNAL_TEXTUREPACKER_INSTALLABLE)
-      add_executable(TexturePacker::TexturePacker::Installable ALIAS TexturePacker)
-      message(STATUS "Shipping internal TexturePacker")
-    endif()
-
-    if(INTERNAL_TEXTUREPACKER_EXECUTABLE)
-      add_executable(TexturePacker::TexturePacker::Executable ALIAS TexturePacker)
-      message(STATUS "Internal TexturePacker will be executed during build")
-    else()
-      message(STATUS "External TexturePacker will be executed during build: ${TEXTUREPACKER_EXECUTABLE}")
-
-      include(FindPackageHandleStandardArgs)
-      find_package_handle_standard_args(TexturePacker DEFAULT_MSG TEXTUREPACKER_EXECUTABLE)
-    endif()
-
-    mark_as_advanced(INTERNAL_TEXTUREPACKER_EXECUTABLE INTERNAL_TEXTUREPACKER_INSTALLABLE TEXTUREPACKER)
+  if(TARGET TexturePacker)
+    add_dependencies(TexturePacker::TexturePacker TexturePacker)
   endif()
 endif()

--- a/cmake/scripts/common/ProjectMacros.cmake
+++ b/cmake/scripts/common/ProjectMacros.cmake
@@ -11,7 +11,7 @@ function(pack_xbt input output)
   get_filename_component(dir ${output} DIRECTORY)
   add_custom_command(OUTPUT  ${output}
                      COMMAND ${CMAKE_COMMAND} -E make_directory ${dir}
-                     COMMAND TexturePacker::TexturePacker::Executable
+                     COMMAND TexturePacker::TexturePacker
                      ARGS    -input ${input}
                              -output ${output}
                              -dupecheck

--- a/cmake/scripts/linux/Install.cmake
+++ b/cmake/scripts/linux/Install.cmake
@@ -163,14 +163,6 @@ install(FILES ${CMAKE_SOURCE_DIR}/privacy-policy.txt
         DESTINATION ${datarootdir}/${APP_NAME_LC}
         COMPONENT kodi)
 
-# Install kodi-tools-texturepacker
-if(INTERNAL_TEXTUREPACKER_INSTALLABLE)
-  install(PROGRAMS $<TARGET_FILE:TexturePacker::TexturePacker::Installable>
-          DESTINATION ${bindir}
-          RENAME "${APP_NAME_LC}-TexturePacker"
-          COMPONENT kodi-tools-texturepacker)
-endif()
-
 # Install kodi-addon-dev headers
 include(${CMAKE_SOURCE_DIR}/xbmc/addons/AddonBindings.cmake)
 install(DIRECTORY ${CORE_ADDON_BINDINGS_DIRS}/

--- a/project/BuildDependencies/scripts/0_package.native-win32.list
+++ b/project/BuildDependencies/scripts/0_package.native-win32.list
@@ -6,5 +6,9 @@
 ; -> sqlite-3.7.12.1-win32\system\sqlite3.dll
 ; -> ...
 ;PLEASE KEEP THIS LIST IN ALPHABETICAL ORDER!
+giflib-5.2.1-win32-v141-20200105.7z
+libjpeg-turbo-2.0.3-win32-v141-20200105.7z
+libpng-1.6.37-win32-v141-20200105.7z
+lzo2-2.10-win32-v141-20200105.7z
 swig-4.0.1-win32-v141-20200105.7z
-TexturePacker-win32-v141-20200105.7z
+zlib-1.2.11-win32-v141-20191222.7z

--- a/project/BuildDependencies/scripts/get_formed.cmd
+++ b/project/BuildDependencies/scripts/get_formed.cmd
@@ -88,7 +88,7 @@ IF EXIST %1 (
 CALL :setSubStageName Extracting %1...
 copy /b "%1" "%TMP_PATH%" >NUL 2>NUL || EXIT /B 5
 PUSHD "%TMP_PATH%" || EXIT /B 10
-%ZIP% x %1 >NUL 2>NUL || (
+%ZIP% x -y %1 >NUL 2>NUL || (
   IF %RetryDownload%==YES (
     POPD || EXIT /B 5
     ECHO WARNING! Can't extract files from archive %1!

--- a/tools/depends/native/Makefile
+++ b/tools/depends/native/Makefile
@@ -28,7 +28,6 @@ NATIVE= \
   pkg-config \
   python3 \
   swig \
-  TexturePacker \
   zlib
 
 ifneq ($(NATIVE_OS),osx)

--- a/tools/depends/native/TexturePacker/TEXTUREPACKER-VERSION
+++ b/tools/depends/native/TexturePacker/TEXTUREPACKER-VERSION
@@ -1,0 +1,2 @@
+LIBNAME=TexturePacker
+VERSION=1.0.0

--- a/tools/depends/native/TexturePacker/src/TexturePacker.cpp
+++ b/tools/depends/native/TexturePacker/src/TexturePacker.cpp
@@ -92,9 +92,15 @@ void Usage()
 {
   puts("Usage:");
   puts("  -help            Show this screen.");
+  puts("  -version         Show version.");
   puts("  -input <dir>     Input directory. Default: current dir");
   puts("  -output <dir>    Output directory/filename. Default: Textures.xbt");
   puts("  -dupecheck       Enable duplicate file detection. Reduces output file size. Default: off");
+}
+
+void Version()
+{
+  puts("TexturePacker version 1.0.0");
 }
 
 } // namespace
@@ -393,6 +399,11 @@ int main(int argc, char* argv[])
     if (!platform_stricmp(args[i], "-help") || !platform_stricmp(args[i], "-h") || !platform_stricmp(args[i], "-?"))
     {
       Usage();
+      return 1;
+    }
+    else if (!platform_stricmp(args[i], "-version") || !platform_stricmp(args[i], "-v"))
+    {
+      Version();
       return 1;
     }
     else if (!platform_stricmp(args[i], "-input") || !platform_stricmp(args[i], "-i"))


### PR DESCRIPTION
## Description
Build texturepacker as part of the core cmake project. This enables building of windows executables rather than prebuilt binaries

## Motivation and context
@lrusak has been tinkering with features for texturepacker. @CrystalP wanted to potentially use these.

Onto the potential bikeshedding points.

Currently there is no way to distinguish a version of texturepacker from another one. Theres no versioning available. 1eab9efa2c589740ad66a477f692781fa00f41d2 is extremely crude way to implement this. I would really rather not get hung up on this. If someone wants to get fancy and fix that all up later, please do, but the goal isnt to make changes to Texturepacker itself here. We just want a way to tell if the texturepacker executable may have had features added (ie a version change) so we can then rebuild if necessary to get those features.

As was mentioned in https://github.com/xbmc/xbmc/pull/23409 , the long standing assumption for native build tools on windows is x86. As it stands, there are other prebuilt tools that arent built from source, and until this changes, i dont see a point in changing the one tool we build from source to target a different arch (ie x86_64). Doing so brings in complications with finding tools in cmake, and really just isnt worth the hassle right now.

The linux installable stuff. that was yuck. Im still not even sure i understand what the use cases are for it all, so @basilgello @wsnipex have a look closely at the FindTexturePacker.cmake changes, in particular the WITH_TEXTUREPACKER usage. The assumption now is if WITH_TEXTUREPACKER is supplied, if the tool is not found, its a hard fail. If it needs to be built, dont supply the argument. I dont believe theres a need for the second target TexturePacker::TexturePacker::Installable, so thats been removed. If theres some use case that is no longer satisfied for linux, please let me know exactly what it is.
Of note, there was no changes made to the autoconf build, so if distro building used that, nothing has changed. 
There is now a cmake build script inside the TexturePacker src folder that is used for this. It was obviously based on the existing CMakeLists.txt file, but has been modified to not be so tightly coupled with the kodi source structure (provides argument to point to kodi source -DKODI_SOURCE_DIR). Whether thats useful for distro stuff, i dont know, ill leave that to maintainers to decide.

## How has this been tested?
Build all platforms on jenkins. Runtime win x86_64, macos arm targets

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
