### PR TITLE
[Android] Change the directory used to verify the SDK path

### DIFF
--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -570,7 +570,7 @@ if test "$platform_os" = "android"; then
     AC_MSG_ERROR("SDK path is required for android")
   fi
 
-  if [ ! test -f $use_sdk_path/tools/bin/sdkmanager ]; then
+  if [ ! test -f $use_sdk_path/tools/bin/sdkmanager ] && [ ! test -f $use_sdk_path/cmdline-tools/bin/sdkmanager ]; then
     AC_MSG_ERROR(verify sdk path)
   fi
 


### PR DESCRIPTION
## Description
The configure script checks the path provided in the `--with-sdk-path` parameter is the Android SDK. The script checks for the existence of `tools/bin/sdkmanager` in this path.

The "tools" directory belongs to the [SDK Tools](https://developer.android.com/tools/releases/sdk-tools) package. This package is obsolete and no longer needed in current versions of build-tools, so it's preferable to check with the "cmdline-tools" directory that belongs to the SDK Command-Line tools package.

## Motivation and context
Fixes SDK path verification error message when configuring the build for the first time on a clean install.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
