### PR TITLE
Remove use of pcrecpp from Kodi

### DIFF
--- a/tools/depends/target/pcre/004-win-pdb.patch
+++ b/tools/depends/target/pcre/004-win-pdb.patch
@@ -1,20 +1,18 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -969,12 +969,14 @@
+@@ -969,12 +969,12 @@
          PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
  
  IF(MSVC AND INSTALL_MSVC_PDB)
 -    INSTALL(FILES ${PROJECT_BINARY_DIR}/pcre.pdb
 -                  ${PROJECT_BINARY_DIR}/pcreposix.pdb
 +    INSTALL(FILES ${PROJECT_BINARY_DIR}/$<CONFIG>/pcre.pdb
-+                  ${PROJECT_BINARY_DIR}/$<CONFIG>/pcrecpp.pdb
 +                  ${PROJECT_BINARY_DIR}/$<CONFIG>/pcreposix.pdb
              DESTINATION bin
              CONFIGURATIONS RelWithDebInfo)
 -    INSTALL(FILES ${PROJECT_BINARY_DIR}/pcred.pdb
 -                  ${PROJECT_BINARY_DIR}/pcreposixd.pdb
 +    INSTALL(FILES ${PROJECT_BINARY_DIR}/$<CONFIG>/pcred.pdb
-+                  ${PROJECT_BINARY_DIR}/$<CONFIG>/pcrecppd.pdb
 +                  ${PROJECT_BINARY_DIR}/$<CONFIG>/pcreposixd.pdb
              DESTINATION bin
              CONFIGURATIONS Debug)

--- a/xbmc/filesystem/FTPParse.cpp
+++ b/xbmc/filesystem/FTPParse.cpp
@@ -8,7 +8,6 @@
 
 #include "FTPParse.h"
 
-#include <cmath>
 #include <regex>
 
 CFTPParse::CFTPParse()
@@ -109,7 +108,7 @@ void CFTPParse::setTime(const std::string& str)
     setMonFromName(time_struct, month);
 
     /* set the day of the month */
-    time_struct.tm_mday = atoi(day.c_str());
+    time_struct.tm_mday = std::stol(day);
 
     time_t t = time(NULL);
     struct tm *current_time;
@@ -122,8 +121,8 @@ void CFTPParse::setTime(const std::string& str)
     if (std::regex_match(year, match, std::regex("(\\d{2}):(\\d{2})")))
     {
       /* set the hour and minute */
-      time_struct.tm_hour = atoi(match[1].str().c_str());
-      time_struct.tm_min = atoi(match[2].str().c_str());
+      time_struct.tm_hour = std::stol(match[1].str());
+      time_struct.tm_min = std::stol(match[2].str());
 
       /* set the year */
       if ((current_time->tm_mon - time_struct.tm_mon < 0) ||
@@ -136,7 +135,7 @@ void CFTPParse::setTime(const std::string& str)
     else
     {
       /* set the year */
-      time_struct.tm_year = atoi(year.c_str()) - 1900;
+      time_struct.tm_year = std::stol(year) - 1900;
     }
   }
   else if (std::regex_match(str, match, multinet_re))
@@ -153,16 +152,16 @@ void CFTPParse::setTime(const std::string& str)
     setMonFromName(time_struct, month);
 
     /* set the day of the month and year */
-    time_struct.tm_mday = atoi(day.c_str());
-    time_struct.tm_year = atoi(year.c_str()) - 1900;
+    time_struct.tm_mday = std::stol(day);
+    time_struct.tm_year = std::stol(year) - 1900;
 
     /* set the hour and minute */
-    time_struct.tm_hour = atoi(hour.c_str());
-    time_struct.tm_min = atoi(minute.c_str());
+    time_struct.tm_hour = std::stol(hour);
+    time_struct.tm_min = std::stol(minute);
 
     /* set the second if given*/
     if (second.length() > 0)
-      time_struct.tm_sec = atoi(second.c_str());
+      time_struct.tm_sec = std::stol(second);
   }
   else if (std::regex_match(str, match, msdos_re))
   {
@@ -174,23 +173,23 @@ void CFTPParse::setTime(const std::string& str)
     am_or_pm = match[6].str();
 
     /* set the month and the day of the month */
-    time_struct.tm_mon = atoi(month.c_str()) - 1;
-    time_struct.tm_mday = atoi(day.c_str());
+    time_struct.tm_mon = std::stol(month) - 1;
+    time_struct.tm_mday = std::stol(day);
 
     /* set the year */
-    time_struct.tm_year = atoi(year.c_str());
+    time_struct.tm_year = std::stoi(year);
     if (time_struct.tm_year < 70)
       time_struct.tm_year += 100;
 
     /* set the hour */
-    time_struct.tm_hour = atoi(hour.c_str());
+    time_struct.tm_hour = std::stoi(hour);
     if (time_struct.tm_hour == 12)
       time_struct.tm_hour -= 12;
     if (am_or_pm == "PM")
       time_struct.tm_hour += 12;
 
     /* set the minute */
-    time_struct.tm_min = atoi(minute.c_str());
+    time_struct.tm_min = std::stoi(minute);
   }
 
   /* now set m_time */
@@ -282,7 +281,7 @@ int CFTPParse::FTPParse(const std::string& str)
     date = match[7].str();
     m_name = match[8].str();
 
-    m_size = (uint64_t)strtod(size.c_str(), NULL);
+    m_size = std::stoull(size);
     if (type == "d")
       m_flagtrycwd = 1;
     if (type == "-")
@@ -308,7 +307,7 @@ int CFTPParse::FTPParse(const std::string& str)
     date = match[5].str();
     m_name = match[6].str();
 
-    m_size = (uint64_t)strtod(size.c_str(), NULL);
+    m_size = std::stoull(size);
     if (type == "d")
       m_flagtrycwd = 1;
     if (type == "-")
@@ -326,7 +325,7 @@ int CFTPParse::FTPParse(const std::string& str)
     date = match[5].str();
     m_name = match[6].str();
 
-    m_size = (uint64_t)strtod(size.c_str(), NULL);
+    m_size = std::stoull(size);
     if (type == "d")
       m_flagtrycwd = 1;
     if (type == "-")
@@ -356,13 +355,13 @@ int CFTPParse::FTPParse(const std::string& str)
     std::regex_search(facts, match, std::regex("(?:\\+|,)m(\\d+),"));
     date = match[1].str();
 
-    m_size = (uint64_t)strtod(size.c_str(), NULL);
+    m_size = std::stoull(size);
     if (type == "/")
       m_flagtrycwd = 1;
     if (type == "r")
       m_flagtryretr = 1;
     /* eplf stores the date in time_t format already */
-    m_time = atoi(date.c_str());
+    m_time = std::stoi(date);
 
     return 1;
   }
@@ -403,7 +402,7 @@ int CFTPParse::FTPParse(const std::string& str)
     else
     {
       m_flagtryretr = 1;
-      m_size = (uint64_t)strtod(size.c_str(), NULL);
+      m_size = std::stoull(size);
     }
     setTime(date);
 

--- a/xbmc/filesystem/FTPParse.cpp
+++ b/xbmc/filesystem/FTPParse.cpp
@@ -138,11 +138,6 @@ void CFTPParse::setTime(const std::string& str)
       /* set the year */
       time_struct.tm_year = atoi(year.c_str()) - 1900;
     }
-
-    /* set the day of the week */
-    time_struct.tm_wday = getDayOfWeek(time_struct.tm_mon + 1,
-                                   time_struct.tm_mday,
-                                   time_struct.tm_year + 1900);
   }
   else if (std::regex_match(str, match, multinet_re))
   {
@@ -168,11 +163,6 @@ void CFTPParse::setTime(const std::string& str)
     /* set the second if given*/
     if (second.length() > 0)
       time_struct.tm_sec = atoi(second.c_str());
-
-    /* set the day of the week */
-    time_struct.tm_wday = getDayOfWeek(time_struct.tm_mon + 1,
-                                   time_struct.tm_mday,
-                                   time_struct.tm_year + 1900);
   }
   else if (std::regex_match(str, match, msdos_re))
   {
@@ -201,90 +191,10 @@ void CFTPParse::setTime(const std::string& str)
 
     /* set the minute */
     time_struct.tm_min = atoi(minute.c_str());
-
-    /* set the day of the week */
-    time_struct.tm_wday = getDayOfWeek(time_struct.tm_mon + 1,
-                                   time_struct.tm_mday,
-                                   time_struct.tm_year + 1900);
   }
 
   /* now set m_time */
   m_time = mktime(&time_struct);
-}
-
-int CFTPParse::getDayOfWeek(int month, int date, int year)
-{
-  /* Here we use the Doomsday rule to calculate the day of the week */
-
-  /* First determine the anchor day */
-  int anchor;
-  if (year >= 1900 && year < 2000)
-    anchor = 3;
-  else if (year >= 2000 && year < 2100)
-    anchor = 2;
-  else if (year >= 2100 && year < 2200)
-    anchor = 0;
-  else if (year >= 2200 && year < 2300)
-    anchor = 5;
-  else // must have been given an invalid year :-/
-    return -1;
-
-  /* Now determine the doomsday */
-  int y = year % 100;
-  int dday =
-    ((y/12 + (y % 12) + ((y % 12)/4)) % 7) + anchor;
-
-  /* Determine if the given year is a leap year */
-  int leap_year = 0;
-  if (((year % 4 == 0) && (year % 100 != 0)) || (year % 400 == 0))
-    leap_year = 1;
-
-  /* Now select a doomsday for the given month */
-  int mdday = 1;
-  if (month == 1)
-  {
-    if (leap_year)
-      mdday = 4;
-    else
-      mdday = 3;
-  }
-  if (month == 2)
-  {
-    if (leap_year)
-      mdday = 1;
-    else
-      mdday = 7;
-  }
-  if (month == 3)
-    mdday = 7;
-  if (month == 4)
-    mdday = 4;
-  if (month == 5)
-    mdday = 9;
-  if (month == 6)
-    mdday = 6;
-  if (month == 7)
-    mdday = 11;
-  if (month == 8)
-    mdday = 8;
-  if (month == 9)
-    mdday = 5;
-  if (month == 10)
-    mdday = 10;
-  if (month == 11)
-    mdday = 9;
-  if (month == 12)
-    mdday = 12;
-
-  /* Now calculate the day of the week
-   * Sunday = 0, Monday = 1, Tuesday = 2, Wednesday = 3, Thursday = 4,
-   * Friday = 5, Saturday = 6.
-   */
-  int day_of_week = ((date - 1) % 7) - ((mdday - 1) % 7) + dday;
-  if (day_of_week >= 7)
-    day_of_week -= 7;
-
-  return day_of_week;
 }
 
 int CFTPParse::FTPParse(const std::string& str)

--- a/xbmc/filesystem/FTPParse.cpp
+++ b/xbmc/filesystem/FTPParse.cpp
@@ -44,20 +44,20 @@ time_t CFTPParse::getTime()
 
 namespace
 {
-  const std::string months = "janfebmaraprmayjunjulaugsepoctnovdec";
+const std::string months = "janfebmaraprmayjunjulaugsepoctnovdec";
 
-  // set time_struct.tm_mon from the 3-letter "abbreviated month name"
-  void setMonFromName(struct tm& time_struct, const std::string& name)
+// set time_struct.tm_mon from the 3-letter "abbreviated month name"
+void setMonFromName(struct tm& time_struct, const std::string& name)
+{
+  std::smatch match;
+  if (std::regex_search(months, match, std::regex(name, std::regex_constants::icase)))
   {
-    std::smatch match;
-    if (std::regex_search(months, match, std::regex(name, std::regex_constants::icase))) 
-    {
-        int pos = match.position();
-        if (name.size() == 3 && pos % 3 == 0)
-            time_struct.tm_mon = pos / 3;
-    }
+    int pos = match.position();
+    if (name.size() == 3 && pos % 3 == 0)
+      time_struct.tm_mon = pos / 3;
   }
 }
+} // namespace
 
 void CFTPParse::setTime(const std::string& str)
 {
@@ -68,10 +68,10 @@ void CFTPParse::setTime(const std::string& str)
   std::smatch match;
 
   // Regex to read Unix, NetWare and NetPresenz time format
-  if (std::regex_match(str, match, std::regex(
-    "^([A-Za-z]{3})" // month
-    "\\s+(\\d{1,2})" // day of month
-    "\\s+([:\\d]{4,5})$"))) // time of day or year
+  if (std::regex_match(str, match,
+                       std::regex("^([A-Za-z]{3})" // month
+                                  "\\s+(\\d{1,2})" // day of month
+                                  "\\s+([:\\d]{4,5})$"))) // time of day or year
   {
     auto month = match[1].str();
     auto day = match[2].str();
@@ -112,13 +112,13 @@ void CFTPParse::setTime(const std::string& str)
     }
   }
   // Regex to read MultiNet time format
-  else if (std::regex_match(str, match, std::regex(
-    "^(\\d{1,2})" // day of month
-    "-([A-Za-z]{3})" // month
-    "-(\\d{4})" // year
-    "\\s+(\\d{2})" // hour
-    ":(\\d{2})" // minute
-    "(:(\\d{2}))?$"))) // second
+  else if (std::regex_match(str, match,
+                            std::regex("^(\\d{1,2})" // day of month
+                                       "-([A-Za-z]{3})" // month
+                                       "-(\\d{4})" // year
+                                       "\\s+(\\d{2})" // hour
+                                       ":(\\d{2})" // minute
+                                       "(:(\\d{2}))?$"))) // second
   {
     auto day = match[1].str();
     auto month = match[2].str();
@@ -144,13 +144,13 @@ void CFTPParse::setTime(const std::string& str)
       time_struct.tm_sec = std::stol(second);
   }
   // Regex to read MSDOS time format
-  else if (std::regex_match(str, match, std::regex(
-    "^(\\d{2})" // month
-    "-(\\d{2})" // day of month
-    "-(\\d{2})" // year
-    "\\s+(\\d{2})" // hour
-    ":(\\d{2})" // minute
-    "([AP]M)$"))) // AM or PM
+  else if (std::regex_match(str, match,
+                            std::regex("^(\\d{2})" // month
+                                       "-(\\d{2})" // day of month
+                                       "-(\\d{2})" // year
+                                       "\\s+(\\d{2})" // hour
+                                       ":(\\d{2})" // minute
+                                       "([AP]M)$"))) // AM or PM
   {
     auto month = match[1].str();
     auto day = match[2].str();
@@ -189,15 +189,16 @@ int CFTPParse::FTPParse(const std::string& str)
   std::smatch match;
 
   // Regex for standard Unix listing formats
-  if (std::regex_match(str, match, std::regex(
-    "^([-bcdlps])" // type
-    "([-rwxXsStT]{9})" // permissions
-    "\\s+(\\d+)" // hard link count
-    "\\s+(\\w+)" // owner
-    "\\s+(\\w+)" // group
-    "\\s+(\\d+)" // size
-    "\\s+([A-Za-z]{3}\\s+\\d{1,2}\\s+[:\\d]{4,5})" // modification date
-    "\\s+(.+)$"))) // name
+  if (std::regex_match(
+          str, match,
+          std::regex("^([-bcdlps])" // type
+                     "([-rwxXsStT]{9})" // permissions
+                     "\\s+(\\d+)" // hard link count
+                     "\\s+(\\w+)" // owner
+                     "\\s+(\\w+)" // group
+                     "\\s+(\\d+)" // size
+                     "\\s+([A-Za-z]{3}\\s+\\d{1,2}\\s+[:\\d]{4,5})" // modification date
+                     "\\s+(.+)$"))) // name
   {
     auto type = match[1].str();
     auto permissions = match[2].str();
@@ -227,13 +228,13 @@ int CFTPParse::FTPParse(const std::string& str)
   }
   // Regex for NetWare listing formats
   // See http://www.novell.com/documentation/oes/ftp_enu/data/a3ep22p.html#fbhbaijf
-  if (std::regex_match(str, match, std::regex(
-    "^([-d])" // type
-    "\\s+(\\[[-SRWCIEMFA]{8}\\])" // rights
-    "\\s+(\\w+)" // owner
-    "\\s+(\\d+)" // size
-    "\\s+([A-Za-z]{3}\\s+\\d{1,2}\\s+[:\\d]{4,5})" // time
-    "\\s+(.+)$"))) // name
+  if (std::regex_match(str, match,
+                       std::regex("^([-d])" // type
+                                  "\\s+(\\[[-SRWCIEMFA]{8}\\])" // rights
+                                  "\\s+(\\w+)" // owner
+                                  "\\s+(\\d+)" // size
+                                  "\\s+([A-Za-z]{3}\\s+\\d{1,2}\\s+[:\\d]{4,5})" // time
+                                  "\\s+(.+)$"))) // name
   {
     auto type = match[1].str();
     auto permissions = match[2].str();
@@ -254,13 +255,14 @@ int CFTPParse::FTPParse(const std::string& str)
   // Regex for NetPresenz
   // See http://files.stairways.com/other/ftp-list-specs-info.txt
   // Here we will capture permissions and size if given
-  if (std::regex_match(str, match, std::regex(
-    "^([-dl])" // type
-    "([-rwx]{9}|)" // permissions
-    "\\s+(.*)" // stuff
-    "\\s+(\\d+|)" // size
-    "\\s+([A-Za-z]{3}\\s+\\d{1,2}\\s+[:\\d]{4,5})" // modification date
-    "\\s+(.+)$"))) // name
+  if (std::regex_match(
+          str, match,
+          std::regex("^([-dl])" // type
+                     "([-rwx]{9}|)" // permissions
+                     "\\s+(.*)" // stuff
+                     "\\s+(\\d+|)" // size
+                     "\\s+([A-Za-z]{3}\\s+\\d{1,2}\\s+[:\\d]{4,5})" // modification date
+                     "\\s+(.+)$"))) // name
   {
     auto type = match[1].str();
     auto permissions = match[2].str();
@@ -289,10 +291,10 @@ int CFTPParse::FTPParse(const std::string& str)
   // Regex for EPLF
   // See http://cr.yp.to/ftp/list/eplf.html
   // SAVE: "(/,|r,|s\\d+,|m\\d+,|i[\\d!#@$%^&*()]+(\\.[\\d!#@$%^&*()]+|),)+"
-  if (std::regex_match(str, match, std::regex(
-    "^\\+" // initial "plus" sign
-    "([^\\s]+)" // facts
-    "\\s(.+)$"))) // name
+  if (std::regex_match(str, match,
+                       std::regex("^\\+" // initial "plus" sign
+                                  "([^\\s]+)" // facts
+                                  "\\s(.+)$"))) // name
   {
     auto facts = match[1].str();
     m_name = match[2].str();
@@ -318,19 +320,20 @@ int CFTPParse::FTPParse(const std::string& str)
   // Regex for MultiNet
   // Best documentation found was
   // http://www-sld.slac.stanford.edu/SLDWWW/workbook/vms_files.html
-  if (std::regex_match(str, match, std::regex(
-    "^([^;]+)" // name
-    ";(\\d+)" // version
-    "\\s+([\\d/]+)" // file id
-    "\\s+(\\d{1,2}-[A-Za-z]{3}-\\d{4}\\s+\\d{2}:\\d{2}(:\\d{2})?)" // date
-    "\\s+\\[([^\\]]+)\\]" // owner,group
-    "\\s+\\(([^\\)]+)\\)$"))) // permissions
+  if (std::regex_match(
+          str, match,
+          std::regex("^([^;]+)" // name
+                     ";(\\d+)" // version
+                     "\\s+([\\d/]+)" // file id
+                     "\\s+(\\d{1,2}-[A-Za-z]{3}-\\d{4}\\s+\\d{2}:\\d{2}(:\\d{2})?)" // date
+                     "\\s+\\[([^\\]]+)\\]" // owner,group
+                     "\\s+\\(([^\\)]+)\\)$"))) // permissions
   {
     auto name = match[1].str();
     auto version = match[2].str();
     auto file_id = match[3].str();
     auto date = match[4].str();
-    // match[5] ignored 
+    // match[5] ignored
     auto owner = match[6].str();
     auto permissions = match[7].str();
 
@@ -349,10 +352,10 @@ int CFTPParse::FTPParse(const std::string& str)
     return 1;
   }
   // Regex for MSDOS
-  if (std::regex_match(str, match, std::regex(
-    "^(\\d{2}-\\d{2}-\\d{2}\\s+\\d{2}:\\d{2}[AP]M)" // date
-    "\\s+(<DIR>|[\\d]+)" // dir or size
-    "\\s+(.+)$"))) // name
+  if (std::regex_match(str, match,
+                       std::regex("^(\\d{2}-\\d{2}-\\d{2}\\s+\\d{2}:\\d{2}[AP]M)" // date
+                                  "\\s+(<DIR>|[\\d]+)" // dir or size
+                                  "\\s+(.+)$"))) // name
   {
     auto date = match[1].str();
     auto size = match[2].str();

--- a/xbmc/filesystem/FTPParse.h
+++ b/xbmc/filesystem/FTPParse.h
@@ -29,5 +29,4 @@ private:
   uint64_t m_size;              // number of octets
   time_t m_time = 0; // modification time
   void setTime(const std::string& str); // Method used to set m_time from a string
-  int getDayOfWeek(int month, int date, int year); // Method to get day of week
 };


### PR DESCRIPTION
## Description
Remove use of pcrecpp from Kodi

This PR converts the only user of  prcecpp in Kodi, `xbmc/filesystem/FTPParse.cpp` , to use `std::regex` instead.
It also removes any reference to pcrecpp from tooling.

The first commit is the actual port from pcrecpp to std::regex. It simply changes `pcrecpp::RE` initializers to `std::regex` and methods `pcre::FullMatch` and `pcre::PartialMatch` to `std::regex_match` and `std::regex_search`, resp.

The only exception is changing the conversion from three-letter abbreviated month name to month number (`tm_mon` in `struct tm`) from the elaborate (pseudocode)
```
if month ~ "jan":
  tm_mon = 0
else if month ~ "feb":
  tm_mon = 1
...
```
to a more compact (and efficient) form (`setMonFromName`).
  
The other commits are optional code clean up:
- remove getDayOfWeek(): unused outside of FTPParse.cpp
- replace atoi() with std::stoi() and strtod() with std::stoul()
- move all regexes to where they're used and use "auto" to name sub matches

## Motivation and context
There are lots of complaints that Kodi still uses the EOL pcre v1 library (and its C++ covenience wrapper pcrecpp) , but efforts to port to pcre2 seem to have been forestalled by the fact that there is no equivalent of pcrecpp for pcre2, see e.g. https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1000113#21

## How has this been tested?
Build (using latest LibreELEC) and tested against a Linux server (proftpd), file listings in `Videos/Files` or `Settings/File Manager` look as expected wrt. reported file sizes and modification dates.

## What is the effect on users?
None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
