### PR TITLE
[Windows] improve user experience when Windows HDR is ON by default

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
@@ -140,13 +140,24 @@ CRendererBase::CRendererBase(CVideoSettings& videoSettings)
 
 CRendererBase::~CRendererBase()
 {
-  if (DX::Windowing()->IsHDROutput())
+  // At playback stop restores Windows HDR state to previous state
+  // Is not need set swap chain color space because toggling HDR re-creates swap chain
+  if (m_AutoSwitchHDR)
   {
-    CLog::LogF(LOGDEBUG, "Restoring SDR rendering");
-    DX::Windowing()->SetHdrColorSpace(DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709);
-    if (m_AutoSwitchHDR)
-      DX::Windowing()->ToggleHDR(); // Toggle display HDR OFF
+    if (m_initiallyHdrEnabled != DX::Windowing()->IsHDROutput())
+    {
+      CLog::LogF(LOGDEBUG, "Restoring {} rendering", m_initiallyHdrEnabled ? "HDR" : "SDR");
+      DX::Windowing()->ToggleHDR();
+    }
   }
+  else // swap chain is not re-created, set proper color space
+    {
+      if (DX::Windowing()->IsHDROutput())
+      DX::Windowing()->SetHdrColorSpace(DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020);
+    else
+      DX::Windowing()->SetHdrColorSpace(DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709);
+    }
+	
   Flush(false);
 }
 
@@ -182,23 +193,26 @@ bool CRendererBase::Configure(const VideoPicture& picture, float fps, unsigned o
   m_ditherDepth = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt("videoscreen.ditherdepth");
 
   m_lastHdr10 = {};
-  m_HdrType = HDR_TYPE::HDR_NONE_SDR;
+  m_HdrType = HDR_TYPE::HDR_INVALID;
   m_useHLGtoPQ = false;
   m_AutoSwitchHDR = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
                         DX::Windowing()->SETTING_WINSYSTEM_IS_HDR_DISPLAY) &&
                     DX::Windowing()->IsHDRDisplay();
-
+					
   // Auto switch HDR only if supported and "Settings/Player/Use HDR display capabilities" = ON
   if (m_AutoSwitchHDR)
   {
-    bool streamIsHDR = (picture.color_primaries == AVCOL_PRI_BT2020) &&
-                       (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
-                        picture.color_transfer == AVCOL_TRC_ARIB_STD_B67);
+    m_initiallyHdrEnabled = DX::Windowing()->IsHDROutput();
+    CLog::LogF(LOGDEBUG, "Storing Windows HDR state: {}", m_initiallyHdrEnabled ? "ON" : "OFF");
+
+    const bool streamIsHDR = (picture.color_primaries == AVCOL_PRI_BT2020) &&
+                             (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
+                              picture.color_transfer == AVCOL_TRC_ARIB_STD_B67);
 
     if (streamIsHDR != DX::Windowing()->IsHDROutput())
       DX::Windowing()->ToggleHDR();
   }
-
+  
   return true;
 }
 
@@ -638,6 +652,7 @@ void CRendererBase::ProcessHDR(CRenderBuffer* rb)
       CLog::LogF(LOGINFO, "Switching to HDR rendering");
       DX::Windowing()->SetHdrColorSpace(DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020);
       m_HdrType = HDR_TYPE::HDR_HLG;
+	  m_lastHdr10 = hdr10;
     }
   }
   // SDR
@@ -647,7 +662,16 @@ void CRendererBase::ProcessHDR(CRenderBuffer* rb)
     {
       // Switch to SDR rendering
       CLog::LogF(LOGINFO, "Switching to SDR rendering");
-      DX::Windowing()->SetHdrColorSpace(DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709);
+      // not need set color space because is alredy set when swap chain is re-created
+      if (m_AutoSwitchHDR)
+      {
+        if (DX::Windowing()->IsHDROutput())
+          DX::Windowing()->ToggleHDR(); // Toggle display HDR OFF
+      }
+      else
+      {
+        DX::Windowing()->SetHdrColorSpace(DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709);
+      }
       m_HdrType = HDR_TYPE::HDR_NONE_SDR;
       m_lastHdr10 = {};
       if (m_AutoSwitchHDR)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
@@ -48,6 +48,7 @@ enum RenderMethod
 
 enum class HDR_TYPE
 {
+  HDR_INVALID = -1,
   HDR_NONE_SDR = 0,
   HDR_HDR10 = 1,
   HDR_HLG = 2
@@ -190,7 +191,8 @@ protected:
   std::map<int, CRenderBuffer*> m_renderBuffers;
 
   DXGI_HDR_METADATA_HDR10 m_lastHdr10 = {};
-  HDR_TYPE m_HdrType = HDR_TYPE::HDR_NONE_SDR;
+  HDR_TYPE m_HdrType = HDR_TYPE::HDR_INVALID;
   bool m_AutoSwitchHDR = false;
+  bool m_initiallyHdrEnabled = false;
   std::string m_renderMethodName;
 };

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -702,14 +702,11 @@ void DX::DeviceResources::ResizeBuffers()
 
     m_IsHDROutput = (swapChainDesc.Format == DXGI_FORMAT_R10G10B10A2_UNORM) && isHdrEnabled;
 
-    const int bits = (swapChainDesc.Format == DXGI_FORMAT_R10G10B10A2_UNORM) ? 10 : 8;
-    std::string flip =
-        (swapChainDesc.SwapEffect == DXGI_SWAP_EFFECT_FLIP_DISCARD) ? "discard" : "sequential";
-
-    CLog::LogF(LOGINFO,
-               "{} bit swapchain is used with {} flip {} buffers and {} output (format {})", bits,
-               swapChainDesc.BufferCount, flip, m_IsHDROutput ? "HDR" : "SDR",
-               DX::DXGIFormatToString(swapChainDesc.Format));
+    CLog::LogF(
+        LOGINFO, "{} bit swapchain is used with {} flip {} buffers and {} output (format {})",
+        (swapChainDesc.Format == DXGI_FORMAT_R10G10B10A2_UNORM) ? 10 : 8, swapChainDesc.BufferCount,
+        (swapChainDesc.SwapEffect == DXGI_SWAP_EFFECT_FLIP_DISCARD) ? "discard" : "sequential",
+        m_IsHDROutput ? "HDR" : "SDR", DX::DXGIFormatToString(swapChainDesc.Format));
 
     hr = swapChain.As(&m_swapChain); CHECK_ERR();
     m_stereoEnabled = bHWStereoEnabled;
@@ -732,6 +729,9 @@ void DX::DeviceResources::ResizeBuffers()
     hr = m_d3dDevice.As(&dxgiDevice); CHECK_ERR();
     dxgiDevice->SetMaximumFrameLatency(1);
     m_usedSwapChain = false;
+	
+    if (m_IsHDROutput)
+      SetHdrColorSpace(DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020);	
   }
 
   CLog::LogF(LOGDEBUG, "end resize buffers.");


### PR DESCRIPTION
Improve user experience when Windows HDR is ON by default

Motivation and context
This is a more simple and improved version of #23500 Some users wants/prefers Windows HDR on all the time.

- For users that has Windows HDR off by default nothing changes. 
- For users that has Windows HDR on by default Kodi GUI follows same desktop HDR on state. 
- No differences in video playback: i.e for SDR videos HDR is allways OFF even users that has Windows HDR on "all the time". 
- Windows HDR state at exit Kodi is not modified: ie. users that has desktop with HDR on when exit Kodi continues with HDR on (even if playback SDR videos). 

The only differences with current master/Nexus is Kodi GUI follows current Windows HDR desktop state and Windows HDR state is preserved when exit Kodi. No differences in HDR videos playback. No differences in SDR videos playback.

How has this been tested?
Tested on Windows 11 Intel/Nvidia

What is the effect on users?
Users will notice their HDR switch is not tampered with on exit of Kodi

Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
