### PR TITLE
Switch remote poweroff button behaviour to show shutdown menu, like on keyboards

### DIFF
--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -50,7 +50,7 @@
       <volumeplus>VolumeUp</volumeplus>
       <volumeminus>VolumeDown</volumeminus>
       <mute>Mute</mute>
-      <power>ShutDown()</power>
+      <power>ActivateWindow(ShutdownMenu)</power>
       <myvideo>ActivateWindow(Videos)</myvideo>
       <mymusic>ActivateWindow(Music)</mymusic>
       <mypictures>ActivateWindow(Pictures)</mypictures>


### PR DESCRIPTION
## Description
When pressing poweroff on a keyboard, (PC) case power button or keyboard-like remote Kodi shows the shutdown menu.

However, when pressing the poweroff button on a Lirc/IR remote kodi shuts down immediately without showing the menu.

As many devices (like RPi, and also PCs) don't support power-up by (IR) remote this is quite fatal as it's very easy to accidentally hit the power button on a remote and then you need to physically walk over to the device to power it up again.

So let's align it to the safe default action of keyboards and give people a chance to confirm that they really want to shut down the device.

## Motivation and context

Avoid frustration of puzzled newcomers and also greybeards who forgot install a custom remote keymap on clean installs.

## How has this been tested?
Tested on RPi4 running LibreELEC master with kodi 21 Alpha3 without my usual .kodi/userdata/keymaps/remote.xml installed

## What is the effect on users?

Less frustration, fewer heart-attacks, better out-of-the box experience in line with other USB/BT/... remotes and input devices

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
