### PR TITLE
[plugins] Move plugin resolve to IDirectory implementation

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -2380,11 +2380,6 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
     return false;
   }
 
-  //! TODO: Move this to plugin vfs dir resolve(item)
-  // if the item is a plugin we need to resolve the plugin paths
-  if (URIUtils::HasPluginPath(item) && !XFILE::CPluginDirectory::GetResolvedPluginResult(item))
-    return false;
-
   // if we have a stacked set of files, we need to setup our stack routines for
   // "seamless" seeking and total time of the movie etc.
   // will recall with restart set to true

--- a/xbmc/filesystem/PluginDirectory.cpp
+++ b/xbmc/filesystem/PluginDirectory.cpp
@@ -546,3 +546,8 @@ bool CPluginDirectory::CheckExists(const std::string& content, const std::string
   CFileItem item;
   return CPluginDirectory::GetPluginResult(url.Get(), item, false);
 }
+
+bool CPluginDirectory::Resolve(CFileItem& item) const
+{
+  return GetResolvedPluginResult(item);
+}

--- a/xbmc/filesystem/PluginDirectory.h
+++ b/xbmc/filesystem/PluginDirectory.h
@@ -30,6 +30,7 @@ public:
   CPluginDirectory();
   ~CPluginDirectory(void) override;
   bool GetDirectory(const CURL& url, CFileItemList& items) override;
+  bool Resolve(CFileItem& item) const override;
   bool AllowAll() const override { return true; }
   bool Exists(const CURL& url) override { return true; }
   float GetProgress() const override;


### PR DESCRIPTION
## Description
This moves the plugin resolution to the `IDirectory` implementation (`CPluginDirectory`) as provided by https://github.com/xbmc/xbmc/pull/23531. This allow us to keep a common implementation for any vfs protocol that needs resolving before playback - simplifying and centralising the code. The resolution of the URL takes place above the removed code section.

## Motivation and context
Cleanup. I think it can even be considered a fix since the header include is guarded by the `HAS_PYTHON` define but application player calls it anyway even if not defined.

## How has this been tested?
Used a couple of plugins, breakpoint on the resolve implementation

## What is the effect on users?
None, internal cleanup

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
