### PR TITLE
[video] Movies window: Movies/Versions node: Context menu fixes

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -509,6 +509,7 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
         newVideoVersion->SetLabel(g_localizeStrings.Get(40004));
         newVideoVersion->SetLabelPreformatted(true);
         newVideoVersion->SetSpecialSort(SortSpecialOnTop);
+        newVideoVersion->SetProperty("IsPlayable", false);
         items.Add(newVideoVersion);
       }
     }
@@ -817,7 +818,8 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
              item->GetVideoInfoTag()->m_type == MediaTypeMusicVideo || // musicvideos
              item->GetVideoInfoTag()->m_type == "tag" || // tags
              item->GetVideoInfoTag()->m_type == MediaTypeVideoCollection || // sets
-             item->GetVideoInfoTag()->m_type == MediaTypeVideoVersion)) // videoversions
+             (item->GetVideoInfoTag()->m_type == MediaTypeVideoVersion &&
+              item->GetVideoInfoTag()->m_iFileId != -1))) // videoversions for a certain video
         {
           buttons.Add(CONTEXT_BUTTON_EDIT, 16106);
         }


### PR DESCRIPTION
1) Remove 'Play from here' from 'New version...' context menu item - makes no sense. 
![screenshot00007](https://github.com/xbmc/xbmc/assets/3226626/70c24082-8afa-4dc6-ab93-f391d8b90195)

2) Remove 'Manage...' context menu item from the version items, because the manage functions (currently) only work for video versions for certain videos, not the version itself.
![screenshot00005](https://github.com/xbmc/xbmc/assets/3226626/8c5976b1-e228-44b5-a780-55cbb27dab22)

Runtime-tested on macOS, latest Kod master,

@enen92 @CrystalP could you please review? thanks.