### PR TITLE
[VideoInfoScanner] Fix processing of <episodeguide> in TV show's NFO.

### DIFF
--- a/xbmc/NfoFile.cpp
+++ b/xbmc/NfoFile.cpp
@@ -59,12 +59,13 @@ CInfoScanner::INFO_TYPE CNfoFile::Create(const std::string& strPath,
       int infos=0;
       while (m_headPos != std::string::npos && details.m_iEpisode != episode)
       {
-        m_headPos = m_doc.find("<episodedetails", m_headPos + 1);
+        m_headPos = m_doc.find("<episodedetails", m_headPos);
         if (m_headPos == std::string::npos)
           break;
 
         bNfo  = GetDetails(details);
         infos++;
+        m_headPos++;
       }
       if (details.m_iEpisode != episode)
       {

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1955,7 +1955,7 @@ namespace VIDEO
       if (!hasEpisodeGuide)
       {
         // fetch episode guide
-        if (!showInfo.m_strEpisodeGuide.empty())
+        if (!showInfo.m_strEpisodeGuide.empty() && scraper->ID() != "metadata.local")
         {
           CScraperUrl url;
           url.ParseAndAppendUrlsFromEpisodeGuide(showInfo.m_strEpisodeGuide);
@@ -1978,8 +1978,10 @@ namespace VIDEO
       {
         CLog::Log(LOGERROR,
                   "VideoInfoScanner: Asked to lookup episode {}"
-                  " online, but we have no episode guide. Check your tvshow.nfo and make"
-                  " sure the <episodeguide> tag is in place.",
+                  " online, but we have either no episode guide or"
+                  " we are using the local scraper. Check your tvshow.nfo and make"
+                  " sure the <episodeguide> tag is in place and/or use an online"
+                  " scraper.",
                   CURL::GetRedacted(file->strPath));
         continue;
       }


### PR DESCRIPTION
## Description

Fix #24559.

## Motivation and context

As explained by @KarellenX - it looks like there are two problems.

1) If there is an episode NFO the `<episodedetails>` (or at least the first one) is not processed. There is an error in the code that means the search for the starts from position 1 and not position 0 in the file.

2) If the scraper is set to local, information is still retrieved online. There is now a check.

## How has this been tested?

Locally

## What is the effect on users?

Fixes above.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
