### PR TITLE
[swig] Fix misleading indentation warnings

### DIFF
--- a/xbmc/interfaces/python/typemaps/python.buffer.intm
+++ b/xbmc/interfaces/python/typemaps/python.buffer.intm
@@ -33,4 +33,6 @@
       ${api}.flip(); // prepare the buffer for reading from
     }
     else
+    {
       throw XBMCAddon::WrongTypeException("argument \"%s\" for \"%s\" must be a string, bytes or a bytearray", "${api}", "${method.@name}");
+    }


### PR DESCRIPTION
## Description
Example of warning fixed by specifically encasing the else 
```
/build/build/swig/AddonModuleXbmcdrm.i.cpp:183:7: warning: misleading indentation; statement is not part of the previous 'else' [-Wmisleading-indentation]
      if (pymimeType) PyXBMCGetUnicodeString(mimeType,pymimeType,false,"mimeType","GetKeyRequest");
      ^
/build/build/swig/AddonModuleXbmcdrm.i.cpp:181:5: note: previous statement is here
     else
     ^
```
## Motivation and context
Fix warnings seen on freebsd builder

## How has this been tested?
Ran on jenkins, no more warnings. Output of generated file is the following that explicitly encloses the else throw call and leaves the remaining codepaths to continue as should be expected
```
    else
    {
      throw XBMCAddon::WrongTypeException(
          "argument \"%s\" for \"%s\" must be a string, bytes or a bytearray", "init",
          "GetKeyRequest");
    }
    if (pymimeType)
      PyXBMCGetUnicodeString(mimeType, pymimeType, false, "mimeType", "GetKeyRequest");

    {
      PyObject *pykey, *pyvalue;
      Py_ssize_t pos = 0;
      while (PyDict_Next(pyoptionalParameters, &pos, &pykey, &pyvalue))
      {
        std::string key;
        std::string value;
        if (pykey)
          PyXBMCGetUnicodeString(key, pykey, false, "key", "GetKeyRequest");
        if (pyvalue)
          PyXBMCGetUnicodeString(value, pyvalue, false, "value", "GetKeyRequest");
        optionalParameters.emplace(std::move(key), std::move(value));
      }
    }
```

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
