### PR TITLE
[video] Change Versions Art Handling

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -4273,3 +4273,17 @@ bool CFileItem::HasVideoExtras() const
   }
   return false;
 }
+
+bool CFileItem::IsVideoAssetNav() const
+{
+  if (!IsVideoDb())
+    return false;
+
+  // @todo maybe in the future look for prefix videodb://movies/videoversions in path instead
+  // @todo better encoding of video assets as path, they won't always be tied with movies.
+  const CURL itemUrl{GetPath()};
+  if (itemUrl.HasOption("videoversionid"))
+    return true;
+
+  return false;
+}

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -261,6 +261,7 @@ public:
   bool IsLiveTV() const;
   bool IsRSS() const;
   bool IsAndroidApp() const;
+  bool IsVideoAssetNav() const;
 
   bool HasVideoVersions() const;
   bool HasVideoExtras() const;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4940,6 +4940,7 @@ bool CVideoDatabase::GetArtForItem(int mediaId, const MediaType &mediaType, std:
 bool CVideoDatabase::GetArtForAsset(int assetId,
                                     int ownerMediaId,
                                     const MediaType& mediaType,
+                                    ArtFallbackOptions fallback,
                                     std::map<std::string, std::string>& art)
 {
   try
@@ -4982,10 +4983,10 @@ bool CVideoDatabase::GetArtForAsset(int assetId,
     {
       if (m_pDS2->fv(0).get_asString() == MediaTypeVideoVersion)
       {
-        // version data has priority over owner's data, used as fallback.
+        // version data has priority over owner's data
         art[m_pDS2->fv(1).get_asString()] = m_pDS2->fv(2).get_asString();
       }
-      else
+      else if (fallback == ArtFallbackOptions::PARENT)
       {
         // insert if not yet present
         art.insert(make_pair(m_pDS2->fv(1).get_asString(), m_pDS2->fv(2).get_asString()));

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4958,16 +4958,22 @@ bool CVideoDatabase::GetArtForAsset(int assetId,
                        "FROM art "
                        "LEFT JOIN videoversion vv "
                        "  ON art.media_id = vv.idMedia AND art.media_type = vv.media_type "
-                       "WHERE (art.media_id = %i AND art.media_type = '%s') "
-                       "OR(vv.idFile = %i) ",
+                       "WHERE art.url <> '' "
+                       "AND ( "
+                       "  (art.media_id = %i AND art.media_type = '%s') "
+                       "  OR (vv.idFile = %i) "
+                       ")",
                        assetId, MediaTypeVideoVersion, assetId);
     }
     else
     {
       sql = PrepareSQL("SELECT media_type, type, url "
                        "FROM art "
-                       "WHERE (media_id = %i AND media_type = '%s') "
-                       "OR (media_id = %i AND media_type = '%s')",
+                       "WHERE art.url <> '' "
+                       "AND ( "
+                       "  (media_id = %i AND media_type = '%s') "
+                       "  OR (media_id = %i AND media_type = '%s')"
+                       ")",
                        assetId, MediaTypeVideoVersion, ownerMediaId, mediaType.c_str());
     }
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -8104,9 +8104,6 @@ bool CVideoDatabase::GetMoviesByWhere(const std::string& strBaseDir, const Filte
     if (!videoUrl.FromString(strBaseDir) || !GetFilter(videoUrl, extFilter, sorting))
       return false;
 
-    if (!videoUrl.HasOption("videoversionid"))
-      extFilter.AppendWhere("isDefaultVersion = 1");
-
     int total = -1;
 
     std::string strSQL = "select %s from movie_view ";
@@ -11551,6 +11548,10 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
             filter.AppendWhere(PrepareSQL("idMovie = %i", mediaId));
         }
       }
+    }
+    else
+    {
+      filter.AppendWhere("isDefaultVersion = 1");
     }
 
     AppendIdLinkFilter("tag", "tag", "movie", "movie", "idMovie", options, filter);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -959,16 +959,12 @@ public:
    * \brief Retrieve all art for the given video asset, with optional fallback to the art of the
    * parent/owner of the asset
    * \param assetId id of the file of the asset
-   * \param ownerId id of the parent/owner of the asset
-   * \param mediaType media type of the parent/owner of the asset
    * \param fallback optionally request fallback to the art of the parent/owner for each art type
      that is not defined for the asset
    * \param art collection of the retrieved art
    * \return 
   */
   bool GetArtForAsset(int assetId,
-                      int ownerId,
-                      const MediaType& mediaType,
                       ArtFallbackOptions fallback,
                       std::map<std::string, std::string>& art);
   bool HasArtForItem(int mediaId, const MediaType &mediaType);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -401,6 +401,12 @@ const struct SDbTableOffsets DbMusicVideoOffsets[] =
   { VIDEODB_TYPE_INT, my_offsetof(CVideoInfoTag,m_iIdUniqueID)}
 };
 
+enum class ArtFallbackOptions
+{
+  NONE,
+  PARENT
+};
+
 #define COMPARE_PERCENTAGE     0.90f // 90%
 #define COMPARE_PERCENTAGE_MIN 0.50f // 50%
 
@@ -948,9 +954,22 @@ public:
   void SetArtForItem(int mediaId, const MediaType &mediaType, const std::map<std::string, std::string> &art);
   bool GetArtForItem(int mediaId, const MediaType &mediaType, std::map<std::string, std::string> &art);
   std::string GetArtForItem(int mediaId, const MediaType &mediaType, const std::string &artType);
+
+  /*!
+   * \brief Retrieve all art for the given video asset, with optional fallback to the art of the
+   * parent/owner of the asset
+   * \param assetId id of the file of the asset
+   * \param ownerId id of the parent/owner of the asset
+   * \param mediaType media type of the parent/owner of the asset
+   * \param fallback optionally request fallback to the art of the parent/owner for each art type
+     that is not defined for the asset
+   * \param art collection of the retrieved art
+   * \return 
+  */
   bool GetArtForAsset(int assetId,
                       int ownerId,
                       const MediaType& mediaType,
+                      ArtFallbackOptions fallback,
                       std::map<std::string, std::string>& art);
   bool HasArtForItem(int mediaId, const MediaType &mediaType);
   bool RemoveArtForItem(int mediaId, const MediaType &mediaType, const std::string &artType);

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -400,7 +400,11 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
     // @todo unify asset path for other items path
     if (item.IsVideoAssetNav())
     {
-      if (m_videoDatabase->GetArtForAsset(tag.m_iFileId, tag.m_iDbId, tag.m_type, artwork))
+      if (m_videoDatabase->GetArtForAsset(tag.m_iFileId, tag.m_iDbId, tag.m_type,
+                                          item.GetProperty("noartfallbacktoowner").asBoolean(false)
+                                              ? ArtFallbackOptions::NONE
+                                              : ArtFallbackOptions::PARENT,
+                                          artwork))
         item.AppendArt(artwork);
     }
     else if (m_videoDatabase->GetArtForItem(tag.m_iDbId, tag.m_type, artwork))

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -397,7 +397,8 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
   {
     m_videoDatabase->Open();
 
-    if (tag.GetAssetInfo().GetId() >= 0)
+    // @todo unify asset path for other items path
+    if (item.IsVideoAssetNav())
     {
       if (m_videoDatabase->GetArtForAsset(tag.m_iFileId, tag.m_iDbId, tag.m_type, artwork))
         item.AppendArt(artwork);

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -400,7 +400,7 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
     // @todo unify asset path for other items path
     if (item.IsVideoAssetNav())
     {
-      if (m_videoDatabase->GetArtForAsset(tag.m_iFileId, tag.m_iDbId, tag.m_type,
+      if (m_videoDatabase->GetArtForAsset(tag.m_iFileId,
                                           item.GetProperty("noartfallbacktoowner").asBoolean(false)
                                               ? ArtFallbackOptions::NONE
                                               : ArtFallbackOptions::PARENT,

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -847,7 +847,7 @@ void AddCurrentArtTypes(std::vector<std::string>& artTypes, const CVideoInfoTag&
   std::map<std::string, std::string> currentArt;
 
   if (tag.GetAssetInfo().GetId() >= 0)
-    db.GetArtForAsset(tag.m_iFileId, tag.m_iDbId, tag.m_type, currentArt);
+    db.GetArtForAsset(tag.m_iFileId, tag.m_iDbId, tag.m_type, ArtFallbackOptions::NONE, currentArt);
   else
     db.GetArtForItem(tag.m_iDbId, tag.m_type, currentArt);
 

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -847,7 +847,7 @@ void AddCurrentArtTypes(std::vector<std::string>& artTypes, const CVideoInfoTag&
   std::map<std::string, std::string> currentArt;
 
   if (tag.GetAssetInfo().GetId() >= 0)
-    db.GetArtForAsset(tag.m_iFileId, tag.m_iDbId, tag.m_type, ArtFallbackOptions::NONE, currentArt);
+    db.GetArtForAsset(tag.m_iFileId, ArtFallbackOptions::NONE, currentArt);
   else
     db.GetArtForItem(tag.m_iDbId, tag.m_type, currentArt);
 

--- a/xbmc/video/dialogs/GUIDialogVideoManager.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -217,7 +217,10 @@ void CGUIDialogVideoManager::Refresh()
   CVideoThumbLoader loader;
 
   for (auto& item : *m_videoAssetsList)
+  {
+    item->SetProperty("noartfallbacktoowner", true);
     loader.LoadItem(item.get());
+  }
 
   CGUIMessage msg{GUI_MSG_LABEL_BIND, GetID(), CONTROL_LIST_ASSETS, 0, 0, m_videoAssetsList.get()};
   OnMessage(msg);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Make the parent movie and versions behave more like sets and movies with respect to art:

- when browsing movies in the library, the art scraped/set by the user for the parent movie is used.
- choosing art from library manage context menu or info dialog sets the parent movie art.
- when browsing the versions of a movie (choose dialog from library, versions as a subfolder of the movie, versions top-level navigation), the art scraped/set by user for the version is used. If some types of art is missing at the version level, the art of the parent movie is used instead. Parent movie art will usually exist, since in v21 the movie is still the core element of the library.
- browsing versions/choosing art from Versions manager shows the art of the versions only, with no fallback on the art of the parent movie, for clarity.

Overall this allows different art for the group and each version, but if version art is not provided, group art will be used for everything.

Technically this is done by checking the path/options of the item at key points, and adding a special property to disable the art fallback that usually takes place, except when editing art.

This PR doesn't address the current issues of the Manage context menu and the Info dialog when launched for a version of a movie (from versions as subfolder of a movie or versions top-level navigation). The problems go beyond art. In that context, the dialog should probably replace some functions of Versions Manager and versions/extas buttons should be hidden. It may be v22 work though, an easier fix would be to remove access to the dialog.

Two small related changes included:
- [fix] ignore art with url field empty: setting art to "no art" doesn't delete the record in the art table but sets the url to blank. Those records have to be ignored for fallback between version and parent movie to work properly.
- [cosmetic] move some code of GetMoviesByWhere() into GetFilter() where it belongs

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Address some surprising behavior of art in master that are consequences of always using version art first, even when browsing movies in the library.
Attempt to provide a no-change solution for the most common case of single version for movies and small code change when there are multiple versions.

From the user point of view should feel similar to what will be available later in v22, although the implementation is not clean due to constraints of the current design.

This superseeds my previous attempts.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Movies with single and multiple versions.
Changed art with context menu > choose art, with info dialog Choose art
Changed art with Versions Manage dialog.
Browsed the library by titles, from versions navigation, in the versions subfolders.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Intuitive behavior of art.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
