### PR TITLE
[bp][discs] Fix playback of optical dvds without mount support

### DIFF
--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -148,7 +148,16 @@ bool CAutorun::RunDisc(IDirectory* pDir, const std::string& strDrive, int& nAdde
   bool bPlaying(false);
   CFileItemList vecItems;
 
-  const CURL pathToUrl(strDrive);
+  CURL pathToUrl{strDrive};
+  // if the url being requested is a generic "iso9660://" we need to expand it with the current drive device.
+  // use the hostname section to prepend the drive path
+  if (pathToUrl.GetRedacted() == "iso9660://")
+  {
+    pathToUrl.Reset();
+    pathToUrl.SetProtocol("iso9660");
+    pathToUrl.SetHostName(CServiceBroker::GetMediaManager().TranslateDevicePath(""));
+  }
+
   if ( !pDir->GetDirectory( pathToUrl, vecItems ) )
   {
     return false;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -767,11 +767,16 @@ bool CVideoPlayer::OpenInputStream()
   CLog::Log(LOGINFO, "Creating InputStream");
 
   // correct the filename if needed
-  std::string filename(m_item.GetPath());
-  if (URIUtils::IsProtocol(filename, "dvd") ||
-      StringUtils::EqualsNoCase(filename, "iso9660://video_ts/video_ts.ifo"))
+  const CURL url{m_item.GetPath()};
+  if (url.GetProtocol() == "dvd")
   {
+    // FIXME: we should deprecate this when more than one device drive is supported
     m_item.SetPath(CServiceBroker::GetMediaManager().TranslateDevicePath(""));
+  }
+  else if (url.GetProtocol() == "iso9660" && !url.GetHostName().empty() &&
+           url.GetFileName() == "VIDEO_TS/video_ts.ifo")
+  {
+    m_item.SetPath(url.GetHostName());
   }
 
   m_pInputStream = CDVDFactoryInputStream::CreateInputStream(this, m_item, true);


### PR DESCRIPTION
Backport of https://github.com/xbmc/xbmc/pull/23488

## Description
The "iso9660: rework IFile and IFileDirectory implementations" changes made on 2019-05-25 broke DVD disc device playback.

This is the cherry-picked fix. Thanks @dmahurin

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
