### PR TITLE
[video] CVideoInfoTag::Reset(): Set m_isDefaultVideoVersion to false,…

### DIFF
--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -47,7 +47,7 @@ void CVideoInfoTag::Reset()
   m_assetInfo.Clear();
   m_hasVideoVersions = false;
   m_hasVideoExtras = false;
-  m_isDefaultVideoVersion = true;
+  m_isDefaultVideoVersion = false;
   m_strFile.clear();
   m_strPath.clear();
   m_strMPAARating.clear();


### PR DESCRIPTION
… matching its default init value.

Not much to say. The values set in `Reset()` must match the default values for the instance. This was not the case here.

Runtime-tested on macOS, latest Kodi master.

@enen92 no-brainer