### PR TITLE
AESinkAudioTrack: Help broken firmwares to make kodi ignore broken delay

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -396,6 +396,9 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
     }
   }
 
+  m_superviseAudioDelay =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_superviseAudioDelay;
+
   int atChannelMask = AEChannelMapToAUDIOTRACKChannelMask(m_format.m_channelLayout);
   m_format.m_channelLayout  = AUDIOTRACKChannelMaskToAEChannelMap(atChannelMask);
   if (m_encoding == CJNIAudioFormat::ENCODING_IEC61937)
@@ -825,7 +828,7 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t **data, unsigned int frames, 
     const double max_stuck_delay_ms = m_audiotrackbuffer_sec_orig * 2000.0;
     const double stime_ms = 1000.0 * frames / m_format.m_sampleRate;
 
-    if (m_stuckCounter * stime_ms > max_stuck_delay_ms)
+    if (m_superviseAudioDelay && (m_stuckCounter * stime_ms > max_stuck_delay_ms))
     {
       CLog::Log(LOGERROR, "Sink got stuck with {:f} ms - ask AE for reopening", max_stuck_delay_ms);
       usleep(max_stuck_delay_ms * 1000);

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -96,6 +96,7 @@ private:
   double m_hw_delay = 0.0;
   CJNIAudioTimestamp m_timestamp;
   XbmcThreads::EndTime<> m_stampTimer;
+  bool m_superviseAudioDelay = false;
 
   std::vector<float> m_floatbuf;
   std::vector<int16_t> m_shortbuf;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -585,6 +585,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetUInt(pElement, "maxpassthroughoffsyncduration", m_maxPassthroughOffSyncDuration,
                       10, 100);
     XMLUtils::GetBoolean(pElement, "allowmultichannelfloat", m_AllowMultiChannelFloat);
+    XMLUtils::GetBoolean(pElement, "superviseaudiodelay", m_superviseAudioDelay);
   }
 
   pElement = pRootElement->FirstChildElement("x11");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -154,7 +154,8 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     float m_videoIgnorePercentAtEnd;
     float m_audioApplyDrc;
     unsigned int m_maxPassthroughOffSyncDuration = 10; // when 10 ms off adjust
-    bool m_AllowMultiChannelFloat = false; // Android only switch to be remved in v22
+    bool m_AllowMultiChannelFloat = false; // Android only switch to be removed in v22
+    bool m_superviseAudioDelay = false; // Android only to correct broken audio firmwares
 
     int   m_videoVDPAUScaling;
     float m_videoNonLinStretchRatio;


### PR DESCRIPTION
Kodi can supervise the sink for being stuck, which means: if you open a sink with 160 ms buffer and it does not move while eating more than twice of the buffer's audio data, it is considered a bug. Sadly - there is a whole lot of broken firmwares out there, one of the leards: Ugoos. Which is the reason I make this opt-in. That means that FireTV Cube 3rd Gen and others would need to enable this - once again - via an advanced settings.

```
<advancedsettings>
<audio>
<superviseaudiodelay>true</superviseaudiodelay> 
</audio>
</advancedsettings>
```

See forum report: https://forum.kodi.tv/showthread.php?tid=376090 - I briefly informed in Slack some weeks ago and just waited to see more broken devices. Yeah, seen now the Ugoos twice ...

For now it's only the Ugoos, while I did not get other reports. The alternative to this change would be a "negative list" .... which we don't want to maintain. Sad thing is, that FireTV Cube 3rd Gen and the other boxes that need this are a bigger number.

Open for suggestions.