### PR TITLE
Picture: Switch internal functions to use smart pointers

### DIFF
--- a/xbmc/pictures/Picture.h
+++ b/xbmc/pictures/Picture.h
@@ -82,37 +82,37 @@ public:
       CPictureScalingAlgorithm::Algorithm scalingAlgorithm = CPictureScalingAlgorithm::NoAlgorithm);
 
 private:
-  static bool OrientateImage(uint32_t*& pixels,
+  static bool OrientateImage(std::unique_ptr<uint32_t[]>& pixels,
                              unsigned int& width,
                              unsigned int& height,
                              int orientation,
                              unsigned int& stridePixels);
 
-  static bool FlipHorizontal(uint32_t*& pixels,
+  static bool FlipHorizontal(std::unique_ptr<uint32_t[]>& pixels,
                              const unsigned int& width,
                              const unsigned int& height,
                              const unsigned int& stridePixels);
-  static bool FlipVertical(uint32_t*& pixels,
+  static bool FlipVertical(std::unique_ptr<uint32_t[]>& pixels,
                            const unsigned int& width,
                            const unsigned int& height,
                            const unsigned int& stridePixels);
-  static bool Rotate90CCW(uint32_t*& pixels,
+  static bool Rotate90CCW(std::unique_ptr<uint32_t[]>& pixels,
                           unsigned int& width,
                           unsigned int& height,
                           unsigned int& stridePixels);
-  static bool Rotate270CCW(uint32_t*& pixels,
+  static bool Rotate270CCW(std::unique_ptr<uint32_t[]>& pixels,
                            unsigned int& width,
                            unsigned int& height,
                            unsigned int& stridePixels);
-  static bool Rotate180CCW(uint32_t*& pixels,
+  static bool Rotate180CCW(std::unique_ptr<uint32_t[]>& pixels,
                            const unsigned int& width,
                            const unsigned int& height,
                            const unsigned int& stridePixels);
-  static bool Transpose(uint32_t*& pixels,
+  static bool Transpose(std::unique_ptr<uint32_t[]>& pixels,
                         unsigned int& width,
                         unsigned int& height,
                         unsigned int& width_aligned);
-  static bool TransposeOffAxis(uint32_t*& pixels,
+  static bool TransposeOffAxis(std::unique_ptr<uint32_t[]>& pixels,
                                unsigned int& width,
                                unsigned int& height,
                                unsigned int& stridePixels);


### PR DESCRIPTION
## Description
Fixes this crash reported in #23993:

<details>
<summary>Address sanitizer output</summary>

```
=================================================================
==118164==ERROR: AddressSanitizer: heap-use-after-free on address 0x7f78cdd40800 at pc 0x5594b17b338e bp 0x7f78c83b4e30 sp 0x7f78c83b45f0
READ of size 1432 at 0x7f78cdd40800 thread T19
    #0 0x5594b17b338d in __asan_memcpy (build_clang_debug_sanitizer_gles/kodi.bin+0xb1d038d) (BuildId: dc87396d417018a5e9305fe0f93c20d617016624)
    #1 0x5594b4a3919d in CPicture::CreateTiledThumb(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>> const&) xbmc/xbmc/pictures/Picture.cpp:332:13
    #2 0x5594b4a42d8b in CPictureFolderImageFileLoader::Load(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, unsigned int, unsigned int) const xbmc/xbmc/pictures/PictureFolderImageFileLoader.cpp:62:10
    #3 0x5594b4eaa7a3 in IMAGE_FILES::CSpecialImageLoaderFactory::Load(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, unsigned int, unsigned int) const xbmc/xbmc/imagefiles/SpecialImageLoaderFactory.cpp:40:26
    #4 0x5594b6b45861 in CTextureCacheJob::LoadImage(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, unsigned int, unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, bool) xbmc/xbmc/TextureCacheJob.cpp:242:39
    #5 0x5594b6b3ee5c in CTextureCacheJob::CacheTexture(std::unique_ptr<CTexture, std::default_delete<CTexture>>*) xbmc/xbmc/TextureCacheJob.cpp:124:39
    #6 0x5594b6b2f6bf in CTextureCache::CacheImage(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::unique_ptr<CTexture, std::default_delete<CTexture>>*, CTextureDetails*) xbmc/xbmc/TextureCache.cpp:161:24
    #7 0x5594b69b6753 in CImageLoader::DoWork() xbmc/xbmc/GUILargeTextureManager.cpp:79:38
    #8 0x5594b429e7f1 in CJobWorker::Process() xbmc/xbmc/utils/JobManager.cpp:55:22
    #9 0x5594b47e1c72 in CThread::Action() xbmc/xbmc/threads/Thread.cpp:283:5
    #10 0x5594b47e4489 in CThread::Create(bool)::$_0::operator()(CThread*, std::promise<bool>) const xbmc/xbmc/threads/Thread.cpp:152:18
    #11 0x5594b47e3116 in void std::__invoke_impl<void, CThread::Create(bool)::$_0, CThread*, std::promise<bool>>(std::__invoke_other, CThread::Create(bool)::$_0&&, CThread*&&, std::promise<bool>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/invoke.h:61:14
    #12 0x5594b47e2d46 in std::__invoke_result<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>::type std::__invoke<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>(CThread::Create(bool)::$_0&&, CThread*&&, std::promise<bool>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/invoke.h:96:14
    #13 0x5594b47e2c7f in void std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>>::_M_invoke<0ul, 1ul, 2ul>(std::_Index_tuple<0ul, 1ul, 2ul>) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:292:13
    #14 0x5594b47e2af8 in std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>>::operator()() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:299:11
    #15 0x5594b47e26c8 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>>>::_M_run() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:244:13
    #16 0x7f78ed2e1942 in execute_native_thread_routine /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++11/thread.cc:104:18
    #17 0x7f78ed0aa9ea  (/usr/lib/libc.so.6+0x8c9ea) (BuildId: 8bfe03f6bf9b6a6e2591babd0bbc266837d8f658)
    #18 0x7f78ed12e7cb  (/usr/lib/libc.so.6+0x1107cb) (BuildId: 8bfe03f6bf9b6a6e2591babd0bbc266837d8f658)

0x7f78cdd40800 is located 0 bytes inside of 289264-byte region [0x7f78cdd40800,0x7f78cdd871f0)
freed by thread T19 here:
    #0 0x5594b17fdcda in operator delete[](void*) (build_clang_debug_sanitizer_gles/kodi.bin+0xb21acda) (BuildId: dc87396d417018a5e9305fe0f93c20d617016624)
    #1 0x5594b4a3ddc8 in CPicture::Rotate270CCW(unsigned int*&, unsigned int&, unsigned int&, unsigned int&) xbmc/xbmc/pictures/Picture.cpp:595:3
    #2 0x5594b4a36e09 in CPicture::OrientateImage(unsigned int*&, unsigned int&, unsigned int&, int, unsigned int&) xbmc/xbmc/pictures/Picture.cpp:477:13
    #3 0x5594b4a38cbe in CPicture::CreateTiledThumb(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>> const&) xbmc/xbmc/pictures/Picture.cpp:322:13
    #4 0x5594b4a42d8b in CPictureFolderImageFileLoader::Load(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, unsigned int, unsigned int) const xbmc/xbmc/pictures/PictureFolderImageFileLoader.cpp:62:10
    #5 0x5594b4eaa7a3 in IMAGE_FILES::CSpecialImageLoaderFactory::Load(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, unsigned int, unsigned int) const xbmc/xbmc/imagefiles/SpecialImageLoaderFactory.cpp:40:26
    #6 0x5594b6b45861 in CTextureCacheJob::LoadImage(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, unsigned int, unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, bool) xbmc/xbmc/TextureCacheJob.cpp:242:39
    #7 0x5594b6b3ee5c in CTextureCacheJob::CacheTexture(std::unique_ptr<CTexture, std::default_delete<CTexture>>*) xbmc/xbmc/TextureCacheJob.cpp:124:39
    #8 0x5594b6b2f6bf in CTextureCache::CacheImage(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::unique_ptr<CTexture, std::default_delete<CTexture>>*, CTextureDetails*) xbmc/xbmc/TextureCache.cpp:161:24
    #9 0x5594b69b6753 in CImageLoader::DoWork() xbmc/xbmc/GUILargeTextureManager.cpp:79:38
    #10 0x5594b429e7f1 in CJobWorker::Process() xbmc/xbmc/utils/JobManager.cpp:55:22
    #11 0x5594b47e1c72 in CThread::Action() xbmc/xbmc/threads/Thread.cpp:283:5
    #12 0x5594b47e4489 in CThread::Create(bool)::$_0::operator()(CThread*, std::promise<bool>) const xbmc/xbmc/threads/Thread.cpp:152:18
    #13 0x5594b47e3116 in void std::__invoke_impl<void, CThread::Create(bool)::$_0, CThread*, std::promise<bool>>(std::__invoke_other, CThread::Create(bool)::$_0&&, CThread*&&, std::promise<bool>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/invoke.h:61:14
    #14 0x5594b47e2d46 in std::__invoke_result<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>::type std::__invoke<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>(CThread::Create(bool)::$_0&&, CThread*&&, std::promise<bool>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/invoke.h:96:14
    #15 0x5594b47e2c7f in void std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>>::_M_invoke<0ul, 1ul, 2ul>(std::_Index_tuple<0ul, 1ul, 2ul>) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:292:13
    #16 0x5594b47e2af8 in std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>>::operator()() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:299:11
    #17 0x5594b47e26c8 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>>>::_M_run() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:244:13
    #18 0x7f78ed2e1942 in execute_native_thread_routine /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++11/thread.cc:104:18

previously allocated by thread T19 here:
    #0 0x5594b17fd282 in operator new[](unsigned long) (build_clang_debug_sanitizer_gles/kodi.bin+0xb21a282) (BuildId: dc87396d417018a5e9305fe0f93c20d617016624)
    #1 0x5594b4a3f25b in std::__detail::_MakeUniq<unsigned int []>::__array std::make_unique<unsigned int []>(unsigned long) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/unique_ptr.h:1085:30
    #2 0x5594b4a383de in CPicture::CreateTiledThumb(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>> const&) xbmc/xbmc/pictures/Picture.cpp:314:44
    #3 0x5594b4a42d8b in CPictureFolderImageFileLoader::Load(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, unsigned int, unsigned int) const xbmc/xbmc/pictures/PictureFolderImageFileLoader.cpp:62:10
    #4 0x5594b4eaa7a3 in IMAGE_FILES::CSpecialImageLoaderFactory::Load(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, unsigned int, unsigned int) const xbmc/xbmc/imagefiles/SpecialImageLoaderFactory.cpp:40:26
    #5 0x5594b6b45861 in CTextureCacheJob::LoadImage(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, unsigned int, unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, bool) xbmc/xbmc/TextureCacheJob.cpp:242:39
    #6 0x5594b6b3ee5c in CTextureCacheJob::CacheTexture(std::unique_ptr<CTexture, std::default_delete<CTexture>>*) xbmc/xbmc/TextureCacheJob.cpp:124:39
    #7 0x5594b6b2f6bf in CTextureCache::CacheImage(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::unique_ptr<CTexture, std::default_delete<CTexture>>*, CTextureDetails*) xbmc/xbmc/TextureCache.cpp:161:24
    #8 0x5594b69b6753 in CImageLoader::DoWork() xbmc/xbmc/GUILargeTextureManager.cpp:79:38
    #9 0x5594b429e7f1 in CJobWorker::Process() xbmc/xbmc/utils/JobManager.cpp:55:22
    #10 0x5594b47e1c72 in CThread::Action() xbmc/xbmc/threads/Thread.cpp:283:5
    #11 0x5594b47e4489 in CThread::Create(bool)::$_0::operator()(CThread*, std::promise<bool>) const xbmc/xbmc/threads/Thread.cpp:152:18
    #12 0x5594b47e3116 in void std::__invoke_impl<void, CThread::Create(bool)::$_0, CThread*, std::promise<bool>>(std::__invoke_other, CThread::Create(bool)::$_0&&, CThread*&&, std::promise<bool>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/invoke.h:61:14
    #13 0x5594b47e2d46 in std::__invoke_result<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>::type std::__invoke<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>(CThread::Create(bool)::$_0&&, CThread*&&, std::promise<bool>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/invoke.h:96:14
    #14 0x5594b47e2c7f in void std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>>::_M_invoke<0ul, 1ul, 2ul>(std::_Index_tuple<0ul, 1ul, 2ul>) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:292:13
    #15 0x5594b47e2af8 in std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>>::operator()() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:299:11
    #16 0x5594b47e26c8 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>>>::_M_run() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:244:13
    #17 0x7f78ed2e1942 in execute_native_thread_routine /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++11/thread.cc:104:18

Thread T19 created by T0 here:
    #0 0x5594b16ee188 in pthread_create (build_clang_debug_sanitizer_gles/kodi.bin+0xb10b188) (BuildId: dc87396d417018a5e9305fe0f93c20d617016624)
    #1 0x7f78ed2e1a29 in __gthread_create /usr/src/debug/gcc/gcc-build/x86_64-pc-linux-gnu/libstdc++-v3/include/x86_64-pc-linux-gnu/bits/gthr-default.h:663:35
    #2 0x7f78ed2e1a29 in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State>>, void (*)()) /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++11/thread.cc:172:37
    #3 0x5594b47df0a2 in CThread::Create(bool) xbmc/xbmc/threads/Thread.cpp:118:20
    #4 0x5594b429d7ea in CJobWorker::CJobWorker(CJobManager*) xbmc/xbmc/utils/JobManager.cpp:32:3
    #5 0x5594b42a9234 in CJobManager::StartWorkers(CJob::PRIORITY) xbmc/xbmc/utils/JobManager.cpp:288:27
    #6 0x5594b42a6b28 in CJobManager::AddJob(CJob*, IJobCallback*, CJob::PRIORITY) xbmc/xbmc/utils/JobManager.cpp:247:3
    #7 0x5594b5b0b9d7 in void CJobManager::Submit<CApplication::Initialize()::$_0>(CApplication::Initialize()::$_0&&, CJob::PRIORITY) xbmc/xbmc/utils/JobManager.h:261:5
    #8 0x5594b5b02cdb in CApplication::Initialize() xbmc/xbmc/application/Application.cpp:625:36
    #9 0x5594b4989f2a in XBMC_Run xbmc/xbmc/platform/xbmc.cpp:43:22
    #10 0x5594b18005a9 in main xbmc/xbmc/platform/posix/main.cpp:70:16
    #11 0x7f78ed045ccf  (/usr/lib/libc.so.6+0x27ccf) (BuildId: 8bfe03f6bf9b6a6e2591babd0bbc266837d8f658)

SUMMARY: AddressSanitizer: heap-use-after-free (build_clang_debug_sanitizer_gles/kodi.bin+0xb1d038d) (BuildId: dc87396d417018a5e9305fe0f93c20d617016624) in __asan_memcpy
Shadow bytes around the buggy address:
  0x7f78cdd40580: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7f78cdd40600: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7f78cdd40680: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7f78cdd40700: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7f78cdd40780: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x7f78cdd40800:[fd]fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7f78cdd40880: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7f78cdd40900: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7f78cdd40980: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7f78cdd40a00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7f78cdd40a80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==118164==ABORTING
```
</details>

The problem was introduces in https://github.com/xbmc/xbmc/pull/23517/commits/2c2c99e7d94bce3698baad279bac4044240ffa2c by freeing a pointer that's owned by a smart pointer. By not mixing the usage of smart pointers and regular pointers the issue is mittigated.

## Motivation and context
Rotating pictures doesn't cause a crash.

## How has this been tested?
Test pictures from #23993 don't cause a crash anymore.

## What is the effect on users?
No more crashes.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
