### PR TITLE
[video] Fix CVideoDatabase::GetMusicVideosByWhere to set dyn path …

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -8925,6 +8925,7 @@ bool CVideoDatabase::GetMusicVideosByWhere(const std::string &baseDir, const Fil
         std::string path = std::to_string(record->at(0).get_asInt());
         itemUrl.AppendPath(path);
         item->SetPath(itemUrl.ToString());
+        item->SetDynPath(musicvideo.m_strFileNameAndPath);
 
         item->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, musicvideo.GetPlayCount() > 0);
         items.Add(item);


### PR DESCRIPTION
… for loaded items (like we do in all the other CVideoDatabase::Get*ByWhere methods already). 

Seems, it was simply forgotten to add for music videos, when dyn path was introduced. My recent "video info" refactoring now revealed that, eventually.

Fixes #23978

Runtime-tested on macOS, latest kodi master.

@enen92 sigh, another dyn path issue... mind reviewing this one-liner?

