### PR TITLE
[Pictures] Implement Slideshow delegator design pattern

### DIFF
--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -271,6 +271,11 @@ CDatabaseManager& CServiceBroker::GetDatabaseManager()
   return g_application.m_ServiceManager->GetDatabaseManager();
 }
 
+CSlideShowDelegator& CServiceBroker::GetSlideShowDelegator()
+{
+  return g_application.m_ServiceManager->GetSlideShowDelegator();
+}
+
 CEventLog* CServiceBroker::GetEventLog()
 {
   if (!g_serviceBroker.m_pSettingsComponent)

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -80,6 +80,7 @@ class CPlatform;
 class CTextureCache;
 class CJobManager;
 class CKeyboardLayoutManager;
+class CSlideShowDelegator;
 
 namespace WSDiscovery
 {
@@ -148,6 +149,7 @@ public:
   static CDataCacheCore& GetDataCacheCore();
   static CPlatform& GetPlatform();
   static PLAYLIST::CPlayListPlayer& GetPlaylistPlayer();
+  static CSlideShowDelegator& GetSlideShowDelegator();
   static KODI::GAME::CControllerManager& GetGameControllerManager();
   static KODI::GAME::CGameServices& GetGameServices();
   static KODI::RETRO::CGUIGameRenderManager& GetGameRenderManager();
@@ -235,6 +237,7 @@ private:
   std::shared_ptr<KODI::MESSAGING::CApplicationMessenger> m_appMessenger;
   std::shared_ptr<CKeyboardLayoutManager> m_keyboardLayoutManager;
   std::shared_ptr<speech::ISpeechRecognition> m_speechRecognition;
+  std::shared_ptr<CSlideShowDelegator> m_slideshowDelegator;
 };
 
 XBMC_GLOBAL_REF(CServiceBroker, g_serviceBroker);

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -43,6 +43,7 @@
 #if !defined(TARGET_WINDOWS) && defined(HAS_OPTICAL_DRIVE)
 #include "storage/DetectDVDType.h"
 #endif
+#include "pictures/SlideShowDelegator.h"
 #include "storage/MediaManager.h"
 #include "utils/FileExtensionProvider.h"
 #include "utils/log.h"
@@ -109,6 +110,7 @@ bool CServiceManager::InitStageOne()
 #endif
 
   m_playlistPlayer = std::make_unique<PLAYLIST::CPlayListPlayer>();
+  m_slideShowDelegator = std::make_unique<CSlideShowDelegator>();
 
   m_network = CNetworkBase::GetNetwork();
 
@@ -273,6 +275,7 @@ void CServiceManager::DeinitStageOne()
 
   m_network.reset();
   m_playlistPlayer.reset();
+  m_slideShowDelegator.reset();
 #ifdef HAS_PYTHON
   CScriptInvocationManager::GetInstance().UnregisterLanguageInvocationHandler(m_XBPython.get());
   m_XBPython.reset();
@@ -426,4 +429,9 @@ CDatabaseManager& CServiceManager::GetDatabaseManager()
 CMediaManager& CServiceManager::GetMediaManager()
 {
   return *m_mediaManager;
+}
+
+CSlideShowDelegator& CServiceManager::GetSlideShowDelegator()
+{
+  return *m_slideShowDelegator;
 }

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -48,6 +48,7 @@ class CNetworkBase;
 class CWinSystemBase;
 class CPowerManager;
 class CWeatherManager;
+class CSlideShowDelegator;
 
 namespace KODI
 {
@@ -127,6 +128,7 @@ public:
   PERIPHERALS::CPeripherals& GetPeripherals();
 
   PLAYLIST::CPlayListPlayer& GetPlaylistPlayer();
+  CSlideShowDelegator& GetSlideShowDelegator();
   int init_level = 0;
 
   CFavouritesService& GetFavouritesService();
@@ -182,4 +184,5 @@ protected:
 #if !defined(TARGET_WINDOWS) && defined(HAS_OPTICAL_DRIVE)
   std::unique_ptr<MEDIA_DETECT::CDetectDVDMedia> m_DetectDVDType;
 #endif
+  std::unique_ptr<CSlideShowDelegator> m_slideShowDelegator;
 };

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -103,7 +103,7 @@
 #include "network/upnp/UPnP.h"
 #endif
 #include "peripherals/Peripherals.h"
-#include "pictures/GUIWindowSlideShow.h"
+#include "pictures/SlideShowDelegator.h"
 #include "platform/Environment.h"
 #include "playlists/PlayList.h"
 #include "playlists/PlayListFactory.h"
@@ -962,10 +962,9 @@ bool CApplication::OnAction(const CAction &action)
   // playing or ACTION_PLAYER_PLAY if we are seeking (FF/RW) or not playing.
   if (action.GetID() == ACTION_PLAYER_PLAYPAUSE)
   {
-    CGUIWindowSlideShow* pSlideShow = CServiceBroker::GetGUI()->
-                         GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
+    CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
     if ((appPlayer->IsPlaying() && appPlayer->GetPlaySpeed() == 1) ||
-        (pSlideShow && pSlideShow->InSlideShow() && !pSlideShow->IsPaused()))
+        (slideShow.InSlideShow() && !slideShow.IsPaused()))
       return OnAction(CAction(ACTION_PAUSE));
     else
       return OnAction(CAction(ACTION_PLAYER_PLAY));
@@ -1636,8 +1635,7 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
 
   case TMSG_PICTURE_SHOW:
   {
-    CGUIWindowSlideShow *pSlideShow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
-    if (!pSlideShow) return;
+    CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
 
     // stop playing file
     if (appPlayer->IsPlayingVideo())
@@ -1664,33 +1662,32 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
       CUtil::GetRecursiveListing(pathToUrl.Get(), items, CServiceBroker::GetFileExtensionProvider().GetPictureExtensions(), XFILE::DIR_FLAG_NO_FILE_DIRS);
       if (items.Size() > 0)
       {
-        pSlideShow->Reset();
+        slideShow.Reset();
         for (int i = 0; i<items.Size(); ++i)
         {
-          pSlideShow->Add(items[i].get());
+          slideShow.Add(items[i].get());
         }
-        pSlideShow->Select(items[0]->GetPath());
+        slideShow.Select(items[0]->GetPath());
       }
     }
     else
     {
       CFileItem item(pMsg->strParam, false);
-      pSlideShow->Reset();
-      pSlideShow->Add(&item);
-      pSlideShow->Select(pMsg->strParam);
+      slideShow.Reset();
+      slideShow.Add(&item);
+      slideShow.Select(pMsg->strParam);
     }
   }
   break;
 
   case TMSG_PICTURE_SLIDESHOW:
   {
-    CGUIWindowSlideShow *pSlideShow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
-    if (!pSlideShow) return;
+    CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
 
     if (appPlayer->IsPlayingVideo())
       StopPlaying();
 
-    pSlideShow->Reset();
+    slideShow.Reset();
 
     CFileItemList items;
     std::string strPath = pMsg->strParam;
@@ -1702,8 +1699,8 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
     if (items.Size() > 0)
     {
       for (int i = 0; i<items.Size(); ++i)
-        pSlideShow->Add(items[i].get());
-      pSlideShow->StartSlideShow(); //Start the slideshow!
+        slideShow.Add(items[i].get());
+      slideShow.StartSlideShow(); //Start the slideshow!
     }
 
     if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() != WINDOW_SLIDESHOW)

--- a/xbmc/guilib/guiinfo/PicturesGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PicturesGUIInfo.cpp
@@ -15,8 +15,8 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/guiinfo/GUIInfo.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
-#include "pictures/GUIWindowSlideShow.h"
 #include "pictures/PictureInfoTag.h"
+#include "pictures/SlideShowDelegator.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -180,10 +180,10 @@ bool CPicturesGUIInfo::GetLabel(std::string& value, const CFileItem *item, int c
       }
       case SLIDESHOW_INDEX:
       {
-        CGUIWindowSlideShow *slideshow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
-        if (slideshow && slideshow->NumSlides())
+        CSlideShowDelegator& slideshow = CServiceBroker::GetSlideShowDelegator();
+        if (slideshow.NumSlides() > 0)
         {
-          value = StringUtils::Format("{}/{}", slideshow->CurrentSlide(), slideshow->NumSlides());
+          value = StringUtils::Format("{}/{}", slideshow.CurrentSlide(), slideshow.NumSlides());
           return true;
         }
         break;
@@ -232,26 +232,26 @@ bool CPicturesGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int conte
     ///////////////////////////////////////////////////////////////////////////////////////////////
     case SLIDESHOW_ISPAUSED:
     {
-      CGUIWindowSlideShow *slideShow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
-      value = (slideShow && slideShow->IsPaused());
+      CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
+      value = slideShow.IsPaused();
       return true;
     }
     case SLIDESHOW_ISRANDOM:
     {
-      CGUIWindowSlideShow *slideShow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
-      value = (slideShow && slideShow->IsShuffled());
+      CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
+      value = slideShow.IsShuffled();
       return true;
     }
     case SLIDESHOW_ISACTIVE:
     {
-      CGUIWindowSlideShow *slideShow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
-      value = (slideShow && slideShow->InSlideShow());
+      CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
+      value = slideShow.InSlideShow();
       return true;
     }
     case SLIDESHOW_ISVIDEO:
     {
-      CGUIWindowSlideShow *slideShow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
-      value = (slideShow && slideShow->GetCurrentSlide() && slideShow->GetCurrentSlide()->IsVideo());
+      CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
+      value = slideShow.GetCurrentSlide() && slideShow.GetCurrentSlide()->IsVideo();
       return true;
     }
   }

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -30,7 +30,7 @@
 #include "interfaces/builtins/Builtins.h"
 #include "messaging/ApplicationMessenger.h"
 #include "music/MusicDatabase.h"
-#include "pictures/GUIWindowSlideShow.h"
+#include "pictures/SlideShowDelegator.h"
 #include "pvr/PVRManager.h"
 #include "pvr/PVRPlaybackState.h"
 #include "pvr/channels/PVRChannel.h"
@@ -279,13 +279,10 @@ JSONRPC_STATUS CPlayerOperations::GetItem(const std::string &method, ITransportL
 
     case Picture:
     {
-      CGUIWindowSlideShow *slideshow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
-      if (!slideshow)
-        return FailedToExecute;
-
+      CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
       CFileItemList slides;
-      slideshow->GetSlideShowContents(slides);
-      fileItem = slides[slideshow->CurrentSlide() - 1];
+      slideShow.GetSlideShowContents(slides);
+      fileItem = slides[slideShow.CurrentSlide() - 1];
       break;
     }
 
@@ -300,7 +297,6 @@ JSONRPC_STATUS CPlayerOperations::GetItem(const std::string &method, ITransportL
 
 JSONRPC_STATUS CPlayerOperations::PlayPause(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
-  CGUIWindowSlideShow *slideshow = NULL;
   switch (GetPlayer(parameterObject["playerid"]))
   {
     case Video:
@@ -328,20 +324,20 @@ JSONRPC_STATUS CPlayerOperations::PlayPause(const std::string &method, ITranspor
       result["speed"] = appPlayer->IsPausedPlayback() ? 0 : (int)lrint(appPlayer->GetPlaySpeed());
       return OK;
     }
-
     case Picture:
-      slideshow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
-      if (slideshow && slideshow->IsPlaying() &&
-         (parameterObject["play"].isString() ||
-         (parameterObject["play"].isBoolean() && parameterObject["play"].asBoolean() == slideshow->IsPaused())))
+    {
+      CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
+      if (slideShow.IsPlaying() && (parameterObject["play"].isString() ||
+                                    (parameterObject["play"].isBoolean() &&
+                                     parameterObject["play"].asBoolean() == slideShow.IsPaused())))
         SendSlideshowAction(ACTION_PAUSE);
 
-      if (slideshow && slideshow->IsPlaying() && !slideshow->IsPaused())
-        result["speed"] = slideshow->GetDirection();
+      if (slideShow.IsPlaying() && !slideShow.IsPaused())
+        result["speed"] = slideShow.GetDirection();
       else
         result["speed"] = 0;
       return OK;
-
+    }
     case None:
     default:
       return FailedToExecute;
@@ -788,14 +784,11 @@ JSONRPC_STATUS CPlayerOperations::Open(const std::string &method, ITransportLaye
         std::string firstPicturePath;
         if (playlistStartPosition > 0)
         {
-          CGUIWindowSlideShow *slideshow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
-          if (slideshow != NULL)
-          {
-            CFileItemList list;
-            slideshow->GetSlideShowContents(list);
-            if (playlistStartPosition < list.Size())
-              firstPicturePath = list.Get(playlistStartPosition)->GetPath();
-          }
+          CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
+          CFileItemList list;
+          slideShow.GetSlideShowContents(list);
+          if (playlistStartPosition < list.Size())
+            firstPicturePath = list.Get(playlistStartPosition)->GetPath();
         }
 
         return StartSlideshow("", false, optionShuffled.isBoolean() && optionShuffled.asBoolean(), firstPicturePath);
@@ -890,14 +883,13 @@ JSONRPC_STATUS CPlayerOperations::Open(const std::string &method, ITransportLaye
 
       if (slideshow)
       {
-        CGUIWindowSlideShow *slideshow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
-        if (!slideshow)
-          return FailedToExecute;
-
+        //! @todo: This should be a delegator method instead of going via GUI!
+        //! look into triggering stop from Reset() itself!
         SendSlideshowAction(ACTION_STOP);
-        slideshow->Reset();
+        CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
+        slideShow.Reset();
         for (int index = 0; index < list.Size(); index++)
-          slideshow->Add(list[index].get());
+          slideShow.Add(list[index].get());
 
         return StartSlideshow("", false, optionShuffled.isBoolean() && optionShuffled.asBoolean());
       }
@@ -1043,7 +1035,6 @@ JSONRPC_STATUS CPlayerOperations::GoTo(const std::string &method, ITransportLaye
 
 JSONRPC_STATUS CPlayerOperations::SetShuffle(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result)
 {
-  CGUIWindowSlideShow *slideshow = NULL;
   CVariant shuffle = parameterObject["shuffle"];
   switch (GetPlayer(parameterObject["playerid"]))
   {
@@ -1074,10 +1065,14 @@ JSONRPC_STATUS CPlayerOperations::SetShuffle(const std::string &method, ITranspo
     }
 
     case Picture:
-      slideshow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
-      if (slideshow == NULL)
+    {
+      CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
+      if (slideShow.NumSlides() < 0)
+      {
         return FailedToExecute;
-      if (slideshow->IsShuffled())
+      }
+
+      if (slideShow.IsShuffled())
       {
         if ((shuffle.isBoolean() && !shuffle.asBoolean()) ||
             (shuffle.isString() && shuffle.asString() == "toggle"))
@@ -1087,10 +1082,10 @@ JSONRPC_STATUS CPlayerOperations::SetShuffle(const std::string &method, ITranspo
       {
         if ((shuffle.isBoolean() && shuffle.asBoolean()) ||
             (shuffle.isString() && shuffle.asString() == "toggle"))
-          slideshow->Shuffle();
+          slideShow.Shuffle();
       }
       break;
-
+    }
     default:
       return FailedToExecute;
   }
@@ -1540,7 +1535,6 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
   }
   else if (property == "speed")
   {
-    CGUIWindowSlideShow *slideshow = NULL;
     switch (player)
     {
       case Video:
@@ -1551,15 +1545,15 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
         result = appPlayer->IsPausedPlayback() ? 0 : (int)lrint(appPlayer->GetPlaySpeed());
         break;
       }
-
       case Picture:
-        slideshow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
-        if (slideshow && slideshow->IsPlaying() && !slideshow->IsPaused())
-          result = slideshow->GetDirection();
+      {
+        CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
+        if (slideShow.IsPlaying() && !slideShow.IsPaused())
+          result = slideShow.GetDirection();
         else
           result = 0;
         break;
-
+      }
       default:
         return FailedToExecute;
     }
@@ -1595,7 +1589,6 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
   }
   else if (property == "percentage")
   {
-    CGUIWindowSlideShow *slideshow = NULL;
     switch (player)
     {
       case Video:
@@ -1613,15 +1606,15 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
         }
         break;
       }
-
       case Picture:
-        slideshow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
-        if (slideshow && slideshow->NumSlides() > 0)
-          result = (double)slideshow->CurrentSlide() / slideshow->NumSlides();
+      {
+        CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
+        if (slideShow.NumSlides() > 0)
+          result = static_cast<double>(slideShow.CurrentSlide()) / slideShow.NumSlides();
         else
           result = 0.0;
         break;
-
+      }
       default:
         return FailedToExecute;
     }
@@ -1682,11 +1675,11 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
   }
   else if (property == "position")
   {
-    CGUIWindowSlideShow *slideshow = NULL;
     switch (player)
     {
       case Video:
       case Audio: /* Return the position of current item if there is an active playlist */
+      {
         if (!IsPVRChannel() &&
             CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist() == playlistId)
         {
@@ -1695,18 +1688,21 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
         else
           result = -1;
         break;
-
+      }
       case Picture:
-        slideshow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
-        if (slideshow && slideshow->IsPlaying())
-          result = slideshow->CurrentSlide() - 1;
+      {
+        CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
+        if (slideShow.IsPlaying())
+          result = slideShow.CurrentSlide() - 1;
         else
           result = -1;
         break;
-
+      }
       default:
+      {
         result = -1;
         break;
+      }
     }
   }
   else if (property == "repeat")
@@ -1743,11 +1739,11 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
   }
   else if (property == "shuffled")
   {
-    CGUIWindowSlideShow *slideshow = NULL;
     switch (player)
     {
       case Video:
       case Audio:
+      {
         if (IsPVRChannel())
         {
           result = false;
@@ -1756,18 +1752,21 @@ JSONRPC_STATUS CPlayerOperations::GetPropertyValue(PlayerType player, const std:
 
         result = CServiceBroker::GetPlaylistPlayer().IsShuffled(playlistId);
         break;
-
+      }
       case Picture:
-        slideshow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
-        if (slideshow && slideshow->IsPlaying())
-          result = slideshow->IsShuffled();
+      {
+        CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
+        if (slideShow.IsPlaying())
+          result = slideShow.IsShuffled();
         else
           result = -1;
         break;
-
+      }
       default:
+      {
         result = -1;
         break;
+      }
     }
   }
   else if (property == "canseek")

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -30,7 +30,7 @@
 #include "interfaces/AnnouncementManager.h"
 #include "messaging/ApplicationMessenger.h"
 #include "network/Network.h"
-#include "pictures/GUIWindowSlideShow.h"
+#include "pictures/SlideShowDelegator.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
@@ -319,6 +319,7 @@ CUPnPRenderer::UpdateState()
         return;
 
     avt->SetStateVariable("TransportStatus", "OK");
+    CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
     const auto& components = CServiceBroker::GetAppComponents();
     const auto appPlayer = components.GetComponent<CApplicationPlayer>();
     if (appPlayer->IsPlaying() || appPlayer->IsPausedPlayback())
@@ -356,18 +357,11 @@ CUPnPRenderer::UpdateState()
       avt->SetStateVariable("CurrentTrackURI", filePath.c_str());
       avt->SetStateVariable("TransportPlaySpeed", "1");
 
-      CGUIWindowSlideShow* slideshow =
-          CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(
-              WINDOW_SLIDESHOW);
-      if (slideshow)
-      {
-        std::string index;
-        index = std::to_string(slideshow->NumSlides());
-        avt->SetStateVariable("NumberOfTracks", index.c_str());
-        index = std::to_string(slideshow->CurrentSlide());
-        avt->SetStateVariable("CurrentTrack", index.c_str());
-      }
-
+      std::string index;
+      index = std::to_string(slideShow.NumSlides());
+      avt->SetStateVariable("NumberOfTracks", index.c_str());
+      index = std::to_string(slideShow.CurrentSlide());
+      avt->SetStateVariable("CurrentTrack", index.c_str());
       avt->SetStateVariable("CurrentTrackMetadata", "");
       avt->SetStateVariable("AVTransportURIMetaData", "");
     }

--- a/xbmc/pictures/CMakeLists.txt
+++ b/xbmc/pictures/CMakeLists.txt
@@ -12,9 +12,11 @@ set(SOURCES ExifParse.cpp
             PictureInfoTag.cpp
             PictureScalingAlgorithm.cpp
             PictureThumbLoader.cpp
+            SlideShowDelegator.cpp
             SlideShowPicture.cpp)
 
-set(HEADERS GUIDialogPictureInfo.h
+set(HEADERS interfaces/ISlideShowDelegate.h
+            GUIDialogPictureInfo.h
             GUIViewStatePictures.h
             GUIWindowPictures.h
             GUIWindowSlideShow.h
@@ -24,6 +26,7 @@ set(HEADERS GUIDialogPictureInfo.h
             PictureInfoTag.h
             PictureScalingAlgorithm.h
             PictureThumbLoader.h
+            SlideShowDelegator.h
             SlideShowPicture.h)
 
 if(TARGET OpenGL::GL)

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -29,6 +29,7 @@
 #include "interfaces/AnnouncementManager.h"
 #include "media/MediaLockState.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "pictures/SlideShowDelegator.h"
 #include "playlists/PlayList.h"
 #include "playlists/PlayListFactory.h"
 #include "settings/MediaSourceSettings.h"
@@ -67,14 +68,14 @@ void CGUIWindowPictures::OnInitWindow()
   CGUIMediaWindow::OnInitWindow();
   if (m_slideShowStarted)
   {
-    CGUIWindowSlideShow* wndw = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
+    CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
     std::string path;
-    if (wndw && wndw->GetCurrentSlide())
-      path = URIUtils::GetDirectory(wndw->GetCurrentSlide()->GetPath());
+    if (slideShow.GetCurrentSlide())
+      path = URIUtils::GetDirectory(slideShow.GetCurrentSlide()->GetPath());
     if (m_vecItems->IsPath(path))
     {
-      if (wndw && wndw->GetCurrentSlide())
-        m_viewControl.SetSelectedItem(wndw->GetCurrentSlide()->GetPath());
+      if (slideShow.GetCurrentSlide())
+        m_viewControl.SetSelectedItem(slideShow.GetCurrentSlide()->GetPath());
       SaveSelectedItemInHistory();
     }
     m_slideShowStarted = false;
@@ -314,15 +315,14 @@ bool CGUIWindowPictures::ShowPicture(int iItem, bool startSlideShow)
   if (pItem->m_bIsShareOrDrive)
     return false;
 
-  CGUIWindowSlideShow *pSlideShow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
-  if (!pSlideShow)
-    return false;
+  //! @todo this should be reactive, based on a given event app player should stop the playback
   const auto& components = CServiceBroker::GetAppComponents();
   const auto appPlayer = components.GetComponent<CApplicationPlayer>();
   if (appPlayer->IsPlayingVideo())
     g_application.StopPlaying();
 
-  pSlideShow->Reset();
+  CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
+  slideShow.Reset();
   bool bShowVideos = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_PICTURES_SHOWVIDEOS);
   for (const auto& pItem : *m_vecItems)
   {
@@ -330,26 +330,28 @@ bool CGUIWindowPictures::ShowPicture(int iItem, bool startSlideShow)
         !(URIUtils::IsRAR(pItem->GetPath()) || URIUtils::IsZIP(pItem->GetPath())) &&
         (pItem->IsPicture() || (bShowVideos && pItem->IsVideo())))
     {
-      pSlideShow->Add(pItem.get());
+      slideShow.Add(pItem.get());
     }
   }
 
-  if (pSlideShow->NumSlides() == 0)
+  if (slideShow.NumSlides() == 0)
     return false;
 
-  pSlideShow->Select(strPicture);
+  slideShow.Select(strPicture);
 
   if (startSlideShow)
-    pSlideShow->StartSlideShow();
+    slideShow.StartSlideShow();
   else
   {
     CVariant param;
     param["player"]["speed"] = 1;
     param["player"]["playerid"] = PLAYLIST::TYPE_PICTURE;
     CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnPlay",
-                                                       pSlideShow->GetCurrentSlide(), param);
+                                                       slideShow.GetCurrentSlide(), param);
   }
 
+  //! @todo this should trigger some event that should led the window manager to activate another window
+  // look into using OnPlay announce!
   m_slideShowStarted = true;
   CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_SLIDESHOW);
 
@@ -358,31 +360,27 @@ bool CGUIWindowPictures::ShowPicture(int iItem, bool startSlideShow)
 
 void CGUIWindowPictures::OnShowPictureRecursive(const std::string& strPath)
 {
-  CGUIWindowSlideShow *pSlideShow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
-  if (pSlideShow)
-  {
-    // stop any video
-    const auto& components = CServiceBroker::GetAppComponents();
-    const auto appPlayer = components.GetComponent<CApplicationPlayer>();
-    if (appPlayer->IsPlayingVideo())
-      g_application.StopPlaying();
+  // stop any video
+  //! @todo this should be reactive, based on a given event app player should stop the playback
+  const auto& components = CServiceBroker::GetAppComponents();
+  const auto appPlayer = components.GetComponent<CApplicationPlayer>();
+  if (appPlayer->IsPlayingVideo())
+    g_application.StopPlaying();
 
-    SortDescription sorting = m_guiState->GetSortMethod();
-    pSlideShow->AddFromPath(strPath, true,
-                            sorting.sortBy, sorting.sortOrder, sorting.sortAttributes);
-    if (pSlideShow->NumSlides())
-    {
-      m_slideShowStarted = true;
-      CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_SLIDESHOW);
-    }
+  CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
+  SortDescription sorting = m_guiState->GetSortMethod();
+  slideShow.AddFromPath(strPath, true, sorting.sortBy, sorting.sortOrder, sorting.sortAttributes);
+  //! @todo window manager should react to a given event and start the window itself!
+  if (slideShow.NumSlides())
+  {
+    m_slideShowStarted = true;
+    CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_SLIDESHOW);
   }
 }
 
 void CGUIWindowPictures::OnSlideShowRecursive(const std::string &strPicture)
 {
-  CGUIWindowSlideShow *pSlideShow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
-  if (pSlideShow)
-  {
+
     std::string strExtensions;
     CFileItemList items;
     CGUIViewState* viewState=CGUIViewState::GetViewState(GetID(), items);
@@ -393,13 +391,13 @@ void CGUIWindowPictures::OnSlideShowRecursive(const std::string &strPicture)
     }
     m_slideShowStarted = true;
 
+    CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
     SortDescription sorting = m_guiState->GetSortMethod();
-    pSlideShow->RunSlideShow(strPicture, true,
-                             CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_SLIDESHOW_SHUFFLE),false,
-                             "", true,
-                             sorting.sortBy, sorting.sortOrder, sorting.sortAttributes,
-                             strExtensions);
-  }
+    slideShow.RunSlideShow(strPicture, true,
+                           CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                               CSettings::SETTING_SLIDESHOW_SHUFFLE),
+                           false, "", true, sorting.sortBy, sorting.sortOrder,
+                           sorting.sortAttributes, strExtensions);
 }
 
 void CGUIWindowPictures::OnSlideShowRecursive()
@@ -414,25 +412,19 @@ void CGUIWindowPictures::OnSlideShow()
 
 void CGUIWindowPictures::OnSlideShow(const std::string &strPicture)
 {
-  CGUIWindowSlideShow *pSlideShow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
-  if (pSlideShow)
+  std::string strExtensions;
+  CFileItemList items;
+  CGUIViewState* viewState = CGUIViewState::GetViewState(GetID(), items);
+  if (viewState)
   {
-    std::string strExtensions;
-    CFileItemList items;
-    CGUIViewState* viewState=CGUIViewState::GetViewState(GetID(), items);
-    if (viewState)
-    {
-      strExtensions = viewState->GetExtensions();
-      delete viewState;
-    }
-    m_slideShowStarted = true;
-
-    SortDescription sorting = m_guiState->GetSortMethod();
-    pSlideShow->RunSlideShow(strPicture, false ,false, false,
-                             "", true,
-                             sorting.sortBy, sorting.sortOrder, sorting.sortAttributes,
-                             strExtensions);
+    strExtensions = viewState->GetExtensions();
+    delete viewState;
   }
+  CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
+  m_slideShowStarted = true;
+  SortDescription sorting = m_guiState->GetSortMethod();
+  slideShow.RunSlideShow(strPicture, false, false, false, "", true, sorting.sortBy,
+                         sorting.sortOrder, sorting.sortAttributes, strExtensions);
 }
 
 void CGUIWindowPictures::OnRegenerateThumbs()
@@ -552,28 +544,30 @@ void CGUIWindowPictures::LoadPlayList(const std::string& strPlayList)
   PLAYLIST::CPlayList playlist = *pPlayList;
   if (playlist.size() > 0)
   {
-    // set up slideshow
-    CGUIWindowSlideShow *pSlideShow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
-    if (!pSlideShow)
-      return;
+    //! @todo this should be reactive, based on a given event app player should stop the playback
     const auto& components = CServiceBroker::GetAppComponents();
     const auto appPlayer = components.GetComponent<CApplicationPlayer>();
     if (appPlayer->IsPlayingVideo())
       g_application.StopPlaying();
 
+    CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
     // convert playlist items into slideshow items
-    pSlideShow->Reset();
+    slideShow.Reset();
     for (int i = 0; i < playlist.size(); ++i)
     {
       CFileItemPtr pItem = playlist[i];
       //CLog::Log(LOGDEBUG,"-- playlist item: {}", pItem->GetPath());
       if (pItem->IsPicture() && !(pItem->IsZIP() || pItem->IsRAR() || pItem->IsCBZ() || pItem->IsCBR()))
-        pSlideShow->Add(pItem.get());
+      {
+        slideShow.Add(pItem.get());
+      }
     }
 
     // start slideshow if there are items
-    pSlideShow->StartSlideShow();
-    if (pSlideShow->NumSlides())
+    slideShow.StartSlideShow();
+    //! @todo this should be reactive based on a triggered event the window manager is the only component
+    // that should be responsible to activate the slideshow window
+    if (slideShow.NumSlides())
       CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_SLIDESHOW);
   }
 }

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -29,6 +29,7 @@
 #include "interfaces/AnnouncementManager.h"
 #include "pictures/GUIViewStatePictures.h"
 #include "pictures/PictureThumbLoader.h"
+#include "pictures/SlideShowDelegator.h"
 #include "playlists/PlayListTypes.h"
 #include "rendering/RenderSystem.h"
 #include "settings/DisplaySettings.h"
@@ -144,7 +145,13 @@ CGUIWindowSlideShow::CGUIWindowSlideShow(void)
   m_Resolution = RES_INVALID;
   m_loadType = KEEP_IN_MEMORY;
   m_bLoadNextPic = false;
+  CServiceBroker::GetSlideShowDelegator().SetDelegate(this);
   Reset();
+}
+
+CGUIWindowSlideShow::~CGUIWindowSlideShow()
+{
+  CServiceBroker::GetSlideShowDelegator().ResetDelegate();
 }
 
 void CGUIWindowSlideShow::AnnouncePlayerPlay(const CFileItemPtr& item)

--- a/xbmc/pictures/GUIWindowSlideShow.h
+++ b/xbmc/pictures/GUIWindowSlideShow.h
@@ -10,9 +10,9 @@
 
 #include "SlideShowPicture.h"
 #include "guilib/GUIDialog.h"
+#include "interfaces/ISlideShowDelegate.h"
 #include "threads/Event.h"
 #include "threads/Thread.h"
-#include "utils/SortUtils.h"
 
 #include <memory>
 #include <set>
@@ -48,51 +48,57 @@ private:
   CGUIWindowSlideShow* m_pCallback = nullptr;
 };
 
-class CGUIWindowSlideShow : public CGUIDialog
+class CGUIWindowSlideShow : public CGUIDialog, public ISlideShowDelegate
 {
 public:
   CGUIWindowSlideShow(void);
-  ~CGUIWindowSlideShow() override = default;
+  ~CGUIWindowSlideShow() override;
 
-  bool OnMessage(CGUIMessage& message) override;
-  EVENT_RESULT OnMouseEvent(const CPoint &point, const CMouseEvent &event) override;
-  bool OnAction(const CAction &action) override;
-  void Render() override;
-  void RenderEx() override;
-  void Process(unsigned int currentTime, CDirtyRegionList &regions) override;
-  void OnDeinitWindow(int nextWindowID) override;
-
-  void Reset();
-  void Add(const CFileItem *picture);
-  bool IsPlaying() const;
-  void Select(const std::string& strPicture);
-  void GetSlideShowContents(CFileItemList &list);
-  std::shared_ptr<const CFileItem> GetCurrentSlide();
-  void RunSlideShow(const std::string &strPath, bool bRecursive = false,
-                    bool bRandom = false, bool bNotRandom = false,
-                    const std::string &beginSlidePath="", bool startSlideShow = true,
+  // Implementation of ISlideShowDelegate
+  void Add(const CFileItem* picture) override;
+  bool IsPlaying() const override;
+  void Select(const std::string& picture) override;
+  void GetSlideShowContents(CFileItemList& list) override;
+  std::shared_ptr<const CFileItem> GetCurrentSlide() override;
+  void StartSlideShow() override;
+  bool InSlideShow() const override;
+  int NumSlides() const override;
+  int CurrentSlide() const override;
+  bool IsPaused() const override { return m_bPause; }
+  bool IsShuffled() const override { return m_bShuffled; }
+  void Reset() override;
+  void RunSlideShow(const std::string& strPath,
+                    bool bRecursive = false,
+                    bool bRandom = false,
+                    bool bNotRandom = false,
+                    const std::string& beginSlidePath = "",
+                    bool startSlideShow = true,
                     SortBy method = SortByLabel,
                     SortOrder order = SortOrderAscending,
                     SortAttribute sortAttributes = SortAttributeNone,
-                    const std::string &strExtensions="");
-  void AddFromPath(const std::string &strPath, bool bRecursive,
+                    const std::string& strExtensions = "") override;
+  void AddFromPath(const std::string& strPath,
+                   bool bRecursive,
                    SortBy method = SortByLabel,
                    SortOrder order = SortOrderAscending,
                    SortAttribute sortAttributes = SortAttributeNone,
-                   const std::string &strExtensions="");
-  void StartSlideShow();
-  bool InSlideShow() const;
+                   const std::string& strExtensions = "") override;
+  void Shuffle() override;
+  int GetDirection() const override { return m_iDirection; }
+
+  bool OnMessage(CGUIMessage& message) override;
+  EVENT_RESULT OnMouseEvent(const CPoint& point, const CMouseEvent& event) override;
+  bool OnAction(const CAction& action) override;
+  void Render() override;
+  void RenderEx() override;
+  void Process(unsigned int currentTime, CDirtyRegionList& regions) override;
+  void OnDeinitWindow(int nextWindowID) override;
+
   void OnLoadPic(int iPic,
                  int iSlideNumber,
                  const std::string& strFileName,
                  std::unique_ptr<CTexture> pTexture,
                  bool bFullSize);
-  int NumSlides() const;
-  int CurrentSlide() const;
-  void Shuffle();
-  bool IsPaused() const { return m_bPause; }
-  bool IsShuffled() const { return m_bShuffled; }
-  int GetDirection() const { return m_iDirection; }
 
   static void RunSlideShow(const std::vector<std::string>& paths, int start = 0);
 

--- a/xbmc/pictures/SlideShowDelegator.cpp
+++ b/xbmc/pictures/SlideShowDelegator.cpp
@@ -1,0 +1,170 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "SlideShowDelegator.h"
+
+void CSlideShowDelegator::SetDelegate(ISlideShowDelegate* delegate)
+{
+  m_delegate = delegate;
+}
+
+void CSlideShowDelegator::ResetDelegate()
+{
+  m_delegate = nullptr;
+}
+
+void CSlideShowDelegator::Add(const CFileItem* picture)
+{
+  if (m_delegate)
+  {
+    m_delegate->Add(picture);
+  }
+}
+
+bool CSlideShowDelegator::IsPlaying() const
+{
+  if (m_delegate)
+  {
+    return m_delegate->IsPlaying();
+  }
+  return false;
+}
+
+void CSlideShowDelegator::Select(const std::string& picture)
+{
+  if (m_delegate)
+  {
+    m_delegate->Select(picture);
+  }
+}
+
+void CSlideShowDelegator::GetSlideShowContents(CFileItemList& list)
+{
+  if (m_delegate)
+  {
+    m_delegate->GetSlideShowContents(list);
+  }
+}
+
+std::shared_ptr<const CFileItem> CSlideShowDelegator::GetCurrentSlide()
+{
+  if (m_delegate)
+  {
+    return m_delegate->GetCurrentSlide();
+  }
+  return nullptr;
+}
+
+void CSlideShowDelegator::StartSlideShow()
+{
+  if (m_delegate)
+  {
+    m_delegate->StartSlideShow();
+  }
+}
+
+bool CSlideShowDelegator::InSlideShow() const
+{
+  if (m_delegate)
+  {
+    return m_delegate->InSlideShow();
+  }
+  return false;
+}
+
+int CSlideShowDelegator::NumSlides() const
+{
+  if (m_delegate)
+  {
+    return m_delegate->NumSlides();
+  }
+  return -1;
+}
+
+int CSlideShowDelegator::CurrentSlide() const
+{
+  if (m_delegate)
+  {
+    return m_delegate->CurrentSlide();
+  }
+  return -1;
+}
+
+bool CSlideShowDelegator::IsPaused() const
+{
+  if (m_delegate)
+  {
+    return m_delegate->IsPaused();
+  }
+  return false;
+}
+
+bool CSlideShowDelegator::IsShuffled() const
+{
+  if (m_delegate)
+  {
+    return m_delegate->IsShuffled();
+  }
+  return false;
+}
+
+void CSlideShowDelegator::Reset()
+{
+  if (m_delegate)
+  {
+    m_delegate->Reset();
+  }
+}
+
+void CSlideShowDelegator::Shuffle()
+{
+  if (m_delegate)
+  {
+    m_delegate->Shuffle();
+  }
+}
+
+int CSlideShowDelegator::GetDirection() const
+{
+  if (m_delegate)
+  {
+    return m_delegate->GetDirection();
+  }
+  return -1;
+}
+
+void CSlideShowDelegator::RunSlideShow(const std::string& strPath,
+                                       bool bRecursive,
+                                       bool bRandom,
+                                       bool bNotRandom,
+                                       const std::string& beginSlidePath,
+                                       bool startSlideShow,
+                                       SortBy method,
+                                       SortOrder order,
+                                       SortAttribute sortAttributes,
+                                       const std::string& strExtensions)
+{
+  if (m_delegate)
+  {
+    m_delegate->RunSlideShow(strPath, bRecursive, bRandom, bNotRandom, beginSlidePath,
+                             startSlideShow, method, order, sortAttributes, strExtensions);
+  }
+}
+
+void CSlideShowDelegator::AddFromPath(const std::string& strPath,
+                                      bool bRecursive,
+                                      SortBy method,
+                                      SortOrder order,
+                                      SortAttribute sortAttributes,
+                                      const std::string& strExtensions)
+{
+  if (m_delegate)
+  {
+    m_delegate->AddFromPath(strPath, bRecursive, method, order, sortAttributes, strExtensions);
+  }
+}

--- a/xbmc/pictures/SlideShowDelegator.h
+++ b/xbmc/pictures/SlideShowDelegator.h
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "interfaces/ISlideShowDelegate.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+class CSlideShowDelegator : public ISlideShowDelegate
+{
+public:
+  CSlideShowDelegator() = default;
+  ~CSlideShowDelegator() = default;
+
+  void SetDelegate(ISlideShowDelegate* delegate);
+  void ResetDelegate();
+
+  // Implementation of ISlideShowDelegate
+  void Add(const CFileItem* picture) override;
+  bool IsPlaying() const override;
+  void Select(const std::string& picture) override;
+  void GetSlideShowContents(CFileItemList& list) override;
+  std::shared_ptr<const CFileItem> GetCurrentSlide() override;
+  void StartSlideShow() override;
+  bool InSlideShow() const override;
+  int NumSlides() const override;
+  int CurrentSlide() const override;
+  bool IsPaused() const override;
+  bool IsShuffled() const override;
+  void Reset() override;
+  void Shuffle() override;
+  int GetDirection() const override;
+  void RunSlideShow(const std::string& strPath,
+                    bool bRecursive = false,
+                    bool bRandom = false,
+                    bool bNotRandom = false,
+                    const std::string& beginSlidePath = "",
+                    bool startSlideShow = true,
+                    SortBy method = SortByLabel,
+                    SortOrder order = SortOrderAscending,
+                    SortAttribute sortAttributes = SortAttributeNone,
+                    const std::string& strExtensions = "") override;
+  void AddFromPath(const std::string& strPath,
+                   bool bRecursive,
+                   SortBy method = SortByLabel,
+                   SortOrder order = SortOrderAscending,
+                   SortAttribute sortAttributes = SortAttributeNone,
+                   const std::string& strExtensions = "") override;
+
+private:
+  ISlideShowDelegate* m_delegate;
+};

--- a/xbmc/pictures/interfaces/ISlideShowDelegate.h
+++ b/xbmc/pictures/interfaces/ISlideShowDelegate.h
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (C) 2023 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "utils/SortUtils.h"
+
+#include <memory>
+
+class CFileItem;
+class CFileItemList;
+
+class ISlideShowDelegate
+{
+public:
+  ISlideShowDelegate() = default;
+  virtual ~ISlideShowDelegate() = default;
+
+  virtual void Add(const CFileItem* picture) = 0;
+  virtual bool IsPlaying() const = 0;
+  virtual void Select(const std::string& picture) = 0;
+  virtual void GetSlideShowContents(CFileItemList& list) = 0;
+  virtual std::shared_ptr<const CFileItem> GetCurrentSlide() = 0;
+  virtual void StartSlideShow() = 0;
+  virtual bool InSlideShow() const = 0;
+  virtual int NumSlides() const = 0;
+  virtual int CurrentSlide() const = 0;
+  virtual bool IsPaused() const = 0;
+  virtual bool IsShuffled() const = 0;
+  virtual void Reset() = 0;
+  virtual void Shuffle() = 0;
+  virtual int GetDirection() const = 0;
+  //! @todo - refactor to use an options struct. Methods with so many arguments are a sign of a bad design...
+  virtual void RunSlideShow(const std::string& strPath,
+                            bool bRecursive = false,
+                            bool bRandom = false,
+                            bool bNotRandom = false,
+                            const std::string& beginSlidePath = "",
+                            bool startSlideShow = true,
+                            SortBy method = SortByLabel,
+                            SortOrder order = SortOrderAscending,
+                            SortAttribute sortAttributes = SortAttributeNone,
+                            const std::string& strExtensions = "") = 0;
+  //! @todo - refactor to use an options struct. Methods with so many arguments are a sign of a bad design...
+  virtual void AddFromPath(const std::string& strPath,
+                           bool bRecursive,
+                           SortBy method = SortByLabel,
+                           SortOrder order = SortOrderAscending,
+                           SortAttribute sortAttributes = SortAttributeNone,
+                           const std::string& strExtensions = "") = 0;
+};

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -38,7 +38,7 @@
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "network/Network.h"
-#include "pictures/GUIWindowSlideShow.h"
+#include "pictures/SlideShowDelegator.h"
 #include "platform/Filesystem.h"
 #include "playlists/PlayList.h"
 #include "playlists/PlayListFactory.h"
@@ -672,18 +672,15 @@ void CGUIWindowFileManager::OnStart(CFileItem *pItem, const std::string &player)
 #endif
   if (pItem->IsPicture())
   {
-    CGUIWindowSlideShow *pSlideShow = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIWindowSlideShow>(WINDOW_SLIDESHOW);
-    if (!pSlideShow)
-      return ;
-
     const auto& components = CServiceBroker::GetAppComponents();
     const auto appPlayer = components.GetComponent<CApplicationPlayer>();
     if (appPlayer->IsPlayingVideo())
       g_application.StopPlaying();
 
-    pSlideShow->Reset();
-    pSlideShow->Add(pItem);
-    pSlideShow->Select(pItem->GetPath());
+    CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
+    slideShow.Reset();
+    slideShow.Add(pItem);
+    slideShow.Select(pItem->GetPath());
 
     CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_SLIDESHOW);
     return;


### PR DESCRIPTION
## Description
Currently the slideshow functionality is shuffled completely into `GUIWindowSlideshow` which ties all components that somehow depend on the slideshow functionality (or slideshow state) to GUI. This spreads GUI includes everywhere making strong couplings between components that should be able to outlive in a headless world -  to a specific window (and inherently to GUI). This PR tries to solve that issue by implementing a delegation design pattern where a delegator (an application service) proxies the respective calls to the delegates:

- `SlideShowDelegator` is an app service registered/obtainable from servicebroker
- When GUI is registered and the `GUIWindowSlideShow` is created it registers itself into the delegator as a delegate
- All component slideshow calls go from the delegator to the delegate if it exists

This means that if somehow Kodi is running headless and GUI is not built or started, no delegate exists on the `SlideShowDelegator` and all other components that have internal slideshow logic are still able to function properly.

## Motivation and context
Honestly, being able to remove GUI dependencies from UPnP. It's still not completely done but this sets the blueprint to build upon on further refactors. Should make the path to headless a bit closer :)
I've left a few todos in places I think we can improve (e.g. make other components react dynamically to events without having to actually call the main logic). There's also two things missing that I plan to work on after this gets in:

- Slideshow controls right now use GUI Actions (should be proxied from the delegate to avoid that dependency on GUI as well). Also should be handled as any other media types (via PlaylistPlayer) without requiring branches on common code.

- Slideshow/picture playback detection is still being done by checking if the active window is `WINDOW_SLIDESHOW`. This is not only wrong due to GUI coupling but also does not work the way it's intended. Slideshow is a dialog and it's not part of the window history so that returns false even though the dialog is visible :)

## How has this been tested?
Runtime tested. Running slideshows, viewing pictures and making Json-RPC calls is pretty much sufficient. This only decouples components and proxies calls anyway.

## What is the effect on users?
Hopefully none.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
