### PR TITLE
[posix] PosixMountProvider excludes +efivarfs +systemd-1

### DIFF
--- a/xbmc/platform/posix/PosixMountProvider.cpp
+++ b/xbmc/platform/posix/PosixMountProvider.cpp
@@ -94,7 +94,7 @@ std::vector<std::string> CPosixMountProvider::GetDiskUsage()
   FILE* pipe = popen("df -h", "r");
 #endif
 
-  static const char* excludes[] = {"rootfs","devtmpfs","tmpfs","none","/dev/loop", "udev", NULL};
+  static const char* excludes[] = {"rootfs","devtmpfs","tmpfs","none","efivarfs","systemd-1","/dev/loop", "udev", NULL};
 
   if (pipe)
   {


### PR DESCRIPTION
## Description
On LibreELEC with busybox df System Information -> Storage shows more mounts then a coreutils df.
I excluded efivarfs and autofs (systemd-1) mounts.

## Motivation and context
Remove not needed lines in System Information -> Storage.

## How has this been tested?
LibreELEC master + kodi from this PR. Tested on a N100 x86_64 box.

## What is the effect on users?
The Storage Info does not show efivarfs or autofs (systemd-1) mounts anymore.

## Screenshots (if appropriate):
![screenshot-le12-before](https://github.com/xbmc/xbmc/assets/40174119/58e26ea4-d4e2-4298-90cc-2b1eca1eb3ca)
![screenshot-le12-after](https://github.com/xbmc/xbmc/assets/40174119/5f23367b-2cd9-442d-a506-b3b713e88e8e)

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [x] **None of the above** (please explain below)
It is a cosmetic change, but it touches code.

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
