### PR TITLE
[video] Fix Versions Art Changes

### DIFF
--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -945,11 +945,7 @@ public:
   void SetArtForItem(int mediaId, const MediaType &mediaType, const std::string &artType, const std::string &url);
   void SetArtForItem(int mediaId, const MediaType &mediaType, const std::map<std::string, std::string> &art);
   bool GetArtForItem(int mediaId, const MediaType &mediaType, std::map<std::string, std::string> &art);
-  std::string GetArtForItem(int mediaId, const MediaType &mediaType, const std::string &artType);
-  bool GetArtForAsset(int assetId,
-                      int ownerId,
-                      const MediaType& mediaType,
-                      std::map<std::string, std::string>& art);
+  std::string GetArtForItem(int mediaId, const MediaType& mediaType, const std::string& artType);
   bool HasArtForItem(int mediaId, const MediaType &mediaType);
   bool RemoveArtForItem(int mediaId, const MediaType &mediaType, const std::string &artType);
   bool RemoveArtForItem(int mediaId, const MediaType &mediaType, const std::set<std::string> &artTypes);

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -397,15 +397,8 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
   {
     m_videoDatabase->Open();
 
-    if (tag.GetAssetInfo().GetId() >= 0)
-    {
-      if (m_videoDatabase->GetArtForAsset(tag.m_iFileId, tag.m_iDbId, tag.m_type, artwork))
-        item.AppendArt(artwork);
-    }
-    else if (m_videoDatabase->GetArtForItem(tag.m_iDbId, tag.m_type, artwork))
-    {
+    if (m_videoDatabase->GetArtForItem(tag.m_iDbId, tag.m_type, artwork))
       item.AppendArt(artwork);
-    }
     else if (tag.m_type == "actor" && !tag.m_artist.empty() &&
              item.GetProperty("musicvideomediatype") != MediaTypeArtist)
     {

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -844,12 +844,7 @@ void AddCurrentArtTypes(std::vector<std::string>& artTypes, const CVideoInfoTag&
   CVideoDatabase& db)
 {
   std::map<std::string, std::string> currentArt;
-
-  if (tag.GetAssetInfo().GetId() >= 0)
-    db.GetArtForAsset(tag.m_iFileId, tag.m_iDbId, tag.m_type, currentArt);
-  else
-    db.GetArtForItem(tag.m_iDbId, tag.m_type, currentArt);
-
+  db.GetArtForItem(tag.m_iDbId, tag.m_type, currentArt);
   for (const auto& art : currentArt)
   {
     if (!art.second.empty() &&

--- a/xbmc/video/dialogs/GUIDialogVideoManager.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -330,6 +330,17 @@ void CGUIDialogVideoManager::ChooseArt()
   if (!CGUIDialogVideoInfo::ChooseAndManageVideoItemArtwork(m_selectedVideoAsset))
     return;
 
+  m_videoAsset->ClearArt();
+  CVideoThumbLoader thumbLoader;
+  thumbLoader.LoadItem(m_videoAsset.get());
+
+  // notify all windows to update the file item
+  // clang-format off
+  CGUIMessage msg{GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_ITEM,
+                  GUI_MSG_FLAG_FORCE_UPDATE, m_videoAsset};
+  // clang-format on
+  CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
+
   // refresh data and controls
   Refresh();
 }

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -69,6 +69,7 @@ bool CGUIDialogVideoManagerVersions::OnMessage(CGUIMessage& message)
       else if (control == CONTROL_BUTTON_SET_DEFAULT)
       {
         SetDefault();
+        m_hasUpdatedItems = true;
       }
       break;
     }
@@ -183,9 +184,15 @@ void CGUIDialogVideoManagerVersions::SetDefaultVideoVersion(const CFileItem& ver
   // update video details since we changed the video file for the item
   m_database.GetDetailsByTypeAndId(*m_videoAsset, itemType, dbId);
 
+  m_videoAsset->ClearArt();
+  CVideoThumbLoader thumbLoader;
+  thumbLoader.LoadItem(m_videoAsset.get());
+
   // notify all windows to update the file item
-  CGUIMessage msg{GUI_MSG_NOTIFY_ALL,        0,           0, GUI_MSG_UPDATE_ITEM,
+  // clang-format off
+  CGUIMessage msg{GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_ITEM,
                   GUI_MSG_FLAG_FORCE_UPDATE, m_videoAsset};
+  // clang-format on
   CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
 }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Change the way movie / versions artwork is stored and retrieved to provide an intuitive and consistent ux.
As a nice side-effect, this restored "thumbnails" as default art for extras, overridable by user.
It should "just work" but here are additional details.

From the user's point of view, the art presented for the movie is the art of the default version (except for version-aware dialogs/nav). Here what it means for different contexts:

1/ Anywhere in Kodi, except 'Manage versions', 'Choose version', 'versions as folder'
  - The art comes from the default version of the movie. Changing art changes the art of the default version and is visible everywhere that's not version-aware.

2/ Manage versions (version-aware)
  - Changing the art of the default version also changes the art visible for the movie outside of Manage versions
  - Changes of the art of a non-default version is visible only in version-aware contexts
  - Changing the default version switches art everywhere that's not version-aware to the art of the new default version

3/ Choose version, Versions as folder (version-aware)
  - Show the individual versions art, default version or not.

Also fixed a few places where changing art was not refreshing the calling dialogs (probably a few left to do).
fanart will require another look, it's handled differently and Info dialog behaves differently as well.

**Technical details**

When reading or setting art for a movie, the code that is not aware of version art (all code except for the manage versions dialog) will be redirected to automatically use the default version art instead (stored with 'videoversion' media_type instead of 'movie').

There is no change for the retrieval/setting of art with a media_type other 'movie'.

The media_type 'movie' is not used in the art table anymore. All existing 'movie' art is migrated automatically to 'videoversion' art during the database upgrade. Manual user changes of the default version art have priority over art of matching 'movie' art.

This may seem like a radical change but it follows the direction of evolving to an asset table that has basic attributes such as art. Conceptually, a record of videoversion is pretty close to a future "asset". In v22 we'll reintroduce movie groups, that will have their art combined with the art of the assets (much like movie sets).

**Some notes:**
- database upgrade code: the accomplished action is an UPDATE. However UPDATE with additional tables has different syntaxes with SQLite and mySql/MariaDB. An INSERT followed by DELETE is more efficient than many single-row UPDATE statements. The DELETE would have been needed anyway after the individual updates to cleanup the 'movie' art that already had an equivalent as 'videoversion'.
- it would be possible to avoid the artwork redirection from movie to videoversion for callers that already have a videotag with the required info. The saving would be rather small though, I made it so that the conversion is efficient in this PR. The number of queries would not change (1) and it's only a join supported by an index that would be saved. Maybe as a future PR if there is a need.
- Took care of some dialog artwork refresh, there may be some left to do. It wasn't the core objective of the PR.
- Something remains to be done for fanart, though some problems already existed and some combinations already work.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

There was an overlap between movie art and default version art which lead to inconsistencies and big UI changes are not an option at this point in the v21 cycle.

There are alternative ways to the proposal but I didn't find one that also didn't create other inconsistencies or eventually leaked the art between versions.

The alternative of cutting version art didn't seem desirable.

v22 will re-add the concept of "movie group" art that will be merged with individual movies/versions art for display, but with proper UI to manage.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

With new database and database migrated from before versions, on sqlite and maria db.
Created versions, changed art of movie, art of versions, changed default version, ...

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
More intuitive and predictable behavior of movie and version art.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
