### PR TITLE
Bump Android SDK 34 + AGP 8.1

### DIFF
--- a/cmake/platform/android/android.cmake
+++ b/cmake/platform/android/android.cmake
@@ -4,7 +4,7 @@ set(APP_RENDER_SYSTEM gles)
 list(APPEND PLATFORM_OPTIONAL_DEPS LibDovi)
 
 # Store SDK compile version
-set(TARGET_SDK 33)
+set(TARGET_SDK 34)
 # Minimum supported SDK version
 set(TARGET_MINSDK 21)
 

--- a/docs/README.Android.md
+++ b/docs/README.Android.md
@@ -68,7 +68,7 @@ sudo apt install autoconf bison build-essential curl default-jdk flex gawk git g
 > If you're running a 32bit Debian/Ubuntu distribution,  remove `lib32stdc++6 lib32z1 lib32z1-dev` from the command.
 
 > [!NOTE]  
-> Gradle 7.0.2+ requires Jave Runtime 11+. Check java version by running `java --version`.  If version is < 11, set JAVA_HOME to java 11+ home directory._
+> Gradle 8.0+ requires JDK 17+. Check java version by running `java --version`. If version is < 17, set `JAVA_HOME` environment variable to java 17+ home directory.
 
 **[back to top](#table-of-contents)**
 
@@ -98,7 +98,7 @@ Before Android SDK can be used, you need to accept the licenses and configure it
 cd $HOME/android-tools/android-sdk-linux/cmdline-tools/bin
 ./sdkmanager --sdk_root=$(pwd)/../.. --licenses
 ./sdkmanager --sdk_root=$(pwd)/../.. platform-tools
-./sdkmanager --sdk_root=$(pwd)/../.. "platforms;android-33"
+./sdkmanager --sdk_root=$(pwd)/../.. "platforms;android-34"
 ./sdkmanager --sdk_root=$(pwd)/../.. "build-tools;33.0.1"
 ./sdkmanager --sdk_root=$(pwd)/../.. "ndk;21.4.7075529"
 ```

--- a/tools/android/packaging/build.gradle
+++ b/tools/android/packaging/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.0'
+        classpath 'com.android.tools.build:gradle:8.1.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
## Description
Bump Android SDK to API level 34. I've reviewed the new features and in principle no changes to the code are needed.

Upgrade Android Gradle Plugin (AGP) to the current stable version.

JDK 17 is now required to run from AGP 8.0 onwards.

It may be necessary to manually upgrade the JDK version from 11 to 17 on Android dockers, most likely version 17 will be the `default-jdk` package, otherwise use `openjdk-17-jdk`.

## How has this been tested?
Builds without issue with the upgrade to JDK 17, AGP 8 and SDK 34.

Runtime-tested on Android TV 9.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
