### PR TITLE
Fix controller not rendering for copied gamecontroller controls

### DIFF
--- a/xbmc/games/controllers/guicontrols/GUIGameController.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIGameController.cpp
@@ -199,19 +199,12 @@ void CGUIGameController::ActivateController(const std::string& controllerId)
 
 void CGUIGameController::ActivateController(const ControllerPtr& controller)
 {
-  if (!controller)
-    return;
+  m_currentController = controller;
 
-  bool updated = false;
-
-  if (!m_currentController || controller->ID() != m_currentController->ID())
-  {
-    m_currentController = controller;
-    updated = true;
-  }
-
-  if (updated)
+  if (m_currentController)
     SetFileName(m_currentController->Layout().ImagePath());
+  else
+    SetFileName("");
 }
 
 std::string CGUIGameController::GetPortAddress()


### PR DESCRIPTION
## Description

This PR fixes an extreme edge case of a `gamecontroller` control used in a list-within-a-list with static listitems provided by a `<content>` node. Sporadically, when updating the outer list, the controller images within the inner list can disappear, and can also sporadically return.

![screenshot00006](https://github.com/xbmc/xbmc/assets/531482/3e2a12f6-02fb-4fda-8add-41961446fcdc)

The reason is because the control path for copying lists-within-lists does not properly clear `m_currentController`, causing the static item state to not set the filename because the new controller has the same ID as `m_currentController`.

However, CGUIImage (which `gamecontroller` derives from) properly resets image filename state when copied (as you can see in the correct "DefaultAddonNone.png" images being shown on each line). So skip the check for the existing controller ID and let CGUIImage handle filename state updates.

## Motivation and context

Helping @HitcherUK develop XML for the new `gameagents` window. He didn't have multiple controllers to test the UI with, so I showed him how to modify the window with static listitems so get skin dimensions right.

However, when scrolling the static items, I noticed all the controller images disappeared and returned sporadically. Debugging led me to this fix.

## How has this been tested?

I added static listitems using this XML:

```patch
--- a/addons/skin.estuary/xml/Includes_Games.xml
+++ b/addons/skin.estuary/xml/Includes_Games.xml
@@ -418,6 +418,44 @@
 							</control>
 							<include>GameDialogAgentLayout</include>
 						</focusedlayout>
+						<content>
+							<item>
+								<label>Player 1</label>
+							</item>
+							<item>
+								<label>Player 2</label>
+							</item>
+							<item>
+								<label>Player 3</label>
+							</item>
+							<item>
+								<label>Player 4</label>
+							</item>
+							<item>
+								<label>Player 5</label>
+							</item>
+							<item>
+								<label>Player 6</label>
+							</item>
+							<item>
+								<label>Player 7</label>
+							</item>
+							<item>
+								<label>Player 8</label>
+							</item>
+							<item>
+								<label>Player 9</label>
+							</item>
+							<item>
+								<label>Player 10</label>
+							</item>
+							<item>
+								<label>Player 11</label>
+							</item>
+							<item>
+								<label>Player 12</label>
+							</item>
+						</content>
 					</control>
 				</control>
 				<control type="scrollbar" id="61">
@@ -465,16 +503,61 @@
 			<enable>false</enable>
 			<itemlayout width="96" height="96">
 				<control type="gamecontroller">
+					<texture>$INFO[ListItem.Icon]</texture>
+					<controllerid>$INFO[ListItem.Property(controllerid)]</controllerid>
 					<peripherallocation>$INFO[ListItem.FilenameAndPath]</peripherallocation>
 					<controllerdiffuse>button_focus</controllerdiffuse>
 				</control>
 			</itemlayout>
 			<focusedlayout width="96" height="96">
 				<control type="gamecontroller">
+					<texture>$INFO[ListItem.Icon]</texture>
+					<controllerid>$INFO[ListItem.Property(controllerid)]</controllerid>
 					<peripherallocation>$INFO[ListItem.FilenameAndPath]</peripherallocation>
 					<controllerdiffuse>button_focus</controllerdiffuse>
 				</control>
 			</focusedlayout>
+			<content>
+				<item>
+					<icon>DefaultAddonNone.png</icon>
+				</item>
+				<item>
+					<property name="controllerid">game.controller.default</property>
+				</item>
+				<item>
+					<property name="controllerid">game.controller.default</property>
+				</item>
+				<item>
+					<property name="controllerid">game.controller.default</property>
+				</item>
+				<item>
+					<property name="controllerid">game.controller.default</property>
+				</item>
+				<item>
+					<property name="controllerid">game.controller.default</property>
+				</item>
+				<item>
+					<property name="controllerid">game.controller.default</property>
+				</item>
+				<item>
+					<property name="controllerid">game.controller.default</property>
+				</item>
+				<item>
+					<property name="controllerid">game.controller.default</property>
+				</item>
+				<item>
+					<property name="controllerid">game.controller.default</property>
+				</item>
+				<item>
+					<property name="controllerid">game.controller.default</property>
+				</item>
+				<item>
+					<property name="controllerid">game.controller.default</property>
+				</item>
+				<item>
+					<property name="controllerid">game.controller.default</property>
+				</item>
+			</content>
 		</control>
 	</include>
 </includes>
```

Screenshot above shows the bug.

After, showing all controllers rendering correctly:

![screenshot00008](https://github.com/xbmc/xbmc/assets/531482/5f242ef2-3a4f-4807-86ca-890479a64ec0)

## What is the effect on users?

* Basically none, edge case is so extreme it's only seen during heavy skin development

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
