### PR TITLE
Game OSD: Move controller ID from core to the skin

### DIFF
--- a/addons/skin.estuary/xml/GameOSD.xml
+++ b/addons/skin.estuary/xml/GameOSD.xml
@@ -32,11 +32,12 @@
 							<height>130</height>
 							<font>font13</font>
 						</control>
-						<control type="gamecontroller" id="1102">
+						<control type="gamecontroller">
 							<top>160</top>
 							<left>30</left>
 							<width>640</width>
 							<height>640</height>
+							<controllerId>game.controller.snes</controllerId>
 						</control>
 						<control type="textbox">
 							<description>Additional help text. This will be removed in future versions.</description>
@@ -200,33 +201,33 @@
 							</control>
 						</focusedlayout>
 						<content>
-							<item id="2101">
+							<item>
 								<description>Pause / Resume button</description>
 								<label>$LOCALIZE[35224]</label>
 								<label2>$LOCALIZE[31059]</label2>
 								<icon>osd/fullscreen/buttons/play.png</icon>
 								<onclick>Play</onclick>
 							</item>
-							<item id="2102">
+							<item>
 								<description>Save / Load button</description>
 								<label>$LOCALIZE[35249]</label>
 								<icon>osd/fullscreen/buttons/saves.png</icon>
 								<onclick>ActivateWindow(InGameSaves)</onclick>
 							</item>
-							<item id="2103">
+							<item>
 								<description>Reset button</description>
 								<label>$LOCALIZE[13007]</label>
 								<icon>osd/fullscreen/buttons/reset.png</icon>
 								<onclick>PlayerControl(Reset)</onclick>
 							</item>
-							<item id="2104">
+							<item>
 								<description>Stop button</description>
 								<label>$LOCALIZE[35222]</label>
 								<label2>$LOCALIZE[31060]</label2>
 								<icon>osd/fullscreen/buttons/stop.png</icon>
 								<onclick>Stop</onclick>
 							</item>
-							<item id="2105">
+							<item>
 								<description>Settings button</description>
 								<label>$LOCALIZE[5]</label>
 								<icon>osd/fullscreen/buttons/settings.png</icon>

--- a/xbmc/games/addons/input/GameClientTopology.cpp
+++ b/xbmc/games/addons/input/GameClientTopology.cpp
@@ -108,3 +108,23 @@ std::string CGameClientTopology::MakeAddress(const std::string& baseAddress,
 
   return address.str();
 }
+
+std::pair<std::string, std::string> CGameClientTopology::SplitAddress(
+    const std::string& nodeAddress)
+{
+  std::string baseAddress;
+  std::string nodeId;
+
+  size_t separatorPos = nodeAddress.find_last_of(CONTROLLER_ADDRESS_SEPARATOR);
+  if (separatorPos != std::string::npos)
+  {
+    baseAddress = nodeAddress.substr(0, separatorPos);
+    nodeId = nodeAddress.substr(separatorPos + 1);
+  }
+  else
+  {
+    baseAddress = nodeAddress;
+  }
+
+  return std::make_pair(baseAddress, nodeId);
+}

--- a/xbmc/games/addons/input/GameClientTopology.h
+++ b/xbmc/games/addons/input/GameClientTopology.h
@@ -30,8 +30,9 @@ public:
   const CControllerTree& GetControllerTree() const { return m_controllers; }
   CControllerTree& GetControllerTree() { return m_controllers; }
 
-  // Utility function
+  // Utility functions
   static std::string MakeAddress(const std::string& baseAddress, const std::string& nodeId);
+  static std::pair<std::string, std::string> SplitAddress(const std::string& nodeAddress);
 
 private:
   static CControllerTree GetControllerTree(const GameClientPortVec& ports);

--- a/xbmc/games/controllers/guicontrols/GUIGameController.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIGameController.cpp
@@ -8,24 +8,40 @@
 
 #include "GUIGameController.h"
 
+#include "FileItem.h"
+#include "ServiceBroker.h"
+#include "games/GameServices.h"
+#include "games/addons/input/GameClientTopology.h"
 #include "games/controllers/Controller.h"
 #include "games/controllers/ControllerLayout.h"
+#include "guilib/GUIListItem.h"
 #include "utils/log.h"
 
 #include <mutex>
+#include <tuple>
 
 using namespace KODI;
 using namespace GAME;
 
-CGUIGameController::CGUIGameController(
-    int parentID, int controlID, float posX, float posY, float width, float height)
-  : CGUIImage(parentID, controlID, posX, posY, width, height, CTextureInfo())
+CGUIGameController::CGUIGameController(int parentID,
+                                       int controlID,
+                                       float posX,
+                                       float posY,
+                                       float width,
+                                       float height,
+                                       const CTextureInfo& texture)
+  : CGUIImage(parentID, controlID, posX, posY, width, height, texture)
 {
   // Initialize CGUIControl
   ControlType = GUICONTROL_GAMECONTROLLER;
 }
 
-CGUIGameController::CGUIGameController(const CGUIGameController& from) : CGUIImage(from)
+CGUIGameController::CGUIGameController(const CGUIGameController& from)
+  : CGUIImage(from),
+    m_controllerIdInfo(from.m_controllerIdInfo),
+    m_controllerAddressInfo(from.m_controllerAddressInfo),
+    m_currentController(from.m_currentController),
+    m_portAddress(from.m_portAddress)
 {
   // Initialize CGUIControl
   ControlType = GUICONTROL_GAMECONTROLLER;
@@ -40,7 +56,7 @@ void CGUIGameController::Render(void)
 {
   CGUIImage::Render();
 
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
 
   if (m_currentController)
   {
@@ -48,17 +64,96 @@ void CGUIGameController::Render(void)
   }
 }
 
+void CGUIGameController::UpdateInfo(const CGUIListItem* item /* = nullptr */)
+{
+  CGUIImage::UpdateInfo(item);
+
+  if (item != nullptr)
+  {
+    std::string controllerId;
+    std::string portAddress;
+
+    if (item->HasProperty("Addon.ID"))
+      controllerId = item->GetProperty("Addon.ID").asString();
+
+    if (controllerId.empty())
+      controllerId = m_controllerIdInfo.GetItemLabel(item);
+
+    std::string controllerAddress = m_controllerAddressInfo.GetItemLabel(item);
+    if (!controllerAddress.empty())
+      std::tie(portAddress, controllerId) = CGameClientTopology::SplitAddress(controllerAddress);
+
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    if (!controllerId.empty())
+      ActivateController(controllerId);
+    if (!portAddress.empty())
+      m_portAddress = portAddress;
+  }
+}
+
+void CGUIGameController::SetControllerID(const KODI::GUILIB::GUIINFO::CGUIInfoLabel& controllerId)
+{
+  m_controllerIdInfo = controllerId;
+
+  // Check if a controller ID is available without a listitem
+  static const CFileItem empty;
+  const std::string strControllerId = m_controllerIdInfo.GetItemLabel(&empty);
+  if (!strControllerId.empty())
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    ActivateController(strControllerId);
+  }
+}
+
+void CGUIGameController::SetControllerAddress(
+    const KODI::GUILIB::GUIINFO::CGUIInfoLabel& controllerAddress)
+{
+  m_controllerAddressInfo = controllerAddress;
+
+  // Check if a controller address is available without a listitem
+  static const CFileItem empty;
+  const std::string strControllerAddress = m_controllerAddressInfo.GetItemLabel(&empty);
+  if (!strControllerAddress.empty())
+  {
+    std::string controllerId;
+    std::string portAddress;
+    std::tie(portAddress, controllerId) = CGameClientTopology::SplitAddress(strControllerAddress);
+
+    std::lock_guard<std::mutex> lock(m_mutex);
+    ActivateController(controllerId);
+    m_portAddress = portAddress;
+  }
+}
+
+void CGUIGameController::ActivateController(const std::string& controllerId)
+{
+  CGameServices& gameServices = CServiceBroker::GetGameServices();
+
+  ControllerPtr controller = gameServices.GetController(controllerId);
+
+  ActivateController(controller);
+}
+
 void CGUIGameController::ActivateController(const ControllerPtr& controller)
 {
-  std::unique_lock<CCriticalSection> lock(m_mutex);
+  if (!controller)
+    return;
 
-  if (controller && controller != m_currentController)
+  bool updated = false;
+
+  if (!m_currentController || controller->ID() != m_currentController->ID())
   {
     m_currentController = controller;
-
-    lock.unlock();
-
-    //! @todo Sometimes this fails on window init
-    SetFileName(m_currentController->Layout().ImagePath());
+    updated = true;
   }
+
+  if (updated)
+    SetFileName(m_currentController->Layout().ImagePath());
+}
+
+std::string CGUIGameController::GetPortAddress()
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+  return m_portAddress;
 }

--- a/xbmc/games/controllers/guicontrols/GUIGameController.h
+++ b/xbmc/games/controllers/guicontrols/GUIGameController.h
@@ -10,7 +10,8 @@
 
 #include "games/controllers/ControllerTypes.h"
 #include "guilib/GUIImage.h"
-#include "threads/CriticalSection.h"
+
+#include <mutex>
 
 namespace KODI
 {
@@ -19,8 +20,13 @@ namespace GAME
 class CGUIGameController : public CGUIImage
 {
 public:
-  CGUIGameController(
-      int parentID, int controlID, float posX, float posY, float width, float height);
+  CGUIGameController(int parentID,
+                     int controlID,
+                     float posX,
+                     float posY,
+                     float width,
+                     float height,
+                     const CTextureInfo& texture);
   CGUIGameController(const CGUIGameController& from);
 
   ~CGUIGameController() override = default;
@@ -28,12 +34,28 @@ public:
   // implementation of CGUIControl via CGUIImage
   CGUIGameController* Clone() const override;
   void Render() override;
+  void UpdateInfo(const CGUIListItem* item = nullptr) override;
 
+  // GUI functions
+  void SetControllerID(const KODI::GUILIB::GUIINFO::CGUIInfoLabel& controllerId);
+  void SetControllerAddress(const KODI::GUILIB::GUIINFO::CGUIInfoLabel& controllerAddress);
+
+  // Game functions
+  void ActivateController(const std::string& controllerId);
   void ActivateController(const ControllerPtr& controller);
+  std::string GetPortAddress();
 
 private:
+  // GUI parameters
+  KODI::GUILIB::GUIINFO::CGUIInfoLabel m_controllerIdInfo;
+  KODI::GUILIB::GUIINFO::CGUIInfoLabel m_controllerAddressInfo;
+
+  // Game parameters
   ControllerPtr m_currentController;
-  CCriticalSection m_mutex;
+  std::string m_portAddress;
+
+  // Synchronization parameters
+  std::mutex m_mutex;
 };
 } // namespace GAME
 } // namespace KODI

--- a/xbmc/games/dialogs/osd/DialogGameOSDHelp.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameOSDHelp.cpp
@@ -9,9 +9,6 @@
 #include "DialogGameOSDHelp.h"
 
 #include "DialogGameOSD.h"
-#include "ServiceBroker.h"
-#include "games/GameServices.h"
-#include "games/controllers/guicontrols/GUIGameController.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
@@ -21,7 +18,6 @@ using namespace KODI;
 using namespace GAME;
 
 const int CDialogGameOSDHelp::CONTROL_ID_HELP_TEXT = 1101;
-const int CDialogGameOSDHelp::CONTROL_ID_GAME_CONTROLLER = 1102;
 
 CDialogGameOSDHelp::CDialogGameOSDHelp(CDialogGameOSD& dialog) : m_dialog(dialog)
 {
@@ -37,28 +33,11 @@ void CDialogGameOSDHelp::OnInitWindow()
   CGUIMessage msg(GUI_MSG_LABEL_SET, WINDOW_DIALOG_GAME_OSD, CONTROL_ID_HELP_TEXT);
   msg.SetLabel(helpText);
   m_dialog.OnMessage(msg);
-
-  // Set controller
-  if (CServiceBroker::IsServiceManagerUp())
-  {
-    CGameServices& gameServices = CServiceBroker::GetGameServices();
-
-    //! @todo Define SNES controller elsewhere
-    ControllerPtr controller = gameServices.GetController("game.controller.snes");
-    if (controller)
-    {
-      //! @todo Activate controller for all game controller controls
-      CGUIGameController* guiController =
-          dynamic_cast<CGUIGameController*>(m_dialog.GetControl(CONTROL_ID_GAME_CONTROLLER));
-      if (guiController != nullptr)
-        guiController->ActivateController(controller);
-    }
-  }
 }
 
 bool CDialogGameOSDHelp::IsVisible()
 {
-  return IsVisible(CONTROL_ID_HELP_TEXT) || IsVisible(CONTROL_ID_GAME_CONTROLLER);
+  return IsVisible(CONTROL_ID_HELP_TEXT);
 }
 
 bool CDialogGameOSDHelp::IsVisible(int windowId)

--- a/xbmc/games/dialogs/osd/DialogGameOSDHelp.h
+++ b/xbmc/games/dialogs/osd/DialogGameOSDHelp.h
@@ -34,7 +34,6 @@ private:
 
   // Help control IDs
   static const int CONTROL_ID_HELP_TEXT;
-  static const int CONTROL_ID_GAME_CONTROLLER;
 };
 } // namespace GAME
 } // namespace KODI

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -1555,8 +1555,29 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     control = new CGUIRenderingControl(parentID, id, posX, posY, width, height);
     break;
   case CGUIControl::GUICONTROL_GAMECONTROLLER:
-    control = new GAME::CGUIGameController(parentID, id, posX, posY, width, height);
+  {
+    control = new GAME::CGUIGameController(parentID, id, posX, posY, width, height, texture);
+
+    GAME::CGUIGameController* gcontrol = static_cast<GAME::CGUIGameController*>(control);
+
+    // Set texture
+    gcontrol->SetInfo(textureFile);
+
+    // Set aspect ratio
+    gcontrol->SetAspectRatio(aspect);
+
+    // Set controller ID
+    GUIINFO::CGUIInfoLabel controllerId;
+    GetInfoLabel(pControlNode, "controllerId", controllerId, parentID);
+    gcontrol->SetControllerID(controllerId);
+
+    // Set controller address
+    GUIINFO::CGUIInfoLabel controllerAddress;
+    GetInfoLabel(pControlNode, "controllerAddress", controllerAddress, parentID);
+    gcontrol->SetControllerAddress(controllerAddress);
+
     break;
+  }
   case CGUIControl::GUICONTROL_COLORBUTTON:
   {
     control = new CGUIColorButtonControl(parentID, id, posX, posY, width, height, textureFocus,


### PR DESCRIPTION
## Description

This PR extends the "gamecontroller" gui control to allow the controller ID to be specified in the skin. A second commit moves the ID from core to the skin.

The following new fields are added to the "gamecontroller" control:

* &lt;texture> - passes it through to the base image control, can be used to show arbitrary artwork in the gamecontroller control
* &lt;aspectratio> - passes it through to the base image control
* &lt;controllerId> - allows the skin to specify a controller profile to show
* &lt;controllerAddress> - allows the skin to specify a port address and controller profile to show

A controller address looks like `/1/game.controller.snes`. If a controller address is provided, the controller ID will be used. The base port address (`/1`) is also saved in a member variable, but isn't accessed yet. It will be used by the Player Manager.

## Motivation and context

More expressive skinning engine for game controller controls, needed for my upcoming Player Manager.

This also lets any skinner throw up any controller image wherever they want, no core changes required.

## How has this been tested?

Included in my 2023-07-12 test builds: https://github.com/garbear/xbmc/releases

### In-game OSD

Tested both without the skin change (first commit) and with the skin change (second commit). In both cases, the SNES controller shows correctly:

![screenshot00002](https://github.com/xbmc/xbmc/assets/531482/1f4addcf-5993-46e8-8496-ec220b74af6e)

In the future, I also want to also remove the "Select + X" hotkey from core as well.

### Player Viewer

Tested with my Player Viewer (not included in this PR), using the following skin XML for the port icons highlighted below:

```xml
<control type="gamecontrollerlist">
	<itemlayout width="96" height="96">
		<control type="gamecontroller">
			<texture>$INFO[ListItem.Icon]</texture>
			<controllerAddress>$INFO[ListItem.FilenameAndPath]</controllerAddress>
		</control>
	</itemlayout>
	<focusedlayout width="96" height="96">
		<control type="gamecontroller">
			<texture>$INFO[ListItem.Icon]</texture>
			<controllerAddress>$INFO[ListItem.FilenameAndPath]</controllerAddress>
		</control>
	</focusedlayout>
</control>
```

![screenshot00003](https://github.com/xbmc/xbmc/assets/531482/5d0285fb-0ee1-424e-be12-bd0fdd68d873)

You can see that the controller address works correctly for the controllers, and the texture works correctly for the "input disabled" icon on the left.

## What is the effect on users?

* Improved skinning engine for game controllers

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
