### PR TITLE
DRMAtomic: Use nonblocking buffer commit

### DIFF
--- a/xbmc/windowing/gbm/drm/DRMAtomic.h
+++ b/xbmc/windowing/gbm/drm/DRMAtomic.h
@@ -41,8 +41,13 @@ private:
 
   bool SetScalingFilter(CDRMObject* object, const char* name, const char* type);
 
+  static void PageFlipHandler(
+      int fd, unsigned int frame, unsigned int sec, unsigned int usec, void* data);
+  void WaitForPageFlip();
+
   bool m_need_modeset;
   bool m_active = true;
+  bool m_waitingForPageFlip{false};
 
   class CDRMAtomicRequest
   {


### PR DESCRIPTION
## Description
Use nonblocking buffer commits to eliminate some waiting in the render thread.

## Motivation and context
I noticed that my Kodi debug build was running smoother when running on Wayland than GBM. With a release build I couldn't notice a difference but with a debug build the difference could be up to 30 fps vs 60 fps depending on the scene on a Ryzen 5700u.

When investigating I found out that using nonblocking buffer commits eliminates the performance difference. I hope that this has a positive effect on slower ARM devices as well.

## How has this been tested?
Runs without graphical artefacts, performance seems improved.

## What is the effect on users?
Hopefully more FPS on weak devices.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
