### PR TITLE
[UPnP] Fix broadcast of item updates

### DIFF
--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -182,8 +182,9 @@ CUPnPServer::PropagateUpdates()
     // only broadcast ids with modified bit set
     for (itr = m_UpdateIDs.begin(); itr != m_UpdateIDs.end(); ++itr) {
         if (itr->second.first) {
-          buffer.append(StringUtils::Format("{},{},", itr->first, itr->second.second));
-          itr->second.first = false;
+            buffer.append(StringUtils::Format("{},{},", EncodeObjectId(itr->first).GetChars(),
+                                              itr->second.second));
+            itr->second.first = false;
         }
     }
 


### PR DESCRIPTION
## Description
Another regression from https://github.com/xbmc/xbmc/pull/24438. When an item suffers a change the server has to broadcast them with the encoded object id so that the consuming player invalidates the cache properly (otherwise the id of the container is unknown).

This fixes https://github.com/xbmc/xbmc/issues/24374

Note the only supported items are the the videodb:// ones:

https://github.com/xbmc/xbmc/blob/master/xbmc/network/upnp/UPnPServer.cpp#L1235-L1242

Support for regular video files is actually a feature request.