### PR TITLE
[Estuary] Fix player controls dialog

### DIFF
--- a/addons/skin.estuary/xml/PlayerControls.xml
+++ b/addons/skin.estuary/xml/PlayerControls.xml
@@ -119,13 +119,13 @@
 					<height>125</height>
 					<visible>Player.HasAudio + !MusicPlayer.Content(LiveTV)</visible>
 					<control type="button" id="704">
-						<left>0</left>
+						<left>40</left>
 						<top>0</top>
 						<width>74</width>
 						<height>74</height>
-						<label>$LOCALIZE[486]$INFO[Playlist.Repeat, : ]</label>
+						<label></label>
 						<font></font>
-						<texturefocus />
+						<texturefocus colordiffuse="button_focus">osd/fullscreen/buttons/button-fo.png</texturefocus>
 						<texturenofocus />
 						<onleft>605</onleft>
 						<onright>607</onright>
@@ -135,30 +135,29 @@
 					</control>
 					<control type="image">
 						<left>40</left>
-						<top>25</top>
+						<top>0</top>
 						<width>74</width>
 						<height>74</height>
-						<animation center="37,37" effect="zoom" end="100" reversible="false" start="95" time="480" tween="back" condition="Control.HasFocus(704)">Conditional</animation>
-						<texture colordiffuse="$VAR[RepeatButtonColordiffuseVar]">$VAR[PlayerControlsRepeatImageVar]</texture>
+						<animation center="38,38" effect="zoom" end="100" reversible="false" start="95" time="480" tween="back" condition="Control.HasFocus(704)">Conditional</animation>
+						<texture colordiffuse="white]">$VAR[PlayerControlsRepeatImageVar]</texture>
 					</control>
 				</control>
 				<control type="radiobutton" id="607">
-					<textureradioonfocus colordiffuse="button_focus">osd/fullscreen/buttons/random-on.png</textureradioonfocus>
+					<textureradioonfocus colordiffuse="white">osd/fullscreen/buttons/random-on.png</textureradioonfocus>
 					<textureradioonnofocus>osd/fullscreen/buttons/random-on.png</textureradioonnofocus>
-					<textureradioofffocus colordiffuse="button_focus">osd/fullscreen/buttons/random-off.png</textureradioofffocus>
+					<textureradioofffocus colordiffuse="white">osd/fullscreen/buttons/random-off.png</textureradioofffocus>
 					<textureradiooffnofocus>osd/fullscreen/buttons/random-off.png</textureradiooffnofocus>
 					<textureradioondisabled colordiffuse="disabled">osd/fullscreen/buttons/random-on.png</textureradioondisabled>
 					<textureradiooffdisabled colordiffuse="disabled">osd/fullscreen/buttons/random-off.png</textureradiooffdisabled>
-					<texturefocus />
-					<width>125</width>
-					<height>123</height>
+					<texturefocus colordiffuse="button_focus">osd/fullscreen/buttons/button-fo.png</texturefocus>
+					<width>76</width>
+					<height>76</height>
 					<radiowidth>74</radiowidth>
 					<radioheight>74</radioheight>
 					<font></font>
 					<texturenofocus />
-					<radioposx>0</radioposx>
+					<radioposx>1</radioposx>
 					<radioposy>0</radioposy>
-					<label>$LOCALIZE[590]$INFO[Playlist.Random, : ]</label>
 					<animation center="62,62" effect="zoom" end="100" reversible="false" start="95" time="480" tween="back">Focus</animation>
 					<selected>Playlist.IsRandom</selected>
 					<visible>Player.HasAudio + !MusicPlayer.Content(LiveTV)</visible>
@@ -172,7 +171,7 @@
 				<height>250</height>
 				<fadetime>400</fadetime>
 				<aspectratio>keep</aspectratio>
-				<texture fallback="DefaultAlbumCover.png" border="2">$INFO[Player.Art(thumb)]</texture>
+				<texture border="2">$VAR[NowPlayingPosterVar]</texture>
 				<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
 				<bordersize>4</bordersize>
 			</control>

--- a/addons/skin.estuary/xml/PlayerControls.xml
+++ b/addons/skin.estuary/xml/PlayerControls.xml
@@ -139,7 +139,7 @@
 						<width>74</width>
 						<height>74</height>
 						<animation center="38,38" effect="zoom" end="100" reversible="false" start="95" time="480" tween="back" condition="Control.HasFocus(704)">Conditional</animation>
-						<texture colordiffuse="white]">$VAR[PlayerControlsRepeatImageVar]</texture>
+						<texture colordiffuse="white">$VAR[PlayerControlsRepeatImageVar]</texture>
 					</control>
 				</control>
 				<control type="radiobutton" id="607">


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Fix alignment of the 'Repeat' and 'Random' buttons in the Player Controls dialog as well matching the buttons styles.
Fix artwork to show poster if available.
## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Noticed these problems while checking what this dialog actually did.
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.
## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):
Before:
![screenshot00003](https://github.com/xbmc/xbmc/assets/133808/7a6e16ea-7f3c-4222-a51e-cd02d7a771e2)
Buttons not lined up with the rest of the controls.
![screenshot00002](https://github.com/xbmc/xbmc/assets/133808/aa404f67-3d11-496b-886d-f246ddf43d96)
No poster for the movie currently playing.

After:
![screenshot00001](https://github.com/xbmc/xbmc/assets/133808/c031d634-2667-4a8d-8b06-7dbdd999ead5)
Correctly aligned buttons with the same style as the rest.
![screenshot00005](https://github.com/xbmc/xbmc/assets/133808/62884d42-f674-4b74-8a4e-78b5e8fb45d2)
Poster shows when playing movie.
## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
