### PR TITLE
[video] CGUIWindowVideoBase: Fix CVideoSelectActionProcessor::OnResumeSelected

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -562,7 +562,7 @@ protected:
       return true;
     }
     // resume playback of the video
-    return m_window.OnClick(m_itemIndex);
+    return m_window.OnClick(m_itemIndex, m_player);
   }
 
   bool OnPlaySelected() override


### PR DESCRIPTION
… to pass player to CGUIWindowVideoBase::OnClick.

Same problem as with https://github.com/xbmc/xbmc/pull/23894, also for resume we should pass on the player, although no actual effect for the users, because as far as I know resume is not supported for external players.

@enen92 no-brainer, please review.