### PR TITLE
[webOS] RendererStarfish: Derive from CBaseRenderer

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererStarfish.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererStarfish.cpp
@@ -37,7 +37,34 @@ bool CRendererStarfish::Configure(const VideoPicture& picture, float fps, unsign
              GetFlagsColorPrimaries(picture.color_primaries) |
              GetFlagsStereoMode(picture.stereoMode);
 
-  return CLinuxRendererGLES::Configure(picture, fps, orientation);
+  m_format = picture.videoBuffer->GetFormat();
+  m_sourceWidth = picture.iWidth;
+  m_sourceHeight = picture.iHeight;
+  m_renderOrientation = orientation;
+
+  // Calculate the input frame aspect ratio.
+  CalculateFrameAspectRatio(picture.iDisplayWidth, picture.iDisplayHeight);
+  SetViewMode(m_videoSettings.m_ViewMode);
+  ManageRenderArea();
+
+  m_configured = true;
+
+  return true;
+}
+
+bool CRendererStarfish::IsConfigured()
+{
+  return m_configured;
+}
+
+bool CRendererStarfish::ConfigChanged(const VideoPicture& picture)
+{
+  if (picture.videoBuffer->GetFormat() != m_format)
+  {
+    return true;
+  }
+
+  return false;
 }
 
 bool CRendererStarfish::Register()
@@ -71,6 +98,16 @@ bool CRendererStarfish::Supports(ERENDERFEATURE feature) const
           feature == RENDERFEATURE_ROTATION);
 }
 
+bool CRendererStarfish::Supports(ESCALINGMETHOD method) const
+{
+  return false;
+}
+
+bool CRendererStarfish::SupportsMultiPassRendering()
+{
+  return false;
+}
+
 void CRendererStarfish::AddVideoPicture(const VideoPicture& picture, int index)
 {
 }
@@ -86,35 +123,36 @@ CRenderInfo CRendererStarfish::GetRenderInfo()
   return info;
 }
 
-bool CRendererStarfish::LoadShadersHook()
-{
-  return true;
-}
-
-bool CRendererStarfish::RenderHook(int index)
-{
-  return true;
-}
-
-bool CRendererStarfish::CreateTexture(int index)
-{
-  return true;
-}
-
-void CRendererStarfish::DeleteTexture(int index)
-{
-}
-
-bool CRendererStarfish::UploadTexture(int index)
-{
-  return true;
-}
-
 bool CRendererStarfish::IsGuiLayer()
 {
   return false;
 }
 
-void CRendererStarfish::RenderUpdateVideo(bool clear, unsigned int flags, unsigned int alpha)
+bool CRendererStarfish::RenderCapture(CRenderCapture* capture)
 {
+  return false;
+}
+
+void CRendererStarfish::UnInit()
+{
+  m_configured = false;
+}
+
+void CRendererStarfish::Update()
+{
+  if (!m_configured)
+  {
+    return;
+  }
+
+  ManageRenderArea();
+}
+
+void CRendererStarfish::RenderUpdate(
+    int index, int index2, bool clear, unsigned int flags, unsigned int alpha)
+{
+  if (!m_configured)
+  {
+    return;
+  }
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererStarfish.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererStarfish.h
@@ -10,7 +10,7 @@
 
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h"
 
-class CRendererStarfish : public CLinuxRendererGLES
+class CRendererStarfish : public CBaseRenderer
 {
 public:
   CRendererStarfish();
@@ -28,22 +28,24 @@ public:
   CRenderInfo GetRenderInfo() override;
 
   bool IsGuiLayer() override;
+  bool IsConfigured() override;
   bool Configure(const VideoPicture& picture, float fps, unsigned int orientation) override;
   bool Supports(ERENDERFEATURE feature) const override;
+  bool Supports(ESCALINGMETHOD method) const override;
+  bool SupportsMultiPassRendering() override;
+  void UnInit() override;
+  void Update() override;
+  void RenderUpdate(
+      int index, int index2, bool clear, unsigned int flags, unsigned int alpha) override;
+  bool RenderCapture(CRenderCapture* capture) override;
+  bool ConfigChanged(const VideoPicture& picture) override;
 
 protected:
-  // textures
-  bool UploadTexture(int index) override;
-  void RenderUpdateVideo(bool clear, unsigned int flags, unsigned int alpha) override;
-  void DeleteTexture(int index) override;
-  bool CreateTexture(int index) override;
-
   // hooks for hw dec renderer
-  bool LoadShadersHook() override;
-  bool RenderHook(int index) override;
   void ManageRenderArea() override;
 
 private:
   CRect m_exportedSourceRect;
   CRect m_exportedDestRect;
+  bool m_configured{false};
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The starfish video renderer is not based on GLES at all. The only reason for deriving from the GLES renderer was the setup of the render area. Rendering of the video is done automatically by the pipeline and all it needs is the region the video should be rendered to.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This should make the class hierachy more clear and also save on some CPU cycles and memory.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
webOS 7/22

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
