### PR TITLE
[macos] Return 'not available' instead of 0.0 for cpu/gpu temps

### DIFF
--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -96,7 +96,12 @@ CTemperature CSystemGUIInfo::GetGPUTemperature() const
 
 #if defined(TARGET_DARWIN_OSX)
   value = SMCGetTemperature(SMC_KEY_GPU_TEMP);
-  return CTemperature::CreateFromCelsius(value);
+  auto temperature = CTemperature::CreateFromCelsius(value);
+  if (temperature == CTemperature::CreateFromCelsius(0.0))
+  {
+    temperature.SetValid(false);
+  }
+  return temperature;
 #elif defined(TARGET_WINDOWS_STORE)
   return CTemperature::CreateFromCelsius(0);
 #else

--- a/xbmc/platform/darwin/osx/CPUInfoOsx.cpp
+++ b/xbmc/platform/darwin/osx/CPUInfoOsx.cpp
@@ -121,6 +121,10 @@ bool CCPUInfoOsx::GetTemperature(CTemperature& temperature)
   int value = SMCGetTemperature(SMC_KEY_CPU_TEMP);
 
   temperature = CTemperature::CreateFromCelsius(value);
+  if (temperature == CTemperature::CreateFromCelsius(0.0))
+  {
+    temperature.SetValid(false);
+  }
 
   return true;
 }

--- a/xbmc/utils/test/TestCPUInfo.cpp
+++ b/xbmc/utils/test/TestCPUInfo.cpp
@@ -41,7 +41,7 @@ TEST_F(TestCPUInfo, GetCPUFrequency)
   EXPECT_GE(CServiceBroker::GetCPUInfo()->GetCPUFrequency(), 0.f);
 }
 
-#if defined(TARGET_WINDOWS)
+#if defined(TARGET_WINDOWS) or defined(TARGET_DARWIN_OSX)
 TEST_F(TestCPUInfo, DISABLED_GetTemperature)
 #else
 TEST_F(TestCPUInfo, GetTemperature)


### PR DESCRIPTION
## Description
Kodi queries the cpu and gpu temperature from the smc. The old project Kodi is using at the moment does not support any of the apple silicon models leading to those temperatures to be reported as 0.0.
This little change makes the failing path to take effect, showing "not available" instead of the wrong value.

## Motivation and context
I am working on trying to improve those temperature reportings in Kodi, switching to a new (maintained) lib. Since this is still work in progress and a few changes are required, just show them as not available for now.

## How has this been tested?
Runtime tested

## What is the effect on users?
On apple silicon macs the 0.0 value is no longer shown.

## Screenshots (if appropriate):
**Before**
<img width="1140" alt="image" src="https://github.com/xbmc/xbmc/assets/7375276/3a8840f7-8508-4c67-ab1b-f6272aa63e16">


**Now**
<img width="1149" alt="image" src="https://github.com/xbmc/xbmc/assets/7375276/5b1f45c9-30c3-400e-998d-350a11e52bfa">


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

