### PR TITLE
[UPnP] Translate object id when marked as watched

### DIFF
--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -1130,7 +1130,7 @@ CUPnPServer::OnUpdateObject(PLT_ActionReference&             action,
                             NPT_Map<NPT_String,NPT_String>&  new_vals,
                             const PLT_HttpRequestContext&    context)
 {
-    std::string path(CURL::Decode(object_id));
+    const std::string path = DecodeObjectId(CURL::Decode(object_id)).GetChars();
     CFileItem updated;
     updated.SetPath(path);
     m_logger->info("OnUpdateObject: {} from {}", path,


### PR DESCRIPTION
## Description
This is a regression from https://github.com/xbmc/xbmc/pull/22869 or, in other words, a spot I missed while introducing the base64 encode/decode of the upnp object ids.
When an item is marked as watched when played on a remote player that's consuming the file from UPnP the request is done with the id encoded. Hence, the item is not marked as watched on the Kodi instance that is serving the file.

This partially addresses https://github.com/xbmc/xbmc/issues/24374

When using Kodi to play the file on a remote target the item is not marked as watched there unless the list is refreshed. This is something that I haven't yet found time to investigate but plan to do.
Note that the only files marked as watched are the library video files. Both music and regular files are not implemented if you browse the code of this method.

