### PR TITLE
[VideoPlayer] Updates audio/video queues for nowadays maximum bitrates

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -61,7 +61,8 @@ CVideoPlayerAudio::CVideoPlayerAudio(CDVDClock* pClock, CDVDMessageQueue& parent
   m_prevskipped = false;
   m_maxspeedadjust = 0.0;
 
-  m_messageQueue.SetMaxDataSize(6 * 1024 * 1024);
+  // 18 MB allows max bitrate of 18 Mbit/s (TrueHD max peak) during 8 seconds
+  m_messageQueue.SetMaxDataSize(18 * 1024 * 1024);
   m_messageQueue.SetMaxTimeSize(8.0);
   m_disconAdjustTimeMs = processInfo.GetMaxPassthroughOffSyncDuration();
 }

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -66,7 +66,9 @@ CVideoPlayerVideo::CVideoPlayerVideo(CDVDClock* pClock
   m_iLateFrames = 0;
   m_iDroppedRequest = 0;
   m_fForcedAspectRatio = 0;
-  m_messageQueue.SetMaxDataSize(40 * 1024 * 1024);
+
+  // 128 MB allows max bitrate of 128 Mbit/s (e.g. UHD Blu-Ray) during 8 seconds
+  m_messageQueue.SetMaxDataSize(128 * 1024 * 1024);
   m_messageQueue.SetMaxTimeSize(8.0);
 
   m_iDroppedFrames = 0;


### PR DESCRIPTION
## Description
[VideoPlayer] Updates audio/video queues for nowadays maximum bitrates

## Motivation and context
Video Player was designed years ago and some maximum values were chosen taking into account Blu-Ray specifications but these values can be much higher on UHD Blu-Ray. Despite this everything still works quite well since the queuing system is robust and 8 seconds is oversized... even so currently it does not work as it should when the video bitrates are high enough (70, 80... 120 Mbps).

Queues allow a maximum of 8 seconds but are also limited in data size. That is, 8 seconds of video can be stored but at maximum of 40 Mbps.... if the stream has a sustained average of 80 Mbps then the video queue is 100% full with only 4 seconds. This also has side effects on audio queue since then there is only 4 seconds of queue and for audio is not full but at 50%.

It is common to see:
aq: 49%
vq: 100%

When this happens, it’s because the video queue is 100% saturated with a playback duration less than 8s.

Having 4s instead of 8s not directly causes playback issues but generates some inconsistencies and unwanted side effects: the playback status bar (forward) oscillates instead of staying a constant distance ahead and Debug Info OSD displays apparently erratic numbers.

In short, VideoPlayer was designed to have a constant 8s of data queued regardless of the video bitrate and when this is not met things start to work erratically...

This PR updates these constants according to the maximums of UHD Blu-Ray (128 Mbps video) and TrueHD (18 Mbps) to continue maintaining the 8s in these (probably) conditions.

Note that this does not works as a buffer where there is an amount of memory reserved/allocated all the time. The 128 MB of memory will only be used if the stream actually has 128 Mbps on average for 8 seconds straight, which is quite unlikely. So, this change will only use more RAM if the stream is more than 40 Mbps (previously the queue length was limited). Now it will begin to be limited with 128 Mbps video.

It can be said that this change has none effect if the streams played are less of 40 Mbps video and 6 Mbps audio.

## How has this been tested?
Runtime tested Windows x64 and Shield (on Shield used for weeks).

## What is the effect on users?
Smoother operation with high bitrate streams. Even without real playback problems, it solves minor/cosmetic glitches in the playback progress bar and Debug info OSD that can make the user think that things are working wrong in FileCache, etc.

## Screenshots (if appropriate):

Tested without FileCache (buffermode 3) as player queue things are more evident.

Debug Info OSD captures are from UHD Remux (Edge of Tomorrow) where video is easily > 80 Mbps and TrueHD audio.
For progress bar issue 110 Mbps Jellyfish video are used because with short duration videos is more evident.

**Before**

![before1](https://github.com/xbmc/xbmc/assets/58434170/72b48d6d-5fe8-49a7-8982-c130ee5b5cc0)


https://github.com/xbmc/xbmc/assets/58434170/a1599437-680c-4197-b28e-005656bc3a23


**After**

![after](https://github.com/xbmc/xbmc/assets/58434170/8f70c170-0b7b-4093-b257-5fef978cebaf)


https://github.com/xbmc/xbmc/assets/58434170/a345ba2c-72c1-4fba-a0d3-65b8d653622e




## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
