### PR TITLE
[video] Video Versions: Remove more dead code 

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23880,7 +23880,6 @@ msgstr ""
 
 #. Button label to make a video version the default version
 #: addons/skin.estuary/xml/DialogVideoVersion.xml
-#: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
 msgctxt "#40023"
 msgid "Set as default"
 msgstr ""

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -12448,43 +12448,6 @@ std::string CVideoDatabase::GetVideoVersionById(int id)
   return GetSingleValue(PrepareSQL("SELECT name FROM videoversiontype WHERE id=%i", id), m_pDS2);
 }
 
-bool CVideoDatabase::GetVideoItemByVideoVersion(int dbId, CFileItem& item)
-{
-  if (!m_pDB || !m_pDS)
-    return false;
-
-  try
-  {
-    m_pDS->query(
-        PrepareSQL("SELECT idMedia, media_type, idType FROM videoversion WHERE idFile = %i", dbId));
-
-    if (m_pDS->num_rows() > 0)
-    {
-      int idMedia = m_pDS->fv("idMedia").get_asInt();
-      std::string mediaType = m_pDS->fv("media_type").get_asString();
-      const int idType{m_pDS->fv("idType").get_asInt()};
-
-      m_pDS->close();
-
-      if (mediaType == MediaTypeMovie)
-      {
-        CVideoInfoTag videoInfo;
-        if (GetMovieInfo("", videoInfo, idMedia, idType))
-        {
-          item.SetFromVideoInfoTag(videoInfo);
-          return true;
-        }
-      }
-    }
-  }
-  catch (...)
-  {
-    CLog::Log(LOGERROR, "{} failed for video version {}", __FUNCTION__, dbId);
-  }
-
-  return false;
-}
-
 void CVideoDatabase::SetVideoVersionDefaultArt(int dbId, int idFrom, VideoDbContentType type)
 {
   MediaType mediaType;

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1008,7 +1008,6 @@ public:
 
   std::string GetVideoItemTitle(VideoDbContentType itemType, int dbId);
   std::string GetVideoVersionById(int id);
-  bool GetVideoItemByVideoVersion(int dbId, CFileItem& item);
   void GetVideoVersions(VideoDbContentType itemType,
                         int dbId,
                         CFileItemList& items,

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -13,7 +13,6 @@
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "cores/VideoPlayer/DVDFileInfo.h"
-#include "dialogs/GUIDialogContextMenu.h"
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogSelect.h"
@@ -309,66 +308,6 @@ bool CGUIDialogVideoManagerVersions::ManageVideoVersions(const std::shared_ptr<C
   dialog->SetVideoAsset(item);
   dialog->Open();
   return dialog->HasUpdatedItems();
-}
-
-int CGUIDialogVideoManagerVersions::ManageVideoVersionContextMenu(
-    const std::shared_ptr<CFileItem>& version)
-{
-  CContextButtons buttons;
-
-  buttons.Add(CONTEXT_BUTTON_RENAME, 118);
-  buttons.Add(CONTEXT_BUTTON_SET_DEFAULT, 40023);
-  buttons.Add(CONTEXT_BUTTON_DELETE, 15015);
-  buttons.Add(CONTEXT_BUTTON_SET_ART, 13511);
-
-  const int button{CGUIDialogContextMenu::ShowAndGetChoice(buttons)};
-  if (button > 0)
-  {
-    CGUIDialogVideoManagerVersions* dialog{
-        CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogVideoManagerVersions>(
-            WINDOW_DIALOG_MANAGE_VIDEO_VERSIONS)};
-    if (!dialog)
-    {
-      CLog::LogF(LOGERROR, "Unable to get WINDOW_DIALOG_MANAGE_VIDEO_VERSIONS instance!");
-      return -1;
-    }
-
-    CFileItem videoItem;
-    if (!dialog->m_database.GetVideoItemByVideoVersion(version->GetVideoInfoTag()->m_iDbId,
-                                                       videoItem))
-      return -1;
-
-    dialog->SetVideoAsset(std::make_shared<CFileItem>(videoItem));
-    dialog->SetSelectedVideoAsset(version);
-
-    switch (static_cast<CONTEXT_BUTTON>(button))
-    {
-      case CONTEXT_BUTTON_RENAME:
-      {
-        dialog->Rename();
-        break;
-      }
-      case CONTEXT_BUTTON_SET_DEFAULT:
-      {
-        dialog->SetDefault();
-        break;
-      }
-      case CONTEXT_BUTTON_DELETE:
-      {
-        dialog->Remove();
-        break;
-      }
-      case CONTEXT_BUTTON_SET_ART:
-      {
-        dialog->ChooseArt();
-        break;
-      }
-      default:
-        break;
-    }
-  }
-
-  return button;
 }
 
 bool CGUIDialogVideoManagerVersions::ChooseVideoAndConvertToVideoVersion(

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
@@ -36,7 +36,6 @@ public:
    * false: no changes
    */
   static bool ManageVideoVersions(const std::shared_ptr<CFileItem>& item);
-  static int ManageVideoVersionContextMenu(const std::shared_ptr<CFileItem>& version);
 
 protected:
   bool OnMessage(CGUIMessage& message) override;

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -41,7 +41,6 @@
 #include "video/VideoInfoScanner.h"
 #include "video/VideoLibraryQueue.h"
 #include "video/dialogs/GUIDialogVideoInfo.h"
-#include "video/dialogs/GUIDialogVideoManagerVersions.h"
 #include "view/GUIViewState.h"
 
 #include <utility>
@@ -805,9 +804,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
              item->GetVideoInfoTag()->m_type == MediaTypeEpisode || // episodes
              item->GetVideoInfoTag()->m_type == MediaTypeMusicVideo || // musicvideos
              item->GetVideoInfoTag()->m_type == "tag" || // tags
-             item->GetVideoInfoTag()->m_type == MediaTypeVideoCollection || // sets
-             (item->GetVideoInfoTag()->m_type == MediaTypeVideoVersion &&
-              item->GetVideoInfoTag()->m_iFileId != -1))) // videoversions for a certain video
+             item->GetVideoInfoTag()->m_type == MediaTypeVideoCollection)) // sets
         {
           buttons.Add(CONTEXT_BUTTON_EDIT, 16106);
         }
@@ -887,10 +884,8 @@ bool CGUIWindowVideoNav::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
   {
   case CONTEXT_BUTTON_EDIT:
     {
-      CONTEXT_BUTTON ret =
-          item->GetVideoInfoTag()->m_type == MediaTypeVideoVersion
-              ? (CONTEXT_BUTTON)CGUIDialogVideoManagerVersions::ManageVideoVersionContextMenu(item)
-              : (CONTEXT_BUTTON)CGUIDialogVideoInfo::ManageVideoItem(item);
+      const CONTEXT_BUTTON ret{
+          static_cast<CONTEXT_BUTTON>(CGUIDialogVideoInfo::ManageVideoItem(item))};
 
       if (ret != CONTEXT_BUTTON_CANCELLED)
       {


### PR DESCRIPTION
... after c84fdfa0971f5c5d23c07e384369033198c9d04e

Since we technically list "movie" items instead of "videoversion" items in movie versions folder view, we need no special "manage" context menu for "videoversion" items anymore.

Runtime-tested on macOS, latest Kodi master.

Note that this PR has a build dependency on #24444

@enen92 @CrystalP something for a quick review...