### PR TITLE
[UPnP] Fix playback restore after pause

### DIFF
--- a/xbmc/network/upnp/UPnPPlayer.h
+++ b/xbmc/network/upnp/UPnPPlayer.h
@@ -36,8 +36,8 @@ public:
   bool CloseFile(bool reopen = false) override;
   bool IsPlaying() const override;
   void Pause() override;
-  bool HasVideo() const override { return false; }
-  bool HasAudio() const override { return false; }
+  bool HasVideo() const override { return true; }
+  bool HasAudio() const override { return true; }
   void Seek(bool bPlus, bool bLargeStep, bool bChapterOverride) override;
   void SeekPercentage(float fPercent = 0) override;
   void SetVolume(float volume) override;


### PR DESCRIPTION
## Description
If playback is restored (e.g. via a set speed call to 1.0f) after being paused the upnp player does nothing. Kodi, acting as the upnp player, is left paused regardless of the call to play. This happens because setspeed in not implemented.
Furthermore if the playback is controlled from the target player (e.g. pause on the tv player) the state is not being synchronized to Kodi.
I plan to move the UPnP Player to a Thread implementation similar to other players but for the time being lets keep it in `DoAudioWork()` which is the application loop equivalent to Process in case it's moved to a new thread.