### PR TITLE
[Estuary] Reset timer as long as the osd is shown

### DIFF
--- a/addons/skin.estuary/xml/Timers.xml
+++ b/addons/skin.estuary/xml/Timers.xml
@@ -11,7 +11,7 @@
     <timer>
         <name>1109_topbaroverlay</name>
         <description>A timer that is activated when the topbaroverlay is loaded and stops automatically after 5 seconds (or playback is resumed)</description>
-        <start reset="true">Window.IsActive(1109) + [Player.Seeking | Player.Forwarding | Player.Rewinding | Player.HasPerformedSeek(1)]</start>
+        <start reset="true">[Window.IsActive(videoosd) | Window.IsActive(musicosd) | Window.IsActive(playerprocessinfo)] | [Window.IsActive(1109) + [Player.Seeking | Player.Forwarding | Player.Rewinding | Player.HasPerformedSeek(1)]]</start>
         <reset>Player.Seeking | Player.Forwarding | Player.Rewinding | Player.HasPerformedSeek(1)</reset>
         <stop>Integer.IsGreaterOrEqual(Skin.TimerElapsedSecs(1109_topbaroverlay),5) | Player.Playing</stop>
     </timer>


### PR DESCRIPTION
## Description
This fixes another misbehaviour that I've found while using the topbar overlay of estuary. The timer is started on window load however this dialog is completely tied to the OSD dialog. It is shown when doing seeks, pause, etc but is also shown whenever the OSD is displayed with stuff like muted, the clearart, the title, etc. This means that the timer might elapse as long as the OSD is visible for a couple of seconds. If you pause the video in the video OSD (using the controls) and close the dialog the topbar overlay will be shown forever.

## Motivation and context
Some day we'll have 0 bugs... :)

## How has this been tested?
Same as before, pausing, rewinding, seeking, etc. Checking the dialog is shown and closed after the elapsed time

## What is the effect on users?
Fixes the regression with the topbaroverlay being displayed after a pause in the video OSD.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

