### PR TITLE
[video] Fix auto play next video not working from inside video info dialog

### DIFF
--- a/xbmc/video/VideoUtils.cpp
+++ b/xbmc/video/VideoUtils.cpp
@@ -396,9 +396,8 @@ bool IsAutoPlayNextItem(const std::string& content)
   return setting && CSettingUtils::FindIntInList(setting, settingValue);
 }
 
-void PlayItem(
-    const std::shared_ptr<CFileItem>& itemIn,
-    ContentUtils::PlayMode mode /* = ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_VIDEO */)
+void PlayItem(const std::shared_ptr<CFileItem>& itemIn,
+              ContentUtils::PlayMode mode /* = ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM */)
 {
   auto item = itemIn;
 

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -739,9 +739,8 @@ void CGUIDialogVideoInfo::Play(bool resume)
       Open();
       return;
     }
-    m_movieItem->SetProperty("playlist_type_hint", PLAYLIST::TYPE_VIDEO);
 
-    pWindow->PlayMovie(m_movieItem.get());
+    pWindow->PlayMedia(m_movieItem);
   }
 }
 

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1086,10 +1086,7 @@ bool CGUIWindowVideoBase::OnPlayMedia(int iItem, const std::string &player)
   }
   CLog::Log(LOGDEBUG, "{} {}", __FUNCTION__, CURL::GetRedacted(item.GetPath()));
 
-  item.SetProperty("playlist_type_hint", m_guiState->GetPlaylist());
-
-  PlayMovie(&item, player);
-
+  PlayMedia(pItem, player, ContentUtils::PlayMode::PLAY_ONLY_THIS);
   return true;
 }
 
@@ -1110,12 +1107,16 @@ bool CGUIWindowVideoBase::OnPlayAndQueueMedia(const CFileItemPtr& item, const st
   return CGUIMediaWindow::OnPlayAndQueueMedia(movieItem, player);
 }
 
-void CGUIWindowVideoBase::PlayMovie(const CFileItem *item, const std::string &player)
+void CGUIWindowVideoBase::PlayMedia(const std::shared_ptr<CFileItem>& item,
+                                    const std::string& player,
+                                    ContentUtils::PlayMode mode)
 {
   if(m_thumbLoader.IsLoading())
     m_thumbLoader.StopAsync();
 
-  CServiceBroker::GetPlaylistPlayer().Play(std::make_shared<CFileItem>(*item), player);
+  item->SetProperty("playlist_type_hint", m_guiState->GetPlaylist());
+  item->SetProperty("ParentPath", m_vecItems->GetPath());
+  VIDEO_UTILS::PlayItem(item, mode);
 
   const auto& components = CServiceBroker::GetAppComponents();
   const auto appPlayer = components.GetComponent<CApplicationPlayer>();

--- a/xbmc/video/windows/GUIWindowVideoBase.h
+++ b/xbmc/video/windows/GUIWindowVideoBase.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "playlists/PlayListTypes.h"
+#include "utils/ContentUtils.h"
 #include "video/VideoDatabase.h"
 #include "video/VideoThumbLoader.h"
 #include "windows/GUIMediaWindow.h"
@@ -33,7 +34,9 @@ public:
   bool OnMessage(CGUIMessage& message) override;
   bool OnAction(const CAction &action) override;
 
-  void PlayMovie(const CFileItem* item, const std::string& player = "");
+  void PlayMedia(const std::shared_ptr<CFileItem>& item,
+                 const std::string& player = "",
+                 ContentUtils::PlayMode mode = ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM);
 
   virtual void OnItemInfo(const CFileItem& fileItem, ADDON::ScraperPtr& scraper);
 


### PR DESCRIPTION
Fixes #23455 

The code called by the "Play" button of the video info dialog was always  playing only the video of the video info dialog. Now, the play next video automatically settings value is respected here. Change was easy because VIDEO_UTILS already support what what need here. 

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 can you please check the code changes?