### PR TITLE
linux use MFD_NOEXEC_SEAL for shared memory

### DIFF
--- a/xbmc/platform/posix/utils/SharedMemory.cpp
+++ b/xbmc/platform/posix/utils/SharedMemory.cpp
@@ -15,6 +15,9 @@
 #if defined(HAVE_LINUX_MEMFD)
 #include <linux/memfd.h>
 #include <sys/syscall.h>
+#ifndef MFD_NOEXEC_SEAL
+#define MFD_NOEXEC_SEAL 0x0008U
+#endif
 #endif
 
 #include <cerrno>
@@ -62,8 +65,13 @@ CFileHandle CSharedMemory::OpenMemfd()
 {
 #if defined(SYS_memfd_create) && defined(HAVE_LINUX_MEMFD)
   // This is specific to Linux >= 3.17, but preferred over shm_create if available
-  // because it is race-free
-  int fd = syscall(SYS_memfd_create, "kodi", MFD_CLOEXEC);
+  // because it is race-free. Since linux >= 6.3 create with the MFD_NOEXEC_SEAL flag.
+  int fd = syscall(SYS_memfd_create, "kodi", MFD_CLOEXEC | MFD_ALLOW_SEALING | MFD_NOEXEC_SEAL);
+  if (fd < 0)
+  {
+    // retry creating fd without MFD_NOEXEC_SEAL to support linux < 6.3
+    fd = syscall(SYS_memfd_create, "kodi", MFD_CLOEXEC | MFD_ALLOW_SEALING);
+  }
   if (fd < 0)
   {
     throw std::system_error(errno, std::generic_category(), "memfd_create");


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. ### -->
### linux use MFD_NOEXEC_SEAL for shared memory

ref: https://lore.kernel.org/lkml/20221207154939.2532830-4-jeffxu@google.com/

The new MFD_NOEXEC_SEAL and MFD_EXEC flags allows application to set executable bit at creation time (memfd_create).

When MFD_NOEXEC_SEAL is set, memfd is created without executable bit (mode:0666), and sealed with F_SEAL_EXEC, so it can't be chmod to be executable (mode: 0777) after creation.

When MFD_EXEC flag is set, memfd is created with executable bit
(mode:0777), this is the same as the old behavior of memfd_create.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Remove warning message from Linux dmesg

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Build and run tested

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
No user impact. Removes a warning from Linux dmesg in recent (6.3 and greater) kernels - https://github.com/torvalds/linux/commit/105ff5339f498af74e60d7662c8f1c4d21f1342d 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
