### PR TITLE
[Pictures] Fix exif parsing regression from v19

### DIFF
--- a/xbmc/pictures/ExifParse.cpp
+++ b/xbmc/pictures/ExifParse.cpp
@@ -105,19 +105,21 @@ static void ErrNonfatal(const char* const msg, int a1, int a2);
 namespace
 {
 constexpr auto FMT_BYTE = 1;
-constexpr auto FMT_USHORT = 2;
-constexpr auto FMT_ULONG = 3;
-constexpr auto FMT_URATIONAL = 4;
-constexpr auto FMT_SBYTE = 5;
-constexpr auto FMT_SSHORT = 6;
-constexpr auto FMT_SLONG = 7;
-constexpr auto FMT_SRATIONAL = 8;
-constexpr auto FMT_SINGLE = 9;
-constexpr auto FMT_DOUBLE = 10;
+[[maybe_unused]] constexpr auto FMT_STRING = 2;
+constexpr auto FMT_USHORT = 3;
+constexpr auto FMT_ULONG = 4;
+constexpr auto FMT_URATIONAL = 5;
+constexpr auto FMT_SBYTE = 6;
+[[maybe_unused]] constexpr auto FMT_UNDEFINED = 7;
+constexpr auto FMT_SSHORT = 8;
+constexpr auto FMT_SLONG = 9;
+constexpr auto FMT_SRATIONAL = 10;
+constexpr auto FMT_SINGLE = 11;
+constexpr auto FMT_DOUBLE = 12;
 // NOTE: Remember to change NUM_FORMATS if you define a new format
-constexpr auto NUM_FORMATS = 10;
+constexpr auto NUM_FORMATS = 12;
 
-const unsigned int BytesPerFormat[NUM_FORMATS] = {1, 2, 4, 8, 1, 2, 4, 8, 4, 8};
+const unsigned int BytesPerFormat[NUM_FORMATS] = {1, 1, 2, 4, 8, 1, 1, 2, 4, 8, 4, 8};
 } // namespace
 
 //--------------------------------------------------------------------------


### PR DESCRIPTION
## Description
This fixes EXIF parsing which has been broken since v19. This is a regression from: https://github.com/xbmc/xbmc/commit/f894813ad1dbc38be36388b8facbd6d6e1487bc2

Fixes https://github.com/xbmc/xbmc/issues/23360
Fixes https://github.com/xbmc/xbmc/issues/22900

## Motivation and context
The code will be nuked for v22 but lets have something actually working for v21.

## How has this been tested?
Runtime tested on macOS

## What is the effect on users?
Exif parsing should now be working.

## Screenshots (if appropriate):
**Prev:**
<img width="627" alt="image" src="https://github.com/xbmc/xbmc/assets/7375276/3c00f8a9-e89f-4513-9a14-0903af04b1f1">


**Now:**
<img width="619" alt="image" src="https://github.com/xbmc/xbmc/assets/7375276/08c12634-7a77-4dec-a065-1b0a7d09dbd7">


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
