### PR TITLE
[Video] Replace videoversiontype with videoversion.name

### DIFF
--- a/xbmc/DatabaseManager.cpp
+++ b/xbmc/DatabaseManager.cpp
@@ -230,17 +230,3 @@ void CDatabaseManager::UpdateStatus(const std::string &name, DB_STATUS status)
   std::unique_lock<CCriticalSection> lock(m_section);
   m_dbStatus[name] = status;
 }
-
-void CDatabaseManager::LocalizationChanged()
-{
-  std::unique_lock<CCriticalSection> lock(m_section);
-
-  // update video version type table after language changed
-  CVideoDatabase videodb;
-  if (videodb.Open())
-  {
-    videodb.UpdateVideoVersionTypeTable();
-    CLog::Log(LOGDEBUG, "{}, Video version type table updated for new language settings",
-              __FUNCTION__);
-  }
-}

--- a/xbmc/DatabaseManager.h
+++ b/xbmc/DatabaseManager.h
@@ -51,8 +51,6 @@ public:
 
   bool IsUpgrading() const { return m_bIsUpgrading; }
 
-  void LocalizationChanged();
-
 private:
   std::atomic<bool> m_bIsUpgrading;
 

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -791,7 +791,6 @@ bool CLangInfo::SetLanguage(std::string language /* = "" */, bool reloadServices
     // also tell our weather and skin to reload as these are localized
     CServiceBroker::GetWeatherManager().Refresh();
     CServiceBroker::GetPVRManager().LocalizationChanged();
-    CServiceBroker::GetDatabaseManager().LocalizationChanged();
     CServiceBroker::GetAppMessenger()->PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr,
                                                "ReloadSkin");
   }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -6214,7 +6214,7 @@ void CVideoDatabase::UpdateTables(int iVersion)
           // currently a versions type, create a corresponding user-added type for extras
           m_pDS2->exec(PrepareSQL(
               "INSERT INTO videoversiontype (id, name, owner, itemType) VALUES(NULL, '%s', %i, %i)",
-              m_pDS2->fv(1).get_asString().c_str(), VideoAssetTypeOwner::USER,
+              m_pDS2->fv(1).get_asString().c_str(), 2 /* was VideoAssetTypeOwner::USER */,
               VideoAssetType::EXTRA));
 
           // update the respective extras to use the new extras type
@@ -11780,13 +11780,13 @@ void CVideoDatabase::InitializeVideoVersionTypeTable(int schemaVersion)
       {
         m_pDS->exec(
             PrepareSQL("INSERT INTO videoversiontype (id, name, owner) VALUES(%i, '%s', %i)", id,
-                       type.c_str(), VideoAssetTypeOwner::SYSTEM));
+                       type.c_str(), 0 /* was VideoAssetTypeOwner::SYSTEM */));
       }
       else
       {
         m_pDS->exec(PrepareSQL(
             "INSERT INTO videoversiontype (id, name, owner, itemType) VALUES(%i, '%s', %i, %i)", id,
-            type.c_str(), VideoAssetTypeOwner::SYSTEM, VideoAssetType::VERSION));
+            type.c_str(), 0 /* was VideoAssetTypeOwner::SYSTEM */, VideoAssetType::VERSION));
       }
     }
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -11797,28 +11797,6 @@ void CVideoDatabase::InitializeVideoVersionTypeTable(int schemaVersion)
   }
 }
 
-void CVideoDatabase::UpdateVideoVersionTypeTable()
-{
-  try
-  {
-    BeginTransaction();
-
-    for (int id = VIDEO_VERSION_ID_BEGIN; id <= VIDEO_VERSION_ID_END; ++id)
-    {
-      std::string type = g_localizeStrings.Get(id);
-      m_pDS->exec(PrepareSQL("UPDATE videoversiontype SET name = '%s', owner = %i WHERE id = '%i'",
-                             type.c_str(), VideoAssetTypeOwner::SYSTEM, id));
-    }
-
-    CommitTransaction();
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
-    RollbackTransaction();
-  }
-}
-
 int CVideoDatabase::AddVideoVersionType(const std::string& typeVideoVersion,
                                         VideoAssetTypeOwner owner,
                                         VideoAssetType assetType)

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -6198,7 +6198,7 @@ void CVideoDatabase::UpdateTables(int iVersion)
     while (!m_pDS->eof())
     {
       const int idType{m_pDS->fv(0).get_asInt()};
-      if (idType > VIDEO_VERSION_ID_END)
+      if (idType > VIDEO_VERSION_ID_MAX)
       {
         // user-added type for extras. change its item type to extras
         m_pDS2->exec(PrepareSQL("UPDATE videoversiontype SET itemType = %i WHERE id = %i",
@@ -6246,7 +6246,7 @@ void CVideoDatabase::UpdateTables(int iVersion)
     m_pDS->exec(PrepareSQL("UPDATE videoversion "
                            "SET idType = 0 "
                            "WHERE idType > %i",
-                           VIDEO_VERSION_ID_END));
+                           VIDEO_VERSION_ID_MAX));
 
     m_pDS->exec("DROP TABLE videoversiontype");
   }
@@ -11773,7 +11773,7 @@ void CVideoDatabase::InitializeVideoVersionTypeTable(int schemaVersion)
   {
     BeginTransaction();
 
-    for (int id = VIDEO_VERSION_ID_BEGIN; id <= VIDEO_VERSION_ID_END; ++id)
+    for (int id = VIDEO_VERSION_ID_BEGIN; id <= VIDEO_VERSION_ID_MAX; ++id)
     {
       const std::string type{g_localizeStrings.Get(id)};
       if (schemaVersion < 127)
@@ -12326,9 +12326,9 @@ bool CVideoDatabase::GetVideoVersionsNav(const std::string& strBaseDir,
   return false;
 }
 
-bool CVideoDatabase::GetVideoVersionTypes(VideoDbContentType idContent,
-                                          VideoAssetType assetType,
-                                          CFileItemList& items)
+bool CVideoDatabase::GetUserAssetNames(VideoDbContentType idContent,
+                                       VideoAssetType assetType,
+                                       CFileItemList& items)
 {
   if (!m_pDB || !m_pDS)
     return false;
@@ -12344,10 +12344,10 @@ bool CVideoDatabase::GetVideoVersionTypes(VideoDbContentType idContent,
 
   try
   {
-    m_pDS->query(
-        PrepareSQL("SELECT name, id FROM videoversiontype WHERE name != '' AND itemType = %i "
-                   "AND owner IN (%i, %i)",
-                   assetType, VideoAssetTypeOwner::SYSTEM, VideoAssetTypeOwner::USER));
+    m_pDS->query(PrepareSQL("SELECT DISTINCT name FROM videoversion "
+                            "WHERE idType = 0 AND itemType = %i "
+                            "ORDER BY name ",
+                            assetType));
 
     while (!m_pDS->eof())
     {

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -11851,9 +11851,9 @@ void CVideoDatabase::GetVideoVersions(VideoDbContentType itemType,
 
     for (auto& version : versions)
     {
-      std::string name = std::get<0>(version);
-      int id = std::get<1>(version);
-      int idFile = std::get<2>(version);
+      const int id = std::get<1>(version);
+      const std::string name = id ? g_localizeStrings.Get(id) : std::get<0>(version);
+      const int idFile = std::get<2>(version);
 
       CVideoInfoTag infoTag;
       if (GetFileInfo("", infoTag, idFile))
@@ -11921,9 +11921,9 @@ void CVideoDatabase::GetDefaultVideoVersion(VideoDbContentType itemType, int dbI
 
     if (!m_pDS->eof())
     {
-      std::string name = m_pDS->fv("name").get_asString();
-      int id = m_pDS->fv("id").get_asInt();
-      int idFile = m_pDS->fv("idFile").get_asInt();
+      const int id = m_pDS->fv("id").get_asInt();
+      const std::string name = id ? g_localizeStrings.Get(id) : m_pDS->fv("name").get_asString();
+      const int idFile = m_pDS->fv("idFile").get_asInt();
       const auto videoAssetType{static_cast<VideoAssetType>(m_pDS->fv("itemType").get_asInt())};
       CVideoInfoTag infoTag;
       if (GetFileInfo("", infoTag, idFile))
@@ -12215,7 +12215,8 @@ int CVideoDatabase::GetVideoVersionInfo(int idFile,
     if (m_pDS->num_rows() > 0)
     {
       idVideoVersion = m_pDS->fv("id").get_asInt();
-      typeVideoVersion = m_pDS->fv("name").get_asString();
+      typeVideoVersion =
+          idVideoVersion ? g_localizeStrings.Get(idVideoVersion) : m_pDS->fv("name").get_asString();
       idMedia = m_pDS->fv("idMedia").get_asInt();
       mediaType = m_pDS->fv("mediaType").get_asString();
       videoAssetType = static_cast<VideoAssetType>(m_pDS->fv("itemType").get_asInt());
@@ -12299,15 +12300,15 @@ bool CVideoDatabase::GetVideoVersionsNav(const std::string& strBaseDir,
 
     while (!m_pDS->eof())
     {
-      std::string name = m_pDS->fv("name").get_asString();
-      int id = m_pDS->fv("id").get_asInt();
+      const int id = m_pDS->fv("id").get_asInt();
+      const std::string name = id ? g_localizeStrings.Get(id) : m_pDS->fv("name").get_asString();
 
       auto item(std::make_shared<CFileItem>(name));
       item->GetVideoInfoTag()->m_type = MediaTypeVideoVersion;
       item->GetVideoInfoTag()->m_iDbId = id;
 
+      const std::string path = StringUtils::Format("{}/", m_pDS->fv("id").get_asInt());
       CVideoDbUrl itemUrl = videoUrl;
-      std::string path = StringUtils::Format("{}/", m_pDS->fv("id").get_asInt());
       itemUrl.AppendPath(path);
       item->SetPath(itemUrl.ToString());
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -11872,12 +11872,8 @@ void CVideoDatabase::GetVideoVersions(VideoDbContentType itemType,
 
   try
   {
-    m_pDS2->query(PrepareSQL("SELECT videoversiontype.name AS name,"
-                             "  videoversiontype.id AS id,"
-                             "  videoversion.idFile AS idFile "
-                             "FROM videoversiontype"
-                             "  JOIN videoversion ON"
-                             "    videoversion.idType = videoversiontype.id "
+    m_pDS2->query(PrepareSQL("SELECT name, idType AS id, idFile "
+                             "FROM videoversion "
                              "WHERE videoversion.idMedia = %i AND videoversion.mediaType = '%s' "
                              "AND videoversion.itemType = %i",
                              dbId, mediaType.c_str(), videoAssetType));
@@ -11952,14 +11948,9 @@ void CVideoDatabase::GetDefaultVideoVersion(VideoDbContentType itemType, int dbI
   if (itemType == VideoDbContentType::MOVIES)
   {
     mediaType = MediaTypeMovie;
-    strSQL = PrepareSQL("SELECT videoversiontype.name AS name,"
-                        "  videoversiontype.id AS id,"
-                        "  videoversion.idFile AS idFile,"
-                        "  videoversion.itemType AS itemType "
-                        "FROM videoversiontype"
-                        "  JOIN videoversion ON"
-                        "    videoversion.idType = videoversiontype.id"
-                        "  JOIN movie ON"
+    strSQL = PrepareSQL("SELECT name, idType as id, videoversion.idFile, itemType "
+                        "FROM videoversion "
+                        "  JOIN movie ON "
                         "    movie.idFile = videoversion.idFile "
                         "WHERE movie.idMovie = %i",
                         dbId);
@@ -12252,14 +12243,8 @@ int CVideoDatabase::GetVideoVersionInfo(int idFile,
 
   try
   {
-    m_pDS->query(PrepareSQL("SELECT videoversiontype.name AS name,"
-                            "  videoversiontype.id AS id,"
-                            "  videoversion.idMedia AS idMedia,"
-                            "  videoversion.mediaType AS mediaType,"
-                            "  videoversion.itemType AS itemType "
-                            "FROM videoversion"
-                            "  JOIN videoversiontype ON "
-                            "    videoversiontype.id = videoversion.idType "
+    m_pDS->query(PrepareSQL("SELECT name, idType as id, idMedia, mediaType, itemType "
+                            "FROM videoversion "
                             "WHERE videoversion.idFile = %i",
                             idFile));
 
@@ -12336,23 +12321,15 @@ bool CVideoDatabase::GetVideoVersionsNav(const std::string& strBaseDir,
     std::string strSQL;
 
     if (idMedia != -1)
-      strSQL =
-          PrepareSQL("SELECT videoversiontype.name AS name,"
-                     "  videoversiontype.id AS id "
-                     "FROM videoversiontype"
-                     "  JOIN videoversion ON"
-                     "    videoversion.idType = videoversiontype.id "
-                     "WHERE idMedia = %i AND mediaType = '%s' AND videoversiontype.itemType = %i",
-                     idMedia, mediaType.c_str(), VideoAssetType::VERSION);
+      strSQL = PrepareSQL("SELECT name, idType AS id "
+                          "FROM videoversion "
+                          "WHERE idMedia = %i AND mediaType = '%s' AND itemType = %i",
+                          idMedia, mediaType.c_str(), VideoAssetType::VERSION);
     else
-      strSQL = PrepareSQL(
-          "SELECT DISTINCT videoversiontype.name AS name,"
-          "  videoversiontype.id AS id "
-          "FROM videoversiontype"
-          "  JOIN videoversion ON"
-          "    videoversion.idType = videoversiontype.id "
-          "WHERE name != '' AND owner IN (%i, %i) AND videoversiontype.itemType = %i",
-          VideoAssetTypeOwner::SYSTEM, VideoAssetTypeOwner::USER, VideoAssetType::VERSION);
+      strSQL = PrepareSQL("SELECT DISTINCT name, idType AS id "
+                          "FROM videoversion "
+                          "WHERE name != '' AND itemType = %i",
+                          VideoAssetType::VERSION);
 
     m_pDS->query(strSQL);
 

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1031,6 +1031,10 @@ public:
                             VideoAssetType asset,
                             CFileItemList& items);
   void SetVideoVersionDefaultArt(int dbId, int idFrom, VideoDbContentType type);
+  /*!
+   * \brief OBSOLETE as of VideoDB 128. Used to pre-populate the videoversiontype table.
+   * \param schemaVersion[in] Database version
+   */
   void InitializeVideoVersionTypeTable(int schemaVersion);
   void UpdateVideoVersionTypeTable();
   bool GetVideoVersionsNav(const std::string& strBaseDir,

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1008,22 +1008,22 @@ public:
                              int dbIdTarget,
                              int idVideoVersion);
   void SetDefaultVideoVersion(VideoDbContentType itemType, int dbId, int idFile);
-  void SetVideoVersion(int idFile, int idVideoVersion);
-  int AddVideoVersionType(const std::string& typeVideoVersion,
-                          VideoAssetTypeOwner owner,
-                          VideoAssetType assetType);
+  void SetVideoVersion(int idFile, int idVideoVersion, const std::string& assetName);
   void AddVideoVersion(VideoDbContentType itemType,
                        int dbId,
                        int idVideoVersion,
+                       const std::string& assetName,
                        VideoAssetType videoAssetType,
                        CFileItem& item);
   void AddPrimaryVideoVersion(VideoDbContentType itemType,
                               int dbId,
                               int idVideoVersion,
+                              const std::string& assetName,
                               CFileItem& item);
   void AddExtrasVideoVersion(VideoDbContentType itemType,
                              int dbId,
                              int idVideoVersion,
+                             const std::string& assetName,
                              CFileItem& item);
   void RemoveVideoVersion(int dbId);
   bool IsDefaultVideoVersion(int idFile);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1027,9 +1027,7 @@ public:
                              CFileItem& item);
   void RemoveVideoVersion(int dbId);
   bool IsDefaultVideoVersion(int idFile);
-  bool GetVideoVersionTypes(VideoDbContentType idContent,
-                            VideoAssetType asset,
-                            CFileItemList& items);
+  bool GetUserAssetNames(VideoDbContentType idContent, VideoAssetType asset, CFileItemList& items);
   void SetVideoVersionDefaultArt(int dbId, int idFrom, VideoDbContentType type);
   /*!
    * \brief OBSOLETE as of VideoDB 128. Used to pre-populate the videoversiontype table.

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -2449,13 +2449,10 @@ namespace VIDEO
                       CURL::GetRedacted(item->GetPath()));
           }
 
-          const std::string typeVideoVersion =
-              CGUIDialogVideoManagerExtras::GenerateVideoExtra(path, item->GetPath());
+          const std::string extraName{
+              CGUIDialogVideoManagerExtras::GenerateVideoExtra(path, item->GetPath())};
 
-          const int idVideoVersion = m_database.AddVideoVersionType(
-              typeVideoVersion, VideoAssetTypeOwner::AUTO, VideoAssetType::EXTRA);
-
-          m_database.AddExtrasVideoVersion(ContentToVideoDbType(content), dbId, idVideoVersion,
+          m_database.AddExtrasVideoVersion(ContentToVideoDbType(content), dbId, 0, extraName,
                                            *item.get());
           CLog::Log(LOGDEBUG, "VideoInfoScanner: Added video extras {}",
                     CURL::GetRedacted(item->GetPath()));

--- a/xbmc/video/VideoManagerTypes.h
+++ b/xbmc/video/VideoManagerTypes.h
@@ -8,14 +8,6 @@
 
 #pragma once
 
-enum class VideoAssetTypeOwner
-{
-  UNKNOWN = -1,
-  SYSTEM = 0,
-  AUTO = 1,
-  USER = 2
-};
-
 enum class VideoAssetType
 {
   UNKNOWN = -1,

--- a/xbmc/video/VideoManagerTypes.h
+++ b/xbmc/video/VideoManagerTypes.h
@@ -24,6 +24,7 @@ enum class VideoAssetType
 };
 
 static constexpr int VIDEO_VERSION_ID_BEGIN = 40400;
-static constexpr int VIDEO_VERSION_ID_END = 40800;
+static constexpr int VIDEO_VERSION_ID_END = 40436; // Last used message. Update when adding messages
+static constexpr int VIDEO_VERSION_ID_MAX = 40800;
 static constexpr int VIDEO_VERSION_ID_DEFAULT = VIDEO_VERSION_ID_BEGIN;
 static constexpr int VIDEO_VERSION_ID_ALL = 0;

--- a/xbmc/video/dialogs/GUIDialogVideoManager.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -339,6 +339,37 @@ void CGUIDialogVideoManager::SetSelectedVideoAsset(const std::shared_ptr<CFileIt
   UpdateControls();
 }
 
+static void GetPredefinedVersionNames(CFileItemList& list)
+{
+  for (int id = VIDEO_VERSION_ID_BEGIN; id <= VIDEO_VERSION_ID_END; ++id)
+  {
+    const std::string name{g_localizeStrings.Get(id)};
+
+    const auto item{std::make_shared<CFileItem>(name)};
+    item->GetVideoInfoTag()->m_type = MediaTypeVideoVersion;
+    item->GetVideoInfoTag()->m_iDbId = id;
+    item->GetVideoInfoTag()->GetAssetInfo().SetId(id);
+    item->GetVideoInfoTag()->GetAssetInfo().SetTitle(name);
+    item->GetVideoInfoTag()->m_strTitle = name;
+
+    item->m_strTitle = name;
+    item->SetLabel(name);
+
+    list.Add(item);
+  }
+}
+
+static void GetPredefinedAssetNames(VideoAssetType assetType, CFileItemList& list)
+{
+  switch (assetType)
+  {
+    case VideoAssetType::VERSION:
+      return GetPredefinedVersionNames(list);
+    default:
+      return;
+  }
+}
+
 std::pair<int, std::string> CGUIDialogVideoManager::ChooseVideoAsset(
     const std::shared_ptr<CFileItem>& item, VideoAssetType assetType)
 {
@@ -364,9 +395,9 @@ std::pair<int, std::string> CGUIDialogVideoManager::ChooseVideoAsset(
     return std::pair{-1, ""};
   }
 
-  //! @todo db refactor: should not be version, but asset
   CFileItemList list;
-  videodb.GetVideoVersionTypes(itemType, assetType, list);
+  GetPredefinedAssetNames(assetType, list);
+  videodb.GetUserAssetNames(itemType, assetType, list);
 
   int assetId{-1};
   std::string assetTitle;

--- a/xbmc/video/dialogs/GUIDialogVideoManager.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.h
@@ -50,7 +50,8 @@ protected:
 
   void UpdateControls();
 
-  static int ChooseVideoAsset(const std::shared_ptr<CFileItem>& item, VideoAssetType assetType);
+  static std::pair<int, std::string> ChooseVideoAsset(const std::shared_ptr<CFileItem>& item,
+                                                      VideoAssetType assetType);
 
   CVideoDatabase m_database;
   std::shared_ptr<CFileItem> m_videoAsset;

--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
@@ -152,13 +152,10 @@ void CGUIDialogVideoManagerExtras::AddVideoExtra()
                  CURL::GetRedacted(item.GetPath()));
     }
 
-    const std::string typeNewVideoVersion{
+    const std::string extraName{
         CGUIDialogVideoManagerExtras::GenerateVideoExtra(URIUtils::GetFileName(path))};
 
-    const int idNewVideoVersion{m_database.AddVideoVersionType(
-        typeNewVideoVersion, VideoAssetTypeOwner::AUTO, VideoAssetType::EXTRA)};
-
-    m_database.AddExtrasVideoVersion(itemType, dbId, idNewVideoVersion, item);
+    m_database.AddExtrasVideoVersion(itemType, dbId, 0, extraName, item);
 
     // refresh data and controls
     Refresh();

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -265,9 +265,11 @@ void CGUIDialogVideoManagerVersions::AddVideoVersion()
                  CURL::GetRedacted(item.GetPath()));
     }
 
-    const int idNewVideoVersion{ChooseVideoAsset(m_videoAsset, VideoAssetType::VERSION)};
-    if (idNewVideoVersion != -1)
-      m_database.AddPrimaryVideoVersion(itemType, dbId, idNewVideoVersion, item);
+    const std::pair<int, std::string> idNewVideoVersion{
+        ChooseVideoAsset(m_videoAsset, VideoAssetType::VERSION)};
+    if (idNewVideoVersion.first != -1)
+      m_database.AddPrimaryVideoVersion(itemType, dbId, idNewVideoVersion.first,
+                                        idNewVideoVersion.second, item);
 
     // refresh data and controls
     Refresh();
@@ -290,11 +292,7 @@ std::tuple<int, std::string> CGUIDialogVideoManagerVersions::NewVideoVersion()
     return std::make_tuple(-1, "");
   }
 
-  typeVideoVersion = StringUtils::Trim(typeVideoVersion);
-  const int idVideoVersion{videodb.AddVideoVersionType(typeVideoVersion, VideoAssetTypeOwner::USER,
-                                                       VideoAssetType::VERSION)};
-
-  return std::make_tuple(idVideoVersion, typeVideoVersion);
+  return std::make_tuple(0, typeVideoVersion);
 }
 
 void CGUIDialogVideoManagerVersions::ManageVideoVersion(const std::shared_ptr<CFileItem>& item)
@@ -409,12 +407,13 @@ bool CGUIDialogVideoManagerVersions::ChooseVideoAndConvertToVideoVersion(
     return false;
 
   // choose a video version for the video
-  const int idVideoVersion{ChooseVideoAsset(selectedItem, VideoAssetType::VERSION)};
-  if (idVideoVersion < 0)
+  const std::pair<int, std::string> idVideoVersion{
+      ChooseVideoAsset(selectedItem, VideoAssetType::VERSION)};
+  if (idVideoVersion.first < 0)
     return false;
 
   videoDb.ConvertVideoToVersion(itemType, dbId, selectedItem->GetVideoInfoTag()->m_iDbId,
-                                idVideoVersion);
+                                idVideoVersion.first);
   return true;
 }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Idea discussed by chat with @ksooo, 90% implemented here, hence draft status.

Replaced the videoversiontype table with a "name" field in videoversion, one step closer to a generic "video asset" table discussed in Slack.

Per its name, "name" contains the name of the version / extra, either the localized name from a predefined list, or a user custom entry.

For the moment the idType field of videoversion still exists and repurposed to contain either the msgctxt of one of the predefined version names, or 0 for a user entered message.
The predefined version name is localized on the fly, avoiding the previous technique of storing the translations in the DB,, with refresh on GUI language change. Message translations are stored in a map, which should be plenty fast.

* Not done yet, unsure:
  *  Complete removal of idType.
I'm not sure because doing it will kill the ability to translate the predefined messages. User will still be able to select from the predefined list in his language, but the message will be stored in that language and won't be re-translated if the UI language changes afterwards. User will still have the ability to re-select from the predefined list in the new language.
Few people would notice (international Kodi setup? multiple profiles with different languages?)
It would simplify the code.
    * edit: we could have both if we were using the .po files like gettext (store in name the untranslated predefined message, run a gettext-like function to retrieve localization) but using the existing CLocalizeStrings is not built for that. Other disadvantage would be to push any sorting to C++ rather than DB, since sorting the untranslated strings in DB would be useless except in english.
  * Provided the ground work for a predefined list of extra names but that list has yet to be created as messages + a bit of code.
 
* Known broken, will fix:
  * default selection in choose version / manage screen when the default is one of multiple custom version names for the movie
  * navigation through all versions - mostly untested at this point and likely broken
  * commit messages to be improved
  * labels in manage screen / select version / new version/extra need change

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Simplify the data model

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
