### PR TITLE
Peripheral API v3.0.2: Stable peripheral locations

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/peripheral/PeripheralUtils.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/peripheral/PeripheralUtils.h
@@ -1263,7 +1263,7 @@ public:
 
   /// @brief Get all primitives on this class (as constant).
   ///
-  /// @return Constant a´rray list of primitives
+  /// @return Constant array list of primitives
   const std::array<DriverPrimitive, JOYSTICK_PRIMITIVE_MAX>& Primitives() const
   {
     return m_primitives;

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/peripheral/PeripheralUtils.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/peripheral/PeripheralUtils.h
@@ -258,6 +258,20 @@ public:
   /// @brief Destructor.
   virtual ~Peripheral(void) = default;
 
+  /// @brief Comparison operator
+  ///
+  /// @note The index is not included in the comparison because it is affected
+  ///       by the presence of other peripherals
+  bool operator==(const Peripheral& rhs) const
+  {
+    // clang-format off
+    return m_type == rhs.m_type &&
+           m_strName == rhs.m_strName &&
+           m_vendorId == rhs.m_vendorId &&
+           m_productId == rhs.m_productId;
+    // clang-format on
+  }
+
   /// @brief Get peripheral type.
   ///
   /// @return Type defined with @ref PERIPHERAL_TYPE
@@ -635,6 +649,21 @@ public:
       m_supportsPowerOff = rhs.m_supportsPowerOff;
     }
     return *this;
+  }
+
+  /// @brief Comparison operator
+  bool operator==(const Joystick& rhs) const
+  {
+    // clang-format off
+    return Peripheral::operator==(rhs) &&
+           m_provider == rhs.m_provider &&
+           m_requestedPort == rhs.m_requestedPort &&
+           m_buttonCount == rhs.m_buttonCount &&
+           m_hatCount == rhs.m_hatCount &&
+           m_axisCount == rhs.m_axisCount &&
+           m_motorCount == rhs.m_motorCount &&
+           m_supportsPowerOff == rhs.m_supportsPowerOff;
+    // clang-format on
   }
 
   /// @brief Get provider name.

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -124,7 +124,7 @@
                                                       "addon-instance/inputstream/StreamCrypto.h" \
                                                       "addon-instance/inputstream/TimingConstants.h"
 
-#define ADDON_INSTANCE_VERSION_PERIPHERAL             "3.0.1"
+#define ADDON_INSTANCE_VERSION_PERIPHERAL             "3.0.2"
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_MIN         "3.0.0"
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_XML_ID      "kodi.binary.instance.peripheral"
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_DEPENDS     "addon-instance/Peripheral.h" \


### PR DESCRIPTION
## Description

This PR introduces a small backwards-compatible addition to the Peripheral binary add-on API. It adds simple comparison operators to the utility class.

This change is required by https://github.com/xbmc/peripheral.joystick/pull/294.

## Motivation and context

By enabling comparison, we can assign the same peripheral index when a controller is unplugged/replugged. This feature will be important in my upcoming Player Manager.

## How has this been tested?

Tested on Ubuntu 22.04.

I made a quick change so that peripheral locations would show in the Player Viewer instead of the driver name:

```patch
--- a/xbmc/games/agents/windows/GUIAgentList.cpp
+++ b/xbmc/games/agents/windows/GUIAgentList.cpp
@@ -209,7 +209,7 @@ void CGUIAgentList::OnEvent(const ADDON::AddonEvent& event)
 void CGUIAgentList::AddItem(const CGameAgent& agent)
 {
   // Create the list item from agent properties
-  const std::string label = agent.GetPeripheralName();
+  const std::string label = agent.GetPeripheralLocation();
   const ControllerPtr controller = agent.GetController();
   const std::string& path = agent.GetPeripheralLocation();
```

I unplugged/replugged controllers randomly and observed that their location was preserved.

## What is the effect on users?

* Player assignment will be slightly more stable when unplugging/replugging controllers during gameplay

## Screenshots (if appropriate):

![Screenshot from 2024-01-01 20-10-46](https://github.com/xbmc/xbmc/assets/531482/8268d436-03af-4b4a-9559-70489337bf4c)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
