### PR TITLE
[ActiveAESink] Improves sinks enumeration names and fallback logic when exact sink name not exists

### DIFF
--- a/xbmc/cores/AudioEngine/AESinkFactory.cpp
+++ b/xbmc/cores/AudioEngine/AESinkFactory.cpp
@@ -38,41 +38,58 @@ bool CAESinkFactory::HasSinks()
   return !m_AESinkRegEntry.empty();
 }
 
-void CAESinkFactory::ParseDevice(std::string &device, std::string &driver)
+AESinkDevice CAESinkFactory::ParseDevice(const std::string& device)
 {
-  int pos = device.find_first_of(':');
+  AESinkDevice dev{};
+  dev.name = device;
+
+  size_t pos = dev.name.find_first_of(':');
   bool found = false;
-  if (pos > 0)
+
+  if (pos != std::string::npos)
   {
-    driver = device.substr(0, pos);
+    dev.driver = device.substr(0, pos);
 
     for (const auto& reg : m_AESinkRegEntry)
     {
-      if (!StringUtils::EqualsNoCase(driver, reg.second.sinkName))
+      if (!StringUtils::EqualsNoCase(dev.driver, reg.second.sinkName))
         continue;
 
-      device = device.substr(pos + 1, device.length() - pos - 1);
+      dev.name = dev.name.substr(pos + 1, dev.name.length() - pos - 1);
       found = true;
     }
   }
 
   if (!found)
-    driver.clear();
+    dev.driver.clear();
+
+  pos = dev.name.find_first_of(':');
+
+  if (pos != std::string::npos)
+  {
+    // if no known driver found considers the string starts
+    // with the device name and discarts the rest
+    if (found)
+      dev.friendlyName = dev.name.substr(pos + 1);
+    dev.name = dev.name.substr(0, pos);
+  }
+
+  return dev;
 }
 
-std::unique_ptr<IAESink> CAESinkFactory::Create(std::string& device, AEAudioFormat& desiredFormat)
+std::unique_ptr<IAESink> CAESinkFactory::Create(const std::string& device,
+                                                AEAudioFormat& desiredFormat)
 {
   // extract the driver from the device string if it exists
-  std::string driver;
-  ParseDevice(device, driver);
+  const AESinkDevice dev = ParseDevice(device);
 
   AEAudioFormat tmpFormat = desiredFormat;
   std::unique_ptr<IAESink> sink;
-  std::string tmpDevice = device;
+  std::string tmpDevice = dev.name;
 
   for (const auto& reg : m_AESinkRegEntry)
   {
-    if (driver != reg.second.sinkName)
+    if (dev.driver != reg.second.sinkName)
       continue;
 
     sink = reg.second.createFunc(tmpDevice, tmpFormat);

--- a/xbmc/cores/AudioEngine/AESinkFactory.h
+++ b/xbmc/cores/AudioEngine/AESinkFactory.h
@@ -47,6 +47,11 @@ struct AESinkDevice
   std::string driver;
   std::string name;
   std::string friendlyName;
+
+  bool IsSameDeviceAs(const AESinkDevice& d) const
+  {
+    return driver == d.driver && (name == d.name || friendlyName == d.friendlyName);
+  }
 };
 
 class CAESinkFactory

--- a/xbmc/cores/AudioEngine/AESinkFactory.h
+++ b/xbmc/cores/AudioEngine/AESinkFactory.h
@@ -42,6 +42,13 @@ struct AESinkRegEntry
   Cleanup cleanupFunc;
 };
 
+struct AESinkDevice
+{
+  std::string driver;
+  std::string name;
+  std::string friendlyName;
+};
+
 class CAESinkFactory
 {
 public:
@@ -49,8 +56,8 @@ public:
   static void ClearSinks();
   static bool HasSinks();
 
-  static void ParseDevice(std::string &device, std::string &driver);
-  static std::unique_ptr<IAESink> Create(std::string& device, AEAudioFormat& desiredFormat);
+  static AESinkDevice ParseDevice(const std::string& device);
+  static std::unique_ptr<IAESink> Create(const std::string& device, AEAudioFormat& desiredFormat);
   static void EnumerateEx(std::vector<AESinkInfo>& list, bool force, const std::string& driver);
   static void Cleanup();
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -516,6 +516,7 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           m_extError = false;
           m_sink.EnumerateSinkList(false, "");
           LoadSettings();
+          ValidateOutputDevices(true);
           Configure();
           if (!m_isWinSysReg)
           {
@@ -647,6 +648,7 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           m_controlPort.PurgeOut(CActiveAEControlProtocol::DEVICECHANGE);
           m_sink.EnumerateSinkList(true, "");
           LoadSettings();
+          ValidateOutputDevices(false);
           m_extError = false;
           Configure();
           if (!m_extError)
@@ -669,6 +671,7 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           {
             UnconfigureSink();
             LoadSettings();
+            ValidateOutputDevices(false);
             m_extError = false;
             Configure();
             if (!m_extError)
@@ -890,6 +893,7 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
             m_controlPort.PurgeOut(CActiveAEControlProtocol::DEVICECOUNTCHANGE);
             m_sink.EnumerateSinkList(true, "");
             LoadSettings();
+            ValidateOutputDevices(false);
           }
           Configure();
           if (!displayReset)
@@ -2668,6 +2672,58 @@ void CActiveAE::LoadSettings()
   m_settings.atempoThreshold = settings->GetInt(CSettings::SETTING_AUDIOOUTPUT_ATEMPOTHRESHOLD) / 100.0;
   m_settings.streamNoise = settings->GetBool(CSettings::SETTING_AUDIOOUTPUT_STREAMNOISE);
   m_settings.silenceTimeoutMinutes = settings->GetInt(CSettings::SETTING_AUDIOOUTPUT_STREAMSILENCE);
+}
+
+void CActiveAE::ValidateOutputDevices(bool saveChanges)
+{
+  std::string device = m_sink.ValidateOuputDevice(m_settings.device, false);
+
+  if (!device.empty() && device != m_settings.device)
+  {
+    CLog::LogF(LOGWARNING, "audio output device setting has been updated from '{}' to '{}'",
+               m_settings.device, device);
+
+    const AESinkDevice oldDevice = CAESinkFactory::ParseDevice(m_settings.device);
+    const AESinkDevice newDevice = CAESinkFactory::ParseDevice(device);
+
+    m_settings.device = device;
+
+    if (saveChanges && newDevice.IsSameDeviceAs(oldDevice))
+    {
+      const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+      if (settings)
+      {
+        settings->SetString(CSettings::SETTING_AUDIOOUTPUT_AUDIODEVICE, m_settings.device);
+        settings->Save();
+        CLog::LogF(LOGDEBUG, "the change of the audio output device setting has been saved");
+      }
+    }
+  }
+
+  device = m_sink.ValidateOuputDevice(m_settings.passthroughdevice, true);
+
+  if (!device.empty() && device != m_settings.passthroughdevice)
+  {
+    CLog::LogF(LOGWARNING, "passthrough output device setting has been updated from '{}' to '{}'",
+               m_settings.passthroughdevice, device);
+
+    const AESinkDevice oldDevice = CAESinkFactory::ParseDevice(m_settings.passthroughdevice);
+    const AESinkDevice newDevice = CAESinkFactory::ParseDevice(device);
+
+    m_settings.passthroughdevice = device;
+
+    if (saveChanges && newDevice.IsSameDeviceAs(oldDevice))
+    {
+      const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+      if (settings)
+      {
+        settings->SetString(CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGHDEVICE,
+                            m_settings.passthroughdevice);
+        settings->Save();
+        CLog::LogF(LOGDEBUG, "the change of the passthrough output device setting has been saved");
+      }
+    }
+  }
 }
 
 void CActiveAE::Start()

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -308,6 +308,7 @@ protected:
   void UnconfigureSink();
   void Dispose();
   void LoadSettings();
+  void ValidateOutputDevices(bool saveChanges);
   bool NeedReconfigureBuffers();
   bool NeedReconfigureSink();
   void ApplySettingsToFormat(AEAudioFormat& format,

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -73,15 +73,14 @@ void CActiveAESink::Dispose()
 
 AEDeviceType CActiveAESink::GetDeviceType(const std::string &device)
 {
-  std::string dev = device;
-  std::string dri;
-  CAESinkFactory::ParseDevice(dev, dri);
+  const AESinkDevice dev = CAESinkFactory::ParseDevice(device);
+
   for (auto itt = m_sinkInfoList.begin(); itt != m_sinkInfoList.end(); ++itt)
   {
     for (AEDeviceInfoList::iterator itt2 = itt->m_deviceInfoList.begin(); itt2 != itt->m_deviceInfoList.end(); ++itt2)
     {
       CAEDeviceInfo& info = *itt2;
-      if (info.m_deviceName == dev)
+      if (info.m_deviceName == dev.name)
         return info.m_deviceType;
     }
   }
@@ -104,18 +103,16 @@ bool CActiveAESink::HasPassthroughDevice()
 
 bool CActiveAESink::SupportsFormat(const std::string &device, AEAudioFormat &format)
 {
-  std::string dev = device;
-  std::string dri;
+  const AESinkDevice dev = CAESinkFactory::ParseDevice(device);
 
-  CAESinkFactory::ParseDevice(dev, dri);
   for (auto itt = m_sinkInfoList.begin(); itt != m_sinkInfoList.end(); ++itt)
   {
-    if (dri == itt->m_sinkName)
+    if (dev.driver == itt->m_sinkName)
     {
       for (auto itt2 = itt->m_deviceInfoList.begin(); itt2 != itt->m_deviceInfoList.end(); ++itt2)
       {
         CAEDeviceInfo& info = *itt2;
-        if (info.m_deviceName == dev)
+        if (info.m_deviceName == dev.name)
         {
           bool isRaw = format.m_dataFormat == AE_FMT_RAW;
           bool formatExists = false;
@@ -184,18 +181,16 @@ bool CActiveAESink::SupportsFormat(const std::string &device, AEAudioFormat &for
 
 bool CActiveAESink::NeedIECPacking()
 {
-  std::string dev = m_device;
-  std::string dri;
+  const AESinkDevice dev = CAESinkFactory::ParseDevice(m_device);
 
-  CAESinkFactory::ParseDevice(dev, dri);
   for (auto itt = m_sinkInfoList.begin(); itt != m_sinkInfoList.end(); ++itt)
   {
-    if (dri == itt->m_sinkName)
+    if (dev.driver == itt->m_sinkName)
     {
       for (auto itt2 = itt->m_deviceInfoList.begin(); itt2 != itt->m_deviceInfoList.end(); ++itt2)
       {
         CAEDeviceInfo& info = *itt2;
-        if (info.m_deviceName == dev)
+        if (info.m_deviceName == dev.name)
         {
           return info.m_wantsIECPassthrough;
         }
@@ -757,6 +752,16 @@ void CActiveAESink::EnumerateOutputDevices(AEDeviceList &devices, bool passthrou
 
       std::string device = sinkInfo.m_sinkName + ":" + devInfo.m_deviceName;
 
+      const std::string friendlyName = (devInfo.m_deviceName != devInfo.m_displayName)
+                                           ? devInfo.m_displayName
+                                           : devInfo.m_displayNameExtra;
+
+      if (!friendlyName.empty())
+      {
+        device.append(":");
+        device.append(friendlyName);
+      }
+
       std::stringstream ss;
 
       /* add the sink name if we have more then one sink type */
@@ -793,15 +798,12 @@ void CActiveAESink::GetDeviceFriendlyName(const std::string& device)
 
 void CActiveAESink::OpenSink()
 {
-  // we need a copy of m_device here because ParseDevice and CreateDevice write back
-  // into this variable
-  std::string device = m_device;
-  std::string driver;
   bool passthrough = (m_requestedFormat.m_dataFormat == AE_FMT_RAW);
 
-  CAESinkFactory::ParseDevice(device, driver);
-  if (driver.empty() && m_sink)
-    driver = m_sink->GetName();
+  AESinkDevice dev = CAESinkFactory::ParseDevice(m_device);
+
+  if (dev.driver.empty() && m_sink)
+    dev.driver = m_sink->GetName();
 
   // iec packing or raw
   if (passthrough)
@@ -825,11 +827,10 @@ void CActiveAESink::OpenSink()
   }
 
   // get the display name of the device
-  GetDeviceFriendlyName(device);
+  GetDeviceFriendlyName(dev.name);
 
   // if we already have a driver, prepend it to the device string
-  if (!driver.empty())
-    device = driver + ":" + device;
+  std::string device = dev.driver.empty() ? dev.name : dev.driver + ":" + dev.name;
 
   // WARNING: this changes format and does not use passthrough
   m_sinkFormat = m_requestedFormat;
@@ -839,11 +840,10 @@ void CActiveAESink::OpenSink()
   // try first device in out list
   if (!m_sink && !m_sinkInfoList.empty())
   {
-    driver = m_sinkInfoList.front().m_sinkName;
-    device = m_sinkInfoList.front().m_deviceInfoList.front().m_deviceName;
-    GetDeviceFriendlyName(device);
-    if (!driver.empty())
-      device = driver + ":" + device;
+    dev.driver = m_sinkInfoList.front().m_sinkName;
+    dev.name = m_sinkInfoList.front().m_deviceInfoList.front().m_deviceName;
+    GetDeviceFriendlyName(dev.name);
+    device = dev.driver.empty() ? dev.name : dev.driver + ":" + dev.name;
     m_sinkFormat = m_requestedFormat;
     CLog::Log(LOGDEBUG, "CActiveAESink::OpenSink - trying to open device {}", device);
     m_sink = CAESinkFactory::Create(device, m_sinkFormat);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
@@ -97,6 +97,7 @@ public:
 
   void EnumerateSinkList(bool force, std::string driver);
   void EnumerateOutputDevices(AEDeviceList &devices, bool passthrough);
+  std::string ValidateOuputDevice(const std::string& device, bool passthrough) const;
   void Start();
   void Dispose();
   AEDeviceType GetDeviceType(const std::string &device);

--- a/xbmc/cores/AudioEngine/Utils/AEDeviceInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEDeviceInfo.cpp
@@ -64,3 +64,19 @@ std::string CAEDeviceInfo::DeviceTypeToString(enum AEDeviceType deviceType)
   }
   return "INVALID";
 }
+
+std::string CAEDeviceInfo::GetFriendlyName() const
+{
+  return (m_deviceName != m_displayName) ? m_displayName : m_displayNameExtra;
+}
+
+std::string CAEDeviceInfo::ToDeviceString(const std::string& driver) const
+{
+  std::string device = driver.empty() ? m_deviceName : driver + ":" + m_deviceName;
+
+  const std::string fn = GetFriendlyName();
+  if (!fn.empty())
+    device += ":" + fn;
+
+  return device;
+}

--- a/xbmc/cores/AudioEngine/Utils/AEDeviceInfo.h
+++ b/xbmc/cores/AudioEngine/Utils/AEDeviceInfo.h
@@ -47,6 +47,8 @@ public:
 
   operator std::string();
   static std::string DeviceTypeToString(enum AEDeviceType deviceType);
+  std::string GetFriendlyName() const;
+  std::string ToDeviceString(const std::string& driver) const;
 };
 
 typedef std::vector<CAEDeviceInfo> AEDeviceInfoList;


### PR DESCRIPTION
## Description
- Improves `CAESinkFactory::ParseDevice` returning values in a struct instead parameters by reference. Also avoids use same "device" parameter as input/output which is confusing and requires make a copy to avoids get overwrited in some places.
- Appends sink friendly name to sink string when is different from sink name. e.g:

  Before
  `WASAPI:{B12C1A75-F8A8-4071-8CFB-A285C619CCB8}`
    
  After
  `WASAPI:{B12C1A75-F8A8-4071-8CFB-A285C619CCB8}:HDMI - DENON-AVR (NVIDIA High Definition Audio)`

- When open sink by name (GUID in Windows) and exact match not found, fallback using friendly name.
- Saved settings are not modified unless user opens audio settings.
- When user opens audio settings current device name is "upgraded" and saved in settings, adding friendly name if available.
- Even if current device GUID not exist in system anymore, current setting is not lost because fallback to a device with same friendly name and saved as current "new" device.
- Fixes https://github.com/xbmc/xbmc/issues/21852


## Motivation and context
On Windows sink names are GUIDs and these may change sporadically with Windows Updates or audio drivers updates. When this happens, current logic is fallback to first audio device in list and this breaks passthrough probably because changes from `WASAPI:x` to `DIRECTSOUND:y`

For some users this is just a Kodi bug "Kodi changes sporadically to DIRECTSOUND and breaks passthrough". See https://github.com/xbmc/xbmc/issues/21852 and https://github.com/xbmc/xbmc/issues/22021

Or in forum: https://forum.kodi.tv/showthread.php?tid=373640 or https://forum.kodi.tv/showthread.php?tid=372205

This PR appends friendly device name to setting and, in this way, if GUID changes, same device can be still referenced by friendly name e.g.:

Device saved in settings is:
 `WASAPI:{B12C1A75-F8A8-4071-8CFB-A285C619CCB8}:HDMI - DENON-AVR (NVIDIA High Definition Audio)`

But current system device is:
`WASAPI:{555C1A75-F8A8-4071-8CFB-A285C619CCB8}:HDMI - DENON-AVR (NVIDIA High Definition Audio)`

Kodi can continue operate in this way and saved setting is not altered but a WARNING log message warns of this situation.
When the user realizes (if it happens) he can fix it in settings and if not, nothing happens... the next time the user enters in settings it will fix itself for the simple fact that the current setting has changed and the settings are saved when changes.

Since the current setting can only be one of the list and in the list there are only the devices that currently exist in the system.

After this, "new" saved setting is:
`WASAPI:{555C1A75-F8A8-4071-8CFB-A285C619CCB8}:HDMI - DENON-AVR (NVIDIA High Definition Audio)`

And the warning message in the logs disappears.

All this is designed for backward compatibility, that is, it is not mandatory that the settings have the friendly name. And it is also not expected that the audio device will change by the fact of starting to use Kodi with these changes nor is it expected any significant change in the operation except the improvement when the same exact device does not exist.

Even in the case that the setting does not (yet) have the friendly name there are some improvements in the logic: it will always be preferred to change to a device of the same driver first e.g. from `WASAPI:x` to `WASAPI:default` instead of switching to the first random device (DIRECTSOUND).

Please review commits separately as has useful descriptions.


## How has this been tested?
Runtime tested Windows x64 also in Shield (to look for side effects)

## What is the effect on users?
Avoids in some systems sporadically audio device settings are lost because Windows Updates or audio drivers updates.
In general it improves (much) the fallback logic when the current audio device is not available.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
