### PR TITLE
[cores] Fix CDVDInputStreamBluray::Open check for item being resumable.

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -332,7 +332,7 @@ bool CDVDInputStreamBluray::Open()
     m_navmode = false;
     m_titleInfo = GetTitleLongest();
   }
-  else if (resumable && m_item.GetStartOffset() == STARTOFFSET_RESUME)
+  else if (resumable && m_item.GetStartOffset() == STARTOFFSET_RESUME && m_item.IsResumable())
   {
     // resuming a bluray for which we have a saved state - the playlist will be open later on SetState
     m_navmode = false;


### PR DESCRIPTION
Not much to say, fixes #23965 

Runtime-tested on macOS, latest Kodi master.

@enen92 can you have a look? The change imo is straight forward, check whether you actually can resume before trying. `STARTOFFSET_RESUME` value only means that we want to resume, not that we actually can.