### PR TITLE
[Doxy] Fix formatting of Window IDs table

### DIFF
--- a/xbmc/guilib/WindowIDs.dox
+++ b/xbmc/guilib/WindowIDs.dox
@@ -112,18 +112,18 @@ This page shows the window names, the window definition, the window ID and the s
 | FullscreenRadioPreview  | WINDOW_FULLSCREEN_RADIO_PREVIEW      | 10803     | None (shortcut to fullscreenradio)  |                                    |
 | FullscreenLivetvInput   | WINDOW_FULLSCREEN_LIVETV_INPUT       | 10804     | None (shortcut to fullscreenlivetv) |                                    |
 | FullscreenRadioInput    | WINDOW_FULLSCREEN_RADIO_INPUT        | 10805     | None (shortcut to fullscreenradio)  |                                    |
-| GameControllers         | WINDOW_DIALOG_GAME_CONTROLLERS       | 10820     | DialogGameControllers.xml           | @skinning_v17 **New window**       |
-| Games                   | WINDOW_GAMES                         | 10821     | MyGames.xml                         | @skinning_v18 **New window**       |
-| GameOSD                 | WINDOW_DIALOG_GAME_OSD               | 10822     | GameOSD.xml                         | @skinning_v18 **New window**       |
-| GameVideoFilter         | WINDOW_DIALOG_GAME_VIDEO_FILTER      | 10823     | DialogSelect.xml                    | @skinning_v18 **New window**       |
-| GameStretchMode         | WINDOW_DIALOG_GAME_STRETCH_MODE      | 10824     | DialogSelect.xml                    | @skinning_v18 **New window**       |
-| GameVolume              | WINDOW_DIALOG_GAME_VOLUME            | 10825     | DialogSlider.xml                    | @skinning_v18 **New window** See https://github.com/xbmc/xbmc/pull/12765 |
-| GameAdvancedSettings    | WINDOW_DIALOG_GAME_ADVANCED_SETTINGS | 10826     | DialogAddonSettings.xml             | @skinning_v18 **New window**       |
-| GameVideoRotation       | WINDOW_DIALOG_GAME_VIDEO_ROTATION    | 10827     | DialogSelect.xml                    | @skinning_v18 **New window**       |
-| GamePorts               | WINDOW_DIALOG_GAME_PORTS             | 10828     | DialogGameControllers.xml           | @skinning_v20 **New window** See https://github.com/xbmc/xbmc/pull/20505 |
-| InGameSaves             | WINDOW_DIALOG_IN_GAME_SAVES          | 10829     | DialogSelect.xml                    | @skinning_v20 **New window** Part of the GSoC 2020 Saved Game Manager |
-| GameSaves               | WINDOW_DIALOG_GAME_SAVES             | 10830     | DialogSelect.xml                    | @skinning_v20 **New window** Part of the GSoC 2020 Saved Game Manager |
-| GameAgents              | WINDOW_DIALOG_GAME_AGENTS            | 10831     | DialogGameControllers.xml           | @skinning_v21 **New window** See https://github.com/xbmc/xbmc/pull/23548 |
+| GameControllers         | WINDOW_DIALOG_GAME_CONTROLLERS       | 10820     | DialogGameControllers.xml           | @skinning_v17 **New window**<p></p> |
+| Games                   | WINDOW_GAMES                         | 10821     | MyGames.xml                         | @skinning_v18 **New window**<p></p> |
+| GameOSD                 | WINDOW_DIALOG_GAME_OSD               | 10822     | GameOSD.xml                         | @skinning_v18 **New window**<p></p> |
+| GameVideoFilter         | WINDOW_DIALOG_GAME_VIDEO_FILTER      | 10823     | DialogSelect.xml                    | @skinning_v18 **New window**<p></p> |
+| GameStretchMode         | WINDOW_DIALOG_GAME_STRETCH_MODE      | 10824     | DialogSelect.xml                    | @skinning_v18 **New window**<p></p> |
+| GameVolume              | WINDOW_DIALOG_GAME_VOLUME            | 10825     | DialogSlider.xml                    | @skinning_v18 **New window** See https://github.com/xbmc/xbmc/pull/12765<p></p> |
+| GameAdvancedSettings    | WINDOW_DIALOG_GAME_ADVANCED_SETTINGS | 10826     | DialogAddonSettings.xml             | @skinning_v18 **New window**<p></p> |
+| GameVideoRotation       | WINDOW_DIALOG_GAME_VIDEO_ROTATION    | 10827     | DialogSelect.xml                    | @skinning_v18 **New window**<p></p> |
+| GamePorts               | WINDOW_DIALOG_GAME_PORTS             | 10828     | DialogGameControllers.xml           | @skinning_v20 **New window** See https://github.com/xbmc/xbmc/pull/20505<p></p> |
+| InGameSaves             | WINDOW_DIALOG_IN_GAME_SAVES          | 10829     | DialogSelect.xml                    | @skinning_v20 **New window** Part of the GSoC 2020 Saved Game Manager<p></p> |
+| GameSaves               | WINDOW_DIALOG_GAME_SAVES             | 10830     | DialogSelect.xml                    | @skinning_v20 **New window** Part of the GSoC 2020 Saved Game Manager<p></p> |
+| GameAgents              | WINDOW_DIALOG_GAME_AGENTS            | 10831     | DialogGameControllers.xml           | @skinning_v21 **New window** See https://github.com/xbmc/xbmc/pull/23548<p></p> |
 | Custom Skin Windows     | -                                    | -         | custom*.xml                         |                                    |
 | SelectDialog            | WINDOW_DIALOG_SELECT                 | 12000     | DialogSelect.xml                    |                                    |
 | MusicInformation        | WINDOW_DIALOG_MUSIC_INFO             | 12001     | DialogMusicInfo.xml                 |                                    |


### PR DESCRIPTION
## Description

In https://github.com/xbmc/xbmc/pull/24055, I introduced new game window IDs, and while it worked on my personal [codedocs.xyz/garbear/xbmc](https://codedocs.xyz/garbear/xbmc/window_ids.html) with older doxygen, the formatting is messed up on our version:

![game window id problem](https://github.com/xbmc/xbmc/assets/531482/8c83959c-bfcf-48c5-a93d-cefb7f245dfb)

While working on https://github.com/xbmc/xbmc/pull/24105, I hit the same issue and fixed it by adding `<p></p>` tags to the end of the table element, which I copied from a window added by @ksooo here: https://github.com/xbmc/xbmc/blob/master/xbmc/guilib/WindowIDs.dox#L145

## Motivation and context

Fix formatting of window IDs introduced in https://github.com/xbmc/xbmc/pull/24055

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

I wasn't able to reproduce the missing `<p></p>` problem locally for game window IDs, but I hit the problem for the `Peripherals` window added in https://github.com/xbmc/xbmc/pull/24105:

![WIthout p](https://github.com/xbmc/xbmc/assets/531482/abc54125-60cf-476d-a282-437adc278db4)

Adding the `<p></p>` tags fixed that, so I assume it'll fix the game window IDs too:

![With p](https://github.com/xbmc/xbmc/assets/531482/8b400253-531f-4989-88b2-037fe6c172a8)

## Screenshots

Game window IDs with the fix:

![Screenshot from 2023-11-15 15-36-38](https://github.com/xbmc/xbmc/assets/531482/2b1c97db-00bd-455b-897e-764f7cb552de)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
