### PR TITLE
add missing c++ headers

### DIFF
--- a/xbmc/addons/AddonUpdateRules.cpp
+++ b/xbmc/addons/AddonUpdateRules.cpp
@@ -12,6 +12,7 @@
 #include "addons/addoninfo/AddonInfo.h"
 #include "utils/log.h"
 
+#include <algorithm>
 #include <mutex>
 
 using namespace ADDON;

--- a/xbmc/addons/binary-addons/AddonDll.cpp
+++ b/xbmc/addons/binary-addons/AddonDll.cpp
@@ -27,6 +27,7 @@
 #include "utils/Variant.h"
 #include "utils/log.h"
 
+#include <algorithm>
 #include <utility>
 
 using namespace KODI::MESSAGING;

--- a/xbmc/interfaces/json-rpc/TextureOperations.cpp
+++ b/xbmc/interfaces/json-rpc/TextureOperations.cpp
@@ -14,6 +14,8 @@
 #include "TextureDatabase.h"
 #include "utils/Variant.h"
 
+#include <algorithm>
+
 using namespace JSONRPC;
 
 JSONRPC_STATUS CTextureOperations::GetTextures(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)

--- a/xbmc/utils/EGLImage.cpp
+++ b/xbmc/utils/EGLImage.cpp
@@ -14,6 +14,7 @@
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
+#include <algorithm>
 #include <map>
 
 namespace

--- a/xbmc/windowing/gbm/drm/DRMConnector.cpp
+++ b/xbmc/windowing/gbm/drm/DRMConnector.cpp
@@ -11,6 +11,7 @@
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
 
+#include <algorithm>
 #include <map>
 
 using namespace KODI::WINDOWING::GBM;

--- a/xbmc/windowing/gbm/drm/DRMPlane.cpp
+++ b/xbmc/windowing/gbm/drm/DRMPlane.cpp
@@ -13,6 +13,8 @@
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
+#include <algorithm>
+
 using namespace KODI::WINDOWING::GBM;
 
 CDRMPlane::CDRMPlane(int fd, uint32_t plane) : CDRMObject(fd), m_plane(drmModeGetPlane(m_fd, plane))


### PR DESCRIPTION
Add a few missing headers which are no longer indirectly included by other headers, fixes build with gcc-14

## Description
Fix build with gcc-14: add a few missing includes which are no longer included implicitly through
other headers.

## Motivation and context
Fix building kodi with gcc-14, mainly due to template errors about std::find() and friends, which are
fixed by including the \<algorithm\> header.

## How has this been tested?
Build kodi-gbm on linux x86_64 with gcc version 14.0.0 20231012 (experimental) 701363d827d45d3e3601735fa42f95644fda8b64

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
