### PR TITLE
Fix compiler warning in BlurayCallback.cpp

### DIFF
--- a/xbmc/filesystem/BlurayCallback.cpp
+++ b/xbmc/filesystem/BlurayCallback.cpp
@@ -78,7 +78,7 @@ int CBlurayCallback::dir_read(BD_DIR_H *dir, BD_DIRENT *entry)
   if (state->curr >= state->list.Size())
     return 1;
 
-  strncpy(entry->d_name, state->list[state->curr]->GetLabel().c_str(), sizeof(entry->d_name));
+  strncpy(entry->d_name, state->list[state->curr]->GetLabel().c_str(), sizeof(entry->d_name) - 1);
   entry->d_name[sizeof(entry->d_name) - 1] = 0;
   state->curr++;
 


### PR DESCRIPTION
## Description

I hit another warning building my smarthome OS on my new RPi 4's. This one should be pretty straightforward.

## Motivation and context

Another warning (beside https://github.com/xbmc/xbmc/pull/24242) hit when rebuilding my smarthome OS on my new RPi 4's.

## How has this been tested?

Before, warning was:

```
In file included from BlurayCallback.cpp:11:
In function ‘char* strncpy(char*, const char*, size_t)’,
    inlined from ‘static int CBlurayCallback::dir_read(BD_DIR_H*, BD_DIRENT*)’ at BlurayCallback.cpp:81:10:

/usr/include/x86_64-linux-gnu/bits/string_fortified.h:95:34: warning: ‘char* __builtin_strncpy(char*, const char*, long unsigned int)’ specified bound 256 equals destination size [-Wstringop-truncation]

   95 |   return __builtin___strncpy_chk (__dest, __src, __len,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
   96 |                                   __glibc_objsize (__dest));
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~
```

After, build continues with no error:

```
[ 15%] Building CXX object build/filesystem/CMakeFiles/filesystem.dir/BlurayCallback.cpp.o
[ 15%] Linking CXX static library filesystem.a
```

## What is the effect on users?

* None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
