### PR TITLE
[video] Fix play/resume of DB and DVD disc images not working from Homescreen widgets

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -3738,7 +3738,10 @@ bool CFileItem::LoadDetails()
     }
 
     if (ret)
+    {
       m_videoInfoTag = tag.release();
+      m_strDynPath = m_videoInfoTag->m_strFileNameAndPath;
+    }
 
     return ret;
   }
@@ -3784,6 +3787,7 @@ bool CFileItem::LoadDetails()
     if (db.LoadVideoInfo(GetDynPath(), *tag))
     {
       m_videoInfoTag = tag.release();
+      m_strDynPath = m_videoInfoTag->m_strFileNameAndPath;
       return true;
     }
 

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -608,13 +608,6 @@ int PlayOrQueueMedia(const std::vector<std::string>& params, bool forcePlay)
 
   if (forcePlay)
   {
-    if (item.HasVideoInfoTag() && item.GetStartOffset() == STARTOFFSET_RESUME)
-    {
-      const CBookmark bookmark = item.GetVideoInfoTag()->GetResumePoint();
-      if (bookmark.IsSet())
-        item.SetStartOffset(CUtil::ConvertSecsToMilliSecs(bookmark.timeInSeconds));
-    }
-
     if ((item.IsAudio() || item.IsVideo()) && !item.IsSmartPlayList())
     {
       if (!item.HasProperty("playlist_type_hint"))


### PR DESCRIPTION
Fixes play/resume of DB and DVD disc images not working from Homescreen widgets. Tries always ended with an error message. 

Reported by and fix runtime-tested by @enen92 (I also runtime-tested).

@enen92 please check the code change. We discussed the change already internally.