### PR TITLE
[video] VIDEO_UTILS::CAsyncGetItemsForPlaylist::GetItemsForPlaylist: …

### DIFF
--- a/xbmc/video/VideoUtils.cpp
+++ b/xbmc/video/VideoUtils.cpp
@@ -176,7 +176,14 @@ void CAsyncGetItemsForPlaylist::GetItemsForPlaylist(const std::shared_ptr<CFileI
 
       SortDescription sortDesc;
       if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == viewStateWindowId)
+      {
         sortDesc = state->GetSortMethod();
+
+        // It makes no sense to play from younger to older.
+        if (sortDesc.sortBy == SortByDate || sortDesc.sortBy == SortByYear ||
+            sortDesc.sortBy == SortByEpisodeNumber)
+          sortDesc.sortOrder = SortOrderAscending;
+      }
       else
         sortDesc = GetSortDescription(*state, items);
 


### PR DESCRIPTION
…If sort by date, year, episodenum enforce sort order ascending for playlist items.

Imo, it makes absolutely no sense to sort playlist items by date, descending. Happens with PVR recording folder contents which are by default sorted by date, descending. But if you want to play the folder content, you for sure want to watch from oldest to newest.

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 I hope you see my point for the change in behavior and that you can approve the code change. 