### PR TITLE
Fix DVD disc device playback (#20048) by fixing device url initialization

### DIFF
--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -279,7 +279,12 @@ void CURL::Parse(const std::string& strURL1)
       m_strFileName = strURL.substr(iPos, iEnd - iPos);
   }
 
-  if (IsProtocol("musicdb") || IsProtocol("videodb") || IsProtocol("sources") || IsProtocol("pvr"))
+  // iso9960 doesnt have an hostname;-)
+  if (IsProtocol("iso9660")
+   || IsProtocol("musicdb")
+   || IsProtocol("videodb")
+   || IsProtocol("sources")
+   || IsProtocol("pvr"))
   {
     if (m_strHostName != "" && m_strFileName != "")
     {

--- a/xbmc/filesystem/ISO9660Directory.cpp
+++ b/xbmc/filesystem/ISO9660Directory.cpp
@@ -13,6 +13,7 @@
 #include "utils/URIUtils.h"
 
 #include <cdio++/iso9660.hpp>
+#include "storage/cdioSupport.h"
 
 using namespace XFILE;
 
@@ -34,7 +35,11 @@ bool CISO9660Directory::GetDirectory(const CURL& url, CFileItemList& items)
 
   std::unique_ptr<ISO9660::IFS> iso(new ISO9660::IFS);
 
-  if (!iso->open(url2.GetHostName().c_str()))
+  std::shared_ptr<MEDIA_DETECT::CLibcdio> c_cdio = MEDIA_DETECT::CLibcdio::GetInstance();
+
+  std::string iso_file = url2.GetHostName();
+
+  if (!iso->open(!iso_file.empty() ? iso_file.c_str() : c_cdio->GetDeviceFileName() ))
     return false;
 
   std::vector<ISO9660::Stat*> isoFiles;


### PR DESCRIPTION

## Description
The "iso9660: rework IFile and IFileDirectory implementations" changes made on 2019-05-25 broke DVD disc device playback.

Fixes needed to restore DVD disc device playback:
 - restore the the iso9660 url host/path update
 - open the disc device filename when no file/directory given in the url

## Motivation and context
Playback of DVD disc devices (unmounted), has apparently be broken for 4 years, due to this change.

commit e846acb56897c9a6b66e08e221024366b08c0a8a
Date:   Sat May 25 11:04:19 2019 -0700
iso9660: rework IFile and IFileDirectory implementations

This led to broken DVD playback on systems without udisk/automount (such as Batocera).

## How has this been tested?
Tested with a DVD drive connected on a Linux Ubuntu 22.04 system, with all automounting disabled.
Open Kodi.  Play Disc.  This would not work without a fix.

Tested with:
Kodi Nexus and Matrix. I do not have ffmpeg 6, so not yet tested on master, though it cherry-picks cleanly and should function the same.

## What is the effect on users?
Functional DVD disc playback of DVD device, without mounting disc.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
