### PR TITLE
[video] Fix text of the context menu Choose version button

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -24081,8 +24081,7 @@ msgctxt "#40207"
 msgid "When enabled, a video with multiple versions will be shown as a folder in the video library. This folder can then be opened to display the individual video versions. When disabled, the configured select action will be applied."
 msgstr ""
 
-#. Choose video version context menu item label and dialog title
-#: xbmc/video/ContextMenus.h
+#. Choose video version dialog title
 #: xbmc/video/guilib/VideoVersionHelper.cpp
 msgctxt "#40208"
 msgid "Choose version: {}"
@@ -24162,7 +24161,13 @@ msgctxt "#40220"
 msgid "New extra name"
 msgstr ""
 
-#empty strings from id 40221 to 40399
+#. Choose video version context menu item label
+#: xbmc/video/ContextMenus.h
+msgctxt "#40221"
+msgid "Choose version"
+msgstr ""
+
+#empty strings from id 40222 to 40399
 
 # Video versions
 

--- a/xbmc/video/ContextMenus.h
+++ b/xbmc/video/ContextMenus.h
@@ -88,7 +88,7 @@ struct CVideoBrowse : CStaticContextMenuAction
 
 struct CVideoChooseVersion : CStaticContextMenuAction
 {
-  CVideoChooseVersion() : CStaticContextMenuAction(40208) {} // Choose version
+  CVideoChooseVersion() : CStaticContextMenuAction(40221) {} // Choose version
   bool IsVisible(const CFileItem& item) const override;
   bool Execute(const std::shared_ptr<CFileItem>& item) const override;
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Previous PR changed the message from "Choose version" to "Choose version: {}" for the dialog title but that doesn't work for the context menu button sharing the message.

Split the message into two messages.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Wrong text on the context menu Choose version button.

## Screenshots
Before:
![image](https://github.com/xbmc/xbmc/assets/489377/84fbf650-83e8-455f-b1d4-745a4bfd90ab)


After:
![image](https://github.com/xbmc/xbmc/assets/489377/3f794700-d2a8-4fc9-80c8-7e294b7904ea)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
