### PR TITLE
[Android] Check if dovi profile is supported by the codec

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -548,6 +548,47 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
           m_mime = "video/dolby-vision";
           m_formatname = isDvhe ? "amc-dvhe" : "amc-dvh1";
           profile = 0; // not an HEVC profile
+
+          if (CJNIBase::GetSDKVersion() >= 24)
+          {
+            switch (m_hints.dovi.dv_profile)
+            {
+              case 0:
+                profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvavPer;
+                break;
+              case 1:
+                profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvavPen;
+                break;
+              case 2:
+                profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheDer;
+                break;
+              case 3:
+                profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheDen;
+                break;
+              case 4:
+                profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheDtr;
+                break;
+              case 5:
+                profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheStn;
+                break;
+              case 6:
+                profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheDth;
+                break;
+              case 7:
+                // profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheDtb;
+                break;
+              case 8:
+                if (CJNIBase::GetSDKVersion() >= 27)
+                  profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheSt;
+                break;
+              case 9:
+                if (CJNIBase::GetSDKVersion() >= 27)
+                  profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvavSe;
+                break;
+              default:
+                break;
+            }
+          }
         }
       }
 


### PR DESCRIPTION
## Description
Similar to identifying video profiles and checking that they are supported by the device's codec capabilities.

When a video is dovi we should assign to the `profile` variable the value of the constant corresponding to the video profile of the `MediaCodecInfoCodec.ProfileLevel` class.

This variable does not affect the decoder, it's only used to check if the video profile is supported by the codec of the device.

## How has this been tested?
As my TV doesn't support dovi I can't do the tests I would like to do, any feedback is welcome.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
