### PR TITLE
[FileSystem] Add GUI settings for NFS and SMB chunk size

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -22143,7 +22143,37 @@ msgctxt "#37052"
 msgid "NFS protocol version to use when establishing NFS connections"
 msgstr ""
 
-#empty strings from id 37053 to 38010
+#. Settings / Services "Chunk Size" group label
+#: system/settings/settings.xml
+msgctxt "#37053"
+msgid "Chunk Size"
+msgstr ""
+
+#. Setting #37054 "NFS Chunk Size"
+#: xbmc/filesystem/NFSFile.cpp
+msgctxt "#37054"
+msgid "NFS Chunk Size"
+msgstr ""
+
+#. Description of setting #37054 "NFS Chunk Size"
+#: system/settings/settings.xml
+msgctxt "#37055"
+msgid "Data chunk size used on NFS connections"
+msgstr ""
+
+#. Setting #37056 "SMB Chunk Size"
+#: system/settings/settings.xml
+msgctxt "#37056"
+msgid "SMB Chunk Size"
+msgstr ""
+
+#. Description of setting #37056 "SMB Chunk Size"
+#: system/settings/settings.xml
+msgctxt "#37057"
+msgid "Data chunk size used on SMB connections"
+msgstr ""
+
+#empty strings from id 37058 to 38010
 
 #. Setting #38011 "Show All Items entry"
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2417,6 +2417,16 @@
           <control type="toggle" />
         </setting>
       </group>
+      <group id="4" label="37053">
+        <setting id="smb.chunksize" type="integer" label="37056" help="37057">
+        <level>2</level>
+        <default>128</default>
+          <constraints>
+            <options>filechunksizes</options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
+      </group>
     </category>
     <category id="nfs" label="1201" help="36356">
       <requirement>HAS_FILESYSTEM_NFS</requirement>
@@ -2430,6 +2440,16 @@
             <maximum>4</maximum>
           </constraints>
           <control type="spinner" format="integer" />
+        </setting>
+      </group>
+      <group id="2" label="37053">
+        <setting id="nfs.chunksize" type="integer" label="37054" help="37055">
+        <level>2</level>
+        <default>128</default>
+          <constraints>
+            <options>filechunksizes</options>
+          </constraints>
+          <control type="list" format="string" />
         </setting>
       </group>
     </category>

--- a/xbmc/platform/posix/filesystem/SMBFile.cpp
+++ b/xbmc/platform/posix/filesystem/SMBFile.cpp
@@ -719,3 +719,9 @@ int CSMBFile::IoControl(EIoControl request, void* param)
   return -1;
 }
 
+int CSMBFile::GetChunkSize()
+{
+  const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+
+  return settings ? (settings->GetInt(CSettings::SETTING_SMB_CHUNKSIZE) * 1024) : (128 * 1024);
+}

--- a/xbmc/platform/posix/filesystem/SMBFile.h
+++ b/xbmc/platform/posix/filesystem/SMBFile.h
@@ -79,7 +79,7 @@ public:
   bool OpenForWrite(const CURL& url, bool bOverWrite = false) override;
   bool Delete(const CURL& url) override;
   bool Rename(const CURL& url, const CURL& urlnew) override;
-  int GetChunkSize() override { return 64*1024; }
+  int GetChunkSize() override;
   int IoControl(EIoControl request, void* param) override;
 
 protected:

--- a/xbmc/platform/win32/filesystem/Win32File.cpp
+++ b/xbmc/platform/win32/filesystem/Win32File.cpp
@@ -8,6 +8,9 @@
 
 #include "Win32File.h"
 
+#include "ServiceBroker.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/log.h"
 
 #include "platform/win32/CharsetConverter.h"
@@ -20,9 +23,7 @@
 #include <intsafe.h>
 #include <sys/stat.h>
 
-
 using namespace XFILE;
-
 
 CWin32File::CWin32File() : m_smbFile(false)
 {
@@ -39,7 +40,6 @@ CWin32File::CWin32File(bool asSmbFile) : m_smbFile(asSmbFile)
   m_allowWrite = false;
   m_lastSMBFileErr = ERROR_SUCCESS;
 }
-
 
 CWin32File::~CWin32File()
 {
@@ -765,7 +765,11 @@ int CWin32File::Stat(struct __stat64* statData)
 int CWin32File::GetChunkSize()
 {
   if (m_smbFile)
-    return 64 * 1024;
+  {
+    const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+
+    return settings ? (settings->GetInt(CSettings::SETTING_SMB_CHUNKSIZE) * 1024) : (128 * 1024);
+  }
 
   return 0;
 }

--- a/xbmc/settings/CMakeLists.txt
+++ b/xbmc/settings/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES AdvancedSettings.cpp
             LibExportSettings.cpp
             MediaSettings.cpp
             MediaSourceSettings.cpp
+            ServicesSettings.cpp
             SettingAddon.cpp
             SettingConditions.cpp
             SettingControl.cpp
@@ -27,6 +28,7 @@ set(HEADERS AdvancedSettings.h
             LibExportSettings.h
             MediaSettings.h
             MediaSourceSettings.h
+            ServicesSettings.h
             SettingAddon.h
             SettingConditions.h
             SettingControl.h

--- a/xbmc/settings/ServicesSettings.cpp
+++ b/xbmc/settings/ServicesSettings.cpp
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ServicesSettings.h"
+
+void CServicesSettings::SettingOptionsChunkSizesFiller(const SettingConstPtr& setting,
+                                                       std::vector<IntegerSettingOption>& list,
+                                                       int& current,
+                                                       void* data)
+{
+  list.emplace_back("16 KB", 16);
+  list.emplace_back("32 KB", 32);
+  list.emplace_back("64 KB", 64);
+  list.emplace_back("128 KB", 128);
+  list.emplace_back("256 KB", 256);
+  list.emplace_back("512 KB", 512);
+  list.emplace_back("1 MB", 1024);
+}

--- a/xbmc/settings/ServicesSettings.h
+++ b/xbmc/settings/ServicesSettings.h
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "settings/ISubSettings.h"
+#include "settings/lib/Setting.h"
+
+#include <vector>
+
+class CServicesSettings : public ISubSettings
+{
+public:
+  static void SettingOptionsChunkSizesFiller(const SettingConstPtr& setting,
+                                             std::vector<IntegerSettingOption>& list,
+                                             int& current,
+                                             void* data);
+};

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -43,6 +43,7 @@
 #include "settings/DisplaySettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/MediaSourceSettings.h"
+#include "settings/ServicesSettings.h"
 #include "settings/SettingConditions.h"
 #include "settings/SettingsComponent.h"
 #include "settings/SkinSettings.h"
@@ -436,6 +437,8 @@ void CSettings::InitializeOptionFillers()
   GetSettingsManager()->RegisterSettingOptionsFiller("timezones", CPosixTimezone::SettingOptionsTimezonesFiller);
 #endif
   GetSettingsManager()->RegisterSettingOptionsFiller("keyboardlayouts", CKeyboardLayoutManager::SettingOptionsKeyboardLayoutsFiller);
+  GetSettingsManager()->RegisterSettingOptionsFiller(
+      "filechunksizes", CServicesSettings::SettingOptionsChunkSizesFiller);
 }
 
 void CSettings::UninitializeOptionFillers()
@@ -482,6 +485,7 @@ void CSettings::UninitializeOptionFillers()
 #endif // defined(TARGET_LINUX)
   GetSettingsManager()->UnregisterSettingOptionsFiller("verticalsyncs");
   GetSettingsManager()->UnregisterSettingOptionsFiller("keyboardlayouts");
+  GetSettingsManager()->UnregisterSettingOptionsFiller("filechunksizes");
 }
 
 void CSettings::InitializeConditions()

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -348,6 +348,7 @@ public:
   static constexpr auto SETTING_SMB_MINPROTOCOL = "smb.minprotocol";
   static constexpr auto SETTING_SMB_MAXPROTOCOL = "smb.maxprotocol";
   static constexpr auto SETTING_SMB_LEGACYSECURITY = "smb.legacysecurity";
+  static constexpr auto SETTING_SMB_CHUNKSIZE = "smb.chunksize";
   static constexpr auto SETTING_SERVICES_WSDISCOVERY = "services.wsdiscovery";
   static constexpr auto SETTING_VIDEOSCREEN_MONITOR = "videoscreen.monitor";
   static constexpr auto SETTING_VIDEOSCREEN_SCREEN = "videoscreen.screen";


### PR DESCRIPTION
## Description
Add GUI settings for NFS and SMB chunk size

Closes https://github.com/xbmc/xbmc/issues/24001

## Motivation and context
Is well known that SMB is some less efficient (protocol overhead) that NFS, however this is more accentuated in Kodi due we using smaller 64 KB chunk size vs. 128 KB chunk size for NFS.

Several users have reported low speed issues playing UHD Blu-Ray Remux using SMB on Fire Stick 4K max and similar devices. On Shield seems less problematic (has 1 Gigabit Ethernet) but anyway in forums exists similar complains.

@hugbug has done some detailed measurements (see  https://github.com/xbmc/xbmc/issues/24001) that confirms the relation between chunk size and maximum effective throughput obtained (on Fire Stick 4K max):

|Chunk size -> | 64KB | 128KB | 256KB | 512KB | 1024KB |
| --- | --- | --- | --- | --- | --- |
|MacBook 2015, MB/s | 17 | 26 | 36 | 46 | 54 |
|Fire TV Stick 4K Max, MB/s | 10 | 15 | 23 | 27 | 30|

- Currently with 64K 10 MB/s (80 Mbit/s) is insufficient for all 4K remuxes.
- Only changing to 128K (same as NFS) improves to 15 MB/s (120 Mbit/s) that is enough for almost all UHD Blu-Ray’s.
- Using 256KB is obtained 23 MB/s (184 Mbit/s) that covers completely maximum UHD Blu-Ray spec of 144 Mbit/s.

This PR changes default SMB chunk size to 128 KB and adds new GUI settings to make this parameter user configurable for both SMB and NFS.

Then for most users the new SMB default value is enough and represent a big improvement even in case of not being aware of the existence of this setting. 

The reason of not choosing higher values by default is that for some content (especially BD ISO’s) may work better small values (faster load/seek times), then probably 128 KB is the most balanced value that works well for all.


## How has this been tested?
Runtime tested on Windows x64 and Shield.

On Shield I not have issues using previous 64 KB chunk in regular UHD Blu-Ray's but using extreme case of 400 Mbps jellyfish test file can also confirm that performance improves using big chunk sizes and in fact this file is only playable thought SMB with 256 chunk size (and 512 works even better).

So this would confirm that it is not a problem isolated to Fire Stick but rather that all devices would be affected but to a lesser degree and therefore the issue is not noticeable when 64 KB is sufficient for the content being played.

Also tested BD ISO's and the new 128 KB default not causes evident issues and not noticeable increasing in load times.

Relevant log lines when using 512 KB chunk size:

**SMB**
```
debug <general>: CFileCache::Open - <smb://DiskStation/NAS/TEST-MEDIA/H264/jellyfish-400-mbps-4k-uhd-hevc-10bit.mkv> opening
debug <general>: CSMBFile::Open - opened smb://USERNAME:PASSWORD@DiskStation/NAS/TEST-MEDIA/H264/jellyfish-400-mbps-4k-uhd-hevc-10bit.mkv, fd=10000
debug <general>: CFileCache::Open - <smb://DiskStation/NAS/TEST-MEDIA/H264/jellyfish-400-mbps-4k-uhd-hevc-10bit.mkv> source chunk size is 524288, setting cache chunk size to 524288
debug <general>: CFileCache::Open - <smb://DiskStation/NAS/TEST-MEDIA/H264/jellyfish-400-mbps-4k-uhd-hevc-10bit.mkv> using double memory cache each sized 67108864 bytes
```

**NFS**
```
debug <general>: NFS: version: 4
debug <general>: NFS: Connected to server 192.168.50.13 and export /
debug <general>: NFS Server did not return max read chunksize - Using setting value 524288
debug <general>: NFS Server did not return max write chunksize - Using setting value 524288
debug <general>: NFS: chunks: r/w 524288/524288
```

```
debug <general>: CFileCache::Open - <nfs://192.168.50.13/volume1/NAS/TEST-MEDIA/H264/jellyfish-400-mbps-4k-uhd-hevc-10bit.mkv> opening
debug <general>: CNFSFile::Open - opened volume1/NAS/TEST-MEDIA/H264/jellyfish-400-mbps-4k-uhd-hevc-10bit.mkv
debug <general>: CFileCache::Open - <nfs://192.168.50.13/volume1/NAS/TEST-MEDIA/H264/jellyfish-400-mbps-4k-uhd-hevc-10bit.mkv> source chunk size is 524288, setting cache chunk size to 524288
debug <general>: CFileCache::Open - <nfs://192.168.50.13/volume1/NAS/TEST-MEDIA/H264/jellyfish-400-mbps-4k-uhd-hevc-10bit.mkv> using double memory cache each sized 67108864 bytes
```


## What is the effect on users?
Enables the possibility to easy configure NFS and SMB chunk sizes according to device used and type of contents most frequently played.

The only functional change is 64 KB to 128 KB for SMB that according tests done seems "better" default, although in case of regressions, users can easily back to previous 64 KB chunk size.

## Screenshots (if appropriate):

![SMB](https://github.com/xbmc/xbmc/assets/58434170/95b63c2b-6915-4080-9e6e-be250473b00a)

![NFS](https://github.com/xbmc/xbmc/assets/58434170/57e7ffcd-8069-423c-8719-f0265cca2805)

![chunksizes](https://github.com/xbmc/xbmc/assets/58434170/3c64cfe0-83e5-43bb-bf64-f70798f05757)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
