### PR TITLE
[estuary] cinemavision => preshowexperience

### DIFF
--- a/addons/skin.estuary/xml/DialogBusy.xml
+++ b/addons/skin.estuary/xml/DialogBusy.xml
@@ -4,7 +4,7 @@
 	<animation effect="fade" start="100" end="0" time="240">WindowClose</animation>
 	<controls>
 		<control type="group">
-			<visible>String.IsEmpty(Window(Home).Property(script.cinemavision.running))</visible>
+			<visible>String.IsEmpty(Window(Home).Property(script.preshowexperience.running))</visible>
 			<animation effect="fade" time="400">VisibleChange</animation>
 			<visible>!Window.IsActive(startup) + !Player.Caching</visible>
 			<control type="image">

--- a/addons/skin.estuary/xml/DialogNotification.xml
+++ b/addons/skin.estuary/xml/DialogNotification.xml
@@ -8,7 +8,7 @@
 			<right>0</right>
 			<width>640</width>
 			<include>OpenClose_Right</include>
-			<visible>String.IsEmpty(Window(Home).Property(script.cinemavision.running))</visible>
+			<visible>String.IsEmpty(Window(Home).Property(script.preshowexperience.running))</visible>
 			<control type="image">
 				<left>0</left>
 				<top>0</top>

--- a/addons/skin.estuary/xml/DialogVideoInfo.xml
+++ b/addons/skin.estuary/xml/DialogVideoInfo.xml
@@ -535,9 +535,9 @@
 						<param name="id" value="441" />
 						<param name="icon" value="icons/infodialogs/cinema.png" />
 						<param name="onclick_1" value="Dialog.Close(MovieInformation)" />
-						<param name="onclick_2" value="RunScript(script.cinemavision,experience)" />
+						<param name="onclick_2" value="RunScript(script.preshowexperience,experience)" />
 						<param name="label" value="$LOCALIZE[31003]" />
-						<param name="visible" value="System.AddonIsEnabled(script.cinemavision) + [String.IsEqual(ListItem.DBType,movie) | String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,season) | String.IsEqual(ListItem.DBType,episode)]" />
+						<param name="visible" value="System.AddonIsEnabled(script.preshowexperience) + [String.IsEqual(ListItem.DBType,movie) | String.IsEqual(ListItem.DBType,tvshow) | String.IsEqual(ListItem.DBType,season) | String.IsEqual(ListItem.DBType,episode)]" />
 					</include>
 					<control type="group" id="400">
 						<width>264</width>


### PR DESCRIPTION
## Description
noticed that skin estuary has some basic support for `script.cinemavision`.  though its possible successor `script.preshowexperience` is not in the official repository (yet), i think it is safe to do this change so it won't get lost.

looks like @gade01 has already done this in `skin.rapier` https://github.com/gade01/Rapier/commit/9a0c4efec946f47942b1e7a19d6bb959a1ac1e61

## Motivation and context
had some play with `script.preshowexperience`

## How has this been tested?
played cinema at home including stupid commercials (McDonalds and Langnese, a must have in german cinemas) audio- and ratingsbumpers etc.

## What is the effect on users?
brings back a little cinema add-on support for estuary

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
