### PR TITLE
Format GUIControlFactory.cpp/h

### DIFF
--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -106,7 +106,7 @@ static const ControlMapping controls[] = {
     {"wraplist", CGUIControl::GUICONTAINER_WRAPLIST},
 };
 
-CGUIControl::GUICONTROLTYPES CGUIControlFactory::TranslateControlType(const std::string &type)
+CGUIControl::GUICONTROLTYPES CGUIControlFactory::TranslateControlType(const std::string& type)
 {
   for (const ControlMapping& control : controls)
     if (StringUtils::EqualsNoCase(type, control.name))
@@ -126,10 +126,15 @@ CGUIControlFactory::CGUIControlFactory(void) = default;
 
 CGUIControlFactory::~CGUIControlFactory(void) = default;
 
-bool CGUIControlFactory::GetIntRange(const TiXmlNode* pRootNode, const char* strTag, int& iMinValue, int& iMaxValue, int& iIntervalValue)
+bool CGUIControlFactory::GetIntRange(const TiXmlNode* pRootNode,
+                                     const char* strTag,
+                                     int& iMinValue,
+                                     int& iMaxValue,
+                                     int& iIntervalValue)
 {
   const TiXmlNode* pNode = pRootNode->FirstChild(strTag);
-  if (!pNode || !pNode->FirstChild()) return false;
+  if (!pNode || !pNode->FirstChild())
+    return false;
   iMinValue = atoi(pNode->FirstChild()->Value());
   const char* maxValue = strchr(pNode->FirstChild()->Value(), ',');
   if (maxValue)
@@ -148,10 +153,15 @@ bool CGUIControlFactory::GetIntRange(const TiXmlNode* pRootNode, const char* str
   return true;
 }
 
-bool CGUIControlFactory::GetFloatRange(const TiXmlNode* pRootNode, const char* strTag, float& fMinValue, float& fMaxValue, float& fIntervalValue)
+bool CGUIControlFactory::GetFloatRange(const TiXmlNode* pRootNode,
+                                       const char* strTag,
+                                       float& fMinValue,
+                                       float& fMaxValue,
+                                       float& fIntervalValue)
 {
   const TiXmlNode* pNode = pRootNode->FirstChild(strTag);
-  if (!pNode || !pNode->FirstChild()) return false;
+  if (!pNode || !pNode->FirstChild())
+    return false;
   fMinValue = (float)atof(pNode->FirstChild()->Value());
   const char* maxValue = strchr(pNode->FirstChild()->Value(), ',');
   if (maxValue)
@@ -184,33 +194,50 @@ float CGUIControlFactory::ParsePosition(const char* pos, const float parentSize)
   return value;
 }
 
-bool CGUIControlFactory::GetPosition(const TiXmlNode *node, const char* strTag, const float parentSize, float& value)
+bool CGUIControlFactory::GetPosition(const TiXmlNode* node,
+                                     const char* strTag,
+                                     const float parentSize,
+                                     float& value)
 {
   const TiXmlElement* pNode = node->FirstChildElement(strTag);
-  if (!pNode || !pNode->FirstChild()) return false;
+  if (!pNode || !pNode->FirstChild())
+    return false;
 
   value = ParsePosition(pNode->FirstChild()->Value(), parentSize);
   return true;
 }
 
-bool CGUIControlFactory::GetDimension(const TiXmlNode *pRootNode, const char* strTag, const float parentSize, float &value, float &min)
+bool CGUIControlFactory::GetDimension(const TiXmlNode* pRootNode,
+                                      const char* strTag,
+                                      const float parentSize,
+                                      float& value,
+                                      float& min)
 {
   const TiXmlElement* pNode = pRootNode->FirstChildElement(strTag);
-  if (!pNode || !pNode->FirstChild()) return false;
+  if (!pNode || !pNode->FirstChild())
+    return false;
   if (0 == StringUtils::CompareNoCase("auto", pNode->FirstChild()->Value(), 4))
   { // auto-width - at least min must be set
     value = ParsePosition(pNode->Attribute("max"), parentSize);
     min = ParsePosition(pNode->Attribute("min"), parentSize);
-    if (!min) min = 1;
+    if (!min)
+      min = 1;
     return true;
   }
   value = ParsePosition(pNode->FirstChild()->Value(), parentSize);
   return true;
 }
 
-bool CGUIControlFactory::GetDimensions(const TiXmlNode *node, const char *leftTag, const char *rightTag, const char *centerLeftTag,
-                                       const char *centerRightTag, const char *widthTag, const float parentSize, float &left,
-                                       float &width, float &min_width)
+bool CGUIControlFactory::GetDimensions(const TiXmlNode* node,
+                                       const char* leftTag,
+                                       const char* rightTag,
+                                       const char* centerLeftTag,
+                                       const char* centerRightTag,
+                                       const char* widthTag,
+                                       const float parentSize,
+                                       float& left,
+                                       float& width,
+                                       float& min_width)
 {
   float center = 0, right = 0;
 
@@ -236,7 +263,7 @@ bool CGUIControlFactory::GetDimensions(const TiXmlNode *node, const char *leftTa
     {
       if (hasWidth)
       {
-        left = center - width/2;
+        left = center - width / 2;
         hasLeft = true;
       }
       else
@@ -276,7 +303,7 @@ bool CGUIControlFactory::GetDimensions(const TiXmlNode *node, const char *leftTa
       else if (center > 0 && center < parentSize)
       { // centre given, so fill to edge of parent
         width = std::max(0.0f, std::min(parentSize - center, center) * 2);
-        left = center - width/2;
+        left = center - width / 2;
         hasLeft = true;
         hasWidth = true;
       }
@@ -290,34 +317,46 @@ bool CGUIControlFactory::GetDimensions(const TiXmlNode *node, const char *leftTa
   return hasLeft && hasWidth;
 }
 
-bool CGUIControlFactory::GetAspectRatio(const TiXmlNode* pRootNode, const char* strTag, CAspectRatio &aspect)
+bool CGUIControlFactory::GetAspectRatio(const TiXmlNode* pRootNode,
+                                        const char* strTag,
+                                        CAspectRatio& aspect)
 {
   std::string ratio;
-  const TiXmlElement *node = pRootNode->FirstChildElement(strTag);
+  const TiXmlElement* node = pRootNode->FirstChildElement(strTag);
   if (!node || !node->FirstChild())
     return false;
 
   ratio = node->FirstChild()->Value();
-  if (StringUtils::EqualsNoCase(ratio, "keep")) aspect.ratio = CAspectRatio::AR_KEEP;
-  else if (StringUtils::EqualsNoCase(ratio, "scale")) aspect.ratio = CAspectRatio::AR_SCALE;
-  else if (StringUtils::EqualsNoCase(ratio, "center")) aspect.ratio = CAspectRatio::AR_CENTER;
-  else if (StringUtils::EqualsNoCase(ratio, "stretch")) aspect.ratio = CAspectRatio::AR_STRETCH;
+  if (StringUtils::EqualsNoCase(ratio, "keep"))
+    aspect.ratio = CAspectRatio::AR_KEEP;
+  else if (StringUtils::EqualsNoCase(ratio, "scale"))
+    aspect.ratio = CAspectRatio::AR_SCALE;
+  else if (StringUtils::EqualsNoCase(ratio, "center"))
+    aspect.ratio = CAspectRatio::AR_CENTER;
+  else if (StringUtils::EqualsNoCase(ratio, "stretch"))
+    aspect.ratio = CAspectRatio::AR_STRETCH;
 
-  const char *attribute = node->Attribute("align");
+  const char* attribute = node->Attribute("align");
   if (attribute)
   {
     std::string align(attribute);
-    if (StringUtils::EqualsNoCase(align, "center")) aspect.align = ASPECT_ALIGN_CENTER | (aspect.align & ASPECT_ALIGNY_MASK);
-    else if (StringUtils::EqualsNoCase(align, "right")) aspect.align = ASPECT_ALIGN_RIGHT | (aspect.align & ASPECT_ALIGNY_MASK);
-    else if (StringUtils::EqualsNoCase(align, "left")) aspect.align = ASPECT_ALIGN_LEFT | (aspect.align & ASPECT_ALIGNY_MASK);
+    if (StringUtils::EqualsNoCase(align, "center"))
+      aspect.align = ASPECT_ALIGN_CENTER | (aspect.align & ASPECT_ALIGNY_MASK);
+    else if (StringUtils::EqualsNoCase(align, "right"))
+      aspect.align = ASPECT_ALIGN_RIGHT | (aspect.align & ASPECT_ALIGNY_MASK);
+    else if (StringUtils::EqualsNoCase(align, "left"))
+      aspect.align = ASPECT_ALIGN_LEFT | (aspect.align & ASPECT_ALIGNY_MASK);
   }
   attribute = node->Attribute("aligny");
   if (attribute)
   {
     std::string align(attribute);
-    if (StringUtils::EqualsNoCase(align, "center")) aspect.align = ASPECT_ALIGNY_CENTER | (aspect.align & ASPECT_ALIGN_MASK);
-    else if (StringUtils::EqualsNoCase(align, "bottom")) aspect.align = ASPECT_ALIGNY_BOTTOM | (aspect.align & ASPECT_ALIGN_MASK);
-    else if (StringUtils::EqualsNoCase(align, "top")) aspect.align = ASPECT_ALIGNY_TOP | (aspect.align & ASPECT_ALIGN_MASK);
+    if (StringUtils::EqualsNoCase(align, "center"))
+      aspect.align = ASPECT_ALIGNY_CENTER | (aspect.align & ASPECT_ALIGN_MASK);
+    else if (StringUtils::EqualsNoCase(align, "bottom"))
+      aspect.align = ASPECT_ALIGNY_BOTTOM | (aspect.align & ASPECT_ALIGN_MASK);
+    else if (StringUtils::EqualsNoCase(align, "top"))
+      aspect.align = ASPECT_ALIGNY_TOP | (aspect.align & ASPECT_ALIGN_MASK);
   }
   attribute = node->Attribute("scalediffuse");
   if (attribute)
@@ -331,7 +370,11 @@ bool CGUIControlFactory::GetAspectRatio(const TiXmlNode* pRootNode, const char* 
   return true;
 }
 
-bool CGUIControlFactory::GetInfoTexture(const TiXmlNode* pRootNode, const char* strTag, CTextureInfo &image, GUIINFO::CGUIInfoLabel &info, int parentID)
+bool CGUIControlFactory::GetInfoTexture(const TiXmlNode* pRootNode,
+                                        const char* strTag,
+                                        CTextureInfo& image,
+                                        GUIINFO::CGUIInfoLabel& info,
+                                        int parentID)
 {
   GetTexture(pRootNode, strTag, image);
   image.filename = "";
@@ -339,11 +382,14 @@ bool CGUIControlFactory::GetInfoTexture(const TiXmlNode* pRootNode, const char* 
   return true;
 }
 
-bool CGUIControlFactory::GetTexture(const TiXmlNode* pRootNode, const char* strTag, CTextureInfo &image)
+bool CGUIControlFactory::GetTexture(const TiXmlNode* pRootNode,
+                                    const char* strTag,
+                                    CTextureInfo& image)
 {
   const TiXmlElement* pNode = pRootNode->FirstChildElement(strTag);
-  if (!pNode) return false;
-  const char *border = pNode->Attribute("border");
+  if (!pNode)
+    return false;
+  const char* border = pNode->Attribute("border");
   if (border)
   {
     GetRectFromString(border, image.border);
@@ -351,22 +397,22 @@ bool CGUIControlFactory::GetTexture(const TiXmlNode* pRootNode, const char* strT
     image.m_infill = (!borderinfill || !StringUtils::EqualsNoCase(borderinfill, "false"));
   }
   image.orientation = 0;
-  const char *flipX = pNode->Attribute("flipx");
+  const char* flipX = pNode->Attribute("flipx");
   if (flipX && StringUtils::CompareNoCase(flipX, "true") == 0)
     image.orientation = 1;
-  const char *flipY = pNode->Attribute("flipy");
+  const char* flipY = pNode->Attribute("flipy");
   if (flipY && StringUtils::CompareNoCase(flipY, "true") == 0)
     image.orientation = 3 - image.orientation; // either 3 or 2
   image.diffuse = XMLUtils::GetAttribute(pNode, "diffuse");
   image.diffuseColor.Parse(XMLUtils::GetAttribute(pNode, "colordiffuse"), 0);
-  const char *background = pNode->Attribute("background");
+  const char* background = pNode->Attribute("background");
   if (background && StringUtils::CompareNoCase(background, "true", 4) == 0)
     image.useLarge = true;
   image.filename = pNode->FirstChild() ? pNode->FirstChild()->Value() : "";
   return true;
 }
 
-void CGUIControlFactory::GetRectFromString(const std::string &string, CRect &rect)
+void CGUIControlFactory::GetRectFromString(const std::string& string, CRect& rect)
 {
   // format is rect="left[,top,right,bottom]"
   std::vector<std::string> strRect = StringUtils::Split(string, ',');
@@ -386,22 +432,31 @@ void CGUIControlFactory::GetRectFromString(const std::string &string, CRect &rec
   }
 }
 
-bool CGUIControlFactory::GetAlignment(const TiXmlNode* pRootNode, const char* strTag, uint32_t& alignment)
+bool CGUIControlFactory::GetAlignment(const TiXmlNode* pRootNode,
+                                      const char* strTag,
+                                      uint32_t& alignment)
 {
   const TiXmlNode* pNode = pRootNode->FirstChild(strTag);
-  if (!pNode || !pNode->FirstChild()) return false;
+  if (!pNode || !pNode->FirstChild())
+    return false;
 
   std::string strAlign = pNode->FirstChild()->Value();
-  if (strAlign == "right" || strAlign == "bottom") alignment = XBFONT_RIGHT;
-  else if (strAlign == "center") alignment = XBFONT_CENTER_X;
-  else if (strAlign == "justify") alignment = XBFONT_JUSTIFIED;
-  else alignment = XBFONT_LEFT;
+  if (strAlign == "right" || strAlign == "bottom")
+    alignment = XBFONT_RIGHT;
+  else if (strAlign == "center")
+    alignment = XBFONT_CENTER_X;
+  else if (strAlign == "justify")
+    alignment = XBFONT_JUSTIFIED;
+  else
+    alignment = XBFONT_LEFT;
   return true;
 }
 
-bool CGUIControlFactory::GetAlignmentY(const TiXmlNode* pRootNode, const char* strTag, uint32_t& alignment)
+bool CGUIControlFactory::GetAlignmentY(const TiXmlNode* pRootNode,
+                                       const char* strTag,
+                                       uint32_t& alignment)
 {
-  const TiXmlNode* pNode = pRootNode->FirstChild(strTag );
+  const TiXmlNode* pNode = pRootNode->FirstChild(strTag);
   if (!pNode || !pNode->FirstChild())
   {
     return false;
@@ -418,14 +473,17 @@ bool CGUIControlFactory::GetAlignmentY(const TiXmlNode* pRootNode, const char* s
   return true;
 }
 
-bool CGUIControlFactory::GetConditionalVisibility(const TiXmlNode* control, std::string &condition, std::string &allowHiddenFocus)
+bool CGUIControlFactory::GetConditionalVisibility(const TiXmlNode* control,
+                                                  std::string& condition,
+                                                  std::string& allowHiddenFocus)
 {
   const TiXmlElement* node = control->FirstChildElement("visible");
-  if (!node) return false;
+  if (!node)
+    return false;
   std::vector<std::string> conditions;
   while (node)
   {
-    const char *hidden = node->Attribute("allowhiddenfocus");
+    const char* hidden = node->Attribute("allowhiddenfocus");
     if (hidden)
       allowHiddenFocus = hidden;
     // add to our condition string
@@ -447,13 +505,16 @@ bool CGUIControlFactory::GetConditionalVisibility(const TiXmlNode* control, std:
   return true;
 }
 
-bool CGUIControlFactory::GetConditionalVisibility(const TiXmlNode *control, std::string &condition)
+bool CGUIControlFactory::GetConditionalVisibility(const TiXmlNode* control, std::string& condition)
 {
   std::string allowHiddenFocus;
   return GetConditionalVisibility(control, condition, allowHiddenFocus);
 }
 
-bool CGUIControlFactory::GetAnimations(TiXmlNode *control, const CRect &rect, int context, std::vector<CAnimation> &animations)
+bool CGUIControlFactory::GetAnimations(TiXmlNode* control,
+                                       const CRect& rect,
+                                       int context,
+                                       std::vector<CAnimation>& animations)
 {
   TiXmlElement* node = control->FirstChildElement("animation");
   bool ret = false;
@@ -471,8 +532,8 @@ bool CGUIControlFactory::GetAnimations(TiXmlNode *control, const CRect &rect, in
       { // add the hidden one as well
         TiXmlElement hidden(*node);
         hidden.FirstChild()->SetValue("hidden");
-        const char *start = hidden.Attribute("start");
-        const char *end = hidden.Attribute("end");
+        const char* start = hidden.Attribute("start");
+        const char* end = hidden.Attribute("end");
         if (start && end)
         {
           std::string temp = end;
@@ -511,7 +572,7 @@ bool CGUIControlFactory::GetActions(const TiXmlNode* pRootNode,
   return actions.HasAnyActions();
 }
 
-bool CGUIControlFactory::GetHitRect(const TiXmlNode *control, CRect &rect, const CRect &parentRect)
+bool CGUIControlFactory::GetHitRect(const TiXmlNode* control, CRect& rect, const CRect& parentRect)
 {
   const TiXmlElement* node = control->FirstChildElement("hitrect");
   if (node)
@@ -531,7 +592,9 @@ bool CGUIControlFactory::GetHitRect(const TiXmlNode *control, CRect &rect, const
   return false;
 }
 
-bool CGUIControlFactory::GetScroller(const TiXmlNode *control, const std::string &scrollerTag, CScroller& scroller)
+bool CGUIControlFactory::GetScroller(const TiXmlNode* control,
+                                     const std::string& scrollerTag,
+                                     CScroller& scroller)
 {
   const TiXmlElement* node = control->FirstChildElement(scrollerTag);
   if (node)
@@ -559,7 +622,10 @@ bool CGUIControlFactory::GetColor(const TiXmlNode* control,
   return false;
 }
 
-bool CGUIControlFactory::GetInfoColor(const TiXmlNode *control, const char *strTag, GUIINFO::CGUIInfoColor &value,int parentID)
+bool CGUIControlFactory::GetInfoColor(const TiXmlNode* control,
+                                      const char* strTag,
+                                      GUIINFO::CGUIInfoColor& value,
+                                      int parentID)
 {
   const TiXmlElement* node = control->FirstChildElement(strTag);
   if (node && node->FirstChild())
@@ -570,7 +636,10 @@ bool CGUIControlFactory::GetInfoColor(const TiXmlNode *control, const char *strT
   return false;
 }
 
-void CGUIControlFactory::GetInfoLabel(const TiXmlNode *pControlNode, const std::string &labelTag, GUIINFO::CGUIInfoLabel &infoLabel, int parentID)
+void CGUIControlFactory::GetInfoLabel(const TiXmlNode* pControlNode,
+                                      const std::string& labelTag,
+                                      GUIINFO::CGUIInfoLabel& infoLabel,
+                                      int parentID)
 {
   std::vector<GUIINFO::CGUIInfoLabel> labels;
   GetInfoLabels(pControlNode, labelTag, labels, parentID);
@@ -578,7 +647,9 @@ void CGUIControlFactory::GetInfoLabel(const TiXmlNode *pControlNode, const std::
     infoLabel = labels[0];
 }
 
-bool CGUIControlFactory::GetInfoLabelFromElement(const TiXmlElement *element, GUIINFO::CGUIInfoLabel &infoLabel, int parentID)
+bool CGUIControlFactory::GetInfoLabelFromElement(const TiXmlElement* element,
+                                                 GUIINFO::CGUIInfoLabel& infoLabel,
+                                                 int parentID)
 {
   if (!element || !element->FirstChild())
     return false;
@@ -598,7 +669,10 @@ bool CGUIControlFactory::GetInfoLabelFromElement(const TiXmlElement *element, GU
   return true;
 }
 
-void CGUIControlFactory::GetInfoLabels(const TiXmlNode *pControlNode, const std::string &labelTag, std::vector<GUIINFO::CGUIInfoLabel> &infoLabels, int parentID)
+void CGUIControlFactory::GetInfoLabels(const TiXmlNode* pControlNode,
+                                       const std::string& labelTag,
+                                       std::vector<GUIINFO::CGUIInfoLabel>& infoLabels,
+                                       int parentID)
 {
   // we can have the following infolabels:
   // 1.  <number>1234</number> -> direct number
@@ -612,7 +686,7 @@ void CGUIControlFactory::GetInfoLabels(const TiXmlNode *pControlNode, const std:
     infoLabels.emplace_back(label);
     return; // done
   }
-  const TiXmlElement *labelNode = pControlNode->FirstChildElement(labelTag);
+  const TiXmlElement* labelNode = pControlNode->FirstChildElement(labelTag);
   while (labelNode)
   {
     GUIINFO::CGUIInfoLabel label;
@@ -620,7 +694,7 @@ void CGUIControlFactory::GetInfoLabels(const TiXmlNode *pControlNode, const std:
       infoLabels.push_back(label);
     labelNode = labelNode->NextSiblingElement(labelTag);
   }
-  const TiXmlNode *infoNode = pControlNode->FirstChild("info");
+  const TiXmlNode* infoNode = pControlNode->FirstChild("info");
   if (infoNode)
   { // <info> nodes override <label>'s (backward compatibility)
     std::string fallback;
@@ -640,7 +714,7 @@ void CGUIControlFactory::GetInfoLabels(const TiXmlNode *pControlNode, const std:
 }
 
 // Convert a string to a GUI label, by translating/parsing the label for localisable strings
-std::string CGUIControlFactory::FilterLabel(const std::string &label)
+std::string CGUIControlFactory::FilterLabel(const std::string& label)
 {
   std::string viewLabel = label;
   if (StringUtils::IsNaturalNumber(viewLabel))
@@ -650,7 +724,9 @@ std::string CGUIControlFactory::FilterLabel(const std::string &label)
   return viewLabel;
 }
 
-bool CGUIControlFactory::GetString(const TiXmlNode* pRootNode, const char *strTag, std::string &text)
+bool CGUIControlFactory::GetString(const TiXmlNode* pRootNode,
+                                   const char* strTag,
+                                   std::string& text)
 {
   if (!XMLUtils::GetString(pRootNode, strTag, text))
     return false;
@@ -659,10 +735,10 @@ bool CGUIControlFactory::GetString(const TiXmlNode* pRootNode, const char *strTa
   return true;
 }
 
-std::string CGUIControlFactory::GetType(const TiXmlElement *pControlNode)
+std::string CGUIControlFactory::GetType(const TiXmlElement* pControlNode)
 {
   std::string type = XMLUtils::GetAttribute(pControlNode, "type");
-  if (type.empty())  // backward compatibility - not desired
+  if (type.empty()) // backward compatibility - not desired
     XMLUtils::GetString(pControlNode, "type", type);
   return type;
 }
@@ -712,7 +788,10 @@ bool CGUIControlFactory::GetMovingSpeedConfig(const TiXmlNode* pRootNode,
   return true;
 }
 
-CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlElement* pControlNode, bool insideContainer)
+CGUIControl* CGUIControlFactory::Create(int parentID,
+                                        const CRect& rect,
+                                        TiXmlElement* pControlNode,
+                                        bool insideContainer)
 {
   // get the control type
   std::string strType = GetType(pControlNode);
@@ -729,12 +808,12 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   GUIINFO::CGUIInfoColor colorDiffuse(0xFFFFFFFF);
   GUIINFO::CGUIInfoColor colorBox(0xFF000000);
   int defaultControl = 0;
-  bool  defaultAlways = false;
+  bool defaultAlways = false;
   std::string strTmp;
   int singleInfo = 0;
   int singleInfo2 = 0;
   std::string strLabel;
-  int iUrlSet=0;
+  int iUrlSet = 0;
   std::string toggleSelect;
 
   float spinWidth = 16;
@@ -832,7 +911,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   CRect hitRect;
   CPoint camera;
   float stereo = 0.f;
-  bool   hasCamera = false;
+  bool hasCamera = false;
   bool resetOnLabelChange = true;
   bool bPassword = false;
   std::string visibleCondition;
@@ -844,24 +923,25 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   //
 
   if (!pControlNode->Attribute("id", &id))
-    XMLUtils::GetInt(pControlNode, "id", id);       // backward compatibility - not desired
+    XMLUtils::GetInt(pControlNode, "id", id); // backward compatibility - not desired
   //! @todo Perhaps we should check here whether id is valid for focusable controls
   //! such as buttons etc.  For labels/fadelabels/images it does not matter
 
   GetAlignment(pControlNode, "align", labelInfo.align);
-  if (!GetDimensions(pControlNode, "left", "right", "centerleft", "centerright", "width", rect.Width(), posX, width, minWidth))
+  if (!GetDimensions(pControlNode, "left", "right", "centerleft", "centerright", "width",
+                     rect.Width(), posX, width, minWidth))
   { // didn't get 2 dimensions, so test for old <posx> as well
     if (GetPosition(pControlNode, "posx", rect.Width(), posX))
     { // <posx> available, so use it along with any hacks we used to support
-      if (!insideContainer &&
-          type == CGUIControl::GUICONTROL_LABEL &&
+      if (!insideContainer && type == CGUIControl::GUICONTROL_LABEL &&
           (labelInfo.align & XBFONT_RIGHT))
         posX -= width;
     }
     if (!width) // no width specified, so compute from parent
       width = std::max(rect.Width() - posX, 0.0f);
   }
-  if (!GetDimensions(pControlNode, "top", "bottom", "centertop", "centerbottom", "height", rect.Height(), posY, height, minHeight))
+  if (!GetDimensions(pControlNode, "top", "bottom", "centertop", "centerbottom", "height",
+                     rect.Height(), posY, height, minHeight))
   {
     GetPosition(pControlNode, "posy", rect.Height(), posY);
     if (!height)
@@ -876,18 +956,18 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
 
   GetInfoColor(pControlNode, "hitrectcolor", hitColor, parentID);
 
-  GetActions(pControlNode, "onup",    actions[ACTION_MOVE_UP]);
-  GetActions(pControlNode, "ondown",  actions[ACTION_MOVE_DOWN]);
-  GetActions(pControlNode, "onleft",  actions[ACTION_MOVE_LEFT]);
+  GetActions(pControlNode, "onup", actions[ACTION_MOVE_UP]);
+  GetActions(pControlNode, "ondown", actions[ACTION_MOVE_DOWN]);
+  GetActions(pControlNode, "onleft", actions[ACTION_MOVE_LEFT]);
   GetActions(pControlNode, "onright", actions[ACTION_MOVE_RIGHT]);
-  GetActions(pControlNode, "onnext",  actions[ACTION_NEXT_CONTROL]);
-  GetActions(pControlNode, "onprev",  actions[ACTION_PREV_CONTROL]);
-  GetActions(pControlNode, "onback",  actions[ACTION_NAV_BACK]);
-  GetActions(pControlNode, "oninfo",  actions[ACTION_SHOW_INFO]);
+  GetActions(pControlNode, "onnext", actions[ACTION_NEXT_CONTROL]);
+  GetActions(pControlNode, "onprev", actions[ACTION_PREV_CONTROL]);
+  GetActions(pControlNode, "onback", actions[ACTION_NAV_BACK]);
+  GetActions(pControlNode, "oninfo", actions[ACTION_SHOW_INFO]);
 
   if (XMLUtils::GetInt(pControlNode, "defaultcontrol", defaultControl))
   {
-    const char *always = pControlNode->FirstChildElement("defaultcontrol")->Attribute("always");
+    const char* always = pControlNode->FirstChildElement("defaultcontrol")->Attribute("always");
     if (always && StringUtils::CompareNoCase(always, "true", 4) == 0)
       defaultAlways = true;
   }
@@ -910,8 +990,9 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   GetInfoColor(pControlNode, "invalidcolor", labelInfo.invalidColor, parentID);
   XMLUtils::GetFloat(pControlNode, "textoffsetx", labelInfo.offsetX);
   XMLUtils::GetFloat(pControlNode, "textoffsety", labelInfo.offsetY);
-  int angle = 0;  // use the negative angle to compensate for our vertically flipped cartesian plane
-  if (XMLUtils::GetInt(pControlNode, "angle", angle)) labelInfo.angle = (float)-angle;
+  int angle = 0; // use the negative angle to compensate for our vertically flipped cartesian plane
+  if (XMLUtils::GetInt(pControlNode, "angle", angle))
+    labelInfo.angle = (float)-angle;
   std::string strFont, strMonoFont;
   if (XMLUtils::GetString(pControlNode, "font", strFont))
     labelInfo.font = g_fontManager.GetFont(strFont);
@@ -960,15 +1041,17 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
 
   XMLUtils::GetFloat(pControlNode, "sliderwidth", sliderWidth);
   XMLUtils::GetFloat(pControlNode, "sliderheight", sliderHeight);
-  if (!GetTexture(pControlNode, "textureradioonfocus", textureRadioOnFocus) || !GetTexture(pControlNode, "textureradioonnofocus", textureRadioOnNoFocus))
+  if (!GetTexture(pControlNode, "textureradioonfocus", textureRadioOnFocus) ||
+      !GetTexture(pControlNode, "textureradioonnofocus", textureRadioOnNoFocus))
   {
-    GetTexture(pControlNode, "textureradiofocus", textureRadioOnFocus);    // backward compatibility
+    GetTexture(pControlNode, "textureradiofocus", textureRadioOnFocus); // backward compatibility
     GetTexture(pControlNode, "textureradioon", textureRadioOnFocus);
     textureRadioOnNoFocus = textureRadioOnFocus;
   }
-  if (!GetTexture(pControlNode, "textureradioofffocus", textureRadioOffFocus) || !GetTexture(pControlNode, "textureradiooffnofocus", textureRadioOffNoFocus))
+  if (!GetTexture(pControlNode, "textureradioofffocus", textureRadioOffFocus) ||
+      !GetTexture(pControlNode, "textureradiooffnofocus", textureRadioOffNoFocus))
   {
-    GetTexture(pControlNode, "textureradionofocus", textureRadioOffFocus);    // backward compatibility
+    GetTexture(pControlNode, "textureradionofocus", textureRadioOffFocus); // backward compatibility
     GetTexture(pControlNode, "textureradiooff", textureRadioOffFocus);
     textureRadioOffNoFocus = textureRadioOffFocus;
   }
@@ -996,11 +1079,11 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   {
     StringUtils::ToLower(strSubType);
 
-    if ( strSubType == "int")
+    if (strSubType == "int")
       iType = SPIN_CONTROL_TYPE_INT;
-    else if ( strSubType == "page")
+    else if (strSubType == "page")
       iType = SPIN_CONTROL_TYPE_PAGE;
-    else if ( strSubType == "float")
+    else if (strSubType == "float")
       iType = SPIN_CONTROL_TYPE_FLOAT;
     else
       iType = SPIN_CONTROL_TYPE_TEXT;
@@ -1034,9 +1117,9 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   GetString(pControlNode, "label2", strLabel2);
 
   XMLUtils::GetBoolean(pControlNode, "wrapmultiline", wrapMultiLine);
-  XMLUtils::GetInt(pControlNode,"urlset",iUrlSet);
+  XMLUtils::GetInt(pControlNode, "urlset", iUrlSet);
 
-  if ( XMLUtils::GetString(pControlNode, "orientation", strTmp) )
+  if (XMLUtils::GetString(pControlNode, "orientation", strTmp))
   {
     StringUtils::ToLower(strTmp);
     if (strTmp == "horizontal")
@@ -1050,16 +1133,16 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   if (XMLUtils::GetBoolean(pControlNode, "scroll", alwaysScroll))
     scrollValue = alwaysScroll ? CGUIControl::ALWAYS : CGUIControl::NEVER;
 
-  XMLUtils::GetBoolean(pControlNode,"pulseonselect", bPulse);
+  XMLUtils::GetBoolean(pControlNode, "pulseonselect", bPulse);
   XMLUtils::GetInt(pControlNode, "timeblocks", timeBlocks);
   XMLUtils::GetInt(pControlNode, "rulerunit", rulerUnit);
   GetTexture(pControlNode, "progresstexture", textureProgressIndicator);
 
   GetInfoTexture(pControlNode, "imagepath", texture, texturePath, parentID);
 
-  XMLUtils::GetUInt(pControlNode,"timeperimage", timePerImage);
-  XMLUtils::GetUInt(pControlNode,"fadetime", fadeTime);
-  XMLUtils::GetUInt(pControlNode,"pauseatend", timeToPauseAtEnd);
+  XMLUtils::GetUInt(pControlNode, "timeperimage", timePerImage);
+  XMLUtils::GetUInt(pControlNode, "fadetime", fadeTime);
+  XMLUtils::GetUInt(pControlNode, "pauseatend", timeToPauseAtEnd);
   XMLUtils::GetBoolean(pControlNode, "randomize", randomized);
   XMLUtils::GetBoolean(pControlNode, "loop", loop);
   XMLUtils::GetBoolean(pControlNode, "scrollout", scrollOut);
@@ -1107,7 +1190,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
     viewType = VIEW_TYPE_WRAP;
     viewLabel = g_localizeStrings.Get(541);
   }
-  TiXmlElement *itemElement = pControlNode->FirstChildElement("viewtype");
+  TiXmlElement* itemElement = pControlNode->FirstChildElement("viewtype");
   if (itemElement && itemElement->FirstChild())
   {
     std::string type = itemElement->FirstChild()->Value();
@@ -1131,12 +1214,12 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
       viewType = VIEW_TYPE_INFO;
     else if (type == "biginfo")
       viewType = VIEW_TYPE_BIG_INFO;
-    const char *label = itemElement->Attribute("label");
+    const char* label = itemElement->Attribute("label");
     if (label)
       viewLabel = GUIINFO::CGUIInfoLabel::GetLabel(FilterLabel(label), INFO::DEFAULT_CONTEXT);
   }
 
-  TiXmlElement *cam = pControlNode->FirstChildElement("camera");
+  TiXmlElement* cam = pControlNode->FirstChildElement("camera");
   if (cam)
   {
     hasCamera = true;
@@ -1159,10 +1242,10 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
   // Instantiate a new control using the properties gathered above
   //
 
-  CGUIControl *control = NULL;
+  CGUIControl* control = NULL;
   switch (type)
   {
-  case CGUIControl::GUICONTROL_GROUP:
+    case CGUIControl::GUICONTROL_GROUP:
     {
       if (insideContainer)
       {
@@ -1170,65 +1253,65 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
       }
       else
       {
-        control = new CGUIControlGroup(
-          parentID, id, posX, posY, width, height);
+        control = new CGUIControlGroup(parentID, id, posX, posY, width, height);
         static_cast<CGUIControlGroup*>(control)->SetDefaultControl(defaultControl, defaultAlways);
         static_cast<CGUIControlGroup*>(control)->SetRenderFocusedLast(renderFocusedLast);
       }
     }
     break;
-  case CGUIControl::GUICONTROL_GROUPLIST:
+    case CGUIControl::GUICONTROL_GROUPLIST:
     {
       CScroller scroller;
       GetScroller(pControlNode, "scrolltime", scroller);
 
-      control = new CGUIControlGroupList(
-        parentID, id, posX, posY, width, height, buttonGap, pageControl, orientation, useControlCoords, labelInfo.align, scroller);
+      control =
+          new CGUIControlGroupList(parentID, id, posX, posY, width, height, buttonGap, pageControl,
+                                   orientation, useControlCoords, labelInfo.align, scroller);
       static_cast<CGUIControlGroup*>(control)->SetDefaultControl(defaultControl, defaultAlways);
       static_cast<CGUIControlGroup*>(control)->SetRenderFocusedLast(renderFocusedLast);
       static_cast<CGUIControlGroupList*>(control)->SetMinSize(minWidth, minHeight);
     }
     break;
-  case CGUIControl::GUICONTROL_LABEL:
+    case CGUIControl::GUICONTROL_LABEL:
     {
       static const GUIINFO::CGUIInfoLabel empty;
       const GUIINFO::CGUIInfoLabel& content = !infoLabels.empty() ? infoLabels[0] : empty;
       if (insideContainer)
       { // inside lists we use CGUIListLabel
-        control = new CGUIListLabel(parentID, id, posX, posY, width, height, labelInfo, content, scrollValue);
+        control = new CGUIListLabel(parentID, id, posX, posY, width, height, labelInfo, content,
+                                    scrollValue);
       }
       else
       {
-        control = new CGUILabelControl(
-          parentID, id, posX, posY, width, height,
-          labelInfo, wrapMultiLine, bHasPath);
+        control = new CGUILabelControl(parentID, id, posX, posY, width, height, labelInfo,
+                                       wrapMultiLine, bHasPath);
         static_cast<CGUILabelControl*>(control)->SetInfo(content);
-        static_cast<CGUILabelControl*>(control)->SetWidthControl(minWidth, (scrollValue == CGUIControl::ALWAYS));
+        static_cast<CGUILabelControl*>(control)->SetWidthControl(
+            minWidth, (scrollValue == CGUIControl::ALWAYS));
       }
     }
     break;
-  case CGUIControl::GUICONTROL_EDIT:
+    case CGUIControl::GUICONTROL_EDIT:
     {
-      control = new CGUIEditControl(
-        parentID, id, posX, posY, width, height, textureFocus, textureNoFocus,
-        labelInfo, strLabel);
+      control = new CGUIEditControl(parentID, id, posX, posY, width, height, textureFocus,
+                                    textureNoFocus, labelInfo, strLabel);
 
       GUIINFO::CGUIInfoLabel hint_text;
       GetInfoLabel(pControlNode, "hinttext", hint_text, parentID);
       static_cast<CGUIEditControl*>(control)->SetHint(hint_text);
 
       if (bPassword)
-        static_cast<CGUIEditControl*>(control)->SetInputType(CGUIEditControl::INPUT_TYPE_PASSWORD, 0);
+        static_cast<CGUIEditControl*>(control)->SetInputType(CGUIEditControl::INPUT_TYPE_PASSWORD,
+                                                             0);
       static_cast<CGUIEditControl*>(control)->SetTextChangeActions(textChangeActions);
     }
     break;
-  case CGUIControl::GUICONTROL_VIDEO:
+    case CGUIControl::GUICONTROL_VIDEO:
     {
-      control = new CGUIVideoControl(
-        parentID, id, posX, posY, width, height);
+      control = new CGUIVideoControl(parentID, id, posX, posY, width, height);
     }
     break;
-  case CGUIControl::GUICONTROL_GAME:
+    case CGUIControl::GUICONTROL_GAME:
     {
       control = new RETRO::CGUIGameControl(parentID, id, posX, posY, width, height);
 
@@ -1249,35 +1332,33 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
       static_cast<RETRO::CGUIGameControl*>(control)->SetPixels(pixels);
     }
     break;
-  case CGUIControl::GUICONTROL_FADELABEL:
+    case CGUIControl::GUICONTROL_FADELABEL:
     {
-      control = new CGUIFadeLabelControl(
-        parentID, id, posX, posY, width, height,
-        labelInfo, scrollOut, timeToPauseAtEnd, resetOnLabelChange, randomized);
+      control =
+          new CGUIFadeLabelControl(parentID, id, posX, posY, width, height, labelInfo, scrollOut,
+                                   timeToPauseAtEnd, resetOnLabelChange, randomized);
 
       static_cast<CGUIFadeLabelControl*>(control)->SetInfo(infoLabels);
 
       // check whether or not a scroll tag was specified.
       if (scrollValue != CGUIControl::FOCUS)
-        static_cast<CGUIFadeLabelControl*>(control)->SetScrolling(scrollValue == CGUIControl::ALWAYS);
+        static_cast<CGUIFadeLabelControl*>(control)->SetScrolling(scrollValue ==
+                                                                  CGUIControl::ALWAYS);
     }
     break;
-  case CGUIControl::GUICONTROL_RSS:
+    case CGUIControl::GUICONTROL_RSS:
     {
-      control = new CGUIRSSControl(
-        parentID, id, posX, posY, width, height,
-        labelInfo, textColor3, headlineColor, strRSSTags);
+      control = new CGUIRSSControl(parentID, id, posX, posY, width, height, labelInfo, textColor3,
+                                   headlineColor, strRSSTags);
       RssUrls::const_iterator iter = CRssManager::GetInstance().GetUrls().find(iUrlSet);
       if (iter != CRssManager::GetInstance().GetUrls().end())
         static_cast<CGUIRSSControl*>(control)->SetUrlSet(iUrlSet);
     }
     break;
-  case CGUIControl::GUICONTROL_BUTTON:
+    case CGUIControl::GUICONTROL_BUTTON:
     {
-      control = new CGUIButtonControl(
-        parentID, id, posX, posY, width, height,
-        textureFocus, textureNoFocus,
-        labelInfo, wrapMultiLine);
+      control = new CGUIButtonControl(parentID, id, posX, posY, width, height, textureFocus,
+                                      textureNoFocus, labelInfo, wrapMultiLine);
 
       CGUIButtonControl* bcontrol = static_cast<CGUIButtonControl*>(control);
       bcontrol->SetLabel(strLabel);
@@ -1288,13 +1369,11 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
       bcontrol->SetUnFocusActions(unfocusActions);
     }
     break;
-  case CGUIControl::GUICONTROL_TOGGLEBUTTON:
+    case CGUIControl::GUICONTROL_TOGGLEBUTTON:
     {
-      control = new CGUIToggleButtonControl(
-        parentID, id, posX, posY, width, height,
-        textureFocus, textureNoFocus,
-        textureAltFocus, textureAltNoFocus,
-        labelInfo, wrapMultiLine);
+      control = new CGUIToggleButtonControl(parentID, id, posX, posY, width, height, textureFocus,
+                                            textureNoFocus, textureAltFocus, textureAltNoFocus,
+                                            labelInfo, wrapMultiLine);
 
       CGUIToggleButtonControl* tcontrol = static_cast<CGUIToggleButtonControl*>(control);
       tcontrol->SetLabel(strLabel);
@@ -1307,13 +1386,12 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
       tcontrol->SetToggleSelect(toggleSelect);
     }
     break;
-  case CGUIControl::GUICONTROL_RADIO:
+    case CGUIControl::GUICONTROL_RADIO:
     {
       control = new CGUIRadioButtonControl(
-        parentID, id, posX, posY, width, height,
-        textureFocus, textureNoFocus,
-        labelInfo,
-        textureRadioOnFocus, textureRadioOnNoFocus, textureRadioOffFocus, textureRadioOffNoFocus, textureRadioOnDisabled, textureRadioOffDisabled);
+          parentID, id, posX, posY, width, height, textureFocus, textureNoFocus, labelInfo,
+          textureRadioOnFocus, textureRadioOnNoFocus, textureRadioOffFocus, textureRadioOffNoFocus,
+          textureRadioOnDisabled, textureRadioOffDisabled);
 
       CGUIRadioButtonControl* rcontrol = static_cast<CGUIRadioButtonControl*>(control);
       rcontrol->SetLabel(strLabel);
@@ -1325,13 +1403,11 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
       rcontrol->SetUnFocusActions(unfocusActions);
     }
     break;
-  case CGUIControl::GUICONTROL_SPIN:
+    case CGUIControl::GUICONTROL_SPIN:
     {
-      control = new CGUISpinControl(
-        parentID, id, posX, posY, width, height,
-        textureUp, textureDown, textureUpFocus, textureDownFocus,
-        textureUpDisabled, textureDownDisabled,
-        labelInfo, iType);
+      control = new CGUISpinControl(parentID, id, posX, posY, width, height, textureUp, textureDown,
+                                    textureUpFocus, textureDownFocus, textureUpDisabled,
+                                    textureDownDisabled, labelInfo, iType);
 
       CGUISpinControl* scontrol = static_cast<CGUISpinControl*>(control);
       scontrol->SetReverse(bReverse);
@@ -1354,7 +1430,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
       }
     }
     break;
-  case CGUIControl::GUICONTROL_SLIDER:
+    case CGUIControl::GUICONTROL_SLIDER:
     {
       control = new CGUISliderControl(
           parentID, id, posX, posY, width, height, textureBar, textureBarDisabled, textureNib,
@@ -1364,7 +1440,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
       static_cast<CGUISliderControl*>(control)->SetAction(action);
     }
     break;
-  case CGUIControl::GUICONTROL_SETTINGS_SLIDER:
+    case CGUIControl::GUICONTROL_SETTINGS_SLIDER:
     {
       control = new CGUISettingsSliderControl(
           parentID, id, posX, posY, width, height, sliderWidth, sliderHeight, textureFocus,
@@ -1375,60 +1451,58 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
       static_cast<CGUISettingsSliderControl*>(control)->SetInfo(singleInfo);
     }
     break;
-  case CGUIControl::GUICONTROL_SCROLLBAR:
+    case CGUIControl::GUICONTROL_SCROLLBAR:
     {
-      control = new GUIScrollBarControl(
-        parentID, id, posX, posY, width, height,
-        textureBackground, textureBar, textureBarFocus, textureNib, textureNibFocus, orientation, showOnePage);
+      control = new GUIScrollBarControl(parentID, id, posX, posY, width, height, textureBackground,
+                                        textureBar, textureBarFocus, textureNib, textureNibFocus,
+                                        orientation, showOnePage);
     }
     break;
-  case CGUIControl::GUICONTROL_PROGRESS:
+    case CGUIControl::GUICONTROL_PROGRESS:
     {
-      control = new CGUIProgressControl(
-        parentID, id, posX, posY, width, height,
-        textureBackground, textureLeft, textureMid, textureRight,
-        textureOverlay, bReveal);
+      control =
+          new CGUIProgressControl(parentID, id, posX, posY, width, height, textureBackground,
+                                  textureLeft, textureMid, textureRight, textureOverlay, bReveal);
 
       static_cast<CGUIProgressControl*>(control)->SetInfo(singleInfo, singleInfo2);
     }
     break;
-  case CGUIControl::GUICONTROL_RANGES:
+    case CGUIControl::GUICONTROL_RANGES:
     {
-      control = new CGUIRangesControl(
-        parentID, id, posX, posY, width, height,
-        textureBackground, textureLeft, textureMid, textureRight,
-        textureOverlay, singleInfo);
+      control =
+          new CGUIRangesControl(parentID, id, posX, posY, width, height, textureBackground,
+                                textureLeft, textureMid, textureRight, textureOverlay, singleInfo);
     }
     break;
-  case CGUIControl::GUICONTROL_IMAGE:
+    case CGUIControl::GUICONTROL_IMAGE:
     {
       // use a bordered texture if we have <bordersize> or <bordertexture> specified.
       if (borderTexture.filename.empty() && borderStr.empty())
-        control = new CGUIImage(
-          parentID, id, posX, posY, width, height, texture);
+        control = new CGUIImage(parentID, id, posX, posY, width, height, texture);
       else
-        control = new CGUIBorderedImage(
-          parentID, id, posX, posY, width, height, texture, borderTexture, borderSize);
+        control = new CGUIBorderedImage(parentID, id, posX, posY, width, height, texture,
+                                        borderTexture, borderSize);
       CGUIImage* icontrol = static_cast<CGUIImage*>(control);
       icontrol->SetInfo(textureFile);
       icontrol->SetAspectRatio(aspect);
       icontrol->SetCrossFade(fadeTime);
     }
     break;
-  case CGUIControl::GUICONTROL_MULTI_IMAGE:
+    case CGUIControl::GUICONTROL_MULTI_IMAGE:
     {
-      control = new CGUIMultiImage(
-        parentID, id, posX, posY, width, height, texture, timePerImage, fadeTime, randomized, loop, timeToPauseAtEnd);
+      control = new CGUIMultiImage(parentID, id, posX, posY, width, height, texture, timePerImage,
+                                   fadeTime, randomized, loop, timeToPauseAtEnd);
       static_cast<CGUIMultiImage*>(control)->SetInfo(texturePath);
       static_cast<CGUIMultiImage*>(control)->SetAspectRatio(aspect);
     }
     break;
-  case CGUIControl::GUICONTAINER_LIST:
+    case CGUIControl::GUICONTAINER_LIST:
     {
       CScroller scroller;
       GetScroller(pControlNode, "scrolltime", scroller);
 
-      control = new CGUIListContainer(parentID, id, posX, posY, width, height, orientation, scroller, preloadItems);
+      control = new CGUIListContainer(parentID, id, posX, posY, width, height, orientation,
+                                      scroller, preloadItems);
       CGUIListContainer* lcontrol = static_cast<CGUIListContainer*>(control);
       lcontrol->LoadLayout(pControlNode);
       lcontrol->LoadListProvider(pControlNode, defaultControl, defaultAlways);
@@ -1441,12 +1515,13 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
       lcontrol->SetUnFocusActions(unfocusActions);
     }
     break;
-  case CGUIControl::GUICONTAINER_WRAPLIST:
+    case CGUIControl::GUICONTAINER_WRAPLIST:
     {
       CScroller scroller;
       GetScroller(pControlNode, "scrolltime", scroller);
 
-      control = new CGUIWrappingListContainer(parentID, id, posX, posY, width, height, orientation, scroller, preloadItems, focusPosition);
+      control = new CGUIWrappingListContainer(parentID, id, posX, posY, width, height, orientation,
+                                              scroller, preloadItems, focusPosition);
       CGUIWrappingListContainer* wcontrol = static_cast<CGUIWrappingListContainer*>(control);
       wcontrol->LoadLayout(pControlNode);
       wcontrol->LoadListProvider(pControlNode, defaultControl, defaultAlways);
@@ -1459,9 +1534,11 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
       wcontrol->SetUnFocusActions(unfocusActions);
     }
     break;
-  case CGUIControl::GUICONTAINER_EPGGRID:
+    case CGUIControl::GUICONTAINER_EPGGRID:
     {
-      CGUIEPGGridContainer *epgGridContainer = new CGUIEPGGridContainer(parentID, id, posX, posY, width, height, orientation, scrollTime, preloadItems, timeBlocks, rulerUnit, textureProgressIndicator);
+      CGUIEPGGridContainer* epgGridContainer =
+          new CGUIEPGGridContainer(parentID, id, posX, posY, width, height, orientation, scrollTime,
+                                   preloadItems, timeBlocks, rulerUnit, textureProgressIndicator);
       control = epgGridContainer;
       epgGridContainer->LoadLayout(pControlNode);
       epgGridContainer->SetRenderOffset(offset);
@@ -1469,12 +1546,13 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
       epgGridContainer->SetPageControl(pageControl);
     }
     break;
-  case CGUIControl::GUICONTAINER_FIXEDLIST:
+    case CGUIControl::GUICONTAINER_FIXEDLIST:
     {
       CScroller scroller;
       GetScroller(pControlNode, "scrolltime", scroller);
 
-      control = new CGUIFixedListContainer(parentID, id, posX, posY, width, height, orientation, scroller, preloadItems, focusPosition, iMovementRange);
+      control = new CGUIFixedListContainer(parentID, id, posX, posY, width, height, orientation,
+                                           scroller, preloadItems, focusPosition, iMovementRange);
       CGUIFixedListContainer* fcontrol = static_cast<CGUIFixedListContainer*>(control);
       fcontrol->LoadLayout(pControlNode);
       fcontrol->LoadListProvider(pControlNode, defaultControl, defaultAlways);
@@ -1487,12 +1565,13 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
       fcontrol->SetUnFocusActions(unfocusActions);
     }
     break;
-  case CGUIControl::GUICONTAINER_PANEL:
+    case CGUIControl::GUICONTAINER_PANEL:
     {
       CScroller scroller;
       GetScroller(pControlNode, "scrolltime", scroller);
 
-      control = new CGUIPanelContainer(parentID, id, posX, posY, width, height, orientation, scroller, preloadItems);
+      control = new CGUIPanelContainer(parentID, id, posX, posY, width, height, orientation,
+                                       scroller, preloadItems);
       CGUIPanelContainer* pcontrol = static_cast<CGUIPanelContainer*>(control);
       pcontrol->LoadLayout(pControlNode);
       pcontrol->LoadListProvider(pControlNode, defaultControl, defaultAlways);
@@ -1505,16 +1584,15 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
       pcontrol->SetUnFocusActions(unfocusActions);
     }
     break;
-  case CGUIControl::GUICONTROL_TEXTBOX:
+    case CGUIControl::GUICONTROL_TEXTBOX:
     {
       if (!strMonoFont.empty())
       {
         labelInfoMono = labelInfo;
         labelInfoMono.font = g_fontManager.GetFont(strMonoFont);
       }
-      control = new CGUITextBox(
-        parentID, id, posX, posY, width, height,
-        labelInfo, scrollTime, strMonoFont.empty() ? nullptr : &labelInfoMono);
+      control = new CGUITextBox(parentID, id, posX, posY, width, height, labelInfo, scrollTime,
+                                strMonoFont.empty() ? nullptr : &labelInfoMono);
 
       CGUITextBox* tcontrol = static_cast<CGUITextBox*>(control);
 
@@ -1525,24 +1603,24 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
       tcontrol->SetMinHeight(minHeight);
     }
     break;
-  case CGUIControl::GUICONTROL_MOVER:
+    case CGUIControl::GUICONTROL_MOVER:
     {
       control = new CGUIMoverControl(parentID, id, posX, posY, width, height, textureFocus,
                                      textureNoFocus, movingSpeedCfg);
     }
     break;
-  case CGUIControl::GUICONTROL_RESIZE:
+    case CGUIControl::GUICONTROL_RESIZE:
     {
       control = new CGUIResizeControl(parentID, id, posX, posY, width, height, textureFocus,
                                       textureNoFocus, movingSpeedCfg);
     }
     break;
-  case CGUIControl::GUICONTROL_SPINEX:
+    case CGUIControl::GUICONTROL_SPINEX:
     {
-      control = new CGUISpinControlEx(
-        parentID, id, posX, posY, width, height, spinWidth, spinHeight,
-        labelInfo, textureFocus, textureNoFocus, textureUp, textureDown, textureUpFocus, textureDownFocus,
-        textureUpDisabled, textureDownDisabled, labelInfo, iType);
+      control = new CGUISpinControlEx(parentID, id, posX, posY, width, height, spinWidth,
+                                      spinHeight, labelInfo, textureFocus, textureNoFocus,
+                                      textureUp, textureDown, textureUpFocus, textureDownFocus,
+                                      textureUpDisabled, textureDownDisabled, labelInfo, iType);
 
       CGUISpinControlEx* scontrol = static_cast<CGUISpinControlEx*>(control);
       scontrol->SetSpinPosition(spinPosX);
@@ -1550,90 +1628,90 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const CRect &rect, TiXmlEl
       scontrol->SetReverse(bReverse);
     }
     break;
-  case CGUIControl::GUICONTROL_VISUALISATION:
-    control = new CGUIVisualisationControl(parentID, id, posX, posY, width, height);
+    case CGUIControl::GUICONTROL_VISUALISATION:
+      control = new CGUIVisualisationControl(parentID, id, posX, posY, width, height);
+      break;
+    case CGUIControl::GUICONTROL_RENDERADDON:
+      control = new CGUIRenderingControl(parentID, id, posX, posY, width, height);
+      break;
+    case CGUIControl::GUICONTROL_GAMECONTROLLER:
+    {
+      control = new GAME::CGUIGameController(parentID, id, posX, posY, width, height, texture);
+
+      GAME::CGUIGameController* gcontrol = static_cast<GAME::CGUIGameController*>(control);
+
+      // Set texture
+      gcontrol->SetInfo(textureFile);
+
+      // Set aspect ratio
+      gcontrol->SetAspectRatio(aspect);
+
+      // Set controller ID
+      GUIINFO::CGUIInfoLabel controllerId;
+      GetInfoLabel(pControlNode, "controllerid", controllerId, parentID);
+      gcontrol->SetControllerID(controllerId);
+
+      // Set controller address
+      GUIINFO::CGUIInfoLabel controllerAddress;
+      GetInfoLabel(pControlNode, "controlleraddress", controllerAddress, parentID);
+      gcontrol->SetControllerAddress(controllerAddress);
+
+      // Set controller diffuse color
+      GUIINFO::CGUIInfoColor controllerDiffuse(0xFFFFFFFF);
+      GetInfoColor(pControlNode, "controllerdiffuse", controllerDiffuse, parentID);
+      gcontrol->SetControllerDiffuse(controllerDiffuse);
+
+      // Set port address
+      GUIINFO::CGUIInfoLabel portAddress;
+      GetInfoLabel(pControlNode, "portaddress", portAddress, parentID);
+      gcontrol->SetPortAddress(portAddress);
+
+      // Set peripheral location
+      GUIINFO::CGUIInfoLabel peripheralLocation;
+      GetInfoLabel(pControlNode, "peripherallocation", peripheralLocation, parentID);
+      gcontrol->SetPeripheralLocation(peripheralLocation);
+
+      break;
+    }
+    case CGUIControl::GUICONTROL_GAMECONTROLLERLIST:
+    {
+      CScroller scroller;
+      GetScroller(pControlNode, "scrolltime", scroller);
+
+      control = new GAME::CGUIGameControllerList(parentID, id, posX, posY, width, height,
+                                                 orientation, labelInfo.align, scroller);
+
+      GAME::CGUIGameControllerList* lcontrol = static_cast<GAME::CGUIGameControllerList*>(control);
+
+      lcontrol->LoadLayout(pControlNode);
+      lcontrol->LoadListProvider(pControlNode, defaultControl, defaultAlways);
+      lcontrol->SetType(viewType, viewLabel);
+      lcontrol->SetPageControl(pageControl);
+      lcontrol->SetRenderOffset(offset);
+      lcontrol->SetAutoScrolling(pControlNode);
+      lcontrol->SetClickActions(clickActions);
+      lcontrol->SetFocusActions(focusActions);
+      lcontrol->SetUnFocusActions(unfocusActions);
+
+      break;
+    }
+    case CGUIControl::GUICONTROL_COLORBUTTON:
+    {
+      control = new CGUIColorButtonControl(parentID, id, posX, posY, width, height, textureFocus,
+                                           textureNoFocus, labelInfo, textureColorMask,
+                                           textureColorDisabledMask);
+
+      CGUIColorButtonControl* rcontrol = static_cast<CGUIColorButtonControl*>(control);
+      rcontrol->SetLabel(strLabel);
+      rcontrol->SetImageBoxColor(colorBox);
+      rcontrol->SetColorDimensions(colorPosX, colorPosY, colorWidth, colorHeight);
+      rcontrol->SetClickActions(clickActions);
+      rcontrol->SetFocusActions(focusActions);
+      rcontrol->SetUnFocusActions(unfocusActions);
+    }
     break;
-  case CGUIControl::GUICONTROL_RENDERADDON:
-    control = new CGUIRenderingControl(parentID, id, posX, posY, width, height);
-    break;
-  case CGUIControl::GUICONTROL_GAMECONTROLLER:
-  {
-    control = new GAME::CGUIGameController(parentID, id, posX, posY, width, height, texture);
-
-    GAME::CGUIGameController* gcontrol = static_cast<GAME::CGUIGameController*>(control);
-
-    // Set texture
-    gcontrol->SetInfo(textureFile);
-
-    // Set aspect ratio
-    gcontrol->SetAspectRatio(aspect);
-
-    // Set controller ID
-    GUIINFO::CGUIInfoLabel controllerId;
-    GetInfoLabel(pControlNode, "controllerid", controllerId, parentID);
-    gcontrol->SetControllerID(controllerId);
-
-    // Set controller address
-    GUIINFO::CGUIInfoLabel controllerAddress;
-    GetInfoLabel(pControlNode, "controlleraddress", controllerAddress, parentID);
-    gcontrol->SetControllerAddress(controllerAddress);
-
-    // Set controller diffuse color
-    GUIINFO::CGUIInfoColor controllerDiffuse(0xFFFFFFFF);
-    GetInfoColor(pControlNode, "controllerdiffuse", controllerDiffuse, parentID);
-    gcontrol->SetControllerDiffuse(controllerDiffuse);
-
-    // Set port address
-    GUIINFO::CGUIInfoLabel portAddress;
-    GetInfoLabel(pControlNode, "portaddress", portAddress, parentID);
-    gcontrol->SetPortAddress(portAddress);
-
-    // Set peripheral location
-    GUIINFO::CGUIInfoLabel peripheralLocation;
-    GetInfoLabel(pControlNode, "peripherallocation", peripheralLocation, parentID);
-    gcontrol->SetPeripheralLocation(peripheralLocation);
-
-    break;
-  }
-  case CGUIControl::GUICONTROL_GAMECONTROLLERLIST:
-  {
-    CScroller scroller;
-    GetScroller(pControlNode, "scrolltime", scroller);
-
-    control = new GAME::CGUIGameControllerList(parentID, id, posX, posY, width, height, orientation,
-                                               labelInfo.align, scroller);
-
-    GAME::CGUIGameControllerList* lcontrol = static_cast<GAME::CGUIGameControllerList*>(control);
-
-    lcontrol->LoadLayout(pControlNode);
-    lcontrol->LoadListProvider(pControlNode, defaultControl, defaultAlways);
-    lcontrol->SetType(viewType, viewLabel);
-    lcontrol->SetPageControl(pageControl);
-    lcontrol->SetRenderOffset(offset);
-    lcontrol->SetAutoScrolling(pControlNode);
-    lcontrol->SetClickActions(clickActions);
-    lcontrol->SetFocusActions(focusActions);
-    lcontrol->SetUnFocusActions(unfocusActions);
-
-    break;
-  }
-  case CGUIControl::GUICONTROL_COLORBUTTON:
-  {
-    control = new CGUIColorButtonControl(parentID, id, posX, posY, width, height, textureFocus,
-                                         textureNoFocus, labelInfo, textureColorMask,
-                                         textureColorDisabledMask);
-
-    CGUIColorButtonControl* rcontrol = static_cast<CGUIColorButtonControl*>(control);
-    rcontrol->SetLabel(strLabel);
-    rcontrol->SetImageBoxColor(colorBox);
-    rcontrol->SetColorDimensions(colorPosX, colorPosY, colorWidth, colorHeight);
-    rcontrol->SetClickActions(clickActions);
-    rcontrol->SetFocusActions(focusActions);
-    rcontrol->SetUnFocusActions(unfocusActions);
-  }
-  break;
-  default:
-    break;
+    default:
+      break;
   }
 
   // things that apply to all controls

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -1257,8 +1257,8 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
         static_cast<CGUIControlGroup*>(control)->SetDefaultControl(defaultControl, defaultAlways);
         static_cast<CGUIControlGroup*>(control)->SetRenderFocusedLast(renderFocusedLast);
       }
+      break;
     }
-    break;
     case CGUIControl::GUICONTROL_GROUPLIST:
     {
       CScroller scroller;
@@ -1270,8 +1270,9 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
       static_cast<CGUIControlGroup*>(control)->SetDefaultControl(defaultControl, defaultAlways);
       static_cast<CGUIControlGroup*>(control)->SetRenderFocusedLast(renderFocusedLast);
       static_cast<CGUIControlGroupList*>(control)->SetMinSize(minWidth, minHeight);
+
+      break;
     }
-    break;
     case CGUIControl::GUICONTROL_LABEL:
     {
       static const GUIINFO::CGUIInfoLabel empty;
@@ -1289,8 +1290,9 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
         static_cast<CGUILabelControl*>(control)->SetWidthControl(
             minWidth, (scrollValue == CGUIControl::ALWAYS));
       }
+
+      break;
     }
-    break;
     case CGUIControl::GUICONTROL_EDIT:
     {
       control = new CGUIEditControl(parentID, id, posX, posY, width, height, textureFocus,
@@ -1304,13 +1306,14 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
         static_cast<CGUIEditControl*>(control)->SetInputType(CGUIEditControl::INPUT_TYPE_PASSWORD,
                                                              0);
       static_cast<CGUIEditControl*>(control)->SetTextChangeActions(textChangeActions);
+
+      break;
     }
-    break;
     case CGUIControl::GUICONTROL_VIDEO:
     {
       control = new CGUIVideoControl(parentID, id, posX, posY, width, height);
+      break;
     }
-    break;
     case CGUIControl::GUICONTROL_GAME:
     {
       control = new RETRO::CGUIGameControl(parentID, id, posX, posY, width, height);
@@ -1330,8 +1333,9 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
       GUIINFO::CGUIInfoLabel pixels;
       GetInfoLabel(pControlNode, "pixels", pixels, parentID);
       static_cast<RETRO::CGUIGameControl*>(control)->SetPixels(pixels);
+
+      break;
     }
-    break;
     case CGUIControl::GUICONTROL_FADELABEL:
     {
       control =
@@ -1344,8 +1348,9 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
       if (scrollValue != CGUIControl::FOCUS)
         static_cast<CGUIFadeLabelControl*>(control)->SetScrolling(scrollValue ==
                                                                   CGUIControl::ALWAYS);
+
+      break;
     }
-    break;
     case CGUIControl::GUICONTROL_RSS:
     {
       control = new CGUIRSSControl(parentID, id, posX, posY, width, height, labelInfo, textColor3,
@@ -1353,8 +1358,9 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
       RssUrls::const_iterator iter = CRssManager::GetInstance().GetUrls().find(iUrlSet);
       if (iter != CRssManager::GetInstance().GetUrls().end())
         static_cast<CGUIRSSControl*>(control)->SetUrlSet(iUrlSet);
+
+      break;
     }
-    break;
     case CGUIControl::GUICONTROL_BUTTON:
     {
       control = new CGUIButtonControl(parentID, id, posX, posY, width, height, textureFocus,
@@ -1367,8 +1373,9 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
       bcontrol->SetClickActions(clickActions);
       bcontrol->SetFocusActions(focusActions);
       bcontrol->SetUnFocusActions(unfocusActions);
+
+      break;
     }
-    break;
     case CGUIControl::GUICONTROL_TOGGLEBUTTON:
     {
       control = new CGUIToggleButtonControl(parentID, id, posX, posY, width, height, textureFocus,
@@ -1384,8 +1391,9 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
       tcontrol->SetFocusActions(focusActions);
       tcontrol->SetUnFocusActions(unfocusActions);
       tcontrol->SetToggleSelect(toggleSelect);
+
+      break;
     }
-    break;
     case CGUIControl::GUICONTROL_RADIO:
     {
       control = new CGUIRadioButtonControl(
@@ -1401,8 +1409,9 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
       rcontrol->SetClickActions(clickActions);
       rcontrol->SetFocusActions(focusActions);
       rcontrol->SetUnFocusActions(unfocusActions);
+
+      break;
     }
-    break;
     case CGUIControl::GUICONTROL_SPIN:
     {
       control = new CGUISpinControl(parentID, id, posX, posY, width, height, textureUp, textureDown,
@@ -1428,8 +1437,9 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
         scontrol->SetFloatRange(fMin, fMax);
         scontrol->SetFloatInterval(fInterval);
       }
+
+      break;
     }
-    break;
     case CGUIControl::GUICONTROL_SLIDER:
     {
       control = new CGUISliderControl(
@@ -1438,8 +1448,9 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
 
       static_cast<CGUISliderControl*>(control)->SetInfo(singleInfo);
       static_cast<CGUISliderControl*>(control)->SetAction(action);
+
+      break;
     }
-    break;
     case CGUIControl::GUICONTROL_SETTINGS_SLIDER:
     {
       control = new CGUISettingsSliderControl(
@@ -1449,15 +1460,16 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
 
       static_cast<CGUISettingsSliderControl*>(control)->SetText(strLabel);
       static_cast<CGUISettingsSliderControl*>(control)->SetInfo(singleInfo);
+
+      break;
     }
-    break;
     case CGUIControl::GUICONTROL_SCROLLBAR:
     {
       control = new GUIScrollBarControl(parentID, id, posX, posY, width, height, textureBackground,
                                         textureBar, textureBarFocus, textureNib, textureNibFocus,
                                         orientation, showOnePage);
+      break;
     }
-    break;
     case CGUIControl::GUICONTROL_PROGRESS:
     {
       control =
@@ -1465,15 +1477,16 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
                                   textureLeft, textureMid, textureRight, textureOverlay, bReveal);
 
       static_cast<CGUIProgressControl*>(control)->SetInfo(singleInfo, singleInfo2);
+
+      break;
     }
-    break;
     case CGUIControl::GUICONTROL_RANGES:
     {
       control =
           new CGUIRangesControl(parentID, id, posX, posY, width, height, textureBackground,
                                 textureLeft, textureMid, textureRight, textureOverlay, singleInfo);
+      break;
     }
-    break;
     case CGUIControl::GUICONTROL_IMAGE:
     {
       // use a bordered texture if we have <bordersize> or <bordertexture> specified.
@@ -1486,16 +1499,18 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
       icontrol->SetInfo(textureFile);
       icontrol->SetAspectRatio(aspect);
       icontrol->SetCrossFade(fadeTime);
+
+      break;
     }
-    break;
     case CGUIControl::GUICONTROL_MULTI_IMAGE:
     {
       control = new CGUIMultiImage(parentID, id, posX, posY, width, height, texture, timePerImage,
                                    fadeTime, randomized, loop, timeToPauseAtEnd);
       static_cast<CGUIMultiImage*>(control)->SetInfo(texturePath);
       static_cast<CGUIMultiImage*>(control)->SetAspectRatio(aspect);
+
+      break;
     }
-    break;
     case CGUIControl::GUICONTAINER_LIST:
     {
       CScroller scroller;
@@ -1513,8 +1528,9 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
       lcontrol->SetClickActions(clickActions);
       lcontrol->SetFocusActions(focusActions);
       lcontrol->SetUnFocusActions(unfocusActions);
+
+      break;
     }
-    break;
     case CGUIControl::GUICONTAINER_WRAPLIST:
     {
       CScroller scroller;
@@ -1532,8 +1548,9 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
       wcontrol->SetClickActions(clickActions);
       wcontrol->SetFocusActions(focusActions);
       wcontrol->SetUnFocusActions(unfocusActions);
+
+      break;
     }
-    break;
     case CGUIControl::GUICONTAINER_EPGGRID:
     {
       CGUIEPGGridContainer* epgGridContainer =
@@ -1544,8 +1561,9 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
       epgGridContainer->SetRenderOffset(offset);
       epgGridContainer->SetType(viewType, viewLabel);
       epgGridContainer->SetPageControl(pageControl);
+
+      break;
     }
-    break;
     case CGUIControl::GUICONTAINER_FIXEDLIST:
     {
       CScroller scroller;
@@ -1563,8 +1581,9 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
       fcontrol->SetClickActions(clickActions);
       fcontrol->SetFocusActions(focusActions);
       fcontrol->SetUnFocusActions(unfocusActions);
+
+      break;
     }
-    break;
     case CGUIControl::GUICONTAINER_PANEL:
     {
       CScroller scroller;
@@ -1582,8 +1601,9 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
       pcontrol->SetClickActions(clickActions);
       pcontrol->SetFocusActions(focusActions);
       pcontrol->SetUnFocusActions(unfocusActions);
+
+      break;
     }
-    break;
     case CGUIControl::GUICONTROL_TEXTBOX:
     {
       if (!strMonoFont.empty())
@@ -1601,20 +1621,21 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
         tcontrol->SetInfo(infoLabels[0]);
       tcontrol->SetAutoScrolling(pControlNode);
       tcontrol->SetMinHeight(minHeight);
+
+      break;
     }
-    break;
     case CGUIControl::GUICONTROL_MOVER:
     {
       control = new CGUIMoverControl(parentID, id, posX, posY, width, height, textureFocus,
                                      textureNoFocus, movingSpeedCfg);
+      break;
     }
-    break;
     case CGUIControl::GUICONTROL_RESIZE:
     {
       control = new CGUIResizeControl(parentID, id, posX, posY, width, height, textureFocus,
                                       textureNoFocus, movingSpeedCfg);
+      break;
     }
-    break;
     case CGUIControl::GUICONTROL_SPINEX:
     {
       control = new CGUISpinControlEx(parentID, id, posX, posY, width, height, spinWidth,
@@ -1626,14 +1647,19 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
       scontrol->SetSpinPosition(spinPosX);
       scontrol->SetText(strLabel);
       scontrol->SetReverse(bReverse);
+
+      break;
     }
-    break;
     case CGUIControl::GUICONTROL_VISUALISATION:
+    {
       control = new CGUIVisualisationControl(parentID, id, posX, posY, width, height);
       break;
+    }
     case CGUIControl::GUICONTROL_RENDERADDON:
+    {
       control = new CGUIRenderingControl(parentID, id, posX, posY, width, height);
       break;
+    }
     case CGUIControl::GUICONTROL_GAMECONTROLLER:
     {
       control = new GAME::CGUIGameController(parentID, id, posX, posY, width, height, texture);
@@ -1708,8 +1734,9 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
       rcontrol->SetClickActions(clickActions);
       rcontrol->SetFocusActions(focusActions);
       rcontrol->SetUnFocusActions(unfocusActions);
+
+      break;
     }
-    break;
     default:
       break;
   }

--- a/xbmc/guilib/GUIControlFactory.h
+++ b/xbmc/guilib/GUIControlFactory.h
@@ -31,10 +31,10 @@ namespace GUILIB
 {
 namespace GUIINFO
 {
-  class CGUIInfoLabel;
+class CGUIInfoLabel;
 }
-}
-}
+} // namespace GUILIB
+} // namespace KODI
 
 /*!
  \ingroup controls
@@ -45,13 +45,16 @@ class CGUIControlFactory
 public:
   CGUIControlFactory(void);
   virtual ~CGUIControlFactory(void);
-  CGUIControl* Create(int parentID, const CRect &rect, TiXmlElement* pControlNode, bool insideContainer = false);
+  CGUIControl* Create(int parentID,
+                      const CRect& rect,
+                      TiXmlElement* pControlNode,
+                      bool insideContainer = false);
 
   /*! \brief translate from control name to control type
    \param type name of the control
    \return type of control
    */
-  static CGUIControl::GUICONTROLTYPES TranslateControlType(const std::string &type);
+  static CGUIControl::GUICONTROLTYPES TranslateControlType(const std::string& type);
 
   /*! \brief translate from control type to control name
    \param type type of the control
@@ -59,12 +62,21 @@ public:
    */
   static std::string TranslateControlType(CGUIControl::GUICONTROLTYPES type);
 
-  static bool GetAspectRatio(const TiXmlNode* pRootNode, const char* strTag, CAspectRatio &aspectRatio);
-  static bool GetInfoTexture(const TiXmlNode* pRootNode, const char* strTag, CTextureInfo &image, KODI::GUILIB::GUIINFO::CGUIInfoLabel &info, int parentID);
-  static bool GetTexture(const TiXmlNode* pRootNode, const char* strTag, CTextureInfo &image);
+  static bool GetAspectRatio(const TiXmlNode* pRootNode,
+                             const char* strTag,
+                             CAspectRatio& aspectRatio);
+  static bool GetInfoTexture(const TiXmlNode* pRootNode,
+                             const char* strTag,
+                             CTextureInfo& image,
+                             KODI::GUILIB::GUIINFO::CGUIInfoLabel& info,
+                             int parentID);
+  static bool GetTexture(const TiXmlNode* pRootNode, const char* strTag, CTextureInfo& image);
   static bool GetAlignment(const TiXmlNode* pRootNode, const char* strTag, uint32_t& dwAlignment);
   static bool GetAlignmentY(const TiXmlNode* pRootNode, const char* strTag, uint32_t& dwAlignment);
-  static bool GetAnimations(TiXmlNode *control, const CRect &rect, int context, std::vector<CAnimation> &animation);
+  static bool GetAnimations(TiXmlNode* control,
+                            const CRect& rect,
+                            int context,
+                            std::vector<CAnimation>& animation);
 
   /*! \brief Create an info label from an XML element
    Processes XML elements of the form
@@ -78,7 +90,7 @@ public:
    \return true if a valid info label was read, false otherwise
    */
 
-   /*! \brief Parse a position string
+  /*! \brief Parse a position string
    Handles strings of the form
    ###   number of pixels
    ###r  number of pixels measured from the right
@@ -89,26 +101,50 @@ public:
    */
   static float ParsePosition(const char* pos, const float parentSize);
 
-  static bool GetInfoLabelFromElement(const TiXmlElement *element, KODI::GUILIB::GUIINFO::CGUIInfoLabel &infoLabel, int parentID);
-  static void GetInfoLabel(const TiXmlNode *pControlNode, const std::string &labelTag, KODI::GUILIB::GUIINFO::CGUIInfoLabel &infoLabel, int parentID);
-  static void GetInfoLabels(const TiXmlNode *pControlNode, const std::string &labelTag, std::vector<KODI::GUILIB::GUIINFO::CGUIInfoLabel> &infoLabels, int parentID);
+  static bool GetInfoLabelFromElement(const TiXmlElement* element,
+                                      KODI::GUILIB::GUIINFO::CGUIInfoLabel& infoLabel,
+                                      int parentID);
+  static void GetInfoLabel(const TiXmlNode* pControlNode,
+                           const std::string& labelTag,
+                           KODI::GUILIB::GUIINFO::CGUIInfoLabel& infoLabel,
+                           int parentID);
+  static void GetInfoLabels(const TiXmlNode* pControlNode,
+                            const std::string& labelTag,
+                            std::vector<KODI::GUILIB::GUIINFO::CGUIInfoLabel>& infoLabels,
+                            int parentID);
   static bool GetColor(const TiXmlNode* pRootNode, const char* strTag, UTILS::COLOR::Color& value);
-  static bool GetInfoColor(const TiXmlNode* pRootNode, const char* strTag, KODI::GUILIB::GUIINFO::CGUIInfoColor &value, int parentID);
-  static std::string FilterLabel(const std::string &label);
-  static bool GetConditionalVisibility(const TiXmlNode* control, std::string &condition);
+  static bool GetInfoColor(const TiXmlNode* pRootNode,
+                           const char* strTag,
+                           KODI::GUILIB::GUIINFO::CGUIInfoColor& value,
+                           int parentID);
+  static std::string FilterLabel(const std::string& label);
+  static bool GetConditionalVisibility(const TiXmlNode* control, std::string& condition);
   static bool GetActions(const TiXmlNode* pRootNode, const char* strTag, CGUIAction& actions);
-  static void GetRectFromString(const std::string &string, CRect &rect);
-  static bool GetHitRect(const TiXmlNode* pRootNode, CRect &rect, const CRect &parentRect);
-  static bool GetScroller(const TiXmlNode *pControlNode, const std::string &scrollerTag, CScroller& scroller);
+  static void GetRectFromString(const std::string& string, CRect& rect);
+  static bool GetHitRect(const TiXmlNode* pRootNode, CRect& rect, const CRect& parentRect);
+  static bool GetScroller(const TiXmlNode* pControlNode,
+                          const std::string& scrollerTag,
+                          CScroller& scroller);
+
 private:
-  static std::string GetType(const TiXmlElement *pControlNode);
+  static std::string GetType(const TiXmlElement* pControlNode);
   static bool GetMovingSpeedConfig(const TiXmlNode* pRootNode,
                                    const char* strTag,
                                    UTILS::MOVING_SPEED::MapEventConfig& movingSpeedCfg);
-  static bool GetConditionalVisibility(const TiXmlNode* control, std::string &condition, std::string &allowHiddenFocus);
+  static bool GetConditionalVisibility(const TiXmlNode* control,
+                                       std::string& condition,
+                                       std::string& allowHiddenFocus);
   bool GetString(const TiXmlNode* pRootNode, const char* strTag, std::string& strString);
-  static bool GetFloatRange(const TiXmlNode* pRootNode, const char* strTag, float& iMinValue, float& iMaxValue, float& iIntervalValue);
-  static bool GetIntRange(const TiXmlNode* pRootNode, const char* strTag, int& iMinValue, int& iMaxValue, int& iIntervalValue);
+  static bool GetFloatRange(const TiXmlNode* pRootNode,
+                            const char* strTag,
+                            float& iMinValue,
+                            float& iMaxValue,
+                            float& iIntervalValue);
+  static bool GetIntRange(const TiXmlNode* pRootNode,
+                          const char* strTag,
+                          int& iMinValue,
+                          int& iMaxValue,
+                          int& iIntervalValue);
 
   /*! \brief Get the value of a position tag from XML
    Handles both absolute and relative values.
@@ -118,7 +154,10 @@ private:
    \param value [out] the returned value.
    \sa ParsePosition, GetDimension, GetDimensions.
    */
-  static bool GetPosition(const TiXmlNode *node, const char* tag, const float parentSize, float& value);
+  static bool GetPosition(const TiXmlNode* node,
+                          const char* tag,
+                          const float parentSize,
+                          float& value);
 
   /*! \brief grab a dimension out of the XML
 
@@ -134,7 +173,8 @@ private:
    \return true if we found and read the tag.
    \sa GetPosition, GetDimensions, ParsePosition.
    */
-  static bool GetDimension(const TiXmlNode *node, const char* strTag, const float parentSize, float &value, float &min);
+  static bool GetDimension(
+      const TiXmlNode* node, const char* strTag, const float parentSize, float& value, float& min);
 
   /*! \brief Retrieve the dimensions for a control.
 
@@ -153,8 +193,14 @@ private:
    \return true if we can successfully derive the position and size, false otherwise.
    \sa GetDimension, GetPosition, ParsePosition.
    */
-  static bool GetDimensions(const TiXmlNode *node, const char *leftTag, const char *rightTag, const char *centerLeftTag,
-                            const char *centerRightTag, const char *widthTag, const float parentSize, float &left,
-                            float &width, float &min_width);
+  static bool GetDimensions(const TiXmlNode* node,
+                            const char* leftTag,
+                            const char* rightTag,
+                            const char* centerLeftTag,
+                            const char* centerRightTag,
+                            const char* widthTag,
+                            const float parentSize,
+                            float& left,
+                            float& width,
+                            float& min_width);
 };
-


### PR DESCRIPTION
## Description

As title says, this PR formats GUIControlFactory.cpp/h using clang-format-11. It then updates the break statements in accordance with current the current style guide.

## Motivation and context

This improves the development experience of anyone adding new GUI controls.

It also makes it easier to rebase https://github.com/xbmc/xbmc/pull/21183 and my next-gen RetroPlayer branch that adds QR code controls.

## How has this been tested?

Compiles successfully.

I'm including this change in my next round of test builds so we'll get some runtime testing done too. I'll update the description with the results.

To check the formatting, I ran:

```bash
clang-format-11 -style=file -i xbmc/guilib/GUIControlFactory.cpp xbmc/guilib/GUIControlFactory.h
```

and verified that no further formatting is done.

## What is the effect on users?

None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
