### PR TITLE
[PVR][Estuary] PVR core should not set label2 for PVR recording folde…

### DIFF
--- a/addons/skin.estuary/xml/MyPVRRecordings.xml
+++ b/addons/skin.estuary/xml/MyPVRRecordings.xml
@@ -28,7 +28,7 @@
 						<param name="info_icon" value="$VAR[ListPVRRecordingsIconVar]" />
 						<param name="has_info_icon" value="true" />
 						<param name="label1" value="$INFO[ListItem.Label]" />
-						<param name="label2" value="$INFO[ListItem.Label2]" />
+						<param name="label2" value="$VAR[ListLabel2Var]" />
 					</include>
 				</control>
 			</control>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -89,6 +89,7 @@
 		<value condition="String.IsEmpty(Container.PluginName) + Container.Content(tvshows) + Container.SortMethod(29)">$VAR[WatchedStatusVar]</value>
 		<value condition="String.IsEmpty(Container.PluginName) + String.IsEqual(ListItem.DBType,season) + Container.SortMethod(29)">$VAR[WatchedStatusVar]</value>
 		<value condition="String.IsEmpty(Container.PluginName) + String.IsEqual(ListItem.DBType,set) + Container.SortMethod(1)">$VAR[WatchedStatusVar]</value>
+		<value condition="ListItem.IsFolder + [Window.IsActive(TVRecordings) | Window.IsActive(RadioRecordings)]">$VAR[WatchedStatusVar]</value>
 		<value condition="Container.SortMethod(7) | Container.SortMethod(29)">$INFO[ListItem.Year]</value>
 		<value condition="!String.isempty(ListItem.Appearances)">$LOCALIZE[38026]: $INFO[ListItem.Appearances]</value>
 		<value condition="Window.IsActive(musicplaylist) | Window.IsActive(videoplaylist)">$INFO[ListItem.Duration]</value>
@@ -289,6 +290,7 @@
 	<variable name="WatchedStatusVar">
 		<value condition="String.IsEqual(Listitem.DBType,tvshow) | String.IsEqual(Listitem.DBType,season)">$INFO[ListItem.Property(WatchedEpisodes)]$INFO[ListItem.Property(TotalEpisodes), / ,]</value>
 		<value condition="String.IsEqual(Listitem.DBType,set)">$INFO[ListItem.Property(Watched)]$INFO[ListItem.Property(Total), / ,]</value>
+		<value condition="ListItem.IsFolder + [Window.IsActive(TVRecordings) | Window.IsActive(RadioRecordings)]">$INFO[ListItem.Property(WatchedEpisodes)]$INFO[ListItem.Property(TotalEpisodes), / ,]</value>
 	</variable>
 	<variable name="VideoPlayerForwardRewindVar">
 		<value condition="Player.Forwarding2x | Player.Rewinding2x">2x</value>

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -345,9 +345,6 @@ void GetSubDirectories(const CPVRRecordingsPath& recParentPath,
     {
       item->IncrementProperty("inprogressepisodes", 1);
     }
-    item->SetLabel2(StringUtils::Format("{} / {}", item->GetProperty("watchedepisodes").asString(),
-                                        item->GetProperty("totalepisodes").asString()));
-
     item->IncrementProperty("sizeinbytes", recording->GetSizeInBytes());
   }
 


### PR DESCRIPTION
…r items. This should be done by the skins, the same way as already implemented for tv shows, seasons, movie sets.

Having the same feature implemented partly in the core code partly in the skins leads to inconsistencies.

No functional/visual changes for Estuary users, but maybe now consistency for users of other skins.

@phunkyfish can you have a look at the trivial core code please
@HitcherUK can you review the skin change? I basically just 'copied' what we already do for the other video "folders".