### PR TITLE
[Backport] Fix missing controller icon in Peripheral Dialog

### DIFF
--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -322,7 +322,8 @@ void CPeripheralBus::GetDirectory(const std::string& strPath, CFileItemList& ite
 
     peripheralFile->SetProperty("version", strVersion);
     peripheralFile->SetLabel2(strDetails);
-    peripheralFile->SetArt("icon", "DefaultAddon.png");
+    peripheralFile->SetArt("icon", peripheral->GetIcon());
+
     items.Add(peripheralFile);
   }
 }


### PR DESCRIPTION
## Description

Backport of https://github.com/xbmc/xbmc/pull/24384.

> This PR updates the peripheral bus base class to take icon into account, without needing the peripheral bus to be peripheral.joystick. As a result, peripheral icons are now shown on Android.

## How has this been tested?

Included in my latest 20.2 build: https://github.com/garbear/xbmc/releases.

Code is unchanged from master PR. I'll make sure this is tested before 20.3 is released.

## What is the effect on users?

* Fixed peripheral icons not shown in Peripheral Dialog on Android

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
