### PR TITLE
[GUIDialogTeletext] Mark dirty if data has changed in the decoder

### DIFF
--- a/xbmc/video/Teletext.cpp
+++ b/xbmc/video/Teletext.cpp
@@ -447,6 +447,25 @@ CTeletextDecoder::CTeletextDecoder()
 
 CTeletextDecoder::~CTeletextDecoder() = default;
 
+bool CTeletextDecoder::Changed()
+{
+  std::unique_lock<CCriticalSection> lock(m_txtCache->m_critSection);
+  if (IsSubtitlePage(m_txtCache->Page))
+  {
+    m_updateTexture = true;
+    return true;
+  }
+
+  /* Update on every changed second */
+  if (m_txtCache->TimeString[7] != prevTimeSec)
+  {
+    prevTimeSec = m_txtCache->TimeString[7];
+    m_updateTexture = true;
+    return true;
+  }
+  return false;
+}
+
 bool CTeletextDecoder::HandleAction(const CAction &action)
 {
   if (m_txtCache == NULL)
@@ -1320,20 +1339,6 @@ void CTeletextDecoder::RenderPage()
         {
           SetPosX(33+i);
         }
-      }
-
-      if (!IsSubtitlePage(m_txtCache->Page))
-      {
-        /* Update on every changed second */
-        if (m_txtCache->TimeString[7] != prevTimeSec)
-        {
-          prevTimeSec = m_txtCache->TimeString[7];
-          m_updateTexture = true;
-        }
-      }
-      else
-      {
-        m_updateTexture = true;
       }
     }
     DoFlashing(StartRow);

--- a/xbmc/video/Teletext.h
+++ b/xbmc/video/Teletext.h
@@ -46,6 +46,13 @@ public:
   }
   int GetHeight() { return m_RenderInfo.Height; }
   int GetWidth() { return m_RenderInfo.Width; }
+
+  /*!
+   \brief Checks if the data in the decoder has changed
+   \return true if the data in the decoder has changed, false otherwise
+   */
+  bool Changed();
+
   bool InitDecoder();
   void EndDecoder();
   void RenderPage();

--- a/xbmc/video/dialogs/GUIDialogTeletext.cpp
+++ b/xbmc/video/dialogs/GUIDialogTeletext.cpp
@@ -75,6 +75,10 @@ bool CGUIDialogTeletext::OnMessage(CGUIMessage& message)
 
 void CGUIDialogTeletext::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions)
 {
+  if (m_TextDecoder.Changed())
+  {
+    MarkDirtyRegion();
+  }
   CGUIDialog::Process(currentTime, dirtyregions);
   m_renderRegion = m_vertCoords;
 }


### PR DESCRIPTION
(subtitles or time string)

## Description
Teletext pages are supposed to be rendered if the timestring (top right corner) changes. This should occur every second (if it exists). 
The issue is that this evaluation is being done on `Render()`. If for some reason dirty regions is empty (as part of subsquent frame moves without the time string actually changing) `Render` is not called and the expected flow does not behave as expected.
This PR moves the evaluation to `Process()` (always called before render) and makes sure dirty regions are set in `GUIDialogTeletext` if the teletext page is actually supposed to be rendered (e.g. time string changes).

@ksooo probably you're not familiar with the teletext code but can understand what's being done here.

## Motivation and context
Have noticed this bug for a while on android (media codec surface enabled) to a point it started to annoy me too much :)

## How has this been tested?
Runtime tested on android and linux

## What is the effect on users?
Teletext pages should refresh every second if they include a time string

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
