### PR TITLE
remove inclusion of MediaSource.h in GUIDialogVideoInfo.h

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoInfo.h
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.h
@@ -8,14 +8,15 @@
 
 #pragma once
 
-#include "MediaSource.h"
 #include "guilib/GUIDialog.h"
 #include "media/MediaType.h"
 
 #include <memory>
+#include <vector>
 
 class CFileItem;
 class CFileItemList;
+class CMediaSource;
 class CVideoDatabase;
 
 class CGUIDialogVideoInfo :
@@ -37,7 +38,8 @@ public:
   const CFileItemList& CurrentDirectory() const { return *m_castList; }
   bool HasListItems() const override { return true; }
 
-  static void AddItemPathToFileBrowserSources(VECSOURCES &sources, const CFileItem &item);
+  static void AddItemPathToFileBrowserSources(std::vector<CMediaSource>& sources,
+                                              const CFileItem& item);
 
   static int ManageVideoItem(const std::shared_ptr<CFileItem>& item);
   static bool UpdateVideoItemTitle(const std::shared_ptr<CFileItem>& pItem);

--- a/xbmc/video/dialogs/GUIDialogVideoManager.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -10,6 +10,7 @@
 
 #include "FileItem.h"
 #include "GUIUserMessages.h"
+#include "MediaSource.h"
 #include "ServiceBroker.h"
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogSelect.h"


### PR DESCRIPTION
follow up to https://github.com/xbmc/xbmc/pull/24405
fix include and forward declaration

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
