### PR TITLE
[tinyxml2] Assorted further migrations 

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/BlurayStateSerializer.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/BlurayStateSerializer.cpp
@@ -9,7 +9,7 @@
 #include "BlurayStateSerializer.h"
 
 #include "utils/StringUtils.h"
-#include "utils/XBMCTinyXML.h"
+#include "utils/XBMCTinyXML2.h"
 #include "utils/log.h"
 
 #include <charconv>
@@ -24,39 +24,47 @@ constexpr int BLURAYSTATESERIALIZER_VERSION = 1;
 
 bool CBlurayStateSerializer::BlurayStateToXML(std::string& xmlstate, const BlurayState& state)
 {
-  CXBMCTinyXML xmlDoc{"libbluraystate"};
+  CXBMCTinyXML2 xmlDoc;
 
-  TiXmlElement eRoot{"libbluraystate"};
-  eRoot.SetAttribute("version", BLURAYSTATESERIALIZER_VERSION);
+  auto* eRoot = xmlDoc.NewElement("libbluraystate");
+  if (eRoot == nullptr)
+    return false;
+  eRoot->SetAttribute("version", BLURAYSTATESERIALIZER_VERSION);
 
-  TiXmlElement xmlElement{"playlistId"};
-  TiXmlText xmlElementValue = std::to_string(state.playlistId);
-  xmlElement.InsertEndChild(xmlElementValue);
-  eRoot.InsertEndChild(xmlElement);
+  auto* xmlElement = xmlDoc.NewElement("playlistId");
+  if (xmlElement == nullptr)
+    return false;
+
+  auto* xmlElementValue = xmlDoc.NewText(std::to_string(state.playlistId).c_str());
+  if (xmlElementValue == nullptr)
+    return false;
+
+  xmlElement->InsertEndChild(xmlElementValue);
+  eRoot->InsertEndChild(xmlElement);
   xmlDoc.InsertEndChild(eRoot);
 
-  std::stringstream stream;
-  stream << xmlDoc;
-  xmlstate = stream.str();
+  tinyxml2::XMLPrinter printer;
+  xmlDoc.Accept(&printer);
+  xmlstate = printer.CStr();
   return true;
 }
 
 bool CBlurayStateSerializer::XMLToBlurayState(BlurayState& state, const std::string& xmlstate)
 {
-  CXBMCTinyXML xmlDoc;
+  CXBMCTinyXML2 xmlDoc;
 
-  xmlDoc.Parse(xmlstate);
-  if (xmlDoc.Error())
+  if (!xmlDoc.Parse(xmlstate))
     return false;
 
-  TiXmlHandle hRoot(xmlDoc.RootElement());
-  if (!hRoot.Element() || !StringUtils::EqualsNoCase(hRoot.Element()->Value(), "libbluraystate"))
+  tinyxml2::XMLHandle hRoot(xmlDoc.RootElement());
+  if (!hRoot.ToElement() ||
+      !StringUtils::EqualsNoCase(hRoot.ToElement()->Value(), "libbluraystate"))
   {
     CLog::LogF(LOGERROR, "Failed to deserialize bluray state - failed to detect root element.");
     return false;
   }
 
-  auto version = hRoot.Element()->Attribute("version");
+  auto version = hRoot.ToElement()->Attribute("version");
   if (!version ||
       !StringUtils::EqualsNoCase(version, std::to_string(BLURAYSTATESERIALIZER_VERSION)))
   {
@@ -64,8 +72,8 @@ bool CBlurayStateSerializer::XMLToBlurayState(BlurayState& state, const std::str
     return false;
   }
 
-  const TiXmlElement* childElement = hRoot.Element()->FirstChildElement();
-  while (childElement)
+  const auto* childElement = hRoot.ToElement()->FirstChildElement();
+  while (childElement != nullptr)
   {
     const std::string property = childElement->Value();
     if (property == "playlistId")

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/BlurayStateSerializer.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/BlurayStateSerializer.h
@@ -10,8 +10,6 @@
 
 #include <string>
 
-class TiXmlElement;
-
 /*! \brief Pod structure which represents the current Bluray state */
 struct BlurayState
 {

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDStateSerializer.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDStateSerializer.h
@@ -10,7 +10,10 @@
 
 #include <string>
 
-class TiXmlElement;
+namespace tinyxml2
+{
+class XMLElement;
+}
 
 /*! \brief Pod structure which represents the current dvd state with respect to dvdnav properties */
 struct DVDState
@@ -63,5 +66,5 @@ private:
   * \param name the new element name
   * \param value the new element value
   */
-  void AddXMLElement(TiXmlElement& root, const std::string& name, const std::string& value);
+  void AddXMLElement(tinyxml2::XMLElement& root, const std::string& name, const std::string& value);
 };

--- a/xbmc/media/decoderfilter/DecoderFilterManager.h
+++ b/xbmc/media/decoderfilter/DecoderFilterManager.h
@@ -19,8 +19,12 @@
 #include <set>
 #include <string>
 
-class TiXmlNode;
 class CDVDStreamInfo;
+
+namespace tinyxml2
+{
+class XMLNode;
+}
 
 /**
 * @class CDecoderFilter
@@ -75,21 +79,20 @@ public:
   virtual bool isValid(const CDVDStreamInfo& streamInfo) const;
 
   /**
-  * \fn CDecoderFilter::Load(const TiXmlNode *settings);
+  * \fn CDecoderFilter::Load(const XMLNode* settings);
   * \brief load all members from XML node
   * \param node filter node from where to get the values
   * \return true if operation was successful, false on error
   */
-  virtual bool Load(const TiXmlNode *node);
+  virtual bool Load(const tinyxml2::XMLNode* node);
 
   /**
-  * \fn CDecoderFilter::Save(TiXmlNode *settings);
+  * \fn CDecoderFilter::Save(XMLNode* settings);
   * \brief store all members in XML node
   * \param node a ready to use filter setting node
   * \return true if operation was successful, false on error
   */
-  virtual bool Save(TiXmlNode *node) const;
-
+  virtual bool Save(tinyxml2::XMLNode* node) const;
 
 private:
   std::string m_name;


### PR DESCRIPTION
## Description
Migrate more standalone components to tinyxml2 usage

## Motivation and context
tinyxml1 deprecation.
An assortment of standalone components that arent tightly coupled into other things.
Of note, the DVD/Bluray state serializers are the ones that i would need some testing on, im not sure  how to test their usage currently

## How has this been tested?
Runtime briefly

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
