### PR TITLE
[edl] Allow EDL files on private subnets for network shares rather than the one the Kodi host in on

### DIFF
--- a/xbmc/addons/interfaces/Network.cpp
+++ b/xbmc/addons/interfaces/Network.cpp
@@ -140,7 +140,9 @@ bool Interface_Network::is_host_on_lan(void* kodiBase, const char* hostname, boo
     return false;
   }
 
-  return URIUtils::IsHostOnLAN(hostname, offLineCheck);
+  //! TODO change to use the LanCheckMode enum class on the API signature
+  return URIUtils::IsHostOnLAN(hostname, offLineCheck ? LanCheckMode::ANY_PRIVATE_SUBNET
+                                                      : LanCheckMode::ONLY_LOCAL_SUBNET);
 }
 
 char* Interface_Network::dns_lookup(void* kodiBase, const char* url, bool* ret)

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -49,10 +49,10 @@ bool CEdl::ReadEditDecisionLists(const CFileItem& fileItem, const float fFramesP
 
   /*
    * Only check for edit decision lists if the movie is on the local hard drive, or accessed over a
-   * network share.
+   * network share (even if from a different private network).
    */
   const std::string& strMovie = fileItem.GetDynPath();
-  if ((URIUtils::IsHD(strMovie) || URIUtils::IsOnLAN(strMovie)) &&
+  if ((URIUtils::IsHD(strMovie) || URIUtils::IsOnLAN(strMovie, LanCheckMode::ANY_PRIVATE_SUBNET)) &&
       !URIUtils::IsInternetStream(strMovie))
   {
     CLog::Log(LOGDEBUG,

--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -640,7 +640,7 @@ void CWakeOnAccess::QueueMACDiscoveryForHost(const std::string& host)
 {
   if (IsEnabled())
   {
-    if (URIUtils::IsHostOnLAN(host, true))
+    if (URIUtils::IsHostOnLAN(host, LanCheckMode::ANY_PRIVATE_SUBNET))
       CServiceBroker::GetJobManager()->AddJob(new CMACDiscoveryJob(host), this);
     else
       CLog::Log(LOGINFO, "{} - skip Mac discovery for non-local host '{}'", __FUNCTION__, host);

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -1130,8 +1130,8 @@ struct ResourcePrioritySort
         prio += 400;
 
     NPT_Url url(res.m_Uri);
-    if (URIUtils::IsHostOnLAN((const char*)url.GetHost(), false))
-        prio += 300;
+    if (URIUtils::IsHostOnLAN(url.GetHost().GetChars(), LanCheckMode::ONLY_LOCAL_SUBNET))
+      prio += 300;
 
     if (res.m_ProtocolInfo.GetProtocol() == "xbmc-get")
         prio += 200;

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -639,16 +639,16 @@ bool URIUtils::IsOnDVD(const std::string& strFile)
   return false;
 }
 
-bool URIUtils::IsOnLAN(const std::string& strPath)
+bool URIUtils::IsOnLAN(const std::string& strPath, LanCheckMode lanCheckMode)
 {
   if(IsMultiPath(strPath))
-    return IsOnLAN(CMultiPathDirectory::GetFirstPath(strPath));
+    return IsOnLAN(CMultiPathDirectory::GetFirstPath(strPath), lanCheckMode);
 
   if(IsStack(strPath))
-    return IsOnLAN(CStackDirectory::GetFirstStackedFile(strPath));
+    return IsOnLAN(CStackDirectory::GetFirstStackedFile(strPath), lanCheckMode);
 
   if(IsSpecial(strPath))
-    return IsOnLAN(CSpecialProtocol::TranslatePath(strPath));
+    return IsOnLAN(CSpecialProtocol::TranslatePath(strPath), lanCheckMode);
 
   if(IsPlugin(strPath))
     return false;
@@ -658,14 +658,14 @@ bool URIUtils::IsOnLAN(const std::string& strPath)
 
   CURL url(strPath);
   if (HasParentInHostname(url))
-    return IsOnLAN(url.GetHostName());
+    return IsOnLAN(url.GetHostName(), lanCheckMode);
 
   if(!IsRemote(strPath))
     return false;
 
   const std::string& host = url.GetHostName();
 
-  return IsHostOnLAN(host);
+  return IsHostOnLAN(host, lanCheckMode);
 }
 
 static bool addr_match(uint32_t addr, const char* target, const char* submask)

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -675,7 +675,7 @@ static bool addr_match(uint32_t addr, const char* target, const char* submask)
   return (addr & mask) == (addr2 & mask);
 }
 
-bool URIUtils::IsHostOnLAN(const std::string& host, bool offLineCheck)
+bool URIUtils::IsHostOnLAN(const std::string& host, LanCheckMode lanCheckMode)
 {
   if(host.length() == 0)
     return false;
@@ -695,7 +695,9 @@ bool URIUtils::IsHostOnLAN(const std::string& host, bool offLineCheck)
 
   if(address != INADDR_NONE)
   {
-    if (offLineCheck) // check if in private range, ref https://en.wikipedia.org/wiki/Private_network
+    if (lanCheckMode ==
+        LanCheckMode::
+            ANY_PRIVATE_SUBNET) // check if in private range, ref https://en.wikipedia.org/wiki/Private_network
     {
       if (
         addr_match(address, "192.168.0.0", "255.255.0.0") ||

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -15,6 +15,17 @@ class CURL;
 class CAdvancedSettings;
 class CFileItem;
 
+/*! \brief Defines the methodology to find hosts on a given subnet 
+    \sa IsHostOnLAN
+*/
+enum class LanCheckMode
+{
+  /*! \brief Only match if the host is on the same subnet as the kodi host */
+  ONLY_LOCAL_SUBNET,
+  /*! \brief Match the host if it belongs to any private subnet */
+  ANY_PRIVATE_SUBNET
+};
+
 class URIUtils
 {
 public:
@@ -147,7 +158,8 @@ public:
   static bool IsNfs(const std::string& strFile);
   static bool IsOnDVD(const std::string& strFile);
   static bool IsOnLAN(const std::string& strFile);
-  static bool IsHostOnLAN(const std::string& hostName, bool offLineCheck = false);
+  static bool IsHostOnLAN(const std::string& hostName,
+                          LanCheckMode lanCheckMode = LanCheckMode::ONLY_LOCAL_SUBNET);
   static bool IsPlugin(const std::string& strFile);
   static bool IsScript(const std::string& strFile);
   static bool IsRAR(const std::string& strFile);

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -157,7 +157,8 @@ public:
   static bool IsMusicDb(const std::string& strFile);
   static bool IsNfs(const std::string& strFile);
   static bool IsOnDVD(const std::string& strFile);
-  static bool IsOnLAN(const std::string& strFile);
+  static bool IsOnLAN(const std::string& strFile,
+                      LanCheckMode lanCheckMode = LanCheckMode::ONLY_LOCAL_SUBNET);
   static bool IsHostOnLAN(const std::string& hostName,
                           LanCheckMode lanCheckMode = LanCheckMode::ONLY_LOCAL_SUBNET);
   static bool IsPlugin(const std::string& strFile);


### PR DESCRIPTION
## Description
This seems like a low-hanging fruit and the request actually makes sense (since I also have a specific subnet for my lan share). Currently Kodi only processes the EDL files if the share is on the same subnet as the Kodi host. However you can simply have multiple routers in your network and the actual share can be behind one of those routers without implicitly meaning it's accessible via the internet. So we can simply consider the check as long as the share is within a private network range.

## Motivation and context
Closes https://github.com/xbmc/xbmc/issues/23651 

## How has this been tested?
On linux with mplayer edl

## What is the effect on users?
EDL should now be taken into account if the media is being played from a share belonging to a private network range

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
