### PR TITLE
Fix potential segfault when missing "layoutList" element

### DIFF
--- a/xbmc/platform/linux/input/LibInputSettings.cpp
+++ b/xbmc/platform/linux/input/LibInputSettings.cpp
@@ -88,8 +88,8 @@ CLibInputSettings::CLibInputSettings(CLibInputHandler *handler) :
   const auto* layoutListElement = rootElement->FirstChildElement("layoutList");
   if (!layoutListElement)
   {
-    CLog::Log(LOGWARNING, "CLibInputSettings: unexpected XML child element {} in: {}",
-              layoutListElement->Value(), xkbFile);
+    CLog::Log(LOGWARNING, "CLibInputSettings: missing XML child element {} in: {}", "layoutList",
+              xkbFile);
     return;
   }
 


### PR DESCRIPTION
## Description

When building Kodi, I noticed an error about `layoutListElement` always being null. Looks like if a "layoutList" element is missing, we'll segfault.

## Motivation and context

Fix a possible segfault likely introduced in https://github.com/xbmc/xbmc/pull/14341.

## How has this been tested?

Before, generated the following warning:

```
LibInputSettings.cpp: In constructor ‘CLibInputSettings::CLibInputSettings(CLibInputHandler*)’:
LibInputSettings.cpp:92:39: warning: ‘this’ pointer is null [-Wnonnull]
   92 |               layoutListElement->Value(), xkbFile);
      |               ~~~~~~~~~~~~~~~~~~~~~~~~^~
```

After, compiles without generating a warning:

```
[ 93%] Building CXX object build/platform/linux/input/CMakeFiles/input_linux.dir/LibInputSettings.cpp.o
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
