### PR TITLE
[webOS] Acb (webOS 4.x) support

### DIFF
--- a/cmake/modules/FindAcbAPI.cmake
+++ b/cmake/modules/FindAcbAPI.cmake
@@ -1,0 +1,37 @@
+#.rst:
+# FindAcbAPI
+# --------
+# Finds the AcbAPI library
+#
+# This will define the following target:
+#
+#   ACBAPI::ACBAPI   - The acbAPI library
+
+if(NOT TARGET ACBAPI::ACBAPI)
+  find_package(PkgConfig)
+  if(PKG_CONFIG_FOUND)
+    pkg_check_modules(PC_ACBAPI libAcbAPI QUIET)
+  endif()
+
+  find_path(ACBAPI_INCLUDE_DIR NAMES appswitching-control-block/AcbAPI.h
+                                   PATHS ${PC_ACBAPI_INCLUDEDIR}
+                                   NO_CACHE)
+  find_library(ACBAPI_LIBRARY NAMES AcbAPI
+                                  PATHS ${PC_ACBAPI_LIBDIR}
+                                  NO_CACHE)
+
+  set(ACBAPI_VERSION ${PC_ACBAPI_VERSION})
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(AcbAPI
+                                    REQUIRED_VARS ACBAPI_LIBRARY ACBAPI_INCLUDE_DIR
+                                    VERSION_VAR ACBAPI_VERSION)
+
+  if(ACBAPI_FOUND)
+    add_library(ACBAPI::ACBAPI UNKNOWN IMPORTED)
+    set_target_properties(ACBAPI::ACBAPI PROPERTIES
+                                                 IMPORTED_LOCATION "${ACBAPI_LIBRARY}"
+                                                 INTERFACE_INCLUDE_DIRECTORIES "${ACBAPI_INCLUDE_DIR}")
+    set_property(GLOBAL APPEND PROPERTY INTERNAL_DEPS_PROP ACBAPI::ACBAPI)
+  endif()
+endif()

--- a/cmake/platform/linux/webos.cmake
+++ b/cmake/platform/linux/webos.cmake
@@ -4,7 +4,7 @@ include(${CMAKE_SOURCE_DIR}/cmake/platform/${CORE_SYSTEM_NAME}/wayland.cmake)
 # saves reworking other assumptions for linux windowing as the platform name.
 list(APPEND CORE_PLATFORM_NAME_LC wayland)
 
-list(APPEND PLATFORM_REQUIRED_DEPS WaylandProtocolsWebOS PlayerAPIs PlayerFactory WebOSHelpers)
+list(APPEND PLATFORM_REQUIRED_DEPS WaylandProtocolsWebOS PlayerAPIs PlayerFactory WebOSHelpers AcbAPI)
 list(APPEND ARCH_DEFINES -DTARGET_WEBOS)
 set(ENABLE_PULSEAUDIO OFF CACHE BOOL "" FORCE)
 set(TARGET_WEBOS TRUE)

--- a/cmake/scripts/webos/Install.cmake
+++ b/cmake/scripts/webos/Install.cmake
@@ -29,7 +29,8 @@ set(APP_INSTALL_DIRS ${CMAKE_BINARY_DIR}/addons
                      ${CMAKE_BINARY_DIR}/system
                      ${CMAKE_BINARY_DIR}/userdata)
 set(APP_TOOLCHAIN_FILES ${TOOLCHAIN}/${HOST}/sysroot/lib/libatomic.so.1
-                        ${TOOLCHAIN}/${HOST}/sysroot/lib/libcrypt.so.1)
+                        ${TOOLCHAIN}/${HOST}/sysroot/lib/libcrypt.so.1
+                        ${DEPENDS_PATH}/lib/libAcbAPI.so.1)
 set(BIN_ADDONS_DIR ${DEPENDS_PATH}/addons)
 
 file(WRITE ${CMAKE_BINARY_DIR}/install.cmake "

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecStarfish.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecStarfish.h
@@ -25,6 +25,7 @@ class CStarfishVideoBuffer : public CVideoBuffer
 public:
   explicit CStarfishVideoBuffer(int id) : CVideoBuffer(id) {}
   AVPixelFormat GetFormat() override { return AV_PIX_FMT_NONE; }
+  long m_acbId{0};
 };
 
 enum class StarfishState
@@ -95,7 +96,10 @@ private:
                              const int64_t numValue,
                              const char* strValue,
                              void* data);
+  static void AcbCallback(
+      long acbId, long taskId, long eventType, long appState, long playState, const char* reply);
   std::unique_ptr<StarfishMediaAPIs> m_starfishMediaAPI;
+  long m_acbId{0};
 
   CDVDStreamInfo m_hints;
   std::string m_codecname;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
@@ -218,7 +218,8 @@ void CBaseRenderer::CalcNormalRenderRect(float offsetX,
     return;
 
   // clip as needed
-  if (!(CServiceBroker::GetWinSystem()->GetGfxContext().IsFullScreenVideo() || CServiceBroker::GetWinSystem()->GetGfxContext().IsCalibrating()))
+  if (m_alwaysClip || !(CServiceBroker::GetWinSystem()->GetGfxContext().IsFullScreenVideo() ||
+                        CServiceBroker::GetWinSystem()->GetGfxContext().IsCalibrating()))
   {
     CRect original(m_destRect);
     m_destRect.Intersect(CRect(offsetX, offsetY, offsetX + width, offsetY + height));
@@ -499,6 +500,11 @@ void CBaseRenderer::SetViewMode(int viewMode)
 void CBaseRenderer::MarkDirty()
 {
   CServiceBroker::GetGUI()->GetWindowManager().MarkDirty(m_destRect);
+}
+
+void CBaseRenderer::EnableAlwaysClip()
+{
+  m_alwaysClip = true;
 }
 
 void CBaseRenderer::SetVideoSettings(const CVideoSettings &settings)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
@@ -114,6 +114,7 @@ protected:
   virtual void ReorderDrawPoints();
   virtual EShaderFormat GetShaderFormat();
   void MarkDirty();
+  void EnableAlwaysClip();
 
   //@todo drop those
   void saveRotatedCoords();//saves the current state of m_rotatedDestCoords
@@ -141,4 +142,7 @@ protected:
   AVPixelFormat m_format = AV_PIX_FMT_NONE;
 
   CVideoSettings m_videoSettings;
+
+private:
+  bool m_alwaysClip = false;
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererStarfish.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererStarfish.h
@@ -48,4 +48,5 @@ private:
   CRect m_exportedSourceRect;
   CRect m_exportedDestRect;
   bool m_configured{false};
+  long m_acbId{0};
 };

--- a/xbmc/windowing/wayland/WinSystemWaylandWebOS.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandWebOS.cpp
@@ -127,6 +127,11 @@ bool CWinSystemWaylandWebOS::SetExportedWindow(CRect orig, CRect src, CRect dest
   return false;
 }
 
+bool CWinSystemWaylandWebOS::SupportsExportedWindow()
+{
+  return m_webosForeign;
+}
+
 IShellSurface* CWinSystemWaylandWebOS::CreateShellSurface(const std::string& name)
 {
   return new CShellSurfaceWebOSShell(*this, *GetConnection(), GetMainSurface(), name,

--- a/xbmc/windowing/wayland/WinSystemWaylandWebOS.h
+++ b/xbmc/windowing/wayland/WinSystemWaylandWebOS.h
@@ -40,6 +40,8 @@ public:
    */
   bool SetExportedWindow(CRect orig, CRect src, CRect dest);
 
+  bool SupportsExportedWindow();
+
   IShellSurface* CreateShellSurface(const std::string& name) override;
   bool CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res) override;
   ~CWinSystemWaylandWebOS() noexcept override;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
On webOS 4.0, MediaPlayerAPIs has to be used with AcbAPI instead of exported window. This PR adds feature to use that when  exported window feature is not available.

## Motivation and context
To make Kodi support webOS 4.x

## How has this been tested?
Compiled app has been tested on webOS 5 TV and webOS 4 TV, both can perform video playback without issue.

## What is the effect on users?
webOS 4 users can now play videos

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
