### PR TITLE
[tvOS] fix assigning bundle ID to the generated frameworks

### DIFF
--- a/tools/darwin/Support/copyframeworks-dylibs2frameworks.command
+++ b/tools/darwin/Support/copyframeworks-dylibs2frameworks.command
@@ -17,7 +17,7 @@
 #  along with MrMC; see the file COPYING.  If not, see
 #  <http://www.gnu.org/licenses/>.
 
-#set -x
+set -x
 
 TARGET_CONTENTS="${TARGET_BUILD_DIR}/${EXECUTABLE_FOLDER_PATH}"
 TARGET_FRAMEWORKS=$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH

--- a/tools/darwin/Support/copyframeworks-dylibs2frameworks.command
+++ b/tools/darwin/Support/copyframeworks-dylibs2frameworks.command
@@ -47,11 +47,7 @@ function convert2framework
   install_name_tool -change  @executable_path/Frameworks/${DYLIB_BASENAME} @executable_path/Frameworks/${DYLIB_LIBNAME}.framework/${DYLIB_LIBNAME} ${TARGET_BUILD_DIR}/${EXECUTABLE_FOLDER_PATH}/${EXECUTABLE_NAME}
   install_name_tool -add_rpath @executable_path/Frameworks/${DYLIB_LIBNAME}.framework ${TARGET_BUILD_DIR}/${EXECUTABLE_FOLDER_PATH}/${EXECUTABLE_NAME}
 
-  BUNDLEID=`mdls -raw -name kMDItemCFBundleIdentifier ${TARGET_BUILD_DIR}/${EXECUTABLE_FOLDER_PATH}`
-  if [ "${BUNDLEID}" == "(null)" ] ; then
-    BUNDLEID=`/usr/libexec/PlistBuddy -c 'Print CFBundleIdentifier' ${TARGET_BUILD_DIR}/${EXECUTABLE_FOLDER_PATH}/Info.plist`
-  fi
-
+  BUNDLEID=$(/usr/libexec/PlistBuddy -c 'Print CFBundleIdentifier' ${TARGET_BUILD_DIR}/${EXECUTABLE_FOLDER_PATH}/Info.plist)
   FRAMEWORKBUNDLEID="${BUNDLEID}.framework.${DYLIB_LIBNAME}"
   echo "CFBundleIdentifier is ${FRAMEWORKBUNDLEID}"
   echo "convert ${DYLIB_BASENAME} to ${DYLIB_LIBNAME}.framework"


### PR DESCRIPTION
## Description
`mdls` utility started producing weird output on our Jenkins slaves (can't reproduce locally), so now we use only `PlistBuddy` to read from Info.plist

## Motivation and context
generating frameworks from dylibs works correctly again (affects only Nexus)

fixes #24425

also:
- https://forum.kodi.tv/showthread.php?tid=375780
- https://forum.kodi.tv/showthread.php?tid=375478

## How has this been tested?
Built Nexus on Jenkins, checked build logs and the produced artifact that bundle ID in the libass framework is correct now

## What is the effect on users?
less hassle to install Nexus on AppleTV

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
