### PR TITLE
[webOS] Add setting to select allowed HDR dynamic metadata formats

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -191,7 +191,12 @@
           <control type="toggle" />
         </setting>
         <setting id="videoplayer.allowedhdrformats" type="list[integer]" label="39198" help="39199">
-          <requirement>HAS_MEDIACODEC</requirement>
+          <requirement><!-- Android and webOS use CBitstreamConverter -->
+            <or>
+              <condition>HAS_MEDIACODEC</condition>
+              <condition>HAVE_WEBOS</condition>
+            </or>
+          </requirement>
           <level>2</level>
           <default>0,1</default> <!-- Allow all HDR formats -->
           <constraints>

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -433,6 +433,10 @@ void CSettingConditions::Initialize()
   m_simpleConditions.emplace("has_dx");
   m_simpleConditions.emplace("hasdxva2");
 #endif
+#if defined(TARGET_WEBOS)
+  m_simpleConditions.emplace("have_webos");
+#endif
+
 #ifdef HAVE_LCMS2
   m_simpleConditions.emplace("have_lcms2");
 #endif


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Adds the `Allowed HDR dynamic metadata formats` setting to webOS Kodi.
webOS uses CBitstreamConverter and supports Dolby Vision. Therefore the setting can be useful.

There are also TV models that have compatibility issues with videos containing both Dolby Vision and HDR10+ metadata in the bitstream. 
Such as #24390.

## Motivation and context
To fix #24390.

## How has this been tested?
Runtime tested on LG OLED C2, the setting works to disable Dolby Vision and HDR10+.

## What is the effect on users?
None by default.
Fixes playback problems for some TVs when the supported HDR dynamic metadata formats are selected by the user.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
