### PR TITLE
[cmake] Add build targets always for multi config generators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,9 @@ if(DEPENDS_DIR)
   list(APPEND CMAKE_PREFIX_PATH ${DEPENDS_DIR})
 endif()
 
+# Variable to indicate if the project is targeting a Multi Config Generator (VS/Xcode primarily)
+get_property(_multiconfig_generator GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+
 # Set CORE_BUILD_DIR
 set(CORE_BUILD_DIR build)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)


### PR DESCRIPTION
## Description
Add internal build targets always when a multi config generator is used (VS/Xcode)

## Motivation and context
Currently there is no way to add a dependency to another target utilising generator expressions.
Some background context. if you build a project (eg Release) and a dependency is built (eg PCRE), if the dependency does not exist, it will be built as the selected config type (Release). If you then destroy your build folder and regenerate the cmake project, the find heuristics we use will "find" the release lib of PCRE, but no debug. Currently this will then skip adding the internal build target in an endeavour to reduce rebuilding libs because a lib has been detected that is suitable already.
The issue this causes means if the project is now built with a different config type (eg Debug), it will link the release lib into the project. Windows however is very susceptible to this issue as Debug and Release config types link against different  system runtime libs that dont allow to run a mix (eg Debug project with release lib)

This PR is more a workaround of that limitation. When a multiconfig generator is used, regardless of whether the lib is found or not, it will add the internal build target to the project. It does NOT add any dependency, so it will not be built unless manually run, however it will allow building the internal lib with the config type required (eg Debug in the above example), to then allow the user to regen the cmake configuration which can then find BOTH built libs (Debug and Release) to be used. And

This isnt a full solution, and there probably never will be due to cmake not having the ability required, however it enables an easier way to build a missing lib when required without cleaning out the pre existing libraries completely.

Xcode isnt really affected by this to the same extent as VS, except for the fact it may be less optimised with mixes of config types.

For review, the internal build is factored out into a macro with no changes to its use in each module.

## How has this been tested?
Check internal targets are available even when a version of a lib already exists.

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
