### PR TITLE
[UPnP] Fix playlist playback on remote players

### DIFF
--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -197,7 +197,11 @@ bool CPlayListPlayer::PlayNext(int offset, bool bAutoPlay)
     return false;
   }
 
-  return Play(iSong, "", false);
+  const auto& components = CServiceBroker::GetAppComponents();
+  const auto appPlayer = components.GetComponent<CApplicationPlayer>();
+  const std::string player = appPlayer->GetName();
+
+  return Play(iSong, player, false);
 }
 
 bool CPlayListPlayer::PlayPrevious()

--- a/xbmc/application/ApplicationPlayer.cpp
+++ b/xbmc/application/ApplicationPlayer.cpp
@@ -105,7 +105,7 @@ bool CApplicationPlayer::OpenFile(const CFileItem& item, const CPlayerOptions& o
     if (player->m_name != newPlayer)
       needToClose = true;
 
-    if (player->m_type != "video")
+    if (player->m_type != "video" && player->m_type != "remote")
       needToClose = true;
 
     if (needToClose)
@@ -987,6 +987,16 @@ bool CApplicationPlayer::IsRemotePlaying() const
       return true;
   }
   return false;
+}
+
+std::string CApplicationPlayer::GetName() const
+{
+  const std::shared_ptr<const IPlayer> player = GetInternal();
+  if (player)
+  {
+    return player->m_name;
+  }
+  return {};
 }
 
 CVideoSettings CApplicationPlayer::GetVideoSettings() const

--- a/xbmc/application/ApplicationPlayer.h
+++ b/xbmc/application/ApplicationPlayer.h
@@ -70,6 +70,12 @@ public:
   bool IsExternalPlaying() const;
   bool IsRemotePlaying() const;
 
+  /*!
+   * \brief Get the name of the player in use
+   * \return the player name if a player is active, otherwise it returns an empty string
+   */
+  std::string GetName() const;
+
   // proxy calls
   void AddSubtitle(const std::string& strSubPath);
   bool CanPause() const;


### PR DESCRIPTION
## Description
This fixes the playback of playlist files in remote players (UPnP). When the playlist player requests the playback of the next item on the queue it always uses the default player, so if Kodi is playing something on a remote player it will start using videoplayer when the item finishes. This is wrong and the active player should be used instead. Note that when there is no active player playlist player will request playback using the default player anyway (empty string).

## Motivation and context
Being able to play music playlists on a remote player

## How has this been tested?
Runtime tested on linux and android

## What is the effect on users?
Playlists should now work fine when using Kodi as an UPnP player to a remote target

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
