### PR TITLE
[video] Video info dialog: Reinit cast list on re-open of dialog afte…

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -751,6 +751,7 @@ void CGUIDialogVideoInfo::Play(bool resume)
   else if (!CGUIWindowVideoBase::ShowResumeMenu(*m_movieItem))
   {
     // The Resume dialog was closed without any choice
+    SetMovie(m_movieItem.get()); // restore cast list, which was cleared on GUI_MSG_WINDOW_DEINIT
     Open();
     return;
   }


### PR DESCRIPTION
…r cancelling resume playback dialog.

Fixes an edge case spotted by pure luck while playing around with the video info dialog.

To reproduce:
1. Have a movie at hand, which is in your library, has a cast list and has a resume bookmark set
2. Open the video info dialog for this movie
3. Hit the "Play" button in the dialog, dialog closes, resume dialog opens
4. Cancel the resume dialog
=> video info dialog re-opens, but instead of the cast list you now see the banner (if available) or "no information" label where the cast list was before.

![screenshot00003](https://github.com/xbmc/xbmc/assets/3226626/e153e441-98b7-432e-9f47-abd4df2173a4)
![screenshot00004](https://github.com/xbmc/xbmc/assets/3226626/2e0b62bf-3e40-4099-ae70-0d38daae9543)
![screenshot00005](https://github.com/xbmc/xbmc/assets/3226626/b6e22331-9593-4ea0-a358-7d597332038d)

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 this one should be easy to review I guess.