### PR TITLE
Update some video versions messages

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23754,7 +23754,7 @@ msgstr ""
 #. Manage video version dialog title
 #: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
 msgctxt "#40002"
-msgid "Convert into an additional version of {0:s}"
+msgid "Convert into an additional version"
 msgstr ""
 
 #empty string with id 40003
@@ -23777,7 +23777,7 @@ msgstr ""
 #. Warning dialog text
 #: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
 msgctxt "#40006"
-msgid "The selected {0:s} contains multiple versions. Cannot convert into an additional version of another one. Remove it from the library, rescan, and convert each version separately."
+msgid "The selected movie has multiple versions, preventing its conversion into a version of another movie. Remove the versions from the movie, rescan the libray and convert them individually."
 msgstr ""
 
 #. Warning dialog text
@@ -23789,13 +23789,13 @@ msgstr ""
 #. Different video version found dialog title
 #: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
 msgctxt "#40008"
-msgid "Different {0:s} version found"
+msgid "Different movie version found"
 msgstr ""
 
 #. Different video version found dialog text
 #: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
 msgctxt "#40009"
-msgid "Found a different version of {0:s} \"{1:s}\" ({2:s}). Would you like to convert it into an additional version of the original?"
+msgid "Found a different version of the movie \"{0:s}\": {1:s}. Would you like to convert it into an additional version of the original?"
 msgstr ""
 
 #. "video version" string in singular format
@@ -23836,18 +23836,16 @@ msgctxt "#40015"
 msgid "Add extra"
 msgstr ""
 
-#. Add video version dialog text. Example: The selected video is already added to this movie as "Director's Cut"
-#: xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+#. Add video version dialog text.
 #: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
 msgctxt "#40016"
-msgid "The selected video is already added to this {0:s} as \"{1:s}\"."
+msgid "The selected video already is the \"{0:s}\" version of the movie."
 msgstr ""
 
-#. Add video version dialog text. Example: The selected video is already added to movie "Fancy movie title" as "Director's Cut". Would you like to remove it and add it to this movie?"
-#: xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+#. Add video version dialog text. Example: The selected video is the "Extended Edition" version of the movie "Movie title". Would you like to move the version to this movie?"
 #: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
 msgctxt "#40017"
-msgid "The selected video is already added to {0:s} \"{1:s}\" as \"{2:s}\". Would you like to remove it and add it to this {3:s}?"
+msgid "The selected video is the \"{0:s}\" version of the movie \"{1:s}\". Would you like to move the version to this movie?"
 msgstr ""
 
 #. Remove video version dialog title
@@ -23860,7 +23858,7 @@ msgstr ""
 #. Add new video version dialog text
 #: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
 msgctxt "#40019"
-msgid "Unable to remove default version \"{0:s}\" from {1:s} \"{2:s}\". Change the default version and try again."
+msgid "The default version of a movie cannot be removed. Set a different default version and try again."
 msgstr ""
 
 #. Remove video version dialog text
@@ -23884,7 +23882,7 @@ msgstr ""
 #. Button label to make a video version the default version
 #: addons/skin.estuary/xml/DialogVideoVersion.xml
 msgctxt "#40023"
-msgid "Set default"
+msgid "Set as default"
 msgstr ""
 
 #. Choose/Manage video version dialog title
@@ -23901,7 +23899,19 @@ msgctxt "#40025"
 msgid "Extras: {0:s}"
 msgstr ""
 
-#empty strings with id 40026 to 40199
+#. Add extra dialog text.
+#: xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+msgctxt "#40026"
+msgid "The selected video already is the \"{0:s}\" extra of the movie."
+msgstr ""
+
+#. Add video extra dialog text. Example: The selected video is the "Behind the scenes" extra of the movie "Movie title". Would you like to move the extra to this movie?"
+#: xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+msgctxt "#40027"
+msgid "The selected video is the \"{0:s}\" extra of the movie \"{1:s}\". Would you like to move the extra to this movie?"
+msgstr ""
+
+#empty strings with id 40028 to 40199
 
 #. Select default video version setting
 #: system/settings/settings.xml

--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
@@ -120,10 +120,9 @@ void CGUIDialogVideoManagerExtras::AddVideoExtra()
                       [idFile](const std::shared_ptr<CFileItem>& version)
                       { return version->GetVideoInfoTag()->m_iDbId == idFile; }))
       {
-        CGUIDialogOK::ShowAndGetInput(g_localizeStrings.Get(40015),
-                                      StringUtils::Format(g_localizeStrings.Get(40016),
-                                                          CMediaTypes::GetLocalization(mediaType),
-                                                          typeVideoVersion));
+        CGUIDialogOK::ShowAndGetInput(
+            g_localizeStrings.Get(40015),
+            StringUtils::Format(g_localizeStrings.Get(40026), typeVideoVersion));
         return;
       }
 
@@ -135,10 +134,8 @@ void CGUIDialogVideoManagerExtras::AddVideoExtra()
         return;
 
       if (!CGUIDialogYesNo::ShowAndGetInput(
-              g_localizeStrings.Get(40015),
-              StringUtils::Format(g_localizeStrings.Get(40017),
-                                  CMediaTypes::GetLocalization(mediaType), videoTitle,
-                                  typeVideoVersion, CMediaTypes::GetLocalization(mediaType))))
+              g_localizeStrings.Get(40014),
+              StringUtils::Format(g_localizeStrings.Get(40027), typeVideoVersion, videoTitle)))
       {
         return;
       }

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -134,12 +134,8 @@ void CGUIDialogVideoManagerVersions::Remove()
   // default video version is not allowed
   if (m_database.IsDefaultVideoVersion(m_selectedVideoAsset->GetVideoInfoTag()->m_iDbId))
   {
-    CGUIDialogOK::ShowAndGetInput(
-        CVariant(40018),
-        StringUtils::Format(g_localizeStrings.Get(40019),
-                            m_selectedVideoAsset->GetVideoInfoTag()->GetAssetInfo().GetTitle(),
-                            CMediaTypes::GetLocalization(mediaType),
-                            m_videoAsset->GetVideoInfoTag()->GetTitle()));
+    CGUIDialogOK::ShowAndGetInput(CVariant(40018),
+                                  StringUtils::Format(g_localizeStrings.Get(40019)));
     return;
   }
 
@@ -217,10 +213,9 @@ void CGUIDialogVideoManagerVersions::AddVideoVersion()
                       [idFile](const std::shared_ptr<CFileItem>& version)
                       { return version->GetVideoInfoTag()->m_iDbId == idFile; }))
       {
-        CGUIDialogOK::ShowAndGetInput(g_localizeStrings.Get(40014),
-                                      StringUtils::Format(g_localizeStrings.Get(40016),
-                                                          CMediaTypes::GetLocalization(mediaType),
-                                                          typeVideoVersion));
+        CGUIDialogOK::ShowAndGetInput(
+            g_localizeStrings.Get(40014),
+            StringUtils::Format(g_localizeStrings.Get(40016), typeVideoVersion));
         return;
       }
 
@@ -233,9 +228,7 @@ void CGUIDialogVideoManagerVersions::AddVideoVersion()
 
       if (!CGUIDialogYesNo::ShowAndGetInput(
               g_localizeStrings.Get(40014),
-              StringUtils::Format(g_localizeStrings.Get(40017),
-                                  CMediaTypes::GetLocalization(mediaType), videoTitle,
-                                  typeVideoVersion, CMediaTypes::GetLocalization(mediaType))))
+              StringUtils::Format(g_localizeStrings.Get(40017), typeVideoVersion, videoTitle)))
       {
         return;
       }
@@ -247,10 +240,8 @@ void CGUIDialogVideoManagerVersions::AddVideoVersion()
 
         if (list.Size() > 1)
         {
-          CGUIDialogOK::ShowAndGetInput(
-              g_localizeStrings.Get(40014),
-              StringUtils::Format(g_localizeStrings.Get(40019), typeVideoVersion,
-                                  CMediaTypes::GetLocalization(mediaType), videoTitle));
+          CGUIDialogOK::ShowAndGetInput(g_localizeStrings.Get(40014),
+                                        StringUtils::Format(g_localizeStrings.Get(40019)));
           return;
         }
         else
@@ -399,9 +390,8 @@ bool CGUIDialogVideoManagerVersions::ConvertVideoVersion(const std::shared_ptr<C
   // invalid operation warning
   if (item->GetVideoInfoTag()->HasVideoVersions())
   {
-    CGUIDialogOK::ShowAndGetInput(
-        CVariant{40005},
-        StringUtils::Format(g_localizeStrings.Get(40006), CMediaTypes::GetLocalization(mediaType)));
+    CGUIDialogOK::ShowAndGetInput(CVariant{40005},
+                                  StringUtils::Format(g_localizeStrings.Get(40006)));
     return false;
   }
 
@@ -461,8 +451,7 @@ bool CGUIDialogVideoManagerVersions::ConvertVideoVersion(const std::shared_ptr<C
 
   dialog->Reset();
   dialog->SetItems(list);
-  dialog->SetHeading(
-      StringUtils::Format(g_localizeStrings.Get(40002), CMediaTypes::GetLocalization(mediaType)));
+  dialog->SetHeading(StringUtils::Format(g_localizeStrings.Get(40002)));
   dialog->SetUseDetails(true);
   dialog->Open();
 
@@ -508,11 +497,10 @@ bool CGUIDialogVideoManagerVersions::ProcessVideoVersion(VideoDbContentType item
   std::string path;
   videodb.GetFilePathById(dbId, path, itemType);
 
-  if (!CGUIDialogYesNo::ShowAndGetInput(
-          StringUtils::Format(g_localizeStrings.Get(40008),
-                              CMediaTypes::GetLocalization(mediaType)),
-          StringUtils::Format(g_localizeStrings.Get(40009), CMediaTypes::GetLocalization(mediaType),
-                              item.GetVideoInfoTag()->GetTitle(), path)))
+  if (!CGUIDialogYesNo::ShowAndGetInput(StringUtils::Format(g_localizeStrings.Get(40008)),
+                                        StringUtils::Format(g_localizeStrings.Get(40009),
+                                                            item.GetVideoInfoTag()->GetTitle(),
+                                                            path)))
   {
     return false;
   }
@@ -544,8 +532,7 @@ bool CGUIDialogVideoManagerVersions::ProcessVideoVersion(VideoDbContentType item
 
   dialog->Reset();
   dialog->SetItems(list);
-  dialog->SetHeading(
-      StringUtils::Format(g_localizeStrings.Get(40002), CMediaTypes::GetLocalization(mediaType)));
+  dialog->SetHeading(StringUtils::Format(g_localizeStrings.Get(40002)));
   dialog->SetUseDetails(true);
   dialog->Open();
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Follow up of the issue #24294, some changes were made in another PR already, this one changes the rest of the messages that used a variable for the word "movie" or "extras".

The only code changes are adaptations of the variables passed to `StringUtils::Format()`. No change in the logic, this is purely about the messages.

Also used the opportunity to touch up a few of the messages in English.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Feedback in the #translations-external Slack channel that some of the messages were difficult to translate because of a variable that stood for 'movie' or 'extra'. Going forward the variable could have taken other unpredictable values, with impact on translation.

Minor text adjustments in English.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran Kodi with the messages.
Some messages are for error conditions that rarely happen or cannot happen anymore due to changes of the dialog.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
``