### PR TITLE
[Estuary][video] Refactor video versions select dialog to use movie items

### DIFF
--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -750,7 +750,9 @@
 				<onright>61</onright>
 				<pagecontrol>61</pagecontrol>
 				<scrolltime>200</scrolltime>
-				<include>MediaInfoListLayout</include>
+				<include content="MediaInfoListLayout">
+					<param name="label_1" value="$INFO[ListItem.VideoVersionName]" />
+				</include>
 			</control>
 			<control type="scrollbar" id="61">
 				<left>1320</left>

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -532,7 +532,8 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         // should be the video version, not the movie title.
         CGUIWindow* videoNav{
             CServiceBroker::GetGUI()->GetWindowManager().GetWindow(WINDOW_VIDEO_NAV)};
-        if (videoNav && videoNav->GetProperty("VideoVersionsFolderView").asBoolean())
+        if (videoNav && videoNav->GetProperty("VideoVersionsFolderView").asBoolean() &&
+            videoNav->IsActive())
         {
           value = tag->GetAssetInfo().GetTitle();
           return true;

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1058,6 +1058,11 @@ public:
                           int& idMedia,
                           MediaType& mediaType,
                           VideoAssetType& videoAssetType);
+  bool GetAssetsForVideo(VideoDbContentType itemType,
+                         int mediaId,
+                         VideoAssetType assetType,
+                         CFileItemList& items);
+  bool GetDefaultVersionForVideo(VideoDbContentType itemType, int mediaId, CFileItem& item);
 
   int GetMovieId(const std::string& strFilenameAndPath);
   std::string GetMovieTitle(int idMovie);
@@ -1233,4 +1238,6 @@ private:
   static void AnnounceUpdate(const std::string& content, int id);
 
   static CDateTime GetDateAdded(const std::string& filename, CDateTime dateAdded = CDateTime());
+
+  bool FillMovieItem(std::unique_ptr<dbiplus::Dataset>& dataset, int movieId, CFileItem& item);
 };


### PR DESCRIPTION
**Take 2 for #24471, this time with fixed support for extras:**

Switches the implementation of `CVideoChooser`(which implements our versions/extras select dialogs) to work directly with items of type `MediaTypeMovie` instead of `MediaTypeVideoVersion` for versions. As input and output for `CVideoChooser`are only items of type `MediaTypeMovie`, the current implementation needs several unneeded item type conversions. 

1. convert input movie item to videoversion item
2. after selection, convert the videoversion item to movie item

No functional changes, just simplification of code and less db queries.

For retrieving extras the existing database functions will be used, as before. 

@jjd-uk there is small Estuary change needed. We must ensure that the select dialog always uses the video version as primary label (ListItem.VideoVersionName). Currently ListItem.Label is used which is not always carrying the version name.

Runtime-tested on macOS, latest Kodi master.

@enen92 @CrystalP could you review the changes, please?