### PR TITLE
AddonSettings: Correct order of destructor calls

### DIFF
--- a/xbmc/addons/settings/AddonSettings.h
+++ b/xbmc/addons/settings/AddonSettings.h
@@ -35,9 +35,9 @@ namespace ADDON
 class IAddon;
 class IAddonInstanceHandler;
 
-class CAddonSettings : public CSettingsBase,
+class CAddonSettings : public CSettingControlCreator,
                        public CSettingCreator,
-                       public CSettingControlCreator,
+                       public CSettingsBase,
                        public ISettingCallback
 {
 public:


### PR DESCRIPTION
## Description
In the original order the method of an already destructed base class was called.

Fixes #24175.

## Motivation and context
The problem is this crash:

<details>
<summary>stack trace</summary>

```
pure virtual method called
terminate called without an active exception

Thread 41 "LanguageInvoker" received signal SIGABRT, Aborted.
[Switching to Thread 0x7fff7effd6c0 (LWP 51962)]
__pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at pthread_kill.c:44
44            return INTERNAL_SYSCALL_ERROR_P (ret) ? INTERNAL_SYSCALL_ERRNO (ret) : 0;                                                                                                                                                                                       
(gdb) set pagination off
(gdb) bt
#0  __pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at pthread_kill.c:44
#1  0x00007ffff50ac8a3 in __pthread_kill_internal (signo=6, threadid=<optimized out>) at pthread_kill.c:78
#2  0x00007ffff505c668 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#3  0x00007ffff50444b8 in __GI_abort () at abort.c:79
#4  0x00007ffff529ca6f in __gnu_cxx::__verbose_terminate_handler() () at /usr/src/debug/gcc/gcc/libstdc++-v3/libsupc++/vterminate.cc:95
#5  0x00007ffff52b011c in __cxxabiv1::__terminate(void (*)()) (handler=<optimized out>) at /usr/src/debug/gcc/gcc/libstdc++-v3/libsupc++/eh_terminate.cc:48
#6  0x00007ffff52b0189 in std::terminate() () at /usr/src/debug/gcc/gcc/libstdc++-v3/libsupc++/eh_terminate.cc:58
#7  0x00007ffff52b0ec7 in __cxxabiv1::__cxa_pure_virtual() () at /usr/src/debug/gcc/gcc/libstdc++-v3/libsupc++/pure.cc:50
#8  0x0000555558c1d1b9 in CSettingsManager::CreateControl(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const (this=0x7fff70693b90, controlType="list")
    at xbmc/settings/lib/SettingsManager.cpp:994
#9  0x0000555558bf53c8 in CSetting::Copy(CSetting const&) (this=0x7fff7074a5c0, setting=...) at xbmc/settings/lib/Setting.cpp:332
#10 0x0000555558bfc91d in CSettingString::copy(CSettingString const&) (this=0x7fff7074a5c0, setting=...) at xbmc/settings/lib/Setting.cpp:1618
#11 0x0000555558bfafdd in CSettingString::CSettingString(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&) (this=0x7fff7074a5c0, id="kodion.mpd.stream.features.0", setting=...)
    at xbmc/settings/lib/Setting.cpp:1371
#12 0x0000555558c07d94 in std::_Construct<CSettingString, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&>(CSettingString*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&) (__p=0x7fff7074a5c0) at /usr/include/c++/13.2.1/bits/stl_construct.h:119
#13 0x0000555558c07479 in std::allocator_traits<std::allocator<void> >::construct<CSettingString, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&>(std::allocator<void>&, CSettingString*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&) (__p=0x7fff7074a5c0) at /usr/include/c++/13.2.1/bits/alloc_traits.h:660
#14 std::_Sp_counted_ptr_inplace<CSettingString, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&>(std::allocator<void>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&) (this=0x7fff7074a5b0, __a=...) at /usr/include/c++/13.2.1/bits/shared_ptr_base.h:604
#15 0x0000555558c06a14 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<CSettingString, std::allocator<void>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&>(CSettingString*&, std::_Sp_alloc_shared_tag<std::allocator<void> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&) (this=0x7fff7effb438, __p=@0x7fff7effb430: 0x0, __a=...) at /usr/include/c++/13.2.1/bits/shared_ptr_base.h:971
#16 0x0000555558c0333c in std::__shared_ptr<CSettingString, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<void>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&>(std::_Sp_alloc_shared_tag<std::allocator<void> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&) (this=0x7fff7effb430, __tag=...) at /usr/include/c++/13.2.1/bits/shared_ptr_base.h:1712
#17 0x0000555558c016d3 in std::shared_ptr<CSettingString>::shared_ptr<std::allocator<void>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&>(std::_Sp_alloc_shared_tag<std::allocator<void> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&) (this=0x7fff7effb430, __tag=...) at /usr/include/c++/13.2.1/bits/shared_ptr.h:464
#18 0x0000555558bff2d3 in std::make_shared<CSettingString, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CSettingString const&) () at /usr/include/c++/13.2.1/bits/shared_ptr.h:1010
#19 0x0000555558bfb2ee in CSettingString::Clone(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const (this=0x7fff706a39c0, id="kodion.mpd.stream.features.0")
    at xbmc/settings/lib/Setting.cpp:1388
#20 0x0000555558bf6697 in CSettingList::Reset() (this=0x7fff706a2960) at xbmc/settings/lib/Setting.cpp:510
#21 0x0000555558c177d0 in CSettingsManager::Unload() (this=0x7fff70693b90) at xbmc/settings/lib/SettingsManager.cpp:210
#22 0x0000555558c178aa in CSettingsManager::Clear() (this=0x7fff70693b90) at xbmc/settings/lib/SettingsManager.cpp:218
#23 0x0000555558cb38e3 in CSettingsBase::Uninitialize() (this=0x7fff70143320) at xbmc/settings/SettingsBase.cpp:152
#24 0x0000555558cb3244 in CSettingsBase::~CSettingsBase() (this=0x7fff70143320, __in_chrg=<optimized out>) at xbmc/settings/SettingsBase.cpp:28
#25 0x000055555894db7d in ADDON::CAddonSettings::~CAddonSettings() (this=0x7fff70143320, __in_chrg=<optimized out>) at xbmc/addons/settings/AddonSettings.h:45
#26 0x0000555558a280b3 in std::_Destroy<ADDON::CAddonSettings>(ADDON::CAddonSettings*) (__pointer=0x7fff70143320) at /usr/include/c++/13.2.1/bits/stl_construct.h:151
#27 0x0000555558a27f84 in std::allocator_traits<std::allocator<void> >::destroy<ADDON::CAddonSettings>(std::allocator<void>&, ADDON::CAddonSettings*) (__p=0x7fff70143320) at /usr/include/c++/13.2.1/bits/alloc_traits.h:674
#28 std::_Sp_counted_ptr_inplace<ADDON::CAddonSettings, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() (this=0x7fff70143310) at /usr/include/c++/13.2.1/bits/shared_ptr_base.h:613
#29 0x0000555557d7860b in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() (this=0x7fff70143310) at /usr/include/c++/13.2.1/bits/shared_ptr_base.h:346
#30 0x0000555557d787f7 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() (this=0x7fff706efe10, __in_chrg=<optimized out>) at /usr/include/c++/13.2.1/bits/shared_ptr_base.h:1071
#31 0x0000555557f5f3a4 in std::__shared_ptr<ADDON::CAddonSettings, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() (this=0x7fff706efe08, __in_chrg=<optimized out>) at /usr/include/c++/13.2.1/bits/shared_ptr_base.h:1524
#32 0x0000555557f5f3c0 in std::shared_ptr<ADDON::CAddonSettings>::~shared_ptr() (this=0x7fff706efe08, __in_chrg=<optimized out>) at /usr/include/c++/13.2.1/bits/shared_ptr.h:175
#33 0x0000555558916bea in ADDON::CAddon::CSettingsData::~CSettingsData() (this=0x7fff706efdc0, __in_chrg=<optimized out>) at xbmc/addons/Addon.h:475
#34 0x0000555558916cd8 in std::pair<unsigned int const, ADDON::CAddon::CSettingsData>::~pair() (this=0x7fff706efdb8, __in_chrg=<optimized out>) at /usr/include/c++/13.2.1/bits/stl_pair.h:187
#35 0x0000555558916768 in std::__new_allocator<std::__detail::_Hash_node<std::pair<unsigned int const, ADDON::CAddon::CSettingsData>, false> >::destroy<std::pair<unsigned int const, ADDON::CAddon::CSettingsData> >(std::pair<unsigned int const, ADDON::CAddon::CSettingsData>*) (__p=0x7fff706efdb8, this=0x7fff706e0cf8) at /usr/include/c++/13.2.1/bits/new_allocator.h:194
#36 std::allocator_traits<std::allocator<std::__detail::_Hash_node<std::pair<unsigned int const, ADDON::CAddon::CSettingsData>, false> > >::destroy<std::pair<unsigned int const, ADDON::CAddon::CSettingsData> >(std::allocator<std::__detail::_Hash_node<std::pair<unsigned int const, ADDON::CAddon::CSettingsData>, false> >&, std::pair<unsigned int const, ADDON::CAddon::CSettingsData>*) (__p=0x7fff706efdb8, __a=...) at /usr/include/c++/13.2.1/bits/alloc_traits.h:557
#37 std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<unsigned int const, ADDON::CAddon::CSettingsData>, false> > >::_M_deallocate_node(std::__detail::_Hash_node<std::pair<unsigned int const, ADDON::CAddon::CSettingsData>, false>*)
    (this=0x7fff706e0cf8, __n=0x7fff706efdb0) at /usr/include/c++/13.2.1/bits/hashtable_policy.h:2020
#38 0x00005555589160bb in std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<unsigned int const, ADDON::CAddon::CSettingsData>, false> > >::_M_deallocate_nodes(std::__detail::_Hash_node<std::pair<unsigned int const, ADDON::CAddon::CSettingsData>, false>*) (this=0x7fff706e0cf8, __n=0x0) at /usr/include/c++/13.2.1/bits/hashtable_policy.h:2042
#39 0x0000555558915d36 in std::_Hashtable<unsigned int, std::pair<unsigned int const, ADDON::CAddon::CSettingsData>, std::allocator<std::pair<unsigned int const, ADDON::CAddon::CSettingsData> >, std::__detail::_Select1st, std::equal_to<unsigned int>, std::hash<unsigned int>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::clear() (this=0x7fff706e0cf8) at /usr/include/c++/13.2.1/bits/hashtable.h:2509
#40 0x00005555589d9c98 in std::_Hashtable<unsigned int, std::pair<unsigned int const, ADDON::CAddon::CSettingsData>, std::allocator<std::pair<unsigned int const, ADDON::CAddon::CSettingsData> >, std::__detail::_Select1st, std::equal_to<unsigned int>, std::hash<unsigned int>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::~_Hashtable() (this=0x7fff706e0cf8, __in_chrg=<optimized out>)
    at /usr/include/c++/13.2.1/bits/hashtable.h:1593
#41 0x00005555589d9b0e in std::unordered_map<unsigned int, ADDON::CAddon::CSettingsData, std::hash<unsigned int>, std::equal_to<unsigned int>, std::allocator<std::pair<unsigned int const, ADDON::CAddon::CSettingsData> > >::~unordered_map()
    (this=0x7fff706e0cf8, __in_chrg=<optimized out>) at /usr/include/c++/13.2.1/bits/unordered_map.h:109
#42 0x00005555589d9b3c in ADDON::CAddon::~CAddon() (this=0x7fff706e0cd0, __in_chrg=<optimized out>) at xbmc/addons/Addon.h:38
#43 0x0000555558a9df4e in ADDON::CPluginSource::~CPluginSource() (this=0x7fff706e0cd0, __in_chrg=<optimized out>) at xbmc/addons/PluginSource.h:20
#44 0x0000555558a312f9 in std::_Destroy<ADDON::CPluginSource>(ADDON::CPluginSource*) (__pointer=0x7fff706e0cd0) at /usr/include/c++/13.2.1/bits/stl_construct.h:151
#45 0x0000555558a30bea in std::allocator_traits<std::allocator<void> >::destroy<ADDON::CPluginSource>(std::allocator<void>&, ADDON::CPluginSource*) (__p=0x7fff706e0cd0) at /usr/include/c++/13.2.1/bits/alloc_traits.h:674
#46 std::_Sp_counted_ptr_inplace<ADDON::CPluginSource, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() (this=0x7fff706e0cc0) at /usr/include/c++/13.2.1/bits/shared_ptr_base.h:613
#47 0x0000555557d7881d in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release_last_use() (this=0x7fff706e0cc0) at /usr/include/c++/13.2.1/bits/shared_ptr_base.h:175
#48 0x0000555557d78790 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release_last_use_cold() (this=0x7fff706e0cc0) at /usr/include/c++/13.2.1/bits/shared_ptr_base.h:199
#49 0x0000555557d786a9 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() (this=0x7fff706e0cc0) at /usr/include/c++/13.2.1/bits/shared_ptr_base.h:353
#50 0x0000555557d787f7 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() (this=0x7fff706dd578, __in_chrg=<optimized out>) at /usr/include/c++/13.2.1/bits/shared_ptr_base.h:1071
#51 0x0000555557d8d6de in std::__shared_ptr<ADDON::IAddon, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() (this=0x7fff706dd570, __in_chrg=<optimized out>) at /usr/include/c++/13.2.1/bits/shared_ptr_base.h:1524
#52 0x0000555557d8d6fa in std::shared_ptr<ADDON::IAddon>::~shared_ptr() (this=0x7fff706dd570, __in_chrg=<optimized out>) at /usr/include/c++/13.2.1/bits/shared_ptr.h:175
#53 0x0000555557f5d393 in XBMCAddon::xbmcaddon::Addon::~Addon() (this=0x7fff706dd520, __in_chrg=<optimized out>) at xbmc/interfaces/legacy/Addon.cpp:77
#54 0x0000555557f5d3ba in XBMCAddon::xbmcaddon::Addon::~Addon() (this=0x7fff706dd520, __in_chrg=<optimized out>) at xbmc/interfaces/legacy/Addon.cpp:77
#55 0x0000555557e8bdf7 in XBMCAddon::AddonClass::Release() const (this=0x7fff706dd520) at xbmc/interfaces/legacy/AddonClass.h:124
#56 0x0000555557f580e5 in PythonBindings::cleanForDealloc(XBMCAddon::AddonClass*) (c=0x7fff706dd520) at xbmc/interfaces/python/swig.cpp:369
#57 0x0000555557e8aefc in PythonBindings::xbmcaddon_XBMCAddon_xbmcaddon_Addon_Dealloc(PythonBindings::PyHolder*) (self=0x7fff3a51c990) at /home/mark/Coding/Repos/kodi-git/build_gcc_debug/build/swig/AddonModuleXbmcaddon.i.cpp:1847
#58 0x00007ffff79ea5ae in _PyEval_EvalFrameDefault (tstate=<optimized out>, frame=<optimized out>, throwflag=<optimized out>) at Python/ceval.c:3105
#59 0x00007ffff7a0bb90 in _PyEval_EvalFrame (throwflag=0, frame=0x7ffff0492120, tstate=0x7fff7001b240) at ./Include/internal/pycore_ceval.h:73
#60 _PyEval_Vector (kwnames=<optimized out>, argcount=1, args=0x7fff7effbd80, locals=0x0, func=0x7fff581ce0c0, tstate=0x7fff7001b240) at Python/ceval.c:6425
#61 _PyFunction_Vectorcall (func=0x7fff581ce0c0, stack=0x7fff7effbd80, nargsf=<optimized out>, kwnames=<optimized out>) at Objects/call.c:393
#62 0x00007ffff7a13c5e in _PyObject_FastCallDictTstate (kwargs=0x0, nargsf=<optimized out>, args=0x7fff7effbd80, callable=0x7fff581ce0c0, tstate=0x7fff7001b240) at Objects/call.c:141
#63 _PyObject_Call_Prepend (kwargs=<optimized out>, args=<optimized out>, obj=<optimized out>, callable=0x7fff581ce0c0, tstate=0x7fff7001b240) at Objects/call.c:482
#64 slot_tp_init (self=<optimized out>, args=<optimized out>, kwds=<optimized out>) at Objects/typeobject.c:7854
#65 0x00007ffff79da92b in type_call (kwds=0x0, args=0x7ffff7d6efd8 <_PyRuntime+58904>, type=<optimized out>) at Objects/typeobject.c:1103
#66 _PyObject_MakeTpCall (tstate=0x7fff7001b240, callable=0x7fff704f5cc0, args=<optimized out>, nargs=<optimized out>, keywords=0x0) at Objects/call.c:214
#67 0x00007ffff79e4c23 in _PyEval_EvalFrameDefault (tstate=<optimized out>, frame=<optimized out>, throwflag=<optimized out>) at Python/ceval.c:4760
#68 0x00007ffff7a9c484 in _PyEval_EvalFrame (throwflag=0, frame=0x7ffff0492020, tstate=0x7fff7001b240) at ./Include/internal/pycore_ceval.h:73
#69 _PyEval_Vector (tstate=tstate@entry=0x7fff7001b240, func=func@entry=0x7fffd81a5080, locals=locals@entry=0x7fffd81affc0, args=args@entry=0x0, argcount=argcount@entry=0, kwnames=kwnames@entry=0x0) at Python/ceval.c:6425
#70 0x00007ffff7a9be6c in PyEval_EvalCode (co=0x7fffc1769a70, globals=<optimized out>, locals=0x7fffd81affc0) at Python/ceval.c:1140
#71 0x00007ffff7ab9fc3 in run_eval_code_obj (tstate=tstate@entry=0x7fff7001b240, co=co@entry=0x7fffc1769a70, globals=globals@entry=0x7fffd81affc0, locals=locals@entry=0x7fffd81affc0) at Python/pythonrun.c:1710
#72 0x00007ffff7ab63ea in run_mod (mod=mod@entry=0x7fff70061fe0, filename=filename@entry=0x7fffc17adab0, globals=globals@entry=0x7fffd81affc0, locals=locals@entry=0x7fffd81affc0, flags=flags@entry=0x0, arena=arena@entry=0x7fffda3e7590) at Python/pythonrun.c:1731
#73 0x00007ffff7acc723 in pyrun_file (fp=fp@entry=0x7fff7002a0c0, filename=filename@entry=0x7fffc17adab0, start=start@entry=257, globals=globals@entry=0x7fffd81affc0, locals=locals@entry=0x7fffd81affc0, closeit=closeit@entry=1, flags=0x0) at Python/pythonrun.c:1626
#74 0x00007ffff79bdd24 in PyRun_FileExFlags (fp=0x7fff7002a0c0, filename=<optimized out>, start=257, globals=0x7fffd81affc0, locals=0x7fffd81affc0, closeit=1, flags=0x0) at Python/pythonrun.c:1646
#75 0x0000555557f41d84 in CPythonInvoker::executeScript(_IO_FILE*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, _object*)
    (this=0x55555dd063e0, fp=0x7fff7002a0c0, script="/home/mark/.kodi/addons/plugin.video.youtube/resources/lib/startup.py", moduleDict=0x7fffd81affc0) at xbmc/interfaces/python/PythonInvoker.cpp:426
#76 0x0000555557f414cd in CPythonInvoker::execute(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<std::__cxx11::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> >, std::allocator<std::__cxx11::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> > > >&) (this=0x55555dd063e0, script="/home/mark/.kodi/addons/plugin.video.youtube/resources/lib/startup.py", arguments=std::vector of length 1, capacity 1 = {...})
    at xbmc/interfaces/python/PythonInvoker.cpp:317
#77 0x0000555557f40775 in CPythonInvoker::execute(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) (this=0x55555dd063e0, script="/home/mark/.kodi/addons/plugin.video.youtube/resources/lib/startup.py", arguments=std::vector of length 0, capacity 0)
    at xbmc/interfaces/python/PythonInvoker.cpp:136
#78 0x00005555592042a2 in ILanguageInvoker::Execute(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) (this=0x55555dd063e0, script="/home/mark/.kodi/addons/plugin.video.youtube/resources/lib/startup.py", arguments=std::vector of length 0, capacity 0)
    at xbmc/interfaces/generic/ILanguageInvoker.cpp:27
#79 0x0000555557f4061c in CPythonInvoker::Execute(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&) (this=0x55555dd063e0, script="/home/mark/.kodi/addons/plugin.video.youtube/resources/lib/startup.py", arguments=std::vector of length 0, capacity 0)
    at xbmc/interfaces/python/PythonInvoker.cpp:124
#80 0x0000555559204b21 in CLanguageInvokerThread::Process() (this=0x55555d8f66d0) at xbmc/interfaces/generic/LanguageInvokerThread.cpp:107
#81 0x00005555585ca627 in CThread::Action() (this=0x55555d8f66f8) at xbmc/threads/Thread.cpp:283
#82 0x00005555585c9d94 in operator()(CThread*, std::promise<bool>) const (__closure=0x55555dadc388, pThread=0x55555d8f66f8, promise=...) at xbmc/threads/Thread.cpp:152
#83 0x00005555585cad65 in std::__invoke_impl<void, CThread::Create(bool)::<lambda(CThread*, std::promise<bool>)>, CThread*, std::promise<bool> >(std::__invoke_other, struct {...} &&) (__f=...) at /usr/include/c++/13.2.1/bits/invoke.h:61
#84 0x00005555585cacd2 in std::__invoke<CThread::Create(bool)::<lambda(CThread*, std::promise<bool>)>, CThread*, std::promise<bool> >(struct {...} &&) (__fn=...) at /usr/include/c++/13.2.1/bits/invoke.h:96
#85 0x00005555585cac05 in std::thread::_Invoker<std::tuple<CThread::Create(bool)::<lambda(CThread*, std::promise<bool>)>, CThread*, std::promise<bool> > >::_M_invoke<0, 1, 2>(std::_Index_tuple<0, 1, 2>) (this=0x55555dadc388)
    at /usr/include/c++/13.2.1/bits/std_thread.h:292
#86 0x00005555585caba2 in std::thread::_Invoker<std::tuple<CThread::Create(bool)::<lambda(CThread*, std::promise<bool>)>, CThread*, std::promise<bool> > >::operator()(void) (this=0x55555dadc388) at /usr/include/c++/13.2.1/bits/std_thread.h:299
#87 0x00005555585cab86 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<CThread::Create(bool)::<lambda(CThread*, std::promise<bool>)>, CThread*, std::promise<bool> > > >::_M_run(void) (this=0x55555dadc380) at /usr/include/c++/13.2.1/bits/std_thread.h:244
#88 0x00007ffff52e1943 in std::execute_native_thread_routine(void*) (__p=0x55555dadc380) at /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++11/thread.cc:104
#89 0x00007ffff50aa9eb in start_thread (arg=<optimized out>) at pthread_create.c:444
#90 0x00007ffff512e7cc in clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:78
```
</details>

This is the object on which the method is called:

```
(gdb) frame 8
#8  0x0000555558c1d1b9 in CSettingsManager::CreateControl (this=0x7fff70693b90, controlType="list") at xbmc/settings/lib/SettingsManager.cpp:994
994         return creator->second->CreateControl(controlType);
(gdb) p creator
$1 = {first = "list", second = 0x7fff70143370}
```

We can see that the object is the same one as the one that's currently destructed in frame 24/25 (The address is slightly different, this due to multiple inheritance):

```
#24 0x0000555558cb3244 in CSettingsBase::~CSettingsBase() (this=0x7fff70143320, __in_chrg=<optimized out>) at xbmc/settings/SettingsBase.cpp:28
#25 0x000055555894db7d in ADDON::CAddonSettings::~CAddonSettings() (this=0x7fff70143320, __in_chrg=<optimized out>) at xbmc/addons/settings/AddonSettings.h:45
```

This is the definition of `CAddonSettings`:

https://github.com/xbmc/xbmc/blob/49ba27934d228aa7c963dc38b8a143dc8cbd1f23/xbmc/addons/settings/AddonSettings.h#L38-L41

We are currently executing the `CSettingsBase` destructor, meaning the `CSettingControlCreator` destructor has already been called. This is why we are getting the pure virtual method called error when calling a method of the CSettingControlCreator parents, it has already been cleaned up.

By changing the order of destructor calls the `CSettingControlCreator` is still valid while it is called. 

## How has this been tested?
Doesn't crash anymore, Valgrind and Address Sanitizer are happy.

## What is the effect on users?
Working Kodi when compiled with GCC >= 13.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
