### PR TITLE
[PVR] Fix/Improve recently played channels widget (e.g. respect hidden groups and channels).

### DIFF
--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -64,7 +64,7 @@ namespace PVR
      * @brief Get the minimal database version that is required to operate correctly.
      * @return The minimal database version.
      */
-    int GetSchemaVersion() const override { return 43; }
+    int GetSchemaVersion() const override { return 44; }
 
     /*!
      * @brief Get the default sqlite database filename.
@@ -285,9 +285,10 @@ namespace PVR
     /*!
      * @brief Updates the last watched timestamp for the channel
      * @param channel the channel
+     * @param groupId the id of the group used to watch the channel
      * @return whether the update was successful
      */
-    bool UpdateLastWatched(const CPVRChannel& channel);
+    bool UpdateLastWatched(const CPVRChannel& channel, int groupId);
 
     /*!
      * @brief Updates the last watched timestamp for the channel group

--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -437,10 +437,47 @@ bool CPVRPlaybackState::CanRecordOnPlayingChannel() const
   return currentChannel && currentChannel->CanRecord();
 }
 
+namespace
+{
+std::shared_ptr<CPVRChannelGroup> GetFirstNonDeletedAndNonHiddenChannelGroup(
+    const std::shared_ptr<CPVRChannelGroupMember>& groupMember)
+{
+  CPVRChannelGroups* groups{
+      CServiceBroker::GetPVRManager().ChannelGroups()->Get(groupMember->IsRadio())};
+  if (groups)
+  {
+    const std::vector<std::shared_ptr<CPVRChannelGroup>> members{
+        groups->GetMembers(true /* exclude hidden */)};
+
+    for (const auto& member : members)
+    {
+      if (member->IsDeleted())
+        continue;
+
+      if (member->GetByUniqueID(groupMember->Channel()->StorageId()))
+        return member;
+    }
+  }
+
+  CLog::LogFC(LOGERROR, LOGPVR,
+              "Failed to obtain non-deleted and non-hidden group for channel '{}‘",
+              groupMember->Channel()->ChannelName());
+  return {};
+}
+} // unnamed namespace
+
 void CPVRPlaybackState::SetActiveChannelGroup(const std::shared_ptr<CPVRChannelGroup>& group)
 {
   if (group)
   {
+    if (group->IsHidden() || group->IsDeleted())
+    {
+      CLog::LogFC(LOGERROR, LOGPVR,
+                  "Rejecting to make hidden or deleted group '{}‘ the active group.",
+                  group->GroupName());
+      return;
+    }
+
     if (group->IsRadio())
       m_activeGroupRadio = group;
     else
@@ -456,57 +493,21 @@ void CPVRPlaybackState::SetActiveChannelGroup(
     const std::shared_ptr<CPVRChannelGroupMember>& channel)
 {
   const bool bRadio = channel->Channel()->IsRadio();
-  const std::shared_ptr<CPVRChannelGroup> group =
-      CServiceBroker::GetPVRManager().ChannelGroups()->Get(bRadio)->GetById(channel->GroupID());
+  std::shared_ptr<CPVRChannelGroup> group{
+      CServiceBroker::GetPVRManager().ChannelGroups()->Get(bRadio)->GetById(channel->GroupID())};
+
+  if (group && (group->IsHidden() || group->IsDeleted()))
+    group = GetFirstNonDeletedAndNonHiddenChannelGroup(channel);
 
   SetActiveChannelGroup(group);
 }
 
-namespace
-{
-std::shared_ptr<CPVRChannelGroup> GetFirstNonDeletedAndNonHiddenChannelGroup(bool bRadio)
-{
-  CPVRChannelGroups* groups = CServiceBroker::GetPVRManager().ChannelGroups()->Get(bRadio);
-  if (groups)
-  {
-    const std::vector<std::shared_ptr<CPVRChannelGroup>> members =
-        groups->GetMembers(true); // exclude hidden
-
-    const auto it = std::find_if(members.cbegin(), members.cend(),
-                                 [](const auto& group) { return !group->IsDeleted(); });
-    if (it != members.cend())
-      return (*it);
-  }
-
-  CLog::LogFC(LOGERROR, LOGPVR, "Failed to obtain any non-deleted and non-hidden group");
-  return {};
-}
-} // unnamed namespace
-
 std::shared_ptr<CPVRChannelGroup> CPVRPlaybackState::GetActiveChannelGroup(bool bRadio) const
 {
   if (bRadio)
-  {
-    if (m_activeGroupRadio && (m_activeGroupRadio->IsDeleted() || m_activeGroupRadio->IsHidden()))
-    {
-      // switch to first non-deleted and non-hidden group
-      const auto group = GetFirstNonDeletedAndNonHiddenChannelGroup(bRadio);
-      if (group)
-        const_cast<CPVRPlaybackState*>(this)->SetActiveChannelGroup(group);
-    }
     return m_activeGroupRadio;
-  }
   else
-  {
-    if (m_activeGroupTV && (m_activeGroupTV->IsDeleted() || m_activeGroupTV->IsHidden()))
-    {
-      // switch to first non-deleted and non-hidden group
-      const auto group = GetFirstNonDeletedAndNonHiddenChannelGroup(bRadio);
-      if (group)
-        const_cast<CPVRPlaybackState*>(this)->SetActiveChannelGroup(group);
-    }
     return m_activeGroupTV;
-  }
 }
 
 CDateTime CPVRPlaybackState::GetPlaybackTime(int iClientID, int iUniqueChannelID) const

--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -544,7 +544,7 @@ void CPVRPlaybackState::UpdateLastWatched(const std::shared_ptr<CPVRChannelGroup
   time_t iTime;
   time.GetAsTime(iTime);
 
-  channel->Channel()->SetLastWatched(iTime);
+  channel->Channel()->SetLastWatched(iTime, channel->GroupID());
 
   // update last watched timestamp for group
   const bool bRadio = channel->Channel()->IsRadio();

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -391,16 +391,17 @@ bool CPVRChannel::SetChannelName(const std::string& strChannelName, bool bIsUser
   return false;
 }
 
-bool CPVRChannel::SetLastWatched(time_t iLastWatched)
+bool CPVRChannel::SetLastWatched(time_t lastWatched, int groupId)
 {
   {
     std::unique_lock<CCriticalSection> lock(m_critSection);
-    m_iLastWatched = iLastWatched;
+    m_iLastWatched = lastWatched;
+    m_lastWatchedGroupId = groupId;
   }
 
   const std::shared_ptr<CPVRDatabase> database = CServiceBroker::GetPVRManager().GetTVDatabase();
   if (database)
-    return database->UpdateLastWatched(*this);
+    return database->UpdateLastWatched(*this, groupId);
 
   return false;
 }
@@ -716,6 +717,12 @@ bool CPVRChannel::IsUserSetHidden() const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_bIsUserSetHidden;
+}
+
+int CPVRChannel::LastWatchedGroupId() const
+{
+  std::unique_lock<CCriticalSection> lock(m_critSection);
+  return m_lastWatchedGroupId;
 }
 
 std::string CPVRChannel::ChannelName() const

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -182,6 +182,11 @@ public:
   bool IsUserSetHidden() const;
 
   /*!
+   * @return the id of the channel group the channel was watched from the last time; -1 if unknown.
+   */
+  int LastWatchedGroupId() const;
+
+  /*!
    * @brief Set the path to the icon for this channel.
    * @param strIconPath The new path.
    * @param bIsUserSetIcon true if user changed the icon via GUI, false otherwise.
@@ -208,11 +213,12 @@ public:
   time_t LastWatched() const;
 
   /*!
-   * @brief Last time channel has been watched
-   * @param iLastWatched The new value.
+   * @brief Set the last time the channel has been watched and the channel group used to watch.
+   * @param lastWatched The new last watched time value.
+   * @param groupId the id of the group used to watch the channel.
    * @return True if the something changed, false otherwise.
    */
-  bool SetLastWatched(time_t iLastWatched);
+  bool SetLastWatched(time_t lastWatched, int groupId);
 
   /*!
    * @brief Check whether this channel has unpersisted data changes.
@@ -543,6 +549,8 @@ private:
   int m_iClientOrder = 0; /*!< the order from this channels group member */
   int m_iClientProviderUid =
       PVR_PROVIDER_INVALID_UID; /*!< the unique id for this provider from the client */
+  int m_lastWatchedGroupId{
+      -1}; /*!< the id of the channel group the channel was watched from the last time */
   //@}
 
   mutable CCriticalSection m_critSection;

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -31,6 +31,8 @@ static constexpr int PVR_GROUP_TYPE_LOCAL = 2;
 static constexpr int PVR_GROUP_CLIENT_ID_UNKNOWN = -2;
 static constexpr int PVR_GROUP_CLIENT_ID_LOCAL = -1;
 
+static constexpr int PVR_GROUP_ID_UNNKOWN{-1};
+
 enum class PVREvent;
 
 class CPVRChannel;


### PR DESCRIPTION
Fixes recently played channels widget to respect hidden channel groups as well as the group the channel was last played from.

Heads-up: For this a TV database bump was needed (we need to store the id of the group used to last watched together with the timestamp).

@Uukrull this should solve all issues you have reported with your setup hiding the "All channels" group. Could you runtime-test and report back?

I carefully runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish could you do the code review?