### PR TITLE
[Android] Remove unnecessary if and use MediaFormat constants

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.cpp
@@ -366,7 +366,7 @@ bool CDVDAudioCodecAndroidMediaCodec::AddData(const DemuxPacket &packet)
     if (xbmc_jnienv()->ExceptionCheck())
     {
       std::string err = CJNIBase::ExceptionToString();
-      CLog::Log(LOGERROR, "CDVDAudioCodecAndroidMediaCodec::AddData ExceptionCheck \n {}", err);
+      CLog::Log(LOGERROR, "CDVDAudioCodecAndroidMediaCodec::AddData ExceptionCheck: {}", err);
     }
     else if (index >= 0)
     {
@@ -635,7 +635,7 @@ int CDVDAudioCodecAndroidMediaCodec::GetData(uint8_t** dst)
   {
     std::string err = CJNIBase::ExceptionToString();
     CLog::Log(LOGERROR,
-              "CDVDAudioCodecAndroidMediaCodec::GetData ExceptionCheck; dequeueOutputBuffer \n {}",
+              "CDVDAudioCodecAndroidMediaCodec::GetData ExceptionCheck: dequeueOutputBuffer: {}",
               err);
     xbmc_jnienv()->ExceptionDescribe();
     xbmc_jnienv()->ExceptionClear();
@@ -749,20 +749,18 @@ int CDVDAudioCodecAndroidMediaCodec::GetData(uint8_t** dst)
 
 void CDVDAudioCodecAndroidMediaCodec::ConfigureOutputFormat(CJNIMediaFormat* mediaformat)
 {
-  m_samplerate       = 0;
-  m_channels         = 0;
+  m_samplerate = 0;
+  m_channels = 0;
 
-  if (mediaformat->containsKey("sample-rate"))
-    m_samplerate       = mediaformat->getInteger("sample-rate");
-  if (mediaformat->containsKey("channel-count"))
-    m_channels     = mediaformat->getInteger("channel-count");
+  if (mediaformat->containsKey(CJNIMediaFormat::KEY_SAMPLE_RATE))
+    m_samplerate = mediaformat->getInteger(CJNIMediaFormat::KEY_SAMPLE_RATE);
+  if (mediaformat->containsKey(CJNIMediaFormat::KEY_CHANNEL_COUNT))
+    m_channels = mediaformat->getInteger(CJNIMediaFormat::KEY_CHANNEL_COUNT);
 
-#if 1 //defined(DEBUG_VERBOSE)
   CLog::Log(LOGDEBUG,
-            "CDVDAudioCodecAndroidMediaCodec:: "
+            "CDVDAudioCodecAndroidMediaCodec::ConfigureOutputFormat "
             "sample_rate({}), channel_count({})",
             m_samplerate, m_channels);
-#endif
 
   // clear any jni exceptions
   if (xbmc_jnienv()->ExceptionCheck())


### PR DESCRIPTION
## Description
Remove unnecessary `if` used previously for logging.

Also replace in this method the constants used directly by value by the corresponding `MediaFormat` constant names.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
