### PR TITLE
[fix build on linux] forward declare CMediaSource in GUIDialogVideoMa…

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoManager.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.h
@@ -15,6 +15,7 @@
 
 class CFileItem;
 class CFileItemList;
+class CMediaSource;
 
 enum class VideoAssetType;
 


### PR DESCRIPTION
…nager.h

## Description
https://github.com/xbmc/xbmc/pull/24394 broke build at least on linux.
need to forward declare `CMediaSource`

## Motivation and context
```
[ 93%] Building CXX object build/video/dialogs/CMakeFiles/video_dialogs.dir/GUIDialogVideoManagerVersions.cpp.o
In file included from /home/fhw/xbmc/xbmc/video/dialogs/GUIDialogVideoManagerExtras.h:11,
                 from /home/fhw/xbmc/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp:9:
/home/fhw/xbmc/xbmc/video/dialogs/GUIDialogVideoManager.h:54:57: error: ‘CMediaSource’ was not declared in this scope
   54 |   void AppendItemFolderToFileBrowserSources(std::vector<CMediaSource>& sources);
      |                                                         ^~~~~~~~~~~~
/home/fhw/xbmc/xbmc/video/dialogs/GUIDialogVideoManager.h:54:69: error: template argument 1 is invalid
   54 |   void AppendItemFolderToFileBrowserSources(std::vector<CMediaSource>& sources);
      |                                                                     ^
/home/fhw/xbmc/xbmc/video/dialogs/GUIDialogVideoManager.h:54:69: error: template argument 2 is invalid
/home/fhw/xbmc/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp: In member function ‘void CGUIDialogVideoManagerExtras::AddVideoExtra()’:
/home/fhw/xbmc/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp:96:40: error: cannot convert ‘VECSOURCES’ {aka ‘std::vector<CMediaSource>’} to ‘int&’
   96 |   AppendItemFolderToFileBrowserSources(sources);
      |                                        ^~~~~~~
      |                                        |
      |                                        VECSOURCES {aka std::vector<CMediaSource>}
```

## How has this been tested?
it builds on bokkworm

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
