### PR TITLE
[video] Modify versions/extras related texts

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -951,6 +951,7 @@ msgstr ""
 
 #. generic "play" (some sort of media) label used in different places
 #: addons/skin.estuary/xml/DialogVideoInfo.xml
+#: addons/skin.estuary/xml/DialogVideoManager.xml
 #: addons/skin.estuary/xml/SkinSettings.xml
 #: addons/skin.estuary/xml/Variables.xml
 #: xbmc/dialogs/GUIDialogPlayEject.cpp
@@ -7564,6 +7565,7 @@ msgctxt "#13510"
 msgid "Sync playback to display"
 msgstr ""
 
+#: addons/skin.estuary/xml/DialogVideoManager.xml
 #: xbmc/music/dialogs/GUIDialogSongInfo.cpp
 #: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
 msgctxt "#13511"
@@ -8688,6 +8690,7 @@ msgctxt "#15014"
 msgid "Keep"
 msgstr ""
 
+#: addons/skin.estuary/xml/DialogVideoManager.xml
 #: xbmc/favourites/ContextMenus.h
 #: xbmc/favourites/GUIDialogFavourites.cpp
 #: xbmc/video/VideoDatabase.cpp
@@ -23857,14 +23860,14 @@ msgstr ""
 
 #. Add video version dialog title
 #: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
-#: addons/skin.estuary/xml/DialogVideoVersion.xml
+#: addons/skin.estuary/xml/DialogVideoManager.xml
 msgctxt "#40014"
 msgid "Add version"
 msgstr ""
 
 #. Add video extra dialog title
 #: xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
-#: addons/skin.estuary/xml/DialogVideoVersion.xml
+#: addons/skin.estuary/xml/DialogVideoManager.xml
 msgctxt "#40015"
 msgid "Add extra"
 msgstr ""
@@ -23909,7 +23912,7 @@ msgid "Manage {0:s}"
 msgstr ""
 
 #. Button label to make a video version the default version
-#: addons/skin.estuary/xml/DialogVideoVersion.xml
+#: addons/skin.estuary/xml/DialogVideoManager.xml
 msgctxt "#40023"
 msgid "Set as default"
 msgstr ""

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -464,6 +464,7 @@ msgctxt "#117"
 msgid "Delete"
 msgstr ""
 
+#: addons/skin.estuary/xml/DialogVideoManager.xml
 #: xbmc/favourites/ContextMenus.h
 #: xbmc/favourites/GUIDialogFavourites.cpp
 #: xbmc/pvr/PVRContextMenus.cpp
@@ -23793,7 +23794,11 @@ msgctxt "#40003"
 msgid "Version"
 msgstr ""
 
-#empty string with id 40004
+#. Button to change the version type of a version in Versions Manager
+#: addons/skin.estuary/xml/DialogVideoManager.xml
+msgctxt "#40004"
+msgid "Choose type"
+msgstr ""
 
 #. Warning dialog title
 #: xbmc/video/dialogs/GUIDialogVideoManager.cpp

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -23793,12 +23793,7 @@ msgctxt "#40003"
 msgid "Version"
 msgstr ""
 
-#. New video version dialog button
-#: xbmc/video/dialogs/GUIDialogVideoManager.cpp
-#: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
-msgctxt "#40004"
-msgid "New version..."
-msgstr ""
+#empty string with id 40004
 
 #. Warning dialog title
 #: xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -24099,7 +24094,43 @@ msgctxt "#40214"
 msgid "Choose extra"
 msgstr ""
 
-#empty strings from id 40215 to 40399
+#. Title of the dialog for version rename action from Versions Manager
+#: xbmc/video/dialogs/GUIDialogVideoManager.cpp
+msgctxt "#40215"
+msgid "Choose version type"
+msgstr ""
+
+#. Caption of the button to create a new version type (Versions Manager > Rename)
+#: xbmc/video/dialogs/GUIDialogVideoManager.cpp
+msgctxt "#40216"
+msgid "New type..."
+msgstr ""
+
+#. Caption of the dialog for keyboard entry of a new version type
+#: xbmc/video/dialogs/GUIDialogVideoManager.cpp
+msgctxt "#40217"
+msgid "New version type"
+msgstr ""
+
+#. Title of the dialog for extra rename action from Extras Manager
+#: xbmc/video/dialogs/GUIDialogVideoManager.cpp
+msgctxt "#40218"
+msgid "Choose extra name"
+msgstr ""
+
+#. Caption of the button to create a new extra name (Extras Manager > Rename)
+#: xbmc/video/dialogs/GUIDialogVideoManager.cpp
+msgctxt "#40219"
+msgid "New name..."
+msgstr ""
+
+#. Caption of the dialog for keyboard entry of a new extra name
+#: xbmc/video/dialogs/GUIDialogVideoManager.cpp
+msgctxt "#40220"
+msgid "New extra name"
+msgstr ""
+
+#empty strings from id 40221 to 40399
 
 # Video versions
 

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -24061,7 +24061,7 @@ msgstr ""
 #: xbmc/video/ContextMenus.h
 #: xbmc/video/guilib/VideoVersionHelper.cpp
 msgctxt "#40208"
-msgid "Choose version"
+msgid "Choose version: {}"
 msgstr ""
 
 #. First choose video version and then select a player and play context menu item label
@@ -24099,7 +24099,7 @@ msgstr ""
 #. Dialog title for the selection of the video extra
 #: xbmc/video/guilib/VideoVersionHelper.cpp
 msgctxt "#40214"
-msgid "Choose extra"
+msgid "Choose extra: {}"
 msgstr ""
 
 #. Title of the dialog for version rename action from Versions Manager

--- a/addons/skin.estuary/xml/DialogVideoManager.xml
+++ b/addons/skin.estuary/xml/DialogVideoManager.xml
@@ -106,7 +106,13 @@
 				</include>
 				<include content="DefaultDialogButton">
 					<param name="id" value="24" />
+					<param name="label" value="$LOCALIZE[40004]" />
+					<param name="visible">Window.IsVisible(managevideoversions)</param>
+				</include>
+				<include content="DefaultDialogButton">
+					<param name="id" value="28" />
 					<param name="label" value="$LOCALIZE[118]" />
+					<param name="visible">Window.IsVisible(managevideoextras)</param>
 				</include>
 				<include content="DefaultDialogButton">
 					<param name="id" value="26" />

--- a/xbmc/video/dialogs/GUIDialogVideoManager.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -38,7 +38,6 @@
 static constexpr unsigned int CONTROL_LABEL_TITLE = 2;
 
 static constexpr unsigned int CONTROL_BUTTON_PLAY = 21;
-static constexpr unsigned int CONTROL_BUTTON_RENAME = 24;
 static constexpr unsigned int CONTROL_BUTTON_REMOVE = 26;
 static constexpr unsigned int CONTROL_BUTTON_CHOOSE_ART = 27;
 
@@ -81,10 +80,6 @@ bool CGUIDialogVideoManager::OnMessage(CGUIMessage& message)
       else if (control == CONTROL_BUTTON_PLAY)
       {
         Play();
-      }
-      else if (control == CONTROL_BUTTON_RENAME)
-      {
-        Rename();
       }
       else if (control == CONTROL_BUTTON_REMOVE)
       {
@@ -142,7 +137,6 @@ void CGUIDialogVideoManager::UpdateButtons()
   if (!m_videoAssetsList->IsEmpty())
   {
     CONTROL_ENABLE(CONTROL_BUTTON_CHOOSE_ART);
-    CONTROL_ENABLE(CONTROL_BUTTON_RENAME);
     CONTROL_ENABLE(CONTROL_BUTTON_REMOVE);
     CONTROL_ENABLE(CONTROL_BUTTON_PLAY);
 
@@ -151,7 +145,6 @@ void CGUIDialogVideoManager::UpdateButtons()
   else
   {
     CONTROL_DISABLE(CONTROL_BUTTON_CHOOSE_ART);
-    CONTROL_DISABLE(CONTROL_BUTTON_RENAME);
     CONTROL_DISABLE(CONTROL_BUTTON_REMOVE);
     CONTROL_DISABLE(CONTROL_BUTTON_PLAY);
   }

--- a/xbmc/video/dialogs/GUIDialogVideoManager.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.h
@@ -52,7 +52,9 @@ protected:
 
   void UpdateControls();
 
-  static int ChooseVideoAsset(const std::shared_ptr<CFileItem>& item, VideoAssetType assetType);
+  static int ChooseVideoAsset(const std::shared_ptr<CFileItem>& item,
+                              VideoAssetType assetType,
+                              const std::string& defaultName);
   void AppendItemFolderToFileBrowserSources(std::vector<CMediaSource>& sources);
 
   CVideoDatabase m_database;

--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
@@ -33,6 +33,7 @@
 #include <string>
 
 static constexpr unsigned int CONTROL_BUTTON_ADD_EXTRAS = 23;
+static constexpr unsigned int CONTROL_BUTTON_RENAME_EXTRA = 28;
 
 CGUIDialogVideoManagerExtras::CGUIDialogVideoManagerExtras()
   : CGUIDialogVideoManager(WINDOW_DIALOG_MANAGE_VIDEO_EXTRAS)
@@ -63,6 +64,10 @@ bool CGUIDialogVideoManagerExtras::OnMessage(CGUIMessage& message)
           m_hasUpdatedItems = true;
         }
       }
+      else if (control == CONTROL_BUTTON_RENAME_EXTRA)
+      {
+        Rename();
+      }
       break;
     }
   }
@@ -77,10 +82,15 @@ void CGUIDialogVideoManagerExtras::UpdateButtons()
   // Always enabled
   CONTROL_ENABLE(CONTROL_BUTTON_ADD_EXTRAS);
 
-  // Enabled if list not empty
+  // Conditional to empty list
   if (m_videoAssetsList->IsEmpty())
   {
     SET_CONTROL_FOCUS(CONTROL_BUTTON_ADD_EXTRAS, 0);
+    CONTROL_DISABLE(CONTROL_BUTTON_RENAME_EXTRA);
+  }
+  else
+  {
+    CONTROL_ENABLE(CONTROL_BUTTON_RENAME_EXTRA);
   }
 }
 

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -34,6 +34,7 @@
 #include <string>
 
 static constexpr unsigned int CONTROL_BUTTON_ADD_VERSION = 22;
+static constexpr unsigned int CONTROL_BUTTON_RENAME_VERSION = 24;
 static constexpr unsigned int CONTROL_BUTTON_SET_DEFAULT = 25;
 
 CGUIDialogVideoManagerVersions::CGUIDialogVideoManagerVersions()
@@ -64,6 +65,10 @@ bool CGUIDialogVideoManagerVersions::OnMessage(CGUIMessage& message)
           m_hasUpdatedItems = true;
         }
       }
+      else if (control == CONTROL_BUTTON_RENAME_VERSION)
+      {
+        Rename();
+      }
       else if (control == CONTROL_BUTTON_SET_DEFAULT)
       {
         SetDefault();
@@ -85,7 +90,7 @@ void CGUIDialogVideoManagerVersions::UpdateButtons()
 {
   CGUIDialogVideoManager::UpdateButtons();
 
-  // Always anabled
+  // Always enabled
   CONTROL_ENABLE(CONTROL_BUTTON_ADD_VERSION);
 
   // Enabled for non-default version only
@@ -101,10 +106,15 @@ void CGUIDialogVideoManagerVersions::UpdateButtons()
     CONTROL_ENABLE(CONTROL_BUTTON_SET_DEFAULT);
   }
 
-  // Enabled if list not empty
+  // Conditional to empty list
   if (m_videoAssetsList->IsEmpty())
   {
     SET_CONTROL_FOCUS(CONTROL_BUTTON_ADD_VERSION, 0);
+    CONTROL_DISABLE(CONTROL_BUTTON_RENAME_VERSION);
+  }
+  else
+  {
+    CONTROL_ENABLE(CONTROL_BUTTON_RENAME_VERSION);
   }
 }
 

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -364,7 +364,7 @@ bool CGUIDialogVideoManagerVersions::ChooseVideoAndConvertToVideoVersion(
   }
 
   // choose a video version for the video
-  const int idVideoVersion{ChooseVideoAsset(selectedItem, VideoAssetType::VERSION)};
+  const int idVideoVersion{ChooseVideoAsset(selectedItem, VideoAssetType::VERSION, "")};
   if (idVideoVersion < 0)
     return false;
 
@@ -562,7 +562,7 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
           return false;
         }
 
-        const int idNewVideoVersion{ChooseVideoAsset(m_videoAsset, VideoAssetType::VERSION)};
+        const int idNewVideoVersion{ChooseVideoAsset(m_videoAsset, VideoAssetType::VERSION, "")};
         if (idNewVideoVersion != -1)
         {
           return m_database.ConvertVideoToVersion(itemType, newAsset.m_idMedia, dbId,
@@ -591,7 +591,7 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
                  CURL::GetRedacted(item.GetPath()));
     }
 
-    const int idNewVideoVersion{ChooseVideoAsset(m_videoAsset, VideoAssetType::VERSION)};
+    const int idNewVideoVersion{ChooseVideoAsset(m_videoAsset, VideoAssetType::VERSION, "")};
     if (idNewVideoVersion == -1)
       return false;
 
@@ -633,7 +633,7 @@ bool CGUIDialogVideoManagerVersions::AddSimilarMovieAsVersion(
   }
 
   // choose a video version type for the video
-  const int idVideoVersion{ChooseVideoAsset(itemMovie, VideoAssetType::VERSION)};
+  const int idVideoVersion{ChooseVideoAsset(itemMovie, VideoAssetType::VERSION, "")};
   if (idVideoVersion < 0)
     return false;
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

* Changed dialog titles and button captions in the dialog triggered by the Rename action of Versions Manager / Extras Manager to distinguish versions and extras.

* Version or extra renaming: provide the current name as default value for the onscreen keyboard entry when the user presses the "New" button.

* Renamed the Rename button of Versions Manager to Choose type

* Brought back the movie name in the title of the Choose version/extra dialog


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #24549. Some strings still inappropriately shared between versions and extras.

Also it's annoying to enter names from scratch when the current one is close to what the new entry is going to be. It's easier to delete the unwanted default value than to enter from scratch.

Fix #24616, movie title disappeared in the code restructure of the Choose dialog to use select dialogs

## Screenshots

**Rename dialogs**

Before, both versions and extras show:

![image](https://github.com/xbmc/xbmc/assets/489377/0508948c-0d12-4f9d-b458-76f7eed1b118)

![image](https://github.com/xbmc/xbmc/assets/489377/32fcfb9d-554d-435e-afd9-e3039e3b90f0)


After, rename version:

![image](https://github.com/xbmc/xbmc/assets/489377/2f94b807-e8ce-4aea-97f2-f95e7f2ebab3)

![image](https://github.com/xbmc/xbmc/assets/489377/307e13cc-92e1-4f3e-aa19-cdfaa60c2f34)

After, rename extra:

![image](https://github.com/xbmc/xbmc/assets/489377/b3114c2e-c0f3-4a85-b664-2a5afd665adb)

![image](https://github.com/xbmc/xbmc/assets/489377/6ddb523f-c891-40b3-a488-868e2784d25e)

**Versions Manager dialog**

Changed text of the button "Rename":
![image](https://github.com/xbmc/xbmc/assets/489377/09ca78b5-eb7a-48a2-a4e5-614387a81ed1)

**Choose dialog**

Movie title in the dialog title:
![image](https://github.com/xbmc/xbmc/assets/489377/181454a5-46ad-4c10-99ad-ec3576dbf43d)

![image](https://github.com/xbmc/xbmc/assets/489377/c2ab190e-f425-46b0-bf31-1fb136d9721f)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manage versions and extras, rename to other predefined/already entered name, rename to new name, cancel half-way.

Play movie with versions and extra to check the movie title in title bar

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
More consistent experience.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
