### PR TITLE
[cmake] fix comments referencing incorrect names

### DIFF
--- a/cmake/modules/FindFmt.cmake
+++ b/cmake/modules/FindFmt.cmake
@@ -143,7 +143,7 @@ if(NOT TARGET fmt::fmt OR Fmt_FIND_REQUIRED)
                                     REQUIRED_VARS FMT_LIBRARY FMT_INCLUDE_DIR
                                     VERSION_VAR FMT_VERSION)
 
-  # Check whether we already have tinyxml2::tinyxml2 target added to dep property list
+  # Check whether we already have fmt::fmt target added to dep property list
   get_property(CHECK_INTERNAL_DEPS GLOBAL PROPERTY INTERNAL_DEPS_PROP)
   list(FIND CHECK_INTERNAL_DEPS "fmt::fmt" FMT_PROP_FOUND)
 

--- a/cmake/modules/FindNFS.cmake
+++ b/cmake/modules/FindNFS.cmake
@@ -18,8 +18,8 @@ if(NOT TARGET libnfs::nfs)
   # Search for cmake config. Suitable for all platforms including windows
   find_package(libnfs CONFIG QUIET)
 
-  # Check for existing TINYXML2. If version >= TINYXML2-VERSION file version, dont build
-  # A corner case, but if a linux/freebsd user WANTS to build internal tinyxml2, build anyway
+  # Check for existing LIBNFS. If version >= LIBNFS-VERSION file version, dont build
+  # A corner case, but if a linux/freebsd user WANTS to build internal libnfs, build anyway
   if((libnfs_VERSION VERSION_LESS ${${MODULE}_VER} AND ENABLE_INTERNAL_NFS) OR
      ((CORE_SYSTEM_NAME STREQUAL linux OR CORE_SYSTEM_NAME STREQUAL freebsd) AND ENABLE_INTERNAL_NFS))
 


### PR DESCRIPTION
## Description
Fix some Copy/pasta in some comments

## Motivation and context
Remove ambiguity of a comment referring to something else.

## How has this been tested?
N/A. change is only in comments, no code change

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
