### PR TITLE
[Windows] Extend high precision setting to use 10 bit or better for all streams

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
@@ -134,9 +134,7 @@ bool CRendererDXVA::Configure(const VideoPicture& picture, float fps, unsigned o
           m_enumerator->SupportedConversions(m_conversionsArgs);
       if (!conversions.empty())
       {
-        const ProcessorConversion chosenConversion = ChooseConversion(conversions);
-        m_intermediateTargetFormat = chosenConversion.m_outputFormat;
-        m_conversion = chosenConversion;
+        m_conversion = ChooseConversion(conversions);
 
         CLog::LogF(LOGINFO, "chosen conversion: {}", m_conversion.ToString());
 
@@ -195,8 +193,6 @@ void CRendererDXVA::CheckVideoParameters()
         CLog::LogF(LOGINFO, "new conversion: {}", conversion.ToString());
 
         m_processor->SetConversion(conversion);
-        m_intermediateTargetFormat = conversion.m_outputFormat;
-
         m_conversion = conversion;
       }
       m_conversionsArgs = args;
@@ -205,7 +201,7 @@ void CRendererDXVA::CheckVideoParameters()
 
   CreateIntermediateTarget(HasHQScaler() ? m_sourceWidth : m_viewWidth,
                            HasHQScaler() ? m_sourceHeight : m_viewHeight, false,
-                           m_intermediateTargetFormat);
+                           m_conversion.m_outputFormat);
 }
 
 void CRendererDXVA::RenderImpl(CD3DTexture& target, CRect& sourceRect, CPoint(&destPoints)[4], uint32_t flags)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
@@ -51,13 +51,9 @@ private:
   /*!
    * \brief Choose the best available conversion for the given source and output constraints
    * \param conversions list of supported conversions
-   * \param picture information about the source
-   * \param tryVSR yes/no favor a conversion that enables Video Super Resolution scaling
-   * \return 
+   * \return best match
    */
-  DXVA::ProcessorConversion ChooseConversion(const DXVA::ProcessorConversions& conversions,
-                                             unsigned int sourceBits,
-                                             AVColorTransferCharacteristic colorTransfer) const;
+  DXVA::ProcessorConversion ChooseConversion(const DXVA::ProcessorConversions& conversions) const;
 
   std::unique_ptr<DXVA::CProcessorHD> m_processor;
   std::shared_ptr<DXVA::CEnumeratorHD> m_enumerator;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
@@ -57,7 +57,6 @@ private:
 
   std::unique_ptr<DXVA::CProcessorHD> m_processor;
   std::shared_ptr<DXVA::CEnumeratorHD> m_enumerator;
-  DXGI_FORMAT m_intermediateTargetFormat{DXGI_FORMAT_UNKNOWN};
   DXVA::ProcessorConversion m_conversion;
   DXVA::SupportedConversionsArgs m_conversionsArgs;
   bool m_tryVSR{false};

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererShaders.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererShaders.cpp
@@ -99,8 +99,7 @@ bool CRendererShaders::Configure(const VideoPicture& picture, float fps, unsigne
         m_format = GetAVFormat(dxgi_format);
     }
 
-    CreateIntermediateTarget(m_sourceWidth, m_sourceHeight, false,
-                             CalcIntermediateTargetFormat(picture));
+    CreateIntermediateTarget(m_sourceWidth, m_sourceHeight, false, CalcIntermediateTargetFormat());
     return true;
   }
   return false;
@@ -203,35 +202,33 @@ AVColorPrimaries CRendererShaders::GetSrcPrimaries(AVColorPrimaries srcPrimaries
   return ret;
 }
 
-DXGI_FORMAT CRendererShaders::CalcIntermediateTargetFormat(const VideoPicture& picture) const
+DXGI_FORMAT CRendererShaders::CalcIntermediateTargetFormat() const
 {
   // Default value: same as the back buffer
   DXGI_FORMAT format{DX::Windowing()->GetBackBuffer().GetFormat()};
 
+  // High precision setting not enabled: use back buffer format, 8 or 10 bits
+  // enabled: look for higher quality format
   if (!DX::Windowing()->IsHighPrecisionProcessingSettingEnabled())
     return format;
 
-  // Preserve HDR precision
-  if (picture.colorBits > 8 && (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
-                                picture.color_transfer == AVCOL_TRC_ARIB_STD_B67))
-  {
-    UINT reqSupport{D3D11_FORMAT_SUPPORT_SHADER_SAMPLE | D3D11_FORMAT_SUPPORT_RENDER_TARGET};
+  UINT reqSupport{D3D11_FORMAT_SUPPORT_SHADER_SAMPLE | D3D11_FORMAT_SUPPORT_RENDER_TARGET};
 
-    // Preferred: float16 as the yuv-rgb conversion takes place in float
-    // => avoids a conversion / quantization round-trip, but uses more bandwidth
-    const std::array hdrformats{DXGI_FORMAT_R16G16B16A16_FLOAT, DXGI_FORMAT_R10G10B10A2_UNORM,
-                                DXGI_FORMAT_R32G32B32A32_FLOAT};
+  // Preferred: float16 as the yuv-rgb conversion takes place in float
+  // => avoids a conversion / quantization round-trip, but uses more memory / bandwidth
+  const std::array hdrformats{DXGI_FORMAT_R16G16B16A16_FLOAT, DXGI_FORMAT_R10G10B10A2_UNORM,
+                              DXGI_FORMAT_R32G32B32A32_FLOAT};
 
-    const auto it =
-        std::find_if(hdrformats.cbegin(), hdrformats.cend(), [&](DXGI_FORMAT outputFormat) {
-          return DX::Windowing()->IsFormatSupport(outputFormat, reqSupport);
-        });
+  const auto it =
+      std::find_if(hdrformats.cbegin(), hdrformats.cend(), [&](DXGI_FORMAT outputFormat) {
+        return DX::Windowing()->IsFormatSupport(outputFormat, reqSupport);
+      });
 
-    if (it != hdrformats.cend())
-      format = *it;
-    else
-      CLog::LogF(LOGDEBUG, "no compatible high precision format found for HDR.");
-  }
+  if (it != hdrformats.cend())
+    format = *it;
+  else
+    CLog::LogF(LOGDEBUG, "no compatible high precision format found.");
+
   return format;
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererShaders.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererShaders.h
@@ -48,7 +48,7 @@ protected:
 
 private:
   static AVColorPrimaries GetSrcPrimaries(AVColorPrimaries srcPrimaries, unsigned int width, unsigned int height);
-  DXGI_FORMAT CalcIntermediateTargetFormat(const VideoPicture& picture) const;
+  DXGI_FORMAT CalcIntermediateTargetFormat() const;
 
   AVColorPrimaries m_srcPrimaries = AVCOL_PRI_BT709;
   std::unique_ptr<CYUV2RGBShader> m_colorShader;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Modified `CRendererDXVA::ChooseConversion` and `CRendererShaders::CalcIntermediateTargetFormat` that select the intermediate target format for dxva and pixel shaders render method.

- Before PR: find compatible format of 10 bits or better when the setting 'High precision processing" is enabled and the source is 10 bit HDR.
- After PR: find a compatible format of 10 bits or better when the setting "High precision processing" is enabled (regardless of the number of bits of the source or its SDR / HDR type)

The exception of using 8 bits for VSR was preserved.

Even the case of 8 bit stream going to 8 bit backbuffer should benefit a bit, since there is scaling, optional LUT and dithering after the color conversion. Extra cost, if any, should be minimal (cheap bit shifting to go 8 bit <=> 10 bits, probably built in gpu and free)
It could be special cased and excluded though, but complex to detect when there is no post-processing after color conversion.


This removes the need to change the same functions to remove duplication of tests that distinguish SDR from HDR (ex PR #23599)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Found out after a bit of research that the conversion of 8 bit YUV to RGB is not exact with 8 bits destination texture, justifying the use of 10 bits.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Windows 10 with sdr, hdr streams, some that activate VSR => 8 bit and 10 bit backbuffers.

- rgb10 or fp16 used then setting is true (except VSR, rgb8)
- rgb8 or rgb10 depending on backbuffers when setting is false.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Slightly improved precision for SDR streams.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
