### PR TITLE
[video] Video versions/extras chooser: Fix button labels.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23885,14 +23885,12 @@ msgid "Set as default"
 msgstr ""
 
 #. Choose/Manage video version dialog title
-#: xbmc/video/guilib/VideoVersionHelper.cpp
 #: xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
 msgctxt "#40024"
 msgid "Versions: {0:s}"
 msgstr ""
 
 #. Choose/Manage video extra dialog title
-#: xbmc/video/guilib/VideoVersionHelper.cpp
 #: xbmc/video/dialogs/GUIDialogVideoManagerExtras.h
 msgctxt "#40025"
 msgid "Extras: {0:s}"
@@ -24004,12 +24002,14 @@ msgstr ""
 
 #. Button label for video versions
 #: addons/skin.estuary/xml/DialogVideoInfo.xml
+#: xbmc/video/guilib/VideoVersionHelper.cpp
 msgctxt "#40210"
 msgid "Versions"
 msgstr ""
 
 #. Button label for video extras
 #: addons/skin.estuary/xml/DialogVideoInfo.xml
+#: xbmc/video/guilib/VideoVersionHelper.cpp
 msgctxt "#40211"
 msgid "Extras"
 msgstr ""

--- a/xbmc/video/guilib/VideoVersionHelper.cpp
+++ b/xbmc/video/guilib/VideoVersionHelper.cpp
@@ -131,7 +131,7 @@ std::shared_ptr<const CFileItem> CVideoChooser::ChooseVideoVersion()
     return {};
   }
 
-  return ChooseVideo(*dialog, 40024 /* Versions */, 40025 /* Extras */, m_videoVersions,
+  return ChooseVideo(*dialog, 40210 /* Versions */, 40211 /* Extras */, m_videoVersions,
                      m_videoExtras);
 }
 
@@ -145,7 +145,7 @@ std::shared_ptr<const CFileItem> CVideoChooser::ChooseVideoExtra()
     return {};
   }
 
-  return ChooseVideo(*dialog, 40025 /* Extras */, 40024 /* Versions */, m_videoExtras,
+  return ChooseVideo(*dialog, 402011 /* Extras */, 40210 /* Versions */, m_videoExtras,
                      m_videoVersions);
 }
 


### PR DESCRIPTION
Fixes fallout from a previous msg id refactoring. Video versions/extras chooser's custom button labels to switch between versions and extras (not activated in current master!) used the wrong message ids:

![screenshot00001](https://github.com/xbmc/xbmc/assets/3226626/7c2fc5db-d757-4a5e-872a-a872cb2912c8)
![screenshot00000](https://github.com/xbmc/xbmc/assets/3226626/4a0a2e65-4221-4f15-9cb9-793a947195a3)

Runtime-tested on macOS, with a patched version of the chooser (which had the custom button enabled), latest Kodi master.

@enen92 another trivial change...