### PR TITLE
[PVR] Fix racing problems due to ACTION_CHANNEL_SWITCH message being …

### DIFF
--- a/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsChannels.cpp
@@ -96,7 +96,7 @@ void UpdateActiveGroup(const std::shared_ptr<CPVRChannelGroupMember>& newChannel
 
 void TriggerChannelSwitchAction(const CPVRChannelNumber& channelNumber)
 {
-  CServiceBroker::GetAppMessenger()->PostMsg(
+  CServiceBroker::GetAppMessenger()->SendMsg(
       TMSG_GUI_ACTION, WINDOW_INVALID, -1,
       static_cast<void*>(new CAction(ACTION_CHANNEL_SWITCH,
                                      static_cast<float>(channelNumber.GetChannelNumber()),


### PR DESCRIPTION
…posted instead of sent (which was recently introduced, but seems to have bad side effects).

Fixes a regression I introduced with #23932 . When starting the channel switch async (PostMsg), this leads to problems at the GUI level, for example non working skin button emulating key press `0` to switch to previous channel (discussed in German Kodinerds forum).

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish could you please review.
