### PR TITLE
[video] Fix watched state / last played not preserved on internet update

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1464,10 +1464,12 @@ namespace VIDEO
 
     if (!pItem->m_bIsFolder)
     {
-      if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bVideoLibraryImportWatchedState || libraryImport)
+      const auto advancedSettings = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
+      if ((libraryImport || advancedSettings->m_bVideoLibraryImportWatchedState) &&
+          (movieDetails.IsPlayCountSet() || movieDetails.m_lastPlayed.IsValid()))
         m_database.SetPlayCount(*pItem, movieDetails.GetPlayCount(), movieDetails.m_lastPlayed);
 
-      if ((CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bVideoLibraryImportResumePoint || libraryImport) &&
+      if ((libraryImport || advancedSettings->m_bVideoLibraryImportResumePoint) &&
           movieDetails.GetResumePoint().IsSet())
         m_database.AddBookMarkToFile(pItem->GetPath(), movieDetails.GetResumePoint(), CBookmark::RESUME);
     }


### PR DESCRIPTION
… of movies / TV show episodes.

Fixes a regression introduced with #20842 (@DaVukovic fyi), Changing the default value of advanced settings `m_bVideoLibraryImportWatchedState` to true has an unexpected side effect.

When refreshing a movie/episode data from the internet and abovementioned setting is set to true, this triggers a bug that resets the play count of the movie/episode to zero, which means movie/episode is unwatched. Internet update does never provide updated play counts, but the code that stores the new values into the video database ignores this fact.

To reproduce:
1. Ensure `importwatchedstate` is not manually set to false in advancedsettings.xml
2. Open the Video Info Dialog for a TV show that has some watched episodes
3. Push the Refresh button
4. Confirm to update info including info for all episodes
==> All formerly episodes marked watched are now unwatched again.

@enen92 fix is trivial - like we already do for resume points, we need to check validity of the play count before overwriting existing database value. Code review should be easy.

@fuzzard this should be backported.