### PR TITLE
Add OEM 102 key (OEM key on 102-key keyboards)

### DIFF
--- a/xbmc/games/controllers/ControllerTranslator.cpp
+++ b/xbmc/games/controllers/ControllerTranslator.cpp
@@ -450,6 +450,8 @@ KEYBOARD::KeySymbol CControllerTranslator::TranslateKeysym(const std::string& sy
     return XBMCK_EURO;
   if (symbol == "undo")
     return XBMCK_UNDO;
+  if (symbol == "oem102")
+    return XBMCK_OEM_102;
 
   return XBMCK_UNKNOWN;
 }
@@ -736,6 +738,8 @@ const char* CControllerTranslator::TranslateKeycode(KEYBOARD::KeySymbol keycode)
       return "euro";
     case XBMCK_UNDO:
       return "undo";
+    case XBMCK_OEM_102:
+      return "oem102";
     default:
       break;
   }

--- a/xbmc/input/XBMC_keysym.h
+++ b/xbmc/input/XBMC_keysym.h
@@ -133,6 +133,11 @@ typedef enum
   XBMCK_MEDIA_REWIND = 0xBA,
   XBMCK_MEDIA_FASTFORWARD = 0xBB,
 
+  // This key is not present on standard US keyboard layouts. For European
+  // layouts it's usually located to the right of left-shift key, with '\' as
+  // its main function.
+  XBMCK_OEM_102 = 0xE2,
+
   // Numeric keypad
   XBMCK_KP0 = 0x100,
   XBMCK_KP1 = 0x101,


### PR DESCRIPTION
## Description

This PR adds the "OEM 102" key, which is an OEM key on 102-key keyboards (not present on US layouts).

According to my documentation in the code:

```
// This key is not present on standard US keyboard layouts. For European
// layouts it's usually located to the right of left-shift key, with '\' as
// its main function.
```

You can see this key on the key table for the Microsoft documentation:

* https://learn.microsoft.com/en-us/windows/iot/iot-enterprise/customize/keyboardfilter-key-names

| Key name | Virtual key | Description
| -- | -- | --
| Oem102 | VK_OEM_102 | Either the angle bracket key or the backslash key on the RT 102-key keyboard

## Motivation and context

This PR is needed to support the `RETROK_OEM_102` key added to the libretro API in https://github.com/libretro/RetroArch/pull/7173.

It has been added to the controller topology project in https://github.com/kodi-game/controller-topology-project/pull/279 (and synced to Kodi in https://github.com/xbmc/xbmc/pull/24191).

Added to game.libretro in https://github.com/kodi-game/game.libretro/pull/115.

## How has this been tested?

Before:

```
info  <general>: Loading controller layout: /home/garrett/kodi/share/kodi/addons/game.controller.keyboard/resources/layout.xml
error <general>: <key> tag - attribute "symbol" is invalid: "oem102"
```

After:

![OEM 102 key](https://github.com/kodi-game/controller-topology-project/assets/531482/3476fafe-c2bd-4f26-b79a-13500d0c8bee)

## What is the effect on users?

* Added support for the OEM 102 key

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
