### PR TITLE
[Estuary][PVR] Revert showing 'in progress' movies/episodes along with the watched status.

### DIFF
--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -287,8 +287,8 @@
 		<value condition="!String.IsEmpty(ListItem.Art(tvshow.poster))">$INFO[ListItem.Art(tvshow.poster)]</value>
 	</variable>
 	<variable name="WatchedStatusVar">
-		<value condition="String.IsEqual(Listitem.DBType,tvshow) | String.IsEqual(Listitem.DBType,season)">$INFO[ListItem.Property(InProgressEpisodes)]$INFO[ListItem.Property(WatchedEpisodes),|,]$INFO[ListItem.Property(TotalEpisodes),|,]</value>
-		<value condition="String.IsEqual(Listitem.DBType,set)">$INFO[ListItem.Property(InProgress)]$INFO[ListItem.Property(Watched),|,]$INFO[ListItem.Property(Total),|,]</value>
+		<value condition="String.IsEqual(Listitem.DBType,tvshow) | String.IsEqual(Listitem.DBType,season)">$INFO[ListItem.Property(WatchedEpisodes)]$INFO[ListItem.Property(TotalEpisodes), / ,]</value>
+		<value condition="String.IsEqual(Listitem.DBType,set)">$INFO[ListItem.Property(Watched)]$INFO[ListItem.Property(Total), / ,]</value>
 	</variable>
 	<variable name="VideoPlayerForwardRewindVar">
 		<value condition="Player.Forwarding2x | Player.Rewinding2x">2x</value>

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -345,9 +345,7 @@ void GetSubDirectories(const CPVRRecordingsPath& recParentPath,
     {
       item->IncrementProperty("inprogressepisodes", 1);
     }
-    item->SetLabel2(StringUtils::Format("{}|{}|{}",
-                                        item->GetProperty("inprogressepisodes").asString(),
-                                        item->GetProperty("watchedepisodes").asString(),
+    item->SetLabel2(StringUtils::Format("{} / {}", item->GetProperty("watchedepisodes").asString(),
                                         item->GetProperty("totalepisodes").asString()));
 
     item->IncrementProperty("sizeinbytes", recording->GetSizeInBytes());


### PR DESCRIPTION
Taking feedback for #23658, as people feel the new watched state information is not intuitive (confusing it with dates and such), this PR party reverts changes of #23658 and we are back to the format "unwatched / total" we had before.

No review needed, as formerly approved code just get resurrected.

I will merge this as soon as Jenkins is happy.