### PR TITLE
[Estuary] Modify settings decription field to avoid unnecessary autoscroll

### DIFF
--- a/addons/skin.estuary/xml/SettingsCategory.xml
+++ b/addons/skin.estuary/xml/SettingsCategory.xml
@@ -175,7 +175,7 @@
 				<left>510</left>
 				<bottom>25</bottom>
 				<right>60</right>
-				<height>102</height>
+				<height>104</height>
 				<font>font12</font>
 				<align>justify</align>
 				<textcolor>button_focus</textcolor>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

In Estuary, 3-line setting descriptions of settings autoscroll, even though there is room available (default font).

Added 1 pixel to the field height to avoid autoscrolling (was due to rounding behavior in `CGUITextBox::UpdateInfo()`).
edit: resolution dependent behavior. 4k and 1080p were OK, need 2 pixels to fix down to 640x480.

**Question**: There is more room available, but I don't know if a bottom margin should be preserved, please let me know.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Autoscrolling of 3-line setting description even though they don't appear truncated.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1, 2, 3, 4 line descriptions and different screen resolutions.
All with default font.
resolutions from 640x480 up to 4k

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Avoid unnecessary scrolling of setting descriptions.

## Screenshots (if appropriate):
Before, autoscroll:
![image](https://github.com/xbmc/xbmc/assets/489377/7c4f42eb-17b6-4d6c-95be-5b353a42e4b0)

After, the 3 lines don't autoscroll.
![image](https://github.com/xbmc/xbmc/assets/489377/95b9e507-f01c-4b2f-a93f-175ce59ecc54)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
