### PR TITLE
[Games] Remove hard-coded button combos

### DIFF
--- a/addons/skin.estuary/language/resource.language.en_gb/strings.po
+++ b/addons/skin.estuary/language/resource.language.en_gb/strings.po
@@ -308,15 +308,7 @@ msgctxt "#31058"
 msgid "Automatic Login on startup"
 msgstr ""
 
-#: /xml/GameOSD.xml
-msgctxt "#31059"
-msgid "Select + X"
-msgstr ""
-
-#: /xml/GameOSD.xml
-msgctxt "#31060"
-msgid "Select + Start"
-msgstr ""
+#empty strings from id 31059 to 31060
 
 #: /xml/SkinSettings.xml
 msgctxt "#31061"

--- a/addons/skin.estuary/xml/Custom_1101_SettingsList.xml
+++ b/addons/skin.estuary/xml/Custom_1101_SettingsList.xml
@@ -160,7 +160,7 @@
 						<width>700</width>
 						<include>DialogSettingButton</include>
 						<label>$LOCALIZE[13376]</label>
-						<label2>[COLOR grey]Select + Right Stick[/COLOR]</label2>
+						<label2>[COLOR grey]$FEATURE[select,game.controller.snes] + $FEATURE[rightstick,game.controller.default][/COLOR]</label2>
 						<onclick>ActivateWindow(GameVolume)</onclick>
 					</control>
 					<control type="button" id="14103">

--- a/addons/skin.estuary/xml/GameOSD.xml
+++ b/addons/skin.estuary/xml/GameOSD.xml
@@ -204,7 +204,7 @@
 							<item>
 								<description>Pause / Resume button</description>
 								<label>$LOCALIZE[35224]</label>
-								<label2>$LOCALIZE[31059]</label2>
+								<label2>$FEATURE[select,game.controller.snes] + $FEATURE[x,game.controller.default]</label2>
 								<icon>osd/fullscreen/buttons/play.png</icon>
 								<onclick>Play</onclick>
 							</item>
@@ -229,7 +229,7 @@
 							<item>
 								<description>Stop button</description>
 								<label>$LOCALIZE[35222]</label>
-								<label2>$LOCALIZE[31060]</label2>
+								<label2>$FEATURE[select,game.controller.snes] + $FEATURE[start,game.controller.default]</label2>
 								<icon>osd/fullscreen/buttons/stop.png</icon>
 								<onclick>Stop</onclick>
 							</item>

--- a/xbmc/games/GameServices.cpp
+++ b/xbmc/games/GameServices.cpp
@@ -57,6 +57,12 @@ ControllerVector CGameServices::GetControllers()
   return m_controllerManager.GetControllers();
 }
 
+std::string CGameServices::TranslateFeature(const std::string& controllerId,
+                                            const std::string& featureName)
+{
+  return m_controllerManager.TranslateFeature(controllerId, featureName);
+}
+
 std::string CGameServices::GetSavestatesFolder() const
 {
   return m_profileManager.GetSavestatesFolder();

--- a/xbmc/games/GameServices.h
+++ b/xbmc/games/GameServices.h
@@ -53,6 +53,17 @@ public:
   ControllerPtr GetDefaultMouse();
   ControllerVector GetControllers();
 
+  /*!
+   * \brief Translate a feature on a controller into its localized name
+   *
+   * \param controllerId The controller ID that the feature belongs to
+   * \param featureName The feature name
+   *
+   * \return The localized feature name, or empty if the controller or feature
+   *         doesn't exist
+   */
+  std::string TranslateFeature(const std::string& controllerId, const std::string& featureName);
+
   std::string GetSavestatesFolder() const;
 
   CGameSettings& GameSettings() { return *m_gameSettings; }

--- a/xbmc/games/controllers/ControllerManager.cpp
+++ b/xbmc/games/controllers/ControllerManager.cpp
@@ -13,6 +13,7 @@
 #include "addons/AddonEvents.h"
 #include "addons/AddonManager.h"
 #include "addons/addoninfo/AddonType.h"
+#include "games/controllers/input/PhysicalFeature.h"
 
 #include <mutex>
 
@@ -87,6 +88,25 @@ ControllerVector CControllerManager::GetControllers()
   }
 
   return controllers;
+}
+
+std::string CControllerManager::TranslateFeature(const std::string& controllerId,
+                                                 const std::string& featureName)
+{
+  ControllerPtr controller = GetController(controllerId);
+  if (controller)
+  {
+    const std::vector<CPhysicalFeature>& features = controller->Features();
+
+    auto it = std::find_if(features.begin(), features.end(),
+                           [&featureName](const CPhysicalFeature& feature)
+                           { return feature.Name() == featureName; });
+
+    if (it != features.end())
+      return it->Label();
+  }
+
+  return "";
 }
 
 void CControllerManager::OnEvent(const ADDON::AddonEvent& event)

--- a/xbmc/games/controllers/ControllerManager.h
+++ b/xbmc/games/controllers/ControllerManager.h
@@ -75,6 +75,17 @@ public:
    */
   ControllerVector GetControllers();
 
+  /*!
+   * \brief Translate a feature on a controller into its localized name
+   *
+   * \param controllerId The controller ID that the feature belongs to
+   * \param featureName The feature name
+   *
+   * \return The localized feature name, or empty if the controller or feature
+   *         doesn't exist
+   */
+  std::string TranslateFeature(const std::string& controllerId, const std::string& featureName);
+
 private:
   // Add-on event handler
   void OnEvent(const ADDON::AddonEvent& event);

--- a/xbmc/games/controllers/ControllerTypes.h
+++ b/xbmc/games/controllers/ControllerTypes.h
@@ -16,11 +16,23 @@ namespace KODI
 namespace GAME
 {
 class CController;
+
+/*!
+ * \ingroup games
+ *
+ * \brief Smart pointer to a game controller (\ref CController)
+ */
 using ControllerPtr = std::shared_ptr<CController>;
+
+/*!
+ * \ingroup games
+ *
+ * \brief Vector of smart pointers to a game controller (\ref CController)
+ */
 using ControllerVector = std::vector<ControllerPtr>;
 
 /*!
- * \ingroup game
+ * \ingroup games
  *
  * \brief Type of input provided by a hardware or controller port
  */

--- a/xbmc/games/dialogs/osd/DialogGameOSDHelp.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameOSDHelp.cpp
@@ -17,6 +17,12 @@
 using namespace KODI;
 using namespace GAME;
 
+namespace
+{
+constexpr char HELP_COMBO[] =
+    "[B]$FEATURE[select,game.controller.snes] + $FEATURE[x,game.controller.default][/B]";
+}
+
 const int CDialogGameOSDHelp::CONTROL_ID_HELP_TEXT = 1101;
 
 CDialogGameOSDHelp::CDialogGameOSDHelp(CDialogGameOSD& dialog) : m_dialog(dialog)
@@ -26,9 +32,8 @@ CDialogGameOSDHelp::CDialogGameOSDHelp(CDialogGameOSD& dialog) : m_dialog(dialog
 void CDialogGameOSDHelp::OnInitWindow()
 {
   // Set help text
-  //! @todo Define Select + X combo elsewhere
   // "Press {0:s} to open the menu."
-  std::string helpText = StringUtils::Format(g_localizeStrings.Get(35235), "Select + X");
+  std::string helpText = StringUtils::Format(g_localizeStrings.Get(35235), HELP_COMBO);
 
   CGUIMessage msg(GUI_MSG_LABEL_SET, WINDOW_DIALOG_GAME_OSD, CONTROL_ID_HELP_TEXT);
   msg.SetLabel(helpText);

--- a/xbmc/guilib/guiinfo/GUIInfoLabel.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabel.h
@@ -92,6 +92,16 @@ public:
    */
   static std::string ReplaceAddonStrings(std::string &&label);
 
+  /*!
+   * \brief Replaces instances of $FEATURE[feature name, controller ID] with
+   *        the appropriate localized controller string
+   *
+   * \param label The text to replace
+   *
+   * \return text with any controller strings filled in
+   */
+  static std::string ReplaceControllerStrings(std::string&& label);
+
   typedef std::function<std::string(const std::string&)> StringReplacerFunc;
 
   /*!


### PR DESCRIPTION
## Description

This PR implements a feature I never finished, the ability to translate button combos using the existing controller add-on translations instead of hard-coding the combos in the skin/core. (button names/translations are defined in [layout.xml](https://github.com/kodi-game/controller-topology-project/blob/master/addons/game.controller.default/resources/layout.xml))

As you can see in the diff, this adds a new info label replacer named `$FEATURE[]` (see documentation). Before, you might have:

```xml
<label>Select + Right Stick</label>
```

Now, this would be:

```xml
<label>$FEATURE[select,game.controller.snes] + $FEATURE[rightstick,game.controller.default]</label>
```

## Motivation and context

Less strings to translate, less hard-coding.

## How has this been tested?

Tested against latest master on my retroplayer dev branch.

## What is the effect on users?

* None

## Screenshots (if appropriate):

![screenshot00002](https://github.com/xbmc/xbmc/assets/531482/cbaff198-973b-49d6-802f-0fa15cdeb00a)

![screenshot00003](https://github.com/xbmc/xbmc/assets/531482/bf4be94d-07b0-4a47-bd77-d9ff1bbcb835)

![screenshot00004](https://github.com/xbmc/xbmc/assets/531482/d2fb7b6d-847a-4b85-b26b-fa129dd2882c)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
