### PR TITLE
[macos][nativewindowing] Fix low fps on the GUI rendering code

### DIFF
--- a/xbmc/windowing/osx/OpenGL/OSXGLView.h
+++ b/xbmc/windowing/osx/OpenGL/OSXGLView.h
@@ -30,4 +30,9 @@
  */
 - (void)FlushBuffer;
 
+/**
+ * @brief Specifies if the glContext is currently owned by the view
+ */
+@property(atomic, assign) BOOL glContextOwned;
+
 @end

--- a/xbmc/windowing/osx/OpenGL/OSXGLView.mm
+++ b/xbmc/windowing/osx/OpenGL/OSXGLView.mm
@@ -21,6 +21,8 @@
   BOOL pause;
 }
 
+@synthesize glContextOwned;
+
 - (void)SendInputEvent:(NSEvent*)nsEvent
 {
   CWinSystemOSX* winSystem = dynamic_cast<CWinSystemOSX*>(CServiceBroker::GetWinSystem());
@@ -69,6 +71,14 @@
 
 - (void)drawRect:(NSRect)rect
 {
+  // whenever the view/window is resized the glContext is made current to the main (rendering) thread.
+  // Since kodi does its rendering on the application main thread (not the macOS rendering thread), we
+  // need to store this so that on a subsquent frame render we get the ownership of the gl context again.
+  // doing this blindly without any sort of control may stall the main thread and lead to low GUI fps
+  // since the glContext ownership needs to be obtained from the rendering thread (diverged from the actual
+  // thread doing the rendering calls).
+  [self setGlContextOwned:TRUE];
+
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     [self setOpenGLContext:m_glcontext];
@@ -196,7 +206,9 @@
 {
   assert(m_glcontext);
   // signals/notifies the context that this view is current (required if we render out of DrawRect)
+  // ownership of the context is transferred to the callee thread
   [m_glcontext makeCurrentContext];
+  [self setGlContextOwned:FALSE];
 }
 
 - (void)FlushBuffer

--- a/xbmc/windowing/osx/OpenGL/OSXGLView.mm
+++ b/xbmc/windowing/osx/OpenGL/OSXGLView.mm
@@ -18,7 +18,6 @@
   NSOpenGLContext* m_glcontext;
   NSOpenGLPixelFormat* m_pixFmt;
   NSTrackingArea* m_trackingArea;
-  BOOL pause;
 }
 
 @synthesize glContextOwned;

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1305,7 +1305,7 @@ CGLContextObj CWinSystemOSX::GetCGLContextObj()
 
 CGraphicContext& CWinSystemOSX::GetGfxContext() const
 {
-  if (m_glView)
+  if (m_glView && [m_glView glContextOwned])
   {
     dispatch_sync(dispatch_get_main_queue(), ^{
       [m_glView NotifyContext];


### PR DESCRIPTION
## Description
Currently the macOS nativewindowing code leads to low fps on the UI rendering code. I suspect this is due to the fact we need to lock the glContext (actually `makeCurrentContext`) to transfer the ownership of the context back to the Kodi main thread. This was done since everytime the window is resized, the ownership of the context is made available automatically to macOS thread 1, i.e. the thread actually running the GL view.
We cannot call `makeCurrentContext` blindly from the Kodi main thread since it stalls the CPU for a bit (needs to executed on thread 1 - pausing the execution of Kodi's main thread). Hence, I went with an atomic bool to only get it when the ownership was actually stolen.

## Motivation and context
Fix the slow FPS when compared to SDL

## How has this been tested?
Checking the FPS gauge in xcode. Checking if resizing the window like a psychopath doesn't lead to a crash.
Checking on xcode instruments that the call to `getGlContext` usually took around 10ms...

## What is the effect on users?
Faster UI in native windowing.

## Screenshots (if appropriate):

On my M2 mac:

**before:**
<img width="871" alt="image" src="https://github.com/xbmc/xbmc/assets/7375276/2da5b901-9c75-4fb0-a5d5-f48ab6529d66">


**now:**
<img width="906" alt="image" src="https://github.com/xbmc/xbmc/assets/7375276/02797d20-e5a1-4f7c-b5d2-d04ffc0f0def">


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
