### PR TITLE
[dxva] Fix flash/wrong picture when skipping

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.h
@@ -16,6 +16,7 @@
 #include <mutex>
 #include <vector>
 
+#include <d3d11_4.h>
 #include <wrl/client.h>
 extern "C"
 {
@@ -62,13 +63,28 @@ class CVideoBufferShared : public CVideoBuffer
 public:
   HRESULT GetResource(ID3D11Resource** ppResource) override;
   void Initialize(CDecoder* decoder) override;
+  virtual ~CVideoBufferShared();
 
 protected:
   explicit CVideoBufferShared(int id)
       : CVideoBuffer(id) {}
+  void InitializeFence(CDecoder* decoder);
+  void SetFence();
 
   HANDLE handle = INVALID_HANDLE_VALUE;
   Microsoft::WRL::ComPtr<ID3D11Resource> m_sharedRes;
+
+  /*! \brief decoder-side fence object */
+  Microsoft::WRL::ComPtr<ID3D11Fence> m_fence;
+  /*! \brief decoder-side context */
+  Microsoft::WRL::ComPtr<ID3D11DeviceContext4> m_deviceContext4;
+  /*! \brief fence shared handle that allows opening the fence on a different device */
+  HANDLE m_handleFence{INVALID_HANDLE_VALUE};
+  UINT64 m_fenceValue{0};
+  /*! \brief app-side fence object */
+  Microsoft::WRL::ComPtr<ID3D11Fence> m_appFence;
+  /*! \brief app-side context */
+  Microsoft::WRL::ComPtr<ID3D11DeviceContext4> m_appContext4;
 };
 
 class CVideoBufferCopy : public CVideoBufferShared

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -1163,6 +1163,14 @@ void DX::DeviceResources::CheckDXVA2SharedDecoderSurfaces()
   CLog::LogF(LOGINFO, "DXVA2 shared decoder surfaces is{}supported",
              m_DXVA2SharedDecoderSurfaces ? " " : " NOT ");
 
+  m_DXVA2UseFence = m_DXVA2SharedDecoderSurfaces &&
+                    (ad.VendorId == PCIV_NVIDIA || ad.VendorId == PCIV_AMD) &&
+                    CSysInfo::IsWindowsVersionAtLeast(CSysInfo::WindowsVersionWin10_1703);
+
+  if (m_DXVA2SharedDecoderSurfaces)
+    CLog::LogF(LOGINFO, "DXVA2 shared decoder surfaces {} fence synchronization.",
+               m_DXVA2UseFence ? "WITH" : "WITHOUT");
+
   m_DXVASuperResolutionSupport =
       m_d3dFeatureLevel >= D3D_FEATURE_LEVEL_12_1 &&
       ((ad.VendorId == PCIV_Intel && driver.valid && driver.majorVersion >= 31) ||

--- a/xbmc/rendering/dx/DeviceResources.h
+++ b/xbmc/rendering/dx/DeviceResources.h
@@ -115,6 +115,7 @@ namespace DX
     bool IsNV12SharedTexturesSupported() const { return m_NV12SharedTexturesSupport; }
     bool IsDXVA2SharedDecoderSurfaces() const { return m_DXVA2SharedDecoderSurfaces; }
     bool IsSuperResolutionSupported() const { return m_DXVASuperResolutionSupport; }
+    bool UseFence() const { return m_DXVA2UseFence; }
 
     // Gets debug info from swapchain
     DEBUG_INFO_RENDER GetDebugInfo() const;
@@ -188,5 +189,6 @@ namespace DX
     bool m_DXVA2SharedDecoderSurfaces{false};
     bool m_DXVASuperResolutionSupport{false};
     bool m_usedSwapChain{false};
+    bool m_DXVA2UseFence{false};
   };
 }

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -875,6 +875,8 @@ CSysInfo::WindowsVersion CSysInfo::GetWindowsVersion()
         m_WinVer = WindowsVersionWin10;
       else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber == 14393)
         m_WinVer = WindowsVersionWin10_1607;
+      else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber == 15063)
+        m_WinVer = WindowsVersionWin10_1703;
       else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber == 16299)
         m_WinVer = WindowsVersionWin10_1709;
       else if (osvi.dwMajorVersion == 10 && osvi.dwMinorVersion == 0 && osvi.dwBuildNumber == 17134)

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -76,7 +76,8 @@ public:
     WindowsVersionWin8_1,       // Windows 8.1, Windows Server 2012 R2
     WindowsVersionWin10,        // Windows 10
     WindowsVersionWin10_1607,   // Windows 10 1607
-    WindowsVersionWin10_1709,   // Windows 10 1709 (FCU)
+    WindowsVersionWin10_1703,   // Windows 10 1703 - Creators Update
+    WindowsVersionWin10_1709,   // Windows 10 1709 - Fall Creators Update
     WindowsVersionWin10_1803,   // Windows 10 1803
     WindowsVersionWin10_1809,   // Windows 10 1809
     WindowsVersionWin10_1903,   // Windows 10 1903


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

When the dxva decoder is on a separate d3d device (gpu of the last 5 years, maybe more), the GPU doesn't always wait for the decoded images to be ready before they're rendered. The same thing happens with both shared and copy buffers.

There is no issue during normal playback but when skipping, wrong pictures or white pictures are briefly displayed, probably because resuming playback from a new position requires more work than the time available during a frame. Maybe it wasn't a problem for 1080p and became visible with 4k increased resource use. Problem only noticed by me on AMD with 4k hevc at this time.
edit: confirmed on nVidia RTX 4070 with software renderer as well

D3D11 provides two synchronization methods: ID3D11Query (any D3D11 system) and ID3D11Fence (Windows 10 Creators Update and above). Only D3D11Fence worked for AMD (unknown for nVidia) and no problem was reported in Windows 8, so there was no reason to implement both.

The concept is the same for query and fence:
- when a picture is decoded (buffer Initialize() function), mark the point in time in the GPU command queue (new function SetFence())
- when the rendering code retrieves the picture (buffer GetResource() function), wait until the point in time marked above is reached by the GPU, to be sure that the picture data is valid before using it any further.
- in addition, during the first use of a buffer (Initialize()), perform various initializations (new function InitializeFence()).
If for any reason the one-time initialization is unsuccessful, the code will revert to pre-PR behavior.
- added destructor to release system handles

Two variations were possible (make the CPU wait, or make the GPU wait without CPU interruption). GPU wait is better in theory, in practice no difference observed (visual or in Task Manager, Visual Studio Performance Profile), maybe due to cpu and gpu idle most of the time. CPU wait degraded things a little bit on Intel 13th gen (which doesn't need the wait at all...) with a tiny freeze after a seek. It seemed best to keep only the GPU wait implementation.

After testing, this code doesn't allow hardware that needed the buffer copy to work without (ie nVidia drivers < 465, AMD prior to GCN 5) so activation conditions of shared surfaces were not modified.

New fence code activated only for AMD and nVidia which benefit from it, and for Window 10 Creators Update and above only.

Notes:
* possibility of UINT64 fenceValue wrapping after reaching UINT64_MAX: tested and the fence doesn't react well, but it won't happen for hundreds of years of continuous playback when the fence starts at value 0. In other words, it's not a problem :-)
* there is no need for fences in other parts of the code so I didn't separate the fence code into its own class, but it wouldn't be much effort.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Self-reported issue #23518, most UHD BD titles have flashes / wrong picture displayed when skipping. Seems limited to AMD and 4k (heavier load on the decoder probably)

Then a comment mentioned that this may fix the shared buffer path for GPUs that need the copy path in master. GPU and memory usage would be reduced for those, but testing is required.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 10, AMD 5600G, Intel 8th and 13th gen
* Skip problem
Played the titles that had issues before (including the sample) => problem removed
Tested other files that didn't have problems => still don't
Tried samples of various accelerated codecs (wmv, mpeg2, avc, hevc). I don't have av1.

Compared cpu/gpu/memory utilization before and after: no clear difference found.

I used to see half-complete frames from time to time during normal playback on AMD and it's not happening anymore.

Testing requested in forum and team slack for previous gen GPU.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Artifact-free skipping for UHD BD on AMD using default options, and nVidia in more limited situations (software renderer)
Maybe it also helps from time to time during normal playback when the system is loaded.

## Screenshots (if appropriate):
Glitch:
https://github.com/xbmc/xbmc/assets/489377/7bc82a0f-a8c5-48f9-921f-17ecbad3adec

no glitch with PR:

https://github.com/xbmc/xbmc/assets/489377/a17b51cd-86e0-487e-aec3-27f339c4d84a


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
