### PR TITLE
Players: Always reset CDataCacheCore on close file

### DIFF
--- a/xbmc/cores/DataCacheCore.cpp
+++ b/xbmc/cores/DataCacheCore.cpp
@@ -34,20 +34,27 @@ void CDataCacheCore::Reset()
 {
   {
     std::unique_lock<CCriticalSection> lock(m_stateSection);
-
-    m_stateInfo.m_speed = 1.0;
-    m_stateInfo.m_tempo = 1.0;
-    m_stateInfo.m_stateSeeking = false;
-    m_stateInfo.m_renderGuiLayer = false;
-    m_stateInfo.m_renderVideoLayer = false;
+    m_stateInfo = {};
     m_playerStateChanged = false;
   }
-
+  {
+    std::unique_lock<CCriticalSection> lock(m_videoPlayerSection);
+    m_playerVideoInfo = {};
+  }
+  {
+    std::unique_lock<CCriticalSection> lock(m_audioPlayerSection);
+    m_playerAudioInfo = {};
+  }
+  m_hasAVInfoChanges = false;
+  {
+    std::unique_lock<CCriticalSection> lock(m_renderSection);
+    m_renderInfo = {};
+  }
   {
     std::unique_lock<CCriticalSection> lock(m_contentSection);
-
     m_contentInfo.Reset();
   }
+  m_timeInfo = {};
 }
 
 bool CDataCacheCore::HasAVInfoChanges()

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -118,7 +118,7 @@ bool CExternalPlayer::CloseFile(bool reopen)
     TerminateProcess(m_processInfo.hProcess, 1);
   }
 #endif
-
+  CServiceBroker::GetDataCacheCore().Reset();
   return true;
 }
 

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -258,8 +258,11 @@ bool CRetroPlayer::CloseFile(bool reopen /* = false */)
   m_gameClient.reset();
 
   m_renderManager.reset();
+  if (m_processInfo)
+  {
+    m_processInfo->ResetInfo();
+  }
   m_processInfo.reset();
-
   CLog::Log(LOGDEBUG, "RetroPlayer[PLAYER]: Playback ended");
   m_callback.OnPlayBackEnded();
 

--- a/xbmc/cores/RetroPlayer/process/RPProcessInfo.cpp
+++ b/xbmc/cores/RetroPlayer/process/RPProcessInfo.cpp
@@ -140,22 +140,7 @@ void CRPProcessInfo::ResetInfo()
 {
   if (m_dataCache != nullptr)
   {
-    m_dataCache->SetVideoDecoderName("", false);
-    m_dataCache->SetVideoDeintMethod("");
-    m_dataCache->SetVideoPixelFormat("");
-    m_dataCache->SetVideoDimensions(0, 0);
-    m_dataCache->SetVideoFps(0.0f);
-    m_dataCache->SetVideoDAR(1.0f);
-    m_dataCache->SetAudioDecoderName("");
-    m_dataCache->SetAudioChannels("");
-    m_dataCache->SetAudioSampleRate(0);
-    m_dataCache->SetAudioBitsPerSample(0);
-    m_dataCache->SetRenderClockSync(false);
-    m_dataCache->SetStateSeeking(false);
-    m_dataCache->SetSpeed(1.0f, 1.0f);
-    m_dataCache->SetGuiRender(true); //! @todo
-    m_dataCache->SetVideoRender(false); //! @todo
-    m_dataCache->SetPlayTimes(0, 0, 0, 0);
+    m_dataCache->Reset();
   }
 }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -729,9 +729,7 @@ bool CVideoPlayer::CloseFile(bool reopen)
   }
 
   m_Edl.Clear();
-  CServiceBroker::GetDataCacheCore().SetEditList(m_Edl.GetEditList());
-  CServiceBroker::GetDataCacheCore().SetCuts(m_Edl.GetCutMarkers());
-  CServiceBroker::GetDataCacheCore().SetSceneMarkers(m_Edl.GetSceneMarkers());
+  CServiceBroker::GetDataCacheCore().Reset();
 
   m_HasVideo = false;
   m_HasAudio = false;

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -543,7 +543,7 @@ bool PAPlayer::CloseFile(bool reopen)
       lock.lock();
     }
   }
-
+  CServiceBroker::GetDataCacheCore().Reset();
   return true;
 }
 

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -463,9 +463,11 @@ bool CUPnPPlayer::CloseFile(bool reopen)
     m_callback.OnPlayBackStopped();
   }
   StopThread(true);
+  CServiceBroker::GetDataCacheCore().Reset();
   return true;
 failed:
   m_logger->error("CloseFile - unable to stop playback");
+  CServiceBroker::GetDataCacheCore().Reset();
   return false;
 }
 


### PR DESCRIPTION
## Description
Found while trying to extend datacachecore. As far as I remember this class was created as a cache directory for players to store information so that the GUI thread (info interface) could obtain the info without stalling the players. Setting a break point on `Reset()` I've found this is only called by the application when playing a new file. Means that state information is left in memory for no reason after a file is closed by the player.
Just call reset when all players Close the file.

## Motivation and context
Better usage of memory resources. In this case it doesn't really make much difference since it just resets the state back to the initial state and the structures sizes are the same. But if for some reason you want to store dynamic information in the cache (e.g. I want to store a pointer to the item being played) it'll be left in memory instead of being garbage collected. 

## How has this been tested?
Runtime tested on linux

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
