### PR TITLE
[macos][cocoainterface] Address deprecations

### DIFF
--- a/xbmc/platform/darwin/osx/CocoaInterface.mm
+++ b/xbmc/platform/darwin/osx/CocoaInterface.mm
@@ -30,11 +30,6 @@ static CVDisplayLinkRef displayLink = NULL;
 
 CGDirectDisplayID Cocoa_GetDisplayIDFromScreen(NSScreen *screen);
 
-NSOpenGLContext* Cocoa_GL_GetCurrentContext(void)
-{
-  return [NSOpenGLContext currentContext];
-}
-
 uint32_t Cocoa_GL_GetCurrentDisplayID(void)
 {
   // Find which display we are on from the current context (default to main display)
@@ -42,10 +37,8 @@ uint32_t Cocoa_GL_GetCurrentDisplayID(void)
 
   NSNumber* __block screenID;
   auto getScreenNumber = ^{
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    screenID = Cocoa_GL_GetCurrentContext().view.window.screen.deviceDescription[@"NSScreenNumber"];
-#pragma clang diagnostic pop
+    screenID =
+        NSApplication.sharedApplication.keyWindow.screen.deviceDescription[@"NSScreenNumber"];
   };
   if (NSThread.isMainThread)
     getScreenNumber();
@@ -64,10 +57,8 @@ bool Cocoa_CVDisplayLinkCreate(void *displayLinkcallback, void *displayLinkConte
 
   // OpenGL Flush synchronised with vertical retrace
   GLint swapInterval = 1;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  [[NSOpenGLContext currentContext] setValues:&swapInterval forParameter:NSOpenGLCPSwapInterval];
-#pragma clang diagnostic pop
+  [[NSOpenGLContext currentContext] setValues:&swapInterval
+                                 forParameter:NSOpenGLContextParameterSwapInterval];
 
   display_id = (CGDirectDisplayID)Cocoa_GL_GetCurrentDisplayID();
   if (!displayLink)


### PR DESCRIPTION
## Description
This simply addresses a few deprecations that were previously silenced off with pragma marks. Since the last bump for the macos target we can simply use the new alternatives.

## Motivation and context
Resolve deprecations

## How has this been tested?
Runtime tested

## What is the effect on users?
None

