### PR TITLE
[favourites] Fix CFavouritesService::IsFavourited to only compare man…

### DIFF
--- a/xbmc/favourites/FavouritesService.h
+++ b/xbmc/favourites/FavouritesService.h
@@ -12,6 +12,7 @@
 #include "threads/CriticalSection.h"
 #include "utils/EventStream.h"
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -25,6 +26,9 @@ public:
   void ReInit(std::string userDataFolder);
 
   bool IsFavourited(const CFileItem& item, int contextWindow) const;
+  std::shared_ptr<CFileItem> GetFavourite(const CFileItem& item, int contextWindow) const;
+  std::shared_ptr<CFileItem> ResolveFavourite(const CFileItem& favItem) const;
+
   void GetAll(CFileItemList& items) const;
   bool AddOrRemove(const CFileItem& item, int contextWindow);
   bool Save(const CFileItemList& items);
@@ -46,11 +50,9 @@ private:
 
   void OnUpdated();
   bool Persist();
-  std::string GetFavouritesUrl(const CFileItem &item, int contextWindow) const;
 
   std::string m_userDataFolder;
   CFileItemList m_favourites;
   CEventSource<FavouritesUpdated> m_events;
   mutable CCriticalSection m_criticalSection;
 };
-


### PR DESCRIPTION
…datory parts of the favourites URLs.

Fixes a (long standing?) bug with items already added to favourites not recognized as such, resulting in context menu item "Add to favourites" offered for them, instead of "Remove from favourites".

How to reproduce:
0) Go to Estuary Home screen, Movies section
1) Open context menu for a movie appearing in "recently added movies" widget.
2) Select "Add to favourites" from context menu of the movie.
3) Open Movies window, navigate to the movie just added to favourites.
4) Open context menu
=> Bug: "Add to favourites" will be offered, not "Remove from favourites"

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 please review.