### PR TITLE
[imagecache] CVideoGeneratedImageFileLoader check setting to extract thumb

### DIFF
--- a/xbmc/video/VideoGeneratedImageFileLoader.cpp
+++ b/xbmc/video/VideoGeneratedImageFileLoader.cpp
@@ -51,7 +51,7 @@ void SetupRarOptions(CFileItem& item, const std::string& path)
 std::unique_ptr<CTexture> VIDEO::CVideoGeneratedImageFileLoader::Load(
     const std::string& specialType, const std::string& filePath, unsigned int, unsigned int) const
 {
-  if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+  if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
           CSettings::SETTING_MYVIDEOS_EXTRACTTHUMB))
   {
     return {};

--- a/xbmc/video/VideoGeneratedImageFileLoader.cpp
+++ b/xbmc/video/VideoGeneratedImageFileLoader.cpp
@@ -10,9 +10,12 @@
 
 #include "DVDFileInfo.h"
 #include "FileItem.h"
+#include "ServiceBroker.h"
 #include "URL.h"
 #include "filesystem/DirectoryCache.h"
 #include "guilib/Texture.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/URIUtils.h"
 #include "video/VideoInfoTag.h"
 
@@ -48,6 +51,12 @@ void SetupRarOptions(CFileItem& item, const std::string& path)
 std::unique_ptr<CTexture> VIDEO::CVideoGeneratedImageFileLoader::Load(
     const std::string& specialType, const std::string& filePath, unsigned int, unsigned int) const
 {
+  if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+          CSettings::SETTING_MYVIDEOS_EXTRACTTHUMB))
+  {
+    return {};
+  }
+
   CFileItem item{filePath, false};
 
   if (URIUtils::IsInRAR(filePath))


### PR DESCRIPTION
## Description
Check the Kodi setting [Extract thumbnails from video files](https://kodi.wiki/view/Settings/Media/Videos#Extract_thumbnails_from_video_files) right before trying to extract the thumbnail from a video file.

## Motivation and context
Recent work separated video thumbnail generation from identification of other artwork, and only checked the setting during identification like other "Artwork" settings. However, there are other ways to get such an image path into the library and the cost to load the images can be high, so check it on the other end, too.

## How has this been tested?
Just a short manual test so far.

## What is the effect on users?
Make the setting behave as expected. Covers the mostly likely cause of #23958.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
