### PR TITLE
[video] Video Versions/Extras: More smaller cleanup and fixes

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23754,7 +23754,7 @@ msgstr ""
 #. Manage video version dialog title
 #: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
 msgctxt "#40002"
-msgid "Convert into an additional version"
+msgid "Add as version to..."
 msgstr ""
 
 #empty string with id 40003
@@ -23867,10 +23867,10 @@ msgctxt "#40020"
 msgid "Are you sure to remove version \"{0:s}\"?"
 msgstr ""
 
-#. Convert video to version context menu item
+#. Add as version to a movie context menu item
 #: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
 msgctxt "#40021"
-msgid "Convert to version"
+msgid "Add as version to..."
 msgstr ""
 
 #. Manage video version dialog title

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1274,7 +1274,8 @@ int CVideoDatabase::GetMovieId(const std::string& strFilenameAndPath)
     if (idFile == -1)
       strSQL=PrepareSQL("select idMovie from movie join files on files.idFile=movie.idFile where files.idPath=%i",idPath);
     else
-      strSQL = PrepareSQL("select idMedia from videoversion where idFile = %i", idFile);
+      strSQL = PrepareSQL("SELECT idMedia FROM videoversion WHERE idFile = %i AND itemType = %i",
+                          idFile, VideoAssetType::VERSION);
 
     CLog::Log(LOGDEBUG, LOGDATABASE, "{} ({}), query = {}", __FUNCTION__,
               CURL::GetRedacted(strFilenameAndPath), strSQL);

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -12340,21 +12340,23 @@ bool CVideoDatabase::GetVideoVersionsNav(const std::string& strBaseDir,
     std::string strSQL;
 
     if (idMedia != -1)
-      strSQL = PrepareSQL("SELECT videoversiontype.name AS name,"
-                          "  videoversiontype.id AS id "
-                          "FROM videoversiontype"
-                          "  JOIN videoversion ON"
-                          "    videoversion.idType = videoversiontype.id "
-                          "WHERE idMedia = %i AND mediaType = '%s'",
-                          idMedia, mediaType.c_str());
+      strSQL =
+          PrepareSQL("SELECT videoversiontype.name AS name,"
+                     "  videoversiontype.id AS id "
+                     "FROM videoversiontype"
+                     "  JOIN videoversion ON"
+                     "    videoversion.idType = videoversiontype.id "
+                     "WHERE idMedia = %i AND mediaType = '%s' AND videoversiontype.itemType = %i",
+                     idMedia, mediaType.c_str(), VideoAssetType::VERSION);
     else
-      strSQL = PrepareSQL("SELECT DISTINCT videoversiontype.name AS name,"
-                          "  videoversiontype.id AS id "
-                          "FROM videoversiontype"
-                          "  JOIN videoversion ON"
-                          "    videoversion.idType = videoversiontype.id "
-                          "WHERE name != '' AND owner IN (%i, %i)",
-                          VideoAssetTypeOwner::SYSTEM, VideoAssetTypeOwner::USER);
+      strSQL = PrepareSQL(
+          "SELECT DISTINCT videoversiontype.name AS name,"
+          "  videoversiontype.id AS id "
+          "FROM videoversiontype"
+          "  JOIN videoversion ON"
+          "    videoversion.idType = videoversiontype.id "
+          "WHERE name != '' AND owner IN (%i, %i) AND videoversiontype.itemType = %i",
+          VideoAssetTypeOwner::SYSTEM, VideoAssetTypeOwner::USER, VideoAssetType::VERSION);
 
     m_pDS->query(strSQL);
 

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1076,7 +1076,7 @@ int CGUIDialogVideoInfo::ManageVideoItem(const std::shared_ptr<CFileItem>& item)
     buttons.Add(CONTEXT_BUTTON_SET_MOVIESET, 20465);
 
     if (!item->GetVideoInfoTag()->HasVideoVersions())
-      buttons.Add(CONTEXT_BUTTON_CONVERT_VIDEOVERSION, 40021); // Convert to version
+      buttons.Add(CONTEXT_BUTTON_CONVERT_VIDEOVERSION, 40021); // Add as version to...
 
     // manage video versions
     buttons.Add(CONTEXT_BUTTON_MANAGE_VIDEOVERSION, 40001); // Manage versions

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1075,11 +1075,11 @@ int CGUIDialogVideoInfo::ManageVideoItem(const std::shared_ptr<CFileItem>& item)
     // set or change movie set the movie belongs to
     buttons.Add(CONTEXT_BUTTON_SET_MOVIESET, 20465);
 
-    if (!item->GetVideoInfoTag()->HasVideoVersions())
-      buttons.Add(CONTEXT_BUTTON_CONVERT_VIDEOVERSION, 40021); // Add as version to...
-
     // manage video versions
     buttons.Add(CONTEXT_BUTTON_MANAGE_VIDEOVERSION, 40001); // Manage versions
+
+    if (!item->GetVideoInfoTag()->HasVideoVersions())
+      buttons.Add(CONTEXT_BUTTON_CONVERT_VIDEOVERSION, 40021); // Add as version to...
   }
 
   if (type == MediaTypeEpisode &&


### PR DESCRIPTION
Some smaller cleanups and fixes for Video Versions and Extras:

**1) Movie window -> node "Versions" does now only show what it says, versions, no extras anymore.**

Before:
![screenshot00000](https://github.com/xbmc/xbmc/assets/3226626/c9ddeb19-118a-42d2-8084-f360ddc609a0)

After:
![screenshot00002](https://github.com/xbmc/xbmc/assets/3226626/aef0a6c2-fe07-470c-8b27-5718d0fb6e5e)

**2) Fix: When playing an extra, the OSD contained the information of the movie the extra was attached to, which makes no sense, as the extra is not the movie itself. What is correct fpor versions, is not for extras.**

**3) Make the labels for video conversion more user friendly:**

![screenshot00005](https://github.com/xbmc/xbmc/assets/3226626/89b36b3b-1e5b-4898-8fd0-976d0753197a)
![screenshot00006](https://github.com/xbmc/xbmc/assets/3226626/cd312b4e-b3e5-4af4-b221-794d1a2e1b5d)

**4) Swapped position of context menu item "Add as version to..." and "Manage versions". Now, "Manage movie sets" and "Manage versions" are located next to each other, followed by "Add as version to...". See screen shot above.**