### PR TITLE
CAddonSettings: Prevent reference cycle with CAddon

### DIFF
--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -436,8 +436,12 @@ bool CAddonSettings::HasSettings() const
 
 bool CAddonSettings::Save()
 {
-  assert(m_addon);
-  return m_addon->SaveSettings();
+  std::shared_ptr<IAddon> addon = m_addon.lock();
+  assert(addon);
+  if (addon)
+    return addon->SaveSettings();
+  else
+    return false;
 }
 
 std::string CAddonSettings::GetSettingLabel(int label) const

--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -154,11 +154,14 @@ namespace ADDON
 
 CAddonSettings::CAddonSettings(const std::shared_ptr<IAddon>& addon, AddonInstanceId instanceId)
   : CSettingsBase(),
+    m_addonId(addon->ID()),
+    m_addonPath(addon->Path()),
+    m_addonProfile(addon->Profile()),
     m_instanceId(instanceId),
     m_addon{addon},
     m_unknownSettingLabelId(UnknownSettingLabelIdStart),
     m_logger(CServiceBroker::GetLogging().GetLogger(
-        StringUtils::Format("CAddonSettings[{}@{}]", m_instanceId, addon->ID())))
+        StringUtils::Format("CAddonSettings[{}@{}]", m_instanceId, m_addonId)))
 {
 }
 
@@ -171,11 +174,6 @@ std::shared_ptr<CSetting> CAddonSettings::CreateSetting(
     return std::make_shared<CSettingUrlEncodedString>(settingId, settingsManager);
 
   return CSettingCreator::CreateSetting(settingType, settingId, settingsManager);
-}
-
-std::string CAddonSettings::GetAddonId() const
-{
-  return m_addon->ID();
 }
 
 void CAddonSettings::OnSettingAction(const std::shared_ptr<const CSetting>& setting)
@@ -191,9 +189,9 @@ void CAddonSettings::OnSettingAction(const std::shared_ptr<const CSetting>& sett
     {
       actionData = settingAction->GetData();
       // replace $CWD with the url of the add-on
-      StringUtils::Replace(actionData, "$CWD", m_addon->Path());
+      StringUtils::Replace(actionData, "$CWD", m_addonPath);
       // replace $ID with the id of the add-on
-      StringUtils::Replace(actionData, "$ID", m_addon->ID());
+      StringUtils::Replace(actionData, "$ID", m_addonId);
     }
   }
 
@@ -229,7 +227,7 @@ bool CAddonSettings::AddInstanceSettings()
     CLog::Log(
         LOGDEBUG,
         "CAddonSettings::{} - Add-on {} using instance setting values byself, Kodi's add ignored",
-        __func__, m_addon->ID());
+        __func__, m_addonId);
     return true;
   }
 
@@ -812,7 +810,7 @@ bool CAddonSettings::InitializeFromOldSettingDefinitions(const CXBMCTinyXML& doc
     return false;
 
   std::shared_ptr<CSettingSection> section =
-      std::make_shared<CSettingSection>(m_addon->ID(), GetSettingsManager());
+      std::make_shared<CSettingSection>(m_addonId, GetSettingsManager());
 
   std::shared_ptr<CSettingCategory> category;
   uint32_t categoryId = 0;
@@ -845,9 +843,9 @@ SettingPtr CAddonSettings::InitializeFromOldSettingAction(const std::string& set
   // parse the action attribute
   std::string action = XMLUtils::GetAttribute(settingElement, "action");
   // replace $CWD with the url of the add-on
-  StringUtils::Replace(action, "$CWD", m_addon->Path());
+  StringUtils::Replace(action, "$CWD", m_addonPath);
   // replace $ID with the id of the add-on
-  StringUtils::Replace(action, "$ID", m_addon->ID());
+  StringUtils::Replace(action, "$ID", m_addonId);
 
   // prepare the setting's control
   auto control = std::make_shared<CSettingControlButton>();
@@ -1314,7 +1312,7 @@ SettingPtr CAddonSettings::InitializeFromOldSettingEnums(
       for (uint32_t i = 0; i < values.size(); ++i)
       {
         int label = static_cast<int>(strtol(values[i].c_str(), nullptr, 0));
-        std::string value = g_localizeStrings.GetAddonString(m_addon->ID(), label);
+        std::string value = g_localizeStrings.GetAddonString(m_addonId, label);
         if (settingEntries.size() > i)
           value = settingEntries[i];
 
@@ -1464,9 +1462,9 @@ SettingPtr CAddonSettings::InitializeFromOldSettingFileWithSource(
   setting->SetDefault(defaultValue);
 
   if (source.find("$PROFILE") != std::string::npos)
-    StringUtils::Replace(source, "$PROFILE", m_addon->Profile());
+    StringUtils::Replace(source, "$PROFILE", m_addonProfile);
   else
-    source = URIUtils::AddFileToFolder(m_addon->Path(), source);
+    source = URIUtils::AddFileToFolder(m_addonPath, source);
 
   setting->SetSources({source});
 

--- a/xbmc/addons/settings/AddonSettings.h
+++ b/xbmc/addons/settings/AddonSettings.h
@@ -60,7 +60,7 @@ public:
   // implementation of ISettingCallback
   void OnSettingAction(const std::shared_ptr<const CSetting>& setting) override;
 
-  std::string GetAddonId() const;
+  const std::string& GetAddonId() const { return m_addonId; }
 
   bool Initialize(const CXBMCTinyXML& doc, bool allowEmpty = false);
   bool Load(const CXBMCTinyXML& doc);
@@ -187,6 +187,10 @@ private:
                                            std::string& current,
                                            void* data);
 
+  // store these values so that we don't always have to access the weak pointer
+  const std::string m_addonId;
+  const std::string m_addonPath;
+  const std::string m_addonProfile;
   const AddonInstanceId m_instanceId{ADDON_SETTINGS_ID};
   std::shared_ptr<IAddon> m_addon;
 

--- a/xbmc/addons/settings/AddonSettings.h
+++ b/xbmc/addons/settings/AddonSettings.h
@@ -192,7 +192,7 @@ private:
   const std::string m_addonPath;
   const std::string m_addonProfile;
   const AddonInstanceId m_instanceId{ADDON_SETTINGS_ID};
-  std::shared_ptr<IAddon> m_addon;
+  std::weak_ptr<IAddon> m_addon;
 
   uint32_t m_unidentifiedSettingId = 0;
   int m_unknownSettingLabelId;


### PR DESCRIPTION
## Description

#23558 added a reference cycle that causes memory leaks as reported in #23786.

The problem is that `CAddon::m_settings` contains `CSettingsData` objects which contains `CAddonSettings` obejcts. The shared_ptr `CAddonSettings::m_addon` creates a cycle that prevents the addon from getting freed.

This PR breaks the cycle by using a `std::weak_ptr` in `CSettingsData`. To prevent constant locking of the weak_ptr the commit e02c6f09b904d90749b3a7bf7453b5d456f99616 is reverted.

Fixes #23786.

## Motivation and context
See above.

## How has this been tested?
Checked with heaptrack that the leak is gone and with ASAN that there are no general memory problems

## What is the effect on users?
Kodi's memory usage doesn't increase indefinitely.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
