### PR TITLE
[darwin] Fix header inclusion for Xcode 15

### DIFF
--- a/xbmc/platform/darwin/peripherals/Input_Gamecontroller.mm
+++ b/xbmc/platform/darwin/peripherals/Input_Gamecontroller.mm
@@ -18,7 +18,7 @@
 #include <mutex>
 
 #import <Foundation/Foundation.h>
-#import <GameController/GCController.h>
+#import <GameController/GameController.h>
 
 struct PlayerControllerState
 {


### PR DESCRIPTION
## Description
Fix building with Xcode 15 for apple platforms.

## Motivation and context
Xcode 15 causes a build failure due to a change in system headers

```
/xbmc/platform/darwin/peripherals/Input_Gamecontroller.mm:300:22: error: property 'rightShoulder' cannot be found in forward class object 'GCExtendedGamepad'
    else if (gamepad.rightShoulder == element)
             ~~~~~~~ ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/System/Library/Frameworks/GameController.framework/Headers/GCController.h:26:8: note: forward declaration of class here @class GCExtendedGamepad;
```

## How has this been tested?
Build macos aarch64

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
