### PR TITLE
Improve Episode Title Recognition.

### DIFF
--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -120,8 +120,8 @@ static constexpr unsigned int CLIP_PLAYLIST_OFFSET =
     2; // First two entries in clip array are clip number and duration. Remaining entries are playlist(s)
 
 void CBlurayDirectory::GetPlaylistInfo(std::vector<std::vector<unsigned int>>& clips,
-    std::vector<std::vector<unsigned int>>& playlists,
-    std::map<unsigned int, std::string>& playlist_langs)
+                                       std::vector<std::vector<unsigned int>>& playlists,
+                                       std::map<unsigned int, std::string>& playlist_langs)
 {
   // Get all titles on disc
   // Sort by playlist for grouping later
@@ -689,10 +689,11 @@ void CBlurayDirectory::GetEpisodeTitles(const CFileItem& episode,
                               episode.GetVideoInfoTag()->m_strTitle);
     newItem->m_strTitle = buf;
     newItem->SetLabel(buf);
-    newItem->SetLabel2(StringUtils::Format(
-        g_localizeStrings.Get(25005) /* Title: {0:d} */ + " - {1:s}: {2:s}\n\r{3:s}: {4:s}", playlist,
-        g_localizeStrings.Get(180) /* Duration */, StringUtils::SecondsToTimeString(duration),
-        g_localizeStrings.Get(24026) /* Languages */, langs));
+    newItem->SetLabel2(StringUtils::Format(g_localizeStrings.Get(25005) /* Title: {0:d} */ +
+                                               " - {1:s}: {2:s}\n\r{3:s}: {4:s}",
+                                           playlist, g_localizeStrings.Get(180) /* Duration */,
+                                           StringUtils::SecondsToTimeString(duration),
+                                           g_localizeStrings.Get(24026) /* Languages */, langs));
     newItem->m_dwSize = 0;
     newItem->SetArt("icon", "DefaultVideo.png");
     items.Add(newItem);

--- a/xbmc/filesystem/BlurayDirectory.h
+++ b/xbmc/filesystem/BlurayDirectory.h
@@ -10,6 +10,7 @@
 
 #include "IDirectory.h"
 #include "URL.h"
+#include "video/VideoInfoTag.h"
 
 #include <memory>
 
@@ -28,6 +29,10 @@ public:
   CBlurayDirectory() = default;
   ~CBlurayDirectory() override;
   bool GetDirectory(const CURL& url, CFileItemList &items) override;
+  bool GetEpisodeDirectory(const CURL& url,
+                           const CFileItem& episode,
+                           CFileItemList& items,
+                           const std::vector<CVideoInfoTag>& episodesOnDisc);
 
   bool InitializeBluray(const std::string &root);
   std::string GetBlurayTitle();
@@ -42,8 +47,15 @@ private:
 
   void         Dispose();
   std::string  GetDiscInfoString(DiscInfo info);
-  void         GetRoot  (CFileItemList &items);
+  void GetRoot(CFileItemList& items);
+  void GetRoot(CFileItemList& items,
+               const CFileItem& episode,
+               const std::vector<CVideoInfoTag>& episodesOnDisc);
+  void AddRootOptions(CFileItemList& items) const;
   void         GetTitles(bool main, CFileItemList &items);
+  void GetEpisodeTitles(const CFileItem& episode,
+                        CFileItemList& items,
+                        std::vector<CVideoInfoTag> episodesOnDisc);
   std::vector<BLURAY_TITLE_INFO*> GetUserPlaylists();
   std::shared_ptr<CFileItem> GetTitle(const BLURAY_TITLE_INFO* title, const std::string& label);
   CURL         GetUnderlyingCURL(const CURL& url);

--- a/xbmc/filesystem/BlurayDirectory.h
+++ b/xbmc/filesystem/BlurayDirectory.h
@@ -53,9 +53,15 @@ private:
                const std::vector<CVideoInfoTag>& episodesOnDisc);
   void AddRootOptions(CFileItemList& items) const;
   void         GetTitles(bool main, CFileItemList &items);
+  void GetPlaylistInfo(std::vector<std::vector<unsigned int>>& clips,
+                       std::vector<std::vector<unsigned int>>& playlists,
+                       std::map<unsigned int, std::string>& playlist_langs);
   void GetEpisodeTitles(const CFileItem& episode,
                         CFileItemList& items,
-                        std::vector<CVideoInfoTag> episodesOnDisc);
+                        std::vector<CVideoInfoTag> episodesOnDisc,
+                        const std::vector<std::vector<unsigned int>>& clips,
+                        const std::vector<std::vector<unsigned int>>& playlists,
+                        std::map<unsigned int, std::string>& playlist_langs);
   std::vector<BLURAY_TITLE_INFO*> GetUserPlaylists();
   std::shared_ptr<CFileItem> GetTitle(const BLURAY_TITLE_INFO* title, const std::string& label);
   CURL         GetUnderlyingCURL(const CURL& url);


### PR DESCRIPTION
## Description

See forum post https://forum.kodi.tv/showthread.php?tid=375249

I've been looking at how episodes are played when they are in an ISO (and I assume BDMV folder as well).

Currently you are asked to select from a list of titles - these are presented in no particular order and (by default) only show those with length 70%+ of the longest.

So, for example, on The Last of Us (UHD Disc 1) - if I try and play episode 2 (disc 1 contains episodes 1 and 2), I get the following:
<img width="452" alt="before" src="https://github.com/xbmc/xbmc/assets/99039295/6db5e22f-c431-4fe5-b4a3-426b98c6be20">

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

This demonstrates a number of issues:
1) No clear idea what titles 801 and 851 contain - they actually are both episode 1 (despite us asking to play episode 2)
2) No idea what languages are associated with each title (801 = episode 1 european languages, 851 = episode 1 japanese)

I've updated the code - so now when I select episode 2 I get the following:
<img width="452" alt="after" src="https://github.com/xbmc/xbmc/assets/99039295/96deaa5f-9208-4bc4-a831-46f84cc496c5">

This is also partly linked with #24173 - as the streamdetails for each episode have not been recorded correctly leading to the suggestion of incorrect episode lengths.

Methodology

```
  // At this stage we have four ways of trying to determine the correct playlist for an episode
  //
  // 1) Using a 'Play All' playlist
  //    - Caveat: there may not be one
  // 
  // 2) Using the longest (non-'Play All') playlists that are consecutive
  //    - Caveat: assumes play-all detection has worked and playlists are consecutive (hopefully reasonable assumptions)
  //
  // 3) Playlists that are +/- 30sec of the episode length that is passed to us
  //    - Caveat: the episode length may be wrong - either from scraper/NFO or from bug in Kodi that overwrites episode streamdetails on same disc
  //
  // 4) Using position in a group of adjacent playlists (see below)
  //    - Cavet: won't work for single episode discs
  //
  // Order of preference:
  //
  // 1) Use 'Play All' playlist - take the nth clip and find a playlist that plays that clip
  // 
  // 2) Take the nth playlist of a consecutive run of longest playlists
  //
  // 3) Refine a group using relative position of playlist found on basis of length
  //    - this tries to account for episodes that have the wrong duration passed
  //    eg. if we have a disc with episodes 4,5,6 we would expect episode 5 to be the middle playlist of a group of 3 consecutive playlists (eg. 801, 802, 803)
  //
  // 4) Playlist based on episode length alone (assumes no groups found or 2) and 3) failed)
  //
  // 5) Look at groups found (ignoring length) and pick the relevant playlist - eg. the middle one for episode 5 using the exampe above
  //    - Only looks at playlists > MIN_EPISODE_LENGTH
```

## Motivation and context

Improve the rather unintuitive episode selection when episodes on bluray.

## How has this been tested?

Windows 11 x64

This will need much more testing with multiple discs - to refine episode selection logic, hence forum post.

## What is the effect on users?

More intuitve episode selection when on bluray.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
