### PR TITLE
Fix/update strings.po with translations for game window IDs

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -5625,27 +5625,67 @@ msgstr ""
 
 #empty strings from id 10802 to 10819
 
+#. Title of controller configuration window
 msgctxt "#10820"
-msgid "Game video filter"
+msgid "Controller Configuration"
 msgstr ""
 
+#. Title of the "My Games" window
 msgctxt "#10821"
 msgid "Games"
 msgstr ""
 
+#. Title of the in-game OSD menu
 msgctxt "#10822"
-msgid "Game OSD"
+msgid "Menu"
 msgstr ""
 
+#. Title of the in-game video filter selection dialog
 msgctxt "#10823"
-msgid "Game controllers"
+msgid "Video Filter"
 msgstr ""
 
+#. Title of the in-game video stretch mode selection dialog
 msgctxt "#10824"
-msgid "Game video settings"
+msgid "Stretch Mode"
 msgstr ""
 
-#empty strings from id 10825 to 11999
+#. Title of the in-game volume dialog
+msgctxt "#10825"
+msgid "Volume"
+msgstr ""
+
+#. Title of the in-game dialog for advanced emulator settings
+msgctxt "#10826"
+msgid "Advanced Settings"
+msgstr ""
+
+#. Title of the in-game video rotation selection dialog
+msgctxt "#10827"
+msgid "Video Rotation"
+msgstr ""
+
+#. Title of the window for setting up controller ports used by the game
+msgctxt "#10828"
+msgid "Port Setup"
+msgstr ""
+
+#. Title of the in-game dialog to select a savestate for the current game
+msgctxt "#10829"
+msgid "Select Savestate"
+msgstr ""
+
+#. Title of the out-of-game dialog to select a savestate for the current game
+msgctxt "#10830"
+msgid "Select Savestate"
+msgstr ""
+
+#. Name of window for viewing and configuring players while playing a game
+msgctxt "#10831"
+msgid "Players"
+msgstr ""
+
+#empty strings from id 10832 to 11999
 
 #: xbmc/guilib/WindowIDs.h
 msgctxt "#12000"


### PR DESCRIPTION
## Description

Now that the game window IDs have been correctly documented in https://github.com/xbmc/xbmc/pull/24055, it was requested that strings are fixed/introduced for each window title using the window IDs for string IDs.

While it makes sense to have matching string IDs and window IDs, this means that a few existing strings will have to change. I'm not sure how desired this is. It also introduces strings that aren't currently used in Estuary. I made the full change here for all game windows to satisfy the request. Now it's a question of which (if any) changes here we want to keep.

## Motivation and context

Requested several times in #skinning on slack and in https://github.com/xbmc/xbmc/pull/24055.

## How has this been tested?

No code changes to test.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
