### PR TITLE
[Windows] Refactor DXVA renderer to enumerate and use the supported conversions

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.cpp
@@ -357,10 +357,8 @@ ProcessorConversions CEnumeratorHD::ListConversions(
 }
 
 void CEnumeratorHD::LogSupportedConversions(const DXGI_FORMAT& inputFormat,
-                                            const DXGI_COLOR_SPACE_TYPE heuristicsInputCS,
                                             const DXGI_COLOR_SPACE_TYPE inputNativeCS,
-                                            const DXGI_FORMAT& outputFormat,
-                                            const DXGI_COLOR_SPACE_TYPE heuristicsOutputCS)
+                                            const DXGI_FORMAT& outputFormat)
 {
   std::unique_lock<CCriticalSection> lock(m_section);
 
@@ -393,14 +391,6 @@ void CEnumeratorHD::LogSupportedConversions(const DXGI_FORMAT& inputFormat,
 
   CLog::LogFC(LOGDEBUG, LOGVIDEO, "The source is {} / {}", DX::DXGIFormatToString(inputFormat),
               DX::DXGIColorSpaceTypeToString(inputNativeCS));
-
-  const bool supported =
-      CheckConversionInternal(inputFormat, inputNativeCS, outputFormat, heuristicsOutputCS);
-
-  CLog::LogFC(LOGDEBUG, LOGVIDEO, "conversion from {} / {} to {} / {} is {}supported.",
-              DX::DXGIFormatToString(inputFormat), DX::DXGIColorSpaceTypeToString(inputNativeCS),
-              DX::DXGIFormatToString(outputFormat),
-              DX::DXGIColorSpaceTypeToString(heuristicsOutputCS), supported ? "" : "NOT ");
 
   // Possible input color spaces: YCbCr only
   std::vector<DXGI_COLOR_SPACE_TYPE> ycbcrColorSpaces;
@@ -444,12 +434,10 @@ void CEnumeratorHD::LogSupportedConversions(const DXGI_FORMAT& inputFormat,
   {
     conversionsString.append("\n");
     conversionsString.append(StringUtils::Format(
-        "{} {} / {}{} {:<{}} to {} {:<{}} / {}{} {:<{}}", "*",
-        DX::DXGIFormatToString(c.m_inputFormat), (c.m_inputCS == heuristicsInputCS) ? "*" : " ",
+        "{} {} / {} {:<{}} to {} {:<{}} / {} {:<{}}", "*", DX::DXGIFormatToString(c.m_inputFormat),
         (c.m_inputCS == inputNativeCS) ? "N" : " ", DX::DXGIColorSpaceTypeToString(c.m_inputCS), 32,
         (c.m_outputFormat == outputFormat) ? "*" : " ", DX::DXGIFormatToString(c.m_outputFormat),
-        26, (c.m_outputCS == heuristicsOutputCS) ? "*" : " ",
-        (backbufferColorSpaces.find(c.m_outputCS) != backbufferColorSpaces.end()) ? "bb" : "  ",
+        26, (backbufferColorSpaces.find(c.m_outputCS) != backbufferColorSpaces.end()) ? "bb" : "  ",
         DX::DXGIColorSpaceTypeToString(c.m_outputCS), 32));
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.cpp
@@ -58,7 +58,15 @@ bool CEnumeratorHD::Open(unsigned int width, unsigned int height, DXGI_FORMAT in
   Close();
 
   std::unique_lock<CCriticalSection> lock(m_section);
+  m_width = width;
+  m_height = height;
+  m_input_dxgi_format = input_dxgi_format;
 
+  return OpenEnumerator();
+}
+
+bool CEnumeratorHD::OpenEnumerator()
+{
   HRESULT hr{};
   ComPtr<ID3D11Device> pD3DDevice = DX::DeviceResources::Get()->GetD3DDevice();
 
@@ -69,21 +77,21 @@ bool CEnumeratorHD::Open(unsigned int width, unsigned int height, DXGI_FORMAT in
     return false;
   }
 
-  CLog::LogF(LOGDEBUG, "initializing video enumerator with params: {}x{}.", width, height);
+  CLog::LogF(LOGDEBUG, "initializing video enumerator with params: {}x{}.", m_width, m_height);
 
   D3D11_VIDEO_PROCESSOR_CONTENT_DESC contentDesc = {};
   contentDesc.InputFrameFormat = D3D11_VIDEO_FRAME_FORMAT_INTERLACED_TOP_FIELD_FIRST;
-  contentDesc.InputWidth = width;
-  contentDesc.InputHeight = height;
-  contentDesc.OutputWidth = width;
-  contentDesc.OutputHeight = height;
+  contentDesc.InputWidth = m_width;
+  contentDesc.InputHeight = m_height;
+  contentDesc.OutputWidth = m_width;
+  contentDesc.OutputHeight = m_height;
   contentDesc.Usage = D3D11_VIDEO_USAGE_PLAYBACK_NORMAL;
 
   if (FAILED(hr = m_pVideoDevice->CreateVideoProcessorEnumerator(
                  &contentDesc, m_pEnumerator.ReleaseAndGetAddressOf())))
   {
-    CLog::LogF(LOGWARNING, "failed to init video enumerator with params: {}x{}. Error {}", width,
-               height, DX::GetErrorDescription(hr));
+    CLog::LogF(LOGWARNING, "failed to init video enumerator with params: {}x{}. Error {}", m_width,
+               m_height, DX::GetErrorDescription(hr));
     return false;
   }
 
@@ -92,8 +100,6 @@ bool CEnumeratorHD::Open(unsigned int width, unsigned int height, DXGI_FORMAT in
     CLog::LogF(LOGDEBUG, "ID3D11VideoProcessorEnumerator1 not available on this system. Message {}",
                DX::GetErrorDescription(hr));
   }
-
-  m_input_dxgi_format = input_dxgi_format;
 
   return true;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.cpp
@@ -528,8 +528,7 @@ ProcessorConversions CEnumeratorHD::ListConversions(
       {
         if (CheckConversionInternal(inputFormat, inputCS, outputFormat, outputCS))
         {
-          result.push_back(
-              ProcessorConversion{m_input_dxgi_format, inputCS, outputFormat, outputCS});
+          result.push_back(ProcessorConversion{inputFormat, inputCS, outputFormat, outputCS});
         }
       }
     }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.cpp
@@ -235,75 +235,9 @@ ProcessorCapabilities CEnumeratorHD::ProbeProcessorCaps()
     }
   }
 
-  if (m_pEnumerator1)
-  {
-    DXGI_FORMAT format = DX::Windowing()->GetBackBuffer().GetFormat();
-
-    // Check if HLG color space conversion is supported by driver
-    result.m_bSupportHLG =
-        CheckConversionInternal(DXGI_FORMAT_P010, DXGI_COLOR_SPACE_YCBCR_STUDIO_GHLG_TOPLEFT_P2020,
-                                format, DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709);
-
-    CLog::LogF(LOGDEBUG, "HLG color space conversion is{}supported.",
-               result.m_bSupportHLG ? " " : " NOT ");
-
-    result.m_BT2020Left = (QueryHDRtoSDRSupport() == Left);
-    result.m_HDR10Left = (QueryHDRtoHDRSupport() == Left);
-  }
-
   result.m_valid = true;
 
   return result;
-}
-
-DXVA::InputFormat CEnumeratorHD::QueryHDRtoHDRSupport()
-{
-  const ProcessorConversions conv = QueryHDRConversions(false);
-
-  if (conv.empty())
-    return None;
-
-  auto it = std::find_if(conv.cbegin(), conv.cend(), [](const ProcessorConversion& c) {
-    return c.m_inputCS == DXGI_COLOR_SPACE_YCBCR_STUDIO_G2084_TOPLEFT_P2020;
-  });
-
-  if (it != conv.end())
-    return TopLeft;
-
-  it = std::find_if(conv.cbegin(), conv.cend(), [](const ProcessorConversion& c) {
-    return c.m_inputCS == DXGI_COLOR_SPACE_YCBCR_STUDIO_G2084_LEFT_P2020;
-  });
-
-  if (it != conv.end())
-    return Left;
-
-  // Conversions returned, none with one of the expected types? Return "not supported"
-  return None;
-}
-
-InputFormat CEnumeratorHD::QueryHDRtoSDRSupport()
-{
-  const ProcessorConversions conv = QueryHDRtoSDRConversions(false);
-
-  if (conv.empty())
-    return None;
-
-  auto it = std::find_if(conv.cbegin(), conv.cend(), [](const ProcessorConversion& c) {
-    return c.m_inputCS == DXGI_COLOR_SPACE_YCBCR_STUDIO_G22_TOPLEFT_P2020;
-  });
-
-  if (it != conv.end())
-    return TopLeft;
-
-  it = std::find_if(conv.cbegin(), conv.cend(), [](const ProcessorConversion& c) {
-    return c.m_inputCS == DXGI_COLOR_SPACE_YCBCR_STUDIO_G22_LEFT_P2020;
-  });
-
-  if (it != conv.end())
-    return Left;
-
-  // Conversions returned, none with one of the expected types? Return "not supported"
-  return None;
 }
 
 ProcessorFormats CEnumeratorHD::GetProcessorFormats(bool inputFormats, bool outputFormats) const

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.cpp
@@ -356,9 +356,8 @@ ProcessorConversions CEnumeratorHD::ListConversions(
   return result;
 }
 
-void CEnumeratorHD::LogSupportedConversions(const DXGI_FORMAT& inputFormat,
-                                            const DXGI_COLOR_SPACE_TYPE inputNativeCS,
-                                            const DXGI_FORMAT& outputFormat)
+void CEnumeratorHD::LogSupportedConversions(const DXGI_FORMAT inputFormat,
+                                            const DXGI_COLOR_SPACE_TYPE inputNativeCS)
 {
   std::unique_lock<CCriticalSection> lock(m_section);
 
@@ -434,16 +433,16 @@ void CEnumeratorHD::LogSupportedConversions(const DXGI_FORMAT& inputFormat,
   {
     conversionsString.append("\n");
     conversionsString.append(StringUtils::Format(
-        "{} {} / {} {:<{}} to {} {:<{}} / {} {:<{}}", "*", DX::DXGIFormatToString(c.m_inputFormat),
+        "{} / {} {:<{}} to {:<{}} / {} {:<{}}", DX::DXGIFormatToString(c.m_inputFormat),
         (c.m_inputCS == inputNativeCS) ? "N" : " ", DX::DXGIColorSpaceTypeToString(c.m_inputCS), 32,
-        (c.m_outputFormat == outputFormat) ? "*" : " ", DX::DXGIFormatToString(c.m_outputFormat),
-        26, (backbufferColorSpaces.find(c.m_outputCS) != backbufferColorSpaces.end()) ? "bb" : "  ",
+        DX::DXGIFormatToString(c.m_outputFormat), 26,
+        (backbufferColorSpaces.find(c.m_outputCS) != backbufferColorSpaces.end()) ? "bb" : "  ",
         DX::DXGIColorSpaceTypeToString(c.m_outputCS), 32));
   }
 
   CLog::LogFC(LOGDEBUG, LOGVIDEO,
-              "Supported conversions from format {}\n(*: values picked by "
-              "heuristics, N native input color space, bb supported as swap chain backbuffer){}",
+              "Supported conversions from format {}\n(N native input color space, bb supported as "
+              "swap chain backbuffer){}",
               DX::DXGIFormatToString(inputFormat), conversionsString);
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
@@ -65,9 +65,6 @@ struct ProcessorCapabilities
   D3D11_VIDEO_PROCESSOR_CAPS m_vcaps{};
   D3D11_VIDEO_PROCESSOR_RATE_CONVERSION_CAPS m_rateCaps{};
   ProcAmpInfo m_Filters[NUM_FILTERS]{};
-  bool m_bSupportHLG{false};
-  bool m_HDR10Left{false};
-  bool m_BT2020Left{false};
   bool m_hasMetadataHDR10Support{false};
 };
 
@@ -244,8 +241,6 @@ public:
 
 protected:
   void UnInit();
-  InputFormat QueryHDRtoHDRSupport();
-  InputFormat QueryHDRtoSDRSupport();
   /*!
    * \brief Retrieve the list of DXGI_FORMAT supported by the DXVA processor
    * \param inputFormats yes/no populate the input formats vector of the returned structure

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
@@ -184,11 +184,9 @@ public:
    * \param inputFormat the source format
    * \param inputNativeCS the input color space that would be used with a direct mapping
    * from avcodec to D3D11, without any workarounds or tricks.
-   * \param outputFormat the destination format
    */
-  void LogSupportedConversions(const DXGI_FORMAT& inputFormat,
-                               const DXGI_COLOR_SPACE_TYPE inputNativeCS,
-                               const DXGI_FORMAT& outputFormat);
+  void LogSupportedConversions(const DXGI_FORMAT inputFormat,
+                               const DXGI_COLOR_SPACE_TYPE inputNativeCS);
 
   bool IsInitialized() const { return m_pEnumerator; }
   /*!

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
@@ -146,7 +146,13 @@ public:
   void Close();
 
   // ID3DResource overrides
-  void OnCreateDevice() override {}
+  void OnCreateDevice() override
+  {
+    std::unique_lock<CCriticalSection> lock(m_section);
+    if (m_width > 0 && m_height > 0)
+      OpenEnumerator();
+  }
+
   void OnDestroyDevice(bool) override
   {
     std::unique_lock<CCriticalSection> lock(m_section);
@@ -236,6 +242,8 @@ public:
 
 protected:
   void UnInit();
+  bool OpenEnumerator();
+
   /*!
    * \brief Retrieve the list of DXGI_FORMAT supported by the DXVA processor
    * \param inputFormats yes/no populate the input formats vector of the returned structure
@@ -285,6 +293,9 @@ protected:
       const std::vector<DXGI_COLOR_SPACE_TYPE>& outputColorSpaces) const;
 
   CCriticalSection m_section;
+
+  uint32_t m_width = 0;
+  uint32_t m_height = 0;
 
   ComPtr<ID3D11VideoDevice> m_pVideoDevice;
   ComPtr<ID3D11VideoProcessorEnumerator> m_pEnumerator;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
@@ -89,6 +89,7 @@ struct ProcessorConversion
   DXGI_FORMAT m_outputFormat{DXGI_FORMAT_UNKNOWN};
   DXGI_COLOR_SPACE_TYPE m_outputCS{DXGI_COLOR_SPACE_RESERVED};
 
+  ProcessorConversion() = default;
   ProcessorConversion(const DXGI_FORMAT& inputFormat,
                       const DXGI_COLOR_SPACE_TYPE& inputCS,
                       const DXGI_FORMAT& outputFormat,
@@ -181,17 +182,13 @@ public:
   /*!
    * \brief Outputs in the log a list of conversions supported by the DXVA processor.
    * \param inputFormat the source format
-   * \param heuristicsInputCS the input color space that will be used for playback
    * \param inputNativeCS the input color space that would be used with a direct mapping
    * from avcodec to D3D11, without any workarounds or tricks.
    * \param outputFormat the destination format
-   * \param heuristicsOutputCS the output color space that will be used for playback
    */
   void LogSupportedConversions(const DXGI_FORMAT& inputFormat,
-                               const DXGI_COLOR_SPACE_TYPE heuristicsInputCS,
                                const DXGI_COLOR_SPACE_TYPE inputNativeCS,
-                               const DXGI_FORMAT& outputFormat,
-                               const DXGI_COLOR_SPACE_TYPE heuristicsOutputCS);
+                               const DXGI_FORMAT& outputFormat);
 
   bool IsInitialized() const { return m_pEnumerator; }
   /*!

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
@@ -102,6 +102,13 @@ struct ProcessorConversion
   }
 
   const std::string ToString() const;
+
+  bool operator!=(const ProcessorConversion& other) const
+  {
+    return m_inputFormat != other.m_inputFormat ||
+           m_inputCS != other.m_inputCS && m_outputFormat != other.m_outputFormat ||
+           m_outputCS != other.m_outputCS;
+  }
 };
 
 using ProcessorConversions = std::vector<ProcessorConversion>;
@@ -115,6 +122,8 @@ struct SupportedConversionsArgs
   AVColorTransferCharacteristic m_colorTransfer{AVCOL_TRC_UNSPECIFIED};
   bool m_fullRange{false};
   bool m_hdrOutput{false};
+
+  SupportedConversionsArgs() = default;
 
   SupportedConversionsArgs(const VideoPicture& picture, bool isHdrOutput)
   {
@@ -133,6 +142,12 @@ struct SupportedConversionsArgs
       m_fullRange(fullRange),
       m_hdrOutput(hdrOutput)
   {
+  }
+
+  bool operator!=(const SupportedConversionsArgs& other) const
+  {
+    return m_colorPrimaries != other.m_colorPrimaries || m_colorTransfer != other.m_colorTransfer ||
+           m_fullRange != other.m_fullRange || m_hdrOutput != other.m_hdrOutput;
   }
 };
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "DVDCodecs/Video/DXVA.h"
 #include "VideoRenderers/Windows/RendererBase.h"
 #include "guilib/D3DResource.h"
 
@@ -90,9 +91,52 @@ struct ProcessorConversion
   DXGI_COLOR_SPACE_TYPE m_inputCS{DXGI_COLOR_SPACE_RESERVED};
   DXGI_FORMAT m_outputFormat{DXGI_FORMAT_UNKNOWN};
   DXGI_COLOR_SPACE_TYPE m_outputCS{DXGI_COLOR_SPACE_RESERVED};
+
+  ProcessorConversion(const DXGI_FORMAT& inputFormat,
+                      const DXGI_COLOR_SPACE_TYPE& inputCS,
+                      const DXGI_FORMAT& outputFormat,
+                      const DXGI_COLOR_SPACE_TYPE& outputCS)
+    : m_inputFormat(inputFormat),
+      m_inputCS(inputCS),
+      m_outputFormat(outputFormat),
+      m_outputCS(outputCS)
+  {
+  }
+
+  const std::string ToString() const;
 };
 
 using ProcessorConversions = std::vector<ProcessorConversion>;
+
+const std::vector<DXGI_FORMAT> RenderingOutputFormats = {DXGI_FORMAT_B8G8R8A8_UNORM,
+                                                         DXGI_FORMAT_R10G10B10A2_UNORM};
+
+struct SupportedConversionsArgs
+{
+  AVColorPrimaries m_colorPrimaries{AVCOL_PRI_UNSPECIFIED};
+  AVColorTransferCharacteristic m_colorTransfer{AVCOL_TRC_UNSPECIFIED};
+  bool m_fullRange{false};
+  bool m_hdrOutput{false};
+
+  SupportedConversionsArgs(const VideoPicture& picture, bool isHdrOutput)
+  {
+    m_colorPrimaries = static_cast<AVColorPrimaries>(picture.color_primaries);
+    m_colorTransfer = static_cast<AVColorTransferCharacteristic>(picture.color_transfer);
+    m_fullRange = picture.color_range == 1;
+    m_hdrOutput = isHdrOutput;
+  }
+
+  SupportedConversionsArgs(const AVColorPrimaries& colorPrimaries,
+                           const AVColorTransferCharacteristic& colorTransfer,
+                           bool fullRange,
+                           bool hdrOutput)
+    : m_colorPrimaries(colorPrimaries),
+      m_colorTransfer(colorTransfer),
+      m_fullRange(fullRange),
+      m_hdrOutput(hdrOutput)
+  {
+  }
+};
 
 class CEnumeratorHD : public ID3DResource
 {
@@ -111,15 +155,6 @@ public:
     UnInit();
   }
 
-  bool IsBT2020Supported();
-  bool IsPQ10PassthroughSupported();
-  /*!
-   * \brief Test whether the dxva video processor supports SDR to SDR conversion.
-   * Support is assumed to exist on systems that don't support the
-   * ID3D11VideoProcessorEnumerator1 interface.
-   * \return conversion supported yes/no
-  */
-  bool IsSDRSupported();
   ProcessorCapabilities ProbeProcessorCaps();
   /*!
    * \brief Check if a conversion is supported by the dxva processor.
@@ -175,11 +210,42 @@ public:
   ComPtr<ID3D11VideoProcessorOutputView> CreateVideoProcessorOutputView(
       ID3D11Resource* pResource, const D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC* pDesc);
 
+  /*!
+   * \brief Return the conversions supported by the processor to play HDR material as HDR.
+   * \param isSourceFullRange Is the source limited or full range
+   * \return conversion list of supported conversions
+   */
+  ProcessorConversions QueryHDRConversions(const bool isSourceFullRange);
+  /*!
+   * \brief Return the conversions supported by the processor to play HDR material as SDR
+   * These conversions avoid tonemapping by the processor and require post processing.
+   * \param isSourceFullRange Is the source limited or full range
+   * \return conversion list of supported conversions
+   */
+  ProcessorConversions QueryHDRtoSDRConversions(const bool isSourceFullRange);
+  /*!
+   * \brief Return the conversions supported by the processor for SDR material.
+   * Support is assumed to exist on systems that don't support the
+   * ID3D11VideoProcessorEnumerator1 interface.
+   * \param isSourceFullRange Is the source limited or full range
+   * \param colorPrimaries color primaries of the source
+   * \param colorTransfer transfer function of the source
+   * \return conversion list of supported conversions
+   */
+  ProcessorConversions QuerySDRConversions(const bool isSourceFullRange,
+                                           AVColorPrimaries colorPrimaries,
+                                           AVColorTransferCharacteristic colorTransfer);
+  /*!
+   * \brief Return a list of conversions supported by the processor for the given parameters.
+   * \param args parameters
+   * \return list of conversions
+   */
+  ProcessorConversions SupportedConversions(const SupportedConversionsArgs& args);
+
 protected:
   void UnInit();
-  InputFormat QueryHDRtoHDRSupport() const;
-  InputFormat QueryHDRtoSDRSupport() const;
-  bool QuerySDRSupport() const;
+  InputFormat QueryHDRtoHDRSupport();
+  InputFormat QueryHDRtoSDRSupport();
   /*!
    * \brief Retrieve the list of DXGI_FORMAT supported by the DXVA processor
    * \param inputFormats yes/no populate the input formats vector of the returned structure

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -554,8 +554,7 @@ ProcColorSpaces CProcessorHD::CalculateDXGIColorSpaces(const DXGIColorSpaceArgs&
   const bool supportHDR = DX::Windowing()->IsHDROutput();
 
   return ProcColorSpaces{
-      GetDXGIColorSpaceSource(csArgs, supportHDR, m_procCaps.m_bSupportHLG, m_procCaps.m_BT2020Left,
-                              m_procCaps.m_HDR10Left),
+      GetDXGIColorSpaceSource(csArgs, supportHDR, m_bSupportHLG, m_BT2020Left, m_HDR10Left),
       GetDXGIColorSpaceTarget(csArgs, supportHDR, DX::Windowing()->UseLimitedColor())};
 }
 
@@ -804,16 +803,15 @@ bool CProcessorHD::SetConversion(const ProcessorConversion& conversion)
   }
 
   // Check if HLG color space conversion is supported by driver
-  m_procCaps.m_bSupportHLG = m_enumerator->CheckConversion(
+  m_bSupportHLG = m_enumerator->CheckConversion(
       conversion.m_inputFormat, DXGI_COLOR_SPACE_YCBCR_STUDIO_GHLG_TOPLEFT_P2020,
       conversion.m_outputFormat, DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709);
 
   CLog::LogF(LOGDEBUG, "HLG color space conversion to SDR is{}supported.",
-             m_procCaps.m_bSupportHLG ? " " : " NOT ");
+             m_bSupportHLG ? " " : " NOT ");
 
-  m_procCaps.m_BT2020Left = (conversion.m_outputCS == DXGI_COLOR_SPACE_YCBCR_STUDIO_G22_LEFT_P2020);
-  m_procCaps.m_HDR10Left =
-      (conversion.m_outputCS == DXGI_COLOR_SPACE_YCBCR_STUDIO_G2084_LEFT_P2020);
+  m_BT2020Left = (conversion.m_outputCS == DXGI_COLOR_SPACE_YCBCR_STUDIO_G22_LEFT_P2020);
+  m_HDR10Left = (conversion.m_outputCS == DXGI_COLOR_SPACE_YCBCR_STUDIO_G2084_LEFT_P2020);
 
   m_output_dxgi_format = conversion.m_outputFormat;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -190,6 +190,7 @@ bool CProcessorHD::Open(const VideoPicture& picture)
   m_height = picture.iHeight;
   m_color_primaries = static_cast<AVColorPrimaries>(picture.color_primaries);
   m_color_transfer = static_cast<AVColorTransferCharacteristic>(picture.color_transfer);
+  m_full_range = picture.color_range == 1;
   const AVPixelFormat av_pixel_format = picture.videoBuffer->GetFormat();
   m_input_dxgi_format =
       CRendererDXVA::GetDXGIFormat(av_pixel_format, CRendererBase::GetDXGIFormat(picture));
@@ -810,4 +811,15 @@ bool CProcessorHD::IsFormatSupportedOutput(DXGI_FORMAT format)
 {
   std::unique_lock<CCriticalSection> lock(m_section);
   return m_enumerator && m_enumerator->IsFormatSupportedOutput(format);
+}
+
+ProcessorConversions CProcessorHD::SupportedConversions(bool isHdrOutput)
+{
+  std::unique_lock<CCriticalSection> lock(m_section);
+
+  if (!m_enumerator)
+    return {};
+
+  return m_enumerator->SupportedConversions(
+      SupportedConversionsArgs(m_color_primaries, m_color_transfer, m_full_range, isHdrOutput));
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -101,6 +101,12 @@ public:
    * \return true when the processor supports the format as output and the format is changed.
    */
   bool SetOutputFormat(DXGI_FORMAT format);
+  /*!
+   * \brief Return a list of conversions supported by the processor.
+   * \param isHdrOutput will the output be HDR yes/no
+   * \return list of conversions
+   */
+  ProcessorConversions SupportedConversions(bool isHdrOutput);
 
   // ID3DResource overrides
   void OnCreateDevice() override  {}
@@ -157,6 +163,7 @@ protected:
 
   AVColorPrimaries m_color_primaries{AVCOL_PRI_UNSPECIFIED};
   AVColorTransferCharacteristic m_color_transfer{AVCOL_TRC_UNSPECIFIED};
+  bool m_full_range{false};
   ProcessorCapabilities m_procCaps;
   DXGI_FORMAT m_input_dxgi_format{DXGI_FORMAT_UNKNOWN};
   DXGI_FORMAT m_output_dxgi_format{DXGI_FORMAT_UNKNOWN};

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -157,7 +157,7 @@ protected:
 
   AVColorPrimaries m_color_primaries{AVCOL_PRI_UNSPECIFIED};
   AVColorTransferCharacteristic m_color_transfer{AVCOL_TRC_UNSPECIFIED};
-  ProcessorCapabilities m_procCaps{};
+  ProcessorCapabilities m_procCaps;
   DXGI_FORMAT m_input_dxgi_format{DXGI_FORMAT_UNKNOWN};
   DXGI_FORMAT m_output_dxgi_format{DXGI_FORMAT_UNKNOWN};
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -157,5 +157,8 @@ protected:
   DXGI_FORMAT m_output_dxgi_format{DXGI_FORMAT_UNKNOWN};
 
   bool m_superResolutionEnabled{false};
+  bool m_bSupportHLG{false};
+  bool m_HDR10Left{false};
+  bool m_BT2020Left{false};
 };
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -116,20 +116,6 @@ protected:
   void ApplyFilter(D3D11_VIDEO_PROCESSOR_FILTER filter, int value, int min, int max, int def) const;
   ComPtr<ID3D11VideoProcessorInputView> GetInputView(CRenderBuffer* view) const;
   /*!
-   * \brief Calculate the color spaces of the input and output of the processor
-   * \param csArgs Arguments for the calculations
-   * \return the input and output color spaces
-   */
-  ProcColorSpaces CalculateDXGIColorSpaces(const DXGIColorSpaceArgs& csArgs) const;
-  static DXGI_COLOR_SPACE_TYPE GetDXGIColorSpaceSource(const DXGIColorSpaceArgs& csArgs,
-                                                       bool supportHDR,
-                                                       bool supportHLG,
-                                                       bool BT2020Left,
-                                                       bool HDRLeft);
-  static DXGI_COLOR_SPACE_TYPE GetDXGIColorSpaceTarget(const DXGIColorSpaceArgs& csArgs,
-                                                       bool supportHDR,
-                                                       bool limitedRange);
-  /*!
    * \brief Converts ffmpeg AV parameters to a DXGI color space
    * \param csArgs ffmpeg AV picture parameters
    * \return DXGI color space
@@ -154,11 +140,8 @@ protected:
   bool m_full_range{false};
   ProcessorCapabilities m_procCaps;
   DXGI_FORMAT m_input_dxgi_format{DXGI_FORMAT_UNKNOWN};
-  DXGI_FORMAT m_output_dxgi_format{DXGI_FORMAT_UNKNOWN};
 
   bool m_superResolutionEnabled{false};
-  bool m_bSupportHLG{false};
-  bool m_HDR10Left{false};
-  bool m_BT2020Left{false};
+  ProcessorConversion m_conversion;
 };
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -75,17 +75,6 @@ public:
    */
   bool IsFormatSupportedOutput(DXGI_FORMAT format);
   /*!
-   * \brief Evaluate if the DXVA processor supports converting between two formats and color spaces.
-   * Always returns true when the Windows 10+ API is not available or cannot be called successfully.
-   * \param inputFormat The source format
-   * \param outputFormat The destination format
-   * \param picture Picture information used to derive the color spaces
-   * \return true if the conversion is supported, false otherwise
-   */
-  bool IsFormatConversionSupported(DXGI_FORMAT inputFormat,
-                                   DXGI_FORMAT outputFormat,
-                                   const VideoPicture& picture);
-  /*!
    * \brief Outputs in the log a list of conversions supported by the DXVA processor.
    * \param inputFormat The source format
    * \param outputFormat The destination format
@@ -94,19 +83,18 @@ public:
   void LogSupportedConversions(const DXGI_FORMAT& inputFormat,
                                const DXGI_FORMAT& outputFormat,
                                const VideoPicture& picture);
-
-  /*!
-   * \brief Set the output format of the dxva processor. Format compatibility will be verified.
-   * \param format The output format
-   * \return true when the processor supports the format as output and the format is changed.
-   */
-  bool SetOutputFormat(DXGI_FORMAT format);
   /*!
    * \brief Return a list of conversions supported by the processor.
    * \param isHdrOutput will the output be HDR yes/no
    * \return list of conversions
    */
   ProcessorConversions SupportedConversions(bool isHdrOutput);
+  /*!
+   * \brief Configure the processor for the provided conversion.
+   * \param conversion the conversion
+   * \return success status, true = success, false = error
+   */
+  bool SetConversion(const ProcessorConversion& conversion);
 
   // ID3DResource overrides
   void OnCreateDevice() override  {}

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
@@ -60,6 +60,7 @@ private:
                                              bool tryVSR) const;
 
   std::unique_ptr<DXVA::CProcessorHD> m_processor;
+  std::shared_ptr<DXVA::CEnumeratorHD> m_enumerator;
   DXGI_FORMAT m_intermediateTargetFormat{DXGI_FORMAT_UNKNOWN};
 };
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
@@ -48,7 +48,16 @@ protected:
 private:
   void FillBuffersSet(CRenderBuffer* (&buffers)[8]);
   CRect ApplyTransforms(const CRect& destRect) const;
-  DXGI_FORMAT CalcIntermediateTargetFormat(const VideoPicture& picture, bool tryVSR) const;
+  /*!
+   * \brief Choose the best available conversion for the given source and output constraints
+   * \param conversions list of supported conversions
+   * \param picture information about the source
+   * \param tryVSR yes/no favor a conversion that enables Video Super Resolution scaling
+   * \return 
+   */
+  DXVA::ProcessorConversion ChooseConversion(const DXVA::ProcessorConversions& conversions,
+                                             const VideoPicture& picture,
+                                             bool tryVSR) const;
 
   std::unique_ptr<DXVA::CProcessorHD> m_processor;
   DXGI_FORMAT m_intermediateTargetFormat{DXGI_FORMAT_UNKNOWN};

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
@@ -56,12 +56,16 @@ private:
    * \return 
    */
   DXVA::ProcessorConversion ChooseConversion(const DXVA::ProcessorConversions& conversions,
-                                             const VideoPicture& picture,
+                                             unsigned int sourceBits,
+                                             AVColorTransferCharacteristic colorTransfer,
                                              bool tryVSR) const;
 
   std::unique_ptr<DXVA::CProcessorHD> m_processor;
   std::shared_ptr<DXVA::CEnumeratorHD> m_enumerator;
   DXGI_FORMAT m_intermediateTargetFormat{DXGI_FORMAT_UNKNOWN};
+  DXVA::ProcessorConversion m_conversion;
+  DXVA::SupportedConversionsArgs m_conversionsArgs;
+  bool m_tryVSR{false};
 };
 
 class CRendererDXVA::CRenderBufferImpl : public CRenderBuffer


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This is the refactor that the previous ones enabled and mostly finishes a transition to have the dxva render method rely on the Windows 10 ID3D11VideoProcessorEnumerator1 interface (with provisions to keep Windows 8 working)

There are barely any functionality changes, with very minor improvements.
One change by commit, clearly labelled (I hope!). A few of the commits were kept separate for review and will be combined for the merge.


Reorganized the DXVA renderer so that it contains the rules to decide how to handle the rendering. The processor is now "dumb", the enumerator still contains some rules to pre-select which conversions make sense for a source/output combination.
The process goes like this:

GetWeight:
- Create enumerator
- List supported conversions for the given source and destination
  - the list has separate entries for the different output formats 8 bits, 10 bits
  - special case for Windows 8: return all SDR conversions as supported, in the absence of the Enumerator1 interface
- At least one result => mark dxva as a candidate render method

Configure:
- Create enumerator
- List supported conversions (same function used by GetWeight)
- Chose best candidate based on source, destination, desired quality, VSR use, ...
- Create processor
- Configure processor for the chosen conversion
- Turn on VSR when requested

CheckVideoParameters (detect changes during playback):
- compare render buffer attributes that impact conversion choice with values in previous frame
- in case of change, list supported conversions and choose new best match
  - no support available: keep using the same conversion. This avoids a black screen. A better way (fallback to Pixel Shaders) requires changes to WinRenderer to switch render methods mid-stream.
- if the new best conversion is different from current conversion, reconfigure the renderer and processor

notes:
- HLG to SDR conversion is supported by AMD processor and used to be activated, but gave strange results. With this PR it will not be used at all, with better visual results. HLG could be revisited in future PR.
- the previous code did not react to changes in VSR setting, high quality setting or source size / pixel format and that was not added here in order to limit the scope. Could be implemented in future PR.
- an enumerator still gets created twice in succession for GetWeight and then Configure, due to the way WinRenderer probes the render methods. Could be improved in future PR.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Reduces logic duplication in the code, enable reacting to changes during playback in a saner way by centralizing the rules in one place.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 10, AMD, Intel gen4 and gen13
no behaviour changes for combinations of SDR/HDR/HLG playback to limited/full/SDR/HDR output.

No nVidia hardware at hand to test impact on VSR. It seems to activate when needed on Intel gen13 but not much visual effect.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
none, will make further improvements possible

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
