### PR TITLE
[Windows] Fix chroma upsampling for pixel shaders render method

### DIFF
--- a/system/shaders/yuv2rgb_d3d.fx
+++ b/system/shaders/yuv2rgb_d3d.fx
@@ -32,7 +32,7 @@ SamplerState YUVSampler : IMMUTABLE
 {
   AddressU = CLAMP;
   AddressV = CLAMP;
-  Filter   = MIN_MAG_MIP_POINT;
+  Filter   = MIN_MAG_MIP_LINEAR;
 };
 
 struct VS_INPUT


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

The chroma of videos encoded as ycbcr 4:2:0 or 4:2:2 is upscaled using nearest neighbor with the pixel shaders render method, resulting in low visual quality.

This is a side effect of #15382, which implemented color conversion at the source video size, followed by scaling.

The sampler filtering mode "point" is OK for the luminance (no scaling needed), but not for the chroma channels. They still require upsampling from 4:2:0 or 4:2:2 to 4:4:4
-  solution: sample Y with point filter and UV with linear filter

It's not clear if sampling Y with point filtering instead of linear actually saves any bandwidth on modern gpus. I haven't been able to measure a difference.

Commit 1 uses linear for everything.
Commit 2 uses point for Y and linear for UV.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As reported in #21850, pixelated chroma with pixel shaders render methods, see screenshots below.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 8 and 10, x64 and UWP versions. Intel, AMD, NVIDIA.
1080p, 720p, 640x380 videos with sharp red characters or logos. codec doesn't matter.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Better picture quality with the pixel shaders render method (used by default with software decoding)

## Screenshots (if appropriate):
Using the example of the issue, current master:
![image](https://github.com/xbmc/xbmc/assets/489377/ed519e42-3ce3-40e1-a456-f5270eae3a20)

with PR:
![image](https://github.com/xbmc/xbmc/assets/489377/e78c5bd5-de1b-4b99-9c00-abef4d71cb5a)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
