### PR TITLE
add renderbuffer index to RenderCapture() (like for RenderUpdate()), fixes sporadic black captures under Linux

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
@@ -66,7 +66,7 @@ public:
   virtual CRenderInfo GetRenderInfo() { return CRenderInfo(); }
   virtual void Update() = 0;
   virtual void RenderUpdate(int index, int index2, bool clear, unsigned int flags, unsigned int alpha) = 0;
-  virtual bool RenderCapture(CRenderCapture* capture) = 0;
+  virtual bool RenderCapture(int index, CRenderCapture* capture) = 0;
   virtual bool ConfigChanged(const VideoPicture &picture) = 0;
 
   // Feature support

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -229,7 +229,7 @@ void CRendererDRMPRIME::RenderUpdate(
   m_iLastRenderBuffer = index;
 }
 
-bool CRendererDRMPRIME::RenderCapture(CRenderCapture* capture)
+bool CRendererDRMPRIME::RenderCapture(int index, CRenderCapture* capture)
 {
   capture->BeginRender();
   capture->EndRender();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.h
@@ -36,7 +36,7 @@ public:
   void Update() override;
   void RenderUpdate(
       int index, int index2, bool clear, unsigned int flags, unsigned int alpha) override;
-  bool RenderCapture(CRenderCapture* capture) override;
+  bool RenderCapture(int index, CRenderCapture* capture) override;
   bool ConfigChanged(const VideoPicture& picture) override;
 
   // Feature support

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -280,7 +280,7 @@ void CRendererDRMPRIMEGLES::RenderUpdate(
   glEnable(GL_BLEND);
 }
 
-bool CRendererDRMPRIMEGLES::RenderCapture(CRenderCapture* capture)
+bool CRendererDRMPRIMEGLES::RenderCapture(int index, CRenderCapture* capture)
 {
   capture->BeginRender();
   capture->EndRender();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
@@ -46,7 +46,7 @@ public:
   void Update() override;
   void RenderUpdate(
       int index, int index2, bool clear, unsigned int flags, unsigned int alpha) override;
-  bool RenderCapture(CRenderCapture* capture) override;
+  bool RenderCapture(int index, CRenderCapture* capture) override;
   bool ConfigChanged(const VideoPicture& picture) override;
 
   // Feature support

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
@@ -73,7 +73,7 @@ CRenderInfo CRendererMediaCodecSurface::GetRenderInfo()
   return info;
 }
 
-bool CRendererMediaCodecSurface::RenderCapture(CRenderCapture* capture)
+bool CRendererMediaCodecSurface::RenderCapture(int index, CRenderCapture* capture)
 {
   capture->BeginRender();
   capture->EndRender();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.h
@@ -21,7 +21,7 @@ public:
   static CBaseRenderer* Create(CVideoBuffer *buffer);
   static bool Register();
 
-  bool RenderCapture(CRenderCapture* capture) override;
+  bool RenderCapture(int index, CRenderCapture* capture) override;
   void AddVideoPicture(const VideoPicture& picture, int index) override;
   void ReleaseBuffer(int idx) override;
   bool Configure(const VideoPicture& picture, float fps, unsigned int orientation) override;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererStarfish.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererStarfish.cpp
@@ -164,7 +164,7 @@ bool CRendererStarfish::IsGuiLayer()
   return false;
 }
 
-bool CRendererStarfish::RenderCapture(CRenderCapture* capture)
+bool CRendererStarfish::RenderCapture(int index, CRenderCapture* capture)
 {
   return false;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererStarfish.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererStarfish.h
@@ -37,7 +37,7 @@ public:
   void Update() override;
   void RenderUpdate(
       int index, int index2, bool clear, unsigned int flags, unsigned int alpha) override;
-  bool RenderCapture(CRenderCapture* capture) override;
+  bool RenderCapture(int index, CRenderCapture* capture) override;
   bool ConfigChanged(const VideoPicture& picture) override;
 
 protected:

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -1662,8 +1662,10 @@ void CLinuxRendererGL::RenderRGB(int index, int field)
   glBindTexture(m_textureTarget, 0);
 }
 
-bool CLinuxRendererGL::RenderCapture(CRenderCapture* capture)
+bool CLinuxRendererGL::RenderCapture(int index, CRenderCapture* capture)
 {
+  m_iYV12RenderBuffer = index;
+  
   if (!m_bValidated)
     return false;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -1664,8 +1664,6 @@ void CLinuxRendererGL::RenderRGB(int index, int field)
 
 bool CLinuxRendererGL::RenderCapture(int index, CRenderCapture* capture)
 {
-  m_iYV12RenderBuffer = index;
-  
   if (!m_bValidated)
     return false;
 
@@ -1690,7 +1688,7 @@ bool CLinuxRendererGL::RenderCapture(int index, CRenderCapture* capture)
 
   capture->BeginRender();
 
-  Render(RENDER_FLAG_NOOSD, m_iYV12RenderBuffer);
+  Render(RENDER_FLAG_NOOSD, index);
   // read pixels
   glReadPixels(0, CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight() - capture->GetHeight(), capture->GetWidth(), capture->GetHeight(),
                GL_BGRA, GL_UNSIGNED_BYTE, capture->GetRenderBuffer());

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
@@ -72,7 +72,7 @@ public:
   void ReleaseBuffer(int idx) override;
   void RenderUpdate(int index, int index2, bool clear, unsigned int flags, unsigned int alpha) override;
   void Update() override;
-  bool RenderCapture(CRenderCapture* capture) override;
+  bool RenderCapture(int index, CRenderCapture* capture) override;
   CRenderInfo GetRenderInfo() override;
   bool ConfigChanged(const VideoPicture &picture) override;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -1245,8 +1245,6 @@ void CLinuxRendererGLES::RenderFromFBO()
 
 bool CLinuxRendererGLES::RenderCapture(int index, CRenderCapture* capture)
 {
-  m_iYV12RenderBuffer = index;
-  
   if (!m_bValidated)
   {
     return false;
@@ -1271,7 +1269,7 @@ bool CLinuxRendererGLES::RenderCapture(int index, CRenderCapture* capture)
 
   capture->BeginRender();
 
-  Render(RENDER_FLAG_NOOSD, m_iYV12RenderBuffer);
+  Render(RENDER_FLAG_NOOSD, index);
   // read pixels
   glReadPixels(0, CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight() - capture->GetHeight(), capture->GetWidth(), capture->GetHeight(),
                GL_RGBA, GL_UNSIGNED_BYTE, capture->GetRenderBuffer());

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -1243,8 +1243,10 @@ void CLinuxRendererGLES::RenderFromFBO()
   VerifyGLState();
 }
 
-bool CLinuxRendererGLES::RenderCapture(CRenderCapture* capture)
+bool CLinuxRendererGLES::RenderCapture(int index, CRenderCapture* capture)
 {
+  m_iYV12RenderBuffer = index;
+  
   if (!m_bValidated)
   {
     return false;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -75,7 +75,7 @@ public:
   void ReleaseBuffer(int idx) override;
   void RenderUpdate(int index, int index2, bool clear, unsigned int flags, unsigned int alpha) override;
   void Update() override;
-  bool RenderCapture(CRenderCapture* capture) override;
+  bool RenderCapture(int index, CRenderCapture* capture) override;
   CRenderInfo GetRenderInfo() override;
   bool ConfigChanged(const VideoPicture& picture) override;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -651,7 +651,7 @@ void CRenderManager::ManageCaptures()
 
 void CRenderManager::RenderCapture(CRenderCapture* capture)
 {
-  if (!m_pRenderer || !m_pRenderer->RenderCapture(capture))
+  if (!m_pRenderer || !m_pRenderer->RenderCapture(m_presentsource, capture))
     capture->SetState(CAPTURESTATE_FAILED);
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
@@ -218,7 +218,7 @@ void CWinRenderer::RenderUpdate(int index, int index2, bool clear, unsigned int 
   DX::Windowing()->SetAlphaBlendEnable(true);
 }
 
-bool CWinRenderer::RenderCapture(CRenderCapture* capture)
+bool CWinRenderer::RenderCapture(int index, CRenderCapture* capture)
 {
   if (!m_bConfigured)
     return false;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.h
@@ -24,7 +24,7 @@ public:
   static bool Register();
 
   void Update() override;
-  bool RenderCapture(CRenderCapture* capture) override;
+  bool RenderCapture(int index, CRenderCapture* capture) override;
 
   // Player functions
   bool Configure(const VideoPicture &picture, float fps, unsigned int orientation) override;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Long ago the following PR removed the `FlipPage()` function and added the renderbuffer index parameter directly to the `RenderUpdate()` function.
- PR in xbmc repo: https://github.com/xbmc/xbmc/pull/12776

But this change was not done for the similiar `RenderCapture()` function, which as a result does not always use the correct renderbuffer index. This leads to sporadic fully black captures on Linux GL/GLES. 
(for me it was around every 10s, seems to be more prominent if refreshrate is synced)


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The Idea for this PR is from @FernetMenta, I tried to execute it to my best knowledge. (https://github.com/xbmc/xbmc/issues/15153#issuecomment-491510240)

This is relevant for users that are using hyperion.ng / HyperHDR with their Kodi Setup and https://github.com/hyperion-project/hyperion.kodi.
Maybe there are also other Addons using the `RenderCapture()`, but I currently do not know any.

fix for:
- issue in xmbc repo: https://github.com/xbmc/xbmc/issues/15153
- issue in Addon repo: https://github.com/hyperion-project/hyperion.kodi/issues/52

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Compiled and tested on Ubuntu/Linux GBM GL GLES
First compiled Master without changes and reproduced the problem. -> sporadic black captures
Then compiled Master with changes and was not able to reproduces the problem.  -> No more black captures.


## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

The `RenderCapture()` function on Linux should now always reproduces correct captures.
This is used by https://github.com/hyperion-project/hyperion.kodi


## Screenshots (if appropriate):
No Screenshots

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
