### PR TITLE
[video] Cleanup translation of versions/extras dialog messages

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
@@ -121,8 +121,7 @@ void CGUIDialogVideoManagerExtras::AddVideoExtra()
                       { return version->GetVideoInfoTag()->m_iDbId == idFile; }))
       {
         CGUIDialogOK::ShowAndGetInput(
-            g_localizeStrings.Get(40015),
-            StringUtils::Format(g_localizeStrings.Get(40026), typeVideoVersion));
+            CVariant{40015}, StringUtils::Format(g_localizeStrings.Get(40026), typeVideoVersion));
         return;
       }
 
@@ -134,7 +133,7 @@ void CGUIDialogVideoManagerExtras::AddVideoExtra()
         return;
 
       if (!CGUIDialogYesNo::ShowAndGetInput(
-              g_localizeStrings.Get(40014),
+              CVariant{40014},
               StringUtils::Format(g_localizeStrings.Get(40027), typeVideoVersion, videoTitle)))
       {
         return;

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -134,8 +134,7 @@ void CGUIDialogVideoManagerVersions::Remove()
   // default video version is not allowed
   if (m_database.IsDefaultVideoVersion(m_selectedVideoAsset->GetVideoInfoTag()->m_iDbId))
   {
-    CGUIDialogOK::ShowAndGetInput(CVariant(40018),
-                                  StringUtils::Format(g_localizeStrings.Get(40019)));
+    CGUIDialogOK::ShowAndGetInput(CVariant{40018}, CVariant{40019});
     return;
   }
 
@@ -214,8 +213,7 @@ void CGUIDialogVideoManagerVersions::AddVideoVersion()
                       { return version->GetVideoInfoTag()->m_iDbId == idFile; }))
       {
         CGUIDialogOK::ShowAndGetInput(
-            g_localizeStrings.Get(40014),
-            StringUtils::Format(g_localizeStrings.Get(40016), typeVideoVersion));
+            CVariant{40014}, StringUtils::Format(g_localizeStrings.Get(40016), typeVideoVersion));
         return;
       }
 
@@ -227,7 +225,7 @@ void CGUIDialogVideoManagerVersions::AddVideoVersion()
         return;
 
       if (!CGUIDialogYesNo::ShowAndGetInput(
-              g_localizeStrings.Get(40014),
+              CVariant{40014},
               StringUtils::Format(g_localizeStrings.Get(40017), typeVideoVersion, videoTitle)))
       {
         return;
@@ -240,8 +238,7 @@ void CGUIDialogVideoManagerVersions::AddVideoVersion()
 
         if (list.Size() > 1)
         {
-          CGUIDialogOK::ShowAndGetInput(g_localizeStrings.Get(40014),
-                                        StringUtils::Format(g_localizeStrings.Get(40019)));
+          CGUIDialogOK::ShowAndGetInput(CVariant{40014}, CVariant{40019});
           return;
         }
         else
@@ -283,8 +280,7 @@ std::tuple<int, std::string> CGUIDialogVideoManagerVersions::NewVideoVersion()
   std::string typeVideoVersion;
 
   // prompt for the new video version
-  if (!CGUIKeyboardFactory::ShowAndGetInput(typeVideoVersion,
-                                            CVariant{g_localizeStrings.Get(40004)}, false))
+  if (!CGUIKeyboardFactory::ShowAndGetInput(typeVideoVersion, CVariant{40004}, false))
     return std::make_tuple(-1, "");
 
   CVideoDatabase videodb;
@@ -390,8 +386,7 @@ bool CGUIDialogVideoManagerVersions::ConvertVideoVersion(const std::shared_ptr<C
   // invalid operation warning
   if (item->GetVideoInfoTag()->HasVideoVersions())
   {
-    CGUIDialogOK::ShowAndGetInput(CVariant{40005},
-                                  StringUtils::Format(g_localizeStrings.Get(40006)));
+    CGUIDialogOK::ShowAndGetInput(CVariant{40005}, CVariant{40006});
     return false;
   }
 
@@ -451,7 +446,7 @@ bool CGUIDialogVideoManagerVersions::ConvertVideoVersion(const std::shared_ptr<C
 
   dialog->Reset();
   dialog->SetItems(list);
-  dialog->SetHeading(StringUtils::Format(g_localizeStrings.Get(40002)));
+  dialog->SetHeading(CVariant{40002});
   dialog->SetUseDetails(true);
   dialog->Open();
 
@@ -497,10 +492,9 @@ bool CGUIDialogVideoManagerVersions::ProcessVideoVersion(VideoDbContentType item
   std::string path;
   videodb.GetFilePathById(dbId, path, itemType);
 
-  if (!CGUIDialogYesNo::ShowAndGetInput(StringUtils::Format(g_localizeStrings.Get(40008)),
-                                        StringUtils::Format(g_localizeStrings.Get(40009),
-                                                            item.GetVideoInfoTag()->GetTitle(),
-                                                            path)))
+  if (!CGUIDialogYesNo::ShowAndGetInput(
+          CVariant{40008}, StringUtils::Format(g_localizeStrings.Get(40009),
+                                               item.GetVideoInfoTag()->GetTitle(), path)))
   {
     return false;
   }
@@ -532,7 +526,7 @@ bool CGUIDialogVideoManagerVersions::ProcessVideoVersion(VideoDbContentType item
 
   dialog->Reset();
   dialog->SetItems(list);
-  dialog->SetHeading(StringUtils::Format(g_localizeStrings.Get(40002)));
+  dialog->SetHeading(CVariant{40002});
   dialog->SetUseDetails(true);
   dialog->Open();
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Modified the Manage versions / extras dialogs:
- removed unnecessary `StringUtils::Format()`
- CVariant{int message number} for message translation where possible

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Comments on PR #24326 pointed out some useless `StringUtils::Format()` calls and a more compact way to localize constant messages.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran before / after for comparison, no difference noticed as expected.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
None.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
