### PR TITLE
[Rendering] Share the heuristics guessing SD/HD primaries across platforms

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -53,7 +53,8 @@ public:
   AVColorSpace color_space;
   unsigned int color_range        : 1;  //< 1 indicate if we have a full range of color
   AVChromaLocation chroma_position;
-  AVColorPrimaries color_primaries;
+  AVColorPrimaries color_primaries; // heuristics applied when original is AVCOL_PRI_UNSPECIFIED
+  AVColorPrimaries m_originalColorPrimaries;
   AVColorTransferCharacteristic color_transfer;
   unsigned int colorBits = 8;
   std::string stereoMode;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -1025,6 +1025,7 @@ bool CDVDVideoCodecFFmpeg::GetPictureCommon(VideoPicture* pVideoPicture)
 
   pVideoPicture->chroma_position = m_pCodecContext->chroma_sample_location;
   pVideoPicture->color_primaries = m_pCodecContext->color_primaries == AVCOL_PRI_UNSPECIFIED ? m_hints.colorPrimaries : m_pCodecContext->color_primaries;
+  pVideoPicture->m_originalColorPrimaries = pVideoPicture->color_primaries;
   pVideoPicture->color_transfer = m_pCodecContext->color_trc == AVCOL_TRC_UNSPECIFIED ? m_hints.colorTransferCharacteristic : m_pCodecContext->color_trc;
   pVideoPicture->color_space = m_pCodecContext->colorspace == AVCOL_SPC_UNSPECIFIED ? m_hints.colorSpace : m_pCodecContext->colorspace;
   pVideoPicture->colorBits = 8;
@@ -1147,6 +1148,14 @@ bool CDVDVideoCodecFFmpeg::GetPictureCommon(VideoPicture* pVideoPicture)
 
   m_requestSkipDeint = false;
   pVideoPicture->iFlags |= m_codecControlFlags;
+
+  if (pVideoPicture->color_primaries == AVCOL_PRI_UNSPECIFIED)
+  {
+    if (pVideoPicture->iDisplayWidth > 1024 || pVideoPicture->iDisplayHeight >= 600)
+      pVideoPicture->color_primaries = AVCOL_PRI_BT709;
+    else
+      pVideoPicture->color_primaries = AVCOL_PRI_BT470BG;
+  }
 
   return true;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -214,7 +214,7 @@ bool CLinuxRendererGL::Configure(const VideoPicture &picture, float fps, unsigne
   m_iFlags = GetFlagsChromaPosition(picture.chroma_position) |
              GetFlagsStereoMode(picture.stereoMode);
 
-  m_srcPrimaries = GetSrcPrimaries(picture.color_primaries, picture.iWidth, picture.iHeight);
+  m_srcPrimaries = picture.color_primaries;
   m_toneMap = false;
 
   // Calculate the input frame aspect ratio.
@@ -2717,10 +2717,9 @@ void CLinuxRendererGL::CheckVideoParameters(int index)
   const CPictureBuffer& buf = m_buffers[index];
   ETONEMAPMETHOD method = m_videoSettings.m_ToneMapMethod;
 
-  AVColorPrimaries srcPrim = GetSrcPrimaries(buf.m_srcPrimaries, buf.image.width, buf.image.height);
-  if (srcPrim != m_srcPrimaries)
+  if (buf.m_srcPrimaries != m_srcPrimaries)
   {
-    m_srcPrimaries = srcPrim;
+    m_srcPrimaries = buf.m_srcPrimaries;
     m_reloadShaders = true;
   }
 
@@ -2739,19 +2738,6 @@ void CLinuxRendererGL::CheckVideoParameters(int index)
   }
   m_toneMap = toneMap;
   m_toneMapMethod = method;
-}
-
-AVColorPrimaries CLinuxRendererGL::GetSrcPrimaries(AVColorPrimaries srcPrimaries, unsigned int width, unsigned int height)
-{
-  AVColorPrimaries ret = srcPrimaries;
-  if (ret == AVCOL_PRI_UNSPECIFIED)
-  {
-    if (width > 1024 || height >= 600)
-      ret = AVCOL_PRI_BT709;
-    else
-      ret = AVCOL_PRI_BT470BG;
-  }
-  return ret;
 }
 
 CRenderCapture* CLinuxRendererGL::GetRenderCapture()

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -114,7 +114,7 @@ bool CLinuxRendererGLES::Configure(const VideoPicture &picture, float fps, unsig
   m_sourceHeight = picture.iHeight;
   m_renderOrientation = orientation;
 
-  m_srcPrimaries = GetSrcPrimaries(picture.color_primaries, picture.iWidth, picture.iHeight);
+  m_srcPrimaries = picture.color_primaries;
   m_toneMap = false;
 
   // Calculate the input frame aspect ratio.
@@ -840,10 +840,9 @@ void CLinuxRendererGLES::RenderSinglePass(int index, int field)
   CPictureBuffer &buf = m_buffers[index];
   CYuvPlane (&planes)[YuvImage::MAX_PLANES] = m_buffers[index].fields[field];
 
-  AVColorPrimaries srcPrim = GetSrcPrimaries(buf.m_srcPrimaries, buf.image.width, buf.image.height);
-  if (srcPrim != m_srcPrimaries)
+  if (buf.m_srcPrimaries != m_srcPrimaries)
   {
-    m_srcPrimaries = srcPrim;
+    m_srcPrimaries = buf.m_srcPrimaries;
     m_reloadShaders = true;
   }
 
@@ -975,10 +974,9 @@ void CLinuxRendererGLES::RenderToFBO(int index, int field)
   CPictureBuffer &buf = m_buffers[index];
   CYuvPlane (&planes)[YuvImage::MAX_PLANES] = m_buffers[index].fields[field];
 
-  AVColorPrimaries srcPrim = GetSrcPrimaries(buf.m_srcPrimaries, buf.image.width, buf.image.height);
-  if (srcPrim != m_srcPrimaries)
+  if (buf.m_srcPrimaries != m_srcPrimaries)
   {
-    m_srcPrimaries = srcPrim;
+    m_srcPrimaries = buf.m_srcPrimaries;
     m_reloadShaders = true;
   }
 
@@ -1755,24 +1753,6 @@ CRenderInfo CLinuxRendererGLES::GetRenderInfo()
 bool CLinuxRendererGLES::IsGuiLayer()
 {
   return true;
-}
-
-AVColorPrimaries CLinuxRendererGLES::GetSrcPrimaries(AVColorPrimaries srcPrimaries, unsigned int width, unsigned int height)
-{
-  AVColorPrimaries ret = srcPrimaries;
-  if (ret == AVCOL_PRI_UNSPECIFIED)
-  {
-    if (width > 1024 || height >= 600)
-    {
-      ret = AVCOL_PRI_BT709;
-    }
-    else
-    {
-      ret = AVCOL_PRI_BT470BG;
-    }
-  }
-
-  return ret;
 }
 
 CRenderCapture* CLinuxRendererGLES::GetRenderCapture()

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
@@ -28,6 +28,7 @@ void CRenderBuffer::AppendPicture(const VideoPicture& picture)
   videoBuffer->Acquire();
 
   pictureFlags = picture.iFlags;
+  m_originalPrimaries = picture.m_originalColorPrimaries;
   primaries = picture.color_primaries;
   color_space = picture.color_space;
   color_transfer = picture.color_transfer;
@@ -674,11 +675,14 @@ DEBUG_INFO_VIDEO CRendererBase::GetDebugInfo(int idx)
 
   const char* px = av_get_pix_fmt_name(rb->pixelFormat);
   const char* pr = av_color_primaries_name(rb->primaries);
+  const char* opr = av_color_primaries_name(rb->m_originalPrimaries);
   const char* tr = av_color_transfer_name(rb->color_transfer);
 
   const std::string pixel = px ? px : "unknown";
-  const std::string prim = pr ? pr : "unknown";
+  const std::string oprim = opr ? opr : "unknown";
   const std::string trans = tr ? tr : "unknown";
+  const std::string prim =
+      (rb->primaries != rb->m_originalPrimaries) ? (oprim + ">" + (pr ? pr : "unknown")) : oprim;
 
   const int max = static_cast<int>(std::exp2(rb->bits));
   const int range_min = rb->full_range ? 0 : (max * 16) / 256;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
@@ -76,6 +76,7 @@ public:
   AVPixelFormat av_format;
   CVideoBuffer* videoBuffer = nullptr;
   unsigned int pictureFlags = 0;
+  AVColorPrimaries m_originalPrimaries = AVCOL_PRI_BT709;
   AVColorPrimaries primaries = AVCOL_PRI_BT709;
   AVColorSpace color_space = AVCOL_SPC_BT709;
   AVColorTransferCharacteristic color_transfer = AVCOL_TRC_BT709;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererShaders.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererShaders.cpp
@@ -98,6 +98,7 @@ bool CRendererShaders::Configure(const VideoPicture& picture, float fps, unsigne
       if (!IsHWPicSupported(picture))
         m_format = GetAVFormat(dxgi_format);
     }
+    m_srcPrimaries = picture.color_primaries;
 
     CreateIntermediateTarget(m_sourceWidth, m_sourceHeight, false, CalcIntermediateTargetFormat());
     return true;
@@ -136,11 +137,10 @@ void CRendererShaders::CheckVideoParameters()
   __super::CheckVideoParameters();
 
   CRenderBuffer* buf = m_renderBuffers[m_iBufferIndex];
-  const AVColorPrimaries srcPrim = GetSrcPrimaries(buf->primaries, buf->GetWidth(), buf->GetHeight());
-  if (srcPrim != m_srcPrimaries)
+  if (buf->primaries != m_srcPrimaries)
   {
     // source params is changed, reset shader
-    m_srcPrimaries = srcPrim;
+    m_srcPrimaries = buf->primaries;
     m_colorShader.reset();
   }
 }
@@ -187,19 +187,6 @@ bool CRendererShaders::IsHWPicSupported(const VideoPicture& picture)
     return SUCCEEDED(pDevice->CreateTexture2D(&texDesc, nullptr, nullptr));
   }
   return false;
-}
-
-AVColorPrimaries CRendererShaders::GetSrcPrimaries(AVColorPrimaries srcPrimaries, unsigned width, unsigned height)
-{
-  AVColorPrimaries ret = srcPrimaries;
-  if (ret == AVCOL_PRI_UNSPECIFIED)
-  {
-    if (width > 1024 || height >= 600)
-      ret = AVCOL_PRI_BT709;
-    else
-      ret = AVCOL_PRI_BT470BG;
-  }
-  return ret;
 }
 
 DXGI_FORMAT CRendererShaders::CalcIntermediateTargetFormat() const


### PR DESCRIPTION

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The function GetSrcPrimaries() that guesses SD or HD yuv matrix based on stream width/height is duplicated in D3D, GL and GLES.
Moved the logic to ffmpeg video codec and store the result in VideoPicture, which later trickles down to the render buffers.

The original value is kept in a new member of VideoPicture, although with current logic it's always going to be "Unknown".

Question: I wasn't sure if I was supposed to use the m_hints or to add directly to GetPictureCommon and did the latter.

Windows only:
- This is an improvement for the dxva and software render method, which didn't have that logic (only Pixel Shaders did).
- Show original/calculated matrix in the video debug OSD (alt-O). This format is very compact but could be nicer, open to suggestions.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Reduce code duplication, extend the heuristics to Windows dxva and software render methods.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 10, with flagged / unflagged material of different width / height.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
More accurate colors in Windows for SD streams with dxva and software render methods.

No change for GL, GLES, Windows / Pixel Shaders.

## Screenshots (if appropriate):
Information visible in Windows video debug OSD:
![image](https://github.com/xbmc/xbmc/assets/489377/37b03264-7aa0-4603-b9a2-5b0df82f8d1b)

DXVA render method uses the heuristics instead of always using BT709:
```
CRendererDXVA::Configure: chosen conversion: NV12 / YCBCR_STUDIO_G22_LEFT_P601 to R10G10B10A2_UNORM / RGB_FULL_G22_NONE_P709
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
