### PR TITLE
[webOS] Tune for Cortex-A53

### DIFF
--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -368,7 +368,7 @@ case $host in
       use_cpu="armeabi-v7a"
     fi
     use_toolchain="${use_toolchain:-/usr}"
-    platform_cflags="-fPIC -DPIC -march=armv7-a -mtune=cortex-a9 -mfloat-abi=softfp -mfpu=neon"
+    platform_cflags="-fPIC -DPIC -mcpu=cortex-a9 -mtune=cortex-a53 -mfloat-abi=softfp"
     platform_cxxflags="$platform_cflags -static-libstdc++"
     optimize_flags="-Os"
     platform_ldflags="-Wl,-rpath-link=$prefix/$deps_dir/lib"


### PR DESCRIPTION
## Description
This commit changes the architecture CFLAGS on webOS from `-march=armv7-a -mtune=cortex-a9 -mfpu=neon` to `-mcpu=cortex-a9 -mtune=cortex-a53` (`-mcpu=cortex-a9` implies `-mfpu=neon-fp16`). This maintains compatibility with all webOS TVs while optimizing for a newer and more common core.

## Motivation and context
The oldest webOS TVs have Cortex-A9 CPUs. However, Kodi has not been tested on webOS versions older than 3.0 (2016), and I'd be surprised if it runs at all. Therefore I think it makes sense to optimize for a newer CPU. TVs from a few years ago tend to have Cortex-A53 or A55 cores, while the most recent high-end models have Cortex-A73, A75, or A76. I am aware of only one webOS 3.0 SoC with an A9 core (MStar M2), and it was used in the very lowest-end 2016 models (FHD only) that would probably struggle to run Kodi anyway.

I believe GCC can optimize for A53 specifically, as it has a [Cortex-A53 md file](https://github.com/gcc-mirror/gcc/blob/aeee4812442c996f184965ce6894e5f3d3657c0f/gcc/config/arm/cortex-a53.md). I'm honestly not sure how this will affect performance on other cores, especially since A53/A55 do not support out-of-order execution while several others (e.g. A73, A76) do. LG and its SoC vendors have used a fairly wide variety of Cortex-A cores. For example, LG OLEDs since 2018 have gone from A73 to A55 to A76. Some benchmarking would probably be useful, but I'm not sure how to go about that.

## How has this been tested?
Planning to test the CI build. I have access to a wide variety of webOS dev boards and a couple TVs.

I have done pretty extensive tests of the GCC ARM architecture options, and I believe these ones will enable the relevant instructions/features that are common to all webOS TVs.

## What is the effect on users?
Hopefully this will improve performance on webOS.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
