### PR TITLE
[webOS] Signal Dolby Vision with AV1 codec

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecStarfish.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecStarfish.cpp
@@ -172,8 +172,25 @@ bool CDVDVideoCodecStarfish::OpenInternal(CDVDStreamInfo& hints, CDVDCodecOption
           m_bitstream.reset();
         }
       }
+
+      break;
     }
-    break;
+    case AV_CODEC_ID_AV1:
+    {
+      if (m_hints.hdrType == StreamHdrType::HDR_TYPE_DOLBYVISION && m_hints.dovi.dv_profile == 10)
+      {
+        m_formatname = "starfish-dav1";
+
+        payloadArg["option"]["externalStreamingInfo"]["contents"]["DolbyHdrInfo"]
+                  ["encryptionType"] = "clear"; //"clear", "bl", "el", "all"
+        payloadArg["option"]["externalStreamingInfo"]["contents"]["DolbyHdrInfo"]["profileId"] =
+            m_hints.dovi.dv_profile; // profile 10
+        payloadArg["option"]["externalStreamingInfo"]["contents"]["DolbyHdrInfo"]["trackType"] =
+            "single"; // "single" / "dual"
+      }
+
+      break;
+    }
     default:
       break;
   }


### PR DESCRIPTION
## Description
Adds the Dolby Vision payload metadata on playback of detected Dolby Vision AV1 files.

## Motivation and context
Allows playing AV1 Dolby Vision files on supported webOS devices.

## How has this been tested?
Runtime tested on LG OLED C2.

## What is the effect on users?
Plays AV1 Dolby Vision correctly for sets that support it.

Up until now, I think it has mostly been assumed to be LG TVs, most of which support Dolby Vision.
I'm not sure if this has any negative impact on devices that don't, and there doesn't seem to be a way to detect Dolby Vision capabilities currently.

And those that don't support AV1, well I assume it falls back to software decoding but I have no way to test.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
