### PR TITLE
[docs] Coding guideline: Add, that we are using prefix operators in t…

### DIFF
--- a/docs/CODE_GUIDELINES.md
+++ b/docs/CODE_GUIDELINES.md
@@ -821,6 +821,25 @@ for (const auto& : var)
 ```
 Remove `const` if the value has to be modified. Do not use references to fundamental types that are not modified.
 
+In traditional for loops, for the `increment statement` of the loop, use prefix increment/decrement operator, not postfix.
+
+✅ Good:
+```cpp
+[...]
+for (int i = 0; i < 100; ++i)
+{
+  [...]
+}
+```
+
+❌ Bad:
+```cpp
+for (int i = 0; i < 100; i++)
+{
+  [...]
+}
+```
+
 ### 12.6. Include guards
 
 Use `#pragma once`.


### PR DESCRIPTION
…raditional for loop's increment statement.

As outcome of recent discussion in a certain PR, we need to add this to our guideline.