### PR TITLE
[Player Viewer] Three improvements

### DIFF
--- a/addons/skin.estuary/xml/Includes_Games.xml
+++ b/addons/skin.estuary/xml/Includes_Games.xml
@@ -352,7 +352,7 @@
 						<bottom>-20</bottom>
 						<left>-20</left>
 						<right>-20</right>
-						<ondown>5</ondown>
+						<ondown>7</ondown>
 						<label>$LOCALIZE[35110]</label>
 						<font>font37</font>
 						<textoffsetx>36</textoffsetx>
@@ -433,26 +433,26 @@
 					</control>
 				</control>
 				<control type="group">
-					<description>Area of the dialog for players</description>
+					<description>Area of the dialog for player controllers</description>
 					<top>136</top>
 					<height>576</height>
 					<control type="image">
-						<description>Player list background</description>
+						<description>Controller list background</description>
 						<top>-20</top>
 						<bottom>-20</bottom>
 						<left>-20</left>
 						<right>-20</right>
 						<texture border="40">buttons/dialogbutton-nofo.png</texture>
 					</control>
-					<control type="list" id="5">
-						<description>Player list</description>
+					<control type="list" id="7">
+						<description>Controller list</description>
 						<onup>3</onup>
-						<ondown>6</ondown>
+						<ondown>10</ondown>
 						<pagecontrol>61</pagecontrol>
 						<scrolltime tween="sine">200</scrolltime>
 						<orientation>vertical</orientation>
 						<itemlayout width="1740" height="96">
-							<include>GameDialogAgentLayout</include>
+							<include>AgentControllerList</include>
 						</itemlayout>
 						<focusedlayout width="1740" height="96">
 							<control type="image">
@@ -461,9 +461,9 @@
 								<left>-20</left>
 								<right>-20</right>
 								<texture border="40" colordiffuse="button_focus">buttons/dialogbutton-fo.png</texture>
-								<visible>Control.HasFocus(5)</visible>
+								<visible>Control.HasFocus(7)</visible>
 							</control>
-							<include>GameDialogAgentLayout</include>
+							<include>AgentControllerList</include>
 						</focusedlayout>
 						<!--
 							Note to skinners: this control can be populated
@@ -510,20 +510,20 @@
 					</control>
 				</control>
 				<control type="scrollbar" id="61">
-					<description>Agent list scroll bar</description>
+					<description>Controller list scroll bar</description>
 					<top>136</top>
 					<height>576</height>
 					<right>-12</right>
 					<width>12</width>
 					<orientation>vertical</orientation>
 				</control>
-				<control type="grouplist" id="6">
+				<control type="grouplist" id="10">
 					<description>Action buttons</description>
 					<left>-20</left>
 					<right>-20</right>
 					<bottom>-20</bottom>
 					<height>100</height>
-					<onup>5</onup>
+					<onup>7</onup>
 					<orientation>horizontal</orientation>
 					<itemgap>dialogbuttons_itemgap</itemgap>
 					<include content="DefaultDialogButton">
@@ -535,9 +535,9 @@
 			</control>
 		</control>
 	</include>
-	<include name="GameDialogAgentLayout">
+	<include name="AgentControllerList">
 		<control type="label">
-			<description>Player name</description>
+			<description>Controller name as reported by the driver</description>
 			<top>20</top>
 			<left>20</left>
 			<label>$INFO[ListItem.Label]</label>
@@ -546,7 +546,7 @@
 			<align>left</align>
 		</control>
 		<control type="gamecontrollerlist">
-			<description>Player's game controller list. Length should fit 13 listitems (12 players and one "input disabled" indicator).</description>
+			<description>Controller list which indicates the port a player's controller is connected to. Length should fit 13 listitems (12 controller items and one "input disabled" item).</description>
 			<right>0</right>
 			<width>1248</width>
 			<orientation>horizontal</orientation>

--- a/cmake/treedata/common/games.txt
+++ b/cmake/treedata/common/games.txt
@@ -3,7 +3,6 @@ xbmc/games/addons                  games/addons
 xbmc/games/addons/cheevos          games/addons/cheevos
 xbmc/games/addons/input            games/addons/input
 xbmc/games/addons/streams          games/addons/streams
-xbmc/games/agents                  games/agents
 xbmc/games/agents/input            games/agents/input
 xbmc/games/agents/windows          games/agents/windows
 xbmc/games/controllers             games/controllers

--- a/xbmc/cores/RetroPlayer/RetroPlayerInput.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayerInput.cpp
@@ -41,7 +41,7 @@ void CRetroPlayerInput::StartAgentManager()
   if (!m_bAgentManagerStarted)
   {
     m_bAgentManagerStarted = true;
-    m_processInfo.GetRenderContext().StartAgentManager(m_gameClient);
+    m_processInfo.GetRenderContext().StartAgentInput(m_gameClient);
   }
 }
 
@@ -50,7 +50,7 @@ void CRetroPlayerInput::StopAgentManager()
   if (m_bAgentManagerStarted)
   {
     m_bAgentManagerStarted = false;
-    m_processInfo.GetRenderContext().StopAgentManager();
+    m_processInfo.GetRenderContext().StopAgentInput();
   }
 }
 

--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
@@ -9,7 +9,7 @@
 #include "RenderContext.h"
 
 #include "games/GameServices.h"
-#include "games/agents/GameAgentManager.h"
+#include "games/agents/input/AgentInput.h"
 #include "rendering/RenderSystem.h"
 #include "settings/DisplaySettings.h"
 #include "settings/MediaSettings.h"
@@ -310,12 +310,12 @@ RESOLUTION_INFO& CRenderContext::GetResolutionInfo(RESOLUTION resolution)
   return m_mediaSettings.GetDefaultGameSettings();
 }
 
-void CRenderContext::StartAgentManager(GAME::GameClientPtr gameClient)
+void CRenderContext::StartAgentInput(GAME::GameClientPtr gameClient)
 {
-  m_gameServices.GameAgentManager().Start(std::move(gameClient));
+  m_gameServices.AgentInput().Start(std::move(gameClient));
 }
 
-void CRenderContext::StopAgentManager()
+void CRenderContext::StopAgentInput()
 {
-  m_gameServices.GameAgentManager().Stop();
+  m_gameServices.AgentInput().Stop();
 }

--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.h
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.h
@@ -105,8 +105,8 @@ public:
   ::CGameSettings& GetDefaultGameSettings();
 
   // Agent functions
-  void StartAgentManager(GAME::GameClientPtr gameClient);
-  void StopAgentManager();
+  void StartAgentInput(GAME::GameClientPtr gameClient);
+  void StopAgentInput();
 
 private:
   // Construction parameters

--- a/xbmc/games/GameServices.cpp
+++ b/xbmc/games/GameServices.cpp
@@ -11,7 +11,7 @@
 #include "controllers/Controller.h"
 #include "controllers/ControllerManager.h"
 #include "games/GameSettings.h"
-#include "games/agents/GameAgentManager.h"
+#include "games/agents/input/AgentInput.h"
 #include "profiles/ProfileManager.h"
 
 using namespace KODI;
@@ -26,7 +26,7 @@ CGameServices::CGameServices(CControllerManager& controllerManager,
     m_gameRenderManager(renderManager),
     m_profileManager(profileManager),
     m_gameSettings(new CGameSettings()),
-    m_gameAgentManager(new CGameAgentManager(peripheralManager, inputManager))
+    m_agentInput(std::make_unique<CAgentInput>(peripheralManager, inputManager))
 {
 }
 

--- a/xbmc/games/GameServices.h
+++ b/xbmc/games/GameServices.h
@@ -30,7 +30,7 @@ class CGUIGameRenderManager;
 
 namespace GAME
 {
-class CGameAgentManager;
+class CAgentInput;
 class CControllerManager;
 class CGameSettings;
 
@@ -70,7 +70,7 @@ public:
 
   RETRO::CGUIGameRenderManager& GameRenderManager() { return m_gameRenderManager; }
 
-  CGameAgentManager& GameAgentManager() { return *m_gameAgentManager; }
+  CAgentInput& AgentInput() { return *m_agentInput; }
 
 private:
   // Construction parameters
@@ -80,7 +80,7 @@ private:
 
   // Game services
   std::unique_ptr<CGameSettings> m_gameSettings;
-  std::unique_ptr<CGameAgentManager> m_gameAgentManager;
+  std::unique_ptr<CAgentInput> m_agentInput;
 };
 } // namespace GAME
 } // namespace KODI

--- a/xbmc/games/agents/CMakeLists.txt
+++ b/xbmc/games/agents/CMakeLists.txt
@@ -1,9 +1,0 @@
-set(SOURCES GameAgent.cpp
-            GameAgentManager.cpp
-)
-
-set(HEADERS GameAgent.h
-            GameAgentManager.h
-)
-
-core_add_library(games_agents)

--- a/xbmc/games/agents/input/AgentController.cpp
+++ b/xbmc/games/agents/input/AgentController.cpp
@@ -1,14 +1,14 @@
 /*
- *  Copyright (C) 2017-2023 Team Kodi
+ *  Copyright (C) 2017-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSES/README.md for more information.
  */
 
-#include "GameAgent.h"
+#include "AgentController.h"
 
-#include "games/agents/input/GameAgentJoystick.h"
+#include "AgentJoystick.h"
 #include "games/controllers/Controller.h"
 #include "games/controllers/ControllerLayout.h"
 #include "peripherals/devices/Peripheral.h"
@@ -16,29 +16,28 @@
 using namespace KODI;
 using namespace GAME;
 
-CGameAgent::CGameAgent(PERIPHERALS::PeripheralPtr peripheral)
-  : m_peripheral(std::move(peripheral)),
-    m_joystick(std::make_unique<CGameAgentJoystick>(m_peripheral))
+CAgentController::CAgentController(PERIPHERALS::PeripheralPtr peripheral)
+  : m_peripheral(std::move(peripheral)), m_joystick(std::make_unique<CAgentJoystick>(m_peripheral))
 {
   Initialize();
 }
 
-CGameAgent::~CGameAgent()
+CAgentController::~CAgentController()
 {
   Deinitialize();
 }
 
-void CGameAgent::Initialize()
+void CAgentController::Initialize()
 {
   m_joystick->Initialize();
 }
 
-void CGameAgent::Deinitialize()
+void CAgentController::Deinitialize()
 {
   m_joystick->Deinitialize();
 }
 
-std::string CGameAgent::GetPeripheralName() const
+std::string CAgentController::GetPeripheralName() const
 {
   std::string deviceName = m_peripheral->DeviceName();
 
@@ -53,12 +52,12 @@ std::string CGameAgent::GetPeripheralName() const
   return deviceName;
 }
 
-const std::string& CGameAgent::GetPeripheralLocation() const
+const std::string& CAgentController::GetPeripheralLocation() const
 {
   return m_peripheral->Location();
 }
 
-ControllerPtr CGameAgent::GetController() const
+ControllerPtr CAgentController::GetController() const
 {
   // Use joystick controller if joystick is initialized
   ControllerPtr controller = m_joystick->Appearance();
@@ -69,12 +68,12 @@ ControllerPtr CGameAgent::GetController() const
   return m_peripheral->ControllerProfile();
 }
 
-CDateTime CGameAgent::LastActive() const
+CDateTime CAgentController::LastActive() const
 {
   return m_peripheral->LastActive();
 }
 
-float CGameAgent::GetActivation() const
+float CAgentController::GetActivation() const
 {
   return m_joystick->GetActivation();
 }

--- a/xbmc/games/agents/input/AgentController.h
+++ b/xbmc/games/agents/input/AgentController.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017-2023 Team Kodi
+ *  Copyright (C) 2017-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -18,21 +18,21 @@ namespace KODI
 {
 namespace GAME
 {
-class CGameAgentJoystick;
+class CAgentJoystick;
 
 /*!
  * \ingroup games
  *
- * \brief Class to represent a game player (a.k.a. agent)
+ * \brief Class to represent the controller of a game player (a.k.a. agent)
  *
  * The term "agent" is used to distinguish game players from the myriad of other
  * uses of the term "player" in Kodi, such as media players and player cores.
  */
-class CGameAgent
+class CAgentController
 {
 public:
-  CGameAgent(PERIPHERALS::PeripheralPtr peripheral);
-  ~CGameAgent();
+  CAgentController(PERIPHERALS::PeripheralPtr peripheral);
+  ~CAgentController();
 
   // Lifecycle functions
   void Initialize();
@@ -51,7 +51,7 @@ private:
   const PERIPHERALS::PeripheralPtr m_peripheral;
 
   // Input parameters
-  std::unique_ptr<CGameAgentJoystick> m_joystick;
+  std::unique_ptr<CAgentJoystick> m_joystick;
 };
 
 } // namespace GAME

--- a/xbmc/games/agents/input/AgentInput.h
+++ b/xbmc/games/agents/input/AgentInput.h
@@ -34,6 +34,14 @@ namespace JOYSTICK
 {
 class IInputProvider;
 }
+namespace KEYBOARD
+{
+class IKeyboardInputProvider;
+}
+namespace MOUSE
+{
+class IMouseInputProvider;
+}
 
 namespace GAME
 {
@@ -82,8 +90,10 @@ public:
   void OnButtonRelease(MOUSE::BUTTON_ID button) override {}
 
   // Public interface
-  std::vector<std::shared_ptr<CAgentController>> GetControllers() const;
+  std::vector<std::shared_ptr<const CAgentController>> GetControllers() const;
   std::string GetPortAddress(JOYSTICK::IInputProvider* inputProvider) const;
+  std::string GetKeyboardAddress(KEYBOARD::IKeyboardInputProvider* inputProvider) const;
+  std::string GetMouseAddress(MOUSE::IMouseInputProvider* inputProvider) const;
   std::vector<std::string> GetInputPorts() const;
   float GetPortActivation(const std::string& address) const;
   float GetPeripheralActivation(const std::string& peripheralLocation) const;
@@ -136,13 +146,15 @@ private:
   GameClientPtr m_gameClient;
   bool m_bHasKeyboard = false;
   bool m_bHasMouse = false;
+  int m_initialMouseX{-1};
+  int m_initialMouseY{-1};
   std::vector<std::shared_ptr<CAgentController>> m_controllers;
 
   // Synchronization parameters
   mutable std::mutex m_controllerMutex;
 
   /*!
-   * \brief Map of input provider to joystick handler
+   * \brief Map of joystick input provider to joystick handler
    *
    * The input provider is a handle to agent input.
    *
@@ -154,6 +166,16 @@ private:
    * Not exposed to the game.
    */
   PortMap m_portMap;
+
+  /*!
+   * \brief Map of keyboard input provider to keyboard port address
+   */
+  std::map<KEYBOARD::IKeyboardInputProvider*, PortAddress> m_keyboardPort;
+
+  /*!
+   * \brief Map of mouse input provider to mouse port address
+   */
+  std::map<MOUSE::IMouseInputProvider*, PortAddress> m_mousePort;
 
   /*!
    * \brief Map of the current ports to their peripheral

--- a/xbmc/games/agents/input/AgentJoystick.cpp
+++ b/xbmc/games/agents/input/AgentJoystick.cpp
@@ -1,12 +1,12 @@
 /*
-*  Copyright (C) 2023 Team Kodi
+*  Copyright (C) 2023-2024 Team Kodi
 *  This file is part of Kodi - https://kodi.tv
 *
 *  SPDX-License-Identifier: GPL-2.0-or-later
 *  See LICENSES/README.md for more information.
 */
 
-#include "GameAgentJoystick.h"
+#include "AgentJoystick.h"
 
 #include "games/controllers/Controller.h"
 #include "games/controllers/input/ControllerActivity.h"
@@ -16,15 +16,15 @@
 using namespace KODI;
 using namespace GAME;
 
-CGameAgentJoystick::CGameAgentJoystick(PERIPHERALS::PeripheralPtr peripheral)
+CAgentJoystick::CAgentJoystick(PERIPHERALS::PeripheralPtr peripheral)
   : m_peripheral(std::move(peripheral)),
     m_controllerActivity(std::make_unique<CControllerActivity>())
 {
 }
 
-CGameAgentJoystick::~CGameAgentJoystick() = default;
+CAgentJoystick::~CAgentJoystick() = default;
 
-void CGameAgentJoystick::Initialize()
+void CAgentJoystick::Initialize()
 {
   // Record appearance to detect changes
   m_controllerAppearance = m_peripheral->ControllerProfile();
@@ -36,7 +36,7 @@ void CGameAgentJoystick::Initialize()
   inputProvider->RegisterInputHandler(this, true);
 }
 
-void CGameAgentJoystick::Deinitialize()
+void CAgentJoystick::Deinitialize()
 {
   // Upcast peripheral to input interface
   JOYSTICK::IInputProvider* inputProvider = m_peripheral.get();
@@ -48,12 +48,12 @@ void CGameAgentJoystick::Deinitialize()
   m_controllerAppearance.reset();
 }
 
-float CGameAgentJoystick::GetActivation() const
+float CAgentJoystick::GetActivation() const
 {
   return m_controllerActivity->GetActivation();
 }
 
-std::string CGameAgentJoystick::ControllerID(void) const
+std::string CAgentJoystick::ControllerID(void) const
 {
   if (m_controllerAppearance)
     return m_controllerAppearance->ID();
@@ -61,61 +61,61 @@ std::string CGameAgentJoystick::ControllerID(void) const
   return "";
 }
 
-bool CGameAgentJoystick::HasFeature(const std::string& feature) const
+bool CAgentJoystick::HasFeature(const std::string& feature) const
 {
   return true; // Capture input for all features
 }
 
-bool CGameAgentJoystick::AcceptsInput(const std::string& feature) const
+bool CAgentJoystick::AcceptsInput(const std::string& feature) const
 {
   return true; // Accept input for all features
 }
 
-bool CGameAgentJoystick::OnButtonPress(const std::string& feature, bool bPressed)
+bool CAgentJoystick::OnButtonPress(const std::string& feature, bool bPressed)
 {
   m_controllerActivity->OnButtonPress(bPressed);
   return true;
 }
 
-void CGameAgentJoystick::OnButtonHold(const std::string& feature, unsigned int holdTimeMs)
+void CAgentJoystick::OnButtonHold(const std::string& feature, unsigned int holdTimeMs)
 {
   m_controllerActivity->OnButtonPress(true);
 }
 
-bool CGameAgentJoystick::OnButtonMotion(const std::string& feature,
-                                        float magnitude,
-                                        unsigned int motionTimeMs)
+bool CAgentJoystick::OnButtonMotion(const std::string& feature,
+                                    float magnitude,
+                                    unsigned int motionTimeMs)
 {
   m_controllerActivity->OnButtonMotion(magnitude);
   return true;
 }
 
-bool CGameAgentJoystick::OnAnalogStickMotion(const std::string& feature,
-                                             float x,
-                                             float y,
-                                             unsigned int motionTimeMs)
+bool CAgentJoystick::OnAnalogStickMotion(const std::string& feature,
+                                         float x,
+                                         float y,
+                                         unsigned int motionTimeMs)
 {
   m_controllerActivity->OnAnalogStickMotion(x, y);
   return true;
 }
 
-bool CGameAgentJoystick::OnWheelMotion(const std::string& feature,
-                                       float position,
-                                       unsigned int motionTimeMs)
+bool CAgentJoystick::OnWheelMotion(const std::string& feature,
+                                   float position,
+                                   unsigned int motionTimeMs)
 {
   m_controllerActivity->OnWheelMotion(position);
   return true;
 }
 
-bool CGameAgentJoystick::OnThrottleMotion(const std::string& feature,
-                                          float position,
-                                          unsigned int motionTimeMs)
+bool CAgentJoystick::OnThrottleMotion(const std::string& feature,
+                                      float position,
+                                      unsigned int motionTimeMs)
 {
   m_controllerActivity->OnThrottleMotion(position);
   return true;
 }
 
-void CGameAgentJoystick::OnInputFrame()
+void CAgentJoystick::OnInputFrame()
 {
   m_controllerActivity->OnInputFrame();
 }

--- a/xbmc/games/agents/input/AgentJoystick.h
+++ b/xbmc/games/agents/input/AgentJoystick.h
@@ -1,5 +1,5 @@
 /*
-*  Copyright (C) 2023 Team Kodi
+*  Copyright (C) 2023-2024 Team Kodi
 *  This file is part of Kodi - https://kodi.tv
 *
 *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -23,12 +23,12 @@ class CControllerActivity;
  *
  * \brief Handles game controller events for game agent functionality
  */
-class CGameAgentJoystick : public JOYSTICK::IInputHandler
+class CAgentJoystick : public JOYSTICK::IInputHandler
 {
 public:
-  CGameAgentJoystick(PERIPHERALS::PeripheralPtr peripheral);
+  CAgentJoystick(PERIPHERALS::PeripheralPtr peripheral);
 
-  ~CGameAgentJoystick() override;
+  ~CAgentJoystick() override;
 
   void Initialize();
   void Deinitialize();

--- a/xbmc/games/agents/input/CMakeLists.txt
+++ b/xbmc/games/agents/input/CMakeLists.txt
@@ -1,7 +1,11 @@
-set(SOURCES GameAgentJoystick.cpp
+set(SOURCES AgentController.cpp
+            AgentInput.cpp
+            AgentJoystick.cpp
 )
 
-set(HEADERS GameAgentJoystick.h
+set(HEADERS AgentController.h
+            AgentInput.h
+            AgentJoystick.h
 )
 
-core_add_library(games_agent_input)
+core_add_library(games_agents_input)

--- a/xbmc/games/agents/windows/CMakeLists.txt
+++ b/xbmc/games/agents/windows/CMakeLists.txt
@@ -1,11 +1,11 @@
-set(SOURCES GUIAgentList.cpp
+set(SOURCES GUIAgentControllerList.cpp
             GUIAgentWindow.cpp
 )
 
-set(HEADERS GUIAgentDefines.h
-            GUIAgentList.h
+set(HEADERS GUIAgentControllerList.h
+            GUIAgentDefines.h
             GUIAgentWindow.h
-            IAgentList.h
+            IAgentControllerList.h
 )
 
 core_add_library(games_agents_windows)

--- a/xbmc/games/agents/windows/GUIAgentControllerList.cpp
+++ b/xbmc/games/agents/windows/GUIAgentControllerList.cpp
@@ -138,8 +138,9 @@ void CGUIAgentControllerList::Refresh()
 
   CAgentInput& agentInput = CServiceBroker::GetGameServices().AgentInput();
 
-  std::vector<std::shared_ptr<CAgentController>> agentControllers = agentInput.GetControllers();
-  for (const std::shared_ptr<CAgentController>& agentController : agentControllers)
+  std::vector<std::shared_ptr<const CAgentController>> agentControllers =
+      agentInput.GetControllers();
+  for (const std::shared_ptr<const CAgentController>& agentController : agentControllers)
     AddItem(*agentController);
 
   // Add a "No controllers connected" item if no agents are available
@@ -261,8 +262,9 @@ void CGUIAgentControllerList::OnControllerSelect(const CFileItem& selectedAgentI
 {
   CAgentInput& agentInput = CServiceBroker::GetGameServices().AgentInput();
 
-  std::vector<std::shared_ptr<CAgentController>> agentControllers = agentInput.GetControllers();
-  for (const std::shared_ptr<CAgentController>& agentController : agentControllers)
+  std::vector<std::shared_ptr<const CAgentController>> agentControllers =
+      agentInput.GetControllers();
+  for (const std::shared_ptr<const CAgentController>& agentController : agentControllers)
   {
     PERIPHERALS::PeripheralPtr peripheral = agentController->GetPeripheral();
     if (peripheral && peripheral->Location() == selectedAgentItem.GetPath())

--- a/xbmc/games/agents/windows/GUIAgentControllerList.h
+++ b/xbmc/games/agents/windows/GUIAgentControllerList.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2022-2023 Team Kodi
+ *  Copyright (C) 2022-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "IAgentList.h"
+#include "IAgentControllerList.h"
 #include "addons/AddonEvents.h"
 #include "games/GameTypes.h"
 #include "games/controllers/ControllerTypes.h"
@@ -28,16 +28,18 @@ namespace KODI
 {
 namespace GAME
 {
+class CAgentController;
+
 /*!
  * \ingroup games
  */
-class CGUIAgentList : public IAgentList, public Observer
+class CGUIAgentControllerList : public IAgentControllerList, public Observer
 {
 public:
-  CGUIAgentList(CGUIWindow& window);
-  ~CGUIAgentList() override;
+  CGUIAgentControllerList(CGUIWindow& window);
+  ~CGUIAgentControllerList() override;
 
-  // Implementation of IAgentList
+  // Implementation of IAgentControllerList
   void OnWindowLoaded() override;
   void OnWindowUnload() override;
   bool Initialize(GameClientPtr gameClient) override;
@@ -57,13 +59,13 @@ private:
   void OnEvent(const ADDON::AddonEvent& event);
 
   // GUI functions
-  void AddItem(const CGameAgent& agent);
+  void AddItem(const CAgentController& agentController);
   void CleanupItems();
   void OnItemFocus(unsigned int itemIndex);
-  void OnAgentFocus(const std::string& focusedAgent);
+  void OnControllerFocus(const std::string& focusedAgent);
   void OnItemSelect(unsigned int itemIndex);
-  void OnAgentSelect(const CFileItem& selectedAgentItem);
-  void ShowAgentDialog(const CGameAgent& agent);
+  void OnControllerSelect(const CFileItem& selectedAgentItem);
+  void ShowControllerDialog(const CAgentController& agentController);
 
   // Construction parameters
   CGUIWindow& m_guiWindow;

--- a/xbmc/games/agents/windows/GUIAgentDefines.h
+++ b/xbmc/games/agents/windows/GUIAgentDefines.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017-2023 Team Kodi
+ *  Copyright (C) 2017-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -12,7 +12,7 @@ constexpr auto AGENT_DIALOG_XML = "DialogGameControllers.xml";
 
 // GUI control IDs
 constexpr auto CONTROL_ACTIVE_PORT_LIST = 4;
-constexpr auto CONTROL_AGENT_LIST = 5;
+constexpr auto CONTROL_AGENT_CONTROLLER_LIST = 7;
 
 // GUI button IDs
 constexpr auto CONTROL_AGENT_CLOSE_BUTTON = 18;

--- a/xbmc/games/agents/windows/GUIAgentList.cpp
+++ b/xbmc/games/agents/windows/GUIAgentList.cpp
@@ -75,6 +75,7 @@ bool CGUIAgentList::Initialize(GameClientPtr gameClient)
 
   // Initialize GUI
   Refresh();
+  m_viewControl->SetSelectedItem(0);
 
   // Register observers
   if (m_gameClient)

--- a/xbmc/games/agents/windows/GUIAgentWindow.cpp
+++ b/xbmc/games/agents/windows/GUIAgentWindow.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2022-2023 Team Kodi
+ *  Copyright (C) 2022-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -8,9 +8,8 @@
 
 #include "GUIAgentWindow.h"
 
+#include "GUIAgentControllerList.h"
 #include "GUIAgentDefines.h"
-#include "GUIAgentList.h"
-#include "IAgentList.h"
 #include "ServiceBroker.h"
 #include "addons/AddonManager.h"
 #include "addons/IAddon.h"
@@ -33,7 +32,7 @@ using namespace GAME;
 CGUIAgentWindow::CGUIAgentWindow()
   : CGUIDialog(WINDOW_DIALOG_GAME_AGENTS, AGENT_DIALOG_XML),
     m_portList(std::make_unique<CGUIActivePortList>(*this, CONTROL_ACTIVE_PORT_LIST, true)),
-    m_agentList(std::make_unique<CGUIAgentList>(*this))
+    m_controllerList(std::make_unique<CGUIAgentControllerList>(*this))
 {
   // Initialize CGUIWindow
   m_loadType = KEEP_IN_MEMORY;
@@ -51,9 +50,10 @@ bool CGUIAgentWindow::OnMessage(CGUIMessage& message)
     case GUI_MSG_SETFOCUS:
     {
       const int controlId = message.GetControlId();
-      if (m_agentList->HasControl(controlId) && m_agentList->GetCurrentControl() != controlId)
+      if (m_controllerList->HasControl(controlId) &&
+          m_controllerList->GetCurrentControl() != controlId)
       {
-        FocusAgentList();
+        FocusControllerList();
         bHandled = true;
       }
       break;
@@ -67,12 +67,12 @@ bool CGUIAgentWindow::OnMessage(CGUIMessage& message)
         CloseDialog();
         bHandled = true;
       }
-      else if (m_agentList->HasControl(controlId))
+      else if (m_controllerList->HasControl(controlId))
       {
         const int actionId = message.GetParam1();
         if (actionId == ACTION_SELECT_ITEM || actionId == ACTION_MOUSE_LEFT_CLICK)
         {
-          OnAgentClick();
+          OnControllerClick();
           bHandled = true;
         }
       }
@@ -89,9 +89,9 @@ bool CGUIAgentWindow::OnMessage(CGUIMessage& message)
           bHandled = true;
           break;
         }
-        case CONTROL_AGENT_LIST:
+        case CONTROL_AGENT_CONTROLLER_LIST:
         {
-          UpdateAgentList();
+          UpdateControllerList();
           bHandled = true;
           break;
         }
@@ -115,19 +115,19 @@ void CGUIAgentWindow::FrameMove()
 {
   CGUIDialog::FrameMove();
 
-  m_agentList->FrameMove();
+  m_controllerList->FrameMove();
 }
 
 void CGUIAgentWindow::OnWindowLoaded()
 {
   CGUIDialog::OnWindowLoaded();
 
-  m_agentList->OnWindowLoaded();
+  m_controllerList->OnWindowLoaded();
 }
 
 void CGUIAgentWindow::OnWindowUnload()
 {
-  m_agentList->OnWindowUnload();
+  m_controllerList->OnWindowUnload();
 
   CGUIDialog::OnWindowUnload();
 }
@@ -153,13 +153,13 @@ void CGUIAgentWindow::OnInitWindow()
 
   // Initialize GUI
   m_portList->Initialize(m_gameClient);
-  m_agentList->Initialize(m_gameClient);
+  m_controllerList->Initialize(m_gameClient);
 }
 
 void CGUIAgentWindow::OnDeinitWindow(int nextWindowID)
 {
   // Deinitialize GUI
-  m_agentList->Deinitialize();
+  m_controllerList->Deinitialize();
   m_portList->Deinitialize();
 
   // Deinitialize game properties
@@ -178,17 +178,17 @@ void CGUIAgentWindow::UpdateActivePortList()
   m_portList->Refresh();
 }
 
-void CGUIAgentWindow::UpdateAgentList()
+void CGUIAgentWindow::UpdateControllerList()
 {
-  m_agentList->Refresh();
+  m_controllerList->Refresh();
 }
 
-void CGUIAgentWindow::FocusAgentList()
+void CGUIAgentWindow::FocusControllerList()
 {
-  m_agentList->SetFocused();
+  m_controllerList->SetFocused();
 }
 
-void CGUIAgentWindow::OnAgentClick()
+void CGUIAgentWindow::OnControllerClick()
 {
-  m_agentList->OnSelect();
+  m_controllerList->OnSelect();
 }

--- a/xbmc/games/agents/windows/GUIAgentWindow.h
+++ b/xbmc/games/agents/windows/GUIAgentWindow.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2022-2023 Team Kodi
+ *  Copyright (C) 2022-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -18,7 +18,7 @@ namespace KODI
 namespace GAME
 {
 class IActivePortList;
-class IAgentList;
+class IAgentControllerList;
 
 /*!
  * \ingroup games
@@ -47,14 +47,14 @@ private:
   // Actions for port list
   void UpdateActivePortList();
 
-  // Actions for agent list
-  void UpdateAgentList();
-  void FocusAgentList();
-  void OnAgentClick();
+  // Actions for controller list
+  void UpdateControllerList();
+  void FocusControllerList();
+  void OnControllerClick();
 
   // GUI parameters
   std::unique_ptr<IActivePortList> m_portList;
-  std::unique_ptr<IAgentList> m_agentList;
+  std::unique_ptr<IAgentControllerList> m_controllerList;
 
   // Game parameters
   GameClientPtr m_gameClient;

--- a/xbmc/games/agents/windows/IAgentControllerList.h
+++ b/xbmc/games/agents/windows/IAgentControllerList.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2021-2023 Team Kodi
+ *  Copyright (C) 2021-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -17,25 +17,19 @@ namespace GAME
 /*!
  * \ingroup games
  *
- * \brief A list populated by game-playing agents (\ref CGameAgent)
+ * \brief A list populated by the controllers of game-playing agents (\ref CGameAgent)
  *
- * This class manages the behavior of the player list (with control ID 5) in
+ * This class manages the behavior of the controller list (with control ID 7) in
  * the player dialog (<b>`GameAgents`</b> window).
- *
- * The list is populated dynamically by the players in the current game.
- *
- * Currently, this is identical to the connected joysticks, because Kodi doesn't
- * yet have a player abstraction. This is planned for a later release along with
- * a full-featured Player Manager.
  *
  * The active ports are determined by \ref IActivePortList.
  *
  * The list is populated by the \ref CGUIGameControllerProvider.
  */
-class IAgentList
+class IAgentControllerList
 {
 public:
-  virtual ~IAgentList() = default;
+  virtual ~IAgentControllerList() = default;
 
   /*!
    * \brief Callback when the GUI window is loaded

--- a/xbmc/games/controllers/guicontrols/GUIGameController.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIGameController.cpp
@@ -12,7 +12,7 @@
 #include "ServiceBroker.h"
 #include "games/GameServices.h"
 #include "games/addons/input/GameClientTopology.h"
-#include "games/agents/GameAgentManager.h"
+#include "games/agents/input/AgentInput.h"
 #include "games/controllers/Controller.h"
 #include "games/controllers/ControllerLayout.h"
 #include "guilib/GUIListItem.h"
@@ -69,17 +69,16 @@ void CGUIGameController::DoProcess(unsigned int currentTime, CDirtyRegionList& d
     peripheralLocation = m_peripheralLocation;
   }
 
-  const GAME::CGameAgentManager& agentManager =
-      CServiceBroker::GetGameServices().GameAgentManager();
+  const GAME::CAgentInput& agentInput = CServiceBroker::GetGameServices().AgentInput();
 
   // Highlight the controller if it is active
   float activation = 0.0f;
 
   if (!portAddress.empty())
-    activation = agentManager.GetPortActivation(portAddress);
+    activation = agentInput.GetPortActivation(portAddress);
 
   if (!peripheralLocation.empty())
-    activation = std::max(agentManager.GetPeripheralActivation(peripheralLocation), activation);
+    activation = std::max(agentInput.GetPeripheralActivation(peripheralLocation), activation);
 
   SetActivation(activation);
 

--- a/xbmc/games/controllers/guicontrols/GUIGameControllerList.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIGameControllerList.cpp
@@ -15,8 +15,8 @@
 #include "games/addons/input/GameClientInput.h"
 #include "games/addons/input/GameClientJoystick.h"
 #include "games/addons/input/GameClientTopology.h"
-#include "games/agents/GameAgent.h"
-#include "games/agents/GameAgentManager.h"
+#include "games/agents/input/AgentController.h"
+#include "games/agents/input/AgentInput.h"
 #include "games/controllers/Controller.h"
 #include "games/controllers/listproviders/GUIGameControllerProvider.h"
 #include "guilib/GUIListItem.h"
@@ -65,10 +65,10 @@ void CGUIGameControllerList::UpdateInfo(const CGUIListItem* item)
   if (item == nullptr)
     return;
 
-  CGameAgentManager& agentManager = CServiceBroker::GetGameServices().GameAgentManager();
+  CAgentInput& agentInput = CServiceBroker::GetGameServices().AgentInput();
 
   // Update port count
-  const std::vector<std::string> inputPorts = agentManager.GetInputPorts();
+  const std::vector<std::string> inputPorts = agentInput.GetInputPorts();
   m_portCount = inputPorts.size();
 
   // Update port index
@@ -148,30 +148,30 @@ void CGUIGameControllerList::UpdatePort(int itemNumber, const std::vector<std::s
   if (itemNumber < 1)
     return;
 
-  const unsigned int agentIndex = static_cast<unsigned int>(itemNumber - 1);
+  const unsigned int controllerIndex = static_cast<unsigned int>(itemNumber - 1);
 
-  CGameAgentManager& agentManager = CServiceBroker::GetGameServices().GameAgentManager();
+  CAgentInput& agentInput = CServiceBroker::GetGameServices().AgentInput();
 
-  GameAgentVec agents = agentManager.GetAgents();
-  if (agentIndex < static_cast<unsigned int>(agents.size()))
+  std::vector<std::shared_ptr<CAgentController>> agentControllers = agentInput.GetControllers();
+  if (controllerIndex < static_cast<unsigned int>(agentControllers.size()))
   {
-    const GameAgentPtr& agent = agents.at(agentIndex);
-    UpdatePortIndex(agent->GetPeripheral(), inputPorts);
-    UpdatePeripheral(agent->GetPeripheral());
+    const std::shared_ptr<CAgentController>& agentController = agentControllers.at(controllerIndex);
+    UpdatePortIndex(agentController->GetPeripheral(), inputPorts);
+    UpdatePeripheral(agentController->GetPeripheral());
   }
 }
 
 void CGUIGameControllerList::UpdatePortIndex(const PERIPHERALS::PeripheralPtr& agentPeripheral,
                                              const std::vector<std::string>& inputPorts)
 {
-  CGameAgentManager& agentManager = CServiceBroker::GetGameServices().GameAgentManager();
+  CAgentInput& agentInput = CServiceBroker::GetGameServices().AgentInput();
 
   // Upcast peripheral to input provider
   JOYSTICK::IInputProvider* const inputProvider =
       static_cast<JOYSTICK::IInputProvider*>(agentPeripheral.get());
 
   // See if the input provider has a port address
-  std::string portAddress = agentManager.GetPortAddress(inputProvider);
+  std::string portAddress = agentInput.GetPortAddress(inputProvider);
   if (portAddress.empty())
     return;
 

--- a/xbmc/games/controllers/guicontrols/GUIGameControllerList.h
+++ b/xbmc/games/controllers/guicontrols/GUIGameControllerList.h
@@ -60,6 +60,8 @@ private:
                        const std::vector<std::string>& inputPorts);
   void UpdatePeripheral(const PERIPHERALS::PeripheralPtr& agentPeripheral);
 
+  static std::string GetPortAddress(const PERIPHERALS::PeripheralPtr& agentPeripheral);
+
   // Game properties
   GameClientPtr m_gameClient;
   unsigned int m_portCount{0};

--- a/xbmc/utils/Observer.h
+++ b/xbmc/utils/Observer.h
@@ -25,7 +25,7 @@ typedef enum
   // Used for example when the subtitle alignment position change
   ObservableMessagePositionChanged,
   ObservableMessageGamePortsChanged,
-  ObservableMessageGameAgentsChanged,
+  ObservableMessageAgentControllersChanged,
 } ObservableMessage;
 
 class Observer


### PR DESCRIPTION
## Description

This PR contains three improvements to the Player Viewer:

### Fix jumping past first controller when window is re-opened

A minor annoyance, when the window is re-opened the focus jumps past the first item in the controller list.

### Refactor agent input for code clarity

Pure refactor, no functional changes.

I created the Player Viewer by stripping down my work-in-progress Player Manager, and my idea for the window hadn't fully been flushed out. So when I ended up with the Player Viewer, the naming of a lot of stuff was slightly off, and the code wasn't well organized.

Now, 100% of the agent code is organized into two folders, `windows/` and `input/`. The naming is simpler, more clear, and more consistent with the rest of the games code.

I made the following name changes:

* GameAgentManager -> input/AgentInput
* GameAgent -> input/AgentController
* GameAgentJoystick -> input/AgentJoystick
* GUIAgentList -> GUIAgentControllerList _(future Player Manager will then get GUIAgentAvatarList)_
* IAgentList -> IAgentControllerList _(and Player Manager will then get IAgentAvatarList)_
* ObservableMessageGameAgentsChanged, -> ObservableMessageAgentControllersChanged

### Added keyboard and mouse to Player Viewer

The keyboard and mouse are now shown in the controller list in the Player Viewer.

For cores with keyboard/mouse input, these show up assigned to their respective controller.

For cores without keyboard/mouse input, these show up in the "input disabled" column, indicating to the player that we can't yet control joysticks with a keyboard or mouse. Of course, the goal of the Player Manager is to allow this.

Example screenshot of SNES with two ports:

![screenshot00002](https://github.com/xbmc/xbmc/assets/531482/9217872e-1026-4a46-b747-854b1596c50a)

Example screenshot when a Multitap is then connected:

![screenshot00003](https://github.com/xbmc/xbmc/assets/531482/e68bef86-09df-42b3-a46d-34fafbc16f45)

Example screenshot of a core with keyboard/mouse support:

![screenshot00004](https://github.com/xbmc/xbmc/assets/531482/89475516-c547-4902-b1d3-9efbc14468c7)

## Motivation and context

I decided to make these quality-of-life improvements as I worked on my Player Manager, and noticed deficiencies in the current Viewer.

## How has this been tested?

Tested on Windows 10 x64 and Ubuntu 22.04. Android testing is still a TODO.

## What is the effect on users?

* Fixed navigation in the Player Viewer
* Added keyboard and mouse to the Player Viewer

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
