### PR TITLE
[settings][video][PVR][listproviders][favourites] Add default play action setting.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -5725,6 +5725,7 @@ msgstr ""
 #: xbmc/pvr/PVRGUIActionsPlayback.cpp
 #: xbmc/video/ContextMenus.cpp
 #: xbmc/video/guilib/VideoSelectActionProcessor.cpp
+#: xbmc/video/guilib/VideoPlayActionProcessor.cpp
 msgctxt "#12021"
 msgid "Play from beginning"
 msgstr ""
@@ -15309,7 +15310,25 @@ msgctxt "#22033"
 msgid "Charset"
 msgstr ""
 
-#empty strings from id 22034 to 22078
+#empty strings from id 22034 to 22075
+
+#. Label for setting to choose the default action for "play"
+#: system/settings/settings.xml
+msgctxt "#22076"
+msgid "Default play action"
+msgstr ""
+
+#. Label for value for default play action setting
+#: system/settings/settings.xml
+msgctxt "#22077"
+msgid "Ask if resumable"
+msgstr ""
+
+#. Label for value for default play action setting
+#: system/settings/settings.xml
+msgctxt "#22078"
+msgid "Resume"
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#22079"
@@ -19638,7 +19657,11 @@ msgctxt "#36203"
 msgid "Enables the \"Personal Video Recorder\" (PVR) features. This requires that at least one PVR add-on is installed."
 msgstr ""
 
-#empty string with id 36204
+#. Description of setting with label #22076 "Default play action"
+#: system/settings/settings.xml
+msgctxt "#36204"
+msgid "Toggle between [Ask if resumable] (default) and [Resume].[CR][Ask if resumable] will ask whether to play from beginning or to resume (if a resume point is present).[CR][Resume] will automatically resume videos from the last position that you were viewing them.[CR]If no resume point is set, playback will automatically start from the beginning."
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#36205"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1015,6 +1015,17 @@
           </constraints>
           <control type="list" format="string" />
         </setting>
+        <setting id="myvideos.playaction" type="integer" label="22076" help="36204">
+          <level>0</level>
+          <default>1</default> <!-- PLAY_ACTION_PLAY_OR_RESUME -->
+          <constraints>
+            <options>
+              <option label="22077">1</option> <!-- PLAY_ACTION_PLAY_OR_RESUME -->
+              <option label="22078">2</option> <!-- PLAY_ACTION_RESUME -->
+            </options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
         <setting id="myvideos.usetags" type="boolean" label="21343" help="21344">
           <level>2</level>
           <default>false</default>

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -40,6 +40,7 @@
 #include "video/VideoThumbLoader.h"
 #include "video/VideoUtils.h"
 #include "video/dialogs/GUIDialogVideoInfo.h"
+#include "video/guilib/VideoPlayActionProcessor.h"
 #include "video/guilib/VideoSelectActionProcessor.h"
 
 #include <memory>
@@ -468,6 +469,11 @@ bool ExecuteAction(const std::string& execute)
   return false;
 }
 
+bool ExecuteAction(const CExecString& execute)
+{
+  return ExecuteAction(execute.GetExecString());
+}
+
 class CVideoSelectActionProcessor : public VIDEO::GUILIB::CVideoSelectActionProcessorBase
 {
 public:
@@ -480,25 +486,25 @@ protected:
   bool OnPlayPartSelected(unsigned int part) override
   {
     // part numbers are 1-based
-    BuildAndExecAction("PlayMedia", StringUtils::Format("playoffset={}", part - 1));
+    ExecuteAction({"PlayMedia", m_item, StringUtils::Format("playoffset={}", part - 1)});
     return true;
   }
 
   bool OnResumeSelected() override
   {
-    BuildAndExecAction("PlayMedia", "resume");
+    ExecuteAction({"PlayMedia", m_item, "resume"});
     return true;
   }
 
   bool OnPlaySelected() override
   {
-    BuildAndExecAction("PlayMedia", "noresume");
+    ExecuteAction({"PlayMedia", m_item, "noresume"});
     return true;
   }
 
   bool OnQueueSelected() override
   {
-    BuildAndExecAction("QueueMedia", "");
+    ExecuteAction({"QueueMedia", m_item, ""});
     return true;
   }
 
@@ -515,92 +521,106 @@ protected:
   }
 
 private:
-  void BuildAndExecAction(const std::string& method, const std::string& param)
+  CDirectoryProvider& m_provider;
+};
+
+class CVideoPlayActionProcessor : public VIDEO::GUILIB::CVideoPlayActionProcessorBase
+{
+public:
+  explicit CVideoPlayActionProcessor(CFileItem& item) : CVideoPlayActionProcessorBase(item) {}
+
+protected:
+  bool OnResumeSelected() override
   {
-    std::vector<std::string> params{StringUtils::Paramify(m_item.GetPath())};
-    if (m_item.m_bIsFolder)
-      params.emplace_back("isdir");
-
-    if (!param.empty())
-      params.emplace_back(param);
-
-    const CExecString es{method, params};
-    ExecuteAction(es.GetExecString());
+    ExecuteAction({"PlayMedia", m_item, "resume"});
+    return true;
   }
 
-  CDirectoryProvider& m_provider;
+  bool OnPlaySelected() override
+  {
+    ExecuteAction({"PlayMedia", m_item, "noresume"});
+    return true;
+  }
 };
 } // namespace
 
 bool CDirectoryProvider::OnClick(const CGUIListItemPtr& item)
 {
-  CFileItem fileItem(*std::static_pointer_cast<CFileItem>(item));
+  CFileItem targetItem{*std::static_pointer_cast<CFileItem>(item)};
 
-  if (fileItem.IsFavourite())
+  bool isPlayMedia{false};
+
+  if (targetItem.IsFavourite())
   {
     // Resolve the favourite
-    const CFavouritesURL url{fileItem.GetPath()};
+    const CFavouritesURL url{targetItem.GetPath()};
     if (!url.IsValid())
       return false;
 
-    if (url.GetAction() == CFavouritesURL::Action::PLAY_MEDIA)
-    {
-      CFileItem targetItem{url.GetTarget(), url.IsDir()};
-      targetItem.LoadDetails();
-      if (targetItem.IsVideo() ||
-          (targetItem.m_bIsFolder && VIDEO_UTILS::IsItemPlayable(targetItem)))
-      {
-        CVideoSelectActionProcessor proc{*this, targetItem};
-        if (proc.Process())
-          return true;
-      }
-    }
+    targetItem = {url.GetTarget(), url.IsDir()};
+    targetItem.LoadDetails();
+
+    isPlayMedia = (url.GetAction() == CFavouritesURL::Action::PLAY_MEDIA);
   }
-  else if (fileItem.HasVideoInfoTag())
+  else
   {
-    CVideoSelectActionProcessor proc{*this, fileItem};
+    const CExecString exec{targetItem, GetTarget(targetItem)};
+    isPlayMedia = (exec.GetFunction() == "playmedia");
+  }
+
+  // video select action setting is for files only, except exec func is playmedia...
+  if (targetItem.HasVideoInfoTag() && (!targetItem.m_bIsFolder || isPlayMedia))
+  {
+    CVideoSelectActionProcessor proc{*this, targetItem};
     if (proc.Process())
       return true;
   }
 
+  // exec the execute string for the original (!) item
+  CFileItem fileItem{*std::static_pointer_cast<CFileItem>(item)};
+
   if (fileItem.HasProperty("node.target_url"))
     fileItem.SetPath(fileItem.GetProperty("node.target_url").asString());
 
-  // grab and execute the execute string
-  return ExecuteAction(CExecString(fileItem, GetTarget(fileItem)).GetExecString());
+  return ExecuteAction({fileItem, GetTarget(fileItem)});
 }
 
 bool CDirectoryProvider::OnPlay(const CGUIListItemPtr& item)
 {
-  CFileItem fileItem(*std::static_pointer_cast<CFileItem>(item));
+  CFileItem targetItem{*std::static_pointer_cast<CFileItem>(item)};
 
-  if (fileItem.IsFavourite())
+  if (targetItem.IsFavourite())
   {
     // Resolve the favourite
-    const CFavouritesURL url(fileItem.GetPath());
-    if (url.IsValid())
-    {
-      // If action is playmedia, just play it
-      if (url.GetAction() == CFavouritesURL::Action::PLAY_MEDIA)
-        return ExecuteAction(url.GetExecString());
+    const CFavouritesURL url(targetItem.GetPath());
+    if (!url.IsValid())
+      return false;
 
-      CFileItem targetItem(url.GetTarget(), url.IsDir());
-      fileItem = targetItem;
-    }
+    targetItem = {url.GetTarget(), url.IsDir()};
+    targetItem.LoadDetails();
   }
 
-  if (CPlayerUtils::IsItemPlayable(fileItem))
+  // video play action setting is for files and folders...
+  if (targetItem.HasVideoInfoTag() ||
+      (targetItem.m_bIsFolder && VIDEO_UTILS::IsItemPlayable(targetItem)))
   {
-    CExecString exec(fileItem, {});
+    CVideoPlayActionProcessor proc{targetItem};
+    if (proc.Process())
+      return true;
+  }
+
+  if (CPlayerUtils::IsItemPlayable(targetItem))
+  {
+    const CExecString exec{targetItem, GetTarget(targetItem)};
     if (exec.GetFunction() == "playmedia")
     {
-      return ExecuteAction(exec.GetExecString());
+      // exec as is
+      return ExecuteAction(exec);
     }
     else
     {
-      // build and execute a playmedia execute string
-      exec = CExecString("PlayMedia", {StringUtils::Paramify(fileItem.GetPath())});
-      return ExecuteAction(exec.GetExecString());
+      // build a playmedia execute string for given target and exec this
+      return ExecuteAction({"PlayMedia", targetItem, ""});
     }
   }
   return true;

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -131,6 +131,7 @@ public:
   static constexpr auto SETTING_VIDEOPLAYER_SUPPORTMVC = "videoplayer.supportmvc";
   static constexpr auto SETTING_VIDEOPLAYER_CONVERTDOVI = "videoplayer.convertdovi";
   static constexpr auto SETTING_MYVIDEOS_SELECTACTION = "myvideos.selectaction";
+  static constexpr auto SETTING_MYVIDEOS_PLAYACTION = "myvideos.playaction";
   static constexpr auto SETTING_MYVIDEOS_USETAGS = "myvideos.usetags";
   static constexpr auto SETTING_MYVIDEOS_EXTRACTFLAGS = "myvideos.extractflags";
   static constexpr auto SETTING_MYVIDEOS_EXTRACTCHAPTERTHUMBS = "myvideos.extractchapterthumbs";

--- a/xbmc/video/guilib/CMakeLists.txt
+++ b/xbmc/video/guilib/CMakeLists.txt
@@ -1,6 +1,9 @@
-set(SOURCES VideoSelectActionProcessor.cpp)
+set(SOURCES VideoPlayActionProcessor.cpp
+            VideoSelectActionProcessor.cpp)
 
-set(HEADERS VideoSelectAction.h
+set(HEADERS VideoPlayAction.h
+            VideoPlayActionProcessor.h
+            VideoSelectAction.h
             VideoSelectActionProcessor.h)
 
 core_add_library(video_guilib)

--- a/xbmc/video/guilib/VideoPlayAction.h
+++ b/xbmc/video/guilib/VideoPlayAction.h
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+namespace VIDEO
+{
+namespace GUILIB
+{
+// Note: Do not change the numerical values of the elements. Some of them are used as values for
+//       the integer setting SETTING_MYVIDEOS_PLAYACTION.
+enum PlayAction
+{
+  PLAY_ACTION_PLAY_OR_RESUME = 1, // if resume is possible, ask user. play from beginning otherwise
+  PLAY_ACTION_RESUME = 2, // resume if possibly, play from beginning otherwise
+  PLAY_ACTION_PLAY_FROM_BEGINNING = 5, // play from beginning, also if resume would be possible
+};
+} // namespace GUILIB
+} // namespace VIDEO

--- a/xbmc/video/guilib/VideoPlayActionProcessor.cpp
+++ b/xbmc/video/guilib/VideoPlayActionProcessor.cpp
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "VideoPlayActionProcessor.h"
+
+#include "ServiceBroker.h"
+#include "dialogs/GUIDialogContextMenu.h"
+#include "guilib/LocalizeStrings.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
+#include "video/VideoUtils.h"
+
+using namespace VIDEO::GUILIB;
+
+PlayAction CVideoPlayActionProcessorBase::GetDefaultPlayAction()
+{
+  return static_cast<PlayAction>(CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+      CSettings::SETTING_MYVIDEOS_PLAYACTION));
+}
+
+bool CVideoPlayActionProcessorBase::Process()
+{
+  return Process(GetDefaultPlayAction());
+}
+
+bool CVideoPlayActionProcessorBase::Process(PlayAction PlayAction)
+{
+  switch (PlayAction)
+  {
+    case PLAY_ACTION_PLAY_OR_RESUME:
+    {
+      const VIDEO::GUILIB::PlayAction action = ChoosePlayOrResume();
+      if (action < 0)
+        return true; // User cancelled the select menu. We're done.
+
+      return Process(action);
+    }
+
+    case PLAY_ACTION_RESUME:
+      return OnResumeSelected();
+
+    case PLAY_ACTION_PLAY_FROM_BEGINNING:
+      return OnPlaySelected();
+
+    default:
+      break;
+  }
+  return false; // We did not handle the action.
+}
+
+PlayAction CVideoPlayActionProcessorBase::ChoosePlayOrResume()
+{
+  PlayAction action = PLAY_ACTION_PLAY_FROM_BEGINNING;
+
+  const std::string resumeString = VIDEO_UTILS::GetResumeString(m_item);
+  if (!resumeString.empty())
+  {
+    CContextButtons choices;
+
+    choices.Add(PLAY_ACTION_RESUME, resumeString);
+    choices.Add(PLAY_ACTION_PLAY_FROM_BEGINNING, 12021); // Play from beginning
+
+    action = static_cast<PlayAction>(CGUIDialogContextMenu::ShowAndGetChoice(choices));
+  }
+
+  return action;
+}

--- a/xbmc/video/guilib/VideoPlayActionProcessor.h
+++ b/xbmc/video/guilib/VideoPlayActionProcessor.h
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "video/guilib/VideoPlayAction.h"
+
+class CFileItem;
+
+namespace VIDEO
+{
+namespace GUILIB
+{
+class CVideoPlayActionProcessorBase
+{
+public:
+  explicit CVideoPlayActionProcessorBase(CFileItem& item) : m_item(item) {}
+  virtual ~CVideoPlayActionProcessorBase() = default;
+
+  static PlayAction GetDefaultPlayAction();
+
+  bool Process();
+  bool Process(PlayAction playAction);
+
+protected:
+  virtual bool OnResumeSelected() = 0;
+  virtual bool OnPlaySelected() = 0;
+
+  CFileItem& m_item;
+
+private:
+  CVideoPlayActionProcessorBase() = delete;
+  PlayAction ChoosePlayOrResume();
+};
+} // namespace GUILIB
+} // namespace VIDEO

--- a/xbmc/video/windows/GUIWindowVideoBase.h
+++ b/xbmc/video/windows/GUIWindowVideoBase.h
@@ -17,11 +17,13 @@
 namespace
 {
 class CVideoSelectActionProcessor;
+class CVideoPlayActionProcessor;
 } // unnamed namespace
 
 class CGUIWindowVideoBase : public CGUIMediaWindow, public IBackgroundLoaderObserver
 {
   friend class ::CVideoSelectActionProcessor;
+  friend class ::CVideoPlayActionProcessor;
 
 public:
   CGUIWindowVideoBase(int id, const std::string &xmlFile);


### PR DESCRIPTION
Adds a new setting for defining what happens when "play" action is executed, similar to what we already have for the "select" action. 

Currently, despite from behaving differently at different places throughout Kodi, you cannot control whether playback will automatically resume if possible or if user shall be asked whether to start over or resume. We have complaints in the Forum, that users find it annoying to always being asked, they want automatic resume, others stated exactly the opposite. This feels like we need a setting. :-)

With this PR, behavior will be consistent throughout video windows, pvr recordings window, favourites window and listprovider lists (aka home screen widgets) ... and user-customizable via the new setting.

![screenshot00003](https://github.com/xbmc/xbmc/assets/3226626/6c4f15b5-7a22-465b-b254-125826fd9961)
![screenshot00004](https://github.com/xbmc/xbmc/assets/3226626/8c6af699-0976-4c72-b261-f00aae8672b8)

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 be my guest for a review, best done commit-by-commit.
