### PR TITLE
[clang-tidy] modernize-make-(shared|unique)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,5 @@
 Checks: "\
+  modernize-make-shared,\
   modernize-use-default-member-init,\
   performance-faster-string-find,\
   performance-for-range-copy,\

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,6 @@
 Checks: "\
   modernize-make-shared,\
+  modernize-make-unique,\
   modernize-use-default-member-init,\
   performance-faster-string-find,\
   performance-for-range-copy,\

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -61,6 +61,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <memory>
 #include <mutex>
 
 using namespace KODI;
@@ -2105,11 +2106,11 @@ bool CFileItem::LoadTracksFromCueDocument(CFileItemList& scannedItems)
       if ( tag.Loaded() && oneFilePerTrack && ! ( tag.GetAlbum().empty() || tag.GetArtist().empty() || tag.GetTitle().empty() ) )
       {
         // If there are multiple files in a cue file, the tags from the files should be preferred if they exist.
-        scannedItems.Add(CFileItemPtr(new CFileItem(song, tag)));
+        scannedItems.Add(std::make_shared<CFileItem>(song, tag));
       }
       else
       {
-        scannedItems.Add(CFileItemPtr(new CFileItem(song)));
+        scannedItems.Add(std::make_shared<CFileItem>(song));
       }
       ++tracksFound;
     }
@@ -2460,7 +2461,7 @@ void CFileItemList::Sort(SortDescription sortDescription)
   SortItems sortItems((size_t)Size());
   for (int index = 0; index < Size(); index++)
   {
-    sortItems[index] = std::shared_ptr<SortItem>(new SortItem);
+    sortItems[index] = std::make_shared<SortItem>();
     m_items[index]->ToSortable(*sortItems[index], fields);
     (*sortItems[index])[FieldId] = index;
   }
@@ -2542,7 +2543,7 @@ void CFileItemList::Archive(CArchive& ar)
     {
       CFileItemPtr pItem=m_items[0];
       if (pItem->IsParentFolder())
-        pParent.reset(new CFileItem(*pItem));
+        pParent = std::make_shared<CFileItem>(*pItem);
     }
 
     SetIgnoreURLOptions(false);

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -46,6 +46,7 @@
 #include "utils/log.h"
 
 #include <functional>
+#include <memory>
 #include <mutex>
 
 using namespace XFILE;
@@ -553,7 +554,7 @@ void CAddonInstaller::PrunePackageCache()
   {
     it->second->Sort(SortByLabel, SortOrderDescending);
     for (int j = 2; j < it->second->Size(); j++)
-      items.Add(CFileItemPtr(new CFileItem(*it->second->Get(j))));
+      items.Add(std::make_shared<CFileItem>(*it->second->Get(j)));
   }
 
   items.Sort(SortBySize, SortOrderDescending);
@@ -572,7 +573,7 @@ void CAddonInstaller::PrunePackageCache()
     for (auto it = packs.begin(); it != packs.end(); ++it)
     {
       if (it->second->Size() > 1)
-        items.Add(CFileItemPtr(new CFileItem(*it->second->Get(1))));
+        items.Add(std::make_shared<CFileItem>(*it->second->Get(1)));
     }
 
     items.Sort(SortByDate, SortOrderAscending);
@@ -626,7 +627,7 @@ int64_t CAddonInstaller::EnumeratePackageFolder(
     CAddonVersion::SplitFileName(pack, dummy, items[i]->GetLabel());
     if (result.find(pack) == result.end())
       result[pack] = std::make_unique<CFileItemList>();
-    result[pack]->Add(CFileItemPtr(new CFileItem(*items[i])));
+    result[pack]->Add(std::make_shared<CFileItem>(*items[i]));
   }
 
   return size;
@@ -979,7 +980,7 @@ bool CAddonInstallJob::DownloadPackage(const std::string &path, const std::strin
 
   // need to download/copy the package first
   CFileItemList list;
-  list.Add(CFileItemPtr(new CFileItem(path, false)));
+  list.Add(std::make_shared<CFileItem>(path, false));
   list[0]->Select(true);
 
   return DoFileOperation(CFileOperationJob::ActionReplace, list, dest, true);

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -34,6 +34,7 @@
 #include "utils/log.h"
 
 #include <charconv>
+#include <memory>
 
 #define XML_SETTINGS      "settings"
 #define XML_SETTING       "setting"
@@ -157,7 +158,7 @@ CSkinInfo::CSkinInfo(const AddonInfoPtr& addonInfo,
     m_effectsSlowDown(1.f),
     m_debugging(false)
 {
-  m_settingsUpdateHandler.reset(new CSkinSettingUpdateHandler(*this));
+  m_settingsUpdateHandler = std::make_unique<CSkinSettingUpdateHandler>(*this);
 }
 
 CSkinInfo::CSkinInfo(const AddonInfoPtr& addonInfo) : CAddon(addonInfo, AddonType::SKIN)
@@ -193,7 +194,7 @@ CSkinInfo::CSkinInfo(const AddonInfoPtr& addonInfo) : CAddon(addonInfo, AddonTyp
 
   m_debugging = Type(AddonType::SKIN)->GetValue("@debugging").asBoolean();
 
-  m_settingsUpdateHandler.reset(new CSkinSettingUpdateHandler(*this));
+  m_settingsUpdateHandler = std::make_unique<CSkinSettingUpdateHandler>(*this);
   LoadStartupWindows(addonInfo);
 }
 

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -45,6 +45,7 @@
 #include "utils/log.h"
 
 #include <functional>
+#include <memory>
 #include <sstream>
 #include <utility>
 
@@ -65,7 +66,8 @@ using namespace XFILE;
 using namespace KODI::MESSAGING;
 
 CGUIDialogAddonInfo::CGUIDialogAddonInfo(void)
-  : CGUIDialog(WINDOW_DIALOG_ADDON_INFO, "DialogAddonInfo.xml"), m_item(CFileItemPtr(new CFileItem))
+  : CGUIDialog(WINDOW_DIALOG_ADDON_INFO, "DialogAddonInfo.xml"),
+    m_item(std::make_shared<CFileItem>())
 {
   m_loadType = KEEP_IN_MEMORY;
 }

--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -39,6 +39,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <memory>
 #include <mutex>
 #include <vector>
 
@@ -590,7 +591,7 @@ std::shared_ptr<CSettingGroup> CAddonSettings::ParseOldSettingElement(
         category->AddGroup(group);
 
         // and create a new one
-        group.reset(new CSettingGroup(std::to_string(groupId), GetSettingsManager()));
+        group = std::make_shared<CSettingGroup>(std::to_string(groupId), GetSettingsManager());
         groupId += 1;
       }
 

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -334,7 +334,7 @@ bool CApplication::Create()
   const auto keyboardLayoutManager = std::make_shared<CKeyboardLayoutManager>();
   CServiceBroker::RegisterKeyboardLayoutManager(keyboardLayoutManager);
 
-  m_ServiceManager.reset(new CServiceManager());
+  m_ServiceManager = std::make_unique<CServiceManager>();
 
   if (!m_ServiceManager->InitStageOne())
   {
@@ -404,7 +404,7 @@ bool CApplication::Create()
     return false;
   }
 
-  m_pActiveAE.reset(new ActiveAE::CActiveAE());
+  m_pActiveAE = std::make_unique<ActiveAE::CActiveAE>();
   CServiceBroker::RegisterAE(m_pActiveAE.get());
 
   // initialize m_replayGainSettings
@@ -545,7 +545,7 @@ bool CApplication::CreateGUI()
   if (sav_res)
     CDisplaySettings::GetInstance().SetCurrentResolution(RES_DESKTOP, true);
 
-  m_pGUI.reset(new CGUIComponent());
+  m_pGUI = std::make_unique<CGUIComponent>();
   m_pGUI->Init();
 
   // Splash requires gui component!!

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -10,20 +10,32 @@
 
 #include "Autorun.h"
 #include "CompileInfo.h"
+#include "DatabaseManager.h"
+#include "FileItem.h"
 #include "GUIInfoManager.h"
+#include "GUILargeTextureManager.h"
+#include "GUIPassword.h"
+#include "GUIUserMessages.h"
 #include "HDRStatus.h"
 #include "LangInfo.h"
+#include "PartyModeManager.h"
 #include "PlayListPlayer.h"
+#include "SectionLoader.h"
+#include "SeekHandler.h"
+#include "ServiceBroker.h"
 #include "ServiceManager.h"
+#include "TextureCache.h"
 #include "URL.h"
 #include "Util.h"
 #include "addons/AddonManager.h"
+#include "addons/AddonSystemSettings.h"
 #include "addons/RepositoryUpdater.h"
 #include "addons/Service.h"
 #include "addons/Skin.h"
 #include "addons/VFSEntry.h"
 #include "addons/addoninfo/AddonInfo.h"
 #include "addons/addoninfo/AddonType.h"
+#include "addons/gui/GUIDialogAddonSettings.h"
 #include "application/AppInboundProtocol.h"
 #include "application/AppParams.h"
 #include "application/ApplicationActionListeners.h"
@@ -33,170 +45,141 @@
 #include "application/ApplicationStackHelper.h"
 #include "application/ApplicationVolumeHandling.h"
 #include "cores/AudioEngine/Engines/ActiveAE/ActiveAE.h"
+#include "cores/FFmpeg.h"
 #include "cores/IPlayer.h"
 #include "cores/playercorefactory/PlayerCoreFactory.h"
 #include "dialogs/GUIDialogBusy.h"
 #include "dialogs/GUIDialogCache.h"
 #include "dialogs/GUIDialogKaiToast.h"
+#include "dialogs/GUIDialogSimpleMenu.h"
 #include "events/EventLog.h"
 #include "events/NotificationEvent.h"
+#include "filesystem/Directory.h"
+#include "filesystem/DirectoryCache.h"
 #include "filesystem/DirectoryFactory.h"
+#include "filesystem/DllLibCurl.h"
 #include "filesystem/File.h"
+#ifdef HAS_FILESYSTEM_NFS
+#include "filesystem/NFSFile.h"
+#endif
+#include "filesystem/PluginDirectory.h"
+#include "filesystem/SpecialProtocol.h"
+#ifdef HAS_UPNP
+#include "filesystem/UPnPDirectory.h"
+#endif
+#include "guilib/GUIAudioManager.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIControlProfiler.h"
 #include "guilib/GUIFontManager.h"
+#include "guilib/GUIWindowManager.h"
+#include "guilib/LocalizeStrings.h"
 #include "guilib/StereoscopicsManager.h"
 #include "guilib/TextureManager.h"
+#include "input/InertialScrollingHandler.h"
+#include "input/InputManager.h"
+#include "input/KeyboardLayoutManager.h"
+#include "input/actions/ActionTranslator.h"
+#include "interfaces/AnnouncementManager.h"
 #include "interfaces/builtins/Builtins.h"
 #include "interfaces/generic/ScriptInvocationManager.h"
-#include "music/MusicLibraryQueue.h"
-#include "music/tags/MusicInfoTag.h"
-#include "network/EventServer.h"
-#include "network/Network.h"
-#include "platform/Environment.h"
-#include "playlists/PlayListFactory.h"
-#include "threads/SystemClock.h"
-#include "utils/ContentUtils.h"
-#include "utils/JobManager.h"
-#include "utils/LangCodeExpander.h"
-#include "utils/Screenshot.h"
-#include "utils/Variant.h"
-#include "video/Bookmark.h"
-#include "video/VideoLibraryQueue.h"
-
+#include "interfaces/json-rpc/JSONRPC.h"
 #ifdef HAS_PYTHON
 #include "interfaces/python/XBPython.h"
 #endif
-#include "GUILargeTextureManager.h"
-#include "GUIPassword.h"
-#include "GUIUserMessages.h"
-#include "SectionLoader.h"
-#include "SeekHandler.h"
-#include "ServiceBroker.h"
-#include "TextureCache.h"
-#include "filesystem/Directory.h"
-#include "filesystem/DirectoryCache.h"
-#include "filesystem/DllLibCurl.h"
-#include "filesystem/PluginDirectory.h"
-#include "filesystem/SpecialProtocol.h"
-#include "guilib/GUIAudioManager.h"
-#include "guilib/LocalizeStrings.h"
-#include "input/InertialScrollingHandler.h"
-#include "input/KeyboardLayoutManager.h"
-#include "input/actions/ActionTranslator.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/ThreadMessage.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "music/MusicLibraryQueue.h"
+#include "music/MusicThumbLoader.h"
+#include "music/MusicUtils.h"
+#include "music/infoscanner/MusicInfoScanner.h"
+#include "music/tags/MusicInfoTag.h"
+#include "network/EventServer.h"
+#include "network/Network.h"
+#include "network/ZeroconfBrowser.h"
+#ifdef HAS_UPNP
+#include "network/upnp/UPnP.h"
+#endif
+#include "peripherals/Peripherals.h"
+#include "pictures/GUIWindowSlideShow.h"
+#include "platform/Environment.h"
 #include "playlists/PlayList.h"
+#include "playlists/PlayListFactory.h"
 #include "playlists/SmartPlayList.h"
 #include "powermanagement/PowerManager.h"
 #include "profiles/ProfileManager.h"
+#include "pvr/PVRManager.h"
+#include "pvr/guilib/PVRGUIActionsPlayback.h"
+#include "pvr/guilib/PVRGUIActionsPowerManagement.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/DisplaySettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "speech/ISpeechRecognition.h"
+#include "storage/MediaManager.h"
 #include "threads/SingleLock.h"
+#include "threads/SystemClock.h"
+#include "utils/AlarmClock.h"
 #include "utils/CPUInfo.h"
+#include "utils/CharsetConverter.h"
+#include "utils/ContentUtils.h"
 #include "utils/FileExtensionProvider.h"
+#include "utils/JobManager.h"
+#include "utils/LangCodeExpander.h"
 #include "utils/RegExp.h"
+#include "utils/Screenshot.h"
+#include "utils/StringUtils.h"
 #include "utils/SystemInfo.h"
 #include "utils/TimeUtils.h"
+#include "utils/URIUtils.h"
+#include "utils/Variant.h"
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
-#include "windowing/WinSystem.h"
-#include "windowing/WindowSystemFactory.h"
-
-#include <cmath>
-
-#ifdef HAS_UPNP
-#include "network/upnp/UPnP.h"
-#include "filesystem/UPnPDirectory.h"
-#endif
-#if defined(TARGET_POSIX) && defined(HAS_FILESYSTEM_SMB)
-#include "platform/posix/filesystem/SMBFile.h"
-#endif
-#ifdef HAS_FILESYSTEM_NFS
-#include "filesystem/NFSFile.h"
-#endif
-#include "PartyModeManager.h"
-#include "network/ZeroconfBrowser.h"
-#ifndef TARGET_POSIX
-#include "platform/win32/threads/Win32Exception.h"
-#endif
-#include "interfaces/json-rpc/JSONRPC.h"
-#include "interfaces/AnnouncementManager.h"
-#include "peripherals/Peripherals.h"
-#include "music/infoscanner/MusicInfoScanner.h"
-#include "music/MusicUtils.h"
-#include "music/MusicThumbLoader.h"
-
-// Windows includes
-#include "guilib/GUIWindowManager.h"
+#include "video/Bookmark.h"
 #include "video/PlayerController.h"
-
-// Dialog includes
-#include "addons/gui/GUIDialogAddonSettings.h"
-#include "dialogs/GUIDialogKaiToast.h"
-#include "dialogs/GUIDialogSimpleMenu.h"
+#include "video/VideoLibraryQueue.h"
 #include "video/dialogs/GUIDialogVideoBookmarks.h"
-
-// PVR related include Files
-#include "pvr/PVRManager.h"
-#include "pvr/guilib/PVRGUIActionsPlayback.h"
-#include "pvr/guilib/PVRGUIActionsPowerManagement.h"
-
 #ifdef TARGET_WINDOWS
 #include "win32util.h"
 #endif
+#include "windowing/WinSystem.h"
+#include "windowing/WindowSystemFactory.h"
 
+#if defined(TARGET_ANDROID)
+#include "platform/android/activity/XBMCApp.h"
+#endif
+#ifdef TARGET_DARWIN
+#include "platform/darwin/DarwinUtils.h"
+#endif
 #ifdef TARGET_DARWIN_OSX
 #ifdef HAS_XBMCHELPER
 #include "platform/darwin/osx/XBMCHelper.h"
 #endif
 #endif
-#ifdef TARGET_DARWIN
-#include "platform/darwin/DarwinUtils.h"
-#endif
-
-#ifdef HAS_OPTICAL_DRIVE
-#include <cdio/logging.h>
-#endif
-
-#include "DatabaseManager.h"
-#include "input/InputManager.h"
-#include "storage/MediaManager.h"
-#include "utils/AlarmClock.h"
-#include "utils/StringUtils.h"
-#include "utils/URIUtils.h"
-
 #ifdef TARGET_POSIX
-#include "platform/posix/XHandle.h"
 #include "platform/posix/PlatformPosix.h"
+#include "platform/posix/XHandle.h"
+#endif
+#if defined(TARGET_POSIX) && defined(HAS_FILESYSTEM_SMB)
+#include "platform/posix/filesystem/SMBFile.h"
+#endif
+#ifndef TARGET_POSIX
+#include "platform/win32/threads/Win32Exception.h"
 #endif
 
-#if defined(TARGET_ANDROID)
-#include "platform/android/activity/XBMCApp.h"
-#endif
-
-#ifdef TARGET_WINDOWS
-#include "platform/Environment.h"
-#endif
+#include <cmath>
+#include <memory>
+#include <mutex>
 
 //TODO: XInitThreads
 #ifdef HAVE_X11
 #include <X11/Xlib.h>
 #endif
-
-#include "FileItem.h"
-#include "addons/AddonSystemSettings.h"
-#include "cores/FFmpeg.h"
-#include "pictures/GUIWindowSlideShow.h"
-#include "utils/CharsetConverter.h"
-
-#include <mutex>
+#ifdef HAS_OPTICAL_DRIVE
+#include <cdio/logging.h>
+#endif
 
 using namespace ADDON;
 using namespace XFILE;
@@ -2747,7 +2730,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
         CGUIMessage msg(GUI_MSG_PLAYLISTPLAYER_CHANGED, 0, 0, CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist(), param, item);
         CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
         CServiceBroker::GetPlaylistPlayer().SetCurrentSong(m_nextPlaylistItem);
-        m_itemCurrentFile.reset(new CFileItem(*item));
+        m_itemCurrentFile = std::make_shared<CFileItem>(*item);
       }
       CServiceBroker::GetGUI()->GetInfoManager().SetCurrentItem(*m_itemCurrentFile);
       g_partyModeManager.OnSongChange(true);

--- a/xbmc/application/ApplicationPlayerCallback.cpp
+++ b/xbmc/application/ApplicationPlayerCallback.cpp
@@ -35,6 +35,8 @@
 #include "video/VideoDatabase.h"
 #include "video/VideoInfoTag.h"
 
+#include <memory>
+
 CApplicationPlayerCallback::CApplicationPlayerCallback()
   : m_itemCurrentFile(new CFileItem), m_playerEvent(true, true)
 {
@@ -77,9 +79,9 @@ void CApplicationPlayerCallback::OnPlayBackStarted(const CFileItem& file)
   auto& components = CServiceBroker::GetAppComponents();
   const auto stackHelper = components.GetComponent<CApplicationStackHelper>();
   if (stackHelper->IsPlayingISOStack() || stackHelper->IsPlayingRegularStack())
-    m_itemCurrentFile.reset(new CFileItem(*stackHelper->GetRegisteredStack(file)));
+    m_itemCurrentFile = std::make_shared<CFileItem>(*stackHelper->GetRegisteredStack(file));
   else
-    m_itemCurrentFile.reset(new CFileItem(file));
+    m_itemCurrentFile = std::make_shared<CFileItem>(file);
 
   /* When playing video pause any low priority jobs, they will be unpaused  when playback stops.
    * This should speed up player startup for files on internet filesystems (eg. webdav) and

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -8,10 +8,6 @@
 
 #include "ActiveAE.h"
 
-#include <mutex>
-
-using namespace AE;
-using namespace ActiveAE;
 #include "ActiveAESettings.h"
 #include "ActiveAESound.h"
 #include "ActiveAEStream.h"
@@ -26,6 +22,12 @@ using namespace ActiveAE;
 #include "settings/SettingsComponent.h"
 #include "utils/log.h"
 #include "windowing/WinSystem.h"
+
+#include <memory>
+#include <mutex>
+
+using namespace AE;
+using namespace ActiveAE;
 
 using namespace std::chrono_literals;
 
@@ -288,7 +290,7 @@ CActiveAE::CActiveAE() :
   m_stats.Reset(44100, true);
   m_streamIdGen = 0;
 
-  m_settingsHandler.reset(new CActiveAESettings(*this));
+  m_settingsHandler = std::make_unique<CActiveAESettings>(*this);
 }
 
 CActiveAE::~CActiveAE()

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
@@ -13,6 +13,8 @@
 #include "cores/AudioEngine/AEResampleFactory.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
 
+#include <memory>
+
 using namespace ActiveAE;
 
 CSoundPacket::CSoundPacket(const SampleConfig& conf, int samples) : config(conf)
@@ -467,7 +469,7 @@ bool CActiveAEBufferPoolAtempo::Create(unsigned int totaltime)
 {
   CActiveAEBufferPool::Create(totaltime);
 
-  m_pTempoFilter.reset(new CActiveAEFilter());
+  m_pTempoFilter = std::make_unique<CActiveAEFilter>();
   m_pTempoFilter->Init(CAEUtil::GetAVSampleFormat(m_format.m_dataFormat), m_format.m_sampleRate, CAEUtil::GetAVChannelLayout(m_format.m_channelLayout));
 
   return true;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.cpp
@@ -16,6 +16,7 @@
 #include "utils/log.h"
 
 #include <array>
+#include <memory>
 #include <mutex>
 
 //-----------------------------------------------------------------------------
@@ -706,7 +707,7 @@ bool CAESinkPULSE::Register()
     pa_simple_free(s);
   }
 
-  m_pMonitor.reset(new CDriverMonitor());
+  m_pMonitor = std::make_unique<CDriverMonitor>();
   m_pMonitor->Start();
 
   AE::AESinkRegEntry entry;

--- a/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.cpp
+++ b/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.cpp
@@ -26,6 +26,7 @@
 #include "utils/log.h"
 
 #include <algorithm>
+#include <memory>
 #include <mutex>
 
 using namespace KODI;
@@ -414,7 +415,7 @@ void CReversiblePlayback::UpdateMemoryStream()
 
     if (!m_memoryStream)
     {
-      m_memoryStream.reset(new CDeltaPairMemoryStream);
+      m_memoryStream = std::make_unique<CDeltaPairMemoryStream>();
       m_memoryStream->Init(m_gameClient->SerializeSize(), frameCount);
     }
 

--- a/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
@@ -20,6 +20,8 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
+#include <memory>
+
 namespace
 {
 constexpr auto SAVESTATE_EXTENSION = ".sav";
@@ -35,7 +37,7 @@ std::unique_ptr<ISavestate> CSavestateDatabase::AllocateSavestate()
 {
   std::unique_ptr<ISavestate> savestate;
 
-  savestate.reset(new CSavestateFlatBuffer);
+  savestate = std::make_unique<CSavestateFlatBuffer>();
 
   return savestate;
 }

--- a/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.cpp
@@ -13,6 +13,8 @@
 #include "utils/log.h"
 #include "video_generated.h"
 
+#include <memory>
+
 using namespace KODI;
 using namespace RETRO;
 
@@ -192,7 +194,7 @@ CSavestateFlatBuffer::~CSavestateFlatBuffer() = default;
 
 void CSavestateFlatBuffer::Reset()
 {
-  m_builder.reset(new flatbuffers::FlatBufferBuilder(INITIAL_FLATBUFFER_SIZE));
+  m_builder = std::make_unique<flatbuffers::FlatBufferBuilder>(INITIAL_FLATBUFFER_SIZE);
   m_data.clear();
   m_savestate = nullptr;
 }
@@ -252,7 +254,7 @@ std::string CSavestateFlatBuffer::Label() const
 
 void CSavestateFlatBuffer::SetLabel(const std::string& label)
 {
-  m_labelOffset.reset(new StringOffset{m_builder->CreateString(label)});
+  m_labelOffset = std::make_unique<StringOffset>(m_builder->CreateString(label));
 }
 
 std::string CSavestateFlatBuffer::Caption() const
@@ -298,7 +300,7 @@ std::string CSavestateFlatBuffer::GameFileName() const
 
 void CSavestateFlatBuffer::SetGameFileName(const std::string& gameFileName)
 {
-  m_gameFileNameOffset.reset(new StringOffset{m_builder->CreateString(gameFileName)});
+  m_gameFileNameOffset = std::make_unique<StringOffset>(m_builder->CreateString(gameFileName));
 }
 
 uint64_t CSavestateFlatBuffer::TimestampFrames() const
@@ -336,7 +338,7 @@ std::string CSavestateFlatBuffer::GameClientID() const
 
 void CSavestateFlatBuffer::SetGameClientID(const std::string& gameClientId)
 {
-  m_emulatorAddonIdOffset.reset(new StringOffset{m_builder->CreateString(gameClientId)});
+  m_emulatorAddonIdOffset = std::make_unique<StringOffset>(m_builder->CreateString(gameClientId));
 }
 
 std::string CSavestateFlatBuffer::GameClientVersion() const
@@ -351,7 +353,8 @@ std::string CSavestateFlatBuffer::GameClientVersion() const
 
 void CSavestateFlatBuffer::SetGameClientVersion(const std::string& gameClientVersion)
 {
-  m_emulatorVersionOffset.reset(new StringOffset{m_builder->CreateString(gameClientVersion)});
+  m_emulatorVersionOffset =
+      std::make_unique<StringOffset>(m_builder->CreateString(gameClientVersion));
 }
 
 AVPixelFormat CSavestateFlatBuffer::GetPixelFormat() const
@@ -517,8 +520,8 @@ uint8_t* CSavestateFlatBuffer::GetMemoryBuffer(size_t size)
 {
   uint8_t* memoryBuffer = nullptr;
 
-  m_memoryDataOffset.reset(
-      new VectorOffset{m_builder->CreateUninitializedVector(size, &memoryBuffer)});
+  m_memoryDataOffset =
+      std::make_unique<VectorOffset>(m_builder->CreateUninitializedVector(size, &memoryBuffer));
 
   return memoryBuffer;
 }

--- a/xbmc/cores/VideoPlayer/DVDClock.cpp
+++ b/xbmc/cores/VideoPlayer/DVDClock.cpp
@@ -16,6 +16,7 @@
 
 #include <inttypes.h>
 #include <math.h>
+#include <memory>
 #include <mutex>
 
 CDVDClock::CDVDClock()
@@ -34,7 +35,7 @@ CDVDClock::CDVDClock()
   m_vSyncAdjust = 0;
   m_frameTime = DVD_TIME_BASE / 60.0;
 
-  m_videoRefClock.reset(new CVideoReferenceClock());
+  m_videoRefClock = std::make_unique<CVideoReferenceClock>();
   m_lastSystemTime = m_videoRefClock->GetTime();
   m_systemOffset = m_videoRefClock->GetTime();
   m_systemFrequency = CurrentHostFrequency();

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -432,7 +432,7 @@ void CDVDDemuxClient::SetStreamProps(CDemuxStream *stream, std::map<int, std::sh
       streamAudio = std::dynamic_pointer_cast<CDemuxStreamClientInternalTpl<CDemuxStreamAudio>>(currentStream);
     if (forceInit || !streamAudio || streamAudio->codec != source->codec)
     {
-      streamAudio.reset(new CDemuxStreamClientInternalTpl<CDemuxStreamAudio>());
+      streamAudio = std::make_shared<CDemuxStreamClientInternalTpl<CDemuxStreamAudio>>();
       streamAudio->m_parser = av_parser_init(source->codec);
       if (streamAudio->m_parser)
         streamAudio->m_parser->flags |= PARSER_FLAG_COMPLETE_FRAMES;
@@ -469,7 +469,7 @@ void CDVDDemuxClient::SetStreamProps(CDemuxStream *stream, std::map<int, std::sh
       streamVideo = std::dynamic_pointer_cast<CDemuxStreamClientInternalTpl<CDemuxStreamVideo>>(currentStream);
     if (forceInit || !streamVideo || streamVideo->codec != source->codec)
     {
-      streamVideo.reset(new CDemuxStreamClientInternalTpl<CDemuxStreamVideo>());
+      streamVideo = std::make_shared<CDemuxStreamClientInternalTpl<CDemuxStreamVideo>>();
       streamVideo->m_parser = av_parser_init(source->codec);
       if (streamVideo->m_parser)
         streamVideo->m_parser->flags |= PARSER_FLAG_COMPLETE_FRAMES;
@@ -513,7 +513,7 @@ void CDVDDemuxClient::SetStreamProps(CDemuxStream *stream, std::map<int, std::sh
       streamSubtitle = std::dynamic_pointer_cast<CDemuxStreamClientInternalTpl<CDemuxStreamSubtitle>>(currentStream);
     if (!streamSubtitle || streamSubtitle->codec != source->codec)
     {
-      streamSubtitle.reset(new CDemuxStreamClientInternalTpl<CDemuxStreamSubtitle>());
+      streamSubtitle = std::make_shared<CDemuxStreamClientInternalTpl<CDemuxStreamSubtitle>>();
       streamSubtitle->m_parser = av_parser_init(source->codec);
       if (streamSubtitle->m_parser)
         streamSubtitle->m_parser->flags |= PARSER_FLAG_COMPLETE_FRAMES;
@@ -543,7 +543,7 @@ void CDVDDemuxClient::SetStreamProps(CDemuxStream *stream, std::map<int, std::sh
        streamTeletext = std::dynamic_pointer_cast<CDemuxStreamClientInternalTpl<CDemuxStreamTeletext>>(currentStream);
     if (!streamTeletext || streamTeletext->codec != source->codec)
     {
-      streamTeletext.reset(new CDemuxStreamClientInternalTpl<CDemuxStreamTeletext>());
+      streamTeletext = std::make_shared<CDemuxStreamClientInternalTpl<CDemuxStreamTeletext>>();
     }
 
     map[stream->uniqueId] = streamTeletext;
@@ -566,7 +566,7 @@ void CDVDDemuxClient::SetStreamProps(CDemuxStream *stream, std::map<int, std::sh
       streamRDS = std::dynamic_pointer_cast<CDemuxStreamClientInternalTpl<CDemuxStreamRadioRDS>>(currentStream);
     if (!streamRDS || streamRDS->codec != source->codec)
     {
-      streamRDS.reset(new CDemuxStreamClientInternalTpl<CDemuxStreamRadioRDS>());
+      streamRDS = std::make_shared<CDemuxStreamClientInternalTpl<CDemuxStreamRadioRDS>>();
     }
 
     map[stream->uniqueId] = streamRDS;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxVobsub.cpp
@@ -18,6 +18,8 @@
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
 #include "utils/StringUtils.h"
 
+#include <memory>
+
 CDVDDemuxVobsub::CDVDDemuxVobsub() = default;
 
 CDVDDemuxVobsub::~CDVDDemuxVobsub()
@@ -64,7 +66,7 @@ bool CDVDDemuxVobsub::Open(const std::string& filename, int source, const std::s
   if (!m_Input || !m_Input->Open())
     return false;
 
-  m_Demuxer.reset(new CDVDDemuxFFmpeg());
+  m_Demuxer = std::make_unique<CDVDDemuxFFmpeg>();
   if (!m_Demuxer->Open(m_Input, false))
     return false;
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -30,6 +30,7 @@
 
 #include <functional>
 #include <limits>
+#include <memory>
 
 #include <libbluray/bluray.h>
 #include <libbluray/log_control.h>
@@ -1241,7 +1242,7 @@ void CDVDInputStreamBluray::SetupPlayerSettings()
 
 bool CDVDInputStreamBluray::OpenStream(CFileItem &item)
 {
-  m_pstream.reset(new CDVDInputStreamFile(item, 0));
+  m_pstream = std::make_unique<CDVDInputStreamFile>(item, 0);
 
   if (!m_pstream->Open())
   {

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -7,25 +7,31 @@
  */
 
 #include "DVDInputStreamNavigator.h"
-#include "filesystem/IFileTypes.h"
-#include "utils/LangCodeExpander.h"
+
 #include "../DVDDemuxSPU.h"
-#include "settings/Settings.h"
-#include "settings/SettingsComponent.h"
 #include "LangInfo.h"
 #include "ServiceBroker.h"
-#include "utils/Geometry.h"
-#include "utils/log.h"
-#include "utils/URIUtils.h"
-#include "utils/StringUtils.h"
+#include "filesystem/IFileTypes.h"
+#if defined(TARGET_WINDOWS_STORE)
+#include "filesystem/SpecialProtocol.h"
+#endif
 #include "guilib/LocalizeStrings.h"
+#if defined(TARGET_WINDOWS_STORE)
+#include "platform/Environment.h"
+#endif
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
+#include "utils/Geometry.h"
+#include "utils/LangCodeExpander.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
+#include "utils/log.h"
+
 #if defined(TARGET_DARWIN_OSX)
 #include "platform/darwin/osx/CocoaInterface.h"
 #endif
-#if defined(TARGET_WINDOWS_STORE)
-#include "filesystem/SpecialProtocol.h"
-#include "platform/Environment.h"
-#endif
+
+#include <memory>
 
 namespace
 {
@@ -144,7 +150,8 @@ bool CDVDInputStreamNavigator::Open()
   if (m_item.IsDiscImage())
   {
     // if dvd image file (ISO or alike) open using libdvdnav stream callback functions
-    m_pstream.reset(new CDVDInputStreamFile(m_item, XFILE::READ_TRUNCATED | XFILE::READ_BITRATE | XFILE::READ_CHUNKED));
+    m_pstream = std::make_unique<CDVDInputStreamFile>(
+        m_item, XFILE::READ_TRUNCATED | XFILE::READ_BITRATE | XFILE::READ_CHUNKED);
 #if DVDNAV_VERSION >= 60100
     if (!m_pstream->Open() || m_dll.dvdnav_open_stream2(&m_dvdnav, m_pstream.get(), &loggerCallback,
                                                         &m_dvdnav_stream_cb) != DVDNAV_STATUS_OK)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -24,6 +24,8 @@
 #include "utils/log.h"
 #include "windowing/Resolution.h"
 
+#include <memory>
+
 CInputStreamProvider::CInputStreamProvider(const ADDON::AddonInfoPtr& addonInfo,
                                            KODI_HANDLE parentInstance)
   : m_addonInfo(addonInfo), m_parentInstance(parentInstance)
@@ -191,8 +193,8 @@ bool CInputStreamAddon::Open()
     m_caps = {};
     m_ifc.inputstream->toAddon->get_capabilities(m_ifc.inputstream, &m_caps);
 
-    m_subAddonProvider = std::shared_ptr<CInputStreamProvider>(
-        new CInputStreamProvider(GetAddonInfo(), m_ifc.inputstream->toAddon->addonInstance));
+    m_subAddonProvider = std::make_shared<CInputStreamProvider>(
+        GetAddonInfo(), m_ifc.inputstream->toAddon->addonInstance);
   }
   return ret;
 }
@@ -444,8 +446,7 @@ KODI_HANDLE CInputStreamAddon::cb_get_stream_transfer(KODI_HANDLE handle,
 
     if (stream->m_masteringMetadata)
     {
-      videoStream->masteringMetaData =
-          std::shared_ptr<AVMasteringDisplayMetadata>(new AVMasteringDisplayMetadata);
+      videoStream->masteringMetaData = std::make_shared<AVMasteringDisplayMetadata>();
       videoStream->masteringMetaData->display_primaries[0][0] =
           av_d2q(stream->m_masteringMetadata->primary_r_chromaticity_x, INT_MAX);
       videoStream->masteringMetaData->display_primaries[0][1] =
@@ -472,8 +473,7 @@ KODI_HANDLE CInputStreamAddon::cb_get_stream_transfer(KODI_HANDLE handle,
 
     if (stream->m_contentLightMetadata)
     {
-      videoStream->contentLightMetaData =
-          std::shared_ptr<AVContentLightMetadata>(new AVContentLightMetadata);
+      videoStream->contentLightMetaData = std::make_shared<AVContentLightMetadata>();
       videoStream->contentLightMetaData->MaxCLL =
           static_cast<unsigned>(stream->m_contentLightMetadata->max_cll);
       videoStream->contentLightMetaData->MaxFALL =
@@ -543,9 +543,9 @@ KODI_HANDLE CInputStreamAddon::cb_get_stream_transfer(KODI_HANDLE handle,
         CRYPTO_SESSION_SYSTEM_PLAYREADY, CRYPTO_SESSION_SYSTEM_WISEPLAY,
         CRYPTO_SESSION_SYSTEM_CLEARKEY,
     };
-    demuxStream->cryptoSession = std::shared_ptr<DemuxCryptoSession>(
-        new DemuxCryptoSession(map[stream->m_cryptoSession.keySystem],
-                               stream->m_cryptoSession.sessionId, stream->m_cryptoSession.flags));
+    demuxStream->cryptoSession = std::make_shared<DemuxCryptoSession>(
+        map[stream->m_cryptoSession.keySystem], stream->m_cryptoSession.sessionId,
+        stream->m_cryptoSession.flags);
 
     if ((stream->m_features & INPUTSTREAM_FEATURE_DECODE) != 0)
       demuxStream->externalInterfaces = thisClass->m_subAddonProvider;

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParser.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleParser.h
@@ -76,7 +76,7 @@ protected:
         return true;
     }
     else
-      m_pStream.reset(new CDVDSubtitleStream());
+      m_pStream = std::make_unique<CDVDSubtitleStream>();
 
     return m_pStream->Open(m_filename);
   }

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
@@ -13,6 +13,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 
+#include <memory>
 #include <mutex>
 
 CCriticalSection createSection;
@@ -42,7 +43,8 @@ CProcessInfo* CProcessInfo::CreateInstance()
 
 CProcessInfo::CProcessInfo()
 {
-  m_videoSettingsLocked.reset(new CVideoSettingsLocked(m_videoSettings, m_settingsSection));
+  m_videoSettingsLocked =
+      std::make_unique<CVideoSettingsLocked>(m_videoSettings, m_settingsSection);
 }
 
 void CProcessInfo::SetDataCache(CDataCacheCore *cache)

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -17,16 +17,12 @@
 #include "DVDDemuxers/DVDFactoryDemuxer.h"
 #include "DVDInputStreams/DVDFactoryInputStream.h"
 #include "DVDInputStreams/DVDInputStream.h"
-#include "DVDMessage.h"
-#include "VideoPlayerVideo.h"
-#include "application/Application.h"
-
-#include <mutex>
 #if defined(HAVE_LIBBLURAY)
 #include "DVDInputStreams/DVDInputStreamBluray.h"
 #endif
 #include "DVDInputStreams/DVDInputStreamNavigator.h"
 #include "DVDInputStreams/InputStreamPVRBase.h"
+#include "DVDMessage.h"
 #include "FileItem.h"
 #include "GUIUserMessages.h"
 #include "LangInfo.h"
@@ -35,6 +31,8 @@
 #include "Util.h"
 #include "VideoPlayerAudio.h"
 #include "VideoPlayerRadioRDS.h"
+#include "VideoPlayerVideo.h"
+#include "application/Application.h"
 #include "cores/DataCacheCore.h"
 #include "cores/EdlEdit.h"
 #include "cores/FFmpeg.h"
@@ -67,6 +65,8 @@
 #include "windowing/WinSystem.h"
 
 #include <iterator>
+#include <memory>
+#include <mutex>
 #include <utility>
 
 using namespace std::chrono_literals;
@@ -616,7 +616,7 @@ CVideoPlayer::CVideoPlayer(IPlayerCallback& callback)
     m_messenger("player"),
     m_renderManager(m_clock, this)
 {
-  m_outboundEvents.reset(new CJobQueue(false, 1, CJob::PRIORITY_NORMAL));
+  m_outboundEvents = std::make_unique<CJobQueue>(false, 1, CJob::PRIORITY_NORMAL);
   m_players_created = false;
   m_pDemuxer = nullptr;
   m_pSubtitleDemuxer = nullptr;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
@@ -10,6 +10,8 @@
 
 #include "utils/log.h"
 
+#include <memory>
+
 using namespace DRMPRIME;
 
 namespace
@@ -55,7 +57,7 @@ CDRMPRIMETexture::~CDRMPRIMETexture()
 
 void CDRMPRIMETexture::Init(EGLDisplay eglDisplay)
 {
-  m_eglImage.reset(new CEGLImage(eglDisplay));
+  m_eglImage = std::make_unique<CEGLImage>(eglDisplay);
 }
 
 bool CDRMPRIMETexture::Map(CVideoBufferDRMPRIME* buffer)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -22,6 +22,8 @@
 #include "windowing/WinSystem.h"
 #include "windowing/linux/WinSystemEGL.h"
 
+#include <memory>
+
 using namespace KODI::UTILS::EGL;
 
 CRendererDRMPRIMEGLES::~CRendererDRMPRIMEGLES()
@@ -110,7 +112,7 @@ bool CRendererDRMPRIMEGLES::Configure(const VideoPicture& picture,
     if (!buf.fence)
     {
       buf.texture.Init(eglDisplay);
-      buf.fence.reset(new CEGLFence(eglDisplay));
+      buf.fence = std::make_unique<CEGLFence>(eglDisplay);
     }
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
@@ -13,6 +13,8 @@
 #include "utils/GLUtils.h"
 #include "utils/log.h"
 
+#include <memory>
+
 using namespace VAAPI;
 
 IVaapiWinSystem* CRendererVAAPIGL::m_pWinSystem = nullptr;
@@ -95,11 +97,11 @@ bool CRendererVAAPIGL::Configure(const VideoPicture& picture, float fps, unsigne
     {
       if (useVaapi2)
       {
-        tex.reset(new VAAPI::CVaapi2Texture);
+        tex = std::make_unique<VAAPI::CVaapi2Texture>();
       }
       else
       {
-        tex.reset(new VAAPI::CVaapi1Texture);
+        tex = std::make_unique<VAAPI::CVaapi1Texture>();
       }
       tex->Init(interop);
     }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.cpp
@@ -17,6 +17,8 @@
 #include "utils/GLUtils.h"
 #include "utils/log.h"
 
+#include <memory>
+
 using namespace VAAPI;
 using namespace KODI::UTILS::EGL;
 
@@ -97,18 +99,18 @@ bool CRendererVAAPIGLES::Configure(const VideoPicture& picture, float fps, unsig
   {
     if (useVaapi2)
     {
-      tex.reset(new VAAPI::CVaapi2Texture);
+      tex = std::make_unique<VAAPI::CVaapi2Texture>();
     }
     else
     {
-      tex.reset(new VAAPI::CVaapi1Texture);
+      tex = std::make_unique<VAAPI::CVaapi1Texture>();
     }
     tex->Init(interop);
   }
 
   for (auto& fence : m_fences)
   {
-    fence.reset(new CEGLFence(CRendererVAAPIGLES::m_pWinSystem->GetEGLDisplay()));
+    fence = std::make_unique<CEGLFence>(CRendererVAAPIGLES::m_pWinSystem->GetEGLDisplay());
   }
 
   return CLinuxRendererGLES::Configure(picture, fps, orientation);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -33,11 +33,15 @@
 #include "windowing/GraphicContext.h"
 #include "windowing/WinSystem.h"
 
-#include <locale.h>
-#include <mutex>
-
 #ifdef TARGET_DARWIN_OSX
 #include "platform/darwin/osx/CocoaInterface.h"
+#endif
+
+#include <locale.h>
+#include <memory>
+#include <mutex>
+
+#if defined(TARGET_DARWIN_OSX)
 #include <CoreVideo/CoreVideo.h>
 #include <OpenGL/CGLIOSurface.h>
 #endif
@@ -119,7 +123,7 @@ CLinuxRendererGL::CLinuxRendererGL()
   m_fbo.width = 0.0;
   m_fbo.height = 0.0;
 
-  m_ColorManager.reset(new CColorManager());
+  m_ColorManager = std::make_unique<CColorManager>();
   m_tCLUTTex = 0;
   m_CLUT = NULL;
   m_CLUTsize = 0;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -8,6 +8,9 @@
 
 #include "RenderManager.h"
 
+/* to use the same as player */
+#include "../VideoPlayer/DVDClock.h"
+#include "../VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h"
 #include "RenderCapture.h"
 #include "RenderFactory.h"
 #include "RenderFlags.h"
@@ -25,11 +28,8 @@
 #include "windowing/GraphicContext.h"
 #include "windowing/WinSystem.h"
 
+#include <memory>
 #include <mutex>
-
-/* to use the same as player */
-#include "../VideoPlayer/DVDClock.h"
-#include "../VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h"
 
 using namespace std::chrono_literals;
 
@@ -141,7 +141,7 @@ bool CRenderManager::Configure(const VideoPicture& picture, float fps, unsigned 
     m_stateEvent.Reset();
     m_clockSync.Reset();
     m_dvdClock.SetVsyncAdjust(0);
-    m_pConfigPicture.reset(new VideoPicture());
+    m_pConfigPicture = std::make_unique<VideoPicture>();
     m_pConfigPicture->CopyRef(picture);
 
     std::unique_lock<CCriticalSection> lock2(m_presentlock);

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -29,6 +29,7 @@
 #include "utils/log.h"
 #include "video/Bookmark.h"
 
+#include <memory>
 #include <mutex>
 
 using namespace std::chrono_literals;
@@ -296,7 +297,7 @@ bool PAPlayer::QueueNextFileEx(const CFileItem &file, bool fadeIn)
         file.GetStartOffset() == m_currentStream->m_fileItem->GetEndOffset() && m_currentStream &&
         m_currentStream->m_prepareTriggered)
     {
-      m_currentStream->m_nextFileItem.reset(new CFileItem(file));
+      m_currentStream->m_nextFileItem = std::make_unique<CFileItem>(file);
       m_upcomingCrossfadeMS = 0;
       return true;
     }

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -12,6 +12,9 @@
 #include "DbUrl.h"
 #include "ServiceBroker.h"
 #include "filesystem/SpecialProtocol.h"
+#if defined(HAS_MYSQL) || defined(HAS_MARIADB)
+#include "mysqldataset.h"
+#endif
 #include "profiles/ProfileManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
@@ -20,13 +23,11 @@
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
-#if defined(HAS_MYSQL) || defined(HAS_MARIADB)
-#include "mysqldataset.h"
-#endif
-
 #ifdef TARGET_POSIX
 #include "platform/posix/ConvUtils.h"
 #endif
+
+#include <memory>
 
 using namespace dbiplus;
 
@@ -583,12 +584,12 @@ bool CDatabase::Connect(const std::string& dbName, const DatabaseSettings& dbSet
   // create the appropriate database structure
   if (dbSettings.type == "sqlite3")
   {
-    m_pDB.reset(new SqliteDatabase());
+    m_pDB = std::make_unique<SqliteDatabase>();
   }
 #if defined(HAS_MYSQL) || defined(HAS_MARIADB)
   else if (dbSettings.type == "mysql")
   {
-    m_pDB.reset(new MysqlDatabase());
+    m_pDB = std::make_unique<MysqlDatabase>();
   }
 #endif
   else

--- a/xbmc/dialogs/GUIDialogColorPicker.cpp
+++ b/xbmc/dialogs/GUIDialogColorPicker.cpp
@@ -19,6 +19,7 @@
 #include "utils/log.h"
 
 #include <algorithm>
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -143,7 +144,7 @@ void CGUIDialogColorPicker::Reset()
 
 void CGUIDialogColorPicker::AddItem(const CFileItem& item)
 {
-  m_vecList->Add(CFileItemPtr(new CFileItem(item)));
+  m_vecList->Add(std::make_shared<CFileItem>(item));
 }
 
 void CGUIDialogColorPicker::SetItems(const CFileItemList& pList)

--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -14,6 +14,8 @@
 #include "input/Key.h"
 #include "utils/StringUtils.h"
 
+#include <memory>
+
 #define CONTROL_HEADING         1
 #define CONTROL_NUMBER_OF_ITEMS 2
 #define CONTROL_SIMPLE_LIST     3
@@ -195,7 +197,7 @@ int CGUIDialogSelect::Add(const std::string& strLabel)
 
 int CGUIDialogSelect::Add(const CFileItem& item)
 {
-  m_vecList->Add(CFileItemPtr(new CFileItem(item)));
+  m_vecList->Add(std::make_shared<CFileItem>(item));
   return m_vecList->Size() - 1;
 }
 
@@ -217,7 +219,7 @@ const CFileItemPtr CGUIDialogSelect::GetSelectedFileItem() const
 {
   if (m_selectedItem)
     return m_selectedItem;
-  return CFileItemPtr(new CFileItem);
+  return std::make_shared<CFileItem>();
 }
 
 const std::vector<int>& CGUIDialogSelect::GetSelectedItems() const

--- a/xbmc/events/EventLogManager.cpp
+++ b/xbmc/events/EventLogManager.cpp
@@ -10,6 +10,7 @@
 
 #include "EventLog.h"
 
+#include <memory>
 #include <mutex>
 #include <utility>
 
@@ -20,7 +21,7 @@ CEventLog& CEventLogManager::GetEventLog(unsigned int profileId)
   auto eventLog = m_eventLogs.find(profileId);
   if (eventLog == m_eventLogs.end())
   {
-    m_eventLogs.insert(std::make_pair(profileId, std::unique_ptr<CEventLog>(new CEventLog)));
+    m_eventLogs.insert(std::make_pair(profileId, std::make_unique<CEventLog>()));
     eventLog = m_eventLogs.find(profileId);
   }
 

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -24,6 +24,7 @@
 #include <array>
 #include <cassert>
 #include <climits>
+#include <memory>
 #include <stdlib.h>
 #include <string>
 
@@ -187,7 +188,7 @@ void CBlurayDirectory::GetRoot(CFileItemList &items)
     CFileItemPtr item;
 
     path.SetFileName(URIUtils::AddFileToFolder(m_url.GetFileName(), "titles"));
-    item.reset(new CFileItem());
+    item = std::make_shared<CFileItem>();
     item->SetPath(path.Get());
     item->m_bIsFolder = true;
     item->SetLabel(g_localizeStrings.Get(25002) /* All titles */);
@@ -202,7 +203,7 @@ void CBlurayDirectory::GetRoot(CFileItemList &items)
     }
 
     path.SetFileName("menu");
-    item.reset(new CFileItem());
+    item = std::make_shared<CFileItem>();
     item->SetPath(path.Get());
     item->m_bIsFolder = false;
     item->SetLabel(g_localizeStrings.Get(25003) /* Menus */);

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -31,6 +31,7 @@
 #include "utils/UrlOptions.h"
 
 #include <climits>
+#include <memory>
 #include <mutex>
 
 using namespace XFILE;
@@ -120,7 +121,7 @@ bool CShoutcastFile::Open(const CURL& url)
   {
     std::unique_lock<CCriticalSection> lock(m_tagSection);
 
-    m_masterTag.reset(new CMusicInfoTag());
+    m_masterTag = std::make_shared<CMusicInfoTag>();
     m_masterTag->SetStationName(icyTitle);
     m_masterTag->SetGenre(icyGenre);
     m_masterTag->SetLoaded(true);

--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -26,6 +26,7 @@
 #include "video/VideoDbUrl.h"
 
 #include <math.h>
+#include <memory>
 
 #define PROPERTY_PATH_DB            "path.db"
 #define PROPERTY_SORT_ORDER         "sort.order"
@@ -82,7 +83,7 @@ namespace XFILE
     playlist.GetVirtualFolders(virtualFolders);
     for (const std::string& virtualFolder : virtualFolders)
     {
-      CFileItemPtr pItem = CFileItemPtr(new CFileItem(virtualFolder, true));
+      CFileItemPtr pItem = std::make_shared<CFileItem>(virtualFolder, true);
       IFileDirectory *dir = CFileDirectoryFactory::Create(pItem->GetURL(), pItem.get());
 
       if (dir != NULL)

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -41,6 +41,7 @@
 #include <algorithm>
 #include <cstring>
 #include <iterator>
+#include <memory>
 #include <mutex>
 #include <utility>
 
@@ -312,7 +313,7 @@ bool CGameClient::InitializeGameplay(const std::string& gamePath,
     m_gamePath = gamePath;
     m_input = input;
 
-    m_inGameSaves.reset(new CGameClientInGameSaves(this, m_ifc.game));
+    m_inGameSaves = std::make_unique<CGameClientInGameSaves>(this, m_ifc.game);
     m_inGameSaves->Load();
 
     return true;

--- a/xbmc/games/addons/GameClientSubsystem.cpp
+++ b/xbmc/games/addons/GameClientSubsystem.cpp
@@ -15,6 +15,8 @@
 #include "games/addons/input/GameClientInput.h"
 #include "games/addons/streams/GameClientStreams.h"
 
+#include <memory>
+
 using namespace KODI;
 using namespace GAME;
 
@@ -34,9 +36,10 @@ GameClientSubsystems CGameClientSubsystem::CreateSubsystems(CGameClient& gameCli
   GameClientSubsystems subsystems = {};
 
   subsystems.Cheevos = std::make_unique<CGameClientCheevos>(gameClient, gameStruct);
-  subsystems.Input.reset(new CGameClientInput(gameClient, gameStruct, clientAccess));
-  subsystems.AddonProperties.reset(new CGameClientProperties(gameClient, *gameStruct.props));
-  subsystems.Streams.reset(new CGameClientStreams(gameClient));
+  subsystems.Input = std::make_unique<CGameClientInput>(gameClient, gameStruct, clientAccess);
+  subsystems.AddonProperties =
+      std::make_unique<CGameClientProperties>(gameClient, *gameStruct.props);
+  subsystems.Streams = std::make_unique<CGameClientStreams>(gameClient);
 
   return subsystems;
 }

--- a/xbmc/games/addons/input/GameClientInput.cpp
+++ b/xbmc/games/addons/input/GameClientInput.cpp
@@ -94,7 +94,7 @@ void CGameClientInput::Start(IGameInputCallback* input)
     }
 
     // Ensure hardware is open to receive events
-    m_hardware.reset(new CGameClientHardware(m_gameClient));
+    m_hardware = std::make_unique<CGameClientHardware>(m_gameClient);
   }
 
   // Notify observers of the initial port configuration
@@ -238,7 +238,7 @@ void CGameClientInput::LoadTopology()
   if (hardwarePorts.empty())
     hardwarePorts.emplace_back(new CGameClientPort(GetControllers(m_gameClient)));
 
-  m_topology.reset(new CGameClientTopology(std::move(hardwarePorts), playerLimit));
+  m_topology = std::make_unique<CGameClientTopology>(std::move(hardwarePorts), playerLimit);
 }
 
 void CGameClientInput::ActivateControllers(CControllerHub& hub)
@@ -264,7 +264,8 @@ void CGameClientInput::SetControllerLayouts(const ControllerVector& controllers)
   {
     const std::string controllerId = controller->ID();
     if (m_controllerLayouts.find(controllerId) == m_controllerLayouts.end())
-      m_controllerLayouts[controllerId].reset(new CGameClientController(*this, controller));
+      m_controllerLayouts[controllerId] =
+          std::make_unique<CGameClientController>(*this, controller);
   }
 
   std::vector<game_controller_layout> controllerStructs;

--- a/xbmc/games/addons/input/GameClientInput.cpp
+++ b/xbmc/games/addons/input/GameClientInput.cpp
@@ -35,6 +35,7 @@
 #include "utils/log.h"
 
 #include <algorithm>
+#include <memory>
 #include <mutex>
 
 using namespace KODI;
@@ -626,7 +627,8 @@ bool CGameClientInput::OpenJoystick(const std::string& portAddress, const Contro
     return false;
   }
 
-  m_joysticks[portAddress].reset(new CGameClientJoystick(m_gameClient, portAddress, controller));
+  m_joysticks[portAddress] =
+      std::make_shared<CGameClientJoystick>(m_gameClient, portAddress, controller);
 
   return true;
 }

--- a/xbmc/games/addons/streams/GameClientStreams.cpp
+++ b/xbmc/games/addons/streams/GameClientStreams.cpp
@@ -97,17 +97,17 @@ std::unique_ptr<IGameClientStream> CGameClientStreams::CreateStream(
   {
     case GAME_STREAM_AUDIO:
     {
-      gameStream.reset(new CGameClientStreamAudio(m_gameClient.GetSampleRate()));
+      gameStream = std::make_unique<CGameClientStreamAudio>(m_gameClient.GetSampleRate());
       break;
     }
     case GAME_STREAM_VIDEO:
     {
-      gameStream.reset(new CGameClientStreamVideo);
+      gameStream = std::make_unique<CGameClientStreamVideo>();
       break;
     }
     case GAME_STREAM_SW_FRAMEBUFFER:
     {
-      gameStream.reset(new CGameClientStreamSwFramebuffer);
+      gameStream = std::make_unique<CGameClientStreamSwFramebuffer>();
       break;
     }
     default:

--- a/xbmc/games/controllers/types/ControllerNode.cpp
+++ b/xbmc/games/controllers/types/ControllerNode.cpp
@@ -14,6 +14,7 @@
 #include "games/ports/types/PortNode.h"
 
 #include <algorithm>
+#include <memory>
 #include <utility>
 
 using namespace KODI;
@@ -32,7 +33,7 @@ CControllerNode& CControllerNode::operator=(const CControllerNode& rhs)
     m_controller = rhs.m_controller;
     m_portAddress = rhs.m_portAddress;
     m_controllerAddress = rhs.m_controllerAddress;
-    m_hub.reset(new CControllerHub(*rhs.m_hub));
+    m_hub = std::make_unique<CControllerHub>(*rhs.m_hub);
   }
 
   return *this;
@@ -56,7 +57,7 @@ void CControllerNode::Clear()
   m_controller.reset();
   m_portAddress.clear();
   m_controllerAddress.clear();
-  m_hub.reset(new CControllerHub);
+  m_hub = std::make_unique<CControllerHub>();
 }
 
 void CControllerNode::SetController(ControllerPtr controller)
@@ -94,7 +95,7 @@ void CControllerNode::SetControllerAddress(std::string controllerAddress)
 
 void CControllerNode::SetHub(CControllerHub hub)
 {
-  m_hub.reset(new CControllerHub(std::move(hub)));
+  m_hub = std::make_unique<CControllerHub>(std::move(hub));
 }
 
 bool CControllerNode::IsControllerAccepted(const std::string& controllerId) const

--- a/xbmc/games/ports/input/PortInput.cpp
+++ b/xbmc/games/ports/input/PortInput.cpp
@@ -15,6 +15,8 @@
 #include "input/joysticks/keymaps/KeymapHandling.h"
 #include "peripherals/devices/Peripheral.h"
 
+#include <memory>
+
 using namespace KODI;
 using namespace GAME;
 
@@ -37,7 +39,7 @@ void CPortInput::RegisterInput(JOYSTICK::IInputProvider* provider)
   provider->RegisterInputHandler(this, false);
 
   // Register GUI input
-  m_appInput.reset(new JOYSTICK::CKeymapHandling(provider, false, this));
+  m_appInput = std::make_unique<JOYSTICK::CKeymapHandling>(provider, false, this);
 }
 
 void CPortInput::UnregisterInput(JOYSTICK::IInputProvider* provider)

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -26,6 +26,8 @@
 #include "utils/XBMCTinyXML.h"
 #include "utils/log.h"
 
+#include <memory>
+
 #define HOLD_TIME_START 100
 #define HOLD_TIME_END   3000
 #define SCROLLING_GAP   200U

--- a/xbmc/guilib/GUIComponent.cpp
+++ b/xbmc/guilib/GUIComponent.cpp
@@ -19,15 +19,17 @@
 #include "URL.h"
 #include "dialogs/GUIDialogYesNo.h"
 
+#include <memory>
+
 CGUIComponent::CGUIComponent()
 {
-  m_pWindowManager.reset(new CGUIWindowManager());
-  m_pTextureManager.reset(new CGUITextureManager());
-  m_pLargeTextureManager.reset(new CGUILargeTextureManager());
-  m_stereoscopicsManager.reset(new CStereoscopicsManager());
-  m_guiInfoManager.reset(new CGUIInfoManager());
-  m_guiColorManager.reset(new CGUIColorManager());
-  m_guiAudioManager.reset(new CGUIAudioManager());
+  m_pWindowManager = std::make_unique<CGUIWindowManager>();
+  m_pTextureManager = std::make_unique<CGUITextureManager>();
+  m_pLargeTextureManager = std::make_unique<CGUILargeTextureManager>();
+  m_stereoscopicsManager = std::make_unique<CStereoscopicsManager>();
+  m_guiInfoManager = std::make_unique<CGUIInfoManager>();
+  m_guiColorManager = std::make_unique<CGUIColorManager>();
+  m_guiAudioManager = std::make_unique<CGUIAudioManager>();
 }
 
 CGUIComponent::~CGUIComponent()

--- a/xbmc/guilib/GUIVisualisationControl.cpp
+++ b/xbmc/guilib/GUIVisualisationControl.cpp
@@ -31,6 +31,8 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
+#include <memory>
+
 namespace
 {
 constexpr unsigned int MAX_AUDIO_BUFFERS = 16;
@@ -386,7 +388,7 @@ bool CGUIVisualisationControl::InitVisualization()
   if (y + h > context.GetHeight())
     h = context.GetHeight() - y;
 
-  m_instance.reset(new KODI::ADDONS::CVisualization(addonBase, x, y, w, h));
+  m_instance = std::make_unique<KODI::ADDONS::CVisualization>(addonBase, x, y, w, h);
   CreateBuffers();
 
   m_alreadyStarted = false;

--- a/xbmc/guilib/guiinfo/PicturesGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PicturesGUIInfo.cpp
@@ -22,6 +22,7 @@
 #include "utils/log.h"
 
 #include <map>
+#include <memory>
 
 using namespace KODI::GUILIB::GUIINFO;
 
@@ -99,7 +100,7 @@ void CPicturesGUIInfo::SetCurrentSlide(CFileItem *item)
       if (!tag->Loaded()) // If picture metadata has not been loaded yet, load it now
         tag->Load(item->GetPath());
     }
-    m_currentSlide.reset(new CFileItem(*item));
+    m_currentSlide = std::make_unique<CFileItem>(*item);
   }
   else if (m_currentSlide)
   {

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -33,6 +33,7 @@
 
 #include <charconv>
 #include <cmath>
+#include <memory>
 
 using namespace KODI::GUILIB::GUIINFO;
 
@@ -147,7 +148,7 @@ bool CPlayerGUIInfo::InitCurrentItem(CFileItem *item)
   if (item && m_appPlayer->IsPlaying())
   {
     CLog::Log(LOGDEBUG, "CPlayerGUIInfo::InitCurrentItem({})", CURL::GetRedacted(item->GetPath()));
-    m_currentItem.reset(new CFileItem(*item));
+    m_currentItem = std::make_unique<CFileItem>(*item);
   }
   else
   {

--- a/xbmc/input/IRTranslator.cpp
+++ b/xbmc/input/IRTranslator.cpp
@@ -19,6 +19,7 @@
 #include "utils/log.h"
 
 #include <cstring>
+#include <memory>
 #include <stdlib.h>
 #include <vector>
 
@@ -106,7 +107,7 @@ void CIRTranslator::MapRemote(tinyxml2::XMLNode* pRemote, const std::string& szD
 
   auto it = m_irRemotesMap.find(szDevice);
   if (it == m_irRemotesMap.end())
-    m_irRemotesMap[szDevice].reset(new IRButtonMap);
+    m_irRemotesMap[szDevice] = std::make_shared<IRButtonMap>();
 
   const std::shared_ptr<IRButtonMap>& buttons = m_irRemotesMap[szDevice];
 

--- a/xbmc/input/JoystickMapper.cpp
+++ b/xbmc/input/JoystickMapper.cpp
@@ -16,6 +16,7 @@
 #include "utils/StringUtils.h"
 
 #include <algorithm>
+#include <memory>
 #include <sstream>
 #include <utility>
 
@@ -43,7 +44,7 @@ void CJoystickMapper::MapActions(int windowID, const tinyxml2::XMLNode* pDevice)
   // Create/overwrite keymap
   auto& keymap = m_joystickKeymaps[controllerId];
   if (!keymap)
-    keymap.reset(new CWindowKeymap(controllerId));
+    keymap = std::make_shared<CWindowKeymap>(controllerId);
 
   const auto* pButton = pDevice->FirstChildElement();
   while (pButton != nullptr)

--- a/xbmc/input/joysticks/generic/ButtonMapping.cpp
+++ b/xbmc/input/joysticks/generic/ButtonMapping.cpp
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <assert.h>
 #include <cmath>
+#include <memory>
 
 using namespace KODI;
 using namespace JOYSTICK;
@@ -571,7 +572,7 @@ CMouseButtonDetector& CButtonMapping::GetMouseButton(MOUSE::BUTTON_ID buttonInde
 CPointerDetector& CButtonMapping::GetPointer()
 {
   if (!m_pointer)
-    m_pointer.reset(new CPointerDetector(this));
+    m_pointer = std::make_unique<CPointerDetector>(this);
 
   return *m_pointer;
 }

--- a/xbmc/input/joysticks/keymaps/KeymapHandler.cpp
+++ b/xbmc/input/joysticks/keymaps/KeymapHandler.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <assert.h>
 #include <cmath>
+#include <memory>
 #include <utility>
 
 using namespace KODI;
@@ -33,7 +34,7 @@ CKeymapHandler::CKeymapHandler(IActionListener* actionHandler, const IKeymap* ke
   assert(m_keymap != nullptr);
 
   if (m_keymap->Environment()->UseEasterEgg())
-    m_easterEgg.reset(new CJoystickEasterEgg(ControllerID()));
+    m_easterEgg = std::make_unique<CJoystickEasterEgg>(ControllerID());
 }
 
 bool CKeymapHandler::HotkeysPressed(const std::set<std::string>& keyNames) const

--- a/xbmc/interfaces/AnnouncementManager.cpp
+++ b/xbmc/interfaces/AnnouncementManager.cpp
@@ -19,6 +19,7 @@
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
 
+#include <memory>
 #include <mutex>
 #include <stdio.h>
 
@@ -135,7 +136,7 @@ void CAnnouncementManager::Announce(AnnouncementFlag flag,
   announcement.data = data;
 
   if (item != nullptr)
-    announcement.item = CFileItemPtr(new CFileItem(*item));
+    announcement.item = std::make_shared<CFileItem>(*item);
 
   {
     std::unique_lock<CCriticalSection> lock(m_queueCritSection);

--- a/xbmc/interfaces/generic/ScriptInvocationManager.cpp
+++ b/xbmc/interfaces/generic/ScriptInvocationManager.cpp
@@ -18,6 +18,7 @@
 #include "utils/log.h"
 
 #include <cerrno>
+#include <memory>
 #include <mutex>
 #include <utility>
 #include <vector>
@@ -268,8 +269,7 @@ int CScriptInvocationManager::ExecuteAsync(
     return invokerThread->GetId();
   }
 
-  m_lastInvokerThread =
-      CLanguageInvokerThreadPtr(new CLanguageInvokerThread(languageInvoker, this, reuseable));
+  m_lastInvokerThread = std::make_shared<CLanguageInvokerThread>(languageInvoker, this, reuseable);
   if (m_lastInvokerThread == NULL)
     return -1;
 

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -29,6 +29,8 @@
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 
+#include <memory>
+
 using namespace MUSIC_INFO;
 using namespace JSONRPC;
 using namespace XFILE;
@@ -495,7 +497,7 @@ JSONRPC_STATUS CAudioLibrary::GetSongDetails(const std::string &method, ITranspo
     return InvalidParams;
 
   CFileItemList items;
-  CFileItemPtr item = CFileItemPtr(new CFileItem(song));
+  CFileItemPtr item = std::make_shared<CFileItem>(song);
   FillItemArtistIDs(song.GetArtistIDArray(), item);
   items.Add(item);
 
@@ -1151,7 +1153,7 @@ bool CAudioLibrary::FillFileItemList(const CVariant &parameterObject, CFileItemL
     CSong song;
     if (musicdatabase.GetSong(songID, song))
     {
-      list.Add(CFileItemPtr(new CFileItem(song)));
+      list.Add(std::make_shared<CFileItem>(song));
       success = true;
     }
   }
@@ -1190,7 +1192,7 @@ void CAudioLibrary::FillAlbumItem(const CAlbum& album,
                                   const std::string& path,
                                   std::shared_ptr<CFileItem>& item)
 {
-  item = CFileItemPtr(new CFileItem(path, album));
+  item = std::make_shared<CFileItem>(path, album);
   // Add album artistIds as separate property as not part of CMusicInfoTag
   std::vector<int> artistids = album.GetArtistIDArray();
   FillItemArtistIDs(artistids, item);

--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -37,6 +37,7 @@
 #include "video/VideoThumbLoader.h"
 
 #include <map>
+#include <memory>
 #include <string.h>
 
 using namespace MUSIC_INFO;
@@ -524,7 +525,7 @@ bool CFileItemHandler::FillFileItemList(const CVariant &parameterObject, CFileIt
 
     if (!added)
     {
-      CFileItemPtr item = CFileItemPtr(new CFileItem(file, false));
+      CFileItemPtr item = std::make_shared<CFileItem>(file, false);
       if (item->IsPicture())
       {
         CPictureInfoTag picture;

--- a/xbmc/interfaces/json-rpc/FileOperations.cpp
+++ b/xbmc/interfaces/json-rpc/FileOperations.cpp
@@ -26,6 +26,8 @@
 #include "utils/Variant.h"
 #include "video/VideoDatabase.h"
 
+#include <memory>
+
 using namespace XFILE;
 using namespace JSONRPC;
 
@@ -44,7 +46,7 @@ JSONRPC_STATUS CFileOperations::GetRootDirectory(const std::string &method, ITra
       if (sources->at(i).m_iHasLock == LOCK_STATE_LOCKED)
         continue;
 
-      items.Add(CFileItemPtr(new CFileItem(sources->at(i))));
+      items.Add(std::make_shared<CFileItem>(sources->at(i)));
     }
 
     for (unsigned int i = 0; i < (unsigned int)items.Size(); i++)
@@ -184,7 +186,7 @@ JSONRPC_STATUS CFileOperations::GetFileDetails(const std::string &method, ITrans
   if (CDirectory::GetDirectory(path, items, "", DIR_FLAG_DEFAULTS) && items.Contains(file))
     item = items.Get(file);
   else
-    item = CFileItemPtr(new CFileItem(file, false));
+    item = std::make_shared<CFileItem>(file, false);
 
   if (!URIUtils::IsUPnP(file))
     FillFileItem(item, item, parameterObject["media"].asString(), parameterObject);

--- a/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
+++ b/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
@@ -30,6 +30,8 @@
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
+#include <memory>
+
 using namespace JSONRPC;
 
 std::map<std::string, CVariant> CJSONServiceDescription::m_notifications = std::map<std::string, CVariant>();
@@ -422,7 +424,7 @@ bool JSONSchemaTypeDefinition::Parse(const CVariant &value, bool isParameter /* 
         // of the current property into it, parse it
         // recursively and add its default value
         // to the current type's default value
-        JSONSchemaTypeDefinitionPtr propertyType = JSONSchemaTypeDefinitionPtr(new JSONSchemaTypeDefinition());
+        JSONSchemaTypeDefinitionPtr propertyType = std::make_shared<JSONSchemaTypeDefinition>();
         propertyType->name = itr->first;
         if (!propertyType->Parse(itr->second))
         {
@@ -435,7 +437,7 @@ bool JSONSchemaTypeDefinition::Parse(const CVariant &value, bool isParameter /* 
     }
 
     hasAdditionalProperties = true;
-    additionalProperties = JSONSchemaTypeDefinitionPtr(new JSONSchemaTypeDefinition());
+    additionalProperties = std::make_shared<JSONSchemaTypeDefinition>();
     if (value.isMember("additionalProperties"))
     {
       if (value["additionalProperties"].isBoolean())
@@ -484,7 +486,7 @@ bool JSONSchemaTypeDefinition::Parse(const CVariant &value, bool isParameter /* 
       // If it is an object, there is only one schema for it
       if (value["additionalItems"].isObject())
       {
-        JSONSchemaTypeDefinitionPtr additionalItem = JSONSchemaTypeDefinitionPtr(new JSONSchemaTypeDefinition());
+        JSONSchemaTypeDefinitionPtr additionalItem = std::make_shared<JSONSchemaTypeDefinition>();
         if (additionalItem->Parse(value["additionalItems"]))
           additionalItems.push_back(additionalItem);
         else
@@ -499,7 +501,7 @@ bool JSONSchemaTypeDefinition::Parse(const CVariant &value, bool isParameter /* 
       {
         for (unsigned int itemIndex = 0; itemIndex < value["additionalItems"].size(); itemIndex++)
         {
-          JSONSchemaTypeDefinitionPtr additionalItem = JSONSchemaTypeDefinitionPtr(new JSONSchemaTypeDefinition());
+          JSONSchemaTypeDefinitionPtr additionalItem = std::make_shared<JSONSchemaTypeDefinition>();
 
           if (additionalItem->Parse(value["additionalItems"][itemIndex]))
             additionalItems.push_back(additionalItem);
@@ -527,7 +529,7 @@ bool JSONSchemaTypeDefinition::Parse(const CVariant &value, bool isParameter /* 
     {
       if (value["items"].isObject())
       {
-        JSONSchemaTypeDefinitionPtr item = JSONSchemaTypeDefinitionPtr(new JSONSchemaTypeDefinition());
+        JSONSchemaTypeDefinitionPtr item = std::make_shared<JSONSchemaTypeDefinition>();
         if (!item->Parse(value["items"]))
         {
           CLog::Log(LOGDEBUG, "Invalid item definition in \"items\" for type {}", name);
@@ -542,7 +544,7 @@ bool JSONSchemaTypeDefinition::Parse(const CVariant &value, bool isParameter /* 
       {
         for (CVariant::const_iterator_array itemItr = value["items"].begin_array(); itemItr != value["items"].end_array(); ++itemItr)
         {
-          JSONSchemaTypeDefinitionPtr item = JSONSchemaTypeDefinitionPtr(new JSONSchemaTypeDefinition());
+          JSONSchemaTypeDefinitionPtr item = std::make_shared<JSONSchemaTypeDefinition>();
           if (!item->Parse(*itemItr))
           {
             CLog::Log(LOGDEBUG, "Invalid item definition in \"items\" array for type {}", name);
@@ -1335,7 +1337,7 @@ bool JsonRpcMethod::Parse(const CVariant &value)
 
       // Parse the parameter and add it to the list
       // of defined parameters
-      JSONSchemaTypeDefinitionPtr param = JSONSchemaTypeDefinitionPtr(new JSONSchemaTypeDefinition());
+      JSONSchemaTypeDefinitionPtr param = std::make_shared<JSONSchemaTypeDefinition>();
       if (!parseParameter(parameter, param))
       {
         missingReference = param->missingReference;
@@ -1615,7 +1617,7 @@ bool CJSONServiceDescription::AddType(const std::string &jsonType)
   // Make sure the "id" attribute is correctly populated
   descriptionObject[typeName]["id"] = typeName;
 
-  JSONSchemaTypeDefinitionPtr globalType = JSONSchemaTypeDefinitionPtr(new JSONSchemaTypeDefinition());
+  JSONSchemaTypeDefinitionPtr globalType = std::make_shared<JSONSchemaTypeDefinition>();
   globalType->name = typeName;
   globalType->ID = typeName;
   CJSONServiceDescription::addReferenceTypeDefinition(globalType);
@@ -1704,7 +1706,7 @@ bool CJSONServiceDescription::AddEnum(const std::string &name, const std::vector
       values.size() == 0)
     return false;
 
-  JSONSchemaTypeDefinitionPtr definition = JSONSchemaTypeDefinitionPtr(new JSONSchemaTypeDefinition());
+  JSONSchemaTypeDefinitionPtr definition = std::make_shared<JSONSchemaTypeDefinition>();
   definition->ID = name;
 
   std::vector<CVariant::VariantType> types;
@@ -1994,7 +1996,7 @@ bool CJSONServiceDescription::parseJSONSchemaType(const CVariant &value, std::ve
     // to handle a union type
     for (unsigned int typeIndex = 0; typeIndex < value.size(); typeIndex++)
     {
-      JSONSchemaTypeDefinitionPtr definition = JSONSchemaTypeDefinitionPtr(new JSONSchemaTypeDefinition());
+      JSONSchemaTypeDefinitionPtr definition = std::make_shared<JSONSchemaTypeDefinition>();
       // If the type is a string try to parse it
       if (value[typeIndex].isString())
         definition->type = StringToSchemaValueType(value[typeIndex].asString());

--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -27,6 +27,8 @@
 #include "pvr/timers/PVRTimers.h"
 #include "utils/Variant.h"
 
+#include <memory>
+
 using namespace JSONRPC;
 using namespace PVR;
 using namespace KODI::MESSAGING;
@@ -217,7 +219,8 @@ JSONRPC_STATUS CPVROperations::GetBroadcastDetails(const std::string &method, IT
   if (!epgTag)
     return InvalidParams;
 
-  HandleFileItem("broadcastid", false, "broadcastdetails", CFileItemPtr(new CFileItem(epgTag)), parameterObject, parameterObject["properties"], result, false);
+  HandleFileItem("broadcastid", false, "broadcastdetails", std::make_shared<CFileItem>(epgTag),
+                 parameterObject, parameterObject["properties"], result, false);
 
   return OK;
 }
@@ -396,7 +399,8 @@ JSONRPC_STATUS CPVROperations::GetTimerDetails(const std::string &method, ITrans
   if (!timer)
     return InvalidParams;
 
-  HandleFileItem("timerid", false, "timerdetails", CFileItemPtr(new CFileItem(timer)), parameterObject, parameterObject["properties"], result, false);
+  HandleFileItem("timerid", false, "timerdetails", std::make_shared<CFileItem>(timer),
+                 parameterObject, parameterObject["properties"], result, false);
 
   return OK;
 }

--- a/xbmc/interfaces/json-rpc/VideoLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/VideoLibrary.cpp
@@ -22,6 +22,8 @@
 #include "video/VideoDbUrl.h"
 #include "video/VideoLibraryQueue.h"
 
+#include <memory>
+
 using namespace JSONRPC;
 
 JSONRPC_STATUS CVideoLibrary::GetMovies(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
@@ -93,7 +95,8 @@ JSONRPC_STATUS CVideoLibrary::GetMovieDetails(const std::string &method, ITransp
   if (!videodatabase.GetMovieInfo("", infos, id, RequiresAdditionalDetails(MediaTypeMovie, parameterObject)) || infos.m_iDbId <= 0)
     return InvalidParams;
 
-  HandleFileItem("movieid", true, "moviedetails", CFileItemPtr(new CFileItem(infos)), parameterObject, parameterObject["properties"], result, false);
+  HandleFileItem("movieid", true, "moviedetails", std::make_shared<CFileItem>(infos),
+                 parameterObject, parameterObject["properties"], result, false);
   return OK;
 }
 
@@ -124,7 +127,8 @@ JSONRPC_STATUS CVideoLibrary::GetMovieSetDetails(const std::string &method, ITra
   if (!videodatabase.GetSetInfo(id, infos) || infos.m_iDbId <= 0)
     return InvalidParams;
 
-  HandleFileItem("setid", false, "setdetails", CFileItemPtr(new CFileItem(infos)), parameterObject, parameterObject["properties"], result, false);
+  HandleFileItem("setid", false, "setdetails", std::make_shared<CFileItem>(infos), parameterObject,
+                 parameterObject["properties"], result, false);
 
   // Get movies from the set
   CFileItemList items;
@@ -227,7 +231,7 @@ JSONRPC_STATUS CVideoLibrary::GetSeasonDetails(const std::string &method, ITrans
       infos.m_iDbId <= 0 || infos.m_iIdShow <= 0)
     return InvalidParams;
 
-  CFileItemPtr pItem = CFileItemPtr(new CFileItem(infos));
+  CFileItemPtr pItem = std::make_shared<CFileItem>(infos);
   HandleFileItem("seasonid", false, "seasondetails", pItem, parameterObject, parameterObject["properties"], result, false);
   return OK;
 }
@@ -301,7 +305,7 @@ JSONRPC_STATUS CVideoLibrary::GetEpisodeDetails(const std::string &method, ITran
   if (!videodatabase.GetEpisodeInfo("", infos, id, RequiresAdditionalDetails(MediaTypeEpisode, parameterObject)) || infos.m_iDbId <= 0)
     return InvalidParams;
 
-  CFileItemPtr pItem = CFileItemPtr(new CFileItem(infos));
+  CFileItemPtr pItem = std::make_shared<CFileItem>(infos);
   // We need to set the correct base path to get the valid fanart
   int tvshowid = infos.m_iIdShow;
   if (tvshowid <= 0)
@@ -374,7 +378,8 @@ JSONRPC_STATUS CVideoLibrary::GetMusicVideoDetails(const std::string &method, IT
   if (!videodatabase.GetMusicVideoInfo("", infos, id, RequiresAdditionalDetails(MediaTypeMusicVideo, parameterObject)) || infos.m_iDbId <= 0)
     return InvalidParams;
 
-  HandleFileItem("musicvideoid", true, "musicvideodetails", CFileItemPtr(new CFileItem(infos)), parameterObject, parameterObject["properties"], result, false);
+  HandleFileItem("musicvideoid", true, "musicvideodetails", std::make_shared<CFileItem>(infos),
+                 parameterObject, parameterObject["properties"], result, false);
   return OK;
 }
 
@@ -861,7 +866,8 @@ JSONRPC_STATUS CVideoLibrary::RefreshMovie(const std::string &method, ITransport
 
   bool ignoreNfo = parameterObject["ignorenfo"].asBoolean();
   std::string searchTitle = parameterObject["title"].asString();
-  CVideoLibraryQueue::GetInstance().RefreshItem(CFileItemPtr(new CFileItem(infos)), ignoreNfo, true, false, searchTitle);
+  CVideoLibraryQueue::GetInstance().RefreshItem(std::make_shared<CFileItem>(infos), ignoreNfo, true,
+                                                false, searchTitle);
 
   return ACK;
 }
@@ -901,7 +907,7 @@ JSONRPC_STATUS CVideoLibrary::RefreshEpisode(const std::string &method, ITranspo
   if (!videodatabase.GetEpisodeInfo("", infos, id) || infos.m_iDbId <= 0)
     return InvalidParams;
 
-  CFileItemPtr item = CFileItemPtr(new CFileItem(infos));
+  CFileItemPtr item = std::make_shared<CFileItem>(infos);
   // We need to set the correct base path to get the valid fanart
   int tvshowid = infos.m_iIdShow;
   if (tvshowid <= 0)
@@ -928,7 +934,8 @@ JSONRPC_STATUS CVideoLibrary::RefreshMusicVideo(const std::string &method, ITran
 
   bool ignoreNfo = parameterObject["ignorenfo"].asBoolean();
   std::string searchTitle = parameterObject["title"].asString();
-  CVideoLibraryQueue::GetInstance().RefreshItem(CFileItemPtr(new CFileItem(infos)), ignoreNfo, true, false, searchTitle);
+  CVideoLibraryQueue::GetInstance().RefreshItem(std::make_shared<CFileItem>(infos), ignoreNfo, true,
+                                                false, searchTitle);
 
   return ACK;
 }
@@ -1063,7 +1070,7 @@ bool CVideoLibrary::FillFileItemList(const CVariant &parameterObject, CFileItemL
     videodatabase.GetMovieInfo("", details, movieID);
     if (!details.IsEmpty())
     {
-      list.Add(CFileItemPtr(new CFileItem(details)));
+      list.Add(std::make_shared<CFileItem>(details));
       success = true;
     }
   }
@@ -1072,7 +1079,7 @@ bool CVideoLibrary::FillFileItemList(const CVariant &parameterObject, CFileItemL
     CVideoInfoTag details;
     if (videodatabase.GetEpisodeInfo("", details, episodeID) && !details.IsEmpty())
     {
-      list.Add(CFileItemPtr(new CFileItem(details)));
+      list.Add(std::make_shared<CFileItem>(details));
       success = true;
     }
   }
@@ -1082,7 +1089,7 @@ bool CVideoLibrary::FillFileItemList(const CVariant &parameterObject, CFileItemL
     videodatabase.GetMusicVideoInfo("", details, musicVideoID);
     if (!details.IsEmpty())
     {
-      list.Add(CFileItemPtr(new CFileItem(details)));
+      list.Add(std::make_shared<CFileItem>(details));
       success = true;
     }
   }

--- a/xbmc/interfaces/legacy/Dialog.cpp
+++ b/xbmc/interfaces/legacy/Dialog.cpp
@@ -33,6 +33,8 @@
 #include "utils/log.h"
 #include "video/dialogs/GUIDialogVideoInfo.h"
 
+#include <memory>
+
  using namespace KODI::MESSAGING;
 
 #define ACTIVE_WINDOW CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow()
@@ -171,7 +173,7 @@ namespace XBMCAddon
       pDialog->Open();
 
       if (pDialog->IsConfirmed())
-        return std::unique_ptr<std::vector<int>>(new std::vector<int>(pDialog->GetSelectedItems()));
+        return std::make_unique<std::vector<int>>(pDialog->GetSelectedItems());
       else
         return std::unique_ptr<std::vector<int>>();
     }

--- a/xbmc/interfaces/legacy/ListItem.cpp
+++ b/xbmc/interfaces/legacy/ListItem.cpp
@@ -23,6 +23,7 @@
 #include "video/VideoInfoTag.h"
 
 #include <cstdlib>
+#include <memory>
 #include <sstream>
 #include <utility>
 
@@ -39,7 +40,7 @@ namespace XBMCAddon
       item.reset();
 
       // create CFileItem
-      item.reset(new CFileItem());
+      item = std::make_shared<CFileItem>();
       if (!item) // not sure if this is really possible
         return;
 

--- a/xbmc/interfaces/legacy/ListItem.h
+++ b/xbmc/interfaces/legacy/ListItem.h
@@ -22,6 +22,7 @@
 #include "commons/Exception.h"
 
 #include <map>
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -110,7 +111,7 @@ namespace XBMCAddon
       static inline AddonClass::Ref<ListItem> fromString(const String& str)
       {
         AddonClass::Ref<ListItem> ret = AddonClass::Ref<ListItem>(new ListItem());
-        ret->item.reset(new CFileItem(str));
+        ret->item = std::make_shared<CFileItem>(str);
         return ret;
       }
 #endif

--- a/xbmc/interfaces/python/ContextItemAddonInvoker.cpp
+++ b/xbmc/interfaces/python/ContextItemAddonInvoker.cpp
@@ -12,14 +12,14 @@
 #include "interfaces/python/swig.h"
 #include "utils/log.h"
 
+#include <memory>
+
 #include <Python.h>
 #include <osdefs.h>
 
-
-CContextItemAddonInvoker::CContextItemAddonInvoker(
-    ILanguageInvocationHandler *invocationHandler,
-    const CFileItemPtr& item)
-  : CAddonPythonInvoker(invocationHandler), m_item(CFileItemPtr(new CFileItem(*item.get())))
+CContextItemAddonInvoker::CContextItemAddonInvoker(ILanguageInvocationHandler* invocationHandler,
+                                                   const CFileItemPtr& item)
+  : CAddonPythonInvoker(invocationHandler), m_item(std::make_shared<CFileItem>(*item.get()))
 {
 }
 

--- a/xbmc/messaging/ApplicationMessenger.cpp
+++ b/xbmc/messaging/ApplicationMessenger.cpp
@@ -96,7 +96,7 @@ int CApplicationMessenger::SendMsg(ThreadMessage&& message, bool wait)
     // forever!
     if (m_guiThreadId != CThread::GetCurrentThreadId())
     {
-      message.waitEvent.reset(new CEvent(true));
+      message.waitEvent = std::make_shared<CEvent>(true);
       waitEvent = message.waitEvent;
       result = message.result;
     }

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -42,6 +42,8 @@
 #include "utils/log.h"
 #include "view/GUIViewState.h"
 
+#include <memory>
+
 using namespace MUSIC_INFO;
 using namespace XFILE;
 using namespace std::chrono_literals;
@@ -155,7 +157,7 @@ public:
     const auto appPlayer = components.GetComponent<CApplicationPlayer>();
     if (appPlayer->IsPlayingAudio() && g_application.CurrentFileItem().HasMusicInfoTag())
     {
-      CFileItemPtr songitem = CFileItemPtr(new CFileItem(g_application.CurrentFileItem()));
+      CFileItemPtr songitem = std::make_shared<CFileItem>(g_application.CurrentFileItem());
       if (HasSongExtraArtChanged(songitem, type, itemID, db))
         g_application.UpdateCurrentPlayArt();
     }

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -8,33 +8,24 @@
 
 #include "GUIWindowMusicBase.h"
 
-#include "GUIUserMessages.h"
-#include "PlayListPlayer.h"
-#include "ServiceBroker.h"
-#include "Util.h"
-#include "application/Application.h"
-#include "application/ApplicationComponents.h"
-#include "application/ApplicationPlayer.h"
-#include "dialogs/GUIDialogMediaSource.h"
-#include "input/actions/Action.h"
-#include "input/actions/ActionIDs.h"
-#include "music/MusicDbUrl.h"
-#include "music/MusicLibraryQueue.h"
-#include "music/MusicUtils.h"
-#include "music/dialogs/GUIDialogInfoProviderSettings.h"
-#include "music/dialogs/GUIDialogMusicInfo.h"
-#include "playlists/PlayList.h"
-#include "playlists/PlayListFactory.h"
-#ifdef HAS_CDDA_RIPPER
-#include "cdrip/CDDARipper.h"
-#endif
 #include "Autorun.h"
 #include "FileItem.h"
 #include "GUIInfoManager.h"
 #include "GUIPassword.h"
+#include "GUIUserMessages.h"
 #include "PartyModeManager.h"
+#include "PlayListPlayer.h"
+#include "ServiceBroker.h"
 #include "URL.h"
+#include "Util.h"
 #include "addons/gui/GUIDialogAddonInfo.h"
+#include "application/Application.h"
+#include "application/ApplicationComponents.h"
+#include "application/ApplicationPlayer.h"
+#ifdef HAS_CDDA_RIPPER
+#include "cdrip/CDDARipper.h"
+#endif
+#include "dialogs/GUIDialogMediaSource.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "dialogs/GUIDialogSmartPlaylistEditor.h"
 #include "dialogs/GUIDialogYesNo.h"
@@ -44,10 +35,19 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
+#include "input/actions/Action.h"
+#include "input/actions/ActionIDs.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "music/MusicDbUrl.h"
+#include "music/MusicLibraryQueue.h"
+#include "music/MusicUtils.h"
+#include "music/dialogs/GUIDialogInfoProviderSettings.h"
+#include "music/dialogs/GUIDialogMusicInfo.h"
 #include "music/infoscanner/MusicInfoScanner.h"
 #include "music/tags/MusicInfoTag.h"
+#include "playlists/PlayList.h"
+#include "playlists/PlayListFactory.h"
 #include "profiles/ProfileManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSourceSettings.h"
@@ -65,6 +65,7 @@
 #include "view/GUIViewState.h"
 
 #include <algorithm>
+#include <memory>
 
 using namespace XFILE;
 using namespace MUSICDATABASEDIRECTORY;
@@ -842,7 +843,7 @@ bool CGUIWindowMusicBase::GetDirectory(const std::string &strDirectory, CFileIte
       newPlaylist->m_bIsFolder = true;
       items.Add(newPlaylist);
 
-      newPlaylist.reset(new CFileItem("newplaylist://", false));
+      newPlaylist = std::make_shared<CFileItem>("newplaylist://", false);
       newPlaylist->SetLabel(g_localizeStrings.Get(525));
       newPlaylist->SetArt("icon", "DefaultAddSource.png");
       newPlaylist->SetLabelPreformatted(true);
@@ -850,7 +851,7 @@ bool CGUIWindowMusicBase::GetDirectory(const std::string &strDirectory, CFileIte
       newPlaylist->SetCanQueue(false);
       items.Add(newPlaylist);
 
-      newPlaylist.reset(new CFileItem("newsmartplaylist://music", false));
+      newPlaylist = std::make_shared<CFileItem>("newsmartplaylist://music", false);
       newPlaylist->SetLabel(g_localizeStrings.Get(21437));
       newPlaylist->SetArt("icon", "DefaultAddSource.png");
       newPlaylist->SetLabelPreformatted(true);

--- a/xbmc/music/windows/MusicFileItemListModifier.cpp
+++ b/xbmc/music/windows/MusicFileItemListModifier.cpp
@@ -17,6 +17,8 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 
+#include <memory>
+
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
 bool CMusicFileItemListModifier::CanModify(const CFileItemList &items) const
@@ -74,7 +76,7 @@ void CMusicFileItemListModifier::AddQueuingFolder(CFileItemList& items)
   switch (nodeChildType)
   {
   case NODE_TYPE_ARTIST:
-    pItem.reset(new CFileItem(g_localizeStrings.Get(15103)));  // "All Artists"
+    pItem = std::make_shared<CFileItem>(g_localizeStrings.Get(15103)); // "All Artists"
     musicUrl.AppendPath("-1/");
     pItem->SetPath(musicUrl.ToString());
     break;
@@ -84,14 +86,14 @@ void CMusicFileItemListModifier::AddQueuingFolder(CFileItemList& items)
   case NODE_TYPE_ALBUM_RECENTLY_PLAYED:
   case NODE_TYPE_ALBUM_RECENTLY_ADDED:
   case NODE_TYPE_ALBUM_TOP100:
-    pItem.reset(new CFileItem(g_localizeStrings.Get(15102)));  // "All Albums"
+    pItem = std::make_shared<CFileItem>(g_localizeStrings.Get(15102)); // "All Albums"
     musicUrl.AppendPath("-1/");
     pItem->SetPath(musicUrl.ToString());
     break;
 
   //  Disc node
   case NODE_TYPE_DISC:
-    pItem.reset(new CFileItem(g_localizeStrings.Get(38075)));  // "All Discs"
+    pItem = std::make_shared<CFileItem>(g_localizeStrings.Get(38075)); // "All Discs"
     musicUrl.AppendPath("-1/");
     pItem->SetPath(musicUrl.ToString());
     break;

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -32,6 +32,7 @@
 
 #include <algorithm>
 #include <array>
+#include <memory>
 #include <optional>
 #include <string_view>
 
@@ -1411,7 +1412,7 @@ std::shared_ptr<CFileItem> GetFileItem(const NPT_String& uri, const NPT_String& 
   }
   else
   {
-    item.reset(new CFileItem((const char*)uri, false));
+    item = std::make_shared<CFileItem>((const char*)uri, false);
   }
   return item;
 }

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -43,6 +43,8 @@
 #include "view/GUIViewState.h"
 #include "xbmc/interfaces/AnnouncementManager.h"
 
+#include <memory>
+
 #include <Platinum/Source/Platinum/Platinum.h>
 
 NPT_SET_LOCAL_LOGGER("xbmc.upnp.server")
@@ -601,7 +603,7 @@ CUPnPServer::OnBrowseMetadata(PLT_ActionReference&          action,
         id.TrimRight("/");
         if (id == "virtualpath://upnproot") {
             id += "/";
-            item.reset(new CFileItem((const char*)id, true));
+            item = std::make_shared<CFileItem>((const char*)id, true);
             item->SetLabel("Root");
             item->SetLabelPreformatted(true);
             object = Build(item, true, context, thumb_loader);
@@ -610,7 +612,7 @@ CUPnPServer::OnBrowseMetadata(PLT_ActionReference&          action,
             return NPT_FAILURE;
         }
     } else {
-        item.reset(new CFileItem((const char*)id, false));
+        item = std::make_shared<CFileItem>((const char*)id, false);
 
         // attempt to determine the parent of this item
         std::string parent;
@@ -713,13 +715,13 @@ CUPnPServer::OnBrowseDirectChildren(PLT_ActionReference&          action,
             CFileItemPtr item;
 
             // music library
-            item.reset(new CFileItem("musicdb://", true));
+            item = std::make_shared<CFileItem>("musicdb://", true);
             item->SetLabel("Music Library");
             item->SetLabelPreformatted(true);
             items.Add(item);
 
             // video library
-            item.reset(new CFileItem("library://video/", true));
+            item = std::make_shared<CFileItem>("library://video/", true);
             item->SetLabel("Video Library");
             item->SetLabelPreformatted(true);
             items.Add(item);

--- a/xbmc/peripherals/addons/AddonButtonMapping.cpp
+++ b/xbmc/peripherals/addons/AddonButtonMapping.cpp
@@ -14,6 +14,8 @@
 #include "peripherals/addons/AddonButtonMap.h"
 #include "utils/log.h"
 
+#include <memory>
+
 using namespace KODI;
 using namespace JOYSTICK;
 using namespace PERIPHERALS;
@@ -31,11 +33,11 @@ CAddonButtonMapping::CAddonButtonMapping(CPeripherals& manager,
   else
   {
     const std::string controllerId = mapper->ControllerID();
-    m_buttonMap.reset(new CAddonButtonMap(peripheral, addon, controllerId));
+    m_buttonMap = std::make_unique<CAddonButtonMap>(peripheral, addon, controllerId);
     if (m_buttonMap->Load())
     {
       IKeymap* keymap = peripheral->GetKeymap(controllerId);
-      m_buttonMapping.reset(new CButtonMapping(mapper, m_buttonMap.get(), keymap));
+      m_buttonMapping = std::make_unique<CButtonMapping>(mapper, m_buttonMap.get(), keymap);
 
       // Allow the mapper to save our button map
       mapper->SetButtonMapCallback(peripheral->Location(), this);

--- a/xbmc/peripherals/addons/AddonInputHandling.cpp
+++ b/xbmc/peripherals/addons/AddonInputHandling.cpp
@@ -20,6 +20,8 @@
 #include "peripherals/addons/AddonButtonMap.h"
 #include "utils/log.h"
 
+#include <memory>
+
 using namespace KODI;
 using namespace JOYSTICK;
 using namespace PERIPHERALS;
@@ -37,14 +39,14 @@ CAddonInputHandling::CAddonInputHandling(CPeripherals& manager,
   }
   else if (!handler->ControllerID().empty())
   {
-    m_buttonMap.reset(new CAddonButtonMap(peripheral, addon, handler->ControllerID()));
+    m_buttonMap = std::make_unique<CAddonButtonMap>(peripheral, addon, handler->ControllerID());
     if (m_buttonMap->Load())
     {
-      m_driverHandler.reset(new CInputHandling(handler, m_buttonMap.get()));
+      m_driverHandler = std::make_unique<CInputHandling>(handler, m_buttonMap.get());
 
       if (receiver)
       {
-        m_inputReceiver.reset(new CDriverReceiving(receiver, m_buttonMap.get()));
+        m_inputReceiver = std::make_unique<CDriverReceiving>(receiver, m_buttonMap.get());
 
         // Interfaces are connected here because they share button map as a common resource
         handler->SetInputReceiver(m_inputReceiver.get());
@@ -69,10 +71,11 @@ CAddonInputHandling::CAddonInputHandling(CPeripherals& manager,
   }
   else if (!handler->ControllerID().empty())
   {
-    m_buttonMap.reset(new CAddonButtonMap(peripheral, addon, handler->ControllerID()));
+    m_buttonMap = std::make_unique<CAddonButtonMap>(peripheral, addon, handler->ControllerID());
     if (m_buttonMap->Load())
     {
-      m_keyboardHandler.reset(new KEYBOARD::CKeyboardInputHandling(handler, m_buttonMap.get()));
+      m_keyboardHandler =
+          std::make_unique<KEYBOARD::CKeyboardInputHandling>(handler, m_buttonMap.get());
     }
     else
     {
@@ -93,10 +96,10 @@ CAddonInputHandling::CAddonInputHandling(CPeripherals& manager,
   }
   else if (!handler->ControllerID().empty())
   {
-    m_buttonMap.reset(new CAddonButtonMap(peripheral, addon, handler->ControllerID()));
+    m_buttonMap = std::make_unique<CAddonButtonMap>(peripheral, addon, handler->ControllerID());
     if (m_buttonMap->Load())
     {
-      m_mouseHandler.reset(new MOUSE::CMouseInputHandling(handler, m_buttonMap.get()));
+      m_mouseHandler = std::make_unique<MOUSE::CMouseInputHandling>(handler, m_buttonMap.get());
     }
     else
     {

--- a/xbmc/peripherals/devices/PeripheralJoystick.cpp
+++ b/xbmc/peripherals/devices/PeripheralJoystick.cpp
@@ -29,6 +29,7 @@
 #include "utils/log.h"
 
 #include <algorithm>
+#include <memory>
 #include <mutex>
 
 using namespace KODI;
@@ -105,9 +106,9 @@ bool CPeripheralJoystick::InitialiseFeature(const PeripheralFeature feature)
         }
 
         // Give joystick monitor priority over default controller
-        m_appInput.reset(
-            new CKeymapHandling(this, false, m_manager.GetInputManager().KeymapEnvironment()));
-        m_joystickMonitor.reset(new CJoystickMonitor);
+        m_appInput = std::make_unique<CKeymapHandling>(
+            this, false, m_manager.GetInputManager().KeymapEnvironment());
+        m_joystickMonitor = std::make_unique<CJoystickMonitor>();
         RegisterInputHandler(m_joystickMonitor.get(), false);
       }
     }
@@ -126,7 +127,7 @@ bool CPeripheralJoystick::InitialiseFeature(const PeripheralFeature feature)
 
 void CPeripheralJoystick::InitializeDeadzoneFiltering(IButtonMap& buttonMap)
 {
-  m_deadzoneFilter.reset(new CDeadzoneFilter(&buttonMap, this));
+  m_deadzoneFilter = std::make_unique<CDeadzoneFilter>(&buttonMap, this);
 }
 
 void CPeripheralJoystick::InitializeControllerProfile(IButtonMap& buttonMap)

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -405,7 +405,7 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
   // Create our background loader if necessary
   if (!m_pBackgroundLoader)
   {
-    m_pBackgroundLoader.reset(new CBackgroundPicLoader());
+    m_pBackgroundLoader = std::make_unique<CBackgroundPicLoader>();
     m_pBackgroundLoader->Create(this);
   }
 

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -40,6 +40,7 @@
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
 
+#include <memory>
 #include <random>
 
 using namespace XFILE;
@@ -345,7 +346,7 @@ void CGUIWindowSlideShow::Select(const std::string& strPicture)
 void CGUIWindowSlideShow::GetSlideShowContents(CFileItemList &list)
 {
   for (size_t index = 0; index < m_slides.size(); index++)
-    list.Add(CFileItemPtr(new CFileItem(*m_slides.at(index))));
+    list.Add(std::make_shared<CFileItem>(*m_slides.at(index)));
 }
 
 std::shared_ptr<const CFileItem> CGUIWindowSlideShow::GetCurrentSlide()

--- a/xbmc/platform/android/activity/JNIXBMCFile.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCFile.cpp
@@ -12,6 +12,8 @@
 #include "utils/FileUtils.h"
 #include "utils/log.h"
 
+#include <memory>
+
 #include <androidjni/jutils-details.hpp>
 
 #define BUFFSIZE 8192
@@ -53,7 +55,7 @@ jboolean CJNIXBMCFile::_open(JNIEnv *env, jobject thiz, jstring path)
     return false;
 
   CJNIXBMCFile* file = new CJNIXBMCFile();
-  file->m_file.reset(new XFILE::CFile());
+  file->m_file = std::make_unique<XFILE::CFile>();
   bool ret = file->m_file->Open(strPath);
   if (!ret)
   {

--- a/xbmc/platform/linux/input/LibInputHandler.cpp
+++ b/xbmc/platform/linux/input/LibInputHandler.cpp
@@ -17,6 +17,7 @@
 #include "utils/log.h"
 
 #include <algorithm>
+#include <memory>
 #include <string.h>
 
 #include <fcntl.h>
@@ -93,10 +94,10 @@ CLibInputHandler::CLibInputHandler() : CThread("libinput")
 
   m_liFd = libinput_get_fd(m_li);
 
-  m_keyboard.reset(new CLibInputKeyboard());
-  m_pointer.reset(new CLibInputPointer());
-  m_touch.reset(new CLibInputTouch());
-  m_settings.reset(new CLibInputSettings(this));
+  m_keyboard = std::make_unique<CLibInputKeyboard>();
+  m_pointer = std::make_unique<CLibInputPointer>();
+  m_touch = std::make_unique<CLibInputTouch>();
+  m_settings = std::make_unique<CLibInputSettings>(this);
 
   CServiceBroker::GetAnnouncementManager()->AddAnnouncer(this);
 }

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -259,7 +259,7 @@ void CPowerManager::StorePlayerState()
   if (appPlayer->IsPlaying())
   {
     m_lastUsedPlayer = appPlayer->GetCurrentPlayer();
-    m_lastPlayedFileItem.reset(new CFileItem(g_application.CurrentFileItem()));
+    m_lastPlayedFileItem = std::make_unique<CFileItem>(g_application.CurrentFileItem());
     // set the actual offset instead of store and load it from database
     m_lastPlayedFileItem->SetStartOffset(appPlayer->GetTime());
     // in case of regular stack, correct the start offset by adding current part start time

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -8,13 +8,17 @@
 
 #include "ProfileManager.h"
 
+#include "ContextMenuManager.h" //! @todo Remove me
 #include "DatabaseManager.h"
 #include "FileItem.h"
 #include "GUIInfoManager.h"
 #include "GUIPassword.h"
 #include "PasswordManager.h"
+#include "PlayListPlayer.h" //! @todo Remove me
 #include "ServiceBroker.h"
 #include "Util.h"
+#include "addons/AddonManager.h" //! @todo Remove me
+#include "addons/Service.h" //! @todo Remove me
 #include "addons/Skin.h"
 #include "application/Application.h" //! @todo Remove me
 #include "application/ApplicationComponents.h"
@@ -23,6 +27,7 @@
 #include "dialogs/GUIDialogYesNo.h"
 #include "events/EventLog.h"
 #include "events/EventLogManager.h"
+#include "favourites/FavouritesService.h" //! @todo Remove me
 #include "filesystem/Directory.h"
 #include "filesystem/DirectoryCache.h"
 #include "filesystem/File.h"
@@ -30,31 +35,20 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
-#include "input/InputManager.h"
-#include "music/MusicLibraryQueue.h"
-#include "settings/Settings.h"
-#include "settings/SettingsComponent.h"
-#include "settings/lib/SettingsManager.h"
-#include "threads/SingleLock.h"
-
-#include <algorithm>
-#include <mutex>
-#include <string>
-#include <vector>
-#if !defined(TARGET_WINDOWS) && defined(HAS_OPTICAL_DRIVE)
-#include "storage/DetectDVDType.h"
-#endif
-#include "ContextMenuManager.h" //! @todo Remove me
-#include "PlayListPlayer.h" //! @todo Remove me
-#include "addons/AddonManager.h" //! @todo Remove me
-#include "addons/Service.h" //! @todo Remove me
-#include "application/Application.h" //! @todo Remove me
-#include "favourites/FavouritesService.h" //! @todo Remove me
 #include "guilib/StereoscopicsManager.h" //! @todo Remove me
+#include "input/InputManager.h"
 #include "interfaces/json-rpc/JSONRPC.h" //! @todo Remove me
+#include "music/MusicLibraryQueue.h"
 #include "network/Network.h" //! @todo Remove me
 #include "network/NetworkServices.h" //! @todo Remove me
 #include "pvr/PVRManager.h" //! @todo Remove me
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
+#include "settings/lib/SettingsManager.h"
+#if !defined(TARGET_WINDOWS) && defined(HAS_OPTICAL_DRIVE)
+#include "storage/DetectDVDType.h"
+#endif
+#include "threads/SingleLock.h"
 #include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -63,6 +57,12 @@
 #include "utils/log.h"
 #include "video/VideoLibraryQueue.h" //! @todo Remove me
 #include "weather/WeatherManager.h" //! @todo Remove me
+
+#include <algorithm>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
 
 //! @todo
 //! eventually the profile should dictate where special://masterprofile/ is
@@ -506,7 +506,8 @@ bool CProfileManager::DeleteProfile(unsigned int index)
     m_settings->Save();
   }
 
-  CFileItemPtr item = CFileItemPtr(new CFileItem(URIUtils::AddFileToFolder(GetUserDataFolder(), strDirectory)));
+  CFileItemPtr item =
+      std::make_shared<CFileItem>(URIUtils::AddFileToFolder(GetUserDataFolder(), strDirectory));
   item->SetPath(URIUtils::AddFileToFolder(GetUserDataFolder(), strDirectory + "/"));
   item->m_bIsFolder = true;
   item->Select(true);

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -354,8 +354,8 @@ void CPVRManager::ResetProperties()
   m_channelGroups = std::make_shared<CPVRChannelGroupsContainer>();
   m_recordings = std::make_shared<CPVRRecordings>();
   m_timers = std::make_shared<CPVRTimers>();
-  m_guiInfo.reset(new CPVRGUIInfo);
-  m_parentalTimer.reset(new CStopWatch);
+  m_guiInfo = std::make_unique<CPVRGUIInfo>();
+  m_parentalTimer = std::make_unique<CStopWatch>();
   m_knownClients.clear();
 }
 

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -349,11 +349,11 @@ void CPVRManager::ResetProperties()
   std::unique_lock<CCriticalSection> lock(m_critSection);
   Clear();
 
-  m_database.reset(new CPVRDatabase);
-  m_providers.reset(new CPVRProviders);
-  m_channelGroups.reset(new CPVRChannelGroupsContainer);
-  m_recordings.reset(new CPVRRecordings);
-  m_timers.reset(new CPVRTimers);
+  m_database = std::make_shared<CPVRDatabase>();
+  m_providers = std::make_shared<CPVRProviders>();
+  m_channelGroups = std::make_shared<CPVRChannelGroupsContainer>();
+  m_recordings = std::make_shared<CPVRRecordings>();
+  m_timers = std::make_shared<CPVRTimers>();
   m_guiInfo.reset(new CPVRGUIInfo);
   m_parentalTimer.reset(new CStopWatch);
   m_knownClients.clear();

--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -31,6 +31,7 @@
 #include "utils/log.h"
 
 #include <algorithm>
+#include <memory>
 #include <mutex>
 
 using namespace PVR;
@@ -186,8 +187,8 @@ void CPVRPlaybackState::OnPlaybackStarted(const CFileItem& item)
       if (m_lastWatchedUpdateTimer)
         m_lastWatchedUpdateTimer->Stop(true);
 
-      m_lastWatchedUpdateTimer.reset(
-          new CLastWatchedUpdateTimer(*this, channel, CDateTime::GetUTCDateTime()));
+      m_lastWatchedUpdateTimer =
+          std::make_unique<CLastWatchedUpdateTimer>(*this, channel, CDateTime::GetUTCDateTime());
       m_lastWatchedUpdateTimer->Start(std::chrono::milliseconds(iLastWatchedDelay));
     }
     else

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -1532,7 +1532,7 @@ PVR_ERROR CPVRClient::OnPowerSavingDeactivated()
 std::shared_ptr<CPVRClientMenuHooks> CPVRClient::GetMenuHooks()
 {
   if (!m_menuhooks)
-    m_menuhooks.reset(new CPVRClientMenuHooks(ID()));
+    m_menuhooks = std::make_shared<CPVRClientMenuHooks>(ID());
 
   return m_menuhooks;
 }

--- a/xbmc/pvr/addons/PVRClientCapabilities.cpp
+++ b/xbmc/pvr/addons/PVRClientCapabilities.cpp
@@ -13,20 +13,21 @@
 
 #include <algorithm>
 #include <iterator>
+#include <memory>
 
 using namespace PVR;
 
 CPVRClientCapabilities::CPVRClientCapabilities(const CPVRClientCapabilities& other)
 {
   if (other.m_addonCapabilities)
-    m_addonCapabilities.reset(new PVR_ADDON_CAPABILITIES(*other.m_addonCapabilities));
+    m_addonCapabilities = std::make_unique<PVR_ADDON_CAPABILITIES>(*other.m_addonCapabilities);
   InitRecordingsLifetimeValues();
 }
 
 const CPVRClientCapabilities& CPVRClientCapabilities::operator=(const CPVRClientCapabilities& other)
 {
   if (other.m_addonCapabilities)
-    m_addonCapabilities.reset(new PVR_ADDON_CAPABILITIES(*other.m_addonCapabilities));
+    m_addonCapabilities = std::make_unique<PVR_ADDON_CAPABILITIES>(*other.m_addonCapabilities);
   InitRecordingsLifetimeValues();
   return *this;
 }
@@ -34,7 +35,7 @@ const CPVRClientCapabilities& CPVRClientCapabilities::operator=(const CPVRClient
 const CPVRClientCapabilities& CPVRClientCapabilities::operator=(
     const PVR_ADDON_CAPABILITIES& addonCapabilities)
 {
-  m_addonCapabilities.reset(new PVR_ADDON_CAPABILITIES(addonCapabilities));
+  m_addonCapabilities = std::make_unique<PVR_ADDON_CAPABILITIES>(addonCapabilities);
   InitRecordingsLifetimeValues();
   return *this;
 }

--- a/xbmc/pvr/addons/PVRClientMenuHooks.cpp
+++ b/xbmc/pvr/addons/PVRClientMenuHooks.cpp
@@ -13,6 +13,8 @@
 #include "pvr/PVRContextMenus.h"
 #include "utils/log.h"
 
+#include <memory>
+
 namespace PVR
 {
 
@@ -100,7 +102,7 @@ std::string CPVRClientMenuHook::GetLabel() const
 void CPVRClientMenuHooks::AddHook(const PVR_MENUHOOK& addonHook)
 {
   if (!m_hooks)
-    m_hooks.reset(new std::vector<CPVRClientMenuHook>());
+    m_hooks = std::make_unique<std::vector<CPVRClientMenuHook>>();
 
   const CPVRClientMenuHook hook(m_addonId, addonHook);
   m_hooks->emplace_back(hook);

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -778,8 +778,8 @@ void CGUIDialogPVRTimerSettings::AddCondition(const std::shared_ptr<CSetting>& s
 {
   GetSettingsManager()->AddDynamicCondition(identifier, condition, this);
   CSettingDependency dep(depType, GetSettingsManager());
-  dep.And()->Add(CSettingDependencyConditionPtr(
-      new CSettingDependencyCondition(identifier, "true", settingId, false, GetSettingsManager())));
+  dep.And()->Add(std::make_shared<CSettingDependencyCondition>(identifier, "true", settingId, false,
+                                                               GetSettingsManager()));
   SettingDependencies deps(setting->GetDependencies());
   deps.push_back(dep);
   setting->SetDependencies(deps);

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -572,8 +572,8 @@ std::shared_ptr<CPVREpg> CPVREpgContainer::CreateChannelEpg(int iEpgId, const st
     if (iEpgId <= 0)
       iEpgId = NextEpgId();
 
-    epg.reset(new CPVREpg(iEpgId, channelData->ChannelName(), strScraperName, channelData,
-                          GetEpgDatabase()));
+    epg = std::make_shared<CPVREpg>(iEpgId, channelData->ChannelName(), strScraperName, channelData,
+                                    GetEpgDatabase());
 
     std::unique_lock<CCriticalSection> lock(m_critSection);
     m_epgIdToEpgMap.insert({iEpgId, epg});

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -741,8 +741,8 @@ bool CPVREpgContainer::UpdateEPG(bool bOnlyPending /* = false */)
 
   std::unique_ptr<CPVRGUIProgressHandler> progressHandler;
   if (bShowProgress && !bOnlyPending && !epgsToUpdate.empty())
-    progressHandler.reset(
-        new CPVRGUIProgressHandler(g_localizeStrings.Get(19004))); // Loading programme guide
+    progressHandler = std::make_unique<CPVRGUIProgressHandler>(
+        g_localizeStrings.Get(19004)); // Loading programme guide
 
   for (const auto& epgEntry : epgsToUpdate)
   {

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -138,7 +138,7 @@ void CPVREpgInfoTag::SetChannelData(const std::shared_ptr<CPVREpgChannelData>& d
   if (data)
     m_channelData = data;
   else
-    m_channelData.reset(new CPVREpgChannelData);
+    m_channelData = std::make_shared<CPVREpgChannelData>();
 }
 
 bool CPVREpgInfoTag::operator==(const CPVREpgInfoTag& right) const

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -72,8 +72,8 @@ bool GetRootDirectory(bool bRadio, CFileItemList& results)
   const bool bAnyClientSupportingEPG = clients->AnyClientSupportingEPG();
   if (bAnyClientSupportingEPG)
   {
-    item.reset(
-        new CFileItem(StringUtils::Format("pvr://guide/{}/", bRadio ? "radio" : "tv"), true));
+    item = std::make_shared<CFileItem>(
+        StringUtils::Format("pvr://guide/{}/", bRadio ? "radio" : "tv"), true);
     item->SetLabel(g_localizeStrings.Get(19069)); // Guide
     item->SetProperty("node.target", CWindowTranslator::TranslateWindow(bRadio ? WINDOW_RADIO_GUIDE
                                                                                : WINDOW_TV_GUIDE));
@@ -82,8 +82,8 @@ bool GetRootDirectory(bool bRadio, CFileItemList& results)
   }
 
   // Channels
-  item.reset(new CFileItem(
-      bRadio ? CPVRChannelsPath::PATH_RADIO_CHANNELS : CPVRChannelsPath::PATH_TV_CHANNELS, true));
+  item = std::make_shared<CFileItem>(
+      bRadio ? CPVRChannelsPath::PATH_RADIO_CHANNELS : CPVRChannelsPath::PATH_TV_CHANNELS, true);
   item->SetLabel(g_localizeStrings.Get(19019)); // Channels
   item->SetProperty("node.target", CWindowTranslator::TranslateWindow(bRadio ? WINDOW_RADIO_CHANNELS
                                                                              : WINDOW_TV_CHANNELS));
@@ -93,9 +93,9 @@ bool GetRootDirectory(bool bRadio, CFileItemList& results)
   // Recordings
   if (clients->AnyClientSupportingRecordings())
   {
-    item.reset(new CFileItem(bRadio ? CPVRRecordingsPath::PATH_ACTIVE_RADIO_RECORDINGS
-                                    : CPVRRecordingsPath::PATH_ACTIVE_TV_RECORDINGS,
-                             true));
+    item = std::make_shared<CFileItem>(bRadio ? CPVRRecordingsPath::PATH_ACTIVE_RADIO_RECORDINGS
+                                              : CPVRRecordingsPath::PATH_ACTIVE_TV_RECORDINGS,
+                                       true);
     item->SetLabel(g_localizeStrings.Get(19017)); // Recordings
     item->SetProperty("node.target", CWindowTranslator::TranslateWindow(
                                          bRadio ? WINDOW_RADIO_RECORDINGS : WINDOW_TV_RECORDINGS));
@@ -105,16 +105,16 @@ bool GetRootDirectory(bool bRadio, CFileItemList& results)
 
   // Timers/Timer rules
   // - always present, because Reminders are always available, no client support needed for this
-  item.reset(new CFileItem(
-      bRadio ? CPVRTimersPath::PATH_RADIO_TIMERS : CPVRTimersPath::PATH_TV_TIMERS, true));
+  item = std::make_shared<CFileItem>(
+      bRadio ? CPVRTimersPath::PATH_RADIO_TIMERS : CPVRTimersPath::PATH_TV_TIMERS, true);
   item->SetLabel(g_localizeStrings.Get(19040)); // Timers
   item->SetProperty("node.target", CWindowTranslator::TranslateWindow(bRadio ? WINDOW_RADIO_TIMERS
                                                                              : WINDOW_TV_TIMERS));
   item->SetArt("icon", "DefaultPVRTimers.png");
   results.Add(item);
 
-  item.reset(new CFileItem(
-      bRadio ? CPVRTimersPath::PATH_RADIO_TIMER_RULES : CPVRTimersPath::PATH_TV_TIMER_RULES, true));
+  item = std::make_shared<CFileItem>(
+      bRadio ? CPVRTimersPath::PATH_RADIO_TIMER_RULES : CPVRTimersPath::PATH_TV_TIMER_RULES, true);
   item->SetLabel(g_localizeStrings.Get(19138)); // Timer rules
   item->SetProperty("node.target", CWindowTranslator::TranslateWindow(
                                        bRadio ? WINDOW_RADIO_TIMER_RULES : WINDOW_TV_TIMER_RULES));
@@ -124,8 +124,8 @@ bool GetRootDirectory(bool bRadio, CFileItemList& results)
   // Search
   if (bAnyClientSupportingEPG)
   {
-    item.reset(new CFileItem(
-        bRadio ? CPVREpgSearchPath::PATH_RADIO_SEARCH : CPVREpgSearchPath::PATH_TV_SEARCH, true));
+    item = std::make_shared<CFileItem>(
+        bRadio ? CPVREpgSearchPath::PATH_RADIO_SEARCH : CPVREpgSearchPath::PATH_TV_SEARCH, true);
     item->SetLabel(g_localizeStrings.Get(137)); // Search
     item->SetProperty("node.target", CWindowTranslator::TranslateWindow(bRadio ? WINDOW_RADIO_SEARCH
                                                                                : WINDOW_TV_SEARCH));
@@ -154,17 +154,17 @@ bool CPVRGUIDirectory::GetDirectory(CFileItemList& results) const
     {
       std::shared_ptr<CFileItem> item;
 
-      item.reset(new CFileItem(base + "channels/", true));
+      item = std::make_shared<CFileItem>(base + "channels/", true);
       item->SetLabel(g_localizeStrings.Get(19019)); // Channels
       item->SetLabelPreformatted(true);
       results.Add(item);
 
-      item.reset(new CFileItem(base + "recordings/active/", true));
+      item = std::make_shared<CFileItem>(base + "recordings/active/", true);
       item->SetLabel(g_localizeStrings.Get(19017)); // Recordings
       item->SetLabelPreformatted(true);
       results.Add(item);
 
-      item.reset(new CFileItem(base + "recordings/deleted/", true));
+      item = std::make_shared<CFileItem>(base + "recordings/deleted/", true);
       item->SetLabel(g_localizeStrings.Get(19184)); // Deleted recordings
       item->SetLabelPreformatted(true);
       results.Add(item);
@@ -309,7 +309,7 @@ void GetSubDirectories(const CPVRRecordingsPath& recParentPath,
     std::shared_ptr<CFileItem> item;
     if (!results.Contains(strFilePath))
     {
-      item.reset(new CFileItem(strCurrent, true));
+      item = std::make_shared<CFileItem>(strCurrent, true);
       item->SetPath(strFilePath);
       item->SetLabel(strCurrent);
       item->SetLabelPreformatted(true);
@@ -468,13 +468,13 @@ bool CPVRGUIDirectory::GetChannelsDirectory(CFileItemList& results) const
       std::shared_ptr<CFileItem> item;
 
       // all tv channels
-      item.reset(new CFileItem(CPVRChannelsPath::PATH_TV_CHANNELS, true));
+      item = std::make_shared<CFileItem>(CPVRChannelsPath::PATH_TV_CHANNELS, true);
       item->SetLabel(g_localizeStrings.Get(19020)); // TV
       item->SetLabelPreformatted(true);
       results.Add(item);
 
       // all radio channels
-      item.reset(new CFileItem(CPVRChannelsPath::PATH_RADIO_CHANNELS, true));
+      item = std::make_shared<CFileItem>(CPVRChannelsPath::PATH_RADIO_CHANNELS, true);
       item->SetLabel(g_localizeStrings.Get(19021)); // Radio
       item->SetLabelPreformatted(true);
       results.Add(item);
@@ -575,7 +575,7 @@ bool GetTimersSubDirectory(const CPVRTimersPath& path,
     if ((timer->IsRadio() == bRadio) && timer->HasParent() && (timer->ClientID() == iClientId) &&
         (timer->ParentClientIndex() == iParentId) && (!bHideDisabled || !timer->IsDisabled()))
     {
-      item.reset(new CFileItem(timer));
+      item = std::make_shared<CFileItem>(timer);
       const CPVRTimersPath timersPath(path.GetPath(), timer->ClientID(), timer->ClientIndex());
       item->SetPath(timersPath.GetPath());
       results.Add(item);

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
@@ -132,7 +132,7 @@ void CGUIEPGGridContainerModel::Initialize(const std::unique_ptr<CFileItemList>&
   const CDateTimeSpan unit(0, 0, iRulerUnit * MINSPERBLOCK, 0);
   for (; ruler < rulerEnd; ruler += unit)
   {
-    rulerItem.reset(new CFileItem(ruler.GetAsLocalizedTime("", false)));
+    rulerItem = std::make_shared<CFileItem>(ruler.GetAsLocalizedTime("", false));
     rulerItem->SetLabel2(ruler.GetAsLocalizedDate(true));
     m_rulerItems.emplace_back(rulerItem);
   }

--- a/xbmc/pvr/guilib/PVRGUIChannelIconUpdater.cpp
+++ b/xbmc/pvr/guilib/PVRGUIChannelIconUpdater.cpp
@@ -25,6 +25,7 @@
 #include "utils/log.h"
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -57,8 +58,8 @@ void CPVRGUIChannelIconUpdater::SearchAndUpdateMissingChannelIcons() const
 
   std::unique_ptr<CPVRGUIProgressHandler> progressHandler;
   if (!m_groups.empty())
-    progressHandler.reset(
-        new CPVRGUIProgressHandler(g_localizeStrings.Get(19286))); // Searching for channel icons
+    progressHandler = std::make_unique<CPVRGUIProgressHandler>(
+        g_localizeStrings.Get(19286)); // Searching for channel icons
 
   for (const auto& group : m_groups)
   {

--- a/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
+++ b/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
@@ -23,6 +23,7 @@
 #include "utils/JobManager.h"
 #include "utils/XTimeUtils.h"
 
+#include <memory>
 #include <mutex>
 
 using namespace KODI::GUILIB::GUIINFO;
@@ -316,7 +317,7 @@ void CPVRGUIChannelNavigator::HideInfo()
     {
       m_currentChannel = m_playingChannel;
       if (m_playingChannel)
-        item.reset(new CFileItem(m_playingChannel));
+        item = std::make_shared<CFileItem>(m_playingChannel);
     }
 
     CheckAndPublishPreviewAndPlayerShowInfoChangedEvent();
@@ -350,7 +351,7 @@ void CPVRGUIChannelNavigator::SetPlayingChannel(
     {
       m_currentChannel = m_playingChannel;
       if (m_playingChannel)
-        item.reset(new CFileItem(m_playingChannel));
+        item = std::make_shared<CFileItem>(m_playingChannel);
     }
 
     CheckAndPublishPreviewAndPlayerShowInfoChangedEvent();

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -329,7 +329,7 @@ CVideoDatabase& CPVRRecordings::GetVideoDatabase()
 {
   if (!m_database)
   {
-    m_database.reset(new CVideoDatabase());
+    m_database = std::make_unique<CVideoDatabase>();
     m_database->Open();
 
     if (!m_database->IsOpen())

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -829,7 +829,7 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTag::CreateFromDate(
 
   if (!newTimer)
   {
-    newTimer.reset(new CPVRTimerInfoTag);
+    newTimer = std::make_shared<CPVRTimerInfoTag>();
 
     newTimer->m_iClientIndex = PVR_TIMER_NO_CLIENT_INDEX;
     newTimer->m_iParentClientIndex = PVR_TIMER_NO_PARENT;

--- a/xbmc/pvr/timers/PVRTimerRuleMatcher.cpp
+++ b/xbmc/pvr/timers/PVRTimerRuleMatcher.cpp
@@ -14,6 +14,8 @@
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "utils/RegExp.h"
 
+#include <memory>
+
 using namespace PVR;
 
 CPVRTimerRuleMatcher::CPVRTimerRuleMatcher(const std::shared_ptr<CPVRTimerInfoTag>& timerRule,
@@ -171,7 +173,7 @@ bool CPVRTimerRuleMatcher::MatchSearchText(const std::shared_ptr<CPVREpgInfoTag>
   {
     if (!m_textSearch)
     {
-      m_textSearch.reset(new CRegExp(true /* case insensitive */));
+      m_textSearch = std::make_unique<CRegExp>(true /* case insensitive */);
       m_textSearch->RegComp(m_timerRule->EpgSearchString());
     }
     return m_textSearch->RegFind(epgTag->Title()) >= 0 ||
@@ -183,7 +185,7 @@ bool CPVRTimerRuleMatcher::MatchSearchText(const std::shared_ptr<CPVREpgInfoTag>
   {
     if (!m_textSearch)
     {
-      m_textSearch.reset(new CRegExp(true /* case insensitive */));
+      m_textSearch = std::make_unique<CRegExp>(true /* case insensitive */);
       m_textSearch->RegComp(m_timerRule->EpgSearchString());
     }
     return m_textSearch->RegFind(epgTag->Title()) >= 0;

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -264,8 +264,7 @@ bool CPVRTimers::UpdateEntries(const CPVRTimersContainer& timers,
       else
       {
         /* new timer */
-        std::shared_ptr<CPVRTimerInfoTag> newTimer =
-            std::shared_ptr<CPVRTimerInfoTag>(new CPVRTimerInfoTag);
+        std::shared_ptr<CPVRTimerInfoTag> newTimer = std::make_shared<CPVRTimerInfoTag>();
         newTimer->UpdateEntry(timersEntry);
         newTimer->SetTimerID(++m_iLastId);
         InsertEntry(newTimer);
@@ -928,7 +927,7 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::UpdateEntry(
   }
   else
   {
-    tag.reset(new CPVRTimerInfoTag());
+    tag = std::make_shared<CPVRTimerInfoTag>();
     if (tag->UpdateEntry(timer))
     {
       tag->SetTimerID(++m_iLastId);

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -246,7 +246,7 @@ void CGUIWindowPVRBase::ClearData()
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   m_channelGroup.reset();
-  m_channelGroupsSelector.reset(new CGUIPVRChannelGroupsSelector);
+  m_channelGroupsSelector = std::make_unique<CGUIPVRChannelGroupsSelector>();
 }
 
 void CGUIWindowPVRBase::OnInitWindow()

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -144,7 +144,7 @@ void CGUIWindowPVRGuideBase::OnDeinitWindow(int nextWindowID)
 void CGUIWindowPVRGuideBase::StartRefreshTimelineItemsThread()
 {
   StopRefreshTimelineItemsThread();
-  m_refreshTimelineItemsThread.reset(new CPVRRefreshTimelineItemsThread(this));
+  m_refreshTimelineItemsThread = std::make_unique<CPVRRefreshTimelineItemsThread>(this);
   m_refreshTimelineItemsThread->Create();
 }
 

--- a/xbmc/rendering/RenderSystem.cpp
+++ b/xbmc/rendering/RenderSystem.cpp
@@ -15,6 +15,8 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 
+#include <memory>
+
 CRenderSystemBase::CRenderSystemBase()
 {
   m_bRenderCreated = false;
@@ -62,8 +64,10 @@ void CRenderSystemBase::ShowSplash(const std::string& message)
 
   if (!m_splashImage)
   {
-    m_splashImage = std::unique_ptr<CGUIImage>(new CGUIImage(0, 0, 0, 0, CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth(),
-                                                       CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight(), CTextureInfo(CUtil::GetSplashPath())));
+    m_splashImage = std::make_unique<CGUIImage>(
+        0, 0, 0, 0, CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth(),
+        CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight(),
+        CTextureInfo(CUtil::GetSplashPath()));
     m_splashImage->SetAspectRatio(CAspectRatio::AR_SCALE);
   }
 
@@ -86,7 +90,7 @@ void CRenderSystemBase::ShowSplash(const std::string& message)
     {
       auto messageFont = g_fontManager.LoadTTF("__splash__", "arial.ttf", 0xFFFFFFFF, 0, 20, FONT_STYLE_NORMAL, false, 1.0f, 1.0f, &res);
       if (messageFont)
-        m_splashMessageLayout = std::unique_ptr<CGUITextLayout>(new CGUITextLayout(messageFont, true, 0));
+        m_splashMessageLayout = std::make_unique<CGUITextLayout>(messageFont, true, 0);
     }
 
     if (m_splashMessageLayout)

--- a/xbmc/rendering/gl/ScreenshotSurfaceGL.cpp
+++ b/xbmc/rendering/gl/ScreenshotSurfaceGL.cpp
@@ -14,6 +14,7 @@
 #include "utils/Screenshot.h"
 #include "windowing/GraphicContext.h"
 
+#include <memory>
 #include <mutex>
 #include <vector>
 
@@ -26,7 +27,7 @@ void CScreenshotSurfaceGL::Register()
 
 std::unique_ptr<IScreenshotSurface> CScreenshotSurfaceGL::CreateSurface()
 {
-  return std::unique_ptr<CScreenshotSurfaceGL>(new CScreenshotSurfaceGL());
+  return std::make_unique<CScreenshotSurfaceGL>();
 }
 
 bool CScreenshotSurfaceGL::Capture()

--- a/xbmc/rendering/gles/ScreenshotSurfaceGLES.cpp
+++ b/xbmc/rendering/gles/ScreenshotSurfaceGLES.cpp
@@ -14,6 +14,7 @@
 #include "utils/Screenshot.h"
 #include "windowing/GraphicContext.h"
 
+#include <memory>
 #include <mutex>
 #include <vector>
 
@@ -26,7 +27,7 @@ void CScreenshotSurfaceGLES::Register()
 
 std::unique_ptr<IScreenshotSurface> CScreenshotSurfaceGLES::CreateSurface()
 {
-  return std::unique_ptr<CScreenshotSurfaceGLES>(new CScreenshotSurfaceGLES());
+  return std::make_unique<CScreenshotSurfaceGLES>();
 }
 
 bool CScreenshotSurfaceGLES::Capture()

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
@@ -367,16 +367,29 @@ void CGUIDialogContentSettings::InitializeSettings()
       // define an enable dependency with (m_useDirectoryNames && !m_containsSingleItem) || !m_useDirectoryNames
       CSettingDependency dependencyScanRecursive(SettingDependencyType::Enable, GetSettingsManager());
       dependencyScanRecursive.Or()
-        ->Add(CSettingDependencyConditionCombinationPtr((new CSettingDependencyConditionCombination(BooleanLogicOperationAnd, GetSettingsManager()))                                     // m_useDirectoryNames && !m_containsSingleItem
-          ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_USE_DIRECTORY_NAMES, "true", SettingDependencyOperator::Equals, false, GetSettingsManager())))      // m_useDirectoryNames
-          ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_CONTAINS_SINGLE_ITEM, "false", SettingDependencyOperator::Equals, false, GetSettingsManager())))))  // !m_containsSingleItem
-        ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_USE_DIRECTORY_NAMES, "false", SettingDependencyOperator::Equals, false, GetSettingsManager())));      // !m_useDirectoryNames
+          ->Add(CSettingDependencyConditionCombinationPtr(
+              (new CSettingDependencyConditionCombination(
+                   BooleanLogicOperationAnd,
+                   GetSettingsManager())) // m_useDirectoryNames && !m_containsSingleItem
+                  ->Add(std::make_shared<CSettingDependencyCondition>(
+                      SETTING_USE_DIRECTORY_NAMES, "true", SettingDependencyOperator::Equals, false,
+                      GetSettingsManager())) // m_useDirectoryNames
+                  ->Add(std::make_shared<CSettingDependencyCondition>(
+                      SETTING_CONTAINS_SINGLE_ITEM, "false", SettingDependencyOperator::Equals,
+                      false, GetSettingsManager())))) // !m_containsSingleItem
+          ->Add(std::make_shared<CSettingDependencyCondition>(
+              SETTING_USE_DIRECTORY_NAMES, "false", SettingDependencyOperator::Equals, false,
+              GetSettingsManager())); // !m_useDirectoryNames
 
       // define an enable dependency with m_useDirectoryNames && !m_scanRecursive
       CSettingDependency dependencyContainsSingleItem(SettingDependencyType::Enable, GetSettingsManager());
       dependencyContainsSingleItem.And()
-        ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_USE_DIRECTORY_NAMES, "true", SettingDependencyOperator::Equals, false, GetSettingsManager())))        // m_useDirectoryNames
-        ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_SCAN_RECURSIVE, "false", SettingDependencyOperator::Equals, false, GetSettingsManager())));           // !m_scanRecursive
+          ->Add(std::make_shared<CSettingDependencyCondition>(
+              SETTING_USE_DIRECTORY_NAMES, "true", SettingDependencyOperator::Equals, false,
+              GetSettingsManager())) // m_useDirectoryNames
+          ->Add(std::make_shared<CSettingDependencyCondition>(
+              SETTING_SCAN_RECURSIVE, "false", SettingDependencyOperator::Equals, false,
+              GetSettingsManager())); // !m_scanRecursive
 
       SettingDependencies deps;
       deps.push_back(dependencyScanRecursive);

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
@@ -30,6 +30,7 @@
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 
+#include <memory>
 #include <set>
 #include <string>
 #include <vector>
@@ -675,8 +676,8 @@ CGUIControl* CGUIDialogSettingsBase::AddSetting(const std::shared_ptr<CSetting>&
       return NULL;
 
     static_cast<CGUIRadioButtonControl*>(pControl)->SetLabel(label);
-    pSettingControl.reset(new CGUIControlRadioButtonSetting(
-        static_cast<CGUIRadioButtonControl*>(pControl), iControlID, pSetting, this));
+    pSettingControl = std::make_shared<CGUIControlRadioButtonSetting>(
+        static_cast<CGUIRadioButtonControl*>(pControl), iControlID, pSetting, this);
   }
   else if (controlType == "spinner")
   {
@@ -686,8 +687,8 @@ CGUIControl* CGUIDialogSettingsBase::AddSetting(const std::shared_ptr<CSetting>&
       return NULL;
 
     static_cast<CGUISpinControlEx*>(pControl)->SetText(label);
-    pSettingControl.reset(new CGUIControlSpinExSetting(static_cast<CGUISpinControlEx*>(pControl),
-                                                       iControlID, pSetting, this));
+    pSettingControl = std::make_shared<CGUIControlSpinExSetting>(
+        static_cast<CGUISpinControlEx*>(pControl), iControlID, pSetting, this);
   }
   else if (controlType == "edit")
   {
@@ -697,8 +698,8 @@ CGUIControl* CGUIDialogSettingsBase::AddSetting(const std::shared_ptr<CSetting>&
       return NULL;
 
     static_cast<CGUIEditControl*>(pControl)->SetLabel(label);
-    pSettingControl.reset(new CGUIControlEditSetting(static_cast<CGUIEditControl*>(pControl),
-                                                     iControlID, pSetting, this));
+    pSettingControl = std::make_shared<CGUIControlEditSetting>(
+        static_cast<CGUIEditControl*>(pControl), iControlID, pSetting, this);
   }
   else if (controlType == "list")
   {
@@ -708,8 +709,8 @@ CGUIControl* CGUIDialogSettingsBase::AddSetting(const std::shared_ptr<CSetting>&
       return NULL;
 
     static_cast<CGUIButtonControl*>(pControl)->SetLabel(label);
-    pSettingControl.reset(new CGUIControlListSetting(static_cast<CGUIButtonControl*>(pControl),
-                                                     iControlID, pSetting, this));
+    pSettingControl = std::make_shared<CGUIControlListSetting>(
+        static_cast<CGUIButtonControl*>(pControl), iControlID, pSetting, this);
   }
   else if (controlType == "button" || controlType == "slider")
   {
@@ -722,8 +723,8 @@ CGUIControl* CGUIDialogSettingsBase::AddSetting(const std::shared_ptr<CSetting>&
         return NULL;
 
       static_cast<CGUIButtonControl*>(pControl)->SetLabel(label);
-      pSettingControl.reset(new CGUIControlButtonSetting(static_cast<CGUIButtonControl*>(pControl),
-                                                         iControlID, pSetting, this));
+      pSettingControl = std::make_shared<CGUIControlButtonSetting>(
+          static_cast<CGUIButtonControl*>(pControl), iControlID, pSetting, this);
     }
     else
     {
@@ -733,8 +734,8 @@ CGUIControl* CGUIDialogSettingsBase::AddSetting(const std::shared_ptr<CSetting>&
         return NULL;
 
       static_cast<CGUISettingsSliderControl*>(pControl)->SetText(label);
-      pSettingControl.reset(new CGUIControlSliderSetting(
-          static_cast<CGUISettingsSliderControl*>(pControl), iControlID, pSetting, this));
+      pSettingControl = std::make_shared<CGUIControlSliderSetting>(
+          static_cast<CGUISettingsSliderControl*>(pControl), iControlID, pSetting, this);
     }
   }
   else if (controlType == "range")
@@ -745,8 +746,8 @@ CGUIControl* CGUIDialogSettingsBase::AddSetting(const std::shared_ptr<CSetting>&
       return NULL;
 
     static_cast<CGUISettingsSliderControl*>(pControl)->SetText(label);
-    pSettingControl.reset(new CGUIControlRangeSetting(
-        static_cast<CGUISettingsSliderControl*>(pControl), iControlID, pSetting, this));
+    pSettingControl = std::make_shared<CGUIControlRangeSetting>(
+        static_cast<CGUISettingsSliderControl*>(pControl), iControlID, pSetting, this);
   }
   else if (controlType == "label")
   {
@@ -756,8 +757,8 @@ CGUIControl* CGUIDialogSettingsBase::AddSetting(const std::shared_ptr<CSetting>&
       return NULL;
 
     static_cast<CGUIButtonControl*>(pControl)->SetLabel(label);
-    pSettingControl.reset(new CGUIControlLabelSetting(static_cast<CGUIButtonControl*>(pControl),
-                                                      iControlID, pSetting, this));
+    pSettingControl = std::make_shared<CGUIControlLabelSetting>(
+        static_cast<CGUIButtonControl*>(pControl), iControlID, pSetting, this);
   }
   else if (controlType == "colorbutton")
   {
@@ -767,8 +768,8 @@ CGUIControl* CGUIDialogSettingsBase::AddSetting(const std::shared_ptr<CSetting>&
       return nullptr;
 
     static_cast<CGUIColorButtonControl*>(pControl)->SetLabel(label);
-    pSettingControl.reset(new CGUIControlColorButtonSetting(
-        static_cast<CGUIColorButtonControl*>(pControl), iControlID, pSetting, this));
+    pSettingControl = std::make_shared<CGUIControlColorButtonSetting>(
+        static_cast<CGUIColorButtonControl*>(pControl), iControlID, pSetting, this);
   }
   else
     return nullptr;

--- a/xbmc/threads/Event.cpp
+++ b/xbmc/threads/Event.cpp
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <memory>
 #include <mutex>
 
 using namespace std::chrono_literals;
@@ -20,7 +21,7 @@ void CEvent::addGroup(XbmcThreads::CEventGroup* group)
 {
   std::unique_lock<CCriticalSection> lock(groupListMutex);
   if (!groups)
-    groups.reset(new std::vector<XbmcThreads::CEventGroup*>);
+    groups = std::make_unique<std::vector<XbmcThreads::CEventGroup*>>();
 
   groups->push_back(group);
 }

--- a/xbmc/threads/test/TestEvent.cpp
+++ b/xbmc/threads/test/TestEvent.cpp
@@ -572,7 +572,7 @@ template <class W> void RunMassEventTest(std::vector<std::shared_ptr<W>>& m, boo
 {
   std::vector<std::shared_ptr<thread>> t(NUMTHREADS);
   for(size_t i=0; i<NUMTHREADS; i++)
-    t[i].reset(new thread(*m[i]));
+    t[i] = std::make_shared<thread>(*m[i]);
 
   EXPECT_TRUE(waitForThread(g_mutex, NUMTHREADS, 10000ms));
   if (canWaitOnEvent)
@@ -608,7 +608,7 @@ TEST(TestMassEvent, General)
 
   std::vector<std::shared_ptr<mass_waiter>> m(NUMTHREADS);
   for(size_t i=0; i<NUMTHREADS; i++)
-    m[i].reset(new mass_waiter());
+    m[i] = std::make_shared<mass_waiter>();
 
   RunMassEventTest(m,true);
   delete g_event;
@@ -620,7 +620,7 @@ TEST(TestMassEvent, Polling)
 
   std::vector<std::shared_ptr<poll_mass_waiter>> m(NUMTHREADS);
   for(size_t i=0; i<NUMTHREADS; i++)
-    m[i].reset(new poll_mass_waiter());
+    m[i] = std::make_shared<poll_mass_waiter>();
 
   RunMassEventTest(m,false);
   delete g_event;

--- a/xbmc/utils/BooleanLogic.cpp
+++ b/xbmc/utils/BooleanLogic.cpp
@@ -12,6 +12,8 @@
 #include "utils/XBMCTinyXML.h"
 #include "utils/log.h"
 
+#include <memory>
+
 bool CBooleanLogicValue::Deserialize(const TiXmlNode *node)
 {
   if (node == NULL)
@@ -112,7 +114,7 @@ bool CBooleanLogic::Deserialize(const TiXmlNode *node)
 
   if (m_operation == NULL)
   {
-    m_operation = CBooleanLogicOperationPtr(new CBooleanLogicOperation());
+    m_operation = std::make_shared<CBooleanLogicOperation>();
 
     if (m_operation == NULL)
       return false;

--- a/xbmc/utils/FileOperationJob.cpp
+++ b/xbmc/utils/FileOperationJob.cpp
@@ -22,6 +22,8 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
+#include <memory>
+
 using namespace XFILE;
 
 CFileOperationJob::CFileOperationJob()
@@ -58,7 +60,7 @@ void CFileOperationJob::SetFileOperation(FileAction action,
 
   m_items.Clear();
   for (int i = 0; i < items.Size(); i++)
-    m_items.Add(CFileItemPtr(new CFileItem(*items[i])));
+    m_items.Add(std::make_shared<CFileItem>(*items[i]));
 }
 
 bool CFileOperationJob::DoWork()

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -6225,7 +6225,7 @@ CDateTime CVideoDatabase::SetPlayCount(const CFileItem& item, int count, const C
       if (item.GetVideoInfoTag()->GetPlayCount() != count)
         data["playcount"] = count;
       CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary, "OnUpdate",
-                                                         CFileItemPtr(new CFileItem(item)), data);
+                                                         std::make_shared<CFileItem>(item), data);
     }
 
     return lastPlayed;

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -47,6 +47,7 @@
 #include "video/VideoThumbLoader.h"
 
 #include <algorithm>
+#include <memory>
 #include <utility>
 
 using namespace XFILE;
@@ -1478,7 +1479,7 @@ namespace VIDEO
 
     m_database.Close();
 
-    CFileItemPtr itemCopy = CFileItemPtr(new CFileItem(*pItem));
+    CFileItemPtr itemCopy = std::make_shared<CFileItem>(*pItem);
     CVariant data;
     data["added"] = true;
     if (m_bRunning)
@@ -2079,7 +2080,7 @@ namespace VIDEO
       const std::vector<std::string> &excludes) const
   {
     CFileItemList items;
-    items.Add(CFileItemPtr(new CFileItem(directory, true)));
+    items.Add(std::make_shared<CFileItem>(directory, true));
     CUtil::GetRecursiveDirsListing(directory, items, DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_NO_FILE_INFO);
 
     CDigest digest{CDigest::Type::MD5};

--- a/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
@@ -33,6 +33,7 @@
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -241,8 +242,11 @@ void CGUIDialogAudioSettings::InitializeSettings()
 
   CSettingDependency dependencyAudioOutputPassthroughDisabled(SettingDependencyType::Enable, GetSettingsManager());
   dependencyAudioOutputPassthroughDisabled.Or()
-    ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_AUDIO_PASSTHROUGH, "false", SettingDependencyOperator::Equals, false, GetSettingsManager())))
-    ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition("IsPlayingPassthrough", "", "", true, GetSettingsManager())));
+      ->Add(std::make_shared<CSettingDependencyCondition>(SETTING_AUDIO_PASSTHROUGH, "false",
+                                                          SettingDependencyOperator::Equals, false,
+                                                          GetSettingsManager()))
+      ->Add(std::make_shared<CSettingDependencyCondition>("IsPlayingPassthrough", "", "", true,
+                                                          GetSettingsManager()));
   SettingDependencies depsAudioOutputPassthroughDisabled;
   depsAudioOutputPassthroughDisabled.push_back(dependencyAudioOutputPassthroughDisabled);
 

--- a/xbmc/video/dialogs/GUIDialogCMSSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogCMSSettings.cpp
@@ -27,6 +27,7 @@
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
 
+#include <memory>
 #include <vector>
 
 #define SETTING_VIDEO_CMSENABLE           "videoscreen.cmsenabled"
@@ -79,31 +80,35 @@ void CGUIDialogCMSSettings::InitializeSettings()
 
   // create "depsCmsEnabled" for settings depending on CMS being enabled
   CSettingDependency dependencyCmsEnabled(SettingDependencyType::Enable, GetSettingsManager());
-  dependencyCmsEnabled.Or()
-    ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_VIDEO_CMSENABLE, "true", SettingDependencyOperator::Equals, false, GetSettingsManager())));
+  dependencyCmsEnabled.Or()->Add(std::make_shared<CSettingDependencyCondition>(
+      SETTING_VIDEO_CMSENABLE, "true", SettingDependencyOperator::Equals, false,
+      GetSettingsManager()));
   SettingDependencies depsCmsEnabled;
   depsCmsEnabled.push_back(dependencyCmsEnabled);
 
   // create "depsCms3dlut" for 3dlut settings
   CSettingDependency dependencyCms3dlut(SettingDependencyType::Visible, GetSettingsManager());
-  dependencyCms3dlut.And()
-    ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_VIDEO_CMSMODE, std::to_string(CMS_MODE_3DLUT), SettingDependencyOperator::Equals, false, GetSettingsManager())));
+  dependencyCms3dlut.And()->Add(std::make_shared<CSettingDependencyCondition>(
+      SETTING_VIDEO_CMSMODE, std::to_string(CMS_MODE_3DLUT), SettingDependencyOperator::Equals,
+      false, GetSettingsManager()));
   SettingDependencies depsCms3dlut;
   depsCms3dlut.push_back(dependencyCmsEnabled);
   depsCms3dlut.push_back(dependencyCms3dlut);
 
   // create "depsCmsIcc" for display settings with icc profile
   CSettingDependency dependencyCmsIcc(SettingDependencyType::Visible, GetSettingsManager());
-  dependencyCmsIcc.And()
-    ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_VIDEO_CMSMODE, std::to_string(CMS_MODE_PROFILE), SettingDependencyOperator::Equals, false, GetSettingsManager())));
+  dependencyCmsIcc.And()->Add(std::make_shared<CSettingDependencyCondition>(
+      SETTING_VIDEO_CMSMODE, std::to_string(CMS_MODE_PROFILE), SettingDependencyOperator::Equals,
+      false, GetSettingsManager()));
   SettingDependencies depsCmsIcc;
   depsCmsIcc.push_back(dependencyCmsEnabled);
   depsCmsIcc.push_back(dependencyCmsIcc);
 
   // create "depsCmsGamma" for effective gamma adjustment (not available with bt.1886)
   CSettingDependency dependencyCmsGamma(SettingDependencyType::Visible, GetSettingsManager());
-  dependencyCmsGamma.And()
-    ->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_VIDEO_CMSGAMMAMODE, std::to_string(CMS_TRC_BT1886), SettingDependencyOperator::Equals, true, GetSettingsManager())));
+  dependencyCmsGamma.And()->Add(std::make_shared<CSettingDependencyCondition>(
+      SETTING_VIDEO_CMSGAMMAMODE, std::to_string(CMS_TRC_BT1886), SettingDependencyOperator::Equals,
+      true, GetSettingsManager()));
   SettingDependencies depsCmsGamma;
   depsCmsGamma.push_back(dependencyCmsEnabled);
   depsCmsGamma.push_back(dependencyCmsIcc);

--- a/xbmc/video/jobs/VideoLibraryMarkWatchedJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryMarkWatchedJob.cpp
@@ -6,22 +6,24 @@
  *  See LICENSES/README.md for more information.
  */
 
-#include <vector>
-
 #include "VideoLibraryMarkWatchedJob.h"
+
 #include "FileItem.h"
+#include "ServiceBroker.h"
 #include "Util.h"
 #include "filesystem/Directory.h"
 #ifdef HAS_UPNP
 #include "network/upnp/UPnP.h"
 #endif
+#include "profiles/ProfileManager.h"
 #include "pvr/PVRManager.h"
 #include "pvr/recordings/PVRRecordings.h"
-#include "profiles/ProfileManager.h"
 #include "settings/SettingsComponent.h"
-#include "ServiceBroker.h"
 #include "utils/URIUtils.h"
 #include "video/VideoDatabase.h"
+
+#include <memory>
+#include <vector>
 
 CVideoLibraryMarkWatchedJob::CVideoLibraryMarkWatchedJob(const std::shared_ptr<CFileItem>& item,
                                                          bool mark)
@@ -50,7 +52,7 @@ bool CVideoLibraryMarkWatchedJob::Work(CVideoDatabase &db)
     return false;
 
   CFileItemList items;
-  items.Add(CFileItemPtr(new CFileItem(*m_item)));
+  items.Add(std::make_shared<CFileItem>(*m_item));
 
   if (m_item->m_bIsFolder)
     CUtil::GetRecursiveListing(m_item->GetPath(), items, "", XFILE::DIR_FLAG_NO_FILE_INFO);

--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
@@ -32,6 +32,7 @@
 #include "video/tags/VideoInfoTagLoaderFactory.h"
 #include "video/tags/VideoTagLoaderPlugin.h"
 
+#include <memory>
 #include <utility>
 
 using namespace KODI::MESSAGING;
@@ -281,13 +282,13 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
       }
       // otherwise just add a copy of the item
       else
-        items.Add(CFileItemPtr(new CFileItem(*m_item->GetVideoInfoTag())));
+        items.Add(std::make_shared<CFileItem>(*m_item->GetVideoInfoTag()));
 
       // update the path to the real path (instead of a videodb:// one)
       path = m_item->GetVideoInfoTag()->m_strPath;
     }
     else
-      items.Add(CFileItemPtr(new CFileItem(*m_item)));
+      items.Add(std::make_shared<CFileItem>(*m_item));
 
     // set the proper path of the list of items to lookup
     items.SetPath(m_item->m_bIsFolder ? URIUtils::GetParentPath(path) : URIUtils::GetDirectory(path));

--- a/xbmc/video/tags/VideoTagLoaderPlugin.cpp
+++ b/xbmc/video/tags/VideoTagLoaderPlugin.cpp
@@ -12,6 +12,8 @@
 #include "URL.h"
 #include "filesystem/PluginDirectory.h"
 
+#include <memory>
+
 using namespace XFILE;
 
 CVideoTagLoaderPlugin::CVideoTagLoaderPlugin(const CFileItem& item, bool forceRefresh)
@@ -21,10 +23,10 @@ CVideoTagLoaderPlugin::CVideoTagLoaderPlugin(const CFileItem& item, bool forceRe
     return;
   // Preserve CFileItem video info and art to avoid info loss between creating VideoInfoTagLoaderFactory and calling Load()
   if (m_item.HasVideoInfoTag())
-    m_tag.reset(new CVideoInfoTag(*m_item.GetVideoInfoTag()));
+    m_tag = std::make_unique<CVideoInfoTag>(*m_item.GetVideoInfoTag());
   auto& art = item.GetArt();
   if (!art.empty())
-    m_art.reset(new CGUIListItem::ArtMap(art));
+    m_art = std::make_unique<CGUIListItem::ArtMap>(art);
 }
 
 bool CVideoTagLoaderPlugin::HasInfo() const
@@ -48,7 +50,7 @@ CInfoScanner::INFO_TYPE CVideoTagLoaderPlugin::Load(CVideoInfoTag& tag, bool, st
     if (!items.IsEmpty())
     {
       const CFileItemPtr &item = items[0];
-      m_art.reset(new CGUIListItem::ArtMap(item->GetArt()));
+      m_art = std::make_unique<CGUIListItem::ArtMap>(item->GetArt());
       if (item->HasVideoInfoTag())
       {
         tag = *item->GetVideoInfoTag();

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -59,6 +59,8 @@
 #include "video/guilib/VideoSelectActionProcessor.h"
 #include "view/GUIViewState.h"
 
+#include <memory>
+
 using namespace XFILE;
 using namespace VIDEODATABASEDIRECTORY;
 using namespace VIDEO;
@@ -1137,7 +1139,7 @@ bool CGUIWindowVideoBase::GetDirectory(const std::string &strDirectory, CFileIte
     newPlaylist->SetLabelPreformatted(true);
     items.Add(newPlaylist);
 */
-    newPlaylist.reset(new CFileItem("newsmartplaylist://video", false));
+    newPlaylist = std::make_shared<CFileItem>("newsmartplaylist://video", false);
     newPlaylist->SetLabel(g_localizeStrings.Get(21437));  // "new smart playlist..."
     newPlaylist->SetArt("icon", "DefaultAddSource.png");
     newPlaylist->SetLabelPreformatted(true);

--- a/xbmc/video/windows/VideoFileItemListModifier.cpp
+++ b/xbmc/video/windows/VideoFileItemListModifier.cpp
@@ -18,6 +18,8 @@
 #include "video/VideoDatabase.h"
 #include "video/VideoDbUrl.h"
 
+#include <memory>
+
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 
 bool CVideoFileItemListModifier::CanModify(const CFileItemList &items) const
@@ -65,7 +67,7 @@ void CVideoFileItemListModifier::AddQueuingFolder(CFileItemList& items)
   case NODE_TYPE_SEASONS:
   {
     const std::string& strLabel = g_localizeStrings.Get(20366);
-    pItem.reset(new CFileItem(strLabel));  // "All Seasons"
+    pItem = std::make_shared<CFileItem>(strLabel); // "All Seasons"
     videoUrl.AppendPath("-1/");
     pItem->SetPath(videoUrl.ToString());
     // set the number of watched and unwatched items accordingly
@@ -120,7 +122,7 @@ void CVideoFileItemListModifier::AddQueuingFolder(CFileItemList& items)
   }
   break;
   case NODE_TYPE_MUSICVIDEOS_ALBUM:
-    pItem.reset(new CFileItem("* " + g_localizeStrings.Get(16100)));  // "* All Videos"
+    pItem = std::make_shared<CFileItem>("* " + g_localizeStrings.Get(16100)); // "* All Videos"
     videoUrl.AppendPath("-1/");
     pItem->SetPath(videoUrl.ToString());
     break;

--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -10,6 +10,9 @@
 
 #include "ServiceBroker.h"
 #include "guilib/DispResource.h"
+#if HAS_GLES
+#include "guilib/GUIFontTTFGL.h"
+#endif
 #include "powermanagement/DPMSSupport.h"
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
@@ -18,13 +21,14 @@
 #include "utils/StringUtils.h"
 #include "windowing/GraphicContext.h"
 
+#include <memory>
 #include <mutex>
 
 const char* CWinSystemBase::SETTING_WINSYSTEM_IS_HDR_DISPLAY = "winsystem.ishdrdisplay";
 
 CWinSystemBase::CWinSystemBase()
 {
-  m_gfxContext.reset(new CGraphicContext());
+  m_gfxContext = std::make_unique<CGraphicContext>();
 }
 
 CWinSystemBase::~CWinSystemBase() = default;
@@ -255,7 +259,8 @@ KODI::WINDOWING::COSScreenSaverManager* CWinSystemBase::GetOSScreenSaver()
     auto impl = GetOSScreenSaverImpl();
     if (impl)
     {
-      m_screenSaverManager.reset(new KODI::WINDOWING::COSScreenSaverManager(std::move(impl)));
+      m_screenSaverManager =
+          std::make_unique<KODI::WINDOWING::COSScreenSaverManager>(std::move(impl));
     }
   }
 

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -26,6 +26,7 @@
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
 
+#include <memory>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -496,7 +497,7 @@ std::unique_ptr<KODI::WINDOWING::IOSScreenSaver> CWinSystemX11::GetOSScreenSaver
   std::unique_ptr<IOSScreenSaver> ret;
   if (m_dpy)
   {
-    ret.reset(new COSScreenSaverX11(m_dpy));
+    ret = std::make_unique<COSScreenSaverX11>(m_dpy);
   }
   return ret;
 }

--- a/xbmc/windowing/X11/WinSystemX11GLContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
@@ -26,6 +26,7 @@
 #include "windowing/GraphicContext.h"
 #include "windowing/WindowSystemFactory.h"
 
+#include <memory>
 #include <mutex>
 #include <vector>
 
@@ -320,7 +321,7 @@ std::unique_ptr<CVideoSync> CWinSystemX11GLContext::GetVideoSync(CVideoReference
 
   if (dynamic_cast<CGLContextEGL*>(m_pGLContext))
   {
-    pVSync.reset(new CVideoSyncOML(clock, *this));
+    pVSync = std::make_unique<CVideoSyncOML>(clock, *this);
   }
   else
   {

--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -24,7 +24,6 @@
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "system_egl.h"
 #include "utils/HDRCapabilities.h"
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
@@ -35,8 +34,11 @@
 #include "platform/android/media/drm/MediaDrmCryptoSession.h"
 
 #include <float.h>
+#include <memory>
 #include <mutex>
 #include <string.h>
+
+#include "system_egl.h"
 
 #include <EGL/eglplatform.h>
 
@@ -54,7 +56,7 @@ CWinSystemAndroid::CWinSystemAndroid()
 
   m_android = nullptr;
 
-  m_winEvents.reset(new CWinEventsAndroid());
+  m_winEvents = std::make_unique<CWinEventsAndroid>();
 }
 
 CWinSystemAndroid::~CWinSystemAndroid()

--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
@@ -17,10 +17,13 @@
 
 #include "platform/android/activity/XBMCApp.h"
 
-#include <EGL/eglext.h>
+#include <memory>
+
 #include <unistd.h>
 
 #include "PlatformDefs.h"
+
+#include <EGL/eglext.h>
 
 void CWinSystemAndroidGLESContext::Register()
 {
@@ -254,7 +257,10 @@ bool CWinSystemAndroidGLESContext::SetHDR(const VideoPicture* videoPicture)
       CLog::Log(LOGDEBUG, "CWinSystemAndroidGLESContext::SetHDR: ColorSpace: {}", HDRColorSpace);
 
       m_HDRColorSpace = HDRColorSpace;
-      m_displayMetadata = m_HDRColorSpace == EGL_NONE ? nullptr : std::unique_ptr<AVMasteringDisplayMetadata>(new AVMasteringDisplayMetadata(videoPicture->displayMetadata));
+      m_displayMetadata =
+          m_HDRColorSpace == EGL_NONE
+              ? nullptr
+              : std::make_unique<AVMasteringDisplayMetadata>(videoPicture->displayMetadata);
       // TODO: discuss with NVIDIA why this prevent turning HDR display off
       //m_lightMetadata = !videoPicture || m_HDRColorSpace == EGL_NONE ? nullptr : std::unique_ptr<AVContentLightMetadata>(new AVContentLightMetadata(videoPicture->lightMetadata));
       m_pGLContext.DestroySurface();

--- a/xbmc/windowing/ios/WinSystemIOS.mm
+++ b/xbmc/windowing/ios/WinSystemIOS.mm
@@ -36,6 +36,7 @@
 #import "platform/darwin/ios/IOSScreenManager.h"
 #import "platform/darwin/ios/XBMCController.h"
 
+#include <memory>
 #include <mutex>
 #include <vector>
 
@@ -102,7 +103,7 @@ CWinSystemIOS::CWinSystemIOS() : CWinSystemBase()
   m_bIsBackgrounded = false;
   m_pDisplayLink = new CADisplayLinkWrapper;
   m_pDisplayLink->callbackClass = [[IOSDisplayLinkCallback alloc] init];
-  m_winEvents.reset(new CWinEventsIOS());
+  m_winEvents = std::make_unique<CWinEventsIOS>();
 
   CAESinkDARWINIOS::Register();
 }

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -40,6 +40,7 @@
 
 #include <array>
 #include <chrono>
+#include <memory>
 #include <mutex>
 
 #import <IOKit/graphics/IOGraphicsLib.h>
@@ -583,7 +584,7 @@ CWinSystemOSX::CWinSystemOSX() : CWinSystemBase(), m_lostDeviceTimer(this)
   m_refreshRate = 0.0;
   m_delayDispReset = false;
 
-  m_winEvents.reset(new CWinEventsOSX());
+  m_winEvents = std::make_unique<CWinEventsOSX>();
 
   AE::CAESinkFactory::ClearSinks();
   CAESinkDARWINOSX::Register();

--- a/xbmc/windowing/tvos/WinSystemTVOS.mm
+++ b/xbmc/windowing/tvos/WinSystemTVOS.mm
@@ -140,7 +140,7 @@ CWinSystemTVOS::CWinSystemTVOS() : CWinSystemBase(), m_lostDeviceTimer(this)
   m_pDisplayLink = new CADisplayLinkWrapper;
   m_pDisplayLink->callbackClass = [[TVOSDisplayLinkCallback alloc] init];
 
-  m_winEvents.reset(new CWinEventsTVOS());
+  m_winEvents = std::make_unique<CWinEventsTVOS>();
 
   CAESinkDARWINTVOS::Register();
 }

--- a/xbmc/windowing/wayland/InputProcessorKeyboard.cpp
+++ b/xbmc/windowing/wayland/InputProcessorKeyboard.cpp
@@ -12,6 +12,7 @@
 
 #include <cassert>
 #include <limits>
+#include <memory>
 
 using namespace KODI::WINDOWING::WAYLAND;
 
@@ -44,7 +45,7 @@ void CInputProcessorKeyboard::OnKeyboardKeymap(CSeat* seat, wayland::keyboard_ke
     if (!m_xkbContext)
     {
       // Lazily initialize XkbcommonContext
-      m_xkbContext.reset(new CXkbcommonContext);
+      m_xkbContext = std::make_unique<CXkbcommonContext>();
     }
 
     m_keymap = m_xkbContext->KeymapFromString(keymap);

--- a/xbmc/windowing/wayland/SeatInputProcessing.cpp
+++ b/xbmc/windowing/wayland/SeatInputProcessing.cpp
@@ -9,6 +9,7 @@
 #include "SeatInputProcessing.h"
 
 #include <cassert>
+#include <memory>
 
 using namespace KODI::WINDOWING::WAYLAND;
 
@@ -22,11 +23,11 @@ void CSeatInputProcessing::AddSeat(CSeat* seat)
   assert(m_seats.find(seat->GetGlobalName()) == m_seats.end());
   auto& seatState = m_seats.emplace(seat->GetGlobalName(), seat).first->second;
 
-  seatState.keyboardProcessor.reset(new CInputProcessorKeyboard(*this));
+  seatState.keyboardProcessor = std::make_unique<CInputProcessorKeyboard>(*this);
   seat->AddRawInputHandlerKeyboard(seatState.keyboardProcessor.get());
-  seatState.pointerProcessor.reset(new CInputProcessorPointer(m_inputSurface, *this));
+  seatState.pointerProcessor = std::make_unique<CInputProcessorPointer>(m_inputSurface, *this);
   seat->AddRawInputHandlerPointer(seatState.pointerProcessor.get());
-  seatState.touchProcessor.reset(new CInputProcessorTouch(m_inputSurface));
+  seatState.touchProcessor = std::make_unique<CInputProcessorTouch>(m_inputSurface);
   seat->AddRawInputHandlerTouch(seatState.touchProcessor.get());
 }
 

--- a/xbmc/windowing/wayland/SeatInputProcessing.h
+++ b/xbmc/windowing/wayland/SeatInputProcessing.h
@@ -79,7 +79,7 @@ public:
  * Multi-seat support is not currently implemented completely, but each seat has
  * separate state.
  */
-class CSeatInputProcessing final : IInputHandlerPointer, IInputHandlerKeyboard
+class CSeatInputProcessing final : public IInputHandlerPointer, public IInputHandlerKeyboard
 {
 public:
   /**

--- a/xbmc/windowing/wayland/WinEventsWayland.cpp
+++ b/xbmc/windowing/wayland/WinEventsWayland.cpp
@@ -216,7 +216,7 @@ void CWinEventsWayland::SetDisplay(wayland::display_t* display)
   if (display && !g_WlMessagePump)
   {
     // Start message processing as soon as we have a display
-    g_WlMessagePump.reset(new CWinEventsWaylandThread(*display));
+    g_WlMessagePump = std::make_unique<CWinEventsWaylandThread>(*display);
   }
   else if (g_WlMessagePump)
   {

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -47,12 +47,9 @@
 
 #include <algorithm>
 #include <limits>
+#include <memory>
 #include <mutex>
 #include <numeric>
-
-#if defined(HAS_DBUS)
-# include "windowing/linux/OSScreenSaverFreedesktop.h"
-#endif
 
 using namespace KODI::WINDOWING;
 using namespace KODI::WINDOWING::WAYLAND;
@@ -139,7 +136,7 @@ struct MsgBufferScale
 CWinSystemWayland::CWinSystemWayland()
 : CWinSystemBase{}, m_protocol{"WinSystemWaylandInternal"}
 {
-  m_winEvents.reset(new CWinEventsWayland());
+  m_winEvents = std::make_unique<CWinEventsWayland>();
 }
 
 CWinSystemWayland::~CWinSystemWayland() noexcept
@@ -167,7 +164,7 @@ bool CWinSystemWayland::InitWindowSystem()
   VIDEOPLAYER::CProcessInfoWayland::Register();
   RETRO::CRPProcessInfoWayland::Register();
 
-  m_registry.reset(new CRegistry{*m_connection});
+  m_registry = std::make_unique<CRegistry>(*m_connection);
 
   m_registry->RequestSingleton(m_compositor, 1, 4);
   m_registry->RequestSingleton(m_shm, 1, 1);
@@ -279,10 +276,10 @@ bool CWinSystemWayland::CreateNewWindow(const std::string& name,
     }
   };
 
-  m_windowDecorator.reset(new CWindowDecorator(*this, *m_connection, m_surface));
+  m_windowDecorator = std::make_unique<CWindowDecorator>(*this, *m_connection, m_surface);
 
-  m_seatInputProcessing.reset(new CSeatInputProcessing(m_surface, *this));
-  m_seatRegistry.reset(new CRegistry{*m_connection});
+  m_seatInputProcessing = std::make_unique<CSeatInputProcessing>(m_surface, *this);
+  m_seatRegistry = std::make_unique<CRegistry>(*m_connection);
   // version 2 adds name event -> optional
   // version 4 adds wl_keyboard repeat_info -> optional
   // version 5 adds discrete axis events in wl_pointer -> unused

--- a/xbmc/windowing/wayland/WinSystemWayland.h
+++ b/xbmc/windowing/wayland/WinSystemWayland.h
@@ -45,8 +45,8 @@ class CRegistry;
 class CWindowDecorator;
 
 class CWinSystemWayland : public CWinSystemBase,
-                          IInputHandler,
-                          IWindowDecorationHandler,
+                          public IInputHandler,
+                          public IWindowDecorationHandler,
                           public IShellSurfaceHandler
 {
 public:

--- a/xbmc/windowing/wayland/WindowDecorator.cpp
+++ b/xbmc/windowing/wayland/WindowDecorator.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <memory>
 #include <mutex>
 #include <vector>
 
@@ -885,7 +886,7 @@ void CWindowDecorator::ResetShm()
 {
   if (IsDecorationActive())
   {
-    m_memory.reset(new CSharedMemory(MemoryBytesForSize(m_mainSurfaceSize, m_scale)));
+    m_memory = std::make_unique<CSharedMemory>(MemoryBytesForSize(m_mainSurfaceSize, m_scale));
     m_memoryAllocatedSize = 0;
     m_shmPool = m_shm.create_pool(m_memory->Fd(), m_memory->Size());
   }

--- a/xbmc/windowing/wayland/XkbcommonKeymap.cpp
+++ b/xbmc/windowing/wayland/XkbcommonKeymap.cpp
@@ -12,6 +12,7 @@
 #include "utils/log.h"
 
 #include <iostream>
+#include <memory>
 #include <sstream>
 #include <stdexcept>
 #include <vector>
@@ -220,7 +221,7 @@ std::unique_ptr<CXkbcommonKeymap> CXkbcommonContext::KeymapFromString(std::strin
     throw std::runtime_error("Failed to compile keymap");
   }
 
-  return std::unique_ptr<CXkbcommonKeymap>{new CXkbcommonKeymap(std::move(xkbKeymap))};
+  return std::make_unique<CXkbcommonKeymap>(std::move(xkbKeymap));
 }
 
 std::unique_ptr<CXkbcommonKeymap> CXkbcommonContext::KeymapFromNames(const std::string& rules, const std::string& model, const std::string& layout, const std::string& variant, const std::string& options)
@@ -240,7 +241,7 @@ std::unique_ptr<CXkbcommonKeymap> CXkbcommonContext::KeymapFromNames(const std::
     throw std::runtime_error("Failed to compile keymap");
   }
 
-  return std::unique_ptr<CXkbcommonKeymap>{new CXkbcommonKeymap(std::move(keymap))};
+  return std::make_unique<CXkbcommonKeymap>(std::move(keymap));
 }
 
 std::unique_ptr<xkb_state, CXkbcommonKeymap::XkbStateDeleter> CXkbcommonKeymap::CreateXkbStateFromKeymap(xkb_keymap* keymap)

--- a/xbmc/windows/GUIWindowSplash.cpp
+++ b/xbmc/windows/GUIWindowSplash.cpp
@@ -14,6 +14,8 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 
+#include <memory>
+
 CGUIWindowSplash::CGUIWindowSplash(void) : CGUIWindow(WINDOW_SPLASH, ""), m_image(nullptr)
 {
   m_loadType = LOAD_ON_GUI_INIT;
@@ -26,7 +28,10 @@ void CGUIWindowSplash::OnInitWindow()
   if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_splashImage)
     return;
 
-  m_image = std::unique_ptr<CGUIImage>(new CGUIImage(0, 0, 0, 0, CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth(), CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight(), CTextureInfo(CUtil::GetSplashPath())));
+  m_image = std::make_unique<CGUIImage>(0, 0, 0, 0,
+                                        CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth(),
+                                        CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight(),
+                                        CTextureInfo(CUtil::GetSplashPath()));
   m_image->SetAspectRatio(CAspectRatio::AR_SCALE);
 }
 


### PR DESCRIPTION
## Description
apply and enable `modernize-make-shared` and `modernize-make-unique clang-tidy` checks

## Motivation and context
revised alternative of #23757

## How has this been tested?
run clang-tidy and compiled for Android (aarch64), iOS, Linux (gl and gles), macOS and tvOS

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
