### PR TITLE
[Estuary] Fix weather layout when busy

### DIFF
--- a/addons/skin.estuary/xml/MyWeather.xml
+++ b/addons/skin.estuary/xml/MyWeather.xml
@@ -68,6 +68,7 @@
 			<scrolltime tween="cubic" easing="out">500</scrolltime>
 			<include>OpenClose_Right</include>
 			<itemgap>-160</itemgap>
+			<visible>!String.StartsWith(Weather.Temperature,$LOCALIZE[503])</visible>
 			<control type="group" id="567">
 				<description>Weather info</description>
 				<height>410</height>
@@ -112,7 +113,7 @@
 					<top>194</top>
 					<aligny>center</aligny>
 					<height>24</height>
-					<width>500</width>
+					<width>300</width>
 					<align>right</align>
 					<font>WeatherTemp</font>
 					<label>$INFO[Weather.Temperature]</label>
@@ -203,5 +204,39 @@
 			<param name="sublabel" value="$INFO[Window(weather).Property(WeatherProvider)]" />
 		</include>
 		<include>BottomBar</include>
+		<control type="group">
+			<visible>String.StartsWith(Weather.Temperature,$LOCALIZE[503])</visible>
+			<animation effect="fade" time="400">VisibleChange</animation>
+			<control type="image">
+				<texture>colors/black.png</texture>
+				<include>FullScreenDimensions</include>
+				<animation effect="fade" start="100" end="70" time="0" condition="true">Conditional</animation>
+			</control>
+			<control type="group">
+				<depth>DepthMax</depth>
+				<centerleft>50%</centerleft>
+				<centertop>50%</centertop>
+				<width>80</width>
+				<height>80</height>
+				<control type="image">
+					<centerleft>50%</centerleft>
+					<centertop>50%</centertop>
+					<width>80</width>
+					<height>80</height>
+					<aspectratio>keep</aspectratio>
+					<animation effect="rotate" end="-45" center="auto" time="200" delay="600" loop="true" reversible="false" condition="true">Conditional</animation>
+					<texture colordiffuse="button_focus">spinner.png</texture>
+				</control>
+				<control type="image">
+					<centerleft>50%</centerleft>
+					<centertop>50%</centertop>
+					<width>50</width>
+					<height>50</height>
+					<aspectratio>keep</aspectratio>
+					<animation effect="rotate" end="45" center="auto" time="200" delay="600" loop="true" reversible="false" condition="true">Conditional</animation>
+					<texture flipx="true" colordiffuse="button_focus">spinner.png</texture>
+				</control>
+			</control>
+		</control>
 	</controls>
 </window>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Hides all updating elements when the weather is being fetched with a busy image.
## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently when the weather is being fetched (or the region is being changed) the temperature label displays 'Busy°C' which overlaps the current conditions as reported [here](https://github.com/xbmc/xbmc/issues/24082). This fix hides all the weather elements and displays the equivalent of Estuary's busy dialog when updating. 
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested and works as expected.
## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):
**Before PR**
Initial loading -
![screenshot00000](https://github.com/xbmc/xbmc/assets/133808/a02b2a55-4d69-43f3-ba6a-51ab71b3ae73)

Region change -
![screenshot00003](https://github.com/xbmc/xbmc/assets/133808/b4020b71-54f2-4c3f-90b0-bbdca89086ee)

**After PR**
Both loading and region change -
![screenshot00004](https://github.com/xbmc/xbmc/assets/133808/fa504d30-c53f-443b-848b-618edcb24a4c)

Once weather is updated -
![screenshot00002](https://github.com/xbmc/xbmc/assets/133808/61d317a0-b825-4a80-b084-ad032061ff61)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
