### PR TITLE
[PVR] Fix recordings with a path containing a ':' not displayed in re…

### DIFF
--- a/xbmc/pvr/recordings/PVRRecordingsPath.cpp
+++ b/xbmc/pvr/recordings/PVRRecordingsPath.cpp
@@ -38,9 +38,9 @@ CPVRRecordingsPath::CPVRRecordingsPath(const std::string& strPath)
               ((segments.at(3) == "active") || (segments.at(3) == "deleted")));
   if (m_bValid)
   {
-    m_bRoot = (m_bValid && (segments.size() == 4));
-    m_bRadio = (m_bValid && (segments.at(2) == "radio"));
-    m_bActive = (m_bValid && (segments.at(3) == "active"));
+    m_bRoot = (segments.size() == 4);
+    m_bRadio = (segments.at(2) == "radio");
+    m_bActive = (segments.at(3) == "active");
 
     if (m_bRoot)
       strVarPath.append("/");
@@ -132,6 +132,20 @@ std::string CPVRRecordingsPath::GetUnescapedDirectoryPath() const
   return CURL::Decode(m_directoryPath);
 }
 
+namespace
+{
+bool PathHasParent(const std::string& path, const std::string& parent)
+{
+  if (path == parent)
+    return true;
+
+  if (!parent.empty() && parent.back() != '/')
+    return StringUtils::StartsWith(path, parent + '/');
+
+  return StringUtils::StartsWith(path, parent);
+}
+} // unnamed namespace
+
 std::string CPVRRecordingsPath::GetUnescapedSubDirectoryPath(const std::string& strPath) const
 {
   // note: strPath must be unescaped.
@@ -144,7 +158,7 @@ std::string CPVRRecordingsPath::GetUnescapedSubDirectoryPath(const std::string& 
   /* adding "/" to make sure that base matches the complete folder name and not only parts of it */
   if (!strUnescapedDirectoryPath.empty() &&
       (strUsePath.size() <= strUnescapedDirectoryPath.size() ||
-       !URIUtils::PathHasParent(strUsePath, strUnescapedDirectoryPath)))
+       !PathHasParent(strUsePath, strUnescapedDirectoryPath)))
     return strReturn;
 
   strUsePath.erase(0, strUnescapedDirectoryPath.size());


### PR DESCRIPTION
…cordings window.

Backport of https://github.com/xbmc/xbmc/pull/24053

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
