### PR TITLE
[Estuary] Extras - change layout

### DIFF
--- a/addons/skin.estuary/xml/DialogSelect.xml
+++ b/addons/skin.estuary/xml/DialogSelect.xml
@@ -4,12 +4,13 @@
 	<include>Animation_DialogPopupOpenClose</include>
 	<depth>DepthOSD</depth>
 	<controls>
-		<include condition="![Window.IsActive(selectvideoversion) | Window.IsActive(gamesaves) | Window.IsActive(gamestretchmode) | Window.IsActive(gamevideofilter) | Window.IsActive(gamevideorotation) | Window.IsActive(ingamesaves)]">DefaultDialogSelectLayout</include>
+		<include condition="![Window.IsActive(selectvideoversion) | Window.IsActive(selectvideoextra) | Window.IsActive(gamesaves) | Window.IsActive(gamestretchmode) | Window.IsActive(gamevideofilter) | Window.IsActive(gamevideorotation) | Window.IsActive(ingamesaves)]">DefaultDialogSelectLayout</include>
 		<include condition="Window.IsActive(gamesaves)">GameDialogSelectSaveLayout</include>
 		<include condition="Window.IsActive(gamevideofilter)">GameDialogSelectFilterLayout</include>
 		<include condition="Window.IsActive(gamestretchmode)">GameDialogSelectViewLayout</include>
 		<include condition="Window.IsActive(gamevideorotation)">GameDialogSelectViewLayout</include>
 		<include condition="Window.IsActive(ingamesaves)">GameDialogSelectSaveInGameLayout</include>
 		<include condition="Window.IsActive(selectvideoversion)">VideoSelectLayout</include>
+		<include condition="Window.IsActive(selectvideoextra)">VideoSelectLayout</include>
 	</controls>
 </window>

--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -1693,12 +1693,6 @@
 	<include name="MediaInfoListLayout">
 		<param name="height">125</param>
 		<param name="width">880</param>
-		<param name="thumbtexture">$VAR[VideoListThumbVar]</param>
-		<param name="font_1">font14</param>
-		<param name="font_2">font12</param>
-		<param name="label_1">$INFO[ListItem.Label]</param>
-		<param name="label_2">$INFO[ListItem.Duration,$LOCALIZE[180]: ]</param>
-		<param name="label_3">$VAR[VideoCodecVar,, ]$INFO[ListItem.VideoResolution,| , ]$VAR[VideoResolutionTypeVar,, ]$VAR[VideoHDRVar,| , ]$INFO[ListItem.VideoAspect,| ,:1 ]$VAR[AudioCodecVar,| , ]$VAR[AudioChannelsVar]</param>
 		<param name="fontcolor">grey</param>
 		<definition>
 			<itemlayout height="$PARAM[height]" width="$PARAM[width]">
@@ -1707,7 +1701,7 @@
 					<top>7</top>
 					<width>110</width>
 					<height>110</height>
-					<texture>$PARAM[thumbtexture]</texture>
+					<texture>$VAR[VideoListThumbVar]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
 				<control type="label">
@@ -1715,30 +1709,30 @@
 					<top>0</top>
 					<right>20</right>
 					<height>60</height>
-					<font>$PARAM[font_1]</font>
+					<font>font14</font>
 					<aligny>center</aligny>
-					<textcolor>$PARAM[fontcolor]</textcolor>
-					<label>$PARAM[label_1]</label>
+					<textcolor>grey</textcolor>
+					<label>$VAR[MediaInfoListLabelVar]</label>
 				</control>
 				<control type="label">
 					<left>135</left>
 					<top>50</top>
 					<right>20</right>
 					<height>35</height>
-					<font>$PARAM[font_2]</font>
+					<font>font12</font>
 					<aligny>center</aligny>
-					<textcolor>$PARAM[fontcolor]</textcolor>
-					<label>$PARAM[label_2]</label>
+					<textcolor>grey</textcolor>
+					<label>$INFO[ListItem.Duration,$LOCALIZE[180]: ]</label>
 				</control>
 				<control type="label">
 					<left>135</left>
 					<top>85</top>
 					<right>20</right>
 					<height>30</height>
-					<font>$PARAM[font_2]</font>
+					<font>font12</font>
 					<aligny>center</aligny>
-					<textcolor>$PARAM[fontcolor]</textcolor>					
-					<label>$PARAM[label_3]</label>
+					<textcolor>grey</textcolor>					
+					<label>$VAR[VideoCodecVar,, ]$INFO[ListItem.VideoResolution,| , ]$VAR[VideoResolutionTypeVar,, ]$VAR[VideoHDRVar,| , ]$INFO[ListItem.VideoAspect,| ,:1 ]$VAR[AudioCodecVar,| , ]$VAR[AudioChannelsVar]</label>
 				</control>
 			</itemlayout>
 			<focusedlayout height="$PARAM[height]" width="$PARAM[width]">
@@ -1755,7 +1749,7 @@
 					<top>7</top>
 					<width>110</width>
 					<height>110</height>
-					<texture>$PARAM[thumbtexture]</texture>
+					<texture>$VAR[VideoListThumbVar]</texture>
 					<aspectratio>keep</aspectratio>
 				</control>
 				<control type="label">
@@ -1765,26 +1759,26 @@
 					<height>60</height>
 					<aligny>center</aligny>
 					<scroll>true</scroll>
-					<font>$PARAM[font_1]</font>
-					<label>$PARAM[label_1]</label>
+					<font>font14</font>
+					<label>$VAR[MediaInfoListLabelVar]</label>
 				</control>
 				<control type="label">
 					<left>135</left>
 					<top>50</top>
 					<right>20</right>
 					<height>35</height>
-					<font>$PARAM[font_2]</font>
+					<font>font12</font>
 					<aligny>center</aligny>
-					<label>$PARAM[label_2]</label>
+					<label>$INFO[ListItem.Duration,$LOCALIZE[180]: ]</label>
 				</control>
 				<control type="label">
 					<left>135</left>
 					<top>85</top>
 					<right>20</right>
 					<height>30</height>
-					<font>$PARAM[font_2]</font>
+					<font>font12</font>
 					<aligny>center</aligny>
-					<label>$PARAM[label_3]</label>
+					<label>$VAR[VideoCodecVar,, ]$INFO[ListItem.VideoResolution,| , ]$VAR[VideoResolutionTypeVar,, ]$VAR[VideoHDRVar,| , ]$INFO[ListItem.VideoAspect,| ,:1 ]$VAR[AudioCodecVar,| , ]$VAR[AudioChannelsVar]</label>
 				</control>
 			</focusedlayout>
 		</definition>

--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -750,9 +750,7 @@
 				<onright>61</onright>
 				<pagecontrol>61</pagecontrol>
 				<scrolltime>200</scrolltime>
-				<include content="MediaInfoListLayout">
-					<param name="label_1" value="$INFO[ListItem.VideoVersionName]" />
-				</include>
+				<include>MediaInfoListLayout</include>
 			</control>
 			<control type="scrollbar" id="61">
 				<left>1320</left>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -683,18 +683,20 @@
 		<value>[B]$LOCALIZE[1223][/B]</value>
 	</variable>
 	<variable name="VideoListPosterVar">
-		<value condition="!String.IsEmpty(container(6).listitem.art(poster))">$INFO[container(6).listitem.art(poster)]</value>
-		<value condition="!String.IsEmpty(container(6).listitem.art(thumb))">$INFO[container(6).listitem.art(thumb)]</value>
-		<value condition="!String.IsEmpty(container(50).listitem.art(poster))">$INFO[container(50).listitem.art(poster)]</value>
-		<value condition="!String.IsEmpty(container(50).listitem.art(thumb))">$INFO[container(50).listitem.art(thumb)]</value>
-		<value condition="String.IsEmpty(Listitem.Art(poster))">$INFO[Listitem.Art(poster)]</value>
-		<value>$INFO[ListItem.Icon]</value>			
+		<value condition="!String.IsEmpty(Container(6).ListItem.Art(poster))">$INFO[Container(6).ListItem.Art(poster)]</value>
+		<value condition="!String.IsEmpty(Container(6).ListItem.Art(thumb))">$INFO[Container(6).ListItem.Art(thumb)]</value>
+		<value condition="!String.IsEmpty(Container(50).ListItem.Art(poster))">$INFO[Container(50).ListItem.Art(poster)]</value>
+		<value condition="!String.IsEmpty(Container(50).ListItem.Art(thumb))">$INFO[Container(50).ListItem.Art(thumb)]</value>
+		<value condition="String.IsEmpty(Container(50).ListItem.Art(thumb))">DefaultMovies.png</value>
+		<value condition="!String.IsEmpty(Listitem.Art(poster))">$INFO[ListItem.Art(poster)]</value>
+		<value>$INFO[ListItem.Art(thumb)]</value>
 	</variable>
 	<variable name="VideoListThumbVar">
-		<value condition="!String.IsEmpty(Listitem.Art(landscape))">$INFO[Listitem.Art(landscape)]</value>
-		<value condition="!String.IsEmpty(Listitem.Art(fanart))">$INFO[Listitem.Art(fanart)]</value>
-		<value condition="!String.IsEmpty(Listitem.Art(thumb))">$INFO[Listitem.Art(thumb)]</value>
-		<value>$INFO[ListItem.Icon]</value>		
+		<value condition="!String.IsEmpty(Container(6).ListItem.Art(landscape))">$INFO[Container(6).ListItem.Art(landscape)]</value>
+		<value condition="!String.IsEmpty(Container(6).ListItem.Art(thumb))">$INFO[Container(6).ListItem.Art(thumb)]</value>
+		<value condition="!String.IsEmpty(Container(50).ListItem.Art(landscape))">$INFO[Container(50).ListItem.Art(landscape)]</value>
+		<value condition="!String.IsEmpty(Container(50).ListItem.Art(thumb))">$INFO[Container(50).ListItem.Art(thumb)]</value>
+		<value>$INFO[ListItem.Art(thumb)]</value>	
 	</variable>
 	<variable name="VideoResolutionTypeVar">
 		<value condition="String.IsEqual(ListItem.VideoResolution,480)">SD</value>
@@ -786,5 +788,9 @@
 		<value condition="String.IsEqual(ListItem.AudioChannels,8)">7.1</value>
 		<value condition="String.IsEqual(ListItem.AudioChannels,10)">9.1</value>
 		<value>$INFO[ListItem.AudioChannels]</value>
+	</variable>
+	<variable name="MediaInfoListLabelVar">
+		<value condition="Window.IsActive(selectvideoversion)">$INFO[ListItem.VideoVersionName]</value>
+		<value>$INFO[ListItem.Label]</value>
 	</variable>
 </includes>


### PR DESCRIPTION
## Description
After https://github.com/xbmc/xbmc/pull/24558 this restores the Estuary layout of Extras to align with that used for Versions.

This also addresses art and casing issues raised in https://github.com/xbmc/xbmc/issues/24588

## Motivation and context
Restore consistency of the Version and Extras dialogs.

I've also simplified the Include `MediaInfoListLayout` as it was probably over engineered in it's previous form for what we need. 

## How has this been tested?
Tested locally on Windows

## What is the effect on users?
Consistency of dialogs

## Screenshots (if appropriate):

**Choose Extras**

![image](https://github.com/xbmc/xbmc/assets/5781142/35818282-1e67-4428-a06f-2950483eebd0)

**Fix for art issue in Manage Extras**
When there are no Extras display the DefaultMovies icon.

![image](https://github.com/xbmc/xbmc/assets/5781142/b5177721-e8d1-4f82-b807-1bbdfe9d1a22)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
