### PR TITLE
Update XMLUtils.h: Add include of cstdint needed for g++ >= 13

### DIFF
--- a/xbmc/utils/XMLUtils.h
+++ b/xbmc/utils/XMLUtils.h
@@ -13,6 +13,7 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 #include <tinyxml2.h>
 


### PR DESCRIPTION
Add include of cstdint needed for g++ >= 13

Types like "uint32_t" are defined in <cstdint> since gcc/g++-13