### PR TITLE
[Nexus][PVR] Fix TV channel subtitles not displayed on playback start, …

### DIFF
--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
@@ -99,6 +99,11 @@ void CGUIDialogSubtitleSettings::OnSettingChanged(const std::shared_ptr<const CS
   if (settingId == SETTING_SUBTITLE_ENABLE)
   {
     bool value = std::static_pointer_cast<const CSettingBool>(setting)->GetValue();
+    if (value)
+    {
+      // Ensure that we use/store the subtitle stream the user currently sees in the dialog.
+      appPlayer->SetSubtitle(m_subtitleStream);
+    }
     appPlayer->SetSubtitleVisible(value);
   }
   else if (settingId == SETTING_SUBTITLE_DELAY)


### PR DESCRIPTION
…although activated in subtitle settings.

Backport of #23669 

@enen92 could you review, please (is a plain cherry-pick)?