### PR TITLE
[favourites][listproviders] Add support for Video Select Actions for Favourites

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -3706,7 +3706,10 @@ bool CFileItem::LoadDetails()
 
     CVideoDatabase db;
     if (!db.Open())
+    {
+      CLog::LogF(LOGERROR, "Error opening video database");
       return false;
+    }
 
     VIDEODATABASEDIRECTORY::CQueryParams params;
     VIDEODATABASEDIRECTORY::CDirectoryNode::GetDatabaseInfo(GetPath(), params);
@@ -3733,11 +3736,8 @@ bool CFileItem::LoadDetails()
                          this);
     }
     else
-    {
-      db.Close();
       return false;
-    }
-    db.Close();
+
     return true;
   }
 
@@ -3773,7 +3773,10 @@ bool CFileItem::LoadDetails()
 
     CVideoDatabase db;
     if (!db.Open())
+    {
+      CLog::LogF(LOGERROR, "Error opening video database");
       return false;
+    }
 
     if (db.LoadVideoInfo(GetDynPath(), *GetVideoInfoTag()))
       return true;

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -3766,6 +3766,22 @@ bool CFileItem::LoadDetails()
     return false;
   }
 
+  if (IsVideo())
+  {
+    if (HasVideoInfoTag())
+      return true;
+
+    CVideoDatabase db;
+    if (!db.Open())
+      return false;
+
+    if (db.LoadVideoInfo(GetDynPath(), *GetVideoInfoTag()))
+      return true;
+
+    CLog::LogF(LOGERROR, "Error filling item details (path={})", GetPath());
+    return false;
+  }
+
   //! @todo add support for other types on demand.
   CLog::LogF(LOGDEBUG, "Unsupported item type (path={})", GetPath());
   return false;

--- a/xbmc/utils/ExecString.cpp
+++ b/xbmc/utils/ExecString.cpp
@@ -33,6 +33,25 @@ CExecString::CExecString(const std::string& function, const std::vector<std::str
     SetExecString();
 }
 
+CExecString::CExecString(const std::string& function,
+                         const CFileItem& target,
+                         const std::string& param)
+  : m_function(function)
+{
+  m_valid = !m_function.empty() && !target.GetPath().empty();
+
+  m_params.emplace_back(StringUtils::Paramify(target.GetPath()));
+
+  if (target.m_bIsFolder)
+    m_params.emplace_back("isdir");
+
+  if (!param.empty())
+    m_params.emplace_back(param);
+
+  if (m_valid)
+    SetExecString();
+}
+
 CExecString::CExecString(const CFileItem& item, const std::string& contextWindow)
 {
   m_valid = Parse(item, contextWindow);

--- a/xbmc/utils/ExecString.h
+++ b/xbmc/utils/ExecString.h
@@ -19,6 +19,7 @@ public:
   CExecString() = default;
   explicit CExecString(const std::string& execString);
   CExecString(const std::string& function, const std::vector<std::string>& params);
+  CExecString(const std::string& function, const CFileItem& target, const std::string& param);
   CExecString(const CFileItem& item, const std::string& contextWindow);
 
   virtual ~CExecString() = default;


### PR DESCRIPTION
Follow-up to #23848, bringing the missing bits 'n pieces for Favourites, namely full support for video select actions.

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 should be straight-forward to review.