### PR TITLE
Peripheral API v3.0.1: Expose keyboard/mouse types to add-on

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/peripheral.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/peripheral.h
@@ -77,6 +77,9 @@ extern "C"
 
     /// @brief Type declared as keyboard.
     PERIPHERAL_TYPE_KEYBOARD,
+
+    /// @brief Type declared as mouse.
+    PERIPHERAL_TYPE_MOUSE,
   } PERIPHERAL_TYPE;
   ///@}
   //----------------------------------------------------------------------------

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -124,7 +124,7 @@
                                                       "addon-instance/inputstream/StreamCrypto.h" \
                                                       "addon-instance/inputstream/TimingConstants.h"
 
-#define ADDON_INSTANCE_VERSION_PERIPHERAL             "3.0.0"
+#define ADDON_INSTANCE_VERSION_PERIPHERAL             "3.0.1"
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_MIN         "3.0.0"
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_XML_ID      "kodi.binary.instance.peripheral"
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_DEPENDS     "addon-instance/Peripheral.h" \

--- a/xbmc/games/controllers/input/PhysicalFeature.cpp
+++ b/xbmc/games/controllers/input/PhysicalFeature.cpp
@@ -94,7 +94,7 @@ bool CPhysicalFeature::Deserialize(const TiXmlElement* pElement,
     return false;
   }
 
-  // Cagegory was obtained from parent XML node
+  // Category was obtained from parent XML node
   m_category = category;
   m_categoryLabelId = categoryLabelId;
 

--- a/xbmc/peripherals/addons/PeripheralAddonTranslator.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddonTranslator.cpp
@@ -55,6 +55,10 @@ PeripheralType CPeripheralAddonTranslator::TranslateType(PERIPHERAL_TYPE type)
   {
     case PERIPHERAL_TYPE_JOYSTICK:
       return PERIPHERAL_JOYSTICK;
+    case PERIPHERAL_TYPE_KEYBOARD:
+      return PERIPHERAL_KEYBOARD;
+    case PERIPHERAL_TYPE_MOUSE:
+      return PERIPHERAL_MOUSE;
     default:
       break;
   }
@@ -67,6 +71,10 @@ PERIPHERAL_TYPE CPeripheralAddonTranslator::TranslateType(PeripheralType type)
   {
     case PERIPHERAL_JOYSTICK:
       return PERIPHERAL_TYPE_JOYSTICK;
+    case PERIPHERAL_KEYBOARD:
+      return PERIPHERAL_TYPE_KEYBOARD;
+    case PERIPHERAL_MOUSE:
+      return PERIPHERAL_TYPE_MOUSE;
     default:
       break;
   }


### PR DESCRIPTION
## Description

In https://github.com/xbmc/xbmc/pull/22856, I added the ability to set a peripheral's "appearance".

In the joystick add-on, when looking up the appearance, the full peripheral's properties are used. However, upon inspection in a debugger, I noticed that the joystick add-on saw mice and keyboards as UNKNOWN.

While no bugs currently arise do to the missing types, we should add them for future use by the add-on.

## How has this been tested?

Included in my latest round of test builds: https://github.com/garbear/xbmc/releases

Tested in the debugger.

Before: When querying the apperaance of mice and keyboards, the joystick sees the peripheral's type as UNKNOWN.

After: The joystick sees the type of mice and keyboards correctly as MOUSE or KEYBOARD, respectively.

## What is the effect on users?

None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
