### PR TITLE
[macos] Remove unneeded include from CApp

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -153,7 +153,6 @@
 #endif
 
 #ifdef TARGET_DARWIN_OSX
-#include "platform/darwin/osx/CocoaInterface.h"
 #ifdef HAS_XBMCHELPER
 #include "platform/darwin/osx/XBMCHelper.h"
 #endif


### PR DESCRIPTION
## Description
Nothing fancy, just removes one unused include from CApp - might have been lost on a previous refactor.
I've built and runtime test it ok.
