### PR TITLE
[webOS] AESinkStarfish: Passthrough sink improvements

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkStarfish.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkStarfish.cpp
@@ -171,7 +171,7 @@ double CAESinkStarfish::GetCacheTotal()
   {
     auto frameTimeSeconds = std::chrono::duration_cast<std::chrono::duration<double>>(
         std::chrono::duration<double, std::milli>(m_format.m_streamInfo.GetDuration()));
-    return STARFISH_AUDIO_BUFFERS * frameTimeSeconds.count() * 2;
+    return STARFISH_AUDIO_BUFFERS * frameTimeSeconds.count() * 4;
   }
   else
     return 0.0;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkStarfish.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkStarfish.cpp
@@ -132,7 +132,7 @@ bool CAESinkStarfish::Initialize(AEAudioFormat& format, std::string& device)
 
   payload["option"]["externalStreamingInfo"]["bufferingCtrInfo"]["preBufferByte"] = 0;
   payload["option"]["externalStreamingInfo"]["bufferingCtrInfo"]["bufferMinLevel"] = 0;
-  payload["option"]["externalStreamingInfo"]["bufferingCtrInfo"]["bufferMaxLevel"] = 0;
+  payload["option"]["externalStreamingInfo"]["bufferingCtrInfo"]["bufferMaxLevel"] = 100;
   // This is the size after which the sink starts blocking
   payload["option"]["externalStreamingInfo"]["bufferingCtrInfo"]["qBufferLevelAudio"] =
       m_bufferSize;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkStarfish.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkStarfish.cpp
@@ -54,6 +54,7 @@ void CAESinkStarfish::EnumerateDevicesEx(AEDeviceInfoList& list, bool force)
   info.m_displayName = "Starfish (Passthrough only)";
   info.m_channels = AE_CH_LAYOUT_2_0;
   info.m_wantsIECPassthrough = false;
+  info.m_onlyPassthrough = true;
 
   // PCM disabled for now as the latency is just too high, needs more research
   // Thankfully, ALSA or PulseAudio do work as an alternative for PCM content

--- a/xbmc/cores/AudioEngine/Sinks/AESinkStarfish.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkStarfish.cpp
@@ -236,7 +236,7 @@ void CAESinkStarfish::GetDelay(AEDelayStatus& status)
 
 void CAESinkStarfish::Drain()
 {
-  m_starfishMediaAPI->flush();
+  m_starfishMediaAPI->pushEOS();
 }
 
 void CAESinkStarfish::PlayerCallback(const int32_t type,

--- a/xbmc/cores/AudioEngine/Sinks/AESinkStarfish.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkStarfish.cpp
@@ -52,7 +52,7 @@ void CAESinkStarfish::EnumerateDevicesEx(AEDeviceInfoList& list, bool force)
   CAEDeviceInfo info;
   info.m_deviceName = "Starfish";
   info.m_displayName = "Starfish (Passthrough only)";
-  info.m_channels = AE_CH_LAYOUT_5_1;
+  info.m_channels = AE_CH_LAYOUT_2_0;
   info.m_wantsIECPassthrough = false;
 
   // PCM disabled for now as the latency is just too high, needs more research

--- a/xbmc/cores/AudioEngine/Sinks/AESinkStarfish.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkStarfish.h
@@ -48,6 +48,5 @@ private:
   AEAudioFormat m_format;
   std::chrono::nanoseconds m_pts{0};
   int64_t m_bufferSize{0};
-  std::chrono::nanoseconds m_delay{0};
   bool m_firstFeed{true};
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Fixes some issues present in the current implementation of the webOS passthrough sink.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Audio was getting out of sync and stuttered at the beginning of playback. After analyzing the audio pipeline using gstreamer directly, it became clear that the cache duration is actually twice the size as configured. The delay calculation is now calculated using the query position API and is calculated more frequently (before it was only calculated when the playtime changed). This was an issue when starting playback because the playtime updates were not issued frequently enough when data was pushed into the pipeline so the delay would not have increased when new packets were added.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
OLED77C28LB (webOS 7/22)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Less A/V sync issues and no more stuttering when playback starts

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
