### PR TITLE
[tvOS] Fix binary addons (PVR) multi instance settings reset

### DIFF
--- a/xbmc/platform/darwin/tvos/TVOSNSUserDefaults.mm
+++ b/xbmc/platform/darwin/tvos/TVOSNSUserDefaults.mm
@@ -67,19 +67,10 @@ bool CTVOSNSUserDefaults::Synchronize()
 void CTVOSNSUserDefaults::GetDirectoryContents(const std::string& path,
                                                std::vector<std::string>& contents)
 {
-  // tvos path adds /private/../..
-  // We need to strip this as GetUserHomeDirectory() doesnt have private in the path
-  std::string subpath = path;
-  const std::string& str_private = "/private";
-  size_t pos = subpath.find(str_private.c_str(), 0, str_private.length());
-
-  if (pos != std::string::npos)
-    subpath.erase(pos, str_private.length());
-
   std::string userDataDir =
       URIUtils::AddFileToFolder(CTVOSFileUtils::GetUserHomeDirectory(), "userdata");
 
-  if (subpath.find(userDataDir) == std::string::npos)
+  if (path.find(userDataDir) == std::string::npos)
     return;
 
   NSDictionary<NSString*, id>* dict =
@@ -94,7 +85,7 @@ void CTVOSNSUserDefaults::GetDirectoryContents(const std::string& path,
     std::string fullKeyPath =
         URIUtils::AddFileToFolder(CTVOSFileUtils::GetUserHomeDirectory(), keypath);
     std::string endingDirectory = URIUtils::GetDirectory(fullKeyPath);
-    if (subpath == endingDirectory)
+    if (path == endingDirectory)
     {
       contents.push_back(fullKeyPath);
     }

--- a/xbmc/platform/darwin/tvos/filesystem/TVOSFileUtils.mm
+++ b/xbmc/platform/darwin/tvos/filesystem/TVOSFileUtils.mm
@@ -35,6 +35,7 @@ const char* CTVOSFileUtils::GetOSCachesDirectory()
   std::call_once(cache_flag, [] {
     NSString* cachePath =
         NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES).lastObject;
+    cachePath = [@"/private" stringByAppendingString:cachePath];
     cacheFolder = cachePath.UTF8String;
     URIUtils::RemoveSlashAtEnd(cacheFolder);
   });


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

The goal of this PR is to fix the bug reported in https://forum.kodi.tv/showthread.php?tid=373609 thread.

To summarize the bug, since Kodi version 20.0 beta1 and the introduction of binary add-on multi instance feature, all tvOS user are not able to save PVR settings anymore (in my case I encounter the bug with TVHeadend PVR client).

@emveepee pointed the finger on the right direction about this issue by proposing a patch here https://forum.kodi.tv/showthread.php?tid=373609&pid=3171570#pid3171570. Thanks to him.

I also investigated on my side and it seems that Kodi (on Apple TV of course) mixing paths with and without the `/private` prefix.
In reality the `getenv("HOME")` call at beginning of the runtime of Kodi returns a path with `/private` prefix while `CTVOSFileUtils::GetOSCachesDirectory()` functions returns a path without this prefix.
This cause some issue in the DirectoryCache system because some directories are registered with this prefix and other without, causing some file existence check to fail.
This is the issue with the multi instance PVR addons, they are not able to find the existing XML setting file because the Directorycache system thinks this file does not exist despite it really exists...

The patch proposed by emveepee should works, but my proposal fix is to use the `/private` prefix everywhere in Kodi to avoid any confusion or complexity.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix multi instance PVR addons usage for tvOS users.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Runtime tested on my device.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Users will be able to have persistent settings for PVR clients.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
