### PR TITLE
[Settings] Adjust the "Use display HDR capabilities" setting

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7307,7 +7307,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#13436"
-msgid "Use display HDR capabilities"
+msgid "Adjust display HDR mode"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -20172,10 +20172,10 @@ msgctxt "#36298"
 msgid "If enabled, a recording for the programme to remind will be scheduled when auto-closing the reminder popup, if supported by the PVR add-on and backend."
 msgstr ""
 
-#. Description of setting with label #13436 "Use display HDR capabilities"
+#. Description of setting with label #13436 "Adjust display HDR mode"
 #: system/settings/settings.xml
 msgctxt "#36299"
-msgid "Switch display into HDR mode if media with HDR information is played.[CR]If disabled, HDR information are applied using Kodi's internal HDR path."
+msgid "Allow the HDR mode of the display to be changed to best match the media.[CR]When disabled, Kodi applies tonemapping as needed to adapt the media to the current HDR mode of the display."
 msgstr ""
 
 #. Description of setting with label #20226 "Movie set information folder"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -60,6 +60,16 @@
           </constraints>
           <control type="list" format="string" />
         </setting>
+        <setting id="winsystem.ishdrdisplay" type="boolean" label="13436" help="36299">
+          <dependencies>
+            <dependency type="visible">
+              <condition on="property" name="ishdrdisplay" />
+            </dependency>
+          </dependencies>
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
         <setting id="videoplayer.usedisplayasclock" type="boolean" label="13510" help="36166">
           <level>1</level>
           <default>false</default>
@@ -159,16 +169,6 @@
         </setting>
         <setting id="videoplayer.usevtb" type="boolean" label="13429" help="36160">
           <requirement>HasVTB</requirement>
-          <level>2</level>
-          <default>true</default>
-          <control type="toggle" />
-        </setting>
-        <setting id="winsystem.ishdrdisplay" type="boolean" label="13436" help="36299">
-          <dependencies>
-            <dependency type="visible">
-              <condition on="property" name="ishdrdisplay" />
-            </dependency>
-          </dependencies>
           <level>2</level>
           <default>true</default>
           <control type="toggle" />


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

* Changed the name of the "Use display HDR capabilities" for consistency with "Adjust Refresh Rate".
Proposed new name: "Adjust display HDR mode"

* Proposed description:
"Allow the HDR/SDR mode of the display to be changed to match the media.
When disabled, Kodi applies tonemapping as needed to adapt the media to the current HDR mode of the display."

* Moved the setting from "Processing" category to "Playback", right after "Adjust refresh rate" as I think both settings are related from a user point of view.

* No functionality change

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Provide a clearer name and better place for the setting.

"Use display HDR capabilities" is not very clear to me and it's placement is odd. Maybe it was considered as "Processing" because when off, tonemapping is activated. But I don't think a user will guess that.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 10, open settings with HDR and non HDR screens > new name, place and description displayed as expected with HDR screen, and hidden with SDR screen.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
More user-friendly setting to let Kodi switch the screen between SDR and HDR mode.

## Screenshots (if appropriate):
Before:
![image](https://github.com/xbmc/xbmc/assets/489377/35269b17-cb11-421e-b33c-5023ff23a670)


After:
![image](https://github.com/xbmc/xbmc/assets/489377/9c7366de-bf34-4484-84a6-ba0e91e46e81)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
