### PR TITLE
[GUI] [Skins] Bump skins backwards-compatibility abi to 5.17.0

### DIFF
--- a/addons/xbmc.gui/addon.xml
+++ b/addons/xbmc.gui/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="xbmc.gui" version="5.17.0" provider-name="Team Kodi">
-  <backwards-compatibility abi="5.15.0"/>
+  <backwards-compatibility abi="5.17.0"/>
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>


### PR DESCRIPTION
## Description
Break backwards-compatibility for skins by bumping to 5.17.0

https://github.com/xbmc/xbmc/pull/23926 MUST go in first.

This is done seperately from the xbmc.gui bump, as bumping this immediately with the xbmc.gui bump will render all skins no longer compatible with Omega until they have bumped their xbmc.gui version to 5.17.0, so as a result I'm unsure when this should go in. Perhaps wait until RC to give skins some time to bump to 5.17.0???

Raising this now even if not wanted immediately so it's not forgotten as something in my view that MUST be done before final release of Omega to ensure skin compatibility.

## Motivation and context
Last ABI version bump was in https://github.com/xbmc/xbmc/pull/18082 meaning Matrix skins are still compatible with both Nexus and Omega up to now.

However since the last bump to the ABI there has been several things that could cause feature breakage in skins, the ones I'm aware of are:

- New DialogColorPicker.xml introduced in Nexus by https://github.com/xbmc/xbmc/pull/20169 and without this new dialog skins installed onto Nexus & Omega can't set subtitle colour or subtitle border colour so these core setting options will be broken.

- If the changes in Nexus to SettingsScreenCalibration.xml necessitated by https://github.com/xbmc/xbmc/pull/21364 haven't been done then the screen calibration window will be broken.

- Removal of DialogFavourites.xml in Omega by https://github.com/xbmc/xbmc/pull/23862 so the new MyFavourites.xml (introduced in Nexus https://github.com/xbmc/xbmc/pull/22001) must be used.

In addition for Games

- In order to support Savestate manager changes to DialogSelect.xml introduced in Nexus by https://github.com/xbmc/xbmc/pull/20913

## How has this been tested?
Runtime tested on Windows
