### PR TITLE
[video][music][interfaces][fileitem] STRM file fixes

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1107,6 +1107,10 @@ bool CFileItem::IsFileFolder(EFileFolderType types) const
   if(IsInternetStream())
     always_type = EFILEFOLDER_TYPE_ONCLICK;
 
+  // strm files are not browsable
+  if (IsType(".strm") && (types & EFILEFOLDER_TYPE_ONBROWSE))
+    return false;
+
   if(types & always_type)
   {
     if(IsSmartPlayList()

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -902,7 +902,7 @@ bool IsItemPlayable(const CFileItem& item)
     if (StringUtils::StartsWith(item.GetPath(), StringUtils::Format("{}/music/", path)))
       return true;
 
-    if (!item.m_bIsFolder)
+    if (!item.m_bIsFolder && !item.HasMusicInfoTag())
     {
       // Unknown location. Type cannot be determined for non-folder items.
       return false;

--- a/xbmc/playlists/PlayList.cpp
+++ b/xbmc/playlists/PlayList.cpp
@@ -475,7 +475,7 @@ bool CPlayList::Expand(int position)
   for (int i = 0;i<playlist->size();i++)
   {
     (*playlist)[i]->SetDynPath((*playlist)[i]->GetPath());
-    (*playlist)[i]->SetPath(item->GetPath());
+    (*playlist)[i]->SetPath(item->GetDynPath());
     (*playlist)[i]->SetStartOffset(item->GetStartOffset());
   }
 

--- a/xbmc/video/VideoUtils.cpp
+++ b/xbmc/video/VideoUtils.cpp
@@ -285,23 +285,8 @@ void CAsyncGetItemsForPlaylist::GetItemsForPlaylist(const std::shared_ptr<CFileI
   }
   else if (item->IsPlayList())
   {
-    const std::unique_ptr<PLAYLIST::CPlayList> playList(PLAYLIST::CPlayListFactory::Create(*item));
-    if (!playList)
-    {
-      CLog::LogF(LOGERROR, "Failed to create playlist {}", item->GetPath());
-      return;
-    }
-
-    if (!playList->Load(item->GetPath()))
-    {
-      CLog::LogF(LOGERROR, "Failed to load playlist {}", item->GetPath());
-      return;
-    }
-
-    for (int i = 0; i < playList->size(); ++i)
-    {
-      GetItemsForPlaylist((*playList)[i]);
-    }
+    // just queue the playlist, it will be expanded on play
+    m_queuedItems.Add(item);
   }
   else if (item->IsInternetStream())
   {
@@ -583,7 +568,7 @@ bool IsItemPlayable(const CFileItem& item)
         StringUtils::StartsWith(item.GetPath(), StringUtils::Format("{}/mixed/", path)))
       return true;
 
-    if (!item.m_bIsFolder)
+    if (!item.m_bIsFolder && !item.HasVideoInfoTag())
     {
       // Unknown location. Type cannot be determined for non-folder items.
       return false;


### PR DESCRIPTION
First commit fixes #24015 . Root cause were two things a) strm files not being recognized as playable, b) strm files not properly expanded by playlist (dynpath issue).

Second commit fixes that strm library items had "Browse into" in their context menu, which is wrong (and did not work) because strm file represent streams/files not folders, although they are technically m3u playlist files.

Runtime-tested on macOS and Adroid, latest Kodi master.

@enen92 could you please do the code review?