### PR TITLE
[Estuary] Adjust plot height in video fullscreen info

### DIFF
--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -409,10 +409,18 @@
 				<orientation>vertical</orientation>
 				<itemgap>10</itemgap>
 				<control type="textbox">
+					<height>294</height>
+					<label fallback="10005">$INFO[VideoPlayer.Tagline,[B],[/B][CR]]$INFO[VideoPlayer.Plot]</label>
+					<align>left</align>
+					<autoscroll delay="5000" repeat="7500" time="5000"></autoscroll>
+					<visible>Integer.IsLessOrEqual(Playlist.Length(video),1)</visible>
+				</control>
+				<control type="textbox">
 					<height>250</height>
 					<label fallback="10005">$INFO[VideoPlayer.Tagline,[B],[/B][CR]]$INFO[VideoPlayer.Plot]</label>
 					<align>left</align>
 					<autoscroll delay="5000" repeat="7500" time="5000"></autoscroll>
+					<visible>Integer.IsGreater(Playlist.Length(video),1)</visible>
 				</control>
 				<control type="label">
 					<height>50</height>

--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -413,19 +413,19 @@
 					<label fallback="10005">$INFO[VideoPlayer.Tagline,[B],[/B][CR]]$INFO[VideoPlayer.Plot]</label>
 					<align>left</align>
 					<autoscroll delay="5000" repeat="7500" time="5000"></autoscroll>
-					<visible>Integer.IsLessOrEqual(Playlist.Length(video),1)</visible>
+					<visible>Integer.IsGreaterOrEqual(Playlist.Position(video), Playlist.Length(video))</visible>
 				</control>
 				<control type="textbox">
 					<height>250</height>
 					<label fallback="10005">$INFO[VideoPlayer.Tagline,[B],[/B][CR]]$INFO[VideoPlayer.Plot]</label>
 					<align>left</align>
 					<autoscroll delay="5000" repeat="7500" time="5000"></autoscroll>
-					<visible>Integer.IsGreater(Playlist.Length(video),1)</visible>
+					<visible>Integer.IsLess(Playlist.Position(video), Playlist.Length(video))</visible>
 				</control>
 				<control type="label">
 					<height>50</height>
 					<label>$VAR[OSDNextLabelVar]</label>
-					<visible>Integer.IsGreater(Playlist.Length(video),1)</visible>
+					<visible>Integer.IsLess(Playlist.Position(video), Playlist.Length(video))</visible>
 				</control>
 			</control>
 		</control>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Expand the plot textbox when the next playlist item label is not needed (items played one at a time, or last item of playlist)

This adds one line for the plot. Adding another to completely fill the space would require more significant layout changes.

Q: I don't know much about skinning. Is it worth reducing the number of visibility conditions, and how? Or is there a way to make the existing textbox's height dynamic, and avoid the extra textbox?

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The space reserved for the next playlist item title under the plot in the info screen is blank when playing items one by one, or when the playlist reached the last item of the playlist.

It looks like there is unused space, and causes some long plots to scroll even when that shouldn't be needed.
For example:
![image](https://github.com/xbmc/xbmc/assets/489377/4273543f-9994-462e-8603-1a066d26b3f3)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Resolutions 640x480 to 4k. With long plots, with playlist and without, at different positions in the playlist.

Tested with local/network files, no PVR or alternate sources available.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Better use of space in video fullscreen info for long plots.

## Screenshots (if appropriate):
Long plot, single played item or last item of a playlist > textbox with extra line:
![image](https://github.com/xbmc/xbmc/assets/489377/cb46abcc-5bad-4738-9e10-25b8fa0b9db8)

Long plot, item in middle of playlist with multiple items > no change:
![image](https://github.com/xbmc/xbmc/assets/489377/4cda796e-eeaa-4079-bdff-831170dc27c1)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
