### PR TITLE
Movie version artwork sync

### DIFF
--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1030,6 +1030,7 @@ public:
                             VideoAssetType asset,
                             CFileItemList& items);
   void SetVideoVersionDefaultArt(int dbId, int idFrom, VideoDbContentType type);
+  void SetArtFromDefaultVideoVersion(int dbId, int idFrom, VideoDbContentType type);
   void InitializeVideoVersionTypeTable(int schemaVersion);
   void UpdateVideoVersionTypeTable();
   bool GetVideoVersionsNav(const std::string& strBaseDir,
@@ -1148,6 +1149,17 @@ protected:
   void GetDetailsFromDB(std::unique_ptr<dbiplus::Dataset> &pDS, int min, int max, const SDbTableOffsets *offsets, CVideoInfoTag &details, int idxOffset = 2);
   void GetDetailsFromDB(const dbiplus::sql_record* const record, int min, int max, const SDbTableOffsets *offsets, CVideoInfoTag &details, int idxOffset = 2);
   std::string GetValueString(const CVideoInfoTag &details, int min, int max, const SDbTableOffsets *offsets) const;
+
+  void SetArtForMovie(int idMovie, int idFile, const std::map<std::string, std::string>& art);
+  void SetArtForMovie(int idMovie, int idFile, const std::string& artType, const std::string& url);
+
+  void SetArtForItemInternal(int mediaId,
+                             const MediaType& mediaType,
+                             const std::string& artType,
+                             const std::string& url);
+  void SetArtForItemInternal(int mediaId,
+                             const MediaType& mediaType,
+                             const std::map<std::string, std::string>& art);
 
 private:
   void CreateTables() override;

--- a/xbmc/video/dialogs/GUIDialogVideoManager.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -329,6 +329,22 @@ void CGUIDialogVideoManager::ChooseArt()
 {
   if (!CGUIDialogVideoInfo::ChooseAndManageVideoItemArtwork(m_selectedVideoAsset))
     return;
+  if (m_selectedVideoAsset->GetVideoInfoTag()->m_iDbId ==
+      m_videoAsset->GetVideoInfoTag()->m_iFileId)
+  {
+    m_database.SetArtFromDefaultVideoVersion(m_videoAsset->GetVideoInfoTag()->m_iDbId,
+                                             m_selectedVideoAsset->GetVideoInfoTag()->m_iDbId,
+                                             m_videoAsset->GetVideoContentType());
+
+    m_videoAsset->ClearArt();
+    CVideoThumbLoader thumbLoader;
+    thumbLoader.LoadItem(m_videoAsset.get());
+
+    // notify all windows to update the file item
+    CGUIMessage msg{GUI_MSG_NOTIFY_ALL,        0,           0, GUI_MSG_UPDATE_ITEM,
+                    GUI_MSG_FLAG_FORCE_UPDATE, m_videoAsset};
+    CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
+  }
 
   // refresh data and controls
   Refresh();

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -176,6 +176,10 @@ void CGUIDialogVideoManagerVersions::SetDefaultVideoVersion(const CFileItem& ver
   // update video details since we changed the video file for the item
   m_database.GetDetailsByTypeAndId(*m_videoAsset, itemType, dbId);
 
+  m_videoAsset->ClearArt();
+  CVideoThumbLoader thumbLoader;
+  thumbLoader.LoadItem(m_videoAsset.get());
+
   // notify all windows to update the file item
   CGUIMessage msg{GUI_MSG_NOTIFY_ALL,        0,           0, GUI_MSG_UPDATE_ITEM,
                   GUI_MSG_FLAG_FORCE_UPDATE, m_videoAsset};


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

There is a disconnect between the art of a movie (used traditionally in Kodi) and the art of the default version of that movie (new with video versions, used in Manage versions and when browsing versions as folders) although from a user's point of view they probably should be identical. The PR hides the disconnect.

Approach used:
*  modify the functions that store artwork to always store 2 copies of changes, one as movie art and one as default version art. The art retrieval functions do not change. That results in some data duplication.

For example, `Info dialog > Choose art` updates the movie art as it always has, but now also updates the default version's art at the same time. The new art will be then be visible in `Manage versions > default version` as well. Conversely, changing the default version's art with `Manage versions > Choose art` updates the movie art in addition to the expected update of the version art.

Other approaches (1/override art retrieval only or 2/override storage and retrieval of artwork of default version) seem easier at first but have issues that make things worse in a small number of cases.

* db bump + data migration to copy the movie artwork to the default version (with preservation of user customizations made since v21 beta 2). Not sure why that wasn't done in the initial data migration to versions in v123, it resulted in all "Standard Edition" versions to have no artwork, which was made to display a thumbnail.
 
During testing I found a number of pre-existing problems around art display / setting that were not addressed in the PR but could be mistaken for bugs of the PR.

The code is functional but not polished yet. I'd like feedback on the idea before spending more time to make it look nice for a merge.



## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Address aspects of #24371

Change movie artwork with info > choose art: the change is not visible for the default version in manage versions, or when browsing the versions as a folder. The opposite happens too.

All "Standard Edition" auto-created versions have no artwork and only received a thumb.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
sqlite and mariadb

Data migration with maria db was slower than usual, I'll see if that can be improved. 

Tried with a data migration from v122 (before versions) and migration of db post 123 with user customizations of default versions art.

That's when I found a number of existing bugs of the manage screen and other art-related issues:
- sometimes art doesn't show at all in Manage versions
- going straight to Choose art in Manage versions shows blank previews of the different art types
- home page recently added / unwatched don't respond to movie art changes
- Chose art selector doesn't show the new art after changing art of one type
- not a bug but less than ideal user experience, after Manage versions > Choose art, focus goes to first item of the list instead of remaining on Choose art, with the same item still selected.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
More intuitive behavior of artwork with versions.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
