### PR TITLE
[guilib] Kill CGUIListItemLayoutPtr typedef

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -236,7 +236,7 @@ void CGUIBaseContainer::ProcessItem(float posX, float posY, CGUIListItemPtr& ite
       item->GetFocusedLayout()->SetFocusedItem(0);  // focus is not set
     if (!item->GetLayout())
     {
-      CGUIListItemLayoutPtr layout = std::make_unique<CGUIListItemLayout>(*m_layout, this);
+      auto layout = std::make_unique<CGUIListItemLayout>(*m_layout, this);
       item->SetLayout(std::move(layout));
     }
     if (item->GetFocusedLayout() && item->GetFocusedLayout()->IsAnimating(ANIM_TYPE_UNFOCUS))

--- a/xbmc/guilib/GUIListItem.cpp
+++ b/xbmc/guilib/GUIListItem.cpp
@@ -323,7 +323,7 @@ void CGUIListItem::FreeMemory(bool immediately)
   }
 }
 
-void CGUIListItem::SetLayout(CGUIListItemLayoutPtr layout)
+void CGUIListItem::SetLayout(std::unique_ptr<CGUIListItemLayout> layout)
 {
   m_layout = std::move(layout);
 }
@@ -333,7 +333,7 @@ CGUIListItemLayout *CGUIListItem::GetLayout()
   return m_layout.get();
 }
 
-void CGUIListItem::SetFocusedLayout(CGUIListItemLayoutPtr layout)
+void CGUIListItem::SetFocusedLayout(std::unique_ptr<CGUIListItemLayout> layout)
 {
   m_focusedLayout = std::move(layout);
 }

--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -19,7 +19,6 @@
 
 //  Forward
 class CGUIListItemLayout;
-using CGUIListItemLayoutPtr = std::unique_ptr<CGUIListItemLayout>;
 class CArchive;
 class CVariant;
 
@@ -125,10 +124,10 @@ public:
   bool HasOverlay() const;
   virtual bool IsFileItem() const { return false; }
 
-  void SetLayout(CGUIListItemLayoutPtr layout);
+  void SetLayout(std::unique_ptr<CGUIListItemLayout> layout);
   CGUIListItemLayout *GetLayout();
 
-  void SetFocusedLayout(CGUIListItemLayoutPtr layout);
+  void SetFocusedLayout(std::unique_ptr<CGUIListItemLayout> layout);
   CGUIListItemLayout *GetFocusedLayout();
 
   void FreeIcons();
@@ -179,8 +178,8 @@ protected:
   std::string m_strLabel2;     // text of column2
   GUIIconOverlay m_overlayIcon; // type of overlay icon
 
-  CGUIListItemLayoutPtr m_layout;
-  CGUIListItemLayoutPtr m_focusedLayout;
+  std::unique_ptr<CGUIListItemLayout> m_layout;
+  std::unique_ptr<CGUIListItemLayout> m_focusedLayout;
   bool m_bSelected;     // item is selected or not
   unsigned int m_currentItem; // current item number within container (starting at 1)
 


### PR DESCRIPTION
## Description
A really small one, just kills `CGUIListItemLayoutPtr` "typedef" making it explicit as a `std::unique_ptr`