### PR TITLE
Install wayland session entry

### DIFF
--- a/cmake/scripts/linux/Install.cmake
+++ b/cmake/scripts/linux/Install.cmake
@@ -39,6 +39,10 @@ configure_file(${CMAKE_SOURCE_DIR}/tools/Linux/kodi-standalone.sh.in
 configure_file(${CMAKE_SOURCE_DIR}/cmake/KodiConfig.cmake.in
                ${CORE_BUILD_DIR}/scripts/${APP_NAME}Config.cmake @ONLY)
 
+# Configure gbm session entry
+configure_file(${CMAKE_SOURCE_DIR}/tools/Linux/kodi-gbm-session.desktop.in
+               ${CORE_BUILD_DIR}/${APP_NAME_LC}-gbm-session.desktop @ONLY)
+
 # Configure xsession entry
 configure_file(${CMAKE_SOURCE_DIR}/tools/Linux/kodi-xsession.desktop.in
                ${CORE_BUILD_DIR}/${APP_NAME_LC}-xsession.desktop @ONLY)
@@ -84,6 +88,12 @@ foreach(file ${install_data})
           DESTINATION ${datarootdir}/${APP_NAME_LC}/${dir}
           COMPONENT kodi)
 endforeach()
+
+# Install gbm session entry
+install(FILES ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/${APP_NAME_LC}-gbm-session.desktop
+        RENAME ${APP_NAME_LC}-gbm.desktop
+        DESTINATION ${datarootdir}/wayland-sessions
+        COMPONENT kodi)
 
 # Install xsession entry
 install(FILES ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/${APP_NAME_LC}-xsession.desktop

--- a/tools/Linux/kodi-gbm-session.desktop.in
+++ b/tools/Linux/kodi-gbm-session.desktop.in
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=@APP_NAME@ on GBM
+Comment=This session will start @APP_NAME@ media center
+Exec=@APP_NAME_LC@-standalone --windowing=gbm
+TryExec=@APP_NAME_LC@-standalone
+Type=Application
+Keywords=audio;video;media;center;tv;movies;series;songs;remote;
+Icon=@APP_NAME_LC@


### PR DESCRIPTION
## Description
Install wayland session entry for linux so that we can start a gbm session from display manager.

## Motivation and context
There is only a xsession entry on linux, which is not enough because some hardware like arm platform has better support for gbm/wayland.

## How has this been tested?
Choose `Kodi Wayland` from display manager, then start a gbm session.

## What is the effect on users?
User will have better experience on arm platforms.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
