### PR TITLE
[GUIWindowVideoBase] Library thumbnail not updated

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -224,7 +224,7 @@ bool CGUIWindowVideoBase::OnItemInfo(const CFileItem& fileItem)
   if (fileItem.m_bIsFolder && fileItem.IsVideoDb() &&
       fileItem.GetPath() != "videodb://movies/sets/" &&
       StringUtils::StartsWith(fileItem.GetPath(), "videodb://movies/sets/"))
-    return ShowInfo(std::make_shared<CFileItem>(fileItem), nullptr);
+    return ShowInfoAndRefresh(std::make_shared<CFileItem>(fileItem), nullptr);
 
   // Music video. Match visibility test of CMusicInfo::IsVisible
   if (fileItem.IsVideoDb() && fileItem.HasVideoInfoTag() &&
@@ -323,7 +323,7 @@ bool CGUIWindowVideoBase::OnItemInfo(const CFileItem& fileItem)
   if (fileItem.m_bIsFolder)
     item.SetProperty("set_folder_thumb", fileItem.GetPath());
 
-  return ShowInfo(std::make_shared<CFileItem>(item), scraper);
+  return ShowInfoAndRefresh(std::make_shared<CFileItem>(item), scraper);
 }
 
 // ShowInfo is called as follows:
@@ -486,14 +486,22 @@ bool CGUIWindowVideoBase::ShowInfo(const CFileItemPtr& item2, const ScraperPtr& 
     listNeedsUpdating = true;
   } while (needsRefresh);
 
-  if (listNeedsUpdating &&
-      IsActive()) // since we can be called from other windows (music, home) we need this check
+  return listNeedsUpdating;
+}
+
+bool CGUIWindowVideoBase::ShowInfoAndRefresh(const CFileItemPtr& item, const ScraperPtr& info)
+{
+  const int ret{ShowInfo(item, info)};
+
+  // Test IsActive() since we can be called from other windows (music, home) we need this check
+  if (ret && IsActive())
   {
-    int itemNumber = m_viewControl.GetSelectedItem();
+    const int itemNumber{m_viewControl.GetSelectedItem()};
     Refresh();
     m_viewControl.SetSelectedItem(itemNumber);
   }
-  return true;
+
+  return ret;
 }
 
 void CGUIWindowVideoBase::OnQueueItem(int iItem, bool first)

--- a/xbmc/video/windows/GUIWindowVideoBase.h
+++ b/xbmc/video/windows/GUIWindowVideoBase.h
@@ -105,7 +105,14 @@ protected:
   using CGUIMediaWindow::LoadPlayList;
   void LoadPlayList(const std::string& strPlayList, PLAYLIST::Id playlistId = PLAYLIST::TYPE_VIDEO);
 
-  bool ShowInfo(const CFileItemPtr& item, const ADDON::ScraperPtr& content);
+  /*!
+   \brief Lookup the information of an item and display an Info dialog
+   If item has changed then refresh the active underlying list
+   \param item the item to lookup
+   \param content
+   \return true: the information of the item was modified. false: no change.
+   */
+  bool ShowInfoAndRefresh(const CFileItemPtr& item, const ADDON::ScraperPtr& content);
 
   void OnSearch();
   void OnSearchItemFound(const CFileItem* pSelItem);
@@ -125,4 +132,13 @@ protected:
 
   CVideoThumbLoader m_thumbLoader;
   bool m_stackingAvailable;
+
+private:
+  /*!
+   \brief Lookup the information of an item and display an Info dialog
+   \param item the item to lookup
+   \param content
+   \return true: the information of the item was modified. false: no change.
+   */
+  bool ShowInfo(const CFileItemPtr& item, const ADDON::ScraperPtr& content);
 };


### PR DESCRIPTION
## Description

As part of #24131 I found that the thumbnail in the library wasn't updated when art was changed in the video information dialog.

This is also true using the existing Choose Art button.

## Motivation and context

Before

Art Changed
![image](https://github.com/xbmc/xbmc/assets/99039295/377b24bd-5e9e-43d9-989e-9b548c81046a)
![image](https://github.com/xbmc/xbmc/assets/99039295/967735fd-e7b7-415a-97ba-0a820e711185)

... but not reflected in library upon return.
![image](https://github.com/xbmc/xbmc/assets/99039295/c21080d9-9bb2-441e-b0c4-88bafeaa11c7)

After - change is reflected
![image](https://github.com/xbmc/xbmc/assets/99039295/68a842c7-4bc6-4b17-b588-83b87bcd4531)

## How has this been tested?

Windows 11 x64

## What is the effect on users?

Art thumbnail correctly shown on library screen (without having to exit library and re-enter)

## Screenshots (if appropriate):

As above.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
