### PR TITLE
Revert "[docs] Fix for-the-badge badges"

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ Kodi couldn't exist without
 ## License
 Kodi is **[GPLv2 licensed](LICENSE.md)**. You may use, distribute and copy it under the license terms.
 
-<a href="https://github.com/xbmc/xbmc/graphs/contributors"><img src="https://raw.githubusercontent.com/BraveUX/for-the-badge/master/src/images/badges/built-by-developers.svg" height="25"></a>
-<a href="https://github.com/xbmc/xbmc"><img src="https://raw.githubusercontent.com/BraveUX/for-the-badge/master/src/images/badges/certified-cousin-terio.svg" height="25"></a>
-<a href="https://github.com/xbmc/xbmc"><img src="https://raw.githubusercontent.com/BraveUX/for-the-badge/master/src/images/badges/approved-by-george-costanza.svg" height="25"></a>
-<a href="https://kodi.tv/download"><img src="https://raw.githubusercontent.com/BraveUX/for-the-badge/master/src/images/badges/check-it-out.svg" height="25"></a>
-<a href="https://github.com/xbmc/xbmc"><img src="https://raw.githubusercontent.com/BraveUX/for-the-badge/master/src/images/badges/winter-is-coming.svg" height="25"></a>
+<a href="https://github.com/xbmc/xbmc/graphs/contributors"><img src="https://forthebadge.com/images/badges/built-by-developers.svg" height="25"></a>
+<a href="https://github.com/xbmc/xbmc"><img src="https://forthebadge.com/images/badges/certified-cousin-terio.svg" height="25"></a>
+<a href="https://github.com/xbmc/xbmc"><img src="https://forthebadge.com/images/badges/approved-by-george-costanza.svg" height="25"></a>
+<a href="https://kodi.tv/download"><img src="https://forthebadge.com/images/badges/check-it-out.svg" height="25"></a>
+<a href="https://github.com/xbmc/xbmc"><img src="https://forthebadge.com/images/badges/winter-is-coming.svg" height="25"></a>

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -45,6 +45,6 @@ The *pull request* description should only contain information relevant to the c
 ## Updating your PR
 Making a *pull request* adhere to the standards above can be difficult. If the maintainers notice anything that they'd like changed, they'll ask you to edit your *pull request* before it gets merged. **There's no need to open a new *pull request*, just edit the existing one**. If you're not sure how to do that, our **[git guide](GIT-FU.md)** provides a step by step guide. If you're still not sure, ask us for guidance. We're all fairly proficient with *git* and happy to be of assistance.
 
-<a href="https://github.com/xbmc/xbmc"><img src="https://raw.githubusercontent.com/BraveUX/for-the-badge/master/src/images/badges/made-with-c-plus-plus.svg" height="25"></a>
-<a href="https://github.com/xbmc/xbmc"><img src="https://raw.githubusercontent.com/BraveUX/for-the-badge/master/src/images/badges/contains-technical-debt.svg" height="25"></a>
+<a href="https://github.com/xbmc/xbmc"><img src="https://forthebadge.com/images/badges/made-with-c-plus-plus.svg" height="25"></a>
+<a href="https://github.com/xbmc/xbmc"><img src="https://forthebadge.com/images/badges/contains-technical-debt.svg" height="25"></a>
 


### PR DESCRIPTION
This reverts commit ea625655cbb84873e5741ef267a10749908ca131.

## Description
Forthebadge.com is again online (see https://github.com/BraveUX/for-the-badge/issues/252#event-10521780990 https://github.com/BraveUX/for-the-badge/issues/252#issuecomment-1741970447)

Reverts https://github.com/xbmc/xbmc/pull/23628

## Motivation and context
Use the actual site instead of a github repo which is more prone to break/cause errors

## How has this been tested?
Check markdown files

## What is the effect on users?
Docs only


