### PR TITLE
[imagecache] Don't check special generated images for file changes every 24 hours

### DIFF
--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -68,6 +68,38 @@ bool CTextureCacheJob::DoWork()
   return false;
 }
 
+namespace
+{
+// Most PVR images use "additional_info" to signify 'ownership' of basic images for easy
+// cache cleaning, rather than special generated images
+bool IsPVROwnedImage(const std::string& additional_info)
+{
+  return additional_info == "pvrchannel_radio" || additional_info == "pvrchannel_tv" ||
+         additional_info == "pvrprovider" || additional_info == "pvrrecording" ||
+         StringUtils::StartsWith(additional_info, "epgtag_");
+}
+
+// DecodeImageURL can also set "additional_info" to 'flipped' for mirror images selected in
+// the GUI, so is not a special generated image
+bool IsControl(const std::string& additional_info)
+{
+  return additional_info == "flipped";
+}
+
+// special generated images and images served via HTTP should not be regularly checked for changes
+bool ShouldCheckForChanges(const std::string& additional_info, const std::string& url)
+{
+  const bool isSpecialImage =
+      !additional_info.empty() && !IsControl(additional_info) && !IsPVROwnedImage(additional_info);
+  if (isSpecialImage)
+    return false;
+
+  const bool isHTTP =
+      StringUtils::StartsWith(url, "http://") || StringUtils::StartsWith(url, "https://");
+  return !isHTTP;
+}
+} // namespace
+
 bool CTextureCacheJob::CacheTexture(std::unique_ptr<CTexture>* out_texture)
 {
   // unwrap the URL as required
@@ -76,14 +108,18 @@ bool CTextureCacheJob::CacheTexture(std::unique_ptr<CTexture>* out_texture)
   CPictureScalingAlgorithm::Algorithm scalingAlgorithm;
   std::string image = DecodeImageURL(m_url, width, height, scalingAlgorithm, additional_info);
 
-  m_details.updateable = additional_info != "music" && UpdateableURL(image);
+  m_details.updateable = ShouldCheckForChanges(additional_info, image);
 
-  // generate the hash
-  m_details.hash = GetImageHash(image);
-  if (m_details.hash.empty())
-    return false;
-  else if (m_details.hash == m_oldHash)
-    return true;
+  if (m_details.updateable)
+  {
+    // generate the hash
+    m_details.hash = GetImageHash(image);
+    if (m_details.hash.empty())
+      return false;
+
+    if (m_details.hash == m_oldHash)
+      return true;
+  }
 
   std::unique_ptr<CTexture> texture = LoadImage(image, width, height, additional_info, true);
   if (texture)
@@ -220,12 +256,6 @@ std::unique_ptr<CTexture> CTextureCacheJob::LoadImage(const std::string& image,
     texture->SetOrientation(texture->GetOrientation() ^ 1);
 
   return texture;
-}
-
-bool CTextureCacheJob::UpdateableURL(const std::string &url) const
-{
-  // we don't constantly check online images
-  return !(StringUtils::StartsWith(url, "http://") || StringUtils::StartsWith(url, "https://"));
 }
 
 std::string CTextureCacheJob::GetImageHash(const std::string &url)

--- a/xbmc/TextureCacheJob.h
+++ b/xbmc/TextureCacheJob.h
@@ -82,15 +82,6 @@ private:
    */
   static std::string GetImageHash(const std::string &url);
 
-  /*! \brief Check whether a given URL represents an image that can be updated
-   We currently don't check http:// and https:// URLs for updates, under the assumption that
-   a image URL is much more likely to be static and the actual image at the URL is unlikely
-   to change, so no point checking all the time.
-   \param url the url to check
-   \return true if the image given by the URL should be checked for updates, false otherwise
-   */
-  bool UpdateableURL(const std::string &url) const;
-
   /*! \brief Decode an image URL to the underlying image, width, height and orientation
    \param url wrapped URL of the image
    \param width width derived from URL

--- a/xbmc/imagefiles/SpecialImageFileLoader.h
+++ b/xbmc/imagefiles/SpecialImageFileLoader.h
@@ -17,10 +17,11 @@ namespace IMAGE_FILES
 {
 
 /*!
- * @brief An interface to load special image files into a texture for the cache.
+ * @brief An interface to load special image files into a texture for display.
  *
- * Special image files are generated or embedded images, like album covers embedded
- * in music files or thumbnails generated from video files.
+ * Special image files are images that are more than just a link or path to an
+ * image file, such as generated or embedded images - like album covers
+ * embedded in music files or thumbnails generated from video files.
 */
 class ISpecialImageFileLoader
 {

--- a/xbmc/music/MusicEmbeddedImageFileLoader.h
+++ b/xbmc/music/MusicEmbeddedImageFileLoader.h
@@ -12,7 +12,9 @@
 
 namespace MUSIC_INFO
 {
-
+/*!
+ * @brief Generates a texture for an image embedded in a music file.
+*/
 class CMusicEmbeddedImageFileLoader : public IMAGE_FILES::ISpecialImageFileLoader
 {
 public:

--- a/xbmc/video/VideoEmbeddedImageFileLoader.h
+++ b/xbmc/video/VideoEmbeddedImageFileLoader.h
@@ -12,7 +12,9 @@
 
 namespace VIDEO
 {
-
+/*!
+ * @brief Generates a texture for an image embedded in a video file.
+*/
 class CVideoEmbeddedImageFileLoader : public IMAGE_FILES::ISpecialImageFileLoader
 {
 public:


### PR DESCRIPTION
## Description
Don't check special generated images for file changes every 24 hours.

Special generated images like video thumbnails and picture folder thumbnails, as generated from the interface introduced in #23197 . 

Also includes a small update to class docs.

## Motivation and context
Special images didn't do this before the new interface, I didn't expect to get this "functionality" with the new interface, and it is a bit frustrating even for the basic images it should apply to right now so we don't need to proliferate it. My upcoming chapter thumbnail change will likely end up with a path that can't be 'stat'ed which fails here unnecessarily, and @ksooo may use the same for PVR.

This does technically also change the behavior of HTTP images and embedded music thumbs, which previously generated and saved the file hash when _first_ loaded, but I think the change is a good thing for HTTP and shouldn't affect outward behavior.

This is quick and a bit messy to avoid the cache behavior - once all the special loaded images are implemented we'll be in a better place to re-arrange and simplify this and other lists of "special image types" and `DecodeImageURL`.

## How has this been tested?
Quickly on Windows.

## What is the effect on users?
Keep classic behavior before the new interface goes out in a wide release.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
