### PR TITLE
[Windows] Fix chroma upsampling for AMD dxva processor and 10 bit output of SDR sources

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.cpp
@@ -683,6 +683,15 @@ ProcessorConversions CEnumeratorHD::LogAndListConversions(
     return {};
   }
 
+  std::vector<DXGI_FORMAT> RenderingOutputFormats = {DXGI_FORMAT_B8G8R8A8_UNORM};
+
+  // The AMD dxva processor of the GCN architecture has low chroma upsampling quality
+  // (nearest neighbor) from YCbCr SDR color primaries to 10 bit RGB. Transfer function doesn't matter.
+  // > Blacklist 10 bit output. Float output (not used at this point) has the same problem.
+
+  if (!DX::DeviceResources::Get()->IsGCNOrOlder() || inputArgs.primaries == AVCOL_PRI_BT2020)
+    RenderingOutputFormats.push_back(DXGI_FORMAT_R10G10B10A2_UNORM);
+
   return ListConversions(m_input_dxgi_format, std::vector<DXGI_COLOR_SPACE_TYPE>{inputCS},
                          RenderingOutputFormats, std::vector<DXGI_COLOR_SPACE_TYPE>{outputCS});
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
@@ -113,9 +113,6 @@ struct ProcessorConversion
 
 using ProcessorConversions = std::vector<ProcessorConversion>;
 
-const std::vector<DXGI_FORMAT> RenderingOutputFormats = {DXGI_FORMAT_B8G8R8A8_UNORM,
-                                                         DXGI_FORMAT_R10G10B10A2_UNORM};
-
 struct SupportedConversionsArgs
 {
   AVColorPrimaries m_colorPrimaries{AVCOL_PRI_UNSPECIFIED};

--- a/xbmc/platform/win32/WIN32Util.cpp
+++ b/xbmc/platform/win32/WIN32Util.cpp
@@ -30,6 +30,7 @@
 #ifdef TARGET_WINDOWS_DESKTOP
 #include <cassert>
 #endif
+#include <array>
 #include <locale.h>
 
 #include <shellapi.h>
@@ -1747,4 +1748,37 @@ bool CWIN32Util::SetThreadName(const HANDLE handle, const std::string& name)
     return false;
 
 #endif
+}
+
+static std::array<int, 4> ParseVideoDriverInfo(const std::string& version)
+{
+  std::array<int, 4> result{};
+
+  // the string is destroyed in the process, make a copy first.
+  std::string v{version};
+
+  char* p = std::strtok(v.data(), ".");
+  for (int idx = 0; p && idx < 4; ++idx)
+  {
+    result[idx] = std::stoi(p);
+    p = std::strtok(NULL, ".");
+  }
+
+  return result;
+}
+
+bool CWIN32Util::IsDriverVersionAtLeast(const std::string& version1, const std::string& version2)
+{
+  const std::array<int, 4> v1 = ParseVideoDriverInfo(version1);
+  const std::array<int, 4> v2 = ParseVideoDriverInfo(version2);
+
+  for (int idx = 0; idx < 4; ++idx)
+  {
+    if (v1[idx] > v2[idx])
+      return true;
+    else if (v1[idx] < v2[idx])
+      return false;
+    // equality: compare the next segment.
+  }
+  return true;
 }

--- a/xbmc/platform/win32/WIN32Util.h
+++ b/xbmc/platform/win32/WIN32Util.h
@@ -91,4 +91,12 @@ public:
    * \return true if the name was successfully set, false otherwise (API not supported or API failure)
    */
   static bool SetThreadName(const HANDLE handle, const std::string& name);
+  /*!
+   * \brief Compare two Windows driver versions (xx.xx.xx.xx string format)
+   * \param version1 First version to compare
+   * \param version2 Second version to compare
+   * \return true when version1 is greater or equal to version2.
+   * Undefined results when the strings are not formatted properly.
+  */
+  static bool IsDriverVersionAtLeast(const std::string& version1, const std::string& version2);
 };

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -1204,7 +1204,7 @@ VideoDriverInfo DX::DeviceResources::GetVideoDriverVersion()
 {
   const DXGI_ADAPTER_DESC ad = GetAdapterDesc();
 
-  VideoDriverInfo driver = CWIN32Util::GetVideoDriverInfo(ad.VendorId, ad.Description);
+  const VideoDriverInfo driver = CWIN32Util::GetVideoDriverInfo(ad.VendorId, ad.Description);
 
   if (ad.VendorId == PCIV_NVIDIA)
     CLog::LogF(LOGINFO, "video driver version is {} {}.{} ({})", GetGFXProviderName(ad.VendorId),

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -1484,3 +1484,21 @@ bool DX::DeviceResources::SetMultithreadProtected(bool enabled) const
 
   return (wasEnabled == TRUE ? true : false);
 }
+
+bool DX::DeviceResources::IsGCNOrOlder() const
+{
+  if (CSysInfo::GetWindowsDeviceFamily() == CSysInfo::Xbox)
+    return false;
+
+  const DXGI_ADAPTER_DESC ad = GetAdapterDesc();
+
+  if (ad.VendorId != PCIV_AMD)
+    return false;
+
+  const VideoDriverInfo driver = CWIN32Util::GetVideoDriverInfo(ad.VendorId, ad.Description);
+
+  if (driver.valid && CWIN32Util::IsDriverVersionAtLeast(driver.version, "31.0.22000.0"))
+    return false;
+
+  return true;
+}

--- a/xbmc/rendering/dx/DeviceResources.h
+++ b/xbmc/rendering/dx/DeviceResources.h
@@ -128,6 +128,7 @@ namespace DX
     DEBUG_INFO_RENDER GetDebugInfo() const;
     std::vector<DXGI_COLOR_SPACE_TYPE> GetSwapChainColorSpaces() const;
     bool SetMultithreadProtected(bool enabled) const;
+    bool IsGCNOrOlder() const;
 
   private:
     class CBackBuffer : public CD3DTexture


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

The quality of chroma upsampling is problematic with the AMD dxva processor for certain combinations.

8/10 bit YCbCr SDR to 10 bit RGB: OK luma, low quality chroma upsampling (point)
8/10 bit YCbCr SDR to 8 bit RGB: OK
10 bit YCbCr HDR/HLG to 8/10 SDR or HDR: OK
(using the latest driver 23.11.1 / 31.0.21905.1001)

Solution: force 8 bit output of the processor for SDR source.
Done with a change of the rules selecting the format of the intermediate target.

No such problem found with Intel and NVIDIA.

For future reference (float/linear not used yet in Kodi)
8 bit YCbCr SDR to float/linear RGB: bad, point luma and chroma
10 bit YCbCr SDR or HDR to float/linear RGB: OK

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Triggered by investigation of chroma issues with pixel shaders and software render methods, prompted by #21850.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 8 and 10, x64 and UWP versions. Intel 4th, 8th, 13th gen, AMD, NVIDIA.
1080p, 720p, 640x380 videos with sharp red characters or logos. codec doesn't matter.
8 bit and 10 bit sources.

[8 bit sample](https://github.com/xbmc/xbmc/assets/489377/dd90f6b3-baa5-4d62-a595-b8988dcbbe72) [10 bit sample](https://github.com/xbmc/xbmc/assets/489377/1aa5eed7-566f-47b7-b1a7-00e18a8819d7)
Zoom 2x to see the impact on chroma very easily.

Not tested on xbox, equipped with an AMD gpu. Not sure that it has the issue in the first place.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Better picture quality with the dxva render method on AMD for SDR material (used by default with hardware decoding)

## Screenshots (if appropriate):
Using the example of the issue, current master:
![image](https://github.com/xbmc/xbmc/assets/489377/ed519e42-3ce3-40e1-a456-f5270eae3a20)

with PR:
![image](https://github.com/xbmc/xbmc/assets/489377/e78c5bd5-de1b-4b99-9c00-abef4d71cb5a)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed