### PR TITLE
[PVR] "Play EPG Tags as Movies"

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -11620,13 +11620,25 @@ msgctxt "#19349"
 msgid "User preference"
 msgstr ""
 
-#. label for PVR settings use backend channel group order control
+#. label for PVR setting use backend channel group order control
 #: system/settings/settings.xml
 msgctxt "#19350"
 msgid "Use channel group order from backend(s)"
 msgstr ""
 
-#empty strings from id 19351 to 19498
+#. label for PVR settings category for live tv catchup and video on demand
+#: system/settings/settings.xml
+msgctxt "#19351"
+msgid "Catchup / Video On Demand"
+msgstr ""
+
+#. label for PVR setting play next programme automatically in catchup / vod mode
+#: system/settings/settings.xml
+msgctxt "#19352"
+msgid "Play next programme automatically"
+msgstr ""
+
+#empty strings from id 19353 to 19498
 
 #. label for epg genre value
 #: xbmc/pvr/epg/Epg.cpp
@@ -21052,7 +21064,13 @@ msgctxt "#36438"
 msgid "Any repositories"
 msgstr ""
 
-#empty strings from id 36439 to 36441
+#. Description of setting with label #19352 "Play next programme automatically"
+#: system/settings/settings.xml
+msgctxt "#36439"
+msgid "Enable automatic playback of the next programme when playing past programmes (catchup) or for Video On Demand (VOD) channels. Please note that catchup and VOD only work if supported by the channel provider."
+msgstr ""
+
+#empty strings from id 36440 to 36441
 
 #. Description of setting "System -> Audio output -> Volume control steps" with label #1302
 #: system/settings/settings.xml

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -11638,7 +11638,19 @@ msgctxt "#19352"
 msgid "Play next programme automatically"
 msgstr ""
 
-#empty strings from id 19353 to 19498
+#. Label of a context menu entry to kick catchup / VOD playback, starting with the selected item, auto playing all following programmes
+#: xbmc/pvr/PVRContextMenuItem.cpp
+msgctxt "#19353"
+msgid "Play programmes from here"
+msgstr ""
+
+#. Label of a context menu entry to kick catchup / VOD playback of only the selected item, not auto playing any following programmes
+#: xbmc/pvr/PVRContextMenuItem.cpp
+msgctxt "#19354"
+msgid "Play only this programme"
+msgstr ""
+
+#empty strings from id 19355 to 19498
 
 #. label for epg genre value
 #: xbmc/pvr/epg/Epg.cpp

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1861,7 +1861,14 @@
           <control type="list" format="string" />
         </setting>
       </group>
-      <group id="2" label="14304">
+      <group id="2" label="19351">
+        <setting id="pvrplayback.autoplaynextprogramme" type="boolean" label="19352" help="36439">
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+      <group id="3" label="14304">
         <setting id="pvrplayback.enableradiords" type="boolean" label="29980" help="29981">
           <level>1</level>
           <default>true</default>

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -2930,11 +2930,20 @@ bool CApplication::OnMessage(CGUIMessage& message)
       PlayFile(stackHelper->SetNextStackPartCurrentFileItem(), "", true);
       return true;
     }
-    ResetCurrentItem();
-    if (!CServiceBroker::GetPlaylistPlayer().PlayNext(1, true))
-      GetComponent<CApplicationPlayer>()->ClosePlayer();
 
-    PlaybackCleanup();
+    // For EPG playlist items we keep the player open to ensure continuous viewing experience.
+    const bool isEpgPlaylistItem{
+        m_itemCurrentFile->GetProperty("epg_playlist_item").asBoolean(false)};
+
+    ResetCurrentItem();
+
+    if (!isEpgPlaylistItem)
+    {
+      if (!CServiceBroker::GetPlaylistPlayer().PlayNext(1, true))
+        GetComponent<CApplicationPlayer>()->ClosePlayer();
+
+      PlaybackCleanup();
+    }
 
 #ifdef HAS_PYTHON
     CServiceBroker::GetXBPython().OnPlayBackEnded();

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -850,7 +850,11 @@ void CPVRManager::OnPlaybackStopped(const CFileItem& item)
 void CPVRManager::OnPlaybackEnded(const CFileItem& item)
 {
   // Playback ended, but not due to user interaction
-  OnPlaybackStopped(item);
+  if (m_playbackState->OnPlaybackEnded(item))
+    PublishEvent(PVREvent::ChannelPlaybackStopped);
+
+  Get<PVR::GUI::Channels>().OnPlaybackStopped(item);
+  m_epgContainer->OnPlaybackStopped();
 }
 
 void CPVRManager::LocalizationChanged()

--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -283,10 +283,10 @@ bool CPVRPlaybackState::OnPlaybackStopped(const CFileItem& item)
   return bChanged;
 }
 
-void CPVRPlaybackState::OnPlaybackEnded(const CFileItem& item)
+bool CPVRPlaybackState::OnPlaybackEnded(const CFileItem& item)
 {
   // Playback ended, but not due to user interaction
-  OnPlaybackStopped(item);
+  return OnPlaybackStopped(item);
 }
 
 bool CPVRPlaybackState::IsPlaying() const

--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -365,7 +365,10 @@ void CPVRPlaybackState::StartPlayback(CFileItem* item) const
     else if (item->IsEPG())
     {
       client->GetEpgTagStreamProperties(item->GetEPGInfoTag(), props);
-      item->SetProperty("epg_playlist_item", true);
+
+      if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+              CSettings::SETTING_PVRPLAYBACK_AUTOPLAYNEXTPROGRAMME))
+        item->SetProperty("epg_playlist_item", true);
     }
 
     if (props.size())

--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -346,7 +346,9 @@ bool CPVRPlaybackState::OnPlaybackEnded(const CFileItem& item)
   return OnPlaybackStopped(item);
 }
 
-void CPVRPlaybackState::StartPlayback(CFileItem* item) const
+void CPVRPlaybackState::StartPlayback(
+    CFileItem* item,
+    ContentUtils::PlayMode mode /* = ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM */) const
 {
   // Obtain dynamic playback url and properties from the respective pvr client
   const std::shared_ptr<const CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(*item);
@@ -366,9 +368,16 @@ void CPVRPlaybackState::StartPlayback(CFileItem* item) const
     {
       client->GetEpgTagStreamProperties(item->GetEPGInfoTag(), props);
 
-      if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-              CSettings::SETTING_PVRPLAYBACK_AUTOPLAYNEXTPROGRAMME))
+      if (mode == ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM)
+      {
+        if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                CSettings::SETTING_PVRPLAYBACK_AUTOPLAYNEXTPROGRAMME))
+          item->SetProperty("epg_playlist_item", true);
+      }
+      else if (mode == ContentUtils::PlayMode::PLAY_FROM_HERE)
+      {
         item->SetProperty("epg_playlist_item", true);
+      }
     }
 
     if (props.size())

--- a/xbmc/pvr/PVRPlaybackState.h
+++ b/xbmc/pvr/PVRPlaybackState.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "threads/CriticalSection.h"
+#include "utils/ContentUtils.h"
 
 #include <memory>
 #include <string>
@@ -71,8 +72,11 @@ public:
   /*!
    * @brief Start playback of the given item.
    * @param item containing a channel, a recording or an epg tag.
+   * @param mode playback mode.
    */
-  void StartPlayback(CFileItem* item) const;
+  void StartPlayback(
+      CFileItem* item,
+      ContentUtils::PlayMode mode = ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM) const;
 
   /*!
    * @brief Check if a TV channel, radio channel or recording is playing.

--- a/xbmc/pvr/PVRPlaybackState.h
+++ b/xbmc/pvr/PVRPlaybackState.h
@@ -23,6 +23,7 @@ class CPVRChannelGroup;
 class CPVRChannelGroupMember;
 class CPVREpgInfoTag;
 class CPVRRecording;
+class CPVRStreamProperties;
 
 class CPVRPlaybackState
 {
@@ -66,6 +67,12 @@ public:
    * @return True, if the state has changed, false otherwise
    */
   bool OnPlaybackEnded(const CFileItem& item);
+
+  /*!
+   * @brief Start playback of the given item.
+   * @param item containing a channel, a recording or an epg tag.
+   */
+  void StartPlayback(CFileItem* item) const;
 
   /*!
    * @brief Check if a TV channel, radio channel or recording is playing.

--- a/xbmc/pvr/PVRPlaybackState.h
+++ b/xbmc/pvr/PVRPlaybackState.h
@@ -254,6 +254,13 @@ private:
   void ClearData();
 
   /*!
+   * @brief Return the next item to play automatically, if any.
+   * @param item The item which just finished playback.
+   * @return The item to play next, if any, nullptr otherwise.
+   */
+  std::unique_ptr<CFileItem> GetNextAutoplayItem(const CFileItem& item);
+
+  /*!
    * @brief Set the active group to the group of the supplied channel group member.
    * @param channel The channel group member
    */

--- a/xbmc/pvr/PVRPlaybackState.h
+++ b/xbmc/pvr/PVRPlaybackState.h
@@ -63,8 +63,9 @@ public:
   /*!
    * @brief Inform that playback of an item has stopped without user interaction.
    * @param item The item that ended to play.
+   * @return True, if the state has changed, false otherwise
    */
-  void OnPlaybackEnded(const CFileItem& item);
+  bool OnPlaybackEnded(const CFileItem& item);
 
   /*!
    * @brief Check if a TV channel, radio channel or recording is playing.

--- a/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
@@ -187,7 +187,9 @@ bool CPVRGUIActionsPlayback::PlayRecordingFolder(const CFileItem& item, bool bCh
   return true;
 }
 
-bool CPVRGUIActionsPlayback::PlayEpgTag(const CFileItem& item) const
+bool CPVRGUIActionsPlayback::PlayEpgTag(
+    const CFileItem& item,
+    ContentUtils::PlayMode mode /* = ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM */) const
 {
   const std::shared_ptr<CPVREpgInfoTag> epgTag(CPVRItem(item).GetEpgInfoTag());
   if (!epgTag)
@@ -225,7 +227,7 @@ bool CPVRGUIActionsPlayback::PlayEpgTag(const CFileItem& item) const
     itemToPlay = new CFileItem(epgTag);
   }
 
-  CServiceBroker::GetPVRManager().PlaybackState()->StartPlayback(itemToPlay);
+  CServiceBroker::GetPVRManager().PlaybackState()->StartPlayback(itemToPlay, mode);
   CheckAndSwitchToFullscreen(true);
   return true;
 }

--- a/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
@@ -108,59 +108,6 @@ void CPVRGUIActionsPlayback::CheckAndSwitchToFullscreen(bool bFullscreen) const
   }
 }
 
-void CPVRGUIActionsPlayback::StartPlayback(CFileItem* item,
-                                           bool bFullscreen,
-                                           const CPVRStreamProperties* epgProps) const
-{
-  // Obtain dynamic playback url and properties from the respective pvr client
-  const std::shared_ptr<const CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(*item);
-  if (client)
-  {
-    CPVRStreamProperties props;
-
-    if (item->IsPVRChannel())
-    {
-      // If this was an EPG Tag to be played as live then PlayEpgTag() will create a channel
-      // fileitem instead and pass the epg tags props so we use those and skip the client call
-      if (epgProps)
-        props = *epgProps;
-      else
-        client->GetChannelStreamProperties(item->GetPVRChannelInfoTag(), props);
-    }
-    else if (item->IsPVRRecording())
-    {
-      client->GetRecordingStreamProperties(item->GetPVRRecordingInfoTag(), props);
-    }
-    else if (item->IsEPG())
-    {
-      if (epgProps) // we already have props from PlayEpgTag()
-        props = *epgProps;
-      else
-        client->GetEpgTagStreamProperties(item->GetEPGInfoTag(), props);
-    }
-
-    if (props.size())
-    {
-      const std::string url = props.GetStreamURL();
-      if (!url.empty())
-        item->SetDynPath(url);
-
-      const std::string mime = props.GetStreamMimeType();
-      if (!mime.empty())
-      {
-        item->SetMimeType(mime);
-        item->SetContentLookup(false);
-      }
-
-      for (const auto& prop : props)
-        item->SetProperty(prop.first, prop.second);
-    }
-  }
-
-  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_PLAY, 0, 0, static_cast<void*>(item));
-  CheckAndSwitchToFullscreen(bFullscreen);
-}
-
 bool CPVRGUIActionsPlayback::PlayRecording(const CFileItem& item, bool bCheckResume) const
 {
   const std::shared_ptr<CPVRRecording> recording(CPVRItem(item).GetRecording());
@@ -209,14 +156,14 @@ bool CPVRGUIActionsPlayback::PlayRecording(const CFileItem& item, bool bCheckRes
 
       CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_PLAY, pos, -1,
                                                  static_cast<void*>(queuedItems.release()));
-      CheckAndSwitchToFullscreen(true);
     }
     else
     {
       CFileItem* itemToPlay = new CFileItem(recording);
       itemToPlay->SetStartOffset(item.GetStartOffset());
-      StartPlayback(itemToPlay, true);
+      CServiceBroker::GetPVRManager().PlaybackState()->StartPlayback(itemToPlay);
     }
+    CheckAndSwitchToFullscreen(true);
   }
   return true;
 }
@@ -278,7 +225,8 @@ bool CPVRGUIActionsPlayback::PlayEpgTag(const CFileItem& item) const
     itemToPlay = new CFileItem(epgTag);
   }
 
-  StartPlayback(itemToPlay, true, &props);
+  CServiceBroker::GetPVRManager().PlaybackState()->StartPlayback(itemToPlay);
+  CheckAndSwitchToFullscreen(true);
   return true;
 }
 
@@ -360,7 +308,8 @@ bool CPVRGUIActionsPlayback::SwitchToChannel(const CFileItem& item, bool bCheckR
     if (!groupMember)
       return false;
 
-    StartPlayback(new CFileItem(groupMember), bFullscreen);
+    CServiceBroker::GetPVRManager().PlaybackState()->StartPlayback(new CFileItem(groupMember));
+    CheckAndSwitchToFullscreen(bFullscreen);
     return true;
   }
   else if (result == ParentalCheckResult::FAILED)

--- a/xbmc/pvr/guilib/PVRGUIActionsPlayback.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsPlayback.h
@@ -10,6 +10,7 @@
 
 #include "pvr/IPVRComponent.h"
 #include "pvr/settings/PVRSettings.h"
+#include "utils/ContentUtils.h"
 
 #include <string>
 
@@ -58,9 +59,12 @@ public:
   /*!
    * @brief Play EPG tag.
    * @param item containing an epg tag.
+   * @param mode playback mode.
    * @return true on success, false otherwise.
    */
-  bool PlayEpgTag(const CFileItem& item) const;
+  bool PlayEpgTag(
+      const CFileItem& item,
+      ContentUtils::PlayMode mode = ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM) const;
 
   /*!
    * @brief Switch channel.

--- a/xbmc/pvr/guilib/PVRGUIActionsPlayback.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsPlayback.h
@@ -24,8 +24,6 @@ enum PlaybackType
   PlaybackTypeRadio
 };
 
-class CPVRStreamProperties;
-
 class CPVRGUIActionsPlayback : public IPVRComponent
 {
 public:
@@ -127,16 +125,6 @@ private:
    * @param bFullscreen switch to fullscreen or set windowed playback.
    */
   void CheckAndSwitchToFullscreen(bool bFullscreen) const;
-
-  /*!
-   * @brief Start playback of the given item.
-   * @param bFullscreen start playback fullscreen or not.
-   * @param epgProps properties to be used instead of calling to the client if supplied.
-   * @param item containing a channel or a recording.
-   */
-  void StartPlayback(CFileItem* item,
-                     bool bFullscreen,
-                     const CPVRStreamProperties* epgProps = nullptr) const;
 
   CPVRSettings m_settings;
 };

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -223,6 +223,8 @@ public:
   static constexpr auto SETTING_PVRPLAYBACK_DELAYMARKLASTWATCHED =
       "pvrplayback.delaymarklastwatched";
   static constexpr auto SETTING_PVRPLAYBACK_FPS = "pvrplayback.fps";
+  static constexpr auto SETTING_PVRPLAYBACK_AUTOPLAYNEXTPROGRAMME =
+      "pvrplayback.autoplaynextprogramme";
   static constexpr auto SETTING_PVRRECORD_INSTANTRECORDACTION = "pvrrecord.instantrecordaction";
   static constexpr auto SETTING_PVRRECORD_INSTANTRECORDTIME = "pvrrecord.instantrecordtime";
   static constexpr auto SETTING_PVRRECORD_MARGINSTART = "pvrrecord.marginstart";


### PR DESCRIPTION
This PR implements a feature requested several times in the forum: In catchup or VOD mode, to be able to automatically start playback of next EPG programme entry in channel's timeline once playback of  an EPG programme entry has finished, given that the feature to catchup programmes or EPG entries as VOD is supported by your PVR client add-on.

Behavior can be controlled using a new setting:

![screenshot00003](https://github.com/xbmc/xbmc/assets/3226626/e3151108-74f3-4614-9568-40d913c1d711)

A new context menu item ensures that it is always possible to either play a single EPG programme entry or start a "play list", similar to what we have for normal videos. "Play programme" always behaves according to the new setting's value, the new context menu entry does exactly the "opposite" of the settings value.

![screenshot00005](https://github.com/xbmc/xbmc/assets/3226626/f600e5ed-1be4-4640-a4f8-03146728b0cd)
![screenshot00004](https://github.com/xbmc/xbmc/assets/3226626/7c342855-9a8a-4915-9b3c-547ef0552e80)

Runtime-tested in macOS and android, latest Kodi master.

@phunkyfish whenever you find time for a code review and maybe even a runtime-test.
