### PR TITLE
[Video] Add a shortcut to the video dir in the Add version/extra file browsers

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoManager.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -14,6 +14,7 @@
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "dialogs/GUIDialogYesNo.h"
+#include "filesystem/Directory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
@@ -21,6 +22,7 @@
 #include "input/Key.h"
 #include "playlists/PlayListTypes.h"
 #include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
 #include "utils/log.h"
 #include "video/VideoManagerTypes.h"
 #include "video/VideoThumbLoader.h"
@@ -419,4 +421,17 @@ int CGUIDialogVideoManager::ChooseVideoAsset(const std::shared_ptr<CFileItem>& i
   }
 
   return assetId;
+}
+
+void CGUIDialogVideoManager::AppendItemFolderToFileBrowserSources(
+    std::vector<CMediaSource>& sources)
+{
+  const std::string itemDir{URIUtils::GetParentPath(m_videoAsset->GetDynPath())};
+  if (!itemDir.empty() && XFILE::CDirectory::Exists(itemDir))
+  {
+    CMediaSource itemSource{};
+    itemSource.strName = g_localizeStrings.Get(36041); // * Item folder
+    itemSource.strPath = itemDir;
+    sources.emplace_back(itemSource);
+  }
 }

--- a/xbmc/video/dialogs/GUIDialogVideoManager.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.h
@@ -51,6 +51,7 @@ protected:
   void UpdateControls();
 
   static int ChooseVideoAsset(const std::shared_ptr<CFileItem>& item, VideoAssetType assetType);
+  void AppendItemFolderToFileBrowserSources(std::vector<CMediaSource>& sources);
 
   CVideoDatabase m_database;
   std::shared_ptr<CFileItem> m_videoAsset;

--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
@@ -16,7 +16,6 @@
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogYesNo.h"
-#include "filesystem/Directory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
@@ -94,9 +93,9 @@ void CGUIDialogVideoManagerExtras::AddVideoExtra()
 
   CServiceBroker::GetMediaManager().GetLocalDrives(sources);
   CServiceBroker::GetMediaManager().GetNetworkLocations(sources);
+  AppendItemFolderToFileBrowserSources(sources);
 
-  std::string path{GetLikelyExtrasPath()};
-
+  std::string path;
   if (CGUIDialogFileBrowser::ShowAndGetFile(
           sources, CServiceBroker::GetFileExtensionProvider().GetVideoExtensions(),
           g_localizeStrings.Get(40015), path))
@@ -208,21 +207,4 @@ std::string CGUIDialogVideoManagerExtras::GenerateVideoExtra(const std::string& 
 
   // trim the string
   return StringUtils::Trim(extrasVersion);
-}
-
-std::string CGUIDialogVideoManagerExtras::GetLikelyExtrasPath()
-{
-  std::string path{URIUtils::GetDirectory(m_videoAsset->GetDynPath())};
-  CFileItemList items;
-
-  if (!XFILE::CDirectory::GetDirectory(path, items, "", XFILE::DIR_FLAG_DEFAULTS))
-    return path;
-
-  for (const auto& item : items)
-  {
-    if (item->m_bIsFolder && item->IsVideoExtras())
-      return item->GetPath();
-  }
-
-  return path;
 }

--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.h
@@ -40,9 +40,4 @@ protected:
 private:
   void AddVideoExtra();
   static std::string GenerateVideoExtra(const std::string& extrasPath);
-  /*!
-   * \brief Return a likely location for extras related to the movie
-   * \return path of the location
-  */
-  std::string GetLikelyExtrasPath();
 };

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -536,6 +536,7 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
 
   CServiceBroker::GetMediaManager().GetLocalDrives(sources);
   CServiceBroker::GetMediaManager().GetNetworkLocations(sources);
+  AppendItemFolderToFileBrowserSources(sources);
 
   std::string path;
   if (CGUIDialogFileBrowser::ShowAndGetFile(


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Add a shortcut to navigate to the directory of the movie that a version or extra is added to.
This is the same as the shortcut in Browse Art of Choose Art.

![image](https://github.com/xbmc/xbmc/assets/489377/70b9e11f-d139-4ec6-b735-ce3fb02fd2be)

This may be more intuitive than directly jumping into the folder as was previously done for extras because there was no indication of the current directory on the dialog, whereas here the user can more easily understand what's happening.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It's likely that additional versions or extras are stored in the same directory as the movie they're being added to.
For that situation, a shortcut significantly cuts down on the navigation.
Consistency with convention used in Browse art.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local and network movies.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Faster manual addition of versions and extras.
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
