### PR TITLE
[cppcheck] Fix performance checks redux

### DIFF
--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -271,8 +271,8 @@ void CGUIDialogAddonInfo::UpdateControls(PerformButtonFocus performButtonFocus)
   CFileItemList items;
   for (const auto& screenshot : m_item->GetAddonInfo()->Screenshots())
   {
-    auto item = std::make_shared<CFileItem>("");
-    item->SetArt("thumb", screenshot);
+    CFileItem item;
+    item.SetArt("thumb", screenshot);
     items.Add(std::move(item));
   }
   CGUIMessage msg(GUI_MSG_LABEL_BIND, GetID(), CONTROL_LIST_SCREENSHOTS, 0, 0, &items);

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -65,7 +65,8 @@ using namespace XFILE;
 using namespace KODI::MESSAGING;
 
 CGUIDialogAddonInfo::CGUIDialogAddonInfo(void)
-  : CGUIDialog(WINDOW_DIALOG_ADDON_INFO, "DialogAddonInfo.xml"), m_item(CFileItemPtr(new CFileItem))
+  : CGUIDialog(WINDOW_DIALOG_ADDON_INFO, "DialogAddonInfo.xml"),
+    m_item(std::make_shared<CFileItem>())
 {
   m_loadType = KEEP_IN_MEMORY;
 }

--- a/xbmc/games/controllers/dialogs/ControllerInstaller.cpp
+++ b/xbmc/games/controllers/dialogs/ControllerInstaller.cpp
@@ -64,8 +64,8 @@ void CControllerInstaller::Process()
   CFileItemList items;
   for (const auto& addon : installableAddons)
   {
-    CFileItemPtr item(new CFileItem(addon->Name()));
-    item->SetArt("icon", addon->Icon());
+    CFileItem item{addon->Name()};
+    item.SetArt("icon", addon->Icon());
     items.Add(std::move(item));
   }
 

--- a/xbmc/games/controllers/dialogs/ControllerSelect.cpp
+++ b/xbmc/games/controllers/dialogs/ControllerSelect.cpp
@@ -81,8 +81,8 @@ void CControllerSelect::Process()
   CFileItemList items;
   for (const ControllerPtr& controller : m_controllers)
   {
-    CFileItemPtr item(new CFileItem(controller->Layout().Label()));
-    item->SetArt("icon", controller->Layout().ImagePath());
+    CFileItem item{controller->Layout().Label()};
+    item.SetArt("icon", controller->Layout().ImagePath());
     items.Add(std::move(item));
 
     // Check if a specified controller should be selected by default
@@ -93,8 +93,8 @@ void CControllerSelect::Process()
   if (m_showDisconnect)
   {
     // Add a button to disconnect the port
-    CFileItemPtr item(new CFileItem(g_localizeStrings.Get(13298))); // "Disconnected"
-    item->SetArt("icon", "DefaultAddonNone.png");
+    CFileItem item{g_localizeStrings.Get(13298)}; // "Disconnected"
+    item.SetArt("icon", "DefaultAddonNone.png");
     items.Add(std::move(item));
 
     // Check if the disconnect button should be selected by default

--- a/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
+++ b/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
@@ -46,12 +46,12 @@ std::string CGUIDialogSelectGameClient::ShowAndGetGameClient(const std::string& 
     {
       CFileItemPtr item(XFILE::CAddonsDirectory::FileItemFromAddon(candidate, candidate->ID()));
       item->SetLabel2(g_localizeStrings.Get(35257)); // "Installed"
-      items.Add(std::move(item));
+      items.Add(std::move(*item));
     }
     for (const auto& addon : installable)
     {
       CFileItemPtr item(XFILE::CAddonsDirectory::FileItemFromAddon(addon, addon->ID()));
-      installableItems.Add(std::move(item));
+      installableItems.Add(std::move(*item));
     }
     items.Sort(SortByLabel, SortOrderAscending);
     installableItems.Sort(SortByLabel, SortOrderAscending);

--- a/xbmc/games/dialogs/osd/DialogGameStretchMode.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameStretchMode.cpp
@@ -77,12 +77,12 @@ void CDialogGameStretchMode::GetItems(CFileItemList& items)
 {
   for (const auto& stretchMode : m_stretchModes)
   {
-    CFileItemPtr item = std::make_shared<CFileItem>(g_localizeStrings.Get(stretchMode.stringIndex));
+    CFileItem item{g_localizeStrings.Get(stretchMode.stringIndex)};
 
     const std::string stretchModeId =
         RETRO::CRetroPlayerUtils::StretchModeToIdentifier(stretchMode.stretchMode);
     if (!stretchModeId.empty())
-      item->SetProperty("game.stretchmode", CVariant{stretchModeId});
+      item.SetProperty("game.stretchmode", CVariant{stretchModeId});
     items.Add(std::move(item));
   }
 }

--- a/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
@@ -54,7 +54,7 @@ void CDialogGameVideoFilter::PreInit()
 
   if (m_items.Size() == 0)
   {
-    CFileItemPtr item = std::make_shared<CFileItem>(g_localizeStrings.Get(231)); // "None"
+    CFileItem item{g_localizeStrings.Get(231)}; // "None"
     m_items.Add(std::move(item));
   }
 
@@ -72,12 +72,11 @@ void CDialogGameVideoFilter::InitVideoFilters()
         RETRO::CRenderVideoSettings videoSettings;
         videoSettings.SetScalingMethod(scalingMethodProps.scalingMethod);
 
-        CFileItemPtr item =
-            std::make_shared<CFileItem>(g_localizeStrings.Get(scalingMethodProps.nameIndex));
-        item->SetLabel2(g_localizeStrings.Get(scalingMethodProps.categoryIndex));
-        item->SetProperty("game.videofilter", CVariant{videoSettings.GetVideoFilter()});
-        item->SetProperty("game.videofilterdescription",
-                          CVariant{g_localizeStrings.Get(scalingMethodProps.descriptionIndex)});
+        CFileItem item{g_localizeStrings.Get(scalingMethodProps.nameIndex)};
+        item.SetLabel2(g_localizeStrings.Get(scalingMethodProps.categoryIndex));
+        item.SetProperty("game.videofilter", CVariant{videoSettings.GetVideoFilter()});
+        item.SetProperty("game.videofilterdescription",
+                         CVariant{g_localizeStrings.Get(scalingMethodProps.descriptionIndex)});
         m_items.Add(std::move(item));
       }
     }

--- a/xbmc/games/dialogs/osd/DialogGameVideoRotation.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoRotation.cpp
@@ -43,8 +43,8 @@ void CDialogGameVideoRotation::GetItems(CFileItemList& items)
 {
   for (unsigned int rotation : m_rotations)
   {
-    CFileItemPtr item = std::make_shared<CFileItem>(GetRotationLabel(rotation));
-    item->SetProperty("game.videorotation", CVariant{rotation});
+    CFileItem item{GetRotationLabel(rotation)};
+    item.SetProperty("game.videorotation", CVariant{rotation});
     items.Add(std::move(item));
   }
 }

--- a/xbmc/games/ports/windows/GUIPortList.cpp
+++ b/xbmc/games/ports/windows/GUIPortList.cpp
@@ -198,10 +198,10 @@ bool CGUIPortList::AddItems(const CPortNode& port,
     const ControllerPtr& controller = controllerNode.GetController();
 
     // Create the list item
-    CFileItemPtr item = std::make_shared<CFileItem>(itemLabel);
-    item->SetLabel2(controller->Layout().Label());
-    item->SetPath(port.GetAddress());
-    item->SetArt("icon", controller->Layout().ImagePath());
+    CFileItem item{itemLabel};
+    item.SetLabel2(controller->Layout().Label());
+    item.SetPath(port.GetAddress());
+    item.SetArt("icon", controller->Layout().ImagePath());
     m_vecItems->Add(std::move(item));
     ++itemId;
 
@@ -221,10 +221,10 @@ bool CGUIPortList::AddItems(const CPortNode& port,
   else
   {
     // Create the list item
-    CFileItemPtr item = std::make_shared<CFileItem>(itemLabel);
-    item->SetLabel2(g_localizeStrings.Get(13298)); // "Disconnected"
-    item->SetPath(port.GetAddress());
-    item->SetArt("icon", "DefaultAddonNone.png");
+    CFileItem item{itemLabel};
+    item.SetLabel2(g_localizeStrings.Get(13298)); // "Disconnected"
+    item.SetPath(port.GetAddress());
+    item.SetArt("icon", "DefaultAddonNone.png");
     m_vecItems->Add(std::move(item));
     ++itemId;
   }

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -262,9 +262,9 @@ void CGUIDialogSongInfo::Update()
   CFileItemList items;
   for (const auto& contributor : m_song->GetMusicInfoTag()->GetContributors())
   {
-    auto item = std::make_shared<CFileItem>(contributor.GetRoleDesc());
-    item->SetLabel2(contributor.GetArtist());
-    item->GetMusicInfoTag()->SetDatabaseId(contributor.GetArtistId(), MediaTypeArtist);
+    CFileItem item{contributor.GetRoleDesc()};
+    item.SetLabel2(contributor.GetArtist());
+    item.GetMusicInfoTag()->SetDatabaseId(contributor.GetArtistId(), MediaTypeArtist);
     items.Add(std::move(item));
   }
   CGUIMessage message(GUI_MSG_LABEL_BIND, GetID(), CONTROL_LIST, 0, 0, &items);


### PR DESCRIPTION
## Description

This PR fixes cppcheck performance checks, similar to https://github.com/xbmc/xbmc/pull/22838, but taking the approach of keeping std::move but using the appropriate move adder in CFileItemList.

In https://github.com/xbmc/xbmc/pull/22838, it was argued that CFileItemList should be extended to accept an item pointer via move operator. It very well could be extended in such a way. However, it already supports a move adder, see: https://github.com/xbmc/xbmc/blob/master/xbmc/FileItem.h#L728-L729

```c++
void Add(CFileItemPtr item);
void Add(CFileItem&& item);
```

So it seems the move parameter is for objects instead of their shared pointer. Fine, lets use this instead of adding another redundant `Add()` function.

## Motivation and context

More performant approach than https://github.com/xbmc/xbmc/pull/22838.

## How has this been tested?

Tested via my RetroPlayer test builds.

## What is the effect on users?

* None

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
