### PR TITLE
[video] Video versions: Fix certain default select action handling scenarios

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -569,7 +569,7 @@ public:
 protected:
   bool OnPlayPartSelected(unsigned int part) override
   {
-    return m_window.OnPlayStackPart(m_itemIndex, part);
+    return m_window.OnPlayStackPart(m_item, part);
   }
 
   bool OnResumeSelected() override
@@ -826,16 +826,13 @@ void CGUIWindowVideoBase::GetContextButtons(int itemNumber, CContextButtons &but
   CGUIMediaWindow::GetContextButtons(itemNumber, buttons);
 }
 
-bool CGUIWindowVideoBase::OnPlayStackPart(int itemIndex, unsigned int partNumber)
+bool CGUIWindowVideoBase::OnPlayStackPart(const std::shared_ptr<CFileItem>& item,
+                                          unsigned int partNumber)
 {
   // part numbers are 1-based.
   if (partNumber < 1)
     return false;
 
-  if (itemIndex < 0 || itemIndex >= m_vecItems->Size())
-    return false;
-
-  const std::shared_ptr<CFileItem> item = m_vecItems->Get(itemIndex);
   const std::string path = item->GetDynPath();
 
   if (!URIUtils::IsStack(path))
@@ -874,7 +871,7 @@ bool CGUIWindowVideoBase::OnPlayStackPart(int itemIndex, unsigned int partNumber
     }
   }
   // play the video
-  return OnClick(itemIndex);
+  return PlayItem(item, "");
 }
 
 bool CGUIWindowVideoBase::OnContextButton(int itemNumber, CONTEXT_BUTTON button)

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -589,7 +589,7 @@ protected:
     return true;
   }
 
-  bool OnInfoSelected() override { return m_window.OnItemInfo(m_itemIndex); }
+  bool OnInfoSelected() override { return m_window.OnItemInfo(*m_item); }
 
   bool OnMoreSelected() override
   {

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -9,6 +9,7 @@
 #include "GUIWindowVideoBase.h"
 
 #include "Autorun.h"
+#include "ContextMenuManager.h"
 #include "GUIPassword.h"
 #include "GUIUserMessages.h"
 #include "PartyModeManager.h"
@@ -593,6 +594,10 @@ protected:
 
   bool OnMoreSelected() override
   {
+    // window only shows the default version, so no window specific context menu items available
+    if (m_item->HasVideoVersions() && !m_item->GetVideoInfoTag()->IsDefaultVideoVersion())
+      return CONTEXTMENU::ShowFor(m_item, CContextMenuManager::MAIN);
+
     m_window.OnPopupMenu(m_itemIndex);
     return true;
   }

--- a/xbmc/video/windows/GUIWindowVideoBase.h
+++ b/xbmc/video/windows/GUIWindowVideoBase.h
@@ -124,7 +124,7 @@ protected:
 
   static bool StackingAvailable(const CFileItemList &items);
 
-  bool OnPlayStackPart(int itemIndex, unsigned int partNumber);
+  bool OnPlayStackPart(const std::shared_ptr<CFileItem>& item, unsigned int partNumber);
 
   void UpdateVideoVersionItems();
   void UpdateVideoVersionItemsLabel(const std::string& directory);


### PR DESCRIPTION
Fixes #24448 

When 'default select action' is `choose` or `info` and 'select default version' is `off` and 'show videos with multiple versions as folder' is `off`, then the action would be executed upon the default video version, not the version selected by the user, e.g. video info dialog with wrong version opened, leading to button 'Play' playing (ofc) the wrong version, from users point of view, though technically working correct. The dialog plays exactly the version it was initialised with. But root cause is to initialise it with the wrong version. ;-)

Runtime-tested on macOS, latest Kodi version.

@enen92 something for you to review, please. Problem with previous implementation was that the version selected is not always in the list of items the window displays. The index passed on points to the default version of the video. We must not pass the index, but the real item to the window.