### PR TITLE
[Joysticks] Fix broken focus on emulated analog stick

### DIFF
--- a/xbmc/input/joysticks/generic/FeatureHandling.cpp
+++ b/xbmc/input/joysticks/generic/FeatureHandling.cpp
@@ -438,10 +438,6 @@ void CAnalogStick::ProcessMotions(void)
   const float newHorizState = m_horizAxis.GetPosition();
 
   const bool bActivated = (newVertState != 0.0f || newHorizState != 0.0f);
-
-  if (!AcceptsInput(bActivated))
-    return;
-
   const bool bWasActivated = (m_vertState != 0.0f || m_horizState != 0.0f);
 
   if (bActivated ^ bWasActivated)


### PR DESCRIPTION
## Description

This PR's a simple one. Clearly some old use case, in the 9 year history of this code, was causing the game to see input when it shouldn't. I added a few checks for input "acceptance", but it seems like I added one-to-many. It can't hurt for the game to not not get input, and it clearly breaks analog sticks in the screenshots below, so disable the check here.

## Motivation and context

This check is called later on, so the redunant call here can cause input to be unnecessarily dropped.

## How has this been tested?

Runtime tested on Windows and Ubuntu 22.04. Will include in test builds.

## Screenshots (if appropriate):

Before: Actual peripheral is highlighted, but game port isn't getting activated.

![Screenshot from 2024-01-15 01-01-48](https://github.com/xbmc/xbmc/assets/531482/4956d5c6-a1a5-4917-9cfe-a92550c4821b)

After: Game port is successfully activated.

![Screenshot from 2024-01-15 01-01-05](https://github.com/xbmc/xbmc/assets/531482/f7f8e2d1-2dcf-4b52-94a1-0b241fd48c24)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
