### PR TITLE
[webOS] Fix timezone reading

### DIFF
--- a/xbmc/platform/posix/PosixTimezone.cpp
+++ b/xbmc/platform/posix/PosixTimezone.cpp
@@ -216,12 +216,9 @@ std::string CPosixTimezone::GetOSConfiguredTimezone()
 std::string CPosixTimezone::ReadFromLocaltime(const std::string_view filename)
 {
   char path[PATH_MAX];
-  ssize_t len = readlink(filename.data(), path, sizeof(path) - 1);
-
-  if (len == -1)
+  if(realpath(filename.data(), path) == nullptr)
     return "";
 
-  path[len] = '\0';
   // Read the timezone starting from the second last occurrence of /
   std::string str = path;
   size_t pos = str.rfind('/');

--- a/xbmc/platform/posix/PosixTimezone.cpp
+++ b/xbmc/platform/posix/PosixTimezone.cpp
@@ -6,21 +6,23 @@
  *  See LICENSES/README.md for more information.
  */
 
-#include <time.h>
-#include "PlatformDefs.h"
 #include "PosixTimezone.h"
-#include "utils/SystemInfo.h"
 
 #include "ServiceBroker.h"
-#include "utils/StringUtils.h"
 #include "XBDateTime.h"
-#include "settings/lib/Setting.h"
-#include "settings/lib/SettingDefinitions.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include <stdlib.h>
+#include "settings/lib/Setting.h"
+#include "settings/lib/SettingDefinitions.h"
+#include "utils/StringUtils.h"
+#include "utils/SystemInfo.h"
 
 #include <algorithm>
+#include <climits>
+#include <cstdlib>
+#include <ctime>
+
+#include "PlatformDefs.h"
 
 CPosixTimezone::CPosixTimezone()
 {
@@ -195,44 +197,61 @@ void CPosixTimezone::SetTimezone(const std::string& timezoneName)
 
 std::string CPosixTimezone::GetOSConfiguredTimezone()
 {
-   char timezoneName[255];
+  std::string timezoneName;
 
-   // try Slackware approach first
-   ssize_t rlrc = readlink("/etc/localtime-copied-from"
-                           , timezoneName, sizeof(timezoneName)-1);
+  // try Slackware approach first
+  timezoneName = ReadFromLocaltime("/etc/localtime-copied-from");
 
-   // RHEL and maybe other distros make /etc/localtime a symlink
-   if (rlrc == -1)
-     rlrc = readlink("/etc/localtime", timezoneName, sizeof(timezoneName)-1);
+  // RHEL and maybe other distros make /etc/localtime a symlink
+  if (timezoneName.empty())
+    timezoneName = ReadFromLocaltime("/etc/localtime");
 
-   if (rlrc != -1)
-   {
-     timezoneName[rlrc] = '\0';
+  // now try Debian approach
+  if (timezoneName.empty())
+    timezoneName = ReadFromTimezone("/etc/timezone");
 
-     char* p = strrchr(timezoneName,'/');
-     if (p)
-     { // we want the previous '/'
-       char* q = p;
-       *q = 0;
-       p = strrchr(timezoneName,'/');
-       *q = '/';
-       if (p)
-         p++;
-     }
-     return p;
-   }
+  return timezoneName;
+}
 
-   // now try Debian approach
-   timezoneName[0] = 0;
-   FILE* fp = fopen("/etc/timezone", "r");
-   if (fp)
-   {
-      if (fgets(timezoneName, sizeof(timezoneName), fp))
-        timezoneName[strlen(timezoneName)-1] = '\0';
-      fclose(fp);
-   }
+std::string CPosixTimezone::ReadFromLocaltime(const std::string_view filename)
+{
+  char path[PATH_MAX];
+  ssize_t len = readlink(filename.data(), path, sizeof(path) - 1);
 
-   return timezoneName;
+  if (len == -1)
+    return "";
+
+  path[len] = '\0';
+  // Read the timezone starting from the second last occurrence of /
+  std::string str = path;
+  size_t pos = str.rfind('/');
+  if (pos == std::string::npos)
+    return "";
+
+  pos = str.rfind('/', pos - 1);
+  if (pos == std::string::npos)
+    return "";
+
+  return str.substr(pos + 1);
+}
+
+std::string CPosixTimezone::ReadFromTimezone(const std::string_view filename)
+{
+  std::string timezoneName;
+  std::FILE* file = std::fopen(filename.data(), "r");
+
+  if (file != nullptr)
+  {
+    char tz[255];
+    if (std::fgets(tz, sizeof(tz), file) != nullptr)
+    {
+      timezoneName = tz;
+    }
+
+    std::fclose(file);
+  }
+
+  return timezoneName;
 }
 
 void CPosixTimezone::SettingOptionsTimezoneCountriesFiller(

--- a/xbmc/platform/posix/PosixTimezone.h
+++ b/xbmc/platform/posix/PosixTimezone.h
@@ -46,12 +46,14 @@ public:
                                             void* data);
 
 private:
-   std::vector<std::string> m_counties;
-   std::map<std::string, std::string> m_countryByCode;
-   std::map<std::string, std::string> m_countryByName;
+  std::string ReadFromLocaltime(std::string_view filename);
+  std::string ReadFromTimezone(std::string_view filename);
+  std::vector<std::string> m_counties;
+  std::map<std::string, std::string> m_countryByCode;
+  std::map<std::string, std::string> m_countryByName;
 
-   std::map<std::string, std::vector<std::string> > m_timezonesByCountryCode;
-   std::map<std::string, std::string> m_countriesByTimezoneName;
+  std::map<std::string, std::vector<std::string>> m_timezonesByCountryCode;
+  std::map<std::string, std::string> m_countriesByTimezoneName;
 };
 
 extern CPosixTimezone g_timezone;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Timezone was not set correctly on startup on webOS. Some refactoring is done first to avoid duplicating code. The diff is a bit large because `clang format` required fixing up the header inclusion order and variable spacing

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The webOS jailer only mounts `/etc/localtime` which is a symlink to `/var/luna/preferences/localtime`. `/var/luna/preferences/localtime ` however is another symlink to the actual zone info.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
webOS22/7

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Fixes timezone initialization

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
