### PR TITLE
fix python XBMCAddon::xbmcgui::Window::onAction() action.getButtonCode()

### DIFF
--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -230,7 +230,7 @@ bool CInputManager::ProcessEventServer(int windowId, float frameTime)
 
           CLog::Log(LOGDEBUG, "EventServer: key {} translated to action {}", wKeyID, actionName);
 
-          return ExecuteInputAction(CAction(actionID, fAmount, 0.0f, actionName));
+          return ExecuteInputAction(CAction(actionID, fAmount, 0.0f, actionName, 0, wKeyID));
         }
         else
         {

--- a/xbmc/input/actions/Action.cpp
+++ b/xbmc/input/actions/Action.cpp
@@ -20,14 +20,15 @@ CAction::CAction(int actionID,
                  float amount1 /* = 1.0f */,
                  float amount2 /* = 0.0f */,
                  const std::string& name /* = "" */,
-                 unsigned int holdTime /*= 0*/)
+                 unsigned int holdTime /*= 0*/,
+                 unsigned int buttonCode /*= 0*/)
   : m_name(name)
 {
   m_id = actionID;
   m_amount[0] = amount1;
   m_amount[1] = amount2;
   m_repeat = 0;
-  m_buttonCode = 0;
+  m_buttonCode = buttonCode;
   m_unicode = 0;
   m_holdTime = holdTime;
 }

--- a/xbmc/input/actions/Action.h
+++ b/xbmc/input/actions/Action.h
@@ -27,7 +27,8 @@ public:
           float amount1 = 1.0f,
           float amount2 = 0.0f,
           const std::string& name = "",
-          unsigned int holdTime = 0);
+          unsigned int holdTime = 0,
+          unsigned int buttonCode = 0);
   CAction(int actionID, wchar_t unicode);
   CAction(int actionID,
           unsigned int state,


### PR DESCRIPTION

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
* changes to populate buttonCode for CAction such that it is available for python addons with custom controllers

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* addons such as Keymap Editor do not work with custom controllers as the code being returned is the default value 0

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* successfully built on MacOS 11.5.2 and tested on MacOS 11.5.2 and 12.6 - functionality of Keymap Editor has been restored for custom controllers
* thread: [https://forum.kodi.tv/showthread.php?tid=356730&pid=3166711#pid3166711](https://forum.kodi.tv/showthread.php?tid=356730&pid=3166711#pid3166711)
not working snippet:
2023-09-18 12:51:19.178 T:3131545   debug <general>: EventClient: button code 194 pressed
2023-09-18 12:51:19.178 T:3131545   debug <general>: EventClient: button code 194 released
2023-09-18 12:51:19.186 T:3131425   debug <general>: EventServer: key 194 translated to action ActivateWindow(Programs)
2023-09-18 12:51:19.187 T:3131425   debug <general>: Activating window ID: 10001
2023-09-18 12:51:19.187 T:5238372   debug <general>: **action.getButtonCode(): 0**
working snippet:
2023-09-20 11:34:16.696 T:5759207   debug <general>: EventClient: button code 194 pressed
2023-09-20 11:34:16.697 T:5759207   debug <general>: EventClient: button code 194 released
2023-09-20 11:34:16.725 T:5758980   debug <general>: EventServer: key 194 translated to action ActivateWindow(Programs)
2023-09-20 11:34:16.725 T:5758980   debug <general>: Activating window ID: 10001
2023-09-20 11:34:16.725 T:5759731   debug <general>: **action.getButtonCode(): 194**

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
* should allow end-users to use Keymap Editor to regain functionality of their custom remotes and controllers

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
