### PR TITLE
[VideoDB][Video Versions] Return the default version first for playback and management

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -11832,14 +11832,23 @@ void CVideoDatabase::GetVideoVersions(VideoDbContentType itemType,
 
   try
   {
-    m_pDS2->query(PrepareSQL("SELECT videoversiontype.name AS name,"
-                             "  videoversiontype.id AS id,"
-                             "  videoversion.idFile AS idFile "
-                             "FROM videoversiontype"
-                             "  JOIN videoversion ON"
+    m_pDS2->query(PrepareSQL("SELECT videoversiontype.name AS name, "
+                             "  videoversiontype.id AS id, "
+                             "  videoversion.idFile AS idFile, "
+                             "  CASE "
+                             "    WHEN movie.idMovie = videoversion.idMedia "
+                             "      THEN 1 "
+                             "	  ELSE 0 "
+                             "  END AS defaultVersion "
+                             "FROM videoversiontype "
+                             "  JOIN videoversion ON "
                              "    videoversion.idType = videoversiontype.id "
-                             "WHERE videoversion.idMedia = %i AND videoversion.mediaType = '%s' "
-                             "AND videoversion.itemType = %i",
+                             "  LEFT JOIN movie ON "
+                             "	  movie.idFile = videoversion.idFile "
+                             "WHERE videoversion.idMedia = %i "
+                             "AND videoversion.mediaType =  '%s' "
+                             "AND videoversion.itemType = %i "
+                             "ORDER BY defaultVersion desc, videoversiontype.id ",
                              dbId, mediaType.c_str(), versionItemType));
 
     std::vector<std::tuple<std::string, int, int>> versions;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

When playing a movie with versions or managing the versions, the item selected by default is the first version type defined in the system, not the default version chosen by the user.

The comments in the issue #24188 indicate that it's not possible to programmatically change the list selection when opening the playback version selection or the version management screens.

An acceptable alternative is to reorder the list items to show the default version as first item. This PR implements that change with a modification of the query that returns the list of versions for a movie.
To be certain that the non-default versions are always listed in the same order, also defined explicitly the sort order.

Could also be done as 2 queries combined by code afterwards instead of integrating both into one.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

After selecting a default version for a movie, that version should be offered as default option for playback or when managing the versions.
See #24188, first item of the list is selected when the screen opens.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With the "default" default version first, then after changing the default and reopening the playback selection or the management screen, the selection is now at the top.

In the management screen, setting the default doesn't reorder immediately the list, the screen should maybe be modified to do that.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Better support of default movie version.

## Screenshots (if appropriate):
Default version when first importing a movie is "Standard" and is offered as default playback option:
![image](https://github.com/xbmc/xbmc/assets/489377/257c95aa-04ca-4032-98be-900dd2153b1d)

Go to manage versions and set the default version to an alternative version:
![image](https://github.com/xbmc/xbmc/assets/489377/92617edd-49f9-49d6-8b27-11726a3823eb)

The new default version will play by default:
![image](https://github.com/xbmc/xbmc/assets/489377/be6b73b6-018f-493b-b8cd-cdf273b73f8b)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
