### PR TITLE
[UPnP] Access to g_UserData must be protected

### DIFF
--- a/xbmc/network/upnp/UPnP.cpp
+++ b/xbmc/network/upnp/UPnP.cpp
@@ -390,57 +390,79 @@ public:
   } while(0)
 
   void OnStopResult(NPT_Result res, PLT_DeviceDataReference& device, void* userdata) override
-  { CHECK_USERDATA_RETURN(userdata);
+  {
+    NPT_AutoLock lock(g_UserDataLock);
+    CHECK_USERDATA_RETURN(userdata);
     static_cast<PLT_MediaControllerDelegate*>(userdata)->OnStopResult(res, device, userdata);
   }
 
   void OnSetPlayModeResult(NPT_Result res, PLT_DeviceDataReference& device, void* userdata) override
-  { CHECK_USERDATA_RETURN(userdata);
+  {
+    NPT_AutoLock lock(g_UserDataLock);
+    CHECK_USERDATA_RETURN(userdata);
     static_cast<PLT_MediaControllerDelegate*>(userdata)->OnSetPlayModeResult(res, device, userdata);
   }
 
   void OnSetAVTransportURIResult(NPT_Result res, PLT_DeviceDataReference& device, void* userdata) override
-  { CHECK_USERDATA_RETURN(userdata);
+  {
+    NPT_AutoLock lock(g_UserDataLock);
+    CHECK_USERDATA_RETURN(userdata);
     static_cast<PLT_MediaControllerDelegate*>(userdata)->OnSetAVTransportURIResult(res, device, userdata);
   }
 
   void OnSeekResult(NPT_Result res, PLT_DeviceDataReference& device, void* userdata) override
-  { CHECK_USERDATA_RETURN(userdata);
+  {
+    NPT_AutoLock lock(g_UserDataLock);
+    CHECK_USERDATA_RETURN(userdata);
     static_cast<PLT_MediaControllerDelegate*>(userdata)->OnSeekResult(res, device, userdata);
   }
 
   void OnPreviousResult(NPT_Result res, PLT_DeviceDataReference& device, void* userdata) override
-  { CHECK_USERDATA_RETURN(userdata);
+  {
+    NPT_AutoLock lock(g_UserDataLock);
+    CHECK_USERDATA_RETURN(userdata);
     static_cast<PLT_MediaControllerDelegate*>(userdata)->OnPreviousResult(res, device, userdata);
   }
 
   void OnPlayResult(NPT_Result res, PLT_DeviceDataReference& device, void* userdata) override
-  { CHECK_USERDATA_RETURN(userdata);
+  {
+    NPT_AutoLock lock(g_UserDataLock);
+    CHECK_USERDATA_RETURN(userdata);
     static_cast<PLT_MediaControllerDelegate*>(userdata)->OnPlayResult(res, device, userdata);
   }
 
   void OnPauseResult(NPT_Result res, PLT_DeviceDataReference& device, void* userdata) override
-  { CHECK_USERDATA_RETURN(userdata);
+  {
+    NPT_AutoLock lock(g_UserDataLock);
+    CHECK_USERDATA_RETURN(userdata);
     static_cast<PLT_MediaControllerDelegate*>(userdata)->OnPauseResult(res, device, userdata);
   }
 
   void OnNextResult(NPT_Result res, PLT_DeviceDataReference& device, void* userdata) override
-  { CHECK_USERDATA_RETURN(userdata);
+  {
+    NPT_AutoLock lock(g_UserDataLock);
+    CHECK_USERDATA_RETURN(userdata);
     static_cast<PLT_MediaControllerDelegate*>(userdata)->OnNextResult(res, device, userdata);
   }
 
   void OnGetMediaInfoResult(NPT_Result res, PLT_DeviceDataReference& device, PLT_MediaInfo* info, void* userdata) override
-  { CHECK_USERDATA_RETURN(userdata);
+  {
+    NPT_AutoLock lock(g_UserDataLock);
+    CHECK_USERDATA_RETURN(userdata);
     static_cast<PLT_MediaControllerDelegate*>(userdata)->OnGetMediaInfoResult(res, device, info, userdata);
   }
 
   void OnGetPositionInfoResult(NPT_Result res, PLT_DeviceDataReference& device, PLT_PositionInfo* info, void* userdata) override
-  { CHECK_USERDATA_RETURN(userdata);
+  {
+    NPT_AutoLock lock(g_UserDataLock);
+    CHECK_USERDATA_RETURN(userdata);
     static_cast<PLT_MediaControllerDelegate*>(userdata)->OnGetPositionInfoResult(res, device, info, userdata);
   }
 
   void OnGetTransportInfoResult(NPT_Result res, PLT_DeviceDataReference& device, PLT_TransportInfo* info, void* userdata) override
-  { CHECK_USERDATA_RETURN(userdata);
+  {
+    NPT_AutoLock lock(g_UserDataLock);
+    CHECK_USERDATA_RETURN(userdata);
     static_cast<PLT_MediaControllerDelegate*>(userdata)->OnGetTransportInfoResult(res, device, info, userdata);
   }
 


### PR DESCRIPTION
## Description
Another easy one...access to the userdata map in UPnP must be lock protected before access. Those locks already exists on `Register` and `Unregister`. All those callbacks that are part of the diff are invoked by the library itself (thus from arbitrary threads) when remote renderers notify the player.

Found while sending bluray iso's from Kodi to another Kodi via UPnP. Since the simple menu is shown on the target player, it is not actually playing the file yet so playback is stopped on the "sender" and the "userdata" removed from the map (this should be fixed...). Later when you actually start the playback by selecting a track, the rendererer notifies the player of the event but the callback/userdata class no longer exists. If the callback happens when the userdata is being removed, kodi crashes.