### PR TITLE
Optimize keyboard/mouse input on first action

### DIFF
--- a/xbmc/games/addons/input/GameClientKeyboard.cpp
+++ b/xbmc/games/addons/input/GameClientKeyboard.cpp
@@ -31,7 +31,7 @@ CGameClientKeyboard::CGameClientKeyboard(CGameClient& gameClient,
     m_inputProvider(inputProvider),
     m_keyboardActivity(std::make_unique<CControllerActivity>())
 {
-  m_inputProvider->RegisterKeyboardHandler(this, false);
+  m_inputProvider->RegisterKeyboardHandler(this, false, false);
 }
 
 CGameClientKeyboard::~CGameClientKeyboard()

--- a/xbmc/games/addons/input/GameClientMouse.cpp
+++ b/xbmc/games/addons/input/GameClientMouse.cpp
@@ -27,7 +27,7 @@ CGameClientMouse::CGameClientMouse(CGameClient& gameClient,
     m_inputProvider(inputProvider),
     m_mouseActivity(std::make_unique<CControllerActivity>())
 {
-  inputProvider->RegisterMouseHandler(this, false);
+  inputProvider->RegisterMouseHandler(this, false, false);
 }
 
 CGameClientMouse::~CGameClientMouse()

--- a/xbmc/games/agents/input/AgentJoystick.cpp
+++ b/xbmc/games/agents/input/AgentJoystick.cpp
@@ -9,6 +9,7 @@
 #include "AgentJoystick.h"
 
 #include "games/controllers/Controller.h"
+#include "games/controllers/ControllerIDs.h"
 #include "games/controllers/input/ControllerActivity.h"
 #include "input/joysticks/interfaces/IInputProvider.h"
 #include "peripherals/devices/Peripheral.h"
@@ -63,7 +64,7 @@ std::string CAgentJoystick::ControllerID(void) const
   if (m_controllerAppearance)
     return m_controllerAppearance->ID();
 
-  return "";
+  return DEFAULT_CONTROLLER_ID;
 }
 
 bool CAgentJoystick::HasFeature(const std::string& feature) const

--- a/xbmc/games/agents/input/AgentKeyboard.cpp
+++ b/xbmc/games/agents/input/AgentKeyboard.cpp
@@ -9,6 +9,7 @@
 #include "AgentKeyboard.h"
 
 #include "games/controllers/Controller.h"
+#include "games/controllers/ControllerIDs.h"
 #include "games/controllers/input/ControllerActivity.h"
 #include "input/keyboard/interfaces/IKeyboardInputProvider.h"
 #include "peripherals/devices/Peripheral.h"
@@ -32,7 +33,7 @@ void CAgentKeyboard::Initialize()
   KEYBOARD::IKeyboardInputProvider* inputProvider = m_peripheral.get();
 
   // Register input handler to silently observe all input
-  inputProvider->RegisterKeyboardHandler(this, true);
+  inputProvider->RegisterKeyboardHandler(this, true, true);
 }
 
 void CAgentKeyboard::Deinitialize()
@@ -59,10 +60,7 @@ float CAgentKeyboard::GetActivation() const
 
 std::string CAgentKeyboard::ControllerID(void) const
 {
-  if (m_controllerAppearance)
-    return m_controllerAppearance->ID();
-
-  return "";
+  return DEFAULT_KEYBOARD_ID;
 }
 
 bool CAgentKeyboard::HasKey(const KEYBOARD::KeyName& key) const

--- a/xbmc/games/agents/input/AgentMouse.cpp
+++ b/xbmc/games/agents/input/AgentMouse.cpp
@@ -9,6 +9,7 @@
 #include "AgentMouse.h"
 
 #include "games/controllers/Controller.h"
+#include "games/controllers/ControllerIDs.h"
 #include "games/controllers/input/ControllerActivity.h"
 #include "input/mouse/interfaces/IMouseInputProvider.h"
 #include "peripherals/devices/Peripheral.h"
@@ -32,7 +33,7 @@ void CAgentMouse::Initialize()
   MOUSE::IMouseInputProvider* inputProvider = m_peripheral.get();
 
   // Register input handler to silently observe all input
-  inputProvider->RegisterMouseHandler(this, true);
+  inputProvider->RegisterMouseHandler(this, true, true);
 }
 
 void CAgentMouse::Deinitialize()
@@ -59,10 +60,7 @@ float CAgentMouse::GetActivation() const
 
 std::string CAgentMouse::ControllerID(void) const
 {
-  if (m_controllerAppearance)
-    return m_controllerAppearance->ID();
-
-  return "";
+  return DEFAULT_MOUSE_ID;
 }
 
 bool CAgentMouse::OnMotion(const MOUSE::PointerName& relpointer, int differenceX, int differenceY)

--- a/xbmc/input/keyboard/interfaces/IKeyboardInputProvider.h
+++ b/xbmc/input/keyboard/interfaces/IKeyboardInputProvider.h
@@ -30,8 +30,12 @@ public:
    * \param handler The handler to receive keyboard input provided by this class
    * \param bPromiscuous True to observe all events without affecting the
    *        input's destination
+   * \param forceDefaultMap Always use the default keyboard buttonmap, avoiding
+   *        buttonmaps provided by add-ons
    */
-  virtual void RegisterKeyboardHandler(IKeyboardInputHandler* handler, bool bPromiscuous) = 0;
+  virtual void RegisterKeyboardHandler(IKeyboardInputHandler* handler,
+                                       bool bPromiscuous,
+                                       bool forceDefaultMap) = 0;
 
   /*!
    * \brief Unregisters handler from keyboard input

--- a/xbmc/input/mouse/interfaces/IMouseInputProvider.h
+++ b/xbmc/input/mouse/interfaces/IMouseInputProvider.h
@@ -30,8 +30,12 @@ public:
    * \param handler The handler to receive mouse input provided by this class
    * \param bPromiscuous True to observe all events without affecting
    *        subsequent handlers
+   * \param forceDefaultMap Always use the default keyboard buttonmap, avoiding
+   *        buttonmaps provided by add-ons
    */
-  virtual void RegisterMouseHandler(IMouseInputHandler* handler, bool bPromiscuous) = 0;
+  virtual void RegisterMouseHandler(IMouseInputHandler* handler,
+                                    bool bPromiscuous,
+                                    bool forceDefaultMap) = 0;
 
   /*!
    * \brief Unregisters handler from mouse input

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -624,24 +624,28 @@ void CPeripheral::UnregisterInputHandler(IInputHandler* handler)
 }
 
 void CPeripheral::RegisterKeyboardHandler(KEYBOARD::IKeyboardInputHandler* handler,
-                                          bool bPromiscuous)
+                                          bool bPromiscuous,
+                                          bool forceDefaultMap)
 {
   auto it = m_keyboardHandlers.find(handler);
   if (it == m_keyboardHandlers.end())
   {
     std::unique_ptr<KODI::KEYBOARD::IKeyboardDriverHandler> keyboardDriverHandler;
 
-    PeripheralAddonPtr addon = m_manager.GetAddonWithButtonMap(this);
-    if (addon)
+    if (!forceDefaultMap)
     {
-      std::unique_ptr<CAddonInputHandling> addonInput =
-          std::make_unique<CAddonInputHandling>(m_manager, this, std::move(addon), handler);
-      if (addonInput->Load())
-        keyboardDriverHandler = std::move(addonInput);
-    }
-    else
-    {
-      CLog::Log(LOGDEBUG, "Failed to locate add-on for \"{}\"", m_strLocation);
+      PeripheralAddonPtr addon = m_manager.GetAddonWithButtonMap(this);
+      if (addon)
+      {
+        std::unique_ptr<CAddonInputHandling> addonInput =
+            std::make_unique<CAddonInputHandling>(m_manager, this, std::move(addon), handler);
+        if (addonInput->Load())
+          keyboardDriverHandler = std::move(addonInput);
+      }
+      else
+      {
+        CLog::Log(LOGDEBUG, "Failed to locate add-on for \"{}\"", m_strLocation);
+      }
     }
 
     if (!keyboardDriverHandler)
@@ -670,24 +674,29 @@ void CPeripheral::UnregisterKeyboardHandler(KEYBOARD::IKeyboardInputHandler* han
   }
 }
 
-void CPeripheral::RegisterMouseHandler(MOUSE::IMouseInputHandler* handler, bool bPromiscuous)
+void CPeripheral::RegisterMouseHandler(MOUSE::IMouseInputHandler* handler,
+                                       bool bPromiscuous,
+                                       bool forceDefaultMap)
 {
   auto it = m_mouseHandlers.find(handler);
   if (it == m_mouseHandlers.end())
   {
     std::unique_ptr<KODI::MOUSE::IMouseDriverHandler> mouseDriverHandler;
 
-    PeripheralAddonPtr addon = m_manager.GetAddonWithButtonMap(this);
-    if (addon)
+    if (!forceDefaultMap)
     {
-      std::unique_ptr<CAddonInputHandling> addonInput =
-          std::make_unique<CAddonInputHandling>(m_manager, this, std::move(addon), handler);
-      if (addonInput->Load())
-        mouseDriverHandler = std::move(addonInput);
-    }
-    else
-    {
-      CLog::Log(LOGDEBUG, "Failed to locate add-on for \"{}\"", m_strLocation);
+      PeripheralAddonPtr addon = m_manager.GetAddonWithButtonMap(this);
+      if (addon)
+      {
+        std::unique_ptr<CAddonInputHandling> addonInput =
+            std::make_unique<CAddonInputHandling>(m_manager, this, std::move(addon), handler);
+        if (addonInput->Load())
+          mouseDriverHandler = std::move(addonInput);
+      }
+      else
+      {
+        CLog::Log(LOGDEBUG, "Failed to locate add-on for \"{}\"", m_strLocation);
+      }
     }
 
     if (!mouseDriverHandler)

--- a/xbmc/peripherals/devices/Peripheral.h
+++ b/xbmc/peripherals/devices/Peripheral.h
@@ -240,11 +240,14 @@ public:
 
   // implementation of IKeyboardInputProvider
   void RegisterKeyboardHandler(KODI::KEYBOARD::IKeyboardInputHandler* handler,
-                               bool bPromiscuous) override;
+                               bool bPromiscuous,
+                               bool forceDefaultMap) override;
   void UnregisterKeyboardHandler(KODI::KEYBOARD::IKeyboardInputHandler* handler) override;
 
   // implementation of IMouseInputProvider
-  void RegisterMouseHandler(KODI::MOUSE::IMouseInputHandler* handler, bool bPromiscuous) override;
+  void RegisterMouseHandler(KODI::MOUSE::IMouseInputHandler* handler,
+                            bool bPromiscuous,
+                            bool forceDefaultMap) override;
   void UnregisterMouseHandler(KODI::MOUSE::IMouseInputHandler* handler) override;
 
   virtual void RegisterJoystickButtonMapper(KODI::JOYSTICK::IButtonMapper* mapper);


### PR DESCRIPTION
## Description

### Problem

One of the changes in adding keyboard and mouse input to the Player Viewer in https://github.com/xbmc/xbmc/pull/24524 was that, when the keyboard/mouse is first detected (when a key is first pressed or the mouse first moves), an object is created to store keyboard/mouse state.

However, one of the unintended consequences of this is that the first object causes buttonmaps to be loaded by peripheral.joystick. This loads a bunch of tiny xml files. Before, this wasn't a problem for most users, because they were only loaded if a controller was connected, and they were always loaded off-thread.

However, now keyboard/mouse activity will also cause these XML files to be loaded. And worse, keyboard/mouse input happens on the main thread. I didn't notice any impact on my Core i9, but I could definitely see this being a big problem on an RPi and slow Android devices.

### Solution

I thought, darn, now I have to bust out asynchronous code and load everything off-thread, with all the synchronization headaches that comes with this. However, a previous change I made comes to the rescue, default keyboard/mouse buttonmaps:

* https://github.com/xbmc/xbmc/pull/24512.

So I just added a flag to force default buttonmaps, avoiding loading the XML files altogether.

## Motivation and context

Noticed when testing the new Atari controllers added in https://github.com/kodi-game/controller-topology-project/pull/292. I thought, hm, why are tons of XML files being loaded on startup before the new Atari controller layouts are even used.

## How has this been tested?

* Tested on Windows 10 by setting breakpoints and observing the buttonmaps are no longer loaded
* Reviewed the log on startup without controllers attached, and observed to buttonmaps being loaded

## What is the effect on users?

* It's only been two weeks since https://github.com/xbmc/xbmc/pull/24524 was merged, so probably no one noticed or cared.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
