### PR TITLE
[VideoPlayer] Fixed: Infinite video halt when cache is full & valid

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1871,7 +1871,10 @@ void CVideoPlayer::HandlePlaySpeed()
         CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(21454), g_localizeStrings.Get(21455));
         SetCaching(CACHESTATE_INIT);
       }
-      if (cache.level >= 1.0)
+      // Note: Previously used cache.level >= 1 would keep video stalled
+      // event after cache was full
+      // Talk link: https://github.com/xbmc/xbmc/pull/23760
+      if (cache.time > 8.0)
         SetCaching(CACHESTATE_INIT);
     }
     else


### PR DESCRIPTION
\+ added SCacheStatus parameters to GetGeneralInfo()

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
- The function `HandlePlaySpeed()` in `CVideoPlayer` class has been added with a multi-conditional clause to account for resuming playback when cache is at it's appropriate level.
If the user the has set `cache->memorysize` in their `advancedsettings.xml` then it will be used for basic gauging purposes.
- The function `GetGeneralInfo()` has been modified to keep track of `SCacheStatus` parameters for debug purposes.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In the quest to enhance Kodi's performance and reliability, I've identified and addressed a specific bug that affects users with low-speed network connections. This issue is quite intricate and impacts the initial caching process during video playback.

Here's the crux of the problem: When the cache initially reaches its full capacity and Kodi notifies the user that the `rate is too slow for continuous playback`, the video stutters momentarily but then plays back normally utilizing the cache as it should. Once the cache gets depleted, it unexpectedly results in video playback stalling, even after the cache returns to its 100% capacity, the VideoPlayer fails to resume the video.

The motivation behind this pull request is to highlight Kodi's commitment to providing a seamless streaming experience for all Kodi users, irrespective of their network speed. By resolving this bug, I aim to ensure that video playback remains uninterrupted as long as cache reserve is at its appropriate level, offering a smoother and more enjoyable viewing experience, even under challenging network conditions.

I look forward to your feedback and collaboration.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The fix has been tested in emulated & real-time environment.
Low-speed internet connection doesn't lead to an infinite halt of video playback anymore.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Cache-oriented smooth playback as per either user's cache memory settings or Kodi's default settings. 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
