### PR TITLE
[Cmake] Migrate libass and libcurl to TARGET usage

### DIFF
--- a/cmake/modules/FindCurl.cmake
+++ b/cmake/modules/FindCurl.cmake
@@ -3,60 +3,57 @@
 # --------
 # Finds the Curl library
 #
-# This will define the following variables::
-#
-# CURL_FOUND - system has Curl
-# CURL_INCLUDE_DIRS - the Curl include directory
-# CURL_LIBRARIES - the Curl libraries
-# CURL_DEFINITIONS - the Curl definitions
-#
-# and the following imported targets::
+# This will define the following target:
 #
 #   Curl::Curl   - The Curl library
+#
+# Note: Curl has the beginnings of native cmake config support, but its not complete
+#       as yet apparently. Look to leverage that for UNIX platforms in the future possibly
+#
 
-if(PKG_CONFIG_FOUND)
-  pkg_check_modules(PC_CURL libcurl QUIET)
-endif()
+if(NOT TARGET CURL::libcurl)
+  if(Curl_FIND_REQUIRED)
+    set(_find_required "REQUIRED")
+  endif()
+  if(WIN32 OR WINDOWS_STORE)
+    include(FindPackageMessage)
 
-find_path(CURL_INCLUDE_DIR NAMES curl/curl.h
-                           PATHS ${PC_CURL_INCLUDEDIR})
-find_library(CURL_LIBRARY NAMES curl libcurl libcurl_imp
-                          PATHS ${PC_CURL_LIBDIR})
+    find_package(CURL CONFIG ${_find_required})
 
-set(CURL_VERSION ${PC_CURL_VERSION})
+    if(CURL_FOUND)
+      # Specifically tailored to kodi windows cmake config - Prebuilt as RelWithDebInfo always currently
+      get_target_property(CURL_LIB CURL::libcurl IMPORTED_LOCATION_RELWITHDEBINFO)
+      get_target_property(CURL_INCLUDE_DIR CURL::libcurl INTERFACE_INCLUDE_DIRECTORIES)
+      find_package_message(CURL "Found CURL: ${CURL_LIB}" "[${CURL_LIB}][${CURL_INCLUDE_DIR}]")
+    endif()
+  else()
+    find_package(PkgConfig)
+    if(PKG_CONFIG_FOUND)
+      pkg_check_modules(CURL libcurl ${_find_required} IMPORTED_TARGET GLOBAL)
+    else()
+      find_path(CURL_INCLUDE_DIR NAMES curl/curl.h
+                                 PATHS ${PC_CURL_INCLUDEDIR})
+      find_library(CURL_LIBRARY NAMES curl libcurl libcurl_imp
+                                PATHS ${PC_CURL_LIBDIR})
 
-set(CURL_LIB_TYPE SHARED)
-set(CURL_LDFLAGS ${PC_CURL_LDFLAGS})
-
-# check if curl is statically linked
-if(${CURL_LIBRARY} MATCHES ".+\.a$" AND PC_CURL_STATIC_LDFLAGS)
-  set(CURL_LIB_TYPE STATIC)
-  set(CURL_LDFLAGS ${PC_CURL_STATIC_LDFLAGS})
-
-  pkg_check_modules(PC_NGHTTP2 libnghttp2 QUIET)
-  find_library(NGHTTP2_LIBRARY NAMES libnghttp2 nghttp2
-                               PATHS ${PC_NGHTTP2_LIBDIR})
-endif()
-
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Curl
-                                  REQUIRED_VARS CURL_LIBRARY CURL_INCLUDE_DIR
-                                  VERSION_VAR CURL_VERSION)
-
-if(CURL_FOUND)
-  set(CURL_INCLUDE_DIRS ${CURL_INCLUDE_DIR})
-  set(CURL_LIBRARIES ${CURL_LIBRARY} ${NGHTTP2_LIBRARY})
-
-  if(NOT TARGET Curl::Curl)
-    add_library(Curl::Curl ${CURL_LIB_TYPE} IMPORTED)
-    set_target_properties(Curl::Curl PROPERTIES
-                                     IMPORTED_LOCATION "${CURL_LIBRARY}"
-                                     INTERFACE_INCLUDE_DIRECTORIES "${CURL_INCLUDE_DIR}")
-    if(HAS_CURL_STATIC)
-        set_target_properties(Curl::Curl PROPERTIES
-                                         INTERFACE_COMPILE_DEFINITIONS HAS_CURL_STATIC=1)
+      include(FindPackageHandleStandardArgs)
+      find_package_handle_standard_args(Curl
+                                        REQUIRED_VARS CURL_LIBRARY CURL_INCLUDE_DIR
+                                        VERSION_VAR CURL_VERSION)
     endif()
   endif()
-endif()
 
-mark_as_advanced(CURL_INCLUDE_DIR CURL_LIBRARY CURL_LDFLAGS)
+  if(CURL_FOUND)
+    if(TARGET PkgConfig::CURL)
+      add_library(CURL::libcurl ALIAS PkgConfig::CURL)
+    elseif(NOT TARGET CURL::libcurl)
+      add_library(CURL::libcurl UNKNOWN IMPORTED)
+      set_target_properties(CURL::libcurl PROPERTIES
+                                          IMPORTED_LOCATION "${CURL_LIBRARY}"
+                                          INTERFACE_INCLUDE_DIRECTORIES "${CURL_INCLUDE_DIR}")
+    endif()
+    set_property(GLOBAL APPEND PROPERTY INTERNAL_DEPS_PROP CURL::libcurl)
+  endif()
+
+  mark_as_advanced(CURL_INCLUDE_DIR CURL_LIBRARY CURL_LDFLAGS)
+endif()


### PR DESCRIPTION
## Description
Migrate libass and libcurl to complete TARGET usage

## Motivation and context
Migrate more libs to full TARGET usage.

@wsnipex im PRing this to potentially get some feedback when you have time on a couple areas hopefully before i continue along with more changes on other libs.

Essentially there are 3 potential search paths, but im wondering if 1 of them (the fallback without pkgconfig) is required.
Path 1: All of our windows libs have cmake config files, so for non native cmake dependencies, we just use find_package(CONFIG).

Path 2: For the UNIX platforms, pkg_check_modules creates an imported target from the pkg-config check. This includes lots more info that we dont currently deal with (eg transitive links/definitions). We partially manually set some of this in some libs currently, but its definitely not consistent or as complete as what the cmake target gets populated with.

My main question is should we expect pkg-config to always be available? If we accept that assumption, we can drop 

Path 3: the find_library/find_path manual usage. The reason this is the worst way is that its impossible to pass on other information like link options/defines, as they are just file searches.

pkg_check_modules creates targets of the form PkgConfig::<modulename>, so we just alias this to a more generic target, which may be what upstream uses, or what our windows cmake exports use, or just a generic <module>::<module> target name.

Let me know what you think about the path 3 usage. If you think we can make the pkgconfig assumption a requirement, i'll drop the path 3 stuff and i'll continue on with other libs if you are happy with this approach.

Some context around the end goal is to reduce some of our macro's that are based around the old style variable passing. Targets can just hold more information, and cmake handles all the deduplication and passing the info around between targets (when they are setup correct). Essentially we'll do all the find_packages for our required/optional, and then we just do a target_link_libraries on our list of targets.

One potential caveat that Cmake has however is the inability to handle with a defined outcome the event where both a static and a shared target information is on a machine. For our purposes, this only effects linux/freebsd, but im hoping the tendency to prefer shared libs, and not have static dev packages means this wont be too much of an issue. For background there is some info on https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7070#note_1207589 which has been reverted due to regressions, but they discuss the issue a fair bit

## How has this been tested?
Configure macos aarch64/win x64

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
