### PR TITLE
[videoversion] Add option to treat videos with same title but differe…

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23922,6 +23922,18 @@ msgctxt "#40207"
 msgid "When enabled, video with multiple versions will be shown as folder in library, this folder can then be opened to display the individual video versions. When disabled, a video version dialog will be opened for the video."
 msgstr ""
 
+#. Ignore different video years settting
+#: system/settings/settings.xml
+msgctxt "#40208"
+msgid "Ignore different video years on scan"
+msgstr ""
+
+#. Help for Ignore different video years settting
+#: system/settings/settings.xml
+msgctxt "#40209"
+msgid "Select scanner action for videos with the same title but different years.[CR][Enabled] Add videos with same title but different years to library seperately without confirmation.[CR][Disabled] Prompt for converting videos with same title but different years into additional versions of the original."
+msgstr ""
+
 # Video versions
 
 #. Name of a video version, like "Director's Cut"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -887,6 +887,14 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
+        <setting id="videolibrary.ignorevideoyears" type="boolean" label="40208" help="40209">
+          <level>1</level>
+          <default>false</default>
+          <dependencies>
+            <dependency type="enable" setting="videolibrary.ignorevideoversions" operator="is">false</dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
         <setting id="videolibrary.ignorevideoextras" type="boolean" label="40204" help="40205">
           <level>1</level>
           <default>false</default>

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -98,6 +98,8 @@ public:
       "videolibrary.musicvideosallperformers";
   static constexpr auto SETTING_VIDEOLIBRARY_IGNOREVIDEOVERSIONS =
       "videolibrary.ignorevideoversions";
+  static constexpr auto SETTING_VIDEOLIBRARY_IGNOREVIDEOYEARS =
+      "videolibrary.ignorevideoyears";
   static constexpr auto SETTING_VIDEOLIBRARY_IGNOREVIDEOEXTRAS = "videolibrary.ignorevideoextras";
   static constexpr auto SETTING_VIDEOLIBRARY_SHOWVIDEOVERSIONSASFOLDER =
       "videolibrary.showvideoversionsasfolder";

--- a/xbmc/video/dialogs/GUIDialogVideoVersion.h
+++ b/xbmc/video/dialogs/GUIDialogVideoVersion.h
@@ -42,6 +42,10 @@ public:
 
   static int ManageVideoVersionContextMenu(const std::shared_ptr<CFileItem>& version);
 
+  static void GetMovieNameAndYear(const CFileItem& movie,
+                                  std::string& movieName,
+                                  std::string& movieYear);
+
 protected:
   void OnInitWindow() override;
 


### PR DESCRIPTION
…nt years as seperate videos and not attempt to version them.

## Description
Thanks for the video version options. It's very useful.

This addition - if you're happy with it - adds an options to allow videos with same title but different year (taken from the path) to be considered seperate and not versioned. Videos with the same title and year will be versioned in the normal way.

## Motivation and context

I have two versions of (for example) Red Dawn - 1984 and 2012.
When library update is run with versioning enabled it asks me if I want one to be a version of the other.
I would prefer that movies with different years (ie. the 2012 version isn't a different cut of the 1984 version - it's a different film) be left alone.

## How has this been tested?

Windows x64 on local test library

## What is the effect on users?

Ability to automatically not version movies with same title but different year.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
