### PR TITLE
[upnp] Move upnp item resolve to IDirectory implementation

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -2385,15 +2385,6 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
   if (URIUtils::HasPluginPath(item) && !XFILE::CPluginDirectory::GetResolvedPluginResult(item))
     return false;
 
-#ifdef HAS_UPNP
-  //! TODO: Move this to upnp vfs dir resolve(item)
-  if (URIUtils::IsUPnP(item.GetPath()))
-  {
-    if (!XFILE::CUPnPDirectory::GetResource(item.GetURL(), item))
-      return false;
-  }
-#endif
-
   // if we have a stacked set of files, we need to setup our stack routines for
   // "seamless" seeking and total time of the movie etc.
   // will recall with restart set to true

--- a/xbmc/filesystem/UPnPDirectory.cpp
+++ b/xbmc/filesystem/UPnPDirectory.cpp
@@ -357,3 +357,8 @@ failure:
     return false;
 }
 }
+
+bool CUPnPDirectory::Resolve(CFileItem& item) const
+{
+  return GetResource(item.GetURL(), item);
+}

--- a/xbmc/filesystem/UPnPDirectory.h
+++ b/xbmc/filesystem/UPnPDirectory.h
@@ -29,6 +29,7 @@ public:
     // IDirectory methods
     bool GetDirectory(const CURL& url, CFileItemList &items) override;
     bool AllowAll() const override { return true; }
+    bool Resolve(CFileItem& item) const override;
 
     // class methods
     static const char* GetFriendlyName(const CURL& url);


### PR DESCRIPTION
## Description
Similar to https://github.com/xbmc/xbmc/pull/23554 the PR moves the `upnp://` item resolution to the `IDirectory` implementation (`CUPnPDirectory`) as enabled by https://github.com/xbmc/xbmc/pull/23531. Resolution occurs in appPlayer, a few lines above the removed code block.

## Motivation and context
Cleanup and improve the codebase, internal refactor.

## How has this been tested?
Playing upnp files (hdhomerun)

## What is the effect on users?
None, internal cleanup

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
