### PR TITLE
[Estuary][GUI] Do not activate fullscreen window if rendering video to remote targets (UPnP)

### DIFF
--- a/addons/skin.estuary/xml/Home.xml
+++ b/addons/skin.estuary/xml/Home.xml
@@ -1080,7 +1080,14 @@
 						<param name="onclick" value="Fullscreen" />
 						<param name="icon" value="icons/now-playing/fullscreen.png" />
 						<param name="label" value="$LOCALIZE[31000]" />
-						<param name="visible" value="Player.HasMedia" />
+						<param name="visible" value="Player.HasMedia + !Player.IsRemote" />
+					</include>
+					<include content="IconButton">
+						<param name="control_id" value="805" />
+						<param name="onclick" value="ActivateWindow(playercontrols)" />
+						<param name="icon" value="icons/now-playing/fullscreen.png" />
+						<param name="label" value="$LOCALIZE[31000]" />
+						<param name="visible" value="Player.HasMedia + Player.IsRemote + !Player.HasAudio" />
 					</include>
 				</control>
 			</control>

--- a/addons/skin.estuary/xml/Includes_MediaMenu.xml
+++ b/addons/skin.estuary/xml/Includes_MediaMenu.xml
@@ -245,6 +245,14 @@
 							<param name="control_id" value="14105" />
 							<param name="onclick" value="Fullscreen" />
 							<param name="icon" value="icons/now-playing/fullscreen.png" />
+							<param name="visible" value="Player.HasMedia + [ !Player.IsRemote | Player.HasAudio ]" />
+						</include>
+						<include content="IconButton">
+							<param name="control_id" value="14106" />
+							<param name="onclick" value="ActivateWindow(playercontrols)" />
+							<param name="icon" value="icons/now-playing/fullscreen.png" />
+							<param name="label" value="$LOCALIZE[31000]" />
+							<param name="visible" value="Player.HasMedia + Player.IsRemote" />
 						</include>
 					</control>
 				</control>
@@ -339,6 +347,13 @@
 					<param name="control_id" value="14105" />
 					<param name="onclick" value="Fullscreen" />
 					<param name="icon" value="icons/now-playing/fullscreen.png" />
+					<param name="visible" value="Player.HasMedia + [ !Player.IsRemote | Player.HasAudio ]" />
+				</include>
+				<include content="IconButton">
+					<param name="control_id" value="14106" />
+					<param name="onclick" value="ActivateWindow(playercontrols)" />
+					<param name="icon" value="icons/now-playing/fullscreen.png" />
+					<param name="visible" value="Player.HasMedia + Player.IsRemote + !Player.HasAudio" />
 				</include>
 			</control>
 		</definition>

--- a/xbmc/windows/GUIWindowHome.cpp
+++ b/xbmc/windows/GUIWindowHome.cpp
@@ -47,7 +47,7 @@ bool CGUIWindowHome::OnAction(const CAction &action)
   {
     const auto& components = CServiceBroker::GetAppComponents();
     const auto appPlayer = components.GetComponent<CApplicationPlayer>();
-    if (appPlayer->IsPlaying())
+    if (appPlayer->IsPlaying() && (!appPlayer->IsRemotePlaying() || appPlayer->HasAudio()))
     {
       CGUIComponent* gui = CServiceBroker::GetGUI();
       if (gui)


### PR DESCRIPTION
## Description
When rendering to a remote UPnP player Kodi is not actually displaying any video so showing the OSD is wrong (and causes all sorts of issues like stealing user control and rendering the GUI at higher fps than needed). Furthermore, the link to go to the controls should open the playercontrols rather than the fullscreen window.

**Before:**
![image](https://github.com/xbmc/xbmc/assets/7375276/11e6c8e7-369a-4861-a671-ad93d95877ef)


**After:**
Video:
![image](https://github.com/xbmc/xbmc/assets/7375276/fbb15079-5981-4999-a193-394c0ee5c54d)
Audio:
![image](https://github.com/xbmc/xbmc/assets/7375276/c392c060-79d9-4d97-a287-c9806bd930eb)


## Motivation and context
Found while working with UPnP. I believe the same could probably happen with external players but I have no way to test it.