### PR TITLE
[macos][nativewindowing] Add support for mediakeys

### DIFF
--- a/xbmc/windowing/osx/WinEventsOSXImpl.mm
+++ b/xbmc/windowing/osx/WinEventsOSXImpl.mm
@@ -22,6 +22,7 @@
 
 #import <AppKit/AppKit.h>
 #import <Foundation/Foundation.h>
+#import <IOKit/hidsystem/ev_keymap.h>
 
 #pragma mark - objc implementation
 
@@ -29,6 +30,7 @@
 {
   std::queue<XBMC_Event> events;
   CCriticalSection m_inputlock;
+  id m_mediaKeysTap;
   bool m_inputEnabled;
 
   //! macOS requires the calls the NSCursor hide/unhide to be balanced
@@ -47,10 +49,8 @@
 {
   self = [super init];
 
-  [self enableInputEvents];
   m_lastAppCursorVisibilityAction = NSCursorVisibilityBalancer::NONE;
-  m_inputEnabled = true;
-
+  [self enableInputEvents];
   return self;
 }
 
@@ -158,11 +158,16 @@
 
 - (void)enableInputEvents
 {
+  m_mediaKeysTap = [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskSystemDefined
+                                                         handler:^(NSEvent* event) {
+                                                           return [self InputEventHandler:event];
+                                                         }];
   m_inputEnabled = true;
 }
 
 - (void)disableInputEvents
 {
+  m_mediaKeysTap = nil;
   m_inputEnabled = false;
 }
 
@@ -307,6 +312,21 @@
 
       break;
     }
+    // media keys
+    case NSEventTypeSystemDefined:
+    {
+      if (nsEvent.subtype == NX_SUBTYPE_AUX_CONTROL_BUTTONS)
+      {
+        const int keyCode = (([nsEvent data1] & 0xFFFF0000) >> 16);
+        const int keyFlags = ([nsEvent data1] & 0x0000FFFF);
+        const int keyState = (((keyFlags & 0xFF00) >> 8)) == 0xA;
+        if (keyState == 1) // if pressed
+        {
+          passEvent = [self HandleMediaKey:keyCode];
+        }
+      }
+      break;
+    }
     default:
       return nsEvent;
   }
@@ -387,6 +407,52 @@
   // cocoa world is upside down ...
   location.y = frame.size.height - location.y;
   return location;
+}
+
+- (void)SendPlayerAction:(int)actionId
+{
+  CAction* action = new CAction(actionId);
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
+                                             static_cast<void*>(action));
+}
+
+- (bool)HandleMediaKey:(int)keyCode
+{
+  bool passEvent = false;
+  switch (keyCode)
+  {
+    case NX_KEYTYPE_PLAY:
+    {
+      [self SendPlayerAction:ACTION_PLAYER_PLAYPAUSE];
+      break;
+    }
+    case NX_KEYTYPE_NEXT:
+    {
+      [self SendPlayerAction:ACTION_NEXT_ITEM];
+      break;
+    }
+    case NX_KEYTYPE_PREVIOUS:
+    {
+      [self SendPlayerAction:ACTION_PREV_ITEM];
+      break;
+    }
+    case NX_KEYTYPE_FAST:
+    {
+      [self SendPlayerAction:ACTION_PLAYER_FORWARD];
+      break;
+    }
+    case NX_KEYTYPE_REWIND:
+    {
+      [self SendPlayerAction:ACTION_PLAYER_REWIND];
+      break;
+    }
+    default:
+    {
+      passEvent = true;
+      break;
+    }
+  }
+  return passEvent;
 }
 
 @end


### PR DESCRIPTION
## Description
This PR adds support for media keys (keyboard play/pause, rewind, forward) for macOS native windowing.

## Motivation and context
It has come as a feature request in https://github.com/xbmc/xbmc/pull/22990. Not sure if currently the SDL version supports media keys (I guess it doesn't - there's code for it but my testing did not succeed).

## How has this been tested?
Runtime tested. Played a file, hit the different keys.
It might open apple music by default, a few ideas to disable this behaviour globally are given in https://apple.stackexchange.com/questions/380126/do-not-open-apple-music-when-pressing-a-media-key
Unfortunately not something we can do much about.

## What is the effect on users?
Kodi should now respond to media keys.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
