### PR TITLE
[cmake] FindTinyXML2 linux corner case for internal build if sys lib exists

### DIFF
--- a/cmake/modules/FindTinyXML2.cmake
+++ b/cmake/modules/FindTinyXML2.cmake
@@ -16,7 +16,11 @@ if(NOT TARGET tinyxml2::tinyxml2)
   SETUP_BUILD_VARS()
 
   # Check for existing TINYXML2. If version >= TINYXML2-VERSION file version, dont build
-  find_package(TINYXML2 CONFIG QUIET)
+  # A corner case, but if a linux/freebsd user WANTS to build internal tinyxml2, skip the
+  # config search and act like tinyxml2 doesnt exist on system
+  if(NOT ((CORE_SYSTEM_NAME STREQUAL linux OR CORE_SYSTEM_NAME STREQUAL freebsd) AND ENABLE_INTERNAL_TINYXML2))
+    find_package(TINYXML2 CONFIG QUIET)
+  endif()
 
   # Some linux distro's dont package cmake config files for TinyXML2
   # This means that they will fall into the below and we will run a pkg_check_modules

--- a/cmake/modules/FindTinyXML2.cmake
+++ b/cmake/modules/FindTinyXML2.cmake
@@ -19,7 +19,14 @@ if(NOT TARGET tinyxml2::tinyxml2)
   # A corner case, but if a linux/freebsd user WANTS to build internal tinyxml2, skip the
   # config search and act like tinyxml2 doesnt exist on system
   if(NOT ((CORE_SYSTEM_NAME STREQUAL linux OR CORE_SYSTEM_NAME STREQUAL freebsd) AND ENABLE_INTERNAL_TINYXML2))
-    find_package(TINYXML2 CONFIG QUIET)
+
+    # Darwin systems we want to avoid system packages. We are entirely self sufficient
+    # Avoids homebrew populating rubbish we cant control
+    if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+      set(_tinyxml2_find_option NO_SYSTEM_ENVIRONMENT_PATH)
+    endif()
+
+    find_package(TINYXML2 ${_tinyxml2_find_option} CONFIG QUIET)
   endif()
 
   # Some linux distro's dont package cmake config files for TinyXML2


### PR DESCRIPTION
## Description
Allow linux/freebsd to use ENABLE_INTERNAL_TINYXML2 even if the system has a shared tinyxml2 of the same version in tools/depends/target/tinyxml2

## Motivation and context
@howie-f raised, what i consider an extreme, corner case in https://github.com/xbmc/xbmc/pull/23605#issuecomment-1672960918

Second commit added to deal with an issue for macos and homebrew installs of tinyxml2 being found. We cant use ```CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH``` in the toolchain file as it can cause searching for buildtools to fail (java in particular when installed via homebrew)

## How has this been tested?
Debian Bookworm with system lib (tinyxml2 9.0.0) installed. With ENABLE_INTERNAL_TINYXML2, builds the internal tinyxml2, without detects system as normal
Macos without existing lib, builds internal, with existing lib from prior build, finds that lib as expected

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
