### PR TITLE
[cmake] FindIconv dont add target if libc is the detected provider for iconv

### DIFF
--- a/cmake/modules/FindIconv.cmake
+++ b/cmake/modules/FindIconv.cmake
@@ -29,10 +29,14 @@ if(NOT TARGET ICONV::ICONV)
                                     REQUIRED_VARS ICONV_LIBRARY ICONV_INCLUDE_DIR HAVE_ICONV_FUNCTION)
 
   if(ICONV_FOUND)
-    add_library(ICONV::ICONV UNKNOWN IMPORTED)
-    set_target_properties(ICONV::ICONV PROPERTIES
-                                       IMPORTED_LOCATION "${ICONV_LIBRARY}"
-                                       INTERFACE_INCLUDE_DIRECTORIES "${ICONV_INCLUDE_DIR}")
-    set_property(GLOBAL APPEND PROPERTY INTERNAL_DEPS_PROP ICONV::ICONV)
+    # Libc causes grief for linux, so search if found library is libc.* and only
+    # create imported TARGET if its not
+    if(NOT ${ICONV_LIBRARY} MATCHES ".*libc\..*")
+      add_library(ICONV::ICONV UNKNOWN IMPORTED)
+      set_target_properties(ICONV::ICONV PROPERTIES
+                                         IMPORTED_LOCATION "${ICONV_LIBRARY}"
+                                         INTERFACE_INCLUDE_DIRECTORIES "${ICONV_INCLUDE_DIR}")
+      set_property(GLOBAL APPEND PROPERTY INTERNAL_DEPS_PROP ICONV::ICONV)
+    endif()
   endif()
 endif()


### PR DESCRIPTION
## Description
If libc is the provider of iconv functions, we dont explicitly add the iconv target to the project. This implies that libc is linked in some other manner.

## Motivation and context
Fixes #23887

## How has this been tested?
@HiassofT 

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
