### PR TITLE
[VIDEO] Prefer nfo streamdetails over file details where possible

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1481,11 +1481,14 @@ namespace VIDEO
                                      movieDetails.m_iSeason, movieDetails.m_iEpisode, strTitle);
     }
 
-    if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-            CSettings::SETTING_MYVIDEOS_EXTRACTFLAGS) &&
-        CDVDFileInfo::GetFileStreamDetails(pItem))
+    if (!movieDetails.HasStreamDetails() &&
+        CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+            CSettings::SETTING_MYVIDEOS_EXTRACTFLAGS))
+    {
+      CDVDFileInfo::GetFileStreamDetails(pItem);
       CLog::Log(LOGDEBUG, "VideoInfoScanner: Extracted filestream details from video file {}",
                 CURL::GetRedacted(pItem->GetPath()));
+    }
 
     CLog::Log(LOGDEBUG, "VideoInfoScanner: Adding new item to {}:{}", TranslateContent(content), CURL::GetRedacted(pItem->GetPath()));
     long lResult = -1;


### PR DESCRIPTION
## Description
Current code loads streamdetails from nfo files but then overwrites all of that by opening the file and using the information from there.  Not only does this take more time as we are opening every video file to get details we might already have, but Kodi should prefer the information in the nfo files over anything else - This is the expected behaviour for nfo files.

This PR adds a check to see if we have already read the streamdetails from an nfo file and if not, opens and probes the file.  Otherwise we store the data we already have.

## Motivation and context
Brought up by @KarellenX in https://github.com/xbmc/xbmc/pull/20247#issuecomment-1873076130 

## How has this been tested?
Tested by altering some values in nfo files to nonsensical ones, removing streamdetails entirely from others and then scanning those into the db.  Checked in the streamdetails table that the nonsensical data was there and that the files where the stream details had been removed were opened and probed correctly.

## What is the effect on users?
Fixes a regression brought about by https://github.com/xbmc/xbmc/pull/20247  which makes Kodi probe every video file whilst scanning and ignore any details in a corresponding nfo file.  Streamdetails from nfo files will now be preferred over the actual file details if they are present in the nfo.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
