### PR TITLE
[clang-tidy] fix modernize-* and performance-* warnings

### DIFF
--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -306,7 +306,7 @@ bool CDirectory::GetDirectory(const CURL& url,
 }
 
 bool CDirectory::EnumerateDirectory(const std::string& path,
-                                    DirectoryEnumerationCallback callback,
+                                    const DirectoryEnumerationCallback& callback,
                                     bool fileOnly /* = false */,
                                     const std::string& mask /* = "" */,
                                     int flags /* = DIR_FLAG_DEFAULTS */)

--- a/xbmc/filesystem/Directory.h
+++ b/xbmc/filesystem/Directory.h
@@ -72,7 +72,7 @@ public:
   using DirectoryEnumerationCallback = std::function<void(const std::shared_ptr<CFileItem>& item)>;
 
   static bool EnumerateDirectory(const std::string& path,
-                                 DirectoryEnumerationCallback callback,
+                                 const DirectoryEnumerationCallback& callback,
                                  bool fileOnly = false,
                                  const std::string& mask = "",
                                  int flags = DIR_FLAG_DEFAULTS);

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -179,7 +179,6 @@ private:
 CUPnPPlayer::CUPnPPlayer(IPlayerCallback& callback, const char* uuid)
   : IPlayer(callback),
     CThread("UPnPPlayer"),
-    m_control(nullptr),
     m_logger(CServiceBroker::GetLogging().GetLogger(StringUtils::Format("CUPnPPlayer[{}]", uuid)))
 {
   m_control = CUPnP::GetInstance()->m_MediaController;

--- a/xbmc/network/upnp/UPnPPlayer.h
+++ b/xbmc/network/upnp/UPnPPlayer.h
@@ -64,7 +64,7 @@ private:
   void Process() override;
   void OnExit() override;
 
-  PLT_MediaController* m_control;
+  PLT_MediaController* m_control = nullptr;
   std::unique_ptr<CUPnPPlayerController> m_delegate;
   std::string m_current_uri;
   std::string m_current_meta;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -11991,9 +11991,8 @@ void CVideoDatabase::GetVideoVersions(VideoDbContentType itemType,
 
     while (!m_pDS2->eof())
     {
-      versions.push_back(std::make_tuple(m_pDS2->fv("name").get_asString(),
-                                         m_pDS2->fv("id").get_asInt(),
-                                         m_pDS2->fv("idFile").get_asInt()));
+      versions.emplace_back(m_pDS2->fv("name").get_asString(), m_pDS2->fv("id").get_asInt(),
+                            m_pDS2->fv("idFile").get_asInt());
       m_pDS2->next();
     }
     m_pDS2->close();

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -11869,7 +11869,7 @@ void CVideoDatabase::InitializeVideoVersionTypeTable(int schemaVersion)
 
     for (int id = VIDEO_VERSION_ID_BEGIN; id <= VIDEO_VERSION_ID_END; ++id)
     {
-      const std::string type{g_localizeStrings.Get(id)};
+      const std::string& type{g_localizeStrings.Get(id)};
       if (schemaVersion < 127)
       {
         m_pDS->exec(
@@ -11901,7 +11901,7 @@ void CVideoDatabase::UpdateVideoVersionTypeTable()
 
     for (int id = VIDEO_VERSION_ID_BEGIN; id <= VIDEO_VERSION_ID_END; ++id)
     {
-      std::string type = g_localizeStrings.Get(id);
+      const std::string& type = g_localizeStrings.Get(id);
       m_pDS->exec(PrepareSQL("UPDATE videoversiontype SET name = '%s', owner = %i WHERE id = '%i'",
                              type.c_str(), VideoAssetTypeOwner::SYSTEM, id));
     }

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -623,7 +623,7 @@ bool CGUIDialogVideoManagerVersions::GetSimilarMovies(const std::shared_ptr<CFil
 }
 
 bool CGUIDialogVideoManagerVersions::AddSimilarMovieAsVersion(
-    const std::shared_ptr<CFileItem> itemMovie)
+    const std::shared_ptr<CFileItem>& itemMovie)
 {
   // A movie with versions cannot be turned into a version
   if (itemMovie->GetVideoInfoTag()->HasVideoVersions())

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
@@ -102,7 +102,7 @@ private:
    * \param itemMovie Movie to convert
    * \return True for success, false otherwse
    */
-  bool AddSimilarMovieAsVersion(const std::shared_ptr<CFileItem> itemMovie);
+  bool AddSimilarMovieAsVersion(const std::shared_ptr<CFileItem>& itemMovie);
 
   /*!
    * \brief Populates a list with all movies of the libray, excluding the item provided as parameter.


### PR DESCRIPTION
## Description
[clang-tidy] fix modernize-* and performance-* warnings

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
