### PR TITLE
[upnp] Fix upnp thumbs when using Kodi as a renderer

### DIFF
--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -652,22 +652,21 @@ BuildObject(CFileItem&                    item,
         thumb = ContentUtils::GetPreferredArtImage(item);
 
         if (!thumb.empty()) {
-          PLT_AlbumArtInfo art;
-          // Set DLNA profileID by extension, defaulting to JPEG.
-          if (URIUtils::HasExtension(thumb, ".png"))
-          {
-            art.dlna_profile = "PNG_TN";
-          }
-          else
-          {
-            art.dlna_profile = "JPEG_TN";
-          }
-          // append /thumb to the safe resource uri to avoid clients flagging the item with
-          // the incorrect mimetype (derived from the file extension)
-          art.uri = upnp_server->BuildSafeResourceUri(
-              rooturi, (*ips.GetFirstItem()).ToString(),
-              std::string(CTextureUtils::GetWrappedImageURL(thumb) + "/thumb").c_str());
-          object->m_ExtraInfo.album_arts.Add(art);
+            PLT_AlbumArtInfo art;
+            art.uri =
+                upnp_server->BuildSafeResourceUri(rooturi, (*ips.GetFirstItem()).ToString(),
+                                                  CTextureUtils::GetWrappedImageURL(thumb).c_str());
+
+            // Set DLNA profileID by extension, defaulting to JPEG.
+            if (URIUtils::HasExtension(thumb, ".png"))
+            {
+                art.dlna_profile = "PNG_TN";
+            }
+            else
+            {
+                art.dlna_profile = "JPEG_TN";
+            }
+            object->m_ExtraInfo.album_arts.Add(art);
         }
 
         for (const auto& itArtwork : item.GetArt())

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -9,7 +9,7 @@
 
 #include "FileItem.h"
 #include "ServiceBroker.h"
-#include "TextureDatabase.h"
+#include "TextureCache.h"
 #include "ThumbLoader.h"
 #include "UPnPServer.h"
 #include "URL.h"
@@ -32,12 +32,29 @@
 
 #include <algorithm>
 #include <array>
+#include <optional>
 #include <string_view>
 
 #include <Platinum/Source/Platinum/Platinum.h>
 
 using namespace MUSIC_INFO;
 using namespace XFILE;
+
+namespace
+{
+std::optional<std::string> GetImageDLNAProfile(const std::string& imgPath)
+{
+  if (URIUtils::HasExtension(imgPath, ".png"))
+  {
+    return "PNG_TN";
+  }
+  else if (URIUtils::HasExtension(imgPath, ".jpg") || URIUtils::HasExtension(imgPath, ".jpeg"))
+  {
+    return "JPEG_TN";
+  }
+  return std::nullopt;
+}
+} // namespace
 
 namespace UPNP
 {
@@ -653,19 +670,40 @@ BuildObject(CFileItem&                    item,
 
         if (!thumb.empty()) {
             PLT_AlbumArtInfo art;
+
+            // Get DLNA profileId for the image
+            std::optional<std::string> imageProfile = GetImageDLNAProfile(thumb);
+            if (imageProfile.has_value())
+            {
+                art.dlna_profile = imageProfile.value().c_str();
+            }
+            else
+            {
+                // unknown image format (might be a embed thumb previously extracted and cached - e.g. mp3, flac, mvk, etc)
+                bool needsRecaching;
+                const std::string cachedImagePath =
+                    CServiceBroker::GetTextureCache()->CheckCachedImage(thumb, needsRecaching);
+                if (!cachedImagePath.empty())
+                {
+                  imageProfile = GetImageDLNAProfile(cachedImagePath);
+                  if (imageProfile.has_value())
+                  {
+                      thumb = cachedImagePath;
+                      art.dlna_profile = imageProfile.value().c_str();
+                  }
+                }
+            }
+
+            // Always default to JPEG if the profile could not be found
+            if (art.dlna_profile.IsEmpty())
+            {
+                art.dlna_profile = "JPEG_TN";
+            }
+
             art.uri =
                 upnp_server->BuildSafeResourceUri(rooturi, (*ips.GetFirstItem()).ToString(),
                                                   CTextureUtils::GetWrappedImageURL(thumb).c_str());
 
-            // Set DLNA profileID by extension, defaulting to JPEG.
-            if (URIUtils::HasExtension(thumb, ".png"))
-            {
-                art.dlna_profile = "PNG_TN";
-            }
-            else
-            {
-                art.dlna_profile = "JPEG_TN";
-            }
             object->m_ExtraInfo.album_arts.Add(art);
         }
 


### PR DESCRIPTION
## Description
In https://github.com/xbmc/xbmc/pull/21837 a small "hack" was introduced to force kodi to load image urls even if the extension was not png or jpeg when used as an upnp renderer. This was somehow a hack since by computing a new path without any sort of extension platinum is not able to derive the mimetype for the item and set the content-type header. This then caused side effects on external upnp clients as reported by https://github.com/xbmc/xbmc/issues/23899.
In the PR I reverted the original fix and went with a better one instead. If the "image://" file being served is not a recognized image extension, try to look into the texture cache to the appropriate extracted image linked to this path. This will return the correct image with a correct image filetype and will make platinum detect the mimetype correctly, sending the appropriate `Content-Type` header.

@CrystalP it'd be nice if you could runtime check to see if it solves the issue for you...

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/23899 while guaranteeing https://github.com/xbmc/xbmc/issues/20845 is still working as expected

## How has this been tested?
Runtime tested with different upnp clients and also the procedure of https://github.com/xbmc/xbmc/issues/20845

## What is the effect on users?
Should restore thumbnails on some official upnp clients

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
