### PR TITLE
Build curl without libpsl dependency

### DIFF
--- a/tools/depends/target/curl/Makefile
+++ b/tools/depends/target/curl/Makefile
@@ -5,7 +5,8 @@ DEPS = ../../Makefile.include Makefile CURL-VERSION ../../download-files.include
 CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
           ./configure --prefix=$(PREFIX) --disable-shared --disable-ldap \
           --without-libssh2 --disable-ntlm-wb --enable-ipv6 --without-librtmp \
-          --without-libidn2 --with-ca-fallback --with-ssl=$(PREFIX) --with-nghttp2=$(PREFIX)
+          --without-libidn2 --with-ca-fallback --with-ssl=$(PREFIX) \
+          --with-nghttp2=$(PREFIX) --without-libpsl
 
 LIBDYLIB=$(PLATFORM)/lib/.libs/$(BYPRODUCT)
 


### PR DESCRIPTION
## Description
Add `--without-libpsl` to curl's `configure` flags. This prevents the resulting libcurl from depending on libpsl, which is not present on webOS.

## Motivation and context
This change prevents curl from picking up a dependency on libpsl when it is present in buildroot-nc4. It's not available on webOS and causes linking to fail with:
```
kodi-deps/arm-webos-linux-gnueabi-release/lib/libcurl.a(libcurl_la-psl.o):psl.c:function Curl_psl_destroy: error: undefined reference to 'psl_free'
kodi-deps/arm-webos-linux-gnueabi-release/lib/libcurl.a(libcurl_la-psl.o):psl.c:function Curl_psl_use: error: undefined reference to 'psl_latest'
kodi-deps/arm-webos-linux-gnueabi-release/lib/libcurl.a(libcurl_la-psl.o):psl.c:function Curl_psl_use: error: undefined reference to 'psl_builtin'
kodi-deps/arm-webos-linux-gnueabi-release/lib/libcurl.a(libcurl_la-cookie.o):cookie.c:function Curl_cookie_add: error: undefined reference to 'psl_is_cookie_domain_acceptable'
```

## How has this been tested?
Successfully built IPK for webOS.

## What is the effect on users?
Fixes potential webOS build issue. Should have no effect on the binaries produced.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
