### PR TITLE
[Video] propagates HDR info through video chain

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.cpp
@@ -54,6 +54,10 @@ void VideoPicture::Reset()
   hasDisplayMetadata = false;
   hasLightMetadata = false;
 
+  isHdr = false;
+  hdrType = StreamHdrType::HDR_TYPE_NONE;
+  pixelFormat = AVPixelFormat::AV_PIX_FMT_NONE;
+
   iWidth = 0;
   iHeight = 0;
   iDisplayWidth = 0;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -68,7 +68,9 @@ public:
   bool hasLightMetadata = false;
   AVContentLightMetadata lightMetadata;
 
-  AVPixelFormat pixelFormat; //< source pixel format
+  bool isHdr{false}; //< true if source is HDR (hdrType != HDR_TYPE_NONE)
+  StreamHdrType hdrType{StreamHdrType::HDR_TYPE_NONE}; //< HDR type enum
+  AVPixelFormat pixelFormat{AVPixelFormat::AV_PIX_FMT_NONE}; //< source pixel format
 
   unsigned int iWidth;
   unsigned int iHeight;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -1052,6 +1052,9 @@ bool CDVDVideoCodecFFmpeg::GetPictureCommon(VideoPicture* pVideoPicture)
   else
     pVideoPicture->color_range = m_hints.colorRange == AVCOL_RANGE_JPEG ? 1 : 0;
 
+  pVideoPicture->hdrType = m_hints.hdrType;
+  pVideoPicture->isHdr = (m_hints.hdrType != StreamHdrType::HDR_TYPE_NONE);
+
   //! @todo: ffmpeg doesn't seem like they know how they want to handle this.
   // av_frame_get_qp_table is deprecated but there doesn't seem to be a valid
   // replacement. the following is basically what av_frame_get_qp_table does

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -192,7 +192,7 @@ bool CProcessorHD::OpenProcessor()
   }
 
   // Output background color (black)
-  D3D11_VIDEO_COLOR color;
+  D3D11_VIDEO_COLOR color{};
   color.YCbCr = { 0.0625f, 0.5f, 0.5f, 1.0f }; // black color
   m_pVideoContext->VideoProcessorSetOutputBackgroundColor(m_pVideoProcessor.Get(), TRUE, &color);
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -34,7 +34,7 @@ public:
  ~CProcessorHD();
 
   void UnInit();
-  bool Open(const VideoPicture& picture, std::shared_ptr<DXVA::CEnumeratorHD> enumerator);
+  bool Open(bool streamIsHDR, std::shared_ptr<DXVA::CEnumeratorHD> enumerator);
   void Close();
   bool Render(CRect src, CRect dst, ID3D11Resource* target, CRenderBuffer **views, DWORD flags, UINT frameIdx, UINT rotation, float contrast, float brightness);
   uint8_t PastRefs() const { return std::min(m_procCaps.m_rateCaps.PastFrames, 4u); }
@@ -85,10 +85,9 @@ protected:
   ComPtr<ID3D11VideoProcessor> m_pVideoProcessor;
   std::shared_ptr<CEnumeratorHD> m_enumerator;
 
-  AVColorPrimaries m_color_primaries{AVCOL_PRI_UNSPECIFIED};
-  AVColorTransferCharacteristic m_color_transfer{AVCOL_TRC_UNSPECIFIED};
   ProcessorCapabilities m_procCaps;
 
+  bool m_streamIsHDR{false};
   bool m_superResolutionEnabled{false};
   ProcessorConversion m_conversion;
   bool m_isValidConversion{false};

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -37,7 +37,7 @@ public:
   bool Open(bool streamIsHDR, std::shared_ptr<DXVA::CEnumeratorHD> enumerator);
   void Close();
   bool Render(CRect src, CRect dst, ID3D11Resource* target, CRenderBuffer **views, DWORD flags, UINT frameIdx, UINT rotation, float contrast, float brightness);
-  uint8_t PastRefs() const { return std::min(m_procCaps.m_rateCaps.PastFrames, 4u); }
+  UINT PastRefs() const { return std::min(m_procCaps.m_rateCaps.PastFrames, 4u); }
 
   /*!
    * \brief Configure the processor for the provided conversion.

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
@@ -87,6 +87,7 @@ public:
   bool hasLightMetadata = false;
   AVMasteringDisplayMetadata displayMetadata = {};
   AVContentLightMetadata lightMetadata = {};
+  bool isHdr{false};
   std::string stereoMode;
   uint64_t frameIdx = 0;
 
@@ -155,7 +156,7 @@ protected:
    * \param picture description of the source
    * \return true: intent to render as HDR, false: intent to render as SDR
    */
-  static bool IntendToRenderAsHDR(const VideoPicture& picture);
+  static bool IntendToRenderAsHDR(bool streamIsHDR);
   /*!
    * \brief Call after rendering has started to find out if the output is configured as SDR or HDR.
    * \return true: HDR output, false: SDR output

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
@@ -135,10 +135,7 @@ bool CRendererDXVA::Configure(const VideoPicture& picture, float fps, unsigned o
 
       if (!conversions.empty())
       {
-        const ProcessorConversion chosenConversion =
-            ChooseConversion(conversions, picture.colorBits, picture.color_transfer);
-        m_intermediateTargetFormat = chosenConversion.m_outputFormat;
-        m_conversion = chosenConversion;
+        m_conversion = ChooseConversion(conversions, picture.colorBits, picture.color_transfer);
 
         CLog::LogF(LOGINFO, "chosen conversion: {}", m_conversion.ToString());
 
@@ -200,8 +197,6 @@ void CRendererDXVA::CheckVideoParameters()
         CLog::LogF(LOGINFO, "new conversion: {}", conversion.ToString());
 
         m_processor->SetConversion(conversion);
-        m_intermediateTargetFormat = conversion.m_outputFormat;
-
         m_conversion = conversion;
       }
       m_conversionsArgs = args;
@@ -210,7 +205,7 @@ void CRendererDXVA::CheckVideoParameters()
 
   CreateIntermediateTarget(HasHQScaler() ? m_sourceWidth : m_viewWidth,
                            HasHQScaler() ? m_sourceHeight : m_viewHeight, false,
-                           m_intermediateTargetFormat);
+                           m_conversion.m_outputFormat);
 }
 
 void CRendererDXVA::RenderImpl(CD3DTexture& target, CRect& sourceRect, CPoint(&destPoints)[4], uint32_t flags)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
@@ -59,7 +59,7 @@ void CRendererDXVA::GetWeight(std::map<RenderMethod, int>& weights, const VideoP
   CEnumeratorHD enumerator;
   enumerator.Open(picture.iWidth, picture.iHeight, dxgi_format);
 
-  if (enumerator.SupportedConversions({picture, IntendToRenderAsHDR(picture)}).empty())
+  if (enumerator.SupportedConversions({picture, IntendToRenderAsHDR(picture.isHdr)}).empty())
   {
     CLog::LogF(LOGWARNING, "DXVA will not be used.");
     return;
@@ -128,10 +128,11 @@ bool CRendererDXVA::Configure(const VideoPicture& picture, float fps, unsigned o
             dxgi_format, CEnumeratorHD::AvToDxgiColorSpace(DXVA::DXGIColorSpaceArgs(picture)));
       }
 
-      m_conversionsArgs = SupportedConversionsArgs{picture, IntendToRenderAsHDR(picture)};
+      m_conversionsArgs = SupportedConversionsArgs{picture, IntendToRenderAsHDR(picture.isHdr)};
 
       const ProcessorConversions conversions =
           m_enumerator->SupportedConversions(m_conversionsArgs);
+
       if (!conversions.empty())
       {
         const ProcessorConversion chosenConversion =
@@ -143,7 +144,9 @@ bool CRendererDXVA::Configure(const VideoPicture& picture, float fps, unsigned o
 
         // create processor
         m_processor = std::make_unique<DXVA::CProcessorHD>();
-        if (m_processor->Open(picture, m_enumerator) && m_processor->SetConversion(m_conversion))
+
+        if (m_processor->Open(picture.isHdr, m_enumerator) &&
+            m_processor->SetConversion(m_conversion))
         {
           if (m_tryVSR)
             m_processor->TryEnableVideoSuperResolution();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
@@ -61,7 +61,6 @@ private:
 
   std::unique_ptr<DXVA::CProcessorHD> m_processor;
   std::shared_ptr<DXVA::CEnumeratorHD> m_enumerator;
-  DXGI_FORMAT m_intermediateTargetFormat{DXGI_FORMAT_UNKNOWN};
   DXVA::ProcessorConversion m_conversion;
   DXVA::SupportedConversionsArgs m_conversionsArgs;
   bool m_tryVSR{false};

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
@@ -56,8 +56,7 @@ private:
    * \return 
    */
   DXVA::ProcessorConversion ChooseConversion(const DXVA::ProcessorConversions& conversions,
-                                             unsigned int sourceBits,
-                                             AVColorTransferCharacteristic colorTransfer) const;
+                                             bool sourceIsHQ) const;
 
   std::unique_ptr<DXVA::CProcessorHD> m_processor;
   std::shared_ptr<DXVA::CEnumeratorHD> m_enumerator;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererShaders.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererShaders.cpp
@@ -211,9 +211,8 @@ DXGI_FORMAT CRendererShaders::CalcIntermediateTargetFormat(const VideoPicture& p
   if (!DX::Windowing()->IsHighPrecisionProcessingSettingEnabled())
     return format;
 
-  // Preserve HDR precision
-  if (picture.colorBits > 8 && (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
-                                picture.color_transfer == AVCOL_TRC_ARIB_STD_B67))
+  // Preserve HDR / 10-bit SDR precision
+  if (picture.colorBits > 8 || picture.isHdr || picture.color_primaries == AVCOL_PRI_BT2020)
   {
     UINT reqSupport{D3D11_FORMAT_SUPPORT_SHADER_SAMPLE | D3D11_FORMAT_SUPPORT_RENDER_TARGET};
 


### PR DESCRIPTION
## Description
[Video] propagates HDR info through video chain

## Motivation and context
This can be used later as better alternative to https://github.com/xbmc/xbmc/pull/23587 for simplify and refactor `streamIsHDR` condition. 

New HDR infos is available in all places where `VideoPicture` is, in all video renderers, etc.

Also seems better alternative as the one mentioned in https://github.com/xbmc/xbmc/pull/23587#issuecomment-1668312251 an is probably the "natural way" as this info is already in:

https://github.com/xbmc/xbmc/blob/ae5c2cc275a4eb0423d732222b2625898e436a93/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp#L2529-L2544

And here:
https://github.com/xbmc/xbmc/blob/ae5c2cc275a4eb0423d732222b2625898e436a93/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp#L1686

Only is need propagate it...


## How has this been tested?
Build Windows x64

## What is the effect on users?
none

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
