### PR TITLE
[video] Fix 'Play using' and external default player not working.

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -574,7 +574,7 @@ protected:
       return true;
     }
     // play the video
-    return m_window.OnClick(m_itemIndex);
+    return m_window.OnClick(m_itemIndex, m_player);
   }
 
   bool OnQueueSelected() override


### PR DESCRIPTION
Fix fallout from https://github.com/xbmc/xbmc/pull/23848

Another proof why I hate default parameters. :-/

Reported in the forum: https://forum.kodi.tv/showthread.php?tid=374657

Runtime-tested by me on macOS, latest Kodi master.

@enen92 should be a no-brainer. Not passing on the player to use will result in not using that player, right?