### PR TITLE
[PVR] Refactor channel groups class hierarchy.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -9560,14 +9560,12 @@ msgid "Radio"
 msgstr ""
 
 #. generic 'hidden' label used in different places
-#: xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
 #: xbmc/pvr/windows/GUIWindowPVRChannels.cpp
 msgctxt "#19022"
 msgid "Hidden"
 msgstr ""
 
 #. generic label for 'Live TV channels' used in different places
-#: xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
 #: addons/skin.estuary/xml/Variables.xml
 #: addons/skin.estuary/xml/DialogPVRChannelManager.xml
 msgctxt "#19023"
@@ -9575,7 +9573,6 @@ msgid "TV channels"
 msgstr ""
 
 #. generic label for pvr-provided 'Radio channels' used in different places
-#: xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
 #: addons/skin.estuary/xml/DialogPVRChannelManager.xml
 #: addons/skin.estuary/xml/Variables.xml
 msgctxt "#19024"

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -709,7 +709,6 @@ int CPVRDatabase::GetGroups(CPVRChannelGroups& results, const std::string& query
                              m_pDS->fv("iClientId").get_asInt()));
 
         group->m_iGroupId = m_pDS->fv("idGroup").get_asInt();
-        group->m_iGroupType = m_pDS->fv("iGroupType").get_asInt();
         group->m_iLastWatched = static_cast<time_t>(m_pDS->fv("iLastWatched").get_asInt());
         group->m_bHidden = m_pDS->fv("bIsHidden").get_asBool();
         group->m_iPosition = m_pDS->fv("iPosition").get_asInt();
@@ -994,8 +993,9 @@ bool CPVRDatabase::Persist(CPVRChannelGroup& group)
   else
     bReturn = true;
 
-  /* only persist the channel data for the internal groups */
-  if (group.IsInternalGroup())
+  // only persist the channel data for the all channels groups as all groups
+  // share the same channel instances and all groups has them all.
+  if (group.IsChannelsOwner())
     bReturn &= PersistChannels(group);
 
   /* persist the group member entries */

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -20,7 +20,7 @@
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRChannelGroup.h"
-#include "pvr/channels/PVRChannelGroupInternal.h"
+#include "pvr/channels/PVRChannelGroupAllChannels.h"
 #include "pvr/channels/PVRChannelGroups.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/channels/PVRChannelsPath.h"
@@ -858,9 +858,9 @@ void CPVRManager::LocalizationChanged()
   std::unique_lock<CCriticalSection> lock(m_critSection);
   if (IsStarted())
   {
-    static_cast<CPVRChannelGroupInternal*>(m_channelGroups->GetGroupAllRadio().get())
+    static_cast<CPVRChannelGroupAllChannels*>(m_channelGroups->GetGroupAllRadio().get())
         ->CheckGroupName();
-    static_cast<CPVRChannelGroupInternal*>(m_channelGroups->GetGroupAllTV().get())
+    static_cast<CPVRChannelGroupAllChannels*>(m_channelGroups->GetGroupAllTV().get())
         ->CheckGroupName();
   }
 }

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -24,7 +24,8 @@
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRChannelGroup.h"
-#include "pvr/channels/PVRChannelGroupInternal.h"
+#include "pvr/channels/PVRChannelGroupAllChannels.h"
+#include "pvr/channels/PVRChannelGroupFromClient.h"
 #include "pvr/channels/PVRChannelGroupMember.h"
 #include "pvr/channels/PVRChannelGroups.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
@@ -1679,8 +1680,8 @@ void CPVRClient::cb_transfer_channel_group(void* kodiInstance,
 
     // transfer this entry to the groups container
     CPVRChannelGroups* kodiGroups = static_cast<CPVRChannelGroups*>(handle->dataAddress);
-    const auto transferGroup =
-        std::make_shared<CPVRChannelGroup>(*group, client->GetID(), kodiGroups->GetGroupAll());
+    const auto transferGroup = std::make_shared<CPVRChannelGroupFromClient>(
+        *group, client->GetID(), kodiGroups->GetGroupAll());
     kodiGroups->UpdateFromClient(transferGroup);
   });
 }

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -20,7 +20,6 @@
 #include "pvr/PVRPlaybackState.h"
 #include "pvr/addons/PVRClient.h"
 #include "pvr/addons/PVRClientUID.h"
-#include "pvr/channels/PVRChannelGroupInternal.h"
 #include "pvr/guilib/PVRGUIProgressHandler.h"
 #include "utils/JobManager.h"
 #include "utils/StringUtils.h"

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -29,7 +29,6 @@ namespace ADDON
 namespace PVR
 {
 class CPVRChannel;
-class CPVRChannelGroupInternal;
 class CPVRChannelGroup;
 class CPVRChannelGroupMember;
 class CPVRChannelGroups;

--- a/xbmc/pvr/channels/CMakeLists.txt
+++ b/xbmc/pvr/channels/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(SOURCES PVRChannel.cpp
             PVRChannelGroup.cpp
-            PVRChannelGroupInternal.cpp
+            PVRChannelGroupAllChannels.cpp
+            PVRChannelGroupFromClient.cpp
+            PVRChannelGroupFromUser.cpp
             PVRChannelGroupMember.cpp
             PVRChannelGroupSettings.cpp
             PVRChannelGroups.cpp
@@ -11,7 +13,9 @@ set(SOURCES PVRChannel.cpp
 
 set(HEADERS PVRChannel.h
             PVRChannelGroup.h
-            PVRChannelGroupInternal.h
+            PVRChannelGroupAllChannels.h
+            PVRChannelGroupFromClient.h
+            PVRChannelGroupFromUser.h
             PVRChannelGroupMember.h
             PVRChannelGroupSettings.h
             PVRChannelGroups.h

--- a/xbmc/pvr/channels/PVRChannelGroupAllChannels.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupAllChannels.cpp
@@ -6,7 +6,7 @@
  *  See LICENSES/README.md for more information.
  */
 
-#include "PVRChannelGroupInternal.h"
+#include "PVRChannelGroupAllChannels.h"
 
 #include "ServiceBroker.h"
 #include "guilib/LocalizeStrings.h"
@@ -28,29 +28,22 @@
 
 using namespace PVR;
 
-CPVRChannelGroupInternal::CPVRChannelGroupInternal(bool bRadio)
-  : CPVRChannelGroup(
-        CPVRChannelsPath(bRadio, g_localizeStrings.Get(19287), PVR_GROUP_CLIENT_ID_LOCAL),
-        PVR_GROUP_TYPE_ALL_CHANNELS,
-        nullptr)
+CPVRChannelGroupAllChannels::CPVRChannelGroupAllChannels(bool bRadio)
+  : CPVRChannelGroupFromUser(
+        CPVRChannelsPath(bRadio, g_localizeStrings.Get(19287), PVR_GROUP_CLIENT_ID_LOCAL), nullptr)
 {
 }
 
-CPVRChannelGroupInternal::CPVRChannelGroupInternal(const CPVRChannelsPath& path)
-  : CPVRChannelGroup(path, PVR_GROUP_TYPE_ALL_CHANNELS, nullptr)
+CPVRChannelGroupAllChannels::CPVRChannelGroupAllChannels(const CPVRChannelsPath& path)
+  : CPVRChannelGroupFromUser(path, nullptr)
 {
 }
 
-CPVRChannelGroupInternal::~CPVRChannelGroupInternal()
+CPVRChannelGroupAllChannels::~CPVRChannelGroupAllChannels()
 {
 }
 
-void CPVRChannelGroupInternal::Unload()
-{
-  CPVRChannelGroup::Unload();
-}
-
-void CPVRChannelGroupInternal::CheckGroupName()
+void CPVRChannelGroupAllChannels::CheckGroupName()
 {
   //! @todo major design flaw to fix: channel and group URLs must not contain the group name!
 
@@ -59,7 +52,7 @@ void CPVRChannelGroupInternal::CheckGroupName()
     SetGroupName(g_localizeStrings.Get(19287));
 }
 
-bool CPVRChannelGroupInternal::UpdateFromClients(
+bool CPVRChannelGroupAllChannels::UpdateFromClients(
     const std::vector<std::shared_ptr<CPVRClient>>& clients)
 {
   // get the channels from the given clients
@@ -78,7 +71,7 @@ bool CPVRChannelGroupInternal::UpdateFromClients(
   return UpdateGroupEntries(groupMembers);
 }
 
-std::vector<std::shared_ptr<CPVRChannelGroupMember>> CPVRChannelGroupInternal::
+std::vector<std::shared_ptr<CPVRChannelGroupMember>> CPVRChannelGroupAllChannels::
     RemoveDeletedGroupMembers(
         const std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers)
 {
@@ -113,7 +106,7 @@ std::vector<std::shared_ptr<CPVRChannelGroupMember>> CPVRChannelGroupInternal::
 
       for (const auto& member : removedMembers)
       {
-        // since channel was not found in the internal group, it was deleted from the backend
+        // since channel was not found in the all channels group, it was deleted from the backend
 
         const auto channel = member->Channel();
         commitPending |= channel->QueueDelete();
@@ -136,7 +129,7 @@ std::vector<std::shared_ptr<CPVRChannelGroupMember>> CPVRChannelGroupInternal::
   return removedMembers;
 }
 
-bool CPVRChannelGroupInternal::AppendToGroup(
+bool CPVRChannelGroupAllChannels::AppendToGroup(
     const std::shared_ptr<CPVRChannelGroupMember>& groupMember)
 {
   if (IsGroupMember(groupMember))
@@ -148,7 +141,7 @@ bool CPVRChannelGroupInternal::AppendToGroup(
   return true;
 }
 
-bool CPVRChannelGroupInternal::RemoveFromGroup(
+bool CPVRChannelGroupAllChannels::RemoveFromGroup(
     const std::shared_ptr<CPVRChannelGroupMember>& groupMember)
 {
   if (!IsGroupMember(groupMember))
@@ -160,7 +153,7 @@ bool CPVRChannelGroupInternal::RemoveFromGroup(
   return true;
 }
 
-bool CPVRChannelGroupInternal::IsGroupMember(
+bool CPVRChannelGroupAllChannels::IsGroupMember(
     const std::shared_ptr<CPVRChannelGroupMember>& groupMember) const
 {
   return !groupMember->Channel()->IsHidden();

--- a/xbmc/pvr/channels/PVRChannelGroupAllChannels.h
+++ b/xbmc/pvr/channels/PVRChannelGroupAllChannels.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "pvr/channels/PVRChannelGroup.h"
+#include "pvr/channels/PVRChannelGroupFromUser.h"
 
 #include <memory>
 #include <vector>
@@ -18,24 +18,24 @@ namespace PVR
 class CPVRChannel;
 class CPVRChannelNumber;
 
-class CPVRChannelGroupInternal : public CPVRChannelGroup
+class CPVRChannelGroupAllChannels : public CPVRChannelGroupFromUser
 {
 public:
-  CPVRChannelGroupInternal() = delete;
+  CPVRChannelGroupAllChannels() = delete;
 
   /*!
-   * @brief Create a new internal channel group.
+   * @brief Create a new all channels channel group.
    * @param bRadio True if this group holds radio channels.
    */
-  explicit CPVRChannelGroupInternal(bool bRadio);
+  explicit CPVRChannelGroupAllChannels(bool bRadio);
 
   /*!
-   * @brief Create a new internal channel group.
+   * @brief Create a new all channels channel group.
    * @param path The path for the new group.
    */
-  explicit CPVRChannelGroupInternal(const CPVRChannelsPath& path);
+  explicit CPVRChannelGroupAllChannels(const CPVRChannelsPath& path);
 
-  ~CPVRChannelGroupInternal() override;
+  ~CPVRChannelGroupAllChannels() override;
 
   /*!
    * @see CPVRChannelGroup::IsGroupMember
@@ -57,6 +57,18 @@ public:
    */
   void CheckGroupName();
 
+  /*!
+   * @brief Check whether this group could be deleted by the user.
+   * @return True if the group could be deleted, false otherwise.
+   */
+  bool SupportsDelete() const override { return false; }
+
+  /*!
+   * @brief Check whether this group is owner of the channel instances it contains.
+   * @return True if owner, false otherwise.
+   */
+  bool IsChannelsOwner() const override { return true; }
+
 protected:
   /*!
    * @brief Remove deleted group members from this group. Delete stale channels.
@@ -73,9 +85,10 @@ protected:
    */
   bool UpdateFromClients(const std::vector<std::shared_ptr<CPVRClient>>& clients) override;
 
+private:
   /*!
-   * @brief Clear all data.
+   * @brief Return the type of this group.
    */
-  void Unload() override;
+  int GroupType() const override { return PVR_GROUP_TYPE_ALL_CHANNELS; }
 };
 } // namespace PVR

--- a/xbmc/pvr/channels/PVRChannelGroupFromClient.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupFromClient.cpp
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (C) 2012-2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PVRChannelGroupFromClient.h"
+
+#include "ServiceBroker.h"
+#include "pvr/PVRManager.h"
+#include "pvr/addons/PVRClient.h"
+#include "pvr/addons/PVRClients.h"
+
+using namespace PVR;
+
+CPVRChannelGroupFromClient::CPVRChannelGroupFromClient(
+    const CPVRChannelsPath& path, const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup)
+  : CPVRChannelGroup(path, allChannelsGroup)
+{
+}
+
+CPVRChannelGroupFromClient::CPVRChannelGroupFromClient(
+    const PVR_CHANNEL_GROUP& group,
+    int clientID,
+    const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup)
+  : CPVRChannelGroup(CPVRChannelsPath(group.bIsRadio, group.strGroupName, clientID),
+                     allChannelsGroup)
+{
+  SetClientGroupName(group.strGroupName);
+  SetClientPosition(group.iPosition);
+}
+
+bool CPVRChannelGroupFromClient::UpdateFromClients(
+    const std::vector<std::shared_ptr<CPVRClient>>& clients)
+{
+  const auto it = std::find_if(clients.cbegin(), clients.cend(), [this](const auto& client) {
+    return client->GetID() == GetClientID();
+  });
+  if (it == clients.cend())
+    return true; // this group is not provided by one of the clients to get the group members for
+
+  // get the channel group members from the backends.
+  std::vector<std::shared_ptr<CPVRChannelGroupMember>> groupMembers;
+  CServiceBroker::GetPVRManager().Clients()->GetChannelGroupMembers({*it}, this, groupMembers,
+                                                                    m_failedClients);
+  return UpdateGroupEntries(groupMembers);
+}

--- a/xbmc/pvr/channels/PVRChannelGroupFromClient.h
+++ b/xbmc/pvr/channels/PVRChannelGroupFromClient.h
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (C) 2012-2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "pvr/channels/PVRChannelGroup.h"
+
+namespace PVR
+{
+
+class CPVRChannelGroupFromClient : public CPVRChannelGroup
+{
+public:
+  /*!
+   * @brief Create a new channel group instance.
+   * @param path The channel group path.
+   * @param allChannelsGroup The channel group containing all TV or radio channels.
+   */
+  CPVRChannelGroupFromClient(const CPVRChannelsPath& path,
+                             const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup);
+
+  /*!
+   * @brief Create a new channel group instance from a channel group provided by a PVR client.
+   * @param group The channel group provided by the client.
+   * @param clientID The id of the client providing the group.
+   * @param allChannelsGroup The channel group containing all TV or radio channels.
+   */
+  CPVRChannelGroupFromClient(const PVR_CHANNEL_GROUP& group,
+                             int clientID,
+                             const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup);
+
+  /*!
+   * @brief Check whether this group could be deleted by the user.
+   * @return True if the group could be deleted, false otherwise.
+   */
+  bool SupportsDelete() const override { return false; }
+
+  /*!
+   * @brief Check whether members could be added to this group by the user.
+   * @return True if members could be added, false otherwise.
+   */
+  bool SupportsMemberAdd() const override { return false; }
+
+  /*!
+   * @brief Check whether members could be removed from this group by the user.
+   * @return True if members could be removed, false otherwise.
+   */
+  bool SupportsMemberRemove() const override { return false; }
+
+  /*!
+   * @brief Check whether this group is owner of the channel instances it contains.
+   * @return True if owner, false otherwise.
+   */
+  bool IsChannelsOwner() const override { return false; }
+
+  /*!
+   * @brief Update data with channel group members from the given clients, sync with local data.
+   * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
+   * @return True on success, false otherwise.
+   */
+  bool UpdateFromClients(const std::vector<std::shared_ptr<CPVRClient>>& clients) override;
+
+private:
+  /*!
+   * @brief Return the type of this group.
+   */
+  int GroupType() const override { return PVR_GROUP_TYPE_REMOTE; }
+};
+} // namespace PVR

--- a/xbmc/pvr/channels/PVRChannelGroupFromUser.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupFromUser.cpp
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (C) 2012-2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PVRChannelGroupFromUser.h"
+
+using namespace PVR;
+
+CPVRChannelGroupFromUser::CPVRChannelGroupFromUser(
+    const CPVRChannelsPath& path, const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup)
+  : CPVRChannelGroup(path, allChannelsGroup)
+{
+}
+
+bool CPVRChannelGroupFromUser::UpdateFromClients(
+    const std::vector<std::shared_ptr<CPVRClient>>& clients)
+{
+  // Nothing to update from any client, because there is none for local groups.
+  return true;
+}

--- a/xbmc/pvr/channels/PVRChannelGroupFromUser.h
+++ b/xbmc/pvr/channels/PVRChannelGroupFromUser.h
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (C) 2012-2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "pvr/channels/PVRChannelGroup.h"
+
+namespace PVR
+{
+
+class CPVRChannelGroupFromUser : public CPVRChannelGroup
+{
+public:
+  /*!
+   * @brief Create a new channel group instance.
+   * @param path The channel group path.
+   * @param allChannelsGroup The channel group containing all TV or radio channels.
+   */
+  CPVRChannelGroupFromUser(const CPVRChannelsPath& path,
+                           const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup);
+
+  /*!
+   * @brief Check whether this group could be deleted by the user.
+   * @return True if the group could be deleted, false otherwise.
+   */
+  bool SupportsDelete() const override { return true; }
+
+  /*!
+   * @brief Check whether members could be added to this group by the user.
+   * @return True if members could be added, false otherwise.
+   */
+  bool SupportsMemberAdd() const override { return true; }
+
+  /*!
+   * @brief Check whether members could be removed from this group by the user.
+   * @return True if members could be removed, false otherwise.
+   */
+  bool SupportsMemberRemove() const override { return true; }
+
+  /*!
+   * @brief Check whether this group is owner of the channel instances it contains.
+   * @return True if owner, false otherwise.
+   */
+  bool IsChannelsOwner() const override { return false; }
+
+  /*!
+   * @brief Update data with channel group members from the given clients, sync with local data.
+   * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
+   * @return True on success, false otherwise.
+   */
+  bool UpdateFromClients(const std::vector<std::shared_ptr<CPVRClient>>& clients) override;
+
+private:
+  /*!
+   * @brief Return the type of this group.
+   */
+  int GroupType() const override { return PVR_GROUP_TYPE_LOCAL; }
+};
+} // namespace PVR

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -93,6 +93,14 @@ public:
       const CPVRChannelsPath& path) const;
 
   /*!
+   * @brief Get all channel group members that could be added to the given group
+   * @param group The group
+   * @return The channel group members that could be added to the group
+   */
+  std::vector<std::shared_ptr<CPVRChannelGroupMember>> GetMembersAvailableForGroup(
+      const std::shared_ptr<CPVRChannelGroup>& group);
+
+  /*!
    * @brief Get a pointer to a channel group given its ID.
    * @param iGroupId The ID of the group.
    * @return The group or NULL if it wasn't found.
@@ -234,6 +242,9 @@ private:
   bool HasValidDataForClients(const std::vector<std::shared_ptr<CPVRClient>>& clients) const;
 
   void OnPVRManagerEvent(const PVR::PVREvent& event);
+
+  int GetGroupTypePriority(const std::shared_ptr<CPVRChannelGroup>& group) const;
+  int GetGroupClientPriority(const std::shared_ptr<CPVRChannelGroup>& group) const;
 
   bool m_bRadio{false};
   std::vector<std::shared_ptr<CPVRChannelGroup>> m_groups;


### PR DESCRIPTION
This PR refactors how channel groups are modeled in Kodi PVR core to cleanup the current mixture of inheritance and type ids to implement/control groups functionality.

New approach is to have `CPVRChannelGroup`  as abstract base class for three derived classes:

1) `CPVRChannelGroupRemote`modelling all groups provided by the different PVR clients.
2) `CPVRChannelGroupAllChannels`modeling the Kodi-created "internal group" containing all channels across all clients
3) `CPVRChannelGroupLocal`modeling all groups created by the user in Kodi's channel group manager.

Beside of better code readability and maintainability, it now should be easy to introduce new kind of groups, like a Kodi-generated group for last used channels.

I'm  using this code for a couple of month in a private build on a daily base and could not find any regressions so far.

@phunkyfish  whenever you find time to look at the code changes.