### PR TITLE
Add tranlation for Peripherals dialog with ID 10149

### DIFF
--- a/xbmc/guilib/WindowIDs.dox
+++ b/xbmc/guilib/WindowIDs.dox
@@ -67,7 +67,7 @@ This page shows the window names, the window definition, the window ID and the s
 | AddonInformation        | WINDOW_DIALOG_ADDON_INFO             | 10146     | DialogAddonInfo.xml                 |                                    |
 | TextViewer              | WINDOW_DIALOG_TEXT_VIEWER            | 10147     | DialogTextViewer.xml                |                                    |
 |                         | WINDOW_DIALOG_PLAY_EJECT             | 10148     | DialogConfirm.xml                   |                                    |
-|                         | WINDOW_DIALOG_PERIPHERALS            | 10149     | DialogSelect.xml                    |                                    |
+| Peripherals             | WINDOW_DIALOG_PERIPHERALS            | 10149     | DialogSelect.xml                    | @skinning_v21 The "Peripherals" alias has been added for this window<p></p> |
 | PeripheralSettings      | WINDOW_DIALOG_PERIPHERAL_SETTINGS    | 10150     | DialogSettings.xml                  |                                    |
 | ExtendedProgressDialog  | WINDOW_DIALOG_EXT_PROGRESS           | 10151     | DialogExtendedProgressBar.xml       |                                    |
 | MediaFilter             | WINDOW_DIALOG_MEDIA_FILTER           | 10152     | DialogSettings.xml                  |                                    |

--- a/xbmc/input/WindowTranslator.cpp
+++ b/xbmc/input/WindowTranslator.cpp
@@ -153,6 +153,7 @@ const CWindowTranslator::WindowMapByName CWindowTranslator::WindowMappingByName 
     {"splash", WINDOW_SPLASH},
     {"startwindow", WINDOW_START},
     {"startup", WINDOW_STARTUP_ANIM},
+    {"peripherals", WINDOW_DIALOG_PERIPHERALS},
     {"peripheralsettings", WINDOW_DIALOG_PERIPHERAL_SETTINGS},
     {"extendedprogressdialog", WINDOW_DIALOG_EXT_PROGRESS},
     {"mediafilter", WINDOW_DIALOG_MEDIA_FILTER},


### PR DESCRIPTION
## Description

This PR adds a new translation for the Peripherals dialog with ID 10149. I named the dialog "Peripherals".

As a result, before a skinner would do:

```xml
<visible>Window.IsVisible(10149)</visible>
```

After, a skinner could do:

```xml
<visible>Window.IsVisible(Peripherals)</visible>
```

## Motivation and context

Requested by @scott967 here: https://github.com/xbmc/xbmc/pull/24055#issuecomment-1806637581

## How has this been tested?

Untested. @scott967 Are you able to test, or describe a possible test case?

## What is the effect on users?

* Add translation for Peripherals dialog with window ID 10149.

## Screenshots (if appropriate):

Before:

![peripherals before](https://github.com/xbmc/xbmc/assets/531482/043de987-5e76-4859-a63c-9dd29d07d736)

After:

![With p](https://github.com/xbmc/xbmc/assets/531482/ff8b8b8f-259a-4ef7-8769-3173b4947697)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
