### PR TITLE
[PVR] CPVRChannelsPath: fix typo.

### DIFF
--- a/xbmc/pvr/channels/PVRChannelsPath.h
+++ b/xbmc/pvr/channels/PVRChannelsPath.h
@@ -21,7 +21,7 @@ namespace PVR
     static const std::string PATH_RADIO_CHANNELS;
 
     explicit CPVRChannelsPath(const std::string& strPath);
-    CPVRChannelsPath(bool bRadio, const std::string& strGroupName, int iGrouupClientID);
+    CPVRChannelsPath(bool bRadio, const std::string& strGroupName, int iGroupClientID);
     CPVRChannelsPath(bool bRadio,
                      bool bHidden,
                      const std::string& strGroupName,


### PR DESCRIPTION
Not much to say - fixes a typo in a parameter name of a member function declaration. No functional changes.

@phunkyfish I feel like this change could be reviewed and approved by you easily. :-)