### PR TITLE
[Android] Enable logging of debug messages even if disabled system-wide (e.g. Fire TV)

### DIFF
--- a/xbmc/platform/android/utils/AndroidInterfaceForCLog.cpp
+++ b/xbmc/platform/android/utils/AndroidInterfaceForCLog.cpp
@@ -10,11 +10,32 @@
 
 #include "CompileInfo.h"
 
+#include <dlfcn.h>
 #include <spdlog/sinks/android_sink.h>
 #include <spdlog/sinks/dist_sink.h>
 
+// On some Android platforms debug logging is deactivated.
+// We try to activate debug logging for our app via function "__android_log_set_minimum_priority" from "/system/lib/liblog.so".
+// The function is defined in API level 30 (Android 11) as:
+//   int32_t __android_log_set_minimum_priority(int32_t priority);
+void ActivateAndroidDebugLogging()
+{
+  void* libHandle = dlopen("liblog.so", RTLD_LAZY);
+  if (libHandle)
+  {
+    void* funcPtr = dlsym(libHandle, "__android_log_set_minimum_priority");
+    if (funcPtr)
+    {
+      typedef int32_t (*android_log_set_minimum_priority_func)(int32_t);
+      reinterpret_cast<android_log_set_minimum_priority_func>(funcPtr)(ANDROID_LOG_DEBUG);
+    }
+    dlclose(libHandle);
+  }
+}
+
 std::unique_ptr<IPlatformLog> IPlatformLog::CreatePlatformLog()
 {
+  ActivateAndroidDebugLogging();
   return std::make_unique<CAndroidInterfaceForCLog>();
 }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
On start we set Android logging level forcibly to DEBUG for our app. That overrides a possibly existing system property, which may set higher logging level. As a result the debug messages produced by Kodi (if activated in Kodi settings) are properly saved into Kodi log.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In the newer versions of FireOS (for Fire TV devices) the system is configured with  logging level set to INFO. Since Kodi uses platform specific logging methods, this system setting prevents saving of debug messages into Kodi.log too. The debug logs posted by users miss debug-messages, that complicates troubleshooting.

The issue was discussed on forum: [Kodi on FireTV Stick 4K Max does not output debug logs](https://forum.kodi.tv/showthread.php?tid=371514) and [Enabling debug logs on FireTV at the android level - Fixed](https://forum.kodi.tv/showthread.php?tid=371987).

The second forum thread describes a method of enabling debug logging by setting of the system property to DEBUG level:
```
adb shell setprop persist.log.tag D

```
or better for our app only:

```
adb shell setprop persist.log.tag.Kodi D

```

Although this method works it involves `adb` and therefore is not very user-friendly.

In this PR we use Android function [__android_log_set_minimum_priority](https://developer.android.com/ndk/reference/group/logging#group___logging_1gad487c002fa1cd610f3b01de1719ff912) to set logging level for our process.

### Limitations
Function `__android_log_set_minimum_priority` was introduced in API level 30 (Android 11). For Fire TV devices that means the latest Amazon hardware with FireOS 8 (Android 11): Fire TV Stick 4K 2nd Generation and Fire TV Stick 4K Max 2nd Generation. For more info on FireOS versions per hardware see [Fire TV Device and Accessory Software Updates](https://www.amazon.com/gp/help/customer/display.html?nodeId=201497590).

The method isn’t limited to Amazon devices as it uses standard Android function. If other vendors follow Amazon approach with restricting logging this method will also work on their devices. Currently I'm not aware of other such hardware.

### Implementation details
Kodi build system for Android uses NDK with API level 21, which doesn't have required function `__android_log_set_minimum_priority`. We use dynamic library loading to execute the call. If the required function isn't presented on the target system, nothing bad happens. The program will behave just like before.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Fire TV Stick 4K Max 1st Generation and Fire TV Stick 4K Max 2nd Generation.

Test procedure:
1. A device with Android 11 is required.
2. For Fire TV devices: if system property `persist.log.tag` was previously manipulated, set it back to `I` from device shell: `setprop persist.log.tag I`. If property `persist.log.tag.Kodi` was manually created, delete it with `setprop persist.log.tag.Kodi ''`.
3. For non-Fire TV devices: create/set system property `persist.log.tag` to `I`: `setprop persist.log.tag I`.
4. Start Kodi and activate debug logging in Settings -> System -> Logging.
5. Restart Kodi.
6. Inspect Kodi.log.

On Fire TV Stick 4K Max 2nd Generation the log-file contains debug messages. On Fire TV Stick 4K Max 1st Generation the debug messages are missing but the app doesn't crash or misbehaves.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
On Android 11 (and later) devices the debug log will always include debug messages, even if the vendor has deactivated them via system properties. In particular Fire TV Stick 4K 2nd Generation and Fire TV Stick 4K Max 2nd Generation are affected. Users no longer need to use `adb` to enable debug logging.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
