### PR TITLE
[input] migrate to tinyxml2

### DIFF
--- a/xbmc/games/controllers/Controller.cpp
+++ b/xbmc/games/controllers/Controller.cpp
@@ -13,11 +13,12 @@
 #include "URL.h"
 #include "addons/addoninfo/AddonType.h"
 #include "games/controllers/input/PhysicalTopology.h"
-#include "utils/XBMCTinyXML.h"
+#include "utils/XBMCTinyXML2.h"
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 
 #include <algorithm>
+#include <cstring>
 
 using namespace KODI;
 using namespace GAME;
@@ -122,16 +123,17 @@ bool CController::LoadLayout(void)
 
     CLog::Log(LOGINFO, "Loading controller layout: {}", CURL::GetRedacted(strLayoutXmlPath));
 
-    CXBMCTinyXML xmlDoc;
+    CXBMCTinyXML2 xmlDoc;
     if (!xmlDoc.LoadFile(strLayoutXmlPath))
     {
-      CLog::Log(LOGDEBUG, "Unable to load file: {} at line {}", xmlDoc.ErrorDesc(),
-                xmlDoc.ErrorRow());
+      CLog::Log(LOGDEBUG, "Unable to load file: {} at line {}", xmlDoc.ErrorStr(),
+                xmlDoc.ErrorLineNum());
       return false;
     }
 
-    TiXmlElement* pRootElement = xmlDoc.RootElement();
-    if (!pRootElement || pRootElement->NoChildren() || pRootElement->ValueStr() != LAYOUT_XML_ROOT)
+    auto* pRootElement = xmlDoc.RootElement();
+    if (pRootElement == nullptr || pRootElement->NoChildren() ||
+        std::strcmp(pRootElement->Value(), LAYOUT_XML_ROOT) != 0)
     {
       CLog::Log(LOGERROR, "Can't find root <{}> tag", LAYOUT_XML_ROOT);
       return false;

--- a/xbmc/games/controllers/ControllerLayout.cpp
+++ b/xbmc/games/controllers/ControllerLayout.cpp
@@ -17,7 +17,10 @@
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 
+#include <cstring>
 #include <sstream>
+
+#include <tinyxml2.h>
 
 using namespace KODI;
 using namespace GAME;
@@ -87,7 +90,7 @@ std::string CControllerLayout::ImagePath(void) const
   return path;
 }
 
-void CControllerLayout::Deserialize(const TiXmlElement* pElement,
+void CControllerLayout::Deserialize(const tinyxml2::XMLElement* pElement,
                                     const CController* controller,
                                     std::vector<CPhysicalFeature>& features)
 {
@@ -116,10 +119,10 @@ void CControllerLayout::Deserialize(const TiXmlElement* pElement,
   if (!image.empty())
     m_strImage = image;
 
-  for (const TiXmlElement* pChild = pElement->FirstChildElement(); pChild != nullptr;
+  for (const auto* pChild = pElement->FirstChildElement(); pChild != nullptr;
        pChild = pChild->NextSiblingElement())
   {
-    if (pChild->ValueStr() == LAYOUT_XML_ELM_CATEGORY)
+    if (std::strcmp(pChild->Value(), LAYOUT_XML_ELM_CATEGORY) == 0)
     {
       // Category
       std::string strCategory = XMLUtils::GetAttribute(pChild, LAYOUT_XML_ATTR_CATEGORY_NAME);
@@ -135,7 +138,7 @@ void CControllerLayout::Deserialize(const TiXmlElement* pElement,
         std::istringstream(strCategoryLabelId) >> categoryLabelId;
 
       // Features
-      for (const TiXmlElement* pFeature = pChild->FirstChildElement(); pFeature != nullptr;
+      for (const auto* pFeature = pChild->FirstChildElement(); pFeature != nullptr;
            pFeature = pFeature->NextSiblingElement())
       {
         CPhysicalFeature feature;
@@ -144,7 +147,7 @@ void CControllerLayout::Deserialize(const TiXmlElement* pElement,
           features.push_back(feature);
       }
     }
-    else if (pChild->ValueStr() == LAYOUT_XML_ELM_TOPOLOGY)
+    else if (std::strcmp(pChild->Value(), LAYOUT_XML_ELM_TOPOLOGY) == 0)
     {
       // Topology
       CPhysicalTopology topology;
@@ -153,7 +156,7 @@ void CControllerLayout::Deserialize(const TiXmlElement* pElement,
     }
     else
     {
-      CLog::Log(LOGDEBUG, "Ignoring <{}> tag", pChild->ValueStr());
+      CLog::Log(LOGDEBUG, "Ignoring <{}> tag", pChild->Value());
     }
   }
 }

--- a/xbmc/games/controllers/ControllerLayout.h
+++ b/xbmc/games/controllers/ControllerLayout.h
@@ -12,7 +12,10 @@
 #include <string>
 #include <vector>
 
-class TiXmlElement;
+namespace tinyxml2
+{
+class XMLElement;
+}
 
 namespace KODI
 {
@@ -76,7 +79,7 @@ public:
    * \param controller The controller, used to obtain read-only properties
    * \param features The deserialized features, if any
    */
-  void Deserialize(const TiXmlElement* pLayoutElement,
+  void Deserialize(const tinyxml2::XMLElement* pLayoutElement,
                    const CController* controller,
                    std::vector<CPhysicalFeature>& features);
 

--- a/xbmc/games/controllers/input/PhysicalFeature.cpp
+++ b/xbmc/games/controllers/input/PhysicalFeature.cpp
@@ -17,6 +17,8 @@
 
 #include <sstream>
 
+#include <tinyxml2.h>
+
 using namespace KODI;
 using namespace GAME;
 using namespace JOYSTICK;
@@ -74,7 +76,7 @@ std::string CPhysicalFeature::Label() const
   return label;
 }
 
-bool CPhysicalFeature::Deserialize(const TiXmlElement* pElement,
+bool CPhysicalFeature::Deserialize(const tinyxml2::XMLElement* pElement,
                                    const CController* controller,
                                    FEATURE_CATEGORY category,
                                    int categoryLabelId)

--- a/xbmc/games/controllers/input/PhysicalFeature.h
+++ b/xbmc/games/controllers/input/PhysicalFeature.h
@@ -14,7 +14,10 @@
 
 #include <string>
 
-class TiXmlElement;
+namespace tinyxml2
+{
+class XMLElement;
+}
 
 namespace KODI
 {
@@ -45,7 +48,7 @@ public:
   JOYSTICK::INPUT_TYPE InputType(void) const { return m_inputType; }
   KEYBOARD::KeySymbol Keycode() const { return m_keycode; }
 
-  bool Deserialize(const TiXmlElement* pElement,
+  bool Deserialize(const tinyxml2::XMLElement* pElement,
                    const CController* controller,
                    JOYSTICK::FEATURE_CATEGORY category,
                    int categoryLabelId);

--- a/xbmc/games/controllers/input/PhysicalTopology.cpp
+++ b/xbmc/games/controllers/input/PhysicalTopology.cpp
@@ -12,7 +12,10 @@
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 
+#include <cstring>
 #include <utility>
+
+#include <tinyxml2.h>
 
 using namespace KODI;
 using namespace GAME;
@@ -28,7 +31,7 @@ void CPhysicalTopology::Reset()
   *this = std::move(defaultTopology);
 }
 
-bool CPhysicalTopology::Deserialize(const TiXmlElement* pElement)
+bool CPhysicalTopology::Deserialize(const tinyxml2::XMLElement* pElement)
 {
   Reset();
 
@@ -37,10 +40,10 @@ bool CPhysicalTopology::Deserialize(const TiXmlElement* pElement)
 
   m_bProvidesInput = (XMLUtils::GetAttribute(pElement, LAYOUT_XML_ATTR_PROVIDES_INPUT) != "false");
 
-  for (const TiXmlElement* pChild = pElement->FirstChildElement(); pChild != nullptr;
+  for (const auto* pChild = pElement->FirstChildElement(); pChild != nullptr;
        pChild = pChild->NextSiblingElement())
   {
-    if (pChild->ValueStr() == LAYOUT_XML_ELM_PORT)
+    if (std::strcmp(pChild->Value(), LAYOUT_XML_ELM_PORT) == 0)
     {
       CPhysicalPort port;
       if (port.Deserialize(pChild))
@@ -48,7 +51,7 @@ bool CPhysicalTopology::Deserialize(const TiXmlElement* pElement)
     }
     else
     {
-      CLog::Log(LOGDEBUG, "Unknown physical topology tag: <{}>", pChild->ValueStr());
+      CLog::Log(LOGDEBUG, "Unknown physical topology tag: <{}>", pChild->Value());
     }
   }
 

--- a/xbmc/games/controllers/input/PhysicalTopology.h
+++ b/xbmc/games/controllers/input/PhysicalTopology.h
@@ -12,7 +12,10 @@
 
 #include <vector>
 
-class TiXmlElement;
+namespace tinyxml2
+{
+class XMLElement;
+}
 
 namespace KODI
 {
@@ -50,7 +53,7 @@ public:
    */
   const std::vector<CPhysicalPort>& Ports() const { return m_ports; }
 
-  bool Deserialize(const TiXmlElement* pElement);
+  bool Deserialize(const tinyxml2::XMLElement* pElement);
 
 private:
   bool m_bProvidesInput = true;

--- a/xbmc/games/ports/input/PhysicalPort.cpp
+++ b/xbmc/games/ports/input/PhysicalPort.cpp
@@ -13,7 +13,10 @@
 #include "utils/log.h"
 
 #include <algorithm>
+#include <cstring>
 #include <utility>
+
+#include <tinyxml2.h>
 
 using namespace KODI;
 using namespace GAME;
@@ -34,7 +37,7 @@ bool CPhysicalPort::IsCompatible(const std::string& controllerId) const
   return std::find(m_accepts.begin(), m_accepts.end(), controllerId) != m_accepts.end();
 }
 
-bool CPhysicalPort::Deserialize(const TiXmlElement* pElement)
+bool CPhysicalPort::Deserialize(const tinyxml2::XMLElement* pElement)
 {
   if (pElement == nullptr)
     return false;
@@ -43,10 +46,10 @@ bool CPhysicalPort::Deserialize(const TiXmlElement* pElement)
 
   m_portId = XMLUtils::GetAttribute(pElement, LAYOUT_XML_ATTR_PORT_ID);
 
-  for (const TiXmlElement* pChild = pElement->FirstChildElement(); pChild != nullptr;
+  for (const auto* pChild = pElement->FirstChildElement(); pChild != nullptr;
        pChild = pChild->NextSiblingElement())
   {
-    if (pChild->ValueStr() == LAYOUT_XML_ELM_ACCEPTS)
+    if (std::strcmp(pChild->Value(), LAYOUT_XML_ELM_ACCEPTS) == 0)
     {
       std::string controller = XMLUtils::GetAttribute(pChild, LAYOUT_XML_ATTR_CONTROLLER);
 
@@ -58,7 +61,7 @@ bool CPhysicalPort::Deserialize(const TiXmlElement* pElement)
     }
     else
     {
-      CLog::Log(LOGDEBUG, "Unknown physical topology port tag: <{}>", pChild->ValueStr());
+      CLog::Log(LOGDEBUG, "Unknown physical topology port tag: <{}>", pChild->Value());
     }
   }
 

--- a/xbmc/games/ports/input/PhysicalPort.h
+++ b/xbmc/games/ports/input/PhysicalPort.h
@@ -11,7 +11,10 @@
 #include <string>
 #include <vector>
 
-class TiXmlElement;
+namespace tinyxml2
+{
+class XMLElement;
+}
 
 namespace KODI
 {
@@ -54,7 +57,7 @@ public:
    */
   bool IsCompatible(const std::string& controllerId) const;
 
-  bool Deserialize(const TiXmlElement* pElement);
+  bool Deserialize(const tinyxml2::XMLElement* pElement);
 
 private:
   std::string m_portId;

--- a/xbmc/games/ports/input/PortManager.h
+++ b/xbmc/games/ports/input/PortManager.h
@@ -14,7 +14,10 @@
 #include <mutex>
 #include <string>
 
-class TiXmlElement;
+namespace tinyxml2
+{
+class XMLElement;
+}
 
 namespace KODI
 {
@@ -41,15 +44,19 @@ public:
   const CControllerTree& GetControllerTree() const { return m_controllerTree; }
 
 private:
-  static void DeserializePorts(const TiXmlElement* pElement, PortVec& ports);
-  static void DeserializePort(const TiXmlElement* pElement, CPortNode& port);
-  static void DeserializeControllers(const TiXmlElement* pElement, ControllerNodeVec& controllers);
-  static void DeserializeController(const TiXmlElement* pElement, CControllerNode& controller);
+  static void DeserializePorts(const tinyxml2::XMLElement* pElement, PortVec& ports);
+  static void DeserializePort(const tinyxml2::XMLElement* pElement, CPortNode& port);
+  static void DeserializeControllers(const tinyxml2::XMLElement* pElement,
+                                     ControllerNodeVec& controllers);
+  static void DeserializeController(const tinyxml2::XMLElement* pElement,
+                                    CControllerNode& controller);
 
-  static void SerializePorts(TiXmlElement& node, const PortVec& ports);
-  static void SerializePort(TiXmlElement& portNode, const CPortNode& port);
-  static void SerializeControllers(TiXmlElement& portNode, const ControllerNodeVec& controllers);
-  static void SerializeController(TiXmlElement& controllerNode, const CControllerNode& controller);
+  static void SerializePorts(tinyxml2::XMLElement& node, const PortVec& ports);
+  static void SerializePort(tinyxml2::XMLElement& portNode, const CPortNode& port);
+  static void SerializeControllers(tinyxml2::XMLElement& portNode,
+                                   const ControllerNodeVec& controllers);
+  static void SerializeController(tinyxml2::XMLElement& controllerNode,
+                                  const CControllerNode& controller);
 
   static bool ConnectController(const std::string& portAddress,
                                 bool connected,

--- a/xbmc/input/ButtonTranslator.h
+++ b/xbmc/input/ButtonTranslator.h
@@ -16,11 +16,15 @@
 #include <string>
 
 class CKey;
-class TiXmlNode;
 class CCustomControllerTranslator;
 class CTouchTranslator;
 class IButtonMapper;
 class IWindowKeymap;
+
+namespace tinyxml2
+{
+class XMLNode;
+}
 
 /// singleton class to map from buttons to actions
 /// Warning: _not_ threadsafe!
@@ -82,7 +86,7 @@ private:
 
   unsigned int GetActionCode(int window, const CKey& key, std::string& strAction) const;
 
-  void MapWindowActions(const TiXmlNode* pWindow, int wWindowID);
+  void MapWindowActions(const tinyxml2::XMLNode* pWindow, int wWindowID);
   void MapAction(uint32_t buttonCode, const std::string& szAction, buttonMap& map);
 
   bool LoadKeymap(const std::string& keymapPath);

--- a/xbmc/input/CustomControllerTranslator.cpp
+++ b/xbmc/input/CustomControllerTranslator.cpp
@@ -11,15 +11,17 @@
 #include "WindowTranslator.h" //! @todo
 #include "input/actions/ActionIDs.h"
 #include "input/actions/ActionTranslator.h"
-#include "utils/XBMCTinyXML.h"
 #include "utils/log.h"
 
-void CCustomControllerTranslator::MapActions(int windowID, const TiXmlNode* pCustomController)
+#include <tinyxml2.h>
+
+void CCustomControllerTranslator::MapActions(int windowID,
+                                             const tinyxml2::XMLNode* pCustomController)
 {
   CustomControllerButtonMap buttonMap;
   std::string controllerName;
 
-  const TiXmlElement* pController = pCustomController->ToElement();
+  const auto* pController = pCustomController->ToElement();
   if (pController != nullptr)
   {
     // Transform loose name to new family, including altnames
@@ -35,15 +37,15 @@ void CCustomControllerTranslator::MapActions(int windowID, const TiXmlNode* pCus
   }
 
   // Parse map
-  const TiXmlElement* pButton = pCustomController->FirstChildElement();
+  const auto* pButton = pCustomController->FirstChildElement();
   int id = 0;
   while (pButton != nullptr)
   {
     std::string action;
     if (!pButton->NoChildren())
-      action = pButton->FirstChild()->ValueStr();
+      action = pButton->FirstChild()->Value();
 
-    if ((pButton->QueryIntAttribute("id", &id) == TIXML_SUCCESS) && id >= 0)
+    if ((pButton->QueryIntAttribute("id", &id) == tinyxml2::XML_SUCCESS) && id >= 0)
     {
       buttonMap[id] = action;
     }

--- a/xbmc/input/CustomControllerTranslator.h
+++ b/xbmc/input/CustomControllerTranslator.h
@@ -13,7 +13,10 @@
 #include <map>
 #include <string>
 
-class TiXmlNode;
+namespace tinyxml2
+{
+class XMLNode;
+}
 
 class CCustomControllerTranslator : public IButtonMapper
 {
@@ -21,7 +24,7 @@ public:
   CCustomControllerTranslator() = default;
 
   // implementation of IButtonMapper
-  void MapActions(int windowID, const TiXmlNode* pDevice) override;
+  void MapActions(int windowID, const tinyxml2::XMLNode* pDevice) override;
   void Clear() override;
 
   bool TranslateCustomControllerString(int windowId,

--- a/xbmc/input/IButtonMapper.h
+++ b/xbmc/input/IButtonMapper.h
@@ -8,7 +8,10 @@
 
 #pragma once
 
-class TiXmlNode;
+namespace tinyxml2
+{
+class XMLNode;
+}
 
 /*!
  * \brief Interface for classes that can map buttons to Kodi actions
@@ -18,7 +21,7 @@ class IButtonMapper
 public:
   virtual ~IButtonMapper() = default;
 
-  virtual void MapActions(int windowId, const TiXmlNode* pDevice) = 0;
+  virtual void MapActions(int windowId, const tinyxml2::XMLNode* pDevice) = 0;
 
   virtual void Clear() = 0;
 };

--- a/xbmc/input/IRTranslator.cpp
+++ b/xbmc/input/IRTranslator.cpp
@@ -15,9 +15,10 @@
 #include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
-#include "utils/XBMCTinyXML.h"
+#include "utils/XBMCTinyXML2.h"
 #include "utils/log.h"
 
+#include <cstring>
 #include <stdlib.h>
 #include <vector>
 
@@ -56,17 +57,20 @@ bool CIRTranslator::LoadIRMap(const std::string& irMapPath)
   StringUtils::ToLower(remoteMapTag);
 
   // Load our xml file, and fill up our mapping tables
-  CXBMCTinyXML xmlDoc;
+  CXBMCTinyXML2 xmlDoc;
 
   // Load the config file
   CLog::Log(LOGINFO, "Loading {}", irMapPath);
   if (!xmlDoc.LoadFile(irMapPath))
   {
-    CLog::Log(LOGERROR, "{}, Line {}\n{}", irMapPath, xmlDoc.ErrorRow(), xmlDoc.ErrorDesc());
+    CLog::Log(LOGERROR, "{}, Line {}\n{}", irMapPath, xmlDoc.ErrorLineNum(), xmlDoc.ErrorStr());
     return false;
   }
 
-  TiXmlElement* pRoot = xmlDoc.RootElement();
+  auto* pRoot = xmlDoc.RootElement();
+  if (pRoot == nullptr)
+    return false;
+
   std::string strValue = pRoot->Value();
   if (strValue != remoteMapTag)
   {
@@ -75,15 +79,15 @@ bool CIRTranslator::LoadIRMap(const std::string& irMapPath)
   }
 
   // Run through our window groups
-  TiXmlNode* pRemote = pRoot->FirstChild();
+  auto* pRemote = pRoot->FirstChild();
   while (pRemote != nullptr)
   {
-    if (pRemote->Type() == TiXmlNode::TINYXML_ELEMENT)
+    if (pRemote->ToElement())
     {
       const char* szRemote = pRemote->Value();
       if (szRemote != nullptr)
       {
-        TiXmlAttribute* pAttr = pRemote->ToElement()->FirstAttribute();
+        auto* pAttr = pRemote->ToElement()->FirstAttribute();
         if (pAttr != nullptr)
           MapRemote(pRemote, pAttr->Value());
       }
@@ -94,7 +98,7 @@ bool CIRTranslator::LoadIRMap(const std::string& irMapPath)
   return true;
 }
 
-void CIRTranslator::MapRemote(TiXmlNode* pRemote, const std::string& szDevice)
+void CIRTranslator::MapRemote(tinyxml2::XMLNode* pRemote, const std::string& szDevice)
 {
   CLog::Log(LOGINFO, "* Adding remote mapping for device '{}'", szDevice);
 
@@ -106,15 +110,15 @@ void CIRTranslator::MapRemote(TiXmlNode* pRemote, const std::string& szDevice)
 
   const std::shared_ptr<IRButtonMap>& buttons = m_irRemotesMap[szDevice];
 
-  TiXmlElement* pButton = pRemote->FirstChildElement();
+  auto* pButton = pRemote->FirstChildElement();
   while (pButton != nullptr)
   {
     if (!pButton->NoChildren())
     {
-      if (pButton->ValueStr() == "altname")
-        remoteNames.push_back(pButton->FirstChild()->ValueStr());
+      if (std::strcmp(pButton->Value(), "altname") == 0)
+        remoteNames.push_back(pButton->FirstChild()->Value());
       else
-        (*buttons)[pButton->FirstChild()->ValueStr()] = pButton->ValueStr();
+        (*buttons)[pButton->FirstChild()->Value()] = pButton->Value();
     }
     pButton = pButton->NextSiblingElement();
   }

--- a/xbmc/input/IRTranslator.h
+++ b/xbmc/input/IRTranslator.h
@@ -12,7 +12,10 @@
 #include <memory>
 #include <string>
 
-class TiXmlNode;
+namespace tinyxml2
+{
+class XMLNode;
+}
 
 class CIRTranslator
 {
@@ -36,7 +39,7 @@ public:
 
 private:
   bool LoadIRMap(const std::string& irMapPath);
-  void MapRemote(TiXmlNode* pRemote, const std::string& szDevice);
+  void MapRemote(tinyxml2::XMLNode* pRemote, const std::string& szDevice);
 
   using IRButtonMap = std::map<std::string, std::string>;
 

--- a/xbmc/input/JoystickMapper.cpp
+++ b/xbmc/input/JoystickMapper.cpp
@@ -14,11 +14,12 @@
 #include "input/joysticks/JoystickTranslator.h"
 #include "input/joysticks/JoystickUtils.h"
 #include "utils/StringUtils.h"
-#include "utils/XBMCTinyXML.h"
 
 #include <algorithm>
 #include <sstream>
 #include <utility>
+
+#include <tinyxml2.h>
 
 using namespace KODI;
 
@@ -27,7 +28,7 @@ using namespace KODI;
 #define JOYSTICK_XML_ATTR_HOLDTIME "holdtime"
 #define JOYSTICK_XML_ATTR_HOTKEY "hotkey"
 
-void CJoystickMapper::MapActions(int windowID, const TiXmlNode* pDevice)
+void CJoystickMapper::MapActions(int windowID, const tinyxml2::XMLNode* pDevice)
 {
   std::string controllerId;
   DeserializeJoystickNode(pDevice, controllerId);
@@ -44,7 +45,7 @@ void CJoystickMapper::MapActions(int windowID, const TiXmlNode* pDevice)
   if (!keymap)
     keymap.reset(new CWindowKeymap(controllerId));
 
-  const TiXmlElement* pButton = pDevice->FirstChildElement();
+  const auto* pButton = pDevice->FirstChildElement();
   while (pButton != nullptr)
   {
     std::string feature;
@@ -92,14 +93,20 @@ std::vector<std::shared_ptr<const IWindowKeymap>> CJoystickMapper::GetJoystickKe
   return keymaps;
 }
 
-void CJoystickMapper::DeserializeJoystickNode(const TiXmlNode* pDevice, std::string& controllerId)
+void CJoystickMapper::DeserializeJoystickNode(const tinyxml2::XMLNode* pDevice,
+                                              std::string& controllerId)
 {
-  const TiXmlElement* deviceElem = pDevice->ToElement();
+  const auto* deviceElem = pDevice->ToElement();
   if (deviceElem != nullptr)
-    deviceElem->QueryValueAttribute(JOYSTICK_XML_NODE_PROFILE, &controllerId);
+  {
+    const char* controller;
+    if (deviceElem->QueryStringAttribute(JOYSTICK_XML_NODE_PROFILE, &controller) ==
+        tinyxml2::XML_SUCCESS)
+      controllerId = controller;
+  }
 }
 
-bool CJoystickMapper::DeserializeButton(const TiXmlElement* pButton,
+bool CJoystickMapper::DeserializeButton(const tinyxml2::XMLElement* pButton,
                                         std::string& feature,
                                         JOYSTICK::ANALOG_STICK_DIRECTION& dir,
                                         unsigned int& holdtimeMs,
@@ -111,7 +118,7 @@ bool CJoystickMapper::DeserializeButton(const TiXmlElement* pButton,
   {
     const char* szAction = nullptr;
 
-    const TiXmlNode* actionNode = pButton->FirstChild();
+    const auto* actionNode = pButton->FirstChild();
     if (actionNode != nullptr)
       szAction = actionNode->Value();
 
@@ -133,8 +140,9 @@ bool CJoystickMapper::DeserializeButton(const TiXmlElement* pButton,
 
     // Process holdtime parameter
     holdtimeMs = 0;
-    std::string strHoldTime;
-    if (pButton->QueryValueAttribute(JOYSTICK_XML_ATTR_HOLDTIME, &strHoldTime) == TIXML_SUCCESS)
+    const char* strHoldTime;
+    if (pButton->QueryStringAttribute(JOYSTICK_XML_ATTR_HOLDTIME, &strHoldTime) ==
+        tinyxml2::XML_SUCCESS)
     {
       std::istringstream ss(strHoldTime);
       ss >> holdtimeMs;
@@ -142,8 +150,9 @@ bool CJoystickMapper::DeserializeButton(const TiXmlElement* pButton,
 
     // Process hotkeys
     hotkeys.clear();
-    std::string strHotkeys;
-    if (pButton->QueryValueAttribute(JOYSTICK_XML_ATTR_HOTKEY, &strHotkeys) == TIXML_SUCCESS)
+    const char* strHotkeys;
+    if (pButton->QueryStringAttribute(JOYSTICK_XML_ATTR_HOTKEY, &strHotkeys) ==
+        tinyxml2::XML_SUCCESS)
     {
       std::vector<std::string> vecHotkeys = StringUtils::Split(strHotkeys, ",");
       for (auto& hotkey : vecHotkeys)

--- a/xbmc/input/JoystickMapper.h
+++ b/xbmc/input/JoystickMapper.h
@@ -18,8 +18,12 @@
 #include <vector>
 
 class IWindowKeymap;
-class TiXmlElement;
-class TiXmlNode;
+
+namespace tinyxml2
+{
+class XMLElement;
+class XMLNode;
+} // namespace tinyxml2
 
 class CJoystickMapper : public IButtonMapper
 {
@@ -28,14 +32,14 @@ public:
   ~CJoystickMapper() override = default;
 
   // implementation of IButtonMapper
-  void MapActions(int windowID, const TiXmlNode* pDevice) override;
+  void MapActions(int windowID, const tinyxml2::XMLNode* pDevice) override;
   void Clear() override;
 
   std::vector<std::shared_ptr<const IWindowKeymap>> GetJoystickKeymaps() const;
 
 private:
-  void DeserializeJoystickNode(const TiXmlNode* pDevice, std::string& controllerId);
-  bool DeserializeButton(const TiXmlElement* pButton,
+  void DeserializeJoystickNode(const tinyxml2::XMLNode* pDevice, std::string& controllerId);
+  bool DeserializeButton(const tinyxml2::XMLElement* pButton,
                          std::string& feature,
                          KODI::JOYSTICK::ANALOG_STICK_DIRECTION& dir,
                          unsigned int& holdtimeMs,

--- a/xbmc/input/KeyboardLayout.cpp
+++ b/xbmc/input/KeyboardLayout.cpp
@@ -12,18 +12,19 @@
 #include "guilib/LocalizeStrings.h"
 #include "utils/CharsetConverter.h"
 #include "utils/StringUtils.h"
-#include "utils/XBMCTinyXML.h"
 #include "utils/log.h"
 
 #include <algorithm>
 #include <set>
 
+#include <tinyxml2.h>
+
 CKeyboardLayout::~CKeyboardLayout() = default;
 
-bool CKeyboardLayout::Load(const TiXmlElement* element)
+bool CKeyboardLayout::Load(const tinyxml2::XMLElement* element)
 {
   const char* language = element->Attribute("language");
-  if (language == NULL)
+  if (language == nullptr)
   {
     CLog::Log(LOGWARNING, "CKeyboardLayout: invalid \"language\" attribute");
     return false;
@@ -37,7 +38,7 @@ bool CKeyboardLayout::Load(const TiXmlElement* element)
   }
 
   const char* layout = element->Attribute("layout");
-  if (layout == NULL)
+  if (layout == nullptr)
   {
     CLog::Log(LOGWARNING, "CKeyboardLayout: invalid \"layout\" attribute");
     return false;
@@ -50,13 +51,13 @@ bool CKeyboardLayout::Load(const TiXmlElement* element)
     return false;
   }
 
-  const TiXmlElement* keyboard = element->FirstChildElement("keyboard");
+  const auto* keyboard = element->FirstChildElement("keyboard");
   if (element->Attribute("codingtable"))
     m_codingtable = IInputCodingTablePtr(
         CInputCodingTableFactory::CreateCodingTable(element->Attribute("codingtable")));
   else
     m_codingtable = NULL;
-  while (keyboard != NULL)
+  while (keyboard != nullptr)
   {
     // parse modifiers keys
     std::set<unsigned int> modifierKeysSet;
@@ -85,12 +86,12 @@ bool CKeyboardLayout::Load(const TiXmlElement* element)
     }
 
     // parse keyboard rows
-    const TiXmlNode* row = keyboard->FirstChild("row");
-    while (row != NULL)
+    const auto* row = keyboard->FirstChildElement("row");
+    while (row != nullptr)
     {
       if (!row->NoChildren())
       {
-        std::string strRow = row->FirstChild()->ValueStr();
+        std::string strRow = row->FirstChild()->Value();
         std::vector<std::string> chars = BreakCharacters(strRow);
         if (!modifierKeysSet.empty())
         {
@@ -101,7 +102,7 @@ bool CKeyboardLayout::Load(const TiXmlElement* element)
           m_keyboards[ModifierKeyNone].push_back(chars);
       }
 
-      row = row->NextSibling();
+      row = row->NextSiblingElement();
     }
 
     keyboard = keyboard->NextSiblingElement();

--- a/xbmc/input/KeyboardLayout.h
+++ b/xbmc/input/KeyboardLayout.h
@@ -14,7 +14,10 @@
 #include <string>
 #include <vector>
 
-class TiXmlElement;
+namespace tinyxml2
+{
+class XMLElement;
+}
 
 class CKeyboardLayout
 {
@@ -23,7 +26,7 @@ public:
   virtual ~CKeyboardLayout();
   IInputCodingTablePtr GetCodingTable() { return m_codingtable; }
 
-  bool Load(const TiXmlElement* element);
+  bool Load(const tinyxml2::XMLElement* element);
 
   std::string GetIdentifier() const;
   std::string GetName() const;

--- a/xbmc/input/KeyboardLayoutManager.cpp
+++ b/xbmc/input/KeyboardLayoutManager.cpp
@@ -14,10 +14,11 @@
 #include "filesystem/Directory.h"
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingDefinitions.h"
-#include "utils/XBMCTinyXML.h"
+#include "utils/XBMCTinyXML2.h"
 #include "utils/log.h"
 
 #include <algorithm>
+#include <cstring>
 
 #define KEYBOARD_LAYOUTS_PATH "special://xbmc/system/keyboardlayouts"
 
@@ -60,30 +61,30 @@ bool CKeyboardLayoutManager::Load(const std::string& path /* = "" */)
     if (layoutPath.empty())
       continue;
 
-    CXBMCTinyXML xmlDoc;
+    CXBMCTinyXML2 xmlDoc;
     if (!xmlDoc.LoadFile(layoutPath))
     {
       CLog::Log(LOGWARNING, "CKeyboardLayoutManager: unable to open {}", layoutPath);
       continue;
     }
 
-    const TiXmlElement* rootElement = xmlDoc.RootElement();
-    if (rootElement == NULL)
+    const auto* rootElement = xmlDoc.RootElement();
+    if (rootElement == nullptr)
     {
       CLog::Log(LOGWARNING, "CKeyboardLayoutManager: missing or invalid XML root element in {}",
                 layoutPath);
       continue;
     }
 
-    if (rootElement->ValueStr() != "keyboardlayouts")
+    if (std::strcmp(rootElement->Value(), "keyboardlayouts") != 0)
     {
       CLog::Log(LOGWARNING, "CKeyboardLayoutManager: unexpected XML root element \"{}\" in {}",
                 rootElement->Value(), layoutPath);
       continue;
     }
 
-    const TiXmlElement* layoutElement = rootElement->FirstChildElement("layout");
-    while (layoutElement != NULL)
+    const auto* layoutElement = rootElement->FirstChildElement("layout");
+    while (layoutElement != nullptr)
     {
       CKeyboardLayout layout;
       if (!layout.Load(layoutElement))

--- a/xbmc/input/KeyboardTranslator.cpp
+++ b/xbmc/input/KeyboardTranslator.cpp
@@ -11,13 +11,14 @@
 #include "Key.h"
 #include "XBMC_keytable.h"
 #include "utils/StringUtils.h"
-#include "utils/XBMCTinyXML.h"
 #include "utils/log.h"
 
 #include <string>
 #include <vector>
 
-uint32_t CKeyboardTranslator::TranslateButton(const TiXmlElement* pButton)
+#include <tinyxml2.h>
+
+uint32_t CKeyboardTranslator::TranslateButton(const tinyxml2::XMLElement* pButton)
 {
   uint32_t button_id = 0;
   const char* szButton = pButton->Value();
@@ -28,10 +29,10 @@ uint32_t CKeyboardTranslator::TranslateButton(const TiXmlElement* pButton)
   const std::string strKey = szButton;
   if (strKey == "key")
   {
-    std::string strID;
-    if (pButton->QueryValueAttribute("id", &strID) == TIXML_SUCCESS)
+    const char* strID;
+    if (pButton->QueryStringAttribute("id", &strID) == tinyxml2::XML_SUCCESS)
     {
-      const char* str = strID.c_str();
+      const char* str = strID;
       char* endptr;
       long int id = strtol(str, &endptr, 0);
       if (endptr - str != (int)strlen(str) || id <= 0 || id > 0x00FFFFFF)
@@ -46,8 +47,8 @@ uint32_t CKeyboardTranslator::TranslateButton(const TiXmlElement* pButton)
     button_id = TranslateString(szButton);
 
   // Process the ctrl/shift/alt modifiers
-  std::string strMod;
-  if (pButton->QueryValueAttribute("mod", &strMod) == TIXML_SUCCESS)
+  const char* strMod;
+  if (pButton->QueryStringAttribute("mod", &strMod) == tinyxml2::XML_SUCCESS)
   {
     StringUtils::ToLower(strMod);
 

--- a/xbmc/input/KeyboardTranslator.h
+++ b/xbmc/input/KeyboardTranslator.h
@@ -11,11 +11,14 @@
 #include <stdint.h>
 #include <string>
 
-class TiXmlElement;
+namespace tinyxml2
+{
+class XMLElement;
+}
 
 class CKeyboardTranslator
 {
 public:
-  static uint32_t TranslateButton(const TiXmlElement* pButton);
+  static uint32_t TranslateButton(const tinyxml2::XMLElement* pButton);
   static uint32_t TranslateString(const std::string& szButton);
 };

--- a/xbmc/input/TouchTranslator.cpp
+++ b/xbmc/input/TouchTranslator.cpp
@@ -12,10 +12,11 @@
 #include "input/actions/ActionIDs.h"
 #include "input/actions/ActionTranslator.h"
 #include "utils/StringUtils.h"
-#include "utils/XBMCTinyXML.h"
 #include "utils/log.h"
 
 #include <map>
+
+#include <tinyxml2.h>
 
 using ActionName = std::string;
 using TouchCommandID = unsigned int;
@@ -33,7 +34,7 @@ static const std::map<ActionName, TouchCommandID> TouchCommands = {
     {"swipeup", ACTION_GESTURE_SWIPE_UP},
     {"swipedown", ACTION_GESTURE_SWIPE_DOWN}};
 
-void CTouchTranslator::MapActions(int windowID, const TiXmlNode* pTouch)
+void CTouchTranslator::MapActions(int windowID, const tinyxml2::XMLNode* pTouch)
 {
   if (pTouch == nullptr)
     return;
@@ -50,11 +51,11 @@ void CTouchTranslator::MapActions(int windowID, const TiXmlNode* pTouch)
     m_touchMap.erase(it);
   }
 
-  const TiXmlElement* pTouchElem = pTouch->ToElement();
+  const auto* pTouchElem = pTouch->ToElement();
   if (pTouchElem == nullptr)
     return;
 
-  const TiXmlElement* pButton = pTouchElem->FirstChildElement();
+  const auto* pButton = pTouchElem->FirstChildElement();
   while (pButton != nullptr)
   {
     CTouchAction action;
@@ -137,7 +138,7 @@ unsigned int CTouchTranslator::GetActionID(WindowID window,
   return touchIt->second.actionId;
 }
 
-unsigned int CTouchTranslator::TranslateTouchCommand(const TiXmlElement* pButton,
+unsigned int CTouchTranslator::TranslateTouchCommand(const tinyxml2::XMLElement* pButton,
                                                      CTouchAction& action)
 {
   const char* szButton = pButton->Value();

--- a/xbmc/input/TouchTranslator.h
+++ b/xbmc/input/TouchTranslator.h
@@ -13,7 +13,11 @@
 #include <map>
 #include <string>
 
-class TiXmlElement;
+namespace tinyxml2
+{
+class XMLElement;
+class XMLNode;
+} // namespace tinyxml2
 
 class CTouchTranslator : public IButtonMapper
 {
@@ -21,7 +25,7 @@ public:
   CTouchTranslator() = default;
 
   // implementation of IButtonMapper
-  void MapActions(int windowID, const TiXmlNode* bDevice) override;
+  void MapActions(int windowID, const tinyxml2::XMLNode* bDevice) override;
   void Clear() override;
 
   bool TranslateTouchAction(
@@ -50,7 +54,8 @@ private:
                            TouchActionKey touchActionKey,
                            std::string& actionString);
 
-  static unsigned int TranslateTouchCommand(const TiXmlElement* pButton, CTouchAction& action);
+  static unsigned int TranslateTouchCommand(const tinyxml2::XMLElement* pButton,
+                                            CTouchAction& action);
 
   static unsigned int GetTouchActionKey(unsigned int touchCommandId, int touchPointers);
 

--- a/xbmc/input/mouse/MouseTranslator.cpp
+++ b/xbmc/input/mouse/MouseTranslator.cpp
@@ -11,11 +11,12 @@
 #include "MouseStat.h"
 #include "input/Key.h"
 #include "utils/StringUtils.h"
-#include "utils/XBMCTinyXML.h"
 #include "utils/log.h"
 
 #include <map>
 #include <string>
+
+#include <tinyxml2.h>
 
 using namespace KODI;
 using namespace MOUSE;
@@ -44,13 +45,13 @@ static const std::map<ActionName, KeyID> MouseKeys = {{"click", KEY_MOUSE_CLICK}
 
 } // anonymous namespace
 
-uint32_t CMouseTranslator::TranslateCommand(const TiXmlElement* pButton)
+uint32_t CMouseTranslator::TranslateCommand(const tinyxml2::XMLElement* pButton)
 {
   uint32_t buttonId = 0;
 
   if (pButton != nullptr)
   {
-    std::string szKey = pButton->ValueStr();
+    std::string szKey = pButton->Value();
     if (!szKey.empty())
     {
       StringUtils::ToLower(szKey);
@@ -66,7 +67,7 @@ uint32_t CMouseTranslator::TranslateCommand(const TiXmlElement* pButton)
       else
       {
         int id = 0;
-        if ((pButton->QueryIntAttribute("id", &id) == TIXML_SUCCESS))
+        if ((pButton->QueryIntAttribute("id", &id) == tinyxml2::XML_SUCCESS))
         {
           if (0 <= id && id < MOUSE_MAX_BUTTON)
             buttonId += id;

--- a/xbmc/input/mouse/MouseTranslator.h
+++ b/xbmc/input/mouse/MouseTranslator.h
@@ -12,7 +12,10 @@
 
 #include <stdint.h>
 
-class TiXmlElement;
+namespace tinyxml2
+{
+class XMLElement;
+}
 
 class CMouseTranslator
 {
@@ -20,7 +23,7 @@ public:
   /*!
    * \brief Translate a keymap element to a key ID
    */
-  static uint32_t TranslateCommand(const TiXmlElement* pButton);
+  static uint32_t TranslateCommand(const tinyxml2::XMLElement* pButton);
 
   /*!
    * \brief Translate a mouse event ID to a mouse button index

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -57,7 +57,7 @@
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
 #include "utils/StringUtils.h"
-#include "utils/XBMCTinyXML.h"
+#include "utils/XBMCTinyXML2.h"
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 
@@ -503,21 +503,22 @@ bool CPeripherals::LoadMappings()
 {
   std::unique_lock<CCriticalSection> lock(m_critSectionMappings);
 
-  CXBMCTinyXML xmlDoc;
+  CXBMCTinyXML2 xmlDoc;
   if (!xmlDoc.LoadFile("special://xbmc/system/peripherals.xml"))
   {
-    CLog::Log(LOGWARNING, "{} - peripherals.xml does not exist", __FUNCTION__);
+    CLog::LogF(LOGWARNING, "peripherals.xml does not exist");
     return true;
   }
 
-  TiXmlElement* pRootElement = xmlDoc.RootElement();
-  if (!pRootElement || StringUtils::CompareNoCase(pRootElement->Value(), "peripherals") != 0)
+  auto* pRootElement = xmlDoc.RootElement();
+  if (pRootElement == nullptr ||
+      StringUtils::CompareNoCase(pRootElement->Value(), "peripherals") != 0)
   {
-    CLog::Log(LOGERROR, "{} - peripherals.xml does not contain <peripherals>", __FUNCTION__);
+    CLog::LogF(LOGERROR, "peripherals.xml does not contain <peripherals>");
     return false;
   }
 
-  for (TiXmlElement* currentNode = pRootElement->FirstChildElement("peripheral"); currentNode;
+  for (auto* currentNode = pRootElement->FirstChildElement("peripheral"); currentNode != nullptr;
        currentNode = currentNode->NextSiblingElement("peripheral"))
   {
     PeripheralID id;
@@ -536,8 +537,8 @@ bool CPeripherals::LoadMappings()
         std::vector<std::string> idArray = StringUtils::Split(i, ":");
         if (idArray.size() != 2)
         {
-          CLog::Log(LOGERROR, "{} - ignoring node \"{}\" with invalid vendor_product attribute",
-                    __FUNCTION__, mapping.m_strDeviceName);
+          CLog::LogF(LOGERROR, "ignoring node \"{}\" with invalid vendor_product attribute",
+                     mapping.m_strDeviceName);
           continue;
         }
 
@@ -556,19 +557,19 @@ bool CPeripherals::LoadMappings()
     GetSettingsFromMappingsFile(currentNode, mapping.m_settings);
 
     m_mappings.push_back(mapping);
-    CLog::Log(LOGDEBUG, "{} - loaded node \"{}\"", __FUNCTION__, mapping.m_strDeviceName);
+    CLog::LogF(LOGDEBUG, "loaded node \"{}\"", mapping.m_strDeviceName);
   }
 
   return true;
 }
 
 void CPeripherals::GetSettingsFromMappingsFile(
-    TiXmlElement* xmlNode, std::map<std::string, PeripheralDeviceSetting>& settings)
+    tinyxml2::XMLElement* xmlNode, std::map<std::string, PeripheralDeviceSetting>& settings)
 {
-  TiXmlElement* currentNode = xmlNode->FirstChildElement("setting");
+  auto* currentNode = xmlNode->FirstChildElement("setting");
   int iMaxOrder = 0;
 
-  while (currentNode)
+  while (currentNode != nullptr)
   {
     SettingPtr setting;
     std::string strKey = XMLUtils::GetAttribute(currentNode, "key");
@@ -640,7 +641,7 @@ void CPeripherals::GetSettingsFromMappingsFile(
 
       /* set the order */
       int iOrder = 0;
-      currentNode->Attribute("order", &iOrder);
+      currentNode->Attribute("order", std::to_string(iOrder).c_str());
       /* if the order attribute is invalid or 0, then the setting will be added at the end */
       if (iOrder < 0)
         iOrder = 0;

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -25,9 +25,13 @@ class CFileItemList;
 class CInputManager;
 class CSetting;
 class CSettingsCategory;
-class TiXmlElement;
 class CAction;
 class CKey;
+
+namespace tinyxml2
+{
+class XMLElement;
+}
 
 namespace KODI
 {
@@ -350,7 +354,7 @@ private:
   bool LoadMappings();
   bool GetMappingForDevice(const CPeripheralBus& bus, PeripheralScanResult& result) const;
   static void GetSettingsFromMappingsFile(
-      TiXmlElement* xmlNode, std::map<std::string, PeripheralDeviceSetting>& m_settings);
+      tinyxml2::XMLElement* xmlNode, std::map<std::string, PeripheralDeviceSetting>& m_settings);
 
   void OnDeviceChanged();
 

--- a/xbmc/peripherals/devices/Peripheral.h
+++ b/xbmc/peripherals/devices/Peripheral.h
@@ -19,7 +19,6 @@
 #include <string>
 #include <vector>
 
-class TiXmlDocument;
 class CDateTime;
 class CSetting;
 class IKeymap;

--- a/xbmc/platform/linux/input/LibInputSettings.cpp
+++ b/xbmc/platform/linux/input/LibInputSettings.cpp
@@ -15,7 +15,7 @@
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingDefinitions.h"
 #include "settings/lib/SettingsManager.h"
-#include "utils/XBMCTinyXML.h"
+#include "utils/XBMCTinyXML2.h"
 #include "utils/log.h"
 
 #include <algorithm>
@@ -64,28 +64,28 @@ CLibInputSettings::CLibInputSettings(CLibInputHandler *handler) :
   /* load the keyboard layouts from xkeyboard-config */
   std::string xkbFile("/usr/share/X11/xkb/rules/base.xml");
 
-  CXBMCTinyXML xmlDoc;
+  CXBMCTinyXML2 xmlDoc;
   if (!xmlDoc.LoadFile(xkbFile))
   {
     CLog::Log(LOGWARNING, "CLibInputSettings: unable to open: {}", xkbFile);
     return;
   }
 
-  const TiXmlElement* rootElement = xmlDoc.RootElement();
+  const auto* rootElement = xmlDoc.RootElement();
   if (!rootElement)
   {
     CLog::Log(LOGWARNING, "CLibInputSettings: missing or invalid XML root element in: {}", xkbFile);
     return;
   }
 
-  if (rootElement->ValueStr() != "xkbConfigRegistry")
+  if (strcmp(rootElement->Value(), "xkbConfigRegistry") != 0)
   {
     CLog::Log(LOGWARNING, "CLibInputSettings: unexpected XML root element {} in: {}",
               rootElement->Value(), xkbFile);
     return;
   }
 
-  const TiXmlElement* layoutListElement = rootElement->FirstChildElement("layoutList");
+  const auto* layoutListElement = rootElement->FirstChildElement("layoutList");
   if (!layoutListElement)
   {
     CLog::Log(LOGWARNING, "CLibInputSettings: unexpected XML child element {} in: {}",
@@ -93,10 +93,10 @@ CLibInputSettings::CLibInputSettings(CLibInputHandler *handler) :
     return;
   }
 
-  const TiXmlElement* layoutElement = layoutListElement->FirstChildElement("layout");
+  const auto* layoutElement = layoutListElement->FirstChildElement("layout");
   while (layoutElement)
   {
-    const TiXmlElement* configElement = layoutElement->FirstChildElement("configItem");
+    const auto* configElement = layoutElement->FirstChildElement("configItem");
     if (!configElement)
     {
       CLog::Log(LOGWARNING, "CLibInputSettings: unexpected XML child element {} in: {}",
@@ -104,7 +104,7 @@ CLibInputSettings::CLibInputSettings(CLibInputHandler *handler) :
       return;
     }
 
-    const TiXmlElement* nameElement = configElement->FirstChildElement("name");
+    const auto* nameElement = configElement->FirstChildElement("name");
     if (!nameElement)
     {
       CLog::Log(LOGWARNING, "CLibInputSettings: unexpected XML child element {} in: {}",
@@ -112,7 +112,7 @@ CLibInputSettings::CLibInputSettings(CLibInputHandler *handler) :
       return;
     }
 
-    const TiXmlElement* descriptionElement = configElement->FirstChildElement("description");
+    const auto* descriptionElement = configElement->FirstChildElement("description");
     if (!descriptionElement)
     {
       CLog::Log(LOGWARNING, "CLibInputSettings: unexpected XML child element {} in: {}",


### PR DESCRIPTION
## Description
Migrate input and a couple other minors to tinyxml2 usage

## Motivation and context
Deprecate tinyxml1 usage
@garbear if you can sanity check for me through all the corner cases of input you may have come familiar with over the years. The input stuff is fairly well sandboxed compared to some other things, so i think this should be ok.

I dont think this should have any conflicts/issues with peripheral.joystick still using tinyxml1, but if anyone using controllers on the regular wants to check and confirm, that would be great.

## How has this been tested?
Runtime macos aarch64. keyboard/mouse input works as before

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
