### PR TITLE
Fix Visual Studio warnings

### DIFF
--- a/xbmc/network/GUIDialogNetworkSetup.cpp
+++ b/xbmc/network/GUIDialogNetworkSetup.cpp
@@ -194,7 +194,7 @@ void CGUIDialogNetworkSetup::InitializeSettings()
   // Add our protocols
   TranslatableIntegerSettingOptions labels;
   for (size_t idx = 0; idx < m_protocols.size(); ++idx)
-    labels.emplace_back(m_protocols[idx].label, idx, m_protocols[idx].addonId);
+    labels.emplace_back(m_protocols[idx].label, static_cast<int>(idx), m_protocols[idx].addonId);
 
   AddSpinner(group, SETTING_PROTOCOL, 1008, SettingLevel::Basic, m_protocol, labels);
   AddEdit(group, SETTING_SERVER_ADDRESS, 1010, SettingLevel::Basic, m_server, true);

--- a/xbmc/windowing/GraphicContext.cpp
+++ b/xbmc/windowing/GraphicContext.cpp
@@ -718,7 +718,7 @@ void CGraphicContext::SetScalingResolution(const RESOLUTION_INFO &res, bool need
   // reset our origin and camera
   while (!m_origins.empty())
     m_origins.pop();
-  m_origins.emplace(0, 0);
+  m_origins.emplace(.0f, .0f);
   while (!m_cameras.empty())
     m_cameras.pop();
   m_cameras.emplace(0.5f * m_iScreenWidth, 0.5f * m_iScreenHeight);


### PR DESCRIPTION
## Description
Fix new Visual Studio warnings after https://github.com/xbmc/xbmc/pull/23960

## Motivation and context
```
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\include\xmemory(673,1): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data (compiling source file C:\jenkins-workspace\workspace\WIN-64\xbmc\network\GUIDialogNetworkSetup.cpp) [C:\jenkins-workspace\workspace\WIN-64\kodi-build.x64\libkodi.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\include\vector(852,1): message : see reference to function template instantiation 'void std::_Default_allocator_traits<_Alloc>::construct<_Ty,T&,size_t&,std::string&>(_Alloc &,_Objty *const ,T &,size_t &,std::string &)' being compiled [C:\jenkins-workspace\workspace\WIN-64\kodi-build.x64\libkodi.vcxproj]
          with
          [
              _Alloc=std::allocator<TranslatableIntegerSettingOption>,
              _Ty=TranslatableIntegerSettingOption,
              T=int,
              _Objty=TranslatableIntegerSettingOption
          ] (compiling source file C:\jenkins-workspace\workspace\WIN-64\xbmc\network\GUIDialogNetworkSetup.cpp)
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\include\vector(863,36): message : see reference to function template instantiation 'void std::_Default_allocator_traits<_Alloc>::construct<_Ty,T&,size_t&,std::string&>(_Alloc &,_Objty *const ,T &,size_t &,std::string &)' being compiled [C:\jenkins-workspace\workspace\WIN-64\kodi-build.x64\libkodi.vcxproj]
          with
          [
              _Alloc=std::allocator<TranslatableIntegerSettingOption>,
              _Ty=TranslatableIntegerSettingOption,
              T=int,
              _Objty=TranslatableIntegerSettingOption
          ] (compiling source file C:\jenkins-workspace\workspace\WIN-64\xbmc\network\GUIDialogNetworkSetup.cpp)
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\include\vector(839,1): message : see reference to function template instantiation '_Ty &std::vector<_Ty,std::allocator<_Ty>>::_Emplace_back_with_unused_capacity<T&,size_t&,std::string&>(T &,size_t &,std::string &)' being compiled [C:\jenkins-workspace\workspace\WIN-64\kodi-build.x64\libkodi.vcxproj]
          with
          [
              _Ty=TranslatableIntegerSettingOption,
              T=int
          ] (compiling source file C:\jenkins-workspace\workspace\WIN-64\xbmc\network\GUIDialogNetworkSetup.cpp)
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\include\vector(845,13): message : see reference to function template instantiation '_Ty &std::vector<_Ty,std::allocator<_Ty>>::_Emplace_back_with_unused_capacity<T&,size_t&,std::string&>(T &,size_t &,std::string &)' being compiled [C:\jenkins-workspace\workspace\WIN-64\kodi-build.x64\libkodi.vcxproj]
          with
          [
              _Ty=TranslatableIntegerSettingOption,
              T=int
          ] (compiling source file C:\jenkins-workspace\workspace\WIN-64\xbmc\network\GUIDialogNetworkSetup.cpp)
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\include\vector(925,1): message : see reference to function template instantiation '_Ty &std::vector<_Ty,std::allocator<_Ty>>::_Emplace_one_at_back<T&,size_t&,std::string&>(T &,size_t &,std::string &)' being compiled [C:\jenkins-workspace\workspace\WIN-64\kodi-build.x64\libkodi.vcxproj]
          with
          [
              _Ty=TranslatableIntegerSettingOption,
              T=int
          ] (compiling source file C:\jenkins-workspace\workspace\WIN-64\xbmc\network\GUIDialogNetworkSetup.cpp)
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\include\vector(927,14): message : see reference to function template instantiation '_Ty &std::vector<_Ty,std::allocator<_Ty>>::_Emplace_one_at_back<T&,size_t&,std::string&>(T &,size_t &,std::string &)' being compiled [C:\jenkins-workspace\workspace\WIN-64\kodi-build.x64\libkodi.vcxproj]
          with
          [
              _Ty=TranslatableIntegerSettingOption,
              T=int
          ] (compiling source file C:\jenkins-workspace\workspace\WIN-64\xbmc\network\GUIDialogNetworkSetup.cpp)
  EventPollHandle.cpp
C:\jenkins-workspace\workspace\WIN-64\xbmc\network\GUIDialogNetworkSetup.cpp(197,78): message : see reference to function template instantiation '_Ty &std::vector<_Ty,std::allocator<_Ty>>::emplace_back<int&,size_t&,std::string&>(int &,size_t &,std::string &)' being compiled [C:\jenkins-workspace\workspace\WIN-64\kodi-build.x64\libkodi.vcxproj]
          with
          [
              _Ty=TranslatableIntegerSettingOption
          ]
```

```
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\include\xmemory(680,68): warning C4244: 'argument': conversion from '_Ty' to 'T', possible loss of data [C:\jenkins-workspace\workspace\WIN-64\kodi-build.x64\libkodi.vcxproj]
          with
          [
              _Ty=int
          ]
          and
          [
              T=float
          ] (compiling source file C:\jenkins-workspace\workspace\WIN-64\xbmc\windowing\GraphicContext.cpp)
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\include\deque(1148,1): message : see reference to function template instantiation 'void std::_Default_allocator_traits<_Alloc>::construct<_Ty,int,int>(_Alloc &,_Objty *const ,int &&,int &&)' being compiled [C:\jenkins-workspace\workspace\WIN-64\kodi-build.x64\libkodi.vcxproj]
          with
          [
              _Alloc=std::allocator<CPoint>,
              _Ty=CPointGen<float>,
              _Objty=CPointGen<float>
          ] (compiling source file C:\jenkins-workspace\workspace\WIN-64\xbmc\windowing\GraphicContext.cpp)
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\include\deque(1159,32): message : see reference to function template instantiation 'void std::_Default_allocator_traits<_Alloc>::construct<_Ty,int,int>(_Alloc &,_Objty *const ,int &&,int &&)' being compiled [C:\jenkins-workspace\workspace\WIN-64\kodi-build.x64\libkodi.vcxproj]
          with
          [
              _Alloc=std::allocator<CPoint>,
              _Ty=CPointGen<float>,
              _Objty=CPointGen<float>
          ] (compiling source file C:\jenkins-workspace\workspace\WIN-64\xbmc\windowing\GraphicContext.cpp)
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\include\deque(856,1): message : see reference to function template instantiation 'void std::deque<CPoint,std::allocator<CPoint>>::_Emplace_back_internal<_Ty,_Ty>(_Ty &&,_Ty &&)' being compiled [C:\jenkins-workspace\workspace\WIN-64\kodi-build.x64\libkodi.vcxproj]
          with
          [
              _Ty=int
          ] (compiling source file C:\jenkins-workspace\workspace\WIN-64\xbmc\windowing\GraphicContext.cpp)
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\include\deque(858,31): message : see reference to function template instantiation 'void std::deque<CPoint,std::allocator<CPoint>>::_Emplace_back_internal<_Ty,_Ty>(_Ty &&,_Ty &&)' being compiled [C:\jenkins-workspace\workspace\WIN-64\kodi-build.x64\libkodi.vcxproj]
          with
          [
              _Ty=int
          ] (compiling source file C:\jenkins-workspace\workspace\WIN-64\xbmc\windowing\GraphicContext.cpp)
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\include\stack(124,1): message : see reference to function template instantiation 'CPointGen<float> &std::deque<CPoint,std::allocator<CPoint>>::emplace_back<_Ty,_Ty>(_Ty &&,_Ty &&)' being compiled [C:\jenkins-workspace\workspace\WIN-64\kodi-build.x64\libkodi.vcxproj]
          with
          [
              _Ty=int
          ] (compiling source file C:\jenkins-workspace\workspace\WIN-64\xbmc\windowing\GraphicContext.cpp)
C:\jenkins-workspace\workspace\WIN-64\xbmc\windowing\GraphicContext.cpp(721,25): message : see reference to function template instantiation 'CPointGen<float> &std::stack<CPoint,std::deque<CPoint,std::allocator<CPoint>>>::emplace<int,int>(int &&,int &&)' being compiled [C:\jenkins-workspace\workspace\WIN-64\kodi-build.x64\libkodi.vcxproj]
```

## How has this been tested?
Build Windows x64

## What is the effect on users?
none

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
