### PR TITLE
XBMCTinyXML2: Strip trailing '\0' when writing to file

### DIFF
--- a/xbmc/utils/XBMCTinyXML2.cpp
+++ b/xbmc/utils/XBMCTinyXML2.cpp
@@ -57,8 +57,8 @@ bool CXBMCTinyXML2::SaveFile(const std::string& filename) const
   {
     tinyxml2::XMLPrinter printer;
     Accept(&printer);
-    bool suc =
-        file.Write(printer.CStr(), printer.CStrSize()) == static_cast<ssize_t>(printer.CStrSize());
+    const ssize_t sizeToWrite = printer.CStrSize() - 1; // strip trailing '\0'
+    bool suc = file.Write(printer.CStr(), sizeToWrite) == sizeToWrite;
     if (suc)
       file.Flush();
 


### PR DESCRIPTION
## Description
When writing the serialized XML to a file we don't want to add the terminating `'\0'` of the string to file.

Fixes #24135.

## Motivation and context
Text editors, validators, etc. don't expect the terminating null. Example:
```
$ xmllint .kodi/userdata/favourites.xml 
.kodi/userdata/favourites.xml:4: parser error : Extra content at the end of the document

^
```

## How has this been tested?
Add something to the favourites in Kodi. Without this change `favourites.xml` has an additional null byte at the end, with this change it's gone.

## What is the effect on users?
Valid XML files.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
