### PR TITLE
[CGUIPassword] Media served through plugins is not shown when there is a master lock.

### DIFF
--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -11,6 +11,7 @@
 #include "FileItem.h"
 #include "GUIUserMessages.h"
 #include "ServiceBroker.h"
+#include "URL.h"
 #include "Util.h"
 #include "dialogs/GUIDialogGamepad.h"
 #include "dialogs/GUIDialogNumeric.h"
@@ -543,6 +544,14 @@ bool CGUIPassword::IsDatabasePathUnlocked(const std::string& strPath, VECSOURCES
 
   if (g_passwordManager.bMasterUser || profileManager->GetMasterProfile().getLockMode() == LOCK_MODE_EVERYONE)
     return true;
+
+  // Don't check plugin paths as they don't have an entry in sources.xml
+  // Base locked status on videos being locked and being in the video
+  // navigation screen (must have passed lock by then)
+  CURL url{strPath};
+  if (url.IsProtocol("plugin"))
+    return !(profileManager->GetCurrentProfile().videoLocked() &&
+             CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() != WINDOW_VIDEO_NAV);
 
   // try to find the best matching source
   bool bName = false;


### PR DESCRIPTION
## Description

One way to fix #24358 - which it looks like has been an issue in various guises for a number of years.

The issue occurs because, when there is a master lock, each media item's lock status is checked in `CGUIPassword::IsDatabasePathUnlocked`. The latter part of this routine tries to find the media's source and checks to see if the source is locked.

Jellyfin (and I assume the other plugins) don't have an entry in `sources.xml` so the source is not found and the routine exits false indicating the media is locked and hence it is not shown.

The workaround has been to create a dummy Jellyfin entry in sources that is 'found' by `CUtil::GetMatchingSource`.

As far as I can see there are 3 possible ways to fix this:

1) As per this PR - check to see if the media source is a plugin, and if so, instead of looking for a non-existant source it simply goes on whether videos are locked generally and if the video selection screen is displayed (as by definition if you're on the latter you've entered the master password).

2) You could just change the `return false` at the end of the `CGUIPassword::IsDatabasePathUnlocked` routine to `return true` - which is similar to the other lock checking routines - ie. assume it's unlocked if all else fails - but this way you'd never be able to lock the plugin video sources.

3) The plugin would need to be modified to add itself to the `sources.xml`. The two obvious issues are 1) it requires the plugin creators to do it and 2) they would need then to manage what can be seen through the source - ie. if you add the dummy entry above you can access all the videos/music/settings of the plugin through the souces entry.

## Motivation and context

As above.

## How has this been tested?

Windows 11 x64 with Jellyfin server.

EDIT: Confirmed working by the OP in https://github.com/xbmc/xbmc/issues/24358#issuecomment-1919616509

## What is the effect on users?

As above.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
