### PR TITLE
[libinput] Add dead-key xkbcommon-compose support

### DIFF
--- a/xbmc/platform/linux/input/LibInputKeyboard.h
+++ b/xbmc/platform/linux/input/LibInputKeyboard.h
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include <libinput.h>
+#include <xkbcommon/xkbcommon-compose.h>
 #include <xkbcommon/xkbcommon.h>
 
 class CLibInputKeyboard
@@ -33,7 +34,22 @@ public:
 private:
   XBMCKey XBMCKeyForKeysym(xkb_keysym_t sym, uint32_t scancode);
   void KeyRepeatTimeout();
-
+  /**
+   * Check if the system supports key composition
+   * \return true if composition is supported, false otherwise
+   */
+  bool SupportsKeyComposition() const;
+  /**
+   * Notify the outside world about key composing events
+   *
+   * \param eventType - the key composition event type
+   * \param unicodeCodepoint - unicode codepoint of the pressed dead key
+   */
+  void NotifyKeyComposingEvent(uint8_t eventType, std::uint16_t unicodeCodepoint);
+  /**
+   * Get Unicode codepoint/UTF32 code for provided keycode
+   */
+  std::uint32_t UnicodeCodepointForKeycode(xkb_keycode_t code) const;
   struct XkbContextDeleter
   {
     void operator()(xkb_context* ctx) const;
@@ -51,6 +67,18 @@ private:
     void operator()(xkb_state* state) const;
   };
   std::unique_ptr<xkb_state, XkbStateDeleter> m_state;
+
+  struct XkbComposeTableDeleter
+  {
+    void operator()(xkb_compose_table* composeTable) const;
+  };
+  std::unique_ptr<xkb_compose_table, XkbComposeTableDeleter> m_composeTable;
+
+  struct XkbComposeStateDeleter
+  {
+    void operator()(xkb_compose_state* state) const;
+  };
+  std::unique_ptr<xkb_compose_state, XkbComposeStateDeleter> m_composedState;
 
   xkb_mod_index_t m_modindex[4];
   xkb_led_index_t m_ledindex[3];


### PR DESCRIPTION
## Description
This adds dead-key/ key composing support for platforms using libinput/evdev for keyboard, similar to what was previously done for wayland in https://github.com/xbmc/xbmc/pull/23943.
It depends on https://github.com/xbmc/xbmc/pull/24036 so the only important commit to review is actually https://github.com/xbmc/xbmc/commit/c2f443e9f228adfbebe84d45ee69e90e7caf51f2

## Motivation and context
I cannot input `~`, `^` or composed keys like `ãêó` on platforms that use libinput (such those using gbm in Libreelec). Passwords or localized movie titles contain such characters.

## How has this been tested?
Runtime tested on Libreelec for alwinner pine64 lts (patched to include the compose files from libx11). As stated in the [documentation](https://github.com/xbmc/xbmc/commit/c2f443e9f228adfbebe84d45ee69e90e7caf51f2):

```
libxkbcommon does not distribute a keymap dataset itself, other than for testing purposes. The most common dataset is xkeyboard-config, which is used by all current distributions for their X11 XKB data. More information on xkeyboard-config is available here: https://www.freedesktop.org/wiki/Software/XKeyboardConfig

The dataset for Compose is distributed in libX11, as part of the X locale data.
```



## What is the effect on users?
Improve the keyboard support

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
