### PR TITLE
[video] rework dimensions

### DIFF
--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -582,14 +582,15 @@ std::string CStreamDetails::VideoDimsToResolutionDescription(int iWidth, int iHe
   if (iWidth == 0 || iHeight == 0)
     return "";
 
-  else if (iWidth <= 720 && iHeight <= 480)
+  // Anamorphic NTSC DVD
+  else if (iWidth <= 854 && iHeight <= 480)
     return "480";
-  // 720x576 (PAL) (768 when rescaled for square pixels)
-  else if (iWidth <= 768 && iHeight <= 576)
-    return "576";
   // 960x540 (sometimes 544 which is multiple of 16)
   else if (iWidth <= 960 && iHeight <= 544)
     return "540";
+  // includes 768x576, 720x576 and 1024x576
+  else if (iWidth <= 1024 && iHeight <= 576)
+    return "576";
   // 1280x720
   else if (iWidth <= 1280 && iHeight <= 962)
     return "720";


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

I'm not too sure about this PR and if it's correct or not or if something might be missing. But I would like to suggest we might think about it. 

Starting point is, that if I have a video in a resolution of 1024*576 Kodi will interpret that as a "HD Video" and will show "720" as a flag. 

Due to its definition a video from a DVD (in thinking of a SD video) has a maximum resolution of 720*576 and has a SAR (Storage Aspect Ratio) of 5:4 and may have a DAR (Display Aspect Ratio) of either 4:3 or 16:9.

Please see: https://de.wikipedia.org/wiki/Standard_Definition_Television (sorry, for the link in german, but I couldn't find anything else which is as informative as that). 

From the same link, also 1024*576 is mentioned which has a SAR of 16:9 and a DAR of 16:9 as well. Hence it's mentioned as "PAL-wide". 

Videos in `1024*576` aren't HD-videos. HD videos start with 720p which is at least `960*720`. As the current logic in our code considers the width first and then the height if the condition of the width matches, and (imho) we're missing a step between, we currently show SD videos as HD videos and present "720" which is not correct, from my point of view.  

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://forum.kodi.tv/showthread.php?tid=375804&pid=3180016#pid3180016

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I asked the user of the mentioned thread to provide a snippet to be able to test with. I'll comment with screenshots after I've tested it. 

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

SD videos in PAL-wide (1024*576) are represented correctly as "576" or "SD" and not in "720" or "HD"

## Screenshots (if appropriate):

TBD

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
