### PR TITLE
[Keyboard] Fix special handling of Num Lock states for XKB common library

### DIFF
--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
@@ -18,6 +18,7 @@
 #include "input/joysticks/JoystickUtils.h"
 #include "input/joysticks/interfaces/IButtonMap.h"
 #include "input/joysticks/interfaces/IButtonMapCallback.h"
+#include "input/keyboard/KeyboardTranslator.h"
 #include "input/keymaps/interfaces/IKeymap.h"
 #include "input/keymaps/keyboard/KeyboardActionMap.h"
 #include "peripherals/Peripherals.h"
@@ -110,7 +111,7 @@ bool CGUIConfigurationWizard::Abort(bool bWait /* = true */)
 void CGUIConfigurationWizard::RegisterKey(const CPhysicalFeature& key)
 {
   if (key.Keycode() != XBMCK_UNKNOWN)
-    m_keyMap[key.Keycode()] = key;
+    m_keyMap[KEYBOARD::CKeyboardTranslator::TranslateKeycode(key.Keycode())] = key;
 }
 
 void CGUIConfigurationWizard::UnregisterKeys()
@@ -266,7 +267,8 @@ bool CGUIConfigurationWizard::MapPrimitive(JOYSTICK::IButtonMap* buttonMap,
       {
         if (primitive.Type() == PRIMITIVE_TYPE::KEY)
         {
-          auto it = m_keyMap.find(primitive.Keycode());
+          auto it =
+              m_keyMap.find(KEYBOARD::CKeyboardTranslator::TranslateKeycode(primitive.Keycode()));
           if (it != m_keyMap.end())
           {
             const CPhysicalFeature& key = it->second;

--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.h
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.h
@@ -115,7 +115,7 @@ private:
 
   // Keyboard handling
   std::unique_ptr<KEYMAP::IKeyboardActionMap> m_actionMap;
-  std::map<XBMCKey, CPhysicalFeature> m_keyMap; // Keycode -> feature
+  std::map<std::string, CPhysicalFeature> m_keyMap; // Key symbol -> feature
 };
 } // namespace GAME
 } // namespace KODI

--- a/xbmc/input/keyboard/KeyboardTranslator.cpp
+++ b/xbmc/input/keyboard/KeyboardTranslator.cpp
@@ -176,6 +176,7 @@ const char* CKeyboardTranslator::TranslateKeycode(XBMCKey keycode)
     case XBMCK_BACKSPACE:
       return KEY_SYMBOL_BACKSPACE;
     case XBMCK_TAB:
+    case XBMCK_XKB_KP_TAB:
       return KEY_SYMBOL_TAB;
     case XBMCK_CLEAR:
       return KEY_SYMBOL_CLEAR;
@@ -186,6 +187,7 @@ const char* CKeyboardTranslator::TranslateKeycode(XBMCKey keycode)
     case XBMCK_ESCAPE:
       return KEY_SYMBOL_ESCAPE;
     case XBMCK_SPACE:
+    case XBMCK_XKB_KP_SPACE:
       return KEY_SYMBOL_SPACE;
     case XBMCK_EXCLAIM:
       return KEY_SYMBOL_EXCLAIM;
@@ -324,38 +326,66 @@ const char* CKeyboardTranslator::TranslateKeycode(XBMCKey keycode)
     case XBMCK_DELETE:
       return KEY_SYMBOL_DELETE;
     case XBMCK_KP0:
+    case XBMCK_XKB_KP_INSERT: // numlock disabled
+    case XBMCK_XKB_KP0: // numlock enabled
       return KEY_SYMBOL_KP0;
     case XBMCK_KP1:
+    case XBMCK_XKB_KP_END: // numlock disabled
+    case XBMCK_XKB_KP1: // numlock enabled
       return KEY_SYMBOL_KP1;
     case XBMCK_KP2:
+    case XBMCK_XKB_KP_DOWN: // numlock disabled
+    case XBMCK_XKB_KP2: // numlock enabled
       return KEY_SYMBOL_KP2;
     case XBMCK_KP3:
+    case XBMCK_XKB_KP_PAGE_DOWN: // numlock disabled
+    case XBMCK_XKB_KP3: // numlock enabled
       return KEY_SYMBOL_KP3;
     case XBMCK_KP4:
+    case XBMCK_XKB_KP_LEFT: // numlock disabled
+    case XBMCK_XKB_KP4: // numlock enabled
       return KEY_SYMBOL_KP4;
     case XBMCK_KP5:
+    case XBMCK_XKB_KP_BEGIN: // numlock disabled
+    case XBMCK_XKB_KP5: // numlock enabled
       return KEY_SYMBOL_KP5;
     case XBMCK_KP6:
+    case XBMCK_XKB_KP_RIGHT: // numlock disabled
+    case XBMCK_XKB_KP6: // numlock enabled
       return KEY_SYMBOL_KP6;
     case XBMCK_KP7:
+    case XBMCK_XKB_KP_HOME: // numlock disabled
+    case XBMCK_XKB_KP7: // numlock enabled
       return KEY_SYMBOL_KP7;
     case XBMCK_KP8:
+    case XBMCK_XKB_KP_UP: // numlock disabled
+    case XBMCK_XKB_KP8: // numlock enabled
       return KEY_SYMBOL_KP8;
     case XBMCK_KP9:
+    case XBMCK_XKB_KP_PAGE_UP: // numlock disabled
+    case XBMCK_XKB_KP9: // numlock enabled
       return KEY_SYMBOL_KP9;
     case XBMCK_KP_PERIOD:
+    case XBMCK_XKB_KP_DELETE: // numlock disabled
+    case XBMCK_XKB_KP_DECIMAL: // numlock enabled
       return KEY_SYMBOL_KPPERIOD;
     case XBMCK_KP_DIVIDE:
+    case XBMCK_XKB_KP_DIVIDE:
       return KEY_SYMBOL_KPDIVIDE;
     case XBMCK_KP_MULTIPLY:
+    case XBMCK_XKB_KP_MULTIPLY:
       return KEY_SYMBOL_KPMULTIPLY;
     case XBMCK_KP_MINUS:
+    case XBMCK_XKB_KP_SUBTRACT:
       return KEY_SYMBOL_KPMINUS;
     case XBMCK_KP_PLUS:
+    case XBMCK_XKB_KP_ADD:
       return KEY_SYMBOL_KPPLUS;
     case XBMCK_KP_ENTER:
+    case XBMCK_XKB_KP_ENTER:
       return KEY_SYMBOL_KPENTER;
     case XBMCK_KP_EQUALS:
+    case XBMCK_XKB_KP_EQUALS:
       return KEY_SYMBOL_KPEQUALS;
     case XBMCK_UP:
       return KEY_SYMBOL_UP;
@@ -376,12 +406,16 @@ const char* CKeyboardTranslator::TranslateKeycode(XBMCKey keycode)
     case XBMCK_PAGEDOWN:
       return KEY_SYMBOL_PAGEDOWN;
     case XBMCK_F1:
+    case XBMCK_XKB_KP_F1:
       return KEY_SYMBOL_F1;
     case XBMCK_F2:
+    case XBMCK_XKB_KP_F2:
       return KEY_SYMBOL_F2;
     case XBMCK_F3:
+    case XBMCK_XKB_KP_F3:
       return KEY_SYMBOL_F3;
     case XBMCK_F4:
+    case XBMCK_XKB_KP_F4:
       return KEY_SYMBOL_F4;
     case XBMCK_F5:
       return KEY_SYMBOL_F5;

--- a/xbmc/input/keyboard/XBMC_keysym.h
+++ b/xbmc/input/keyboard/XBMC_keysym.h
@@ -16,13 +16,13 @@
 
 // The XBMC_keysym identifies a physical key on the keyboard i.e. it is
 // analogous to a scan code but is hardware independent.
-// These values are bazsed on the SDL_keysym standards, see:
+// These values are based on the SDL_keysym standards, see:
 //
 //   http://www.libsdl.org/tmp/SDL-1.3-docs/SDL__keysym_8h.html
 //
 // On SDL_KEYDOWN messages the keysym.sym will be one of these values.
 //
-// On OSs that don't support SDL (i.e. Windows) the OS dependant key
+// On OSs that don't support SDL (i.e. Windows) the OS dependent key
 // handling code converts keypresses to an XBMC_keysym value.
 
 enum XBMCKey

--- a/xbmc/input/keyboard/XBMC_keysym.h
+++ b/xbmc/input/keyboard/XBMC_keysym.h
@@ -284,6 +284,63 @@ enum XBMCKey
   XBMCK_FASTFORWARD = 343,
   XBMCK_EJECT = 344,
 
+  /*
+   * Extended keypad key symbols for Num Lock state-specific behaviors
+   *
+   * These key symbols address the dual behavior of the numeric keypad's keys,
+   * observed within the context of the Linux platform, using the XKB common
+   * library.
+   *
+   * Depending on the Num Lock state — enabled or disabled — the key on the
+   * numeric keypad emits different keycodes.
+   */
+  XBMCK_XKB_KP_HOME = 0xFF95, // XBMCK_KP7
+  XBMCK_XKB_KP_LEFT = 0xFF96, // XBMCK_KP4
+  XBMCK_XKB_KP_UP = 0xFF97, // XBMCK_KP8
+  XBMCK_XKB_KP_RIGHT = 0xFF98, // XBMCK_KP6
+  XBMCK_XKB_KP_DOWN = 0xFF99, // XBMCK_KP2
+  XBMCK_XKB_KP_PAGE_UP = 0xFF9A, // XBMCK_KP9
+  XBMCK_XKB_KP_PAGE_DOWN = 0xFF9B, // XBMCK_KP3
+  XBMCK_XKB_KP_END = 0xFF9C, // XBMCK_KP1
+  XBMCK_XKB_KP_BEGIN = 0xFF9D, // XBMCK_KP5
+  XBMCK_XKB_KP_INSERT = 0xFF9E, // XBMCK_KP0
+  XBMCK_XKB_KP_DELETE = 0xFF9F, // XBMCK_KP_PERIOD
+
+  XBMCK_XKB_KP_DECIMAL = 0xFFAE, // XBMCK_KP_PERIOD
+  XBMCK_XKB_KP0 = 0xFFB0, // XBMCK_KP0
+  XBMCK_XKB_KP1 = 0xFFB1, // XBMCK_KP1
+  XBMCK_XKB_KP2 = 0xFFB2, // XBMCK_KP2
+  XBMCK_XKB_KP3 = 0xFFB3, // XBMCK_KP3
+  XBMCK_XKB_KP4 = 0xFFB4, // XBMCK_KP4
+  XBMCK_XKB_KP5 = 0xFFB5, // XBMCK_KP5
+  XBMCK_XKB_KP6 = 0xFFB6, // XBMCK_KP6
+  XBMCK_XKB_KP7 = 0xFFB7, // XBMCK_KP7
+  XBMCK_XKB_KP8 = 0xFFB8, // XBMCK_KP8
+  XBMCK_XKB_KP9 = 0xFFB9, // XBMCK_KP9
+
+  /*
+   * Extended keypad key symbols for Num Lock state-independent behaviors
+   *
+   * These key symbols address the behavior of the numeric keypad's keys,
+   * observed within the context of the Linux platform, using the XKB common
+   * library.
+   *
+   * The keycodes emitted by these keys are independent of the Num Lock state.
+   */
+  XBMCK_XKB_KP_SPACE = 0xFF80,
+  XBMCK_XKB_KP_TAB = 0xFF89,
+  XBMCK_XKB_KP_ENTER = 0xFF8D, // XBMCK_KP_ENTER
+  XBMCK_XKB_KP_F1 = 0xFF91,
+  XBMCK_XKB_KP_F2 = 0xFF92,
+  XBMCK_XKB_KP_F3 = 0xFF93,
+  XBMCK_XKB_KP_F4 = 0xFF94,
+  XBMCK_XKB_KP_EQUALS = 0xFFBD, // XBMCK_KP_EQUALS
+  XBMCK_XKB_KP_MULTIPLY = 0xFFAA, // XBMCK_KP_MULTIPLY
+  XBMCK_XKB_KP_ADD = 0xFFAB, // XBMCK_KP_PLUS
+  XBMCK_XKB_KP_SEPARATOR = 0xFFAC,
+  XBMCK_XKB_KP_SUBTRACT = 0xFFAD, // XBMCK_KP_MINUS
+  XBMCK_XKB_KP_DIVIDE = 0xFFAF, // XBMCK_KP_DIVIDE
+
   XBMCK_LAST
 };
 

--- a/xbmc/input/keyboard/XBMC_keytable.cpp
+++ b/xbmc/input/keyboard/XBMC_keytable.cpp
@@ -19,6 +19,7 @@ namespace
 {
 // The array of XBMCKEYTABLEs used in XBMC.
 // scancode, sym, unicode, ascii, vkey, keyname
+// clang-format off
 static const XBMCKEYTABLE XBMCKeyTable[] = {
     {XBMCK_BACKSPACE, 0, 0, XBMCVK_BACK, "backspace"},
     {XBMCK_TAB, 0, 0, XBMCVK_TAB, "tab"},
@@ -247,7 +248,59 @@ static const XBMCKEYTABLE XBMCKeyTable[] = {
     {XBMCK_FAVORITES, 0, 0, XBMCVK_FAVORITES, "favorites"},
     {XBMCK_HOMEPAGE, 0, 0, XBMCVK_HOMEPAGE, "homepage"},
     {XBMCK_CONFIG, 0, 0, XBMCVK_CONFIG, "config"},
-    {XBMCK_EPG, 0, 0, XBMCVK_EPG, "epg"}};
+    {XBMCK_EPG, 0, 0, XBMCVK_EPG, "epg"},
+
+    /*
+     * Numpad extended keypad keys at table end
+     *
+     * They are appended to the end of this key table to ensure backward
+     * compatibility and minimize disruption to existing keycode mappings.
+     */
+
+    // Extended keypad key symbols for Num Lock state-specific behaviors, with
+    // Num Lock disabled
+    {XBMCK_XKB_KP_HOME, 0, 0, XBMCVK_HOME, "home"},
+    {XBMCK_XKB_KP_LEFT, 0, 0, XBMCVK_LEFT, "left"},
+    {XBMCK_XKB_KP_UP, 0, 0, XBMCVK_UP, "up"},
+    {XBMCK_XKB_KP_RIGHT, 0, 0, XBMCVK_RIGHT, "right"},
+    {XBMCK_XKB_KP_DOWN, 0, 0, XBMCVK_DOWN, "down"},
+    {XBMCK_XKB_KP_PAGE_UP, 0, 0, XBMCVK_PAGEUP, "pageup"},
+    {XBMCK_XKB_KP_PAGE_DOWN, 0, 0, XBMCVK_PAGEDOWN, "pagedown"},
+    {XBMCK_XKB_KP_END, 0, 0, XBMCVK_END, "end"},
+    {XBMCK_XKB_KP_BEGIN, 0, 0, XBMCVK_HOME, "home"},
+    {XBMCK_XKB_KP_INSERT, 0, 0, XBMCVK_INSERT, "insert"},
+    {XBMCK_XKB_KP_DELETE, 0, 0, XBMCVK_DELETE, "delete"},
+
+    // Extended keypad key symbols for Num Lock state-specific behaviors, with
+    // Num Lock enabled
+    {XBMCK_XKB_KP_DECIMAL, '.', '.', XBMCVK_NUMPADPERIOD, "numpadperiod"},
+    {XBMCK_XKB_KP0, '0', '0', XBMCVK_NUMPAD0, "numpadzero"},
+    {XBMCK_XKB_KP1, '1', '1', XBMCVK_NUMPAD1, "numpadone"},
+    {XBMCK_XKB_KP2, '2', '2', XBMCVK_NUMPAD2, "numpadtwo"},
+    {XBMCK_XKB_KP3, '3', '3', XBMCVK_NUMPAD3, "numpadthree"},
+    {XBMCK_XKB_KP4, '4', '4', XBMCVK_NUMPAD4, "numpadfour"},
+    {XBMCK_XKB_KP5, '5', '5', XBMCVK_NUMPAD5, "numpadfive"},
+    {XBMCK_XKB_KP6, '6', '6', XBMCVK_NUMPAD6, "numpadsix"},
+    {XBMCK_XKB_KP7, '7', '7', XBMCVK_NUMPAD7, "numpadseven"},
+    {XBMCK_XKB_KP8, '8', '8', XBMCVK_NUMPAD8, "numpadeight"},
+    {XBMCK_XKB_KP9, '9', '9', XBMCVK_NUMPAD9, "numpadnine"},
+
+    // Extended keypad key symbols for Num Lock state-independent behaviors
+    {XBMCK_XKB_KP_SPACE, ' ', ' ', XBMCVK_SPACE, "space"},
+    {XBMCK_XKB_KP_TAB, 0, 0, XBMCVK_TAB, "tab"},
+    {XBMCK_XKB_KP_ENTER, 0, 0, XBMCVK_NUMPADENTER, "enter"},
+    {XBMCK_XKB_KP_F1, 0, 0, XBMCVK_F1, "f1"},
+    {XBMCK_XKB_KP_F2, 0, 0, XBMCVK_F2, "f2"},
+    {XBMCK_XKB_KP_F3, 0, 0, XBMCVK_F3, "f3"},
+    {XBMCK_XKB_KP_F4, 0, 0, XBMCVK_F4, "f4"},
+    {XBMCK_XKB_KP_EQUALS, '=', '=', 0, "numpadequals"},
+    {XBMCK_XKB_KP_MULTIPLY, '*', '*', XBMCVK_NUMPADTIMES, "numpadtimes"},
+    {XBMCK_XKB_KP_ADD, '+', '+', XBMCVK_NUMPADPLUS, "numpadplus"},
+    {XBMCK_XKB_KP_SEPARATOR, 0, 0, 0, "numpadseparator"},
+    {XBMCK_XKB_KP_SUBTRACT, '-', '-', XBMCVK_NUMPADMINUS, "numpadminus"},
+    {XBMCK_XKB_KP_DIVIDE, '/', '/', XBMCVK_NUMPADDIVIDE, "numpaddivide"},
+};
+// clang-format on
 
 static int XBMCKeyTableSize = sizeof(XBMCKeyTable) / sizeof(XBMCKEYTABLE);
 } // namespace

--- a/xbmc/platform/android/activity/AndroidKey.cpp
+++ b/xbmc/platform/android/activity/AndroidKey.cpp
@@ -19,7 +19,7 @@
 
 typedef struct {
   int32_t nativeKey;
-  int16_t xbmcKey;
+  uint16_t xbmcKey;
 } KeyMap;
 
 static KeyMap keyMap[] = {


### PR DESCRIPTION
## Description

While testing https://github.com/kodi-game/controller-topology-project/pull/290, I noticed that my numpad wasn't working fully. Without numlock, no keys would work or map. With numlock, I could press keys in the GUI, but couldn't map them in the controller configuration utility.

The reason is because XKB uses an extended range of keycodes for the numpad in order to distinguish keycodes between when numlock is active and when it's not.

This PR adds the extended keycodes so that they work in the GUI (respecting numlock), and modifies the controller mapper and game input to be numlock-independent.

A more extensive explanation can be found the commit description:

```
This commit introduces enhanced handling for the numeric keypad's extended
keys, addressing dual behavior under different Num Lock states.

For example, the keypad's period key can emit different keycodes depending
on whether Num Lock is enabled or disabled — a behavior observed on Linux
systems using the XKB common library:

  - XBMCK_XKB_KP_DELETE is used when Num Lock is disabled,
    representing a delete function.

  - XBMCK_XKB_KP_DECIMAL is used when Num Lock is enabled, allowing for
    decimal point input.

These keys have been added to the keyboard mapping tables and are properly
handled in the keyboard translator to ensure consistent application and game
behavior across varying Num Lock states, enhancing compatibility and user
experience on systems exhibiting this dual-key behavior.
```

## Motivation and context

I'm working on getting Atari 800 input fully working.

Generic input, using the default controller/keyboard, was added in https://github.com/kodi-game/game.libretro.atari800/pull/5.

Now, I'm finishing the job for authentic Atari 800 input, with help from a forum user in the thread https://forum.kodi.tv/showthread.php?tid=376031.

## How has this been tested?

I performed two rounds of testing (Ubuntu 22.04/wayland): extensive testing with the delete/period key, and full integration testing with both a keyboard and numeric keypad.

### Testing with delete/period key

Before, the period key couldn't be mapped, neither with numlock enabled nor disabled. Attempting to map in either state would result in a bad buttonmap:

```xml
<buttonmap>
    <device name="Keyboard" provider="application">
        <controller id="game.controller.keyboard">
            <feature name="kpperiod" key="unknown" />
        </controller>
    </device>
</buttonmap>
```

After, without numlock (delete):

```xml
<feature name="kpperiod" key="kpperiod" />
```

After, with numlock (period):

```xml
<feature name="kpperiod" key="kpperiod" />
```

I also did in-depth testing in the GUI.

Before, without numlock (delete), no action would be performed:

```
debug <general>: Keyboard: scancode: 0x5b, sym: 0xff9f (unknown), unicode: 0x00, modifier: 0x0
debug <general>: GetActionCode: Trying Hardy keycode for 0xf200
 info <general>: Skipped 4 duplicate messages..
debug <general>: HandleKey: 0 (0xf200, obc-61697) pressed, trying keyboard action f000
debug <general>: GetActionCode: Trying Hardy keycode for 0xf200
 info <general>: Skipped 1 duplicate messages..
debug <general>: HandleKey: 0 (0xf200, obc-61697) pressed, window 10103, action is 
debug <general>: Keyboard: scancode: 0x5b, sym: 0xff9f (unknown), unicode: 0x00, modifier: 0x0
```

After, without numlock (delete), the delete action is successfully performed:

```
debug <general>: Keyboard: scancode: 0x5b, sym: 0xff9f (kpperiod), unicode: 0x00, modifier: 0x0
debug <general>: HandleKey: delete (0xf087) pressed, trying keyboard action f087
debug <general>: Keyboard: scancode: 0x5b, sym: 0xff9f (kpperiod), unicode: 0x00, modifier: 0x0
```

Before, with numlock (period), we see the correct input in the GUI but the key symbol is marked as `unknown` in the log:

```
debug <general>: Keyboard: scancode: 0x5b, sym: 0xffae (unknown), unicode: 0x2e, modifier: 0x0
debug <general>: HandleKey: period (0xf02e) pressed, trying keyboard action f200
debug <general>: Keyboard: scancode: 0x5b, sym: 0xff9f (unknown), unicode: 0x00, modifier: 0x0
```

After, with numlock (period), the GUI input is still correct, and we now see the correct key symbol:

```
debug <general>: Keyboard: scancode: 0x5b, sym: 0xffae (kpperiod), unicode: 0x2e, modifier: 0x0
debug <general>: HandleKey: numpadperiod (0xf066) pressed, trying keyboard action f200
debug <general>: Keyboard: scancode: 0x5b, sym: 0xff9f (kpperiod), unicode: 0x00, modifier: 0x0
```

### Integration testing

I tested two devices, an authentic Dell keyboard will the full set of keys for a US layout, and a Kinesis Freestyle 2 numeric keypad:

![Screenshot from 2024-02-03 14-42-28](https://github.com/xbmc/xbmc/assets/531482/7d2e7c09-4646-4740-983c-7803c61e2481)

Integration testing with keyboard, numlock disabled:

```xml
<buttonmap>
    <device name="Keyboard" provider="application">
        <controller id="game.controller.keyboard">
            <feature name="kp0" key="kp0" />
            <feature name="kp1" key="kp1" />
            <feature name="kp2" key="kp2" />
            <feature name="kp3" key="kp3" />
            <feature name="kp4" key="kp4" />
            <feature name="kp5" key="kp5" />
            <feature name="kp6" key="kp6" />
            <feature name="kp7" key="kp7" />
            <feature name="kp8" key="kp8" />
            <feature name="kp9" key="kp9" />
            <feature name="kpdivide" key="kpdivide" />
            <feature name="kpenter" key="kpenter" />
            <feature name="kpminus" key="kpminus" />
            <feature name="kpmultiply" key="kpmultiply" />
            <feature name="kpperiod" key="kpperiod" />
            <feature name="kpplus" key="kpplus" />
            <feature name="numlock" key="numlock" />
        </controller>
    </device>
</buttonmap>
```

Integration testing with keyboard, numlock enabled:

```xml
<buttonmap>
    <device name="Keyboard" provider="application">
        <controller id="game.controller.keyboard">
            <feature name="kp0" key="kp0" />
            <feature name="kp1" key="kp1" />
            <feature name="kp2" key="kp2" />
            <feature name="kp3" key="kp3" />
            <feature name="kp4" key="kp4" />
            <feature name="kp5" key="kp5" />
            <feature name="kp6" key="kp6" />
            <feature name="kp7" key="kp7" />
            <feature name="kp8" key="kp8" />
            <feature name="kp9" key="kp9" />
            <feature name="kpdivide" key="kpdivide" />
            <feature name="kpenter" key="kpenter" />
            <feature name="kpminus" key="kpminus" />
            <feature name="kpmultiply" key="kpmultiply" />
            <feature name="kpperiod" key="kpperiod" />
            <feature name="kpplus" key="kpplus" />
            <feature name="numlock" key="numlock" />
        </controller>
    </device>
</buttonmap>
```

Integration testing with numeric keypad, numlock disabled:

```xml
<buttonmap>
    <device name="Keyboard" provider="application">
        <controller id="game.controller.keyboard">
            <feature name="backspace" key="backspace" />
            <feature name="equals" key="equals" />
            <feature name="kp0" key="kp0" />
            <feature name="kp1" key="kp1" />
            <feature name="kp2" key="kp2" />
            <feature name="kp3" key="kp3" />
            <feature name="kp4" key="kp4" />
            <feature name="kp5" key="kp5" />
            <feature name="kp6" key="kp6" />
            <feature name="kp7" key="kp7" />
            <feature name="kp8" key="kp8" />
            <feature name="kp9" key="kp9" />
            <feature name="kpdivide" key="kpdivide" />
            <feature name="kpenter" key="kpenter" />
            <feature name="kpminus" key="kpminus" />
            <feature name="kpmultiply" key="kpmultiply" />
            <feature name="kpperiod" key="kpperiod" />
            <feature name="kpplus" key="kpplus" />
            <feature name="numlock" key="numlock" />
            <feature name="tab" key="tab" />
        </controller>
    </device>
</buttonmap>
```

Integration testing with numeric keypad, numlock enabled:

```xml
<buttonmap>
    <device name="Keyboard" provider="application">
        <controller id="game.controller.keyboard">
            <feature name="backspace" key="backspace" />
            <feature name="equals" key="equals" />
            <feature name="kp0" key="kp0" />
            <feature name="kp1" key="kp1" />
            <feature name="kp2" key="kp2" />
            <feature name="kp3" key="kp3" />
            <feature name="kp4" key="kp4" />
            <feature name="kp5" key="kp5" />
            <feature name="kp6" key="kp6" />
            <feature name="kp7" key="kp7" />
            <feature name="kp8" key="kp8" />
            <feature name="kp9" key="kp9" />
            <feature name="kpdivide" key="kpdivide" />
            <feature name="kpenter" key="kpenter" />
            <feature name="kpminus" key="kpminus" />
            <feature name="kpmultiply" key="kpmultiply" />
            <feature name="kpperiod" key="kpperiod" />
            <feature name="kpplus" key="kpplus" />
            <feature name="numlock" key="numlock" />
            <feature name="tab" key="tab" />
        </controller>
    </device>
</buttonmap>
```

Both devices now correctly perform navigation in the UI with numlock disabled, and the full set of keys still work with numlock enabled:

![Screenshot from 2024-02-03 14-20-18](https://github.com/xbmc/xbmc/assets/531482/b28eb6bd-d903-4813-b6de-d32f074d066c)

## What is the effect on users?

* Fixed numpad input on Linux with the XKB common library

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
