### PR TITLE
[Windows] Remove unused variables

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin32.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin32.cpp
@@ -213,7 +213,6 @@ std::string CAESinkFactoryWin::GetDefaultDeviceId()
   std::string strDeviceId = "";
   ComPtr<IMMDevice> pDevice = nullptr;
   ComPtr<IMMDeviceEnumerator> pEnumerator = nullptr;
-  LPWSTR pwszID = NULL;
   std::wstring wstrDDID;
 
   HRESULT hr = CoCreateInstance(CLSID_MMDeviceEnumerator, NULL, CLSCTX_ALL, IID_IMMDeviceEnumerator, reinterpret_cast<void**>(pEnumerator.GetAddressOf()));

--- a/xbmc/windowing/windows/VideoSyncD3D.cpp
+++ b/xbmc/windowing/windows/VideoSyncD3D.cpp
@@ -74,7 +74,7 @@ void CVideoSyncD3D::Run(CEvent& stopEvent)
     // sleep until vblank
     Microsoft::WRL::ComPtr<IDXGIOutput> pOutput;
     DX::DeviceResources::Get()->GetOutput(&pOutput);
-    HRESULT hr = pOutput->WaitForVBlank();
+    pOutput->WaitForVBlank();
 
     // calculate how many vblanks happened
     Now = CurrentHostCounter();

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -180,9 +180,6 @@ bool CWinSystemWin32::CreateNewWindow(const std::string& name, bool fullScreen, 
       // are for the client part of the window.
       RECT rcWorkArea = GetScreenWorkArea(m_hMonitor);
 
-      int workAreaWidth = rcWorkArea.right - rcWorkArea.left;
-      int workAreaHeight = rcWorkArea.bottom - rcWorkArea.top;
-
       RECT rcNcArea = GetNcAreaOffsets(m_windowStyle, false, m_windowExStyle);
       int maxClientWidth = (rcWorkArea.right - rcNcArea.right) - (rcWorkArea.left - rcNcArea.left);
       int maxClientHeight = (rcWorkArea.bottom - rcNcArea.bottom) - (rcWorkArea.top - rcNcArea.top);
@@ -405,9 +402,6 @@ void CWinSystemWin32::AdjustWindow(bool forceResize)
         // Windowed mode: position and size in settings and most places in Kodi
         // are for the client part of the window.
         RECT rcWorkArea = GetScreenWorkArea(m_hMonitor);
-
-        int workAreaWidth = rcWorkArea.right - rcWorkArea.left;
-        int workAreaHeight = rcWorkArea.bottom - rcWorkArea.top;
 
         RECT rcNcArea = GetNcAreaOffsets(m_windowStyle, false, m_windowExStyle);
         int maxClientWidth =
@@ -817,9 +811,6 @@ RECT CWinSystemWin32::ScreenRect(HMONITOR handle)
 void CWinSystemWin32::GetConnectedDisplays(std::vector<MONITOR_DETAILS>& outputs)
 {
   using KODI::PLATFORM::WINDOWS::FromW;
-
-  const POINT ptZero = { 0, 0 };
-  HMONITOR hmPrimary = MonitorFromPoint(ptZero, MONITOR_DEFAULTTOPRIMARY);
 
   DISPLAY_DEVICEW ddAdapter = {};
   ddAdapter.cb = sizeof(ddAdapter);


### PR DESCRIPTION
## Description
Remove unused variables

## Motivation and context
Detected some unused variables by compiler:

`22>T:\KODI\kodi\xbmc\cores\AudioEngine\Sinks\windows\AESinkFactoryWin32.cpp(216,10): warning C4189: 'pwszID': local variable is initialized but not referenced`

`22>T:\KODI\kodi\xbmc\windowing\windows\VideoSyncD3D.cpp(77,13): warning C4189: 'hr': local variable is initialized but not referenced`

```
22>T:\KODI\kodi\xbmc\windowing\windows\WinSystemWin32.cpp(183,11): warning C4189: 'workAreaWidth': local variable is initialized but not referenced
22>T:\KODI\kodi\xbmc\windowing\windows\WinSystemWin32.cpp(184,11): warning C4189: 'workAreaHeight': local variable is initialized but not referenced
22>T:\KODI\kodi\xbmc\windowing\windows\WinSystemWin32.cpp(409,13): warning C4189: 'workAreaWidth': local variable is initialized but not referenced
22>T:\KODI\kodi\xbmc\windowing\windows\WinSystemWin32.cpp(410,13): warning C4189: 'workAreaHeight': local variable is initialized but not referenced 
```

`22>T:\KODI\kodi\xbmc\windowing\windows\WinSystemWin32.cpp(822,12): warning C4189: 'hmPrimary': local variable is initialized but not referenced`

## How has this been tested?
Still builds and runs

## What is the effect on users?
none

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
