### PR TITLE
[VideoDB] fix movie title index creation and version bump

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -289,7 +289,7 @@ void CVideoDatabase::CreateAnalytics()
 
   m_pDS->exec("CREATE INDEX ix_videoversion ON videoversion (idMedia, mediaType(20))");
 
-  m_pDS->exec(PrepareSQL("CREATE INDEX ix_movie_title ON movie (c%02d)", VIDEODB_ID_TITLE));
+  m_pDS->exec(PrepareSQL("CREATE INDEX ix_movie_title ON movie (c%02d(255))", VIDEODB_ID_TITLE));
 
   CreateLinkIndex("tag");
   CreateForeignLinkIndex("director", "actor");
@@ -6162,13 +6162,11 @@ void CVideoDatabase::UpdateTables(int iVersion)
         "INSERT INTO videoversion SELECT idFile, idMovie, 'movie', '%i', '%i' FROM movie",
         VideoVersionItemType::PRIMARY, VIDEO_VERSION_ID_DEFAULT));
   }
-
-  // Version 124: add index to videoversion
 }
 
 int CVideoDatabase::GetSchemaVersion() const
 {
-  return 124;
+  return 125;
 }
 
 bool CVideoDatabase::LookupByFolders(const std::string &path, bool shows)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Video database bump missed in PR #24157
Index won't be created until next version bump otherwise.

Removed comment I added in other PR in error, looks like we don't account for every version in `UpdateTables()`.

MySQL / MariaDB wants a number of characters specified for text field indexes, 
From Mysql doc::

```
For string columns, indexes can be created that use only the leading part of column values, using col_name(length) syntax to specify an index prefix length
* Prefixes must be specified for BLOB and TEXT key parts
```
30 chars should be plenty to disambiguate most titles? The more characters => the larger index, with diminishing returns.

## How has this been tested?
Sqlite: ran on existing db to confim creation of new db version including the index. New db created fine.

Mysql / MariaDB: not available, would like feedback.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
