### PR TITLE
[Windows] Fix 24Hz refresh rate when HDR is ON on AMD systems

### DIFF
--- a/xbmc/rendering/dx/DeviceResources.h
+++ b/xbmc/rendering/dx/DeviceResources.h
@@ -188,7 +188,6 @@ namespace DX
     bool m_NV12SharedTexturesSupport{false};
     bool m_DXVA2SharedDecoderSurfaces{false};
     bool m_DXVASuperResolutionSupport{false};
-    bool m_usedSwapChain{false};
     bool m_DXVA2UseFence{false};
   };
 }


### PR DESCRIPTION
## Description
[Windows] Fix 24Hz refresh rate when HDR is ON on AMD systems

Closes https://github.com/xbmc/xbmc/issues/23759

## Motivation and context
This is broken from https://github.com/xbmc/xbmc/pull/23241. The only reason this currently only affects AMD is because for Intel and NVIDIA was already reverted in https://github.com/xbmc/xbmc/pull/23522

Since this also affects AMD there is no reason for have different code for AMD only with workaround for another fix than produces more harm than goods. The other issue is wrong color space only when Windows HDR is on all the time (and this is no standard setting because Kodi default setting "Use HDR display capabilities" ON switches HDR Off every time is displayed Kodi GUI).

On the other hand current refresh rate issue (https://github.com/xbmc/xbmc/issues/23759) is much more important because is present with default/more common settings (HDR ON only for HDR videos and HDR off for SDR / Kodi GUI).

There was also some confusion about whether this happened only with Windows 11 but it has also been reported in Windows 10. That is, it affects all Windows and Intel / NVIDIA / AMD so the bug is in Kodi code. Maybe the solution is not perfect but at least things return to a stable and known state.

Specifically, this PR only contains code removes because the idea is also backport to 20.3, leaving the solution to the other problem (if necessary) for later.

Note that I don't know of any bug reports for the other problem. I am not saying that it cannot exist, but without a doubt the impact is much more limited to very specific cases (probably not affects all AMD systems or all drivers).


## How has this been tested?
Not tested on AMD but this restores Kodi 20.1 behavior and users has reported this fixes the issue:
https://forum.kodi.tv/showthread.php?tid=374325

## What is the effect on users?
Fixes refresh rate not switch to 24 Hz when HDR is ON in AMD graphics systems 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
