### PR TITLE
Fix edge case when downloading subtitles for http(s) streams

### DIFF
--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -548,7 +548,7 @@ void CGUIDialogSubtitles::OnDownloadComplete(const CFileItemList *items, const s
   std::vector<std::string> vecFiles;
 
   std::string strCurrentFilePath;
-  if (StringUtils::StartsWith(strCurrentFilePath, "http://"))
+  if (StringUtils::StartsWith(strCurrentFile, "http://") || StringUtils::StartsWith(strCurrentFile, "https://"))
   {
     strCurrentFile = "TempSubtitle";
     vecFiles.push_back(strCurrentFile);

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -548,7 +548,7 @@ void CGUIDialogSubtitles::OnDownloadComplete(const CFileItemList *items, const s
   std::vector<std::string> vecFiles;
 
   std::string strCurrentFilePath;
-  if (StringUtils::StartsWith(strCurrentFile, "http://") || StringUtils::StartsWith(strCurrentFile, "https://"))
+  if (URIUtils::IsHTTP(strCurrentFile))
   {
     strCurrentFile = "TempSubtitle";
     vecFiles.push_back(strCurrentFile);


### PR DESCRIPTION
## Description
This PR resolves a bug in the `CGUIDialogSubtitles` class. The issue was due to an incomplete conditional check where `strCurrentFilePath` was referenced before being set, leading to the failure of the subtitle download in some edge cases.

## Motivation and context
This fixes the subtitles downloads in cases where the URL decoded file name of the stream is not a valid file name in the OS's file system. For example a URL such as `http://localhost/http%3A%2F%2Fexample.com%2Fvideo.mp4` will currently lead Kodi to try to save the subtitles as `http://example.com/video.srt`, which is obviously not a valid file name in most OSs.

I also added `https` to the if condition that was previously only checking for `http`.

## How has this been tested?
I noticed this issue in an addon that uses URLs with a pattern similar to the example above. After applying this change, the download of subtitles now works as expected.

## What is the effect on users?
It makes subtitles downloads work for the scenario described above.

## Screenshots (if appropriate):
N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
