### PR TITLE
Add another msys2 binary to fix game add-on build failures

### DIFF
--- a/tools/buildsteps/windows/prepare-env.bat
+++ b/tools/buildsteps/windows/prepare-env.bat
@@ -13,7 +13,8 @@ IF EXIST %WORKSPACE%\project\Win32BuildSetup\BUILD_WIN32 rmdir %WORKSPACE%\proje
 rem also clean 'build' dir used to build ffmpeg as git clean has trouble to remove some times
 IF EXIST %WORKSPACE%\project\BuildDependencies\build rmdir %WORKSPACE%\project\BuildDependencies\build /S /Q
 
-rem daemonized gpg-agent blocks mingw from being cleaned with git
+rem daemonized executables block mingw from being cleaned with git
+TASKKILL /IM "dirmngr.exe" /F >nul 2>&1
 TASKKILL /IM "gpg-agent.exe" /F >nul 2>&1
 
 rem we assume git in path as this is a requirement


### PR DESCRIPTION
## Description

This PR adds another msys2 binary to be killed if it gets stuck running. Jenkins got stuck on this one after about 40 windows builds. I hit problems with `dirmngr.exe` also while testing https://github.com/xbmc/xbmc/pull/24562, but didn't include it because I hadn't seen jenkins fail on it yet.

Now that the failure has occurred, let's include `dirmngr.exe` in the list of msys2 executables to kill.

## Motivation and context

Get to a wall of green: https://jenkins.kodi.tv/view/Game%20Binary%20Addons/

## How has this been tested?

After about 40 Windows builds, Jenkins hit the error:

```
  running git clean -xffd -e "project/BuildDependencies/downloads" -e "project/BuildDependencies/downloads2" -e "project/BuildDependencies/mingwlibs" -e "project/BuildDependencies/msys64" -e "project/BuildDependencies/tools" -e "cmake/addons/build/download/msys2-base-*.tar.xz"
  warning: failed to remove cmake/addons/build/mingw/src/mingw/usr/bin/dirmngr.exe: Invalid argument
  warning: failed to remove cmake/addons/build/mingw/src/mingw/usr/bin/msys-2.0.dll: Invalid argument
  warning: failed to remove cmake/addons/build/mingw/src/mingw/usr/bin/msys-assuan-0.dll: Invalid argument
  warning: failed to remove cmake/addons/build/mingw/src/mingw/usr/bin/msys-ffi-8.dll: Invalid argument
  warning: failed to remove cmake/addons/build/mingw/src/mingw/usr/bin/msys-gcc_s-seh-1.dll: Invalid argument
  warning: failed to remove cmake/addons/build/mingw/src/mingw/usr/bin/msys-gcrypt-20.dll: Invalid argument
  warning: failed to remove cmake/addons/build/mingw/src/mingw/usr/bin/msys-gmp-10.dll: Invalid argument
  warning: failed to remove cmake/addons/build/mingw/src/mingw/usr/bin/msys-gnutls-30.dll: Invalid argument
  warning: failed to remove cmake/addons/build/mingw/src/mingw/usr/bin/msys-gpg-error-0.dll: Invalid argument
  warning: failed to remove cmake/addons/build/mingw/src/mingw/usr/bin/msys-hogweed-6.dll: Invalid argument
  warning: failed to remove cmake/addons/build/mingw/src/mingw/usr/bin/msys-iconv-2.dll: Invalid argument
  warning: failed to remove cmake/addons/build/mingw/src/mingw/usr/bin/msys-idn2-0.dll: Invalid argument
  warning: failed to remove cmake/addons/build/mingw/src/mingw/usr/bin/msys-intl-8.dll: Invalid argument
  warning: failed to remove cmake/addons/build/mingw/src/mingw/usr/bin/msys-ksba-8.dll: Invalid argument
  warning: failed to remove cmake/addons/build/mingw/src/mingw/usr/bin/msys-nettle-8.dll: Invalid argument
  warning: failed to remove cmake/addons/build/mingw/src/mingw/usr/bin/msys-npth-0.dll: Invalid argument
  warning: failed to remove cmake/addons/build/mingw/src/mingw/usr/bin/msys-p11-kit-0.dll: Invalid argument
  warning: failed to remove cmake/addons/build/mingw/src/mingw/usr/bin/msys-tasn1-6.dll: Invalid argument
  warning: failed to remove cmake/addons/build/mingw/src/mingw/usr/bin/msys-unistring-5.dll: Invalid argument
  warning: failed to remove cmake/addons/build/mingw/src/mingw/usr/bin/msys-z.dll: Invalid argument
```

With the patch applied, the error goes away on my local machine.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
