### PR TITLE
[ContextMenus] Don't populate python context items if browsing sub-menus

### DIFF
--- a/xbmc/ContextMenuItem.cpp
+++ b/xbmc/ContextMenuItem.cpp
@@ -47,6 +47,11 @@ bool CContextMenuItem::IsGroup() const
   return !m_groupId.empty();
 }
 
+bool CContextMenuItem::HasParent() const
+{
+  return !m_parent.empty();
+}
+
 bool CContextMenuItem::Execute(const std::shared_ptr<CFileItem>& item) const
 {
   if (!item || m_library.empty() || IsGroup())

--- a/xbmc/ContextMenuItem.h
+++ b/xbmc/ContextMenuItem.h
@@ -33,6 +33,7 @@ public:
   virtual bool Execute(const std::shared_ptr<CFileItem>& item) const = 0;
   virtual std::string GetLabel(const CFileItem& item) const = 0;
   virtual bool IsGroup() const { return false; }
+  virtual bool HasParent() const { return false; }
 };
 
 
@@ -56,6 +57,7 @@ public:
   bool IsVisible(const CFileItem& item) const override ;
   bool IsParentOf(const CContextMenuItem& menuItem) const;
   bool IsGroup() const override ;
+  bool HasParent() const override;
   bool Execute(const std::shared_ptr<CFileItem>& item) const override;
   bool operator==(const CContextMenuItem& other) const;
   std::string ToString() const;

--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -298,6 +298,8 @@ bool CONTEXTMENU::ShowFor(const std::shared_ptr<CFileItem>& fileItem, const CCon
 
   CContextButtons buttons;
   // compute fileitem property-based contextmenu items
+  // unless we're browsing a child menu item
+  if (!root.HasParent())
   {
     int i = 0;
     while (fileItem->HasProperty(StringUtils::Format("contextmenulabel({})", i)))


### PR DESCRIPTION
## Description
This is a regression from https://github.com/xbmc/xbmc/pull/21866 brought in slack by @basrieter. If we're navigating a sub-menu, e.g.:

```
<menu>
                <label>Sub Menu &gt;</label>

                <item library="addon.py" args="bitrate">
                    <label>Sub Menu 1 Addon.xml</label>
                    <visible>True</visible>
                </item>
                <item library="addon.py" args="bitrate2">
                    <label>Sub Menu 2 Addon.xml</label>
                    <visible>True</visible>
                </item>
            </menu>
```

we don't actually want to present the items set from python but only those that actually belong to the sub-menu.

## Motivation and context
Fix regression, sane default behaviour IMOH. If we're to present items set from python they should either be added when browsing the context menu or clicking on a context menu item that invokes the addon with a set of specific args.

## How has this been tested?
Runtime tested with the small test addon attached to this PR
[plugin.video.menu.zip](https://github.com/xbmc/xbmc/files/13991889/plugin.video.menu.zip)
Also tested the addon provided in https://github.com/xbmc/xbmc/issues/21843 that lead to the original PR

## What is the effect on users?
When browsing sub-menus, addon items are not placed there anymore:

**Previously:**
![image](https://github.com/xbmc/xbmc/assets/7375276/6b3bf2b8-8650-4fdc-aa70-8ad8655fcb08)
![image](https://github.com/xbmc/xbmc/assets/7375276/d0783bfb-d183-4304-9844-4aa758b662e6)


**Now:**
![image](https://github.com/xbmc/xbmc/assets/7375276/c6c88d6f-5734-4c25-aff4-8c7fe47fb8f9)
![image](https://github.com/xbmc/xbmc/assets/7375276/21d05455-a202-4b38-b7f8-b64efa3d7481)


## Screenshots (if appropriate):
See above

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
