### PR TITLE
[video] Separate video versions and extras items

### DIFF
--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -770,7 +770,7 @@ bool CVideoGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contextW
         value = tag->HasVideoVersions();
         return true;
       case LISTITEM_ISVIDEOEXTRA:
-        value = (tag->GetAssetInfo().GetType() == VideoAssetType::EXTRAS);
+        value = (tag->GetAssetInfo().GetType() == VideoAssetType::EXTRA);
         return true;
     }
   }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -597,7 +597,7 @@ void CVideoDatabase::CreateViews()
                                      "    rating.rating_id=movie.c%02d"
                                      "  LEFT JOIN uniqueid ON"
                                      "    uniqueid.uniqueid_id=movie.c%02d",
-                                     VideoAssetType::VERSION, VideoAssetType::EXTRAS,
+                                     VideoAssetType::VERSION, VideoAssetType::EXTRA,
                                      VIDEODB_ID_RATING_ID, VIDEODB_ID_IDENT_ID);
   m_pDS->exec(movieview);
 }
@@ -6204,7 +6204,7 @@ void CVideoDatabase::UpdateTables(int iVersion)
       {
         // user-added type for extras. change its item type to extras
         m_pDS2->exec(PrepareSQL("UPDATE videoversiontype SET itemType = %i WHERE id = %i",
-                                VideoAssetType::EXTRAS, idType));
+                                VideoAssetType::EXTRA, idType));
       }
       else
       {
@@ -6217,7 +6217,7 @@ void CVideoDatabase::UpdateTables(int iVersion)
           m_pDS2->exec(PrepareSQL(
               "INSERT INTO videoversiontype (id, name, owner, itemType) VALUES(NULL, '%s', %i, %i)",
               m_pDS2->fv(1).get_asString().c_str(), VideoAssetTypeOwner::USER,
-              VideoAssetType::EXTRAS));
+              VideoAssetType::EXTRA));
 
           // update the respective extras to use the new extras type
           const int newId{static_cast<int>(m_pDS2->lastinsertid())};
@@ -11855,7 +11855,7 @@ void CVideoDatabase::GetVideoVersions(VideoDbContentType itemType, int dbId, CFi
 
   // get video extras versions
   CFileItemList extrasList;
-  GetVideoVersions(itemType, dbId, extrasList, VideoAssetType::EXTRAS);
+  GetVideoVersions(itemType, dbId, extrasList, VideoAssetType::EXTRA);
   items.Append(extrasList);
 }
 
@@ -12146,7 +12146,7 @@ void CVideoDatabase::AddExtrasVideoVersion(VideoDbContentType itemType,
                                            int idVideoVersion,
                                            CFileItem& item)
 {
-  AddVideoVersion(itemType, dbId, idVideoVersion, VideoAssetType::EXTRAS, item);
+  AddVideoVersion(itemType, dbId, idVideoVersion, VideoAssetType::EXTRA, item);
 }
 
 void CVideoDatabase::AddVideoVersion(VideoDbContentType itemType,

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -12385,7 +12385,9 @@ bool CVideoDatabase::GetVideoVersionsNav(const std::string& strBaseDir,
   return false;
 }
 
-bool CVideoDatabase::GetVideoVersionTypes(VideoDbContentType idContent, CFileItemList& items)
+bool CVideoDatabase::GetVideoVersionTypes(VideoDbContentType idContent,
+                                          VideoAssetType assetType,
+                                          CFileItemList& items)
 {
   if (!m_pDB || !m_pDS)
     return false;
@@ -12402,8 +12404,9 @@ bool CVideoDatabase::GetVideoVersionTypes(VideoDbContentType idContent, CFileIte
   try
   {
     m_pDS->query(
-        PrepareSQL("SELECT name, id FROM videoversiontype WHERE name != '' and owner IN (%i, %i)",
-                   VideoAssetTypeOwner::SYSTEM, VideoAssetTypeOwner::USER));
+        PrepareSQL("SELECT name, id FROM videoversiontype WHERE name != '' AND itemType = %i "
+                   "AND owner IN (%i, %i)",
+                   assetType, VideoAssetTypeOwner::SYSTEM, VideoAssetTypeOwner::USER));
 
     while (!m_pDS->eof())
     {

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -11802,7 +11802,8 @@ void CVideoDatabase::UpdateVideoVersionTypeTable()
 }
 
 int CVideoDatabase::AddVideoVersionType(const std::string& typeVideoVersion,
-                                        VideoAssetTypeOwner owner)
+                                        VideoAssetTypeOwner owner,
+                                        VideoAssetType assetType)
 {
   if (typeVideoVersion.empty())
     return -1;
@@ -11814,14 +11815,15 @@ int CVideoDatabase::AddVideoVersionType(const std::string& typeVideoVersion,
     if (!m_pDB || !m_pDS)
       return -1;
 
-    m_pDS->query(PrepareSQL("SELECT id, owner FROM videoversiontype WHERE name = '%s'",
-                            typeVideoVersion.c_str()));
+    m_pDS->query(PrepareSQL(
+        "SELECT id, owner, itemType FROM videoversiontype WHERE name = '%s' AND itemtype = %i",
+        typeVideoVersion.c_str(), assetType));
     if (m_pDS->num_rows() == 0)
     {
-      m_pDS->exec(
-          PrepareSQL("INSERT INTO videoversiontype (id, name, owner) VALUES(NULL, '%s', %i)",
-                     typeVideoVersion.c_str(), owner));
-      id = m_pDS->lastinsertid();
+      m_pDS->exec(PrepareSQL("INSERT INTO videoversiontype (id, name, owner, itemType) "
+                             "VALUES(NULL, '%s', %i, %i)",
+                             typeVideoVersion.c_str(), owner, assetType));
+      id = static_cast<int>(m_pDS->lastinsertid());
     }
     else
     {

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1009,7 +1009,9 @@ public:
                              int idVideoVersion);
   void SetDefaultVideoVersion(VideoDbContentType itemType, int dbId, int idFile);
   void SetVideoVersion(int idFile, int idVideoVersion);
-  int AddVideoVersionType(const std::string& typeVideoVersion, VideoAssetTypeOwner owner);
+  int AddVideoVersionType(const std::string& typeVideoVersion,
+                          VideoAssetTypeOwner owner,
+                          VideoAssetType assetType);
   void AddVideoVersion(VideoDbContentType itemType,
                        int dbId,
                        int idVideoVersion,

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1027,7 +1027,7 @@ public:
   bool IsDefaultVideoVersion(int idFile);
   bool GetVideoVersionTypes(VideoDbContentType idContent, CFileItemList& items);
   void SetVideoVersionDefaultArt(int dbId, int idFrom, VideoDbContentType type);
-  void InitializeVideoVersionTypeTable();
+  void InitializeVideoVersionTypeTable(int schemaVersion);
   void UpdateVideoVersionTypeTable();
   bool GetVideoVersionsNav(const std::string& strBaseDir,
                            CFileItemList& items,

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1025,7 +1025,9 @@ public:
                              CFileItem& item);
   void RemoveVideoVersion(int dbId);
   bool IsDefaultVideoVersion(int idFile);
-  bool GetVideoVersionTypes(VideoDbContentType idContent, CFileItemList& items);
+  bool GetVideoVersionTypes(VideoDbContentType idContent,
+                            VideoAssetType asset,
+                            CFileItemList& items);
   void SetVideoVersionDefaultArt(int dbId, int idFrom, VideoDbContentType type);
   void InitializeVideoVersionTypeTable(int schemaVersion);
   void UpdateVideoVersionTypeTable();

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -2452,8 +2452,8 @@ namespace VIDEO
           const std::string typeVideoVersion =
               CGUIDialogVideoManagerExtras::GenerateVideoExtra(path, item->GetPath());
 
-          const int idVideoVersion =
-              m_database.AddVideoVersionType(typeVideoVersion, VideoAssetTypeOwner::AUTO);
+          const int idVideoVersion = m_database.AddVideoVersionType(
+              typeVideoVersion, VideoAssetTypeOwner::AUTO, VideoAssetType::EXTRAS);
 
           m_database.AddExtrasVideoVersion(ContentToVideoDbType(content), dbId, idVideoVersion,
                                            *item.get());

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -2453,7 +2453,7 @@ namespace VIDEO
               CGUIDialogVideoManagerExtras::GenerateVideoExtra(path, item->GetPath());
 
           const int idVideoVersion = m_database.AddVideoVersionType(
-              typeVideoVersion, VideoAssetTypeOwner::AUTO, VideoAssetType::EXTRAS);
+              typeVideoVersion, VideoAssetTypeOwner::AUTO, VideoAssetType::EXTRA);
 
           m_database.AddExtrasVideoVersion(ContentToVideoDbType(content), dbId, idVideoVersion,
                                            *item.get());

--- a/xbmc/video/VideoManagerTypes.h
+++ b/xbmc/video/VideoManagerTypes.h
@@ -20,7 +20,7 @@ enum class VideoAssetType
 {
   UNKNOWN = -1,
   VERSION = 0,
-  EXTRAS = 1
+  EXTRA = 1
 };
 
 static constexpr int VIDEO_VERSION_ID_BEGIN = 40400;

--- a/xbmc/video/dialogs/GUIDialogVideoManager.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -310,7 +310,7 @@ void CGUIDialogVideoManager::Remove()
 
 void CGUIDialogVideoManager::Rename()
 {
-  const int idAsset{ChooseVideoAsset(m_videoAsset)};
+  const int idAsset{ChooseVideoAsset(m_videoAsset, GetVideoAssetType())};
   if (idAsset != -1)
   {
     //! @todo db refactor: should not be version, but asset
@@ -338,7 +338,8 @@ void CGUIDialogVideoManager::SetSelectedVideoAsset(const std::shared_ptr<CFileIt
   UpdateControls();
 }
 
-int CGUIDialogVideoManager::ChooseVideoAsset(const std::shared_ptr<CFileItem>& item)
+int CGUIDialogVideoManager::ChooseVideoAsset(const std::shared_ptr<CFileItem>& item,
+                                             VideoAssetType assetType)
 {
   if (!item || !item->HasVideoInfoTag())
     return -1;
@@ -364,7 +365,7 @@ int CGUIDialogVideoManager::ChooseVideoAsset(const std::shared_ptr<CFileItem>& i
 
   //! @todo db refactor: should not be version, but asset
   CFileItemList list;
-  videodb.GetVideoVersionTypes(itemType, list);
+  videodb.GetVideoVersionTypes(itemType, assetType, list);
 
   int assetId{-1};
   while (true)

--- a/xbmc/video/dialogs/GUIDialogVideoManager.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -385,7 +385,7 @@ int CGUIDialogVideoManager::ChooseVideoAsset(const std::shared_ptr<CFileItem>& i
       {
         assetTitle = StringUtils::Trim(assetTitle);
         //! @todo db refactor: should not be version, but asset
-        assetId = videodb.AddVideoVersionType(assetTitle, VideoAssetTypeOwner::USER);
+        assetId = videodb.AddVideoVersionType(assetTitle, VideoAssetTypeOwner::USER, assetType);
       }
     }
     else if (dialog->IsConfirmed())

--- a/xbmc/video/dialogs/GUIDialogVideoManager.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.h
@@ -50,7 +50,7 @@ protected:
 
   void UpdateControls();
 
-  static int ChooseVideoAsset(const std::shared_ptr<CFileItem>& item);
+  static int ChooseVideoAsset(const std::shared_ptr<CFileItem>& item, VideoAssetType assetType);
 
   CVideoDatabase m_database;
   std::shared_ptr<CFileItem> m_videoAsset;

--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
@@ -155,8 +155,8 @@ void CGUIDialogVideoManagerExtras::AddVideoExtra()
     const std::string typeNewVideoVersion{
         CGUIDialogVideoManagerExtras::GenerateVideoExtra(URIUtils::GetFileName(path))};
 
-    const int idNewVideoVersion{
-        m_database.AddVideoVersionType(typeNewVideoVersion, VideoAssetTypeOwner::AUTO)};
+    const int idNewVideoVersion{m_database.AddVideoVersionType(
+        typeNewVideoVersion, VideoAssetTypeOwner::AUTO, VideoAssetType::EXTRAS)};
 
     m_database.AddExtrasVideoVersion(itemType, dbId, idNewVideoVersion, item);
 

--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
@@ -41,7 +41,7 @@ CGUIDialogVideoManagerExtras::CGUIDialogVideoManagerExtras()
 
 VideoAssetType CGUIDialogVideoManagerExtras::GetVideoAssetType()
 {
-  return VideoAssetType::EXTRAS;
+  return VideoAssetType::EXTRA;
 }
 
 bool CGUIDialogVideoManagerExtras::OnMessage(CGUIMessage& message)
@@ -156,7 +156,7 @@ void CGUIDialogVideoManagerExtras::AddVideoExtra()
         CGUIDialogVideoManagerExtras::GenerateVideoExtra(URIUtils::GetFileName(path))};
 
     const int idNewVideoVersion{m_database.AddVideoVersionType(
-        typeNewVideoVersion, VideoAssetTypeOwner::AUTO, VideoAssetType::EXTRAS)};
+        typeNewVideoVersion, VideoAssetTypeOwner::AUTO, VideoAssetType::EXTRA)};
 
     m_database.AddExtrasVideoVersion(itemType, dbId, idNewVideoVersion, item);
 

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -265,7 +265,7 @@ void CGUIDialogVideoManagerVersions::AddVideoVersion()
                  CURL::GetRedacted(item.GetPath()));
     }
 
-    const int idNewVideoVersion{ChooseVideoAsset(m_videoAsset)};
+    const int idNewVideoVersion{ChooseVideoAsset(m_videoAsset, VideoAssetType::VERSION)};
     if (idNewVideoVersion != -1)
       m_database.AddPrimaryVideoVersion(itemType, dbId, idNewVideoVersion, item);
 
@@ -409,7 +409,7 @@ bool CGUIDialogVideoManagerVersions::ChooseVideoAndConvertToVideoVersion(
     return false;
 
   // choose a video version for the video
-  const int idVideoVersion{ChooseVideoAsset(selectedItem)};
+  const int idVideoVersion{ChooseVideoAsset(selectedItem, VideoAssetType::VERSION)};
   if (idVideoVersion < 0)
     return false;
 

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -291,8 +291,8 @@ std::tuple<int, std::string> CGUIDialogVideoManagerVersions::NewVideoVersion()
   }
 
   typeVideoVersion = StringUtils::Trim(typeVideoVersion);
-  const int idVideoVersion{
-      videodb.AddVideoVersionType(typeVideoVersion, VideoAssetTypeOwner::USER)};
+  const int idVideoVersion{videodb.AddVideoVersionType(typeVideoVersion, VideoAssetTypeOwner::USER,
+                                                       VideoAssetType::VERSION)};
 
   return std::make_tuple(idVideoVersion, typeVideoVersion);
 }

--- a/xbmc/video/guilib/VideoVersionHelper.cpp
+++ b/xbmc/video/guilib/VideoVersionHelper.cpp
@@ -75,7 +75,7 @@ std::shared_ptr<const CFileItem> CVideoChooser::ChooseVideo()
                       m_videoVersions, VideoAssetType::VERSION);
   if (m_enableExtras)
     db.GetVideoVersions(m_item->GetVideoContentType(), m_item->GetVideoInfoTag()->m_iDbId,
-                        m_videoExtras, VideoAssetType::EXTRAS);
+                        m_videoExtras, VideoAssetType::EXTRA);
   else
     m_videoExtras.Clear();
 
@@ -96,7 +96,7 @@ std::shared_ptr<const CFileItem> CVideoChooser::ChooseVideo()
     if (itemType == VideoAssetType::VERSION)
     {
       result = ChooseVideoVersion();
-      itemType = VideoAssetType::EXTRAS;
+      itemType = VideoAssetType::EXTRA;
     }
     else
     {


### PR DESCRIPTION
Fixes the last open problem reported in issue #24245 : "the extras rename selection dialog should contain items specific to extras, same as the wording of the window heading and its buttons". 

All lists (not only on rename, like requested in the issue) are now only displaying the items belonging to the respective asset type.

For this we need to extend the database scheme, because in the original design the entries in the "videoversiontype" table were not for specific assets (versions, extras, ...), but for all types of assets.

I tried to migrate data as good as possible, by inspecting where the types are actually used, to find out the asset type for those types. That was actually the most challenging (== time consuming) part of this PR.

Runtime-tested on macOS, latest Kodi master.

@enen92 can you please have a look?