### PR TITLE
[MUSIC] Only drop music db triggers on clean if they exist

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -4569,8 +4569,11 @@ int CMusicDatabase::Cleanup(CGUIDialogProgress* progressDialog /*= nullptr*/)
   SetLibraryLastCleaned();
 
   // Drop triggers  song_artist and album_artist to avoid creation of entries in removed_link
-  m_pDS->exec("DROP TRIGGER tgrDeleteSongArtist");
-  m_pDS->exec("DROP TRIGGER tgrDeleteAlbumArtist");
+  // Check that triggers actually exist first as interrupting the clean causes them to not be
+  // re-created
+
+  m_pDS->exec("DROP TRIGGER IF EXISTS tgrDeleteSongArtist");
+  m_pDS->exec("DROP TRIGGER IF EXISTS tgrDeleteAlbumArtist");
 
   // first cleanup any songs with invalid paths
   if (progressDialog)


### PR DESCRIPTION
## Description
Database errors are generated in the music db when attempting to clean the db if there are two triggers missing.  If this is the case, no progress dialog appears and the cleaning is aborted immediately.

## Motivation and context
When starting a clean operation, for efficiency the music database temporarily drops two triggers.  If for some reason they do not exist, then the entire operation errors out and no cleaning is possible.

The missing triggers are caused by the data cleaning process being interrupted either by Kodi being shutdown, or with client server setups network access to the server being broken.  There is a thread on the forum discussing it -> https://forum.kodi.tv/showthread.php?tid=363270. It is nothing related to Kore, except that if you are not using the Kodi GUI e.g. listening to music with TV off using a remote app to control Kodi, then it easier to accidentally not notice Kodi is still cleaning when you shutdown. 

As the thread was started in 2021 but still appears to be a bit of an issue in 2023 I thought I'd see if I could make the cleaning code a little more robust.  Fixes https://github.com/xbmc/xbmc/issues/19759

## How has this been tested?
Tested with MariaDB and sqlite by dropping the triggers manually and then initiating a scan.  Dialog box appears correctly and the clean completed without errors.  Triggers were re-created correctly at the end of the clean.

## What is the effect on users?
In the event of a previous music db clean being interrupted for whatever reason before it completed, Kodi will now attempt to clean the database anyway and re-create the missing triggers at the end of the cleaning routine.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
