### PR TITLE
[uPnP] Fix playback of files accessed with curl (ftp, http, ...)

### DIFF
--- a/xbmc/filesystem/NptXbmcFile.cpp
+++ b/xbmc/filesystem/NptXbmcFile.cpp
@@ -13,7 +13,9 @@
 +---------------------------------------------------------------------*/
 #include "File.h"
 #include "FileFactory.h"
+#include "PasswordManager.h"
 #include "URL.h"
+#include "utils/URIUtils.h"
 
 #include <limits>
 
@@ -294,16 +296,17 @@ NPT_XbmcFile::Open(NPT_File::OpenMode mode)
         }
 
         bool result;
-        CURL* url = new CURL(name);
+        CURL url(URIUtils::SubstitutePath(name));
+
+        if (CPasswordManager::GetInstance().IsURLSupported(url) && url.GetUserName().empty())
+          CPasswordManager::GetInstance().AuthenticateURL(url);
 
         // compute mode
-        if (mode & NPT_FILE_OPEN_MODE_WRITE) {
-            result = file->OpenForWrite(*url, (mode & NPT_FILE_OPEN_MODE_TRUNCATE)?true:false);
-        } else {
-            result = file->Open(*url);
-        }
+        if (mode & NPT_FILE_OPEN_MODE_WRITE)
+          result = file->OpenForWrite(url, (mode & NPT_FILE_OPEN_MODE_TRUNCATE) ? true : false);
+        else
+          result = file->Open(url);
 
-        delete url;
         if (!result) return NPT_ERROR_NO_SUCH_FILE;
     }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Problem of Kodi's uPnP server: for items from authenticated sources accessed via curl (as of now, ftp ftps rss rsss http https), a DLNA client is able to retrieve the list of files and directories but cannot play anything.

`NPT_XbmcFile::Open()` does not provide authentication information in the URL passed to instance of FileFactory loader (`CCurlFile::Open()` for curl), resulting in denied access and playback failure..

There are two possible places for the change: in `NPT_XbmcFile::Open()` or in `CCurlFile::Open()` and `CCurlFile::OpenForWrite()` and unfortunately the existing code is not consistent.
* other sources like smb and nfs retrieve the information in their own code
* VideoPlayer path populates the authentication information of the url to be played
* `NPT_File::GetInfo()` and `CFile::Stat()` (the already working uPnP listing of files) adds the authentication information to the URL before invoking the FileFactory loader.

=> I decided to modify `NPT_XbmcFile::Open()` and to add the few lines of the `NPT_File::GetInfo()` path that are missing.

Used the opportunity to turn the dynamically allocated url variable into stack allocated. I didn't see a reason for the dynamic allocation.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Reported in forums https://forum.kodi.tv/showthread.php?tid=374299

A DLNA client is unable to play from Kodi uPnP the files served from an authenticated ftp source. They can be listed but not played.

Affects all DLNA clients, all Kodi platforms and uPnP sharing of all authenticated sources accessed through libcurl from what I can tell.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows Kodi, but affects all platforms.
Added password protected ftp source to the library, turned on uPnP sharing.
Browsed and played successfully with LG TV uPnP client.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Working playback of files shared with uPnP and hosted on curl-accessed sources (ftp ftps rss rsss http https)

## Screenshots (if appropriate):
Before, "Login denied":
```
2023-09-01 20:59:13.008 T:18012   debug <CUPnPServer[Kodi]>: Received request to serve 'bafd3a48de99341504d1a7c91f3c1e2f/bbb_sunflower_1080p_60fps_normal.mp4' = 'ftp://XXX.XXX.XXX.XXX:21/Big Buck Bunny/bbb_sunflower_1080p_60fps_normal.mp4'
2023-09-01 20:59:13.011 T:18012   debug <general>: CurlFile::XFILE::CCurlFile::Open - <ftp://XXX.XXX.XXX.XXX:21/Big%20Buck%20Bunny/bbb_sunflower_1080p_60fps_normal.mp4>
2023-09-01 20:59:13.042 T:18012   error <general>: CCurlFile::CReadState::XFILE::CCurlFile::CReadState::FillBuffer - (0x1a44013e400) Failed: Login denied(67)
```

After, successful opening:
```
2023-09-01 22:17:08.744 T:23104   debug <CUPnPServer[Kodi]>: Received request to serve 'e97d09032dfea4b9d833e35b2921ac8d/bbb_sunflower_1080p_60fps_normal.mp4' = 'ftp://XXX.XXX.XXX.XXX:21/Big Buck Bunny/bbb_sunflower_1080p_60fps_normal.mp4'
2023-09-01 22:17:08.748 T:23104   debug <general>: CurlFile::XFILE::CCurlFile::Open - <ftp://USERNAME:PASSWORD@XXX.XXX.XXX.XXX:21/Big%20Buck%20Bunny/bbb_sunflower_1080p_60fps_normal.mp4>
2023-09-01 22:17:09.160 T:19120   debug <CUPnPServer[Kodi]>: Received request to serve 'e97d09032dfea4b9d833e35b2921ac8d/bbb_sunflower_1080p_60fps_normal.mp4' = 'ftp://XXX.XXX.XXX.XXX:21/Big Buck Bunny/bbb_sunflower_1080p_60fps_normal.mp4'
2023-09-01 22:17:09.176 T:19120   debug <general>: CurlFile::XFILE::CCurlFile::Open - <ftp://USERNAME:PASSWORD@XXX.XXX.XXX.XXX:21/Big%20Buck%20Bunny/bbb_sunflower_1080p_60fps_normal.mp4>
2023-09-01 22:17:09.399 T:19120   debug <general>: CurlFile::CReadState::XFILE::CCurlFile::CReadState::Connect - (0x21fd4e554f0) Resume from position 3060651
...

```
## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
