### PR TITLE
[video] Fix auto play next item not working if 'uncategorized' is not…

### DIFF
--- a/xbmc/media/MediaType.h
+++ b/xbmc/media/MediaType.h
@@ -27,6 +27,13 @@ using MediaType = std::string;
 #define MediaTypeEpisode          "episode"
 #define MediaTypeVideoVersion "videoversion"
 
+constexpr const char* MediaTypeVideoCollections = "sets";
+constexpr const char* MediaTypeMusicVideos = "musicvideos";
+constexpr const char* MediaTypeMovies = "movies";
+constexpr const char* MediaTypeTvShows = "tvshows";
+constexpr const char* MediaTypeSeasons = "seasons";
+constexpr const char* MediaTypeEpisodes = "episodes";
+
 class CMediaTypes
 {
 public:

--- a/xbmc/video/VideoUtils.cpp
+++ b/xbmc/video/VideoUtils.cpp
@@ -377,13 +377,15 @@ bool IsAutoPlayNextItem(const CFileItem& item)
 bool IsAutoPlayNextItem(const std::string& content)
 {
   int settingValue = CSettings::SETTING_AUTOPLAYNEXT_UNCATEGORIZED;
-  if (content == MediaTypeMovie)
+  if (content == MediaTypeMovie || content == MediaTypeMovies ||
+      content == MediaTypeVideoCollections)
     settingValue = CSettings::SETTING_AUTOPLAYNEXT_MOVIES;
-  else if (content == MediaTypeEpisode)
+  else if (content == MediaTypeEpisode || content == MediaTypeSeasons ||
+           content == MediaTypeEpisodes)
     settingValue = CSettings::SETTING_AUTOPLAYNEXT_EPISODES;
-  else if (content == MediaTypeMusicVideo)
+  else if (content == MediaTypeMusicVideo || content == MediaTypeMusicVideos)
     settingValue = CSettings::SETTING_AUTOPLAYNEXT_MUSICVIDEOS;
-  else if (content == MediaTypeTvShow)
+  else if (content == MediaTypeTvShow || content == MediaTypeTvShows)
     settingValue = CSettings::SETTING_AUTOPLAYNEXT_TVSHOWS;
 
   const auto setting = std::dynamic_pointer_cast<CSettingList>(


### PR DESCRIPTION
… selected in the respective GUI setting.

Fixes #24129 

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 another small fix. The fixed method gets not only called for video items but also for the item representing the folder the video is located in. So, both video types and video folder types need to be checked here.

BTW: Yes we only have defines for the video types, not for the video folder types. Something for a follow-up PR maybe.