### PR TITLE
[Input] Default buttonmaps for keyboard and mouse

### DIFF
--- a/cmake/treedata/common/tests.txt
+++ b/cmake/treedata/common/tests.txt
@@ -4,6 +4,7 @@ xbmc/cores/AudioEngine/Sinks/test test/audioengine_sinks
 xbmc/cores/VideoPlayer/test/edl   test/edl
 xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/test test/videoshaders
 xbmc/filesystem/test              test/filesystem
+xbmc/games/controllers/input/test test/games/controllers/input
 xbmc/interfaces/python/test       test/python
 xbmc/music/tags/test              test/music_tags
 xbmc/network/test                 test/network

--- a/xbmc/games/controllers/input/CMakeLists.txt
+++ b/xbmc/games/controllers/input/CMakeLists.txt
@@ -1,10 +1,16 @@
 set(SOURCES ControllerActivity.cpp
+            DefaultButtonMap.cpp
+            DefaultKeyboardTranslator.cpp
+            DefaultMouseTranslator.cpp
             InputSink.cpp
             PhysicalFeature.cpp
             PhysicalTopology.cpp
 )
 
 set(HEADERS ControllerActivity.h
+            DefaultButtonMap.h
+            DefaultKeyboardTranslator.h
+            DefaultMouseTranslator.h
             InputSink.h
             PhysicalFeature.h
             PhysicalTopology.h

--- a/xbmc/games/controllers/input/DefaultButtonMap.cpp
+++ b/xbmc/games/controllers/input/DefaultButtonMap.cpp
@@ -1,0 +1,103 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "DefaultButtonMap.h"
+
+#include "DefaultKeyboardTranslator.h"
+#include "DefaultMouseTranslator.h"
+#include "games/controllers/Controller.h"
+#include "games/controllers/ControllerIDs.h"
+#include "input/joysticks/DriverPrimitive.h"
+#include "peripherals/devices/Peripheral.h"
+#include "utils/log.h"
+
+using namespace KODI;
+using namespace GAME;
+
+CDefaultButtonMap::CDefaultButtonMap(PERIPHERALS::CPeripheral* device, std::string strControllerId)
+  : m_device(device), m_strControllerId(std::move(strControllerId))
+{
+}
+
+CDefaultButtonMap::~CDefaultButtonMap() = default;
+
+std::string CDefaultButtonMap::Location() const
+{
+  return m_device->Location();
+}
+
+bool CDefaultButtonMap::Load()
+{
+  // Verify we're using the appropriate controller
+  switch (m_device->Type())
+  {
+    case PERIPHERALS::PERIPHERAL_KEYBOARD:
+      return m_strControllerId == DEFAULT_KEYBOARD_ID;
+    case PERIPHERALS::PERIPHERAL_MOUSE:
+      return m_strControllerId == DEFAULT_MOUSE_ID;
+    default:
+      break;
+  }
+
+  CLog::Log(LOGDEBUG, "Failed to load button map for \"{}\" with profile {}", m_device->Location(),
+            m_strControllerId);
+  return false;
+}
+
+std::string CDefaultButtonMap::GetAppearance() const
+{
+  ControllerPtr controller = m_device->ControllerProfile();
+  if (controller)
+    return controller->ID();
+
+  return m_strControllerId;
+}
+
+bool CDefaultButtonMap::GetFeature(const JOYSTICK::CDriverPrimitive& primitive,
+                                   JOYSTICK::FeatureName& feature)
+{
+  switch (primitive.Type())
+  {
+    case JOYSTICK::PRIMITIVE_TYPE::KEY:
+    {
+      std::string featureName = CDefaultKeyboardTranslator::TranslateKeycode(primitive.Keycode());
+      if (!featureName.empty())
+      {
+        feature = std::move(featureName);
+        return true;
+      }
+      break;
+    }
+    case JOYSTICK::PRIMITIVE_TYPE::MOUSE_BUTTON:
+    {
+      std::string featureName =
+          CDefaultMouseTranslator::TranslateMouseButton(primitive.MouseButton());
+      if (!featureName.empty())
+      {
+        feature = std::move(featureName);
+        return true;
+      }
+      break;
+    }
+    case JOYSTICK::PRIMITIVE_TYPE::RELATIVE_POINTER:
+    {
+      std::string featureName =
+          CDefaultMouseTranslator::TranslateMousePointer(primitive.PointerDirection());
+      if (!featureName.empty())
+      {
+        feature = std::move(featureName);
+        return true;
+      }
+      break;
+    }
+    default:
+      break;
+  }
+
+  return false;
+}

--- a/xbmc/games/controllers/input/DefaultButtonMap.h
+++ b/xbmc/games/controllers/input/DefaultButtonMap.h
@@ -1,0 +1,140 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "input/joysticks/interfaces/IButtonMap.h"
+
+#include <memory>
+#include <string>
+
+namespace PERIPHERALS
+{
+class CPeripheral;
+}
+
+namespace KODI
+{
+namespace GAME
+{
+/*!
+ * \ingroup games
+ *
+ * \brief A fallback buttonmap to be used with the default keyboard profile
+ */
+class CDefaultButtonMap : public JOYSTICK::IButtonMap
+{
+public:
+  CDefaultButtonMap(PERIPHERALS::CPeripheral* device, std::string strControllerId);
+
+  ~CDefaultButtonMap() override;
+
+  // Implementation of IButtonMap
+  std::string ControllerID() const override { return m_strControllerId; }
+  std::string Location() const override;
+  bool Load() override;
+  void Reset() override {}
+  bool IsEmpty() const override { return false; }
+  std::string GetAppearance() const override;
+  bool SetAppearance(const std::string& controllerId) const override { return false; }
+  bool GetFeature(const JOYSTICK::CDriverPrimitive& primitive,
+                  JOYSTICK::FeatureName& feature) override;
+  JOYSTICK::FEATURE_TYPE GetFeatureType(const JOYSTICK::FeatureName& feature) override
+  {
+    return JOYSTICK::FEATURE_TYPE::UNKNOWN;
+  }
+  bool GetScalar(const JOYSTICK::FeatureName& feature,
+                 JOYSTICK::CDriverPrimitive& primitive) override
+  {
+    return false;
+  }
+  void AddScalar(const JOYSTICK::FeatureName& feature,
+                 const JOYSTICK::CDriverPrimitive& primitive) override
+  {
+  }
+  bool GetAnalogStick(const JOYSTICK::FeatureName& feature,
+                      JOYSTICK::ANALOG_STICK_DIRECTION direction,
+                      JOYSTICK::CDriverPrimitive& primitive) override
+  {
+    return false;
+  }
+  void AddAnalogStick(const JOYSTICK::FeatureName& feature,
+                      JOYSTICK::ANALOG_STICK_DIRECTION direction,
+                      const JOYSTICK::CDriverPrimitive& primitive) override
+  {
+  }
+  bool GetRelativePointer(const JOYSTICK::FeatureName& feature,
+                          JOYSTICK::RELATIVE_POINTER_DIRECTION direction,
+                          JOYSTICK::CDriverPrimitive& primitive) override
+  {
+    return false;
+  }
+  void AddRelativePointer(const JOYSTICK::FeatureName& feature,
+                          JOYSTICK::RELATIVE_POINTER_DIRECTION direction,
+                          const JOYSTICK::CDriverPrimitive& primitive) override
+  {
+  }
+  bool GetAccelerometer(const JOYSTICK::FeatureName& feature,
+                        JOYSTICK::CDriverPrimitive& positiveX,
+                        JOYSTICK::CDriverPrimitive& positiveY,
+                        JOYSTICK::CDriverPrimitive& positiveZ) override
+  {
+    return false;
+  }
+  void AddAccelerometer(const JOYSTICK::FeatureName& feature,
+                        const JOYSTICK::CDriverPrimitive& positiveX,
+                        const JOYSTICK::CDriverPrimitive& positiveY,
+                        const JOYSTICK::CDriverPrimitive& positiveZ) override
+  {
+  }
+  bool GetWheel(const JOYSTICK::FeatureName& feature,
+                JOYSTICK::WHEEL_DIRECTION direction,
+                JOYSTICK::CDriverPrimitive& primitive) override
+  {
+    return false;
+  }
+  void AddWheel(const JOYSTICK::FeatureName& feature,
+                JOYSTICK::WHEEL_DIRECTION direction,
+                const JOYSTICK::CDriverPrimitive& primitive) override
+  {
+  }
+  bool GetThrottle(const JOYSTICK::FeatureName& feature,
+                   JOYSTICK::THROTTLE_DIRECTION direction,
+                   JOYSTICK::CDriverPrimitive& primitive) override
+  {
+    return false;
+  }
+  void AddThrottle(const JOYSTICK::FeatureName& feature,
+                   JOYSTICK::THROTTLE_DIRECTION direction,
+                   const JOYSTICK::CDriverPrimitive& primitive) override
+  {
+  }
+  bool GetKey(const JOYSTICK::FeatureName& feature, JOYSTICK::CDriverPrimitive& primitive) override
+  {
+    return false;
+  }
+  void AddKey(const JOYSTICK::FeatureName& feature,
+              const JOYSTICK::CDriverPrimitive& primitive) override
+  {
+  }
+  void SetIgnoredPrimitives(const std::vector<JOYSTICK::CDriverPrimitive>& primitives) override {}
+  bool IsIgnored(const JOYSTICK::CDriverPrimitive& primitive) override { return false; }
+  bool GetAxisProperties(unsigned int axisIndex, int& center, unsigned int& range) override
+  {
+    return false;
+  }
+  void SaveButtonMap() override {}
+  void RevertButtonMap() override {}
+
+private:
+  // Construction parameters
+  PERIPHERALS::CPeripheral* const m_device;
+  const std::string m_strControllerId;
+};
+} // namespace GAME
+} // namespace KODI

--- a/xbmc/games/controllers/input/DefaultKeyboardTranslator.cpp
+++ b/xbmc/games/controllers/input/DefaultKeyboardTranslator.cpp
@@ -1,0 +1,447 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "DefaultKeyboardTranslator.h"
+
+using namespace KODI;
+using namespace GAME;
+
+namespace
+{
+constexpr auto DEFAULT_KEYBOARD_FEATURE_BACKSPACE = "backspace";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_TAB = "tab";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_CLEAR = "clear";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_ENTER = "enter";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_PAUSE = "pause";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_ESCAPE = "escape";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_SPACE = "space";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_EXCLAIM = "exclaim";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_DOUBLEQUOTE = "doublequote";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_HASH = "hash";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_DOLLAR = "dollar";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_AMPERSAND = "ampersand";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_QUOTE = "quote";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_LEFTPAREN = "leftparen";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_RIGHTPAREN = "rightparen";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_ASTERISK = "asterisk";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_PLUS = "plus";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_COMMA = "comma";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_MINUS = "minus";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_PERIOD = "period";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_SLASH = "slash";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_0 = "0";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_1 = "1";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_2 = "2";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_3 = "3";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_4 = "4";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_5 = "5";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_6 = "6";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_7 = "7";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_8 = "8";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_9 = "9";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_COLON = "colon";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_SEMICOLON = "semicolon";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_LESS = "less";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_EQUALS = "equals";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_GREATER = "greater";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_QUESTION = "question";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_AT = "at";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_LEFTBRACKET = "leftbracket";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_BACKSLASH = "backslash";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_RIGHTBRACKET = "rightbracket";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_CARET = "caret";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_UNDERSCORE = "underscore";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_GRAVE = "grave";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_A = "a";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_B = "b";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_C = "c";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_D = "d";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_E = "e";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_F = "f";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_G = "g";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_H = "h";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_I = "i";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_J = "j";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_K = "k";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_L = "l";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_M = "m";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_N = "n";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_O = "o";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_P = "p";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_Q = "q";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_R = "r";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_S = "s";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_T = "t";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_U = "u";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_V = "v";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_W = "w";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_X = "x";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_Y = "y";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_Z = "z";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_LEFTBRACE = "leftbrace";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_BAR = "bar";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_RIGHTBRACE = "rightbrace";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_TILDE = "tilde";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_DELETE = "delete";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_KP0 = "kp0";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_KP1 = "kp1";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_KP2 = "kp2";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_KP3 = "kp3";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_KP4 = "kp4";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_KP5 = "kp5";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_KP6 = "kp6";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_KP7 = "kp7";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_KP8 = "kp8";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_KP9 = "kp9";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_KPPERIOD = "kpperiod";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_KPDIVIDE = "kpdivide";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_KPMULTIPLY = "kpmultiply";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_KPMINUS = "kpminus";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_KPPLUS = "kpplus";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_KPENTER = "kpenter";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_KPEQUALS = "kpequals";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_UP = "up";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_DOWN = "down";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_RIGHT = "right";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_LEFT = "left";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_INSERT = "insert";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_HOME = "home";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_END = "end";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_PAGEUP = "pageup";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_PAGEDOWN = "pagedown";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_F1 = "f1";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_F2 = "f2";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_F3 = "f3";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_F4 = "f4";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_F5 = "f5";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_F6 = "f6";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_F7 = "f7";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_F8 = "f8";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_F9 = "f9";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_F10 = "f10";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_F11 = "f11";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_F12 = "f12";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_F13 = "f13";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_F14 = "f14";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_F15 = "f15";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_NUMLOCK = "numlock";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_CAPSLOCK = "capslock";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_SCROLLLOCK = "scrolllock";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_RIGHTSHIFT = "rightshift";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_LEFTSHIFT = "leftshift";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_RIGHTCTRL = "rightctrl";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_LEFTCTRL = "leftctrl";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_RIGHTALT = "rightalt";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_LEFTALT = "leftalt";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_RIGHTMETA = "rightmeta";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_LEFTMETA = "leftmeta";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_RIGHTSUPER = "rightsuper";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_LEFTSUPER = "leftsuper";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_MODE = "mode";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_COMPOSE = "compose";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_HELP = "help";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_PRINTSCREEN = "printscreen";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_SYSREQ = "sysreq";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_BREAK = "break";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_MENU = "menu";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_POWER = "power";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_EURO = "euro";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_UNDO = "undo";
+constexpr auto DEFAULT_KEYBOARD_FEATURE_OEM_102 = "oem102";
+} // namespace
+
+const char* CDefaultKeyboardTranslator::TranslateKeycode(KEYBOARD::XBMCKey keycode)
+{
+  switch (keycode)
+  {
+    case XBMCK_BACKSPACE:
+      return DEFAULT_KEYBOARD_FEATURE_BACKSPACE;
+    case XBMCK_TAB:
+      return DEFAULT_KEYBOARD_FEATURE_TAB;
+    case XBMCK_CLEAR:
+      return DEFAULT_KEYBOARD_FEATURE_CLEAR;
+    case XBMCK_RETURN:
+      return DEFAULT_KEYBOARD_FEATURE_ENTER;
+    case XBMCK_PAUSE:
+      return DEFAULT_KEYBOARD_FEATURE_PAUSE;
+    case XBMCK_ESCAPE:
+      return DEFAULT_KEYBOARD_FEATURE_ESCAPE;
+    case XBMCK_SPACE:
+      return DEFAULT_KEYBOARD_FEATURE_SPACE;
+    case XBMCK_EXCLAIM:
+      return DEFAULT_KEYBOARD_FEATURE_EXCLAIM;
+    case XBMCK_QUOTEDBL:
+      return DEFAULT_KEYBOARD_FEATURE_DOUBLEQUOTE;
+    case XBMCK_HASH:
+      return DEFAULT_KEYBOARD_FEATURE_HASH;
+    case XBMCK_DOLLAR:
+      return DEFAULT_KEYBOARD_FEATURE_DOLLAR;
+    case XBMCK_AMPERSAND:
+      return DEFAULT_KEYBOARD_FEATURE_AMPERSAND;
+    case XBMCK_QUOTE:
+      return DEFAULT_KEYBOARD_FEATURE_QUOTE;
+    case XBMCK_LEFTPAREN:
+      return DEFAULT_KEYBOARD_FEATURE_LEFTPAREN;
+    case XBMCK_RIGHTPAREN:
+      return DEFAULT_KEYBOARD_FEATURE_RIGHTPAREN;
+    case XBMCK_ASTERISK:
+      return DEFAULT_KEYBOARD_FEATURE_ASTERISK;
+    case XBMCK_PLUS:
+      return DEFAULT_KEYBOARD_FEATURE_PLUS;
+    case XBMCK_COMMA:
+      return DEFAULT_KEYBOARD_FEATURE_COMMA;
+    case XBMCK_MINUS:
+      return DEFAULT_KEYBOARD_FEATURE_MINUS;
+    case XBMCK_PERIOD:
+      return DEFAULT_KEYBOARD_FEATURE_PERIOD;
+    case XBMCK_SLASH:
+      return DEFAULT_KEYBOARD_FEATURE_SLASH;
+    case XBMCK_0:
+      return DEFAULT_KEYBOARD_FEATURE_0;
+    case XBMCK_1:
+      return DEFAULT_KEYBOARD_FEATURE_1;
+    case XBMCK_2:
+      return DEFAULT_KEYBOARD_FEATURE_2;
+    case XBMCK_3:
+      return DEFAULT_KEYBOARD_FEATURE_3;
+    case XBMCK_4:
+      return DEFAULT_KEYBOARD_FEATURE_4;
+    case XBMCK_5:
+      return DEFAULT_KEYBOARD_FEATURE_5;
+    case XBMCK_6:
+      return DEFAULT_KEYBOARD_FEATURE_6;
+    case XBMCK_7:
+      return DEFAULT_KEYBOARD_FEATURE_7;
+    case XBMCK_8:
+      return DEFAULT_KEYBOARD_FEATURE_8;
+    case XBMCK_9:
+      return DEFAULT_KEYBOARD_FEATURE_9;
+    case XBMCK_COLON:
+      return DEFAULT_KEYBOARD_FEATURE_COLON;
+    case XBMCK_SEMICOLON:
+      return DEFAULT_KEYBOARD_FEATURE_SEMICOLON;
+    case XBMCK_LESS:
+      return DEFAULT_KEYBOARD_FEATURE_LESS;
+    case XBMCK_EQUALS:
+      return DEFAULT_KEYBOARD_FEATURE_EQUALS;
+    case XBMCK_GREATER:
+      return DEFAULT_KEYBOARD_FEATURE_GREATER;
+    case XBMCK_QUESTION:
+      return DEFAULT_KEYBOARD_FEATURE_QUESTION;
+    case XBMCK_AT:
+      return DEFAULT_KEYBOARD_FEATURE_AT;
+    case XBMCK_LEFTBRACKET:
+      return DEFAULT_KEYBOARD_FEATURE_LEFTBRACKET;
+    case XBMCK_BACKSLASH:
+      return DEFAULT_KEYBOARD_FEATURE_BACKSLASH;
+    case XBMCK_RIGHTBRACKET:
+      return DEFAULT_KEYBOARD_FEATURE_RIGHTBRACKET;
+    case XBMCK_CARET:
+      return DEFAULT_KEYBOARD_FEATURE_CARET;
+    case XBMCK_UNDERSCORE:
+      return DEFAULT_KEYBOARD_FEATURE_UNDERSCORE;
+    case XBMCK_BACKQUOTE:
+      return DEFAULT_KEYBOARD_FEATURE_GRAVE;
+    case XBMCK_a:
+      return DEFAULT_KEYBOARD_FEATURE_A;
+    case XBMCK_b:
+      return DEFAULT_KEYBOARD_FEATURE_B;
+    case XBMCK_c:
+      return DEFAULT_KEYBOARD_FEATURE_C;
+    case XBMCK_d:
+      return DEFAULT_KEYBOARD_FEATURE_D;
+    case XBMCK_e:
+      return DEFAULT_KEYBOARD_FEATURE_E;
+    case XBMCK_f:
+      return DEFAULT_KEYBOARD_FEATURE_F;
+    case XBMCK_g:
+      return DEFAULT_KEYBOARD_FEATURE_G;
+    case XBMCK_h:
+      return DEFAULT_KEYBOARD_FEATURE_H;
+    case XBMCK_i:
+      return DEFAULT_KEYBOARD_FEATURE_I;
+    case XBMCK_j:
+      return DEFAULT_KEYBOARD_FEATURE_J;
+    case XBMCK_k:
+      return DEFAULT_KEYBOARD_FEATURE_K;
+    case XBMCK_l:
+      return DEFAULT_KEYBOARD_FEATURE_L;
+    case XBMCK_m:
+      return DEFAULT_KEYBOARD_FEATURE_M;
+    case XBMCK_n:
+      return DEFAULT_KEYBOARD_FEATURE_N;
+    case XBMCK_o:
+      return DEFAULT_KEYBOARD_FEATURE_O;
+    case XBMCK_p:
+      return DEFAULT_KEYBOARD_FEATURE_P;
+    case XBMCK_q:
+      return DEFAULT_KEYBOARD_FEATURE_Q;
+    case XBMCK_r:
+      return DEFAULT_KEYBOARD_FEATURE_R;
+    case XBMCK_s:
+      return DEFAULT_KEYBOARD_FEATURE_S;
+    case XBMCK_t:
+      return DEFAULT_KEYBOARD_FEATURE_T;
+    case XBMCK_u:
+      return DEFAULT_KEYBOARD_FEATURE_U;
+    case XBMCK_v:
+      return DEFAULT_KEYBOARD_FEATURE_V;
+    case XBMCK_w:
+      return DEFAULT_KEYBOARD_FEATURE_W;
+    case XBMCK_x:
+      return DEFAULT_KEYBOARD_FEATURE_X;
+    case XBMCK_y:
+      return DEFAULT_KEYBOARD_FEATURE_Y;
+    case XBMCK_z:
+      return DEFAULT_KEYBOARD_FEATURE_Z;
+    case XBMCK_LEFTBRACE:
+      return DEFAULT_KEYBOARD_FEATURE_LEFTBRACE;
+    case XBMCK_PIPE:
+      return DEFAULT_KEYBOARD_FEATURE_BAR;
+    case XBMCK_RIGHTBRACE:
+      return DEFAULT_KEYBOARD_FEATURE_RIGHTBRACE;
+    case XBMCK_TILDE:
+      return DEFAULT_KEYBOARD_FEATURE_TILDE;
+    case XBMCK_DELETE:
+      return DEFAULT_KEYBOARD_FEATURE_DELETE;
+    case XBMCK_KP0:
+      return DEFAULT_KEYBOARD_FEATURE_KP0;
+    case XBMCK_KP1:
+      return DEFAULT_KEYBOARD_FEATURE_KP1;
+    case XBMCK_KP2:
+      return DEFAULT_KEYBOARD_FEATURE_KP2;
+    case XBMCK_KP3:
+      return DEFAULT_KEYBOARD_FEATURE_KP3;
+    case XBMCK_KP4:
+      return DEFAULT_KEYBOARD_FEATURE_KP4;
+    case XBMCK_KP5:
+      return DEFAULT_KEYBOARD_FEATURE_KP5;
+    case XBMCK_KP6:
+      return DEFAULT_KEYBOARD_FEATURE_KP6;
+    case XBMCK_KP7:
+      return DEFAULT_KEYBOARD_FEATURE_KP7;
+    case XBMCK_KP8:
+      return DEFAULT_KEYBOARD_FEATURE_KP8;
+    case XBMCK_KP9:
+      return DEFAULT_KEYBOARD_FEATURE_KP9;
+    case XBMCK_KP_PERIOD:
+      return DEFAULT_KEYBOARD_FEATURE_KPPERIOD;
+    case XBMCK_KP_DIVIDE:
+      return DEFAULT_KEYBOARD_FEATURE_KPDIVIDE;
+    case XBMCK_KP_MULTIPLY:
+      return DEFAULT_KEYBOARD_FEATURE_KPMULTIPLY;
+    case XBMCK_KP_MINUS:
+      return DEFAULT_KEYBOARD_FEATURE_KPMINUS;
+    case XBMCK_KP_PLUS:
+      return DEFAULT_KEYBOARD_FEATURE_KPPLUS;
+    case XBMCK_KP_ENTER:
+      return DEFAULT_KEYBOARD_FEATURE_KPENTER;
+    case XBMCK_KP_EQUALS:
+      return DEFAULT_KEYBOARD_FEATURE_KPEQUALS;
+    case XBMCK_UP:
+      return DEFAULT_KEYBOARD_FEATURE_UP;
+    case XBMCK_DOWN:
+      return DEFAULT_KEYBOARD_FEATURE_DOWN;
+    case XBMCK_RIGHT:
+      return DEFAULT_KEYBOARD_FEATURE_RIGHT;
+    case XBMCK_LEFT:
+      return DEFAULT_KEYBOARD_FEATURE_LEFT;
+    case XBMCK_INSERT:
+      return DEFAULT_KEYBOARD_FEATURE_INSERT;
+    case XBMCK_HOME:
+      return DEFAULT_KEYBOARD_FEATURE_HOME;
+    case XBMCK_END:
+      return DEFAULT_KEYBOARD_FEATURE_END;
+    case XBMCK_PAGEUP:
+      return DEFAULT_KEYBOARD_FEATURE_PAGEUP;
+    case XBMCK_PAGEDOWN:
+      return DEFAULT_KEYBOARD_FEATURE_PAGEDOWN;
+    case XBMCK_F1:
+      return DEFAULT_KEYBOARD_FEATURE_F1;
+    case XBMCK_F2:
+      return DEFAULT_KEYBOARD_FEATURE_F2;
+    case XBMCK_F3:
+      return DEFAULT_KEYBOARD_FEATURE_F3;
+    case XBMCK_F4:
+      return DEFAULT_KEYBOARD_FEATURE_F4;
+    case XBMCK_F5:
+      return DEFAULT_KEYBOARD_FEATURE_F5;
+    case XBMCK_F6:
+      return DEFAULT_KEYBOARD_FEATURE_F6;
+    case XBMCK_F7:
+      return DEFAULT_KEYBOARD_FEATURE_F7;
+    case XBMCK_F8:
+      return DEFAULT_KEYBOARD_FEATURE_F8;
+    case XBMCK_F9:
+      return DEFAULT_KEYBOARD_FEATURE_F9;
+    case XBMCK_F10:
+      return DEFAULT_KEYBOARD_FEATURE_F10;
+    case XBMCK_F11:
+      return DEFAULT_KEYBOARD_FEATURE_F11;
+    case XBMCK_F12:
+      return DEFAULT_KEYBOARD_FEATURE_F12;
+    case XBMCK_F13:
+      return DEFAULT_KEYBOARD_FEATURE_F13;
+    case XBMCK_F14:
+      return DEFAULT_KEYBOARD_FEATURE_F14;
+    case XBMCK_F15:
+      return DEFAULT_KEYBOARD_FEATURE_F15;
+    case XBMCK_NUMLOCK:
+      return DEFAULT_KEYBOARD_FEATURE_NUMLOCK;
+    case XBMCK_CAPSLOCK:
+      return DEFAULT_KEYBOARD_FEATURE_CAPSLOCK;
+    case XBMCK_SCROLLOCK:
+      return DEFAULT_KEYBOARD_FEATURE_SCROLLLOCK;
+    case XBMCK_RSHIFT:
+      return DEFAULT_KEYBOARD_FEATURE_RIGHTSHIFT;
+    case XBMCK_LSHIFT:
+      return DEFAULT_KEYBOARD_FEATURE_LEFTSHIFT;
+    case XBMCK_RCTRL:
+      return DEFAULT_KEYBOARD_FEATURE_RIGHTCTRL;
+    case XBMCK_LCTRL:
+      return DEFAULT_KEYBOARD_FEATURE_LEFTCTRL;
+    case XBMCK_RALT:
+      return DEFAULT_KEYBOARD_FEATURE_RIGHTALT;
+    case XBMCK_LALT:
+      return DEFAULT_KEYBOARD_FEATURE_LEFTALT;
+    case XBMCK_RMETA:
+      return DEFAULT_KEYBOARD_FEATURE_RIGHTMETA;
+    case XBMCK_LMETA:
+      return DEFAULT_KEYBOARD_FEATURE_LEFTMETA;
+    case XBMCK_RSUPER:
+      return DEFAULT_KEYBOARD_FEATURE_RIGHTSUPER;
+    case XBMCK_LSUPER:
+      return DEFAULT_KEYBOARD_FEATURE_LEFTSUPER;
+    case XBMCK_MODE:
+      return DEFAULT_KEYBOARD_FEATURE_MODE;
+    case XBMCK_COMPOSE:
+      return DEFAULT_KEYBOARD_FEATURE_COMPOSE;
+    case XBMCK_HELP:
+      return DEFAULT_KEYBOARD_FEATURE_HELP;
+    case XBMCK_PRINT:
+      return DEFAULT_KEYBOARD_FEATURE_PRINTSCREEN;
+    case XBMCK_SYSREQ:
+      return DEFAULT_KEYBOARD_FEATURE_SYSREQ;
+    case XBMCK_BREAK:
+      return DEFAULT_KEYBOARD_FEATURE_BREAK;
+    case XBMCK_MENU:
+      return DEFAULT_KEYBOARD_FEATURE_MENU;
+    case XBMCK_POWER:
+      return DEFAULT_KEYBOARD_FEATURE_POWER;
+    case XBMCK_EURO:
+      return DEFAULT_KEYBOARD_FEATURE_EURO;
+    case XBMCK_UNDO:
+      return DEFAULT_KEYBOARD_FEATURE_UNDO;
+    case XBMCK_OEM_102:
+      return DEFAULT_KEYBOARD_FEATURE_OEM_102;
+    default:
+      break;
+  }
+
+  return "";
+}

--- a/xbmc/games/controllers/input/DefaultKeyboardTranslator.h
+++ b/xbmc/games/controllers/input/DefaultKeyboardTranslator.h
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "input/keyboard/KeyboardTypes.h"
+
+namespace KODI
+{
+namespace GAME
+{
+
+/*!
+ * \ingroup games
+ */
+class CDefaultKeyboardTranslator
+{
+public:
+  /*!
+   * \brief Translate a Kodi key code to a keyboard key name in a controller profile
+   *
+   * \param keycode The Kodi key code
+   *
+   * \return The key's name, or an empty string if no symbol is defined for the keycode
+   */
+  static const char* TranslateKeycode(KEYBOARD::XBMCKey keycode);
+};
+
+} // namespace GAME
+} // namespace KODI

--- a/xbmc/games/controllers/input/DefaultMouseTranslator.cpp
+++ b/xbmc/games/controllers/input/DefaultMouseTranslator.cpp
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "DefaultMouseTranslator.h"
+
+using namespace KODI;
+using namespace GAME;
+
+namespace
+{
+// Mouse buttons
+constexpr auto DEFAULT_MOUSE_FEATURE_LEFT = "left";
+constexpr auto DEFAULT_MOUSE_FEATURE_RIGHT = "right";
+constexpr auto DEFAULT_MOUSE_FEATURE_MIDDLE = "middle";
+constexpr auto DEFAULT_MOUSE_FEATURE_BUTTON4 = "button4";
+constexpr auto DEFAULT_MOUSE_FEATURE_BUTTON5 = "button5";
+constexpr auto DEFAULT_MOUSE_FEATURE_WHEEL_UP = "wheelup";
+constexpr auto DEFAULT_MOUSE_FEATURE_WHEEL_DOWN = "wheeldown";
+constexpr auto DEFAULT_MOUSE_FEATURE_HORIZ_WHEEL_LEFT = "horizwheelleft";
+constexpr auto DEFAULT_MOUSE_FEATURE_HORIZ_WHEEL_RIGHT = "horizwheelright";
+
+// Mouse pointers
+constexpr auto DEFAULT_MOUSE_FEATURE_POINTER = "pointer";
+} // namespace
+
+const char* CDefaultMouseTranslator::TranslateMouseButton(MOUSE::BUTTON_ID button)
+{
+  switch (button)
+  {
+    case MOUSE::BUTTON_ID::LEFT:
+      return DEFAULT_MOUSE_FEATURE_LEFT;
+    case MOUSE::BUTTON_ID::RIGHT:
+      return DEFAULT_MOUSE_FEATURE_RIGHT;
+    case MOUSE::BUTTON_ID::MIDDLE:
+      return DEFAULT_MOUSE_FEATURE_MIDDLE;
+    case MOUSE::BUTTON_ID::BUTTON4:
+      return DEFAULT_MOUSE_FEATURE_BUTTON4;
+    case MOUSE::BUTTON_ID::BUTTON5:
+      return DEFAULT_MOUSE_FEATURE_BUTTON5;
+    case MOUSE::BUTTON_ID::WHEEL_UP:
+      return DEFAULT_MOUSE_FEATURE_WHEEL_UP;
+    case MOUSE::BUTTON_ID::WHEEL_DOWN:
+      return DEFAULT_MOUSE_FEATURE_WHEEL_DOWN;
+    case MOUSE::BUTTON_ID::HORIZ_WHEEL_LEFT:
+      return DEFAULT_MOUSE_FEATURE_HORIZ_WHEEL_LEFT;
+    case MOUSE::BUTTON_ID::HORIZ_WHEEL_RIGHT:
+      return DEFAULT_MOUSE_FEATURE_HORIZ_WHEEL_RIGHT;
+    default:
+      break;
+  }
+
+  return "";
+}
+
+const char* CDefaultMouseTranslator::TranslateMousePointer(MOUSE::POINTER_DIRECTION direction)
+{
+  switch (direction)
+  {
+    case MOUSE::POINTER_DIRECTION::UP:
+    case MOUSE::POINTER_DIRECTION::DOWN:
+    case MOUSE::POINTER_DIRECTION::RIGHT:
+    case MOUSE::POINTER_DIRECTION::LEFT:
+      return DEFAULT_MOUSE_FEATURE_POINTER;
+    default:
+      break;
+  }
+
+  return "";
+}

--- a/xbmc/games/controllers/input/DefaultMouseTranslator.h
+++ b/xbmc/games/controllers/input/DefaultMouseTranslator.h
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "input/mouse/MouseTypes.h"
+
+namespace KODI
+{
+namespace GAME
+{
+
+/*!
+ * \ingroup games
+ */
+class CDefaultMouseTranslator
+{
+public:
+  /*!
+   * \brief Translate a mouse button ID to a mouse button name
+   *
+   * \param button The button ID
+   *
+   * \return The mouse button's name, or empty if unknown
+   */
+  static const char* TranslateMouseButton(MOUSE::BUTTON_ID button);
+
+  /*!
+   * \brief Translate a mouse pointer direction
+   *
+   * \param direction The relative pointer direction
+   *
+   * \return The relative pointer direction, or empty if unknown
+   */
+  static const char* TranslateMousePointer(MOUSE::POINTER_DIRECTION direction);
+};
+
+} // namespace GAME
+} // namespace KODI

--- a/xbmc/games/controllers/input/test/CMakeLists.txt
+++ b/xbmc/games/controllers/input/test/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES TestDefaultKeyboardTranslator.cpp
+            TestDefaultMouseTranslator.cpp
+)
+
+core_add_test_library(test_games_controllers_input)

--- a/xbmc/games/controllers/input/test/TestDefaultKeyboardTranslator.cpp
+++ b/xbmc/games/controllers/input/test/TestDefaultKeyboardTranslator.cpp
@@ -1,0 +1,207 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ServiceBroker.h"
+#include "addons/AddonManager.h"
+#include "addons/addoninfo/AddonType.h"
+#include "games/controllers/Controller.h"
+#include "games/controllers/ControllerIDs.h"
+#include "games/controllers/input/DefaultKeyboardTranslator.h"
+#include "games/controllers/input/PhysicalFeature.h"
+
+#include <gtest/gtest.h>
+
+using namespace KODI;
+using namespace GAME;
+
+namespace
+{
+// Helper functions
+KEYBOARD::XBMCKey GetKeycode(KEYBOARD::XBMCKey keysym,
+                             const ControllerPtr& controller,
+                             unsigned int& count)
+{
+  KEYBOARD::KeyName keyName = CDefaultKeyboardTranslator::TranslateKeycode(keysym);
+  ++count;
+  return controller->GetFeature(keyName).Keycode();
+}
+
+const GAME::ControllerPtr GetController()
+{
+  ADDON::CAddonMgr& addonManager = CServiceBroker::GetAddonMgr();
+
+  // Load add-on info
+  ADDON::AddonPtr addon;
+  EXPECT_TRUE(addonManager.GetAddon(DEFAULT_KEYBOARD_ID, addon, ADDON::AddonType::GAME_CONTROLLER,
+                                    ADDON::OnlyEnabled::CHOICE_YES));
+
+  // Convert to game controller
+  GAME::ControllerPtr controller = std::static_pointer_cast<GAME::CController>(addon);
+  EXPECT_NE(controller.get(), nullptr);
+  EXPECT_EQ(controller->ID(), DEFAULT_KEYBOARD_ID);
+
+  // Load controller profile
+  EXPECT_TRUE(controller->LoadLayout());
+  EXPECT_EQ(controller->Features().size(), 140);
+
+  return controller;
+}
+} // namespace
+
+TEST(TestDefaultKeyboardTranslator, TranslateKeycode)
+{
+  GAME::ControllerPtr controller = GetController();
+
+  //
+  // Spec: Should translate all keyboard keys
+  //
+  unsigned int count = 0;
+
+  EXPECT_EQ(GetKeycode(XBMCK_BACKSPACE, controller, count), XBMCK_BACKSPACE);
+  EXPECT_EQ(GetKeycode(XBMCK_TAB, controller, count), XBMCK_TAB);
+  EXPECT_EQ(GetKeycode(XBMCK_CLEAR, controller, count), XBMCK_CLEAR);
+  EXPECT_EQ(GetKeycode(XBMCK_RETURN, controller, count), XBMCK_RETURN);
+  EXPECT_EQ(GetKeycode(XBMCK_PAUSE, controller, count), XBMCK_PAUSE);
+  EXPECT_EQ(GetKeycode(XBMCK_ESCAPE, controller, count), XBMCK_ESCAPE);
+  EXPECT_EQ(GetKeycode(XBMCK_SPACE, controller, count), XBMCK_SPACE);
+  EXPECT_EQ(GetKeycode(XBMCK_EXCLAIM, controller, count), XBMCK_EXCLAIM);
+  EXPECT_EQ(GetKeycode(XBMCK_QUOTEDBL, controller, count), XBMCK_QUOTEDBL);
+  EXPECT_EQ(GetKeycode(XBMCK_HASH, controller, count), XBMCK_HASH);
+  EXPECT_EQ(GetKeycode(XBMCK_DOLLAR, controller, count), XBMCK_DOLLAR);
+  EXPECT_EQ(GetKeycode(XBMCK_AMPERSAND, controller, count), XBMCK_AMPERSAND);
+  EXPECT_EQ(GetKeycode(XBMCK_QUOTE, controller, count), XBMCK_QUOTE);
+  EXPECT_EQ(GetKeycode(XBMCK_LEFTPAREN, controller, count), XBMCK_LEFTPAREN);
+  EXPECT_EQ(GetKeycode(XBMCK_RIGHTPAREN, controller, count), XBMCK_RIGHTPAREN);
+  EXPECT_EQ(GetKeycode(XBMCK_ASTERISK, controller, count), XBMCK_ASTERISK);
+  EXPECT_EQ(GetKeycode(XBMCK_PLUS, controller, count), XBMCK_PLUS);
+  EXPECT_EQ(GetKeycode(XBMCK_COMMA, controller, count), XBMCK_COMMA);
+  EXPECT_EQ(GetKeycode(XBMCK_MINUS, controller, count), XBMCK_MINUS);
+  EXPECT_EQ(GetKeycode(XBMCK_PERIOD, controller, count), XBMCK_PERIOD);
+  EXPECT_EQ(GetKeycode(XBMCK_SLASH, controller, count), XBMCK_SLASH);
+  EXPECT_EQ(GetKeycode(XBMCK_0, controller, count), XBMCK_0);
+  EXPECT_EQ(GetKeycode(XBMCK_1, controller, count), XBMCK_1);
+  EXPECT_EQ(GetKeycode(XBMCK_2, controller, count), XBMCK_2);
+  EXPECT_EQ(GetKeycode(XBMCK_3, controller, count), XBMCK_3);
+  EXPECT_EQ(GetKeycode(XBMCK_4, controller, count), XBMCK_4);
+  EXPECT_EQ(GetKeycode(XBMCK_5, controller, count), XBMCK_5);
+  EXPECT_EQ(GetKeycode(XBMCK_6, controller, count), XBMCK_6);
+  EXPECT_EQ(GetKeycode(XBMCK_7, controller, count), XBMCK_7);
+  EXPECT_EQ(GetKeycode(XBMCK_8, controller, count), XBMCK_8);
+  EXPECT_EQ(GetKeycode(XBMCK_9, controller, count), XBMCK_9);
+  EXPECT_EQ(GetKeycode(XBMCK_COLON, controller, count), XBMCK_COLON);
+  EXPECT_EQ(GetKeycode(XBMCK_SEMICOLON, controller, count), XBMCK_SEMICOLON);
+  EXPECT_EQ(GetKeycode(XBMCK_LESS, controller, count), XBMCK_LESS);
+  EXPECT_EQ(GetKeycode(XBMCK_EQUALS, controller, count), XBMCK_EQUALS);
+  EXPECT_EQ(GetKeycode(XBMCK_GREATER, controller, count), XBMCK_GREATER);
+  EXPECT_EQ(GetKeycode(XBMCK_QUESTION, controller, count), XBMCK_QUESTION);
+  EXPECT_EQ(GetKeycode(XBMCK_AT, controller, count), XBMCK_AT);
+  EXPECT_EQ(GetKeycode(XBMCK_LEFTBRACKET, controller, count), XBMCK_LEFTBRACKET);
+  EXPECT_EQ(GetKeycode(XBMCK_BACKSLASH, controller, count), XBMCK_BACKSLASH);
+  EXPECT_EQ(GetKeycode(XBMCK_RIGHTBRACKET, controller, count), XBMCK_RIGHTBRACKET);
+  EXPECT_EQ(GetKeycode(XBMCK_CARET, controller, count), XBMCK_CARET);
+  EXPECT_EQ(GetKeycode(XBMCK_UNDERSCORE, controller, count), XBMCK_UNDERSCORE);
+  EXPECT_EQ(GetKeycode(XBMCK_BACKQUOTE, controller, count), XBMCK_BACKQUOTE);
+  EXPECT_EQ(GetKeycode(XBMCK_a, controller, count), XBMCK_a);
+  EXPECT_EQ(GetKeycode(XBMCK_b, controller, count), XBMCK_b);
+  EXPECT_EQ(GetKeycode(XBMCK_c, controller, count), XBMCK_c);
+  EXPECT_EQ(GetKeycode(XBMCK_d, controller, count), XBMCK_d);
+  EXPECT_EQ(GetKeycode(XBMCK_e, controller, count), XBMCK_e);
+  EXPECT_EQ(GetKeycode(XBMCK_f, controller, count), XBMCK_f);
+  EXPECT_EQ(GetKeycode(XBMCK_g, controller, count), XBMCK_g);
+  EXPECT_EQ(GetKeycode(XBMCK_h, controller, count), XBMCK_h);
+  EXPECT_EQ(GetKeycode(XBMCK_i, controller, count), XBMCK_i);
+  EXPECT_EQ(GetKeycode(XBMCK_j, controller, count), XBMCK_j);
+  EXPECT_EQ(GetKeycode(XBMCK_k, controller, count), XBMCK_k);
+  EXPECT_EQ(GetKeycode(XBMCK_l, controller, count), XBMCK_l);
+  EXPECT_EQ(GetKeycode(XBMCK_m, controller, count), XBMCK_m);
+  EXPECT_EQ(GetKeycode(XBMCK_n, controller, count), XBMCK_n);
+  EXPECT_EQ(GetKeycode(XBMCK_o, controller, count), XBMCK_o);
+  EXPECT_EQ(GetKeycode(XBMCK_p, controller, count), XBMCK_p);
+  EXPECT_EQ(GetKeycode(XBMCK_q, controller, count), XBMCK_q);
+  EXPECT_EQ(GetKeycode(XBMCK_r, controller, count), XBMCK_r);
+  EXPECT_EQ(GetKeycode(XBMCK_s, controller, count), XBMCK_s);
+  EXPECT_EQ(GetKeycode(XBMCK_t, controller, count), XBMCK_t);
+  EXPECT_EQ(GetKeycode(XBMCK_u, controller, count), XBMCK_u);
+  EXPECT_EQ(GetKeycode(XBMCK_v, controller, count), XBMCK_v);
+  EXPECT_EQ(GetKeycode(XBMCK_w, controller, count), XBMCK_w);
+  EXPECT_EQ(GetKeycode(XBMCK_x, controller, count), XBMCK_x);
+  EXPECT_EQ(GetKeycode(XBMCK_y, controller, count), XBMCK_y);
+  EXPECT_EQ(GetKeycode(XBMCK_z, controller, count), XBMCK_z);
+  EXPECT_EQ(GetKeycode(XBMCK_LEFTBRACE, controller, count), XBMCK_LEFTBRACE);
+  EXPECT_EQ(GetKeycode(XBMCK_PIPE, controller, count), XBMCK_PIPE);
+  EXPECT_EQ(GetKeycode(XBMCK_RIGHTBRACE, controller, count), XBMCK_RIGHTBRACE);
+  EXPECT_EQ(GetKeycode(XBMCK_TILDE, controller, count), XBMCK_TILDE);
+  EXPECT_EQ(GetKeycode(XBMCK_DELETE, controller, count), XBMCK_DELETE);
+  EXPECT_EQ(GetKeycode(XBMCK_KP0, controller, count), XBMCK_KP0);
+  EXPECT_EQ(GetKeycode(XBMCK_KP1, controller, count), XBMCK_KP1);
+  EXPECT_EQ(GetKeycode(XBMCK_KP2, controller, count), XBMCK_KP2);
+  EXPECT_EQ(GetKeycode(XBMCK_KP3, controller, count), XBMCK_KP3);
+  EXPECT_EQ(GetKeycode(XBMCK_KP4, controller, count), XBMCK_KP4);
+  EXPECT_EQ(GetKeycode(XBMCK_KP5, controller, count), XBMCK_KP5);
+  EXPECT_EQ(GetKeycode(XBMCK_KP6, controller, count), XBMCK_KP6);
+  EXPECT_EQ(GetKeycode(XBMCK_KP7, controller, count), XBMCK_KP7);
+  EXPECT_EQ(GetKeycode(XBMCK_KP8, controller, count), XBMCK_KP8);
+  EXPECT_EQ(GetKeycode(XBMCK_KP9, controller, count), XBMCK_KP9);
+  EXPECT_EQ(GetKeycode(XBMCK_KP_PERIOD, controller, count), XBMCK_KP_PERIOD);
+  EXPECT_EQ(GetKeycode(XBMCK_KP_DIVIDE, controller, count), XBMCK_KP_DIVIDE);
+  EXPECT_EQ(GetKeycode(XBMCK_KP_MULTIPLY, controller, count), XBMCK_KP_MULTIPLY);
+  EXPECT_EQ(GetKeycode(XBMCK_KP_MINUS, controller, count), XBMCK_KP_MINUS);
+  EXPECT_EQ(GetKeycode(XBMCK_KP_PLUS, controller, count), XBMCK_KP_PLUS);
+  EXPECT_EQ(GetKeycode(XBMCK_KP_ENTER, controller, count), XBMCK_KP_ENTER);
+  EXPECT_EQ(GetKeycode(XBMCK_KP_EQUALS, controller, count), XBMCK_KP_EQUALS);
+  EXPECT_EQ(GetKeycode(XBMCK_UP, controller, count), XBMCK_UP);
+  EXPECT_EQ(GetKeycode(XBMCK_DOWN, controller, count), XBMCK_DOWN);
+  EXPECT_EQ(GetKeycode(XBMCK_RIGHT, controller, count), XBMCK_RIGHT);
+  EXPECT_EQ(GetKeycode(XBMCK_LEFT, controller, count), XBMCK_LEFT);
+  EXPECT_EQ(GetKeycode(XBMCK_INSERT, controller, count), XBMCK_INSERT);
+  EXPECT_EQ(GetKeycode(XBMCK_HOME, controller, count), XBMCK_HOME);
+  EXPECT_EQ(GetKeycode(XBMCK_END, controller, count), XBMCK_END);
+  EXPECT_EQ(GetKeycode(XBMCK_PAGEUP, controller, count), XBMCK_PAGEUP);
+  EXPECT_EQ(GetKeycode(XBMCK_PAGEDOWN, controller, count), XBMCK_PAGEDOWN);
+  EXPECT_EQ(GetKeycode(XBMCK_F1, controller, count), XBMCK_F1);
+  EXPECT_EQ(GetKeycode(XBMCK_F2, controller, count), XBMCK_F2);
+  EXPECT_EQ(GetKeycode(XBMCK_F3, controller, count), XBMCK_F3);
+  EXPECT_EQ(GetKeycode(XBMCK_F4, controller, count), XBMCK_F4);
+  EXPECT_EQ(GetKeycode(XBMCK_F5, controller, count), XBMCK_F5);
+  EXPECT_EQ(GetKeycode(XBMCK_F6, controller, count), XBMCK_F6);
+  EXPECT_EQ(GetKeycode(XBMCK_F7, controller, count), XBMCK_F7);
+  EXPECT_EQ(GetKeycode(XBMCK_F8, controller, count), XBMCK_F8);
+  EXPECT_EQ(GetKeycode(XBMCK_F9, controller, count), XBMCK_F9);
+  EXPECT_EQ(GetKeycode(XBMCK_F10, controller, count), XBMCK_F10);
+  EXPECT_EQ(GetKeycode(XBMCK_F11, controller, count), XBMCK_F11);
+  EXPECT_EQ(GetKeycode(XBMCK_F12, controller, count), XBMCK_F12);
+  EXPECT_EQ(GetKeycode(XBMCK_F13, controller, count), XBMCK_F13);
+  EXPECT_EQ(GetKeycode(XBMCK_F14, controller, count), XBMCK_F14);
+  EXPECT_EQ(GetKeycode(XBMCK_F15, controller, count), XBMCK_F15);
+  EXPECT_EQ(GetKeycode(XBMCK_NUMLOCK, controller, count), XBMCK_NUMLOCK);
+  EXPECT_EQ(GetKeycode(XBMCK_CAPSLOCK, controller, count), XBMCK_CAPSLOCK);
+  EXPECT_EQ(GetKeycode(XBMCK_SCROLLOCK, controller, count), XBMCK_SCROLLOCK);
+  EXPECT_EQ(GetKeycode(XBMCK_LSHIFT, controller, count), XBMCK_LSHIFT);
+  EXPECT_EQ(GetKeycode(XBMCK_RSHIFT, controller, count), XBMCK_RSHIFT);
+  EXPECT_EQ(GetKeycode(XBMCK_LCTRL, controller, count), XBMCK_LCTRL);
+  EXPECT_EQ(GetKeycode(XBMCK_RCTRL, controller, count), XBMCK_RCTRL);
+  EXPECT_EQ(GetKeycode(XBMCK_LALT, controller, count), XBMCK_LALT);
+  EXPECT_EQ(GetKeycode(XBMCK_RALT, controller, count), XBMCK_RALT);
+  EXPECT_EQ(GetKeycode(XBMCK_LMETA, controller, count), XBMCK_LMETA);
+  EXPECT_EQ(GetKeycode(XBMCK_RMETA, controller, count), XBMCK_RMETA);
+  EXPECT_EQ(GetKeycode(XBMCK_LSUPER, controller, count), XBMCK_LSUPER);
+  EXPECT_EQ(GetKeycode(XBMCK_RSUPER, controller, count), XBMCK_RSUPER);
+  EXPECT_EQ(GetKeycode(XBMCK_MODE, controller, count), XBMCK_MODE);
+  EXPECT_EQ(GetKeycode(XBMCK_COMPOSE, controller, count), XBMCK_COMPOSE);
+  EXPECT_EQ(GetKeycode(XBMCK_HELP, controller, count), XBMCK_HELP);
+  EXPECT_EQ(GetKeycode(XBMCK_PRINT, controller, count), XBMCK_PRINT);
+  EXPECT_EQ(GetKeycode(XBMCK_SYSREQ, controller, count), XBMCK_SYSREQ);
+  EXPECT_EQ(GetKeycode(XBMCK_BREAK, controller, count), XBMCK_BREAK);
+  EXPECT_EQ(GetKeycode(XBMCK_MENU, controller, count), XBMCK_MENU);
+  EXPECT_EQ(GetKeycode(XBMCK_POWER, controller, count), XBMCK_POWER);
+  EXPECT_EQ(GetKeycode(XBMCK_EURO, controller, count), XBMCK_EURO);
+  EXPECT_EQ(GetKeycode(XBMCK_UNDO, controller, count), XBMCK_UNDO);
+  EXPECT_EQ(GetKeycode(XBMCK_OEM_102, controller, count), XBMCK_OEM_102);
+
+  EXPECT_EQ(count, 140);
+}

--- a/xbmc/games/controllers/input/test/TestDefaultMouseTranslator.cpp
+++ b/xbmc/games/controllers/input/test/TestDefaultMouseTranslator.cpp
@@ -1,0 +1,111 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ServiceBroker.h"
+#include "addons/AddonManager.h"
+#include "addons/addoninfo/AddonType.h"
+#include "games/controllers/Controller.h"
+#include "games/controllers/ControllerIDs.h"
+#include "games/controllers/input/DefaultMouseTranslator.h"
+#include "games/controllers/input/PhysicalFeature.h"
+
+#include <gtest/gtest.h>
+
+using namespace KODI;
+using namespace GAME;
+
+namespace
+{
+// Helper functions
+JOYSTICK::FEATURE_TYPE GetButtonType(MOUSE::BUTTON_ID buttonId,
+                                     const ControllerPtr& controller,
+                                     unsigned int& count)
+{
+  std::string buttonName = CDefaultMouseTranslator::TranslateMouseButton(buttonId);
+  ++count;
+  return controller->GetFeature(buttonName).Type();
+}
+
+JOYSTICK::FEATURE_TYPE GetPointerType(MOUSE::POINTER_DIRECTION direction,
+                                      const ControllerPtr& controller)
+{
+  std::string pointerName = CDefaultMouseTranslator::TranslateMousePointer(direction);
+  return controller->GetFeature(pointerName).Type();
+}
+
+GAME::ControllerPtr GetController()
+{
+  ADDON::CAddonMgr& addonManager = CServiceBroker::GetAddonMgr();
+
+  // Load add-on info
+  ADDON::AddonPtr addon;
+  EXPECT_TRUE(addonManager.GetAddon(DEFAULT_MOUSE_ID, addon, ADDON::AddonType::GAME_CONTROLLER,
+                                    ADDON::OnlyEnabled::CHOICE_YES));
+
+  // Convert to game controller
+  GAME::ControllerPtr controller = std::static_pointer_cast<GAME::CController>(addon);
+  EXPECT_NE(controller.get(), nullptr);
+  EXPECT_EQ(controller->ID(), DEFAULT_MOUSE_ID);
+
+  // Load controller profile
+  EXPECT_TRUE(controller->LoadLayout());
+  EXPECT_EQ(controller->Features().size(), 10);
+
+  return controller;
+}
+} // namespace
+
+TEST(TestDefaultMouseTranslator, TranslateButton)
+{
+  GAME::ControllerPtr controller = GetController();
+
+  //
+  // Spec: Should translate all mouse buttons
+  //
+  unsigned int count = 0;
+
+  EXPECT_EQ(GetButtonType(MOUSE::BUTTON_ID::LEFT, controller, count),
+            JOYSTICK::FEATURE_TYPE::SCALAR);
+  EXPECT_EQ(GetButtonType(MOUSE::BUTTON_ID::RIGHT, controller, count),
+            JOYSTICK::FEATURE_TYPE::SCALAR);
+  EXPECT_EQ(GetButtonType(MOUSE::BUTTON_ID::MIDDLE, controller, count),
+            JOYSTICK::FEATURE_TYPE::SCALAR);
+  EXPECT_EQ(GetButtonType(MOUSE::BUTTON_ID::BUTTON4, controller, count),
+            JOYSTICK::FEATURE_TYPE::SCALAR);
+  EXPECT_EQ(GetButtonType(MOUSE::BUTTON_ID::BUTTON5, controller, count),
+            JOYSTICK::FEATURE_TYPE::SCALAR);
+  EXPECT_EQ(GetButtonType(MOUSE::BUTTON_ID::WHEEL_UP, controller, count),
+            JOYSTICK::FEATURE_TYPE::SCALAR);
+  EXPECT_EQ(GetButtonType(MOUSE::BUTTON_ID::WHEEL_DOWN, controller, count),
+            JOYSTICK::FEATURE_TYPE::SCALAR);
+  EXPECT_EQ(GetButtonType(MOUSE::BUTTON_ID::HORIZ_WHEEL_LEFT, controller, count),
+            JOYSTICK::FEATURE_TYPE::SCALAR);
+  EXPECT_EQ(GetButtonType(MOUSE::BUTTON_ID::HORIZ_WHEEL_RIGHT, controller, count),
+            JOYSTICK::FEATURE_TYPE::SCALAR);
+
+  EXPECT_EQ(count, 9);
+}
+
+TEST(TestDefaultMouseTranslator, TranslatePointer)
+{
+  GAME::ControllerPtr controller = GetController();
+
+  //
+  // Spec: Should translate mouse pointer
+  //
+  EXPECT_EQ(GetPointerType(MOUSE::POINTER_DIRECTION::UP, controller),
+            JOYSTICK::FEATURE_TYPE::RELPOINTER);
+  EXPECT_EQ(GetPointerType(MOUSE::POINTER_DIRECTION::DOWN, controller),
+            JOYSTICK::FEATURE_TYPE::RELPOINTER);
+  EXPECT_EQ(GetPointerType(MOUSE::POINTER_DIRECTION::RIGHT, controller),
+            JOYSTICK::FEATURE_TYPE::RELPOINTER);
+  EXPECT_EQ(GetPointerType(MOUSE::POINTER_DIRECTION::LEFT, controller),
+            JOYSTICK::FEATURE_TYPE::RELPOINTER);
+  EXPECT_EQ(GetPointerType(MOUSE::POINTER_DIRECTION::NONE, controller),
+            JOYSTICK::FEATURE_TYPE::UNKNOWN);
+}

--- a/xbmc/input/keyboard/generic/CMakeLists.txt
+++ b/xbmc/input/keyboard/generic/CMakeLists.txt
@@ -1,5 +1,7 @@
-set(SOURCES KeyboardInputHandling.cpp)
+set(SOURCES DefaultKeyboardHandling.cpp
+            KeyboardInputHandling.cpp)
 
-set(HEADERS KeyboardInputHandling.h)
+set(HEADERS DefaultKeyboardHandling.h
+            KeyboardInputHandling.h)
 
 core_add_library(input_keyboard_generic)

--- a/xbmc/input/keyboard/generic/DefaultKeyboardHandling.cpp
+++ b/xbmc/input/keyboard/generic/DefaultKeyboardHandling.cpp
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "DefaultKeyboardHandling.h"
+
+#include "KeyboardInputHandling.h"
+#include "games/controllers/input/DefaultButtonMap.h"
+#include "input/keyboard/interfaces/IKeyboardInputHandler.h"
+
+#include <memory>
+
+using namespace KODI;
+using namespace KEYBOARD;
+
+CDefaultKeyboardHandling::CDefaultKeyboardHandling(PERIPHERALS::CPeripheral* peripheral,
+                                                   IKeyboardInputHandler* handler)
+  : m_peripheral(peripheral), m_inputHandler(handler)
+{
+}
+
+CDefaultKeyboardHandling::~CDefaultKeyboardHandling(void)
+{
+  m_driverHandler.reset();
+  m_buttonMap.reset();
+}
+
+bool CDefaultKeyboardHandling::Load()
+{
+  std::string controllerId;
+  if (m_inputHandler != nullptr)
+    controllerId = m_inputHandler->ControllerID();
+
+  if (!controllerId.empty())
+    m_buttonMap = std::make_unique<GAME::CDefaultButtonMap>(m_peripheral, std::move(controllerId));
+
+  if (m_buttonMap && m_buttonMap->Load())
+  {
+    m_driverHandler = std::make_unique<CKeyboardInputHandling>(m_inputHandler, m_buttonMap.get());
+    return true;
+  }
+
+  return false;
+}
+
+bool CDefaultKeyboardHandling::OnKeyPress(const CKey& key)
+{
+  if (m_driverHandler)
+    return m_driverHandler->OnKeyPress(key);
+
+  return false;
+}
+
+void CDefaultKeyboardHandling::OnKeyRelease(const CKey& key)
+{
+  if (m_driverHandler)
+    m_driverHandler->OnKeyRelease(key);
+}

--- a/xbmc/input/keyboard/generic/DefaultKeyboardHandling.h
+++ b/xbmc/input/keyboard/generic/DefaultKeyboardHandling.h
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "input/keyboard/interfaces/IKeyboardDriverHandler.h"
+
+#include <memory>
+
+namespace PERIPHERALS
+{
+class CPeripheral;
+} // namespace PERIPHERALS
+
+namespace KODI
+{
+namespace JOYSTICK
+{
+class IButtonMap;
+} // namespace JOYSTICK
+
+namespace KEYBOARD
+{
+class IKeyboardInputHandler;
+
+class CDefaultKeyboardHandling : public IKeyboardDriverHandler
+{
+public:
+  CDefaultKeyboardHandling(PERIPHERALS::CPeripheral* peripheral, IKeyboardInputHandler* handler);
+
+  ~CDefaultKeyboardHandling() override;
+
+  bool Load();
+
+  // Implementation of IKeyboardDriverHandler
+  bool OnKeyPress(const CKey& key) override;
+  void OnKeyRelease(const CKey& key) override;
+
+private:
+  // Construction parameters
+  PERIPHERALS::CPeripheral* const m_peripheral;
+  IKeyboardInputHandler* const m_inputHandler;
+
+  // Input parameters
+  std::unique_ptr<IKeyboardDriverHandler> m_driverHandler;
+  std::unique_ptr<JOYSTICK::IButtonMap> m_buttonMap;
+};
+} // namespace KEYBOARD
+} // namespace KODI

--- a/xbmc/input/mouse/generic/CMakeLists.txt
+++ b/xbmc/input/mouse/generic/CMakeLists.txt
@@ -1,5 +1,7 @@
-set(SOURCES MouseInputHandling.cpp)
+set(SOURCES DefaultMouseHandling.cpp
+            MouseInputHandling.cpp)
 
-set(HEADERS MouseInputHandling.h)
+set(HEADERS DefaultMouseHandling.h
+            MouseInputHandling.h)
 
 core_add_library(input_mouse_generic)

--- a/xbmc/input/mouse/generic/DefaultMouseHandling.cpp
+++ b/xbmc/input/mouse/generic/DefaultMouseHandling.cpp
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "DefaultMouseHandling.h"
+
+#include "MouseInputHandling.h"
+#include "games/controllers/input/DefaultButtonMap.h"
+#include "input/mouse/interfaces/IMouseInputHandler.h"
+
+using namespace KODI;
+using namespace MOUSE;
+
+CDefaultMouseHandling::CDefaultMouseHandling(PERIPHERALS::CPeripheral* peripheral,
+                                             IMouseInputHandler* handler)
+  : m_peripheral(peripheral), m_inputHandler(handler)
+{
+}
+
+CDefaultMouseHandling::~CDefaultMouseHandling(void)
+{
+  m_driverHandler.reset();
+  m_buttonMap.reset();
+}
+
+bool CDefaultMouseHandling::Load()
+{
+  std::string controllerId;
+  if (m_inputHandler != nullptr)
+    controllerId = m_inputHandler->ControllerID();
+
+  if (!controllerId.empty())
+    m_buttonMap = std::make_unique<GAME::CDefaultButtonMap>(m_peripheral, std::move(controllerId));
+
+  if (m_buttonMap && m_buttonMap->Load())
+  {
+    m_driverHandler = std::make_unique<CMouseInputHandling>(m_inputHandler, m_buttonMap.get());
+    return true;
+  }
+
+  return false;
+}
+
+bool CDefaultMouseHandling::OnPosition(int x, int y)
+{
+  if (m_driverHandler)
+    return m_driverHandler->OnPosition(x, y);
+
+  return false;
+}
+
+bool CDefaultMouseHandling::OnButtonPress(BUTTON_ID button)
+{
+  if (m_driverHandler)
+    return m_driverHandler->OnButtonPress(button);
+
+  return false;
+}
+
+void CDefaultMouseHandling::OnButtonRelease(BUTTON_ID button)
+{
+  if (m_driverHandler)
+    m_driverHandler->OnButtonRelease(button);
+}

--- a/xbmc/input/mouse/generic/DefaultMouseHandling.h
+++ b/xbmc/input/mouse/generic/DefaultMouseHandling.h
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "input/mouse/interfaces/IMouseDriverHandler.h"
+
+#include <memory>
+
+namespace PERIPHERALS
+{
+class CPeripheral;
+} // namespace PERIPHERALS
+
+namespace KODI
+{
+namespace JOYSTICK
+{
+class IButtonMap;
+} // namespace JOYSTICK
+
+namespace MOUSE
+{
+class IMouseInputHandler;
+
+class CDefaultMouseHandling : public IMouseDriverHandler
+{
+public:
+  CDefaultMouseHandling(PERIPHERALS::CPeripheral* peripheral, IMouseInputHandler* handler);
+
+  ~CDefaultMouseHandling() override;
+
+  bool Load();
+
+  // Implementation of IMouseDriverHandler
+  bool OnPosition(int x, int y) override;
+  bool OnButtonPress(BUTTON_ID button) override;
+  void OnButtonRelease(BUTTON_ID button) override;
+
+private:
+  // Construction parameters
+  PERIPHERALS::CPeripheral* const m_peripheral;
+  IMouseInputHandler* const m_inputHandler;
+
+  // Input parameters
+  std::unique_ptr<IMouseDriverHandler> m_driverHandler;
+  std::unique_ptr<JOYSTICK::IButtonMap> m_buttonMap;
+};
+} // namespace MOUSE
+} // namespace KODI

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -14,6 +14,8 @@
 #include "games/controllers/ControllerLayout.h"
 #include "guilib/LocalizeStrings.h"
 #include "input/joysticks/interfaces/IInputHandler.h"
+#include "input/keyboard/generic/DefaultKeyboardHandling.h"
+#include "input/mouse/generic/DefaultMouseHandling.h"
 #include "peripherals/Peripherals.h"
 #include "peripherals/addons/AddonButtonMapping.h"
 #include "peripherals/addons/AddonInputHandling.h"
@@ -642,6 +644,14 @@ void CPeripheral::RegisterKeyboardHandler(KEYBOARD::IKeyboardInputHandler* handl
       CLog::Log(LOGDEBUG, "Failed to locate add-on for \"{}\"", m_strLocation);
     }
 
+    if (!keyboardDriverHandler)
+    {
+      std::unique_ptr<KODI::KEYBOARD::CDefaultKeyboardHandling> defaultInput =
+          std::make_unique<KODI::KEYBOARD::CDefaultKeyboardHandling>(this, handler);
+      if (defaultInput->Load())
+        keyboardDriverHandler = std::move(defaultInput);
+    }
+
     if (keyboardDriverHandler)
     {
       RegisterKeyboardDriverHandler(keyboardDriverHandler.get(), bPromiscuous);
@@ -678,6 +688,14 @@ void CPeripheral::RegisterMouseHandler(MOUSE::IMouseInputHandler* handler, bool 
     else
     {
       CLog::Log(LOGDEBUG, "Failed to locate add-on for \"{}\"", m_strLocation);
+    }
+
+    if (!mouseDriverHandler)
+    {
+      std::unique_ptr<KODI::MOUSE::CDefaultMouseHandling> defaultInput =
+          std::make_unique<KODI::MOUSE::CDefaultMouseHandling>(this, handler);
+      if (defaultInput->Load())
+        mouseDriverHandler = std::move(defaultInput);
     }
 
     if (mouseDriverHandler)


### PR DESCRIPTION
## Description

This PR provides buttonmaps for the default keyboard and mouse controllers to allow for keyboard/mouse input without peripheral.joystick installed or enabled.

The first three commits are renames/refactors with no functional change.

The final commit provides the default buttonmaps, and includes test cases to make sure they are correct. The test cases actually caught a bug in the existing code where the left/right meta keys were swapped.

## Motivation and context

When testing the keyboard and mouse added to the Player Viewer in https://github.com/xbmc/xbmc/pull/24406, I noticed that when peripheral.joystick was disabled, there was no keyboard/mouse input.

## How has this been tested?

* Compiles successfully on Windows/Ubuntu/macOS.
* Two new test files were added, both pass tests.
* Brief runtime testing confirmed that keyboard/mouse work without peripheral.joystick.

Included in my latest round of test builds: https://github.com/garbear/xbmc/releases

## What is the effect on users?

* Fixed keyboard/mouse input in game if peripheral.joystick isn't present

## Screenshots (if appropriate):

![screenshot00004](https://github.com/xbmc/xbmc/assets/531482/89475516-c547-4902-b1d3-9efbc14468c7)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
