### PR TITLE
[macos][network][info] Improvements to DNS determination

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -1091,6 +1091,7 @@ msgstr ""
 #: xbmc/playlists/SmartPlaylist.cpp
 #: system/settings/settings.xml
 #: xbmc/LangInfo.cpp
+#: xbmc/utils/Systeminfo.cpp
 #: ###this documented usage does not cover all usecases yet###
 msgctxt "#231"
 msgid "None"

--- a/xbmc/platform/darwin/osx/network/NetworkOsx.cpp
+++ b/xbmc/platform/darwin/osx/network/NetworkOsx.cpp
@@ -180,7 +180,7 @@ std::vector<std::string> CNetworkOsx::GetNameServers()
 {
   std::vector<std::string> result;
 
-  FILE* pipe = popen("scutil --dns | grep \"nameserver\" | tail -n2", "r");
+  FILE* pipe = popen("scutil --dns | grep \"nameserver\" | uniq | tail -n2", "r");
   usleep(100000);
   if (pipe)
   {

--- a/xbmc/platform/darwin/osx/network/NetworkOsx.cpp
+++ b/xbmc/platform/darwin/osx/network/NetworkOsx.cpp
@@ -21,6 +21,7 @@
 #include <net/if_types.h>
 #include <net/route.h>
 #include <netinet/if_ether.h>
+#include <poll.h>
 #include <sys/sockio.h>
 #include <unistd.h>
 
@@ -180,27 +181,43 @@ std::vector<std::string> CNetworkOsx::GetNameServers()
 {
   std::vector<std::string> result;
 
-  FILE* pipe = popen("scutil --dns | grep \"nameserver\" | uniq | tail -n2", "r");
-  usleep(100000);
+  FILE* pipe = popen("scutil --dns | grep -F \"nameserver\" | uniq | tail -n2", "r");
+
   if (pipe)
   {
-    std::vector<std::string> tmpStr;
-    char buffer[256] = {'\0'};
-    if (fread(buffer, sizeof(char), sizeof(buffer), pipe) > 0 && !ferror(pipe))
+    int fineNoPipe = ::fileno(pipe);
+
+    struct pollfd pollFd;
+    pollFd.fd = fineNoPipe;
+    pollFd.events = POLLIN;
+    pollFd.revents = 0;
+
+    int pollResult = poll(&pollFd, 1, 1000); // Poll for 1 second
+    if (pollResult > 0 && (pollFd.revents & POLLIN))
     {
-      tmpStr = StringUtils::Split(buffer, "\n");
-      for (unsigned int i = 0; i < tmpStr.size(); i++)
+      char buffer[256] = {'\0'};
+      if (fgets(buffer, sizeof(buffer), pipe))
       {
         // result looks like this - > '  nameserver[0] : 192.168.1.1'
         // 2 blank spaces + 13 in 'nameserver[0]' + blank + ':' + blank == 18 :)
-        if (tmpStr[i].length() >= 18)
-          result.push_back(tmpStr[i].substr(18));
+        const unsigned int nameserverLineSize = 18;
+        std::vector<std::string> tmpStr = StringUtils::Split(buffer, "\n");
+        for (const std::string& str : tmpStr)
+        {
+          if (str.length() >= nameserverLineSize)
+          {
+            result.push_back(str.substr(nameserverLineSize));
+          }
+        }
       }
     }
     pclose(pipe);
   }
+
   if (result.empty())
-    CLog::Log(LOGWARNING, "Unable to determine nameserver");
+  {
+    CLog::Log(LOGWARNING, "Unable to determine nameservers");
+  }
 
   return result;
 }

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -450,9 +450,9 @@ std::string CSysInfo::TranslateInfo(int info) const
   case NETWORK_GATEWAY_ADDRESS:
     return m_info.gatewayAddress;
   case NETWORK_DNS1_ADDRESS:
-    return m_info.dnsServers.size() > 0 ? m_info.dnsServers.at(0) : "";
+    return m_info.dnsServers.size() > 0 ? m_info.dnsServers.at(0) : g_localizeStrings.Get(231);
   case NETWORK_DNS2_ADDRESS:
-    return m_info.dnsServers.size() > 1 ? m_info.dnsServers.at(1) : "";
+    return m_info.dnsServers.size() > 1 ? m_info.dnsServers.at(1) : g_localizeStrings.Get(231);
   case NETWORK_LINK_STATE:
     return m_info.networkLinkState;
   case SYSTEM_OS_VERSION_INFO:


### PR DESCRIPTION
## Description
This PR brings a few improvements to `GetDNSServers` for mac. As far as I could search, using scutil is still the best way of getting those values.
The issue is that we currently don't filter per unique values, so if you have only a single DNS configured the command returns:
```
➜  xbmc git:(apple_dns) scutil --dns | grep "nameserver" | tail -n2
  nameserver[0] : 1.1.1.1
  nameserver[0] : 1.1.1.1
```

Furthermore, we sleep blindingly for 1 second to allow for the buffer of popen() to fill. I moved it to pselect with a timeout of a second instead.
Another commit added to simply display "None" instead of an empty string.


## Motivation and context
Make the code faster. Fixup inconsistencies for single DNS configuration.

## How has this been tested?
Runtime tested. Single DNS server and multiple DNS Servers.
In my case I only have 1 DNS configured (1.1.1.1), so Kodi reported this:
<img width="1146" alt="image" src="https://github.com/xbmc/xbmc/assets/7375276/dfcfcc0c-0e53-4637-8761-be0e1a9cfabc">

**Now:**
<img width="1153" alt="image" src="https://github.com/xbmc/xbmc/assets/7375276/7fc2a9ef-ecc0-4553-83f1-9e06934115c6">


## What is the effect on users?
Faster detection of the DNS entries (important since this is exposed to the info interface), fix reporting for single DNS server.

## Screenshots (if appropriate):
See above

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
