### PR TITLE
[Android] Clang -march flag is not needed

### DIFF
--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -323,7 +323,7 @@ case $host in
           use_cpu="armeabi-v7a"
         fi
         if test "x$use_cpu" = "xarmeabi-v7a"; then
-          platform_cflags="${platform_cflags} -march=armv7-a -mtune=cortex-a9 -mfloat-abi=softfp"
+          platform_cflags="${platform_cflags} -mtune=cortex-a9 -mfloat-abi=softfp"
         fi
         platform_ldflags="${platform_ldflags} -Wl,--exclude-libs,libunwind.a"
         meson_cpu="arm"
@@ -333,7 +333,7 @@ case $host in
           use_cpu="arm64-v8a"
         fi
         if test "x$use_cpu" = "xarm64-v8a"; then
-          platform_cflags="${platform_cflags} -march=armv8-a -mtune=cortex-a53"
+          platform_cflags="${platform_cflags} -mtune=cortex-a53"
         fi
         meson_cpu="aarch64"
       ;;


### PR DESCRIPTION
## Description
This Clang flag has no actual effects.

Cross-compilation targets are selected based on the clang and clang++ binary wrapper scripts used, named `<triple><API-level>-clang` and `<triple><API-level>-clang++`.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
