### PR TITLE
[VideoInfoScanner][GUIDialogVideoInfo] Update blank movie sets with artwork from Movie Set Information Folder

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -14160,7 +14160,14 @@ msgctxt "#20474"
 msgid "HDR type"
 msgstr ""
 
-#empty strings from id 20475 to 21329
+#. Used dynamically to allow set art update from MSIF
+#: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+#: addons/skin.estuary/xml/DialogVideoInfo.xml
+msgctxt "#20475"
+msgid "Use local art"
+msgstr ""
+
+#empty strings from id 20476 to 21329
 #up to 21329 is reserved for the video db !! !
 
 #: system/settings/settings.xml

--- a/addons/skin.estuary/xml/DialogVideoInfo.xml
+++ b/addons/skin.estuary/xml/DialogVideoInfo.xml
@@ -650,6 +650,12 @@
 						<param name="visible" value="Control.IsEnabled(10)" />
 					</include>
 					<include content="InfoDialogButton">
+						<param name="id" value="15" />
+						<param name="icon" value="icons/infodialogs/choose_image.png" />
+						<param name="label" value="$LOCALIZE[20475]" />
+						<param name="visible" value="Control.IsEnabled(15)" />
+					</include>
+					<include content="InfoDialogButton">
 						<param name="id" value="6" />
 						<param name="icon" value="icons/infodialogs/update.png" />
 						<param name="label" value="$LOCALIZE[184]" />

--- a/xbmc/dialogs/GUIDialogContextMenu.h
+++ b/xbmc/dialogs/GUIDialogContextMenu.h
@@ -88,6 +88,7 @@ enum CONTEXT_BUTTON
   CONTEXT_BUTTON_PLAY_NEXT,
   CONTEXT_BUTTON_NAVIGATE,
   CONTEXT_BUTTON_MANAGE_VIDEOVERSIONS,
+  CONTEXT_BUTTON_MOVIESET_USE_LOCAL_ART,
 };
 
 class CContextButtons : public std::vector< std::pair<size_t, std::string> >

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -92,6 +92,9 @@ namespace VIDEO
      */
     void GetArtwork(CFileItem *pItem, const CONTENT_TYPE &content, bool bApplyToDir=false, bool useLocal=true, const std::string &actorArtPath = "");
 
+    std::map<std::string, std::string> UpdateSetFromLocalArtwork(const CVideoInfoTag& setDetails);
+    bool IsArtNeededAndLocalArtwork(const CVideoInfoTag& setDetails);
+
     /*! \brief Get season thumbs for a tvshow.
      All seasons (regardless of whether the user has episodes) are added to the art map.
      \param show     tvshow info tag

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.h
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.h
@@ -60,6 +60,9 @@ public:
   static bool AddItemsToTag(const std::shared_ptr<CFileItem>& tagItem);
   static bool RemoveItemsFromTag(const std::shared_ptr<CFileItem>& tagItem);
 
+  static std::map<std::string, std::string> UpdateSetFromLocalArtwork(
+      const std::shared_ptr<CFileItem>& item);
+
   static bool ChooseAndManageVideoItemArtwork(const std::shared_ptr<CFileItem>& item);
   static bool ManageVideoItemArtwork(const std::shared_ptr<CFileItem>& item, const MediaType& type);
 


### PR DESCRIPTION






There are now three ways the movie set artwork can be updated:

1) On a library update - good if you have multiple sets with no artwork.
2) Right click (just the same as choose art)
3) Through the video information dialog (just the same as choose art)

After 3 the library display isn't automatically updated - this is a different bug - see #24176.

## Description
When a movie set is added by the scraper, sometimes there is no associated artwork, for example:

<img width="195" alt="image" src="https://github.com/xbmc/xbmc/assets/99039295/babcdc09-19fb-4e9a-9f7b-f8a0899238ae">

If, when the movie is added, there is an entry in the Movie Set Information Folder (as per https://kodi.wiki/view/Movie_set_information_folder) then any artwork from there is used.

## Motivation and context

Obviously, you are't going to know if there is no set artwork until you've added the movie. Even if you then add artwork in the Movie Set Information Folder - it is never scanned again - you would have to add the artwork manually through the context menu.

If you have a number of sets to update - this is slow.

This PR rescans any movie sets with no atwork, when the library is updated, to see if there is any artwork in the Movie Set Information Folder and adds it automatically.

## How has this been tested?

On my library in Win 11 x64.

## What is the effect on users?

Easier to add movie set artwork - just need to setup the Movie Set Information folder (as per Wiki above) and then place a poster.jpg in a subdiretory with the name of the movie set. It will then be used automatically at next library update.

## Screenshots (if appropriate):

Using above example:

<img width="390" alt="image" src="https://github.com/xbmc/xbmc/assets/99039295/18f301ba-2d26-42e6-a569-5ceeb74cb34b">

After library update:

<img width="219" alt="image" src="https://github.com/xbmc/xbmc/assets/99039295/9903d668-e81d-4bdb-9cb2-eac69fd79deb">

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ X ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

I'm sure it's probably not in the right place in the code!