### PR TITLE
Add LoongArch support to system info

### DIFF
--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -1033,7 +1033,7 @@ int CSysInfo::GetKernelBitness(void)
       std::string machine(un.machine);
       if (machine == "x86_64" || machine == "amd64" || machine == "arm64" || machine == "aarch64" ||
           machine == "ppc64" || machine == "ppc64el" || machine == "ppc64le" || machine == "ia64" ||
-          machine == "mips64" || machine == "s390x" || machine == "riscv64")
+          machine == "loongarch64" || machine == "mips64" || machine == "s390x" || machine == "riscv64")
         kernelBitness = 64;
       else
         kernelBitness = 32;
@@ -1080,6 +1080,8 @@ const std::string& CSysInfo::GetKernelCpuFamily(void)
       std::string machine(un.machine);
       if (machine.compare(0, 3, "arm", 3) == 0 || machine.compare(0, 7, "aarch64", 7) == 0)
         kernelCpuFamily = "ARM";
+      else if (machine.compare(0, 9, "loongarch", 9) == 0 || machine.compare(0, 7, "loong64", 7) == 0)
+        kernelCpuFamily = "LoongArch";
       else if (machine.compare(0, 4, "mips", 4) == 0)
         kernelCpuFamily = "MIPS";
       else if (machine.compare(0, 4, "i686", 4) == 0 || machine == "i386" || machine == "amd64" ||  machine.compare(0, 3, "x86", 3) == 0)
@@ -1466,6 +1468,8 @@ std::string CSysInfo::GetBuildTargetCpuFamily(void)
   return "ARM (Thumb)";
 #elif defined(__arm__) || defined(_M_ARM) || defined (__aarch64__)
   return "ARM";
+#elif defined(__loongarch__)
+  return "LoongArch";
 #elif defined(__mips__) || defined(mips) || defined(__mips)
   return "MIPS";
 #elif defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64) || defined(_M_X64) || defined(_M_AMD64) || \


### PR DESCRIPTION
## Description
Improved support for LoongArch architecture.
<!--- Describe your change in detail here. -->

## Motivation and context
When compiling the package kodi for loong64 in the Debian Package Auto-Building environment [1], the error messages are as follows.
```
The following tests FAILED:
	130 - TestSystemInfo.GetKernelBitness (Failed)
	131 - TestSystemInfo.GetKernelCpuFamily (Failed)
	132 - TestSystemInfo.GetXbmcBitness (Failed)
	137 - TestSystemInfo.GetBuildTargetCpuFamily (Failed)
Errors while running CTest
make[2]: *** [Makefile:74: test] Error 8
make[2]: Leaving directory '/<<PKGBUILDDIR>>/obj-loongarch64-linux-gnu'
dh_auto_test: error: cd obj-loongarch64-linux-gnu && make -j16 test ARGS\+=--verbose ARGS\+=-j16 returned exit code 2
```
The full compilation log can be found at [2].
[1]:https://buildd.debian.org/status/package.php?p=kodi&suite=sid
[2]:https://buildd.debian.org/status/logs.php?pkg=kodi&ver=2%3A20.2%2Bdfsg-4&arch=loong64

## How has this been tested?
Using test cases from the Debian kodi source package. 
Such as, 
```
- The tests rules in debian/rules.
override_dh_auto_test-arch:
        dh_auto_build -- kodi-test
        dh_auto_test -a

- The actual test commands run are as follows.
Running tests...
/usr/bin/ctest --force-new-ctest-process --verbose -j16
```
## What is the effect on users?
When the user uses kodi compiled on the loongarch64, the test cases related to system info will pass.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
