### PR TITLE
[Android] Unused variable m_colorFormat in MediaCodec

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -68,24 +68,6 @@ enum MEDIACODEC_STATES
   MEDIACODEC_STATE_STOPPED
 };
 
-static bool IsSupportedColorFormat(int color_format)
-{
-  static const int supported_colorformats[] = {
-    CJNIMediaCodecInfoCodecCapabilities::COLOR_FormatYUV420Planar,
-    CJNIMediaCodecInfoCodecCapabilities::COLOR_TI_FormatYUV420PackedSemiPlanar,
-    CJNIMediaCodecInfoCodecCapabilities::COLOR_FormatYUV420SemiPlanar,
-    CJNIMediaCodecInfoCodecCapabilities::COLOR_QCOM_FormatYUV420SemiPlanar,
-    CJNIMediaCodecInfoCodecCapabilities::OMX_QCOM_COLOR_FormatYVU420SemiPlanarInterlace,
-    -1
-  };
-  for (const int *ptr = supported_colorformats; *ptr != -1; ptr++)
-  {
-    if (color_format == *ptr)
-      return true;
-  }
-  return false;
-}
-
 /*****************************************************************************/
 /*****************************************************************************/
 class CDVDMediaCodecOnFrameAvailable : public CEvent,
@@ -713,7 +695,6 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
   }
 
   m_codec = nullptr;
-  m_colorFormat = -1;
   codecInfos = CJNIMediaCodecList(CJNIMediaCodecList::REGULAR_CODECS).getCodecInfos();
 
   for (const CJNIMediaCodecInfo& codec_info : codecInfos)
@@ -751,8 +732,6 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
       continue;
     }
 
-    std::vector<int> color_formats = codec_caps.colorFormats();
-
     if (profile)
     {
       std::vector<CJNIMediaCodecInfoCodecProfileLevel> profileLevels = codec_caps.profileLevels();
@@ -785,16 +764,6 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
         {
           CLog::Log(LOGERROR, "CDVDVideoCodecAndroidMediaCodec::Open cannot create codec");
           continue;
-        }
-
-        for (size_t k = 0; k < color_formats.size(); ++k)
-        {
-          CLog::Log(LOGDEBUG,
-                    "CDVDVideoCodecAndroidMediaCodec::Open "
-                    "m_codecname({}), colorFormat({})",
-                    m_codecname, color_formats[k]);
-          if (IsSupportedColorFormat(color_formats[k]))
-            m_colorFormat = color_formats[k]; // Save color format for initial output configuration
         }
         break;
       }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -151,7 +151,6 @@ protected:
   CDVDStreamInfo m_hints;
   std::string m_mime;
   std::string m_codecname;
-  int m_colorFormat;
   std::string m_formatname;
   bool m_opened = false;
   bool m_needSecureDecoder = false;


### PR DESCRIPTION
## Description
The `m_colorFormat` variable is set once the MediaCodec has been selected, it's not used, nor does it have any effect on the codec configuration or during playback.

I propose to delete this variable and the related code.

## How has this been tested?
Play videos as usual on Android TV

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
