### PR TITLE
DNSNameCache: check hostname can be an IPv6 address

### DIFF
--- a/xbmc/network/DNSNameCache.cpp
+++ b/xbmc/network/DNSNameCache.cpp
@@ -24,6 +24,10 @@
 #include <netdb.h>
 #include <netinet/in.h>
 
+#if defined(TARGET_FREEBSD)
+#include <sys/socket.h>
+#endif
+
 CDNSNameCache g_DNSCache;
 
 CCriticalSection CDNSNameCache::m_critical;

--- a/xbmc/network/DNSNameCache.cpp
+++ b/xbmc/network/DNSNameCache.cpp
@@ -38,18 +38,19 @@ bool CDNSNameCache::Lookup(const std::string& strHostName, std::string& strIpAdd
     return false;
 
   // first see if this is already an ip address
-  unsigned long address = inet_addr(strHostName.c_str());
+  in_addr addr4;
+  in6_addr addr6;
   strIpAddress.clear();
 
-  if (address != INADDR_NONE)
+  if (inet_pton(AF_INET, strHostName.c_str(), &addr4) ||
+      inet_pton(AF_INET6, strHostName.c_str(), &addr6))
   {
-    strIpAddress = StringUtils::Format("{}.{}.{}.{}", (address & 0xFF), (address & 0xFF00) >> 8,
-                                       (address & 0xFF0000) >> 16, (address & 0xFF000000) >> 24);
+    strIpAddress = strHostName;
     return true;
   }
 
   // check if there's a custom entry or if it's already cached
-  if(g_DNSCache.GetCached(strHostName, strIpAddress))
+  if (g_DNSCache.GetCached(strHostName, strIpAddress))
     return true;
 
   // perform dns lookup


### PR DESCRIPTION
## Description
In the same way that checks that the hostname can be an IPv4 address, add the check for an IPv6 address.

## How has this been tested?
Tested on Linux that correctly connects to an IPv6 address on a dual-stack network interface. 

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
