### PR TITLE
[Android] MediaCodec: Add support for AV1 Dolby Vision codec selection

### DIFF
--- a/xbmc/windowing/android/AndroidUtils.cpp
+++ b/xbmc/windowing/android/AndroidUtils.cpp
@@ -438,3 +438,14 @@ bool CAndroidUtils::SupportsMediaCodecMimeType(const std::string& mimeType)
 
   return false;
 }
+
+std::pair<bool, bool> CAndroidUtils::GetDolbyVisionCapabilities()
+{
+  const bool displaySupportsDovi = GetDisplayHDRCapabilities().SupportsDolbyVision();
+  const bool mediaCodecSupportsDovi = SupportsMediaCodecMimeType("video/dolby-vision");
+
+  CLog::Log(LOGDEBUG, "CAndroidUtils::GetDolbyVisionCapabilities Display: {}, MediaCodec: {}",
+            displaySupportsDovi, mediaCodecSupportsDovi);
+
+  return std::make_pair(displaySupportsDovi, mediaCodecSupportsDovi);
+}

--- a/xbmc/windowing/android/AndroidUtils.h
+++ b/xbmc/windowing/android/AndroidUtils.h
@@ -46,6 +46,7 @@ public:
 
   static std::vector<int> GetDisplaySupportedHdrTypes();
   static CHDRCapabilities GetDisplayHDRCapabilities();
+  static std::pair<bool, bool> GetDolbyVisionCapabilities();
 
 protected:
   mutable int m_width;


### PR DESCRIPTION
## Description
For AV1 files with Dolby Vision stream side data, the profile must be specified as the mime type is not enough to query the correct MediaCodec codec.

Also, some devices support AV1 Dolby Vision on API version < 30, so we should attempt to use the profile constant regardless of the API version.

The changes bring support for AV1 Dolby Vision on devices that support it.

## Motivation and context
Being able to play Dolby Vision AV1 files.

## How has this been tested?
Runtime tested on Amazon FireTV Stick 4K Max.

Example of codec selection log: [kodi.txt](https://github.com/xbmc/xbmc/files/12284519/kodi.txt)

## What is the effect on users?
Should allow Dolby Vision playback in AV1 files.
No negative effect for existing behaviours.

Unfortunately `CAndroidUtils::SupportsMediaCodecMimeType("video/dolby-vision")` would likely always return support for HEVC codec, but I'm not sure if it's worth adding a function to also check if the profile is supported prior to setting the mime type.
As that's what the codec testing code already does, except it can't fallback to another mime type.
It's possible that playback of Dolby Vision in AV1 might not fallback to a HW decoder if MediaCodec only supports Dolby Vision in HEVC.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
