### PR TITLE
[InputStream] Fix extradata size casts

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Inputstream.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Inputstream.h
@@ -649,7 +649,7 @@ public:
   {
     m_extraData = extraData;
     m_cStructure->m_ExtraData = m_extraData.data();
-    m_cStructure->m_ExtraSize = m_extraData.size();
+    m_cStructure->m_ExtraSize = static_cast<unsigned int>(m_extraData.size());
   }
 
   /// @brief Additional data where can needed on streams.
@@ -666,7 +666,7 @@ public:
     }
 
     m_cStructure->m_ExtraData = m_extraData.data();
-    m_cStructure->m_ExtraSize = m_extraData.size();
+    m_cStructure->m_ExtraSize = static_cast<unsigned int>(m_extraData.size());
   }
 
   /// @brief To get with @ref SetExtraData changed values.
@@ -697,7 +697,7 @@ public:
   {
     m_extraData.clear();
     m_cStructure->m_ExtraData = m_extraData.data();
-    m_cStructure->m_ExtraSize = m_extraData.size();
+    m_cStructure->m_ExtraSize = static_cast<unsigned int>(m_extraData.size());
   }
 
   /// @brief RFC 5646 language code (empty string if undefined).


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Fix extradata size casts
## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Every time i compile InputStreamAdaptive the compiler prints many times complaining as follow:
```
3>D:\GIT\inputstream.adaptive\build\build\depends\include\kodi/addon-instance/Inputstream.h(652,1): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data
3>D:\GIT\inputstream.adaptive\build\build\depends\include\kodi/addon-instance/Inputstream.h(669,1): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data
3>D:\GIT\inputstream.adaptive\build\build\depends\include\kodi/addon-instance/Inputstream.h(700,1): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data
```


## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
