### PR TITLE
[UPnP] Player: Add option to avoid volume synchronization to target

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23952,7 +23952,19 @@ msgctxt "#40211"
 msgid "Extras"
 msgstr ""
 
-#empty strings from id 40212 to 40399
+#. UPnP remote player volume level sync setting
+#: system/settings/settings.xml
+msgctxt "#40212"
+msgid "Synchronize volume level to remote UPnP players"
+msgstr ""
+
+#. Help string for UPnP remote player volume level sync setting
+#: system/settings/settings.xml
+msgctxt "#40213"
+msgid "If selected the remote player volume level will be synchronized with the volume of this application.[CR]Warning: Global system volume level may be different than the application volume level - they are controlled independently.[CR]This may lead the remote player to be set to 100% volume level if the application has 100% volume level but the overall system volume level is smaller."
+msgstr ""
+
+#empty strings from id 40214 to 40399
 
 # Video versions
 

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2320,6 +2320,18 @@
           </dependencies>
           <control type="toggle" />
         </setting>
+        <setting id="services.upnpplayervolumesync" type="boolean" parent="services.upnpserver" label="40212" help="40213">
+          <level>2</level>
+          <default>true</default>
+          <dependencies>
+            <dependency type="enable">
+              <and>
+                <condition setting="services.upnpcontroller" operator="is">true</condition>
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
         <setting id="services.upnprenderer" type="boolean" label="21881" help="36325">
           <level>1</level>
           <default>false</default>

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -21,6 +21,8 @@
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "music/MusicThumbLoader.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
 #include "threads/Event.h"
 #include "utils/StringUtils.h"
 #include "utils/TimeUtils.h"
@@ -553,6 +555,12 @@ failed:
 
 void CUPnPPlayer::SetVolume(float volume)
 {
+  if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+          CSettings::SETTING_SERVICES_UPNPPLAYERVOLUMESYNC))
+  {
+    return;
+  }
+
   NPT_CHECK_POINTER_LABEL_SEVERE(m_delegate, failed);
   NPT_CHECK_LABEL(m_control->SetVolume(m_delegate->m_device, m_delegate->m_instance, "Master",
                                        (int)(volume * 100), m_delegate.get()),

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -327,6 +327,7 @@ public:
   static constexpr auto SETTING_SERVICES_UPNPLOOKFOREXTERNALSUBTITLES =
       "services.upnplookforexternalsubtitles";
   static constexpr auto SETTING_SERVICES_UPNPCONTROLLER = "services.upnpcontroller";
+  static constexpr auto SETTING_SERVICES_UPNPPLAYERVOLUMESYNC = "services.upnpplayervolumesync";
   static constexpr auto SETTING_SERVICES_UPNPRENDERER = "services.upnprenderer";
   static constexpr auto SETTING_SERVICES_WEBSERVER = "services.webserver";
   static constexpr auto SETTING_SERVICES_WEBSERVERPORT = "services.webserverport";


### PR DESCRIPTION
## Description
When the UPnP player starts to play to a remote player it tries to synchronize Kodi volume with the target volume. The problem is that the Kodi volume is not representative of the system volume. For instance, you could have a global volume level of 50% on your phone while leaving the Kodi application volume at 100%. If the remote player is standalone (i.e. player volume == system volume) you might get to a situation where the target volume is set to max on the target player on startup.
I thought a lot about this and I don't think there is any other way around it. We could get the volume of the target player on playback startup and try to get the ratio against the Kodi volume but then controlling kodi volume won't give you the actual increment/decrement steps to act accordingly (not to mention the additional complexity).

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/24152 (or at least provide a workaround)

## How has this been tested?
Runtime tested with the setting enabled and disabled, checking the volume is not syncronized not controlled if the second is active.

## What is the effect on users?
Should now have a way of disabling target volume control and auto-sync for the UPnP player.

## Screenshots
![Screenshot from 2023-12-17 20-25-37](https://github.com/xbmc/xbmc/assets/7375276/7277c35e-7bf4-45cd-9fec-3b7c8a0449ca)
 (if appropriate):


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
