### PR TITLE
AndroidMediaCodec: Retry VC1 as mime type is confusing vendors

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -28,6 +28,7 @@
 #include "utils/BitstreamConverter.h"
 #include "utils/BitstreamWriter.h"
 #include "utils/CPUInfo.h"
+#include "utils/StringUtils.h"
 #include "utils/TimeUtils.h"
 #include "utils/log.h"
 #include "windowing/android/AndroidUtils.h"
@@ -35,6 +36,7 @@
 #include "platform/android/activity/JNIXBMCSurfaceTextureOnFrameAvailableListener.h"
 #include "platform/android/activity/XBMCApp.h"
 
+#include <array>
 #include <cassert>
 #include <memory>
 #include <mutex>
@@ -749,13 +751,39 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
 
     CLog::Log(LOGINFO, "CDVDVideoCodecAndroidMediaCodec::Open Testing codec: {}", m_codecname);
 
+    // There is some confusion for video/VC1 vs. video/wvc1 especially on Sony devices, while
+    // IANA defines VC-1 as video/vc1, Android API defines it as video/wvc1 - be nice and test it
+    const bool isVC1 = StringUtils::Contains(m_codecname, "vc1", true);
+
     CJNIMediaCodecInfoCodecCapabilities codec_caps = codec_info.getCapabilitiesForType(m_mime);
     if (xbmc_jnienv()->ExceptionCheck())
     {
       // Unsupported type?
       xbmc_jnienv()->ExceptionDescribe();
       xbmc_jnienv()->ExceptionClear();
-      continue;
+      if (!isVC1)
+        continue;
+
+      const std::array<const std::string, 2> mimes = {"video/VC1", "video/vc1"};
+      bool success = false;
+      for (const auto& v : mimes)
+      {
+        codec_caps = codec_info.getCapabilitiesForType(v);
+        if (xbmc_jnienv()->ExceptionCheck())
+        {
+          xbmc_jnienv()->ExceptionDescribe();
+          xbmc_jnienv()->ExceptionClear();
+        }
+        else
+        {
+          m_mime = v;
+          CLog::Log(LOGDEBUG, "Succesfully replaced VC1 mime type to {}", m_mime);
+          success = true;
+          break;
+        }
+      }
+      if (!success)
+        continue;
     }
 
     bool codecIsSecure(


### PR DESCRIPTION
This is a follow up of: #24488 in a more generic fashion. Does not look like a simply Sony workaround.