### PR TITLE
[macOS][nativewindowing] Fix moving between different hidpi screens w…

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1215,10 +1215,10 @@ void CWinSystemOSX::OnMove(int x, int y)
 
     // send a message so that videoresolution (and refreshrate) is changed
     dispatch_sync(dispatch_get_main_queue(), ^{
-      NSWindow* win = m_appWindow;
-      NSRect frame = win.contentView.frame;
-      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_VIDEORESIZE, frame.size.width,
-                                                 frame.size.height);
+      NSRect rect = [m_appWindow.contentView
+          convertRectToBacking:[m_appWindow contentRectForFrameRect:m_appWindow.frame]];
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_VIDEORESIZE, rect.size.width,
+                                                 rect.size.height);
     });
   }
   if (m_fullScreenMovingToScreen.has_value())


### PR DESCRIPTION
…hen fps differ

## Description
This fixes a simple bug I found while moving the window between screens with different hiDPIs when the refresh rate differs between screens. In those cases we trigger a resize because of the new resolution but not take into account the backing scale factor (use `contentRectForFrameRect`). This is some use-case I overlooked when implementing hidpi/retina support.

**Before:**
<img width="1161" alt="image" src="https://github.com/xbmc/xbmc/assets/7375276/22f257ec-6046-4e8b-accf-16ac12be68d9">


**Now:** 
<img width="1169" alt="image" src="https://github.com/xbmc/xbmc/assets/7375276/e79abc57-2d58-4bb1-9b4b-9c5a11f83b48">
