### PR TITLE
[UPnP] Player: Make hasvideo and hasaudio conditional on the item type

### DIFF
--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -373,6 +373,16 @@ bool CUPnPPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options)
 
   m_stopremote = true;
   m_started = true;
+
+  if (file.IsVideo())
+  {
+    m_hasVideo = true;
+  }
+  else if (file.IsAudio())
+  {
+    m_hasAudio = true;
+  }
+
   m_callback.OnPlayBackStarted(file);
   m_callback.OnAVStarted(file);
   NPT_CHECK_LABEL_SEVERE(

--- a/xbmc/network/upnp/UPnPPlayer.h
+++ b/xbmc/network/upnp/UPnPPlayer.h
@@ -35,8 +35,8 @@ public:
   bool CloseFile(bool reopen = false) override;
   bool IsPlaying() const override;
   void Pause() override;
-  bool HasVideo() const override { return true; }
-  bool HasAudio() const override { return true; }
+  bool HasVideo() const override { return m_hasVideo; }
+  bool HasAudio() const override { return m_hasAudio; }
   void Seek(bool bPlus, bool bLargeStep, bool bChapterOverride) override;
   void SeekPercentage(float fPercent = 0) override;
   void SetVolume(float volume) override;
@@ -70,6 +70,8 @@ private:
   std::string m_current_meta;
   bool m_started = false;
   bool m_stopremote = false;
+  bool m_hasVideo{false};
+  bool m_hasAudio{false};
   XbmcThreads::EndTime<> m_updateTimer;
 
   Logger m_logger;


### PR DESCRIPTION
## Description
There's a lot of conditional logic (specially on the skin) that presents information depending on `Player.HasAudio` and `Player.HasVideo`. Those are often checked sequentially, so if the player is playing an audio file but HasVideo is true, infos will be shown for video...
This just makes the return type dependent on the actual item type and should be a no-brainer.