### PR TITLE
[Windows] improve GetAdapterDesc() - return struct by value

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -333,12 +333,10 @@ bool CContext::CreateContext()
                            D3D11_SDK_VERSION, &pD3DDevice, &d3dFeatureLevel, &pD3DDeviceContext);
     if (SUCCEEDED(hr))
     {
-      DXGI_ADAPTER_DESC aDesc;
-      DX::DeviceResources::Get()->GetAdapter()->GetDesc(&aDesc);
-
-      CLog::LogF(LOGINFO, "device for decoding created on adapter '{}' with {}",
-                 KODI::PLATFORM::WINDOWS::FromW(aDesc.Description),
-                 DX::GetFeatureLevelDescription(d3dFeatureLevel));
+      CLog::LogF(
+          LOGINFO, "device for decoding created on adapter '{}' with {}",
+          KODI::PLATFORM::WINDOWS::FromW(DX::DeviceResources::Get()->GetAdapterDesc().Description),
+          DX::GetFeatureLevelDescription(d3dFeatureLevel));
 
 #ifdef _DEBUG
       if (FAILED(pD3DDevice.As(&m_d3d11Debug)))
@@ -705,8 +703,7 @@ bool CContext::Reset()
 {
   if (Check())
   {
-    DXGI_ADAPTER_DESC appDesc = {};
-    DX::DeviceResources::Get()->GetAdapterDesc(&appDesc);
+    const DXGI_ADAPTER_DESC appDesc = DX::DeviceResources::Get()->GetAdapterDesc();
 
     ComPtr<IDXGIDevice> ctxDevice;
     ComPtr<IDXGIAdapter> ctxAdapter;
@@ -1093,8 +1090,7 @@ static bool CheckH264L41(AVCodecContext* avctx)
 
 static bool IsL41LimitedATI()
 {
-  DXGI_ADAPTER_DESC AIdentifier = {};
-  DX::DeviceResources::Get()->GetAdapterDesc(&AIdentifier);
+  const DXGI_ADAPTER_DESC AIdentifier = DX::DeviceResources::Get()->GetAdapterDesc();
 
   if (AIdentifier.VendorId == PCIV_AMD)
   {
@@ -1110,8 +1106,7 @@ static bool IsL41LimitedATI()
 static bool HasVP3WidthBug(AVCodecContext* avctx)
 {
   // Some nVidia VP3 hardware cannot do certain macroblock widths
-  DXGI_ADAPTER_DESC AIdentifier = {};
-  DX::DeviceResources::Get()->GetAdapterDesc(&AIdentifier);
+  const DXGI_ADAPTER_DESC AIdentifier = DX::DeviceResources::Get()->GetAdapterDesc();
 
   if (AIdentifier.VendorId == PCIV_NVIDIA &&
       !CDVDCodecUtils::IsVP3CompatibleWidth(avctx->coded_width))
@@ -1126,8 +1121,8 @@ static bool HasVP3WidthBug(AVCodecContext* avctx)
 
 static bool HasATIMP2Bug(AVCodecContext* avctx)
 {
-  DXGI_ADAPTER_DESC AIdentifier = {};
-  DX::DeviceResources::Get()->GetAdapterDesc(&AIdentifier);
+  const DXGI_ADAPTER_DESC AIdentifier = DX::DeviceResources::Get()->GetAdapterDesc();
+
   if (AIdentifier.VendorId != PCIV_AMD)
     return false;
 
@@ -1141,8 +1136,7 @@ static bool HasATIMP2Bug(AVCodecContext* avctx)
 
 static bool HasAMDH264SDiBug(AVCodecContext* avctx)
 {
-  DXGI_ADAPTER_DESC AIdentifier = {};
-  DX::DeviceResources::Get()->GetAdapterDesc(&AIdentifier);
+  const DXGI_ADAPTER_DESC AIdentifier = DX::DeviceResources::Get()->GetAdapterDesc();
 
   if (AIdentifier.VendorId != PCIV_AMD)
     return false;
@@ -1245,8 +1239,7 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, enum AVPixel
   m_refs = 2 + m_shared; // 1 decode + 1 safety + display
   m_surface_alignment = 16;
 
-  DXGI_ADAPTER_DESC ad = {};
-  DX::DeviceResources::Get()->GetAdapterDesc(&ad);
+  const DXGI_ADAPTER_DESC ad = DX::DeviceResources::Get()->GetAdapterDesc();
 
   size_t videoMem = ad.SharedSystemMemory + ad.DedicatedVideoMemory + ad.DedicatedSystemMemory;
   CLog::LogF(LOGINFO, "Total video memory available is {} MB (dedicated = {} MB, shared = {} MB)",

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -185,8 +185,7 @@ bool CProcessorHD::OpenProcessor()
   // AMD/HDR (as of 2023-06-16): processor tone maps by default and modifies high code values
   // We want "passthrough" of the signal and to do our own tone mapping when needed.
   // Disable the functionality by pretending that the display supports all PQ levels (0-10000)
-  DXGI_ADAPTER_DESC ad{};
-  DX::DeviceResources::Get()->GetAdapterDesc(&ad);
+  const DXGI_ADAPTER_DESC ad = DX::DeviceResources::Get()->GetAdapterDesc();
   bool streamIsHDR =
       (m_color_primaries == AVCOL_PRI_BT2020) &&
       (m_color_transfer == AVCOL_TRC_SMPTE2084 || m_color_transfer == AVCOL_TRC_ARIB_STD_B67);
@@ -525,8 +524,7 @@ void CProcessorHD::TryEnableVideoSuperResolution()
   if (!m_pVideoContext || !m_pVideoProcessor)
     return;
 
-  DXGI_ADAPTER_DESC ad{};
-  DX::DeviceResources::Get()->GetAdapterDesc(&ad);
+  const DXGI_ADAPTER_DESC ad = DX::DeviceResources::Get()->GetAdapterDesc();
 
   if (ad.VendorId == PCIV_Intel)
   {

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -131,15 +131,19 @@ void DX::DeviceResources::GetOutput(IDXGIOutput** ppOutput) const
   *ppOutput = pOutput.Detach();
 }
 
-void DX::DeviceResources::GetAdapterDesc(DXGI_ADAPTER_DESC* desc) const
+DXGI_ADAPTER_DESC DX::DeviceResources::GetAdapterDesc() const
 {
+  DXGI_ADAPTER_DESC desc{};
+
   if (m_adapter)
-    m_adapter->GetDesc(desc);
+    m_adapter->GetDesc(&desc);
 
   // GetDesc() returns VendorId == 0 in Xbox however, we need to know that
   // GPU is AMD to apply workarounds in DXVA.cpp CheckCompatibility() same as desktop
   if (CSysInfo::GetWindowsDeviceFamily() == CSysInfo::Xbox)
-    desc->VendorId = PCIV_AMD;
+    desc.VendorId = PCIV_AMD;
+
+  return desc;
 }
 
 void DX::DeviceResources::GetDisplayMode(DXGI_MODE_DESC* mode) const
@@ -620,12 +624,9 @@ void DX::DeviceResources::ResizeBuffers()
 
 // Xbox needs 10 bit swapchain to output true 4K resolution
 #ifdef TARGET_WINDOWS_DESKTOP
-    DXGI_ADAPTER_DESC ad = {};
-    GetAdapterDesc(&ad);
-
     // Some AMD graphics has issues with 10 bit in SDR.
     // Enabled by default only in Intel and NVIDIA with latest drivers/hardware
-    if (m_d3dFeatureLevel < D3D_FEATURE_LEVEL_12_1 || ad.VendorId == PCIV_AMD)
+    if (m_d3dFeatureLevel < D3D_FEATURE_LEVEL_12_1 || GetAdapterDesc().VendorId == PCIV_AMD)
       use10bit = false;
 #endif
 
@@ -1151,8 +1152,7 @@ void DX::DeviceResources::CheckDXVA2SharedDecoderSurfaces()
   if (!m_NV12SharedTexturesSupport)
     return;
 
-  DXGI_ADAPTER_DESC ad = {};
-  GetAdapterDesc(&ad);
+  const DXGI_ADAPTER_DESC ad = GetAdapterDesc();
 
   m_DXVA2SharedDecoderSurfaces =
       ad.VendorId == PCIV_Intel ||
@@ -1174,8 +1174,7 @@ void DX::DeviceResources::CheckDXVA2SharedDecoderSurfaces()
 
 VideoDriverInfo DX::DeviceResources::GetVideoDriverVersion()
 {
-  DXGI_ADAPTER_DESC ad = {};
-  GetAdapterDesc(&ad);
+  const DXGI_ADAPTER_DESC ad = GetAdapterDesc();
 
   VideoDriverInfo driver = CWIN32Util::GetVideoDriverInfo(ad.VendorId, ad.Description);
 
@@ -1311,10 +1310,7 @@ void DX::DeviceResources::SetHdrColorSpace(const DXGI_COLOR_SPACE_TYPE colorSpac
     if (m_usedSwapChain &&
         m_IsTransferPQ != (colorSpace == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020))
     {
-      DXGI_ADAPTER_DESC ad{};
-      GetAdapterDesc(&ad);
-
-      if (ad.VendorId == PCIV_AMD)
+      if (GetAdapterDesc().VendorId == PCIV_AMD)
       {
         // Temporary release, can't hold references during swap chain re-creation
         swapChain3 = nullptr;

--- a/xbmc/rendering/dx/DeviceResources.h
+++ b/xbmc/rendering/dx/DeviceResources.h
@@ -68,7 +68,7 @@ namespace DX
     CD3DTexture& GetBackBuffer() { return m_backBufferTex; }
 
     void GetOutput(IDXGIOutput** ppOutput) const;
-    void GetAdapterDesc(DXGI_ADAPTER_DESC *desc) const;
+    DXGI_ADAPTER_DESC GetAdapterDesc() const;
     void GetDisplayMode(DXGI_MODE_DESC *mode) const;
 
     D3D11_VIEWPORT GetScreenViewport() const { return m_screenViewport; }

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -88,8 +88,7 @@ bool CRenderSystemDX::InitRenderSystem()
   CPoint camPoint = { outputSize.Width * 0.5f, outputSize.Height * 0.5f };
   SetCameraPosition(camPoint, outputSize.Width, outputSize.Height);
 
-  DXGI_ADAPTER_DESC AIdentifier = {};
-  m_deviceResources->GetAdapterDesc(&AIdentifier);
+  const DXGI_ADAPTER_DESC AIdentifier = m_deviceResources->GetAdapterDesc();
   m_RenderRenderer = KODI::PLATFORM::WINDOWS::FromW(AIdentifier.Description);
   uint32_t version = 0;
   for (uint32_t decimal = m_deviceResources->GetDeviceFeatureLevel() >> 8, round = 0; decimal > 0; decimal >>= 4, ++round)


### PR DESCRIPTION
## Description
improve `GetAdapterDesc()` - return struct by value

## Motivation and context
Code more simple and optimized

In some places allows use `GetAdapterDesc().VendorId` inline

## How has this been tested?
Windows x64

## What is the effect on users?
nothing

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
