### PR TITLE
[DataCacheCore] Make players store the current playing item in data cache core, remove CApp dependency

### DIFF
--- a/xbmc/cores/DataCacheCore.cpp
+++ b/xbmc/cores/DataCacheCore.cpp
@@ -8,6 +8,7 @@
 
 #include "DataCacheCore.h"
 
+#include "FileItem.h"
 #include "ServiceBroker.h"
 #include "cores/EdlEdit.h"
 
@@ -41,6 +42,7 @@ void CDataCacheCore::Reset()
     m_stateInfo.m_renderGuiLayer = false;
     m_stateInfo.m_renderVideoLayer = false;
     m_playerStateChanged = false;
+    m_item.reset();
   }
 
   {
@@ -475,6 +477,18 @@ int64_t CDataCacheCore::GetMaxTime()
 {
   std::unique_lock<CCriticalSection> lock(m_stateSection);
   return m_timeInfo.m_timeMax;
+}
+
+void CDataCacheCore::SetFileItem(const CFileItem& item)
+{
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  m_item = std::make_shared<CFileItem>(item);
+}
+
+std::shared_ptr<CFileItem> CDataCacheCore::GetFileItem() const
+{
+  std::unique_lock<CCriticalSection> lock(m_stateSection);
+  return m_item;
 }
 
 float CDataCacheCore::GetPlayPercentage()

--- a/xbmc/cores/DataCacheCore.h
+++ b/xbmc/cores/DataCacheCore.h
@@ -13,8 +13,11 @@
 
 #include <atomic>
 #include <chrono>
+#include <memory>
 #include <string>
 #include <vector>
+
+class CFileItem;
 
 class CDataCacheCore
 {
@@ -195,8 +198,23 @@ public:
    */
   int64_t GetMaxTime();
 
+  /*!
+   * \brief Cache the current playing item
+   *
+   * \param item - the item to store
+   */
+  void SetFileItem(const CFileItem& item);
+
+  /*!
+   * \brief Get the current playing item
+   *
+   * \return the item currently cached by the player
+   */
+  std::shared_ptr<CFileItem> GetFileItem() const;
+
 protected:
   std::atomic_bool m_hasAVInfoChanges = false;
+  std::shared_ptr<CFileItem> m_item;
 
   CCriticalSection m_videoPlayerSection;
   struct SPlayerVideoInfo

--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -94,6 +94,7 @@ bool CExternalPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &opti
     m_playbackStartTime = std::chrono::steady_clock::now();
     m_launchFilename = file.GetDynPath();
     CLog::Log(LOGINFO, "{}: {}", __FUNCTION__, m_launchFilename);
+    CServiceBroker::GetDataCacheCore().SetFileItem(file);
     Create();
 
     return true;

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -99,6 +99,7 @@ bool CRetroPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options
 
   m_processInfo->SetDataCache(&CServiceBroker::GetDataCacheCore());
   m_processInfo->ResetInfo();
+  m_processInfo->SetFileItem(fileCopy);
 
   m_guiMessenger = std::make_unique<CGUIGameMessenger>(*m_processInfo);
   m_renderManager = std::make_unique<CRPRenderManager>(*m_processInfo);

--- a/xbmc/cores/RetroPlayer/process/RPProcessInfo.cpp
+++ b/xbmc/cores/RetroPlayer/process/RPProcessInfo.cpp
@@ -159,6 +159,14 @@ void CRPProcessInfo::ResetInfo()
   }
 }
 
+void CRPProcessInfo::SetFileItem(const CFileItem& item)
+{
+  if (m_dataCache != nullptr)
+  {
+    m_dataCache->SetFileItem(item);
+  }
+}
+
 bool CRPProcessInfo::HasScalingMethod(SCALINGMETHOD scalingMethod) const
 {
   return m_renderBufferManager->HasScalingMethod(scalingMethod);

--- a/xbmc/cores/RetroPlayer/process/RPProcessInfo.h
+++ b/xbmc/cores/RetroPlayer/process/RPProcessInfo.h
@@ -22,6 +22,7 @@ extern "C"
 #include <libavutil/pixfmt.h>
 }
 
+class CFileItem;
 class CDataCacheCore;
 
 namespace KODI
@@ -146,6 +147,16 @@ public:
    */
   SCALINGMETHOD GetDefaultScalingMethod() const { return m_defaultScalingMethod; }
 
+  ///}
+
+  /// @name Item
+  ///{
+  /*!
+   * \brief Cache the current playing item
+   *
+   * \param item - the item to store
+   */
+  void SetFileItem(const CFileItem& item);
   ///}
 
   /// @name Player video info

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -682,6 +682,8 @@ bool CVideoPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options
   }
 
   m_item = file;
+  CServiceBroker::GetDataCacheCore().SetFileItem(m_item);
+
   m_playerOptions = options;
 
   m_processInfo->SetPlayTimes(0,0,0,0);

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -240,6 +240,7 @@ bool PAPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options)
   // OnPlayBackStarted to be made only once. Callback processing may be slower than player process
   // so clear signal flag first otherwise async stream processing could also make callback
   m_signalStarted = false;
+  CServiceBroker::GetDataCacheCore().SetFileItem(file);
   m_callback.OnPlayBackStarted(file);
 
   return true;

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -16,7 +16,6 @@
 #include "UPnP.h"
 #include "UPnPInternal.h"
 #include "URL.h"
-#include "application/Application.h"
 #include "cores/DataCacheCore.h"
 #include "filesystem/SpecialProtocol.h"
 #include "guilib/GUIComponent.h"
@@ -28,6 +27,7 @@
 #include "messaging/ApplicationMessenger.h"
 #include "network/Network.h"
 #include "pictures/SlideShowDelegator.h"
+#include "playlists/PlayListTypes.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
@@ -335,18 +335,20 @@ void CUPnPRenderer::UpdateState()
     avt->SetStateVariable("CurrentTrack", "1");
 
     // get elapsed time
-    std::string buffer =
-        StringUtils::SecondsToTimeString(std::lrint(g_application.GetTime()), TIME_FORMAT_HH_MM_SS);
-    avt->SetStateVariable("RelativeTimePosition", buffer.c_str());
-    avt->SetStateVariable("AbsoluteTimePosition", buffer.c_str());
+    const std::string playTime = StringUtils::SecondsToTimeString(
+        std::lrint(static_cast<double>(CServiceBroker::GetDataCacheCore().GetPlayTime()) / 1000),
+        TIME_FORMAT_HH_MM_SS);
+    avt->SetStateVariable("RelativeTimePosition", playTime.c_str());
+    avt->SetStateVariable("AbsoluteTimePosition", playTime.c_str());
 
     // get duration
-    buffer = StringUtils::SecondsToTimeString(std::lrint(g_application.GetTotalTime()),
-                                              TIME_FORMAT_HH_MM_SS);
-    if (buffer.length() > 0)
+    const std::string totalTime = StringUtils::SecondsToTimeString(
+        std::lrint(static_cast<double>(CServiceBroker::GetDataCacheCore().GetMaxTime()) / 1000),
+        TIME_FORMAT_HH_MM_SS);
+    if (totalTime.length() > 0)
     {
-      avt->SetStateVariable("CurrentTrackDuration", buffer.c_str());
-      avt->SetStateVariable("CurrentMediaDuration", buffer.c_str());
+      avt->SetStateVariable("CurrentTrackDuration", totalTime.c_str());
+      avt->SetStateVariable("CurrentMediaDuration", totalTime.c_str());
     }
     else
     {

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -19,6 +19,7 @@
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPlayer.h"
 #include "application/ApplicationPowerHandling.h"
+#include "cores/DataCacheCore.h"
 #include "filesystem/Directory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUILabelControl.h"
@@ -156,6 +157,8 @@ CGUIWindowSlideShow::~CGUIWindowSlideShow()
 
 void CGUIWindowSlideShow::AnnouncePlayerPlay(const CFileItemPtr& item)
 {
+  CServiceBroker::GetDataCacheCore().SetFileItem(*item.get());
+
   CVariant param;
   param["player"]["speed"] = m_bSlideShow && !m_bPause ? 1 : 0;
   param["player"]["playerid"] = PLAYLIST::TYPE_PICTURE;
@@ -172,6 +175,8 @@ void CGUIWindowSlideShow::AnnouncePlayerPause(const CFileItemPtr& item)
 
 void CGUIWindowSlideShow::AnnouncePlayerStop(const CFileItemPtr& item)
 {
+  CServiceBroker::GetDataCacheCore().Reset();
+
   CVariant param;
   param["player"]["playerid"] = PLAYLIST::TYPE_PICTURE;
   param["end"] = true;


### PR DESCRIPTION
## Description
Looking into how to decouple components from GUI and from the Application I've found that a lot of examples just call into g_application to obtain either the item that is being played or the player times (max and current playing time). In fact I think that the item being played is something that could be cached elsewhere (e.g. exploiting data cache core) along side other information about the running player that's already available there for the info interface to consume.
Doing this I was able to remove the `Application.h` include from the UPnP Renderer. Next step will be dropping the ApplicationPlayer dependencies.

This "depends" on https://github.com/xbmc/xbmc/pull/24402
Note: clang-format is broken on upnp renderer file, I'll prefer to do it in bulk later than now to avoid the exploding diff.

## Motivation and context
Untangle stuff, being able to run headless some day

## How has this been tested?
Runtime tested on linux with breakpoints in the affected places to confirm the data that was returned previously and the one that is return now match completely

## What is the effect on users?
None, internal refactor/cleanup.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
