### PR TITLE
CPlatformFreebsd: use app params to set audio backend

### DIFF
--- a/cmake/scripts/freebsd/ArchSetup.cmake
+++ b/cmake/scripts/freebsd/ArchSetup.cmake
@@ -44,3 +44,5 @@ if(NOT USE_INTERNAL_LIBS)
     set(USE_INTERNAL_LIBS OFF)
   endif()
 endif()
+
+list(APPEND AUDIO_BACKENDS_LIST "oss")

--- a/tools/Linux/kodi.sh.in
+++ b/tools/Linux/kodi.sh.in
@@ -182,6 +182,8 @@ if [ -n "${KODI_AE_SINK}" ]; then
     ENV_ARGS="--audio-backend=pulseaudio"
   elif [ "${KODI_AE_SINK}" = "ALSA" ]; then
     ENV_ARGS="--audio-backend=alsa"
+  elif [ "${KODI_AE_SINK}" = "OSS" ]; then
+    ENV_ARGS="--audio-backend=oss"
   elif [ "${KODI_AE_SINK}" = "SNDIO" ]; then
     ENV_ARGS="--audio-backend=sndio"
   elif [ "${KODI_AE_SINK}" = "ALSA+PULSE" ]; then

--- a/xbmc/platform/freebsd/PlatformFreebsd.cpp
+++ b/xbmc/platform/freebsd/PlatformFreebsd.cpp
@@ -8,6 +8,8 @@
 
 #include "PlatformFreebsd.h"
 
+#include "ServiceBroker.h"
+#include "application/AppParams.h"
 #include "utils/StringUtils.h"
 
 #include "platform/freebsd/OptionalsReg.h"
@@ -79,27 +81,25 @@ bool CPlatformFreebsd::InitStageOne()
 
   CLinuxPowerSyscall::Register();
 
-  std::string envSink;
-  if (getenv("KODI_AE_SINK"))
-    envSink = getenv("KODI_AE_SINK");
+  std::string_view sink = CServiceBroker::GetAppParams()->GetAudioBackend();
 
-  if (StringUtils::EqualsNoCase(envSink, "ALSA"))
+  if (sink == "alsa")
   {
     OPTIONALS::ALSARegister();
   }
-  else if (StringUtils::EqualsNoCase(envSink, "PULSE"))
+  else if (sink == "pulseaudio")
   {
     OPTIONALS::PulseAudioRegister();
   }
-  else if (StringUtils::EqualsNoCase(envSink, "OSS"))
+  else if (sink == "oss")
   {
     OPTIONALS::OSSRegister();
   }
-  else if (StringUtils::EqualsNoCase(envSink, "SNDIO"))
+  else if (sink == "sndio")
   {
     OPTIONALS::SndioRegister();
   }
-  else if (StringUtils::EqualsNoCase(envSink, "ALSA+PULSE"))
+  else if (sink == "alsa+pulseaudio")
   {
     OPTIONALS::ALSARegister();
     OPTIONALS::PulseAudioRegister();


### PR DESCRIPTION
This probably should have been done in #23148 but oh well.

~I'm not actually sure if the cmake change will work as I think it may have to be propagated up one more parent scope.~