### PR TITLE
[Video] Improve episode display/selection for multi-episode discs.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -8097,7 +8097,11 @@ msgctxt "#14084"
 msgid "Queue songs on selection"
 msgstr ""
 
-#empty string with id 14085
+#. Name of a setting for DVD playback mode
+#: system/settings/settings.xml
+msgctxt "#14085"
+msgid "DVD playback mode"
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#14086"
@@ -16608,7 +16612,14 @@ msgctxt "#29805"
 msgid "This Blu-ray disc (or file) is encrypted and can't be played."
 msgstr ""
 
-#empty strings from id 29806 to 29899
+#. A DVD playback mode and a option in the simplified DVD menu
+#: xbmc/filesystem/DVDDirectory.cpp
+#: system/settings/settings.xml
+msgctxt "#29806"
+msgid "Show DVD menu"
+msgstr ""
+
+#empty strings from id 29807 to 29899
 
 #. Header string on RDS Radiotext+ Info dialog
 #: addons/skin.estuary/xml/DialogPVRRadioRDSInfo.xml
@@ -22225,7 +22236,13 @@ msgctxt "#37057"
 msgid "Data chunk size used on SMB connections"
 msgstr ""
 
-#empty strings from id 37058 to 37100
+#. Description of setting #14129 DVD playback mode
+#: system/settings/settings.xml
+msgctxt "#37058"
+msgid "Specifies how DVDs should be opened / played back. Note: Some disc menus are not fully supported and may cause problems."
+msgstr ""
+
+#empty strings from id 37059 to 37100
 
 #. Settings / Services "Caching" category label
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -395,10 +395,25 @@
           </constraints>
           <control type="spinner" format="string" />
         </setting>
+        <setting id="dvds.playback" type="integer" label="14085" help="37058">
+          <level>1</level>
+          <default>1</default> <!-- default -->
+          <constraints>
+            <options>
+              <option label="14104">0</option> <!-- show simplified menu -->
+              <option label="29806">1</option> <!-- show disc menu -->
+              <option label="14103">2</option> <!-- play main movie -->
+            </options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
         <setting id="dvds.automenu" type="boolean" label="21882" help="36196">
           <level>2</level>
           <default>false</default>
           <control type="toggle" />
+          <dependencies>
+            <dependency type="enable" setting="dvds.playback" operator="is">1</dependency>
+          </dependencies>
         </setting>
       </group>
       <group id="2" label="14234">

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -535,6 +535,7 @@ CFileItem& CFileItem::operator=(const CFileItem& item)
   m_specialSort = item.m_specialSort;
   m_bIsAlbum = item.m_bIsAlbum;
   m_doContentLookup = item.m_doContentLookup;
+  m_titlesJob = item.m_titlesJob;
   return *this;
 }
 
@@ -561,6 +562,7 @@ void CFileItem::Initialize()
   m_bCanQueue = true;
   m_specialSort = SortSpecialNone;
   m_doContentLookup = true;
+  m_titlesJob = 0;
 }
 
 void CFileItem::Reset()
@@ -1621,7 +1623,9 @@ bool CFileItem::IsAlbum() const
   return m_bIsAlbum;
 }
 
-void CFileItem::UpdateInfo(const CFileItem &item, bool replaceLabels /*=true*/)
+void CFileItem::UpdateInfo(const CFileItem& item,
+                           bool replaceLabels /*=true*/,
+                           bool replaceEpisodes /* false */)
 {
   if (item.HasVideoInfoTag())
   { // copy info across
@@ -1684,12 +1688,91 @@ void CFileItem::UpdateInfo(const CFileItem &item, bool replaceLabels /*=true*/)
     SetInvalid();
   }
   SetDynPath(item.GetDynPath());
-  if (replaceLabels && !item.GetLabel().empty())
-    SetLabel(item.GetLabel());
+
+  // Alter label to episode number(s) if requested
+  if (replaceLabels)
+  {
+    std::string label;
+    if (item.GetVideoContentType() == VideoDbContentType::EPISODES && replaceEpisodes &&
+        (item.IsDiscImage() || item.IsDVDFile() || item.IsBluray()))
+    {
+      // Get episodes on disc
+      CVideoDatabase database;
+      if (!database.Open())
+      {
+        CLog::LogF(LOGERROR, "Failed to open video database");
+        return;
+      }
+
+      std::vector<CVideoInfoTag> episodes;
+      database.GetEpisodesByFileId(item.GetVideoInfoTag()->m_iFileId, episodes);
+      if (!episodes.empty())
+      {
+        bool specials = false;
+        const int startEpisode =
+            (*std::min_element(episodes.begin(), episodes.end(),
+                               [&](const CVideoInfoTag& i, const CVideoInfoTag& j)
+                               {
+                                 if (i.m_iSeason == 0 && j.m_iSeason != 0)
+                                   return false;
+                                 if (i.m_iSeason != 0 && j.m_iSeason == 0)
+                                   return true;
+                                 return i.m_iEpisode < j.m_iEpisode;
+                               }))
+                .m_iEpisode;
+        const int endEpisode =
+            (*std::max_element(episodes.begin(), episodes.end(),
+                               [&](const CVideoInfoTag& i, const CVideoInfoTag& j)
+                               {
+                                 if (i.m_iSeason == 0 && j.m_iSeason != 0)
+                                   return true;
+                                 if (i.m_iSeason != 0 && j.m_iSeason == 0)
+                                   return false;
+                                 return i.m_iEpisode < j.m_iEpisode;
+                               }))
+                .m_iEpisode;
+        if (std::count_if(episodes.begin(), episodes.end(),
+                          [&](const CVideoInfoTag& i) { return i.m_iSeason == 0; }) > 0)
+          specials = true;
+
+        if (startEpisode == endEpisode)
+          label = StringUtils::Format("{} {}", g_localizeStrings.Get(20359) /* Episode */,
+                                      startEpisode);
+        else
+        {
+          label = StringUtils::Format("{} {}-{}", g_localizeStrings.Get(20360) /* Episodes */,
+                                      startEpisode, endEpisode);
+
+          // Get description of plot as more generic for multiple episodes
+          CVideoInfoTag details;
+          database.GetTvShowInfo(GetPath(), details, GetVideoInfoTag()->m_iIdShow);
+          std::string strParentDirectory;
+          URIUtils::GetParentPath(details.m_basePath, strParentDirectory);
+          CFileItemList dbItems;
+          database.GetItemsForPath("tvshows", strParentDirectory, dbItems);
+          const CFileItemPtr match = dbItems.Get(details.m_basePath);
+          m_videoInfoTag->m_strPlot = match->GetVideoInfoTag()->m_strPlot;
+        }
+
+        if (specials)
+          label += StringUtils::Format(" and Specials");
+
+        m_titlesJob = TITLES_JOB_ALL_EPISODES;
+      }
+    }
+    else if (!item.GetLabel().empty())
+    {
+      label = item.GetLabel();
+    }
+    if (!label.empty())
+      SetLabel(label);
+  }
+
   if (replaceLabels && !item.GetLabel2().empty())
     SetLabel2(item.GetLabel2());
   if (!item.GetArt().empty())
     SetArt(item.GetArt());
+
   AppendProperties(item);
   UpdateMimeType();
 }

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1694,7 +1694,7 @@ void CFileItem::UpdateInfo(const CFileItem& item,
   {
     std::string label;
     if (item.GetVideoContentType() == VideoDbContentType::EPISODES && replaceEpisodes &&
-        (item.IsDiscImage() || item.IsDVDFile() || item.IsBluray()))
+        (item.IsDiscImage() || IsDVDFile(item) || item.IsBluray()))
     {
       // Get episodes on disc
       CVideoDatabase database;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -552,8 +552,9 @@ public:
    in the given item.
    \param item the item used to supplement information
    \param replaceLabels whether to replace labels (defaults to true)
+   \param replaceEpisodes whether to list all episodes on multi-episode disc (defaults to false)
    */
-  void UpdateInfo(const CFileItem &item, bool replaceLabels = true);
+  void UpdateInfo(const CFileItem& item, bool replaceLabels = true, bool replaceEpisodes = false);
 
   /*! \brief Merge an item with information from another item
   We take metadata/art information from the given item and supplement the current
@@ -605,6 +606,16 @@ public:
   std::string m_strLockCode;
   int m_iHasLock; // 0 - no lock 1 - lock, but unlocked 2 - locked
   int m_iBadPwdCount;
+
+  enum TITLES_JOB
+  {
+    TITLES_JOB_MAIN_TITLE = 0, // Default
+    TITLES_JOB_ALL_TITLES = 1,
+    TITLES_JOB_SINGLE_EPISODE = 2,
+    TITLES_JOB_ALL_EPISODES = 3
+  };
+
+  int m_titlesJob;
 
   void SetCueDocument(const CCueDocumentPtr& cuePtr);
   void LoadEmbeddedCue();
@@ -659,7 +670,6 @@ private:
   bool m_bIsAlbum;
   int64_t m_lStartOffset;
   int64_t m_lEndOffset;
-
   CCueDocumentPtr m_cueDocument;
 };
 

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -2424,12 +2424,12 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
     }
   }
 
-  // a disc image might be Blu-Ray disc
+  // a disc image might be DVD or Blu-Ray disc
   if (!(options.startpercent > 0.0 || options.starttime > 0.0) &&
-      (IsBDFile(item) || item.IsDiscImage()))
+      (IsBDFile(item) || IsDVDFile(item) || item.IsDiscImage()))
   {
     // No video selection when using external or remote players (they handle it if supported)
-    const bool isSimpleMenuAllowed = [&]()
+    const bool isPlaylistChoiceAllowed = [&]()
     {
       const std::string defaulPlayer{
           player.empty() ? m_ServiceManager->GetPlayerCoreFactory().GetDefaultPlayer(item)
@@ -2441,9 +2441,9 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
       return !isExternalPlayer && !isRemotePlayer;
     }();
 
-    if (isSimpleMenuAllowed)
+    if (isPlaylistChoiceAllowed)
     {
-      // Check if we must show the simplified bd menu.
+      // Check if we must show the simplified menu.
       if (!CGUIDialogSimpleMenu::ShowPlaySelection(item))
         return true;
     }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -108,7 +108,7 @@ std::shared_ptr<CDVDInputStream> CDVDFactoryInputStream::CreateInputStream(IVide
   if (url.IsProtocol("dvd"))
     return std::make_shared<CDVDInputStreamNavigator>(pPlayer, fileitem);
 
-  if (VIDEO::fileitem, IsDVDFile(false, true))
+  if (VIDEO::IsDVDFile(fileitem,false, true))
     return std::make_shared<CDVDInputStreamNavigator>(pPlayer, fileitem);
   else if (URIUtils::IsPVRChannel(file))
     return std::make_shared<CInputStreamPVRChannel>(pPlayer, fileitem);

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -104,7 +104,11 @@ std::shared_ptr<CDVDInputStream> CDVDFactoryInputStream::CreateInputStream(IVide
   }
 #endif
 
-  if (VIDEO::IsDVDFile(fileitem, false, true))
+  CURL url{file};
+  if (url.IsProtocol("dvd"))
+    return std::make_shared<CDVDInputStreamNavigator>(pPlayer, fileitem);
+
+  if (VIDEO::fileitem, IsDVDFile(false, true))
     return std::make_shared<CDVDInputStreamNavigator>(pPlayer, fileitem);
   else if (URIUtils::IsPVRChannel(file))
     return std::make_shared<CInputStreamPVRChannel>(pPlayer, fileitem);

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -329,11 +329,6 @@ bool CDVDInputStreamBluray::Open()
     m_navmode = false;
     m_titleInfo = GetTitleFile(filename);
   }
-  else if (mode == BD_PLAYBACK_MAIN_TITLE)
-  {
-    m_navmode = false;
-    m_titleInfo = GetTitleLongest();
-  }
   else if (resumable && m_item.GetStartOffset() == STARTOFFSET_RESUME && m_item.IsResumable())
   {
     // resuming a bluray for which we have a saved state - the playlist will be open later on SetState

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
@@ -126,6 +126,10 @@ public:
   CDVDInputStream::IPosTime* GetIPosTime() override { return this; }
   bool PosTime(int iTimeInMsec) override; //seek within current pg(c)
 
+  void GetPlaylistInfo(std::vector<std::vector<unsigned int>>& clips,
+                       std::vector<std::vector<unsigned int>>& playlists,
+                       std::map<unsigned int, std::string>& playlist_langs);
+
   std::string GetDVDTitleString();
 
   /*!
@@ -175,6 +179,7 @@ protected:
 
   int m_iTitleCount;
   int m_iTitle;
+  bool m_directToTitle;
 
   int m_iPartCount;
   int m_iPart;

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -25,8 +25,8 @@
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
+#include "video/VideoDatabase.h"
 #include "video/VideoFileItemClassify.h"
-#include "video/VideoInfoTag.h"
 
 using namespace KODI;
 
@@ -90,7 +90,7 @@ bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item)
 {
   std::string directory{};
 
-  if (VIDEO::IsDVDFile(item))
+  if (KODI::VIDEO::IsDVDFile(item))
   {
     std::string root = URIUtils::GetParentPath(item.GetDynPath());
     URIUtils::RemoveSlashAtEnd(root);
@@ -103,7 +103,7 @@ bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item)
     }
   }
 
-  if (VIDEO::IsBDFile(item))
+  if (KODI::VIDEO::IsBDFile(item))
   {
     std::string root = URIUtils::GetParentPath(item.GetDynPath());
     URIUtils::RemoveSlashAtEnd(root);

--- a/xbmc/dialogs/GUIDialogSimpleMenu.h
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.h
@@ -25,4 +25,8 @@ public:
 
 protected:
   static bool GetDirectoryItems(const std::string &path, CFileItemList &items, const XFILE::CDirectory::CHints &hints);
+  static bool GetEpisodeDirectoryItems(const std::string& path,
+                                       CFileItemList& items,
+                                       const CFileItem& item);
+  static bool GetMainItem(const std::string& path, CFileItem& main, const CFileItem& item);
 };

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -31,7 +31,6 @@
 
 #include <libbluray/bluray-version.h>
 #include <libbluray/bluray.h>
-#include <libbluray/filesystem.h>
 #include <libbluray/log_control.h>
 
 namespace XFILE
@@ -46,7 +45,7 @@ CBlurayDirectory::~CBlurayDirectory()
 
 void CBlurayDirectory::Dispose()
 {
-  if(m_bd)
+  if (m_bd)
   {
     bd_close(m_bd);
     m_bd = nullptr;
@@ -63,156 +62,888 @@ std::string CBlurayDirectory::GetBlurayID()
   return GetDiscInfoString(DiscInfo::ID);
 }
 
-std::string CBlurayDirectory::GetDiscInfoString(DiscInfo info)
+std::string CBlurayDirectory::GetDiscInfoString(DiscInfo info) const
 {
   switch (info)
   {
-  case XFILE::CBlurayDirectory::DiscInfo::TITLE:
-  {
-    if (!m_blurayInitialized)
-      return "";
-    const BLURAY_DISC_INFO* disc_info = bd_get_disc_info(m_bd);
-    if (!disc_info || !disc_info->bluray_detected)
-      return "";
-
-    std::string title = "";
-
-#if (BLURAY_VERSION > BLURAY_VERSION_CODE(1,0,0))
-    title = disc_info->disc_name ? disc_info->disc_name : "";
-#endif
-
-    return title;
-  }
-  case XFILE::CBlurayDirectory::DiscInfo::ID:
-  {
-    if (!m_blurayInitialized)
-      return "";
-
-    const BLURAY_DISC_INFO* disc_info = bd_get_disc_info(m_bd);
-    if (!disc_info || !disc_info->bluray_detected)
-      return "";
-
-    std::string id = "";
-
-#if (BLURAY_VERSION > BLURAY_VERSION_CODE(1,0,0))
-    id = disc_info->udf_volume_id ? disc_info->udf_volume_id : "";
-
-    if (id.empty())
+    case XFILE::CBlurayDirectory::DiscInfo::TITLE:
     {
-      id = HexToString(disc_info->disc_id, 20);
-    }
+      if (!m_blurayInitialized)
+        return "";
+      const BLURAY_DISC_INFO* disc_info = bd_get_disc_info(m_bd);
+      if (!disc_info || !disc_info->bluray_detected)
+        return "";
+
+      std::string title;
+
+#if (BLURAY_VERSION > BLURAY_VERSION_CODE(1, 0, 0))
+      title = disc_info->disc_name ? disc_info->disc_name : "";
 #endif
 
-    return id;
-  }
-  default:
-    break;
+      return title;
+    }
+    case XFILE::CBlurayDirectory::DiscInfo::ID:
+    {
+      if (!m_blurayInitialized)
+        return "";
+
+      const BLURAY_DISC_INFO* disc_info = bd_get_disc_info(m_bd);
+      if (!disc_info || !disc_info->bluray_detected)
+        return "";
+
+      std::string id;
+
+#if (BLURAY_VERSION > BLURAY_VERSION_CODE(1, 0, 0))
+      id = disc_info->udf_volume_id ? disc_info->udf_volume_id : "";
+
+      if (id.empty())
+      {
+        id = HexToString(disc_info->disc_id, 20);
+      }
+#endif
+
+      return id;
+    }
+    default:
+      break;
   }
 
   return "";
 }
 
-std::shared_ptr<CFileItem> CBlurayDirectory::GetTitle(const BLURAY_TITLE_INFO* title,
-                                                      const std::string& label)
+static constexpr unsigned int MIN_EPISODE_LENGTH = 15 * 60; // 15 minutes
+static constexpr unsigned int MAX_EPISODE_DIFFERENCE = 30; // 30 seconds
+static constexpr unsigned int MIN_SPECIAL_LENGTH = 5 * 60; // 5 minutes
+static constexpr unsigned int MAX_CLIPS_PER_EPISODE = 3;
+static constexpr unsigned int PLAYLIST_CLIP_OFFSET =
+    2; //First two entries in playlist array are playlist number and duration. Remaining entries are clip(s)
+static constexpr unsigned int CLIP_PLAYLIST_OFFSET =
+    2; // First two entries in clip array are clip number and duration. Remaining entries are playlist(s)
+
+void CBlurayDirectory::GetPlaylistInfo(std::vector<std::vector<unsigned int>>& clips,
+                                       std::vector<std::vector<unsigned int>>& playlists,
+                                       std::map<unsigned int, std::string>& playlist_langs) const
 {
-  std::string buf;
-  std::string chap;
+  // Get all titles on disc
+  // Sort by playlist for grouping later
+
+  CFileItemList allTitles;
+  GetTitles(GET_TITLES_ALL, allTitles, SORT_TITLES_NONE);
+  SortDescription sorting;
+  sorting.sortBy = SortByFile;
+  allTitles.Sort(sorting);
+
+  // Get information on all titles
+  // Including relationship between clips and playlists
+  // List all playlists
+
+  CLog::LogF(LOGDEBUG, "*** Playlist information ***");
+  for (const auto& title : allTitles)
+  {
+    CURL url(title->GetDynPath());
+    std::string filename = URIUtils::GetFileName(url.GetFileName());
+    unsigned int playlist;
+
+    if (sscanf(filename.c_str(), "%05u.mpls", &playlist) == 1)
+    {
+      BLURAY_TITLE_INFO* titleInfo = bd_get_playlist_info(m_bd, playlist, 0);
+      if (!titleInfo)
+      {
+        CLog::Log(LOGDEBUG, "Unable to get playlist {}", playlist);
+      }
+      else
+      {
+        // Save playlist
+        auto pl = std::vector<unsigned int>{playlist};
+
+        // Save playlist duration
+        pl.emplace_back(titleInfo->duration / 90000);
+
+        // Get clips
+        std::string clipsStr;
+        for (unsigned int i = 0; i < titleInfo->clip_count; ++i)
+        {
+          unsigned int clip;
+          sscanf(titleInfo->clips[i].clip_id, "%u", &clip);
+
+          // Add clip to playlist
+          pl.emplace_back(clip);
+
+          // Add/extend clip information
+          const auto& it =
+              std::find_if(clips.begin(), clips.end(),
+                           [&clip](const std::vector<unsigned int>& x) { return x[0] == clip; });
+          if (it == clips.end())
+          {
+            // First reference to clip
+            const unsigned int duration =
+                ((titleInfo->clips[i].out_time - titleInfo->clips[i].in_time) / 90000);
+            clips.emplace_back(std::vector<unsigned int>{clip, duration, playlist});
+          }
+          else
+            // Additional reference to clip
+            it->emplace_back(playlist);
+
+          std::string c(reinterpret_cast<char const*>(titleInfo->clips[i].clip_id));
+          clipsStr += c + ',';
+        }
+        if (!clipsStr.empty())
+          clipsStr.pop_back();
+
+        playlists.emplace_back(pl);
+
+        // Get languages
+        std::string langs;
+        for (int i = 0; i < titleInfo->clips[0].audio_stream_count; ++i)
+        {
+          std::string l(reinterpret_cast<char const*>(titleInfo->clips[0].audio_streams[i].lang));
+          langs += l + '/';
+        }
+        if (!langs.empty())
+          langs.pop_back();
+
+        playlist_langs[playlist] = langs;
+
+        CLog::Log(LOGDEBUG, "Playlist {}, Duration {}, Langs {}, Clips {} ", playlist,
+                  title->GetVideoInfoTag()->GetDuration(), langs, clipsStr);
+
+        bd_free_title_info(titleInfo);
+      }
+    }
+  }
+
+  // Sort and list clip info
+  std::sort(clips.begin(), clips.end(),
+            [](const std::vector<unsigned int>& i, const std::vector<unsigned int>& j)
+            { return (i[0] < j[0]); });
+  for (const auto& c : clips)
+  {
+    std::string ps(StringUtils::Format("Clip {0:d} duration {1:d} - playlists ", c[0], c[1]));
+    for (unsigned int i = CLIP_PLAYLIST_OFFSET; i < c.size(); ++i)
+    {
+      ps += StringUtils::Format("{0:d},", c[i]);
+    }
+    ps.pop_back();
+    CLog::Log(LOGDEBUG, ps);
+  }
+
+  CLog::LogF(LOGDEBUG, "*** Playlist information End ***");
+}
+
+void CBlurayDirectory::GetEpisodeTitles(const CFileItem& episode,
+                                        CFileItemList& items,
+                                        std::vector<CVideoInfoTag> episodesOnDisc,
+                                        const std::vector<std::vector<unsigned int>>& clips,
+                                        const std::vector<std::vector<unsigned int>>& playlists,
+                                        std::map<unsigned int, std::string>& playlist_langs) const
+{
+  // Find our episode on disc
+  // Need to differentiate between specials and episodes
+  std::vector<CVideoInfoTag> specialsOnDisc;
+  bool isSpecial = false;
+  unsigned int episodeOffset = 0;
+  const bool allEpisodes = episode.m_titlesJob == CFileItem::TITLES_JOB_ALL_EPISODES;
+
+  for (unsigned int i = 0; i < episodesOnDisc.size(); ++i)
+  {
+    if (episodesOnDisc[i].m_iSeason > 0 &&
+        episodesOnDisc[i].m_iSeason == episode.GetVideoInfoTag()->m_iSeason &&
+        episodesOnDisc[i].m_iEpisode == episode.GetVideoInfoTag()->m_iEpisode)
+    {
+      // Episode found
+      episodeOffset = i;
+    }
+    else if (episodesOnDisc[i].m_iSeason == 0)
+    {
+      // Special
+      specialsOnDisc.emplace_back(episodesOnDisc[i]);
+
+      if (episode.GetVideoInfoTag()->m_iSeason == 0 &&
+          episodesOnDisc[i].m_iEpisode == episode.GetVideoInfoTag()->m_iEpisode)
+      {
+        // Special found
+        episodeOffset = specialsOnDisc.size() - 1;
+        if (!allEpisodes)
+          isSpecial = true;
+      }
+
+      // Remove from episode list
+      episodesOnDisc.erase(episodesOnDisc.begin() + i);
+      --i;
+    }
+  }
+
+  const unsigned int numEpisodes = episodesOnDisc.size();
+  const unsigned int episodeDuration = episode.GetVideoInfoTag()->GetDuration();
+
+  CLog::LogF(LOGDEBUG, "*** Episode Search Start ***");
+
+  CLog::Log(LOGDEBUG, "Looking for season {} episode {} duration {}",
+            episode.GetVideoInfoTag()->m_iSeason, episode.GetVideoInfoTag()->m_iEpisode,
+            episode.GetVideoInfoTag()->GetDuration());
+
+  // List episodes expected on disc
+  for (const auto& e : episodesOnDisc)
+  {
+    CLog::Log(LOGDEBUG, "On disc - season {} episode {} duration {}", e.m_iSeason, e.m_iEpisode,
+              e.GetDuration());
+  }
+  for (const auto& e : specialsOnDisc)
+  {
+    CLog::Log(LOGDEBUG, "On disc - special - season {} episode {} duration {}", e.m_iSeason,
+              e.m_iEpisode, e.GetDuration());
+  }
+
+  // Look for a potential play all playlist (can give episode order)
+  //
+  // Assumptions
+  //   1) Playlist clip count = number of episodes on disc (+1)
+  //   2) Each clip will be in at least one other playlist
+  //   3) Each clip (bar the last) will be at least MIN_EPISODE_LENGTH long
+  //   4) Each playlist containing a clip will have at most one other clip after
+
+  std::vector<unsigned int> playAllPlaylists;
+  std::vector<std::pair<int, int>> groups;
+
+  // Only look for groups if enough playlists and more than one episode on disc
+  if (playlists.size() >= numEpisodes && numEpisodes > 1)
+  {
+    for (const auto& playlist : playlists)
+    {
+      // Find playlists that have a clip count = number of episodes on disc (1)
+      if (playlist.size() == numEpisodes + PLAYLIST_CLIP_OFFSET ||
+          playlist.size() == numEpisodes + PLAYLIST_CLIP_OFFSET + 1)
+      {
+        bool allClipsQualify = true;
+        for (unsigned int i = PLAYLIST_CLIP_OFFSET; i < PLAYLIST_CLIP_OFFSET + numEpisodes; ++i)
+        {
+          // Get clip information
+          const auto& it =
+              std::find_if(clips.begin(), clips.end(),
+                           [&](const std::vector<unsigned int>& x) { return x[0] == playlist[i]; });
+          const unsigned int duration = it->at(1);
+
+          // If clip only appears in one other playlist or is too short this is not a Play All playlist (2)(3)
+          if (it->size() < (CLIP_PLAYLIST_OFFSET + 2) || duration < MIN_EPISODE_LENGTH)
+          {
+            allClipsQualify = false;
+            break;
+          }
+
+          // Now check the playlists to ensure they start with each clip and have at most only one other clip after (4)
+          unsigned int p = (it->at(CLIP_PLAYLIST_OFFSET) == playlist[0])
+                               ? it->at(CLIP_PLAYLIST_OFFSET + 1)
+                               : it->at(CLIP_PLAYLIST_OFFSET);
+          const auto& it2 =
+              std::find_if(playlists.begin(), playlists.end(),
+                           [&p](const std::vector<unsigned int>& x) { return x[0] == p; });
+          if (it2->size() > (PLAYLIST_CLIP_OFFSET + 2) ||
+              it2->at(PLAYLIST_CLIP_OFFSET) != it->at(0))
+          {
+            allClipsQualify = false;
+            break;
+          }
+        }
+        if (allClipsQualify)
+        {
+          CLog::Log(LOGDEBUG, "Potential play all playlist {}", playlist[0]);
+          playAllPlaylists.emplace_back(playlist[0]);
+        }
+      }
+    }
+
+    // Look for groups of playlists
+    unsigned int length = 1;
+    for (unsigned int i = 1; i <= playlists.size(); ++i)
+    {
+      const int curPlaylist =
+          (i == playlists.size()) ? 0 : playlists[i][0]; // Ensure last group is recognised
+      const int prevPlaylist = playlists[i - 1][0];
+      if (i == playlists.size() || (curPlaylist - prevPlaylist) != 1)
+      {
+        if (length == numEpisodes)
+        {
+          // Found a group of consecutive playlists of at least the number of episodes on disc
+          const int firstPlaylist = playlists[i - length][0];
+          groups.emplace_back(firstPlaylist, prevPlaylist);
+          CLog::Log(LOGDEBUG, "Playlist group found from {} to {}", firstPlaylist, prevPlaylist);
+        }
+        length = 1;
+      }
+      else
+      {
+        length++;
+      }
+    }
+  }
+
+  // At this stage we have a number of ways of trying to determine the correct playlist for an episode
+  //
+  // 1) Using a 'Play All' playlist
+  //    - Caveat: there may not be one
+  //
+  // 2) Using the longest (non-'Play All') playlists that are consecutive
+  //    - Caveat: assumes play-all detection has worked and playlists are consecutive (hopefully reasonable assumptions)
+  //
+  // 3) Playlists that are +/- 30sec of the episode length that is passed to us
+  //    - Caveat: the episode length may be wrong - either from scraper/NFO or from bug in Kodi that overwrites episode streamdetails on same disc
+  //
+  // 4) Using position in a group of adjacent playlists (see below)
+  //    - Cavet: won't work for single episode discs
+  //
+  // 5) - For single episode discs - this is hard. There are some discs where there are extras that are longer than the episode itself
+  //      The only obvious difference sometimes seems to be number of languages
+  //
+  // Order of preference:
+  //
+  // 1) Use 'Play All' playlist - take the nth clip and find a playlist that plays that clip
+  //
+  // 2) Take the nth playlist of a consecutive run of longest playlists
+  //
+  // 3) Refine a group using relative position of playlist found on basis of length
+  //    - this tries to account for episodes that have the wrong duration passed
+  //    eg. if we have a disc with episodes 4,5,6 we would expect episode 5 to be the middle playlist of a group of 3 consecutive playlists (eg. 801, 802, 803)
+  //
+  // 4) Playlist based on episode length alone (assumes no groups found or 2) and 3) failed)
+  //
+  // 5) Look at groups found (ignoring length) and pick the relevant playlist - eg. the middle one for episode 5 using the example above
+  //    - Only looks at playlists > MIN_EPISODE_LENGTH
+  //
+  // 6) For single episode discs only, look at the longest playlist with multiple languages
+  //
+  // SPECIALS
+  //
+  // These are more difficult - as there may only be one per disc and we can't make assumptions about playlists.
+  // So have to look on basis of duration alone.
+  //
+
+  std::vector<std::pair<unsigned int, unsigned int>> candidatePlaylists;
+  bool foundEpisode = false;
+  bool findIdenticalEpisodes = false;
+
+  if (allEpisodes)
+    CLog::Log(LOGDEBUG, "Looking for all episodes on disc");
+
+  if (playAllPlaylists.size() == 1 && !isSpecial)
+  {
+    CLog::Log(LOGDEBUG, "Using Play All playlist method");
+
+    // Get the relevant clip
+    const auto& it = std::find_if(playlists.begin(), playlists.end(),
+                                  [&](const std::vector<unsigned int>& x)
+                                  { return x[0] == playAllPlaylists[0]; });
+
+    for (unsigned int i = PLAYLIST_CLIP_OFFSET; i < it->size(); ++i)
+    {
+      if (allEpisodes || i == PLAYLIST_CLIP_OFFSET + episodeOffset)
+      {
+        const unsigned int clip = it->at(i);
+        CLog::Log(LOGDEBUG, "Clip is {}", clip);
+
+        // Find playlist with starting with that clip (that isn't the play all playlist)
+        const auto& it2 =
+            std::find_if(playlists.begin(), playlists.end(),
+                         [&](const std::vector<unsigned int>& x) {
+                           return (x[PLAYLIST_CLIP_OFFSET] == clip && x[0] != playAllPlaylists[0]);
+                         });
+        const unsigned int playlist = it2->at(0);
+        const unsigned int duration = it2->at(1);
+
+        CLog::Log(LOGDEBUG, "Candidate playlist {} duration {}", playlist, duration);
+
+        candidatePlaylists.emplace_back(playlist, i - PLAYLIST_CLIP_OFFSET);
+      }
+    }
+    foundEpisode = true;
+    findIdenticalEpisodes = true;
+  }
+
+  // Look for the longest (non-Play All) playlists
+
+  if (!foundEpisode)
+  {
+    CLog::Log(LOGDEBUG, "Using longest playlists method");
+    std::vector<unsigned int> longPlaylists;
+
+    // Sort playlists by length
+    std::vector<std::vector<unsigned int>> playlists_length(playlists);
+    std::sort(playlists_length.begin(), playlists_length.end(),
+              [](const std::vector<unsigned int>& i, const std::vector<unsigned int>& j)
+              {
+                if (i[1] == j[1])
+                  return i[0] < j[0];
+                return i[1] > j[1];
+              });
+
+    // Remove duplicate lengths
+    for (unsigned int i = 0; i < playlists_length.size() - 1; ++i)
+    {
+      if (playlists_length[i][1] == playlists_length[i + 1][1])
+      {
+        playlists_length.erase(playlists_length.begin() + (i + 1));
+        --i;
+      }
+    }
+
+    // Get longest playlist(s)
+    unsigned int foundPlaylists = 0;
+    for (const auto& playlist : playlists_length)
+    {
+      // Check not a 'Play All' playlist
+      const auto& it =
+          std::find_if(playAllPlaylists.begin(), playAllPlaylists.end(),
+                       [&playlist](const unsigned int& x) { return x == playlist[0]; });
+      if (it == playAllPlaylists.end() && playlist[1] >= MIN_EPISODE_LENGTH &&
+          (playlist.size() - PLAYLIST_CLIP_OFFSET) <= MAX_CLIPS_PER_EPISODE &&
+          foundPlaylists < numEpisodes)
+      {
+        foundPlaylists += 1;
+        longPlaylists.emplace_back(playlist[0]);
+        CLog::Log(LOGDEBUG, "Long playlist {} duration {}", playlist[0], playlist[1]);
+      }
+    }
+
+    if (foundPlaylists > 0 && foundPlaylists == numEpisodes && !isSpecial)
+    {
+      // Sort found playlists
+      std::sort(longPlaylists.begin(), longPlaylists.end(),
+                [](unsigned int i, unsigned int j) { return (i < j); });
+
+      // Ensure sequential
+      if (longPlaylists[0] + numEpisodes - 1 == longPlaylists[numEpisodes - 1])
+      {
+        for (unsigned int i = 0; i < numEpisodes; ++i)
+        {
+          // Now select the nth playlist for single episode
+          // or numEpisodes playlists for all episodes
+          if (allEpisodes || i == episodeOffset)
+          {
+            candidatePlaylists.emplace_back(longPlaylists[i], i);
+
+            CLog::Log(LOGDEBUG, "Candidate playlist {}", longPlaylists[i]);
+          }
+        }
+        foundEpisode = true;
+        findIdenticalEpisodes = true;
+      }
+    }
+
+    if (isSpecial && !allEpisodes)
+    {
+      // Assume specials are the longest playlists that are not (assumed) episodes or play-all lists
+      for (const auto& playlist : playlists_length)
+      {
+        // Check not a 'Play All' playlist
+        const auto& it =
+            std::find_if(playAllPlaylists.begin(), playAllPlaylists.end(),
+                         [&playlist](const unsigned int& x) { return x == playlist[0]; });
+
+        if (it == playAllPlaylists.end() && playlist[1] >= MIN_SPECIAL_LENGTH &&
+            std::count(longPlaylists.begin(), longPlaylists.end(), playlist[0]) == 0)
+        {
+          // This will only work if one special on disc (otherwise no way of knowing lengths)
+          if (specialsOnDisc.size() == 1)
+          {
+            candidatePlaylists.emplace_back(playlist[0], 0);
+
+            CLog::Log(LOGDEBUG, "Candidate special playlist {}", playlist[0]);
+
+            foundEpisode = true;
+          }
+        }
+      }
+    }
+  }
+
+  // See if we can find titles of similar length (+/- MAX_EPISODE_DIFFERENCE sec) to the desired episode or special
+  // Not for all episodes
+  // For single episodes use this to try and confirm/refute any episode found on length basis
+
+  if (numEpisodes == 1 || (!foundEpisode && !allEpisodes))
+  {
+    CLog::Log(LOGDEBUG, "Using episode length method");
+
+    const int existingCandidates = candidatePlaylists.size();
+
+    for (const auto& playlist : playlists)
+    {
+      const unsigned int titleDuration = playlist[1];
+      if (episodeDuration > (titleDuration - MAX_EPISODE_DIFFERENCE) &&
+          episodeDuration < (titleDuration + MAX_EPISODE_DIFFERENCE))
+      {
+        // episode candidate found (on basis of duration)
+        candidatePlaylists.emplace_back(playlist[0], 0);
+
+        CLog::Log(LOGDEBUG, "Candidate playlist {} - actual duration {}, desired duration {}",
+                  playlist[0], titleDuration, episodeDuration);
+      }
+    }
+
+    if (!groups.empty() && !isSpecial && numEpisodes > 1)
+    {
+      // Found candidate groupings of playlists matching the number of episodes on disc
+      // This assumes that the episodes have sequential playlist numbers
+
+      // Firstly, cross-reference with duration based approach above
+      // ie. look for episodes of correct approx duration in correct position in group of playlists
+      // (titleCandidates already contains playlists of approx duration)
+
+      CLog::Log(LOGDEBUG, "Refining candidate titles using groups");
+      for (unsigned int i = 0; i < candidatePlaylists.size(); ++i)
+      {
+        const unsigned int playlist = candidatePlaylists[i].first;
+        bool remove = true;
+        for (const auto& group : groups)
+        {
+          if (playlist == group.first + episodeOffset)
+          {
+            CLog::Log(LOGDEBUG, "Candidate {} kept as in position {} in group", playlist,
+                      episodeOffset + 1);
+            remove = false;
+            break;
+          }
+        }
+        if (remove)
+        {
+          CLog::Log(LOGDEBUG, "Removed candidate {} as not in position {} in group", playlist,
+                    episodeOffset + 1);
+          candidatePlaylists.erase(candidatePlaylists.begin() + i);
+          --i;
+        }
+      }
+    }
+    else if (numEpisodes == 1 && existingCandidates > 0 && candidatePlaylists.size() > 1)
+    {
+      // If we have candidates from another method (ie. length) then try and decide which of them is most likely to be the single episode
+      // Favour one with most languages, otherwise favour one based on matching length
+
+      // Get languages
+      std::vector<int> langs;
+      langs.reserve(candidatePlaylists.size());
+      for (const auto& playlist : candidatePlaylists)
+        langs.emplace_back(std::count(playlist_langs[playlist.first].begin(),
+                                      playlist_langs[playlist.first].end(), '/') +
+                           1);
+
+      // Loop backwards as desired length preferred to the longest length
+      int keepPlaylist = -1;
+      for (unsigned int i = candidatePlaylists.size() - 1; i >= 0; --i)
+      {
+        if (langs[i] > 1)
+        {
+          // If more than one language then keep
+          keepPlaylist = candidatePlaylists[i].first;
+          break;
+        }
+      }
+      if (keepPlaylist != -1)
+        // Remove other playlists (keep the first one with more than one language)
+        candidatePlaylists.erase(
+            std::remove_if(candidatePlaylists.begin(), candidatePlaylists.end(),
+                           [&keepPlaylist](const std::pair<unsigned int, unsigned int>& p)
+                           { return static_cast<int>(p.first) != keepPlaylist; }),
+            candidatePlaylists.end());
+      else if (existingCandidates > 0)
+        // Keep those based on desired length
+        candidatePlaylists.erase(candidatePlaylists.begin(),
+                                 candidatePlaylists.begin() + existingCandidates);
+    }
+
+    // candidatePlaylists now contains playlists of the approx duration, refined by group position (if there were groups)
+    // If found nothing then it could be duration is wrong (ie from scraper)
+    // In which case favour groups starting with common start points (eg. 1, 800, 801)
+
+    if (candidatePlaylists.empty() && !isSpecial)
+    {
+      CLog::Log(LOGDEBUG, "Using find playlist using candidate groups alone method");
+      std::vector<unsigned int> candidateGroups = {801, 800, 1};
+
+      for (const auto& candidateGroup : candidateGroups)
+      {
+        bool foundFirst = false;
+        for (const auto& playlist : playlists)
+        {
+          if (playlist[0] == candidateGroup)
+          {
+            // Need to make sure the beginning of the candidate group is present
+            // Otherwise a group starting at 802 and containing 803 would be found, whereas the intention would be a group starting with 800
+            // (or whatever candidateGroup is)
+            CLog::Log(LOGDEBUG, "Potential candidate group start at playlist {}", candidateGroup);
+            foundFirst = true;
+          }
+
+          unsigned int duration = playlist[1];
+          if (foundFirst && playlist[0] == candidateGroup + episodeOffset &&
+              duration >= MIN_EPISODE_LENGTH)
+          {
+            CLog::Log(LOGDEBUG, "Candidate playlist {} duration {}", candidateGroup + episodeOffset,
+                      duration);
+            candidatePlaylists.emplace_back(playlist[0], 0);
+            findIdenticalEpisodes = true;
+          }
+        }
+      }
+    }
+  }
+
+  // candidatePlaylists should now (ideally) contain one or more candidate titles for the episode
+  // Now look at durations of found playlist and add identical (in case language options)
+  // Note this has already happened with the episode duration method
+
+  if (findIdenticalEpisodes && !candidatePlaylists.empty())
+  {
+    const unsigned int n = candidatePlaylists.size(); // Save here as add potential clips to end
+    for (unsigned int i = 0; i < n; ++i)
+    {
+      // Find candidatePlaylist duration
+      const auto& it = std::find_if(playlists.begin(), playlists.end(),
+                                    [&](const std::vector<unsigned int>& x)
+                                    { return x[0] == candidatePlaylists[i].first; });
+
+      // Look for other playlists of same duration with same clips
+      for (const auto& playlist : playlists)
+      {
+        if (candidatePlaylists[i].first != playlist[0] &&
+            std::equal(it->begin() + 1, it->end(), playlist.begin() + 1))
+        {
+          CLog::Log(LOGDEBUG, "Adding playlist {} as same duration as playlist {}", playlist[0],
+                    candidatePlaylists[i].first);
+          candidatePlaylists.emplace_back(playlist[0], candidatePlaylists[i].second);
+        }
+      }
+    }
+  }
+
+  // Remove duplicates (ie. those that play exactly the same clip with same languages)
+
+  if (candidatePlaylists.size() > 1)
+  {
+    for (unsigned int i = 0; i < candidatePlaylists.size() - 1; ++i)
+    {
+      const auto& it = std::find_if(playlists.begin(), playlists.end(),
+                                    [&](const std::vector<unsigned int>& x)
+                                    { return x[0] == candidatePlaylists[i].first; });
+
+      for (unsigned int j = i + 1; j < candidatePlaylists.size(); ++j)
+      {
+        const auto& it2 = std::find_if(playlists.begin(), playlists.end(),
+                                       [&](const std::vector<unsigned int>& x)
+                                       { return x[0] == candidatePlaylists[j].first; });
+
+        if (std::equal(it->begin() + PLAYLIST_CLIP_OFFSET, it->end(),
+                       it2->begin() + PLAYLIST_CLIP_OFFSET))
+        {
+          // Clips are the same so check languages
+          if (playlist_langs[candidatePlaylists[i].first] ==
+              playlist_langs[candidatePlaylists[j].first])
+          {
+            // Remove duplicate
+            CLog::Log(LOGDEBUG, "Removing duplicate playlist {}", candidatePlaylists[j].first);
+            candidatePlaylists.erase(candidatePlaylists.begin() + j);
+            --j;
+          }
+        }
+      }
+    }
+  }
+
+  CLog::LogF(LOGDEBUG, "*** Episode Search End ***");
+
+  // ** Now populate CFileItemList to return
+  CFileItemList newItems;
+  for (const auto& playlist : candidatePlaylists)
+  {
+    const auto newItem{std::make_shared<CFileItem>("", false)};
+
+    // Get clips
+    const auto& it = std::find_if(playlists.begin(), playlists.end(),
+                                  [&playlist](const std::vector<unsigned int>& x)
+                                  { return x[0] == playlist.first; });
+    const int duration = it->at(1);
+
+    // Get languages
+    std::string langs = playlist_langs[playlist.first];
+
+    std::string buf;
+    CURL path(m_url);
+    buf = StringUtils::Format("BDMV/PLAYLIST/{:05}.mpls", playlist.first);
+    path.SetFileName(buf);
+    newItem->SetPath(path.Get());
+
+    newItem->GetVideoInfoTag()->SetDuration(duration);
+    newItem->GetVideoInfoTag()->m_iTrack = playlist.first;
+
+    // Get episode title
+    buf = StringUtils::Format("{0:s} {1:d} - {2:s}", g_localizeStrings.Get(20359) /* Episode */,
+                              episodesOnDisc[playlist.second].m_iEpisode,
+                              episodesOnDisc[playlist.second].GetTitle());
+    newItem->m_strTitle = buf;
+    newItem->SetLabel(buf);
+    newItem->SetLabel2(StringUtils::Format(
+        g_localizeStrings.Get(25005) /* Title: {0:d} */ + " - {1:s}: {2:s}\n\r{3:s}: {4:s}",
+        playlist.first, g_localizeStrings.Get(180) /* Duration */,
+        StringUtils::SecondsToTimeString(duration), g_localizeStrings.Get(24026) /* Languages */,
+        langs));
+    newItem->m_dwSize = 0;
+    newItem->SetArt("icon", "DefaultVideo.png");
+    items.Add(newItem);
+  }
+}
+
+std::shared_ptr<CFileItem> CBlurayDirectory::GetTitle(const BLURAY_TITLE_INFO* title,
+                                                      const std::string& label) const
+{
   CFileItemPtr item(new CFileItem("", false));
   CURL path(m_url);
-  buf = StringUtils::Format("BDMV/PLAYLIST/{:05}.mpls", title->playlist);
+  std::string buf{StringUtils::Format("BDMV/PLAYLIST/{:05}.mpls", title->playlist)};
   path.SetFileName(buf);
   item->SetPath(path.Get());
-  int duration = (int)(title->duration / 90000);
+  const int duration = static_cast<int>(title->duration / 90000);
   item->GetVideoInfoTag()->SetDuration(duration);
   item->GetVideoInfoTag()->m_iTrack = title->playlist;
   buf = StringUtils::Format(label, title->playlist);
   item->m_strTitle = buf;
   item->SetLabel(buf);
-  chap = StringUtils::Format(g_localizeStrings.Get(25007), title->chapter_count,
-                             StringUtils::SecondsToTimeString(duration));
+  const std::string chap{StringUtils::Format(g_localizeStrings.Get(25007), title->chapter_count,
+                                             StringUtils::SecondsToTimeString(duration))};
   item->SetLabel2(chap);
   item->m_dwSize = 0;
   item->SetArt("icon", "DefaultVideo.png");
-  for(unsigned int i = 0; i < title->clip_count; ++i)
+  for (unsigned int i = 0; i < title->clip_count; ++i)
     item->m_dwSize += title->clips[i].pkt_count * 192;
 
   return item;
 }
 
-void CBlurayDirectory::GetTitles(bool main, CFileItemList &items)
+void CBlurayDirectory::GetTitles(const int job, CFileItemList& items, const int sort) const
 {
   std::vector<BLURAY_TITLE_INFO*> titleList;
-  uint64_t minDuration = 0;
+  uint64_t maxDuration{0};
+  int maxPlaylist{-1};
+  int mainPlaylist{-1};
 
-  // Searching for a user provided list of playlists.
-  if (main)
-    titleList = GetUserPlaylists();
-
-  if (!main || titleList.empty())
+  // See if disc.inf for main playlist
+  if (job != GET_TITLES_ALL)
   {
-    uint32_t numTitles = bd_get_titles(m_bd, TITLES_RELEVANT, 0);
-
-    for (uint32_t i = 0; i < numTitles; i++)
+    mainPlaylist = GetUserPlaylists();
+    if (mainPlaylist != -1)
     {
-      BLURAY_TITLE_INFO* t = bd_get_title_info(m_bd, i, 0);
-
+      // Only main playlist is needed
+      BLURAY_TITLE_INFO* t = bd_get_playlist_info(m_bd, mainPlaylist, 0);
       if (!t)
-      {
-        CLog::Log(LOGDEBUG, "CBlurayDirectory - unable to get title {}", i);
-        continue;
-      }
-
-      if (main && t->duration > minDuration)
-          minDuration = t->duration;
-
-      titleList.emplace_back(t);
+        CLog::LogF(LOGDEBUG, "CBlurayDirectory - unable to get title {}", mainPlaylist);
+      else
+        titleList.emplace_back(t);
     }
   }
 
-  minDuration = minDuration * MAIN_TITLE_LENGTH_PERCENT / 100;
-
-  for (auto& title : titleList)
+  if (titleList.empty())
   {
-    if (title->duration < minDuration)
-      continue;
+    const uint32_t numTitles = bd_get_titles(m_bd, TITLES_RELEVANT, 0);
+    for (uint32_t i = 0; i < numTitles; i++)
+    {
+      BLURAY_TITLE_INFO* t = bd_get_title_info(m_bd, i, 0);
+      if (!t)
+        CLog::LogF(LOGDEBUG, "CBlurayDirectory - unable to get title {}", i);
+      else
+      {
+        if (t->duration > maxDuration)
+        {
+          maxDuration = t->duration;
+          maxPlaylist = static_cast<int>(t->playlist);
+        }
+        titleList.emplace_back(t);
+      }
+    }
+  }
 
-    items.Add(GetTitle(title, main ? g_localizeStrings.Get(25004) /* Main Title */ : g_localizeStrings.Get(25005) /* Title */));
+  // Sort
+  // Movies - placing main title - if present - first, then by duration
+  // Episodes - by playlist number
+  if (sort != SORT_TITLES_NONE)
+  {
+    std::sort(titleList.begin(), titleList.end(),
+              [&sort](const BLURAY_TITLE_INFO* i, const BLURAY_TITLE_INFO* j)
+              {
+                if (sort == SORT_TITLES_MOVIE)
+                {
+                  if (i->duration == j->duration)
+                    return i->playlist < j->playlist;
+                  return i->duration > j->duration;
+                }
+                return i->playlist < j->playlist;
+              });
+
+    const auto pivot = std::find_if(titleList.begin(), titleList.end(),
+                                    [&mainPlaylist](const BLURAY_TITLE_INFO* title)
+                                    { return title->playlist == mainPlaylist; });
+    if (pivot != titleList.end())
+      std::rotate(titleList.begin(), pivot, pivot + 1);
+  }
+
+  const uint64_t minDuration{maxDuration * MAIN_TITLE_LENGTH_PERCENT / 100};
+  for (const auto& title : titleList)
+  {
+    if (job == GET_TITLES_ALL || (job == GET_TITLES_MAIN && title->duration >= minDuration) ||
+        (job == GET_TITLES_ONE && (title->playlist == mainPlaylist ||
+                                   (mainPlaylist == -1 && title->playlist == maxPlaylist))))
+      items.Add(GetTitle(title, title->playlist == mainPlaylist
+                                    ? g_localizeStrings.Get(25004) /* Main Title */
+                                    : g_localizeStrings.Get(25005) /* Title */));
     bd_free_title_info(title);
   }
 }
 
-void CBlurayDirectory::GetRoot(CFileItemList &items)
+void CBlurayDirectory::GetRoot(CFileItemList& items) const
 {
-    GetTitles(true, items);
+  GetTitles(GET_TITLES_MAIN, items, SORT_TITLES_MOVIE);
 
-    CURL path(m_url);
-    CFileItemPtr item;
-
-    path.SetFileName(URIUtils::AddFileToFolder(m_url.GetFileName(), "titles"));
-    item = std::make_shared<CFileItem>();
-    item->SetPath(path.Get());
-    item->m_bIsFolder = true;
-    item->SetLabel(g_localizeStrings.Get(25002) /* All titles */);
-    item->SetArt("icon", "DefaultVideoPlaylists.png");
-    items.Add(item);
-
-    const BLURAY_DISC_INFO* disc_info = bd_get_disc_info(m_bd);
-    if (disc_info && disc_info->no_menu_support)
-    {
-      CLog::Log(LOGDEBUG, "CBlurayDirectory::GetRoot - no menu support, skipping menu entry");
-      return;
-    }
-
-    path.SetFileName("menu");
-    item = std::make_shared<CFileItem>();
-    item->SetPath(path.Get());
-    item->m_bIsFolder = false;
-    item->SetLabel(g_localizeStrings.Get(25003) /* Menus */);
-    item->SetArt("icon", "DefaultProgram.png");
-    items.Add(item);
+  AddRootOptions(items);
 }
 
-bool CBlurayDirectory::GetDirectory(const CURL& url, CFileItemList &items)
+void CBlurayDirectory::GetRoot(CFileItemList& items,
+                               const CFileItem& episode,
+                               const std::vector<CVideoInfoTag>& episodesOnDisc) const
+{
+  // Get playlist, clip and language information
+  std::vector<std::vector<unsigned int>> clips;
+  std::vector<std::vector<unsigned int>> playlists;
+  std::map<unsigned int, std::string> playlist_langs;
+
+  GetPlaylistInfo(clips, playlists, playlist_langs);
+
+  // Get episode playlists
+  GetEpisodeTitles(episode, items, episodesOnDisc, clips, playlists, playlist_langs);
+
+  if (!items.IsEmpty())
+    AddRootOptions(items);
+}
+
+void CBlurayDirectory::AddRootOptions(CFileItemList& items) const
+{
+  CURL path(m_url);
+  path.SetFileName(URIUtils::AddFileToFolder(m_url.GetFileName(), "titles"));
+
+  auto item{std::make_shared<CFileItem>(path.Get(), true)};
+  item->SetLabel(g_localizeStrings.Get(25002) /* All titles */);
+  item->SetArt("icon", "DefaultVideoPlaylists.png");
+  items.Add(item);
+
+  const BLURAY_DISC_INFO* disc_info = bd_get_disc_info(m_bd);
+  if (disc_info && disc_info->no_menu_support)
+  {
+    CLog::Log(LOGDEBUG, "CBlurayDirectory::GetRoot - no menu support, skipping menu entry");
+    return;
+  }
+
+  path.SetFileName("menu");
+  item = {std::make_shared<CFileItem>(path.Get(), false)};
+  item->SetLabel(g_localizeStrings.Get(25003) /* Menu */);
+  item->SetArt("icon", "DefaultProgram.png");
+  items.Add(item);
+}
+
+bool CBlurayDirectory::GetDirectory(const CURL& url, CFileItemList& items)
 {
   Dispose();
   m_url = url;
@@ -224,21 +955,64 @@ bool CBlurayDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   if (!InitializeBluray(root))
     return false;
 
-  if(file == "root")
+  if (file == "root")
     GetRoot(items);
-  else if(file == "root/titles")
-    GetTitles(false, items);
+  else if (file == "root/titles")
+    GetTitles(GET_TITLES_ALL, items, SORT_TITLES_MOVIE);
   else
   {
-    CURL url2 = GetUnderlyingCURL(url);
+    const CURL url2 = GetUnderlyingCURL(url);
     CDirectory::CHints hints;
     hints.flags = m_flags;
     if (!CDirectory::GetDirectory(url2, items, hints))
       return false;
   }
 
-  items.AddSortMethod(SortByTrackNumber,  554, LABEL_MASKS("%L", "%D", "%L", ""));    // FileName, Duration | Foldername, empty
-  items.AddSortMethod(SortBySize,         553, LABEL_MASKS("%L", "%I", "%L", "%I"));  // FileName, Size | Foldername, Size
+  items.AddSortMethod(SortByTrackNumber, 554,
+                      LABEL_MASKS("%L", "%D", "%L", "")); // FileName, Duration | Foldername, empty
+  items.AddSortMethod(SortBySize, 553,
+                      LABEL_MASKS("%L", "%I", "%L", "%I")); // FileName, Size | Foldername, Size
+
+  return true;
+}
+
+bool CBlurayDirectory::GetEpisodeDirectory(const CURL& url,
+                                           const CFileItem& episode,
+                                           CFileItemList& items,
+                                           const std::vector<CVideoInfoTag>& episodesOnDisc)
+{
+  Dispose();
+  m_url = url;
+  std::string root = m_url.GetHostName();
+  URIUtils::RemoveSlashAtEnd(root);
+
+  if (!InitializeBluray(root))
+    return false;
+
+  GetRoot(items, episode, episodesOnDisc);
+
+  items.AddSortMethod(SortByTrackNumber, 554,
+                      LABEL_MASKS("%L", "%D", "%L", "")); // FileName, Duration | Foldername, empty
+  items.AddSortMethod(SortBySize, 553,
+                      LABEL_MASKS("%L", "%I", "%L", "%I")); // FileName, Size | Foldername, Size
+
+  return true;
+}
+
+bool CBlurayDirectory::GetMainItem(const CURL& url, CFileItem& main)
+{
+  Dispose();
+  m_url = url;
+  std::string root = m_url.GetHostName();
+  URIUtils::RemoveSlashAtEnd(root);
+
+  if (!InitializeBluray(root))
+    return false;
+
+  CFileItemList items;
+  GetTitles(GET_TITLES_ONE, items, SORT_TITLES_NONE);
+  if (items.Size() == 1)
+    main = *items[0];
 
   return true;
 }
@@ -288,59 +1062,32 @@ std::string CBlurayDirectory::HexToString(const uint8_t *buf, int count)
     sprintf(tmp.data() + (i * 2), "%02x", buf[i]);
   }
 
-  return std::string(std::begin(tmp), std::end(tmp));
+  return std::string{std::begin(tmp), std::end(tmp)};
 }
 
-std::vector<BLURAY_TITLE_INFO*> CBlurayDirectory::GetUserPlaylists()
+int CBlurayDirectory::GetUserPlaylists() const
 {
-  std::string root = m_url.GetHostName();
-  std::string discInfPath = URIUtils::AddFileToFolder(root, "disc.inf");
-  std::vector<BLURAY_TITLE_INFO*> userTitles;
+  const std::string root = m_url.GetHostName();
+  const std::string discInfPath = URIUtils::AddFileToFolder(root, "disc.inf");
   CFile file;
-  char buffer[1025];
+  int playlist{-1};
 
   if (file.Open(discInfPath))
   {
     CLog::Log(LOGDEBUG, "CBlurayDirectory::GetTitles - disc.inf found");
 
-    CRegExp pl(true);
-    if (!pl.RegComp("(\\d+)"))
+    char buffer[1025];
+    CRegExp pl(true,CRegExp::autoUtf8,R"((?:playlists=)(\d+))");
+    while (file.ReadString(buffer, 1024))
     {
-      file.Close();
-      return userTitles;
-    }
-
-    uint8_t maxLines = 100;
-    while ((maxLines > 0) && file.ReadString(buffer, 1024))
-    {
-      maxLines--;
-      if (StringUtils::StartsWithNoCase(buffer, "playlists"))
+      if (pl.RegFind(buffer) != -1)
       {
-        int pos = 0;
-        while ((pos = pl.RegFind(buffer, static_cast<unsigned int>(pos))) >= 0)
-        {
-          std::string playlist = pl.GetMatch(0);
-          uint32_t len = static_cast<uint32_t>(playlist.length());
-
-          if (len <= 5)
-          {
-            unsigned long int plNum = strtoul(playlist.c_str(), nullptr, 10);
-
-            BLURAY_TITLE_INFO* t = bd_get_playlist_info(m_bd, static_cast<uint32_t>(plNum), 0);
-            if (t)
-              userTitles.emplace_back(t);
-          }
-
-          if (static_cast<int64_t>(pos) + static_cast<int64_t>(len) > INT_MAX)
-            break;
-          else
-            pos += len;
-        }
+        playlist = std::stoi(pl.GetMatch(1));
+        break;
       }
     }
     file.Close();
   }
-  return userTitles;
+  return playlist;
 }
-
 } /* namespace XFILE */

--- a/xbmc/filesystem/BlurayDirectory.h
+++ b/xbmc/filesystem/BlurayDirectory.h
@@ -10,6 +10,7 @@
 
 #include "IDirectory.h"
 #include "URL.h"
+#include "video/VideoInfoTag.h"
 
 #include <memory>
 
@@ -27,9 +28,13 @@ class CBlurayDirectory : public IDirectory
 public:
   CBlurayDirectory() = default;
   ~CBlurayDirectory() override;
-  bool GetDirectory(const CURL& url, CFileItemList &items) override;
-
-  bool InitializeBluray(const std::string &root);
+  bool InitializeBluray(const std::string& root);
+  bool GetDirectory(const CURL& url, CFileItemList& items) override;
+  bool GetEpisodeDirectory(const CURL& url,
+                           const CFileItem& episode,
+                           CFileItemList& items,
+                           const std::vector<CVideoInfoTag>& episodesOnDisc) override;
+  bool GetMainItem(const CURL& url, CFileItem& main) override;
   std::string GetBlurayTitle();
   std::string GetBlurayID();
 
@@ -40,14 +45,28 @@ private:
     ID
   };
 
-  void         Dispose();
-  std::string  GetDiscInfoString(DiscInfo info);
-  void         GetRoot  (CFileItemList &items);
-  void         GetTitles(bool main, CFileItemList &items);
-  std::vector<BLURAY_TITLE_INFO*> GetUserPlaylists();
-  std::shared_ptr<CFileItem> GetTitle(const BLURAY_TITLE_INFO* title, const std::string& label);
-  CURL         GetUnderlyingCURL(const CURL& url);
-  std::string  HexToString(const uint8_t * buf, int count);
+  void Dispose();
+  std::string GetDiscInfoString(DiscInfo info) const;
+  void GetRoot(CFileItemList& items) const;
+  void GetRoot(CFileItemList& items,
+               const CFileItem& episode,
+               const std::vector<CVideoInfoTag>& episodesOnDisc) const;
+  void AddRootOptions(CFileItemList& items) const;
+  void GetTitles(const int job, CFileItemList& items, const int sort) const;
+  void GetPlaylistInfo(std::vector<std::vector<unsigned int>>& clips,
+                       std::vector<std::vector<unsigned int>>& playlists,
+                       std::map<unsigned int, std::string>& playlist_langs) const;
+  void GetEpisodeTitles(const CFileItem& episode,
+                        CFileItemList& items,
+                        std::vector<CVideoInfoTag> episodesOnDisc,
+                        const std::vector<std::vector<unsigned int>>& clips,
+                        const std::vector<std::vector<unsigned int>>& playlists,
+                        std::map<unsigned int, std::string>& playlist_langs) const;
+  int GetUserPlaylists() const;
+  std::shared_ptr<CFileItem> GetTitle(const BLURAY_TITLE_INFO* title,
+                                      const std::string& label) const;
+  static CURL GetUnderlyingCURL(const CURL& url);
+  static std::string HexToString(const uint8_t* buf, int count);
   CURL          m_url;
   BLURAY*       m_bd = nullptr;
   bool          m_blurayInitialized = false;

--- a/xbmc/filesystem/CMakeLists.txt
+++ b/xbmc/filesystem/CMakeLists.txt
@@ -11,6 +11,8 @@ set(SOURCES AddonsDirectory.cpp
             DirectoryFactory.cpp
             DirectoryHistory.cpp
             DllLibCurl.cpp
+            DVDDirectory.cpp
+            DVDFile.cpp
             EventsDirectory.cpp
             FavouritesDirectory.cpp
             FileCache.cpp
@@ -73,6 +75,8 @@ set(HEADERS AddonsDirectory.h
             DirectoryFactory.h
             DirectoryHistory.h
             DllLibCurl.h
+            DVDDirectory.h
+	    DVDFile.h
             EventsDirectory.h
             FTPDirectory.h
             FTPParse.h
@@ -151,11 +155,9 @@ endif()
 
 if(ENABLE_OPTICAL)
   list(APPEND SOURCES CDDADirectory.cpp
-                      CDDAFile.cpp
-                      DVDDirectory.cpp)
+                      CDDAFile.cpp)
   list(APPEND HEADERS CDDADirectory.h
-                      CDDAFile.h
-                      DVDDirectory.h)
+                      CDDAFile.h)
 endif()
 
 if(TARGET libnfs::nfs)

--- a/xbmc/filesystem/DVDDirectory.cpp
+++ b/xbmc/filesystem/DVDDirectory.cpp
@@ -11,7 +11,12 @@
 #include "FileItem.h"
 #include "ServiceBroker.h"
 #include "URL.h"
+#include "cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h"
+#include "filesystem/Directory.h"
+#include "guilib/LocalizeStrings.h"
 #include "storage/MediaManager.h"
+#include "utils/URIUtils.h"
+#include "utils/log.h"
 
 using namespace XFILE;
 
@@ -25,4 +30,504 @@ bool CDVDDirectory::Resolve(CFileItem& item) const
 
   item.SetDynPath(CServiceBroker::GetMediaManager().TranslateDevicePath(""));
   return true;
+}
+
+static constexpr unsigned int MIN_EPISODE_LENGTH = 15 * 60; // 15 minutes
+static constexpr unsigned int MIN_CHAPTERS_PER_EPISODE = 3;
+static constexpr unsigned int PLAYLIST_CHAPTER_OFFSET =
+    2; //First two entries in playlist array are playlist number and duration. Remaining are chapter durations
+
+void CDVDDirectory::GetEpisodeTitles(const CFileItem& episode,
+                                     CFileItemList& items,
+                                     std::vector<CVideoInfoTag> episodesOnDisc,
+                                     const std::vector<std::vector<unsigned int>>& clips,
+                                     const std::vector<std::vector<unsigned int>>& playlists,
+                                     std::map<unsigned int, std::string>& playlist_langs) const
+{
+  // Find our episode on disc
+  // Need to differentiate between specials and episodes
+  std::vector<CVideoInfoTag> specialsOnDisc;
+  bool isSpecial = false;
+  unsigned int episodeOffset = 0;
+  const bool allEpisodes = episode.m_titlesJob == CFileItem::TITLES_JOB_ALL_EPISODES;
+
+  for (unsigned int i = 0; i < episodesOnDisc.size(); ++i)
+  {
+    if (episodesOnDisc[i].m_iSeason > 0 &&
+        episodesOnDisc[i].m_iSeason == episode.GetVideoInfoTag()->m_iSeason &&
+        episodesOnDisc[i].m_iEpisode == episode.GetVideoInfoTag()->m_iEpisode)
+    {
+      // Episode found
+      episodeOffset = i;
+    }
+    else if (episodesOnDisc[i].m_iSeason == 0)
+    {
+      // Special
+      specialsOnDisc.emplace_back(episodesOnDisc[i]);
+
+      if (episode.GetVideoInfoTag()->m_iSeason == 0 &&
+          episodesOnDisc[i].m_iEpisode == episode.GetVideoInfoTag()->m_iEpisode)
+      {
+        // Special found
+        episodeOffset = specialsOnDisc.size() - 1;
+        if (!allEpisodes)
+          isSpecial = true;
+      }
+
+      // Remove from episode list
+      episodesOnDisc.erase(episodesOnDisc.begin() + i);
+      --i;
+    }
+  }
+
+  const unsigned int numEpisodes = episodesOnDisc.size();
+
+  CLog::LogF(LOGDEBUG, "*** Episode Search Start ***");
+
+  CLog::LogF(LOGDEBUG, "Looking for season {} episode {} duration {}",
+             episode.GetVideoInfoTag()->m_iSeason, episode.GetVideoInfoTag()->m_iEpisode,
+             episode.GetVideoInfoTag()->GetDuration());
+
+  // List episodes expected on disc
+  for (const auto& e : episodesOnDisc)
+  {
+    CLog::LogF(LOGDEBUG, "On disc - season {} episode {} duration {}", e.m_iSeason, e.m_iEpisode,
+               e.GetDuration());
+  }
+  for (const auto& e : specialsOnDisc)
+  {
+    CLog::LogF(LOGDEBUG, "On disc - special - season {} episode {} duration {}", e.m_iSeason,
+               e.m_iEpisode, e.GetDuration());
+  }
+
+  // Look for a potential play all playlist (can give episode order)
+  //
+  // Assumptions
+  //   1) There will be consistency in chapter length between the play all playlist and episode playlist
+  //
+  // Consider chapter duration array - exclude first and last as they are more likely
+  // to be episode specific (intro/trailers)
+  // Look for titles that contain chapter duration array as a subset
+
+  // Adjust array from absolute chapter offsets to lengths
+  std::vector<std::vector<unsigned int>> playlists_length(playlists);
+  for (unsigned int i = 0; i < playlists.size(); ++i)
+    for (unsigned int j = playlists[i].size() - 2; j >= PLAYLIST_CHAPTER_OFFSET; --j)
+      playlists_length[i][j + 1] -= playlists_length[i][j];
+
+  // Remove zero length titles
+  playlists_length.erase(std::remove_if(playlists_length.begin(), playlists_length.end(),
+                                        [](const std::vector<unsigned int>& i)
+                                        { return i[1] == 0; }),
+                         playlists_length.end());
+
+  // Remove zero length chapters from end
+  for (auto& playlist : playlists_length)
+    while (playlist.back() == 0)
+      playlist.pop_back();
+
+  // Start with title with most chapters
+  std::sort(playlists_length.begin(), playlists_length.end(),
+            [](const std::vector<unsigned int>& i, const std::vector<unsigned int>& j)
+            {
+              if (i.size() == j.size())
+                return i[1] > j[1]; // Duration
+              return i.size() > j.size();
+            });
+
+  // playAllPlaylists[n][x,y] - n is the index
+  //                            x is title
+  //                            y is vector of pairs - first is title, second is chapter position in x's chapters
+  std::vector<std::pair<unsigned int, std::vector<std::pair<unsigned int, unsigned int>>>>
+      playAllPlaylists;
+
+  // Only look for groups if enough playlists and more than one episode on disc
+  if (playlists.size() >= numEpisodes && numEpisodes > 1)
+  {
+    // Find chapter matches
+    for (unsigned int i = 0; i < playlists_length.size(); ++i)
+    {
+      unsigned int foundEpisodes{0};
+      std::vector<std::pair<unsigned int, unsigned int>> titleOrder;
+      for (unsigned int j = 0; j < playlists_length.size(); ++j)
+      {
+        // Play all playlist must have more chapters
+        // Also check minimums
+        if (i != j && playlists_length[i].size() > playlists_length[j].size() &&
+            playlists_length[j].size() >= PLAYLIST_CHAPTER_OFFSET + MIN_CHAPTERS_PER_EPISODE &&
+            playlists_length[j][1] >= MIN_EPISODE_LENGTH)
+        {
+          const auto& it =
+              std::search(std::next(playlists_length[i].begin(), 2), playlists_length[i].end(),
+                          std::next(playlists_length[j].begin(), 2), playlists_length[j].end());
+          if (it != playlists_length[i].end())
+          {
+            foundEpisodes += 1;
+            titleOrder.emplace_back(playlists_length[j][0],
+                                    std::distance(playlists_length[i].begin(), it));
+
+            // Overwrite elements associated with this episode
+            // To prevent future false positives
+            for (unsigned int k = 0; k < playlists_length[j].size() - PLAYLIST_CHAPTER_OFFSET; ++k)
+              playlists_length[i][std::distance(playlists_length[i].begin(), it) + k] = 0;
+          }
+        }
+      }
+      CLog::LogF(LOGDEBUG, "Found {} episodes in playlist {}", foundEpisodes,
+                 playlists_length[i][0]);
+      if (foundEpisodes == numEpisodes)
+      {
+        CLog::LogF(LOGDEBUG, "Potential play all playlist {}", playlists_length[i][0]);
+
+        playAllPlaylists.emplace_back(playlists_length[i][0], titleOrder);
+      }
+    }
+  }
+
+  std::vector<std::pair<unsigned int, unsigned int>> candidatePlaylists;
+  bool foundEpisode{false};
+  bool chapters{false};
+
+  if (allEpisodes)
+    CLog::LogF(LOGDEBUG, "Looking for all episodes on disc");
+
+  // See if just one title with numEpisodes chapters
+  // Assume each chapter is an episode
+  if (playAllPlaylists.empty() && playlists_length.size() == 1 &&
+      playlists_length[0].size() == numEpisodes + PLAYLIST_CHAPTER_OFFSET)
+  {
+    foundEpisode = chapters = true;
+    CLog::LogF(LOGDEBUG, "Single playlist with {} chapters found", numEpisodes);
+  }
+
+  if (!foundEpisode && playAllPlaylists.size() == 1 && !isSpecial)
+  {
+    CLog::LogF(LOGDEBUG, "Using Play All playlist method");
+
+    // See where that title was found in the play all playlist
+    std::vector<std::pair<unsigned int, unsigned int>> titleOrder{playAllPlaylists[0].second};
+    std::sort(titleOrder.begin(), titleOrder.end(),
+              [](const std::pair<unsigned int, unsigned int>& i,
+                 const std::pair<unsigned int, unsigned int>& j) { return i.second < j.second; });
+
+    for (unsigned int i = 0; i < numEpisodes; ++i)
+    {
+      if (allEpisodes || i == episodeOffset)
+      {
+        // Get ith title number from play all playlist
+        candidatePlaylists.emplace_back(titleOrder[i].first, i);
+
+        CLog::LogF(LOGDEBUG, "Candidate playlist {}", titleOrder[episodeOffset].first);
+      }
+    }
+    foundEpisode = true;
+  }
+
+  // If no play all playlist then look for the n longest playlists and assume they are episodes
+  if (!foundEpisode && playlists_length.size() >= numEpisodes)
+  {
+    CLog::LogF(LOGDEBUG, "Using longest playlists method");
+    std::vector<unsigned int> longPlaylists;
+
+    // Sort playlists by length
+    std::sort(playlists_length.begin(), playlists_length.end(),
+              [](const std::vector<unsigned int>& i, const std::vector<unsigned int>& j)
+              {
+                if (i[1] == j[1]) // Duration
+                  return i[0] < j[0]; // Title
+                return i[1] > j[1];
+              });
+
+    // See if the first n titles are longer than minimum length
+    bool correctLength = true;
+    for (unsigned int i = 0; i < numEpisodes; ++i)
+      if (playlists_length[i][1] < MIN_EPISODE_LENGTH)
+        correctLength = false;
+
+    if (correctLength)
+    {
+      // If they are sequential then assume they are episodes (in order)
+      std::vector<std::vector<unsigned int>> playlists_order{
+          playlists_length.begin(), playlists_length.begin() + numEpisodes};
+      std::sort(playlists_order.begin(), playlists_order.end(),
+                [](const std::vector<unsigned int>& i, const std::vector<unsigned int>& j)
+                {
+                  return i[0] < j[0]; // Title
+                });
+
+      bool sequential = true;
+      for (unsigned int i = 0; i < numEpisodes - 1; ++i)
+        if (playlists_order[i + 1][0] != playlists_order[i][0] + 1)
+          sequential = false;
+
+      if (sequential)
+      {
+        for (unsigned int i = 0; i < numEpisodes; ++i)
+        {
+          if (allEpisodes || i == episodeOffset)
+          {
+            // Get ith title number from play all playlist
+            candidatePlaylists.emplace_back(playlists_order[i][0], i);
+
+            CLog::LogF(LOGDEBUG, "Candidate playlist {}", playlists_order[i][0]);
+          }
+        }
+        foundEpisode = true;
+      }
+    }
+  }
+
+  CLog::LogF(LOGDEBUG, "*** Episode Search End ***");
+
+  // ** Now populate CFileItemList to return
+  CFileItemList newItems;
+
+  if (chapters)
+  {
+    CURL path(m_url);
+    for (unsigned int e = 0; e < numEpisodes; ++e)
+    {
+      if (allEpisodes || e == episodeOffset)
+      {
+        const auto newItem{std::make_shared<CFileItem>("", false)};
+
+        std::string buf{StringUtils::Format("title/1/chapter/{}", e + 1)};
+        path.SetFileName(buf);
+        newItem->SetPath(path.Get());
+
+        const unsigned int duration{playlists_length[0][e + PLAYLIST_CHAPTER_OFFSET]};
+        newItem->GetVideoInfoTag()->SetDuration(duration);
+        newItem->GetVideoInfoTag()->m_iTrack = 1;
+
+        // Get episode title
+        buf = StringUtils::Format("{0:s} {1:d} - {2:s}", g_localizeStrings.Get(20359) /* Episode */,
+                                  episodesOnDisc[e].m_iEpisode, episodesOnDisc[e].GetTitle());
+        newItem->m_strTitle = buf;
+        newItem->SetLabel(buf);
+        newItem->SetLabel2(StringUtils::Format(
+            g_localizeStrings.Get(21396) /* Chapter */ + ": {0:d} - {1:s}: {2:s}", e + 1,
+            g_localizeStrings.Get(180) /* Duration */, StringUtils::SecondsToTimeString(duration)));
+
+        newItem->m_dwSize = 0;
+        newItem->SetArt("icon", "DefaultVideo.png");
+        items.Add(newItem);
+      }
+    }
+  }
+  else
+  {
+    for (const auto& playlist : candidatePlaylists)
+    {
+      const auto newItem{std::make_shared<CFileItem>("", false)};
+
+      // Get duration
+      const auto& it = std::find_if(playlists.begin(), playlists.end(),
+                                    [&playlist](const std::vector<unsigned int>& x)
+                                    { return x[0] == playlist.first; });
+      const int duration = it->at(1);
+
+      CURL path(m_url);
+      std::string buf{StringUtils::Format("title/{}", playlist.first)};
+      path.SetFileName(buf);
+      newItem->SetPath(path.Get());
+
+      newItem->GetVideoInfoTag()->SetDuration(duration);
+      newItem->GetVideoInfoTag()->m_iTrack = playlist.first;
+
+      // Get episode title
+      buf = StringUtils::Format("{0:s} {1:d} - {2:s}", g_localizeStrings.Get(20359) /* Episode */,
+                                episodesOnDisc[playlist.second].m_iEpisode,
+                                episodesOnDisc[playlist.second].GetTitle());
+
+      newItem->m_strTitle = buf;
+      newItem->SetLabel(buf);
+      newItem->SetLabel2(StringUtils::Format(
+          g_localizeStrings.Get(25005) /* Title: {0:d} */ + " - {1:s}: {2:s}", playlist.first,
+          g_localizeStrings.Get(180) /* Duration */, StringUtils::SecondsToTimeString(duration)));
+
+      newItem->m_dwSize = 0;
+      newItem->SetArt("icon", "DefaultVideo.png");
+      items.Add(newItem);
+    }
+  }
+}
+
+void CDVDDirectory::GetRoot(CFileItemList& items) const
+{
+  GetTitles(GET_TITLES_MAIN, items);
+
+  AddRootOptions(items);
+}
+
+void CDVDDirectory::GetRoot(CFileItemList& items,
+                            const CFileItem& episode,
+                            const std::vector<CVideoInfoTag>& episodesOnDisc) const
+{
+  if (CDVDInputStreamNavigator dvd{nullptr, episode}; dvd.Open())
+  {
+    // Get playlist, clip and language information
+    std::vector<std::vector<unsigned int>> clips;
+    std::vector<std::vector<unsigned int>> playlists;
+    std::map<unsigned int, std::string> playlist_langs;
+
+    dvd.GetPlaylistInfo(clips, playlists, playlist_langs);
+
+    // Get episode playlists
+    GetEpisodeTitles(episode, items, episodesOnDisc, clips, playlists, playlist_langs);
+
+    if (!items.IsEmpty())
+      AddRootOptions(items);
+
+    dvd.Close();
+  }
+}
+
+void CDVDDirectory::AddRootOptions(CFileItemList& items) const
+{
+  CURL path(m_url);
+  path.SetFileName(URIUtils::AddFileToFolder(m_url.GetFileName(), "titles"));
+
+  auto item{std::make_shared<CFileItem>(path.Get(), true)};
+  item->SetLabel(g_localizeStrings.Get(25002) /* All titles */);
+  item->SetArt("icon", "DefaultVideoPlaylists.png");
+  items.Add(item);
+
+  path.SetFileName("menu");
+  item = {std::make_shared<CFileItem>(path.Get(), false)};
+  item->SetLabel(g_localizeStrings.Get(29806) /* Menu */);
+  item->SetArt("icon", "DefaultProgram.png");
+  items.Add(item);
+}
+
+bool CDVDDirectory::GetEpisodeDirectory(const CURL& url,
+                                        const CFileItem& episode,
+                                        CFileItemList& items,
+                                        const std::vector<CVideoInfoTag>& episodesOnDisc)
+{
+  m_url = url;
+  GetRoot(items, episode, episodesOnDisc);
+
+  items.AddSortMethod(SortByTrackNumber, 554,
+                      LABEL_MASKS("%L", "%D", "%L", "")); // FileName, Duration | Foldername, empty
+  items.AddSortMethod(SortBySize, 553,
+                      LABEL_MASKS("%L", "%I", "%L", "%I")); // FileName, Size | Foldername, Size
+
+  return true;
+}
+
+bool CDVDDirectory::GetDirectory(const CURL& url, CFileItemList& items)
+{
+  m_url = url;
+  std::string file = m_url.GetFileName();
+  URIUtils::RemoveSlashAtEnd(file);
+
+  if (file == "root")
+    GetRoot(items);
+  else if (file == "root/titles")
+    GetTitles(GET_TITLES_ALL, items);
+  else
+  {
+    CURL url2 = GetUnderlyingCURL(url);
+    CDirectory::CHints hints;
+    hints.flags = m_flags;
+    if (!CDirectory::GetDirectory(url2, items, hints))
+      return false;
+  }
+
+  items.AddSortMethod(SortByTrackNumber, 554,
+                      LABEL_MASKS("%L", "%D", "%L", "")); // FileName, Duration | Foldername, empty
+  items.AddSortMethod(SortBySize, 553,
+                      LABEL_MASKS("%L", "%I", "%L", "%I")); // FileName, Size | Foldername, Size
+
+  return true;
+}
+
+static constexpr unsigned int MAIN_TITLE_LENGTH_PERCENT = 70;
+
+void CDVDDirectory::GetTitles(const int job, CFileItemList& items) const
+{
+  const CFileItem episode{m_url, false};
+  CDVDInputStreamNavigator dvd{nullptr, episode};
+  if (dvd.Open())
+  {
+    // Get playlist, clip and language information
+    std::vector<std::vector<unsigned int>> clips;
+    std::vector<std::vector<unsigned int>> playlists;
+    std::map<unsigned int, std::string> playlist_langs;
+
+    dvd.GetPlaylistInfo(clips, playlists, playlist_langs);
+
+    // Remove zero length titles
+    playlists.erase(std::remove_if(playlists.begin(), playlists.end(),
+                                   [](const std::vector<unsigned int>& i) { return i[1] == 0; }),
+                    playlists.end());
+
+    // Get the longest title and calculate minimum title length
+    unsigned int minDuration{0};
+    unsigned int maxPlaylist{0};
+    if (job != GET_TITLES_ALL)
+    {
+      for (unsigned int i = 0; i < playlists.size(); ++i)
+        if (playlists[i][1] > minDuration)
+        {
+          minDuration = playlists[i][1];
+          maxPlaylist = i;
+        }
+    }
+    minDuration = minDuration * MAIN_TITLE_LENGTH_PERCENT / 100;
+
+    for (unsigned int i = 0; i < playlists.size(); ++i)
+    {
+      const unsigned int duration = playlists[i][1];
+      if (job == GET_TITLES_ALL || (job == GET_TITLES_MAIN && duration >= minDuration) ||
+          (job == GET_TITLES_ONE && i == maxPlaylist))
+      {
+        const auto newItem{std::make_shared<CFileItem>("", false)};
+
+        CURL path(m_url);
+        const unsigned int playlist{playlists[i][0]};
+        std::string buf{StringUtils::Format("title/{}", playlist)};
+        path.SetFileName(buf);
+        newItem->SetPath(path.Get());
+
+        newItem->GetVideoInfoTag()->SetDuration(duration);
+        newItem->GetVideoInfoTag()->m_iTrack = playlist;
+
+        // Get episode title
+        buf = StringUtils::Format(g_localizeStrings.Get(25005) /* Title */, playlist);
+        newItem->m_strTitle = buf;
+        newItem->SetLabel(buf);
+
+        buf = StringUtils::Format(g_localizeStrings.Get(25007),
+                                  playlists[i].size() - PLAYLIST_CHAPTER_OFFSET,
+                                  StringUtils::SecondsToTimeString(duration));
+        newItem->SetLabel2(buf);
+
+        newItem->m_dwSize = 0;
+        newItem->SetArt("icon", "DefaultVideo.png");
+        items.Add(newItem);
+      }
+    }
+    dvd.Close();
+  }
+}
+
+bool CDVDDirectory::GetMainItem(const CURL& url, CFileItem& main)
+{
+  m_url = url;
+  CFileItemList items;
+  GetTitles(GET_TITLES_ONE, items);
+
+  if (items.Size() == 1)
+    main = *items[0];
+
+  return true;
+}
+
+CURL CDVDDirectory::GetUnderlyingCURL(const CURL& url)
+{
+  assert(url.IsProtocol("dvd"));
+  std::string host = url.GetHostName();
+  const std::string& filename = url.GetFileName();
+  return CURL(host.append(filename));
 }

--- a/xbmc/filesystem/DVDDirectory.cpp
+++ b/xbmc/filesystem/DVDDirectory.cpp
@@ -9,6 +9,7 @@
 #include "DVDDirectory.h"
 
 #include "FileItem.h"
+#include "FileItemList.h"
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h"

--- a/xbmc/filesystem/DVDDirectory.h
+++ b/xbmc/filesystem/DVDDirectory.h
@@ -8,7 +8,8 @@
 
 #pragma once
 
-#include "IFileDirectory.h"
+#include "IDirectory.h"
+#include "URL.h"
 
 namespace XFILE
 {
@@ -16,13 +17,34 @@ namespace XFILE
 /*!
  \brief Abstracts a DVD virtual directory (dvd://) which in turn points to the actual physical drive
  */
-class CDVDDirectory : public IFileDirectory
+class CDVDDirectory : public IDirectory
 {
 public:
   CDVDDirectory() = default;
   ~CDVDDirectory() override = default;
-  bool GetDirectory(const CURL& url, CFileItemList& items) override { return false; };
-  bool ContainsFiles(const CURL& url) override { return false; }
+  bool GetDirectory(const CURL& url, CFileItemList& items) override;
   bool Resolve(CFileItem& item) const override;
+  void GetEpisodeTitles(const CFileItem& episode,
+                        CFileItemList& items,
+                        std::vector<CVideoInfoTag> episodesOnDisc,
+                        const std::vector<std::vector<unsigned int>>& clips,
+                        const std::vector<std::vector<unsigned int>>& playlists,
+                        std::map<unsigned int, std::string>& playlist_langs) const;
+  bool GetMainItem(const CURL& url, CFileItem& main) override;
+
+private:
+  void GetRoot(CFileItemList& items) const;
+  void GetRoot(CFileItemList& items,
+               const CFileItem& episode,
+               const std::vector<CVideoInfoTag>& episodesOnDisc) const;
+  bool GetEpisodeDirectory(const CURL& url,
+                           const CFileItem& episode,
+                           CFileItemList& items,
+                           const std::vector<CVideoInfoTag>& episodesOnDisc) override;
+  void AddRootOptions(CFileItemList& items) const;
+  void GetTitles(const int job, CFileItemList& items) const;
+  static CURL GetUnderlyingCURL(const CURL& url);
+
+  CURL m_url;
 };
 } // namespace XFILE

--- a/xbmc/filesystem/DVDFile.cpp
+++ b/xbmc/filesystem/DVDFile.cpp
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "DVDFile.h"
+
+#include "URL.h"
+
+#include <assert.h>
+
+namespace XFILE
+{
+
+CDVDFile::CDVDFile(void) : COverrideFile(false)
+{
+}
+
+CDVDFile::~CDVDFile(void) = default;
+
+std::string CDVDFile::TranslatePath(const CURL& url)
+{
+  assert(url.IsProtocol("dvd"));
+
+  std::string host = url.GetHostName();
+  const std::string& filename = url.GetFileName();
+  if (host.empty() || filename.empty())
+    return "";
+
+  return host.append(filename);
+}
+} /* namespace XFILE */

--- a/xbmc/filesystem/DVDFile.h
+++ b/xbmc/filesystem/DVDFile.h
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "filesystem/OverrideFile.h"
+
+namespace XFILE
+{
+
+class CDVDFile : public COverrideFile
+{
+public:
+  CDVDFile();
+  ~CDVDFile() override;
+
+protected:
+  std::string TranslatePath(const CURL& url) override;
+};
+} // namespace XFILE

--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -26,7 +26,8 @@
 #include "utils/JobManager.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
-#include "video/VideoFileItemClassify.h"
+#include "video/VideoDatabase.h"
+#include "video/VideoInfoTag.h"
 
 using namespace KODI;
 using namespace XFILE;
@@ -307,6 +308,44 @@ bool CDirectory::GetDirectory(const CURL& url,
   catch (...) { CLog::Log(LOGERROR, "{} - Unhandled exception", __FUNCTION__); }
   CLog::Log(LOGERROR, "{} - Error getting {}", __FUNCTION__, url.GetRedacted());
   return false;
+}
+
+bool CDirectory::GetDirectory(const std::string& path, CFileItemList& items, const CFileItem& item)
+{
+  // Specifically looking for dvd/blu-ray episodes
+  const CURL url(path);
+  const CURL realURL = URIUtils::SubstitutePath(url);
+
+  if (url.IsProtocol("bluray") || url.IsProtocol("dvd"))
+  {
+    std::shared_ptr<IDirectory> pDirectory(CDirectoryFactory::Create(realURL));
+
+    if (pDirectory)
+    {
+      std::vector<CVideoInfoTag> episodesOnDisc;
+
+      CVideoDatabase database;
+      if (!database.Open())
+      {
+        CLog::LogF(LOGERROR, "Failed to open video database");
+        return false;
+      }
+      database.GetEpisodesByFileId(item.GetVideoInfoTag()->m_iFileId, episodesOnDisc);
+
+      return pDirectory->GetEpisodeDirectory(url, item, items, episodesOnDisc);
+    }
+  }
+
+  return false;
+}
+
+bool CDirectory::GetDirectory(const std::string& path, CFileItem& main, const CFileItem& item)
+{
+  // specifically looking for main title
+  const CURL url(path);
+  const CURL realURL = URIUtils::SubstitutePath(url);
+  std::shared_ptr<IDirectory> pDirectory(CDirectoryFactory::Create(realURL));
+  return pDirectory->GetMainItem(url, main);
 }
 
 bool CDirectory::EnumerateDirectory(

--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -27,6 +27,7 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
+#include "video/VideoFileItemClassify.h"
 #include "video/VideoInfoTag.h"
 
 using namespace KODI;
@@ -286,7 +287,7 @@ bool CDirectory::GetDirectory(const CURL& url,
 
     //  Should any of the files we read be treated as a directory?
     //  Disable for database folders, as they already contain the extracted items
-    if (!(hints.flags & DIR_FLAG_NO_FILE_DIRS) && !items.IsMusicDb() && !VIDEO::IsVideoDb(items) &&
+    if (!(hints.flags & DIR_FLAG_NO_FILE_DIRS) && !items.IsMusicDb() && !KODI::VIDEO::IsVideoDb(items) &&
         !items.IsSmartPlayList())
       FilterFileDirectories(items, hints.mask);
 

--- a/xbmc/filesystem/Directory.h
+++ b/xbmc/filesystem/Directory.h
@@ -69,6 +69,10 @@ public:
                            , CFileItemList &items
                            , const CHints &hints);
 
+  static bool GetDirectory(const std::string& path, CFileItemList& items, const CFileItem& item);
+
+  static bool GetDirectory(const std::string& path, CFileItem& main, const CFileItem& item);
+
   using DirectoryEnumerationCallback = std::function<void(const std::shared_ptr<CFileItem>& item)>;
   using DirectoryFilter = std::function<bool(const std::shared_ptr<CFileItem>& folder)>;
 

--- a/xbmc/filesystem/FileFactory.cpp
+++ b/xbmc/filesystem/FileFactory.cpp
@@ -50,12 +50,13 @@
 #ifdef HAVE_LIBBLURAY
 #include "BlurayFile.h"
 #endif
-#include "PipeFile.h"
+#include "DVDFile.h"
+#include "MultiPathFile.h"
 #include "MusicDatabaseFile.h"
-#include "VideoDatabaseFile.h"
+#include "PipeFile.h"
 #include "PluginFile.h"
 #include "SpecialProtocolFile.h"
-#include "MultiPathFile.h"
+#include "VideoDatabaseFile.h"
 #if defined(HAS_UDFREAD)
 #include "UDFFile.h"
 #endif
@@ -147,6 +148,8 @@ IFile* CFileFactory::CreateLoader(const CURL& url)
 #ifdef HAVE_LIBBLURAY
   else if (url.IsProtocol("bluray")) return new CBlurayFile();
 #endif
+  else if (url.IsProtocol("dvd"))
+    return new CDVDFile();
   else if (url.IsProtocol("resource")) return new CResourceFile();
 #ifdef TARGET_WINDOWS_STORE
   else if (CWinLibraryFile::IsValid(url)) return new CWinLibraryFile();

--- a/xbmc/filesystem/IDirectory.h
+++ b/xbmc/filesystem/IDirectory.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "utils/Variant.h"
+#include "video/VideoInfoTag.h"
 
 #include <string>
 
@@ -40,7 +41,22 @@ namespace XFILE
     DIR_FLAG_READ_CACHE    = (2 << 4), ///< Force reading from the directory cache (if available)
     DIR_FLAG_BYPASS_CACHE  = (2 << 5)  ///< Completely bypass the directory cache (no reading, no writing)
   };
-/*!
+
+  enum GET_TITLES_JOB
+  {
+    GET_TITLES_ONE = 0,
+    GET_TITLES_MAIN = 1,
+    GET_TITLES_ALL = 2
+  };
+
+  enum SORT_TITLES_JOB
+  {
+    SORT_TITLES_NONE = 0,
+    SORT_TITLES_EPISODE = 1,
+    SORT_TITLES_MOVIE = 2
+  };
+
+  /*!
  \ingroup filesystem
  \brief Interface to the directory on a file system.
 
@@ -48,102 +64,116 @@ namespace XFILE
  access the directories on a filesystem.
  \sa CDirectoryFactory
  */
-class IDirectory
-{
-public:
-  static void RegisterProfileManager(const CProfileManager &profileManager);
-  static void UnregisterProfileManager();
+  class IDirectory
+  {
+  public:
+    static void RegisterProfileManager(const CProfileManager& profileManager);
+    static void UnregisterProfileManager();
 
-  IDirectory();
-  virtual ~IDirectory(void);
-  /*!
+    IDirectory();
+    virtual ~IDirectory(void);
+    /*!
    \brief Get the \e items of the directory \e strPath.
    \param url Directory to read.
    \param items Retrieves the directory entries.
    \return Returns \e true, if successful.
    \sa CDirectoryFactory
    */
-  virtual bool GetDirectory(const CURL& url, CFileItemList &items) = 0;
-  /*!
+    virtual bool GetDirectory(const CURL& url, CFileItemList& items) { return false; }
+
+    virtual bool GetEpisodeDirectory(const CURL& url,
+                                     const CFileItem& episode,
+                                     CFileItemList& items,
+                                     const std::vector<CVideoInfoTag>& episodesOnDisc)
+    {
+      return false;
+    }
+
+    virtual bool GetMainItem(const CURL& url, CFileItem& main)
+    {
+      return false;
+    }
+
+    /*!
    \brief Retrieve the progress of the current directory fetch (if possible).
    \return the progress as a float in the range 0..100.
    \sa GetDirectory, CancelDirectory
    */
-  virtual float GetProgress() const { return 0.0f; }
-  /*!
+    virtual float GetProgress() const { return 0.0f; }
+    /*!
    \brief Cancel the current directory fetch (if possible).
    \sa GetDirectory
    */
-  virtual void CancelDirectory() {}
-  /*!
+    virtual void CancelDirectory() {}
+    /*!
   \brief Create the directory
   \param url Directory to create.
   \return Returns \e true, if directory is created or if it already exists
   \sa CDirectoryFactory
   */
-  virtual bool Create(const CURL& url) { return false; }
-  /*!
+    virtual bool Create(const CURL& url) { return false; }
+    /*!
   \brief Check for directory existence
   \param url Directory to check.
   \return Returns \e true, if directory exists
   \sa CDirectoryFactory
   */
-  virtual bool Exists(const CURL& url) { return false; }
-  /*!
+    virtual bool Exists(const CURL& url) { return false; }
+    /*!
   \brief Removes the directory
   \param url Directory to remove.
   \return Returns \e false if not successful
   */
-  virtual bool Remove(const CURL& url) { return false; }
+    virtual bool Remove(const CURL& url) { return false; }
 
-  /*!
+    /*!
   \brief Recursively removes the directory
   \param url Directory to remove.
   \return Returns \e false if not successful
   */
-  virtual bool RemoveRecursive(const CURL& url) { return false; }
+    virtual bool RemoveRecursive(const CURL& url) { return false; }
 
-  /*!
+    /*!
   \brief Whether this file should be listed
   \param url File to test.
   \return Returns \e true if the file should be listed
   */
-  virtual bool IsAllowed(const CURL& url) const;
+    virtual bool IsAllowed(const CURL& url) const;
 
-  /*! \brief Whether to allow all files/folders to be listed.
+    /*! \brief Whether to allow all files/folders to be listed.
    \return Returns \e true if all files/folder should be listed.
    */
-  virtual bool AllowAll() const { return false; }
+    virtual bool AllowAll() const { return false; }
 
-  /*!
+    /*!
   \brief How this directory should be cached
   \param url Directory at hand.
   \return Returns the cache type.
   */
-  virtual DIR_CACHE_TYPE GetCacheType(const CURL& url) const { return DIR_CACHE_ONCE; }
+    virtual DIR_CACHE_TYPE GetCacheType(const CURL& url) const { return DIR_CACHE_ONCE; }
 
-  void SetMask(const std::string& strMask);
-  void SetFlags(int flags);
+    void SetMask(const std::string& strMask);
+    void SetFlags(int flags);
 
-  /*! \brief Process additional requirements before the directory fetch is performed.
+    /*! \brief Process additional requirements before the directory fetch is performed.
    Some directory fetches may require authentication, keyboard input etc.  The IDirectory subclass
    should call GetKeyboardInput, SetErrorDialog or RequireAuthentication and then return false
    from the GetDirectory method. CDirectory will then prompt for input from the user, before
    re-calling the GetDirectory method.
    \sa GetKeyboardInput, SetErrorDialog, RequireAuthentication
    */
-  bool ProcessRequirements();
+    bool ProcessRequirements();
 
-  /*!
+    /*!
   \brief Resolves a given item to a playable item
   \note Some directories (e.g. dvd, bluray, plugins etc) need to be translated/resolved to the actual playback url
   \param item The item being manipulated (which the path points to a vfs protocol implementation)
   \return true if the item was resolved, false if it failed to resolve
   */
-  virtual bool Resolve(CFileItem& item) const { return true; };
+    virtual bool Resolve(CFileItem& item) const { return true; };
 
-protected:
-  /*! \brief Prompt the user for some keyboard input
+  protected:
+    /*! \brief Prompt the user for some keyboard input
    Call this method from the GetDirectory method to retrieve additional input from the user.
    If this function returns false then no input has been received, and the GetDirectory call
    should return false.
@@ -152,9 +182,9 @@ protected:
    \return true if keyboard input has been received. False if it hasn't.
    \sa ProcessRequirements
    */
-  bool GetKeyboardInput(const CVariant &heading, std::string &input, bool hiddenInput = false);
+    bool GetKeyboardInput(const CVariant& heading, std::string& input, bool hiddenInput = false);
 
-  /*! \brief Show an error dialog on failure of GetDirectory call
+    /*! \brief Show an error dialog on failure of GetDirectory call
    Call this method from the GetDirectory method to set an error message to be shown to the user
    \param heading an integer or string heading for the error dialog.
    \param line1 the first line to be displayed (integer or string).
@@ -162,23 +192,26 @@ protected:
    \param line3 the first line to be displayed (integer or string).
    \sa ProcessRequirements
    */
-  void SetErrorDialog(const CVariant &heading, const CVariant &line1, const CVariant &line2 = 0, const CVariant &line3 = 0);
+    void SetErrorDialog(const CVariant& heading,
+                        const CVariant& line1,
+                        const CVariant& line2 = 0,
+                        const CVariant& line3 = 0);
 
-  /*! \brief Prompt the user for authentication of a URL.
+    /*! \brief Prompt the user for authentication of a URL.
    Call this method from the GetDirectory method when authentication is required from the user, before returning
    false from the GetDirectory call. The user will be prompted for authentication, and GetDirectory will be
    re-called.
    \param url the URL to authenticate.
    \sa ProcessRequirements
    */
-  void RequireAuthentication(const CURL& url);
+    void RequireAuthentication(const CURL& url);
 
-  static const CProfileManager *m_profileManager;
+    static const CProfileManager* m_profileManager;
 
-  std::string m_strFileMask;  ///< Holds the file mask specified by SetMask()
+    std::string m_strFileMask; ///< Holds the file mask specified by SetMask()
 
-  int m_flags; ///< Directory flags - see DIR_FLAG
+    int m_flags; ///< Directory flags - see DIR_FLAG
 
-  CVariant m_requirements;
-};
+    CVariant m_requirements;
+  };
 }

--- a/xbmc/settings/DiscSettings.h
+++ b/xbmc/settings/DiscSettings.h
@@ -18,6 +18,13 @@ enum BDPlaybackMode
   BD_PLAYBACK_MAIN_TITLE,
 };
 
+enum DVDPlaybackMode
+{
+  DVD_PLAYBACK_SIMPLE_MENU = 0,
+  DVD_PLAYBACK_DISC_MENU,
+  DVD_PLAYBACK_MAIN_TITLE,
+};
+
 #include "settings/lib/ISettingCallback.h"
 
 class CDiscSettings : public ISettingCallback

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -175,6 +175,7 @@ public:
   static constexpr auto SETTING_SUBTITLES_MOVIE = "subtitles.movie";
   static constexpr auto SETTING_DVDS_AUTORUN = "dvds.autorun";
   static constexpr auto SETTING_DVDS_PLAYERREGION = "dvds.playerregion";
+  static constexpr auto SETTING_DVDS_PLAYBACK = "dvds.playback";
   static constexpr auto SETTING_DVDS_AUTOMENU = "dvds.automenu";
   static constexpr auto SETTING_DISC_PLAYBACK = "disc.playback";
   static constexpr auto SETTING_BLURAY_PLAYERREGION = "bluray.playerregion";

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -159,10 +159,15 @@ void CSaveFileState::DoWork(CFileItem& item,
           CFileItem dbItem(item);
 
           // Check whether the item's db streamdetails need updating
-          if (!videodatabase.GetStreamDetails(dbItem) ||
-              dbItem.GetVideoInfoTag()->m_streamDetails != item.GetVideoInfoTag()->m_streamDetails)
+          if ((!videodatabase.GetStreamDetails(dbItem) ||
+               dbItem.GetVideoInfoTag()->m_streamDetails !=
+                   item.GetVideoInfoTag()->m_streamDetails) &&
+              item.m_titlesJob !=
+                  CFileItem::
+                      TITLES_JOB_ALL_EPISODES) // Don't update if multi-episode disc and browsing through Videos -> Files ...
           {
-            videodatabase.SetStreamDetailsForFile(item.GetVideoInfoTag()->m_streamDetails, progressTrackingFile);
+            videodatabase.SetStreamDetailsForFile(item.GetVideoInfoTag()->m_streamDetails,
+                                                  progressTrackingFile);
             updateListing = true;
           }
         }

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -291,7 +291,8 @@ void URIUtils::GetCommonPath(std::string& strParent, const std::string& strPath)
 bool URIUtils::HasParentInHostname(const CURL& url)
 {
   return url.IsProtocol("zip") || url.IsProtocol("apk") || url.IsProtocol("bluray") ||
-         url.IsProtocol("udf") || url.IsProtocol("iso9660") || url.IsProtocol("xbt") ||
+         url.IsProtocol("dvd") || url.IsProtocol("udf") || url.IsProtocol("iso9660") ||
+         url.IsProtocol("xbt") ||
          (CServiceBroker::IsAddonInterfaceUp() &&
           CServiceBroker::GetFileExtensionProvider().EncodedHostName(url.GetProtocol()));
 }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3463,6 +3463,27 @@ void CVideoDatabase::GetEpisodesByFile(const std::string& strFilenameAndPath, st
   }
 }
 
+void CVideoDatabase::GetEpisodesByFileId(const int& fileId, std::vector<CVideoInfoTag>& episodes)
+{
+  try
+  {
+    std::string strSQL =
+        PrepareSQL("select * from episode_view where idFile=%i order by c%02d, c%02d asc", fileId,
+                   VIDEODB_ID_EPISODE_SORTSEASON, VIDEODB_ID_EPISODE_SORTEPISODE);
+    m_pDS->query(strSQL);
+    while (!m_pDS->eof())
+    {
+      episodes.emplace_back(GetDetailsForEpisode(m_pDS));
+      m_pDS->next();
+    }
+    m_pDS->close();
+  }
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "(FileId {}) failed", fileId);
+  }
+}
+
 //********************************************************************************************************************************
 void CVideoDatabase::AddBookMarkToFile(const std::string& strFilenameAndPath, const CBookmark &bookmark, CBookmark::EType type /*= CBookmark::STANDARD*/)
 {

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -558,6 +558,7 @@ public:
   int GetSeasonId(int idShow, int season);
 
   void GetEpisodesByFile(const std::string& strFilenameAndPath, std::vector<CVideoInfoTag>& episodes);
+  void GetEpisodesByFileId(const int& fileId, std::vector<CVideoInfoTag>& episodes);
 
   int SetDetailsForItem(CVideoInfoTag& details, const std::map<std::string, std::string> &artwork);
   int SetDetailsForItem(int id, const MediaType& mediaType, CVideoInfoTag& details, const std::map<std::string, std::string> &artwork);

--- a/xbmc/video/guilib/VideoGUIUtils.cpp
+++ b/xbmc/video/guilib/VideoGUIUtils.cpp
@@ -142,6 +142,7 @@ void CAsyncGetItemsForPlaylist::GetItemsForPlaylist(const std::shared_ptr<CFileI
     if (!mediapath.empty())
     {
       m_queuedItems.Add(std::make_shared<CFileItem>(mediapath, false));
+      m_queuedItems.Get(m_queuedItems.Size() - 1)->m_titlesJob = item->m_titlesJob;
       return;
     }
 

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -713,7 +713,7 @@ void CGUIWindowVideoBase::LoadVideoInfo(CFileItemList& items,
     }
     if (match)
     {
-      pItem->UpdateInfo(*match, replaceLabels);
+      pItem->UpdateInfo(*match, replaceLabels, true);
 
       if (stackItems)
       {


### PR DESCRIPTION
This is an evolution of #24178, which I have closed as I have made many changes/improvements.

I've been looking at how episodes are played when they are in a blu-ray ISO

EDIT: Bluray scraping now fixed in v21/master
EDIT: Simple DVD menu now supported (like bluray) - this allows selection of episode without DVD menu.

Currently you are asked to select from a list of titles - these are presented in no particular order and (by default) only show those with length 70%+ of the longest.

So, for example, on The Last of Us (UHD Disc 1) - if I try and play episode 2 (disc 1 contains episodes 1 and 2), I get the following:
<img width="452" alt="before" src="https://github.com/xbmc/xbmc/assets/99039295/6db5e22f-c431-4fe5-b4a3-426b98c6be20">

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

This demonstrates a number of issues:
1) No clear idea what titles 801 and 851 contain - they actually are both episode 1 (despite us asking to play episode 2)
2) No idea what languages are associated with each title (801 = episode 1 european languages, 851 = episode 1 japanese)

I've updated the code - so now when I select episode 2 I get the following:
<img width="804" alt="image" src="https://github.com/xbmc/xbmc/assets/99039295/e10cc6cf-7b95-4e49-82f0-6d8cb54170ec">

This also makes the Videos -> Files -> ... more logical as well.

Instead of:
![Before](https://github.com/xbmc/xbmc/assets/99039295/fbfcd807-71fc-4213-b84f-451e9e8c62fa)

We now have:
<img width="1280" alt="image" src="https://github.com/xbmc/xbmc/assets/99039295/4882ef7e-66b6-4a92-9f30-b66729195326">

Showing all the episodes on the disc instead of just the first one (with no indication the others are there)

and:
<img width="803" alt="image" src="https://github.com/xbmc/xbmc/assets/99039295/765d7425-4bcc-445a-9a87-60d94a4aba77">

Allowing you to sellect each episode rather than a random title list.

Methodology (from code comments)

```
  // At this stage we have a number of ways of trying to determine the correct playlist for an episode
  //
  // 1) Using a 'Play All' playlist
  //    - Caveat: there may not be one
  //
  // 2) Using the longest (non-'Play All') playlists that are consecutive
  //    - Caveat: assumes play-all detection has worked and playlists are consecutive (hopefully reasonable assumptions)
  //
  // 3) Playlists that are +/- 30sec of the episode length that is passed to us
  //    - Caveat: the episode length may be wrong - either from scraper/NFO or from bug in Kodi that overwrites episode streamdetails on same disc
  //
  // 4) Using position in a group of adjacent playlists (see below)
  //    - Cavet: won't work for single episode discs
  // 
  // 5) - For single episode discs - this is hard. There are some discs where there are extras that are longer than the episode itself
  //      The only obvious difference sometimes seems to be number of languages
  //
  // Order of preference:
  //
  // 1) Use 'Play All' playlist - take the nth clip and find a playlist that plays that clip
  //
  // 2) Take the nth playlist of a consecutive run of longest playlists
  //
  // 3) Refine a group using relative position of playlist found on basis of length
  //    - this tries to account for episodes that have the wrong duration passed
  //    eg. if we have a disc with episodes 4,5,6 we would expect episode 5 to be the middle playlist of a group of 3 consecutive playlists (eg. 801, 802, 803)
  //
  // 4) Playlist based on episode length alone (assumes no groups found or 2) and 3) failed)
  //
  // 5) Look at groups found (ignoring length) and pick the relevant playlist - eg. the middle one for episode 5 using the exampe above
  //    - Only looks at playlists > MIN_EPISODE_LENGTH
  // 
  // 6) For single episode discs only, look at the longest playlist with multiple languages
  //
  // SPECIALS
  //
  // These are more difficult - as there may only be one per disc and we can't make assumptions about playlists.
  // So have to look on basis of duration alone.
  //
```

## Motivation and context

Improve the rather unintuitive episode selection when episodes on bluray.

## How has this been tested?

Windows 11 x64

## What is the effect on users?

More intuitve episode selection when on bluray.

## Screenshots (if appropriate):

See above

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
