### PR TITLE
[Estuary] Refactor of poster/widget overlay icons

### DIFF
--- a/addons/skin.estuary/xml/Includes_Home.xml
+++ b/addons/skin.estuary/xml/Includes_Home.xml
@@ -496,7 +496,7 @@
 							<top>30</top>
 							<width>32</width>
 							<height>32</height>
-							<texture>$VAR[WallWatchedIconVar]</texture>
+							<texture>$VAR[ItemStatusIconVar]</texture>
 						</control>
 						<control type="progress">
 							<left>20</left>
@@ -597,7 +597,7 @@
 							<top>30</top>
 							<width>32</width>
 							<height>32</height>
-							<texture>$VAR[WallWatchedIconVar]</texture>
+							<texture>$VAR[ItemStatusIconVar]</texture>
 						</control>
 						<control type="progress">
 							<left>20</left>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -473,17 +473,20 @@
 		<value condition="!String.IsEmpty(ListItem.Overlay)">$INFO[ListItem.Overlay]</value>
 		<value condition="!ListItem.IsParentFolder">OverlayUnwatched.png</value>
 	</variable>
-	<variable name="WallWatchedIconVar">
+	<variable name="ItemStatusIconVar">
+		<value condition="String.IsEqual(ListItem.DBtype,tvshow) | String.IsEqual(ListItem.DBtype,set) | String.IsEqual(ListItem.DBType,season)">lists/played-total.png</value>
 		<value condition="ListItem.IsRecording">windows/pvr/record.png</value>
 		<value condition="ListItem.HasReminder">icons/pvr/timers/bell.png</value>
 		<value condition="ListItem.HasTimer">icons/pvr/timers/recording.png</value>
-		<value condition="ListItem.IsCollection">overlays/set.png</value>
-		<value condition="ListItem.HasVideoVersions">overlays/versions.png</value>
 		<value condition="ListItem.IsPlaying">overlays/watched/OverlayPlaying-List.png</value>
 		<value condition="ListItem.IsResumable">overlays/watched/resume.png</value>
-		<value condition="ListItem.HasVideoExtras">overlays/extras.png</value>
 		<value condition="ListItem.HasArchive">windows/pvr/archive.png</value>
 		<value condition="Integer.IsGreater(ListItem.Playcount,0)">$INFO[ListItem.Overlay]</value>
+	</variable>
+	<variable name="ItemTypeIconVar">
+		<value condition="ListItem.IsCollection">overlays/set.png</value>
+		<value condition="ListItem.HasVideoVersions">overlays/versions.png</value>
+		<value condition="ListItem.HasVideoExtras">overlays/extras.png</value>
 	</variable>
 	<variable name="ListPVRRecordingsIconVar">
 		<value condition="ListItem.IsRecording">windows/pvr/record.png</value>

--- a/addons/skin.estuary/xml/View_51_Poster.xml
+++ b/addons/skin.estuary/xml/View_51_Poster.xml
@@ -147,19 +147,29 @@
 					<visible>!String.IsEmpty(ListItem.Art(poster))</visible>
 				</control>
 				<control type="image">
-					<left>6</left>
+					<left>10</left>
 					<top>684</top>
 					<width>32</width>
 					<height>32</height>
-					<texture>$VAR[WallWatchedIconVar]</texture>
-					<align>right</align>
+					<align>left</align>
 					<aligny>center</aligny>
+					<texture>$VAR[ItemTypeIconVar]</texture>
+				</control>
+				<control type="image">
+					<left>45</left>
+					<top>684</top>
+					<width>32</width>
+					<height>32</height>
+					<align>left</align>
+					<aligny>center</aligny>
+					<texture>overlays/extras.png</texture>
+					<visible>ListItem.HasVideoVersions + ListItem.HasVideoExtras</visible>
 				</control>
 				<control type="label">
-					<left>0</left>
-					<top>690</top>
-					<width>435</width>
-					<height>24</height>
+					<left>100</left>
+					<top>684</top>
+					<width>330</width>
+					<height>32</height>
 					<label>$VAR[WatchedStatusVar]</label>
 					<font>font20_title</font>
 					<shadowcolor>text_shadow</shadowcolor>
@@ -168,14 +178,13 @@
 					<visible>String.IsEqual(ListItem.DBtype,tvshow) | String.IsEqual(ListItem.DBtype,set) | String.IsEqual(ListItem.DBType,season)</visible>
 				</control>
 				<control type="image">
-					<left>445</left>
-					<top>690</top>
-					<width>24</width>
-					<height>24</height>
-					<texture>lists/played-total.png</texture>
+					<left>435</left>
+					<top>684</top>
+					<width>32</width>
+					<height>32</height>
+					<texture>$VAR[ItemStatusIconVar]</texture>
 					<align>right</align>
 					<aligny>center</aligny>
-					<visible>String.IsEqual(ListItem.DBtype,tvshow) | String.IsEqual(ListItem.DBtype,set) | String.IsEqual(ListItem.DBType,season)</visible>
 				</control>
 			</control>
 			<control type="progress">

--- a/addons/skin.estuary/xml/View_53_Shift.xml
+++ b/addons/skin.estuary/xml/View_53_Shift.xml
@@ -208,10 +208,29 @@
 				<texture colordiffuse="CCFFFFFF">overlays/overlayfade.png</texture>
 				<visible>!String.IsEmpty(ListItem.Art(poster))</visible>
 			</control>
-			<control type="label">
+			<control type="image">
+				<left>45</left>
+				<top>522</top>
+				<width>24</width>
+				<height>24</height>
+				<align>left</align>
+				<aligny>center</aligny>
+				<texture>$VAR[ItemTypeIconVar]</texture>
+			</control>
+			<control type="image">
 				<left>75</left>
 				<top>522</top>
-				<width>222</width>
+				<width>24</width>
+				<height>24</height>
+				<align>left</align>
+				<aligny>center</aligny>
+				<texture>overlays/extras.png</texture>
+				<visible>ListItem.HasVideoVersions + ListItem.HasVideoExtras</visible>
+			</control>
+			<control type="label">
+				<left>110</left>
+				<top>522</top>
+				<width>185</width>
 				<height>24</height>
 				<label>$VAR[WatchedStatusVar]</label>
 				<font>font20_title</font>
@@ -225,19 +244,9 @@
 				<top>522</top>
 				<width>24</width>
 				<height>24</height>
-				<texture>lists/played-total.png</texture>
+				<texture>$VAR[ItemStatusIconVar]</texture>
 				<align>right</align>
 				<aligny>center</aligny>
-				<visible>String.IsEqual(ListItem.DBtype,tvshow) | String.IsEqual(ListItem.DBtype,set) | String.IsEqual(ListItem.DBType,season)</visible>
-			</control>
-			<control type="image">
-				<left>45</left>
-				<top>522</top>
-				<width>24</width>
-				<height>24</height>
-				<align>left</align>
-				<aligny>center</aligny>
-				<texture>$VAR[WallWatchedIconVar]</texture>
 			</control>
 		</control>
 	</include>

--- a/addons/skin.estuary/xml/View_54_InfoWall.xml
+++ b/addons/skin.estuary/xml/View_54_InfoWall.xml
@@ -176,7 +176,7 @@
 				<top>175</top>
 				<width>32</width>
 				<height>32</height>
-				<texture>$VAR[WallWatchedIconVar]</texture>
+				<texture>$VAR[ItemStatusIconVar]</texture>
 			</control>
 			<control type="textbox">
 				<left>28</left>
@@ -310,16 +310,28 @@
 					<visible>!String.IsEmpty(ListItem.Art(poster))</visible>
 				</control>
 				<control type="image">
-					<left>35</left>
-					<top>353</top>
-					<width>32</width>
-					<height>32</height>
-					<texture>$VAR[WallWatchedIconVar]</texture>
+					<left>40</left>
+					<top>358</top>
+					<width>24</width>
+					<height>24</height>
+					<align>left</align>
+					<aligny>center</aligny>
+					<texture>$VAR[ItemTypeIconVar]</texture>
+				</control>
+				<control type="image">
+					<left>70</left>
+					<top>358</top>
+					<width>24</width>
+					<height>24</height>
+					<align>left</align>
+					<aligny>center</aligny>
+					<texture>overlays/extras.png</texture>
+					<visible>ListItem.HasVideoVersions + ListItem.HasVideoExtras</visible>
 				</control>
 				<control type="label">
-					<left>0</left>
+					<left>105</left>
 					<top>355</top>
-					<width>244</width>
+					<width>145</width>
 					<label>$VAR[WatchedStatusVar]</label>
 					<font>font20_title</font>
 					<shadowcolor>text_shadow</shadowcolor>
@@ -331,8 +343,7 @@
 					<top>358</top>
 					<width>24</width>
 					<height>24</height>
-					<texture>lists/played-total.png</texture>
-					<visible>String.IsEqual(ListItem.DBtype,tvshow) | String.IsEqual(ListItem.DBtype,set) | String.IsEqual(ListItem.DBType,season)</visible>
+					<texture>$VAR[ItemStatusIconVar]</texture>
 				</control>
 			</control>
 			<control type="group">


### PR DESCRIPTION
## Description
Split the previous Variable `WallWatchedIconVar` into more logical chunks.

## Motivation and context

Item type icons and the watched status was previously mixed together within  `WallWatchedIconVar`. With this both Item type icons and the watched status can always be seen seperately at the same time. In addition this allows the Extras icon to be displayed if an item also has versions.

## How has this been tested?
Tried all poster views.

## What is the effect on users?
A consistent display of overlay icons across all views with use a poster.

The bottom left corner is now an area to display icons idicating item type.

The bottom right corner is now always item status, so is it playing, in progress, watched.

## Screenshots (if appropriate):
**Before**
Watched status not always shown
Extras icon not shown if there are Versions
![image](https://github.com/xbmc/xbmc/assets/5781142/5fdfde4b-8ae1-4508-81a3-83eefe814bb0)

**After**
![image](https://github.com/xbmc/xbmc/assets/5781142/753b2ce2-af60-4be3-bef1-7ebf0065fba4)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
