### PR TITLE
AESinkAudioTrack: Allow multi-channel float for new devices

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -584,6 +584,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetFloat(pElement, "limiterrelease", m_limiterRelease, 0.001f, 100.0f);
     XMLUtils::GetUInt(pElement, "maxpassthroughoffsyncduration", m_maxPassthroughOffSyncDuration,
                       10, 100);
+    XMLUtils::GetBoolean(pElement, "allowmultichannelfloat", m_AllowMultiChannelFloat);
   }
 
   pElement = pRootElement->FirstChildElement("x11");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -154,6 +154,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     float m_videoIgnorePercentAtEnd;
     float m_audioApplyDrc;
     unsigned int m_maxPassthroughOffSyncDuration = 10; // when 10 ms off adjust
+    bool m_AllowMultiChannelFloat = false; // Android only switch to be remved in v22
 
     int   m_videoVDPAUScaling;
     float m_videoNonLinStretchRatio;


### PR DESCRIPTION
    AESinkAudioTrack: Allow multi-channel float by advanced setting
    
    While supported since API level 21, we had lots of issues up to 3 years
    ago with devices opening multi-channel but not outputting anything. Let's
    try it again this time but safe guard with an advanced setting.
    At least running Android TV 11 should be fine. Float is the highest precision
    and quality Android offers. Exxoplayer only distinguish between standard 16 bit
    and 32 bit float for high precision.
    
    All the other formats are created / downsampled / converted by Audiotrack to
    match the final output.
    
    As this does not work reliably and settings times for sinks (sinks don't have
    settings as of now), let's go opt-in via advancedsettings.

Before: Multi-Channel 16 bit always
After: Advacedsetting 
```
<advancedsettings>
  <audio>
    <allowmultichannelfloat>true</allowmultichannelfloat>
  </audio>
</advancedsettings>
```