### PR TITLE
[macOS] fix crash on pressing Caps Lock on an ARM Mac

### DIFF
--- a/xbmc/platform/darwin/osx/HotKeyController.m
+++ b/xbmc/platform/darwin/osx/HotKeyController.m
@@ -123,7 +123,10 @@ static CGEventRef tapEventCallback2(CGEventTapProxy proxy, CGEventType type, CGE
   if ((type != NX_SYSDEFINED) || (![hot_key_controller getActive]))
     return event;
 
-  NSEvent *nsEvent = [NSEvent eventWithCGEvent:event];
+  NSEvent *__block nsEvent;
+  dispatch_sync(dispatch_get_main_queue(), ^{
+    nsEvent = [NSEvent eventWithCGEvent:event];
+  });
   if (!nsEvent || [nsEvent subtype] != 8)
     return event;
 


### PR DESCRIPTION
## Description
Based on stack trace, when Caps Lock is pressed, macOS SDK tries to pull list of input languages which apparently must be done only on the main thread

## Motivation and context
fixes #22676

## How has this been tested?
tested on my Intel and ARM Macs

## What is the effect on users?
crash is gone

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
