### PR TITLE
[Windows][UWP] VSync Detection Fixes and Improvements

### DIFF
--- a/xbmc/rendering/dx/DeviceResources.h
+++ b/xbmc/rendering/dx/DeviceResources.h
@@ -68,6 +68,13 @@ namespace DX
     CD3DTexture& GetBackBuffer() { return m_backBufferTex; }
 
     void GetOutput(IDXGIOutput** ppOutput) const;
+    /*!
+     * \brief Retrieve current output and output description. Use cached data first to avoid delays due
+     * to dxgi internal multithreading synchronization.
+     * \param output The output
+     * \param outputDesc The output description
+    */
+    void GetCachedOutputAndDesc(IDXGIOutput** output, DXGI_OUTPUT_DESC* outputDesc) const;
     DXGI_ADAPTER_DESC GetAdapterDesc() const;
     void GetDisplayMode(DXGI_MODE_DESC *mode) const;
 
@@ -152,6 +159,7 @@ namespace DX
     Microsoft::WRL::ComPtr<IDXGIFactory2> m_dxgiFactory;
     Microsoft::WRL::ComPtr<IDXGIAdapter1> m_adapter;
     Microsoft::WRL::ComPtr<IDXGIOutput1> m_output;
+    DXGI_OUTPUT_DESC m_outputDesc{};
 
     Microsoft::WRL::ComPtr<ID3D11Device1> m_d3dDevice;
     Microsoft::WRL::ComPtr<ID3D11DeviceContext1> m_d3dContext;

--- a/xbmc/windowing/windows/VideoSyncD3D.cpp
+++ b/xbmc/windowing/windows/VideoSyncD3D.cpp
@@ -63,7 +63,7 @@ void CVideoSyncD3D::Run(CEvent& stopEvent)
   int64_t LastVBlankTime;
   int NrVBlanks;
   double VBlankTime;
-  int64_t systemFrequency = CurrentHostFrequency();
+  const int64_t systemFrequency = CurrentHostFrequency();
 
   // init the vblanktime
   Now = CurrentHostCounter();

--- a/xbmc/windowing/windows/VideoSyncD3D.cpp
+++ b/xbmc/windowing/windows/VideoSyncD3D.cpp
@@ -61,8 +61,7 @@ bool CVideoSyncD3D::Setup()
   CreateDXGIFactory1(IID_PPV_ARGS(m_factory.ReleaseAndGetAddressOf()));
 
   Microsoft::WRL::ComPtr<IDXGIOutput> pOutput;
-  DX::DeviceResources::Get()->GetOutput(&pOutput);
-  pOutput->GetDesc(&m_outputDesc);
+  DX::DeviceResources::Get()->GetCachedOutputAndDesc(&pOutput, &m_outputDesc);
 
   return true;
 }
@@ -84,11 +83,11 @@ void CVideoSyncD3D::Run(CEvent& stopEvent)
   {
     // sleep until vblank
     Microsoft::WRL::ComPtr<IDXGIOutput> pOutput;
-    DX::DeviceResources::Get()->GetOutput(&pOutput);
-    pOutput->GetDesc(&m_outputDesc);
+    DX::DeviceResources::Get()->GetCachedOutputAndDesc(pOutput.ReleaseAndGetAddressOf(),
+                                                       &m_outputDesc);
 
     const int64_t WaitForVBlankStartTime = CurrentHostCounter();
-    const HRESULT hr = pOutput->WaitForVBlank();
+    const HRESULT hr = pOutput ? pOutput->WaitForVBlank() : E_INVALIDARG;
     const int64_t WaitForVBlankElapsedTime = CurrentHostCounter() - WaitForVBlankStartTime;
 
     // WaitForVBlank() can return very quickly due to errors or screen sleeping

--- a/xbmc/windowing/windows/VideoSyncD3D.cpp
+++ b/xbmc/windowing/windows/VideoSyncD3D.cpp
@@ -93,14 +93,6 @@ void CVideoSyncD3D::Run(CEvent& stopEvent)
       if (fps != GetFps())
         break;
     }
-
-    // because we had a vblank, sleep until half the refreshrate period because i think WaitForVBlank block any rendering stuf
-    // without sleeping we have freeze rendering
-    int SleepTime = (int)((LastVBlankTime + (systemFrequency / MathUtils::round_int(m_fps) / 2) - Now) * 1000 / systemFrequency);
-    if (SleepTime > 50)
-      SleepTime = 50; //failsafe
-    if (SleepTime > 0)
-      ::Sleep(SleepTime);
   }
 
   m_lostEvent.Set();

--- a/xbmc/windowing/windows/VideoSyncD3D.h
+++ b/xbmc/windowing/windows/VideoSyncD3D.h
@@ -12,6 +12,8 @@
 #include "threads/Event.h"
 #include "windowing/VideoSync.h"
 
+#include <dxgi1_5.h>
+
 class CVideoSyncD3D : public CVideoSync, IDispResource
 {
 public:
@@ -33,5 +35,6 @@ private:
   volatile bool m_displayReset;
   CEvent m_lostEvent;
   int64_t m_lastUpdateTime;
+  DXGI_OUTPUT_DESC m_outputDesc{};
 };
 

--- a/xbmc/windowing/windows/VideoSyncD3D.h
+++ b/xbmc/windowing/windows/VideoSyncD3D.h
@@ -18,7 +18,7 @@ class CVideoSyncD3D : public CVideoSync, IDispResource
 {
 public:
   CVideoSyncD3D(CVideoReferenceClock* clock)
-    : CVideoSync(clock), m_displayLost(false), m_displayReset(false), m_lastUpdateTime(0)
+    : CVideoSync(clock), m_displayLost(false), m_displayReset(false)
   {
   }
   bool Setup() override;
@@ -34,7 +34,7 @@ private:
   volatile bool m_displayLost;
   volatile bool m_displayReset;
   CEvent m_lostEvent;
-  int64_t m_lastUpdateTime;
   DXGI_OUTPUT_DESC m_outputDesc{};
+  Microsoft::WRL::ComPtr<IDXGIFactory2> m_factory;
 };
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

When using the "Sync to playback" mode, the "missed vsync" counter of the player debug info (ctrl-shift-O) constantly increases for both win64 and uwp on win64 (most likely on xbox as well). The higher the display refresh rate, the faster the counter increases.

After investigation with VS "Concurrency Visualizer", the largest contributor to the missed vsyncs is dxgi's multithreading synchronization. The  vsync detection loop runs on a different thread than rendering and a few functions get blocked by the Present() calls on the main thread, which block from the completion of rendering until vsync. As a result, every second vsync is missed.

It took a while and a lot of testing to figure things out and create the PR as there were many unexpected side effects...

One commit per change, descriptions in the commit messages.

The change with the most impact is the removal of the sleep of half a vsync period, which was necessary with Windows 7 but not with later versions of Windows. It caused the output release before WaitForVBlank to wait for Present of main thread to complete, and missed the vblank. With UWP, in addition, the lack of API to increase timer resolution did not allow sleeping accurately enough.

The last commit uses the dxgi output maintained by windowing code rather than retrieving it from dxgi for every frame. It's not 100% necessary to do after the half-vsync sleep removal, but still helps reduce resource usage and provides more safety for nVidia + combined HDR/refresh rate switch (see testing).

Testing for refresh rate change was kept for safety when HDR status is switched, because there is an intermediate state right after HDR switch when the refresh rate reverts to desktop rate before it's changed again to the wanted refresh rate. There is nothing preventing the video clock code from sampling the refresh rate exactly at this transition time, and to retrieve an incorrect value. It happened from time to time during testing.
Could be removed after improving events around the HDR switch. Throwing the events OnLostDisplay/OnResetDisplay is enough to cause the video clock to sample the refresh rate again.
Until then, optimized the code a bit to be less costly per frame.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Missed vsync counter increases quickly in the player debug info (ctrl-shift-O) in Windows 10 x64 with native and UWP builds (most likely on xbox as well).

That doesn't seem right, although it's not clear that there is much impact because the video clock seems to interpolate from the last good vsync.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 10 64 bits, native and UWP version. Windows 8 64 bits.
Windows 7: not available but should still be OK since the half-vsync sleep was not changed.
Xbox: testing required, I don't have the HW.

Tried AMD, Intel (multiple generations) and nVidia, with/without refresh rate and HDR switching > missed counter usually doesn't increase after initial rendering initializations. Stressing the system can still cause some misses but that seems difficult to avoid completely.

One weird problem noticed (but pre-existing so no action needed in PR): with nVidia and HDR + refresh rate switch, the vsync detection works fine, but the main thread / rendering still presents at the original desktop refresh rate speed instead of the new refresh rate > not normal. May explain some jerkyness/stutter/...
This is clearly visible with the Concurrency Visualizer tool of VS. No problem with AMD in same scenario.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Theoretically slightly better synchronization, but not clear as it seems that the video reference clock interpolates the good vsyncs to hide the missed vsyncs.

## Screenshots (if appropriate):
With the PR, low and steady missed count
![image](https://github.com/xbmc/xbmc/assets/489377/2f1a518e-056b-4621-9635-61b666bd04e5)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
