### PR TITLE
[Peripherals] Fix missing controller icons in Peripheral Dialog

### DIFF
--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -321,7 +321,8 @@ void CPeripheralBus::GetDirectory(const std::string& strPath, CFileItemList& ite
 
     peripheralFile->SetProperty("version", strVersion);
     peripheralFile->SetLabel2(strDetails);
-    peripheralFile->SetArt("icon", "DefaultAddon.png");
+    peripheralFile->SetArt("icon", peripheral->GetIcon());
+
     items.Add(peripheralFile);
   }
 }


### PR DESCRIPTION
## Description

Controller profiles were introduced for peripherals in https://github.com/xbmc/xbmc/pull/21182, and in https://github.com/xbmc/xbmc/pull/22856 it became possible to change a peripheral's appearance.

However, the appearance always depended on peripheral.joystick being used. On Android, the peripheral bus is in core instead of the add-on. As a result, peripheral icons aren't shown on Android.

This PR updates the peripheral bus base class to take icon into account, without needing the peripheral bus to be peripheral.joystick. As a result, peripheral icons are now shown on Android.

## Motivation and context

Giving Android some love now that my NVidia Shield is working again.

## How has this been tested?

Included in my latest round of test builds: https://github.com/garbear/xbmc/releases

## What is the effect on users?

* Fixed peripheral icons not shown in Peripheral Dialog on Android

## Screenshots (if appropriate):

Before:

![Screenshot_20231231-192412](https://github.com/xbmc/xbmc/assets/531482/eaad2415-64c9-4ca5-966d-299134e92c12)

After:

![Screenshot_20231231-191332](https://github.com/xbmc/xbmc/assets/531482/b2a901da-1fcd-45b5-a638-510cd0973280)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
