### PR TITLE
[PVR] const correctness improvements.

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -122,19 +122,20 @@ CFileItem::CFileItem(const CVideoInfoTag& movie)
 
 namespace
 {
-  std::string GetEpgTagTitle(const std::shared_ptr<CPVREpgInfoTag>& epgTag)
-  {
-    if (CServiceBroker::GetPVRManager().IsParentalLocked(epgTag))
-      return g_localizeStrings.Get(19266); // Parental locked
-    else if (epgTag->Title().empty() &&
-             !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_EPG_HIDENOINFOAVAILABLE))
-      return g_localizeStrings.Get(19055); // no information available
-    else
-      return epgTag->Title();
-  }
+std::string GetEpgTagTitle(const std::shared_ptr<const CPVREpgInfoTag>& epgTag)
+{
+  if (CServiceBroker::GetPVRManager().IsParentalLocked(epgTag))
+    return g_localizeStrings.Get(19266); // Parental locked
+  else if (epgTag->Title().empty() &&
+           !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+               CSettings::SETTING_EPG_HIDENOINFOAVAILABLE))
+    return g_localizeStrings.Get(19055); // no information available
+  else
+    return epgTag->Title();
+}
 } // unnamed namespace
 
-void CFileItem::FillMusicInfoTag(const std::shared_ptr<CPVREpgInfoTag>& tag)
+void CFileItem::FillMusicInfoTag(const std::shared_ptr<const CPVREpgInfoTag>& tag)
 {
   CMusicInfoTag* musictag = GetMusicInfoTag(); // create (!) the music tag.
 
@@ -215,7 +216,7 @@ CFileItem::CFileItem(const std::shared_ptr<CPVRChannelGroupMember>& channelGroup
 {
   Initialize();
 
-  const std::shared_ptr<CPVRChannel> channel = channelGroupMember->Channel();
+  const std::shared_ptr<const CPVRChannel> channel = channelGroupMember->Channel();
 
   m_pvrChannelGroupMemberInfoTag = channelGroupMember;
 
@@ -240,7 +241,7 @@ CFileItem::CFileItem(const std::shared_ptr<CPVRChannelGroupMember>& channelGroup
 
   if (channel->IsRadio() && !HasMusicInfoTag())
   {
-    const std::shared_ptr<CPVREpgInfoTag> epgNow = channel->GetEPGNow();
+    const std::shared_ptr<const CPVREpgInfoTag> epgNow = channel->GetEPGNow();
     FillMusicInfoTag(epgNow);
   }
   FillInMimeType(false);
@@ -263,7 +264,7 @@ CFileItem::CFileItem(const std::shared_ptr<CPVRRecording>& record)
     SetArt("icon", record->IconPath());
   else
   {
-    const std::shared_ptr<CPVRChannel> channel = record->Channel();
+    const std::shared_ptr<const CPVRChannel> channel = record->Channel();
     if (channel && !channel->IconPath().empty())
       SetArt("icon", channel->IconPath());
     else if (record->IsRadio())

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -651,7 +651,7 @@ private:
   /*!
    \brief Fill item's music tag from given epg tag.
    */
-  void FillMusicInfoTag(const std::shared_ptr<PVR::CPVREpgInfoTag>& tag);
+  void FillMusicInfoTag(const std::shared_ptr<const PVR::CPVREpgInfoTag>& tag);
 
   std::string m_strPath;            ///< complete path to item
   std::string m_strDynPath;

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_defines.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_defines.h
@@ -64,7 +64,7 @@ extern "C"
    */
   struct PVR_HANDLE_STRUCT
   {
-    void* callerAddress; /*!< address of the caller */
+    const void* callerAddress; /*!< address of the caller */
     void* dataAddress; /*!< address to store data in */
     int dataIdentifier; /*!< parameter to pass back when calling the callback */
   };

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -130,7 +130,7 @@
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_DEPENDS     "addon-instance/Peripheral.h" \
                                                       "addon-instance/PeripheralUtils.h"
 
-#define ADDON_INSTANCE_VERSION_PVR                    "8.2.0"
+#define ADDON_INSTANCE_VERSION_PVR                    "8.3.0"
 #define ADDON_INSTANCE_VERSION_PVR_MIN                "8.2.0"
 #define ADDON_INSTANCE_VERSION_PVR_XML_ID             "kodi.binary.instance.pvr"
 #define ADDON_INSTANCE_VERSION_PVR_DEPENDS            "c-api/addon-instance/pvr.h" \

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -272,7 +272,8 @@ std::string CDatabase::PrepareSQL(std::string strStmt, ...) const
   return strResult;
 }
 
-std::string CDatabase::GetSingleValue(const std::string& query, std::unique_ptr<Dataset>& ds)
+std::string CDatabase::GetSingleValue(const std::string& query,
+                                      const std::unique_ptr<Dataset>& ds) const
 {
   std::string ret;
   try
@@ -295,7 +296,7 @@ std::string CDatabase::GetSingleValue(const std::string& query, std::unique_ptr<
 std::string CDatabase::GetSingleValue(const std::string& strTable,
                                       const std::string& strColumn,
                                       const std::string& strWhereClause /* = std::string() */,
-                                      const std::string& strOrderBy /* = std::string() */)
+                                      const std::string& strOrderBy /* = std::string() */) const
 {
   std::string query = PrepareSQL("SELECT %s FROM %s", strColumn.c_str(), strTable.c_str());
   if (!strWhereClause.empty())
@@ -306,7 +307,7 @@ std::string CDatabase::GetSingleValue(const std::string& strTable,
   return GetSingleValue(query, m_pDS);
 }
 
-std::string CDatabase::GetSingleValue(const std::string& query)
+std::string CDatabase::GetSingleValue(const std::string& query) const
 {
   return GetSingleValue(query, m_pDS);
 }
@@ -815,7 +816,9 @@ void CDatabase::UpdateVersionNumber()
   m_pDS->exec(strSQL);
 }
 
-bool CDatabase::BuildSQL(const std::string& strQuery, const Filter& filter, std::string& strSQL)
+bool CDatabase::BuildSQL(const std::string& strQuery,
+                         const Filter& filter,
+                         std::string& strSQL) const
 {
   strSQL = strQuery;
 

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -312,7 +312,7 @@ std::string CDatabase::GetSingleValue(const std::string& query) const
   return GetSingleValue(query, m_pDS);
 }
 
-int CDatabase::GetSingleValueInt(const std::string& query, std::unique_ptr<Dataset>& ds)
+int CDatabase::GetSingleValueInt(const std::string& query, const std::unique_ptr<Dataset>& ds) const
 {
   int ret = 0;
   try
@@ -335,13 +335,13 @@ int CDatabase::GetSingleValueInt(const std::string& query, std::unique_ptr<Datas
 int CDatabase::GetSingleValueInt(const std::string& strTable,
                                  const std::string& strColumn,
                                  const std::string& strWhereClause /* = std::string() */,
-                                 const std::string& strOrderBy /* = std::string() */)
+                                 const std::string& strOrderBy /* = std::string() */) const
 {
   std::string strResult = GetSingleValue(strTable, strColumn, strWhereClause, strOrderBy);
   return static_cast<int>(strtol(strResult.c_str(), NULL, 10));
 }
 
-int CDatabase::GetSingleValueInt(const std::string& query)
+int CDatabase::GetSingleValueInt(const std::string& query) const
 {
   return GetSingleValueInt(query, m_pDS);
 }

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -147,15 +147,16 @@ public:
   int GetSingleValueInt(const std::string& strTable,
                         const std::string& strColumn,
                         const std::string& strWhereClause = std::string(),
-                        const std::string& strOrderBy = std::string());
-  int GetSingleValueInt(const std::string& query);
+                        const std::string& strOrderBy = std::string()) const;
+  int GetSingleValueInt(const std::string& query) const;
 
   /*! \brief Get a single integer value from a query on a dataset.
    \param query the query in question.
    \param ds the dataset to use for the query.
    \return the value from the query, 0 on failure.
    */
-  int GetSingleValueInt(const std::string& query, std::unique_ptr<dbiplus::Dataset>& ds);
+  int GetSingleValueInt(const std::string& query,
+                        const std::unique_ptr<dbiplus::Dataset>& ds) const;
 
   /*!
    * @brief Delete values from a table.

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -124,15 +124,16 @@ public:
   std::string GetSingleValue(const std::string& strTable,
                              const std::string& strColumn,
                              const std::string& strWhereClause = std::string(),
-                             const std::string& strOrderBy = std::string());
-  std::string GetSingleValue(const std::string& query);
+                             const std::string& strOrderBy = std::string()) const;
+  std::string GetSingleValue(const std::string& query) const;
 
   /*! \brief Get a single value from a query on a dataset.
    \param query the query in question.
    \param ds the dataset to use for the query.
    \return the value from the query, empty on failure.
    */
-  std::string GetSingleValue(const std::string& query, std::unique_ptr<dbiplus::Dataset>& ds);
+  std::string GetSingleValue(const std::string& query,
+                             const std::unique_ptr<dbiplus::Dataset>& ds) const;
 
   /*!
  * @brief Get a single integer value from a table.
@@ -294,7 +295,7 @@ protected:
 
   int GetDBVersion();
 
-  bool BuildSQL(const std::string& strQuery, const Filter& filter, std::string& strSQL);
+  bool BuildSQL(const std::string& strQuery, const Filter& filter, std::string& strSQL) const;
 
   bool m_sqlite; ///< \brief whether we use sqlite (defaults to true)
 

--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -234,7 +234,7 @@ JSONRPC_STATUS CPVROperations::GetBroadcastIsPlayable(const std::string& method,
   if (!CServiceBroker::GetPVRManager().IsStarted())
     return FailedToExecute;
 
-  const std::shared_ptr<CPVREpgInfoTag> epgTag =
+  const std::shared_ptr<const CPVREpgInfoTag> epgTag =
       CServiceBroker::GetPVRManager().EpgContainer().GetTagByDatabaseId(
           parameterObject["broadcastid"].asInteger());
 

--- a/xbmc/interfaces/json-rpc/PVROperations.cpp
+++ b/xbmc/interfaces/json-rpc/PVROperations.cpp
@@ -337,7 +337,11 @@ JSONRPC_STATUS CPVROperations::GetPropertyValue(const std::string &property, CVa
   return OK;
 }
 
-void CPVROperations::FillChannelGroupDetails(const std::shared_ptr<CPVRChannelGroup> &channelGroup, const CVariant &parameterObject, CVariant &result, bool append /* = false */)
+void CPVROperations::FillChannelGroupDetails(
+    const std::shared_ptr<const CPVRChannelGroup>& channelGroup,
+    const CVariant& parameterObject,
+    CVariant& result,
+    bool append /* = false */)
 {
   if (channelGroup == NULL)
     return;

--- a/xbmc/interfaces/json-rpc/PVROperations.h
+++ b/xbmc/interfaces/json-rpc/PVROperations.h
@@ -53,6 +53,10 @@ namespace JSONRPC
 
   private:
     static JSONRPC_STATUS GetPropertyValue(const std::string &property, CVariant &result);
-    static void FillChannelGroupDetails(const std::shared_ptr<PVR::CPVRChannelGroup> &channelGroup, const CVariant &parameterObject, CVariant &result, bool append = false);
+    static void FillChannelGroupDetails(
+        const std::shared_ptr<const PVR::CPVRChannelGroup>& channelGroup,
+        const CVariant& parameterObject,
+        CVariant& result,
+        bool append = false);
   };
 }

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -836,11 +836,13 @@ JSONRPC_STATUS CPlayerOperations::Open(const std::string &method, ITransportLaye
   }
   else if (parameterObject["item"].isMember("channelid"))
   {
-    const std::shared_ptr<CPVRChannelGroupsContainer> channelGroupContainer = CServiceBroker::GetPVRManager().ChannelGroups();
+    const std::shared_ptr<const CPVRChannelGroupsContainer> channelGroupContainer =
+        CServiceBroker::GetPVRManager().ChannelGroups();
     if (!channelGroupContainer)
       return FailedToExecute;
 
-    const std::shared_ptr<CPVRChannel> channel = channelGroupContainer->GetChannelById(static_cast<int>(parameterObject["item"]["channelid"].asInteger()));
+    const std::shared_ptr<const CPVRChannel> channel = channelGroupContainer->GetChannelById(
+        static_cast<int>(parameterObject["item"]["channelid"].asInteger()));
     if (!channel)
       return InvalidParams;
 
@@ -857,7 +859,8 @@ JSONRPC_STATUS CPlayerOperations::Open(const std::string &method, ITransportLaye
   }
   else if (parameterObject["item"].isMember("recordingid"))
   {
-    const std::shared_ptr<CPVRRecordings> recordingsContainer = CServiceBroker::GetPVRManager().Recordings();
+    const std::shared_ptr<const CPVRRecordings> recordingsContainer =
+        CServiceBroker::GetPVRManager().Recordings();
     if (!recordingsContainer)
       return FailedToExecute;
 
@@ -2148,17 +2151,19 @@ double CPlayerOperations::ParseTimeInSeconds(const CVariant &time)
 
 bool CPlayerOperations::IsPVRChannel()
 {
-  const std::shared_ptr<CPVRPlaybackState> state = CServiceBroker::GetPVRManager().PlaybackState();
+  const std::shared_ptr<const CPVRPlaybackState> state =
+      CServiceBroker::GetPVRManager().PlaybackState();
   return state->IsPlayingTV() || state->IsPlayingRadio();
 }
 
 std::shared_ptr<CPVREpgInfoTag> CPlayerOperations::GetCurrentEpg()
 {
-  const std::shared_ptr<CPVRPlaybackState> state = CServiceBroker::GetPVRManager().PlaybackState();
+  const std::shared_ptr<const CPVRPlaybackState> state =
+      CServiceBroker::GetPVRManager().PlaybackState();
   if (!state->IsPlayingTV() && !state->IsPlayingRadio())
     return {};
 
-  const std::shared_ptr<CPVRChannel> currentChannel = state->GetPlayingChannel();
+  const std::shared_ptr<const CPVRChannel> currentChannel = state->GetPlayingChannel();
   if (!currentChannel)
     return {};
 

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -98,7 +98,7 @@ std::shared_ptr<CPVRTimerInfoTag> GetTimerInfoTagFromItem(const CFileItem& item)
 {
   std::shared_ptr<CPVRTimerInfoTag> timer;
 
-  const std::shared_ptr<CPVREpgInfoTag> epg(item.GetEPGInfoTag());
+  const std::shared_ptr<const CPVREpgInfoTag> epg(item.GetEPGInfoTag());
   if (epg)
     timer = CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epg);
 
@@ -113,7 +113,7 @@ std::shared_ptr<CPVRTimerInfoTag> GetTimerInfoTagFromItem(const CFileItem& item)
 
 bool PlayEpgTag::IsVisible(const CFileItem& item) const
 {
-  const std::shared_ptr<CPVREpgInfoTag> epg(item.GetEPGInfoTag());
+  const std::shared_ptr<const CPVREpgInfoTag> epg(item.GetEPGInfoTag());
   if (epg)
     return epg->IsPlayable();
 
@@ -130,7 +130,7 @@ bool PlayEpgTag::Execute(const CFileItemPtr& item) const
 
 bool PlayRecording::IsVisible(const CFileItem& item) const
 {
-  const std::shared_ptr<CPVRRecording> recording =
+  const std::shared_ptr<const CPVRRecording> recording =
       CServiceBroker::GetPVRManager().Recordings()->GetRecordingForEpgTag(item.GetEPGInfoTag());
   if (recording)
     return !recording->IsDeleted();
@@ -157,14 +157,14 @@ std::string ShowInformation::GetLabel(const CFileItem& item) const
 
 bool ShowInformation::IsVisible(const CFileItem& item) const
 {
-  const std::shared_ptr<CPVRChannel> channel(item.GetPVRChannelInfoTag());
+  const std::shared_ptr<const CPVRChannel> channel(item.GetPVRChannelInfoTag());
   if (channel)
     return channel->GetEPGNow().get() != nullptr;
 
   if (item.HasEPGInfoTag())
     return !item.GetEPGInfoTag()->IsGapTag();
 
-  const std::shared_ptr<CPVRTimerInfoTag> timer(item.GetPVRTimerInfoTag());
+  const std::shared_ptr<const CPVRTimerInfoTag> timer(item.GetPVRTimerInfoTag());
   if (timer && !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER))
     return timer->GetEpgInfoTag().get() != nullptr;
 
@@ -187,7 +187,7 @@ bool ShowInformation::Execute(const CFileItemPtr& item) const
 
 bool ShowChannelGuide::IsVisible(const CFileItem& item) const
 {
-  const std::shared_ptr<CPVRChannel> channel(item.GetPVRChannelInfoTag());
+  const std::shared_ptr<const CPVRChannel> channel(item.GetPVRChannelInfoTag());
   if (channel)
     return channel->GetEPGNow().get() != nullptr;
 
@@ -204,18 +204,18 @@ bool ShowChannelGuide::Execute(const CFileItemPtr& item) const
 
 bool FindSimilar::IsVisible(const CFileItem& item) const
 {
-  const std::shared_ptr<CPVRChannel> channel(item.GetPVRChannelInfoTag());
+  const std::shared_ptr<const CPVRChannel> channel(item.GetPVRChannelInfoTag());
   if (channel)
     return channel->GetEPGNow().get() != nullptr;
 
   if (item.HasEPGInfoTag())
     return !item.GetEPGInfoTag()->IsGapTag();
 
-  const std::shared_ptr<CPVRTimerInfoTag> timer(item.GetPVRTimerInfoTag());
+  const std::shared_ptr<const CPVRTimerInfoTag> timer(item.GetPVRTimerInfoTag());
   if (timer && !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER))
     return timer->GetEpgInfoTag().get() != nullptr;
 
-  const std::shared_ptr<CPVRRecording> recording(item.GetPVRRecordingInfoTag());
+  const std::shared_ptr<const CPVRRecording> recording(item.GetPVRRecordingInfoTag());
   if (recording)
     return !recording->IsDeleted();
 
@@ -232,14 +232,14 @@ bool FindSimilar::Execute(const CFileItemPtr& item) const
 
 bool StartRecording::IsVisible(const CFileItem& item) const
 {
-  const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(item);
+  const std::shared_ptr<const CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(item);
 
   std::shared_ptr<CPVRChannel> channel = item.GetPVRChannelInfoTag();
   if (channel)
     return client && client->GetClientCapabilities().SupportsTimers() &&
            !CServiceBroker::GetPVRManager().Timers()->IsRecordingOnChannel(*channel);
 
-  const std::shared_ptr<CPVREpgInfoTag> epg = item.GetEPGInfoTag();
+  const std::shared_ptr<const CPVREpgInfoTag> epg = item.GetEPGInfoTag();
   if (epg && epg->IsRecordable())
   {
     if (epg->IsGapTag())
@@ -262,7 +262,7 @@ bool StartRecording::IsVisible(const CFileItem& item) const
 
 bool StartRecording::Execute(const CFileItemPtr& item) const
 {
-  const std::shared_ptr<CPVREpgInfoTag> epgTag = item->GetEPGInfoTag();
+  const std::shared_ptr<const CPVREpgInfoTag> epgTag = item->GetEPGInfoTag();
   if (!epgTag || epgTag->IsActive())
   {
     // instant recording
@@ -286,7 +286,7 @@ bool StartRecording::Execute(const CFileItemPtr& item) const
 
 bool StopRecording::IsVisible(const CFileItem& item) const
 {
-  const std::shared_ptr<CPVRRecording> recording(item.GetPVRRecordingInfoTag());
+  const std::shared_ptr<const CPVRRecording> recording(item.GetPVRRecordingInfoTag());
   if (recording && recording->IsInProgress())
     return true;
 
@@ -294,11 +294,11 @@ bool StopRecording::IsVisible(const CFileItem& item) const
   if (channel)
     return CServiceBroker::GetPVRManager().Timers()->IsRecordingOnChannel(*channel);
 
-  const std::shared_ptr<CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
+  const std::shared_ptr<const CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
   if (timer && !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER))
     return timer->IsRecording();
 
-  const std::shared_ptr<CPVREpgInfoTag> epg = item.GetEPGInfoTag();
+  const std::shared_ptr<const CPVREpgInfoTag> epg = item.GetEPGInfoTag();
   if (epg && epg->IsGapTag())
   {
     channel = CServiceBroker::GetPVRManager().ChannelGroups()->GetChannelForEpgTag(epg);
@@ -311,7 +311,7 @@ bool StopRecording::IsVisible(const CFileItem& item) const
 
 bool StopRecording::Execute(const CFileItemPtr& item) const
 {
-  const std::shared_ptr<CPVREpgInfoTag> epgTag = item->GetEPGInfoTag();
+  const std::shared_ptr<const CPVREpgInfoTag> epgTag = item->GetEPGInfoTag();
   if (epgTag && epgTag->IsGapTag())
   {
     // instance recording
@@ -330,7 +330,7 @@ bool StopRecording::Execute(const CFileItemPtr& item) const
 
 bool EditRecording::IsVisible(const CFileItem& item) const
 {
-  const std::shared_ptr<CPVRRecording> recording(item.GetPVRRecordingInfoTag());
+  const std::shared_ptr<const CPVRRecording> recording(item.GetPVRRecordingInfoTag());
   if (recording && !recording->IsDeleted() && !recording->IsInProgress())
   {
     return CServiceBroker::GetPVRManager().Get<PVR::GUI::Recordings>().CanEditRecording(item);
@@ -348,7 +348,7 @@ bool EditRecording::Execute(const CFileItemPtr& item) const
 
 std::string DeleteRecording::GetLabel(const CFileItem& item) const
 {
-  const std::shared_ptr<CPVRRecording> recording(item.GetPVRRecordingInfoTag());
+  const std::shared_ptr<const CPVRRecording> recording(item.GetPVRRecordingInfoTag());
   if (recording && recording->IsDeleted())
     return g_localizeStrings.Get(19291); /* Delete permanently */
 
@@ -357,11 +357,11 @@ std::string DeleteRecording::GetLabel(const CFileItem& item) const
 
 bool DeleteRecording::IsVisible(const CFileItem& item) const
 {
-  const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(item);
+  const std::shared_ptr<const CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(item);
   if (client && !client->GetClientCapabilities().SupportsRecordingsDelete())
     return false;
 
-  const std::shared_ptr<CPVRRecording> recording(item.GetPVRRecordingInfoTag());
+  const std::shared_ptr<const CPVRRecording> recording(item.GetPVRRecordingInfoTag());
   if (recording && !recording->IsInProgress())
     return true;
 
@@ -386,7 +386,7 @@ bool DeleteRecording::Execute(const CFileItemPtr& item) const
 
 bool UndeleteRecording::IsVisible(const CFileItem& item) const
 {
-  const std::shared_ptr<CPVRRecording> recording(item.GetPVRRecordingInfoTag());
+  const std::shared_ptr<const CPVRRecording> recording(item.GetPVRRecordingInfoTag());
   if (recording && recording->IsDeleted())
     return true;
 
@@ -420,7 +420,7 @@ bool DeleteWatchedRecordings::Execute(const std::shared_ptr<CFileItem>& item) co
 
 bool AddReminder::IsVisible(const CFileItem& item) const
 {
-  const std::shared_ptr<CPVREpgInfoTag> epg = item.GetEPGInfoTag();
+  const std::shared_ptr<const CPVREpgInfoTag> epg = item.GetEPGInfoTag();
   if (epg && !CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epg) &&
       epg->StartAsLocalTime() > CDateTime::GetCurrentDateTime())
     return true;
@@ -438,7 +438,7 @@ bool AddReminder::Execute(const std::shared_ptr<CFileItem>& item) const
 
 std::string ToggleTimerState::GetLabel(const CFileItem& item) const
 {
-  const std::shared_ptr<CPVRTimerInfoTag> timer(item.GetPVRTimerInfoTag());
+  const std::shared_ptr<const CPVRTimerInfoTag> timer(item.GetPVRTimerInfoTag());
   if (timer && !timer->IsDisabled())
     return g_localizeStrings.Get(844); /* Deactivate */
 
@@ -447,7 +447,7 @@ std::string ToggleTimerState::GetLabel(const CFileItem& item) const
 
 bool ToggleTimerState::IsVisible(const CFileItem& item) const
 {
-  const std::shared_ptr<CPVRTimerInfoTag> timer(item.GetPVRTimerInfoTag());
+  const std::shared_ptr<const CPVRTimerInfoTag> timer(item.GetPVRTimerInfoTag());
   if (!timer || URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER) ||
       timer->IsBroken())
     return false;
@@ -465,7 +465,7 @@ bool ToggleTimerState::Execute(const CFileItemPtr& item) const
 
 bool AddTimerRule::IsVisible(const CFileItem& item) const
 {
-  const std::shared_ptr<CPVREpgInfoTag> epg = item.GetEPGInfoTag();
+  const std::shared_ptr<const CPVREpgInfoTag> epg = item.GetEPGInfoTag();
   return (epg && !epg->IsGapTag() &&
           !CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epg));
 }
@@ -480,10 +480,10 @@ bool AddTimerRule::Execute(const CFileItemPtr& item) const
 
 std::string EditTimerRule::GetLabel(const CFileItem& item) const
 {
-  const std::shared_ptr<CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
+  const std::shared_ptr<const CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
   if (timer && !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER))
   {
-    const std::shared_ptr<CPVRTimerInfoTag> parentTimer(
+    const std::shared_ptr<const CPVRTimerInfoTag> parentTimer(
         CServiceBroker::GetPVRManager().Timers()->GetTimerRule(timer));
     if (parentTimer)
     {
@@ -497,7 +497,7 @@ std::string EditTimerRule::GetLabel(const CFileItem& item) const
 
 bool EditTimerRule::IsVisible(const CFileItem& item) const
 {
-  const std::shared_ptr<CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
+  const std::shared_ptr<const CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
   if (timer && !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER))
     return timer->HasParent();
 
@@ -514,10 +514,10 @@ bool EditTimerRule::Execute(const CFileItemPtr& item) const
 
 bool DeleteTimerRule::IsVisible(const CFileItem& item) const
 {
-  const std::shared_ptr<CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
+  const std::shared_ptr<const CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
   if (timer && !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER))
   {
-    const std::shared_ptr<CPVRTimerInfoTag> parentTimer(
+    const std::shared_ptr<const CPVRTimerInfoTag> parentTimer(
         CServiceBroker::GetPVRManager().Timers()->GetTimerRule(timer));
     if (parentTimer)
       return parentTimer->GetTimerType()->AllowsDelete();
@@ -541,10 +541,10 @@ bool DeleteTimerRule::Execute(const CFileItemPtr& item) const
 
 std::string EditTimer::GetLabel(const CFileItem& item) const
 {
-  const std::shared_ptr<CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
+  const std::shared_ptr<const CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
   if (timer)
   {
-    const std::shared_ptr<CPVRTimerType> timerType = timer->GetTimerType();
+    const std::shared_ptr<const CPVRTimerType> timerType = timer->GetTimerType();
     if (item.GetEPGInfoTag())
     {
       if (timerType->IsReminder())
@@ -562,7 +562,7 @@ std::string EditTimer::GetLabel(const CFileItem& item) const
 
 bool EditTimer::IsVisible(const CFileItem& item) const
 {
-  const std::shared_ptr<CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
+  const std::shared_ptr<const CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
   return timer && (!item.GetEPGInfoTag() ||
                    !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER));
 }
@@ -580,10 +580,10 @@ std::string DeleteTimer::GetLabel(const CFileItem& item) const
   if (item.GetPVRTimerInfoTag())
     return g_localizeStrings.Get(117); /* Delete */
 
-  const std::shared_ptr<CPVREpgInfoTag> epg = item.GetEPGInfoTag();
+  const std::shared_ptr<const CPVREpgInfoTag> epg = item.GetEPGInfoTag();
   if (epg)
   {
-    const std::shared_ptr<CPVRTimerInfoTag> timer =
+    const std::shared_ptr<const CPVRTimerInfoTag> timer =
         CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epg);
     if (timer && timer->IsReminder())
       return g_localizeStrings.Get(827); /* Delete reminder */
@@ -593,7 +593,7 @@ std::string DeleteTimer::GetLabel(const CFileItem& item) const
 
 bool DeleteTimer::IsVisible(const CFileItem& item) const
 {
-  const std::shared_ptr<CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
+  const std::shared_ptr<const CPVRTimerInfoTag> timer(GetTimerInfoTagFromItem(item));
   if (timer &&
       (!item.GetEPGInfoTag() ||
        !URIUtils::PathEquals(item.GetPath(), CPVRTimersPath::PATH_ADDTIMER)) &&
@@ -618,7 +618,7 @@ std::string PVRClientMenuHook::GetLabel(const CFileItem& item) const
 
 bool PVRClientMenuHook::IsVisible(const CFileItem& item) const
 {
-  const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(item);
+  const std::shared_ptr<const CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(item);
   if (!client || m_hook.GetAddonId() != client->ID())
     return false;
 

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -410,7 +410,7 @@ bool CPVRDatabase::Delete(const CPVRClient& client)
   return DeleteValues("clients", filter);
 }
 
-int CPVRDatabase::GetPriority(const CPVRClient& client)
+int CPVRDatabase::GetPriority(const CPVRClient& client) const
 {
   if (client.GetID() == PVR_INVALID_CLIENT_ID)
     return 0;
@@ -544,7 +544,7 @@ bool CPVRDatabase::Get(CPVRProviders& results,
   return bReturn;
 }
 
-int CPVRDatabase::GetMaxProviderId()
+int CPVRDatabase::GetMaxProviderId() const
 {
   std::string strQuery = PrepareSQL("SELECT max(idProvider) as maxProviderId from providers");
   std::unique_lock<CCriticalSection> lock(m_critSection);

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -100,7 +100,7 @@ namespace PVR
      * @param client The client.
      * @return The priority.
      */
-    int GetPriority(const CPVRClient& client);
+    int GetPriority(const CPVRClient& client) const;
 
     /*! @name Channel methods */
     //@{
@@ -187,7 +187,7 @@ namespace PVR
      * @brief Get the maximum provider id in the database
      * @return The maximum provider id in the database
      */
-    int GetMaxProviderId();
+    int GetMaxProviderId() const;
 
     //@}
 

--- a/xbmc/pvr/PVRItem.cpp
+++ b/xbmc/pvr/PVRItem.cpp
@@ -50,7 +50,7 @@ std::shared_ptr<CPVREpgInfoTag> CPVRItem::GetNextEpgInfoTag() const
 {
   if (m_item->IsEPG())
   {
-    const std::shared_ptr<CPVRChannel> channel =
+    const std::shared_ptr<const CPVRChannel> channel =
         CServiceBroker::GetPVRManager().ChannelGroups()->GetChannelForEpgTag(
             m_item->GetEPGInfoTag());
     if (channel)
@@ -62,7 +62,7 @@ std::shared_ptr<CPVREpgInfoTag> CPVRItem::GetNextEpgInfoTag() const
   }
   else if (m_item->IsPVRTimer())
   {
-    const std::shared_ptr<CPVRChannel> channel = m_item->GetPVRTimerInfoTag()->Channel();
+    const std::shared_ptr<const CPVRChannel> channel = m_item->GetPVRTimerInfoTag()->Channel();
     if (channel)
       return channel->GetEPGNext();
   }

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -793,7 +793,7 @@ void CPVRManager::RestartParentalTimer()
     m_parentalTimer->StartZero();
 }
 
-bool CPVRManager::IsParentalLocked(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
+bool CPVRManager::IsParentalLocked(const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const
 {
   return m_channelGroups && epgTag &&
          IsCurrentlyParentalLocked(
@@ -801,12 +801,12 @@ bool CPVRManager::IsParentalLocked(const std::shared_ptr<CPVREpgInfoTag>& epgTag
              epgTag->IsParentalLocked());
 }
 
-bool CPVRManager::IsParentalLocked(const std::shared_ptr<CPVRChannel>& channel) const
+bool CPVRManager::IsParentalLocked(const std::shared_ptr<const CPVRChannel>& channel) const
 {
   return channel && IsCurrentlyParentalLocked(channel, channel->IsLocked());
 }
 
-bool CPVRManager::IsCurrentlyParentalLocked(const std::shared_ptr<CPVRChannel>& channel,
+bool CPVRManager::IsCurrentlyParentalLocked(const std::shared_ptr<const CPVRChannel>& channel,
                                             bool bGenerallyLocked) const
 {
   bool bReturn = false;

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -293,7 +293,7 @@ std::shared_ptr<CPVRClient> CPVRManager::GetClient(const CFileItem& item) const
     iClientID = item.GetEPGInfoTag()->ClientID();
   else if (URIUtils::IsPVRChannel(item.GetPath()))
   {
-    const std::shared_ptr<CPVRChannel> channel = m_channelGroups->GetByPath(item.GetPath());
+    const std::shared_ptr<const CPVRChannel> channel = m_channelGroups->GetByPath(item.GetPath());
     if (channel)
       iClientID = channel->ClientID();
   }
@@ -304,7 +304,7 @@ std::shared_ptr<CPVRClient> CPVRManager::GetClient(const CFileItem& item) const
   }
   else if (URIUtils::IsPVRRecording(item.GetPath()))
   {
-    const std::shared_ptr<CPVRRecording> recording = m_recordings->GetByPath(item.GetPath());
+    const std::shared_ptr<const CPVRRecording> recording = m_recordings->GetByPath(item.GetPath());
     if (recording)
       iClientID = recording->ClientID();
   }
@@ -814,7 +814,7 @@ bool CPVRManager::IsCurrentlyParentalLocked(const std::shared_ptr<const CPVRChan
   if (!channel || !bGenerallyLocked)
     return bReturn;
 
-  const std::shared_ptr<CPVRChannel> currentChannel = m_playbackState->GetPlayingChannel();
+  const std::shared_ptr<const CPVRChannel> currentChannel = m_playbackState->GetPlayingChannel();
 
   if ( // if channel in question is currently playing it must be currently unlocked.
       (!currentChannel || channel != currentChannel) &&

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -308,14 +308,14 @@ public:
    * @param channel The channel to check.
    * @return True if parental lock is overridden, false otherwise.
    */
-  bool IsParentalLocked(const std::shared_ptr<CPVRChannel>& channel) const;
+  bool IsParentalLocked(const std::shared_ptr<const CPVRChannel>& channel) const;
 
   /*!
    * @brief Check if parental lock is overridden at the given moment.
    * @param epgTag The epg tag to check.
    * @return True if parental lock is overridden, false otherwise.
    */
-  bool IsParentalLocked(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
+  bool IsParentalLocked(const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const;
 
   /*!
    * @brief Restart the parental timer.
@@ -427,7 +427,7 @@ private:
    */
   void TriggerPlayChannelOnStartup();
 
-  bool IsCurrentlyParentalLocked(const std::shared_ptr<CPVRChannel>& channel,
+  bool IsCurrentlyParentalLocked(const std::shared_ptr<const CPVRChannel>& channel,
                                  bool bGenerallyLocked) const;
 
   CEventSource<PVREvent> m_events;

--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -331,7 +331,7 @@ bool CPVRPlaybackState::IsPlayingChannel(int iClientID, int iUniqueChannelID) co
   return m_playingClientId == iClientID && m_playingChannelUniqueId == iUniqueChannelID;
 }
 
-bool CPVRPlaybackState::IsPlayingChannel(const std::shared_ptr<CPVRChannel>& channel) const
+bool CPVRPlaybackState::IsPlayingChannel(const std::shared_ptr<const CPVRChannel>& channel) const
 {
   if (channel)
   {
@@ -344,7 +344,8 @@ bool CPVRPlaybackState::IsPlayingChannel(const std::shared_ptr<CPVRChannel>& cha
   return false;
 }
 
-bool CPVRPlaybackState::IsPlayingRecording(const std::shared_ptr<CPVRRecording>& recording) const
+bool CPVRPlaybackState::IsPlayingRecording(
+    const std::shared_ptr<const CPVRRecording>& recording) const
 {
   if (recording)
   {
@@ -357,7 +358,7 @@ bool CPVRPlaybackState::IsPlayingRecording(const std::shared_ptr<CPVRRecording>&
   return false;
 }
 
-bool CPVRPlaybackState::IsPlayingEpgTag(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
+bool CPVRPlaybackState::IsPlayingEpgTag(const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const
 {
   if (epgTag)
   {
@@ -512,7 +513,7 @@ std::shared_ptr<CPVRChannelGroup> CPVRPlaybackState::GetActiveChannelGroup(bool 
 
 CDateTime CPVRPlaybackState::GetPlaybackTime(int iClientID, int iUniqueChannelID) const
 {
-  const std::shared_ptr<CPVREpgInfoTag> epgTag = GetPlayingEpgTag();
+  const std::shared_ptr<const CPVREpgInfoTag> epgTag = GetPlayingEpgTag();
   if (epgTag && iClientID == epgTag->ClientID() && iUniqueChannelID == epgTag->UniqueChannelID())
   {
     // playing an epg tag on requested channel

--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -71,7 +71,7 @@ void CPVRPlaybackState::ReInit()
   {
     if (m_playingChannelUniqueId != -1)
     {
-      const std::shared_ptr<CPVRChannelGroup> group =
+      const std::shared_ptr<const CPVRChannelGroup> group =
           CServiceBroker::GetPVRManager().ChannelGroups()->GetByIdFromAll(m_playingGroupId);
       if (group)
         m_playingChannel = group->GetByUniqueID({m_playingClientId, m_playingChannelUniqueId});
@@ -85,7 +85,7 @@ void CPVRPlaybackState::ReInit()
     }
     else if (m_playingEpgTagChannelUniqueId != -1 && m_playingEpgTagUniqueId != 0)
     {
-      const std::shared_ptr<CPVREpg> epg =
+      const std::shared_ptr<const CPVREpg> epg =
           CServiceBroker::GetPVRManager().EpgContainer().GetByChannelUid(
               m_playingClientId, m_playingEpgTagChannelUniqueId);
       if (epg)
@@ -93,7 +93,7 @@ void CPVRPlaybackState::ReInit()
     }
   }
 
-  const std::shared_ptr<CPVRChannelGroupsContainer> groups =
+  const std::shared_ptr<const CPVRChannelGroupsContainer> groups =
       CServiceBroker::GetPVRManager().ChannelGroups();
   const CPVRChannelGroups* groupsTV = groups->GetTV();
   const CPVRChannelGroups* groupsRadio = groups->GetRadio();
@@ -217,7 +217,7 @@ void CPVRPlaybackState::OnPlaybackStarted(const CFileItem& item)
 
   if (m_playingClientId != -1)
   {
-    const std::shared_ptr<CPVRClient> client =
+    const std::shared_ptr<const CPVRClient> client =
         CServiceBroker::GetPVRManager().GetClient(m_playingClientId);
     if (client)
       m_strPlayingClientName = client->GetFriendlyName();
@@ -335,7 +335,7 @@ bool CPVRPlaybackState::IsPlayingChannel(const std::shared_ptr<const CPVRChannel
 {
   if (channel)
   {
-    const std::shared_ptr<CPVRChannel> current = GetPlayingChannel();
+    const std::shared_ptr<const CPVRChannel> current = GetPlayingChannel();
     if (current && current->ClientID() == channel->ClientID() &&
         current->UniqueID() == channel->UniqueID())
       return true;
@@ -349,7 +349,7 @@ bool CPVRPlaybackState::IsPlayingRecording(
 {
   if (recording)
   {
-    const std::shared_ptr<CPVRRecording> current = GetPlayingRecording();
+    const std::shared_ptr<const CPVRRecording> current = GetPlayingRecording();
     if (current && current->ClientID() == recording->ClientID() &&
         current->ClientRecordingID() == recording->ClientRecordingID())
       return true;
@@ -362,7 +362,7 @@ bool CPVRPlaybackState::IsPlayingEpgTag(const std::shared_ptr<const CPVREpgInfoT
 {
   if (epgTag)
   {
-    const std::shared_ptr<CPVREpgInfoTag> current = GetPlayingEpgTag();
+    const std::shared_ptr<const CPVREpgInfoTag> current = GetPlayingEpgTag();
     if (current && current->ClientID() == epgTag->ClientID() &&
         current->UniqueChannelID() == epgTag->UniqueChannelID() &&
         current->UniqueBroadcastID() == epgTag->UniqueBroadcastID())
@@ -421,20 +421,20 @@ bool CPVRPlaybackState::IsRecording() const
 
 bool CPVRPlaybackState::IsRecordingOnPlayingChannel() const
 {
-  const std::shared_ptr<CPVRChannel> currentChannel = GetPlayingChannel();
+  const std::shared_ptr<const CPVRChannel> currentChannel = GetPlayingChannel();
   return currentChannel &&
          CServiceBroker::GetPVRManager().Timers()->IsRecordingOnChannel(*currentChannel);
 }
 
 bool CPVRPlaybackState::IsPlayingActiveRecording() const
 {
-  const std::shared_ptr<CPVRRecording> currentRecording = GetPlayingRecording();
+  const std::shared_ptr<const CPVRRecording> currentRecording = GetPlayingRecording();
   return currentRecording && currentRecording->IsInProgress();
 }
 
 bool CPVRPlaybackState::CanRecordOnPlayingChannel() const
 {
-  const std::shared_ptr<CPVRChannel> currentChannel = GetPlayingChannel();
+  const std::shared_ptr<const CPVRChannel> currentChannel = GetPlayingChannel();
   return currentChannel && currentChannel->CanRecord();
 }
 

--- a/xbmc/pvr/PVRPlaybackState.h
+++ b/xbmc/pvr/PVRPlaybackState.h
@@ -115,21 +115,21 @@ public:
    * @param channel The channel to check.
    * @return True if it's playing, false otherwise.
    */
-  bool IsPlayingChannel(const std::shared_ptr<CPVRChannel>& channel) const;
+  bool IsPlayingChannel(const std::shared_ptr<const CPVRChannel>& channel) const;
 
   /*!
    * @brief Check if the given recording is playing.
    * @param recording The recording to check.
    * @return True if it's playing, false otherwise.
    */
-  bool IsPlayingRecording(const std::shared_ptr<CPVRRecording>& recording) const;
+  bool IsPlayingRecording(const std::shared_ptr<const CPVRRecording>& recording) const;
 
   /*!
    * @brief Check if the given epg tag is playing.
    * @param epgTag The tag to check.
    * @return True if it's playing, false otherwise.
    */
-  bool IsPlayingEpgTag(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
+  bool IsPlayingEpgTag(const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const;
 
   /*!
    * @brief Return the channel that is currently playing.

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -421,7 +421,7 @@ const std::string CPVRClient::GetFriendlyName() const
   return Name();
 }
 
-PVR_ERROR CPVRClient::GetDriveSpace(uint64_t& iTotal, uint64_t& iUsed)
+PVR_ERROR CPVRClient::GetDriveSpace(uint64_t& iTotal, uint64_t& iUsed) const
 {
   /* default to 0 in case of error */
   iTotal = 0;
@@ -498,7 +498,10 @@ PVR_ERROR CPVRClient::RenameChannel(const std::shared_ptr<const CPVRChannel>& ch
       m_clientCapabilities.SupportsChannelSettings());
 }
 
-PVR_ERROR CPVRClient::GetEPGForChannel(int iChannelUid, CPVREpg* epg, time_t start, time_t end)
+PVR_ERROR CPVRClient::GetEPGForChannel(int iChannelUid,
+                                       CPVREpg* epg,
+                                       time_t start,
+                                       time_t end) const
 {
   return DoAddonCall(
       __func__,
@@ -653,7 +656,7 @@ void CPVRClient::WriteStreamProperties(const PVR_NAMED_VALUE* properties,
 }
 
 PVR_ERROR CPVRClient::GetEpgTagStreamProperties(const std::shared_ptr<const CPVREpgInfoTag>& tag,
-                                                CPVRStreamProperties& props)
+                                                CPVRStreamProperties& props) const
 {
   return DoAddonCall(__func__, [&tag, &props](const AddonInstance* addon) {
     CAddonEpgTag addonTag(tag);
@@ -672,7 +675,7 @@ PVR_ERROR CPVRClient::GetEpgTagStreamProperties(const std::shared_ptr<const CPVR
 }
 
 PVR_ERROR CPVRClient::GetEpgTagEdl(const std::shared_ptr<const CPVREpgInfoTag>& epgTag,
-                                   std::vector<PVR_EDL_ENTRY>& edls)
+                                   std::vector<PVR_EDL_ENTRY>& edls) const
 {
   edls.clear();
   return DoAddonCall(
@@ -694,7 +697,7 @@ PVR_ERROR CPVRClient::GetEpgTagEdl(const std::shared_ptr<const CPVREpgInfoTag>& 
       m_clientCapabilities.SupportsEpgTagEdl());
 }
 
-PVR_ERROR CPVRClient::GetChannelGroupsAmount(int& iGroups)
+PVR_ERROR CPVRClient::GetChannelGroupsAmount(int& iGroups) const
 {
   iGroups = -1;
   return DoAddonCall(
@@ -705,7 +708,7 @@ PVR_ERROR CPVRClient::GetChannelGroupsAmount(int& iGroups)
       m_clientCapabilities.SupportsChannelGroups());
 }
 
-PVR_ERROR CPVRClient::GetChannelGroups(CPVRChannelGroups* groups)
+PVR_ERROR CPVRClient::GetChannelGroups(CPVRChannelGroups* groups) const
 {
   return DoAddonCall(__func__,
                      [this, groups](const AddonInstance* addon) {
@@ -718,7 +721,8 @@ PVR_ERROR CPVRClient::GetChannelGroups(CPVRChannelGroups* groups)
 }
 
 PVR_ERROR CPVRClient::GetChannelGroupMembers(
-    CPVRChannelGroup* group, std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers)
+    CPVRChannelGroup* group,
+    std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers) const
 {
   return DoAddonCall(__func__,
                      [this, group, &groupMembers](const AddonInstance* addon) {
@@ -733,7 +737,7 @@ PVR_ERROR CPVRClient::GetChannelGroupMembers(
                      m_clientCapabilities.SupportsChannelGroups());
 }
 
-PVR_ERROR CPVRClient::GetProvidersAmount(int& iProviders)
+PVR_ERROR CPVRClient::GetProvidersAmount(int& iProviders) const
 {
   iProviders = -1;
   return DoAddonCall(__func__, [&iProviders](const AddonInstance* addon) {
@@ -741,7 +745,7 @@ PVR_ERROR CPVRClient::GetProvidersAmount(int& iProviders)
   });
 }
 
-PVR_ERROR CPVRClient::GetProviders(CPVRProvidersContainer& providers)
+PVR_ERROR CPVRClient::GetProviders(CPVRProvidersContainer& providers) const
 {
   return DoAddonCall(__func__,
                      [this, &providers](const AddonInstance* addon) {
@@ -753,7 +757,7 @@ PVR_ERROR CPVRClient::GetProviders(CPVRProvidersContainer& providers)
                      m_clientCapabilities.SupportsProviders());
 }
 
-PVR_ERROR CPVRClient::GetChannelsAmount(int& iChannels)
+PVR_ERROR CPVRClient::GetChannelsAmount(int& iChannels) const
 {
   iChannels = -1;
   return DoAddonCall(__func__, [&iChannels](const AddonInstance* addon) {
@@ -761,7 +765,8 @@ PVR_ERROR CPVRClient::GetChannelsAmount(int& iChannels)
   });
 }
 
-PVR_ERROR CPVRClient::GetChannels(bool radio, std::vector<std::shared_ptr<CPVRChannel>>& channels)
+PVR_ERROR CPVRClient::GetChannels(bool radio,
+                                  std::vector<std::shared_ptr<CPVRChannel>>& channels) const
 {
   return DoAddonCall(__func__,
                      [this, radio, &channels](const AddonInstance* addon) {
@@ -774,7 +779,7 @@ PVR_ERROR CPVRClient::GetChannels(bool radio, std::vector<std::shared_ptr<CPVRCh
                          (!radio && m_clientCapabilities.SupportsTV()));
 }
 
-PVR_ERROR CPVRClient::GetRecordingsAmount(bool deleted, int& iRecordings)
+PVR_ERROR CPVRClient::GetRecordingsAmount(bool deleted, int& iRecordings) const
 {
   iRecordings = -1;
   return DoAddonCall(
@@ -786,7 +791,7 @@ PVR_ERROR CPVRClient::GetRecordingsAmount(bool deleted, int& iRecordings)
           (!deleted || m_clientCapabilities.SupportsRecordingsUndelete()));
 }
 
-PVR_ERROR CPVRClient::GetRecordings(CPVRRecordings* results, bool deleted)
+PVR_ERROR CPVRClient::GetRecordings(CPVRRecordings* results, bool deleted) const
 {
   return DoAddonCall(__func__,
                      [this, results, deleted](const AddonInstance* addon) {
@@ -882,7 +887,8 @@ PVR_ERROR CPVRClient::SetRecordingLastPlayedPosition(const CPVRRecording& record
       m_clientCapabilities.SupportsRecordingsLastPlayedPosition());
 }
 
-PVR_ERROR CPVRClient::GetRecordingLastPlayedPosition(const CPVRRecording& recording, int& iPosition)
+PVR_ERROR CPVRClient::GetRecordingLastPlayedPosition(const CPVRRecording& recording,
+                                                     int& iPosition) const
 {
   iPosition = -1;
   return DoAddonCall(
@@ -896,7 +902,7 @@ PVR_ERROR CPVRClient::GetRecordingLastPlayedPosition(const CPVRRecording& record
 }
 
 PVR_ERROR CPVRClient::GetRecordingEdl(const CPVRRecording& recording,
-                                      std::vector<PVR_EDL_ENTRY>& edls)
+                                      std::vector<PVR_EDL_ENTRY>& edls) const
 {
   edls.clear();
   return DoAddonCall(
@@ -919,7 +925,7 @@ PVR_ERROR CPVRClient::GetRecordingEdl(const CPVRRecording& recording,
       m_clientCapabilities.SupportsRecordingsEdl());
 }
 
-PVR_ERROR CPVRClient::GetRecordingSize(const CPVRRecording& recording, int64_t& sizeInBytes)
+PVR_ERROR CPVRClient::GetRecordingSize(const CPVRRecording& recording, int64_t& sizeInBytes) const
 {
   return DoAddonCall(
       __func__,
@@ -931,7 +937,7 @@ PVR_ERROR CPVRClient::GetRecordingSize(const CPVRRecording& recording, int64_t& 
       m_clientCapabilities.SupportsRecordingsSize());
 }
 
-PVR_ERROR CPVRClient::GetTimersAmount(int& iTimers)
+PVR_ERROR CPVRClient::GetTimersAmount(int& iTimers) const
 {
   iTimers = -1;
   return DoAddonCall(
@@ -942,7 +948,7 @@ PVR_ERROR CPVRClient::GetTimersAmount(int& iTimers)
       m_clientCapabilities.SupportsTimers());
 }
 
-PVR_ERROR CPVRClient::GetTimers(CPVRTimersContainer* results)
+PVR_ERROR CPVRClient::GetTimers(CPVRTimersContainer* results) const
 {
   return DoAddonCall(__func__,
                      [this, results](const AddonInstance* addon) {
@@ -1110,7 +1116,7 @@ PVR_ERROR CPVRClient::UpdateTimerTypes()
   return retVal;
 }
 
-PVR_ERROR CPVRClient::GetStreamReadChunkSize(int& iChunkSize)
+PVR_ERROR CPVRClient::GetStreamReadChunkSize(int& iChunkSize) const
 {
   return DoAddonCall(
       __func__,
@@ -1166,7 +1172,7 @@ PVR_ERROR CPVRClient::SeekTime(double time, bool backwards, double* startpts)
   });
 }
 
-PVR_ERROR CPVRClient::GetLiveStreamLength(int64_t& iLength)
+PVR_ERROR CPVRClient::GetLiveStreamLength(int64_t& iLength) const
 {
   iLength = -1;
   return DoAddonCall(__func__, [&iLength](const AddonInstance* addon) {
@@ -1175,7 +1181,7 @@ PVR_ERROR CPVRClient::GetLiveStreamLength(int64_t& iLength)
   });
 }
 
-PVR_ERROR CPVRClient::GetRecordedStreamLength(int64_t& iLength)
+PVR_ERROR CPVRClient::GetRecordedStreamLength(int64_t& iLength) const
 {
   iLength = -1;
   return DoAddonCall(__func__, [&iLength](const AddonInstance* addon) {
@@ -1184,7 +1190,7 @@ PVR_ERROR CPVRClient::GetRecordedStreamLength(int64_t& iLength)
   });
 }
 
-PVR_ERROR CPVRClient::SignalQuality(int channelUid, PVR_SIGNAL_STATUS& qualityinfo)
+PVR_ERROR CPVRClient::SignalQuality(int channelUid, PVR_SIGNAL_STATUS& qualityinfo) const
 {
   return DoAddonCall(__func__, [channelUid, &qualityinfo](const AddonInstance* addon) {
     return addon->toAddon->GetSignalStatus(addon, channelUid, &qualityinfo);
@@ -1202,7 +1208,7 @@ PVR_ERROR CPVRClient::GetDescrambleInfo(int channelUid, PVR_DESCRAMBLE_INFO& des
 }
 
 PVR_ERROR CPVRClient::GetChannelStreamProperties(const std::shared_ptr<const CPVRChannel>& channel,
-                                                 CPVRStreamProperties& props)
+                                                 CPVRStreamProperties& props) const
 {
   return DoAddonCall(__func__, [this, &channel, &props](const AddonInstance* addon) {
     if (!CanPlayChannel(channel))
@@ -1225,7 +1231,7 @@ PVR_ERROR CPVRClient::GetChannelStreamProperties(const std::shared_ptr<const CPV
 }
 
 PVR_ERROR CPVRClient::GetRecordingStreamProperties(
-    const std::shared_ptr<const CPVRRecording>& recording, CPVRStreamProperties& props)
+    const std::shared_ptr<const CPVRRecording>& recording, CPVRStreamProperties& props) const
 {
   return DoAddonCall(__func__, [this, &recording, &props](const AddonInstance* addon) {
     if (!m_clientCapabilities.SupportsRecordings())
@@ -1247,7 +1253,7 @@ PVR_ERROR CPVRClient::GetRecordingStreamProperties(
   });
 }
 
-PVR_ERROR CPVRClient::GetStreamProperties(PVR_STREAM_PROPERTIES* props)
+PVR_ERROR CPVRClient::GetStreamProperties(PVR_STREAM_PROPERTIES* props) const
 {
   return DoAddonCall(__func__, [&props](const AddonInstance* addon) {
     return addon->toAddon->GetStreamProperties(addon, props);
@@ -1487,7 +1493,7 @@ PVR_ERROR CPVRClient::CanSeekStream(bool& bCanSeek) const
   });
 }
 
-PVR_ERROR CPVRClient::GetStreamTimes(PVR_STREAM_TIMES* times)
+PVR_ERROR CPVRClient::GetStreamTimes(PVR_STREAM_TIMES* times) const
 {
   return DoAddonCall(__func__, [&times](const AddonInstance* addon) {
     return addon->toAddon->GetStreamTimes(addon, times);
@@ -1529,7 +1535,7 @@ PVR_ERROR CPVRClient::OnPowerSavingDeactivated()
   });
 }
 
-std::shared_ptr<CPVRClientMenuHooks> CPVRClient::GetMenuHooks()
+std::shared_ptr<CPVRClientMenuHooks> CPVRClient::GetMenuHooks() const
 {
   if (!m_menuhooks)
     m_menuhooks = std::make_shared<CPVRClientMenuHooks>(ID());

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -448,7 +448,7 @@ PVR_ERROR CPVRClient::StartChannelScan()
       m_clientCapabilities.SupportsChannelScan());
 }
 
-PVR_ERROR CPVRClient::OpenDialogChannelAdd(const std::shared_ptr<CPVRChannel>& channel)
+PVR_ERROR CPVRClient::OpenDialogChannelAdd(const std::shared_ptr<const CPVRChannel>& channel)
 {
   return DoAddonCall(
       __func__,
@@ -460,7 +460,7 @@ PVR_ERROR CPVRClient::OpenDialogChannelAdd(const std::shared_ptr<CPVRChannel>& c
       m_clientCapabilities.SupportsChannelSettings());
 }
 
-PVR_ERROR CPVRClient::OpenDialogChannelSettings(const std::shared_ptr<CPVRChannel>& channel)
+PVR_ERROR CPVRClient::OpenDialogChannelSettings(const std::shared_ptr<const CPVRChannel>& channel)
 {
   return DoAddonCall(
       __func__,
@@ -472,7 +472,7 @@ PVR_ERROR CPVRClient::OpenDialogChannelSettings(const std::shared_ptr<CPVRChanne
       m_clientCapabilities.SupportsChannelSettings());
 }
 
-PVR_ERROR CPVRClient::DeleteChannel(const std::shared_ptr<CPVRChannel>& channel)
+PVR_ERROR CPVRClient::DeleteChannel(const std::shared_ptr<const CPVRChannel>& channel)
 {
   return DoAddonCall(
       __func__,
@@ -484,7 +484,7 @@ PVR_ERROR CPVRClient::DeleteChannel(const std::shared_ptr<CPVRChannel>& channel)
       m_clientCapabilities.SupportsChannelSettings());
 }
 
-PVR_ERROR CPVRClient::RenameChannel(const std::shared_ptr<CPVRChannel>& channel)
+PVR_ERROR CPVRClient::RenameChannel(const std::shared_ptr<const CPVRChannel>& channel)
 {
   return DoAddonCall(
       __func__,
@@ -652,7 +652,7 @@ void CPVRClient::WriteStreamProperties(const PVR_NAMED_VALUE* properties,
   }
 }
 
-PVR_ERROR CPVRClient::GetEpgTagStreamProperties(const std::shared_ptr<CPVREpgInfoTag>& tag,
+PVR_ERROR CPVRClient::GetEpgTagStreamProperties(const std::shared_ptr<const CPVREpgInfoTag>& tag,
                                                 CPVRStreamProperties& props)
 {
   return DoAddonCall(__func__, [&tag, &props](const AddonInstance* addon) {
@@ -1091,7 +1091,7 @@ PVR_ERROR CPVRClient::UpdateTimerTypes()
     for (const auto& type : timerTypes)
     {
       const auto it = std::find_if(m_timertypes.cbegin(), m_timertypes.cend(),
-                                   [&type](const std::shared_ptr<CPVRTimerType>& entry) {
+                                   [&type](const std::shared_ptr<const CPVRTimerType>& entry) {
                                      return entry->GetTypeId() == type->GetTypeId();
                                    });
       if (it == m_timertypes.cend())
@@ -1201,7 +1201,7 @@ PVR_ERROR CPVRClient::GetDescrambleInfo(int channelUid, PVR_DESCRAMBLE_INFO& des
       m_clientCapabilities.SupportsDescrambleInfo());
 }
 
-PVR_ERROR CPVRClient::GetChannelStreamProperties(const std::shared_ptr<CPVRChannel>& channel,
+PVR_ERROR CPVRClient::GetChannelStreamProperties(const std::shared_ptr<const CPVRChannel>& channel,
                                                  CPVRStreamProperties& props)
 {
   return DoAddonCall(__func__, [this, &channel, &props](const AddonInstance* addon) {
@@ -1224,8 +1224,8 @@ PVR_ERROR CPVRClient::GetChannelStreamProperties(const std::shared_ptr<CPVRChann
   });
 }
 
-PVR_ERROR CPVRClient::GetRecordingStreamProperties(const std::shared_ptr<CPVRRecording>& recording,
-                                                   CPVRStreamProperties& props)
+PVR_ERROR CPVRClient::GetRecordingStreamProperties(
+    const std::shared_ptr<const CPVRRecording>& recording, CPVRStreamProperties& props)
 {
   return DoAddonCall(__func__, [this, &recording, &props](const AddonInstance* addon) {
     if (!m_clientCapabilities.SupportsRecordings())
@@ -1379,13 +1379,13 @@ PVR_ERROR CPVRClient::DoAddonCall(const char* strFunctionName,
   return error;
 }
 
-bool CPVRClient::CanPlayChannel(const std::shared_ptr<CPVRChannel>& channel) const
+bool CPVRClient::CanPlayChannel(const std::shared_ptr<const CPVRChannel>& channel) const
 {
   return (m_bReadyToUse && ((m_clientCapabilities.SupportsTV() && !channel->IsRadio()) ||
                             (m_clientCapabilities.SupportsRadio() && channel->IsRadio())));
 }
 
-PVR_ERROR CPVRClient::OpenLiveStream(const std::shared_ptr<CPVRChannel>& channel)
+PVR_ERROR CPVRClient::OpenLiveStream(const std::shared_ptr<const CPVRChannel>& channel)
 {
   if (!channel)
     return PVR_ERROR_INVALID_PARAMETERS;
@@ -1410,7 +1410,7 @@ PVR_ERROR CPVRClient::OpenLiveStream(const std::shared_ptr<CPVRChannel>& channel
   });
 }
 
-PVR_ERROR CPVRClient::OpenRecordedStream(const std::shared_ptr<CPVRRecording>& recording)
+PVR_ERROR CPVRClient::OpenRecordedStream(const std::shared_ptr<const CPVRRecording>& recording)
 {
   if (!recording)
     return PVR_ERROR_INVALID_PARAMETERS;
@@ -1538,7 +1538,7 @@ std::shared_ptr<CPVRClientMenuHooks> CPVRClient::GetMenuHooks()
 }
 
 PVR_ERROR CPVRClient::CallEpgTagMenuHook(const CPVRClientMenuHook& hook,
-                                         const std::shared_ptr<CPVREpgInfoTag>& tag)
+                                         const std::shared_ptr<const CPVREpgInfoTag>& tag)
 {
   return DoAddonCall(__func__, [&hook, &tag](const AddonInstance* addon) {
     CAddonEpgTag addonTag(tag);
@@ -1553,7 +1553,7 @@ PVR_ERROR CPVRClient::CallEpgTagMenuHook(const CPVRClientMenuHook& hook,
 }
 
 PVR_ERROR CPVRClient::CallChannelMenuHook(const CPVRClientMenuHook& hook,
-                                          const std::shared_ptr<CPVRChannel>& channel)
+                                          const std::shared_ptr<const CPVRChannel>& channel)
 {
   return DoAddonCall(__func__, [&hook, &channel](const AddonInstance* addon) {
     PVR_CHANNEL tag;
@@ -1569,7 +1569,7 @@ PVR_ERROR CPVRClient::CallChannelMenuHook(const CPVRClientMenuHook& hook,
 }
 
 PVR_ERROR CPVRClient::CallRecordingMenuHook(const CPVRClientMenuHook& hook,
-                                            const std::shared_ptr<CPVRRecording>& recording,
+                                            const std::shared_ptr<const CPVRRecording>& recording,
                                             bool bDeleted)
 {
   return DoAddonCall(__func__, [&hook, &recording, &bDeleted](const AddonInstance* addon) {
@@ -1586,7 +1586,7 @@ PVR_ERROR CPVRClient::CallRecordingMenuHook(const CPVRClientMenuHook& hook,
 }
 
 PVR_ERROR CPVRClient::CallTimerMenuHook(const CPVRClientMenuHook& hook,
-                                        const std::shared_ptr<CPVRTimerInfoTag>& timer)
+                                        const std::shared_ptr<const CPVRTimerInfoTag>& timer)
 {
   return DoAddonCall(__func__, [&hook, &timer](const AddonInstance* addon) {
     PVR_TIMER tag;

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -188,28 +188,28 @@ public:
    * @param channel The channel to add
    * @return PVR_ERROR_NO_ERROR if the add has been fetched successfully.
    */
-  PVR_ERROR OpenDialogChannelAdd(const std::shared_ptr<CPVRChannel>& channel);
+  PVR_ERROR OpenDialogChannelAdd(const std::shared_ptr<const CPVRChannel>& channel);
 
   /*!
    * @brief Request the client to open dialog about given channel settings
    * @param channel The channel to edit
    * @return PVR_ERROR_NO_ERROR if the edit has been fetched successfully.
    */
-  PVR_ERROR OpenDialogChannelSettings(const std::shared_ptr<CPVRChannel>& channel);
+  PVR_ERROR OpenDialogChannelSettings(const std::shared_ptr<const CPVRChannel>& channel);
 
   /*!
    * @brief Request the client to delete given channel
    * @param channel The channel to delete
    * @return PVR_ERROR_NO_ERROR if the delete has been fetched successfully.
    */
-  PVR_ERROR DeleteChannel(const std::shared_ptr<CPVRChannel>& channel);
+  PVR_ERROR DeleteChannel(const std::shared_ptr<const CPVRChannel>& channel);
 
   /*!
    * @brief Request the client to rename given channel
    * @param channel The channel to rename
    * @return PVR_ERROR_NO_ERROR if the rename has been fetched successfully.
    */
-  PVR_ERROR RenameChannel(const std::shared_ptr<CPVRChannel>& channel);
+  PVR_ERROR RenameChannel(const std::shared_ptr<const CPVRChannel>& channel);
 
   /*
    * @brief Check if an epg tag can be recorded
@@ -236,7 +236,7 @@ public:
    * @param props The container to be filled with the stream properties.
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */
-  PVR_ERROR GetEpgTagStreamProperties(const std::shared_ptr<CPVREpgInfoTag>& tag,
+  PVR_ERROR GetEpgTagStreamProperties(const std::shared_ptr<const CPVREpgInfoTag>& tag,
                                       CPVRStreamProperties& props);
 
   //@}
@@ -509,7 +509,7 @@ public:
    * @param channel The channel to stream.
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */
-  PVR_ERROR OpenLiveStream(const std::shared_ptr<CPVRChannel>& channel);
+  PVR_ERROR OpenLiveStream(const std::shared_ptr<const CPVRChannel>& channel);
 
   /*!
    * @brief Close an open live stream.
@@ -571,7 +571,7 @@ public:
    * @param props The container to be filled with the stream properties.
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */
-  PVR_ERROR GetChannelStreamProperties(const std::shared_ptr<CPVRChannel>& channel,
+  PVR_ERROR GetChannelStreamProperties(const std::shared_ptr<const CPVRChannel>& channel,
                                        CPVRStreamProperties& props);
 
   /*!
@@ -623,7 +623,7 @@ public:
    * @param recording The recording to open.
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */
-  PVR_ERROR OpenRecordedStream(const std::shared_ptr<CPVRRecording>& recording);
+  PVR_ERROR OpenRecordedStream(const std::shared_ptr<const CPVRRecording>& recording);
 
   /*!
    * @brief Close an open recording stream.
@@ -662,7 +662,7 @@ public:
    * @param props The container to be filled with the stream properties.
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */
-  PVR_ERROR GetRecordingStreamProperties(const std::shared_ptr<CPVRRecording>& recording,
+  PVR_ERROR GetRecordingStreamProperties(const std::shared_ptr<const CPVRRecording>& recording,
                                          CPVRStreamProperties& props);
 
   //@}
@@ -723,7 +723,7 @@ public:
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */
   PVR_ERROR CallEpgTagMenuHook(const CPVRClientMenuHook& hook,
-                               const std::shared_ptr<CPVREpgInfoTag>& tag);
+                               const std::shared_ptr<const CPVREpgInfoTag>& tag);
 
   /*!
    * @brief Call one of the channel menu hooks of the client.
@@ -732,7 +732,7 @@ public:
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */
   PVR_ERROR CallChannelMenuHook(const CPVRClientMenuHook& hook,
-                                const std::shared_ptr<CPVRChannel>& channel);
+                                const std::shared_ptr<const CPVRChannel>& channel);
 
   /*!
    * @brief Call one of the recording menu hooks of the client.
@@ -742,7 +742,7 @@ public:
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */
   PVR_ERROR CallRecordingMenuHook(const CPVRClientMenuHook& hook,
-                                  const std::shared_ptr<CPVRRecording>& recording,
+                                  const std::shared_ptr<const CPVRRecording>& recording,
                                   bool bDeleted);
 
   /*!
@@ -752,7 +752,7 @@ public:
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */
   PVR_ERROR CallTimerMenuHook(const CPVRClientMenuHook& hook,
-                              const std::shared_ptr<CPVRTimerInfoTag>& timer);
+                              const std::shared_ptr<const CPVRTimerInfoTag>& timer);
 
   /*!
    * @brief Call one of the settings menu hooks of the client.
@@ -828,7 +828,7 @@ private:
    * @param channel The channel to check.
    * @return True when it can be played, false otherwise.
    */
-  bool CanPlayChannel(const std::shared_ptr<CPVRChannel>& channel) const;
+  bool CanPlayChannel(const std::shared_ptr<const CPVRChannel>& channel) const;
 
   /*!
    * @brief Stop this instance, if it is currently running.

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -141,7 +141,7 @@ public:
    * @param pProperties The properties.
    * @return PVR_ERROR_NO_ERROR if the properties have been fetched successfully.
    */
-  PVR_ERROR GetStreamProperties(PVR_STREAM_PROPERTIES* pProperties);
+  PVR_ERROR GetStreamProperties(PVR_STREAM_PROPERTIES* pProperties) const;
 
   /*!
    * @return The name reported by the backend.
@@ -175,7 +175,7 @@ public:
    * @param iUsed The used disk space.
    * @return PVR_ERROR_NO_ERROR if the drive space has been fetched successfully.
    */
-  PVR_ERROR GetDriveSpace(uint64_t& iTotal, uint64_t& iUsed);
+  PVR_ERROR GetDriveSpace(uint64_t& iTotal, uint64_t& iUsed) const;
 
   /*!
    * @brief Start a channel scan on the server.
@@ -237,7 +237,7 @@ public:
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */
   PVR_ERROR GetEpgTagStreamProperties(const std::shared_ptr<const CPVREpgInfoTag>& tag,
-                                      CPVRStreamProperties& props);
+                                      CPVRStreamProperties& props) const;
 
   //@}
   /** @name PVR EPG methods */
@@ -251,7 +251,7 @@ public:
    * @param end The end time to use.
    * @return PVR_ERROR_NO_ERROR if the table has been fetched successfully.
    */
-  PVR_ERROR GetEPGForChannel(int iChannelUid, CPVREpg* epg, time_t start, time_t end);
+  PVR_ERROR GetEPGForChannel(int iChannelUid, CPVREpg* epg, time_t start, time_t end) const;
 
   /*!
    * @brief Tell the client the past time frame to use when notifying epg events back
@@ -294,14 +294,14 @@ public:
    * @param iGroups The total amount of channel groups on the server or -1 on error.
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */
-  PVR_ERROR GetChannelGroupsAmount(int& iGroups);
+  PVR_ERROR GetChannelGroupsAmount(int& iGroups) const;
 
   /*!
    * @brief Request the list of all channel groups from the backend.
    * @param groups The groups container to get the groups for.
    * @return PVR_ERROR_NO_ERROR if the list has been fetched successfully.
    */
-  PVR_ERROR GetChannelGroups(CPVRChannelGroups* groups);
+  PVR_ERROR GetChannelGroups(CPVRChannelGroups* groups) const;
 
   /*!
    * @brief Request the list of all group members from the backend.
@@ -310,7 +310,8 @@ public:
    * @return PVR_ERROR_NO_ERROR if the list has been fetched successfully.
    */
   PVR_ERROR GetChannelGroupMembers(
-      CPVRChannelGroup* group, std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers);
+      CPVRChannelGroup* group,
+      std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers) const;
 
   //@}
   /** @name PVR channel methods */
@@ -321,7 +322,7 @@ public:
    * @param iChannels The total amount of channels on the server or -1 on error.
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */
-  PVR_ERROR GetChannelsAmount(int& iChannels);
+  PVR_ERROR GetChannelsAmount(int& iChannels) const;
 
   /*!
    * @brief Request the list of all channels from the backend.
@@ -329,21 +330,21 @@ public:
    * @param channels The container for the channels.
    * @return PVR_ERROR_NO_ERROR if the list has been fetched successfully.
    */
-  PVR_ERROR GetChannels(bool bRadio, std::vector<std::shared_ptr<CPVRChannel>>& channels);
+  PVR_ERROR GetChannels(bool bRadio, std::vector<std::shared_ptr<CPVRChannel>>& channels) const;
 
   /*!
    * @brief Get the total amount of providers from the backend.
    * @param iChannels The total amount of channels on the server or -1 on error.
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */
-  PVR_ERROR GetProvidersAmount(int& iProviders);
+  PVR_ERROR GetProvidersAmount(int& iProviders) const;
 
   /*!
    * @brief Request the list of all providers from the backend.
    * @param providers The providers list to add the providers to.
    * @return PVR_ERROR_NO_ERROR if the list has been fetched successfully.
    */
-  PVR_ERROR GetProviders(CPVRProvidersContainer& providers);
+  PVR_ERROR GetProviders(CPVRProvidersContainer& providers) const;
 
   //@}
   /** @name PVR recording methods */
@@ -355,7 +356,7 @@ public:
    * @param iRecordings The total amount of recordings on the server or -1 on error.
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */
-  PVR_ERROR GetRecordingsAmount(bool deleted, int& iRecordings);
+  PVR_ERROR GetRecordingsAmount(bool deleted, int& iRecordings) const;
 
   /*!
    * @brief Request the list of all recordings from the backend.
@@ -363,7 +364,7 @@ public:
    * @param deleted True to return deleted recordings.
    * @return PVR_ERROR_NO_ERROR if the list has been fetched successfully.
    */
-  PVR_ERROR GetRecordings(CPVRRecordings* results, bool deleted);
+  PVR_ERROR GetRecordings(CPVRRecordings* results, bool deleted) const;
 
   /*!
    * @brief Delete a recording on the backend.
@@ -421,7 +422,7 @@ public:
    * @param iPosition The last watched position in seconds or -1 on error
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */
-  PVR_ERROR GetRecordingLastPlayedPosition(const CPVRRecording& recording, int& iPosition);
+  PVR_ERROR GetRecordingLastPlayedPosition(const CPVRRecording& recording, int& iPosition) const;
 
   /*!
    * @brief Retrieve the edit decision list (EDL) from the backend.
@@ -429,7 +430,7 @@ public:
    * @param edls The edit decision list (empty on error).
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */
-  PVR_ERROR GetRecordingEdl(const CPVRRecording& recording, std::vector<PVR_EDL_ENTRY>& edls);
+  PVR_ERROR GetRecordingEdl(const CPVRRecording& recording, std::vector<PVR_EDL_ENTRY>& edls) const;
 
   /*!
    * @brief Retrieve the size of a recording on the backend.
@@ -437,7 +438,7 @@ public:
    * @param sizeInBytes The size in bytes
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */
-  PVR_ERROR GetRecordingSize(const CPVRRecording& recording, int64_t& sizeInBytes);
+  PVR_ERROR GetRecordingSize(const CPVRRecording& recording, int64_t& sizeInBytes) const;
 
   /*!
    * @brief Retrieve the edit decision list (EDL) from the backend.
@@ -446,7 +447,7 @@ public:
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */
   PVR_ERROR GetEpgTagEdl(const std::shared_ptr<const CPVREpgInfoTag>& epgTag,
-                         std::vector<PVR_EDL_ENTRY>& edls);
+                         std::vector<PVR_EDL_ENTRY>& edls) const;
 
   //@}
   /** @name PVR timer methods */
@@ -457,14 +458,14 @@ public:
    * @param iTimers The total amount of timers on the backend or -1 on error.
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */
-  PVR_ERROR GetTimersAmount(int& iTimers);
+  PVR_ERROR GetTimersAmount(int& iTimers) const;
 
   /*!
    * @brief Request the list of all timers from the backend.
    * @param results The container to store the result in.
    * @return PVR_ERROR_NO_ERROR if the list has been fetched successfully.
    */
-  PVR_ERROR GetTimers(CPVRTimersContainer* results);
+  PVR_ERROR GetTimers(CPVRTimersContainer* results) const;
 
   /*!
    * @brief Add a timer on the backend.
@@ -540,7 +541,7 @@ public:
    * @param iLength The total length of the stream that's currently being read or -1 on error.
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */
-  PVR_ERROR GetLiveStreamLength(int64_t& iLength);
+  PVR_ERROR GetLiveStreamLength(int64_t& iLength) const;
 
   /*!
    * @brief (Un)Pause a stream.
@@ -555,7 +556,7 @@ public:
    * @param qualityinfo The signal quality.
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */
-  PVR_ERROR SignalQuality(int channelUid, PVR_SIGNAL_STATUS& qualityinfo);
+  PVR_ERROR SignalQuality(int channelUid, PVR_SIGNAL_STATUS& qualityinfo) const;
 
   /*!
    * @brief Get the descramble information of the stream that's currently open.
@@ -572,7 +573,7 @@ public:
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */
   PVR_ERROR GetChannelStreamProperties(const std::shared_ptr<const CPVRChannel>& channel,
-                                       CPVRStreamProperties& props);
+                                       CPVRStreamProperties& props) const;
 
   /*!
    * @brief Check whether PVR backend supports pausing the currently playing stream
@@ -654,7 +655,7 @@ public:
    * @param iLength The total length of the stream that's currently being read or -1 on error.
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */
-  PVR_ERROR GetRecordedStreamLength(int64_t& iLength);
+  PVR_ERROR GetRecordedStreamLength(int64_t& iLength) const;
 
   /*!
    * @brief Fill the given container with the properties required for playback of the given recording. Values are obtained from the PVR backend.
@@ -663,7 +664,7 @@ public:
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */
   PVR_ERROR GetRecordingStreamProperties(const std::shared_ptr<const CPVRRecording>& recording,
-                                         CPVRStreamProperties& props);
+                                         CPVRStreamProperties& props) const;
 
   //@}
   /** @name PVR demultiplexer methods */
@@ -708,13 +709,13 @@ public:
    * @param times The stream times.
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */
-  PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES* times);
+  PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES* times) const;
 
   /*!
    * @brief Get the client's menu hooks.
    * @return The hooks. Guaranteed never to be nullptr.
    */
-  std::shared_ptr<CPVRClientMenuHooks> GetMenuHooks();
+  std::shared_ptr<CPVRClientMenuHooks> GetMenuHooks() const;
 
   /*!
    * @brief Call one of the EPG tag menu hooks of the client.
@@ -787,7 +788,7 @@ public:
    * @param iChunkSize the chunk size in bytes.
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */
-  PVR_ERROR GetStreamReadChunkSize(int& iChunkSize);
+  PVR_ERROR GetStreamReadChunkSize(int& iChunkSize) const;
 
   /*!
    * @brief Get the interface table used between addon and Kodi.
@@ -1056,7 +1057,7 @@ private:
   std::string m_strConnectionString; /*!< the cached connection string */
   std::string m_strBackendHostname; /*!< the cached backend hostname */
   CPVRClientCapabilities m_clientCapabilities; /*!< the cached add-on's capabilities */
-  std::shared_ptr<CPVRClientMenuHooks> m_menuhooks; /*!< the menu hooks for this add-on */
+  mutable std::shared_ptr<CPVRClientMenuHooks> m_menuhooks; /*!< the menu hooks for this add-on */
 
   /* stored strings to make sure const char* members in AddonProperties_PVR stay valid */
   std::string m_strUserPath; /*!< @brief translated path to the user profile */

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -135,7 +135,7 @@ void CPVRClients::UpdateClients(
           // determine actual enabled state of instance
           if (instanceEnabled && instanceId != ADDON_SINGLETON_INSTANCE_ID)
           {
-            const std::shared_ptr<CPVRClient> client = GetClient(clientId);
+            const std::shared_ptr<const CPVRClient> client = GetClient(clientId);
             instanceEnabled = client ? client->IsEnabled() : false;
           }
 
@@ -431,7 +431,7 @@ int CPVRClients::EnabledClientAmount() const
 
 bool CPVRClients::IsEnabledClient(int clientId) const
 {
-  const std::shared_ptr<CPVRClient> client = GetClient(clientId);
+  const std::shared_ptr<const CPVRClient> client = GetClient(clientId);
   return client && !CServiceBroker::GetAddonMgr().IsAddonDisabled(client->ID());
 }
 

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -377,7 +377,7 @@ std::vector<CVariant> CPVRClients::GetClientProviderInfos() const
   return clientProviderInfos;
 }
 
-int CPVRClients::GetFirstCreatedClientID()
+int CPVRClients::GetFirstCreatedClientID() const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   const auto it = std::find_if(m_clientMap.cbegin(), m_clientMap.cend(),
@@ -555,48 +555,50 @@ std::vector<SBackend> CPVRClients::GetBackendProperties() const
 {
   std::vector<SBackend> backendProperties;
 
-  ForCreatedClients(__FUNCTION__, [&backendProperties](const std::shared_ptr<CPVRClient>& client) {
-    SBackend properties;
+  ForCreatedClients(
+      __FUNCTION__, [&backendProperties](const std::shared_ptr<const CPVRClient>& client) {
+        SBackend properties;
 
-    if (client->GetDriveSpace(properties.diskTotal, properties.diskUsed) == PVR_ERROR_NO_ERROR)
-    {
-      properties.diskTotal *= 1024;
-      properties.diskUsed *= 1024;
-    }
+        if (client->GetDriveSpace(properties.diskTotal, properties.diskUsed) == PVR_ERROR_NO_ERROR)
+        {
+          properties.diskTotal *= 1024;
+          properties.diskUsed *= 1024;
+        }
 
-    int iAmount = 0;
-    if (client->GetProvidersAmount(iAmount) == PVR_ERROR_NO_ERROR)
-      properties.numProviders = iAmount;
-    if (client->GetChannelGroupsAmount(iAmount) == PVR_ERROR_NO_ERROR)
-      properties.numChannelGroups = iAmount;
-    if (client->GetChannelsAmount(iAmount) == PVR_ERROR_NO_ERROR)
-      properties.numChannels = iAmount;
-    if (client->GetTimersAmount(iAmount) == PVR_ERROR_NO_ERROR)
-      properties.numTimers = iAmount;
-    if (client->GetRecordingsAmount(false, iAmount) == PVR_ERROR_NO_ERROR)
-      properties.numRecordings = iAmount;
-    if (client->GetRecordingsAmount(true, iAmount) == PVR_ERROR_NO_ERROR)
-      properties.numDeletedRecordings = iAmount;
-    properties.name = client->GetBackendName();
-    properties.version = client->GetBackendVersion();
-    properties.host = client->GetConnectionString();
+        int iAmount = 0;
+        if (client->GetProvidersAmount(iAmount) == PVR_ERROR_NO_ERROR)
+          properties.numProviders = iAmount;
+        if (client->GetChannelGroupsAmount(iAmount) == PVR_ERROR_NO_ERROR)
+          properties.numChannelGroups = iAmount;
+        if (client->GetChannelsAmount(iAmount) == PVR_ERROR_NO_ERROR)
+          properties.numChannels = iAmount;
+        if (client->GetTimersAmount(iAmount) == PVR_ERROR_NO_ERROR)
+          properties.numTimers = iAmount;
+        if (client->GetRecordingsAmount(false, iAmount) == PVR_ERROR_NO_ERROR)
+          properties.numRecordings = iAmount;
+        if (client->GetRecordingsAmount(true, iAmount) == PVR_ERROR_NO_ERROR)
+          properties.numDeletedRecordings = iAmount;
+        properties.name = client->GetBackendName();
+        properties.version = client->GetBackendVersion();
+        properties.host = client->GetConnectionString();
 
-    backendProperties.emplace_back(properties);
-    return PVR_ERROR_NO_ERROR;
-  });
+        backendProperties.emplace_back(properties);
+        return PVR_ERROR_NO_ERROR;
+      });
 
   return backendProperties;
 }
 
 bool CPVRClients::GetTimers(const std::vector<std::shared_ptr<CPVRClient>>& clients,
                             CPVRTimersContainer* timers,
-                            std::vector<int>& failedClients)
+                            std::vector<int>& failedClients) const
 {
-  return ForClients(__FUNCTION__, clients,
-                    [timers](const std::shared_ptr<CPVRClient>& client) {
-                      return client->GetTimers(timers);
-                    },
-                    failedClients) == PVR_ERROR_NO_ERROR;
+  return ForClients(
+             __FUNCTION__, clients,
+             [timers](const std::shared_ptr<const CPVRClient>& client) {
+               return client->GetTimers(timers);
+             },
+             failedClients) == PVR_ERROR_NO_ERROR;
 }
 
 PVR_ERROR CPVRClients::UpdateTimerTypes(const std::vector<std::shared_ptr<CPVRClient>>& clients,
@@ -629,13 +631,14 @@ const std::vector<std::shared_ptr<CPVRTimerType>> CPVRClients::GetTimerTypes() c
 PVR_ERROR CPVRClients::GetRecordings(const std::vector<std::shared_ptr<CPVRClient>>& clients,
                                      CPVRRecordings* recordings,
                                      bool deleted,
-                                     std::vector<int>& failedClients)
+                                     std::vector<int>& failedClients) const
 {
-  return ForClients(__FUNCTION__, clients,
-                    [recordings, deleted](const std::shared_ptr<CPVRClient>& client) {
-                      return client->GetRecordings(recordings, deleted);
-                    },
-                    failedClients);
+  return ForClients(
+      __FUNCTION__, clients,
+      [recordings, deleted](const std::shared_ptr<const CPVRClient>& client) {
+        return client->GetRecordings(recordings, deleted);
+      },
+      failedClients);
 }
 
 PVR_ERROR CPVRClients::DeleteAllRecordingsFromTrash()
@@ -662,48 +665,52 @@ PVR_ERROR CPVRClients::SetEPGMaxFutureDays(int iFutureDays)
 PVR_ERROR CPVRClients::GetChannels(const std::vector<std::shared_ptr<CPVRClient>>& clients,
                                    bool bRadio,
                                    std::vector<std::shared_ptr<CPVRChannel>>& channels,
-                                   std::vector<int>& failedClients)
+                                   std::vector<int>& failedClients) const
 {
-  return ForClients(__FUNCTION__, clients,
-                    [bRadio, &channels](const std::shared_ptr<CPVRClient>& client) {
-                      return client->GetChannels(bRadio, channels);
-                    },
-                    failedClients);
+  return ForClients(
+      __FUNCTION__, clients,
+      [bRadio, &channels](const std::shared_ptr<const CPVRClient>& client) {
+        return client->GetChannels(bRadio, channels);
+      },
+      failedClients);
 }
 
 PVR_ERROR CPVRClients::GetProviders(const std::vector<std::shared_ptr<CPVRClient>>& clients,
                                     CPVRProvidersContainer* providers,
-                                    std::vector<int>& failedClients)
+                                    std::vector<int>& failedClients) const
 {
-  return ForClients(__FUNCTION__, clients,
-                    [providers](const std::shared_ptr<CPVRClient>& client) {
-                      return client->GetProviders(*providers);
-                    },
-                    failedClients);
+  return ForClients(
+      __FUNCTION__, clients,
+      [providers](const std::shared_ptr<const CPVRClient>& client) {
+        return client->GetProviders(*providers);
+      },
+      failedClients);
 }
 
 PVR_ERROR CPVRClients::GetChannelGroups(const std::vector<std::shared_ptr<CPVRClient>>& clients,
                                         CPVRChannelGroups* groups,
-                                        std::vector<int>& failedClients)
+                                        std::vector<int>& failedClients) const
 {
-  return ForClients(__FUNCTION__, clients,
-                    [groups](const std::shared_ptr<CPVRClient>& client) {
-                      return client->GetChannelGroups(groups);
-                    },
-                    failedClients);
+  return ForClients(
+      __FUNCTION__, clients,
+      [groups](const std::shared_ptr<const CPVRClient>& client) {
+        return client->GetChannelGroups(groups);
+      },
+      failedClients);
 }
 
 PVR_ERROR CPVRClients::GetChannelGroupMembers(
     const std::vector<std::shared_ptr<CPVRClient>>& clients,
     CPVRChannelGroup* group,
     std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers,
-    std::vector<int>& failedClients)
+    std::vector<int>& failedClients) const
 {
-  return ForClients(__FUNCTION__, clients,
-                    [group, &groupMembers](const std::shared_ptr<CPVRClient>& client) {
-                      return client->GetChannelGroupMembers(group, groupMembers);
-                    },
-                    failedClients);
+  return ForClients(
+      __FUNCTION__, clients,
+      [group, &groupMembers](const std::shared_ptr<const CPVRClient>& client) {
+        return client->GetChannelGroupMembers(group, groupMembers);
+      },
+      failedClients);
 }
 
 std::vector<std::shared_ptr<CPVRClient>> CPVRClients::GetClientsSupportingChannelScan() const

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -886,7 +886,7 @@ void CPVRClients::ConnectionStateChange(CPVRClient* client,
 namespace
 {
 
-void LogClientWarning(const char* strFunctionName, const std::shared_ptr<CPVRClient>& client)
+void LogClientWarning(const char* strFunctionName, const std::shared_ptr<const CPVRClient>& client)
 {
   if (client->IgnoreClient())
     CLog::Log(LOGWARNING, "{}: Not calling add-on '{}'. Add-on not (yet) connected.",

--- a/xbmc/pvr/addons/PVRClients.h
+++ b/xbmc/pvr/addons/PVRClients.h
@@ -150,7 +150,7 @@ struct SBackend
      * @brief Get the ID of the first created client.
      * @return the ID or -1 if no clients are created;
      */
-    int GetFirstCreatedClientID();
+    int GetFirstCreatedClientID() const;
 
     /*!
      * @brief Check whether there are any created, but not (yet) connected clients.
@@ -208,7 +208,7 @@ struct SBackend
      */
     bool GetTimers(const std::vector<std::shared_ptr<CPVRClient>>& clients,
                    CPVRTimersContainer* timers,
-                   std::vector<int>& failedClients);
+                   std::vector<int>& failedClients) const;
 
     /*!
      * @brief Update all timer types from the given clients
@@ -241,7 +241,7 @@ struct SBackend
     PVR_ERROR GetRecordings(const std::vector<std::shared_ptr<CPVRClient>>& clients,
                             CPVRRecordings* recordings,
                             bool deleted,
-                            std::vector<int>& failedClients);
+                            std::vector<int>& failedClients) const;
 
     /*!
      * @brief Delete all "soft" deleted recordings permanently on the backend.
@@ -300,7 +300,7 @@ struct SBackend
     PVR_ERROR GetChannels(const std::vector<std::shared_ptr<CPVRClient>>& clients,
                           bool bRadio,
                           std::vector<std::shared_ptr<CPVRChannel>>& channels,
-                          std::vector<int>& failedClients);
+                          std::vector<int>& failedClients) const;
 
     /*!
      * @brief Get all providers from backends.
@@ -311,7 +311,7 @@ struct SBackend
      */
     PVR_ERROR GetProviders(const std::vector<std::shared_ptr<CPVRClient>>& clients,
                            CPVRProvidersContainer* providers,
-                           std::vector<int>& failedClients);
+                           std::vector<int>& failedClients) const;
 
     /*!
      * @brief Get all channel groups from the given clients.
@@ -322,7 +322,7 @@ struct SBackend
      */
     PVR_ERROR GetChannelGroups(const std::vector<std::shared_ptr<CPVRClient>>& clients,
                                CPVRChannelGroups* groups,
-                               std::vector<int>& failedClients);
+                               std::vector<int>& failedClients) const;
 
     /*!
      * @brief Get all group members of a channel group from the given clients.
@@ -336,7 +336,7 @@ struct SBackend
         const std::vector<std::shared_ptr<CPVRClient>>& clients,
         CPVRChannelGroup* group,
         std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers,
-        std::vector<int>& failedClients);
+        std::vector<int>& failedClients) const;
 
     /*!
      * @brief Get a list of clients providing a channel scan dialog.

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -205,7 +205,7 @@ void CPVRChannel::ResetEPG()
     epgToUnsubscribe->Events().Unsubscribe(this);
 }
 
-bool CPVRChannel::UpdateFromClient(const std::shared_ptr<CPVRChannel>& channel)
+bool CPVRChannel::UpdateFromClient(const std::shared_ptr<const CPVRChannel>& channel)
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
 

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -136,7 +136,7 @@ bool CPVRChannel::QueueDelete()
   if (!database)
     return bReturn;
 
-  const std::shared_ptr<CPVREpg> epg = GetEPG();
+  const std::shared_ptr<const CPVREpg> epg = GetEPG();
   if (epg)
     ResetEPG();
 
@@ -262,7 +262,7 @@ bool CPVRChannel::SetChannelID(int iChannelId)
   {
     m_iChannelId = iChannelId;
 
-    const std::shared_ptr<CPVREpg> epg = GetEPG();
+    const std::shared_ptr<const CPVREpg> epg = GetEPG();
     if (epg)
       epg->GetChannelData()->SetChannelId(m_iChannelId);
 
@@ -300,7 +300,7 @@ bool CPVRChannel::SetLocked(bool bIsLocked)
   {
     m_bIsLocked = bIsLocked;
 
-    const std::shared_ptr<CPVREpg> epg = GetEPG();
+    const std::shared_ptr<const CPVREpg> epg = GetEPG();
     if (epg)
       epg->GetChannelData()->SetLocked(m_bIsLocked);
 
@@ -357,7 +357,7 @@ bool CPVRChannel::SetIconPath(const std::string& strIconPath, bool bIsUserSetIco
 
   m_iconPath.SetClientImage(strIconPath);
 
-  const std::shared_ptr<CPVREpg> epg = GetEPG();
+  const std::shared_ptr<const CPVREpg> epg = GetEPG();
   if (epg)
     epg->GetChannelData()->SetChannelIconPath(strIconPath);
 
@@ -380,7 +380,7 @@ bool CPVRChannel::SetChannelName(const std::string& strChannelName, bool bIsUser
     m_strChannelName = strName;
     m_bIsUserSetName = bIsUserSetName;
 
-    const std::shared_ptr<CPVREpg> epg = GetEPG();
+    const std::shared_ptr<const CPVREpg> epg = GetEPG();
     if (epg)
       epg->GetChannelData()->SetChannelName(m_strChannelName);
 
@@ -535,7 +535,7 @@ bool CPVRChannel::SetClientProviderUid(int iClientProviderUid)
 
 std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVRChannel::GetEpgTags() const
 {
-  const std::shared_ptr<CPVREpg> epg = GetEPG();
+  const std::shared_ptr<const CPVREpg> epg = GetEPG();
   if (!epg)
   {
     CLog::LogFC(LOGDEBUG, LOGPVR, "Cannot get EPG for channel '{}'", m_strChannelName);
@@ -551,7 +551,7 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVRChannel::GetEPGTimeline(
     const CDateTime& minEventEnd,
     const CDateTime& maxEventStart) const
 {
-  const std::shared_ptr<CPVREpg> epg = GetEPG();
+  const std::shared_ptr<const CPVREpg> epg = GetEPG();
   if (epg)
   {
     return epg->GetTimeline(timelineStart, timelineEnd, minEventEnd, maxEventStart);
@@ -567,7 +567,7 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVRChannel::GetEPGTimeline(
 std::shared_ptr<CPVREpgInfoTag> CPVRChannel::CreateEPGGapTag(const CDateTime& start,
                                                              const CDateTime& end) const
 {
-  const std::shared_ptr<CPVREpg> epg = GetEPG();
+  const std::shared_ptr<const CPVREpg> epg = GetEPG();
   if (epg)
     return std::make_shared<CPVREpgInfoTag>(epg->GetChannelData(), epg->EpgID(), start, end, true);
   else
@@ -578,7 +578,7 @@ std::shared_ptr<CPVREpgInfoTag> CPVRChannel::CreateEPGGapTag(const CDateTime& st
 std::shared_ptr<CPVREpgInfoTag> CPVRChannel::GetEPGNow() const
 {
   std::shared_ptr<CPVREpgInfoTag> tag;
-  const std::shared_ptr<CPVREpg> epg = GetEPG();
+  const std::shared_ptr<const CPVREpg> epg = GetEPG();
   if (epg)
     tag = epg->GetTagNow();
 
@@ -588,7 +588,7 @@ std::shared_ptr<CPVREpgInfoTag> CPVRChannel::GetEPGNow() const
 std::shared_ptr<CPVREpgInfoTag> CPVRChannel::GetEPGNext() const
 {
   std::shared_ptr<CPVREpgInfoTag> tag;
-  const std::shared_ptr<CPVREpg> epg = GetEPG();
+  const std::shared_ptr<const CPVREpg> epg = GetEPG();
   if (epg)
     tag = epg->GetTagNext();
 
@@ -598,7 +598,7 @@ std::shared_ptr<CPVREpgInfoTag> CPVRChannel::GetEPGNext() const
 std::shared_ptr<CPVREpgInfoTag> CPVRChannel::GetEPGPrevious() const
 {
   std::shared_ptr<CPVREpgInfoTag> tag;
-  const std::shared_ptr<CPVREpg> epg = GetEPG();
+  const std::shared_ptr<const CPVREpg> epg = GetEPG();
   if (epg)
     tag = epg->GetTagPrevious();
 
@@ -816,7 +816,8 @@ std::string CPVRChannel::EPGScraper() const
 
 bool CPVRChannel::CanRecord() const
 {
-  const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_iClientId);
+  const std::shared_ptr<const CPVRClient> client =
+      CServiceBroker::GetPVRManager().GetClient(m_iClientId);
   return client && client->GetClientCapabilities().SupportsRecordings() &&
          client->GetClientCapabilities().SupportsTimers();
 }

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -71,7 +71,7 @@ public:
    * @param channel The new channel data.
    * @return True if something changed, false otherwise.
    */
-  bool UpdateFromClient(const std::shared_ptr<CPVRChannel>& channel);
+  bool UpdateFromClient(const std::shared_ptr<const CPVRChannel>& channel);
 
   /*!
    * @brief Persists the changes in the database.

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -38,7 +38,7 @@
 using namespace PVR;
 
 CPVRChannelGroup::CPVRChannelGroup(const CPVRChannelsPath& path,
-                                   const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup)
+                                   const std::shared_ptr<const CPVRChannelGroup>& allChannelsGroup)
   : m_allChannelsGroup(allChannelsGroup), m_path(path)
 {
   GetSettings()->RegisterCallback(this);
@@ -182,8 +182,8 @@ void CPVRChannelGroup::SetPath(const CPVRChannelsPath& path)
 
 struct sortByClientChannelNumber
 {
-  bool operator()(const std::shared_ptr<CPVRChannelGroupMember>& channel1,
-                  const std::shared_ptr<CPVRChannelGroupMember>& channel2) const
+  bool operator()(const std::shared_ptr<const CPVRChannelGroupMember>& channel1,
+                  const std::shared_ptr<const CPVRChannelGroupMember>& channel2) const
   {
     if (channel1->ClientPriority() == channel2->ClientPriority())
     {
@@ -198,8 +198,8 @@ struct sortByClientChannelNumber
 
 struct sortByChannelNumber
 {
-  bool operator()(const std::shared_ptr<CPVRChannelGroupMember>& channel1,
-                  const std::shared_ptr<CPVRChannelGroupMember>& channel2) const
+  bool operator()(const std::shared_ptr<const CPVRChannelGroupMember>& channel1,
+                  const std::shared_ptr<const CPVRChannelGroupMember>& channel2) const
   {
     return channel1->ChannelNumber() < channel2->ChannelNumber();
   }
@@ -353,7 +353,7 @@ GroupMemberPair CPVRChannelGroup::GetLastAndPreviousToLastPlayedChannelGroupMemb
 }
 
 CPVRChannelNumber CPVRChannelGroup::GetChannelNumber(
-    const std::shared_ptr<CPVRChannel>& channel) const
+    const std::shared_ptr<const CPVRChannel>& channel) const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   const std::shared_ptr<CPVRChannelGroupMember> member = GetByUniqueID(channel->StorageId());
@@ -361,7 +361,7 @@ CPVRChannelNumber CPVRChannelGroup::GetChannelNumber(
 }
 
 CPVRChannelNumber CPVRChannelGroup::GetClientChannelNumber(
-    const std::shared_ptr<CPVRChannel>& channel) const
+    const std::shared_ptr<const CPVRChannel>& channel) const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   const std::shared_ptr<CPVRChannelGroupMember> member = GetByUniqueID(channel->StorageId());
@@ -385,7 +385,7 @@ std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroup::GetByChannelNumber(
 }
 
 std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroup::GetNextChannelGroupMember(
-    const std::shared_ptr<CPVRChannelGroupMember>& groupMember) const
+    const std::shared_ptr<const CPVRChannelGroupMember>& groupMember) const
 {
   std::shared_ptr<CPVRChannelGroupMember> nextMember;
 
@@ -413,7 +413,7 @@ std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroup::GetNextChannelGroupMem
 }
 
 std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroup::GetPreviousChannelGroupMember(
-    const std::shared_ptr<CPVRChannelGroupMember>& groupMember) const
+    const std::shared_ptr<const CPVRChannelGroupMember>& groupMember) const
 {
   std::shared_ptr<CPVRChannelGroupMember> previousMember;
 
@@ -641,10 +641,11 @@ bool CPVRChannelGroup::HasValidDataForClient(int iClientId) const
 bool CPVRChannelGroup::HasValidDataForClients(
     const std::vector<std::shared_ptr<CPVRClient>>& clients) const
 {
-  return m_failedClients.empty() || std::none_of(clients.cbegin(), clients.cend(),
-                                                 [this](const std::shared_ptr<CPVRClient>& client) {
-                                                   return !HasValidDataForClient(client->GetID());
-                                                 });
+  return m_failedClients.empty() ||
+         std::none_of(clients.cbegin(), clients.cend(),
+                      [this](const std::shared_ptr<const CPVRClient>& client) {
+                        return !HasValidDataForClient(client->GetID());
+                      });
 }
 
 bool CPVRChannelGroup::UpdateChannelNumbersFromAllChannelsGroup()
@@ -756,7 +757,8 @@ bool CPVRChannelGroup::UpdateGroupEntries(
   return bReturn;
 }
 
-bool CPVRChannelGroup::RemoveFromGroup(const std::shared_ptr<CPVRChannelGroupMember>& groupMember)
+bool CPVRChannelGroup::RemoveFromGroup(
+    const std::shared_ptr<const CPVRChannelGroupMember>& groupMember)
 {
   bool bReturn = false;
   const auto channel = groupMember->Channel();
@@ -782,7 +784,8 @@ bool CPVRChannelGroup::RemoveFromGroup(const std::shared_ptr<CPVRChannelGroupMem
   return bReturn;
 }
 
-bool CPVRChannelGroup::AppendToGroup(const std::shared_ptr<CPVRChannelGroupMember>& groupMember)
+bool CPVRChannelGroup::AppendToGroup(
+    const std::shared_ptr<const CPVRChannelGroupMember>& groupMember)
 {
   bool bReturn = false;
 
@@ -814,7 +817,7 @@ bool CPVRChannelGroup::AppendToGroup(const std::shared_ptr<CPVRChannelGroupMembe
 }
 
 bool CPVRChannelGroup::IsGroupMember(
-    const std::shared_ptr<CPVRChannelGroupMember>& groupMember) const
+    const std::shared_ptr<const CPVRChannelGroupMember>& groupMember) const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_members.find(groupMember->Channel()->StorageId()) != m_members.end();

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -247,7 +247,7 @@ void CPVRChannelGroup::UpdateClientPriorities()
 
 bool CPVRChannelGroup::UpdateMembersClientPriority()
 {
-  const std::shared_ptr<CPVRClients> clients = CServiceBroker::GetPVRManager().Clients();
+  const std::shared_ptr<const CPVRClients> clients = CServiceBroker::GetPVRManager().Clients();
   bool bChanged = false;
 
   std::unique_lock<CCriticalSection> lock(m_critSection);
@@ -259,7 +259,7 @@ bool CPVRChannelGroup::UpdateMembersClientPriority()
 
     if (bUseBackendChannelOrder)
     {
-      const std::shared_ptr<CPVRClient> client =
+      const std::shared_ptr<const CPVRClient> client =
           clients->GetCreatedClient(member->Channel()->ClientID());
       if (!client)
         continue;
@@ -291,7 +291,7 @@ std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroup::GetByUniqueID(
 std::shared_ptr<CPVRChannel> CPVRChannelGroup::GetByUniqueID(int iUniqueChannelId,
                                                              int iClientID) const
 {
-  const std::shared_ptr<CPVRChannelGroupMember> groupMember =
+  const std::shared_ptr<const CPVRChannelGroupMember> groupMember =
       GetByUniqueID(std::make_pair(iClientID, iUniqueChannelId));
   return groupMember ? groupMember->Channel() : std::shared_ptr<CPVRChannel>();
 }
@@ -314,7 +314,7 @@ std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroup::GetLastPlayedChannelGr
   std::shared_ptr<CPVRChannelGroupMember> groupMember;
   for (const auto& memberPair : m_members)
   {
-    const std::shared_ptr<CPVRChannel> channel = memberPair.second->Channel();
+    const std::shared_ptr<const CPVRChannel> channel = memberPair.second->Channel();
     if (channel->ChannelID() != iCurrentChannel &&
         CServiceBroker::GetPVRManager().Clients()->IsCreatedClient(channel->ClientID()) &&
         channel->LastWatched() > 0 &&
@@ -356,7 +356,7 @@ CPVRChannelNumber CPVRChannelGroup::GetChannelNumber(
     const std::shared_ptr<const CPVRChannel>& channel) const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
-  const std::shared_ptr<CPVRChannelGroupMember> member = GetByUniqueID(channel->StorageId());
+  const std::shared_ptr<const CPVRChannelGroupMember> member = GetByUniqueID(channel->StorageId());
   return member ? member->ChannelNumber() : CPVRChannelNumber();
 }
 
@@ -364,7 +364,7 @@ CPVRChannelNumber CPVRChannelGroup::GetClientChannelNumber(
     const std::shared_ptr<const CPVRChannel>& channel) const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
-  const std::shared_ptr<CPVRChannelGroupMember> member = GetByUniqueID(channel->StorageId());
+  const std::shared_ptr<const CPVRChannelGroupMember> member = GetByUniqueID(channel->StorageId());
   return member ? member->ClientChannelNumber() : CPVRChannelNumber();
 }
 
@@ -484,7 +484,8 @@ void CPVRChannelGroup::GetChannelNumbers(std::vector<std::string>& channelNumber
 
 int CPVRChannelGroup::LoadFromDatabase(const std::vector<std::shared_ptr<CPVRClient>>& clients)
 {
-  const std::shared_ptr<CPVRDatabase> database(CServiceBroker::GetPVRManager().GetTVDatabase());
+  const std::shared_ptr<const CPVRDatabase> database(
+      CServiceBroker::GetPVRManager().GetTVDatabase());
   if (!database)
     return -1;
 
@@ -494,7 +495,7 @@ int CPVRChannelGroup::LoadFromDatabase(const std::vector<std::shared_ptr<CPVRCli
   std::vector<std::shared_ptr<CPVRChannelGroupMember>> membersToDelete;
   if (!results.empty())
   {
-    const std::shared_ptr<CPVRClients> allClients = CServiceBroker::GetPVRManager().Clients();
+    const std::shared_ptr<const CPVRClients> allClients = CServiceBroker::GetPVRManager().Clients();
 
     std::unique_lock<CCriticalSection> lock(m_critSection);
     for (const auto& member : results)
@@ -686,7 +687,7 @@ std::vector<std::shared_ptr<CPVRChannelGroupMember>> CPVRChannelGroup::RemoveDel
   // check for deleted/invalid channels
   for (auto it = m_sortedMembers.begin(); it != m_sortedMembers.end();)
   {
-    const std::shared_ptr<CPVRChannel> channel = (*it)->Channel();
+    const std::shared_ptr<const CPVRChannel> channel = (*it)->Channel();
 
     if (GetClientID() >= 0 && GetClientID() != channel->ClientID())
     {

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -63,7 +63,7 @@ public:
    * @param allChannelsGroup The channel group containing all TV or radio channels.
    */
   CPVRChannelGroup(const CPVRChannelsPath& path,
-                   const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup);
+                   const std::shared_ptr<const CPVRChannelGroup>& allChannelsGroup);
 
   ~CPVRChannelGroup() override;
 
@@ -136,21 +136,22 @@ public:
    * @param groupMember The channel group member to remove.
    * @return True if the channel group member was removed, false otherwise.
    */
-  virtual bool RemoveFromGroup(const std::shared_ptr<CPVRChannelGroupMember>& groupMember);
+  virtual bool RemoveFromGroup(const std::shared_ptr<const CPVRChannelGroupMember>& groupMember);
 
   /*!
    * @brief Append a channel group member to this container.
    * @param groupMember The channel group member to append.
    * @return True if the channel group member was appended, false otherwise.
    */
-  virtual bool AppendToGroup(const std::shared_ptr<CPVRChannelGroupMember>& groupMember);
+  virtual bool AppendToGroup(const std::shared_ptr<const CPVRChannelGroupMember>& groupMember);
 
   /*!
    * @brief Check whether a channel group member is in this container.
    * @param groupMember The channel group member to check.
    * @return True if the channel group member was found, false otherwise.
    */
-  virtual bool IsGroupMember(const std::shared_ptr<CPVRChannelGroupMember>& groupMember) const;
+  virtual bool IsGroupMember(
+      const std::shared_ptr<const CPVRChannelGroupMember>& groupMember) const;
 
   /*!
    * @brief Change the name of this group.
@@ -285,14 +286,14 @@ public:
    * @param channel The channel to get the channel number for.
    * @return The channel number in this group.
    */
-  CPVRChannelNumber GetChannelNumber(const std::shared_ptr<CPVRChannel>& channel) const;
+  CPVRChannelNumber GetChannelNumber(const std::shared_ptr<const CPVRChannel>& channel) const;
 
   /*!
    * @brief Get the client channel number in this group of the given channel.
    * @param channel The channel to get the channel number for.
    * @return The client channel number in this group.
    */
-  CPVRChannelNumber GetClientChannelNumber(const std::shared_ptr<CPVRChannel>& channel) const;
+  CPVRChannelNumber GetClientChannelNumber(const std::shared_ptr<const CPVRChannel>& channel) const;
 
   /*!
    * @brief Get the next channel group member in this group.
@@ -300,7 +301,7 @@ public:
    * @return The channel group member or nullptr if it wasn't found.
    */
   std::shared_ptr<CPVRChannelGroupMember> GetNextChannelGroupMember(
-      const std::shared_ptr<CPVRChannelGroupMember>& groupMember) const;
+      const std::shared_ptr<const CPVRChannelGroupMember>& groupMember) const;
 
   /*!
    * @brief Get the previous channel group member in this group.
@@ -308,7 +309,7 @@ public:
    * @return The channel group member or nullptr if it wasn't found.
    */
   std::shared_ptr<CPVRChannelGroupMember> GetPreviousChannelGroupMember(
-      const std::shared_ptr<CPVRChannelGroupMember>& groupMember) const;
+      const std::shared_ptr<const CPVRChannelGroupMember>& groupMember) const;
 
   /*!
    * @brief Get a channel given it's channel ID.
@@ -573,7 +574,7 @@ private:
 
   void OnSettingChanged();
 
-  std::shared_ptr<CPVRChannelGroup> m_allChannelsGroup;
+  std::shared_ptr<const CPVRChannelGroup> m_allChannelsGroup;
   CPVRChannelsPath m_path;
   bool m_bDeleted = false;
   mutable std::optional<int> m_clientPriority;

--- a/xbmc/pvr/channels/PVRChannelGroupAllChannels.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupAllChannels.cpp
@@ -130,7 +130,7 @@ std::vector<std::shared_ptr<CPVRChannelGroupMember>> CPVRChannelGroupAllChannels
 }
 
 bool CPVRChannelGroupAllChannels::AppendToGroup(
-    const std::shared_ptr<CPVRChannelGroupMember>& groupMember)
+    const std::shared_ptr<const CPVRChannelGroupMember>& groupMember)
 {
   if (IsGroupMember(groupMember))
     return false;
@@ -142,7 +142,7 @@ bool CPVRChannelGroupAllChannels::AppendToGroup(
 }
 
 bool CPVRChannelGroupAllChannels::RemoveFromGroup(
-    const std::shared_ptr<CPVRChannelGroupMember>& groupMember)
+    const std::shared_ptr<const CPVRChannelGroupMember>& groupMember)
 {
   if (!IsGroupMember(groupMember))
     return false;
@@ -154,7 +154,7 @@ bool CPVRChannelGroupAllChannels::RemoveFromGroup(
 }
 
 bool CPVRChannelGroupAllChannels::IsGroupMember(
-    const std::shared_ptr<CPVRChannelGroupMember>& groupMember) const
+    const std::shared_ptr<const CPVRChannelGroupMember>& groupMember) const
 {
   return !groupMember->Channel()->IsHidden();
 }

--- a/xbmc/pvr/channels/PVRChannelGroupAllChannels.h
+++ b/xbmc/pvr/channels/PVRChannelGroupAllChannels.h
@@ -40,17 +40,18 @@ public:
   /*!
    * @see CPVRChannelGroup::IsGroupMember
    */
-  bool IsGroupMember(const std::shared_ptr<CPVRChannelGroupMember>& groupMember) const override;
+  bool IsGroupMember(
+      const std::shared_ptr<const CPVRChannelGroupMember>& groupMember) const override;
 
   /*!
    * @see CPVRChannelGroup::AppendToGroup
    */
-  bool AppendToGroup(const std::shared_ptr<CPVRChannelGroupMember>& groupMember) override;
+  bool AppendToGroup(const std::shared_ptr<const CPVRChannelGroupMember>& groupMember) override;
 
   /*!
    * @see CPVRChannelGroup::RemoveFromGroup
    */
-  bool RemoveFromGroup(const std::shared_ptr<CPVRChannelGroupMember>& groupMember) override;
+  bool RemoveFromGroup(const std::shared_ptr<const CPVRChannelGroupMember>& groupMember) override;
 
   /*!
    * @brief Check whether the group name is still correct after the language setting changed.

--- a/xbmc/pvr/channels/PVRChannelGroupFromClient.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupFromClient.cpp
@@ -16,7 +16,7 @@
 using namespace PVR;
 
 CPVRChannelGroupFromClient::CPVRChannelGroupFromClient(
-    const CPVRChannelsPath& path, const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup)
+    const CPVRChannelsPath& path, const std::shared_ptr<const CPVRChannelGroup>& allChannelsGroup)
   : CPVRChannelGroup(path, allChannelsGroup)
 {
 }
@@ -24,7 +24,7 @@ CPVRChannelGroupFromClient::CPVRChannelGroupFromClient(
 CPVRChannelGroupFromClient::CPVRChannelGroupFromClient(
     const PVR_CHANNEL_GROUP& group,
     int clientID,
-    const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup)
+    const std::shared_ptr<const CPVRChannelGroup>& allChannelsGroup)
   : CPVRChannelGroup(CPVRChannelsPath(group.bIsRadio, group.strGroupName, clientID),
                      allChannelsGroup)
 {

--- a/xbmc/pvr/channels/PVRChannelGroupFromClient.h
+++ b/xbmc/pvr/channels/PVRChannelGroupFromClient.h
@@ -22,7 +22,7 @@ public:
    * @param allChannelsGroup The channel group containing all TV or radio channels.
    */
   CPVRChannelGroupFromClient(const CPVRChannelsPath& path,
-                             const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup);
+                             const std::shared_ptr<const CPVRChannelGroup>& allChannelsGroup);
 
   /*!
    * @brief Create a new channel group instance from a channel group provided by a PVR client.
@@ -32,7 +32,7 @@ public:
    */
   CPVRChannelGroupFromClient(const PVR_CHANNEL_GROUP& group,
                              int clientID,
-                             const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup);
+                             const std::shared_ptr<const CPVRChannelGroup>& allChannelsGroup);
 
   /*!
    * @brief Check whether this group could be deleted by the user.

--- a/xbmc/pvr/channels/PVRChannelGroupFromUser.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupFromUser.cpp
@@ -11,7 +11,7 @@
 using namespace PVR;
 
 CPVRChannelGroupFromUser::CPVRChannelGroupFromUser(
-    const CPVRChannelsPath& path, const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup)
+    const CPVRChannelsPath& path, const std::shared_ptr<const CPVRChannelGroup>& allChannelsGroup)
   : CPVRChannelGroup(path, allChannelsGroup)
 {
 }

--- a/xbmc/pvr/channels/PVRChannelGroupFromUser.h
+++ b/xbmc/pvr/channels/PVRChannelGroupFromUser.h
@@ -22,7 +22,7 @@ public:
    * @param allChannelsGroup The channel group containing all TV or radio channels.
    */
   CPVRChannelGroupFromUser(const CPVRChannelsPath& path,
-                           const std::shared_ptr<CPVRChannelGroup>& allChannelsGroup);
+                           const std::shared_ptr<const CPVRChannelGroup>& allChannelsGroup);
 
   /*!
    * @brief Check whether this group could be deleted by the user.

--- a/xbmc/pvr/channels/PVRChannelGroupMember.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupMember.cpp
@@ -88,7 +88,7 @@ void CPVRChannelGroupMember::SetGroupID(int iGroupID)
 
 void CPVRChannelGroupMember::SetGroupName(const std::string& groupName)
 {
-  const std::shared_ptr<CPVRClient> client =
+  const std::shared_ptr<const CPVRClient> client =
       CServiceBroker::GetPVRManager().GetClient(m_iChannelClientID);
   if (client)
     m_path = CPVRChannelsPath(m_bIsRadio, groupName, m_iGroupClientID, client->ID(),

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -239,7 +239,7 @@ std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroups::GetChannelGroupMember
 {
   if (path.IsChannel())
   {
-    const std::shared_ptr<CPVRChannelGroup> group =
+    const std::shared_ptr<const CPVRChannelGroup> group =
         GetByName(path.GetGroupName(), path.GetGroupClientID());
     if (group)
       return group->GetByUniqueID(
@@ -389,7 +389,8 @@ std::shared_ptr<CPVRChannelGroup> CPVRChannelGroups::CreateChannelGroup(
 
 bool CPVRChannelGroups::LoadFromDatabase(const std::vector<std::shared_ptr<CPVRClient>>& clients)
 {
-  const std::shared_ptr<CPVRDatabase> database(CServiceBroker::GetPVRManager().GetTVDatabase());
+  const std::shared_ptr<const CPVRDatabase> database(
+      CServiceBroker::GetPVRManager().GetTVDatabase());
   if (!database)
     return false;
 

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -165,7 +165,8 @@ bool CPVRChannelGroups::Update(const std::shared_ptr<CPVRChannelGroup>& group,
   return true;
 }
 
-int CPVRChannelGroups::GetGroupTypePriority(const std::shared_ptr<CPVRChannelGroup>& group) const
+int CPVRChannelGroups::GetGroupTypePriority(
+    const std::shared_ptr<const CPVRChannelGroup>& group) const
 {
   switch (group->GroupType())
   {
@@ -180,7 +181,8 @@ int CPVRChannelGroups::GetGroupTypePriority(const std::shared_ptr<CPVRChannelGro
   }
 }
 
-int CPVRChannelGroups::GetGroupClientPriority(const std::shared_ptr<CPVRChannelGroup>& group) const
+int CPVRChannelGroups::GetGroupClientPriority(
+    const std::shared_ptr<const CPVRChannelGroup>& group) const
 {
   // if no priority was set by the user, use the client id to distinguish between the clients
   const int priority = group->GetClientPriority();
@@ -248,7 +250,7 @@ std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroups::GetChannelGroupMember
 }
 
 std::vector<std::shared_ptr<CPVRChannelGroupMember>> CPVRChannelGroups::GetMembersAvailableForGroup(
-    const std::shared_ptr<CPVRChannelGroup>& group)
+    const std::shared_ptr<const CPVRChannelGroup>& group)
 {
   std::vector<std::shared_ptr<CPVRChannelGroupMember>> result;
 
@@ -307,7 +309,7 @@ bool CPVRChannelGroups::HasValidDataForClients(
 {
   return m_failedClientsForChannelGroups.empty() ||
          std::none_of(clients.cbegin(), clients.cend(),
-                      [this](const std::shared_ptr<CPVRClient>& client) {
+                      [this](const std::shared_ptr<const CPVRClient>& client) {
                         return std::find(m_failedClientsForChannelGroups.cbegin(),
                                          m_failedClientsForChannelGroups.cend(),
                                          client->GetID()) != m_failedClientsForChannelGroups.cend();

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -98,7 +98,7 @@ public:
    * @return The channel group members that could be added to the group
    */
   std::vector<std::shared_ptr<CPVRChannelGroupMember>> GetMembersAvailableForGroup(
-      const std::shared_ptr<CPVRChannelGroup>& group);
+      const std::shared_ptr<const CPVRChannelGroup>& group);
 
   /*!
    * @brief Get a pointer to a channel group given its ID.
@@ -243,8 +243,8 @@ private:
 
   void OnPVRManagerEvent(const PVR::PVREvent& event);
 
-  int GetGroupTypePriority(const std::shared_ptr<CPVRChannelGroup>& group) const;
-  int GetGroupClientPriority(const std::shared_ptr<CPVRChannelGroup>& group) const;
+  int GetGroupTypePriority(const std::shared_ptr<const CPVRChannelGroup>& group) const;
+  int GetGroupClientPriority(const std::shared_ptr<const CPVRChannelGroup>& group) const;
 
   bool m_bRadio{false};
   std::vector<std::shared_ptr<CPVRChannelGroup>> m_groups;

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
@@ -97,7 +97,8 @@ std::shared_ptr<CPVRChannel> CPVRChannelGroupsContainer::GetChannelById(int iCha
   return channel;
 }
 
-std::shared_ptr<CPVRChannel> CPVRChannelGroupsContainer::GetChannelForEpgTag(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
+std::shared_ptr<CPVRChannel> CPVRChannelGroupsContainer::GetChannelForEpgTag(
+    const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const
 {
   if (!epgTag)
     return {};

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
@@ -118,7 +118,8 @@ std::shared_ptr<CPVRChannelGroupMember> CPVRChannelGroupsContainer::GetChannelGr
 
 std::shared_ptr<CPVRChannel> CPVRChannelGroupsContainer::GetByPath(const std::string& strPath) const
 {
-  const std::shared_ptr<CPVRChannelGroupMember> groupMember = GetChannelGroupMemberByPath(strPath);
+  const std::shared_ptr<const CPVRChannelGroupMember> groupMember =
+      GetChannelGroupMemberByPath(strPath);
   if (groupMember)
     return groupMember->Channel();
 

--- a/xbmc/pvr/channels/PVRChannelGroupsContainer.h
+++ b/xbmc/pvr/channels/PVRChannelGroupsContainer.h
@@ -113,7 +113,8 @@ namespace PVR
      * @param epgTag The epg tag.
      * @return The channel.
      */
-    std::shared_ptr<CPVRChannel> GetChannelForEpgTag(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
+    std::shared_ptr<CPVRChannel> GetChannelForEpgTag(
+        const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const;
 
     /*!
      * @brief Get a channel given it's path.

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelGuide.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelGuide.cpp
@@ -25,7 +25,7 @@ CGUIDialogPVRChannelGuide::CGUIDialogPVRChannelGuide()
 {
 }
 
-void CGUIDialogPVRChannelGuide::Open(const std::shared_ptr<CPVRChannel>& channel)
+void CGUIDialogPVRChannelGuide::Open(const std::shared_ptr<const CPVRChannel>& channel)
 {
   m_channel = channel;
   CGUIDialogPVRItemsViewBase::Open();

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelGuide.h
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelGuide.h
@@ -22,13 +22,13 @@ namespace PVR
     CGUIDialogPVRChannelGuide();
     ~CGUIDialogPVRChannelGuide() override = default;
 
-    void Open(const std::shared_ptr<CPVRChannel>& channel);
+    void Open(const std::shared_ptr<const CPVRChannel>& channel);
 
   protected:
     void OnInitWindow() override;
     void OnDeinitWindow(int nextWindowID) override;
 
   private:
-    std::shared_ptr<CPVRChannel> m_channel;
+    std::shared_ptr<const CPVRChannel> m_channel;
   };
 }

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -208,7 +208,7 @@ void CGUIDialogPVRChannelManager::OnInitWindow()
   if (m_initialSelection)
   {
     // set initial selection
-    const std::shared_ptr<CPVRChannel> channel = m_initialSelection->GetPVRChannelInfoTag();
+    const std::shared_ptr<const CPVRChannel> channel = m_initialSelection->GetPVRChannelInfoTag();
     for (int i = 0; i < m_channelItems->Size(); ++i)
     {
       if (m_channelItems->Get(i)->GetPVRChannelInfoTag() == channel)
@@ -750,7 +750,7 @@ bool CGUIDialogPVRChannelManager::OnContextButton(int itemNumber, CONTEXT_BUTTON
       const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(*pItem);
       if (client)
       {
-        const std::shared_ptr<CPVRChannel> channel = pItem->GetPVRChannelInfoTag();
+        const std::shared_ptr<const CPVRChannel> channel = pItem->GetPVRChannelInfoTag();
         PVR_ERROR ret = client->DeleteChannel(channel);
         if (ret == PVR_ERROR_NO_ERROR)
         {
@@ -821,7 +821,7 @@ void CGUIDialogPVRChannelManager::Update()
     channelFile = std::make_shared<CFileItem>(member);
     if (!channelFile)
       continue;
-    const std::shared_ptr<CPVRChannel> channel(channelFile->GetPVRChannelInfoTag());
+    const std::shared_ptr<const CPVRChannel> channel(channelFile->GetPVRChannelInfoTag());
 
     channelFile->SetProperty(PROPERTY_CHANNEL_ENABLED, !channel->IsHidden());
     channelFile->SetProperty(PROPERTY_CHANNEL_USER_SET_HIDDEN, channel->IsUserSetHidden());
@@ -835,7 +835,8 @@ void CGUIDialogPVRChannelManager::Update()
     channelFile->SetProperty(PROPERTY_CHANNEL_NUMBER,
                              member->ChannelNumber().FormattedChannelNumber());
 
-    const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(*channelFile);
+    const std::shared_ptr<const CPVRClient> client =
+        CServiceBroker::GetPVRManager().GetClient(*channelFile);
     if (client)
     {
       channelFile->SetProperty(PROPERTY_CLIENT_NAME, client->GetFriendlyName());
@@ -923,7 +924,7 @@ void CGUIDialogPVRChannelManager::RenameChannel(const CFileItemPtr& pItem)
   std::string strChannelName = pItem->GetProperty(PROPERTY_CHANNEL_NAME).asString();
   if (strChannelName != pItem->GetPVRChannelInfoTag()->ChannelName())
   {
-    std::shared_ptr<CPVRChannel> channel = pItem->GetPVRChannelInfoTag();
+    const std::shared_ptr<CPVRChannel> channel = pItem->GetPVRChannelInfoTag();
     channel->SetChannelName(strChannelName);
 
     const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(*pItem);
@@ -1068,7 +1069,8 @@ namespace
 
 bool IsItemChanged(const std::shared_ptr<CFileItem>& item)
 {
-  const std::shared_ptr<CPVRChannelGroupMember> member = item->GetPVRChannelGroupMemberInfoTag();
+  const std::shared_ptr<const CPVRChannelGroupMember> member =
+      item->GetPVRChannelGroupMemberInfoTag();
   const std::shared_ptr<const CPVRChannel> channel = member->Channel();
 
   return item->GetProperty(PROPERTY_CHANNEL_ENABLED).asBoolean() == channel->IsHidden() ||

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -1069,7 +1069,7 @@ namespace
 bool IsItemChanged(const std::shared_ptr<CFileItem>& item)
 {
   const std::shared_ptr<CPVRChannelGroupMember> member = item->GetPVRChannelGroupMemberInfoTag();
-  const std::shared_ptr<CPVRChannel> channel = member->Channel();
+  const std::shared_ptr<const CPVRChannel> channel = member->Channel();
 
   return item->GetProperty(PROPERTY_CHANNEL_ENABLED).asBoolean() == channel->IsHidden() ||
          item->GetProperty(PROPERTY_CHANNEL_USER_SET_HIDDEN).asBoolean() !=

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelsOSD.cpp
@@ -177,7 +177,7 @@ void CGUIDialogPVRChannelsOSD::Update()
   CPVRManager& pvrMgr = CServiceBroker::GetPVRManager();
   pvrMgr.Events().Subscribe(this, &CGUIDialogPVRChannelsOSD::Notify);
 
-  const std::shared_ptr<CPVRChannel> channel = pvrMgr.PlaybackState()->GetPlayingChannel();
+  const std::shared_ptr<const CPVRChannel> channel = pvrMgr.PlaybackState()->GetPlayingChannel();
   if (channel)
   {
     const std::shared_ptr<CPVRChannelGroup> group =

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -581,7 +581,8 @@ void CGUIDialogPVRGroupManager::Update()
 
   for (auto& group : *m_channelGroups)
   {
-    const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(*group);
+    const std::shared_ptr<const CPVRClient> client =
+        CServiceBroker::GetPVRManager().GetClient(*group);
     if (client)
       group->SetProperty(PROPERTY_CLIENT_NAME, client->GetFriendlyName());
   }

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
@@ -214,7 +214,7 @@ void CGUIDialogPVRGuideInfo::OnInitWindow()
 
   bool bHideRecord = true;
   bool bHideAddTimer = true;
-  const std::shared_ptr<CPVRTimerInfoTag> timer = mgr.Timers()->GetTimerForEpgTag(epgTag);
+  const std::shared_ptr<const CPVRTimerInfoTag> timer = mgr.Timers()->GetTimerForEpgTag(epgTag);
   bool bHideSetReminder = timer || (epgTag->StartAsLocalTime() <= CDateTime::GetCurrentDateTime());
 
   if (timer)
@@ -232,7 +232,7 @@ void CGUIDialogPVRGuideInfo::OnInitWindow()
   }
   else if (epgTag->IsRecordable())
   {
-    const std::shared_ptr<CPVRClient> client = mgr.GetClient(epgTag->ClientID());
+    const std::shared_ptr<const CPVRClient> client = mgr.GetClient(epgTag->ClientID());
     if (client && client->GetClientCapabilities().SupportsTimers())
     {
       SET_CONTROL_LABEL(CONTROL_BTN_RECORD, 264); /* Record */

--- a/xbmc/pvr/dialogs/GUIDialogPVRRadioRDSInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRadioRDSInfo.cpp
@@ -64,11 +64,12 @@ bool CGUIDialogPVRRadioRDSInfo::OnMessage(CGUIMessage& message)
     }
     else if (iControl == SPIN_CONTROL_INFO)
     {
-      const std::shared_ptr<CPVRChannel> channel = CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel();
+      const std::shared_ptr<const CPVRChannel> channel =
+          CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel();
       if (!channel)
         return false;
 
-      const std::shared_ptr<CPVRRadioRDSInfoTag> currentRDS = channel->GetRadioRDSInfoTag();
+      const std::shared_ptr<const CPVRRadioRDSInfoTag> currentRDS = channel->GetRadioRDSInfoTag();
       if (!currentRDS)
         return false;
 
@@ -158,11 +159,12 @@ void CGUIDialogPVRRadioRDSInfo::InitInfoControls()
 
 void CGUIDialogPVRRadioRDSInfo::UpdateInfoControls()
 {
-  const std::shared_ptr<CPVRChannel> channel = CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel();
+  const std::shared_ptr<const CPVRChannel> channel =
+      CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel();
   if (!channel)
     return;
 
-  const std::shared_ptr<CPVRRadioRDSInfoTag> currentRDS = channel->GetRadioRDSInfoTag();
+  const std::shared_ptr<const CPVRRadioRDSInfoTag> currentRDS = channel->GetRadioRDSInfoTag();
   if (!currentRDS)
     return;
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
@@ -86,7 +86,7 @@ void CGUIDialogPVRRecordingSettings::InitializeSettings()
   }
 
   std::shared_ptr<CSetting> setting = nullptr;
-  const std::shared_ptr<CPVRClient> client =
+  const std::shared_ptr<const CPVRClient> client =
       CServiceBroker::GetPVRManager().GetClient(m_recording->ClientID());
 
   // Name
@@ -109,7 +109,7 @@ bool CGUIDialogPVRRecordingSettings::CanEditRecording(const CFileItem& item)
   if (!item.HasPVRRecordingInfoTag())
     return false;
 
-  const std::shared_ptr<CPVRClient> client =
+  const std::shared_ptr<const CPVRClient> client =
       CServiceBroker::GetPVRManager().GetClient(item.GetPVRRecordingInfoTag()->ClientID());
 
   if (!client)
@@ -200,7 +200,7 @@ void CGUIDialogPVRRecordingSettings::LifetimesFiller(const SettingConstPtr& sett
   {
     list.clear();
 
-    const std::shared_ptr<CPVRClient> client =
+    const std::shared_ptr<const CPVRClient> client =
         CServiceBroker::GetPVRManager().GetClient(pThis->m_recording->ClientID());
     if (client)
     {

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -841,7 +841,7 @@ void CGUIDialogPVRTimerSettings::InitializeTypesList()
     // Drop TimerTypes without 'Series' EPG attributes if none are set
     if (type->RequiresEpgSeriesOnCreate())
     {
-      const std::shared_ptr<CPVREpgInfoTag> epgTag(m_timerInfoTag->GetEpgInfoTag());
+      const std::shared_ptr<const CPVREpgInfoTag> epgTag(m_timerInfoTag->GetEpgInfoTag());
       if (epgTag && !epgTag->IsSeries())
         continue;
     }
@@ -849,7 +849,7 @@ void CGUIDialogPVRTimerSettings::InitializeTypesList()
     // Drop TimerTypes which need series link if none is set
     if (type->RequiresEpgSeriesLinkOnCreate())
     {
-      const std::shared_ptr<CPVREpgInfoTag> epgTag(m_timerInfoTag->GetEpgInfoTag());
+      const std::shared_ptr<const CPVREpgInfoTag> epgTag(m_timerInfoTag->GetEpgInfoTag());
       if (!epgTag || epgTag->SeriesLink().empty())
         continue;
     }
@@ -861,7 +861,7 @@ void CGUIDialogPVRTimerSettings::InitializeTypesList()
     // Drop TimerTypes that aren't rules and cannot be recorded
     if (!type->IsTimerRule())
     {
-      const std::shared_ptr<CPVREpgInfoTag> epgTag(m_timerInfoTag->GetEpgInfoTag());
+      const std::shared_ptr<const CPVREpgInfoTag> epgTag(m_timerInfoTag->GetEpgInfoTag());
       bool bCanRecord = epgTag ? epgTag->IsRecordable()
                                : m_timerInfoTag->EndAsLocalTime() > CDateTime::GetCurrentDateTime();
       if (!bCanRecord)
@@ -895,13 +895,13 @@ void CGUIDialogPVRTimerSettings::InitializeChannelsList()
   }
 
   // Add regular channels
-  const std::shared_ptr<CPVRChannelGroup> allGroup =
+  const std::shared_ptr<const CPVRChannelGroup> allGroup =
       CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAll(m_bIsRadio);
   const std::vector<std::shared_ptr<CPVRChannelGroupMember>> groupMembers =
       allGroup->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);
   for (const auto& groupMember : groupMembers)
   {
-    const std::shared_ptr<CPVRChannel> channel = groupMember->Channel();
+    const std::shared_ptr<const CPVRChannel> channel = groupMember->Channel();
     const std::string channelDescription = StringUtils::Format(
         "{} {}", groupMember->ChannelNumber().FormattedChannelNumber(), channel->ChannelName());
     m_channelEntries.insert(

--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -180,7 +180,7 @@ bool CPVREpg::UpdateEntries(const CPVREpg& epg)
 namespace
 {
 
-bool IsTagExpired(const std::shared_ptr<CPVREpgInfoTag>& tag)
+bool IsTagExpired(const std::shared_ptr<const CPVREpgInfoTag>& tag)
 {
   // Respect epg linger time.
   const int iPastDays = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(

--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -398,7 +398,8 @@ bool CPVREpg::UpdateFromScraper(time_t start, time_t end, bool bForceUpdate)
       return true;
     }
 
-    const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_channelData->ClientId());
+    const std::shared_ptr<const CPVRClient> client =
+        CServiceBroker::GetPVRManager().GetClient(m_channelData->ClientId());
     if (client)
     {
       if (!client->GetClientCapabilities().SupportsEPG())

--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -542,7 +542,7 @@ void CPVREpg::RemovedFromContainer()
   m_events.Publish(PVREvent::EpgDeleted);
 }
 
-int CPVREpg::CleanupCachedImages(const std::shared_ptr<CPVREpgDatabase>& database)
+int CPVREpg::CleanupCachedImages(const std::shared_ptr<const CPVREpgDatabase>& database)
 {
   const std::vector<std::string> urlsToCheck = database->GetAllIconPaths(EpgID());
   const std::string owner = StringUtils::Format(CPVREpgInfoTag::IMAGE_OWNER_PATTERN, EpgID());

--- a/xbmc/pvr/epg/Epg.h
+++ b/xbmc/pvr/epg/Epg.h
@@ -281,7 +281,7 @@ namespace PVR
      * @param database The EPG database
      * @return number of cleaned up images.
      */
-    int CleanupCachedImages(const std::shared_ptr<CPVREpgDatabase>& database);
+    int CleanupCachedImages(const std::shared_ptr<const CPVREpgDatabase>& database);
 
   private:
     CPVREpg() = delete;

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -486,7 +486,8 @@ std::shared_ptr<CPVREpg> CPVREpgContainer::GetByChannelUid(int iClientId, int iC
   return epg;
 }
 
-std::shared_ptr<CPVREpgInfoTag> CPVREpgContainer::GetTagById(const std::shared_ptr<CPVREpg>& epg, unsigned int iBroadcastId) const
+std::shared_ptr<CPVREpgInfoTag> CPVREpgContainer::GetTagById(
+    const std::shared_ptr<const CPVREpg>& epg, unsigned int iBroadcastId) const
 {
   std::shared_ptr<CPVREpgInfoTag> retval;
 
@@ -650,7 +651,7 @@ bool CPVREpgContainer::QueueDeleteEpgs(const std::vector<std::shared_ptr<CPVREpg
   return true;
 }
 
-bool CPVREpgContainer::QueueDeleteEpg(const std::shared_ptr<CPVREpg>& epg,
+bool CPVREpgContainer::QueueDeleteEpg(const std::shared_ptr<const CPVREpg>& epg,
                                       const std::shared_ptr<CPVREpgDatabase>& database)
 {
   if (!epg || epg->EpgID() < 0)

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -529,7 +529,7 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgContainer::GetTags(
   // make sure we have up-to-date data in the database.
   PersistAll(std::numeric_limits<unsigned int>::max());
 
-  const std::shared_ptr<CPVREpgDatabase> database = GetEpgDatabase();
+  const std::shared_ptr<const CPVREpgDatabase> database = GetEpgDatabase();
   std::vector<std::shared_ptr<CPVREpgInfoTag>> results = database->GetEpgTags(searchData);
 
   std::unique_lock<CCriticalSection> lock(m_critSection);
@@ -813,7 +813,7 @@ std::pair<CDateTime, CDateTime> CPVREpgContainer::GetFirstAndLastEPGDate() const
 {
   // Get values from db
   std::pair<CDateTime, CDateTime> dbDates;
-  const std::shared_ptr<CPVREpgDatabase> database = GetEpgDatabase();
+  const std::shared_ptr<const CPVREpgDatabase> database = GetEpgDatabase();
   if (database)
     dbDates = database->GetFirstAndLastEPGDate();
 
@@ -935,7 +935,7 @@ void CPVREpgContainer::OnSystemWake()
 
 int CPVREpgContainer::CleanupCachedImages()
 {
-  const std::shared_ptr<CPVREpgDatabase> database = GetEpgDatabase();
+  const std::shared_ptr<const CPVREpgDatabase> database = GetEpgDatabase();
   if (!database)
   {
     CLog::LogF(LOGERROR, "No EPG database");
@@ -955,7 +955,7 @@ int CPVREpgContainer::CleanupCachedImages()
 
 std::vector<std::shared_ptr<CPVREpgSearchFilter>> CPVREpgContainer::GetSavedSearches(bool bRadio)
 {
-  const std::shared_ptr<CPVREpgDatabase> database = GetEpgDatabase();
+  const std::shared_ptr<const CPVREpgDatabase> database = GetEpgDatabase();
   if (!database)
   {
     CLog::LogF(LOGERROR, "No EPG database");
@@ -967,7 +967,7 @@ std::vector<std::shared_ptr<CPVREpgSearchFilter>> CPVREpgContainer::GetSavedSear
 
 std::shared_ptr<CPVREpgSearchFilter> CPVREpgContainer::GetSavedSearchById(bool bRadio, int iId)
 {
-  const std::shared_ptr<CPVREpgDatabase> database = GetEpgDatabase();
+  const std::shared_ptr<const CPVREpgDatabase> database = GetEpgDatabase();
   if (!database)
   {
     CLog::LogF(LOGERROR, "No EPG database");

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -144,7 +144,8 @@ namespace PVR
      * @param iBroadcastId The event id to lookup.
      * @return The requested event, or an empty tag when not found
      */
-    std::shared_ptr<CPVREpgInfoTag> GetTagById(const std::shared_ptr<CPVREpg>& epg, unsigned int iBroadcastId) const;
+    std::shared_ptr<CPVREpgInfoTag> GetTagById(const std::shared_ptr<const CPVREpg>& epg,
+                                               unsigned int iBroadcastId) const;
 
     /*!
      * @brief Get the EPG event with the given database id
@@ -321,7 +322,7 @@ namespace PVR
      * @param database The database containing the epg data.
      * @return True on success, false otherwise.
      */
-    bool QueueDeleteEpg(const std::shared_ptr<CPVREpg>& epg,
+    bool QueueDeleteEpg(const std::shared_ptr<const CPVREpg>& epg,
                         const std::shared_ptr<CPVREpgDatabase>& database);
 
     std::shared_ptr<CPVREpgDatabase> m_database; /*!< the EPG database */

--- a/xbmc/pvr/epg/EpgDatabase.cpp
+++ b/xbmc/pvr/epg/EpgDatabase.cpp
@@ -408,7 +408,7 @@ std::vector<std::shared_ptr<CPVREpg>> CPVREpgDatabase::GetAll()
 }
 
 std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::CreateEpgTag(
-    const std::unique_ptr<dbiplus::Dataset>& pDS)
+    const std::unique_ptr<dbiplus::Dataset>& pDS) const
 {
   if (!pDS->eof())
   {
@@ -460,7 +460,7 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::CreateEpgTag(
   return {};
 }
 
-bool CPVREpgDatabase::HasTags(int iEpgID)
+bool CPVREpgDatabase::HasTags(int iEpgID) const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   const std::string strQuery =
@@ -469,7 +469,7 @@ bool CPVREpgDatabase::HasTags(int iEpgID)
   return !strValue.empty();
 }
 
-CDateTime CPVREpgDatabase::GetLastEndTime(int iEpgID)
+CDateTime CPVREpgDatabase::GetLastEndTime(int iEpgID) const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   const std::string strQuery =
@@ -481,7 +481,7 @@ CDateTime CPVREpgDatabase::GetLastEndTime(int iEpgID)
   return {};
 }
 
-std::pair<CDateTime, CDateTime> CPVREpgDatabase::GetFirstAndLastEPGDate()
+std::pair<CDateTime, CDateTime> CPVREpgDatabase::GetFirstAndLastEPGDate() const
 {
   CDateTime first;
   CDateTime last;
@@ -505,7 +505,7 @@ std::pair<CDateTime, CDateTime> CPVREpgDatabase::GetFirstAndLastEPGDate()
   return {first, last};
 }
 
-CDateTime CPVREpgDatabase::GetMinStartTime(int iEpgID, const CDateTime& minStart)
+CDateTime CPVREpgDatabase::GetMinStartTime(int iEpgID, const CDateTime& minStart) const
 {
   time_t t;
   minStart.GetAsTime(t);
@@ -522,7 +522,7 @@ CDateTime CPVREpgDatabase::GetMinStartTime(int iEpgID, const CDateTime& minStart
   return {};
 }
 
-CDateTime CPVREpgDatabase::GetMaxEndTime(int iEpgID, const CDateTime& maxEnd)
+CDateTime CPVREpgDatabase::GetMaxEndTime(int iEpgID, const CDateTime& maxEnd) const
 {
   time_t t;
   maxEnd.GetAsTime(t);
@@ -665,7 +665,7 @@ private:
 } // unnamed namespace
 
 std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgDatabase::GetEpgTags(
-    const PVREpgSearchData& searchData)
+    const PVREpgSearchData& searchData) const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
 
@@ -786,7 +786,7 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgDatabase::GetEpgTags(
 }
 
 std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::GetEpgTagByUniqueBroadcastID(
-    int iEpgID, unsigned int iUniqueBroadcastId)
+    int iEpgID, unsigned int iUniqueBroadcastId) const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   const std::string strQuery = PrepareSQL("SELECT * "
@@ -812,7 +812,8 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::GetEpgTagByUniqueBroadcastID(
   return {};
 }
 
-std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::GetEpgTagByDatabaseID(int iEpgID, int iDatabaseId)
+std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::GetEpgTagByDatabaseID(int iEpgID,
+                                                                       int iDatabaseId) const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   const std::string strQuery = PrepareSQL("SELECT * "
@@ -838,8 +839,8 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::GetEpgTagByDatabaseID(int iEpgI
   return {};
 }
 
-std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::GetEpgTagByStartTime(int iEpgID,
-                                                                      const CDateTime& startTime)
+std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::GetEpgTagByStartTime(
+    int iEpgID, const CDateTime& startTime) const
 {
   time_t start;
   startTime.GetAsTime(start);
@@ -869,7 +870,7 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::GetEpgTagByStartTime(int iEpgID
 }
 
 std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::GetEpgTagByMinStartTime(
-    int iEpgID, const CDateTime& minStartTime)
+    int iEpgID, const CDateTime& minStartTime) const
 {
   time_t minStart;
   minStartTime.GetAsTime(minStart);
@@ -899,8 +900,8 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::GetEpgTagByMinStartTime(
   return {};
 }
 
-std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::GetEpgTagByMaxEndTime(int iEpgID,
-                                                                       const CDateTime& maxEndTime)
+std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::GetEpgTagByMaxEndTime(
+    int iEpgID, const CDateTime& maxEndTime) const
 {
   time_t maxEnd;
   maxEndTime.GetAsTime(maxEnd);
@@ -931,7 +932,7 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::GetEpgTagByMaxEndTime(int iEpgI
 }
 
 std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgDatabase::GetEpgTagsByMinStartMaxEndTime(
-    int iEpgID, const CDateTime& minStartTime, const CDateTime& maxEndTime)
+    int iEpgID, const CDateTime& minStartTime, const CDateTime& maxEndTime) const
 {
   time_t minStart;
   minStartTime.GetAsTime(minStart);
@@ -971,7 +972,7 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgDatabase::GetEpgTagsByMinSta
 }
 
 std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgDatabase::GetEpgTagsByMinEndMaxStartTime(
-    int iEpgID, const CDateTime& minEndTime, const CDateTime& maxStartTime)
+    int iEpgID, const CDateTime& minEndTime, const CDateTime& maxStartTime) const
 {
   time_t minEnd;
   minEndTime.GetAsTime(minEnd);
@@ -1034,7 +1035,7 @@ bool CPVREpgDatabase::QueueDeleteEpgTagsByMinEndMaxStartTimeQuery(int iEpgID,
   return false;
 }
 
-std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgDatabase::GetAllEpgTags(int iEpgID)
+std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgDatabase::GetAllEpgTags(int iEpgID) const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   const std::string strQuery =
@@ -1060,7 +1061,7 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgDatabase::GetAllEpgTags(int 
   return {};
 }
 
-std::vector<std::string> CPVREpgDatabase::GetAllIconPaths(int iEpgID)
+std::vector<std::string> CPVREpgDatabase::GetAllIconPaths(int iEpgID) const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   const std::string strQuery =
@@ -1086,7 +1087,7 @@ std::vector<std::string> CPVREpgDatabase::GetAllIconPaths(int iEpgID)
   return {};
 }
 
-bool CPVREpgDatabase::GetLastEpgScanTime(int iEpgId, CDateTime* lastScan)
+bool CPVREpgDatabase::GetLastEpgScanTime(int iEpgId, CDateTime* lastScan) const
 {
   bool bReturn = false;
 
@@ -1269,7 +1270,7 @@ bool CPVREpgDatabase::QueuePersistQuery(const CPVREpgInfoTag& tag)
   return true;
 }
 
-int CPVREpgDatabase::GetLastEPGId()
+int CPVREpgDatabase::GetLastEPGId() const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   std::string strQuery = PrepareSQL("SELECT MAX(idEpg) FROM epg");
@@ -1282,7 +1283,7 @@ int CPVREpgDatabase::GetLastEPGId()
 /********** Saved searches methods **********/
 
 std::shared_ptr<CPVREpgSearchFilter> CPVREpgDatabase::CreateEpgSearchFilter(
-    bool bRadio, const std::unique_ptr<dbiplus::Dataset>& pDS)
+    bool bRadio, const std::unique_ptr<dbiplus::Dataset>& pDS) const
 {
   if (!pDS->eof())
   {
@@ -1328,7 +1329,8 @@ std::shared_ptr<CPVREpgSearchFilter> CPVREpgDatabase::CreateEpgSearchFilter(
   return {};
 }
 
-std::vector<std::shared_ptr<CPVREpgSearchFilter>> CPVREpgDatabase::GetSavedSearches(bool bRadio)
+std::vector<std::shared_ptr<CPVREpgSearchFilter>> CPVREpgDatabase::GetSavedSearches(
+    bool bRadio) const
 {
   std::vector<std::shared_ptr<CPVREpgSearchFilter>> result;
 
@@ -1354,7 +1356,7 @@ std::vector<std::shared_ptr<CPVREpgSearchFilter>> CPVREpgDatabase::GetSavedSearc
   return result;
 }
 
-std::shared_ptr<CPVREpgSearchFilter> CPVREpgDatabase::GetSavedSearchById(bool bRadio, int iId)
+std::shared_ptr<CPVREpgSearchFilter> CPVREpgDatabase::GetSavedSearchById(bool bRadio, int iId) const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   const std::string strQuery =

--- a/xbmc/pvr/epg/EpgDatabase.h
+++ b/xbmc/pvr/epg/EpgDatabase.h
@@ -108,34 +108,34 @@ namespace PVR
      * @param iEpgID The ID of the EPG.
      * @return The entries.
      */
-    std::vector<std::shared_ptr<CPVREpgInfoTag>> GetAllEpgTags(int iEpgID);
+    std::vector<std::shared_ptr<CPVREpgInfoTag>> GetAllEpgTags(int iEpgID) const;
 
     /*!
      * @brief Get all icon paths for a given EPG id.
      * @param iEpgID The ID of the EPG.
      * @return The entries.
      */
-    std::vector<std::string> GetAllIconPaths(int iEpgID);
+    std::vector<std::string> GetAllIconPaths(int iEpgID) const;
 
     /*!
      * @brief Check whether this EPG has any tags.
      * @param iEpgID The ID of the EPG.
      * @return True in case there are tags, false otherwise.
      */
-    bool HasTags(int iEpgID);
+    bool HasTags(int iEpgID) const;
 
     /*!
      * @brief Get the end time of the last tag in this EPG.
      * @param iEpgID The ID of the EPG.
      * @return The time.
      */
-    CDateTime GetLastEndTime(int iEpgID);
+    CDateTime GetLastEndTime(int iEpgID) const;
 
     /*!
      * @brief Get the start and end time across all EPGs.
      * @return The times; first: start time, second: end time.
      */
-    std::pair<CDateTime, CDateTime> GetFirstAndLastEPGDate();
+    std::pair<CDateTime, CDateTime> GetFirstAndLastEPGDate() const;
 
     /*!
      * @brief Get the start time of the first tag with a start time greater than the given min time.
@@ -143,7 +143,7 @@ namespace PVR
      * @param minStart The min start time.
      * @return The time.
      */
-    CDateTime GetMinStartTime(int iEpgID, const CDateTime& minStart);
+    CDateTime GetMinStartTime(int iEpgID, const CDateTime& minStart) const;
 
     /*!
      * @brief Get the end time of the first tag with an end time less than the given max time.
@@ -151,14 +151,15 @@ namespace PVR
      * @param maxEnd The mx end time.
      * @return The time.
      */
-    CDateTime GetMaxEndTime(int iEpgID, const CDateTime& maxEnd);
+    CDateTime GetMaxEndTime(int iEpgID, const CDateTime& maxEnd) const;
 
     /*!
      * @brief Get all EPG tags matching the given search criteria.
      * @param searchData The search criteria.
      * @return The matching tags.
      */
-    std::vector<std::shared_ptr<CPVREpgInfoTag>> GetEpgTags(const PVREpgSearchData& searchData);
+    std::vector<std::shared_ptr<CPVREpgInfoTag>> GetEpgTags(
+        const PVREpgSearchData& searchData) const;
 
     /*!
      * @brief Get an EPG tag given its EPG id and unique broadcast ID.
@@ -166,8 +167,8 @@ namespace PVR
      * @param iUniqueBroadcastId The unique broadcast ID for the tag to get.
      * @return The tag or nullptr, if not found.
      */
-    std::shared_ptr<CPVREpgInfoTag> GetEpgTagByUniqueBroadcastID(int iEpgID,
-                                                                 unsigned int iUniqueBroadcastId);
+    std::shared_ptr<CPVREpgInfoTag> GetEpgTagByUniqueBroadcastID(
+        int iEpgID, unsigned int iUniqueBroadcastId) const;
 
     /*!
      * @brief Get an EPG tag given its EPG id and database ID.
@@ -175,7 +176,7 @@ namespace PVR
      * @param iDatabaseId The database ID for the tag to get.
      * @return The tag or nullptr, if not found.
      */
-    std::shared_ptr<CPVREpgInfoTag> GetEpgTagByDatabaseID(int iEpgID, int iDatabaseId);
+    std::shared_ptr<CPVREpgInfoTag> GetEpgTagByDatabaseID(int iEpgID, int iDatabaseId) const;
 
     /*!
      * @brief Get an EPG tag given its EPG ID and start time.
@@ -183,7 +184,8 @@ namespace PVR
      * @param startTime The start time for the tag to get.
      * @return The tag or nullptr, if not found.
      */
-    std::shared_ptr<CPVREpgInfoTag> GetEpgTagByStartTime(int iEpgID, const CDateTime& startTime);
+    std::shared_ptr<CPVREpgInfoTag> GetEpgTagByStartTime(int iEpgID,
+                                                         const CDateTime& startTime) const;
 
     /*!
      * @brief Get the next EPG tag matching the given EPG id and min start time.
@@ -192,7 +194,7 @@ namespace PVR
      * @return The tag or nullptr, if not found.
      */
     std::shared_ptr<CPVREpgInfoTag> GetEpgTagByMinStartTime(int iEpgID,
-                                                            const CDateTime& minStartTime);
+                                                            const CDateTime& minStartTime) const;
 
     /*!
      * @brief Get the next EPG tag matching the given EPG id and max end time.
@@ -200,7 +202,8 @@ namespace PVR
      * @param maxEndTime The max end time for the tag to get.
      * @return The tag or nullptr, if not found.
      */
-    std::shared_ptr<CPVREpgInfoTag> GetEpgTagByMaxEndTime(int iEpgID, const CDateTime& maxEndTime);
+    std::shared_ptr<CPVREpgInfoTag> GetEpgTagByMaxEndTime(int iEpgID,
+                                                          const CDateTime& maxEndTime) const;
 
     /*!
      * @brief Get all EPG tags matching the given EPG id, min start time and max end time.
@@ -210,7 +213,7 @@ namespace PVR
      * @return The tags or empty vector, if no tags were found.
      */
     std::vector<std::shared_ptr<CPVREpgInfoTag>> GetEpgTagsByMinStartMaxEndTime(
-        int iEpgID, const CDateTime& minStartTime, const CDateTime& maxEndTime);
+        int iEpgID, const CDateTime& minStartTime, const CDateTime& maxEndTime) const;
 
     /*!
      * @brief Get all EPG tags matching the given EPG id, min end time and max start time.
@@ -220,7 +223,7 @@ namespace PVR
      * @return The tags or empty vector, if no tags were found.
      */
     std::vector<std::shared_ptr<CPVREpgInfoTag>> GetEpgTagsByMinEndMaxStartTime(
-        int iEpgID, const CDateTime& minEndTime, const CDateTime& maxStartTime);
+        int iEpgID, const CDateTime& minEndTime, const CDateTime& maxStartTime) const;
 
     /*!
      * @brief Write the query to delete all EPG tags in range of given EPG id, min end time and max
@@ -240,7 +243,7 @@ namespace PVR
      * @param lastScan The last scan time or -1 if it wasn't found.
      * @return True if the time was fetched successfully, false otherwise.
      */
-    bool GetLastEpgScanTime(int iEpgId, CDateTime* lastScan);
+    bool GetLastEpgScanTime(int iEpgId, CDateTime* lastScan) const;
 
     /*!
      * @brief Write the query to update the last scan time for the given EPG to db query queue.
@@ -297,7 +300,7 @@ namespace PVR
     /*!
      * @return Last EPG id in the database
      */
-    int GetLastEPGId();
+    int GetLastEPGId() const;
 
     //@}
 
@@ -309,7 +312,7 @@ namespace PVR
      * @param bRadio Whether to fetch saved searches for radio or TV.
      * @return The searches.
      */
-    std::vector<std::shared_ptr<CPVREpgSearchFilter>> GetSavedSearches(bool bRadio);
+    std::vector<std::shared_ptr<CPVREpgSearchFilter>> GetSavedSearches(bool bRadio) const;
 
     /*!
      * @brief Get the saved search matching the given id.
@@ -317,7 +320,7 @@ namespace PVR
      * @param iId The id.
      * @return The saved search or nullptr if not found.
      */
-    std::shared_ptr<CPVREpgSearchFilter> GetSavedSearchById(bool bRadio, int iId);
+    std::shared_ptr<CPVREpgSearchFilter> GetSavedSearchById(bool bRadio, int iId) const;
 
     /*!
      * @brief Persist a search.
@@ -367,11 +370,12 @@ namespace PVR
 
     int GetMinSchemaVersion() const override { return 4; }
 
-    std::shared_ptr<CPVREpgInfoTag> CreateEpgTag(const std::unique_ptr<dbiplus::Dataset>& pDS);
+    std::shared_ptr<CPVREpgInfoTag> CreateEpgTag(
+        const std::unique_ptr<dbiplus::Dataset>& pDS) const;
 
     std::shared_ptr<CPVREpgSearchFilter> CreateEpgSearchFilter(
-        bool bRadio, const std::unique_ptr<dbiplus::Dataset>& pDS);
+        bool bRadio, const std::unique_ptr<dbiplus::Dataset>& pDS) const;
 
-    CCriticalSection m_critSection;
+    mutable CCriticalSection m_critSection;
   };
 }

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -598,7 +598,7 @@ bool CPVREpgInfoTag::IsRecordable() const
   bool bIsRecordable = false;
 
   std::unique_lock<CCriticalSection> lock(m_critSection);
-  const std::shared_ptr<CPVRClient> client =
+  const std::shared_ptr<const CPVRClient> client =
       CServiceBroker::GetPVRManager().GetClient(m_channelData->ClientId());
   if (!client || (client->IsRecordable(shared_from_this(), bIsRecordable) != PVR_ERROR_NO_ERROR))
   {
@@ -613,7 +613,7 @@ bool CPVREpgInfoTag::IsPlayable() const
   bool bIsPlayable = false;
 
   std::unique_lock<CCriticalSection> lock(m_critSection);
-  const std::shared_ptr<CPVRClient> client =
+  const std::shared_ptr<const CPVRClient> client =
       CServiceBroker::GetPVRManager().GetClient(m_channelData->ClientId());
   if (!client || (client->IsPlayable(shared_from_this(), bIsPlayable) != PVR_ERROR_NO_ERROR))
   {

--- a/xbmc/pvr/epg/EpgInfoTag.cpp
+++ b/xbmc/pvr/epg/EpgInfoTag.cpp
@@ -573,7 +573,7 @@ std::vector<PVR_EDL_ENTRY> CPVREpgInfoTag::GetEdl() const
   std::vector<PVR_EDL_ENTRY> edls;
 
   std::unique_lock<CCriticalSection> lock(m_critSection);
-  const std::shared_ptr<CPVRClient> client =
+  const std::shared_ptr<const CPVRClient> client =
       CServiceBroker::GetPVRManager().GetClient(m_channelData->ClientId());
 
   if (client && client->GetClientCapabilities().SupportsEpgTagEdl())

--- a/xbmc/pvr/epg/EpgSearchFilter.cpp
+++ b/xbmc/pvr/epg/EpgSearchFilter.cpp
@@ -365,10 +365,10 @@ bool CPVREpgSearchFilter::MatchChannelGroup(const std::shared_ptr<const CPVREpgI
   {
     if (!m_groupIdMatches.has_value())
     {
-      const std::shared_ptr<CPVRChannelGroup> group = CServiceBroker::GetPVRManager()
-                                                          .ChannelGroups()
-                                                          ->Get(m_bIsRadio)
-                                                          ->GetById(m_iChannelGroupID);
+      const std::shared_ptr<const CPVRChannelGroup> group = CServiceBroker::GetPVRManager()
+                                                                .ChannelGroups()
+                                                                ->Get(m_bIsRadio)
+                                                                ->GetById(m_iChannelGroupID);
       m_groupIdMatches =
           group && (group->GetByUniqueID({tag->ClientID(), tag->UniqueChannelID()}) != nullptr);
     }
@@ -383,7 +383,8 @@ bool CPVREpgSearchFilter::MatchFreeToAir(const std::shared_ptr<const CPVREpgInfo
 {
   if (m_bFreeToAirOnly)
   {
-    const std::shared_ptr<CPVRChannel> channel = CServiceBroker::GetPVRManager().ChannelGroups()->GetChannelForEpgTag(tag);
+    const std::shared_ptr<const CPVRChannel> channel =
+        CServiceBroker::GetPVRManager().ChannelGroups()->GetChannelForEpgTag(tag);
     return channel && !channel->IsEncrypted();
   }
 

--- a/xbmc/pvr/epg/EpgSearchFilter.cpp
+++ b/xbmc/pvr/epg/EpgSearchFilter.cpp
@@ -257,7 +257,7 @@ void CPVREpgSearchFilter::SetLastExecutedDateTime(const CDateTime& lastExecutedD
   m_lastExecutedDateTime = lastExecutedDateTime;
 }
 
-bool CPVREpgSearchFilter::MatchGenre(const std::shared_ptr<CPVREpgInfoTag>& tag) const
+bool CPVREpgSearchFilter::MatchGenre(const std::shared_ptr<const CPVREpgInfoTag>& tag) const
 {
   if (m_bEpgSearchDataFiltered)
     return true;
@@ -282,7 +282,7 @@ bool CPVREpgSearchFilter::MatchGenre(const std::shared_ptr<CPVREpgInfoTag>& tag)
   return true;
 }
 
-bool CPVREpgSearchFilter::MatchDuration(const std::shared_ptr<CPVREpgInfoTag>& tag) const
+bool CPVREpgSearchFilter::MatchDuration(const std::shared_ptr<const CPVREpgInfoTag>& tag) const
 {
   bool bReturn(true);
 
@@ -295,7 +295,8 @@ bool CPVREpgSearchFilter::MatchDuration(const std::shared_ptr<CPVREpgInfoTag>& t
   return bReturn;
 }
 
-bool CPVREpgSearchFilter::MatchStartAndEndTimes(const std::shared_ptr<CPVREpgInfoTag>& tag) const
+bool CPVREpgSearchFilter::MatchStartAndEndTimes(
+    const std::shared_ptr<const CPVREpgInfoTag>& tag) const
 {
   if (m_bEpgSearchDataFiltered)
     return true;
@@ -310,7 +311,7 @@ bool CPVREpgSearchFilter::MatchStartAndEndTimes(const std::shared_ptr<CPVREpgInf
            tag->EndAsUTC() <= m_searchData.m_endDateTime));
 }
 
-bool CPVREpgSearchFilter::MatchSearchTerm(const std::shared_ptr<CPVREpgInfoTag>& tag) const
+bool CPVREpgSearchFilter::MatchSearchTerm(const std::shared_ptr<const CPVREpgInfoTag>& tag) const
 {
   bool bReturn(true);
 
@@ -329,7 +330,7 @@ bool CPVREpgSearchFilter::MatchSearchTerm(const std::shared_ptr<CPVREpgInfoTag>&
   return bReturn;
 }
 
-bool CPVREpgSearchFilter::FilterEntry(const std::shared_ptr<CPVREpgInfoTag>& tag) const
+bool CPVREpgSearchFilter::FilterEntry(const std::shared_ptr<const CPVREpgInfoTag>& tag) const
 {
   return MatchGenre(tag) && MatchDuration(tag) && MatchStartAndEndTimes(tag) &&
          MatchSearchTerm(tag) && MatchChannel(tag) && MatchChannelGroup(tag) && MatchTimers(tag) &&
@@ -340,20 +341,17 @@ void CPVREpgSearchFilter::RemoveDuplicates(std::vector<std::shared_ptr<CPVREpgIn
 {
   for (auto it = results.begin(); it != results.end();)
   {
-    it = results.erase(std::remove_if(results.begin(),
-                                      results.end(),
-                                      [&it](const std::shared_ptr<CPVREpgInfoTag>& entry)
-                                      {
-                                         return *it != entry &&
-                                                (*it)->Title() == entry->Title() &&
-                                                (*it)->Plot() == entry->Plot() &&
-                                                (*it)->PlotOutline() == entry->PlotOutline();
+    it = results.erase(std::remove_if(results.begin(), results.end(),
+                                      [&it](const std::shared_ptr<const CPVREpgInfoTag>& entry) {
+                                        return *it != entry && (*it)->Title() == entry->Title() &&
+                                               (*it)->Plot() == entry->Plot() &&
+                                               (*it)->PlotOutline() == entry->PlotOutline();
                                       }),
                        results.end());
   }
 }
 
-bool CPVREpgSearchFilter::MatchChannel(const std::shared_ptr<CPVREpgInfoTag>& tag) const
+bool CPVREpgSearchFilter::MatchChannel(const std::shared_ptr<const CPVREpgInfoTag>& tag) const
 {
   return tag && (tag->IsRadio() == m_bIsRadio) &&
          (m_iClientID == -1 || tag->ClientID() == m_iClientID) &&
@@ -361,7 +359,7 @@ bool CPVREpgSearchFilter::MatchChannel(const std::shared_ptr<CPVREpgInfoTag>& ta
          CServiceBroker::GetPVRManager().Clients()->IsCreatedClient(tag->ClientID());
 }
 
-bool CPVREpgSearchFilter::MatchChannelGroup(const std::shared_ptr<CPVREpgInfoTag>& tag) const
+bool CPVREpgSearchFilter::MatchChannelGroup(const std::shared_ptr<const CPVREpgInfoTag>& tag) const
 {
   if (m_iChannelGroupID != -1)
   {
@@ -381,7 +379,7 @@ bool CPVREpgSearchFilter::MatchChannelGroup(const std::shared_ptr<CPVREpgInfoTag
   return true;
 }
 
-bool CPVREpgSearchFilter::MatchFreeToAir(const std::shared_ptr<CPVREpgInfoTag>& tag) const
+bool CPVREpgSearchFilter::MatchFreeToAir(const std::shared_ptr<const CPVREpgInfoTag>& tag) const
 {
   if (m_bFreeToAirOnly)
   {
@@ -392,12 +390,12 @@ bool CPVREpgSearchFilter::MatchFreeToAir(const std::shared_ptr<CPVREpgInfoTag>& 
   return true;
 }
 
-bool CPVREpgSearchFilter::MatchTimers(const std::shared_ptr<CPVREpgInfoTag>& tag) const
+bool CPVREpgSearchFilter::MatchTimers(const std::shared_ptr<const CPVREpgInfoTag>& tag) const
 {
   return (!m_bIgnorePresentTimers || !CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(tag));
 }
 
-bool CPVREpgSearchFilter::MatchRecordings(const std::shared_ptr<CPVREpgInfoTag>& tag) const
+bool CPVREpgSearchFilter::MatchRecordings(const std::shared_ptr<const CPVREpgInfoTag>& tag) const
 {
   return (!m_bIgnorePresentRecordings || !CServiceBroker::GetPVRManager().Recordings()->GetRecordingForEpgTag(tag));
 }

--- a/xbmc/pvr/epg/EpgSearchFilter.h
+++ b/xbmc/pvr/epg/EpgSearchFilter.h
@@ -47,7 +47,7 @@ namespace PVR
      * @param tag The tag to check.
      * @return True if this tag matches the filter, false if not.
      */
-    bool FilterEntry(const std::shared_ptr<CPVREpgInfoTag>& tag) const;
+    bool FilterEntry(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
 
     /*!
      * @brief remove duplicates from a list of epg tags.
@@ -133,15 +133,15 @@ namespace PVR
     void SetChanged(bool bChanged) { m_bChanged = bChanged; }
 
   private:
-    bool MatchGenre(const std::shared_ptr<CPVREpgInfoTag>& tag) const;
-    bool MatchDuration(const std::shared_ptr<CPVREpgInfoTag>& tag) const;
-    bool MatchStartAndEndTimes(const std::shared_ptr<CPVREpgInfoTag>& tag) const;
-    bool MatchSearchTerm(const std::shared_ptr<CPVREpgInfoTag>& tag) const;
-    bool MatchChannel(const std::shared_ptr<CPVREpgInfoTag>& tag) const;
-    bool MatchChannelGroup(const std::shared_ptr<CPVREpgInfoTag>& tag) const;
-    bool MatchFreeToAir(const std::shared_ptr<CPVREpgInfoTag>& tag) const;
-    bool MatchTimers(const std::shared_ptr<CPVREpgInfoTag>& tag) const;
-    bool MatchRecordings(const std::shared_ptr<CPVREpgInfoTag>& tag) const;
+    bool MatchGenre(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
+    bool MatchDuration(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
+    bool MatchStartAndEndTimes(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
+    bool MatchSearchTerm(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
+    bool MatchChannel(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
+    bool MatchChannelGroup(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
+    bool MatchFreeToAir(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
+    bool MatchTimers(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
+    bool MatchRecordings(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
 
     bool m_bChanged = false;
 

--- a/xbmc/pvr/epg/EpgTagsCache.cpp
+++ b/xbmc/pvr/epg/EpgTagsCache.cpp
@@ -76,7 +76,7 @@ bool CPVREpgTagsCache::Refresh()
       m_nowActiveEnd > activeTime)
     return false;
 
-  const std::shared_ptr<CPVREpgInfoTag> prevNowActiveTag = m_nowActiveTag;
+  const std::shared_ptr<const CPVREpgInfoTag> prevNowActiveTag = m_nowActiveTag;
 
   m_lastEndedTag.reset();
   m_nowActiveTag.reset();

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -66,7 +66,7 @@ bool GetRootDirectory(bool bRadio, CFileItemList& results)
 {
   std::shared_ptr<CFileItem> item;
 
-  const std::shared_ptr<CPVRClients> clients = CServiceBroker::GetPVRManager().Clients();
+  const std::shared_ptr<const CPVRClients> clients = CServiceBroker::GetPVRManager().Clients();
 
   // EPG
   const bool bAnyClientSupportingEPG = clients->AnyClientSupportingEPG();
@@ -466,7 +466,7 @@ std::shared_ptr<CPVRChannelGroupMember> GetLastWatchedChannelGroupMember(
   const int lastGroupId{channel->LastWatchedGroupId()};
   if (lastGroupId != PVR_GROUP_ID_UNNKOWN)
   {
-    const std::shared_ptr<CPVRChannelGroup> lastGroup{
+    const std::shared_ptr<const CPVRChannelGroup> lastGroup{
         CServiceBroker::GetPVRManager().ChannelGroups()->GetByIdFromAll(lastGroupId)};
     if (lastGroup && !lastGroup->IsHidden() && !lastGroup->IsDeleted())
       return lastGroup->GetByUniqueID(channel->StorageId());

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -690,7 +690,7 @@ void CGUIEPGGridContainer::UpdateItems()
       const std::shared_ptr<CFileItem> prevItem = GetPrevItem().first;
       if (prevItem)
       {
-        const std::shared_ptr<CPVREpgInfoTag> tag = prevItem->GetEPGInfoTag();
+        const std::shared_ptr<const CPVREpgInfoTag> tag = prevItem->GetEPGInfoTag();
         if (tag && !tag->IsGapTag())
         {
           if (oldGridStart >= tag->StartAsUTC())

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
@@ -641,7 +641,7 @@ int CGUIEPGGridContainerModel::GetNowBlock() const
 }
 
 int CGUIEPGGridContainerModel::GetFirstEventBlock(
-    const std::shared_ptr<CPVREpgInfoTag>& event) const
+    const std::shared_ptr<const CPVREpgInfoTag>& event) const
 {
   const CDateTime eventStart = event->StartAsUTC();
   int diff;
@@ -658,14 +658,15 @@ int CGUIEPGGridContainerModel::GetFirstEventBlock(
   return static_cast<int>(std::ceil(fBlockIndex));
 }
 
-int CGUIEPGGridContainerModel::GetLastEventBlock(const std::shared_ptr<CPVREpgInfoTag>& event) const
+int CGUIEPGGridContainerModel::GetLastEventBlock(
+    const std::shared_ptr<const CPVREpgInfoTag>& event) const
 {
   // Last block of a tag is always the block calculated using event's end time, not rounded up.
   return GetBlock(event->EndAsUTC());
 }
 
-bool CGUIEPGGridContainerModel::IsEventMemberOfBlock(const std::shared_ptr<CPVREpgInfoTag>& event,
-                                                     int iBlock) const
+bool CGUIEPGGridContainerModel::IsEventMemberOfBlock(
+    const std::shared_ptr<const CPVREpgInfoTag>& event, int iBlock) const
 {
   const int iFirstBlock = GetFirstEventBlock(event);
   const int iLastBlock = GetLastEventBlock(event);

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.cpp
@@ -41,7 +41,8 @@ void CGUIEPGGridContainerModel::SetInvalid()
 
 std::shared_ptr<CFileItem> CGUIEPGGridContainerModel::CreateGapItem(int iChannel) const
 {
-  const std::shared_ptr<CPVRChannel> channel = m_channelItems[iChannel]->GetPVRChannelInfoTag();
+  const std::shared_ptr<const CPVRChannel> channel =
+      m_channelItems[iChannel]->GetPVRChannelInfoTag();
   const std::shared_ptr<CPVREpgInfoTag> gapTag = channel->CreateEPGGapTag(m_gridStart, m_gridEnd);
   return std::make_shared<CFileItem>(gapTag);
 }
@@ -244,7 +245,7 @@ std::shared_ptr<CFileItem> CGUIEPGGridContainerModel::GetEpgTagsBefore(EpgTags& 
       // ptr comp does not work for gap tags!
       // if ((*it) == epgTags.tags.front()->GetEPGInfoTag())
 
-      const std::shared_ptr<CPVREpgInfoTag> t = epgTags.tags.front()->GetEPGInfoTag();
+      const std::shared_ptr<const CPVREpgInfoTag> t = epgTags.tags.front()->GetEPGInfoTag();
       if ((*it)->StartAsUTC() == t->StartAsUTC() && (*it)->EndAsUTC() == t->EndAsUTC())
       {
         if (!result && IsEventMemberOfBlock(*it, iBlock))
@@ -306,7 +307,7 @@ std::shared_ptr<CFileItem> CGUIEPGGridContainerModel::GetEpgTagsAfter(EpgTags& e
       // ptr comp does not work for gap tags!
       // if ((*it) == epgTags.tags.back()->GetEPGInfoTag())
 
-      const std::shared_ptr<CPVREpgInfoTag> t = epgTags.tags.back()->GetEPGInfoTag();
+      const std::shared_ptr<const CPVREpgInfoTag> t = epgTags.tags.back()->GetEPGInfoTag();
       if ((*it)->StartAsUTC() == t->StartAsUTC() && (*it)->EndAsUTC() == t->EndAsUTC())
       {
         if (!result && IsEventMemberOfBlock(*it, iBlock))
@@ -373,10 +374,10 @@ void CGUIEPGGridContainerModel::FindChannelAndBlockIndex(int channelUid,
       newChannelIndex = iCurrentChannel;
 
       // find the new block index
-      const std::shared_ptr<CPVREpg> epg = channel->GetPVRChannelInfoTag()->GetEPG();
+      const std::shared_ptr<const CPVREpg> epg = channel->GetPVRChannelInfoTag()->GetEPG();
       if (epg)
       {
-        const std::shared_ptr<CPVREpgInfoTag> tag = epg->GetTagByBroadcastId(broadcastUid);
+        const std::shared_ptr<const CPVREpgInfoTag> tag = epg->GetTagByBroadcastId(broadcastUid);
         if (tag)
           newBlockIndex = GetFirstEventBlock(tag) + eventOffset;
       }
@@ -405,7 +406,7 @@ GridItem* CGUIEPGGridContainerModel::GetGridItemPtr(int iChannel, int iBlock) co
       return nullptr;
     }
 
-    const std::shared_ptr<CPVREpgInfoTag> epgTag = item->GetEPGInfoTag();
+    const std::shared_ptr<const CPVREpgInfoTag> epgTag = item->GetEPGInfoTag();
 
     const int startBlock = GetFirstEventBlock(epgTag);
     const int endBlock = GetLastEventBlock(epgTag);

--- a/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainerModel.h
@@ -105,9 +105,9 @@ public:
 
   CDateTime GetStartTimeForBlock(int block) const;
   int GetBlock(const CDateTime& datetime) const;
-  int GetFirstEventBlock(const std::shared_ptr<CPVREpgInfoTag>& event) const;
-  int GetLastEventBlock(const std::shared_ptr<CPVREpgInfoTag>& event) const;
-  bool IsEventMemberOfBlock(const std::shared_ptr<CPVREpgInfoTag>& event, int iBlock) const;
+  int GetFirstEventBlock(const std::shared_ptr<const CPVREpgInfoTag>& event) const;
+  int GetLastEventBlock(const std::shared_ptr<const CPVREpgInfoTag>& event) const;
+  bool IsEventMemberOfBlock(const std::shared_ptr<const CPVREpgInfoTag>& event, int iBlock) const;
 
   std::unique_ptr<CFileItemList> GetCurrentTimeLineItems(int firstChannel, int numChannels) const;
 

--- a/xbmc/pvr/guilib/PVRGUIActionListener.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionListener.cpp
@@ -283,9 +283,9 @@ bool CPVRGUIActionListener::OnAction(const CAction& action)
       int iChannelNumber = static_cast<int>(action.GetAmount(0));
       int iSubChannelNumber = static_cast<int>(action.GetAmount(1));
 
-      const std::shared_ptr<CPVRPlaybackState> playbackState =
+      const std::shared_ptr<const CPVRPlaybackState> playbackState =
           CServiceBroker::GetPVRManager().PlaybackState();
-      const std::shared_ptr<CPVRChannelGroup> activeGroup =
+      const std::shared_ptr<const CPVRChannelGroup> activeGroup =
           playbackState->GetActiveChannelGroup(playbackState->IsPlayingRadio());
       const std::shared_ptr<CPVRChannelGroupMember> groupMember =
           activeGroup->GetByChannelNumber(CPVRChannelNumber(iChannelNumber, iSubChannelNumber));

--- a/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
@@ -326,7 +326,7 @@ bool CPVRGUIActionsChannels::StartChannelScan(int clientId)
 }
 
 std::shared_ptr<CPVRChannelGroupMember> CPVRGUIActionsChannels::GetChannelGroupMember(
-    const std::shared_ptr<CPVRChannel>& channel) const
+    const std::shared_ptr<const CPVRChannel>& channel) const
 {
   if (!channel)
     return {};

--- a/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
@@ -60,10 +60,11 @@ void CPVRChannelSwitchingInputHandler::AppendChannelNumberCharacter(char cCharac
 void CPVRChannelSwitchingInputHandler::GetChannelNumbers(std::vector<std::string>& channelNumbers)
 {
   const CPVRManager& pvrMgr = CServiceBroker::GetPVRManager();
-  const std::shared_ptr<CPVRChannel> playingChannel = pvrMgr.PlaybackState()->GetPlayingChannel();
+  const std::shared_ptr<const CPVRChannel> playingChannel =
+      pvrMgr.PlaybackState()->GetPlayingChannel();
   if (playingChannel)
   {
-    const std::shared_ptr<CPVRChannelGroup> group =
+    const std::shared_ptr<const CPVRChannelGroup> group =
         pvrMgr.ChannelGroups()->GetGroupAll(playingChannel->IsRadio());
     if (group)
       group->GetChannelNumbers(channelNumbers);
@@ -83,7 +84,7 @@ void UpdateActiveGroup(const std::shared_ptr<CPVRChannelGroupMember>& newChannel
 {
   const std::shared_ptr<CPVRPlaybackState> playbackState{
       CServiceBroker::GetPVRManager().PlaybackState()};
-  const std::shared_ptr<CPVRChannelGroupsContainer> groups{
+  const std::shared_ptr<const CPVRChannelGroupsContainer> groups{
       CServiceBroker::GetPVRManager().ChannelGroups()};
   const std::shared_ptr<CPVRChannelGroup> group{
       groups->Get(newChannel->IsRadio())->GetById(newChannel->GroupID())};
@@ -107,12 +108,12 @@ void CPVRChannelSwitchingInputHandler::SwitchToChannel(const CPVRChannelNumber& 
 {
   if (channelNumber.IsValid() && CServiceBroker::GetPVRManager().PlaybackState()->IsPlaying())
   {
-    const std::shared_ptr<CPVRChannel> playingChannel =
+    const std::shared_ptr<const CPVRChannel> playingChannel =
         CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel();
     if (playingChannel)
     {
       bool bRadio = playingChannel->IsRadio();
-      const std::shared_ptr<CPVRChannelGroup> group =
+      const std::shared_ptr<const CPVRChannelGroup> group =
           CServiceBroker::GetPVRManager().PlaybackState()->GetActiveChannelGroup(bRadio);
 
       if (channelNumber != group->GetChannelNumber(playingChannel))
@@ -151,11 +152,11 @@ void CPVRChannelSwitchingInputHandler::SwitchToChannel(const CPVRChannelNumber& 
 
 void CPVRChannelSwitchingInputHandler::SwitchToPreviousChannel()
 {
-  const std::shared_ptr<CPVRPlaybackState> playbackState =
+  const std::shared_ptr<const CPVRPlaybackState> playbackState =
       CServiceBroker::GetPVRManager().PlaybackState();
   if (playbackState->IsPlaying())
   {
-    const std::shared_ptr<CPVRChannel> playingChannel = playbackState->GetPlayingChannel();
+    const std::shared_ptr<const CPVRChannel> playingChannel = playbackState->GetPlayingChannel();
     if (playingChannel)
     {
       const std::shared_ptr<CPVRChannelGroupMember> groupMember =
@@ -344,7 +345,7 @@ std::shared_ptr<CPVRChannelGroupMember> CPVRGUIActionsChannels::GetChannelGroupM
 
   if (std::find(windowIDs.cbegin(), windowIDs.cend(), activeWindowID) == windowIDs.cend())
   {
-    const std::shared_ptr<CPVRChannelGroup> group =
+    const std::shared_ptr<const CPVRChannelGroup> group =
         CServiceBroker::GetPVRManager().PlaybackState()->GetActiveChannelGroup(channel->IsRadio());
     if (group)
       groupMember = group->GetByUniqueID(channel->StorageId());
@@ -353,7 +354,7 @@ std::shared_ptr<CPVRChannelGroupMember> CPVRGUIActionsChannels::GetChannelGroupM
   // as fallback, obtain the member from the 'all channels' group
   if (!groupMember)
   {
-    const std::shared_ptr<CPVRChannelGroup> group =
+    const std::shared_ptr<const CPVRChannelGroup> group =
         CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAll(channel->IsRadio());
     if (group)
       groupMember = group->GetByUniqueID(channel->StorageId());
@@ -425,15 +426,16 @@ std::string CPVRGUIActionsChannels::GetSelectedChannelPath(bool bRadio) const
     CPVRManager& mgr = CServiceBroker::GetPVRManager();
 
     // if preselect playing channel is activated, return the path of the playing channel, if any.
-    const std::shared_ptr<CPVRChannelGroupMember> playingChannel =
+    const std::shared_ptr<const CPVRChannelGroupMember> playingChannel =
         mgr.PlaybackState()->GetPlayingChannelGroupMember();
     if (playingChannel && playingChannel->IsRadio() == bRadio)
       return GetChannelGroupMember(playingChannel->Channel())->Path();
 
-    const std::shared_ptr<CPVREpgInfoTag> playingTag = mgr.PlaybackState()->GetPlayingEpgTag();
+    const std::shared_ptr<const CPVREpgInfoTag> playingTag =
+        mgr.PlaybackState()->GetPlayingEpgTag();
     if (playingTag && playingTag->IsRadio() == bRadio)
     {
-      const std::shared_ptr<CPVRChannel> channel =
+      const std::shared_ptr<const CPVRChannel> channel =
           mgr.ChannelGroups()->GetChannelForEpgTag(playingTag);
       if (channel)
         return GetChannelGroupMember(channel)->Path();

--- a/xbmc/pvr/guilib/PVRGUIActionsChannels.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsChannels.h
@@ -108,7 +108,7 @@ public:
    * @return the group member or nullptr if not found.
    */
   std::shared_ptr<CPVRChannelGroupMember> GetChannelGroupMember(
-      const std::shared_ptr<CPVRChannel>& channel) const;
+      const std::shared_ptr<const CPVRChannel>& channel) const;
 
   /*!
    * @brief Get a channel group member for the given item, either from the currently active group

--- a/xbmc/pvr/guilib/PVRGUIActionsEPG.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsEPG.cpp
@@ -55,7 +55,7 @@ PVR::CGUIWindowPVRSearchBase* GetSearchWindow(bool bRadio)
 
 bool CPVRGUIActionsEPG::ShowEPGInfo(const CFileItem& item) const
 {
-  const std::shared_ptr<CPVRChannel> channel(CPVRItem(item).GetChannel());
+  const std::shared_ptr<const CPVRChannel> channel(CPVRItem(item).GetChannel());
   if (channel && CServiceBroker::GetPVRManager().Get<PVR::GUI::Parental>().CheckParentalLock(
                      channel) != ParentalCheckResult::SUCCESS)
     return false;
@@ -83,7 +83,7 @@ bool CPVRGUIActionsEPG::ShowEPGInfo(const CFileItem& item) const
 
 bool CPVRGUIActionsEPG::ShowChannelEPG(const CFileItem& item) const
 {
-  const std::shared_ptr<CPVRChannel> channel(CPVRItem(item).GetChannel());
+  const std::shared_ptr<const CPVRChannel> channel(CPVRItem(item).GetChannel());
   if (channel && CServiceBroker::GetPVRManager().Get<PVR::GUI::Parental>().CheckParentalLock(
                      channel) != ParentalCheckResult::SUCCESS)
     return false;

--- a/xbmc/pvr/guilib/PVRGUIActionsParentalControl.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsParentalControl.cpp
@@ -30,7 +30,7 @@ CPVRGUIActionsParentalControl::CPVRGUIActionsParentalControl()
 }
 
 ParentalCheckResult CPVRGUIActionsParentalControl::CheckParentalLock(
-    const std::shared_ptr<CPVRChannel>& channel) const
+    const std::shared_ptr<const CPVRChannel>& channel) const
 {
   if (!CServiceBroker::GetPVRManager().IsParentalLocked(channel))
     return ParentalCheckResult::SUCCESS;

--- a/xbmc/pvr/guilib/PVRGUIActionsParentalControl.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsParentalControl.h
@@ -35,7 +35,7 @@ public:
    * @param channel The channel to do the check for.
    * @return the result of the check (success, failed, or canceled by user).
    */
-  ParentalCheckResult CheckParentalLock(const std::shared_ptr<CPVRChannel>& channel) const;
+  ParentalCheckResult CheckParentalLock(const std::shared_ptr<const CPVRChannel>& channel) const;
 
   /*!
    * @brief Open Numeric dialog to check for parental PIN.

--- a/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
@@ -288,7 +288,7 @@ bool CPVRGUIActionsPlayback::SwitchToChannel(const CFileItem& item, bool bCheckR
     return false;
 
   std::shared_ptr<CPVRRecording> recording;
-  const std::shared_ptr<CPVRChannel> channel(CPVRItem(item).GetChannel());
+  const std::shared_ptr<const CPVRChannel> channel(CPVRItem(item).GetChannel());
   if (channel)
   {
     bool bSwitchToFullscreen =

--- a/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
@@ -113,7 +113,7 @@ void CPVRGUIActionsPlayback::StartPlayback(CFileItem* item,
                                            const CPVRStreamProperties* epgProps) const
 {
   // Obtain dynamic playback url and properties from the respective pvr client
-  const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(*item);
+  const std::shared_ptr<const CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(*item);
   if (client)
   {
     CPVRStreamProperties props;
@@ -255,7 +255,7 @@ bool CPVRGUIActionsPlayback::PlayEpgTag(const CFileItem& item) const
   }
 
   // Obtain dynamic playback url and properties from the respective pvr client
-  const std::shared_ptr<CPVRClient> client =
+  const std::shared_ptr<const CPVRClient> client =
       CServiceBroker::GetPVRManager().GetClient(epgTag->ClientID());
   if (!client)
     return false;

--- a/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
@@ -405,7 +405,7 @@ bool CPVRGUIActionsPlayback::SwitchToChannel(PlaybackType type) const
       if (CServiceBroker::GetPVRManager().PlaybackState()->IsPlayingTV())
         return true;
 
-      const std::shared_ptr<CPVRChannelGroup> allGroup =
+      const std::shared_ptr<const CPVRChannelGroup> allGroup =
           CServiceBroker::GetPVRManager().ChannelGroups()->GetGroupAllTV();
       if (allGroup)
         groupMember = allGroup->GetLastPlayedChannelGroupMember();
@@ -429,7 +429,7 @@ bool CPVRGUIActionsPlayback::SwitchToChannel(PlaybackType type) const
   else
   {
     // if we don't, find the active channel group of the demanded type and play it's first channel
-    const std::shared_ptr<CPVRChannelGroup> channelGroup =
+    const std::shared_ptr<const CPVRChannelGroup> channelGroup =
         CServiceBroker::GetPVRManager().PlaybackState()->GetActiveChannelGroup(bIsRadio);
     if (channelGroup)
     {
@@ -473,7 +473,7 @@ bool CPVRGUIActionsPlayback::PlayChannelOnStartup() const
 
   if (!groupMember)
   {
-    const std::shared_ptr<CPVRChannelGroup> group =
+    const std::shared_ptr<const CPVRChannelGroup> group =
         CServiceBroker::GetPVRManager().ChannelGroups()->Get(playRadio)->GetGroupAll();
     auto channels = group->GetMembers();
     if (channels.empty())
@@ -531,7 +531,7 @@ void CPVRGUIActionsPlayback::SeekForward()
   time_t playbackStartTime = CServiceBroker::GetDataCacheCore().GetStartTime();
   if (playbackStartTime > 0)
   {
-    const std::shared_ptr<CPVRChannel> playingChannel =
+    const std::shared_ptr<const CPVRChannel> playingChannel =
         CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel();
     if (playingChannel)
     {
@@ -569,7 +569,7 @@ void CPVRGUIActionsPlayback::SeekBackward(unsigned int iThreshold)
   time_t playbackStartTime = CServiceBroker::GetDataCacheCore().GetStartTime();
   if (playbackStartTime > 0)
   {
-    const std::shared_ptr<CPVRChannel> playingChannel =
+    const std::shared_ptr<const CPVRChannel> playingChannel =
         CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel();
     if (playingChannel)
     {

--- a/xbmc/pvr/guilib/PVRGUIActionsPowerManagement.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsPowerManagement.cpp
@@ -166,7 +166,7 @@ bool CPVRGUIActionsPowerManagement::AllLocalBackendsIdle(
 bool CPVRGUIActionsPowerManagement::EventOccursOnLocalBackend(
     const std::shared_ptr<CPVRTimerInfoTag>& event) const
 {
-  const std::shared_ptr<CPVRClient> client =
+  const std::shared_ptr<const CPVRClient> client =
       CServiceBroker::GetPVRManager().GetClient(CFileItem(event));
   if (client)
   {

--- a/xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
@@ -159,7 +159,7 @@ private:
     const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(*item);
     if (client)
     {
-      const std::shared_ptr<CPVRRecording> recording = item->GetPVRRecordingInfoTag();
+      const std::shared_ptr<const CPVRRecording> recording = item->GetPVRRecordingInfoTag();
       return client->SetRecordingPlayCount(*recording, recording->GetLocalPlayCount()) ==
              PVR_ERROR_NO_ERROR;
     }

--- a/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
@@ -371,7 +371,7 @@ bool CPVRGUIActionsTimers::SetRecordingOnChannel(const std::shared_ptr<CPVRChann
       ParentalCheckResult::SUCCESS)
     return bReturn;
 
-  const std::shared_ptr<CPVRClient> client =
+  const std::shared_ptr<const CPVRClient> client =
       CServiceBroker::GetPVRManager().GetClient(channel->ClientID());
   if (client && client->GetClientCapabilities().SupportsTimers())
   {
@@ -749,7 +749,7 @@ bool CPVRGUIActionsTimers::ConfirmDeleteTimer(const std::shared_ptr<const CPVRTi
                                               bool& bDeleteRule) const
 {
   bool bConfirmed(false);
-  const std::shared_ptr<CPVRTimerInfoTag> parentTimer(
+  const std::shared_ptr<const CPVRTimerInfoTag> parentTimer(
       CServiceBroker::GetPVRManager().Timers()->GetTimerRule(timer));
 
   if (parentTimer && parentTimer->GetTimerType()->AllowsDelete())
@@ -827,7 +827,7 @@ void AddEventLogEntry(const std::shared_ptr<const CPVRTimerInfoTag>& timer, int 
   std::string name;
   std::string icon;
 
-  const std::shared_ptr<CPVRClient> client =
+  const std::shared_ptr<const CPVRClient> client =
       CServiceBroker::GetPVRManager().GetClient(timer->GetTimerType()->GetClientId());
   if (client)
   {
@@ -884,7 +884,7 @@ void CPVRGUIActionsTimers::AnnounceReminder(const std::shared_ptr<CPVRTimerInfoT
   std::string text = GetAnnouncerText(timer, 19307, 19308); // Reminder for ...
 
   bool bCanRecord = false;
-  const std::shared_ptr<CPVRClient> client =
+  const std::shared_ptr<const CPVRClient> client =
       CServiceBroker::GetPVRManager().GetClient(timer->ClientID());
   if (client && client->GetClientCapabilities().SupportsTimers())
   {

--- a/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
@@ -534,7 +534,7 @@ bool CPVRGUIActionsTimers::ToggleTimer(const CFileItem& item) const
   if (!item.HasEPGInfoTag())
     return false;
 
-  const std::shared_ptr<CPVRTimerInfoTag> timer(CPVRItem(item).GetTimerInfoTag());
+  const std::shared_ptr<const CPVRTimerInfoTag> timer(CPVRItem(item).GetTimerInfoTag());
   if (timer)
   {
     if (timer->IsRecording())
@@ -654,7 +654,7 @@ bool CPVRGUIActionsTimers::DeleteTimer(const CFileItem& item,
                                        bool bDeleteRule) const
 {
   std::shared_ptr<CPVRTimerInfoTag> timer;
-  const std::shared_ptr<CPVRRecording> recording(CPVRItem(item).GetRecording());
+  const std::shared_ptr<const CPVRRecording> recording(CPVRItem(item).GetRecording());
   if (recording)
     timer = recording->GetRecordingTimer();
 
@@ -745,7 +745,7 @@ bool CPVRGUIActionsTimers::DeleteTimer(const std::shared_ptr<CPVRTimerInfoTag>& 
   return false;
 }
 
-bool CPVRGUIActionsTimers::ConfirmDeleteTimer(const std::shared_ptr<CPVRTimerInfoTag>& timer,
+bool CPVRGUIActionsTimers::ConfirmDeleteTimer(const std::shared_ptr<const CPVRTimerInfoTag>& timer,
                                               bool& bDeleteRule) const
 {
   bool bConfirmed(false);
@@ -792,7 +792,7 @@ bool CPVRGUIActionsTimers::StopRecording(const CFileItem& item) const
 }
 
 bool CPVRGUIActionsTimers::ConfirmStopRecording(
-    const std::shared_ptr<CPVRTimerInfoTag>& timer) const
+    const std::shared_ptr<const CPVRTimerInfoTag>& timer) const
 {
   return CGUIDialogYesNo::ShowAndGetInput(
       CVariant{847}, // "Confirm stop recording"
@@ -802,7 +802,9 @@ bool CPVRGUIActionsTimers::ConfirmStopRecording(
 
 namespace
 {
-std::string GetAnnouncerText(const std::shared_ptr<CPVRTimerInfoTag>& timer, int idEpg, int idNoEpg)
+std::string GetAnnouncerText(const std::shared_ptr<const CPVRTimerInfoTag>& timer,
+                             int idEpg,
+                             int idNoEpg)
 {
   std::string text;
   if (timer->IsEpgBased())
@@ -820,7 +822,7 @@ std::string GetAnnouncerText(const std::shared_ptr<CPVRTimerInfoTag>& timer, int
   return text;
 }
 
-void AddEventLogEntry(const std::shared_ptr<CPVRTimerInfoTag>& timer, int idEpg, int idNoEpg)
+void AddEventLogEntry(const std::shared_ptr<const CPVRTimerInfoTag>& timer, int idEpg, int idNoEpg)
 {
   std::string name;
   std::string icon;

--- a/xbmc/pvr/guilib/PVRGUIActionsTimers.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsTimers.h
@@ -206,14 +206,15 @@ private:
    * timer. out, for one shot timer not scheduled by a timer rule: ignored
    * @return true, to proceed with delete, false otherwise.
    */
-  bool ConfirmDeleteTimer(const std::shared_ptr<CPVRTimerInfoTag>& timer, bool& bDeleteRule) const;
+  bool ConfirmDeleteTimer(const std::shared_ptr<const CPVRTimerInfoTag>& timer,
+                          bool& bDeleteRule) const;
 
   /*!
    * @brief Open a dialog to confirm stop recording.
    * @param timer the recording to stop (actually the timer to delete).
    * @return true, to proceed with delete, false otherwise.
    */
-  bool ConfirmStopRecording(const std::shared_ptr<CPVRTimerInfoTag>& timer) const;
+  bool ConfirmStopRecording(const std::shared_ptr<const CPVRTimerInfoTag>& timer) const;
 
   /*!
    * @brief Announce and process a reminder timer.

--- a/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
+++ b/xbmc/pvr/guilib/PVRGUIChannelNavigator.cpp
@@ -183,7 +183,7 @@ std::shared_ptr<CPVRChannelGroupMember> CPVRGUIChannelNavigator::GetNextOrPrevCh
 
   if (bPlayingTV || bPlayingRadio)
   {
-    const std::shared_ptr<CPVRChannelGroup> group =
+    const std::shared_ptr<const CPVRChannelGroup> group =
         CServiceBroker::GetPVRManager().PlaybackState()->GetActiveChannelGroup(bPlayingRadio);
     if (group)
     {

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -233,7 +233,7 @@ void CPVRGUIInfo::UpdateQualityData()
           CSettings::SETTING_PVRPLAYBACK_SIGNALQUALITY))
     return;
 
-  const std::shared_ptr<CPVRPlaybackState> playbackState =
+  const std::shared_ptr<const CPVRPlaybackState> playbackState =
       CServiceBroker::GetPVRManager().PlaybackState();
   if (!playbackState)
     return;
@@ -257,7 +257,7 @@ void CPVRGUIInfo::UpdateQualityData()
 
 void CPVRGUIInfo::UpdateDescrambleData()
 {
-  const std::shared_ptr<CPVRPlaybackState> playbackState =
+  const std::shared_ptr<const CPVRPlaybackState> playbackState =
       CServiceBroker::GetPVRManager().PlaybackState();
   if (!playbackState)
     return;
@@ -268,7 +268,7 @@ void CPVRGUIInfo::UpdateDescrambleData()
   const int channelUid = playbackState->GetPlayingChannelUniqueID();
   if (channelUid > 0)
   {
-    const std::shared_ptr<CPVRClient> client =
+    const std::shared_ptr<const CPVRClient> client =
         CServiceBroker::GetPVRManager().Clients()->GetCreatedClient(
             playbackState->GetPlayingClientID());
     if (client)
@@ -283,7 +283,7 @@ void CPVRGUIInfo::UpdateMisc()
 {
   const CPVRManager& mgr = CServiceBroker::GetPVRManager();
   bool bStarted = mgr.IsStarted();
-  const std::shared_ptr<CPVRPlaybackState> state = mgr.PlaybackState();
+  const std::shared_ptr<const CPVRPlaybackState> state = mgr.PlaybackState();
 
   /* safe to fetch these unlocked, since they're updated from the same thread as this one */
   const std::string strPlayingClientName = bStarted ? state->GetPlayingClientName() : "";
@@ -383,7 +383,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
                                             const CGUIInfo& info,
                                             std::string& strValue) const
 {
-  const std::shared_ptr<CPVRTimerInfoTag> timer = item->GetPVRTimerInfoTag();
+  const std::shared_ptr<const CPVRTimerInfoTag> timer = item->GetPVRTimerInfoTag();
   if (timer)
   {
     switch (info.m_info)
@@ -444,7 +444,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
     }
   }
 
-  const std::shared_ptr<CPVRRecording> recording(item->GetPVRRecordingInfoTag());
+  const std::shared_ptr<const CPVRRecording> recording(item->GetPVRRecordingInfoTag());
   if (recording)
   {
     // Note: CPVRRecoding is derived from CVideoInfoTag. All base class properties will be handled
@@ -508,7 +508,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
       case VIDEOPLAYER_CHANNEL_NUMBER:
       case LISTITEM_CHANNEL_NUMBER:
       {
-        const std::shared_ptr<CPVRChannelGroupMember> groupMember =
+        const std::shared_ptr<const CPVRChannelGroupMember> groupMember =
             CServiceBroker::GetPVRManager().Get<PVR::GUI::Channels>().GetChannelGroupMember(*item);
         if (groupMember)
         {
@@ -562,7 +562,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
     return false;
   }
 
-  const std::shared_ptr<CPVREpgSearchFilter> filter = item->GetEPGSearchFilter();
+  const std::shared_ptr<const CPVREpgSearchFilter> filter = item->GetEPGSearchFilter();
   if (filter)
   {
     switch (info.m_info)
@@ -788,7 +788,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
     {
       case MUSICPLAYER_CHANNEL_NAME:
       {
-        const std::shared_ptr<CPVRRadioRDSInfoTag> rdsTag = channel->GetRadioRDSInfoTag();
+        const std::shared_ptr<const CPVRRadioRDSInfoTag> rdsTag = channel->GetRadioRDSInfoTag();
         if (rdsTag)
         {
           strValue = rdsTag->GetProgStation();
@@ -1070,7 +1070,7 @@ bool CPVRGUIInfo::GetRadioRDSLabel(const CFileItem* item,
   if (!item->HasPVRChannelInfoTag())
     return false;
 
-  const std::shared_ptr<CPVRRadioRDSInfoTag> tag =
+  const std::shared_ptr<const CPVRRadioRDSInfoTag> tag =
       item->GetPVRChannelInfoTag()->GetRadioRDSInfoTag();
   if (tag)
   {
@@ -1491,7 +1491,8 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item,
       }
       else if (item->IsPVRChannel())
       {
-        const std::shared_ptr<CPVREpgInfoTag> epgNow = item->GetPVRChannelInfoTag()->GetEPGNow();
+        const std::shared_ptr<const CPVREpgInfoTag> epgNow =
+            item->GetPVRChannelInfoTag()->GetEPGNow();
         bValue = epgNow ? epgNow->IsNew() : false;
         return true;
       }
@@ -1514,7 +1515,8 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item,
       }
       else if (item->IsPVRChannel())
       {
-        const std::shared_ptr<CPVREpgInfoTag> epgNow = item->GetPVRChannelInfoTag()->GetEPGNow();
+        const std::shared_ptr<const CPVREpgInfoTag> epgNow =
+            item->GetPVRChannelInfoTag()->GetEPGNow();
         bValue = epgNow ? epgNow->IsPremiere() : false;
         return true;
       }
@@ -1537,7 +1539,8 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item,
       }
       else if (item->IsPVRChannel())
       {
-        const std::shared_ptr<CPVREpgInfoTag> epgNow = item->GetPVRChannelInfoTag()->GetEPGNow();
+        const std::shared_ptr<const CPVREpgInfoTag> epgNow =
+            item->GetPVRChannelInfoTag()->GetEPGNow();
         bValue = epgNow ? epgNow->IsFinale() : false;
         return true;
       }
@@ -1560,7 +1563,8 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item,
       }
       else if (item->IsPVRChannel())
       {
-        const std::shared_ptr<CPVREpgInfoTag> epgNow = item->GetPVRChannelInfoTag()->GetEPGNow();
+        const std::shared_ptr<const CPVREpgInfoTag> epgNow =
+            item->GetPVRChannelInfoTag()->GetEPGNow();
         bValue = epgNow ? epgNow->IsLive() : false;
         return true;
       }
@@ -1568,11 +1572,11 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item,
     case LISTITEM_ISPLAYING:
       if (item->IsPVRChannel())
       {
-        const std::shared_ptr<CPVRChannel> playingChannel{
+        const std::shared_ptr<const CPVRChannel> playingChannel{
             CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel()};
         if (playingChannel)
         {
-          const std::shared_ptr<CPVRChannel> channel{item->GetPVRChannelInfoTag()};
+          const std::shared_ptr<const CPVRChannel> channel{item->GetPVRChannelInfoTag()};
           bValue = (channel->StorageId() == playingChannel->StorageId());
           return true;
         }
@@ -1603,10 +1607,10 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item,
     case VIDEOPLAYER_CAN_RESUME_LIVE_TV:
       if (item->IsPVRRecording())
       {
-        const std::shared_ptr<CPVRRecording> recording = item->GetPVRRecordingInfoTag();
-        const std::shared_ptr<CPVREpg> epg =
+        const std::shared_ptr<const CPVRRecording> recording = item->GetPVRRecordingInfoTag();
+        const std::shared_ptr<const CPVREpg> epg =
             recording->Channel() ? recording->Channel()->GetEPG() : nullptr;
-        const std::shared_ptr<CPVREpgInfoTag> epgTag =
+        const std::shared_ptr<const CPVREpgInfoTag> epgTag =
             CServiceBroker::GetPVRManager().EpgContainer().GetTagById(epg,
                                                                       recording->BroadcastUid());
         bValue = (epgTag && epgTag->IsActive());
@@ -1708,7 +1712,7 @@ bool CPVRGUIInfo::GetRadioRDSBool(const CFileItem* item, const CGUIInfo& info, b
   if (!item->HasPVRChannelInfoTag())
     return false;
 
-  const std::shared_ptr<CPVRRadioRDSInfoTag> tag =
+  const std::shared_ptr<const CPVRRadioRDSInfoTag> tag =
       item->GetPVRChannelInfoTag()->GetRadioRDSInfoTag();
   if (tag)
   {
@@ -1885,7 +1889,7 @@ void CPVRGUIInfo::CharInfoEncryption(std::string& strValue) const
   }
   else
   {
-    const std::shared_ptr<CPVRChannel> channel =
+    const std::shared_ptr<const CPVRChannel> channel =
         CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel();
     if (channel)
     {

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -360,7 +360,7 @@ std::string GetAsLocalizedDateTimeString(const CDateTime& datetime)
   return datetime.IsValid() ? datetime.GetAsLocalizedDateTime(false, false) : "";
 }
 
-std::string GetEpgTagTitle(const std::shared_ptr<CPVREpgInfoTag>& epgTag)
+std::string GetEpgTagTitle(const std::shared_ptr<const CPVREpgInfoTag>& epgTag)
 {
   if (epgTag)
   {
@@ -580,8 +580,8 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
     return false;
   }
 
-  std::shared_ptr<CPVREpgInfoTag> epgTag;
-  std::shared_ptr<CPVRChannel> channel;
+  std::shared_ptr<const CPVREpgInfoTag> epgTag;
+  std::shared_ptr<const CPVRChannel> channel;
   if (item->IsPVRChannel() || item->IsEPG() || item->IsPVRTimer())
   {
     CPVRItem pvrItem(item);
@@ -841,7 +841,7 @@ bool CPVRGUIInfo::GetPVRLabel(const CFileItem* item,
   {
     case PVR_EPG_EVENT_ICON:
     {
-      const std::shared_ptr<CPVREpgInfoTag> epgTag =
+      const std::shared_ptr<const CPVREpgInfoTag> epgTag =
           (item->IsPVRChannel() || item->IsEPG()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
       if (epgTag)
       {
@@ -851,14 +851,14 @@ bool CPVRGUIInfo::GetPVRLabel(const CFileItem* item,
     }
     case PVR_EPG_EVENT_DURATION:
     {
-      const std::shared_ptr<CPVREpgInfoTag> epgTag =
+      const std::shared_ptr<const CPVREpgInfoTag> epgTag =
           (item->IsPVRChannel() || item->IsEPG()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
       strValue = m_timesInfo.GetEpgEventDuration(epgTag, static_cast<TIME_FORMAT>(info.GetData1()));
       return true;
     }
     case PVR_EPG_EVENT_ELAPSED_TIME:
     {
-      const std::shared_ptr<CPVREpgInfoTag> epgTag =
+      const std::shared_ptr<const CPVREpgInfoTag> epgTag =
           (item->IsPVRChannel() || item->IsEPG()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
       strValue =
           m_timesInfo.GetEpgEventElapsedTime(epgTag, static_cast<TIME_FORMAT>(info.GetData1()));
@@ -866,7 +866,7 @@ bool CPVRGUIInfo::GetPVRLabel(const CFileItem* item,
     }
     case PVR_EPG_EVENT_REMAINING_TIME:
     {
-      const std::shared_ptr<CPVREpgInfoTag> epgTag =
+      const std::shared_ptr<const CPVREpgInfoTag> epgTag =
           (item->IsPVRChannel() || item->IsEPG()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
       strValue =
           m_timesInfo.GetEpgEventRemainingTime(epgTag, static_cast<TIME_FORMAT>(info.GetData1()));
@@ -874,7 +874,7 @@ bool CPVRGUIInfo::GetPVRLabel(const CFileItem* item,
     }
     case PVR_EPG_EVENT_FINISH_TIME:
     {
-      const std::shared_ptr<CPVREpgInfoTag> epgTag =
+      const std::shared_ptr<const CPVREpgInfoTag> epgTag =
           (item->IsPVRChannel() || item->IsEPG()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
       strValue =
           m_timesInfo.GetEpgEventFinishTime(epgTag, static_cast<TIME_FORMAT>(info.GetData1()));
@@ -1250,7 +1250,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerInt(const CFileItem* item,
     case LISTITEM_PROGRESS:
       if (item->IsPVRChannel() || item->IsEPG())
       {
-        const std::shared_ptr<CPVREpgInfoTag> epgTag = CPVRItem(item).GetEpgInfoTag();
+        const std::shared_ptr<const CPVREpgInfoTag> epgTag = CPVRItem(item).GetEpgInfoTag();
         if (epgTag)
           iValue = static_cast<int>(epgTag->ProgressPercentage());
       }
@@ -1267,14 +1267,14 @@ bool CPVRGUIInfo::GetPVRInt(const CFileItem* item, const CGUIInfo& info, int& iV
   {
     case PVR_EPG_EVENT_DURATION:
     {
-      const std::shared_ptr<CPVREpgInfoTag> epgTag =
+      const std::shared_ptr<const CPVREpgInfoTag> epgTag =
           (item->IsPVRChannel() || item->IsEPG()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
       iValue = m_timesInfo.GetEpgEventDuration(epgTag);
       return true;
     }
     case PVR_EPG_EVENT_PROGRESS:
     {
-      const std::shared_ptr<CPVREpgInfoTag> epgTag =
+      const std::shared_ptr<const CPVREpgInfoTag> epgTag =
           (item->IsPVRChannel() || item->IsEPG()) ? CPVRItem(item).GetEpgInfoTag() : nullptr;
       iValue = m_timesInfo.GetEpgEventProgress(epgTag);
       return true;
@@ -1361,7 +1361,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item,
       }
       else if (item->IsEPG() || item->IsPVRTimer())
       {
-        const std::shared_ptr<CPVRTimerInfoTag> timer = CPVRItem(item).GetTimerInfoTag();
+        const std::shared_ptr<const CPVRTimerInfoTag> timer = CPVRItem(item).GetTimerInfoTag();
         if (timer)
           bValue = timer->IsRecording();
         return true;
@@ -1375,7 +1375,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item,
     case LISTITEM_INPROGRESS:
       if (item->IsPVRChannel() || item->IsEPG())
       {
-        const std::shared_ptr<CPVREpgInfoTag> epgTag = CPVRItem(item).GetEpgInfoTag();
+        const std::shared_ptr<const CPVREpgInfoTag> epgTag = CPVRItem(item).GetEpgInfoTag();
         if (epgTag)
           bValue = epgTag->IsActive();
         return true;
@@ -1384,7 +1384,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item,
     case LISTITEM_HASTIMER:
       if (item->IsPVRChannel() || item->IsEPG() || item->IsPVRTimer())
       {
-        const std::shared_ptr<CPVRTimerInfoTag> timer = CPVRItem(item).GetTimerInfoTag();
+        const std::shared_ptr<const CPVRTimerInfoTag> timer = CPVRItem(item).GetTimerInfoTag();
         if (timer)
           bValue = true;
         return true;
@@ -1393,7 +1393,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item,
     case LISTITEM_HASTIMERSCHEDULE:
       if (item->IsPVRChannel() || item->IsEPG() || item->IsPVRTimer())
       {
-        const std::shared_ptr<CPVRTimerInfoTag> timer = CPVRItem(item).GetTimerInfoTag();
+        const std::shared_ptr<const CPVRTimerInfoTag> timer = CPVRItem(item).GetTimerInfoTag();
         if (timer)
           bValue = timer->HasParent();
         return true;
@@ -1402,7 +1402,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item,
     case LISTITEM_HASREMINDER:
       if (item->IsPVRChannel() || item->IsEPG() || item->IsPVRTimer())
       {
-        const std::shared_ptr<CPVRTimerInfoTag> timer = CPVRItem(item).GetTimerInfoTag();
+        const std::shared_ptr<const CPVRTimerInfoTag> timer = CPVRItem(item).GetTimerInfoTag();
         if (timer)
           bValue = timer->IsReminder();
         return true;
@@ -1411,7 +1411,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item,
     case LISTITEM_HASREMINDERRULE:
       if (item->IsPVRChannel() || item->IsEPG() || item->IsPVRTimer())
       {
-        const std::shared_ptr<CPVRTimerInfoTag> timer = CPVRItem(item).GetTimerInfoTag();
+        const std::shared_ptr<const CPVRTimerInfoTag> timer = CPVRItem(item).GetTimerInfoTag();
         if (timer)
           bValue = timer->IsReminder() && timer->HasParent();
         return true;
@@ -1420,7 +1420,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item,
     case LISTITEM_TIMERISACTIVE:
       if (item->IsPVRChannel() || item->IsEPG())
       {
-        const std::shared_ptr<CPVRTimerInfoTag> timer = CPVRItem(item).GetTimerInfoTag();
+        const std::shared_ptr<const CPVRTimerInfoTag> timer = CPVRItem(item).GetTimerInfoTag();
         if (timer)
           bValue = timer->IsActive();
         break;
@@ -1429,7 +1429,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item,
     case LISTITEM_TIMERHASCONFLICT:
       if (item->IsPVRChannel() || item->IsEPG())
       {
-        const std::shared_ptr<CPVRTimerInfoTag> timer = CPVRItem(item).GetTimerInfoTag();
+        const std::shared_ptr<const CPVRTimerInfoTag> timer = CPVRItem(item).GetTimerInfoTag();
         if (timer)
           bValue = timer->HasConflict();
         return true;
@@ -1438,7 +1438,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item,
     case LISTITEM_TIMERHASERROR:
       if (item->IsPVRChannel() || item->IsEPG())
       {
-        const std::shared_ptr<CPVRTimerInfoTag> timer = CPVRItem(item).GetTimerInfoTag();
+        const std::shared_ptr<const CPVRTimerInfoTag> timer = CPVRItem(item).GetTimerInfoTag();
         if (timer)
           bValue = (timer->IsBroken() && !timer->HasConflict());
         return true;
@@ -1447,7 +1447,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item,
     case LISTITEM_HASRECORDING:
       if (item->IsPVRChannel() || item->IsEPG())
       {
-        const std::shared_ptr<CPVREpgInfoTag> epgTag = CPVRItem(item).GetEpgInfoTag();
+        const std::shared_ptr<const CPVREpgInfoTag> epgTag = CPVRItem(item).GetEpgInfoTag();
         if (epgTag)
           bValue = !!CServiceBroker::GetPVRManager().Recordings()->GetRecordingForEpgTag(epgTag);
         return true;
@@ -1456,7 +1456,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item,
     case LISTITEM_HAS_EPG:
       if (item->IsPVRChannel() || item->IsEPG() || item->IsPVRTimer())
       {
-        const std::shared_ptr<CPVREpgInfoTag> epgTag = CPVRItem(item).GetEpgInfoTag();
+        const std::shared_ptr<const CPVREpgInfoTag> epgTag = CPVRItem(item).GetEpgInfoTag();
         bValue = (epgTag != nullptr);
         return true;
       }
@@ -1464,7 +1464,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item,
     case LISTITEM_ISENCRYPTED:
       if (item->IsPVRChannel() || item->IsEPG())
       {
-        const std::shared_ptr<CPVRChannel> channel = CPVRItem(item).GetChannel();
+        const std::shared_ptr<const CPVRChannel> channel = CPVRItem(item).GetChannel();
         if (channel)
           bValue = channel->IsEncrypted();
         return true;

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -244,7 +244,7 @@ void CPVRGUIInfo::UpdateQualityData()
   const int channelUid = playbackState->GetPlayingChannelUniqueID();
   if (channelUid > 0)
   {
-    const std::shared_ptr<CPVRClient> client =
+    const std::shared_ptr<const CPVRClient> client =
         CServiceBroker::GetPVRManager().Clients()->GetCreatedClient(
             playbackState->GetPlayingClientID());
     if (client)

--- a/xbmc/pvr/guilib/guiinfo/PVRGUITimerInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUITimerInfo.cpp
@@ -95,7 +95,7 @@ void CPVRGUITimerInfo::UpdateTimersToggle()
     std::vector<std::shared_ptr<CPVRTimerInfoTag>> activeTags = GetActiveRecordings();
     if (m_iTimerInfoToggleCurrent < activeTags.size())
     {
-      const std::shared_ptr<CPVRTimerInfoTag> tag = activeTags.at(m_iTimerInfoToggleCurrent);
+      const std::shared_ptr<const CPVRTimerInfoTag> tag = activeTags.at(m_iTimerInfoToggleCurrent);
       strActiveTimerTitle = tag->Title();
       strActiveTimerChannelName = tag->ChannelName();
       strActiveTimerChannelIcon = tag->ChannelIcon();
@@ -133,7 +133,7 @@ void CPVRGUITimerInfo::UpdateNextTimer()
   std::string strNextRecordingTime;
   std::string strNextTimerInfo;
 
-  const std::shared_ptr<CPVRTimerInfoTag> timer = GetNextActiveTimer();
+  const std::shared_ptr<const CPVRTimerInfoTag> timer = GetNextActiveTimer();
   if (timer)
   {
     strNextRecordingTitle = timer->Title();

--- a/xbmc/pvr/guilib/guiinfo/PVRGUITimesInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUITimesInfo.cpp
@@ -53,7 +53,8 @@ void CPVRGUITimesInfo::Reset()
 
 void CPVRGUITimesInfo::UpdatePlayingTag()
 {
-  const std::shared_ptr<CPVRChannel> currentChannel = CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel();
+  const std::shared_ptr<const CPVRChannel> currentChannel =
+      CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel();
   std::shared_ptr<CPVREpgInfoTag> currentTag = CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingEpgTag();
 
   if (currentChannel || currentTag)
@@ -61,11 +62,12 @@ void CPVRGUITimesInfo::UpdatePlayingTag()
     if (currentChannel && !currentTag)
       currentTag = currentChannel->GetEPGNow();
 
-    const std::shared_ptr<CPVRChannelGroupsContainer> groups = CServiceBroker::GetPVRManager().ChannelGroups();
+    const std::shared_ptr<const CPVRChannelGroupsContainer> groups =
+        CServiceBroker::GetPVRManager().ChannelGroups();
 
     std::unique_lock<CCriticalSection> lock(m_critSection);
 
-    const std::shared_ptr<CPVRChannel> playingChannel =
+    const std::shared_ptr<const CPVRChannel> playingChannel =
         m_playingEpgTag ? groups->GetChannelForEpgTag(m_playingEpgTag) : nullptr;
 
     if (!m_playingEpgTag || !currentTag || !playingChannel || !currentChannel ||
@@ -91,7 +93,8 @@ void CPVRGUITimesInfo::UpdatePlayingTag()
   }
   else
   {
-    const std::shared_ptr<CPVRRecording> recording = CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingRecording();
+    const std::shared_ptr<const CPVRRecording> recording =
+        CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingRecording();
     if (recording)
     {
       std::unique_lock<CCriticalSection> lock(m_critSection);
@@ -115,7 +118,8 @@ void CPVRGUITimesInfo::UpdateTimeshiftData()
   int64_t iPlayTime, iMinTime, iMaxTime;
   CServiceBroker::GetDataCacheCore().GetPlayTimes(iStartTime, iPlayTime, iMinTime, iMaxTime);
   bool bPlaying = CServiceBroker::GetDataCacheCore().GetSpeed() == 1.0f;
-  const std::shared_ptr<CPVRChannel> playingChannel = CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel();
+  const std::shared_ptr<const CPVRChannel> playingChannel =
+      CServiceBroker::GetPVRManager().PlaybackState()->GetPlayingChannel();
 
   std::unique_lock<CCriticalSection> lock(m_critSection);
 

--- a/xbmc/pvr/guilib/guiinfo/PVRGUITimesInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUITimesInfo.cpp
@@ -284,13 +284,15 @@ std::string CPVRGUITimesInfo::GetTimeshiftProgressEndTime(TIME_FORMAT format) co
   return TimeToTimeString(m_iTimeshiftProgressEndTime, format, false);
 }
 
-std::string CPVRGUITimesInfo::GetEpgEventDuration(const std::shared_ptr<CPVREpgInfoTag>& epgTag, TIME_FORMAT format) const
+std::string CPVRGUITimesInfo::GetEpgEventDuration(
+    const std::shared_ptr<const CPVREpgInfoTag>& epgTag, TIME_FORMAT format) const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   return StringUtils::SecondsToTimeString(GetEpgEventDuration(epgTag), format);
 }
 
-std::string CPVRGUITimesInfo::GetEpgEventElapsedTime(const std::shared_ptr<CPVREpgInfoTag>& epgTag, TIME_FORMAT format) const
+std::string CPVRGUITimesInfo::GetEpgEventElapsedTime(
+    const std::shared_ptr<const CPVREpgInfoTag>& epgTag, TIME_FORMAT format) const
 {
   int iElapsed = 0;
   std::unique_lock<CCriticalSection> lock(m_critSection);
@@ -302,13 +304,15 @@ std::string CPVRGUITimesInfo::GetEpgEventElapsedTime(const std::shared_ptr<CPVRE
   return StringUtils::SecondsToTimeString(iElapsed, format);
 }
 
-std::string CPVRGUITimesInfo::GetEpgEventRemainingTime(const std::shared_ptr<CPVREpgInfoTag>& epgTag, TIME_FORMAT format) const
+std::string CPVRGUITimesInfo::GetEpgEventRemainingTime(
+    const std::shared_ptr<const CPVREpgInfoTag>& epgTag, TIME_FORMAT format) const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   return StringUtils::SecondsToTimeString(GetRemainingTime(epgTag), format);
 }
 
-std::string CPVRGUITimesInfo::GetEpgEventFinishTime(const std::shared_ptr<CPVREpgInfoTag>& epgTag, TIME_FORMAT format) const
+std::string CPVRGUITimesInfo::GetEpgEventFinishTime(
+    const std::shared_ptr<const CPVREpgInfoTag>& epgTag, TIME_FORMAT format) const
 {
   CDateTime finish = CDateTime::GetCurrentDateTime();
   finish += CDateTimeSpan(0, 0, 0, GetRemainingTime(epgTag));
@@ -336,7 +340,7 @@ int CPVRGUITimesInfo::GetElapsedTime() const
   }
 }
 
-int CPVRGUITimesInfo::GetRemainingTime(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
+int CPVRGUITimesInfo::GetRemainingTime(const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   if (epgTag && m_playingEpgTag && *epgTag != *m_playingEpgTag)
@@ -399,7 +403,7 @@ int CPVRGUITimesInfo::GetTimeshiftProgressBufferEnd() const
   return std::lrintf(static_cast<float>(m_iTimeshiftEndTime - m_iTimeshiftProgressStartTime) / m_iTimeshiftProgressDuration * 100);
 }
 
-int CPVRGUITimesInfo::GetEpgEventDuration(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
+int CPVRGUITimesInfo::GetEpgEventDuration(const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   if (epgTag && m_playingEpgTag && *epgTag != *m_playingEpgTag)
@@ -408,7 +412,7 @@ int CPVRGUITimesInfo::GetEpgEventDuration(const std::shared_ptr<CPVREpgInfoTag>&
     return m_iDuration;
 }
 
-int CPVRGUITimesInfo::GetEpgEventProgress(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
+int CPVRGUITimesInfo::GetEpgEventProgress(const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   if (epgTag && m_playingEpgTag && *epgTag != *m_playingEpgTag)

--- a/xbmc/pvr/guilib/guiinfo/PVRGUITimesInfo.h
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUITimesInfo.h
@@ -36,10 +36,14 @@ namespace PVR
     std::string GetTimeshiftProgressStartTime(TIME_FORMAT format) const;
     std::string GetTimeshiftProgressEndTime(TIME_FORMAT format) const;
 
-    std::string GetEpgEventDuration(const std::shared_ptr<CPVREpgInfoTag>& epgTag, TIME_FORMAT format) const;
-    std::string GetEpgEventElapsedTime(const std::shared_ptr<CPVREpgInfoTag>& epgTag, TIME_FORMAT format) const;
-    std::string GetEpgEventRemainingTime(const std::shared_ptr<CPVREpgInfoTag>& epgTag, TIME_FORMAT format) const;
-    std::string GetEpgEventFinishTime(const std::shared_ptr<CPVREpgInfoTag>& epgTag, TIME_FORMAT format) const;
+    std::string GetEpgEventDuration(const std::shared_ptr<const CPVREpgInfoTag>& epgTag,
+                                    TIME_FORMAT format) const;
+    std::string GetEpgEventElapsedTime(const std::shared_ptr<const CPVREpgInfoTag>& epgTag,
+                                       TIME_FORMAT format) const;
+    std::string GetEpgEventRemainingTime(const std::shared_ptr<const CPVREpgInfoTag>& epgTag,
+                                         TIME_FORMAT format) const;
+    std::string GetEpgEventFinishTime(const std::shared_ptr<const CPVREpgInfoTag>& epgTag,
+                                      TIME_FORMAT format) const;
     std::string GetEpgEventSeekTime(int iSeekSize, TIME_FORMAT format) const;
 
     // GUI info ints
@@ -51,8 +55,8 @@ namespace PVR
     int GetTimeshiftProgressBufferStart() const;
     int GetTimeshiftProgressBufferEnd() const;
 
-    int GetEpgEventDuration(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
-    int GetEpgEventProgress(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
+    int GetEpgEventDuration(const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const;
+    int GetEpgEventProgress(const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const;
 
     // GUI info bools
     bool IsTimeshifting() const;
@@ -65,12 +69,12 @@ namespace PVR
     static std::string TimeToTimeString(time_t datetime, TIME_FORMAT format, bool withSeconds);
 
     int GetElapsedTime() const;
-    int GetRemainingTime(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
+    int GetRemainingTime(const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const;
 
     mutable CCriticalSection m_critSection;
 
-    std::shared_ptr<CPVREpgInfoTag> m_playingEpgTag;
-    std::shared_ptr<CPVRChannel> m_playingChannel;
+    std::shared_ptr<const CPVREpgInfoTag> m_playingEpgTag;
+    std::shared_ptr<const CPVRChannel> m_playingChannel;
 
     time_t m_iStartTime;
     unsigned int m_iDuration;

--- a/xbmc/pvr/providers/PVRProviders.cpp
+++ b/xbmc/pvr/providers/PVRProviders.cpp
@@ -102,7 +102,8 @@ void CPVRProviders::Unload()
 
 bool CPVRProviders::LoadFromDatabase(const std::vector<std::shared_ptr<CPVRClient>>& clients)
 {
-  const std::shared_ptr<CPVRDatabase> database = CServiceBroker::GetPVRManager().GetTVDatabase();
+  const std::shared_ptr<const CPVRDatabase> database =
+      CServiceBroker::GetPVRManager().GetTVDatabase();
   if (database)
   {
     m_iLastId = database->GetMaxProviderId();

--- a/xbmc/pvr/providers/PVRProviders.cpp
+++ b/xbmc/pvr/providers/PVRProviders.cpp
@@ -174,7 +174,7 @@ bool CPVRProviders::UpdateDefaultEntries(const CPVRProvidersContainer& newProvid
   for (std::vector<std::shared_ptr<CPVRProvider>>::iterator it = m_providers.begin();
        it != m_providers.end();)
   {
-    const std::shared_ptr<CPVRProvider> provider = *it;
+    const std::shared_ptr<const CPVRProvider> provider = *it;
     if (!newProviders.GetByClient(provider->GetClientId(), provider->GetUniqueId()))
     {
       // provider was not found
@@ -222,7 +222,7 @@ bool CPVRProviders::UpdateClientEntries(const CPVRProvidersContainer& newProvide
   // check for deleted providers
   for (auto it = m_providers.begin(); it != m_providers.end();)
   {
-    const std::shared_ptr<CPVRProvider> provider = *it;
+    const std::shared_ptr<const CPVRProvider> provider = *it;
     if (!newProviders.GetByClient(provider->GetClientId(), provider->GetUniqueId()))
     {
       const bool bIgnoreProvider =
@@ -355,7 +355,7 @@ void CPVRProviders::RemoveEntry(const std::shared_ptr<CPVRProvider>& provider)
 
   m_providers.erase(
       std::remove_if(m_providers.begin(), m_providers.end(),
-                     [&provider](const std::shared_ptr<CPVRProvider>& providerToRemove) {
+                     [&provider](const std::shared_ptr<const CPVRProvider>& providerToRemove) {
                        return provider->GetClientId() == providerToRemove->GetClientId() &&
                               provider->GetUniqueId() == providerToRemove->GetUniqueId();
                      }),

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -364,7 +364,8 @@ bool CPVRRecording::SetResumePoint(double timeInSeconds,
 
 CBookmark CPVRRecording::GetResumePoint() const
 {
-  const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_iClientId);
+  const std::shared_ptr<const CPVRClient> client =
+      CServiceBroker::GetPVRManager().GetClient(m_iClientId);
   if (client && client->GetClientCapabilities().SupportsRecordingsLastPlayedPosition() &&
       m_resumePointRefetchTimeout.IsTimePast())
   {
@@ -388,7 +389,8 @@ CBookmark CPVRRecording::GetResumePoint() const
 
 bool CPVRRecording::UpdateRecordingSize()
 {
-  const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_iClientId);
+  const std::shared_ptr<const CPVRClient> client =
+      CServiceBroker::GetPVRManager().GetClient(m_iClientId);
   if (client && client->GetClientCapabilities().SupportsRecordingsSize() &&
       m_recordingSizeRefetchTimeout.IsTimePast())
   {
@@ -433,7 +435,8 @@ std::vector<PVR_EDL_ENTRY> CPVRRecording::GetEdl() const
 {
   std::vector<PVR_EDL_ENTRY> edls;
 
-  const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_iClientId);
+  const std::shared_ptr<const CPVRClient> client =
+      CServiceBroker::GetPVRManager().GetClient(m_iClientId);
   if (client && client->GetClientCapabilities().SupportsRecordingsEdl())
     client->GetRecordingEdl(*this, edls);
 

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -124,14 +124,14 @@ CPVRRecording::CPVRRecording(const PVR_RECORDING& recording, unsigned int iClien
   }
   else
   {
-    const std::shared_ptr<CPVRChannel> channel(Channel());
+    const std::shared_ptr<const CPVRChannel> channel(Channel());
     if (channel)
     {
       m_bRadio = channel->IsRadio();
     }
     else
     {
-      const std::shared_ptr<CPVRClient> client =
+      const std::shared_ptr<const CPVRClient> client =
           CServiceBroker::GetPVRManager().GetClient(m_iClientId);
       bool bSupportsRadio = client && client->GetClientCapabilities().SupportsRadio();
       if (bSupportsRadio && client && client->GetClientCapabilities().SupportsTV())

--- a/xbmc/pvr/recordings/PVRRecordings.cpp
+++ b/xbmc/pvr/recordings/PVRRecordings.cpp
@@ -219,7 +219,7 @@ void CPVRRecordings::UpdateFromClient(const std::shared_ptr<CPVRRecording>& tag,
 }
 
 std::shared_ptr<CPVRRecording> CPVRRecordings::GetRecordingForEpgTag(
-    const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
+    const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const
 {
   if (!epgTag)
     return {};

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -98,7 +98,7 @@ public:
    * @return The requested recording, or an empty recordingptr if none was found.
    */
   std::shared_ptr<CPVRRecording> GetRecordingForEpgTag(
-      const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
+      const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const;
 
   /*!
    * @brief Erase stale texture db entries and image files.

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -61,7 +61,8 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(bool bRadio /* = false */)
 
   std::shared_ptr<CPVRTimerType> type;
 
-  const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_iClientId);
+  const std::shared_ptr<const CPVRClient> client =
+      CServiceBroker::GetPVRManager().GetClient(m_iClientId);
   if (client && client->GetClientCapabilities().SupportsTimers())
   {
     // default to first available type for given client
@@ -132,7 +133,8 @@ CPVRTimerInfoTag::CPVRTimerInfoTag(const PVR_TIMER& timer,
   if (m_iClientIndex == PVR_TIMER_NO_CLIENT_INDEX)
     CLog::LogF(LOGERROR, "Invalid client index supplied by client {} (must be > 0)!", m_iClientId);
 
-  const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_iClientId);
+  const std::shared_ptr<const CPVRClient> client =
+      CServiceBroker::GetPVRManager().GetClient(m_iClientId);
   if (client && client->GetClientCapabilities().SupportsTimers())
   {
     // begin compat section

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -233,7 +233,7 @@ void CPVRTimerInfoTag::FillAddonData(PVR_TIMER& timer) const
   StartAsUTC().GetAsTime(start);
   EndAsUTC().GetAsTime(end);
   FirstDayAsUTC().GetAsTime(firstDay);
-  const std::shared_ptr<CPVREpgInfoTag> epgTag = GetEpgInfoTag();
+  const std::shared_ptr<const CPVREpgInfoTag> epgTag = GetEpgInfoTag();
   const int iPVRTimeCorrection =
       CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRTimeCorrection;
 
@@ -611,7 +611,7 @@ bool CPVRTimerInfoTag::DeleteFromDatabase()
   return false;
 }
 
-bool CPVRTimerInfoTag::UpdateEntry(const std::shared_ptr<CPVRTimerInfoTag>& tag)
+bool CPVRTimerInfoTag::UpdateEntry(const std::shared_ptr<const CPVRTimerInfoTag>& tag)
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
 
@@ -664,7 +664,7 @@ bool CPVRTimerInfoTag::UpdateEntry(const std::shared_ptr<CPVRTimerInfoTag>& tag)
   return true;
 }
 
-bool CPVRTimerInfoTag::UpdateChildState(const std::shared_ptr<CPVRTimerInfoTag>& childTimer,
+bool CPVRTimerInfoTag::UpdateChildState(const std::shared_ptr<const CPVRTimerInfoTag>& childTimer,
                                         bool bAdd)
 {
   if (!childTimer || childTimer->m_iParentClientIndex != m_iClientIndex)

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -140,7 +140,7 @@ public:
    * @param tag A timer containing the data that shall be merged into this timer's data.
    * @return true if the timer was updated successfully
    */
-  bool UpdateEntry(const std::shared_ptr<CPVRTimerInfoTag>& tag);
+  bool UpdateEntry(const std::shared_ptr<const CPVRTimerInfoTag>& tag);
 
   /*!
    * @brief merge in the state of this child timer.
@@ -148,7 +148,7 @@ public:
    * @param bAdd If true, add child's data to parent's state, otherwise subtract.
    * @return true if the child timer's state was merged successfully
    */
-  bool UpdateChildState(const std::shared_ptr<CPVRTimerInfoTag>& childTimer, bool bAdd);
+  bool UpdateChildState(const std::shared_ptr<const CPVRTimerInfoTag>& childTimer, bool bAdd);
 
   /*!
    * @brief reset the state of children related to this timer.

--- a/xbmc/pvr/timers/PVRTimerRuleMatcher.cpp
+++ b/xbmc/pvr/timers/PVRTimerRuleMatcher.cpp
@@ -26,7 +26,7 @@ CPVRTimerRuleMatcher::CPVRTimerRuleMatcher(const std::shared_ptr<CPVRTimerInfoTa
 
 CPVRTimerRuleMatcher::~CPVRTimerRuleMatcher() = default;
 
-std::shared_ptr<CPVRChannel> CPVRTimerRuleMatcher::GetChannel() const
+std::shared_ptr<const CPVRChannel> CPVRTimerRuleMatcher::GetChannel() const
 {
   if (m_timerRule->GetTimerType()->SupportsChannels())
     return m_timerRule->Channel();
@@ -71,14 +71,15 @@ CDateTime CPVRTimerRuleMatcher::GetNextTimerStart() const
   return nextStart.GetAsUTCDateTime();
 }
 
-bool CPVRTimerRuleMatcher::Matches(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
+bool CPVRTimerRuleMatcher::Matches(const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const
 {
   return epgTag && CPVRTimerInfoTag::ConvertUTCToLocalTime(epgTag->EndAsUTC()) > m_start &&
          MatchSeriesLink(epgTag) && MatchChannel(epgTag) && MatchStart(epgTag) &&
          MatchEnd(epgTag) && MatchDayOfWeek(epgTag) && MatchSearchText(epgTag);
 }
 
-bool CPVRTimerRuleMatcher::MatchSeriesLink(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
+bool CPVRTimerRuleMatcher::MatchSeriesLink(
+    const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const
 {
   if (m_timerRule->GetTimerType()->RequiresEpgSeriesLinkOnCreate())
     return epgTag->SeriesLink() == m_timerRule->SeriesLink();
@@ -86,7 +87,7 @@ bool CPVRTimerRuleMatcher::MatchSeriesLink(const std::shared_ptr<CPVREpgInfoTag>
     return true;
 }
 
-bool CPVRTimerRuleMatcher::MatchChannel(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
+bool CPVRTimerRuleMatcher::MatchChannel(const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const
 {
   if (m_timerRule->GetTimerType()->SupportsAnyChannel() &&
       m_timerRule->ClientChannelUID() == PVR_CHANNEL_INVALID_UID)
@@ -100,7 +101,7 @@ bool CPVRTimerRuleMatcher::MatchChannel(const std::shared_ptr<CPVREpgInfoTag>& e
     return true;
 }
 
-bool CPVRTimerRuleMatcher::MatchStart(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
+bool CPVRTimerRuleMatcher::MatchStart(const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const
 {
   if (m_timerRule->GetTimerType()->SupportsFirstDay())
   {
@@ -132,7 +133,7 @@ bool CPVRTimerRuleMatcher::MatchStart(const std::shared_ptr<CPVREpgInfoTag>& epg
     return true;
 }
 
-bool CPVRTimerRuleMatcher::MatchEnd(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
+bool CPVRTimerRuleMatcher::MatchEnd(const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const
 {
   if (m_timerRule->GetTimerType()->SupportsEndAnyTime() && m_timerRule->IsEndAnyTime())
     return true; // matches any end time
@@ -150,7 +151,7 @@ bool CPVRTimerRuleMatcher::MatchEnd(const std::shared_ptr<CPVREpgInfoTag>& epgTa
     return true;
 }
 
-bool CPVRTimerRuleMatcher::MatchDayOfWeek(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
+bool CPVRTimerRuleMatcher::MatchDayOfWeek(const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const
 {
   if (m_timerRule->GetTimerType()->SupportsWeekdays())
   {
@@ -167,7 +168,8 @@ bool CPVRTimerRuleMatcher::MatchDayOfWeek(const std::shared_ptr<CPVREpgInfoTag>&
   return true;
 }
 
-bool CPVRTimerRuleMatcher::MatchSearchText(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
+bool CPVRTimerRuleMatcher::MatchSearchText(
+    const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const
 {
   if (m_timerRule->GetTimerType()->SupportsEpgFulltextMatch() && m_timerRule->IsFullTextEpgSearch())
   {

--- a/xbmc/pvr/timers/PVRTimerRuleMatcher.h
+++ b/xbmc/pvr/timers/PVRTimerRuleMatcher.h
@@ -28,17 +28,17 @@ public:
 
   std::shared_ptr<CPVRTimerInfoTag> GetTimerRule() const { return m_timerRule; }
 
-  std::shared_ptr<CPVRChannel> GetChannel() const;
+  std::shared_ptr<const CPVRChannel> GetChannel() const;
   CDateTime GetNextTimerStart() const;
-  bool Matches(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
+  bool Matches(const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const;
 
 private:
-  bool MatchSeriesLink(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
-  bool MatchChannel(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
-  bool MatchStart(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
-  bool MatchEnd(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
-  bool MatchDayOfWeek(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
-  bool MatchSearchText(const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
+  bool MatchSeriesLink(const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const;
+  bool MatchChannel(const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const;
+  bool MatchStart(const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const;
+  bool MatchEnd(const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const;
+  bool MatchDayOfWeek(const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const;
+  bool MatchSearchText(const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const;
 
   const std::shared_ptr<CPVRTimerInfoTag> m_timerRule;
   CDateTime m_start;

--- a/xbmc/pvr/timers/PVRTimerType.cpp
+++ b/xbmc/pvr/timers/PVRTimerType.cpp
@@ -103,7 +103,8 @@ const std::vector<std::shared_ptr<CPVRTimerType>> CPVRTimerType::GetAllTypes()
   return allTypes;
 }
 
-const std::shared_ptr<CPVRTimerType> CPVRTimerType::GetFirstAvailableType(const std::shared_ptr<CPVRClient>& client)
+const std::shared_ptr<CPVRTimerType> CPVRTimerType::GetFirstAvailableType(
+    const std::shared_ptr<const CPVRClient>& client)
 {
   if (client)
   {

--- a/xbmc/pvr/timers/PVRTimerType.h
+++ b/xbmc/pvr/timers/PVRTimerType.h
@@ -39,7 +39,8 @@ namespace PVR
      * @param client the PVR client.
      * @return A timer type or NULL if none available.
      */
-    static const std::shared_ptr<CPVRTimerType> GetFirstAvailableType(const std::shared_ptr<CPVRClient>& client);
+    static const std::shared_ptr<CPVRTimerType> GetFirstAvailableType(
+        const std::shared_ptr<const CPVRClient>& client);
 
     /*!
      * @brief Create a timer type from given timer type id and client id.

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -109,7 +109,8 @@ bool CPVRTimers::Update(const std::vector<std::shared_ptr<CPVRClient>>& clients)
 bool CPVRTimers::LoadFromDatabase(const std::vector<std::shared_ptr<CPVRClient>>& clients)
 {
   // load local timers from database
-  const std::shared_ptr<CPVRDatabase> database = CServiceBroker::GetPVRManager().GetTVDatabase();
+  const std::shared_ptr<const CPVRDatabase> database =
+      CServiceBroker::GetPVRManager().GetTVDatabase();
   if (database)
   {
     const std::vector<std::shared_ptr<CPVRTimerInfoTag>> timers =
@@ -200,7 +201,7 @@ void CPVRTimers::RemoveEntry(const std::shared_ptr<const CPVRTimerInfoTag>& tag)
   if (it != m_tags.end())
   {
     it->second.erase(std::remove_if(it->second.begin(), it->second.end(),
-                                    [&tag](const std::shared_ptr<CPVRTimerInfoTag>& timer) {
+                                    [&tag](const std::shared_ptr<const CPVRTimerInfoTag>& timer) {
                                       return tag->ClientID() == timer->ClientID() &&
                                              tag->ClientIndex() == timer->ClientIndex();
                                     }),
@@ -384,7 +385,7 @@ bool CPVRTimers::UpdateEntries(const CPVRTimersContainer& timers,
       /* queue notifications / fill eventlog */
       for (const auto& entry : timerNotifications)
       {
-        const std::shared_ptr<CPVRClient> client =
+        const std::shared_ptr<const CPVRClient> client =
             CServiceBroker::GetPVRManager().GetClient(entry.first);
         if (client)
         {
@@ -412,7 +413,7 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> GetEpgTagsForTimerRule(
   if (channel)
   {
     // match single channel
-    const std::shared_ptr<CPVREpg> epg = channel->GetEPG();
+    const std::shared_ptr<const CPVREpg> epg = channel->GetEPG();
     if (epg)
     {
       const std::vector<std::shared_ptr<CPVREpgInfoTag>> tags = epg->GetTags();
@@ -513,7 +514,7 @@ bool CPVRTimers::UpdateEntries(int iMaxNotificationDelay)
         if (timer->IsEpgBased())
         {
           // update epg tag
-          const std::shared_ptr<CPVREpg> epg =
+          const std::shared_ptr<const CPVREpg> epg =
               CServiceBroker::GetPVRManager().EpgContainer().GetByChannelUid(
                   timer->Channel()->ClientID(), timer->Channel()->UniqueID());
           if (epg)
@@ -1262,7 +1263,7 @@ CDateTime CPVRTimers::GetNextEventTime() const
   CDateTime wakeuptime;
 
   /* Check next active time */
-  const std::shared_ptr<CPVRTimerInfoTag> timer = GetNextActiveTimer(false);
+  const std::shared_ptr<const CPVRTimerInfoTag> timer = GetNextActiveTimer(false);
   if (timer)
   {
     const CDateTimeSpan prestart(0, 0, timer->MarginStart(), 0);

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -192,7 +192,7 @@ bool CPVRTimers::IsRecording() const
   return false;
 }
 
-void CPVRTimers::RemoveEntry(const std::shared_ptr<CPVRTimerInfoTag>& tag)
+void CPVRTimers::RemoveEntry(const std::shared_ptr<const CPVRTimerInfoTag>& tag)
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
 
@@ -213,7 +213,7 @@ void CPVRTimers::RemoveEntry(const std::shared_ptr<CPVRTimerInfoTag>& tag)
 
 bool CPVRTimers::CheckAndAppendTimerNotification(
     std::vector<std::pair<int, std::string>>& timerNotifications,
-    const std::shared_ptr<CPVRTimerInfoTag>& tag,
+    const std::shared_ptr<const CPVRTimerInfoTag>& tag,
     bool bDeleted) const
 {
   // no notification on first update or if previous update failed for tag's client.
@@ -408,7 +408,7 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> GetEpgTagsForTimerRule(
 {
   std::vector<std::shared_ptr<CPVREpgInfoTag>> matches;
 
-  const std::shared_ptr<CPVRChannel> channel = matcher.GetChannel();
+  const std::shared_ptr<const CPVRChannel> channel = matcher.GetChannel();
   if (channel)
   {
     // match single channel
@@ -443,7 +443,7 @@ void AddTimerRuleToEpgMap(
     std::map<std::shared_ptr<CPVREpg>, std::vector<std::shared_ptr<CPVRTimerRuleMatcher>>>& epgMap,
     bool& bFetchedAllEpgs)
 {
-  const std::shared_ptr<CPVRChannel> channel = timer->Channel();
+  const std::shared_ptr<const CPVRChannel> channel = timer->Channel();
   if (channel)
   {
     const std::shared_ptr<CPVREpg> epg = channel->GetEPG();
@@ -601,10 +601,11 @@ bool CPVRTimers::UpdateEntries(int iMaxNotificationDelay)
               if (it1 == m_tags.end())
                 bCreate = true;
               else
-                bCreate = std::none_of(it1->second.cbegin(), it1->second.cend(),
-                                       [&timer](const std::shared_ptr<CPVRTimerInfoTag>& tmr) {
-                                         return tmr->ParentClientIndex() == timer->ClientIndex();
-                                       });
+                bCreate =
+                    std::none_of(it1->second.cbegin(), it1->second.cend(),
+                                 [&timer](const std::shared_ptr<const CPVRTimerInfoTag>& tmr) {
+                                   return tmr->ParentClientIndex() == timer->ClientIndex();
+                                 });
               if (bCreate)
               {
                 const CDateTimeSpan duration = timer->EndAsUTC() - timer->StartAsUTC();
@@ -707,7 +708,7 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::GetNextReminderToAnnnounce()
 }
 
 bool CPVRTimers::KindMatchesTag(const TimerKind& eKind,
-                                const std::shared_ptr<CPVRTimerInfoTag>& tag) const
+                                const std::shared_ptr<const CPVRTimerInfoTag>& tag) const
 {
   return (eKind == TimerKindAny) || (eKind == TimerKindTV && !tag->IsRadio()) ||
          (eKind == TimerKindRadio && tag->IsRadio());
@@ -904,7 +905,7 @@ bool CPVRTimers::DeleteTimersOnChannel(const std::shared_ptr<CPVRChannel>& chann
 }
 
 std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::UpdateEntry(
-    const std::shared_ptr<CPVRTimerInfoTag>& timer)
+    const std::shared_ptr<const CPVRTimerInfoTag>& timer)
 {
   bool bChanged = false;
 
@@ -1147,7 +1148,7 @@ bool CPVRTimers::IsRecordingOnChannel(const CPVRChannel& channel) const
 }
 
 std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::GetActiveTimerForChannel(
-    const std::shared_ptr<CPVRChannel>& channel) const
+    const std::shared_ptr<const CPVRChannel>& channel) const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   for (const auto& tagsEntry : m_tags)
@@ -1166,7 +1167,7 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::GetActiveTimerForChannel(
 }
 
 std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::GetTimerForEpgTag(
-    const std::shared_ptr<CPVREpgInfoTag>& epgTag) const
+    const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const
 {
   if (epgTag)
   {
@@ -1203,7 +1204,7 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::GetTimerForEpgTag(
 }
 
 std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::GetTimerRule(
-    const std::shared_ptr<CPVRTimerInfoTag>& timer) const
+    const std::shared_ptr<const CPVRTimerInfoTag>& timer) const
 {
   if (timer)
   {

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -181,7 +181,7 @@ public:
    * @return the timer, null otherwise.
    */
   std::shared_ptr<CPVRTimerInfoTag> GetActiveTimerForChannel(
-      const std::shared_ptr<CPVRChannel>& channel) const;
+      const std::shared_ptr<const CPVRChannel>& channel) const;
 
   /*!
    * @return The amount of tv and radio timers that are currently recording
@@ -250,7 +250,7 @@ public:
    * @return The requested timer tag, or nullptr if none was found.
    */
   std::shared_ptr<CPVRTimerInfoTag> GetTimerForEpgTag(
-      const std::shared_ptr<CPVREpgInfoTag>& epgTag) const;
+      const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const;
 
   /*!
    * @brief Get the timer rule for a given timer tag
@@ -258,7 +258,7 @@ public:
    * @return The timer rule, or nullptr if none was found.
    */
   std::shared_ptr<CPVRTimerInfoTag> GetTimerRule(
-      const std::shared_ptr<CPVRTimerInfoTag>& timer) const;
+      const std::shared_ptr<const CPVRTimerInfoTag>& timer) const;
 
   /*!
      * @brief Update the channel pointers.
@@ -288,10 +288,11 @@ private:
    */
   bool LoadFromDatabase(const std::vector<std::shared_ptr<CPVRClient>>& clients);
 
-  void RemoveEntry(const std::shared_ptr<CPVRTimerInfoTag>& tag);
+  void RemoveEntry(const std::shared_ptr<const CPVRTimerInfoTag>& tag);
   bool UpdateEntries(const CPVRTimersContainer& timers, const std::vector<int>& failedClients);
   bool UpdateEntries(int iMaxNotificationDelay);
-  std::shared_ptr<CPVRTimerInfoTag> UpdateEntry(const std::shared_ptr<CPVRTimerInfoTag>& timer);
+  std::shared_ptr<CPVRTimerInfoTag> UpdateEntry(
+      const std::shared_ptr<const CPVRTimerInfoTag>& timer);
 
   bool AddLocalTimer(const std::shared_ptr<CPVRTimerInfoTag>& tag, bool bNotify);
   bool DeleteLocalTimer(const std::shared_ptr<CPVRTimerInfoTag>& tag, bool bNotify);
@@ -308,7 +309,8 @@ private:
     TimerKindRadio
   };
 
-  bool KindMatchesTag(const TimerKind& eKind, const std::shared_ptr<CPVRTimerInfoTag>& tag) const;
+  bool KindMatchesTag(const TimerKind& eKind,
+                      const std::shared_ptr<const CPVRTimerInfoTag>& tag) const;
 
   std::shared_ptr<CPVRTimerInfoTag> GetNextActiveTimer(const TimerKind& eKind,
                                                        bool bIgnoreReminders) const;
@@ -317,7 +319,7 @@ private:
   int AmountActiveRecordings(const TimerKind& eKind) const;
 
   bool CheckAndAppendTimerNotification(std::vector<std::pair<int, std::string>>& timerNotifications,
-                                       const std::shared_ptr<CPVRTimerInfoTag>& tag,
+                                       const std::shared_ptr<const CPVRTimerInfoTag>& tag,
                                        bool bDeleted) const;
 
   bool m_bIsUpdating = false;

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -214,7 +214,7 @@ bool CGUIWindowPVRBase::OnAction(const CAction& action)
 
 bool CGUIWindowPVRBase::ActivatePreviousChannelGroup()
 {
-  const std::shared_ptr<CPVRChannelGroup> channelGroup = GetChannelGroup();
+  const std::shared_ptr<const CPVRChannelGroup> channelGroup = GetChannelGroup();
   if (channelGroup)
   {
     const CPVRChannelGroups* groups = CServiceBroker::GetPVRManager().ChannelGroups()->Get(channelGroup->IsRadio());
@@ -229,7 +229,7 @@ bool CGUIWindowPVRBase::ActivatePreviousChannelGroup()
 
 bool CGUIWindowPVRBase::ActivateNextChannelGroup()
 {
-  const std::shared_ptr<CPVRChannelGroup> channelGroup = GetChannelGroup();
+  const std::shared_ptr<const CPVRChannelGroup> channelGroup = GetChannelGroup();
   if (channelGroup)
   {
     const CPVRChannelGroups* groups = CServiceBroker::GetPVRManager().ChannelGroups()->Get(channelGroup->IsRadio());
@@ -405,7 +405,7 @@ bool CGUIWindowPVRBase::OpenChannelGroupSelectionDialog()
     std::string selectedName;
     std::string selectedClient;
 
-    const std::shared_ptr<CPVRChannelGroup> channelGroup = GetChannelGroup();
+    const std::shared_ptr<const CPVRChannelGroup> channelGroup = GetChannelGroup();
     if (channelGroup)
     {
       selectedName = channelGroup->GroupName();
@@ -420,7 +420,7 @@ bool CGUIWindowPVRBase::OpenChannelGroupSelectionDialog()
     for (auto& group : options)
     {
       // set client name as label2
-      const std::shared_ptr<CPVRClient> client = pvrMgr.GetClient(*group);
+      const std::shared_ptr<const CPVRClient> client = pvrMgr.GetClient(*group);
       if (client)
         group->SetLabel2(client->GetFriendlyName());
 
@@ -444,7 +444,7 @@ bool CGUIWindowPVRBase::OpenChannelGroupSelectionDialog()
   }
   else
   {
-    const std::shared_ptr<CPVRChannelGroup> channelGroup = GetChannelGroup();
+    const std::shared_ptr<const CPVRChannelGroup> channelGroup = GetChannelGroup();
     if (channelGroup)
     {
       int idx = -1;

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -320,7 +320,7 @@ bool CGUIWindowPVRChannelsBase::OnContextButtonManage(const CFileItemPtr& item,
 
 void CGUIWindowPVRChannelsBase::UpdateEpg(const CFileItemPtr& item)
 {
-  const std::shared_ptr<CPVRChannel> channel(item->GetPVRChannelInfoTag());
+  const std::shared_ptr<const CPVRChannel> channel(item->GetPVRChannelInfoTag());
 
   if (!CGUIDialogYesNo::ShowAndGetInput(
           CVariant{19251}, // "Update guide information"
@@ -400,7 +400,7 @@ void CGUIWindowPVRChannelsBase::OnInputDone()
 
 void CGUIWindowPVRChannelsBase::GetChannelNumbers(std::vector<std::string>& channelNumbers)
 {
-  const std::shared_ptr<CPVRChannelGroup> group = GetChannelGroup();
+  const std::shared_ptr<const CPVRChannelGroup> group = GetChannelGroup();
   if (group)
     group->GetChannelNumbers(channelNumbers);
 }

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -197,7 +197,7 @@ void CGUIWindowPVRGuideBase::UpdateSelectedItemPath()
   CGUIEPGGridContainer* epgGridContainer = GetGridControl();
   if (epgGridContainer)
   {
-    const std::shared_ptr<CPVRChannelGroupMember> groupMember =
+    const std::shared_ptr<const CPVRChannelGroupMember> groupMember =
         epgGridContainer->GetSelectedChannelGroupMember();
     if (groupMember)
       CServiceBroker::GetPVRManager().Get<PVR::GUI::Channels>().SetSelectedChannelPath(
@@ -211,7 +211,7 @@ void CGUIWindowPVRGuideBase::UpdateButtons()
 
   SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, g_localizeStrings.Get(19032));
 
-  const std::shared_ptr<CPVRChannelGroup> group = GetChannelGroup();
+  const std::shared_ptr<const CPVRChannelGroup> group = GetChannelGroup();
   SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, group ? group->GroupName() : "");
 }
 
@@ -463,7 +463,7 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
                   break;
                 case EPG_SELECT_ACTION_SMART_SELECT:
                 {
-                  const std::shared_ptr<CPVREpgInfoTag> tag(pItem->GetEPGInfoTag());
+                  const std::shared_ptr<const CPVREpgInfoTag> tag(pItem->GetEPGInfoTag());
                   if (tag)
                   {
                     const CDateTime start(tag->StartAsUTC());
@@ -484,7 +484,8 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
                       else
                       {
                         bool bCanRecord = true;
-                        const std::shared_ptr<CPVRChannel> channel = CPVRItem(pItem).GetChannel();
+                        const std::shared_ptr<const CPVRChannel> channel =
+                            CPVRItem(pItem).GetChannel();
                         if (channel)
                           bCanRecord = channel->CanRecord();
 
@@ -782,7 +783,8 @@ bool CGUIWindowPVRGuideBase::GotoCurrentProgramme()
 
   if (!channel)
   {
-    const std::shared_ptr<CPVREpgInfoTag> playingTag = mgr.PlaybackState()->GetPlayingEpgTag();
+    const std::shared_ptr<const CPVREpgInfoTag> playingTag =
+        mgr.PlaybackState()->GetPlayingEpgTag();
     if (playingTag)
       channel = mgr.ChannelGroups()->GetChannelForEpgTag(playingTag);
   }
@@ -850,7 +852,8 @@ bool CGUIWindowPVRGuideBase::GotoPlayingChannel()
 
   if (!channel)
   {
-    const std::shared_ptr<CPVREpgInfoTag> playingTag = mgr.PlaybackState()->GetPlayingEpgTag();
+    const std::shared_ptr<const CPVREpgInfoTag> playingTag =
+        mgr.PlaybackState()->GetPlayingEpgTag();
     if (playingTag)
       channel = mgr.ChannelGroups()->GetChannelForEpgTag(playingTag);
   }
@@ -874,7 +877,7 @@ void CGUIWindowPVRGuideBase::OnInputDone()
 
 void CGUIWindowPVRGuideBase::GetChannelNumbers(std::vector<std::string>& channelNumbers)
 {
-  const std::shared_ptr<CPVRChannelGroup> group = GetChannelGroup();
+  const std::shared_ptr<const CPVRChannelGroup> group = GetChannelGroup();
   if (group)
     group->GetChannelNumbers(channelNumbers);
 }

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -280,7 +280,7 @@ CFileItemPtr CGUIWindowPVRGuideBase::GetCurrentListItem(int offset /*= 0*/)
   return {};
 }
 
-int CGUIWindowPVRGuideBase::GetCurrentListItemIndex(const std::shared_ptr<CFileItem>& item)
+int CGUIWindowPVRGuideBase::GetCurrentListItemIndex(const std::shared_ptr<const CFileItem>& item)
 {
   return item ? item->GetProperty("TimelineIndex").asInteger() : -1;
 }

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.h
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.h
@@ -85,7 +85,7 @@ private:
 
   void RefreshView(CGUIMessage& message, bool bInitGridControl);
 
-  int GetCurrentListItemIndex(const std::shared_ptr<CFileItem>& item);
+  int GetCurrentListItemIndex(const std::shared_ptr<const CFileItem>& item);
 
   std::unique_ptr<CPVRRefreshTimelineItemsThread> m_refreshTimelineItemsThread;
   std::atomic_bool m_bRefreshTimelineItems{false};

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -144,7 +144,7 @@ void CGUIWindowPVRSearchBase::SetItemToSearch(const CFileItem& item)
   {
     SetSearchFilter(std::make_shared<CPVREpgSearchFilter>(m_bRadio));
 
-    const std::shared_ptr<CPVREpgInfoTag> epgTag(CPVRItem(item).GetEpgInfoTag());
+    const std::shared_ptr<const CPVREpgInfoTag> epgTag(CPVRItem(item).GetEpgInfoTag());
     if (epgTag && !CServiceBroker::GetPVRManager().IsParentalLocked(epgTag))
       m_searchfilter->SetSearchPhrase(epgTag->Title());
   }


### PR DESCRIPTION
Nothing functional, just const correctness improvements - especially passing const shared pointer references to const objects whenever possible. That makes clear that the passed objects (not the shared pointer) are not supposed to be changed by the called method. Additionally, corrected const correctness of many std::shared_ptr local variables.

Compiles fine, runtime-tested on macOS, latest master.

@phunkyfish when you find some time for a review, many files, but trivial changes. Risk to introduce a regression is nearly zero.