### PR TITLE
[video][dialogs] Video versions: Fix delay before "Convert to version" video select dialog opens

### DIFF
--- a/xbmc/BackgroundInfoLoader.cpp
+++ b/xbmc/BackgroundInfoLoader.cpp
@@ -90,6 +90,9 @@ void CBackgroundInfoLoader::Run()
     m_bIsLoading = false;
     CLog::Log(LOGERROR, "{} - Unhandled exception", __FUNCTION__);
   }
+
+  m_pVecItems = nullptr;
+  m_vecItems.clear();
 }
 
 void CBackgroundInfoLoader::Load(CFileItemList& items)

--- a/xbmc/BackgroundInfoLoader.cpp
+++ b/xbmc/BackgroundInfoLoader.cpp
@@ -15,18 +15,18 @@
 
 #include <mutex>
 
-CBackgroundInfoLoader::CBackgroundInfoLoader() : m_thread (NULL)
-{
-  m_bStop = true;
-  m_pObserver=NULL;
-  m_pProgressCallback=NULL;
-  m_pVecItems = NULL;
-  m_bIsLoading = false;
-}
+CBackgroundInfoLoader::CBackgroundInfoLoader() = default;
 
 CBackgroundInfoLoader::~CBackgroundInfoLoader()
 {
   StopThread();
+}
+
+void CBackgroundInfoLoader::Reset()
+{
+  m_pVecItems = nullptr;
+  m_vecItems.clear();
+  m_bIsLoading = false;
 }
 
 void CBackgroundInfoLoader::Run()
@@ -83,16 +83,13 @@ void CBackgroundInfoLoader::Run()
     }
 
     OnLoaderFinish();
-    m_bIsLoading = false;
   }
   catch (...)
   {
-    m_bIsLoading = false;
     CLog::Log(LOGERROR, "{} - Unhandled exception", __FUNCTION__);
   }
 
-  m_pVecItems = nullptr;
-  m_vecItems.clear();
+  Reset();
 }
 
 void CBackgroundInfoLoader::Load(CFileItemList& items)
@@ -132,9 +129,7 @@ void CBackgroundInfoLoader::StopThread()
     delete m_thread;
     m_thread = NULL;
   }
-  m_vecItems.clear();
-  m_pVecItems = NULL;
-  m_bIsLoading = false;
+  Reset();
 }
 
 bool CBackgroundInfoLoader::IsLoading()

--- a/xbmc/BackgroundInfoLoader.h
+++ b/xbmc/BackgroundInfoLoader.h
@@ -48,15 +48,18 @@ protected:
   virtual void OnLoaderStart() {}
   virtual void OnLoaderFinish() {}
 
-  CFileItemList *m_pVecItems;
+  CFileItemList* m_pVecItems{nullptr};
   std::vector<CFileItemPtr> m_vecItems; // FileItemList would delete the items and we only want to keep a reference.
   CCriticalSection m_lock;
 
-  volatile bool m_bIsLoading;
-  volatile bool m_bStop;
-  CThread *m_thread;
+  volatile bool m_bIsLoading{false};
+  volatile bool m_bStop{true};
+  CThread* m_thread{nullptr};
 
-  IBackgroundLoaderObserver* m_pObserver;
-  IProgressCallback* m_pProgressCallback;
+  IBackgroundLoaderObserver* m_pObserver{nullptr};
+  IProgressCallback* m_pProgressCallback{nullptr};
+
+private:
+  void Reset();
 };
 

--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -203,9 +203,8 @@ int CGUIDialogSelect::Add(const CFileItem& item)
 
 void CGUIDialogSelect::SetItems(const CFileItemList& pList)
 {
-  // need to make internal copy of list to be sure dialog is owner of it
   m_vecList->Clear();
-  m_vecList->Copy(pList);
+  m_vecList->Append(pList);
 
   m_viewControl.SetItems(*m_vecList);
 }

--- a/xbmc/video/dialogs/GUIDialogVideoManager.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -310,7 +310,7 @@ void CGUIDialogVideoManager::Remove()
 
 void CGUIDialogVideoManager::Rename()
 {
-  const int idAsset{SelectVideoAsset(m_videoAsset)};
+  const int idAsset{ChooseVideoAsset(m_videoAsset)};
   if (idAsset != -1)
   {
     //! @todo db refactor: should not be version, but asset
@@ -338,7 +338,7 @@ void CGUIDialogVideoManager::SetSelectedVideoAsset(const std::shared_ptr<CFileIt
   UpdateControls();
 }
 
-int CGUIDialogVideoManager::SelectVideoAsset(const std::shared_ptr<CFileItem>& item)
+int CGUIDialogVideoManager::ChooseVideoAsset(const std::shared_ptr<CFileItem>& item)
 {
   if (!item || !item->HasVideoInfoTag())
     return -1;

--- a/xbmc/video/dialogs/GUIDialogVideoManager.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.h
@@ -50,7 +50,7 @@ protected:
 
   void UpdateControls();
 
-  static int SelectVideoAsset(const std::shared_ptr<CFileItem>& item);
+  static int ChooseVideoAsset(const std::shared_ptr<CFileItem>& item);
 
   CVideoDatabase m_database;
   std::shared_ptr<CFileItem> m_videoAsset;

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -373,7 +373,7 @@ int CGUIDialogVideoManagerVersions::ManageVideoVersionContextMenu(
 }
 
 bool CGUIDialogVideoManagerVersions::ChooseVideoAndConvertToVideoVersion(
-    const CFileItemList& items,
+    CFileItemList& items,
     VideoDbContentType itemType,
     const std::string& mediaType,
     int dbId,
@@ -388,11 +388,18 @@ bool CGUIDialogVideoManagerVersions::ChooseVideoAndConvertToVideoVersion(
     return {};
   }
 
+  // Load thumbs async
+  CVideoThumbLoader loader;
+  loader.Load(items);
+
   dialog->Reset();
   dialog->SetItems(items);
   dialog->SetHeading(CVariant{40002});
   dialog->SetUseDetails(true);
   dialog->Open();
+
+  if (loader.IsLoading())
+    loader.StopThread();
 
   if (!dialog->IsConfirmed())
     return false;
@@ -467,10 +474,8 @@ bool CGUIDialogVideoManagerVersions::ConvertVideoVersion(const std::shared_ptr<C
   }
 
   // decorate the items
-  CVideoThumbLoader loader;
   for (const auto& item : list)
   {
-    loader.LoadItem(item.get());
     item->SetLabel2(item->GetVideoInfoTag()->m_strFileNameAndPath);
   }
 
@@ -521,10 +526,8 @@ bool CGUIDialogVideoManagerVersions::ProcessVideoVersion(VideoDbContentType item
   }
 
   // decorate the items
-  CVideoThumbLoader loader;
   for (const auto& item : list)
   {
-    loader.LoadItem(item.get());
     item->SetLabel2(item->GetVideoInfoTag()->m_strFileNameAndPath);
   }
 

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
@@ -49,5 +49,11 @@ private:
   void SetDefault();
   void UpdateDefaultVideoVersionSelection();
 
+  static bool ChooseVideoAndConvertToVideoVersion(const CFileItemList& items,
+                                                  VideoDbContentType itemType,
+                                                  const std::string& mediaType,
+                                                  int dbId,
+                                                  CVideoDatabase& videoDb);
+
   std::shared_ptr<CFileItem> m_defaultVideoVersion;
 };

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
@@ -49,7 +49,7 @@ private:
   void SetDefault();
   void UpdateDefaultVideoVersionSelection();
 
-  static bool ChooseVideoAndConvertToVideoVersion(const CFileItemList& items,
+  static bool ChooseVideoAndConvertToVideoVersion(CFileItemList& items,
                                                   VideoDbContentType itemType,
                                                   const std::string& mediaType,
                                                   int dbId,


### PR DESCRIPTION
Fixes #24293 

@CrystalP fyi

Idea for the fix is to enhance `CGUIDialogSelect`with the capability to asynchronously load thumbnails of the items to display and to use that from the video manage dialogs implementation for the version conversion. => Commit 1.

While working on this I stumbled over a reproducable crash on Kodi exit triggered by this change. If not stopped before the async load is done, a `CBackgroundInfoLoader` will hold the list of items containing the smart pointers to the items originally handed over to the dialog until Kodi exits or the loader is reused and stopped prematurely then). On exit, when the dialog instance gets destroyed, other kodi parts are already deallocated (GUI control structures referenced by the items for example). Fix for this is also to clear the item list of `CGUIDialogSelect` when the async load completed. I checked that the list is not accessed by any derived classes after it gets cleared now. => Commit 2

Commit 3 is removing of some duplicate code.

Runtime-tested on macOS, latest Kodi master

@enen92 something different this time.