### PR TITLE
[GUI][macos][nativewindowing] Kill XBMC_FULLSCREEN_UPDATE event

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -296,22 +296,12 @@ void CApplication::HandlePortEvents()
             //auto& gfxContext = CServiceBroker::GetWinSystem()->GetGfxContext();
             //gfxContext.SetVideoResolution(gfxContext.GetVideoResolution(), true);
             // try to resize window back to it's full screen size
-            //! TODO: DX windowing should emit XBMC_FULLSCREEN_UPDATE instead with the proper dimensions
-            //! and position to avoid the ifdef in common code
             auto& res_info = CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP);
             CServiceBroker::GetWinSystem()->ResizeWindow(res_info.iScreenWidth, res_info.iScreenHeight, 0, 0);
           }
 #endif
         }
         break;
-      case XBMC_FULLSCREEN_UPDATE:
-      {
-        if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_fullScreen)
-        {
-          CServiceBroker::GetWinSystem()->ResizeWindow(newEvent.resize.w, newEvent.resize.h, 0, 0);
-        }
-        break;
-      }
       case XBMC_VIDEOMOVE:
       {
         CServiceBroker::GetWinSystem()->OnMove(newEvent.move.x, newEvent.move.y);

--- a/xbmc/windowing/XBMC_events.h
+++ b/xbmc/windowing/XBMC_events.h
@@ -22,7 +22,6 @@ typedef enum
   XBMC_MOUSEBUTTONUP, /* Mouse button released */
   XBMC_QUIT, /* User-requested quit */
   XBMC_VIDEORESIZE, /* User resized video mode */
-  XBMC_FULLSCREEN_UPDATE, /* Triggered by an OS event when Kodi is running in fullscreen, rescale and repositioning is required  */
   XBMC_SCREENCHANGE, /* Window moved to a different screen */
   XBMC_VIDEOMOVE, /* User moved the window */
   XBMC_MODECHANGE, /* Video mode must be changed */

--- a/xbmc/windowing/osx/OpenGL/WindowControllerMacOS.mm
+++ b/xbmc/windowing/osx/OpenGL/WindowControllerMacOS.mm
@@ -54,41 +54,25 @@
 
 - (void)windowDidResize:(NSNotification*)aNotification
 {
-  NSRect rect = [self.window.contentView
-      convertRectToBacking:[self.window contentRectForFrameRect:self.window.frame]];
-  int width = static_cast<int>(rect.size.width);
-  int height = static_cast<int>(rect.size.height);
-
-  XBMC_Event newEvent = {};
-
   if ((self.window.styleMask & NSWindowStyleMaskFullScreen) != NSWindowStyleMaskFullScreen)
   {
-    RESOLUTION res_index = RES_DESKTOP;
-    if ((width == CDisplaySettings::GetInstance().GetResolutionInfo(res_index).iWidth) &&
-        (height == CDisplaySettings::GetInstance().GetResolutionInfo(res_index).iHeight))
-      return;
+    NSRect rect = [self.window.contentView
+        convertRectToBacking:[self.window contentRectForFrameRect:self.window.frame]];
 
+    XBMC_Event newEvent = {};
     newEvent.type = XBMC_VIDEORESIZE;
-  }
-  else
-  {
-    // macos may trigger a resize/rescale event after (or in) the fullscreen state. Use a different event
-    // so that window coordinates are properly set (XBMC_VIDEORESIZE is only supposed to be used when running
-    // windowed)
-    newEvent.type = XBMC_FULLSCREEN_UPDATE;
-  }
+    newEvent.resize.w = static_cast<int>(rect.size.width);
+    newEvent.resize.h = static_cast<int>(rect.size.height);
 
-  newEvent.resize.w = width;
-  newEvent.resize.h = height;
-
-  // check for valid sizes cause in some cases
-  // we are hit during fullscreen transition from macos
-  // and might be technically "zero" sized
-  if (newEvent.resize.w != 0 && newEvent.resize.h != 0)
-  {
-    std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
-    if (appPort)
-      appPort->OnEvent(newEvent);
+    // check for valid sizes cause in some cases
+    // we are hit during fullscreen transition from macos
+    // and might be technically "zero" sized
+    if (newEvent.resize.w != 0 && newEvent.resize.h != 0)
+    {
+      std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
+      if (appPort)
+        appPort->OnEvent(newEvent);
+    }
   }
 }
 


### PR DESCRIPTION
## Description
I added this event a while ago while working on the macos nativewindowing implementation and to differentiate the code path from the non-fullscreen alternative. This was added because of some inconsistencies I was facing on my mac because of the notch. Also added as a possible way to kill the ifdef in windows dx right above.
Since moving the definition of edgeInsets right on the resolution_info object when they are listed this is not needed anymore. Let's kill it before it's too late :)

## Motivation and context
Cleanup

## How has this been tested?
Runtime tested on macos, multi-monitor setup

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
