### PR TITLE
[video] Fix disappearing artwork on end of multi-version movie playback.

### DIFF
--- a/xbmc/video/guilib/VideoVersionHelper.cpp
+++ b/xbmc/video/guilib/VideoVersionHelper.cpp
@@ -235,5 +235,7 @@ std::shared_ptr<CFileItem> CVideoVersionHelper::GetMovieForVideoVersion(
 {
   auto item{std::make_shared<CFileItem>(videoVersion.GetDynPath(), false)};
   item->LoadDetails();
+  CVideoThumbLoader thumbLoader;
+  thumbLoader.LoadItem(item.get());
   return item;
 }


### PR DESCRIPTION
Fixes #24300 

Runtime-tested on macOS, latest Kodi master.

@Hitcher fyi.

@enen92 @CrystalP trivial change to review I guess. Like for "normal" movies, we must load item artwork before passing it on for playback. Otherwise, on playback stop, the fully loaded item in the movie window will be overwritten with the item missing the artwork. 

The overwrite happened here: https://github.com/xbmc/xbmc/blob/master/xbmc/windows/GUIMediaWindow.cpp#L414 (`newItem` being the item we have created and passed on for playback, `m_vecItems` containing the fully loaded items.)