### PR TITLE
[video] Fix 'Scan to library' on a directory containing a movie file doesn't work anymore.

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -263,8 +263,6 @@ bool CGUIWindowVideoBase::OnItemInfo(const CFileItem& fileItem)
       item.ClearArt();
       item.GetVideoInfoTag()->m_iDbId = item.GetVideoInfoTag()->m_iIdShow;
     }
-    item.SetProperty("original_listitem_url", item.GetPath());
-    item.SetPath(item.GetVideoInfoTag()->GetPath());
   }
   else
   {
@@ -314,7 +312,7 @@ bool CGUIWindowVideoBase::OnItemInfo(const CFileItem& fileItem)
   if (fileItem.m_bIsFolder)
     item.SetProperty("set_folder_thumb", fileItem.GetPath());
 
-  return ShowInfo(std::make_shared<CFileItem>(fileItem), scraper);
+  return ShowInfo(std::make_shared<CFileItem>(item), scraper);
 }
 
 // ShowInfo is called as follows:


### PR DESCRIPTION
Fixes #23732 

This time I missed to remove the old hack to overwrite item path and to preserve the original path in a property, which does not work anymore after my refactoring of the subsequently called code to use the "new" item dynpath.

Runtime-tested on macOS and Android, latest Kodi master. 

@enen92 here we go again. ;-) as promised, I will take care of the regressions I may have introduced.