### PR TITLE
[VideoDB] restore compatibility with MariaDB < 10.5.2

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -6302,7 +6302,14 @@ void CVideoDatabase::UpdateTables(int iVersion)
 
   if (iVersion < 128)
   {
-    m_pDS2->exec("ALTER TABLE videoversion RENAME COLUMN mediaType TO media_type");
+    m_pDS->exec("CREATE TABLE videoversion_new "
+                "(idFile INTEGER PRIMARY KEY, idMedia INTEGER, media_type TEXT, "
+                " itemType INTEGER, idType INTEGER)");
+    m_pDS->exec("INSERT INTO videoversion_new "
+                " (idFile, idMedia, media_type, itemType, idType) "
+                "SELECT idFile, idMedia, mediaType, itemType, idType FROM videoversion");
+    m_pDS->exec("DROP TABLE videoversion");
+    m_pDS->exec("ALTER TABLE videoversion_new RENAME TO videoversion");
 
     // Fix gap in the migration to videodb v127 for unused user-defined video version types.
     // Unfortunately due to original design we cannot tell which ones were movie versions or


### PR DESCRIPTION
Migrating the database fails when the database is on a remote MariaDB instance < 10.5.2:
    2024-01-14 08:13:48.448 T:1461     info <general>: Old database found - updating from version 121 to 129
    2024-01-14 08:14:04.686 T:1461     info <general>: Attempting to update the database kodi-video-main129 from version 121 to 129
    2024-01-14 08:14:11.105 T:1461    error <general>: SQL: [kodi-video-main129] Undefined MySQL error: Code (1064)
                                                       Query: ALTER TABLE videoversion RENAME COLUMN mediaType TO media_type

    2024-01-14 08:14:11.106 T:1461    error <general>: Exception updating database kodi-video-main129 from version 121 to 129
    2024-01-14 08:14:11.106 T:1461    error <general>: Error updating database kodi-video-main129 from version 121 to 129
    2024-01-14 08:14:11.118 T:1461    error <general>: Unable to open database: kodi-video-main120 [1049](Unknown database 'kodi-video-main120')
This means no access to the videos is possible.

As per https://mariadb.com/kb/en/alter-table/#rename-column support for rename column was only added in 10.5.2.

Rewrite the statement to support older versions as well.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
