### PR TITLE
[video] Versions/Extras Manage Dialogs: Selection improvements

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoManager.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -70,18 +70,8 @@ bool CGUIDialogVideoManager::OnMessage(CGUIMessage& message)
         const int action{message.GetParam1()};
         if (action == ACTION_SELECT_ITEM || action == ACTION_MOUSE_LEFT_CLICK)
         {
-          CGUIMessage msg{GUI_MSG_ITEM_SELECTED, GetID(), control};
-          OnMessage(msg);
-
-          const int item{msg.GetParam1()};
-          if (item < 0 || item >= m_videoAssetsList->Size())
-            break;
-
-          m_selectedVideoAsset = m_videoAssetsList->Get(item);
-
-          UpdateButtons();
-
-          SET_CONTROL_FOCUS(CONTROL_BUTTON_PLAY, 0);
+          if (UpdateSelectedAsset())
+            SET_CONTROL_FOCUS(CONTROL_BUTTON_PLAY, 0);
         }
       }
       else if (control == CONTROL_BUTTON_PLAY)
@@ -105,6 +95,22 @@ bool CGUIDialogVideoManager::OnMessage(CGUIMessage& message)
   }
 
   return CGUIDialog::OnMessage(message);
+}
+
+bool CGUIDialogVideoManager::OnAction(const CAction& action)
+{
+  const int actionId{action.GetID()};
+  if (actionId == ACTION_MOVE_DOWN || actionId == ACTION_MOVE_UP || actionId == ACTION_PAGE_DOWN ||
+      actionId == ACTION_PAGE_UP || actionId == ACTION_FIRST_PAGE || actionId == ACTION_LAST_PAGE)
+  {
+    if (GetFocusedControlID() == CONTROL_LIST_ASSETS)
+    {
+      CGUIDialog::OnAction(action);
+      return UpdateSelectedAsset();
+    }
+  }
+
+  return CGUIDialog::OnAction(action);
 }
 
 void CGUIDialogVideoManager::OnInitWindow()
@@ -160,6 +166,22 @@ void CGUIDialogVideoManager::UpdateAssetsList()
       break;
     }
   }
+}
+
+bool CGUIDialogVideoManager::UpdateSelectedAsset()
+{
+  CGUIMessage msg{GUI_MSG_ITEM_SELECTED, GetID(), CONTROL_LIST_ASSETS};
+  OnMessage(msg);
+
+  const int item{msg.GetParam1()};
+  if (item >= 0 && item < m_videoAssetsList->Size())
+  {
+    m_selectedVideoAsset = m_videoAssetsList->Get(item);
+    UpdateButtons();
+    UpdateAssetsList();
+    return true;
+  }
+  return false;
 }
 
 void CGUIDialogVideoManager::DisableRemove()

--- a/xbmc/video/dialogs/GUIDialogVideoManager.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -124,8 +124,7 @@ void CGUIDialogVideoManager::OnInitWindow()
   CGUIMessage msg{GUI_MSG_LABEL_BIND, GetID(), CONTROL_LIST_ASSETS, 0, 0, m_videoAssetsList.get()};
   OnMessage(msg);
 
-  UpdateButtons();
-  UpdateAssetsList();
+  UpdateControls();
 }
 
 void CGUIDialogVideoManager::Clear()
@@ -177,8 +176,7 @@ bool CGUIDialogVideoManager::UpdateSelectedAsset()
   if (item >= 0 && item < m_videoAssetsList->Size())
   {
     m_selectedVideoAsset = m_videoAssetsList->Get(item);
-    UpdateButtons();
-    UpdateAssetsList();
+    UpdateControls();
     return true;
   }
   return false;
@@ -192,6 +190,12 @@ void CGUIDialogVideoManager::DisableRemove()
 void CGUIDialogVideoManager::EnableRemove()
 {
   CONTROL_ENABLE(CONTROL_BUTTON_REMOVE);
+}
+
+void CGUIDialogVideoManager::UpdateControls()
+{
+  UpdateButtons();
+  UpdateAssetsList();
 }
 
 void CGUIDialogVideoManager::Refresh()
@@ -301,8 +305,7 @@ void CGUIDialogVideoManager::Remove()
 
   // refresh data and controls
   Refresh();
-
-  UpdateButtons();
+  UpdateControls();
 }
 
 void CGUIDialogVideoManager::Rename()
@@ -316,6 +319,7 @@ void CGUIDialogVideoManager::Rename()
 
   // refresh data and controls
   Refresh();
+  UpdateControls();
 }
 
 void CGUIDialogVideoManager::ChooseArt()
@@ -331,8 +335,7 @@ void CGUIDialogVideoManager::SetSelectedVideoAsset(const std::shared_ptr<CFileIt
 {
   m_selectedVideoAsset = asset;
 
-  UpdateButtons();
-  UpdateAssetsList();
+  UpdateControls();
 }
 
 int CGUIDialogVideoManager::SelectVideoAsset(const std::shared_ptr<CFileItem>& item)

--- a/xbmc/video/dialogs/GUIDialogVideoManager.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -109,6 +109,8 @@ bool CGUIDialogVideoManager::OnMessage(CGUIMessage& message)
 
 void CGUIDialogVideoManager::OnInitWindow()
 {
+  CGUIDialog::OnInitWindow();
+
   SET_CONTROL_LABEL(CONTROL_LABEL_TITLE,
                     StringUtils::Format(g_localizeStrings.Get(GetHeadingId()),
                                         m_videoAsset->GetVideoInfoTag()->GetTitle()));
@@ -117,8 +119,7 @@ void CGUIDialogVideoManager::OnInitWindow()
   OnMessage(msg);
 
   UpdateButtons();
-
-  CGUIDialog::OnInitWindow();
+  UpdateAssetsList();
 }
 
 void CGUIDialogVideoManager::Clear()
@@ -144,6 +145,20 @@ void CGUIDialogVideoManager::UpdateButtons()
     CONTROL_DISABLE(CONTROL_BUTTON_RENAME);
     CONTROL_DISABLE(CONTROL_BUTTON_REMOVE);
     CONTROL_DISABLE(CONTROL_BUTTON_PLAY);
+  }
+}
+
+void CGUIDialogVideoManager::UpdateAssetsList()
+{
+  // find new item in list and select it
+  for (int i = 0; i < m_videoAssetsList->Size(); ++i)
+  {
+    if (m_videoAssetsList->Get(i)->GetVideoInfoTag()->m_iDbId ==
+        m_selectedVideoAsset->GetVideoInfoTag()->m_iDbId)
+    {
+      CONTROL_SELECT_ITEM(CONTROL_LIST_ASSETS, i);
+      break;
+    }
   }
 }
 
@@ -293,6 +308,9 @@ void CGUIDialogVideoManager::ChooseArt()
 void CGUIDialogVideoManager::SetSelectedVideoAsset(const std::shared_ptr<CFileItem>& asset)
 {
   m_selectedVideoAsset = asset;
+
+  UpdateButtons();
+  UpdateAssetsList();
 }
 
 int CGUIDialogVideoManager::SelectVideoAsset(const std::shared_ptr<CFileItem>& item)

--- a/xbmc/video/dialogs/GUIDialogVideoManager.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.h
@@ -48,6 +48,8 @@ protected:
   void DisableRemove();
   void EnableRemove();
 
+  void UpdateControls();
+
   static int SelectVideoAsset(const std::shared_ptr<CFileItem>& item);
 
   CVideoDatabase m_database;

--- a/xbmc/video/dialogs/GUIDialogVideoManager.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.h
@@ -37,6 +37,7 @@ protected:
   virtual void Clear();
   virtual void Refresh();
   virtual void UpdateButtons();
+  virtual void UpdateAssetsList();
 
   virtual void Play();
   virtual void Remove();

--- a/xbmc/video/dialogs/GUIDialogVideoManager.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.h
@@ -30,6 +30,7 @@ public:
 protected:
   void OnInitWindow() override;
   bool OnMessage(CGUIMessage& message) override;
+  bool OnAction(const CAction& action) override;
 
   virtual VideoAssetType GetVideoAssetType() = 0;
   virtual int GetHeadingId() = 0;
@@ -58,4 +59,5 @@ private:
   CGUIDialogVideoManager() = delete;
 
   void CloseAll();
+  bool UpdateSelectedAsset();
 };

--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
@@ -76,6 +76,14 @@ void CGUIDialogVideoManagerExtras::UpdateButtons()
   }
 }
 
+void CGUIDialogVideoManagerExtras::SetVideoAsset(const std::shared_ptr<CFileItem>& item)
+{
+  CGUIDialogVideoManager::SetVideoAsset(item);
+
+  if (!m_videoAssetsList->IsEmpty())
+    SetSelectedVideoAsset(m_videoAssetsList->Get(0));
+}
+
 void CGUIDialogVideoManagerExtras::AddVideoExtra()
 {
   const MediaType mediaType{m_videoAsset->GetVideoInfoTag()->m_type};

--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
@@ -166,6 +166,7 @@ void CGUIDialogVideoManagerExtras::AddVideoExtra()
 
     // refresh data and controls
     Refresh();
+    UpdateButtons();
   }
 }
 

--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
@@ -166,7 +166,7 @@ void CGUIDialogVideoManagerExtras::AddVideoExtra()
 
     // refresh data and controls
     Refresh();
-    UpdateButtons();
+    UpdateControls();
   }
 }
 

--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.h
@@ -23,6 +23,8 @@ public:
   CGUIDialogVideoManagerExtras();
   ~CGUIDialogVideoManagerExtras() override = default;
 
+  void SetVideoAsset(const std::shared_ptr<CFileItem>& item) override;
+
   static void ManageVideoExtra(const std::shared_ptr<CFileItem>& item);
   static std::string GenerateVideoExtra(const std::string& extrasRoot,
                                         const std::string& extrasPath);

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -98,6 +98,16 @@ void CGUIDialogVideoManagerVersions::UpdateButtons()
   }
 }
 
+void CGUIDialogVideoManagerVersions::UpdateDefaultVideoVersionSelection()
+{
+  // find new item in list and select it
+  const int defaultDbId{m_defaultVideoVersion->GetVideoInfoTag()->m_iDbId};
+  for (const auto& item : *m_videoAssetsList)
+  {
+    item->Select(item->GetVideoInfoTag()->m_iDbId == defaultDbId);
+  }
+}
+
 void CGUIDialogVideoManagerVersions::Refresh()
 {
   CGUIDialogVideoManager::Refresh();
@@ -106,6 +116,8 @@ void CGUIDialogVideoManagerVersions::Refresh()
   const int dbId{m_videoAsset->GetVideoInfoTag()->m_iDbId};
   const VideoDbContentType itemType{m_videoAsset->GetVideoContentType()};
   m_database.GetDefaultVideoVersion(itemType, dbId, *m_defaultVideoVersion);
+
+  UpdateDefaultVideoVersionSelection();
 }
 
 void CGUIDialogVideoManagerVersions::SetVideoAsset(const std::shared_ptr<CFileItem>& item)
@@ -146,6 +158,8 @@ void CGUIDialogVideoManagerVersions::SetDefault()
   m_database.GetDefaultVideoVersion(itemType, dbId, *m_defaultVideoVersion);
 
   UpdateButtons();
+
+  UpdateDefaultVideoVersionSelection();
 }
 
 void CGUIDialogVideoManagerVersions::SetDefaultVideoVersion(const CFileItem& version)

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -157,8 +157,7 @@ void CGUIDialogVideoManagerVersions::SetDefault()
   // update our default video version
   m_database.GetDefaultVideoVersion(itemType, dbId, *m_defaultVideoVersion);
 
-  UpdateButtons();
-
+  UpdateControls();
   UpdateDefaultVideoVersionSelection();
 }
 
@@ -284,7 +283,7 @@ void CGUIDialogVideoManagerVersions::AddVideoVersion()
 
     // refresh data and controls
     Refresh();
-    UpdateButtons();
+    UpdateControls();
   }
 }
 

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -284,6 +284,7 @@ void CGUIDialogVideoManagerVersions::AddVideoVersion()
 
     // refresh data and controls
     Refresh();
+    UpdateButtons();
   }
 }
 

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -112,7 +112,7 @@ void CGUIDialogVideoManagerVersions::SetVideoAsset(const std::shared_ptr<CFileIt
 {
   CGUIDialogVideoManager::SetVideoAsset(item);
 
-  m_selectedVideoAsset = m_defaultVideoVersion;
+  SetSelectedVideoAsset(m_defaultVideoVersion);
 }
 
 void CGUIDialogVideoManagerVersions::Remove()

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
@@ -47,6 +47,7 @@ private:
   void SetDefaultVideoVersion(const CFileItem& version);
   void AddVideoVersion();
   void SetDefault();
+  void UpdateDefaultVideoVersionSelection();
 
   std::shared_ptr<CFileItem> m_defaultVideoVersion;
 };


### PR DESCRIPTION
Couple of fixes and improvements for the Video versions/extras manage dialogs:

1. Fix initial selection to be set to default video version / first extra
2. Update button state after "Rename"
3. Highlight default video version in list of available versions.
![screenshot00005](https://github.com/xbmc/xbmc/assets/3226626/1f86e17c-48d7-4ba8-8bcc-e6d82a3784c4)

5. Update buttons whenever the selection in list changes (e.g. up/down key pressed); no longer need to click to update the buttons.

Runtime-tested on macOS, latest Kodi master.

@enen92 this time not that much code to review. Thanks for all your support. ;-)

@HitcherUK @jjd-uk @CrystalP everyone, fyi. Runtime-test feedback appreciated.