### PR TITLE
[python] Fix xmbc.getRegion("time")

### DIFF
--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -446,11 +446,14 @@ namespace XBMCAddon
         else
         {
           StringUtils::Replace(result, "H", "%H");
+          StringUtils::Replace(result, "hh", "%I");
           StringUtils::Replace(result, "h", "%I");
-          StringUtils::Replace(result, "mm", "%M");
-          StringUtils::Replace(result, "ss", "%S");
-          StringUtils::Replace(result, "xx", "%p");
         }
+        StringUtils::Replace(result, "mm", "%M");
+        StringUtils::Replace(result, "m", "%M");
+        StringUtils::Replace(result, "ss", "%S");
+        StringUtils::Replace(result, "s", "%S");
+        StringUtils::Replace(result, "xx", "%p");
       }
       else if (StringUtils::CompareNoCase(id, "meridiem") == 0)
       {

--- a/xbmc/interfaces/legacy/ModuleXbmc.h
+++ b/xbmc/interfaces/legacy/ModuleXbmc.h
@@ -649,9 +649,11 @@ namespace XBMCAddon
     /// @param id                    string - id of setting to return
     /// @return                      Region setting
     ///
-    /// @note choices are (dateshort, datelong, time, meridiem, tempunit, speedunit)
-    ///        You can use the above as keywords for arguments.
+    /// @note choices are (dateshort, datelong, time, meridiem, tempunit, speedunit,
+    ///       datelongraw, dateshortraw, timeraw)
+    ///       You can use the above as keywords for arguments.
     ///
+    /// @warning an empty string is returned if the provided Id is not supported
     ///
     /// ------------------------------------------------------------------------
     ///


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

-  Always convert minutes and seconds, fix after #22982
- Complete time formatting codes from https://kodi.wiki/view/Language_support#langinfo.xml

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #23974

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local Linux build, locale set to German.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Regression fix.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
