### PR TITLE
[cmake] add_custom_command only use OUTPUT genex for multi config generators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -433,20 +433,27 @@ add_custom_target(gen_system_addons
                                              -P ${CMAKE_SOURCE_DIR}/cmake/scripts/common/GenerateSystemAddons.cmake
                     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
+if(_multiconfig_generator)
+  # Generator expressions in add_custom_command(OUTPUT) are only available in cmake 3.20+
+  # we dont really need config aware locations for a single config generator, so we only
+  # set this for multi config generators who all use newer cmake
+  set(CONFIG_VAR $<CONFIG>)
+endif()
+
 # Pack skins and copy to correct build dir (MultiConfig Generator aware)
 add_custom_command(
-  OUTPUT ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/$<CONFIG>/gen_skin.timestamp
+  OUTPUT ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/${CONFIG_VAR}/gen_skin.timestamp
   COMMAND ${CMAKE_COMMAND} -DBUNDLEDIR=${_bundle_dir}
                            -DTEXTUREPACKER_EXECUTABLE=$<TARGET_FILE:TexturePacker::TexturePacker::Executable>
                            -P ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/GeneratedPackSkins.cmake
-  COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/$<CONFIG>
-  COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/$<CONFIG>/gen_skin.timestamp
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/${CONFIG_VAR}
+  COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/${CONFIG_VAR}/gen_skin.timestamp
   DEPENDS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/GeneratedPackSkins.cmake
           ${XBT_SOURCE_FILELIST}
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   COMMENT "Generating skin xbt"
 )
-add_custom_target(gen_skin_pack DEPENDS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/$<CONFIG>/gen_skin.timestamp)
+add_custom_target(gen_skin_pack DEPENDS ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/${CONFIG_VAR}/gen_skin.timestamp)
 
 # Packaging target. This generates system addon, xbt creation, copy files to build tree
 add_custom_target(generate-packaging ALL


### PR DESCRIPTION
## Description
Fix using cmake < 3.20. Tested against cmake 3.18.3

## Motivation and context
@a1rwulf raised an issue building with Ubuntu 20.04 that had cmake 3.18.3.
This means we dont need to actively bump minimum cmake project version to 3.20, however i do wonder if we should bump to 3.18 as a minimum. Ive no idea if 3.12 still functions, and i dont really care to test that far back.

## How has this been tested?
Build macos aarch64 cmake 3.18.3 makefile
Build macos aarch64 cmake 3.26.4 Xcode

gen_skin.timestamp is in the expected location.

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
