### PR TITLE
[UPnP] Fix OnSetAVTransportURI

### DIFF
--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -584,7 +584,6 @@ CUPnPRenderer::OnSetAVTransportURI(PLT_ActionReference& action)
       service->SetStateVariable("NextAVTransportURIMetaData", "");
 
       NPT_CHECK_SEVERE(action->SetArgumentsOutFromStateVariable());
-      return NPT_SUCCESS;
     }
 
     return PlayMedia(uri, meta, action.AsPointer());


### PR DESCRIPTION
## Description
UPnP can be used as a remote, e.g. by calling AVTransport Service `SetAVTransportURI` a new item might be requested for playback. If Kodi is currently not playing a file and it receives a request it clears the state and just returns early without starting the playback of the new item.