### PR TITLE
Port Dialog: Highlight active controllers

### DIFF
--- a/addons/skin.estuary/xml/GameOSD.xml
+++ b/addons/skin.estuary/xml/GameOSD.xml
@@ -37,7 +37,7 @@
 							<left>30</left>
 							<width>640</width>
 							<height>640</height>
-							<controllerId>game.controller.snes</controllerId>
+							<controllerid>game.controller.snes</controllerid>
 						</control>
 						<control type="textbox">
 							<description>Additional help text. This will be removed in future versions.</description>

--- a/addons/skin.estuary/xml/Includes_Games.xml
+++ b/addons/skin.estuary/xml/Includes_Games.xml
@@ -254,10 +254,12 @@
 									<shadowcolor>text_shadow</shadowcolor>
 									<align>right</align>
 								</control>
-								<control type="image">
+								<control type="gamecontroller">
 									<right>12</right>
 									<width>100</width>
 									<texture>$INFO[ListItem.Icon]</texture>
+									<portaddress>$INFO[ListItem.FilenameAndPath]</portaddress>
+									<controllerdiffuse>button_focus</controllerdiffuse>
 								</control>
 							</control>
 						</itemlayout>
@@ -287,10 +289,12 @@
 									<shadowcolor>text_shadow</shadowcolor>
 									<align>right</align>
 								</control>
-								<control type="image">
+								<control type="gamecontroller">
 									<right>12</right>
 									<width>100</width>
 									<texture>$INFO[ListItem.Icon]</texture>
+									<portaddress>$INFO[ListItem.FilenameAndPath]</portaddress>
+									<controllerdiffuse>button_focus</controllerdiffuse>
 								</control>
 							</control>
 						</focusedlayout>

--- a/xbmc/games/GameUtils.cpp
+++ b/xbmc/games/GameUtils.cpp
@@ -71,7 +71,7 @@ bool CGameUtils::FillInGameClient(CFileItem& item, std::string& savestatePath)
           int errorTextId = bHasVfsGameClient ? 35214 : 35212;
 
           // "Failed to play game"
-          KODI::MESSAGING::HELPERS::ShowOKDialogText(CVariant{35210}, CVariant{errorTextId});
+          MESSAGING::HELPERS::ShowOKDialogText(CVariant{35210}, CVariant{errorTextId});
         }
         else if (candidates.size() == 1 && installable.empty())
         {

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -46,7 +46,6 @@
 
 using namespace KODI;
 using namespace GAME;
-using namespace KODI::MESSAGING;
 
 #define EXTENSION_SEPARATOR "|"
 #define EXTENSION_WILDCARD "*"
@@ -209,7 +208,7 @@ bool CGameClient::OpenFile(const CFileItem& file,
 
     // Failed to play game
     // The required files can't be found.
-    HELPERS::ShowOKDialogText(CVariant{35210}, CVariant{g_localizeStrings.Get(35219)});
+    MESSAGING::HELPERS::ShowOKDialogText(CVariant{35210}, CVariant{g_localizeStrings.Get(35219)});
     return false;
   }
 
@@ -409,15 +408,16 @@ void CGameClient::NotifyError(GAME_ERROR error)
   {
     // Failed to play game
     // This game requires the following add-on: %s
-    HELPERS::ShowOKDialogText(CVariant{35210}, CVariant{StringUtils::Format(
-                                                   g_localizeStrings.Get(35211), missingResource)});
+    MESSAGING::HELPERS::ShowOKDialogText(
+        CVariant{35210},
+        CVariant{StringUtils::Format(g_localizeStrings.Get(35211), missingResource)});
   }
   else
   {
     // Failed to play game
     // The emulator "%s" had an internal error.
-    HELPERS::ShowOKDialogText(CVariant{35210},
-                              CVariant{StringUtils::Format(g_localizeStrings.Get(35213), Name())});
+    MESSAGING::HELPERS::ShowOKDialogText(
+        CVariant{35210}, CVariant{StringUtils::Format(g_localizeStrings.Get(35213), Name())});
   }
 }
 

--- a/xbmc/games/addons/input/GameClientInput.cpp
+++ b/xbmc/games/addons/input/GameClientInput.cpp
@@ -61,8 +61,6 @@ void CGameClientInput::Initialize()
   // Send controller layouts to game client
   SetControllerLayouts(m_topology->GetControllerTree().GetControllers());
 
-  std::lock_guard<std::recursive_mutex> lock(m_portMutex);
-
   // Reset ports to default state (first accepted controller is connected)
   ActivateControllers(m_topology->GetControllerTree());
 
@@ -74,27 +72,23 @@ void CGameClientInput::Initialize()
 
 void CGameClientInput::Start(IGameInputCallback* input)
 {
+  m_inputCallback = input;
+
+  // Connect/disconnect active controllers
+  for (const CPortNode& port : GetActiveControllerTree().GetPorts())
   {
-    std::lock_guard<std::recursive_mutex> lock(m_portMutex);
-
-    m_inputCallback = input;
-
-    // Connect/disconnect active controllers
-    for (const CPortNode& port : GetActiveControllerTree().GetPorts())
+    if (port.IsConnected())
     {
-      if (port.IsConnected())
-      {
-        const ControllerPtr& activeController = port.GetActiveController().GetController();
-        if (activeController)
-          ConnectController(port.GetAddress(), activeController);
-      }
-      else
-        DisconnectController(port.GetAddress());
+      const ControllerPtr& activeController = port.GetActiveController().GetController();
+      if (activeController)
+        ConnectController(port.GetAddress(), activeController);
     }
-
-    // Ensure hardware is open to receive events
-    m_hardware.reset(new CGameClientHardware(m_gameClient));
+    else
+      DisconnectController(port.GetAddress());
   }
+
+  // Ensure hardware is open to receive events
+  m_hardware.reset(new CGameClientHardware(m_gameClient));
 
   // Notify observers of the initial port configuration
   NotifyObservers(ObservableMessageGamePortsChanged);
@@ -111,8 +105,6 @@ void CGameClientInput::Deinitialize()
 
 void CGameClientInput::Stop()
 {
-  std::lock_guard<std::recursive_mutex> lock(m_portMutex);
-
   m_hardware.reset();
 
   CloseMouse();
@@ -320,8 +312,6 @@ bool CGameClientInput::ConnectController(const std::string& portAddress,
     return false;
   }
 
-  std::lock_guard<std::recursive_mutex> lock(m_portMutex);
-
   const CPortNode& currentPort = GetActiveControllerTree().GetPort(portAddress);
 
   // Close current ports if any are open
@@ -377,8 +367,6 @@ bool CGameClientInput::DisconnectController(const std::string& portAddress)
 {
   PERIPHERALS::EventLockHandlePtr inputHandlingLock;
 
-  std::lock_guard<std::recursive_mutex> lock(m_portMutex);
-
   // If port is a multitap, we need to deactivate its children
   const CPortNode& currentPort = GetActiveControllerTree().GetPort(portAddress);
   CloseJoysticks(currentPort, inputHandlingLock);
@@ -419,12 +407,8 @@ bool CGameClientInput::DisconnectController(const std::string& portAddress)
 
 void CGameClientInput::SavePorts()
 {
-  {
-    std::lock_guard<std::recursive_mutex> lock(m_portMutex);
-
-    // Save port state
-    m_portManager->SaveXMLAsync();
-  }
+  // Save port state
+  m_portManager->SaveXMLAsync();
 
   // Let the observers know that ports have changed
   NotifyObservers(ObservableMessageGamePortsChanged);
@@ -432,8 +416,6 @@ void CGameClientInput::SavePorts()
 
 void CGameClientInput::ResetPorts()
 {
-  std::lock_guard<std::recursive_mutex> lock(m_portMutex);
-
   const CControllerTree& controllerTree = GetDefaultControllerTree();
   for (const CPortNode& port : controllerTree.GetPorts())
     ConnectController(port.GetAddress(), port.GetActiveController().GetController());
@@ -441,8 +423,6 @@ void CGameClientInput::ResetPorts()
 
 bool CGameClientInput::HasAgent() const
 {
-  std::lock_guard<std::recursive_mutex> lock(m_portMutex);
-
   if (!m_joysticks.empty())
     return true;
 
@@ -470,8 +450,6 @@ bool CGameClientInput::OpenKeyboard(const ControllerPtr& controller,
     return false;
 
   bool bSuccess = false;
-
-  std::lock_guard<std::recursive_mutex> lock(m_portMutex);
 
   {
     std::unique_lock<CCriticalSection> lock(m_clientAccess);
@@ -502,15 +480,11 @@ bool CGameClientInput::OpenKeyboard(const ControllerPtr& controller,
 
 bool CGameClientInput::IsKeyboardOpen() const
 {
-  std::lock_guard<std::recursive_mutex> lock(m_portMutex);
-
   return static_cast<bool>(m_keyboard);
 }
 
 void CGameClientInput::CloseKeyboard()
 {
-  std::lock_guard<std::recursive_mutex> lock(m_portMutex);
-
   if (m_keyboard)
   {
     m_keyboard.reset();
@@ -547,8 +521,6 @@ bool CGameClientInput::OpenMouse(const ControllerPtr& controller,
 
   bool bSuccess = false;
 
-  std::lock_guard<std::recursive_mutex> lock(m_portMutex);
-
   {
     std::unique_lock<CCriticalSection> lock(m_clientAccess);
 
@@ -577,15 +549,11 @@ bool CGameClientInput::OpenMouse(const ControllerPtr& controller,
 
 bool CGameClientInput::IsMouseOpen() const
 {
-  std::lock_guard<std::recursive_mutex> lock(m_portMutex);
-
   return static_cast<bool>(m_mouse);
 }
 
 void CGameClientInput::CloseMouse()
 {
-  std::lock_guard<std::recursive_mutex> lock(m_portMutex);
-
   if (m_mouse)
   {
     m_mouse.reset();

--- a/xbmc/games/addons/input/GameClientInput.cpp
+++ b/xbmc/games/addons/input/GameClientInput.cpp
@@ -166,6 +166,17 @@ bool CGameClientInput::InputEvent(const game_input_event& event)
   return bHandled;
 }
 
+float CGameClientInput::GetPortActivation(const std::string& portAddress)
+{
+  float activation = 0.0f;
+
+  auto it = m_joysticks.find(portAddress);
+  if (it != m_joysticks.end())
+    activation = it->second->GetActivation();
+
+  return activation;
+}
+
 void CGameClientInput::LoadTopology()
 {
   game_input_topology* topologyStruct = nullptr;

--- a/xbmc/games/addons/input/GameClientInput.cpp
+++ b/xbmc/games/addons/input/GameClientInput.cpp
@@ -682,8 +682,6 @@ bool CGameClientInput::SetRumble(const std::string& portAddress,
 
 ControllerVector CGameClientInput::GetControllers(const CGameClient& gameClient)
 {
-  using namespace ADDON;
-
   ControllerVector controllers;
 
   CGameServices& gameServices = CServiceBroker::GetGameServices();

--- a/xbmc/games/addons/input/GameClientInput.h
+++ b/xbmc/games/addons/input/GameClientInput.h
@@ -62,6 +62,7 @@ public:
   bool HasFeature(const std::string& controllerId, const std::string& featureName) const;
   bool AcceptsInput() const;
   bool InputEvent(const game_input_event& event);
+  float GetPortActivation(const std::string& portAddress);
 
   // Topology functions
   const CControllerTree& GetDefaultControllerTree() const;

--- a/xbmc/games/addons/input/GameClientInput.h
+++ b/xbmc/games/addons/input/GameClientInput.h
@@ -16,7 +16,6 @@
 
 #include <map>
 #include <memory>
-#include <mutex>
 #include <string>
 
 class CCriticalSection;
@@ -132,18 +131,8 @@ private:
    */
   JoystickMap m_joysticks;
 
-  /*!
-   * \brief Serializable port state
-   */
+  // TODO: Guard with a mutex
   std::unique_ptr<CPortManager> m_portManager;
-
-  /*!
-   * \brief Mutex for port state
-   *
-   * Mutex is recursive to allow for management of several ports within the
-   * function ResetPorts().
-   */
-  mutable std::recursive_mutex m_portMutex;
 
   /*!
    * \brief Keyboard handler

--- a/xbmc/games/addons/input/GameClientJoystick.cpp
+++ b/xbmc/games/addons/input/GameClientJoystick.cpp
@@ -184,6 +184,11 @@ std::string CGameClientJoystick::GetSourceLocation() const
   return "";
 }
 
+float CGameClientJoystick::GetActivation() const
+{
+  return m_portInput->GetActivation();
+}
+
 void CGameClientJoystick::SetSource(PERIPHERALS::PeripheralPtr sourcePeripheral)
 {
   m_sourcePeripheral = std::move(sourcePeripheral);

--- a/xbmc/games/addons/input/GameClientJoystick.h
+++ b/xbmc/games/addons/input/GameClientJoystick.h
@@ -75,10 +75,11 @@ public:
 
   // Input accessors
   const std::string& GetPortAddress() const { return m_portAddress; }
-  const ControllerPtr& GetController() const { return m_controller; }
+  ControllerPtr GetController() const { return m_controller; }
   std::string GetControllerAddress() const;
-  const PERIPHERALS::PeripheralPtr& GetSource() const { return m_sourcePeripheral; }
+  PERIPHERALS::PeripheralPtr GetSource() const { return m_sourcePeripheral; }
   std::string GetSourceLocation() const;
+  float GetActivation() const;
 
   // Input mutators
   void SetSource(PERIPHERALS::PeripheralPtr sourcePeripheral);

--- a/xbmc/games/agents/GameAgentManager.cpp
+++ b/xbmc/games/agents/GameAgentManager.cpp
@@ -133,6 +133,16 @@ bool CGameAgentManager::OnButtonPress(MOUSE::BUTTON_ID button)
   return false;
 }
 
+float CGameAgentManager::GetPortActivation(const std::string& portAddress) const
+{
+  float activation = 0.0f;
+
+  if (m_gameClient)
+    activation = m_gameClient->Input().GetPortActivation(portAddress);
+
+  return activation;
+}
+
 void CGameAgentManager::ProcessJoysticks(PERIPHERALS::EventLockHandlePtr& inputHandlingLock)
 {
   // Get system joysticks.

--- a/xbmc/games/agents/GameAgentManager.cpp
+++ b/xbmc/games/agents/GameAgentManager.cpp
@@ -8,7 +8,6 @@
 
 #include "GameAgentManager.h"
 
-#include "ServiceBroker.h"
 #include "games/addons/GameClient.h"
 #include "games/addons/input/GameClientInput.h"
 #include "games/addons/input/GameClientJoystick.h"
@@ -63,7 +62,7 @@ void CGameAgentManager::Stop()
     for (const auto& [inputProvider, joystick] : m_portMap)
     {
       if (!inputHandlingLock)
-        inputHandlingLock = CServiceBroker::GetPeripherals().RegisterEventLock();
+        inputHandlingLock = m_peripheralManager.RegisterEventLock();
 
       joystick->UnregisterInput(inputProvider);
 
@@ -179,8 +178,7 @@ void CGameAgentManager::ProcessKeyboard()
       !m_gameClient->Input().IsKeyboardOpen())
   {
     PERIPHERALS::PeripheralVector keyboards;
-    CServiceBroker::GetPeripherals().GetPeripheralsWithFeature(keyboards,
-                                                               PERIPHERALS::FEATURE_KEYBOARD);
+    m_peripheralManager.GetPeripheralsWithFeature(keyboards, PERIPHERALS::FEATURE_KEYBOARD);
     if (!keyboards.empty())
     {
       const CControllerTree& controllers = m_gameClient->Input().GetActiveControllerTree();
@@ -202,7 +200,7 @@ void CGameAgentManager::ProcessMouse()
   if (m_bHasMouse && m_gameClient->Input().SupportsMouse() && !m_gameClient->Input().IsMouseOpen())
   {
     PERIPHERALS::PeripheralVector mice;
-    CServiceBroker::GetPeripherals().GetPeripheralsWithFeature(mice, PERIPHERALS::FEATURE_MOUSE);
+    m_peripheralManager.GetPeripheralsWithFeature(mice, PERIPHERALS::FEATURE_MOUSE);
     if (!mice.empty())
     {
       const CControllerTree& controllers = m_gameClient->Input().GetActiveControllerTree();
@@ -251,7 +249,7 @@ void CGameAgentManager::UpdateExpiredJoysticks(const PERIPHERALS::PeripheralVect
       joystick->UnregisterInput(nullptr);
 
       if (!inputHandlingLock)
-        inputHandlingLock = CServiceBroker::GetPeripherals().RegisterEventLock();
+        inputHandlingLock = m_peripheralManager.RegisterEventLock();
       m_portMap.erase(inputProvider);
 
       SetChanged(true);
@@ -293,7 +291,7 @@ void CGameAgentManager::UpdateConnectedJoysticks(
         oldJoystick->UnregisterInput(inputProvider);
 
         if (!inputHandlingLock)
-          inputHandlingLock = CServiceBroker::GetPeripherals().RegisterEventLock();
+          inputHandlingLock = m_peripheralManager.RegisterEventLock();
         m_portMap.erase(itDisconnectedPort);
 
         SetChanged(true);

--- a/xbmc/games/agents/GameAgentManager.h
+++ b/xbmc/games/agents/GameAgentManager.h
@@ -78,6 +78,9 @@ public:
   bool OnButtonPress(MOUSE::BUTTON_ID button) override;
   void OnButtonRelease(MOUSE::BUTTON_ID button) override {}
 
+  // Public interface
+  float GetPortActivation(const std::string& address) const;
+
 private:
   //! @todo De-duplicate these types
   using PortAddress = std::string;

--- a/xbmc/games/controllers/dialogs/GUIDialogButtonCapture.cpp
+++ b/xbmc/games/controllers/dialogs/GUIDialogButtonCapture.cpp
@@ -23,7 +23,6 @@
 
 using namespace KODI;
 using namespace GAME;
-using namespace KODI::MESSAGING;
 
 CGUIDialogButtonCapture::CGUIDialogButtonCapture() : CThread("ButtonCaptureDlg")
 {
@@ -42,8 +41,8 @@ void CGUIDialogButtonCapture::Show()
 
     Create();
 
-    bool bAccepted =
-        HELPERS::ShowOKDialogText(CVariant{GetDialogHeader()}, CVariant{GetDialogText()});
+    bool bAccepted = MESSAGING::HELPERS::ShowOKDialogText(CVariant{GetDialogHeader()},
+                                                          CVariant{GetDialogText()});
 
     StopThread(false);
 
@@ -65,7 +64,7 @@ void CGUIDialogButtonCapture::Process()
       break;
 
     //! @todo Move to rendering thread when there is a rendering thread
-    HELPERS::UpdateOKDialogText(CVariant{35013}, CVariant{GetDialogText()});
+    MESSAGING::HELPERS::UpdateOKDialogText(CVariant{35013}, CVariant{GetDialogText()});
   }
 }
 

--- a/xbmc/games/controllers/guicontrols/GUIGameController.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIGameController.cpp
@@ -12,6 +12,7 @@
 #include "ServiceBroker.h"
 #include "games/GameServices.h"
 #include "games/addons/input/GameClientTopology.h"
+#include "games/agents/GameAgentManager.h"
 #include "games/controllers/Controller.h"
 #include "games/controllers/ControllerLayout.h"
 #include "guilib/GUIListItem.h"
@@ -40,6 +41,8 @@ CGUIGameController::CGUIGameController(const CGUIGameController& from)
   : CGUIImage(from),
     m_controllerIdInfo(from.m_controllerIdInfo),
     m_controllerAddressInfo(from.m_controllerAddressInfo),
+    m_controllerDiffuse(from.m_controllerDiffuse),
+    m_portAddressInfo(from.m_portAddressInfo),
     m_currentController(from.m_currentController),
     m_portAddress(from.m_portAddress)
 {
@@ -52,16 +55,27 @@ CGUIGameController* CGUIGameController::Clone(void) const
   return new CGUIGameController(*this);
 }
 
-void CGUIGameController::Render(void)
+void CGUIGameController::DoProcess(unsigned int currentTime, CDirtyRegionList& dirtyregions)
 {
-  CGUIImage::Render();
+  std::string portAddress;
 
-  std::lock_guard<std::mutex> lock(m_mutex);
-
-  if (m_currentController)
   {
-    //! @todo Render pressed buttons
+    std::lock_guard<std::mutex> lock(m_mutex);
+    portAddress = m_portAddress;
   }
+
+  const GAME::CGameAgentManager& agentManager =
+      CServiceBroker::GetGameServices().GameAgentManager();
+
+  // Highlight the controller if it is active
+  float activation = 0.0f;
+
+  if (!portAddress.empty())
+    activation = agentManager.GetPortActivation(portAddress);
+
+  SetActivation(activation);
+
+  CGUIImage::DoProcess(currentTime, dirtyregions);
 }
 
 void CGUIGameController::UpdateInfo(const CGUIListItem* item /* = nullptr */)
@@ -78,6 +92,8 @@ void CGUIGameController::UpdateInfo(const CGUIListItem* item /* = nullptr */)
 
     if (controllerId.empty())
       controllerId = m_controllerIdInfo.GetItemLabel(item);
+
+    portAddress = m_portAddressInfo.GetItemLabel(item);
 
     std::string controllerAddress = m_controllerAddressInfo.GetItemLabel(item);
     if (!controllerAddress.empty())
@@ -126,6 +142,25 @@ void CGUIGameController::SetControllerAddress(
   }
 }
 
+void CGUIGameController::SetControllerDiffuse(const GUILIB::GUIINFO::CGUIInfoColor& color)
+{
+  m_controllerDiffuse = color;
+}
+
+void CGUIGameController::SetPortAddress(const GUILIB::GUIINFO::CGUIInfoLabel& portAddress)
+{
+  m_portAddressInfo = portAddress;
+
+  // Check if a port address is available without a listitem
+  static const CFileItem empty;
+  const std::string strPortAddress = m_portAddressInfo.GetItemLabel(&empty);
+  if (!strPortAddress.empty())
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_portAddress = strPortAddress;
+  }
+}
+
 void CGUIGameController::ActivateController(const std::string& controllerId)
 {
   CGameServices& gameServices = CServiceBroker::GetGameServices();
@@ -156,4 +191,31 @@ std::string CGUIGameController::GetPortAddress()
 {
   std::lock_guard<std::mutex> lock(m_mutex);
   return m_portAddress;
+}
+
+void CGUIGameController::SetActivation(float activation)
+{
+  // Validate parameters
+  if (activation < 0.0f)
+    activation = 0.0f;
+  if (activation > 1.0f)
+    activation = 1.0f;
+
+  // Get diffuse color parts
+  const uint8_t alpha = (m_controllerDiffuse >> 24) & 0xff;
+  const uint8_t red = (m_controllerDiffuse >> 16) & 0xff;
+  const uint8_t green = (m_controllerDiffuse >> 8) & 0xff;
+  const uint8_t blue = m_controllerDiffuse & 0xff;
+
+  // Merge the diffuse color with white as a portion of the activation
+  const uint8_t newAlpha = static_cast<uint8_t>(0xff - (0xff - alpha) * activation);
+  const uint8_t newRed = static_cast<uint8_t>(0xff - (0xff - red) * activation);
+  const uint8_t newGreen = static_cast<uint8_t>(0xff - (0xff - green) * activation);
+  const uint8_t newBlue = static_cast<uint8_t>(0xff - (0xff - blue) * activation);
+
+  const UTILS::COLOR::Color activationColor =
+      (newAlpha << 24) | (newRed << 16) | (newGreen << 8) | newBlue;
+
+  if (CGUIImage::SetColorDiffuse(activationColor))
+    CGUIImage::UpdateDiffuseColor(nullptr);
 }

--- a/xbmc/games/controllers/guicontrols/GUIGameController.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIGameController.cpp
@@ -92,7 +92,7 @@ void CGUIGameController::UpdateInfo(const CGUIListItem* item /* = nullptr */)
   }
 }
 
-void CGUIGameController::SetControllerID(const KODI::GUILIB::GUIINFO::CGUIInfoLabel& controllerId)
+void CGUIGameController::SetControllerID(const GUILIB::GUIINFO::CGUIInfoLabel& controllerId)
 {
   m_controllerIdInfo = controllerId;
 
@@ -107,7 +107,7 @@ void CGUIGameController::SetControllerID(const KODI::GUILIB::GUIINFO::CGUIInfoLa
 }
 
 void CGUIGameController::SetControllerAddress(
-    const KODI::GUILIB::GUIINFO::CGUIInfoLabel& controllerAddress)
+    const GUILIB::GUIINFO::CGUIInfoLabel& controllerAddress)
 {
   m_controllerAddressInfo = controllerAddress;
 

--- a/xbmc/games/controllers/guicontrols/GUIGameController.h
+++ b/xbmc/games/controllers/guicontrols/GUIGameController.h
@@ -33,12 +33,14 @@ public:
 
   // implementation of CGUIControl via CGUIImage
   CGUIGameController* Clone() const override;
-  void Render() override;
+  void DoProcess(unsigned int currentTime, CDirtyRegionList& dirtyregions) override;
   void UpdateInfo(const CGUIListItem* item = nullptr) override;
 
   // GUI functions
   void SetControllerID(const GUILIB::GUIINFO::CGUIInfoLabel& controllerId);
   void SetControllerAddress(const GUILIB::GUIINFO::CGUIInfoLabel& controllerAddress);
+  void SetControllerDiffuse(const GUILIB::GUIINFO::CGUIInfoColor& color);
+  void SetPortAddress(const GUILIB::GUIINFO::CGUIInfoLabel& portAddress);
 
   // Game functions
   void ActivateController(const std::string& controllerId);
@@ -46,9 +48,14 @@ public:
   std::string GetPortAddress();
 
 private:
+  // GUI functions
+  void SetActivation(float activation);
+
   // GUI parameters
   GUILIB::GUIINFO::CGUIInfoLabel m_controllerIdInfo;
   GUILIB::GUIINFO::CGUIInfoLabel m_controllerAddressInfo;
+  GUILIB::GUIINFO::CGUIInfoColor m_controllerDiffuse;
+  GUILIB::GUIINFO::CGUIInfoLabel m_portAddressInfo;
 
   // Game parameters
   ControllerPtr m_currentController;

--- a/xbmc/games/controllers/guicontrols/GUIGameController.h
+++ b/xbmc/games/controllers/guicontrols/GUIGameController.h
@@ -37,8 +37,8 @@ public:
   void UpdateInfo(const CGUIListItem* item = nullptr) override;
 
   // GUI functions
-  void SetControllerID(const KODI::GUILIB::GUIINFO::CGUIInfoLabel& controllerId);
-  void SetControllerAddress(const KODI::GUILIB::GUIINFO::CGUIInfoLabel& controllerAddress);
+  void SetControllerID(const GUILIB::GUIINFO::CGUIInfoLabel& controllerId);
+  void SetControllerAddress(const GUILIB::GUIINFO::CGUIInfoLabel& controllerAddress);
 
   // Game functions
   void ActivateController(const std::string& controllerId);
@@ -47,8 +47,8 @@ public:
 
 private:
   // GUI parameters
-  KODI::GUILIB::GUIINFO::CGUIInfoLabel m_controllerIdInfo;
-  KODI::GUILIB::GUIINFO::CGUIInfoLabel m_controllerAddressInfo;
+  GUILIB::GUIINFO::CGUIInfoLabel m_controllerIdInfo;
+  GUILIB::GUIINFO::CGUIInfoLabel m_controllerAddressInfo;
 
   // Game parameters
   ControllerPtr m_currentController;

--- a/xbmc/games/controllers/input/CMakeLists.txt
+++ b/xbmc/games/controllers/input/CMakeLists.txt
@@ -1,9 +1,11 @@
-set(SOURCES InputSink.cpp
+set(SOURCES ControllerActivity.cpp
+            InputSink.cpp
             PhysicalFeature.cpp
             PhysicalTopology.cpp
 )
 
-set(HEADERS InputSink.h
+set(HEADERS ControllerActivity.h
+            InputSink.h
             PhysicalFeature.h
             PhysicalTopology.h
 )

--- a/xbmc/games/controllers/input/ControllerActivity.cpp
+++ b/xbmc/games/controllers/input/ControllerActivity.cpp
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ControllerActivity.h"
+
+using namespace KODI;
+using namespace GAME;
+
+#include <algorithm>
+#include <cstdlib>
+
+void CControllerActivity::OnButtonPress(bool pressed)
+{
+  if (pressed)
+    m_currentActivation = 1.0f;
+}
+
+void CControllerActivity::OnButtonMotion(float magnitude)
+{
+  m_currentActivation = std::max(magnitude, m_currentActivation);
+}
+
+void CControllerActivity::OnAnalogStickMotion(float x, float y)
+{
+  m_currentActivation = std::max(std::abs(x), m_currentActivation);
+  m_currentActivation = std::max(std::abs(y), m_currentActivation);
+}
+
+void CControllerActivity::OnWheelMotion(float position)
+{
+  m_currentActivation = std::max(std::abs(position), m_currentActivation);
+}
+
+void CControllerActivity::OnThrottleMotion(float position)
+{
+  m_currentActivation = std::max(std::abs(position), m_currentActivation);
+}
+
+void CControllerActivity::OnInputFrame()
+{
+  m_lastActivation = m_currentActivation;
+  m_currentActivation = 0.0f;
+}

--- a/xbmc/games/controllers/input/ControllerActivity.h
+++ b/xbmc/games/controllers/input/ControllerActivity.h
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+namespace KODI
+{
+namespace GAME
+{
+/*!
+ * \ingroup games
+ *
+ * \brief Class to hold state about the current activity of a controller
+ *
+ * The state is held as a single float value, which is updated by the various
+ * On*() methods. The activity is the maximum value on a single input frame.
+ * The value is saved to m_lastActivity on each call to OnInputFrame().
+ */
+class CControllerActivity
+{
+public:
+  CControllerActivity() = default;
+  ~CControllerActivity() = default;
+
+  float GetActivation() const { return m_lastActivation; }
+
+  void OnButtonPress(bool pressed);
+  void OnButtonMotion(float magnitude);
+  void OnAnalogStickMotion(float x, float y);
+  void OnWheelMotion(float position);
+  void OnThrottleMotion(float position);
+  void OnInputFrame();
+
+private:
+  float m_lastActivation{0.0f};
+  float m_currentActivation{0.0f};
+};
+} // namespace GAME
+} // namespace KODI

--- a/xbmc/games/controllers/windows/GUIControllerList.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerList.cpp
@@ -36,7 +36,6 @@
 #include <iterator>
 
 using namespace KODI;
-using namespace ADDON;
 using namespace GAME;
 
 CGUIControllerList::CGUIControllerList(CGUIWindow* window,

--- a/xbmc/games/controllers/windows/GUIControllerWindow.cpp
+++ b/xbmc/games/controllers/windows/GUIControllerWindow.cpp
@@ -32,7 +32,6 @@
 
 using namespace KODI;
 using namespace GAME;
-using namespace KODI::MESSAGING;
 
 CGUIControllerWindow::CGUIControllerWindow(void)
   : CGUIDialog(WINDOW_DIALOG_GAME_CONTROLLERS, "DialogGameControllers.xml"),
@@ -348,7 +347,7 @@ void CGUIControllerWindow::GetMoreControllers(void)
   {
     // "Controller profiles"
     // "All available controller profiles are installed."
-    HELPERS::ShowOKDialogText(CVariant{35050}, CVariant{35062});
+    MESSAGING::HELPERS::ShowOKDialogText(CVariant{35050}, CVariant{35062});
     return;
   }
 }
@@ -371,7 +370,7 @@ void CGUIControllerWindow::ShowHelp(void)
 {
   // "Help"
   // <help text>
-  HELPERS::ShowOKDialogText(CVariant{10043}, CVariant{35055});
+  MESSAGING::HELPERS::ShowOKDialogText(CVariant{10043}, CVariant{35055});
 }
 
 void CGUIControllerWindow::ShowButtonCaptureDialog(void)

--- a/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
+++ b/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
@@ -21,7 +21,6 @@
 #include "utils/log.h"
 
 using namespace KODI;
-using namespace KODI::MESSAGING;
 using namespace GAME;
 
 std::string CGUIDialogSelectGameClient::ShowAndGetGameClient(const std::string& gamePath,

--- a/xbmc/games/ports/input/PortInput.h
+++ b/xbmc/games/ports/input/PortInput.h
@@ -23,6 +23,8 @@ class IInputProvider;
 
 namespace GAME
 {
+class CControllerActivity;
+
 class CPortInput : public JOYSTICK::IInputHandler, public IKeymapEnvironment
 {
 public:
@@ -32,7 +34,8 @@ public:
   void RegisterInput(JOYSTICK::IInputProvider* provider);
   void UnregisterInput(JOYSTICK::IInputProvider* provider);
 
-  JOYSTICK::IInputHandler* InputHandler() { return m_gameInput; }
+  // Input parameters
+  float GetActivation() const;
 
   // Implementation of IInputHandler
   std::string ControllerID() const override;
@@ -54,7 +57,7 @@ public:
   bool OnThrottleMotion(const std::string& feature,
                         float position,
                         unsigned int motionTimeMs) override;
-  void OnInputFrame() override {}
+  void OnInputFrame() override;
 
   // Implementation of IKeymapEnvironment
   int GetWindowID() const override;
@@ -72,6 +75,9 @@ private:
 
   // Prevents input falling through to Kodi when not handled by the game
   std::unique_ptr<JOYSTICK::IInputHandler> m_inputSink;
+
+  // Records controller activity
+  std::unique_ptr<CControllerActivity> m_controllerActivity;
 };
 } // namespace GAME
 } // namespace KODI

--- a/xbmc/games/ports/windows/GUIPortList.cpp
+++ b/xbmc/games/ports/windows/GUIPortList.cpp
@@ -32,7 +32,6 @@
 #include "view/ViewState.h"
 
 using namespace KODI;
-using namespace ADDON;
 using namespace GAME;
 
 CGUIPortList::CGUIPortList(CGUIWindow& window)

--- a/xbmc/games/windows/GUIViewStateWindowGames.cpp
+++ b/xbmc/games/windows/GUIViewStateWindowGames.cpp
@@ -61,8 +61,6 @@ std::string CGUIViewStateWindowGames::GetLockType()
 
 std::string CGUIViewStateWindowGames::GetExtensions()
 {
-  using namespace ADDON;
-
   std::set<std::string> exts = CGameUtils::GetGameExtensions();
 
   // Ensure .zip appears

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -1576,6 +1576,16 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     GetInfoLabel(pControlNode, "controlleraddress", controllerAddress, parentID);
     gcontrol->SetControllerAddress(controllerAddress);
 
+    // Set controller diffuse color
+    GUIINFO::CGUIInfoColor controllerDiffuse(0xFFFFFFFF);
+    GetInfoColor(pControlNode, "controllerdiffuse", controllerDiffuse, parentID);
+    gcontrol->SetControllerDiffuse(controllerDiffuse);
+
+    // Set port address
+    GUIINFO::CGUIInfoLabel portAddress;
+    GetInfoLabel(pControlNode, "portaddress", portAddress, parentID);
+    gcontrol->SetPortAddress(portAddress);
+
     break;
   }
   case CGUIControl::GUICONTROL_COLORBUTTON:

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -1568,12 +1568,12 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
 
     // Set controller ID
     GUIINFO::CGUIInfoLabel controllerId;
-    GetInfoLabel(pControlNode, "controllerId", controllerId, parentID);
+    GetInfoLabel(pControlNode, "controllerid", controllerId, parentID);
     gcontrol->SetControllerID(controllerId);
 
     // Set controller address
     GUIINFO::CGUIInfoLabel controllerAddress;
-    GetInfoLabel(pControlNode, "controllerAddress", controllerAddress, parentID);
+    GetInfoLabel(pControlNode, "controlleraddress", controllerAddress, parentID);
     gcontrol->SetControllerAddress(controllerAddress);
 
     break;

--- a/xbmc/peripherals/addons/AddonInputHandling.cpp
+++ b/xbmc/peripherals/addons/AddonInputHandling.cpp
@@ -35,7 +35,7 @@ CAddonInputHandling::CAddonInputHandling(CPeripherals& manager,
   {
     CLog::Log(LOGDEBUG, "Failed to locate add-on for \"{}\"", peripheral->DeviceName());
   }
-  else
+  else if (!handler->ControllerID().empty())
   {
     m_buttonMap.reset(new CAddonButtonMap(peripheral, addon, handler->ControllerID()));
     if (m_buttonMap->Load())
@@ -67,7 +67,7 @@ CAddonInputHandling::CAddonInputHandling(CPeripherals& manager,
   {
     CLog::Log(LOGDEBUG, "Failed to locate add-on for \"{}\"", peripheral->DeviceName());
   }
-  else
+  else if (!handler->ControllerID().empty())
   {
     m_buttonMap.reset(new CAddonButtonMap(peripheral, addon, handler->ControllerID()));
     if (m_buttonMap->Load())
@@ -91,7 +91,7 @@ CAddonInputHandling::CAddonInputHandling(CPeripherals& manager,
   {
     CLog::Log(LOGDEBUG, "Failed to locate add-on for \"{}\"", peripheral->DeviceName());
   }
-  else
+  else if (!handler->ControllerID().empty())
   {
     m_buttonMap.reset(new CAddonButtonMap(peripheral, addon, handler->ControllerID()));
     if (m_buttonMap->Load())

--- a/xbmc/peripherals/devices/PeripheralMouse.cpp
+++ b/xbmc/peripherals/devices/PeripheralMouse.cpp
@@ -54,8 +54,6 @@ bool CPeripheralMouse::InitialiseFeature(const PeripheralFeature feature)
 void CPeripheralMouse::RegisterMouseDriverHandler(MOUSE::IMouseDriverHandler* handler,
                                                   bool bPromiscuous)
 {
-  using namespace KEYBOARD;
-
   std::unique_lock<CCriticalSection> lock(m_mutex);
 
   MouseHandle handle{handler, bPromiscuous};

--- a/xbmc/peripherals/dialogs/GUIDialogPeripherals.h
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripherals.h
@@ -40,7 +40,6 @@ private:
   // implementation of CGUIWindow via CGUIDialogSelect
   void OnInitWindow() override;
 
-  void ShowInternal();
   void UpdatePeripheralsAsync();
   void UpdatePeripheralsSync();
 


### PR DESCRIPTION
## Description

This PR extends the `gamecontroller` control to allow for ports to be highlighted when the underlying peripheral is activated.

Similar to https://github.com/xbmc/xbmc/pull/23501, new fields are added. The new fields are:

* `<portaddress>` - allows the skin to specify a port address that is used to detect active input
* `<controllerdiffuse>` - the color to diffuse over a controller with active input

The `controllerdiffuse` color is overlaid on the controller proportional to the activation. E.g. as a trigger is depressed or an analog stick is moved, the diffusion is applied gradually from 0% to 100%. It's kinda a cool effect when you do analog input.

Additionally, this PR reverts the mutex added in https://github.com/xbmc/xbmc/pull/23499, due to a [report](https://forum.kodi.tv/showthread.php?tid=173361&pid=3159592#pid3159592) that it introduces more problems than it fixes.

The PR diff got a little ugly, so I recommend reviewing commit-by-commit.

## Motivation and context

Helps to identify which controller is attached to which port, without needing my full-blown Player Manager (which isn't quite ready yet).

## How has this been tested?

Included in my 2023-07-17 test builds: https://github.com/garbear/xbmc/releases

## What is the effect on users?

* Highlights active controller in the Port Dialog

## Screenshots (if appropriate):

Shows the 4th controller highlighted as buttons are being pressed:

![screenshot00004](https://github.com/xbmc/xbmc/assets/531482/aca72d3c-d661-46f9-a07a-1094a589534e)

Shows both the emulated controller and the underlying peripheral being highlighted as buttons are being pressed in the Player Viewer (not included in this PR):

![screenshot00006](https://github.com/xbmc/xbmc/assets/531482/2205d98c-8b59-4fbb-97ba-fd086981e1eb)

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)
