### PR TITLE
[video] Fix 'Play using' offering RetroPlayer for playback of iso bd/dvd disc images.

### DIFF
--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -204,7 +204,9 @@ std::vector<std::string> GetPlayers(const CPlayerCoreFactory& playerCoreFactory,
   std::vector<std::string> players;
   if (item.IsVideoDb())
   {
-    const CFileItem item2{item.GetVideoInfoTag()->m_strFileNameAndPath, false};
+    //! @todo CPlayerCoreFactory and classes called from there do not handle dyn path correctly.
+    CFileItem item2{item};
+    item2.SetPath(item.GetDynPath());
     playerCoreFactory.GetPlayers(item2, players);
   }
   else


### PR DESCRIPTION
Yet another dynpath issue...

Fixes a problem reported in the forum, that "Play using..." offers RetroPlayer for playback of DB/DVD iso disc images.

![screenshot00003](https://github.com/xbmc/xbmc/assets/3226626/fbe476ae-9cb9-439b-a0cb-e343ed857ce9)

@CrystalP fyi

Runtime-tested on macOS, latest master + external player VLC + bd iso image.

@enen92 here we go again... thx for reviewing.
 