### PR TITLE
[cmake] FindPulseAudio fix compile definition

### DIFF
--- a/cmake/modules/FindPulseAudio.cmake
+++ b/cmake/modules/FindPulseAudio.cmake
@@ -62,7 +62,7 @@ if(NOT TARGET PulseAudio::PulseAudio)
     set_target_properties(PulseAudio::PulseAudio PROPERTIES
                                                  IMPORTED_LOCATION "${PULSEAUDIO_LIBRARY}"
                                                  INTERFACE_INCLUDE_DIRECTORIES "${PULSEAUDIO_INCLUDE_DIR}"
-                                                 INTERFACE_COMPILE_DEFINITIONS HAVE_LIBPULSE=1
+                                                 INTERFACE_COMPILE_DEFINITIONS HAS_PULSEAUDIO=1
                                                  INTERFACE_LINK_LIBRARIES "PulseAudio::PulseAudioMainloop;PulseAudio::PulseAudioSimple")
 
     set_property(GLOBAL APPEND PROPERTY INTERNAL_DEPS_PROP PulseAudio::PulseAudio)


### PR DESCRIPTION
## Description
Fixes #23952

## Motivation and context
Kept the wrong compile definition, that'll teach me to trust things

## How has this been tested?
N/A

## What is the effect on users?
Pulseaudio

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
