### PR TITLE
[CApp] Kill XBMC to Kodi migration

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16098,17 +16098,7 @@ msgctxt "#24127"
 msgid "Automatically download first subtitle from the search result list"
 msgstr ""
 
-#. Info dialog after migrating userdata from xbmc to kodi
-#: xbmc/Application.cpp
-msgctxt "#24128"
-msgid "Configuration has been moved"
-msgstr ""
-
-#. Info dialog after migrating userdata from xbmc to kodi
-#: xbmc/Application.cpp
-msgctxt "#24129"
-msgid "The configuration of XBMC has been moved to the new location for Kodi. Please refer to http://kodi.wiki/view/Migration - this message will not be shown again!"
-msgstr ""
+#empty strings from id 24128 to 24129
 
 #: system/settings/settings.xml
 msgctxt "#24130"

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -2689,9 +2689,6 @@ bool CApplication::OnMessage(CGUIMessage& message)
           m_incompatibleAddons.clear();
         }
 
-        // show info dialog about moved configuration files if needed
-        ShowAppMigrationMessage();
-
         // offer enabling addons at kodi startup that are disabled due to
         // e.g. os package manager installation on linux
         ConfigureAndEnableAddons();
@@ -2989,26 +2986,6 @@ bool CApplication::ExecuteXBMCAction(std::string actionStr, const CGUIListItemPt
     }
   }
   return true;
-}
-
-// inform the user that the configuration data has moved from old XBMC location
-// to new Kodi location - if applicable
-void CApplication::ShowAppMigrationMessage()
-{
-  // .kodi_migration_complete will be created from the installer/packaging
-  // once an old XBMC configuration was moved to the new Kodi location
-  // if this is the case show the migration info to the user once which
-  // tells him to have a look into the wiki where the move of configuration
-  // is further explained.
-  if (CFile::Exists("special://home/.kodi_data_was_migrated") &&
-      !CFile::Exists("special://home/.kodi_migration_info_shown"))
-  {
-    HELPERS::ShowOKDialogText(CVariant{24128}, CVariant{24129});
-    CFile tmpFile;
-    // create the file which will prevent this dialog from appearing in the future
-    tmpFile.OpenForWrite("special://home/.kodi_migration_info_shown");
-    tmpFile.Close();
-  }
 }
 
 void CApplication::ConfigureAndEnableAddons()


### PR DESCRIPTION
## Description
Kodi announced the name change from XBMC back in 2014, the first version being Kodi Helix. I doubt anyone is still migrating from Frodo to Kodi Nexus these days (and it will likely fail too). So lets just kill the migration message.

## Motivation and context
Cleanup

## How has this been tested?
Not tested but it simply makes sense

## What is the effect on users?
Hopefully none as nobody is migrating from XBMC to Kodi. Even if that's the case, this is just a GUI message anyway.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

