### PR TITLE
[favourites] Fix context menu item 'play' and 'resume' not working.

### DIFF
--- a/xbmc/favourites/ContextMenus.cpp
+++ b/xbmc/favourites/ContextMenus.cpp
@@ -146,8 +146,11 @@ bool CFavouritesTargetResume::IsVisible(const CFileItem& item) const
 
 bool CFavouritesTargetResume::Execute(const std::shared_ptr<CFileItem>& item) const
 {
-  FAVOURITES_UTILS::ExecuteAction({"PlayMedia", *item, "resume"});
-  return true;
+  const std::shared_ptr<CFileItem> targetItem{ResolveFavouriteItem(*item)};
+  if (targetItem)
+    return FAVOURITES_UTILS::ExecuteAction({"PlayMedia", *targetItem, "resume"});
+
+  return false;
 }
 
 std::string CFavouritesTargetPlay::GetLabel(const CFileItem& item) const
@@ -166,8 +169,11 @@ bool CFavouritesTargetPlay::IsVisible(const CFileItem& item) const
 
 bool CFavouritesTargetPlay::Execute(const std::shared_ptr<CFileItem>& item) const
 {
-  FAVOURITES_UTILS::ExecuteAction({"PlayMedia", *item, "noresume"});
-  return true;
+  const std::shared_ptr<CFileItem> targetItem{ResolveFavouriteItem(*item)};
+  if (targetItem)
+    return FAVOURITES_UTILS::ExecuteAction({"PlayMedia", *targetItem, "noresume"});
+
+  return false;
 }
 
 bool CFavouritesTargetInfo::IsVisible(const CFileItem& item) const


### PR DESCRIPTION
Worked initially, must have been broken by me while incorporating PR review feedback and not testing changes afterwards. :-(

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 this one is important to have for beta. Cause of the bug: target item of the favourite was not resolved be starting playback. For v22 we need to find a central place where those favourites are resolved automatically.