### PR TITLE
[video] GUIWindowVideoNav.cpp: Remove unused include.

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -27,7 +27,6 @@
 #include "messaging/helpers/DialogOKHelper.h"
 #include "music/MusicDatabase.h"
 #include "profiles/ProfileManager.h"
-#include "pvr/recordings/PVRRecording.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/MediaSourceSettings.h"


### PR DESCRIPTION
Not much more to say, just an unneeded header gets removed here.

@enen92 please gimme your thumb up.