### PR TITLE
[input] remove unused tinyxml usage in InputCodineTableFactory

### DIFF
--- a/xbmc/input/InputCodingTableFactory.cpp
+++ b/xbmc/input/InputCodingTableFactory.cpp
@@ -10,11 +10,9 @@
 
 #include "InputCodingTableBasePY.h"
 #include "InputCodingTableKorean.h"
-#include "utils/XBMCTinyXML.h"
 #include "utils/log.h"
 
-IInputCodingTable* CInputCodingTableFactory::CreateCodingTable(const std::string& strTableName,
-                                                               const TiXmlElement* element)
+IInputCodingTable* CInputCodingTableFactory::CreateCodingTable(const std::string& strTableName)
 {
   if (strTableName == "BasePY")
     return new CInputCodingTableBasePY();

--- a/xbmc/input/InputCodingTableFactory.h
+++ b/xbmc/input/InputCodingTableFactory.h
@@ -10,12 +10,10 @@
 
 #include <string>
 
-class TiXmlElement;
 class IInputCodingTable;
 
 class CInputCodingTableFactory
 {
 public:
-  static IInputCodingTable* CreateCodingTable(const std::string& strTableName,
-                                              const TiXmlElement* element);
+  static IInputCodingTable* CreateCodingTable(const std::string& strTableName);
 };

--- a/xbmc/input/KeyboardLayout.cpp
+++ b/xbmc/input/KeyboardLayout.cpp
@@ -53,7 +53,7 @@ bool CKeyboardLayout::Load(const TiXmlElement* element)
   const TiXmlElement* keyboard = element->FirstChildElement("keyboard");
   if (element->Attribute("codingtable"))
     m_codingtable = IInputCodingTablePtr(
-        CInputCodingTableFactory::CreateCodingTable(element->Attribute("codingtable"), element));
+        CInputCodingTableFactory::CreateCodingTable(element->Attribute("codingtable")));
   else
     m_codingtable = NULL;
   while (keyboard != NULL)


### PR DESCRIPTION
## Description
The only use of the timyxml component was removed in https://github.com/xbmc/xbmc/pull/20489

## Motivation and context
Migrating further tinyxml usage to tinyxml2, came across this thats no longer in use. Remove unused method parameter and includes.

## How has this been tested?
Jenkins

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
