### PR TITLE
[upnp] Fix smart playlist folder definitions

### DIFF
--- a/xbmc/playlists/PlayListFactory.cpp
+++ b/xbmc/playlists/PlayListFactory.cpp
@@ -134,12 +134,12 @@ bool CPlayListFactory::IsPlaylist(const CFileItem& item)
 bool CPlayListFactory::IsPlaylist(const CURL& url)
 {
   return URIUtils::HasExtension(url,
-                                ".m3u|.m3u8|.b4s|.pls|.strm|.wpl|.asx|.ram|.url|.pxml|.xspf");
+                                ".m3u|.m3u8|.b4s|.pls|.strm|.wpl|.asx|.ram|.url|.pxml|.xspf|.xsp");
 }
 
 bool CPlayListFactory::IsPlaylist(const std::string& filename)
 {
   return URIUtils::HasExtension(filename,
-                     ".m3u|.m3u8|.b4s|.pls|.strm|.wpl|.asx|.ram|.url|.pxml|.xspf");
+                                ".m3u|.m3u8|.b4s|.pls|.strm|.wpl|.asx|.ram|.url|.pxml|.xspf|.xsp");
 }
 


### PR DESCRIPTION
## Description
xsp extensions (our format for smartplaylists) is missing from the `IsPlaylist` check which leads the upnp code to return them as fileitems instead of containers, see affected code below:

https://github.com/xbmc/xbmc/blob/master/xbmc/network/upnp/UPnPServer.cpp#L411-L415

Unsure if this creates regressions elsewhere but the fix is technically correct. So, I'm here to run after possible ones.

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/23819

## How has this been tested?
With VLC using the methodology specified on the issue report

## What is the effect on users?
Smart playlists should now be listed and browsable via UPnP

## Screenshots (if appropriate):

![image](https://github.com/xbmc/xbmc/assets/7375276/8706c7f6-aef2-4f04-bb29-561b1b6c86db)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

