### PR TITLE
[cmake] FindTagLib Add version test for internal build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,7 +219,7 @@ set(required_deps ASS>=0.15.0
                   RapidJSON>=1.0.2
                   Spdlog
                   Sqlite3
-                  TagLib
+                  TagLib>=1.9.0
                   TinyXML
                   TinyXML2
                   ZLIB

--- a/cmake/modules/FindTagLib.cmake
+++ b/cmake/modules/FindTagLib.cmake
@@ -21,12 +21,6 @@ macro(buildTagLib)
   find_package(ZLIB REQUIRED)
   unset(FPHSA_NAME_MISMATCHED)
 
-  include(cmake/scripts/common/ModuleHelpers.cmake)
-
-  set(MODULE_LC taglib)
-
-  SETUP_BUILD_VARS()
-
   set(TAGLIB_VERSION ${${MODULE}_VER})
 
   if(WIN32 OR WINDOWS_STORE)
@@ -55,12 +49,39 @@ macro(buildTagLib)
 endmacro()
 
 if(NOT TARGET TagLib::TagLib)
-  if(ENABLE_INTERNAL_TAGLIB)
+
+  include(cmake/scripts/common/ModuleHelpers.cmake)
+
+  set(MODULE_LC taglib)
+
+  SETUP_BUILD_VARS()
+
+  # Taglib installs a shell script for all platforms. This can provide version universally
+  find_program(TAGLIB-CONFIG NAMES taglib-config taglib-config.command
+                             HINTS ${DEPENDSPATH}/bin)
+
+  if(TAGLIB-CONFIG)
+    execute_process(COMMAND "${TAGLIB-CONFIG}" --version
+                    OUTPUT_VARIABLE TAGLIBCONFIG_VER
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  endif()
+
+  if((TAGLIBCONFIG_VER VERSION_LESS ${${MODULE}_VER} AND ENABLE_INTERNAL_TAGLIB) OR
+     ((CORE_SYSTEM_NAME STREQUAL linux OR CORE_SYSTEM_NAME STREQUAL freebsd) AND ENABLE_INTERNAL_TAGLIB))
+    # Build Taglib
     buildTagLib()
   else()
-
     if(PKG_CONFIG_FOUND)
-      pkg_check_modules(PC_TAGLIB taglib>=1.9.0 QUIET)
+      if(TagLib_FIND_VERSION)
+        if(TagLib_FIND_VERSION_EXACT)
+          set(TagLib_FIND_SPEC "=${TagLib_FIND_VERSION_COMPLETE}")
+        else()
+          set(TagLib_FIND_SPEC ">=${TagLib_FIND_VERSION_COMPLETE}")
+        endif()
+      endif()
+      pkg_check_modules(PC_TAGLIB taglib${TagLib_FIND_SPEC} QUIET)
+
+      set(TAGLIB_LINK_LIBS ${PC_TAGLIB_LIBRARIES})
     endif()
 
     find_path(TAGLIB_INCLUDE_DIR NAMES taglib/tag.h
@@ -75,9 +96,12 @@ if(NOT TARGET TagLib::TagLib)
                                       HINTS ${DEPENDS_PATH}/lib ${PC_TAGLIB_LIBDIR}
                                       ${${CORE_PLATFORM_NAME_LC}_SEARCH_CONFIG}
                                       NO_CACHE)
-    set(TAGLIB_VERSION ${PC_TAGLIB_VERSION})
 
-    set(TAGLIB_LINK_LIBS ${PC_TAGLIB_LIBRARIES})
+    if(TAGLIBCONFIG_VER)
+      set(TAGLIB_VERSION ${TAGLIBCONFIG_VER})
+    else()
+      set(TAGLIB_VERSION ${PC_TAGLIB_VERSION})
+    endif()
   endif()
 
   include(SelectLibraryConfigurations)
@@ -131,13 +155,10 @@ if(NOT TARGET TagLib::TagLib)
       add_dependencies(build_internal_depends taglib)
     endif()
 
-
     set_property(GLOBAL APPEND PROPERTY INTERNAL_DEPS_PROP TagLib::TagLib)
   else()
     if(TagLib_FIND_REQUIRED)
       message(FATAL_ERROR "TagLib not found.")
     endif()
   endif()
-  mark_as_advanced(TAGLIB_INCLUDE_DIR TAGLIB_LIBRARY)
 endif()
-


### PR DESCRIPTION
## Description
This allows platforms to use the supplied taglib-config script to do version checking to reduce rebuilding when an adequate version lib exists. Some other minor cleanups to remove find spec from Find module and put into root CMakeLists.txt

## Motivation and context
Reduce rebuilding lib on windows platforms primarily, however this helps any platform using ENABLE_INTERNAL_TAGLIB

## How has this been tested?
Android aarch64 build

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
