### PR TITLE
Games: Fix clang-formatting after tinyxml2 update

### DIFF
--- a/xbmc/games/ports/input/PortManager.cpp
+++ b/xbmc/games/ports/input/PortManager.cpp
@@ -105,21 +105,19 @@ void CPortManager::SaveXMLAsync()
                       m_saveFutures.end());
 
   // Save async
-  std::future<void> task = std::async(std::launch::async,
-                                      [this, ports = std::move(ports)]()
-                                      {
-                                        CXBMCTinyXML2 doc;
-                                        auto* node = doc.NewElement(XML_ROOT_PORTS);
-                                        if (node == nullptr)
-                                          return;
+  std::future<void> task = std::async(std::launch::async, [this, ports = std::move(ports)]() {
+    CXBMCTinyXML2 doc;
+    auto* node = doc.NewElement(XML_ROOT_PORTS);
+    if (node == nullptr)
+      return;
 
-                                        SerializePorts(*node, ports);
+    SerializePorts(*node, ports);
 
-                                        doc.InsertEndChild(node);
+    doc.InsertEndChild(node);
 
-                                        std::lock_guard<std::mutex> lock(m_saveMutex);
-                                        doc.SaveFile(m_xmlPath);
-                                      });
+    std::lock_guard<std::mutex> lock(m_saveMutex);
+    doc.SaveFile(m_xmlPath);
+  });
 
   m_saveFutures.emplace_back(std::move(task));
 }


### PR DESCRIPTION
## Description

Fixes clang-formatting after https://github.com/xbmc/xbmc/pull/23600.

## Motivation and context

Less conflicts for me when I clang-format my development branch.

## How has this been tested?

Compiles successfully on all platforms.

## What is the effect on users?

* None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
