### PR TITLE
[Windows] Fix: show 119.88Hz and future higher fractional refresh rates correctly

### DIFF
--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -188,7 +188,7 @@ void DX::DeviceResources::GetDisplayMode(DXGI_MODE_DESC* mode) const
   if (hdmiInfo) // Xbox only
   {
     auto currentMode = hdmiInfo.GetCurrentDisplayMode();
-    AVRational refresh = av_d2q(currentMode.RefreshRate(), 60000);
+    AVRational refresh = av_d2q(currentMode.RefreshRate(), 120000);
     mode->RefreshRate.Numerator = refresh.num;
     mode->RefreshRate.Denominator = refresh.den;
   }

--- a/xbmc/windowing/windows/VideoSyncD3D.cpp
+++ b/xbmc/windowing/windows/VideoSyncD3D.cpp
@@ -128,9 +128,6 @@ float CVideoSyncD3D::GetFps()
   if (m_fps == 0.0)
     m_fps = 60.0f;
 
-  if (m_fps == 23 || m_fps == 29 || m_fps == 59)
-    m_fps++;
-
   return m_fps;
 }
 

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -735,7 +735,7 @@ void CWinSystemWin32::RestoreDesktopResolution(MONITOR_DETAILS* details)
   RESOLUTION_INFO info;
   info.iWidth = details->ScreenWidth;
   info.iHeight = details->ScreenHeight;
-  if (details->RefreshRate == 59 || details->RefreshRate == 29 || details->RefreshRate == 23)
+  if ((details->RefreshRate + 1) % 24 == 0 || (details->RefreshRate + 1) % 30 == 0)
     info.fRefreshRate = static_cast<float>(details->RefreshRate + 1) / 1.001f;
   else
     info.fRefreshRate = static_cast<float>(details->RefreshRate);
@@ -1022,7 +1022,7 @@ void CWinSystemWin32::UpdateResolutions()
   float refreshRate;
   int w = details->ScreenWidth;
   int h = details->ScreenHeight;
-  if( (details->RefreshRate == 59) || (details->RefreshRate == 29) || (details->RefreshRate == 23) )
+  if ((details->RefreshRate + 1) % 24 == 0 || (details->RefreshRate + 1) % 30 == 0)
     refreshRate = static_cast<float>(details->RefreshRate + 1) / 1.001f;
   else
     refreshRate = static_cast<float>(details->RefreshRate);
@@ -1051,7 +1051,7 @@ void CWinSystemWin32::UpdateResolutions()
       continue;
 
     float refresh;
-    if(devmode.dmDisplayFrequency == 59 || devmode.dmDisplayFrequency == 29 || devmode.dmDisplayFrequency == 23)
+    if ((devmode.dmDisplayFrequency + 1) % 24 == 0 || (devmode.dmDisplayFrequency + 1) % 30 == 0)
       refresh = static_cast<float>(devmode.dmDisplayFrequency + 1) / 1.001f;
     else
       refresh = static_cast<float>(devmode.dmDisplayFrequency);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Reused the generic trick of DeviceResources::GetDisplayMode() to detect the fractional rates that need normalization, so that future refresh rates won't need code updates.

In VideoSyncD3D, removed the cases for 23, 29, 59, etc and only left 60Hz for 0 value because it calls DeviceResources::GetDisplayMode to fill the structure, and:
- Windows desktop case, the conversion int to fractional is already done for 23, 29, 59, ... 0 is returned in case of API failure. In all cases the removed if would never match.
- Windows UWP case returns 0 => no match either
- Xbox case, the hdmi API should return the expected fractional or int value already - @thexai confirmation would be appreciated.
Unrelated: maybe Xbox will run into trouble with 120 / 119.88 because of this existing code in DeviceResources::GetDisplayMode:
```
AVRational refresh = av_d2q(currentMode.RefreshRate(), 60000);
```

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fractional rates up to 59.94 are displayed correctly, but 119 is not and shows 119.00Hz instead of 119.88Hz (or 119).
Reported in forum https://forum.kodi.tv/showthread.php?tid=370505

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 10, fullscreen windowed, fullscreen exclusive, windowed modes
Previously working fractional refresh rates still appear correctly, and 119.88 as well.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Cosmetic. Consistency with refresh rate displayed by modern Windows.

## Screenshots (if appropriate):
![image](https://github.com/xbmc/xbmc/assets/489377/62029acb-cd9b-499f-877a-42ff276bca3b)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
