### PR TITLE
[video] fill GUIListItem properties with streamdetails for the hybrid…

### DIFF
--- a/xbmc/video/VideoManagerTypes.h
+++ b/xbmc/video/VideoManagerTypes.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <string>
+
 enum class VideoAssetTypeOwner
 {
   UNKNOWN = -1,
@@ -33,6 +35,7 @@ static constexpr int VIDEO_VERSION_ID_BEGIN = 40400;
 static constexpr int VIDEO_VERSION_ID_END = 40800;
 static constexpr int VIDEO_VERSION_ID_DEFAULT = VIDEO_VERSION_ID_BEGIN;
 static constexpr int VIDEO_VERSION_ID_ALL = 0;
+static const std::string VIDEODB_PATH_VERSION_ID_ALL{"videodb://movies/videoversions/0"};
 
 struct VideoAssetInfo
 {

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -559,7 +559,9 @@ std::string CVideoThumbLoader::GetEmbeddedThumbURL(const CFileItem &item)
 
 void CVideoThumbLoader::DetectAndAddMissingItemData(CFileItem &item)
 {
-  if (item.m_bIsFolder) return;
+  // @todo remove exception for hybrid movie/folder of versions
+  if (item.m_bIsFolder && !StringUtils::StartsWith(item.GetPath(), VIDEODB_PATH_VERSION_ID_ALL))
+    return;
 
   if (item.HasVideoInfoTag())
   {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

The videotag stream details are not copied into item properties for folders.

Added an exception for the special hybrid movie/folders representing parent movies when the "Show versions as folder" setting is turned on. The properties will be populated using the stream details of the default version.

To be removed in v22 with better handling of versions.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Issue reported in the forum https://forum.kodi.tv/showthread.php?tid=337992&pid=3182306#pid3182306
Thanks @jjd-uk for the modified dialog to visualize the properties.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Regular folder, .. parent folder, movies without additional versions, movie sets, navigation from Versions node.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Skins that use listitem.property to retrieve audio stream details will have receive the information of the default version.

## Screenshots (if appropriate):

Before:
![image](https://github.com/xbmc/xbmc/assets/489377/ea9778b0-b3e1-4149-b356-e2c4c7e53d4c)


After:
![image](https://github.com/xbmc/xbmc/assets/489377/7cc21a7b-8945-4651-aa2f-996baa08cc5b)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
