### PR TITLE
[Discs] Fix ISOs are opened using File Cache in some cases and bad read size (sector size)

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -1242,7 +1242,8 @@ void CDVDInputStreamBluray::SetupPlayerSettings()
 
 bool CDVDInputStreamBluray::OpenStream(CFileItem &item)
 {
-  m_pstream = std::make_unique<CDVDInputStreamFile>(item, 0);
+  m_pstream = std::make_unique<CDVDInputStreamFile>(item, READ_TRUNCATED | READ_BITRATE |
+                                                              READ_CHUNKED | READ_NO_CACHE);
 
   if (!m_pstream->Open())
   {

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -184,7 +184,7 @@ protected:
     bool OpenStream(CFileItem &item);
     void SetupPlayerSettings();
     void FreeTitleInfo();
-    std::unique_ptr<CDVDInputStreamFile> m_pstream = nullptr;
+    std::unique_ptr<CDVDInputStreamFile> m_pstream;
     std::string m_rootPath;
 
     /*! Bluray state serializer handler */


### PR DESCRIPTION
## Description
[Discs] Fix ISOs are opened using File Cache in some cases and bad read size (sector size)

## Motivation and context
Fixes https://github.com/xbmc/xbmc/issues/24040


Also found missing others file flags to calculate bitrate stats and read with correct chunk size that corresponds to sector size in case of local files Blu-Ray's:

https://github.com/xbmc/xbmc/blob/55669b9bb0f8d99f885f4371c923a98d10ab91ec/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h#L64

Without `READ_CHUNKED` flag is read at 64K chunks (as MKV local files):

![before](https://github.com/xbmc/xbmc/assets/58434170/e0216c1b-d3f0-4d7e-9611-d377bff171c7)

With `READ_CHUNKED` flag is read at 6144 chunks (defined block size for Blu-Ray):

![after](https://github.com/xbmc/xbmc/assets/58434170/f4e6097b-0feb-45c0-8d84-7c3d5231b5a1)

Note: If ISOs are on network is need a much big chunk size and is used what defined in chunk size for NFS, SMB, etc.


These file flags already used in all other similar places as here:

https://github.com/xbmc/xbmc/blob/55669b9bb0f8d99f885f4371c923a98d10ab91ec/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp#L150-L154


## How has this been tested?
Runtime Windows x64

## What is the effect on users?
Fast opening and seek of local Blu-Ray ISOs files

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
