### PR TITLE
[InputStreamAddon] Fix memory leak

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -550,6 +550,10 @@ KODI_HANDLE CInputStreamAddon::cb_get_stream_transfer(KODI_HANDLE handle,
     if ((stream->m_features & INPUTSTREAM_FEATURE_DECODE) != 0)
       demuxStream->externalInterfaces = thisClass->m_subAddonProvider;
   }
+
+  // Tie the lifetime of the stream to the CInputStreamAddon
+  thisClass->m_streams.emplace_back(demuxStream);
+
   return demuxStream;
 }
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
@@ -123,6 +123,12 @@ private:
   std::shared_ptr<CInputStreamProvider> m_subAddonProvider;
 
   /*!
+   * This class takes ownership of the `CDemuxStream`s created
+   * in `cb_get_stream_transfer` by storing them in this vector
+   */
+  std::vector<std::unique_ptr<CDemuxStream>> m_streams;
+
+  /*!
    * Callbacks from add-on to kodi
    */
   //@{


### PR DESCRIPTION
## Description
Fixes leak of `CDemuxStream` objects created via the `CInputStreamAddon::cb_get_stream_transfer` callback. See the commit message for an example.

## Motivation and context
No more leaks.

## How has this been tested?
Tested with inputstream.adaptive and the YouTube and Twitch add-ons.

## What is the effect on users?
Basically none, the leak is very minor.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
