### PR TITLE
[video] Video versions select dialog: Highlight default version in list of versions

### DIFF
--- a/xbmc/video/guilib/VideoVersionHelper.cpp
+++ b/xbmc/video/guilib/VideoVersionHelper.cpp
@@ -79,6 +79,17 @@ std::shared_ptr<const CFileItem> CVideoChooser::ChooseVideo()
   else
     m_videoExtras.Clear();
 
+  CFileItem defaultVideoVersion;
+  db.GetDefaultVideoVersion(m_item->GetVideoContentType(), m_item->GetVideoInfoTag()->m_iDbId,
+                            defaultVideoVersion);
+
+  // find default version item in list and select it
+  const int defaultDbId{defaultVideoVersion.GetVideoInfoTag()->m_iDbId};
+  for (const auto& item : m_videoVersions)
+  {
+    item->Select(item->GetVideoInfoTag()->m_iDbId == defaultDbId);
+  }
+
   VideoAssetType itemType{VideoAssetType::VERSION};
   while (true)
   {


### PR DESCRIPTION
Like in versions manage dialog, now the default version gets highlighted also in the versions select dialog:

![screenshot00000](https://github.com/xbmc/xbmc/assets/3226626/2dc1314b-5dfc-4c1d-9044-4ef427103479)

@CrystalP fyi

Runtime-tested on macOS, latest Kodi master.

@enen92 the review journey continues...