### PR TITLE
[Windows] DXVAHD: simplifies parameters in CProcessorHD::Open()

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -204,14 +204,14 @@ bool CProcessorHD::IsFormatConversionSupported(DXGI_FORMAT inputFormat,
   return supported == TRUE;
 }
 
-bool CProcessorHD::Open(UINT width, UINT height, const VideoPicture& picture)
+bool CProcessorHD::Open(const VideoPicture& picture)
 {
   Close();
 
   std::unique_lock<CCriticalSection> lock(m_section);
 
-  m_width = width;
-  m_height = height;
+  m_width = picture.iWidth;
+  m_height = picture.iHeight;
   m_color_primaries = static_cast<AVColorPrimaries>(picture.color_primaries);
   m_color_transfer = static_cast<AVColorTransferCharacteristic>(picture.color_transfer);
   const AVPixelFormat av_pixel_format = picture.videoBuffer->GetFormat();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -58,7 +58,7 @@ public:
 
   bool PreInit() const;
   void UnInit();
-  bool Open(UINT width, UINT height, const VideoPicture& picture);
+  bool Open(const VideoPicture& picture);
   void Close();
   bool Render(CRect src, CRect dst, ID3D11Resource* target, CRenderBuffer **views, DWORD flags, UINT frameIdx, UINT rotation, float contrast, float brightness);
   uint8_t PastRefs() const { return std::min(m_procCaps.m_rateCaps.PastFrames, 4u); }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
@@ -147,7 +147,7 @@ bool CRendererDXVA::Configure(const VideoPicture& picture, float fps, unsigned o
 
     // create processor
     m_processor = std::make_unique<DXVA::CProcessorHD>();
-    if (m_processor->PreInit() && m_processor->Open(m_sourceWidth, m_sourceHeight, picture) &&
+    if (m_processor->PreInit() && m_processor->Open(picture) &&
         m_processor->IsFormatSupported(dxgi_format, support_type))
     {
       if (CServiceBroker::GetLogging().IsLogLevelLogged(LOGDEBUG) &&


### PR DESCRIPTION
## Description
DXVAHD: simplifies parameters in `CProcessorHD::Open`

## Motivation and context
Width and height is also present in `VideoPicture`, not need to pass as separate parameters.

## How has this been tested?
Runtime Windows x64

## What is the effect on users?
nothing

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
