### PR TITLE
[favourites][listproviders] Favourites: Add support for action 'info'.

### DIFF
--- a/xbmc/favourites/GUIWindowFavourites.cpp
+++ b/xbmc/favourites/GUIWindowFavourites.cpp
@@ -111,19 +111,23 @@ protected:
 };
 } // namespace
 
-bool CGUIWindowFavourites::OnSelect(int item)
+bool CGUIWindowFavourites::OnSelect(int itemIdx)
 {
-  if (item < 0 || item >= m_vecItems->Size())
+  if (itemIdx < 0 || itemIdx >= m_vecItems->Size())
     return false;
 
-  const CFavouritesURL favURL{*(*m_vecItems)[item], GetID()};
+  const auto item{(*m_vecItems)[itemIdx]};
+  const CFavouritesURL favURL{*item, GetID()};
   if (!favURL.IsValid())
     return false;
 
-  CFileItem targetItem{favURL.GetTarget(), favURL.IsDir()};
-  targetItem.LoadDetails();
-
   const bool isPlayMedia{favURL.GetAction() == CFavouritesURL::Action::PLAY_MEDIA};
+
+  const auto target{CServiceBroker::GetFavouritesService().ResolveFavourite(*item)};
+  if (!target)
+    return false;
+
+  CFileItem targetItem{*target};
 
   // video select action setting is for files only, except exec func is playmedia...
   if (targetItem.HasVideoInfoTag() && (!targetItem.m_bIsFolder || isPlayMedia))
@@ -145,12 +149,12 @@ bool CGUIWindowFavourites::OnAction(const CAction& action)
 
   if (action.GetID() == ACTION_PLAYER_PLAY)
   {
-    const CFavouritesURL favURL((*m_vecItems)[selectedItem]->GetPath());
-    if (!favURL.IsValid())
+    const auto target{
+        CServiceBroker::GetFavouritesService().ResolveFavourite(*(*m_vecItems)[selectedItem])};
+    if (!target)
       return false;
 
-    CFileItem item{favURL.GetTarget(), favURL.IsDir()};
-    item.LoadDetails();
+    CFileItem item{*target};
 
     // video play action setting is for files and folders...
     if (item.HasVideoInfoTag() || (item.m_bIsFolder && VIDEO_UTILS::IsItemPlayable(item)))

--- a/xbmc/favourites/GUIWindowFavourites.cpp
+++ b/xbmc/favourites/GUIWindowFavourites.cpp
@@ -173,6 +173,13 @@ bool CGUIWindowFavourites::OnAction(const CAction& action)
     }
     return false;
   }
+  else if (action.GetID() == ACTION_SHOW_INFO)
+  {
+    const auto targetItem{
+        CServiceBroker::GetFavouritesService().ResolveFavourite(*(*m_vecItems)[selectedItem])};
+
+    return UTILS::GUILIB::CGUIContentUtils::ShowInfoForItem(*targetItem);
+  }
   else if (action.GetID() == ACTION_MOVE_ITEM_UP)
   {
     if (FAVOURITES_UTILS::ShouldEnableMoveItems())

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -626,7 +626,11 @@ bool CDirectoryProvider::OnPlay(const CGUIListItemPtr& item)
 
 bool CDirectoryProvider::OnInfo(const std::shared_ptr<CFileItem>& fileItem)
 {
-  return UTILS::GUILIB::CGUIContentUtils::ShowInfoForItem(*fileItem);
+  const auto targetItem{fileItem->IsFavourite()
+                            ? CServiceBroker::GetFavouritesService().ResolveFavourite(*fileItem)
+                            : fileItem};
+
+  return UTILS::GUILIB::CGUIContentUtils::ShowInfoForItem(*targetItem);
 }
 
 bool CDirectoryProvider::OnInfo(const CGUIListItemPtr& item)


### PR DESCRIPTION
Add support for action 'info' for favourites (provided by `CGUIWindowFavourites`and `CDirectoryProvider`) and some code consolitation (use `CFavouritesService::ResolveFavourite` instead of own impl.)

Now the info dialog for supported resources (movies, shows, episodes, seasons, albums, songs, artists, pvr recordings, ...) will pop up once you press the key assigned to action "info", on keyboard this is usually "i".

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 should be easy to review.