### PR TITLE
Prototype pattern added to CFileItem class

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -118,6 +118,13 @@ CFileItem::CFileItem(const CVideoInfoTag& movie)
   SetFromVideoInfoTag(movie);
 }
 
+CFileItem* CFileItem::Clone()
+{
+  CFileItem* clone = new CFileItem();
+  *clone = *this;
+  return clone;
+}
+
 namespace
 {
   std::string GetEpgTagTitle(const std::shared_ptr<CPVREpgInfoTag>& epgTag)
@@ -2351,7 +2358,7 @@ bool CFileItemList::Copy(const CFileItemList& items, bool copyItems /* = true */
     // make a copy of each item
     for (int i = 0; i < items.Size(); i++)
     {
-      CFileItemPtr newItem(new CFileItem(*items[i]));
+      CFileItemPtr newItem(items[i]->Clone());
       Add(newItem);
     }
   }

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -127,8 +127,9 @@ public:
   explicit CFileItem(std::shared_ptr<const ADDON::IAddon> addonInfo);
   explicit CFileItem(const EventPtr& eventLogEntry);
 
+  CFileItem* Clone();
   ~CFileItem(void) override;
-  CGUIListItem* Clone() const override { return new CFileItem(*this); }
+  CGUIListItem* Clone() const override { return Clone(); }
 
   const CURL GetURL() const;
   void SetURL(const CURL& url);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The clone method is added to the CFileItem class and is used in the CGUIListItem* Clone() and Copy (CFileItemList class) methods.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Encapsulate the copying of elements

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested that the program will run without problems

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
None
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ X ] **None of the above** (please explain below)
Object copying is encapsulated
