### PR TITLE
[Android] Add HDR allowed dynamic metadata formats setting

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23765,6 +23765,24 @@ msgctxt "#39197"
 msgid "If enabled, Dolby Vision profile 7 will be converted to profile 8.1, which is more commonly supported by devices. Enable if your device supports Dolby Vision, but has issues with some videos."
 msgstr ""
 
+#. Title of "Allowed HDR dynamic metadata formats" setting
+#: system/settings/settings.xml
+msgctxt "#39198"
+msgid "Allowed HDR dynamic metadata formats"
+msgstr ""
+
+#. Help text for setting "Allowed HDR dynamic metadata formats" of label #39198
+#: system/settings/settings.xml
+msgctxt "#39199"
+msgid "Alters the video bitstream to remove dynamic HDR metadata. Select the HDR formats your device and display supports."
+msgstr ""
+
+#. Label of Dolby Vision option for setting "Allowed HDR dynamic metadata formats" of label #39198
+#: system/settings/settings.xml
+msgctxt "#39200"
+msgid "Dolby Vision"
+msgstr ""
+
 # 40000 to 40800 are reserved for Video Versions feature
 
 #. Generic video versions label (plural)

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23783,6 +23783,12 @@ msgctxt "#39200"
 msgid "Dolby Vision"
 msgstr ""
 
+#. Label of HDR10+ option for setting "Allowed HDR dynamic metadata formats" of label #39198
+#: system/settings/settings.xml
+msgctxt "#39201"
+msgid "HDR10+"
+msgstr ""
+
 # 40000 to 40800 are reserved for Video Versions feature
 
 #. Generic video versions label (plural)

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -193,10 +193,11 @@
         <setting id="videoplayer.allowedhdrformats" type="list[integer]" label="39198" help="39199">
           <requirement>HAS_MEDIACODEC</requirement>
           <level>2</level>
-          <default>0</default> <!-- Allow all HDR formats -->
+          <default>0,1</default> <!-- Allow all HDR formats -->
           <constraints>
             <options>
               <option label="39200">0</option> <!-- Dolby Vision -->
+              <option label="39201">1</option> <!-- HDR10+ -->
             </options>
             <delimiter>,</delimiter>
           </constraints>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -190,6 +190,21 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
+        <setting id="videoplayer.allowedhdrformats" type="list[integer]" label="39198" help="39199">
+          <requirement>HAS_MEDIACODEC</requirement>
+          <level>2</level>
+          <default>0</default> <!-- Allow all HDR formats -->
+          <constraints>
+            <options>
+              <option label="39200">0</option> <!-- Dolby Vision -->
+            </options>
+            <delimiter>,</delimiter>
+          </constraints>
+          <control type="list" format="string">
+            <multiselect>true</multiselect>
+            <hidevalue>false</hidevalue>
+          </control>
+        </setting>
       </group>
       <group id="4" label="14232">
         <setting id="videoplayer.stereoscopicplaybackmode" type="integer" label="36520" help="36537">

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -505,6 +505,7 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
       const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
       bool convertDovi{false};
       bool removeDovi{false};
+      bool removeHdr10Plus{false};
 
       if (settings)
       {
@@ -515,6 +516,8 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
                 settings->GetSetting(CSettings::SETTING_VIDEOPLAYER_ALLOWEDHDRFORMATS)));
         removeDovi = !CSettingUtils::FindIntInList(
             allowedHdrFormatsSetting, CSettings::VIDEOPLAYER_ALLOWED_HDR_TYPE_DOLBY_VISION);
+        removeHdr10Plus = !CSettingUtils::FindIntInList(
+            allowedHdrFormatsSetting, CSettings::VIDEOPLAYER_ALLOWED_HDR_TYPE_HDR10PLUS);
       }
 
       bool isDvhe = (m_hints.codec_tag == MKTAG('d', 'v', 'h', 'e'));
@@ -605,6 +608,7 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
         if (m_bitstream)
         {
           m_bitstream->SetRemoveDovi(removeDovi);
+          m_bitstream->SetRemoveHdr10Plus(removeHdr10Plus);
 
           // Only set for profile 7, container hint allows to skip parsing unnecessarily
           if (m_hints.dovi.dv_profile == 7)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -23,8 +23,10 @@
 #include "cores/VideoPlayer/VideoRenderers/RenderManager.h"
 #include "media/decoderfilter/DecoderFilterManager.h"
 #include "messaging/ApplicationMessenger.h"
+#include "settings/SettingUtils.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "settings/lib/Setting.h"
 #include "utils/BitstreamConverter.h"
 #include "utils/BitstreamWriter.h"
 #include "utils/CPUInfo.h"
@@ -501,8 +503,19 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
       m_formatname = "amc-hevc";
 
       const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-      const bool convertDovi =
-          (settings) ? settings->GetBool(CSettings::SETTING_VIDEOPLAYER_CONVERTDOVI) : false;
+      bool convertDovi{false};
+      bool removeDovi{false};
+
+      if (settings)
+      {
+        convertDovi = settings->GetBool(CSettings::SETTING_VIDEOPLAYER_CONVERTDOVI);
+
+        const std::shared_ptr<CSettingList> allowedHdrFormatsSetting(
+            std::dynamic_pointer_cast<CSettingList>(
+                settings->GetSetting(CSettings::SETTING_VIDEOPLAYER_ALLOWEDHDRFORMATS)));
+        removeDovi = !CSettingUtils::FindIntInList(
+            allowedHdrFormatsSetting, CSettings::VIDEOPLAYER_ALLOWED_HDR_TYPE_DOLBY_VISION);
+      }
 
       bool isDvhe = (m_hints.codec_tag == MKTAG('d', 'v', 'h', 'e'));
       bool isDvh1 = (m_hints.codec_tag == MKTAG('d', 'v', 'h', '1'));
@@ -517,7 +530,7 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
           isDvhe = true;
       }
 
-      if (isDvhe || isDvh1)
+      if (!removeDovi && (isDvhe || isDvh1))
       {
         bool displaySupportsDovi{false};
         bool mediaCodecSupportsDovi{false};
@@ -589,15 +602,20 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
           m_bitstream.reset();
         }
 
-        // Only set for profile 7, container hint allows to skip parsing unnecessarily
-        if (m_bitstream && m_hints.dovi.dv_profile == 7)
+        if (m_bitstream)
         {
-          CLog::Log(LOGDEBUG,
-                    "CDVDVideoCodecAndroidMediaCodec::Open Dolby Vision compatibility mode "
-                    "enabled: {}",
-                    convertDovi);
+          m_bitstream->SetRemoveDovi(removeDovi);
 
-          m_bitstream->SetConvertDovi(convertDovi);
+          // Only set for profile 7, container hint allows to skip parsing unnecessarily
+          if (m_hints.dovi.dv_profile == 7)
+          {
+            CLog::Log(LOGDEBUG,
+                      "CDVDVideoCodecAndroidMediaCodec::Open Dolby Vision compatibility mode "
+                      "enabled: {}",
+                      convertDovi);
+
+            m_bitstream->SetConvertDovi(convertDovi);
+          }
         }
       }
 

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -135,6 +135,7 @@ public:
   static constexpr auto SETTING_VIDEOPLAYER_LIMITGUIUPDATE = "videoplayer.limitguiupdate";
   static constexpr auto SETTING_VIDEOPLAYER_SUPPORTMVC = "videoplayer.supportmvc";
   static constexpr auto SETTING_VIDEOPLAYER_CONVERTDOVI = "videoplayer.convertdovi";
+  static constexpr auto SETTING_VIDEOPLAYER_ALLOWEDHDRFORMATS = "videoplayer.allowedhdrformats";
   static constexpr auto SETTING_MYVIDEOS_SELECTACTION = "myvideos.selectaction";
   static constexpr auto SETTING_MYVIDEOS_SELECTDEFAULTVERSION = "myvideos.selectdefaultversion";
   static constexpr auto SETTING_MYVIDEOS_PLAYACTION = "myvideos.playaction";
@@ -497,6 +498,9 @@ public:
   static constexpr int SETTING_AUTOPLAYNEXT_EPISODES = 2;
   static constexpr int SETTING_AUTOPLAYNEXT_MOVIES = 3;
   static constexpr int SETTING_AUTOPLAYNEXT_UNCATEGORIZED = 4;
+
+  // values for SETTING_VIDEOPLAYER_ALLOWEDHDRFORMATS
+  static const int VIDEOPLAYER_ALLOWED_HDR_TYPE_DOLBY_VISION = 0;
 
   /*!
    \brief Creates a new settings wrapper around a new settings manager.

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -501,6 +501,7 @@ public:
 
   // values for SETTING_VIDEOPLAYER_ALLOWEDHDRFORMATS
   static const int VIDEOPLAYER_ALLOWED_HDR_TYPE_DOLBY_VISION = 0;
+  static const int VIDEOPLAYER_ALLOWED_HDR_TYPE_HDR10PLUS = 1;
 
   /*!
    \brief Creates a new settings wrapper around a new settings manager.

--- a/xbmc/utils/BitstreamConverter.cpp
+++ b/xbmc/utils/BitstreamConverter.cpp
@@ -356,6 +356,7 @@ CBitstreamConverter::CBitstreamConverter()
   m_sps_pps_context.sps_pps_data = NULL;
   m_start_decode = true;
   m_convert_dovi = false;
+  m_removeDovi = false;
 }
 
 CBitstreamConverter::~CBitstreamConverter()
@@ -976,7 +977,10 @@ bool CBitstreamConverter::BitstreamConvert(uint8_t* pData, int iSize, uint8_t **
           m_sps_pps_context.idr_sps_pps_seen = 0;
       }
 
-      if (m_convert_dovi)
+      if (m_removeDovi && (unit_type == HEVC_NAL_UNSPEC62 || unit_type == HEVC_NAL_UNSPEC63))
+        write_buf = false;
+
+      if (write_buf && m_convert_dovi)
       {
         if (unit_type == HEVC_NAL_UNSPEC62)
         {

--- a/xbmc/utils/BitstreamConverter.cpp
+++ b/xbmc/utils/BitstreamConverter.cpp
@@ -17,6 +17,7 @@
 #include "BitstreamConverter.h"
 #include "BitstreamReader.h"
 #include "BitstreamWriter.h"
+#include "HevcSei.h"
 
 #include <algorithm>
 
@@ -357,6 +358,7 @@ CBitstreamConverter::CBitstreamConverter()
   m_start_decode = true;
   m_convert_dovi = false;
   m_removeDovi = false;
+  m_removeHdr10Plus = false;
 }
 
 CBitstreamConverter::~CBitstreamConverter()
@@ -914,6 +916,8 @@ bool CBitstreamConverter::BitstreamConvert(uint8_t* pData, int iSize, uint8_t **
   const DoviData* rpu_data = NULL;
 #endif
 
+  std::vector<uint8_t> finalPrefixSeiNalu;
+
   switch (m_codec)
   {
     case AV_CODEC_ID_H264:
@@ -971,6 +975,8 @@ bool CBitstreamConverter::BitstreamConvert(uint8_t* pData, int iSize, uint8_t **
       const uint8_t* buf_to_write = buf;
       int32_t final_nal_size = nal_size;
 
+      bool containsHdr10Plus{false};
+
       if (!m_sps_pps_context.first_idr && IsSlice(unit_type))
       {
           m_sps_pps_context.first_idr = 1;
@@ -979,6 +985,26 @@ bool CBitstreamConverter::BitstreamConvert(uint8_t* pData, int iSize, uint8_t **
 
       if (m_removeDovi && (unit_type == HEVC_NAL_UNSPEC62 || unit_type == HEVC_NAL_UNSPEC63))
         write_buf = false;
+
+      // Try removing HDR10+ only if the NAL is big enough, optimization
+      if (m_removeHdr10Plus && unit_type == HEVC_NAL_SEI_PREFIX && nal_size >= 7)
+      {
+        std::tie(containsHdr10Plus, finalPrefixSeiNalu) =
+            CHevcSei::RemoveHdr10PlusFromSeiNalu(buf, nal_size);
+
+        if (containsHdr10Plus)
+        {
+          if (!finalPrefixSeiNalu.empty())
+          {
+            buf_to_write = finalPrefixSeiNalu.data();
+            final_nal_size = finalPrefixSeiNalu.size();
+          }
+          else
+          {
+            write_buf = false;
+          }
+        }
+      }
 
       if (write_buf && m_convert_dovi)
       {
@@ -1012,6 +1038,9 @@ bool CBitstreamConverter::BitstreamConvert(uint8_t* pData, int iSize, uint8_t **
         rpu_data = NULL;
       }
 #endif
+
+      if (containsHdr10Plus && !finalPrefixSeiNalu.empty())
+        finalPrefixSeiNalu.clear();
     }
 
     buf += nal_size;

--- a/xbmc/utils/BitstreamConverter.h
+++ b/xbmc/utils/BitstreamConverter.h
@@ -101,6 +101,7 @@ public:
   bool              CanStartDecode() const;
   void SetConvertDovi(bool value) { m_convert_dovi = value; }
   void SetRemoveDovi(bool value) { m_removeDovi = value; }
+  void SetRemoveHdr10Plus(bool value) { m_removeHdr10Plus = value; }
 
   static bool       mpeg2_sequence_header(const uint8_t *data, const uint32_t size, mpeg2_sequence *sequence);
 
@@ -147,4 +148,5 @@ protected:
   bool              m_start_decode;
   bool m_convert_dovi;
   bool m_removeDovi;
+  bool m_removeHdr10Plus;
 };

--- a/xbmc/utils/BitstreamConverter.h
+++ b/xbmc/utils/BitstreamConverter.h
@@ -100,6 +100,7 @@ public:
   void              ResetStartDecode(void);
   bool              CanStartDecode() const;
   void SetConvertDovi(bool value) { m_convert_dovi = value; }
+  void SetRemoveDovi(bool value) { m_removeDovi = value; }
 
   static bool       mpeg2_sequence_header(const uint8_t *data, const uint32_t size, mpeg2_sequence *sequence);
 
@@ -145,4 +146,5 @@ protected:
   AVCodecID         m_codec;
   bool              m_start_decode;
   bool m_convert_dovi;
+  bool m_removeDovi;
 };

--- a/xbmc/utils/BitstreamReader.cpp
+++ b/xbmc/utils/BitstreamReader.cpp
@@ -21,6 +21,8 @@ uint32_t CBitstreamReader::ReadBits(int nbits)
   buffer += offbits / 8;
   offbits %= 8;
 
+  m_posBits += nbits;
+
   return ret;
 }
 
@@ -29,6 +31,8 @@ void CBitstreamReader::SkipBits(int nbits)
   offbits += nbits;
   buffer += offbits / 8;
   offbits %= 8;
+
+  m_posBits += nbits;
 
   if (buffer > (start + length))
     oflow = 1;

--- a/xbmc/utils/BitstreamReader.h
+++ b/xbmc/utils/BitstreamReader.h
@@ -17,10 +17,13 @@ public:
   uint32_t   ReadBits(int nbits);
   void       SkipBits(int nbits);
   uint32_t   GetBits(int nbits);
+  unsigned int Position() { return m_posBits; }
+  unsigned int AvailableBits() { return length * 8 - m_posBits; }
 
 private:
   const uint8_t *buffer, *start;
   int offbits = 0, length, oflow = 0;
+  int m_posBits{0};
 };
 
 const uint8_t* find_start_code(const uint8_t *p, const uint8_t *end, uint32_t *state);

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -29,6 +29,7 @@ set(SOURCES ActorProtocol.cpp
             FontUtils.cpp
             GpuInfo.cpp
             GroupUtils.cpp
+            HevcSei.cpp
             HTMLUtil.cpp
             HttpHeader.cpp
             HttpParser.cpp
@@ -115,6 +116,7 @@ set(HEADERS ActorProtocol.h
             GpuInfo.h
             GroupUtils.h
             HDRCapabilities.h
+            HevcSei.h
             HTMLUtil.h
             HttpHeader.h
             HttpParser.h

--- a/xbmc/utils/HevcSei.cpp
+++ b/xbmc/utils/HevcSei.cpp
@@ -1,0 +1,122 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "HevcSei.h"
+
+void HevcAddStartCodeEmulationPrevention3Byte(std::vector<uint8_t>& buf)
+{
+  size_t i = 0;
+
+  while (i < buf.size())
+  {
+    if (i > 2 && buf[i - 2] == 0 && buf[i - 1] == 0 && buf[i] <= 3)
+      buf.insert(buf.begin() + i, 3);
+
+    i += 1;
+  }
+}
+
+void HevcClearStartCodeEmulationPrevention3Byte(const uint8_t* buf,
+                                                const size_t len,
+                                                std::vector<uint8_t>& out)
+{
+  size_t i = 0;
+
+  if (len > 2)
+  {
+    out.reserve(len);
+
+    out.emplace_back(buf[0]);
+    out.emplace_back(buf[1]);
+
+    for (i = 2; i < len; i++)
+    {
+      if (!(buf[i - 2] == 0 && buf[i - 1] == 0 && buf[i] == 3))
+        out.emplace_back(buf[i]);
+    }
+  }
+  else
+  {
+    out.assign(buf, buf + len);
+  }
+}
+
+int CHevcSei::ParseSeiMessage(CBitstreamReader& br, std::vector<CHevcSei>& messages)
+{
+  CHevcSei sei;
+  uint8_t lastPayloadTypeByte{0};
+  uint8_t lastPayloadSizeByte{0};
+
+  sei.m_msgOffset = br.Position() / 8;
+
+  lastPayloadTypeByte = br.ReadBits(8);
+  while (lastPayloadTypeByte == 0xFF)
+  {
+    lastPayloadTypeByte = br.ReadBits(8);
+    sei.m_payloadType += 255;
+  }
+
+  sei.m_payloadType += lastPayloadTypeByte;
+
+  lastPayloadSizeByte = br.ReadBits(8);
+  while (lastPayloadSizeByte == 0xFF)
+  {
+    lastPayloadSizeByte = br.ReadBits(8);
+    sei.m_payloadSize += 255;
+  }
+
+  sei.m_payloadSize += lastPayloadSizeByte;
+  sei.m_payloadOffset = br.Position() / 8;
+
+  // Invalid size
+  if (sei.m_payloadSize > br.AvailableBits())
+    return 1;
+
+  br.SkipBits(sei.m_payloadSize * 8);
+  messages.emplace_back(sei);
+
+  return 0;
+}
+
+std::vector<CHevcSei> CHevcSei::ParseSeiRbspInternal(const uint8_t* buf, const size_t len)
+{
+  std::vector<CHevcSei> messages;
+
+  if (len > 4)
+  {
+    CBitstreamReader br(buf, len);
+
+    // forbidden_zero_bit, nal_type, nuh_layer_id, temporal_id
+    // nal_type == SEI_PREFIX should already be verified by caller
+    br.SkipBits(16);
+
+    while (true)
+    {
+      if (ParseSeiMessage(br, messages))
+        break;
+
+      if (br.AvailableBits() <= 8)
+        break;
+    }
+  }
+
+  return messages;
+}
+
+std::vector<CHevcSei> CHevcSei::ParseSeiRbsp(const uint8_t* buf, const size_t len)
+{
+  return ParseSeiRbspInternal(buf, len);
+}
+
+std::vector<CHevcSei> CHevcSei::ParseSeiRbspUnclearedEmulation(const uint8_t* inData,
+                                                               const size_t inDataLen,
+                                                               std::vector<uint8_t>& buf)
+{
+  HevcClearStartCodeEmulationPrevention3Byte(inData, inDataLen, buf);
+  return ParseSeiRbsp(buf.data(), buf.size());
+}

--- a/xbmc/utils/HevcSei.h
+++ b/xbmc/utils/HevcSei.h
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "BitstreamReader.h"
+
+#include <optional>
+#include <vector>
+
+/*!
+ * \brief Parses HEVC SEI messages for supplemental video information.
+ *
+ * The CHevcSei class is used to interpret and handle Supplemental Enhancement
+ * Information (SEI) messages found in High Efficiency Video Coding (HEVC)
+ * bitstreams. It is particularly useful for extracting HDR10+ metadata and
+ * other types of supplemental data from HEVC encoded video streams.
+ *
+ * \note This class deals with SEI messages in HEVC streams and does not
+ * process the video content itself.
+ */
+class CHevcSei
+{
+public:
+  CHevcSei() = default;
+  ~CHevcSei() = default;
+
+  uint8_t m_payloadType{0};
+  size_t m_payloadSize{0};
+
+  // In relation to the input SEI rbsp payload
+  size_t m_msgOffset{0};
+  size_t m_payloadOffset{0};
+
+  // Parses SEI payload assumed to not have emulation prevention 3 bytes
+  static std::vector<CHevcSei> ParseSeiRbsp(const uint8_t* buf, const size_t len);
+
+  // Clears emulation prevention 3 bytes and fills in the passed buf
+  static std::vector<CHevcSei> ParseSeiRbspUnclearedEmulation(const uint8_t* inData,
+                                                              const size_t inDataLen,
+                                                              std::vector<uint8_t>& buf);
+
+private:
+  // Parses single SEI message from the reader and pushes it to the list
+  static int ParseSeiMessage(CBitstreamReader& br, std::vector<CHevcSei>& messages);
+
+  static std::vector<CHevcSei> ParseSeiRbspInternal(const uint8_t* buf, const size_t len);
+};

--- a/xbmc/utils/HevcSei.h
+++ b/xbmc/utils/HevcSei.h
@@ -45,6 +45,18 @@ public:
                                                               const size_t inDataLen,
                                                               std::vector<uint8_t>& buf);
 
+  // Returns a HDR10+ SEI message if present in the list
+  static std::optional<const CHevcSei*> FindHdr10PlusSeiMessage(
+      const std::vector<uint8_t>& buf, const std::vector<CHevcSei>& messages);
+
+  // Returns a pair with:
+  //   1) a bool for whether or not the NALU SEI payload contains a HDR10+ SEI message.
+  //   2) a vector of bytes:
+  //      When not empty: the new NALU containing all but the HDR10+ SEI message.
+  //      Otherwise: the NALU contained only one HDR10+ SEI and can be discarded.
+  static std::pair<bool, const std::vector<uint8_t>> RemoveHdr10PlusFromSeiNalu(
+      const uint8_t* inData, const size_t inDataLen);
+
 private:
   // Parses single SEI message from the reader and pushes it to the list
   static int ParseSeiMessage(CBitstreamReader& br, std::vector<CHevcSei>& messages);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The changes add a new Expert setting in the Player/Video settings, named `Allowed HDR dynamic metadata formats`.
The setting allows users to choose the preferred dynamic HDR format for playback, or none.

It works by completely removing the metadata from the bitstream prior to decoding.
For Dolby Vision, the NAL types can just be filtered out.
For HDR10+, it is necessary to parse the SEI messages and remove the SMPTE ST 2094-40 / HDR10+ one.
Supports HEVC only.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improves compatibility problems with videos containing both Dolby Vision and HDR10+ on some devices (FireTV Stick).
As dynamic HDR videos are becoming more and more common, a lot of people encounter issues playing them because the hardware has major bugs that cannot be worked around through Android APIs.

Furthermore, webOS on some TV models also needs this setting: https://github.com/xbmc/xbmc/issues/24390
It will be added once this is accepted.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There's a custom build on the forums: https://forum.kodi.tv/showthread.php?tid=371557

The Dolby Vision removing code has been in use for a while.
The HDR10+ code has been reworked but the SEI parsing code should be OK and mostly matches other implementations like in `FFmpeg`.

Tested in runtime on FireTV Stick 4K Max gen 1 and 2.
With a display supporting both Dolby Vision/HDR10+, the display switches modes correctly and the image looks fine.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
No effect by default.
Users must manually select the HDR dynamic metadata to keep, otherwise the videos are left untouched.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
