### PR TITLE
[Wayland] Skip unknown key events

### DIFF
--- a/xbmc/windowing/wayland/InputProcessorKeyboard.cpp
+++ b/xbmc/windowing/wayland/InputProcessorKeyboard.cpp
@@ -122,6 +122,14 @@ void CInputProcessorKeyboard::ConvertAndSendKey(std::uint32_t scancode, bool pre
     scancode = 0;
   }
 
+  if (xbmcKey == XBMCKey::XBMCK_UNKNOWN && utf32 == 0)
+  {
+    // Such an event would carry no useful information in it and thus can be safely dropped here
+    // This prevents starting an unnecessary timer for key presses
+    CLog::Log(LOGDEBUG, "Unknown key event ignored (scancode: {})", scancode);
+    return;
+  }
+
   XBMC_Event event{SendKey(scancode, xbmcKey, static_cast<std::uint16_t> (utf32), pressed)};
 
   if (pressed && m_keymap->ShouldKeycodeRepeat(xkbCode) && m_keyRepeatInterval > 0)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Skip `XBMCKey::XBMCK_UNKNOWN` key events early.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On webOS we have two different fake events for cursor show and cursor hide. Those are mapped to `XBMC_UNKNOWN`:

```c++
    {XKB_KEY_WEBOS_CURSOR_HIDE, XBMCK_UNKNOWN},
    {XKB_KEY_WEBOS_CURSOR_SHOW, XBMCK_UNKNOWN},
```

However, since those two events have different keycodes they will each trigger the pressed key timers. Since these events unfortunately work differently from a normal key event, there is never a key released event tricking kodi into thinking that the key is still being pressed. Thus it creates a log of spam in the debug log and also starts useless key pressed timers: 

```
2023-08-23 00:40:03.140 T:4414    debug <general>: Keyboard: scancode: 0x0, sym: 0x00, unicode: 0x00, modifier: 0x0
2023-08-23 00:40:03.140 T:4414     info <general>: Skipped 1 duplicate messages..
2023-08-23 00:40:03.140 T:4414    debug <general>: GetActionCode: Trying Hardy keycode for 0xf200
2023-08-23 00:40:03.140 T:4414     info <general>: Skipped 3 duplicate messages..
2023-08-23 00:40:03.140 T:4414    debug <general>: HandleKey: long-0 (0x100f200, obc-16838913) pressed, window 12901, action is
2023-08-23 00:40:03.158 T:4414    debug <general>: Keyboard: scancode: 0x0, sym: 0x00, unicode: 0x00, modifier: 0x0
2023-08-23 00:40:03.158 T:4414     info <general>: Skipped 1 duplicate messages..
2023-08-23 00:40:03.158 T:4414    debug <general>: GetActionCode: Trying Hardy keycode for 0xf200
2023-08-23 00:40:03.158 T:4414     info <general>: Skipped 3 duplicate messages..
2023-08-23 00:40:03.158 T:4414    debug <general>: HandleKey: long-0 (0x100f200, obc-16838913) pressed, window 12901, action is
```
Might also relate to #23633 as the issue is also seen in the attached debug log

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
webOS7/22

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
