### PR TITLE
[guilib][utils] Set IsPlayable false on add items

### DIFF
--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -930,10 +930,10 @@ bool IsItemPlayable(const CFileItem& item)
     return true;
   else if (item.m_bIsFolder)
   {
-    // Not a music-specific folder (just file:// or nfs://). Allow play if context is Music window.
-    if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_MUSIC_NAV &&
-        item.GetPath() != "add") // Exclude "Add music source" item
+    if (!item.HasProperty("IsPlayable") || item.GetProperty("IsPlayable").asBoolean())
+    {
       return true;
+    }
   }
   return false;
 }

--- a/xbmc/video/VideoUtils.cpp
+++ b/xbmc/video/VideoUtils.cpp
@@ -606,10 +606,10 @@ bool IsItemPlayable(const CFileItem& item)
   }
   else if (item.m_bIsFolder)
   {
-    // Not a video-specific folder (like file:// or nfs://). Allow play if context is Video window.
-    if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_VIDEO_NAV &&
-        item.GetPath() != "add") // Exclude "Add video source" item
+    if (!item.HasProperty("IsPlayable") || item.GetProperty("IsPlayable").asBoolean())
+    {
       return true;
+    }
   }
 
   return false;

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -907,6 +907,7 @@ bool CGUIMediaWindow::Update(const std::string &strDirectory, bool updateFilterP
     const std::string& strLabel = g_localizeStrings.Get(showLabel);
     CFileItemPtr pItem(new CFileItem(strLabel));
     pItem->SetPath("add");
+    pItem->SetProperty("IsPlayable", false);
     pItem->SetArt("icon", "DefaultAddSource.png");
     pItem->SetLabel(strLabel);
     pItem->SetLabelPreformatted(true);

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -493,6 +493,7 @@ bool CGUIWindowFileManager::Update(int iList, const std::string &strDirectory)
     const std::string& strLabel = g_localizeStrings.Get(1026);
     CFileItemPtr pItem(new CFileItem(strLabel));
     pItem->SetPath("add");
+    pItem->SetProperty("IsPlayable", false);
     pItem->SetArt("icon", "DefaultAddSource.png");
     pItem->SetLabel(strLabel);
     pItem->SetLabelPreformatted(true);


### PR DESCRIPTION
## Description
Instead of querying the window manager for the active window and check if the item is "add" just set the property "IsPlayable" to false when actually adding the items.
Most of the file usages is GUI but maybe common non-gui logic could be factored out. For instance this is used from PlayerUtils which then is a dependency of DirectoryProvider. There's no reason for DirectoryProviders to depend on GUI.