### PR TITLE
VideoInfoScanner: Support .nomedia files in TV show subdirectories

### DIFF
--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -305,11 +305,13 @@ bool CDirectory::GetDirectory(const CURL& url,
   return false;
 }
 
-bool CDirectory::EnumerateDirectory(const std::string& path,
-                                    const DirectoryEnumerationCallback& callback,
-                                    bool fileOnly /* = false */,
-                                    const std::string& mask /* = "" */,
-                                    int flags /* = DIR_FLAG_DEFAULTS */)
+bool CDirectory::EnumerateDirectory(
+    const std::string& path,
+    const DirectoryEnumerationCallback& callback,
+    const DirectoryFilter& filter /* = [](const std::shared_ptr<CFileItem>&) {return true;} */,
+    bool fileOnly /* = false */,
+    const std::string& mask /* = "" */,
+    int flags /* = DIR_FLAG_DEFAULTS */)
 {
   CFileItemList items;
 
@@ -327,12 +329,12 @@ bool CDirectory::EnumerateDirectory(const std::string& path,
   // process all directories
   for (const auto& item : items)
   {
-    if (item->m_bIsFolder)
+    if (item->m_bIsFolder && filter(item))
     {
       if (!fileOnly)
         callback(item);
 
-      if (!EnumerateDirectory(item->GetPath(), callback, fileOnly, mask, flags))
+      if (!EnumerateDirectory(item->GetPath(), callback, filter, fileOnly, mask, flags))
         return false;
     }
   }

--- a/xbmc/filesystem/Directory.h
+++ b/xbmc/filesystem/Directory.h
@@ -70,12 +70,25 @@ public:
                            , const CHints &hints);
 
   using DirectoryEnumerationCallback = std::function<void(const std::shared_ptr<CFileItem>& item)>;
+  using DirectoryFilter = std::function<bool(const std::shared_ptr<CFileItem>& folder)>;
 
-  static bool EnumerateDirectory(const std::string& path,
-                                 const DirectoryEnumerationCallback& callback,
-                                 bool fileOnly = false,
-                                 const std::string& mask = "",
-                                 int flags = DIR_FLAG_DEFAULTS);
+  /*!
+   * \brief Enumerates files and folders in and below a directory. Every applicable gets passed to the callback.
+   *
+   * \param path Directory to enumerate
+   * \param callback Files and folders matching the criteria are passed to this function
+   * \param filter Only folders are passed to this function. If it return false the folder and everything below it will skipped from the enumeration
+   * \param fileOnly If true only files are passed to \p callback. Doesn't affect \p filter
+   * \param mask Only files matching this mask are passed to \p callback
+   * \param flags See \ref DIR_FLAG enum
+   */
+  static bool EnumerateDirectory(
+      const std::string& path,
+      const DirectoryEnumerationCallback& callback,
+      const DirectoryFilter& filter = [](const std::shared_ptr<CFileItem>&) { return true; },
+      bool fileOnly = false,
+      const std::string& mask = "",
+      int flags = DIR_FLAG_DEFAULTS);
 
   static bool Create(const std::string& strPath);
   static bool Exists(const std::string& strPath, bool bUseCache = true);

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -2481,7 +2481,8 @@ namespace VIDEO
           CLog::Log(LOGDEBUG, "VideoInfoScanner: Added video extras {}",
                     CURL::GetRedacted(item->GetPath()));
         },
-        true, CServiceBroker::GetFileExtensionProvider().GetVideoExtensions(), DIR_FLAG_DEFAULTS);
+        [](auto) { return true; }, true,
+        CServiceBroker::GetFileExtensionProvider().GetVideoExtensions(), DIR_FLAG_DEFAULTS);
 
     return true;
   }


### PR DESCRIPTION
## Description
Support `.nomedia` files in TV show subdirectories to exclude folders and their sub folders from being added to the library.

Fixes #23975.

## Motivation and context
See #23975.

## How has this been tested?
```
$ tree -a .
.
├── TV Show A (2019)
│   ├── Season 1
│   │   └── TV Show A (2019) - S01E01.mkv
│   └── Season 2
│       ├── .nomedia
│       └── TV Show A (2019) - S02E01.mkv
└── TV Show B (2006)
    ├── .nomedia
    └── TV Show B (2006) - S01E01.mp4
    └── Extras
        └── TV Show B (2006) - S00E01.mp4
```
After this change only `TV Show A (2019) - S01E01.mkv` is scanned to the library.

## What is the effect on users?
Ability to exclude TV show from library scanning.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
