### PR TITLE
[Windows] RetroPlayer: Fix blue/pink washed out colors on 10-bit displays

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
@@ -52,6 +52,12 @@ CWinRenderBuffer::CWinRenderBuffer(AVPixelFormat pixFormat, DXGI_FORMAT dxFormat
 {
 }
 
+CWinRenderBuffer::~CWinRenderBuffer()
+{
+  if (m_swsContext != nullptr)
+    sws_freeContext(m_swsContext);
+}
+
 bool CWinRenderBuffer::CreateTexture()
 {
   if (!m_intermediateTarget->Create(m_width, m_height, 1, D3D11_USAGE_DYNAMIC, m_targetDxFormat))

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
@@ -143,12 +143,12 @@ bool CWinRenderBuffer::CreateScalingContext()
   return true;
 }
 
-void CWinRenderBuffer::ScalePixels(uint8_t* source,
+void CWinRenderBuffer::ScalePixels(const uint8_t* source,
                                    unsigned int sourceStride,
                                    uint8_t* target,
                                    unsigned int targetStride)
 {
-  uint8_t* src[] = {source, nullptr, nullptr, nullptr};
+  uint8_t* src[] = {const_cast<uint8_t*>(source), nullptr, nullptr, nullptr};
   int srcStride[] = {static_cast<int>(sourceStride), 0, 0, 0};
   uint8_t* dst[] = {target, nullptr, nullptr, nullptr};
   int dstStride[] = {static_cast<int>(targetStride), 0, 0, 0};

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
@@ -48,7 +48,7 @@ RenderBufferPoolVector CWinRendererFactory::CreateBufferPools(CRenderContext& co
 // --- CWinRenderBuffer --------------------------------------------------------
 
 CWinRenderBuffer::CWinRenderBuffer(AVPixelFormat pixFormat, DXGI_FORMAT dxFormat)
-  : m_pixFormat(pixFormat), m_targetDxFormat(dxFormat), m_targetPixFormat(GetPixFormat(dxFormat))
+  : m_pixFormat(pixFormat), m_targetDxFormat(dxFormat), m_targetPixFormat(GetPixFormat())
 {
 }
 
@@ -162,9 +162,9 @@ void CWinRenderBuffer::ScalePixels(const uint8_t* source,
   sws_scale(m_swsContext, src, srcStride, 0, m_height, dst, dstStride);
 }
 
-AVPixelFormat CWinRenderBuffer::GetPixFormat(DXGI_FORMAT dxFormat)
+AVPixelFormat CWinRenderBuffer::GetPixFormat()
 {
-  return AV_PIX_FMT_BGRA; //! @todo
+  return AV_PIX_FMT_BGRA;
 }
 
 // --- CWinRenderBufferPool ----------------------------------------------------
@@ -184,12 +184,15 @@ IRenderBuffer* CWinRenderBufferPool::CreateRenderBuffer(void* header /* = nullpt
   return new CWinRenderBuffer(m_format, m_targetDxFormat);
 }
 
-bool CWinRenderBufferPool::ConfigureDX(DXGI_FORMAT dxFormat)
+bool CWinRenderBufferPool::ConfigureDX()
 {
   if (m_targetDxFormat != DXGI_FORMAT_UNKNOWN)
     return false; // Already configured
 
-  m_targetDxFormat = dxFormat;
+  // There are three pixel formats used by libretro: 0RGB32, RGB565 and
+  // RGB555. DirectX support for these varies, so always use BGRA32 as the
+  // intermediate format.
+  m_targetDxFormat = DXGI_FORMAT_B8G8R8A8_UNORM;
 
   return true;
 }
@@ -240,9 +243,7 @@ bool CRPWinRenderer::ConfigureInternal()
 {
   CRenderSystemDX* renderingDx = static_cast<CRenderSystemDX*>(m_context.Rendering());
 
-  DXGI_FORMAT targetDxFormat = renderingDx->GetBackBuffer().GetFormat();
-
-  static_cast<CWinRenderBufferPool*>(m_bufferPool.get())->ConfigureDX(targetDxFormat);
+  static_cast<CWinRenderBufferPool*>(m_bufferPool.get())->ConfigureDX();
 
   return true;
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.h
@@ -64,7 +64,7 @@ private:
                    uint8_t* target,
                    unsigned int targetStride);
 
-  static AVPixelFormat GetPixFormat(DXGI_FORMAT dxFormat);
+  static AVPixelFormat GetPixFormat();
 
   // Construction parameters
   const AVPixelFormat m_pixFormat;
@@ -89,7 +89,7 @@ public:
   IRenderBuffer* CreateRenderBuffer(void* header = nullptr) override;
 
   // DirectX interface
-  bool ConfigureDX(DXGI_FORMAT dxFormat);
+  bool ConfigureDX();
   CRPWinOutputShader* GetShader(SCALINGMETHOD scalingMethod) const;
 
 private:

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.h
@@ -46,7 +46,7 @@ class CWinRenderBuffer : public CRenderBufferSysMem
 {
 public:
   CWinRenderBuffer(AVPixelFormat pixFormat, DXGI_FORMAT dxFormat);
-  ~CWinRenderBuffer() override = default;
+  ~CWinRenderBuffer() override;
 
   // implementation of IRenderBuffer via CRenderBufferSysMem
   bool UploadTexture() override;

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.h
@@ -59,7 +59,7 @@ private:
   bool ReleaseTexture();
 
   bool CreateScalingContext();
-  void ScalePixels(uint8_t* source,
+  void ScalePixels(const uint8_t* source,
                    unsigned int sourceStride,
                    uint8_t* target,
                    unsigned int targetStride);


### PR DESCRIPTION
## Description

On Windows, when running in 10-bit colors, the wrong format is chosen when scaling pixels. In fact, of the 10-bit RGB formats that our version of libav supports, none are 1:1 compatible with `DXGI_FORMAT_R10G10B10A2_UNORM`.

I tried writing a manual pixel scaler for 10-bit displays. It worked! So I'm PRing it.

## Motivation and context

Reported here: https://forum.kodi.tv/showthread.php?tid=365817

## How has this been tested?

Included in my latest round of test builds: https://github.com/garbear/xbmc/releases

Tested on 4k Samsung QLED TV in 10-bit mode.

Before: washed out colors using RGB565

After: correct colors using RGB565

Tested a game with 0RGB32 pixels:

![screenshot00006](https://github.com/xbmc/xbmc/assets/531482/7e9ff0b0-a336-4198-bad3-e0900582fd6c)

## What is the effect on users?

Fixes blue/pink washed out colors on 10-bit displays on Windows.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
