### PR TITLE
Windowing: fix dialog confirmation not showing when moving fullscreen…

### DIFF
--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -310,7 +310,6 @@ bool CDisplaySettings::OnSettingChanging(const std::shared_ptr<const CSetting>& 
           std::static_pointer_cast<const CSettingString>(setting)->GetValue();
       const unsigned int screenIdx = winSystem->GetScreenId(screen);
       winSystem->MoveToScreen(screenIdx);
-      m_resolutionChangeAborted = true;
     }
     winSystem->UpdateResolutions();
     RESOLUTION newRes = GetResolutionForScreen();


### PR DESCRIPTION
… window

## Description
This fixes a small regression introduced in https://github.com/xbmc/xbmc/commit/15f6e65880889f9564c5b42fdc0ad1776875e51f (https://github.com/xbmc/xbmc/pull/23335) where the dialog confirmation was not shown when selecting a different monitor in display settings (and running fullscreen).

@CrystalP since this was reported by you it'd be nice if you can confirm the fix/runtime test on windows. Sorry for the small amount of time this took (not easy with a baby screaming every two hours :) )

## Motivation and context
Keep previous behaviour.

## How has this been tested?
Runtime tested on macos (nativewindowing)

## What is the effect on users?
Dialog is shown when moving the window from settings between screens

## Screenshots (if appropriate):
<img width="1459" alt="image" src="https://github.com/xbmc/xbmc/assets/7375276/40a23ef1-0f6a-4b95-9a36-da1a21530142">

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

