### PR TITLE
[MUSIC] Allow navigating from artist directly to songs via AS.xml setting

### DIFF
--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeArtist.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeArtist.cpp
@@ -12,6 +12,7 @@
 #include "ServiceBroker.h"
 #include "guilib/LocalizeStrings.h"
 #include "music/MusicDatabase.h"
+#include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 
@@ -25,7 +26,12 @@ CDirectoryNodeArtist::CDirectoryNodeArtist(const std::string& strName, CDirector
 
 NODE_TYPE CDirectoryNodeArtist::GetChildType() const
 {
-  return NODE_TYPE_ALBUM;
+  if (!CServiceBroker::GetSettingsComponent()
+           ->GetAdvancedSettings()
+           ->m_bMusicLibraryArtistNavigatesToSongs)
+    return NODE_TYPE_ALBUM;
+  else
+    return NODE_TYPE_SONG;
 }
 
 std::string CDirectoryNodeArtist::GetLocalizedName() const

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -315,6 +315,7 @@ void CAdvancedSettings::Initialize()
   m_videoItemSeparator = " / ";
   m_iMusicLibraryDateAdded = 1; // prefer mtime over ctime and current time
   m_bMusicLibraryUseISODates = false;
+  m_bMusicLibraryArtistNavigatesToSongs = false;
 
   m_bVideoLibraryAllItemsOnBottom = false;
   m_iVideoLibraryRecentlyAddedItems = 25;
@@ -790,6 +791,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetString(pElement, "itemseparator", m_musicItemSeparator);
     XMLUtils::GetInt(pElement, "dateadded", m_iMusicLibraryDateAdded);
     XMLUtils::GetBoolean(pElement, "useisodates", m_bMusicLibraryUseISODates);
+    XMLUtils::GetBoolean(pElement, "artistnavigatestosongs", m_bMusicLibraryArtistNavigatesToSongs);
     //Music artist name separators
     TiXmlElement* separators = pElement->FirstChildElement("artistseparators");
     if (separators)

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -246,6 +246,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_bMusicLibraryCleanOnUpdate;
     bool m_bMusicLibraryArtistSortOnUpdate;
     bool m_bMusicLibraryUseISODates;
+    bool m_bMusicLibraryArtistNavigatesToSongs;
     std::string m_strMusicLibraryAlbumFormat;
     bool m_prioritiseAPEv2tags;
     std::string m_musicItemSeparator;


### PR DESCRIPTION
## Description
As per the title, this allows users to skip navigating to albums from artists and goes directly to all the songs for an artist.
This works for any list of artists, so navigating via role -> composer -> artist -> songs also skips albums.

## Motivation and context
Was requested or at least suggested on the forum https://forum.kodi.tv/showthread.php?tid=375313 by a team member. I can see how this is useful in some situations and at some point I think it's a candidate for the context menu, but not at the moment as that would be too invasive at this point.

## How has this been tested?
Added the appropriate AS.xml setting and navigated through several screens of artists , composers, lyricists etc and in all cases, skipped the album node and navigated directly to songs.

## What is the effect on users?
Users can choose to navigate from an artist directly to a list of songs, skipping the album / disc parts.  This has to be enabled via AS.xml.  Other navigation paths (album, boxsets, top 100 etc) are not affected by this.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
