### PR TITLE
xbmc c++ core/Video/DVDCodec: Created parent class and inherited children classes

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodec.h
@@ -11,6 +11,7 @@
 #include "cores/AudioEngine/Utils/AEAudioFormat.h"
 #include "cores/VideoPlayer/Interface/DemuxPacket.h"
 #include "cores/VideoPlayer/Process/ProcessInfo.h"
+#include "cores/VideoPlayer/DVDCodecs/DVDCodec.h"
 
 #include <vector>
 
@@ -45,17 +46,12 @@ typedef struct stDVDAudioFrame
   double centerMixLevel;
 } DVDAudioFrame;
 
-class CDVDAudioCodec
+class CDVDAudioCodec : public CDVDCodec
 {
 public:
 
-  explicit CDVDAudioCodec(CProcessInfo &processInfo) : m_processInfo(processInfo) {}
+  explicit CDVDAudioCodec(CProcessInfo &processInfo) : CDVDCodec(processInfo) {}
   virtual ~CDVDAudioCodec() = default;
-
-  /*
-   * Open the decoder, returns true on success
-   */
-  virtual bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options) = 0;
 
   /*
    * Dispose, Free all resources
@@ -63,20 +59,9 @@ public:
   virtual void Dispose() = 0;
 
   /*
-   * returns false on error
-   *
-   */
-  virtual bool AddData(const DemuxPacket &packet) = 0;
-
-  /*
    * the data is valid until the next call
    */
   virtual void GetData(DVDAudioFrame &frame) = 0;
-
-  /*
-   * resets the decoder
-   */
-  virtual void Reset() = 0;
 
   /*
    * returns the format for the audio stream
@@ -96,7 +81,7 @@ public:
   /*
    * should return codecs name
    */
-  virtual std::string GetName() = 0;
+//  virtual std::string GetName() = 0;
 
   /*
    * should return amount of data decoded has buffered in preparation for next audio frame
@@ -118,6 +103,4 @@ public:
    */
   virtual int GetProfile() { return 0; }
 
-protected:
-  CProcessInfo &m_processInfo;
 };

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecFFmpeg.h
@@ -33,7 +33,7 @@ public:
   void GetData(DVDAudioFrame &frame) override;
   void Reset() override;
   AEAudioFormat GetFormat() override { return m_format; }
-  std::string GetName() override { return m_codecName; }
+  const char* GetName() override { return m_codecName.c_str(); }
   enum AVMatrixEncoding GetMatrixEncoding() override;
   enum AVAudioServiceType GetAudioServiceType() override;
   int GetProfile() override;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.h
@@ -31,7 +31,7 @@ public:
   void Reset() override;
   AEAudioFormat GetFormat() override { return m_format; }
   bool NeedPassthrough() override { return true; }
-  std::string GetName() override { return m_codecName; }
+  const char* GetName() override { return m_codecName.c_str(); }
   int GetBufferSize() override;
 
 private:

--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDCodec.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "cores/VideoPlayer/Process/ProcessInfo.h"
+
+class CDVDStreamInfo;
+class CDVDCodecOptions;
+
+class CDVDCodec {
+	public:
+		explicit CDVDCodec(CProcessInfo& processInfo) : m_processInfo(processInfo) {}
+				
+		/**
+		* Open the decoder, returns true on success
+		* Decoders not capable of running multiple instances should return false in case
+		* there is already a instance open
+		*/
+		virtual bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options) = 0;
+
+		/**
+		* add data, decoder has to consume the entire packet
+		* returns true if the packet was consumed or if resubmitting it is useless
+		*/
+		virtual bool AddData(const DemuxPacket& packet) = 0;
+		
+		 /**
+		 * Reset the decoder.
+		 * Should be the same as calling Dispose and Open after each other
+		 */
+		 virtual void Reset() = 0;
+
+		 /**
+		 * should return codecs name
+		 */
+         virtual const char* GetName() = 0;
+	
+	protected:
+		CProcessInfo& m_processInfo;
+};

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -12,6 +12,7 @@
 #include "cores/VideoPlayer/Buffers/VideoBuffer.h"
 #include "cores/VideoPlayer/Interface/DemuxPacket.h"
 #include "cores/VideoPlayer/Process/ProcessInfo.h"
+#include "cores/VideoPlayer/DVDCodecs/DVDCodec.h"
 
 extern "C" {
 #include <libavcodec/avcodec.h>
@@ -104,7 +105,7 @@ class CDVDStreamInfo;
 class CDVDCodecOption;
 class CDVDCodecOptions;
 
-class CDVDVideoCodec
+class CDVDVideoCodec : public CDVDCodec
 {
 public:
 
@@ -121,16 +122,9 @@ public:
     VC_EOF              //< EOF
   };
 
-  explicit CDVDVideoCodec(CProcessInfo &processInfo) : m_processInfo(processInfo) {}
+  explicit CDVDVideoCodec(CProcessInfo &processInfo) : CDVDCodec(processInfo) {}
   virtual ~CDVDVideoCodec() = default;
-
-  /**
-   * Open the decoder, returns true on success
-   * Decoders not capable of running multiple instances should return false in case
-   * there is already a instance open
-   */
-  virtual bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options) = 0;
-
+  
   /**
    * Reconfigure the decoder, returns true on success
    * Decoders not capable of running multiple instances may be capable of reconfiguring
@@ -141,18 +135,6 @@ public:
   {
     return false;
   }
-
-  /**
-   * add data, decoder has to consume the entire packet
-   * returns true if the packet was consumed or if resubmitting it is useless
-   */
-  virtual bool AddData(const DemuxPacket &packet) = 0;
-
-  /**
-   * Reset the decoder.
-   * Should be the same as calling Dispose and Open after each other
-   */
-  virtual void Reset() = 0;
 
   /**
    * GetPicture controls decoding. Player calls it on every cycle
@@ -166,11 +148,6 @@ public:
    * DVD_PLAYSPEED_PAUSE and friends.
    */
   virtual void SetSpeed(int iSpeed) {}
-
-  /**
-   * should return codecs name
-   */
-  virtual const char* GetName() = 0;
 
   /**
    * How many packets should player remember, so codec can recover should
@@ -237,8 +214,8 @@ public:
    */
   virtual void Reopen() {}
 
-protected:
-  CProcessInfo &m_processInfo;
+// protected:
+//  CProcessInfo &m_processInfo;
 };
 
 // callback interface for ffmpeg hw accelerators


### PR DESCRIPTION
Created common parent class for CDVDVideoCodec and CDVDAudioCodec.

## Inheritance implemented to avoid duplicates of same code in both places
Before the change, both classes used in the same factory, had no link between them, and so code repeated.
Creating a parent class ensures that the code is written once, and give cohesion to that part.

## Improvement as a design pattern can be applied
It makes more clear the use of the DVDCodec classes.

## How has this been tested?
Running tests, and running locally in my Windows Machine.

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
