### PR TITLE
[video] Refresh library list after the addition of extras in Info > Manage extras 

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -164,7 +164,7 @@ bool CGUIDialogVideoInfo::OnMessage(CGUIMessage& message)
       }
       else if (iControl == CONTROL_BTN_MANAGE_VIDEO_EXTRAS)
       {
-        OnManageVideoExtras();
+        m_hasUpdatedItems = OnManageVideoExtras();
       }
       else if (iControl == CONTROL_BTN_PLAY)
       {
@@ -2095,9 +2095,9 @@ bool CGUIDialogVideoInfo::OnManageVideoVersions()
   return CGUIDialogVideoManagerVersions::ManageVideoVersions(m_movieItem);
 }
 
-void CGUIDialogVideoInfo::OnManageVideoExtras()
+bool CGUIDialogVideoInfo::OnManageVideoExtras()
 {
-  CGUIDialogVideoManagerExtras::ManageVideoExtras(m_movieItem);
+  return CGUIDialogVideoManagerExtras::ManageVideoExtras(m_movieItem);
 }
 
 void CGUIDialogVideoInfo::ManageVideoVersions(const std::shared_ptr<CFileItem>& item)

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.h
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.h
@@ -92,7 +92,7 @@ protected:
    */
   void OnSearchItemFound(const CFileItem* pItem);
   bool OnManageVideoVersions();
-  void OnManageVideoExtras();
+  bool OnManageVideoExtras();
   void Play(bool resume = false);
   void OnGetArt();
   void OnGetFanart();

--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
@@ -58,6 +58,9 @@ bool CGUIDialogVideoManagerExtras::OnMessage(CGUIMessage& message)
           // refresh data and controls
           Refresh();
           UpdateControls();
+          // @todo more detailed status to trigger an library list refresh or item update only when
+          // needed. For example, library movie was converted into an extra.
+          m_hasUpdatedItems = true;
         }
       }
       break;
@@ -232,7 +235,7 @@ bool CGUIDialogVideoManagerExtras::AddVideoExtra()
   return false;
 }
 
-void CGUIDialogVideoManagerExtras::ManageVideoExtras(const std::shared_ptr<CFileItem>& item)
+bool CGUIDialogVideoManagerExtras::ManageVideoExtras(const std::shared_ptr<CFileItem>& item)
 {
   CGUIDialogVideoManagerExtras* dialog{
       CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogVideoManagerExtras>(
@@ -240,11 +243,12 @@ void CGUIDialogVideoManagerExtras::ManageVideoExtras(const std::shared_ptr<CFile
   if (!dialog)
   {
     CLog::LogF(LOGERROR, "Unable to get WINDOW_DIALOG_MANAGE_VIDEO_EXTRAS instance!");
-    return;
+    return false;
   }
 
   dialog->SetVideoAsset(item);
   dialog->Open();
+  return dialog->HasUpdatedItems();
 }
 
 std::string CGUIDialogVideoManagerExtras::GenerateVideoExtra(const std::string& extrasRoot,

--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.h
@@ -24,8 +24,13 @@ public:
   ~CGUIDialogVideoManagerExtras() override = default;
 
   void SetVideoAsset(const std::shared_ptr<CFileItem>& item) override;
-
-  static void ManageVideoExtras(const std::shared_ptr<CFileItem>& item);
+  /*!
+   * \brief Open the Manage Extras dialog for a video
+   * \param item video to manage
+   * \return true: the video or another item was modified, a containing list should be refreshed.
+   * false: no changes
+   */
+  static bool ManageVideoExtras(const std::shared_ptr<CFileItem>& item);
   static std::string GenerateVideoExtra(const std::string& extrasRoot,
                                         const std::string& extrasPath);
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Same thing as PR#24419 but for extras. Now that addition of movies as extras works well, adding such an extra would require a refresh of the library list so that the removed movie doesn't appear anymore.

Added the plumbing to propagate the success status of "Add extra" to the Info dialog and the library list.

future PR:  more fine-grained return to request a library list refresh only for situations that require it (creation of an extra from a movie) and not for every addition.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Inconsistency of the library list after turning a movie into an extra.

Manage Extras accessed through context menu > manage is not impacted because a refresh always happens when leaving the context menu.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

local and remote db, tested the changed case (movie changed to extra) and other cases that should not see changes (change extra art, remove extra, ...)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

More consistent GUI.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
