### PR TITLE
[FileSystem] Move File Cache settings to GUI settings

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -22173,7 +22173,125 @@ msgctxt "#37057"
 msgid "Data chunk size used on SMB connections"
 msgstr ""
 
-#empty strings from id 37058 to 38010
+#empty strings from id 37058 to 37100
+
+#. Settings / Services "Caching" category label
+#: system/settings/settings.xml
+msgctxt "#37101"
+msgid "Caching"
+msgstr ""
+
+#. Description of category #37101 "Caching"
+#: system/settings/settings.xml
+msgctxt "#37102"
+msgid "This category contains settings that configure caching of local and network files, and internet streams."
+msgstr ""
+
+#. Setting #37103 "Buffer Mode"
+#: system/settings/settings.xml
+msgctxt "#37103"
+msgid "Buffer Mode"
+msgstr ""
+
+#. Description of setting #37103 "Buffer Mode"
+#: system/settings/settings.xml
+msgctxt "#37104"
+msgid "Configure the media content to buffer."
+msgstr ""
+
+#. Setting #37105 "Memory Size"
+#: system/settings/settings.xml
+msgctxt "#37105"
+msgid "Memory Size"
+msgstr ""
+
+#. Description of setting #37105 "Memory Size"
+#: system/settings/settings.xml
+msgctxt "#37106"
+msgid "The size of the memory buffer in Mbytes. Setting zero (0) forces buffering to disk, which is not recommend on flash storage devices (eMMC, SD cards, SSD)."
+msgstr ""
+
+#. Setting #37107 "Read Factor"
+#: system/settings/settings.xml
+msgctxt "#37107"
+msgid "Read Factor"
+msgstr ""
+
+#. Description of setting #37107 "Read Factor"
+#: system/settings/settings.xml
+msgctxt "#37108"
+msgid "The read factor determines cache fill rate in terms of avg. bitrate of stream x Read Factor. Increasing this multiple, cache fills faster but more bandwidth is consumed. Large multiples may cause CPU spikes on some devices, saturate the connection and worsen performance."
+msgstr ""
+
+#. Description of setting "Chunk Size"
+#: system/settings/settings.xml
+msgctxt "#37109"
+msgid "The data chunk size to use when a filesystem or protocol does not force the value, e.g. NFS will override this with its own value."
+msgstr ""
+
+#. Value of setting - NONE
+#: xbmc/settings/SevicesSettings.cpp
+msgctxt "#37110"
+msgid "No buffer"
+msgstr ""
+
+#. Value of setting - TRUE INTERNET
+#: xbmc/settings/SevicesSettings.cpp
+msgctxt "#37111"
+msgid "Only buffer true internet streams: HTTP, HTTPS, etc."
+msgstr ""
+
+#. Value of setting - INTERNET
+#: xbmc/settings/SevicesSettings.cpp
+msgctxt "#37112"
+msgid "Buffer all internet filesystems, including: FTP, WebDAV, etc."
+msgstr ""
+
+#. Value of setting - NETWORK
+#: xbmc/settings/SevicesSettings.cpp
+msgctxt "#37113"
+msgid "Buffer all network filesystems, including: SMB, NFS, etc."
+msgstr ""
+
+#. Value of setting - ALL
+#: xbmc/settings/SevicesSettings.cpp
+msgctxt "#37114"
+msgid "Buffer all filesystems, including local files"
+msgstr ""
+
+#. Value of setting
+#: xbmc/settings/SevicesSettings.cpp
+msgctxt "#37115"
+msgid "Caches entire file on disk storage"
+msgstr ""
+
+#empty strings from id 37116 to 37119
+
+#. Value of setting - Byte
+#: xbmc/settings/SevicesSettings.cpp
+msgctxt "#37120"
+msgid "{0:d} Byte"
+msgstr ""
+
+#. Value of setting - KByte
+#: xbmc/settings/SevicesSettings.cpp
+msgctxt "#37121"
+msgid "{0:d} KB"
+msgstr ""
+
+#. Value of setting - MByte
+#: xbmc/settings/SevicesSettings.cpp
+msgctxt "#37122"
+msgid "{0:d} MB"
+msgstr ""
+
+#. Value of setting - GByte
+#: xbmc/settings/SevicesSettings.cpp
+msgctxt "#37123"
+msgid "{0:d} GB"
+msgstr ""
+
+#empty strings from id 37124 to 38010
 
 #. Setting #38011 "Show All Items entry"
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2453,6 +2453,59 @@
         </setting>
       </group>
     </category>
+    <category id="filecache" label="37101" help="37102">
+      <group id="1" label="16000">
+        <setting id="filecache.buffermode" type="integer" label="37103" help="37104">
+          <level>2</level>
+          <default>4</default>
+          <constraints>
+            <options>filecachebuffermodes</options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
+        <setting id="filecache.memorysize" type="integer" label="37105" help="37106">
+          <level>2</level>
+          <default>20</default>
+          <dependencies>
+            <dependency type="enable">
+              <condition setting="filecache.buffermode" operator="!is">3</condition>
+            </dependency>
+          </dependencies>
+          <constraints>
+            <options>filecachememorysizes</options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
+        <setting id="filecache.readfactor" type="integer" label="37107" help="37108">
+          <level>2</level>
+          <default>400</default>
+          <dependencies>
+            <dependency type="enable">
+              <condition setting="filecache.buffermode" operator="!is">3</condition>
+            </dependency>
+          </dependencies>
+          <constraints>
+            <options>filecachereadfactors</options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
+      </group>
+      <group id="2" label="37053">
+        <setting id="filecache.chunksize" type="integer" label="37053" help="37109">
+          <level>2</level>
+          <default>131072</default>
+          <dependencies>
+            <dependency type="enable">
+              <condition setting="filecache.buffermode" operator="!is">3</condition>
+            </dependency>
+          </dependencies>
+          <constraints>
+            <options>filecachechunksizes</options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
+      </group>
+    </category>
     <category id="weather" label="8" help="36316">
       <group id="1" label="16000">
         <setting id="weather.currentlocation" type="integer" label="0" help="36317">

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -379,9 +379,19 @@ bool CApplication::Create()
   if (!settingsComponent->Load())
     return false;
 
+  // Log Cache GUI settings (replacement of cache in advancedsettings.xml)
+  const auto settings = settingsComponent->GetSettings();
+  CLog::Log(LOGINFO,
+            "New Cache GUI Settings (replacement of cache in advancedsettings.xml) are:\n - Buffer "
+            "Mode: {}\n - Memory Size: {} MB\n - Read "
+            "Factor: {:.2f} x\n - Chunk Size : {} bytes",
+            settings->GetInt(CSettings::SETTING_FILECACHE_BUFFERMODE),
+            settings->GetInt(CSettings::SETTING_FILECACHE_MEMORYSIZE),
+            settings->GetInt(CSettings::SETTING_FILECACHE_READFACTOR) / 100.0f,
+            settings->GetInt(CSettings::SETTING_FILECACHE_CHUNKSIZE));
+
   CLog::Log(LOGINFO, "creating subdirectories");
   const std::shared_ptr<CProfileManager> profileManager = settingsComponent->GetProfileManager();
-  const std::shared_ptr<CSettings> settings = settingsComponent->GetSettings();
   CLog::Log(LOGINFO, "userdata folder: {}",
             CURL::GetRedacted(profileManager->GetProfileUserDataFolder()));
   CLog::Log(LOGINFO, "recording folder: {}",

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -20,7 +20,7 @@
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPowerHandling.h"
 #include "commons/Exception.h"
-#include "settings/AdvancedSettings.h"
+#include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/BitstreamStats.h"
 #include "utils/StringUtils.h"
@@ -287,15 +287,19 @@ bool CFile::Open(const CURL& file, const unsigned int flags)
       if (URIUtils::IsDVD(pathToUrl) || URIUtils::IsBluray(pathToUrl) ||
           (m_flags & READ_AUDIO_VIDEO))
       {
-        const unsigned int iCacheBufferMode =
-            CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_cacheBufferMode;
-        if ((iCacheBufferMode == CACHE_BUFFER_MODE_INTERNET &&
+        const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+
+        const int cacheBufferMode = (settings)
+                                        ? settings->GetInt(CSettings::SETTING_FILECACHE_BUFFERMODE)
+                                        : CACHE_BUFFER_MODE_NETWORK;
+
+        if ((cacheBufferMode == CACHE_BUFFER_MODE_INTERNET &&
              URIUtils::IsInternetStream(pathToUrl, true)) ||
-            (iCacheBufferMode == CACHE_BUFFER_MODE_TRUE_INTERNET &&
+            (cacheBufferMode == CACHE_BUFFER_MODE_TRUE_INTERNET &&
              URIUtils::IsInternetStream(pathToUrl, false)) ||
-            (iCacheBufferMode == CACHE_BUFFER_MODE_NETWORK &&
+            (cacheBufferMode == CACHE_BUFFER_MODE_NETWORK &&
              URIUtils::IsNetworkFilesystem(pathToUrl)) ||
-            (iCacheBufferMode == CACHE_BUFFER_MODE_ALL &&
+            (cacheBufferMode == CACHE_BUFFER_MODE_ALL &&
              (URIUtils::IsNetworkFilesystem(pathToUrl) || URIUtils::IsHD(pathToUrl))))
         {
           m_flags |= READ_CACHED;

--- a/xbmc/filesystem/IFileTypes.h
+++ b/xbmc/filesystem/IFileTypes.h
@@ -54,6 +54,15 @@ struct SCacheStatus
   uint32_t lowrate; /**< low speed read rate (bytes/second) (if any, else 0) */
 };
 
+enum CACHE_BUFFER_MODES
+{
+  CACHE_BUFFER_MODE_INTERNET = 0,
+  CACHE_BUFFER_MODE_ALL = 1,
+  CACHE_BUFFER_MODE_TRUE_INTERNET = 2,
+  CACHE_BUFFER_MODE_NONE = 3,
+  CACHE_BUFFER_MODE_NETWORK = 4,
+};
+
 typedef enum {
   IOCTRL_NATIVE        = 1,  /**< SNativeIoControl structure, containing what should be passed to native ioctrl */
   IOCTRL_SEEK_POSSIBLE = 2,  /**< return 0 if known not to work, 1 if it should work */

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -397,14 +397,6 @@ void CAdvancedSettings::Initialize()
   m_PVRDefaultSortOrder.sortBy = SortByDate;
   m_PVRDefaultSortOrder.sortOrder = SortOrderDescending;
 
-  m_cacheMemSize = 1024 * 1024 * 20; // 20 MiB
-  m_cacheBufferMode = CACHE_BUFFER_MODE_NETWORK; // Default (buffer all network filesystems)
-  m_cacheChunkSize = 128 * 1024; // 128 KiB
-
-  // the following setting determines the readRate of a player data
-  // as multiply of the default data read rate
-  m_cacheReadFactor = 4.0f;
-
   m_addonPackageFolderSize = 200;
 
   m_jsonOutputCompact = true;
@@ -847,15 +839,6 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetBoolean(pElement, "disableipv6", m_curlDisableIPV6);
     XMLUtils::GetBoolean(pElement, "disablehttp2", m_curlDisableHTTP2);
     XMLUtils::GetString(pElement, "catrustfile", m_caTrustFile);
-  }
-
-  pElement = pRootElement->FirstChildElement("cache");
-  if (pElement)
-  {
-    XMLUtils::GetUInt(pElement, "memorysize", m_cacheMemSize);
-    XMLUtils::GetUInt(pElement, "buffermode", m_cacheBufferMode, 0, 4);
-    XMLUtils::GetUInt(pElement, "chunksize", m_cacheChunkSize, 256, 1024 * 1024);
-    XMLUtils::GetFloat(pElement, "readfactor", m_cacheReadFactor);
   }
 
   pElement = pRootElement->FirstChildElement("jsonrpc");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -18,12 +18,6 @@
 #include <utility>
 #include <vector>
 
-#define CACHE_BUFFER_MODE_INTERNET 0
-#define CACHE_BUFFER_MODE_ALL 1
-#define CACHE_BUFFER_MODE_TRUE_INTERNET 2
-#define CACHE_BUFFER_MODE_NONE 3
-#define CACHE_BUFFER_MODE_NETWORK 4
-
 class CProfileManager;
 class CSettingsManager;
 class CVariant;
@@ -334,11 +328,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int  m_guiAlgorithmDirtyRegions;
     bool m_guiSmartRedraw;
     unsigned int m_addonPackageFolderSize;
-
-    unsigned int m_cacheMemSize;
-    unsigned int m_cacheBufferMode;
-    unsigned int m_cacheChunkSize;
-    float m_cacheReadFactor;
 
     bool m_jsonOutputCompact;
     unsigned int m_jsonTcpPort;

--- a/xbmc/settings/ServicesSettings.cpp
+++ b/xbmc/settings/ServicesSettings.cpp
@@ -8,16 +8,108 @@
 
 #include "ServicesSettings.h"
 
+#include "filesystem/IFileTypes.h"
+#include "guilib/LocalizeStrings.h"
+#include "utils/StringUtils.h"
+
+using namespace XFILE;
+
 void CServicesSettings::SettingOptionsChunkSizesFiller(const SettingConstPtr& setting,
                                                        std::vector<IntegerSettingOption>& list,
                                                        int& current,
                                                        void* data)
 {
-  list.emplace_back("16 KB", 16);
-  list.emplace_back("32 KB", 32);
-  list.emplace_back("64 KB", 64);
-  list.emplace_back("128 KB", 128);
-  list.emplace_back("256 KB", 256);
-  list.emplace_back("512 KB", 512);
-  list.emplace_back("1 MB", 1024);
+  const auto& kb = g_localizeStrings.Get(37121);
+  const auto& mb = g_localizeStrings.Get(37122);
+
+  list.emplace_back(StringUtils::Format(kb, 16), 16);
+  list.emplace_back(StringUtils::Format(kb, 32), 32);
+  list.emplace_back(StringUtils::Format(kb, 64), 64);
+  list.emplace_back(StringUtils::Format(kb, 128), 128);
+  list.emplace_back(StringUtils::Format(kb, 256), 256);
+  list.emplace_back(StringUtils::Format(kb, 512), 512);
+  list.emplace_back(StringUtils::Format(mb, 1), 1024);
+}
+
+void CServicesSettings::SettingOptionsBufferModesFiller(const SettingConstPtr& setting,
+                                                        std::vector<IntegerSettingOption>& list,
+                                                        int& current,
+                                                        void* data)
+{
+  list.emplace_back(g_localizeStrings.Get(37110), CACHE_BUFFER_MODE_NONE);
+  list.emplace_back(g_localizeStrings.Get(37111), CACHE_BUFFER_MODE_TRUE_INTERNET);
+  list.emplace_back(g_localizeStrings.Get(37112), CACHE_BUFFER_MODE_INTERNET);
+  list.emplace_back(g_localizeStrings.Get(37113), CACHE_BUFFER_MODE_NETWORK);
+  list.emplace_back(g_localizeStrings.Get(37114), CACHE_BUFFER_MODE_ALL);
+}
+
+void CServicesSettings::SettingOptionsMemorySizesFiller(const SettingConstPtr& setting,
+                                                        std::vector<IntegerSettingOption>& list,
+                                                        int& current,
+                                                        void* data)
+{
+  const auto& mb = g_localizeStrings.Get(37122);
+  const auto& gb = g_localizeStrings.Get(37123);
+
+  list.emplace_back(StringUtils::Format(mb, 16), 16);
+  list.emplace_back(StringUtils::Format(mb, 20), 20);
+  list.emplace_back(StringUtils::Format(mb, 24), 24);
+  list.emplace_back(StringUtils::Format(mb, 32), 32);
+  list.emplace_back(StringUtils::Format(mb, 48), 48);
+  list.emplace_back(StringUtils::Format(mb, 64), 64);
+  list.emplace_back(StringUtils::Format(mb, 96), 96);
+  list.emplace_back(StringUtils::Format(mb, 128), 128);
+  list.emplace_back(StringUtils::Format(mb, 192), 192);
+  list.emplace_back(StringUtils::Format(mb, 256), 256);
+  list.emplace_back(StringUtils::Format(mb, 384), 384);
+  list.emplace_back(StringUtils::Format(mb, 512), 512);
+  list.emplace_back(StringUtils::Format(mb, 768), 768);
+  list.emplace_back(StringUtils::Format(gb, 1), 1024);
+  list.emplace_back(g_localizeStrings.Get(37115), 0);
+}
+
+void CServicesSettings::SettingOptionsReadFactorsFiller(const SettingConstPtr& setting,
+                                                        std::vector<IntegerSettingOption>& list,
+                                                        int& current,
+                                                        void* data)
+{
+  list.emplace_back("1.1x", 110);
+  list.emplace_back("1.25x", 125);
+  list.emplace_back("1.5x", 150);
+  list.emplace_back("1.75x", 175);
+  list.emplace_back("2x", 200);
+  list.emplace_back("2.5x", 250);
+  list.emplace_back("3x", 300);
+  list.emplace_back("4x", 400);
+  list.emplace_back("5x", 500);
+  list.emplace_back("7x", 700);
+  list.emplace_back("10x", 1000);
+  list.emplace_back("15x", 1500);
+  list.emplace_back("20x", 2000);
+  list.emplace_back("30x", 3000);
+  list.emplace_back("50x", 5000);
+}
+
+void CServicesSettings::SettingOptionsCacheChunkSizesFiller(const SettingConstPtr& setting,
+                                                            std::vector<IntegerSettingOption>& list,
+                                                            int& current,
+                                                            void* data)
+{
+  const auto& byte = g_localizeStrings.Get(37120);
+  const auto& kb = g_localizeStrings.Get(37121);
+  const auto& mb = g_localizeStrings.Get(37122);
+
+  list.emplace_back(StringUtils::Format(byte, 256), 256);
+  list.emplace_back(StringUtils::Format(byte, 512), 512);
+  list.emplace_back(StringUtils::Format(kb, 1), 1024);
+  list.emplace_back(StringUtils::Format(kb, 2), 2 * 1024);
+  list.emplace_back(StringUtils::Format(kb, 4), 4 * 1024);
+  list.emplace_back(StringUtils::Format(kb, 8), 8 * 1024);
+  list.emplace_back(StringUtils::Format(kb, 16), 16 * 1024);
+  list.emplace_back(StringUtils::Format(kb, 32), 32 * 1024);
+  list.emplace_back(StringUtils::Format(kb, 64), 64 * 1024);
+  list.emplace_back(StringUtils::Format(kb, 128), 128 * 1024);
+  list.emplace_back(StringUtils::Format(kb, 256), 256 * 1024);
+  list.emplace_back(StringUtils::Format(kb, 512), 512 * 1024);
+  list.emplace_back(StringUtils::Format(mb, 1), 1024 * 1024);
 }

--- a/xbmc/settings/ServicesSettings.h
+++ b/xbmc/settings/ServicesSettings.h
@@ -20,4 +20,20 @@ public:
                                              std::vector<IntegerSettingOption>& list,
                                              int& current,
                                              void* data);
+  static void SettingOptionsBufferModesFiller(const SettingConstPtr& setting,
+                                              std::vector<IntegerSettingOption>& list,
+                                              int& current,
+                                              void* data);
+  static void SettingOptionsMemorySizesFiller(const SettingConstPtr& setting,
+                                              std::vector<IntegerSettingOption>& list,
+                                              int& current,
+                                              void* data);
+  static void SettingOptionsReadFactorsFiller(const SettingConstPtr& setting,
+                                              std::vector<IntegerSettingOption>& list,
+                                              int& current,
+                                              void* data);
+  static void SettingOptionsCacheChunkSizesFiller(const SettingConstPtr& setting,
+                                                  std::vector<IntegerSettingOption>& list,
+                                                  int& current,
+                                                  void* data);
 };

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -439,6 +439,14 @@ void CSettings::InitializeOptionFillers()
   GetSettingsManager()->RegisterSettingOptionsFiller("keyboardlayouts", CKeyboardLayoutManager::SettingOptionsKeyboardLayoutsFiller);
   GetSettingsManager()->RegisterSettingOptionsFiller(
       "filechunksizes", CServicesSettings::SettingOptionsChunkSizesFiller);
+  GetSettingsManager()->RegisterSettingOptionsFiller(
+      "filecachebuffermodes", CServicesSettings::SettingOptionsBufferModesFiller);
+  GetSettingsManager()->RegisterSettingOptionsFiller(
+      "filecachememorysizes", CServicesSettings::SettingOptionsMemorySizesFiller);
+  GetSettingsManager()->RegisterSettingOptionsFiller(
+      "filecachereadfactors", CServicesSettings::SettingOptionsReadFactorsFiller);
+  GetSettingsManager()->RegisterSettingOptionsFiller(
+      "filecachechunksizes", CServicesSettings::SettingOptionsCacheChunkSizesFiller);
 }
 
 void CSettings::UninitializeOptionFillers()
@@ -486,6 +494,10 @@ void CSettings::UninitializeOptionFillers()
   GetSettingsManager()->UnregisterSettingOptionsFiller("verticalsyncs");
   GetSettingsManager()->UnregisterSettingOptionsFiller("keyboardlayouts");
   GetSettingsManager()->UnregisterSettingOptionsFiller("filechunksizes");
+  GetSettingsManager()->UnregisterSettingOptionsFiller("filecachebuffermodes");
+  GetSettingsManager()->UnregisterSettingOptionsFiller("filecachememorysizes");
+  GetSettingsManager()->UnregisterSettingOptionsFiller("filecachereadfactors");
+  GetSettingsManager()->UnregisterSettingOptionsFiller("filecachechunksizes");
 }
 
 void CSettings::InitializeConditions()

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -461,6 +461,10 @@ public:
   static constexpr auto SETTING_SOURCE_VIDEOS = "source.videos";
   static constexpr auto SETTING_SOURCE_MUSIC = "source.music";
   static constexpr auto SETTING_SOURCE_PICTURES = "source.pictures";
+  static constexpr auto SETTING_FILECACHE_BUFFERMODE = "filecache.buffermode";
+  static constexpr auto SETTING_FILECACHE_MEMORYSIZE = "filecache.memorysize"; // in MBytes
+  static constexpr auto SETTING_FILECACHE_READFACTOR = "filecache.readfactor"; // as integer (x100)
+  static constexpr auto SETTING_FILECACHE_CHUNKSIZE = "filecache.chunksize"; // in Bytes
 
   // values for SETTING_VIDEOLIBRARY_SHOWUNWATCHEDPLOTS
   static const int VIDEOLIBRARY_PLOTS_SHOW_UNWATCHED_MOVIES = 0;

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -15,6 +15,7 @@
 #include "cores/VideoPlayer/DVDFileInfo.h"
 #include "cores/VideoSettings.h"
 #include "filesystem/Directory.h"
+#include "filesystem/File.h"
 #include "filesystem/StackDirectory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/StereoscopicsManager.h"
@@ -483,10 +484,14 @@ std::string CVideoThumbLoader::GetLocalArt(const CFileItem &item, const std::str
      thumbloader thread accesses the streamed filesystem at the same time as the
      app thread and the latter has to wait for it.
    */
-  if (item.m_bIsFolder &&
-      (item.IsStreamedFilesystem() ||
-       CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_cacheBufferMode ==
-           CACHE_BUFFER_MODE_ALL))
+
+  const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+
+  const bool cacheAll =
+      settings ? settings->GetInt(CSettings::SETTING_FILECACHE_BUFFERMODE) == CACHE_BUFFER_MODE_ALL
+               : false;
+
+  if (item.m_bIsFolder && (item.IsStreamedFilesystem() || cacheAll))
   {
     CFileItemList items; // Dummy list
     CDirectory::GetDirectory(item.GetPath(), items, "", DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);


### PR DESCRIPTION
## Description
- Move File Cache settings to GUI settings (no functional changes).
- Provides compatibility for translate Bytes units in previous PR https://github.com/xbmc/xbmc/pull/24019

## Motivation and context
More easy cache settings for users and less headaches. Easier documentation using built-in GUI help strings.

Almost no functional changes, only some minor differences in File Cache defaults:

- Buffer Mode not changes default still `CACHE_BUFFER_MODE_NETWORK = 4`
~- Memory Size default increased a little from 20 MB to 32 MB (all current devices should capable handle it)~
~- Read Factor lowered from 4.0 to 1.5 reason: in some UHD streams (100 Mbit/s) * 4.0 is more than Wi-Fi  or USB connection can handle anyway and in some devices read at limit speeds also can cause CPU spikes. In other words: with big caches sizes is not necessary fill entire cache at fist second that playback starts but is better fill slowly when bitrate < avg. bitrate * 1.5~
- Chunk Size not changes default is 128 KB

Keep ALL  same defaults for now for smooth transition and low risk PR.

Thinking also in add a new chunk size setting only for local files but not in this PR yet.


## How has this been tested?
Runtime Windows x64 and Android (Shield)

## What is the effect on users?
No functional changes but users with personalized advancedsettings should re-configure File Cache in GUI (only a few clicks). The old settings in advancedsettings.xml will no longer have any effect.

## Screenshots (if appropriate):

![screenshot00000](https://github.com/xbmc/xbmc/assets/58434170/2aebf22d-1791-4f52-972b-cba34225914e)

![screenshot00001](https://github.com/xbmc/xbmc/assets/58434170/59e6ccc6-dd1a-43e9-a6cf-03582f4095c5)

![screenshot00002](https://github.com/xbmc/xbmc/assets/58434170/bd67a5ab-2fab-4122-a0d4-690bde91481a)

![screenshot00003](https://github.com/xbmc/xbmc/assets/58434170/25e28449-f9d5-40a7-ad93-cc5d44fb9e75)

![screenshot00004](https://github.com/xbmc/xbmc/assets/58434170/0c5e5b9f-29cb-4f26-93f3-48ccd28e96c3)

![screenshot00005](https://github.com/xbmc/xbmc/assets/58434170/5a73cd42-b2df-4d60-87aa-74071b5e8566)

![screenshot00006](https://github.com/xbmc/xbmc/assets/58434170/3b69dfa9-f39c-439b-8b63-5265dc5d84b0)

![screenshot00007](https://github.com/xbmc/xbmc/assets/58434170/8a863d6b-c47c-4397-be48-92d26c615d0e)

![screenshot00008](https://github.com/xbmc/xbmc/assets/58434170/7cae48b9-0ada-44a6-9aa8-a3df3db2c6fd)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
