### PR TITLE
[AddonSettings] Fix setting persistency when acessing raw Settings interface

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -372,11 +372,12 @@ bool CAddon::HasSettingsToSave(AddonInstanceId id /* = ADDON_SETTINGS_ID */) con
   return SettingsLoaded(id);
 }
 
-void CAddon::SaveSettings(AddonInstanceId id /* = ADDON_SETTINGS_ID */)
+bool CAddon::SaveSettings(AddonInstanceId id /* = ADDON_SETTINGS_ID */)
 {
   if (!HasSettingsToSave(id))
-    return; // no settings to save
+    return false; // no settings to save
 
+  bool success{true};
   CSettingsData& data = m_settings[id];
 
   // break down the path into directories
@@ -385,14 +386,14 @@ void CAddon::SaveSettings(AddonInstanceId id /* = ADDON_SETTINGS_ID */)
 
   // create the individual folders
   if (!CDirectory::Exists(strRoot))
-    CDirectory::Create(strRoot);
+    success = CDirectory::Create(strRoot);
   if (!CDirectory::Exists(strAddon))
-    CDirectory::Create(strAddon);
+    success = CDirectory::Create(strAddon);
 
   // create the XML file
   CXBMCTinyXML doc;
   if (SettingsToXML(doc, id))
-    doc.SaveFile(data.m_userSettingsPath);
+    success = doc.SaveFile(data.m_userSettingsPath);
 
   data.m_hasUserSettings = true;
 
@@ -401,6 +402,7 @@ void CAddon::SaveSettings(AddonInstanceId id /* = ADDON_SETTINGS_ID */)
 #ifdef HAS_PYTHON
   CServiceBroker::GetXBPython().OnSettingsChanged(ID());
 #endif
+  return success;
 }
 
 std::string CAddon::GetSetting(const std::string& key, AddonInstanceId id)

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -203,10 +203,11 @@ public:
    *
    * \param[in] instance Instance identifier to use, use @ref ADDON_SETTINGS_ID
    *                     to denote global add-on settings from settings.xml.
+   * \return true if the operation was successful, false otherwise
    *
    * \sa LoadSettings, LoadUserSettings, HasSettings, HasUserSettings, GetSetting, UpdateSetting
    */
-  void SaveSettings(AddonInstanceId id = ADDON_SETTINGS_ID) override;
+  bool SaveSettings(AddonInstanceId id = ADDON_SETTINGS_ID) override;
 
   /*!
    * \brief Update a user-configured setting with a new value.

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -112,7 +112,7 @@ public:
   virtual bool CanHaveAddonOrInstanceSettings() = 0;
   virtual bool HasSettings(AddonInstanceId id = ADDON_SETTINGS_ID) = 0;
   virtual bool HasUserSettings(AddonInstanceId id = ADDON_SETTINGS_ID) = 0;
-  virtual void SaveSettings(AddonInstanceId id = ADDON_SETTINGS_ID) = 0;
+  virtual bool SaveSettings(AddonInstanceId id = ADDON_SETTINGS_ID) = 0;
   virtual void UpdateSetting(const std::string& key,
                              const std::string& value,
                              AddonInstanceId id = ADDON_SETTINGS_ID) = 0;

--- a/xbmc/addons/binary-addons/AddonDll.cpp
+++ b/xbmc/addons/binary-addons/AddonDll.cpp
@@ -345,12 +345,13 @@ CAddonVersion CAddonDll::GetTypeMinVersionDll(int type) const
   return CAddonVersion(m_pDll ? m_pDll->GetAddonTypeMinVersion(type) : nullptr);
 }
 
-void CAddonDll::SaveSettings(AddonInstanceId id /* = ADDON_SETTINGS_ID */)
+bool CAddonDll::SaveSettings(AddonInstanceId id /* = ADDON_SETTINGS_ID */)
 {
   // must save first, as TransferSettings() reloads saved settings!
-  CAddon::SaveSettings(id);
+  bool success = CAddon::SaveSettings(id);
   if (m_initialized)
     TransferSettings(id);
+  return success;
 }
 
 ADDON_STATUS CAddonDll::TransferSettings(AddonInstanceId instanceId)

--- a/xbmc/addons/binary-addons/AddonDll.h
+++ b/xbmc/addons/binary-addons/AddonDll.h
@@ -59,7 +59,7 @@ public:
   std::string LibPath() const override;
 
   // addon settings
-  void SaveSettings(AddonInstanceId id = ADDON_SETTINGS_ID) override;
+  bool SaveSettings(AddonInstanceId id = ADDON_SETTINGS_ID) override;
 
   bool DllLoaded(void) const;
 

--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -38,6 +38,7 @@
 #include "utils/log.h"
 
 #include <algorithm>
+#include <cassert>
 #include <mutex>
 #include <vector>
 
@@ -151,13 +152,13 @@ SettingPtr AddSettingWithoutDefinition(ADDON::CAddonSettings& settings,
 namespace ADDON
 {
 
-CAddonSettings::CAddonSettings(const std::shared_ptr<const IAddon>& addon,
-                               AddonInstanceId instanceId)
+CAddonSettings::CAddonSettings(const std::shared_ptr<IAddon>& addon, AddonInstanceId instanceId)
   : CSettingsBase(),
     m_addonId(addon->ID()),
     m_addonPath(addon->Path()),
     m_addonProfile(addon->Profile()),
     m_instanceId(instanceId),
+    m_addon{addon},
     m_unknownSettingLabelId(UnknownSettingLabelIdStart),
     m_logger(CServiceBroker::GetLogging().GetLogger(
         StringUtils::Format("CAddonSettings[{}@{}]", m_instanceId, m_addonId)))
@@ -431,6 +432,12 @@ bool CAddonSettings::Save(CXBMCTinyXML& doc) const
 bool CAddonSettings::HasSettings() const
 {
   return IsInitialized() && GetSettingsManager()->HasSettings();
+}
+
+bool CAddonSettings::Save()
+{
+  assert(m_addon);
+  return m_addon->SaveSettings();
 }
 
 std::string CAddonSettings::GetSettingLabel(int label) const

--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -154,14 +154,11 @@ namespace ADDON
 
 CAddonSettings::CAddonSettings(const std::shared_ptr<IAddon>& addon, AddonInstanceId instanceId)
   : CSettingsBase(),
-    m_addonId(addon->ID()),
-    m_addonPath(addon->Path()),
-    m_addonProfile(addon->Profile()),
     m_instanceId(instanceId),
     m_addon{addon},
     m_unknownSettingLabelId(UnknownSettingLabelIdStart),
     m_logger(CServiceBroker::GetLogging().GetLogger(
-        StringUtils::Format("CAddonSettings[{}@{}]", m_instanceId, m_addonId)))
+        StringUtils::Format("CAddonSettings[{}@{}]", m_instanceId, addon->ID())))
 {
 }
 
@@ -174,6 +171,11 @@ std::shared_ptr<CSetting> CAddonSettings::CreateSetting(
     return std::make_shared<CSettingUrlEncodedString>(settingId, settingsManager);
 
   return CSettingCreator::CreateSetting(settingType, settingId, settingsManager);
+}
+
+std::string CAddonSettings::GetAddonId() const
+{
+  return m_addon->ID();
 }
 
 void CAddonSettings::OnSettingAction(const std::shared_ptr<const CSetting>& setting)
@@ -189,9 +191,9 @@ void CAddonSettings::OnSettingAction(const std::shared_ptr<const CSetting>& sett
     {
       actionData = settingAction->GetData();
       // replace $CWD with the url of the add-on
-      StringUtils::Replace(actionData, "$CWD", m_addonPath);
+      StringUtils::Replace(actionData, "$CWD", m_addon->Path());
       // replace $ID with the id of the add-on
-      StringUtils::Replace(actionData, "$ID", m_addonId);
+      StringUtils::Replace(actionData, "$ID", m_addon->ID());
     }
   }
 
@@ -227,7 +229,7 @@ bool CAddonSettings::AddInstanceSettings()
     CLog::Log(
         LOGDEBUG,
         "CAddonSettings::{} - Add-on {} using instance setting values byself, Kodi's add ignored",
-        __func__, m_addonId);
+        __func__, m_addon->ID());
     return true;
   }
 
@@ -810,7 +812,7 @@ bool CAddonSettings::InitializeFromOldSettingDefinitions(const CXBMCTinyXML& doc
     return false;
 
   std::shared_ptr<CSettingSection> section =
-      std::make_shared<CSettingSection>(m_addonId, GetSettingsManager());
+      std::make_shared<CSettingSection>(m_addon->ID(), GetSettingsManager());
 
   std::shared_ptr<CSettingCategory> category;
   uint32_t categoryId = 0;
@@ -843,9 +845,9 @@ SettingPtr CAddonSettings::InitializeFromOldSettingAction(const std::string& set
   // parse the action attribute
   std::string action = XMLUtils::GetAttribute(settingElement, "action");
   // replace $CWD with the url of the add-on
-  StringUtils::Replace(action, "$CWD", m_addonPath);
+  StringUtils::Replace(action, "$CWD", m_addon->Path());
   // replace $ID with the id of the add-on
-  StringUtils::Replace(action, "$ID", m_addonId);
+  StringUtils::Replace(action, "$ID", m_addon->ID());
 
   // prepare the setting's control
   auto control = std::make_shared<CSettingControlButton>();
@@ -1312,7 +1314,7 @@ SettingPtr CAddonSettings::InitializeFromOldSettingEnums(
       for (uint32_t i = 0; i < values.size(); ++i)
       {
         int label = static_cast<int>(strtol(values[i].c_str(), nullptr, 0));
-        std::string value = g_localizeStrings.GetAddonString(m_addonId, label);
+        std::string value = g_localizeStrings.GetAddonString(m_addon->ID(), label);
         if (settingEntries.size() > i)
           value = settingEntries[i];
 
@@ -1462,9 +1464,9 @@ SettingPtr CAddonSettings::InitializeFromOldSettingFileWithSource(
   setting->SetDefault(defaultValue);
 
   if (source.find("$PROFILE") != std::string::npos)
-    StringUtils::Replace(source, "$PROFILE", m_addonProfile);
+    StringUtils::Replace(source, "$PROFILE", m_addon->Profile());
   else
-    source = URIUtils::AddFileToFolder(m_addonPath, source);
+    source = URIUtils::AddFileToFolder(m_addon->Path(), source);
 
   setting->SetSources({source});
 

--- a/xbmc/addons/settings/AddonSettings.h
+++ b/xbmc/addons/settings/AddonSettings.h
@@ -60,7 +60,7 @@ public:
   // implementation of ISettingCallback
   void OnSettingAction(const std::shared_ptr<const CSetting>& setting) override;
 
-  const std::string& GetAddonId() const { return m_addonId; }
+  std::string GetAddonId() const;
 
   bool Initialize(const CXBMCTinyXML& doc, bool allowEmpty = false);
   bool Load(const CXBMCTinyXML& doc);
@@ -187,10 +187,6 @@ private:
                                            std::string& current,
                                            void* data);
 
-  // store these values so that we don't always have to access the weak pointer
-  const std::string m_addonId;
-  const std::string m_addonPath;
-  const std::string m_addonProfile;
   const AddonInstanceId m_instanceId{ADDON_SETTINGS_ID};
   std::shared_ptr<IAddon> m_addon;
 

--- a/xbmc/addons/settings/AddonSettings.h
+++ b/xbmc/addons/settings/AddonSettings.h
@@ -41,7 +41,7 @@ class CAddonSettings : public CSettingsBase,
                        public ISettingCallback
 {
 public:
-  CAddonSettings(const std::shared_ptr<const IAddon>& addon, AddonInstanceId instanceId);
+  CAddonSettings(const std::shared_ptr<IAddon>& addon, AddonInstanceId instanceId);
   ~CAddonSettings() override = default;
 
   // specialization of CSettingsBase
@@ -49,7 +49,7 @@ public:
 
   // implementations of CSettingsBase
   bool Load() override { return false; }
-  bool Save() override { return false; }
+  bool Save() override;
 
   // specialization of CSettingCreator
   std::shared_ptr<CSetting> CreateSetting(
@@ -192,6 +192,7 @@ private:
   const std::string m_addonPath;
   const std::string m_addonProfile;
   const AddonInstanceId m_instanceId{ADDON_SETTINGS_ID};
+  std::shared_ptr<IAddon> m_addon;
 
   uint32_t m_unidentifiedSettingId = 0;
   int m_unknownSettingLabelId;

--- a/xbmc/interfaces/legacy/Settings.h
+++ b/xbmc/interfaces/legacy/Settings.h
@@ -270,7 +270,6 @@ public:
   ///
   /// @param id                     string - id of the setting that the module needs to access.
   /// @param value                  bool - value of the setting.
-  /// @return                       bool - True if the value of the setting was set, false otherwise
   ///
   ///
   /// @note You can use the above as keywords for arguments.
@@ -299,7 +298,6 @@ public:
   ///
   /// @param id                     string - id of the setting that the module needs to access.
   /// @param value                  integer - value of the setting.
-  /// @return                       bool - True if the value of the setting was set, false otherwise
   ///
   ///
   /// @note You can use the above as keywords for arguments.
@@ -328,7 +326,6 @@ public:
   ///
   /// @param id                     string - id of the setting that the module needs to access.
   /// @param value                  float - value of the setting.
-  /// @return                       bool - True if the value of the setting was set, false otherwise
   ///
   ///
   /// @note You can use the above as keywords for arguments.
@@ -357,7 +354,6 @@ public:
   ///
   /// @param id                     string - id of the setting that the module needs to access.
   /// @param value                  string or unicode - value of the setting.
-  /// @return                       bool - True if the value of the setting was set, false otherwise
   ///
   ///
   /// @note You can use the above as keywords for arguments.
@@ -386,7 +382,6 @@ public:
   ///
   /// @param id                     string - id of the setting that the module needs to access.
   /// @param values                 list of boolean - values of the setting.
-  /// @return                       bool - True if the values of the setting were set, false otherwise
   ///
   ///
   /// @note You can use the above as keywords for arguments.
@@ -415,7 +410,6 @@ public:
   ///
   /// @param id                     string - id of the setting that the module needs to access.
   /// @param values                 list of int - values of the setting.
-  /// @return                       bool - True if the values of the setting were set, false otherwise
   ///
   ///
   /// @note You can use the above as keywords for arguments.
@@ -444,7 +438,6 @@ public:
   ///
   /// @param id                     string - id of the setting that the module needs to access.
   /// @param values                 list of float - values of the setting.
-  /// @return                       bool - True if the values of the setting were set, false otherwise
   ///
   ///
   /// @note You can use the above as keywords for arguments.
@@ -473,7 +466,6 @@ public:
   ///
   /// @param id                     string - id of the setting that the module needs to access.
   /// @param values                 list of string or unicode - values of the setting.
-  /// @return                       bool - True if the values of the setting were set, false otherwise
   ///
   ///
   /// @note You can use the above as keywords for arguments.

--- a/xbmc/interfaces/legacy/Settings.h
+++ b/xbmc/interfaces/legacy/Settings.h
@@ -52,15 +52,13 @@ XBMCCOMMONS_STANDARD_EXCEPTION(SettingCallbacksNotSupportedException);
 class Settings : public AddonClass
 {
 public:
-#if !defined SWIG && !defined DOXYGEN_SHOULD_SKIP_THIS
-  std::shared_ptr<CSettingsBase> settings;
-#endif
-
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 #ifndef SWIG
+  std::shared_ptr<CSettingsBase> settings;
   Settings(std::shared_ptr<CSettingsBase> settings);
 #endif
-
   virtual ~Settings() = default;
+#endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
   ///


### PR DESCRIPTION
## Description

As reported by https://github.com/xbmc/xbmc/issues/23551 currently when settings are acessed via the new Nexus `Settings` interface, persistency does not occur:

```
import xbmc
import xbmcaddon

addon = xbmcaddon.Addon()
settings = addon.getSettings()
key = 'firstRun'
first_run = settings.getBool(key)
xbmc.log(f'[Test settings] first run: {first_run}')
settings.setBool(key, False)
outcome = "success" if  not settings.getBool(key) else "failure"
xbmc.log(f'[Test settings] {outcome}')
```

Root cause is the fact the `Save()` override pretty much doing nothing :)
The implementation stores the addon pointer (can no longer be const) and saves the settings.

I am a bit unsure if we should just nuke:
```
m_addonId(addon->ID()),
m_addonPath(addon->Path()),
m_addonProfile(addon->Profile()),
```
In the code there's the comment ` // store these values so that we don't always have to access the weak pointer` but as far as I can see we don't access it often (only for a few log lines) and the performance gain should be pretty much negligible. Remove commit: https://github.com/xbmc/xbmc/pull/23558/commits/e02c6f09b904d90749b3a7bf7453b5d456f99616

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/23551 

## How has this been tested?
As described in the bug report

## What is the effect on users?
Should fix settings not being persisted for addons if acessed via the raw `Settings` class

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
