### PR TITLE
GL: improve HQ scaler quality/performance

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7356,6 +7356,31 @@ msgid "Enable HQ scalers for scaling above"
 msgstr ""
 
 #: system/settings/settings.xml
+msgctxt "#39198"
+msgid "HQ upscaler intermediate format"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#39199"
+msgid "Sets the precision of the intermediate scaling buffer used in the GPU rendering path. 16 bit precision likely demands more performance. If the hardware is unable to support the selected format, Kodi will fall back to the next best format."
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#39200"
+msgid "8 bit per channel"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#39201"
+msgid "10 bit per channel"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#39202"
+msgid "16 bit per channel"
+msgstr ""
+
+#: system/settings/settings.xml
 msgctxt "#13436"
 msgid "Adjust display HDR mode"
 msgstr ""

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -123,6 +123,19 @@
             <formatlabel>14047</formatlabel>
           </control>
         </setting>
+        <setting id="videoplayer.hqscalerprecision" type="integer" label="39198" help="39199">
+          <requirement>HAS_GL</requirement>
+          <level>2</level>
+          <default>10</default>
+          <constraints>
+            <options>
+              <option label="39200">8</option>
+              <option label="39201">10</option>
+              <option label="39202">16</option>
+            </options>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
         <setting id="videoplayer.usesuperresolution" type="boolean" label="13417" help="39194">
           <requirement>HAS_DX</requirement>
           <dependencies>

--- a/system/shaders/GL/1.5/gl_convolution-4x4.glsl
+++ b/system/shaders/GL/1.5/gl_convolution-4x4.glsl
@@ -67,5 +67,10 @@ vec4 process()
     line(xystart.y + stepxy.y * 3.0, xpos, linetaps) * columntaps.a;
 
   rgb.a = m_alpha;
+
+#if defined(KODI_GAMMA_LINEARIZATION_FAST)
+  rgb.rgb *= rgb.rgb;
+#endif
+
   return rgb;
 }

--- a/system/shaders/GL/1.5/gl_convolution-6x6.glsl
+++ b/system/shaders/GL/1.5/gl_convolution-6x6.glsl
@@ -79,5 +79,9 @@ vec4 process()
 
   rgb.a = m_alpha;
 
+#if defined(KODI_GAMMA_LINEARIZATION_FAST)
+  rgb.rgb *= rgb.rgb;
+#endif
+
   return rgb;
 }

--- a/system/shaders/GL/1.5/gl_yuv2rgb_basic.glsl
+++ b/system/shaders/GL/1.5/gl_yuv2rgb_basic.glsl
@@ -119,5 +119,9 @@ vec4 process()
 
 #endif
 
+#if defined(KODI_GAMMA_LINEARIZATION_FAST)
+  rgb.rgb = sqrt(rgb.rgb);
+#endif
+
   return rgb;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -131,6 +131,21 @@ CLinuxRendererGL::CLinuxRendererGL()
   m_cmsOn = false;
 
   m_renderSystem = dynamic_cast<CRenderSystemGL*>(CServiceBroker::GetRenderSystem());
+
+  int32_t intermediatePrecision = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+      CSettings::SETTING_VIDEOPLAYER_HQSCALERPRECISION);
+  if (intermediatePrecision == 16)
+  {
+    m_intermediateFormat = GL_RGBA16;
+    m_intermediateType = GL_SHORT;
+    m_intermediateGammaCorrection = true;
+  }
+  else if (intermediatePrecision == 10)
+  {
+    m_intermediateFormat = GL_RGB10_A2;
+    m_intermediateType = GL_UNSIGNED_INT_2_10_10_10_REV;
+    m_intermediateGammaCorrection = true;
+  }
 }
 
 CLinuxRendererGL::~CLinuxRendererGL()
@@ -825,7 +840,8 @@ void CLinuxRendererGL::UpdateVideoFilter()
         break;
       }
 
-      if (!m_fbo.fbo.CreateAndBindToTexture(GL_TEXTURE_2D, m_sourceWidth, m_sourceHeight, GL_RGBA16, GL_SHORT))
+      if (!m_fbo.fbo.CreateAndBindToTexture(GL_TEXTURE_2D, m_sourceWidth, m_sourceHeight,
+                                            m_intermediateFormat, m_intermediateType, GL_NEAREST))
       {
         CLog::Log(LOGERROR, "GL: Error creating texture and binding to FBO");
         break;
@@ -839,14 +855,14 @@ void CLinuxRendererGL::UpdateVideoFilter()
         m_cmsOn ? m_fullRange : false,
         m_cmsOn ? m_tCLUTTex : 0,
         m_CLUTsize);
-    m_pVideoFilterShader = new ConvolutionFilterShader(m_scalingMethod, m_nonLinStretch, out);
+    m_pVideoFilterShader = new ConvolutionFilterShader(m_scalingMethod, m_nonLinStretch,
+                                                       m_intermediateGammaCorrection, out);
     if (!m_pVideoFilterShader->CompileAndLink())
     {
       CLog::Log(LOGERROR, "GL: Error compiling and linking video filter shader");
       break;
     }
 
-    SetTextureFilter(GL_LINEAR);
     m_renderQuality = RQ_MULTIPASS;
     return;
 
@@ -935,9 +951,11 @@ void CLinuxRendererGL::LoadShaders(int field)
 
     if (!m_pYUVShader)
     {
-      m_pYUVShader = new YUV2RGBProgressiveShader(m_textureTarget == GL_TEXTURE_RECTANGLE, shaderFormat,
-                                                  m_nonLinStretch && m_renderQuality == RQ_SINGLEPASS,
-                                                  AVColorPrimaries::AVCOL_PRI_BT709, m_srcPrimaries, m_toneMap, m_toneMapMethod, out);
+      m_pYUVShader = new YUV2RGBProgressiveShader(
+          m_textureTarget == GL_TEXTURE_RECTANGLE, shaderFormat,
+          m_nonLinStretch && m_renderQuality == RQ_SINGLEPASS, AVColorPrimaries::AVCOL_PRI_BT709,
+          m_srcPrimaries, m_toneMap, m_toneMapMethod, out,
+          m_intermediateGammaCorrection && m_renderQuality == RQ_MULTIPASS);
 
       if (!m_cmsOn)
         m_pYUVShader->SetConvertFullColorRange(m_fullRange);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
@@ -146,6 +146,10 @@ protected:
     float width, height;
   } m_fbo;
 
+  GLint m_intermediateFormat{GL_RGBA8};
+  GLint m_intermediateType{GL_UNSIGNED_BYTE};
+  bool m_intermediateGammaCorrection{false};
+
   int m_iYV12RenderBuffer = 0;
   int m_NumYV12Buffers = 0;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGL.cpp
@@ -48,7 +48,10 @@ BaseVideoFilterShader::~BaseVideoFilterShader()
 // ConvolutionFilterShader - base class for video filter shaders
 //////////////////////////////////////////////////////////////////////
 
-ConvolutionFilterShader::ConvolutionFilterShader(ESCALINGMETHOD method, bool stretch, GLSLOutput *output)
+ConvolutionFilterShader::ConvolutionFilterShader(ESCALINGMETHOD method,
+                                                 bool stretch,
+                                                 bool gammaCorrection,
+                                                 GLSLOutput* output)
 {
   m_method = method;
 
@@ -92,6 +95,9 @@ ConvolutionFilterShader::ConvolutionFilterShader(ESCALINGMETHOD method, bool str
     defines += "#define XBMC_STRETCH 1\n";
   else
     defines += "#define XBMC_STRETCH 0\n";
+
+  if (gammaCorrection)
+    defines += "#define KODI_GAMMA_LINEARIZATION_FAST\n";
 
   // get defines from the output stage if used
   m_glslOutput = output;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGL.h
@@ -74,7 +74,10 @@ protected:
   class ConvolutionFilterShader : public BaseVideoFilterShader
   {
   public:
-    ConvolutionFilterShader(ESCALINGMETHOD method, bool stretch, GLSLOutput *output=NULL);
+    ConvolutionFilterShader(ESCALINGMETHOD method,
+                            bool stretch,
+                            bool gammaCorrection,
+                            GLSLOutput* output = NULL);
     ~ConvolutionFilterShader() override;
     void OnCompiledAndLinked() override;
     bool OnEnabled() override;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.cpp
@@ -272,7 +272,8 @@ YUV2RGBProgressiveShader::YUV2RGBProgressiveShader(bool rect,
                                                    AVColorPrimaries srcPrimaries,
                                                    bool toneMap,
                                                    ETONEMAPMETHOD toneMapMethod,
-                                                   std::shared_ptr<GLSLOutput> output)
+                                                   std::shared_ptr<GLSLOutput> output,
+                                                   bool gammaCorrection)
   : BaseYUV2RGBGLSLShader(rect,
                           format,
                           stretch,
@@ -282,6 +283,9 @@ YUV2RGBProgressiveShader::YUV2RGBProgressiveShader(bool rect,
                           toneMapMethod,
                           std::move(output))
 {
+  if (gammaCorrection)
+    m_defines += "#define KODI_GAMMA_LINEARIZATION_FAST\n";
+
   PixelShader()->LoadSource("gl_yuv2rgb_basic.glsl", m_defines);
   PixelShader()->AppendSource("gl_output.glsl");
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.h
@@ -134,7 +134,8 @@ public:
                            AVColorPrimaries srcPrimaries,
                            bool toneMap,
                            ETONEMAPMETHOD toneMapMethod,
-                           std::shared_ptr<GLSLOutput> output);
+                           std::shared_ptr<GLSLOutput> output,
+                           bool gammaCorrection);
 };
 
 class YUV2RGBFilterShader4 : public BaseYUV2RGBGLSLShader

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -118,6 +118,7 @@ public:
       "videoplayer.quitstereomodeonstop";
   static constexpr auto SETTING_VIDEOPLAYER_RENDERMETHOD = "videoplayer.rendermethod";
   static constexpr auto SETTING_VIDEOPLAYER_HQSCALERS = "videoplayer.hqscalers";
+  static constexpr auto SETTING_VIDEOPLAYER_HQSCALERPRECISION = "videoplayer.hqscalerprecision";
   static constexpr auto SETTING_VIDEOPLAYER_USESUPERRESOLUTION = "videoplayer.usesuperresolution";
   static constexpr auto SETTING_VIDEOPLAYER_HIGHPRECISIONPROCESSING = "videoplayer.highprecision";
   static constexpr auto SETTING_VIDEOPLAYER_USEMEDIACODEC = "videoplayer.usemediacodec";


### PR DESCRIPTION
## Description
The PR adds a new setting for the intermediate buffer format of the HQ upscaler on GL. The user can now choose a precision between 8, 10 (default) and 16 bit per color channel.

If 10/16 bit upscaling is active, the buffer is also "linearized" (with an fast approximation).

## Motivation and context
Previously, we had an FP16 intermediate format. This equates to 64bit/texel. With the 8 and 10 bit options, we reduce texture memory bandwidth/storage by half (32bit/texel). For an intermediate format of 1280x720/60fps, this equates to roughly 440MB/s savings. On a lot of GPUs, the 32bit texture rate is also double that of 64bit formats, marking an additional improvement.

The intermediate buffer (and subsequent scaling) is gamma corrected (when using a 10/16 buffer), which increases scaling quality. Bright highlights now have less effect on the upscaled image. There is also less ringing in dark regions with an adjacent light transitions.

## How has this been tested?
The 10 bit buffer is noticeably faster on my desktop (RX570).  The scenes below render at 440/470/600 µs for the respective 8/10/16 bit buffer.

## What is the effect on users?
Higher performance and quality when using the HQ scalers.

## Screenshots (if appropriate):
Elephants Dream upscaled with Lanczos2 from 854x480 to 1920x1080.

8 bit intermediate:
![8bit](https://github.com/xbmc/xbmc/assets/30039775/b2ee5387-1631-4f6a-bc51-949169a170be)

10 bit intermediate (gamma corrected):
![10bit](https://github.com/xbmc/xbmc/assets/30039775/f2f8be87-dfc4-48ad-9e74-e00850e23c3c)

16 bit intermediate (gamma corrected):
![16bit](https://github.com/xbmc/xbmc/assets/30039775/4fa9bc12-540a-4176-a984-3bc06264bff9)

No gamma correction (8 bit) vs gamma correction (10 bit). Notice the less pronounced ringing in the darker portions:
![8vs10](https://github.com/xbmc/xbmc/assets/30039775/a1be9170-8538-41e3-adc6-3a5ae2ca0286)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
