### PR TITLE
[macOS] Default to nativewindowing

### DIFF
--- a/docs/README.macOS.md
+++ b/docs/README.macOS.md
@@ -114,9 +114,9 @@ make -j$(getconf _NPROCESSORS_ONLN)
 ./configure --host=x86_64-apple-darwin --with-platform=macos --with-sdk=10.14
 ```
 
-Developers can also select native windowing/input handling with the following
+Developers can also select the legacy SDL windowing/input handling with the following
 ```
-./configure --host=x86_64-apple-darwin --with-platform=macos --with-windowsystem=native
+./configure --host=x86_64-apple-darwin --with-platform=macos --with-windowsystem=sdl
 ```
 
 ### 4.1. Advanced Configure Options
@@ -189,7 +189,7 @@ Developers can also select native windowing/input handling with the following
 ```
 --with-windowsystem=<native:sdl>
 ```
-  Windowing system to use (default is sdl when not provided). arm64 MacOS requires native
+  Windowing system to use (default is native windowing when not provided). arm64 MacOS does not support SDL windowing.
 
 ```
 --with-sdk=<sdknumber>
@@ -241,9 +241,9 @@ Generate Xcode project as per configure command in **[Configure and build tools 
 make -C tools/depends/target/cmakebuildsys BUILD_DIR=$HOME/kodi-build GEN=Xcode
 ```
 
-To explicitly select the windowing/input system to use do the following (default is to use SDL if not provided)
+To explicitly select the windowing/input system to use do the following (default is to use native if not provided)
 ```
-make -C tools/depends/target/cmakebuildsys BUILD_DIR=$HOME/kodi-build GEN=Xcode APP_WINDOW_SYSTEM=native
+make -C tools/depends/target/cmakebuildsys BUILD_DIR=$HOME/kodi-build GEN=Xcode APP_WINDOW_SYSTEM=sdl
 ```
 
 **TIP:** BUILD_DIR can be omitted, and project will be created in $HOME/kodi/build

--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -464,13 +464,13 @@ case $host in
         target_minver="10.14"
 
         # check provided window system is valid_sdk
-        # if no window system supplied, default to SDL for now.
+        # if no window system supplied, default to native.
         if test -n "$app_winsystem"; then
           if test "$app_winsystem" != "native" && test "$app_winsystem" != "sdl"; then
             AC_MSG_ERROR(Window system must be native or sdl)
           fi
         else
-          app_winsystem=sdl
+          app_winsystem=native
         fi
       ;;
       aarch64-apple-darwin*)

--- a/tools/depends/target/cmakebuildsys/Makefile
+++ b/tools/depends/target/cmakebuildsys/Makefile
@@ -29,10 +29,10 @@ else
 endif
 
 ifeq ($(OS),osx)
-  ifeq ($(APP_WINDOW_SYSTEM),native)
-    WINDOWSYSTEM=-DAPP_WINDOW_SYSTEM=native
-  else
+  ifeq ($(APP_WINDOW_SYSTEM),sdl)
     WINDOWSYSTEM=-DAPP_WINDOW_SYSTEM=sdl
+  else
+    WINDOWSYSTEM=-DAPP_WINDOW_SYSTEM=native
   endif
 endif
 


### PR DESCRIPTION
## Description
Suggested by @fuzzard, this PR changes the default windowing implementation in macOS to nativewindowing (while still keeping the SDL implementation). The idea is to merge this for alpha3 and if everything goes well until the end of betas then go with the removal of SDL in https://github.com/xbmc/xbmc/pull/22990.

## Motivation and context
See https://github.com/xbmc/xbmc/pull/22990 for the complete description