### PR TITLE
[listproviders] CDirectoryProvider: Add attribute 'browse' …

### DIFF
--- a/addons/skin.estuary/xml/Home.xml
+++ b/addons/skin.estuary/xml/Home.xml
@@ -80,6 +80,7 @@
 							<param name="content_path" value="special://skin/playlists/random_movies.xsp"/>
 							<param name="widget_header" value="$LOCALIZE[31006]"/>
 							<param name="widget_target" value="videos"/>
+							<param name="browse_mode" value="never"/>
 							<param name="list_id" value="5400"/>
 						</include>
 						<include content="WidgetListCategories" condition="Library.HasContent(movies)">
@@ -214,6 +215,7 @@
 							<param name="content_path" value="special://skin/playlists/random_albums.xsp"/>
 							<param name="widget_header" value="$LOCALIZE[31012]"/>
 							<param name="widget_target" value="music"/>
+							<param name="browse_mode" value="never"/>
 							<param name="list_id" value="7300"/>
 							<param name="fallback_icon" value="DefaultMusicAlbums.png"/>
 							<param name="onclick_condition" value="true"/>
@@ -223,6 +225,7 @@
 							<param name="content_path" value="special://skin/playlists/random_artists.xsp"/>
 							<param name="widget_header" value="$LOCALIZE[31013]"/>
 							<param name="widget_target" value="music"/>
+							<param name="browse_mode" value="never"/>
 							<param name="list_id" value="7400"/>
 							<param name="fallback_icon" value="DefaultMusicArtists.png"/>
 						</include>
@@ -739,6 +742,7 @@
 							<param name="content_path" value="special://skin/playlists/random_musicvideo_artists.xsp"/>
 							<param name="widget_header" value="$LOCALIZE[31013]"/>
 							<param name="widget_target" value="music"/>
+							<param name="browse_mode" value="never"/>
 							<param name="list_id" value="16200"/>
 							<param name="widget_limit" value="10"/>
 						</include>
@@ -756,6 +760,7 @@
 							<param name="content_path" value="special://skin/playlists/random_musicvideos.xsp"/>
 							<param name="widget_header" value="$LOCALIZE[31152]"/>
 							<param name="widget_target" value="videos"/>
+							<param name="browse_mode" value="never"/>
 							<param name="fallback_image" value="DefaultMusicSongs.png" />
 							<param name="list_id" value="16500"/>
 						</include>

--- a/addons/skin.estuary/xml/Includes_Home.xml
+++ b/addons/skin.estuary/xml/Includes_Home.xml
@@ -27,6 +27,7 @@
 	</include>
 	<include name="WidgetListPoster">
 		<param name="onclick_condition">false</param>
+		<param name="browse_mode">auto</param>
 		<definition>
 			<include content="CategoryLabel">
 				<param name="label">$PARAM[widget_header]</param>
@@ -71,7 +72,7 @@
 						</include>
 					</control>
 				</focusedlayout>
-				<content sortby="$PARAM[sortby]" sortorder="$PARAM[sortorder]" target="$PARAM[widget_target]" limit="15">$PARAM[content_path]</content>
+				<content sortby="$PARAM[sortby]" sortorder="$PARAM[sortorder]" target="$PARAM[widget_target]" limit="15" browse="$PARAM[browse_mode]">$PARAM[content_path]</content>
 			</control>
 		</definition>
 	</include>
@@ -154,6 +155,7 @@
 		<param name="visible">True</param>
 		<param name="sortorder">ascending</param>
 		<param name="widget_limit">15</param>
+		<param name="browse_mode">auto</param>
 		<definition>
 			<include content="CategoryLabel">
 				<param name="label">$PARAM[widget_header]</param>
@@ -204,7 +206,7 @@
 						</include>
 					</control>
 				</focusedlayout>
-				<content sortby="$PARAM[sortby]" sortorder="$PARAM[sortorder]" target="$PARAM[widget_target]" limit="$PARAM[widget_limit]">$PARAM[content_path]</content>
+				<content sortby="$PARAM[sortby]" sortorder="$PARAM[sortorder]" target="$PARAM[widget_target]" limit="$PARAM[widget_limit]" browse="$PARAM[browse_mode]">$PARAM[content_path]</content>
 			</control>
 		</definition>
 	</include>
@@ -216,6 +218,7 @@
 		<param name="widget_limit">15</param>
 		<param name="fallback_icon">DefaultAudio.png</param>
 		<param name="onclick_condition">false</param>
+		<param name="browse_mode">auto</param>
 		<definition>
 			<include content="CategoryLabel">
 				<param name="label">$PARAM[widget_header]</param>
@@ -267,7 +270,7 @@
 						</include>
 					</control>
 				</focusedlayout>
-				<content sortby="$PARAM[sortby]" sortorder="$PARAM[sortorder]" target="$PARAM[widget_target]" limit="$PARAM[widget_limit]">$PARAM[content_path]</content>
+				<content sortby="$PARAM[sortby]" sortorder="$PARAM[sortorder]" target="$PARAM[widget_target]" limit="$PARAM[widget_limit]" browse="$PARAM[browse_mode]">$PARAM[content_path]</content>
 			</control>
 		</definition>
 	</include>
@@ -278,6 +281,7 @@
 		<param name="additional_movie_items">false</param>
 		<param name="additional_tvshow_items">false</param>
 		<param name="visible">true</param>
+		<param name="browse">auto</param>
 		<definition>
 			<include content="CategoryLabel">
 				<param name="label">$PARAM[widget_header]</param>
@@ -374,7 +378,7 @@
 						</control>
 					</control>
 				</focusedlayout>
-				<content target="$PARAM[widget_target]" limit="$PARAM[item_limit]">$PARAM[content_path]</content>
+				<content target="$PARAM[widget_target]" limit="$PARAM[item_limit]" browse="$PARAM[browse_mode]">$PARAM[content_path]</content>
 				<include condition="$PARAM[additional_movie_items]" content="MovieSubmenuItems" />
 				<include condition="$PARAM[additional_tvshow_items]" content="TVShowSubmenuItems" />
 			</control>
@@ -412,6 +416,7 @@
 		<param name="label">$INFO[ListItem.Label]</param>
 		<param name="label2">$INFO[ListItem.Title]</param>
 		<param name="info_update">0</param>
+		<param name="browse_mode">auto</param>
 		<definition>
 			<include content="CategoryLabel">
 				<param name="label">$PARAM[widget_header]</param>
@@ -616,7 +621,7 @@
 						</control>
 					</control>
 				</focusedlayout>
-				<content sortby="$PARAM[sortby]" sortorder="$PARAM[sortorder]" target="$PARAM[widget_target]" limit="$PARAM[item_limit]">$PARAM[content_path]</content>
+				<content sortby="$PARAM[sortby]" sortorder="$PARAM[sortorder]" target="$PARAM[widget_target]" limit="$PARAM[item_limit]" browse="$PARAM[browse_mode]">$PARAM[content_path]</content>
 			</control>
 		</definition>
 	</include>

--- a/xbmc/listproviders/DirectoryProvider.h
+++ b/xbmc/listproviders/DirectoryProvider.h
@@ -50,6 +50,13 @@ public:
     DONE
   } UpdateState;
 
+  enum class BrowseMode
+  {
+    NEVER,
+    AUTO, // add browse item if list is longer than given limit
+    ALWAYS
+  };
+
   CDirectoryProvider(const TiXmlElement *element, int parentID);
   explicit CDirectoryProvider(const CDirectoryProvider& other);
   ~CDirectoryProvider() override;
@@ -80,10 +87,12 @@ private:
   KODI::GUILIB::GUIINFO::CGUIInfoLabel m_sortMethod;
   KODI::GUILIB::GUIINFO::CGUIInfoLabel m_sortOrder;
   KODI::GUILIB::GUIINFO::CGUIInfoLabel m_limit;
+  KODI::GUILIB::GUIINFO::CGUIInfoLabel m_browse;
   std::string      m_currentUrl;
   std::string      m_currentTarget;   ///< \brief node.target property on the list as a whole
   SortDescription  m_currentSort;
-  unsigned int m_currentLimit = 0;
+  unsigned int m_currentLimit{0};
+  BrowseMode m_currentBrowse{BrowseMode::AUTO};
   std::vector<CGUIStaticItemPtr> m_items;
   std::vector<InfoTagType> m_itemTypes;
   mutable CCriticalSection m_section;
@@ -91,6 +100,7 @@ private:
   bool UpdateURL();
   bool UpdateLimit();
   bool UpdateSort();
+  bool UpdateBrowse();
   void OnAddonEvent(const ADDON::AddonEvent& event);
   void OnAddonRepositoryEvent(const ADDON::CRepositoryUpdater::RepositoryUpdated& event);
   void OnPVRManagerEvent(const PVR::PVREvent& event);


### PR DESCRIPTION
… to give skinners the possibility to control the 'more' button for a list, as requested by @jurialmunkey. :-)

Presence of the "More..." button introduced by #23682 now can be controlled via the new attribute `browse` for the `content` tag when filling containers of type "list", "wraplist", "panel" with dynamic content. 

Values:
* `always` : add the button item, if list contains at least one item
* `auto`: add the button item, if the list as provided by the core actually has more items than specified by attribute "limit"
* `never`: never add the button

Default: `auto`

Example:
```xml
<content sortby="date" sortorder="ascending" target="videos" limit="15" browse="auto">special://skin/playlists/inprogress_movies.xsp</content>
```

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 I hope this one is straight forward to review.

I will update the Skinning Manual (https://kodi.wiki/view/Skinning_Manual#List_Container ff.) once this PR is approved for merge.