### PR TITLE
[Windows][dxva] Test support of the video processor for SDR to SDR conversion

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
@@ -96,6 +96,13 @@ public:
 
   bool IsBT2020Supported();
   bool IsPQ10PassthroughSupported();
+  /*!
+   * \brief Test whether the dxva video processor supports SDR to SDR conversion.
+   * Support is assumed to exist on systems that don't support the
+   * ID3D11VideoProcessorEnumerator1 interface.
+   * \return conversion supported yes/no
+  */
+  bool IsSDRSupported();
   ProcessorCapabilities ProbeProcessorCaps();
 
   ComPtr<ID3D11VideoProcessorEnumerator> Get() { return m_pEnumerator; }
@@ -105,6 +112,7 @@ protected:
   void UnInit();
   InputFormat QueryHDRtoHDRSupport() const;
   InputFormat QueryHDRtoSDRSupport() const;
+  bool QuerySDRSupport() const;
 
   CCriticalSection m_section;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
@@ -54,8 +54,12 @@ void CRendererDXVA::GetWeight(std::map<RenderMethod, int>& weights, const VideoP
     if (streamIsHDR && systemUsesHDR && !enumerator.IsPQ10PassthroughSupported())
       return;
 
-    // Check if BT.2020 color space is supported by DXVA video processor
+    // Check if BT.2020 color space is supported by DXVA video processor (for own HDR-SDR tonemap)
     if (picture.color_primaries == AVCOL_PRI_BT2020 && !enumerator.IsBT2020Supported())
+      return;
+
+    // Everything else is played as HD / BT709, check support.
+    if (picture.color_primaries != AVCOL_PRI_BT2020 && !enumerator.IsSDRSupported())
       return;
 
     weight += 1000;
@@ -91,6 +95,10 @@ void CRendererDXVA::GetWeight(std::map<RenderMethod, int>& weights, const VideoP
 
     // Check if BT.2020 color space is supported by DXVA video processor
     if (picture.color_primaries == AVCOL_PRI_BT2020 && !enumerator.IsBT2020Supported())
+      return;
+
+    // Everything else is played as HD / BT709, check support.
+    if (picture.color_primaries != AVCOL_PRI_BT2020 && !enumerator.IsSDRSupported())
       return;
 
     if (av_pixel_format == AV_PIX_FMT_NV12 ||


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Check the support by the dxva video processor of SDR to SDR conversion, following the pattern of the HDR passthrough and SDR tonemap checks.

This helps the AMD gpu that lack driver support for limited range output: they now fallback to Pixel Shaders 

The condition (picture.color_primaries != AVCOL_PRI_BT2020) triggering the check is broad, but matches the current code behavior.
It could be refined in a future PR to let only certain transfers / primaries / etc through and have the rest fallback.

** not added to the "configure" path of RendererDXVA because it doesn't reach that point when not compatible.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

AMD with setting "Use limited color range" enabled give a black screen for SDR material, because of the dxva video processor's lack of support for limited range output and failed IsFormatConversionSupported() check.
 When the check is bypassed, there is output, but full range instead of limited range.
It was decided in a previous PR to fallback to Pixel Shaders in that situation.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

AMD (falls back to Pixel Shaders for limited range output), Intel gen 8 & gen 4 (accept full and limited output range)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Working SDR playback with AMD GPU and limited range output (HDR was taken care of in previous PR)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
