### PR TITLE
[ActiveAE] Fix parsing audio devices names when names contains ':' character

### DIFF
--- a/xbmc/cores/AudioEngine/AESinkFactory.cpp
+++ b/xbmc/cores/AudioEngine/AESinkFactory.cpp
@@ -63,7 +63,7 @@ AESinkDevice CAESinkFactory::ParseDevice(const std::string& device)
   if (!found)
     dev.driver.clear();
 
-  pos = dev.name.find_first_of(':');
+  pos = dev.name.find_last_of('|');
 
   if (pos != std::string::npos)
   {

--- a/xbmc/cores/AudioEngine/Utils/AEDeviceInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEDeviceInfo.cpp
@@ -76,7 +76,7 @@ std::string CAEDeviceInfo::ToDeviceString(const std::string& driver) const
 
   const std::string fn = GetFriendlyName();
   if (!fn.empty())
-    device += ":" + fn;
+    device += "|" + fn;
 
   return device;
 }


### PR DESCRIPTION
## Description
Fix parsing audio devices names when names contains `:` character

## Motivation and context
After https://github.com/xbmc/xbmc/pull/23650 some Linux (ALSA) systems are broken because audio devices names includes character `:` used as separator of `deviceName:friendlyName`

See https://github.com/xbmc/xbmc/pull/23650#issuecomment-1707248849

Could be enough use `find_last_of(':');` to fix the issue but since anyway affected systems has reset their audio settings to default device seems more safe replace separator to `|` (probably not used character). 

In this way, users who have not yet updated to nightly version with previous PR will not have problems when starting to use a new version that includes two PRs. (i.e. update directly from Alpha2 to Alpha3 or v20 to v21). Users who have already updated will have to re-select the desired audio device in settings. I don't think it's worth creating a migration system at this time, but if the change were delayed further then there would be many users affected (audio device reset to default without the user's knowledge).

## How has this been tested?
Runtime Windows x64

## What is the effect on users?
Fix bad audio device name parsing on systems that contains ':' character (ALSA)

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
