### PR TITLE
[Windows] Remove unused code in DeviceResources.cpp

### DIFF
--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -638,9 +638,6 @@ void DX::DeviceResources::ResizeBuffers()
     else if (use10bitSetting == 2)
       use10bit = true;
 
-    if (m_force8bit)
-      use10bit = false;
-
     DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {};
     swapChainDesc.Width = lround(m_outputSize.Width);
     swapChainDesc.Height = lround(m_outputSize.Height);
@@ -1368,17 +1365,12 @@ HDR_STATUS DX::DeviceResources::ToggleHDR()
   return hdrStatus;
 }
 
-void DX::DeviceResources::ApplyDisplaySettings(bool force8bit)
+void DX::DeviceResources::ApplyDisplaySettings()
 {
   CLog::LogF(LOGDEBUG, "Re-create swapchain due Display Settings changed");
 
-  if (force8bit)
-    m_force8bit = true;
-
   DestroySwapChain();
   CreateWindowSizeDependentResources();
-
-  m_force8bit = false;
 }
 
 DEBUG_INFO_RENDER DX::DeviceResources::GetDebugInfo() const

--- a/xbmc/rendering/dx/DeviceResources.h
+++ b/xbmc/rendering/dx/DeviceResources.h
@@ -81,7 +81,7 @@ namespace DX
     bool SetFullScreen(bool fullscreen, RESOLUTION_INFO& res);
 
     // Apply display settings changes
-    void ApplyDisplaySettings(bool force8bit = false);
+    void ApplyDisplaySettings();
 
     // HDR display support
     HDR_STATUS ToggleHDR();
@@ -188,6 +188,5 @@ namespace DX
     bool m_DXVA2SharedDecoderSurfaces{false};
     bool m_DXVASuperResolutionSupport{false};
     bool m_usedSwapChain{false};
-    bool m_force8bit{false};
   };
 }


### PR DESCRIPTION
## Description
Remove unused code in DeviceResources.cpp

## Motivation and context
Removes force 8 bit swap chain code not needed/used anymore after https://github.com/xbmc/xbmc/pull/23458

## How has this been tested?
Build Windows x64

## What is the effect on users?
none

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
