### PR TITLE
[Profile] Profile usability/consistency updates.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -14456,7 +14456,12 @@ msgctxt "#20478"
 msgid "DV profile"
 msgstr ""
 
-#empty strings from id 20479 to 21329
+#: xbmc/profiles/dialogs/GUIDialogProfileSettings.xml
+msgctxt "#20479"
+msgid "Profile needs reloading for changes to take effect. Reload now?"
+msgstr ""
+
+#empty strings from id 20480 to 21329
 #up to 21329 is reserved for the video db !! !
 
 #: system/settings/settings.xml

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -12800,7 +12800,7 @@ msgstr ""
 
 #: addons/skin.estuary/xml/Variables.xml
 msgctxt "#20060"
-msgid "Media info"
+msgid "Media"
 msgstr ""
 
 msgctxt "#20061"

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -580,6 +580,17 @@ void CUtil::CleanString(const std::string& strFileName,
     strTitleAndYear += URIUtils::GetExtension(strFileName);
 }
 
+std::string CUtil::SQLTableCleanString(const std::string& table)
+{
+  std::string t = table.substr(0, 32);
+  for (char& c : t)
+  {
+    if (c == '.' || c == '/')
+      c = '_';
+  }
+  return t;
+}
+
 void CUtil::GetQualifiedFilename(const std::string &strBasePath, std::string &strFilename)
 {
   // Check if the filename is a fully qualified URL such as protocol://path/to/file

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -50,6 +50,7 @@ public:
                           std::string& strYear,
                           bool bRemoveExtension = false,
                           bool bCleanChars = true);
+  static std::string SQLTableCleanString(const std::string& table);
   static bool GetFilenameIdentifier(const std::string& fileName,
                                     std::string& identifierType,
                                     std::string& identifier);

--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -573,8 +573,8 @@ void CDatabase::InitSettings(DatabaseSettings& dbSettings)
       dbSettings.host = CSpecialProtocol::TranslatePath(m_profileManager.GetDatabaseFolder());
   }
 
-  // use separate, versioned database
-  if (dbSettings.name.empty())
+  // use separate, versioned database unless user has elected to share default in profile
+  if (dbSettings.name.empty() || !m_profileManager.GetCurrentProfile().hasDatabases())
     dbSettings.name = GetBaseDBName();
 }
 

--- a/xbmc/profiles/Profile.cpp
+++ b/xbmc/profiles/Profile.cpp
@@ -41,6 +41,7 @@ CProfile::CProfile(const std::string &directory, const std::string &name, const 
   m_bSources = true;
   m_bCanWriteSources = true;
   m_bAddons = true;
+  m_bNeedsRefresh = false;
 }
 
 CProfile::~CProfile(void) = default;

--- a/xbmc/profiles/Profile.h
+++ b/xbmc/profiles/Profile.h
@@ -75,6 +75,7 @@ public:
   bool programsLocked() const { return m_locks.programs; }
   bool gamesLocked() const { return m_locks.games; }
   const CLock &GetLocks() const { return m_locks; }
+  bool needsRefresh() const { return m_bNeedsRefresh; }
 
   void setName(const std::string& name) {m_name = name;}
   void setDirectory(const std::string& directory) {m_directory = directory;}
@@ -86,6 +87,7 @@ public:
   void setSources(bool bHas) { m_bSources = bHas; }
   void setWriteSources(bool bCan) { m_bCanWriteSources = bCan; }
   void SetLocks(const CLock &locks);
+  void SetNeedsRefresh(const bool needsRefresh) { m_bNeedsRefresh = needsRefresh; }
 
 private:
   std::string m_directory;
@@ -98,5 +100,6 @@ private:
   bool m_bSources;
   bool m_bCanWriteSources;
   bool m_bAddons;
+  bool m_bNeedsRefresh;
   CLock m_locks;
 };

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -21,7 +21,6 @@
 #include "addons/Service.h" //! @todo Remove me
 #include "addons/Skin.h"
 #include "application/Application.h" //! @todo Remove me
-#include "application/ApplicationComponents.h"
 #include "application/ApplicationPowerHandling.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "events/EventLog.h"
@@ -52,7 +51,6 @@
 #include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
-#include "utils/Variant.h"
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 #include "video/VideoLibraryQueue.h" //! @todo Remove me
@@ -298,6 +296,10 @@ bool CProfileManager::LoadProfile(unsigned int index)
     return true;
   }
 
+  // check if the profile is already active
+  if (m_currentProfile == index && !m_profiles.at(index).needsRefresh())
+    return true;
+
   // save any settings of the currently used skin but only if the (master)
   // profile hasn't just been loaded as a temporary profile for login
   auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
@@ -312,6 +314,7 @@ bool CProfileManager::LoadProfile(unsigned int index)
 
   SetCurrentProfileId(index);
   m_previousProfileLoadedForLogin = false;
+  m_profiles.at(index).SetNeedsRefresh(false);
 
   // load the new settings
   if (!settings->Load())

--- a/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
@@ -24,6 +24,7 @@
 #include "profiles/dialogs/GUIDialogLockSettings.h"
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
+#include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
 #include "settings/windows/GUIControlSettings.h"
@@ -31,6 +32,8 @@
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
+#include "utils/XBMCTinyXML2.h"
+#include "utils/XMLUtils.h"
 #include "utils/log.h"
 
 #include <cassert>
@@ -174,6 +177,58 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
                                 URIUtils::AddFileToFolder("special://masterprofile/", dialog->m_directory, "sources.xml"));
           }
       }
+
+      exists = XFILE::CFile::Exists(URIUtils::AddFileToFolder(
+          "special://masterprofile/", dialog->m_directory, "advancedsettings.xml"));
+      const DatabaseSettings dbv =
+          CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_databaseVideo;
+      const DatabaseSettings dbm =
+          CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_databaseMusic;
+      if (!exists && (!dbv.type.empty() || !dbm.type.empty()))
+      {
+        // Remote database so cannot create seperate database files
+        // Instead use <name> to create a unique name
+        CXBMCTinyXML xmlDoc;
+        TiXmlElement xmlRootElement("advancedsettings");
+        TiXmlNode* pRoot = xmlDoc.InsertEndChild(xmlRootElement);
+        if (pRoot != nullptr)
+        {
+          if (!dbv.type.empty())
+          {
+            TiXmlElement xmlVideoElement("videodatabase");
+            TiXmlNode* pVideo = pRoot->InsertEndChild(xmlVideoElement);
+            XMLUtils::SetString(pVideo, "type", dbv.type);
+            XMLUtils::SetString(pVideo, "host", dbv.host);
+            XMLUtils::SetString(pVideo, "port", dbv.port);
+            XMLUtils::SetString(pVideo, "user", dbv.user);
+            XMLUtils::SetString(pVideo, "pass", dbv.pass);
+
+            // Generate name
+            XMLUtils::SetString(
+                pVideo, "name",
+                StringUtils::Format("{}-myvideos", CUtil::SQLTableCleanString(dialog->m_name)));
+          }
+
+          if (!dbm.type.empty())
+          {
+            TiXmlElement xmlMusicElement("musicdatabase");
+            TiXmlNode* pMusic = pRoot->InsertEndChild(xmlMusicElement);
+            XMLUtils::SetString(pMusic, "type", dbm.type);
+            XMLUtils::SetString(pMusic, "host", dbm.host);
+            XMLUtils::SetString(pMusic, "port", dbm.port);
+            XMLUtils::SetString(pMusic, "user", dbm.user);
+            XMLUtils::SetString(pMusic, "pass", dbm.pass);
+
+            // Generate name
+            XMLUtils::SetString(
+                pMusic, "name",
+                StringUtils::Format("{}-mymusic", CUtil::SQLTableCleanString(dialog->m_name)));
+          }
+
+          xmlDoc.SaveFile(StringUtils::Format("special://masterprofile/{}/advancedsettings.xml",
+                                              dialog->m_directory));
+        }
+      }
     }
 
     /*if (!dialog->m_bIsNewUser)
@@ -190,6 +245,7 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
     profile->setDatabases((dialog->m_dbMode & 2) == 2);
     profile->setSources((dialog->m_sourcesMode & 2) == 2);
     profile->SetLocks(dialog->m_locks);
+    profile->SetNeedsRefresh(true);
     profileManager->Save();
 
     return true;

--- a/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
+++ b/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
@@ -13,6 +13,7 @@
 #include "ServiceBroker.h"
 #include "dialogs/GUIDialogContextMenu.h"
 #include "dialogs/GUIDialogSelect.h"
+#include "dialogs/GUIDialogYesNo.h"
 #include "filesystem/Directory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIMessage.h"
@@ -150,10 +151,16 @@ bool CGUIWindowSettingsProfile::OnMessage(CGUIMessage& message)
           {
             if (CGUIDialogProfileSettings::ShowForProfile(iItem))
             {
-              LoadList();
-              CGUIMessage msg(GUI_MSG_ITEM_SELECT, GetID(), 2,iItem);
-              CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
-
+              // if current profile, ask user if wants to log out now (= yes)
+              if (profileManager->GetCurrentProfileId() == iItem &&
+                  CGUIDialogYesNo::ShowAndGetInput(CVariant{13200}, CVariant{20479}))
+                profileManager->LoadProfile(iItem); // Refresh profile now
+              else
+              {
+                LoadList();
+                CGUIMessage msg(GUI_MSG_ITEM_SELECT, GetID(), 2, iItem);
+                CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
+              }
               return true;
             }
 

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -301,6 +301,15 @@ void CGUIDialogVideoInfo::OnInitWindow()
   else
     CONTROL_DISABLE(CONTROL_BTN_GET_FANART);
 
+  // Do not enable video versions and extras if database is read only
+  CONTROL_ENABLE_ON_CONDITION(
+      CONTROL_BTN_MANAGE_VIDEO_VERSIONS,
+      (profileManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser));
+
+  CONTROL_ENABLE_ON_CONDITION(
+      CONTROL_BTN_MANAGE_VIDEO_EXTRAS,
+      (profileManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser));
+
   Update();
 
   CGUIDialog::OnInitWindow();


### PR DESCRIPTION
## Description

Provides a number of usability/consistency fixes for profiles when a remote database is in use v. profiles when local databases are in use.

Currently local profiles behave as described in the wiki - https://kodi.wiki/view/Profiles. Remote profiles do not (and this is not made clear).

The only (vague) reference to making remote database profiles work correctly is in https://kodi.wiki/view/MySQL/Setting_up_Kodi#Name_tag.

There has been discussion in the links below as to whether the should be one music and video database (which is what PR #24383 attempted) or seperate ones (which seems to be by design for local databases). I accept that using a remote database is exprimental (and needs `advancessettings.xml` knowledge - although that is well explained in the wiki) but my feeling is that profilies should behave consistently, hence this PR. I know this may all change in v22 but these relatively simple fixes will make it consistent for now.

The remainder are some usability fixes, as a result from playing around with profiles.

## Motivation and context

As highlighted in #24424 and following on from #23999 (and closed PR #24383).

1) In the profile dialog it refers to 'Media Info' - it seems to mean the actual media itself (ie. the content of the myvideos/mymusic databases) - I think it should just say 'Media'??

Changed to just say Media - more accurately reflects effect.

2) Once a profile is created and you make changes to the profile you need to log off and on again for them to take effect - this isn't explain in the GUI - perhaps a dialog offering to log off now if a change is made??

The user is now presented with a dialog to reload profile.

3) Versions and extras can still be manipulated if 'Shares with Source (Read Only)' is chosen for Media - these buttons in the info dialog should be greyed out like Change Art is.

These two buttons are now appropriately greyed out.

4) When creating a profile with a remote database - Media Info effectively doesn't do anything. The same mymovies and mymusic tables are used for each profile - this can be overcome with the tag in advancedsettings.xml but this isn't obvious - I wonder if it should be default that an advancedsettings.xml is created in the profile directory with the and tags copied over and inserted??

A custom `advancedsettings.xml` is now created in the profile directory if there is a remote database in the current profile - these details are copied over and name for the music/video database is given as <profilename>-mymusic/myvideos.

5) Once a exists for a remote database in a profile advancedsettings.xml - the media option to share default database is ignored.

This is fixed.

## How has this been tested?

Locally on Win64 with a remote mariadb database.

## What is the effect on users?

As above

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Improvement** (non-breaking change which improves existing functionality))

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
