### PR TITLE
[upnp] Renderer: playlist changed is an event that should e emitted b…

### DIFF
--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -693,6 +693,10 @@ void CPlayListPlayer::Add(Id playlistId, const CFileItemPtr& pItem)
   list.Add(pItem);
   if (list.IsShuffled())
     ReShuffle(playlistId, iSize);
+
+  // its likely that the playlist changed
+  CGUIMessage msg(GUI_MSG_PLAYLIST_CHANGED, 0, 0);
+  CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
 }
 
 void CPlayListPlayer::Add(Id playlistId, const CFileItemList& items)

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -627,10 +627,6 @@ CUPnPRenderer::OnSetNextAVTransportURI(PLT_ActionReference& action)
         CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(playlistId);
       }
 
-        CGUIMessage msg(GUI_MSG_PLAYLIST_CHANGED, 0, 0);
-        CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
-
-
         service->SetStateVariable("NextAVTransportURI", uri);
         service->SetStateVariable("NextAVTransportURIMetaData", meta);
 


### PR DESCRIPTION
…y the playlist player

## Description
Another simple one aiming at decoupling upnp from GUI. When a new playlist entry is sent to Kodi UPnP renderer it adds it to the playlist and it emits a `GUI_MSG_PLAYLIST_CHANGED`. I don't think this is correct as the playlistplayer is the component in charge of notifying other components of playlist changes. In fact the same already happens on the other `Add()` overload.
So, this moves the notification to the playlist player adding it to this `Add()` method too. Can't say emitting GUI messages from the playlist player is optimal but at least it centralizes them on a single place. I think the windowmanager should subscribe as an observer for the playlist player and emit the messages when the events happen (playlist player should survive without GUI). But yeah, one step at a time...for now I'm trying to cleanup the UPnP components.