### PR TITLE
[video] Detect similar movies when scanning movies with nfo files

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -748,8 +748,11 @@ namespace VIDEO
     }
     if (result == CInfoScanner::FULL_NFO)
     {
-      if (AddVideo(pItem, info2->Content(), bDirNames, true) < 0)
+      const int dbId = AddVideo(pItem, info2->Content(), bDirNames, true);
+      if (dbId < 0)
         return INFO_ERROR;
+      if (!m_ignoreVideoVersions && ProcessVideoVersion(VideoDbContentType::MOVIES, dbId))
+        return INFO_HAVE_ALREADY;
       return INFO_ADDED;
     }
     if (result == CInfoScanner::URL_NFO || result == CInfoScanner::COMBINED_NFO)
@@ -780,8 +783,11 @@ namespace VIDEO
                          : nullptr,
                      pDlgProgress))
       {
-        if (AddVideo(pItem, info2->Content(), bDirNames, useLocal) < 0)
+        const int dbId = AddVideo(pItem, info2->Content(), bDirNames, useLocal);
+        if (dbId < 0)
           return INFO_ERROR;
+        if (!m_ignoreVideoVersions && ProcessVideoVersion(VideoDbContentType::MOVIES, dbId))
+          return INFO_HAVE_ALREADY;
         return INFO_ADDED;
       }
     }
@@ -800,11 +806,10 @@ namespace VIDEO
                        : nullptr,
                    pDlgProgress))
     {
-      int dbId = AddVideo(pItem, info2->Content(), bDirNames, useLocal);
+      const int dbId = AddVideo(pItem, info2->Content(), bDirNames, useLocal);
       if (dbId < 0)
         return INFO_ERROR;
-      if (info2->Content() == CONTENT_MOVIES && !m_ignoreVideoVersions &&
-          ProcessVideoVersion(VideoDbContentType::MOVIES, dbId))
+      if (!m_ignoreVideoVersions && ProcessVideoVersion(VideoDbContentType::MOVIES, dbId))
         return INFO_HAVE_ALREADY;
       return INFO_ADDED;
     }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

The function that looks for similar movies when scanning sources was not called for scanned movies with nfo files.
Added the call, and added it to the other remaining exit path out of `CVideoInfoScanner::RetrieveInfoForMovie`.

@KarellenX FYI

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Scanning a movie with nfo file did not trigger the lookup of similar movies already in the library.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

scanned movie with and without nfo, with and without the setting to ignore similar movies.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Expected normal behavior for movies with nfo files.

## Screenshots (if appropriate):
With the PR, popup appears as expected when there are similar versions:
![image](https://github.com/xbmc/xbmc/assets/489377/afb4eb73-299f-408b-bf7b-25430638fe2b)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
