### PR TITLE
[Windows][Android] Remove some settings includes and better HDR settings code reuse

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -1018,9 +1018,7 @@ bool CApplication::OnAction(const CAction &action)
   if (action.GetID() == ACTION_HDR_TOGGLE)
   {
     // Only enables manual HDR toggle if no video is playing or auto HDR switch is disabled
-    if (appPlayer->IsPlayingVideo() &&
-        CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-            CServiceBroker::GetWinSystem()->SETTING_WINSYSTEM_IS_HDR_DISPLAY))
+    if (appPlayer->IsPlayingVideo() && CServiceBroker::GetWinSystem()->IsHDRDisplaySettingEnabled())
       return true;
 
     HDR_STATUS hdrStatus = CServiceBroker::GetWinSystem()->ToggleHDR();
@@ -1041,9 +1039,7 @@ bool CApplication::OnAction(const CAction &action)
   if (action.GetID() == ACTION_CYCLE_TONEMAP_METHOD)
   {
     // Only enables tone mapping switch if display is not HDR capable or HDR is not enabled
-    if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-            CServiceBroker::GetWinSystem()->SETTING_WINSYSTEM_IS_HDR_DISPLAY) &&
-        CServiceBroker::GetWinSystem()->IsHDRDisplay())
+    if (CServiceBroker::GetWinSystem()->IsHDRDisplaySettingEnabled())
       return true;
 
     if (appPlayer->IsPlayingVideo())

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
@@ -184,9 +184,7 @@ bool CRendererBase::Configure(const VideoPicture& picture, float fps, unsigned o
   m_lastHdr10 = {};
   m_HdrType = HDR_TYPE::HDR_NONE_SDR;
   m_useHLGtoPQ = false;
-  m_AutoSwitchHDR = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-                        DX::Windowing()->SETTING_WINSYSTEM_IS_HDR_DISPLAY) &&
-                    DX::Windowing()->IsHDRDisplay();
+  m_AutoSwitchHDR = DX::Windowing()->IsHDRDisplaySettingEnabled();
 
   // Auto switch HDR only if supported and "Settings/Player/Use HDR display capabilities" = ON
   if (m_AutoSwitchHDR)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererShaders.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererShaders.cpp
@@ -10,8 +10,6 @@
 
 #include "DVDCodecs/Video/DXVA.h"
 #include "rendering/dx/RenderContext.h"
-#include "settings/Settings.h"
-#include "settings/SettingsComponent.h"
 #include "utils/CPUInfo.h"
 #ifndef _M_ARM
   #include "utils/gpu_memcpy_sse4.h"
@@ -210,9 +208,7 @@ DXGI_FORMAT CRendererShaders::CalcIntermediateTargetFormat(const VideoPicture& p
   // Default value: same as the back buffer
   DXGI_FORMAT format{DX::Windowing()->GetBackBuffer().GetFormat()};
 
-  const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-
-  if (!settings || !settings->GetBool(CSettings::SETTING_VIDEOPLAYER_HIGHPRECISIONPROCESSING))
+  if (!DX::Windowing()->IsHighPrecisionProcessingSettingEnabled())
     return format;
 
   // Preserve HDR precision

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -441,9 +441,7 @@ void CGUIDialogVideoSettings::InitializeSettings()
   // tone mapping
   if (appPlayer->Supports(RENDERFEATURE_TONEMAP))
   {
-    bool visible = !(CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-                         CServiceBroker::GetWinSystem()->SETTING_WINSYSTEM_IS_HDR_DISPLAY) &&
-                     CServiceBroker::GetWinSystem()->IsHDRDisplay());
+    const bool visible = !CServiceBroker::GetWinSystem()->IsHDRDisplaySettingEnabled();
     entries.clear();
     entries.push_back(TranslatableIntegerSettingOption(36554, VS_TONEMAPMETHOD_OFF));
     entries.push_back(TranslatableIntegerSettingOption(36555, VS_TONEMAPMETHOD_REINHARD));

--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -296,3 +296,30 @@ std::shared_ptr<CDPMSSupport> CWinSystemBase::GetDPMSManager()
 {
   return m_dpms;
 }
+
+bool CWinSystemBase::IsHDRDisplaySettingEnabled()
+{
+  if (!IsHDRDisplay())
+    return false;
+
+  const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+
+  return (settings && settings->GetBool(SETTING_WINSYSTEM_IS_HDR_DISPLAY));
+}
+
+bool CWinSystemBase::IsVideoSuperResolutionSettingEnabled()
+{
+  if (!SupportsVideoSuperResolution())
+    return false;
+
+  const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+
+  return (settings && settings->GetBool(CSettings::SETTING_VIDEOPLAYER_USESUPERRESOLUTION));
+}
+
+bool CWinSystemBase::IsHighPrecisionProcessingSettingEnabled()
+{
+  const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+
+  return (settings && settings->GetBool(CSettings::SETTING_VIDEOPLAYER_HIGHPRECISIONPROCESSING));
+}

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -84,8 +84,8 @@ public:
   //the number of presentation buffers
   virtual int NoOfBuffers();
 
-  /**
-   * Get average display latency
+  /*!
+   * \brief Get average display latency
    *
    * The latency should be measured as the time between finishing the rendering
    * of a frame, i.e. calling PresentRender, and the rendered content becoming
@@ -94,8 +94,9 @@ public:
    * \return average display latency in seconds, or negative value if unknown
    */
   virtual float GetDisplayLatency() { return -1.0f; }
-  /**
-   * Get time that should be subtracted from the display latency for this frame
+
+  /*!
+   * \brief Get time that should be subtracted from the display latency for this frame
    * in milliseconds
    *
    * Contrary to \ref GetDisplayLatency, this value is calculated ad-hoc
@@ -115,26 +116,31 @@ public:
   // notifications
   virtual void OnMove(int x, int y) {}
 
-  /*! \brief Get the screen ID provided the screen name
-   *  \param screen the name of the screen as presented on the application display settings
-   *  \return the screen index as known by the windowing system implementation (or the default screen by default)
-  */
+  /*!
+   * \brief Get the screen ID provided the screen name
+   *
+   * \param screen the name of the screen as presented on the application display settings
+   * \return the screen index as known by the windowing system implementation (or the default screen by default)
+   */
   virtual unsigned int GetScreenId(const std::string& screen) { return 0; }
 
-  /*! \brief Window was requested to move to the given screen
-   *  \param screenIdx the screen index as known by the windowing system implementation
-  */
+  /*!
+   * \brief Window was requested to move to the given screen
+   *
+   * \param screenIdx the screen index as known by the windowing system implementation
+   */
   virtual void MoveToScreen(unsigned int screenIdx) {}
 
-  /**
+  /*!
    * \brief Used to signal the windowing system about the change of the current screen
+   *
    * \param screenIdx the screen index as known by the windowing system implementation
-  */
+   */
   virtual void OnChangeScreen(unsigned int screenIdx) {}
 
   // OS System screensaver
-  /**
-   * Get OS screen saver inhibit implementation if available
+  /*!
+   * \brief Get OS screen saver inhibit implementation if available
    *
    * \return OS screen saver implementation that can be used with this windowing system
    *         or nullptr if unsupported.
@@ -149,9 +155,11 @@ public:
   virtual bool CanDoWindowed() { return true; }
   bool IsFullScreen() { return m_bFullScreen; }
 
-  /*! \brief Check if the windowing system supports moving windows across screens
-    \return true if the windowing system supports moving windows across screens, false otherwise
-  */
+  /*!
+   * \brief Check if the windowing system supports moving windows across screens
+   *
+   * \return true if the windowing system supports moving windows across screens, false otherwise
+   */
   virtual bool SupportsScreenMove() { return true; }
 
   virtual void UpdateResolutions();
@@ -179,8 +187,8 @@ public:
   // Access render system interface
   virtual CGraphicContext& GetGfxContext() const;
 
-  /**
-   * Get OS specific hardware context
+  /*!
+   * \brief Get OS specific hardware context
    *
    * \return OS specific context or nullptr if OS not have
    *
@@ -192,8 +200,8 @@ public:
 
   std::shared_ptr<CDPMSSupport> GetDPMSManager();
 
-  /**
-   * @brief Set the HDR metadata. Passing nullptr as the parameter should
+  /*!
+   * \brief Set the HDR metadata. Passing nullptr as the parameter should
    * disable HDR.
    *
    */
@@ -205,17 +213,38 @@ public:
   static const char* SETTING_WINSYSTEM_IS_HDR_DISPLAY;
   virtual bool HasSystemSdrPeakLuminance() { return false; }
 
-  /**
-   * @brief System supports Video Super Resolution HW upscaler i.e.:
+  /*!
+   * \brief System supports Video Super Resolution HW upscaler i.e.:
    * "NVIDIA RTX Video Super Resolution" or "Intel Video Super Resolution"
    *
    */
   virtual bool SupportsVideoSuperResolution() { return false; }
 
-  // Gets debug info from video renderer
+  /*!
+   * \brief Gets debug info from video renderer for use in "Debug Info OSD" (Alt + O)
+   *
+   */
   virtual DEBUG_INFO_RENDER GetDebugInfo() { return {}; }
 
   virtual std::vector<std::string> GetConnectedOutputs() { return {}; }
+
+  /*!
+   * \brief Return true when HDR display is available and enabled in settings
+   *
+   */
+  bool IsHDRDisplaySettingEnabled();
+
+  /*!
+   * \brief Return true when "Video Super Resolution" is supported and enabled in settings
+   *
+   */
+  bool IsVideoSuperResolutionSettingEnabled();
+
+  /*!
+   * \brief Return true when setting "High Precision Processing" is enabled
+   *
+   */
+  bool IsHighPrecisionProcessingSettingEnabled();
 
 protected:
   void UpdateDesktopResolution(RESOLUTION_INFO& newRes, const std::string &output, int width, int height, float refreshRate, uint32_t dwFlags);

--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
@@ -11,8 +11,6 @@
 #include "ServiceBroker.h"
 #include "VideoSyncAndroid.h"
 #include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h"
-#include "settings/Settings.h"
-#include "settings/SettingsComponent.h"
 #include "threads/SingleLock.h"
 #include "utils/log.h"
 #include "windowing/WindowSystemFactory.h"
@@ -222,7 +220,7 @@ bool CWinSystemAndroidGLESContext::IsHDRDisplay()
 
 bool CWinSystemAndroidGLESContext::SetHDR(const VideoPicture* videoPicture)
 {
-  if (!CWinSystemAndroid::IsHDRDisplay() || !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(SETTING_WINSYSTEM_IS_HDR_DISPLAY))
+  if (!CServiceBroker::GetWinSystem()->IsHDRDisplaySettingEnabled())
     return false;
 
   EGLint HDRColorSpace = 0;


### PR DESCRIPTION
## Description
Remove some settings include headers and better HDR settings code reuse

## Motivation and context
Lately, new settings have been added that have made it necessary to add settings includes in files where they were not present and duplicate code fragments to use these settings.

These codes are moved to common files and also taken advantage to improve existing HDR settings code.

No functional changes, is a pure code refactor only.

~NOTE: still exist code duplicity but is due Windows x64 and UWP is treated as different platforms / code paths~

## How has this been tested?
Runtime Windows x64

## What is the effect on users?
none

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
