### PR TITLE
[keymaps] Remove leftovers from favourites dialog.

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -672,15 +672,6 @@
       <blue>Blue</blue>
     </keyboard>
   </Teletext>
-  <Favourites>
-    <keyboard>
-      <backspace>Close</backspace>
-      <browser_back>Close</browser_back>
-      <u>MoveItemUp</u>
-      <d>MoveItemDown</d>
-      <backspace mod="longpress">ActivateWindow(Home)</backspace>
-    </keyboard>
-  </Favourites>
   <FavouritesBrowser>
     <keyboard>
       <u>MoveItemUp</u>

--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -564,11 +564,6 @@
       <teletext>Back</teletext>
     </remote>
   </Teletext>
-  <Favourites>
-    <remote>
-      <back>Close</back>
-    </remote>
-  </Favourites>
   <FullscreenLiveTV>
     <remote>
       <left>StepBack</left>


### PR DESCRIPTION
Follow-up to #23862

Fixes logspam on kodi startup: 

```log
2023-10-16 22:45:43.897 T:4927032   error <general>: Window Translator: Can't find window Favourites
```

