### PR TITLE
[discs] Improve Linux dvd playback without mounting

### DIFF
--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -149,7 +149,7 @@ bool CAutorun::RunDisc(IDirectory* pDir, const std::string& strDrive, int& nAdde
   CFileItemList vecItems;
 
   CURL pathToUrl{strDrive};
-  // if the url being requested is a generic "iso9660://" we need to expand it with the current drive device.
+  // if the url being requested is a generic "iso9660://" we need to enrich it with the actual drive.
   // use the hostname section to prepend the drive path
   if (pathToUrl.GetRedacted() == "iso9660://")
   {

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -40,6 +40,7 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "events/EventLog.h"
 #include "events/NotificationEvent.h"
+#include "filesystem/DirectoryFactory.h"
 #include "filesystem/File.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIControlProfiler.h"
@@ -2371,6 +2372,13 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
 
   if (item.IsPlayList())
     return false;
+
+  // Translate/Resolve the url if needed
+  const std::unique_ptr<IDirectory> dir{CDirectoryFactory::Create(item)};
+  if (dir && !dir->Resolve(item))
+  {
+    return false;
+  }
 
   // if the item is a plugin we need to resolve the plugin paths
   if (URIUtils::HasPluginPath(item) && !XFILE::CPluginDirectory::GetResolvedPluginResult(item))

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -2380,11 +2380,13 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
     return false;
   }
 
+  //! TODO: Move this to plugin vfs dir resolve(item)
   // if the item is a plugin we need to resolve the plugin paths
   if (URIUtils::HasPluginPath(item) && !XFILE::CPluginDirectory::GetResolvedPluginResult(item))
     return false;
 
 #ifdef HAS_UPNP
+  //! TODO: Move this to upnp vfs dir resolve(item)
   if (URIUtils::IsUPnP(item.GetPath()))
   {
     if (!XFILE::CUPnPDirectory::GetResource(item.GetURL(), item))

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -773,11 +773,6 @@ bool CVideoPlayer::OpenInputStream()
     // FIXME: we should deprecate this when more than one device drive is supported
     m_item.SetPath(CServiceBroker::GetMediaManager().TranslateDevicePath(""));
   }
-  else if (url.GetProtocol() == "iso9660" && !url.GetHostName().empty() &&
-           url.GetFileName() == "VIDEO_TS/video_ts.ifo")
-  {
-    m_item.SetPath(url.GetHostName());
-  }
 
   m_pInputStream = CDVDFactoryInputStream::CreateInputStream(this, m_item, true);
   if (m_pInputStream == nullptr)

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -766,14 +766,6 @@ bool CVideoPlayer::OpenInputStream()
 
   CLog::Log(LOGINFO, "Creating InputStream");
 
-  // correct the filename if needed
-  const CURL url{m_item.GetPath()};
-  if (url.GetProtocol() == "dvd")
-  {
-    // FIXME: we should deprecate this when more than one device drive is supported
-    m_item.SetPath(CServiceBroker::GetMediaManager().TranslateDevicePath(""));
-  }
-
   m_pInputStream = CDVDFactoryInputStream::CreateInputStream(this, m_item, true);
   if (m_pInputStream == nullptr)
   {

--- a/xbmc/filesystem/CMakeLists.txt
+++ b/xbmc/filesystem/CMakeLists.txt
@@ -151,9 +151,11 @@ endif()
 
 if(ENABLE_OPTICAL)
   list(APPEND SOURCES CDDADirectory.cpp
-                      CDDAFile.cpp)
+                      CDDAFile.cpp
+                      DVDDirectory.cpp)
   list(APPEND HEADERS CDDADirectory.h
-                      CDDAFile.h)
+                      CDDAFile.h
+                      DVDDirectory.h)
 endif()
 
 if(NFS_FOUND)

--- a/xbmc/filesystem/DVDDirectory.cpp
+++ b/xbmc/filesystem/DVDDirectory.cpp
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "DVDDirectory.h"
+
+#include "FileItem.h"
+#include "ServiceBroker.h"
+#include "URL.h"
+#include "storage/MediaManager.h"
+
+using namespace XFILE;
+
+bool CDVDDirectory::Resolve(CFileItem& item) const
+{
+  const CURL url{item.GetDynPath()};
+  if (url.GetProtocol() != "dvd")
+  {
+    return false;
+  }
+
+  item.SetDynPath(CServiceBroker::GetMediaManager().TranslateDevicePath(""));
+  return true;
+}

--- a/xbmc/filesystem/DVDDirectory.h
+++ b/xbmc/filesystem/DVDDirectory.h
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "IFileDirectory.h"
+
+namespace XFILE
+{
+
+/*!
+ \brief Abstracts a DVD virtual directory (dvd://) which in turn points to the actual physical drive
+ */
+class CDVDDirectory : public IFileDirectory
+{
+public:
+  CDVDDirectory() = default;
+  ~CDVDDirectory() override = default;
+  bool GetDirectory(const CURL& url, CFileItemList& items) override { return false; };
+  bool ContainsFiles(const CURL& url) override { return false; }
+  bool Resolve(CFileItem& item) const override;
+};
+} // namespace XFILE

--- a/xbmc/filesystem/DirectoryFactory.cpp
+++ b/xbmc/filesystem/DirectoryFactory.cpp
@@ -74,6 +74,9 @@
 #ifdef HAVE_LIBBLURAY
 #include "BlurayDirectory.h"
 #endif
+#ifdef HAS_OPTICAL_DRIVE
+#include "DVDDirectory.h"
+#endif
 #if defined(TARGET_ANDROID)
 #include "platform/android/filesystem/AndroidAppDirectory.h"
 #endif
@@ -196,6 +199,10 @@ IDirectory* CDirectoryFactory::Create(const CURL& url)
 #endif
 #ifdef HAS_FILESYSTEM_NFS
   if (url.IsProtocol("nfs")) return new CNFSDirectory();
+#endif
+#ifdef HAS_OPTICAL_DRIVE
+  if (url.IsProtocol("dvd"))
+    return new CDVDDirectory();
 #endif
 
   if (url.IsProtocol("pvr"))

--- a/xbmc/filesystem/DirectoryFactory.cpp
+++ b/xbmc/filesystem/DirectoryFactory.cpp
@@ -87,6 +87,17 @@ using namespace ADDON;
 using namespace XFILE;
 
 /*!
+ \brief Create a IDirectory object of the share type specified in a given item path.
+ \param item Specifies the item to which the factory will create the directory instance
+ \return IDirectory object to access the directories on the share.
+ \sa IDirectory
+ */
+IDirectory* CDirectoryFactory::Create(const CFileItem& item)
+{
+  return Create(CURL{item.GetDynPath()});
+}
+
+/*!
  \brief Create a IDirectory object of the share type specified in \e strPath .
  \param strPath Specifies the share type to access, can be a share or share with path.
  \return IDirectory object to access the directories on the share.

--- a/xbmc/filesystem/DirectoryFactory.h
+++ b/xbmc/filesystem/DirectoryFactory.h
@@ -10,6 +10,8 @@
 
 #include "IDirectory.h"
 
+class CFileItem;
+
 namespace XFILE
 {
 /*!
@@ -35,5 +37,6 @@ class CDirectoryFactory
 {
 public:
   static IDirectory* Create(const CURL& url);
+  static IDirectory* Create(const CFileItem& item);
 };
 }

--- a/xbmc/filesystem/IDirectory.h
+++ b/xbmc/filesystem/IDirectory.h
@@ -15,6 +15,7 @@
 class CFileItemList;
 class CProfileManager;
 class CURL;
+class CFileItem;
 
 namespace XFILE
 {
@@ -132,6 +133,14 @@ public:
    \sa GetKeyboardInput, SetErrorDialog, RequireAuthentication
    */
   bool ProcessRequirements();
+
+  /*!
+  \brief Resolves a given item to a playable item
+  \note Some directories (e.g. dvd, bluray, plugins etc) need to be translated/resolved to the actual playback url
+  \param item The item being manipulated (which the path points to a vfs protocol implementation)
+  \return true if the item was resolved, false if it failed to resolve
+  */
+  virtual bool Resolve(CFileItem& item) const { return true; };
 
 protected:
   /*! \brief Prompt the user for some keyboard input

--- a/xbmc/filesystem/IFileDirectory.h
+++ b/xbmc/filesystem/IFileDirectory.h
@@ -15,7 +15,7 @@ namespace XFILE
 class IFileDirectory : public IDirectory
 {
 public:
-  ~IFileDirectory(void) override = default;
+  ~IFileDirectory() override = default;
   virtual bool ContainsFiles(const CURL& url)=0;
 };
 

--- a/xbmc/filesystem/ISO9660Directory.cpp
+++ b/xbmc/filesystem/ISO9660Directory.cpp
@@ -79,3 +79,19 @@ bool CISO9660Directory::Exists(const CURL& url)
   CFileItemList items;
   return GetDirectory(url, items);
 }
+
+bool CISO9660Directory::Resolve(CFileItem& item) const
+{
+  const CURL url{item.GetDynPath()};
+  if (url.GetProtocol() != "iso9660")
+  {
+    return false;
+  }
+
+  // translate a generic iso9660:// url to the actual disc drive for playback
+  if (!url.GetHostName().empty() && url.GetFileName() == "VIDEO_TS/video_ts.ifo")
+  {
+    item.SetDynPath(url.GetHostName());
+  }
+  return true;
+}

--- a/xbmc/filesystem/ISO9660Directory.h
+++ b/xbmc/filesystem/ISO9660Directory.h
@@ -21,5 +21,6 @@ public:
   bool GetDirectory(const CURL& url, CFileItemList& items) override;
   bool Exists(const CURL& url) override;
   bool ContainsFiles(const CURL& url) override { return true; }
+  bool Resolve(CFileItem& item) const override;
 };
 }


### PR DESCRIPTION
## Description
This is an ~alternative~ (follow up) to https://github.com/xbmc/xbmc/pull/23488 and attempts to fix optical DVD playback on Linux where mounting is not supported (e.g. udisks2 not installed). It brings several other improvements that hopefully makes Kodi a bit more future proof instead of just hacking stuff around:

- Introduces a `Resolve` method on `IDirectory` implementations which vfs implementations are free to use to resolve urls before playback (this will allow us to extend PluginDirectory and UPNPDirectory in the future instead of having VP to resolve the paths)
- Moves directory resolution to application player (resolving directories should not be dependent on player implementations, Kodi should provide the entries already resolved to the players/inputstreams)
- Implements DVDDirectory to abstract raw `dvd://` paths. For instance, it did not work if set from strm files (or playlists).
- Doesn't bind the `iso9660://` vfs paths to a specific drive. Kodi only supports one at the moment but we should be able to support more than one drive in the future. The implementation accounts for this and exploits the hostname of the vfs entry to propagate the actual drive directory (thanks @rmrector).

Closes https://github.com/xbmc/xbmc/issues/20048

## Motivation and context
Restore Leia behaviour concerning DVDs while improving the architecture

## How has this been tested?
- Tested on arch linux by removing udisks2 package
- Tested on windows to make sure no regressions are introduced
- Tested `dvd://` from strm files

## What is the effect on users?
Kodi on linux should now be able to play optical dvds without requiring the discs to be mounted.
Code is also a bit more clean since directory resolution for playback is centralised and implementation dependent.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
