### PR TITLE
[info] Platform code for GPUInfo

### DIFF
--- a/xbmc/guilib/guiinfo/SystemGUIInfo.h
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.h
@@ -9,7 +9,10 @@
 #pragma once
 
 #include "guilib/guiinfo/GUIInfoProvider.h"
+#include "utils/GpuInfo.h"
 #include "utils/Temperature.h"
+
+#include <memory>
 
 namespace KODI
 {
@@ -37,7 +40,8 @@ public:
 
 private:
   std::string GetSystemHeatInfo(int info) const;
-  CTemperature GetGPUTemperature() const;
+
+  std::unique_ptr<CGPUInfo> m_gpuInfo;
 
   static const int SYSTEM_HEAT_UPDATE_INTERVAL = 60000;
 

--- a/xbmc/platform/android/CMakeLists.txt
+++ b/xbmc/platform/android/CMakeLists.txt
@@ -1,8 +1,10 @@
 set(SOURCES CPUInfoAndroid.cpp
+            GPUInfoAndroid.cpp
             MemUtils.cpp
             PlatformAndroid.cpp)
 
 set(HEADERS CPUInfoAndroid.h
+            GPUInfoAndroid.h
             PlatformAndroid.h)
 
 core_add_library(androidsupport)

--- a/xbmc/platform/android/GPUInfoAndroid.cpp
+++ b/xbmc/platform/android/GPUInfoAndroid.cpp
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GPUInfoAndroid.h"
+
+std::unique_ptr<CGPUInfo> CGPUInfo::GetGPUInfo()
+{
+  return std::make_unique<CGPUInfoAndroid>();
+}
+
+bool CGPUInfoAndroid::SupportsPlatformTemperature() const
+{
+  return false;
+}
+
+bool CGPUInfoAndroid::GetGPUPlatformTemperature(CTemperature& temperature) const
+{
+  return false;
+}

--- a/xbmc/platform/android/GPUInfoAndroid.h
+++ b/xbmc/platform/android/GPUInfoAndroid.h
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "platform/posix/GPUInfoPosix.h"
+
+class CGPUInfoAndroid : public CGPUInfoPosix
+{
+public:
+  CGPUInfoAndroid() = default;
+  ~CGPUInfoAndroid() = default;
+
+private:
+  bool SupportsPlatformTemperature() const override;
+  bool GetGPUPlatformTemperature(CTemperature& temperature) const override;
+};

--- a/xbmc/platform/darwin/ios-common/CMakeLists.txt
+++ b/xbmc/platform/darwin/ios-common/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES AnnounceReceiver.mm
             DarwinEmbedKeyboardView.mm
             DarwinEmbedNowPlayingInfoManager.mm
             DarwinEmbedUtils.mm
+            GPUInfoDarwinEmbed.cpp
             NSData+GZIP.m
             PlatformDarwinEmbedded.cpp)
 
@@ -13,6 +14,7 @@ set(HEADERS AnnounceReceiver.h
             DarwinEmbedKeyboardView.h
             DarwinEmbedNowPlayingInfoManager.h
             DarwinEmbedUtils.h
+            GPUInfoDarwinEmbed.h
             NSData+GZIP.h
             PlatformDarwinEmbedded.h)
 

--- a/xbmc/platform/darwin/ios-common/GPUInfoDarwinEmbed.cpp
+++ b/xbmc/platform/darwin/ios-common/GPUInfoDarwinEmbed.cpp
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GPUInfoDarwinEmbed.h"
+
+std::unique_ptr<CGPUInfo> CGPUInfo::GetGPUInfo()
+{
+  return std::make_unique<CGPUInfoDarwinEmbed>();
+}
+
+bool CGPUInfoDarwinEmbed::SupportsPlatformTemperature() const
+{
+  return false;
+}
+
+bool CGPUInfoDarwinEmbed::GetGPUPlatformTemperature(CTemperature& temperature) const
+{
+  return false;
+}

--- a/xbmc/platform/darwin/ios-common/GPUInfoDarwinEmbed.h
+++ b/xbmc/platform/darwin/ios-common/GPUInfoDarwinEmbed.h
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "platform/posix/GPUInfoPosix.h"
+
+class CGPUInfoDarwinEmbed : public CGPUInfoPosix
+{
+public:
+  CGPUInfoDarwinEmbed() = default;
+  ~CGPUInfoDarwinEmbed() = default;
+
+private:
+  bool SupportsPlatformTemperature() const override;
+  bool GetGPUPlatformTemperature(CTemperature& temperature) const override;
+};

--- a/xbmc/platform/darwin/osx/CMakeLists.txt
+++ b/xbmc/platform/darwin/osx/CMakeLists.txt
@@ -1,11 +1,13 @@
 set(SOURCES CocoaInterface.mm
             CPUInfoOsx.cpp
+            GPUInfoMacOS.cpp
             HotKeyController.m
             PlatformDarwinOSX.cpp
             smc.c)
 
 set(HEADERS CocoaInterface.h
             CPUInfoOsx.h
+            GPUInfoMacOS.h
             HotKeyController.h
             PlatformDarwinOSX.h
             smc.h)

--- a/xbmc/platform/darwin/osx/GPUInfoMacOS.cpp
+++ b/xbmc/platform/darwin/osx/GPUInfoMacOS.cpp
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GPUInfoMacOS.h"
+
+#include "platform/darwin/osx/smc.h"
+
+std::unique_ptr<CGPUInfo> CGPUInfo::GetGPUInfo()
+{
+  return std::make_unique<CGPUInfoMacOS>();
+}
+
+bool CGPUInfoMacOS::SupportsPlatformTemperature() const
+{
+  return true;
+}
+
+bool CGPUInfoMacOS::GetGPUPlatformTemperature(CTemperature& temperature) const
+{
+  double temperatureValue = SMCGetTemperature(SMC_KEY_GPU_TEMP);
+  if (temperatureValue <= 0.0)
+  {
+    return false;
+  }
+  temperature = CTemperature::CreateFromCelsius(temperatureValue);
+  return true;
+}

--- a/xbmc/platform/darwin/osx/GPUInfoMacOS.h
+++ b/xbmc/platform/darwin/osx/GPUInfoMacOS.h
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "platform/posix/GPUInfoPosix.h"
+
+class CGPUInfoMacOS : public CGPUInfoPosix
+{
+public:
+  CGPUInfoMacOS() = default;
+  ~CGPUInfoMacOS() = default;
+
+private:
+  bool SupportsPlatformTemperature() const override;
+  bool GetGPUPlatformTemperature(CTemperature& temperature) const override;
+};

--- a/xbmc/platform/freebsd/CMakeLists.txt
+++ b/xbmc/platform/freebsd/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES ../linux/AppParamParserLinux.cpp
             CPUInfoFreebsd.cpp
+            GPUInfoFreebsd.cpp
             OptionalsReg.cpp
             ../linux/OptionalsReg.cpp
             ../linux/TimeUtils.cpp
@@ -8,6 +9,7 @@ set(SOURCES ../linux/AppParamParserLinux.cpp
 
 set(HEADERS ../linux/AppParamParserLinux.cpp
             CPUInfoFreebsd.h
+            GPUInfoFreebsd.h
             OptionalsReg.h
             ../linux/OptionalsReg.h
             ../linux/TimeUtils.h

--- a/xbmc/platform/freebsd/GPUInfoFreebsd.cpp
+++ b/xbmc/platform/freebsd/GPUInfoFreebsd.cpp
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GPUInfoFreebsd.h"
+
+std::unique_ptr<CGPUInfo> CGPUInfo::GetGPUInfo()
+{
+  return std::make_unique<CGPUInfoFreebsd>();
+}
+
+bool CGPUInfoFreebsd::SupportsPlatformTemperature() const
+{
+  return false;
+}
+
+bool CGPUInfoFreebsd::GetGPUPlatformTemperature(CTemperature& temperature) const
+{
+  return false;
+}

--- a/xbmc/platform/freebsd/GPUInfoFreebsd.h
+++ b/xbmc/platform/freebsd/GPUInfoFreebsd.h
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "platform/posix/GPUInfoPosix.h"
+
+class CGPUInfoFreebsd : public CGPUInfoPosix
+{
+public:
+  CGPUInfoFreebsd() = default;
+  ~CGPUInfoFreebsd() = default;
+
+private:
+  bool SupportsPlatformTemperature() const override;
+  bool GetGPUPlatformTemperature(CTemperature& temperature) const override;
+};

--- a/xbmc/platform/linux/CMakeLists.txt
+++ b/xbmc/platform/linux/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES AppParamParserLinux.cpp
             CPUInfoLinux.cpp
+            GPUInfoLinux.cpp
             MemUtils.cpp
             OptionalsReg.cpp
             PlatformLinux.cpp
@@ -8,6 +9,7 @@ set(SOURCES AppParamParserLinux.cpp
 
 set(HEADERS AppParamParserLinux.h
             CPUInfoLinux.h
+            GPUInfoLinux.h
             OptionalsReg.h
             PlatformLinux.h
             SysfsPath.h

--- a/xbmc/platform/linux/GPUInfoLinux.cpp
+++ b/xbmc/platform/linux/GPUInfoLinux.cpp
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GPUInfoLinux.h"
+
+std::unique_ptr<CGPUInfo> CGPUInfo::GetGPUInfo()
+{
+  return std::make_unique<CGPUInfoLinux>();
+}
+
+bool CGPUInfoLinux::SupportsPlatformTemperature() const
+{
+  return false;
+}
+
+bool CGPUInfoLinux::GetGPUPlatformTemperature(CTemperature& temperature) const
+{
+  return false;
+}

--- a/xbmc/platform/linux/GPUInfoLinux.h
+++ b/xbmc/platform/linux/GPUInfoLinux.h
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "platform/posix/GPUInfoPosix.h"
+
+class CGPUInfoLinux : public CGPUInfoPosix
+{
+public:
+  CGPUInfoLinux() = default;
+  ~CGPUInfoLinux() = default;
+
+private:
+  bool SupportsPlatformTemperature() const override;
+  bool GetGPUPlatformTemperature(CTemperature& temperature) const override;
+};

--- a/xbmc/platform/posix/CMakeLists.txt
+++ b/xbmc/platform/posix/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES ConvUtils.cpp
             CPUInfoPosix.cpp
             Filesystem.cpp
+            GPUInfoPosix.cpp
             MessagePrinter.cpp
             PlatformPosix.cpp
             PosixMountProvider.cpp
@@ -11,6 +12,7 @@ set(SOURCES ConvUtils.cpp
 
 set(HEADERS ConvUtils.h
             CPUInfoPosix.h
+            GPUInfoPosix.h
             PlatformDefs.h
             PlatformPosix.h
             PosixMountProvider.h

--- a/xbmc/platform/posix/GPUInfoPosix.cpp
+++ b/xbmc/platform/posix/GPUInfoPosix.cpp
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GPUInfoPosix.h"
+
+#include <stdio.h>
+
+bool CGPUInfoPosix::SupportsCustomTemperatureCommand() const
+{
+  return true;
+}
+
+bool CGPUInfoPosix::GetGPUTemperatureFromCommand(CTemperature& temperature,
+                                                 const std::string& cmd) const
+{
+  int value = 0;
+  char scale = 0;
+  int ret = 0;
+  FILE* p = nullptr;
+
+  if (cmd.empty() || !(p = popen(cmd.c_str(), "r")))
+  {
+    return false;
+  }
+
+  ret = fscanf(p, "%d %c", &value, &scale);
+  pclose(p);
+
+  if (ret != 2)
+  {
+    return false;
+  }
+
+  if (scale == 'C' || scale == 'c')
+  {
+    temperature = CTemperature::CreateFromCelsius(value);
+  }
+  else if (scale == 'F' || scale == 'f')
+  {
+    temperature = CTemperature::CreateFromFahrenheit(value);
+  }
+  else
+  {
+    return false;
+  }
+  return true;
+}

--- a/xbmc/platform/posix/GPUInfoPosix.h
+++ b/xbmc/platform/posix/GPUInfoPosix.h
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "utils/GpuInfo.h"
+
+class CGPUInfoPosix : public CGPUInfo
+{
+protected:
+  CGPUInfoPosix() = default;
+  virtual ~CGPUInfoPosix() = default;
+
+  virtual bool SupportsCustomTemperatureCommand() const override;
+  virtual bool GetGPUTemperatureFromCommand(CTemperature& temperature,
+                                            const std::string& cmd) const override;
+};

--- a/xbmc/platform/win10/CMakeLists.txt
+++ b/xbmc/platform/win10/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES CPUInfoWin10.cpp
             input/RemoteControlXbox.cpp
             Environment.cpp
+            GPUInfoWin10.cpp
             Win10App.cpp
             MessagePrinter.cpp
             PlatformWin10.cpp
@@ -14,6 +15,7 @@ set(SOURCES CPUInfoWin10.cpp
 
 set(HEADERS AsyncHelpers.h
             CPUInfoWin10.h
+            GPUInfoWin10.h
             input/RemoteControlXbox.h
             Win10App.h
             PlatformWin10.h

--- a/xbmc/platform/win10/GPUInfoWin10.cpp
+++ b/xbmc/platform/win10/GPUInfoWin10.cpp
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GPUInfoWin10.h"
+
+std::unique_ptr<CGPUInfo> CGPUInfo::GetGPUInfo()
+{
+  return std::make_unique<CGPUInfoWin10>();
+}
+
+bool CGPUInfoWin10::SupportsCustomTemperatureCommand() const
+{
+  return false;
+}
+
+bool CGPUInfoWin10::SupportsPlatformTemperature() const
+{
+  return false;
+}
+
+bool CGPUInfoWin10::GetGPUPlatformTemperature(CTemperature& temperature) const
+{
+  return false;
+}
+
+bool CGPUInfoWin10::GetGPUTemperatureFromCommand(CTemperature& temperature,
+                                                 const std::string& cmd) const
+{
+  return false;
+}

--- a/xbmc/platform/win10/GPUInfoWin10.h
+++ b/xbmc/platform/win10/GPUInfoWin10.h
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "utils/GpuInfo.h"
+
+class CGPUInfoWin10 : public CGPUInfo
+{
+public:
+  CGPUInfoWin10() = default;
+  ~CGPUInfoWin10() = default;
+
+private:
+  bool SupportsCustomTemperatureCommand() const override;
+  bool SupportsPlatformTemperature() const override;
+  bool GetGPUPlatformTemperature(CTemperature& temperature) const override;
+  bool GetGPUTemperatureFromCommand(CTemperature& temperature,
+                                    const std::string& cmd) const override;
+};

--- a/xbmc/platform/win32/CMakeLists.txt
+++ b/xbmc/platform/win32/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES CharsetConverter.cpp
             CPUInfoWin32.cpp
             Environment.cpp
+            GPUInfoWin32.cpp
             MemUtils.cpp
             MessagePrinter.cpp
             dxerr.cpp
@@ -15,6 +16,7 @@ set(HEADERS CharsetConverter.h
             CPUInfoWin32.h
             dirent.h
             dxerr.h
+            GPUInfoWin32.h
             IMMNotificationClient.h
             my_ntddcdrm.h
             my_ntddscsi.h

--- a/xbmc/platform/win32/GPUInfoWin32.cpp
+++ b/xbmc/platform/win32/GPUInfoWin32.cpp
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GPUInfoWin32.h"
+
+std::unique_ptr<CGPUInfo> CGPUInfo::GetGPUInfo()
+{
+  return std::make_unique<CGPUInfoWin32>();
+}
+
+bool CGPUInfoWin32::SupportsCustomTemperatureCommand() const
+{
+  return false;
+}
+
+bool CGPUInfoWin32::SupportsPlatformTemperature() const
+{
+  return false;
+}
+
+bool CGPUInfoWin32::GetGPUPlatformTemperature(CTemperature& temperature) const
+{
+  return false;
+}
+
+bool CGPUInfoWin32::GetGPUTemperatureFromCommand(CTemperature& temperature,
+                                                 const std::string& cmd) const
+{
+  return false;
+}

--- a/xbmc/platform/win32/GPUInfoWin32.h
+++ b/xbmc/platform/win32/GPUInfoWin32.h
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "utils/GpuInfo.h"
+
+class CGPUInfoWin32 : public CGPUInfo
+{
+public:
+  CGPUInfoWin32() = default;
+  ~CGPUInfoWin32() = default;
+
+private:
+  bool GetGPUPlatformTemperature(CTemperature& temperature) const override;
+  bool GetGPUTemperatureFromCommand(CTemperature& temperature,
+                                    const std::string& cmd) const override;
+  bool SupportsCustomTemperatureCommand() const override;
+  bool SupportsPlatformTemperature() const override;
+};

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -27,6 +27,7 @@ set(SOURCES ActorProtocol.cpp
             FileOperationJob.cpp
             FileUtils.cpp
             FontUtils.cpp
+            GpuInfo.cpp
             GroupUtils.cpp
             HTMLUtil.cpp
             HttpHeader.cpp
@@ -111,6 +112,7 @@ set(HEADERS ActorProtocol.h
             FontUtils.h
             Geometry.h
             GlobalsHandling.h
+            GpuInfo.h
             GroupUtils.h
             HDRCapabilities.h
             HTMLUtil.h

--- a/xbmc/utils/GpuInfo.cpp
+++ b/xbmc/utils/GpuInfo.cpp
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GpuInfo.h"
+
+#include "ServiceBroker.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
+
+bool CGPUInfo::GetTemperature(CTemperature& temperature) const
+{
+  // user custom cmd takes precedence over platform implementation
+  if (SupportsCustomTemperatureCommand())
+  {
+    auto cmd = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_gpuTempCmd;
+    if (!cmd.empty() && GetGPUTemperatureFromCommand(temperature, cmd))
+    {
+      return true;
+    }
+  }
+
+  if (SupportsPlatformTemperature() && GetGPUPlatformTemperature(temperature))
+  {
+    return true;
+  }
+
+  temperature = CTemperature();
+  temperature.SetValid(false);
+  return false;
+}

--- a/xbmc/utils/GpuInfo.h
+++ b/xbmc/utils/GpuInfo.h
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "utils/Temperature.h"
+
+#include <memory>
+#include <string>
+
+/*! \brief Class to concentrate all methods related to GPU information
+* \details This is used by the Info interface to obtain the current GPU temperature
+*/
+class CGPUInfo
+{
+public:
+  CGPUInfo() = default;
+  virtual ~CGPUInfo() = default;
+
+  /*! \brief Getter from the specific platform GPUInfo
+   \return the platform specific implementation of GPUInfo
+   */
+  static std::unique_ptr<CGPUInfo> GetGPUInfo();
+
+  /*! \brief Get the temperature of the GPU
+   \param[in,out] temperature - the temperature to fill with the result
+   \return true if it was possible to obtain the GPU temperature, false otherwise
+   */
+  bool GetTemperature(CTemperature& temperature) const;
+
+protected:
+  /*! \brief Checks if the specific platform implementation supports obtaining the GPU temperature
+    via the execution of a custom command line command
+    \note this is false on the base class but may be overridden by the specific platform implementation.
+    Custom GPU command is defined in advancedsettings.
+    \return true if the implementation supports obtaining the GPU temperature from a custom command, false otherwise
+  */
+  virtual bool SupportsCustomTemperatureCommand() const { return false; }
+
+  /*! \brief Checks if the specific platform implementation supports obtaining the GPU temperature
+    from the platform SDK itself
+    \note this is false on the base class but may be overridden by the specific platform implementation.
+    \return true if the implementation supports obtaining the GPU temperature from the platform SDK, false otherwise
+  */
+  virtual bool SupportsPlatformTemperature() const { return false; }
+
+  /*! \brief Get the GPU temperature from the platform SDK
+    \note platform implementations must override this. For this to take effect SupportsPlatformTemperature must be true.
+    \param[in,out] temperature - the temperature to fill with the result
+    \return true if obtaining the GPU temperature succeeded, false otherwise
+  */
+  virtual bool GetGPUPlatformTemperature(CTemperature& temperature) const = 0;
+
+  /*! \brief Get the GPU temperature from a user provided command (advanced settings)
+    \note platform implementations must override this. For this to take effect SupportsCustomTemperatureCommand must be true.
+    \param[in,out] temperature - the temperature to fill with the result
+    \return true if obtaining the GPU temperature succeeded, false otherwise
+  */
+  virtual bool GetGPUTemperatureFromCommand(CTemperature& temperature,
+                                            const std::string& cmd) const = 0;
+};

--- a/xbmc/utils/test/CMakeLists.txt
+++ b/xbmc/utils/test/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SOURCES TestAlarmClock.cpp
             TestFileOperationJob.cpp
             TestFileUtils.cpp
             TestGlobalsHandling.cpp
+            TestGPUInfo.cpp
             TestHTMLUtil.cpp
             TestHttpHeader.cpp
             TestHttpParser.cpp

--- a/xbmc/utils/test/TestGPUInfo.cpp
+++ b/xbmc/utils/test/TestGPUInfo.cpp
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ServiceBroker.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
+#include "utils/GpuInfo.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+class TestGPUInfo : public ::testing::Test
+{
+protected:
+  TestGPUInfo() = default;
+};
+
+#if defined(TARGET_WINDOWS)
+TEST_F(TestGPUInfo, DISABLED_GetTemperatureFromCmd)
+#else
+TEST_F(TestGPUInfo, GetTemperature)
+#endif
+{
+  CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_gpuTempCmd = "echo '50 c'";
+  std::unique_ptr<CGPUInfo> gpuInfo = CGPUInfo::GetGPUInfo();
+  EXPECT_NE(gpuInfo, nullptr);
+  CTemperature t;
+  bool success = gpuInfo->GetTemperature(t);
+  EXPECT_TRUE(t.IsValid());
+  EXPECT_EQ(t.ToCelsius(), 50);
+}


### PR DESCRIPTION
## Description
This PR splits the code to obtain the GPU temperature, currently platform ifdefd in `SystemGUIInfo.cpp` into specific platform implementations. The idea was to split the obtaining code into 2 blocks:
- Custom CMD for platforms which can obtain the GPU temperature via the execution of a shell command (advanced settings) -> the case of all posix platforms
- Platform based temperature -> e.g. MacOS can read the GPU sensors from the SMC.

Custom CMD takes precedence over platform builtin sensors.
Added a Posix implementation that is shared over all *nix platforms. For windows this does pretty much nothing just like before.

## Motivation and context
I want to update the old smc code for macOS for reading the CPU and GPU temperatures moving it to an external dependency since this is pretty much unmaintained code by now. Figured out I should remove the `smc.h` include from the `SystemGUIInfo`. One thing lead to another and we should probably do this cleanup/refactoring first :)

## How has this been tested?
Runtime tested. Also added unit tests.

## What is the effect on users?
None, internal refactor

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
