### PR TITLE
DVDDemuxFFmpeg: Fix issues after st->cur_pts replacement

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -2319,10 +2319,13 @@ TRANSPORT_STREAM_STATE CDVDDemuxFFmpeg::TransportStreamAudioState()
     for (unsigned int i = 0; i < m_pFormatContext->programs[m_program]->nb_stream_indexes; i++)
     {
       int idx = m_pFormatContext->programs[m_program]->stream_index[i];
+      // if we match m_seekStream then we are ready
+      if (idx == m_seekStream)
+        return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[idx];
-      if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
+      if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO && idx == m_pkt.pkt.stream_index)
       {
-        if (st->start_time != AV_NOPTS_VALUE)
+        if (m_pkt.pkt.dts != AV_NOPTS_VALUE)
         {
           if (!m_startTime)
           {
@@ -2340,10 +2343,14 @@ TRANSPORT_STREAM_STATE CDVDDemuxFFmpeg::TransportStreamAudioState()
   {
     for (unsigned int i = 0; i < m_pFormatContext->nb_streams; i++)
     {
+      // if we match m_seekStream then we are ready
+      if (static_cast<int>(i) == m_seekStream)
+        return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[i];
-      if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
+      if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO &&
+          static_cast<int>(i) == m_pkt.pkt.stream_index)
       {
-        if (st->start_time != AV_NOPTS_VALUE)
+        if (m_pkt.pkt.dts != AV_NOPTS_VALUE)
         {
           if (!m_startTime)
           {
@@ -2374,10 +2381,13 @@ TRANSPORT_STREAM_STATE CDVDDemuxFFmpeg::TransportStreamVideoState()
     for (unsigned int i = 0; i < m_pFormatContext->programs[m_program]->nb_stream_indexes; i++)
     {
       int idx = m_pFormatContext->programs[m_program]->stream_index[i];
+      // if we match m_seekStream then we are ready
+      if (idx == m_seekStream)
+        return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[idx];
-      if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
+      if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO && idx == m_pkt.pkt.stream_index)
       {
-        if (st->codecpar->extradata)
+        if (m_pkt.pkt.dts != AV_NOPTS_VALUE && st->codecpar->extradata)
         {
           if (!m_startTime)
           {
@@ -2395,10 +2405,14 @@ TRANSPORT_STREAM_STATE CDVDDemuxFFmpeg::TransportStreamVideoState()
   {
     for (unsigned int i = 0; i < m_pFormatContext->nb_streams; i++)
     {
+      // if we match m_seekStream then we are ready
+      if (static_cast<int>(i) == m_seekStream)
+        return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[i];
-      if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
+      if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO &&
+          static_cast<int>(i) == m_pkt.pkt.stream_index)
       {
-        if (st->codecpar->extradata)
+        if (m_pkt.pkt.dts != AV_NOPTS_VALUE && st->codecpar->extradata)
         {
           if (!m_startTime)
           {

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -130,7 +130,6 @@ protected:
   void ResetVideoStreams();
   AVDictionary* GetFFMpegOptionsFromInput();
   double ConvertTimestamp(int64_t pts, int den, int num);
-  void UpdateCurrentPTS();
   bool IsProgramChange();
   unsigned int HLSSelectProgram();
 


### PR DESCRIPTION
## Description
Fix issues after st->cur_pts replacement

## Motivation and context
The move to ffmpeg5 removed st->cur_pts which kodi was using in a number of places.

The fixup replaced these uses with m_pkt.pkt.dts,
but that makes no sense in the Seek code as
m_pkt.pkt is only updated in Read function,
so we are using a stale value.

Also m_pkt.pkt.dts may be AV_NOPTS_VALUE in
TransportStreamAudioState/TransportStreamVideoState

which needs protecting against, otherwise we perform arithmetic on that and that breaks playback.

## How has this been tested?
I've been running with it for a few days, and resuming from PVR recordings and seeking is fixed.
Live TV and playback from local files seem fine.

## What is the effect on users?
Fixes broken PVR recording resume
See: https://github.com/xbmc/xbmc/issues/23199

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
