### PR TITLE
[python] Add songVideoURL to InfoTagMusic

### DIFF
--- a/xbmc/interfaces/legacy/InfoTagMusic.cpp
+++ b/xbmc/interfaces/legacy/InfoTagMusic.cpp
@@ -179,6 +179,11 @@ namespace XBMCAddon
       return infoTag->GetMusicBrainzAlbumArtistID();
     }
 
+    String InfoTagMusic::getSongVideoURL()
+    {
+      return infoTag->GetSongVideoURL();
+    }
+
     void InfoTagMusic::setDbId(int dbId, const String& type)
     {
       XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
@@ -330,6 +335,12 @@ namespace XBMCAddon
       setCommentRaw(infoTag, comment);
     }
 
+    void InfoTagMusic::setSongVideoURL(const String& songVideoURL)
+    {
+      XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
+      setSongVideoURLRaw(infoTag, songVideoURL);
+    }
+
     void InfoTagMusic::setDbIdRaw(MUSIC_INFO::CMusicInfoTag* infoTag, int dbId, const String& type)
     {
       infoTag->SetDatabaseId(dbId, type);
@@ -462,6 +473,12 @@ namespace XBMCAddon
     void InfoTagMusic::setCommentRaw(MUSIC_INFO::CMusicInfoTag* infoTag, const String& comment)
     {
       infoTag->SetComment(comment);
+    }
+
+    void InfoTagMusic::setSongVideoURLRaw(MUSIC_INFO::CMusicInfoTag* infoTag,
+                                          const String& songVideoURL)
+    {
+      infoTag->SetSongVideoURL(songVideoURL);
     }
   }
 }

--- a/xbmc/interfaces/legacy/InfoTagMusic.h
+++ b/xbmc/interfaces/legacy/InfoTagMusic.h
@@ -572,6 +572,23 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
       ///
       /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ getSongVideoURL() }
+      /// Returns the URL to a video of the song from the music tag as a string (if present).
+      ///
+      /// @return [string] URL to a video of the song.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v21 New function added.
+      ///
+      getSongVideoURL();
+#else
+      String getSongVideoURL();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
       /// @brief \python_func{ setDbId(dbId, type) }
       /// Set the database identifier of the music item.
       ///
@@ -995,6 +1012,23 @@ namespace XBMCAddon
       void setComment(const String& comment);
 #endif
 
+#ifdef DOXYGEN_SHOULD_USE_THIS
+      ///
+      /// \ingroup python_InfoTagMusic
+      /// @brief \python_func{ setSongVideoURL(songVideoURL) }
+      /// Set the URL of the song to point to a video.
+      ///
+      /// @param songVideoURL            string - URL to a video of the song.
+      ///
+      ///
+      ///-----------------------------------------------------------------------
+      /// @python_v21 New function added.
+      ///
+      setSongVideoURL(...);
+#else
+      void setSongVideoURL(const String& songVideoURL);
+#endif
+
 #ifndef SWIG
       static void setDbIdRaw(MUSIC_INFO::CMusicInfoTag* infoTag, int dbId, const String& type);
       static void setURLRaw(MUSIC_INFO::CMusicInfoTag* infoTag, const String& url);
@@ -1027,6 +1061,8 @@ namespace XBMCAddon
       static void setMusicBrainzAlbumArtistIDRaw(
           MUSIC_INFO::CMusicInfoTag* infoTag, const std::vector<String>& musicBrainzAlbumArtistID);
       static void setCommentRaw(MUSIC_INFO::CMusicInfoTag* infoTag, const String& comment);
+      static void setSongVideoURLRaw(MUSIC_INFO::CMusicInfoTag* infoTag,
+                                     const String& songVideoURL);
 #endif
     };
     //@}


### PR DESCRIPTION
## Description
Further to a request from @jurialmunkey  here https://github.com/xbmc/xbmc/pull/22654#issuecomment-1793326835 this adds the SongVideoURL that is present in the MusicInfoTag to the python interface so that addons can get/set it.

## How has this been tested?
I haven't tested it other than building Kodi and the documentation.

## What is the effect on users?
Allows addons to fetch or set the url of a video for a song.


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
