### PR TITLE
Fix crash due nullptr surface using DXVA2

### DIFF
--- a/tools/buildsteps/windows/patches/0005-ffmpeg-windows-dxva2-check-nullptr-surface.patch
+++ b/tools/buildsteps/windows/patches/0005-ffmpeg-windows-dxva2-check-nullptr-surface.patch
@@ -1,0 +1,12 @@
+diff --git a/libavcodec/dxva2.c b/libavcodec/dxva2.c
+--- a/libavcodec/dxva2.c
++++ b/libavcodec/dxva2.c
+@@ -777,7 +777,7 @@ unsigned ff_dxva2_get_surface_index(const AVCodecContext *avctx,
+ #if CONFIG_D3D11VA
+     if (avctx->pix_fmt == AV_PIX_FMT_D3D11)
+         return (intptr_t)frame->data[1];
+-    if (avctx->pix_fmt == AV_PIX_FMT_D3D11VA_VLD) {
++    if (avctx->pix_fmt == AV_PIX_FMT_D3D11VA_VLD && surface) {
+         D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESC viewDesc;
+         ID3D11VideoDecoderOutputView_GetDesc((ID3D11VideoDecoderOutputView*) surface, &viewDesc);
+         return viewDesc.Texture2D.ArraySlice;


### PR DESCRIPTION
This may happen when a stream starts with non I frame.

Follow-Up of: #24058

Reasoning:
Kodi will release Omega with version 6.0.1
6.0.1 for sure won't get this fix upstream, therefore we include it as shown here for windows (it's dxva2 anyways) only
Latest when bumping to the next ffmpeg version in Omega+1, we send the patch upstream again
Any input welcome with the focus on working user experience, means: What can we do so that Windows users can enjoy, especially LiveTV without crashes.