### PR TITLE
[Backport] Savestate Manager: Map "delete" key in savestate dialogs

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -423,6 +423,16 @@
       <menu>OSD</menu>
     </keyboard>
   </GameOSD>
+  <GameSaves>
+    <keyboard>
+      <delete>delete</delete>
+    </keyboard>
+  </GameSaves>
+  <InGameSaves>
+    <keyboard>
+      <delete>delete</delete>
+    </keyboard>
+  </InGameSaves>
   <VideoTimeSeek>
     <keyboard>
       <return>Select</return>

--- a/xbmc/games/dialogs/osd/DialogGameSaves.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameSaves.cpp
@@ -385,8 +385,6 @@ void CDialogGameSaves::OnContextMenu(CFileItem& item)
     OnRename(item);
   else if (index == 1)
     OnDelete(item);
-
-  m_viewControl->SetItems(*m_vecList);
 }
 
 void CDialogGameSaves::OnRename(CFileItem& item)
@@ -410,8 +408,7 @@ void CDialogGameSaves::OnRename(CFileItem& item)
       RETRO::CSavestateDatabase::GetSavestateItem(*newSavestate, savestatePath, item);
 
       // Refresh thumbnails
-      CGUIMessage message(GUI_MSG_REFRESH_LIST, GetID(), CONTROL_SAVES_DETAILED_LIST);
-      OnMessage(message);
+      m_viewControl->SetItems(*m_vecList);
     }
     else
     {
@@ -436,8 +433,7 @@ void CDialogGameSaves::OnDelete(CFileItem& item)
       m_vecList->Remove(&item);
 
       // Refresh thumbnails
-      CGUIMessage message(GUI_MSG_REFRESH_LIST, GetID(), CONTROL_SAVES_DETAILED_LIST);
-      OnMessage(message);
+      m_viewControl->SetItems(*m_vecList);
     }
     else
     {


### PR DESCRIPTION
## Description

Backport of https://github.com/xbmc/xbmc/pull/23471

## How has this been tested?

Tested as part of my test builds: https://github.com/garbear/xbmc/releases (since 2023-07-03 build)

## What is the effect on users?

* Fixed delete key not working in Savestate Manager

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
