### PR TITLE
[video] Fix multi version movie playback

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1069,7 +1069,9 @@ void CGUIWindowVideoBase::LoadPlayList(const std::string& strPlayList,
 bool CGUIWindowVideoBase::PlayItem(const std::shared_ptr<CFileItem>& pItem,
                                    const std::string& player)
 {
-  if (pItem->m_bIsFolder && !pItem->IsPlugin())
+  //! @todo get rid of "videos with versions as folder" hack!
+  if (pItem->m_bIsFolder && !pItem->IsPlugin() &&
+      !(pItem->HasVideoInfoTag() && pItem->GetVideoInfoTag()->IsDefaultVideoVersion()))
   {
     // take a copy so we can alter the queue state
     const auto item{std::make_shared<CFileItem>(*pItem)};


### PR DESCRIPTION
Fixes two issues which only occur if "show movies with multiple versions as folder" is activated.

In Movie window, after navigating to a movie with multiple versions:

1) Context menu items `Play`and `Resume` do not work. Nothing happens after selection.
2) Action `Play`(usually triggered using the `P` key on keyboard) does not work. Nothing happens.

Runtime-tested on macOS, latest Kodi master.

@enen92 @CrystalP whenever you find some time for a code review. 