### PR TITLE
[Pictures addons] support Date Taken sort for pics decoded via addons

### DIFF
--- a/xbmc/addons/ImageDecoder.cpp
+++ b/xbmc/addons/ImageDecoder.cpp
@@ -130,7 +130,10 @@ bool CImageDecoder::LoadInfoTag(const std::string& fileName, CPictureInfoTag* ta
     tag->m_exifInfo.ExposureProgram = ifcTag.exposure_program;
     tag->m_exifInfo.ExposureMode = ifcTag.exposure_mode;
     tag->m_exifInfo.ISOequivalent = static_cast<int>(ifcTag.iso_speed);
-    tag->m_iptcInfo.TimeCreated = CDateTime(ifcTag.time_created).GetAsLocalizedDateTime();
+    CDateTime dt;
+    dt.SetFromUTCDateTime(ifcTag.time_created);
+    tag->m_iptcInfo.TimeCreated = dt.GetAsLocalizedDateTime();
+    tag->m_dateTimeTaken = dt;
     tag->m_exifInfo.GpsInfoPresent = ifcTag.gps_info_present;
     if (tag->m_exifInfo.GpsInfoPresent)
     {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
When a pictures folder contains HEIC images (from iPhone, etc.), they don't sort correctly when sorting is set to Date Taken. HEIC files are decoded via imagedecoder.heif addon. The `CImageDecoder::LoadInfoTag` is not filling `CPictureInfoTag::m_dateTimeTaken` and hence sort doesn't work. Additionally the `time_created` was in UTC and hence not showing correct time in the Info panel.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fixes Date Taken sorting of Pictures when folder contains heic files.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Env: Win11 with VS2022
Created a folder with a mix of jpg (from android phone) and heic (from iPhone) files. Checked the behaviour of the sort before and after fix. See screenshots.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
[Pictures addons] support Date Taken sort for pics decoded via addons

## Screenshots (if appropriate):
Before:
![Omega beta 2](https://github.com/xbmc/xbmc/assets/3681180/dc1d52b4-d818-494e-bfdb-924d9f54b0ec)

After fix:
![with fix](https://github.com/xbmc/xbmc/assets/3681180/c2e6755c-6141-4a14-aece-8861af3ab137)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
