### PR TITLE
[Android] Ignore obsolete DOVI profiles from codec selection

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -540,25 +540,18 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
             switch (m_hints.dovi.dv_profile)
             {
               case 0:
-                profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvavPer;
-                break;
               case 1:
-                profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvavPen;
-                break;
               case 2:
-                profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheDer;
-                break;
               case 3:
-                profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheDen;
+              case 6:
+                // obsolete profiles that are not supported in current applications.
+                // 0 is ignored in case the AVDOVIDecoderConfigurationRecord hint is unset.
                 break;
               case 4:
                 profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheDtr;
                 break;
               case 5:
                 profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheStn;
-                break;
-              case 6:
-                profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheDth;
                 break;
               case 7:
                 // set profile 8 when converting


### PR DESCRIPTION
## Description
When the `AVDOVIDecoderConfigurationRecord` is not valid, the fields are zeroed and profile is set to 1, which is incorrect. It should default to profile 0.

Fixes #24171.

## Motivation and context
Fixes Dolby Vision playback when file hints are not provided by FFmpeg demuxer.
In Dolby's specifications it also says `Profiles 0–3 and 6 are not supported for new applications.`

## How has this been tested?
Not tested.

## What is the effect on users?
Corrects playback of videos through streaming addons.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
