### PR TITLE
[MusicDatabase][VideoDatabase] Enforce separate media in profiles with remote database.

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -9640,7 +9640,7 @@ int CMusicDatabase::GetSongsCount(Filter filter)
       return 0;
 
     std::string strSQL = "select count(idSong) as NumSongs from songview ";
-    
+
     // Apply profile filter. Needed here to show empty (filtered) library properly
     if (m_enforceProfileInSearch)
       filter.AppendWhere(GetProfileFilter("song", true));
@@ -13451,10 +13451,9 @@ bool CMusicDatabase::GetFilter(CDbUrl& musicUrl, Filter& filter, SortDescription
       // No souces in profile
       strSQLSources = "album_source.idSource=0";
   }
-  else
-    if (idSource > 0)
-      // Single source
-      strSQLSources = StringUtils::Format("album_source.idSource={}", idSource);
+  else if (idSource > 0)
+    // Single source
+    strSQLSources = StringUtils::Format("album_source.idSource={}", idSource);
 
   bool doneProfileInSeach{false};
 
@@ -13563,7 +13562,8 @@ bool CMusicDatabase::GetFilter(CDbUrl& musicUrl, Filter& filter, SortDescription
         ExistsSubQuery songArtistSub("song_artist", "song_artist.idArtist = artistview.idArtist");
         if (idRole > 0)
           songArtistSub.AppendWhere(PrepareSQL("song_artist.idRole = %i", idRole));
-        if ((idSource > 0 || m_enforceProfileInSearch) && idGenre > 0 && !albumArtistsOnly && idRole >= 1)
+        if ((idSource > 0 || m_enforceProfileInSearch) && idGenre > 0 && !albumArtistsOnly &&
+            idRole >= 1)
         {
           songArtistSub.AppendWhere(PrepareSQL("EXISTS(SELECT 1 FROM song "
                                                "JOIN song_genre ON song_genre.idSong = song.idSong "

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -3954,17 +3954,20 @@ bool CMusicDatabase::GetRecentlyAddedAlbumSongs(const std::string& strBaseDir,
     // Determine the recently added albums from dateAdded (usually derived from music file
     // timestamps, nothing to do with when albums added to library)
     std::string strSQL;
-    strSQL = PrepareSQL("SELECT songview.*, songartistview.* "
-                        "FROM (SELECT idAlbum, dateAdded FROM album "
-                        "ORDER BY dateAdded DESC LIMIT %u) AS recentalbums "
-                        "JOIN songview ON songview.idAlbum = recentalbums.idAlbum "
-                        "JOIN songartistview ON songview.idSong = songartistview.idSong "
-                        "ORDER BY recentalbums.dateAdded DESC, songview.idAlbum DESC, "
-                        "songview.idSong, songartistview.idRole, songartistview.iOrder ",
-                        limit ? limit
-                              : CServiceBroker::GetSettingsComponent()
-                                    ->GetAdvancedSettings()
-                                    ->m_iMusicLibraryRecentlyAddedItems);
+    strSQL = PrepareSQL(
+        StringUtils::Format("SELECT songview.*, songartistview.* "
+                            "FROM (SELECT idAlbum, dateAdded FROM album "
+                            "ORDER BY dateAdded DESC LIMIT %u) AS recentalbums "
+                            "JOIN songview ON songview.idAlbum = recentalbums.idAlbum "
+                            "JOIN songartistview ON songview.idSong = songartistview.idSong "
+                            "{} "
+                            "ORDER BY recentalbums.dateAdded DESC, songview.idAlbum DESC, "
+                            "songview.idSong, songartistview.idRole, songartistview.iOrder ",
+                            GetProfileFilter("song")),
+        limit ? limit
+              : CServiceBroker::GetSettingsComponent()
+                    ->GetAdvancedSettings()
+                    ->m_iMusicLibraryRecentlyAddedItems);
     CLog::Log(LOGDEBUG, "GetRecentlyAddedAlbumSongs() query: {}", strSQL);
     if (!m_pDS->query(strSQL))
       return false;

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -3371,8 +3371,11 @@ std::string CMusicDatabase::GetProfileFilter(std::string viewTable, bool noWhere
   std::string strSQL{};
   VECSOURCES sources(*CMediaSourceSettings::GetInstance().GetSources("music"));
   for (CMediaSource& source : sources)
-    strSQL = StringUtils::Format("{}album_source.idSource={} OR ", strSQL,
-                                 GetSourceFromPath(source.strPath));
+  {
+    const int s = GetSourceFromPath(source.strPath);
+    if (s > 0)
+      strSQL = StringUtils::Format("{}album_source.idSource={} OR ", strSQL, s);
+  }
 
   if (strSQL.empty())
     // No sources in profile

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -646,7 +646,7 @@ public:
                          const SortDescription& sortDescription = SortDescription(),
                          bool countOnly = false);
   int GetDiscsCount(const std::string& baseDir, const Filter& filter = Filter());
-  int GetSongsCount(const Filter& filter = Filter());
+  int GetSongsCount(Filter filter = Filter());
   bool GetFilter(CDbUrl& musicUrl, Filter& filter, SortDescription& sorting) override;
   int GetOrderFilter(const std::string& type, const SortDescription& sorting, Filter& filter);
 
@@ -982,6 +982,9 @@ private:
   returns true when successfully done
   */
   bool MigrateSources();
+
+  std::string GetProfileFilter(std::string viewTable = "album", bool noWhere = false);
+  bool m_enforceProfileInSearch = true;
 
   bool m_translateBlankArtist;
 

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1224,4 +1224,7 @@ private:
   static void AnnounceUpdate(const std::string& content, int id);
 
   static CDateTime GetDateAdded(const std::string& filename, CDateTime dateAdded = CDateTime());
+
+  std::string GetProfileFilter();
+  bool m_enforceProfileInSearch = true;
 };


### PR DESCRIPTION
## Description

If you have a local database and create profiles, each profile will have a seperate database (and a seperate `sources.xml`).
If you have a remote database then there will only be one database, despite seperate `sources.xml`.

So if, for example, you want an adults and kids profile but have a remote database then any music you add can be accessed from both profiles.

It also seems that everytime you add a source in either profile all sources are deleted from the `source` table in the database - does anyone know why?? I cant see a good reason (but may be missing something obvious!

## Motivation and context

Thas was highlighted in bug report #23999.

## How has this been tested?

Created 3 profiles and test remote mariadb.

## What is the effect on users?

On the one hand this will mean that 'remote' and 'local' profiles (w.r.t to database location) will now behave the same.

BUT this may an unexpected change for those not expecting it. In code I've linked everything to a bool `m_enforceProfileInSearch` - this isn't currently linked to a menu option or an `advancedsettings.xml` option - my feeling is the latter.

ALSO I don't think videos are seperated by profile either (and I assume music videos as well) when a remote database is used.

So I guess the question is do we want this?? Should we have consistent behaviour seperating content between profiles irrespective of local/remote database??

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [X] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
