### PR TITLE
[webOS] Renderer: Fix render region

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererStarfish.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererStarfish.cpp
@@ -83,7 +83,27 @@ bool CRendererStarfish::Register()
 
 void CRendererStarfish::ManageRenderArea()
 {
+  // this hack is needed to get the 2D mode of a 3D movie going
+  RENDER_STEREO_MODE stereoMode = CServiceBroker::GetWinSystem()->GetGfxContext().GetStereoMode();
+  if (stereoMode == RENDER_STEREO_MODE_MONO)
+    CServiceBroker::GetWinSystem()->GetGfxContext().SetStereoView(RENDER_STEREO_VIEW_LEFT);
+
   CBaseRenderer::ManageRenderArea();
+
+  if (stereoMode == RENDER_STEREO_MODE_MONO)
+    CServiceBroker::GetWinSystem()->GetGfxContext().SetStereoView(RENDER_STEREO_VIEW_OFF);
+
+  switch (stereoMode)
+  {
+    case RENDER_STEREO_MODE_SPLIT_HORIZONTAL:
+      m_destRect.y2 *= 2.0f;
+      break;
+    case RENDER_STEREO_MODE_SPLIT_VERTICAL:
+      m_destRect.x2 *= 2.0f;
+      break;
+    default:
+      break;
+  }
 
   if ((m_exportedDestRect != m_destRect || m_exportedSourceRect != m_sourceRect) &&
       !m_sourceRect.IsEmpty() && !m_destRect.IsEmpty())
@@ -160,8 +180,6 @@ void CRendererStarfish::Update()
   {
     return;
   }
-
-  ManageRenderArea();
 }
 
 void CRendererStarfish::RenderUpdate(
@@ -171,4 +189,6 @@ void CRendererStarfish::RenderUpdate(
   {
     return;
   }
+
+  ManageRenderArea();
 }


### PR DESCRIPTION
## Description
Properly calls `ManageRenderArea` in `RenderUpdate` to make sure video region gets updated. Inspired by `CRendererMediaCodecSurface` to fix 3D video playback.

Supersedes #23859 (basically same fix, but with additional logic to keep 3D videos working)

## Motivation and context
Rendered videos were sometimes misplaced

## How has this been tested?
Tested on webOS 7/5 and webOS 4 TVs with Confluence theme.

## What is the effect on users?
When video doesn't take up whole screen it will be properly placed

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
