### PR TITLE
[Estuary] Hide next if conditions for next don't met

### DIFF
--- a/addons/skin.estuary/xml/Includes_MediaMenu.xml
+++ b/addons/skin.estuary/xml/Includes_MediaMenu.xml
@@ -239,6 +239,7 @@
 							<param name="control_id" value="14104" />
 							<param name="onclick" value="Next" />
 							<param name="icon" value="icons/now-playing/next.png" />
+							<param name="visible" value="Integer.IsLess(Playlist.Position(video), Playlist.Length(video)) | MusicPlayer.HasNext" />
 						</include>
 						<include content="IconButton">
 							<param name="control_id" value="14105" />
@@ -332,6 +333,7 @@
 					<param name="control_id" value="14104" />
 					<param name="onclick" value="PlayerControl(Next)" />
 					<param name="icon" value="icons/now-playing/next.png" />
+					<param name="visible" value="Integer.IsLess(Playlist.Position(video), Playlist.Length(video)) | MusicPlayer.HasNext" />
 				</include>
 				<include content="IconButton">
 					<param name="control_id" value="14105" />


### PR DESCRIPTION
## Description
Estuary shows the next button on the side panel when a video/music is playing regardless of meeting the conditions for triggering next (e.g. a single video with no chapters, scene markers, playlist count == 1, etc). This is wrong since hitting next does nothing.
This actually sets the visible condition on this button for the cases it makes sense.

## Motivation and context
Found while working on other stuff.

## How has this been tested?
Runtime tested, single item vs playlist vs item with chapters.

## What is the effect on users?
Next icon is hidden if it doesn't have any effect.

## Screenshots (if appropriate):

**Playing a single item (no next)**
![image](https://github.com/xbmc/xbmc/assets/7375276/91da82bd-fbdc-4927-b0a5-9ef5141a4d69)

**Playing playlist (after queuing a new video)**
![image](https://github.com/xbmc/xbmc/assets/7375276/c5ab86a6-ce55-4baf-92e3-7bd604a09df8)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

