### PR TITLE
[VideoPlayer] Fix cache level calculation and add to Debug Info OSD

### DIFF
--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -605,6 +605,8 @@ int CFileCache::IoControl(EIoControl request, void* param)
   if (request == IOCTRL_CACHE_STATUS)
   {
     SCacheStatus* status = (SCacheStatus*)param;
+    status->maxforward =
+        (m_forwardCacheSize != 0) ? m_forwardCacheSize : static_cast<uint64_t>(m_fileSize);
     status->forward = m_pCache->WaitForData(0, 0ms);
     status->maxrate = m_writeRate;
     status->currate = m_writeRateActual;

--- a/xbmc/filesystem/IFileTypes.h
+++ b/xbmc/filesystem/IFileTypes.h
@@ -48,6 +48,7 @@ struct SNativeIoControl
 
 struct SCacheStatus
 {
+  uint64_t maxforward; /**< forward cache max capacity in bytes */
   uint64_t forward; /**< number of bytes cached forward of current position */
   uint32_t maxrate; /**< maximum allowed read(fill) rate (bytes/second) */
   uint32_t currate; /**< average read rate (bytes/second) since last position change */


### PR DESCRIPTION
## Description
Fix cache level calculation and add to Debug Info OSD

## Motivation and context
This is a follow-up of https://github.com/xbmc/xbmc/pull/22881 and is the "last step" to fix Cache Level.

We know that the cache level calculation was erratic and that is why it was no longer used internally. After https://github.com/xbmc/xbmc/pull/23760 it no longer has any effect on Video Player but the add-ons still have access to that (wrong) level with `Player.CacheLevel`. See https://github.com/xbmc/xbmc/pull/23760#issuecomment-1814383711

In this PR is fixed this level calculation as simple current_forward_bytes / max_forward_bytes and exposed to add-ons using same interface. Also is re-added to Debug Info OSD. 

Add-ons also can use `Player.ProgressCache`: this is the percentage of stream cached forward. This also added to Debug OSD in this way it will be easier to tell if something still wrong.

![debug-osd](https://github.com/xbmc/xbmc/assets/58434170/a7e99631-d5eb-44d4-9ccf-6606e3203a7c)

47.96 MB --> cached forward MB
100% --> cache level
19.859s --> estimated playback time of cached bytes
0,477% --> percentage of stream cached (cached time / total stream duration time)

Add-ons have access to cache level `Player.CacheLevel` and percentage of stream cached `Player.ProgressCache`

Note that progress cache has usually low values with long stream durations but with short videos can be understood better:

![debug-osd-2](https://github.com/xbmc/xbmc/assets/58434170/1cc4c9d1-9a69-4d6f-868b-33f2603d3626)

In this short video 33% is cached.

![progress-2](https://github.com/xbmc/xbmc/assets/58434170/313d7eb3-0bfb-4403-93d6-41f016ee7749)

Also coincides with progress bar indication (grey part ahead).


On usual duration movies also maintains the relation:
![debug-osd](https://github.com/xbmc/xbmc/assets/58434170/6ac3dcb0-cabf-4356-89d0-9bf052710241)

![progress](https://github.com/xbmc/xbmc/assets/58434170/6758e16a-b243-4702-93a5-f9c9fe0ee7e9)

## How has this been tested?
Runtime Windows x64


## What is the effect on users?
Fixes cache level calculation exposed to add-ons and make visible on Debug Info OSD again. Also add  `Player.ProgressCache` to Debug OSD.


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
