### PR TITLE
[windows] CGUIMediaWindow::OnContextButton: Fix 'Browse into' …

### DIFF
--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1837,7 +1837,7 @@ bool CGUIMediaWindow::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
   case CONTEXT_BUTTON_BROWSE_INTO:
     {
       CFileItemPtr item = m_vecItems->Get(itemNumber);
-      Update(item->GetPath());
+      Update(item->GetDynPath());
       return true;
     }
   default:


### PR DESCRIPTION
…(e.g. for BD and DVD disc images).

Another path vs. dynpath bug. Must have been there for "ages".

Fixes "Browse into" context menu item, which is available for example for disc images in Movies window. This item is supposed to browse into the file system structure (here UDF) of the disc image.

![screenshot00003](https://github.com/xbmc/xbmc/assets/3226626/45a15c62-edd6-4be2-8e01-de62bb371345)
![screenshot00004](https://github.com/xbmc/xbmc/assets/3226626/8406e52f-5c5d-4e86-a808-30e35468f7a8)

Runtime-tested on macOS, latest Kodi master with BD and DVD iso images.

@enen92  no-brainer to review I guess.
