### PR TITLE
WIP: Fix hang when logout to switch profile

### DIFF
--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -621,6 +621,8 @@ void CProfileManager::LoadMasterProfileForLogin()
     // determines that the (master) profile has only been loaded for login
     m_profileLoadedForLogin = true;
 
+    lock.unlock();
+
     LoadProfile(0);
 
     // remember that the (master) profile has only been loaded for login


### PR DESCRIPTION
## Description
As described in #23592, when there are multiple user profile, if we logout the current profile and it has content in the library, kodi hangs instead of displaying the profile selection window.

This issue occurs at least on Android and Linux.

The issue is caused by a locked mutex. I propose a possible fix: I think it's not necessary for the function to be inside the lock section, the function manages the required locks itself. In the tests I've done it works fine.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
