### PR TITLE
[Estuary] Fix home categories focus position

### DIFF
--- a/addons/skin.estuary/xml/Includes_Home.xml
+++ b/addons/skin.estuary/xml/Includes_Home.xml
@@ -378,9 +378,9 @@
 						</control>
 					</control>
 				</focusedlayout>
-				<content target="$PARAM[widget_target]" limit="$PARAM[item_limit]" browse="$PARAM[browse_mode]">$PARAM[content_path]</content>
 				<include condition="$PARAM[additional_movie_items]" content="MovieSubmenuItems" />
 				<include condition="$PARAM[additional_tvshow_items]" content="TVShowSubmenuItems" />
+				<content target="$PARAM[widget_target]" limit="$PARAM[item_limit]" browse="$PARAM[browse_mode]">$PARAM[content_path]</content>
 			</control>
 		</definition>
 	</include>

--- a/addons/skin.estuary/xml/View_53_Shift.xml
+++ b/addons/skin.estuary/xml/View_53_Shift.xml
@@ -260,26 +260,26 @@
 				<control type="panel">
 					<left>20</left>
 					<top>48</top>
-					<width>1880</width>
+					<width>940</width>
 					<height>180</height>
 					<orientation>horizontal</orientation>
 					<visible>ListItem.IsCollection</visible>
 					<animation effect="fade" time="200">VisibleChange</animation>
-					<focusedlayout height="40" width="628">
+					<focusedlayout height="40" width="470">
 						<control type="label">
 							<textoffsetx>10</textoffsetx>
 							<height>40</height>
-							<width>628</width>
+							<width>470</width>
 							<aligny>center</aligny>
 							<label>$INFO[ListItem.Year,[COLOR button_focus],[/COLOR]  -  ]$INFO[ListItem.Title]</label>
 							<shadowcolor>text_shadow</shadowcolor>
 						</control>
 					</focusedlayout>
-					<itemlayout height="40" width="628">
+					<itemlayout height="40" width="470">
 						<control type="label">
 							<textoffsetx>10</textoffsetx>
 							<height>40</height>
-							<width>628</width>
+							<width>470</width>
 							<aligny>center</aligny>
 							<label>$INFO[ListItem.Year,[COLOR button_focus],[/COLOR]  -  ]$INFO[ListItem.Title]</label>
 							<shadowcolor>text_shadow</shadowcolor>

--- a/addons/skin.estuary/xml/View_53_Shift.xml
+++ b/addons/skin.estuary/xml/View_53_Shift.xml
@@ -260,26 +260,26 @@
 				<control type="panel">
 					<left>20</left>
 					<top>48</top>
-					<width>940</width>
+					<width>1880</width>
 					<height>180</height>
 					<orientation>horizontal</orientation>
 					<visible>ListItem.IsCollection</visible>
 					<animation effect="fade" time="200">VisibleChange</animation>
-					<focusedlayout height="40" width="470">
+					<focusedlayout height="40" width="628">
 						<control type="label">
 							<textoffsetx>10</textoffsetx>
 							<height>40</height>
-							<width>470</width>
+							<width>628</width>
 							<aligny>center</aligny>
 							<label>$INFO[ListItem.Year,[COLOR button_focus],[/COLOR]  -  ]$INFO[ListItem.Title]</label>
 							<shadowcolor>text_shadow</shadowcolor>
 						</control>
 					</focusedlayout>
-					<itemlayout height="40" width="470">
+					<itemlayout height="40" width="628">
 						<control type="label">
 							<textoffsetx>10</textoffsetx>
 							<height>40</height>
-							<width>470</width>
+							<width>628</width>
 							<aligny>center</aligny>
 							<label>$INFO[ListItem.Year,[COLOR button_focus],[/COLOR]  -  ]$INFO[ListItem.Title]</label>
 							<shadowcolor>text_shadow</shadowcolor>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This fixes the problem where the 'Now playing' (for Movies) and 'Next Aired' (for TV Shows) would get focus even though they're at the end of the categories list.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It seems that in a mixed content type list the static content gets focus ahead of the dynamic content. By simply placing the static items at the front of the categories list means the focus always goes to the front of the list.
Problem reported on the forum - [Category Icons at top is right aligned for some reason](https://forum.kodi.tv/showthread.php?tid=374267)
Fixes this issue - https://github.com/xbmc/xbmc/issues/20139

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested and works as expected.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):
Before PR:
The categories list is offset on load
![screenshot00004](https://github.com/xbmc/xbmc/assets/133808/dee0cd79-5cd2-4b94-9837-556c41200cb9)
And the first item doesn't get selected
![screenshot00005](https://github.com/xbmc/xbmc/assets/133808/27b92b3c-0da3-4afc-814c-3a21e3a40f90)

After PR:
The categories list is correctly aligned
![screenshot00006](https://github.com/xbmc/xbmc/assets/133808/e65e4ad6-7e73-4f22-8f4f-0b93aa04498c)
And the first item gets selected
![screenshot00007](https://github.com/xbmc/xbmc/assets/133808/88cf8443-6cd2-4874-9c68-4456a2c18737)
## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
