### PR TITLE
[pvr] Improve support for live streaming from Epg Tags for Archive/Catchup

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_general.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_general.h
@@ -215,6 +215,7 @@ extern "C"
   ///
   /// // On PVR instance of addon
   /// PVR_ERROR CMyPVRInstance::GetChannelStreamProperties(const kodi::addon::PVRChannel& channel,
+  ///                                                      PVR_SOURCE source,
   ///                                                      std::vector<PVRStreamProperty>& properties)
   /// {
   ///   ...

--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -368,6 +368,16 @@ void CPVRPlaybackState::StartPlayback(CFileItem* item,
       }
 
       client->GetChannelStreamProperties(item->GetPVRChannelInfoTag(), source, props);
+
+      if (props.LivePlaybackAsEPG())
+      {
+        const std::shared_ptr<CPVREpgInfoTag> epgTag = item->GetPVRChannelInfoTag()->GetEPGNow();
+        if (epgTag)
+        {
+          delete item;
+          item = new CFileItem(epgTag);
+        }
+      }
     }
     else if (item->IsPVRRecording())
     {

--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -341,14 +341,15 @@ bool CPVRPlaybackState::OnPlaybackEnded(const CFileItem& item)
 
   std::unique_ptr<CFileItem> nextToPlay{GetNextAutoplayItem(item)};
   if (nextToPlay)
-    StartPlayback(nextToPlay.release());
+    StartPlayback(nextToPlay.release(), ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM,
+                  PVR_SOURCE::DEFAULT);
 
   return OnPlaybackStopped(item);
 }
 
-void CPVRPlaybackState::StartPlayback(
-    CFileItem* item,
-    ContentUtils::PlayMode mode /* = ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM */) const
+void CPVRPlaybackState::StartPlayback(CFileItem* item,
+                                      ContentUtils::PlayMode mode,
+                                      PVR_SOURCE source) const
 {
   // Obtain dynamic playback url and properties from the respective pvr client
   const std::shared_ptr<const CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(*item);
@@ -358,7 +359,7 @@ void CPVRPlaybackState::StartPlayback(
 
     if (item->IsPVRChannel())
     {
-      client->GetChannelStreamProperties(item->GetPVRChannelInfoTag(), props);
+      client->GetChannelStreamProperties(item->GetPVRChannelInfoTag(), source, props);
     }
     else if (item->IsPVRRecording())
     {

--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -341,13 +341,13 @@ bool CPVRPlaybackState::OnPlaybackEnded(const CFileItem& item)
 
   std::unique_ptr<CFileItem> nextToPlay{GetNextAutoplayItem(item)};
   if (nextToPlay)
-    StartPlayback(nextToPlay.release(), ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM,
+    StartPlayback(nextToPlay, ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM,
                   PVR_SOURCE::DEFAULT);
 
   return OnPlaybackStopped(item);
 }
 
-void CPVRPlaybackState::StartPlayback(CFileItem* item,
+void CPVRPlaybackState::StartPlayback(std::unique_ptr<CFileItem>& item,
                                       ContentUtils::PlayMode mode,
                                       PVR_SOURCE source) const
 {
@@ -374,8 +374,7 @@ void CPVRPlaybackState::StartPlayback(CFileItem* item,
         const std::shared_ptr<CPVREpgInfoTag> epgTag = item->GetPVRChannelInfoTag()->GetEPGNow();
         if (epgTag)
         {
-          delete item;
-          item = new CFileItem(epgTag);
+          item = std::make_unique<CFileItem>(epgTag);
         }
       }
     }
@@ -422,7 +421,8 @@ void CPVRPlaybackState::StartPlayback(CFileItem* item,
     }
   }
 
-  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_PLAY, 0, 0, static_cast<void*>(item));
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_PLAY, 0, 0,
+                                             static_cast<void*>(item.release()));
 }
 
 bool CPVRPlaybackState::IsPlaying() const

--- a/xbmc/pvr/PVRPlaybackState.cpp
+++ b/xbmc/pvr/PVRPlaybackState.cpp
@@ -359,6 +359,14 @@ void CPVRPlaybackState::StartPlayback(CFileItem* item,
 
     if (item->IsPVRChannel())
     {
+      if (source == PVR_SOURCE::DEFAULT)
+      {
+        PVR_ERROR retVal = client->StreamClosed();
+        if (retVal != PVR_ERROR_NO_ERROR)
+          CLog::LogFC(LOGERROR, LOGPVR, "Client error on call to StreamClosed(): {}",
+                      CPVRClient::ToString(retVal));
+      }
+
       client->GetChannelStreamProperties(item->GetPVRChannelInfoTag(), source, props);
     }
     else if (item->IsPVRRecording())
@@ -367,6 +375,11 @@ void CPVRPlaybackState::StartPlayback(CFileItem* item,
     }
     else if (item->IsEPG())
     {
+      PVR_ERROR retVal = client->StreamClosed();
+      if (retVal != PVR_ERROR_NO_ERROR)
+        CLog::LogFC(LOGERROR, LOGPVR, "Client error on call to StreamClosed(): {}",
+                    CPVRClient::ToString(retVal));
+
       client->GetEpgTagStreamProperties(item->GetEPGInfoTag(), props);
 
       if (mode == ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM)

--- a/xbmc/pvr/PVRPlaybackState.h
+++ b/xbmc/pvr/PVRPlaybackState.h
@@ -76,7 +76,9 @@ public:
    * @param item containing a channel, a recording or an epg tag.
    * @param mode playback mode.
    */
-  void StartPlayback(CFileItem* item, ContentUtils::PlayMode mode, PVR_SOURCE source) const;
+  void StartPlayback(std::unique_ptr<CFileItem>& item,
+                     ContentUtils::PlayMode mode,
+                     PVR_SOURCE source) const;
 
   /*!
    * @brief Check if a TV channel, radio channel or recording is playing.

--- a/xbmc/pvr/PVRPlaybackState.h
+++ b/xbmc/pvr/PVRPlaybackState.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_general.h"
 #include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
 #include "threads/CriticalSection.h"
 #include "utils/ContentUtils.h"
@@ -75,9 +76,7 @@ public:
    * @param item containing a channel, a recording or an epg tag.
    * @param mode playback mode.
    */
-  void StartPlayback(
-      CFileItem* item,
-      ContentUtils::PlayMode mode = ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM) const;
+  void StartPlayback(CFileItem* item, ContentUtils::PlayMode mode, PVR_SOURCE source) const;
 
   /*!
    * @brief Check if a TV channel, radio channel or recording is playing.

--- a/xbmc/pvr/PVRStreamProperties.cpp
+++ b/xbmc/pvr/PVRStreamProperties.cpp
@@ -38,3 +38,11 @@ bool CPVRStreamProperties::EPGPlaybackAsLive() const
   });
   return it != cend() ? StringUtils::EqualsNoCase((*it).second, "true") : false;
 }
+
+bool CPVRStreamProperties::LivePlaybackAsEPG() const
+{
+  const auto it = std::find_if(cbegin(), cend(),
+                               [](const auto& prop)
+                               { return prop.first == PVR_STREAM_PROPERTY_LIVEPLAYBACKASEPG; });
+  return it != cend() ? StringUtils::EqualsNoCase((*it).second, "true") : false;
+}

--- a/xbmc/pvr/PVRStreamProperties.h
+++ b/xbmc/pvr/PVRStreamProperties.h
@@ -38,6 +38,12 @@ public:
    * @return true if it should be played back as live, false otherwise.
    */
   bool EPGPlaybackAsLive() const;
+
+  /*!
+   * @brief If props are from an channel indicates if playback should be as a video playback would be
+   * @return true if it should be played back as live, false otherwise.
+   */
+  bool LivePlaybackAsEPG() const;
 };
 
 } // namespace PVR

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -1608,6 +1608,12 @@ PVR_ERROR CPVRClient::GetStreamProperties(PVR_STREAM_PROPERTIES* props) const
                      { return addon->toAddon->GetStreamProperties(addon, props); });
 }
 
+PVR_ERROR CPVRClient::StreamClosed() const
+{
+  return DoAddonCall(__func__, [](const AddonInstance* addon)
+                     { return addon->toAddon->StreamClosed(addon); });
+}
+
 PVR_ERROR CPVRClient::DemuxReset()
 {
   return DoAddonCall(

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -1554,11 +1554,12 @@ PVR_ERROR CPVRClient::GetDescrambleInfo(int channelUid, CPVRDescrambleInfo& desc
 }
 
 PVR_ERROR CPVRClient::GetChannelStreamProperties(const std::shared_ptr<const CPVRChannel>& channel,
+                                                 PVR_SOURCE source,
                                                  CPVRStreamProperties& props) const
 {
   return DoAddonCall(
       __func__,
-      [this, &channel, &props](const AddonInstance* addon)
+      [this, &channel, source, &props](const AddonInstance* addon)
       {
         if (!CanPlayChannel(channel))
           return PVR_ERROR_NO_ERROR; // no error, but no need to obtain the values from the addon
@@ -1568,7 +1569,7 @@ PVR_ERROR CPVRClient::GetChannelStreamProperties(const std::shared_ptr<const CPV
         PVR_NAMED_VALUE** property_array{nullptr};
         unsigned int size{0};
         const PVR_ERROR error{addon->toAddon->GetChannelStreamProperties(
-            addon, &addonChannel, PVR_SOURCE::DEFAULT, &property_array, &size)};
+            addon, &addonChannel, source, &property_array, &size)};
         if (error == PVR_ERROR_NO_ERROR)
           WriteStreamProperties(property_array, size, props);
 

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -589,10 +589,12 @@ public:
   /*!
    * @brief Fill the given container with the properties required for playback of the given channel. Values are obtained from the PVR backend.
    * @param channel The channel.
+   * @param source PVR_SOURCE_EPG_AS_LIVE if this call resulted from PVR_STREAM_PROPERTY_EPGPLAYBACKASLIVE being set from GetEPGTagStreamProperties(), PVR_SOURCE_SWITCH_LIVE otherwise.
    * @param props The container to be filled with the stream properties.
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */
   PVR_ERROR GetChannelStreamProperties(const std::shared_ptr<const CPVRChannel>& channel,
+                                       PVR_SOURCE source,
                                        CPVRStreamProperties& props) const;
 
   /*!

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -150,6 +150,12 @@ public:
   PVR_ERROR GetStreamProperties(PVR_STREAM_PROPERTIES* pProperties) const;
 
   /*!
+   * @brief A stream was closed or has ended
+   * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
+   */
+  PVR_ERROR StreamClosed() const;
+
+  /*!
    * @return The name reported by the backend.
    */
   const std::string& GetBackendName() const;
@@ -589,7 +595,7 @@ public:
   /*!
    * @brief Fill the given container with the properties required for playback of the given channel. Values are obtained from the PVR backend.
    * @param channel The channel.
-   * @param source PVR_SOURCE_EPG_AS_LIVE if this call resulted from PVR_STREAM_PROPERTY_EPGPLAYBACKASLIVE being set from GetEPGTagStreamProperties(), PVR_SOURCE_SWITCH_LIVE otherwise.
+   * @param source PVR_SOURCE_EPG_AS_LIVE if this call resulted from PVR_STREAM_PROPERTY_EPGPLAYBACKASLIVE being set from GetEPGTagStreamProperties(), DEFAULT otherwise.
    * @param props The container to be filled with the stream properties.
    * @return PVR_ERROR_NO_ERROR on success, respective error code otherwise.
    */

--- a/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
@@ -164,7 +164,8 @@ bool CPVRGUIActionsPlayback::PlayRecording(const CFileItem& item, bool bCheckRes
     {
       CFileItem* itemToPlay = new CFileItem(recording);
       itemToPlay->SetStartOffset(item.GetStartOffset());
-      CServiceBroker::GetPVRManager().PlaybackState()->StartPlayback(itemToPlay);
+      CServiceBroker::GetPVRManager().PlaybackState()->StartPlayback(
+          itemToPlay, ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM, PVR_SOURCE::DEFAULT);
     }
     CheckAndSwitchToFullscreen(true);
   }
@@ -216,6 +217,7 @@ bool CPVRGUIActionsPlayback::PlayEpgTag(
   client->GetEpgTagStreamProperties(epgTag, props);
 
   CFileItem* itemToPlay = nullptr;
+  PVR_SOURCE source = DEFAULT;
   if (props.EPGPlaybackAsLive())
   {
     const std::shared_ptr<CPVRChannelGroupMember> groupMember =
@@ -223,6 +225,7 @@ bool CPVRGUIActionsPlayback::PlayEpgTag(
     if (!groupMember)
       return false;
 
+    source = PVR_SOURCE_EPG_AS_LIVE;
     itemToPlay = new CFileItem(groupMember);
   }
   else
@@ -230,7 +233,7 @@ bool CPVRGUIActionsPlayback::PlayEpgTag(
     itemToPlay = new CFileItem(epgTag);
   }
 
-  CServiceBroker::GetPVRManager().PlaybackState()->StartPlayback(itemToPlay, mode);
+  CServiceBroker::GetPVRManager().PlaybackState()->StartPlayback(itemToPlay, mode, source);
   CheckAndSwitchToFullscreen(true);
   return true;
 }
@@ -313,7 +316,9 @@ bool CPVRGUIActionsPlayback::SwitchToChannel(const CFileItem& item, bool bCheckR
     if (!groupMember)
       return false;
 
-    CServiceBroker::GetPVRManager().PlaybackState()->StartPlayback(new CFileItem(groupMember));
+    CServiceBroker::GetPVRManager().PlaybackState()->StartPlayback(
+        new CFileItem(groupMember), ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM,
+        PVR_SOURCE::DEFAULT);
     CheckAndSwitchToFullscreen(bFullscreen);
     return true;
   }

--- a/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
@@ -162,7 +162,7 @@ bool CPVRGUIActionsPlayback::PlayRecording(const CFileItem& item, bool bCheckRes
     }
     else
     {
-      CFileItem* itemToPlay = new CFileItem(recording);
+      std::unique_ptr<CFileItem> itemToPlay{std::make_unique<CFileItem>(recording)};
       itemToPlay->SetStartOffset(item.GetStartOffset());
       CServiceBroker::GetPVRManager().PlaybackState()->StartPlayback(
           itemToPlay, ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM, PVR_SOURCE::DEFAULT);
@@ -221,7 +221,7 @@ bool CPVRGUIActionsPlayback::PlayEpgTag(
 
   client->GetEpgTagStreamProperties(epgTag, props);
 
-  CFileItem* itemToPlay = nullptr;
+  std::unique_ptr<CFileItem> itemToPlay;
   PVR_SOURCE source = DEFAULT;
   if (props.EPGPlaybackAsLive())
   {
@@ -231,11 +231,11 @@ bool CPVRGUIActionsPlayback::PlayEpgTag(
       return false;
 
     source = PVR_SOURCE_EPG_AS_LIVE;
-    itemToPlay = new CFileItem(groupMember);
+    itemToPlay = std::make_unique<CFileItem>(groupMember);
   }
   else
   {
-    itemToPlay = new CFileItem(epgTag);
+    itemToPlay = std::make_unique<CFileItem>(epgTag);
   }
 
   CServiceBroker::GetPVRManager().PlaybackState()->StartPlayback(itemToPlay, mode, source);
@@ -321,9 +321,9 @@ bool CPVRGUIActionsPlayback::SwitchToChannel(const CFileItem& item, bool bCheckR
     if (!groupMember)
       return false;
 
+    std::unique_ptr<CFileItem> itemToPlay{std::make_unique<CFileItem>(groupMember)};
     CServiceBroker::GetPVRManager().PlaybackState()->StartPlayback(
-        new CFileItem(groupMember), ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM,
-        PVR_SOURCE::DEFAULT);
+        itemToPlay, ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM, PVR_SOURCE::DEFAULT);
     CheckAndSwitchToFullscreen(bFullscreen);
     return true;
   }

--- a/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
@@ -214,6 +214,11 @@ bool CPVRGUIActionsPlayback::PlayEpgTag(
     return false;
 
   CPVRStreamProperties props;
+  PVR_ERROR retVal = client->StreamClosed();
+  if (retVal != PVR_ERROR_NO_ERROR)
+    CLog::LogFC(LOGERROR, LOGPVR, "Client error on call to StreamClosed(): {}",
+                CPVRClient::ToString(retVal));
+
   client->GetEpgTagStreamProperties(epgTag, props);
 
   CFileItem* itemToPlay = nullptr;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

IptvSimple has complex logic to tell if a call to `GetChannelStreamProperties()` originated from an EPG Tag. Right now we set the `PVR_STREAM_PROPERTY_EPGPLAYBACKASLIVE` property when we call `GetEPGTagStreamProperties()`, which initiates a call to GetChannelStreamProperties().

This is what allows iptvsimple to use the live OSD for catchup so you can channel surf. 

Moving this logic into kodi PVR is one step to give any add-on support for live channel surfing. Still needs some coding in the add-on but the logic is much simplified. Added bonus, we could likely get play next programme for free for live catchup, so it would complement the [continuous playback feature](https://github.com/xbmc/xbmc/pull/24528) recently implemented for video play in PVR.

This is the first part. The second to be added later is to have a callback for when a stream is stopped. For PVR add-ons that `PVRCapabilities::SetHandlesInputStream()` or `PVRCapabilities::SetHandlesDemuxing()` already have this ability via `CloseLiveStream()`. But add-ons such as iptvsimple and others that do not handle those capabilities do not have this ability. This is the second commit. It is called if playing back a channel that didn't originate from an EpgTag or when plaing back an EPG Tag.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

On MacOSX with iptvsimple.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Nothing currnetly.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [X] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
