### PR TITLE
[Windows] fix 'FileTimeToLocalFileTime' to account for daylight saving

### DIFF
--- a/xbmc/platform/win32/XTimeUtils.cpp
+++ b/xbmc/platform/win32/XTimeUtils.cpp
@@ -84,12 +84,20 @@ void GetLocalTime(SystemTime* systemTime)
 
 int FileTimeToLocalFileTime(const FileTime* fileTime, FileTime* localFileTime)
 {
-  FILETIME file;
+  FILETIME file{};
   file.dwLowDateTime = fileTime->lowDateTime;
   file.dwHighDateTime = fileTime->highDateTime;
 
-  FILETIME localFile;
-  int ret = ::FileTimeToLocalFileTime(&file, &localFile);
+  SYSTEMTIME systemTime{};
+  if (FALSE == ::FileTimeToSystemTime(&file, &systemTime))
+    return FALSE;
+
+  SYSTEMTIME localSystemTime{};
+  if (FALSE == ::SystemTimeToTzSpecificLocalTime(nullptr, &systemTime, &localSystemTime))
+    return FALSE;
+
+  FILETIME localFile{};
+  int ret = ::SystemTimeToFileTime(&localSystemTime, &localFile);
 
   localFileTime->lowDateTime = localFile.dwLowDateTime;
   localFileTime->highDateTime = localFile.dwHighDateTime;


### PR DESCRIPTION
## Description
Fix `FileTimeToLocalFileTime` to account for daylight saving

## Motivation and context
Found that in SQL video library used from multiple platforms (Android and Windows) hashes of paths stored on DB is different if is calculated from Windows setup or Android setup. This with same media files in a simple folder (no sub folders).

`nfs://192.168.50.13/volume1/NAS/MKV/2/`

Inside this folder only MKV files and this path corresponds to one entry in media sources.

The hash of folder is stored in `path` table of DB:

![path](https://github.com/xbmc/xbmc/assets/58434170/415553dd-9c9a-4e0f-a1ff-60cc8fa3ca3e)

This hash is used to detect if contents of folder has changed and needs to be re-scanned for changes (e.g movies added or removed).

Since hash is different depending if is calculated from Windows or Android, opening Kodi in Windows after use Android triggers full scan of this path as Kodi "thinks" content has changed. New hash is calculated and stored and nothing more happens (no new movies, etc.). But now if is opened in Android same ting happens and folder is re-scanned for changes... 

If the folder contains several thousand files this is a slow process that takes several seconds.

This MD5 hash can be calculated in two different methods `GetFastHash`:

https://github.com/xbmc/xbmc/blob/6601acd5c559649e3d2f27050a331c922550f355/xbmc/video/VideoInfoScanner.cpp#L2037

This is based on directory modified time only and works fine but cannot be used when folder contains sub folders.... not is the case but due Synology generates some times system folders with metadata called `@eaDir` that was present preventing fast hashing...

When is not possible use fast hash is used `GetPathHash`:

https://github.com/xbmc/xbmc/blob/6601acd5c559649e3d2f27050a331c922550f355/xbmc/video/VideoInfoScanner.cpp#L1990

Using this when the hash difference occurs. After some tests difference is due file time part. Removing this line "fixes" the issue:

https://github.com/xbmc/xbmc/blob/6601acd5c559649e3d2f27050a331c922550f355/xbmc/video/VideoInfoScanner.cpp#L2015
 
(excluding file times from hash calculation)

After more tests time of some files (not all) is incorrect.  e.g. `16:52`  when true file time is `17:52` from Windows explorer or directly from NAS web interface or from Android phone or Kodi in Android. 

Then file time is wrong only from Kodi Windows.

In this case (using NFS) the bad conversion occurs here:

https://github.com/xbmc/xbmc/blob/6601acd5c559649e3d2f27050a331c922550f355/xbmc/filesystem/NFSDirectory.cpp#L278-L283

The root cause is in last line and found this in Microsoft documentation:

> Remarks
> To account for daylight saving time when converting a file time to a local time, use the following sequence of functions in place of using FileTimeToLocalFileTime:

[FileTimeToSystemTime](https://learn.microsoft.com/en-us/windows/desktop/api/timezoneapi/nf-timezoneapi-filetimetosystemtime)
[SystemTimeToTzSpecificLocalTime](https://learn.microsoft.com/en-us/windows/desktop/api/timezoneapi/nf-timezoneapi-systemtimetotzspecificlocaltime)
[SystemTimeToFileTime](https://learn.microsoft.com/en-us/windows/desktop/api/timezoneapi/nf-timezoneapi-systemtimetofiletime)

https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-filetimetolocalfiletime

Implemented and works fine.... now MD5 hash calculated form all files names sizes and times is the same in Windows and Android.

## How has this been tested?
Runtime tested Windows x64

## What is the effect on users?
Fixes some paths of SQL media library are re-scanned needlessly when Kodi used from multiple platforms (Windows and other) due MD5 hashes of same files mismatch depending if is calculated from Windows / Android.

NOTE: Since the hashes change when using the correct time, users will notice that the first time they open Kodi including this change it will re-scan all sources (even if there are no changes).


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
