### PR TITLE
[windowing][dx] Implement ForceFullScreen to get rid of CApp ifdef

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -288,18 +288,11 @@ void CApplication::HandlePortEvents()
             settings->SetInt(CSettings::SETTING_WINDOW_HEIGHT, newEvent.resize.h);
             settings->Save();
           }
-#ifdef TARGET_WINDOWS
           else
           {
-            // this may occurs when OS tries to resize application window
-            //CDisplaySettings::GetInstance().SetCurrentResolution(RES_DESKTOP, true);
-            //auto& gfxContext = CServiceBroker::GetWinSystem()->GetGfxContext();
-            //gfxContext.SetVideoResolution(gfxContext.GetVideoResolution(), true);
-            // try to resize window back to it's full screen size
-            auto& res_info = CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP);
-            CServiceBroker::GetWinSystem()->ResizeWindow(res_info.iScreenWidth, res_info.iScreenHeight, 0, 0);
+            const auto& res_info = CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP);
+            CServiceBroker::GetWinSystem()->ForceFullScreen(res_info);
           }
-#endif
         }
         break;
       case XBMC_VIDEOMOVE:

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -85,6 +85,12 @@ public:
   virtual int NoOfBuffers();
 
   /*!
+   * \brief Forces the window to fullscreen provided the window resolution
+   * \param resInfo - the resolution info
+   */
+  virtual void ForceFullScreen(const RESOLUTION_INFO& resInfo) {}
+
+  /*!
    * \brief Get average display latency
    *
    * The latency should be measured as the time between finishing the rendering

--- a/xbmc/windowing/win10/WinSystemWin10.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10.cpp
@@ -155,6 +155,11 @@ void CWinSystemWin10::FinishWindowResize(int newWidth, int newHeight)
   ApplicationView::PreferredLaunchWindowingMode(ApplicationViewWindowingMode::PreferredLaunchViewSize);
 }
 
+void CWinSystemWin10::ForceFullScreen(const RESOLUTION_INFO& resInfo)
+{
+  ResizeWindow(resInfo.iScreenWidth, resInfo.iScreenHeight, 0, 0);
+}
+
 void CWinSystemWin10::AdjustWindow()
 {
   CLog::Log(LOGDEBUG, __FUNCTION__": adjusting window if required.");

--- a/xbmc/windowing/win10/WinSystemWin10.h
+++ b/xbmc/windowing/win10/WinSystemWin10.h
@@ -71,6 +71,7 @@ public:
   bool DestroyWindowSystem() override;
   bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
   void FinishWindowResize(int newWidth, int newHeight) override;
+  void ForceFullScreen(const RESOLUTION_INFO& resInfo) override;
   void UpdateResolutions() override;
   void NotifyAppFocusChange(bool bGaining) override;
   void ShowOSMouse(bool show) override;

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -365,6 +365,11 @@ void CWinSystemWin32::FinishWindowResize(int newWidth, int newHeight)
   m_nHeight = newHeight;
 }
 
+void CWinSystemWin32::ForceFullScreen(const RESOLUTION_INFO& resInfo)
+{
+  ResizeWindow(resInfo.iScreenWidth, resInfo.iScreenHeight, 0, 0);
+}
+
 void CWinSystemWin32::AdjustWindow(bool forceResize)
 {
   CLog::LogF(LOGDEBUG, "adjusting window if required.");

--- a/xbmc/windowing/windows/WinSystemWin32.h
+++ b/xbmc/windowing/windows/WinSystemWin32.h
@@ -84,6 +84,7 @@ public:
   bool DestroyWindowSystem() override;
   bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
   void FinishWindowResize(int newWidth, int newHeight) override;
+  void ForceFullScreen(const RESOLUTION_INFO& resInfo) override;
   void UpdateResolutions() override;
   bool CenterWindow() override;
   virtual void NotifyAppFocusChange(bool bGaining) override;


### PR DESCRIPTION
## Description
One cleanup I had on the queue.
~When working on the macos nativewindowing stuff I found out that the resize event might be triggered when running in fullscreen. The treatment of this event is different than the resize in windowed mode because of the window coordinates (0,0 vs -1,-1). Hence, I added a new event `XBMC_FULLSCREENUPDATE` to differentiate it from the other one.
In CApp there's an ifdef for windows that pretty much does the same, so just emit the new event from the windowing implementation to cleanup CApp.~

After the discussion on this PR probably the best way to get rid of the ifdef is to create a new method for windowing that platforms can use to force/refresh the fullscreen state. Added `ForcedFullScreen()` and implemented it for win10 and win32. The origins may be wrong (0,0) - virtual screens - and this doesn't attempt to cover the whole range of issues but should be identical to the code we have currently on master (without the ifdef).

~v3 - lets just nuke it a see who screams :)~

v4 - back to v2 :)

## Motivation and context
Cleanup

## How has this been tested?
Runtime tested, did not find regressions. Would be nice if some windows user can confirm no regressions are created.

## What is the effect on users?
I hope none

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
