### PR TITLE
[guilib] VideoThumbLoader don't look for basic local artwork when library items are displayed

### DIFF
--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -240,9 +240,9 @@ bool CVideoThumbLoader::LoadItemLookup(CFileItem* pItem)
 
   m_videoDatabase->Open();
 
-  bool isLibraryItem = pItem->HasVideoInfoTag() && pItem->GetVideoInfoTag()->m_iDbId > -1 &&
-                       !pItem->GetVideoInfoTag()->m_type.empty();
-  bool libraryArtFilled =
+  const bool isLibraryItem = pItem->HasVideoInfoTag() && pItem->GetVideoInfoTag()->m_iDbId > -1 &&
+                             !pItem->GetVideoInfoTag()->m_type.empty();
+  const bool libraryArtFilled =
       pItem->HasVideoInfoTag() && pItem->GetProperty("libraryartfilled").asBoolean();
   if (!isLibraryItem || !libraryArtFilled)
   {

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -240,40 +240,48 @@ bool CVideoThumbLoader::LoadItemLookup(CFileItem* pItem)
 
   m_videoDatabase->Open();
 
-  std::map<std::string, std::string> artwork = pItem->GetArt();
-  std::vector<std::string> artTypes = GetArtTypes(pItem->HasVideoInfoTag() ? pItem->GetVideoInfoTag()->m_type : "");
-  if (find(artTypes.begin(), artTypes.end(), "thumb") == artTypes.end())
-    artTypes.emplace_back("thumb"); // always look for "thumb" art for files
-  for (std::vector<std::string>::const_iterator i = artTypes.begin(); i != artTypes.end(); ++i)
+  bool isLibraryItem = pItem->HasVideoInfoTag() && pItem->GetVideoInfoTag()->m_iDbId > -1 &&
+                       !pItem->GetVideoInfoTag()->m_type.empty();
+  bool libraryArtFilled =
+      pItem->HasVideoInfoTag() && pItem->GetProperty("libraryartfilled").asBoolean();
+  if (!isLibraryItem || !libraryArtFilled)
   {
-    std::string type = *i;
-    if (!pItem->HasArt(type))
+    std::map<std::string, std::string> artwork = pItem->GetArt();
+    std::vector<std::string> artTypes =
+        GetArtTypes(pItem->HasVideoInfoTag() ? pItem->GetVideoInfoTag()->m_type : "");
+    if (find(artTypes.begin(), artTypes.end(), "thumb") == artTypes.end())
+      artTypes.emplace_back("thumb"); // always look for "thumb" art for files
+    for (std::vector<std::string>::const_iterator i = artTypes.begin(); i != artTypes.end(); ++i)
     {
-      std::string art = GetLocalArt(*pItem, type, type=="fanart");
-      if (!art.empty()) // cache it
+      std::string type = *i;
+      if (!pItem->HasArt(type))
       {
-        SetCachedImage(*pItem, type, art);
-        CServiceBroker::GetTextureCache()->BackgroundCacheImage(art);
-        artwork.insert(std::make_pair(type, art));
-      }
-      else
-      {
-        // If nothing was found, try embedded art
-        if (pItem->HasVideoInfoTag() && !pItem->GetVideoInfoTag()->m_coverArt.empty())
+        std::string art = GetLocalArt(*pItem, type, type == "fanart");
+        if (!art.empty()) // cache it
         {
-          for (auto& it : pItem->GetVideoInfoTag()->m_coverArt)
+          SetCachedImage(*pItem, type, art);
+          CServiceBroker::GetTextureCache()->BackgroundCacheImage(art);
+          artwork.insert(std::make_pair(type, art));
+        }
+        else
+        {
+          // If nothing was found, try embedded art
+          if (pItem->HasVideoInfoTag() && !pItem->GetVideoInfoTag()->m_coverArt.empty())
           {
-            if (it.m_type == type)
+            for (auto& it : pItem->GetVideoInfoTag()->m_coverArt)
             {
-              art = CTextureUtils::GetWrappedImageURL(pItem->GetPath(), "video_" + type);
-              artwork.insert(std::make_pair(type, art));
+              if (it.m_type == type)
+              {
+                art = CTextureUtils::GetWrappedImageURL(pItem->GetPath(), "video_" + type);
+                artwork.insert(std::make_pair(type, art));
+              }
             }
           }
         }
       }
     }
+    pItem->AppendArt(artwork);
   }
-  pItem->AppendArt(artwork);
 
   // We can only extract flags/thumbs for file-like items
   if (!pItem->m_bIsFolder && pItem->IsVideo())


### PR DESCRIPTION
## Description
Artwork identification during scanning / scraping is more robust so library items already have better artwork, and before #23717 / 21 Alpha 3 this didn't work for library items anyway. That change makes sense, but had an unexpected effect here.

Ignoring whitespace clarifies the diff.

@ksooo This may be interesting if you are still seeing issues related to #23958.

## Motivation and context

Before #23717, VideoThumbLoader would have a "virtual" file path like `videodb://movies/titles/8555?xsp=...` from an Estuary home widget, and then naively look for missing fanart next to the file at `videodb://movies/titles/fanart.jpg`, which couldn't be satisfied so non-existence of the file is quickly determined.

After #23717, that virtual path is translated to a real path, like "smb://" or "nfs://", so it tries to find the fanart on server next to the real file, which causes unnecessary file access, drive spin-up, and for an offline NAS like #23958 is much slower to check existence due to connection timeout.

## How has this been tested?
Quick manual test.

## What is the effect on users?
I found this investigating #23958. That issue has been closed, but this behavior still seems unnecessary and is another potential cause of additional NAS / drive spinup.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
