### PR TITLE
[video] Fix the refresh of movies with additional versions or extras

### DIFF
--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -407,6 +407,12 @@ enum class ArtFallbackOptions
   PARENT
 };
 
+enum class DeleteMovieCascadeAction
+{
+  DEFAULT_VERSION,
+  ALL_ASSETS
+};
+
 #define COMPARE_PERCENTAGE     0.90f // 90%
 #define COMPARE_PERCENTAGE_MIN 0.50f // 50%
 
@@ -594,7 +600,9 @@ public:
 
   int UpdateDetailsForMovie(int idMovie, CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, const std::set<std::string> &updatedDetails);
 
-  void DeleteMovie(int idMovie, bool bKeepId = false);
+  void DeleteMovie(int idMovie,
+                   bool bKeepId = false,
+                   DeleteMovieCascadeAction action = DeleteMovieCascadeAction::ALL_ASSETS);
   void DeleteTvShow(int idTvShow, bool bKeepId = false);
   void DeleteTvShow(const std::string& strPath);
   void DeleteSeason(int idSeason, bool bKeepId = false);
@@ -1082,6 +1090,7 @@ public:
                          VideoAssetType assetType,
                          CFileItemList& items);
   bool GetDefaultVersionForVideo(VideoDbContentType itemType, int mediaId, CFileItem& item);
+  bool UpdateAssetsOwner(const std::string& mediaType, int dbIdSource, int dbIdTarget);
 
   int GetMovieId(const std::string& strFilenameAndPath);
   std::string GetMovieTitle(int idMovie);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

The Refresh button of the Info dialog deletes the movie from the database then recreates it with updated information.
With the automatic deletion cascade, all versions and extras linked with the movie are deleted at the same time as the movie but there is nothing to recreate them afterwards.

For v21, in order to avoid losing the additional versions and extras:
- Modified the movie delete trigger so that it only deletes the default version
  - cascading the delete to the other versions and the extras is now handled by DeleteMovie, conditional to a new parameter
  - videodb version bump is required to recreate the triggers
- Modifed the Refresh function to detect the presence of versions or extras and call a new videodb function to transfer the assets from the old movie id to the new movie id after the recreation.

This is a bit of a hack but there is nothing available to persist or recreate the assets so the only solution is to avoid their deletion from the database.

(calling DeleteMovie with bKeepId = true to avoid deleting the movie and triggering the deletion cascade doesn't work because the code then thinks there is no need to retrieve new data from the scraper and fixing that seemed to be a much bigger task)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Refreshing movie information in the Info dialog removes any additional version or extra set up by the user and they have to be added again manually, art must be selected again.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Movies with versions and/or extras, movies with single version and no extras.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Avoid surprising loss of data when refreshing movie information.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
