### PR TITLE
[macos][nativewindowing] Signal mouse enabled/disabled when window becomes …

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1379,11 +1379,13 @@ bool CWinSystemOSX::MessagePump()
 void CWinSystemOSX::enableInputEvents()
 {
   m_winEvents->enableInputEvents();
+  signalMouseEntered();
 }
 
 void CWinSystemOSX::disableInputEvents()
 {
   m_winEvents->disableInputEvents();
+  signalMouseExited();
 }
 
 std::string CWinSystemOSX::GetClipboardText()


### PR DESCRIPTION
…key (and resigns key)

## Description
This fixes an issue found by @kambala-decapitator when using the mouse on a multi-monitor setup (see https://github.com/xbmc/xbmc/pull/23630#issuecomment-1691509540).
Basically, when the windows becomes key (and resigns key) it must signal the windowing system that the mouse is available (or not available). `WINDOW_DIALOG_POINTER` depends on this state (stored by the windowing system) to properly display the pointer. Furthermore, hide/unhide `NSCursor` already balances the state.

## Motivation and context
Fix the issue reported in https://github.com/xbmc/xbmc/pull/23630#issuecomment-1691509540

## How has this been tested?
Multi-monitor setup. Focusing Kodi and focusing other apps. Realising that hitting the Kodi screen when the application is not key makes the mouse behave proper again.

## What is the effect on users?
Should now see the pointer in all its glory when running fullscreen on a multi-monitor setup and switching from/to Kodi to other apps.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
