### PR TITLE
[Subtitles] Add support to font collection (.ttc)

### DIFF
--- a/xbmc/guilib/GUIFontManager.h
+++ b/xbmc/guilib/GUIFontManager.h
@@ -20,6 +20,7 @@
 #include "utils/GlobalsHandling.h"
 #include "windowing/GraphicContext.h"
 
+#include <set>
 #include <utility>
 #include <vector>
 
@@ -44,13 +45,13 @@ struct OrigFontInfo
 
 struct FontMetadata
 {
-  FontMetadata(const std::string& filename, const std::string& familyName)
-    : m_filename{filename}, m_familyName{familyName}
+  FontMetadata(const std::string& filename, const std::set<std::string>& familyNames)
+    : m_filename{filename}, m_familyNames{familyNames}
   {
   }
 
   std::string m_filename;
-  std::string m_familyName;
+  std::set<std::string> m_familyNames;
 };
 
 /*!

--- a/xbmc/utils/FontUtils.cpp
+++ b/xbmc/utils/FontUtils.cpp
@@ -25,6 +25,147 @@
 
 using namespace XFILE;
 
+namespace
+{
+// \brief Get font family from SFNT table entries
+std::string GetFamilyNameFromSfnt(FT_Face face)
+{
+  std::string familyName;
+
+  for (FT_UInt index = 0; index < FT_Get_Sfnt_Name_Count(face); ++index)
+  {
+    FT_SfntName name;
+    if (FT_Get_Sfnt_Name(face, index, &name) != 0)
+    {
+      CLog::LogF(LOGWARNING, "Failed to get SFNT name at index {}", index);
+      continue;
+    }
+
+    // Get the unicode font family name (format-specific interface)
+    // In properties there may be one or more font family names encoded for each platform.
+    // NOTE: we give preference to MS/APPLE platform data, then fallback to MAC
+    // because has been found some fonts that provide names not convertible MAC text to UTF8
+    if (name.name_id == TT_NAME_ID_FONT_FAMILY)
+    {
+      const std::string nameEnc{reinterpret_cast<const char*>(name.string), name.string_len};
+
+      if (name.platform_id == TT_PLATFORM_MICROSOFT ||
+          name.platform_id == TT_PLATFORM_APPLE_UNICODE)
+      {
+        if (name.language_id != TT_MAC_LANGID_ENGLISH &&
+            name.language_id != TT_MS_LANGID_ENGLISH_UNITED_STATES &&
+            name.language_id != TT_MS_LANGID_ENGLISH_UNITED_KINGDOM)
+          continue;
+
+        if (CCharsetConverter::utf16BEtoUTF8(nameEnc, familyName))
+          break; // Stop here to prefer the name given with this platform
+        else
+          CLog::LogF(LOGERROR, "Failed to convert the font name string encoded as \"UTF-16BE\"");
+      }
+      else if (name.platform_id == TT_PLATFORM_MACINTOSH && familyName.empty())
+      {
+        if (name.language_id != TT_MAC_LANGID_ENGLISH || name.encoding_id != TT_MAC_ID_ROMAN)
+          continue;
+
+        if (!CCharsetConverter::MacintoshToUTF8(nameEnc, familyName))
+          CLog::LogF(LOGERROR, "Failed to convert the font name string encoded as \"macintosh\"");
+      }
+      else
+      {
+        CLog::LogF(LOGERROR, "Unsupported font SFNT name platform \"{}\"", name.platform_id);
+      }
+    }
+  }
+  return familyName;
+}
+} // unnamed namespace
+
+bool UTILS::FONT::GetFontFamilyNames(const std::vector<uint8_t>& buffer,
+                                     std::set<std::string>& familyNames)
+{
+  FT_Library m_library{nullptr};
+  FT_Init_FreeType(&m_library);
+  if (!m_library)
+  {
+    CLog::LogF(LOGERROR, "Unable to initialize freetype library");
+    return false;
+  }
+
+  FT_Open_Args args{};
+  args.flags = FT_OPEN_MEMORY;
+  args.memory_base = reinterpret_cast<const FT_Byte*>(buffer.data());
+  args.memory_size = static_cast<FT_Long>(buffer.size());
+
+  FT_Long numFaces{0};
+  FT_Long numInstances{0};
+  FT_Long faceIndex{0};
+  FT_Long instanceIndex{0};
+
+  // Iterate over all font faces, files like .ttc (TrueType Collection) contains multiple fonts
+  do
+  {
+    FT_Long idx = (instanceIndex << 16) + faceIndex;
+    FT_Face face{nullptr};
+
+    FT_Error error = FT_Open_Face(m_library, &args, idx, &face);
+    if (error)
+    {
+      CLog::LogF(LOGERROR, "Failed to open font face at index {} error code {}", idx, error);
+      break;
+    }
+
+    std::string familyName = GetFamilyNameFromSfnt(face);
+    if (familyName.empty())
+    {
+      CLog::LogF(LOGWARNING, "Failed to get the unicode family name for \"{}\", fallback to ASCII",
+                 face->family_name);
+      // ASCII font family name may differ from the unicode one, use this as fallback only
+      familyName = std::string{face->family_name};
+      if (familyName.empty())
+      {
+        CLog::LogF(LOGERROR, "Family name missing in the font");
+        return false;
+      }
+    }
+
+    // We use the "set" container to avoid duplicate names that can happens
+    // for example when a font have each style on different files
+    familyNames.insert(familyName);
+
+    numFaces = face->num_faces;
+    numInstances = face->style_flags >> 16;
+
+    FT_Done_Face(face);
+
+    if (instanceIndex < numInstances)
+      instanceIndex++;
+    else
+    {
+      faceIndex++;
+      instanceIndex = 0;
+    }
+
+  } while (faceIndex < numFaces);
+
+  FT_Done_FreeType(m_library);
+  return true;
+}
+
+bool UTILS::FONT::GetFontFamilyNames(const std::string& filepath,
+                                     std::set<std::string>& familyNames)
+{
+  std::vector<uint8_t> buffer;
+  if (filepath.empty())
+    return false;
+
+  if (XFILE::CFile().LoadFile(filepath, buffer) <= 0)
+  {
+    CLog::LogF(LOGERROR, "Failed to load file {}", filepath);
+    return false;
+  }
+  return GetFontFamilyNames(buffer, familyNames);
+}
+
 std::string UTILS::FONT::GetFontFamily(std::vector<uint8_t>& buffer)
 {
   FT_Library m_library{nullptr};
@@ -41,48 +182,15 @@ std::string UTILS::FONT::GetFontFamily(std::vector<uint8_t>& buffer)
   if (FT_New_Memory_Face(m_library, reinterpret_cast<const FT_Byte*>(buffer.data()), buffer.size(),
                          0, &face) == 0)
   {
-    // Get SFNT table entries to get font properties
-    for (FT_UInt index = 0; index < FT_Get_Sfnt_Name_Count(face); index++)
-    {
-      FT_SfntName name;
-      if (FT_Get_Sfnt_Name(face, index, &name) != 0)
-      {
-        CLog::LogF(LOGWARNING, "Failed to get SFNT name at index {}", index);
-        continue;
-      }
-
-      // Get the unicode font family name (format-specific interface)
-      // In properties there may be one or more font family names encoded for
-      // each platform, we take the first available converting it to UTF-8
-      if (name.name_id == TT_NAME_ID_FONT_FAMILY)
-      {
-        const std::string nameEnc{reinterpret_cast<const char*>(name.string), name.string_len};
-
-        if (name.platform_id == TT_PLATFORM_MICROSOFT ||
-            name.platform_id == TT_PLATFORM_APPLE_UNICODE)
-        {
-          if (!CCharsetConverter::utf16BEtoUTF8(nameEnc, familyName))
-            CLog::LogF(LOGERROR, "Failed to convert the font name string encoded as \"UTF-16BE\"");
-        }
-        else if (name.platform_id == TT_PLATFORM_MACINTOSH)
-        {
-          if (!CCharsetConverter::MacintoshToUTF8(nameEnc, familyName))
-            CLog::LogF(LOGERROR, "Failed to convert the font name string encoded as \"macintosh\"");
-        }
-        else
-        {
-          CLog::LogF(LOGERROR, "Unsupported font SFNT name platform \"{}\"", name.platform_id);
-        }
-        if (!familyName.empty())
-          break;
-      }
-    }
+    familyName = GetFamilyNameFromSfnt(face);
     if (familyName.empty())
     {
       CLog::LogF(LOGWARNING, "Failed to get the unicode family name for \"{}\", fallback to ASCII",
                  face->family_name);
       // ASCII font family name may differ from the unicode one, use this as fallback only
       familyName = std::string{face->family_name};
+      if (familyName.empty())
+        CLog::LogF(LOGERROR, "Family name missing in the font");
     }
   }
   else

--- a/xbmc/utils/FontUtils.h
+++ b/xbmc/utils/FontUtils.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <set>
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -16,7 +17,7 @@ namespace UTILS
 {
 namespace FONT
 {
-constexpr const char* SUPPORTED_EXTENSIONS_MASK = ".ttf|.otf";
+constexpr const char* SUPPORTED_EXTENSIONS_MASK = ".ttf|.ttc|.otf";
 
 // The default application font
 constexpr const char* FONT_DEFAULT_FILENAME = "arial.ttf";
@@ -40,14 +41,34 @@ std::string GetSystemFontPath(const std::string& filename);
 }; // namespace FONTPATH
 
 /*!
- *  \brief Get the font family name from a font file
+ *  \brief Get the font family name from a font file,
+ *         in case of font collection (.ttc) will take the family name of all fonts
+ *  \param buffer The font data
+ *  \param familyNames The font family names
+ *  \return True if success, otherwise false when an error occurs
+ */
+bool GetFontFamilyNames(const std::vector<uint8_t>& buffer, std::set<std::string>& familyNames);
+
+/*!
+ *  \brief Get the font family name from a font file,
+ *         in case of font collection (.ttc) will take the family name of all fonts
+ *  \param filepath The path where read the font data
+ *  \param familyNames The font family names
+ *  \return True if success, otherwise false when an error occurs
+ */
+bool GetFontFamilyNames(const std::string& filepath, std::set<std::string>& familyNames);
+
+/*!
+ *  \brief Get the font family name from a font file,
+ *         in case of font collection (.ttc) will take the first available
  *  \param buffer The font data
  *  \return The font family name, otherwise empty if fails
  */
 std::string GetFontFamily(std::vector<uint8_t>& buffer);
 
 /*!
- *  \brief Get the font family name from a font file
+ *  \brief Get the font family name from a font file,
+ *         in case of font collection (.ttc) will take the first available
  *  \param filepath The path where read the font data
  *  \return The font family name, otherwise empty if fails
  */


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This PR add support to use font collection (.ttc) to subtitles
since .ttc contains more fonts, we need to inspect the file to get family name of each font

this format is already supported in to libass renderer but we have not allowed his use
that lead to the problem with mkv's where user opened issue

this code change
- fix the problem that mkv was not extracting .ttc files
- allow load .ttc from the "fonts" folder to allow show each font contained, in the subtitles fonts list setting menu

the results in the fontcache.xml will be as follow:
```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
<fonts>
    <font>
        <filename>DFMrg9.ttc</filename>
        <familyname>DFGMaruGothic-SB</familyname>
        <familyname>DFMaruGothic-SB</familyname>
        <familyname>DFPMaruGothic-SB</familyname>
    </font>
    <font>
        <filename>Helvetica.ttc</filename>
        <familyname>.Helvetica Light</familyname>
        <familyname>Helvetica</familyname>
    </font>
    <font>
        <filename>wqy-microhei.ttc</filename>
        <familyname>WenQuanYi Micro Hei</familyname>
        <familyname>WenQuanYi Micro Hei Mono</familyname>
    </font>
</fonts>
```

NOTE 1: the DFMrg9.ttc file on zip below contains multiple font familynames for different architectures on each font,
but for some reason to me unknown with this particular fonts kodi is not able to convert the familyname enoceded "macintosh" to uft8, i tried use fontforge to check fonts, but i have not found problems and i have no idea where is the problem (could be also on freetype library). So for now i prioritized the family name set for MS/APPLE platforms then use MAC as fallback, in this way we can workaround it.

NOTE 2: i add fontfamily name selection from "english" field that should be always filled, this for two reasons, prevent possible problems of "tofu" chars appears in the GUI font list, kodi dont support multilanguage GUI, and avoid add a encoding mapping to decode each language with iconv, if there will be problems on particular use cases it will be addressed when reported

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #23402
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested mkv provided in the issue that embed an ass subtitle + fonts
tested .ttc fonts with srt subtitles by using fonts on zip [Fonts.zip](https://github.com/xbmc/xbmc/files/11833493/Fonts.zip)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Allow users to use .ttc files and display font correctly
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
