### PR TITLE
[Windows] Disable video settings not supported by the DXVA processor.

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -660,3 +660,18 @@ bool CProcessorHD::SetConversion(const ProcessorConversion& conversion)
 
   return true;
 }
+
+bool CProcessorHD::Supports(ERENDERFEATURE feature) const
+{
+  switch (feature)
+  {
+    case RENDERFEATURE_BRIGHTNESS:
+      return m_procCaps.m_Filters[D3D11_VIDEO_PROCESSOR_FILTER_BRIGHTNESS].bSupported;
+    case RENDERFEATURE_CONTRAST:
+      return m_procCaps.m_Filters[D3D11_VIDEO_PROCESSOR_FILTER_CONTRAST].bSupported;
+    case RENDERFEATURE_ROTATION:
+      return (m_procCaps.m_vcaps.FeatureCaps & D3D11_VIDEO_PROCESSOR_FEATURE_CAPS_ROTATION);
+    default:
+      return false;
+  }
+}

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.h
@@ -57,6 +57,7 @@ public:
   static bool IsSuperResolutionSuitable(const VideoPicture& picture);
   void TryEnableVideoSuperResolution();
   bool IsVideoSuperResolutionEnabled() const { return m_superResolutionEnabled; }
+  bool Supports(ERENDERFEATURE feature) const;
 
 protected:
   bool ReInit();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
@@ -272,23 +272,10 @@ bool CWinRenderer::Flush(bool saveBuffers)
 
 bool CWinRenderer::Supports(ERENDERFEATURE feature) const
 {
-  if(feature == RENDERFEATURE_BRIGHTNESS)
-    return true;
+  if (!m_bConfigured)
+    return false;
 
-  if(feature == RENDERFEATURE_CONTRAST)
-    return true;
-
-  if (feature == RENDERFEATURE_STRETCH         ||
-      feature == RENDERFEATURE_NONLINSTRETCH   ||
-      feature == RENDERFEATURE_ZOOM            ||
-      feature == RENDERFEATURE_VERTICAL_SHIFT  ||
-      feature == RENDERFEATURE_PIXEL_RATIO     ||
-      feature == RENDERFEATURE_ROTATION        ||
-      feature == RENDERFEATURE_POSTPROCESS     ||
-      feature == RENDERFEATURE_TONEMAP)
-    return true;
-
-  return false;
+  return m_renderer->Supports(feature);
 }
 
 bool CWinRenderer::Supports(ESCALINGMETHOD method) const

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
@@ -770,3 +770,15 @@ bool CRendererBase::IntendToRenderAsHDR(const VideoPicture& picture)
 
   return streamIsHDR && canDisplayHDR;
 }
+
+bool CRendererBase::Supports(ERENDERFEATURE feature) const
+{
+  if (feature == RENDERFEATURE_BRIGHTNESS || feature == RENDERFEATURE_CONTRAST ||
+      feature == RENDERFEATURE_STRETCH || feature == RENDERFEATURE_NONLINSTRETCH ||
+      feature == RENDERFEATURE_ZOOM || feature == RENDERFEATURE_VERTICAL_SHIFT ||
+      feature == RENDERFEATURE_PIXEL_RATIO || feature == RENDERFEATURE_ROTATION ||
+      feature == RENDERFEATURE_POSTPROCESS || feature == RENDERFEATURE_TONEMAP)
+    return true;
+
+  return false;
+}

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.h
@@ -115,6 +115,8 @@ public:
   virtual CRenderInfo GetRenderInfo();
   virtual bool Configure(const VideoPicture &picture, float fps, unsigned int orientation);
   virtual bool Supports(ESCALINGMETHOD method) const = 0;
+  virtual bool Supports(ERENDERFEATURE feature) const;
+
   virtual bool WantsDoublePass() { return false; }
   virtual bool NeedBuffer(int idx) { return false; }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.cpp
@@ -304,6 +304,20 @@ void CRendererDXVA::FillBuffersSet(CRenderBuffer* (&buffers)[8])
   }
 }
 
+bool CRendererDXVA::Supports(ERENDERFEATURE feature) const
+{
+  if (feature == RENDERFEATURE_BRIGHTNESS || feature == RENDERFEATURE_CONTRAST ||
+      feature == RENDERFEATURE_ROTATION)
+  {
+    if (m_processor)
+      return m_processor->Supports(feature);
+
+    return false;
+  }
+
+  return CRendererBase::Supports(feature);
+}
+
 bool CRendererDXVA::Supports(ESCALINGMETHOD method) const
 {
   if (method == VS_SCALINGMETHOD_DXVA_HARDWARE)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererDXVA.h
@@ -29,6 +29,7 @@ public:
 
   CRenderInfo GetRenderInfo() override;
   bool Supports(ESCALINGMETHOD method) const override;
+  bool Supports(ERENDERFEATURE feature) const override;
   bool WantsDoublePass() override { return true; }
   bool Configure(const VideoPicture& picture, float fps, unsigned orientation) override;
   bool NeedBuffer(int idx) override;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Brightness and contrast video settings available even when the dxva processor doesn't support them.

Windows was unconditionally reporting those two features as supported without testing the hardware. The DXVA API reports that type of information so propagate the information to enabled/disable the settings based on hardware support.

Used the opportunity to also propagate the rotation capability, but it has no effect on the video settings screen. There are workarounds in place for some situations, the situation is a bit complicated and more work would be needed to do this correctly.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix issue #23962, surface pro arm tablets don't support brightness and contrast adjustments. Kodi still shows them in the video settings, but they have no effect.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Simulated on Windows 10 by altering the capabilities detected by CEnumeratorHD, as no Surface pro arm on hand and it's the only known Windows hardware lacking the support.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Clearer user interface for Surface pro arm users.

## Screenshots (if appropriate):
dxva processor with brightness/contrast support:
![image](https://github.com/xbmc/xbmc/assets/489377/591f8c7e-61e7-41aa-abcf-ff8686d71c16)

simulated processor without brightness/contrast support:
![image](https://github.com/xbmc/xbmc/assets/489377/08f59de3-a7a7-48ca-8749-814ee044e689)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
