### PR TITLE
[Windows][FFmpeg] Fix crash due nullptr surface using DXVA2

### DIFF
--- a/tools/buildsteps/windows/patches/0005-ffmpeg-windows-dxva2-check-nullptr-surface.patch
+++ b/tools/buildsteps/windows/patches/0005-ffmpeg-windows-dxva2-check-nullptr-surface.patch
@@ -1,0 +1,12 @@
+diff --git a/libavcodec/dxva2.c b/libavcodec/dxva2.c
+--- a/libavcodec/dxva2.c
++++ b/libavcodec/dxva2.c
+@@ -777,7 +777,7 @@ unsigned ff_dxva2_get_surface_index(const AVCodecContext *avctx,
+ #if CONFIG_D3D11VA
+     if (avctx->pix_fmt == AV_PIX_FMT_D3D11)
+         return (intptr_t)frame->data[1];
+-    if (avctx->pix_fmt == AV_PIX_FMT_D3D11VA_VLD) {
++    if (avctx->pix_fmt == AV_PIX_FMT_D3D11VA_VLD && surface) {
+         D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESC viewDesc;
+         ID3D11VideoDecoderOutputView_GetDesc((ID3D11VideoDecoderOutputView*) surface, &viewDesc);
+         return viewDesc.Texture2D.ArraySlice;


### PR DESCRIPTION
## Description
Fix crash due nullptr surface using DXVA2

This may happen when a stream starts with non I frame.

## Motivation and context
This (necessary) patch was lost when migrating to FFmpeg 6.0

Fixes https://github.com/xbmc/xbmc/issues/24021
Fixes https://github.com/xbmc/xbmc/issues/23547


## How has this been tested?
Runtime Windows x64

## What is the effect on users?
Fix (rare) crash with some video samples, mainly interlaced or old VC-1

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
