### PR TITLE
[tools/depends][native] gettext force am_cv_func_iconv_works for apple host

### DIFF
--- a/tools/depends/native/gettext/Makefile
+++ b/tools/depends/native/gettext/Makefile
@@ -22,6 +22,14 @@ CONFIGURE=./configure --prefix=$(PREFIX) \
     --without-git --without-cvs \
     --disable-shared --disable-curses --disable-acl --disable-c++ --disable-nls
 
+ifeq ($(NATIVE_OS), osx)
+  # As per homebrew - https://github.com/Homebrew/homebrew-core/blob/f6df737d9479dd215185000a3dbd641185eafec2/Formula/g/gettext.rb#L52C1-L55
+  # Sonoma iconv() has a regression w.r.t. transliteration, which happens to
+  # break gettext's configure check. Force it.
+  # Reported to Apple as FB13163914
+  CONFIGURE+= am_cv_func_iconv_works=y
+endif
+
 LIBDYLIB=$(PLATFORM)/gettext-tools/src/.libs/libgettextsrc.a
 
 all: .installed-$(PLATFORM)


### PR DESCRIPTION
## Description
MacOS Sonoma (14.0) has a change in iconv that the gettext configure script fails when testing if iconv works. We just force it on.

## Motivation and context
This fixes building native dependencies on MacOS Sonoma

## How has this been tested?
Build full macos aarch64 dependencies

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
