### PR TITLE
[playlistplayer] Fix PVR items not handled correctly. Those need to b…

### DIFF
--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -958,7 +958,7 @@ void PLAYLIST::CPlayListPlayer::OnApplicationMessage(KODI::MESSAGING::ThreadMess
           {
             return;
           }
-          if (item->IsAudio() || item->IsVideo())
+          if (!item->IsPVR() && (item->IsAudio() || item->IsVideo()))
             Play(item, pMsg->strParam);
           else
             g_application.PlayMedia(*item, pMsg->strParam, playlistId);


### PR DESCRIPTION
…e played using CApplication::PlayMedia

Fixes a problem reported in the Forum: https://forum.kodi.tv/showthread.php?tid=374760&pid=3169494#pid3169494

No regression, something that according to my code analysis never worked for pvr add-ons providing playback parameters using `GetChannelStreamProperties` resp. `GetRecordingStreamProperties`API call.

Runtime-tested on macOS, latest Kodi master + latest (Testflight) "Kodi Remote" app on iPhone.

@phunkyfish something for you to review.