### PR TITLE
[Windows] remove unused extra frame rate doubling for interlaced resolutions in CVideoSyncD3D

### DIFF
--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -44,7 +44,6 @@ using namespace Microsoft::WRL;
 using namespace std::chrono_literals;
 
 CRenderSystemDX::CRenderSystemDX() : CRenderSystemBase()
-  , m_interlaced(false)
 {
   m_bVSync = true;
 

--- a/xbmc/rendering/dx/RenderSystemDX.h
+++ b/xbmc/rendering/dx/RenderSystemDX.h
@@ -56,7 +56,6 @@ public:
 
   // CRenderSystemDX methods
   CGUIShaderDX* GetGUIShader() const { return m_pGUIShader; }
-  bool Interlaced() const { return m_interlaced; }
   bool IsFormatSupport(DXGI_FORMAT format, unsigned int usage) const;
   CRect GetBackBufferRect();
   CD3DTexture& GetBackBuffer();
@@ -83,7 +82,6 @@ protected:
   CCriticalSection m_decoderSection;
 
   // our adapter could change as we go
-  bool m_interlaced;
   bool m_inScene{ false }; ///< True if we're in a BeginScene()/EndScene() block
   bool m_BlendEnabled{ false };
   bool m_ScissorsEnabled{ false };

--- a/xbmc/windowing/windows/VideoSyncD3D.cpp
+++ b/xbmc/windowing/windows/VideoSyncD3D.cpp
@@ -131,10 +131,6 @@ float CVideoSyncD3D::GetFps()
   if (m_fps == 23 || m_fps == 29 || m_fps == 59)
     m_fps++;
 
-  if (DX::Windowing()->Interlaced())
-  {
-    m_fps *= 2;
-  }
   return m_fps;
 }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

The Interlaced() function always returns false anyway due to initialization of m_interlaced to false and no code to change the value. It is not an overriden virtual function and looks like a left over from old code.
For interlaced resolutions, DeviceResources::GetDisplayMode() provides frame rate doubling.

The Xbox code doesn't have frame rate doubling but the hdmi information doesn't signal interlaced resolutions. The Xbox likely doesn't support interlaced resolutions.
@thexai could you confirm?

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Cleanup leftovers of old code.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Don't have a screen that reports interlaced resolutions anymore. No change for progressive resolutions on Windows 10.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
