### PR TITLE
tools/depends: Fix rustup by delegating shell choice to shebang

### DIFF
--- a/tools/depends/native/rustup/Makefile
+++ b/tools/depends/native/rustup/Makefile
@@ -26,7 +26,7 @@ $(PLATFORM): $(DEPS) | $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 
 $(APP): $(PLATFORM)
-	bash $(PLATFORM)/rustup-init.sh -y --no-modify-path \
+	./$(PLATFORM)/rustup-init.sh -y --no-modify-path \
 		--profile minimal \
 		--default-toolchain=$(RUST_TOOLCHAIN_VERSION)
 


### PR DESCRIPTION
## Description

Currently, rustup fails to run on my Ubuntu 22.04 x64 machine. The reason is because the Makefile cannot resolve which bash executable to use. However, the file itself specifies its runtime shell. The file knows what's best for itself, so invoke it directly.

## Motivation and context

Ran into problem building 21 Alpha 3 for Android.

## How has this been tested?

Before: Build fails with the error:

```
make: bash: Permission denied
make: *** [Makefile:29: x86_64-linux-native/bin/rustup] Error 127
```

After: Build succeeds.

## What is the effect on users?

* None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
