### PR TITLE
[video] Take 2 to fix auto play next video not working from inside video info dialog.

### DIFF
--- a/xbmc/video/VideoUtils.cpp
+++ b/xbmc/video/VideoUtils.cpp
@@ -396,8 +396,9 @@ bool IsAutoPlayNextItem(const std::string& content)
   return setting && CSettingUtils::FindIntInList(setting, settingValue);
 }
 
-void PlayItem(const std::shared_ptr<CFileItem>& itemIn,
-              ContentUtils::PlayMode mode /* = ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM */)
+void PlayItem(
+    const std::shared_ptr<CFileItem>& itemIn,
+    ContentUtils::PlayMode mode /* = ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_VIDEO */)
 {
   auto item = itemIn;
 

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -739,8 +739,9 @@ void CGUIDialogVideoInfo::Play(bool resume)
       Open();
       return;
     }
+    m_movieItem->SetProperty("playlist_type_hint", PLAYLIST::TYPE_VIDEO);
 
-    pWindow->PlayMedia(m_movieItem);
+    pWindow->PlayMovie(m_movieItem.get());
   }
 }
 

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -52,6 +52,7 @@
 #include "video/VideoInfoTag.h"
 #include "video/VideoLibraryQueue.h"
 #include "video/VideoThumbLoader.h"
+#include "video/VideoUtils.h"
 #include "video/tags/VideoTagLoaderFFmpeg.h"
 #include "video/windows/GUIWindowVideoNav.h"
 
@@ -726,23 +727,26 @@ void CGUIDialogVideoInfo::Play(bool resume)
     return;
   }
 
-  CGUIWindowVideoNav* pWindow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowVideoNav>(WINDOW_VIDEO_NAV);
-  if (pWindow)
-  {
-    // close our dialog
-    Close(true);
-    if (resume)
-      m_movieItem->SetStartOffset(STARTOFFSET_RESUME);
-    else if (!CGUIWindowVideoBase::ShowResumeMenu(*m_movieItem))
-    {
-      // The Resume dialog was closed without any choice
-      Open();
-      return;
-    }
-    m_movieItem->SetProperty("playlist_type_hint", PLAYLIST::TYPE_VIDEO);
+  // close our dialog
+  Close(true);
 
-    pWindow->PlayMovie(m_movieItem.get());
+  if (resume)
+  {
+    m_movieItem->SetStartOffset(STARTOFFSET_RESUME);
   }
+  else if (!CGUIWindowVideoBase::ShowResumeMenu(*m_movieItem))
+  {
+    // The Resume dialog was closed without any choice
+    Open();
+    return;
+  }
+
+  m_movieItem->SetProperty("playlist_type_hint", PLAYLIST::TYPE_VIDEO);
+
+  const ContentUtils::PlayMode mode = m_movieItem->GetProperty("CheckAutoPlayNextItem").asBoolean()
+                                          ? ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM
+                                          : ContentUtils::PlayMode::PLAY_ONLY_THIS;
+  VIDEO_UTILS::PlayItem(m_movieItem, mode);
 }
 
 namespace

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1086,7 +1086,10 @@ bool CGUIWindowVideoBase::OnPlayMedia(int iItem, const std::string &player)
   }
   CLog::Log(LOGDEBUG, "{} {}", __FUNCTION__, CURL::GetRedacted(item.GetPath()));
 
-  PlayMedia(pItem, player, ContentUtils::PlayMode::PLAY_ONLY_THIS);
+  item.SetProperty("playlist_type_hint", m_guiState->GetPlaylist());
+
+  PlayMovie(&item, player);
+
   return true;
 }
 
@@ -1107,16 +1110,12 @@ bool CGUIWindowVideoBase::OnPlayAndQueueMedia(const CFileItemPtr& item, const st
   return CGUIMediaWindow::OnPlayAndQueueMedia(movieItem, player);
 }
 
-void CGUIWindowVideoBase::PlayMedia(const std::shared_ptr<CFileItem>& item,
-                                    const std::string& player,
-                                    ContentUtils::PlayMode mode)
+void CGUIWindowVideoBase::PlayMovie(const CFileItem *item, const std::string &player)
 {
   if(m_thumbLoader.IsLoading())
     m_thumbLoader.StopAsync();
 
-  item->SetProperty("playlist_type_hint", m_guiState->GetPlaylist());
-  item->SetProperty("ParentPath", m_vecItems->GetPath());
-  VIDEO_UTILS::PlayItem(item, mode);
+  CServiceBroker::GetPlaylistPlayer().Play(std::make_shared<CFileItem>(*item), player);
 
   const auto& components = CServiceBroker::GetAppComponents();
   const auto appPlayer = components.GetComponent<CApplicationPlayer>();

--- a/xbmc/video/windows/GUIWindowVideoBase.h
+++ b/xbmc/video/windows/GUIWindowVideoBase.h
@@ -33,8 +33,6 @@ public:
   bool OnMessage(CGUIMessage& message) override;
   bool OnAction(const CAction &action) override;
 
-  void PlayMovie(const CFileItem* item, const std::string& player = "");
-
   virtual void OnItemInfo(const CFileItem& fileItem, ADDON::ScraperPtr& scraper);
 
 

--- a/xbmc/video/windows/GUIWindowVideoBase.h
+++ b/xbmc/video/windows/GUIWindowVideoBase.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "playlists/PlayListTypes.h"
-#include "utils/ContentUtils.h"
 #include "video/VideoDatabase.h"
 #include "video/VideoThumbLoader.h"
 #include "windows/GUIMediaWindow.h"
@@ -34,9 +33,7 @@ public:
   bool OnMessage(CGUIMessage& message) override;
   bool OnAction(const CAction &action) override;
 
-  void PlayMedia(const std::shared_ptr<CFileItem>& item,
-                 const std::string& player = "",
-                 ContentUtils::PlayMode mode = ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM);
+  void PlayMovie(const CFileItem* item, const std::string& player = "");
 
   virtual void OnItemInfo(const CFileItem& fileItem, ADDON::ScraperPtr& scraper);
 


### PR DESCRIPTION
Followup to #23460, which did not work if playback was started from Estuary home screen items (technically: via `CDirectoryListProvider`). This PR first reverts the initial fix (for better readability of the second commit)  and implements a slightly different fix approach.

Runtime-tested on macOS and Android, latest Kodi.

@enen92 might want to take a look. You only need to look at the second commit. First only reverts the initial fix attempt.