### PR TITLE
[macos][input] Support NSEnterCharacter for XBMCK_RETURN

### DIFF
--- a/xbmc/windowing/osx/WinEventsOSXImpl.mm
+++ b/xbmc/windowing/osx/WinEventsOSXImpl.mm
@@ -108,6 +108,7 @@
     case NSDeleteCharacter:
       return XBMCK_BACKSPACE;
     case NSCarriageReturnCharacter:
+    case NSEnterCharacter:
       return XBMCK_RETURN;
     default:
       return character;


### PR DESCRIPTION
## Description
`NSEnterCharacter` (enter in the numpad) was not being recognized as a valid key. Just make it return `XBMCK_RETURN` just like the builtin mac `NSCarriageReturnCharacter`

@kambala-decapitator you report it you review it :)

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/23858

## How has this been tested?
Runtime tested with an external keyboard

## What is the effect on users?
Enter should now work properly.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
