### PR TITLE
PythonBindings: TypeInfo: add initialization of tp_watched for PyTypeObject

### DIFF
--- a/xbmc/interfaces/python/swig.cpp
+++ b/xbmc/interfaces/python/swig.cpp
@@ -18,8 +18,8 @@ namespace PythonBindings
 {
   TypeInfo::TypeInfo(const std::type_info& ti) : swigType(NULL), parentType(NULL), typeIndex(ti)
   {
-    static PyTypeObject py_type_object_header =
-    { PyVarObject_HEAD_INIT(nullptr, 0) 0,
+    static PyTypeObject py_type_object_header = {
+      PyVarObject_HEAD_INIT(nullptr, 0) 0,
       0,
       0,
       0,

--- a/xbmc/interfaces/python/swig.cpp
+++ b/xbmc/interfaces/python/swig.cpp
@@ -72,6 +72,9 @@ namespace PythonBindings
 #if PY_VERSION_HEX < 0x03090000
       0,
 #endif
+#if PY_VERSION_HEX >= 0x030C00A1
+      0,
+#endif
     };
 
     static int size = (long*)&(py_type_object_header.tp_name) - (long*)&py_type_object_header;


### PR DESCRIPTION
This member was added in upstream commit https://github.com/python/cpython/commit/82ccbf69a842db25d8117f1c41b47aa5b4ed96ab

This change first appeared in Python v3.12.0a1

fixes #23503 

I haven't actually runtime tested Kodi with Python 3.12 but it builds ok with this fix.