### PR TITLE
[bp][addons] fix debug assert because of non-deterministic comparison of …

### DIFF
--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -896,13 +896,29 @@ void CGUIDialogAddonInfo::BuildDependencyList()
                 return a.m_depInfo.optional;
               }
 
-              // 3. scripts/modules to bottom
+              // 3. addon type asc, except scripts/modules at the bottom
               const std::shared_ptr<IAddon>& depA = a.m_installed ? a.m_installed : a.m_available;
               const std::shared_ptr<IAddon>& depB = b.m_installed ? b.m_installed : b.m_available;
 
-              if (depA && depB && depA->MainType() != depB->MainType())
+              if (depA && depB)
               {
-                return depA->MainType() != AddonType::SCRIPT_MODULE;
+                const AddonType typeA = depA->MainType();
+                const AddonType typeB = depB->MainType();
+                if (typeA != typeB)
+                {
+                  if ((typeA == AddonType::SCRIPT_MODULE) == (typeB == AddonType::SCRIPT_MODULE))
+                  {
+                    // both are scripts/modules or neither one is => sort by addon type asc
+                    return typeA < typeB;
+                  }
+                  else
+                  {
+                    // At this point, either:
+                    // A is script/module and B is not, or A is not script/module and B is.
+                    // the script/module goes to the bottom
+                    return typeA != AddonType::SCRIPT_MODULE;
+                  }
+                }
               }
 
               // 4. finally order by addon-id


### PR DESCRIPTION
…dependencies

## Description
backport of https://github.com/xbmc/xbmc/pull/23469

thx @CrystalP, your review and button

## What is the effect on users?
Not much, there was no assert() in release mode. The sort order of addon dependencies will be more consistent.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
