### PR TITLE
[Cmake] assorted updates to search paths and fixes to *_LIBRARIES usage

### DIFF
--- a/cmake/modules/FindAlsa.cmake
+++ b/cmake/modules/FindAlsa.cmake
@@ -14,10 +14,10 @@ if(NOT TARGET ALSA::ALSA)
   endif()
 
   find_path(ALSA_INCLUDE_DIR NAMES alsa/asoundlib.h
-                             PATHS ${PC_ALSA_INCLUDEDIR}
+                             HINTS ${PC_ALSA_INCLUDEDIR}
                              NO_CACHE)
   find_library(ALSA_LIBRARY NAMES asound
-                            PATHS ${PC_ALSA_LIBDIR}
+                            HINTS ${PC_ALSA_LIBDIR}
                             NO_CACHE)
 
   set(ALSA_VERSION ${PC_ALSA_VERSION})

--- a/cmake/modules/FindAvahi.cmake
+++ b/cmake/modules/FindAvahi.cmake
@@ -15,16 +15,20 @@ if(NOT TARGET Avahi::Avahi)
   endif()
 
   find_path(AVAHI_CLIENT_INCLUDE_DIR NAMES avahi-client/client.h
-                                     PATHS ${PC_AVAHI_INCLUDEDIR}
+                                     HINTS ${DEPENDS_PATH}/include ${PC_AVAHI_INCLUDEDIR}
+                                     ${${CORE_PLATFORM_LC}_SEARCH_CONFIG}
                                      NO_CACHE)
   find_path(AVAHI_COMMON_INCLUDE_DIR NAMES avahi-common/defs.h
-                                     PATHS ${PC_AVAHI_INCLUDEDIR}
+                                     HINTS ${DEPENDS_PATH}/include ${PC_AVAHI_INCLUDEDIR}
+                                     ${${CORE_PLATFORM_LC}_SEARCH_CONFIG}
                                      NO_CACHE)
   find_library(AVAHI_CLIENT_LIBRARY NAMES avahi-client
-                                    PATHS ${PC_AVAHI_LIBDIR}
+                                    HINTS ${DEPENDS_PATH}/lib ${PC_AVAHI_LIBDIR}
+                                    ${${CORE_PLATFORM_LC}_SEARCH_CONFIG}
                                     NO_CACHE)
   find_library(AVAHI_COMMON_LIBRARY NAMES avahi-common
-                                    PATHS ${PC_AVAHI_LIBDIR}
+                                    HINTS ${DEPENDS_PATH}/lib ${PC_AVAHI_LIBDIR}
+                                    ${${CORE_PLATFORM_LC}_SEARCH_CONFIG}
                                     NO_CACHE)
 
   set(AVAHI_VERSION ${PC_AVAHI_VERSION})

--- a/cmake/modules/FindBluetooth.cmake
+++ b/cmake/modules/FindBluetooth.cmake
@@ -14,10 +14,10 @@ if(NOT TARGET Bluetooth::Bluetooth)
   endif()
 
   find_path(BLUETOOTH_INCLUDE_DIR NAMES bluetooth/bluetooth.h
-                                  PATHS ${PC_BLUETOOTH_INCLUDEDIR}
+                                  HINTS ${PC_BLUETOOTH_INCLUDEDIR}
                                   NO_CACHE)
   find_library(BLUETOOTH_LIBRARY NAMES bluetooth libbluetooth
-                                 PATHS ${PC_BLUETOOTH_LIBDIR}
+                                 HINTS ${PC_BLUETOOTH_LIBDIR}
                                  NO_CACHE)
 
   set(BLUETOOTH_VERSION ${PC_BLUETOOTH_VERSION})

--- a/cmake/modules/FindCAP.cmake
+++ b/cmake/modules/FindCAP.cmake
@@ -14,10 +14,10 @@ if(NOT TARGET CAP::CAP)
   endif()
 
   find_path(CAP_INCLUDE_DIR NAMES sys/capability.h
-                            PATHS ${PC_CAP_INCLUDEDIR}
+                            HINTS ${PC_CAP_INCLUDEDIR}
                             NO_CACHE)
   find_library(CAP_LIBRARY NAMES cap libcap
-                           PATHS ${PC_CAP_LIBDIR}
+                           HINTS ${PC_CAP_LIBDIR}
                            NO_CACHE)
 
   set(CAP_VERSION ${PC_CAP_VERSION})

--- a/cmake/modules/FindCrossGUID.cmake
+++ b/cmake/modules/FindCrossGUID.cmake
@@ -38,17 +38,25 @@ if(NOT TARGET CrossGUID::CrossGUID)
   if(ENABLE_INTERNAL_CROSSGUID)
     buildCrossGUID()
   else()
-    if(PKG_CONFIG_FOUND)
+    find_package(PkgConfig)
+    # Do not use pkgconfig on windows
+    if(PKG_CONFIG_FOUND AND NOT WIN32)
       pkg_check_modules(PC_CROSSGUID crossguid QUIET)
       set(CROSSGUID_VERSION ${PC_CROSSGUID_VERSION})
     endif()
 
     find_path(CROSSGUID_INCLUDE_DIR NAMES crossguid/guid.hpp guid.h
-                                    HINTS ${DEPENDS_PATH}/include ${PC_CROSSGUID_INCLUDEDIR})
+                                    HINTS ${DEPENDS_PATH}/include ${PC_CROSSGUID_INCLUDEDIR}
+                                    ${${CORE_PLATFORM_LC}_SEARCH_CONFIG}
+                                    NO_CACHE)
     find_library(CROSSGUID_LIBRARY_RELEASE NAMES crossguid
-                                           HINTS ${DEPENDS_PATH}/lib ${PC_CROSSGUID_LIBDIR})
+                                           HINTS ${DEPENDS_PATH}/lib ${PC_CROSSGUID_LIBDIR}
+                                           ${${CORE_PLATFORM_LC}_SEARCH_CONFIG}
+                                           NO_CACHE)
     find_library(CROSSGUID_LIBRARY_DEBUG NAMES crossguidd crossguid-dgb
-                                         HINTS ${DEPENDS_PATH}/lib ${PC_CROSSGUID_LIBDIR})
+                                         HINTS ${DEPENDS_PATH}/lib ${PC_CROSSGUID_LIBDIR}
+                                         ${${CORE_PLATFORM_LC}_SEARCH_CONFIG}
+                                         NO_CACHE)
 
     # NEW_CROSSGUID >= 0.2.0 release
     if(EXISTS "${CROSSGUID_INCLUDE_DIR}/crossguid/guid.hpp")

--- a/cmake/modules/FindCrossGUID.cmake
+++ b/cmake/modules/FindCrossGUID.cmake
@@ -67,6 +67,7 @@ if(NOT TARGET CrossGUID::CrossGUID)
   # Select relevant lib build type (ie CROSSGUID_LIBRARY_RELEASE or CROSSGUID_LIBRARY_DEBUG)
   include(SelectLibraryConfigurations)
   select_library_configurations(CROSSGUID)
+  unset(CROSSGUID_LIBRARIES)
 
   include(FindPackageHandleStandardArgs)
   find_package_handle_standard_args(CrossGUID

--- a/cmake/modules/FindDBus.cmake
+++ b/cmake/modules/FindDBus.cmake
@@ -15,13 +15,13 @@ if(NOT TARGET DBus::DBus)
 
   find_path(DBUS_INCLUDE_DIR NAMES dbus/dbus.h
                              PATH_SUFFIXES dbus-1.0
-                             PATHS ${PC_DBUS_INCLUDE_DIR})
+                             HINTS ${PC_DBUS_INCLUDE_DIR})
   find_path(DBUS_ARCH_INCLUDE_DIR NAMES dbus/dbus-arch-deps.h
                                   PATH_SUFFIXES dbus-1.0/include
-                                  PATHS ${PC_DBUS_LIBDIR}
-                                        /usr/lib/${CMAKE_LIBRARY_ARCHITECTURE})
+                                  HINTS ${PC_DBUS_LIBDIR}
+                                  PATHS /usr/lib/${CMAKE_LIBRARY_ARCHITECTURE})
   find_library(DBUS_LIBRARY NAMES dbus-1
-                            PATHS ${PC_DBUS_LIBDIR})
+                            HINTS ${PC_DBUS_LIBDIR})
 
   set(DBUS_VERSION ${PC_DBUS_VERSION})
 
@@ -31,7 +31,6 @@ if(NOT TARGET DBus::DBus)
                                     VERSION_VAR DBUS_VERSION)
 
   if(DBUS_FOUND)
-
     add_library(DBus::DBus UNKNOWN IMPORTED)
     set_target_properties(DBus::DBus PROPERTIES
                                    IMPORTED_LOCATION "${DBUS_LIBRARY}"

--- a/cmake/modules/FindDav1d.cmake
+++ b/cmake/modules/FindDav1d.cmake
@@ -35,16 +35,20 @@ if(NOT TARGET dav1d::dav1d)
 
     BUILD_DEP_TARGET()
   else()
-    if(PKG_CONFIG_FOUND)
+    find_package(PkgConfig)
+    # Do not use pkgconfig on windows
+    if(PKG_CONFIG_FOUND AND NOT WIN32)
       pkg_check_modules(PC_DAV1D dav1d QUIET)
     endif()
 
     find_library(DAV1D_LIBRARY NAMES dav1d libdav1d
                                HINTS ${DEPENDS_PATH}/lib ${PC_DAV1D_LIBDIR}
+                               ${${CORE_PLATFORM_LC}_SEARCH_CONFIG}
                                NO_CACHE)
 
     find_path(DAV1D_INCLUDE_DIR NAMES dav1d/dav1d.h
                                 HINTS ${DEPENDS_PATH}/include ${PC_DAV1D_INCLUDEDIR}
+                                ${${CORE_PLATFORM_LC}_SEARCH_CONFIG}
                                 NO_CACHE)
 
     set(DAV1D_VERSION ${PC_DAV1D_VERSION})

--- a/cmake/modules/FindDetours.cmake
+++ b/cmake/modules/FindDetours.cmake
@@ -12,8 +12,10 @@ if(NOT TARGET windows::Detours)
                                 NO_CACHE)
 
   find_library(DETOURS_LIBRARY_RELEASE NAMES detours
+                                       ${${CORE_PLATFORM_LC}_SEARCH_CONFIG}
                                        NO_CACHE)
   find_library(DETOURS_LIBRARY_DEBUG NAMES detoursd
+                                     ${${CORE_PLATFORM_LC}_SEARCH_CONFIG}
                                      NO_CACHE)
 
   include(SelectLibraryConfigurations)

--- a/cmake/modules/FindEGL.cmake
+++ b/cmake/modules/FindEGL.cmake
@@ -14,11 +14,11 @@ if(NOT TARGET EGL::EGL)
   endif()
 
   find_path(EGL_INCLUDE_DIR EGL/egl.h
-                            PATHS ${PC_EGL_INCLUDEDIR}
+                            HINTS ${PC_EGL_INCLUDEDIR}
                             NO_CACHE)
 
   find_library(EGL_LIBRARY NAMES EGL egl
-                           PATHS ${PC_EGL_LIBDIR}
+                           HINTS ${PC_EGL_LIBDIR}
                            NO_CACHE)
 
   set(EGL_VERSION ${PC_EGL_VERSION})

--- a/cmake/modules/FindFmt.cmake
+++ b/cmake/modules/FindFmt.cmake
@@ -162,6 +162,7 @@ if(NOT TARGET fmt::fmt OR Fmt_FIND_REQUIRED)
 
   include(SelectLibraryConfigurations)
   select_library_configurations(FMT)
+  unset(FMT_LIBRARIES)
 
   include(FindPackageHandleStandardArgs)
   find_package_handle_standard_args(Fmt

--- a/cmake/modules/FindFreeType.cmake
+++ b/cmake/modules/FindFreeType.cmake
@@ -9,17 +9,21 @@
 
 if(NOT TARGET FreeType::FreeType)
   find_package(PkgConfig)
-  if(PKG_CONFIG_FOUND)
+  # Do not use pkgconfig on windows
+  if(PKG_CONFIG_FOUND AND NOT WIN32)
     pkg_check_modules(PC_FREETYPE freetype2 QUIET)
   endif()
 
   find_path(FREETYPE_INCLUDE_DIR NAMES freetype/freetype.h freetype.h
-                                 PATHS ${PC_FREETYPE_INCLUDEDIR}
+                                 HINTS ${DEPENDS_PATH}/include
+                                       ${PC_FREETYPE_INCLUDEDIR}
                                        ${PC_FREETYPE_INCLUDE_DIRS}
                                  PATH_SUFFIXES freetype2
+                                 ${${CORE_PLATFORM_LC}_SEARCH_CONFIG}
                                  NO_CACHE)
   find_library(FREETYPE_LIBRARY NAMES freetype freetype246MT
-                                PATHS ${PC_FREETYPE_LIBDIR}
+                                HINTS ${DEPENDS_PATH}/lib ${PC_FREETYPE_LIBDIR}
+                                ${${CORE_PLATFORM_LC}_SEARCH_CONFIG}
                                 NO_CACHE)
 
   set(FREETYPE_VERSION ${PC_FREETYPE_VERSION})

--- a/cmake/modules/FindFstrcmp.cmake
+++ b/cmake/modules/FindFstrcmp.cmake
@@ -27,15 +27,20 @@ if(NOT TARGET fstrcmp::fstrcmp)
 
     BUILD_DEP_TARGET()
   else()
+    find_package(PkgConfig)
     if(PKG_CONFIG_FOUND)
       pkg_check_modules(PC_FSTRCMP fstrcmp QUIET)
     endif()
 
     find_path(FSTRCMP_INCLUDE_DIR NAMES fstrcmp.h
-                                   PATHS ${PC_FSTRCMP_INCLUDEDIR})
+                                  HINTS ${DEPENDS_PATH}/include ${PC_FSTRCMP_INCLUDEDIR}
+                                  ${${CORE_PLATFORM_LC}_SEARCH_CONFIG}
+                                  NO_CACHE)
 
     find_library(FSTRCMP_LIBRARY NAMES fstrcmp
-                                  PATHS ${PC_FSTRCMP_LIBDIR})
+                                 HINTS ${DEPENDS_PATH}/lib ${PC_FSTRCMP_LIBDIR}
+                                 ${${CORE_PLATFORM_LC}_SEARCH_CONFIG}
+                                 NO_CACHE)
 
     set(FSTRCMP_VER ${PC_FSTRCMP_VERSION})
   endif()
@@ -56,5 +61,3 @@ if(NOT TARGET fstrcmp::fstrcmp)
 
   set_property(GLOBAL APPEND PROPERTY INTERNAL_DEPS_PROP fstrcmp::fstrcmp)
 endif()
-
-mark_as_advanced(FSTRCMP_INCLUDE_DIR FSTRCMP_LIBRARY)

--- a/cmake/modules/FindGBM.cmake
+++ b/cmake/modules/FindGBM.cmake
@@ -13,10 +13,10 @@ if(NOT TARGET GBM::GBM)
   endif()
 
   find_path(GBM_INCLUDE_DIR NAMES gbm.h
-                            PATHS ${PC_GBM_INCLUDEDIR}
+                            HINTS ${PC_GBM_INCLUDEDIR}
                             NO_CACHE)
   find_library(GBM_LIBRARY NAMES gbm
-                           PATHS ${PC_GBM_LIBDIR}
+                           HINTS ${PC_GBM_LIBDIR}
                            NO_CACHE)
 
   set(GBM_VERSION ${PC_GBM_VERSION})

--- a/cmake/modules/FindHarfBuzz.cmake
+++ b/cmake/modules/FindHarfBuzz.cmake
@@ -14,12 +14,14 @@ if(NOT TARGET HarfBuzz::HarfBuzz)
   endif()
 
   find_path(HARFBUZZ_INCLUDE_DIR NAMES harfbuzz/hb-ft.h hb-ft.h
-                                 HINTS ${PC_HARFBUZZ_INCLUDEDIR}
+                                 HINTS ${DEPENDS_PATH}/include
+                                       ${PC_HARFBUZZ_INCLUDEDIR}
                                        ${PC_HARFBUZZ_INCLUDE_DIRS}
-                                 PATH_SUFFIXES harfbuzz
+                                 ${${CORE_PLATFORM_LC}_SEARCH_CONFIG}
                                  NO_CACHE)
   find_library(HARFBUZZ_LIBRARY NAMES harfbuzz
-                                HINTS ${PC_HARFBUZZ_LIBDIR}
+                                HINTS ${DEPENDS_PATH}/lib ${PC_HARFBUZZ_LIBDIR}
+                                ${${CORE_PLATFORM_LC}_SEARCH_CONFIG}
                                 NO_CACHE)
 
   set(HARFBUZZ_VERSION ${PC_HARFBUZZ_VERSION})

--- a/cmake/modules/FindPCRE.cmake
+++ b/cmake/modules/FindPCRE.cmake
@@ -147,6 +147,8 @@ if(NOT PCRE::pcre)
   include(SelectLibraryConfigurations)
   select_library_configurations(PCRECPP)
   select_library_configurations(PCRE)
+  unset(PCRECPP_LIBRARIES)
+  unset(PCRE_LIBRARIES)
 
   include(FindPackageHandleStandardArgs)
   find_package_handle_standard_args(PCRE

--- a/cmake/modules/FindSpdlog.cmake
+++ b/cmake/modules/FindSpdlog.cmake
@@ -129,6 +129,7 @@ if(NOT TARGET spdlog::spdlog)
 
   include(SelectLibraryConfigurations)
   select_library_configurations(SPDLOG)
+  unset(SPDLOG_LIBRARIES)
 
   include(FindPackageHandleStandardArgs)
   find_package_handle_standard_args(Spdlog

--- a/cmake/modules/FindTagLib.cmake
+++ b/cmake/modules/FindTagLib.cmake
@@ -82,6 +82,7 @@ if(NOT TARGET TagLib::TagLib)
 
   include(SelectLibraryConfigurations)
   select_library_configurations(TAGLIB)
+  unset(TAGLIB_LIBRARIES)
 
   include(FindPackageHandleStandardArgs)
   find_package_handle_standard_args(TagLib

--- a/cmake/modules/FindTinyXML2.cmake
+++ b/cmake/modules/FindTinyXML2.cmake
@@ -109,6 +109,7 @@ if(NOT TARGET tinyxml2::tinyxml2)
 
   include(SelectLibraryConfigurations)
   select_library_configurations(TINYXML2)
+  unset(TINYXML2_LIBRARIES)
 
   include(FindPackageHandleStandardArgs)
   find_package_handle_standard_args(TinyXML2

--- a/tools/EventClients/Clients/WiiRemote/CMakeLists.txt
+++ b/tools/EventClients/Clients/WiiRemote/CMakeLists.txt
@@ -11,12 +11,12 @@ set(HEADERS CWIID_WiiRemote.h)
 add_executable(${APP_NAME_LC}-wiiremote ${SOURCES} ${HEADERS})
 
 target_include_directories(${APP_NAME_LC}-wiiremote
-                           PRIVATE ${BLUETOOTH_INCLUDE_DIRS}
+                           PRIVATE $<TARGET_PROPERTY:Bluetooth::Bluetooth,INTERFACE_INCLUDE_DIRECTORIES>
                                    ${CWIID_INCLUDE_DIRS})
 
 target_link_libraries(${APP_NAME_LC}-wiiremote
                       PRIVATE ${SYSTEM_LDFLAGS}
-                              ${BLUETOOTH_LIBRARIES}
+                              Bluetooth::Bluetooth
                               ${CWIID_LIBRARIES})
 
 target_compile_options(${APP_NAME_LC}-wiiremote PRIVATE ${ARCH_DEFINES})


### PR DESCRIPTION
## Description
Update search path options for a number of Find modules.
Unset *_LIBRARIES variables to reduce linker duplication/length

## Motivation and context
Primary commit is 35ef8b175c5fe81e44c6028880e3e39cd600b0c7
This just removes *_LIBRARIES variables being set for a number of find modules that were already migrated to TARGETs. When the *_LIBRARIES variables are set, they are appended to DEPLIBS before TARGET usage was available. Targets allow deduplication so instead of having a lib listed in the linker command 3-4 times, its only listed once. Just cleans things up if you have to dig into that sort of thing.

Also 574208b21069dbdab8c7c0c8f66f94c79d17476e is a fix after 9f075a723900aa2d9be1e81e40b4503829d4d2b0 migrated to TARGET usage. the eventclients stuff still uses core find modules, and BLUETOOTH_INCLUDE_DIRS and BLUETOOTH_LIBRARIES are no longer populated directly.

## How has this been tested?
Build Win/macos as part of other work.

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
