### PR TITLE
[FileCache] Implements adaptative read factor based on cache level

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -22296,7 +22296,7 @@ msgstr ""
 #. Description of setting #37107 "Read Factor"
 #: system/settings/settings.xml
 msgctxt "#37108"
-msgid "The read factor determines cache fill rate in terms of avg. bitrate of stream x Read Factor. Increasing this multiple, cache fills faster but more bandwidth is consumed. Large multiples may cause CPU spikes on some devices, saturate the connection and worsen performance."
+msgid "Determines cache fill rate in terms of avg. bitrate of stream x Read Factor. Increasing this multiple, cache fills faster. Large multiples may cause CPU spikes on some devices, saturate the connection and worsen performance.[CR][Adaptative] Uses dynamically calculated Read Factor based on cache level."
 msgstr ""
 
 #. Description of setting "Chunk Size"
@@ -22335,13 +22335,19 @@ msgctxt "#37114"
 msgid "Buffer all filesystems, including local files"
 msgstr ""
 
-#. Value of setting
+#. Value of setting #37105 "Memory Size"
 #: xbmc/settings/SevicesSettings.cpp
 msgctxt "#37115"
 msgid "Caches entire file on disk storage"
 msgstr ""
 
-#empty strings from id 37116 to 37119
+#. Value of setting #37107 "Read Factor"
+#: xbmc/settings/SevicesSettings.cpp
+msgctxt "#37116"
+msgid "Adaptative"
+msgstr ""
+
+#empty strings from id 37117 to 37119
 
 #. Value of setting - Byte
 #: xbmc/settings/SevicesSettings.cpp

--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -73,6 +73,7 @@ namespace XFILE
     uint32_t m_writeRateActual = 0;
     uint32_t m_writeRateLowSpeed = 0;
     int64_t m_forwardCacheSize = 0;
+    int64_t m_maxForward = 0;
     bool m_bFilling = false;
     std::atomic<int64_t> m_fileSize;
     unsigned int m_flags;

--- a/xbmc/settings/ServicesSettings.cpp
+++ b/xbmc/settings/ServicesSettings.cpp
@@ -73,6 +73,7 @@ void CServicesSettings::SettingOptionsReadFactorsFiller(const SettingConstPtr& s
                                                         int& current,
                                                         void* data)
 {
+  list.emplace_back(g_localizeStrings.Get(37116), 0);
   list.emplace_back("1.1x", 110);
   list.emplace_back("1.25x", 125);
   list.emplace_back("1.5x", 150);


### PR DESCRIPTION
## Description
Implements adaptative read factor based on cache level

## Motivation and context
Use low read factors works better on less powerful Android devices because prevents CPU spikes and saturate network connection when using high bitrate media content (80 - 90 Mbit/s).

But it also has two drawbacks:

1. It didn't work well on some files. Already fixed in https://github.com/xbmc/xbmc/pull/24582
2. Cache takes longer to fill ---> Improved in this PR.

We can use cache level variable to use more aggressive read factor when cache is empty and as it fills, lower the filling rate. Since 99% of the time the cache will be full during normal operation, the low read factor (1.5x) will be used and the behavior will be the same as with a static 1.5x read factor but the cache will have filled faster.

![read_factor](https://github.com/xbmc/xbmc/assets/58434170/838cce0f-134f-4018-8a6a-55a97d47494c)

As initial value is used 4.0x that is current setting default.

The algorithm is robust and tends to self-stabilize: if for any unknown reason the cache begins to empty, it will try to compensate by using a higher read factor.


## How has this been tested?
Runtime Windows x64 and Shield

## What is the effect on users?
More easy setup with read factor that should work good on all scenarios. Although not enabled by default yet.

## Screenshots (if appropriate):

![screenshot00001](https://github.com/xbmc/xbmc/assets/58434170/bca8bdaa-a1d7-4603-aa1f-0ac50c7756c2)

![adaptative](https://github.com/xbmc/xbmc/assets/58434170/d811b6b5-9632-4fd4-a0fa-a497002d617c)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
