### PR TITLE
[guilib][guiinfo][Estuary] LISTITEM_IS_RESUMABLE: Added support for folders.

### DIFF
--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -452,9 +452,9 @@
 	</variable>
 	<variable name="ListWatchedIconVar">
 		<value condition="ListItem.IsRecording">windows/pvr/record.png</value>
+		<value condition="ListItem.IsCollection">overlays/set.png</value>
 		<value condition="ListItem.IsPlaying">overlays/watched/OverlayPlaying-List.png</value>
 		<value condition="ListItem.IsResumable">overlays/watched/resume.png</value>
-		<value condition="ListItem.IsCollection">overlays/set.png</value>
 		<value condition="ListItem.IsFolder + String.IsEmpty(Listitem.dbtype) + !String.IsEqual(ListItem.Overlay,OverlayWatched.png) + !ListItem.IsParentFolder">overlays/folder.png</value>
 		<value condition="!String.IsEmpty(ListItem.Overlay)">$INFO[ListItem.Overlay]</value>
 		<value condition="!ListItem.IsParentFolder">OverlayUnwatched.png</value>

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -4029,8 +4029,3 @@ bool CFileItem::GetCurrentResumeTimeAndPartNumber(int64_t& startOffset, int& par
   }
   return false;
 }
-
-bool CFileItem::IsResumable() const
-{
-  return (!IsNFO() && !IsPlayList()) || IsType(".strm");
-}

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -4029,3 +4029,33 @@ bool CFileItem::GetCurrentResumeTimeAndPartNumber(int64_t& startOffset, int& par
   }
   return false;
 }
+
+bool CFileItem::IsResumable() const
+{
+  if (m_bIsFolder)
+  {
+    int64_t watched = 0;
+    int64_t inprogress = 0;
+    int64_t total = 0;
+    if (HasProperty("inprogressepisodes"))
+    {
+      // show/season
+      watched = GetProperty("watchedepisodes").asInteger();
+      inprogress = GetProperty("inprogressepisodes").asInteger();
+      total = GetProperty("totalepisodes").asInteger();
+    }
+    else if (HasProperty("inprogress"))
+    {
+      // movie set
+      watched = GetProperty("watched").asInteger();
+      inprogress = GetProperty("inprogress").asInteger();
+      total = GetProperty("total").asInteger();
+    }
+
+    return ((total != watched) && (inprogress > 0 || watched != 0));
+  }
+  else
+  {
+    return HasVideoInfoTag() && GetVideoInfoTag()->GetResumePoint().IsPartWay();
+  }
+}

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -368,12 +368,6 @@ public:
   bool GetCurrentResumeTimeAndPartNumber(int64_t& startOffset, int& partNumber) const;
 
   /*!
-   * \brief Test if this item type can be resumed.
-   * \return True if this item can be resumed, false otherwise.
-   */
-  bool IsResumable() const;
-
-  /*!
    * \brief Get the offset where start the playback.
    * \return The offset value as ms.
    *         Can return also special value -1, see define STARTOFFSET_RESUME.

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -368,6 +368,14 @@ public:
   bool GetCurrentResumeTimeAndPartNumber(int64_t& startOffset, int& partNumber) const;
 
   /*!
+   * \brief Test if this item type can be resumed.
+   * \return True if this item is a folder and has at least one child with a partway resume bookmark
+   * or at least one unwatched child or if it is not a folder, if it has a partway resume bookmark,
+   * false otherwise.
+   */
+  bool IsResumable() const;
+
+  /*!
    * \brief Get the offset where start the playback.
    * \return The offset value as ms.
    *         Can return also special value -1, see define STARTOFFSET_RESUME.

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -748,9 +748,6 @@ bool CVideoGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contextW
       /////////////////////////////////////////////////////////////////////////////////////////////
       // LISTITEM_*
       /////////////////////////////////////////////////////////////////////////////////////////////
-      case LISTITEM_IS_RESUMABLE:
-        value = tag->GetResumePoint().timeInSeconds > 0;
-        return true;
       case LISTITEM_IS_COLLECTION:
         value = tag->m_type == MediaTypeVideoCollection;
         return true;
@@ -803,6 +800,9 @@ bool CVideoGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contextW
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // LISTITEM_*
     ///////////////////////////////////////////////////////////////////////////////////////////////
+    case LISTITEM_IS_RESUMABLE:
+      value = item->IsResumable();
+      return true;
     case LISTITEM_IS_STEREOSCOPIC:
     {
       std::string stereoMode = item->GetProperty("stereomode").asString();

--- a/xbmc/video/VideoUtils.cpp
+++ b/xbmc/video/VideoUtils.cpp
@@ -682,7 +682,12 @@ ResumeInformation GetFolderItemResumeInformation(const CFileItem& item)
 
 ResumeInformation GetNonFolderItemResumeInformation(const CFileItem& item)
 {
-  if (!item.IsResumable())
+  // do not resume nfo files
+  if (item.IsNFO())
+    return {};
+
+  // do not resume playlists, except strm files
+  if (!item.IsType("strm") && item.IsPlayList())
     return {};
 
   // do not resume Live TV and 'deleted' items (e.g. trashed pvr recordings)

--- a/xbmc/video/VideoUtils.cpp
+++ b/xbmc/video/VideoUtils.cpp
@@ -652,25 +652,7 @@ ResumeInformation GetFolderItemResumeInformation(const CFileItem& item)
     }
   }
 
-  int64_t watched = 0;
-  int64_t inprogress = 0;
-  int64_t total = 0;
-  if (folderItem.HasProperty("inprogressepisodes"))
-  {
-    // show/season
-    watched = folderItem.GetProperty("watchedepisodes").asInteger();
-    inprogress = folderItem.GetProperty("inprogressepisodes").asInteger();
-    total = folderItem.GetProperty("totalepisodes").asInteger();
-  }
-  else if (folderItem.HasProperty("inprogress"))
-  {
-    // movie set
-    watched = folderItem.GetProperty("watched").asInteger();
-    inprogress = folderItem.GetProperty("inprogress").asInteger();
-    total = folderItem.GetProperty("total").asInteger();
-  }
-
-  if ((total != watched) && (inprogress > 0 || watched != 0))
+  if (folderItem.IsResumable())
   {
     ResumeInformation resumeInfo;
     resumeInfo.isResumable = true;

--- a/xbmc/video/VideoUtils.cpp
+++ b/xbmc/video/VideoUtils.cpp
@@ -677,7 +677,6 @@ ResumeInformation GetFolderItemResumeInformation(const CFileItem& item)
     return resumeInfo;
   }
 
-  CLog::LogF(LOGERROR, "Cannot obtain inprogress state for {}", folderItem.GetPath());
   return {};
 }
 


### PR DESCRIPTION
Followup to #23658

TV Shows/Seasons/Movie sets/Recording folders now expose their 'in progress' state via LISTITEM_IS_RESUMABLE.

Examples:

![screenshot00002](https://github.com/xbmc/xbmc/assets/3226626/5c6ee3f2-6276-4a4e-b39d-a1b4ab045e88)
![screenshot00001](https://github.com/xbmc/xbmc/assets/3226626/d1828417-b6ae-4854-9a84-5940891b7f37)

Runtime-tested (like always) on macOS and Android, latest Kodi master.

@enen92 another one I had in my PR queue...