### PR TITLE
[Windows] refactor DXGI_FORMAT to std::string for Debug Info OSD

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
@@ -14,6 +14,7 @@
 #include "VideoRenderers/BaseRenderer.h"
 #include "VideoRenderers/RenderFlags.h"
 #include "cores/VideoPlayer/Buffers/VideoBuffer.h"
+#include "rendering/dx/DirectXHelper.h"
 #include "rendering/dx/RenderContext.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -737,27 +738,8 @@ DEBUG_INFO_VIDEO CRendererBase::GetDebugInfo(int idx)
   if (m_outputShader)
     info.shader = m_outputShader->GetDebugInfo();
 
-  std::string itformat;
-  switch (m_IntermediateTarget.GetFormat())
-  {
-    case DXGI_FORMAT_B8G8R8A8_UNORM:
-      itformat = "BGRA8";
-      break;
-    case DXGI_FORMAT_R10G10B10A2_UNORM:
-      itformat = "RGBA10";
-      break;
-    case DXGI_FORMAT_R16G16B16A16_FLOAT:
-      itformat = "FP16";
-      break;
-    case DXGI_FORMAT_R32G32B32A32_FLOAT:
-      itformat = "FP32";
-      break;
-    default:
-      itformat = "unknown";
-  }
-
-  info.render =
-      StringUtils::Format("Render method: {}, IT format: {}", m_renderMethodName, itformat);
+  info.render = StringUtils::Format("Render method: {}, IT format: {}", m_renderMethodName,
+                                    DX::DXGIFormatToShortString(m_IntermediateTarget.GetFormat()));
 
   std::string rmInfo = GetRenderMethodDebugInfo();
   if (!rmInfo.empty())

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -1413,7 +1413,7 @@ DEBUG_INFO_RENDER DX::DeviceResources::GetDebugInfo() const
       (md.ScanlineOrdering > DXGI_MODE_SCANLINE_ORDER_PROGRESSIVE) ? "i" : "p",
       static_cast<double>(md.RefreshRate.Numerator) /
           static_cast<double>(md.RefreshRate.Denominator),
-      (desc.Format == DXGI_FORMAT_R10G10B10A2_UNORM) ? "R10G10B10A2" : "B8G8R8A8", bits,
+      DXGIFormatToShortString(desc.Format), bits,
       DX::Windowing()->UseLimitedColor() ? "limited" : "full", range_min, range_max);
 
   return info;

--- a/xbmc/rendering/dx/DirectXHelper.h
+++ b/xbmc/rendering/dx/DirectXHelper.h
@@ -124,6 +124,23 @@ namespace DX
     return name;
   }
 
+  constexpr std::string_view DXGIFormatToShortString(const DXGI_FORMAT format)
+  {
+    switch (format)
+    {
+      case DXGI_FORMAT_B8G8R8A8_UNORM:
+        return "BGRA8";
+      case DXGI_FORMAT_R10G10B10A2_UNORM:
+        return "RGBA10";
+      case DXGI_FORMAT_R16G16B16A16_FLOAT:
+        return "FP16";
+      case DXGI_FORMAT_R32G32B32A32_FLOAT:
+        return "FP32";
+      default:
+        return "unknown";
+    }
+  }
+
   template <typename T> struct SizeGen
   {
     SizeGen<T>() { Width = Height = 0; }

--- a/xbmc/rendering/dx/DirectXHelper.h
+++ b/xbmc/rendering/dx/DirectXHelper.h
@@ -102,26 +102,21 @@ namespace DX
     return StringUtils::Format("D3D_FEATURE_LEVEL_{}_{}", fl_major, fl_minor);
   }
 
-  inline std::string GetGFXProviderName(UINT vendorId)
+  constexpr std::string_view GetGFXProviderName(UINT vendorId)
   {
-    std::string name;
     switch (vendorId)
     {
       case PCIV_AMD:
-        name = "AMD";
-        break;
+        return "AMD";
       case PCIV_Intel:
-        name = "Intel";
-        break;
+        return "Intel";
       case PCIV_NVIDIA:
-        name = "NVIDIA";
-        break;
+        return "NVIDIA";
       case PCIV_MICROSOFT:
-        name = "Microsoft";
-        break;
+        return "Microsoft";
+      default:
+        return "unknown";
     }
-
-    return name;
   }
 
   constexpr std::string_view DXGIFormatToShortString(const DXGI_FORMAT format)


### PR DESCRIPTION
## Description

- Move DXGI_FORMAT to string code to `DirectXHelper.cpp` to reuse same code in `DeviceResources.cpp` and `RendererBase.cpp`.
- Simplify a bit `GetGFXProviderName`.

## Motivation and context
Simplify and code reuse

## How has this been tested?
Runtime Windows x64

## What is the effect on users?
none

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
