### PR TITLE
[WIP][utils ] allow URIUtils::HasExtension check by vector list

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1069,7 +1069,11 @@ bool CFileItem::IsPicture() const
 
 bool CFileItem::IsLyrics() const
 {
-  return URIUtils::HasExtension(m_strPath, ".cdg|.lrc");
+  static const std::vector<std::string> extensions = {
+    ".cdg",
+    ".lrc"
+  };
+  return URIUtils::HasExtension(m_strPath, extensions);
 }
 
 bool CFileItem::IsSubtitle() const

--- a/xbmc/interfaces/builtins/AddonBuiltins.cpp
+++ b/xbmc/interfaces/builtins/AddonBuiltins.cpp
@@ -226,7 +226,7 @@ static int RunScript(const std::vector<std::string>& params)
 #if defined(TARGET_DARWIN_OSX)
   std::string execute;
   std::string parameter = params.size() ? params[0] : "";
-  if (URIUtils::HasExtension(parameter, ".applescript|.scpt"))
+  if (URIUtils::HasExtension(parameter, {".applescript", ".scpt"}))
   {
     std::string osxPath = CSpecialProtocol::TranslatePath(parameter);
     Cocoa_DoAppleScriptFile(osxPath.c_str());

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -1219,7 +1219,11 @@ void CGUIWindowSlideShow::OnLoadPic(int iPic,
     {
       CURL url(m_slides.at(m_iCurrentSlide)->GetPath());
       const std::string& strHostName = url.GetHostName();
-      if (URIUtils::HasExtension(strHostName, ".cbr|.cbz"))
+      static const std::vector<std::string> extensions = {
+        ".cbr",
+        ".cbz"
+      };
+      if (URIUtils::HasExtension(strHostName, extensions))
       {
         m_Image[iPic]->m_bIsComic = true;
         m_Image[iPic]->Move((float)m_Image[iPic]->GetOriginalWidth(),

--- a/xbmc/playlists/PlayListFactory.cpp
+++ b/xbmc/playlists/PlayListFactory.cpp
@@ -133,13 +133,25 @@ bool CPlayListFactory::IsPlaylist(const CFileItem& item)
 
 bool CPlayListFactory::IsPlaylist(const CURL& url)
 {
-  return URIUtils::HasExtension(url,
-                                ".m3u|.m3u8|.b4s|.pls|.strm|.wpl|.asx|.ram|.url|.pxml|.xspf");
+  static const std::vector<std::string> list = {
+    ".m3u",
+    ".m3u8",
+    ".b4s",
+    ".pls",
+    ".strm",
+    ".wpl",
+    ".asx",
+    ".ram",
+    ".url",
+    ".pxml",
+    ".xspf"
+  };
+  return URIUtils::HasExtension(url, list);
 }
 
 bool CPlayListFactory::IsPlaylist(const std::string& filename)
 {
-  return URIUtils::HasExtension(filename,
-                     ".m3u|.m3u8|.b4s|.pls|.strm|.wpl|.asx|.ram|.url|.pxml|.xspf");
+  const CURL curl(filename);
+  return IsPlaylist(curl);
 }
 

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -90,28 +90,8 @@ bool URIUtils::HasExtension(const CURL& url, const std::string& strExtensions)
 
 bool URIUtils::HasExtension(const std::string& strFileName, const std::string& strExtensions)
 {
-  if (IsURL(strFileName))
-  {
-    const CURL url(strFileName);
-    return HasExtension(url.GetFileName(), strExtensions);
-  }
-
-  const size_t pos = strFileName.find_last_of("./\\");
-  if (pos == std::string::npos || strFileName[pos] != '.')
-    return false;
-
-  const std::string extensionLower = StringUtils::ToLower(strFileName.substr(pos));
-
-  const std::vector<std::string> extensionsLower =
-      StringUtils::Split(StringUtils::ToLower(strExtensions), '|');
-
-  for (const auto& ext : extensionsLower)
-  {
-    if (StringUtils::EndsWith(ext, extensionLower))
-      return true;
-  }
-
-  return false;
+  const std::vector<std::string> extList = StringUtils::Split(strExtensions, '|');
+  return HasExtension(strFileName, extList);
 }
 
 bool URIUtils::HasExtension(const CURL& url, const std::vector<std::string>& extList)

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -114,6 +114,34 @@ bool URIUtils::HasExtension(const std::string& strFileName, const std::string& s
   return false;
 }
 
+bool URIUtils::HasExtension(const CURL& url, const std::vector<std::string>& extList)
+{
+  return HasExtension(url.GetFileName(), extList);
+}
+
+bool URIUtils::HasExtension(const std::string& strFileName, const std::vector<std::string>& extList)
+{
+  if (IsURL(strFileName))
+  {
+    const CURL url(strFileName);
+    return HasExtension(url.GetFileName(), extList);
+  }
+
+  const size_t pos = strFileName.find_last_of("./\\");
+  if (pos == std::string::npos || strFileName[pos] != '.')
+    return false;
+
+  const std::string extension = strFileName.substr(pos);
+
+  for (const auto& ext : extList)
+  {
+    if (StringUtils::EndsWithNoCase(ext, extension))
+      return true;
+  }
+
+  return false;
+}
+
 void URIUtils::RemoveExtension(std::string& strFileName)
 {
   if(IsURL(strFileName))

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -859,17 +859,34 @@ bool URIUtils::IsAPK(const std::string& strFile)
 
 bool URIUtils::IsZIP(const std::string& strFile) // also checks for comic books!
 {
-  return HasExtension(strFile, ".zip|.cbz");
+  static const std::vector<std::string> extensions = {
+    ".zip",
+    ".cbz"
+  };
+  return HasExtension(strFile, extensions);
 }
 
 bool URIUtils::IsArchive(const std::string& strFile)
 {
-  return HasExtension(strFile, ".zip|.rar|.apk|.cbz|.cbr");
+  static const std::vector<std::string> extensions = {
+    ".zip",
+    ".rar",
+    ".apk",
+    ".cbz",
+    ".cbr"
+  };
+  return HasExtension(strFile, extensions);
 }
 
 bool URIUtils::IsDiscImage(const std::string& file)
 {
-  return HasExtension(file, ".img|.iso|.nrg|.udf");
+  static const std::vector<std::string> extensions = {
+    ".img",
+    ".iso",
+    ".nrg",
+    ".udf"
+  };
+  return HasExtension(file, extensions);
 }
 
 bool URIUtils::IsDiscImageStack(const std::string& file)

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -70,6 +70,39 @@ public:
   static bool HasExtension(const std::string& strFileName, const std::string& strExtensions);
   static bool HasExtension(const CURL& url, const std::string& strExtensions);
 
+  /*!
+   * \brief Check if filename have any of the listed extensions
+   *
+   * \param[in] strFileName Path or URL to check
+   * \param[in] extList List of '.' prefixed lowercase extensions
+   * \return \e true if strFileName have any one of the extensions.
+   *
+   * \note The check is case insensitive for strFileName, but requires
+   * extList content to be lowercase. Returns false when strFileName or
+   * extList is empty.
+   *
+   * \sa GetExtension
+   *
+   * ------------------------------------------------------------------------
+   *
+   * **Example:**
+   * ~~~~~~~~~~~~~{.cpp}
+   * static const std::vector<std::string> list = {
+   *   ".mkv",
+   *   ".mp4",
+   *   ".avi",
+   *   ".m4v"
+   * };
+   *
+   * if (URIUtils::HasExtension(fileNameAndPath, list))
+   * {
+   *   ...
+   * }
+   * ~~~~~~~~~~~~~
+   */
+  static bool HasExtension(const std::string& strFileName, const std::vector<std::string>& extList);
+  static bool HasExtension(const CURL& url, const std::vector<std::string>& extList);
+
   static void RemoveExtension(std::string& strFileName);
   static std::string ReplaceExtension(const std::string& strFile,
                                      const std::string& strNewExtension);

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -74,6 +74,12 @@ TEST_F(TestURIUtils, HasExtension)
   EXPECT_FALSE(URIUtils::HasExtension("/path/movie.AvI", ".mpg|.mkv|.mp4"));
   EXPECT_FALSE(URIUtils::HasExtension("/path.mkv/movie.AvI", ".mpg|.mkv|.mp4"));
   EXPECT_FALSE(URIUtils::HasExtension("", ".avi|.mkv|.mp4"));
+
+  EXPECT_TRUE(URIUtils::HasExtension("/path/movie.AvI", {".avi", ".mkv", ".mp4"}));
+  EXPECT_TRUE(URIUtils::HasExtension("/path/movie.AvI", {".mkv", ".avi", ".mp4"}));
+  EXPECT_FALSE(URIUtils::HasExtension("/path/movie.AvI", {".mpg", ".mkv", ".mp4"}));
+  EXPECT_FALSE(URIUtils::HasExtension("/path.mkv/movie.AvI", {".mpg", ".mkv", ".mp4"}));
+  EXPECT_FALSE(URIUtils::HasExtension("", {".avi", ".mkv", ".mp4"}));
 }
 
 TEST_F(TestURIUtils, GetFileName)


### PR DESCRIPTION
## Description

With the request https://github.com/xbmc/xbmc/pull/23726 I came to use this where possible using vector because it makes a difference in performance.

Previously, there was always a string with split at "|" used which requires unnecessary work to some fixed points.

For text settings, e.g. advanced settings, it remains at "|" only hard-coded ones now use vector.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

Here the used test code about:

Measured times on i7-9600:
- CPU time 1 used: 0.346 ms
- CPU time 2 used: 0.188 ms
- CPU time 3 used: 0.054 ms
- CPU time 4 used: 0.091 ms
- CPU time 5 used: 0.092 ms

```cpp
  std::string fileNameAndPath = "/home/alwin/test.mp4";
  double time_elapsed_ms_1 = 0.0;
  double time_elapsed_ms_2 = 0.0;
  double time_elapsed_ms_3 = 0.0;
  double time_elapsed_ms_4 = 0.0;
  double time_elapsed_ms_5 = 0.0;

  for (int i = 0; i < 10; i++)
  {
    {
      std::clock_t c_start = std::clock();

      for (int i = 0; i < 100; i++)
      {
        URIUtils::HasExtension(fileNameAndPath, ".mkv");
        URIUtils::HasExtension(fileNameAndPath, ".mp4");
        URIUtils::HasExtension(fileNameAndPath, ".avi");
        URIUtils::HasExtension(fileNameAndPath, ".m4v");
      }

      std::clock_t c_end = std::clock();
      time_elapsed_ms_1 += 1000.0 * (c_end-c_start) / CLOCKS_PER_SEC;
    }

    {
      std::clock_t c_start = std::clock();

      for (int i = 0; i < 100; i++)
      {
        URIUtils::HasExtension(fileNameAndPath, ".mkv|.mp4|.avi|.m4v");
      }

      std::clock_t c_end = std::clock();
      time_elapsed_ms_2 += 1000.0 * (c_end-c_start) / CLOCKS_PER_SEC;
    }

    {
      std::clock_t c_start = std::clock();

      for (int i = 0; i < 100; i++)
      {
        static const std::vector<std::string> list = {
          ".mkv",
          ".mp4",
          ".avi",
          ".m4v"
        };
        URIUtils::HasExtension(fileNameAndPath, list);
      }

      std::clock_t c_end = std::clock();
      time_elapsed_ms_3 += 1000.0 * (c_end-c_start) / CLOCKS_PER_SEC;
    }

    {
      std::clock_t c_start = std::clock();

      for (int i = 0; i < 100; i++)
      {
        const std::vector<std::string> list = {
          ".mkv",
          ".mp4",
          ".avi",
          ".m4v"
        };
        URIUtils::HasExtension(fileNameAndPath, list);
      }

      std::clock_t c_end = std::clock();
      time_elapsed_ms_4 += 1000.0 * (c_end-c_start) / CLOCKS_PER_SEC;
    }

    {
      std::clock_t c_start = std::clock();

      for (int i = 0; i < 100; i++)
      {
        URIUtils::HasExtension(fileNameAndPath, { ".mkv", ".mp4", ".avi", ".m4v" });
      }

      std::clock_t c_end = std::clock();
      time_elapsed_ms_5 += 1000.0 * (c_end-c_start) / CLOCKS_PER_SEC;
    }
  }

  std::cout << "CPU time 1 used: " << time_elapsed_ms_1 << " ms\n";
  std::cout << "CPU time 2 used: " << time_elapsed_ms_2 << " ms\n";
  std::cout << "CPU time 3 used: " << time_elapsed_ms_3 << " ms\n";
  std::cout << "CPU time 4 used: " << time_elapsed_ms_4 << " ms\n";
  std::cout << "CPU time 5 used: " << time_elapsed_ms_5 << " ms\n";
```
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
