### PR TITLE
[ContextMenus] Don't show move up/down if single favourite

### DIFF
--- a/xbmc/favourites/FavouritesService.cpp
+++ b/xbmc/favourites/FavouritesService.cpp
@@ -313,6 +313,12 @@ std::shared_ptr<CFileItem> CFavouritesService::ResolveFavourite(const CFileItem&
   return {};
 }
 
+int CFavouritesService::Size() const
+{
+  std::unique_lock<CCriticalSection> lock(m_criticalSection);
+  return m_favourites.Size();
+}
+
 void CFavouritesService::GetAll(CFileItemList& items) const
 {
   std::unique_lock<CCriticalSection> lock(m_criticalSection);

--- a/xbmc/favourites/FavouritesService.h
+++ b/xbmc/favourites/FavouritesService.h
@@ -30,6 +30,7 @@ public:
   std::shared_ptr<CFileItem> GetFavourite(const CFileItem& item, int contextWindow) const;
   std::shared_ptr<CFileItem> ResolveFavourite(const CFileItem& favItem) const;
 
+  int Size() const;
   void GetAll(CFileItemList& items) const;
   bool AddOrRemove(const CFileItem& item, int contextWindow);
   bool Save(const CFileItemList& items);

--- a/xbmc/favourites/FavouritesUtils.cpp
+++ b/xbmc/favourites/FavouritesUtils.cpp
@@ -111,6 +111,9 @@ bool RemoveItem(CFileItemList& items, const std::shared_ptr<CFileItem>& item)
 
 bool ShouldEnableMoveItems()
 {
+  if (CServiceBroker::GetFavouritesService().Size() <= 1)
+    return false;
+
   auto& mgr = CServiceBroker::GetGUI()->GetWindowManager();
   CGUIWindowFavourites* window = mgr.GetWindow<CGUIWindowFavourites>(WINDOW_FAVOURITES);
   if (window && window->IsActive())


### PR DESCRIPTION
## Description
Partial fix for https://github.com/xbmc/xbmc/issues/24187, avoid showing move up/down in context menus if the favourite list size is 1.