### PR TITLE
[PVR] CGUIWindowPVRBase: Prevent concurrent updates caused by GUI_MSG_UPDATE

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -352,6 +352,16 @@ bool CGUIWindowPVRBase::OnMessage(CGUIMessage& message)
           bReturn = true;
           break;
         }
+        case GUI_MSG_UPDATE:
+        {
+          if (IsActive() && m_bUpdating)
+          {
+            // no concurrent updates
+            CLog::LogF(LOGWARNING, "GUI_MSG_UPDATE: Updating in progress");
+            bReturn = true;
+          }
+          break;
+        }
       }
       break;
     }
@@ -553,6 +563,7 @@ bool CGUIWindowPVRBase::Update(const std::string& strDirectory, bool updateFilte
   if (m_bUpdating)
   {
     // no concurrent updates
+    CLog::LogF(LOGWARNING, "Updating in progress");
     return false;
   }
 


### PR DESCRIPTION
I have not seen this happen, but in theory it could. So, let's fix it. There are no side effects to be expected.

For testing, I simulated this situation by sending those messages from another thread. Works as designed.

@phunkyfish can you review, please.