### PR TITLE
[PVR] Fix playing channel not always highlighted in dialogs/windows.

### DIFF
--- a/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
@@ -428,7 +428,7 @@ std::string CPVRGUIActionsChannels::GetSelectedChannelPath(bool bRadio) const
     const std::shared_ptr<CPVRChannelGroupMember> playingChannel =
         mgr.PlaybackState()->GetPlayingChannelGroupMember();
     if (playingChannel && playingChannel->IsRadio() == bRadio)
-      return playingChannel->Path();
+      return GetChannelGroupMember(playingChannel->Channel())->Path();
 
     const std::shared_ptr<CPVREpgInfoTag> playingTag = mgr.PlaybackState()->GetPlayingEpgTag();
     if (playingTag && playingTag->IsRadio() == bRadio)

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -1565,6 +1565,19 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item,
         return true;
       }
       break;
+    case LISTITEM_ISPLAYING:
+      if (item->IsPVRChannel())
+      {
+        const std::shared_ptr<CPVRChannel> playingChannel{
+            CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel()};
+        if (playingChannel)
+        {
+          const std::shared_ptr<CPVRChannel> channel{item->GetPVRChannelInfoTag()};
+          bValue = (channel->StorageId() == playingChannel->StorageId());
+          return true;
+        }
+      }
+      break;
     case MUSICPLAYER_CONTENT:
     case VIDEOPLAYER_CONTENT:
       if (item->IsPVRChannel())


### PR DESCRIPTION
Fixes #23968 - take 2.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish something for you to review, thanks.

@Uukrull could you runtime-test and report back, please?