### PR TITLE
[video] 'Choose art' improvements

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoInfo.h
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.h
@@ -107,7 +107,6 @@ protected:
   int m_startUserrating = -1;
 
 private:
-  static std::string ChooseArtType(const CFileItem& item);
   static bool ManageVideoItemArtwork(const std::shared_ptr<CFileItem>& item,
                                      const MediaType& mediaType,
                                      const std::string& artType);


### PR DESCRIPTION
1. Select last selected art type on re-open of type selection dialog. Modernize the surrounding code a bit.
2. Offload gathering art to separate thread, so GUI does not block. I experienced this whenever the NAS carrying my movie collection was in sleep mode while I was doing something with the choose art dialog.

Runtime--tested an mcOS and Android, latest Kodi master.

@enen92 meanwhile you are also quite familiar with this code, right? Time for another review - best commit by commit? 