### PR TITLE
[videoplayer] Go to Chapter Start for "Previous Chapter" Past Grace Period

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -469,6 +469,7 @@ protected:
   void UpdateContentState();
 
   void UpdateFileItemStreamDetails(CFileItem& item);
+  int GetPreviousChapter();
 
   bool m_players_created;
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Modify VP actions when a backwards chapter skip is requested ("previous chapter", "previous chapter or big step back" actions)

Skip requested within 5 seconds of chapter start: go to the beginning of the previous chapter (same as current behavior)
Skip requested past 5 seconds from chapter start: go to the beginning of the current chapter.

(5 seconds taken from similar code used for scenes, could be adjusted)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I find the current behavior of going to the previous chapter regardless of the playing position in the current chapter unintuitive, even though it's technically correct.

For example in the situation below, skipping to previous chapter goes to the very beginning position 00:00, even though playback is almost at the end of chapter 2.
![image](https://github.com/xbmc/xbmc/assets/489377/c0d36d07-55bc-4c29-8bae-5ac6f908522f)

In addition, I didn't find a way to go back to the start of the currently playing chapter.

I think it's a nice improvement to extend the previous chapter action, and to make it go back to the start of the current chapter after a certain time has passed in the current chapter. It avoids the need to map another button on a remote or on keyboard for a "back to chapter start" function.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows, but platform is not relevant.
Files with / without chapters, skip backwards before 5 seconds of playback

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
More intuitive behavior for chapter backwards skip / Down key for large step or chapter back.

## Screenshots (if appropriate):
Initial situation:
![image](https://github.com/xbmc/xbmc/assets/489377/c0d36d07-55bc-4c29-8bae-5ac6f908522f)

Current master: "previous chapter"goes to the beginning of the file
![image](https://github.com/xbmc/xbmc/assets/489377/6ad656d7-e5db-480e-9d8e-e109eedd5d60)

With PR, "previous chapter" goes to start of the current chapter:
![image](https://github.com/xbmc/xbmc/assets/489377/96e464b6-671e-4c11-9f20-7182b24868d1)
An additional "previous chapter" within 5 seconds of chapter start goes to the previous chapter (=beginning of the file here).
![image](https://github.com/xbmc/xbmc/assets/489377/6ad656d7-e5db-480e-9d8e-e109eedd5d60)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
