### PR TITLE
[Windows] Fix 24Hz refresh rate when HDR is ON on AMD systems

### DIFF
--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -708,7 +708,6 @@ void DX::DeviceResources::ResizeBuffers()
     ComPtr<IDXGIDevice1> dxgiDevice;
     hr = m_d3dDevice.As(&dxgiDevice); CHECK_ERR();
     dxgiDevice->SetMaximumFrameLatency(1);
-    m_usedSwapChain = false;
   }
 
   CLog::LogF(LOGDEBUG, "end resize buffers.");
@@ -936,7 +935,6 @@ void DX::DeviceResources::HandleDeviceLost(bool removed)
 bool DX::DeviceResources::Begin()
 {
   HRESULT hr = m_swapChain->Present(0, DXGI_PRESENT_TEST);
-  m_usedSwapChain = true;
 
   // If the device was removed either by a disconnection or a driver upgrade, we
   // must recreate all device resources.
@@ -968,7 +966,6 @@ void DX::DeviceResources::Present()
   // frames that will never be displayed to the screen.
   DXGI_PRESENT_PARAMETERS parameters = {};
   HRESULT hr = m_swapChain->Present1(1, 0, &parameters);
-  m_usedSwapChain = true;
 
   // If the device was removed either by a disconnection or a driver upgrade, we
   // must recreate all device resources.
@@ -1273,26 +1270,6 @@ void DX::DeviceResources::SetHdrColorSpace(const DXGI_COLOR_SPACE_TYPE colorSpac
 
   if (SUCCEEDED(m_swapChain.As(&swapChain3)))
   {
-    // Set the color space on a new swap chain - not mandated by MS documentation but needed
-    // at least for some AMD on Windows 10, at least up to driver 31.0.21001.45002
-    // Applying to AMD only because it breaks refresh rate switching in Windows 11 for Intel and
-    // nVidia and they don't need the workaround.
-    if (m_usedSwapChain &&
-        m_IsTransferPQ != (colorSpace == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020))
-    {
-      DXGI_ADAPTER_DESC ad{};
-      GetAdapterDesc(&ad);
-
-      if (ad.VendorId == PCIV_AMD)
-      {
-        // Temporary release, can't hold references during swap chain re-creation
-        swapChain3 = nullptr;
-        DestroySwapChain();
-        CreateWindowSizeDependentResources();
-        m_swapChain.As(&swapChain3);
-      }
-    }
-
     if (SUCCEEDED(swapChain3->SetColorSpace1(colorSpace)))
     {
       m_IsTransferPQ = (colorSpace == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020);

--- a/xbmc/rendering/dx/DeviceResources.h
+++ b/xbmc/rendering/dx/DeviceResources.h
@@ -183,6 +183,5 @@ namespace DX
     bool m_IsTransferPQ;
     bool m_NV12SharedTexturesSupport{false};
     bool m_DXVA2SharedDecoderSurfaces{false};
-    bool m_usedSwapChain{false};
   };
 }


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/23766


## What is the effect on users?
Fixes refresh rate not switch to 24 Hz when HDR is ON in AMD graphics systems


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
