### PR TITLE
[Windows] [Rendering] HDR Auto Switch rework

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7303,7 +7303,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#13436"
-msgid "Use display HDR capabilities"
+msgid "AutoHDR Switching"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -20121,10 +20121,10 @@ msgctxt "#36298"
 msgid "If enabled, a recording for the programme to remind will be scheduled when auto-closing the reminder popup, if supported by the PVR add-on and backend."
 msgstr ""
 
-#. Description of setting with label #13436 "Use display HDR capabilities"
+#. Description of setting with label #13436 "AutoHDR Switching"
 #: system/settings/settings.xml
 msgctxt "#36299"
-msgid "Switch display into HDR mode if media with HDR information is played.[CR]If disabled, HDR information are applied using Kodi's internal HDR path."
+msgid "Switch display into HDR mode if media with HDR information is played.[CR]If disabled, HDR information is applied using Kodi's internal path."
 msgstr ""
 
 #. Description of setting with label #20226 "Movie set information folder"

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
@@ -192,5 +192,6 @@ protected:
   DXGI_HDR_METADATA_HDR10 m_lastHdr10 = {};
   HDR_TYPE m_HdrType = HDR_TYPE::HDR_NONE_SDR;
   bool m_AutoSwitchHDR = false;
+  bool m_isHdrEnabled = false;
   std::string m_renderMethodName;
 };


### PR DESCRIPTION


## Description
When auto switch HDR is enabled in settings, Kodi will now try to remember Windows HDR toggle status and restore after playback. Also removed some not-needed code and changed SDR detection a little

## Motivation and context
 I noticed Kodi was toggling HDR twice sometimes in log. Also, Kodi shouldn't try to force users to view the GUI in SDR. Kodi should leave things how it found them, including the state of HDR toggle in Windows.

## How has this been tested?
I tested it on my own machine when I'm watching movies every night.

## What is the effect on users?
Users will notice when they exit Kodi that their Windows HDR state is the same as before opening Kodi.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
