### PR TITLE
[Windows] Add "Graphics" log component for Direct3D

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.cpp
@@ -100,7 +100,8 @@ ProcessorCapabilities CEnumeratorHD::ProbeProcessorCaps()
   HRESULT hr{};
   ProcessorCapabilities result{};
 
-  if (CServiceBroker::GetLogging().IsLogLevelLogged(LOGDEBUG))
+  if (CServiceBroker::GetLogging().IsLogLevelLogged(LOGDEBUG) &&
+      CServiceBroker::GetLogging().CanLogComponent(LOGVIDEO))
   {
     std::string inputFormats{};
     std::string outputFormats{};
@@ -121,8 +122,8 @@ ProcessorCapabilities CEnumeratorHD::ProbeProcessorCaps()
         }
       }
     }
-    CLog::LogF(LOGDEBUG, "Supported input formats:{}", inputFormats);
-    CLog::LogF(LOGDEBUG, "Supported output formats:{}", outputFormats);
+    CLog::LogFC(LOGDEBUG, LOGVIDEO, "Supported input formats:{}", inputFormats);
+    CLog::LogFC(LOGDEBUG, LOGVIDEO, "Supported output formats:{}", outputFormats);
   }
 
   if (FAILED(hr = m_pEnumerator->GetVideoProcessorCaps(&result.m_vcaps)))

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -643,14 +643,16 @@ void CProcessorHD::ListSupportedConversions(const DXGI_FORMAT& inputFormat,
 
   if (FAILED(hr = m_enumerator->Get()->CheckVideoProcessorFormat(inputFormat, &uiFlags)))
   {
-    CLog::LogF(LOGDEBUG, "unable to retrieve processor support of input format {}. Error {}",
-               DX::DXGIFormatToString(inputFormat), DX::GetErrorDescription(hr));
+    CLog::LogFC(LOGDEBUG, LOGVIDEO,
+                "unable to retrieve processor support of input format {}. Error {}",
+                DX::DXGIFormatToString(inputFormat), DX::GetErrorDescription(hr));
     return;
   }
   else if (!(uiFlags & D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT_INPUT))
   {
-    CLog::LogF(LOGERROR, "input format {} not supported by the processor. No conversion possible.",
-               DX::DXGIFormatToString(inputFormat));
+    CLog::LogFC(LOGDEBUG, LOGVIDEO,
+                "input format {} not supported by the processor. No conversion possible.",
+                DX::DXGIFormatToString(inputFormat));
     return;
   }
 
@@ -665,23 +667,23 @@ void CProcessorHD::ListSupportedConversions(const DXGI_FORMAT& inputFormat,
   BOOL supported{FALSE};
 
   const DXGI_COLOR_SPACE_TYPE inputNativeCS = AvToDxgiColorSpace(csArgs);
-  CLog::LogF(LOGDEBUG, "The source is {} / {}", DX::DXGIFormatToString(inputFormat),
-             DX::DXGIColorSpaceTypeToString(inputNativeCS));
+  CLog::LogFC(LOGDEBUG, LOGVIDEO, "The source is {} / {}", DX::DXGIFormatToString(inputFormat),
+              DX::DXGIColorSpaceTypeToString(inputNativeCS));
 
   if (SUCCEEDED(hr = m_enumerator->Get1()->CheckVideoProcessorFormatConversion(
                     inputFormat, inputNativeCS, heuristicsOutputFormat,
                     heuristicsCS.outputColorSpace, &supported)))
   {
-    CLog::LogF(LOGDEBUG, "conversion from {} / {} to {} / {} is {}supported.",
-               DX::DXGIFormatToString(inputFormat), DX::DXGIColorSpaceTypeToString(inputNativeCS),
-               DX::DXGIFormatToString(heuristicsOutputFormat),
-               DX::DXGIColorSpaceTypeToString(heuristicsCS.outputColorSpace),
-               supported == TRUE ? "" : "NOT ");
+    CLog::LogFC(LOGDEBUG, LOGVIDEO, "conversion from {} / {} to {} / {} is {}supported.",
+                DX::DXGIFormatToString(inputFormat), DX::DXGIColorSpaceTypeToString(inputNativeCS),
+                DX::DXGIFormatToString(heuristicsOutputFormat),
+                DX::DXGIColorSpaceTypeToString(heuristicsCS.outputColorSpace),
+                supported == TRUE ? "" : "NOT ");
   }
   else
   {
-    CLog::LogF(LOGERROR, "unable to validate the default format conversion, error {}",
-               DX::GetErrorDescription(hr));
+    CLog::LogFC(LOGDEBUG, LOGVIDEO, "unable to validate the default format conversion, error {}",
+                DX::GetErrorDescription(hr));
   }
 
   // Possible input color spaces: YCbCr only
@@ -750,10 +752,10 @@ void CProcessorHD::ListSupportedConversions(const DXGI_FORMAT& inputFormat,
     }
   }
 
-  CLog::LogF(LOGDEBUG,
-             "supported conversions from format {}\n(*: values picked by "
-             "heuristics, N native input color space, bb supported as swap chain backbuffer){}",
-             DX::DXGIFormatToString(inputFormat), conversions);
+  CLog::LogFC(LOGDEBUG, LOGVIDEO,
+              "supported conversions from format {}\n(*: values picked by "
+              "heuristics, N native input color space, bb supported as swap chain backbuffer){}",
+              DX::DXGIFormatToString(inputFormat), conversions);
 }
 
 std::vector<DXGI_FORMAT> CProcessorHD::GetProcessorOutputFormats() const

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
@@ -142,7 +142,8 @@ bool CRendererDXVA::Configure(const VideoPicture& picture, float fps, unsigned o
     if (m_processor->PreInit() && m_processor->Open(m_sourceWidth, m_sourceHeight, picture) &&
         m_processor->IsFormatSupported(dxgi_format, support_type))
     {
-      if (CServiceBroker::GetLogging().IsLogLevelLogged(LOGDEBUG))
+      if (CServiceBroker::GetLogging().IsLogLevelLogged(LOGDEBUG) &&
+          CServiceBroker::GetLogging().CanLogComponent(LOGVIDEO))
         m_processor->ListSupportedConversions(dxgi_format, dest_format, picture);
 
       if (m_processor->IsFormatConversionSupported(dxgi_format, dest_format, picture))

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -717,7 +717,8 @@ void DX::DeviceResources::ResizeBuffers()
     hr = swapChain.As(&m_swapChain); CHECK_ERR();
     m_stereoEnabled = bHWStereoEnabled;
 
-    if (CServiceBroker::GetLogging().IsLogLevelLogged(LOGDEBUG))
+    if (CServiceBroker::GetLogging().IsLogLevelLogged(LOGDEBUG) &&
+        CServiceBroker::GetLogging().CanLogComponent(LOGVIDEO))
     {
       std::string colorSpaces;
       for (const DXGI_COLOR_SPACE_TYPE& colorSpace : GetSwapChainColorSpaces())
@@ -725,7 +726,7 @@ void DX::DeviceResources::ResizeBuffers()
         colorSpaces.append("\n");
         colorSpaces.append(DX::DXGIColorSpaceTypeToString(colorSpace));
       }
-      CLog::LogF(LOGDEBUG, "Color spaces supported by the swap chain:{}", colorSpaces);
+      CLog::LogFC(LOGDEBUG, LOGVIDEO, "Color spaces supported by the swap chain:{}", colorSpaces);
     }
 
     // Ensure that DXGI does not queue more than one frame at a time. This both reduces latency and


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Moved the output of a few D3D11 enumeration functions into the VIDEO component to lighten the typical debug log.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Clean up the debug log for the most common situations.
It was brought up that the Windows log is getting too busy.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran with/without the component enabled,

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Easier to read debug log for common problems.

## Screenshots (if appropriate):

component enabled:
```
2023-06-19 20:46:28.350 T:23292   debug <general>: CWinRenderer::SelectRenderer: selected render method: DXVA
2023-06-19 20:46:28.350 T:23292   debug <general>: DXVA::CEnumeratorHD::Open: initializing video enumerator with params: 1920x1080.
2023-06-19 20:46:28.351 T:23292   debug <general>: DXVA::CEnumeratorHD::ProbeProcessorCaps: Supported input formats:
                                                   R16G16B16A16_FLOAT
                                                   R10G10B10A2_UNORM
                                                   R8G8B8A8_TYPELESS
                                                   R8G8B8A8_UNORM
                                                   R8G8B8A8_UNORM_SRGB

... more lines of enumeration ...

2023-06-19 20:46:28.352 T:23292   debug <general>: DXVA::CEnumeratorHD::ProbeProcessorCaps: video processor has 1 rate conversion.
2023-06-19 20:46:28.352 T:23292   debug <general>: DXVA::CEnumeratorHD::ProbeProcessorCaps: video processor has 0x8e6 feature caps.

```

component disabled:
```
2023-06-19 20:47:22.225 T:23292   debug <general>: CWinRenderer::SelectRenderer: selected render method: DXVA
2023-06-19 20:47:22.226 T:23292   debug <general>: DXVA::CEnumeratorHD::Open: initializing video enumerator with params: 1920x1080.
2023-06-19 20:47:22.226 T:23292   debug <general>: DXVA::CEnumeratorHD::ProbeProcessorCaps: video processor has 1 rate conversion.
2023-06-19 20:47:22.226 T:23292   debug <general>: DXVA::CEnumeratorHD::ProbeProcessorCaps: video processor has 0x8e6 feature caps.
```


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

There is most likely a Wiki page with the list of components to update,