### PR TITLE
[Windows] AESinkWASAPI: improve fallback when is not supported exact output channel layout

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -730,6 +730,7 @@ bool CAESinkWASAPI::InitializeExclusive(AEAudioFormat &format)
   unsigned int requestedChannels = 0;
   unsigned int noOfCh = 0;
   uint64_t desired_map = 0;
+  bool matchNoChannelsOnly = false;
 
   if (SUCCEEDED(hr))
   {
@@ -762,16 +763,34 @@ bool CAESinkWASAPI::InitializeExclusive(AEAudioFormat &format)
     // as the last resort try stereo
     if (layout == ARRAYSIZE(layoutsList))
     {
-      wfxex.dwChannelMask = SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT;
-      wfxex.Format.nChannels = 2;
+      if (matchNoChannelsOnly)
+      {
+        wfxex.dwChannelMask = SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT;
+        wfxex.Format.nChannels = 2;
+      }
+      else
+      {
+        matchNoChannelsOnly = true;
+        layout = -1;
+        CLog::Log(LOGWARNING, "AESinkWASAPI: Match only number of audio channels as fallback");
+        continue;
+      }
     }
     else if (layout >= 0)
     {
       wfxex.dwChannelMask = CAESinkFactoryWin::ChLayoutToChMask(layoutsList[layout], &noOfCh);
       wfxex.Format.nChannels = noOfCh;
       int res = desired_map & wfxex.dwChannelMask;
-      if (res != desired_map)
-        continue; // output channel layout doesn't match input channels
+      if (matchNoChannelsOnly)
+      {
+        if (noOfCh < requestedChannels)
+          continue; // number of channels doesn't match requested channels
+      }
+      else
+      {
+        if (res != desired_map)
+          continue; // output channel layout doesn't match input channels
+      }
     }
     CAEChannelInfo foundChannels;
     CAESinkFactoryWin::AEChannelsFromSpeakerMask(foundChannels, wfxex.dwChannelMask);

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -745,15 +745,15 @@ bool CAESinkWASAPI::InitializeExclusive(AEAudioFormat &format)
   else if (format.m_dataFormat == AE_FMT_RAW) //No sense in trying other formats for passthrough.
     return false;
 
-  CLog::LogFC(LOGDEBUG, LOGAUDIO,
-              "IsFormatSupported failed ({}) - trying to find a compatible format",
-              WASAPIErrToStr(hr));
+  CLog::Log(LOGWARNING,
+            "AESinkWASAPI: IsFormatSupported failed ({}) - trying to find a compatible format",
+            WASAPIErrToStr(hr));
 
   requestedChannels = wfxex.Format.nChannels;
   desired_map = CAESinkFactoryWin::SpeakerMaskFromAEChannels(format.m_channelLayout);
 
   /* The requested format is not supported by the device.  Find something that works */
-  CLog::Log(LOGDEBUG,
+  CLog::Log(LOGWARNING,
             "AESinkWASAPI: Input channels are [{}] - Trying to find a matching output layout",
             std::string(format.m_channelLayout));
   for (int layout = -1; layout <= (int)ARRAYSIZE(layoutsList); layout++)


### PR DESCRIPTION
## Description
AESinkWASAPI: improve fallback when is not supported exact output channel layout

Fixes https://github.com/xbmc/xbmc/issues/22584

## Motivation and context
While https://github.com/xbmc/xbmc/pull/19786 implements better channel layout match, may cause regressions in systems / drivers that not supports exact output layout (fallback only to stereo).

This PR implements the old method as alternative (point 3) if primary exact match fails and finally fallback to stereo same as before.

1. Direct mapping using `IsFormatSupported`.
2. Test predefined list of common layouts with exact match.
3. Test predefined list of common layouts with only number of channels >= requested channels.
4. Fallback to stereo.

Also adjusted some logs messages (in separated commit) because only is used component audio in one single message and anyway is in the fallback code path, so not visible in normal debug logs without this specific audio issue. Changed to LOGWARNING.
 

## How has this been tested?
Not tested but original bug reporter has confirmed is fixed here https://github.com/xbmc/xbmc/issues/22584#issuecomment-1897767976


## What is the effect on users?
More robust WASAPI audio channels layout matching when is not used passthrough.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
