### PR TITLE
[Cmake] Create build_internal_depends for MultiConfig Generators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,9 @@ endif()
 
 # Variable to indicate if the project is targeting a Multi Config Generator (VS/Xcode primarily)
 get_property(_multiconfig_generator GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(_multiconfig_generator)
+  add_custom_target(build_internal_depends)
+endif()
 
 # Set CORE_BUILD_DIR
 set(CORE_BUILD_DIR build)

--- a/cmake/modules/FindCrossGUID.cmake
+++ b/cmake/modules/FindCrossGUID.cmake
@@ -94,18 +94,21 @@ if(NOT TARGET CrossGUID::CrossGUID)
 
   if(TARGET crossguid)
     add_dependencies(CrossGUID::CrossGUID crossguid)
-  else()
-    # Add internal build target when a Multi Config Generator is used
-    # We cant add a dependency based off a generator expression for targeted build types,
-    # https://gitlab.kitware.com/cmake/cmake/-/issues/19467
-    # therefore if the find heuristics only find the library, we add the internal build 
-    # target to the project to allow user to manually trigger for any build type they need
-    # in case only a specific build type is actually available (eg Release found, Debug Required)
-    # This is mainly targeted for windows who required different runtime libs for different
-    # types, and they arent compatible
-    if(_multiconfig_generator)
+  endif()
+
+  # Add internal build target when a Multi Config Generator is used
+  # We cant add a dependency based off a generator expression for targeted build types,
+  # https://gitlab.kitware.com/cmake/cmake/-/issues/19467
+  # therefore if the find heuristics only find the library, we add the internal build
+  # target to the project to allow user to manually trigger for any build type they need
+  # in case only a specific build type is actually available (eg Release found, Debug Required)
+  # This is mainly targeted for windows who required different runtime libs for different
+  # types, and they arent compatible
+  if(_multiconfig_generator)
+    if(NOT TARGET crossguid)
       buildCrossGUID()
     endif()
+    add_dependencies(build_internal_depends crossguid)
   endif()
 
   set_property(GLOBAL APPEND PROPERTY INTERNAL_DEPS_PROP CrossGUID::CrossGUID)

--- a/cmake/modules/FindFmt.cmake
+++ b/cmake/modules/FindFmt.cmake
@@ -49,7 +49,7 @@ if(NOT TARGET fmt::fmt OR Fmt_FIND_REQUIRED)
 
   # Check for existing FMT. If version >= FMT-VERSION file version, dont build
   find_package(FMT CONFIG QUIET
-                   HINTS ${DEPENDS_PATH}/lib
+                   HINTS ${DEPENDS_PATH}/lib/cmake
                    ${${CORE_PLATFORM_NAME_LC}_SEARCH_CONFIG})
 
   # Build if ENABLE_INTERNAL_FMT, or if required version in find_package call is greater 
@@ -120,18 +120,21 @@ if(NOT TARGET fmt::fmt OR Fmt_FIND_REQUIRED)
 
     if(TARGET fmt)
       add_dependencies(fmt::fmt fmt)
-    else()
-      # Add internal build target when a Multi Config Generator is used
-      # We cant add a dependency based off a generator expression for targeted build types,
-      # https://gitlab.kitware.com/cmake/cmake/-/issues/19467
-      # therefore if the find heuristics only find the library, we add the internal build 
-      # target to the project to allow user to manually trigger for any build type they need
-      # in case only a specific build type is actually available (eg Release found, Debug Required)
-      # This is mainly targeted for windows who required different runtime libs for different
-      # types, and they arent compatible
-      if(_multiconfig_generator)
+    endif()
+
+    # Add internal build target when a Multi Config Generator is used
+    # We cant add a dependency based off a generator expression for targeted build types,
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/19467
+    # therefore if the find heuristics only find the library, we add the internal build
+    # target to the project to allow user to manually trigger for any build type they need
+    # in case only a specific build type is actually available (eg Release found, Debug Required)
+    # This is mainly targeted for windows who required different runtime libs for different
+    # types, and they arent compatible
+    if(_multiconfig_generator)
+      if(NOT TARGET fmt)
         buildFmt()
       endif()
+      add_dependencies(build_internal_depends fmt)
     endif()
   endif()
 

--- a/cmake/modules/FindPCRE.cmake
+++ b/cmake/modules/FindPCRE.cmake
@@ -67,7 +67,7 @@ if(NOT PCRE::pcre)
 
   # Check for existing PCRE. If version >= PCRE-VERSION file version, dont build
   find_package(PCRE CONFIG QUIET
-                           HINTS ${DEPENDS_PATH}/lib
+                           HINTS ${DEPENDS_PATH}/lib/cmake
                            ${${CORE_PLATFORM_NAME_LC}_SEARCH_CONFIG})
 
   if((PCRE_VERSION VERSION_LESS ${${MODULE}_VER} AND ENABLE_INTERNAL_PCRE) OR
@@ -196,18 +196,21 @@ if(NOT PCRE::pcre)
     if(TARGET pcre)
       add_dependencies(PCRE::pcre pcre)
       add_dependencies(PCRE::pcrecpp pcre)
-    else()
-      # Add internal build target when a Multi Config Generator is used
-      # We cant add a dependency based off a generator expression for targeted build types,
-      # https://gitlab.kitware.com/cmake/cmake/-/issues/19467
-      # therefore if the find heuristics only find the library, we add the internal build 
-      # target to the project to allow user to manually trigger for any build type they need
-      # in case only a specific build type is actually available (eg Release found, Debug Required)
-      # This is mainly targeted for windows who required different runtime libs for different
-      # types, and they arent compatible
-      if(_multiconfig_generator)
+    endif()
+
+    # Add internal build target when a Multi Config Generator is used
+    # We cant add a dependency based off a generator expression for targeted build types,
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/19467
+    # therefore if the find heuristics only find the library, we add the internal build
+    # target to the project to allow user to manually trigger for any build type they need
+    # in case only a specific build type is actually available (eg Release found, Debug Required)
+    # This is mainly targeted for windows who required different runtime libs for different
+    # types, and they arent compatible
+    if(_multiconfig_generator)
+      if(NOT TARGET pcre)
         buildPCRE()
       endif()
+      add_dependencies(build_internal_depends pcre)
     endif()
 
     set_property(GLOBAL APPEND PROPERTY INTERNAL_DEPS_PROP PCRE::pcre)

--- a/cmake/modules/FindSpdlog.cmake
+++ b/cmake/modules/FindSpdlog.cmake
@@ -65,7 +65,7 @@ if(NOT TARGET spdlog::spdlog)
 
   # Check for existing SPDLOG. If version >= SPDLOG-VERSION file version, dont build
   find_package(SPDLOG CONFIG QUIET
-                             HINTS ${DEPENDS_PATH}/lib
+                             HINTS ${DEPENDS_PATH}/lib/cmake
                              ${${CORE_PLATFORM_LC}_SEARCH_CONFIG})
 
   if((SPDLOG_VERSION VERSION_LESS ${${MODULE}_VER} AND ENABLE_INTERNAL_SPDLOG) OR
@@ -164,18 +164,21 @@ if(NOT TARGET spdlog::spdlog)
 
     if(TARGET spdlog)
       add_dependencies(spdlog::spdlog spdlog)
-    else()
-      # Add internal build target when a Multi Config Generator is used
-      # We cant add a dependency based off a generator expression for targeted build types,
-      # https://gitlab.kitware.com/cmake/cmake/-/issues/19467
-      # therefore if the find heuristics only find the library, we add the internal build 
-      # target to the project to allow user to manually trigger for any build type they need
-      # in case only a specific build type is actually available (eg Release found, Debug Required)
-      # This is mainly targeted for windows who required different runtime libs for different
-      # types, and they arent compatible
-      if(_multiconfig_generator)
+    endif()
+
+    # Add internal build target when a Multi Config Generator is used
+    # We cant add a dependency based off a generator expression for targeted build types,
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/19467
+    # therefore if the find heuristics only find the library, we add the internal build
+    # target to the project to allow user to manually trigger for any build type they need
+    # in case only a specific build type is actually available (eg Release found, Debug Required)
+    # This is mainly targeted for windows who required different runtime libs for different
+    # types, and they arent compatible
+    if(_multiconfig_generator)
+      if(NOT TARGET spdlog)
         buildSpdlog()
       endif()
+      add_dependencies(build_internal_depends spdlog)
     endif()
   endif()
 endif()

--- a/cmake/modules/FindTagLib.cmake
+++ b/cmake/modules/FindTagLib.cmake
@@ -112,19 +112,23 @@ if(NOT TARGET TagLib::TagLib)
 
     if(TARGET taglib)
       add_dependencies(TagLib::TagLib taglib)
-    else()
-      # Add internal build target when a Multi Config Generator is used
-      # We cant add a dependency based off a generator expression for targeted build types,
-      # https://gitlab.kitware.com/cmake/cmake/-/issues/19467
-      # therefore if the find heuristics only find the library, we add the internal build 
-      # target to the project to allow user to manually trigger for any build type they need
-      # in case only a specific build type is actually available (eg Release found, Debug Required)
-      # This is mainly targeted for windows who required different runtime libs for different
-      # types, and they arent compatible
-      if(_multiconfig_generator)
+    endif()
+
+    # Add internal build target when a Multi Config Generator is used
+    # We cant add a dependency based off a generator expression for targeted build types,
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/19467
+    # therefore if the find heuristics only find the library, we add the internal build
+    # target to the project to allow user to manually trigger for any build type they need
+    # in case only a specific build type is actually available (eg Release found, Debug Required)
+    # This is mainly targeted for windows who required different runtime libs for different
+    # types, and they arent compatible
+    if(_multiconfig_generator)
+      if(NOT TARGET taglib)
         buildTagLib()
       endif()
+      add_dependencies(build_internal_depends taglib)
     endif()
+
 
     set_property(GLOBAL APPEND PROPERTY INTERNAL_DEPS_PROP TagLib::TagLib)
   else()

--- a/cmake/modules/FindTinyXML2.cmake
+++ b/cmake/modules/FindTinyXML2.cmake
@@ -49,7 +49,7 @@ if(NOT TARGET tinyxml2::tinyxml2)
   SETUP_BUILD_VARS()
 
   find_package(TINYXML2 CONFIG QUIET
-                               HINTS ${DEPENDS_PATH}/lib
+                               HINTS ${DEPENDS_PATH}/lib/cmake
                                ${${CORE_PLATFORM_NAME_LC}_SEARCH_CONFIG})
 
   # Check for existing TINYXML2. If version >= TINYXML2-VERSION file version, dont build
@@ -134,19 +134,23 @@ if(NOT TARGET tinyxml2::tinyxml2)
 
     if(TARGET tinyxml2)
       add_dependencies(tinyxml2::tinyxml2 tinyxml2)
-    else()
-      # Add internal build target when a Multi Config Generator is used
-      # We cant add a dependency based off a generator expression for targeted build types,
-      # https://gitlab.kitware.com/cmake/cmake/-/issues/19467
-      # therefore if the find heuristics only find the library, we add the internal build 
-      # target to the project to allow user to manually trigger for any build type they need
-      # in case only a specific build type is actually available (eg Release found, Debug Required)
-      # This is mainly targeted for windows who required different runtime libs for different
-      # types, and they arent compatible
-      if(_multiconfig_generator)
+    endif()
+
+    # Add internal build target when a Multi Config Generator is used
+    # We cant add a dependency based off a generator expression for targeted build types,
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/19467
+    # therefore if the find heuristics only find the library, we add the internal build
+    # target to the project to allow user to manually trigger for any build type they need
+    # in case only a specific build type is actually available (eg Release found, Debug Required)
+    # This is mainly targeted for windows who required different runtime libs for different
+    # types, and they arent compatible
+    if(_multiconfig_generator)
+      if(NOT TARGET tinyxml2)
         buildTinyXML2()
       endif()
+      add_dependencies(build_internal_depends tinyxml2)
     endif()
+
   endif()
 
   set_property(GLOBAL APPEND PROPERTY INTERNAL_DEPS_PROP tinyxml2::tinyxml2)


### PR DESCRIPTION
## Description
Create a standalone target that can build all ENABLE_INTERNAL_* based dependency build targets for Multi Config Generators (VS/Xcode)
Additionally some HINTS paths for find_package calls have been updated when ${CORE_PLATFORM_NAME_LC}_SEARCH_CONFIG are used to correctly allow finding the cmake config files

## Motivation and context
Windows has an issue with our Find heuristics where we look for existing libs that match minimum versions to reduce rebuilding. The issue with windows is it has a different runtime that is required between Rel* and Debug variants, and a lib built with one cannot be used by a kodi build type of the other.

Due to shortcomings in cmake, there currently isnt a way to only build a target based on a generator expression of a config type and to link up the add_dependencies of it all. This means if a dev built a config type of a lib (eg Debug spdlog), we currently find the existing lib and dont auto build the lib. If the dev wants Release kodi, it will fail with linker errors.

This allows us to add all internal build targets into a single target, and allow a dev to build all libs at once for any config type to essentially pre-populate the DEPENDS_PATH

## How has this been tested?
Build build_internal_depends target with Xcode. all targets built for correct config type.

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
