### PR TITLE
[video][music] Hide play-related context menu items for party mode pl…

### DIFF
--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -851,6 +851,19 @@ bool GetItemsForPlayList(const std::shared_ptr<CFileItem>& item, CFileItemList& 
                               true); // can be cancelled
 }
 
+namespace
+{
+bool IsNonExistingUserPartyModePlaylist(const CFileItem& item)
+{
+  if (!item.IsSmartPlayList())
+    return false;
+
+  const std::string path{item.GetPath()};
+  const auto profileManager{CServiceBroker::GetSettingsComponent()->GetProfileManager()};
+  return ((profileManager->GetUserDataItem("PartyMode.xsp") == path) && !CFileUtils::Exists(path));
+}
+} // unnamed namespace
+
 bool IsItemPlayable(const CFileItem& item)
 {
   // Exclude all parent folders
@@ -893,6 +906,9 @@ bool IsItemPlayable(const CFileItem& item)
       return false;
     }
   }
+
+  if (IsNonExistingUserPartyModePlaylist(item))
+    return false;
 
   if (item.m_bIsFolder &&
       (item.IsMusicDb() || StringUtils::StartsWithNoCase(item.GetPath(), "library://music/")))


### PR DESCRIPTION
…aylists if not existing.

In video or music window, the node "Playlists" contains always an entry "Party mode playlist" (see screen shot below). What happens when clicking on this entry depends on whether there already was a party mode playlist created. If yes, the content of that list will be displayed in the respective window, if not, a dialog to create the playlist will be opened. If no playlist exists (yet) and you open the context menu of the "Party mode playlist" item, it should not contain any playback related items, because there is nothing to play. This is, what this PR does: hiding those context menu entries in case there is no party mode playlist yet.

![screenshot00003](https://github.com/xbmc/xbmc/assets/3226626/9fb3c2b9-1092-486a-b584-4e1aa3cbabf5)

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 a quick code review would be nice.
