### PR TITLE
[guilib][GUITextBox] Use vecText to determine text width

### DIFF
--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -252,7 +252,7 @@ void CGUITextBox::Render()
         {
           // We need to adjust the posX in similar way the CGUILabel recalculate the render rect
           // see CGUILabel::UpdateRenderRect()
-          linePosX -= GetTextWidth(lineString.GetAsWstring());
+          linePosX -= GetTextWidth(lineString.m_text);
         }
 
         m_font->DrawText(linePosX, posY, m_colors, m_label.shadowColor, lineString.m_text, align,

--- a/xbmc/guilib/GUITextLayout.cpp
+++ b/xbmc/guilib/GUITextLayout.cpp
@@ -29,18 +29,6 @@ std::string CGUIString::GetAsString() const
   return text;
 }
 
-std::wstring CGUIString::GetAsWstring() const
-{
-  std::wstring text;
-  text.reserve(m_text.size());
-  // Get text without style
-  for (const auto& it : m_text)
-  {
-    text += static_cast<wchar_t>(it & 0xffff);
-  }
-  return text;
-}
-
 CGUITextLayout::CGUITextLayout(CGUIFont *font, bool wrap, float fHeight, CGUIFont *borderFont)
 {
   m_varFont = m_font = font;
@@ -694,6 +682,11 @@ float CGUITextLayout::GetTextWidth(const std::wstring &text) const
   vecText utf32;
   AppendToUTF32(text, (m_font->GetStyle() & FONT_STYLE_MASK) << 24, utf32);
   return m_font->GetTextWidth(utf32);
+}
+
+float CGUITextLayout::GetTextWidth(const vecText& text) const
+{
+  return m_font->GetTextWidth(text);
 }
 
 std::string CGUITextLayout::GetText() const

--- a/xbmc/guilib/GUITextLayout.h
+++ b/xbmc/guilib/GUITextLayout.h
@@ -44,7 +44,6 @@ public:
   CGUIString(iString start, iString end, bool carriageReturn);
 
   std::string GetAsString() const;
-  std::wstring GetAsWstring() const;
 
   // The text is UTF-16 and the data stored in a character_t hold multiple informations by bits:
   // <16 bits: are unicode code bits
@@ -99,7 +98,9 @@ public:
   float GetTextWidth() const { return m_textWidth; }
 
   float GetTextWidth(const std::wstring &text) const;
-  
+
+  float GetTextWidth(const vecText& text) const;
+
   /*! \brief Returns the precalculated height of the text to be rendered (in constant time).
    \return height of text
   */


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
GetAsWstring has been introduced from PR #22691 but has the side effect to discard the font styles
so pre-calculate text width by using vecText directly
so that when there is right aligned text will be placed in the right position when have font styles like bold

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #24276
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):
Look text right aligned below

BEFORE
![immagine](https://github.com/xbmc/xbmc/assets/3257156/e9b661de-3603-4e5e-8508-ca3938514a07)
AFTER
![immagine](https://github.com/xbmc/xbmc/assets/3257156/479e29fb-aad8-4443-be73-3110f3fc7a39)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
