### PR TITLE
[UPnP] Move Player to its own thread

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -3177,9 +3177,6 @@ void CApplication::Process()
   CServiceBroker::GetAppMessenger()->ProcessMessages();
   if (m_bStop) return; //we're done, everything has been unloaded
 
-  // update sound
-  GetComponent<CApplicationPlayer>()->DoAudioWork();
-
   // do any processing that isn't needed on each run
   if( m_slowTimer.GetElapsedMilliseconds() > 500 )
   {

--- a/xbmc/application/ApplicationPlayer.cpp
+++ b/xbmc/application/ApplicationPlayer.cpp
@@ -544,13 +544,6 @@ void CApplicationPlayer::FrameAdvance(int frames)
     player->FrameAdvance(frames);
 }
 
-void CApplicationPlayer::DoAudioWork()
-{
-  std::shared_ptr<IPlayer> player = GetInternal();
-  if (player)
-    player->DoAudioWork();
-}
-
 std::string CApplicationPlayer::GetPlayerState()
 {
   std::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/application/ApplicationPlayer.h
+++ b/xbmc/application/ApplicationPlayer.h
@@ -74,7 +74,6 @@ public:
   void AddSubtitle(const std::string& strSubPath);
   bool CanPause() const;
   bool CanSeek() const;
-  void DoAudioWork();
   int GetAudioDelay() const;
   void GetAudioCapabilities(std::vector<int>& audioCaps) const;
   int GetAudioStream();

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.h
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.h
@@ -44,7 +44,6 @@ public:
 
   void SeekTime(int64_t iTime) override;
   void SetSpeed(float speed) override;
-  void DoAudioWork() override {}
 
   bool SetPlayerState(const std::string& state) override;
 

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -204,7 +204,6 @@ public:
   */
   virtual MenuType GetSupportedMenuType() const { return MenuType::NONE; }
 
-  virtual void DoAudioWork() {}
   virtual bool OnAction(const CAction& action) { return false; }
 
   //returns a state that is needed for resuming from a specific time

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -171,7 +171,8 @@ private:
 
 CUPnPPlayer::CUPnPPlayer(IPlayerCallback& callback, const char* uuid)
   : IPlayer(callback),
-    m_control(NULL),
+    CThread("UPnPPlayer"),
+    m_control(nullptr),
     m_logger(CServiceBroker::GetLogging().GetLogger(StringUtils::Format("CUPnPPlayer[{}]", uuid)))
 {
   m_control  = CUPnP::GetInstance()->m_MediaController;
@@ -370,6 +371,9 @@ bool CUPnPPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options)
   else
     NPT_CHECK_LABEL_SEVERE(PlayFile(file, options, timeout), failed);
 
+  if (!IsRunning())
+    Create();
+
   m_stopremote = true;
   m_started = true;
   m_callback.OnPlayBackStarted(file);
@@ -442,7 +446,7 @@ bool CUPnPPlayer::CloseFile(bool reopen)
     m_started = false;
     m_callback.OnPlayBackStopped();
   }
-
+  StopThread(true);
   return true;
 failed:
   m_logger->error("CloseFile - unable to stop playback");
@@ -505,49 +509,53 @@ void CUPnPPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
 {
 }
 
-void CUPnPPlayer::DoAudioWork()
+void CUPnPPlayer::Process()
 {
-  NPT_CHECK_POINTER_LABEL_SEVERE(m_delegate, failed);
-  m_delegate->UpdatePositionInfo();
+  while (!m_bStop)
+  {
+    NPT_CHECK_POINTER_LABEL_SEVERE(m_delegate, failed);
+    m_delegate->UpdatePositionInfo();
 
-  if(m_started) {
     NPT_String uri, meta;
     NPT_CHECK_LABEL(m_delegate->m_transport->GetStateVariableValue("CurrentTrackURI", uri), failed);
-    NPT_CHECK_LABEL(m_delegate->m_transport->GetStateVariableValue("CurrentTrackMetadata", meta), failed);
+    NPT_CHECK_LABEL(m_delegate->m_transport->GetStateVariableValue("CurrentTrackMetadata", meta),
+                    failed);
 
-    if(m_current_uri  != (const char*)uri
-    || m_current_meta != (const char*)meta) {
-      m_current_uri  = (const char*)uri;
-      m_current_meta = (const char*)meta;
-      CFileItemPtr item = GetFileItem(uri, meta);
-      g_application.CurrentFileItem() = *item;
-      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_UPDATE_CURRENT_ITEM, 0, -1,
-                                                 static_cast<void*>(new CFileItem(*item)));
-    }
+    if (m_started)
+    {
+      if (m_current_uri != (const char*)uri || m_current_meta != (const char*)meta)
+      {
+        m_current_uri = (const char*)uri;
+        m_current_meta = (const char*)meta;
+        const std::shared_ptr<CFileItem> item = GetFileItem(uri, meta);
+        g_application.CurrentFileItem() = *item;
+        CServiceBroker::GetAppMessenger()->PostMsg(TMSG_UPDATE_CURRENT_ITEM, 0, -1,
+                                                   static_cast<void*>(new CFileItem(*item)));
+      }
 
-    // Player may be paused or resumed from the target player, state needs to be synchronized to data cache core.
-    CDataCacheCore& dataCacheCore = CDataCacheCore::GetInstance();
-    if (IsPaused() && dataCacheCore.GetSpeed() > 0.0f)
-    {
-      m_callback.OnPlayBackPaused();
-      dataCacheCore.SetSpeed(1.0, 0.0);
-    }
-    else if (!IsPaused() && dataCacheCore.GetSpeed() == 0.0f)
-    {
-      m_callback.OnPlayBackResumed();
-      dataCacheCore.SetSpeed(1.0, 1.0);
-    }
+      // Player may be paused or resumed from the target player, state needs to be synchronized to data cache core.
+      CDataCacheCore& dataCacheCore = CDataCacheCore::GetInstance();
+      if (IsPaused() && dataCacheCore.GetSpeed() > 0.0f)
+      {
+        m_callback.OnPlayBackPaused();
+        dataCacheCore.SetSpeed(1.0, 0.0);
+      }
+      else if (!IsPaused() && dataCacheCore.GetSpeed() == 0.0f)
+      {
+        m_callback.OnPlayBackResumed();
+        dataCacheCore.SetSpeed(1.0, 1.0);
+      }
 
-    if (m_delegate->GetTransportState() == "STOPPED")
-    {
-      m_logger->info("Transport state flagged as STOPPED. Triggering OnPlayBackEnded.");
-      m_started = false;
-      m_callback.OnPlayBackEnded();
+      if (m_delegate->GetTransportState() == "STOPPED")
+      {
+        m_logger->info("Transport state flagged as STOPPED. Triggering OnPlayBackEnded.");
+        m_started = false;
+        m_callback.OnPlayBackEnded();
+      }
     }
   }
-  return;
 failed:
-  return;
+  CloseFile();
 }
 
 bool CUPnPPlayer::IsPlaying() const
@@ -633,6 +641,14 @@ void CUPnPPlayer::FrameMove()
   {
     CDataCacheCore::GetInstance().SetPlayTimes(0, GetTime(), 0, GetTotalTime());
     m_updateTimer.Set(500ms);
+  }
+}
+
+void CUPnPPlayer::OnExit()
+{
+  if (m_started)
+  {
+    m_callback.OnPlayBackEnded();
   }
 }
 

--- a/xbmc/network/upnp/UPnPPlayer.h
+++ b/xbmc/network/upnp/UPnPPlayer.h
@@ -10,7 +10,6 @@
 #pragma once
 
 #include "cores/IPlayer.h"
-#include "guilib/DispResource.h"
 #include "threads/SystemClock.h"
 #include "threads/Thread.h"
 #include "utils/logtypes.h"
@@ -25,7 +24,7 @@ namespace UPNP
 
 class CUPnPPlayerController;
 
-class CUPnPPlayer : public IPlayer, public CThread, public IRenderLoop
+class CUPnPPlayer : public IPlayer, public CThread
 {
 public:
   CUPnPPlayer(IPlayerCallback& callback, const char* uuid);
@@ -50,8 +49,6 @@ public:
   bool IsCaching() const override { return false; }
   int GetCacheLevel() const override { return -1; }
   bool OnAction(const CAction &action) override;
-
-  void FrameMove() override;
 
   int PlayFile(const CFileItem& file,
                const CPlayerOptions& options,

--- a/xbmc/network/upnp/UPnPPlayer.h
+++ b/xbmc/network/upnp/UPnPPlayer.h
@@ -12,6 +12,7 @@
 #include "cores/IPlayer.h"
 #include "guilib/DispResource.h"
 #include "threads/SystemClock.h"
+#include "threads/Thread.h"
 #include "utils/logtypes.h"
 
 #include <memory>
@@ -24,8 +25,7 @@ namespace UPNP
 
 class CUPnPPlayerController;
 
-class CUPnPPlayer
-  : public IPlayer, public IRenderLoop
+class CUPnPPlayer : public IPlayer, public CThread, public IRenderLoop
 {
 public:
   CUPnPPlayer(IPlayerCallback& callback, const char* uuid);
@@ -49,7 +49,6 @@ public:
 
   bool IsCaching() const override { return false; }
   int GetCacheLevel() const override { return -1; }
-  void DoAudioWork() override;
   bool OnAction(const CAction &action) override;
 
   void FrameMove() override;
@@ -63,6 +62,10 @@ private:
   int64_t GetTime();
   int64_t GetTotalTime();
   float GetPercentage();
+
+  // implementation of CThread
+  void Process() override;
+  void OnExit() override;
 
   PLT_MediaController* m_control;
   std::unique_ptr<CUPnPPlayerController> m_delegate;


### PR DESCRIPTION
## Description
With the recent decision to delay the release of Omega RC and the creation of a new Beta I thought this is probably something that can still go in. Currently the UPnP player is the only player that doesn't have its own thread. Hence, all the business logic that should take place in `Process` is being delegated to the application loop inside a call to `DoAudioWork` that only this player uses. Furthermore, the implementation of DoAudioWork has nothing to do with audio...
This moves it to its own thread, leading to the removal of the `DoAudioWork` player interface method globally.

## Motivation and context
Cleanup, improve consistency

## How has this been tested?
Runtime tested on Linux and android.

## What is the effect on users?
None hopefully.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
