### PR TITLE
[contextmenumanager] Fix 'More...' context menu item displayed for favourites…

### DIFF
--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -208,11 +208,10 @@ bool CContextMenuManager::IsVisible(
   return menuItem.IsVisible(fileItem);
 }
 
-bool CContextMenuManager::HasItems(const CFileItem& fileItem,
-                                   const CContextMenuItem& root /*= MAIN*/) const
+bool CContextMenuManager::HasItems(const CFileItem& fileItem, const CContextMenuItem& root) const
 {
   //! @todo implement group support
-  if (&root == &MAIN)
+  if (&root == &CContextMenuManager::MAIN)
   {
     std::unique_lock<CCriticalSection> lock(m_criticalSection);
     return std::any_of(m_items.cbegin(), m_items.cend(),
@@ -223,11 +222,12 @@ bool CContextMenuManager::HasItems(const CFileItem& fileItem,
   return false;
 }
 
-ContextMenuView CContextMenuManager::GetItems(const CFileItem& fileItem, const CContextMenuItem& root /*= MAIN*/) const
+ContextMenuView CContextMenuManager::GetItems(const CFileItem& fileItem,
+                                              const CContextMenuItem& root) const
 {
   ContextMenuView result;
   //! @todo implement group support
-  if (&root == &MAIN)
+  if (&root == &CContextMenuManager::MAIN)
   {
     std::unique_lock<CCriticalSection> lock(m_criticalSection);
     std::copy_if(m_items.begin(), m_items.end(), std::back_inserter(result),
@@ -237,7 +237,7 @@ ContextMenuView CContextMenuManager::GetItems(const CFileItem& fileItem, const C
 }
 
 bool CContextMenuManager::HasAddonItems(const CFileItem& fileItem,
-                                        const CContextMenuItem& root /*= MAIN*/) const
+                                        const CContextMenuItem& root) const
 {
   std::unique_lock<CCriticalSection> lock(m_criticalSection);
   return std::any_of(m_addonItems.cbegin(), m_addonItems.cend(),
@@ -246,7 +246,8 @@ bool CContextMenuManager::HasAddonItems(const CFileItem& fileItem,
                      });
 }
 
-ContextMenuView CContextMenuManager::GetAddonItems(const CFileItem& fileItem, const CContextMenuItem& root /*= MAIN*/) const
+ContextMenuView CContextMenuManager::GetAddonItems(const CFileItem& fileItem,
+                                                   const CContextMenuItem& root) const
 {
   ContextMenuView result;
   {
@@ -256,7 +257,7 @@ ContextMenuView CContextMenuManager::GetAddonItems(const CFileItem& fileItem, co
         result.emplace_back(new CContextMenuItem(menu));
   }
 
-  if (&root == &MANAGE)
+  if (&root == &CContextMenuManager::MANAGE)
   {
     std::sort(result.begin(), result.end(),
         [&](const ContextMenuView::value_type& lhs, const ContextMenuView::value_type& rhs)
@@ -269,7 +270,7 @@ ContextMenuView CContextMenuManager::GetAddonItems(const CFileItem& fileItem, co
 }
 
 bool CONTEXTMENU::HasAnyMenuItemsFor(const std::shared_ptr<CFileItem>& fileItem,
-                                     const CContextMenuItem& root /*= MAIN*/)
+                                     const CContextMenuItem& root)
 {
   if (!fileItem)
     return false;

--- a/xbmc/ContextMenuManager.h
+++ b/xbmc/ContextMenuManager.h
@@ -40,11 +40,11 @@ public:
   void Init();
   void Deinit();
 
-  bool HasItems(const CFileItem& fileItem, const CContextMenuItem& root = MAIN) const;
-  ContextMenuView GetItems(const CFileItem& item, const CContextMenuItem& root = MAIN) const;
+  bool HasItems(const CFileItem& fileItem, const CContextMenuItem& root) const;
+  ContextMenuView GetItems(const CFileItem& item, const CContextMenuItem& root) const;
 
-  bool HasAddonItems(const CFileItem& fileItem, const CContextMenuItem& root = MAIN) const;
-  ContextMenuView GetAddonItems(const CFileItem& item, const CContextMenuItem& root = MAIN) const;
+  bool HasAddonItems(const CFileItem& fileItem, const CContextMenuItem& root) const;
+  ContextMenuView GetAddonItems(const CFileItem& item, const CContextMenuItem& root) const;
 
 private:
   CContextMenuManager(const CContextMenuManager&) = delete;
@@ -72,14 +72,12 @@ namespace CONTEXTMENU
 /*!
  * Checks whether any context menu items are available for a file item.
  * */
-bool HasAnyMenuItemsFor(const std::shared_ptr<CFileItem>& fileItem,
-                        const CContextMenuItem& root = CContextMenuManager::MAIN);
+bool HasAnyMenuItemsFor(const std::shared_ptr<CFileItem>& fileItem, const CContextMenuItem& root);
 
 /*!
    * Starts the context menu loop for a file item.
    * */
-bool ShowFor(const std::shared_ptr<CFileItem>& fileItem,
-             const CContextMenuItem& root = CContextMenuManager::MAIN);
+bool ShowFor(const std::shared_ptr<CFileItem>& fileItem, const CContextMenuItem& root);
 
 /*!
    * Shortcut for continuing the context menu loop from an existing menu item.

--- a/xbmc/ContextMenuManager.h
+++ b/xbmc/ContextMenuManager.h
@@ -40,10 +40,10 @@ public:
   void Init();
   void Deinit();
 
-  bool HasItems(const CFileItem& fileItem) const;
+  bool HasItems(const CFileItem& fileItem, const CContextMenuItem& root = MAIN) const;
   ContextMenuView GetItems(const CFileItem& item, const CContextMenuItem& root = MAIN) const;
 
-  bool HasAddonItems(const CFileItem& fileItem) const;
+  bool HasAddonItems(const CFileItem& fileItem, const CContextMenuItem& root = MAIN) const;
   ContextMenuView GetAddonItems(const CFileItem& item, const CContextMenuItem& root = MAIN) const;
 
 private:
@@ -72,7 +72,8 @@ namespace CONTEXTMENU
 /*!
  * Checks whether any context menu items are available for a file item.
  * */
-bool HasAnyMenuItemsFor(const std::shared_ptr<CFileItem>& fileItem);
+bool HasAnyMenuItemsFor(const std::shared_ptr<CFileItem>& fileItem,
+                        const CContextMenuItem& root = CContextMenuManager::MAIN);
 
 /*!
    * Starts the context menu loop for a file item.

--- a/xbmc/ContextMenuManager.h
+++ b/xbmc/ContextMenuManager.h
@@ -40,11 +40,35 @@ public:
   void Init();
   void Deinit();
 
+  /*! \brief Checks whether context menu items are available for a file item.
+   \param fileItem the file item
+   \param root the root context menu item
+   \return true if any items are present, false otherwise
+   */
   bool HasItems(const CFileItem& fileItem, const CContextMenuItem& root) const;
-  ContextMenuView GetItems(const CFileItem& item, const CContextMenuItem& root) const;
 
+  /*! \brief Gets the context menu items available for a file item.
+   \param fileItem the file item
+   \param root the root context menu item
+   \return the items
+   \sa ContextMenuView
+   */
+  ContextMenuView GetItems(const CFileItem& fileItem, const CContextMenuItem& root) const;
+
+  /*! \brief Checks whether addon context menu items are available for a file item.
+   \param fileItem the file item
+   \param root the root context menu item
+   \return true if any items are present, false otherwise
+   */
   bool HasAddonItems(const CFileItem& fileItem, const CContextMenuItem& root) const;
-  ContextMenuView GetAddonItems(const CFileItem& item, const CContextMenuItem& root) const;
+
+  /*! \brief Gets the addon context menu items available for a file item.
+   \param fileItem the file item
+   \param root the root context menu item
+   \return the items
+   \sa ContextMenuView
+   */
+  ContextMenuView GetAddonItems(const CFileItem& fileItem, const CContextMenuItem& root) const;
 
 private:
   CContextMenuManager(const CContextMenuManager&) = delete;
@@ -69,18 +93,24 @@ private:
 
 namespace CONTEXTMENU
 {
-/*!
- * Checks whether any context menu items are available for a file item.
- * */
+/*! \brief Checks whether any context menu items are available for a file item.
+ \param fileItem the file item
+ \param root the root context menu item
+ \return true if any items are present, false otherwise
+ */
 bool HasAnyMenuItemsFor(const std::shared_ptr<CFileItem>& fileItem, const CContextMenuItem& root);
 
-/*!
-   * Starts the context menu loop for a file item.
-   * */
+/*! \brief Starts the context menu loop for a file item.
+ \param fileItem the file item
+ \param root the root context menu item
+ \return true on success, false otherwise
+ */
 bool ShowFor(const std::shared_ptr<CFileItem>& fileItem, const CContextMenuItem& root);
 
-/*!
-   * Shortcut for continuing the context menu loop from an existing menu item.
-   */
+/*! \brief Shortcut for continuing the context menu loop from an existing menu item.
+ \param menu the menu item
+ \param fileItem the file item
+ \return true on success, false otherwise
+ */
 bool LoopFrom(const IContextMenuItem& menu, const std::shared_ptr<CFileItem>& fileItem);
 }

--- a/xbmc/favourites/ContextMenus.cpp
+++ b/xbmc/favourites/ContextMenus.cpp
@@ -198,7 +198,7 @@ bool CFavouritesTargetContextMenu::IsVisible(const CFileItem& item) const
 {
   const std::shared_ptr<CFileItem> targetItem{ResolveFavouriteItem(item)};
   if (targetItem)
-    return CONTEXTMENU::HasAnyMenuItemsFor(targetItem);
+    return CONTEXTMENU::HasAnyMenuItemsFor(targetItem, CContextMenuManager::MAIN);
 
   return false;
 }
@@ -208,7 +208,7 @@ bool CFavouritesTargetContextMenu::Execute(const std::shared_ptr<CFileItem>& ite
   const std::shared_ptr<CFileItem> targetItem{ResolveFavouriteItem(*item)};
   if (targetItem)
   {
-    CONTEXTMENU::ShowFor(targetItem);
+    CONTEXTMENU::ShowFor(targetItem, CContextMenuManager::MAIN);
     return true;
   }
   return false;

--- a/xbmc/favourites/GUIWindowFavourites.cpp
+++ b/xbmc/favourites/GUIWindowFavourites.cpp
@@ -86,7 +86,7 @@ protected:
 
   bool OnMoreSelected() override
   {
-    CONTEXTMENU::ShowFor(std::make_shared<CFileItem>(m_item));
+    CONTEXTMENU::ShowFor(std::make_shared<CFileItem>(m_item), CContextMenuManager::MAIN);
     return true;
   }
 };

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -634,7 +634,7 @@ bool CDirectoryProvider::OnContextMenu(const std::shared_ptr<CFileItem>& fileIte
   if (!target.empty())
     fileItem->SetProperty("targetwindow", target);
 
-  return CONTEXTMENU::ShowFor(fileItem);
+  return CONTEXTMENU::ShowFor(fileItem, CContextMenuManager::MAIN);
 }
 
 bool CDirectoryProvider::OnContextMenu(const CGUIListItemPtr& item)


### PR DESCRIPTION
…, although no target context menu items are available.

I wrongly implemented `CContextMenuManager::HasAddonItems`in the first place; which this PR fixes. Effect is that in the context menu for favourites the "More ..." item (supposed to open the context menu of favourites's target item) only appears if the target item actually offers any context menu item.

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 please review, thanks. The `Has` methods need to do what the corresponding `Get` methods (which are available for a long time) do, but only shall check with `std::any_of`, not actually collect all items.