### PR TITLE
[Video] Improve default folder for "Add Extra" file picker

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
@@ -16,6 +16,7 @@
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogYesNo.h"
+#include "filesystem/Directory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
@@ -94,7 +95,8 @@ void CGUIDialogVideoManagerExtras::AddVideoExtra()
   CServiceBroker::GetMediaManager().GetLocalDrives(sources);
   CServiceBroker::GetMediaManager().GetNetworkLocations(sources);
 
-  std::string path;
+  std::string path{GetLikelyExtrasPath()};
+
   if (CGUIDialogFileBrowser::ShowAndGetFile(
           sources, CServiceBroker::GetFileExtensionProvider().GetVideoExtensions(),
           g_localizeStrings.Get(40015), path))
@@ -206,4 +208,21 @@ std::string CGUIDialogVideoManagerExtras::GenerateVideoExtra(const std::string& 
 
   // trim the string
   return StringUtils::Trim(extrasVersion);
+}
+
+std::string CGUIDialogVideoManagerExtras::GetLikelyExtrasPath()
+{
+  std::string path{URIUtils::GetDirectory(m_videoAsset->GetDynPath())};
+  CFileItemList items;
+
+  if (!XFILE::CDirectory::GetDirectory(path, items, "", XFILE::DIR_FLAG_DEFAULTS))
+    return path;
+
+  for (const auto& item : items)
+  {
+    if (item->m_bIsFolder && item->IsVideoExtras())
+      return item->GetPath();
+  }
+
+  return path;
 }

--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.h
@@ -40,4 +40,9 @@ protected:
 private:
   void AddVideoExtra();
   static std::string GenerateVideoExtra(const std::string& extrasPath);
+  /*!
+   * \brief Return a likely location for extras related to the movie
+   * \return path of the location
+  */
+  std::string GetLikelyExtrasPath();
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

When adding an extra to a movie, current master opens a file picker at the root of all local and network directories. It can mean a long navigation to the extra to be added.

This PR opens the file picker on the folder containing the movie that the extra will be added to, or an "extras" sub directory if it exists. An extra will most likely be located in one of those directories.

"Extras" is a fairly standard name that's already used by the scanner when updating the library as a likely container of extras.
This PR uses the same function as the scanner to detect directories that may contain extras, it would be easy to add other standard names. Or create an advanced settings for a custom list.

Q: I used `m_videoAsset->GetVideoInfoTag()->GetPath())` to retrieve the path of the movie but `m_videoAsset->GetDynPath()` would have worked too. Which one is best?

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Starting from the root of all sources to add an extra is not convenient.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local and smb paths.
Movie folders that contains extras sub directory or not, with varying capitalization (extras / Extras / EXTRAS)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Usable "Add Extra" button. Faster addition of extra to movie.

## Screenshots (if appropriate):
From Manage Extras of movie "Elephants Dream"
![image](https://github.com/xbmc/xbmc/assets/489377/f3692515-eb37-4591-9c2e-d138e365c25e)

Press "Add extra" and the file picker opens directly in the extras subfolder of the "Elephants Dream" directory:
![image](https://github.com/xbmc/xbmc/assets/489377/874ee938-ff0a-4bad-8342-643e2741f263)

Different movie, with a trailers sub directory that contains some extras but no extras sub directory: the file picker opens on the folder containing the movie:
![image](https://github.com/xbmc/xbmc/assets/489377/34de0191-84a5-4bce-93ac-6276a7668b2f)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
