### PR TITLE
[Backport] Add another msys2 binary to fix game add-on build failures

### DIFF
--- a/tools/buildsteps/windows/prepare-env.bat
+++ b/tools/buildsteps/windows/prepare-env.bat
@@ -13,7 +13,8 @@ IF EXIST %WORKSPACE%\project\Win32BuildSetup\BUILD_WIN32 rmdir %WORKSPACE%\proje
 rem also clean 'build' dir used to build ffmpeg as git clean has trouble to remove some times
 IF EXIST %WORKSPACE%\project\BuildDependencies\build rmdir %WORKSPACE%\project\BuildDependencies\build /S /Q
 
-rem daemonized gpg-agent blocks mingw from being cleaned with git
+rem daemonized executables block mingw from being cleaned with git
+TASKKILL /IM "dirmngr.exe" /F >nul 2>&1
 TASKKILL /IM "gpg-agent.exe" /F >nul 2>&1
 
 rem we assume git in path as this is a requirement


### PR DESCRIPTION
## Description

Backport of https://github.com/xbmc/xbmc/pull/24567, needed because we currently build game add-ons against the Nexus branch.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
