### PR TITLE
[FileSystem] Refactored and improved logic to use CFileStreamBuffer

### DIFF
--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -364,12 +364,7 @@ bool CFile::Open(const CURL& file, const unsigned int flags)
       return false;
     }
 
-    constexpr int64_t len = 200 * 1024 * 1024; // 200 MB
-
-    // Use CFileStreamBuffer for all "big" files (audio/video files) when FileCache is not used
-    // This also makes use of 64K file read chunk size, suitable for localfiles, USB files, etc.
-    // Also enbles basic cache for Blu-Ray but only big .m2ts files (main audio/video files only)
-    if ((m_pFile->GetChunkSize() || m_pFile->GetLength() > len) && !(m_flags & READ_CHUNKED))
+    if (ShouldUseStreamBuffer(url))
     {
       m_pBuffer = std::make_unique<CFileStreamBuffer>(0);
       m_pBuffer->Attach(m_pFile.get());
@@ -386,6 +381,21 @@ bool CFile::Open(const CURL& file, const unsigned int flags)
   XBMCCOMMONS_HANDLE_UNCHECKED
   catch (...) { CLog::Log(LOGERROR, "{} - Unhandled exception", __FUNCTION__); }
   CLog::Log(LOGERROR, "{} - Error opening {}", __FUNCTION__, file.GetRedacted());
+  return false;
+}
+
+bool CFile::ShouldUseStreamBuffer(const CURL& url)
+{
+  if (m_flags & READ_CHUNKED || m_pFile->GetChunkSize() > 0)
+    return true;
+
+  // file size > 200 MB but not in optical disk
+  if (m_pFile->GetLength() > 200 * 1024 * 1024 && !URIUtils::IsDVD(url.GetShareName()))
+    return true;
+
+  if (URIUtils::IsNetworkFilesystem(url.Get()))
+    return true;
+
   return false;
 }
 

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -155,6 +155,23 @@ public:
   double GetDownloadSpeed();
 
 private:
+  /*!
+   * \brief Determines if CFileStreamBuffer should be used to read a file.
+   *
+   * In general, should be used for ALL media files (only when is not used FileCache)
+   * and NOT used for non-media files e.g. small local files as config/settings xml files.
+   * Enables basic buffer that allows read sources with 64K chunk size even if FFmpeg only reads
+   * data with small 4K chunks or Blu-Ray sector size (6144 bytes):
+   *
+   * [FFmpeg] <-----4K chunks----- [CFileStreamBuffer] <-----64K chunks----- [Source file / Network]
+   *
+   * NOTE: in case of SMB / NFS default 64K chunk size is replaced with value configured in
+   * settings for the protocol.
+   * This improves performance when reads big files through Network.
+   * \param url Source file info as CULR class.
+   */
+  bool ShouldUseStreamBuffer(const CURL& url);
+
   unsigned int m_flags = 0;
   CURL                m_curl;
   std::unique_ptr<IFile> m_pFile;


### PR DESCRIPTION
## Description
Refactored and improved logic to use CFileStreamBuffer.

This is a follow-up of https://github.com/xbmc/xbmc/pull/22941 and https://github.com/xbmc/xbmc/pull/24060 and a complementary fix for https://github.com/xbmc/xbmc/issues/24040

## Motivation and context

Fixes the use case commented here: https://github.com/xbmc/xbmc/issues/24040#issuecomment-1872434040 and probably others. 

While changes in https://github.com/xbmc/xbmc/pull/22941 works fine especially for USB files in Shield or similar devices the logic is not enough to cover all cases, especially ISO files because some times should be treated as "optical drive" and others as "big file streamed trough network".

Some important points:

- This code only is used when is NOT used FileCache, then with default Kodi settings the behavior changes are almost nonexistent (only for Blu-Ray discs).

- If FileCache is disabled the _only_ way of use big chunk size (64KB, 128KB, 256KB, etc) is use `CFileStreamBuffer` because is not possible read with 256KB chunk if buffer is only 4K:

```
[FFmpeg] <-----4K chunks----- [CFileStreamBuffer] <-----64K chunks----- [Source file / Network]
```

There is no single "chunk size": There is the chunk size at which it is read from the source (e.g 256K ) and the chunk size at which FFmpeg can read from the local buffer or cache (e.g. 4K).

- For the new GUI NFS / SMB chunk size settings to be used, it is essential that `FileCache` or failing `CFileStreamBuffer` be used.


## How has this been tested?
Runtime tested in Windows x64 and Android (Shield). 

Tested with FileCache disabled and almost all use cases:

- Local optical disks (DVD / Blu-Ray).
- ISO files mounted locally in Windows.
- ISO files on local storage open directly with Kodi (not mounted).
- ISO files on remote storage (tested SMB and NFS).
- BDMV folder structure locally and on network.
- MKVs.
- Others remote streams: HTTPS.

Optical discs and local mounted ISO files read with chunk size of 6144 bytes in both options Settings / Player / Disks / Blu-Ray Playback Mode "Show simplified menu" and "Play main movie".

ISO files and BDMV folders read from network (SMB / NFS) use defined chunk size in settings (e.g. 256 KB) in both options  "Show simplified menu" and "Play main movie".


## What is the effect on users?
ISO files read trough network always use chunk size defined in GUI settings while ISO files mounted locally (and optical disks) always use sector size of Blu-Ray (6144 bytes) without intermediate buffer.

Is guaranteed that when `FileCache` is disabled always is used `CFileStreamBuffer` for all network or remote streams.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
