### PR TITLE
[Windows] Fix swapchain destruction / recreation

### DIFF
--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -583,7 +583,9 @@ void DX::DeviceResources::DestroySwapChain()
   if (!!bFullcreen)
     m_swapChain->SetFullscreenState(false, nullptr); // mandatory before releasing swapchain
   m_swapChain = nullptr;
+  m_deferrContext->ClearState();
   m_deferrContext->Flush();
+  m_d3dContext->ClearState();
   m_d3dContext->Flush();
   m_IsTransferPQ = false;
 }
@@ -773,6 +775,9 @@ void DX::DeviceResources::CreateWindowSizeDependentResources()
   ResizeBuffers();
 
   CreateBackBuffer();
+
+  // restore pipeline state destroyed when releasing the swap chain
+  CServiceBroker::GetWinSystem()->GetGfxContext().ApplyStateBlock();
 }
 
 // Determine the dimensions of the render target and whether it will be scaled down.

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -1389,7 +1389,6 @@ void DX::DeviceResources::ApplyDisplaySettings()
 {
   CLog::LogF(LOGDEBUG, "Re-create swapchain due Display Settings changed");
 
-  DestroySwapChain();
   CreateWindowSizeDependentResources();
 }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Implement MS guidelines to make sure the swap chain is properly released when it's being recreated:
https://learn.microsoft.com/en-us/windows/win32/api/d3d11/nf-d3d11-id3d11devicecontext-flush#deferred-destruction-issues-with-flip-presentation-swap-chains

Modified DestroySwapChain() to add the required ClearState() calls.

Modified CreateWindowSizeDependentResources() to recreate the state destroyed during the swap chain destruction.

Removed redundant call to DestroySwapChain() from ApplyDisplaySettings() since CreateWindowSizeDependentResources() called immediately after takes care of it.

Maybe worth a backport as I'd guess that problems related to this are more likely in old hardware / drivers and Windows 7 support stops with v20.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Compliance with Microsoft recommendations.

Should fix the forum issue https://forum.kodi.tv/showthread.php?tid=374049

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 10, AMD, nVidia, Intel.
With "Use display HDR capabilities" on, played HDR and SDR material to make Kodi switch Windows HDR mode and recreate the swap chain.
Also cycled through the values of the "Use 10 bit for SDR" setting, which recreates the swap chain.

Testing requested for Windows 11 and Xbox (if it has a path that recreates the swap chain).

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Eliminate rare swap chain creation errors.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
