### PR TITLE
[Windows][dxva] Don't send repeated frames through the processor / Fix nVidia deinterlacing / VSR with deinterlacing

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -535,9 +535,6 @@ bool CProcessorHD::IsSuperResolutionSuitable(const VideoPicture& picture)
   if (outputWidth <= picture.iWidth)
     return false;
 
-  if (picture.iFlags & DVP_FLAG_INTERLACED)
-    return false;
-
   if (picture.color_primaries == AVCOL_PRI_BT2020 ||
       picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
       picture.color_transfer == AVCOL_TRC_ARIB_STD_B67)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -65,6 +65,15 @@ protected:
   bool OpenProcessor();
   void ApplyFilter(D3D11_VIDEO_PROCESSOR_FILTER filter, int value, int min, int max, int def) const;
   ComPtr<ID3D11VideoProcessorInputView> GetInputView(CRenderBuffer* view) const;
+  /*!
+   * \brief Apply new video settings if there was a change. Returns true if a parameter changed, false otherwise.
+   */
+  bool CheckVideoParameters(const CRect& src,
+                            const CRect& dst,
+                            const UINT& rotation,
+                            const float& contrast,
+                            const float& brightness,
+                            const CRenderBuffer& rb);
 
   void EnableIntelVideoSuperResolution();
   void EnableNvidiaRTXVideoSuperResolution();
@@ -85,12 +94,20 @@ protected:
   bool m_isValidConversion{false};
 
   /*!
-   * \brief true when at least one frame has been processed successfully since initialization
+   * \brief true when at least one frame has been processed successfully since init
    */
   bool m_configured{false};
 
   // Members to compare the current frame with the previous frame
   UINT m_lastInputFrameOrField{0};
   UINT m_lastOutputIndex{0};
+  CRect m_lastSrc{};
+  CRect m_lastDst{};
+  UINT m_lastRotation{0};
+  float m_lastContrast{.0f};
+  float m_lastBrightness{.0f};
+  ProcessorConversion m_lastConversion{};
+  AVColorSpace m_lastColorSpace{AVCOL_SPC_UNSPECIFIED};
+  bool m_lastFullRange{false};
 };
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -83,5 +83,14 @@ protected:
   bool m_superResolutionEnabled{false};
   ProcessorConversion m_conversion;
   bool m_isValidConversion{false};
+
+  /*!
+   * \brief true when at least one frame has been processed successfully since initialization
+   */
+  bool m_configured{false};
+
+  // Members to compare the current frame with the previous frame
+  UINT m_lastInputFrameOrField{0};
+  UINT m_lastOutputIndex{0};
 };
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

**Cause of the issue**

`Render()` is called for each displayed frame so there can be frame / field repetitions, as needed to adapt the source fps to the screen refresh rate.
For example, 25i source to 60Hz screen: frames A B get rendered as A0 A1 B0 B1 B1

*** begin rant ***
The nVidia dxva processor expects each frame/field only once or it loses cadence and uses bob deinterlacing with noticeable flickering on static scenes and thin lines. In the previous example, the duplicate B1 frame causes it to use bob.

That is because nVidia implemented "interesting" deviations from MS spec and ignores some parameters, most likely to help programs that don't follow the rules (provide the requested future and past frames, input/output indexes).
Since the processor is guessing everything from the submitted frames instead of using the parameters, it breaks when a field is repeated (even when properly flagged) as it's not a recognized pattern anymore.
*** end rant ***

AMD and Intel follow the rules and have no issue with Kodi.


**The change**

1/ Main commit: modified the `Render()` function of `CProcessorHD` to send each field only once to the dxva processor.
- Solution relies on the intermediate target not being cleared between renders, so in case of repeated frame it still contains the result of the last processor blit
- Made sure that the processor knows we're rendering at normal speed (no frame halving, doubling or custom rate)
- Slightly modified InputFrameOrField values: 0 1 2 3 4 etc... for interlaced. See MS examples https://learn.microsoft.com/en-us/windows/win32/api/dxvahd/ns-dxvahd-dxvahd_stream_data and https://learn.microsoft.com/en-us/windows/win32/api/d3d12video/ns-d3d12video-d3d12_video_process_input_stream_rate
- The OutputFrame parameter of VideoProcessorBlt doesn't seem to have any effect for any gpu vendor, might as well set it to 0. Maybe it would be better to provide a continuously increasing number (frameIdx values are not continuous). Maybe it makes a difference when converting frame rates, which Kodi doesn't do.
- side-benefit: small gpu load reduction for refresh rates higher than double source fps (interlaced source), reduction for progressive when refresh rate is greater than source fps, and reduction on pause since VP keeps rendering once per vsync Will help most with the costly VSR scaling.

There may be a better way to do this and it may be possible to tell videoplayer to behave differently but I'm not aware.

The same idea could be applied to the other render methods for a gpu / cpu load reduction.

2/ Second commit: many parameters that rarely change were set every frame. Reworked that code to set the parameters only when they change.

3/ Third commit: as reported in comments, this fixes deinterlacing + VSR combination for nVidia so enabling it for wider testing, especially for Intel Arc gpu.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Problems reported with nVidia dxva deinterlacing in forum
at least https://forum.kodi.tv/showthread.php?tid=370507 (includes sample) and related ivtc issues at high screen refresh rate reported in https://forum.kodi.tv/showthread.php?tid=372941

The issue may have existed since the port to D3D11 (it worked correctly with D3D9).

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 10, nVidia GT 1030, AMD 5600G, Intel 8th gen
Tried interlaced and progressive material, with fps that matched screen refresh rate or not, went up to 120Hz.
nVidia and AMD worked well, Intel 8th internal laptop screen was OK but external screen was terrible with stutter / frames dropped and skipped (but was equally terrible before PR)

Note that for refresh rates higher than double the source fps, videoplayer doesn't present the fields the same number of times and movement will not be as smooth as expected. That's a separate issue to fix.
ex. source 25i on 100Hz screen: frame A turns into A0 A1 A1 A1 instead of A0 A0 A1 A1

Report of thexai that deinterlacing + VSR works for everything he threw at it with RTX 4070 and positive feedback in forum of a user with RTX 3080.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Advanced deinterlacing should now work for nVidia in all cases, in combination with VSR on supporting gpus.

More specifically, deinterlacing was fixed for PAL on NTSC display and vice-versa, as well as when display refresh rate is higher than doubled source fps (ex. 100Hz, 120Hz, 165Hz, ...)
The gpu will now switch to the more advanced algorithms like adaptive deinterlacing. instead of using only bob, 

Small reduction of gpu usage for all systems that don't "Adjust refresh rate" (with VSR, significant reduction)

Unknown effect of deinterlacing+VSR on Intel Arc, left it enabled for alpha to receive user feedback and block it before release if need be,

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
