### PR TITLE
Port Dialog: Fix segfault when choosing a controller, and minor improvements

### DIFF
--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -599,8 +599,6 @@ void CGameClient::LogException(const char* strFunctionName) const
 
 void CGameClient::cb_close_game(KODI_HANDLE kodiInstance)
 {
-  using namespace MESSAGING;
-
   CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
                                              static_cast<void*>(new CAction(ACTION_STOP)));
 }

--- a/xbmc/games/addons/input/GameClientInput.cpp
+++ b/xbmc/games/addons/input/GameClientInput.cpp
@@ -407,11 +407,11 @@ bool CGameClientInput::DisconnectController(const std::string& portAddress)
 
 void CGameClientInput::SavePorts()
 {
+  // Save port state
+  m_portManager->SaveXMLAsync();
+
   // Let the observers know that ports have changed
   NotifyObservers(ObservableMessageGamePortsChanged);
-
-  // Save port state
-  m_portManager->SaveXML();
 }
 
 void CGameClientInput::ResetPorts()

--- a/xbmc/games/addons/input/GameClientInput.cpp
+++ b/xbmc/games/addons/input/GameClientInput.cpp
@@ -61,6 +61,8 @@ void CGameClientInput::Initialize()
   // Send controller layouts to game client
   SetControllerLayouts(m_topology->GetControllerTree().GetControllers());
 
+  std::lock_guard<std::recursive_mutex> lock(m_portMutex);
+
   // Reset ports to default state (first accepted controller is connected)
   ActivateControllers(m_topology->GetControllerTree());
 
@@ -72,23 +74,27 @@ void CGameClientInput::Initialize()
 
 void CGameClientInput::Start(IGameInputCallback* input)
 {
-  m_inputCallback = input;
-
-  // Connect/disconnect active controllers
-  for (const CPortNode& port : GetActiveControllerTree().GetPorts())
   {
-    if (port.IsConnected())
-    {
-      const ControllerPtr& activeController = port.GetActiveController().GetController();
-      if (activeController)
-        ConnectController(port.GetAddress(), activeController);
-    }
-    else
-      DisconnectController(port.GetAddress());
-  }
+    std::lock_guard<std::recursive_mutex> lock(m_portMutex);
 
-  // Ensure hardware is open to receive events
-  m_hardware.reset(new CGameClientHardware(m_gameClient));
+    m_inputCallback = input;
+
+    // Connect/disconnect active controllers
+    for (const CPortNode& port : GetActiveControllerTree().GetPorts())
+    {
+      if (port.IsConnected())
+      {
+        const ControllerPtr& activeController = port.GetActiveController().GetController();
+        if (activeController)
+          ConnectController(port.GetAddress(), activeController);
+      }
+      else
+        DisconnectController(port.GetAddress());
+    }
+
+    // Ensure hardware is open to receive events
+    m_hardware.reset(new CGameClientHardware(m_gameClient));
+  }
 
   // Notify observers of the initial port configuration
   NotifyObservers(ObservableMessageGamePortsChanged);
@@ -105,6 +111,8 @@ void CGameClientInput::Deinitialize()
 
 void CGameClientInput::Stop()
 {
+  std::lock_guard<std::recursive_mutex> lock(m_portMutex);
+
   m_hardware.reset();
 
   CloseMouse();
@@ -312,6 +320,8 @@ bool CGameClientInput::ConnectController(const std::string& portAddress,
     return false;
   }
 
+  std::lock_guard<std::recursive_mutex> lock(m_portMutex);
+
   const CPortNode& currentPort = GetActiveControllerTree().GetPort(portAddress);
 
   // Close current ports if any are open
@@ -367,6 +377,8 @@ bool CGameClientInput::DisconnectController(const std::string& portAddress)
 {
   PERIPHERALS::EventLockHandlePtr inputHandlingLock;
 
+  std::lock_guard<std::recursive_mutex> lock(m_portMutex);
+
   // If port is a multitap, we need to deactivate its children
   const CPortNode& currentPort = GetActiveControllerTree().GetPort(portAddress);
   CloseJoysticks(currentPort, inputHandlingLock);
@@ -407,8 +419,12 @@ bool CGameClientInput::DisconnectController(const std::string& portAddress)
 
 void CGameClientInput::SavePorts()
 {
-  // Save port state
-  m_portManager->SaveXMLAsync();
+  {
+    std::lock_guard<std::recursive_mutex> lock(m_portMutex);
+
+    // Save port state
+    m_portManager->SaveXMLAsync();
+  }
 
   // Let the observers know that ports have changed
   NotifyObservers(ObservableMessageGamePortsChanged);
@@ -416,6 +432,8 @@ void CGameClientInput::SavePorts()
 
 void CGameClientInput::ResetPorts()
 {
+  std::lock_guard<std::recursive_mutex> lock(m_portMutex);
+
   const CControllerTree& controllerTree = GetDefaultControllerTree();
   for (const CPortNode& port : controllerTree.GetPorts())
     ConnectController(port.GetAddress(), port.GetActiveController().GetController());
@@ -423,6 +441,8 @@ void CGameClientInput::ResetPorts()
 
 bool CGameClientInput::HasAgent() const
 {
+  std::lock_guard<std::recursive_mutex> lock(m_portMutex);
+
   if (!m_joysticks.empty())
     return true;
 
@@ -450,6 +470,8 @@ bool CGameClientInput::OpenKeyboard(const ControllerPtr& controller,
     return false;
 
   bool bSuccess = false;
+
+  std::lock_guard<std::recursive_mutex> lock(m_portMutex);
 
   {
     std::unique_lock<CCriticalSection> lock(m_clientAccess);
@@ -480,11 +502,15 @@ bool CGameClientInput::OpenKeyboard(const ControllerPtr& controller,
 
 bool CGameClientInput::IsKeyboardOpen() const
 {
+  std::lock_guard<std::recursive_mutex> lock(m_portMutex);
+
   return static_cast<bool>(m_keyboard);
 }
 
 void CGameClientInput::CloseKeyboard()
 {
+  std::lock_guard<std::recursive_mutex> lock(m_portMutex);
+
   if (m_keyboard)
   {
     m_keyboard.reset();
@@ -521,6 +547,8 @@ bool CGameClientInput::OpenMouse(const ControllerPtr& controller,
 
   bool bSuccess = false;
 
+  std::lock_guard<std::recursive_mutex> lock(m_portMutex);
+
   {
     std::unique_lock<CCriticalSection> lock(m_clientAccess);
 
@@ -549,11 +577,15 @@ bool CGameClientInput::OpenMouse(const ControllerPtr& controller,
 
 bool CGameClientInput::IsMouseOpen() const
 {
+  std::lock_guard<std::recursive_mutex> lock(m_portMutex);
+
   return static_cast<bool>(m_mouse);
 }
 
 void CGameClientInput::CloseMouse()
 {
+  std::lock_guard<std::recursive_mutex> lock(m_portMutex);
+
   if (m_mouse)
   {
     m_mouse.reset();

--- a/xbmc/games/addons/input/GameClientInput.h
+++ b/xbmc/games/addons/input/GameClientInput.h
@@ -16,6 +16,7 @@
 
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 
 class CCriticalSection;
@@ -131,8 +132,18 @@ private:
    */
   JoystickMap m_joysticks;
 
-  // TODO: Guard with a mutex
+  /*!
+   * \brief Serializable port state
+   */
   std::unique_ptr<CPortManager> m_portManager;
+
+  /*!
+   * \brief Mutex for port state
+   *
+   * Mutex is recursive to allow for management of several ports within the
+   * function ResetPorts().
+   */
+  mutable std::recursive_mutex m_portMutex;
 
   /*!
    * \brief Keyboard handler

--- a/xbmc/games/controllers/dialogs/ControllerSelect.cpp
+++ b/xbmc/games/controllers/dialogs/ControllerSelect.cpp
@@ -39,6 +39,9 @@ void CControllerSelect::Initialize(ControllerVector controllers,
   if (!callback)
     return;
 
+  // Stop thread and reset state
+  Deinitialize();
+
   // Initialize state
   m_controllers = std::move(controllers);
   m_defaultController = std::move(defaultController);

--- a/xbmc/games/controllers/guicontrols/GUIFeatureButton.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIFeatureButton.cpp
@@ -44,8 +44,6 @@ bool CGUIFeatureButton::DoPrompt(const std::string& strPrompt,
                                  const std::string& strFeature,
                                  CEvent& waitEvent)
 {
-  using namespace MESSAGING;
-
   bool bInterrupted = false;
 
   if (!HasFocus())

--- a/xbmc/games/controllers/windows/GUIControllerList.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerList.cpp
@@ -171,7 +171,6 @@ void CGUIControllerList::OnEvent(const ADDON::AddonEvent& event)
       typeid(event) == typeid(ADDON::AddonEvents::ReInstalled) ||
       typeid(event) == typeid(ADDON::AddonEvents::UnInstalled))
   {
-    using namespace MESSAGING;
     CGUIMessage msg(GUI_MSG_REFRESH_LIST, m_guiWindow->GetID(), CONTROL_CONTROLLER_LIST);
 
     // Focus installed add-on

--- a/xbmc/games/ports/input/PortManager.h
+++ b/xbmc/games/ports/input/PortManager.h
@@ -10,6 +10,10 @@
 
 #include "games/controllers/types/ControllerTree.h"
 
+#include <future>
+#include <mutex>
+#include <string>
+
 class TiXmlElement;
 
 namespace KODI
@@ -27,7 +31,7 @@ public:
 
   void SetControllerTree(const CControllerTree& controllerTree);
   void LoadXML();
-  void SaveXML();
+  void SaveXMLAsync();
   void Clear();
 
   void ConnectController(const std::string& portAddress,
@@ -69,6 +73,9 @@ private:
 
   CControllerTree m_controllerTree;
   std::string m_xmlPath;
+
+  std::vector<std::future<void>> m_saveFutures;
+  std::mutex m_saveMutex;
 };
 } // namespace GAME
 } // namespace KODI

--- a/xbmc/games/ports/types/PortNode.cpp
+++ b/xbmc/games/ports/types/PortNode.cpp
@@ -45,6 +45,7 @@ CPortNode& CPortNode::operator=(CPortNode&& rhs) noexcept
     m_portType = rhs.m_portType;
     m_portId = std::move(rhs.m_portId);
     m_address = std::move(rhs.m_address);
+    m_forceConnected = rhs.m_forceConnected;
     m_controllers = std::move(rhs.m_controllers);
   }
 

--- a/xbmc/games/ports/windows/GUIPortList.cpp
+++ b/xbmc/games/ports/windows/GUIPortList.cpp
@@ -160,7 +160,6 @@ void CGUIPortList::ResetPorts()
     m_gameClient->Input().SavePorts();
 
     // Refresh the GUI
-    using namespace MESSAGING;
     CGUIMessage msg(GUI_MSG_REFRESH_LIST, m_guiWindow.GetID(), CONTROL_PORT_LIST);
     CServiceBroker::GetAppMessenger()->SendGUIMessage(msg, m_guiWindow.GetID());
   }
@@ -173,7 +172,6 @@ void CGUIPortList::OnEvent(const ADDON::AddonEvent& event)
       typeid(event) == typeid(ADDON::AddonEvents::ReInstalled) ||
       typeid(event) == typeid(ADDON::AddonEvents::UnInstalled))
   {
-    using namespace MESSAGING;
     CGUIMessage msg(GUI_MSG_REFRESH_LIST, m_guiWindow.GetID(), CONTROL_PORT_LIST);
     msg.SetStringParam(event.addonId);
     CServiceBroker::GetAppMessenger()->SendGUIMessage(msg, m_guiWindow.GetID());
@@ -301,7 +299,6 @@ void CGUIPortList::OnControllerSelected(const CPortNode& port, const ControllerP
     }
 
     // Send a GUI message to reload the port list
-    using namespace MESSAGING;
     CGUIMessage msg(GUI_MSG_REFRESH_LIST, m_guiWindow.GetID(), CONTROL_PORT_LIST);
     CServiceBroker::GetAppMessenger()->SendGUIMessage(msg, m_guiWindow.GetID());
   }

--- a/xbmc/games/ports/windows/GUIPortList.cpp
+++ b/xbmc/games/ports/windows/GUIPortList.cpp
@@ -208,6 +208,7 @@ bool CGUIPortList::AddItems(const CPortNode& port,
     for (const CPortNode& childPort : ports)
     {
       std::ostringstream childItemLabel;
+      childItemLabel << " - ";
       childItemLabel << controller->Layout().Label();
       childItemLabel << " - ";
       childItemLabel << GetLabel(childPort);


### PR DESCRIPTION
Replaces https://github.com/xbmc/xbmc/pull/23494 to fix Jenkins issues.

## Description

I was able to reproduce a segfault in the Port Dialog. The problem occurs if you chose a controller, and then too quickly choose another controller.

The fix is to simply block until the first controller is done being selected, and then allow the new controller to be selected:

```patch
--- a/xbmc/games/controllers/dialogs/ControllerSelect.cpp
+++ b/xbmc/games/controllers/dialogs/ControllerSelect.cpp
@@ -39,6 +39,9 @@ void CControllerSelect::Initialize(ControllerVector controllers,
   if (!callback)
     return;

+  // Stop thread and reset state
+  Deinitialize();
+
   // Initialize state
   m_controllers = std::move(controllers);
   m_defaultController = std::move(defaultController);
```

The PR also includes a completion of a TODO, by adding a mutex where there should be a mutex. I wasn't able to navigate fast enough to crash Kodi without it but better safe than sorry.

Finally, I moved saving the ports.xml file off-thread, as the newly added lock was held when writing the file, and therefore could block the GUI or other threads waiting on file I/O.

EDIT

I pushed one more tweak (`Port Dialog: More visible multitaps`) to make multitaps more visible:

```patch
--- a/xbmc/games/ports/windows/GUIPortList.cpp
+++ b/xbmc/games/ports/windows/GUIPortList.cpp
@@ -208,6 +208,7 @@ bool CGUIPortList::AddItems(const CPortNode& port,
     for (const CPortNode& childPort : ports)
     {
       std::ostringstream childItemLabel;
+      childItemLabel << " - ";
       childItemLabel << controller->Layout().Label();
       childItemLabel << " - ";
       childItemLabel << GetLabel(childPort);
```

Result, before:

![screenshot00020](https://github.com/xbmc/xbmc/assets/531482/80db0911-a532-4669-bc11-0b45a61bc985)

Result, after:

![screenshot00019](https://github.com/xbmc/xbmc/assets/531482/1ecb6c7e-12db-4750-931b-6f192bb0a263)

## Motivation and context

Discovered when putting the Player Viewer through some heavy testing.

## How has this been tested?

Tested as part of my latest builds: https://github.com/garbear/xbmc/releases

## What is the effect on users?

* Fixed segfault in the Port Dialog

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
