### PR TITLE
[windows] Dont ship vswhere executable

### DIFF
--- a/project/BuildDependencies/scripts/0_package.native-win32.list
+++ b/project/BuildDependencies/scripts/0_package.native-win32.list
@@ -9,4 +9,3 @@
 JsonSchemaBuilder-win32-v141-20200105.7z
 swig-4.0.1-win32-v141-20200105.7z
 TexturePacker-win32-v141-20200105.7z
-vswhere-2.2.11-win32.7z

--- a/tools/buildsteps/windows/vswhere.bat
+++ b/tools/buildsteps/windows/vswhere.bat
@@ -35,7 +35,7 @@ IF "%arch%" NEQ "x64" (
   SET vcarch=%vcarch%_%arch%
 )
 
-SET vswhere="%builddeps%\%toolsdir%\tools\vswhere\vswhere.exe"
+SET vswhere="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
 
 FOR /f "usebackq tokens=1* delims=" %%i in (`%vswhere% -latest -property installationPath`) do (
   IF EXIST "%%i\VC\Auxiliary\Build\vcvarsall.bat" (


### PR DESCRIPTION
## Description
Remove executable that is already provided by Visual Studio

## Motivation and context
According to the docs at https://github.com/microsoft/vswhere, vswhere is shipped with Visual Studio 2017 onwards at a standard location. Use this instead of shipping a vswhere executable.

One less prebuilt executable being shipped, one less thing to maintain.

## How has this been tested?
Jenkins

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
