### PR TITLE
[video] Fix 'Local art' missing in art selection dialog.

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -3382,20 +3382,22 @@ std::string CFileItem::GetLocalArtBaseFilename() const
 
 std::string CFileItem::GetLocalArtBaseFilename(bool& useFolder) const
 {
-  std::string strFile = m_strPath;
+  std::string strFile;
   if (IsStack())
   {
     std::string strPath;
     URIUtils::GetParentPath(m_strPath,strPath);
-    strFile = URIUtils::AddFileToFolder(strPath, URIUtils::GetFileName(CStackDirectory::GetStackedTitlePath(strFile)));
+    strFile = URIUtils::AddFileToFolder(
+        strPath, URIUtils::GetFileName(CStackDirectory::GetStackedTitlePath(m_strPath)));
   }
 
-  if (URIUtils::IsInRAR(strFile) || URIUtils::IsInZIP(strFile))
+  std::string file = strFile.empty() ? m_strPath : strFile;
+  if (URIUtils::IsInRAR(file) || URIUtils::IsInZIP(file))
   {
-    std::string strPath = URIUtils::GetDirectory(strFile);
+    std::string strPath = URIUtils::GetDirectory(file);
     std::string strParent;
     URIUtils::GetParentPath(strPath,strParent);
-    strFile = URIUtils::AddFileToFolder(strParent, URIUtils::GetFileName(strFile));
+    strFile = URIUtils::AddFileToFolder(strParent, URIUtils::GetFileName(file));
   }
 
   if (IsMultiPath())
@@ -3407,7 +3409,13 @@ std::string CFileItem::GetLocalArtBaseFilename(bool& useFolder) const
     strFile = GetLocalMetadataPath();
   }
   else if (useFolder && !(m_bIsFolder && !IsFileFolder()))
-    strFile = URIUtils::GetDirectory(strFile);
+  {
+    file = strFile.empty() ? m_strPath : strFile;
+    strFile = URIUtils::GetDirectory(file);
+  }
+
+  if (strFile.empty())
+    strFile = GetDynPath();
 
   return strFile;
 }

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1996,6 +1996,8 @@ bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const std::shared_ptr<CFileItem
     }
   }
 
+  std::string localThumb;
+
   bool local = false;
   std::vector<std::string> thumbs;
   if (type != MediaTypeArtist)
@@ -2056,8 +2058,7 @@ bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const std::shared_ptr<CFileItem
       else
         noneitem->SetArt("icon", "DefaultActor.png");
     }
-
-    if (type == MediaTypeVideoCollection)
+    else if (type == MediaTypeVideoCollection)
     {
       std::string localFile = FindLocalMovieSetArtworkFile(item, artType);
       if (!localFile.empty())
@@ -2070,6 +2071,20 @@ bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const std::shared_ptr<CFileItem
       }
       else
         noneitem->SetArt("icon", "DefaultVideo.png");
+    }
+    else
+    {
+      localThumb = CVideoThumbLoader::GetLocalArt(*item, artType);
+      if (!localThumb.empty())
+      {
+        const auto localitem = std::make_shared<CFileItem>("thumb://Local", false);
+        localitem->SetArt("thumb", localThumb);
+        localitem->SetArt("icon", "DefaultPicture.png");
+        localitem->SetLabel(g_localizeStrings.Get(13514));
+        items.Add(localitem);
+      }
+      else
+        noneitem->SetArt("icon", "DefaultPicture.png");
     }
   }
   else
@@ -2125,6 +2140,9 @@ bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const std::shared_ptr<CFileItem
 
   if (result == "thumb://Current")
     result = currentThumb;   // user chose the one they have
+
+  if (result == "thumb://Local")
+    result = localThumb;
 
   if (result == "thumb://Embedded")
     result = embeddedArt;


### PR DESCRIPTION
Fixes #23715 

This fixes a regression introduced with #23674 where we started to hand over `CFileItem` with a videodb path (and the real file as dynpath) instances to `CGUIDialogVideoInfo`, which broke detecting local art and made the respective item vanish from the art file selection dialog.

Even worse, refactoring done in #23675  accidentally completely removed the code for local art support, because it was forgotten to take over the respective code to the new unified implementation in `CGUIDialogVideoInfo::ManageVideoItemArtwork`.

This PR fixes both issues.

BTW, will we ever find the last dynpath bug? ;-)

Runtime-tested by me on macOS and Android, and by the issue submitter on Win64.

@enen92 please review, thanks. 

