### PR TITLE
[GUIEditControl] Use left truncate (and relative ellipses) for edit controls only

### DIFF
--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -83,6 +83,7 @@ void CGUIEditControl::DefaultConstructor()
   m_smsLastKey = 0;
   m_smsKeyIndex = 0;
   m_label2.GetLabelInfo().offsetX = 0;
+  m_label2.SetReversedTruncate(true); // Truncate the text by default on the left
   m_isMD5 = false;
   m_invalidInput = false;
   m_inputValidator = NULL;

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -91,8 +91,12 @@ void CGUIEditControl::DefaultConstructor()
   m_editOffset = 0;
 }
 
-CGUIEditControl::CGUIEditControl(const CGUIButtonControl &button)
-    : CGUIButtonControl(button)
+CGUIEditControl::CGUIEditControl(const CGUIButtonControl& button) : CGUIButtonControl(button)
+{
+  DefaultConstructor();
+}
+
+CGUIEditControl::CGUIEditControl(const CGUIEditControl& button) : CGUIButtonControl(button)
 {
   DefaultConstructor();
 }

--- a/xbmc/guilib/GUIEditControl.h
+++ b/xbmc/guilib/GUIEditControl.h
@@ -44,7 +44,8 @@ public:
   CGUIEditControl(int parentID, int controlID, float posX, float posY,
                   float width, float height, const CTextureInfo &textureFocus, const CTextureInfo &textureNoFocus,
                   const CLabelInfo& labelInfo, const std::string &text);
-  explicit CGUIEditControl(const CGUIButtonControl &button);
+  explicit CGUIEditControl(const CGUIButtonControl& button);
+  explicit CGUIEditControl(const CGUIEditControl& button);
   ~CGUIEditControl(void) override;
   CGUIEditControl* Clone() const override { return new CGUIEditControl(*this); }
 

--- a/xbmc/guilib/GUILabel.cpp
+++ b/xbmc/guilib/GUILabel.cpp
@@ -131,7 +131,8 @@ void CGUILabel::Render()
     else
     {
       align |= XBFONT_TRUNCATED;
-      if (m_label.align & XBFONT_RIGHT)
+      // Allow to text truncate (and relative ellipsis "...") on the left for use cases like edit controls (CGUIEditControl)
+      if (m_isReversedTruncate && (m_label.align & XBFONT_RIGHT))
         align |= XBFONT_RIGHT;
     }
     m_textLayout.Render(posX, posY, m_label.angle, color, m_label.shadowColor, align, m_overflowType == OVER_FLOW_CLIP ? m_textLayout.GetTextWidth() : m_renderRect.Width(), renderSolid);

--- a/xbmc/guilib/GUILabel.h
+++ b/xbmc/guilib/GUILabel.h
@@ -156,6 +156,12 @@ public:
    */
   bool SetOverflow(OVER_FLOW overflow);
 
+  /*!
+   * \brief Set if the text truncate (and ellipsis "...") must be done in reverse (on LTR text by default on the left).
+   * \param isReversed Set true to reversed behaviour
+   */
+  void SetReversedTruncate(bool isReversed) { m_isReversedTruncate = isReversed; }
+
   /*! \brief Set this label invalid.  Forces an update of the control
    */
   void SetInvalid();
@@ -231,6 +237,7 @@ private:
 
   bool           m_scrolling;
   OVER_FLOW      m_overflowType;
+  bool m_isReversedTruncate{false};
   CScrollInfo    m_scrollInfo;
   CRect          m_renderRect;   ///< actual sizing of text
   CRect          m_maxRect;      ///< maximum sizing of text


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The PR #22691 has changed the default behaviour for text truncate/ellipses ("...") for right aligned text case

old kodi versions: Labels on right aligned text, the text was truncated always on the right
current master: Labels on right aligned text, the text was truncated always on the left

mainly this has been done for edit controls but since the underlay control is the Label has been applied also on all Labels, as shown in the Issue

this PR restore the original behaviour for the simple Label controls, and then apply the new behaviour only for edit control cases
such as "edit control setting"

there is room for future improvement, such as automatically distinguishing whether it is LTR or RTL text and applying truncate at the correct position (from text start/left, or text end/right)
in any case, reverse mode should still be required

it's probably a debatable thing too, but for now I think this little adjustment is enough to restore old behaviour for regular label case

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #24610
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
by using custom addon with two labels having right alignment:
CURERNT MASTER:
![301778461-cf45af5e-e75d-4ebb-80ac-7fa4186c01f6](https://github.com/xbmc/xbmc/assets/3257156/9cee22b5-0807-4fb5-aa31-f3f743aae33c)
THIS PR:
![301780724-0de9f454-b97a-413b-8fbe-a75e7fadb0fb](https://github.com/xbmc/xbmc/assets/3257156/f5457111-61ac-4f2a-9183-878159225914)
see also issue for more explicit examples

test confirmed by user https://github.com/xbmc/xbmc/issues/24610#issuecomment-1924766455

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
