### PR TITLE
[PVR] Fix CPVRRecordingsPath path directory/params parsing.

### DIFF
--- a/xbmc/pvr/recordings/PVRRecordingsPath.cpp
+++ b/xbmc/pvr/recordings/PVRRecordingsPath.cpp
@@ -46,7 +46,7 @@ CPVRRecordingsPath::CPVRRecordingsPath(const std::string& strPath)
       strVarPath.append("/");
     else
     {
-      size_t paramStart = m_path.find(", TV");
+      size_t paramStart = strVarPath.find(", TV");
       if (paramStart == std::string::npos)
         m_directoryPath = strVarPath.substr(GetDirectoryPathPosition());
       else


### PR DESCRIPTION
Just a small bug which i found while reading the code. I have not found any actual bugs caused by this, however, the code was wrong. `m_path` was not even assigned a value when it was used here.

@phunkyfish could you please review? Thanks.