### PR TITLE
[macos][network] Avoid executing shell commands to get the DefaultGateway and nameserver list

### DIFF
--- a/xbmc/platform/darwin/osx/network/CMakeLists.txt
+++ b/xbmc/platform/darwin/osx/network/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(SOURCES NetworkOsx.cpp)
-set(HEADERS NetworkOsx.h)
+set(SOURCES NetworkMacOS.mm)
+set(HEADERS NetworkMacOS.h)
 
-core_add_library(platform_osx_network)
+core_add_library(platform_macos_network)

--- a/xbmc/platform/darwin/osx/network/NetworkMacOS.h
+++ b/xbmc/platform/darwin/osx/network/NetworkMacOS.h
@@ -13,23 +13,23 @@
 #include <string>
 #include <vector>
 
-class CNetworkInterfaceOsx : public CNetworkInterfacePosix
+class CNetworkInterfaceMacOS : public CNetworkInterfacePosix
 {
 public:
-  CNetworkInterfaceOsx(CNetworkPosix* network,
-                       const std::string& interfaceName,
-                       char interfaceMacAddrRaw[6]);
-  ~CNetworkInterfaceOsx() override = default;
+  CNetworkInterfaceMacOS(CNetworkPosix* network,
+                         const std::string& interfaceName,
+                         char interfaceMacAddrRaw[6]);
+  ~CNetworkInterfaceMacOS() override = default;
 
   std::string GetCurrentDefaultGateway() const override;
   bool GetHostMacAddress(unsigned long host, std::string& mac) const override;
 };
 
-class CNetworkOsx : public CNetworkPosix
+class CNetworkMacOS : public CNetworkPosix
 {
 public:
-  CNetworkOsx();
-  ~CNetworkOsx() override = default;
+  CNetworkMacOS();
+  ~CNetworkMacOS() override = default;
 
   bool PingHost(unsigned long host, unsigned int timeout_ms = 2000) override;
   std::vector<std::string> GetNameServers() override;

--- a/xbmc/platform/darwin/osx/network/NetworkMacOS.mm
+++ b/xbmc/platform/darwin/osx/network/NetworkMacOS.mm
@@ -226,7 +226,7 @@ bool CNetworkMacOS::PingHost(unsigned long remote_ip, unsigned int timeout_ms)
   char cmd_line[64];
 
   struct in_addr host_ip;
-  host_ip.s_addr = remote_ip;
+  host_ip.s_addr = static_cast<in_addr_t>(remote_ip);
 
   snprintf(cmd_line, sizeof(cmd_line), "ping -c 1 -t %d %s",
            timeout_ms / 1000 + (timeout_ms % 1000) != 0, inet_ntoa(host_ip));

--- a/xbmc/platform/darwin/osx/network/NetworkMacOS.mm
+++ b/xbmc/platform/darwin/osx/network/NetworkMacOS.mm
@@ -6,7 +6,7 @@
  *  See LICENSES/README.md for more information.
  */
 
-#include "NetworkOsx.h"
+#include "NetworkmacOS.h"
 
 #include "utils/StringUtils.h"
 #include "utils/log.h"
@@ -25,14 +25,14 @@
 #include <sys/sockio.h>
 #include <unistd.h>
 
-CNetworkInterfaceOsx::CNetworkInterfaceOsx(CNetworkPosix* network,
-                                           const std::string& interfaceName,
-                                           char interfaceMacAddrRaw[6])
+CNetworkInterfaceMacOS::CNetworkInterfaceMacOS(CNetworkPosix* network,
+                                               const std::string& interfaceName,
+                                               char interfaceMacAddrRaw[6])
   : CNetworkInterfacePosix(network, interfaceName, interfaceMacAddrRaw)
 {
 }
 
-std::string CNetworkInterfaceOsx::GetCurrentDefaultGateway() const
+std::string CNetworkInterfaceMacOS::GetCurrentDefaultGateway() const
 {
   std::string result;
 
@@ -56,7 +56,7 @@ std::string CNetworkInterfaceOsx::GetCurrentDefaultGateway() const
   return result;
 }
 
-bool CNetworkInterfaceOsx::GetHostMacAddress(unsigned long host_ip, std::string& mac) const
+bool CNetworkInterfaceMacOS::GetHostMacAddress(unsigned long host_ip, std::string& mac) const
 {
   bool ret = false;
   size_t needed;
@@ -100,16 +100,15 @@ bool CNetworkInterfaceOsx::GetHostMacAddress(unsigned long host_ip, std::string&
 
 std::unique_ptr<CNetworkBase> CNetworkBase::GetNetwork()
 {
-  return std::make_unique<CNetworkOsx>();
+  return std::make_unique<CNetworkMacOS>();
 }
 
-CNetworkOsx::CNetworkOsx() : CNetworkPosix()
+CNetworkMacOS::CNetworkMacOS() : CNetworkPosix()
 {
   queryInterfaceList();
 }
 
-
-void CNetworkOsx::GetMacAddress(const std::string& interfaceName, char rawMac[6])
+void CNetworkMacOS::GetMacAddress(const std::string& interfaceName, char rawMac[6])
 {
   memset(rawMac, 0, 6);
 
@@ -149,7 +148,7 @@ void CNetworkOsx::GetMacAddress(const std::string& interfaceName, char rawMac[6]
   freeifaddrs(list);
 }
 
-void CNetworkOsx::queryInterfaceList()
+void CNetworkMacOS::queryInterfaceList()
 {
   char macAddrRaw[6];
   m_interfaces.clear();
@@ -171,13 +170,13 @@ void CNetworkOsx::queryInterfaceList()
     if (macAddrRaw[0] || macAddrRaw[1] || macAddrRaw[2] || macAddrRaw[3] || macAddrRaw[4] ||
         macAddrRaw[5])
       // Add the interface.
-      m_interfaces.push_back(new CNetworkInterfaceOsx(this, cur->ifa_name, macAddrRaw));
+      m_interfaces.push_back(new CNetworkInterfaceMacOS(this, cur->ifa_name, macAddrRaw));
   }
 
   freeifaddrs(list);
 }
 
-std::vector<std::string> CNetworkOsx::GetNameServers()
+std::vector<std::string> CNetworkMacOS::GetNameServers()
 {
   std::vector<std::string> result;
 
@@ -222,7 +221,7 @@ std::vector<std::string> CNetworkOsx::GetNameServers()
   return result;
 }
 
-bool CNetworkOsx::PingHost(unsigned long remote_ip, unsigned int timeout_ms)
+bool CNetworkMacOS::PingHost(unsigned long remote_ip, unsigned int timeout_ms)
 {
   char cmd_line[64];
 


### PR DESCRIPTION
## Description
This superseeds https://github.com/xbmc/xbmc/pull/23700 and basically avoids executing shell commands to get the default gateway and the nameserver list.
Diff is a bit big but basically the first commits are unrelated, just renames the class and moves it to objc so that we can use the `SystemConfiguration` API. I'd say the important stuff to review is:

https://github.com/xbmc/xbmc/commit/752c8eed7d0954ee277a611b67f129437a7091b2 -> DNS
https://github.com/xbmc/xbmc/commit/687ae81b3fcb113c4c3c5f7fe79595e1b1da2f16 -> Default gateway

The code to obtain the default gateway is identical to iOS maybe we can create some other class that inherits from CNetworkPosix. The reason I didn't do it is because I couldn't find any network class for TvOS to confirm (also net/route.h doesn't exist in ios and tvos). @kambala-decapitator do you know if that is available in tvOS as well?

## Motivation and context
Remove sleeps and avoid parsing output of shell commands.

## How has this been tested?
Runtime tested

## What is the effect on users?
Not much, internal refactor.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

