### PR TITLE
[Android][FFmpeg] flag --enable-neon has no actual effects on Android targets

### DIFF
--- a/tools/depends/target/ffmpeg/Makefile
+++ b/tools/depends/target/ffmpeg/Makefile
@@ -35,12 +35,6 @@ else
   BASE_URL := http://mirrors.kodi.tv/build-deps/sources
 endif
 
-ifeq ($(OS), android)
-  ifeq ($(findstring arm64, $(CPU)), arm64)
-  CMAKE_ARGS+= -DENABLE_NEON=YES
-  endif
-endif
-
 include ../../download-files.include
 all: .installed-$(PLATFORM)
 


### PR DESCRIPTION
## Description
FFmpeg configure script checks if Neon is supported and enable it.

## Motivation and context
Arises from #23830

## How has this been tested?
I've checked that it's correctly detected on the two ARM targets we built (search for `NEON enabled`).

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
