### PR TITLE
[video] Remove item 'New version...' from node 'Movies/Versions'. …

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23766,7 +23766,6 @@ msgstr ""
 #. New video version dialog button
 #: xbmc/video/dialogs/GUIDialogVideoManager.cpp
 #: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
-#: xbmc/video/windows/GUIWindowVideoNav.cpp
 msgctxt "#40004"
 msgid "New version..."
 msgstr ""

--- a/xbmc/ContextMenus.cpp
+++ b/xbmc/ContextMenus.cpp
@@ -85,7 +85,6 @@ bool CAddRemoveFavourite::IsVisible(const CFileItem& item) const
           !item.IsPath("newplaylist://") && !URIUtils::IsProtocol(item.GetPath(), "favourites") &&
           !URIUtils::IsProtocol(item.GetPath(), "newsmartplaylist") &&
           !URIUtils::IsProtocol(item.GetPath(), "newtag") &&
-          !URIUtils::IsProtocol(item.GetPath(), "newvideoversion") &&
           !URIUtils::IsProtocol(item.GetPath(), "musicsearch") &&
           // Hide this item for all PVR EPG/timers/search except EPG/timer/timer rules/search root
           // folders.

--- a/xbmc/video/VideoUtils.cpp
+++ b/xbmc/video/VideoUtils.cpp
@@ -549,8 +549,7 @@ bool IsItemPlayable(const CFileItem& item)
   // Exclude special items
   if (StringUtils::StartsWithNoCase(item.GetPath(), "newsmartplaylist://") ||
       StringUtils::StartsWithNoCase(item.GetPath(), "newplaylist://") ||
-      StringUtils::StartsWithNoCase(item.GetPath(), "newtag://") ||
-      StringUtils::StartsWithNoCase(item.GetPath(), "newvideoversion://"))
+      StringUtils::StartsWithNoCase(item.GetPath(), "newtag://"))
     return false;
 
   // Include playlists located at one of the possible video/mixed playlist locations

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -19,7 +19,6 @@
 #include "dialogs/GUIDialogSelect.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIComponent.h"
-#include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "settings/MediaSourceSettings.h"
@@ -294,28 +293,6 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersion()
                                                MediaRole::Parent);
   }
   return false;
-}
-
-std::tuple<int, std::string> CGUIDialogVideoManagerVersions::NewVideoVersion()
-{
-  std::string typeVideoVersion;
-
-  // prompt for the new video version
-  if (!CGUIKeyboardFactory::ShowAndGetInput(typeVideoVersion, CVariant{40004}, false))
-    return std::make_tuple(-1, "");
-
-  CVideoDatabase videodb;
-  if (!videodb.Open())
-  {
-    CLog::LogF(LOGERROR, "Failed to open video database!");
-    return std::make_tuple(-1, "");
-  }
-
-  typeVideoVersion = StringUtils::Trim(typeVideoVersion);
-  const int idVideoVersion{videodb.AddVideoVersionType(typeVideoVersion, VideoAssetTypeOwner::USER,
-                                                       VideoAssetType::VERSION)};
-
-  return std::make_tuple(idVideoVersion, typeVideoVersion);
 }
 
 bool CGUIDialogVideoManagerVersions::ManageVideoVersions(const std::shared_ptr<CFileItem>& item)

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
@@ -28,7 +28,6 @@ public:
 
   void SetVideoAsset(const std::shared_ptr<CFileItem>& item) override;
 
-  static std::tuple<int, std::string> NewVideoVersion();
   static bool ProcessVideoVersion(VideoDbContentType itemType, int dbId);
   /*!
    * \brief Open the Manage Versions dialog for a video

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -541,9 +541,7 @@ bool CGUIWindowVideoBase::OnSelect(int iItem)
   if (!item->m_bIsFolder && path != "add" &&
       !StringUtils::StartsWith(path, "newsmartplaylist://") &&
       !StringUtils::StartsWith(path, "newplaylist://") &&
-      !StringUtils::StartsWith(path, "newtag://") &&
-      !StringUtils::StartsWith(path, "newvideoversion://") &&
-      !StringUtils::StartsWith(path, "script://"))
+      !StringUtils::StartsWith(path, "newtag://") && !StringUtils::StartsWith(path, "script://"))
     return OnFileAction(iItem, CVideoSelectActionProcessorBase::GetDefaultSelectAction(), "");
 
   return CGUIMediaWindow::OnSelect(iItem);

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -501,17 +501,6 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
         newTag->SetSpecialSort(SortSpecialOnTop);
         items.Add(newTag);
       }
-      else if (items.GetContent() == "videoversions" &&
-               !items.Contains("newvideoversion://" + videoUrl.GetType()))
-      {
-        const auto newVideoVersion{
-            std::make_shared<CFileItem>("newvideoversion://" + videoUrl.GetType(), false)};
-        newVideoVersion->SetLabel(g_localizeStrings.Get(40004));
-        newVideoVersion->SetLabelPreformatted(true);
-        newVideoVersion->SetSpecialSort(SortSpecialOnTop);
-        newVideoVersion->SetProperty("IsPlayable", false);
-        items.Add(newVideoVersion);
-      }
     }
   }
   return bResult;
@@ -685,8 +674,7 @@ void CGUIWindowVideoNav::OnDeleteItem(const CFileItemPtr& pItem)
   if (!m_vecItems->IsVideoDb() && !pItem->IsVideoDb())
   {
     if (!pItem->IsPath("newsmartplaylist://video") && !pItem->IsPath("special://videoplaylists/") &&
-        !pItem->IsPath("sources://video/") && !URIUtils::IsProtocol(pItem->GetPath(), "newtag") &&
-        !URIUtils::IsProtocol(pItem->GetPath(), "newvideoversion"))
+        !pItem->IsPath("sources://video/") && !URIUtils::IsProtocol(pItem->GetPath(), "newtag"))
       CGUIWindowVideoBase::OnDeleteItem(pItem);
   }
   else if (StringUtils::StartsWithNoCase(pItem->GetPath(), "videodb://movies/sets/") &&
@@ -1046,20 +1034,6 @@ bool CGUIWindowVideoNav::OnClick(int iItem, const std::string &player)
         videodb.AddTagToItem(items[index]->GetVideoInfoTag()->m_iDbId, idTag, mediaType);
       }
     }
-
-    Refresh(true);
-    return true;
-  }
-  else if (StringUtils::StartsWithNoCase(item->GetPath(), "newvideoversion://"))
-  {
-    // dont allow update while scanning
-    if (CVideoLibraryQueue::GetInstance().IsScanningLibrary())
-    {
-      HELPERS::ShowOKDialogText(CVariant{257}, CVariant{14057});
-      return true;
-    }
-
-    CGUIDialogVideoManagerVersions::NewVideoVersion();
 
     Refresh(true);
     return true;


### PR DESCRIPTION
Functionality is also available in video versions manage dialog, where it is offered while adding a new version of a movie. No need to have this functionality at two different places.

![screenshot00002](https://github.com/xbmc/xbmc/assets/3226626/3b64dc90-5713-4bdd-9aad-e6968cc1e142)

Runtime-tested on macOS, latest Kodi master.

@enen92 @CrystalP something trivial for a review I guess.
