### PR TITLE
[input] Use smartpointers to wrap raw xkb pointers in libinput

### DIFF
--- a/xbmc/platform/linux/input/LibInputKeyboard.cpp
+++ b/xbmc/platform/linux/input/LibInputKeyboard.cpp
@@ -18,7 +18,6 @@
 #include "utils/log.h"
 
 #include <algorithm>
-#include <map>
 #include <string.h>
 
 #include <fcntl.h>
@@ -33,123 +32,122 @@ namespace
 constexpr int REPEAT_DELAY = 400;
 constexpr int REPEAT_RATE = 80;
 
-static const std::map<xkb_keysym_t, XBMCKey> xkbMap =
-{
-  // Function keys before start of ASCII printable character range
-  { XKB_KEY_BackSpace, XBMCK_BACKSPACE },
-  { XKB_KEY_Tab, XBMCK_TAB },
-  { XKB_KEY_Clear, XBMCK_CLEAR },
-  { XKB_KEY_Return, XBMCK_RETURN },
-  { XKB_KEY_Pause, XBMCK_PAUSE },
-  { XKB_KEY_Escape, XBMCK_ESCAPE },
+constexpr auto xkbMap = make_map<xkb_keysym_t, XBMCKey>({
+    // Function keys before start of ASCII printable character range
+    {XKB_KEY_BackSpace, XBMCK_BACKSPACE},
+    {XKB_KEY_Tab, XBMCK_TAB},
+    {XKB_KEY_Clear, XBMCK_CLEAR},
+    {XKB_KEY_Return, XBMCK_RETURN},
+    {XKB_KEY_Pause, XBMCK_PAUSE},
+    {XKB_KEY_Escape, XBMCK_ESCAPE},
 
-  // ASCII printable range - not included here
+    // ASCII printable range - not included here
 
-  // Function keys after end of ASCII printable character range
-  { XKB_KEY_Delete, XBMCK_DELETE },
+    // Function keys after end of ASCII printable character range
+    {XKB_KEY_Delete, XBMCK_DELETE},
 
-  // Multimedia keys
-  { XKB_KEY_XF86Back, XBMCK_BROWSER_BACK },
-  { XKB_KEY_XF86Forward, XBMCK_BROWSER_FORWARD },
-  { XKB_KEY_XF86Refresh, XBMCK_BROWSER_REFRESH },
-  { XKB_KEY_XF86Stop, XBMCK_BROWSER_STOP },
-  { XKB_KEY_XF86Search, XBMCK_BROWSER_SEARCH },
-  // XKB_KEY_XF86Favorites could be XBMCK_BROWSER_FAVORITES or XBMCK_FAVORITES,
-  // XBMCK_FAVORITES was chosen here because it is more general
-  { XKB_KEY_XF86HomePage, XBMCK_BROWSER_HOME },
-  { XKB_KEY_XF86AudioMute, XBMCK_VOLUME_MUTE },
-  { XKB_KEY_XF86AudioLowerVolume, XBMCK_VOLUME_DOWN },
-  { XKB_KEY_XF86AudioRaiseVolume, XBMCK_VOLUME_UP },
-  { XKB_KEY_XF86AudioNext, XBMCK_MEDIA_NEXT_TRACK },
-  { XKB_KEY_XF86AudioPrev, XBMCK_MEDIA_PREV_TRACK },
-  { XKB_KEY_XF86AudioStop, XBMCK_MEDIA_STOP },
-  { XKB_KEY_XF86AudioPause, XBMCK_MEDIA_PLAY_PAUSE },
-  { XKB_KEY_XF86Mail, XBMCK_LAUNCH_MAIL },
-  { XKB_KEY_XF86Select, XBMCK_LAUNCH_MEDIA_SELECT },
-  { XKB_KEY_XF86Launch0, XBMCK_LAUNCH_APP1 },
-  { XKB_KEY_XF86Launch1, XBMCK_LAUNCH_APP2 },
-  { XKB_KEY_XF86WWW, XBMCK_LAUNCH_FILE_BROWSER },
-  { XKB_KEY_XF86AudioMedia, XBMCK_LAUNCH_MEDIA_CENTER },
-  { XKB_KEY_XF86AudioRewind, XBMCK_MEDIA_REWIND },
-  { XKB_KEY_XF86AudioForward, XBMCK_MEDIA_FASTFORWARD },
+    // Multimedia keys
+    {XKB_KEY_XF86Back, XBMCK_BROWSER_BACK},
+    {XKB_KEY_XF86Forward, XBMCK_BROWSER_FORWARD},
+    {XKB_KEY_XF86Refresh, XBMCK_BROWSER_REFRESH},
+    {XKB_KEY_XF86Stop, XBMCK_BROWSER_STOP},
+    {XKB_KEY_XF86Search, XBMCK_BROWSER_SEARCH},
+    // XKB_KEY_XF86Favorites could be XBMCK_BROWSER_FAVORITES or XBMCK_FAVORITES,
+    // XBMCK_FAVORITES was chosen here because it is more general
+    {XKB_KEY_XF86HomePage, XBMCK_BROWSER_HOME},
+    {XKB_KEY_XF86AudioMute, XBMCK_VOLUME_MUTE},
+    {XKB_KEY_XF86AudioLowerVolume, XBMCK_VOLUME_DOWN},
+    {XKB_KEY_XF86AudioRaiseVolume, XBMCK_VOLUME_UP},
+    {XKB_KEY_XF86AudioNext, XBMCK_MEDIA_NEXT_TRACK},
+    {XKB_KEY_XF86AudioPrev, XBMCK_MEDIA_PREV_TRACK},
+    {XKB_KEY_XF86AudioStop, XBMCK_MEDIA_STOP},
+    {XKB_KEY_XF86AudioPause, XBMCK_MEDIA_PLAY_PAUSE},
+    {XKB_KEY_XF86Mail, XBMCK_LAUNCH_MAIL},
+    {XKB_KEY_XF86Select, XBMCK_LAUNCH_MEDIA_SELECT},
+    {XKB_KEY_XF86Launch0, XBMCK_LAUNCH_APP1},
+    {XKB_KEY_XF86Launch1, XBMCK_LAUNCH_APP2},
+    {XKB_KEY_XF86WWW, XBMCK_LAUNCH_FILE_BROWSER},
+    {XKB_KEY_XF86AudioMedia, XBMCK_LAUNCH_MEDIA_CENTER},
+    {XKB_KEY_XF86AudioRewind, XBMCK_MEDIA_REWIND},
+    {XKB_KEY_XF86AudioForward, XBMCK_MEDIA_FASTFORWARD},
 
-  // Numeric keypad
-  { XKB_KEY_KP_0, XBMCK_KP0 },
-  { XKB_KEY_KP_1, XBMCK_KP1 },
-  { XKB_KEY_KP_2, XBMCK_KP2 },
-  { XKB_KEY_KP_3, XBMCK_KP3 },
-  { XKB_KEY_KP_4, XBMCK_KP4 },
-  { XKB_KEY_KP_5, XBMCK_KP5 },
-  { XKB_KEY_KP_6, XBMCK_KP6 },
-  { XKB_KEY_KP_7, XBMCK_KP7 },
-  { XKB_KEY_KP_8, XBMCK_KP8 },
-  { XKB_KEY_KP_9, XBMCK_KP9 },
-  { XKB_KEY_KP_Decimal, XBMCK_KP_PERIOD },
-  { XKB_KEY_KP_Divide, XBMCK_KP_DIVIDE },
-  { XKB_KEY_KP_Multiply, XBMCK_KP_MULTIPLY },
-  { XKB_KEY_KP_Subtract, XBMCK_KP_MINUS },
-  { XKB_KEY_KP_Add, XBMCK_KP_PLUS },
-  { XKB_KEY_KP_Enter, XBMCK_KP_ENTER },
-  { XKB_KEY_KP_Equal, XBMCK_KP_EQUALS },
+    // Numeric keypad
+    {XKB_KEY_KP_0, XBMCK_KP0},
+    {XKB_KEY_KP_1, XBMCK_KP1},
+    {XKB_KEY_KP_2, XBMCK_KP2},
+    {XKB_KEY_KP_3, XBMCK_KP3},
+    {XKB_KEY_KP_4, XBMCK_KP4},
+    {XKB_KEY_KP_5, XBMCK_KP5},
+    {XKB_KEY_KP_6, XBMCK_KP6},
+    {XKB_KEY_KP_7, XBMCK_KP7},
+    {XKB_KEY_KP_8, XBMCK_KP8},
+    {XKB_KEY_KP_9, XBMCK_KP9},
+    {XKB_KEY_KP_Decimal, XBMCK_KP_PERIOD},
+    {XKB_KEY_KP_Divide, XBMCK_KP_DIVIDE},
+    {XKB_KEY_KP_Multiply, XBMCK_KP_MULTIPLY},
+    {XKB_KEY_KP_Subtract, XBMCK_KP_MINUS},
+    {XKB_KEY_KP_Add, XBMCK_KP_PLUS},
+    {XKB_KEY_KP_Enter, XBMCK_KP_ENTER},
+    {XKB_KEY_KP_Equal, XBMCK_KP_EQUALS},
 
-  // Arrows + Home/End pad
-  { XKB_KEY_Up, XBMCK_UP },
-  { XKB_KEY_Down, XBMCK_DOWN },
-  { XKB_KEY_Right, XBMCK_RIGHT },
-  { XKB_KEY_Left, XBMCK_LEFT },
-  { XKB_KEY_Insert, XBMCK_INSERT },
-  { XKB_KEY_Home, XBMCK_HOME },
-  { XKB_KEY_End, XBMCK_END },
-  { XKB_KEY_Page_Up, XBMCK_PAGEUP },
-  { XKB_KEY_Page_Down, XBMCK_PAGEDOWN },
+    // Arrows + Home/End pad
+    {XKB_KEY_Up, XBMCK_UP},
+    {XKB_KEY_Down, XBMCK_DOWN},
+    {XKB_KEY_Right, XBMCK_RIGHT},
+    {XKB_KEY_Left, XBMCK_LEFT},
+    {XKB_KEY_Insert, XBMCK_INSERT},
+    {XKB_KEY_Home, XBMCK_HOME},
+    {XKB_KEY_End, XBMCK_END},
+    {XKB_KEY_Page_Up, XBMCK_PAGEUP},
+    {XKB_KEY_Page_Down, XBMCK_PAGEDOWN},
 
-  // Key state modifier keys
-  { XKB_KEY_Num_Lock, XBMCK_NUMLOCK },
-  { XKB_KEY_Caps_Lock, XBMCK_CAPSLOCK },
-  { XKB_KEY_Scroll_Lock, XBMCK_SCROLLOCK },
-  { XKB_KEY_Shift_R, XBMCK_RSHIFT },
-  { XKB_KEY_Shift_L, XBMCK_LSHIFT },
-  { XKB_KEY_Control_R, XBMCK_RCTRL },
-  { XKB_KEY_Control_L, XBMCK_LCTRL },
-  { XKB_KEY_Alt_R, XBMCK_RALT },
-  { XKB_KEY_Alt_L, XBMCK_LALT },
-  { XKB_KEY_Meta_R, XBMCK_RMETA },
-  { XKB_KEY_Meta_L, XBMCK_LMETA },
-  { XKB_KEY_Super_R, XBMCK_RSUPER },
-  { XKB_KEY_Super_L, XBMCK_LSUPER },
-  // XKB does not have XBMCK_MODE/"Alt Gr" - probably equal to XKB_KEY_Alt_R
-  { XKB_KEY_Multi_key, XBMCK_COMPOSE },
+    // Key state modifier keys
+    {XKB_KEY_Num_Lock, XBMCK_NUMLOCK},
+    {XKB_KEY_Caps_Lock, XBMCK_CAPSLOCK},
+    {XKB_KEY_Scroll_Lock, XBMCK_SCROLLOCK},
+    {XKB_KEY_Shift_R, XBMCK_RSHIFT},
+    {XKB_KEY_Shift_L, XBMCK_LSHIFT},
+    {XKB_KEY_Control_R, XBMCK_RCTRL},
+    {XKB_KEY_Control_L, XBMCK_LCTRL},
+    {XKB_KEY_Alt_R, XBMCK_RALT},
+    {XKB_KEY_Alt_L, XBMCK_LALT},
+    {XKB_KEY_Meta_R, XBMCK_RMETA},
+    {XKB_KEY_Meta_L, XBMCK_LMETA},
+    {XKB_KEY_Super_R, XBMCK_RSUPER},
+    {XKB_KEY_Super_L, XBMCK_LSUPER},
+    // XKB does not have XBMCK_MODE/"Alt Gr" - probably equal to XKB_KEY_Alt_R
+    {XKB_KEY_Multi_key, XBMCK_COMPOSE},
 
-  // Miscellaneous function keys
-  { XKB_KEY_Help, XBMCK_HELP },
-  { XKB_KEY_Print, XBMCK_PRINT },
-  { XKB_KEY_Sys_Req, XBMCK_SYSREQ},
-  { XKB_KEY_Break, XBMCK_BREAK },
-  { XKB_KEY_Menu, XBMCK_MENU },
-  { XKB_KEY_XF86PowerOff, XBMCK_POWER },
-  { XKB_KEY_EcuSign, XBMCK_EURO },
-  { XKB_KEY_Undo, XBMCK_UNDO },
-  { XKB_KEY_XF86Sleep, XBMCK_SLEEP },
-  // Unmapped: XBMCK_GUIDE, XBMCK_SETTINGS, XBMCK_INFO
-  { XKB_KEY_XF86Red, XBMCK_RED },
-  { XKB_KEY_XF86Green, XBMCK_GREEN },
-  { XKB_KEY_XF86Yellow, XBMCK_YELLOW },
-  { XKB_KEY_XF86Blue, XBMCK_BLUE },
-  // Unmapped: XBMCK_ZOOM, XBMCK_TEXT
-  { XKB_KEY_XF86Favorites, XBMCK_FAVORITES },
-  { XKB_KEY_XF86HomePage, XBMCK_HOMEPAGE },
-  // Unmapped: XBMCK_CONFIG, XBMCK_EPG
+    // Miscellaneous function keys
+    {XKB_KEY_Help, XBMCK_HELP},
+    {XKB_KEY_Print, XBMCK_PRINT},
+    {XKB_KEY_Sys_Req, XBMCK_SYSREQ},
+    {XKB_KEY_Break, XBMCK_BREAK},
+    {XKB_KEY_Menu, XBMCK_MENU},
+    {XKB_KEY_XF86PowerOff, XBMCK_POWER},
+    {XKB_KEY_EcuSign, XBMCK_EURO},
+    {XKB_KEY_Undo, XBMCK_UNDO},
+    {XKB_KEY_XF86Sleep, XBMCK_SLEEP},
+    // Unmapped: XBMCK_GUIDE, XBMCK_SETTINGS, XBMCK_INFO
+    {XKB_KEY_XF86Red, XBMCK_RED},
+    {XKB_KEY_XF86Green, XBMCK_GREEN},
+    {XKB_KEY_XF86Yellow, XBMCK_YELLOW},
+    {XKB_KEY_XF86Blue, XBMCK_BLUE},
+    // Unmapped: XBMCK_ZOOM, XBMCK_TEXT
+    {XKB_KEY_XF86Favorites, XBMCK_FAVORITES},
+    {XKB_KEY_XF86HomePage, XBMCK_HOMEPAGE},
+    // Unmapped: XBMCK_CONFIG, XBMCK_EPG
 
-  // Media keys
-  { XKB_KEY_XF86Eject, XBMCK_EJECT },
-  { XKB_KEY_Cancel, XBMCK_STOP },
-  { XKB_KEY_XF86AudioRecord, XBMCK_RECORD },
-  // XBMCK_REWIND clashes with XBMCK_MEDIA_REWIND
-  { XKB_KEY_XF86Phone, XBMCK_PHONE },
-  { XKB_KEY_XF86AudioPlay, XBMCK_PLAY },
-  { XKB_KEY_XF86AudioRandomPlay, XBMCK_SHUFFLE }
-  // XBMCK_FASTFORWARD clashes with XBMCK_MEDIA_FASTFORWARD
-};
+    // Media keys
+    {XKB_KEY_XF86Eject, XBMCK_EJECT},
+    {XKB_KEY_Cancel, XBMCK_STOP},
+    {XKB_KEY_XF86AudioRecord, XBMCK_RECORD},
+    // XBMCK_REWIND clashes with XBMCK_MEDIA_REWIND
+    {XKB_KEY_XF86Phone, XBMCK_PHONE},
+    {XKB_KEY_XF86AudioPlay, XBMCK_PLAY},
+    {XKB_KEY_XF86AudioRandomPlay, XBMCK_SHUFFLE}
+    // XBMCK_FASTFORWARD clashes with XBMCK_MEDIA_FASTFORWARD
+});
 
 constexpr auto logLevelMap = make_map<xkb_log_level, int>({{XKB_LOG_LEVEL_CRITICAL, LOGERROR},
                                                            {XKB_LOG_LEVEL_ERROR, LOGERROR},
@@ -369,7 +367,7 @@ XBMCKey CLibInputKeyboard::XBMCKeyForKeysym(xkb_keysym_t sym, uint32_t scancode)
   }
 
   auto xkbmapping = xkbMap.find(sym);
-  if (xkbmapping != xkbMap.end())
+  if (xkbmapping != xkbMap.cend())
     return xkbmapping->second;
 
   return XBMCK_UNKNOWN;

--- a/xbmc/platform/linux/input/LibInputKeyboard.cpp
+++ b/xbmc/platform/linux/input/LibInputKeyboard.cpp
@@ -29,8 +29,8 @@
 
 namespace
 {
-constexpr int REPEAT_DELAY = 400;
-constexpr int REPEAT_RATE = 80;
+constexpr unsigned int REPEAT_DELAY = 400;
+constexpr unsigned int REPEAT_RATE = 80;
 
 constexpr auto xkbMap = make_map<xkb_keysym_t, XBMCKey>({
     // Function keys before start of ASCII printable character range

--- a/xbmc/platform/linux/input/LibInputKeyboard.h
+++ b/xbmc/platform/linux/input/LibInputKeyboard.h
@@ -12,6 +12,7 @@
 #include "windowing/XBMC_events.h"
 
 #include <map>
+#include <memory>
 #include <vector>
 
 #include <libinput.h>
@@ -21,7 +22,7 @@ class CLibInputKeyboard
 {
 public:
   CLibInputKeyboard();
-  ~CLibInputKeyboard();
+  ~CLibInputKeyboard() = default;
 
   void ProcessKey(libinput_event_keyboard *e);
   void UpdateLeds(libinput_device *dev);
@@ -33,9 +34,24 @@ private:
   XBMCKey XBMCKeyForKeysym(xkb_keysym_t sym, uint32_t scancode);
   void KeyRepeatTimeout();
 
-  xkb_context *m_ctx = nullptr;
-  xkb_keymap *m_keymap = nullptr;
-  xkb_state *m_state = nullptr;
+  struct XkbContextDeleter
+  {
+    void operator()(xkb_context* ctx) const;
+  };
+  std::unique_ptr<xkb_context, XkbContextDeleter> m_ctx;
+
+  struct XkbKeymapDeleter
+  {
+    void operator()(xkb_keymap* keymap) const;
+  };
+  std::unique_ptr<xkb_keymap, XkbKeymapDeleter> m_keymap;
+
+  struct XkbStateDeleter
+  {
+    void operator()(xkb_state* state) const;
+  };
+  std::unique_ptr<xkb_state, XkbStateDeleter> m_state;
+
   xkb_mod_index_t m_modindex[4];
   xkb_led_index_t m_ledindex[3];
 


### PR DESCRIPTION
## Description
I was thinking about implementing dead-key/compose support for devices using libinput similar to what was done in https://github.com/xbmc/xbmc/pull/23943. While at it I figured out I should probably first avoid using raw pointers in the class and wrap them into smart pointers with custom deleters.

Also adds a logger implementation hooked to our CLog class.
Should be quite straightforward to review (@neo1973 was selected after throwing a dice with "neo1973" written on all faces :) )

## Motivation and context
Improvement over the existing code

## How has this been tested?
Runtime tested with Librelec on a gbm platform (allwinner pine64 lts)

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
