### PR TITLE
[VideoPlayer] Remove unused code

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -55,7 +55,6 @@ struct SPlayerState
     caching = false;
     cache_bytes = 0;
     cache_level = 0.0;
-    cache_delay = 0.0;
     cache_offset = 0.0;
     lastSeek = 0;
     streamsReady = false;
@@ -86,7 +85,6 @@ struct SPlayerState
 
   int64_t cache_bytes;   // number of bytes current's cached
   double cache_level;   // current estimated required cache level
-  double cache_delay;   // time until cache is expected to reach estimated level
   double cache_offset;  // percentage of file ahead of current position
   double cache_time; // estimated playback time of current cached bytes
 };
@@ -241,7 +239,6 @@ protected:
 struct CacheInfo
 {
   double level; // current estimated required cache level
-  double delay; // time until cache is expected to reach estimated level
   double offset; // percentage of file ahead of current position
   double time; // estimated playback time of current cached bytes
   bool valid;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -83,9 +83,9 @@ struct SPlayerState
   bool cantempo;
   bool caching;
 
-  int64_t cache_bytes;   // number of bytes current's cached
-  double cache_level;   // current estimated required cache level
-  double cache_offset;  // percentage of file ahead of current position
+  int64_t cache_bytes; // number of bytes current's cached
+  double cache_level; // current cache level
+  double cache_offset; // percentage of file ahead of current position
   double cache_time; // estimated playback time of current cached bytes
 };
 
@@ -238,7 +238,7 @@ protected:
 
 struct CacheInfo
 {
-  double level; // current estimated required cache level
+  double level; // current cache level
   double offset; // percentage of file ahead of current position
   double time; // estimated playback time of current cached bytes
   bool valid;


### PR DESCRIPTION
## Description
[VideoPlayer] Remove unused code after https://github.com/xbmc/xbmc/pull/24117

## Motivation and context
Removes almost unused code:

- Intermediate variables related to old cache level method (calculated but not used).
- "Cache delay" variable is calculated and only used on debug OSD when video is paused. Is supposed informative only and anyway related to old cache level algorithm "estimated time to cache reaches estimated level". I'm not sure if many people have fully understood this at some point :)

## How has this been tested?
Videos still playing

## What is the effect on users?
none

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
