### PR TITLE
windowing/gbm: add EGL fencing for atomic drm

### DIFF
--- a/xbmc/utils/EGLFence.cpp
+++ b/xbmc/utils/EGLFence.cpp
@@ -22,6 +22,14 @@ CEGLFence::CEGLFence(EGLDisplay display)
     m_eglGetSyncAttribKHR(
         CEGLUtils::GetRequiredProcAddress<PFNEGLGETSYNCATTRIBKHRPROC>("eglGetSyncAttribKHR"))
 {
+#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+  m_eglDupNativeFenceFDANDROID =
+      CEGLUtils::GetRequiredProcAddress<PFNEGLDUPNATIVEFENCEFDANDROIDPROC>(
+          "eglDupNativeFenceFDANDROID");
+  m_eglClientWaitSyncKHR =
+      CEGLUtils::GetRequiredProcAddress<PFNEGLCLIENTWAITSYNCKHRPROC>("eglClientWaitSyncKHR");
+  m_eglWaitSyncKHR = CEGLUtils::GetRequiredProcAddress<PFNEGLWAITSYNCKHRPROC>("eglWaitSyncKHR");
+#endif
 }
 
 void CEGLFence::CreateFence()
@@ -71,3 +79,65 @@ bool CEGLFence::IsSignaled()
 
   return false;
 }
+
+#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+EGLSyncKHR CEGLFence::CreateFence(int fd)
+{
+  CEGLAttributes<1> attributeList;
+  attributeList.Add({{EGL_SYNC_NATIVE_FENCE_FD_ANDROID, fd}});
+
+  EGLSyncKHR fence =
+      m_eglCreateSyncKHR(m_display, EGL_SYNC_NATIVE_FENCE_ANDROID, attributeList.Get());
+
+  if (fence == EGL_NO_SYNC_KHR)
+  {
+    CEGLUtils::Log(LOGERROR, "failed to create EGL sync object");
+    return nullptr;
+  }
+
+  return fence;
+}
+
+void CEGLFence::CreateGPUFence()
+{
+  m_gpuFence = CreateFence(EGL_NO_NATIVE_FENCE_FD_ANDROID);
+}
+
+void CEGLFence::CreateKMSFence(int fd)
+{
+  m_kmsFence = CreateFence(fd);
+}
+
+EGLint CEGLFence::FlushFence()
+{
+  EGLint fd = m_eglDupNativeFenceFDANDROID(m_display, m_gpuFence);
+  if (fd == EGL_NO_NATIVE_FENCE_FD_ANDROID)
+    CEGLUtils::Log(LOGERROR, "failed to duplicate EGL fence fd");
+
+  m_eglDestroySyncKHR(m_display, m_gpuFence);
+
+  return fd;
+}
+
+void CEGLFence::WaitSyncGPU()
+{
+  if (!m_kmsFence)
+    return;
+
+  if (m_eglWaitSyncKHR(m_display, m_kmsFence, 0) != EGL_TRUE)
+    CEGLUtils::Log(LOGERROR, "failed to create EGL sync point");
+}
+
+void CEGLFence::WaitSyncCPU()
+{
+  if (!m_kmsFence)
+    return;
+
+  EGLint status{EGL_FALSE};
+
+  while (status != EGL_CONDITION_SATISFIED_KHR)
+    status = m_eglClientWaitSyncKHR(m_display, m_kmsFence, 0, EGL_FOREVER_KHR);
+
+  m_eglDestroySyncKHR(m_display, m_kmsFence);
+}
+#endif

--- a/xbmc/utils/EGLFence.h
+++ b/xbmc/utils/EGLFence.h
@@ -30,6 +30,14 @@ public:
   void DestroyFence();
   bool IsSignaled();
 
+#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+  void CreateKMSFence(int fd);
+  void CreateGPUFence();
+  EGLint FlushFence();
+  void WaitSyncGPU();
+  void WaitSyncCPU();
+#endif
+
 private:
   EGLDisplay m_display{nullptr};
   EGLSyncKHR m_fence{nullptr};
@@ -37,6 +45,17 @@ private:
   PFNEGLCREATESYNCKHRPROC m_eglCreateSyncKHR{nullptr};
   PFNEGLDESTROYSYNCKHRPROC m_eglDestroySyncKHR{nullptr};
   PFNEGLGETSYNCATTRIBKHRPROC m_eglGetSyncAttribKHR{nullptr};
+
+#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+  EGLSyncKHR CreateFence(int fd);
+
+  EGLSyncKHR m_gpuFence{EGL_NO_SYNC_KHR};
+  EGLSyncKHR m_kmsFence{EGL_NO_SYNC_KHR};
+
+  PFNEGLDUPNATIVEFENCEFDANDROIDPROC m_eglDupNativeFenceFDANDROID{nullptr};
+  PFNEGLCLIENTWAITSYNCKHRPROC m_eglClientWaitSyncKHR{nullptr};
+  PFNEGLWAITSYNCKHRPROC m_eglWaitSyncKHR{nullptr};
+#endif
 };
 
 }

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -278,7 +278,7 @@ void CWinSystemGbm::UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo)
   SetFullScreen(true, resMutable, false);
 }
 
-void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer)
+void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer, bool async)
 {
   if (m_videoLayerBridge && !videoLayer)
   {
@@ -293,7 +293,7 @@ void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer)
     bo = m_GBM->GetDevice()->GetSurface()->LockFrontBuffer()->Get();
   }
 
-  m_DRM->FlipPage(bo, rendered, videoLayer);
+  m_DRM->FlipPage(bo, rendered, videoLayer, async);
 
   if (m_videoLayerBridge && !videoLayer)
   {
@@ -310,14 +310,14 @@ bool CWinSystemGbm::UseLimitedColor()
 bool CWinSystemGbm::Hide()
 {
   bool ret = m_DRM->SetActive(false);
-  FlipPage(false, false);
+  FlipPage(false, false, false);
   return ret;
 }
 
 bool CWinSystemGbm::Show(bool raise)
 {
   bool ret = m_DRM->SetActive(true);
-  FlipPage(false, false);
+  FlipPage(false, false, false);
   return ret;
 }
 

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -49,7 +49,7 @@ public:
   bool DisplayHardwareScalingEnabled() override;
   void UpdateDisplayHardwareScaling(const RESOLUTION_INFO& resInfo) override;
 
-  void FlipPage(bool rendered, bool videoLayer);
+  void FlipPage(bool rendered, bool videoLayer, bool async);
 
   bool CanDoWindowed() override { return false; }
   void UpdateResolutions() override;

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -58,6 +58,17 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint 
     return false;
   }
 
+  if (CEGLUtils::HasExtension(m_eglContext.GetEGLDisplay(), "EGL_ANDROID_native_fence_sync") &&
+      CEGLUtils::HasExtension(m_eglContext.GetEGLDisplay(), "EGL_KHR_fence_sync"))
+  {
+    m_eglFence = std::make_unique<KODI::UTILS::EGL::CEGLFence>(m_eglContext.GetEGLDisplay());
+  }
+  else
+  {
+    CLog::Log(LOGWARNING, "[GBM] missing support for EGL_KHR_fence_sync and "
+                          "EGL_ANDROID_native_fence_sync - performance may be impacted");
+  }
+
   return true;
 }
 

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "WinSystemGbm.h"
+#include "utils/EGLFence.h"
 #include "utils/EGLUtils.h"
 #include "windowing/linux/WinSystemEGL.h"
 
@@ -45,6 +46,8 @@ protected:
    */
   bool InitWindowSystemEGL(EGLint renderableType, EGLint apiType);
   virtual bool CreateContext() = 0;
+
+  std::unique_ptr<KODI::UTILS::EGL::CEGLFence> m_eglFence;
 
   struct delete_CVaapiProxy
   {

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -128,13 +128,38 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
   {
     if (rendered)
     {
+#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+      if (m_eglFence)
+      {
+        int fd = m_DRM->TakeOutFenceFd();
+        if (fd != -1)
+        {
+          m_eglFence->CreateKMSFence(fd);
+          m_eglFence->WaitSyncGPU();
+        }
+
+        m_eglFence->CreateGPUFence();
+      }
+#endif
+
       if (!m_eglContext.TrySwapBuffers())
       {
         CEGLUtils::Log(LOGERROR, "eglSwapBuffers failed");
         throw std::runtime_error("eglSwapBuffers failed");
       }
+
+#if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
+      if (m_eglFence)
+      {
+        int fd = m_eglFence->FlushFence();
+        m_DRM->SetInFenceFd(fd);
+
+        m_eglFence->WaitSyncCPU();
+      }
+#endif
     }
-    CWinSystemGbm::FlipPage(rendered, videoLayer);
+
+    CWinSystemGbm::FlipPage(rendered, videoLayer, static_cast<bool>(m_eglFence));
 
     if (m_dispReset && m_dispResetTimer.IsTimePast())
     {

--- a/xbmc/windowing/gbm/drm/DRMAtomic.h
+++ b/xbmc/windowing/gbm/drm/DRMAtomic.h
@@ -27,7 +27,7 @@ class CDRMAtomic : public CDRMUtils
 public:
   CDRMAtomic() = default;
   ~CDRMAtomic() override = default;
-  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) override;
+  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override;
   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) override;
   bool SetActive(bool active) override;
   bool InitDrm() override;

--- a/xbmc/windowing/gbm/drm/DRMLegacy.cpp
+++ b/xbmc/windowing/gbm/drm/DRMLegacy.cpp
@@ -108,7 +108,7 @@ bool CDRMLegacy::QueueFlip(struct gbm_bo *bo)
   return true;
 }
 
-void CDRMLegacy::FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer)
+void CDRMLegacy::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async)
 {
   if (rendered || videoLayer)
   {

--- a/xbmc/windowing/gbm/drm/DRMLegacy.h
+++ b/xbmc/windowing/gbm/drm/DRMLegacy.h
@@ -22,7 +22,7 @@ class CDRMLegacy : public CDRMUtils
 public:
   CDRMLegacy() = default;
   ~CDRMLegacy() override = default;
-  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) override;
+  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override;
   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) override;
   bool SetActive(bool active) override;
   bool InitDrm() override;

--- a/xbmc/windowing/gbm/drm/DRMUtils.h
+++ b/xbmc/windowing/gbm/drm/DRMUtils.h
@@ -15,6 +15,7 @@
 #include "windowing/Resolution.h"
 #include "windowing/gbm/GBMUtils.h"
 
+#include <utility>
 #include <vector>
 
 #include <gbm.h>
@@ -39,7 +40,7 @@ class CDRMUtils
 public:
   CDRMUtils() = default;
   virtual ~CDRMUtils();
-  virtual void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer) {}
+  virtual void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) {}
   virtual bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo* bo) { return false; }
   virtual bool SetActive(bool active) { return false; }
   virtual bool InitDrm();
@@ -62,6 +63,13 @@ public:
   static uint32_t FourCCWithAlpha(uint32_t fourcc);
   static uint32_t FourCCWithoutAlpha(uint32_t fourcc);
 
+  void SetInFenceFd(int fd) { m_inFenceFd = fd; }
+  int TakeOutFenceFd()
+  {
+    int fd{-1};
+    return std::exchange(m_outFenceFd, fd);
+  }
+
 protected:
   bool OpenDrm(bool needConnector);
   drm_fb* DrmFbGetFromBo(struct gbm_bo *bo);
@@ -77,6 +85,9 @@ protected:
 
   int m_width = 0;
   int m_height = 0;
+
+  int m_inFenceFd{-1};
+  int m_outFenceFd{-1};
 
   std::vector<std::unique_ptr<CDRMPlane>> m_planes;
 

--- a/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
+++ b/xbmc/windowing/gbm/drm/OffScreenModeSetting.h
@@ -22,7 +22,7 @@ class COffScreenModeSetting : public CDRMUtils
 public:
   COffScreenModeSetting() = default;
   ~COffScreenModeSetting() override = default;
-  void FlipPage(struct gbm_bo *bo, bool rendered, bool videoLayer) override {}
+  void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override {}
   bool SetVideoMode(const RESOLUTION_INFO& res, struct gbm_bo *bo) override { return false; }
   bool SetActive(bool active) override { return false; }
   bool InitDrm() override;


### PR DESCRIPTION
This is an alternative to #23793 and possibly #22012

This uses EGL fencing to allow async rendering via non-blocking atomic commits.

This is mostly taken from the kmscube implementation here -> https://gitlab.freedesktop.org/mesa/kmscube/-/commit/497ab787e5ab56c630014a20b43bfab16e3b43aa

This commit has been around since 2018 when I first implemented it. I never PR'd it because many platforms didn't use an up to date mesa or allowed for async drm.

This commit also adds a check that the DRM driver allows for async behaviour.

It seems to work ok on my AMD GPU. It would be nice to check on a lower power platform.