### PR TITLE
[PVR] Fix some CPPCheck and clang-tidy warnings

### DIFF
--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -320,7 +320,7 @@ bool CPVRClient::GetAddonProperties()
   std::unique_lock<CCriticalSection> lock(m_critSection);
   m_clientCapabilities = addonCapabilities;
 
-  return retVal == PVR_ERROR_NO_ERROR;
+  return true;
 }
 
 bool CPVRClient::GetAddonNameStringProperties()

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -370,7 +370,7 @@ bool CGUIDialogPVRChannelManager::OnClickButtonEditName()
     CFileItemPtr pItem = m_channelItems->Get(m_iSelected);
     if (pItem)
     {
-      std::string label = msg.GetLabel();
+      const std::string& label = msg.GetLabel();
       if (pItem->GetProperty(PROPERTY_CHANNEL_NAME).asString() != label)
       {
         pItem->SetProperty(PROPERTY_CHANNEL_NAME, label);

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -481,11 +481,8 @@ bool CGUIDialogPVRGroupManager::OnActionMove(const CAction& action)
       {
         if (iSelected != m_iSelectedChannelGroup)
         {
-          if (iSelected != m_iSelectedChannelGroup)
-          {
-            m_iSelectedChannelGroup = iSelected;
-            Update();
-          }
+          m_iSelectedChannelGroup = iSelected;
+          Update();
         }
       }
       else


### PR DESCRIPTION
Just fixes some warning I came across recently.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish can you please take a look at the code changes?