### PR TITLE
[Games] Filter out "virtual" Android joysticks

### DIFF
--- a/xbmc/games/agents/GameAgentManager.cpp
+++ b/xbmc/games/agents/GameAgentManager.cpp
@@ -20,6 +20,8 @@
 #include "peripherals/devices/PeripheralJoystick.h"
 #include "utils/log.h"
 
+#include <array>
+
 using namespace KODI;
 using namespace GAME;
 
@@ -198,6 +200,62 @@ void CGameAgentManager::ProcessJoysticks(PERIPHERALS::EventLockHandlePtr& inputH
   //
   PERIPHERALS::PeripheralVector joysticks;
   m_peripheralManager.GetPeripheralsWithFeature(joysticks, PERIPHERALS::FEATURE_JOYSTICK);
+
+  // Remove "virtual" Android joysticks
+  //
+  // The heuristic used to identify these is to check if the device name is all
+  // lowercase letters and dashes (and contains at least one dash). The
+  // following virtual devices have been observed:
+  //
+  //   shield-ask-remote
+  //   sunxi-ir-uinput
+  //   virtual-search
+  //
+  // Additionally, we specifically allow the following devices:
+  //
+  //   virtual-remote
+  //
+  joysticks.erase(
+      std::remove_if(joysticks.begin(), joysticks.end(),
+                     [](const PERIPHERALS::PeripheralPtr& joystick)
+                     {
+                       const std::string& joystickName = joystick->DeviceName();
+
+                       // Skip joysticks in the allowlist
+                       static const std::array<std::string, 1> peripheralAllowlist = {
+                           "virtual-remote",
+                       };
+                       if (std::find_if(peripheralAllowlist.begin(), peripheralAllowlist.end(),
+                                        [&joystickName](const std::string& allowedJoystick) {
+                                          return allowedJoystick == joystickName;
+                                        }) != peripheralAllowlist.end())
+                       {
+                         return false;
+                       }
+
+                       // Require at least one dash
+                       if (std::find_if(joystickName.begin(), joystickName.end(),
+                                        [](char c) { return c == '-'; }) == joystickName.end())
+                       {
+                         return false;
+                       }
+
+                       // Require all lowercase letters or dashes
+                       if (std::find_if(joystickName.begin(), joystickName.end(),
+                                        [](char c)
+                                        {
+                                          const bool isLowercase = ('a' <= c && c <= 'z');
+                                          const bool isDash = (c == '-');
+                                          return !(isLowercase || isDash);
+                                        }) != joystickName.end())
+                       {
+                         return false;
+                       }
+
+                       // Joystick matches the pattern, remove it
+                       return true;
+                     }),
+      joysticks.end());
 
   // Update agents
   ProcessAgents(joysticks, inputHandlingLock);


### PR DESCRIPTION
## Description

Currently, input in games is broken on some Android devices due to "virtual" Android joysticks. I attempted to fix this in https://github.com/xbmc/xbmc/pull/23482 by introducing stable player assignment based on when the last button was pressed.

However, this didn't apply to joysticks that specify a specific player number - intended to allow XInput controllers to map to their XInput player. Android specifies the virtual joystick as being specifically player 1, so the time-based sorting method didn't apply to it.

When doing some research on the reports for this problem, I discovered several "virtual" joysticks, all with a similar naming pattern:

* shield-ask-remote
* sunxi-ir-uinput
* virtual-search

So, to handle unseen virtual joysticks, I've introduced a heuristic to match virtual joysticks with similar names. See the comment in the code for how the heuristic works.

## Motivation and context

Reported here:

* https://forum.kodi.tv/showthread.php?tid=367630
* https://forum.kodi.tv/showthread.php?tid=375270
* https://forum.kodi.tv/showthread.php?tid=374826

## How has this been tested?

Tested with my newest test build based on 21 Beta 2: https://github.com/garbear/xbmc/releases

## What is the effect on users?

* Fixed controller input on Android

## Screenshots

Before:

![Screenshot_20231231-192717](https://github.com/xbmc/xbmc/assets/531482/db77a05b-7007-4678-a086-3424a9028eff)

After:

![Screenshot_20231231-192456](https://github.com/xbmc/xbmc/assets/531482/8eb2e5f5-1fac-4c82-88f6-864280f41743)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
