### PR TITLE
call -eventWithCGEvent: on the main queue

### DIFF
--- a/xbmc/platform/darwin/osx/HotKeyController.m
+++ b/xbmc/platform/darwin/osx/HotKeyController.m
@@ -123,7 +123,10 @@ static CGEventRef tapEventCallback2(CGEventTapProxy proxy, CGEventType type, CGE
   if ((type != NX_SYSDEFINED) || (![hot_key_controller getActive]))
     return event;
 
-  NSEvent *nsEvent = [NSEvent eventWithCGEvent:event];
+  NSEvent* __block nsEvent;
+  dispatch_sync(dispatch_get_main_queue(), ^{
+    nsEvent = [NSEvent eventWithCGEvent:event];
+  });
   if (!nsEvent || [nsEvent subtype] != 8)
     return event;
 


### PR DESCRIPTION
fixes crash on pressing Caps Lock on an ARM Mac

## Description
Same as https://github.com/xbmc/xbmc/pull/23686 but for master (so the original PR can be backported). I plan to remove SDL by the end of beta 3 so the code path is still valid in the next alpha (although disabled by default).
Our "rules" dictate that for something to be backported it has to go into master first.