### PR TITLE
Fix Visual Studio warning C4701: potentially uninitialized local variable used

### DIFF
--- a/xbmc/cdrip/CDDARipJob.cpp
+++ b/xbmc/cdrip/CDDARipJob.cpp
@@ -98,8 +98,8 @@ bool CCDDARipJob::DoWork()
   // start ripping
   int percent = 0;
   int oldpercent = 0;
-  bool cancelled(false);
-  int result;
+  bool cancelled{false};
+  int result{-1};
   while (!cancelled && (result = RipChunk(reader, encoder, percent)) == 0)
   {
     cancelled = ShouldCancel(percent, 100);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -3017,7 +3017,7 @@ IAE::SoundPtr CActiveAE::MakeSound(const std::string& file)
   AVIOContext *io_ctx;
   const AVInputFormat* io_fmt = nullptr;
   const AVCodec* dec = nullptr;
-  SampleConfig config;
+  SampleConfig config{};
 
   // No custom deleter until sound is registered
   auto sound = std::make_unique<CActiveAESound>(file, this);

--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
@@ -590,8 +590,7 @@ unsigned int CAEStreamParser::SyncDTS(uint8_t* data, unsigned int size)
     if (m_fsize < 96 || m_fsize > 16384)
       continue;
 
-    bool invalid = false;
-    CAEStreamInfo::DataType dataType;
+    CAEStreamInfo::DataType dataType{CAEStreamInfo::STREAM_TYPE_NULL};
     switch (dtsBlocks << 5)
     {
       case 512:
@@ -603,12 +602,9 @@ unsigned int CAEStreamParser::SyncDTS(uint8_t* data, unsigned int size)
       case 2048:
         dataType = CAEStreamInfo::STREAM_TYPE_DTS_2048;
         break;
-      default:
-        invalid = true;
-        break;
     }
 
-    if (invalid)
+    if (dataType == CAEStreamInfo::STREAM_TYPE_NULL)
       continue;
 
     // adjust the fsize for 14 bit streams

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -727,7 +727,7 @@ std::vector<CGUIFontTTF::Glyph> CGUIFontTTF::GetHarfBuzzShapedGlyphs(const vecTe
   std::vector<hb_script_t> scripts;
   std::vector<RunInfo> runs;
   hb_unicode_funcs_t* ufuncs = hb_unicode_funcs_get_default();
-  hb_script_t lastScript;
+  hb_script_t lastScript{HB_SCRIPT_INVALID};
   int lastScriptIndex = -1;
   int lastSetIndex = -1;
 


### PR DESCRIPTION
## Description
Fix Visual Studio warning C4701: potentially uninitialized local variable used

## Motivation and context
Visual Studio detects these warnings although seems none of them occurs in normal use (but code allows potentially occurs):

```
22>T:\KODI\kodi\xbmc\cores\AudioEngine\Utils\AEStreamInfo.cpp(671): warning C4701: potentially uninitialized local variable 'dataType' used
22>T:\KODI\kodi\xbmc\cores\AudioEngine\Engines\ActiveAE\ActiveAE.cpp(3089): warning C4701: potentially uninitialized local variable 'config' used
22>T:\KODI\kodi\xbmc\guilib\GUIFontTTF.cpp(747): warning C4701: potentially uninitialized local variable 'lastScript' used
22>T:\KODI\kodi\xbmc\cdrip\CDDARipJob.cpp(118): warning C4701: potentially uninitialized local variable 'result' used
```

It is better to remove these warnings even if they do not cause damage.

## How has this been tested?
Build and runtime test Windows x64

## What is the effect on users?
none

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
