### PR TITLE
CXbtManager: Synchronize access to internal data structures

### DIFF
--- a/xbmc/filesystem/XbtManager.cpp
+++ b/xbmc/filesystem/XbtManager.cpp
@@ -29,11 +29,13 @@ CXbtManager& CXbtManager::GetInstance()
 
 bool CXbtManager::HasFiles(const CURL& path) const
 {
+  std::lock_guard l(m_lock);
   return ProcessFile(path) != m_readers.end();
 }
 
 bool CXbtManager::GetFiles(const CURL& path, std::vector<CXBTFFile>& files) const
 {
+  std::lock_guard l(m_lock);
   const auto& reader = ProcessFile(path);
   if (reader == m_readers.end())
     return false;
@@ -44,6 +46,7 @@ bool CXbtManager::GetFiles(const CURL& path, std::vector<CXBTFFile>& files) cons
 
 bool CXbtManager::GetReader(const CURL& path, CXBTFReaderPtr& reader) const
 {
+  std::lock_guard l(m_lock);
   const auto& it = ProcessFile(path);
   if (it == m_readers.end())
     return false;
@@ -54,6 +57,7 @@ bool CXbtManager::GetReader(const CURL& path, CXBTFReaderPtr& reader) const
 
 void CXbtManager::Release(const CURL& path)
 {
+  std::lock_guard l(m_lock);
   const auto& it = GetReader(path);
   if (it == m_readers.end())
     return;

--- a/xbmc/filesystem/XbtManager.h
+++ b/xbmc/filesystem/XbtManager.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "guilib/XBTFReader.h"
+#include "threads/CriticalSection.h"
 
 #include <map>
 #include <memory>
@@ -54,5 +55,6 @@ private:
   static std::string NormalizePath(const CURL& path);
 
   mutable XBTFReaders m_readers;
+  mutable CCriticalSection m_lock;
 };
 }


### PR DESCRIPTION
## Description
Thread Sanitizer complained about a data race (there are more similar ones concerning `CXbtManager`):

<details>
<summary>Thread Sanitizer output</summary>

```
==================
WARNING: ThreadSanitizer: data race (pid=45819)
  Read of size 8 at 0x7b1800272650 by thread T220:
    #0 std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>>::_S_left(std::_Rb_tree_node_base*) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/stl_tree.h:782:45 (kodi.bin+0x49edc5d) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #1 std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>>::_M_lower_bound(std::_Rb_tree_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>*, std::_Rb_tree_node_base*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/stl_tree.h:1953:21 (kodi.bin+0x49ee857) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #2 std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>>::lower_bound(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/stl_tree.h:1271:16 (kodi.bin+0x49ef296) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #3 std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>>::lower_bound(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/stl_map.h:1309:21 (kodi.bin+0x49ef005) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #4 std::enable_if<is_constructible<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader>>::value, std::pair<std::_Rb_tree_iterator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>, bool>>::type std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>>::insert<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader>>(std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/stl_map.h:857:20 (kodi.bin+0x49ed727) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #5 XFILE::CXbtManager::ProcessFile[abi:cxx11](CURL const&) const xbmc/filesystem/XbtManager.cpp:115:61 (kodi.bin+0x49ec572) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #6 XFILE::CXbtManager::GetReader(CURL const&, std::shared_ptr<CXBTFReader>&) const xbmc/filesystem/XbtManager.cpp:47:20 (kodi.bin+0x49ec8e5) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #7 XFILE::CXbtFile::GetReader(CURL const&, std::shared_ptr<CXBTFReader>&) xbmc/filesystem/XbtFile.cpp:344:37 (kodi.bin+0x49ea68f) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #8 XFILE::CXbtFile::GetReaderAndFile(CURL const&, std::shared_ptr<CXBTFReader>&, CXBTFFile&) xbmc/filesystem/XbtFile.cpp:349:8 (kodi.bin+0x49e87a2) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #9 XFILE::CXbtFile::Open(CURL const&) xbmc/filesystem/XbtFile.cpp:49:8 (kodi.bin+0x49e83b2) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #10 XFILE::CFile::Open(CURL const&, unsigned int) xbmc/filesystem/File.cpp:331:21 (kodi.bin+0x4976197) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #11 XFILE::CFile::Open(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, unsigned int) xbmc/filesystem/File.cpp:242:10 (kodi.bin+0x4972a0f) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #12 XFILE::COverrideFile::Open(CURL const&) xbmc/filesystem/OverrideFile.cpp:32:17 (kodi.bin+0x499f5bd) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #13 XFILE::CFile::Open(CURL const&, unsigned int) xbmc/filesystem/File.cpp:331:21 (kodi.bin+0x4976197) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #14 XFILE::CFile::LoadFile(CURL const&, std::vector<unsigned char, std::allocator<unsigned char>>&) xbmc/filesystem/File.cpp:994:8 (kodi.bin+0x497a69a) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #15 XFILE::CFile::LoadFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::vector<unsigned char, std::allocator<unsigned char>>&) xbmc/filesystem/File.cpp:983:10 (kodi.bin+0x497a543) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #16 CTexture::LoadFromFileInternal(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, unsigned int, unsigned int, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) xbmc/guilib/Texture.cpp:264:12 (kodi.bin+0x368da11) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #17 CTexture::LoadFromFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, unsigned int, unsigned int, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) xbmc/guilib/Texture.cpp:221:16 (kodi.bin+0x368d487) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #18 CImageLoader::DoWork() xbmc/GUILargeTextureManager.cpp:54:9 (kodi.bin+0x3c4424c) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #19 CJobWorker::Process() xbmc/utils/JobManager.cpp:55:22 (kodi.bin+0x30945ce) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #20 CThread::Action() xbmc/threads/Thread.cpp:283:5 (kodi.bin+0x326241b) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #21 CThread::Create(bool)::$_0::operator()(CThread*, std::promise<bool>) const xbmc/threads/Thread.cpp:152:18 (kodi.bin+0x32631cb) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #22 void std::__invoke_impl<void, CThread::Create(bool)::$_0, CThread*, std::promise<bool>>(std::__invoke_other, CThread::Create(bool)::$_0&&, CThread*&&, std::promise<bool>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/invoke.h:61:14 (kodi.bin+0x3262d2c) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #23 std::__invoke_result<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>::type std::__invoke<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>(CThread::Create(bool)::$_0&&, CThread*&&, std::promise<bool>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/invoke.h:96:14 (kodi.bin+0x3262bb5) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #24 void std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>>::_M_invoke<0ul, 1ul, 2ul>(std::_Index_tuple<0ul, 1ul, 2ul>) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:292:13 (kodi.bin+0x3262b43) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #25 std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>>::operator()() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:299:11 (kodi.bin+0x3262ac5) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #26 std::thread::_State_impl<std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>>>::_M_run() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:244:13 (kodi.bin+0x3262869) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #27 execute_native_thread_routine /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++11/thread.cc:104:18 (libstdc++.so.6+0xe1942) (BuildId: 207eb738c5976dd9aac1ae0640fc4de5946b547e)

  Previous write of size 8 at 0x7b1800272650 by thread T219:
    #0 operator new(unsigned long) <null> (kodi.bin+0x23afcf9) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #1 std::__new_allocator<std::_Rb_tree_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>>::allocate(unsigned long, void const*) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/new_allocator.h:147:27 (kodi.bin+0x49eff58) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #2 std::allocator_traits<std::allocator<std::_Rb_tree_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>>>::allocate(std::allocator<std::_Rb_tree_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>>&, unsigned long) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/alloc_traits.h:482:20 (kodi.bin+0x49efdf2) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #3 std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>>::_M_get_node() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/stl_tree.h:563:16 (kodi.bin+0x49efdf2)
    #4 std::_Rb_tree_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>* std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>>::_M_create_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader>>(std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/stl_tree.h:613:23 (kodi.bin+0x49efd55) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #5 std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>>::_Auto_node::_Auto_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader>>(std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>>&, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/stl_tree.h:1637:18 (kodi.bin+0x49ef559) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #6 std::_Rb_tree_iterator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>> std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>>::_M_emplace_hint_unique<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader>>(std::_Rb_tree_const_iterator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/stl_tree.h:2462:13 (kodi.bin+0x49ef355) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #7 std::_Rb_tree_iterator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>> std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>>::emplace_hint<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader>>(std::_Rb_tree_const_iterator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/stl_map.h:640:16 (kodi.bin+0x49ef13c) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #8 std::enable_if<is_constructible<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader>>::value, std::pair<std::_Rb_tree_iterator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>, bool>>::type std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>>::insert<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader>>(std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/stl_map.h:860:15 (kodi.bin+0x49ed7d1) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #9 XFILE::CXbtManager::ProcessFile[abi:cxx11](CURL const&) const xbmc/filesystem/XbtManager.cpp:115:61 (kodi.bin+0x49ec572) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #10 XFILE::CXbtManager::GetReader(CURL const&, std::shared_ptr<CXBTFReader>&) const xbmc/filesystem/XbtManager.cpp:47:20 (kodi.bin+0x49ec8e5) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #11 XFILE::CXbtFile::GetReader(CURL const&, std::shared_ptr<CXBTFReader>&) xbmc/filesystem/XbtFile.cpp:344:37 (kodi.bin+0x49ea68f) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #12 XFILE::CXbtFile::GetReaderAndFile(CURL const&, std::shared_ptr<CXBTFReader>&, CXBTFFile&) xbmc/filesystem/XbtFile.cpp:349:8 (kodi.bin+0x49e87a2) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #13 XFILE::CXbtFile::Open(CURL const&) xbmc/filesystem/XbtFile.cpp:49:8 (kodi.bin+0x49e83b2) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #14 XFILE::CFile::Open(CURL const&, unsigned int) xbmc/filesystem/File.cpp:331:21 (kodi.bin+0x4976197) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #15 XFILE::CFile::Open(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, unsigned int) xbmc/filesystem/File.cpp:242:10 (kodi.bin+0x4972a0f) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #16 XFILE::COverrideFile::Open(CURL const&) xbmc/filesystem/OverrideFile.cpp:32:17 (kodi.bin+0x499f5bd) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #17 XFILE::CFile::Open(CURL const&, unsigned int) xbmc/filesystem/File.cpp:331:21 (kodi.bin+0x4976197) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #18 XFILE::CFile::LoadFile(CURL const&, std::vector<unsigned char, std::allocator<unsigned char>>&) xbmc/filesystem/File.cpp:994:8 (kodi.bin+0x497a69a) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #19 XFILE::CFile::LoadFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::vector<unsigned char, std::allocator<unsigned char>>&) xbmc/filesystem/File.cpp:983:10 (kodi.bin+0x497a543) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #20 CTexture::LoadFromFileInternal(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, unsigned int, unsigned int, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) xbmc/guilib/Texture.cpp:264:12 (kodi.bin+0x368da11) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #21 CTexture::LoadFromFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, unsigned int, unsigned int, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) xbmc/guilib/Texture.cpp:221:16 (kodi.bin+0x368d487) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #22 CImageLoader::DoWork() xbmc/GUILargeTextureManager.cpp:54:9 (kodi.bin+0x3c4424c) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #23 CJobWorker::Process() xbmc/utils/JobManager.cpp:55:22 (kodi.bin+0x30945ce) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #24 CThread::Action() xbmc/threads/Thread.cpp:283:5 (kodi.bin+0x326241b) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #25 CThread::Create(bool)::$_0::operator()(CThread*, std::promise<bool>) const xbmc/threads/Thread.cpp:152:18 (kodi.bin+0x32631cb) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #26 void std::__invoke_impl<void, CThread::Create(bool)::$_0, CThread*, std::promise<bool>>(std::__invoke_other, CThread::Create(bool)::$_0&&, CThread*&&, std::promise<bool>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/invoke.h:61:14 (kodi.bin+0x3262d2c) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #27 std::__invoke_result<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>::type std::__invoke<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>(CThread::Create(bool)::$_0&&, CThread*&&, std::promise<bool>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/invoke.h:96:14 (kodi.bin+0x3262bb5) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #28 void std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>>::_M_invoke<0ul, 1ul, 2ul>(std::_Index_tuple<0ul, 1ul, 2ul>) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:292:13 (kodi.bin+0x3262b43) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #29 std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>>::operator()() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:299:11 (kodi.bin+0x3262ac5) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #30 std::thread::_State_impl<std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>>>::_M_run() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:244:13 (kodi.bin+0x3262869) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #31 execute_native_thread_routine /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++11/thread.cc:104:18 (libstdc++.so.6+0xe1942) (BuildId: 207eb738c5976dd9aac1ae0640fc4de5946b547e)

  Location is heap block of size 88 at 0x7b1800272640 allocated by thread T219:
    #0 operator new(unsigned long) <null> (kodi.bin+0x23afcf9) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #1 std::__new_allocator<std::_Rb_tree_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>>::allocate(unsigned long, void const*) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/new_allocator.h:147:27 (kodi.bin+0x49eff58) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #2 std::allocator_traits<std::allocator<std::_Rb_tree_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>>>::allocate(std::allocator<std::_Rb_tree_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>>&, unsigned long) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/alloc_traits.h:482:20 (kodi.bin+0x49efdf2) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #3 std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>>::_M_get_node() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/stl_tree.h:563:16 (kodi.bin+0x49efdf2)
    #4 std::_Rb_tree_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>* std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>>::_M_create_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader>>(std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/stl_tree.h:613:23 (kodi.bin+0x49efd55) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #5 std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>>::_Auto_node::_Auto_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader>>(std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>>&, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/stl_tree.h:1637:18 (kodi.bin+0x49ef559) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #6 std::_Rb_tree_iterator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>> std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>>::_M_emplace_hint_unique<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader>>(std::_Rb_tree_const_iterator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/stl_tree.h:2462:13 (kodi.bin+0x49ef355) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #7 std::_Rb_tree_iterator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>> std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>>::emplace_hint<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader>>(std::_Rb_tree_const_iterator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/stl_map.h:640:16 (kodi.bin+0x49ef13c) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #8 std::enable_if<is_constructible<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader>>::value, std::pair<std::_Rb_tree_iterator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>, bool>>::type std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>>::insert<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader>>(std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, XFILE::CXbtManager::XBTFReader>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/stl_map.h:860:15 (kodi.bin+0x49ed7d1) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #9 XFILE::CXbtManager::ProcessFile[abi:cxx11](CURL const&) const xbmc/filesystem/XbtManager.cpp:115:61 (kodi.bin+0x49ec572) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #10 XFILE::CXbtManager::GetReader(CURL const&, std::shared_ptr<CXBTFReader>&) const xbmc/filesystem/XbtManager.cpp:47:20 (kodi.bin+0x49ec8e5) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #11 XFILE::CXbtFile::GetReader(CURL const&, std::shared_ptr<CXBTFReader>&) xbmc/filesystem/XbtFile.cpp:344:37 (kodi.bin+0x49ea68f) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #12 XFILE::CXbtFile::GetReaderAndFile(CURL const&, std::shared_ptr<CXBTFReader>&, CXBTFFile&) xbmc/filesystem/XbtFile.cpp:349:8 (kodi.bin+0x49e87a2) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #13 XFILE::CXbtFile::Open(CURL const&) xbmc/filesystem/XbtFile.cpp:49:8 (kodi.bin+0x49e83b2) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #14 XFILE::CFile::Open(CURL const&, unsigned int) xbmc/filesystem/File.cpp:331:21 (kodi.bin+0x4976197) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #15 XFILE::CFile::Open(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, unsigned int) xbmc/filesystem/File.cpp:242:10 (kodi.bin+0x4972a0f) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #16 XFILE::COverrideFile::Open(CURL const&) xbmc/filesystem/OverrideFile.cpp:32:17 (kodi.bin+0x499f5bd) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #17 XFILE::CFile::Open(CURL const&, unsigned int) xbmc/filesystem/File.cpp:331:21 (kodi.bin+0x4976197) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #18 XFILE::CFile::LoadFile(CURL const&, std::vector<unsigned char, std::allocator<unsigned char>>&) xbmc/filesystem/File.cpp:994:8 (kodi.bin+0x497a69a) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #19 XFILE::CFile::LoadFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::vector<unsigned char, std::allocator<unsigned char>>&) xbmc/filesystem/File.cpp:983:10 (kodi.bin+0x497a543) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #20 CTexture::LoadFromFileInternal(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, unsigned int, unsigned int, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) xbmc/guilib/Texture.cpp:264:12 (kodi.bin+0x368da11) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #21 CTexture::LoadFromFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, unsigned int, unsigned int, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) xbmc/guilib/Texture.cpp:221:16 (kodi.bin+0x368d487) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #22 CImageLoader::DoWork() xbmc/GUILargeTextureManager.cpp:54:9 (kodi.bin+0x3c4424c) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #23 CJobWorker::Process() xbmc/utils/JobManager.cpp:55:22 (kodi.bin+0x30945ce) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #24 CThread::Action() xbmc/threads/Thread.cpp:283:5 (kodi.bin+0x326241b) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #25 CThread::Create(bool)::$_0::operator()(CThread*, std::promise<bool>) const xbmc/threads/Thread.cpp:152:18 (kodi.bin+0x32631cb) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #26 void std::__invoke_impl<void, CThread::Create(bool)::$_0, CThread*, std::promise<bool>>(std::__invoke_other, CThread::Create(bool)::$_0&&, CThread*&&, std::promise<bool>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/invoke.h:61:14 (kodi.bin+0x3262d2c) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #27 std::__invoke_result<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>::type std::__invoke<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>(CThread::Create(bool)::$_0&&, CThread*&&, std::promise<bool>&&) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/invoke.h:96:14 (kodi.bin+0x3262bb5) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #28 void std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>>::_M_invoke<0ul, 1ul, 2ul>(std::_Index_tuple<0ul, 1ul, 2ul>) /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:292:13 (kodi.bin+0x3262b43) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #29 std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>>::operator()() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:299:11 (kodi.bin+0x3262ac5) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #30 std::thread::_State_impl<std::thread::_Invoker<std::tuple<CThread::Create(bool)::$_0, CThread*, std::promise<bool>>>>::_M_run() /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/std_thread.h:244:13 (kodi.bin+0x3262869) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #31 execute_native_thread_routine /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++11/thread.cc:104:18 (libstdc++.so.6+0xe1942) (BuildId: 207eb738c5976dd9aac1ae0640fc4de5946b547e)

  Thread T220 'JobWorker' (tid=47058, running) created by main thread at:
    #0 pthread_create <null> (kodi.bin+0x232be56) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #1 __gthread_create /usr/src/debug/gcc/gcc-build/x86_64-pc-linux-gnu/libstdc++-v3/include/x86_64-pc-linux-gnu/bits/gthr-default.h:663:35 (libstdc++.so.6+0xe1a29) (BuildId: 207eb738c5976dd9aac1ae0640fc4de5946b547e)
    #2 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State>>, void (*)()) /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++11/thread.cc:172:37 (libstdc++.so.6+0xe1a29)
    #3 CThread::Create(bool) xbmc/threads/Thread.cpp:118:20 (kodi.bin+0x3261846) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #4 CJobWorker::CJobWorker(CJobManager*) xbmc/utils/JobManager.cpp:32:3 (kodi.bin+0x30941ad) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #5 CJobManager::StartWorkers(CJob::PRIORITY) xbmc/utils/JobManager.cpp:288:27 (kodi.bin+0x3097138) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #6 CJobManager::AddJob(CJob*, IJobCallback*, CJob::PRIORITY) xbmc/utils/JobManager.cpp:247:3 (kodi.bin+0x3096424) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #7 CGUILargeTextureManager::QueueImage(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, bool) xbmc/GUILargeTextureManager.cpp:225:57 (kodi.bin+0x3c454ed) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #8 CGUILargeTextureManager::GetImage(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, CTextureArray&, bool, bool) xbmc/GUILargeTextureManager.cpp:174:5 (kodi.bin+0x3c45208) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #9 CGUITexture::AllocResources() xbmc/guilib/GUITexture.cpp:335:62 (kodi.bin+0x3626153) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #10 CGUIImage::AllocResources() xbmc/guilib/GUIImage.cpp:246:14 (kodi.bin+0x35a4d68) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #11 CGUIBorderedImage::AllocResources() xbmc/guilib/GUIBorderedImage.cpp:73:14 (kodi.bin+0x34ed246) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #12 CGUIImage::AllocateOnDemand() xbmc/guilib/GUIImage.cpp:102:5 (kodi.bin+0x35a3a49) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #13 CGUIImage::UpdateVisibility(CGUIListItem const*) xbmc/guilib/GUIImage.cpp:60:3 (kodi.bin+0x35a3617) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #14 CGUIListGroup::UpdateInfo(CGUIListItem const*) xbmc/guilib/GUIListGroup.cpp:103:12 (kodi.bin+0x35c66b5) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #15 CGUIListGroup::UpdateInfo(CGUIListItem const*) xbmc/guilib/GUIListGroup.cpp:102:12 (kodi.bin+0x35c666f) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #16 CGUIListGroup::UpdateInfo(CGUIListItem const*) xbmc/guilib/GUIListGroup.cpp:102:12 (kodi.bin+0x35c666f) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #17 CGUIListItemLayout::Process(CGUIListItem*, int, unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIListItemLayout.cpp:73:13 (kodi.bin+0x35d3c45) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #18 CGUIBaseContainer::ProcessItem(float, float, std::shared_ptr<CGUIListItem>&, bool, unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIBaseContainer.cpp:245:26 (kodi.bin+0x34dbe57) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #19 CGUIPanelContainer::Process(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIPanelContainer.cpp:72:9 (kodi.bin+0x35e0d16) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #20 CGUIControl::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIControl.cpp:143:5 (kodi.bin+0x3501cac) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #21 CGUIBaseContainer::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIBaseContainer.cpp:116:16 (kodi.bin+0x34da185) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #22 CGUIControlGroupList::Process(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIControlGroupList.cpp:78:14 (kodi.bin+0x3534f93) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #23 CGUIControl::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIControl.cpp:143:5 (kodi.bin+0x3501cac) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #24 CGUIControlGroup::Process(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIControlGroup.cpp:93:14 (kodi.bin+0x352b12d) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #25 CGUIControl::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIControl.cpp:143:5 (kodi.bin+0x3501cac) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #26 CGUIControlGroup::Process(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIControlGroup.cpp:93:14 (kodi.bin+0x352b12d) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #27 CGUIControl::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIControl.cpp:143:5 (kodi.bin+0x3501cac) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #28 CGUIControlGroup::Process(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIControlGroup.cpp:93:14 (kodi.bin+0x352b12d) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #29 CGUIControl::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIControl.cpp:143:5 (kodi.bin+0x3501cac) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #30 CGUIControlGroup::Process(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIControlGroup.cpp:93:14 (kodi.bin+0x352b12d) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #31 CGUIControl::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIControl.cpp:143:5 (kodi.bin+0x3501cac) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #32 CGUIWindow::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIWindow.cpp:330:21 (kodi.bin+0x363a517) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #33 CGUIWindowManager::Process(unsigned int) xbmc/guilib/GUIWindowManager.cpp:1217:14 (kodi.bin+0x3653d1d) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #34 CApplication::FrameMove(bool, bool) xbmc/application/Application.cpp:1857:54 (kodi.bin+0x37ca1dd) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #35 CApplication::Run() xbmc/application/Application.cpp:1903:7 (kodi.bin+0x37ca697) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #36 XBMC_Run xbmc/platform/xbmc.cpp:61:26 (kodi.bin+0x32e1b91) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #37 main xbmc/platform/posix/main.cpp:70:16 (kodi.bin+0x23b0315) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)

  Thread T219 'JobWorker' (tid=47057, running) created by main thread at:
    #0 pthread_create <null> (kodi.bin+0x232be56) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #1 __gthread_create /usr/src/debug/gcc/gcc-build/x86_64-pc-linux-gnu/libstdc++-v3/include/x86_64-pc-linux-gnu/bits/gthr-default.h:663:35 (libstdc++.so.6+0xe1a29) (BuildId: 207eb738c5976dd9aac1ae0640fc4de5946b547e)
    #2 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State>>, void (*)()) /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++11/thread.cc:172:37 (libstdc++.so.6+0xe1a29)
    #3 CThread::Create(bool) xbmc/threads/Thread.cpp:118:20 (kodi.bin+0x3261846) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #4 CJobWorker::CJobWorker(CJobManager*) xbmc/utils/JobManager.cpp:32:3 (kodi.bin+0x30941ad) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #5 CJobManager::StartWorkers(CJob::PRIORITY) xbmc/utils/JobManager.cpp:288:27 (kodi.bin+0x3097138) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #6 CJobManager::AddJob(CJob*, IJobCallback*, CJob::PRIORITY) xbmc/utils/JobManager.cpp:247:3 (kodi.bin+0x3096424) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #7 CGUILargeTextureManager::QueueImage(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, bool) xbmc/GUILargeTextureManager.cpp:225:57 (kodi.bin+0x3c454ed) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #8 CGUILargeTextureManager::GetImage(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, CTextureArray&, bool, bool) xbmc/GUILargeTextureManager.cpp:174:5 (kodi.bin+0x3c45208) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #9 CGUITexture::AllocResources() xbmc/guilib/GUITexture.cpp:335:62 (kodi.bin+0x3626153) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #10 CGUIImage::AllocResources() xbmc/guilib/GUIImage.cpp:246:14 (kodi.bin+0x35a4d68) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #11 CGUIBorderedImage::AllocResources() xbmc/guilib/GUIBorderedImage.cpp:73:14 (kodi.bin+0x34ed246) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #12 CGUIImage::AllocateOnDemand() xbmc/guilib/GUIImage.cpp:102:5 (kodi.bin+0x35a3a49) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #13 CGUIImage::UpdateVisibility(CGUIListItem const*) xbmc/guilib/GUIImage.cpp:60:3 (kodi.bin+0x35a3617) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #14 CGUIListGroup::UpdateInfo(CGUIListItem const*) xbmc/guilib/GUIListGroup.cpp:103:12 (kodi.bin+0x35c66b5) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #15 CGUIListGroup::UpdateInfo(CGUIListItem const*) xbmc/guilib/GUIListGroup.cpp:102:12 (kodi.bin+0x35c666f) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #16 CGUIListGroup::UpdateInfo(CGUIListItem const*) xbmc/guilib/GUIListGroup.cpp:102:12 (kodi.bin+0x35c666f) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #17 CGUIListItemLayout::Process(CGUIListItem*, int, unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIListItemLayout.cpp:73:13 (kodi.bin+0x35d3c45) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #18 CGUIBaseContainer::ProcessItem(float, float, std::shared_ptr<CGUIListItem>&, bool, unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIBaseContainer.cpp:245:26 (kodi.bin+0x34dbe57) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #19 CGUIPanelContainer::Process(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIPanelContainer.cpp:72:9 (kodi.bin+0x35e0d16) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #20 CGUIControl::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIControl.cpp:143:5 (kodi.bin+0x3501cac) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #21 CGUIBaseContainer::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIBaseContainer.cpp:116:16 (kodi.bin+0x34da185) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #22 CGUIControlGroupList::Process(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIControlGroupList.cpp:78:14 (kodi.bin+0x3534f93) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #23 CGUIControl::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIControl.cpp:143:5 (kodi.bin+0x3501cac) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #24 CGUIControlGroup::Process(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIControlGroup.cpp:93:14 (kodi.bin+0x352b12d) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #25 CGUIControl::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIControl.cpp:143:5 (kodi.bin+0x3501cac) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #26 CGUIControlGroup::Process(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIControlGroup.cpp:93:14 (kodi.bin+0x352b12d) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #27 CGUIControl::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIControl.cpp:143:5 (kodi.bin+0x3501cac) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #28 CGUIControlGroup::Process(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIControlGroup.cpp:93:14 (kodi.bin+0x352b12d) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #29 CGUIControl::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIControl.cpp:143:5 (kodi.bin+0x3501cac) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #30 CGUIControlGroup::Process(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIControlGroup.cpp:93:14 (kodi.bin+0x352b12d) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #31 CGUIControl::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIControl.cpp:143:5 (kodi.bin+0x3501cac) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #32 CGUIWindow::DoProcess(unsigned int, std::vector<CDirtyRegion, std::allocator<CDirtyRegion>>&) xbmc/guilib/GUIWindow.cpp:330:21 (kodi.bin+0x363a517) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #33 CGUIWindowManager::Process(unsigned int) xbmc/guilib/GUIWindowManager.cpp:1217:14 (kodi.bin+0x3653d1d) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #34 CApplication::FrameMove(bool, bool) xbmc/application/Application.cpp:1857:54 (kodi.bin+0x37ca1dd) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #35 CApplication::Run() xbmc/application/Application.cpp:1903:7 (kodi.bin+0x37ca697) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #36 XBMC_Run xbmc/platform/xbmc.cpp:61:26 (kodi.bin+0x32e1b91) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)
    #37 main xbmc/platform/posix/main.cpp:70:16 (kodi.bin+0x23b0315) (BuildId: 2689a3b01f5beb8a7085341524b290db20a597f8)

SUMMARY: ThreadSanitizer: data race /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/13.2.1/../../../../include/c++/13.2.1/bits/stl_tree.h:782:45 in std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const, XFILE::CXbtManager::XBTFReader>>>::_S_left(std::_Rb_tree_node_base*)
==================
```
</details>

## Motivation and context
Prevent potential undefined behaviour.

## How has this been tested?
Thread Sanitizer doesn't complain anymore. 

## What is the effect on users?
Not clear.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
