### PR TITLE
Fix cmake failing on systems with older cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
-if(WIN32)
-  # Version 3.20 is required for multi-config generator expressions to work
-  cmake_minimum_required(VERSION 3.20)
-endif()
+cmake_minimum_required(VERSION 3.20)
 project(kodi LANGUAGES CXX C ASM)
 
 if(POLICY CMP0069)


### PR DESCRIPTION
CMake 3.20 appears to be  the minimum requirement for multi-config generator expressions in general, not only on windows.

Building on Ubuntu 20.04 for example fails with following error: CMake Error at CMakeLists.txt:437 (add_custom_command):
  add_custom_command called with OUTPUT containing a "<".  This character is
  not allowed.

This error happens with at least 3.16-3.19 and is fixed when switching to 3.20.

## How has this been tested?
Tested on my Ubuntu 20.04 build machine.

## What is the effect on users?
Require minimum version instead of failing with a weird error.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
