### PR TITLE
[imagecache] clarify logic around image revalidation, fixing some images returning 404 via HTTP

### DIFF
--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -296,7 +296,7 @@ void CTextureCache::OnCachingComplete(bool success, CTextureCacheJob *job)
 {
   if (success)
   {
-    if (job->m_details.id != -1 && job->m_oldHash == job->m_details.hash)
+    if (job->m_details.hashRevalidated)
       SetCachedTextureValid(job->m_url, job->m_details.updateable);
     else
       AddCachedTexture(job->m_url, job->m_details);

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -87,6 +87,9 @@ std::string CTextureCache::GetCachedImage(const std::string &image, CTextureDeta
   // lookup the item in the database
   if (GetCachedTexture(url, details))
   {
+    if (details.file.empty())
+      return "";
+
     if (trackUsage)
       IncrementUseCount(details);
     return GetCachedPath(details.file);

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -88,7 +88,7 @@ std::string CTextureCache::GetCachedImage(const std::string &image, CTextureDeta
   if (GetCachedTexture(url, details))
   {
     if (details.file.empty())
-      return "";
+      return {};
 
     if (trackUsage)
       IncrementUseCount(details);

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -118,7 +118,10 @@ bool CTextureCacheJob::CacheTexture(std::unique_ptr<CTexture>* out_texture)
       return false;
 
     if (m_details.hash == m_oldHash)
+    {
+      m_details.hashRevalidated = true;
       return true;
+    }
   }
 
   std::unique_ptr<CTexture> texture = LoadImage(image, width, height, additional_info, true);

--- a/xbmc/TextureCacheJob.h
+++ b/xbmc/TextureCacheJob.h
@@ -26,26 +26,20 @@ class CTexture;
 class CTextureDetails
 {
 public:
-  CTextureDetails()
-  {
-    id = -1;
-    width = height = 0;
-    updateable = false;
-    hashRevalidated = false;
-  };
   bool operator==(const CTextureDetails &right) const
   {
     return (id    == right.id    &&
             file  == right.file  &&
             width == right.width );
   };
-  int          id;
-  std::string  file;
-  std::string  hash;
-  unsigned int width;
-  unsigned int height;
-  bool         updateable;
-  bool hashRevalidated;
+
+  int id{-1};
+  std::string file;
+  std::string hash;
+  unsigned int width{0};
+  unsigned int height{0};
+  bool updateable{false};
+  bool hashRevalidated{false};
 };
 
 /*!

--- a/xbmc/TextureCacheJob.h
+++ b/xbmc/TextureCacheJob.h
@@ -31,6 +31,7 @@ public:
     id = -1;
     width = height = 0;
     updateable = false;
+    hashRevalidated = false;
   };
   bool operator==(const CTextureDetails &right) const
   {
@@ -44,6 +45,7 @@ public:
   unsigned int width;
   unsigned int height;
   bool         updateable;
+  bool hashRevalidated;
 };
 
 /*!


### PR DESCRIPTION
## Description
Use explicit logic when image hash is revalidated, rather than guessing from other properties.

## Motivation and context
Alpha adjustments around image caching fiddled with some fiddly logic and spawned an issue - in some combinations, a record in the image cache DB can be saved _without_ a path to the cached image, which then breaks viewing those images via HTTP, like the web UI or remote app. xbmc/Official-Kodi-Remote-iOS#940

## How has this been tested?
Quick test on Windows build, only early dogfooding yet. This is tough to pin down a clear reproduction case.

## What is the effect on users?
fix a bug

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
