### PR TITLE
AESinkWASAPI: improve fallback when is not supported exact output channel layout

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
@@ -731,6 +731,7 @@ bool CAESinkWASAPI::InitializeExclusive(AEAudioFormat &format)
   unsigned int requestedChannels = 0;
   unsigned int noOfCh = 0;
   uint64_t desired_map = 0;
+  bool matchNoChannelsOnly = false;
 
   if (SUCCEEDED(hr))
   {
@@ -763,16 +764,34 @@ bool CAESinkWASAPI::InitializeExclusive(AEAudioFormat &format)
     // as the last resort try stereo
     if (layout == ARRAYSIZE(layoutsList))
     {
-      wfxex.dwChannelMask = SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT;
-      wfxex.Format.nChannels = 2;
+      if (matchNoChannelsOnly)
+      {
+        wfxex.dwChannelMask = SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT;
+        wfxex.Format.nChannels = 2;
+      }
+      else
+      {
+        matchNoChannelsOnly = true;
+        layout = -1;
+        CLog::Log(LOGWARNING, "AESinkWASAPI: Match only number of audio channels as fallback");
+        continue;
+      }
     }
     else if (layout >= 0)
     {
       wfxex.dwChannelMask = CAESinkFactoryWin::ChLayoutToChMask(layoutsList[layout], &noOfCh);
       wfxex.Format.nChannels = noOfCh;
       int res = desired_map & wfxex.dwChannelMask;
-      if (res != desired_map)
-        continue; // output channel layout doesn't match input channels
+      if (matchNoChannelsOnly)
+      {
+        if (noOfCh < requestedChannels)
+          continue; // number of channels doesn't match requested channels
+      }
+      else
+      {
+        if (res != desired_map)
+          continue; // output channel layout doesn't match input channels
+      }
     }
     CAEChannelInfo foundChannels;
     CAESinkFactoryWin::AEChannelsFromSpeakerMask(foundChannels, wfxex.dwChannelMask);


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/24534


## Motivation and context
If there is going to be 20.4 it would be good to include this as fixes a regression from v19.



## What is the effect on users?
More robust WASAPI audio channels layout matching when is not used passthrough.



## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
