### PR TITLE
[MUSIC] Only drop sql triggers on cleaning if they exist

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -4444,8 +4444,11 @@ int CMusicDatabase::Cleanup(CGUIDialogProgress* progressDialog /*= nullptr*/)
   SetLibraryLastCleaned();
 
   // Drop triggers  song_artist and album_artist to avoid creation of entries in removed_link
-  m_pDS->exec("DROP TRIGGER tgrDeleteSongArtist");
-  m_pDS->exec("DROP TRIGGER tgrDeleteAlbumArtist");
+  // Check that triggers actually exist first as interrupting the clean causes them to not be
+  // re-created
+
+  m_pDS->exec("DROP TRIGGER IF EXISTS tgrDeleteSongArtist");
+  m_pDS->exec("DROP TRIGGER IF EXISTS tgrDeleteAlbumArtist");
 
   // first cleanup any songs with invalid paths
   if (progressDialog)


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/24388

Only drop music db triggers when cleaning the music library if the triggers actually exist.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
