### PR TITLE
Allow android devices to use the dolby vision decoder even if the display does not report capability.

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -23,6 +23,7 @@
 #include "cores/VideoPlayer/VideoRenderers/RenderManager.h"
 #include "media/decoderfilter/DecoderFilterManager.h"
 #include "messaging/ApplicationMessenger.h"
+#include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/BitstreamConverter.h"
@@ -553,7 +554,7 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
         // ensure HDR10 output if display is not DV capable.
         bool notHasHDR10fallback = (m_hints.dovi.dv_profile == 4 || m_hints.dovi.dv_profile == 5);
 
-        if (mediaCodecSupportsDovi && (displaySupportsDovi || notHasHDR10fallback))
+        if (mediaCodecSupportsDovi && (displaySupportsDovi || notHasHDR10fallback || enforceDVOutput))
         {
           m_mime = "video/dolby-vision";
           m_formatname = isDvhe ? "amc-dvhe" : "amc-dvh1";

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -643,6 +643,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetInt(pElement, "useocclusionquery", m_videoCaptureUseOcclusionQuery, -1, 1);
     XMLUtils::GetBoolean(pElement,"vdpauInvTelecine",m_videoVDPAUtelecine);
     XMLUtils::GetBoolean(pElement,"vdpauHDdeintSkipChroma",m_videoVDPAUdeintSkipChromaHD);
+    XMLUtils::GetBoolean(pElement,"forcedolbyvisionoutput", m_enforceDolbyVisionOutput);
 
     TiXmlElement* pAdjustRefreshrate = pElement->FirstChildElement("adjustrefreshrate");
     if (pAdjustRefreshrate)

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -160,6 +160,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     float m_videoIgnorePercentAtEnd;
     float m_audioApplyDrc;
     unsigned int m_maxPassthroughOffSyncDuration = 10; // when 10 ms off adjust
+    bool m_enforceDolbyVisionOutput = false;
 
     int   m_videoVDPAUScaling;
     float m_videoNonLinStretchRatio;


### PR DESCRIPTION
## Description
Allow android devices to use the dolby vision decoder for dolby vision files regardless of display capability.
Previous PR allowed this then a second reverted it, propose allowing via advancedsettings.xml

Conversations on the forum -
Feature request - https://forum.kodi.tv/showthread.php?tid=373260
Work and testing - https://forum.kodi.tv/showthread.php?tid=371883&pid=3155763#pid3155763
Initial discovery that the code in question was inhibiting the use of the dolby vision decoder resulting in the first PR - https://forum.kodi.tv/showthread.php?tid=371557&pid=3145081#pid3145081

Original PR which allowed this behavior - https://github.com/xbmc/xbmc/pull/22950

Originally committed by fritsch to his fork - https://github.com/fritsch/xbmc/commit/21c41e99a0bbae9f8f1fbd4b285567c4364a3848

## Motivation and context
Video looks better on my own display when using the dolby vision decoder vs the hevc decoder even though the display is only HDR10+, it would seem the dv decoder does a better job of this.

## How has this been tested?
Add advanced setting, observe which decoder is used, with setting on it uses dolby vision decoder, with setting off it does not and behaves "normally"

## What is the effect on users?
Existing users will not be affected as the setting will not be present.
New users will not be affected as the setting will not be present.
Advanced users who wish you utilize the dolby vision decoder to allow hardware tone mapping to their display will benefit from crisper displays and full hardware utilization.
Advanced users who set this erroneously who experience issues as a result only need to remove the setting again.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
