### PR TITLE
[cmake][buildtools] use flatbuffers::flatc target for executable

### DIFF
--- a/cmake/modules/FindFlatBuffers.cmake
+++ b/cmake/modules/FindFlatBuffers.cmake
@@ -1,12 +1,10 @@
 # FindFlatBuffers
 # --------
-# Find the FlatBuffers schema compiler and headers
+# Find the FlatBuffers schema headers
 #
-# This will define the following variables:
+# This will define the following target:
 #
-# FLATBUFFERS_FOUND - system has FlatBuffers compiler and headers
-# FLATBUFFERS_INCLUDE_DIRS - the FlatFuffers include directory
-# FLATBUFFERS_MESSAGES_INCLUDE_DIR - the directory for generated headers
+#   flatbuffers::flatbuffers - The flatbuffers headers
 
 find_package(FlatC REQUIRED)
 
@@ -15,7 +13,9 @@ if(NOT TARGET flatbuffers::flatbuffers)
     include(cmake/scripts/common/ModuleHelpers.cmake)
 
     set(MODULE_LC flatbuffers)
-
+    # Duplicate URL may exist from FindFlatC.cmake
+    # unset otherwise it thinks we are providing a local file location and incorrect concatenation happens
+    unset(FLATBUFFERS_URL)
     SETUP_BUILD_VARS()
 
     # Override build type detection and always build as release
@@ -42,12 +42,10 @@ if(NOT TARGET flatbuffers::flatbuffers)
                                     REQUIRED_VARS FLATBUFFERS_INCLUDE_DIR
                                     VERSION_VAR FLATBUFFERS_VER)
 
-  set(FLATBUFFERS_MESSAGES_INCLUDE_DIR ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/cores/RetroPlayer/messages CACHE INTERNAL "Generated FlatBuffer headers")
-
   add_library(flatbuffers::flatbuffers INTERFACE IMPORTED)
   set_target_properties(flatbuffers::flatbuffers PROPERTIES
                              FOLDER "External Projects"
-                             INTERFACE_INCLUDE_DIRECTORIES "${FLATBUFFERS_INCLUDE_DIR};${FLATBUFFERS_MESSAGES_INCLUDE_DIR}")
+                             INTERFACE_INCLUDE_DIRECTORIES "${FLATBUFFERS_INCLUDE_DIR}")
 
   add_dependencies(flatbuffers::flatbuffers flatbuffers::flatc)
 
@@ -55,7 +53,4 @@ if(NOT TARGET flatbuffers::flatbuffers)
     add_dependencies(flatbuffers::flatbuffers flatbuffers)
   endif()
   set_property(GLOBAL APPEND PROPERTY INTERNAL_DEPS_PROP flatbuffers::flatbuffers)
-
 endif()
-
-mark_as_advanced(FLATBUFFERS_INCLUDE_DIR)

--- a/cmake/modules/buildtools/FindFlatC.cmake
+++ b/cmake/modules/buildtools/FindFlatC.cmake
@@ -2,13 +2,7 @@
 # --------
 # Find the FlatBuffers schema compiler
 #
-# This will define the following variables:
-#
-# FLATBUFFERS_FLATC_EXECUTABLE_FOUND - system has FlatBuffers compiler
-# FLATBUFFERS_FLATC_EXECUTABLE - the flatc compiler executable
-# FLATBUFFERS_FLATC_VERSION - the flatc compiler version
-#
-# and the following imported targets:
+# This will define the following target:
 #
 #   flatbuffers::flatc - The FlatC compiler
 
@@ -17,7 +11,8 @@ if(NOT TARGET flatbuffers::flatc)
 
   # Check for existing FLATC.
   find_program(FLATBUFFERS_FLATC_EXECUTABLE NAMES flatc
-                                            HINTS ${NATIVEPREFIX}/bin)
+                                            HINTS ${NATIVEPREFIX}/bin
+                                            NO_CACHE)
 
   if(FLATBUFFERS_FLATC_EXECUTABLE)
     execute_process(COMMAND "${FLATBUFFERS_FLATC_EXECUTABLE}" --version
@@ -34,7 +29,8 @@ if(NOT TARGET flatbuffers::flatc)
   unset(FLATBUFFERS_URL)
   SETUP_BUILD_VARS()
 
-  if(NOT FLATBUFFERS_FLATC_EXECUTABLE OR (ENABLE_INTERNAL_FLATBUFFERS AND NOT "${FLATBUFFERS_FLATC_VERSION}" VERSION_EQUAL "${FLATBUFFERS_VER}"))
+  if(NOT FLATBUFFERS_FLATC_EXECUTABLE OR
+      (ENABLE_INTERNAL_FLATBUFFERS AND NOT "${FLATBUFFERS_FLATC_VERSION}" VERSION_EQUAL "${FLATBUFFERS_VER}"))
 
     # Override build type detection and always build as release
     set(FLATBUFFERS_BUILD_TYPE Release)
@@ -67,7 +63,7 @@ if(NOT TARGET flatbuffers::flatc)
       set(WIN_DISABLE_PROJECT_FLAGS 1)
     endif()
 
-    set(FLATBUFFERS_FLATC_EXECUTABLE ${INSTALL_DIR}/flatc CACHE INTERNAL "FlatBuffer compiler")
+    set(FLATBUFFERS_FLATC_EXECUTABLE ${INSTALL_DIR}/flatc)
 
     set(BUILD_NAME flatc)
     set(BUILD_BYPRODUCTS ${FLATBUFFERS_FLATC_EXECUTABLE})
@@ -76,25 +72,15 @@ if(NOT TARGET flatbuffers::flatc)
     BUILD_DEP_TARGET()
   endif()
 
-  include(FindPackageHandleStandardArgs)
-  find_package_handle_standard_args(FlatC
-                                    REQUIRED_VARS FLATBUFFERS_FLATC_EXECUTABLE
-                                    VERSION_VAR FLATBUFFERS_FLATC_VERSION)
+  include(FindPackageMessage)
+  find_package_message(FlatC "Found FlatC Compiler: ${FLATBUFFERS_FLATC_EXECUTABLE} (found version \"${FLATBUFFERS_FLATC_VERSION}\")" "[${FLATBUFFERS_FLATC_EXECUTABLE}][${FLATBUFFERS_FLATC_VERSION}]")
 
-  if(FLATC_FOUND)
+  add_executable(flatbuffers::flatc IMPORTED)
+  set_target_properties(flatbuffers::flatc PROPERTIES
+                                           IMPORTED_LOCATION "${FLATBUFFERS_FLATC_EXECUTABLE}"
+                                           FOLDER "External Projects")
 
-    add_library(flatbuffers::flatc UNKNOWN IMPORTED)
-    set_target_properties(flatbuffers::flatc PROPERTIES
-                                             FOLDER "External Projects")
-
-    if(TARGET flatc)
-      add_dependencies(flatbuffers::flatc flatc)
-    endif()
-  else()
-    if(FLATC_FIND_REQUIRED)
-      message(FATAL_ERROR "Flatc compiler not found.")
-    endif()
+  if(TARGET flatc)
+    add_dependencies(flatbuffers::flatc flatc)
   endif()
-
-  mark_as_advanced(FLATBUFFERS_FLATC_EXECUTABLE)
 endif()

--- a/xbmc/cores/RetroPlayer/messages/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/messages/CMakeLists.txt
@@ -8,8 +8,8 @@ foreach(_file ${MESSAGES})
   list(APPEND FLATC_OUTPUTS ${FLATC_OUTPUT})
 
   add_custom_command(OUTPUT ${FLATC_OUTPUT}
-                     COMMAND ${FLATBUFFERS_FLATC_EXECUTABLE}
-                     ARGS -c -o "${FLATBUFFERS_MESSAGES_INCLUDE_DIR}/" ${_file}
+                     COMMAND flatbuffers::flatc
+                     ARGS -c -o "${CMAKE_CURRENT_BINARY_DIR}/" ${_file}
                      DEPENDS ${_file}
                      COMMENT "Building C++ header for ${_file}"
                      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
@@ -21,5 +21,7 @@ set_target_properties(retroplayer_messages PROPERTIES FOLDER "Generated Messages
                                                       SOURCES "${FLATC_OUTPUTS}")
 
 if(TARGET flatbuffers::flatbuffers)
+  set_property(TARGET flatbuffers::flatbuffers APPEND PROPERTY
+                                               INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_BINARY_DIR}")
   add_dependencies(retroplayer_messages flatbuffers::flatbuffers)
 endif()


### PR DESCRIPTION
## Description
Use target instead of cached variables for flatc

## Motivation and context
some modernisation.
if we use add_executable(), we can then use the TARGET instead of a cached variable. 
We can then also remove FLATBUFFERS_MESSAGES_INCLUDE_DIR as a cached variable being set in the FindFlatbuffers file. Really its tied to another location (xbmc/cores/Retroplayer/messages). When we deal with the intent of this variable in its actual location, the variable no longer is required as CMAKE_CURRENT_BINARY_DIR is the same content. We then just append that to INTERFACE_INCLUDE_DIRECTORIES for flatbuffers::flatbuffers TARGET and we no longer need explicit location handling.

## How has this been tested?
configure/build macos aarch64

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
