### PR TITLE
[favourites] Add selected items of the target to favourite's context menu

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -953,6 +953,7 @@ msgstr ""
 #: addons/skin.estuary/xml/SkinSettings.xml
 #: addons/skin.estuary/xml/Variables.xml
 #: xbmc/dialogs/GUIDialogPlayEject.cpp
+#: xbmc/favourites/ContextMenus.cpp
 #: xbmc/games/windows/GUIWindowGames.cpp
 #: xbmc/music/ContextMenus.h
 #: xbmc/video/ContextMenus.cpp
@@ -5722,6 +5723,7 @@ msgstr ""
 #: addons/skin.estuary/xml/SkinSettings.xml
 #: addons/skin.estuary/xml/Variables.xml
 #: xbmc/Autorun.cpp
+#: xbmc/favourites/ContextMenus.cpp
 #: xbmc/pvr/PVRGUIActionsPlayback.cpp
 #: xbmc/video/ContextMenus.cpp
 #: xbmc/video/guilib/VideoSelectActionProcessor.cpp
@@ -9637,6 +9639,7 @@ msgstr ""
 
 #. generic 'information' label used in different places, like labels for message box headers
 #: xbmc/event/windows/GUIWindowEventLog.cpp
+#: xbmc/favourites/ContextMenus.cpp
 #: xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
 #: xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
 #: xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -15348,6 +15351,7 @@ msgid "Show information"
 msgstr ""
 
 #. Label to denote that there is something 'more'
+#. xbmc/favourites/ContextMenus.h
 #: xbmc/listproviders/DirectoryProvider.cpp
 #: xbmc/video/guilib/VideoSelectActionProcessor.cpp
 #: system/settings/settings.xml
@@ -21937,8 +21941,10 @@ msgctxt "#37014"
 msgid "Last used profile"
 msgstr ""
 
+#. Label used in different places to denote the function to open a folder to list its content
 #: addons/skin.estuary/xml/SkinSettings.xml
 #: addons/skin.estuary/xml/Variables.xml
+#: xbmc/favourites/ContextMenus.h
 #: xbmc/music/ContextMenus.h
 #: xbmc/windows/GUIMediaWindow.cpp
 msgctxt "#37015"

--- a/cmake/treedata/common/subdirs.txt
+++ b/cmake/treedata/common/subdirs.txt
@@ -41,6 +41,7 @@ xbmc/speech                                     speech
 xbmc/storage                                    storage
 xbmc/threads                                    threads
 xbmc/utils                                      utils
+xbmc/utils/guilib                               utils_guilib
 xbmc/view                                       view
 xbmc/weather                                    weather
 xbmc/windowing                                  windowing

--- a/xbmc/ContextMenuManager.h
+++ b/xbmc/ContextMenuManager.h
@@ -40,8 +40,10 @@ public:
   void Init();
   void Deinit();
 
+  bool HasItems(const CFileItem& fileItem) const;
   ContextMenuView GetItems(const CFileItem& item, const CContextMenuItem& root = MAIN) const;
 
+  bool HasAddonItems(const CFileItem& fileItem) const;
   ContextMenuView GetAddonItems(const CFileItem& item, const CContextMenuItem& root = MAIN) const;
 
 private:
@@ -67,7 +69,12 @@ private:
 
 namespace CONTEXTMENU
 {
-  /*!
+/*!
+ * Checks whether any context menu items are available for a file item.
+ * */
+bool HasAnyMenuItemsFor(const std::shared_ptr<CFileItem>& fileItem);
+
+/*!
    * Starts the context menu loop for a file item.
    * */
 bool ShowFor(const std::shared_ptr<CFileItem>& fileItem,

--- a/xbmc/ContextMenus.cpp
+++ b/xbmc/ContextMenus.cpp
@@ -78,6 +78,9 @@ std::string CAddRemoveFavourite::GetLabel(const CFileItem& item) const
 
 bool CAddRemoveFavourite::IsVisible(const CFileItem& item) const
 {
+  if (item.GetProperty("hide_add_remove_favourite").asBoolean())
+    return false;
+
   return (!item.GetPath().empty() && !item.IsParentFolder() && !item.IsPath("add") &&
           !item.IsPath("newplaylist://") && !URIUtils::IsProtocol(item.GetPath(), "favourites") &&
           !URIUtils::IsProtocol(item.GetPath(), "newsmartplaylist") &&

--- a/xbmc/favourites/ContextMenus.cpp
+++ b/xbmc/favourites/ContextMenus.cpp
@@ -8,14 +8,20 @@
 
 #include "ContextMenus.h"
 
+#include "ContextMenuManager.h"
 #include "FileItem.h"
 #include "ServiceBroker.h"
 #include "favourites/FavouritesService.h"
+#include "favourites/FavouritesURL.h"
 #include "favourites/FavouritesUtils.h"
+#include "guilib/LocalizeStrings.h"
 #include "utils/URIUtils.h"
+#include "utils/Variant.h"
+#include "utils/guilib/GUIContentUtils.h"
+#include "video/VideoUtils.h"
 
-namespace CONTEXTMENU
-{
+using namespace CONTEXTMENU;
+
 bool CFavouriteContextMenuAction::IsVisible(const CFileItem& item) const
 {
   return URIUtils::IsProtocol(item.GetPath(), "favourites");
@@ -73,4 +79,131 @@ bool CChooseThumbnailForFavourite::DoExecute(CFileItemList&,
   return FAVOURITES_UTILS::ChooseAndSetNewThumbnail(*item);
 }
 
-} // namespace CONTEXTMENU
+namespace
+{
+std::shared_ptr<CFileItem> ResolveFavouriteItem(const CFileItem& item)
+{
+  const std::shared_ptr<CFileItem> targetItem{
+      CServiceBroker::GetFavouritesService().ResolveFavourite(item)};
+  if (targetItem)
+    targetItem->SetProperty("hide_add_remove_favourite", CVariant{true});
+
+  return targetItem;
+}
+
+bool IsPlayMediaFavourite(const CFileItem& item)
+{
+  if (item.IsFavourite())
+  {
+    const CFavouritesURL favURL{item, -1};
+    if (favURL.IsValid())
+      return favURL.GetAction() == CFavouritesURL::Action::PLAY_MEDIA;
+  }
+  return false;
+}
+
+bool IsActivateWindowFavourite(const CFileItem& item)
+{
+  if (item.IsFavourite())
+  {
+    const CFavouritesURL favURL{item, -1};
+    if (favURL.IsValid())
+      return favURL.GetAction() == CFavouritesURL::Action::ACTIVATE_WINDOW;
+  }
+  return false;
+}
+} // unnamed namespace
+
+bool CFavouritesTargetBrowse::IsVisible(const CFileItem& item) const
+{
+  return IsActivateWindowFavourite(item);
+}
+
+bool CFavouritesTargetBrowse::Execute(const std::shared_ptr<CFileItem>& item) const
+{
+  return FAVOURITES_UTILS::ExecuteAction({*item, -1});
+}
+
+std::string CFavouritesTargetResume::GetLabel(const CFileItem& item) const
+{
+  const std::shared_ptr<CFileItem> targetItem{ResolveFavouriteItem(item)};
+  if (targetItem)
+    return VIDEO_UTILS::GetResumeString(*targetItem);
+
+  return {};
+}
+
+bool CFavouritesTargetResume::IsVisible(const CFileItem& item) const
+{
+  if (IsPlayMediaFavourite(item))
+  {
+    const std::shared_ptr<CFileItem> targetItem{ResolveFavouriteItem(item)};
+    if (targetItem)
+      return VIDEO_UTILS::GetItemResumeInformation(*targetItem).isResumable;
+  }
+  return false;
+}
+
+bool CFavouritesTargetResume::Execute(const std::shared_ptr<CFileItem>& item) const
+{
+  FAVOURITES_UTILS::ExecuteAction({"PlayMedia", *item, "resume"});
+  return true;
+}
+
+std::string CFavouritesTargetPlay::GetLabel(const CFileItem& item) const
+{
+  const std::shared_ptr<CFileItem> targetItem{ResolveFavouriteItem(item)};
+  if (targetItem && VIDEO_UTILS::GetItemResumeInformation(*targetItem).isResumable)
+    return g_localizeStrings.Get(12021); // Play from beginning
+
+  return g_localizeStrings.Get(208); // Play
+}
+
+bool CFavouritesTargetPlay::IsVisible(const CFileItem& item) const
+{
+  return IsPlayMediaFavourite(item);
+}
+
+bool CFavouritesTargetPlay::Execute(const std::shared_ptr<CFileItem>& item) const
+{
+  FAVOURITES_UTILS::ExecuteAction({"PlayMedia", *item, "noresume"});
+  return true;
+}
+
+bool CFavouritesTargetInfo::IsVisible(const CFileItem& item) const
+{
+  const std::shared_ptr<CFileItem> targetItem{ResolveFavouriteItem(item)};
+  if (targetItem)
+    return UTILS::GUILIB::CGUIContentUtils::HasInfoForItem(*targetItem);
+
+  return false;
+}
+
+bool CFavouritesTargetInfo::Execute(const std::shared_ptr<CFileItem>& item) const
+{
+  const std::shared_ptr<CFileItem> targetItem{ResolveFavouriteItem(*item)};
+  if (targetItem)
+    return UTILS::GUILIB::CGUIContentUtils::ShowInfoForItem(*targetItem);
+
+  return false;
+}
+
+bool CFavouritesTargetContextMenu::IsVisible(const CFileItem& item) const
+{
+  const std::shared_ptr<CFileItem> targetItem{ResolveFavouriteItem(item)};
+  if (targetItem)
+    return CONTEXTMENU::HasAnyMenuItemsFor(targetItem);
+
+  return false;
+}
+
+bool CFavouritesTargetContextMenu::Execute(const std::shared_ptr<CFileItem>& item) const
+{
+  const std::shared_ptr<CFileItem> targetItem{ResolveFavouriteItem(*item)};
+  if (targetItem)
+  {
+    CONTEXTMENU::ShowFor(targetItem);
+    return true;
+  }
+  return false;
+}

--- a/xbmc/favourites/ContextMenus.cpp
+++ b/xbmc/favourites/ContextMenus.cpp
@@ -16,65 +16,61 @@
 
 namespace CONTEXTMENU
 {
-  bool CFavouriteContextMenuAction::IsVisible(const CFileItem& item) const
-  {
-    return URIUtils::IsProtocol(item.GetPath(), "favourites");
-  }
+bool CFavouriteContextMenuAction::IsVisible(const CFileItem& item) const
+{
+  return URIUtils::IsProtocol(item.GetPath(), "favourites");
+}
 
-  bool CFavouriteContextMenuAction::Execute(const std::shared_ptr<CFileItem>& item) const
+bool CFavouriteContextMenuAction::Execute(const std::shared_ptr<CFileItem>& item) const
+{
+  CFileItemList items;
+  CServiceBroker::GetFavouritesService().GetAll(items);
+  for (const auto& favourite : items)
   {
-    CFileItemList items;
-    CServiceBroker::GetFavouritesService().GetAll(items);
-    for (const auto& favourite : items)
+    if (favourite->GetPath() == item->GetPath())
     {
-      if (favourite->GetPath() == item->GetPath())
-      {
-        if (DoExecute(items, favourite))
-          return CServiceBroker::GetFavouritesService().Save(items);
-      }
+      if (DoExecute(items, favourite))
+        return CServiceBroker::GetFavouritesService().Save(items);
     }
-    return false;
   }
+  return false;
+}
 
-  bool CMoveUpFavourite::DoExecute(CFileItemList& items,
+bool CMoveUpFavourite::DoExecute(CFileItemList& items, const std::shared_ptr<CFileItem>& item) const
+{
+  return FAVOURITES_UTILS::MoveItem(items, item, -1);
+}
+
+bool CMoveUpFavourite::IsVisible(const CFileItem& item) const
+{
+  return CFavouriteContextMenuAction::IsVisible(item) && FAVOURITES_UTILS::ShouldEnableMoveItems();
+}
+
+bool CMoveDownFavourite::DoExecute(CFileItemList& items,
                                    const std::shared_ptr<CFileItem>& item) const
-  {
-    return FAVOURITES_UTILS::MoveItem(items, item, -1);
-  }
+{
+  return FAVOURITES_UTILS::MoveItem(items, item, +1);
+}
 
-  bool CMoveUpFavourite::IsVisible(const CFileItem& item) const
-  {
-    return CFavouriteContextMenuAction::IsVisible(item) &&
-           FAVOURITES_UTILS::ShouldEnableMoveItems();
-  }
+bool CMoveDownFavourite::IsVisible(const CFileItem& item) const
+{
+  return CFavouriteContextMenuAction::IsVisible(item) && FAVOURITES_UTILS::ShouldEnableMoveItems();
+}
 
-  bool CMoveDownFavourite::DoExecute(CFileItemList& items,
-                                     const std::shared_ptr<CFileItem>& item) const
-  {
-    return FAVOURITES_UTILS::MoveItem(items, item, +1);
-  }
+bool CRemoveFavourite::DoExecute(CFileItemList& items, const std::shared_ptr<CFileItem>& item) const
+{
+  return FAVOURITES_UTILS::RemoveItem(items, item);
+}
 
-  bool CMoveDownFavourite::IsVisible(const CFileItem& item) const
-  {
-    return CFavouriteContextMenuAction::IsVisible(item) &&
-           FAVOURITES_UTILS::ShouldEnableMoveItems();
-  }
+bool CRenameFavourite::DoExecute(CFileItemList&, const std::shared_ptr<CFileItem>& item) const
+{
+  return FAVOURITES_UTILS::ChooseAndSetNewName(*item);
+}
 
-  bool CRemoveFavourite::DoExecute(CFileItemList& items,
-                                   const std::shared_ptr<CFileItem>& item) const
-  {
-    return FAVOURITES_UTILS::RemoveItem(items, item);
-  }
-
-  bool CRenameFavourite::DoExecute(CFileItemList&, const std::shared_ptr<CFileItem>& item) const
-  {
-    return FAVOURITES_UTILS::ChooseAndSetNewName(*item);
-  }
-
-  bool CChooseThumbnailForFavourite::DoExecute(CFileItemList&,
-                                               const std::shared_ptr<CFileItem>& item) const
-  {
-    return FAVOURITES_UTILS::ChooseAndSetNewThumbnail(*item);
-  }
+bool CChooseThumbnailForFavourite::DoExecute(CFileItemList&,
+                                             const std::shared_ptr<CFileItem>& item) const
+{
+  return FAVOURITES_UTILS::ChooseAndSetNewThumbnail(*item);
+}
 
 } // namespace CONTEXTMENU

--- a/xbmc/favourites/ContextMenus.h
+++ b/xbmc/favourites/ContextMenus.h
@@ -73,4 +73,44 @@ protected:
   bool DoExecute(CFileItemList& items, const std::shared_ptr<CFileItem>& item) const override;
 };
 
+class CFavouritesTargetBrowse : public CStaticContextMenuAction
+{
+public:
+  explicit CFavouritesTargetBrowse() : CStaticContextMenuAction(37015) {} // Browse into
+  bool IsVisible(const CFileItem& item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override;
+};
+
+class CFavouritesTargetResume : public IContextMenuItem
+{
+public:
+  std::string GetLabel(const CFileItem& item) const override;
+  bool IsVisible(const CFileItem& item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override;
+};
+
+class CFavouritesTargetPlay : public IContextMenuItem
+{
+public:
+  std::string GetLabel(const CFileItem& item) const override;
+  bool IsVisible(const CFileItem& item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override;
+};
+
+class CFavouritesTargetInfo : public CStaticContextMenuAction
+{
+public:
+  explicit CFavouritesTargetInfo() : CStaticContextMenuAction(19033) {} // Information
+  bool IsVisible(const CFileItem& item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override;
+};
+
+class CFavouritesTargetContextMenu : public CStaticContextMenuAction
+{
+public:
+  explicit CFavouritesTargetContextMenu() : CStaticContextMenuAction(22082) {} // More...
+  bool IsVisible(const CFileItem& item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override;
+};
+
 } // namespace CONTEXTMENU

--- a/xbmc/favourites/ContextMenus.h
+++ b/xbmc/favourites/ContextMenus.h
@@ -73,4 +73,4 @@ protected:
   bool DoExecute(CFileItemList& items, const std::shared_ptr<CFileItem>& item) const override;
 };
 
-}
+} // namespace CONTEXTMENU

--- a/xbmc/favourites/FavouritesService.h
+++ b/xbmc/favourites/FavouritesService.h
@@ -14,6 +14,7 @@
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 class CFavouritesService
@@ -53,6 +54,7 @@ private:
 
   std::string m_userDataFolder;
   CFileItemList m_favourites;
+  mutable std::unordered_map<std::string, std::shared_ptr<CFileItem>> m_targets;
   CEventSource<FavouritesUpdated> m_events;
   mutable CCriticalSection m_criticalSection;
 };

--- a/xbmc/favourites/FavouritesUtils.cpp
+++ b/xbmc/favourites/FavouritesUtils.cpp
@@ -11,12 +11,15 @@
 #include "FileItem.h"
 #include "ServiceBroker.h"
 #include "dialogs/GUIDialogFileBrowser.h"
+#include "favourites/FavouritesURL.h"
 #include "favourites/GUIWindowFavourites.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
+#include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "storage/MediaManager.h"
+#include "utils/ExecString.h"
 #include "utils/Variant.h"
 #include "view/GUIViewState.h"
 
@@ -119,6 +122,34 @@ bool ShouldEnableMoveItems()
       return false; // in favs window, allow move only if current sort method is by user preference
   }
   return true;
+}
+
+namespace
+{
+bool ExecuteAction(const std::string& execString)
+{
+  if (!execString.empty())
+  {
+    CGUIMessage message(GUI_MSG_EXECUTE, 0, 0);
+    message.SetStringParam(execString);
+    CServiceBroker::GetGUI()->GetWindowManager().SendMessage(message);
+    return true;
+  }
+  return false;
+}
+} // unnamed namespace
+
+bool ExecuteAction(const CExecString& execString)
+{
+  return ExecuteAction(execString.GetExecString());
+}
+
+bool ExecuteAction(const CFavouritesURL& favURL)
+{
+  if (favURL.IsValid())
+    return ExecuteAction(favURL.GetExecString());
+
+  return false;
 }
 
 } // namespace FAVOURITES_UTILS

--- a/xbmc/favourites/FavouritesUtils.h
+++ b/xbmc/favourites/FavouritesUtils.h
@@ -10,6 +10,8 @@
 
 #include <memory>
 
+class CExecString;
+class CFavouritesURL;
 class CFileItem;
 class CFileItemList;
 
@@ -20,5 +22,8 @@ bool ChooseAndSetNewThumbnail(CFileItem& item);
 bool MoveItem(CFileItemList& items, const std::shared_ptr<CFileItem>& item, int amount);
 bool RemoveItem(CFileItemList& items, const std::shared_ptr<CFileItem>& item);
 bool ShouldEnableMoveItems();
+
+bool ExecuteAction(const CExecString& execString);
+bool ExecuteAction(const CFavouritesURL& favURL);
 
 } // namespace FAVOURITES_UTILS

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -12,7 +12,6 @@
 #include "FileItem.h"
 #include "ServiceBroker.h"
 #include "addons/AddonManager.h"
-#include "addons/gui/GUIDialogAddonInfo.h"
 #include "favourites/FavouritesService.h"
 #include "favourites/FavouritesURL.h"
 #include "filesystem/Directory.h"
@@ -21,25 +20,24 @@
 #include "guilib/LocalizeStrings.h"
 #include "interfaces/AnnouncementManager.h"
 #include "music/MusicThumbLoader.h"
-#include "music/dialogs/GUIDialogMusicInfo.h"
 #include "pictures/PictureThumbLoader.h"
 #include "pvr/PVRManager.h"
 #include "pvr/PVRThumbLoader.h"
-#include "pvr/guilib/PVRGUIActionsUtils.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/ExecString.h"
 #include "utils/JobManager.h"
 #include "utils/PlayerUtils.h"
 #include "utils/SortUtils.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "utils/XMLUtils.h"
+#include "utils/guilib/GUIContentUtils.h"
 #include "utils/log.h"
 #include "video/VideoInfoTag.h"
 #include "video/VideoThumbLoader.h"
 #include "video/VideoUtils.h"
-#include "video/dialogs/GUIDialogVideoInfo.h"
 #include "video/guilib/VideoPlayActionProcessor.h"
 #include "video/guilib/VideoSelectActionProcessor.h"
 
@@ -628,32 +626,7 @@ bool CDirectoryProvider::OnPlay(const CGUIListItemPtr& item)
 
 bool CDirectoryProvider::OnInfo(const std::shared_ptr<CFileItem>& fileItem)
 {
-  if (fileItem->HasAddonInfo())
-  {
-    return CGUIDialogAddonInfo::ShowForItem(fileItem);
-  }
-  else if (fileItem->IsPVR())
-  {
-    return CServiceBroker::GetPVRManager().Get<PVR::GUI::Utils>().OnInfo(*fileItem);
-  }
-  else if (fileItem->HasVideoInfoTag())
-  {
-    auto mediaType = fileItem->GetVideoInfoTag()->m_type;
-    if (mediaType == MediaTypeMovie || mediaType == MediaTypeTvShow ||
-        mediaType == MediaTypeSeason || mediaType == MediaTypeEpisode ||
-        mediaType == MediaTypeVideo || mediaType == MediaTypeVideoCollection ||
-        mediaType == MediaTypeMusicVideo)
-    {
-      CGUIDialogVideoInfo::ShowFor(*fileItem);
-      return true;
-    }
-  }
-  else if (fileItem->HasMusicInfoTag())
-  {
-    CGUIDialogMusicInfo::ShowFor(fileItem.get());
-    return true;
-  }
-  return false;
+  return UTILS::GUILIB::CGUIContentUtils::ShowInfoForItem(*fileItem);
 }
 
 bool CDirectoryProvider::OnInfo(const CGUIListItemPtr& item)

--- a/xbmc/utils/guilib/CMakeLists.txt
+++ b/xbmc/utils/guilib/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES GUIContentUtils.cpp)
+
+set(HEADERS GUIContentUtils.h)
+
+core_add_library(utils_guilib)

--- a/xbmc/utils/guilib/GUIContentUtils.cpp
+++ b/xbmc/utils/guilib/GUIContentUtils.cpp
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GUIContentUtils.h"
+
+#include "FileItem.h"
+#include "ServiceBroker.h"
+#include "addons/gui/GUIDialogAddonInfo.h"
+#include "music/dialogs/GUIDialogMusicInfo.h"
+#include "pvr/PVRManager.h"
+#include "pvr/guilib/PVRGUIActionsUtils.h"
+#include "video/VideoInfoTag.h"
+#include "video/dialogs/GUIDialogVideoInfo.h"
+
+using namespace UTILS::GUILIB;
+
+bool CGUIContentUtils::HasInfoForItem(const CFileItem& item)
+{
+  if (item.HasVideoInfoTag() && !item.HasPVRRecordingInfoTag())
+  {
+    auto mediaType = item.GetVideoInfoTag()->m_type;
+    return (mediaType == MediaTypeMovie || mediaType == MediaTypeTvShow ||
+            mediaType == MediaTypeSeason || mediaType == MediaTypeEpisode ||
+            mediaType == MediaTypeVideo || mediaType == MediaTypeVideoCollection ||
+            mediaType == MediaTypeMusicVideo);
+  }
+
+  return (item.HasMusicInfoTag() || item.IsPVR() || item.HasAddonInfo());
+}
+
+bool CGUIContentUtils::ShowInfoForItem(const CFileItem& item)
+{
+  if (item.HasAddonInfo())
+  {
+    return CGUIDialogAddonInfo::ShowForItem(std::make_shared<CFileItem>(item));
+  }
+  else if (item.IsPVR())
+  {
+    return CServiceBroker::GetPVRManager().Get<PVR::GUI::Utils>().OnInfo(item);
+  }
+  else if (item.HasVideoInfoTag())
+  {
+    CGUIDialogVideoInfo::ShowFor(item);
+    return true;
+  }
+  else if (item.HasMusicInfoTag())
+  {
+    CGUIDialogMusicInfo::ShowFor(std::make_shared<CFileItem>(item).get());
+    return true;
+  }
+  return false;
+}

--- a/xbmc/utils/guilib/GUIContentUtils.h
+++ b/xbmc/utils/guilib/GUIContentUtils.h
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+class CFileItem;
+
+namespace UTILS
+{
+namespace GUILIB
+{
+class CGUIContentUtils
+{
+public:
+  /*! \brief Check whether an information dialog is available for the given item.
+    \param item The item to process
+    \return True if an information dialog is available, false otherwise
+  */
+  static bool HasInfoForItem(const CFileItem& item);
+
+  /*! \brief Show an information dialog for the given item.
+    \param item The item to process
+    \return True if an information dialog was displayed, false otherwise
+  */
+  static bool ShowInfoForItem(const CFileItem& item);
+};
+} // namespace GUILIB
+} // namespace UTILS


### PR DESCRIPTION
Requested in the forum. People want favourites to have the most common context menu items of the favourited items.

This PR adds selected context menu items from the favourites' source context menu to the context menu of the favourite itself.

* Browse into (for folders)
* Play vs. Play from beginning / Resume 
* Information
* More... (opens the complete context menu of the favourited item)

![screenshot00011](https://github.com/xbmc/xbmc/assets/3226626/1750c27e-f1ce-47d7-9eca-a1cab8508d74)
![screenshot00012](https://github.com/xbmc/xbmc/assets/3226626/ba937cc6-1df6-45bd-99ce-88ea5ad65430)
![screenshot00003](https://github.com/xbmc/xbmc/assets/3226626/ee1afb61-bdd0-4f21-90b9-6bf59ef35767)

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 another one I would be happy to get your review for.
