### PR TITLE
Revert "[guilib][utils] Set IsPlayable false on add items"

### DIFF
--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -930,10 +930,10 @@ bool IsItemPlayable(const CFileItem& item)
     return true;
   else if (item.m_bIsFolder)
   {
-    if (!item.HasProperty("IsPlayable") || item.GetProperty("IsPlayable").asBoolean())
-    {
+    // Not a music-specific folder (just file:// or nfs://). Allow play if context is Music window.
+    if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_MUSIC_NAV &&
+        item.GetPath() != "add") // Exclude "Add music source" item
       return true;
-    }
   }
   return false;
 }

--- a/xbmc/video/VideoUtils.cpp
+++ b/xbmc/video/VideoUtils.cpp
@@ -606,10 +606,10 @@ bool IsItemPlayable(const CFileItem& item)
   }
   else if (item.m_bIsFolder)
   {
-    if (!item.HasProperty("IsPlayable") || item.GetProperty("IsPlayable").asBoolean())
-    {
+    // Not a video-specific folder (like file:// or nfs://). Allow play if context is Video window.
+    if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_VIDEO_NAV &&
+        item.GetPath() != "add") // Exclude "Add video source" item
       return true;
-    }
   }
 
   return false;

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -907,7 +907,6 @@ bool CGUIMediaWindow::Update(const std::string &strDirectory, bool updateFilterP
     const std::string& strLabel = g_localizeStrings.Get(showLabel);
     CFileItemPtr pItem(new CFileItem(strLabel));
     pItem->SetPath("add");
-    pItem->SetProperty("IsPlayable", false);
     pItem->SetArt("icon", "DefaultAddSource.png");
     pItem->SetLabel(strLabel);
     pItem->SetLabelPreformatted(true);

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -493,7 +493,6 @@ bool CGUIWindowFileManager::Update(int iList, const std::string &strDirectory)
     const std::string& strLabel = g_localizeStrings.Get(1026);
     CFileItemPtr pItem(new CFileItem(strLabel));
     pItem->SetPath("add");
-    pItem->SetProperty("IsPlayable", false);
     pItem->SetArt("icon", "DefaultAddSource.png");
     pItem->SetLabel(strLabel);
     pItem->SetLabelPreformatted(true);


### PR DESCRIPTION
This reverts commit f6dd52e3aee595ddb6b6079253db51dd00a710b4.

## Description
Reverts https://github.com/xbmc/xbmc/pull/24461 to solve https://github.com/xbmc/xbmc/issues/24560

## Motivation and context
I don't see other way of fixing this. The original change was simply an architectural improvement to remove dependencies on GUI but the only consumers are actually on the scope of GUI anyway...

We want to show the play item context menu if we're browsing a media folder - we can't simply set the property on the CFileItemList (we'd have to iterate over all items on the list) and would also affect directory caching.
