### PR TITLE
[video] Video version dialog: Fix wrong item played.

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoVersion.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoVersion.cpp
@@ -289,9 +289,8 @@ namespace
 class CVideoPlayActionProcessor : public VIDEO::GUILIB::CVideoPlayActionProcessorBase
 {
 public:
-  explicit CVideoPlayActionProcessor(const std::shared_ptr<CFileItem>& item,
-                                     const std::shared_ptr<CFileItem>& videoVersion)
-    : CVideoPlayActionProcessorBase(item, videoVersion)
+  explicit CVideoPlayActionProcessor(const std::shared_ptr<CFileItem>& item)
+    : CVideoPlayActionProcessorBase(item)
   {
   }
 
@@ -325,7 +324,7 @@ void CGUIDialogVideoVersion::Play()
 {
   CloseAll();
 
-  CVideoPlayActionProcessor proc{m_videoItem, m_selectedVideoVersion};
+  CVideoPlayActionProcessor proc{m_selectedVideoVersion};
   proc.ProcessDefaultAction();
 }
 

--- a/xbmc/video/guilib/VideoPlayActionProcessor.h
+++ b/xbmc/video/guilib/VideoPlayActionProcessor.h
@@ -22,11 +22,6 @@ class CVideoPlayActionProcessorBase
 {
 public:
   explicit CVideoPlayActionProcessorBase(const std::shared_ptr<CFileItem>& item) : m_item(item) {}
-  CVideoPlayActionProcessorBase(const std::shared_ptr<CFileItem>& item,
-                                const std::shared_ptr<const CFileItem>& videoVersion)
-    : m_item{item}, m_videoVersion{videoVersion}
-  {
-  }
   virtual ~CVideoPlayActionProcessorBase() = default;
 
   bool ProcessDefaultAction();
@@ -48,8 +43,6 @@ protected:
 
 private:
   CVideoPlayActionProcessorBase() = delete;
-
-  const std::shared_ptr<const CFileItem> m_videoVersion;
 };
 } // namespace GUILIB
 } // namespace VIDEO

--- a/xbmc/video/guilib/VideoSelectActionProcessor.h
+++ b/xbmc/video/guilib/VideoSelectActionProcessor.h
@@ -26,12 +26,6 @@ public:
   {
   }
 
-  CVideoSelectActionProcessorBase(const std::shared_ptr<CFileItem>& item,
-                                  const std::shared_ptr<const CFileItem>& videoVersion)
-    : CVideoPlayActionProcessorBase(item, videoVersion)
-  {
-  }
-
   ~CVideoSelectActionProcessorBase() override = default;
 
   static Action GetDefaultSelectAction();


### PR DESCRIPTION
Fix fallout from a recent refactoring (not the dialog cleanup, something that happened earlier). On playback triggered from video versions dialog, the wrong item was played if selected item was not the default video version.

Runtime-tested on macOS, latest Kodi master.

@enen92 sorry to bother you one more time... 