### PR TITLE
Fix build of native/waylandpp-scanner with GCC 13

### DIFF
--- a/tools/depends/native/waylandpp-scanner/001-fix-gcc13-build.patch
+++ b/tools/depends/native/waylandpp-scanner/001-fix-gcc13-build.patch
@@ -1,0 +1,28 @@
+--- a/include/wayland-client.hpp
++++ b/include/wayland-client.hpp
+@@ -33,6 +33,7 @@
+ #include <memory>
+ #include <string>
+ #include <vector>
++#include <cstdint>
+ #include <wayland-version.hpp>
+ #include <wayland-client-core.h>
+ #include <wayland-util.hpp>
+
+--- a/scanner/scanner.cpp
++++ b/scanner/scanner.cpp
+@@ -24,6 +24,7 @@
+ #include <cctype>
+ #include <cmath>
+ #include <stdexcept>
++#include <cstdint>
+
+ #include "pugixml.hpp"
+
+@@ -928,6 +929,7 @@
+               << "#include <memory>" << std::endl
+               << "#include <string>" << std::endl
+               << "#include <vector>" << std::endl
++              << "#include <cstdint>" << std::endl
+               << std::endl
+               << "#include <wayland-client.hpp>" << std::endl;

--- a/tools/depends/native/waylandpp-scanner/Makefile
+++ b/tools/depends/native/waylandpp-scanner/Makefile
@@ -1,7 +1,7 @@
 include ../../Makefile.include
 PREFIX=$(NATIVEPREFIX)
 PLATFORM=$(NATIVEPLATFORM)
-DEPS =../../Makefile.include Makefile ../../download-files.include
+DEPS =../../Makefile.include Makefile ../../download-files.include 001-fix-gcc13-build.patch
 
 # lib name, version
 LIBNAME=waylandpp
@@ -27,6 +27,7 @@ all: .installed-$(PLATFORM)
 $(PLATFORM): $(DEPS) | $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE)
 	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); patch -p1 -i ../001-fix-gcc13-build.patch
 	mkdir -p $(BUILDDIR)
 	cd $(BUILDDIR); $(NATIVEPREFIX)/bin/cmake $(CMAKE_OPTIONS) ..
 


### PR DESCRIPTION
## Description
This adds a patch for `tools/depends/native/waylandpp-scanner` to explicitly include `<cstdint>` where required to build with GCC 13. The patch was copied from `tools/depends/target/waylandpp` (#23239).

## Motivation and context
When using a GCC 13-based native toolchain, `native/waylandpp-scanner` fails to build because of ["header dependency changes"](https://gcc.gnu.org/gcc-13/porting_to.html) in GCC 13. Specifically, it seems that Wayland++ was relying on `<string>`  transitively including `<cstdint>`, which it no longer does. This is exactly the same issue that was resolved for `target/waylandpp` in #23239 (commit a7db7ad).

## How has this been tested?
Successfully built all dependencies (targeting webOS) with GCC 13.2 on Debian unstable (x86-64, WSL2).

## What is the effect on users?
Before, it didn't build. Now, it builds.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed