### PR TITLE
[Windows] fix WASAPI devices enumeration: "WASAPI:default" is repeated multiple times

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin32.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin32.cpp
@@ -68,7 +68,7 @@ std::vector<RendererDetail> CAESinkFactoryWin::GetRendererDetails()
 
   for (UINT i = 0; i < uiCount; i++)
   {
-    RendererDetail details;
+    RendererDetail details{};
     ComPtr<IMMDevice> pDevice = nullptr;
     ComPtr<IPropertyStore> pProperty = nullptr;
     PROPVARIANT varName;


### PR DESCRIPTION
## Description
Fix WASAPI devices enumeration: `WASAPI: default` is repeated multiple times

## Motivation and context
Cause is struct `RendererDetail` not zero initialized and "default" flag only is set when es true but not set when is false, then final state is indeterminate/random.

https://github.com/xbmc/xbmc/blob/c22ff3d0e1b5b98ae23fa2141d886581617de648/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin32.cpp#L134-L135 

## How has this been tested?
Runtime Windows x64

## What is the effect on users?
Less confusing audio device list

## Screenshots (if appropriate):
**Before**
![before](https://github.com/xbmc/xbmc/assets/58434170/496d5045-1fb4-483f-be04-d10f9f1ebe4b)


**After**
![after](https://github.com/xbmc/xbmc/assets/58434170/e93db0ed-82ca-434b-870b-65ee4e36f486)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
