### PR TITLE
Fix Input method on X11

### DIFF
--- a/xbmc/windowing/X11/WinEventsX11.cpp
+++ b/xbmc/windowing/X11/WinEventsX11.cpp
@@ -329,7 +329,7 @@ bool CWinEventsX11::MessagePump()
       continue;
     }
 
-    if (XFilterEvent(&xevent, m_window))
+    if (XFilterEvent(&xevent, None))
       continue;
 
     switch (xevent.type)


### PR DESCRIPTION
The XIM will not only use the passed in client window, but also some internal invisible window to communicate with input method server.

The libx11 code link for the reference: https://gitlab.freedesktop.org/xorg/lib/libx11/-/blob/master/modules/im/ximcp/imTrX.c#L165 . Without call XFilterEvent against this window, the certain part of input method message will fail to work. 

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
In order to make XIM work correctly, in most case, XFilterEvent(xevent, None) should be used. As input method is  the sole built-in user to the XFilterEvent function. From the man page for XFilterEvent: `If the window argument is None, XFilterEvent applies the filter to the window specified in the XEvent structure.`

Sample callsite to XFilterEvent in other toolkits:
e.g. https://github.com/mono/mono/blob/89f1d3cc22fd3b0848ecedbd6215b0bdfeea9477/mcs/class/System.Windows.Forms/System.Windows.Forms/XplatUIX11.cs#L1770
https://github.com/libsdl-org/SDL/blob/87b8f096579fc12727f6e6ba63ded0a4b7bf8d4a/src/video/x11/SDL_x11messagebox.c#L633

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/fcitx/fcitx5/issues/923

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I manually patched it and test with fcitx5. I also noticed some other issue between kodi and fcitx5, which I tried to address in https://github.com/fcitx/xcb-imdkit/commit/2553f2ec1397cd93facde4bff9fd841056611ddc. So if anyone is interested in testing the fix, you'd need this commit.

There's also a test_server.c in xcb-imdkit project if you don't want to setup fcitx5.
```
git clone https://github.com/fcitx/xcb-imdkit
mkdir build
cmake -S xcb-imdkit -B build # need extra-cmake-modules and libxcb devel files.
cmake --build build
./build/test/test_server &
XMODIFIERS=@im=test_server kodi
```
Then go to anywhere that allows you to type text, press ctrl+space to trigger and then you can press "t" should gives you a string "hello word....." (hardcoded logic in test_server).

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Being able to use system input method on X11 

## Screenshots (if appropriate):
When able to type with input method: ![图片](https://github.com/xbmc/xbmc/assets/259684/ef6c772e-8604-4313-b025-d37a6a2ad177)

Screenshot when testing with xcb-imdkit's test_server ("Tofu" character is mainly a font issue, the emoji being displayed correctly indicates that is string is correct, since the text is being committed to client is actually: "hello world你好世界켐ㅇㄹ貴方元気？☺"): 
![图片](https://github.com/xbmc/xbmc/assets/259684/eabf444a-657c-496c-829c-6f856ebe8fea)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
