### PR TITLE
[xkbcommon] Unify xkbLogger

### DIFF
--- a/xbmc/windowing/wayland/XkbcommonKeymap.cpp
+++ b/xbmc/windowing/wayland/XkbcommonKeymap.cpp
@@ -24,32 +24,22 @@ using namespace KODI::WINDOWING::WAYLAND;
 
 namespace
 {
+static const std::unordered_map<xkb_log_level, int> logLevelMap = {
+    {XKB_LOG_LEVEL_CRITICAL, LOGERROR},  {XKB_LOG_LEVEL_ERROR, LOGERROR},
+    {XKB_LOG_LEVEL_WARNING, LOGWARNING}, {XKB_LOG_LEVEL_INFO, LOGINFO},
+    {XKB_LOG_LEVEL_DEBUG, LOGDEBUG},
+};
+
 static void xkbLogger(xkb_context* context,
                       xkb_log_level priority,
                       const char* format,
                       va_list args)
 {
   const std::string message = StringUtils::FormatV(format, args);
-  auto logLevel = LOGDEBUG;
-  switch (priority)
-  {
-    case XKB_LOG_LEVEL_INFO:
-      logLevel = LOGINFO;
-      break;
-    case XKB_LOG_LEVEL_ERROR:
-      logLevel = LOGERROR;
-      break;
-    case XKB_LOG_LEVEL_WARNING:
-      logLevel = LOGWARNING;
-      break;
-    case XKB_LOG_LEVEL_DEBUG:
-      logLevel = LOGDEBUG;
-      break;
-    default:
-      break;
-  };
-  CLog::LogF(logLevel, "{}", message);
+  auto logLevel = logLevelMap.find(priority);
+  CLog::Log(logLevel != logLevelMap.end() ? logLevel->second : LOGDEBUG, "[xkb] {}", message);
 }
+
 struct ModifierNameXBMCMapping
 {
   const char* name;


### PR DESCRIPTION
## Description
In https://github.com/xbmc/xbmc/pull/24036 it was pointed out that a map is preferred over a switch case and also that prefixing the log messages from xkbcommon with `[xkb]` would be better than just using `LogF`. Hence, to avoid having different implementations this PR does exactly the same for the already existing logger in the wayland implementation.