### PR TITLE
[favourites][listproviders] Fix select action not to show the choose …

### DIFF
--- a/xbmc/favourites/GUIWindowFavourites.cpp
+++ b/xbmc/favourites/GUIWindowFavourites.cpp
@@ -138,6 +138,9 @@ bool CGUIWindowFavourites::OnSelect(int itemIdx)
   // video select action setting is for files only, except exec func is playmedia...
   if (targetItem.HasVideoInfoTag() && (!targetItem.m_bIsFolder || isPlayMedia))
   {
+    // play the given/default video version, even if multiple versions are available
+    targetItem.SetProperty("has_resolved_video_asset", true);
+
     CVideoSelectActionProcessor proc{std::make_shared<CFileItem>(targetItem)};
     if (proc.ProcessDefaultAction())
       return true;

--- a/xbmc/guilib/listproviders/DirectoryProvider.cpp
+++ b/xbmc/guilib/listproviders/DirectoryProvider.cpp
@@ -563,6 +563,9 @@ bool CDirectoryProvider::OnClick(const CGUIListItemPtr& item)
   // video select action setting is for files only, except exec func is playmedia...
   if (targetItem.HasVideoInfoTag() && (!targetItem.m_bIsFolder || isPlayMedia))
   {
+    // play the given/default video version, even if multiple versions are available
+    targetItem.SetProperty("has_resolved_video_asset", true);
+
     CVideoSelectActionProcessor proc{*this, std::make_shared<CFileItem>(targetItem)};
     if (proc.ProcessDefaultAction())
       return true;


### PR DESCRIPTION
…video version dialog for movies with multiple versions but to directly play the version.

Fixes #24628 

Runtime-tested on macOS, latest Kodi master.

@CrystalP please review.