### PR TITLE
[discs] fix playback of iso-files

### DIFF
--- a/xbmc/filesystem/ISO9660Directory.cpp
+++ b/xbmc/filesystem/ISO9660Directory.cpp
@@ -83,7 +83,7 @@ bool CISO9660Directory::Exists(const CURL& url)
 bool CISO9660Directory::Resolve(CFileItem& item) const
 {
   const CURL url{item.GetDynPath()};
-  if (url.GetProtocol() != "iso9660")
+  if (url.GetProtocol() != "iso9660" && url.GetFileType() != "iso")
   {
     return false;
   }


### PR DESCRIPTION
## Description
follow up to https://github.com/xbmc/xbmc/pull/23531
closes https://github.com/xbmc/xbmc/issues/23603

in commit https://github.com/xbmc/xbmc/pull/23531/commits/987a482a9ab61636324e3dc79c5ec15a7ea68295 `move disc resolve to IFileDirectory` ISO-Files were missed.

![grafik](https://github.com/xbmc/xbmc/assets/58829855/5a98bbf3-b476-4599-a9af-85023b7cd573)


## How has this been tested?
locally

## What is the effect on users?
iso-files playing

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document