### PR TITLE
[Estuary] Better visual indicator of focused item

### DIFF
--- a/addons/skin.estuary/xml/DialogMediaSource.xml
+++ b/addons/skin.estuary/xml/DialogMediaSource.xml
@@ -60,16 +60,8 @@
 					<top>0</top>
 					<bottom>0</bottom>
 					<right>0</right>
-					<visible>Control.HasFocus(10)</visible>
 					<texture colordiffuse="button_focus">lists/focus.png</texture>
-				</control>
-				<control type="image">
-					<left>0</left>
-					<top>0</top>
-					<bottom>0</bottom>
-					<right>0</right>
-					<visible>!Control.HasFocus(10)</visible>
-					<texture colordiffuse="button_alt_focus">lists/focus.png</texture>
+					<animation effect="fade" start="100" end="50" time="0">UnFocus</animation>
 				</control>
 				<control type="label">
 					<left>10</left>

--- a/addons/skin.estuary/xml/DialogMediaSource.xml
+++ b/addons/skin.estuary/xml/DialogMediaSource.xml
@@ -63,6 +63,14 @@
 					<visible>Control.HasFocus(10)</visible>
 					<texture colordiffuse="button_focus">lists/focus.png</texture>
 				</control>
+				<control type="image">
+					<left>0</left>
+					<top>0</top>
+					<bottom>0</bottom>
+					<right>0</right>
+					<visible>!Control.HasFocus(10)</visible>
+					<texture colordiffuse="button_alt_focus">lists/focus.png</texture>
+				</control>
 				<control type="label">
 					<left>10</left>
 					<top>0</top>

--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -265,15 +265,7 @@
 					<right>0</right>
 					<bottom>0</bottom>
 					<texture colordiffuse="button_focus">lists/focus.png</texture>
-					<visible>Control.HasFocus($PARAM[list_id])</visible>
-				</control>
-				<control type="image">
-					<left>0</left>
-					<top>0</top>
-					<right>0</right>
-					<bottom>0</bottom>
-					<texture colordiffuse="button_alt_focus">lists/focus.png</texture>
-					<visible>!Control.HasFocus($PARAM[list_id])</visible>
+					<animation effect="fade" start="100" end="50" time="0">UnFocus</animation>
 				</control>
 				<control type="group">
 					<visible>ListItem.Property(PVR.IsRecordingTimer) | ListItem.Property(PVR.IsRemindingTimer)</visible>

--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -267,6 +267,14 @@
 					<texture colordiffuse="button_focus">lists/focus.png</texture>
 					<visible>Control.HasFocus($PARAM[list_id])</visible>
 				</control>
+				<control type="image">
+					<left>0</left>
+					<top>0</top>
+					<right>0</right>
+					<bottom>0</bottom>
+					<texture colordiffuse="button_alt_focus">lists/focus.png</texture>
+					<visible>!Control.HasFocus($PARAM[list_id])</visible>
+				</control>
 				<control type="group">
 					<visible>ListItem.Property(PVR.IsRecordingTimer) | ListItem.Property(PVR.IsRemindingTimer)</visible>
 					<control type="image">

--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -102,15 +102,7 @@
 						<right>0</right>
 						<bottom>0</bottom>
 						<texture colordiffuse="button_focus">lists/focus.png</texture>
-						<visible>Control.HasFocus(6)</visible>
-					</control>
-					<control type="image">
-						<left>0</left>
-						<top>0</top>
-						<right>0</right>
-						<bottom>0</bottom>
-						<texture colordiffuse="button_alt_focus">lists/focus.png</texture>
-						<visible>!Control.HasFocus(3) + !Control.HasFocus(6)</visible>
+						<animation effect="fade" start="100" end="50" time="0">UnFocus</animation>
 					</control>
 					<control type="image">
 						<left>12</left>

--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -105,6 +105,14 @@
 						<visible>Control.HasFocus(6)</visible>
 					</control>
 					<control type="image">
+						<left>0</left>
+						<top>0</top>
+						<right>0</right>
+						<bottom>0</bottom>
+						<texture colordiffuse="button_alt_focus">lists/focus.png</texture>
+						<visible>!Control.HasFocus(3) + !Control.HasFocus(6)</visible>
+					</control>
+					<control type="image">
 						<left>12</left>
 						<top>7</top>
 						<width>110</width>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This adds a texture to the focused item in dialog lists when the list isn't focused. It's set at 50% alpha of the focused texture which is consistent with other places in Estuary where a non-focused item is faded 50% (eg addon settings).

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While updating video versions it's become apparent that we need a better visual indication of which item is currently focused when navigating away from the list.  

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally on various dialogs.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Better visual indication.

## Screenshots (if appropriate):

## Video versions manage dialog before PR:

![screenshot00002](https://github.com/xbmc/xbmc/assets/133808/6cabd6ce-94f1-4ed9-98c8-fbddf104a55c)

![screenshot00003](https://github.com/xbmc/xbmc/assets/133808/13cc9fa4-e962-487e-969d-45382fc1577e)

![screenshot00004](https://github.com/xbmc/xbmc/assets/133808/e3007080-ed02-4809-a55e-aefb81df1341)

![screenshot00005](https://github.com/xbmc/xbmc/assets/133808/591a2ff5-e6bd-4257-a00f-5638ae8cae27)

Note: It's not obvious which list item is the focus of the button controls.

## Video versions manage dialog after PR:

![screenshot00008](https://github.com/xbmc/xbmc/assets/133808/6a7f1310-abdb-4d8a-be3b-96cf7ff83956)

![screenshot00009](https://github.com/xbmc/xbmc/assets/133808/784654e9-56c0-4b86-92ca-83683f00ca71)

Note: Clear indication of the affected list item.

## Other areas of Estuary that use the same style of indication:

![screenshot00006](https://github.com/xbmc/xbmc/assets/133808/aaf0ea23-58c5-43af-b9d1-31dbe1e1ae61)

![screenshot00007](https://github.com/xbmc/xbmc/assets/133808/8031443d-17ac-4f13-ba69-2016d70ddb05)

## Media source dialog before PR:

![screenshot00010](https://github.com/xbmc/xbmc/assets/133808/6b367a8c-503b-40f7-8c44-0a36ad13ff12)

## Media source dialog after PR:

![screenshot00011](https://github.com/xbmc/xbmc/assets/133808/74cb5862-d3ba-443c-9aaa-ab9d2035546a)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
