### PR TITLE
[upnp] Alternative fix for serving smartplaylists via upnp

### DIFF
--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -410,8 +410,8 @@ PLT_MediaObject* CUPnPServer::Build(const std::shared_ptr<CFileItem>& item,
                 }
             }
         }
-        // playlists are folders
-        else if (item->IsPlayList())
+        // all playlist types are folders
+        else if (item->IsPlayList() || item->IsSmartPlayList())
         {
             item->m_bIsFolder = true;
         }

--- a/xbmc/playlists/PlayListFactory.cpp
+++ b/xbmc/playlists/PlayListFactory.cpp
@@ -134,12 +134,12 @@ bool CPlayListFactory::IsPlaylist(const CFileItem& item)
 bool CPlayListFactory::IsPlaylist(const CURL& url)
 {
   return URIUtils::HasExtension(url,
-                                ".m3u|.m3u8|.b4s|.pls|.strm|.wpl|.asx|.ram|.url|.pxml|.xspf|.xsp");
+                                ".m3u|.m3u8|.b4s|.pls|.strm|.wpl|.asx|.ram|.url|.pxml|.xspf");
 }
 
 bool CPlayListFactory::IsPlaylist(const std::string& filename)
 {
   return URIUtils::HasExtension(filename,
-                                ".m3u|.m3u8|.b4s|.pls|.strm|.wpl|.asx|.ram|.url|.pxml|.xspf|.xsp");
+                     ".m3u|.m3u8|.b4s|.pls|.strm|.wpl|.asx|.ram|.url|.pxml|.xspf");
 }
 


### PR DESCRIPTION
## Description
As discussed internally the original fix https://github.com/xbmc/xbmc/pull/23831 introduced regressions in other parts of the code (honestly I was hoping the regressions would come up sooner :) ).
Since smarplaylists are not part of the playlistfactory nor derive from CPlaylist they probably don't belong on that list. Hence, check for the smartplaylist type on the upnp server instead.

## Motivation and context
Bug fixing for playlist types being overridden 

## How has this been tested?
Use the same metodology in https://github.com/xbmc/xbmc/pull/23831 and https://github.com/xbmc/xbmc/issues/23819 using VLC as the client.

## What is the effect on users?
Should fix the issue mentioned in slack. The original issue that lead to the change should also still be fixed.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)


