### PR TITLE
[docs] Use gh markdown highlights of warnings, tips and notes

### DIFF
--- a/LICENSES/README.md
+++ b/LICENSES/README.md
@@ -43,7 +43,8 @@ Since most source files in Kodi are `GPL-2.0-or-later` licensed, the typical cop
  */
 ```
 
-**NOTE:** Kodi is developed and maintained by Kodi Team members and the open-source community. We thank all of our **[contributors](https://github.com/xbmc/xbmc/graphs/contributors)**! **For the detailed history of contributions** of a given file, use `git blame <filename>` to see line-by-line credits or `git log --follow <filename>` to see the changelog across renames, rewrites and code shuffle.
+> [!NOTE]  
+> Kodi is developed and maintained by Kodi Team members and the open-source community. We thank all of our **[contributors](https://github.com/xbmc/xbmc/graphs/contributors)**! **For the detailed history of contributions** of a given file, use `git blame <filename>` to see line-by-line credits or `git log --follow <filename>` to see the changelog across renames, rewrites and code shuffle.
 
 ### License Files
 All SPDX license identifiers must have a corresponding file in the **LICENSES** subdirectory. This is required to allow tool verification (e.g. **[ScanCode toolkit](https://github.com/nexB/scancode-toolkit)**) and to have the licenses ready to read and extract right from the source, which is recommended by various FOSS organizations, e.g. the **[FSFE REUSE Initiative](https://reuse.software/)**.

--- a/docs/CODE_GUIDELINES.md
+++ b/docs/CODE_GUIDELINES.md
@@ -595,7 +595,9 @@ Prefix global variables with `g_`
 ```cpp
 int g_globalVariableA;
 ```
-**WARNING:** Avoid use of globals as far as reasonably possible. We generally do not want to introduce new global variables.
+
+> [!WARNING]  
+> Avoid use of globals as far as reasonably possible. We generally do not want to introduce new global variables.
 
 **[back to top](#table-of-contents)**
 

--- a/docs/GIT-FU.md
+++ b/docs/GIT-FU.md
@@ -86,9 +86,14 @@ git clone -b Krypton https://github.com/xbmc/xbmc kodi
 
 Several different strategies are used to draw your attention to certain pieces of information. In order of how critical the information is, these items are marked as a note, tip, or warning. For example:
  
-**NOTE:** Linux is user friendly... It's just very particular about who its friends are.  
-**TIP:** Algorithm is what developers call code they do not want to explain.  
-**WARNING:** Developers don't change light bulbs. It's a hardware problem.
+> [!NOTE]  
+> Linux is user friendly... It's just very particular about who its friends are.
+
+> [!TIP]
+> Algorithm is what developers call code they do not want to explain.
+
+> [!WARNING]  
+> Developers don't change light bulbs. It's a hardware problem.
 
 **[back to top](#table-of-contents)** | **[back to section top](#2-document-conventions)**
 
@@ -121,7 +126,8 @@ cd kodi                                                  // change to the newly 
 git remote add upstream https://github.com/xbmc/xbmc.git // assign Kodi's main repo to a remote
 ```
 
-**TIP:** Windows users should use `cd %userprofile%` instead.
+> [!TIP]
+> Windows users should use `cd %userprofile%` instead.
 
 From this point forward, every command shown assumes you're inside `$HOME/kodi` or `%userprofile%\kodi` if you're a Windows user. To get there, issue:
 ```
@@ -197,7 +203,8 @@ Delete remote branch:
 git push origin -d <feature-branch>
 ```
 
-**WARNING:** Be careful deleting branches. Make sure you don't need them anymore.
+> [!WARNING]  
+> Be careful deleting branches. Make sure you don't need them anymore.
 
 ### 5.8. Rebase branch
 ```
@@ -236,7 +243,8 @@ git checkout <feature-branch> // switch to feature branch
 git push origin               // push updated feature branch to your personal remote repo
 ```
 
-**WARNING:** Be **very careful** updating to and from origin. It can cause loss of work, specially if you work on more than one machine. Make sure your remote origin repo **always** holds the most up-to-date version of your code. **No, seriously**. Make a mental rule: *remote origin repo always holds the most up-to-date version of my code!* and **stick to it!** It's almost always possible to recover lost work with `git` but it's hard and unnecessary work if you follow some simple rules.
+> [!WARNING]  
+> Be **very careful** updating to and from origin. It can cause loss of work, specially if you work on more than one machine. Make sure your remote origin repo **always** holds the most up-to-date version of your code. **No, seriously**. Make a mental rule: *remote origin repo always holds the most up-to-date version of my code!* and **stick to it!** It's almost always possible to recover lost work with `git` but it's hard and unnecessary work if you follow some simple rules.
 
 **[back to top](#table-of-contents)** | **[back to section top](#6-syncing-branches)**
 

--- a/docs/README.Android.md
+++ b/docs/README.Android.md
@@ -48,9 +48,14 @@ git clone -b Krypton https://github.com/xbmc/xbmc kodi
 
 Several different strategies are used to draw your attention to certain pieces of information. In order of how critical the information is, these items are marked as a note, tip, or warning. For example:
  
-**NOTE:** Linux is user friendly... It's just very particular about who its friends are.  
-**TIP:** Algorithm is what developers call code they do not want to explain.  
-**WARNING:** Developers don't change light bulbs. It's a hardware problem.
+> [!NOTE]  
+> Linux is user friendly... It's just very particular about who its friends are.
+
+> [!TIP]
+> Algorithm is what developers call code they do not want to explain.
+
+> [!WARNING]  
+> Developers don't change light bulbs. It's a hardware problem.
 
 **[back to top](#table-of-contents)** | **[back to section top](#1-document-conventions)**
 
@@ -59,9 +64,11 @@ Install build dependencies needed to cross-compile Kodi for Android:
 ```
 sudo apt install autoconf bison build-essential curl default-jdk flex gawk git gperf lib32stdc++6 lib32z1 lib32z1-dev libcurl4-openssl-dev unzip zip zlib1g-dev
 ```
-**NOTE:** If you're running a 32bit Debian/Ubuntu distribution,  remove `lib32stdc++6 lib32z1 lib32z1-dev` from the command.
-**NOTE:** Gradle 7.0.2+ requires Jave Runtime 11+. Check java version by running `java --version`.  If version is < 11, set JAVA_HOME to java 11+ home directory._
+> [!NOTE]  
+> If you're running a 32bit Debian/Ubuntu distribution,  remove `lib32stdc++6 lib32z1 lib32z1-dev` from the command.
 
+> [!NOTE]  
+> Gradle 7.0.2+ requires Jave Runtime 11+. Check java version by running `java --version`.  If version is < 11, set JAVA_HOME to java 11+ home directory._
 
 **[back to top](#table-of-contents)**
 
@@ -82,7 +89,8 @@ Extract Android SDK Command line tools:
 unzip $HOME/Downloads/commandlinetools-linux-6200805_latest.zip -d $HOME/android-tools/android-sdk-linux/
 ```
 
-**NOTE:** Since we're using the latest SDK Command line tools available, filename can change over time. Adapt the `unzip` command accordingly.
+> [!NOTE]  
+> Since we're using the latest SDK Command line tools available, filename can change over time. Adapt the `unzip` command accordingly.
 
 ### 3.2. Configure Android SDK
 Before Android SDK can be used, you need to accept the licenses and configure it:
@@ -122,7 +130,8 @@ cd $HOME/kodi/tools/depends
 ./bootstrap
 ```
 
-**TIP:** Look for comments starting with `Or ...` and only execute the command(s) you need.
+> [!TIP]
+> Look for comments starting with `Or ...` and only execute the command(s) you need.
 
 Configure build for aarch64:
 ```
@@ -144,16 +153,19 @@ Or configure build for x86_64:
 ./configure --with-tarballs=$HOME/android-tools/xbmc-tarballs --host=x86_64-linux-android --with-sdk-path=$HOME/android-tools/android-sdk-linux --with-ndk-path=$HOME/android-tools/android-sdk-linux/ndk/21.4.7075529 --prefix=$HOME/android-tools/xbmc-depends
 ```
 
-> **Note:** Android x86 and x86_64 are not maintained and are not 100% sure that everything works correctly!
+> [!NOTE]  
+> Android x86 and x86_64 are not maintained and are not 100% sure that everything works correctly!
 
 Build tools and dependencies:
 ```
 make -j$(getconf _NPROCESSORS_ONLN)
 ```
 
-**TIP:** By adding `-j<number>` to the make command, you can choose how many concurrent jobs will be used and expedite the build process. It is recommended to use `-j$(getconf _NPROCESSORS_ONLN)` to compile on all available processor cores. The build machine can also be configured to do this automatically by adding `export MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"` to your shell config (e.g. `~/.bashrc`).
+> [!TIP]
+> By adding `-j<number>` to the make command, you can choose how many concurrent jobs will be used and expedite the build process. It is recommended to use `-j$(getconf _NPROCESSORS_ONLN)` to compile on all available processor cores. The build machine can also be configured to do this automatically by adding `export MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"` to your shell config (e.g. `~/.bashrc`).
 
-**WARNING:** Look for the `Dependencies built successfully.` success message. If in doubt run a single threaded `make` command until the message appears. If the single make fails, clean the specific library by issuing `make -C target/<name_of_failed_lib> distclean` and run `make`again.
+> [!WARNING]  
+> Look for the `Dependencies built successfully.` success message. If in doubt run a single threaded `make` command until the message appears. If the single make fails, clean the specific library by issuing `make -C target/<name_of_failed_lib> distclean` and run `make`again.
 
 ### 5.1. Advanced Configure Options
 
@@ -280,7 +292,9 @@ cd $HOME/kodi
 make -C tools/depends/target/cmakebuildsys
 ```
 
-**TIP:** BUILD_DIR can be provided as an argument to cmakebuildsys. This allows you to provide an alternate build location. Change all paths onwards as required if BUILD_DIR option used.
+> [!TIP]
+> BUILD_DIR can be provided as an argument to cmakebuildsys. This allows you to provide an alternate build location. Change all paths onwards as required if BUILD_DIR option used.
+
 ```
 mkdir $HOME/kodi-build
 make -C tools/depends/target/cmakebuildsys BUILD_DIR=$HOME/kodi-build
@@ -358,7 +372,8 @@ Enable CheckJNI (**before** starting the Kodi):
 adb shell setprop debug.checkjni 1
 ```
 
-**NOTE:** These commands assume that current directory is `$HOME/kodi-build/tools/android/packaging` and that the proper SDK/NDK paths are set.
+> [!NOTE]  
+> These commands assume that current directory is `$HOME/kodi-build/tools/android/packaging` and that the proper SDK/NDK paths are set.
 
 GDB can be used to debug, though the support is rather primitive. Rather than using `gdb` directly, you will need to use `ndk-gdb` which wraps it. You can use the `-p/--project` switches or instead you will need to `cd` to `$HOME/kodi-build/tools/android/packaging/xbmc` and execute it from there.
 ```

--- a/docs/README.Fedora.md
+++ b/docs/README.Fedora.md
@@ -38,9 +38,14 @@ git clone -b Krypton https://github.com/xbmc/xbmc kodi
 
 Several different strategies are used to draw your attention to certain pieces of information. In order of how critical the information is, these items are marked as a note, tip, or warning. For example:
  
-**NOTE:** Linux is user friendly... It's just very particular about who its friends are.  
-**TIP:** Algorithm is what developers call code they do not want to explain.  
-**WARNING:** Developers don't change light bulbs. It's a hardware problem.
+> [!NOTE]  
+> Linux is user friendly... It's just very particular about who its friends are.
+
+> [!TIP]
+> Algorithm is what developers call code they do not want to explain.
+
+> [!WARNING]  
+> Developers don't change light bulbs. It's a hardware problem.
 
 **[back to top](#table-of-contents)** | **[back to section top](#1-document-conventions)**
 
@@ -61,14 +66,16 @@ git clone https://github.com/xbmc/xbmc kodi
 ## 3. Install the required packages
 If you get a `package not found` type of message with the below command, remove the offending package(s) from the install list and reissue the command. Take a note of the missing dependencies and, after a successful step completion, **[build the missing dependencies manually](README.Linux.md#31-build-missing-dependencies)**.
 
-**NOTE:** Kodi requires a compiler with C++17 support, i.e. gcc >= 7 or clang >= 5
+> [!NOTE]  
+> Kodi requires a compiler with C++17 support, i.e. gcc >= 7 or clang >= 5
 
 Install build dependencies:
 ```
 sudo dnf install alsa-lib-devel autoconf automake avahi-compat-libdns_sd-devel avahi-devel bluez-libs-devel bzip2-devel cmake curl dbus-devel flatbuffers flatbuffers-devel fmt-devel fontconfig-devel freetype-devel fribidi-devel fstrcmp-devel gawk gcc gcc-c++ gettext gettext-devel giflib-devel gperf gtest-devel java-11-openjdk-headless jre lcms2-devel libao-devel libass-devel libbluray-devel libcap-devel libcdio-devel libcec-devel libcurl-devel libidn2-devel libjpeg-turbo-devel libmicrohttpd-devel libmpc-devel libnfs-devel libplist-devel libpng12-devel libsmbclient-devel libtool libtool-ltdl-devel libudev-devel libunistring libunistring-devel libusb-devel libuuid-devel libva-devel libvdpau-devel libxkbcommon-devel libxml2-devel libXmu-devel libXrandr-devel libxslt-devel libXt-devel lirc-devel lzo-devel make mariadb-devel mesa-libEGL-devel mesa-libGL-devel mesa-libGLU-devel mesa-libGLw-devel mesa-libOSMesa-devel nasm openssl-devel openssl-libs patch pcre-devel pulseaudio-libs-devel python3-devel python3-pillow rapidjson-devel shairplay-devel spdlog-devel sqlite-devel swig taglib-devel tinyxml-devel tinyxml2-devel trousers-devel uuid-devel zlib-devel
 ```
 
-**WARNING:** Make sure you copy paste the entire line or you might receive an error or miss a few dependencies.
+> [!WARNING]  
+> Make sure you copy paste the entire line or you might receive an error or miss a few dependencies.
 
 Building for Wayland requires some extra packages:
 ```
@@ -85,14 +92,16 @@ Optional packages that you might want to install for extra functionality (genera
 sudo dnf install doxygen mariadb-devel
 ```
 
-**NOTE:** For developers and anyone else who builds frequently it is recommended to install `ccache` to expedite subsequent builds of Kodi.
+> [!NOTE]  
+> For developers and anyone else who builds frequently it is recommended to install `ccache` to expedite subsequent builds of Kodi.
 
 You can install it with:
 ```
 sudo dnf install ccache
 ```
 
-**TIP:** If you have multiple computers at home, `distcc` will distribute build workloads of C and C++ code across several machines on a network. Team Kodi may not be willing to give support if problems arise using such a build configuration.
+> [!TIP]
+> If you have multiple computers at home, `distcc` will distribute build workloads of C and C++ code across several machines on a network. Team Kodi may not be willing to give support if problems arise using such a build configuration.
 
 You can install it with:
 ```

--- a/docs/README.FreeBSD.md
+++ b/docs/README.FreeBSD.md
@@ -45,9 +45,14 @@ git clone -b Krypton https://github.com/xbmc/xbmc kodi
 
 Several different strategies are used to draw your attention to certain pieces of information. In order of how critical the information is, these items are marked as a note, tip, or warning. For example:
  
-**NOTE:** Linux is user friendly... It's just very particular about who its friends are.  
-**TIP:** Algorithm is what developers call code they do not want to explain.  
-**WARNING:** Developers don't change light bulbs. It's a hardware problem.
+> [!NOTE]  
+> Linux is user friendly... It's just very particular about who its friends are.
+
+> [!TIP]
+> Algorithm is what developers call code they do not want to explain.
+
+> [!WARNING]  
+> Developers don't change light bulbs. It's a hardware problem.
 
 **[back to top](#table-of-contents)** | **[back to section top](#1-document-conventions)**
 
@@ -72,23 +77,27 @@ git clone https://github.com/xbmc/xbmc kodi
 ## 3. Install the required packages
 If you get a `package not found` type of message with the below command, remove the offending package(s) from the install list and reissue the command. Take a note of the missing dependencies and, after a successful step completion, **[build the missing dependencies manually](#31-build-missing-dependencies)**.
 
-**NOTE:** Kodi requires a compiler with C++17 support, i.e. gcc >= 7 or clang >= 5
+> [!NOTE]  
+> Kodi requires a compiler with C++17 support, i.e. gcc >= 7 or clang >= 5
 
 Install build dependencies:
 ```
 sudo pkg install autoconf automake avahi-app binutils cmake curl dbus doxygen e2fsprogs-libuuid enca encodings flac flatbuffers font-util fontconfig freetype2 fribidi fstrcmp gawk gettext-tools giflib git glew gmake gmp gnutls googletest gperf gstreamer1-vaapi hal jpeg-turbo libaacs libass libbdplus libbluray libcapn libcdio libcec libedit libfmt libgcrypt libgpg-error libidn libinotify libmicrohttpd libnfs libogg libplist librtmp libtool libudev-devd libva libvdpau libvorbis libxslt lirc lzo2 m4 mesa-libs mysql57-client nasm openjdk8 p8-platform pkgconf python3 rapidjson shairplay sndio sqlite3 swig30 taglib tiff tinyxml tinyxml2 xf86-input-keyboard xf86-input-mouse xorg-server xrandr zip
 ```
 
-**WARNING:** Make sure you copy paste the entire line or you might receive an error or miss a few dependencies.
+> [!WARNING]  
+> Make sure you copy paste the entire line or you might receive an error or miss a few dependencies.
 
-**NOTE:** For developers and anyone else who builds frequently it is recommended to install `ccache` to expedite subsequent builds of Kodi.
+> [!NOTE]  
+> For developers and anyone else who builds frequently it is recommended to install `ccache` to expedite subsequent builds of Kodi.
 
 You can install it with:
 ```
 sudo pkg install ccache
 ```
 
-**TIP:** If you have multiple computers at home, `distcc` will distribute build workloads of C and C++ code across several machines on a network. Team Kodi may not be willing to give support if problems arise using such a build configuration.
+> [!TIP]
+> If you have multiple computers at home, `distcc` will distribute build workloads of C and C++ code across several machines on a network. Team Kodi may not be willing to give support if problems arise using such a build configuration.
 
 You can install it with:
 ```
@@ -123,7 +132,8 @@ cmake ../kodi -DCMAKE_INSTALL_PREFIX=/usr/local
 ```
 cmake --build . -- VERBOSE=1 -j$(sysctl hw.ncpu | awk '{print $2}')
 ```
-**TIP:** By adding `-j<number>` to the make command, you can choose how many concurrent jobs will be used and expedite the build process. It is recommended to use `-j$(sysctl hw.ncpu | awk '{print $2}')` to compile on all available processor cores.
+> [!TIP]
+> By adding `-j<number>` to the make command, you can choose how many concurrent jobs will be used and expedite the build process. It is recommended to use `-j$(sysctl hw.ncpu | awk '{print $2}')` to compile on all available processor cores.
 
 After the build process completes successfully you can test your shiny new Kodi build while in the build directory:
 ```
@@ -135,11 +145,14 @@ If everything was OK during your test you can now install the binaries to their 
 sudo gmake install
 ```
 
-**NOTE:** `gmake` stands for *GNU Make*. BSD's own make does not work here.
+> [!NOTE]  
+> `gmake` stands for *GNU Make*. BSD's own make does not work here.
 
 This will install Kodi in the prefix provided in **[section 4.1](#41-configure-build)**.
 
-**TIP:** To override Kodi's install location, use `DESTDIR=<path>`. For example:
+> [!TIP]
+> To override Kodi's install location, use `DESTDIR=<path>`. For example:
+
 ```
 sudo gmake install DESTDIR=$HOME/kodi
 ```
@@ -176,7 +189,8 @@ sudo gmake -C tools/depends/target/binary-addons clean
 
 For additional information on regular expression usage for ADDONS_TO_BUILD, view ADDONS_TO_BUILD section located at [Kodi add-ons CMake based buildsystem](../cmake/addons/README.md)
 
-**NOTE:** `PREFIX=/usr/local` should match Kodi's `-DCMAKE_INSTALL_PREFIX=` prefix used in **[section 4.1](#41-configure-build)**.
+> [!NOTE]  
+> `PREFIX=/usr/local` should match Kodi's `-DCMAKE_INSTALL_PREFIX=` prefix used in **[section 4.1](#41-configure-build)**.
 
 **[back to top](#table-of-contents)**
 
@@ -199,7 +213,8 @@ To run Kodi in *portable* mode (useful for testing):
 ```
 sudo gmake uninstall
 ```
-**WARNING:**: If you reran CMakes' configure step with a different `-DCMAKE_INSTALL_PREFIX=`, you will need to rerun configure with the correct path for this step to work correctly.
+> [!WARNING]  
+> If you reran CMakes' configure step with a different `-DCMAKE_INSTALL_PREFIX=`, you will need to rerun configure with the correct path for this step to work correctly.
 
 If you would like to also remove any settings and third-party addons (skins, scripts, etc.) and Kodi configuration files, you should also run:
 ```

--- a/docs/README.Linux.md
+++ b/docs/README.Linux.md
@@ -48,9 +48,14 @@ git clone -b Krypton https://github.com/xbmc/xbmc kodi
 
 Several different strategies are used to draw your attention to certain pieces of information. In order of how critical the information is, these items are marked as a note, tip, or warning. For example:
  
-**NOTE:** Linux is user friendly... It's just very particular about who its friends are.  
-**TIP:** Algorithm is what developers call code they do not want to explain.  
-**WARNING:** Developers don't change light bulbs. It's a hardware problem.
+> [!NOTE]  
+> Linux is user friendly... It's just very particular about who its friends are.
+
+> [!TIP]
+> Algorithm is what developers call code they do not want to explain.
+
+> [!WARNING]  
+> Developers don't change light bulbs. It's a hardware problem.
 
 **[back to top](#table-of-contents)** | **[back to section top](#1-document-conventions)**
 
@@ -72,7 +77,8 @@ git clone https://github.com/xbmc/xbmc kodi
 ## 3. Install the required packages
 The following is the list of packages that are used to build Kodi on Debian/Ubuntu (with all supported external libraries enabled).
 
-**NOTE:** Kodi requires a compiler with C++17 support, i.e. gcc >= 7 or clang >= 5
+> [!NOTE]  
+> Kodi requires a compiler with C++17 support, i.e. gcc >= 7 or clang >= 5
 
 * autoconf, automake, autopoint, gettext, autotools-dev, cmake, curl, default-jre | openjdk-6-jre | openjdk-7-jre, gawk, gcc (>= 7) | gcc-7, g++ (>= 7) | g++-7, cpp (>= 7) | cpp-7, flatbuffers, gdc, gperf, libasound2-dev | libasound-dev, libass-dev (>= 0.9.8), libavahi-client-dev, libavahi-common-dev, libbluetooth-dev, libbluray-dev, libbz2-dev, libcdio-dev, libcec4-dev | libcec-dev, libp8-platform-dev, libcrossguid-dev, libcurl4-openssl-dev | libcurl4-gnutls-dev | libcurl-dev, libcwiid-dev, libdbus-1-dev, libegl1-mesa-dev, libenca-dev, libflac-dev, libfontconfig-dev, libfmt3-dev | libfmt-dev, libfreetype6-dev, libfribidi-dev, libfstrcmp-dev, libgcrypt-dev, libgif-dev (>= 5.0.5), libgles2-mesa-dev [armel] | libgl1-mesa-dev | libgl-dev, libglew-dev, libglu1-mesa-dev | libglu-dev, libgnutls-dev | libgnutls28-dev, libgpg-error-dev, libgtest-dev, libiso9660-dev, libjpeg-dev, liblcms2-dev, liblirc-dev, libltdl-dev, liblzo2-dev, libmicrohttpd-dev, libmysqlclient-dev, libnfs-dev, libogg-dev, libomxil-bellagio-dev [armel], libpcre3-dev, libplist-dev, libpng12-dev | libpng-dev, libpulse-dev, libshairplay-dev, libsmbclient-dev, libspdlog-dev, libsqlite3-dev, libssl-dev, libtag1-dev (>= 1.8) | libtag1x8, libtiff5-dev | libtiff-dev | libtiff4-dev, libtinyxml-dev, libtinyxml2-dev, libtool, libudev-dev, libunistring-dev, libva-dev, libvdpau-dev, libvorbis-dev, libxkbcommon-dev, libxmu-dev, libxrandr-dev, libxslt1-dev | libxslt-dev, libxt-dev, waylandpp-dev | netcat, wayland-protocols | wipe, lsb-release, meson (>= 0.47.0), nasm (>= 2.14), ninja-build, python3-dev, python3-pil | python-imaging, python-support | python3-minimal, rapidjson-dev, swig, unzip, uuid-dev, zip, zlib1g-dev
 
@@ -114,15 +120,18 @@ Build and install waylandpp:
 sudo make -C tools/depends/target/waylandpp PREFIX=/usr/local
 ```
 
-**WARNING:** Building `waylandpp` has some dependencies of its own, namely `scons, libwayland-dev (>= 1.11.0) and libwayland-egl1-mesa`
+> [!WARNING]  
+> Building `waylandpp` has some dependencies of its own, namely `scons, libwayland-dev (>= 1.11.0) and libwayland-egl1-mesa`
 
-**TIP:** Complete list of dependencies is available **[here](https://github.com/xbmc/xbmc/tree/master/tools/depends/target)**.
+> [!TIP]
+> Complete list of dependencies is available **[here](https://github.com/xbmc/xbmc/tree/master/tools/depends/target)**.
 
 ### 3.2. Enable internal dependencies
 Some dependencies can be configured to build before Kodi. That's the case with `flatbuffers`, `crossguid`, `fmt`, `spdlog`, `rapidjson`, `fstrcmp` and `dav1d`. To enable the internal build of a dependency, append `-DENABLE_INTERNAL_<DEPENDENCY_NAME>=ON` to the configure command below. For example, configuring an X11 build with internal `fmt` would become `cmake ../kodi -DCMAKE_INSTALL_PREFIX=/usr/local -DENABLE_INTERNAL_FMT=ON` instead of `cmake ../kodi -DCMAKE_INSTALL_PREFIX=/usr/local`.
 Internal dependencies that are based on cmake upstream (currently crossguid, ffmpeg, fmt, spdlog) can have their build type overridden by defining `-D<DEPENDENCY_NAME>_BUILD_TYPE=<buildtype>`. Build Type can be one of `Release, RelWithDebInfo, Debug, MinSizeRel`. eg `-DFFMPEG_BUILD_TYPE=RelWithDebInfo`. If not provided, the build type will be the same as the core Kodi project.
 
-**Note:** fstrcmp requires libtool
+> [!NOTE]  
+> fstrcmp requires libtool
 
 ### 3.3. External Dependencies
 
@@ -139,7 +148,8 @@ Create an out-of-source build directory:
 mkdir $HOME/kodi-build
 ```
 
-**TIP:** Look for comments starting with `Or ...` and only execute the command(s) you need.
+> [!TIP]
+> Look for comments starting with `Or ...` and only execute the command(s) you need.
 
 Change to build directory:
 ```
@@ -151,31 +161,35 @@ Configure build for X11:
 cmake ../kodi -DCMAKE_INSTALL_PREFIX=/usr/local -DCORE_PLATFORM_NAME=x11 -DAPP_RENDER_SYSTEM=gl
 ```
 
-**NOTE:** You can use `gles` instead of `gl` if you want to build with `GLES`.
+> [!NOTE]  
+> You can use `gles` instead of `gl` if you want to build with `GLES`.
 
 Or configure build for Wayland:
 ```
 cmake ../kodi -DCMAKE_INSTALL_PREFIX=/usr/local -DCORE_PLATFORM_NAME=wayland -DAPP_RENDER_SYSTEM=gl
 ```
 
-**NOTE:** You can use `gles` instead of `gl` if you want to build with `GLES`.
+> [!NOTE]  
+> You can use `gles` instead of `gl` if you want to build with `GLES`.
 
 Or configure build for GBM:
 ```
 cmake ../kodi -DCMAKE_INSTALL_PREFIX=/usr/local -DCORE_PLATFORM_NAME=gbm -DAPP_RENDER_SYSTEM=gles
 ```
 
-**NOTE:** You can use `gl` instead of `gles` if you want to build with `GL`.
+> [!NOTE]  
+> You can use `gl` instead of `gles` if you want to build with `GL`.
 
 Or configure build with any combination of the three (default is "x11 wayland gbm"):
 ```
 cmake ../kodi -DCMAKE_INSTALL_PREFIX=/usr/local -DCORE_PLATFORM_NAME="x11 wayland gbm" -DAPP_RENDER_SYSTEM=gl
 ```
 
-**NOTE:** You can use `gles` instead of `gl` if you want to build with `GLES`.
+> [!NOTE]  
+> You can use `gles` instead of `gl` if you want to build with `GLES`.
 
-
-**NOTE:** You can use several alternative linkers if available on your system: gnu gold (default), llvm lld or mold
+> [!NOTE]  
+> You can use several alternative linkers if available on your system: gnu gold (default), llvm lld or mold
 
 To use an alternative linker, enable it with `-DENABLE_GOLD=ON` or `-DENABLE_LLD=ON` or `-DENABLE_MOLD=ON`
 
@@ -184,7 +198,9 @@ To use an alternative linker, enable it with `-DENABLE_GOLD=ON` or `-DENABLE_LLD
 ```
 cmake --build . -- VERBOSE=1 -j$(getconf _NPROCESSORS_ONLN)
 ```
-**TIP:** By adding `-j<number>` to the make command, you can choose how many concurrent jobs will be used and expedite the build process. It is recommended to use `-j$(getconf _NPROCESSORS_ONLN)` to compile on all available processor cores. The build machine can also be configured to do this automatically by adding `export MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"` to your shell config (e.g. `~/.bashrc`).
+
+> [!TIP]
+> By adding `-j<number>` to the make command, you can choose how many concurrent jobs will be used and expedite the build process. It is recommended to use `-j$(getconf _NPROCESSORS_ONLN)` to compile on all available processor cores. The build machine can also be configured to do this automatically by adding `export MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"` to your shell config (e.g. `~/.bashrc`).
 
 After the build process completes successfully you can test your shiny new Kodi build while in the build directory:
 ```
@@ -201,7 +217,8 @@ Or if you built for GBM:
 ./kodi-gbm
 ```
 
-**WARNING:** User running `kodi-gbm` needs to be part of `input` and `video` groups. Otherwise you'll have to use `sudo`.
+> [!WARNING]  
+> User running `kodi-gbm` needs to be part of `input` and `video` groups. Otherwise you'll have to use `sudo`.
 
 Add user to input and video groups:
 ```
@@ -220,7 +237,9 @@ sudo make install
 
 This will install Kodi in the prefix provided in **[section 4.1](#41-configure-build)**.
 
-**TIP:** To override Kodi's install location, use `DESTDIR=<path>`. For example:
+> [!TIP]
+> To override Kodi's install location, use `DESTDIR=<path>`. For example:
+
 ```
 sudo make install DESTDIR=$HOME/kodi
 ```
@@ -264,7 +283,8 @@ sudo make -C tools/depends/target/binary-addons clean
 
 For additional information on regular expression usage for ADDONS_TO_BUILD, view ADDONS_TO_BUILD section located here [Kodi add-ons CMake based buildsystem](../cmake/addons/README.md)
 
-**NOTE:** `PREFIX=/usr/local` should match Kodi's `-DCMAKE_INSTALL_PREFIX=` prefix used in **[section 4.1](#41-configure-build)**.
+> [!NOTE]  
+> `PREFIX=/usr/local` should match Kodi's `-DCMAKE_INSTALL_PREFIX=` prefix used in **[section 4.1](#41-configure-build)**.
 
 **[back to top](#table-of-contents)**
 
@@ -314,7 +334,8 @@ cmake -DCMAKE_INSTALL_PREFIX=/usr/local
 make && make install
 ```
 
-**NOTE:** `-DCMAKE_INSTALL_PREFIX=` should match Kodi's `-DCMAKE_INSTALL_PREFIX=` prefix used in **[section 4.1](#41-configure-build)**.
+> [!NOTE]  
+> `-DCMAKE_INSTALL_PREFIX=` should match Kodi's `-DCMAKE_INSTALL_PREFIX=` prefix used in **[section 4.1](#41-configure-build)**.
 
 ## 6. Run Kodi
 If you chose to install Kodi using `/usr` or `/usr/local` as the `-DCMAKE_INSTALL_PREFIX=`, you can just issue *kodi* in a terminal session.
@@ -335,7 +356,9 @@ To run Kodi in *portable* mode (useful for testing):
 ```
 sudo make uninstall
 ```
-**WARNING:**: If you reran CMakes' configure step with a different `-DCMAKE_INSTALL_PREFIX=`, you will need to rerun configure with the correct path for this step to work correctly.
+
+> [!WARNING]  
+> If you reran CMakes' configure step with a different `-DCMAKE_INSTALL_PREFIX=`, you will need to rerun configure with the correct path for this step to work correctly.
 
 If you would like to also remove any settings and third-party addons (skins, scripts, etc.) and Kodi configuration files, you should also run:
 ```

--- a/docs/README.Ubuntu.md
+++ b/docs/README.Ubuntu.md
@@ -41,9 +41,14 @@ git clone -b Krypton https://github.com/xbmc/xbmc kodi
 
 Several different strategies are used to draw your attention to certain pieces of information. In order of how critical the information is, these items are marked as a note, tip, or warning. For example:
  
-**NOTE:** Linux is user friendly... It's just very particular about who its friends are.  
-**TIP:** Algorithm is what developers call code they do not want to explain.  
-**WARNING:** Developers don't change light bulbs. It's a hardware problem.
+> [!NOTE]  
+> Linux is user friendly... It's just very particular about who its friends are.
+
+> [!TIP]
+> Algorithm is what developers call code they do not want to explain.
+
+> [!WARNING]  
+> Developers don't change light bulbs. It's a hardware problem.
 
 **[back to top](#table-of-contents)** | **[back to section top](#1-document-conventions)**
 
@@ -68,7 +73,8 @@ git clone https://github.com/xbmc/xbmc kodi
 ## 3. Install the required packages
 You can install the required packages using one of two methods: automagically or manually. Please use the former whenever possible.
 
-**WARNING:** Oldest supported Ubuntu version is 16.04 (Xenial). It is possible to build on older Ubuntu releases but due to outdated packages it will require considerable fiddling. Sorry, you're on your own if you decide to go down that particular rabbit hole.
+> [!WARNING]  
+> Oldest supported Ubuntu version is 16.04 (Xenial). It is possible to build on older Ubuntu releases but due to outdated packages it will require considerable fiddling. Sorry, you're on your own if you decide to go down that particular rabbit hole.
 
 ### 3.1. Get build dependencies automagically
 Add Kodi's *nightly* PPA to grab dependencies:
@@ -87,7 +93,8 @@ Super-duper magic command to get the build dependencies:
 sudo apt build-dep kodi
 ```
 
-**WARNING:** Do not use `aptitude` for the `build-dep` command. It doesn't resolve everything properly.
+> [!WARNING]  
+> Do not use `aptitude` for the `build-dep` command. It doesn't resolve everything properly.
 
 If at a later point you decide you do not want Kodi's PPAs on your system, removing them is as easy as:
 ```
@@ -95,14 +102,16 @@ sudo add-apt-repository -r ppa:team-xbmc/xbmc-nightly
 sudo add-apt-repository -r ppa:team-xbmc/xbmc-ppa-build-depends
 ```
 
-**NOTE:** For developers and anyone else who builds frequently it is recommended to install `ccache` to expedite subsequent builds of Kodi.
+> [!NOTE]  
+> For developers and anyone else who builds frequently it is recommended to install `ccache` to expedite subsequent builds of Kodi.
 
 You can install it with:
 ```
 sudo apt install ccache
 ```
 
-**TIP:** If you have multiple computers at home, `distcc` will distribute build workloads of C and C++ code across several machines on a network. Team Kodi may not be willing to give support if problems arise using such a build configuration.
+> [!TIP]
+> If you have multiple computers at home, `distcc` will distribute build workloads of C and C++ code across several machines on a network. Team Kodi may not be willing to give support if problems arise using such a build configuration.
 
 You can install it with:
 ```
@@ -112,14 +121,16 @@ sudo apt install distcc
 ### 3.2. Get build dependencies manually
 If you get a `package not found` type of message with the below command, remove the offending package(s) from the install list and reissue the command. Take a note of the missing dependencies and, after a successful step completion, **[build the missing dependencies manually](README.Linux.md#31-build-missing-dependencies)**.
 
-**NOTE:** Kodi requires a compiler with C++17 support, i.e. gcc >= 7 or clang >= 5
+> [!NOTE]  
+> Kodi requires a compiler with C++17 support, i.e. gcc >= 7 or clang >= 5
 
 Install build dependencies manually:
 ```
 sudo apt install debhelper autoconf automake autopoint gettext autotools-dev cmake curl default-jre doxygen gawk gcc gdc gperf libasound2-dev libass-dev libavahi-client-dev libavahi-common-dev libbluetooth-dev libbluray-dev libbz2-dev libcdio-dev libp8-platform-dev libcrossguid-dev libcurl4-openssl-dev libcwiid-dev libdbus-1-dev libdrm-dev libegl1-mesa-dev libenca-dev libflac-dev libfmt-dev libfontconfig-dev libfreetype6-dev libfribidi-dev libfstrcmp-dev libgcrypt-dev libgif-dev libgles2-mesa-dev libgl1-mesa-dev libglu1-mesa-dev libgnutls28-dev libgpg-error-dev libgtest-dev libiso9660-dev libjpeg-dev liblcms2-dev libltdl-dev liblzo2-dev libmicrohttpd-dev libmysqlclient-dev libnfs-dev libogg-dev libpcre3-dev libplist-dev libpng-dev libpulse-dev libshairplay-dev libsmbclient-dev libspdlog-dev libsqlite3-dev libssl-dev libtag1-dev libtiff5-dev libtinyxml-dev libtinyxml2-dev libtool libudev-dev libunistring-dev libva-dev libvdpau-dev libvorbis-dev libxmu-dev libxrandr-dev libxslt1-dev libxt-dev lsb-release meson nasm ninja-build python3-dev python3-pil python3-pip rapidjson-dev swig unzip uuid-dev zip zlib1g-dev
 ```
 
-**WARNING:** Make sure you copy paste the entire line or you might receive an error or miss a few dependencies.
+> [!WARNING]  
+> Make sure you copy paste the entire line or you might receive an error or miss a few dependencies.
 
 If you're using Ubuntu 16.04, you also need to install:
 ```

--- a/docs/README.Windows.md
+++ b/docs/README.Windows.md
@@ -38,9 +38,14 @@ git clone -b Matrix https://github.com/xbmc/xbmc kodi
 
 Several different strategies are used to draw your attention to certain pieces of information. In order of how critical the information is, these items are marked as a note, tip, or warning. For example:
 
-**NOTE:** Linux is user friendly... It's just very particular about who its friends are.  
-**TIP:** Algorithm is what developers call code they do not want to explain.  
-**WARNING:** Developers don't change light bulbs. It's a hardware problem.
+> [!NOTE]  
+> Linux is user friendly... It's just very particular about who its friends are.
+
+> [!TIP]
+> Algorithm is what developers call code they do not want to explain.
+
+> [!WARNING]  
+> Developers don't change light bulbs. It's a hardware problem.
 
 **[back to top](#table-of-contents)** | **[back to section top](#1-document-conventions)**
 
@@ -104,11 +109,13 @@ git clone https://github.com/xbmc/xbmc kodi
 ## 4. Set up the build environment
 To set up the build environment, several scripts must be called.
 
-**WARNING:** The scripts may fail if you have a space in the path to the bat files.
+> [!WARNING]  
+> The scripts may fail if you have a space in the path to the bat files.
 
 Kodi can be built as either a normal 32bit or 64bit program, UWP 32bit and 64bit and UWP ARM 32bit. Unless there is a reason to prefer 32bit builds, we advise you to build Kodi for 64bit.
 
-**TIP:** Look for comments starting with `Or ...` and only execute the command(s) you need.
+> [!TIP]
+> Look for comments starting with `Or ...` and only execute the command(s) you need.
 
 Change to the 64bit build directory (**recommended**):
 ```
@@ -139,7 +146,9 @@ Download dependencies:
 ```
 download-dependencies.bat
 ```
-**TIP:** Look for the `All formed packages ready!` success message. If you see the message `ERROR: Not all formed packages are ready!`, execute the command again until you see the success message.
+
+> [!TIP]
+> Look for the `All formed packages ready!` success message. If you see the message `ERROR: Not all formed packages are ready!`, execute the command again until you see the success message.
 
 Download and setup the build environment for libraries:
 ```
@@ -165,7 +174,8 @@ BuildSetup.bat
 
 UWP builds generate `msix`, `appxsym` and `cer` files, located at `%userprofile%\kodi\project\UWPBuildSetup`. You can install them following this **[guide](https://kodi.wiki/view/HOW-TO:Install_Kodi_for_Universal_Windows_Platform)**.
 
-**NOTE:** To generate an exact replica of the official Kodi Windows installer, some additional steps are required:
+> [!NOTE]  
+> To generate an exact replica of the official Kodi Windows installer, some additional steps are required:
 
 Build built-in add-ons (peripheral.joystick only) with command line:
 ```

--- a/docs/README.iOS.md
+++ b/docs/README.iOS.md
@@ -46,9 +46,14 @@ git clone -b Krypton https://github.com/xbmc/xbmc kodi
 
 Several different strategies are used to draw your attention to certain pieces of information. In order of how critical the information is, these items are marked as a note, tip, or warning. For example:
  
-**NOTE:** Linux is user friendly... It's just very particular about who its friends are.  
-**TIP:** Algorithm is what developers call code they do not want to explain.  
-**WARNING:** Developers don't change light bulbs. It's a hardware problem.
+> [!NOTE]  
+> Linux is user friendly... It's just very particular about who its friends are.
+
+> [!TIP]
+> Algorithm is what developers call code they do not want to explain.
+
+> [!WARNING]  
+> Developers don't change light bulbs. It's a hardware problem.
 
 **[back to top](#table-of-contents)** | **[back to section top](#1-document-conventions)**
 
@@ -62,7 +67,8 @@ Building for iOS should work with the following constellations of Xcode and macO
   * Xcode 13.x against iOS SDK 15.5 on 12.x (Monterey)(recommended)
 
 Team Kodi CI infrastructure is limited, and therefore we only have the single combination tested. Newer xcode/macos combinations generally should work, however the team does not actively test/use pre-release versions, so use with caution. Earlier versions may work, however we dont actively support them, so use with caution.
-**WARNING:** Start Xcode after installation finishes. You need to accept the licenses and install missing components.
+> [!WARNING]  
+> Start Xcode after installation finishes. You need to accept the licenses and install missing components.
 
 **[back to top](#table-of-contents)**
 
@@ -82,8 +88,11 @@ git clone https://github.com/xbmc/xbmc kodi
 ## 4. Configure and build tools and dependencies
 Kodi can be built as a 64bit program for iOS. The dependencies are built in `$HOME/kodi/tools/depends` and installed into `/Users/Shared/xbmc-depends`.
 
-**TIP:** Look for comments starting with `Or ...` and only execute the command(s) you need.
-**NOTE:** `--with-platform` is mandatory for all Apple platforms
+> [!TIP]
+> Look for comments starting with `Or ...` and only execute the command(s) you need.
+
+> [!NOTE]  
+> `--with-platform` is mandatory for all Apple platforms
 
 Configure build:
 ```
@@ -97,11 +106,15 @@ Build tools and dependencies:
 make -j$(getconf _NPROCESSORS_ONLN)
 ```
 
-**TIP:** By adding `-j<number>` to the make command, you can choose how many concurrent jobs will be used and expedite the build process. It is recommended to use `-j$(getconf _NPROCESSORS_ONLN)` to compile on all available processor cores. The build machine can also be configured to do this automatically by adding `export MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"` to your shell config (e.g. `~/.bashrc`).
+> [!TIP]
+> By adding `-j<number>` to the make command, you can choose how many concurrent jobs will be used and expedite the build process. It is recommended to use `-j$(getconf _NPROCESSORS_ONLN)` to compile on all available processor cores. The build machine can also be configured to do this automatically by adding `export MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"` to your shell config (e.g. `~/.bashrc`).
 
-**WARNING:** Look for the `Dependencies built successfully.` success message. If in doubt run a single threaded `make` command until the message appears. If the single make fails, clean the specific library by issuing `make -C target/<name_of_failed_lib> distclean` and run `make`again.
+> [!WARNING]  
+> Look for the `Dependencies built successfully.` success message. If in doubt run a single threaded `make` command until the message appears. If the single make fails, clean the specific library by issuing `make -C target/<name_of_failed_lib> distclean` and run `make`again.
 
-**NOTE:** **Advanced developers** may want to specify an iOS SDK version (if multiple versions are installed) in the configure line(s) shown above. The example below would use the iOS SDK 11.0:
+> [!NOTE]  
+> **Advanced developers** may want to specify an iOS SDK version (if multiple versions are installed) in the configure line(s) shown above. The example below would use the iOS SDK 11.0:
+
 ```
 ./configure --host=aarch64-apple-darwin --with-platform=ios --with-sdk=11.0
 ```
@@ -231,13 +244,17 @@ Generate Xcode project to build all add-ons automatically:
 make -C tools/depends/target/cmakebuildsys CMAKE_EXTRA_ARGUMENTS="-DENABLE_XCODE_ADDONBUILD=ON"
 ```
 
-**TIP:** If you wish to not automatically build addons added to your xcode project, omit
+> [!TIP]
+> If you wish to not automatically build addons added to your xcode project, omit
 `-DENABLE_XCODE_ADDONBUILD=ON`. The target will be added to the project, but the dependency
  will not be set to automatically build  
-**TIP:** Binary add-ons added to the generated Xcode project can be built independently of 
+
+> [!TIP]
+> Binary add-ons added to the generated Xcode project can be built independently of 
 the Kodi app by selecting the scheme/target `binary-addons` in the Xcode project.
 You can also build the binary-addons target via xcodebuild. This will not build the Kodi
 App, but will build any/all binary addons added for the project Generation.
+
 ```sh
 xcodebuild -config "Debug" -target binary-addons
 ```
@@ -259,7 +276,8 @@ Generate Xcode project as per configure command in **[Configure and build tools 
 make -C tools/depends/target/cmakebuildsys BUILD_DIR=$HOME/kodi-build
 ```
 
-**TIP:** BUILD_DIR can be omitted, and project will be created in $HOME/kodi/build
+> [!TIP]
+> BUILD_DIR can be omitted, and project will be created in $HOME/kodi/build
 Change all relevant paths onwards if omitted.
 
 Additional cmake arguments can be supplied via the CMAKE_EXTRA_ARGUMENTS command line variable
@@ -272,7 +290,8 @@ cd $HOME/kodi-build
 /Users/Shared/xbmc-depends/x86_64-darwin17.5.0-native/bin/cmake -G Xcode -DCMAKE_TOOLCHAIN_FILE=/Users/Shared/xbmc-depends/iphoneos11.3_arm64-target-debug/share/Toolchain.cmake $HOME/kodi
 ```
 
-**WARNING:** The toolchain file location differs depending on your iOS and SDK version. You have to replace `x86_64-darwin15.6.0-native` and `iphoneos11.3_arm64-target-debug` in the paths above with the correct ones on your system.
+> [!WARNING]  
+> The toolchain file location differs depending on your iOS and SDK version. You have to replace `x86_64-darwin15.6.0-native` and `iphoneos11.3_arm64-target-debug` in the paths above with the correct ones on your system.
 
 You can check `Users/Shared/xbmc-depends` directory content with:
 ```
@@ -282,7 +301,8 @@ ls -l /Users/Shared/xbmc-depends
 
 **Start Xcode, open the Kodi project file** (`kodi.xcodeproj`) located in `$HOME/kodi-build` and hit `Build`.
 
-**WARNING:** If you have selected a specific iOS SDK Version in step 4 then you might need to adapt the active target to use the same iOS SDK version, otherwise build will fail. Be sure to select a device configuration. Building for simulator is not supported.
+> [!WARNING]  
+> If you have selected a specific iOS SDK Version in step 4 then you might need to adapt the active target to use the same iOS SDK version, otherwise build will fail. Be sure to select a device configuration. Building for simulator is not supported.
 
 **Alternatively**, you can also build via Xcode from the command-line with `xcodebuild`:
 
@@ -292,7 +312,8 @@ cd $HOME/kodi-build
 xcodebuild -config "Debug" -jobs $(getconf _NPROCESSORS_ONLN)
 ```
 
-**TIP:** You can specify Release instead of Debug as -config parameter.
+> [!TIP]
+> You can specify Release instead of Debug as -config parameter.
 
 **[back to top](#table-of-contents)** | **[back to section top](#6-build-kodi)**
 

--- a/docs/README.macOS.md
+++ b/docs/README.macOS.md
@@ -47,9 +47,14 @@ git clone -b Krypton https://github.com/xbmc/xbmc kodi
 
 Several different strategies are used to draw your attention to certain pieces of information. In order of how critical the information is, these items are marked as a note, tip, or warning. For example:
  
-**NOTE:** Linux is user friendly... It's just very particular about who its friends are.  
-**TIP:** Algorithm is what developers call code they do not want to explain.  
-**WARNING:** Developers don't change light bulbs. It's a hardware problem.
+> [!NOTE]  
+> Linux is user friendly... It's just very particular about who its friends are.
+
+> [!TIP]
+> Algorithm is what developers call code they do not want to explain.
+
+> [!WARNING]  
+> Developers don't change light bulbs. It's a hardware problem.
 
 **[back to top](#table-of-contents)** | **[back to section top](#1-document-conventions)**
 
@@ -63,7 +68,8 @@ Building for OSX/macOS should work with the following constellations of Xcode an
   * Xcode 13.x against MacOSX SDK 12.3 on 12.x (Monterey)(recommended)
 
 Team Kodi CI infrastructure is limited, and therefore we only have the single combination tested. Newer xcode/macos combinations generally should work, however the team does not actively test/use pre-release versions, so use with caution. Earlier versions may work, however we dont actively support them, so use with caution.
-**WARNING:** Start Xcode after installation finishes. You need to accept the licenses and install missing components.
+> [!WARNING]  
+> Start Xcode after installation finishes. You need to accept the licenses and install missing components.
 
 **[back to top](#table-of-contents)**
 
@@ -83,8 +89,11 @@ git clone https://github.com/xbmc/xbmc kodi
 ## 4. Configure and build tools and dependencies
 Kodi can be built as either a 32bit or 64bit program. The dependencies are built in `$HOME/kodi/tools/depends` and installed into `/Users/Shared/xbmc-depends`.
 
-**TIP:** Look for comments starting with `Or ...` and only execute the command(s) you need.
-**NOTE:** `--with-platform` is mandatory for all Apple platforms
+> [!TIP]
+> Look for comments starting with `Or ...` and only execute the command(s) you need.
+
+> [!NOTE]  
+> `--with-platform` is mandatory for all Apple platforms
 
 Configure build (x86 intel):
 ```
@@ -105,11 +114,15 @@ Build tools and dependencies:
 make -j$(getconf _NPROCESSORS_ONLN)
 ```
 
-**TIP:** By adding `-j<number>` to the make command, you can choose how many concurrent jobs will be used and expedite the build process. It is recommended to use `-j$(getconf _NPROCESSORS_ONLN)` to compile on all available processor cores. The build machine can also be configured to do this automatically by adding `export MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"` to your shell config (e.g. `~/.bashrc`).
+> [!TIP]
+> By adding `-j<number>` to the make command, you can choose how many concurrent jobs will be used and expedite the build process. It is recommended to use `-j$(getconf _NPROCESSORS_ONLN)` to compile on all available processor cores. The build machine can also be configured to do this automatically by adding `export MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"` to your shell config (e.g. `~/.bashrc`).
 
-**WARNING:** Look for the `Dependencies built successfully.` success message. If in doubt run a single threaded `make` command until the message appears. If the single make fails, clean the specific library by issuing `make -C target/<name_of_failed_lib> distclean` and run `make`again.
+> [!WARNING]  
+> Look for the `Dependencies built successfully.` success message. If in doubt run a single threaded `make` command until the message appears. If the single make fails, clean the specific library by issuing `make -C target/<name_of_failed_lib> distclean` and run `make`again.
 
-**NOTE:** **Advanced developers** may want to specify an SDK version (if multiple versions are installed) in the configure line(s) shown above. The example below would use SDK 10.14:
+> [!NOTE]  
+> **Advanced developers** may want to specify an SDK version (if multiple versions are installed) in the configure line(s) shown above. The example below would use SDK 10.14:
+
 ```
 ./configure --host=x86_64-apple-darwin --with-platform=macos --with-sdk=10.14
 ```
@@ -231,7 +244,8 @@ Generate Xcode project as per configure command in **[Configure and build tools 
 make -C tools/depends/target/cmakebuildsys BUILD_DIR=$HOME/kodi-build GEN=Xcode
 ```
 
-**TIP:** BUILD_DIR can be omitted, and project will be created in $HOME/kodi/build
+> [!TIP]
+> BUILD_DIR can be omitted, and project will be created in $HOME/kodi/build
 Change all relevant paths onwards if omitted.
 
 Additional cmake arguments can be supplied via the CMAKE_EXTRA_ARGUMENTS command line variable
@@ -248,7 +262,8 @@ Generate Xcode project (x86_64 intel):
 /Users/Shared/xbmc-depends/x86_64-darwin17.5.0-native/bin/cmake -G Xcode -DCMAKE_TOOLCHAIN_FILE=/Users/Shared/xbmc-depends/macosx10.14_x86_64-target-debug/share/Toolchain.cmake ../kodi
 ```
 
-**WARNING:** The toolchain file location differs depending on SDK version. You have to replace `x86_64-darwin17.5.0-native` and `macosx10.14_x86_64-target-debug` in the paths above with the correct ones on your system.
+> [!WARNING]  
+> The toolchain file location differs depending on SDK version. You have to replace `x86_64-darwin17.5.0-native` and `macosx10.14_x86_64-target-debug` in the paths above with the correct ones on your system.
 
 You can check `Users/Shared/xbmc-depends` directory content with:
 ```
@@ -257,7 +272,8 @@ ls -l /Users/Shared/xbmc-depends
 
 **Start Xcode, open the Kodi project file** (`kodi.xcodeproj`) located in `$HOME/kodi-build` and hit `Build`.
 
-**WARNING:** If you have selected a specific SDK version in **[step 4](#4-configure-and-build-tools-and-dependencies)** then you might need to adapt the active target to use the same SDK version, otherwise build will fail. Be sure to select a device configuration. Building for simulator is **not** supported.
+> [!WARNING]  
+> If you have selected a specific SDK version in **[step 4](#4-configure-and-build-tools-and-dependencies)** then you might need to adapt the active target to use the same SDK version, otherwise build will fail. Be sure to select a device configuration. Building for simulator is **not** supported.
 
 ### 6.2. Build with xcodebuild
 Alternatively, you can also build via Xcode from the command-line with `xcodebuild`, triggered by CMake:
@@ -268,7 +284,8 @@ cd $HOME/kodi-build
 xcodebuild -config "Debug" -jobs $(getconf _NPROCESSORS_ONLN)
 ```
 
-**TIP:** You can specify Release instead of Debug as -config parameter.
+> [!TIP]
+> You can specify Release instead of Debug as -config parameter.
 
 **Alternatively**
 
@@ -277,7 +294,8 @@ Build Kodi:
 /Users/Shared/xbmc-depends/x86_64-darwin17.5.0-native/bin/cmake --build . --config "Debug" -- -verbose -jobs $(getconf _NPROCESSORS_ONLN)
 ```
 
-**TIP:** You can specify `Release` instead of `Debug` as `--config` parameter.
+> [!TIP]
+> You can specify `Release` instead of `Debug` as `--config` parameter.
 
 ### 6.3. Build with make
 CMake is also able to generate makefiles that can be used to build with make.
@@ -292,7 +310,8 @@ Generate makefiles:
 make -C tools/depends/target/cmakebuildsys
 ```
 
-**TIP:** BUILD_DIR can be provided as an argument to cmakebuildsys. This allows you to provide an alternate build location. Change all paths onwards as required if BUILD_DIR option used.
+> [!TIP]
+> BUILD_DIR can be provided as an argument to cmakebuildsys. This allows you to provide an alternate build location. Change all paths onwards as required if BUILD_DIR option used.
 ```
 mkdir $HOME/kodi-build
 make -C tools/depends/target/cmakebuildsys BUILD_DIR=$HOME/kodi-build

--- a/docs/README.openSUSE.md
+++ b/docs/README.openSUSE.md
@@ -41,9 +41,14 @@ git clone -b Krypton https://github.com/xbmc/xbmc kodi
 
 Several different strategies are used to draw your attention to certain pieces of information. In order of how critical the information is, these items are marked as a note, tip, or warning. For example:
  
-**NOTE:** Linux is user friendly... It's just very particular about who its friends are.  
-**TIP:** Algorithm is what developers call code they do not want to explain.  
-**WARNING:** Developers don't change light bulbs. It's a hardware problem.
+> [!NOTE]  
+> Linux is user friendly... It's just very particular about who its friends are.
+
+> [!TIP]
+> Algorithm is what developers call code they do not want to explain.
+
+> [!WARNING]  
+> Developers don't change light bulbs. It's a hardware problem.
 
 **[back to top](#table-of-contents)** | **[back to section top](#1-document-conventions)**
 
@@ -68,18 +73,21 @@ sudo zypper ar -f http://ftp.gwdg.de/pub/opensuse/repositories/multimedia:/libs/
 sudo zypper ref
 ```
 
-**NOTE:** A message will ask you to accept the key. Enter `a`, the *trust always* option.
+> [!NOTE]  
+> A message will ask you to accept the key. Enter `a`, the *trust always* option.
 
 If you get a `package not found` type of message with the below command, remove the offending package(s) from the install list and reissue the command. Take a note of the missing dependencies and, after a successful step completion, **[build the missing dependencies manually](#31-build-missing-dependencies)**.
 
-**NOTE:** Kodi requires a compiler with C++17 support, i.e. gcc >= 7 or clang >= 5
+> [!NOTE]  
+> Kodi requires a compiler with C++17 support, i.e. gcc >= 7 or clang >= 5
 
 Install build dependencies:
 ```
 sudo zypper install alsa-devel autoconf automake bluez-devel boost-devel capi4linux-devel ccache cmake doxygen flac-devel fribidi-devel fstrcmp-devel gcc gcc-c++ gettext-devel giflib-devel glew-devel googletest gperf java-openjdk libass-devel libavahi-devel libbluray-devel libbz2-devel libcap-devel libcap-ng-devel libcdio-devel libcec-devel libcurl-devel libdvdread-devel libgudev-1_0-devel libidn2-devel libjasper-devel libjpeg-devel liblcms2-devel libmad-devel libmicrohttpd-devel libmodplug-devel libmpeg2-devel libmysqlclient-devel libnfs-devel libogg-devel libpcap-devel libplist-devel libpng12-devel libpulse-devel libsamplerate-devel libsmbclient-devel libtag-devel libtiff-devel libtool libudev-devel libuuid-devel libva-devel libvdpau-devel libvorbis-devel libXrandr-devel libXrender-devel libxslt-devel lirc-devel lzo-devel make Mesa-libEGL-devel Mesa-libGLESv2-devel Mesa-libGLESv3-devel nasm patch pcre-devel python3-devel python3-Pillow randrproto-devel renderproto-devel shairplay-devel sqlite3-devel swig tinyxml-devel tinyxml2-devel
 ```
 
-**WARNING:** Make sure you copy paste the entire line or you might receive an error or miss a few dependencies.
+> [!WARNING]  
+> Make sure you copy paste the entire line or you might receive an error or miss a few dependencies.
 
 Building for Wayland requires some extra packages:
 ```
@@ -91,21 +99,24 @@ Similarly, building for GBM also requires some extra packages:
 sudo zypper install libgbm-devel libinput-devel libxkbcommon-devel
 ```
 
-**WARNING:** Fedora repositories don't have install candidates for `libfmt`, `rapidjson` and `waylandpp`. See **[build missing dependencies manually](#31-build-missing-dependencies)** section before you proceed.
+> [!WARNING]  
+> Fedora repositories don't have install candidates for `libfmt`, `rapidjson` and `waylandpp`. See **[build missing dependencies manually](#31-build-missing-dependencies)** section before you proceed.
 
 Optional packages that you might want to install for extra functionality (generating doxygen documentation, for instance):
 ```
 sudo zypper install doxygen sndio-devel libmariadb-devel
 ```
 
-**NOTE:** For developers and anyone else who builds frequently it is recommended to install `ccache` to expedite subsequent builds of Kodi.
+> [!NOTE]  
+> For developers and anyone else who builds frequently it is recommended to install `ccache` to expedite subsequent builds of Kodi.
 
 You can install it with:
 ```
 sudo zypper install ccache
 ```
 
-**TIP:** If you have multiple computers at home, `distcc` will distribute build workloads of C and C++ code across several machines on a network. Team Kodi may not be willing to give support if problems arise using such a build configuration.
+> [!TIP]
+> If you have multiple computers at home, `distcc` will distribute build workloads of C and C++ code across several machines on a network. Team Kodi may not be willing to give support if problems arise using such a build configuration.
 
 You can install it with:
 ```

--- a/docs/README.tvOS.md
+++ b/docs/README.tvOS.md
@@ -52,9 +52,14 @@ git clone -b Krypton https://github.com/xbmc/xbmc kodi
 
 Several different strategies are used to draw your attention to certain pieces of information. In order of how critical the information is, these items are marked as a note, tip, or warning. For example:
 
-**NOTE:** Linux is user friendly... It's just very particular about who its friends are.
-**TIP:** Algorithm is what developers call code they do not want to explain.
-**WARNING:** Developers don't change light bulbs. It's a hardware problem.
+> [!NOTE]  
+> Linux is user friendly... It's just very particular about who its friends are.
+
+> [!TIP]
+> Algorithm is what developers call code they do not want to explain.
+
+> [!WARNING]  
+> Developers don't change light bulbs. It's a hardware problem.
 
 **[back to top](#table-of-contents)** | **[back to section top](#1-document-conventions)**
 
@@ -68,7 +73,8 @@ Building for tvOS should work with the following combinations of Xcode and macOS
   * Xcode 13.x against tvOS SDK 15.4 on 12.x (Monterey)(recommended)
 
 Team Kodi CI infrastructure is limited, and therefore we only have the single combination tested. Newer xcode/macos combinations generally should work, however the team does not actively test/use pre-release versions, so use with caution. Earlier versions may work, however we dont actively support them, so use with caution.
-**WARNING:** Start Xcode after installation finishes. You need to accept the licenses and install missing components.
+> [!WARNING]  
+> Start Xcode after installation finishes. You need to accept the licenses and install missing components.
 
 **[back to top](#table-of-contents)**
 
@@ -87,7 +93,8 @@ git clone https://github.com/xbmc/xbmc kodi
 
 ## 4. Configure and build tools and dependencies
 Kodi can be built as a 64bit program only for tvOS. The dependencies are built in `$HOME/kodi/tools/depends` and installed into `/Users/Shared/xbmc-depends`.
-**NOTE:** `--with-platform` is mandatory for all Apple platforms
+> [!NOTE]  
+> `--with-platform` is mandatory for all Apple platforms
 
 Configure build:
 ```
@@ -101,11 +108,15 @@ Build tools and dependencies:
 make -j$(getconf _NPROCESSORS_ONLN)
 ```
 
-**TIP:** By adding `-j<number>` to the make command, you can choose how many concurrent jobs will be used and expedite the build process. It is recommended to use `-j$(getconf _NPROCESSORS_ONLN)` to compile on all available processor cores. The build machine can also be configured to do this automatically by adding `export MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"` to your shell config (e.g. `~/.bashrc`).
+> [!TIP]
+> By adding `-j<number>` to the make command, you can choose how many concurrent jobs will be used and expedite the build process. It is recommended to use `-j$(getconf _NPROCESSORS_ONLN)` to compile on all available processor cores. The build machine can also be configured to do this automatically by adding `export MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"` to your shell config (e.g. `~/.bashrc`).
 
-**WARNING:** Look for the `Dependencies built successfully.` success message. If in doubt run a single threaded `make` command until the message appears. If the single make fails, clean the specific library by issuing `make -C target/<name_of_failed_lib> distclean` and run `make`again.
+> [!WARNING]  
+> Look for the `Dependencies built successfully.` success message. If in doubt run a single threaded `make` command until the message appears. If the single make fails, clean the specific library by issuing `make -C target/<name_of_failed_lib> distclean` and run `make`again.
 
-**NOTE:** **Advanced developers** may want to specify an tvOS SDK version (if multiple versions are installed) in the configure line(s) shown above. The example below would use the tvOS SDK 11.0:
+> [!NOTE]  
+> **Advanced developers** may want to specify an tvOS SDK version (if multiple versions are installed) in the configure line(s) shown above. The example below would use the tvOS SDK 11.0:
+
 ```
 ./configure --host=aarch64-apple-darwin --with-platform=tvos --with-sdk=11.0
 ```
@@ -202,7 +213,8 @@ Generate Xcode project for TVOS:
 make -C tools/depends/target/cmakebuildsys BUILD_DIR=$HOME/kodi-build
 ```
 
-**TIP:** BUILD_DIR can be omitted, and project will be created in $HOME/kodi/build
+> [!TIP]
+> BUILD_DIR can be omitted, and project will be created in $HOME/kodi/build
 Change all relevant paths onwards if omitted.
 
 Additional cmake arguments can be supplied via the CMAKE_EXTRA_ARGUMENTS command line variable
@@ -220,7 +232,8 @@ PROVISIONING_PROFILE_TOPSHELF - provprofile name for the top shelf
 
 ## 5.2. Add Binary Addons to Project
 
-**TIP:** If you wish to add signing settings automatically, look at **[Generate XCode Project Files](#51-generate-xcode-project-files)** for the additional `CMAKE_EXTRA_ARGUMENTS`
+> [!TIP]
+> If you wish to add signing settings automatically, look at **[Generate XCode Project Files](#51-generate-xcode-project-files)** for the additional `CMAKE_EXTRA_ARGUMENTS`
 
 You can find a complete list of available binary add-ons **[here](https://github.com/xbmc/repo-binary-addons)**.
 
@@ -242,8 +255,11 @@ Generate Xcode project to build all add-ons automatically:
 make -C tools/depends/target/cmakebuildsys CMAKE_EXTRA_ARGUMENTS="-DENABLE_XCODE_ADDONBUILD=ON"
 ```
 
-**TIP:** If you wish to not automatically build addons added to your xcode project, omit `-DENABLE_XCODE_ADDONBUILD=ON`. The target will be added to the project, but the dependency will not be set to automatically build
-**TIP:** Binary add-ons added to the generated Xcode project can be built independently of the Kodi app by selecting the scheme/target `binary-addons` in the Xcode project.
+> [!TIP]
+> If you wish to not automatically build addons added to your xcode project, omit `-DENABLE_XCODE_ADDONBUILD=ON`. The target will be added to the project, but the dependency will not be set to automatically build
+
+> [!TIP]
+> Binary add-ons added to the generated Xcode project can be built independently of the Kodi app by selecting the scheme/target `binary-addons` in the Xcode project.
 You can also build the binary-addons target via xcodebuild. This will not build the Kodi App, but will build any/all binary addons added for the project Generation.
 ```
 xcodebuild -config "Debug" -target binary-addons
@@ -256,16 +272,21 @@ xcodebuild -config "Debug" -target binary-addons
 
 Start Xcode, open the Kodi project file created in **[Generate Kodi Build files](#5-generate-kodi-build-files)**
 
-**TIP:** (`kodi.xcodeproj`) is located in `$HOME/kodi-build`
+> [!TIP]
+> (`kodi.xcodeproj`) is located in `$HOME/kodi-build`
 
 Once the project has loaded, select `Generic TvOs Device` (or your actual connected device if you have it connected) and hit `Build`.
 
 This will create a `Kodi.app` file located in `$HOME/kodi-build/build/Debug-appletvos`. This App can be deployed via Xcode to an AppleTV via `Window -> Devices and Simulators -> Select device and click +`
 
-**TIP:** If you build as a release target, the location of the `Kodi.app` will be `$HOME/kodi-build/build/Release-appletvos`
+> [!TIP]
+> If you build as a release target, the location of the `Kodi.app` will be `$HOME/kodi-build/build/Release-appletvos`
 
-**WARNING:** If you have selected a specific tvOS SDK Version in step 4 then you might need to adapt the active target to use the same tvOS SDK version, otherwise build will fail. Be sure to select a device configuration.
-**WARNING:** Building for simulator is NOT supported.
+> [!WARNING]  
+> If you have selected a specific tvOS SDK Version in step 4 then you might need to adapt the active target to use the same tvOS SDK version, otherwise build will fail. Be sure to select a device configuration.
+
+> [!WARNING]  
+> Building for simulator is NOT supported.
 
 ### 6.2. Build with xcodebuild
 Alternatively, you can also build via Xcode from the command-line with `xcodebuild`, triggered by CMake:
@@ -278,8 +299,11 @@ xcodebuild -config "Debug" -jobs $(getconf _NPROCESSORS_ONLN)
 
 This will create a `Kodi.app` file located in `$HOME/kodi-build/build/Debug-appletvos`. This App can be deployed via Xcode to an AppleTV via `Window -> Devices and Simulators -> Select device and click +`
 
-**TIP:** You can specify Release instead of Debug as -config parameter.
-**TIP:** If you build as a release target, the location of the `Kodi.app` will be `$HOME/kodi-build/build/Release-appletvos`
+> [!TIP]
+> You can specify Release instead of Debug as -config parameter.
+
+> [!TIP]
+> If you build as a release target, the location of the `Kodi.app` will be `$HOME/kodi-build/build/Release-appletvos`
 
 **[back to top](#table-of-contents)** | **[back to section top](#6-build)**
 
@@ -290,13 +314,15 @@ CMake generates a target called `deb` which will package Kodi ready for distribu
 
 Start Xcode, open the Kodi project file created in **[Generate XCode Project Files](#51-generate-xcode-project-files)**
 
-**TIP:** (`kodi.xcodeproj`) is located in `$HOME/kodi-build`
+> [!TIP]
+> (`kodi.xcodeproj`) is located in `$HOME/kodi-build`
 
 Click on `Product` in the top menu bar, and then go to `Scheme`, then select `deb`
 
 Hit `Build`
 
-**TIP:** The generated package will be located at $HOME/kodi-build/tools/darwin/packaging/tvos.
+> [!TIP]
+> The generated package will be located at $HOME/kodi-build/tools/darwin/packaging/tvos.
 
 ## 7.2. Package via Xcodebuild
 
@@ -306,13 +332,15 @@ cd $HOME/kodi-build
 xcodebuild -target deb
 ```
 
-**TIP:** The generated package will be located at $HOME/kodi-build/tools/darwin/packaging/tvos.
+> [!TIP]
+> The generated package will be located at $HOME/kodi-build/tools/darwin/packaging/tvos.
 
 **[back to top](#table-of-contents)**
 
 ## 8. Signing
 
-**TIP:** If your device is jailbroken, you can go direct to **[Installing on Jailbroken Device](#91-jailbroken-devices)**
+> [!TIP]
+> If your device is jailbroken, you can go direct to **[Installing on Jailbroken Device](#91-jailbroken-devices)**
 
 ## 8.1. Signing using a developer account
 

--- a/docs/README.webOS.md
+++ b/docs/README.webOS.md
@@ -53,9 +53,14 @@ git clone -b Krypton https://github.com/xbmc/xbmc kodi
 
 Several different strategies are used to draw your attention to certain pieces of information. In order of how critical the information is, these items are marked as a note, tip, or warning. For example:
 
-**NOTE:** Linux is user friendly... It's just very particular about who its friends are.
-**TIP:** Algorithm is what developers call code they do not want to explain.
-**WARNING:** Developers don't change light bulbs. It's a hardware problem.
+> [!NOTE]  
+> Linux is user friendly... It's just very particular about who its friends are.
+
+> [!TIP]
+> Algorithm is what developers call code they do not want to explain.
+
+> [!WARNING]  
+> Developers don't change light bulbs. It's a hardware problem.
 
 **[back to top](#table-of-contents)** | **[back to section top](#1-document-conventions)**
 
@@ -123,11 +128,15 @@ Build tools and dependencies:
 make -j$(getconf _NPROCESSORS_ONLN)
 ```
 
-**TIP:** By adding `-j<number>` to the make command, you can choose how many concurrent jobs will be used and expedite the build process. It is recommended to use `-j$(getconf _NPROCESSORS_ONLN)` to compile on all available processor cores. The build machine can also be configured to do this automatically by adding `export MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"` to your shell config (e.g. `~/.bashrc`).
+> [!TIP]
+> By adding `-j<number>` to the make command, you can choose how many concurrent jobs will be used and expedite the build process. It is recommended to use `-j$(getconf _NPROCESSORS_ONLN)` to compile on all available processor cores. The build machine can also be configured to do this automatically by adding `export MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"` to your shell config (e.g. `~/.bashrc`).
 
-**WARNING:** Look for the `Dependencies built successfully.` success message. If in doubt run a single threaded `make` command until the message appears. If the single make fails, clean the specific library by issuing `make -C target/<name_of_failed_lib> distclean` and run `make`again.
+> [!WARNING]  
+> Look for the `Dependencies built successfully.` success message. If in doubt run a single threaded `make` command until the message appears. If the single make fails, clean the specific library by issuing `make -C target/<name_of_failed_lib> distclean` and run `make`again.
 
-**NOTE:** You may want to modify arch, float-abi or fpu to obtain the best performance out of the target CPU, however the defaults are recommended for now until you have a working build:
+> [!NOTE]  
+> You may want to modify arch, float-abi or fpu to obtain the best performance out of the target CPU, however the defaults are recommended for now until you have a working build:
+
 ```
 ./configure --with-target-cflags='-march=armv7-a -mfloat-abi=softfp -mfpu=neon'
 ```
@@ -212,7 +221,8 @@ Generate project for webOS:
 make -C tools/depends/target/cmakebuildsys
 ```
 
-**TIP:** BUILD_DIR can be omitted, and project will be created in $HOME/kodi/build
+> [!TIP]
+> BUILD_DIR can be omitted, and project will be created in $HOME/kodi/build
 Change all relevant paths onwards if omitted.
 
 Additional cmake arguments can be supplied via the CMAKE_EXTRA_ARGUMENTS command line variable
@@ -246,7 +256,8 @@ make -j$(getconf _NPROCESSORS_ONLN) -C tools/depends/target/binary-addons PREFIX
 
 To build specific addons or help with regular expression usage for ADDONS_TO_BUILD, view ADDONS_TO_BUILD section located at [Kodi add-ons CMake based buildsystem](../cmake/addons/README.md)
 
-**TIP:** Binary add-ons added to the generated project can be built independently of the Kodi app by selecting the scheme/target `binary-addons` in the project.
+> [!TIP]
+> Binary add-ons added to the generated project can be built independently of the Kodi app by selecting the scheme/target `binary-addons` in the project.
 
 **[back to top](#table-of-contents)** | **[back to section top](#5-Generate-Kodi-Build-files)**
 
@@ -260,7 +271,8 @@ In '$HOME/kodi/build`
 make -j$(getconf _NPROCESSORS_ONLN)
 ```
 
-**WARNING:** Building for simulator is NOT supported.
+> [!WARNING]  
+> Building for simulator is NOT supported.
 
 **[back to top](#table-of-contents)** | **[back to section top](#6-Build)**
 

--- a/tools/depends/README.md
+++ b/tools/depends/README.md
@@ -29,7 +29,8 @@ Paths below are examples. If you want to build Kodi, follow our **[build guides]
 **tvOS**
 `./configure --host=aarch64-apple-darwin --with-platform=tvos`
 
-**NOTE:** You can target the same `--prefix=` path. Each setup will be done in an isolated directory. The last configure/make you do is the one used for Kodi/Xcode.
+> [!NOTE]  
+> You can target the same `--prefix=` path. Each setup will be done in an isolated directory. The last configure/make you do is the one used for Kodi/Xcode.
 
 ### Android
 **arm**
@@ -44,7 +45,8 @@ Paths below are examples. If you want to build Kodi, follow our **[build guides]
 **x86_64**
 `./configure --with-tarballs=$HOME/android-tools/xbmc-tarballs --host=x86_64-linux-android --with-sdk-path=$HOME/android-tools/android-sdk-linux --with-ndk-path=$HOME/android-tools/android-ndk-r20 --prefix=$HOME/android-tools/xbmc-depends`
 
-> **Note:** Android x86 and x86_64 are not maintained and are not 100% sure that everything works correctly!
+> [!NOTE]  
+> Android x86 and x86_64 are not maintained and are not 100% sure that everything works correctly!
 
 ### Linux
 **ARM (codesourcery/lenaro/etc)**


### PR DESCRIPTION
## Description
Github added options to markdown to display notes, tips and warnings (along others). See https://github.com/orgs/community/discussions/16925

Since we host on github let's take advantage of them to make our docs prettier. And even if such marks are not supported they are simple quote marks that are easily readable - standing out better than simple lines starting with a bold prefix.

**Before:**
![image](https://github.com/xbmc/xbmc/assets/7375276/4b7ec24b-aafc-4deb-9680-0c1d1b29aab8)

**Now:**
![image](https://github.com/xbmc/xbmc/assets/7375276/4e6dbe7a-0e30-4a0e-b4f2-e9a58ab1f8e4)


**If not supported:**
![image](https://github.com/xbmc/xbmc/assets/7375276/e7dff35e-bc7a-4f36-bc5f-34f62e9ff5e6)



