### PR TITLE
[Xbox] Add support for HDR10 passthrough

### DIFF
--- a/xbmc/windowing/win10/WinSystemWin10DX.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10DX.cpp
@@ -166,7 +166,7 @@ void CWinSystemWin10DX::InitHooks(IDXGIOutput* pOutput)
 
 bool CWinSystemWin10DX::IsHDRDisplay()
 {
-  return false; // use tone mapping by default on Xbox
+  return (CWIN32Util::GetWindowsHDRStatus() != HDR_STATUS::HDR_UNSUPPORTED);
 }
 
 HDR_STATUS CWinSystemWin10DX::GetOSHDRStatus()


### PR DESCRIPTION
## Description
[Xbox] Add support for HDR10 passthrough.

Closes https://github.com/xbmc/xbmc/issues/24070

## Motivation and context
As commented in https://github.com/xbmc/xbmc/issues/24070 Microsoft has recently changed something in UWP API (at least for Xbox) and now HDR toggle works using `HdmiDisplayInformation` API.

Almost same code removed in https://github.com/xbmc/xbmc/pull/19879 (due not working) now works. Main difference is that now is used `HdmiDisplayHdrOption::Eotf2084` for GUI because from https://github.com/xbmc/xbmc/pull/23509 GUI is always rendered in BT.2020 and PQ transfer when HDR is ON. This is same in Windows x64.

Toggle code switches HDR state while keep same refresh rate and resolution.

Changes in `CWinSystemWin10::ChangeResolution` are necessary to change video mode (resolution/refresh) while keeps same HDR state: e.g. HDR is alredy on with 59Hz (GUI) and starts playback of 23.976 fps HDR movie.

Logic is quite complex (same as x64) but tested and all seems working as should:

**Auto Mode - "Use HDR display capabilities"  = ON (default)**

- GUI is rendered in SDR mode. HDR only is switched on at playback HDR contents. None is tone mapped.

**Auto Mode but GUI in HDR - "Use HDR display capabilities"  = ON (default)**

- User opens Kodi in SDR but press F11 key (manual HDR toggle). GUI is now in HDR PQ.
- Playing HDR contents HDR not toggles because is already in HDR.
- Playing SDR contents HDR toggles OFF and is played in SDR (no tone mapped).
- When playback stops GUI returns to initial state (HDR PQ ON).

**Manual Mode - "Use HDR display capabilities" = OFF**
- HDR videos are played in SDR mode (tone mapped Renhard/Hable/ACES) unless F11 key is pressed to toggle HDR ON.
- SDR videos are played in SDR and optionally (if HDR is manually ON / F11) are tone mapped to HDR10 by Windows.


All combinations works as expected with correct picture:
- GUI looks fine both SDR and HDR PQ (tone mapped Kodi shaders).
- SDR videos has correct picture when output is HDR PQ (handled by Windows).
- HDR videos has correct picture when output is SDR (tone mapped Kodi).


This after all seems low-risk change because Windows x64 HDR code is not touched and in Xbox feature not working at all previously and in case of some unexpected error users may switch "Use HDR display capabilities" OFF and all works as before (in the worst case scenario).
 

## How has this been tested?
Runtime Xbox Series S

## What is the effect on users?
Enables HDR10 passthrough on Xbox Series S/X

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
