### PR TITLE
[dialogs] Fix CGUIDialogSubtitleSettings::BrowseForSubtitle to use it…

### DIFF
--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
@@ -128,13 +128,14 @@ std::string CGUIDialogSubtitleSettings::BrowseForSubtitle()
   }
 
   std::string strPath;
-  if (URIUtils::IsInRAR(g_application.CurrentFileItem().GetPath()) || URIUtils::IsInZIP(g_application.CurrentFileItem().GetPath()))
+  const std::string dynPath{g_application.CurrentFileItem().GetDynPath()};
+  if (URIUtils::IsInRAR(dynPath) || URIUtils::IsInZIP(dynPath))
   {
-    strPath = CURL(g_application.CurrentFileItem().GetPath()).GetHostName();
+    strPath = CURL(dynPath).GetHostName();
   }
-  else if (!URIUtils::IsPlugin(g_application.CurrentFileItem().GetPath()))
+  else if (!URIUtils::IsPlugin(dynPath))
   {
-    strPath = g_application.CurrentFileItem().GetPath();
+    strPath = dynPath;
   }
 
   std::string strMask =


### PR DESCRIPTION
…em's dynpath, not path.

Fixes #24219
 
Runtime-tested on macOS, latest Kodi master.

@enen92 here we go with another dynpath issue. We will (and need to) catch them all over time, the question is, "how long will this take"?