### PR TITLE
[video] CVideoInfoTag: Remove CVideoDataBase dependency. 

### DIFF
--- a/xbmc/video/CMakeLists.txt
+++ b/xbmc/video/CMakeLists.txt
@@ -36,6 +36,7 @@ set(HEADERS Bookmark.h
             VideoLibraryQueue.h
             VideoThumbLoader.h
             VideoUtils.h
+            VideoVersionTypes.h
             ViewModeSettings.h)
 
 core_add_library(video)

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -54,7 +54,8 @@
 #include "video/VideoDbUrl.h"
 #include "video/VideoInfoTag.h"
 #include "video/VideoLibraryQueue.h"
-#include "video/windows/GUIWindowVideoBase.h"
+#include "video/VideoThumbLoader.h"
+#include "video/VideoVersionTypes.h"
 
 #include <algorithm>
 #include <map>
@@ -11778,25 +11779,6 @@ int CVideoDatabase::AddVideoVersionType(const std::string& typeVideoVersion,
   return id;
 }
 
-bool CVideoDatabase::IsVideoExtras(int dbId)
-{
-  if (!m_pDB || !m_pDS)
-    return false;
-
-  try
-  {
-    return static_cast<VideoVersionItemType>(GetSingleValueInt(
-               PrepareSQL("SELECT itemType FROM videoversion WHERE idFile = %i", dbId))) ==
-           VideoVersionItemType::EXTRAS;
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "{} failed for {} {}", __FUNCTION__, dbId);
-  }
-
-  return false;
-}
-
 void CVideoDatabase::GetVideoVersions(VideoDbContentType itemType, int dbId, CFileItemList& items)
 {
   // get main video versions
@@ -11865,6 +11847,7 @@ void CVideoDatabase::GetVideoVersions(VideoDbContentType itemType,
         infoTag.m_idVideoVersion = id;
         infoTag.m_typeVideoVersion = name;
         infoTag.m_strTitle = name;
+        infoTag.m_videoVersionItemType = versionItemType;
 
         infoTag.m_strPictureURL = videoItem.GetVideoInfoTag()->m_strPictureURL;
         infoTag.m_fanart = videoItem.GetVideoInfoTag()->m_fanart;
@@ -11908,7 +11891,8 @@ void CVideoDatabase::GetDefaultVideoVersion(VideoDbContentType itemType, int dbI
     mediaType = MediaTypeMovie;
     strSQL = PrepareSQL("SELECT videoversiontype.name AS name,"
                         "  videoversiontype.id AS id,"
-                        "  videoversion.idFile AS idFile "
+                        "  videoversion.idFile AS idFile,"
+                        "  videoversion.itemType AS itemType "
                         "FROM videoversiontype"
                         "  JOIN videoversion ON"
                         "    videoversion.idType = videoversiontype.id"
@@ -11929,7 +11913,8 @@ void CVideoDatabase::GetDefaultVideoVersion(VideoDbContentType itemType, int dbI
       std::string name = m_pDS->fv("name").get_asString();
       int id = m_pDS->fv("id").get_asInt();
       int idFile = m_pDS->fv("idFile").get_asInt();
-
+      const auto versionItemType{
+          static_cast<VideoVersionItemType>(m_pDS->fv("itemType").get_asInt())};
       CVideoInfoTag infoTag;
       if (GetFileInfo("", infoTag, idFile))
       {
@@ -11938,6 +11923,7 @@ void CVideoDatabase::GetDefaultVideoVersion(VideoDbContentType itemType, int dbI
         infoTag.m_idVideoVersion = id;
         infoTag.m_typeVideoVersion = name;
         infoTag.m_strTitle = name;
+        infoTag.m_videoVersionItemType = versionItemType;
 
         item.SetFromVideoInfoTag(infoTag);
         item.m_strTitle = name;

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -26,6 +26,9 @@ class CVideoSettings;
 class CGUIDialogProgress;
 class CGUIDialogProgressBarHandle;
 
+enum class VideoVersionTypeOwner;
+enum class VideoVersionItemType;
+
 namespace dbiplus
 {
   class field_value;
@@ -392,27 +395,6 @@ const struct SDbTableOffsets DbMusicVideoOffsets[] =
 
 #define COMPARE_PERCENTAGE     0.90f // 90%
 #define COMPARE_PERCENTAGE_MIN 0.50f // 50%
-
-// Video Versions
-enum class VideoVersionTypeOwner
-{
-  UNKNOWN = -1,
-  SYSTEM = 0,
-  AUTO = 1,
-  USER = 2
-};
-
-enum class VideoVersionItemType
-{
-  UNKNOWN = -1,
-  PRIMARY = 0,
-  EXTRAS = 1
-};
-
-static constexpr int VIDEO_VERSION_ID_BEGIN = 40400;
-static constexpr int VIDEO_VERSION_ID_END = 40800;
-static constexpr int VIDEO_VERSION_ID_DEFAULT = VIDEO_VERSION_ID_BEGIN;
-static constexpr int VIDEO_VERSION_ID_ALL = 0;
 
 class CVideoDatabase : public CDatabase
 {
@@ -1014,7 +996,6 @@ public:
   std::string GetVideoVersionById(int id);
   bool GetVideoItemByVideoVersion(int dbId, CFileItem& item);
   int GetVideoVersionFile(VideoDbContentType itemType, int dbId, int idVideoVersion);
-  bool IsVideoExtras(int dbId);
   void GetVideoVersions(VideoDbContentType itemType, int dbId, CFileItemList& items);
   void GetVideoVersions(VideoDbContentType itemType,
                         int dbId,

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -43,6 +43,7 @@
 #include "utils/Variant.h"
 #include "utils/log.h"
 #include "video/VideoThumbLoader.h"
+#include "video/VideoVersionTypes.h"
 #include "video/dialogs/GUIDialogVideoVersion.h"
 
 #include <algorithm>

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -24,6 +24,8 @@ class TiXmlNode;
 class TiXmlElement;
 class CVariant;
 
+enum class VideoVersionItemType;
+
 struct SActorInfo
 {
   bool operator<(const SActorInfo &right) const
@@ -245,6 +247,7 @@ public:
   std::string m_typeVideoVersion;
   int m_idVideoVersion{-1};
   bool m_hasVideoVersions{false};
+  VideoVersionItemType m_videoVersionItemType{-1};
   std::string m_strFile;
   std::string m_strPath;
   std::string m_strMPAARating;

--- a/xbmc/video/VideoVersionTypes.h
+++ b/xbmc/video/VideoVersionTypes.h
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+enum class VideoVersionTypeOwner
+{
+  UNKNOWN = -1,
+  SYSTEM = 0,
+  AUTO = 1,
+  USER = 2
+};
+
+enum class VideoVersionItemType
+{
+  UNKNOWN = -1,
+  PRIMARY = 0,
+  EXTRAS = 1
+};
+
+static constexpr int VIDEO_VERSION_ID_BEGIN = 40400;
+static constexpr int VIDEO_VERSION_ID_END = 40800;
+static constexpr int VIDEO_VERSION_ID_DEFAULT = VIDEO_VERSION_ID_BEGIN;
+static constexpr int VIDEO_VERSION_ID_ALL = 0;

--- a/xbmc/video/dialogs/GUIDialogVideoVersion.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoVersion.cpp
@@ -39,6 +39,7 @@
 #include "video/VideoInfoTag.h"
 #include "video/VideoThumbLoader.h"
 #include "video/VideoUtils.h"
+#include "video/VideoVersionTypes.h"
 #include "video/dialogs/GUIDialogVideoInfo.h"
 #include "video/guilib/VideoPlayActionProcessor.h"
 

--- a/xbmc/video/guilib/VideoVersionHelper.cpp
+++ b/xbmc/video/guilib/VideoVersionHelper.cpp
@@ -21,6 +21,7 @@
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
 #include "video/VideoThumbLoader.h"
+#include "video/VideoVersionTypes.h"
 
 using namespace VIDEO::GUILIB;
 

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -56,6 +56,7 @@
 #include "video/VideoInfoScanner.h"
 #include "video/VideoLibraryQueue.h"
 #include "video/VideoUtils.h"
+#include "video/VideoVersionTypes.h"
 #include "video/dialogs/GUIDialogVideoInfo.h"
 #include "video/guilib/VideoPlayActionProcessor.h"
 #include "video/guilib/VideoSelectActionProcessor.h"


### PR DESCRIPTION
Improves per…formance of ListItem.IsVideoExtras GUI label implementation drastically, because no more db lookup needed.

<img width="768" alt="Screenshot 2023-12-16 at 23 48 19" src="https://github.com/xbmc/xbmc/assets/3226626/aca75925-6341-4012-bd47-b31900c04bb1">

Runtime-tested on macOS, latest Kodi master.

@enen92 whenever you find some time for a review.
