### PR TITLE
[videoplayer] use ffmpeg types in VideoPicture

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
@@ -309,12 +309,12 @@ CDVDVideoCodec::VCReturn CAddonVideoCodec::GetPicture(VideoPicture* pVideoPictur
     pVideoPicture->pts = static_cast<double>(picture.pts);
     pVideoPicture->dts = DVD_NOPTS_VALUE;
     pVideoPicture->iFlags = 0;
-    pVideoPicture->chroma_position = 0;
+    pVideoPicture->chroma_position = AVCHROMA_LOC_UNSPECIFIED;
     pVideoPicture->colorBits = GetColorBitsFromVideoFormat(picture.videoFormat);
     pVideoPicture->color_primaries = AVColorPrimaries::AVCOL_PRI_UNSPECIFIED;
     pVideoPicture->color_range = 0;
     pVideoPicture->color_space = AVCOL_SPC_UNSPECIFIED;
-    pVideoPicture->color_transfer = 0;
+    pVideoPicture->color_transfer = AVCOL_TRC_UNSPECIFIED;
     pVideoPicture->hasDisplayMetadata = false;
     pVideoPicture->hasLightMetadata = false;
     pVideoPicture->iDuration = 0;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.cpp
@@ -40,9 +40,9 @@ void VideoPicture::Reset()
   iFrameType = 0;
   color_space = AVCOL_SPC_UNSPECIFIED;
   color_range = 0;
-  chroma_position = 0;
+  chroma_position = AVCHROMA_LOC_UNSPECIFIED;
   color_primaries = AVColorPrimaries::AVCOL_PRI_UNSPECIFIED;
-  color_transfer = 0;
+  color_transfer = AVCOL_TRC_UNSPECIFIED;
   colorBits = 8;
   stereoMode.clear();
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -50,11 +50,11 @@ public:
   double iRepeatPicture;
   double iDuration;
   unsigned int iFrameType         : 4;  //< see defines above // 1->I, 2->P, 3->B, 0->Undef
-  unsigned int color_space;
+  AVColorSpace color_space;
   unsigned int color_range        : 1;  //< 1 indicate if we have a full range of color
-  unsigned int chroma_position;
-  unsigned int color_primaries;
-  unsigned int color_transfer;
+  AVChromaLocation chroma_position;
+  AVColorPrimaries color_primaries;
+  AVColorTransferCharacteristic color_transfer;
   unsigned int colorBits = 8;
   std::string stereoMode;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
@@ -128,9 +128,9 @@ struct SupportedConversionsArgs
 
   SupportedConversionsArgs(const VideoPicture& picture, bool isHdrOutput)
   {
-    m_colorPrimaries = static_cast<AVColorPrimaries>(picture.color_primaries);
-    m_colorSpace = static_cast<AVColorSpace>(picture.color_space);
-    m_colorTransfer = static_cast<AVColorTransferCharacteristic>(picture.color_transfer);
+    m_colorPrimaries = picture.color_primaries;
+    m_colorSpace = picture.color_space;
+    m_colorTransfer = picture.color_transfer;
     m_fullRange = picture.color_range == 1;
     m_hdrOutput = isHdrOutput;
   }
@@ -165,11 +165,11 @@ struct DXGIColorSpaceArgs
 
   DXGIColorSpaceArgs(const VideoPicture& picture)
   {
-    primaries = static_cast<AVColorPrimaries>(picture.color_primaries);
-    color_space = static_cast<AVColorSpace>(picture.color_space);
-    color_transfer = static_cast<AVColorTransferCharacteristic>(picture.color_transfer);
+    primaries = picture.color_primaries;
+    color_space = picture.color_space;
+    color_transfer = picture.color_transfer;
     full_range = picture.color_range == 1;
-    chroma_location = static_cast<AVChromaLocation>(picture.chroma_position);
+    chroma_location = picture.chroma_position;
   }
 
   DXGIColorSpaceArgs(AVColorPrimaries primaries,

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -132,8 +132,8 @@ bool CProcessorHD::Open(const VideoPicture& picture,
 
   std::unique_lock<CCriticalSection> lock(m_section);
 
-  m_color_primaries = static_cast<AVColorPrimaries>(picture.color_primaries);
-  m_color_transfer = static_cast<AVColorTransferCharacteristic>(picture.color_transfer);
+  m_color_primaries = picture.color_primaries;
+  m_color_transfer = picture.color_transfer;
   m_enumerator = enumerator;
 
   if (!InitProcessor())

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -210,8 +210,7 @@ bool CLinuxRendererGL::Configure(const VideoPicture &picture, float fps, unsigne
   m_iFlags = GetFlagsChromaPosition(picture.chroma_position) |
              GetFlagsStereoMode(picture.stereoMode);
 
-  m_srcPrimaries = GetSrcPrimaries(static_cast<AVColorPrimaries>(picture.color_primaries),
-                                   picture.iWidth, picture.iHeight);
+  m_srcPrimaries = GetSrcPrimaries(picture.color_primaries, picture.iWidth, picture.iHeight);
   m_toneMap = false;
 
   // Calculate the input frame aspect ratio.
@@ -273,8 +272,8 @@ void CLinuxRendererGL::AddVideoPicture(const VideoPicture &picture, int index)
   buf.videoBuffer = picture.videoBuffer;
   buf.videoBuffer->Acquire();
   buf.loaded = false;
-  buf.m_srcPrimaries = static_cast<AVColorPrimaries>(picture.color_primaries);
-  buf.m_srcColSpace = static_cast<AVColorSpace>(picture.color_space);
+  buf.m_srcPrimaries = picture.color_primaries;
+  buf.m_srcColSpace = picture.color_space;
   buf.m_srcFullRange = picture.color_range == 1;
   buf.m_srcBits = picture.colorBits;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -114,8 +114,7 @@ bool CLinuxRendererGLES::Configure(const VideoPicture &picture, float fps, unsig
   m_sourceHeight = picture.iHeight;
   m_renderOrientation = orientation;
 
-  m_srcPrimaries = GetSrcPrimaries(static_cast<AVColorPrimaries>(picture.color_primaries),
-                                   picture.iWidth, picture.iHeight);
+  m_srcPrimaries = GetSrcPrimaries(picture.color_primaries, picture.iWidth, picture.iHeight);
   m_toneMap = false;
 
   // Calculate the input frame aspect ratio.
@@ -169,8 +168,8 @@ void CLinuxRendererGLES::AddVideoPicture(const VideoPicture &picture, int index)
   buf.videoBuffer = picture.videoBuffer;
   buf.videoBuffer->Acquire();
   buf.loaded = false;
-  buf.m_srcPrimaries = static_cast<AVColorPrimaries>(picture.color_primaries);
-  buf.m_srcColSpace = static_cast<AVColorSpace>(picture.color_space);
+  buf.m_srcPrimaries = picture.color_primaries;
+  buf.m_srcColSpace = picture.color_space;
   buf.m_srcFullRange = picture.color_range == 1;
   buf.m_srcBits = picture.colorBits;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
@@ -30,9 +30,9 @@ void CRenderBuffer::AppendPicture(const VideoPicture& picture)
   videoBuffer->Acquire();
 
   pictureFlags = picture.iFlags;
-  primaries = static_cast<AVColorPrimaries>(picture.color_primaries);
-  color_space = static_cast<AVColorSpace>(picture.color_space);
-  color_transfer = static_cast<AVColorTransferCharacteristic>(picture.color_transfer);
+  primaries = picture.color_primaries;
+  color_space = picture.color_space;
+  color_transfer = picture.color_transfer;
   full_range = picture.color_range == 1;
   bits = picture.colorBits;
   stereoMode = picture.stereoMode;
@@ -476,13 +476,8 @@ void CRendererBase::CheckVideoParameters()
     OnOutputReset();
   }
 
-  if (m_cmsOn && !m_lutIsLoading)
-  {
-    const AVColorPrimaries color_primaries = static_cast<AVColorPrimaries>(buf->primaries);
-
-    if (!m_colorManager->CheckConfiguration(m_cmsToken, color_primaries))
-      OnCMSConfigChanged(color_primaries);
-  }
+  if (m_cmsOn && !m_lutIsLoading && !m_colorManager->CheckConfiguration(m_cmsToken, buf->primaries))
+    OnCMSConfigChanged(buf->primaries);
 }
 
 DXGI_FORMAT CRendererBase::GetDXGIFormat(const VideoPicture& picture)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
@@ -135,8 +135,7 @@ bool CRendererDXVA::Configure(const VideoPicture& picture, float fps, unsigned o
       if (!conversions.empty())
       {
         const ProcessorConversion chosenConversion =
-            ChooseConversion(conversions, picture.colorBits,
-                             static_cast<AVColorTransferCharacteristic>(picture.color_transfer));
+            ChooseConversion(conversions, picture.colorBits, picture.color_transfer);
         m_intermediateTargetFormat = chosenConversion.m_outputFormat;
         m_conversion = chosenConversion;
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Use the ffmpeg types `AVColorSpace`, `AVChromaLocation`, `AVColorPrimaries` and `AVColorTransferCharacteristic` instead of `unsigned int` in `VideoPicture`, and remove the now unnecessary casts.

No change for InputStream, which already exposes its own enums (synchronized with ffmpeg enums) to clients and shouldn't be impacted.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Stronger typing, remove type casts in renderers, consistency with other fields of VideoPicture.

Maybe `unsigned int` was used at the time with the idea of building a ffmpeg-free Kodi one day but the work was only partially done and that didn't happen.

Currently code is just casting back and forth with the assumption that the values of the ffmpeg enums and Kodi's unsigned ints are the same.
The approach was not consistently followed over time, some fields of VideoPicture are already using ffmpeg types (AVMasteringDisplayMetadata, AVContentLightMetadata, AVPixelFormat).

For proper ffmpeg-free Kodi, new Kodi enums would be needed (similar to InputStream's), casts/conversion functions,...
It's possible but more work to do (and maintain) than using the ffmpeg types for now, until a need for ffmpeg-free appears.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 10, builds & runs the same, since this "just" removes a few casts.

InputStream testing: there shouldn't be an impact but I'm not a user and not sure how to test, could someone try? 

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
none

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
