### PR TITLE
[cmake][macOS] Allow building without xbmchelper - default for arm64

### DIFF
--- a/cmake/scripts/osx/ArchSetup.cmake
+++ b/cmake/scripts/osx/ArchSetup.cmake
@@ -24,6 +24,17 @@ else()
   endif()
 endif()
 
+# xbmchelper (old apple IR remotes) only make sense for x86
+# last macs featuring the IR receiver are those of mid 2012
+# which are still able to run Mojave (10.14). Drop all together
+# when the sdk requirement is bumped.
+if(CPU STREQUAL arm64)
+  set(ENABLE_XBMCHELPER OFF)
+else()
+  set(ENABLE_XBMCHELPER ON)
+  list(APPEND SYSTEM_DEFINES -DHAS_XBMCHELPER)
+endif()
+
 # m1 macs can execute x86_64 code via rosetta
 if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64" AND
    CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")

--- a/cmake/scripts/osx/ExtraTargets.cmake
+++ b/cmake/scripts/osx/ExtraTargets.cmake
@@ -1,3 +1,5 @@
 # XBMCHelper
-add_subdirectory(${CMAKE_SOURCE_DIR}/tools/EventClients/Clients/OSXRemote build/XBMCHelper)
-add_dependencies(${APP_NAME_LC} XBMCHelper)
+if(ENABLE_XBMCHELPER)
+  add_subdirectory(${CMAKE_SOURCE_DIR}/tools/EventClients/Clients/OSXRemote build/XBMCHelper)
+  add_dependencies(${APP_NAME_LC} XBMCHelper)
+endif()

--- a/system/settings/darwin.xml
+++ b/system/settings/darwin.xml
@@ -28,6 +28,7 @@
     <category id="input">
       <group id="3">
         <setting id="input.appleremotemode" type="integer" label="13600" help="36416">
+          <requirement>HAS_XBMCHELPER</requirement>
           <level>1</level>
           <default>1</default> <!-- APPLE_REMOTE_STANDARD -->
           <constraints>
@@ -41,6 +42,7 @@
           <control type="list" format="string"/>
         </setting>
         <setting id="input.appleremotealwayson" type="boolean" label="13602" help="36417">
+          <requirement>HAS_XBMCHELPER</requirement>
           <level>4</level>
           <default>false</default>
           <dependencies>
@@ -49,6 +51,7 @@
           <control type="toggle" />
         </setting>
         <setting id="input.appleremotesequencetime" type="integer" label="13603" help="36418">
+          <requirement>HAS_XBMCHELPER</requirement>
           <level>1</level>
           <default>500</default>
           <constraints>

--- a/tools/EventClients/Clients/OSXRemote/CMakeLists.txt
+++ b/tools/EventClients/Clients/OSXRemote/CMakeLists.txt
@@ -1,20 +1,22 @@
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
+if(ENABLE_XBMCHELPER)
+  list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
 
-set(SOURCES xbmcclientwrapper.mm
-            xbmchelper_main.mm
-            XBMCHelper.m
-            HIDRemote/HIDRemote.m)
+  set(SOURCES xbmcclientwrapper.mm
+              xbmchelper_main.mm
+              XBMCHelper.m
+              HIDRemote/HIDRemote.m)
 
-set(HEADERS XBMCDebugHelpers.h)
+  set(HEADERS XBMCDebugHelpers.h)
 
-add_executable(XBMCHelper ${SOURCES} ${HEADERS})
-set_target_properties(XBMCHelper PROPERTIES
-                                 RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tools/darwin/runtime
-                                 RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/tools/darwin/runtime
-                                 RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/tools/darwin/runtime
-                                 FOLDER Tools)
-target_link_libraries(XBMCHelper
-                      PRIVATE ${SYSTEM_LDFLAGS}
-                              "-framework IOKit"
-                              "-framework Carbon"
-                              "-framework Cocoa")
+  add_executable(XBMCHelper ${SOURCES} ${HEADERS})
+  set_target_properties(XBMCHelper PROPERTIES
+                                   RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tools/darwin/runtime
+                                   RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/tools/darwin/runtime
+                                   RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/tools/darwin/runtime
+                                   FOLDER Tools)
+  target_link_libraries(XBMCHelper
+                        PRIVATE ${SYSTEM_LDFLAGS}
+                                "-framework IOKit"
+                                "-framework Carbon"
+                                "-framework Cocoa")
+endif()

--- a/tools/darwin/packaging/osx/mkdmg-osx.sh.in
+++ b/tools/darwin/packaging/osx/mkdmg-osx.sh.in
@@ -38,7 +38,9 @@ if [ "$EXPANDED_CODE_SIGN_IDENTITY_NAME" ]; then
   # execute codesign script
   "$DIRNAME/Codesign.command"
   # sign helper tool
-  codesign --verbose=4 --sign "$EXPANDED_CODE_SIGN_IDENTITY_NAME" --force --options runtime --timestamp --entitlements Kodi.entitlements "$APP/Contents/Resources/Kodi/tools/darwin/runtime/XBMCHelper"
+  if [ -f "$APP/Contents/Resources/Kodi/tools/darwin/runtime/XBMCHelper" ]; then
+    codesign --verbose=4 --sign "$EXPANDED_CODE_SIGN_IDENTITY_NAME" --force --options runtime --timestamp --entitlements Kodi.entitlements "$APP/Contents/Resources/Kodi/tools/darwin/runtime/XBMCHelper"
+  fi
   # perform top-level signing (Xcode does it automatically when signing settings are configured)
   codesign --verbose=4 --sign "$EXPANDED_CODE_SIGN_IDENTITY_NAME" --force --options runtime --timestamp --entitlements Kodi.entitlements "$APP"
 fi

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -154,7 +154,9 @@
 
 #ifdef TARGET_DARWIN_OSX
 #include "platform/darwin/osx/CocoaInterface.h"
+#ifdef HAS_XBMCHELPER
 #include "platform/darwin/osx/XBMCHelper.h"
+#endif
 #endif
 #ifdef TARGET_DARWIN
 #include "platform/darwin/DarwinUtils.h"
@@ -2162,7 +2164,7 @@ bool CApplication::Stop(int exitCode)
     smb.Deinit();
 #endif
 
-#if defined(TARGET_DARWIN_OSX)
+#if defined(TARGET_DARWIN_OSX) and defined(HAS_XBMCHELPER)
     if (XBMCHelper::GetInstance().IsAlwaysOn() == false)
       XBMCHelper::GetInstance().Stop();
 #endif

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -74,7 +74,7 @@
 #endif
 #endif
 
-#if defined(TARGET_DARWIN_OSX)
+#if defined(TARGET_DARWIN_OSX) and defined(HAS_XBMCHELPER)
 #include "platform/darwin/osx/XBMCHelper.h"
 #endif
 
@@ -432,7 +432,7 @@ bool CNetworkServices::OnSettingChanging(const std::shared_ptr<const CSetting>& 
       return false;
     }
 
-#if defined(TARGET_DARWIN_OSX)
+#if defined(TARGET_DARWIN_OSX) and defined(HAS_XBMCHELPER)
     // reconfigure XBMCHelper for port changes
     XBMCHelper::GetInstance().Configure();
 #endif // TARGET_DARWIN_OSX

--- a/xbmc/platform/darwin/osx/CMakeLists.txt
+++ b/xbmc/platform/darwin/osx/CMakeLists.txt
@@ -2,14 +2,17 @@ set(SOURCES CocoaInterface.mm
             CPUInfoOsx.cpp
             HotKeyController.m
             PlatformDarwinOSX.cpp
-            smc.c
-            XBMCHelper.cpp)
+            smc.c)
 
 set(HEADERS CocoaInterface.h
             CPUInfoOsx.h
             HotKeyController.h
             PlatformDarwinOSX.h
-            smc.h
-            XBMCHelper.h)
+            smc.h)
+
+if(ENABLE_XBMCHELPER)
+  list(APPEND SOURCES XBMCHelper.cpp)
+  list(APPEND HEADERS XBMCHelper.h)
+endif()
 
 core_add_library(platform_osx)

--- a/xbmc/platform/darwin/osx/PlatformDarwinOSX.cpp
+++ b/xbmc/platform/darwin/osx/PlatformDarwinOSX.cpp
@@ -14,7 +14,9 @@
 #include "windowing/osx/OpenGL/WinSystemOSXGL.h"
 #endif
 
+#if defined(HAS_XBMCHELPER)
 #include "platform/darwin/osx/XBMCHelper.h"
+#endif
 #include "platform/darwin/osx/powermanagement/CocoaPowerSyscall.h"
 
 #include <stdlib.h>
@@ -48,7 +50,9 @@ bool CPlatformDarwinOSX::InitStageOne()
 bool CPlatformDarwinOSX::InitStageTwo()
 {
   // Configure and possible manually start the helper.
+#if defined(HAS_XBMCHELPER)
   XBMCHelper::GetInstance().Configure();
+#endif
 
   return true;
 }

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -455,6 +455,10 @@ void CSettingConditions::Initialize()
   m_simpleConditions.emplace("has_optical_drive");
 #endif
 
+#ifdef HAS_XBMCHELPER
+  m_simpleConditions.emplace("has_xbmchelper");
+#endif
+
   // add complex conditions
   m_complexConditions.emplace("addonhassettings", AddonHasSettings);
   m_complexConditions.emplace("checkmasterlock", CheckMasterLock);

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -26,7 +26,7 @@
 #endif // defined(TARGET_POSIX)
 #include "network/upnp/UPnPSettings.h"
 #include "network/WakeOnAccess.h"
-#if defined(TARGET_DARWIN_OSX)
+#if defined(TARGET_DARWIN_OSX) and defined(HAS_XBMCHELPER)
 #include "platform/darwin/osx/XBMCHelper.h"
 #endif // defined(TARGET_DARWIN_OSX)
 #if defined(TARGET_DARWIN_TVOS)
@@ -619,7 +619,7 @@ void CSettings::InitializeISettingCallbacks()
   GetSettingsManager()->RegisterCallback(&g_timezone, settingSet);
 #endif
 
-#if defined(TARGET_DARWIN_OSX)
+#if defined(TARGET_DARWIN_OSX) and defined(HAS_XBMCHELPER)
   settingSet.clear();
   settingSet.insert(CSettings::SETTING_INPUT_APPLEREMOTEMODE);
   settingSet.insert(CSettings::SETTING_INPUT_APPLEREMOTEALWAYSON);
@@ -664,7 +664,7 @@ void CSettings::UninitializeISettingCallbacks()
 #if defined(TARGET_LINUX)
   GetSettingsManager()->UnregisterCallback(&g_timezone);
 #endif // defined(TARGET_LINUX)
-#if defined(TARGET_DARWIN_OSX)
+#if defined(TARGET_DARWIN_OSX) and defined(HAS_XBMCHELPER)
   GetSettingsManager()->UnregisterCallback(&XBMCHelper::GetInstance());
 #endif
   GetSettingsManager()->UnregisterCallback(&CWakeOnAccess::GetInstance());


### PR DESCRIPTION
## Description
XBMCHelper is a little tool that allows Kodi to be controlled via old Apple Remotes (those that date back the Siri remote - using the builtin infrared receiver https://en.wikipedia.org/wiki/Apple_Remote). It includes other stuff like a builtin Launch Agent and the companion event server remote. Code is a bit legacy (even depends on carbon) and is spread a bit throughout the application (the peripheral interface was not available at that time).

The last mac models featuring the IR receiver (and the companion apple remote) are the MacBook Pro mid 2012 model and the mac mini mid 2012. The last macOS version allowed to run on such equipment is Mojave (10.14), precisely the minimum version required to run Kodi Omega :( .
Since it's not a good policy to simply drop stuff that might still be supported and usable (and used?), I propose to drop this once the macOS minimum requirement is bumped - rendering the last devices featuring the IR remote obsolete for Kodi. I honestly doubt we still have any users using such equipment for Kodi usage but you never know - this might even be easily (or already) supported in peripheral.joystick - I don't have any hardware to confirm.
Recent macs need some external usb IR receivers to still use those remotes (plus the required adaptation software - e.g. flirc or equivalent) so this doesn't really make sense for recent macs (especially those with apple silicon).

@fuzzard would be nice to have your review as our main cmake expert (pretty much copy pasta from the optical implementation)

## Motivation and context
While I'd love to simply remove XBMCHelper (see footprint of the removal in https://github.com/xbmc/xbmc/pull/23580) it might still make sense for x86 macOS builds. It doesn't make sense for arm64/Apple Silicon since the minimum target is 11.0 (big sur). This allow us to save build time and space.

## How has this been tested?
Compiled on arm64 with and without the `ENABLE_XBMCHELPER` defined. Checked the target is included and the settings shown if true, false otherwise.

## What is the effect on users?
None, this can't be used on any device featuring an apple silicon processor.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
