### PR TITLE
EGLUtils: Fix nullptr usage in EglErrorCallback

### DIFF
--- a/xbmc/utils/EGLUtils.cpp
+++ b/xbmc/utils/EGLUtils.cpp
@@ -115,7 +115,8 @@ void EglErrorCallback(EGLenum error,
     typeStr = eglType->second;
   }
 
-  CLog::Log(LOGDEBUG, "EGL Debugging:\nError: {}\nCommand: {}\nType: {}\nMessage: {}", errorStr, command, typeStr, message);
+  CLog::Log(LOGDEBUG, "EGL Debugging:\nError: {}\nCommand: {}\nType: {}\nMessage: {}", errorStr,
+            command, typeStr, message ? message : "");
 }
 
 std::set<std::string> CEGLUtils::GetClientExtensions()


### PR DESCRIPTION
## Description
The message passed to the EGL error callback can be NULL according to the [specification](https://registry.khronos.org/EGL/extensions/KHR/EGL_KHR_debug.txt):

```
The callback will receive the following in its parameters:

[...]
        <message> will contain a platform specific debug string message;
        This string should provide added information to the application
        developer regarding the condition that generated the message.
        The format of a message is implementation-defined, although it should
        represent a concise description of the event that caused the message
        to be generated. Message strings can be NULL and should not be assumed
        otherwise.
```

## Motivation and context
Fixes #23867.

## How has this been tested?
Only tested compilation.

## What is the effect on users?
No crash if an implementation doesn't supply a `message`.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
