### PR TITLE
[video] Refactor artwork selection (last step)

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23068,8 +23068,9 @@ msgctxt "#39122"
 msgid "Library Information Sources"
 msgstr ""
 
-#. Label for section of settings
+#. Label for section of settings, label for artwork file browse dialog
 #: system/settings/settings.xml
+#: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
 msgctxt "#39123"
 msgid "Artwork"
 msgstr ""

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -13099,6 +13099,7 @@ msgid "Where no local album cover exists, online art will be used. Where neither
 msgstr ""
 
 #: system/settings/settings.xml
+#: xbmc/video/VideoItemArtworkHandler.cpp
 #: xbmc/music/dialogs/GUIDialogVideoInfo.cpp
 msgctxt "#20226"
 msgid "Movie set information folder"
@@ -18915,7 +18916,8 @@ msgctxt "#36040"
 msgid "Detected version of libCEC interface ({0:x}) is lower than the supported version {1:x}."
 msgstr ""
 
-#: xbmc/video/dialogs/guidialogvideoinfo.cpp
+#: xbmc/video/VideoItemArtworkHandler.cpp
+#: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
 #: xbmc/music/dialogs/GUIDialogMusicInfo.cpp
 msgctxt "#36041"
 msgid "* Item folder"

--- a/xbmc/video/CMakeLists.txt
+++ b/xbmc/video/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCES Bookmark.cpp
             GUIViewStateVideo.cpp
             PlayerController.cpp
             Teletext.cpp
+            VideoItemArtworkHandler.cpp
             VideoDatabase.cpp
             VideoDbUrl.cpp
             VideoEmbeddedImageFileLoader.cpp
@@ -22,6 +23,7 @@ set(HEADERS Bookmark.h
             PlayerController.h
             Teletext.h
             TeletextDefines.h
+            VideoItemArtworkHandler.h
             VideoDatabase.h
             VideoDbUrl.h
             VideoEmbeddedImageFileLoader.h

--- a/xbmc/video/VideoItemArtworkHandler.cpp
+++ b/xbmc/video/VideoItemArtworkHandler.cpp
@@ -1,0 +1,454 @@
+/*
+ *  Copyright (C) 2005-2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "VideoItemArtworkHandler.h"
+
+#include "FileItem.h"
+#include "MediaSource.h"
+#include "ServiceBroker.h"
+#include "TextureDatabase.h"
+#include "filesystem/Directory.h"
+#include "guilib/LocalizeStrings.h"
+#include "music/MusicDatabase.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
+#include "utils/FileExtensionProvider.h"
+#include "utils/FileUtils.h"
+#include "utils/URIUtils.h"
+#include "utils/Variant.h"
+#include "utils/log.h"
+#include "video/VideoDatabase.h"
+#include "video/VideoInfoScanner.h"
+#include "video/VideoInfoTag.h"
+#include "video/VideoThumbLoader.h"
+#include "video/tags/VideoTagExtractionHelper.h"
+
+using namespace VIDEO;
+using namespace XFILE;
+
+namespace
+{
+//-------------------------------------------------------------------------------------------------
+// CVideoItemArtworkHandler (Generic handler)
+//-------------------------------------------------------------------------------------------------
+
+class CVideoItemArtworkHandler : public IVideoItemArtworkHandler
+{
+public:
+  explicit CVideoItemArtworkHandler(const std::shared_ptr<CFileItem>& item,
+                                    const std::string& artType)
+    : m_item(item), m_artType(artType)
+  {
+  }
+
+  std::string GetCurrentArt() const override;
+  std::string GetEmbeddedArt() const override;
+  std::vector<std::string> GetRemoteArt() const override;
+  std::string GetLocalArt() const override;
+
+  std::string GetDefaultIcon() const override;
+
+  void AddItemPathToFileBrowserSources(std::vector<CMediaSource>& sources) override;
+
+  void PersistArt(const std::string& art) override;
+
+protected:
+  void AddItemPathStringToFileBrowserSources(std::vector<CMediaSource>& sources,
+                                             const std::string& itemDir,
+                                             const std::string& label);
+
+  const std::shared_ptr<CFileItem> m_item;
+  const std::string m_artType;
+};
+
+std::string CVideoItemArtworkHandler::GetCurrentArt() const
+{
+  if (m_artType.empty())
+  {
+    CLog::LogF(LOGERROR, "Art type not set!");
+    return {};
+  }
+
+  std::string currentArt;
+  if (m_item->HasArt(m_artType))
+    currentArt = m_item->GetArt(m_artType);
+  else if (m_item->HasArt("thumb") && (m_artType == "poster" || m_artType == "banner"))
+    currentArt = m_item->GetArt("thumb");
+
+  return currentArt;
+}
+
+std::string CVideoItemArtworkHandler::GetEmbeddedArt() const
+{
+  if (TAGS::CVideoTagExtractionHelper::IsExtractionSupportedFor(*m_item))
+    return TAGS::CVideoTagExtractionHelper::ExtractEmbeddedArtFor(*m_item, m_artType);
+
+  return {};
+}
+
+std::vector<std::string> CVideoItemArtworkHandler::GetRemoteArt() const
+{
+  std::vector<std::string> remoteArt;
+  CVideoInfoTag tag(*m_item->GetVideoInfoTag());
+  tag.m_strPictureURL.Parse();
+  tag.m_strPictureURL.GetThumbUrls(remoteArt, m_artType);
+  return remoteArt;
+}
+
+std::string CVideoItemArtworkHandler::GetLocalArt() const
+{
+  return CVideoThumbLoader::GetLocalArt(*m_item, m_artType);
+}
+
+std::string CVideoItemArtworkHandler::GetDefaultIcon() const
+{
+  return m_item->m_bIsFolder ? "DefaultFolder.png" : "DefaultPicture.png";
+}
+
+void CVideoItemArtworkHandler::AddItemPathToFileBrowserSources(std::vector<CMediaSource>& sources)
+{
+  std::string itemDir = m_item->GetVideoInfoTag()->m_basePath;
+  //season
+  if (itemDir.empty())
+    itemDir = m_item->GetVideoInfoTag()->GetPath();
+
+  const CFileItem itemTmp(itemDir, false);
+  if (itemTmp.IsVideo())
+    itemDir = URIUtils::GetParentPath(itemDir);
+
+  AddItemPathStringToFileBrowserSources(sources, itemDir,
+                                        g_localizeStrings.Get(36041) /* * Item folder */);
+}
+
+void CVideoItemArtworkHandler::PersistArt(const std::string& art)
+{
+  CVideoDatabase videodb;
+  if (!videodb.Open())
+  {
+    CLog::LogF(LOGERROR, "Cannot open video database!");
+    return;
+  }
+
+  videodb.SetArtForItem(m_item->GetVideoInfoTag()->m_iDbId, m_item->GetVideoInfoTag()->m_type,
+                        m_artType, art);
+}
+
+void CVideoItemArtworkHandler::AddItemPathStringToFileBrowserSources(
+    std::vector<CMediaSource>& sources, const std::string& itemDir, const std::string& label)
+{
+  if (!itemDir.empty() && CDirectory::Exists(itemDir))
+  {
+    CMediaSource itemSource;
+    itemSource.strName = label;
+    itemSource.strPath = itemDir;
+    sources.emplace_back(itemSource);
+  }
+}
+
+//-------------------------------------------------------------------------------------------------
+// CVideoItemArtworkArtistHandler (Artist handler)
+//-------------------------------------------------------------------------------------------------
+
+class CVideoItemArtworkArtistHandler : public CVideoItemArtworkHandler
+{
+public:
+  explicit CVideoItemArtworkArtistHandler(const std::shared_ptr<CFileItem>& item,
+                                          const std::string& artType)
+    : CVideoItemArtworkHandler(item, artType)
+  {
+  }
+
+  std::string GetCurrentArt() const override;
+  std::vector<std::string> GetRemoteArt() const override;
+  std::string GetLocalArt() const override;
+
+  std::string GetDefaultIcon() const override { return "DefaultArtist.png"; }
+
+  void PersistArt(const std::string& art) override;
+};
+
+std::string CVideoItemArtworkArtistHandler::GetCurrentArt() const
+{
+  CMusicDatabase musicdb;
+  if (!musicdb.Open())
+  {
+    CLog::LogF(LOGERROR, "Cannot open music database!");
+    return {};
+  }
+
+  std::string currentArt;
+  const int idArtist = musicdb.GetArtistByName(m_item->GetLabel());
+  if (idArtist >= 0)
+    currentArt = musicdb.GetArtForItem(idArtist, MediaTypeArtist, "thumb");
+
+  if (currentArt.empty())
+  {
+    CVideoDatabase videodb;
+    if (!videodb.Open())
+    {
+      CLog::LogF(LOGERROR, "Cannot open video database!");
+      return {};
+    }
+
+    currentArt = videodb.GetArtForItem(m_item->GetVideoInfoTag()->m_iDbId,
+                                       m_item->GetVideoInfoTag()->m_type, "thumb");
+  }
+  return currentArt;
+}
+
+std::vector<std::string> CVideoItemArtworkArtistHandler::GetRemoteArt() const
+{
+  return {};
+}
+
+std::string CVideoItemArtworkArtistHandler::GetLocalArt() const
+{
+  CMusicDatabase musicdb;
+  if (!musicdb.Open())
+  {
+    CLog::LogF(LOGERROR, "Cannot open music database!");
+    return {};
+  }
+
+  std::string localArt;
+  const int idArtist = musicdb.GetArtistByName(m_item->GetLabel());
+  if (idArtist >= 0)
+  {
+    // Get artist paths - possible locations for thumb - while music db open
+    CArtist artist;
+    musicdb.GetArtist(idArtist, artist);
+    std::string artistPath;
+    musicdb.GetArtistPath(artist, artistPath); // Artist path in artist info folder
+
+    std::string thumb;
+    bool existsThumb = false;
+
+    // First look for artist thumb in the primary location
+    if (!artistPath.empty())
+    {
+      thumb = URIUtils::AddFileToFolder(artistPath, "folder.jpg");
+      existsThumb = CFileUtils::Exists(thumb);
+    }
+    // If not there fall back local to music files (historic location for those album artists with a unique folder)
+    if (!existsThumb)
+    {
+      std::string artistOldPath;
+      musicdb.GetOldArtistPath(idArtist, artistOldPath); // Old artist path, local to music files
+      if (!artistOldPath.empty())
+      {
+        thumb = URIUtils::AddFileToFolder(artistOldPath, "folder.jpg");
+        existsThumb = CFileUtils::Exists(thumb);
+      }
+    }
+
+    if (existsThumb)
+      localArt = thumb;
+  }
+  return localArt;
+}
+
+void CVideoItemArtworkArtistHandler::PersistArt(const std::string& art)
+{
+  CMusicDatabase musicdb;
+  if (!musicdb.Open())
+  {
+    CLog::LogF(LOGERROR, "Cannot open music database!");
+    return;
+  }
+
+  const int idArtist = musicdb.GetArtistByName(m_item->GetLabel());
+  if (idArtist >= 0)
+    musicdb.SetArtForItem(idArtist, MediaTypeArtist, m_artType, art);
+}
+
+//-------------------------------------------------------------------------------------------------
+// CVideoItemArtworkActorHandler (Actor handler)
+//-------------------------------------------------------------------------------------------------
+
+class CVideoItemArtworkActorHandler : public CVideoItemArtworkHandler
+{
+public:
+  explicit CVideoItemArtworkActorHandler(const std::shared_ptr<CFileItem>& item,
+                                         const std::string& artType)
+    : CVideoItemArtworkHandler(item, artType)
+  {
+  }
+
+  std::string GetCurrentArt() const override;
+  std::string GetLocalArt() const override;
+
+  std::string GetDefaultIcon() const override { return "DefaultActor.png"; }
+};
+
+std::string CVideoItemArtworkActorHandler::GetCurrentArt() const
+{
+  CVideoDatabase videodb;
+  if (!videodb.Open())
+  {
+    CLog::LogF(LOGERROR, "Cannot open video database!");
+    return {};
+  }
+
+  return videodb.GetArtForItem(m_item->GetVideoInfoTag()->m_iDbId,
+                               m_item->GetVideoInfoTag()->m_type, "thumb");
+}
+
+std::string CVideoItemArtworkActorHandler::GetLocalArt() const
+{
+  std::string localArt;
+  std::string picturePath;
+  const std::string thumb = URIUtils::AddFileToFolder(picturePath, "folder.jpg");
+  if (CFileUtils::Exists(thumb))
+    localArt = thumb;
+
+  return localArt;
+}
+
+//-------------------------------------------------------------------------------------------------
+// CVideoItemArtworkSeasonHandler (Season handler)
+//-------------------------------------------------------------------------------------------------
+
+class CVideoItemArtworkSeasonHandler : public CVideoItemArtworkHandler
+{
+public:
+  explicit CVideoItemArtworkSeasonHandler(const std::shared_ptr<CFileItem>& item,
+                                          const std::string& artType)
+    : CVideoItemArtworkHandler(item, artType)
+  {
+  }
+
+  std::vector<std::string> GetRemoteArt() const override;
+};
+
+std::vector<std::string> CVideoItemArtworkSeasonHandler::GetRemoteArt() const
+{
+  CVideoDatabase videodb;
+  if (!videodb.Open())
+  {
+    CLog::LogF(LOGERROR, "Cannot open video database!");
+    return {};
+  }
+
+  std::vector<std::string> remoteArt;
+  CVideoInfoTag tag;
+  videodb.GetTvShowInfo("", tag, m_item->GetVideoInfoTag()->m_iIdShow);
+  tag.m_strPictureURL.Parse();
+  tag.m_strPictureURL.GetThumbUrls(remoteArt, m_artType, m_item->GetVideoInfoTag()->m_iSeason);
+  return remoteArt;
+}
+
+//-------------------------------------------------------------------------------------------------
+// CVideoItemArtworkMovieSetHandler (Movie set handler)
+//-------------------------------------------------------------------------------------------------
+
+class CVideoItemArtworkMovieSetHandler : public CVideoItemArtworkHandler
+{
+public:
+  explicit CVideoItemArtworkMovieSetHandler(const std::shared_ptr<CFileItem>& item,
+                                            const std::string& artType)
+    : CVideoItemArtworkHandler(item, artType)
+  {
+  }
+
+  std::vector<std::string> GetRemoteArt() const override;
+  std::string GetLocalArt() const override;
+
+  std::string GetDefaultIcon() const override { return "DefaultVideo.png"; }
+
+  void AddItemPathToFileBrowserSources(std::vector<CMediaSource>& sources) override;
+};
+
+std::vector<std::string> CVideoItemArtworkMovieSetHandler::GetRemoteArt() const
+{
+  CVideoDatabase videodb;
+  if (!videodb.Open())
+  {
+    CLog::LogF(LOGERROR, "Cannot open video database!");
+    return {};
+  }
+
+  std::vector<std::string> remoteArt;
+  const std::string baseDir =
+      StringUtils::Format("videodb://movies/sets/{}", m_item->GetVideoInfoTag()->m_iDbId);
+  CFileItemList items;
+  if (videodb.GetMoviesNav(baseDir, items))
+  {
+    for (const auto& item : items)
+    {
+      CVideoInfoTag* videotag = item->GetVideoInfoTag();
+      videotag->m_strPictureURL.Parse();
+      videotag->m_strPictureURL.GetThumbUrls(remoteArt, "set." + m_artType, -1, true);
+    }
+  }
+  return remoteArt;
+}
+
+std::string CVideoItemArtworkMovieSetHandler::GetLocalArt() const
+{
+  std::string localArt;
+  const std::string infoFolder =
+      VIDEO::CVideoInfoScanner::GetMovieSetInfoFolder(m_item->GetLabel());
+  if (!infoFolder.empty())
+  {
+    CFileItemList availableArtFiles;
+    CDirectory::GetDirectory(infoFolder, availableArtFiles,
+                             CServiceBroker::GetFileExtensionProvider().GetPictureExtensions(),
+                             DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
+    for (const auto& artFile : availableArtFiles)
+    {
+      std::string candidate = URIUtils::GetFileName(artFile->GetDynPath());
+      URIUtils::RemoveExtension(candidate);
+      if (StringUtils::EqualsNoCase(candidate, m_artType))
+      {
+        localArt = artFile->GetDynPath();
+        break;
+      }
+    }
+  }
+  return localArt;
+}
+
+void CVideoItemArtworkMovieSetHandler::AddItemPathToFileBrowserSources(
+    std::vector<CMediaSource>& sources)
+{
+  AddItemPathStringToFileBrowserSources(
+      sources, VIDEO::CVideoInfoScanner::GetMovieSetInfoFolder(m_item->GetLabel()),
+      g_localizeStrings.Get(36041) /* * Item folder */);
+  AddItemPathStringToFileBrowserSources(
+      sources,
+      CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(
+          CSettings::SETTING_VIDEOLIBRARY_MOVIESETSFOLDER),
+      "* " + g_localizeStrings.Get(20226) /* Movie set information folder */);
+}
+
+} // unnamed namespace
+
+//-------------------------------------------------------------------------------------------------
+// IVideoItemArtworkHandlerFactory
+//-------------------------------------------------------------------------------------------------
+
+std::unique_ptr<IVideoItemArtworkHandler> IVideoItemArtworkHandlerFactory::Create(
+    const std::shared_ptr<CFileItem>& item,
+    const std::string& mediaType,
+    const std::string& artType)
+{
+  std::unique_ptr<IVideoItemArtworkHandler> artHandler;
+
+  if (mediaType == MediaTypeArtist)
+    artHandler = std::make_unique<CVideoItemArtworkArtistHandler>(item, artType);
+  else if (mediaType == "actor")
+    artHandler = std::make_unique<CVideoItemArtworkActorHandler>(item, artType);
+  else if (mediaType == MediaTypeSeason)
+    artHandler = std::make_unique<CVideoItemArtworkSeasonHandler>(item, artType);
+  else if (mediaType == MediaTypeVideoCollection)
+    artHandler = std::make_unique<CVideoItemArtworkMovieSetHandler>(item, artType);
+  else
+    artHandler = std::make_unique<CVideoItemArtworkHandler>(item, artType);
+
+  return artHandler;
+}

--- a/xbmc/video/VideoItemArtworkHandler.h
+++ b/xbmc/video/VideoItemArtworkHandler.h
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (C) 2005-2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+class CFileItem;
+class CMediaSource;
+
+namespace VIDEO
+{
+class IVideoItemArtworkHandler
+{
+public:
+  virtual ~IVideoItemArtworkHandler() = default;
+
+  virtual std::string GetCurrentArt() const = 0;
+
+  virtual std::string GetEmbeddedArt() const { return {}; }
+  virtual std::vector<std::string> GetRemoteArt() const { return {}; }
+  virtual std::string GetLocalArt() const { return {}; }
+
+  virtual std::string GetDefaultIcon() const = 0;
+
+  virtual void AddItemPathToFileBrowserSources(std::vector<CMediaSource>& sources) {}
+
+  virtual void PersistArt(const std::string& art) = 0;
+};
+
+class IVideoItemArtworkHandlerFactory
+{
+public:
+  static std::unique_ptr<IVideoItemArtworkHandler> Create(const std::shared_ptr<CFileItem>& item,
+                                                          const std::string& mediaType,
+                                                          const std::string& artType);
+};
+
+} // namespace VIDEO

--- a/xbmc/video/VideoItemArtworkHandler.h
+++ b/xbmc/video/VideoItemArtworkHandler.h
@@ -29,8 +29,15 @@ public:
   virtual std::string GetLocalArt() const { return {}; }
 
   virtual std::string GetDefaultIcon() const = 0;
+  virtual bool SupportsFlippedArt() const { return false; }
 
   virtual void AddItemPathToFileBrowserSources(std::vector<CMediaSource>& sources) {}
+
+  virtual std::string UpdateEmbeddedArt(const std::string& art) { return art; }
+  virtual std::string UpdateRemoteArt(const std::vector<std::string>& art, int index)
+  {
+    return art[index];
+  }
 
   virtual void PersistArt(const std::string& art) = 0;
 };

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.h
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.h
@@ -97,11 +97,6 @@ protected:
                                 bool bRemove,
                                 CVideoDatabase& database);
 
-  /*! \brief Pop up a fanart chooser. Does not utilise remote URLs.
-   \param videoItem the item to choose fanart for.
-   */
-  static bool OnGetFanart(const std::shared_ptr<CFileItem>& videoItem);
-
   std::shared_ptr<CFileItem> m_movieItem;
   CFileItemList *m_castList;
   bool m_bViewReview = false;

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.h
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.h
@@ -55,6 +55,7 @@ public:
   static bool AddItemsToTag(const std::shared_ptr<CFileItem>& tagItem);
   static bool RemoveItemsFromTag(const std::shared_ptr<CFileItem>& tagItem);
 
+  static bool ChooseAndManageVideoItemArtwork(const std::shared_ptr<CFileItem>& item);
   static bool ManageVideoItemArtwork(const std::shared_ptr<CFileItem>& item, const MediaType& type);
 
   static std::string GetLocalizedVideoType(const std::string &strType);
@@ -113,6 +114,6 @@ protected:
 private:
   static std::string ChooseArtType(const CFileItem& item);
   static bool ManageVideoItemArtwork(const std::shared_ptr<CFileItem>& item,
-                                     const MediaType& type,
-                                     bool& finished);
+                                     const MediaType& mediaType,
+                                     const std::string& artType);
 };

--- a/xbmc/video/tags/CMakeLists.txt
+++ b/xbmc/video/tags/CMakeLists.txt
@@ -1,9 +1,11 @@
-set(SOURCES VideoInfoTagLoaderFactory.cpp
+set(SOURCES VideoTagExtractionHelper.cpp
+            VideoInfoTagLoaderFactory.cpp
             VideoTagLoaderFFmpeg.cpp
             VideoTagLoaderNFO.cpp
             VideoTagLoaderPlugin.cpp)
 
 set(HEADERS IVideoInfoTagLoader.h
+            VideoTagExtractionHelper.h
             VideoInfoTagLoaderFactory.h
             VideoTagLoaderFFmpeg.h
             VideoTagLoaderNFO.h

--- a/xbmc/video/tags/VideoInfoTagLoaderFactory.cpp
+++ b/xbmc/video/tags/VideoInfoTagLoaderFactory.cpp
@@ -9,12 +9,10 @@
 #include "VideoInfoTagLoaderFactory.h"
 
 #include "FileItem.h"
-#include "ServiceBroker.h"
 #include "VideoTagLoaderFFmpeg.h"
 #include "VideoTagLoaderNFO.h"
 #include "VideoTagLoaderPlugin.h"
-#include "settings/Settings.h"
-#include "settings/SettingsComponent.h"
+#include "video/tags/VideoTagExtractionHelper.h"
 
 using namespace VIDEO;
 
@@ -37,8 +35,7 @@ IVideoInfoTagLoader* CVideoInfoTagLoaderFactory::CreateLoader(const CFileItem& i
     return nfo;
   delete nfo;
 
-  if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_MYVIDEOS_USETAGS) &&
-      (item.IsType(".mkv") || item.IsType(".mp4") || item.IsType(".avi") || item.IsType(".m4v")))
+  if (TAGS::CVideoTagExtractionHelper::IsExtractionSupportedFor(item))
   {
     CVideoTagLoaderFFmpeg* ff = new CVideoTagLoaderFFmpeg(item, info, lookInFolder);
     if (ff->HasInfo())

--- a/xbmc/video/tags/VideoTagExtractionHelper.cpp
+++ b/xbmc/video/tags/VideoTagExtractionHelper.cpp
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "VideoTagExtractionHelper.h"
+
+#include "FileItem.h"
+#include "ServiceBroker.h"
+#include "TextureDatabase.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
+#include "utils/URIUtils.h"
+#include "video/VideoInfoTag.h"
+#include "video/tags/VideoTagLoaderFFmpeg.h"
+
+using namespace VIDEO::TAGS;
+
+bool CVideoTagExtractionHelper::IsExtractionSupportedFor(const CFileItem& item)
+{
+  const std::string fileNameAndPath = item.GetVideoInfoTag()->m_strFileNameAndPath;
+  return CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+             CSettings::SETTING_MYVIDEOS_USETAGS) &&
+         URIUtils::HasExtension(fileNameAndPath, ".mkv|.mp4|.avi|.m4v");
+}
+
+std::string CVideoTagExtractionHelper::ExtractEmbeddedArtFor(const CFileItem& item,
+                                                             const std::string& artType)
+{
+  CVideoTagLoaderFFmpeg loader(item, nullptr, false);
+  CVideoInfoTag tag;
+  loader.Load(tag, false, nullptr);
+  for (const auto& it : tag.m_coverArt)
+  {
+    if (it.m_type == artType)
+    {
+      return CTextureUtils::GetWrappedImageURL(item.GetVideoInfoTag()->m_strFileNameAndPath,
+                                               "video_" + artType);
+    }
+  }
+  return {};
+}

--- a/xbmc/video/tags/VideoTagExtractionHelper.h
+++ b/xbmc/video/tags/VideoTagExtractionHelper.h
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+
+class CFileItem;
+
+namespace VIDEO
+{
+namespace TAGS
+{
+class CVideoTagExtractionHelper
+{
+public:
+  /*!
+   \brief Check whether tag extraction is supported for the given item. This is no
+   check whether the video denoted by the item actually contains any tags. There is also a Kodi
+   setting for enabling video tag support that is taken into consideration by the implementation of
+   this function.
+   \param item [in] the item denoting a video file.
+   \return True if tag support is enabled and extraction is supported for the given file type.
+   */
+  static bool IsExtractionSupportedFor(const CFileItem& item);
+
+  /*!
+   \brief Try to extract embedded art of given type from the given item denoting a video file.
+   \param item [in] the item.
+   \param artType The type of the art to extract (e.g. "fanart").
+   \return The image URL of the embedded art if extraction was successful, false otherwise.
+   */
+  static std::string ExtractEmbeddedArtFor(const CFileItem& item, const std::string& artType);
+};
+} // namespace TAGS
+} // namespace VIDEO


### PR DESCRIPTION
This is the last step of my effort to refactor and streamline the artwork selection code (`CGUIDialogVideoInfo` and friends).

1. Consolidate two `OnGetFanart`methods doing basically the same
2. Turn spaghetti code into an object oriented implementation
3. Migrate fanart selection code to the new oo implementation

No intended functional changes in this PR.

Runtime-time tested on android and macOS, latest Kodi master.

@enen92 whenever you find some time for a review. Best reviewed commit by commit.