### PR TITLE
tools/depends: Update waylandpp patch to fix build again with gcc 13

### DIFF
--- a/tools/depends/target/waylandpp/001-fix-gcc13-build.patch
+++ b/tools/depends/target/waylandpp/001-fix-gcc13-build.patch
@@ -8,7 +8,16 @@
  #include <wayland-version.hpp>
  #include <wayland-client-core.h>
  #include <wayland-util.hpp>
-
+--- a/include/wayland-server.hpp
++++ b/include/wayland-server.hpp
+@@ -27,6 +27,7 @@
+ #define WAYLAND_SERVER_HPP
+ 
+ #include <atomic>
++#include <cstdint>
+ #include <functional>
+ #include <list>
+ #include <memory>
 --- a/scanner/scanner.cpp
 +++ b/scanner/scanner.cpp
 @@ -24,6 +24,7 @@
@@ -16,13 +25,13 @@
  #include <cmath>
  #include <stdexcept>
 +#include <cstdint>
-
+ 
  #include "pugixml.hpp"
-
-@@ -928,6 +929,7 @@
+ 
+@@ -1110,6 +1111,7 @@ int main(int argc, char *argv[])
                << "#include <memory>" << std::endl
                << "#include <string>" << std::endl
                << "#include <vector>" << std::endl
 +              << "#include <cstdint>" << std::endl
                << std::endl
-               << "#include <wayland-client.hpp>" << std::endl;
+               << (server ? "#include <wayland-server.hpp>" : "#include <wayland-client.hpp>") << std::endl;


### PR DESCRIPTION
## Description

This PR contains the patch update split out from https://github.com/xbmc/xbmc/pull/24623.

## Motivation and context

Fixes building updated waylandpp on gcc13 after it was updated to 1.0.0 in https://github.com/xbmc/xbmc/pull/23982.

## How has this been tested?

Tested as part of https://github.com/xbmc/xbmc/pull/24623. With the updated patch, waylandpp compiles on the Steam Deck (uses a fork of Arch Linux).

## What is the effect on users?

* None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
