### PR TITLE
[Posix][Filesystem] Fixed SMB logging

### DIFF
--- a/xbmc/platform/posix/filesystem/SMBFile.cpp
+++ b/xbmc/platform/posix/filesystem/SMBFile.cpp
@@ -34,9 +34,9 @@
 
 using namespace XFILE;
 
-void xb_smbc_log(const char* msg)
+void xb_smbc_log(void* private_ptr, int level, const char* msg)
 {
-  CLog::Log(LOGINFO, "{}{}", "smb: ", msg);
+  CLog::Log(LOGDEBUG, "smb: {}", msg);
 }
 
 void xb_smbc_auth(const char *srv, const char *shr, char *wg, int wglen,
@@ -175,6 +175,7 @@ void CSMB::Init()
 
 #ifdef DEPRECATED_SMBC_INTERFACE
     smbc_setDebug(m_context, CServiceBroker::GetLogging().CanLogComponent(LOGSAMBA) ? 10 : 0);
+    smbc_setLogCallback(m_context, this, xb_smbc_log);
     smbc_setFunctionAuthData(m_context, xb_smbc_auth);
     orig_cache = smbc_getFunctionGetCachedServer(m_context);
     smbc_setFunctionGetCachedServer(m_context, xb_smbc_cache);

--- a/xbmc/platform/posix/filesystem/SMBFile.cpp
+++ b/xbmc/platform/posix/filesystem/SMBFile.cpp
@@ -36,7 +36,19 @@ using namespace XFILE;
 
 void xb_smbc_log(void* private_ptr, int level, const char* msg)
 {
-  CLog::Log(LOGDEBUG, "smb: {}", msg);
+  const int logLevel = [level]()
+  {
+    switch (level)
+    {
+      case 0:
+        return LOGWARNING;
+      case 1:
+        return LOGINFO;
+      default:
+        return LOGDEBUG;
+    }
+  }();
+  CLog::Log(logLevel, "smb: {}", msg);
 }
 
 void xb_smbc_auth(const char *srv, const char *shr, char *wg, int wglen,


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The logging of SMB component (libsmbclient) requires setup of a logging function.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Kodi has a set of logging options for troubleshooting. One of the options activates logging for SMB component. However it did not work. The required logging function for libsmbclient was not properly set.

There was already a function defined but not used. It seems that function was used 15 years ago but only on Windows. Currently libsmbclient isn't used on Windows at all. I corrected the function for current libsmbclient requirements and added the code to attach the callback to libsmbclient.

Small example of a log after fix:
```
2024-01-02 22:52:24.521 T:11488    debug <general>: smb: SMBC_server: server_n=[192.168.0.105] server=[192.168.0.105]
2024-01-02 22:52:24.521 T:11488    debug <general>: smb:  -> server_n=[192.168.0.105] server=[192.168.0.105]
2024-01-02 22:52:24.523 T:11488    debug <general>: smb: Connecting to 192.168.0.105 at port 445
2024-01-02 22:52:24.527 T:11488    debug <general>: smb: socket options: SO_KEEPALIVE=0, SO_REUSEADDR=0, SO_BROADCAST=0, 
TCP_NODELAY=1, TCP_KEEPCNT=9, TCP_KEEPIDLE=7200, TCP_KEEPINTVL=75, IPTOS_LOWDELAY=0, IPTOS_THROUGHPUT=0, SO_REUSEPORT=0, SO_SNDBUF=524288,
SO_RCVBUF=1048576, SO_SNDLOWAT=1, SO_RCVLOWAT=1, SO_SNDTIMEO=0, SO_RCVTIMEO=0, TCP_QUICKACK=1, TCP_DEFER_ACCEPT=0, TCP_USER_TIMEOUT=0
…..
2024-01-02 22:52:54.428 T:11538    debug <general>: smb: smbc_stat(smb://username:password@192.168.0.105/Testvideos/Video.mp4)
2024-01-02 22:52:54.428 T:11538    debug <general>: smb: SMBC_getatr: sending qpathinfo
2024-01-02 22:52:54.475 T:11538    debug <general>: smb: smbc_read(0xb321cbf0, 1048576)
2024-01-02 22:52:54.519 T:11538    debug <general>: smb:   --> 1048576
2024-01-02 22:52:54.520 T:11538    debug <general>: smb: smbc_read(0xb321cbf0, 1048576)
2024-01-02 22:52:54.544 T:11538    debug <general>: smb:   --> 1048576

```

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Kodi is running on Mac with Intel CPU. SMB share is on PC with Windows 11 Pro.

In Kodi under Settings -> System -> Logging the option "Enable component-specific logging" was activated and in the option "Specify component-specific logging" the item "Verbose logging for the SMB library" was selected. Kodi was restarted. In Kodi File Manager a new source pointing to a network SMB share was added. A video file located on this SMB source was played. Then kodi.log was inspected.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
The logging of SMB component works now. The logs can be helpful for troubleshooting.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
