### PR TITLE
[DVDDemux] Add new audio codec descriptions

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
@@ -8,21 +8,41 @@
 
 #include "DVDDemux.h"
 
+#include "utils/StringUtils.h"
+
 std::string CDemuxStreamAudio::GetStreamType()
 {
   std::string strInfo;
   switch (codec)
   {
+    //! @todo: With ffmpeg >= 6.1 add new AC4 codec
     case AV_CODEC_ID_AC3:
       strInfo = "AC3 ";
       break;
     case AV_CODEC_ID_EAC3:
-      strInfo = "DD+ ";
+    {
+      //! @todo: With ffmpeg >= 6.1 add new atmos profile case
+      // "JOC" its EAC3 Atmos underlying profile, there is no standard codec name string
+      if (StringUtils::Contains(codecName, "JOC"))
+        strInfo = "DD+ ATMOS ";
+      else
+        strInfo = "DD+ ";
       break;
+    }
     case AV_CODEC_ID_DTS:
     {
+      //! @todo: With ffmpeg >= 6.1 add new DTSX profile cases
       switch (profile)
       {
+        case FF_PROFILE_DTS_96_24:
+          strInfo = "DTS 96/24 ";
+          break;
+        case FF_PROFILE_DTS_ES:
+          strInfo = "DTS ES ";
+          break;
+        case FF_PROFILE_DTS_EXPRESS:
+          strInfo = "DTS EXPRESS ";
+          break;
         case FF_PROFILE_DTS_HD_MA:
           strInfo = "DTS-HD MA ";
           break;
@@ -45,8 +65,46 @@ std::string CDemuxStreamAudio::GetStreamType()
       strInfo = "TrueHD ";
       break;
     case AV_CODEC_ID_AAC:
-      strInfo = "AAC ";
+    {
+      switch (profile)
+      {
+        case FF_PROFILE_AAC_LOW:
+        case FF_PROFILE_MPEG2_AAC_LOW:
+          strInfo = "AAC-LC ";
+          break;
+        case FF_PROFILE_AAC_HE:
+        case FF_PROFILE_MPEG2_AAC_HE:
+          strInfo = "HE-AAC ";
+          break;
+        case FF_PROFILE_AAC_HE_V2:
+          strInfo = "HE-AACv2 ";
+          break;
+        case FF_PROFILE_AAC_SSR:
+          strInfo = "AAC-SSR ";
+          break;
+        case FF_PROFILE_AAC_LTP:
+          strInfo = "AAC-LTP ";
+          break;
+        default:
+        {
+          // Try check by codec full string according to RFC 6381
+          if (codecName == "mp4a.40.2" || codecName == "mp4a.40.17")
+            strInfo = "AAC-LC ";
+          else if (codecName == "mp4a.40.3")
+            strInfo = "AAC-SSR ";
+          else if (codecName == "mp4a.40.4" || codecName == "mp4a.40.19")
+            strInfo = "AAC-LTP ";
+          else if (codecName == "mp4a.40.5")
+            strInfo = "HE-AAC ";
+          else if (codecName == "mp4a.40.29")
+            strInfo = "HE-AACv2 ";
+          else
+            strInfo = "AAC ";
+          break;
+        }
+      }
       break;
+    }
     case AV_CODEC_ID_ALAC:
       strInfo = "ALAC ";
       break;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
@@ -13,59 +13,59 @@ std::string CDemuxStreamAudio::GetStreamType()
   std::string strInfo;
   switch (codec)
   {
-  case AV_CODEC_ID_AC3:
-    strInfo = "AC3 ";
-    break;
-  case AV_CODEC_ID_EAC3:
-    strInfo = "DD+ ";
-    break;
-  case AV_CODEC_ID_DTS:
-  {
-    switch (profile)
+    case AV_CODEC_ID_AC3:
+      strInfo = "AC3 ";
+      break;
+    case AV_CODEC_ID_EAC3:
+      strInfo = "DD+ ";
+      break;
+    case AV_CODEC_ID_DTS:
     {
-    case FF_PROFILE_DTS_HD_MA:
-      strInfo = "DTS-HD MA ";
-      break;
-    case FF_PROFILE_DTS_HD_HRA:
-      strInfo = "DTS-HD HRA ";
-      break;
-    default:
-      strInfo = "DTS ";
+      switch (profile)
+      {
+        case FF_PROFILE_DTS_HD_MA:
+          strInfo = "DTS-HD MA ";
+          break;
+        case FF_PROFILE_DTS_HD_HRA:
+          strInfo = "DTS-HD HRA ";
+          break;
+        default:
+          strInfo = "DTS ";
+          break;
+      }
       break;
     }
-    break;
-  }
-  case AV_CODEC_ID_MP2:
-    strInfo = "MP2 ";
-    break;
-  case AV_CODEC_ID_MP3:
-    strInfo = "MP3 ";
-    break;
-  case AV_CODEC_ID_TRUEHD:
-    strInfo = "TrueHD ";
-    break;
-  case AV_CODEC_ID_AAC:
-    strInfo = "AAC ";
-    break;
-  case AV_CODEC_ID_ALAC:
-    strInfo = "ALAC ";
-    break;
-  case AV_CODEC_ID_FLAC:
-    strInfo = "FLAC ";
-    break;
-  case AV_CODEC_ID_OPUS:
-    strInfo = "Opus ";
-    break;
-  case AV_CODEC_ID_VORBIS:
-    strInfo = "Vorbis ";
-    break;
-  case AV_CODEC_ID_PCM_BLURAY:
-  case AV_CODEC_ID_PCM_DVD:
-    strInfo = "PCM ";
-    break;
-  default:
-    strInfo = "";
-    break;
+    case AV_CODEC_ID_MP2:
+      strInfo = "MP2 ";
+      break;
+    case AV_CODEC_ID_MP3:
+      strInfo = "MP3 ";
+      break;
+    case AV_CODEC_ID_TRUEHD:
+      strInfo = "TrueHD ";
+      break;
+    case AV_CODEC_ID_AAC:
+      strInfo = "AAC ";
+      break;
+    case AV_CODEC_ID_ALAC:
+      strInfo = "ALAC ";
+      break;
+    case AV_CODEC_ID_FLAC:
+      strInfo = "FLAC ";
+      break;
+    case AV_CODEC_ID_OPUS:
+      strInfo = "Opus ";
+      break;
+    case AV_CODEC_ID_VORBIS:
+      strInfo = "Vorbis ";
+      break;
+    case AV_CODEC_ID_PCM_BLURAY:
+    case AV_CODEC_ID_PCM_DVD:
+      strInfo = "PCM ";
+      break;
+    default:
+      strInfo = "";
+      break;
   }
 
   strInfo += m_channelLayoutName;
@@ -79,7 +79,8 @@ int CDVDDemux::GetNrOfStreams(StreamType streamType)
 
   for (auto pStream : GetStreams())
   {
-    if (pStream && pStream->type == streamType) iCounter++;
+    if (pStream && pStream->type == streamType)
+      iCounter++;
   }
 
   return iCounter;

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -1889,6 +1889,22 @@ std::string StringUtils::FormatFileSize(uint64_t bytes)
   return Format("{:.{}f}{}", value, decimals, units[i]);
 }
 
+bool StringUtils::Contains(std::string_view str,
+                           std::string_view keyword,
+                           bool isCaseInsensitive /* = true */)
+{
+  if (isCaseInsensitive)
+  {
+    auto itStr = std::search(str.begin(), str.end(), keyword.begin(), keyword.end(),
+                             [](unsigned char ch1, unsigned char ch2) {
+                               return std::toupper(ch1) == std::toupper(ch2);
+                             });
+    return (itStr != str.end());
+  }
+
+  return str.find(keyword) != std::string_view::npos;
+}
+
 const std::locale& StringUtils::GetOriginalLocale() noexcept
 {
   return g_langInfo.GetOriginalLocale();

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -417,6 +417,16 @@ public:
    */
   static std::string CreateFromCString(const char* cstr);
 
+  /*!
+   * \brief Check if a keyword string is contained on another string.
+   * \param str The string in which to search for the keyword
+   * \param keyword The string to search for
+   * \return True if the keyword if found.
+   */
+  static bool Contains(std::string_view str,
+                       std::string_view keyword,
+                       bool isCaseInsensitive = true);
+
 private:
   /*!
    * Wrapper for CLangInfo::GetOriginalLocale() which allows us to


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This change extend the codec descriptions with the most common audio standard format tyoes used most of the time on all video services

Currently video services using common protocols mainly HLS / DASH can provide videos with more audio tracks with same languages but different codec type, this results that on GUI audio track list appears all the same and its not possible distinguish them, with following change we can show the appropriate audio codec description.

This is done by parsing the _full codec string_ that can be read (when provided) from the existing `CDemuxStream::codecName` variable, e.g. "mp4a.40.2"

The full codec string ususally consist in the fourcc+profile/object type as RFC 6381,
some common definitions can be found also on:
https://dashif.org/codecs/audio/
https://developer.mozilla.org/en-US/docs/Web/Media/Formats/codecs_parameter#mpeg-4_audio
other documents say the same

"JOC" its the specific ec3 atmos format, im not aware of a full codec string that expose it, but i know that exists the mimetype (eac3-joc) for example on DASH protocol its set with a separate xml property that we can translate it in a full codec string
despite not exists a full codec string, it would be great if we could still keep it, since we have the possibility to parse it easily

BEFORE:
![immagine](https://github.com/xbmc/xbmc/assets/3257156/34dfc829-21d7-4501-8a31-35880a34fff7)

AFTER:
![immagine](https://github.com/xbmc/xbmc/assets/3257156/8805552d-b247-4c8d-8719-044579482e59)

**UPDATE:**
I have add missing ffmpeg profile cases so that also local files can benefit from this change

SIDE NOTE ~TODO~:
For InputStream addons to set audio profiles is required PR #23541

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix issue https://github.com/xbmc/inputstream.adaptive/issues/650

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Play this STRM, required inputstream.adaptive:
```
#KODIPROP:inputstream=inputstream.adaptive
#KODIPROP:inputstream.adaptive.manifest_type=hls
https://devstreaming-cdn.apple.com/videos/streaming/examples/adv_dv_atmos/main.m3u8
```
and tested with a local mp4 video with AAC LC

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
user can distinguish audio tracks by format type
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
