### PR TITLE
[video] Restore selection of extras in "Choose" dialog

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -24093,7 +24093,7 @@ msgctxt "#40213"
 msgid "If selected the remote player volume level will be synchronized with the volume of this application.[CR]Warning: Global system volume level may be different than the application volume level - they are controlled independently.[CR]This may lead the remote player to be set to 100% volume level if the application has 100% volume level but the overall system volume level is smaller."
 msgstr ""
 
-#. Dialog title for the selection of the video extra after "select" in library
+#. Dialog title for the selection of the video extra
 #: xbmc/video/guilib/VideoVersionHelper.cpp
 msgctxt "#40214"
 msgid "Choose extra"

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -24054,8 +24054,9 @@ msgctxt "#40207"
 msgid "When enabled, a video with multiple versions will be shown as a folder in the video library. This folder can then be opened to display the individual video versions. When disabled, the configured select action will be applied."
 msgstr ""
 
-#. Choose video version context menu item label
+#. Choose video version context menu item label and dialog title
 #: xbmc/video/ContextMenus.h
+#: xbmc/video/guilib/VideoVersionHelper.cpp
 msgctxt "#40208"
 msgid "Choose version"
 msgstr ""
@@ -24092,7 +24093,13 @@ msgctxt "#40213"
 msgid "If selected the remote player volume level will be synchronized with the volume of this application.[CR]Warning: Global system volume level may be different than the application volume level - they are controlled independently.[CR]This may lead the remote player to be set to 100% volume level if the application has 100% volume level but the overall system volume level is smaller."
 msgstr ""
 
-#empty strings from id 40214 to 40399
+#. Dialog title for the selection of the video extra after "select" in library
+#: xbmc/video/guilib/VideoVersionHelper.cpp
+msgctxt "#40214"
+msgid "Choose extra"
+msgstr ""
+
+#empty strings from id 40215 to 40399
 
 # Video versions
 

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -22,10 +22,12 @@
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "video/VideoInfoTag.h"
+#include "video/VideoManagerTypes.h"
 #include "video/VideoUtils.h"
 #include "video/dialogs/GUIDialogVideoInfo.h"
 #include "video/guilib/VideoPlayActionProcessor.h"
 #include "video/guilib/VideoSelectActionProcessor.h"
+#include "video/guilib/VideoVersionHelper.h"
 
 #include <utility>
 
@@ -228,16 +230,18 @@ protected:
 
 bool CVideoChooseVersion::IsVisible(const CFileItem& item) const
 {
-  return item.HasVideoVersions() || item.HasVideoExtras();
+  return item.HasVideoVersions() && !VIDEO::IsVideoAssetFile(item);
 }
 
 bool CVideoChooseVersion::Execute(const std::shared_ptr<CFileItem>& item) const
 {
   // force selection dialog, regardless of any settings like 'Select default video version'
   item->SetProperty("needs_resolved_video_asset", true);
+  item->SetProperty("video_asset_type", static_cast<int>(VideoAssetType::VERSION));
   CVideoSelectActionProcessor proc{item};
   const bool ret = proc.ProcessDefaultAction();
   item->ClearProperty("needs_resolved_video_asset");
+  item->ClearProperty("video_asset_type");
   return ret;
 }
 
@@ -436,12 +440,13 @@ bool CVideoPlayUsing::Execute(const std::shared_ptr<CFileItem>& itemIn) const
 
 bool CVideoPlayVersionUsing::IsVisible(const CFileItem& item) const
 {
-  return item.HasVideoVersions() || item.HasVideoExtras();
+  return item.HasVideoVersions() && !VIDEO::IsVideoAssetFile(item);
 }
 
 bool CVideoPlayVersionUsing::Execute(const std::shared_ptr<CFileItem>& itemIn) const
 {
   const auto item{std::make_shared<CFileItem>(itemIn->GetItemToPlay())};
+  item->SetProperty("video_asset_type", "version");
   SetPathAndPlay(item, PlayMode::PLAY_VERSION_USING);
   return true;
 }

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -228,16 +228,16 @@ protected:
 
 bool CVideoChooseVersion::IsVisible(const CFileItem& item) const
 {
-  return item.HasVideoVersions();
+  return item.HasVideoVersions() || item.HasVideoExtras();
 }
 
 bool CVideoChooseVersion::Execute(const std::shared_ptr<CFileItem>& item) const
 {
   // force selection dialog, regardless of any settings like 'Select default video version'
-  item->SetProperty("needs_resolved_video_version", true);
+  item->SetProperty("needs_resolved_video_asset", true);
   CVideoSelectActionProcessor proc{item};
   const bool ret = proc.ProcessDefaultAction();
-  item->ClearProperty("needs_resolved_video_version");
+  item->ClearProperty("needs_resolved_video_asset");
   return ret;
 }
 
@@ -357,12 +357,12 @@ void SetPathAndPlay(const std::shared_ptr<CFileItem>& item, PlayMode mode)
     if (mode == PlayMode::PLAY_VERSION_USING)
     {
       // force video version selection dialog
-      itemCopy->SetProperty("needs_resolved_video_version", true);
+      itemCopy->SetProperty("needs_resolved_video_asset", true);
     }
     else
     {
       // play the given/default video version, if multiple versions are available
-      itemCopy->SetProperty("has_resolved_video_version", true);
+      itemCopy->SetProperty("has_resolved_video_asset", true);
     }
 
     const bool choosePlayer{mode == PlayMode::PLAY_USING || mode == PlayMode::PLAY_VERSION_USING};
@@ -436,7 +436,7 @@ bool CVideoPlayUsing::Execute(const std::shared_ptr<CFileItem>& itemIn) const
 
 bool CVideoPlayVersionUsing::IsVisible(const CFileItem& item) const
 {
-  return item.HasVideoVersions();
+  return item.HasVideoVersions() || item.HasVideoExtras();
 }
 
 bool CVideoPlayVersionUsing::Execute(const std::shared_ptr<CFileItem>& itemIn) const

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -8177,7 +8177,7 @@ bool CVideoDatabase::GetMoviesByWhere(const std::string& strBaseDir, const Filte
             path = RewriteVideoVersionURL(strBaseDir, movie);
           }
           // this is a certain version, no need to resolve (e.g. no version chooser on select)
-          pItem->SetProperty("has_resolved_video_version", true);
+          pItem->SetProperty("has_resolved_video_asset", true);
         }
 
         if (path.empty())

--- a/xbmc/video/VideoManagerTypes.h
+++ b/xbmc/video/VideoManagerTypes.h
@@ -16,7 +16,7 @@ enum class VideoAssetTypeOwner
   USER = 2
 };
 
-enum class VideoAssetType
+enum class VideoAssetType : int
 {
   UNKNOWN = -1,
   VERSION = 0,

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -805,7 +805,7 @@ void CGUIDialogVideoInfo::Play(bool resume)
   Close(true);
 
   // play the current video version, even if multiple versions are available
-  m_movieItem->SetProperty("has_resolved_video_version", true);
+  m_movieItem->SetProperty("has_resolved_video_asset", true);
 
   if (resume)
   {
@@ -834,7 +834,7 @@ void CGUIDialogVideoInfo::Play(bool resume)
     }
   }
 
-  m_movieItem->ClearProperty("has_resolved_video_version");
+  m_movieItem->ClearProperty("has_resolved_video_asset");
 }
 
 namespace

--- a/xbmc/video/guilib/VideoPlayActionProcessor.cpp
+++ b/xbmc/video/guilib/VideoPlayActionProcessor.cpp
@@ -35,7 +35,7 @@ bool CVideoPlayActionProcessorBase::ProcessAction(Action action)
 {
   m_userCancelled = false;
 
-  const auto movie{CVideoVersionHelper::ChooseMovieFromVideoVersions(m_item)};
+  const auto movie{CVideoVersionHelper::ChooseMovieFromVideoAssets(m_item)};
   if (movie)
     m_item = movie;
   else

--- a/xbmc/video/guilib/VideoPlayActionProcessor.cpp
+++ b/xbmc/video/guilib/VideoPlayActionProcessor.cpp
@@ -35,7 +35,7 @@ bool CVideoPlayActionProcessorBase::ProcessAction(Action action)
 {
   m_userCancelled = false;
 
-  const auto movie{CVideoVersionHelper::ChooseMovieFromVideoAssets(m_item)};
+  const auto movie{CVideoVersionHelper::ChooseVideoFromAssets(m_item)};
   if (movie)
     m_item = movie;
   else

--- a/xbmc/video/guilib/VideoVersionHelper.h
+++ b/xbmc/video/guilib/VideoVersionHelper.h
@@ -19,8 +19,7 @@ namespace GUILIB
 class CVideoVersionHelper
 {
 public:
-  static std::shared_ptr<CFileItem> ChooseMovieFromVideoAssets(
-      const std::shared_ptr<CFileItem>& item);
+  static std::shared_ptr<CFileItem> ChooseVideoFromAssets(const std::shared_ptr<CFileItem>& item);
 };
 } // namespace GUILIB
 

--- a/xbmc/video/guilib/VideoVersionHelper.h
+++ b/xbmc/video/guilib/VideoVersionHelper.h
@@ -19,7 +19,7 @@ namespace GUILIB
 class CVideoVersionHelper
 {
 public:
-  static std::shared_ptr<CFileItem> ChooseMovieFromVideoVersions(
+  static std::shared_ptr<CFileItem> ChooseMovieFromVideoAssets(
       const std::shared_ptr<CFileItem>& item);
 };
 } // namespace GUILIB

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1474,7 +1474,7 @@ void CGUIWindowVideoBase::UpdateVideoVersionItems()
       int videoVersionId{-1};
       if (item->GetVideoInfoTag()->HasVideoVersions())
       {
-        if (item->GetProperty("has_resolved_video_version").asBoolean(false))
+        if (item->GetProperty("has_resolved_video_asset").asBoolean(false))
         {
           // certain version of the movie
           videoVersionId = item->GetVideoInfoTag()->GetAssetInfo().GetId();


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Reenabled the toggle between selection of versions and extras in the "Choose video" dialog when started from library select.

Playback of extras from context menu didn't work due to path handling, which goes much beyond the scope of this PR, so context menu changes are not included.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Easier access to playback of extras, only available through Info > Extras previously.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tried with movies that have single version, single version and extras, multiple versions, multiple versions and extras
Play from library select and context menu Choose version / Play version using...
Local and remote files (smb, nfs)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Easier access to playback of extras, fixed version playback in context menu.

## Screenshots (if appropriate):
Before:
![image](https://github.com/xbmc/xbmc/assets/489377/56f04daa-8161-4ba5-b3bf-65252f541653)


With PR, dialog from library selection (with toggle between versions and extras):
![image](https://github.com/xbmc/xbmc/assets/489377/7cac3fdf-6b1e-431e-8f89-eac91ccb767f)

Dialog from context menu Choose version / Play version using... (no toggle to extras):
![image](https://github.com/xbmc/xbmc/assets/489377/97efca5c-d58c-4e28-b8a0-5d015980cd16)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
