### PR TITLE
[video] Fix no video information available when playing strm files, …

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -2394,8 +2394,9 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
       if (videoInfoTagPath.find("removable://") == 0 || item.IsVideoDb())
         path = videoInfoTagPath;
 
-      if (!item.HasVideoInfoTag())
-        dbs.LoadVideoInfo(path, *item.GetVideoInfoTag());
+      // Note that we need to load the tag from database also if the item already has a tag,
+      // because for example the (full) video info for strm files will be loaded here.
+      dbs.LoadVideoInfo(path, *item.GetVideoInfoTag());
 
       if (item.HasProperty("savedplayerstate"))
       {

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1077,8 +1077,10 @@ bool CGUIWindowVideoBase::PlayItem(const std::shared_ptr<CFileItem>& pItem,
     CServiceBroker::GetPlaylistPlayer().Play();
     return true;
   }
-  else if (pItem->IsPlayList())
+  else if (pItem->IsPlayList() && !pItem->IsType(".strm"))
   {
+    // Note: strm files being somehow special playlists need to be handled in OnPlay*Media
+
     // load the playlist the old way
     LoadPlayList(pItem->GetDynPath(), PLAYLIST::TYPE_VIDEO);
     return true;


### PR DESCRIPTION
…although they where added to the video library.

Fixes fallout from video versions feature playback adaptions.

Reported here: https://github.com/xbmc/xbmc/pull/24318#issuecomment-1869697747 (no GH issue for this as of now)

First, `Application::PlayMedia` needs to load video info tag from database unconditional as it was done in Nexus, because for example there the video info for strm files is loaded if they where added to the video library. 

Second, `CGUIWindowVideoBase` must not call `LoadPlayList` for stream files, as "the old way" (see existing code comment)  simply does not work for strm files. This code path was not reached in Nexus, but in Omega, due to other changes that were done to make video versions selections and playback work.

Runtime-tested on macOS, latest Kodi master.

@enen92 whenever you find some time for a review.