### PR TITLE
Fix Visual Studio warnings

### DIFF
--- a/xbmc/rendering/RenderSystem.cpp
+++ b/xbmc/rendering/RenderSystem.cpp
@@ -65,8 +65,9 @@ void CRenderSystemBase::ShowSplash(const std::string& message)
   if (!m_splashImage)
   {
     m_splashImage = std::make_unique<CGUIImage>(
-        0, 0, 0, 0, CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth(),
-        CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight(),
+        0, 0, .0f, .0f,
+        static_cast<float>(CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth()),
+        static_cast<float>(CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight()),
         CTextureInfo(CUtil::GetSplashPath()));
     m_splashImage->SetAspectRatio(CAspectRatio::AR_SCALE);
   }
@@ -90,7 +91,7 @@ void CRenderSystemBase::ShowSplash(const std::string& message)
     {
       auto messageFont = g_fontManager.LoadTTF("__splash__", "arial.ttf", 0xFFFFFFFF, 0, 20, FONT_STYLE_NORMAL, false, 1.0f, 1.0f, &res);
       if (messageFont)
-        m_splashMessageLayout = std::make_unique<CGUITextLayout>(messageFont, true, 0);
+        m_splashMessageLayout = std::make_unique<CGUITextLayout>(messageFont, true, .0f);
     }
 
     if (m_splashMessageLayout)

--- a/xbmc/windows/GUIWindowSplash.cpp
+++ b/xbmc/windows/GUIWindowSplash.cpp
@@ -28,10 +28,11 @@ void CGUIWindowSplash::OnInitWindow()
   if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_splashImage)
     return;
 
-  m_image = std::make_unique<CGUIImage>(0, 0, 0, 0,
-                                        CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth(),
-                                        CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight(),
-                                        CTextureInfo(CUtil::GetSplashPath()));
+  m_image = std::make_unique<CGUIImage>(
+      0, 0, .0f, .0f,
+      static_cast<float>(CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth()),
+      static_cast<float>(CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight()),
+      CTextureInfo(CUtil::GetSplashPath()));
   m_image->SetAspectRatio(CAspectRatio::AR_SCALE);
 }
 


### PR DESCRIPTION
## Description
Fix Visual Studio warnings

## Motivation and context
```
18:11:11 C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\include\memory(3433,56): warning C4244: 'argument': conversion from '_Ty' to 'float', possible loss of data [C:\jenkins-workspace\workspace\WIN-64\kodi-build.x64\libkodi.vcxproj]
18:11:11           with
18:11:11           [
18:11:11               _Ty=int
18:11:11           ] (compiling source file C:\jenkins-workspace\workspace\WIN-64\xbmc\rendering\RenderSystem.cpp)
18:11:11 C:\jenkins-workspace\workspace\WIN-64\xbmc\rendering\RenderSystem.cpp(70,1): message : see reference to function template instantiation 'std::unique_ptr<CGUIImage,std::default_delete<CGUIImage>> std::make_unique<CGUIImage,int,int,int,int,int,int,CTextureInfo,0>(int &&,int &&,int &&,int &&,int &&,int &&,CTextureInfo &&)' being compiled [C:\jenkins-workspace\workspace\WIN-64\kodi-build.x64\libkodi.vcxproj]
```

```
18:11:28 C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\include\memory(3433,56): warning C4244: 'argument': conversion from '_Ty' to 'float', possible loss of data [C:\jenkins-workspace\workspace\WIN-64\kodi-build.x64\libkodi.vcxproj]
18:11:28           with
18:11:28           [
18:11:28               _Ty=int
18:11:28           ] (compiling source file C:\jenkins-workspace\workspace\WIN-64\xbmc\windows\GUIWindowSplash.cpp)
18:11:28 C:\jenkins-workspace\workspace\WIN-64\xbmc\windows\GUIWindowSplash.cpp(34,1): message : see reference to function template instantiation 'std::unique_ptr<CGUIImage,std::default_delete<CGUIImage>> std::make_unique<CGUIImage,int,int,int,int,int,int,CTextureInfo,0>(int &&,int &&,int &&,int &&,int &&,int &&,CTextureInfo &&)' being compiled [C:\jenkins-workspace\workspace\WIN-64\kodi-build.x64\libkodi.vcxproj]
```

## How has this been tested?
Build Windows x64

## What is the effect on users?
none

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
