### PR TITLE
[db][streamdetails] Reintroduce external subtitles into streamdetails

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDFileInfo.h
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.h
@@ -54,4 +54,10 @@ private:
   *   \param[out] details The external subtitle file's StreamDetails.
   */
   static bool AddExternalSubtitleToDetails(const std::string &path, CStreamDetails &details, const std::string& filename, const std::string& subfilename = "");
+
+  /** \brief Checks external subtitles for a giving item and adds any existing to the item stream details
+  *   \param item The video item
+  *   \sa AddExternalSubtitleToDetails
+  */
+  static void ProcessExternalSubtitles(CFileItem* item);
 };


### PR DESCRIPTION
## Description
Currently, Kodi does not save the subtitle language for external subtitles into streamdetails. I believe this was inadvertently removed by @rmrector in https://github.com/xbmc/xbmc/pull/23134
The above PR has the benefit of removing the dependency of external subtitles on thumb generation but the affected code was just removed without any alternative.
This creates a new method to process the subtitles and includes them in the streamdetails extraction logic. 

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/23763

## How has this been tested?
Runtime tested on linux, checking the streamdetails table now have the external subtitle files too

## What is the effect on users?
Should fix smartplaylists et al that depend on subtitle language

## Screenshots (if appropriate):

![image](https://github.com/xbmc/xbmc/assets/7375276/78cbe4fb-47fb-4890-8b3f-4e4c400ea09c)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

