### PR TITLE
[cmake] gen_skin_pack remove BYPRODUCT to fix ninja build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -443,7 +443,6 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/$<CONFIG>/gen_skin.timestamp
   DEPENDS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/GeneratedPackSkins.cmake
           ${XBT_SOURCE_FILELIST}
-  BYPRODUCTS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/$<CONFIG>/gen_skin.timestamp
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   COMMENT "Generating skin xbt"
 )


### PR DESCRIPTION
## Description
Remove BYPRODUCT from add_custom_command

## Motivation and context
Fixes #23792

## How has this been tested?
Skin generation still works with ninja/Makefile/VS

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
