### PR TITLE
[DRMPRIME] Remove pitch check

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -105,7 +105,7 @@ bool CVideoLayerBridgeDRMPRIME::Map(CVideoBufferDRMPRIME* buffer)
   {
     int object = layer->planes[plane].object_index;
     uint32_t handle = buffer->m_handles[object];
-    if (handle && layer->planes[plane].pitch)
+    if (handle)
     {
       handles[plane] = handle;
       pitches[plane] = layer->planes[plane].pitch;


### PR DESCRIPTION
## Description
With some formats, like single plane and/or compressed ones, pitch can be 0, since it has no meaning there.

In any case, drmModeAddFB2WithModifiers() will verify arguments, including pitch (if applicable), and reject invalid combinations.

In order to fix this, remove pitch check.

## Motivation and context
Kodi failed to render AFBC compressed video buffers when testing on Allwinner H6 SoC.

## How has this been tested?
Tested on Allwinner H6 with AFBC compressed frames and LibreELEC master branch.

## What is the effect on users?
Proper video rendering with less common HW formats.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
