### PR TITLE
[cmake] copy_file_to_buildtree make sure we create ExportFiles.cmake

### DIFF
--- a/cmake/scripts/common/Macros.cmake
+++ b/cmake/scripts/common/Macros.cmake
@@ -245,6 +245,8 @@ function(copy_file_to_buildtree file)
                                        COMMAND ${CMAKE_COMMAND} -DBUNDLEDIR=${_bundle_dir}
                                                                 -P ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/ExportFiles.cmake)
     set_target_properties(export-files PROPERTIES FOLDER "Build Utilities")
+    # Add comment to ensure ExportFiles.cmake is created even if not used.
+    file(APPEND ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/ExportFiles.cmake "# Export files to build tree\n")
   endif()
 
   if(${CORE_SYSTEM_NAME} MATCHES "windows")


### PR DESCRIPTION
## Description
We have to make sure we create something into ExportFiles.cmake. There are instances where no files are added to the generated cmake file, and therefore it isnt created, and the cmake rule fails to run and the build will then fail.

## Motivation and context
Flathub build fails building beta1 tag. 

## How has this been tested?
N/A

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
