### PR TITLE
[info] Deprecated Process and Colour picture/slideshow infos

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -5171,6 +5171,11 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///                  \anchor ListItem_PictureColour
 ///                  _string_,
 ///     @return Whether the selected picture is "Colour" or "Black and White".
+///     <p>
+///     @deprecated \link ListItem_PictureColour `ListItem.PictureColour`\endlink is deprecated and will be removed in future Kodi versions
+///     <p><hr>
+///     @skinning_v20 **[Deprecated]** \link ListItem_PictureColour `ListItem.PictureColour`\endlink is deprecated and will be removed in future Kodi versions
+///     <p>
 ///     <p><hr>
 ///     @skinning_v13 **[New Infolabel]** \link ListItem_PictureColour `ListItem.PictureColour`\endlink
 ///     <p>
@@ -5489,6 +5494,11 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///                  \anchor ListItem_PictureProcess
 ///                  _string_,
 ///     @return The process used to compress the selected picture.
+///     <p>
+///     @deprecated \link ListItem_PictureProcess `ListItem.PictureProcess`\endlink is deprecated and will be removed in future Kodi versions
+///     <p><hr>
+///     @skinning_v20 **[Deprecated]** \link ListItem_PictureProcess `ListItem.PictureProcess`\endlink is deprecated and will be removed in future Kodi versions
+///     <p>
 ///     <p><hr>
 ///     @skinning_v13 **[New Infolabel]** \link ListItem_PictureProcess `ListItem.PictureProcess`\endlink
 ///     <p>
@@ -9076,6 +9086,11 @@ const infomap rds[] =            {{ "hasrds",                   RDS_HAS_RDS },
 ///     @return the colour of the picture. It can have one of the following values:
 ///       - <b>"Colour"</b>
 ///       - <b>"Black and White"</b>
+///     <p>
+///     @deprecated Slideshow_Colour `Slideshow.Colour`\endlink is deprecated and will be removed in future Kodi versions
+///     <p><hr>
+///     @skinning_v20 **[Deprecated]** \link Slideshow_Colour `Slideshow.Colour`\endlink is deprecated and will be removed in future Kodi versions
+///     <p>
 ///     <p><hr>
 ///     @skinning_v13 **[New Infolabel]** \link Slideshow_Colour `Slideshow.Colour`\endlink
 ///     <p>
@@ -9405,6 +9420,11 @@ const infomap rds[] =            {{ "hasrds",                   RDS_HAS_RDS },
 ///                  \anchor Slideshow_Process
 ///                  _string_,
 ///     @return The process used to compress the current picture.
+///     <p>
+///     @deprecated \link Slideshow_Process `Slideshow.Process`\endlink is deprecated and will be removed in future Kodi versions
+///     <p><hr>
+///     @skinning_v20 **[Deprecated]** \link Slideshow_Process `Slideshow.Process`\endlink is deprecated and will be removed in future Kodi versions
+///     <p>
 ///     <p><hr>
 ///     @skinning_v13 **[New Infolabel]** \link Slideshow_Process `Slideshow.Process`\endlink
 ///     <p>


### PR DESCRIPTION
## Description
I plan to remove `Slideshow.Colour` and `Slideshow.Process` (and the Picture equiivalents) for v22 as part of the rewrite of the image metadata retrieval (see https://github.com/xbmc/xbmc/pull/24109). Those "tags" are specific of the parsing of JPEG files (thus for a unique image format) and have nothing to do with any metatada group (exif, iptc, xmp, etc). Furthermore they convey little to no useful information and are not available unless you implement your own parser (just like Kodi does nowadays) or in specific tools like exiftool (see SOF tags in https://exiftool.org/TagNames/JPEG.html). I could try to contribute the implementation to exiv2 but IMOH is not worth the effort as the added benefit is none.

I plan to add the ColorSpace exif tag as an alternative for IsColour. Process is simply nuked (will add Software tag since the implementation in Kodi is incomplete nowadays). Tried to collect user feedback in https://forum.kodi.tv/showthread.php?tid=375062 for new tags but, as usual, feedback was close to non-existent.

This just marks those infos as deprecated to avoid killing them without further notice. Will post on the skinning thread once merged.