### PR TITLE
[video] Refresh library list after changes in Info > Manage versions

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -160,7 +160,7 @@ bool CGUIDialogVideoInfo::OnMessage(CGUIMessage& message)
       }
       else if (iControl == CONTROL_BTN_MANAGE_VIDEO_VERSIONS)
       {
-        OnManageVideoVersions();
+        m_hasUpdatedItems = OnManageVideoVersions();
       }
       else if (iControl == CONTROL_BTN_MANAGE_VIDEO_EXTRAS)
       {
@@ -2082,9 +2082,9 @@ void CGUIDialogVideoInfo::ShowFor(const CFileItem& item)
     window->OnItemInfo(item);
 }
 
-void CGUIDialogVideoInfo::OnManageVideoVersions()
+bool CGUIDialogVideoInfo::OnManageVideoVersions()
 {
-  CGUIDialogVideoManagerVersions::ManageVideoVersions(m_movieItem);
+  return CGUIDialogVideoManagerVersions::ManageVideoVersions(m_movieItem);
 }
 
 void CGUIDialogVideoInfo::OnManageVideoExtras()

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.h
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.h
@@ -32,6 +32,7 @@ public:
   bool RefreshAll() const;
   bool HasUpdatedThumb() const { return m_hasUpdatedThumb; }
   bool HasUpdatedUserrating() const { return m_hasUpdatedUserrating; }
+  bool HasUpdatedItems() const { return m_hasUpdatedItems; }
 
   std::string GetThumbnail() const;
   std::shared_ptr<CFileItem> GetCurrentListItem(int offset = 0) override { return m_movieItem; }
@@ -90,7 +91,7 @@ protected:
    * \param pItem Search result item
    */
   void OnSearchItemFound(const CFileItem* pItem);
-  void OnManageVideoVersions();
+  bool OnManageVideoVersions();
   void OnManageVideoExtras();
   void Play(bool resume = false);
   void OnGetArt();
@@ -111,6 +112,7 @@ protected:
   bool m_hasUpdatedThumb = false;
   bool m_hasUpdatedUserrating = false;
   int m_startUserrating = -1;
+  bool m_hasUpdatedItems{false};
 
 private:
   static bool ManageVideoItemArtwork(const std::shared_ptr<CFileItem>& item,

--- a/xbmc/video/dialogs/GUIDialogVideoManager.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.h
@@ -27,6 +27,7 @@ public:
 
   virtual void SetVideoAsset(const std::shared_ptr<CFileItem>& item);
   virtual void SetSelectedVideoAsset(const std::shared_ptr<CFileItem>& asset);
+  virtual bool HasUpdatedItems() const { return m_hasUpdatedItems; }
 
 protected:
   void OnInitWindow() override;
@@ -58,6 +59,7 @@ protected:
   std::shared_ptr<CFileItem> m_videoAsset;
   std::unique_ptr<CFileItemList> m_videoAssetsList;
   std::shared_ptr<CFileItem> m_selectedVideoAsset;
+  bool m_hasUpdatedItems{false};
 
 private:
   CGUIDialogVideoManager() = delete;

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -63,6 +63,7 @@ bool CGUIDialogVideoManagerVersions::OnMessage(CGUIMessage& message)
           // refresh data and controls
           Refresh();
           UpdateControls();
+          m_hasUpdatedItems = true;
         }
       }
       else if (control == CONTROL_BUTTON_SET_DEFAULT)
@@ -310,7 +311,7 @@ std::tuple<int, std::string> CGUIDialogVideoManagerVersions::NewVideoVersion()
   return std::make_tuple(idVideoVersion, typeVideoVersion);
 }
 
-void CGUIDialogVideoManagerVersions::ManageVideoVersions(const std::shared_ptr<CFileItem>& item)
+bool CGUIDialogVideoManagerVersions::ManageVideoVersions(const std::shared_ptr<CFileItem>& item)
 {
   CGUIDialogVideoManagerVersions* dialog{
       CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogVideoManagerVersions>(
@@ -318,11 +319,12 @@ void CGUIDialogVideoManagerVersions::ManageVideoVersions(const std::shared_ptr<C
   if (!dialog)
   {
     CLog::LogF(LOGERROR, "Unable to get WINDOW_DIALOG_MANAGE_VIDEO_VERSIONS instance!");
-    return;
+    return false;
   }
 
   dialog->SetVideoAsset(item);
   dialog->Open();
+  return dialog->HasUpdatedItems();
 }
 
 int CGUIDialogVideoManagerVersions::ManageVideoVersionContextMenu(

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
@@ -30,7 +30,13 @@ public:
 
   static std::tuple<int, std::string> NewVideoVersion();
   static bool ProcessVideoVersion(VideoDbContentType itemType, int dbId);
-  static void ManageVideoVersions(const std::shared_ptr<CFileItem>& item);
+  /*!
+   * \brief Open the Manage Versions dialog for a video
+   * \param item video to manage
+   * \return true: the video or another item was modified, a containing list should be refreshed.
+   * false: no changes
+   */
+  static bool ManageVideoVersions(const std::shared_ptr<CFileItem>& item);
   static int ManageVideoVersionContextMenu(const std::shared_ptr<CFileItem>& version);
 
 protected:

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -429,7 +429,7 @@ bool CGUIWindowVideoBase::ShowInfo(const CFileItemPtr& item2, const ScraperPtr& 
       return true;
     needsRefresh = pDlgInfo->NeedRefresh();
     if (!needsRefresh)
-      return pDlgInfo->HasUpdatedThumb();
+      return (pDlgInfo->HasUpdatedThumb() || pDlgInfo->HasUpdatedItems());
     // check if the item in the video info dialog has changed and if so, get the new item
     else if (pDlgInfo->GetCurrentListItem() != NULL)
     {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Added the plumbing to propagate the success status of "Add version" to the Info dialog and the library list, so that movies turned into versions are removed from the library list without having to leave/return to the library.

Refresh only when an addition was completed to avoid the unnecessary delay of a large library list refresh if the user cancels the action half-way through.

Propagation applied only to the Add version button of Manage versions because the other ones don't have impacts that could impact the library list (yet!).

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #24378

Version creation through the context menu didn't have the problem because the manage context menu systematically refreshes the library list.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local and remote db, similar movie, different movie from library, movie picked with file browser.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Improved user experience.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
