### PR TITLE
[FileCache] adjust Read Factor algorithm

### DIFF
--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -15,7 +15,10 @@
 #include "threads/Thread.h"
 
 #include <atomic>
+#include <chrono>
 #include <memory>
+
+using namespace std::chrono_literals;
 
 namespace XFILE
 {
@@ -74,6 +77,7 @@ namespace XFILE
     std::atomic<int64_t> m_fileSize;
     unsigned int m_flags;
     CCriticalSection m_sync;
+    std::chrono::milliseconds m_processWait{100ms};
   };
 
 }


### PR DESCRIPTION
## Description
[FileCache] adjust Read Factor algorithm

- Fixes cache not fills with high bitrate files and "low" read factors.
- Add a new debug log line to see FileCache read rate in Mbit/s in this way is easy to compare with values displayed in Debug Info OSD also expressed in Mbit/s.

`debug <general>: CFileCache::IoControl - setting maxRate to 96.88 Mbit/s with processWait of 30 ms`

- Probably fixes https://github.com/xbmc/xbmc/issues/21885 (if is not already fixed by others recent related improvements)

## Motivation and context
With some high bitrate files (rare cases) read factor (fill rate) seems not follows calculated value and cache never fills properly. This only happens with some high bitrate files but not all, then also depends on others factors: probably the way data is muxed (audio, video interleaving) and overhead counting others audio tracks, etc. But when happens are always 4K +80 Mbit/s files. 
The issue is more visible using low read factors (1.5x – 2.0x) and at first was thinking it's because files has much variable bitrate and probably some fragments have bitrate > average_bitrate * read_factor. After some tests this is not the case:

Example:  "Edge of Tomorrow" --> avg. file bitrate 96 Mbit/s  (audio + video)

96 * 1.5 read_factor = 144 Mbit/s

File Cache should able to read at these 144 Mbit/s but this issue happens on scenes of only 80 Mbit/s video + 5 Mbit/s audio when using 1.5 read factor or even 2.0 read factor (192 Mbit/s theoretical).

Then on these cases, FileCache needs bigger read factors to compensate this deviation or error from theoretical numbers…. And with read factor of 4.0x works "fine" (behaves as 2.0x).
 
As default read factor value is 4x and users usually sets even bigger values (15x – 20x) this issue is not much visible currently but I want to fix because my final goal is implement "adaptive read factor" setting.  Ideally "read factor" should not be static, but a dynamically calculated value to fill the cache at a reasonable speed: probably depending on other parameters (cache size and level) and once the cache is full be less aggressive in keeping it full. But this is for another PR…

This PR is only a previous step to fix read factor deviations on some files.

Analyzing FileCache code with additional log calls found this wait is reached various times:

https://github.com/xbmc/xbmc/blob/41c4a59fc315df1d4c97c591188fb2cde216851f/xbmc/filesystem/FileCache.cpp#L303

As is 100 ms and all FileCache code is in same thread, only is possible execute this code 10 times / second and found that when this effect happens (cache not fills) this code is reached exact 10 times/s. Then this 100 ms wait is throttling File Cache thread causing this (in some files only) i.e. to recover needs 15 executions/second but 100 ms wait it's limiting to only 10.

Empirically, I have found that the best value for these files is 30 ms and in fact I have been using a fixed value of 30 ms for some time since it seems to work well for everything. Even so, since this is only necessary when the bitrate is very high, I think that a better solution is to adjust the value based on the bitrate.

Also keep in mind that very small values like 5 ms can also cause incorrect operation and smaller values produce an increase in CPU usage... so it seems better to continue using 100 ms in general but allow using lower values only if the bitrate is high and limit it to 30 ms.

With all this in mind proposed formula is:

wait time = 110 – avr_bitrate in Mbit/s

![wait](https://github.com/xbmc/xbmc/assets/58434170/23072fbb-bbe1-4ccc-9262-f607110b1a26)

- For most Internet streams and HD files (less 10 Mbit/s) wait is same as before: constant 100 ms.
- For files with bitrate between 10 to 80 Mbit/s wait is inversely proportional to bitrate.
- For files >= 80 Mbit/s wait is constant 30 ms.
 

## How has this been tested?
Runtime tested Windows x64 and Android (Shield) for several days.

## What is the effect on users?
More consistent FileCache behavior for all media files (high / low bitrates) and using high / low read factors. Read factor only should change speed of cache filling but not limit cache fill to only small part or cause stop cache filling.

## Screenshots (if appropriate):

**Before**
![Before](https://github.com/xbmc/xbmc/assets/58434170/bd0a9fd6-7666-4a5a-b15a-97ce25f4679d)


https://github.com/xbmc/xbmc/assets/58434170/b1590593-f060-4b75-8933-9964fe8f83f3


**After**
![After](https://github.com/xbmc/xbmc/assets/58434170/b5f69133-ff45-47d0-9d11-c18b848c0933)


https://github.com/xbmc/xbmc/assets/58434170/b576c7db-c286-48de-9eeb-d466ff62b587




## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
