### PR TITLE
[Backport] Port Dialog: Fix segfault when choosing a controller, and minor improvements

### DIFF
--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -599,8 +599,6 @@ void CGameClient::LogException(const char* strFunctionName) const
 
 void CGameClient::cb_close_game(KODI_HANDLE kodiInstance)
 {
-  using namespace MESSAGING;
-
   CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
                                              static_cast<void*>(new CAction(ACTION_STOP)));
 }

--- a/xbmc/games/addons/input/GameClientInput.cpp
+++ b/xbmc/games/addons/input/GameClientInput.cpp
@@ -407,11 +407,11 @@ bool CGameClientInput::DisconnectController(const std::string& portAddress)
 
 void CGameClientInput::SavePorts()
 {
+  // Save port state
+  m_portManager->SaveXMLAsync();
+
   // Let the observers know that ports have changed
   NotifyObservers(ObservableMessageGamePortsChanged);
-
-  // Save port state
-  m_portManager->SaveXML();
 }
 
 void CGameClientInput::ResetPorts()

--- a/xbmc/games/controllers/dialogs/ControllerSelect.cpp
+++ b/xbmc/games/controllers/dialogs/ControllerSelect.cpp
@@ -39,6 +39,9 @@ void CControllerSelect::Initialize(ControllerVector controllers,
   if (!callback)
     return;
 
+  // Stop thread and reset state
+  Deinitialize();
+
   // Initialize state
   m_controllers = std::move(controllers);
   m_defaultController = std::move(defaultController);

--- a/xbmc/games/controllers/guicontrols/GUIFeatureButton.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIFeatureButton.cpp
@@ -44,8 +44,6 @@ bool CGUIFeatureButton::DoPrompt(const std::string& strPrompt,
                                  const std::string& strFeature,
                                  CEvent& waitEvent)
 {
-  using namespace MESSAGING;
-
   bool bInterrupted = false;
 
   if (!HasFocus())

--- a/xbmc/games/controllers/windows/GUIControllerList.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerList.cpp
@@ -169,7 +169,6 @@ void CGUIControllerList::OnEvent(const ADDON::AddonEvent& event)
       typeid(event) == typeid(ADDON::AddonEvents::ReInstalled) ||
       typeid(event) == typeid(ADDON::AddonEvents::UnInstalled))
   {
-    using namespace MESSAGING;
     CGUIMessage msg(GUI_MSG_REFRESH_LIST, m_guiWindow->GetID(), CONTROL_CONTROLLER_LIST);
 
     // Focus installed add-on

--- a/xbmc/games/ports/input/PortManager.h
+++ b/xbmc/games/ports/input/PortManager.h
@@ -10,6 +10,10 @@
 
 #include "games/controllers/types/ControllerTree.h"
 
+#include <future>
+#include <mutex>
+#include <string>
+
 class TiXmlElement;
 
 namespace KODI
@@ -27,7 +31,7 @@ public:
 
   void SetControllerTree(const CControllerTree& controllerTree);
   void LoadXML();
-  void SaveXML();
+  void SaveXMLAsync();
   void Clear();
 
   void ConnectController(const std::string& portAddress,
@@ -69,6 +73,9 @@ private:
 
   CControllerTree m_controllerTree;
   std::string m_xmlPath;
+
+  std::vector<std::future<void>> m_saveFutures;
+  std::mutex m_saveMutex;
 };
 } // namespace GAME
 } // namespace KODI

--- a/xbmc/games/ports/types/PortNode.cpp
+++ b/xbmc/games/ports/types/PortNode.cpp
@@ -45,6 +45,7 @@ CPortNode& CPortNode::operator=(CPortNode&& rhs) noexcept
     m_portType = rhs.m_portType;
     m_portId = std::move(rhs.m_portId);
     m_address = std::move(rhs.m_address);
+    m_forceConnected = rhs.m_forceConnected;
     m_controllers = std::move(rhs.m_controllers);
   }
 

--- a/xbmc/games/ports/windows/GUIPortList.cpp
+++ b/xbmc/games/ports/windows/GUIPortList.cpp
@@ -160,7 +160,6 @@ void CGUIPortList::ResetPorts()
     m_gameClient->Input().SavePorts();
 
     // Refresh the GUI
-    using namespace MESSAGING;
     CGUIMessage msg(GUI_MSG_REFRESH_LIST, m_guiWindow.GetID(), CONTROL_PORT_LIST);
     CServiceBroker::GetAppMessenger()->SendGUIMessage(msg, m_guiWindow.GetID());
   }
@@ -173,7 +172,6 @@ void CGUIPortList::OnEvent(const ADDON::AddonEvent& event)
       typeid(event) == typeid(ADDON::AddonEvents::ReInstalled) ||
       typeid(event) == typeid(ADDON::AddonEvents::UnInstalled))
   {
-    using namespace MESSAGING;
     CGUIMessage msg(GUI_MSG_REFRESH_LIST, m_guiWindow.GetID(), CONTROL_PORT_LIST);
     msg.SetStringParam(event.addonId);
     CServiceBroker::GetAppMessenger()->SendGUIMessage(msg, m_guiWindow.GetID());
@@ -301,7 +299,6 @@ void CGUIPortList::OnControllerSelected(const CPortNode& port, const ControllerP
     }
 
     // Send a GUI message to reload the port list
-    using namespace MESSAGING;
     CGUIMessage msg(GUI_MSG_REFRESH_LIST, m_guiWindow.GetID(), CONTROL_PORT_LIST);
     CServiceBroker::GetAppMessenger()->SendGUIMessage(msg, m_guiWindow.GetID());
   }

--- a/xbmc/games/ports/windows/GUIPortList.cpp
+++ b/xbmc/games/ports/windows/GUIPortList.cpp
@@ -208,6 +208,7 @@ bool CGUIPortList::AddItems(const CPortNode& port,
     for (const CPortNode& childPort : ports)
     {
       std::ostringstream childItemLabel;
+      childItemLabel << " - ";
       childItemLabel << controller->Layout().Label();
       childItemLabel << " - ";
       childItemLabel << GetLabel(childPort);


### PR DESCRIPTION
## Description

Backport of https://github.com/xbmc/xbmc/pull/23499, except for the added mutex (see [comment](https://github.com/xbmc/xbmc/pull/23499#issuecomment-1637284236)).

## Motivation and context

Discovered when putting the Player Viewer through some heavy testing.

## How has this been tested?

Tested as part of my latest builds: https://github.com/garbear/xbmc/releases

## What is the effect on users?

* Fixed segfault in the Port Dialog

## Screenshots (if appropriate):

Shows the small improvement adding ` - ` to the beginning of multitap ports:

![screenshot00019](https://github.com/xbmc/xbmc/assets/531482/1ecb6c7e-12db-4750-931b-6f192bb0a263)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
