### PR TITLE
[application] Fix a race condition on CApplicationPlayerCallback::m_itemCurrentFile

### DIFF
--- a/xbmc/GUIUserMessages.h
+++ b/xbmc/GUIUserMessages.h
@@ -143,3 +143,8 @@ constexpr const int GUI_MSG_PLAYBACK_AVSTARTED      = GUI_MSG_USER + 44;
 // Sent to notify system sleep/wake
 constexpr const int GUI_MSG_SYSTEM_SLEEP  			= GUI_MSG_USER + 45;
 constexpr const int GUI_MSG_SYSTEM_WAKE 			= GUI_MSG_USER + 46;
+
+constexpr const int GUI_MSG_PLAYBACK_PAUSED = GUI_MSG_USER + 47;
+constexpr const int GUI_MSG_PLAYBACK_RESUMED = GUI_MSG_USER + 48;
+constexpr const int GUI_MSG_PLAYBACK_SEEKED = GUI_MSG_USER + 49;
+constexpr const int GUI_MSG_PLAYBACK_SPEED_CHANGED = GUI_MSG_USER + 50;

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -45,6 +45,7 @@
 #include "application/ApplicationStackHelper.h"
 #include "application/ApplicationVolumeHandling.h"
 #include "cores/AudioEngine/Engines/ActiveAE/ActiveAE.h"
+#include "cores/DataCacheCore.h"
 #include "cores/FFmpeg.h"
 #include "cores/IPlayer.h"
 #include "cores/playercorefactory/PlayerCoreFactory.h"
@@ -211,7 +212,9 @@ CApplication::CApplication(void)
     m_Autorun(new CAutorun()),
 #endif
     m_pInertialScrollingHandler(new CInertialScrollingHandler()),
-    m_WaitingExternalCalls(0)
+    m_WaitingExternalCalls(0),
+    m_itemCurrentFile(std::make_shared<CFileItem>()),
+    m_playerEvent(true, true)
 {
   TiXmlBase::SetCondenseWhiteSpace(false);
 
@@ -2719,6 +2722,12 @@ bool CApplication::OnMessage(CGUIMessage& message)
       // @TODO move this away to platform code
       CDarwinUtils::SetScheduling(GetComponent<CApplicationPlayer>()->IsPlayingVideo());
 #endif
+      m_itemCurrentFile =
+          std::make_shared<CFileItem>(*std::static_pointer_cast<CFileItem>(message.GetItem()));
+      m_playerEvent.Reset();
+
+      CServiceBroker::GetPVRManager().OnPlaybackStarted(*m_itemCurrentFile);
+
       PLAYLIST::CPlayList playList = CServiceBroker::GetPlaylistPlayer().GetPlaylist(
           CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist());
 
@@ -2860,6 +2869,14 @@ bool CApplication::OnMessage(CGUIMessage& message)
     }
 
   case GUI_MSG_PLAYBACK_STOPPED:
+  {
+    CServiceBroker::GetPVRManager().OnPlaybackStopped(*m_itemCurrentFile);
+
+    CVariant data(CVariant::VariantTypeObject);
+    data["end"] = false;
+    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnStop",
+                                                       m_itemCurrentFile, data);
+
     m_playerEvent.Set();
     ResetCurrentItem();
     PlaybackCleanup();
@@ -2867,9 +2884,17 @@ bool CApplication::OnMessage(CGUIMessage& message)
     CServiceBroker::GetXBPython().OnPlayBackStopped();
 #endif
      return true;
+  }
 
   case GUI_MSG_PLAYBACK_ENDED:
   {
+    CServiceBroker::GetPVRManager().OnPlaybackEnded(*m_itemCurrentFile);
+
+    CVariant data(CVariant::VariantTypeObject);
+    data["end"] = true;
+    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnStop",
+                                                       m_itemCurrentFile, data);
+
     m_playerEvent.Set();
     const auto stackHelper = GetComponent<CApplicationStackHelper>();
     if (stackHelper->IsPlayingRegularStack() && stackHelper->HasNextStackPartFileItem())
@@ -2897,6 +2922,12 @@ bool CApplication::OnMessage(CGUIMessage& message)
     return true;
 
   case GUI_MSG_PLAYBACK_AVSTARTED:
+  {
+    CVariant param;
+    param["player"]["speed"] = 1;
+    param["player"]["playerid"] = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
+    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnAVStart",
+                                                       m_itemCurrentFile, param);
     m_playerEvent.Set();
 #ifdef HAS_PYTHON
     // informs python script currently running playback has started
@@ -2904,14 +2935,72 @@ bool CApplication::OnMessage(CGUIMessage& message)
     CServiceBroker::GetXBPython().OnAVStarted(*m_itemCurrentFile);
 #endif
     return true;
+  }
 
   case GUI_MSG_PLAYBACK_AVCHANGE:
+  {
 #ifdef HAS_PYTHON
     // informs python script currently running playback has started
     // (does nothing if python is not loaded)
     CServiceBroker::GetXBPython().OnAVChange();
 #endif
-      return true;
+    CVariant param;
+    param["player"]["speed"] = 1;
+    param["player"]["playerid"] = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
+    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnAVChange",
+                                                       m_itemCurrentFile, param);
+    return true;
+  }
+
+  case GUI_MSG_PLAYBACK_PAUSED:
+  {
+    CVariant param;
+    param["player"]["speed"] = 0;
+    param["player"]["playerid"] = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
+    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnPause",
+                                                       m_itemCurrentFile, param);
+    return true;
+  }
+
+  case GUI_MSG_PLAYBACK_RESUMED:
+  {
+    CVariant param;
+    param["player"]["speed"] = 1;
+    param["player"]["playerid"] = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
+    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnResume",
+                                                       m_itemCurrentFile, param);
+    return true;
+  }
+
+  case GUI_MSG_PLAYBACK_SEEKED:
+  {
+    CVariant param;
+    const int64_t iTime = message.GetParam1AsI64();
+    const int64_t seekOffset = message.GetParam2AsI64();
+    JSONRPC::CJSONUtils::MillisecondsToTimeObject(iTime, param["player"]["time"]);
+    JSONRPC::CJSONUtils::MillisecondsToTimeObject(seekOffset, param["player"]["seekoffset"]);
+    param["player"]["playerid"] = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
+    const auto& components = CServiceBroker::GetAppComponents();
+    const auto appPlayer = components.GetComponent<CApplicationPlayer>();
+    param["player"]["speed"] = static_cast<int>(appPlayer->GetPlaySpeed());
+    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnSeek",
+                                                       m_itemCurrentFile, param);
+
+    CDataCacheCore::GetInstance().SeekFinished(static_cast<int>(seekOffset));
+
+    return true;
+  }
+
+  case GUI_MSG_PLAYBACK_SPEED_CHANGED:
+  {
+    CVariant param;
+    param["player"]["speed"] = message.GetParam1();
+    param["player"]["playerid"] = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
+    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnSpeedChanged",
+                                                       m_itemCurrentFile, param);
+
+    return true;
+  }
 
   case GUI_MSG_PLAYBACK_ERROR:
     HELPERS::ShowOKDialogText(CVariant{16026}, CVariant{16027});

--- a/xbmc/application/Application.h
+++ b/xbmc/application/Application.h
@@ -251,6 +251,8 @@ private:
   unsigned int m_ProcessedExternalCalls = 0;      /*!< counts calls which are processed during one "door open" cycle in FrameMove */
   unsigned int m_ProcessedExternalDecay = 0;      /*!< counts to close door after a few frames of no python activity */
   int m_ExitCode{EXITCODE_QUIT};
+  std::shared_ptr<CFileItem> m_itemCurrentFile; //!< Currently playing file
+  CEvent m_playerEvent;
 };
 
 XBMC_GLOBAL_REF(CApplication,g_application);

--- a/xbmc/application/ApplicationPlayerCallback.h
+++ b/xbmc/application/ApplicationPlayerCallback.h
@@ -36,8 +36,4 @@ public:
   void OnAVStarted(const CFileItem& file) override;
   void RequestVideoSettings(const CFileItem& fileItem) override;
   void StoreVideoSettings(const CFileItem& fileItem, const CVideoSettings& vs) override;
-
-protected:
-  std::shared_ptr<CFileItem> m_itemCurrentFile; //!< Currently playing file
-  CEvent m_playerEvent;
 };

--- a/xbmc/guilib/GUIMessage.cpp
+++ b/xbmc/guilib/GUIMessage.cpp
@@ -12,7 +12,7 @@
 
 std::string CGUIMessage::empty_string;
 
-CGUIMessage::CGUIMessage(int msg, int senderID, int controlID, int param1, int param2)
+CGUIMessage::CGUIMessage(int msg, int senderID, int controlID, int64_t param1, int64_t param2)
 {
   m_message = msg;
   m_senderID = senderID;
@@ -22,7 +22,8 @@ CGUIMessage::CGUIMessage(int msg, int senderID, int controlID, int param1, int p
   m_pointer = NULL;
 }
 
-CGUIMessage::CGUIMessage(int msg, int senderID, int controlID, int param1, int param2, CFileItemList *item)
+CGUIMessage::CGUIMessage(
+    int msg, int senderID, int controlID, int64_t param1, int64_t param2, CFileItemList* item)
 {
   m_message = msg;
   m_senderID = senderID;
@@ -32,8 +33,12 @@ CGUIMessage::CGUIMessage(int msg, int senderID, int controlID, int param1, int p
   m_pointer = item;
 }
 
-CGUIMessage::CGUIMessage(
-    int msg, int senderID, int controlID, int param1, int param2, const CGUIListItemPtr& item)
+CGUIMessage::CGUIMessage(int msg,
+                         int senderID,
+                         int controlID,
+                         int64_t param1,
+                         int64_t param2,
+                         const CGUIListItemPtr& item)
   : m_item(item)
 {
   m_message = msg;
@@ -71,10 +76,20 @@ CGUIListItemPtr CGUIMessage::GetItem() const
 
 int CGUIMessage::GetParam1() const
 {
+  return static_cast<int>(m_param1);
+}
+
+int64_t CGUIMessage::GetParam1AsI64() const
+{
   return m_param1;
 }
 
 int CGUIMessage::GetParam2() const
+{
+  return static_cast<int>(m_param2);
+}
+
+int64_t CGUIMessage::GetParam2AsI64() const
 {
   return m_param2;
 }
@@ -86,12 +101,12 @@ int CGUIMessage::GetSenderId() const
 
 CGUIMessage& CGUIMessage::operator = (const CGUIMessage& msg) = default;
 
-void CGUIMessage::SetParam1(int param1)
+void CGUIMessage::SetParam1(int64_t param1)
 {
   m_param1 = param1;
 }
 
-void CGUIMessage::SetParam2(int param2)
+void CGUIMessage::SetParam2(int64_t param2)
 {
   m_param2 = param2;
 }

--- a/xbmc/guilib/GUIMessage.h
+++ b/xbmc/guilib/GUIMessage.h
@@ -365,9 +365,15 @@ class CFileItemList;
 class CGUIMessage final
 {
 public:
-  CGUIMessage(int dwMsg, int senderID, int controlID, int param1 = 0, int param2 = 0);
-  CGUIMessage(int msg, int senderID, int controlID, int param1, int param2, CFileItemList* item);
-  CGUIMessage(int msg, int senderID, int controlID, int param1, int param2, const CGUIListItemPtr &item);
+  CGUIMessage(int dwMsg, int senderID, int controlID, int64_t param1 = 0, int64_t param2 = 0);
+  CGUIMessage(
+      int msg, int senderID, int controlID, int64_t param1, int64_t param2, CFileItemList* item);
+  CGUIMessage(int msg,
+              int senderID,
+              int controlID,
+              int64_t param1,
+              int64_t param2,
+              const CGUIListItemPtr& item);
   CGUIMessage(const CGUIMessage& msg);
   ~CGUIMessage(void);
   CGUIMessage& operator = (const CGUIMessage& msg);
@@ -377,10 +383,12 @@ public:
   void* GetPointer() const;
   CGUIListItemPtr GetItem() const;
   int GetParam1() const;
+  int64_t GetParam1AsI64() const;
   int GetParam2() const;
+  int64_t GetParam2AsI64() const;
   int GetSenderId() const;
-  void SetParam1(int param1);
-  void SetParam2(int param2);
+  void SetParam1(int64_t param1);
+  void SetParam2(int64_t param2);
   void SetPointer(void* pointer);
   void SetLabel(const std::string& strLabel);
   void SetLabel(int iString);               // for convenience - looks up in strings.po
@@ -398,8 +406,8 @@ private:
   int m_controlID;
   int m_message;
   void* m_pointer;
-  int m_param1;
-  int m_param2;
+  int64_t m_param1;
+  int64_t m_param2;
   CGUIListItemPtr m_item;
 
   static std::string empty_string;


### PR DESCRIPTION
## Description
There's a possibility of a race codition on CApplicationPlayerCallback::m_itemCurrentFile leading to heap-use-after-free reported by the address sanitizer [1].
    
The crash happens when GUI_MSG_UPDATE_ITEM is being handled. CApplicationPlayerCallback::m_itemCurrentFile can be accessed concurrently by the main thread in CApplication::OnMessage and CApplicationPlayerCallback::OnPlayBackStarted in the video thread.

Sometimes CApplicationPlayerCallback::OnPlayBackStarted is called first, resets the m_itemCurrentFile (and deallocates the object). Then CApplication::OnMessage tries to read it - this is where heap-use-after-free occurs.
    
In order to mitigate the issue introduce additional messages GUI_MSG_PLAYBACK_PAUSED, GUI_MSG_PLAYBACK_RESUMED, GUI_MSG_PLAYBACK_PAUSED and GUI_MSG_PLAYBACK_SPEED_CHANGED. Those messages are sent from the GUI thread to the main thread. That way the access to CApplicationPlayerCallback::m_itemCurrentFile is serialized (it will be accessed only from the main thread).

## Motivation and context
It fixes https://github.com/xbmc/xbmc/issues/23247.

## How has this been tested?
Mainly it has been tested on Arch Linux ARM on 20.1. Since 4 months Kodi haven't crashed. Previously it was crashing couple of times a month.

## What is the effect on users?
Kodi shouldn't crash while switching the items.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
