### PR TITLE
[cmake] TexturePacker: don't force static libraries

### DIFF
--- a/cmake/modules/buildtools/FindTexturePacker.cmake
+++ b/cmake/modules/buildtools/FindTexturePacker.cmake
@@ -70,10 +70,8 @@ if(NOT TARGET TexturePacker::TexturePacker::Executable)
     # Build and install internal TexturePacker if needed
     if (INTERNAL_TEXTUREPACKER_EXECUTABLE OR INTERNAL_TEXTUREPACKER_INSTALLABLE)
       set(KODI_SOURCE_DIR ${CMAKE_SOURCE_DIR})
-      set(ENABLE_STATIC 1)
       add_subdirectory(${CMAKE_SOURCE_DIR}/tools/depends/native/TexturePacker/src build/texturepacker)
       unset(KODI_SOURCE_DIR)
-      unset(ENABLE_STATIC)
       message(STATUS "Building internal TexturePacker")
     endif()
 


### PR DESCRIPTION
This is needed to allow building on a linux host that only has shared libraries (not a depends build).

Let's see what the CI says.