### PR TITLE
[music][video] Context menu play items: Set playlist_type_hint before…

### DIFF
--- a/xbmc/music/ContextMenus.cpp
+++ b/xbmc/music/ContextMenus.cpp
@@ -72,12 +72,12 @@ bool CMusicPlay::IsVisible(const CFileItem& item) const
 
 bool CMusicPlay::Execute(const std::shared_ptr<CFileItem>& item) const
 {
+  item->SetProperty("playlist_type_hint", PLAYLIST::TYPE_MUSIC);
+
   const ContentUtils::PlayMode mode = item->GetProperty("CheckAutoPlayNextItem").asBoolean()
                                           ? ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM
                                           : ContentUtils::PlayMode::PLAY_ONLY_THIS;
   MUSIC_UTILS::PlayItem(item, mode);
-
-  item->SetProperty("playlist_type_hint", PLAYLIST::TYPE_MUSIC);
   return true;
 }
 

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -185,12 +185,12 @@ void SetPathAndPlay(CFileItem& item)
   }
   else
   {
+    item.SetProperty("playlist_type_hint", PLAYLIST::TYPE_VIDEO);
+
     const ContentUtils::PlayMode mode = item.GetProperty("CheckAutoPlayNextItem").asBoolean()
                                             ? ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM
                                             : ContentUtils::PlayMode::PLAY_ONLY_THIS;
     VIDEO_UTILS::PlayItem(std::make_shared<CFileItem>(item), mode);
-
-    item.SetProperty("playlist_type_hint", PLAYLIST::TYPE_VIDEO);
   }
 }
 } // unnamed namespace


### PR DESCRIPTION
… starting playback, not after.

Fixes just a small stupid mistake I made when I was introducing the code. The property needs to be set before the playback is started to have any effect, not afterwards.

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 something you can review?