### PR TITLE
[UPnP] Fix crash when adding UPnP source while UPnP is disabled

### DIFF
--- a/xbmc/filesystem/UPnPDirectory.cpp
+++ b/xbmc/filesystem/UPnPDirectory.cpp
@@ -102,14 +102,13 @@ static bool FindDeviceWait(CUPnP* upnp, const char* uuid, PLT_DeviceDataReferenc
 /*----------------------------------------------------------------------
 |   CUPnPDirectory::GetFriendlyName
 +---------------------------------------------------------------------*/
-const char*
-CUPnPDirectory::GetFriendlyName(const CURL& url)
+std::string CUPnPDirectory::GetFriendlyName(const CURL& url)
 {
     NPT_String path = url.Get().c_str();
     if (!path.EndsWith("/")) path += "/";
 
     if (path.Left(7).Compare("upnp://", true) != 0) {
-        return NULL;
+      return {};
     } else if (path.Compare("upnp://", true) == 0) {
         return "UPnP Media Servers (Auto-Discover)";
     }
@@ -117,7 +116,7 @@ CUPnPDirectory::GetFriendlyName(const CURL& url)
     // look for nextslash
     int next_slash = path.Find('/', 7);
     if (next_slash == -1)
-        return NULL;
+      return {};
 
     NPT_String uuid = path.SubString(7, next_slash-7);
     NPT_String object_id = path.SubString(next_slash+1, path.GetLength()-next_slash-2);
@@ -125,9 +124,9 @@ CUPnPDirectory::GetFriendlyName(const CURL& url)
     // look for device
     PLT_DeviceDataReference device;
     if(!FindDeviceWait(CUPnP::GetInstance(), uuid, device))
-        return NULL;
+      return {};
 
-    return (const char*)device->GetFriendlyName();
+    return device->GetFriendlyName().GetChars();
 }
 
 /*----------------------------------------------------------------------

--- a/xbmc/filesystem/UPnPDirectory.h
+++ b/xbmc/filesystem/UPnPDirectory.h
@@ -32,7 +32,7 @@ public:
     bool Resolve(CFileItem& item) const override;
 
     // class methods
-    static const char* GetFriendlyName(const CURL& url);
+    static std::string GetFriendlyName(const CURL& url);
     static bool        GetResource(const CURL &path, CFileItem& item);
 };
 }


### PR DESCRIPTION
## Description
In that case CUPnPDirectory::GetFriendlyName returned a nullptr which wasn't expected by CUtil::GetTitleFromPath. Also the last retrun returned memory that's freed when returning from the function. Switching the return type to std::string solves all these issues.

Fixes #24213.

## Motivation and context
Prevent crash.

## How has this been tested?
Adding UPnP source whith UPnP disabled in Kodi settings --> No crash. When enabled UPnP still works as expected.

## What is the effect on users?
No crash. But the user still doesn't know why UPnP doesn't work :slightly_frowning_face: 

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
