### PR TITLE
[Android] Fix audio engine initialisation after sleep

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -1333,6 +1333,11 @@ void CXBMCApp::onReceive(CJNIIntent intent)
       if (winSystem && dynamic_cast<CWinSystemAndroid*>(winSystem))
         dynamic_cast<CWinSystemAndroid*>(winSystem)->SetHdmiState(hdmiPlugged);
     }
+    if (hdmiPlugged)
+    {
+      CLog::Log(LOGDEBUG, "CXBMCApp::{}: Reset audio engine", __FUNCTION__);
+      CServiceBroker::GetActiveAE()->DeviceChange();
+    }
   }
   else if (action == CJNIIntent::ACTION_SCREEN_ON)
   {

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -1333,10 +1333,11 @@ void CXBMCApp::onReceive(CJNIIntent intent)
       if (winSystem && dynamic_cast<CWinSystemAndroid*>(winSystem))
         dynamic_cast<CWinSystemAndroid*>(winSystem)->SetHdmiState(hdmiPlugged);
     }
-    if (hdmiPlugged)
+    if (hdmiPlugged && m_wakeUp)
     {
       CLog::Log(LOGDEBUG, "CXBMCApp::{}: Reset audio engine", __FUNCTION__);
       CServiceBroker::GetActiveAE()->DeviceChange();
+      m_wakeUp = false;
     }
   }
   else if (action == CJNIIntent::ACTION_SCREEN_ON)
@@ -1359,6 +1360,8 @@ void CXBMCApp::onReceive(CJNIIntent intent)
       const auto appPower = components.GetComponent<CApplicationPowerHandling>();
       appPower->WakeUpScreenSaverAndDPMS();
     }
+
+    m_wakeUp = true;
   }
   else if (action == CJNIIntent::ACTION_SCREEN_OFF)
   {

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -255,6 +255,7 @@ private:
   bool m_hasFocus{false};
   bool m_headsetPlugged{false};
   bool m_hdmiSource{false};
+  bool m_wakeUp{false};
   IInputDeviceCallbacks* m_inputDeviceCallbacks{nullptr};
   IInputDeviceEventHandler* m_inputDeviceEventHandler{nullptr};
   bool m_hasReqVisible{false};


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Audio engine is reinitialised when event ACTION_HDMI_AUDIO_PLUG is received.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When a device goes to sleep the audio engine is suspended. On wake-up the audio engine is initialised again (resumed). Wake-up processing is performed on event ACTION_SCREEN_ON. There is another event (ACTION_HDMI_AUDIO_PLUG), which system also sends on wake-up. At least on my system the HDMI handshake isn't completed when the first event arrives. As a result the audio engine isn't properly initialised. This causes all kind of issues such as:

- Kodi IEC packer isn't listed in audio device list
- Audio passthrough isn't working anymore
- Audio is played as PCM stereo only, etc.

The problem is reported by various users on forum since 2018 - [Audio Passthrough gone after Shield Sleep](https://forum.kodi.tv/showthread.php?tid=333546). It is not Shield specific though. I have it with Fire TV 4K Max.

When the event ACTION_HDMI_AUDIO_PLUG is received, the initialisation of audio engine can be performed properly.

I considered moving audio engine initialisation from ACTION_SCREEN_ON to ACTION_HDMI_AUDIO_PLUG but decided against it. This would make the code more complex and requires changes in Power Manager. I'm also not sure if the second event is presented on all devices. I guess Android phones will not get it, as opposed to ACTION_SCREEN_ON, which probably every device receives.

What the fix does instead: on receiving ACTION_HDMI_AUDIO_PLUG event the audio engine is reinitialised using Suspend/Resume. This approach seems to be more robust and will hopefully not break anything.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Fire TV Stick 4K Max 2nd gen, connected to AVR Denon AVC-X4800H, connected to TV LG C1. Fire TV is configured to stop outputting signal on sleep. Fire TV and Kodi are configured to output all audio formats as passthrough, using Kodi IEC packer.

#### Test 1

1. Start Kodi
2. Make sure audio passthrough is configured in Kodi settings, using Kodi IEC packer.
3. Playback a video with multichannel audio such as Dolby Digital or DTS, check on AVR that the incoming signal is correct
4. Stop video playback
5. On Fire TV remote control click the gear-button and choose "Sleep" in the menu 
6. Wait a few seconds for sleep mode to activate
7. AVR and TV remain still on in this test
8. Wake up Fire TV by clicking select-button on the remote
9. Kodi should be active
10. Try to playback the same video
11. Check incoming signal on AVR.
12. Go to Audio settings in Kodi. Check that Kodi IEC packer is still selected as audio passthrough device.

#### Test 2

This test is similar to Test 1 but on step 5 instead of putting only Fire TV to sleep we switch off all devices using on/off button on Fire TV remote. If Fire TV is properly configured the AVR and TV will both switch off. On step 8 we use the same on/off button on remote to wake up Fire TV and switch on AVR and TV.

#### Test results
##### Before fix
On step 11 AVR shows input signal as "PCM Stereo". On step 12 "Kodi IEC packer" disappears from the list of audio devices. Android IEC packer is shown instead (it doesn't work properly on Fire TV).

##### After fix
On step 11 AVR shows the same input signal as on step 3. On step 12 "Kodi IEC packer" is in the list of audio devices and it is selected as output device. Audio passthrough works correctly.

## What is the effect on users?

<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Users who were having problem with passthrough not working after sleep should have the issue fixed. In particular Shield and Fire TV devices (especially if connected to AVR) are known to be affected.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
