### PR TITLE
[guilib] let oninfo propagate from the item to the container if the c…

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -404,14 +404,14 @@ bool CGUIBaseContainer::OnAction(const CAction &action)
   case ACTION_SHOW_INFO:
     if (m_listProvider)
     {
-      int selected = GetSelectedItem();
+      const int selected = GetSelectedItem();
       if (selected >= 0 && selected < static_cast<int>(m_items.size()))
       {
-        m_listProvider->OnInfo(m_items[selected]);
-        return true;
+        if (m_listProvider->OnInfo(m_items[selected]))
+          return true;
       }
     }
-    else if (OnInfo())
+    if (OnInfo())
       return true;
     else if (action.GetID())
       return OnClick(action.GetID());


### PR DESCRIPTION
…ontainer cannot handle the item info

## Description
This is precisely the case of `CStaticListProvider`(s) (see https://github.com/xbmc/xbmc/blob/489f1bcf686c5a62b5ef41b4be5a6060559cc3d3/xbmc/listproviders/StaticProvider.h#L29) which cannot pass the info evaluation into the item. The current code returns true regardless avoiding the evaluation of the info that could be bound to the parent control. 

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/23838

## How has this been tested?
Runtime tested with the procedure of the bug report

## What is the effect on users?
Info should be executed if defined on `<oninfo>` of static list containers.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

