### PR TITLE
[Teletext] Only override the language code from header if it is actua…

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayerTeletext.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerTeletext.cpp
@@ -361,8 +361,12 @@ void CDVDTeletextData::Process()
               b1 = dehamming[vtxt_row[9]];
               if (b1 != 0xFF)
               {
-                pageinfo_thread->nationalvalid = 1;
-                pageinfo_thread->national = rev_lut[b1] & 0x07;
+                int countryCode = rev_lut[b1] & 0x07;
+                if (countryCode != NAT_DEFAULT)
+                {
+                  pageinfo_thread->nationalvalid = 1;
+                  pageinfo_thread->national = countryCode;
+                }
               }
 
               if (dehamming[vtxt_row[7]] & 0x08)// subtitle page
@@ -583,10 +587,11 @@ void CDVDTeletextData::Process()
                 {
                   int t1 = CDVDTeletextTools::deh24(&vtxt_row[7-4]);
                   pageinfo_thread->function = t1 & 0x0f;
-                  if (!pageinfo_thread->nationalvalid)
+                  int countryCode = (t1 >> 4) & 0x07;
+                  if (!pageinfo_thread->nationalvalid && countryCode != NAT_DEFAULT)
                   {
                     pageinfo_thread->nationalvalid = 1;
-                    pageinfo_thread->national = (t1>>4) & 0x07;
+                    pageinfo_thread->national = countryCode;
                   }
                 }
 


### PR DESCRIPTION
…lly valid

## Description
In our teletext implementation we always override the national subset which might have been received from a Packet X/28 (see https://www.etsi.org/deliver/etsi_en/300700_300799/300706/01.02.01_60/en_300706v010201p.pdf table 33) with the page header country code. The issue is that even if the header doesn't have a valid subset (0x00 countrycode) we set it anyway overriding any valid value previously set.

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/23882

## How has this been tested?
Runtime tested against the provided sample as well as my other test samples (and actual tv channels):

## What is the effect on users?
Some charsets were incorrectly setcausing visual glitches and unknown characters in the teletext browser.

## Screenshots (if appropriate):


**Before:**
![image](https://github.com/xbmc/xbmc/assets/7375276/d515403b-47d6-4951-995a-82579180f73a)


**Now:**
![image](https://github.com/xbmc/xbmc/assets/7375276/f54559dd-e621-4229-ae77-eabcd5aabeed)

**Other tested samples with different charsets:**
(pt)
![image](https://github.com/xbmc/xbmc/assets/7375276/4edd09ce-a6fb-42d6-82bd-13b3672781d7)

(spanish)
![image](https://github.com/xbmc/xbmc/assets/7375276/9797e810-ca30-4300-ad4e-b7de956884a1)

(uk)
![image](https://github.com/xbmc/xbmc/assets/7375276/a139a0ed-b19a-4c97-9496-66e85984d9ec)

(russian)
![image](https://github.com/xbmc/xbmc/assets/7375276/5276c9ab-34cf-4c5e-a8c9-2e6595e94561)




## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
