### PR TITLE
[clang-tidy] modernize-use-emplace

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,7 @@ Checks: "\
   modernize-make-shared,\
   modernize-make-unique,\
   modernize-use-default-member-init,\
+  modernize-use-emplace,\
   performance-faster-string-find,\
   performance-for-range-copy,\
   performance-implicit-conversion-in-loop,\

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -9908,7 +9908,7 @@ void CGUIInfoManager::SplitInfoString(const std::string &infoString, std::vector
       if (!property.empty()) // add our property and parameters
       {
         StringUtils::ToLower(property);
-        info.emplace_back(Property(property, param));
+        info.emplace_back(property, param);
       }
       property.clear();
       param.clear();
@@ -9926,7 +9926,7 @@ void CGUIInfoManager::SplitInfoString(const std::string &infoString, std::vector
   if (!property.empty())
   {
     StringUtils::ToLower(property);
-    info.emplace_back(Property(property, param));
+    info.emplace_back(property, param);
   }
 }
 

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -140,16 +140,16 @@ bool CServiceManager::InitStageTwo(const std::string& profilesUserDataFolder)
 
   m_PVRManager = std::make_unique<PVR::CPVRManager>();
 
-  m_dataCacheCore.reset(new CDataCacheCore());
+  m_dataCacheCore = std::make_unique<CDataCacheCore>();
 
   m_binaryAddonCache = std::make_unique<ADDON::CBinaryAddonCache>();
   m_binaryAddonCache->Init();
 
-  m_favouritesService.reset(new CFavouritesService(profilesUserDataFolder));
+  m_favouritesService = std::make_unique<CFavouritesService>(profilesUserDataFolder);
 
   m_serviceAddons = std::make_unique<ADDON::CServiceAddonManager>(*m_addonMgr);
 
-  m_contextMenuManager.reset(new CContextMenuManager(*m_addonMgr));
+  m_contextMenuManager = std::make_unique<CContextMenuManager>(*m_addonMgr);
 
   m_gameControllerManager = std::make_unique<GAME::CControllerManager>(*m_addonMgr);
   m_inputManager = std::make_unique<CInputManager>();

--- a/xbmc/addons/addoninfo/AddonExtensions.cpp
+++ b/xbmc/addons/addoninfo/AddonExtensions.cpp
@@ -55,7 +55,7 @@ const EXT_ELEMENTS CAddonExtensions::GetElements(const std::string& id) const
   for (const auto& child : m_children)
   {
     if (child.first == id)
-      children.push_back(std::make_pair(child.first, child.second));
+      children.emplace_back(child.first, child.second);
   }
   return children;
 }
@@ -63,6 +63,6 @@ const EXT_ELEMENTS CAddonExtensions::GetElements(const std::string& id) const
 void CAddonExtensions::Insert(const std::string& id, const std::string& value)
 {
   EXT_VALUE extension;
-  extension.push_back(std::make_pair(id, SExtValue(value)));
-  m_values.push_back(std::make_pair(id, extension));
+  extension.emplace_back(id, SExtValue(value));
+  m_values.emplace_back(id, extension);
 }

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Game.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Game.h
@@ -52,21 +52,21 @@ public:
   {
     provides_input = layout.provides_input;
     for (unsigned int i = 0; i < layout.digital_button_count; ++i)
-      digital_buttons.push_back(layout.digital_buttons[i]);
+      digital_buttons.emplace_back(layout.digital_buttons[i]);
     for (unsigned int i = 0; i < layout.analog_button_count; ++i)
-      analog_buttons.push_back(layout.analog_buttons[i]);
+      analog_buttons.emplace_back(layout.analog_buttons[i]);
     for (unsigned int i = 0; i < layout.analog_stick_count; ++i)
-      analog_sticks.push_back(layout.analog_sticks[i]);
+      analog_sticks.emplace_back(layout.analog_sticks[i]);
     for (unsigned int i = 0; i < layout.accelerometer_count; ++i)
-      accelerometers.push_back(layout.accelerometers[i]);
+      accelerometers.emplace_back(layout.accelerometers[i]);
     for (unsigned int i = 0; i < layout.key_count; ++i)
-      keys.push_back(layout.keys[i]);
+      keys.emplace_back(layout.keys[i]);
     for (unsigned int i = 0; i < layout.rel_pointer_count; ++i)
-      rel_pointers.push_back(layout.rel_pointers[i]);
+      rel_pointers.emplace_back(layout.rel_pointers[i]);
     for (unsigned int i = 0; i < layout.abs_pointer_count; ++i)
-      abs_pointers.push_back(layout.abs_pointers[i]);
+      abs_pointers.emplace_back(layout.abs_pointers[i]);
     for (unsigned int i = 0; i < layout.motor_count; ++i)
-      motors.push_back(layout.motors[i]);
+      motors.emplace_back(layout.motors[i]);
   }
   /*! @endcond */
 
@@ -201,7 +201,7 @@ public:
     for (unsigned int i = 0; i < m_instanceData->props->proxy_dll_count; ++i)
     {
       if (m_instanceData->props->proxy_dll_paths[i] != nullptr)
-        paths.push_back(m_instanceData->props->proxy_dll_paths[i]);
+        paths.emplace_back(m_instanceData->props->proxy_dll_paths[i]);
     }
     return !paths.empty();
   }
@@ -223,7 +223,7 @@ public:
     for (unsigned int i = 0; i < m_instanceData->props->resource_directory_count; ++i)
     {
       if (m_instanceData->props->resource_directories[i] != nullptr)
-        dirs.push_back(m_instanceData->props->resource_directories[i]);
+        dirs.emplace_back(m_instanceData->props->resource_directories[i]);
     }
     return !dirs.empty();
   }
@@ -269,7 +269,7 @@ public:
     for (unsigned int i = 0; i < m_instanceData->props->extension_count; ++i)
     {
       if (m_instanceData->props->extensions[i] != nullptr)
-        extensions.push_back(m_instanceData->props->extensions[i]);
+        extensions.emplace_back(m_instanceData->props->extensions[i]);
     }
     return !extensions.empty();
   }
@@ -1079,7 +1079,7 @@ private:
     for (size_t i = 0; i < urlCount; ++i)
     {
       if (urls[i] != nullptr)
-        urlList.push_back(urls[i]);
+        urlList.emplace_back(urls[i]);
     }
 
     return static_cast<CInstanceGame*>(instance->toAddon->addonInstance)
@@ -1165,7 +1165,7 @@ private:
 
     std::vector<GameControllerLayout> controllerList;
     for (unsigned int i = 0; i < controller_count; ++i)
-      controllerList.push_back(controllers[i]);
+      controllerList.emplace_back(controllers[i]);
 
     static_cast<CInstanceGame*>(instance->toAddon->addonInstance)
         ->SetControllerLayouts(controllerList);

--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -350,7 +350,7 @@ bool CAddonSettings::Load(const CXBMCTinyXML& doc)
         settingValue = setting->FirstChild()->ValueStr();
 
       // add the setting to the map
-      settingValues.emplace(std::make_pair(settingId, settingValue));
+      settingValues.emplace(settingId, settingValue);
     };
 
     // check if there were any setting values without a definition
@@ -1106,7 +1106,7 @@ SettingPtr CAddonSettings::InitializeFromOldSettingSelect(
 
       StringSettingOptions options;
       for (const auto& value : values)
-        options.push_back(StringSettingOption(value, value));
+        options.emplace_back(value, value);
       settingString->SetOptions(options);
 
       setting = settingString;
@@ -1119,8 +1119,7 @@ SettingPtr CAddonSettings::InitializeFromOldSettingSelect(
 
       TranslatableIntegerSettingOptions options;
       for (uint32_t i = 0; i < values.size(); ++i)
-        options.push_back(TranslatableIntegerSettingOption(
-            static_cast<int>(strtol(values[i].c_str(), nullptr, 0)), i));
+        options.emplace_back(static_cast<int>(strtol(values[i].c_str(), nullptr, 0)), i);
       settingInt->SetTranslatableOptions(options);
 
       setting = settingInt;
@@ -1263,7 +1262,7 @@ SettingPtr CAddonSettings::InitializeFromOldSettingEnums(
         if (settingEntries.size() > i)
           value = static_cast<int>(strtol(settingEntries[i].c_str(), nullptr, 0));
 
-        options.push_back(IntegerSettingOption(label, value));
+        options.emplace_back(label, value);
       }
 
       settingInt->SetOptions(options);
@@ -1278,7 +1277,7 @@ SettingPtr CAddonSettings::InitializeFromOldSettingEnums(
         if (settingEntries.size() > i)
           value = static_cast<int>(strtol(settingEntries[i].c_str(), nullptr, 0));
 
-        options.push_back(TranslatableIntegerSettingOption(label, value));
+        options.emplace_back(label, value);
       }
 
       settingInt->SetTranslatableOptions(options);
@@ -1306,7 +1305,7 @@ SettingPtr CAddonSettings::InitializeFromOldSettingEnums(
         if (settingEntries.size() > i)
           value = settingEntries[i];
 
-        options.push_back(StringSettingOption(value, value));
+        options.emplace_back(value, value);
       }
 
       settingString->SetOptions(options);
@@ -1321,7 +1320,7 @@ SettingPtr CAddonSettings::InitializeFromOldSettingEnums(
         if (settingEntries.size() > i)
           value = settingEntries[i];
 
-        options.push_back(std::make_pair(label, value));
+        options.emplace_back(label, value);
       }
 
       settingString->SetTranslatableOptions(options);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -872,7 +872,7 @@ void CActiveAESink::EnumerateOutputDevices(AEDeviceList &devices, bool passthrou
       if (!devInfo.m_displayNameExtra.empty())
         ss << ", " << devInfo.m_displayNameExtra;
 
-      devices.push_back(AEDevice(ss.str(), device));
+      devices.emplace_back(ss.str(), device);
     }
   }
 }

--- a/xbmc/cores/AudioEngine/Sinks/osx/AEDeviceEnumerationOSX.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/osx/AEDeviceEnumerationOSX.cpp
@@ -220,11 +220,11 @@ CADeviceList AEDeviceEnumerationOSX::GetDeviceInfoList() const
         deviceInfo.m_deviceName = getDeviceNameForStream(streamIdx) + ":source" + sourceIdxStr.str();
         deviceInfo.m_displayNameExtra = m_caDevice.GetDataSourceName(sourceList[sourceIdx]);
         devInstance.sourceId = sourceList[sourceIdx];
-        list.push_back(std::make_pair(devInstance, deviceInfo));
+        list.emplace_back(devInstance, deviceInfo);
       }
     }
     else
-      list.push_back(std::make_pair(devInstance, deviceInfo));
+      list.emplace_back(devInstance, deviceInfo);
   }
   return list;
 }

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxMultiSource.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DemuxMultiSource.cpp
@@ -138,7 +138,7 @@ bool CDemuxMultiSource::Open(const std::shared_ptr<CDVDInputStream>& pInput)
 
       m_demuxerMap[demuxer->GetDemuxerId()] = demuxer;
       m_DemuxerToInputStreamMap[demuxer] = *iter;
-      m_demuxerQueue.push(std::make_pair(-1.0, demuxer));
+      m_demuxerQueue.emplace(-1.0, demuxer);
       ++iter;
     }
   }
@@ -175,7 +175,7 @@ DemuxPacket* CDemuxMultiSource::Read()
       readTime = packet->dts;
     else
       readTime = packet->pts;
-    m_demuxerQueue.push(std::make_pair(readTime, currentDemuxer));
+    m_demuxerQueue.emplace(readTime, currentDemuxer);
   }
   else
   {
@@ -188,7 +188,7 @@ DemuxPacket* CDemuxMultiSource::Read()
                   __FUNCTION__, CURL::GetRedacted(currentDemuxer->GetFileName()));
       }
       else    //maybe add an error counter?
-        m_demuxerQueue.push(std::make_pair(-1.0, currentDemuxer));
+        m_demuxerQueue.emplace(-1.0, currentDemuxer);
     }
   }
 
@@ -203,7 +203,7 @@ bool CDemuxMultiSource::SeekTime(double time, bool backwards, double* startpts)
   {
     if (iter.second->SeekTime(time, false, startpts))
     {
-      demuxerQueue.push(std::make_pair(*startpts, iter.second));
+      demuxerQueue.emplace(*startpts, iter.second);
       CLog::Log(LOGDEBUG, "{} - starting demuxer from: {:f}", __FUNCTION__, time);
       ret = true;
     }

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4832,7 +4832,7 @@ void CVideoPlayer::UpdatePlayState(double timeout)
         {
           std::string name;
           pChapter->GetChapterName(name, i + 1);
-          state.chapters.push_back(make_pair(name, pChapter->GetChapterPos(i + 1)));
+          state.chapters.emplace_back(name, pChapter->GetChapterPos(i + 1));
         }
       }
       CServiceBroker::GetDataCacheCore().SetChapters(state.chapters);

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -127,7 +127,7 @@ void CGUIDialogBusy::DoProcess(unsigned int currentTime, CDirtyRegionList &dirty
 {
   bool visible = CServiceBroker::GetGUI()->GetWindowManager().IsModalDialogTopmost(WINDOW_DIALOG_BUSY);
   if(!visible && m_bLastVisible)
-    dirtyregions.push_back(CDirtyRegion(m_renderRegion));
+    dirtyregions.emplace_back(m_renderRegion);
   m_bLastVisible = visible;
 
   CGUIDialog::DoProcess(currentTime, dirtyregions);

--- a/xbmc/dialogs/GUIDialogBusyNoCancel.cpp
+++ b/xbmc/dialogs/GUIDialogBusyNoCancel.cpp
@@ -33,7 +33,7 @@ void CGUIDialogBusyNoCancel::DoProcess(unsigned int currentTime, CDirtyRegionLis
 {
   bool visible = CServiceBroker::GetGUI()->GetWindowManager().IsModalDialogTopmost(WINDOW_DIALOG_BUSY_NOCANCEL);
   if (!visible && m_bLastVisible)
-    dirtyregions.push_back(CDirtyRegion(m_renderRegion));
+    dirtyregions.emplace_back(m_renderRegion);
   m_bLastVisible = visible;
 
   CGUIDialog::DoProcess(currentTime, dirtyregions);

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -437,9 +437,9 @@ void CGUIDialogMediaFilter::InitializeSettings()
         value = filter.rule->m_operator == CDatabaseQueryRule::OPERATOR_TRUE ? CHECK_YES : CHECK_NO;
 
       TranslatableIntegerSettingOptions entries;
-      entries.push_back(TranslatableIntegerSettingOption(CHECK_LABEL_ALL, CHECK_ALL));
-      entries.push_back(TranslatableIntegerSettingOption(CHECK_LABEL_NO, CHECK_NO));
-      entries.push_back(TranslatableIntegerSettingOption(CHECK_LABEL_YES, CHECK_YES));
+      entries.emplace_back(CHECK_LABEL_ALL, CHECK_ALL);
+      entries.emplace_back(CHECK_LABEL_NO, CHECK_NO);
+      entries.emplace_back(CHECK_LABEL_YES, CHECK_YES);
 
       filter.setting = AddSpinner(group, settingId, filter.label, SettingLevel::Basic, value, entries, true);
     }

--- a/xbmc/filesystem/DirectoryCache.cpp
+++ b/xbmc/filesystem/DirectoryCache.cpp
@@ -105,7 +105,7 @@ void CDirectoryCache::SetDirectory(const std::string& strPath, const CFileItemLi
   CDir dir(cacheType);
   dir.m_Items->Copy(items);
   dir.SetLastAccess(m_accessCounter);
-  m_cache.emplace(std::make_pair(storedPath, std::move(dir)));
+  m_cache.emplace(storedPath, std::move(dir));
 }
 
 void CDirectoryCache::ClearFile(const std::string& strFile)

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -126,7 +126,7 @@ bool CShoutcastFile::Open(const CURL& url)
     m_masterTag->SetGenre(icyGenre);
     m_masterTag->SetLoaded(true);
 
-    m_tags.push({1, m_masterTag});
+    m_tags.emplace(1, m_masterTag);
     m_tagChange.Set();
   }
 
@@ -304,7 +304,7 @@ bool CShoutcastFile::ExtractTagInfo(const char* buf)
       tag->SetTitle(title);
       tag->SetStationArt(coverURL);
 
-      m_tags.push({m_file.GetPosition(), tag});
+      m_tags.emplace(m_file.GetPosition(), tag);
       m_tagChange.Set();
     }
   }

--- a/xbmc/filesystem/XbtDirectory.cpp
+++ b/xbmc/filesystem/XbtDirectory.cpp
@@ -52,7 +52,7 @@ bool CXbtDirectory::GetDirectory(const CURL& urlOrig, CFileItemList& items)
   DirectorizeEntries<CXBTFFile> entries;
   entries.reserve(files.size());
   for (const auto& file : files)
-    entries.push_back(DirectorizeEntry<CXBTFFile>(file.GetPath(), file));
+    entries.emplace_back(file.GetPath(), file);
 
   Directorize(urlXbt, entries, XBTFFileToFileItem, items);
 

--- a/xbmc/filesystem/ZipDirectory.cpp
+++ b/xbmc/filesystem/ZipDirectory.cpp
@@ -53,7 +53,7 @@ namespace XFILE
     DirectorizeEntries<SZipEntry> entries;
     entries.reserve(zipEntries.size());
     for (const auto& zipEntry : zipEntries)
-      entries.push_back(DirectorizeEntry<SZipEntry>(zipEntry.name, zipEntry));
+      entries.emplace_back(zipEntry.name, zipEntry);
 
     // directorize the ZIP entries into files and directories
     Directorize(urlZip, entries, ZipEntryToFileItem, items);

--- a/xbmc/guilib/GUIColorManager.cpp
+++ b/xbmc/guilib/GUIColorManager.cpp
@@ -130,9 +130,8 @@ bool CGUIColorManager::LoadColorsListFromXML(
   {
     if (xmlColor->FirstChild() && xmlColor->Attribute("name"))
     {
-      colors.emplace_back(
-          std::make_pair(xmlColor->Attribute("name"),
-                         UTILS::COLOR::MakeColorInfo(xmlColor->FirstChild()->Value())));
+      colors.emplace_back(xmlColor->Attribute("name"),
+                          UTILS::COLOR::MakeColorInfo(xmlColor->FirstChild()->Value()));
     }
     xmlColor = xmlColor->NextSiblingElement("color");
   }

--- a/xbmc/guilib/GUIDialog.cpp
+++ b/xbmc/guilib/GUIDialog.cpp
@@ -114,7 +114,7 @@ void CGUIDialog::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregi
 
   // if we were running but now we're not, mark us dirty
   if (!m_active && m_wasRunning)
-    dirtyregions.push_back(CDirtyRegion(m_renderRegion));
+    dirtyregions.emplace_back(m_renderRegion);
 
   if (m_active)
     CGUIWindow::DoProcess(currentTime, dirtyregions);

--- a/xbmc/guilib/GUIRangesControl.cpp
+++ b/xbmc/guilib/GUIRangesControl.cpp
@@ -260,8 +260,8 @@ void CGUIRangesControl::SetRanges(const std::vector<std::pair<float, float>>& ra
 {
   ClearRanges();
   for (const auto& range : ranges)
-    m_ranges.emplace_back(CGUIRange(m_posX, m_posY, m_width, m_height,
-                                    m_guiLowerTextureInfo, m_guiFillTextureInfo, m_guiUpperTextureInfo, range));
+    m_ranges.emplace_back(m_posX, m_posY, m_width, m_height, m_guiLowerTextureInfo,
+                          m_guiFillTextureInfo, m_guiUpperTextureInfo, range);
 
   for (auto& range : m_ranges)
     range.AllocResources(); // note: we need to alloc the instance actually inserted into the vector; hence the second loop.
@@ -399,7 +399,7 @@ void CGUIRangesControl::UpdateInfo(const CGUIListItem* item /* = nullptr */)
           ++it;
 
           if (first <= second)
-            ranges.emplace_back(std::make_pair(first, second));
+            ranges.emplace_back(first, second);
           else
             CLog::Log(LOGERROR, "CGUIRangesControl::UpdateInfo - malformed ranges csv string (end element must be larger or equal than start element)");
         }

--- a/xbmc/guilib/GUIStaticItem.cpp
+++ b/xbmc/guilib/GUIStaticItem.cpp
@@ -37,10 +37,14 @@ CGUIStaticItem::CGUIStaticItem(const TiXmlElement *item, int parentID) : CFileIt
   SetLabel2(label2.GetLabel(parentID));
   SetArt("thumb", thumb.GetLabel(parentID, true));
   SetArt("icon", icon.GetLabel(parentID, true));
-  if (!label.IsConstant())  m_info.push_back(std::make_pair(label, "label"));
-  if (!label2.IsConstant()) m_info.push_back(std::make_pair(label2, "label2"));
-  if (!thumb.IsConstant())  m_info.push_back(std::make_pair(thumb, "thumb"));
-  if (!icon.IsConstant())   m_info.push_back(std::make_pair(icon, "icon"));
+  if (!label.IsConstant())
+    m_info.emplace_back(label, "label");
+  if (!label2.IsConstant())
+    m_info.emplace_back(label2, "label2");
+  if (!thumb.IsConstant())
+    m_info.emplace_back(thumb, "thumb");
+  if (!icon.IsConstant())
+    m_info.emplace_back(icon, "icon");
   m_iprogramCount = id ? atoi(id) : 0;
   // add any properties
   const TiXmlElement *property = item->FirstChildElement("property");
@@ -52,7 +56,7 @@ CGUIStaticItem::CGUIStaticItem(const TiXmlElement *item, int parentID) : CFileIt
     {
       SetProperty(name, prop.GetLabel(parentID, true).c_str());
       if (!prop.IsConstant())
-        m_info.push_back(std::make_pair(prop, name));
+        m_info.emplace_back(prop, name);
     }
     property = property->NextSiblingElement("property");
   }

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1518,7 +1518,7 @@ void CGUIWindowManager::SendThreadMessage(CGUIMessage& message, int window /*= 0
   std::unique_lock<CCriticalSection> lock(m_critSection);
 
   CGUIMessage* msg = new CGUIMessage(message);
-  m_vecThreadMessages.emplace_back(std::pair<CGUIMessage*, int>(msg,window));
+  m_vecThreadMessages.emplace_back(msg, window);
 }
 
 void CGUIWindowManager::DispatchThreadMessages()

--- a/xbmc/guilib/guiinfo/LibraryGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/LibraryGUIInfo.cpp
@@ -245,7 +245,7 @@ bool CLibraryGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contex
         {
           artistcount = db.GetArtistCountForRole(strRole);
           db.Close();
-          m_libraryRoleCounts.emplace_back(std::make_pair(strRole, artistcount));
+          m_libraryRoleCounts.emplace_back(strRole, artistcount);
         }
       }
       value = artistcount > 0;

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -667,7 +667,7 @@ std::vector<std::pair<float, float>> CPlayerGUIInfo::GetEditList(const CDataCach
   {
     float editStart = edit.start * 100.0f / duration;
     float editEnd = edit.end * 100.0f / duration;
-    ranges.emplace_back(std::make_pair(editStart, editEnd));
+    ranges.emplace_back(editStart, editEnd);
   }
   return ranges;
 }
@@ -683,7 +683,7 @@ std::vector<std::pair<float, float>> CPlayerGUIInfo::GetCuts(const CDataCacheCor
   {
     float marker = cut * 100.0f / duration;
     if (marker != 0)
-      ranges.emplace_back(std::make_pair(lastMarker, marker));
+      ranges.emplace_back(lastMarker, marker);
 
     lastMarker = marker;
   }
@@ -701,7 +701,7 @@ std::vector<std::pair<float, float>> CPlayerGUIInfo::GetSceneMarkers(const CData
   {
     float marker = scene * 100.0f / duration;
     if (marker != 0)
-      ranges.emplace_back(std::make_pair(lastMarker, marker));
+      ranges.emplace_back(lastMarker, marker);
 
     lastMarker = marker;
   }
@@ -719,7 +719,7 @@ std::vector<std::pair<float, float>> CPlayerGUIInfo::GetChapters(const CDataCach
   {
     float marker = chapter.second * 1000 * 100.0f / duration;
     if (marker != 0)
-      ranges.emplace_back(std::make_pair(lastMarker, marker));
+      ranges.emplace_back(lastMarker, marker);
 
     lastMarker = marker;
   }

--- a/xbmc/input/IRTranslator.cpp
+++ b/xbmc/input/IRTranslator.cpp
@@ -117,7 +117,7 @@ void CIRTranslator::MapRemote(tinyxml2::XMLNode* pRemote, const std::string& szD
     if (!pButton->NoChildren())
     {
       if (std::strcmp(pButton->Value(), "altname") == 0)
-        remoteNames.push_back(pButton->FirstChild()->Value());
+        remoteNames.emplace_back(pButton->FirstChild()->Value());
       else
         (*buttons)[pButton->FirstChild()->Value()] = pButton->Value();
     }

--- a/xbmc/music/dialogs/GUIDialogInfoProviderSettings.cpp
+++ b/xbmc/music/dialogs/GUIDialogInfoProviderSettings.cpp
@@ -408,15 +408,15 @@ void CGUIDialogInfoProviderSettings::InitializeSettings()
     entries.clear();
     if (m_singleScraperType == CONTENT_ALBUMS)
     {
-      entries.push_back(TranslatableIntegerSettingOption(38066, INFOPROVIDER_THISITEM));
-      entries.push_back(TranslatableIntegerSettingOption(38067, INFOPROVIDER_ALLVIEW));
+      entries.emplace_back(38066, INFOPROVIDER_THISITEM);
+      entries.emplace_back(38067, INFOPROVIDER_ALLVIEW);
     }
     else
     {
-      entries.push_back(TranslatableIntegerSettingOption(38064, INFOPROVIDER_THISITEM));
-      entries.push_back(TranslatableIntegerSettingOption(38065, INFOPROVIDER_ALLVIEW));
+      entries.emplace_back(38064, INFOPROVIDER_THISITEM);
+      entries.emplace_back(38065, INFOPROVIDER_ALLVIEW);
     }
-    entries.push_back(TranslatableIntegerSettingOption(38063, INFOPROVIDER_DEFAULT));
+    entries.emplace_back(38063, INFOPROVIDER_DEFAULT);
     AddList(group1, SETTING_APPLYTOITEMS, 38338, SettingLevel::Basic, m_applyToItems, entries, 38339); // "Apply settings to"
   }
 

--- a/xbmc/network/EventClient.cpp
+++ b/xbmc/network/EventClient.cpp
@@ -610,7 +610,7 @@ bool CEventClient::OnPacketACTION(CEventPacket *packet)
   case AT_BUTTON:
     {
       std::unique_lock<CCriticalSection> lock(m_critSection);
-      m_actionQueue.push(CEventAction(actionString.c_str(), actionType));
+      m_actionQueue.emplace(actionString.c_str(), actionType);
     }
     break;
 

--- a/xbmc/network/GUIDialogNetworkSetup.cpp
+++ b/xbmc/network/GUIDialogNetworkSetup.cpp
@@ -194,8 +194,7 @@ void CGUIDialogNetworkSetup::InitializeSettings()
   // Add our protocols
   TranslatableIntegerSettingOptions labels;
   for (size_t idx = 0; idx < m_protocols.size(); ++idx)
-    labels.push_back(
-        TranslatableIntegerSettingOption(m_protocols[idx].label, idx, m_protocols[idx].addonId));
+    labels.emplace_back(m_protocols[idx].label, idx, m_protocols[idx].addonId);
 
   AddSpinner(group, SETTING_PROTOCOL, 1008, SettingLevel::Basic, m_protocol, labels);
   AddEdit(group, SETTING_SERVER_ADDRESS, 1010, SettingLevel::Basic, m_server, true);

--- a/xbmc/network/httprequesthandler/HTTPImageTransformationHandler.cpp
+++ b/xbmc/network/httprequesthandler/HTTPImageTransformationHandler.cpp
@@ -150,12 +150,13 @@ MHD_RESULT CHTTPImageTransformationHandler::HandleRequest()
   // nothing else to do if the request is not ranged
   if (!GetRequestedRanges(m_response.totalLength))
   {
-    m_responseData.push_back(CHttpResponseRange(m_buffer, 0, m_response.totalLength - 1));
+    m_responseData.emplace_back(m_buffer, 0, m_response.totalLength - 1);
     return MHD_YES;
   }
 
   for (HttpRanges::const_iterator range = m_request.ranges.Begin(); range != m_request.ranges.End(); ++range)
-    m_responseData.push_back(CHttpResponseRange(m_buffer + range->GetFirstPosition(), range->GetFirstPosition(), range->GetLastPosition()));
+    m_responseData.emplace_back(m_buffer + range->GetFirstPosition(), range->GetFirstPosition(),
+                                range->GetLastPosition());
 
   return MHD_YES;
 }

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -395,7 +395,9 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
 
   // if we haven't processed yet, we should mark the whole screen
   if (!HasProcessed())
-    regions.push_back(CDirtyRegion(CRect(0.0f, 0.0f, (float)CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth(), (float)CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight())));
+    regions.emplace_back(CRect(
+        0.0f, 0.0f, static_cast<float>(CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth()),
+        static_cast<float>(CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight())));
 
   if (m_iCurrentSlide < 0 || m_iCurrentSlide >= static_cast<int>(m_slides.size()))
     m_iCurrentSlide = 0;
@@ -478,7 +480,9 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
 
   if (m_bErrorMessage)
   { // hack, just mark it all
-    regions.push_back(CDirtyRegion(CRect(0.0f, 0.0f, (float)CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth(), (float)CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight())));
+    regions.emplace_back(CRect(
+        0.0f, 0.0f, static_cast<float>(CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth()),
+        static_cast<float>(CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight())));
     return;
   }
 

--- a/xbmc/pictures/SlideShowPicture.cpp
+++ b/xbmc/pictures/SlideShowPicture.cpp
@@ -263,8 +263,8 @@ void CSlideShowPic::UpdateVertices(float cur_x[4], float cur_y[4], const float n
   || memcmp(cur_y, new_y, count)
   || m_bIsDirty)
   {
-    dirtyregions.push_back(CDirtyRegion(GetRectangle(cur_x, cur_y)));
-    dirtyregions.push_back(CDirtyRegion(GetRectangle(new_x, new_y)));
+    dirtyregions.emplace_back(GetRectangle(cur_x, cur_y));
+    dirtyregions.emplace_back(GetRectangle(new_x, new_y));
     memcpy(cur_x, new_x, count);
     memcpy(cur_y, new_y, count);
   }

--- a/xbmc/platform/darwin/ios-common/network/NetworkIOS.mm
+++ b/xbmc/platform/darwin/ios-common/network/NetworkIOS.mm
@@ -392,7 +392,7 @@ std::vector<std::string> CNetworkIOS::GetNameServers()
                       static_cast<socklen_t>(s.sin.sin_len), static_cast<char*>(hostBuffer),
                       sizeof(hostBuffer), nullptr, 0, NI_NUMERICHOST) == 0)
       {
-        nameServers.push_back(hostBuffer);
+        nameServers.emplace_back(hostBuffer);
       }
     }
   }

--- a/xbmc/platform/darwin/osx/storage/OSXStorageProvider.cpp
+++ b/xbmc/platform/darwin/osx/storage/OSXStorageProvider.cpp
@@ -325,11 +325,11 @@ bool COSXStorageProvider::PumpDriveChangeEvents(IStorageEventsCallback* callback
 void COSXStorageProvider::VolumeMountNotification(const char* label, const char* mountpoint)
 {
   if (label && mountpoint)
-    m_mountsToNotify.emplace_back(std::make_pair(label, mountpoint));
+    m_mountsToNotify.emplace_back(label, mountpoint);
 }
 
 void COSXStorageProvider::VolumeUnmountNotification(const char* label, const char* mountpoint)
 {
   if (label && mountpoint)
-   m_unmountsToNotify.emplace_back(std::make_pair(label, mountpoint));
+    m_unmountsToNotify.emplace_back(label, mountpoint);
 }

--- a/xbmc/platform/linux/input/LibInputSettings.cpp
+++ b/xbmc/platform/linux/input/LibInputSettings.cpp
@@ -124,7 +124,7 @@ CLibInputSettings::CLibInputSettings(CLibInputHandler *handler) :
     std::string layoutDescription = descriptionElement->GetText();
 
     if (!layout.empty() && !layoutDescription.empty())
-      layouts.emplace_back(StringSettingOption(layoutDescription, layout));
+      layouts.emplace_back(layoutDescription, layout);
 
     layoutElement = layoutElement->NextSiblingElement();
   }

--- a/xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
@@ -276,11 +276,11 @@ void CGUIDialogLockSettings::InitializeSettings()
     AddToggle(groupDetails, SETTING_LOCK_FILEMANAGER, 20042, SettingLevel::Basic, m_locks.files);
 
     TranslatableIntegerSettingOptions settingsLevelOptions;
-    settingsLevelOptions.push_back(TranslatableIntegerSettingOption(106, LOCK_LEVEL::NONE));
-    settingsLevelOptions.push_back(TranslatableIntegerSettingOption(593, LOCK_LEVEL::ALL));
-    settingsLevelOptions.push_back(TranslatableIntegerSettingOption(10037, LOCK_LEVEL::STANDARD));
-    settingsLevelOptions.push_back(TranslatableIntegerSettingOption(10038, LOCK_LEVEL::ADVANCED));
-    settingsLevelOptions.push_back(TranslatableIntegerSettingOption(10039, LOCK_LEVEL::EXPERT));
+    settingsLevelOptions.emplace_back(106, LOCK_LEVEL::NONE);
+    settingsLevelOptions.emplace_back(593, LOCK_LEVEL::ALL);
+    settingsLevelOptions.emplace_back(10037, LOCK_LEVEL::STANDARD);
+    settingsLevelOptions.emplace_back(10038, LOCK_LEVEL::ADVANCED);
+    settingsLevelOptions.emplace_back(10039, LOCK_LEVEL::EXPERT);
     AddList(groupDetails, SETTING_LOCK_SETTINGS, 20043, SettingLevel::Basic, static_cast<int>(m_locks.settings), settingsLevelOptions, 20043);
 
     AddToggle(groupDetails, SETTING_LOCK_ADDONMANAGER, 24090, SettingLevel::Basic, m_locks.addonManager);

--- a/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
@@ -347,11 +347,11 @@ void CGUIDialogProfileSettings::InitializeSettings()
     }
 
     TranslatableIntegerSettingOptions entries;
-    entries.push_back(TranslatableIntegerSettingOption(20062, 0));
-    entries.push_back(TranslatableIntegerSettingOption(20063, 1));
-    entries.push_back(TranslatableIntegerSettingOption(20061, 2));
+    entries.emplace_back(20062, 0);
+    entries.emplace_back(20063, 1);
+    entries.emplace_back(20061, 2);
     if (profileManager->GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE)
-      entries.push_back(TranslatableIntegerSettingOption(20107, 3));
+      entries.emplace_back(20107, 3);
 
     AddSpinner(groupMedia, SETTING_PROFILE_MEDIA, 20060, SettingLevel::Basic, m_dbMode, entries);
     AddSpinner(groupMedia, SETTING_PROFILE_MEDIA_SOURCES, 20094, SettingLevel::Basic, m_sourcesMode, entries);

--- a/xbmc/pvr/PVREventLogJob.cpp
+++ b/xbmc/pvr/PVREventLogJob.cpp
@@ -31,7 +31,7 @@ void CPVREventLogJob::AddEvent(bool bNotifyUser,
                                const std::string& msg,
                                const std::string& icon)
 {
-  m_events.emplace_back(Event(bNotifyUser, eLevel, label, msg, icon));
+  m_events.emplace_back(bNotifyUser, eLevel, label, msg, icon);
 }
 
 bool CPVREventLogJob::DoWork()

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -512,7 +512,7 @@ bool CPVRClients::GetAddonsWithStatus(
   for (const auto& addon : addons)
   {
     bool enabled = !CServiceBroker::GetAddonMgr().IsAddonDisabled(addon->ID());
-    addonsWithStatus.emplace_back(std::make_pair(addon, enabled));
+    addonsWithStatus.emplace_back(addon, enabled);
 
     if (!foundChangedAddon && addon->ID() == changedAddonId)
       foundChangedAddon = true;
@@ -539,8 +539,7 @@ std::vector<std::pair<ADDON::AddonInstanceId, bool>> CPVRClients::GetInstanceIds
     if (std::find(instanceIds.begin(), instanceIds.end(), knownInstanceId) == instanceIds.end())
     {
       // instance was removed
-      instanceIdsWithStatus.emplace_back(
-          std::pair<ADDON::AddonInstanceId, bool>(knownInstanceId, false));
+      instanceIdsWithStatus.emplace_back(knownInstanceId, false);
     }
   }
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
@@ -87,7 +87,7 @@ void CGUIDialogPVRGuideSearch::UpdateChannelSpin()
   int iSelectedChannel = EPG_SEARCH_UNSET;
   for (const auto& groupMember : groupMembers)
   {
-    labels.emplace_back(std::make_pair(groupMember->Channel()->ChannelName(), iIndex));
+    labels.emplace_back(groupMember->Channel()->ChannelName(), iIndex);
     m_channelsMap.insert(std::make_pair(iIndex, groupMember));
 
     if (iSelectedChannel == EPG_SEARCH_UNSET &&

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -974,8 +974,7 @@ void CGUIDialogPVRTimerSettings::ChannelsFiller(const SettingConstPtr& setting,
             !pThis->m_timerType->SupportsAnyChannel())
           continue;
 
-        list.emplace_back(
-            IntegerSettingOption(channelEntry.second.description, channelEntry.first));
+        list.emplace_back(channelEntry.second.description, channelEntry.first);
       }
 
       if (!foundCurrent && (pThis->m_channel == channelEntry.second))

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -892,13 +892,13 @@ void CPVREpgContainer::SetHasPendingUpdates(bool bHasPendingUpdates /* = true */
 void CPVREpgContainer::UpdateRequest(int iClientID, int iUniqueChannelID)
 {
   std::unique_lock<CCriticalSection> lock(m_updateRequestsLock);
-  m_updateRequests.emplace_back(CEpgUpdateRequest(iClientID, iUniqueChannelID));
+  m_updateRequests.emplace_back(iClientID, iUniqueChannelID);
 }
 
 void CPVREpgContainer::UpdateFromClient(const std::shared_ptr<CPVREpgInfoTag>& tag, EPG_EVENT_STATE eNewState)
 {
   std::unique_lock<CCriticalSection> lock(m_epgTagChangesLock);
-  m_epgTagChanges.emplace_back(CEpgTagStateChange(tag, eNewState));
+  m_epgTagChanges.emplace_back(tag, eNewState);
 }
 
 int CPVREpgContainer::GetPastDaysToDisplay() const

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -486,7 +486,7 @@ std::shared_ptr<CPVRChannelGroupMember> GetFirstMatchingGroupMember(
       if (channelGroup->IsDeleted())
         continue;
 
-      const std::shared_ptr<CPVRChannelGroupMember> groupMember{
+      std::shared_ptr<CPVRChannelGroupMember> groupMember{
           channelGroup->GetByUniqueID(channel->StorageId())};
       if (groupMember)
         return groupMember;

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -223,7 +223,7 @@ bool CPVRTimers::CheckAndAppendTimerNotification(
   {
     const std::string strMessage =
         bDeleted ? tag->GetDeletedNotificationText() : tag->GetNotificationText();
-    timerNotifications.emplace_back(std::make_pair(tag->ClientID(), strMessage));
+    timerNotifications.emplace_back(tag->ClientID(), strMessage);
     return true;
   }
   return false;
@@ -616,8 +616,8 @@ bool CPVRTimers::UpdateEntries(int iMaxNotificationDelay)
                 if (childTimer)
                 {
                   bChanged = true;
-                  childTimersToInsert.emplace_back(
-                      std::make_pair(timer, childTimer)); // remember and insert/save later
+                  childTimersToInsert.emplace_back(timer,
+                                                   childTimer); // remember and insert/save later
                 }
               }
             }
@@ -664,8 +664,8 @@ bool CPVRTimers::UpdateEntries(int iMaxNotificationDelay)
         if (childTimer)
         {
           bChanged = true;
-          childTimersToInsert.emplace_back(std::make_pair(
-              matcher->GetTimerRule(), childTimer)); // remember and insert/save later
+          childTimersToInsert.emplace_back(matcher->GetTimerRule(),
+                                           childTimer); // remember and insert/save later
         }
       }
     }

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -254,25 +254,29 @@ void CAdvancedSettings::Initialize()
 
   m_tvshowEnumRegExps.clear();
   // foo.s01.e01, foo.s01_e01, S01E02 foo, S01 - E02, S01xE02
-  m_tvshowEnumRegExps.push_back(TVShowRegexp(false,"s([0-9]+)[ ._x-]*e([0-9]+(?:(?:[a-i]|\\.[1-9])(?![0-9]))?)([^\\\\/]*)$"));
+  m_tvshowEnumRegExps.emplace_back(
+      false, "s([0-9]+)[ ._x-]*e([0-9]+(?:(?:[a-i]|\\.[1-9])(?![0-9]))?)([^\\\\/]*)$");
   // foo.ep01, foo.EP_01, foo.E01
-  m_tvshowEnumRegExps.push_back(TVShowRegexp(
-      false, "[\\._ -]?()e(?:p[ ._-]?)?([0-9]+(?:(?:[a-i]|\\.[1-9])(?![0-9]))?)([^\\\\/]*)$"));
+  m_tvshowEnumRegExps.emplace_back(
+      false, "[\\._ -]?()e(?:p[ ._-]?)?([0-9]+(?:(?:[a-i]|\\.[1-9])(?![0-9]))?)([^\\\\/]*)$");
   // foo.yyyy.mm.dd.* (byDate=true)
-  m_tvshowEnumRegExps.push_back(TVShowRegexp(true,"([0-9]{4})[\\.-]([0-9]{2})[\\.-]([0-9]{2})"));
+  m_tvshowEnumRegExps.emplace_back(true, "([0-9]{4})[\\.-]([0-9]{2})[\\.-]([0-9]{2})");
   // foo.mm.dd.yyyy.* (byDate=true)
-  m_tvshowEnumRegExps.push_back(TVShowRegexp(true,"([0-9]{2})[\\.-]([0-9]{2})[\\.-]([0-9]{4})"));
+  m_tvshowEnumRegExps.emplace_back(true, "([0-9]{2})[\\.-]([0-9]{2})[\\.-]([0-9]{4})");
   // foo.1x09* or just /1x09*
-  m_tvshowEnumRegExps.push_back(TVShowRegexp(false,"[\\\\/\\._ \\[\\(-]([0-9]+)x([0-9]+(?:(?:[a-i]|\\.[1-9])(?![0-9]))?)([^\\\\/]*)$"));
+  m_tvshowEnumRegExps.emplace_back(
+      false, "[\\\\/\\._ \\[\\(-]([0-9]+)x([0-9]+(?:(?:[a-i]|\\.[1-9])(?![0-9]))?)([^\\\\/]*)$");
   // Part I, Pt.VI, Part 1
-  m_tvshowEnumRegExps.push_back(TVShowRegexp(false,"[\\/._ -]p(?:ar)?t[_. -]()([ivx]+|[0-9]+)([._ -][^\\/]*)$"));
+  m_tvshowEnumRegExps.emplace_back(false,
+                                   "[\\/._ -]p(?:ar)?t[_. -]()([ivx]+|[0-9]+)([._ -][^\\/]*)$");
   // This regexp is for matching special episodes by their title, e.g. foo.special.mp4
-  m_tvshowEnumRegExps.push_back(
-      TVShowRegexp(false, "[\\\\/]([^\\\\/]+)\\.special\\.[a-z0-9]+$", 0, true));
+  m_tvshowEnumRegExps.emplace_back(false, "[\\\\/]([^\\\\/]+)\\.special\\.[a-z0-9]+$", 0, true);
 
   // foo.103*, 103 foo
   // XXX: This regex is greedy and will match years in show names.  It should always be last.
-  m_tvshowEnumRegExps.push_back(TVShowRegexp(false,"[\\\\/\\._ -]([0-9]+)([0-9][0-9](?:(?:[a-i]|\\.[1-9])(?![0-9]))?)([\\._ -][^\\\\/]*)$"));
+  m_tvshowEnumRegExps.emplace_back(
+      false,
+      "[\\\\/\\._ -]([0-9]+)([0-9][0-9](?:(?:[a-i]|\\.[1-9])(?![0-9]))?)([\\._ -][^\\\\/]*)$");
 
   m_tvshowMultiPartEnumRegExp = "^[-_ex]+([0-9]+(?:(?:[a-i]|\\.[1-9])(?![0-9]))?)";
 
@@ -1027,7 +1031,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
         CLog::Log(LOGDEBUG,"  Registering substitution pair:");
         CLog::Log(LOGDEBUG, "    From: [{}]", CURL::GetRedacted(strFrom));
         CLog::Log(LOGDEBUG, "    To:   [{}]", CURL::GetRedacted(strTo));
-        m_pathSubstitutions.push_back(std::make_pair(strFrom,strTo));
+        m_pathSubstitutions.emplace_back(strFrom, strTo);
       }
       else
       {
@@ -1301,7 +1305,7 @@ void CAdvancedSettings::GetCustomTVRegexps(TiXmlElement *pRootElement, SETTINGS_
         }
         else
         {
-          settings.push_back(TVShowRegexp(bByDate, regExp, iDefaultSeason, byTitle));
+          settings.emplace_back(bByDate, regExp, iDefaultSeason, byTitle);
         }
       }
       pRegExp = pRegExp->NextSibling("regexp");

--- a/xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
@@ -348,23 +348,21 @@ void CGUIDialogLibExportSettings::InitializeSettings()
 
   TranslatableIntegerSettingOptions entries;
 
-  entries.push_back(TranslatableIntegerSettingOption(38301, ELIBEXPORT_SINGLEFILE));
-  entries.push_back(TranslatableIntegerSettingOption(38303, ELIBEXPORT_TOLIBRARYFOLDER));
-  entries.push_back(TranslatableIntegerSettingOption(38302, ELIBEXPORT_SEPARATEFILES));
-  entries.push_back(TranslatableIntegerSettingOption(38321, ELIBEXPORT_ARTISTFOLDERS));
+  entries.emplace_back(38301, ELIBEXPORT_SINGLEFILE);
+  entries.emplace_back(38303, ELIBEXPORT_TOLIBRARYFOLDER);
+  entries.emplace_back(38302, ELIBEXPORT_SEPARATEFILES);
+  entries.emplace_back(38321, ELIBEXPORT_ARTISTFOLDERS);
   AddList(groupDetails, CSettings::SETTING_MUSICLIBRARY_EXPORT_FILETYPE, 38304, SettingLevel::Basic, m_settings.GetExportType(), entries, 38304); // "Choose kind of export output"
   AddButton(groupDetails, CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER, 38305, SettingLevel::Basic);
 
   entries.clear();
   if (!m_settings.IsArtistFoldersOnly())
-    entries.push_back(TranslatableIntegerSettingOption(132, ELIBEXPORT_ALBUMS)); //ablums
+    entries.emplace_back(132, ELIBEXPORT_ALBUMS); //ablums
   if (m_settings.IsSingleFile())
-    entries.push_back(TranslatableIntegerSettingOption(134, ELIBEXPORT_SONGS)); //songs
-  entries.push_back(
-      TranslatableIntegerSettingOption(38043, ELIBEXPORT_ALBUMARTISTS)); //album artists
-  entries.push_back(TranslatableIntegerSettingOption(38312, ELIBEXPORT_SONGARTISTS)); //song artists
-  entries.push_back(
-      TranslatableIntegerSettingOption(38313, ELIBEXPORT_OTHERARTISTS)); //other artists
+    entries.emplace_back(134, ELIBEXPORT_SONGS); //songs
+  entries.emplace_back(38043, ELIBEXPORT_ALBUMARTISTS); //album artists
+  entries.emplace_back(38312, ELIBEXPORT_SONGARTISTS); //song artists
+  entries.emplace_back(38313, ELIBEXPORT_OTHERARTISTS); //other artists
 
   std::vector<int> items;
   if (m_settings.IsArtistFoldersOnly())

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -124,8 +124,7 @@ static bool GetIntegerOptions(const SettingConstPtr& setting,
       const TranslatableIntegerSettingOptions& settingOptions =
           pSettingInt->GetTranslatableOptions();
       for (const auto& option : settingOptions)
-        options.push_back(
-            IntegerSettingOption(Localize(option.label, localizer, option.addonId), option.value));
+        options.emplace_back(Localize(option.label, localizer, option.addonId), option.value);
       break;
     }
 
@@ -163,7 +162,7 @@ static bool GetIntegerOptions(const SettingConstPtr& setting,
         else
           strLabel = StringUtils::Format(control->GetFormatString(), i);
 
-        options.push_back(IntegerSettingOption(strLabel, i));
+        options.emplace_back(strLabel, i);
       }
 
       break;
@@ -230,7 +229,7 @@ static bool GetStringOptions(const SettingConstPtr& setting,
       const TranslatableStringSettingOptions& settingOptions =
           pSettingString->GetTranslatableOptions();
       for (const auto& option : settingOptions)
-        options.push_back(StringSettingOption(Localize(option.first, localizer), option.second));
+        options.emplace_back(Localize(option.first, localizer), option.second);
       break;
     }
 

--- a/xbmc/utils/FileOperationJob.cpp
+++ b/xbmc/utils/FileOperationJob.cpp
@@ -101,7 +101,7 @@ bool CFileOperationJob::DoProcessFile(FileAction action, const std::string& strF
       time += data.st_size;
   }
 
-  fileOperations.push_back(CFileOperation(action, strFileA, strFileB, time));
+  fileOperations.emplace_back(action, strFileA, strFileB, time);
 
   totalTime += time;
 
@@ -135,7 +135,7 @@ bool CFileOperationJob::DoProcessFolder(FileAction action, const std::string& st
 
   if (action == ActionMove)
   {
-    fileOperations.push_back(CFileOperation(ActionDeleteFolder, strPath, "", 1));
+    fileOperations.emplace_back(ActionDeleteFolder, strPath, "", 1);
     totalTime += 1.0;
   }
 

--- a/xbmc/utils/HttpHeader.cpp
+++ b/xbmc/utils/HttpHeader.cpp
@@ -81,7 +81,7 @@ bool CHttpHeader::ParseLine(const std::string& headerLine)
     StringUtils::Trim(strValue, m_whitespaceChars);
 
     if (!strParam.empty() && !strValue.empty())
-      m_params.push_back(HeaderParams::value_type(strParam, strValue));
+      m_params.emplace_back(strParam, strValue);
     else
       return false;
   }
@@ -117,7 +117,7 @@ void CHttpHeader::AddParam(const std::string& param, const std::string& value, c
   if (valueTrim.empty())
     return;
 
-  m_params.push_back(HeaderParams::value_type(paramLower, valueTrim));
+  m_params.emplace_back(paramLower, valueTrim);
 }
 
 std::string CHttpHeader::GetValue(const std::string& strParam) const

--- a/xbmc/utils/HttpRangeUtils.cpp
+++ b/xbmc/utils/HttpRangeUtils.cpp
@@ -306,7 +306,7 @@ bool CHttpRanges::Parse(const std::string& header, uint64_t totalLength)
     if (end < start)
       return false;
 
-    m_ranges.push_back(CHttpRange(start, end));
+    m_ranges.emplace_back(start, end);
   }
 
   if (m_ranges.empty())

--- a/xbmc/utils/JobManager.cpp
+++ b/xbmc/utils/JobManager.cpp
@@ -118,9 +118,9 @@ bool CJobQueue::AddJob(CJob *job)
   }
 
   if (m_lifo)
-    m_jobQueue.push_back(CJobPointer(job));
+    m_jobQueue.emplace_back(job);
   else
-    m_jobQueue.push_front(CJobPointer(job));
+    m_jobQueue.emplace_front(job);
   QueueNextJob();
 
   return true;

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -189,15 +189,18 @@ TEST_F(TestURIUtils, SubstitutePath)
 
   from = "C:\\My Videos";
   to = "https://myserver/some%20other%20path";
-  CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_pathSubstitutions.push_back(std::make_pair(from, to));
+  CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_pathSubstitutions.emplace_back(
+      from, to);
 
   from = "/this/path1";
   to = "/some/other/path2";
-  CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_pathSubstitutions.push_back(std::make_pair(from, to));
+  CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_pathSubstitutions.emplace_back(
+      from, to);
 
   from = "davs://otherserver/my%20music%20path";
   to = "D:\\Local Music\\MP3 Collection";
-  CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_pathSubstitutions.push_back(std::make_pair(from, to));
+  CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_pathSubstitutions.emplace_back(
+      from, to);
 
   ref = "https://myserver/some%20other%20path/sub%20dir/movie%20name.avi";
   var = URIUtils::SubstitutePath("C:\\My Videos\\sub dir\\movie name.avi");

--- a/xbmc/utils/test/TestVariant.cpp
+++ b/xbmc/utils/test/TestVariant.cpp
@@ -294,7 +294,7 @@ TEST(TestVariant, empty)
 
   std::map<std::string, std::string> strmap;
   EXPECT_TRUE(CVariant(strmap).empty());
-  strmap.emplace(std::make_pair(std::string("key"), std::string("value")));
+  strmap.emplace(std::string("key"), std::string("value"));
   EXPECT_FALSE(CVariant(strmap).empty());
 
   std::string str;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -6819,7 +6819,7 @@ bool CVideoDatabase::GetMusicVideoAlbumsNav(const std::string& strBaseDir, CFile
           pItem->GetVideoInfoTag()->m_iDbId = idMVideo;
           items.Add(pItem);
           idMVideoList.push_back(idMVideo);
-          idData.push_back(make_pair(m_pDS->fv(0).get_asString(), m_pDS->fv(5).get_asString()));
+          idData.emplace_back(m_pDS->fv(0).get_asString(), m_pDS->fv(5).get_asString());
         }
       m_pDS->next();
     }

--- a/xbmc/video/dialogs/GUIDialogCMSSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogCMSSettings.cpp
@@ -122,9 +122,9 @@ void CGUIDialogCMSSettings::InitializeSettings()
   int currentMode = settings->GetInt(SETTING_VIDEO_CMSMODE);
   entries.clear();
   // entries.push_back(TranslatableIntegerSettingOption(16039, CMS_MODE_OFF)); // FIXME: get from CMS class
-  entries.push_back(TranslatableIntegerSettingOption(36580, CMS_MODE_3DLUT));
+  entries.emplace_back(36580, CMS_MODE_3DLUT);
 #ifdef HAVE_LCMS2
-  entries.push_back(TranslatableIntegerSettingOption(36581, CMS_MODE_PROFILE));
+  entries.emplace_back(36581, CMS_MODE_PROFILE);
 #endif
   std::shared_ptr<CSettingInt> settingCmsMode = AddSpinner(groupColorManagement, SETTING_VIDEO_CMSMODE, 36562, SettingLevel::Basic, currentMode, entries);
   settingCmsMode->SetDependencies(depsCmsEnabled);
@@ -136,29 +136,29 @@ void CGUIDialogCMSSettings::InitializeSettings()
   // display settings
   int currentWhitepoint = settings->GetInt(SETTING_VIDEO_CMSWHITEPOINT);
   entries.clear();
-  entries.push_back(TranslatableIntegerSettingOption(36586, CMS_WHITEPOINT_D65));
-  entries.push_back(TranslatableIntegerSettingOption(36587, CMS_WHITEPOINT_D93));
+  entries.emplace_back(36586, CMS_WHITEPOINT_D65);
+  entries.emplace_back(36587, CMS_WHITEPOINT_D93);
   std::shared_ptr<CSettingInt> settingCmsWhitepoint = AddSpinner(groupColorManagement, SETTING_VIDEO_CMSWHITEPOINT, 36568, SettingLevel::Basic, currentWhitepoint, entries);
   settingCmsWhitepoint->SetDependencies(depsCmsIcc);
 
   int currentPrimaries = settings->GetInt(SETTING_VIDEO_CMSPRIMARIES);
   entries.clear();
-  entries.push_back(TranslatableIntegerSettingOption(36588, CMS_PRIMARIES_AUTO));
-  entries.push_back(TranslatableIntegerSettingOption(36589, CMS_PRIMARIES_BT709));
-  entries.push_back(TranslatableIntegerSettingOption(36579, CMS_PRIMARIES_BT2020));
-  entries.push_back(TranslatableIntegerSettingOption(36590, CMS_PRIMARIES_170M));
-  entries.push_back(TranslatableIntegerSettingOption(36591, CMS_PRIMARIES_BT470M));
-  entries.push_back(TranslatableIntegerSettingOption(36592, CMS_PRIMARIES_BT470BG));
-  entries.push_back(TranslatableIntegerSettingOption(36593, CMS_PRIMARIES_240M));
+  entries.emplace_back(36588, CMS_PRIMARIES_AUTO);
+  entries.emplace_back(36589, CMS_PRIMARIES_BT709);
+  entries.emplace_back(36579, CMS_PRIMARIES_BT2020);
+  entries.emplace_back(36590, CMS_PRIMARIES_170M);
+  entries.emplace_back(36591, CMS_PRIMARIES_BT470M);
+  entries.emplace_back(36592, CMS_PRIMARIES_BT470BG);
+  entries.emplace_back(36593, CMS_PRIMARIES_240M);
   std::shared_ptr<CSettingInt> settingCmsPrimaries = AddSpinner(groupColorManagement, SETTING_VIDEO_CMSPRIMARIES, 36570, SettingLevel::Basic, currentPrimaries, entries);
   settingCmsPrimaries->SetDependencies(depsCmsIcc);
 
   int currentGammaMode = settings->GetInt(SETTING_VIDEO_CMSGAMMAMODE);
   entries.clear();
-  entries.push_back(TranslatableIntegerSettingOption(36582, CMS_TRC_BT1886));
-  entries.push_back(TranslatableIntegerSettingOption(36583, CMS_TRC_INPUT_OFFSET));
-  entries.push_back(TranslatableIntegerSettingOption(36584, CMS_TRC_OUTPUT_OFFSET));
-  entries.push_back(TranslatableIntegerSettingOption(36585, CMS_TRC_ABSOLUTE));
+  entries.emplace_back(36582, CMS_TRC_BT1886);
+  entries.emplace_back(36583, CMS_TRC_INPUT_OFFSET);
+  entries.emplace_back(36584, CMS_TRC_OUTPUT_OFFSET);
+  entries.emplace_back(36585, CMS_TRC_ABSOLUTE);
   std::shared_ptr<CSettingInt> settingCmsGammaMode = AddSpinner(groupColorManagement, SETTING_VIDEO_CMSGAMMAMODE, 36572, SettingLevel::Basic, currentGammaMode, entries);
   settingCmsGammaMode->SetDependencies(depsCmsIcc);
 
@@ -170,9 +170,9 @@ void CGUIDialogCMSSettings::InitializeSettings()
 
   int currentLutSize = settings->GetInt(SETTING_VIDEO_CMSLUTSIZE);
   entries.clear();
-  entries.push_back(TranslatableIntegerSettingOption(36594, 4));
-  entries.push_back(TranslatableIntegerSettingOption(36595, 6));
-  entries.push_back(TranslatableIntegerSettingOption(36596, 8));
+  entries.emplace_back(36594, 4);
+  entries.emplace_back(36595, 6);
+  entries.emplace_back(36596, 8);
   std::shared_ptr<CSettingInt> settingCmsLutSize = AddSpinner(groupColorManagement, SETTING_VIDEO_CMSLUTSIZE, 36576, SettingLevel::Basic, currentLutSize, entries);
   settingCmsLutSize->SetDependencies(depsCmsIcc);
 }

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -332,25 +332,22 @@ void CGUIDialogVideoSettings::InitializeSettings()
   TranslatableIntegerSettingOptions entries;
 
   entries.clear();
-  entries.push_back(TranslatableIntegerSettingOption(16039, VS_INTERLACEMETHOD_NONE));
-  entries.push_back(TranslatableIntegerSettingOption(16019, VS_INTERLACEMETHOD_AUTO));
-  entries.push_back(TranslatableIntegerSettingOption(20131, VS_INTERLACEMETHOD_RENDER_BLEND));
-  entries.push_back(TranslatableIntegerSettingOption(20129, VS_INTERLACEMETHOD_RENDER_WEAVE));
-  entries.push_back(TranslatableIntegerSettingOption(16021, VS_INTERLACEMETHOD_RENDER_BOB));
-  entries.push_back(TranslatableIntegerSettingOption(16020, VS_INTERLACEMETHOD_DEINTERLACE));
-  entries.push_back(TranslatableIntegerSettingOption(16036, VS_INTERLACEMETHOD_DEINTERLACE_HALF));
-  entries.push_back(
-      TranslatableIntegerSettingOption(16311, VS_INTERLACEMETHOD_VDPAU_TEMPORAL_SPATIAL));
-  entries.push_back(TranslatableIntegerSettingOption(16310, VS_INTERLACEMETHOD_VDPAU_TEMPORAL));
-  entries.push_back(TranslatableIntegerSettingOption(16325, VS_INTERLACEMETHOD_VDPAU_BOB));
-  entries.push_back(
-      TranslatableIntegerSettingOption(16318, VS_INTERLACEMETHOD_VDPAU_TEMPORAL_SPATIAL_HALF));
-  entries.push_back(
-      TranslatableIntegerSettingOption(16317, VS_INTERLACEMETHOD_VDPAU_TEMPORAL_HALF));
-  entries.push_back(TranslatableIntegerSettingOption(16327, VS_INTERLACEMETHOD_VAAPI_BOB));
-  entries.push_back(TranslatableIntegerSettingOption(16328, VS_INTERLACEMETHOD_VAAPI_MADI));
-  entries.push_back(TranslatableIntegerSettingOption(16329, VS_INTERLACEMETHOD_VAAPI_MACI));
-  entries.push_back(TranslatableIntegerSettingOption(16320, VS_INTERLACEMETHOD_DXVA_AUTO));
+  entries.emplace_back(16039, VS_INTERLACEMETHOD_NONE);
+  entries.emplace_back(16019, VS_INTERLACEMETHOD_AUTO);
+  entries.emplace_back(20131, VS_INTERLACEMETHOD_RENDER_BLEND);
+  entries.emplace_back(20129, VS_INTERLACEMETHOD_RENDER_WEAVE);
+  entries.emplace_back(16021, VS_INTERLACEMETHOD_RENDER_BOB);
+  entries.emplace_back(16020, VS_INTERLACEMETHOD_DEINTERLACE);
+  entries.emplace_back(16036, VS_INTERLACEMETHOD_DEINTERLACE_HALF);
+  entries.emplace_back(16311, VS_INTERLACEMETHOD_VDPAU_TEMPORAL_SPATIAL);
+  entries.emplace_back(16310, VS_INTERLACEMETHOD_VDPAU_TEMPORAL);
+  entries.emplace_back(16325, VS_INTERLACEMETHOD_VDPAU_BOB);
+  entries.emplace_back(16318, VS_INTERLACEMETHOD_VDPAU_TEMPORAL_SPATIAL_HALF);
+  entries.emplace_back(16317, VS_INTERLACEMETHOD_VDPAU_TEMPORAL_HALF);
+  entries.emplace_back(16327, VS_INTERLACEMETHOD_VAAPI_BOB);
+  entries.emplace_back(16328, VS_INTERLACEMETHOD_VAAPI_MADI);
+  entries.emplace_back(16329, VS_INTERLACEMETHOD_VAAPI_MACI);
+  entries.emplace_back(16320, VS_INTERLACEMETHOD_DXVA_AUTO);
 
   /* remove unsupported methods */
   for (TranslatableIntegerSettingOptions::iterator it = entries.begin(); it != entries.end(); )
@@ -372,25 +369,25 @@ void CGUIDialogVideoSettings::InitializeSettings()
   }
 
   entries.clear();
-  entries.push_back(TranslatableIntegerSettingOption(16301, VS_SCALINGMETHOD_NEAREST));
-  entries.push_back(TranslatableIntegerSettingOption(16302, VS_SCALINGMETHOD_LINEAR));
-  entries.push_back(TranslatableIntegerSettingOption(16303, VS_SCALINGMETHOD_CUBIC_B_SPLINE));
-  entries.push_back(TranslatableIntegerSettingOption(16314, VS_SCALINGMETHOD_CUBIC_MITCHELL));
-  entries.push_back(TranslatableIntegerSettingOption(16321, VS_SCALINGMETHOD_CUBIC_CATMULL));
-  entries.push_back(TranslatableIntegerSettingOption(16326, VS_SCALINGMETHOD_CUBIC_0_075));
-  entries.push_back(TranslatableIntegerSettingOption(16330, VS_SCALINGMETHOD_CUBIC_0_1));
-  entries.push_back(TranslatableIntegerSettingOption(16304, VS_SCALINGMETHOD_LANCZOS2));
-  entries.push_back(TranslatableIntegerSettingOption(16323, VS_SCALINGMETHOD_SPLINE36_FAST));
-  entries.push_back(TranslatableIntegerSettingOption(16315, VS_SCALINGMETHOD_LANCZOS3_FAST));
-  entries.push_back(TranslatableIntegerSettingOption(16322, VS_SCALINGMETHOD_SPLINE36));
-  entries.push_back(TranslatableIntegerSettingOption(16305, VS_SCALINGMETHOD_LANCZOS3));
-  entries.push_back(TranslatableIntegerSettingOption(16306, VS_SCALINGMETHOD_SINC8));
-  entries.push_back(TranslatableIntegerSettingOption(16307, VS_SCALINGMETHOD_BICUBIC_SOFTWARE));
-  entries.push_back(TranslatableIntegerSettingOption(16308, VS_SCALINGMETHOD_LANCZOS_SOFTWARE));
-  entries.push_back(TranslatableIntegerSettingOption(16309, VS_SCALINGMETHOD_SINC_SOFTWARE));
-  entries.push_back(TranslatableIntegerSettingOption(13120, VS_SCALINGMETHOD_VDPAU_HARDWARE));
-  entries.push_back(TranslatableIntegerSettingOption(16319, VS_SCALINGMETHOD_DXVA_HARDWARE));
-  entries.push_back(TranslatableIntegerSettingOption(16316, VS_SCALINGMETHOD_AUTO));
+  entries.emplace_back(16301, VS_SCALINGMETHOD_NEAREST);
+  entries.emplace_back(16302, VS_SCALINGMETHOD_LINEAR);
+  entries.emplace_back(16303, VS_SCALINGMETHOD_CUBIC_B_SPLINE);
+  entries.emplace_back(16314, VS_SCALINGMETHOD_CUBIC_MITCHELL);
+  entries.emplace_back(16321, VS_SCALINGMETHOD_CUBIC_CATMULL);
+  entries.emplace_back(16326, VS_SCALINGMETHOD_CUBIC_0_075);
+  entries.emplace_back(16330, VS_SCALINGMETHOD_CUBIC_0_1);
+  entries.emplace_back(16304, VS_SCALINGMETHOD_LANCZOS2);
+  entries.emplace_back(16323, VS_SCALINGMETHOD_SPLINE36_FAST);
+  entries.emplace_back(16315, VS_SCALINGMETHOD_LANCZOS3_FAST);
+  entries.emplace_back(16322, VS_SCALINGMETHOD_SPLINE36);
+  entries.emplace_back(16305, VS_SCALINGMETHOD_LANCZOS3);
+  entries.emplace_back(16306, VS_SCALINGMETHOD_SINC8);
+  entries.emplace_back(16307, VS_SCALINGMETHOD_BICUBIC_SOFTWARE);
+  entries.emplace_back(16308, VS_SCALINGMETHOD_LANCZOS_SOFTWARE);
+  entries.emplace_back(16309, VS_SCALINGMETHOD_SINC_SOFTWARE);
+  entries.emplace_back(13120, VS_SCALINGMETHOD_VDPAU_HARDWARE);
+  entries.emplace_back(16319, VS_SCALINGMETHOD_DXVA_HARDWARE);
+  entries.emplace_back(16316, VS_SCALINGMETHOD_AUTO);
 
   /* remove unsupported methods */
   for(TranslatableIntegerSettingOptions::iterator it = entries.begin(); it != entries.end(); )
@@ -443,10 +440,10 @@ void CGUIDialogVideoSettings::InitializeSettings()
   {
     const bool visible = !CServiceBroker::GetWinSystem()->IsHDRDisplaySettingEnabled();
     entries.clear();
-    entries.push_back(TranslatableIntegerSettingOption(36554, VS_TONEMAPMETHOD_OFF));
-    entries.push_back(TranslatableIntegerSettingOption(36555, VS_TONEMAPMETHOD_REINHARD));
-    entries.push_back(TranslatableIntegerSettingOption(36557, VS_TONEMAPMETHOD_ACES));
-    entries.push_back(TranslatableIntegerSettingOption(36558, VS_TONEMAPMETHOD_HABLE));
+    entries.emplace_back(36554, VS_TONEMAPMETHOD_OFF);
+    entries.emplace_back(36555, VS_TONEMAPMETHOD_REINHARD);
+    entries.emplace_back(36557, VS_TONEMAPMETHOD_ACES);
+    entries.emplace_back(36558, VS_TONEMAPMETHOD_HABLE);
 
     AddSpinner(groupVideo, SETTING_VIDEO_TONEMAP_METHOD, 36553, SettingLevel::Basic,
                videoSettings.m_ToneMapMethod, entries, false, visible);
@@ -457,9 +454,9 @@ void CGUIDialogVideoSettings::InitializeSettings()
 
   // stereoscopic settings
   entries.clear();
-  entries.push_back(TranslatableIntegerSettingOption(16316, RENDER_STEREO_MODE_OFF));
-  entries.push_back(TranslatableIntegerSettingOption(36503, RENDER_STEREO_MODE_SPLIT_HORIZONTAL));
-  entries.push_back(TranslatableIntegerSettingOption(36504, RENDER_STEREO_MODE_SPLIT_VERTICAL));
+  entries.emplace_back(16316, RENDER_STEREO_MODE_OFF);
+  entries.emplace_back(36503, RENDER_STEREO_MODE_SPLIT_HORIZONTAL);
+  entries.emplace_back(36504, RENDER_STEREO_MODE_SPLIT_VERTICAL);
   AddSpinner(groupStereoscopic, SETTING_VIDEO_STEREOSCOPICMODE, 36535, SettingLevel::Basic, videoSettings.m_StereoMode, entries);
   AddToggle(groupStereoscopic, SETTING_VIDEO_STEREOSCOPICINVERT, 36536, SettingLevel::Basic, videoSettings.m_StereoInvert);
 

--- a/xbmc/video/tags/VideoTagLoaderFFmpeg.cpp
+++ b/xbmc/video/tags/VideoTagLoaderFFmpeg.cpp
@@ -163,10 +163,9 @@ CInfoScanner::INFO_TYPE CVideoTagLoaderFFmpeg::LoadMKV(CVideoInfoTag& tag,
         continue;
       size_t size = m_fctx->streams[i]->attached_pic.size;
       if (art)
-        art->emplace_back(EmbeddedArt(m_fctx->streams[i]->attached_pic.data,
-                                      size, avtag->value, type));
+        art->emplace_back(m_fctx->streams[i]->attached_pic.data, size, avtag->value, type);
       else
-        tag.m_coverArt.emplace_back(EmbeddedArtInfo(size, avtag->value, type));
+        tag.m_coverArt.emplace_back(size, avtag->value, type);
     }
   }
 
@@ -258,10 +257,9 @@ CInfoScanner::INFO_TYPE CVideoTagLoaderFFmpeg::LoadMP4(CVideoInfoTag& tag,
     size_t size = m_fctx->streams[i]->attached_pic.size;
     const std::string type = "poster";
     if (art)
-      art->emplace_back(EmbeddedArt(m_fctx->streams[i]->attached_pic.data,
-                                    size, "image/png", type));
+      art->emplace_back(m_fctx->streams[i]->attached_pic.data, size, "image/png", type);
     else
-      tag.m_coverArt.emplace_back(EmbeddedArtInfo(size, "image/png", type));
+      tag.m_coverArt.emplace_back(size, "image/png", type);
   }
 
   return hasfull ? CInfoScanner::FULL_NFO : CInfoScanner::TITLE_NFO;

--- a/xbmc/video/test/TestVideoInfoScanner.cpp
+++ b/xbmc/video/test/TestVideoInfoScanner.cpp
@@ -52,7 +52,7 @@ TEST_P(TestVideoInfoScanner, EnumerateEpisodeItem)
   CFileItem item(entry.path, false);
   EPISODELIST expected;
   for (int i = 0; i < 3 && entry.episode[i]; i++)
-    expected.push_back(EPISODE(entry.season, entry.episode[i], 0, false));
+    expected.emplace_back(entry.season, entry.episode[i], 0, false);
 
   EPISODELIST result;
   ASSERT_TRUE(scanner.EnumerateEpisodeItem(&item, result));

--- a/xbmc/windowing/GraphicContext.cpp
+++ b/xbmc/windowing/GraphicContext.cpp
@@ -37,7 +37,7 @@ void CGraphicContext::SetOrigin(float x, float y)
   if (!m_origins.empty())
     m_origins.push(CPoint(x,y) + m_origins.top());
   else
-    m_origins.push(CPoint(x,y));
+    m_origins.emplace(x, y);
 
   AddTransform(TransformMatrix::CreateTranslation(x, y));
 }
@@ -718,10 +718,10 @@ void CGraphicContext::SetScalingResolution(const RESOLUTION_INFO &res, bool need
   // reset our origin and camera
   while (!m_origins.empty())
     m_origins.pop();
-  m_origins.push(CPoint(0, 0));
+  m_origins.emplace(0, 0);
   while (!m_cameras.empty())
     m_cameras.pop();
-  m_cameras.push(CPoint(0.5f*m_iScreenWidth, 0.5f*m_iScreenHeight));
+  m_cameras.emplace(0.5f * m_iScreenWidth, 0.5f * m_iScreenHeight);
   while (!m_stereoFactors.empty())
     m_stereoFactors.pop();
   m_stereoFactors.push(0.0f);

--- a/xbmc/windowing/WindowSystemFactory.cpp
+++ b/xbmc/windowing/WindowSystemFactory.cpp
@@ -38,5 +38,5 @@ std::unique_ptr<CWinSystemBase> CWindowSystemFactory::CreateWindowSystem(const s
 void CWindowSystemFactory::RegisterWindowSystem(
     const std::function<std::unique_ptr<CWinSystemBase>()>& createFunction, const std::string& name)
 {
-  m_windowSystems.emplace_back(std::make_pair(name, createFunction));
+  m_windowSystems.emplace_back(name, createFunction);
 }

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1346,7 +1346,7 @@ std::unique_ptr<CVideoSync> CWinSystemOSX::GetVideoSync(CVideoReferenceClock* cl
 std::vector<std::string> CWinSystemOSX::GetConnectedOutputs()
 {
   std::vector<std::string> outputs;
-  outputs.push_back(DEFAULT_SCREEN_NAME);
+  outputs.emplace_back(DEFAULT_SCREEN_NAME);
 
   // screen 0 is always the "Default" setting, avoid duplicating the available
   // screens here.
@@ -1356,7 +1356,7 @@ std::vector<std::string> CWinSystemOSX::GetConnectedOutputs()
     for (NSUInteger disp = 1; disp <= numDisplays - 1; disp++)
     {
       NSString* const dispName = screenNameForDisplay(disp);
-      outputs.push_back(dispName.UTF8String);
+      outputs.emplace_back(dispName.UTF8String);
     }
   }
 

--- a/xbmc/windowing/wayland/XkbcommonKeymap.cpp
+++ b/xbmc/windowing/wayland/XkbcommonKeymap.cpp
@@ -311,8 +311,7 @@ std::unique_ptr<CXkbcommonKeymap> CXkbcommonContext::LocalizedKeymapFromString(
     CLog::LogF(LOGWARNING,
                "Failed to compile localized compose table, composed key support will be disabled");
   }
-  return std::unique_ptr<CXkbcommonKeymap>{
-      new CXkbcommonKeymap(std::move(xkbKeymap), std::move(xkbComposeTable))};
+  return std::make_unique<CXkbcommonKeymap>(std::move(xkbKeymap), std::move(xkbComposeTable));
 }
 
 std::unique_ptr<xkb_state, CXkbcommonKeymap::XkbStateDeleter> CXkbcommonKeymap::


### PR DESCRIPTION
## Description
apply and enable `modernize-use-emplace` clang-tidy check

## How has this been tested?
run clang-tidy and compiled for Android (aarch64), iOS, Linux (gl and gles), macOS and tvOS

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
