### PR TITLE
[Windows] refactor 'streamIsHDR' condition to simplify code/remove static_cast

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -76,10 +76,9 @@ protected:
   ComPtr<ID3D11VideoProcessor> m_pVideoProcessor;
   std::shared_ptr<CEnumeratorHD> m_enumerator;
 
-  AVColorPrimaries m_color_primaries{AVCOL_PRI_UNSPECIFIED};
-  AVColorTransferCharacteristic m_color_transfer{AVCOL_TRC_UNSPECIFIED};
   ProcessorCapabilities m_procCaps;
 
+  bool m_streamIsHDR{false};
   bool m_superResolutionEnabled{false};
   ProcessorConversion m_conversion;
   bool m_isValidConversion{false};

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
@@ -136,6 +136,8 @@ public:
   static DXGI_FORMAT GetDXGIFormat(CVideoBuffer* videoBuffer);
   static AVPixelFormat GetAVFormat(DXGI_FORMAT dxgi_format);
   static DXGI_HDR_METADATA_HDR10 GetDXGIHDR10MetaData(CRenderBuffer* rb);
+  static bool StreamIsHDR(CRenderBuffer* buffer);
+  static bool StreamIsHDR(const VideoPicture& picture);
 
 protected:
   explicit CRendererBase(CVideoSettings& videoSettings);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
@@ -51,17 +51,16 @@ private:
   /*!
    * \brief Choose the best available conversion for the given source and output constraints
    * \param conversions list of supported conversions
-   * \param picture information about the source
-   * \param tryVSR yes/no favor a conversion that enables Video Super Resolution scaling
-   * \return 
+   * \param picture information about the source, optional (pass {} if not used)
+   * \param buffer pointer to render buffer, optional (pass nullptr if not used)
+   * \return chosen conversion
    */
   DXVA::ProcessorConversion ChooseConversion(const DXVA::ProcessorConversions& conversions,
-                                             unsigned int sourceBits,
-                                             AVColorTransferCharacteristic colorTransfer) const;
+                                             const VideoPicture& picture,
+                                             CRenderBuffer* buffer) const;
 
   std::unique_ptr<DXVA::CProcessorHD> m_processor;
   std::shared_ptr<DXVA::CEnumeratorHD> m_enumerator;
-  DXGI_FORMAT m_intermediateTargetFormat{DXGI_FORMAT_UNKNOWN};
   DXVA::ProcessorConversion m_conversion;
   DXVA::SupportedConversionsArgs m_conversionsArgs;
   bool m_tryVSR{false};

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererShaders.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererShaders.cpp
@@ -212,8 +212,7 @@ DXGI_FORMAT CRendererShaders::CalcIntermediateTargetFormat(const VideoPicture& p
     return format;
 
   // Preserve HDR precision
-  if (picture.colorBits > 8 && (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
-                                picture.color_transfer == AVCOL_TRC_ARIB_STD_B67))
+  if (picture.colorBits > 8 && StreamIsHDR(picture))
   {
     UINT reqSupport{D3D11_FORMAT_SUPPORT_SHADER_SAMPLE | D3D11_FORMAT_SUPPORT_RENDER_TARGET};
 


### PR DESCRIPTION
## Description
Refactor 'streamIsHDR' condition to simplify code/remove static_cast

## Motivation and context

- Code simplification and use same `StreamIsHDR` condition in all places
- Remove some `static_cast<AVColorTransferCharacteristic>`
- Remove redundant variable `m_intermediateTargetFormat`
- No functional changes

## How has this been tested?
Windows x64

## What is the effect on users?
none

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
