### PR TITLE
[Windows] improve user experience when Windows HDR is ON by default

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
@@ -48,6 +48,7 @@ enum RenderMethod
 
 enum class HDR_TYPE
 {
+  HDR_INVALID = -1,
   HDR_NONE_SDR = 0,
   HDR_HDR10 = 1,
   HDR_HLG = 2
@@ -190,7 +191,8 @@ protected:
   std::map<int, CRenderBuffer*> m_renderBuffers;
 
   DXGI_HDR_METADATA_HDR10 m_lastHdr10 = {};
-  HDR_TYPE m_HdrType = HDR_TYPE::HDR_NONE_SDR;
+  HDR_TYPE m_HdrType = HDR_TYPE::HDR_INVALID;
   bool m_AutoSwitchHDR = false;
+  bool m_initialHdrEnabled = false;
   std::string m_renderMethodName;
 };

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -729,6 +729,9 @@ void DX::DeviceResources::ResizeBuffers()
     hr = m_d3dDevice.As(&dxgiDevice); CHECK_ERR();
     dxgiDevice->SetMaximumFrameLatency(1);
     m_usedSwapChain = false;
+
+    if (m_IsHDROutput)
+      SetHdrColorSpace(DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020);
   }
 
   CLog::LogF(LOGDEBUG, "end resize buffers.");

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -702,14 +702,11 @@ void DX::DeviceResources::ResizeBuffers()
 
     m_IsHDROutput = (swapChainDesc.Format == DXGI_FORMAT_R10G10B10A2_UNORM) && isHdrEnabled;
 
-    const int bits = (swapChainDesc.Format == DXGI_FORMAT_R10G10B10A2_UNORM) ? 10 : 8;
-    std::string flip =
-        (swapChainDesc.SwapEffect == DXGI_SWAP_EFFECT_FLIP_DISCARD) ? "discard" : "sequential";
-
-    CLog::LogF(LOGINFO,
-               "{} bit swapchain is used with {} flip {} buffers and {} output (format {})", bits,
-               swapChainDesc.BufferCount, flip, m_IsHDROutput ? "HDR" : "SDR",
-               DX::DXGIFormatToString(swapChainDesc.Format));
+    CLog::LogF(
+        LOGINFO, "{} bit swapchain is used with {} flip {} buffers and {} output (format {})",
+        (swapChainDesc.Format == DXGI_FORMAT_R10G10B10A2_UNORM) ? 10 : 8, swapChainDesc.BufferCount,
+        (swapChainDesc.SwapEffect == DXGI_SWAP_EFFECT_FLIP_DISCARD) ? "discard" : "sequential",
+        m_IsHDROutput ? "HDR" : "SDR", DX::DXGIFormatToString(swapChainDesc.Format));
 
     hr = swapChain.As(&m_swapChain); CHECK_ERR();
     m_stereoEnabled = bHWStereoEnabled;


### PR DESCRIPTION
## Description
Improve user experience when Windows HDR is ON by default

## Motivation and context
This is a more simple and improved version of https://github.com/xbmc/xbmc/pull/23500
Some users wants/prefers Windows HDR on all the time.

- For users that has Windows HDR off by default nothing changes.
- For users that has Windows HDR on by default Kodi GUI follows same desktop HDR on state.
- No differences in video playback: i.e for SDR videos HDR is allways OFF even users that has Windows HDR on "all the time".
- Windows HDR state at exit Kodi is not modified: ie. users that has desktop with HDR on when exit Kodi continues with HDR on (even if playback SDR videos).

The only differences with current master/Nexus is Kodi GUI follows current Windows HDR desktop state and Windows HDR state is preserved when exit Kodi. No differences in HDR videos playback. No differences in SDR videos playback. 

**EDIT:** 
This also enables GUI rendered in BT.2020 color space when Windows HDR is ON. Its a small first step to allow support true HDR elements in GUI/skins. As Shader code is modular with different shader methods is possible create new methods that NOT tonemaps SDR to HDR (HDR to HDR) for use when HDR is ON and HDR textures are used.

For now as all skin elements are SDR, all is tone mapped... but only if HDR is on (obviously)

When Windows HDR is on, GUI looks better in BT.2020 color space (using built-in tone map shaders) that BT.709 using Windows default tone map route for SDR apps.


## How has this been tested?
Runtime tested Windows 11 22H2 (Intel NUC8i3BEK)

## What is the effect on users?
See Motivation and context

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
