### PR TITLE
[Video] Always respect video versions/extras ignore setting

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -65,6 +65,11 @@ namespace VIDEO
   {
     m_bStop = false;
     m_scanAll = false;
+
+    const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+
+    m_ignoreVideoVersions = settings->GetBool(CSettings::SETTING_VIDEOLIBRARY_IGNOREVIDEOVERSIONS);
+    m_ignoreVideoExtras = settings->GetBool(CSettings::SETTING_VIDEOLIBRARY_IGNOREVIDEOEXTRAS);
   }
 
   CVideoInfoScanner::~CVideoInfoScanner()
@@ -76,11 +81,7 @@ namespace VIDEO
 
     try
     {
-      auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-
-      m_ignoreVideoVersions =
-          settings->GetBool(CSettings::SETTING_VIDEOLIBRARY_IGNOREVIDEOVERSIONS);
-      m_ignoreVideoExtras = settings->GetBool(CSettings::SETTING_VIDEOLIBRARY_IGNOREVIDEOEXTRAS);
+      const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
 
       if (m_showDialog && !settings->GetBool(CSettings::SETTING_VIDEOLIBRARY_BACKGROUNDUPDATE))
       {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Respect the settings to ignore video versions or extras for all data flows involving scanning and refresh.

![image](https://github.com/xbmc/xbmc/assets/489377/de431896-93a1-45f5-af8e-43dd9860f204)

The settings were respected for "Library update" and the json-rpc equivalent, but not when refreshing a movie from the Info dialog.

That happened because the settings were read by the `Process()` function, which is not always involved for scans.

The settings are now read in the class constructor and will always be respected.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Noticed the "similar movie found" popup after refreshing a movie information even the setting was to ignore the situation.

Forum user thezoggy may have found another way to trigger the popup regardless of the setting, though it's not clear how and no further details were provided (https://forum.kodi.tv/showthread.php?tid=337992&pid=3176212#pid3176212)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
"Update library" and "Refresh" button of the Info dialog both execute the constructor of the scanner class and read the settings.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
No popups for similar movie when the setting is to ignore them.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
