### PR TITLE
[video] CAsyncItemsForPlaylist: If we shall resume but can't, default…

### DIFF
--- a/xbmc/video/VideoUtils.cpp
+++ b/xbmc/video/VideoUtils.cpp
@@ -46,7 +46,8 @@ class CAsyncGetItemsForPlaylist : public IRunnable
 public:
   CAsyncGetItemsForPlaylist(const std::shared_ptr<CFileItem>& item, CFileItemList& queuedItems)
     : m_item(item),
-      m_resume(item->GetStartOffset() == STARTOFFSET_RESUME),
+      m_resume((item->GetStartOffset() == STARTOFFSET_RESUME) &&
+               VIDEO_UTILS::GetItemResumeInformation(*item).isResumable),
       m_queuedItems(queuedItems)
   {
   }


### PR DESCRIPTION
… to play from beginning.

Fixes a bug for an edge case. To reproduce:

0) Set video default play action to "Resume" (Settings>Media>Videos>Default play action). Enable show movie sets (Settings>Media>Videos>Show movie sets)
1) Open Movies window (Movies / Titles), scroll to a movie set folder for a fully watched set (all movies fully watched)
2) Hit P on keyboard
=> nothing happens, but like for watched single movies, the playback should start from the beginning, with the first movie of the set.

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 could you please review?