### PR TITLE
[EDL] Migrate to tinyxml2

### DIFF
--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -17,7 +17,7 @@
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
-#include "utils/XBMCTinyXML.h"
+#include "utils/XBMCTinyXML2.h"
 #include "utils/log.h"
 
 #include "PlatformDefs.h"
@@ -482,22 +482,22 @@ bool CEdl::ReadBeyondTV(const std::string& strMovie)
   if (!CFile::Exists(beyondTVFilename))
     return false;
 
-  CXBMCTinyXML xmlDoc;
+  CXBMCTinyXML2 xmlDoc;
   if (!xmlDoc.LoadFile(beyondTVFilename))
   {
     CLog::Log(LOGERROR, "{} - Could not load Beyond TV file: {}. {}", __FUNCTION__,
-              CURL::GetRedacted(beyondTVFilename), xmlDoc.ErrorDesc());
+              CURL::GetRedacted(beyondTVFilename), xmlDoc.ErrorStr());
     return false;
   }
 
   if (xmlDoc.Error())
   {
     CLog::Log(LOGERROR, "{} - Could not parse Beyond TV file: {}. {}", __FUNCTION__,
-              CURL::GetRedacted(beyondTVFilename), xmlDoc.ErrorDesc());
+              CURL::GetRedacted(beyondTVFilename), xmlDoc.ErrorStr());
     return false;
   }
 
-  TiXmlElement *pRoot = xmlDoc.RootElement();
+  const tinyxml2::XMLElement* pRoot = xmlDoc.RootElement();
   if (!pRoot || strcmp(pRoot->Value(), "cutlist"))
   {
     CLog::Log(LOGERROR, "{} - Invalid Beyond TV file: {}. Expected root node to be <cutlist>",
@@ -506,11 +506,11 @@ bool CEdl::ReadBeyondTV(const std::string& strMovie)
   }
 
   bool bValid = true;
-  TiXmlElement *pRegion = pRoot->FirstChildElement("Region");
+  const tinyxml2::XMLElement* pRegion = pRoot->FirstChildElement("Region");
   while (bValid && pRegion)
   {
-    TiXmlElement *pStart = pRegion->FirstChildElement("start");
-    TiXmlElement *pEnd = pRegion->FirstChildElement("end");
+    const tinyxml2::XMLElement* pStart = pRegion->FirstChildElement("start");
+    const tinyxml2::XMLElement* pEnd = pRegion->FirstChildElement("end");
     if (pStart && pEnd && pStart->FirstChild() && pEnd->FirstChild())
     {
       /*

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -497,21 +497,21 @@ bool CEdl::ReadBeyondTV(const std::string& strMovie)
     return false;
   }
 
-  const tinyxml2::XMLElement* pRoot = xmlDoc.RootElement();
-  if (!pRoot || strcmp(pRoot->Value(), "cutlist"))
+  const tinyxml2::XMLElement* root = xmlDoc.RootElement();
+  if (!root || strcmp(root->Value(), "cutlist"))
   {
     CLog::Log(LOGERROR, "{} - Invalid Beyond TV file: {}. Expected root node to be <cutlist>",
               __FUNCTION__, CURL::GetRedacted(beyondTVFilename));
     return false;
   }
 
-  bool bValid = true;
-  const tinyxml2::XMLElement* pRegion = pRoot->FirstChildElement("Region");
-  while (bValid && pRegion)
+  bool valid = true;
+  const tinyxml2::XMLElement* region = root->FirstChildElement("Region");
+  while (valid && region)
   {
-    const tinyxml2::XMLElement* pStart = pRegion->FirstChildElement("start");
-    const tinyxml2::XMLElement* pEnd = pRegion->FirstChildElement("end");
-    if (pStart && pEnd && pStart->FirstChild() && pEnd->FirstChild())
+    const tinyxml2::XMLElement* start = region->FirstChildElement("start");
+    const tinyxml2::XMLElement* end = region->FirstChildElement("end");
+    if (start && end && start->FirstChild() && end->FirstChild())
     {
       /*
        * Need to divide the start and end times by a factor of 10,000 to get msec.
@@ -526,17 +526,17 @@ bool CEdl::ReadBeyondTV(const std::string& strMovie)
        * atof() returns 0 if there were any problems and will subsequently be rejected in AddEdit().
        */
       Edit edit;
-      edit.start = std::lround((std::atof(pStart->FirstChild()->Value()) / 10000));
-      edit.end = std::lround((std::atof(pEnd->FirstChild()->Value()) / 10000));
+      edit.start = std::lround((std::atof(start->FirstChild()->Value()) / 10000));
+      edit.end = std::lround((std::atof(end->FirstChild()->Value()) / 10000));
       edit.action = Action::COMM_BREAK;
-      bValid = AddEdit(edit);
+      valid = AddEdit(edit);
     }
     else
-      bValid = false;
+      valid = false;
 
-    pRegion = pRegion->NextSiblingElement("Region");
+    region = region->NextSiblingElement("Region");
   }
-  if (!bValid)
+  if (!valid)
   {
     CLog::Log(LOGERROR,
               "{} - Invalid Beyond TV file: {}. Clearing any valid commercial breaks found.",


### PR DESCRIPTION
## Description
Snapcast BeyondTV uses a XML format for EDL markers. Move the usage to tinyxml2.
While at it I've ditched the hungarian notation too (I won't be changing any other stuff).
We have unit tests for this so as long as they pass we are fine.
