### PR TITLE
[video] CVideoTagExtractionHelper::ExtractEmbeddedArtFor: Use item's dyn path

### DIFF
--- a/xbmc/video/tags/VideoTagExtractionHelper.cpp
+++ b/xbmc/video/tags/VideoTagExtractionHelper.cpp
@@ -35,10 +35,7 @@ std::string CVideoTagExtractionHelper::ExtractEmbeddedArtFor(const CFileItem& it
   for (const auto& it : tag.m_coverArt)
   {
     if (it.m_type == artType)
-    {
-      return CTextureUtils::GetWrappedImageURL(item.GetVideoInfoTag()->m_strFileNameAndPath,
-                                               "video_" + artType);
-    }
+      return CTextureUtils::GetWrappedImageURL(item.GetDynPath(), "video_" + artType);
   }
   return {};
 }


### PR DESCRIPTION
…, so the code even works if item has no videotag (should not happen, but just in case for the future).

Inspired by the fix brought in with https://github.com/xbmc/xbmc/pull/23767

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 this is a no-brainer to review... improves code robustness.