### PR TITLE
[GUI] [Skins] Add locale InfoLabels for Skins

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1741,6 +1741,20 @@ const infomap weather[] =        {{ "isfetched",        WEATHER_IS_FETCHED },
 ///     @return the current language.
 ///     <p>
 ///   }
+///   \table_row3{   <b>`System.Locale(type)`</b>,
+///                  \anchor System_Locale
+///                  _string_,
+///     @return Locale-specific information depending on the requested type.
+///     @param type - Can be one of the following:
+///       - <b>timezonecountry</b> The country name for the current time zone.
+///       - <b>timezone</b> The full timezone name with country and optional region.
+///       - <b>region</b> The currently selected region name within the selected language ( \link System_Language `System.Language` \endlink).
+///       - <b>iso</b> The country code of the currently selected region as specified in <a href="https://kodi.wiki/view/Language_support#What_is_langinfo.xml">langinfo.xml</a>.
+///     <p><hr>
+///     @skinning_v21 **[New Infolabel]** \link System_Locale
+///     `System.Locale(type)`\endlink
+///     <p>
+///   }
 ///   \table_row3{   <b>`System.ProfileName`</b>,
 ///                  \anchor System_ProfileName
 ///                  _string_,
@@ -10138,6 +10152,25 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
         }
         else if (prop.name == "idletime")
           return AddMultiInfo(CGUIInfo(SYSTEM_IDLE_TIME, atoi(param.c_str())));
+        else if (prop.name == "locale")
+        {
+          if (param == "timezonecountry")
+          {
+            return SYSTEM_LOCALE_TIMEZONECOUNTRY;
+          }
+          else if (param == "timezone")
+          {
+            return SYSTEM_LOCALE_TIMEZONE;
+          }
+          else if (param == "region")
+          {
+            return SYSTEM_LOCALE_REGION;
+          }
+          else if (param == "iso")
+          {
+            return SYSTEM_LOCALE;
+          }
+        }
       }
       if (prop.name == "alarmlessorequal" && prop.num_params() == 2)
         return AddMultiInfo(CGUIInfo(SYSTEM_ALARM_LESS_OR_EQUAL, prop.param(0), atoi(prop.param(1).c_str())));

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -564,6 +564,11 @@
 #define SYSTEM_BUILD_VERSION_CODE 1007
 #define SYSTEM_BUILD_VERSION_GIT 1008
 
+static constexpr unsigned int SYSTEM_LOCALE_TIMEZONECOUNTRY = 1009;
+static constexpr unsigned int SYSTEM_LOCALE_TIMEZONE = 1010;
+static constexpr unsigned int SYSTEM_LOCALE_REGION = 1011;
+static constexpr unsigned int SYSTEM_LOCALE = 1012;
+
 #define PVR_CONDITIONS_START        1100
 #define PVR_IS_RECORDING            (PVR_CONDITIONS_START)
 #define PVR_HAS_TIMER               (PVR_CONDITIONS_START + 1)

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -326,8 +326,33 @@ bool CSystemGUIInfo::GetLabel(std::string& value, const CFileItem *item, int con
 
       return true;
     }
-  }
 
+    case SYSTEM_LOCALE_TIMEZONECOUNTRY:
+    {
+      value = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(
+          CSettings::SETTING_LOCALE_TIMEZONECOUNTRY);
+      return true;
+    }
+
+    case SYSTEM_LOCALE_TIMEZONE:
+    {
+      value = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(
+          CSettings::SETTING_LOCALE_TIMEZONE);
+      return true;
+    }
+
+    case SYSTEM_LOCALE_REGION:
+    {
+      value = g_langInfo.GetCurrentRegion();
+      return true;
+    }
+
+    case SYSTEM_LOCALE:
+    {
+      value = g_langInfo.GetRegionLocale();
+      return true;
+    }
+  }
   return false;
 }
 


### PR DESCRIPTION
## Description
Add the following $INFO labels to extract some locale-based information for use in skins.

$INFO[System.Locale(timezonecountry)] = Kodi settings ‘locale.timezonecountry’.
$INFO[System.Locale(timezone)] = Kodi settings ‘locale.timezone’.
$INFO[System.Locale(region)] = Kodi language system ‘GetCurrentRegion()’.
$INFO[System.Locale(iso)] = Kodi language system ‘GetRegionLocale()’.

## Motivation and context
Ability to adapt skins to regional/locale variations.

## How has this been tested?
A sample skin was updated and the results compared to source locations such as langinfo.xml and GUI settings screens.

## What is the effect on users?
Skin developers will be able to employ locale-specific resources and other customisations where required.

## Screenshots (if appropriate):
![Skin](https://github.com/xbmc/xbmc/assets/127641886/bb468f70-15f5-4403-ae24-353768e939a3)
![Settings](https://github.com/xbmc/xbmc/assets/127641886/368091bd-4e7b-4c2b-b6c7-9d9607e6a043)

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
