### PR TITLE
[VideoDatabase] Fix unnecessary query is always made to obtain cast

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4290,7 +4290,8 @@ CVideoInfoTag CVideoDatabase::GetDetailsForMovie(const dbiplus::sql_record* cons
 
   if (getDetails)
   {
-    GetCast(details.m_iDbId, MediaTypeMovie, details.m_cast);
+    if (getDetails & VideoDbDetailsCast)
+      GetCast(details.m_iDbId, MediaTypeMovie, details.m_cast);
 
     if (getDetails & VideoDbDetailsTag)
       GetTags(details.m_iDbId, MediaTypeMovie, details.m_tags);


### PR DESCRIPTION
## Description
[VideoDatabase] Fix unnecessary query is always made to obtain cast.

Extra cast query only should be made when `VideoDbDetailsCast` mask is set.

## Motivation and context
Found while working on https://github.com/xbmc/xbmc/pull/24170

Avoids extra DB query to obtain cast when is not used e.g. in home screen populating recently added movies list. Cast only is necessary when explicit `VideoDbDetailsCast` mask is set of when mask is 0xFF (`VideoDbDetailsAll`).


## How has this been tested?
Runtime Windows x64

## What is the effect on users?
Speed up home screen / movies lists with less database queries.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
