### PR TITLE
[Cmake] fix dav1d ENABLE_INTERNAL build

### DIFF
--- a/cmake/modules/FindDav1d.cmake
+++ b/cmake/modules/FindDav1d.cmake
@@ -3,60 +3,67 @@
 # --------
 # Finds the dav1d library
 #
-# This will define the following variables::
+# This will define the following target:
 #
-# DAV1D_FOUND - system has dav1d
-# DAV1D_INCLUDE_DIRS - the dav1d include directories
-# DAV1D_LIBRARIES - the dav1d libraries
+#   dav1d::dav1d   - The dav1d library
 
-if(ENABLE_INTERNAL_DAV1D)
-  include(cmake/scripts/common/ModuleHelpers.cmake)
+if(NOT TARGET dav1d::dav1d)
+  if(ENABLE_INTERNAL_DAV1D)
+    include(cmake/scripts/common/ModuleHelpers.cmake)
 
-  set(MODULE_LC dav1d)
+    set(MODULE_LC dav1d)
 
-  SETUP_BUILD_VARS()
+    SETUP_BUILD_VARS()
 
-  set(DAV1D_VERSION ${${MODULE}_VER})
+    set(DAV1D_VERSION ${${MODULE}_VER})
 
-  find_program(NINJA_EXECUTABLE ninja REQUIRED)
-  find_program(MESON_EXECUTABLE meson REQUIRED)
+    find_program(NINJA_EXECUTABLE ninja REQUIRED)
+    find_program(MESON_EXECUTABLE meson REQUIRED)
 
-  set(CONFIGURE_COMMAND ${MESON_EXECUTABLE}
-                        --buildtype=release
-                        --default-library=static
-                        --prefix=${DEPENDS_PATH}
-                        --libdir=lib
-                        -Denable_asm=true
-                        -Denable_tools=false
-                        -Denable_examples=false
-                        -Denable_tests=false
-                        ../dav1d)
-  set(BUILD_COMMAND ${NINJA_EXECUTABLE})
-  set(INSTALL_COMMAND ${NINJA_EXECUTABLE} install)
+    set(CONFIGURE_COMMAND ${MESON_EXECUTABLE}
+                          --buildtype=release
+                          --default-library=static
+                          --prefix=${DEPENDS_PATH}
+                          --libdir=lib
+                          -Denable_asm=true
+                          -Denable_tools=false
+                          -Denable_examples=false
+                          -Denable_tests=false
+                          ../dav1d)
+    set(BUILD_COMMAND ${NINJA_EXECUTABLE})
+    set(INSTALL_COMMAND ${NINJA_EXECUTABLE} install)
 
-  BUILD_DEP_TARGET()
-else()
-  if(PKG_CONFIG_FOUND)
-    pkg_check_modules(PC_DAV1D dav1d QUIET)
+    BUILD_DEP_TARGET()
+  else()
+    if(PKG_CONFIG_FOUND)
+      pkg_check_modules(PC_DAV1D dav1d QUIET)
+    endif()
+
+    find_library(DAV1D_LIBRARY NAMES dav1d libdav1d
+                               PATHS ${PC_DAV1D_LIBDIR}
+                               NO_CACHE)
+
+    find_path(DAV1D_INCLUDE_DIR NAMES dav1d/dav1d.h
+                                PATHS ${PC_DAV1D_INCLUDEDIR}
+                                NO_CACHE)
+
+    set(DAV1D_VERSION ${PC_DAV1D_VERSION})
   endif()
 
-  find_library(DAV1D_LIBRARY NAMES dav1d libdav1d
-                             PATHS ${PC_DAV1D_LIBDIR})
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(Dav1d
+                                    REQUIRED_VARS DAV1D_LIBRARY DAV1D_INCLUDE_DIR
+                                    VERSION_VAR DAV1D_VERSION)
 
-  find_path(DAV1D_INCLUDE_DIR NAMES dav1d/dav1d.h
-                              PATHS ${PC_DAV1D_INCLUDEDIR})
+  if(DAV1D_FOUND)
+    add_library(dav1d::dav1d UNKNOWN IMPORTED)
+    set_target_properties(dav1d::dav1d PROPERTIES
+                                             IMPORTED_LOCATION "${DAV1D_LIBRARY}"
+                                             INTERFACE_INCLUDE_DIRECTORIES "${DAV1D_INCLUDE_DIR}")
+    set_property(GLOBAL APPEND PROPERTY INTERNAL_DEPS_PROP dav1d::dav1d)
 
-  set(DAV1D_VERSION ${PC_DAV1D_VERSION})
+    if(TARGET dav1d)
+      add_dependencies(dav1d::dav1d dav1d)
+    endif()
+  endif()
 endif()
-
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Dav1d
-                                  REQUIRED_VARS DAV1D_LIBRARY DAV1D_INCLUDE_DIR
-                                  VERSION_VAR DAV1D_VERSION)
-
-if(DAV1D_FOUND)
-  set(DAV1D_INCLUDE_DIRS ${DAV1D_INCLUDE_DIR})
-  set(DAV1D_LIBRARIES ${DAV1D_LIBRARY})
-endif()
-
-mark_as_advanced(DAV1D_INCLUDE_DIR DAV1D_LIBRARY)

--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -32,20 +32,21 @@ macro(buildFFMPEG)
   # Check for dependencies - Must be done before SETUP_BUILD_VARS
   get_libversion_data("dav1d" "target")
   find_package(Dav1d ${LIB_DAV1D_VER} MODULE)
-  if(NOT DAV1D_FOUND)
+  if(NOT TARGET dav1d::dav1d)
     message(STATUS "dav1d not found, internal ffmpeg build will be missing AV1 support!")
+  else()
+    set(FFMPEG_OPTIONS -DENABLE_DAV1D=ON)
   endif()
 
   set(MODULE_LC ffmpeg)
 
   SETUP_BUILD_VARS()
 
-  set(FFMPEG_OPTIONS -DENABLE_CCACHE=${ENABLE_CCACHE}
-                     -DCCACHE_PROGRAM=${CCACHE_PROGRAM}
-                     -DENABLE_VAAPI=${ENABLE_VAAPI}
-                     -DENABLE_VDPAU=${ENABLE_VDPAU}
-                     -DENABLE_DAV1D=${DAV1D_FOUND}
-                     -DEXTRA_FLAGS=${FFMPEG_EXTRA_FLAGS})
+  list(APPEND FFMPEG_OPTIONS -DENABLE_CCACHE=${ENABLE_CCACHE}
+                             -DCCACHE_PROGRAM=${CCACHE_PROGRAM}
+                             -DENABLE_VAAPI=${ENABLE_VAAPI}
+                             -DENABLE_VDPAU=${ENABLE_VDPAU}
+                             -DEXTRA_FLAGS=${FFMPEG_EXTRA_FLAGS})
 
   if(KODI_DEPENDSBUILD)
     set(CROSS_ARGS -DDEPENDS_PATH=${DEPENDS_PATH}
@@ -87,8 +88,8 @@ macro(buildFFMPEG)
 
   BUILD_DEP_TARGET()
 
-  if(TARGET dav1d)
-    add_dependencies(ffmpeg dav1d)
+  if(TARGET dav1d::dav1d)
+    add_dependencies(ffmpeg dav1d::dav1d)
   endif()
 
   find_program(BASH_COMMAND bash)

--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -127,37 +127,30 @@ fi")
 
   add_library(ffmpeg::libavcodec INTERFACE IMPORTED)
   set_target_properties(ffmpeg::libavcodec PROPERTIES
-                                           FOLDER "FFMPEG - External Projects"
                                            INTERFACE_INCLUDE_DIRECTORIES "${FFMPEG_INCLUDE_DIR}")
 
   add_library(ffmpeg::libavfilter INTERFACE IMPORTED)
   set_target_properties(ffmpeg::libavfilter PROPERTIES
-                                            FOLDER "FFMPEG - External Projects"
                                             INTERFACE_INCLUDE_DIRECTORIES "${FFMPEG_INCLUDE_DIR}")
 
   add_library(ffmpeg::libavformat INTERFACE IMPORTED)
   set_target_properties(ffmpeg::libavformat PROPERTIES
-                                            FOLDER "FFMPEG - External Projects"
                                             INTERFACE_INCLUDE_DIRECTORIES "${FFMPEG_INCLUDE_DIR}")
 
   add_library(ffmpeg::libavutil INTERFACE IMPORTED)
   set_target_properties(ffmpeg::libavutil PROPERTIES
-                                          FOLDER "FFMPEG - External Projects"
                                           INTERFACE_INCLUDE_DIRECTORIES "${FFMPEG_INCLUDE_DIR}")
 
   add_library(ffmpeg::libswscale INTERFACE IMPORTED)
   set_target_properties(ffmpeg::libswscale PROPERTIES
-                                           FOLDER "FFMPEG - External Projects"
                                            INTERFACE_INCLUDE_DIRECTORIES "${FFMPEG_INCLUDE_DIR}")
 
   add_library(ffmpeg::libswresample INTERFACE IMPORTED)
   set_target_properties(ffmpeg::libswresample PROPERTIES
-                                              FOLDER "FFMPEG - External Projects"
                                               INTERFACE_INCLUDE_DIRECTORIES "${FFMPEG_INCLUDE_DIR}")
 
   add_library(ffmpeg::libpostproc INTERFACE IMPORTED)
   set_target_properties(ffmpeg::libpostproc PROPERTIES
-                                            FOLDER "FFMPEG - External Projects"
                                             INTERFACE_INCLUDE_DIRECTORIES "${FFMPEG_INCLUDE_DIR}")
 endmacro()
 
@@ -396,7 +389,6 @@ if(FFMPEG_FOUND)
   if(NOT TARGET ffmpeg::ffmpeg)
     add_library(ffmpeg::ffmpeg INTERFACE IMPORTED)
     set_target_properties(ffmpeg::ffmpeg PROPERTIES
-                                         FOLDER "External Projects"
                                          INTERFACE_INCLUDE_DIRECTORIES "${FFMPEG_INCLUDE_DIRS}"
                                          INTERFACE_COMPILE_DEFINITIONS "${_ffmpeg_definitions}")
   endif()

--- a/cmake/modules/FindFlatBuffers.cmake
+++ b/cmake/modules/FindFlatBuffers.cmake
@@ -44,8 +44,7 @@ if(NOT TARGET flatbuffers::flatbuffers)
 
   add_library(flatbuffers::flatbuffers INTERFACE IMPORTED)
   set_target_properties(flatbuffers::flatbuffers PROPERTIES
-                             FOLDER "External Projects"
-                             INTERFACE_INCLUDE_DIRECTORIES "${FLATBUFFERS_INCLUDE_DIR}")
+                                                 INTERFACE_INCLUDE_DIRECTORIES "${FLATBUFFERS_INCLUDE_DIR}")
 
   add_dependencies(flatbuffers::flatbuffers flatbuffers::flatc)
 

--- a/cmake/modules/FindRapidJSON.cmake
+++ b/cmake/modules/FindRapidJSON.cmake
@@ -64,7 +64,6 @@ if(NOT TARGET RapidJSON::RapidJSON)
   if(RAPIDJSON_FOUND)
     add_library(RapidJSON::RapidJSON INTERFACE IMPORTED)
     set_target_properties(RapidJSON::RapidJSON PROPERTIES
-                                               FOLDER "External Projects"
                                                INTERFACE_INCLUDE_DIRECTORIES "${RAPIDJSON_INCLUDE_DIRS}")
     if(TARGET rapidjson)
       add_dependencies(RapidJSON::RapidJSON rapidjson)


### PR DESCRIPTION
## Description
Fixes building with internal dav1d
Fixes building for ffmpeg using < cmake 3.19

## Motivation and context
Fixes #23743
Fixes building for ffmpeg using < cmake 3.19

## How has this been tested?


## What is the effect on users?
Building

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
