### PR TITLE
Fix the scourge of game add-on build failures

### DIFF
--- a/tools/buildsteps/windows/prepare-env.bat
+++ b/tools/buildsteps/windows/prepare-env.bat
@@ -13,6 +13,9 @@ IF EXIST %WORKSPACE%\project\Win32BuildSetup\BUILD_WIN32 rmdir %WORKSPACE%\proje
 rem also clean 'build' dir used to build ffmpeg as git clean has trouble to remove some times
 IF EXIST %WORKSPACE%\project\BuildDependencies\build rmdir %WORKSPACE%\project\BuildDependencies\build /S /Q
 
+rem daemonized gpg-agent blocks mingw from being cleaned with git
+TASKKILL /IM "gpg-agent.exe" /F >nul 2>&1
+
 rem we assume git in path as this is a requirement
 rem git clean the untracked files and directories
 rem but keep the downloaded dependencies

--- a/tools/buildsteps/windows/prepare-env.bat
+++ b/tools/buildsteps/windows/prepare-env.bat
@@ -20,7 +20,7 @@ rem we assume git in path as this is a requirement
 rem git clean the untracked files and directories
 rem but keep the downloaded dependencies
 rem also keeps MSYS2 installation
-SET GIT_CLEAN_CMD=git clean -xffd -e "project/BuildDependencies/downloads" -e "project/BuildDependencies/downloads2" -e "project/BuildDependencies/mingwlibs" -e "project/BuildDependencies/msys64" -e "project/BuildDependencies/tools"
+SET GIT_CLEAN_CMD=git clean -xffd -e "project/BuildDependencies/downloads" -e "project/BuildDependencies/downloads2" -e "project/BuildDependencies/mingwlibs" -e "project/BuildDependencies/msys64" -e "project/BuildDependencies/tools" -e "cmake/addons/build/download/msys2-base-*.tar.xz"
 
 ECHO running %GIT_CLEAN_CMD%
 %GIT_CLEAN_CMD%


### PR DESCRIPTION
## Description

As can be seen at https://jenkins.kodi.tv/view/Game%20Binary%20Addons/, not many add-ons are green. This is because about 3/4 of the time on Windows, calling `prepare-env.bat` fails during git clean because gpg-agent.exe is daemonized in the background. An example is [here](https://jenkins.kodi.tv/blue/organizations/jenkins/kodi-game%2Fgame.libretro.bsnes/detail/115.0.0.13-Nexus/1/pipeline/282).

To fix this and allow `prepare-env.bat` to run successfully, I've added a line to kill the daemon.

## Motivation and context

Fix game binary add-ons failing 3/4 of the time.

## How has this been tested?

Started by building 2048:

```
PS C:\Users\thema\Documents\kodi-master\tools\buildsteps\windows\x64> .\prepare-env.bat
PS C:\Users\thema\Documents\kodi-master\tools\buildsteps\windows\x64> .\make-addons.bat package game.libretro.2048
```

Then daemonized gpg-agent.exe:

```
PS C:\Users\thema\Documents\kodi-master\cmake\addons\build\mingw\src\mingw\usr\bin> .\gpg-agent.exe --daemon
```

Verified it couldn't be removed:

```
PS C:\Users\thema\Documents\kodi-master\cmake\addons\build\mingw\src\mingw\usr\bin> rm .\gpg-agent.exe
rm : Cannot remove item C:\Users\thema\Documents\kodi-master\cmake\addons\build\mingw\src\mingw\usr\bin\gpg-agent.exe:
Access to the path 'C:\Users\thema\Documents\kodi-master\cmake\addons\build\mingw\src\mingw\usr\bin\gpg-agent.exe' is
denied.
At line:1 char:1
+ rm .\gpg-agent.exe
+ ~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : PermissionDenied: (C:\Users\thema\...n\gpg-agent.exe:FileInfo) [Remove-Item], Unauthoriz
   edAccessException
    + FullyQualifiedErrorId : RemoveFileSystemItemUnAuthorizedAccess,Microsoft.PowerShell.Commands.RemoveItemCommand
```

Ran `prepare-env.bat`, viewed the failure:

```
PS C:\Users\thema\Documents\kodi-master\tools\buildsteps\windows\x64> .\prepare-env.bat
Workspace is C:\Users\thema\Documents\kodi-master
running git clean -xffd -e "project/BuildDependencies/downloads" -e "project/BuildDependencies/downloads2" -e "project/BuildDependencies/mingwlibs" -e "project/BuildDependencies/msys64" -e "project/BuildDependencies/tools"
Unlink of file 'cmake/addons/build/mingw/src/mingw/usr/bin/gpg-agent.exe' failed. Should I try again? (y/n)
```

Applied the patch, ran `prepare-env.bat` again, verified it completed successfully:

```
PS C:\Users\thema\Documents\kodi-master\tools\buildsteps\windows\x64> .\prepare-env.bat
Workspace is C:\Users\thema\Documents\kodi-master
running git clean -xffd -e "project/BuildDependencies/downloads" -e "project/BuildDependencies/downloads2" -e "project/BuildDependencies/mingwlibs" -e "project/BuildDependencies/msys64" -e "project/BuildDependencies/tools"
Removing cmake/addons/build/
Removing cmake/addons/output/
Removing project/BuildDependencies/win32/
Removing project/BuildDependencies/x64/
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
