### PR TITLE
Games: Stable player assignment

### DIFF
--- a/xbmc/games/addons/input/GameClientInput.cpp
+++ b/xbmc/games/addons/input/GameClientInput.cpp
@@ -471,6 +471,7 @@ bool CGameClientInput::OpenKeyboard(const ControllerPtr& controller,
   {
     m_keyboard =
         std::make_unique<CGameClientKeyboard>(m_gameClient, controller->ID(), keyboard.get());
+    m_keyboard->SetSource(keyboard);
     return true;
   }
 
@@ -539,6 +540,7 @@ bool CGameClientInput::OpenMouse(const ControllerPtr& controller,
   if (bSuccess)
   {
     m_mouse = std::make_unique<CGameClientMouse>(m_gameClient, controller->ID(), mouse.get());
+    m_mouse->SetSource(mouse);
     return true;
   }
 

--- a/xbmc/games/addons/input/GameClientJoystick.cpp
+++ b/xbmc/games/addons/input/GameClientJoystick.cpp
@@ -13,6 +13,7 @@
 #include "games/controllers/Controller.h"
 #include "games/ports/input/PortInput.h"
 #include "input/joysticks/interfaces/IInputReceiver.h"
+#include "peripherals/devices/Peripheral.h"
 #include "utils/log.h"
 
 #include <assert.h>
@@ -167,6 +168,24 @@ bool CGameClientJoystick::OnThrottleMotion(const std::string& feature,
   event.axis.position = position;
 
   return m_gameClient.Input().InputEvent(event);
+}
+
+std::string CGameClientJoystick::GetSourceLocation() const
+{
+  if (m_sourcePeripheral)
+    return m_sourcePeripheral->Location();
+
+  return "";
+}
+
+void CGameClientJoystick::SetSource(PERIPHERALS::PeripheralPtr sourcePeripheral)
+{
+  m_sourcePeripheral = std::move(sourcePeripheral);
+}
+
+void CGameClientJoystick::ClearSource()
+{
+  m_sourcePeripheral.reset();
 }
 
 bool CGameClientJoystick::SetRumble(const std::string& feature, float magnitude)

--- a/xbmc/games/addons/input/GameClientJoystick.cpp
+++ b/xbmc/games/addons/input/GameClientJoystick.cpp
@@ -9,6 +9,7 @@
 #include "GameClientJoystick.h"
 
 #include "GameClientInput.h"
+#include "GameClientTopology.h"
 #include "games/addons/GameClient.h"
 #include "games/controllers/Controller.h"
 #include "games/ports/input/PortInput.h"
@@ -168,6 +169,11 @@ bool CGameClientJoystick::OnThrottleMotion(const std::string& feature,
   event.axis.position = position;
 
   return m_gameClient.Input().InputEvent(event);
+}
+
+std::string CGameClientJoystick::GetControllerAddress() const
+{
+  return CGameClientTopology::MakeAddress(m_portAddress, m_controller->ID());
 }
 
 std::string CGameClientJoystick::GetSourceLocation() const

--- a/xbmc/games/addons/input/GameClientJoystick.h
+++ b/xbmc/games/addons/input/GameClientJoystick.h
@@ -76,6 +76,7 @@ public:
   // Input accessors
   const std::string& GetPortAddress() const { return m_portAddress; }
   const ControllerPtr& GetController() const { return m_controller; }
+  std::string GetControllerAddress() const;
   const PERIPHERALS::PeripheralPtr& GetSource() const { return m_sourcePeripheral; }
   std::string GetSourceLocation() const;
 

--- a/xbmc/games/addons/input/GameClientJoystick.h
+++ b/xbmc/games/addons/input/GameClientJoystick.h
@@ -10,6 +10,7 @@
 
 #include "games/controllers/ControllerTypes.h"
 #include "input/joysticks/interfaces/IInputHandler.h"
+#include "peripherals/PeripheralTypes.h"
 
 #include <memory>
 
@@ -72,6 +73,17 @@ public:
                         unsigned int motionTimeMs) override;
   void OnInputFrame() override {}
 
+  // Input accessors
+  const std::string& GetPortAddress() const { return m_portAddress; }
+  const ControllerPtr& GetController() const { return m_controller; }
+  const PERIPHERALS::PeripheralPtr& GetSource() const { return m_sourcePeripheral; }
+  std::string GetSourceLocation() const;
+
+  // Input mutators
+  void SetSource(PERIPHERALS::PeripheralPtr sourcePeripheral);
+  void ClearSource();
+
+  // Input handlers
   bool SetRumble(const std::string& feature, float magnitude);
 
 private:
@@ -82,6 +94,7 @@ private:
 
   // Input parameters
   std::unique_ptr<CPortInput> m_portInput;
+  PERIPHERALS::PeripheralPtr m_sourcePeripheral;
 };
 } // namespace GAME
 } // namespace KODI

--- a/xbmc/games/addons/input/GameClientKeyboard.cpp
+++ b/xbmc/games/addons/input/GameClientKeyboard.cpp
@@ -89,3 +89,13 @@ void CGameClientKeyboard::OnKeyRelease(const KEYBOARD::KeyName& key,
 
   m_gameClient.Input().InputEvent(event);
 }
+
+void CGameClientKeyboard::SetSource(PERIPHERALS::PeripheralPtr sourcePeripheral)
+{
+  m_sourcePeripheral = std::move(sourcePeripheral);
+}
+
+void CGameClientKeyboard::ClearSource()
+{
+  m_sourcePeripheral.reset();
+}

--- a/xbmc/games/addons/input/GameClientKeyboard.h
+++ b/xbmc/games/addons/input/GameClientKeyboard.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "input/keyboard/interfaces/IKeyboardInputHandler.h"
+#include "peripherals/PeripheralTypes.h"
 
 namespace KODI
 {
@@ -54,11 +55,22 @@ public:
                     KEYBOARD::Modifier mod,
                     uint32_t unicode) override;
 
+  // Input accessors
+  const std::string& GetControllerID() const { return m_controllerId; }
+  const PERIPHERALS::PeripheralPtr& GetSource() const { return m_sourcePeripheral; }
+
+  // Input mutators
+  void SetSource(PERIPHERALS::PeripheralPtr sourcePeripheral);
+  void ClearSource();
+
 private:
   // Construction parameters
   CGameClient& m_gameClient;
   const std::string m_controllerId;
   KEYBOARD::IKeyboardInputProvider* const m_inputProvider;
+
+  // Input parameters
+  PERIPHERALS::PeripheralPtr m_sourcePeripheral;
 };
 } // namespace GAME
 } // namespace KODI

--- a/xbmc/games/addons/input/GameClientMouse.cpp
+++ b/xbmc/games/addons/input/GameClientMouse.cpp
@@ -94,3 +94,13 @@ void CGameClientMouse::OnButtonRelease(const std::string& button)
 
   m_gameClient.Input().InputEvent(event);
 }
+
+void CGameClientMouse::SetSource(PERIPHERALS::PeripheralPtr sourcePeripheral)
+{
+  m_sourcePeripheral = std::move(sourcePeripheral);
+}
+
+void CGameClientMouse::ClearSource()
+{
+  m_sourcePeripheral.reset();
+}

--- a/xbmc/games/addons/input/GameClientMouse.h
+++ b/xbmc/games/addons/input/GameClientMouse.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "input/mouse/interfaces/IMouseInputHandler.h"
+#include "peripherals/PeripheralTypes.h"
 
 namespace KODI
 {
@@ -52,11 +53,22 @@ public:
   bool OnButtonPress(const std::string& button) override;
   void OnButtonRelease(const std::string& button) override;
 
+  // Input accessors
+  const std::string& GetControllerID() const { return m_controllerId; }
+  const PERIPHERALS::PeripheralPtr& GetSource() const { return m_sourcePeripheral; }
+
+  // Input mutators
+  void SetSource(PERIPHERALS::PeripheralPtr sourcePeripheral);
+  void ClearSource();
+
 private:
   // Construction parameters
   CGameClient& m_gameClient;
   const std::string m_controllerId;
   MOUSE::IMouseInputProvider* const m_inputProvider;
+
+  // Input parameters
+  PERIPHERALS::PeripheralPtr m_sourcePeripheral;
 };
 } // namespace GAME
 } // namespace KODI

--- a/xbmc/games/addons/input/GameClientTopology.h
+++ b/xbmc/games/addons/input/GameClientTopology.h
@@ -30,14 +30,14 @@ public:
   const CControllerTree& GetControllerTree() const { return m_controllers; }
   CControllerTree& GetControllerTree() { return m_controllers; }
 
+  // Utility function
+  static std::string MakeAddress(const std::string& baseAddress, const std::string& nodeId);
+
 private:
   static CControllerTree GetControllerTree(const GameClientPortVec& ports);
   static CPortNode GetPortNode(const GameClientPortPtr& port, const std::string& controllerAddress);
   static CControllerNode GetControllerNode(const GameClientDevicePtr& device,
                                            const std::string& portAddress);
-
-  // Utility function
-  static std::string MakeAddress(const std::string& baseAddress, const std::string& nodeId);
 
   // Game API parameters
   GameClientPortVec m_ports;

--- a/xbmc/games/agents/GameAgentManager.cpp
+++ b/xbmc/games/agents/GameAgentManager.cpp
@@ -299,44 +299,17 @@ CGameAgentManager::PortMap CGameAgentManager::MapJoysticks(
 {
   PortMap result;
 
+  // Sort by order of last button press
   //! @todo Preserve existing joystick ports
   PERIPHERALS::PeripheralVector sortedJoysticks = peripheralJoysticks;
   std::sort(sortedJoysticks.begin(), sortedJoysticks.end(),
             [](const PERIPHERALS::PeripheralPtr& lhs, const PERIPHERALS::PeripheralPtr& rhs) {
-              PERIPHERALS::CPeripheralJoystick* lhsJoystick =
-                  dynamic_cast<PERIPHERALS::CPeripheralJoystick*>(lhs.get());
-              PERIPHERALS::CPeripheralJoystick* rhsJoystick =
-                  dynamic_cast<PERIPHERALS::CPeripheralJoystick*>(lhs.get());
-
-              // Sort joysticks before other peripheral types
-              if (lhsJoystick && !rhsJoystick)
+              if (lhs->LastActive().IsValid() && !rhs->LastActive().IsValid())
                 return true;
-              if (!lhsJoystick && rhsJoystick)
+              if (!lhs->LastActive().IsValid() && rhs->LastActive().IsValid())
                 return false;
 
-              if (lhsJoystick && rhsJoystick)
-              {
-                // Sort joysticks with a requested port before joysticks without a requested port
-                if (lhsJoystick->RequestedPort() != -1 && rhsJoystick->RequestedPort() == -1)
-                  return true;
-                if (lhsJoystick->RequestedPort() == -1 && rhsJoystick->RequestedPort() != -1)
-                  return false;
-
-                // Sort by requested port, if provided
-                if (lhsJoystick->RequestedPort() < rhsJoystick->RequestedPort())
-                  return true;
-                if (lhsJoystick->RequestedPort() > rhsJoystick->RequestedPort())
-                  return false;
-
-                // Sort by location on the peripheral bus
-                if (lhs->Location() < rhs->Location())
-                  return true;
-                if (lhs->Location() > rhs->Location())
-                  return false;
-              }
-
-              // Shouldn't happen
-              return false;
+              return lhs->LastActive() > rhs->LastActive();
             });
 
   unsigned int i = 0;

--- a/xbmc/games/agents/GameAgentManager.h
+++ b/xbmc/games/agents/GameAgentManager.h
@@ -83,6 +83,10 @@ private:
   using JoystickMap = std::map<PortAddress, std::shared_ptr<CGameClientJoystick>>;
   using PortMap = std::map<JOYSTICK::IInputProvider*, std::shared_ptr<CGameClientJoystick>>;
 
+  using PeripheralLocation = std::string;
+  using CurrentPortMap = std::map<PortAddress, PeripheralLocation>;
+  using CurrentPeripheralMap = std::map<PeripheralLocation, PortAddress>;
+
   // Internal interface
   void ProcessJoysticks(PERIPHERALS::EventLockHandlePtr& inputHandlingLock);
   void ProcessKeyboard();
@@ -98,7 +102,12 @@ private:
   // Static functionals
   static PortMap MapJoysticks(const PERIPHERALS::PeripheralVector& peripheralJoysticks,
                               const JoystickMap& gameClientjoysticks,
+                              CurrentPortMap& currentPorts,
+                              CurrentPeripheralMap& currentPeripherals,
                               int playerLimit);
+  static void MapJoystick(PERIPHERALS::PeripheralPtr peripheralJoystick,
+                          std::shared_ptr<CGameClientJoystick> gameClientJoystick,
+                          PortMap& result);
 
   // Construction parameters
   PERIPHERALS::CPeripherals& m_peripheralManager;
@@ -122,6 +131,20 @@ private:
    * Not exposed to the game.
    */
   PortMap m_portMap;
+
+  /*!
+   * \brief Map of the current ports to their peripheral
+   *
+   * This allows attempt to preserve player numbers.
+   */
+  CurrentPortMap m_currentPorts;
+
+  /*!
+   * \brief Map of the current peripherals to their port
+   *
+   * This allows attempt to preserve player numbers.
+   */
+  CurrentPeripheralMap m_currentPeripherals;
 };
 } // namespace GAME
 } // namespace KODI

--- a/xbmc/games/agents/GameAgentManager.h
+++ b/xbmc/games/agents/GameAgentManager.h
@@ -15,6 +15,7 @@
 
 #include <map>
 #include <memory>
+#include <set>
 #include <string>
 
 class CInputManager;
@@ -87,6 +88,9 @@ private:
   using CurrentPortMap = std::map<PortAddress, PeripheralLocation>;
   using CurrentPeripheralMap = std::map<PeripheralLocation, PortAddress>;
 
+  using ControllerAddress = std::string;
+  using PeripheralMap = std::map<ControllerAddress, PERIPHERALS::PeripheralPtr>;
+
   // Internal interface
   void ProcessJoysticks(PERIPHERALS::EventLockHandlePtr& inputHandlingLock);
   void ProcessKeyboard();
@@ -97,7 +101,8 @@ private:
                               PERIPHERALS::EventLockHandlePtr& inputHandlingLock);
   void UpdateConnectedJoysticks(const PERIPHERALS::PeripheralVector& joysticks,
                                 const PortMap& newPortMap,
-                                PERIPHERALS::EventLockHandlePtr& inputHandlingLock);
+                                PERIPHERALS::EventLockHandlePtr& inputHandlingLock,
+                                std::set<PERIPHERALS::PeripheralPtr>& disconnectedJoysticks);
 
   // Static functionals
   static PortMap MapJoysticks(const PERIPHERALS::PeripheralVector& peripheralJoysticks,
@@ -108,6 +113,8 @@ private:
   static void MapJoystick(PERIPHERALS::PeripheralPtr peripheralJoystick,
                           std::shared_ptr<CGameClientJoystick> gameClientJoystick,
                           PortMap& result);
+  static void LogPeripheralMap(const PeripheralMap& peripheralMap,
+                               const std::set<PERIPHERALS::PeripheralPtr>& disconnectedPeripherals);
 
   // Construction parameters
   PERIPHERALS::CPeripherals& m_peripheralManager;
@@ -145,6 +152,20 @@ private:
    * This allows attempt to preserve player numbers.
    */
   CurrentPeripheralMap m_currentPeripherals;
+
+  /*!
+   * Map of controller address to source peripheral
+   *
+   * Source peripherals are not exposed to the game.
+   */
+  PeripheralMap m_peripheralMap;
+
+  /*!
+   * Collection of disconnected joysticks
+   *
+   * Source peripherals are not exposed to the game.
+   */
+  std::set<PERIPHERALS::PeripheralPtr> m_disconnectedPeripherals;
 };
 } // namespace GAME
 } // namespace KODI


### PR DESCRIPTION
## Description

In https://github.com/xbmc/xbmc/pull/22036, I pulled in some work from my Player Manager, but unintentionally pulled in an unfinished change that causes a regression in v20.

The change in behavior has to do with how players are sorted into controller ports. In v19, the most recently active controller got port 1, etc. However, in the refactor, new, unfinished behavior was introduced, and the behavior contained [an error](https://github.com/xbmc/xbmc/pull/22036/files#diff-c9a9a33df7eabea92e79b782e14daef8bfd963d02a084906fc832a8ae6566d33R309) that caused joysticks to never be sorted; they're simply given a port depending on when they were detected by the OS.

As a result, on some Android boxes, "virtual" joysticks were now sorted in front of legit joysticks, causing input to be dropped.

This PR restores the old behavior of sorting ports by last activated joystick. It's a stop gap measure to solve the phantom joystick problem until the Player Manager is ready to allow control over port mappings.

I also added new logging when the port mapping changes to help debug future issues.

## Motivation and context

Reported several places, most recently here: https://forum.kodi.tv/showthread.php?tid=373412

## How has this been tested?

Test builds available here: https://github.com/garbear/xbmc/releases

Example logging with 5 controllers connected and a Multitap in port 2:

```
debug <general>: ===== Peripheral Map =====
debug <general>: /1/game.controller.snes.mouse:
debug <general>:     peripheral.joystick/0 [Xbox 360-compatible controller]
debug <general>:
debug <general>: /2/game.controller.snes.multitap/1/game.controller.snes:
debug <general>:     peripheral.joystick/1 [Xbox 360-compatible controller]
debug <general>:
debug <general>: /2/game.controller.snes.multitap/2/game.controller.snes:
debug <general>:     peripheral.joystick/2 [Xbox 360-compatible controller]
debug <general>:
debug <general>: /2/game.controller.snes.multitap/3/game.controller.snes:
debug <general>:     peripheral.joystick/3 [Xbox 360-compatible controller]
debug <general>:
debug <general>: /2/game.controller.snes.multitap/4/game.controller.snes:
debug <general>:     peripheral.joystick/4 [Wireless Controller]
debug <general>: ==========================
```

Example logging when the Multitap in port 2 is changed to a SNES controller:

```
debug <general>: ===== Peripheral Map =====
debug <general>: /1/game.controller.snes:
debug <general>:     peripheral.joystick/0 [Xbox 360-compatible controller]
debug <general>: 
debug <general>: /2/game.controller.snes:
debug <general>:     peripheral.joystick/1 [Xbox 360-compatible controller]
debug <general>: 
debug <general>: Disconnected:
debug <general>:     peripheral.joystick/2 [Xbox 360-compatible controller]
debug <general>:     peripheral.joystick/3 [Xbox 360-compatible controller]
debug <general>:     peripheral.joystick/4 [Wireless Controller]
debug <general>: ==========================
```

I also created a stripped-down version of the Player manager that I call "View Players" that simply allows you to view player mappings without changing anything:

![screenshot00012](https://github.com/xbmc/xbmc/assets/531482/37707917-f39b-4288-ab53-dc18d0d90bba)

The View Players window is included in my test builds, but not in this PR.

## What is the effect on users?

* Fixed game controllers not working when "virtual" joysticks are detected

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
