### PR TITLE
Add "Student submission" check mark in PR template

### DIFF
--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -27,6 +27,7 @@
 - [ ] **New feature** (non-breaking change which adds functionality)
 - [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
 - [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
+- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
 - [ ] **None of the above** (please explain below)
 
 ## Checklist:

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,7 @@
 ## Screenshots (if appropriate):
 
 ## Types of change
-<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
+<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
 - [ ] **Bug fix** (non-breaking change which fixes an issue)
 - [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
 - [ ] **Improvement** (non-breaking change which improves existing functionality)
@@ -31,7 +31,7 @@
 - [ ] **None of the above** (please explain below)
 
 ## Checklist:
-<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
+<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
 - [ ] My change requires a change to the documentation, either Doxygen or wiki


### PR DESCRIPTION
## Description

To address the recent PRs sent as part of a software design course, I'm adding a new PR type to the PR template to inform developers and reduce frustration in the review process, while expanding the usefulness of Kodi to the classroom environment.

When checked, the new PR type will look like:

- [x] **Student submission** (PR was done for educational purposes and will be treated as such)

If approved, I'm also adding a new GitHub label named `Student submission` that can be used to tag PRs that use the student submission check box. I debated including instructions for the student on how to add the label themselves, but I can see many first-time PRers simply missing github "Labels" on the right anyway. So we'll just have students self-identify PRs using the new check box and then developers can add the label by hand.

### CI debate

An open question is whether we want to allow Jenkins to run on student PRs. The cost is hammering the servers for about an hour at the exclusion of all other PRs. However, I'd argue it's worth it, as that's what the CI is there for, and learning how to "turn a PR green" is a valuable part of the review process. I would hope that CI is included in a software design course.

### Bot request for additional information

It would be useful to include some related questions in the PR template (like "How long should the PR remain open for grading to take place?"). But I don't really want to clutter the template for such a niche use case. So maybe we agree on some questions here and have a bot hop in when a PR is tagged as a student submission.

Questions like:

* How long should the PR remain open for grading to take place?
* Does the change violate Chesterton's Fence?
* Has a justification been made, given the risk of touching existing code?
* Should we offer extra help in order to see the PR through to a successful merge?
* Would you like suggestions on a change that could actually possibly be merged?

### The ultimate goal is for stuff to actually be merged

It should also be explicitly stated that anyone can throw code at the wall; *proper* software design is "doing it right". The "doing it right" part can be skipped for the grade, but it's a requirement to actually merge anything and is the lesson that best values everyone's time.

## Motivation and context

Motivated by the recent PRs sent as part of a software design course:

* https://github.com/xbmc/xbmc/pull/23506
* https://github.com/xbmc/xbmc/pull/23512
* https://github.com/xbmc/xbmc/pull/23511
* https://github.com/xbmc/xbmc/pull/23514

See the discussion here: https://github.com/xbmc/xbmc/pull/23511

Given that Kodi was how I learned software engineering, I think it's valuable to have our review process be approachable by the classroom environment.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
