### PR TITLE
[Cmake] FindASS migrate to TARGET usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,7 @@ core_optional_dep(${optional_buildtools})
 core_require_dep(${required_buildtools})
 
 # Required dependencies. Keep in alphabetical order please
-set(required_deps ASS
+set(required_deps ASS>=0.15.0
                   Cdio
                   CrossGUID
                   Curl

--- a/tools/depends/target/Toolchain.cmake.in
+++ b/tools/depends/target/Toolchain.cmake.in
@@ -81,12 +81,17 @@ endif()
 # where is the target environment
 set(CMAKE_FIND_ROOT_PATH @prefix@/@deps_dir@)
 set(CMAKE_LIBRARY_PATH @prefix@/@deps_dir@/lib)
-if(NOT "@use_toolchain@" STREQUAL "")
-  list(APPEND CMAKE_FIND_ROOT_PATH @use_toolchain@ @use_toolchain@/@use_host@ @use_toolchain@/@use_host@/sysroot @use_toolchain@/@use_host@/sysroot/usr @use_toolchain@/@use_host@/libc @use_toolchain@/lib/@use_host@/sysroot @use_toolchain@/usr @use_toolchain@/sysroot/usr)
-  set(CMAKE_LIBRARY_PATH "${CMAKE_LIBRARY_PATH}:@use_toolchain@/usr/lib/@use_host@:@use_toolchain@/lib/@use_host@")
-endif()
 if(NOT "@use_sdk_path@" STREQUAL "")
   list(APPEND CMAKE_FIND_ROOT_PATH @use_sdk_path@ @use_sdk_path@/usr)
+endif()
+# Currently this is only set to reject android by default
+if(NOT "@use_toolchain@" STREQUAL "")
+  list(APPEND CMAKE_FIND_ROOT_PATH @use_toolchain@/@use_host@ @use_toolchain@/@use_host@/sysroot @use_toolchain@/@use_host@/sysroot/usr @use_toolchain@/@use_host@/libc @use_toolchain@/lib/@use_host@/sysroot @use_toolchain@/usr @use_toolchain@/sysroot/usr)
+  # Explicitly set this as last. This potentially is /usr which can then cause linux
+  # cross compilation to search paths that are not relevant to target arch (eg host libs)
+  # x86/x86_64 jenkins CI jobs require /usr for libs like iconv
+  list(APPEND CMAKE_FIND_ROOT_PATH @use_toolchain@)
+  set(CMAKE_LIBRARY_PATH "${CMAKE_LIBRARY_PATH}:@use_toolchain@/usr/lib/@use_host@:@use_toolchain@/lib/@use_host@")
 endif()
 
 # add Android directories and tools


### PR DESCRIPTION
## Description
Migrates FindASS to full TARGET usage. Also add version requirement specification to ASS required_deps

## Motivation and context
Migrate to more modern cmake. Accurately enforce minimum version of lib
@a1rwulf this should now correctly error out on incorrect version of libass before compilation failure.

## How has this been tested?
Build macos aarch64
Build win x64

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
