### PR TITLE
[addon] support to set binary add-on instance settings by python

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -462,6 +462,28 @@ bool CAddon::GetSettingString(const std::string& key,
   return GetSettingValue<CSettingString>(*this, id, key, value);
 }
 
+bool CAddon::GetInstanceSetting(AddonInstanceId id, bool& enabled, std::string& name)
+{
+  if (!HasSettings(id))
+    return false;
+
+  const auto settings = GetSettings(id);
+
+  const auto instanceEnabled = settings->GetSetting(ADDON_SETTING_INSTANCE_ENABLED_VALUE, true);
+  if (!instanceEnabled)
+    return false;
+
+  enabled = std::static_pointer_cast<CSettingBool>(instanceEnabled)->GetValue();
+
+  const auto instanceName = settings->GetSetting(ADDON_SETTING_INSTANCE_NAME_VALUE, true);
+  if (!instanceName)
+    return false;
+
+  name = std::static_pointer_cast<CSettingString>(instanceName)->GetValue();
+
+  return true;
+}
+
 void CAddon::UpdateSetting(const std::string& key,
                            const std::string& value,
                            AddonInstanceId id /* = ADDON_SETTINGS_ID */)
@@ -496,7 +518,7 @@ bool UpdateSettingValue(CAddon& addon,
     return false;
 
   // try to get the setting
-  auto setting = addon.GetSettings(instanceId)->GetSetting(key);
+  auto setting = addon.GetSettings(instanceId)->GetSetting(key, false);
 
   // if the setting doesn't exist, try to add it
   if (setting == nullptr)

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -368,6 +368,17 @@ public:
                         std::string& value,
                         AddonInstanceId id = ADDON_SETTINGS_ID) override;
 
+  /*!
+   * \brief Function to get Kodi's internal settings related to an add-on instance.
+   *
+   * \param[in] id Instance identifier to use, use @ref ADDON_SETTINGS_ID
+   *               to denote global add-on settings from settings.xml.
+   * \param[out] enabled Whether instance is declared enabled, true if so.
+   * \param[out] name The instance name used and set by the user
+   * \return true if the setting's value was retrieved, false otherwise.
+   */
+  bool GetInstanceSetting(AddonInstanceId id, bool& enabled, std::string& name) override;
+
   std::shared_ptr<CAddonSettings> GetSettings(AddonInstanceId id = ADDON_SETTINGS_ID) override;
 
   /*! \brief get the required version of a dependency.

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -142,6 +142,7 @@ public:
   virtual bool GetSettingString(const std::string& key,
                                 std::string& value,
                                 AddonInstanceId id = ADDON_SETTINGS_ID) = 0;
+  virtual bool GetInstanceSetting(AddonInstanceId id, bool& enabled, std::string& instanceName) = 0;
   virtual std::shared_ptr<CAddonSettings> GetSettings(AddonInstanceId id = ADDON_SETTINGS_ID) = 0;
   virtual const std::vector<DependencyInfo>& GetDependencies() const = 0;
   virtual CAddonVersion GetDependencyVersion(const std::string& dependencyID) const = 0;

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -49,6 +49,11 @@ constexpr AddonInstanceId ADDON_SINGLETON_INSTANCE_ID = 0;
 constexpr AddonInstanceId ADDON_FIRST_INSTANCE_ID = 1;
 
 /*!
+ * @brief Identifier denoting initial first add-on instance set by a Python script.
+ */
+constexpr AddonInstanceId ADDON_FIRST_SCRIPT_SET_INSTANCE_ID = 1000;
+
+/*!
  * @brief Identifier denoting add-on instance id as unused.
  *
  * @sa ADDON::IAddonInstanceHandler

--- a/xbmc/addons/gui/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonSettings.cpp
@@ -149,8 +149,10 @@ bool CGUIDialogAddonSettings::OnAction(const CAction& action)
   return CGUIDialogSettingsManagerBase::OnAction(action);
 }
 
-bool CGUIDialogAddonSettings::ShowForAddon(const ADDON::AddonPtr& addon,
-                                           bool saveToDisk /* = true */)
+bool CGUIDialogAddonSettings::ShowForAddon(
+    const ADDON::AddonPtr& addon,
+    bool saveToDisk /* = true */,
+    ADDON::AddonInstanceId instanceId /* = ADDON::ADDON_SETTINGS_ID */)
 {
   if (!addon)
   {
@@ -169,9 +171,12 @@ bool CGUIDialogAddonSettings::ShowForAddon(const ADDON::AddonPtr& addon,
     return false;
 
   if (addon->SupportsInstanceSettings())
-    return ShowForMultipleInstances(addon, saveToDisk);
-  else
-    return ShowForSingleInstance(addon, saveToDisk);
+  {
+    if (instanceId == ADDON::ADDON_SETTINGS_ID)
+      return ShowForMultipleInstances(addon, saveToDisk);
+  }
+
+  return ShowForSingleInstance(addon, saveToDisk, instanceId);
 }
 
 bool CGUIDialogAddonSettings::ShowForSingleInstance(
@@ -240,13 +245,11 @@ bool CGUIDialogAddonSettings::ShowForMultipleInstances(const ADDON::AddonPtr& ad
     ADDON::AddonInstanceId highestId = 0;
     for (const auto& id : ids)
     {
+      bool enabled = false;
       std::string name;
-      addon->GetSettingString(ADDON_SETTING_INSTANCE_NAME_VALUE, name, id);
+      addon->GetInstanceSetting(id, enabled, name);
       if (name.empty())
         name = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205); // Unknown
-
-      bool enabled = false;
-      addon->GetSettingBool(ADDON_SETTING_INSTANCE_ENABLED_VALUE, enabled, id);
 
       const std::string label = StringUtils::Format(
           CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(10020), name,
@@ -420,6 +423,11 @@ std::string CGUIDialogAddonSettings::GetCurrentAddonID() const
     return "";
 
   return m_addon->ID();
+}
+
+AddonInstanceId CGUIDialogAddonSettings::GetCurrentAddonInstanceId() const
+{
+  return m_instanceId;
 }
 
 void CGUIDialogAddonSettings::SetupView()

--- a/xbmc/addons/gui/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonSettings.cpp
@@ -261,7 +261,7 @@ bool CGUIDialogAddonSettings::ShowForMultipleInstances(const ADDON::AddonPtr& ad
       item->SetProperty("name", name);
       itemsInstances.Add(item);
 
-      if (id > highestId)
+      if (id < ADDON_FIRST_SCRIPT_SET_INSTANCE_ID && id > highestId)
         highestId = id;
     }
 

--- a/xbmc/addons/gui/GUIDialogAddonSettings.h
+++ b/xbmc/addons/gui/GUIDialogAddonSettings.h
@@ -21,10 +21,13 @@ public:
   bool OnMessage(CGUIMessage& message) override;
   bool OnAction(const CAction& action) override;
 
-  static bool ShowForAddon(const ADDON::AddonPtr& addon, bool saveToDisk = true);
+  static bool ShowForAddon(const ADDON::AddonPtr& addon,
+                           bool saveToDisk = true,
+                           ADDON::AddonInstanceId instanceId = ADDON::ADDON_SETTINGS_ID);
   static void SaveAndClose();
 
   std::string GetCurrentAddonID() const;
+  ADDON::AddonInstanceId GetCurrentAddonInstanceId() const;
 
 protected:
   // implementation of CGUIDialogSettingsBase

--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -437,7 +437,7 @@ bool CAddonSettings::Save()
   std::shared_ptr<IAddon> addon = m_addon.lock();
   assert(addon);
   if (addon)
-    return addon->SaveSettings();
+    return addon->SaveSettings(m_instanceId);
   else
     return false;
 }

--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -221,8 +221,8 @@ void CAddonSettings::OnSettingAction(const std::shared_ptr<const CSetting>& sett
 
 bool CAddonSettings::AddInstanceSettings() const
 {
-  if (GetSetting(ADDON_SETTING_INSTANCE_NAME_VALUE) ||
-      GetSetting(ADDON_SETTING_INSTANCE_ENABLED_VALUE))
+  if (GetSetting(ADDON_SETTING_INSTANCE_NAME_VALUE, false) ||
+      GetSetting(ADDON_SETTING_INSTANCE_ENABLED_VALUE, false))
   {
     CLog::LogF(LOGDEBUG, "Add-on {} using instance setting values byself, Kodi's add ignored",
                m_addonId);

--- a/xbmc/interfaces/legacy/Addon.cpp
+++ b/xbmc/interfaces/legacy/Addon.cpp
@@ -19,6 +19,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
+#include "settings/lib/Setting.h"
 #include "utils/StringUtils.h"
 
 using namespace ADDON;
@@ -83,9 +84,96 @@ namespace XBMCAddon
           pAddon->ID(), id);
     }
 
-    Settings* Addon::getSettings()
+    bool Addon::supportsInstanceSettings()
     {
-      return new Settings(pAddon->GetSettings());
+      return pAddon->SupportsInstanceSettings();
+    }
+
+    std::vector<unsigned int> Addon::getInstanceIds()
+    {
+      return pAddon->GetKnownInstanceIds();
+    }
+
+    unsigned int Addon::getFreeNewInstanceId()
+    {
+      const auto ids = pAddon->GetKnownInstanceIds();
+      ADDON::AddonInstanceId highestId = ADDON::ADDON_FIRST_SCRIPT_SET_INSTANCE_ID;
+      for (const auto& id : ids)
+      {
+        if (id == ADDON::ADDON_SINGLETON_INSTANCE_ID)
+          throw XBMCAddon::WrongTypeException("Invalid add-on type");
+
+        if (id >= ADDON::ADDON_FIRST_SCRIPT_SET_INSTANCE_ID && id > highestId)
+          highestId = id;
+      }
+
+      return highestId + 1;
+    }
+
+    bool Addon::setInstanceState(unsigned int instance,
+                                 bool enabled,
+                                 const String& name /* = emptyString*/)
+    {
+      const auto settings = pAddon->GetSettings(instance);
+      if (!settings || instance == ADDON_SINGLETON_INSTANCE_ID)
+        throw XBMCAddon::WrongTypeException("Invalid add-on instance type");
+
+      const auto settingEnabled = settings->GetSetting(ADDON_SETTING_INSTANCE_ENABLED_VALUE, false);
+      if (!settingEnabled)
+        return false;
+
+      const auto settingName = settings->GetSetting(ADDON_SETTING_INSTANCE_NAME_VALUE, false);
+      if (!settingName)
+        return false;
+
+      const bool currentlyEnabled =
+          std::static_pointer_cast<CSettingBool>(settingEnabled)->GetValue();
+      const std::string currentName =
+          std::static_pointer_cast<CSettingString>(settingName)->GetValue();
+
+      if (currentName.empty() && name.empty())
+        throw XBMCAddon::WrongTypeException("New added add-on instances needs name set");
+
+      if (!name.empty() && currentName.empty() != name.empty())
+        std::static_pointer_cast<CSettingString>(settingName)->SetValue(name);
+
+      // Check is changed in enable, also check currentName empty and new name added, if yes should it a new added instance.
+      if (currentlyEnabled != enabled || (currentName.empty() && !name.empty()))
+      {
+        std::static_pointer_cast<CSettingBool>(settingEnabled)->SetValue(enabled);
+
+        // Save changed settings
+        settings->Save();
+
+        if (enabled)
+          CServiceBroker::GetAddonMgr().PublishInstanceAdded(pAddon->ID(), instance);
+        else
+          CServiceBroker::GetAddonMgr().PublishInstanceRemoved(pAddon->ID(), instance);
+      }
+
+      return true;
+    }
+
+    bool Addon::deleteInstance(unsigned int instance)
+    {
+      const auto settings = pAddon->GetSettings(instance);
+      if (!settings || instance == ADDON_SINGLETON_INSTANCE_ID)
+        throw XBMCAddon::WrongTypeException("Invalid add-on instance type");
+
+      const auto settingEnabled = settings->GetSetting(ADDON_SETTING_INSTANCE_ENABLED_VALUE, false);
+      if (!settingEnabled)
+        return false;
+      const bool enabled = std::static_pointer_cast<CSettingBool>(settingEnabled)->GetValue();
+
+      const bool ret = pAddon->DeleteInstanceSettings(instance);
+      if (ret && enabled)
+        CServiceBroker::GetAddonMgr().PublishInstanceRemoved(pAddon->ID(), instance);
+      return ret;
+    }
+
+    Settings* Addon::getSettings(unsigned int instance /* = 0*/)
+    {
+      return new Settings(pAddon->GetSettings(instance));
     }
 
     String Addon::getSetting(const char* id)
@@ -200,12 +288,12 @@ namespace XBMCAddon
       return true;
     }
 
-    void Addon::openSettings()
+    void Addon::openSettings(unsigned int instance /* = 0*/)
     {
       DelayedCallGuard dcguard(languageHook);
       // show settings dialog
       ADDON::AddonPtr addon(pAddon);
-      CGUIDialogAddonSettings::ShowForAddon(addon);
+      CGUIDialogAddonSettings::ShowForAddon(addon, true, instance);
     }
 
     String Addon::getAddonInfo(const char* id)

--- a/xbmc/interfaces/legacy/Addon.h
+++ b/xbmc/interfaces/legacy/Addon.h
@@ -100,10 +100,155 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_xbmcaddon
-      /// @brief \python_func{ xbmcaddon.Addon([id]).getSettings() }
+      /// @brief \python_func{ xbmcaddon.Addon([id]).supportsInstanceSettings() }
+      /// Returns true if the requested add-on supports several instances.
+      ///
+      /// @return Returns true if supported, false otherwise
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v21 New function added.
+      ///
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ..
+      /// supportsInstances = self.Addon('pvr.iptvsimple').supportsInstanceSettings()
+      /// ..
+      /// ~~~~~~~~~~~~~
+      ///
+      supportsInstanceSettings();
+#else
+      bool supportsInstanceSettings();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcaddon
+      /// @brief \python_func{ xbmcaddon.Addon([id]).getInstanceIds() }
+      /// Returns the list of known available instance ids.
+      ///
+      /// @return List of used add-on instances
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v21 New function added.
+      ///
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ..
+      /// usedInstances = self.Addon('pvr.iptvsimple').getInstanceIds()
+      /// ..
+      /// ~~~~~~~~~~~~~
+      ///
+      getInstanceIds();
+#else
+      std::vector<unsigned int> getInstanceIds();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcaddon
+      /// @brief \python_func{ xbmcaddon.Addon([id]).getFreeNewInstanceId() }
+      /// Get free add-on instance id to set new independent instance and settings about.
+      ///
+      /// @note After setting the new instance settings a @ref setInstanceState() call is required.
+      ///
+      /// @return Next usable and free instance id
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v21 New function added.
+      ///
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ..
+      /// addon = xbmcaddon.Addon('pvr.iptvsimple')
+      /// newinstanceid = addon.getFreeNewInstanceId()
+      /// ..
+      /// ~~~~~~~~~~~~~
+      ///
+      getFreeNewInstanceId();
+#else
+      unsigned int getFreeNewInstanceId();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcaddon
+      /// @brief \python_func{ xbmcaddon.Addon([id]).setInstanceState(id, enabled, [name]) }
+      /// Set changed state on add-on instance system.
+      ///
+      /// @param instance unsigned integer - Instance identifier to use.
+      /// @param enabled boolean - To enable or disable the instance
+      /// @param name [opt] string or unicode - The instance name used inside Kodi
+      ///             @warning Needs on new added instances set.
+      /// @return True if the setting the instance change was successful, false otherwise
+      ///
+      /// @note To add or Enable/Disable an instance this function needs to be called.
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v21 New function added.
+      ///
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ..
+      ///
+      /// addon = xbmcaddon.Addon('pvr.iptvsimple')
+      /// newinstanceid = addon.getFreeNewInstanceId()
+      ///
+      /// settings = addon.getSettings(newinstanceid)
+      /// settings.setInt('m3uPathType', 0)
+      /// settings.setString('m3uPath', '/SOME_PATH_OF_YOU')
+      /// ...
+      /// addon.setInstanceState(newinstanceid, True, 'Example by Python added')
+      /// ..
+      /// ~~~~~~~~~~~~~
+      ///
+      setInstanceState(...);
+#else
+      bool setInstanceState(unsigned int instance, bool enabled, const String& name = emptyString);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcaddon
+      /// @brief \python_func{ xbmcaddon.Addon([id]).deleteInstance(id) }
+      /// Delete selected instance settings from storage.
+      ///
+      /// @param instance unsigned integer - Instance identifier to use.
+      /// @return true on success, false otherwise.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v21 New function added.
+      ///
+      ///
+      /// **Example:**
+      /// ~~~~~~~~~~~~~{.py}
+      /// ..
+      /// instance = 1;
+      /// self.Addon('pvr.iptvsimple').deleteInstance(instance)
+      /// ..
+      /// ~~~~~~~~~~~~~
+      ///
+      deleteInstance(...);
+#else
+      bool deleteInstance(unsigned int instance);
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_xbmcaddon
+      /// @brief \python_func{ xbmcaddon.Addon([id]).getSettings([instance]) }
       /// Returns a wrapper around the addon's settings.
       ///
-      /// @return                        @ref python_settings wrapper
+      /// @param instance [opt] unsigned integer - used id of the requested add-on instance setting
+      ///                 @note use 0 to access regular settings.xml.
+      /// @return @ref python_settings wrapper
       ///
       ///
       ///-----------------------------------------------------------------------
@@ -119,7 +264,7 @@ namespace XBMCAddon
       ///
       getSettings(...);
 #else
-      Settings* getSettings();
+      Settings* getSettings(unsigned int instance = 0);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS
@@ -427,8 +572,12 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_xbmcaddon
-      /// @brief \python_func{ xbmcaddon.Addon([id]).openSettings() }
+      /// @brief \python_func{ xbmcaddon.Addon([id]).openSettings([instance]) }
       /// Opens this scripts settings dialog.
+      ///
+      /// @param instance [opt] unsigned integer - used id of the requested add-on instance setting
+      ///                 @note use 0 to access regular settings.xml.
+      ///
       ///
       ///-----------------------------------------------------------------------
       ///
@@ -441,7 +590,7 @@ namespace XBMCAddon
       ///
       openSettings();
 #else
-      void openSettings();
+      void openSettings(unsigned int instance = 0);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS

--- a/xbmc/settings/SettingsBase.cpp
+++ b/xbmc/settings/SettingsBase.cpp
@@ -173,12 +173,13 @@ void CSettingsBase::UnregisterCallback(ISettingCallback* callback)
   m_settingsManager->UnregisterCallback(callback);
 }
 
-SettingPtr CSettingsBase::GetSetting(const std::string& id) const
+SettingPtr CSettingsBase::GetSetting(const std::string& id,
+                                     bool presenceValidated /* = true */) const
 {
   if (id.empty())
     return nullptr;
 
-  return m_settingsManager->GetSetting(id);
+  return m_settingsManager->GetSetting(id, presenceValidated);
 }
 
 std::vector<std::shared_ptr<CSettingSection>> CSettingsBase::GetSections() const

--- a/xbmc/settings/SettingsBase.h
+++ b/xbmc/settings/SettingsBase.h
@@ -103,9 +103,13 @@ public:
    \brief Gets the setting with the given identifier.
 
    \param id Setting identifier
+   \param[in] presenceValidated If is set to false, error messages are ignored because the given
+                                setting might not actually exist.
+                                Can refer to background settings related to Kodi, which may be
+                                added later, e.g. to an add-on.
    \return Setting object with the given identifier or nullptr if the identifier is unknown
    */
-  std::shared_ptr<CSetting> GetSetting(const std::string& id) const;
+  std::shared_ptr<CSetting> GetSetting(const std::string& id, bool presenceValidated = true) const;
   /*!
    \brief Gets the full list of setting sections.
 

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -534,7 +534,8 @@ bool CSettingsManager::HasSettings() const
   return !m_settings.empty();
 }
 
-SettingPtr CSettingsManager::GetSetting(const std::string &id) const
+SettingPtr CSettingsManager::GetSetting(const std::string& id,
+                                        bool presenceValidated /* = true */) const
 {
   std::shared_lock lock(m_settingsCritical);
   if (id.empty())
@@ -548,7 +549,7 @@ SettingPtr CSettingsManager::GetSetting(const std::string &id) const
     return setting->second.setting;
   }
 
-  if (m_loaded)
+  if (m_loaded && presenceValidated)
     m_logger->debug("requested setting ({}) was not found.", id);
   return nullptr;
 }

--- a/xbmc/settings/lib/SettingsManager.h
+++ b/xbmc/settings/lib/SettingsManager.h
@@ -315,9 +315,14 @@ public:
    \brief Gets the setting with the given identifier.
 
    \param id Setting identifier
+   \param[in] presenceValidated If is set to false, error messages are ignored because the given
+                                setting might not actually exist.
+                                Can refer to background settings related to Kodi, which may be
+                                added later, e.g. to an add-on.
    \return Setting object with the given identifier or nullptr if the identifier is unknown
    */
-  std::shared_ptr<CSetting> GetSetting(const std::string &id) const;
+  std::shared_ptr<CSetting> GetSetting(const std::string& id, bool presenceValidated = true) const;
+
   /*!
    \brief Gets the full list of setting sections.
 


### PR DESCRIPTION
## Description

This allow a python script to edit add-on instance settings where used within PVR add-ons.

To prevent conflicts by user set within Kodi's GUI are the by python created ones starting with id >1000. 
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
By a small python script has it works for tests.

```py
import xbmcaddon
import xbmcgui
 
addon       = xbmcaddon.Addon('pvr.demo')
addonname   = addon.getAddonInfo('name')

newid = addon.getFreeNewInstanceId()
addonsettingnew = addon.getSettings(newid)
addonsettingnew.setString('host', '10.144.12.13')
addon.setInstanceIdState(newid, True, 'By Python added')

# addon.deleteInstanceId(1001);

printstring = "Support Instances: " + str(addon.supportsInstanceSettings()) + "\n" \
              "Used Instances:\n"
for x in addon.getKnownInstanceIds():
    printstring += "ID: " + str(x) + "\n"
    printstring += "Test setting: " + addon.getSettings(x).getString('host') + "\n"

xbmcgui.Dialog().textviewer(addonname, printstring)
```

If the instance already present is it enough to call:
```py
id = 1001
instancesetting = addon.getSettings(id)
instancesetting.setString('host', '10.144.12.13')
```

By this the add-on becomes the `ADDON_STATUS SetInstanceSetting(const std::string& settingName, const kodi::addon::CSettingValue& settingValue)` call.

<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
