### PR TITLE
[Discs][UPnP] Don't show simplified menu if playing to remote players

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -2465,12 +2465,20 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
   if (!(options.startpercent > 0.0 || options.starttime > 0.0) &&
       (item.IsBDFile() || item.IsDiscImage()))
   {
-    // No video selection when using an external player, because it needs to handle that on its own.
-    const std::string defaulPlayer{
-        player.empty() ? m_ServiceManager->GetPlayerCoreFactory().GetDefaultPlayer(item) : player};
-    const bool isExternalPlayer{
-        m_ServiceManager->GetPlayerCoreFactory().IsExternalPlayer(defaulPlayer)};
-    if (!isExternalPlayer)
+    // No video selection when using external or remote players (they handle it if supported)
+    const bool isSimpleMenuAllowed = [&]()
+    {
+      const std::string defaulPlayer{
+          player.empty() ? m_ServiceManager->GetPlayerCoreFactory().GetDefaultPlayer(item)
+                         : player};
+      const bool isExternalPlayer{
+          m_ServiceManager->GetPlayerCoreFactory().IsExternalPlayer(defaulPlayer)};
+      const bool isRemotePlayer{
+          m_ServiceManager->GetPlayerCoreFactory().IsRemotePlayer(defaulPlayer)};
+      return !isExternalPlayer && !isRemotePlayer;
+    }();
+
+    if (isSimpleMenuAllowed)
     {
       // Check if we must show the simplified bd menu.
       if (!CGUIDialogSimpleMenu::ShowPlaySelection(item))

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
@@ -259,6 +259,11 @@ bool CPlayerCoreFactory::IsExternalPlayer(const std::string& player) const
   return (GetPlayerType(player) == "external");
 }
 
+bool CPlayerCoreFactory::IsRemotePlayer(const std::string& player) const
+{
+  return (GetPlayerType(player) == "remote");
+}
+
 bool CPlayerCoreFactory::PlaysAudio(const std::string& player) const
 {
   std::unique_lock<CCriticalSection> lock(m_section);

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.h
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.h
@@ -45,6 +45,7 @@ public:
   void GetRemotePlayers(std::vector<std::string>&players) const;                    //All remote players we can attach to
   std::string GetPlayerType(const std::string &player) const;
   bool IsExternalPlayer(const std::string& player) const;
+  bool IsRemotePlayer(const std::string& player) const;
   bool PlaysAudio(const std::string &player) const;
   bool PlaysVideo(const std::string &player) const;
 


### PR DESCRIPTION
## Description
Another no brainer. Currently the simplified menu is not shown if using external players. The same should also apply to remote players (upnp). There's more issues affecting playback of discs via UPnP (playback is flagged as stopped when showing the menu on the remote target) but I'll eventually got to that in the future.