### PR TITLE
[video] Improve library refresh progress dialog content a bit.

### DIFF
--- a/xbmc/dialogs/GUIDialogBoxBase.cpp
+++ b/xbmc/dialogs/GUIDialogBoxBase.cpp
@@ -60,6 +60,12 @@ void CGUIDialogBoxBase::SetHeading(const CVariant& heading)
   }
 }
 
+bool CGUIDialogBoxBase::HasHeading() const
+{
+  std::unique_lock<CCriticalSection> lock(m_section);
+  return !m_strHeading.empty();
+}
+
 void CGUIDialogBoxBase::SetLine(unsigned int iLine, const CVariant& line)
 {
   std::string label = GetLocalized(line);
@@ -82,6 +88,12 @@ void CGUIDialogBoxBase::SetText(const CVariant& text)
     m_text = label;
     SetInvalid();
   }
+}
+
+bool CGUIDialogBoxBase::HasText() const
+{
+  std::unique_lock<CCriticalSection> lock(m_section);
+  return !m_text.empty();
 }
 
 void CGUIDialogBoxBase::SetChoice(int iButton, const CVariant &choice) // iButton == 0 for no, 1 for yes

--- a/xbmc/dialogs/GUIDialogBoxBase.h
+++ b/xbmc/dialogs/GUIDialogBoxBase.h
@@ -34,7 +34,9 @@ public:
   bool IsConfirmed() const;
   void SetLine(unsigned int iLine, const CVariant& line);
   void SetText(const CVariant& text);
+  bool HasText() const;
   void SetHeading(const CVariant& heading);
+  bool HasHeading() const;
   void SetChoice(int iButton, const CVariant &choice);
 protected:
   std::string GetDefaultLabel(int controlId) const;
@@ -54,7 +56,7 @@ protected:
   bool m_hasTextbox;
 
   // actual strings
-  CCriticalSection m_section;
+  mutable CCriticalSection m_section;
   std::string m_strHeading;
   std::string m_text;
   std::string m_strChoices[DIALOG_MAX_CHOICES];

--- a/xbmc/utils/ProgressJob.cpp
+++ b/xbmc/utils/ProgressJob.cpp
@@ -103,7 +103,9 @@ void CProgressJob::SetTitle(const std::string &title)
   {
     m_progressDialog->SetHeading(CVariant{title});
 
-    ShowProgressDialog();
+    // Prevent displaying the progress dialog without any heading and/or text.
+    if (m_progressDialog->HasHeading() && m_progressDialog->HasText())
+      ShowProgressDialog();
   }
 }
 
@@ -118,7 +120,9 @@ void CProgressJob::SetText(const std::string &text)
   {
     m_progressDialog->SetText(CVariant{text});
 
-    ShowProgressDialog();
+    // Prevent displaying the progress dialog without any heading and/or text.
+    if (m_progressDialog->HasText() && m_progressDialog->HasHeading())
+      ShowProgressDialog();
   }
 }
 

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -576,7 +576,9 @@ namespace VIDEO
       return ret;
     }
 
-    if (ProgressCancelled(pDlgProgress, pItem->m_bIsFolder ? 20353 : 20361, pItem->GetLabel()))
+    if (ProgressCancelled(pDlgProgress, pItem->m_bIsFolder ? 20353 : 20361,
+                          pItem->m_bIsFolder ? pItem->GetVideoInfoTag()->m_strShowTitle
+                                             : pItem->GetVideoInfoTag()->m_strTitle))
       return INFO_CANCELLED;
 
     if (m_handle)
@@ -1729,8 +1731,7 @@ namespace VIDEO
   {
     if (pDlgProgress)
     {
-      pDlgProgress->SetLine(1, CVariant{showInfo.m_strTitle});
-      pDlgProgress->SetLine(2, CVariant{20361});
+      pDlgProgress->SetLine(1, CVariant{20361}); // Loading episode details
       pDlgProgress->SetPercentage(0);
       pDlgProgress->ShowProgressBar(true);
       pDlgProgress->Progress();
@@ -1745,7 +1746,11 @@ namespace VIDEO
     {
       if (pDlgProgress)
       {
-        pDlgProgress->SetLine(2, CVariant{20361});
+        pDlgProgress->SetLine(1, CVariant{20361}); // Loading episode details
+        pDlgProgress->SetLine(2, StringUtils::Format("{} {}", g_localizeStrings.Get(20373),
+                                                     file->iSeason)); // Season x
+        pDlgProgress->SetLine(3, StringUtils::Format("{} {}", g_localizeStrings.Get(20359),
+                                                     file->iEpisode)); // Episode y
         pDlgProgress->SetPercentage((int)((float)(iCurr++)/iMax*100));
         pDlgProgress->Progress();
       }
@@ -1808,7 +1813,7 @@ namespace VIDEO
 
           if (pDlgProgress)
           {
-            pDlgProgress->SetLine(2, CVariant{20354});
+            pDlgProgress->SetLine(1, CVariant{20354}); // Fetching episode guide
             pDlgProgress->Progress();
           }
 
@@ -1978,7 +1983,8 @@ namespace VIDEO
 
       if (pDialog)
       {
-        pDialog->SetLine(1, CVariant{movieDetails.m_strTitle});
+        if (!pDialog->HasText())
+          pDialog->SetLine(0, CVariant{movieDetails.m_strTitle});
         pDialog->Progress();
       }
 
@@ -2237,7 +2243,6 @@ namespace VIDEO
     {
       progress->SetHeading(CVariant{heading});
       progress->SetLine(0, CVariant{line1});
-      progress->SetLine(2, CVariant{""});
       progress->Progress();
       return progress->IsCanceled();
     }

--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
@@ -305,7 +305,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
 
     // prepare the progress dialog for downloading all the necessary information
     SetTitle(g_localizeStrings.Get(headingLabel));
-    SetText(scraperUrl.GetTitle());
+    SetText(itemTitle);
     SetProgress(0);
 
     // remove any existing data for the item we're going to refresh


### PR DESCRIPTION
While experimenting with / fixing refreshing of video meta data, I felt like the content of the refresh progress dialog could be improved a bit to be more informative for the user, for example to display the current season and episode being refreshed.

![screenshot00003](https://github.com/xbmc/xbmc/assets/3226626/36d97977-fa1b-434a-9cf3-3bb0ffcb3c9b)

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 good to go in?