### PR TITLE
[Windows] DXVA: minor code improvements

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.cpp
@@ -571,14 +571,13 @@ ProcessorConversions CEnumeratorHD::QueryHDRConversions(const bool isSourceFullR
   // ffmpeg flags of the source can be missing of bad anyway
   DXGI_COLOR_SPACE_TYPE inputCS = DXGI_COLOR_SPACE_YCBCR_STUDIO_G2084_TOPLEFT_P2020;
 
-  const DXGI_COLOR_SPACE_TYPE destColor = DX::Windowing()->UseLimitedColor()
-                                              ? DXGI_COLOR_SPACE_RGB_STUDIO_G2084_NONE_P2020
-                                              : DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020;
-  const DXGI_COLOR_SPACE_TYPE outputCS = destColor;
+  const DXGI_COLOR_SPACE_TYPE destCS = DX::Windowing()->UseLimitedColor()
+                                           ? DXGI_COLOR_SPACE_RGB_STUDIO_G2084_NONE_P2020
+                                           : DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020;
 
   const ProcessorConversions convTopLeft =
       ListConversions(m_input_dxgi_format, std::vector<DXGI_COLOR_SPACE_TYPE>{inputCS},
-                      RenderingOutputFormats, std::vector<DXGI_COLOR_SPACE_TYPE>{outputCS});
+                      RenderingOutputFormats, std::vector<DXGI_COLOR_SPACE_TYPE>{destCS});
 
   CLog::LogF(LOGDEBUG, "HDR input color spaces support with HDR {} range output: {}: {}",
              DX::Windowing()->UseLimitedColor() ? "limited" : "full",
@@ -601,7 +600,7 @@ ProcessorConversions CEnumeratorHD::QueryHDRConversions(const bool isSourceFullR
   inputCS = DXGI_COLOR_SPACE_YCBCR_STUDIO_G2084_LEFT_P2020;
   const ProcessorConversions convLeft =
       ListConversions(m_input_dxgi_format, std::vector<DXGI_COLOR_SPACE_TYPE>{inputCS},
-                      RenderingOutputFormats, std::vector<DXGI_COLOR_SPACE_TYPE>{outputCS});
+                      RenderingOutputFormats, std::vector<DXGI_COLOR_SPACE_TYPE>{destCS});
 
   CLog::LogF(LOGDEBUG, "HDR input color spaces support with HDR {} range output: {}: {}",
              DX::Windowing()->UseLimitedColor() ? "limited" : "full",
@@ -648,14 +647,13 @@ ProcessorConversions CEnumeratorHD::QueryHDRtoSDRConversions(const bool isSource
   // ffmpeg flags of the source can be missing of bad anyway
   DXGI_COLOR_SPACE_TYPE inputCS = DXGI_COLOR_SPACE_YCBCR_STUDIO_G22_TOPLEFT_P2020;
 
-  const DXGI_COLOR_SPACE_TYPE destColor = DX::Windowing()->UseLimitedColor()
-                                              ? DXGI_COLOR_SPACE_RGB_STUDIO_G22_NONE_P709
-                                              : DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
-  const DXGI_COLOR_SPACE_TYPE outputCS = destColor;
+  const DXGI_COLOR_SPACE_TYPE destCS = DX::Windowing()->UseLimitedColor()
+                                           ? DXGI_COLOR_SPACE_RGB_STUDIO_G22_NONE_P709
+                                           : DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
 
   const ProcessorConversions convTopLeft =
       ListConversions(m_input_dxgi_format, std::vector<DXGI_COLOR_SPACE_TYPE>{inputCS},
-                      RenderingOutputFormats, std::vector<DXGI_COLOR_SPACE_TYPE>{outputCS});
+                      RenderingOutputFormats, std::vector<DXGI_COLOR_SPACE_TYPE>{destCS});
 
   CLog::LogF(LOGDEBUG, "BT.2020 input color spaces supported with SDR {} range output: {}: {}",
              DX::Windowing()->UseLimitedColor() ? "limited" : "full",
@@ -678,7 +676,7 @@ ProcessorConversions CEnumeratorHD::QueryHDRtoSDRConversions(const bool isSource
   inputCS = DXGI_COLOR_SPACE_YCBCR_STUDIO_G22_LEFT_P2020;
   const ProcessorConversions convLeft =
       ListConversions(m_input_dxgi_format, std::vector<DXGI_COLOR_SPACE_TYPE>{inputCS},
-                      RenderingOutputFormats, std::vector<DXGI_COLOR_SPACE_TYPE>{outputCS});
+                      RenderingOutputFormats, std::vector<DXGI_COLOR_SPACE_TYPE>{destCS});
 
   CLog::LogF(LOGDEBUG, "BT.2020 input color spaces supported with SDR {} range output: {}: {}",
              DX::Windowing()->UseLimitedColor() ? "limited" : "full",

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
@@ -498,13 +498,9 @@ ProcessorConversion CRendererDXVA::ChooseConversion(
   if (!m_tryVSR)
   {
     // Try high quality when: backbuffer is 10 bits or High precision processing is on and the source is HDR
-    tryHQ = (DX::Windowing()->GetBackBuffer().GetFormat() == DXGI_FORMAT_R10G10B10A2_UNORM);
-
-    if (DX::Windowing()->IsHighPrecisionProcessingSettingEnabled() && sourceBits > 8 &&
-        (colorTransfer == AVCOL_TRC_SMPTE2084 || colorTransfer == AVCOL_TRC_ARIB_STD_B67))
-    {
-      tryHQ = true;
-    }
+    tryHQ = (DX::Windowing()->GetBackBuffer().GetFormat() == DXGI_FORMAT_R10G10B10A2_UNORM) ||
+            (DX::Windowing()->IsHighPrecisionProcessingSettingEnabled() && sourceBits > 8 &&
+             (colorTransfer == AVCOL_TRC_SMPTE2084 || colorTransfer == AVCOL_TRC_ARIB_STD_B67));
   }
 
   // RGB8 processor output format is required for VSR

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
@@ -144,9 +144,9 @@ bool CRendererDXVA::Configure(const VideoPicture& picture, float fps, unsigned o
           m_enumerator->SupportedConversions(m_conversionsArgs);
       if (!conversions.empty())
       {
-        const ProcessorConversion chosenConversion = ChooseConversion(
-            conversions, picture.colorBits,
-            static_cast<AVColorTransferCharacteristic>(picture.color_transfer), m_tryVSR);
+        const ProcessorConversion chosenConversion =
+            ChooseConversion(conversions, picture.colorBits,
+                             static_cast<AVColorTransferCharacteristic>(picture.color_transfer));
         m_intermediateTargetFormat = chosenConversion.m_outputFormat;
         m_conversion = chosenConversion;
 
@@ -200,9 +200,8 @@ void CRendererDXVA::CheckVideoParameters()
       // TODO case no supported conversion: add support in WinRenderer to fallback to a render method with support
       // For now, keep using the current conversion. Results won't be ideal but a black screen is avoided
       const ProcessorConversion conversion =
-          conversions.empty()
-              ? m_conversion
-              : ChooseConversion(conversions, buf->bits, buf->color_transfer, m_tryVSR);
+          conversions.empty() ? m_conversion
+                              : ChooseConversion(conversions, buf->bits, buf->color_transfer);
 
       if (m_conversion != conversion)
       {
@@ -488,15 +487,15 @@ bool CRendererDXVA::CRenderBufferImpl::UploadToTexture()
   return m_bLoaded;
 }
 
-ProcessorConversion CRendererDXVA::ChooseConversion(const ProcessorConversions& conversions,
-                                                    unsigned int sourceBits,
-                                                    AVColorTransferCharacteristic colorTransfer,
-                                                    bool tryVSR) const
+ProcessorConversion CRendererDXVA::ChooseConversion(
+    const ProcessorConversions& conversions,
+    unsigned int sourceBits,
+    AVColorTransferCharacteristic colorTransfer) const
 {
   assert(conversions.size() > 0);
 
   bool tryHQ{false};
-  if (!tryVSR)
+  if (!m_tryVSR)
   {
     // Try high quality when: backbuffer is 10 bits or High precision processing is on and the source is HDR
     tryHQ = (DX::Windowing()->GetBackBuffer().GetFormat() == DXGI_FORMAT_R10G10B10A2_UNORM);
@@ -509,7 +508,7 @@ ProcessorConversion CRendererDXVA::ChooseConversion(const ProcessorConversions& 
   }
 
   // RGB8 processor output format is required for VSR
-  if (!tryVSR && tryHQ)
+  if (!m_tryVSR && tryHQ)
   {
     const auto it =
         std::find_if(conversions.cbegin(), conversions.cend(), [](const ProcessorConversion& c) {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
@@ -57,8 +57,7 @@ private:
    */
   DXVA::ProcessorConversion ChooseConversion(const DXVA::ProcessorConversions& conversions,
                                              unsigned int sourceBits,
-                                             AVColorTransferCharacteristic colorTransfer,
-                                             bool tryVSR) const;
+                                             AVColorTransferCharacteristic colorTransfer) const;
 
   std::unique_ptr<DXVA::CProcessorHD> m_processor;
   std::shared_ptr<DXVA::CEnumeratorHD> m_enumerator;


### PR DESCRIPTION
## Description
DXVA: minor improvements

## Motivation and context
All are very simple changes in separated commits. 

~The fist two~ not changes the functionality, only removes redundant variables/parameters.

~The third has a minimal functional change enabling 10 bit intermediate target also when "High precision processing" setting is enabled and  source is 10 bit SDR.~

~It's not used much today, but 10-bit x264 encodings still exist.~


## How has this been tested?
Windows x64


## What is the effect on users?
~May improve video quality when source is 10 bit SDR and "High precision processing" is enabled (default) and "Use 10 bit for SDR" is disabled (default when is an SDR display).~

none


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
