### PR TITLE
[UPnP] Remove unuseful code block plus strong dependency on CApp

### DIFF
--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -13,12 +13,10 @@
 #include "ThumbLoader.h"
 #include "UPnP.h"
 #include "UPnPInternal.h"
-#include "application/Application.h"
 #include "cores/DataCacheCore.h"
 #include "dialogs/GUIDialogBusy.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
-#include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "music/MusicThumbLoader.h"
 #include "threads/Event.h"
@@ -523,23 +521,8 @@ void CUPnPPlayer::Process()
     NPT_CHECK_POINTER_LABEL_SEVERE(m_delegate, failed);
     m_delegate->UpdatePositionInfo();
 
-    NPT_String uri, meta;
-    NPT_CHECK_LABEL(m_delegate->m_transport->GetStateVariableValue("CurrentTrackURI", uri), failed);
-    NPT_CHECK_LABEL(m_delegate->m_transport->GetStateVariableValue("CurrentTrackMetadata", meta),
-                    failed);
-
     if (m_started)
     {
-      if (m_current_uri != (const char*)uri || m_current_meta != (const char*)meta)
-      {
-        m_current_uri = (const char*)uri;
-        m_current_meta = (const char*)meta;
-        const std::shared_ptr<CFileItem> item = GetFileItem(uri, meta);
-        g_application.CurrentFileItem() = *item;
-        CServiceBroker::GetAppMessenger()->PostMsg(TMSG_UPDATE_CURRENT_ITEM, 0, -1,
-                                                   static_cast<void*>(new CFileItem(*item)));
-      }
-
       // Update player times
       CDataCacheCore& dataCacheCore = CDataCacheCore::GetInstance();
       if (m_updateTimer.IsTimePast())


### PR DESCRIPTION
## Description
Now that playlists in UPnP should be fixed by https://github.com/xbmc/xbmc/pull/24274 it's time to remove the block of code that updated the item during the player loop. There's no chance of this being useful since if the item on the remote player changes by some user action the remote renderer will flag stop to the UPnP player (Kodi in this case) anyway.
When playing playlists via UPnP you don't have next/previous since the only entity with knowledge about the playlist is the UPnP player itself.
This block of code not only ties UPnP and CApp together but also has bad side effects on the information about the item. Before:

**Before:**
![image](https://github.com/xbmc/xbmc/assets/7375276/7af4f9ff-4164-4682-98df-e5f176b0f7be)


**Now:**
![image](https://github.com/xbmc/xbmc/assets/7375276/b3382d6e-bc8e-4e6e-be17-c4b27861da04)

