### PR TITLE
[video] Unify code paths for 'show video information' …

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -2406,8 +2406,5 @@ void CGUIDialogVideoInfo::ShowFor(const CFileItem& item)
 {
   auto window = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowVideoNav>(WINDOW_VIDEO_NAV);
   if (window)
-  {
-    ADDON::ScraperPtr info;
-    window->OnItemInfo(item, info);
-  }
+    window->OnItemInfo(item);
 }

--- a/xbmc/video/windows/GUIWindowVideoBase.h
+++ b/xbmc/video/windows/GUIWindowVideoBase.h
@@ -37,11 +37,9 @@ public:
    Default implementation shows a dialog containing information for the movie/episode/...
    represented by the file item.
    \param fileItem the item for which information is to be presented.
-   \param scraper a scraper addon instance that can be used to obtain additional information for
-   the given item
    \return true if information was presented, false otherwise.
    */
-  virtual bool OnItemInfo(const CFileItem& fileItem, ADDON::ScraperPtr& scraper);
+  bool OnItemInfo(const CFileItem& fileItem);
 
   /*! \brief Show the resume menu for this item (if it has a resume bookmark)
    If a resume bookmark is found, we set the item's m_lStartOffset to STARTOFFSET_RESUME.
@@ -126,7 +124,7 @@ protected:
   using CGUIMediaWindow::LoadPlayList;
   void LoadPlayList(const std::string& strPlayList, PLAYLIST::Id playlistId = PLAYLIST::TYPE_VIDEO);
 
-  bool ShowIMDB(CFileItemPtr item, const ADDON::ScraperPtr& content, bool fromDB);
+  bool ShowInfo(const CFileItemPtr& item, const ADDON::ScraperPtr& content);
 
   void OnSearch();
   void OnSearchItemFound(const CFileItem* pSelItem);

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -138,8 +138,7 @@ bool CGUIWindowVideoNav::OnMessage(CGUIMessage& message)
             i = -1;
             if (url.GetOption("showinfo") == "true")
             {
-              ADDON::ScraperPtr scrapper;
-              OnItemInfo(*pItem, scrapper);
+              OnItemInfo(*pItem);
             }
             break;
           }
@@ -159,8 +158,7 @@ bool CGUIWindowVideoNav::OnMessage(CGUIMessage& message)
               if (!item.GetVideoInfoTag()->IsEmpty())
               {
                 item.SetPath(item.GetVideoInfoTag()->m_strFileNameAndPath);
-                ADDON::ScraperPtr scrapper;
-                OnItemInfo(item, scrapper);
+                OnItemInfo(item);
               }
             }
           }
@@ -650,24 +648,6 @@ void CGUIWindowVideoNav::PlayItem(int iItem)
     return;
 
   CGUIWindowVideoBase::PlayItem(iItem);
-}
-
-bool CGUIWindowVideoNav::OnItemInfo(const CFileItem& fileItem, ADDON::ScraperPtr& scraper)
-{
-  if (!scraper || scraper->Content() == CONTENT_NONE)
-  {
-    m_database.Open(); // since we can be called from the music library without being inited
-    if (fileItem.IsVideoDb())
-      scraper = m_database.GetScraperForPath(fileItem.GetVideoInfoTag()->m_strPath);
-    else
-    {
-      std::string strPath,strFile;
-      URIUtils::Split(fileItem.GetPath(),strPath,strFile);
-      scraper = m_database.GetScraperForPath(strPath);
-    }
-    m_database.Close();
-  }
-  return CGUIWindowVideoBase::OnItemInfo(fileItem, scraper);
 }
 
 void CGUIWindowVideoNav::OnDeleteItem(const CFileItemPtr& pItem)

--- a/xbmc/video/windows/GUIWindowVideoNav.h
+++ b/xbmc/video/windows/GUIWindowVideoNav.h
@@ -37,8 +37,6 @@ public:
   bool OnAction(const CAction &action) override;
   bool OnMessage(CGUIMessage& message) override;
 
-  bool OnItemInfo(const CFileItem& fileItem, ADDON::ScraperPtr& info) override;
-
 protected:
   bool ApplyWatchedFilter(CFileItemList &items);
   bool GetFilteredItems(const std::string &filter, CFileItemList &items) override;


### PR DESCRIPTION
…to gain consistent behavior. Optimize and modernize code a bit.

Existing code to open the video information dialog is kinda unstructured (it grew in an organic manner over time, I'd say.). This PR tries to unify and simplify the different code paths. No functional changes intended, just refactoring for better maintainability.

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 can you please take a look... 