### PR TITLE
don't try to set protocol options on a NFS URL

### DIFF
--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -365,6 +365,8 @@ void CURL::SetOptions(std::string strOptions)
 
 void CURL::SetProtocolOptions(std::string strOptions)
 {
+  if (AreProtocolOptionsProhibited())
+    return;
   m_strProtocolOptions.clear();
   m_protocolOptions.Clear();
   if (strOptions.length() > 0)
@@ -799,6 +801,8 @@ std::string CURL::GetProtocolOption(const std::string &key) const
 
 void CURL::SetProtocolOption(const std::string &key, const std::string &value)
 {
+  if (AreProtocolOptionsProhibited())
+    return;
   m_protocolOptions.AddOption(key, value);
   m_strProtocolOptions = m_protocolOptions.GetOptionsString(false);
 }
@@ -807,4 +811,9 @@ void CURL::RemoveProtocolOption(const std::string &key)
 {
   m_protocolOptions.RemoveOption(key);
   m_strProtocolOptions = m_protocolOptions.GetOptionsString(false);
+}
+
+bool CURL::AreProtocolOptionsProhibited() const
+{
+  return IsProtocol("nfs");
 }

--- a/xbmc/URL.h
+++ b/xbmc/URL.h
@@ -170,6 +170,7 @@ public:
   std::string GetProtocolOption(const std::string &key) const;
   void SetProtocolOption(const std::string &key, const std::string &value);
   void RemoveProtocolOption(const std::string &key);
+  bool AreProtocolOptionsProhibited() const;
 
 protected:
   int m_iPort = 0;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
[Recently](https://github.com/kodi-pvr/pvr.iptvsimple/commit/32c407ddc26a8884f4dc8e23d7647fd02f613382#diff-71bd6abbadcd63ab3bf527a5eeea4cd56d66179e58018fd28fd7d20a548d5df2) IPTVSimple addon started setting protocol option (timeout) on playlist URL. My playlist is on a NFS share and it couldn't be fetched any more after this change, as the protocol option ends up being appended to the raw URL causing filename component to be broken, see bug report #24618.

@phunkyfish has added a [workaround](https://github.com/kodi-pvr/pvr.iptvsimple/pull/831/commits/db67b1d47d9de4e66d3396b22e3077c116250c1c) to IPTVSimple, but this feels like curing symptom instead of the real cause. So this PR forbids setting protocol options on NFS URLs.

The issue is coming from [URIUtils::SubstitutePath](https://github.com/xbmc/xbmc/blob/827936d3f0cc2fc39499b3019586d4e7a10ef743/xbmc/utils/URIUtils.cpp#L506-L507-): on the first line we receive raw URL with options appended after `|`, and the CURL constructor on the next line doesn't parse them for NFS URLs.

I'm not entirely sure if this is the right approach. Another one would be actually parsing protocol options on NFS (even though they will never be read):

```diff
diff --cc xbmc/URL.cpp
index 99b661e36f,99b661e36f..d2c644c31f
--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@@ -187,6 -187,6 +187,8 @@@
    else if(IsProtocolEqual(strProtocol2, "ftp")
         || IsProtocolEqual(strProtocol2, "ftps"))
      sep = "?;|";
++  else if (IsProtocolEqual(strProtocol2, "nfs"))
++    sep = "|";
  
    if(sep)
    {
```

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- allows setting protocol options safely on any kind of URL
- resolves #24618

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
built and verified that IPTVSimple addon can fetch playlist over NFS again

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
using NFS URLs as remote addresses is completely safe


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
