### PR TITLE
[video] Fix/cleanup: We never want to obtain all video versions and all extras at the same time.

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -11867,19 +11867,6 @@ int CVideoDatabase::AddVideoVersionType(const std::string& typeVideoVersion,
   return id;
 }
 
-void CVideoDatabase::GetVideoVersions(VideoDbContentType itemType, int dbId, CFileItemList& items)
-{
-  // get main video versions
-  CFileItemList mainList;
-  GetVideoVersions(itemType, dbId, mainList, VideoAssetType::VERSION);
-  items.Append(mainList);
-
-  // get video extras versions
-  CFileItemList extrasList;
-  GetVideoVersions(itemType, dbId, extrasList, VideoAssetType::EXTRA);
-  items.Append(extrasList);
-}
-
 void CVideoDatabase::GetVideoVersions(VideoDbContentType itemType,
                                       int dbId,
                                       CFileItemList& items,

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -997,7 +997,6 @@ public:
   std::string GetVideoVersionById(int id);
   bool GetVideoItemByVideoVersion(int dbId, CFileItem& item);
   int GetVideoVersionFile(VideoDbContentType itemType, int dbId, int idVideoVersion);
-  void GetVideoVersions(VideoDbContentType itemType, int dbId, CFileItemList& items);
   void GetVideoVersions(VideoDbContentType itemType,
                         int dbId,
                         CFileItemList& items,

--- a/xbmc/video/dialogs/GUIDialogVideoManager.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -404,7 +404,7 @@ int CGUIDialogVideoManager::ChooseVideoAsset(const std::shared_ptr<CFileItem>& i
 
     //! @todo db refactor: should not be versions, but assets
     CFileItemList assets;
-    videodb.GetVideoVersions(itemType, dbId, assets);
+    videodb.GetVideoVersions(itemType, dbId, assets, assetType);
 
     // the selected video asset already exists
     if (std::any_of(assets.cbegin(), assets.cend(),

--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
@@ -117,7 +117,7 @@ void CGUIDialogVideoManagerExtras::AddVideoExtra()
     if (idVideoVersion != -1)
     {
       CFileItemList versions;
-      m_database.GetVideoVersions(itemType, dbId, versions);
+      m_database.GetVideoVersions(itemType, dbId, versions, videoAssetType);
       if (std::any_of(versions.begin(), versions.end(),
                       [idFile](const std::shared_ptr<CFileItem>& version)
                       { return version->GetVideoInfoTag()->m_iDbId == idFile; }))

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -556,7 +556,7 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
     if (idVideoVersion != -1)
     {
       CFileItemList versions;
-      m_database.GetVideoVersions(itemType, dbId, versions);
+      m_database.GetVideoVersions(itemType, dbId, versions, videoAssetType);
       if (std::any_of(versions.begin(), versions.end(),
                       [idFile](const std::shared_ptr<CFileItem>& version)
                       { return version->GetVideoInfoTag()->m_iDbId == idFile; }))
@@ -583,7 +583,7 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
       if (m_database.IsDefaultVideoVersion(idFile))
       {
         CFileItemList list;
-        m_database.GetVideoVersions(itemType, idMedia, list);
+        m_database.GetVideoVersions(itemType, idMedia, list, videoAssetType);
 
         if (list.Size() > 1)
         {


### PR DESCRIPTION
This was overlooked in the first refactoring to separate video versions and extras.

Runtime-tested on macOS, latest Kodi version.

@enen92 @CrystalP please review. Should be self-explaining.