### PR TITLE
[cmake] FindEGL set CMAKE_REQUIRED_INCLUDES for check_include_files

### DIFF
--- a/cmake/modules/FindEGL.cmake
+++ b/cmake/modules/FindEGL.cmake
@@ -32,8 +32,10 @@ if(NOT TARGET EGL::EGL)
     list(APPEND GL_INTERFACES_LIST egl egl-pb)
     set(GL_INTERFACES_LIST ${GL_INTERFACES_LIST} PARENT_SCOPE)
 
+    set(CMAKE_REQUIRED_INCLUDES "${EGL_INCLUDE_DIR}")
     include(CheckIncludeFiles)
     check_include_files("EGL/egl.h;EGL/eglext.h;EGL/eglext_angle.h" HAVE_EGLEXTANGLE)
+    unset(CMAKE_REQUIRED_INCLUDES)
 
     add_library(EGL::EGL UNKNOWN IMPORTED)
     set_target_properties(EGL::EGL PROPERTIES


### PR DESCRIPTION
This fixes building FreeBSD 13.2

It seems freebsd kodi ports are carrying some patches: https://cgit.freebsd.org/ports/tree/multimedia/kodi/files

This specifically targets replacing https://cgit.freebsd.org/ports/tree/multimedia/kodi/files/patch-cmake_modules_FindEGL.cmake

This is required because FreeBSD ports use `/usr/local` as the prefix.
