### PR TITLE
[video] Video Versions Playback: Fixes and Cleanup

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -2394,7 +2394,7 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
       if (videoInfoTagPath.find("removable://") == 0 || item.IsVideoDb())
         path = videoInfoTagPath;
 
-      if (!item.HasVideoInfoTag() || item.GetVideoInfoTag()->m_type != MediaTypeVideoVersion)
+      if (!item.HasVideoInfoTag())
         dbs.LoadVideoInfo(path, *item.GetVideoInfoTag());
 
       if (item.HasProperty("savedplayerstate"))

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2147,6 +2147,17 @@ bool CVideoDatabase::GetMovieInfo(const std::string& strFilenameAndPath, CVideoI
     if (!m_pDS->query(sql))
       return false;
     details = GetDetailsForMovie(m_pDS, getDetails);
+
+    //! @todo ugly video versions hack. patch the video file for a non-default video version
+    //! into the video info tag that was just loaded for the default video version.
+    if (!details.IsEmpty() && details.m_hasVideoVersions && !strFilenameAndPath.empty() &&
+        strFilenameAndPath != details.m_strFileNameAndPath)
+    {
+      details.m_lastPlayed.SetValid(false);
+      details.m_dateAdded.SetValid(false);
+      details.SetResumePoint({});
+      GetFileInfo(strFilenameAndPath, details);
+    }
     return !details.IsEmpty();
   }
   catch (...)

--- a/xbmc/video/guilib/VideoActionProcessorHelper.cpp
+++ b/xbmc/video/guilib/VideoActionProcessorHelper.cpp
@@ -9,10 +9,7 @@
 #include "VideoActionProcessorHelper.h"
 
 #include "FileItem.h"
-#include "GUIUserMessages.h"
 #include "ServiceBroker.h"
-#include "guilib/GUIComponent.h"
-#include "guilib/GUIWindowManager.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
@@ -21,79 +18,6 @@
 #include "video/dialogs/GUIDialogVideoVersion.h"
 
 using namespace VIDEO::GUILIB;
-
-CVideoActionProcessorHelper::~CVideoActionProcessorHelper()
-{
-  RestoreDefaultVideoVersion();
-}
-
-void CVideoActionProcessorHelper::SetDefaultVideoVersion()
-{
-  RestoreDefaultVideoVersion();
-
-  //! @todo this hack must go away! Playback currently only works if we persist the
-  //! movie version to play in the video database temporarily, until playback was started.
-  CVideoDatabase db;
-  if (!db.Open())
-  {
-    CLog::LogF(LOGERROR, "Unable to open video database!");
-    return;
-  }
-
-  const VideoDbContentType itemType{m_item->GetVideoContentType()};
-  const int dbId{m_item->GetVideoInfoTag()->m_iDbId};
-
-  CFileItem defaultVideoVersion;
-  db.GetDefaultVideoVersion(itemType, dbId, defaultVideoVersion);
-  m_defaultVideoVersionFileId = defaultVideoVersion.GetVideoInfoTag()->m_iDbId;
-  m_defaultVideoVersionDynPath = defaultVideoVersion.GetDynPath();
-
-  db.SetDefaultVideoVersion(itemType, dbId, m_videoVersion->GetVideoInfoTag()->m_iDbId);
-
-  m_item->SetDynPath(m_videoVersion->GetDynPath());
-  db.GetDetailsByTypeAndId(*m_item, itemType, dbId);
-
-  // notify all windows to update the file item
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_ITEM, GUI_MSG_FLAG_FORCE_UPDATE, m_item);
-  CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
-}
-
-void CVideoActionProcessorHelper::RestoreDefaultVideoVersion()
-{
-  //! @todo this hack must go away!
-  if (m_restoreFolderFlag)
-  {
-    m_restoreFolderFlag = false;
-    m_item->m_bIsFolder = true;
-  }
-
-  if (m_defaultVideoVersionFileId == -1)
-    return;
-
-  //! @todo this hack must go away! Playback currently only works if we persist the
-  //! movie version to play in the video database temporarily, until playback was started.
-  CVideoDatabase db;
-  if (!db.Open())
-  {
-    CLog::LogF(LOGERROR, "Unable to open video database!");
-    return;
-  }
-
-  const VideoDbContentType itemType{m_item->GetVideoContentType()};
-  const int dbId{m_item->GetVideoInfoTag()->m_iDbId};
-
-  db.SetDefaultVideoVersion(itemType, dbId, m_defaultVideoVersionFileId);
-
-  m_item->SetDynPath(m_defaultVideoVersionDynPath);
-  db.GetDetailsByTypeAndId(*m_item, itemType, dbId);
-
-  m_defaultVideoVersionFileId = -1;
-  m_defaultVideoVersionDynPath.clear();
-
-  // notify all windows to update the file item
-  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_ITEM, GUI_MSG_FLAG_FORCE_UPDATE, m_item);
-  CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
-}
 
 std::shared_ptr<CFileItem> CVideoActionProcessorHelper::ChooseVideoVersion()
 {
@@ -105,23 +29,10 @@ std::shared_ptr<CFileItem> CVideoActionProcessorHelper::ChooseVideoVersion()
       if (m_item->GetVideoInfoTag()->m_idVideoVersion > 0)
         m_videoVersion = m_item;
 
-      const auto settings{CServiceBroker::GetSettingsComponent()->GetSettings()};
-
-      if (!m_videoVersion)
-      {
-        //! @todo get rid of this hack to patch away item's folder flag if it is video version
-        //! folder
-        if (m_item->GetVideoInfoTag()->m_idVideoVersion == VIDEO_VERSION_ID_ALL &&
-            settings->GetBool(CSettings::SETTING_VIDEOLIBRARY_SHOWVIDEOVERSIONSASFOLDER))
-        {
-          m_item->m_bIsFolder = false;
-          m_restoreFolderFlag = true;
-        }
-      }
-
       if (!m_videoVersion)
       {
         // select the default video version
+        const auto settings{CServiceBroker::GetSettingsComponent()->GetSettings()};
         if (settings->GetBool(CSettings::SETTING_MYVIDEOS_SELECTDEFAULTVERSION))
         {
           CVideoDatabase db;
@@ -155,7 +66,10 @@ std::shared_ptr<CFileItem> CVideoActionProcessorHelper::ChooseVideoVersion()
   }
 
   if (m_videoVersion)
-    SetDefaultVideoVersion();
+  {
+    m_item = std::make_shared<CFileItem>(m_videoVersion->GetDynPath(), false);
+    m_item->LoadDetails();
+  }
 
   return m_item;
 }

--- a/xbmc/video/guilib/VideoActionProcessorHelper.h
+++ b/xbmc/video/guilib/VideoActionProcessorHelper.h
@@ -25,20 +25,15 @@ public:
     : m_item{item}, m_videoVersion{videoVersion}
   {
   }
-  virtual ~CVideoActionProcessorHelper();
+  virtual ~CVideoActionProcessorHelper() = default;
 
   std::shared_ptr<CFileItem> ChooseVideoVersion();
 
 private:
   CVideoActionProcessorHelper() = delete;
-  void SetDefaultVideoVersion();
-  void RestoreDefaultVideoVersion();
 
   std::shared_ptr<CFileItem> m_item;
   std::shared_ptr<const CFileItem> m_videoVersion;
-  int m_defaultVideoVersionFileId{-1};
-  std::string m_defaultVideoVersionDynPath;
-  bool m_restoreFolderFlag{false};
 };
 } // namespace GUILIB
 } // namespace VIDEO

--- a/xbmc/video/windows/GUIWindowVideoBase.h
+++ b/xbmc/video/windows/GUIWindowVideoBase.h
@@ -79,6 +79,7 @@ protected:
   void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
   bool OnContextButton(int itemNumber, CONTEXT_BUTTON button) override;
   virtual void OnQueueItem(int iItem, bool first = false);
+  void OnQueueItem(const std::shared_ptr<CFileItem>& item, int iItem, bool first = false);
   virtual void OnDeleteItem(const CFileItemPtr& pItem);
   void OnDeleteItem(int iItem) override;
   virtual void DoSearch(const std::string& strSearch, CFileItemList& items) {}
@@ -99,11 +100,12 @@ protected:
 
   void OnRestartItem(int iItem, const std::string &player = "");
   bool OnPlayOrResumeItem(int iItem, const std::string& player = "");
-  void PlayItem(int iItem, const std::string &player = "");
   bool OnPlayMedia(int iItem, const std::string &player = "") override;
+  bool OnPlayMedia(const std::shared_ptr<CFileItem>& item, const std::string& player);
   bool OnPlayAndQueueMedia(const CFileItemPtr& item, const std::string& player = "") override;
   using CGUIMediaWindow::LoadPlayList;
   void LoadPlayList(const std::string& strPlayList, PLAYLIST::Id playlistId = PLAYLIST::TYPE_VIDEO);
+  bool PlayItem(const std::shared_ptr<CFileItem>& item, const std::string& player);
 
   bool ShowInfo(const CFileItemPtr& item, const ADDON::ScraperPtr& content);
 

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -676,19 +676,6 @@ void CGUIWindowVideoNav::DoSearch(const std::string& strSearch, CFileItemList& i
   });
 }
 
-void CGUIWindowVideoNav::PlayItem(int iItem)
-{
-  // unlike additemtoplaylist, we need to check the items here
-  // before calling it since the current playlist will be stopped
-  // and cleared!
-
-  // root is not allowed
-  if (m_vecItems->IsVirtualDirectoryRoot())
-    return;
-
-  CGUIWindowVideoBase::PlayItem(iItem);
-}
-
 void CGUIWindowVideoNav::OnDeleteItem(const CFileItemPtr& pItem)
 {
   if (m_vecItems->IsParentFolder())

--- a/xbmc/video/windows/GUIWindowVideoNav.h
+++ b/xbmc/video/windows/GUIWindowVideoNav.h
@@ -48,7 +48,6 @@ protected:
   bool GetDirectory(const std::string &strDirectory, CFileItemList &items) override;
   void UpdateButtons() override;
   void DoSearch(const std::string& strSearch, CFileItemList& items) override;
-  virtual void PlayItem(int iItem);
   void OnDeleteItem(const CFileItemPtr& pItem) override;
   void GetContextButtons(int itemNumber, CContextButtons &buttons) override;
   bool OnPopupMenu(int iItem) override;


### PR DESCRIPTION
Three commits:

* First commit removes the hack to patch the video database entry for a non-default movie version to become the default version right before playback start and to revert that patch right after playback start was triggered. Correct data will now be obtained from database on demand, without any patch of the database. Still not a masterpiece of software (because still special handling for video versions is needed), but far better than the original hack, imo.
* Second commit is just removal of dead code.
* Third commit fixes duplicate video version select dialogs presented on certain actions in the Video window. Wrong item was handed over to the application.

Runtime-tested on macOS, latest Kodi master, no regressions found.

@enen92 you know quite a bit about this code, so best reviewed by you. Please review commit by commit.