### PR TITLE
[Settings] Disable video version scan

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -879,12 +879,12 @@
         </setting>
         <setting id="videolibrary.ignorevideoversions" type="boolean" label="40202" help="40203">
           <level>1</level>
-          <default>false</default>
+          <default>true</default>
           <control type="toggle" />
         </setting>
         <setting id="videolibrary.ignorevideoextras" type="boolean" label="40204" help="40205">
           <level>1</level>
-          <default>false</default>
+          <default>true</default>
           <control type="toggle" />
         </setting>
         <setting id="videolibrary.cleanup" type="action" label="14247" help="36148">


### PR DESCRIPTION
## Description
Disable the scanning of video versions and extras by default until a decision is taken what to do about the wider code.

## Motivation and context

See https://github.com/xbmc/xbmc/pull/14972#issuecomment-1863753002

## Screenshots (if appropriate):

Before
![image](https://github.com/xbmc/xbmc/assets/5781142/50751314-004f-4a6d-90d7-32ef2d90c1f4)

After
![image](https://github.com/xbmc/xbmc/assets/5781142/8060ffbf-5fce-4c8d-8a6f-01346255eab4)
