### PR TITLE
[addons] fix debug assert because of non-deterministic comparison of dependencies

### DIFF
--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -895,13 +895,29 @@ void CGUIDialogAddonInfo::BuildDependencyList()
                 return a.m_depInfo.optional;
               }
 
-              // 3. scripts/modules to bottom
+              // 3. addon type asc, except scripts/modules at the bottom
               const std::shared_ptr<IAddon>& depA = a.m_installed ? a.m_installed : a.m_available;
               const std::shared_ptr<IAddon>& depB = b.m_installed ? b.m_installed : b.m_available;
 
-              if (depA && depB && depA->MainType() != depB->MainType())
+              if (depA && depB)
               {
-                return depA->MainType() != AddonType::SCRIPT_MODULE;
+                const AddonType typeA = depA->MainType();
+                const AddonType typeB = depB->MainType();
+                if (typeA != typeB)
+                {
+                  if ((typeA == AddonType::SCRIPT_MODULE) == (typeB == AddonType::SCRIPT_MODULE))
+                  {
+                    // both are scripts/modules or neither one is => sort by addon type asc
+                    return typeA < typeB;
+                  }
+                  else
+                  {
+                    // At this point, either:
+                    // A is script/module and B is not, or A is not script/module and B is.
+                    // the script/module goes to the bottom
+                    return typeA != AddonType::SCRIPT_MODULE;
+                  }
+                }
               }
 
               // 4. finally order by addon-id


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

The sort of addon dependencies with the same installed/available and optional attributes was not deterministic because it was only comparing the type of a with AddonType::SCRIPT_MODULE.
When a and b are SCRIPT_MODULE, or neither one is, pred(a,b) == pred(b,a), which triggers an assert in debug mode on Windows.

The change adds a comparison of the type of a and b when they're both SCRIPT_MODULE or neither one is, for a deterministic comparison.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Frequent asserts when attempting to download / install addons in debug mode in Windows.

![image](https://github.com/xbmc/xbmc/assets/489377/ee4e43ea-81f4-41d2-af07-1c6ece50bcee)

Happens because the comparison of (a,b) returns the same result as the comparison of (b,a)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Attempting to install the same addons now works - but I don't know much about addons and would appreciate another pair of eyes on this or help to provide better test coverage.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Not much, there was no assert() in release mode. The sort order of addon dependencies will be more consistent.

## Screenshots (if appropriate):
Before, press Enter on the skin item:
![image](https://github.com/xbmc/xbmc/assets/489377/9726947d-05a3-42f4-9c8e-db088f0e15bd)

With PR, the addon info page appears and the dependencies are listed in expected order:
![image](https://github.com/xbmc/xbmc/assets/489377/d502b222-6fa3-4271-a3d9-bbe698340f77)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
