### PR TITLE
[ContextMenus][PVR] Do not show play using for live tv

### DIFF
--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -414,6 +414,9 @@ bool CVideoPlayUsing::IsVisible(const CFileItem& itemIn) const
   if (itemIn.HasVideoVersions())
     return false; // display "Play version using..." if multiple versions are available.
 
+  if (itemIn.IsLiveTV())
+    return false;
+
   const CFileItem item{itemIn.GetItemToPlay()};
   const CPlayerCoreFactory& playerCoreFactory{CServiceBroker::GetPlayerCoreFactory()};
   return (GetPlayers(playerCoreFactory, item).size() > 1) && VIDEO_UTILS::IsItemPlayable(item);


### PR DESCRIPTION
## Description

It seems that, unfortunately, picking up a player for live tv channels is not supported. Hitting the context menu always plays using the default player (see https://github.com/xbmc/xbmc/blob/ffbc0975418c9cac34c057d7e91c834ef0d5b691/xbmc/video/ContextMenus.cpp#L336-L338). Since this is not supported, lets avoid showing the `Play Using...` context menu item in such cases since `Switch to Channel` already does the same.
Hopefully it could somehow be supported in the future. I'd expect `pvr://` to work similar to plugins with the dynpath set to the actual stream url.