### PR TITLE
[info] Move network infos to sysinfo

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -2068,24 +2068,14 @@ const infomap system_param[] =   {{ "hasalarm",         SYSTEM_HAS_ALARM },
 ///     @return The network DNS 2 address.
 ///     <p>
 ///   }
-///   \table_row3{   <b>`Network.DHCPAddress`</b>,
-///                  \anchor Network_DHCPAddress
-///                  _string_,
-///     @return The DHCP IP address.
-///     <p>
-///   }
 /// \table_end
 ///
 /// -----------------------------------------------------------------------------
-const infomap network_labels[] = {{ "isdhcp",            NETWORK_IS_DHCP },
-                                  { "ipaddress",         NETWORK_IP_ADDRESS }, //labels from here
-                                  { "linkstate",         NETWORK_LINK_STATE },
-                                  { "macaddress",        NETWORK_MAC_ADDRESS },
-                                  { "subnetmask",        NETWORK_SUBNET_MASK },
-                                  { "gatewayaddress",    NETWORK_GATEWAY_ADDRESS },
-                                  { "dns1address",       NETWORK_DNS1_ADDRESS },
-                                  { "dns2address",       NETWORK_DNS2_ADDRESS },
-                                  { "dhcpaddress",       NETWORK_DHCP_ADDRESS }};
+const infomap network_labels[] = {
+    {"isdhcp", NETWORK_IS_DHCP},           {"ipaddress", NETWORK_IP_ADDRESS}, //labels from here
+    {"linkstate", NETWORK_LINK_STATE},     {"macaddress", NETWORK_MAC_ADDRESS},
+    {"subnetmask", NETWORK_SUBNET_MASK},   {"gatewayaddress", NETWORK_GATEWAY_ADDRESS},
+    {"dns1address", NETWORK_DNS1_ADDRESS}, {"dns2address", NETWORK_DNS2_ADDRESS}};
 
 /// \page modules__infolabels_boolean_conditions
 /// \subsection modules__infolabels_boolean_conditions_musicpartymode Music party mode
@@ -9714,6 +9704,11 @@ const infomap slideshow[] =      {{ "ispaused",               SLIDESHOW_ISPAUSED
 
 /// \page modules__infolabels_boolean_conditions
 /// \section modules_rm_infolabels_booleans Additional revision history for Infolabels and Boolean Conditions
+/// <hr>
+/// \subsection modules_rm_infolabels_booleans_v21 Kodi v21 (Omega)
+/// @skinning_v21 **[Removed Infolabels]** The following infolabels have been removed:
+///   - `Network.DHCPAddress` - this info did not return any meaningful value (always an empty string)
+///
 /// <hr>
 /// \subsection modules_rm_infolabels_booleans_v20 Kodi v20 (Nexus)
 /// @skinning_v20 **[Removed Boolean conditions]** The following boolean conditions have been removed:

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -2071,11 +2071,18 @@ const infomap system_param[] =   {{ "hasalarm",         SYSTEM_HAS_ALARM },
 /// \table_end
 ///
 /// -----------------------------------------------------------------------------
+// clang-format off
 const infomap network_labels[] = {
-    {"isdhcp", NETWORK_IS_DHCP},           {"ipaddress", NETWORK_IP_ADDRESS}, //labels from here
-    {"linkstate", NETWORK_LINK_STATE},     {"macaddress", NETWORK_MAC_ADDRESS},
-    {"subnetmask", NETWORK_SUBNET_MASK},   {"gatewayaddress", NETWORK_GATEWAY_ADDRESS},
-    {"dns1address", NETWORK_DNS1_ADDRESS}, {"dns2address", NETWORK_DNS2_ADDRESS}};
+    {"isdhcp", NETWORK_IS_DHCP},
+    {"ipaddress", NETWORK_IP_ADDRESS}, //labels from here
+    {"linkstate", NETWORK_LINK_STATE},
+    {"macaddress", NETWORK_MAC_ADDRESS},
+    {"subnetmask", NETWORK_SUBNET_MASK},
+    {"gatewayaddress", NETWORK_GATEWAY_ADDRESS},
+    {"dns1address", NETWORK_DNS1_ADDRESS},
+    {"dns2address", NETWORK_DNS2_ADDRESS}
+};
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 /// \subsection modules__infolabels_boolean_conditions_musicpartymode Music party mode

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -167,7 +167,6 @@
 #define NETWORK_GATEWAY_ADDRESS     195
 #define NETWORK_DNS1_ADDRESS        196
 #define NETWORK_DNS2_ADDRESS        197
-#define NETWORK_DHCP_ADDRESS        198
 
 // Keep musicplayer infolabels that work with offset and position together
 #define MUSICPLAYER_TITLE           200

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -176,7 +176,12 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
       value = GetSystemHeatInfo(info.m_info);
       return true;
     case SYSTEM_VIDEO_ENCODER_INFO:
+    case NETWORK_IP_ADDRESS:
     case NETWORK_MAC_ADDRESS:
+    case NETWORK_SUBNET_MASK:
+    case NETWORK_GATEWAY_ADDRESS:
+    case NETWORK_DNS1_ADDRESS:
+    case NETWORK_DNS2_ADDRESS:
     case SYSTEM_OS_VERSION_INFO:
     case SYSTEM_CPUFREQUENCY:
     case SYSTEM_INTERNET_STATE:
@@ -364,73 +369,11 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // NETWORK_*
     ///////////////////////////////////////////////////////////////////////////////////////////////
-    case NETWORK_IP_ADDRESS:
-    {
-      CNetworkInterface* iface = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
-      if (iface)
-      {
-        value = iface->GetCurrentIPAddress();
-        return true;
-      }
-      break;
-    }
-    case NETWORK_SUBNET_MASK:
-    {
-      CNetworkInterface* iface = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
-      if (iface)
-      {
-        value = iface->GetCurrentNetmask();
-        return true;
-      }
-      break;
-    }
-    case NETWORK_GATEWAY_ADDRESS:
-    {
-      CNetworkInterface* iface = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
-      if (iface)
-      {
-        value = iface->GetCurrentDefaultGateway();
-        return true;
-      }
-      break;
-    }
-    case NETWORK_DNS1_ADDRESS:
-    {
-      const std::vector<std::string> nss = CServiceBroker::GetNetwork().GetNameServers();
-      if (nss.size() >= 1)
-      {
-        value = nss[0];
-        return true;
-      }
-      break;
-    }
-    case NETWORK_DNS2_ADDRESS:
-    {
-      const std::vector<std::string> nss = CServiceBroker::GetNetwork().GetNameServers();
-      if (nss.size() >= 2)
-      {
-        value = nss[1];
-        return true;
-      }
-      break;
-    }
     case NETWORK_DHCP_ADDRESS:
     {
       // wtf?
       std::string dhcpserver;
       value = dhcpserver;
-      return true;
-    }
-    case NETWORK_LINK_STATE:
-    {
-      std::string linkStatus = g_localizeStrings.Get(151);
-      linkStatus += " ";
-      CNetworkInterface* iface = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
-      if (iface && iface->IsConnected())
-        linkStatus += g_localizeStrings.Get(15207);
-      else
-        linkStatus += g_localizeStrings.Get(15208);
-      value = linkStatus;
       return true;
     }
   }

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -365,17 +365,6 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
 
       return true;
     }
-
-    ///////////////////////////////////////////////////////////////////////////////////////////////
-    // NETWORK_*
-    ///////////////////////////////////////////////////////////////////////////////////////////////
-    case NETWORK_DHCP_ADDRESS:
-    {
-      // wtf?
-      std::string dhcpserver;
-      value = dhcpserver;
-      return true;
-    }
   }
 
   return false;

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -288,6 +288,11 @@ bool CSysInfoJob::DoWork()
   m_info.osVersionInfo     = CSysInfo::GetOsPrettyNameWithVersion() + " (kernel: " + CSysInfo::GetKernelName() + " " + CSysInfo::GetKernelVersionFull() + ")";
   m_info.macAddress        = GetMACAddress();
   m_info.batteryLevel      = GetBatteryLevel();
+  m_info.ipAddress = GetIPAddress();
+  m_info.netMask = GetNetMask();
+  m_info.dnsServers = GetDNSServers();
+  m_info.gatewayAddress = GetGatewayAddress();
+  m_info.networkLinkState = GetNetworkLinkState();
   return true;
 }
 
@@ -312,6 +317,57 @@ std::string CSysInfoJob::GetMACAddress()
     return iface->GetMacAddress();
 
   return "";
+}
+
+std::string CSysInfoJob::GetIPAddress()
+{
+  CNetworkInterface* iface = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
+  if (iface)
+  {
+    return iface->GetCurrentIPAddress();
+  }
+  return {};
+}
+
+std::string CSysInfoJob::GetNetMask()
+{
+  CNetworkInterface* iface = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
+  if (iface)
+  {
+    return iface->GetCurrentNetmask();
+  }
+  return {};
+}
+
+std::string CSysInfoJob::GetGatewayAddress()
+{
+  CNetworkInterface* iface = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
+  if (iface)
+  {
+    return iface->GetCurrentDefaultGateway();
+  }
+  return {};
+}
+
+std::string CSysInfoJob::GetNetworkLinkState()
+{
+  std::string linkStatus = g_localizeStrings.Get(151);
+  linkStatus += " ";
+  CNetworkInterface* iface = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
+  if (iface && iface->IsConnected())
+  {
+    linkStatus += g_localizeStrings.Get(15207);
+  }
+  else
+  {
+    linkStatus += g_localizeStrings.Get(15208);
+  }
+  return linkStatus;
+}
+
+std::vector<std::string> CSysInfoJob::GetDNSServers()
+{
+  return CServiceBroker::GetNetwork().GetNameServers();
 }
 
 std::string CSysInfoJob::GetVideoEncoder()
@@ -387,6 +443,18 @@ std::string CSysInfo::TranslateInfo(int info) const
     return m_info.videoEncoder;
   case NETWORK_MAC_ADDRESS:
     return m_info.macAddress;
+  case NETWORK_IP_ADDRESS:
+    return m_info.ipAddress;
+  case NETWORK_SUBNET_MASK:
+    return m_info.netMask;
+  case NETWORK_GATEWAY_ADDRESS:
+    return m_info.gatewayAddress;
+  case NETWORK_DNS1_ADDRESS:
+    return m_info.dnsServers.size() > 0 ? m_info.dnsServers.at(0) : "";
+  case NETWORK_DNS2_ADDRESS:
+    return m_info.dnsServers.size() > 1 ? m_info.dnsServers.at(1) : "";
+  case NETWORK_LINK_STATE:
+    return m_info.networkLinkState;
   case SYSTEM_OS_VERSION_INFO:
     return m_info.osVersionInfo;
   case SYSTEM_CPUFREQUENCY:

--- a/xbmc/utils/SystemInfo.h
+++ b/xbmc/utils/SystemInfo.h
@@ -10,8 +10,10 @@
 
 #include "InfoLoader.h"
 #include "settings/ISubSettings.h"
+#include "utils/Job.h"
 
 #include <string>
+#include <vector>
 
 #define KB  (1024)          // 1 KiloByte (1KB)   1024 Byte (2^10 Byte)
 #define MB  (1024*KB)       // 1 MegaByte (1MB)   1024 KB (2^10 KB)
@@ -44,6 +46,11 @@ public:
   std::string cpuFrequency;
   std::string osVersionInfo;
   std::string macAddress;
+  std::string ipAddress;
+  std::string netMask;
+  std::string gatewayAddress;
+  std::string networkLinkState;
+  std::vector<std::string> dnsServers;
   std::string batteryLevel;
 };
 
@@ -60,8 +67,13 @@ private:
   static bool SystemUpTime(int iInputMinutes, int &iMinutes, int &iHours, int &iDays);
   static std::string GetSystemUpTime(bool bTotalUptime);
   static std::string GetMACAddress();
+  static std::string GetIPAddress();
+  static std::string GetNetMask();
+  static std::string GetGatewayAddress();
+  static std::string GetNetworkLinkState();
   static std::string GetVideoEncoder();
   static std::string GetBatteryLevel();
+  static std::vector<std::string> GetDNSServers();
 
   CSysData m_info;
 };


### PR DESCRIPTION
## Description
On the mac I can't barely move the mouse when accessing the system information screen. This is due to the long time it takes to get the network information. Part of it is already handled by sysinfo (which dispatches a job and returns busy while getting the first values - obtaining them out of the main thread) so lets just add all the other network infos there too.

Took the opportunity to kill one of the infos that currently only returns an empty string.

@ksooo maybe you can review this one? Should be pretty simple.

## Motivation and context
Really slow GUI on the mac on the info screen

## How has this been tested?
Runtime tested

## What is the effect on users?
Increase the GUI fps on the System Information

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

