### PR TITLE
[favourites] Fix crash on moving items in favourites widget and favourites window.

### DIFF
--- a/xbmc/favourites/ContextMenus.cpp
+++ b/xbmc/favourites/ContextMenus.cpp
@@ -31,14 +31,14 @@ bool CFavouriteContextMenuAction::Execute(const std::shared_ptr<CFileItem>& item
 {
   CFileItemList items;
   CServiceBroker::GetFavouritesService().GetAll(items);
-  for (const auto& favourite : items)
-  {
-    if (favourite->GetPath() == item->GetPath())
-    {
-      if (DoExecute(items, favourite))
-        return CServiceBroker::GetFavouritesService().Save(items);
-    }
-  }
+
+  const auto it = std::find_if(items.cbegin(), items.cend(), [&item](const auto& favourite) {
+    return favourite->GetPath() == item->GetPath();
+  });
+
+  if ((it != items.cend()) && DoExecute(items, *it))
+    return CServiceBroker::GetFavouritesService().Save(items);
+
   return false;
 }
 

--- a/xbmc/favourites/FavouritesService.cpp
+++ b/xbmc/favourites/FavouritesService.cpp
@@ -147,6 +147,8 @@ CFavouritesService::CFavouritesService(std::string userDataFolder) : m_favourite
 
 void CFavouritesService::ReInit(std::string userDataFolder)
 {
+  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+
   m_userDataFolder = std::move(userDataFolder);
   m_favourites.Clear();
   m_targets.clear();
@@ -288,6 +290,8 @@ std::shared_ptr<CFileItem> CFavouritesService::ResolveFavourite(const CFileItem&
 {
   if (item.IsFavourite())
   {
+    std::unique_lock<CCriticalSection> lock(m_criticalSection);
+
     const auto it = m_targets.find(item.GetPath());
     if (it != m_targets.end())
       return (*it).second;

--- a/xbmc/favourites/FavouritesUtils.cpp
+++ b/xbmc/favourites/FavouritesUtils.cpp
@@ -87,15 +87,13 @@ bool MoveItem(CFileItemList& items, const std::shared_ptr<CFileItem>& item, int 
   int nextItem = (itemPos + amount) % items.Size();
   if (nextItem < 0)
   {
-    const auto& itemToAdd(item);
-    items.Remove(itemPos);
-    items.Add(itemToAdd);
+    items.Add(item);
+    items.Remove(0);
   }
   else if (nextItem == 0)
   {
-    const auto& itemToAdd(item);
-    items.Remove(itemPos);
-    items.AddFront(itemToAdd, 0);
+    items.AddFront(item, 0);
+    items.Remove(itemPos + 1);
   }
   else
   {


### PR DESCRIPTION
Fallout from https://github.com/xbmc/xbmc/pull/22738/commits/322bb807776c5bbcbe736fc30f77a11824d5f210, where a shared pointer instance essential to ensure that `item` gets not destructed was replaced by a reference. :-/ I rewrote the code, so that this cannot happen again (eliminated the variable in question).

Fixes #23936 

Runtime-tested by @vpeter4 on LibreELEC, and by me on Android and macOS, latest Kodi master.

@enen92 can you please have a look? Second commit is the fix, the others are not directly related to the issue, nevertheless bug fixes.