### PR TITLE
[Android] Exec wake-up routine only after hdmi handshake

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -1335,16 +1335,21 @@ void CXBMCApp::onReceive(CJNIIntent intent)
   {
     const bool hdmiPlugged = (intent.getIntExtra(CJNIAudioManager::EXTRA_AUDIO_PLUG_STATE, 0) != 0);
     android_printf("-- HDMI is plugged in: %s", hdmiPlugged ? "yes" : "no");
-    if (m_hdmiSource && g_application.IsInitialized())
+    if (g_application.IsInitialized())
     {
       CWinSystemBase* winSystem = CServiceBroker::GetWinSystem();
       if (winSystem && dynamic_cast<CWinSystemAndroid*>(winSystem))
         dynamic_cast<CWinSystemAndroid*>(winSystem)->SetHdmiState(hdmiPlugged);
     }
-    if (hdmiPlugged && m_wakeUp)
+    if (hdmiPlugged && m_aeReset)
     {
       android_printf("CXBMCApp::onReceive: Reset audio engine");
       CServiceBroker::GetActiveAE()->DeviceChange();
+      m_aeReset = false;
+    }
+    if (hdmiPlugged && m_wakeUp)
+    {
+      OnWakeup();
       m_wakeUp = false;
     }
   }
@@ -1355,21 +1360,12 @@ void CXBMCApp::onReceive(CJNIIntent intent)
     // For historical reasons, the name of this broadcast action refers to the power state of the
     // screen but it is actually sent in response to changes in the overall interactive state of
     // the device.
-    IPowerSyscall* syscall = CServiceBroker::GetPowerManager().GetPowerSyscall();
-    if (syscall)
-    {
-      CLog::Log(LOGINFO, "Got device wakeup intent");
-      static_cast<CAndroidPowerSyscall*>(syscall)->SetResumed();
-    }
-
-    if (HasFocus())
-    {
-      auto& components = CServiceBroker::GetAppComponents();
-      const auto appPower = components.GetComponent<CApplicationPowerHandling>();
-      appPower->WakeUpScreenSaverAndDPMS();
-    }
-
-    m_wakeUp = true;
+    CLog::Log(LOGINFO, "Got device wakeup intent");
+    if (m_hdmiSource)
+      // wake-up sequence continues in ACTION_HDMI_AUDIO_PLUG intent
+      m_wakeUp = true;
+    else
+      OnWakeup();
   }
   else if (action == CJNIIntent::ACTION_SCREEN_OFF)
   {
@@ -1378,12 +1374,8 @@ void CXBMCApp::onReceive(CJNIIntent intent)
     // For historical reasons, the name of this broadcast action refers to the power state of the
     // screen but it is actually sent in response to changes in the overall interactive state of
     // the device.
-    IPowerSyscall* syscall = CServiceBroker::GetPowerManager().GetPowerSyscall();
-    if (syscall)
-    {
-      CLog::Log(LOGINFO, "Got device sleep intent");
-      static_cast<CAndroidPowerSyscall*>(syscall)->SetSuspended();
-    }
+    CLog::Log(LOGINFO, "Got device sleep intent");
+    OnSleep();
   }
   else if (action == CJNIIntent::ACTION_MEDIA_BUTTON)
   {
@@ -1430,6 +1422,29 @@ void CXBMCApp::onReceive(CJNIIntent intent)
         netdroid->RetrieveInterfaces();
       }
     }
+  }
+}
+
+void CXBMCApp::OnSleep()
+{
+  CLog::Log(LOGINFO, "CXBMCApp::OnSleep");
+  IPowerSyscall* syscall = CServiceBroker::GetPowerManager().GetPowerSyscall();
+  if (syscall)
+    static_cast<CAndroidPowerSyscall*>(syscall)->SetSuspended();
+}
+
+void CXBMCApp::OnWakeup()
+{
+  CLog::Log(LOGINFO, "CXBMCApp::OnWakeup");
+  IPowerSyscall* syscall = CServiceBroker::GetPowerManager().GetPowerSyscall();
+  if (syscall)
+    static_cast<CAndroidPowerSyscall*>(syscall)->SetResumed();
+
+  if (HasFocus())
+  {
+    auto& components = CServiceBroker::GetAppComponents();
+    const auto appPower = components.GetComponent<CApplicationPowerHandling>();
+    appPower->WakeUpScreenSaverAndDPMS();
   }
 }
 
@@ -1759,7 +1774,7 @@ void CXBMCApp::onDisplayChanged(int displayId)
 
   if (!g_application.IsInitialized())
     // Display mode has beed changed during app startup; we want to reset audio engine on next ACTION_HDMI_AUDIO_PLUG event
-    m_wakeUp = true;
+    m_aeReset = true;
 
   // Update display modes
   CWinSystemAndroid* winSystemAndroid = dynamic_cast<CWinSystemAndroid*>(CServiceBroker::GetWinSystem());

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -1333,6 +1333,7 @@ void CXBMCApp::onReceive(CJNIIntent intent)
   }
   else if (action == CJNIAudioManager::ACTION_HDMI_AUDIO_PLUG)
   {
+    m_supportsHdmiAudioPlug = true;
     const bool hdmiPlugged = (intent.getIntExtra(CJNIAudioManager::EXTRA_AUDIO_PLUG_STATE, 0) != 0);
     android_printf("-- HDMI is plugged in: %s", hdmiPlugged ? "yes" : "no");
     if (g_application.IsInitialized())
@@ -1361,7 +1362,7 @@ void CXBMCApp::onReceive(CJNIIntent intent)
     // screen but it is actually sent in response to changes in the overall interactive state of
     // the device.
     CLog::Log(LOGINFO, "Got device wakeup intent");
-    if (m_hdmiSource)
+    if (m_supportsHdmiAudioPlug)
       // wake-up sequence continues in ACTION_HDMI_AUDIO_PLUG intent
       m_wakeUp = true;
     else

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -1427,7 +1427,7 @@ void CXBMCApp::onReceive(CJNIIntent intent)
 
 void CXBMCApp::OnSleep()
 {
-  CLog::Log(LOGINFO, "CXBMCApp::OnSleep");
+  CLog::Log(LOGDEBUG, "CXBMCApp::OnSleep");
   IPowerSyscall* syscall = CServiceBroker::GetPowerManager().GetPowerSyscall();
   if (syscall)
     static_cast<CAndroidPowerSyscall*>(syscall)->SetSuspended();
@@ -1435,7 +1435,7 @@ void CXBMCApp::OnSleep()
 
 void CXBMCApp::OnWakeup()
 {
-  CLog::Log(LOGINFO, "CXBMCApp::OnWakeup");
+  CLog::Log(LOGDEBUG, "CXBMCApp::OnWakeup");
   IPowerSyscall* syscall = CServiceBroker::GetPowerManager().GetPowerSyscall();
   if (syscall)
     static_cast<CAndroidPowerSyscall*>(syscall)->SetResumed();

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -257,6 +257,7 @@ private:
   bool m_hdmiSource{false};
   bool m_wakeUp{false};
   bool m_aeReset{false};
+  bool m_supportsHdmiAudioPlug{false};
   IInputDeviceCallbacks* m_inputDeviceCallbacks{nullptr};
   IInputDeviceEventHandler* m_inputDeviceEventHandler{nullptr};
   bool m_hasReqVisible{false};

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -256,6 +256,7 @@ private:
   bool m_headsetPlugged{false};
   bool m_hdmiSource{false};
   bool m_wakeUp{false};
+  bool m_aeReset{false};
   IInputDeviceCallbacks* m_inputDeviceCallbacks{nullptr};
   IInputDeviceEventHandler* m_inputDeviceEventHandler{nullptr};
   bool m_hasReqVisible{false};
@@ -277,6 +278,9 @@ private:
 
   bool XBMC_DestroyDisplay();
   bool XBMC_SetupDisplay();
+
+  void OnSleep();
+  void OnWakeup();
 
   uint32_t m_playback_state{0};
   int64_t m_frameTimeNanos{0};


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
When device wakes up after sleep the wake-up jobs are executed. They include reinitialisation of audio engine. To avoid errors in audio engine we wait for hdmi handshake to complete before executing wake-up jobs.
This PR improves my previous PRs #24369 and #24484.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
PR #24369 has fixed an issue with audio passthrough not working after sleep/wakeup. The issue has affected Fire TV and Shield devices, especially when used with AVRs. The fix worked well for me until I had to change passthrough and HDMI-CEC settings on my AVR. The change was necessary to fix an issue with AVR waking up by TV when it shouldn't.

After the changes of HDMI-settings on AVR the problem with audio passthrough on Fire TV has returned. The fix of PR #24369 didn't work anymore. The Kodi debug logs indicated an error when resuming audio engine during wakeup jobs (ACTION_SCREEN_ON):

>2024-02-03 12:01:52.852 T:5647    debug <general>: CXBMCApp::onReceive - Got intent. Action: android.intent.action.SCREEN_ON
>2024-02-03 12:01:52.852 T:5647     info <general>: Got device wakeup intent
>2024-02-03 12:01:53.268 T:5674     info <general>: OnWake: Running resume jobs
>...
>2024-02-03 12:01:58.269 T:5674    error <general>: ActiveAE::Resume - failed to init

Later, when ACTION_HDMI_AUDIO_PLUG event is received, an attempt is made to reinitialise audio engine but it fails:
>2024-02-03 12:01:58.463 T:5647    debug <general>: CXBMCApp::onReceive - Got intent. Action: android.media.action.HDMI_AUDIO_PLUG
>2024-02-03 12:01:58.463 T:5647    debug <general>: -- HDMI is plugged in: yes
>2024-02-03 12:01:58.463 T:5647    debug <general>: CWinSystemAndroid::SetHdmiState: state: 1
>2024-02-03 12:01:58.463 T:5647    debug <general>: CXBMCApp::onReceive: Reset audio engine
>...
>2024-02-03 12:01:58.500 T:5691  warning <general>: CActiveAE::StateMachine - signal: 3 from port: OutputControlPort not handled for state: 2

Full log containing error: https://paste.kodi.tv/opurigawed.kodi

### Possible approaches to fix the issue

1. The failed resuming of audio engine sets it into an error state in which it doesn't process device-change events. I guess it would be possible to extend/rework audio engine to be able to handle device change events even in error state. That requires a rework of classes used globally on all platforms.

2. Audio engine is resumed in wakeup-jobs. The jobs are executed in power management module when event ACTION_SCREEN_ON is processed in Android app. We could change the wakeup-jobs management and not resume audio engine there. Instead we could resume it separately later, when ACTION_HDMI_AUDIO_PLUG  is received by our Android app. This code change requires reworking of general power management classes and would also affect other platforms.

3. The less intrusive fix is to run all wakeup-jobs on ACTION_HDMI_AUDIO_PLUG event instead of ACTION_SCREEN_ON. That requires changes only in Android app class. That's the solution proposed in this PR.

### Implementation details
Event ACTION_HDMI_AUDIO_PLUG is processed only on certain device types. If we can use the event we run wakeup-jobs in this event, otherwise in ACTION_SCREEN_ON (old behaviour). In order to execute the required code in two different events I extracted the code from ACTION_SCREEN_ON into a new routine `CXBMCApp::OnWakeup()` (no actual changes to the code there).

I also moved the code from ACTION_SCREEN_OFF event to a new routine `CXBMCApp::OnSleep()`. That was technically not necessary but makes the code cleaner and keeps the both related code parts nearby.

New class member `m_aeReset` was introduced to keep the fix #24484 working.

I've been using the fix for the last 10 days without issues on my Fire TV Stick 4K Max 2nd gen.

Kodi-log after fix shows no error during resuming of audio engine: https://paste.kodi.tv/racuzilaju.kodi

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Fire TV Stick 4K Max 2nd gen, connected to AVR Denon AVC-X4800H, connected to TV LG C1. Fire TV is configured to stop outputting signal on sleep. Fire TV and Kodi are configured to output all audio formats as passthrough, using Kodi IEC packer. HDMI-passthrough and HDMI-Control (CEC) are disabled on AVR.

1. Start Kodi.
2. Make sure audio passthrough is configured in Kodi settings, using Kodi IEC packer.
3. Playback a video with multichannel audio such as Dolby Digital or DTS, check on AVR that the incoming signal is correct.
4. Stop video playback.
5. Switch off all devices using on/off button on Fire TV remote. If Fire TV is properly configured the AVR and TV will both switch off.
6. Wait a few seconds for sleep mode to activate.
7. Press on/off button on Fire TV remote to wake up Fire TV and switch on AVR and TV.
8. Kodi should be active.
9. Try to playback the same video.
10. Check incoming signal on AVR.
11. Go to Audio settings in Kodi. Check that Kodi IEC packer is still selected as audio passthrough device.

### Test results

#### Before fix

On step 10 AVR shows input signal as "PCM Stereo". On step 11 "Kodi IEC packer" disappears from the list of audio devices. Android IEC packer is shown instead (it doesn't work properly on Fire TV).

#### After fix

On step 10 AVR shows the same input signal as on step 3. On step 11 "Kodi IEC packer" is in the list of audio devices and it is selected as output device. Audio passthrough works correctly.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
More robust handling of sleep/wakeup states on Android fixes some remaining audio passthrough issues, happened with certain device combinations, in particular Fire TV connected to AVR.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
