### PR TITLE
[Datacachecore] Initiallize SStateInfo with sane values

### DIFF
--- a/xbmc/cores/DataCacheCore.h
+++ b/xbmc/cores/DataCacheCore.h
@@ -312,12 +312,12 @@ protected:
   bool m_playerStateChanged = false;
   struct SStateInfo
   {
-    bool m_stateSeeking;
-    bool m_renderGuiLayer;
-    bool m_renderVideoLayer;
-    float m_tempo;
-    float m_speed;
-    bool m_frameAdvance;
+    bool m_stateSeeking{false};
+    bool m_renderGuiLayer{false};
+    bool m_renderVideoLayer{false};
+    float m_tempo{1.0f};
+    float m_speed{1.0f};
+    bool m_frameAdvance{false};
     /*! Time point of the last seek operation */
     std::chrono::time_point<std::chrono::system_clock> m_lastSeekTime{
         std::chrono::time_point<std::chrono::system_clock>{}};


### PR DESCRIPTION
## Description
This is a regression caused by https://github.com/xbmc/xbmc/pull/24402/commits/03e1badf7389310b2c54e5241cdd4b08c15070f6. By initializing the sstateinfo struct with the default values on reset, it made it explicit that the struct members are not being initialised with sane values. This moves the logic that was there before on reset (setting the members one by one) to the initialization of the struct instead.

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/24517#issuecomment-1894217509

## How has this been tested?
Runtime tested with the music library

## What is the effect on users?
Paplayer should have state playing (speed = 1.0) again in the info interface (and GUI)
