### PR TITLE
[SkinTimers] Add unit tests for skin timer parsing

### DIFF
--- a/cmake/installdata/test-reference-data.txt
+++ b/cmake/installdata/test-reference-data.txt
@@ -1,3 +1,4 @@
+xbmc/addons/gui/skin/test/testdata/Timers.xml
 xbmc/cores/VideoPlayer/test/edl/testdata/comskipversion1.txt
 xbmc/cores/VideoPlayer/test/edl/testdata/comskipversion2.txt
 xbmc/cores/VideoPlayer/test/edl/testdata/edlautowindautowait.edl

--- a/cmake/treedata/common/tests.txt
+++ b/cmake/treedata/common/tests.txt
@@ -1,4 +1,5 @@
 xbmc/addons/test                  test/addons
+xbmc/addons/gui/skin/test         test/skin
 xbmc/cores/AudioEngine/Sinks/test test/audioengine_sinks
 xbmc/cores/VideoPlayer/test/edl   test/edl
 xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/test test/videoshaders

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -10706,7 +10706,7 @@ INFO::InfoPtr CGUIInfoManager::Register(const std::string &expression, int conte
     res = m_bools.insert(std::make_shared<InfoSingle>(condition, context, m_refreshCounter));
 
   if (res.second)
-    res.first->get()->Initialize();
+    res.first->get()->Initialize(this);
 
   return *(res.first);
 }

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -285,15 +285,17 @@ void CSkinInfo::LoadIncludes()
 
 void CSkinInfo::LoadTimers()
 {
+  m_skinTimerManager =
+      std::make_unique<CSkinTimerManager>(CServiceBroker::GetGUI()->GetInfoManager());
   const std::string timersPath =
       CSpecialProtocol::TranslatePathConvertCase(GetSkinPath("Timers.xml"));
   CLog::LogF(LOGINFO, "Trying to load skin timers from {}", timersPath);
-  m_skinTimerManager.LoadTimers(timersPath);
+  m_skinTimerManager->LoadTimers(timersPath);
 }
 
 void CSkinInfo::ProcessTimers()
 {
-  m_skinTimerManager.Process();
+  m_skinTimerManager->Process();
 }
 void CSkinInfo::ResolveIncludes(TiXmlElement* node,
                                 std::map<INFO::InfoPtr, bool>* xmlIncludeConditions /* = nullptr */)
@@ -418,27 +420,27 @@ void CSkinInfo::OnPostInstall(bool update, bool modal)
 
 void CSkinInfo::Unload()
 {
-  m_skinTimerManager.Stop();
+  m_skinTimerManager->Stop();
 }
 
 bool CSkinInfo::TimerIsRunning(const std::string& timer) const
 {
-  return m_skinTimerManager.TimerIsRunning(timer);
+  return m_skinTimerManager->TimerIsRunning(timer);
 }
 
 float CSkinInfo::GetTimerElapsedSeconds(const std::string& timer) const
 {
-  return m_skinTimerManager.GetTimerElapsedSeconds(timer);
+  return m_skinTimerManager->GetTimerElapsedSeconds(timer);
 }
 
 void CSkinInfo::TimerStart(const std::string& timer) const
 {
-  m_skinTimerManager.TimerStart(timer);
+  m_skinTimerManager->TimerStart(timer);
 }
 
 void CSkinInfo::TimerStop(const std::string& timer) const
 {
-  m_skinTimerManager.TimerStop(timer);
+  m_skinTimerManager->TimerStop(timer);
 }
 
 void CSkinInfo::SettingOptionsSkinColorsFiller(const SettingConstPtr& setting,

--- a/xbmc/addons/Skin.h
+++ b/xbmc/addons/Skin.h
@@ -283,7 +283,7 @@ protected:
   bool m_debugging;
 
   /*! Manager/Owner of skin timers */
-  CSkinTimerManager m_skinTimerManager;
+  std::unique_ptr<CSkinTimerManager> m_skinTimerManager;
 
 private:
   std::map<int, CSkinSettingStringPtr> m_strings;

--- a/xbmc/addons/gui/skin/SkinTimer.cpp
+++ b/xbmc/addons/gui/skin/SkinTimer.cpp
@@ -80,6 +80,11 @@ INFO::InfoPtr CSkinTimer::GetStopCondition() const
   return m_stopCondition;
 }
 
+bool CSkinTimer::ResetsOnStart() const
+{
+  return m_resetOnStart;
+}
+
 void CSkinTimer::OnStart()
 {
   if (m_startActions.HasAnyActions())

--- a/xbmc/addons/gui/skin/SkinTimer.cpp
+++ b/xbmc/addons/gui/skin/SkinTimer.cpp
@@ -85,6 +85,16 @@ INFO::InfoPtr CSkinTimer::GetStopCondition() const
   return m_stopCondition;
 }
 
+const CGUIAction& CSkinTimer::GetStartActions() const
+{
+  return m_startActions;
+}
+
+const CGUIAction& CSkinTimer::GetStopActions() const
+{
+  return m_stopActions;
+}
+
 bool CSkinTimer::ResetsOnStart() const
 {
   return m_resetOnStart;

--- a/xbmc/addons/gui/skin/SkinTimer.cpp
+++ b/xbmc/addons/gui/skin/SkinTimer.cpp
@@ -65,6 +65,11 @@ bool CSkinTimer::VerifyStopCondition() const
   return m_stopCondition && m_stopCondition->Get(INFO::DEFAULT_CONTEXT);
 }
 
+const std::string& CSkinTimer::GetName() const
+{
+  return m_name;
+}
+
 INFO::InfoPtr CSkinTimer::GetStartCondition() const
 {
   return m_startCondition;

--- a/xbmc/addons/gui/skin/SkinTimer.h
+++ b/xbmc/addons/gui/skin/SkinTimer.h
@@ -53,6 +53,11 @@ public:
   /*! \brief stops the skin timer */
   void Stop();
 
+  /*! \brief Getter for the timer name
+   * \return the timer name
+  */
+  const std::string& GetName() const;
+
   /*! \brief Getter for the timer start boolean condition/expression
   * \return the start boolean condition/expression (may be null)
   */

--- a/xbmc/addons/gui/skin/SkinTimer.h
+++ b/xbmc/addons/gui/skin/SkinTimer.h
@@ -68,6 +68,11 @@ public:
   */
   INFO::InfoPtr GetStopCondition() const;
 
+  /*! \brief Checks if a given timer is configured to reset every time it starts
+   * \return true if the timer is configured to reset on start, false otherwise
+  */
+  bool ResetsOnStart() const;
+
   /*! \brief Evaluates the timer start boolean info expression returning the respective result.
   * \details Called from the skin timer manager to check if the timer should be started
   * \return true if the condition is true, false otherwise

--- a/xbmc/addons/gui/skin/SkinTimer.h
+++ b/xbmc/addons/gui/skin/SkinTimer.h
@@ -78,6 +78,16 @@ public:
   */
   bool ResetsOnStart() const;
 
+  /*! \brief Gets the start actions of this skin timer
+   * \return the actions configured to start when the timer is started
+  */
+  const CGUIAction& GetStartActions() const;
+
+  /*! \brief Gets the stop actions of this skin timer
+   * \return the actions configured to start when the timer is stopped
+  */
+  const CGUIAction& GetStopActions() const;
+
   /*! \brief Evaluates the timer start boolean info expression returning the respective result.
   * \details Called from the skin timer manager to check if the timer should be started
   * \return true if the condition is true, false otherwise

--- a/xbmc/addons/gui/skin/SkinTimerManager.cpp
+++ b/xbmc/addons/gui/skin/SkinTimerManager.cpp
@@ -9,7 +9,6 @@
 #include "SkinTimerManager.h"
 
 #include "GUIInfoManager.h"
-#include "ServiceBroker.h"
 #include "guilib/GUIAction.h"
 #include "guilib/GUIComponent.h"
 #include "utils/StringUtils.h"
@@ -19,6 +18,10 @@
 #include <chrono>
 
 using namespace std::chrono_literals;
+
+CSkinTimerManager::CSkinTimerManager(CGUIInfoManager& infoMgr) : m_infoMgr{infoMgr}
+{
+}
 
 void CSkinTimerManager::LoadTimers(const std::string& path)
 {
@@ -69,8 +72,7 @@ void CSkinTimerManager::LoadTimerInternal(const TiXmlElement* node)
   if (node->FirstChild("start") && node->FirstChild("start")->FirstChild() &&
       !node->FirstChild("start")->FirstChild()->ValueStr().empty())
   {
-    startInfo = CServiceBroker::GetGUI()->GetInfoManager().Register(
-        node->FirstChild("start")->FirstChild()->ValueStr());
+    startInfo = m_infoMgr.Register(node->FirstChild("start")->FirstChild()->ValueStr());
     // check if timer needs to be reset after start
     if (node->FirstChildElement("start")->Attribute("reset") &&
         StringUtils::EqualsNoCase(node->FirstChildElement("start")->Attribute("reset"), "true"))
@@ -84,16 +86,14 @@ void CSkinTimerManager::LoadTimerInternal(const TiXmlElement* node)
   if (node->FirstChild("reset") && node->FirstChild("reset")->FirstChild() &&
       !node->FirstChild("reset")->FirstChild()->ValueStr().empty())
   {
-    resetInfo = CServiceBroker::GetGUI()->GetInfoManager().Register(
-        node->FirstChild("reset")->FirstChild()->ValueStr());
+    resetInfo = m_infoMgr.Register(node->FirstChild("reset")->FirstChild()->ValueStr());
   }
   // timer stop
   INFO::InfoPtr stopInfo{nullptr};
   if (node->FirstChild("stop") && node->FirstChild("stop")->FirstChild() &&
       !node->FirstChild("stop")->FirstChild()->ValueStr().empty())
   {
-    stopInfo = CServiceBroker::GetGUI()->GetInfoManager().Register(
-        node->FirstChild("stop")->FirstChild()->ValueStr());
+    stopInfo = m_infoMgr.Register(node->FirstChild("stop")->FirstChild()->ValueStr());
   }
 
   // process onstart actions
@@ -207,15 +207,15 @@ void CSkinTimerManager::Stop()
     const std::unique_ptr<CSkinTimer>::pointer timer = val.get();
     if (timer->GetStartCondition())
     {
-      CServiceBroker::GetGUI()->GetInfoManager().UnRegister(timer->GetStartCondition());
+      m_infoMgr.UnRegister(timer->GetStartCondition());
     }
     if (timer->GetStopCondition())
     {
-      CServiceBroker::GetGUI()->GetInfoManager().UnRegister(timer->GetStopCondition());
+      m_infoMgr.UnRegister(timer->GetStopCondition());
     }
     if (timer->GetResetCondition())
     {
-      CServiceBroker::GetGUI()->GetInfoManager().UnRegister(timer->GetResetCondition());
+      m_infoMgr.UnRegister(timer->GetResetCondition());
     }
   }
   m_timers.clear();

--- a/xbmc/addons/gui/skin/SkinTimerManager.cpp
+++ b/xbmc/addons/gui/skin/SkinTimerManager.cpp
@@ -174,6 +174,11 @@ void CSkinTimerManager::TimerStop(const std::string& timer) const
   m_timers.at(timer)->Stop();
 }
 
+size_t CSkinTimerManager::GetTimerCount() const
+{
+  return m_timers.size();
+}
+
 bool CSkinTimerManager::TimerExists(const std::string& timer) const
 {
   return m_timers.count(timer) != 0;

--- a/xbmc/addons/gui/skin/SkinTimerManager.cpp
+++ b/xbmc/addons/gui/skin/SkinTimerManager.cpp
@@ -136,42 +136,40 @@ void CSkinTimerManager::LoadTimerInternal(const TiXmlElement* node)
 
 bool CSkinTimerManager::TimerIsRunning(const std::string& timer) const
 {
-  if (!TimerExists(timer))
+  if (auto iter = m_timers.find(timer); iter != m_timers.end())
   {
-    CLog::LogF(LOGERROR, "Couldn't find Skin Timer with name: {}", timer);
-    return false;
+    return iter->second->IsRunning();
   }
-  return m_timers.at(timer)->IsRunning();
+  CLog::LogF(LOGERROR, "Couldn't find Skin Timer with name: {}", timer);
+  return false;
 }
 
 float CSkinTimerManager::GetTimerElapsedSeconds(const std::string& timer) const
 {
-  if (!TimerExists(timer))
+  if (auto iter = m_timers.find(timer); iter != m_timers.end())
   {
-    CLog::LogF(LOGERROR, "Couldn't find Skin Timer with name: {}", timer);
-    return 0;
+    return iter->second->GetElapsedSeconds();
   }
-  return m_timers.at(timer)->GetElapsedSeconds();
+  CLog::LogF(LOGERROR, "Couldn't find Skin Timer with name: {}", timer);
+  return 0;
 }
 
 void CSkinTimerManager::TimerStart(const std::string& timer) const
 {
-  if (!TimerExists(timer))
+  if (auto iter = m_timers.find(timer); iter != m_timers.end())
   {
-    CLog::LogF(LOGERROR, "Couldn't find Skin Timer with name: {}", timer);
-    return;
+    return iter->second->Start();
   }
-  m_timers.at(timer)->Start();
+  CLog::LogF(LOGERROR, "Couldn't find Skin Timer with name: {}", timer);
 }
 
 void CSkinTimerManager::TimerStop(const std::string& timer) const
 {
-  if (!TimerExists(timer))
+  if (auto iter = m_timers.find(timer); iter != m_timers.end())
   {
-    CLog::LogF(LOGERROR, "Couldn't find Skin Timer with name: {}", timer);
-    return;
+    return iter->second->Stop();
   }
-  m_timers.at(timer)->Stop();
+  CLog::LogF(LOGERROR, "Couldn't find Skin Timer with name: {}", timer);
 }
 
 size_t CSkinTimerManager::GetTimerCount() const

--- a/xbmc/addons/gui/skin/SkinTimerManager.cpp
+++ b/xbmc/addons/gui/skin/SkinTimerManager.cpp
@@ -184,6 +184,17 @@ bool CSkinTimerManager::TimerExists(const std::string& timer) const
   return m_timers.count(timer) != 0;
 }
 
+std::unique_ptr<CSkinTimer> CSkinTimerManager::GrabTimer(const std::string& timer)
+{
+  if (auto iter = m_timers.find(timer); iter != m_timers.end())
+  {
+    auto timerInstance = std::move(iter->second);
+    m_timers.erase(iter);
+    return timerInstance;
+  }
+  return {};
+}
+
 void CSkinTimerManager::Stop()
 {
   // skintimers, as infomanager clients register info conditions/expressions in the infomanager.

--- a/xbmc/addons/gui/skin/SkinTimerManager.cpp
+++ b/xbmc/addons/gui/skin/SkinTimerManager.cpp
@@ -55,7 +55,7 @@ void CSkinTimerManager::LoadTimerInternal(const TiXmlElement* node)
   }
 
   std::string timerName = node->FirstChild("name")->FirstChild()->Value();
-  if (m_timers.count(timerName) > 0)
+  if (TimerExists(timerName))
   {
     CLog::LogF(LOGWARNING,
                "Ignoring timer with name {} - another timer with the same name already exists",
@@ -136,7 +136,7 @@ void CSkinTimerManager::LoadTimerInternal(const TiXmlElement* node)
 
 bool CSkinTimerManager::TimerIsRunning(const std::string& timer) const
 {
-  if (m_timers.count(timer) == 0)
+  if (!TimerExists(timer))
   {
     CLog::LogF(LOGERROR, "Couldn't find Skin Timer with name: {}", timer);
     return false;
@@ -146,7 +146,7 @@ bool CSkinTimerManager::TimerIsRunning(const std::string& timer) const
 
 float CSkinTimerManager::GetTimerElapsedSeconds(const std::string& timer) const
 {
-  if (m_timers.count(timer) == 0)
+  if (!TimerExists(timer))
   {
     CLog::LogF(LOGERROR, "Couldn't find Skin Timer with name: {}", timer);
     return 0;
@@ -156,7 +156,7 @@ float CSkinTimerManager::GetTimerElapsedSeconds(const std::string& timer) const
 
 void CSkinTimerManager::TimerStart(const std::string& timer) const
 {
-  if (m_timers.count(timer) == 0)
+  if (!TimerExists(timer))
   {
     CLog::LogF(LOGERROR, "Couldn't find Skin Timer with name: {}", timer);
     return;
@@ -166,12 +166,17 @@ void CSkinTimerManager::TimerStart(const std::string& timer) const
 
 void CSkinTimerManager::TimerStop(const std::string& timer) const
 {
-  if (m_timers.count(timer) == 0)
+  if (!TimerExists(timer))
   {
     CLog::LogF(LOGERROR, "Couldn't find Skin Timer with name: {}", timer);
     return;
   }
   m_timers.at(timer)->Stop();
+}
+
+bool CSkinTimerManager::TimerExists(const std::string& timer) const
+{
+  return m_timers.count(timer) != 0;
 }
 
 void CSkinTimerManager::Stop()

--- a/xbmc/addons/gui/skin/SkinTimerManager.h
+++ b/xbmc/addons/gui/skin/SkinTimerManager.h
@@ -14,6 +14,8 @@
 #include <memory>
 #include <string>
 
+class CGUIInfoManager;
+
 /*! \brief CSkinTimerManager is the container and manager for Skin timers. Its role is that of
  * checking if the timer boolean conditions are valid, start or stop timers and execute the respective
  * builtin actions linked to the timer lifecycle
@@ -24,8 +26,11 @@
 class CSkinTimerManager
 {
 public:
-  /*! \brief Skin timer manager constructor */
-  CSkinTimerManager() = default;
+  /*! \brief Skin timer manager constructor
+   *  \param infoMgr reference to the infomanager
+   */
+  CSkinTimerManager(CGUIInfoManager& infoMgr);
+  CSkinTimerManager() = delete;
 
   /*! \brief Default skin timer manager destructor */
   ~CSkinTimerManager() = default;
@@ -91,4 +96,5 @@ private:
 
   /*! Container for the skin timers */
   std::map<std::string, std::unique_ptr<CSkinTimer>> m_timers;
+  CGUIInfoManager& m_infoMgr;
 };

--- a/xbmc/addons/gui/skin/SkinTimerManager.h
+++ b/xbmc/addons/gui/skin/SkinTimerManager.h
@@ -38,6 +38,11 @@ public:
   /*! \brief Stops the manager */
   void Stop();
 
+  /*! \brief Gets the total number of timers registered in the manager
+     *  \return the timer count
+    */
+  size_t GetTimerCount() const;
+
   /*! \brief Checks if the timer with name `timer` exists
    *  \param timer the name of the skin timer
    *  \return true if the given timer exists, false otherwise

--- a/xbmc/addons/gui/skin/SkinTimerManager.h
+++ b/xbmc/addons/gui/skin/SkinTimerManager.h
@@ -49,6 +49,12 @@ public:
   */
   bool TimerExists(const std::string& timer) const;
 
+  /*! \brief Move a given timer, removing it from the manager
+   *  \param timer the name of the skin timer
+   *  \return the timer (moved), nullptr if it doesn't exist
+  */
+  std::unique_ptr<CSkinTimer> GrabTimer(const std::string& timer);
+
   /*! \brief Checks if the timer with name `timer` is running
    \param timer the name of the skin timer
    \return true if the given timer exists and is running, false otherwise

--- a/xbmc/addons/gui/skin/SkinTimerManager.h
+++ b/xbmc/addons/gui/skin/SkinTimerManager.h
@@ -38,6 +38,12 @@ public:
   /*! \brief Stops the manager */
   void Stop();
 
+  /*! \brief Checks if the timer with name `timer` exists
+   *  \param timer the name of the skin timer
+   *  \return true if the given timer exists, false otherwise
+  */
+  bool TimerExists(const std::string& timer) const;
+
   /*! \brief Checks if the timer with name `timer` is running
    \param timer the name of the skin timer
    \return true if the given timer exists and is running, false otherwise

--- a/xbmc/addons/gui/skin/test/CMakeLists.txt
+++ b/xbmc/addons/gui/skin/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(SOURCES TestSkinTimers.cpp)
+
+core_add_test_library(skin_test)

--- a/xbmc/addons/gui/skin/test/TestSkinTimers.cpp
+++ b/xbmc/addons/gui/skin/test/TestSkinTimers.cpp
@@ -1,0 +1,88 @@
+/*
+ *  Copyright (C) 2023- Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+#include "GUIInfoManager.h"
+#include "addons/gui/skin/SkinTimerManager.h"
+#include "test/TestUtils.h"
+
+#include <gtest/gtest.h>
+
+class TestSkinTimers : public ::testing::Test
+{
+protected:
+  TestSkinTimers() = default;
+};
+
+TEST_F(TestSkinTimers, TestSkinTimerParsing)
+{
+  auto timersFile = XBMC_REF_FILE_PATH("xbmc/addons/gui/skin/test/testdata/Timers.xml");
+  CGUIInfoManager infoMgr;
+  CSkinTimerManager skinTimerManager{infoMgr};
+  skinTimerManager.LoadTimers(timersFile);
+  // ensure only 5 timers are loaded (there are two invalid timers in the test file)
+  EXPECT_EQ(skinTimerManager.GetTimerCount(), 5);
+  // timer1
+  EXPECT_EQ(skinTimerManager.TimerExists("timer1"), true);
+  auto timer1 = skinTimerManager.GrabTimer("timer1");
+  EXPECT_NE(timer1, nullptr);
+  EXPECT_EQ(skinTimerManager.GetTimerCount(), 4);
+  EXPECT_EQ(timer1->GetName(), "timer1");
+  EXPECT_EQ(timer1->ResetsOnStart(), true);
+  EXPECT_EQ(timer1->GetStartCondition()->GetExpression(), "true");
+  EXPECT_EQ(timer1->GetStopCondition()->GetExpression(), "true");
+  EXPECT_EQ(timer1->GetResetCondition()->GetExpression(), "true");
+  EXPECT_EQ(timer1->GetStartActions().GetActionCount(), 2);
+  EXPECT_EQ(timer1->GetStopActions().GetActionCount(), 2);
+  EXPECT_EQ(timer1->GetStartActions().HasConditionalActions(), false);
+  EXPECT_EQ(timer1->GetStopActions().HasConditionalActions(), false);
+  EXPECT_EQ(timer1->GetStartActions().HasAnyActions(), true);
+  EXPECT_EQ(timer1->GetStopActions().HasAnyActions(), true);
+  // timer2
+  auto timer2 = skinTimerManager.GrabTimer("timer2");
+  EXPECT_NE(timer2, nullptr);
+  EXPECT_EQ(skinTimerManager.GetTimerCount(), 3);
+  EXPECT_EQ(timer2->ResetsOnStart(), false);
+  EXPECT_EQ(timer2->GetStartActions().GetActionCount(), 1);
+  EXPECT_EQ(timer2->GetStopActions().GetActionCount(), 1);
+  EXPECT_EQ(timer2->GetStartActions().HasConditionalActions(), false);
+  EXPECT_EQ(timer2->GetStopActions().HasConditionalActions(), false);
+  EXPECT_EQ(timer2->GetStartActions().HasAnyActions(), true);
+  EXPECT_EQ(timer2->GetStopActions().HasAnyActions(), true);
+  // timer3
+  auto timer3 = skinTimerManager.GrabTimer("timer3");
+  EXPECT_NE(timer3, nullptr);
+  EXPECT_EQ(skinTimerManager.GetTimerCount(), 2);
+  EXPECT_EQ(timer3->GetName(), "timer3");
+  EXPECT_EQ(timer3->GetStartActions().HasConditionalActions(), false);
+  EXPECT_EQ(timer3->GetStopActions().HasConditionalActions(), false);
+  EXPECT_EQ(timer3->GetStartActions().HasAnyActions(), false);
+  EXPECT_EQ(timer3->GetStopActions().HasAnyActions(), false);
+  EXPECT_EQ(timer3->GetStartCondition(), nullptr);
+  EXPECT_EQ(timer3->GetStopCondition(), nullptr);
+  EXPECT_EQ(timer3->GetResetCondition(), nullptr);
+  // timer4
+  auto timer4 = skinTimerManager.GrabTimer("timer4");
+  EXPECT_NE(timer4, nullptr);
+  EXPECT_EQ(skinTimerManager.GetTimerCount(), 1);
+  EXPECT_EQ(timer4->GetName(), "timer4");
+  EXPECT_EQ(timer4->GetStartCondition(), nullptr);
+  EXPECT_EQ(timer4->GetStopCondition(), nullptr);
+  EXPECT_EQ(timer4->GetResetCondition(), nullptr);
+  EXPECT_EQ(timer4->GetStartActions().HasAnyActions(), true);
+  EXPECT_EQ(timer4->GetStopActions().HasAnyActions(), true);
+  EXPECT_EQ(timer4->GetStartActions().HasConditionalActions(), false);
+  EXPECT_EQ(timer4->GetStopActions().HasConditionalActions(), false);
+  // timer5
+  auto timer5 = skinTimerManager.GrabTimer("timer5");
+  EXPECT_NE(timer5, nullptr);
+  EXPECT_EQ(skinTimerManager.GetTimerCount(), 0);
+  EXPECT_EQ(timer5->GetName(), "timer5");
+  EXPECT_EQ(timer5->GetStartActions().HasAnyActions(), true);
+  EXPECT_EQ(timer5->GetStopActions().HasAnyActions(), true);
+  EXPECT_EQ(timer5->GetStartActions().HasConditionalActions(), true);
+  EXPECT_EQ(timer5->GetStopActions().HasConditionalActions(), true);
+}

--- a/xbmc/addons/gui/skin/test/testdata/Timers.xml
+++ b/xbmc/addons/gui/skin/test/testdata/Timers.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<timers>
+    <timer>
+        <name>timer1</name>
+        <description>This is a valid timer with multiple actions and resets everytime it is started</description>
+        <start reset="true">true</start>
+        <reset>true</reset>
+        <stop>true</stop>
+        <onstart>Notification(timer1, notification 1, 1000)</onstart>
+        <onstart>Notification(timer1, notification 2, 1000)</onstart>
+        <onstop>Notification(timer1, notification 3, 1000)</onstop>
+        <onstop>Notification(timer1, notification 4, 1000)</onstop>
+    </timer>
+    <timer>
+        <name>timer2</name>
+        <description>This is a valid timer without reset on start</description>
+        <start>true</start>
+        <reset>true</reset>
+        <stop>true</stop>
+        <onstart>Notification(timer1, notification 1, 1000)</onstart>
+        <onstop>Notification(timer1, notification 2, 1000)</onstop>
+    </timer>
+    <timer>
+        <name>timer3</name>
+        <description>This is a valid timer fully managed from builtins</description>
+    </timer>
+    <timer>
+        <name>timer4</name>
+        <description>This is a valid timer fully managed from builtins (and executes a few bultins)</description>
+        <onstart>Notification(timer1, notification 1, 1000)</onstart>
+        <onstop>Notification(timer1, notification 2, 1000)</onstop>
+    </timer>
+    <timer>
+        <name>timer5</name>
+        <description>This is a timer with conditional execution on builtins</description>
+        <onstart condition="Integer.IsEven(Integer.ValueOf(2))">Notification(timer1, notification 1, 1000)</onstart>
+        <onstop condition="true">Notification(timer1, notification 2, 1000)</onstop>
+    </timer>
+    <timer>
+        <name></name>
+        <description>This is an invalid timer (name empty)</description>
+        <start>true</start>
+        <stop>true</stop>
+    </timer>
+    <timer>
+        <description>This is an invalid timer (no name element)</description>
+        <start>true</start>
+        <stop>true</stop>
+    </timer>
+</timers>

--- a/xbmc/guilib/GUIAction.cpp
+++ b/xbmc/guilib/GUIAction.cpp
@@ -121,6 +121,16 @@ void CGUIAction::SetNavigation(int id)
   m_actions.emplace_back(std::move(strId));
 }
 
+bool CGUIAction::HasConditionalActions() const
+{
+  for (const auto& i : m_actions)
+  {
+    if (i.HasCondition())
+      return true;
+  }
+  return false;
+}
+
 bool CGUIAction::HasActionsMeetingCondition() const
 {
   CGUIInfoManager& infoMgr = CServiceBroker::GetGUI()->GetInfoManager();
@@ -135,6 +145,11 @@ bool CGUIAction::HasActionsMeetingCondition() const
 bool CGUIAction::HasAnyActions() const
 {
   return m_actions.size() > 0;
+}
+
+size_t CGUIAction::GetActionCount() const
+{
+  return m_actions.size();
 }
 
 void CGUIAction::Append(const CExecutableAction& action)

--- a/xbmc/guilib/GUIAction.h
+++ b/xbmc/guilib/GUIAction.h
@@ -85,6 +85,10 @@ public:
    */
   bool ExecuteActions(int controlID, int parentID, const CGUIListItemPtr& item = nullptr) const;
   /**
+   * Check if there are any conditional actions
+  */
+  bool HasConditionalActions() const;
+  /**
    * Check if there is any action that meet its condition
    */
   bool HasActionsMeetingCondition() const;
@@ -92,6 +96,10 @@ public:
    * Check if there is any action
    */
   bool HasAnyActions() const;
+  /**
+   * Get the total number of actions
+  */
+  size_t GetActionCount() const;
   /**
    * Get navigation route that meet its conditions first
    */

--- a/xbmc/interfaces/info/InfoBool.h
+++ b/xbmc/interfaces/info/InfoBool.h
@@ -12,6 +12,7 @@
 #include <string>
 
 class CGUIListItem;
+class CGUIInfoManager;
 
 namespace INFO
 {
@@ -25,7 +26,7 @@ public:
   InfoBool(const std::string &expression, int context, unsigned int &refreshCounter);
   virtual ~InfoBool() = default;
 
-  virtual void Initialize() {}
+  virtual void Initialize(CGUIInfoManager* infoMgr) { m_infoMgr = infoMgr; }
 
   /*! \brief Get the value of this info bool
    This is called to update (if dirty) and fetch the value of the info bool
@@ -72,6 +73,7 @@ protected:
   int m_context;               ///< contextual information to go with the condition
   bool m_listItemDependent = false; ///< do not cache if a listitem pointer is given
   std::string  m_expression;   ///< original expression
+  CGUIInfoManager* m_infoMgr;
 
 private:
   unsigned int m_refreshCounter = 0;

--- a/xbmc/interfaces/info/InfoExpression.h
+++ b/xbmc/interfaces/info/InfoExpression.h
@@ -28,7 +28,7 @@ public:
     : InfoBool(expression, context, refreshCounter)
   {
   }
-  void Initialize() override;
+  void Initialize(CGUIInfoManager* infoMgr) override;
 
   void Update(int contextWindow, const CGUIListItem* item) override;
 
@@ -47,7 +47,7 @@ public:
   }
   ~InfoExpression() override = default;
 
-  void Initialize() override;
+  void Initialize(CGUIInfoManager* infoMgr) override;
 
   void Update(int contextWindow, const CGUIListItem* item) override;
 


### PR DESCRIPTION
## Description
This PR adds unit tests for the parsing of `Timers.xml` - the skin timers file. Unfortunately since there are many components in the codebase which are tangled together (even if abstracted via service broker) making these was not easy at all...

I've decoupled a few components from service broker (using injection instead). Namely, all components that need to register infoconditions should not require to get the GUI from the service broker - the GUI is the owner of such components (if not something is wrong), hence the manager can simply be injected.

Drawback of this PR that I had to create a few methods/getters that aren't currently used anywhere except on the tests. Regardless I personally think it is better to have "dead code" as long as we increase the coverage of the tests and the interface is also improved anyway.

## Motivation and context
Correctness of the codebase. Setup the base for migrating this to tinyxml2.

## How has this been tested?
Runtime tested, executed tests

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
