### PR TITLE
[fileitem][pvr] Fix context menu item "information" not working...

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1740,6 +1740,26 @@ void CFileItem::UpdateInfo(const CFileItem &item, bool replaceLabels /*=true*/)
     *GetGameInfoTag() = *item.GetGameInfoTag();
     SetInvalid();
   }
+  if (item.HasPVRChannelGroupMemberInfoTag())
+  {
+    m_pvrChannelGroupMemberInfoTag = item.GetPVRChannelGroupMemberInfoTag();
+    SetInvalid();
+  }
+  if (item.HasPVRTimerInfoTag())
+  {
+    m_pvrTimerInfoTag = item.m_pvrTimerInfoTag;
+    SetInvalid();
+  }
+  if (item.HasEPGInfoTag())
+  {
+    m_epgInfoTag = item.m_epgInfoTag;
+    SetInvalid();
+  }
+  if (item.HasEPGSearchFilter())
+  {
+    m_epgSearchFilter = item.m_epgSearchFilter;
+    SetInvalid();
+  }
   SetDynPath(item.GetDynPath());
   if (replaceLabels && !item.GetLabel().empty())
     SetLabel(item.GetLabel());
@@ -1781,6 +1801,26 @@ void CFileItem::MergeInfo(const CFileItem& item)
   if (item.HasGameInfoTag())
   {
     *GetGameInfoTag() = *item.GetGameInfoTag();
+    SetInvalid();
+  }
+  if (item.HasPVRChannelGroupMemberInfoTag())
+  {
+    m_pvrChannelGroupMemberInfoTag = item.GetPVRChannelGroupMemberInfoTag();
+    SetInvalid();
+  }
+  if (item.HasPVRTimerInfoTag())
+  {
+    m_pvrTimerInfoTag = item.m_pvrTimerInfoTag;
+    SetInvalid();
+  }
+  if (item.HasEPGInfoTag())
+  {
+    m_epgInfoTag = item.m_epgInfoTag;
+    SetInvalid();
+  }
+  if (item.HasEPGSearchFilter())
+  {
+    m_epgSearchFilter = item.m_epgSearchFilter;
     SetInvalid();
   }
   SetDynPath(item.GetDynPath());

--- a/xbmc/pvr/guilib/PVRGUIActionsUtils.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsUtils.cpp
@@ -16,6 +16,12 @@
 
 namespace PVR
 {
+bool CPVRGUIActionsUtils::HasInfoForItem(const CFileItem& item) const
+{
+  return item.HasPVRRecordingInfoTag() || item.HasPVRChannelInfoTag() ||
+         item.HasPVRTimerInfoTag() || item.HasEPGSearchFilter();
+}
+
 bool CPVRGUIActionsUtils::OnInfo(const CFileItem& item)
 {
   if (item.HasPVRRecordingInfoTag())

--- a/xbmc/pvr/guilib/PVRGUIActionsUtils.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsUtils.cpp
@@ -10,9 +10,12 @@
 
 #include "FileItem.h"
 #include "ServiceBroker.h"
+#include "filesystem/Directory.h"
 #include "pvr/PVRManager.h"
 #include "pvr/guilib/PVRGUIActionsEPG.h"
 #include "pvr/guilib/PVRGUIActionsRecordings.h"
+#include "utils/URIUtils.h"
+#include "utils/log.h"
 
 namespace PVR
 {
@@ -37,6 +40,43 @@ bool CPVRGUIActionsUtils::OnInfo(const CFileItem& item)
     return CServiceBroker::GetPVRManager().Get<PVR::GUI::EPG>().EditSavedSearch(item);
   }
   return false;
+}
+
+namespace
+{
+std::shared_ptr<CFileItem> LoadRecordingFileOrFolderItem(const CFileItem& item)
+{
+  if (URIUtils::IsPVRRecordingFileOrFolder(item.GetPath()))
+  {
+    //! @todo prop misused to detect loaded state for recording folder item
+    if (item.HasPVRRecordingInfoTag() || item.HasProperty("watchedepisodes"))
+      return std::make_shared<CFileItem>(item); // already loaded
+
+    const std::string parentPath{URIUtils::GetParentPath(item.GetPath())};
+
+    //! @todo optimize, find a way to set the details of the item without loading parent directory.
+    CFileItemList items;
+    if (XFILE::CDirectory::GetDirectory(parentPath, items, "", XFILE::DIR_FLAG_DEFAULTS))
+    {
+      const std::string path{item.GetPath()};
+      const auto it = std::find_if(items.cbegin(), items.cend(),
+                                   [&path](const auto& entry) { return entry->GetPath() == path; });
+      if (it != items.cend())
+        return *it;
+    }
+  }
+  return {};
+}
+} // unnamed namespace
+
+std::shared_ptr<CFileItem> CPVRGUIActionsUtils::LoadItem(const CFileItem& item)
+{
+  std::shared_ptr<CFileItem> loadedItem{LoadRecordingFileOrFolderItem(item)};
+  if (loadedItem)
+    return loadedItem;
+
+  CLog::LogFC(LOGWARNING, LOGPVR, "Error loading item details (path={})", item.GetPath());
+  return {};
 }
 
 } // namespace PVR

--- a/xbmc/pvr/guilib/PVRGUIActionsUtils.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsUtils.h
@@ -10,6 +10,8 @@
 
 #include "pvr/IPVRComponent.h"
 
+#include <memory>
+
 class CFileItem;
 
 namespace PVR
@@ -33,6 +35,13 @@ public:
      * @return True on success, false otherwise.
      */
   bool OnInfo(const CFileItem& item);
+
+  /*!
+   * @brief Load item details (create recording info tag etc.).
+   * @param item The item.
+   * @return Loaded item on success, nullptr otherwise.
+   */
+  std::shared_ptr<CFileItem> LoadItem(const CFileItem& item);
 
 private:
   CPVRGUIActionsUtils(const CPVRGUIActionsUtils&) = delete;

--- a/xbmc/pvr/guilib/PVRGUIActionsUtils.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsUtils.h
@@ -21,8 +21,16 @@ public:
   ~CPVRGUIActionsUtils() override = default;
 
   /*!
+     * @brief Check whether OnInfo supports the given item.
+     * @param item The item.
+     * @return True if supported, false otherwise.
+     */
+  bool HasInfoForItem(const CFileItem& item) const;
+
+  /*!
      * @brief Process info action for the given item.
      * @param item The item.
+     * @return True on success, false otherwise.
      */
   bool OnInfo(const CFileItem& item);
 

--- a/xbmc/utils/guilib/GUIContentUtils.cpp
+++ b/xbmc/utils/guilib/GUIContentUtils.cpp
@@ -30,7 +30,8 @@ bool CGUIContentUtils::HasInfoForItem(const CFileItem& item)
             mediaType == MediaTypeMusicVideo);
   }
 
-  return (item.HasMusicInfoTag() || item.IsPVR() || item.HasAddonInfo());
+  return (item.HasMusicInfoTag() || item.HasAddonInfo() ||
+          CServiceBroker::GetPVRManager().Get<PVR::GUI::Utils>().HasInfoForItem(item));
 }
 
 bool CGUIContentUtils::ShowInfoForItem(const CFileItem& item)
@@ -39,7 +40,7 @@ bool CGUIContentUtils::ShowInfoForItem(const CFileItem& item)
   {
     return CGUIDialogAddonInfo::ShowForItem(std::make_shared<CFileItem>(item));
   }
-  else if (item.IsPVR())
+  else if (CServiceBroker::GetPVRManager().Get<PVR::GUI::Utils>().HasInfoForItem(item))
   {
     return CServiceBroker::GetPVRManager().Get<PVR::GUI::Utils>().OnInfo(item);
   }


### PR DESCRIPTION
... for PVR TV channel favourites items. Nothing happened after clicking the menu item.

Reason: the item was not fully loaded, had no channel info tag.

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 would be cool to have this in beta. Some refactoring (for better maintainability) is also included here.