### PR TITLE
[video] Fix watched overlay image of parent movie item

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1754,7 +1754,8 @@ void CFileItem::UpdateInfo(const CFileItem &item, bool replaceLabels /*=true*/)
 
     m_pvrRecordingInfoTag = item.m_pvrRecordingInfoTag;
 
-    SetOverlayImage(ICON_OVERLAY_UNWATCHED, GetVideoInfoTag()->GetPlayCount() > 0);
+    SetOverlayImage(GetVideoInfoTag()->GetPlayCount() > 0 ? CGUIListItem::ICON_OVERLAY_WATCHED
+                                                          : CGUIListItem::ICON_OVERLAY_UNWATCHED);
     SetInvalid();
   }
   if (item.HasMusicInfoTag())
@@ -1818,7 +1819,8 @@ void CFileItem::MergeInfo(const CFileItem& item)
 
     m_pvrRecordingInfoTag = item.m_pvrRecordingInfoTag;
 
-    SetOverlayImage(ICON_OVERLAY_UNWATCHED, GetVideoInfoTag()->GetPlayCount() > 0);
+    SetOverlayImage(GetVideoInfoTag()->GetPlayCount() > 0 ? CGUIListItem::ICON_OVERLAY_WATCHED
+                                                          : CGUIListItem::ICON_OVERLAY_UNWATCHED);
     SetInvalid();
   }
   if (item.HasMusicInfoTag())

--- a/xbmc/guilib/GUIListItem.cpp
+++ b/xbmc/guilib/GUIListItem.cpp
@@ -154,12 +154,11 @@ bool CGUIListItem::HasArt(const std::string &type) const
   return !GetArt(type).empty();
 }
 
-void CGUIListItem::SetOverlayImage(GUIIconOverlay icon, bool bOnOff)
+void CGUIListItem::SetOverlayImage(GUIIconOverlay icon)
 {
-  GUIIconOverlay newIcon = (bOnOff) ? GUIIconOverlay((int)(icon)+1) : icon;
-  if (m_overlayIcon == newIcon)
+  if (m_overlayIcon == icon)
     return;
-  m_overlayIcon = newIcon;
+  m_overlayIcon = icon;
   SetInvalid();
 }
 

--- a/xbmc/guilib/GUIListItem.h
+++ b/xbmc/guilib/GUIListItem.h
@@ -60,7 +60,7 @@ public:
   void SetLabel2(const std::string& strLabel);
   const std::string& GetLabel2() const;
 
-  void SetOverlayImage(GUIIconOverlay icon, bool bOnOff=false);
+  void SetOverlayImage(GUIIconOverlay icon);
   std::string GetOverlayImage() const;
 
   /*! \brief Set a particular art type for an item

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -1269,7 +1269,8 @@ std::shared_ptr<CFileItem> BuildObject(PLT_MediaObject* entry,
     }
     else if (type == MediaTypeEpisode || type == MediaTypeMovie)
       watched = (played > 0);
-    pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, watched);
+    pItem->SetOverlayImage(watched ? CGUIListItem::ICON_OVERLAY_WATCHED
+                                   : CGUIListItem::ICON_OVERLAY_UNWATCHED);
   }
   return pItem;
 }

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -321,7 +321,7 @@ void GetSubDirectories(const CPVRRecordingsPath& recParentPath,
       item->SetProperty("sizeinbytes", UINT64_C(0));
 
       // Assume all folders are watched, we'll change the overlay later
-      item->SetOverlayImage(CGUIListItem::ICON_OVERLAY_WATCHED, false);
+      item->SetOverlayImage(CGUIListItem::ICON_OVERLAY_WATCHED);
       results.Add(item);
     }
     else
@@ -360,7 +360,7 @@ void GetSubDirectories(const CPVRRecordingsPath& recParentPath,
 
   // Change the watched overlay to unwatched for folders containing unwatched entries
   for (auto& item : unwatchedFolders)
-    item->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, false);
+    item->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED);
 }
 
 } // unnamed namespace
@@ -412,7 +412,8 @@ bool CPVRGUIDirectory::GetRecordingsDirectory(CFileItemList& results) const
         continue;
 
       item = std::make_shared<CFileItem>(recording);
-      item->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, recording->GetPlayCount() > 0);
+      item->SetOverlayImage(recording->GetPlayCount() > 0 ? CGUIListItem::ICON_OVERLAY_WATCHED
+                                                          : CGUIListItem::ICON_OVERLAY_UNWATCHED);
       results.Add(item);
     }
   }

--- a/xbmc/utils/GroupUtils.cpp
+++ b/xbmc/utils/GroupUtils.cpp
@@ -142,7 +142,8 @@ bool GroupUtils::Group(GroupBy groupBy, const std::string &baseDir, const CFileI
       pItem->SetProperty("watched", iWatched);
       pItem->SetProperty("unwatched", (int)set->second.size() - iWatched);
       pItem->SetProperty("inprogress", inProgress);
-      pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, setInfo->GetPlayCount() > 0);
+      pItem->SetOverlayImage(setInfo->GetPlayCount() > 0 ? CGUIListItem::ICON_OVERLAY_WATCHED
+                                                         : CGUIListItem::ICON_OVERLAY_UNWATCHED);
 
       groupedItems.Add(pItem);
     }

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -100,7 +100,7 @@ void CSaveFileState::DoWork(CFileItem& item,
               // consider this item as played
               const CDateTime newLastPlayed = videodatabase.IncrementPlayCount(item);
 
-              item.SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, true);
+              item.SetOverlayImage(CGUIListItem::ICON_OVERLAY_WATCHED);
               updateListing = true;
 
               if (item.HasVideoInfoTag())

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -7884,7 +7884,10 @@ bool CVideoDatabase::GetSeasonsByWhere(const std::string& strBaseDir, const Filt
         if (iSeason == 0)
           pItem->SetProperty("isspecial", true);
         pItem->GetVideoInfoTag()->SetPlayCount((totalEpisodes == watchedEpisodes) ? 1 : 0);
-        pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, (pItem->GetVideoInfoTag()->GetPlayCount() > 0) && (pItem->GetVideoInfoTag()->m_iEpisode > 0));
+        pItem->SetOverlayImage((pItem->GetVideoInfoTag()->GetPlayCount() > 0) &&
+                                       (pItem->GetVideoInfoTag()->m_iEpisode > 0)
+                                   ? CGUIListItem::ICON_OVERLAY_WATCHED
+                                   : CGUIListItem::ICON_OVERLAY_UNWATCHED);
 
         items.Add(pItem);
       }
@@ -8188,7 +8191,8 @@ bool CVideoDatabase::GetMoviesByWhere(const std::string& strBaseDir, const Filte
         pItem->SetPath(path);
         pItem->SetDynPath(movie.m_strFileNameAndPath);
 
-        pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED,movie.GetPlayCount() > 0);
+        pItem->SetOverlayImage(movie.GetPlayCount() > 0 ? CGUIListItem::ICON_OVERLAY_WATCHED
+                                                        : CGUIListItem::ICON_OVERLAY_UNWATCHED);
         items.Add(pItem);
       }
     }
@@ -8297,7 +8301,10 @@ bool CVideoDatabase::GetTvShowsByWhere(const std::string& strBaseDir, const Filt
         itemUrl.AppendPath(path);
         pItem->SetPath(itemUrl.ToString());
 
-        pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, (pItem->GetVideoInfoTag()->GetPlayCount() > 0) && (pItem->GetVideoInfoTag()->m_iEpisode > 0));
+        pItem->SetOverlayImage((pItem->GetVideoInfoTag()->GetPlayCount() > 0) &&
+                                       (pItem->GetVideoInfoTag()->m_iEpisode > 0)
+                                   ? CGUIListItem::ICON_OVERLAY_WATCHED
+                                   : CGUIListItem::ICON_OVERLAY_UNWATCHED);
         items.Add(pItem);
       }
     }
@@ -8433,7 +8440,8 @@ bool CVideoDatabase::GetEpisodesByWhere(const std::string& strBaseDir, const Fil
         pItem->SetPath(itemUrl.ToString());
         pItem->SetDynPath(episode.m_strFileNameAndPath);
 
-        pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, episode.GetPlayCount() > 0);
+        pItem->SetOverlayImage(episode.GetPlayCount() > 0 ? CGUIListItem::ICON_OVERLAY_WATCHED
+                                                          : CGUIListItem::ICON_OVERLAY_UNWATCHED);
         pItem->m_dateTime = episode.m_firstAired;
         items.Add(pItem);
       }
@@ -9339,7 +9347,8 @@ bool CVideoDatabase::GetMusicVideosByWhere(const std::string &baseDir, const Fil
         item->SetPath(itemUrl.ToString());
         item->SetDynPath(musicvideo.m_strFileNameAndPath);
 
-        item->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, musicvideo.GetPlayCount() > 0);
+        item->SetOverlayImage(musicvideo.GetPlayCount() > 0 ? CGUIListItem::ICON_OVERLAY_WATCHED
+                                                            : CGUIListItem::ICON_OVERLAY_UNWATCHED);
         items.Add(item);
       }
     }
@@ -12033,7 +12042,8 @@ void CVideoDatabase::GetVideoVersions(VideoDbContentType itemType,
 
         item->SetDynPath(infoTag.m_strFileNameAndPath);
 
-        item->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, GetPlayCount(idFile) > 0);
+        item->SetOverlayImage(GetPlayCount(idFile) > 0 ? CGUIListItem::ICON_OVERLAY_WATCHED
+                                                       : CGUIListItem::ICON_OVERLAY_UNWATCHED);
 
         items.Add(item);
       }

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -727,9 +727,10 @@ void CGUIWindowVideoBase::LoadVideoInfo(CFileItemList& items,
 
       // set the watched overlay
       if (pItem->IsVideo())
-        pItem->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED,
-                               pItem->HasVideoInfoTag() &&
-                                   pItem->GetVideoInfoTag()->GetPlayCount() > 0);
+        pItem->SetOverlayImage(pItem->HasVideoInfoTag() &&
+                                       pItem->GetVideoInfoTag()->GetPlayCount() > 0
+                                   ? CGUIListItem::ICON_OVERLAY_WATCHED
+                                   : CGUIListItem::ICON_OVERLAY_UNWATCHED);
     }
   }
 }

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1480,7 +1480,6 @@ void CGUIWindowVideoBase::UpdateVideoVersionItems()
           videoVersionId = VIDEO_VERSION_ID_ALL;
           item->GetVideoInfoTag()->GetAssetInfo().SetId(videoVersionId);
           item->m_bIsFolder = true;
-          item->SetOverlayImage(CGUIListItem::ICON_OVERLAY_UNWATCHED, true);
         }
 
         CVideoDbUrl itemUrl;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

The watched/unwatched overlay icon doesn't need to be overriden to "always watched" for the parent item of versions when navigation of versions as a folder is enabled. It is already set with a reasonable value (watched status of the default version).

FYI @jurialmunkey could you confirm it fixes the issue.

I used the opportunity to refactor SetOverlayImage() calls a bit with a second commit, the API was confusing with an inverted bool condition, there was a weird +1 in the overlay index... No change in the logic or the results.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #24493

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
movie without versions watched/unwatched, movie with versions and default version watched/unwatched.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Some skins depend on ListItem.Overlay

## Screenshots (if appropriate):
The effect is not visible in standard Estuary but a change suggested in #24493 adds a label displaying the overlay image name in purple at the bottom of the screen.

before, with no versions watched:
![image](https://github.com/xbmc/xbmc/assets/489377/6b2b95ad-aefc-49ee-8598-f19f31bc3c3c)

after, with no versions watched, or versions watched except for the default version:
![image](https://github.com/xbmc/xbmc/assets/489377/e0f87c2e-2aaa-4eca-a854-5dcd40c0a95b)


after, with the default version watched:
![image](https://github.com/xbmc/xbmc/assets/489377/6b2b95ad-aefc-49ee-8598-f19f31bc3c3c)



## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
