### PR TITLE
[video] Fix no information dialog for music videos.

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -239,7 +239,8 @@ bool CGUIWindowVideoBase::OnItemInfo(const CFileItem& fileItem)
 
   if (!scraper && !(fileItem.IsPlugin() || fileItem.IsScript()) &&
       !(m_database.HasMovieInfo(fileItem.GetDynPath()) || m_database.HasTvShowInfo(strDir) ||
-        m_database.HasEpisodeInfo(fileItem.GetDynPath())))
+        m_database.HasEpisodeInfo(fileItem.GetDynPath()) ||
+        m_database.HasMusicVideoInfo(fileItem.GetDynPath())))
   {
     HELPERS::ShowOKDialogText(CVariant{20176}, // Show video information
                               CVariant{19055}); // no information available
@@ -396,7 +397,7 @@ bool CGUIWindowVideoBase::ShowInfo(const CFileItemPtr& item2, const ScraperPtr& 
     }
     if (info->Content() == CONTENT_MUSICVIDEOS)
     {
-      bHasInfo = m_database.GetMusicVideoInfo(item->GetPath(), movieDetails);
+      bHasInfo = m_database.GetMusicVideoInfo(item->GetDynPath(), movieDetails);
     }
     m_database.Close();
   }


### PR DESCRIPTION
Fixes #23720 

Well, another dynpath issue... but I will not give up to fix them one by one...

Runtime-tested by me (macOS, Android) and the issue reporter (Win64), confirming the fix working.

@enen92 another for kindly review.