### PR TITLE
Fix WebVTT compiler warning

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.cpp
@@ -95,7 +95,8 @@ bool ValidateSignature(const std::string& data, const char* signature)
     if (data.compare(0, signatureLen, signature) == 0)
     {
       // Check if last char is valid
-      if (std::strchr(signatureLastChars, data[signatureLen]) != nullptr)
+      if (std::memchr(signatureLastChars, data[signatureLen], sizeof(signatureLastChars)) !=
+          nullptr)
         return true;
     }
   }


### PR DESCRIPTION
## Description

This PR fixes a possible buffer overflow in the WebVTT parser.

CC @CastagnaIT

## Motivation and context

Discovered while building Kodi on my new Steam Deck.


## How has this been tested?

Before, warning was:

```
warning: ‘char* __builtin_strchr(const char*, int)’ argument missing terminating nul [-Wstringop-overread]
  241 |   return __builtin_strchr (__s, __c);
      |          ~~~~~~~~~~~~~~~~~^~~~~~~~~~
```

After, file compiles on my Steam Deck with no warning:

```
[ 87%] Building CXX object build/cores/VideoPlayer/subtitles/webvtt/CMakeFiles/subtitles_webvtt.dir/WebVTTHandler.cpp.o
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
