### PR TITLE
[video] Fix movie set overview not updated when refreshing data.

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1710,6 +1710,11 @@ int CVideoDatabase::AddSet(const std::string& strSet, const std::string& strOver
     {
       int id = m_pDS->fv("idSet").get_asInt();
       m_pDS->close();
+
+      // update set data
+      strSQL = PrepareSQL("UPDATE sets SET strOverview = '%s' WHERE idSet = %i",
+                          strOverview.c_str(), id);
+      m_pDS->exec(strSQL);
       return id;
     }
   }


### PR DESCRIPTION
When refreshing movie set data, changed movie set overview was not saved to database.

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 something for you to review, please.