### PR TITLE
[Video] Redesign of the "Add version" dialog of Manage versions

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23920,7 +23920,13 @@ msgctxt "#40029"
 msgid "Browse library"
 msgstr ""
 
-#empty strings with id 40030 to 40199
+#. Select the movie to be added as a version
+#: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+msgctxt "#40030"
+msgid "Select movie to add as a version"
+msgstr ""
+
+#empty strings with id 40031 to 40199
 
 #. Select default video version setting
 #: system/settings/settings.xml

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23926,7 +23926,13 @@ msgctxt "#40030"
 msgid "Select movie to add as a version"
 msgstr ""
 
-#empty strings with id 40031 to 40199
+#. No other movies found in the library
+#: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+msgctxt "#40031"
+msgid "No other movies found in the library."
+msgstr ""
+
+#empty strings with id 40032 to 40199
 
 #. Select default video version setting
 #: system/settings/settings.xml

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23932,7 +23932,13 @@ msgctxt "#40031"
 msgid "No other movies found in the library."
 msgstr ""
 
-#empty strings with id 40032 to 40199
+#. Add version: no similar movies were found in the library.
+#: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+msgctxt "#40032"
+msgid "No similar movies were found in the library."
+msgstr ""
+
+#empty strings with id 40033 to 40199
 
 #. Select default video version setting
 #: system/settings/settings.xml

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23908,7 +23908,19 @@ msgctxt "#40027"
 msgid "The selected video is the \"{0:s}\" extra of the movie \"{1:s}\". Would you like to move the extra to this movie?"
 msgstr ""
 
-#empty strings with id 40028 to 40199
+#. Browse the computer files for the file to be added as version
+#: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+msgctxt "#40028"
+msgid "Browse files"
+msgstr ""
+
+#. Browse the library for the movie to be added as version
+#: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+msgctxt "#40029"
+msgid "Browse library"
+msgstr ""
+
+#empty strings with id 40030 to 40199
 
 #. Select default video version setting
 #: system/settings/settings.xml

--- a/xbmc/dialogs/GUIDialogYesNo.cpp
+++ b/xbmc/dialogs/GUIDialogYesNo.cpp
@@ -142,10 +142,10 @@ bool CGUIDialogYesNo::ShowAndGetInput(const CVariant& heading,
                                       unsigned int autoCloseTime,
                                       int defaultButtonId /* = CONTROL_NO_BUTTON */)
 {
-  int result =
+  const DialogResult result =
       ShowAndGetInput(heading, text, noLabel, yesLabel, "", autoCloseTime, defaultButtonId);
 
-  bCanceled = result == -1;
+  bCanceled = result == DIALOG_RESULT_CANCEL;
   return result == 1;
 }
 
@@ -158,29 +158,30 @@ void CGUIDialogYesNo::Reset()
   m_defaultButtonId = CONTROL_NO_BUTTON;
 }
 
-int CGUIDialogYesNo::GetResult() const
+CGUIDialogYesNo::DialogResult CGUIDialogYesNo::GetResult() const
 {
   if (m_bCanceled)
-    return -1;
+    return DIALOG_RESULT_CANCEL;
   else if (m_bCustom)
-    return 2;
+    return DIALOG_RESULT_CUSTOM;
   else if (IsConfirmed())
-    return 1;
+    return DIALOG_RESULT_YES;
   else
-    return 0;
+    return DIALOG_RESULT_NO;
 }
 
-int CGUIDialogYesNo::ShowAndGetInput(const CVariant& heading,
-                                     const CVariant& text,
-                                     const CVariant& noLabel,
-                                     const CVariant& yesLabel,
-                                     const CVariant& customLabel,
-                                     unsigned int autoCloseTime,
-                                     int defaultButtonId /* = CONTROL_NO_BUTTON */)
+CGUIDialogYesNo::DialogResult CGUIDialogYesNo::ShowAndGetInput(
+    const CVariant& heading,
+    const CVariant& text,
+    const CVariant& noLabel,
+    const CVariant& yesLabel,
+    const CVariant& customLabel,
+    unsigned int autoCloseTime,
+    int defaultButtonId /* = CONTROL_NO_BUTTON */)
 {
   CGUIDialogYesNo *dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogYesNo>(WINDOW_DIALOG_YES_NO);
   if (!dialog)
-    return false;
+    return DIALOG_RESULT_CANCEL;
 
   dialog->SetHeading(heading);
   dialog->SetText(text);
@@ -197,7 +198,8 @@ int CGUIDialogYesNo::ShowAndGetInput(const CVariant& heading,
   return dialog->GetResult();
 }
 
-int CGUIDialogYesNo::ShowAndGetInput(const KODI::MESSAGING::HELPERS::DialogYesNoMessage& options)
+CGUIDialogYesNo::DialogResult CGUIDialogYesNo::ShowAndGetInput(
+    const KODI::MESSAGING::HELPERS::DialogYesNoMessage& options)
 {
   //Set default yes/no labels, these might be overwritten further down if specified
   //by the caller

--- a/xbmc/dialogs/GUIDialogYesNo.h
+++ b/xbmc/dialogs/GUIDialogYesNo.h
@@ -32,7 +32,16 @@ public:
   bool OnBack(int actionID) override;
 
   void Reset();
-  int GetResult() const;
+
+  enum DialogResult
+  {
+    DIALOG_RESULT_CANCEL = -1,
+    DIALOG_RESULT_NO = 0,
+    DIALOG_RESULT_YES = 1,
+    DIALOG_RESULT_CUSTOM = 2,
+  };
+
+  DialogResult GetResult() const;
 
   enum TimeOut
   {
@@ -122,15 +131,15 @@ public:
   \param customLabel Localized label id or string for the custom button
   \param autoCloseTime Time in ms before the dialog becomes automatically closed
   \param defaultButtonId Specifies the default focused button
-  \return -1 for cancelled, 0 for No, 1 for Yes and 2 for custom button
+  \return action that closed the dialog
   */
-  static int ShowAndGetInput(const CVariant& heading,
-                             const CVariant& text,
-                             const CVariant& noLabel,
-                             const CVariant& yesLabel,
-                             const CVariant& customLabel,
-                             unsigned int autoCloseTime,
-                             int defaultButtonId = CONTROL_NO_BUTTON);
+  static DialogResult ShowAndGetInput(const CVariant& heading,
+                                      const CVariant& text,
+                                      const CVariant& noLabel,
+                                      const CVariant& yesLabel,
+                                      const CVariant& customLabel,
+                                      unsigned int autoCloseTime,
+                                      int defaultButtonId = CONTROL_NO_BUTTON);
 
   /*!
     \brief Open a Yes/No dialog and wait for input
@@ -138,10 +147,10 @@ public:
     \param[in] options  a struct of type DialogYesNoMessage containing
                         the options to set for this dialog.
 
-    \returns -1 for cancelled, 0 for No and 1 for Yes
+    \returns action that closed the dialog
     \sa KODI::MESSAGING::HELPERS::DialogYesNoMessage
   */
-  int ShowAndGetInput(const KODI::MESSAGING::HELPERS::DialogYesNoMessage& options);
+  DialogResult ShowAndGetInput(const KODI::MESSAGING::HELPERS::DialogYesNoMessage& options);
 
 protected:
   void OnInitWindow() override;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -12025,7 +12025,7 @@ void CVideoDatabase::GetDefaultVideoVersion(VideoDbContentType itemType, int dbI
   }
 }
 
-void CVideoDatabase::ConvertVideoToVersion(VideoDbContentType itemType,
+bool CVideoDatabase::ConvertVideoToVersion(VideoDbContentType itemType,
                                            int dbIdSource,
                                            int dbIdTarget,
                                            int idVideoVersion)
@@ -12037,10 +12037,10 @@ void CVideoDatabase::ConvertVideoToVersion(VideoDbContentType itemType,
     idFile = GetFileIdByMovie(dbIdSource);
   }
   else
-    return;
+    return false;
 
   if (idFile < 0)
-    return;
+    return false;
 
   BeginTransaction();
 
@@ -12058,6 +12058,8 @@ void CVideoDatabase::ConvertVideoToVersion(VideoDbContentType itemType,
                             idFile));
 
   CommitTransaction();
+
+  return true;
 }
 
 void CVideoDatabase::SetDefaultVideoVersion(VideoDbContentType itemType, int dbId, int idFile)

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1003,7 +1003,7 @@ public:
                         CFileItemList& items,
                         VideoAssetType videoAssetType);
   void GetDefaultVideoVersion(VideoDbContentType itemType, int dbId, CFileItem& item);
-  void ConvertVideoToVersion(VideoDbContentType itemType,
+  bool ConvertVideoToVersion(VideoDbContentType itemType,
                              int dbIdSource,
                              int dbIdTarget,
                              int idVideoVersion);

--- a/xbmc/video/VideoManagerTypes.h
+++ b/xbmc/video/VideoManagerTypes.h
@@ -23,6 +23,12 @@ enum class VideoAssetType
   EXTRA = 1
 };
 
+enum class MediaRole
+{
+  NewVersion,
+  Parent
+};
+
 static constexpr int VIDEO_VERSION_ID_BEGIN = 40400;
 static constexpr int VIDEO_VERSION_ID_END = 40800;
 static constexpr int VIDEO_VERSION_ID_DEFAULT = VIDEO_VERSION_ID_BEGIN;

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -184,7 +184,48 @@ void CGUIDialogVideoManagerVersions::SetDefaultVideoVersion(const CFileItem& ver
 
 bool CGUIDialogVideoManagerVersions::AddVideoVersion()
 {
-  return AddVideoVersionFilePicker();
+  CFileItemList items;
+
+  CGUIDialogSelect* dialog{CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(
+      WINDOW_DIALOG_SELECT)};
+
+  if (!dialog)
+  {
+    CLog::LogF(LOGERROR, "Unable to get WINDOW_DIALOG_SELECT instance!");
+    return false;
+  }
+
+  // Load thumbs async
+  CVideoThumbLoader loader;
+  loader.Load(items);
+
+  dialog->Reset();
+  dialog->SetItems(items);
+  dialog->SetHeading(CVariant{40002});
+  dialog->SetUseDetails(true);
+  dialog->EnableButton(true, 40028); // Browse files
+  dialog->EnableButton2(true, 40029); // Browse library
+  dialog->Open();
+
+  if (loader.IsLoading())
+    loader.StopThread();
+
+  if (dialog->IsConfirmed())
+  {
+    // A similar movie was selected
+    return false;
+  }
+  else if (dialog->IsButtonPressed())
+  {
+    // User wants to browse the files
+    return AddVideoVersionFilePicker();
+  }
+  else if (dialog->IsButton2Pressed())
+  {
+    // User wants to browse the library
+    return false;
+  }
+  return false;
 }
 
 std::tuple<int, std::string> CGUIDialogVideoManagerVersions::NewVideoVersion()

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -552,6 +552,7 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
     const int idVideoVersion{m_database.GetVideoVersionInfo(path, idFile, typeVideoVersion, idMedia,
                                                             itemMediaType, videoAssetType)};
 
+    // @todo look only for a version identified by idFile instead of retrieving all versions
     if (idVideoVersion != -1)
     {
       CFileItemList versions;

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -58,7 +58,12 @@ bool CGUIDialogVideoManagerVersions::OnMessage(CGUIMessage& message)
       const int control{message.GetSenderId()};
       if (control == CONTROL_BUTTON_ADD_VERSION)
       {
-        AddVideoVersion();
+        if (AddVideoVersion())
+        {
+          // refresh data and controls
+          Refresh();
+          UpdateControls();
+        }
       }
       else if (control == CONTROL_BUTTON_SET_DEFAULT)
       {
@@ -177,9 +182,9 @@ void CGUIDialogVideoManagerVersions::SetDefaultVideoVersion(const CFileItem& ver
   CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
 }
 
-void CGUIDialogVideoManagerVersions::AddVideoVersion()
+bool CGUIDialogVideoManagerVersions::AddVideoVersion()
 {
-  AddVideoVersionFilePicker();
+  return AddVideoVersionFilePicker();
 }
 
 std::tuple<int, std::string> CGUIDialogVideoManagerVersions::NewVideoVersion()
@@ -377,7 +382,7 @@ bool CGUIDialogVideoManagerVersions::ProcessVideoVersion(VideoDbContentType item
   return ChooseVideoAndConvertToVideoVersion(list, itemType, mediaType, dbId, videodb);
 }
 
-void CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
+bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
 {
   const int dbId{m_videoAsset->GetVideoInfoTag()->m_iDbId};
   const MediaType mediaType{m_videoAsset->GetVideoInfoTag()->m_type};
@@ -414,7 +419,7 @@ void CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
       {
         CGUIDialogOK::ShowAndGetInput(
             CVariant{40014}, StringUtils::Format(g_localizeStrings.Get(40016), typeVideoVersion));
-        return;
+        return false;
       }
 
       if (itemMediaType == MediaTypeMovie)
@@ -422,13 +427,13 @@ void CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
         videoTitle = m_database.GetMovieTitle(idMedia);
       }
       else
-        return;
+        return false;
 
       if (!CGUIDialogYesNo::ShowAndGetInput(
               CVariant{40014},
               StringUtils::Format(g_localizeStrings.Get(40017), typeVideoVersion, videoTitle)))
       {
-        return;
+        return false;
       }
 
       if (m_database.IsDefaultVideoVersion(idFile))
@@ -439,7 +444,7 @@ void CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
         if (list.Size() > 1)
         {
           CGUIDialogOK::ShowAndGetInput(CVariant{40014}, CVariant{40019});
-          return;
+          return false;
         }
         else
         {
@@ -448,7 +453,7 @@ void CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
             m_database.DeleteMovie(idMedia);
           }
           else
-            return;
+            return false;
         }
       }
       else
@@ -469,8 +474,7 @@ void CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
     if (idNewVideoVersion != -1)
       m_database.AddPrimaryVideoVersion(itemType, dbId, idNewVideoVersion, item);
 
-    // refresh data and controls
-    Refresh();
-    UpdateControls();
+    return true;
   }
+  return false;
 }

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
@@ -18,6 +18,7 @@ class CFileItem;
 
 enum class VideoDbContentType;
 enum class VideoAssetType;
+enum class MediaRole;
 
 class CGUIDialogVideoManagerVersions : public CGUIDialogVideoManager
 {
@@ -53,19 +54,26 @@ private:
   void UpdateDefaultVideoVersionSelection();
 
   /*!
-   * \brief 
-   * \param items The items for the user to choose from
-   * \param itemType Type of the item being chosen
-   * \param mediaType "movie" ?
-   * \param dbId id of the video being added
-   * \param videoDb Databse connection
-   * \return 
-  */
+   * \brief Ask the user to choose an item from the list of items, the version type of the item,
+   * and perform the version conversion according to the role parameter.
+   * \param[in] items The items for the user to choose from
+   * \param[in] itemType Type of the item being chosen
+   * \param[in] mediaType ?
+   * \param[in] dbId id of the video being added if role is NewVersion, id of the video being added
+   * to if role is Parent
+   * \param[in] videoDb Database connection
+   * \param[in] role NewVersion: dbId will be converted to a version of the movie chosen by
+   * the user from the whole libray.
+   * Parent: dbId will have another movie chosen by the user from the whole library as a new version.
+   *
+   * \return True: success, a version was created and attached, false otherwise.
+   */
   static bool ChooseVideoAndConvertToVideoVersion(CFileItemList& items,
                                                   VideoDbContentType itemType,
                                                   const std::string& mediaType,
                                                   int dbId,
-                                                  CVideoDatabase& videoDb);
+                                                  CVideoDatabase& videoDb,
+                                                  MediaRole role);
   /*!
    * \brief Use a file picker to select a file to add as a new version of a movie.
    * \return True when a version was added, false otherwise
@@ -86,6 +94,17 @@ private:
    * \return True for success, false otherwse
    */
   bool AddSimilarMovieAsVersion(const std::shared_ptr<CFileItem> itemMovie);
+
+  /*!
+   * \brief Populates a list with all movies of the libray, excluding the item provided as parameter.
+   * \param[in] item The item that will be excluded from the list
+   * \param[out] list List to populate
+   * \param[in] videoDb Database connection
+   * \return True for success, false otherwise.
+   */
+  static bool GetAllOtherMovies(const std::shared_ptr<CFileItem>& item,
+                                CFileItemList& list,
+                                CVideoDatabase& videoDb);
 
   std::shared_ptr<CFileItem> m_defaultVideoVersion;
 };

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
@@ -52,6 +52,15 @@ private:
   void SetDefault();
   void UpdateDefaultVideoVersionSelection();
 
+  /*!
+   * \brief 
+   * \param items The items for the user to choose from
+   * \param itemType Type of the item being chosen
+   * \param mediaType "movie" ?
+   * \param dbId id of the video being added
+   * \param videoDb Databse connection
+   * \return 
+  */
   static bool ChooseVideoAndConvertToVideoVersion(CFileItemList& items,
                                                   VideoDbContentType itemType,
                                                   const std::string& mediaType,
@@ -62,6 +71,21 @@ private:
    * \return True when a version was added, false otherwise
    */
   bool AddVideoVersionFilePicker();
+
+  /*!
+   * \brief Populates a list of movies of the library that are similar to the video asset of the
+   * dialog
+   * \param[out] list The list of movies
+   * \return True for success, false otherwise
+   */
+  bool GetSimilarMovies(CFileItemList& list);
+
+  /*!
+   * \brief Convert the movie into a version
+   * \param itemMovie Movie to convert
+   * \return True for success, false otherwse
+   */
+  bool AddSimilarMovieAsVersion(const std::shared_ptr<CFileItem> itemMovie);
 
   std::shared_ptr<CFileItem> m_defaultVideoVersion;
 };

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
@@ -44,7 +44,11 @@ protected:
 
 private:
   void SetDefaultVideoVersion(const CFileItem& version);
-  void AddVideoVersion();
+  /*!
+   * \brief Prompt the user to select a file / movie to add as version
+   * \return true if a version was added, false otherwise.
+   */
+  bool AddVideoVersion();
   void SetDefault();
   void UpdateDefaultVideoVersionSelection();
 
@@ -55,8 +59,9 @@ private:
                                                   CVideoDatabase& videoDb);
   /*!
    * \brief Use a file picker to select a file to add as a new version of a movie.
+   * \return True when a version was added, false otherwise
    */
-  void AddVideoVersionFilePicker();
+  bool AddVideoVersionFilePicker();
 
   std::shared_ptr<CFileItem> m_defaultVideoVersion;
 };

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
@@ -53,6 +53,10 @@ private:
                                                   const std::string& mediaType,
                                                   int dbId,
                                                   CVideoDatabase& videoDb);
+  /*!
+   * \brief Use a file picker to select a file to add as a new version of a movie.
+   */
+  void AddVideoVersionFilePicker();
 
   std::shared_ptr<CFileItem> m_defaultVideoVersion;
 };

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
@@ -81,12 +81,16 @@ private:
   bool AddVideoVersionFilePicker();
 
   /*!
-   * \brief Populates a list of movies of the library that are similar to the video asset of the
-   * dialog
-   * \param[out] list The list of movies
+   * \brief Populates a list of movies of the library that are similar to the item provided as
+   * parameter.
+   * \param[in] item The reference item
+   * \param[out] list List to populate
+   * \param[in] videoDb Database connection
    * \return True for success, false otherwise
    */
-  bool GetSimilarMovies(CFileItemList& list);
+  static bool GetSimilarMovies(const std::shared_ptr<CFileItem>& item,
+                               CFileItemList& list,
+                               CVideoDatabase& videoDb);
 
   /*!
    * \brief Convert the movie into a version
@@ -105,6 +109,14 @@ private:
   static bool GetAllOtherMovies(const std::shared_ptr<CFileItem>& item,
                                 CFileItemList& list,
                                 CVideoDatabase& videoDb);
+
+  /*!
+   * \brief Shared post processing of lists after extraction and before display
+   * \param[in,out] list the list of movies
+   * \param[in] dbId item to remove from the list
+   * \return True for success, false otherwise.
+   */
+  static bool PostProcessList(CFileItemList& list, int dbId);
 
   std::shared_ptr<CFileItem> m_defaultVideoVersion;
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Redesign of the "Add version" dialog of the Manage versions dialog, as discussed in Slack
* Offer similar movies from the library at first (same imdb id/tmdb id or same name and year)
* Buttons for alternative search methods
  * file picker to search in the file system videos that were not added to the library
  * selection from the whole library if the wanted movie was not in the similar movies shortlist

![image](https://github.com/xbmc/xbmc/assets/489377/c06553e2-22b4-4e26-9e9c-1ec61cf09087)

This is a select dialog. The diff may look large but this is mostly shuffling / copying of existing code, followed by some refactor (more left to do ideally...) See the intermediate commits for the step by step transformations. Validations of various strange situations kept as is, no more no less.

Left to do: 
* there already is a message "Browse files" in strings.po but I wasn't sure if the context was similar enough to reuse it.

not caused by the PR, existing wrong behavior: extras of a movie are lost when turning the movie into a version.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
User feedback and team consensus on the evolution of the button functionality.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Sqlite and Maria DB, movies that have similar movies in db or not.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Easier to use versions functionality.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
