### PR TITLE
[video] Remove non-working context menu manage / info dialog buttons for versions

### DIFF
--- a/addons/skin.estuary/xml/DialogVideoInfo.xml
+++ b/addons/skin.estuary/xml/DialogVideoInfo.xml
@@ -647,6 +647,7 @@
 						<param name="id" value="10" />
 						<param name="icon" value="icons/infodialogs/choose_image.png" />
 						<param name="label" value="$LOCALIZE[13511]" />
+						<param name="visible" value="Control.IsEnabled(10)" />
 					</include>
 					<include content="InfoDialogButton">
 						<param name="id" value="6" />

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -4273,17 +4273,3 @@ bool CFileItem::HasVideoExtras() const
   }
   return false;
 }
-
-bool CFileItem::IsVideoAssetNav() const
-{
-  if (!IsVideoDb())
-    return false;
-
-  // @todo maybe in the future look for prefix videodb://movies/videoversions in path instead
-  // @todo better encoding of video assets as path, they won't always be tied with movies.
-  const CURL itemUrl{GetPath()};
-  if (itemUrl.HasOption("videoversionid"))
-    return true;
-
-  return false;
-}

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -261,7 +261,6 @@ public:
   bool IsLiveTV() const;
   bool IsRSS() const;
   bool IsAndroidApp() const;
-  bool IsVideoAssetNav() const;
 
   bool HasVideoVersions() const;
   bool HasVideoExtras() const;

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -30,6 +30,7 @@
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
 #include "video/VideoInfoTag.h"
+#include "video/guilib/VideoVersionHelper.h"
 
 #include <algorithm>
 #include <cstdlib>
@@ -398,7 +399,7 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
     m_videoDatabase->Open();
 
     // @todo unify asset path for other items path
-    if (item.IsVideoAssetNav())
+    if (VIDEO::IsVideoAssetFile(item))
     {
       if (m_videoDatabase->GetArtForAsset(tag.m_iFileId,
                                           item.GetProperty("noartfallbacktoowner").asBoolean(false)

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -59,6 +59,7 @@
 #include "video/dialogs/GUIDialogVideoManagerExtras.h"
 #include "video/dialogs/GUIDialogVideoManagerVersions.h"
 #include "video/guilib/VideoPlayActionProcessor.h"
+#include "video/guilib/VideoVersionHelper.h"
 #include "video/windows/GUIWindowVideoNav.h"
 
 #include <algorithm>
@@ -277,7 +278,7 @@ void CGUIDialogVideoInfo::OnInitWindow()
     CONTROL_DISABLE(CONTROL_BTN_REFRESH);
 
   // @todo add support to edit video asset art. Until then edit art through Versions Manager.
-  if (m_movieItem->m_bIsFolder || !m_movieItem->IsVideoAssetNav())
+  if (!VIDEO::IsVideoAssetFile(*m_movieItem))
     CONTROL_ENABLE_ON_CONDITION(
         CONTROL_BTN_GET_THUMB,
         (profileManager->GetCurrentProfile().canWriteDatabases() ||
@@ -1068,18 +1069,18 @@ int CGUIDialogVideoInfo::ManageVideoItem(const std::shared_ptr<CFileItem>& item)
   int dbId = item->GetVideoInfoTag()->m_iDbId;
 
   CContextButtons buttons;
-  if ((type == MediaTypeMovie && (item->m_bIsFolder || !item->IsVideoAssetNav())) ||
+  if ((type == MediaTypeMovie && !VIDEO::IsVideoAssetFile(*item)) ||
       type == MediaTypeVideoCollection || type == MediaTypeTvShow || type == MediaTypeEpisode ||
       (type == MediaTypeSeason &&
        item->GetVideoInfoTag()->m_iSeason > 0) || // seasons without "all seasons" and "specials"
       type == MediaTypeMusicVideo)
     buttons.Add(CONTEXT_BUTTON_EDIT, 16105);
 
-  if ((type == MediaTypeMovie && (item->m_bIsFolder || !item->IsVideoAssetNav())) ||
-      type == MediaTypeTvShow || type == MediaTypeSeason)
+  if ((type == MediaTypeMovie && !VIDEO::IsVideoAssetFile(*item)) || type == MediaTypeTvShow ||
+      type == MediaTypeSeason)
     buttons.Add(CONTEXT_BUTTON_EDIT_SORTTITLE, 16107);
 
-  if (type == MediaTypeMovie && (item->m_bIsFolder || !item->IsVideoAssetNav()))
+  if (type == MediaTypeMovie && !VIDEO::IsVideoAssetFile(*item))
   {
     // only show link/unlink if there are tvshows available
     if (database.HasContent(VideoDbContentType::TVSHOWS))
@@ -1104,8 +1105,8 @@ int CGUIDialogVideoInfo::ManageVideoItem(const std::shared_ptr<CFileItem>& item)
     buttons.Add(CONTEXT_BUTTON_UNLINK_BOOKMARK, 20405);
 
   if (type == MediaTypeVideoCollection ||
-      (type == MediaTypeMovie && (item->m_bIsFolder || !item->IsVideoAssetNav())) ||
-      type == MediaTypeTvShow || type == MediaTypeSeason || type == MediaTypeEpisode)
+      (type == MediaTypeMovie && !VIDEO::IsVideoAssetFile(*item)) || type == MediaTypeTvShow ||
+      type == MediaTypeSeason || type == MediaTypeEpisode)
     buttons.Add(CONTEXT_BUTTON_SET_ART, 13511);
 
   // movie sets
@@ -1129,7 +1130,7 @@ int CGUIDialogVideoInfo::ManageVideoItem(const std::shared_ptr<CFileItem>& item)
     }
   }
 
-  if (type != MediaTypeSeason && (item->m_bIsFolder || !item->IsVideoAssetNav()))
+  if (type != MediaTypeSeason && !VIDEO::IsVideoAssetFile(*item))
   {
     // Remove from library
     buttons.Add(CONTEXT_BUTTON_DELETE, 646);

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1060,16 +1060,18 @@ int CGUIDialogVideoInfo::ManageVideoItem(const std::shared_ptr<CFileItem>& item)
   int dbId = item->GetVideoInfoTag()->m_iDbId;
 
   CContextButtons buttons;
-  if (type == MediaTypeMovie || type == MediaTypeVideoCollection ||
-      type == MediaTypeTvShow || type == MediaTypeEpisode ||
-     (type == MediaTypeSeason && item->GetVideoInfoTag()->m_iSeason > 0) ||  // seasons without "all seasons" and "specials"
+  if ((type == MediaTypeMovie && (item->m_bIsFolder || !item->IsVideoAssetNav())) ||
+      type == MediaTypeVideoCollection || type == MediaTypeTvShow || type == MediaTypeEpisode ||
+      (type == MediaTypeSeason &&
+       item->GetVideoInfoTag()->m_iSeason > 0) || // seasons without "all seasons" and "specials"
       type == MediaTypeMusicVideo)
     buttons.Add(CONTEXT_BUTTON_EDIT, 16105);
 
-  if (type == MediaTypeMovie || type == MediaTypeTvShow || type == MediaTypeSeason)
+  if ((type == MediaTypeMovie && (item->m_bIsFolder || !item->IsVideoAssetNav())) ||
+      type == MediaTypeTvShow || type == MediaTypeSeason)
     buttons.Add(CONTEXT_BUTTON_EDIT_SORTTITLE, 16107);
 
-  if (type == MediaTypeMovie)
+  if (type == MediaTypeMovie && (item->m_bIsFolder || !item->IsVideoAssetNav()))
   {
     // only show link/unlink if there are tvshows available
     if (database.HasContent(VideoDbContentType::TVSHOWS))
@@ -1081,7 +1083,10 @@ int CGUIDialogVideoInfo::ManageVideoItem(const std::shared_ptr<CFileItem>& item)
 
     // set or change movie set the movie belongs to
     buttons.Add(CONTEXT_BUTTON_SET_MOVIESET, 20465);
+  }
 
+  if (type == MediaTypeMovie)
+  {
     // manage video versions
     buttons.Add(CONTEXT_BUTTON_MANAGE_VIDEOVERSIONS, 40001); // Manage versions
   }
@@ -1090,8 +1095,9 @@ int CGUIDialogVideoInfo::ManageVideoItem(const std::shared_ptr<CFileItem>& item)
       item->GetVideoInfoTag()->m_iBookmarkId > 0)
     buttons.Add(CONTEXT_BUTTON_UNLINK_BOOKMARK, 20405);
 
-  if (type == MediaTypeVideoCollection || type == MediaTypeMovie || type == MediaTypeTvShow ||
-      type == MediaTypeSeason || type == MediaTypeEpisode)
+  if (type == MediaTypeVideoCollection ||
+      (type == MediaTypeMovie && (item->m_bIsFolder || !item->IsVideoAssetNav())) ||
+      type == MediaTypeTvShow || type == MediaTypeSeason || type == MediaTypeEpisode)
     buttons.Add(CONTEXT_BUTTON_SET_ART, 13511);
 
   // movie sets
@@ -1115,8 +1121,11 @@ int CGUIDialogVideoInfo::ManageVideoItem(const std::shared_ptr<CFileItem>& item)
     }
   }
 
-  if (type != MediaTypeSeason)
+  if (type != MediaTypeSeason && (item->m_bIsFolder || !item->IsVideoAssetNav()))
+  {
+    // Remove from library
     buttons.Add(CONTEXT_BUTTON_DELETE, 646);
+  }
 
   //temporary workaround until the context menu ids are removed
   const int addonItemOffset = 10000;

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -275,10 +275,18 @@ void CGUIDialogVideoInfo::OnInitWindow()
         g_passwordManager.bMasterUser));
   else
     CONTROL_DISABLE(CONTROL_BTN_REFRESH);
-  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_GET_THUMB,
-      (profileManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser) &&
-      !StringUtils::StartsWithNoCase(m_movieItem->GetVideoInfoTag()->
-      GetUniqueID().c_str(), "plugin"));
+
+  // @todo add support to edit video asset art. Until then edit art through Versions Manager.
+  if (m_movieItem->m_bIsFolder || !m_movieItem->IsVideoAssetNav())
+    CONTROL_ENABLE_ON_CONDITION(
+        CONTROL_BTN_GET_THUMB,
+        (profileManager->GetCurrentProfile().canWriteDatabases() ||
+         g_passwordManager.bMasterUser) &&
+            !StringUtils::StartsWithNoCase(m_movieItem->GetVideoInfoTag()->GetUniqueID().c_str(),
+                                           "plugin"));
+  else
+    CONTROL_DISABLE(CONTROL_BTN_GET_THUMB);
+
   // Disable video user rating button for plugins and sets as they don't have tables to save this
   CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_USERRATING, !m_movieItem->IsPlugin() && m_movieItem->GetVideoInfoTag()->m_type != MediaTypeVideoCollection);
 

--- a/xbmc/video/guilib/VideoVersionHelper.cpp
+++ b/xbmc/video/guilib/VideoVersionHelper.cpp
@@ -10,6 +10,7 @@
 
 #include "FileItem.h"
 #include "ServiceBroker.h"
+#include "URL.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
@@ -223,4 +224,18 @@ std::shared_ptr<CFileItem> CVideoVersionHelper::ChooseMovieFromVideoVersions(
     return std::make_shared<CFileItem>(*videoVersion);
 
   return item;
+}
+
+bool VIDEO::IsVideoAssetFile(const CFileItem& item)
+{
+  if (item.m_bIsFolder || !item.IsVideoDb())
+    return false;
+
+  // @todo maybe in the future look for prefix videodb://movies/videoversions in path instead
+  // @todo better encoding of video assets as path, they won't always be tied with movies.
+  const CURL itemUrl{item.GetPath()};
+  if (itemUrl.HasOption("videoversionid"))
+    return true;
+
+  return false;
 }

--- a/xbmc/video/guilib/VideoVersionHelper.h
+++ b/xbmc/video/guilib/VideoVersionHelper.h
@@ -23,4 +23,12 @@ public:
       const std::shared_ptr<CFileItem>& item);
 };
 } // namespace GUILIB
+
+/*!
+ * \brief Is the item a video asset, excluding folders
+ * \param[in] item the item
+ * \return true if it is, false otherwise
+ */
+bool IsVideoAssetFile(const CFileItem& item);
+
 } // namespace VIDEO

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -422,8 +422,9 @@ bool CGUIWindowVideoBase::ShowInfo(const CFileItemPtr& item2, const ScraperPtr& 
   bool needsRefresh = false;
   if (bHasInfo)
   {
-    if (!info || info->Content() == CONTENT_NONE) // disable refresh button
-      item->SetProperty("xxuniqueid", "xx" + movieDetails.GetUniqueID());
+    // @todo add support to refresh movie version information
+    if (!info || info->Content() == CONTENT_NONE || (!item->m_bIsFolder && item->IsVideoAssetNav()))
+      item->SetProperty("xxuniqueid", "xx" + movieDetails.GetUniqueID()); // disable refresh button
     item->SetProperty("CheckAutoPlayNextItem", IsActive());
     *item->GetVideoInfoTag() = movieDetails;
     pDlgInfo->SetMovie(item.get());

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -61,6 +61,7 @@
 #include "video/dialogs/GUIDialogVideoInfo.h"
 #include "video/guilib/VideoPlayActionProcessor.h"
 #include "video/guilib/VideoSelectActionProcessor.h"
+#include "video/guilib/VideoVersionHelper.h"
 #include "view/GUIViewState.h"
 
 #include <memory>
@@ -423,7 +424,7 @@ bool CGUIWindowVideoBase::ShowInfo(const CFileItemPtr& item2, const ScraperPtr& 
   if (bHasInfo)
   {
     // @todo add support to refresh movie version information
-    if (!info || info->Content() == CONTENT_NONE || (!item->m_bIsFolder && item->IsVideoAssetNav()))
+    if (!info || info->Content() == CONTENT_NONE || VIDEO::IsVideoAssetFile(*item))
       item->SetProperty("xxuniqueid", "xx" + movieDetails.GetUniqueID()); // disable refresh button
     item->SetProperty("CheckAutoPlayNextItem", IsActive());
     *item->GetVideoInfoTag() = movieDetails;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Context menu > Manage on versions:
- Removed: Edit title, Edit sort title, Link to TV show, Manage movie set, Choose art, Remove from library
- Remains: Manage versions

Removed from Info dialog opened on version:
- Choose art (use Versions Manager instead)
- Refresh - not applicable to versions at this time

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Cleanup the GUI and remove options that don't work as expected

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
with "Show videos with multiple versions as folder" and without, on movies with and without versions, inside the versions folders

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Less cluttered GUI.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
