### PR TITLE
[VideoVersion] Optimize performance especially when is used external/shared video DB

### DIFF
--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -59,16 +59,17 @@ namespace VIDEO
 
 enum VideoDbDetails
 {
-  VideoDbDetailsNone     = 0x00,
-  VideoDbDetailsRating   = 0x01,
-  VideoDbDetailsTag      = 0x02,
+  VideoDbDetailsNone = 0x00,
+  VideoDbDetailsRating = 0x01,
+  VideoDbDetailsTag = 0x02,
   VideoDbDetailsShowLink = 0x04,
-  VideoDbDetailsStream   = 0x08,
-  VideoDbDetailsCast     = 0x10,
+  VideoDbDetailsStream = 0x08,
+  VideoDbDetailsCast = 0x10,
   VideoDbDetailsBookmark = 0x20,
   VideoDbDetailsUniqueID = 0x40,
-  VideoDbDetailsAll      = 0xFF
-} ;
+  VideoDbDetailsVideoVersion = 0x80,
+  VideoDbDetailsAll = 0xFF
+};
 
 // these defines are based on how many columns we have and which column certain data is going to be in
 // when we do GetDetailsForMovie()


### PR DESCRIPTION
## Description
[VideoVersion] Optimize performance especially when is used external/shared video DB

## Motivation and context
Fixes https://github.com/xbmc/xbmc/issues/24169

Retrieve entire `videoversion` table only takes 40 ms similar time that individual SQL query to check video versions in one movie...

Then saves 15~20 ms * num_of_movies in DB.

`HasVideoVersions()` is still used when only is need this info for one movie (or less of 15 movies).


## How has this been tested?
Runtime Windows x64 and Shield

## What is the effect on users?
Restores video DB performance same as before of video versions feature.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
