### PR TITLE
Fix websocket pong

### DIFF
--- a/xbmc/network/TCPServer.cpp
+++ b/xbmc/network/TCPServer.cpp
@@ -719,7 +719,8 @@ void CTCPServer::CWebSocketClient::PushBuffer(CTCPServer *host, const char *buff
       if (send)
       {
         for (unsigned int index = 0; index < frames.size(); index++)
-          Send(frames.at(index)->GetFrameData(), (unsigned int)frames.at(index)->GetFrameLength());
+          CTCPClient::Send(frames.at(index)->GetFrameData(),
+                           static_cast<unsigned int>(frames.at(index)->GetFrameLength()));
       }
       else
       {

--- a/xbmc/network/websocket/WebSocket.cpp
+++ b/xbmc/network/websocket/WebSocket.cpp
@@ -325,7 +325,7 @@ const CWebSocketMessage* CWebSocket::Handle(const char* &buffer, size_t &length,
             case WebSocketPing:
               msg = GetMessage();
               if (msg != NULL)
-                msg->AddFrame(Pong(frame->GetApplicationData()));
+                msg->AddFrame(Pong(frame->GetApplicationData(), frame->GetLength()));
               break;
 
             case WebSocketConnectionClose:

--- a/xbmc/network/websocket/WebSocket.h
+++ b/xbmc/network/websocket/WebSocket.h
@@ -121,7 +121,7 @@ public:
   virtual const CWebSocketMessage* Handle(const char* &buffer, size_t &length, bool &send);
   virtual const CWebSocketMessage* Send(WebSocketFrameOpcode opcode, const char* data = NULL, uint32_t length = 0);
   virtual const CWebSocketFrame* Ping(const char* data = NULL) const = 0;
-  virtual const CWebSocketFrame* Pong(const char* data = NULL) const = 0;
+  virtual const CWebSocketFrame* Pong(const char* data, uint32_t length) const = 0;
   virtual const CWebSocketFrame* Close(WebSocketCloseReason reason = WebSocketCloseNormal, const std::string &message = "") = 0;
   virtual void Fail() = 0;
 

--- a/xbmc/network/websocket/WebSocketV8.h
+++ b/xbmc/network/websocket/WebSocketV8.h
@@ -19,7 +19,10 @@ public:
 
   bool Handshake(const char* data, size_t length, std::string &response) override;
   const CWebSocketFrame* Ping(const char* data = NULL) const override { return new CWebSocketFrame(WebSocketPing, data); }
-  const CWebSocketFrame* Pong(const char* data = NULL) const override { return new CWebSocketFrame(WebSocketPong, data); }
+  const CWebSocketFrame* Pong(const char* data, uint32_t length) const override
+  {
+    return new CWebSocketFrame(WebSocketPong, data, length);
+  }
   const CWebSocketFrame* Close(WebSocketCloseReason reason = WebSocketCloseNormal, const std::string &message = "") override;
   void Fail() override;
 


### PR DESCRIPTION
## Description
After updating my web remote to latest packages and node, I was surprised by websocket disconnects.
Debugging showed after every ping I did, my connection was aborted with following error:
1007 Illegal UTF-8 Sequence

Furthermore while investigating the issue I found that our implementation violates the RFC as specified here:
https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.3

Prior to this PR, our pong always contained an empty body.

## How has this been tested?
Run this using current node 18 LTS.
Run `npm i ws` to install the websocket client library.

```
const WS = require('ws');

const ws = new WS('ws://localhost:9090/jsonrpc');

ws.on('open', () => {
    console.log('connected');
});

ws.on('message', (data) => {
    console.log('message received');
});

ws.on('close', () => {
    console.log('closed');
});

ws.on('error', (err) => {
    console.log('error', err);
});

ws.on('pong', (appdata) => {
    console.log(`got pong: ${appdata}`);
});

const keepAliveId = setInterval(() => { ws.ping('test'); }, 1500);
```

## What is the effect on users?
Properly working remotes.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
