### PR TITLE
Fixup warnings macos

### DIFF
--- a/xbmc/platform/darwin/osx/network/NetworkMacOS.mm
+++ b/xbmc/platform/darwin/osx/network/NetworkMacOS.mm
@@ -6,7 +6,7 @@
  *  See LICENSES/README.md for more information.
  */
 
-#include "NetworkmacOS.h"
+#include "NetworkMacOS.h"
 
 #include "utils/StringUtils.h"
 #include "utils/log.h"

--- a/xbmc/utils/test/TestGPUInfo.cpp
+++ b/xbmc/utils/test/TestGPUInfo.cpp
@@ -32,6 +32,7 @@ TEST_F(TestGPUInfo, GetTemperature)
   EXPECT_NE(gpuInfo, nullptr);
   CTemperature t;
   bool success = gpuInfo->GetTemperature(t);
+  EXPECT_TRUE(success);
   EXPECT_TRUE(t.IsValid());
   EXPECT_EQ(t.ToCelsius(), 50);
 }


### PR DESCRIPTION
## Description
Fixes two new warnings introduced with my recent PRs which is leading the quality gate to fail.
One include was incorrectly named, and one of the variables on the tests was unused.

I'll merge this if jenkins is green, no need to bother anyone with a review.

Regressions introduced in https://github.com/xbmc/xbmc/pull/23741 and https://github.com/xbmc/xbmc/pull/23724 respectively 