### PR TITLE
[PVR][Settings] Recording timer padding 

### DIFF
--- a/xbmc/pvr/settings/PVRSettings.cpp
+++ b/xbmc/pvr/settings/PVRSettings.cpp
@@ -172,9 +172,8 @@ void CPVRSettings::MarginTimeFiller(const SettingConstPtr& /*setting*/,
 {
   list.clear();
 
-  static const int marginTimeValues[] =
-  {
-    0, 1, 3, 5, 10, 15, 20, 30, 60, 90, 120, 180 // minutes
+  static const int marginTimeValues[] = {
+      0, 1, 2, 3, 5, 10, 15, 20, 30, 60, 90, 120, 180 // minutes
   };
 
   for (int iValue : marginTimeValues)


### PR DESCRIPTION
## Description
Padding time in PVR Recording settings.  Add "2" minutes in padding time option box.

## Motivation and context
Padding time should allows user more fine-grained control of recording. 
The padding time  prevents PVR settings from EGP not match with real broadcasting time, in many cases just a little bit time shift.
0, 1, 2, 3, 5... Fibonacci series?  

## How has this been tested?
Simple variable return list of integers. 

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Add padding time option "2" minutes.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
