### PR TITLE
[Estuary] Fix shift view overlay

### DIFF
--- a/addons/skin.estuary/xml/View_53_Shift.xml
+++ b/addons/skin.estuary/xml/View_53_Shift.xml
@@ -199,7 +199,7 @@
 	</include>
 	<include name="IconStatusOverlay">
 		<control type="group">
-			<visible>String.IsEqual(ListItem.DBtype,tvshow) | String.IsEqual(ListItem.DBtype,set) | String.IsEqual(ListItem.DBType,season) | String.IsEqual(ListItem.IsCollection) | String.IsEqual(ListItem.HasVideoVersions) | String.IsEqual(ListItem.IsResumable) | Integer.IsGreater(ListItem.Playcount,0)</visible>
+			<visible>String.IsEqual(ListItem.DBtype,tvshow) | String.IsEqual(ListItem.DBtype,set) | String.IsEqual(ListItem.DBType,season) | ListItem.HasVideoVersions | ListItem.IsResumable | Integer.IsGreater(ListItem.Playcount,0)</visible>
 			<control type="image">
 				<left>38</left>
 				<top>500</top>


### PR DESCRIPTION
## Description

Noticed when using Beta 2 that some icon overlays were not shown in Estuary Shift view, this is due to some visibility conditions being incorrect. It seems the wrong version of View_53_Shift.xml got into https://github.com/xbmc/xbmc/pull/24168 as what I have locally is correct.

Simply fix to rectify this.