### PR TITLE
[videodb] Move the extras of a movie converted to a version

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -12033,6 +12033,14 @@ bool CVideoDatabase::ConvertVideoToVersion(VideoDbContentType itemType,
 
   if (dbIdSource != dbIdTarget)
   {
+    // First transfer the extras to the new movie.
+    // A movie with versions cannot be transformed into a version of another movie so there is no
+    // problem with moving all extras to the new movie. With the the current data model it's not
+    // possible to tell which extras initially belonged to which version.
+    ExecuteQuery(
+        PrepareSQL("UPDATE videoversion SET idMedia = %i WHERE idMedia = %i AND itemType = %i",
+                   dbIdTarget, dbIdSource, VideoAssetType::EXTRA));
+
     ExecuteQuery(PrepareSQL("UPDATE videoversion SET idMedia = %i, idType = %i WHERE idFile = %i",
                             dbIdTarget, idVideoVersion, idFile));
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Convert the extras of the movie A into extras of the movie B at the same time the movie A is turned into a version of movie B (navigation Manage versions > Add version)

Could have tested for itemType != VideoAssetType::MOVIE for some future-proofing, but I don't know what other item types may be created in the future and whether they should be moved as well.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
After manual conversion of a movie into a version of another one, the extras of the converted movie were lost (orphaned in the db).

Things were already OK when a similar movie is detected during library scan and the user accepts the conversion in the popup.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
sqlite and mariadb, original and added movie both with and without extras.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
More intuitive behavior of the version addition. No lost extras.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
