### PR TITLE
[linux][docs] add note about libdisplay-info when building kodi with gbm windowing

### DIFF
--- a/docs/README.Linux.md
+++ b/docs/README.Linux.md
@@ -124,6 +124,10 @@ Internal dependencies that are based on cmake upstream (currently crossguid, ffm
 
 **Note:** fstrcmp requires libtool
 
+### 3.3. External Dependencies
+
+Building with GBM windowing (including `gbm` in the `CORE_PLATFORM_NAME` cmake config) requires `libdisplay-info` for EDID parsing. This is currently a hard dependency for GBM windowing and no internal build option is available. Some distributions may already package it but if not it is available to build from source here: https://gitlab.freedesktop.org/emersion/libdisplay-info
+
 **[back to top](#table-of-contents)** | **[back to section top](#3-install-the-required-packages)**
 
 ## 4. Build Kodi


### PR DESCRIPTION
This adds a small blurb in the linux build docs about the requirement on `libdisplay-info`.

`libdisplay-info` is build with meson and we currently don't have any plumbing for using meson with the cmake internal build stuff. So adding some text is better than nothing at all.

We do build it as part of the depends build for CI purposes but I don't plan to extend that for the internal build.