### PR TITLE
[video][PVR] Info dialogs: Add support for default play action

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingInfo.cpp
@@ -13,7 +13,7 @@
 #include "guilib/GUIMessage.h"
 #include "pvr/PVRManager.h"
 #include "pvr/guilib/PVRGUIActionsEPG.h"
-#include "pvr/guilib/PVRGUIActionsPlayback.h"
+#include "pvr/guilib/PVRGUIRecordingsPlayActionProcessor.h"
 
 using namespace PVR;
 
@@ -59,8 +59,12 @@ bool CGUIDialogPVRRecordingInfo::OnClickButtonPlay(const CGUIMessage& message)
     Close();
 
     if (m_recordItem)
-      CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayRecording(
-          *m_recordItem, true /* check resume */);
+    {
+      CGUIPVRRecordingsPlayActionProcessor proc{*m_recordItem};
+      proc.Process();
+      if (proc.UserCancelled())
+        Open();
+    }
 
     bReturn = true;
   }

--- a/xbmc/pvr/guilib/CMakeLists.txt
+++ b/xbmc/pvr/guilib/CMakeLists.txt
@@ -30,6 +30,7 @@ set(HEADERS GUIEPGGridContainer.h
             PVRGUIActionsTimers.h
             PVRGUIChannelIconUpdater.h
             PVRGUIChannelNavigator.h
-            PVRGUIProgressHandler.h)
+            PVRGUIProgressHandler.h
+            PVRGUIRecordingsPlayActionProcessor.h)
 
 core_add_library(pvr_guilib)

--- a/xbmc/pvr/guilib/PVRGUIRecordingsPlayActionProcessor.h
+++ b/xbmc/pvr/guilib/PVRGUIRecordingsPlayActionProcessor.h
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "FileItem.h"
+#include "ServiceBroker.h"
+#include "pvr/PVRManager.h"
+#include "pvr/guilib/PVRGUIActionsPlayback.h"
+#include "video/guilib/VideoPlayActionProcessor.h"
+
+namespace PVR
+{
+class CGUIPVRRecordingsPlayActionProcessor : public VIDEO::GUILIB::CVideoPlayActionProcessorBase
+{
+public:
+  explicit CGUIPVRRecordingsPlayActionProcessor(CFileItem& item)
+    : CVideoPlayActionProcessorBase(item)
+  {
+  }
+
+protected:
+  bool OnResumeSelected() override
+  {
+    m_item.SetStartOffset(STARTOFFSET_RESUME);
+    Play();
+    return true;
+  }
+
+  bool OnPlaySelected() override
+  {
+    Play();
+    return true;
+  }
+
+private:
+  void Play()
+  {
+    CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayRecording(
+        m_item, false /* no resume check */);
+  }
+};
+} // namespace PVR

--- a/xbmc/video/guilib/VideoPlayActionProcessor.cpp
+++ b/xbmc/video/guilib/VideoPlayActionProcessor.cpp
@@ -30,13 +30,18 @@ bool CVideoPlayActionProcessorBase::Process()
 
 bool CVideoPlayActionProcessorBase::Process(PlayAction PlayAction)
 {
+  m_userCancelled = false;
+
   switch (PlayAction)
   {
     case PLAY_ACTION_PLAY_OR_RESUME:
     {
       const VIDEO::GUILIB::PlayAction action = ChoosePlayOrResume();
       if (action < 0)
+      {
+        m_userCancelled = true;
         return true; // User cancelled the select menu. We're done.
+      }
 
       return Process(action);
     }

--- a/xbmc/video/guilib/VideoPlayActionProcessor.h
+++ b/xbmc/video/guilib/VideoPlayActionProcessor.h
@@ -27,11 +27,14 @@ public:
   bool Process();
   bool Process(PlayAction playAction);
 
+  bool UserCancelled() const { return m_userCancelled; }
+
 protected:
   virtual bool OnResumeSelected() = 0;
   virtual bool OnPlaySelected() = 0;
 
   CFileItem& m_item;
+  bool m_userCancelled{false};
 
 private:
   CVideoPlayActionProcessorBase() = delete;


### PR DESCRIPTION
Video, PVR recordings and PVR guide dialogs offer "play" buttons. This PR adds support for default play action for these buttons, means, the button will act according to the settings value.

Runtime-tested on macOS and android, latest Kodi master.

@enen92 @phunkyfish mind taking a look at the code changes?