### PR TITLE
[cleanup] change deprecated 'CAddonMgr::IsCompatible(const IAddon& ad…

### DIFF
--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -901,7 +901,7 @@ bool CAddonMgr::EnableSingle(const std::string& id)
 
   auto eventLog = CServiceBroker::GetEventLog();
 
-  if (!IsCompatible(*addon))
+  if (!IsCompatible(addon))
   {
     CLog::Log(LOGERROR, "Add-on '{}' is not compatible with Kodi", addon->ID());
     if (eventLog)
@@ -1111,9 +1111,9 @@ void CAddonMgr::PublishInstanceRemoved(const std::string& addonId, AddonInstance
   m_events.Publish(AddonEvents::InstanceRemoved(addonId, instanceId));
 }
 
-bool CAddonMgr::IsCompatible(const IAddon& addon) const
+bool CAddonMgr::IsCompatible(const std::shared_ptr<const IAddon>& addon) const
 {
-  for (const auto& dependency : addon.GetDependencies())
+  for (const auto& dependency : addon->GetDependencies())
   {
     if (!dependency.optional)
     {
@@ -1122,10 +1122,10 @@ bool CAddonMgr::IsCompatible(const IAddon& addon) const
       if (StringUtils::StartsWith(dependency.id, "xbmc.") ||
           StringUtils::StartsWith(dependency.id, "kodi."))
       {
-        AddonPtr addon;
-        bool haveAddon =
-            GetAddon(dependency.id, addon, AddonType::UNKNOWN, OnlyEnabled::CHOICE_YES);
-        if (!haveAddon || !addon->MeetsVersion(dependency.versionMin, dependency.version))
+        std::shared_ptr<IAddon> dep;
+        const bool haveDependency =
+            GetAddon(dependency.id, dep, AddonType::UNKNOWN, OnlyEnabled::CHOICE_YES);
+        if (!haveDependency || !dep->MeetsVersion(dependency.versionMin, dependency.version))
           return false;
       }
     }

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -426,10 +426,12 @@ public:
   bool ServicesHasStarted() const;
 
   /*!
-     * @deprecated This addon function should no more used and becomes replaced
-     * in future with the other below by his callers.
+     * @brief Check if given addon is compatible with Kodi.
+     *
+     * @param[in] addon Addon to check
+     * @return true if compatible, false if not
      */
-  bool IsCompatible(const IAddon& addon) const;
+  bool IsCompatible(const std::shared_ptr<const IAddon>& addon) const;
 
   /*!
      * @brief Check given addon information is compatible with Kodi.

--- a/xbmc/addons/AddonRepos.cpp
+++ b/xbmc/addons/AddonRepos.cpp
@@ -120,7 +120,7 @@ bool CAddonRepos::LoadAddonsFromDatabase(const std::string& addonId,
 
   for (const auto& addon : m_allAddons)
   {
-    if (m_addonMgr.IsCompatible(*addon))
+    if (m_addonMgr.IsCompatible(addon))
     {
       m_addonsByRepoMap[addon->Origin()].insert({addon->ID(), addon});
     }
@@ -487,7 +487,7 @@ void CAddonRepos::BuildCompatibleVersionsList(
 
   for (const auto& addon : m_allAddons)
   {
-    if (m_addonMgr.IsCompatible(*addon))
+    if (m_addonMgr.IsCompatible(addon))
     {
       if (IsFromOfficialRepo(addon, CheckAddonPath::CHOICE_YES))
       {


### PR DESCRIPTION
…don)'

this member takes a `const std::shared_ptr<IAddon>&` now.
it was only used twice in the codebase, so should be no big deal.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
