### PR TITLE
GL/GLES: Optimize tonemap shaders

### DIFF
--- a/system/shaders/GL/1.5/gl_tonemap.glsl
+++ b/system/shaders/GL/1.5/gl_tonemap.glsl
@@ -1,4 +1,4 @@
-#if (defined(KODI_TONE_MAPPING_REINHARD) || defined(KODI_TONE_MAPPING_ACES) || defined(KODI_TONE_MAPPING_HABLE))
+#if (defined(KODI_TONE_MAPPING_ACES) || defined(KODI_TONE_MAPPING_HABLE))
 const float ST2084_m1 = 2610.0 / (4096.0 * 4.0);
 const float ST2084_m2 = (2523.0 / 4096.0) * 128.0;
 const float ST2084_c1 = 3424.0 / 4096.0;
@@ -9,7 +9,7 @@ const float ST2084_c3 = (2392.0 / 4096.0) * 32.0;
 #if defined(KODI_TONE_MAPPING_REINHARD)
 float reinhard(float x)
 {
-  return x * (1.0 + x / (m_toneP1 * m_toneP1)) / (1.0 + x);
+  return (x * m_reinhardParam1 + 1.0) / (1.0 + x);
 }
 #endif
 
@@ -41,7 +41,8 @@ vec3 hable(vec3 x)
 #if (defined(KODI_TONE_MAPPING_ACES) || defined(KODI_TONE_MAPPING_HABLE))
 vec3 inversePQ(vec3 x)
 {
-  x = pow(max(x, 0.0), vec3(1.0 / ST2084_m2));
+  // the following line has been folded into the color conversion pow():
+  //  x = pow(max(x, 0.0), vec3(1.0 / ST2084_m2));
   x = max(x - ST2084_c1, 0.0) / (ST2084_c2 - ST2084_c3 * x);
   x = pow(x, vec3(1.0 / ST2084_m1));
   return x;

--- a/system/shaders/GL/1.5/gl_yuv2rgb_basic.glsl
+++ b/system/shaders/GL/1.5/gl_yuv2rgb_basic.glsl
@@ -15,9 +15,12 @@ uniform float m_alpha;
 uniform mat3 m_primMat;
 uniform float m_gammaDstInv;
 uniform float m_gammaSrc;
-uniform float m_toneP1;
-uniform float m_luminance;
 uniform vec3 m_coefsDst;
+uniform float m_reinhardParam1;
+uniform float m_acesParam1;
+uniform float m_acesParam2;
+uniform float m_hableParam1;
+uniform float m_hableParam2;
 in vec2 m_cordY;
 in vec2 m_cordU;
 in vec2 m_cordV;
@@ -100,20 +103,20 @@ vec4 process()
 
 #if defined(KODI_TONE_MAPPING_REINHARD)
   float luma = dot(rgb.rgb, m_coefsDst);
-  rgb.rgb *= reinhard(luma) / luma;
+  rgb.rgb *= reinhard(luma);
 
 #elif defined(KODI_TONE_MAPPING_ACES)
   rgb.rgb = inversePQ(rgb.rgb);
-  rgb.rgb *= (10000.0 / m_luminance) * (2.0 / m_toneP1);
+  rgb.rgb *= m_acesParam1;
   rgb.rgb = aces(rgb.rgb);
-  rgb.rgb *= (1.24 / m_toneP1);
+  rgb.rgb *= m_acesParam2;
   rgb.rgb = pow(rgb.rgb, vec3(0.27));
 
 #elif defined(KODI_TONE_MAPPING_HABLE)
   rgb.rgb = inversePQ(rgb.rgb);
-  rgb.rgb *= m_toneP1;
-  float wp = m_luminance / 100.0;
-  rgb.rgb = hable(rgb.rgb * wp) / hable(vec3(wp));
+  rgb.rgb *= m_hableParam1;
+  rgb.rgb = hable(rgb.rgb);
+  rgb.rgb *= m_hableParam2;
   rgb.rgb = pow(rgb.rgb, vec3(1.0 / 2.2));
 #endif
 

--- a/system/shaders/GLES/2.0/gles_tonemap.frag
+++ b/system/shaders/GLES/2.0/gles_tonemap.frag
@@ -9,7 +9,7 @@ const float ST2084_c3 = (2392.0 / 4096.0) * 32.0;
 #if defined(KODI_TONE_MAPPING_REINHARD)
 float reinhard(float x)
 {
-  return x * (1.0 + x / (m_toneP1 * m_toneP1)) / (1.0 + x);
+  return (x * m_reinhardParam1 + 1.0) / (1.0 + x);
 }
 #endif
 
@@ -41,7 +41,8 @@ vec3 hable(vec3 x)
 #if (defined(KODI_TONE_MAPPING_ACES) || defined(KODI_TONE_MAPPING_HABLE))
 vec3 inversePQ(vec3 x)
 {
-  x = pow(max(x, 0.0), vec3(1.0 / ST2084_m2));
+  // the following line has been folded into the color conversion pow():
+  //  x = pow(max(x, 0.0), vec3(1.0 / ST2084_m2));
   x = max(x - ST2084_c1, 0.0) / (ST2084_c2 - ST2084_c3 * x);
   x = pow(x, vec3(1.0 / ST2084_m1));
   return x;

--- a/system/shaders/GLES/2.0/gles_yuv2rgb_basic.frag
+++ b/system/shaders/GLES/2.0/gles_yuv2rgb_basic.frag
@@ -37,6 +37,11 @@ uniform float m_toneP1;
 uniform float m_luminance;
 uniform vec3 m_coefsDst;
 uniform float m_alpha;
+uniform float m_reinhardParam1;
+uniform float m_acesParam1;
+uniform float m_acesParam2;
+uniform float m_hableParam1;
+uniform float m_hableParam2;
 
 void main()
 {
@@ -69,20 +74,20 @@ void main()
 
 #if defined(KODI_TONE_MAPPING_REINHARD)
   float luma = dot(rgb.rgb, m_coefsDst);
-  rgb.rgb *= reinhard(luma) / luma;
+  rgb.rgb *= reinhard(luma);
 
 #elif defined(KODI_TONE_MAPPING_ACES)
   rgb.rgb = inversePQ(rgb.rgb);
-  rgb.rgb *= (10000.0 / m_luminance) * (2.0 / m_toneP1);
+  rgb.rgb *= m_acesParam1;
   rgb.rgb = aces(rgb.rgb);
-  rgb.rgb *= (1.24 / m_toneP1);
+  rgb.rgb *= m_acesParam2;
   rgb.rgb = pow(rgb.rgb, vec3(0.27));
 
 #elif defined(KODI_TONE_MAPPING_HABLE)
   rgb.rgb = inversePQ(rgb.rgb);
-  rgb.rgb *= m_toneP1;
-  float wp = m_luminance / 100.0;
-  rgb.rgb = hable(rgb.rgb * wp) / hable(vec3(wp));
+  rgb.rgb *= m_hableParam1;
+  rgb.rgb = hable(rgb.rgb);
+  rgb.rgb *= m_hableParam2;
   rgb.rgb = pow(rgb.rgb, vec3(1.0 / 2.2));
 #endif
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.cpp
@@ -13,6 +13,7 @@
 #include "ConvolutionKernels.h"
 #include "ServiceBroker.h"
 #include "ToneMappers.h"
+#include "cores/VideoSettings.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/GLUtils.h"
@@ -101,6 +102,8 @@ BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(bool rect,
       m_defines += "#define KODI_TONE_MAPPING_ACES\n";
     else if (toneMapMethod == VS_TONEMAPMETHOD_HABLE)
       m_defines += "#define KODI_TONE_MAPPING_HABLE\n";
+    else
+      m_defines += "#define KODI_TONE_MAPPING_OFF\n";
   }
 
   VertexShader()->LoadSource("gl_yuv2rgb_vertex.glsl", m_defines);
@@ -136,8 +139,12 @@ void BaseYUV2RGBGLSLShader::OnCompiledAndLinked()
   m_hGammaSrc = glGetUniformLocation(ProgramHandle(), "m_gammaSrc");
   m_hGammaDstInv = glGetUniformLocation(ProgramHandle(), "m_gammaDstInv");
   m_hCoefsDst = glGetUniformLocation(ProgramHandle(), "m_coefsDst");
-  m_hToneP1 = glGetUniformLocation(ProgramHandle(), "m_toneP1");
-  m_hLuminance = glGetUniformLocation(ProgramHandle(), "m_luminance");
+  m_hReinhardParam1 = glGetUniformLocation(ProgramHandle(), "m_reinhardParam1");
+  m_hACESParam1 = glGetUniformLocation(ProgramHandle(), "m_acesParam1");
+  m_hACESParam2 = glGetUniformLocation(ProgramHandle(), "m_acesParam2");
+  m_hHableParam1 = glGetUniformLocation(ProgramHandle(), "m_hableParam1");
+  m_hHableParam2 = glGetUniformLocation(ProgramHandle(), "m_hableParam2");
+
   VerifyGLState();
 
   if (m_glslOutput)
@@ -168,7 +175,17 @@ bool BaseYUV2RGBGLSLShader::OnEnabled()
     Matrix3 primMat = m_convMatrix.GetPrimMat();
     glUniformMatrix3fv(m_hPrimMat, 1, GL_FALSE, reinterpret_cast<GLfloat*>(primMat.ToRaw()));
     glUniform1f(m_hGammaSrc, m_convMatrix.GetGammaSrc());
-    glUniform1f(m_hGammaDstInv, 1 / m_convMatrix.GetGammaDst());
+
+    // if we have aces or hable, merge two pows into one. i.e. pow(pow())
+    if (!m_toneMapping || m_toneMappingMethod == VS_TONEMAPMETHOD_REINHARD)
+    {
+      glUniform1f(m_hGammaDstInv, 1 / m_convMatrix.GetGammaDst());
+    }
+    else
+    {
+      const float st2084_m2 = (2523.0f / 4096.0f) * 128.0f;
+      glUniform1f(m_hGammaDstInv, 1 / (m_convMatrix.GetGammaDst() * st2084_m2));
+    }
   }
 
   if (m_toneMapping)
@@ -186,25 +203,44 @@ bool BaseYUV2RGBGLSLShader::OnEnabled()
         param = 0.7f;
 
       param *= m_toneMappingParam;
+      param = 1.0f / (param * param);
 
       Matrix3x1 coefs = m_convMatrix.GetRGBYuvCoefs(AVColorSpace::AVCOL_SPC_BT709);
       glUniform3f(m_hCoefsDst, coefs[0], coefs[1], coefs[2]);
-      glUniform1f(m_hToneP1, param);
+      glUniform1f(m_hReinhardParam1, param);
     }
     else if (m_toneMappingMethod == VS_TONEMAPMETHOD_ACES)
     {
       const float lumin = CToneMappers::GetLuminanceValue(m_hasDisplayMetadata, m_displayMetadata,
                                                           m_hasLightMetadata, m_lightMetadata);
-      glUniform1f(m_hLuminance, lumin);
-      glUniform1f(m_hToneP1, m_toneMappingParam);
+
+      const float param1 = (10000.0f / lumin) * (2.0f / m_toneMappingParam);
+      const float param2 = 1.24f / m_toneMappingParam;
+
+      glUniform1f(m_hACESParam1, param1);
+      glUniform1f(m_hACESParam2, param2);
     }
     else if (m_toneMappingMethod == VS_TONEMAPMETHOD_HABLE)
     {
       const float lumin = CToneMappers::GetLuminanceValue(m_hasDisplayMetadata, m_displayMetadata,
                                                           m_hasLightMetadata, m_lightMetadata);
       const float param = (10000.0f / lumin) * (2.0f / m_toneMappingParam);
-      glUniform1f(m_hLuminance, lumin);
-      glUniform1f(m_hToneP1, param);
+
+      const float wp = lumin / 100.0f;
+
+      const float param1 = wp * param;
+
+      const float A = 0.15;
+      const float B = 0.5;
+      const float C = 0.1;
+      const float D = 0.2;
+      const float E = 0.02;
+      const float F = 0.3;
+      const float param2 =
+          1.0f / ((wp * (A * wp + C * B) + D * E) / (wp * (A * wp + B) + D * F)) - E / F;
+
+      glUniform1f(m_hHableParam1, param1);
+      glUniform1f(m_hHableParam2, param2);
     }
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.h
@@ -110,9 +110,12 @@ protected:
   GLint m_hGammaSrc = -1;
   GLint m_hGammaDstInv = -1;
   GLint m_hPrimMat = -1;
-  GLint m_hToneP1 = -1;
   GLint m_hCoefsDst = -1;
-  GLint m_hLuminance = -1;
+  GLint m_hReinhardParam1 = -1;
+  GLint m_hACESParam1 = -1;
+  GLint m_hACESParam2 = -1;
+  GLint m_hHableParam1 = -1;
+  GLint m_hHableParam2 = -1;
 
   // vertex shader attribute handles
   GLint m_hVertex = -1;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.h
@@ -90,9 +90,12 @@ class BaseYUV2RGBGLSLShader : public CGLSLShaderProgram
     GLint m_hGammaSrc{-1};
     GLint m_hGammaDstInv{-1};
     GLint m_hPrimMat{-1};
-    GLint m_hToneP1{-1};
     GLint m_hCoefsDst{-1};
-    GLint m_hLuminance = -1;
+    GLint m_hReinhardParam1 = -1;
+    GLint m_hACESParam1 = -1;
+    GLint m_hACESParam2 = -1;
+    GLint m_hHableParam1 = -1;
+    GLint m_hHableParam2 = -1;
 
     GLint m_hVertex{-1};
     GLint m_hYcoord{-1};


### PR DESCRIPTION
## Description
This PR folds a bunch of shader calculated uniform values, and moves the calculation to the CPU.

## Motivation and context
This avoids a bunch of uniform calculations for the tone mapping path. 

Savings: 
Reinhard: 2 MADs, 2 DIVs
ACES: 1 MAD, 3 DIVs, 1 POW
Hable: 5 MADs, 2 DIVs, 1 ADD, 1 POW

Especially the POWs are expensive. By folding two POWs into one (i.e. y = (x^a)^b = x^(ab)), we save quite some processing on the GPU.

I guesstimate that we save around 5-15% GPU cycles, depending on hardware and tone mapping method. And since we have FP32 floats on the CPU, it might be a tiny bit more exact.

## How has this been tested?
Compiles and runs fine on Linux. GL and GLES mapping methods look the same as before.

## What is the effect on users?
Less GPU utilization while tone mapping is active. 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
