### PR TITLE
[video] Remove fallback to movie art for undefined extra art types

### DIFF
--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -30,6 +30,7 @@
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
 #include "video/VideoInfoTag.h"
+#include "video/VideoManagerTypes.h"
 #include "video/guilib/VideoVersionHelper.h"
 
 #include <algorithm>
@@ -409,11 +410,13 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
     // @todo unify asset path for other items path
     if (VIDEO::IsVideoAssetFile(item))
     {
-      if (m_videoDatabase->GetArtForAsset(tag.m_iFileId,
-                                          item.GetProperty("noartfallbacktoowner").asBoolean(false)
-                                              ? ArtFallbackOptions::NONE
-                                              : ArtFallbackOptions::PARENT,
-                                          artwork))
+      if (m_videoDatabase->GetArtForAsset(
+              tag.m_iFileId,
+              (item.GetProperty("noartfallbacktoowner").asBoolean(false) ||
+               item.GetVideoInfoTag()->GetAssetInfo().GetType() != VideoAssetType::VERSION)
+                  ? ArtFallbackOptions::NONE
+                  : ArtFallbackOptions::PARENT,
+              artwork))
         item.AppendArt(artwork);
     }
     else if (m_videoDatabase->GetArtForItem(tag.m_iDbId, tag.m_type, artwork))


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Remove the fallback to the art of the movie for the art types that are not defined on extras.

By default extra art is a thumb of the video and that's all that will be displayed in the various dialogs unless the user explicitly defines additional art types for the extra through the Extras Manager dialog.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Identical movie art for all extras of a movie is not helpful, it's better to show only the default thumb, and additional art only when set by the user for the extra.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Choose extra and Extras Manager dialogs for movies with/without extras.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

More helpful art by default when selecting an extra to play

## Screenshots (if appropriate):
Before:
![image](https://github.com/xbmc/xbmc/assets/489377/50decc24-6a6a-4ded-bd6c-d9348599e221)

After:
![image](https://github.com/xbmc/xbmc/assets/489377/b64cd64d-92ec-4077-9654-1779a5dc3ded)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
