### PR TITLE
[cmake] gen_skin_pack move to add_custom_command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -412,6 +412,7 @@ else()
 endif()
 
 # These are skins that are copied into place from the source tree
+set(XBT_SOURCE_FILELIST "")
 foreach(skin ${SKINS})
   list(GET skin 0 dir)
   list(GET skin 1 relative)
@@ -430,11 +431,20 @@ add_custom_target(gen_system_addons
                     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 # Pack skins and copy to correct build dir (MultiConfig Generator aware)
-add_custom_target(gen_skin_pack
-                    COMMAND ${CMAKE_COMMAND} -DBUNDLEDIR=${_bundle_dir}
-                                             -DTEXTUREPACKER_EXECUTABLE=$<TARGET_FILE:TexturePacker::TexturePacker::Executable>
-                                             -P ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/GeneratedPackSkins.cmake
-                    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+add_custom_command(
+  OUTPUT ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/$<CONFIG>/gen_skin.timestamp
+  COMMAND ${CMAKE_COMMAND} -DBUNDLEDIR=${_bundle_dir}
+                           -DTEXTUREPACKER_EXECUTABLE=$<TARGET_FILE:TexturePacker::TexturePacker::Executable>
+                           -P ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/GeneratedPackSkins.cmake
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/$<CONFIG>
+  COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/$<CONFIG>/gen_skin.timestamp
+  DEPENDS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/GeneratedPackSkins.cmake
+          ${XBT_SOURCE_FILELIST}
+  BYPRODUCTS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/$<CONFIG>/gen_skin.timestamp
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  COMMENT "Generating skin xbt"
+)
+add_custom_target(gen_skin_pack DEPENDS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/$<CONFIG>/gen_skin.timestamp)
 
 # Packaging target. This generates system addon, xbt creation, copy files to build tree
 add_custom_target(generate-packaging ALL

--- a/cmake/scripts/common/ProjectMacros.cmake
+++ b/cmake/scripts/common/ProjectMacros.cmake
@@ -8,6 +8,8 @@
 #   xbt is added to ${XBT_FILES}
 function(pack_xbt input output)
   file(GLOB_RECURSE MEDIA_FILES ${input}/*)
+  list(APPEND XBT_SOURCE_FILELIST ${MEDIA_FILES})
+  set(XBT_SOURCE_FILELIST ${XBT_SOURCE_FILELIST} PARENT_SCOPE)
 
   get_filename_component(dir ${output} DIRECTORY)
   if(${CORE_SYSTEM_NAME} MATCHES "windows")
@@ -45,6 +47,7 @@ function(copy_skin_to_buildtree skin)
   endforeach()
 
   set(XBT_FILES ${XBT_FILES} PARENT_SCOPE)
+  set(XBT_SOURCE_FILELIST ${XBT_SOURCE_FILELIST} PARENT_SCOPE)
   set(install_data ${install_data} PARENT_SCOPE)
 endfunction()
 


### PR DESCRIPTION
## Description
Move gen_skin_pack to add_custom_command and generate a "timestamp" file for dependency tracking. This allows the custom command to only be run once, rather than every build. clean in VS also removes timestamp file, allowing for a full clean and full rebuild including running the custom command.

## Motivation and context
Fixes #23778

## How has this been tested?
Win x64 VS full build executes packing, build again doesnt. clean solution and packing is run again as expected after a clean
macos aarch64 makefile. as above with VS solution

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
