### PR TITLE
Player Viewer: Two fixes

### DIFF
--- a/xbmc/games/addons/input/GameClientInput.h
+++ b/xbmc/games/addons/input/GameClientInput.h
@@ -16,6 +16,7 @@
 
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 
 class CCriticalSection;
@@ -66,7 +67,7 @@ public:
 
   // Topology functions
   const CControllerTree& GetDefaultControllerTree() const;
-  const CControllerTree& GetActiveControllerTree() const;
+  CControllerTree GetActiveControllerTree() const;
   bool SupportsKeyboard() const;
   bool SupportsMouse() const;
   int GetPlayerLimit() const;
@@ -132,8 +133,18 @@ private:
    */
   JoystickMap m_joysticks;
 
-  // TODO: Guard with a mutex
+  /*!
+   * \brief Serializable port state
+   */
   std::unique_ptr<CPortManager> m_portManager;
+
+  /*!
+   * \brief Mutex for port state
+   *
+   * Mutex is recursive to allow for management of several ports within the
+   * function ResetPorts().
+   */
+  mutable std::recursive_mutex m_portMutex;
 
   /*!
    * \brief Keyboard handler

--- a/xbmc/games/agents/GameAgentManager.cpp
+++ b/xbmc/games/agents/GameAgentManager.cpp
@@ -156,7 +156,7 @@ std::vector<std::string> CGameAgentManager::GetInputPorts() const
 
   if (m_gameClient)
   {
-    const CControllerTree& controllerTree = m_gameClient->Input().GetActiveControllerTree();
+    CControllerTree controllerTree = m_gameClient->Input().GetActiveControllerTree();
     controllerTree.GetInputPorts(inputPorts);
   }
 
@@ -237,7 +237,7 @@ void CGameAgentManager::ProcessKeyboard()
     m_peripheralManager.GetPeripheralsWithFeature(keyboards, PERIPHERALS::FEATURE_KEYBOARD);
     if (!keyboards.empty())
     {
-      const CControllerTree& controllers = m_gameClient->Input().GetActiveControllerTree();
+      CControllerTree controllers = m_gameClient->Input().GetActiveControllerTree();
 
       auto it = std::find_if(
           controllers.GetPorts().begin(), controllers.GetPorts().end(),
@@ -259,7 +259,7 @@ void CGameAgentManager::ProcessMouse()
     m_peripheralManager.GetPeripheralsWithFeature(mice, PERIPHERALS::FEATURE_MOUSE);
     if (!mice.empty())
     {
-      const CControllerTree& controllers = m_gameClient->Input().GetActiveControllerTree();
+      CControllerTree controllers = m_gameClient->Input().GetActiveControllerTree();
 
       auto it = std::find_if(
           controllers.GetPorts().begin(), controllers.GetPorts().end(),

--- a/xbmc/games/agents/windows/GUIAgentList.cpp
+++ b/xbmc/games/agents/windows/GUIAgentList.cpp
@@ -182,6 +182,7 @@ void CGUIAgentList::Notify(const Observable& obs, const ObservableMessage msg)
   switch (msg)
   {
     case ObservableMessageGameAgentsChanged:
+    case ObservableMessageGamePortsChanged:
     {
       CGUIMessage msg(GUI_MSG_REFRESH_LIST, m_guiWindow.GetID(), CONTROL_AGENT_LIST);
       CServiceBroker::GetAppMessenger()->SendGUIMessage(msg, m_guiWindow.GetID());

--- a/xbmc/games/controllers/guicontrols/GUIGameControllerList.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIGameControllerList.cpp
@@ -171,7 +171,7 @@ void CGUIGameControllerList::UpdatePortIndex(const PERIPHERALS::PeripheralPtr& a
       static_cast<JOYSTICK::IInputProvider*>(agentPeripheral.get());
 
   // See if the input provider has a port address
-  const std::string& portAddress = agentManager.GetPortAddress(inputProvider);
+  std::string portAddress = agentManager.GetPortAddress(inputProvider);
   if (portAddress.empty())
     return;
 

--- a/xbmc/games/ports/guicontrols/GUIActivePortList.cpp
+++ b/xbmc/games/ports/guicontrols/GUIActivePortList.cpp
@@ -86,7 +86,10 @@ void CGUIActivePortList::Refresh()
 
   // Add controllers of active ports
   if (m_gameClient)
-    AddItems(m_gameClient->Input().GetActiveControllerTree().GetPorts());
+  {
+    CControllerTree controllerTree = m_gameClient->Input().GetActiveControllerTree();
+    AddItems(controllerTree.GetPorts());
+  }
 
   // Add padding if right-aligned
   if (m_alignment == XBFONT_RIGHT)

--- a/xbmc/games/ports/windows/GUIPortList.cpp
+++ b/xbmc/games/ports/windows/GUIPortList.cpp
@@ -106,8 +106,10 @@ void CGUIPortList::Refresh()
 
   if (m_gameClient)
   {
+    CControllerTree controllerTree = m_gameClient->Input().GetActiveControllerTree();
+
     unsigned int itemIndex = 0;
-    for (const CPortNode& port : m_gameClient->Input().GetActiveControllerTree().GetPorts())
+    for (const CPortNode& port : controllerTree.GetPorts())
       AddItems(port, itemIndex, GetLabel(port));
 
     m_viewControl->SetItems(*m_vecItems);
@@ -254,7 +256,7 @@ void CGUIPortList::OnItemSelect(unsigned int itemIndex)
     if (portAddress.empty())
       return;
 
-    const CPortNode& port = m_gameClient->Input().GetActiveControllerTree().GetPort(portAddress);
+    CPortNode port = m_gameClient->Input().GetActiveControllerTree().GetPort(portAddress);
 
     ControllerVector controllers;
     for (const CControllerNode& controllerNode : port.GetCompatibleControllers())
@@ -263,11 +265,13 @@ void CGUIPortList::OnItemSelect(unsigned int itemIndex)
     // Get current controller to give initial focus
     ControllerPtr controller = port.GetActiveController().GetController();
 
-    auto callback = [this, &port](const ControllerPtr& controller) {
+    // Check if we should show a "disconnect" option
+    const bool showDisconnect = !port.IsForceConnected();
+
+    auto callback = [this, port = std::move(port)](const ControllerPtr& controller) {
       OnControllerSelected(port, controller);
     };
 
-    const bool showDisconnect = !port.IsForceConnected();
     m_controllerSelectDialog.Initialize(std::move(controllers), std::move(controller),
                                         showDisconnect, callback);
   }


### PR DESCRIPTION
## Description

This PR contains two fixes for the Player Viewer added in https://github.com/xbmc/xbmc/pull/23548:

* Fixed segfault when changing ports
* Fixed player list not updating occasionally when changing ports

#### Segfault

The segfault happens due to the controller highlighting. The GUI thread is constantly checking controller activity, but when changing ports we pull the joystick memory out from under us, causing a segfault.

The solution is to re-introduce the mutex added in https://github.com/xbmc/xbmc/pull/23499 (and reverted in https://github.com/xbmc/xbmc/pull/23521) but a little more carefully, and then place a try_lock in the GUI path. If the mutex is already locked in another thread, then an activation of 0.0 is safely used and the controller simply doesn't highlight during port changes.

#### Stale player list

The second bug is a minor annoyance. When changing multiple ports, if the final change doesn't cause players to be re-shuffled among ports, then the player list wouldn't update correctly. The solution is to simply refresh the player list on port changes in addition to player changes.

## Motivation and context

Discovered when testing https://github.com/xbmc/xbmc/pull/23600.

## How has this been tested?

Tested in my retroplayer alpha 3 develoment branch, based on master.

## What is the effect on users?

* Fixed crash and minor glitches in the Player Viewer

## Screenshots (if appropriate):

![screenshot00006](https://github.com/xbmc/xbmc/assets/531482/9cca2491-1418-4bbf-aca2-85a01a46a30c)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
