### PR TITLE
[Estuary] Player Viewer: Give example static content for skin devs

### DIFF
--- a/addons/skin.estuary/xml/Includes_Games.xml
+++ b/addons/skin.estuary/xml/Includes_Games.xml
@@ -372,6 +372,7 @@
 						<itemlayout width="96" height="96">
 							<control type="gamecontroller">
 								<texture>$INFO[ListItem.Icon]</texture>
+								<controllerid>$INFO[ListItem.Property(game.controllerid)]</controllerid>
 								<controlleraddress>$INFO[ListItem.FilenameAndPath]</controlleraddress>
 								<controllerdiffuse>button_focus</controllerdiffuse>
 							</control>
@@ -379,10 +380,56 @@
 						<focusedlayout width="96" height="96">
 							<control type="gamecontroller">
 								<texture>$INFO[ListItem.Icon]</texture>
+								<controllerid>$INFO[ListItem.Property(game.controllerid)]</controllerid>
 								<controlleraddress>$INFO[ListItem.FilenameAndPath]</controlleraddress>
 								<controllerdiffuse>button_focus</controllerdiffuse>
 							</control>
 						</focusedlayout>
+						<!--
+							Note to skinners: this control can be populated
+							with static content for testing.
+						<content>
+							<item>
+								<icon>DefaultAddonNone.png</icon>
+							</item>
+							<item>
+								<property name="game.controllerid">game.controller.snes</property>
+							</item>
+							<item>
+								<property name="game.controllerid">game.controller.snes</property>
+							</item>
+							<item>
+								<property name="game.controllerid">game.controller.snes</property>
+							</item>
+							<item>
+								<property name="game.controllerid">game.controller.snes</property>
+							</item>
+							<item>
+								<property name="game.controllerid">game.controller.snes</property>
+							</item>
+							<item>
+								<property name="game.controllerid">game.controller.snes</property>
+							</item>
+							<item>
+								<property name="game.controllerid">game.controller.snes</property>
+							</item>
+							<item>
+								<property name="game.controllerid">game.controller.snes</property>
+							</item>
+							<item>
+								<property name="game.controllerid">game.controller.snes</property>
+							</item>
+							<item>
+								<property name="game.controllerid">game.controller.snes</property>
+							</item>
+							<item>
+								<property name="game.controllerid">game.controller.snes</property>
+							</item>
+							<item>
+								<property name="game.controllerid">game.controller.snes</property>
+							</item>
+						</content>
+						-->
 					</control>
 				</control>
 				<control type="group">
@@ -418,6 +465,48 @@
 							</control>
 							<include>GameDialogAgentLayout</include>
 						</focusedlayout>
+						<!--
+							Note to skinners: this control can be populated
+							with static content for testing.
+						<content>
+							<item>
+								<label>Player 1</label>
+							</item>
+							<item>
+								<label>Player 2</label>
+							</item>
+							<item>
+								<label>Player 3</label>
+							</item>
+							<item>
+								<label>Player 4</label>
+							</item>
+							<item>
+								<label>Player 5</label>
+							</item>
+							<item>
+								<label>Player 6</label>
+							</item>
+							<item>
+								<label>Player 7</label>
+							</item>
+							<item>
+								<label>Player 8</label>
+							</item>
+							<item>
+								<label>Player 9</label>
+							</item>
+							<item>
+								<label>Player 10</label>
+							</item>
+							<item>
+								<label>Player 11</label>
+							</item>
+							<item>
+								<label>Player 12</label>
+							</item>
+						</content>
+						-->
 					</control>
 				</control>
 				<control type="scrollbar" id="61">
@@ -465,16 +554,65 @@
 			<enable>false</enable>
 			<itemlayout width="96" height="96">
 				<control type="gamecontroller">
+					<texture>$INFO[ListItem.Icon]</texture>
+					<controllerid>$INFO[ListItem.Property(game.controllerid)]</controllerid>
 					<peripherallocation>$INFO[ListItem.FilenameAndPath]</peripherallocation>
 					<controllerdiffuse>button_focus</controllerdiffuse>
 				</control>
 			</itemlayout>
 			<focusedlayout width="96" height="96">
 				<control type="gamecontroller">
+					<texture>$INFO[ListItem.Icon]</texture>
+					<controllerid>$INFO[ListItem.Property(game.controllerid)]</controllerid>
 					<peripherallocation>$INFO[ListItem.FilenameAndPath]</peripherallocation>
 					<controllerdiffuse>button_focus</controllerdiffuse>
 				</control>
 			</focusedlayout>
+			<!--
+				Note to skinners: this control can be populated
+				with static content for testing.
+			<content>
+				<item>
+					<icon>DefaultAddonNone.png</icon>
+				</item>
+				<item>
+					<property name="game.controllerid">game.controller.default</property>
+				</item>
+				<item>
+					<property name="game.controllerid">game.controller.default</property>
+				</item>
+				<item>
+					<property name="game.controllerid">game.controller.default</property>
+				</item>
+				<item>
+					<property name="game.controllerid">game.controller.default</property>
+				</item>
+				<item>
+					<property name="game.controllerid">game.controller.default</property>
+				</item>
+				<item>
+					<property name="game.controllerid">game.controller.default</property>
+				</item>
+				<item>
+					<property name="game.controllerid">game.controller.default</property>
+				</item>
+				<item>
+					<property name="game.controllerid">game.controller.default</property>
+				</item>
+				<item>
+					<property name="game.controllerid">game.controller.default</property>
+				</item>
+				<item>
+					<property name="game.controllerid">game.controller.default</property>
+				</item>
+				<item>
+					<property name="game.controllerid">game.controller.default</property>
+				</item>
+				<item>
+					<property name="game.controllerid">game.controller.default</property>
+				</item>
+			</content>
+			-->
 		</control>
 	</include>
 </includes>


### PR DESCRIPTION
## Description

In order to test https://github.com/xbmc/xbmc/pull/23987, I added static list item content to the player list. I figured it'd be useful to provide the example in the skin itself to help skinners build their Player Viewer without needing to hunt down that PR.

## Motivation and context

Help skinners build and test their Player Viewer dialog.

## How has this been tested?

Tested on my retroplayer dev branch based on the Beta 1 release.

## What is the effect on users?

* Improved documentation for skin developers

## Screenshots (if appropriate):

When the new content is uncommented:

![screenshot00012](https://github.com/xbmc/xbmc/assets/531482/2db2b2e6-a8f9-4bf8-908b-8c0531779255)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
