### PR TITLE
[DllLibCurl][TestXBMCTinyXML2] Fix memory leaks

### DIFF
--- a/xbmc/filesystem/DllLibCurl.cpp
+++ b/xbmc/filesystem/DllLibCurl.cpp
@@ -123,6 +123,15 @@ DllLibCurlGlobal::DllLibCurlGlobal()
 
 DllLibCurlGlobal::~DllLibCurlGlobal()
 {
+  for (auto& session : m_sessions)
+  {
+    if (session.m_multi && session.m_easy)
+      multi_remove_handle(session.m_multi, session.m_easy);
+    if (session.m_easy)
+      easy_cleanup(session.m_easy);
+    if (session.m_multi)
+      multi_cleanup(session.m_multi);
+  }
   // close libcurl
   curl_global_cleanup();
 }

--- a/xbmc/utils/test/TestXBMCTinyXML2.cpp
+++ b/xbmc/utils/test/TestXBMCTinyXML2.cpp
@@ -131,6 +131,7 @@ TEST(TestXBMCTinyXML2, SaveFile)
   ASSERT_NE(nullptr, f);
   inputdoc.LoadFile(f);
   fclose(f);
+  XBMC_DELETETEMPFILE(file);
 
   auto* root = inputdoc.RootElement();
   if (root && (strcmp(root->Value(), "details") == 0))


### PR DESCRIPTION
## Description
Fixes two memory leaks observed when running the unit tests. Details are in the commit messages.

## Motivation and context
Fewer errors when running unit tests with address sanitizer.

## How has this been tested?
Address sanitizer is happy, no problems when runtime testing Kodi.

## What is the effect on users?
None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
