### PR TITLE
[Estuary] Add media flags for music

### DIFF
--- a/addons/skin.estuary/xml/DialogMusicInfo.xml
+++ b/addons/skin.estuary/xml/DialogMusicInfo.xml
@@ -527,6 +527,13 @@
 				</include>
 			</control>
 		</control>
+		<control type="group">
+			<centerleft>50%</centerleft>
+			<width>1920</width>
+			<bottom>0</bottom>
+			<height>70</height>
+			<include>MediaFlags</include>
+		</control>
 		<include condition="Skin.HasSetting(touchmode)">TouchBackButton</include>
 	</controls>
 </window>

--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -355,6 +355,7 @@
 		<param name="resolution_var">$VAR[ResolutionFlagVar]</param>
 		<definition>
 			<control type="grouplist">
+				<visible>Window.IsActive(Home) | Window.IsActive(10025)</visible>
 				<orientation>horizontal</orientation>
 				<right>20</right>
 				<top>0</top>
@@ -418,6 +419,112 @@
 					<param name="texture" value="$INFO[$PARAM[infolabel_prefix]ListItem.AudioChannels,flags/audiochannel/,.png]" />
 					<param name="visible" value="!String.IsEmpty($PARAM[infolabel_prefix]ListItem.AudioChannels)" />
 				</include>
+			</control>
+			<control type="grouplist">
+				<visible>Container.Content(albums) | Window.IsActive(10502)</visible>
+				<orientation>horizontal</orientation>
+				<right>20</right>
+				<top>0</top>
+				<height>70</height>
+				<align>right</align>
+				<itemgap>10</itemgap>
+				<width>1900</width>
+				<usecontrolcoords>true</usecontrolcoords>
+				<control type="group">
+					<width>115</width>
+					<visible>!String.IsEmpty($PARAM[infolabel_prefix]ListItem.Duration)</visible>
+					<visible>Container.Content(albums) | Window.IsActive(DialogMusicInfo.xml) + Container.Content(songs)</visible>
+					<control type="label">
+						<width>110</width>
+						<height>60</height>
+						<align>center</align>
+						<aligny>center</aligny>
+						<label>$INFO[$PARAM[infolabel_prefix]ListItem.Duration]</label>
+						<font>font_flag</font>
+					</control>
+					<include content="MediaFlag">
+						<param name="texture" value="flags/flag.png" />
+					</include>
+				</control>
+				<control type="group">
+					<width>115</width>
+					<visible>!String.IsEmpty($PARAM[infolabel_prefix]ListItem.FileExtension)</visible>
+					<control type="label">
+						<width>110</width>
+						<height>60</height>
+						<align>center</align>
+						<aligny>center</aligny>
+						<label>$INFO[$PARAM[infolabel_prefix]ListItem.FileExtension]</label>
+						<font>font_flag</font>
+					</control>
+					<include content="MediaFlag">
+						<param name="texture" value="flags/flag.png" />
+					</include>
+				</control>
+				<include content="MediaFlag">
+					<param name="texture" value="$INFO[$PARAM[infolabel_prefix]ListItem.MusicChannels,flags/audiochannel/,.png]" />
+					<param name="visible" value="!String.IsEmpty($PARAM[infolabel_prefix]ListItem.MusicChannels)" />
+				</include>
+				<control type="group">
+					<visible>!String.IsEmpty(ListItem.Samplerate)</visible>
+					<width>115</width>
+					<control type="label">
+						<width>110</width>
+						<height>60</height>
+						<align>center</align>
+						<aligny>center</aligny>
+						<label>$INFO[ListItem.Samplerate, ,kHz]</label>
+						<font>font_flag</font>
+					</control>
+					<include content="MediaFlag">
+						<param name="texture" value="flags/flag.png" />
+					</include>
+				</control>
+				<control type="group">
+					<visible>!String.IsEmpty(ListItem.BitRate)</visible>
+					<width>115</width>
+					<control type="label">
+						<width>110</width>
+						<height>60</height>
+						<align>center</align>
+						<aligny>center</aligny>
+						<label>$INFO[ListItem.BitRate, ,kbps]</label>
+						<font>font_flag</font>
+					</control>
+					<include content="MediaFlag">
+						<param name="texture" value="flags/flag.png" />
+					</include>
+				</control>
+				<control type="group">
+					<visible>!String.IsEmpty(ListItem.MusicBitsPerSample)</visible>
+					<width>115</width>
+					<control type="label">
+						<width>110</width>
+						<height>60</height>
+						<align>center</align>
+						<aligny>center</aligny>
+						<label>$INFO[ListItem.MusicBitsPerSample, ,bit]</label>
+						<font>font_flag</font>
+					</control>
+					<include content="MediaFlag">
+						<param name="texture" value="flags/flag.png" />
+					</include>
+				</control>
+				<control type="group">
+					<visible>!String.IsEmpty(ListItem.BMP)</visible>
+					<width>115</width>
+					<control type="label">
+						<width>110</width>
+						<height>60</height>
+						<align>center</align>
+						<aligny>center</aligny>
+						<label>$INFO[ListItem.BMP, ,bpm]</label>
+						<font>font_flag</font>
+					</control>
+					<include content="MediaFlag">
+						<param name="texture" value="flags/flag.png" />
+					</include>
+				</control>
 			</control>
 		</definition>
 	</include>

--- a/addons/skin.estuary/xml/MyMusicNav.xml
+++ b/addons/skin.estuary/xml/MyMusicNav.xml
@@ -27,6 +27,14 @@
 			<include content="BottomBar">
 				<param name="info_visible" value="true" />
 			</include>
+			<control type="group">
+				<depth>DepthBars</depth>
+				<bottom>0</bottom>
+				<height>70</height>
+				<animation effect="fade" start="0" end="100" time="300" delay="300">WindowOpen</animation>
+				<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
+				<include condition="!Skin.HasSetting(hide_mediaflags)">MediaFlags</include>
+			</control>
 			<include>MediaMenuMouseOverlay</include>
 			<control type="group">
 				<include>MediaMenuCommon</include>


### PR DESCRIPTION
## Description
Add media flags for music

## Motivation and context
Currently we do not provide media flags for music, so this further aligns music with the video sections.

## How has this been tested?
This is code I've been using locally for some time.

## What is the effect on users?
Consistency between music and video sections.

## Screenshots (if appropriate):

**Duration now shown for albums on Home and Album node**

![image](https://github.com/xbmc/xbmc/assets/5781142/34c9a656-04c5-40eb-add0-0b9bad09d1c7)
![image](https://github.com/xbmc/xbmc/assets/5781142/8b9b146f-2662-41ab-8a1a-eb4623b65c63)

**Media flags shown for songs**

![image](https://github.com/xbmc/xbmc/assets/5781142/2f3b150e-beea-44d4-afb6-f688e1032aec)
![image](https://github.com/xbmc/xbmc/assets/5781142/ace07386-8692-4c35-8cf4-89567a6af449)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
