### PR TITLE
[Resolution] Allow Kodi to use higher refresh rates.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -8516,7 +8516,21 @@ msgctxt "#14128"
 msgid "Allow double refresh rates"
 msgstr ""
 
-#empty strings from id 14129 to 14186
+#: system/settings/settings.xml
+msgctxt "#14129"
+msgid "Use higher refresh rates"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#14130"
+msgid "Try and match video resolution"
+msgstr ""
+
+msgctxt "#14131"
+msgid "Whitelist, Resolution and Refresh Rate"
+msgstr ""
+
+#empty strings from id 14132 to 14186
 
 #: system/settings/settings.xml
 msgctxt "#14187"
@@ -21526,7 +21540,19 @@ msgctxt "#36445"
 msgid "Select this option to allow using double refresh rates (playing 29.97 FPS video on a 59.94 Hz monitor or playing 30 FPS video on a 60 Hz monitor). You may want to use this option if your monitor doesn't have a 29.97 Hz or 30 Hz mode."
 msgstr ""
 
-#empty strings from id 36446 to 36459
+#. Description of setting with label #14129 "Whitelist"
+#: system/settings/settings.xml
+msgctxt "#36446"
+msgid "Select this option to prefer higher multiple refresh rates (playing 23.976 FPS or 29.97 FPS video on a 119.88 Hz monitor or playing 25 FPS video on a 100 Hz monitor)."
+msgstr ""
+
+#. Description of setting with label #14130 "Whitelist"
+#: system/settings/settings.xml
+msgctxt "#36447"
+msgid "Disabled - Keep the desktop resolution or use a higher resolution matching the video, if available (ie. Kodi will scale the video if needed)[CR]Enabled - Use a display resolution that matches the video, if available (ie. the TV will scale the video if needed)."
+msgstr ""
+
+#empty strings from id 36449 to 36459
 
 #. Description of settings with label #14112 "Enable event logging"
 #: system/settings/settings.xml

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -8587,7 +8587,21 @@ msgctxt "#14128"
 msgid "Allow double refresh rates"
 msgstr ""
 
-#empty strings from id 14129 to 14186
+#: system/settings/settings.xml
+msgctxt "#14129"
+msgid "Use higher refresh rates"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#14130"
+msgid "Try and match video resolution"
+msgstr ""
+
+msgctxt "#14131"
+msgid "Whitelist, Resolution and Refresh Rate"
+msgstr ""
+
+#empty strings from id 14132 to 14186
 
 #: system/settings/settings.xml
 msgctxt "#14187"
@@ -21912,7 +21926,19 @@ msgctxt "#36448"
 msgid "Video files only: display order in the stream selection dialogs. [Media] stream order in the media, [Sorted] sorted using the stream attributes[CR]"
 msgstr ""
 
-#empty strings from id 36449 to 36459
+#. Description of setting with label #14129 "Whitelist Multiple Refresh Rates"
+#: system/settings/settings.xml
+msgctxt "#36449"
+msgid "Select this option to prefer higher multiple refresh rates (playing 23.976 FPS or 29.97 FPS video on a 119.88 Hz monitor or playing 25 FPS video on a 100 Hz monitor)."
+msgstr ""
+
+#. Description of setting with label #14130 "Match Resolution"
+#: system/settings/settings.xml
+msgctxt "#36450"
+msgid "Disabled - Keep the desktop resolution or use a higher resolution matching the video, if available (ie. Kodi will scale the video if needed)[CR]Enabled - Use a display resolution that matches the video, if available (ie. the TV will scale the video if needed)."
+msgstr ""
+
+#empty strings from id 36451 to 36459
 
 #. Description of settings with label #14112 "Enable event logging"
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3116,7 +3116,7 @@
         <control type="slider" format="percentage" range="0,100" />
       </setting>
       </group>
-      <group id="3" label="14126">
+      <group id="3" label="14131">
         <setting id="videoscreen.whitelist" type="list[string]" parent="videoscreen.screen" label="14126" help="36443">
           <level>3</level>
           <default></default>
@@ -3129,20 +3129,35 @@
             <multiselect>true</multiselect>
           </control>
         </setting>
-        <setting id="videoscreen.whitelistpulldown" type="boolean" parent="videoscreen.whitelist" label="14127" help="36444">
+        <setting id="videoscreen.whitelistpulldown" type="boolean" label="14127" help="36444">
           <level>3</level>
-          <default>false</default>
-          <dependencies>
-            <dependency type="enable" setting="videoscreen.whitelist" operator="!is"></dependency>
-          </dependencies>
+          <default>true</default>
           <control type="toggle" />
+	  <dependencies>
+	    <dependency type="visible" setting="videoscreen.whitelist" operator="!is"></dependency>
+	  </dependencies>
         </setting>
-        <setting id="videoscreen.whitelistdoublerefreshrate" type="boolean" parent="videoscreen.whitelist" label="14128" help="36445">
+        <setting id="videoscreen.whitelistdoublerefreshrate" type="boolean" label="14128" help="36445">
+          <level>3</level>
+          <default>true</default>
+          <control type="toggle" />
+	  <dependencies>
+	    <dependency type="visible" setting="videoscreen.whitelist" operator="!is"></dependency>
+	  </dependencies>
+        </setting>
+        <setting id="videoscreen.whitelistmultiplerefreshrate" type="boolean" label="14129" help="36446">
           <level>3</level>
           <default>false</default>
-          <dependencies>
-            <dependency type="enable" setting="videoscreen.whitelist" operator="!is"></dependency>
-          </dependencies>
+          <control type="toggle" />
+	  <dependencies>
+            <dependency type="enable">
+              <condition setting="videoscreen.whitelistdoublerefreshrate" operator="is">true</condition>
+	    </dependency>
+	  </dependencies>
+        </setting>
+        <setting id="videoscreen.matchvideoresolution" type="boolean" label="14130" help="36447">
+          <level>3</level>
+          <default>false</default>
           <control type="toggle" />
         </setting>
       </group>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3207,7 +3207,7 @@
         <control type="slider" format="percentage" range="0,100" />
       </setting>
       </group>
-      <group id="3" label="14126">
+      <group id="3" label="14131">
         <setting id="videoscreen.whitelist" type="list[string]" parent="videoscreen.screen" label="14126" help="36443">
           <level>3</level>
           <default></default>
@@ -3220,20 +3220,35 @@
             <multiselect>true</multiselect>
           </control>
         </setting>
-        <setting id="videoscreen.whitelistpulldown" type="boolean" parent="videoscreen.whitelist" label="14127" help="36444">
+        <setting id="videoscreen.whitelistpulldown" type="boolean" label="14127" help="36444">
           <level>3</level>
-          <default>false</default>
-          <dependencies>
-            <dependency type="enable" setting="videoscreen.whitelist" operator="!is"></dependency>
-          </dependencies>
+          <default>true</default>
           <control type="toggle" />
+	  <dependencies>
+	    <dependency type="visible" setting="videoscreen.whitelist" operator="!is"></dependency>
+	  </dependencies>
         </setting>
-        <setting id="videoscreen.whitelistdoublerefreshrate" type="boolean" parent="videoscreen.whitelist" label="14128" help="36445">
+        <setting id="videoscreen.whitelistdoublerefreshrate" type="boolean" label="14128" help="36445">
+          <level>3</level>
+          <default>true</default>
+          <control type="toggle" />
+	  <dependencies>
+	    <dependency type="visible" setting="videoscreen.whitelist" operator="!is"></dependency>
+	  </dependencies>
+        </setting>
+        <setting id="videoscreen.whitelistmultiplerefreshrate" type="boolean" label="14129" help="36449">
           <level>3</level>
           <default>false</default>
-          <dependencies>
-            <dependency type="enable" setting="videoscreen.whitelist" operator="!is"></dependency>
-          </dependencies>
+          <control type="toggle" />
+	  <dependencies>
+            <dependency type="enable">
+              <condition setting="videoscreen.whitelistdoublerefreshrate" operator="is">true</condition>
+	    </dependency>
+	  </dependencies>
+        </setting>
+        <setting id="videoscreen.matchvideoresolution" type="boolean" label="14130" help="36450">
+          <level>3</level>
+          <default>false</default>
           <control type="toggle" />
         </setting>
       </group>

--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -25,14 +25,21 @@
 namespace
 {
 
-const char* SETTING_VIDEOSCREEN_WHITELIST_PULLDOWN{"videoscreen.whitelistpulldown"};
-const char* SETTING_VIDEOSCREEN_WHITELIST_DOUBLEREFRESHRATE{
+struct ResolutionEntry
+{
+  RESOLUTION index;
+  int resolutionDifference;
+  float frequency;
+  int weighting;
+};
+
+constexpr const char* SETTING_VIDEOSCREEN_WHITELIST_PULLDOWN{"videoscreen.whitelistpulldown"};
+constexpr const char* SETTING_VIDEOSCREEN_WHITELIST_DOUBLEREFRESHRATE{
     "videoscreen.whitelistdoublerefreshrate"};
-const char* SETTING_VIDEOSCREEN_WHITELIST_MULTIPLEREFRESHRATE{
+constexpr const char* SETTING_VIDEOSCREEN_WHITELIST_MULTIPLEREFRESHRATE{
     "videoscreen.whitelistmultiplerefreshrate"};
-const char* SETTING_VIDEOSCREEN_PREFER_HIGHER_REFRESH_RATES{
-    ("videoscreen.preferhigherrefreshrates")};
-const char* SETTING_VIDEOSCREEN_MATCH_VIDEO_RESOLUTION{("videoscreen.matchvideoresolution")};
+constexpr const char* SETTING_VIDEOSCREEN_MATCH_VIDEO_RESOLUTION{
+    ("videoscreen.matchvideoresolution")};
 
 } // namespace
 
@@ -40,40 +47,38 @@ EdgeInsets::EdgeInsets(float l, float t, float r, float b) : left(l), top(t), ri
 {
 }
 
-RESOLUTION_INFO::RESOLUTION_INFO(int width, int height, float aspect, const std::string &mode) :
-  strMode(mode)
+RESOLUTION_INFO::RESOLUTION_INFO(int width, int height, float aspect, std::string mode)
+  : iWidth(width),
+    iHeight(height),
+    iScreenWidth(width),
+    iScreenHeight(height),
+    fPixelRatio(aspect > 0.0f ? static_cast<float>(width) / static_cast<float>(height) / aspect
+                              : 1.0f),
+    strMode(std::move(mode))
 {
-  iWidth = width;
-  iHeight = height;
-  iBlanking = 0;
-  iScreenWidth = width;
-  iScreenHeight = height;
-  fPixelRatio = aspect ? ((float)width)/height / aspect : 1.0f;
-  bFullScreen = true;
-  fRefreshRate = 0;
-  dwFlags = iSubtitles = 0;
 }
 
 float RESOLUTION_INFO::DisplayRatio() const
 {
-  return iWidth * fPixelRatio / iHeight;
+  return static_cast<float>(iWidth) * fPixelRatio / static_cast<float>(iHeight);
 }
 
 RESOLUTION CResolutionUtils::ChooseBestResolution(float fps, int width, int height, bool is3D)
 {
-  RESOLUTION res = CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution();
-  float weight = 0.0f;
+  const auto& gfxContext{CServiceBroker::GetWinSystem()->GetGfxContext()};
+  RESOLUTION res{gfxContext.GetVideoResolution()};
 
-  if (!FindResolutionFromOverride(fps, width, is3D, res, weight, false)) //find a refreshrate from overrides
+  if (!FindResolutionFromOverride(fps, res, false)) //find a refreshrate from overrides
   {
-    if (!FindResolutionFromOverride(fps, width, is3D, res, weight, true)) //if that fails find it from a fallback
+    if (!FindResolutionFromOverride(fps, res, true)) //if that fails find it from a fallback
     {
-      FindResolutionFromWhitelist(fps, width, height, is3D, res); //find a refreshrate from whitelist
+      FindResolutionFromWhitelist(fps, width, height, is3D,
+                                  res); //find a refreshrate from whitelist
     }
   }
 
-  CLog::Log(LOGINFO, "Display resolution ADJUST : {} ({}) (weight: {:.3f})",
-            CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(res).strMode, res, weight);
+  CLog::LogF(LOGINFO, "Display resolution ADJUST : {} ({})", gfxContext.GetResInfo(res).strMode,
+             res);
   return res;
 }
 
@@ -117,14 +122,14 @@ void CResolutionUtils::FindResolutionFromWhitelist(
   }
 
   // Get additional parameters
-  const bool allowDouble =
-      noWhiteList || CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-                         SETTING_VIDEOSCREEN_WHITELIST_DOUBLEREFRESHRATE);
-  const bool allowPulldown =
-      noWhiteList || CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-                         SETTING_VIDEOSCREEN_WHITELIST_PULLDOWN);
-  const bool useMultiple = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-      SETTING_VIDEOSCREEN_WHITELIST_MULTIPLEREFRESHRATE);
+  const bool allowDouble{noWhiteList ||
+                         CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                             SETTING_VIDEOSCREEN_WHITELIST_DOUBLEREFRESHRATE)};
+  const bool allowPulldown{noWhiteList ||
+                           CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                               SETTING_VIDEOSCREEN_WHITELIST_PULLDOWN)};
+  const bool useMultiple{CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+      SETTING_VIDEOSCREEN_WHITELIST_MULTIPLEREFRESHRATE)};
 
   if (noWhiteList)
     CLog::LogF(LOGDEBUG, "No whitelist - forces allow double refresh rates and pulldown rates ON");
@@ -134,35 +139,36 @@ void CResolutionUtils::FindResolutionFromWhitelist(
   CLog::LogF(LOGDEBUG, "Match video resolution {}", matchResolution ? "ON" : "OFF");
 
   // Precision
-  static constexpr float FPS_PRECISION = 0.01f;
-  static constexpr float FPS_MULTIPLE_PRECISION = 0.0005f;
+  static constexpr float FPS_PRECISION{0.01f};
+  static constexpr float FPS_MULTIPLE_PRECISION{0.0005f};
 
   // Weighting
-  int MATCH_RESOLUTION = 128;
-  int MATCH_DESKTOP_RESOLUTION = 64;
-  // reserved (32)
-  int MATCH_MULTIPLE_REFRESH_RATE = 16;
-  int MATCH_DOUBLE_REFRESH_RATE = 8;
-  int MATCH_REFRESH_RATE = 4;
-  int MATCH_PULLDOWN_RATE = 2;
-  int MATCH_DESKTOP_REFRESH_RATE = 1;
+  enum class Weighting : uint8_t
+  {
+    MATCH_RESOLUTION = 64,
+    MATCH_DESKTOP_RESOLUTION = 32,
+    MATCH_MULTIPLE_REFRESH_RATE = 16,
+    MATCH_DOUBLE_REFRESH_RATE = 8,
+    MATCH_REFRESH_RATE = 4,
+    MATCH_PULLDOWN_RATE = 2,
+    MATCH_DESKTOP_REFRESH_RATE = 1,
+    NO_MATCH = 0
+  };
 
   // Adjust weighting
-  if (!useMultiple)
-  {
-    MATCH_MULTIPLE_REFRESH_RATE = 0;
-    MATCH_REFRESH_RATE = 32;
-  }
-  if (!allowDouble)
-    MATCH_DOUBLE_REFRESH_RATE = 0;
-  if (!allowPulldown)
-    MATCH_PULLDOWN_RATE = 0;
+  using enum Weighting;
+  const int multipleRefreshRateMatch{!useMultiple ? static_cast<int>(NO_MATCH)
+                                                  : static_cast<int>(MATCH_MULTIPLE_REFRESH_RATE)};
+  const int dobuleRefreshRateMatch{!useMultiple || !allowDouble
+                                       ? static_cast<int>(NO_MATCH)
+                                       : static_cast<int>(MATCH_DOUBLE_REFRESH_RATE)};
+  const int pulldownRateMatch{!allowPulldown ? static_cast<int>(NO_MATCH)
+                                             : static_cast<int>(MATCH_PULLDOWN_RATE)};
 
-  const RESOLUTION_INFO desktop_info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(
-      CDisplaySettings::GetInstance().GetCurrentResolution());
+  const RESOLUTION_INFO desktop_info{CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(
+      CDisplaySettings::GetInstance().GetCurrentResolution())};
 
-  std::vector<std::tuple<RESOLUTION, int, float, int>>
-      resolutions; // index, resolution dfference, frequency, weighting
+  std::vector<ResolutionEntry> resolutions;
 
   CLog::LogF(LOGDEBUG, "Scanning available resolutions");
   for (const auto& mode : indexList)
@@ -182,29 +188,32 @@ void CResolutionUtils::FindResolutionFromWhitelist(
       // note: height has greater tolerance due to 32/64px boundaries e.g. 1080?1088 or 2160?2176
       if ((height == info.iScreenHeight && width <= info.iScreenWidth + 8) ||
           (width == info.iScreenWidth && height <= info.iScreenHeight + 32))
-        w |= MATCH_RESOLUTION;
+        w |= static_cast<int>(MATCH_RESOLUTION);
       else if (info.iScreenWidth == desktop_info.iScreenWidth &&
                info.iScreenHeight == desktop_info.iScreenHeight)
-        w |= MATCH_DESKTOP_RESOLUTION;
+        w |= static_cast<int>(MATCH_DESKTOP_RESOLUTION);
       if (MathUtils::FloatEquals(info.fRefreshRate, fps, FPS_PRECISION))
-        w |= MATCH_REFRESH_RATE;
+        w |= static_cast<int>(MATCH_REFRESH_RATE);
       else if (MathUtils::FloatEquals(info.fRefreshRate, fps * 2.0f, FPS_PRECISION))
-        w |= MATCH_DOUBLE_REFRESH_RATE;
+        w |= dobuleRefreshRateMatch;
       else if (useMultiple && (f < FPS_MULTIPLE_PRECISION || abs(1 - f) < FPS_MULTIPLE_PRECISION))
-        w |= MATCH_MULTIPLE_REFRESH_RATE;
+        w |= multipleRefreshRateMatch;
       else if (allowPulldown &&
                (MathUtils::FloatEquals(info.fRefreshRate, fps * 2.5f, FPS_PRECISION) ||
                 (useMultiple &&
                  (p < FPS_MULTIPLE_PRECISION || abs(1 - p) < FPS_MULTIPLE_PRECISION))))
-        w |= MATCH_PULLDOWN_RATE;
+        w |= pulldownRateMatch;
       else if (MathUtils::FloatEquals(info.fRefreshRate, desktop_info.fRefreshRate, FPS_PRECISION))
-        w |= MATCH_DESKTOP_REFRESH_RATE;
+        w |= static_cast<int>(MATCH_DESKTOP_REFRESH_RATE);
 
       if (w > 0)
       {
         // Found resolution for consideration
-        resolutions.emplace_back(std::make_tuple(
-            i, (info.iScreenWidth + info.iScreenHeight - height - width), info.fRefreshRate, w));
+        resolutions.emplace_back(ResolutionEntry{
+            .index = i,
+            .resolutionDifference = (info.iScreenWidth + info.iScreenHeight - height - width),
+            .frequency = info.fRefreshRate,
+            .weighting = w});
         CLog::LogF(LOGDEBUG, "Resolution {} given weighting {} ({})", info.strMode, w, i);
       }
     }
@@ -213,51 +222,45 @@ void CResolutionUtils::FindResolutionFromWhitelist(
   if (!resolutions.empty())
   {
     // Sort list based on weighting (then proximity of resolution, then frequency)
-    std::sort(resolutions.begin(), resolutions.end(),
-              [&](const std::tuple<RESOLUTION, int, float, int>& i,
-                  const std::tuple<RESOLUTION, int, float, int>& j)
-              {
-                if (std::get<3>(i) == std::get<3>(j)) // weighting
-                  if (std::get<1>(i) == std::get<1>(j)) // resolution proximity
-                    return std::get<2>(i) > std::get<2>(j); // frequency
-                  else
-                    return std::get<1>(i) < std::get<1>(j);
-                else
-                  return std::get<3>(i) > std::get<3>(j);
-              });
+    std::ranges::sort(resolutions,
+                      [](const ResolutionEntry& i, const ResolutionEntry& j)
+                      {
+                        if (i.weighting == j.weighting)
+                        {
+                          if (i.resolutionDifference == j.resolutionDifference)
+                            return i.frequency > j.frequency;
+                          return i.resolutionDifference < j.resolutionDifference;
+                        }
+                        return i.weighting > j.weighting;
+                      });
 
     // Log sorted list
     CLog::LogF(LOGDEBUG, "Sorted weighted resolution list");
     for (const auto& r : resolutions)
     {
-      const auto info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(std::get<0>(r));
-      CLog::LogF(LOGDEBUG, "Resolution {} Weighting {} ({})", info.strMode, std::get<3>(r),
-                 std::get<0>(r));
+      const auto info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(r.index);
+      CLog::LogF(LOGDEBUG, "Resolution {} Weighting {} ({})", info.strMode, r.weighting, r.index);
     }
 
     // Choose resolution
-    CLog::LogF(LOGINFO, "Chosen resolution {}",
-               CServiceBroker::GetWinSystem()
-                   ->GetGfxContext()
-                   .GetResInfo(std::get<0>(resolutions[0]))
-                   .strMode);
-    resolution = std::get<0>(resolutions[0]);
+    CLog::LogF(
+        LOGINFO, "Chosen resolution {}",
+        CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(resolutions[0].index).strMode);
+    resolution = resolutions[0].index;
   }
   else
     CLog::LogF(LOGINFO, "No resolution matched");
-
-  return;
 }
 
-bool CResolutionUtils::FindResolutionFromOverride(float fps, int width, bool is3D, RESOLUTION &resolution, float& weight, bool fallback)
+bool CResolutionUtils::FindResolutionFromOverride(float fps, RESOLUTION& resolution, bool fallback)
 {
-  RESOLUTION_INFO curr = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(resolution);
+  const auto& gfxContext{CServiceBroker::GetWinSystem()->GetGfxContext()};
+  RESOLUTION_INFO curr{gfxContext.GetResInfo(resolution)};
 
   //try to find a refreshrate from the override
-  for (int i = 0; i < (int)CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoAdjustRefreshOverrides.size(); i++)
+  for (const auto& override :
+       CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoAdjustRefreshOverrides)
   {
-    RefreshOverride& override = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoAdjustRefreshOverrides[i];
-
     if (override.fallback != fallback)
       continue;
 
@@ -265,93 +268,64 @@ bool CResolutionUtils::FindResolutionFromOverride(float fps, int width, bool is3
     if (!fallback && (fps < override.fpsmin || fps > override.fpsmax))
       continue;
 
-    for (size_t j = (int)RES_DESKTOP; j < CDisplaySettings::GetInstance().ResolutionInfoSize(); j++)
+    for (size_t j = RES_DESKTOP; j < CDisplaySettings::GetInstance().ResolutionInfoSize(); j++)
     {
-      RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo((RESOLUTION)j);
+      RESOLUTION_INFO info{gfxContext.GetResInfo(static_cast<RESOLUTION>(j))};
 
-      if (info.iScreenWidth  == curr.iScreenWidth &&
-          info.iScreenHeight == curr.iScreenHeight &&
-          (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK))
+      if (info.iScreenWidth != curr.iScreenWidth || info.iScreenHeight != curr.iScreenHeight ||
+          (info.dwFlags & D3DPRESENTFLAG_MODEMASK) != (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) ||
+          info.fRefreshRate > override.refreshmax || info.fRefreshRate < override.refreshmin)
+        continue;
+
+      resolution = static_cast<RESOLUTION>(j);
+
+      if (fallback)
       {
-        if (info.fRefreshRate <= override.refreshmax &&
-            info.fRefreshRate >= override.refreshmin)
-        {
-          resolution = (RESOLUTION)j;
-
-          if (fallback)
-          {
-            CLog::Log(
-                LOGDEBUG,
-                "Found Resolution {} ({}) from fallback (refreshmin:{:.3f} refreshmax:{:.3f})",
-                info.strMode, resolution, override.refreshmin, override.refreshmax);
-          }
-          else
-          {
-            CLog::Log(LOGDEBUG,
-                      "Found Resolution {} ({}) from override of fps {:.3f} (fpsmin:{:.3f} "
-                      "fpsmax:{:.3f} refreshmin:{:.3f} refreshmax:{:.3f})",
-                      info.strMode, resolution, fps, override.fpsmin, override.fpsmax,
-                      override.refreshmin, override.refreshmax);
-          }
-
-          weight = RefreshWeight(info.fRefreshRate, fps);
-
-          return true; //fps and refresh match with this override, use this resolution
-        }
+        CLog::LogF(LOGDEBUG,
+                   "Found Resolution {} ({}) from fallback (refreshmin:{:.3f} refreshmax:{:.3f})",
+                   info.strMode, resolution, override.refreshmin, override.refreshmax);
       }
+      else
+      {
+        CLog::LogF(LOGDEBUG,
+                   "Found Resolution {} ({}) from override of fps {:.3f} (fpsmin:{:.3f} "
+                   "fpsmax:{:.3f} refreshmin:{:.3f} refreshmax:{:.3f})",
+                   info.strMode, resolution, fps, override.fpsmin, override.fpsmax,
+                   override.refreshmin, override.refreshmax);
+      }
+      return true; //fps and refresh match with this override, use this resolution
     }
   }
-
   return false; //no override found
-}
-
-//distance of refresh to the closest multiple of fps (multiple is 1 or higher), as a multiplier of fps
-float CResolutionUtils::RefreshWeight(float refresh, float fps)
-{
-  float div   = refresh / fps;
-  int round = MathUtils::round_int(static_cast<double>(div));
-
-  float weight = 0.0f;
-
-  if (round < 1)
-    weight = (fps - refresh) / fps;
-  else
-    weight = fabs(div / round - 1.0f);
-
-  // punish higher refreshrates and prefer better matching
-  // e.g. 30 fps content at 60 hz is better than
-  // 30 fps at 120 hz - as we sometimes don't know if
-  // the content is interlaced at the start, only
-  // punish when refreshrate > 60 hz to not have to switch
-  // twice for 30i content
-  if (refresh > 60 && round > 1)
-    weight += round / 10000.0f;
-
-  return weight;
 }
 
 bool CResolutionUtils::HasWhitelist()
 {
-  std::vector<CVariant> indexList = CServiceBroker::GetSettingsComponent()->GetSettings()->GetList(CSettings::SETTING_VIDEOSCREEN_WHITELIST);
-  return !indexList.empty();
+  return !CServiceBroker::GetSettingsComponent()
+              ->GetSettings()
+              ->GetList(CSettings::SETTING_VIDEOSCREEN_WHITELIST)
+              .empty();
 }
 
 void CResolutionUtils::PrintWhitelist()
 {
-  std::string modeStr;
-  auto indexList = CServiceBroker::GetSettingsComponent()->GetSettings()->GetList(
-      CSettings::SETTING_VIDEOSCREEN_WHITELIST);
-  if (!indexList.empty())
-  {
-    for (const auto& mode : indexList)
-    {
-      auto i = CDisplaySettings::GetInstance().GetResFromString(mode.asString());
-      const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
-      modeStr.append("\n" + info.strMode);
-    }
+  const auto indexList{CServiceBroker::GetSettingsComponent()->GetSettings()->GetList(
+      CSettings::SETTING_VIDEOSCREEN_WHITELIST)};
 
-    CLog::Log(LOGDEBUG, "[WHITELIST] whitelisted modes:{}", modeStr);
+  if (indexList.empty())
+    return;
+
+  auto& displaySettings{CDisplaySettings::GetInstance()};
+  const auto& gfxContext{CServiceBroker::GetWinSystem()->GetGfxContext()};
+  std::string modeStr;
+  for (const auto& mode : indexList)
+  {
+    const auto& i{displaySettings.GetResFromString(mode.asString())};
+    const RESOLUTION_INFO& info{gfxContext.GetResInfo(i)};
+    modeStr.append("\n" + info.strMode);
   }
+
+  CLog::LogF(LOGDEBUG, "[WHITELIST] whitelisted modes:{}", modeStr);
 }
 
 void CResolutionUtils::GetMaxAllowedScreenResolution(unsigned int& width, unsigned int& height)
@@ -359,22 +333,22 @@ void CResolutionUtils::GetMaxAllowedScreenResolution(unsigned int& width, unsign
   if (!CServiceBroker::GetWinSystem()->GetGfxContext().IsFullScreenRoot())
     return;
 
-  std::vector<RESOLUTION_INFO> resList;
-
-  auto indexList = CServiceBroker::GetSettingsComponent()->GetSettings()->GetList(
-      CSettings::SETTING_VIDEOSCREEN_WHITELIST);
+  const auto indexList{CServiceBroker::GetSettingsComponent()->GetSettings()->GetList(
+      CSettings::SETTING_VIDEOSCREEN_WHITELIST)};
 
   unsigned int maxWidth{0};
   unsigned int maxHeight{0};
 
   if (!indexList.empty())
   {
+    auto& displaySettings{CDisplaySettings::GetInstance()};
+    const auto& gfxContext{CServiceBroker::GetWinSystem()->GetGfxContext()};
     for (const auto& mode : indexList)
     {
-      RESOLUTION res = CDisplaySettings::GetInstance().GetResFromString(mode.asString());
-      RESOLUTION_INFO resInfo{CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(res)};
-      if (static_cast<unsigned int>(resInfo.iScreenWidth) > maxWidth &&
-          static_cast<unsigned int>(resInfo.iScreenHeight) > maxHeight)
+      RESOLUTION res{displaySettings.GetResFromString(mode.asString())};
+      RESOLUTION_INFO resInfo{gfxContext.GetResInfo(res)};
+      if (std::cmp_greater(resInfo.iScreenWidth, maxWidth) &&
+          std::cmp_greater(resInfo.iScreenHeight, maxHeight))
       {
         maxWidth = static_cast<unsigned int>(resInfo.iScreenWidth);
         maxHeight = static_cast<unsigned int>(resInfo.iScreenHeight);
@@ -384,13 +358,14 @@ void CResolutionUtils::GetMaxAllowedScreenResolution(unsigned int& width, unsign
   else
   {
     std::vector<RESOLUTION> resList;
-    CServiceBroker::GetWinSystem()->GetGfxContext().GetAllowedResolutions(resList);
+    auto& gfxContext{CServiceBroker::GetWinSystem()->GetGfxContext()};
+    gfxContext.GetAllowedResolutions(resList);
 
     for (const auto& res : resList)
     {
-      RESOLUTION_INFO resInfo{CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(res)};
-      if (static_cast<unsigned int>(resInfo.iScreenWidth) > maxWidth &&
-          static_cast<unsigned int>(resInfo.iScreenHeight) > maxHeight)
+      RESOLUTION_INFO resInfo{gfxContext.GetResInfo(res)};
+      if (std::cmp_greater(resInfo.iScreenWidth, maxWidth) &&
+          std::cmp_greater(resInfo.iScreenHeight, maxHeight))
       {
         maxWidth = static_cast<unsigned int>(resInfo.iScreenWidth);
         maxHeight = static_cast<unsigned int>(resInfo.iScreenHeight);

--- a/xbmc/windowing/Resolution.h
+++ b/xbmc/windowing/Resolution.h
@@ -72,34 +72,34 @@ struct RESOLUTION_INFO
   EdgeInsets guiInsets;
 
   //!< Specify if it is a fullscreen resolution, otherwise windowed
-  bool bFullScreen;
+  bool bFullScreen{true};
 
   //!< Width GUI resolution (pixels), may differ from the screen value if GUI resolution limit, 3D is set or in HiDPI screens
-  int iWidth;
+  int iWidth{0};
 
   //!< Height GUI resolution (pixels), may differ from the screen value if GUI resolution limit, 3D is set or in HiDPI screens
-  int iHeight;
+  int iHeight{0};
 
   //!< Number of pixels of padding between stereoscopic frames
-  int iBlanking;
+  int iBlanking{0};
 
   //!< Screen width (logical width in pixels)
-  int iScreenWidth;
+  int iScreenWidth{0};
 
   //!< Screen height (logical height in pixels)
-  int iScreenHeight;
+  int iScreenHeight{0};
 
   //!< The vertical subtitle baseline position, may be changed by Video calibration
-  int iSubtitles;
+  int iSubtitles{0};
 
   //!< Properties of the resolution e.g. interlaced mode
-  uint32_t dwFlags;
+  uint32_t dwFlags{0};
 
   //!< Pixel aspect ratio
-  float fPixelRatio;
+  float fPixelRatio{1.0f};
 
   //!< Refresh rate
-  float fRefreshRate;
+  float fRefreshRate{0.0f};
 
   //!< Resolution mode description
   std::string strMode;
@@ -111,7 +111,10 @@ struct RESOLUTION_INFO
   std::string strId;
 
 public:
-  RESOLUTION_INFO(int width = 1280, int height = 720, float aspect = 0, const std::string &mode = "");
+  RESOLUTION_INFO(int width = 1280, int height = 720, float aspect = 0, std::string mode = "");
+  RESOLUTION_INFO(const RESOLUTION_INFO& res) = default;
+  RESOLUTION_INFO& operator=(const RESOLUTION_INFO&) = default;
+
   float DisplayRatio() const;
 };
 
@@ -129,8 +132,7 @@ public:
    */
   static void GetMaxAllowedScreenResolution(unsigned int& width, unsigned int& height);
 
-protected:
+private:
   static void FindResolutionFromWhitelist(float fps, int width, int height, bool is3D, RESOLUTION &resolution);
-  static bool FindResolutionFromOverride(float fps, int width, bool is3D, RESOLUTION &resolution, float& weight, bool fallback);
-  static float RefreshWeight(float refresh, float fps);
+  static bool FindResolutionFromOverride(float fps, RESOLUTION& resolution, bool fallback);
 };


### PR DESCRIPTION
## Description

Allow Kodi to use higher refresh rates and match video resolution..

## Motivation and context

With the following setup - Samsung QN95C TV, Denon X3800H, HTPC with Nvidia Geforce RTX 3050 - I can access 4K @ 120Hz (and 119.88Hz, 100Hz) - but it is difficult to use these as they are more than double the usual frequency of 23.98Hz (and 25Hz PAL here in the UK).

Even if you whitelist them they are never used (unless you preset the desktop refresh rate to match or use the `<advancedsettings>` override) - this seems overly complicated esp. as higher resolution TVs/monitors and HDMI 2.1 etc.. are becoming more commonplace.

## How has this been tested?

System above and laptop with pretty refresh rates and limited resolutions.

I am sure there are things I haven't thought about here - grateful for feedback.

## What is the effect on users?

There are two new settings

**1) Use higher refresh rates**

If disabled then default/original behaviour:
- Try to match the exact refresh rate and then failing that it depends on whether there is a whitelist.
- If there isn't a whitelist then both the Double refresh rate and the Pulldown refresh rate are treated as being on (irrespective of what is shown in the GUI).
- If there is a whitelist then the Double refersh rate and Pulldown refresh rates are utilised as shown in the GUI (as per the original code)

eg. For a 23.976 FPS video the maximum refresh rate that could be used is 59.94 Hz (3:2 pulldown). There is no double rate (typically).
eg. For 25 FPS video the maimum refresh rate that could be used is 50 Hz. There is typically no pulldown rate.

If enabled:
- Highest multiple refresh rate is preferred
- If no whitelist then 3:2 pulldown rates are included (as above).

eg. For a display that maxes out at 144 Hz, for a 23.976 FPS video 119.88 Hz would be used and for 25 FPS video 100Hz would be used.

**2) Try and match video resolution**

Disabled - default/original behavour - only desktop resolution or video resolution (if higher than desktop) is used. Kodi is doing the scaling.

eg. If the desktop resolution is 2160p then a 1080p video will be upscaled in Kodi to 2160p.

Enabled - if the resolution of the video can be matched exactly then that resolution is selected, otherwise the desktop resolution is preferred.

eg. If the desktop resolution is 2160p then a 1080p video will be played at 1920x1080 (and the TV will upscale).

## Screenshots (if appropriate):

Before:
![image](https://github.com/xbmc/xbmc/assets/99039295/6b011fd4-91c2-458a-be8b-62b5c2ac74d8)

After:
![image](https://github.com/xbmc/xbmc/assets/99039295/5770c4de-788d-4e8f-a02f-2dd3d6ba399c)
![image](https://github.com/xbmc/xbmc/assets/99039295/286cd3bf-4077-4921-b60c-3432ce1d6133)

I've hidden the Double and Pulldown options when there is no whitelist both the original and new code assumes they are on - so the GUI can be confusing.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
