### PR TITLE
[cmake] FindBluray migrate to full TARGET usage

### DIFF
--- a/cmake/modules/FindBluray.cmake
+++ b/cmake/modules/FindBluray.cmake
@@ -3,74 +3,76 @@
 # ----------
 # Finds the libbluray library
 #
-# This will define the following variables::
-#
-# BLURAY_FOUND - system has libbluray
-# BLURAY_INCLUDE_DIRS - the libbluray include directory
-# BLURAY_LIBRARIES - the libbluray libraries
-# BLURAY_DEFINITIONS - the libbluray compile definitions
-#
-# and the following imported targets::
+# This will define the following target:
 #
 #   Bluray::Bluray   - The libbluray library
 
-if(Bluray_FIND_VERSION)
-  if(Bluray_FIND_VERSION_EXACT)
-    set(Bluray_FIND_SPEC "=${Bluray_FIND_VERSION_COMPLETE}")
-  else()
-    set(Bluray_FIND_SPEC ">=${Bluray_FIND_VERSION_COMPLETE}")
-  endif()
-endif()
+if(NOT TARGET Bluray::Bluray)
 
-find_package(PkgConfig)
+  find_package(PkgConfig)
 
-if(PKG_CONFIG_FOUND)
-  pkg_check_modules(PC_BLURAY libbluray${Bluray_FIND_SPEC} QUIET)
-  set(BLURAY_VERSION ${PC_BLURAY_VERSION})
-endif()
-
-find_path(BLURAY_INCLUDE_DIR libbluray/bluray.h
-                             HINTS ${PC_BLURAY_INCLUDEDIR})
-
-if(NOT BLURAY_VERSION AND EXISTS ${BLURAY_INCLUDE_DIR}/libbluray/bluray-version.h)
-  file(STRINGS ${BLURAY_INCLUDE_DIR}/libbluray/bluray-version.h _bluray_version_str
-       REGEX "#define[ \t]BLURAY_VERSION_STRING[ \t][\"]?[0-9.]+[\"]?")
-  string(REGEX REPLACE "^.*BLURAY_VERSION_STRING[ \t][\"]?([0-9.]+).*$" "\\1" BLURAY_VERSION ${_bluray_version_str})
-  unset(_bluray_version_str)
-endif()
-
-find_library(BLURAY_LIBRARY NAMES bluray libbluray
-                            HINTS ${PC_BLURAY_LIBDIR})
-
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Bluray
-                                  REQUIRED_VARS BLURAY_LIBRARY BLURAY_INCLUDE_DIR BLURAY_VERSION
-                                  VERSION_VAR BLURAY_VERSION)
-
-if(BLURAY_FOUND)
-  set(BLURAY_LIBRARIES ${BLURAY_LIBRARY})
-  set(BLURAY_INCLUDE_DIRS ${BLURAY_INCLUDE_DIR})
-  set(BLURAY_DEFINITIONS -DHAVE_LIBBLURAY=1)
-
-  # todo: improve syntax
-  if (NOT CORE_PLATFORM_NAME_LC STREQUAL windowsstore)
-    list(APPEND BLURAY_DEFINITIONS -DHAVE_LIBBLURAY_BDJ=1)
-  endif()
-
-  if(${BLURAY_LIBRARY} MATCHES ".+\.a$" AND PC_BLURAY_STATIC_LIBRARIES)
-    list(APPEND BLURAY_LIBRARIES ${PC_BLURAY_STATIC_LIBRARIES})
-  endif()
-
-  if(NOT TARGET Bluray::Bluray)
-    add_library(Bluray::Bluray UNKNOWN IMPORTED)
-    if(BLURAY_LIBRARY)
-      set_target_properties(Bluray::Bluray PROPERTIES
-                                           IMPORTED_LOCATION "${BLURAY_LIBRARY}")
+  # We only rely on pkgconfig for non windows platforms
+  if(PKG_CONFIG_FOUND AND NOT (WIN32 OR WINDOWS_STORE))
+    if(Bluray_FIND_VERSION_EXACT)
+      set(Bluray_FIND_SPEC "=${Bluray_FIND_VERSION_COMPLETE}")
+    else()
+      set(Bluray_FIND_SPEC ">=${Bluray_FIND_VERSION_COMPLETE}")
     endif()
+    pkg_check_modules(BLURAY libbluray${Bluray_FIND_SPEC} QUIET)
+
+    # First item is the full path of the library file found
+    # pkg_check_modules does not populate a variable of the found library explicitly
+    list(GET BLURAY_LINK_LIBRARIES 0 BLURAY_LIBRARY)
+  else()
+    # todo: for windows use find_package CONFIG call potentially
+
+    find_path(BLURAY_INCLUDEDIR NAMES libbluray/bluray.h
+                                HINTS ${DEPENDS_PATH}/include
+                                ${${CORE_PLATFORM_LC}_SEARCH_CONFIG}
+                                NO_CACHE)
+
+    find_library(BLURAY_LIBRARY NAMES bluray libbluray
+                                HINTS ${DEPENDS_PATH}/lib
+                                ${${CORE_PLATFORM_LC}_SEARCH_CONFIG}
+                                NO_CACHE)
+  endif()
+
+  if(NOT BLURAY_VERSION AND EXISTS ${BLURAY_INCLUDEDIR}/libbluray/bluray-version.h)
+    file(STRINGS ${BLURAY_INCLUDEDIR}/libbluray/bluray-version.h _bluray_version_str
+         REGEX "#define[ \t]BLURAY_VERSION_STRING[ \t][\"]?[0-9.]+[\"]?")
+    string(REGEX REPLACE "^.*BLURAY_VERSION_STRING[ \t][\"]?([0-9.]+).*$" "\\1" BLURAY_VERSION ${_bluray_version_str})
+    unset(_bluray_version_str)
+  endif()
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(Bluray
+                                    REQUIRED_VARS BLURAY_LIBRARY BLURAY_INCLUDEDIR BLURAY_VERSION
+                                    VERSION_VAR BLURAY_VERSION)
+
+  if(BLURAY_FOUND)
+    add_library(Bluray::Bluray UNKNOWN IMPORTED)
     set_target_properties(Bluray::Bluray PROPERTIES
-                                         INTERFACE_INCLUDE_DIRECTORIES "${BLURAY_INCLUDE_DIR}"
-                                         INTERFACE_COMPILE_DEFINITIONS HAVE_LIBBLURAY=1)
+                                         IMPORTED_LOCATION "${BLURAY_LIBRARY}"
+                                         INTERFACE_COMPILE_DEFINITIONS "HAVE_LIBBLURAY=1"
+                                         INTERFACE_INCLUDE_DIRECTORIES "${BLURAY_INCLUDEDIR}")
+
+    # Add link libraries for static lib usage
+    if(${BLURAY_LIBRARY} MATCHES ".+\.a$" AND BLURAY_LINK_LIBRARIES)
+      # Remove duplicates
+      list(REMOVE_DUPLICATES BLURAY_LINK_LIBRARIES)
+
+      # Remove own library - eg libbluray.a
+      list(FILTER BLURAY_LINK_LIBRARIES EXCLUDE REGEX ".*bluray.*\.a$")
+
+      set_target_properties(Bluray::Bluray PROPERTIES
+                                           INTERFACE_LINK_LIBRARIES "${BLURAY_LINK_LIBRARIES}")
+    endif()
+
+    if(NOT CORE_PLATFORM_NAME_LC STREQUAL windowsstore)
+      set_target_properties(Bluray::Bluray PROPERTIES
+                                           INTERFACE_COMPILE_DEFINITIONS "HAVE_LIBBLURAY_BDJ=1")
+    endif()
+
+    set_property(GLOBAL APPEND PROPERTY INTERNAL_DEPS_PROP Bluray::Bluray)
   endif()
 endif()
-
-mark_as_advanced(BLURAY_INCLUDE_DIR BLURAY_LIBRARY)


### PR DESCRIPTION
## Description
Migrate FindBluray to TARGET usage

## Motivation and context
Modern cmake

## How has this been tested?
Generate and build macos aarch64

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
