### PR TITLE
[application] Fix bd selection menu shown when external player is used.

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -2450,9 +2450,17 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
   if (!(options.startpercent > 0.0 || options.starttime > 0.0) &&
       (item.IsBDFile() || item.IsDiscImage()))
   {
-    //check if we must show the simplified bd menu
-    if (!CGUIDialogSimpleMenu::ShowPlaySelection(item))
-      return true;
+    // No video selection when using an external player, because it needs to handle that on its own.
+    const std::string defaulPlayer{
+        player.empty() ? m_ServiceManager->GetPlayerCoreFactory().GetDefaultPlayer(item) : player};
+    const bool isExternalPlayer{
+        m_ServiceManager->GetPlayerCoreFactory().IsExternalPlayer(defaulPlayer)};
+    if (!isExternalPlayer)
+    {
+      // Check if we must show the simplified bd menu.
+      if (!CGUIDialogSimpleMenu::ShowPlaySelection(item))
+        return true;
+    }
   }
 
   // this really aught to be inside !bRestart, but since PlayStack

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
@@ -254,6 +254,11 @@ std::string CPlayerCoreFactory::GetPlayerType(const std::string& player) const
   return m_vecPlayerConfigs[idx]->m_type;
 }
 
+bool CPlayerCoreFactory::IsExternalPlayer(const std::string& player) const
+{
+  return (GetPlayerType(player) == "external");
+}
+
 bool CPlayerCoreFactory::PlaysAudio(const std::string& player) const
 {
   std::unique_lock<CCriticalSection> lock(m_section);

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.h
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.h
@@ -44,6 +44,7 @@ public:
   void GetPlayers(std::vector<std::string>&players, std::string &type) const;
   void GetRemotePlayers(std::vector<std::string>&players) const;                    //All remote players we can attach to
   std::string GetPlayerType(const std::string &player) const;
+  bool IsExternalPlayer(const std::string& player) const;
   bool PlaysAudio(const std::string &player) const;
   bool PlaysVideo(const std::string &player) const;
 


### PR DESCRIPTION
Fix fallout from #23905
Reported at the forum: https://forum.kodi.tv/showthread.php?tid=374705&pid=3168847#pid3168847

Root cause: Worked formerly only by luck, due to a bug setting wrong resume info. Above mentioned PR fixed that, revealing the bug fix with this PR here.

Runtime-tested on macOS, latest Kodi master, with VLC as default external player for all iso files.

@enen92 here we go one more time. Can you check please. This is the best approach to detect that an external player is used I could find.