### PR TITLE
[Backport] Fix the scourge of game add-on build failures

### DIFF
--- a/tools/buildsteps/windows/prepare-env.bat
+++ b/tools/buildsteps/windows/prepare-env.bat
@@ -13,6 +13,9 @@ IF EXIST %WORKSPACE%\project\Win32BuildSetup\BUILD_WIN32 rmdir %WORKSPACE%\proje
 rem also clean 'build' dir used to build ffmpeg as git clean has trouble to remove some times
 IF EXIST %WORKSPACE%\project\BuildDependencies\build rmdir %WORKSPACE%\project\BuildDependencies\build /S /Q
 
+rem daemonized gpg-agent blocks mingw from being cleaned with git
+TASKKILL /IM "gpg-agent.exe" /F >nul 2>&1
+
 rem we assume git in path as this is a requirement
 rem git clean the untracked files and directories
 rem but keep the downloaded dependencies

--- a/tools/buildsteps/windows/prepare-env.bat
+++ b/tools/buildsteps/windows/prepare-env.bat
@@ -20,7 +20,7 @@ rem we assume git in path as this is a requirement
 rem git clean the untracked files and directories
 rem but keep the downloaded dependencies
 rem also keeps MSYS2 installation
-SET GIT_CLEAN_CMD=git clean -xffd -e "project/BuildDependencies/downloads" -e "project/BuildDependencies/downloads2" -e "project/BuildDependencies/mingwlibs" -e "project/BuildDependencies/msys64" -e "project/BuildDependencies/tools"
+SET GIT_CLEAN_CMD=git clean -xffd -e "project/BuildDependencies/downloads" -e "project/BuildDependencies/downloads2" -e "project/BuildDependencies/mingwlibs" -e "project/BuildDependencies/msys64" -e "project/BuildDependencies/tools" -e "cmake/addons/build/download/msys2-base-*.tar.xz"
 
 ECHO running %GIT_CLEAN_CMD%
 %GIT_CLEAN_CMD%


### PR DESCRIPTION
## Description

Backport of https://github.com/xbmc/xbmc/pull/24531.

Because we build game add-ons against Nexus, this needs to be in the Nexus branch.

## Motivation and context

After https://github.com/xbmc/xbmc/pull/24531, building game add-ons against Omega is successful: https://jenkins.kodi.tv/blue/organizations/jenkins/kodi-game%2Fgame.libretro.2048/detail/master/145/pipeline/.

However, our CI script targets Nexus. It should target Leia, as the libretro remains at v1.0.0 as it was back then, but we're far more limited in Kodi compatibility than Libretto compatibility (which has never broken against v1.0.0), and Leia (even Matrix) scripts clearly no longer work.

So, might as well target the last stable release of Kodi, which is where this PR ends up.

## How has this been tested?

Tested against omega: https://jenkins.kodi.tv/blue/organizations/jenkins/kodi-game%2Fgame.libretro.2048/detail/master/145/pipeline/.

## What is the effect on users?

* None

# How has this been tested?

Build game add-on against Nexus, observed, command wasn't modifiied:

```
c:\jenkins-workspace\workspace\binary-addons\kodi-windows-x86_64-Nexus>tools/buildsteps/windows/x64/prepare-env.bat

Workspace is c:\jenkins-workspace\workspace\binary-addons\kodi-windows-x86_64-Nexus

running git clean -xffd -e "project/BuildDependencies/downloads" -e "project/BuildDependencies/downloads2" -e "project/BuildDependencies/mingwlibs" -e "project/BuildDependencies/msys64" -e "project/BuildDependencies/tools"

Removing cmake/addons/build/
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
