### PR TITLE
[Windows] address recommendations of VS code analysis tools for WinMain

### DIFF
--- a/xbmc/platform/win32/WinMain.cpp
+++ b/xbmc/platform/win32/WinMain.cpp
@@ -62,13 +62,8 @@ static void LogError(const wchar_t* format, Args&&... args)
   wprintf(buf.get());
 }
 
-//-----------------------------------------------------------------------------
-// Name: WinMain()
-// Desc: The application's entry point
-//-----------------------------------------------------------------------------
-_Use_decl_annotations_ INT WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, INT)
+static std::shared_ptr<CAppParams> ParseCommandLine()
 {
-  // parse command line parameters
   int argc = 0;
   LPWSTR* argvW = CommandLineToArgvW(GetCommandLineW(), &argc);
   char** argv = new char*[argc];
@@ -86,7 +81,21 @@ _Use_decl_annotations_ INT WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, INT)
   CAppParamParser appParamParser;
   appParamParser.Parse(argv, argc);
 
-  const auto params = appParamParser.GetAppParams();
+  for (int i = 0; i < argc; ++i)
+    delete[] argv[i];
+  delete[] argv;
+
+  return appParamParser.GetAppParams();
+}
+
+//-----------------------------------------------------------------------------
+// Name: WinMain()
+// Desc: The application's entry point
+//-----------------------------------------------------------------------------
+_Use_decl_annotations_ INT WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, INT)
+{
+  // parse command line parameters
+  const auto params = ParseCommandLine();
 
   // this fixes crash if OPENSSL_CONF is set to existed openssl.cfg
   // need to set it as soon as possible
@@ -157,10 +166,6 @@ _Use_decl_annotations_ INT WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, INT)
   int status = XBMC_Run(true);
 
   CAppEnvironment::TearDown();
-
-  for (int i = 0; i < argc; ++i)
-    delete[] argv[i];
-  delete[] argv;
 
   // clear previously set timer resolution
   timeEndPeriod(1);

--- a/xbmc/platform/win32/WinMain.cpp
+++ b/xbmc/platform/win32/WinMain.cpp
@@ -112,7 +112,7 @@ _Use_decl_annotations_ INT WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, INT)
   using KODI::PLATFORM::WINDOWS::ToW;
   std::string appName = CCompileInfo::GetAppName();
   HANDLE appRunningMutex = CreateMutex(nullptr, FALSE, ToW(appName + " Media Center").c_str());
-  if (GetLastError() == ERROR_ALREADY_EXISTS)
+  if (appRunningMutex != nullptr && GetLastError() == ERROR_ALREADY_EXISTS)
   {
     auto appNameW = ToW(appName);
     HWND hwnd = FindWindow(appNameW.c_str(), appNameW.c_str());
@@ -122,7 +122,7 @@ _Use_decl_annotations_ INT WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, INT)
       ShowWindow(hwnd, SW_RESTORE);
       SetForegroundWindow(hwnd);
     }
-    ReleaseMutex(appRunningMutex);
+    CloseHandle(appRunningMutex);
     return 0;
   }
 
@@ -167,7 +167,8 @@ _Use_decl_annotations_ INT WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, INT)
 
   WSACleanup();
   CoUninitialize();
-  ReleaseMutex(appRunningMutex);
+  if (appRunningMutex)
+    CloseHandle(appRunningMutex);
 
   return status;
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Code analysis issues for WinMain:
```
WinMain.cpp(40): warning C28251: Inconsistent annotation for 'WinMain': this instance has no annotations. See c:\program files (x86)\windows kits\10\include\10.0.22621.0\um\winbase.h(1037). 
WinMain.cpp(102): warning C6031: Return value ignored: 'CoInitializeEx'.
WinMain.cpp(106): warning C6031: Return value ignored: 'WSAStartup'.
WinMain.cpp(132): warning C6387: 'appRunningMutex' could be '0'.
```
The errors are raised before logging facilities are initialized. Changing start order would be a big multiplatform undertaking, so simply output to debugger if attached, and to a console/cmd.exe that started Kodi.

Adding own console for a cleaner output is a lot more work for situations that will almost never happen. For those rare cases we'll be able to ask the user to start kodi from cmd.exe and to get the exact message and error code.
There are convenient Win API methods for debug mode but they are commented out in release mode so useless here.

Return code values: I didn't find a place where Kodi defines the possible application return codes, so started at -1 and went downwards. It may conflict with other values in use.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Low priority code issues, still worth taking care of. The annotations are annoying with no impact.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Artificially raised the errors in code, under debugger and when started from cmd.exe

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
More logging for very rare cases of Kodi not getting to the point of starting the core.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
