### PR TITLE
[cmake] FindOpenGLES add IMPORTED_NO_SONAME property

### DIFF
--- a/cmake/modules/FindOpenGLES.cmake
+++ b/cmake/modules/FindOpenGLES.cmake
@@ -42,10 +42,16 @@ if(NOT TARGET OpenGL::GLES)
       endif()
     endif()
 
-    add_library(OpenGL::GLES UNKNOWN IMPORTED)
+    if(${OPENGLES_gl_LIBRARY} MATCHES ".+\.so$")
+      add_library(OpenGL::GLES SHARED IMPORTED)
+    else()
+      add_library(OpenGL::GLES UNKNOWN IMPORTED)
+    endif()
+
     set_target_properties(OpenGL::GLES PROPERTIES
                                        IMPORTED_LOCATION "${OPENGLES_gl_LIBRARY}"
-                                       INTERFACE_INCLUDE_DIRECTORIES "${OPENGLES_INCLUDE_DIR}")
+                                       INTERFACE_INCLUDE_DIRECTORIES "${OPENGLES_INCLUDE_DIR}"
+                                       IMPORTED_NO_SONAME TRUE)
 
     if(OPENGLES3_INCLUDE_DIR)
       set_property(TARGET OpenGL::GLES APPEND PROPERTY


### PR DESCRIPTION
## Description
Some linux projects were having a fixed library path for install that caused runtime failures.

As per https://cmake.org/cmake/help/latest/prop_tgt/IMPORTED_NO_SONAME.html

CMake may adjust generated link commands for some platforms to prevent the linker from using the path to the library in place of its missing soname

## Motivation and context
*elec distributions were experiencing runtime failures due to install linking have a hardcoded build address.
https://github.com/xbmc/xbmc/pull/23749#discussion_r1349912123

@vpeter4 any idea if this needs to be done for opengl find module as well?

I believe platforms that dont use sonames just disregard the property, so i think its safe to add generic like this. Jenkins might tell me if i need to target it more specifically. It may need to be gated by platform (linux/freebsd) and also potentially only for a shared lib and not static. I figure we'll try the path of least resistance first.

## How has this been tested?
@vpeter4 could you let me know if this works completely

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
