### PR TITLE
tools/depends: curl adjust configure options

### DIFF
--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -150,7 +150,7 @@ $(DOWNLOAD_TARGETS):
 download: $(DOWNLOAD_TARGETS)
 
 crossguid: $(LIBUUID)
-curl: openssl nghttp2
+curl: openssl nghttp2 $(ZLIB)
 dbus: expat
 ffmpeg: $(ICONV) $(ZLIB) bzip2 gnutls dav1d $(LIBVA)
 fontconfig: freetype2 expat $(ICONV) $(LIBUUID)

--- a/tools/depends/target/curl/Makefile
+++ b/tools/depends/target/curl/Makefile
@@ -3,10 +3,18 @@ DEPS = ../../Makefile.include Makefile CURL-VERSION ../../download-files.include
 
 # configuration settings
 CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
-          ./configure --prefix=$(PREFIX) --disable-shared --disable-ldap \
-          --without-libssh2 --disable-ntlm-wb --enable-ipv6 --without-librtmp \
-          --without-libidn2 --with-ca-fallback --with-ssl=$(PREFIX) \
-          --with-nghttp2=$(PREFIX) --without-libpsl
+          ./configure --prefix=$(PREFIX) \
+                      --disable-shared \
+                      --disable-ldap \
+                      --without-libssh2 \
+                      --disable-ntlm-wb \
+                      --enable-ipv6 \
+                      --without-librtmp \
+                      --without-libidn2 \
+                      --with-ca-fallback \
+                      --with-ssl=$(PREFIX) \
+                      --with-nghttp2=$(PREFIX) \
+                      --without-libpsl
 
 LIBDYLIB=$(PLATFORM)/lib/.libs/$(BYPRODUCT)
 

--- a/tools/depends/target/curl/Makefile
+++ b/tools/depends/target/curl/Makefile
@@ -25,7 +25,8 @@ CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
                       --without-quiche \
                       --without-msh3 \
                       --without-gnutls \
-                      --without-nss
+                      --without-nss \
+                      --without-mbedtls
 
 LIBDYLIB=$(PLATFORM)/lib/.libs/$(BYPRODUCT)
 

--- a/tools/depends/target/curl/Makefile
+++ b/tools/depends/target/curl/Makefile
@@ -16,7 +16,8 @@ CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
                       --with-nghttp2=$(PREFIX) \
                       --without-libpsl \
                       --without-zstd \
-                      --without-brotli
+                      --without-brotli \
+                      --without-gssapi
 
 LIBDYLIB=$(PLATFORM)/lib/.libs/$(BYPRODUCT)
 

--- a/tools/depends/target/curl/Makefile
+++ b/tools/depends/target/curl/Makefile
@@ -14,6 +14,7 @@ CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
                       --with-ca-fallback \
                       --with-ssl=$(PREFIX) \
                       --with-nghttp2=$(PREFIX) \
+                      --with-zlib \
                       --without-libpsl \
                       --without-zstd \
                       --without-brotli \

--- a/tools/depends/target/curl/Makefile
+++ b/tools/depends/target/curl/Makefile
@@ -17,7 +17,8 @@ CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
                       --without-libpsl \
                       --without-zstd \
                       --without-brotli \
-                      --without-gssapi
+                      --without-gssapi \
+                      --without-gsasl
 
 LIBDYLIB=$(PLATFORM)/lib/.libs/$(BYPRODUCT)
 

--- a/tools/depends/target/curl/Makefile
+++ b/tools/depends/target/curl/Makefile
@@ -24,7 +24,8 @@ CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
                       --without-nghttp3 \
                       --without-quiche \
                       --without-msh3 \
-                      --without-gnutls
+                      --without-gnutls \
+                      --without-nss
 
 LIBDYLIB=$(PLATFORM)/lib/.libs/$(BYPRODUCT)
 

--- a/tools/depends/target/curl/Makefile
+++ b/tools/depends/target/curl/Makefile
@@ -26,7 +26,8 @@ CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
                       --without-msh3 \
                       --without-gnutls \
                       --without-nss \
-                      --without-mbedtls
+                      --without-mbedtls \
+                      --without-wolfssl
 
 LIBDYLIB=$(PLATFORM)/lib/.libs/$(BYPRODUCT)
 

--- a/tools/depends/target/curl/Makefile
+++ b/tools/depends/target/curl/Makefile
@@ -18,7 +18,8 @@ CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
                       --without-zstd \
                       --without-brotli \
                       --without-gssapi \
-                      --without-gsasl
+                      --without-gsasl \
+                      --without-hyper
 
 LIBDYLIB=$(PLATFORM)/lib/.libs/$(BYPRODUCT)
 

--- a/tools/depends/target/curl/Makefile
+++ b/tools/depends/target/curl/Makefile
@@ -21,7 +21,8 @@ CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
                       --without-gsasl \
                       --without-hyper \
                       --without-ngtcp2 \
-                      --without-nghttp3
+                      --without-nghttp3 \
+                      --without-quiche
 
 LIBDYLIB=$(PLATFORM)/lib/.libs/$(BYPRODUCT)
 

--- a/tools/depends/target/curl/Makefile
+++ b/tools/depends/target/curl/Makefile
@@ -23,7 +23,8 @@ CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
                       --without-ngtcp2 \
                       --without-nghttp3 \
                       --without-quiche \
-                      --without-msh3
+                      --without-msh3 \
+                      --without-gnutls
 
 LIBDYLIB=$(PLATFORM)/lib/.libs/$(BYPRODUCT)
 

--- a/tools/depends/target/curl/Makefile
+++ b/tools/depends/target/curl/Makefile
@@ -22,7 +22,8 @@ CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
                       --without-hyper \
                       --without-ngtcp2 \
                       --without-nghttp3 \
-                      --without-quiche
+                      --without-quiche \
+                      --without-msh3
 
 LIBDYLIB=$(PLATFORM)/lib/.libs/$(BYPRODUCT)
 

--- a/tools/depends/target/curl/Makefile
+++ b/tools/depends/target/curl/Makefile
@@ -14,7 +14,8 @@ CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
                       --with-ca-fallback \
                       --with-ssl=$(PREFIX) \
                       --with-nghttp2=$(PREFIX) \
-                      --without-libpsl
+                      --without-libpsl \
+                      --without-zstd
 
 LIBDYLIB=$(PLATFORM)/lib/.libs/$(BYPRODUCT)
 

--- a/tools/depends/target/curl/Makefile
+++ b/tools/depends/target/curl/Makefile
@@ -20,7 +20,8 @@ CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
                       --without-gssapi \
                       --without-gsasl \
                       --without-hyper \
-                      --without-ngtcp2
+                      --without-ngtcp2 \
+                      --without-nghttp3
 
 LIBDYLIB=$(PLATFORM)/lib/.libs/$(BYPRODUCT)
 

--- a/tools/depends/target/curl/Makefile
+++ b/tools/depends/target/curl/Makefile
@@ -15,7 +15,8 @@ CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
                       --with-ssl=$(PREFIX) \
                       --with-nghttp2=$(PREFIX) \
                       --without-libpsl \
-                      --without-zstd
+                      --without-zstd \
+                      --without-brotli
 
 LIBDYLIB=$(PLATFORM)/lib/.libs/$(BYPRODUCT)
 

--- a/tools/depends/target/curl/Makefile
+++ b/tools/depends/target/curl/Makefile
@@ -19,7 +19,8 @@ CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
                       --without-brotli \
                       --without-gssapi \
                       --without-gsasl \
-                      --without-hyper
+                      --without-hyper \
+                      --without-ngtcp2
 
 LIBDYLIB=$(PLATFORM)/lib/.libs/$(BYPRODUCT)
 


### PR DESCRIPTION
This should fix some build errors we have been having.

We should make sure the system libs (headers, dev packages) don't exist but we should also be explicit in the features we actually want.

The one change here that may be significant is the option `--with-zlib` however, this seems to be enabled automatically in our CI builds.

current curl config status (before this PR)
```
 curl version:     8.1.2
  SSL:              enabled (OpenSSL)
  SSH:              no      (--with-{libssh,libssh2})
  zlib:             enabled
  brotli:           no      (--with-brotli)
  zstd:             enabled (libzstd)
  GSS-API:          no      (--with-gssapi)
  GSASL:            no      (libgsasl not found)
  TLS-SRP:          enabled
  resolver:         POSIX threaded
  IPv6:             enabled
  Unix sockets:     enabled
  IDN:              no      (--with-{libidn2,winidn})
  Build libcurl:    Shared=no, Static=yes
  Built-in manual:  enabled
  --libcurl option: enabled (--disable-libcurl-option)
  Verbose errors:   enabled (--disable-verbose)
  Code coverage:    disabled
  SSPI:             no      (--enable-sspi)
  ca cert bundle:   no
  ca cert path:     no
  ca fallback:      yes
  LDAP:             no      (--enable-ldap / --with-ldap-lib / --with-lber-lib)
  LDAPS:            no      (--enable-ldaps)
  RTSP:             enabled
  RTMP:             no      (--with-librtmp)
  PSL:              no      (--with-libpsl)
  Alt-svc:          enabled (--disable-alt-svc)
  Headers API:      enabled (--disable-headers-api)
  HSTS:             enabled (--disable-hsts)
  HTTP1:            enabled (internal)
  HTTP2:            enabled (nghttp2)
  HTTP3:            no      (--with-ngtcp2 --with-nghttp3, --with-quiche, --with-msh3)
  ECH:              no      (--enable-ech)
  WebSockets:       no      (--enable-websockets)
  Protocols:        DICT FILE FTP FTPS GOPHER GOPHERS HTTP HTTPS IMAP IMAPS MQTT POP3 POP3S RTSP SMB SMBS SMTP SMTPS TELNET TFTP
  Features:         AsynchDNS HSTS HTTP2 HTTPS-proxy IPv6 Largefile NTLM SSL TLS-SRP UnixSockets alt-svc libz threadsafe zstd
```