### PR TITLE
[video] CGUIWindowVideoBase::OnItemInfo: Skip check whether a video i…

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -240,11 +240,12 @@ bool CGUIWindowVideoBase::OnItemInfo(const CFileItem& fileItem)
   bool foundDirectly = false;
   const ADDON::ScraperPtr scraper = m_database.GetScraperForPath(strDir, settings, foundDirectly);
 
-  if (!scraper && !(fileItem.IsPlugin() || fileItem.IsScript()) &&
+  if (!fileItem.HasVideoInfoTag() && !scraper && !(fileItem.IsPlugin() || fileItem.IsScript()) &&
       !(m_database.HasMovieInfo(fileItem.GetDynPath()) || m_database.HasTvShowInfo(strDir) ||
         m_database.HasEpisodeInfo(fileItem.GetDynPath()) ||
         m_database.HasMusicVideoInfo(fileItem.GetDynPath())))
   {
+    // We have no chance to fill a video info tag, neither scraper nor db data available.
     HELPERS::ShowOKDialogText(CVariant{20176}, // Show video information
                               CVariant{19055}); // no information available
     m_database.Close();


### PR DESCRIPTION
…nfo tag can be filled in case we already have one.

Fixes an issue reported in the Forum: https://forum.kodi.tv/showthread.php?tid=374771

Runtime-tested by me and the issue reporter (test build), confirming the issue fixed.

@enen92 another some glitch that sneaked in while the recent larger refactoring. 