### PR TITLE
[GUI] Fix focus behaviour when scrolling to the bottom of the panel

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -153,7 +153,7 @@ protected:
   bool m_layoutCondition = false;
   bool m_focusedLayoutCondition = false;
 
-  void ScrollToOffset(int offset);
+  virtual void ScrollToOffset(int offset);
   void SetContainerMoving(int direction);
   void UpdateScrollOffset(unsigned int currentTime);
 

--- a/xbmc/guilib/GUIPanelContainer.cpp
+++ b/xbmc/guilib/GUIPanelContainer.cpp
@@ -399,9 +399,18 @@ void CGUIPanelContainer::ValidateOffset()
 
 void CGUIPanelContainer::SetCursor(int cursor)
 {
+  // exceeds the number of items the panel can hold
   if (cursor > m_itemsPerPage * m_itemsPerRow - 1)
     cursor = m_itemsPerPage * m_itemsPerRow - 1;
-  if (cursor < 0) cursor = 0;
+
+  // exceeds the number of items being displayed
+  const int itemsOn = m_items.size() - 1 - GetOffset() * m_itemsPerRow;
+  if (cursor > itemsOn)
+    cursor = itemsOn;
+
+  if (cursor < 0)
+    cursor = 0;
+
   if (!m_wasReset)
     SetContainerMoving(cursor - GetCursor());
   CGUIBaseContainer::SetCursor(cursor);

--- a/xbmc/guilib/GUIPanelContainer.cpp
+++ b/xbmc/guilib/GUIPanelContainer.cpp
@@ -574,3 +574,8 @@ bool CGUIPanelContainer::HasNextPage() const
   return (GetOffset() != (int)GetRows() - m_itemsPerPage && (int)GetRows() > m_itemsPerPage);
 }
 
+void CGUIPanelContainer::ScrollToOffset(int offset)
+{
+  CGUIBaseContainer::ScrollToOffset(offset);
+  SetCursor(GetCursor());
+}

--- a/xbmc/guilib/GUIPanelContainer.h
+++ b/xbmc/guilib/GUIPanelContainer.h
@@ -53,6 +53,7 @@ protected:
   void SelectItem(int item) override;
   bool HasPreviousPage() const override;
   bool HasNextPage() const override;
+  void ScrollToOffset(int offset) override;
 
   int GetCurrentRow() const;
   int GetCurrentColumn() const;


### PR DESCRIPTION
## Description
As described in the issue #15626 if you scroll to the bottom of the panel using the scroll bar and there is no item near the focus, an item from the top row is selected. Displays the info for an item that is not on the screen.

This issue can also be reproduced by pointing the mouse at the bottom where there are no elements.

I propose to solve this by preventing the cursor from taking values that exceed the number of items being displayed. In these cases the cursor will be positioned on the last item.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
