### PR TITLE
CGBMUtils: return references to objects in getters

### DIFF
--- a/xbmc/utils/GBMBufferObject.cpp
+++ b/xbmc/utils/GBMBufferObject.cpp
@@ -30,7 +30,7 @@ void CGBMBufferObject::Register()
 CGBMBufferObject::CGBMBufferObject()
 {
   m_device =
-      static_cast<CWinSystemGbmEGLContext*>(CServiceBroker::GetWinSystem())->GetGBMDevice()->Get();
+      static_cast<CWinSystemGbmEGLContext*>(CServiceBroker::GetWinSystem())->GetGBMDevice().Get();
 }
 
 CGBMBufferObject::~CGBMBufferObject()

--- a/xbmc/windowing/gbm/GBMUtils.cpp
+++ b/xbmc/windowing/gbm/GBMUtils.cpp
@@ -74,7 +74,7 @@ CGBMUtils::CGBMDevice::CGBMSurface::CGBMSurface(gbm_surface* surface) : m_surfac
 {
 }
 
-CGBMUtils::CGBMDevice::CGBMSurface::CGBMSurfaceBuffer* CGBMUtils::CGBMDevice::CGBMSurface::
+CGBMUtils::CGBMDevice::CGBMSurface::CGBMSurfaceBuffer& CGBMUtils::CGBMDevice::CGBMSurface::
     LockFrontBuffer()
 {
   m_buffers.emplace(std::make_unique<CGBMSurfaceBuffer>(m_surface));
@@ -92,7 +92,7 @@ CGBMUtils::CGBMDevice::CGBMSurface::CGBMSurfaceBuffer* CGBMUtils::CGBMDevice::CG
     m_buffers.pop();
   }
 
-  return m_buffers.back().get();
+  return *m_buffers.back();
 }
 
 CGBMUtils::CGBMDevice::CGBMSurface::CGBMSurfaceBuffer::CGBMSurfaceBuffer(gbm_surface* surface)

--- a/xbmc/windowing/gbm/GBMUtils.h
+++ b/xbmc/windowing/gbm/GBMUtils.h
@@ -125,7 +125,7 @@ public:
        *
        * @return CGBMSurfaceBuffer* A pointer to a CGBMSurfaceBuffer object
        */
-      CGBMSurfaceBuffer* LockFrontBuffer();
+      CGBMSurfaceBuffer& LockFrontBuffer();
 
     private:
       gbm_surface* m_surface{nullptr};

--- a/xbmc/windowing/gbm/GBMUtils.h
+++ b/xbmc/windowing/gbm/GBMUtils.h
@@ -158,7 +158,7 @@ public:
    *
    * @return CGBMDevice* A pointer to the CGBMDevice object
    */
-  CGBMUtils::CGBMDevice* GetDevice() const { return m_device.get(); }
+  CGBMUtils::CGBMDevice& GetDevice() const { return *m_device; }
 
 private:
   struct CGBMDeviceDeleter

--- a/xbmc/windowing/gbm/GBMUtils.h
+++ b/xbmc/windowing/gbm/GBMUtils.h
@@ -137,7 +137,7 @@ public:
      *
      * @return CGBMSurface* A pointer to the CGBMSurface object
      */
-    CGBMDevice::CGBMSurface* GetSurface() const { return m_surface.get(); }
+    CGBMDevice::CGBMSurface& GetSurface() const { return *m_surface; }
 
   private:
     gbm_device* m_device{nullptr};

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -242,7 +242,7 @@ bool CWinSystemGbm::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
 
   if (!std::dynamic_pointer_cast<CDRMAtomic>(m_DRM))
   {
-    bo = m_GBM->GetDevice()->GetSurface()->LockFrontBuffer()->Get();
+    bo = m_GBM->GetDevice().GetSurface()->LockFrontBuffer()->Get();
   }
 
   auto result = m_DRM->SetVideoMode(res, bo);
@@ -290,7 +290,7 @@ void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer)
 
   if (rendered)
   {
-    bo = m_GBM->GetDevice()->GetSurface()->LockFrontBuffer()->Get();
+    bo = m_GBM->GetDevice().GetSurface()->LockFrontBuffer()->Get();
   }
 
   m_DRM->FlipPage(bo, rendered, videoLayer);

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -242,7 +242,7 @@ bool CWinSystemGbm::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
 
   if (!std::dynamic_pointer_cast<CDRMAtomic>(m_DRM))
   {
-    bo = m_GBM->GetDevice().GetSurface().LockFrontBuffer()->Get();
+    bo = m_GBM->GetDevice().GetSurface().LockFrontBuffer().Get();
   }
 
   auto result = m_DRM->SetVideoMode(res, bo);
@@ -290,7 +290,7 @@ void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer)
 
   if (rendered)
   {
-    bo = m_GBM->GetDevice().GetSurface().LockFrontBuffer()->Get();
+    bo = m_GBM->GetDevice().GetSurface().LockFrontBuffer().Get();
   }
 
   m_DRM->FlipPage(bo, rendered, videoLayer);

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -242,7 +242,7 @@ bool CWinSystemGbm::SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool bl
 
   if (!std::dynamic_pointer_cast<CDRMAtomic>(m_DRM))
   {
-    bo = m_GBM->GetDevice().GetSurface()->LockFrontBuffer()->Get();
+    bo = m_GBM->GetDevice().GetSurface().LockFrontBuffer()->Get();
   }
 
   auto result = m_DRM->SetVideoMode(res, bo);
@@ -290,7 +290,7 @@ void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer)
 
   if (rendered)
   {
-    bo = m_GBM->GetDevice().GetSurface()->LockFrontBuffer()->Get();
+    bo = m_GBM->GetDevice().GetSurface().LockFrontBuffer()->Get();
   }
 
   m_DRM->FlipPage(bo, rendered, videoLayer);

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -71,7 +71,7 @@ public:
     m_videoLayerBridge = std::move(bridge);
   };
 
-  CGBMUtils::CGBMDevice* GetGBMDevice() const { return m_GBM->GetDevice(); }
+  CGBMUtils::CGBMDevice& GetGBMDevice() const { return m_GBM->GetDevice(); }
   std::shared_ptr<CDRMUtils> GetDrm() const { return m_DRM; }
 
   std::vector<std::string> GetConnectedOutputs() override;

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -98,8 +98,8 @@ bool CWinSystemGbmEGLContext::CreateNewWindow(const std::string& name,
   static_assert(sizeof(EGLNativeWindowType) == sizeof(gbm_surface*), "Declaration specifier differs in size");
 
   if (!m_eglContext.CreatePlatformSurface(
-          m_GBM->GetDevice().GetSurface()->Get(),
-          reinterpret_cast<khronos_uintptr_t>(m_GBM->GetDevice().GetSurface()->Get())))
+          m_GBM->GetDevice().GetSurface().Get(),
+          reinterpret_cast<khronos_uintptr_t>(m_GBM->GetDevice().GetSurface().Get())))
   {
     return false;
   }

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -23,7 +23,7 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint 
     return false;
   }
 
-  if (!m_eglContext.CreatePlatformDisplay(m_GBM->GetDevice()->Get(), m_GBM->GetDevice()->Get()))
+  if (!m_eglContext.CreatePlatformDisplay(m_GBM->GetDevice().Get(), m_GBM->GetDevice().Get()))
   {
     return false;
   }
@@ -87,8 +87,8 @@ bool CWinSystemGbmEGLContext::CreateNewWindow(const std::string& name,
   if (plane)
     modifiers = plane->GetModifiersForFormat(format);
 
-  if (!m_GBM->GetDevice()->CreateSurface(res.iWidth, res.iHeight, format, modifiers.data(),
-                                         modifiers.size()))
+  if (!m_GBM->GetDevice().CreateSurface(res.iWidth, res.iHeight, format, modifiers.data(),
+                                        modifiers.size()))
   {
     CLog::Log(LOGERROR, "CWinSystemGbmEGLContext::{} - failed to initialize GBM", __FUNCTION__);
     return false;
@@ -98,8 +98,8 @@ bool CWinSystemGbmEGLContext::CreateNewWindow(const std::string& name,
   static_assert(sizeof(EGLNativeWindowType) == sizeof(gbm_surface*), "Declaration specifier differs in size");
 
   if (!m_eglContext.CreatePlatformSurface(
-          m_GBM->GetDevice()->GetSurface()->Get(),
-          reinterpret_cast<khronos_uintptr_t>(m_GBM->GetDevice()->GetSurface()->Get())))
+          m_GBM->GetDevice().GetSurface()->Get(),
+          reinterpret_cast<khronos_uintptr_t>(m_GBM->GetDevice().GetSurface()->Get())))
   {
     return false;
   }


### PR DESCRIPTION
Very simple change to use references instead of pointers. This references the smart pointer object instead of returning a raw pointer.
