### PR TITLE
[VIDEO] fix tv show episodes not probed for streamdetails when refres…

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1486,13 +1486,23 @@ namespace VIDEO
                                      movieDetails.m_iSeason, movieDetails.m_iEpisode, strTitle);
     }
 
-    if (!movieDetails.HasStreamDetails() &&
-        CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+    /* As HasStreamDetails() returns true for TV shows (because the scraper calls SetVideoInfoTag()
+     * directly to set the duration) a better test is just to see if we have any common flag info
+     * missing.  If we have already read an nfo file then this data should be populated, otherwise
+     * get it from the video file */
+
+    if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
             CSettings::SETTING_MYVIDEOS_EXTRACTFLAGS))
     {
-      CDVDFileInfo::GetFileStreamDetails(pItem);
-      CLog::Log(LOGDEBUG, "VideoInfoScanner: Extracted filestream details from video file {}",
-                CURL::GetRedacted(pItem->GetPath()));
+      const auto& strmdetails = movieDetails.m_streamDetails;
+      if (strmdetails.GetVideoCodec(1).empty() || strmdetails.GetVideoHeight(1) == 0 ||
+          strmdetails.GetVideoWidth(1) == 0 || strmdetails.GetVideoDuration(1) == 0)
+
+      {
+        CDVDFileInfo::GetFileStreamDetails(pItem);
+        CLog::Log(LOGDEBUG, "VideoInfoScanner: Extracted filestream details from video file {}",
+                  CURL::GetRedacted(pItem->GetPath()));
+      }
     }
 
     CLog::Log(LOGDEBUG, "VideoInfoScanner: Adding new item to {}:{}", TranslateContent(content), CURL::GetRedacted(pItem->GetPath()));


### PR DESCRIPTION
…hed from scrapers

## Description
Test for more than just `item->HasStreamDetails()` as this is misleading in some cases.

## Motivation and context
The TV show scraper calls `SetVideoInfoTag()` directly but the only information it has to set is the duration of an episode.  With the old test, HasStreamDetails() would return true because at least one streamdetails item is set.  This means that when refreshing a TV show, if the user ignores any local nfo files and refreshes from the internet, the episode file is not probed for streamdetails and all that info disappears.

This doesn't occur with movies as the scraper uses a different method of setting the streamdetails so at this point in the code, they are not yet set.

Fixes https://github.com/xbmc/xbmc/issues/24498

## How has this been tested?
Tested by using local nfo files to set incorrect details in the db, then refreshing from the internet and checking the new details match the file details.  Tested against TV shows and movies.

## What is the effect on users?
Stream details will be obtained if they are either missing from an nfo file, or the show / movie is being refreshed from the internet.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
