### PR TITLE
[fileitem] CFileItem::LoadDetails: Add support for strm files containing an audio item.

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -3849,20 +3849,31 @@ bool CFileItem::LoadDetails()
     {
       if (playlist->Load(GetPath()) && playlist->size() == 1)
       {
-        CVideoDatabase db;
-        if (!db.Open())
+        const auto item{(*playlist)[0]};
+        if (item->IsVideo())
         {
-          CLog::LogF(LOGERROR, "Error opening video database");
-          return false;
-        }
+          CVideoDatabase db;
+          if (!db.Open())
+          {
+            CLog::LogF(LOGERROR, "Error opening video database");
+            return false;
+          }
 
-        CVideoInfoTag tag;
-        if (db.LoadVideoInfo(GetDynPath(), tag))
+          CVideoInfoTag tag;
+          if (db.LoadVideoInfo(GetDynPath(), tag))
+          {
+            UpdateInfo(*item);
+            *GetVideoInfoTag() = tag;
+            return true;
+          }
+        }
+        else if (item->IsAudio())
         {
-          const CFileItem loadedItem{*(*playlist)[0]};
-          UpdateInfo(loadedItem);
-          *GetVideoInfoTag() = tag;
-          return true;
+          if (item->LoadMusicTag())
+          {
+            UpdateInfo(*item);
+            return true;
+          }
         }
       }
     }


### PR DESCRIPTION
Before:

![screenshot00003](https://github.com/xbmc/xbmc/assets/3226626/17a084f4-d9a4-4f06-9b81-d476781306fc)

After:

![screenshot00004](https://github.com/xbmc/xbmc/assets/3226626/8c26ab68-9b7b-464a-8939-f4ef4417bd11)

Runtime-tested with a strm file containing the path to an mp3 file contained in my music library, macOS and Android, latest Kodi master.

@enen92 can you please review. In fact, only the `else if (item->IsAudio())` block is new code , the rest is just indentation change due to the new `if (item->IsVideo())` check.