### PR TITLE
Fix DVD disc device playback (#20048) by fixing device url initialization

### DIFF
--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -148,7 +148,16 @@ bool CAutorun::RunDisc(IDirectory* pDir, const std::string& strDrive, int& nAdde
   bool bPlaying(false);
   CFileItemList vecItems;
 
-  const CURL pathToUrl(strDrive);
+  CURL pathToUrl{strDrive};
+  // if the url being requested is a generic "iso9660://" we need to expand it with the current drive device.
+  // use the hostname section to prepend the drive path
+  if (pathToUrl.GetRedacted() == "iso9660://")
+  {
+    pathToUrl.Reset();
+    pathToUrl.SetProtocol("iso9660");
+    pathToUrl.SetHostName(CServiceBroker::GetMediaManager().TranslateDevicePath(""));
+  }
+
   if ( !pDir->GetDirectory( pathToUrl, vecItems ) )
   {
     return false;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -767,11 +767,16 @@ bool CVideoPlayer::OpenInputStream()
   CLog::Log(LOGINFO, "Creating InputStream");
 
   // correct the filename if needed
-  std::string filename(m_item.GetPath());
-  if (URIUtils::IsProtocol(filename, "dvd") ||
-      StringUtils::EqualsNoCase(filename, "iso9660://video_ts/video_ts.ifo"))
+  const CURL url{m_item.GetPath()};
+  if (url.GetProtocol() == "dvd")
   {
+    // FIXME: we should deprecate this when more than one device drive is supported
     m_item.SetPath(CServiceBroker::GetMediaManager().TranslateDevicePath(""));
+  }
+  else if (url.GetProtocol() == "iso9660" && !url.GetHostName().empty() &&
+           url.GetFileName() == "VIDEO_TS/video_ts.ifo")
+  {
+    m_item.SetPath(url.GetHostName());
   }
 
   m_pInputStream = CDVDFactoryInputStream::CreateInputStream(this, m_item, true);


### PR DESCRIPTION

## Description
The "iso9660: rework IFile and IFileDirectory implementations" changes made on 2019-05-25 broke DVD disc device playback.

Fixes needed to restore DVD disc device playback:
 - restore the the iso9660 url host/path update
 - open the disc device filename when no file/directory given in the url

## Motivation and context
Playback of DVD disc devices (unmounted), have apparently been broken for 4 years, due to this change.

commit e846acb56897c9a6b66e08e221024366b08c0a8a
Date:   Sat May 25 11:04:19 2019 -0700
iso9660: rework IFile and IFileDirectory implementations

This led to broken DVD playback on systems without udisk/automount (such as Batocera).

## How has this been tested?
Tested with a DVD drive connected on a Linux Ubuntu 22.04 system, with all automounting disabled.
Open Kodi.  Play Disc.  It plays. This would not work without a fix.

Tested with:
Kodi Nexus and Matrix. I do not have ffmpeg 6, so not yet tested on master, though it cherry-picks cleanly and should function the same.

## What is the effect on users?
Functional DVD disc playback of DVD device, without mounting disc.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
