### PR TITLE
[video] Video Versions: Fix empty context menu item label.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23877,6 +23877,7 @@ msgstr ""
 
 #. Button label to make a video version the default version
 #: addons/skin.estuary/xml/DialogVideoVersion.xml
+#: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
 msgctxt "#40023"
 msgid "Set as default"
 msgstr ""

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -318,7 +318,7 @@ int CGUIDialogVideoManagerVersions::ManageVideoVersionContextMenu(
   CContextButtons buttons;
 
   buttons.Add(CONTEXT_BUTTON_RENAME, 118);
-  buttons.Add(CONTEXT_BUTTON_SET_DEFAULT, 31614);
+  buttons.Add(CONTEXT_BUTTON_SET_DEFAULT, 40023);
   buttons.Add(CONTEXT_BUTTON_DELETE, 15015);
   buttons.Add(CONTEXT_BUTTON_SET_ART, 13511);
 


### PR DESCRIPTION
Reported in the forum. Fixes some fallout from recent message id changes.

Before:
![screenshot00001](https://github.com/xbmc/xbmc/assets/3226626/3a3f91dd-d348-437a-b6ca-f800defdc685)

After:
![screenshot00002](https://github.com/xbmc/xbmc/assets/3226626/941c3906-d3a8-48c7-8c75-f9d10657ee8d)

Runtime-tested on macOS, latest Kodi master.

@enen92 @CrystalP should be a no-brainer. 