### PR TITLE
[info] Add Player.IsRemote and Player.IsExternal

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -381,7 +381,6 @@ const infomap integer_bools[] =  {{ "isequal",          INTEGER_IS_EQUAL },
                                   { "iseven",           INTEGER_EVEN },
                                   { "isodd",            INTEGER_ODD }};
 
-
 /// \page modules__infolabels_boolean_conditions
 /// \subsection modules__infolabels_boolean_conditions_Player Player
 /// \table_start
@@ -852,10 +851,28 @@ const infomap integer_bools[] =  {{ "isequal",          INTEGER_IS_EQUAL },
 ///     @skinning_v19 **[New Infolabel]** \link Player_Chapters `Player.Chapters`\endlink
 ///     <p>
 ///   }
+///   \table_row3{   <b>`Player.IsExternal`</b>,
+///                  \anchor Player_IsExternal
+///                  _boolean_,
+///     @return **True** if the playing player is an external player\, **False** otherwise
+///     <p><hr>
+///     @skinning_v21 **[New Boolean Condition]** \link Player_IsExternal `Player.IsExternal`\endlink
+///     <p>
+///   }
+///   \table_row3{   <b>`Player.IsRemote`</b>,
+///                  \anchor Player_IsRemote
+///                  _boolean_,
+///     @return **True** if the playing player is a remote player (e.g. UPnP)\, **False** otherwise
+///     <p><hr>
+///     @skinning_v21 **[New Boolean Condition]** \link Player_IsRemote `Player.IsRemote`\endlink
+///     <p>
+///   }
 const infomap player_labels[] = {{"hasmedia", PLAYER_HAS_MEDIA},
                                  {"hasaudio", PLAYER_HAS_AUDIO},
                                  {"hasvideo", PLAYER_HAS_VIDEO},
                                  {"hasgame", PLAYER_HAS_GAME},
+                                 {"isexternal", PLAYER_IS_EXTERNAL},
+                                 {"isremote", PLAYER_IS_REMOTE},
                                  {"playing", PLAYER_PLAYING},
                                  {"paused", PLAYER_PAUSED},
                                  {"rewinding", PLAYER_REWINDING},

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -83,6 +83,8 @@
 #define PLAYER_FILEPATH              82
 #define PLAYER_TITLE                 83
 #define PLAYER_FILENAME              84
+#define PLAYER_IS_REMOTE      85
+#define PLAYER_IS_EXTERNAL    86
 
 // Range of player infolabels that work with offset and position
 #define PLAYER_OFFSET_POSITION_FIRST PLAYER_PATH

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -427,6 +427,12 @@ bool CPlayerGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
     case PLAYER_HAS_GAME:
       value = m_appPlayer->IsPlayingGame();
       return true;
+    case PLAYER_IS_REMOTE:
+      value = m_appPlayer->IsRemotePlaying();
+      return true;
+    case PLAYER_IS_EXTERNAL:
+      value = m_appPlayer->IsExternalPlaying();
+      return true;
     case PLAYER_PLAYING:
       value = m_appPlayer->GetPlaySpeed() == 1.0f;
       return true;


### PR DESCRIPTION
## Description
This adds `Player.IsRemote` and `Player.IsExternal` to the info interface.

## Motivation and context
I need to know when a remote player is active so that the icon on the skin to toggle fullscreen opens the playercontrols dialog instead for remote control (same likely applies to external players too). The fullscreen window causes all sort of problems since the remote player is not exactly rendering to the current Kodi window.

## How has this been tested?
Untested but should work (TM)

## What is the effect on users?
None, at least for now.

