### PR TITLE
[Pictures] Better control of play/stop annoucements

### DIFF
--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -26,7 +26,6 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/actions/ActionIDs.h"
-#include "interfaces/AnnouncementManager.h"
 #include "media/MediaLockState.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "pictures/SlideShowDelegator.h"
@@ -343,11 +342,7 @@ bool CGUIWindowPictures::ShowPicture(int iItem, bool startSlideShow)
     slideShow.StartSlideShow();
   else
   {
-    CVariant param;
-    param["player"]["speed"] = 1;
-    param["player"]["playerid"] = PLAYLIST::TYPE_PICTURE;
-    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnPlay",
-                                                       slideShow.GetCurrentSlide(), param);
+    slideShow.PlayPicture();
   }
 
   //! @todo this should trigger some event that should led the window manager to activate another window

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -1317,14 +1317,16 @@ void CGUIWindowSlideShow::RunSlideShow(const std::string &strPath,
     StartSlideShow();
   else
   {
-    CVariant param;
-    param["player"]["speed"] = 0;
-    param["player"]["playerid"] = PLAYLIST::TYPE_PICTURE;
-    CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnPlay",
-                                                       GetCurrentSlide(), param);
+    PlayPicture();
   }
 
   CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_SLIDESHOW);
+}
+
+void CGUIWindowSlideShow::PlayPicture()
+{
+  if (m_iCurrentSlide >= 0 && m_iCurrentSlide < static_cast<int>(m_slides.size()))
+    AnnouncePlayerPlay(m_slides.at(m_iCurrentSlide));
 }
 
 void CGUIWindowSlideShow::AddItems(const std::string &strPath, path_set *recursivePaths, SortBy method, SortOrder order, SortAttribute sortAttributes)

--- a/xbmc/pictures/GUIWindowSlideShow.h
+++ b/xbmc/pictures/GUIWindowSlideShow.h
@@ -61,6 +61,7 @@ public:
   void GetSlideShowContents(CFileItemList& list) override;
   std::shared_ptr<const CFileItem> GetCurrentSlide() override;
   void StartSlideShow() override;
+  void PlayPicture() override;
   bool InSlideShow() const override;
   int NumSlides() const override;
   int CurrentSlide() const override;

--- a/xbmc/pictures/SlideShowDelegator.cpp
+++ b/xbmc/pictures/SlideShowDelegator.cpp
@@ -68,6 +68,14 @@ void CSlideShowDelegator::StartSlideShow()
   }
 }
 
+void CSlideShowDelegator::PlayPicture()
+{
+  if (m_delegate)
+  {
+    m_delegate->PlayPicture();
+  }
+}
+
 bool CSlideShowDelegator::InSlideShow() const
 {
   if (m_delegate)

--- a/xbmc/pictures/SlideShowDelegator.h
+++ b/xbmc/pictures/SlideShowDelegator.h
@@ -30,6 +30,7 @@ public:
   void GetSlideShowContents(CFileItemList& list) override;
   std::shared_ptr<const CFileItem> GetCurrentSlide() override;
   void StartSlideShow() override;
+  void PlayPicture() override;
   bool InSlideShow() const override;
   int NumSlides() const override;
   int CurrentSlide() const override;

--- a/xbmc/pictures/interfaces/ISlideShowDelegate.h
+++ b/xbmc/pictures/interfaces/ISlideShowDelegate.h
@@ -27,6 +27,7 @@ public:
   virtual void GetSlideShowContents(CFileItemList& list) = 0;
   virtual std::shared_ptr<const CFileItem> GetCurrentSlide() = 0;
   virtual void StartSlideShow() = 0;
+  virtual void PlayPicture() = 0;
   virtual bool InSlideShow() const = 0;
   virtual int NumSlides() const = 0;
   virtual int CurrentSlide() const = 0;


### PR DESCRIPTION
## Description
Simple change, it concentrates all announcements on GUIWindowSlideShow since it's the actual Slideshow/Picture player. This is helpful in the future to cache the playing item and make sure it's always refreshed (e.g. when moving to the next/previous picture or playing an actual slideshow).