### PR TITLE
[Estuary] View_501_Banner.xml: Fixed syntax error (unmatched parentheses).

### DIFF
--- a/addons/skin.estuary/xml/View_501_Banner.xml
+++ b/addons/skin.estuary/xml/View_501_Banner.xml
@@ -142,7 +142,7 @@
 								<width>22</width>
 								<height>22</height>
 								<texture>lists/played-total.png</texture>
-								<visible>(String.IsEqual(Listitem.dbtype,tvshow) | String.IsEqual(Listitem.dbtype,season)) + !String.IsEmpty(ListItem.Property(TotalEpisodes))</visible>
+								<visible>[String.IsEqual(Listitem.dbtype,tvshow) | String.IsEqual(Listitem.dbtype,season)] + !String.IsEmpty(ListItem.Property(TotalEpisodes))</visible>
 							</control>
 							<control type="label">
 								<right>103</right>


### PR DESCRIPTION
Fix a stupid syntax error that slipped in with 4c4d544410e038c688845f98b6dd7519567f66a0.

Exposed in the log with:
```
2023-08-27 23:21:39.551199+0200 Kodi[57908:5743380] 2023-08-27 23:21:39.551 T:5743380   error <general>: unmatched parentheses in (string.isequal(listitem.dbtype,tvshow)
2023-08-27 23:21:39.551444+0200 Kodi[57908:5743380] 2023-08-27 23:21:39.551 T:5743380   error <general>: unmatched parentheses in string.isequal(listitem.dbtype,season))
```

Sorry.