### PR TITLE
CWebSocketFrame: Fix alignment issues

### DIFF
--- a/xbmc/network/websocket/WebSocket.cpp
+++ b/xbmc/network/websocket/WebSocket.cpp
@@ -13,6 +13,7 @@
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
+#include <cstdint>
 #include <sstream>
 #include <string>
 
@@ -85,12 +86,15 @@ CWebSocketFrame::CWebSocketFrame(const char* data, uint64_t length)
   int offset = 0;
   if (m_length == 126)
   {
-    m_length = (uint64_t)Endian_SwapBE16(*(const uint16_t *)(m_data + 2));
+    uint16_t length;
+    std::memcpy(&length, m_data + 2, 2);
+    m_length = Endian_SwapBE16(length);
     offset = 2;
   }
   else if (m_length == 127)
   {
-    m_length = Endian_SwapBE64(*(const uint64_t *)(m_data + 2));
+    std::memcpy(&m_length, m_data + 2, 8);
+    m_length = Endian_SwapBE64(m_length);
     offset = 8;
   }
 
@@ -104,7 +108,7 @@ CWebSocketFrame::CWebSocketFrame(const char* data, uint64_t length)
   // Get the mask
   if (m_masked)
   {
-    m_mask = *(const uint32_t *)(m_data + LENGTH_MIN + offset);
+    std::memcpy(&m_mask, m_data + LENGTH_MIN + offset, 4);
     offset += 4;
   }
 


### PR DESCRIPTION
## Description
Fix unaligned memory access in `CWebSocketFrame`. See commit message for UBSAN error.

## Motivation and context
An unaligned memory access can cause crashes depending on the platform and generated code.

## How has this been tested?
The web interface still works.

## What is the effect on users?
None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
