### PR TITLE
[UPnP] Remove dependency on AppVolumeHandling

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -1748,6 +1748,19 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
   }
   break;
 
+  case TMSG_SET_VOLUME:
+  {
+    const float volumedB = static_cast<float>(pMsg->param3);
+    GetComponent<CApplicationVolumeHandling>()->SetVolume(volumedB);
+  }
+  break;
+
+  case TMSG_SET_MUTE:
+  {
+    GetComponent<CApplicationVolumeHandling>()->SetMute(pMsg->param3 == 1 ? true : false);
+  }
+  break;
+
   default:
     CLog::Log(LOGERROR, "{}: Unhandled threadmessage sent, {}", __FUNCTION__, msg);
     break;

--- a/xbmc/messaging/ApplicationMessenger.h
+++ b/xbmc/messaging/ApplicationMessenger.h
@@ -88,6 +88,9 @@
 /// @brief Called from the player when its current item is updated
 #define TMSG_UPDATE_PLAYER_ITEM TMSG_MASK_APPLICATION + 35
 
+#define TMSG_SET_VOLUME                   TMSG_MASK_APPLICATION + 36
+#define TMSG_SET_MUTE                     TMSG_MASK_APPLICATION + 37
+
 #define TMSG_GUI_INFOLABEL                TMSG_MASK_GUIINFOMANAGER + 0
 #define TMSG_GUI_INFOBOOL                 TMSG_MASK_GUIINFOMANAGER + 1
 #define TMSG_UPDATE_CURRENT_ITEM          TMSG_MASK_GUIINFOMANAGER + 2

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -20,7 +20,6 @@
 #include "application/Application.h"
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPlayer.h"
-#include "application/ApplicationVolumeHandling.h"
 #include "filesystem/SpecialProtocol.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
@@ -700,9 +699,13 @@ CUPnPRenderer::OnSetVolume(PLT_ActionReference& action)
 {
     NPT_String volume;
     NPT_CHECK_SEVERE(action->GetArgumentValue("DesiredVolume", volume));
-    auto& components = CServiceBroker::GetAppComponents();
-    const auto appVolume = components.GetComponent<CApplicationVolumeHandling>();
-    appVolume->SetVolume((float)strtod((const char*)volume, NULL));
+    // From RenderingControl:3 Service Spec (2.2.16 Volume):
+    // The **unsigned integer** state variable represents the current volume
+    // setting of the associated audio channel. Its value ranges from a minimum
+    // of 0 to some device specific maximum, N.
+    NPT_UInt32 appVolume;
+    NPT_CHECK_SEVERE(volume.ToInteger32(appVolume));
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_SET_VOLUME, static_cast<int64_t>(appVolume));
     return NPT_SUCCESS;
 }
 
@@ -713,11 +716,9 @@ NPT_Result
 CUPnPRenderer::OnSetMute(PLT_ActionReference& action)
 {
     NPT_String mute;
-    NPT_CHECK_SEVERE(action->GetArgumentValue("DesiredMute",mute));
-    auto& components = CServiceBroker::GetAppComponents();
-    const auto appVolume = components.GetComponent<CApplicationVolumeHandling>();
-    if ((mute == "1") ^ appVolume->IsMuted())
-      appVolume->ToggleMute();
+    NPT_CHECK_SEVERE(action->GetArgumentValue("DesiredMute", mute));
+    CServiceBroker::GetAppMessenger()->PostMsg(
+        TMSG_SET_MUTE, (mute.Compare("1") == 0 || mute.Compare("true", true) == 0) ? 1 : 0);
     return NPT_SUCCESS;
 }
 


### PR DESCRIPTION
## Description
Similar to previous changes this removes the dependency between the UPnP renderer and CApplicationVolumeHandling (which is in fact...CApp itself). All volume operations go via messaging to the application.
I took a bit of time to look into the standard, one of the parameters was in fact wrong (the volume is an unsigned integer and not a float).