### PR TITLE
[LanguageCodes] Narrow mode for finding language code

### DIFF
--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -592,8 +592,7 @@ std::string CLangCodeExpander::ConvertToISO6392T(const std::string& lang)
 std::string CLangCodeExpander::FindLanguageCodeWithSubtag(const std::string& str)
 {
   CRegExp regLangCode;
-  if (regLangCode.RegComp(
-          "(?:^|\\s|\\()(([A-Za-z]{2,3})-([A-Za-z]{2}|[0-9]{3}|[A-Za-z]{4}))(?:$|\\s|\\))") &&
+  if (regLangCode.RegComp("\\{(([A-Za-z]{2,3})-([A-Za-z]{2}|[0-9]{3}|[A-Za-z]{4}))\\}") &&
       regLangCode.RegFind(str) >= 0)
   {
     return regLangCode.GetMatch(1);

--- a/xbmc/utils/LangCodeExpander.h
+++ b/xbmc/utils/LangCodeExpander.h
@@ -120,7 +120,7 @@ public:
    * \brief Find a language code with subtag (e.g. zh-tw, zh-Hans) in to a string.
    *        This function find a limited set of IETF BCP47 specs, so:
    *        language tag + region subtag, or, language tag + script subtag.
-   *        The language code can be found also if wrapped with round brackets.
+   *        The language code can be found if wrapped by curly brackets e.g. {pt-br}.
    * \param str The string where find the language code.
    * \return The language code found in the string, otherwise empty string
    */


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Restricted the way to detect the language code on mkv title

BEFORE:
`my title (pt-br)` (brackets optionals)
AFTER
`my title {pt-br}` (curly brackets mandatory without spaces)

i preferred change the behaviour to require as mandatory the curly brackets, that i think on text are most of time uncommon, then less chance to cause side effects

this "feature/workaround" is still not documented on wiki, im not sure where is the best place to mention this

should be better also do backport, if so let me know

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
with PR #21776 has been introduced a workaround to allow kodi detect the correct language code for a mkv audio/subtitles track
by adding in the track "title" the language code (read `Playing an MKV video with tracks defined with language and country codes`)

but has been found that mkv files containing on track titles text like `DTS-HD` cause side effects because detected as language code, see #22712

fix #22712

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
modified an mkv locally and changed audio track title to `my title {pt-br}`
## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
