### PR TITLE
[video] Adjust the validations and messages in add version/extra

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23944,7 +23944,13 @@ msgctxt "#40033"
 msgid "The default version of a movie with multiple versions cannot be added as a version to another movie. Please add its additional versions first."
 msgstr ""
 
-#empty strings with id 40034 to 40199
+#. Addition of new extra: a movie with multiple versions cannot be turned into an extra of another movie.
+#: xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+msgctxt "#40034"
+msgid "The default version of a movie with multiple versions cannot be added as an extra to another movie. Please move or remove the other versions first."
+msgstr ""
+
+#empty strings with id 40035 to 40199
 
 #. Select default video version setting
 #: system/settings/settings.xml

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23858,7 +23858,7 @@ msgctxt "#40018"
 msgid "Remove video version"
 msgstr ""
 
-#. Add new video version dialog text
+#. Manage versions, remove: removing the default version of a movie is not allowed.
 #: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
 msgctxt "#40019"
 msgid "The default version of a movie cannot be removed. Set a different default version and try again."
@@ -23938,7 +23938,13 @@ msgctxt "#40032"
 msgid "No similar movies were found in the library."
 msgstr ""
 
-#empty strings with id 40033 to 40199
+#. Addition of new version: a movie with multiple versions cannot be turned into a version of another movie.
+#: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+msgctxt "#40033"
+msgid "The default version of a movie with multiple versions cannot be added as a version to another movie. Please add its additional versions first."
+msgstr ""
+
+#empty strings with id 40034 to 40199
 
 #. Select default video version setting
 #: system/settings/settings.xml

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23968,7 +23968,13 @@ msgctxt "#40037"
 msgid "The movie to be added has multiple versions.[CR]The type of the default version will be selected in the next dialog. The other versions will keep their current type.[CR]Do you want to continue?"
 msgstr ""
 
-#empty strings with id 40038 to 40199
+#. Addition of new version: the default version of a movie with multiple versions cannot be turned into a version of another movie.
+#: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+msgctxt "#40038"
+msgid "The default version of a movie with multiple versions cannot be added to another movie. Please move or remove the other versions first."
+msgstr ""
+
+#empty strings with id 40039 to 40199
 
 #. Select default video version setting
 #: system/settings/settings.xml

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23950,7 +23950,19 @@ msgctxt "#40034"
 msgid "The default version of a movie with multiple versions cannot be added as an extra to another movie. Please move or remove the other versions first."
 msgstr ""
 
-#empty strings with id 40035 to 40199
+#. Addition of new version: the user picked an extra of another movie. Ask for confirmation.
+#: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+msgctxt "#40035"
+msgid "You are about to convert a movie extra into a movie version. Are you sure?"
+msgstr ""
+
+#. Addition of new version: the user picked an extra of another movie. Ask for confirmation.
+#: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+msgctxt "#40036"
+msgid "You are about to convert a movie version into a movie extra. Are you sure?"
+msgstr ""
+
+#empty strings with id 40037 to 40199
 
 #. Select default video version setting
 #: system/settings/settings.xml

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23962,7 +23962,13 @@ msgctxt "#40036"
 msgid "You are about to convert a movie version into a movie extra. Are you sure?"
 msgstr ""
 
-#empty strings with id 40037 to 40199
+#. Addition of new version to a movie: the user chose a movie that has multiple versions. Ask for confirmation.
+#: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+msgctxt "#40037"
+msgid "The movie to be added has multiple versions.[CR]The type of the default version will be selected in the next dialog. The other versions will keep their current type.[CR]Do you want to continue?"
+msgstr ""
+
+#empty strings with id 40038 to 40199
 
 #. Select default video version setting
 #: system/settings/settings.xml

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -12420,30 +12420,16 @@ void CVideoDatabase::AddVideoVersion(VideoDbContentType itemType,
   }
 }
 
-int CVideoDatabase::GetVideoVersionInfo(const std::string& fileNameAndPath,
-                                        int& idFile,
-                                        std::string& typeVideoVersion,
-                                        int& idMedia,
-                                        MediaType& mediaType,
-                                        VideoAssetType& videoAssetType)
+VideoAssetInfo CVideoDatabase::GetVideoVersionInfo(const std::string& filenameAndPath)
 {
-  idFile = GetFileId(fileNameAndPath);
-  if (idFile < 0)
-    return -1;
+  VideoAssetInfo info;
 
-  return GetVideoVersionInfo(idFile, typeVideoVersion, idMedia, mediaType, videoAssetType);
-}
+  info.m_idFile = GetFileId(filenameAndPath);
+  if (info.m_idFile < 0)
+    return info;
 
-int CVideoDatabase::GetVideoVersionInfo(int idFile,
-                                        std::string& typeVideoVersion,
-                                        int& idMedia,
-                                        MediaType& mediaType,
-                                        VideoAssetType& videoAssetType)
-{
   if (!m_pDB || !m_pDS)
-    return -1;
-
-  int idVideoVersion = -1;
+    return info;
 
   try
   {
@@ -12456,25 +12442,25 @@ int CVideoDatabase::GetVideoVersionInfo(int idFile,
                             "  JOIN videoversiontype ON "
                             "    videoversiontype.id = videoversion.idType "
                             "WHERE videoversion.idFile = %i",
-                            idFile));
+                            info.m_idFile));
 
     if (m_pDS->num_rows() > 0)
     {
-      idVideoVersion = m_pDS->fv("id").get_asInt();
-      typeVideoVersion = m_pDS->fv("name").get_asString();
-      idMedia = m_pDS->fv("idMedia").get_asInt();
-      mediaType = m_pDS->fv("media_type").get_asString();
-      videoAssetType = static_cast<VideoAssetType>(m_pDS->fv("itemType").get_asInt());
+      info.m_assetTypeId = m_pDS->fv("id").get_asInt();
+      info.m_assetTypeName = m_pDS->fv("name").get_asString();
+      info.m_idMedia = m_pDS->fv("idMedia").get_asInt();
+      info.m_mediaType = m_pDS->fv("media_type").get_asString();
+      info.m_assetType = static_cast<VideoAssetType>(m_pDS->fv("itemType").get_asInt());
     }
 
     m_pDS->close();
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed for {}", __FUNCTION__, idFile);
+    CLog::LogF(LOGERROR, "failed for {}", filenameAndPath);
   }
 
-  return idVideoVersion;
+  return info;
 }
 
 bool CVideoDatabase::GetVideoVersionsNav(const std::string& strBaseDir,

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -12223,7 +12223,8 @@ bool CVideoDatabase::GetDefaultVersionForVideo(VideoDbContentType itemType,
 bool CVideoDatabase::ConvertVideoToVersion(VideoDbContentType itemType,
                                            int dbIdSource,
                                            int dbIdTarget,
-                                           int idVideoVersion)
+                                           int idVideoVersion,
+                                           VideoAssetType assetType)
 {
   int idFile = -1;
   MediaType mediaType;
@@ -12257,8 +12258,8 @@ bool CVideoDatabase::ConvertVideoToVersion(VideoDbContentType itemType,
   }
 
   // Rename the default version
-  ExecuteQuery(
-      PrepareSQL("UPDATE videoversion SET idType = %i WHERE idFile = %i", idVideoVersion, idFile));
+  ExecuteQuery(PrepareSQL("UPDATE videoversion SET idType = %i, itemType = %i WHERE idFile = %i",
+                          idVideoVersion, assetType, idFile));
 
   CommitTransaction();
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -12319,13 +12319,13 @@ bool CVideoDatabase::IsDefaultVideoVersion(int idFile)
   return false;
 }
 
-void CVideoDatabase::RemoveVideoVersion(int dbId)
+bool CVideoDatabase::RemoveVideoVersion(int dbId)
 {
   if (!m_pDB || !m_pDS)
-    return;
+    return false;
 
   if (IsDefaultVideoVersion(dbId))
-    return;
+    return false;
 
   try
   {
@@ -12336,11 +12336,14 @@ void CVideoDatabase::RemoveVideoVersion(int dbId)
       InvalidatePathHash(path);
 
     m_pDS->exec(PrepareSQL("DELETE FROM videoversion WHERE idFile = %i", dbId));
+
+    return true;
   }
   catch (...)
   {
     CLog::Log(LOGERROR, "{} failed for {}", __FUNCTION__, dbId);
   }
+  return false;
 }
 
 void CVideoDatabase::SetVideoVersion(int idFile, int idVideoVersion)

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1037,7 +1037,7 @@ public:
                              int dbId,
                              int idVideoVersion,
                              CFileItem& item);
-  void RemoveVideoVersion(int dbId);
+  bool RemoveVideoVersion(int dbId);
   bool IsDefaultVideoVersion(int idFile);
   bool GetVideoVersionTypes(VideoDbContentType idContent,
                             VideoAssetType asset,

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1015,10 +1015,22 @@ public:
                         CFileItemList& items,
                         VideoAssetType videoAssetType);
   void GetDefaultVideoVersion(VideoDbContentType itemType, int dbId, CFileItem& item);
+
+  /*!
+   * \brief Remove a video from the library and transfer all of its assets to another video of the
+   * same type.
+   * \param itemType Type of the video being converted
+   * \param dbIdSource id of the video being converted
+   * \param dbIdTarget id that the video will be attached to
+   * \param idVideoVersion new versiontype of the default version of the video
+   * \param assetType new asset type of the default version of the video
+   * \return true for success, false otherwise
+   */
   bool ConvertVideoToVersion(VideoDbContentType itemType,
                              int dbIdSource,
                              int dbIdTarget,
-                             int idVideoVersion);
+                             int idVideoVersion,
+                             VideoAssetType assetType);
   void SetDefaultVideoVersion(VideoDbContentType itemType, int dbId, int idFile);
   void SetVideoVersion(int idFile, int idVideoVersion);
   int AddVideoVersionType(const std::string& typeVideoVersion,

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -26,6 +26,8 @@ class CVideoSettings;
 class CGUIDialogProgress;
 class CGUIDialogProgressBarHandle;
 
+struct VideoAssetInfo;
+
 enum class VideoAssetTypeOwner;
 enum class VideoAssetType;
 
@@ -1047,17 +1049,7 @@ public:
                            CFileItemList& items,
                            VideoDbContentType idContent = VideoDbContentType::UNKNOWN,
                            const Filter& filter = Filter());
-  int GetVideoVersionInfo(const std::string& strFilenameAndPath,
-                          int& idFile,
-                          std::string& typeVideoVersion,
-                          int& idMedia,
-                          MediaType& mediaType,
-                          VideoAssetType& videoAssetType);
-  int GetVideoVersionInfo(int idFile,
-                          std::string& typeVideoVersion,
-                          int& idMedia,
-                          MediaType& mediaType,
-                          VideoAssetType& videoAssetType);
+  VideoAssetInfo GetVideoVersionInfo(const std::string& filenameAndPath);
   bool GetAssetsForVideo(VideoDbContentType itemType,
                          int mediaId,
                          VideoAssetType assetType,

--- a/xbmc/video/VideoManagerTypes.h
+++ b/xbmc/video/VideoManagerTypes.h
@@ -33,3 +33,13 @@ static constexpr int VIDEO_VERSION_ID_BEGIN = 40400;
 static constexpr int VIDEO_VERSION_ID_END = 40800;
 static constexpr int VIDEO_VERSION_ID_DEFAULT = VIDEO_VERSION_ID_BEGIN;
 static constexpr int VIDEO_VERSION_ID_ALL = 0;
+
+struct VideoAssetInfo
+{
+  int m_idFile{-1};
+  int m_assetTypeId{-1};
+  std::string m_assetTypeName;
+  int m_idMedia{-1};
+  MediaType m_mediaType{MediaTypeNone};
+  VideoAssetType m_assetType{VideoAssetType::UNKNOWN};
+};

--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
@@ -135,7 +135,9 @@ bool CGUIDialogVideoManagerExtras::AddVideoExtra()
         return false;
       }
 
-      m_database.RemoveVideoVersion(newAsset.m_idFile);
+      // @todo: should be in a database transaction with the addition as a new version below
+      if (!m_database.RemoveVideoVersion(newAsset.m_idFile))
+        return false;
     }
 
     CFileItem item{path, false};

--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
@@ -133,6 +133,14 @@ bool CGUIDialogVideoManagerExtras::AddVideoExtra()
 
       // The video is an asset of another movie
 
+      // The video is a version, ask for confirmation
+      if (newAsset.m_assetType == VideoAssetType::VERSION &&
+          !CGUIDialogYesNo::ShowAndGetInput(CVariant{40015},
+                                            StringUtils::Format(g_localizeStrings.Get(40036))))
+      {
+        return false;
+      }
+
       std::string videoTitle;
       if (newAsset.m_mediaType == MediaTypeMovie)
       {

--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
@@ -84,7 +84,7 @@ void CGUIDialogVideoManagerExtras::SetVideoAsset(const std::shared_ptr<CFileItem
     SetSelectedVideoAsset(m_videoAssetsList->Get(0));
 }
 
-void CGUIDialogVideoManagerExtras::AddVideoExtra()
+bool CGUIDialogVideoManagerExtras::AddVideoExtra()
 {
   const MediaType mediaType{m_videoAsset->GetVideoInfoTag()->m_type};
 
@@ -116,7 +116,7 @@ void CGUIDialogVideoManagerExtras::AddVideoExtra()
         CGUIDialogOK::ShowAndGetInput(
             CVariant{40015},
             StringUtils::Format(g_localizeStrings.Get(40026), newAsset.m_assetTypeName));
-        return;
+        return false;
       }
 
       std::string videoTitle;
@@ -126,13 +126,13 @@ void CGUIDialogVideoManagerExtras::AddVideoExtra()
         videoTitle = m_database.GetMovieTitle(newAsset.m_idMedia);
       }
       else
-        return;
+        return false;
 
       if (!CGUIDialogYesNo::ShowAndGetInput(
               CVariant{40014}, StringUtils::Format(g_localizeStrings.Get(40027),
                                                    newAsset.m_assetTypeName, videoTitle)))
       {
-        return;
+        return false;
       }
 
       m_database.RemoveVideoVersion(newAsset.m_idFile);
@@ -154,12 +154,18 @@ void CGUIDialogVideoManagerExtras::AddVideoExtra()
     const int idNewVideoVersion{m_database.AddVideoVersionType(
         typeNewVideoVersion, VideoAssetTypeOwner::AUTO, VideoAssetType::EXTRA)};
 
+    if (idNewVideoVersion == -1)
+      return false;
+
     m_database.AddExtrasVideoVersion(itemType, dbId, idNewVideoVersion, item);
 
     // refresh data and controls
     Refresh();
     UpdateControls();
+
+    return true;
   }
+  return false;
 }
 
 void CGUIDialogVideoManagerExtras::ManageVideoExtras(const std::shared_ptr<CFileItem>& item)

--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.h
@@ -38,6 +38,10 @@ protected:
   void UpdateButtons() override;
 
 private:
-  void AddVideoExtra();
+  /*!
+   * \brief Add an extra to the video, using GUI user-provided information.
+   * \return true if an extra was added, false otherwise.
+   */
+  bool AddVideoExtra();
   static std::string GenerateVideoExtra(const std::string& extrasPath);
 };

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -353,6 +353,16 @@ bool CGUIDialogVideoManagerVersions::ChooseVideoAndConvertToVideoVersion(
   if (!selectedItem)
     return false;
 
+  CFileItemList list;
+  videoDb.GetVideoVersions(itemType, selectedItem->GetVideoInfoTag()->m_iDbId, list,
+                           VideoAssetType::VERSION);
+
+  // ask confirmation for the addition of a movie with multiple versions to another movie
+  if (list.Size() > 1 && !CGUIDialogYesNo::ShowAndGetInput(CVariant{40014}, CVariant{40037}))
+  {
+    return false;
+  }
+
   // choose a video version for the video
   const int idVideoVersion{ChooseVideoAsset(selectedItem, VideoAssetType::VERSION)};
   if (idVideoVersion < 0)

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -516,6 +516,7 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
         {
           if (newAsset.m_mediaType == MediaTypeMovie)
           {
+            // @todo: should be in a database transaction with the addition as a new version below
             m_database.DeleteMovie(newAsset.m_idMedia);
           }
           else
@@ -523,7 +524,11 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
         }
       }
       else
-        m_database.RemoveVideoVersion(newAsset.m_idFile);
+      {
+        // @todo: should be in a database transaction with the addition as a new version below
+        if (!m_database.RemoveVideoVersion(newAsset.m_idFile))
+          return false;
+      }
     }
 
     CFileItem item{path, false};

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -500,6 +500,14 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
 
       // The video is an asset of another movie
 
+      // The video is an extra, ask for confirmation
+      if (newAsset.m_assetType == VideoAssetType::EXTRA &&
+          !CGUIDialogYesNo::ShowAndGetInput(CVariant{40014},
+                                            StringUtils::Format(g_localizeStrings.Get(40035))))
+      {
+        return false;
+      }
+
       std::string videoTitle;
       if (newAsset.m_mediaType == MediaTypeMovie)
       {

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -509,7 +509,8 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
 
         if (list.Size() > 1)
         {
-          CGUIDialogOK::ShowAndGetInput(CVariant{40014}, CVariant{40019});
+          // cannot add the default version of a movie with multiple versions as version of another movie
+          CGUIDialogOK::ShowAndGetInput(CVariant{40014}, CVariant{40033});
           return false;
         }
         else

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -383,7 +383,8 @@ bool CGUIDialogVideoManagerVersions::ChooseVideoAndConvertToVideoVersion(
       return false;
   }
 
-  return videoDb.ConvertVideoToVersion(itemType, sourceDbId, targetDbId, idVideoVersion);
+  return videoDb.ConvertVideoToVersion(itemType, sourceDbId, targetDbId, idVideoVersion,
+                                       VideoAssetType::VERSION);
 }
 
 bool CGUIDialogVideoManagerVersions::GetAllOtherMovies(const std::shared_ptr<CFileItem>& item,
@@ -557,18 +558,19 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
         if (list.Size() > 1)
         {
           // cannot add the default version of a movie with multiple versions to another movie
-          CGUIDialogOK::ShowAndGetInput(CVariant{40014}, CVariant{40033});
+          CGUIDialogOK::ShowAndGetInput(CVariant{40014}, CVariant{40038});
           return false;
+        }
+
+        const int idNewVideoVersion{ChooseVideoAsset(m_videoAsset, VideoAssetType::VERSION)};
+        if (idNewVideoVersion != -1)
+        {
+          return m_database.ConvertVideoToVersion(itemType, newAsset.m_idMedia, dbId,
+                                                  idNewVideoVersion, VideoAssetType::VERSION);
         }
         else
         {
-          if (newAsset.m_mediaType == MediaTypeMovie)
-          {
-            // @todo: should be in a database transaction with the addition as a new asset below
-            m_database.DeleteMovie(newAsset.m_idMedia);
-          }
-          else
-            return false;
+          return false;
         }
       }
       else
@@ -645,7 +647,7 @@ bool CGUIDialogVideoManagerVersions::AddSimilarMovieAsVersion(
   const int sourceDbId{itemMovie->GetVideoInfoTag()->m_iDbId};
   const int targetDbId{m_videoAsset->GetVideoInfoTag()->m_iDbId};
   return videoDb.ConvertVideoToVersion(VideoDbContentType::MOVIES, sourceDbId, targetDbId,
-                                       idVideoVersion);
+                                       idVideoVersion, VideoAssetType::VERSION);
 }
 
 bool CGUIDialogVideoManagerVersions::PostProcessList(CFileItemList& list, int dbId)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Reviewed, refactored, added messages. clarified messages related to the addition of a version or extra from library or files.
Both Manage versions > Add and the popup for similar movie found on scan are taken care of.
Manage versions > Add can add from library, relatively straightforward, but can also add any video file, which can be in many situations and require lots of validations and cases (videos is unknown, video is in library and is an extra, video is in library and is a version - could be default version or secondary version of a movie with only one version or multiple).

The design would need to change with the addition of a new dialog to clarify what's happening in some of the situations and avoid some overly long and not so clear messages. Only so much can be done with the available dialogs and space available in a popup yesno / OK dialog.

Messages changes:
- reviewed and tried to simplify some
- duplicated and specialized some messages because the same actions can be done to add an extra or a version and the message needs to reflect it.

Addressed functionality gaps:
- adding movies of the library as new version or extra was silently losing the extras and non-default versions of the movie being added
- through Browse files, a version can be turned into an extra and vice-versa. It has its uses but warrants a warning.
- selecting the default version of a movie already in library in browse files removed the library entry and made the default version a version of the new movie, but any extras were silently discarded.


Future todo: the code for versions and extras was made very similar on purpose, it will be possible to group them in one function.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Noticed some misleading messages and that code had to be reviewed.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
all combinations of adding version or extra from:
- library
- files: unscanned/unknown video
- files: video that's already an extra of a movie
- files: video that's already an version of a movie
- files: video that's a single version movie
- files: video that's a the default version of a movie with multiple versions

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Better messages, error checking and handling of the addition.

## Screenshots (if appropriate):

upcoming

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
