### PR TITLE
[Windows] refactor Video Super Resolution

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -81,11 +81,6 @@ void CProcessorHD::Close()
   m_pVideoProcessor = nullptr;
   m_pVideoContext = nullptr;
   m_pVideoDevice = nullptr;
-
-  // restores 10 bit swap chain if previously forced to 8 bit
-  if (m_forced8bit)
-    DX::DeviceResources::Get()->ApplyDisplaySettings();
-
   m_superResolutionEnabled = false;
 }
 
@@ -863,15 +858,6 @@ void CProcessorHD::TryEnableVideoSuperResolution()
 {
   if (!m_pVideoContext || !m_pVideoProcessor)
     return;
-
-  const DXGI_FORMAT format = DX::Windowing()->GetBackBuffer().GetFormat();
-
-  if (format == DXGI_FORMAT_R10G10B10A2_UNORM)
-  {
-    // force 8 bit swap chain temporally as NVIDIA Super Resolution not supports 10 bit
-    DX::DeviceResources::Get()->ApplyDisplaySettings(true);
-    m_forced8bit = true;
-  }
 
   DXGI_ADAPTER_DESC ad{};
   DX::DeviceResources::Get()->GetAdapterDesc(&ad);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -155,7 +155,6 @@ protected:
   DXGI_FORMAT m_input_dxgi_format{DXGI_FORMAT_UNKNOWN};
   DXGI_FORMAT m_output_dxgi_format{DXGI_FORMAT_UNKNOWN};
 
-  bool m_forced8bit{false};
   bool m_superResolutionEnabled{false};
 };
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
@@ -342,14 +342,8 @@ bool CRendererBase::CreateIntermediateTarget(unsigned width,
                                              bool dynamic,
                                              DXGI_FORMAT format)
 {
-  // No format specified by renderer or high precision disabled > mirror swap chain's backbuffer format
-  const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-
-  if (!settings)
-    return false;
-
-  if (format == DXGI_FORMAT_UNKNOWN ||
-      !settings->GetBool(CSettings::SETTING_VIDEOPLAYER_HIGHPRECISIONPROCESSING))
+  // No format specified by renderer
+  if (format == DXGI_FORMAT_UNKNOWN)
     format = DX::Windowing()->GetBackBuffer().GetFormat();
 
   // don't create new one if it exists with requested size and format

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
@@ -738,8 +738,10 @@ DEBUG_INFO_VIDEO CRendererBase::GetDebugInfo(int idx)
   if (m_outputShader)
     info.shader = m_outputShader->GetDebugInfo();
 
-  info.render = StringUtils::Format("Render method: {}, IT format: {}", m_renderMethodName,
-                                    DX::DXGIFormatToShortString(m_IntermediateTarget.GetFormat()));
+  info.render =
+      StringUtils::Format("Render method: {}, IT: {}x{} {}", m_renderMethodName,
+                          m_IntermediateTarget.GetWidth(), m_IntermediateTarget.GetHeight(),
+                          DX::DXGIFormatToShortString(m_IntermediateTarget.GetFormat()));
 
   std::string rmInfo = GetRenderMethodDebugInfo();
   if (!rmInfo.empty())

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
@@ -478,6 +478,11 @@ DXGI_FORMAT CRendererDXVA::CalcIntermediateTargetFormat(const VideoPicture& pict
   if (!m_processor)
     return format;
 
+  const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+
+  if (!settings || !settings->GetBool(CSettings::SETTING_VIDEOPLAYER_HIGHPRECISIONPROCESSING))
+    return format;
+
   // Preserve HDR precision
   if (picture.colorBits > 8 && (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
                                 picture.color_transfer == AVCOL_TRC_ARIB_STD_B67))

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
@@ -48,7 +48,7 @@ protected:
 private:
   void FillBuffersSet(CRenderBuffer* (&buffers)[8]);
   CRect ApplyTransforms(const CRect& destRect) const;
-  DXGI_FORMAT CalcIntermediateTargetFormat(const VideoPicture& picture) const;
+  DXGI_FORMAT CalcIntermediateTargetFormat(const VideoPicture& picture, bool tryVSR) const;
 
   std::unique_ptr<DXVA::CProcessorHD> m_processor;
   DXGI_FORMAT m_intermediateTargetFormat{DXGI_FORMAT_UNKNOWN};

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererShaders.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererShaders.cpp
@@ -10,6 +10,8 @@
 
 #include "DVDCodecs/Video/DXVA.h"
 #include "rendering/dx/RenderContext.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/CPUInfo.h"
 #ifndef _M_ARM
   #include "utils/gpu_memcpy_sse4.h"
@@ -207,6 +209,11 @@ DXGI_FORMAT CRendererShaders::CalcIntermediateTargetFormat(const VideoPicture& p
 {
   // Default value: same as the back buffer
   DXGI_FORMAT format{DX::Windowing()->GetBackBuffer().GetFormat()};
+
+  const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+
+  if (!settings || !settings->GetBool(CSettings::SETTING_VIDEOPLAYER_HIGHPRECISIONPROCESSING))
+    return format;
 
   // Preserve HDR precision
   if (picture.colorBits > 8 && (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Set the intermediate target format to RGB8 when required for VSR, instead of recreating the swap chain. This takes advantage of recent PR to decouple the intermediate target format from the backbuffers.
- VSR has priority when choosing a format, otherwise it won't engage.
- let the render methods handle the "High precision processing" setting, otherwise RenderBase would sometimes override 8 bit for VSR back to 10 bits
- added intermediate target size in video debug osd, makes it a bit easier to follow activation of dxva scaler. Idea for future PR: add the current scaler to video debug OSD.

known limitations: format / VSR activation are set once when starting playback regardless of current scaler, and don't react to scaler or VSR setting change during playback. This is the same as the original code, could be improved in other PR. full vs limited output range may also need to be tested in IsSuperResolutionSuitable()

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Recreating the swap chain when video super resolution needs 8 bit processor output rather than 10 works but is heavy handed and couples intermediate steps of the processing chain with the output.

Should help with future PR for dynamic enable/disable of VSR during playback, 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 10, AMD (no VSR), Intel gen13 (has VSR)
Pixel Shader and DXVA render methods, with combinations of VSR, "use 10 bit for SDR" and "High precision processing"
No change in behavior noticed.

Don't have nVidia HW to test.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
none. Decouples the steps of the rendering chain.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
