### PR TITLE
[PVR] Fix TV channel subtitles not displayed on playback start, …

### DIFF
--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
@@ -99,6 +99,11 @@ void CGUIDialogSubtitleSettings::OnSettingChanged(const std::shared_ptr<const CS
   if (settingId == SETTING_SUBTITLE_ENABLE)
   {
     bool value = std::static_pointer_cast<const CSettingBool>(setting)->GetValue();
+    if (value)
+    {
+      // Ensure that we use/store the subtitle stream the user currently sees in the dialog.
+      appPlayer->SetSubtitle(m_subtitleStream);
+    }
     appPlayer->SetSubtitleVisible(value);
   }
   else if (settingId == SETTING_SUBTITLE_DELAY)


### PR DESCRIPTION
... although activated in subtitle settings.

To reproduce:
1. Start watching a TV channel, with has at least one subtitle stream available
2. Open the subtitle settings dialog
3. Enable subtitle (but do no select any of the available subtitle streams, just keep the presented stream) => subtitles appear
4. close the dialog
5. stop watching the channel
6. start watching the channel again
==> no subtitles

If you do not change the preselected subtitle stream in the dialog, you expect that the preselected stream will be used (which happens) and stored across playback stop and restart (which does not happen).

The problem's cause: In this scenario, the "enable" info will be stored in the video database (which is fine), but not, that you want to use a certain subtitle stream, the one presented in the dialog as first entry. Instead of storing the id of this channel in the database, -1 for "default stream" is stored. On start of watching the channel in question, VideoPlayer looks for a subtitle stream flagged as "default", but this information is not available for any PVR Live TV channel. Thus, no matching subtitle stream can be found and as a consequence, no subtitles appear. Even if PVR would support the "default" flag, the stream flagged as such might not be the one you've seen in the dialog while activating subtitles for the channel.

BTW, in theory, this problem is not hitting only PVR. It can also appear with other subtitle stream sources not supporting the "default" flag, but I don't know whether their are others than PVR.

Runtime tested on android and macOS, latest Kodi master.

@enen92 The code change is quite simple and this should be easy to review.

@fuzzard we should backport this fix.