### PR TITLE
[GUI][Skins] Bump to xbmc.gui 5.17.0

### DIFF
--- a/addons/skin.estouchy/addon.xml
+++ b/addons/skin.estouchy/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="skin.estouchy" version="3.0.8" name="Estouchy" provider-name="Team Kodi">
+<addon id="skin.estouchy" version="4.0.0" name="Estouchy" provider-name="Team Kodi">
 	<requires>
-		<import addon="xbmc.gui" version="5.16.0"/>
+		<import addon="xbmc.gui" version="5.17.0"/>
 	</requires>
 	<extension point="xbmc.gui.skin" debugging="false">
 		<res width="1280" height="960" aspect="4:3" folder="xml"/>

--- a/addons/skin.estuary/addon.xml
+++ b/addons/skin.estuary/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="skin.estuary" version="3.0.10" name="Estuary" provider-name="phil65, Ichabod Fletchman">
+<addon id="skin.estuary" version="4.0.0" name="Estuary" provider-name="phil65, Ichabod Fletchman">
 	<requires>
-		<import addon="xbmc.gui" version="5.16.0"/>
+		<import addon="xbmc.gui" version="5.17.0"/>
 	</requires>
 	<extension point="xbmc.gui.skin" debugging="false">
 		<res width="1920" height="1440" aspect="4:3" default="false" folder="xml" />

--- a/addons/xbmc.gui/addon.xml
+++ b/addons/xbmc.gui/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.gui" version="5.16.0" provider-name="Team Kodi">
+<addon id="xbmc.gui" version="5.17.0" provider-name="Team Kodi">
   <backwards-compatibility abi="5.15.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>


### PR DESCRIPTION
## Description
Bump xbmc.gui for skins to 5.17.0

There is also https://github.com/xbmc/xbmc/pull/23927 as a follow up to bump the backwards-compatibility abi.

## Motivation and context
Since last version bump in https://github.com/xbmc/xbmc/pull/20169 there has been:

- Breakage to the calabration screen by the changes to SettingsScreenCalibration.xml necessitated by  https://github.com/xbmc/xbmc/pull/21364

- Removal of DialogFavourites.xml by https://github.com/xbmc/xbmc/pull/23862

## How has this been tested?
Runtime tested on Windows

