### PR TITLE
[Estuary] Fix duplicate music flags

### DIFF
--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -433,7 +433,7 @@
 				<control type="group">
 					<width>115</width>
 					<visible>!String.IsEmpty($PARAM[infolabel_prefix]ListItem.Duration)</visible>
-					<visible>Container.Content(albums) | Window.IsActive(DialogMusicInfo.xml) + Container.Content(songs)</visible>
+					<visible>Container.Content(albums) + ![Window.IsVisible(songinformation) | Window.IsVisible(musicinformation)]</visible>
 					<control type="label">
 						<width>110</width>
 						<height>60</height>

--- a/addons/skin.estuary/xml/MyMusicNav.xml
+++ b/addons/skin.estuary/xml/MyMusicNav.xml
@@ -33,7 +33,7 @@
 				<height>70</height>
 				<animation effect="fade" start="0" end="100" time="300" delay="300">WindowOpen</animation>
 				<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
-				<include condition="!Skin.HasSetting(hide_mediaflags)">MediaFlags</include>
+				<include condition="!Skin.HasSetting(hide_mediaflags) + ![Window.IsVisible(songinformation) | Window.IsVisible(musicinformation)]">MediaFlags</include>
 			</control>
 			<include>MediaMenuMouseOverlay</include>
 			<control type="group">


### PR DESCRIPTION
## Description
https://github.com/xbmc/xbmc/pull/24162 introduced media flags for music, however this caused a double rendered flag on Linux. This introduces conditions to make sure this can't happen.

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/24342

As https://github.com/xbmc/xbmc/pull/24162 introduced flags for both the music nav windows and the music/song dialogs it appears that on Linux these get double rendered.

## How has this been tested?
Tested by @neo1973 

For some unknown to me reason this issue is not seen on Windows, however @neo1973 has confirmed the proposed fix works.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
