### PR TITLE
MacOS: add missing key mappings

### DIFF
--- a/xbmc/windowing/osx/WinEventsOSXImpl.mm
+++ b/xbmc/windowing/osx/WinEventsOSXImpl.mm
@@ -110,6 +110,48 @@
     case NSCarriageReturnCharacter:
     case NSEnterCharacter:
       return XBMCK_RETURN;
+    case NSF1FunctionKey:
+      return XBMCK_F1;
+    case NSF2FunctionKey:
+      return XBMCK_F2;
+    case NSF3FunctionKey:
+      return XBMCK_F3;
+    case NSF4FunctionKey:
+      return XBMCK_F4;
+    case NSF5FunctionKey:
+      return XBMCK_F5;
+    case NSF6FunctionKey:
+      return XBMCK_F6;
+    case NSF7FunctionKey:
+      return XBMCK_F7;
+    case NSF8FunctionKey:
+      return XBMCK_F8;
+    case NSF9FunctionKey:
+      return XBMCK_F9;
+    case NSF10FunctionKey:
+      return XBMCK_F10;
+    case NSF11FunctionKey:
+      return XBMCK_F11;
+    case NSF12FunctionKey:
+      return XBMCK_F12;
+    case NSF13FunctionKey:
+      return XBMCK_F13;
+    case NSF14FunctionKey:
+      return XBMCK_F14;
+    case NSF15FunctionKey:
+      return XBMCK_F15;
+    case NSHomeFunctionKey:
+      return XBMCK_HOME;
+    case NSEndFunctionKey:
+      return XBMCK_END;
+    case NSPageDownFunctionKey:
+      return XBMCK_PAGEDOWN;
+    case NSPageUpFunctionKey:
+      return XBMCK_PAGEUP;
+    case NSPauseFunctionKey:
+      return XBMCK_PAUSE;
+    case NSInsertCharFunctionKey:
+      return XBMCK_INSERT;
     default:
       return character;
   }


### PR DESCRIPTION
## Description
This adds a few missing NS* to XBMCK key mappings. A few more might still be missing but let's add them as they are actually requested.

## Motivation and context
Fixes https://github.com/xbmc/xbmc/issues/24544 for omega/master. It looks like it was broken between 20.2 and 20.3 but I've really no interest to dig into it as we've replaced the windowing implementation altogether for v21.

## How has this been tested?
Runtime tested with the keymap provided in the issue report

## What is the effect on users?
Restore functionality for some edge cases - keymaps

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

