### PR TITLE
[video] Fix playback of multi-version movies. Do not prompt for versi…

### DIFF
--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -234,10 +234,10 @@ bool CVideoChooseVersion::IsVisible(const CFileItem& item) const
 bool CVideoChooseVersion::Execute(const std::shared_ptr<CFileItem>& item) const
 {
   // force selection dialog, regardless of any settings like 'Select default video version'
-  item->SetProperty("force_choose_video_version", true);
+  item->SetProperty("needs_resolved_video_version", true);
   CVideoSelectActionProcessor proc{item};
   const bool ret = proc.ProcessDefaultAction();
-  item->ClearProperty("force_choose_video_version");
+  item->ClearProperty("needs_resolved_video_version");
   return ret;
 }
 
@@ -348,12 +348,12 @@ void SetPathAndPlay(const std::shared_ptr<CFileItem>& item, PlayMode mode)
     if (mode == PlayMode::PLAY_VERSION_USING)
     {
       // force video version selection dialog
-      item->SetProperty("force_choose_video_version", true);
+      item->SetProperty("needs_resolved_video_version", true);
     }
     else
     {
       // play the given/default video version, if multiple versions are available
-      item->SetProperty("prohibit_choose_video_version", true);
+      item->SetProperty("has_resolved_video_version", true);
     }
 
     const bool choosePlayer{mode == PlayMode::PLAY_USING || mode == PlayMode::PLAY_VERSION_USING};
@@ -364,8 +364,8 @@ void SetPathAndPlay(const std::shared_ptr<CFileItem>& item, PlayMode mode)
     else // all other modes are actually PLAY
       proc.ProcessAction(VIDEO::GUILIB::ACTION_PLAY_FROM_BEGINNING);
 
-    item->ClearProperty("force_choose_video_version");
-    item->ClearProperty("prohibit_choose_video_version");
+    item->ClearProperty("needs_resolved_video_version");
+    item->ClearProperty("has_resolved_video_version");
   }
 }
 } // unnamed namespace

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -793,6 +793,9 @@ void CGUIDialogVideoInfo::Play(bool resume)
   // close our dialog
   Close(true);
 
+  // play the current video version, even if multiple versions are available
+  m_movieItem->SetProperty("prohibit_choose_video_version", true);
+
   if (resume)
   {
     CVideoPlayActionProcessor proc{m_movieItem};
@@ -819,6 +822,8 @@ void CGUIDialogVideoInfo::Play(bool resume)
       }
     }
   }
+
+  m_movieItem->ClearProperty("prohibit_choose_video_version");
 }
 
 namespace

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -794,7 +794,7 @@ void CGUIDialogVideoInfo::Play(bool resume)
   Close(true);
 
   // play the current video version, even if multiple versions are available
-  m_movieItem->SetProperty("prohibit_choose_video_version", true);
+  m_movieItem->SetProperty("has_resolved_video_version", true);
 
   if (resume)
   {
@@ -823,7 +823,7 @@ void CGUIDialogVideoInfo::Play(bool resume)
     }
   }
 
-  m_movieItem->ClearProperty("prohibit_choose_video_version");
+  m_movieItem->ClearProperty("has_resolved_video_version");
 }
 
 namespace

--- a/xbmc/video/guilib/VideoVersionHelper.cpp
+++ b/xbmc/video/guilib/VideoVersionHelper.cpp
@@ -169,7 +169,7 @@ std::shared_ptr<CFileItem> CVideoVersionHelper::ChooseMovieFromVideoVersions(
   std::shared_ptr<const CFileItem> videoVersion;
   if (item->HasVideoVersions())
   {
-    if (!item->GetProperty("force_choose_video_version").asBoolean(false))
+    if (!item->GetProperty("needs_resolved_video_version").asBoolean(false))
     {
       // select the specified video version
       if (item->GetVideoInfoTag()->GetAssetInfo().GetId() > 0)
@@ -200,8 +200,8 @@ std::shared_ptr<CFileItem> CVideoVersionHelper::ChooseMovieFromVideoVersions(
       }
     }
 
-    if (!videoVersion && (item->GetProperty("force_choose_video_version").asBoolean(false) ||
-                          !item->GetProperty("prohibit_choose_video_version").asBoolean(false)))
+    if (!videoVersion && (item->GetProperty("needs_resolved_video_version").asBoolean(false) ||
+                          !item->GetProperty("has_resolved_video_version").asBoolean(false)))
     {
       CVideoChooser chooser{item};
       chooser.EnableExtras(false);


### PR DESCRIPTION
…on to play, as we already know it from the context of the info dialog.

Fixes #24322 

In the context of the info dialog, we always display information for a certain version. No need to ask which one to play.

@jurialmunkey fyi

Runtime-tested on macOS, latest Kodi master.

@enen92 should be simple to review. We have an item property to control whether version chooser will be used.