### PR TITLE
[UPnP] Renderer: Remove dependency on ApplicationPlayer

### DIFF
--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -366,17 +366,28 @@ CUPnPRenderer::UpdateState()
     }
     else
     {
-      avt->SetStateVariable("TransportState", "STOPPED");
-      avt->SetStateVariable("TransportPlaySpeed", "1");
-      avt->SetStateVariable("NumberOfTracks", "0");
-      avt->SetStateVariable("CurrentTrack", "0");
-      avt->SetStateVariable("RelativeTimePosition", "00:00:00");
-      avt->SetStateVariable("AbsoluteTimePosition", "00:00:00");
-      avt->SetStateVariable("CurrentTrackDuration", "00:00:00");
-      avt->SetStateVariable("CurrentMediaDuration", "00:00:00");
-      avt->SetStateVariable("NextAVTransportURI", "");
-      avt->SetStateVariable("NextAVTransportURIMetaData", "");
+      Reset(avt);
     }
+}
+
+NPT_Result CUPnPRenderer::Reset(PLT_Service* avt)
+{
+    if (!avt)
+    {
+      return NPT_ERROR_INTERNAL;
+    }
+
+    avt->SetStateVariable("TransportState", "STOPPED");
+    avt->SetStateVariable("TransportPlaySpeed", "1");
+    avt->SetStateVariable("NumberOfTracks", "0");
+    avt->SetStateVariable("CurrentTrack", "0");
+    avt->SetStateVariable("RelativeTimePosition", "00:00:00");
+    avt->SetStateVariable("AbsoluteTimePosition", "00:00:00");
+    avt->SetStateVariable("CurrentTrackDuration", "00:00:00");
+    avt->SetStateVariable("CurrentMediaDuration", "00:00:00");
+    avt->SetStateVariable("NextAVTransportURI", "");
+    avt->SetStateVariable("NextAVTransportURIMetaData", "");
+    return NPT_SUCCESS;
 }
 
 /*----------------------------------------------------------------------

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -278,6 +278,10 @@ void CUPnPRenderer::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
       avt->SetStateVariable("TransportPlaySpeed",
                             NPT_String::FromInteger(data["player"]["speed"].asInteger()));
     }
+    else if (message == "OnStop")
+    {
+      Reset(avt);
+    }
   }
   else if (flag == ANNOUNCEMENT::Application && message == "OnVolumeChanged")
   {

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -370,6 +370,18 @@ CUPnPRenderer::UpdateState()
     }
 }
 
+NPT_String CUPnPRenderer::GetTransportState()
+{
+    NPT_AutoLock lock(m_state);
+    NPT_String transportState;
+    PLT_Service* avt;
+    if (NPT_FAILED(FindServiceByType("urn:schemas-upnp-org:service:AVTransport:1", avt)))
+      return transportState;
+
+    avt->GetStateVariableValue("TransportState", transportState);
+    return transportState;
+}
+
 NPT_Result CUPnPRenderer::Reset(PLT_Service* avt)
 {
     if (!avt)

--- a/xbmc/network/upnp/UPnPRenderer.h
+++ b/xbmc/network/upnp/UPnPRenderer.h
@@ -67,6 +67,7 @@ private:
                          const NPT_String& meta,
                          PLT_Action* action = NULL);
     NPT_Result Reset(PLT_Service* avt);
+    NPT_String GetTransportState();
     NPT_Mutex m_state;
 };
 

--- a/xbmc/network/upnp/UPnPRenderer.h
+++ b/xbmc/network/upnp/UPnPRenderer.h
@@ -66,6 +66,7 @@ private:
     NPT_Result PlayMedia(const NPT_String& uri,
                          const NPT_String& meta,
                          PLT_Action* action = NULL);
+    NPT_Result Reset(PLT_Service* avt);
     NPT_Mutex m_state;
 };
 


### PR DESCRIPTION
## Description
This continues to decouple UPnP components by removing the dependency of the UPnP renderer on ApplicationPlayer (i.e. application). The renderer receives announcements from the players (via AnnoucementManager) each time a given action occurs (OnPlay, Resume, Stop, etc) and sets internal properties on the transport service related to this state.
For this reason, it does not need to query application player for the state since it has already this state stored.

Next step will be trying to decouple the missing slideshow bits (the only pieces still missing for a GUI free sub-component).

Regarding clang-format, note that a lot of the code of the file is broken. I prefer to handle this in bulk after I finish this.