### PR TITLE
[Video] Fix crash when scan to library on a directory containing new movies

### DIFF
--- a/xbmc/video/tags/VideoTagExtractionHelper.cpp
+++ b/xbmc/video/tags/VideoTagExtractionHelper.cpp
@@ -21,10 +21,9 @@ using namespace VIDEO::TAGS;
 
 bool CVideoTagExtractionHelper::IsExtractionSupportedFor(const CFileItem& item)
 {
-  const std::string fileNameAndPath = item.GetVideoInfoTag()->m_strFileNameAndPath;
   return CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
              CSettings::SETTING_MYVIDEOS_USETAGS) &&
-         URIUtils::HasExtension(fileNameAndPath, ".mkv|.mp4|.avi|.m4v");
+         URIUtils::HasExtension(item.GetDynPath(), ".mkv|.mp4|.avi|.m4v");
 }
 
 std::string CVideoTagExtractionHelper::ExtractEmbeddedArtFor(const CFileItem& item,


### PR DESCRIPTION
## Description
This function tries to access the `VideoInfoTag` but it's not yet available at that time.

It's enough to get the path from the item (video file).

## Motivation and context
Null pointer dereference.

## How has this been tested?
Scan new movies and check add to the library.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
