### PR TITLE
[Windows][dxva] refactor CProcessorHD/CEnumeratorHD to remove direct access to the D3D enumerator interfaces

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.cpp
@@ -452,10 +452,8 @@ ProcessorFormats CEnumeratorHD::GetProcessorFormats(bool inputFormats, bool outp
   return formats;
 }
 
-std::vector<DXGI_FORMAT> CEnumeratorHD::GetProcessorRGBOutputFormats()
+std::vector<DXGI_FORMAT> CEnumeratorHD::GetProcessorRGBOutputFormats() const
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
-
   ProcessorFormats formats = GetProcessorFormats(false, true);
   if (!formats.m_valid)
     return {};
@@ -514,11 +512,9 @@ ProcessorConversions CEnumeratorHD::ListConversions(
     DXGI_FORMAT inputFormat,
     const std::vector<DXGI_COLOR_SPACE_TYPE>& inputColorSpaces,
     const std::vector<DXGI_FORMAT>& outputFormats,
-    const std::vector<DXGI_COLOR_SPACE_TYPE>& outputColorSpaces)
+    const std::vector<DXGI_COLOR_SPACE_TYPE>& outputColorSpaces) const
 {
-  std::unique_lock<CCriticalSection> lock(m_section);
-
-  // Not initialized yet, or under Windows 10
+  // Not initialized yet or OS < Windows 10
   if (!m_pEnumerator || !m_pEnumerator1)
     return {};
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.cpp
@@ -639,3 +639,33 @@ void CEnumeratorHD::LogSupportedConversions(const DXGI_FORMAT& inputFormat,
               "heuristics, N native input color space, bb supported as swap chain backbuffer){}",
               DX::DXGIFormatToString(inputFormat), conversionsString);
 }
+
+bool CEnumeratorHD::IsFormatSupportedInput(DXGI_FORMAT format)
+{
+  std::unique_lock<CCriticalSection> lock(m_section);
+  return IsFormatSupportedInternal(format, D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT_INPUT);
+}
+bool CEnumeratorHD::IsFormatSupportedOutput(DXGI_FORMAT format)
+{
+  std::unique_lock<CCriticalSection> lock(m_section);
+  return IsFormatSupportedInternal(format, D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT_OUTPUT);
+}
+
+bool CEnumeratorHD::IsFormatSupportedInternal(DXGI_FORMAT format,
+                                              D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT support) const
+{
+  // Not initialized yet
+  if (!m_pEnumerator)
+    return false;
+
+  UINT uiFlags;
+  if (S_OK == m_pEnumerator->CheckVideoProcessorFormat(format, &uiFlags))
+  {
+    if (uiFlags & support)
+      return true;
+  }
+
+  CLog::LogF(LOGERROR, "unsupported format {} for {}.", DX::DXGIFormatToString(format),
+             DX::D3D11VideoProcessorFormatSupportToString(support));
+  return false;
+}

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
@@ -77,6 +77,13 @@ enum InputFormat
   Left
 };
 
+struct ProcessorFormats
+{
+  std::vector<DXGI_FORMAT> m_input;
+  std::vector<DXGI_FORMAT> m_output;
+  bool m_valid{false};
+};
+
 class CEnumeratorHD : public ID3DResource
 {
 public:
@@ -104,6 +111,11 @@ public:
   */
   bool IsSDRSupported();
   ProcessorCapabilities ProbeProcessorCaps();
+  /*!
+   * \brief Retrieve the list of RGB DXGI_FORMAT supported as output by the DXVA processor
+   * \return Vector of formats
+   */
+  std::vector<DXGI_FORMAT> GetProcessorRGBOutputFormats();
 
   ComPtr<ID3D11VideoProcessorEnumerator> Get() { return m_pEnumerator; }
   ComPtr<ID3D11VideoProcessorEnumerator1> Get1() { return m_pEnumerator1; }
@@ -113,6 +125,13 @@ protected:
   InputFormat QueryHDRtoHDRSupport() const;
   InputFormat QueryHDRtoSDRSupport() const;
   bool QuerySDRSupport() const;
+  /*!
+   * \brief Retrieve the list of DXGI_FORMAT supported by the DXVA processor
+   * \param inputFormats yes/no populate the input formats vector of the returned structure
+   * \param outputFormats yes/no populate the output formats vector of the returned structure
+   * \return requested list of input and/or output formats.
+   */
+  ProcessorFormats GetProcessorFormats(bool inputFormats, bool outputFormats) const;
 
   CCriticalSection m_section;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
@@ -84,6 +84,16 @@ struct ProcessorFormats
   bool m_valid{false};
 };
 
+struct ProcessorConversion
+{
+  DXGI_FORMAT m_inputFormat{DXGI_FORMAT_UNKNOWN};
+  DXGI_COLOR_SPACE_TYPE m_inputCS{DXGI_COLOR_SPACE_RESERVED};
+  DXGI_FORMAT m_outputFormat{DXGI_FORMAT_UNKNOWN};
+  DXGI_COLOR_SPACE_TYPE m_outputCS{DXGI_COLOR_SPACE_RESERVED};
+};
+
+using ProcessorConversions = std::vector<ProcessorConversion>;
+
 class CEnumeratorHD : public ID3DResource
 {
 public:
@@ -116,6 +126,32 @@ public:
    * \return Vector of formats
    */
   std::vector<DXGI_FORMAT> GetProcessorRGBOutputFormats();
+  /*!
+   * \brief Check if a conversion is supported by the dxva processor.
+   * \param inputFormat the input format
+   * \param inputCS the input color space
+   * \param outputFormat the output format
+   * \param outputCS the output color space
+   * \return true when the conversion is supported, false when it is not
+   * or the API used to validate is not availe (Windows < 10)
+  */
+  bool CheckConversion(DXGI_FORMAT inputFormat,
+                       DXGI_COLOR_SPACE_TYPE inputCS,
+                       DXGI_FORMAT outputFormat,
+                       DXGI_COLOR_SPACE_TYPE outputCS);
+  /*!
+   * \brief Iterate over all combinations of the input parameters and return a list of
+   * the combinations that are supported conversions.
+   * \param inputFormat The input format
+   * \param inputColorSpaces The possible source color spaces
+   * \param outputFormats The possible output formats
+   * \param outputColorSpaces The possible output color spaces
+   * \return List of the supported conversion.
+   */
+  ProcessorConversions ListConversions(DXGI_FORMAT inputFormat,
+                                       const std::vector<DXGI_COLOR_SPACE_TYPE>& inputColorSpaces,
+                                       const std::vector<DXGI_FORMAT>& outputFormats,
+                                       const std::vector<DXGI_COLOR_SPACE_TYPE>& outputColorSpaces);
 
   ComPtr<ID3D11VideoProcessorEnumerator> Get() { return m_pEnumerator; }
   ComPtr<ID3D11VideoProcessorEnumerator1> Get1() { return m_pEnumerator1; }
@@ -132,6 +168,19 @@ protected:
    * \return requested list of input and/or output formats.
    */
   ProcessorFormats GetProcessorFormats(bool inputFormats, bool outputFormats) const;
+  /*!
+   * \brief Check if a conversion is supported by the dxva processor.
+   * \param inputFormat the input format
+   * \param inputCS the input color space
+   * \param outputFormat the output format
+   * \param outputCS the output color space
+   * \return true when the conversion is supported, false when it is not
+   * or the API used to validate is not available (Windows < 10)
+  */
+  bool CheckConversionInternal(DXGI_FORMAT inputFormat,
+                               DXGI_COLOR_SPACE_TYPE inputCS,
+                               DXGI_FORMAT outputFormat,
+                               DXGI_COLOR_SPACE_TYPE outputCS) const;
 
   CCriticalSection m_section;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
@@ -135,6 +135,18 @@ public:
                        DXGI_FORMAT outputFormat,
                        DXGI_COLOR_SPACE_TYPE outputCS);
   /*!
+   * \brief Check dxva processor for support of the format as input texture
+   * \param format the format
+   * \return true supported, false not supported
+   */
+  bool IsFormatSupportedInput(DXGI_FORMAT format);
+  /*!
+   * \brief Check dxva processor for support of the format as output texture
+   * \param format the format
+   * \return true supported, false not supported
+   */
+  bool IsFormatSupportedOutput(DXGI_FORMAT format);
+  /*!
    * \brief Outputs in the log a list of conversions supported by the DXVA processor.
    * \param inputFormat the source format
    * \param heuristicsInputCS the input color space that will be used for playback
@@ -187,6 +199,14 @@ protected:
                                DXGI_COLOR_SPACE_TYPE inputCS,
                                DXGI_FORMAT outputFormat,
                                DXGI_COLOR_SPACE_TYPE outputCS) const;
+  /*!
+   * \brief Check dxva processor for support of the format as input texture
+   * \param format the format
+   * \return true supported, false not supported
+   */
+  bool IsFormatSupportedInternal(DXGI_FORMAT format,
+                                 D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT support) const;
+
   /*!
    * \brief Iterate over all combinations of the input parameters and return a list of
    * the combinations that are supported conversions.

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
@@ -162,12 +162,19 @@ public:
                                const DXGI_COLOR_SPACE_TYPE heuristicsOutputCS);
 
   ComPtr<ID3D11VideoProcessorEnumerator> Get() { return m_pEnumerator; }
+  bool IsInitialized() const { return m_pEnumerator; }
   /*!
    * \brief Returns the availability of the interface ID3D11VideoProcessorEnumerator1
    * (Windows 10 supporting HDR and above)
    * \return true when the interface is available and initialized, false otherwise
    */
   bool IsEnumerator1Available() { return m_pEnumerator1; }
+
+  ComPtr<ID3D11VideoProcessor> CreateVideoProcessor(UINT RateConversionIndex);
+  ComPtr<ID3D11VideoProcessorInputView> CreateVideoProcessorInputView(
+      ID3D11Resource* pResource, const D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC* pDesc);
+  ComPtr<ID3D11VideoProcessorOutputView> CreateVideoProcessorOutputView(
+      ID3D11Resource* pResource, const D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC* pDesc);
 
 protected:
   void UnInit();
@@ -224,6 +231,7 @@ protected:
 
   CCriticalSection m_section;
 
+  ComPtr<ID3D11VideoDevice> m_pVideoDevice;
   ComPtr<ID3D11VideoProcessorEnumerator> m_pEnumerator;
   ComPtr<ID3D11VideoProcessorEnumerator1> m_pEnumerator1;
   DXGI_FORMAT m_input_dxgi_format{DXGI_FORMAT_UNKNOWN};

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
@@ -150,7 +150,12 @@ public:
                                const DXGI_COLOR_SPACE_TYPE heuristicsOutputCS);
 
   ComPtr<ID3D11VideoProcessorEnumerator> Get() { return m_pEnumerator; }
-  ComPtr<ID3D11VideoProcessorEnumerator1> Get1() { return m_pEnumerator1; }
+  /*!
+   * \brief Returns the availability of the interface ID3D11VideoProcessorEnumerator1
+   * (Windows 10 supporting HDR and above)
+   * \return true when the interface is available and initialized, false otherwise
+   */
+  bool IsEnumerator1Available() { return m_pEnumerator1; }
 
 protected:
   void UnInit();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
@@ -161,7 +161,6 @@ public:
                                const DXGI_FORMAT& outputFormat,
                                const DXGI_COLOR_SPACE_TYPE heuristicsOutputCS);
 
-  ComPtr<ID3D11VideoProcessorEnumerator> Get() { return m_pEnumerator; }
   bool IsInitialized() const { return m_pEnumerator; }
   /*!
    * \brief Returns the availability of the interface ID3D11VideoProcessorEnumerator1

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
@@ -122,11 +122,6 @@ public:
   bool IsSDRSupported();
   ProcessorCapabilities ProbeProcessorCaps();
   /*!
-   * \brief Retrieve the list of RGB DXGI_FORMAT supported as output by the DXVA processor
-   * \return Vector of formats
-   */
-  std::vector<DXGI_FORMAT> GetProcessorRGBOutputFormats();
-  /*!
    * \brief Check if a conversion is supported by the dxva processor.
    * \param inputFormat the input format
    * \param inputCS the input color space
@@ -139,19 +134,6 @@ public:
                        DXGI_COLOR_SPACE_TYPE inputCS,
                        DXGI_FORMAT outputFormat,
                        DXGI_COLOR_SPACE_TYPE outputCS);
-  /*!
-   * \brief Iterate over all combinations of the input parameters and return a list of
-   * the combinations that are supported conversions.
-   * \param inputFormat The input format
-   * \param inputColorSpaces The possible source color spaces
-   * \param outputFormats The possible output formats
-   * \param outputColorSpaces The possible output color spaces
-   * \return List of the supported conversion.
-   */
-  ProcessorConversions ListConversions(DXGI_FORMAT inputFormat,
-                                       const std::vector<DXGI_COLOR_SPACE_TYPE>& inputColorSpaces,
-                                       const std::vector<DXGI_FORMAT>& outputFormats,
-                                       const std::vector<DXGI_COLOR_SPACE_TYPE>& outputColorSpaces);
   /*!
    * \brief Outputs in the log a list of conversions supported by the DXVA processor.
    * \param inputFormat the source format
@@ -183,6 +165,11 @@ protected:
    */
   ProcessorFormats GetProcessorFormats(bool inputFormats, bool outputFormats) const;
   /*!
+   * \brief Retrieve the list of RGB DXGI_FORMAT supported as output by the DXVA
+   * processor \return Vector of formats
+   */
+  std::vector<DXGI_FORMAT> GetProcessorRGBOutputFormats() const;
+  /*!
    * \brief Check if a conversion is supported by the dxva processor.
    * \param inputFormat the input format
    * \param inputCS the input color space
@@ -195,6 +182,20 @@ protected:
                                DXGI_COLOR_SPACE_TYPE inputCS,
                                DXGI_FORMAT outputFormat,
                                DXGI_COLOR_SPACE_TYPE outputCS) const;
+  /*!
+   * \brief Iterate over all combinations of the input parameters and return a list of
+   * the combinations that are supported conversions.
+   * \param inputFormat The input format
+   * \param inputColorSpaces The possible source color spaces
+   * \param outputFormats The possible output formats
+   * \param outputColorSpaces The possible output color spaces
+   * \return List of the supported conversion.
+   */
+  ProcessorConversions ListConversions(
+      DXGI_FORMAT inputFormat,
+      const std::vector<DXGI_COLOR_SPACE_TYPE>& inputColorSpaces,
+      const std::vector<DXGI_FORMAT>& outputFormats,
+      const std::vector<DXGI_COLOR_SPACE_TYPE>& outputColorSpaces) const;
 
   CCriticalSection m_section;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
@@ -152,6 +152,20 @@ public:
                                        const std::vector<DXGI_COLOR_SPACE_TYPE>& inputColorSpaces,
                                        const std::vector<DXGI_FORMAT>& outputFormats,
                                        const std::vector<DXGI_COLOR_SPACE_TYPE>& outputColorSpaces);
+  /*!
+   * \brief Outputs in the log a list of conversions supported by the DXVA processor.
+   * \param inputFormat the source format
+   * \param heuristicsInputCS the input color space that will be used for playback
+   * \param inputNativeCS the input color space that would be used with a direct mapping
+   * from avcodec to D3D11, without any workarounds or tricks.
+   * \param outputFormat the destination format
+   * \param heuristicsOutputCS the output color space that will be used for playback
+   */
+  void LogSupportedConversions(const DXGI_FORMAT& inputFormat,
+                               const DXGI_COLOR_SPACE_TYPE heuristicsInputCS,
+                               const DXGI_COLOR_SPACE_TYPE inputNativeCS,
+                               const DXGI_FORMAT& outputFormat,
+                               const DXGI_COLOR_SPACE_TYPE heuristicsOutputCS);
 
   ComPtr<ID3D11VideoProcessorEnumerator> Get() { return m_pEnumerator; }
   ComPtr<ID3D11VideoProcessorEnumerator1> Get1() { return m_pEnumerator1; }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -175,7 +175,7 @@ bool CProcessorHD::IsFormatConversionSupported(DXGI_FORMAT inputFormat,
   // accept the conversion unless the API can be called successfully and disallows it
   BOOL supported{TRUE};
 
-  if (!m_enumerator || !m_enumerator->Get1())
+  if (!m_enumerator || !m_enumerator->IsEnumerator1Available())
     return true;
 
   ProcColorSpaces spaces = CalculateDXGIColorSpaces(DXGIColorSpaceArgs(picture));

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -694,14 +694,7 @@ void CProcessorHD::ListSupportedConversions(const DXGI_FORMAT& inputFormat,
   }
 
   // Only probe the output formats of RGB/BGR type supported by the processor.
-  std::vector<DXGI_FORMAT> outputFormats;
-  for (const auto& format : GetProcessorOutputFormats())
-  {
-    std::string name = DX::DXGIFormatToString(format);
-    if (name.find('R') != std::string::npos && name.find('G') != std::string::npos &&
-        name.find('B') != std::string::npos)
-      outputFormats.push_back(format);
-  }
+  const std::vector<DXGI_FORMAT>& outputFormats = m_enumerator->GetProcessorRGBOutputFormats();
 
   // Color spaces supported directly by the swap chain - as a set for easy lookup
   std::vector<DXGI_COLOR_SPACE_TYPE> bbcs = DX::DeviceResources::Get()->GetSwapChainColorSpaces();
@@ -744,21 +737,6 @@ void CProcessorHD::ListSupportedConversions(const DXGI_FORMAT& inputFormat,
               "supported conversions from format {}\n(*: values picked by "
               "heuristics, N native input color space, bb supported as swap chain backbuffer){}",
               DX::DXGIFormatToString(inputFormat), conversions);
-}
-
-std::vector<DXGI_FORMAT> CProcessorHD::GetProcessorOutputFormats() const
-{
-  std::vector<DXGI_FORMAT> result;
-
-  UINT uiFlags;
-  for (int fmt = DXGI_FORMAT_UNKNOWN; fmt <= DXGI_FORMAT_V408; fmt++)
-  {
-    DXGI_FORMAT dxgiFormat = static_cast<DXGI_FORMAT>(fmt);
-    if (S_OK == m_enumerator->Get()->CheckVideoProcessorFormat(dxgiFormat, &uiFlags) &&
-        uiFlags & D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT_OUTPUT)
-      result.push_back(dxgiFormat);
-  }
-  return result;
 }
 
 DXGI_COLOR_SPACE_TYPE CProcessorHD::AvToDxgiColorSpace(const DXGIColorSpaceArgs& csArgs)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -80,9 +80,9 @@ public:
    * \param outputFormat The destination format
    * \param picture Picture information used to derive the color spaces
    */
-  void ListSupportedConversions(const DXGI_FORMAT& inputFormat,
-                                const DXGI_FORMAT& outputFormat,
-                                const VideoPicture& picture);
+  void LogSupportedConversions(const DXGI_FORMAT& inputFormat,
+                               const DXGI_FORMAT& outputFormat,
+                               const VideoPicture& picture);
 
   /*!
    * \brief Set the output format of the dxva processor. Format compatibility will be verified.

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -130,11 +130,6 @@ protected:
    * \return DXGI color space
    */
   static DXGI_COLOR_SPACE_TYPE AvToDxgiColorSpace(const DXGIColorSpaceArgs& csArgs);
-  /*!
-   * \brief Retrieve the list of DXGI_FORMAT supported as output by the DXVA processor
-   * \return Vector of formats
-   */
-  std::vector<DXGI_FORMAT> GetProcessorOutputFormats() const;
 
   void EnableIntelVideoSuperResolution();
   void EnableNvidiaRTXVideoSuperResolution();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -62,7 +62,18 @@ public:
   void Close();
   bool Render(CRect src, CRect dst, ID3D11Resource* target, CRenderBuffer **views, DWORD flags, UINT frameIdx, UINT rotation, float contrast, float brightness);
   uint8_t PastRefs() const { return std::min(m_procCaps.m_rateCaps.PastFrames, 4u); }
-  bool IsFormatSupported(DXGI_FORMAT format, D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT support) const;
+  /*!
+   * \brief Check support of the format as input texture
+   * \param format the format
+   * \return true supported, false not supported
+   */
+  bool IsFormatSupportedInput(DXGI_FORMAT format);
+  /*!
+   * \brief Check support of the format as input texture
+   * \param format the format
+   * \return true supported, false not supported
+   */
+  bool IsFormatSupportedOutput(DXGI_FORMAT format);
   /*!
    * \brief Evaluate if the DXVA processor supports converting between two formats and color spaces.
    * Always returns true when the Windows 10+ API is not available or cannot be called successfully.

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -120,7 +120,7 @@ protected:
   bool CheckFormats() const;
   bool OpenProcessor();
   void ApplyFilter(D3D11_VIDEO_PROCESSOR_FILTER filter, int value, int min, int max, int def) const;
-  ID3D11VideoProcessorInputView* GetInputView(CRenderBuffer* view) const;
+  ComPtr<ID3D11VideoProcessorInputView> GetInputView(CRenderBuffer* view) const;
   /*!
    * \brief Calculate the color spaces of the input and output of the processor
    * \param csArgs Arguments for the calculations

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
@@ -137,8 +137,6 @@ CRenderInfo CRendererDXVA::GetRenderInfo()
 
 bool CRendererDXVA::Configure(const VideoPicture& picture, float fps, unsigned orientation)
 {
-  const auto support_type = D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT_INPUT;
-
   if (__super::Configure(picture, fps, orientation))
   {
     m_format = picture.videoBuffer->GetFormat();
@@ -159,7 +157,7 @@ bool CRendererDXVA::Configure(const VideoPicture& picture, float fps, unsigned o
     // create processor
     m_processor = std::make_unique<DXVA::CProcessorHD>();
     if (m_processor->PreInit() && m_processor->Open(picture) &&
-        m_processor->IsFormatSupported(dxgi_format, support_type))
+        m_processor->IsFormatSupportedInput(dxgi_format))
     {
       m_intermediateTargetFormat = CalcIntermediateTargetFormat(picture, tryVSR);
       if (m_processor->SetOutputFormat(m_intermediateTargetFormat))
@@ -502,8 +500,7 @@ DXGI_FORMAT CRendererDXVA::CalcIntermediateTargetFormat(const VideoPicture& pict
 
     const auto it =
         std::find_if(hdrformats.cbegin(), hdrformats.cend(), [&](DXGI_FORMAT outputFormat) {
-          return m_processor->IsFormatSupported(outputFormat,
-                                                D3D11_VIDEO_PROCESSOR_FORMAT_SUPPORT_OUTPUT) &&
+          return m_processor->IsFormatSupportedOutput(outputFormat) &&
                  m_processor->IsFormatConversionSupported(inputFormat, outputFormat, picture);
         });
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
@@ -143,7 +143,6 @@ bool CRendererDXVA::Configure(const VideoPicture& picture, float fps, unsigned o
   {
     m_format = picture.videoBuffer->GetFormat();
     const DXGI_FORMAT dxgi_format = GetDXGIFormat(m_format, __super::GetDXGIFormat(picture));
-    const DXGI_FORMAT dest_format = DX::Windowing()->GetBackBuffer().GetFormat();
     bool tryVSR{false};
 
     if (DX::Windowing()->SupportsVideoSuperResolution())
@@ -167,9 +166,10 @@ bool CRendererDXVA::Configure(const VideoPicture& picture, float fps, unsigned o
       {
         if (CServiceBroker::GetLogging().IsLogLevelLogged(LOGDEBUG) &&
             CServiceBroker::GetLogging().CanLogComponent(LOGVIDEO))
-          m_processor->ListSupportedConversions(dxgi_format, dest_format, picture);
+          m_processor->LogSupportedConversions(dxgi_format, m_intermediateTargetFormat, picture);
 
-        if (m_processor->IsFormatConversionSupported(dxgi_format, dest_format, picture))
+        if (m_processor->IsFormatConversionSupported(dxgi_format, m_intermediateTargetFormat,
+                                                     picture))
         {
           if (tryVSR)
             m_processor->TryEnableVideoSuperResolution();


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Refactor with no functionality change. The previous refactor PR #23408 started splitting the functionality of CProcessorHD related to the enumerators into a new class CEnumeratorHD but left a couple direct accessors from the outside to the D3D Enumerator/Enumerator1 interfaces in order to limit the size of the PR and make the change process more manageable.

This refactor removes those accessors that break object encapsulation, and moves most of the code using them into CEnumeratorHD. The code was kept very similar when it could not be identical.

Each commit corresponds to a functionality of CProcessorHD moved to CEnumeratorHD and can be examined and run on its own.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

After starting a refactor to harmonize the GetWeight and Configure paths of RendererDXVA, it quickly became clear the split of the enumerator functionality from the processor had to be continued.
There aren't many benefits at this stage other than better encapsulation, but it is a necessary step and will help with the review, by breaking things in smaller units of work.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with Windows 10, AMD, Intel, no change in behavior noticed. No resource leaks introduced either.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [X] **None of the above** (please explain below)
Code refactor.

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
