### PR TITLE
[webOS] AESinkStarfish: Implement acb

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkStarfish.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkStarfish.h
@@ -43,10 +43,13 @@ private:
                              const int64_t numValue,
                              const char* strValue,
                              void* data);
+  static void AcbCallback(
+      long acbId, long taskId, long eventType, long appState, long playState, const char* reply);
 
   std::unique_ptr<StarfishMediaAPIs> m_starfishMediaAPI;
   AEAudioFormat m_format;
   std::chrono::nanoseconds m_pts{0};
   int64_t m_bufferSize{0};
   bool m_firstFeed{true};
+  long m_acbId{0};
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Passthrough sink is apparently not working on webOS 4.x as mentioned in #23834.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not tested, except for that it doesn't break on webOS 22/7. An AVR is not needed for testing because the passthrough sink will also output to the TV internal speakers.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
