### PR TITLE
[CImageFile] Fix texture cache handling

### DIFF
--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -207,9 +207,10 @@ bool CTextureCache::CacheImage(const std::string &image, CTextureDetails &detail
   return !path.empty();
 }
 
-void CTextureCache::ClearCachedImage(const std::string &url, bool deleteSource /*= false */)
+void CTextureCache::ClearCachedImage(const std::string& image, bool deleteSource /*= false */)
 {
   //! @todo This can be removed when the texture cache covers everything.
+  const std::string url = CTextureUtils::UnwrapImageURL(image);
   std::string path = deleteSource ? url : "";
   std::string cachedFile;
   if (ClearCachedTexture(url, cachedFile))

--- a/xbmc/filesystem/ImageFile.cpp
+++ b/xbmc/filesystem/ImageFile.cpp
@@ -45,7 +45,13 @@ bool CImageFile::Exists(const CURL& url)
   std::string cachedFile =
       CServiceBroker::GetTextureCache()->CheckCachedImage(url.Get(), needsRecaching);
   if (!cachedFile.empty())
-    return CFile::Exists(cachedFile, false);
+  {
+    if (CFile::Exists(cachedFile, false))
+      return true;
+    else
+      // Remove from cache so it gets cached again on next Open()
+      CServiceBroker::GetTextureCache()->ClearCachedImage(url.Get());
+  }
 
   // need to check if the original can be cached on demand and that the file exists
   if (!CTextureCache::CanCacheImageURL(url))


### PR DESCRIPTION
## Description
It was discovered in #24398 and https://forum.kodi.tv/showthread.php?tid=375576&pid=3178186#pid3178186 that when deleting the thumbnails folders but not the TexturesXX.db, images that were already cached will never load when requested via the JSON API. This is fixed by two commits, one general fix in `CTextureCache` and a fix specific for the issue in `CImageFile`. See the commit messages for a little more information.

Inside Kodi this wasn't an issue because `CImageLoader` already has similar behaviour.

@wutschel: Could you give this a test please?

## Motivation and context
See above.

## How has this been tested?
Images in the web interface (e.g. album art) loads for these two cases:

1. Image was never cashed (or TexturesXX.db has been deleted)
2. Image has already been cached in the past but ~/.kodi/userdata/Thumbnails was deleted (or the specific file)

## What is the effect on users?
JSON API server pictures after cleaning the thumbnails folder, e.g. because of corrupted thumbs. 

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
