### PR TITLE
[Scraper] Support for filename identifiers

### DIFF
--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -43,6 +43,13 @@ public:
                           std::string& strYear,
                           bool bRemoveExtension = false,
                           bool bCleanChars = true);
+  static bool GetFilenameIdentifier(const std::string& fileName,
+                                    std::string& identifierType,
+                                    std::string& identifier);
+  static bool GetFilenameIdentifier(const std::string& fileName,
+                                    std::string& identifierType,
+                                    std::string& identifier,
+                                    std::string& match);
   static std::string GetTitleFromPath(const CURL& url, bool bIsFolder = false);
   static std::string GetTitleFromPath(const std::string& strFileNameAndPath, bool bIsFolder = false);
 

--- a/xbmc/addons/Scraper.h
+++ b/xbmc/addons/Scraper.h
@@ -131,8 +131,11 @@ public:
     XFILE::CCurlFile &fcurl, const std::string &sArtist);
   VIDEO::EPISODELIST GetEpisodeList(XFILE::CCurlFile &fcurl, const CScraperUrl &scurl);
 
-  bool GetVideoDetails(XFILE::CCurlFile &fcurl, const CScraperUrl &scurl,
-    bool fMovie/*else episode*/, CVideoInfoTag &video);
+  bool GetVideoDetails(XFILE::CCurlFile& fcurl,
+                       const std::unordered_map<std::string, std::string>& uniqueIDs,
+                       const CScraperUrl& scurl,
+                       bool fMovie /*else episode*/,
+                       CVideoInfoTag& video);
   bool GetAlbumDetails(XFILE::CCurlFile &fcurl, const CScraperUrl &scurl,
     CAlbum &album);
   bool GetArtistDetails(XFILE::CCurlFile &fcurl, const CScraperUrl &scurl,

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -195,6 +195,7 @@ void CAdvancedSettings::Initialize()
   m_fullScreenOnMovieStart = true;
   m_cachePath = "special://temp/";
 
+  m_videoFilenameIdentifierRegExp = R"([\{\[](\w+?)(?:id)?[-=](\w+)[\}|\]])";
   m_videoCleanDateTimeRegExp = "(.*[^ _\\,\\.\\(\\)\\[\\]\\-])[ _\\.\\(\\)\\[\\]\\-]+(19[0-9][0-9]|20[0-9][0-9])([ _\\,\\.\\(\\)\\[\\]\\-]|[^0-9]$)?";
 
   m_videoCleanStringRegExps.clear();
@@ -632,6 +633,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     if (pVideoExcludes)
       GetCustomRegexps(pVideoExcludes, m_videoCleanStringRegExps);
 
+    XMLUtils::GetString(pElement, "filenameidentifier", m_videoFilenameIdentifierRegExp);
     XMLUtils::GetString(pElement,"cleandatetime", m_videoCleanDateTimeRegExp);
     XMLUtils::GetString(pElement,"ppffmpegpostprocessing",m_videoPPFFmpegPostProc);
     XMLUtils::GetInt(pElement,"vdpauscaling",m_videoVDPAUScaling);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -199,6 +199,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_fullScreenOnMovieStart;
     std::string m_cachePath;
     std::string m_videoCleanDateTimeRegExp;
+    std::string m_videoFilenameIdentifierRegExp;
     std::vector<std::string> m_videoCleanStringRegExps;
     std::vector<std::string> m_videoExcludeFromListingRegExps;
     std::vector<std::string> m_allExcludeFromScanRegExps;

--- a/xbmc/test/TestUtil.cpp
+++ b/xbmc/test/TestUtil.cpp
@@ -97,6 +97,8 @@ struct TestUtilCleanStringData
   std::string expTitle;
   std::string expTitleYear;
   std::string expYear;
+  std::string expIdentifierType{};
+  std::string expIdentifier{};
 };
 
 std::ostream& operator<<(std::ostream& os, const TestUtilCleanStringData& rhs)
@@ -109,6 +111,15 @@ std::ostream& operator<<(std::ostream& os, const TestUtilCleanStringData& rhs)
 class TestUtilCleanString : public Test, public WithParamInterface<TestUtilCleanStringData>
 {
 };
+
+TEST_P(TestUtilCleanString, GetFilenameIdentifier)
+{
+  std::string identifierType;
+  std::string identifier;
+  CUtil::GetFilenameIdentifier(GetParam().input, identifierType, identifier);
+  EXPECT_EQ(identifierType, GetParam().expIdentifierType);
+  EXPECT_EQ(identifier, GetParam().expIdentifier);
+}
 
 TEST_P(TestUtilCleanString, CleanString)
 {
@@ -131,6 +142,12 @@ const TestUtilCleanStringData values[] = {
     {"Some.Movie.1954.BDRip.1080p.mkv", true, "Some Movie", "Some Movie (1954)", "1954"},
     {"Some «Movie».2021.WEB-DL.2160p.HDR.mkv", true, "Some «Movie»", "Some «Movie» (2021)", "2021"},
     {"Some Movie (2013).mp4", true, "Some Movie", "Some Movie (2013)", "2013"},
+    {"Some Movie (2013) [imdbid-tt123].mp4", true, "Some Movie", "Some Movie (2013)", "2013",
+     "imdb", "tt123"},
+    {"Some Movie (2013) {tmdb-123}.mp4", true, "Some Movie", "Some Movie (2013)", "2013", "tmdb",
+     "123"},
+    {"Some Movie (2013) {tmdb=123}.mp4", true, "Some Movie", "Some Movie (2013)", "2013", "tmdb",
+     "123"},
     // no result because of the text (Director Cut), it can also a be a movie translation
     {"Some (Director Cut).BDRemux.mkv", true, "Some (Director Cut)", "Some (Director Cut)", ""}};
 

--- a/xbmc/video/VideoInfoDownloader.cpp
+++ b/xbmc/video/VideoInfoDownloader.cpp
@@ -80,7 +80,7 @@ void CVideoInfoDownloader::Process()
   }
   else if (m_state == GET_DETAILS)
   {
-    if (!GetDetails(m_url, m_movieDetails))
+    if (!GetDetails(m_uniqueIDs, m_url, m_movieDetails))
       CLog::Log(LOGERROR, "{}: Error getting details from {}", __FUNCTION__,
                 m_url.GetFirstThumbUrl());
   }
@@ -147,12 +147,14 @@ bool CVideoInfoDownloader::GetArtwork(CVideoInfoTag &details)
   return m_info->GetArtwork(*m_http, details);
 }
 
-bool CVideoInfoDownloader::GetDetails(const CScraperUrl &url,
-                                      CVideoInfoTag &movieDetails,
-                                      CGUIDialogProgress *pProgress /* = NULL */)
+bool CVideoInfoDownloader::GetDetails(const std::unordered_map<std::string, std::string>& uniqueIDs,
+                                      const CScraperUrl& url,
+                                      CVideoInfoTag& movieDetails,
+                                      CGUIDialogProgress* pProgress /* = NULL */)
 {
   //CLog::Log(LOGDEBUG,"CVideoInfoDownloader::GetDetails({})", url.m_strURL);
   m_url = url;
+  m_uniqueIDs = uniqueIDs;
   m_movieDetails = movieDetails;
 
   // fill in the defaults
@@ -179,7 +181,7 @@ bool CVideoInfoDownloader::GetDetails(const CScraperUrl &url,
     return true;
   }
   else  // unthreaded
-    return m_info->GetVideoDetails(*m_http, url, true/*fMovie*/, movieDetails);
+    return m_info->GetVideoDetails(*m_http, m_uniqueIDs, url, true /*fMovie*/, movieDetails);
 }
 
 bool CVideoInfoDownloader::GetEpisodeDetails(const CScraperUrl &url,
@@ -214,7 +216,7 @@ bool CVideoInfoDownloader::GetEpisodeDetails(const CScraperUrl &url,
     return true;
   }
   else  // unthreaded
-    return m_info->GetVideoDetails(*m_http, url, false/*fMovie*/, movieDetails);
+    return m_info->GetVideoDetails(*m_http, m_uniqueIDs, url, false /*fMovie*/, movieDetails);
 }
 
 bool CVideoInfoDownloader::GetEpisodeList(const CScraperUrl& url,

--- a/xbmc/video/VideoInfoDownloader.h
+++ b/xbmc/video/VideoInfoDownloader.h
@@ -54,7 +54,10 @@ public:
    */
   bool GetArtwork(CVideoInfoTag &details);
 
-  bool GetDetails(const CScraperUrl& url, CVideoInfoTag &movieDetails, CGUIDialogProgress *pProgress = NULL);
+  bool GetDetails(const std::unordered_map<std::string, std::string>& uniqueIDs,
+                  const CScraperUrl& url,
+                  CVideoInfoTag& movieDetails,
+                  CGUIDialogProgress* pProgress = NULL);
   bool GetEpisodeDetails(const CScraperUrl& url, CVideoInfoTag &movieDetails, CGUIDialogProgress *pProgress = NULL);
   bool GetEpisodeList(const CScraperUrl& url, VIDEO::EPISODELIST& details, CGUIDialogProgress *pProgress = NULL);
 
@@ -70,6 +73,7 @@ protected:
   XFILE::CCurlFile*   m_http;
   std::string         m_movieTitle;
   int                 m_movieYear;
+  std::unordered_map<std::string, std::string> m_uniqueIDs;
   MOVIELIST           m_movieList;
   CVideoInfoTag       m_movieDetails;
   CScraperUrl         m_url;

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -144,14 +144,17 @@ namespace VIDEO
     /*! \brief Retrieve detailed information for an item from an online source, optionally supplemented with local data
      @todo sort out some better return codes.
      \param pItem item to retrieve online details for.
+     \param uniqueIDs Unique IDs for additional information for scrapers.
      \param url URL to use to retrieve online details.
      \param scraper Scraper that handles parsing the online data.
      \param nfoFile if set, we override the online data with the locally supplied data. Defaults to NULL.
      \param pDialog progress dialog to update and check for cancellation during processing. Defaults to NULL.
      \return true if information is found, false if an error occurred, the lookup was cancelled, or no information was found.
      */
-    bool GetDetails(CFileItem *pItem, CScraperUrl &url,
-                    const ADDON::ScraperPtr &scraper,
+    bool GetDetails(CFileItem* pItem,
+                    const std::unordered_map<std::string, std::string>& uniqueIDs,
+                    CScraperUrl& url,
+                    const ADDON::ScraperPtr& scraper,
                     VIDEO::IVideoInfoTagLoader* nfoFile = nullptr,
                     CGUIDialogProgress* pDialog = nullptr);
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Parse filenames for identifier tags and pass them through `getDetails` by providing an optional `uniqueIDs` parameter.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For quite some time now, [Jellyfin](https://jellyfin.org/docs/general/server/media/movies/), [Emby](https://emby.media/support/articles/Movie-Naming.html#id-tags-in-folder--file-names), and [Plex](https://support.plex.tv/articles/naming-and-organizing-your-tv-show-files/) have been supporting supplying database identifier tags inside the filename. The naming is not completely consistent between these three, the general idea of `dbidentifier-XXXX` is common amongst them. Kodi does not officially support any of these tagging conventions. What's worse though is that kodi fails a tagged movie like this completely. Assuming a Jellyfin like tagging for a movie like this
```
Avatar (2009) [tmdbid-19995]&title=Avatar (2009)/Avatar (2009).mkv
```
Kodi would parse the file and misinterpret `tmdbid` as year and the title is parsed wrong too:
```
title=Avatar (2009) [tmdbid
year=1999
```
This happens because the movie title is passed into `CUtil::CleanString` which apparently breaks here.

This change additionally parses the filename for such identifiers and passes them into `getDetails` using the `uniqueIDs` parameter.

There was already an [attempt](https://github.com/xbmc/metadata.themoviedb.org.python/pull/182) at fixing this at the addon level, however it required adding the identifier after the year. This also shows that there is a valid use case for this amongst users.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
OLED77C28LB / webOS7/22
MacOS

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Add support for filename identifiers

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed