### PR TITLE
webOS: Remove leftover libcec depend

### DIFF
--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -127,7 +127,7 @@ ifeq ($(OS),linux)
 
   ifeq ($(TARGET_PLATFORM),webos)
     DEPENDS += wayland waylandpp wayland-protocols webos-wayland-extensions webos-userland
-    EXCLUDED_DEPENDS += dbus libcec linux-system-x11-libs pipewire mesa
+    EXCLUDED_DEPENDS += dbus linux-system-x11-libs pipewire mesa
   endif
 
   ifneq (,$(findstring gbm,$(TARGET_PLATFORM)))


### PR DESCRIPTION
## Description

This PR removes a Makefile target that was removed when CEC was moved to an internal dependency in https://github.com/xbmc/xbmc/pull/21585.

CC @sundermann

## Motivation and context

Clean up leftover dependency.

## How has this been tested?

 Successfully built Kodi on my new Steam Deck with this change.

## What is the effect on users?

* None, code cleanup

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
