### PR TITLE
[Windows] Fix chroma upsampling for software render method

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererSoftware.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererSoftware.h
@@ -35,6 +35,7 @@ protected:
 
 private:
   SwsContext* m_sw_scale_ctx = nullptr;
+  SwsFilter* m_srcFilter = nullptr;
   bool m_restoreMultithreadProtectedOff = false;
 };
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

The chroma of videos encoded as ycbcr 4:2:0 or 4:2:2 is upscaled using nearest neighbor with the software render method, resulting in low visual quality.

This is a pre-existing problem made much more visible by #15382, which implemented color conversion at the source video size, followed by scaling.

swscale doesn't interpolate chroma unless the flag SWS_FULL_CHR_H_INT is provided. That wasn't enough though.

Digging in swscale code and turning on additional logging (SWS_PRINT_INFO), revealed that a different path `ff_get_unscaled_swscale()` is used when source and dest size are identical and no filtering is done. That algorithm upsamples chroma with nearest neighbor and ignores SWS_FULL_CHR_H_INT.

I could think of multiple ways to fix this, none very satisfying or practical.
  1/ Kodi workaround: add a pixel to destination size
  2/ Kodi workaround: use an identity filter of depth 3 instead of the default 1 (no picture difference)
  3/ ffmpeg fix: patch swscale to force the algorithm needed
  4/ ffmpeg fix: modify `ff_get_unscaled_swscale()` to use linear interpolation
  5/ Kodi fix: use a different ffmpeg filter for color conversion
  6/ restore previous behavior of converting colors and scaling at the same time. The issue would still happen when no scaling is needed.

I used 2/ in this PR after benchmarking cpu usage against current master on the oldest/slowest computer I had.
There was no cpu usage difference with the baseline (current master), and also no noticeable speed difference between fast bilinear and bilinear.
Bilinear has slightly better visual quality (see screenshots) and it's 2023 > switched to bilinear.

To make things a bit more complicated, swscale 7.1.100 doesn't support chroma interpolation with 10 bit rgb output so I turned off the workaround logic. To make it work a double conversion would have been necessary, or forcing an 8 bit intermediate target format (and lose the extra precision for real 10 bit HDR).

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As reported in #21850

Pixelated chroma with the software render method, see screenshots below.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 8 and 10 x64 and UWP versions.
1080p, 720p, 640x380 videos with sharp red characters or logos. codec doesn't matter.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Better picture quality with the software render method.

## Screenshots (if appropriate):
Using the example of the issue, current master:
![image](https://github.com/xbmc/xbmc/assets/489377/ed519e42-3ce3-40e1-a456-f5270eae3a20)

software with fast bilinear for information only, not in the final solution of the PR:
![image](https://github.com/xbmc/xbmc/assets/489377/619235b7-25d3-4314-bffc-4b10b6756085)

pixel shaders and software with bilinear:
![image](https://github.com/xbmc/xbmc/assets/489377/e78c5bd5-de1b-4b99-9c00-abef4d71cb5a)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
