### PR TITLE
[webOS] Acb: Install empty dummy library

### DIFF
--- a/cmake/modules/FindAcbAPI.cmake
+++ b/cmake/modules/FindAcbAPI.cmake
@@ -33,5 +33,10 @@ if(NOT TARGET ACBAPI::ACBAPI)
                                                  IMPORTED_LOCATION "${ACBAPI_LIBRARY}"
                                                  INTERFACE_INCLUDE_DIRECTORIES "${ACBAPI_INCLUDE_DIR}")
     set_property(GLOBAL APPEND PROPERTY INTERNAL_DEPS_PROP ACBAPI::ACBAPI)
+
+    # creates an empty library to install on webOS 5+ devices
+    file(TOUCH dummy.c)
+    add_library(AcbAPI SHARED dummy.c)
+    set_target_properties(AcbAPI PROPERTIES VERSION 1.0.0 SOVERSION 1)
   endif()
 endif()

--- a/cmake/scripts/webos/Install.cmake
+++ b/cmake/scripts/webos/Install.cmake
@@ -30,7 +30,7 @@ set(APP_INSTALL_DIRS ${CMAKE_BINARY_DIR}/addons
                      ${CMAKE_BINARY_DIR}/userdata)
 set(APP_TOOLCHAIN_FILES ${TOOLCHAIN}/${HOST}/sysroot/lib/libatomic.so.1
                         ${TOOLCHAIN}/${HOST}/sysroot/lib/libcrypt.so.1
-                        ${DEPENDS_PATH}/lib/libAcbAPI.so.1)
+                        ${CMAKE_BINARY_DIR}/libAcbAPI.so.1)
 set(BIN_ADDONS_DIR ${DEPENDS_PATH}/addons)
 
 file(WRITE ${CMAKE_BINARY_DIR}/install.cmake "
@@ -54,7 +54,7 @@ file(WRITE ${CMAKE_BINARY_DIR}/install.cmake "
 
 # Copy files to the location expected by the webOS packaging scripts.
 add_custom_target(bundle
-  DEPENDS ${APP_NAME_LC} ${CMAKE_BINARY_DIR}/missing_libs.txt
+  DEPENDS ${APP_NAME_LC} ${CMAKE_BINARY_DIR}/missing_libs.txt AcbAPI
   COMMAND ${CMAKE_COMMAND} -P ${CMAKE_BINARY_DIR}/install.cmake
 )
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
For compability reasons we need to ship the `libAcbAPI` library for webOS 5+ devices. These used to be shipped from webos-userland. These libraries are merely used as a linking target and contain no code at all. They are generated using some linker script tricks. For some strange reason having these libraries present on webOS 5+ results in AV1 files not playing as reported in #23897. Functions from `libAcbAPI` are never called on webOS 5+. It is possible that the linker script tricks end up with a corrupted library but the exact reason for why the library segfaults for AV1 files is unknown. As a workaround compile a empty library and install that instead.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #23897

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
webOS 7/22

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
