### PR TITLE
[video] Fix video info dialog play button to always play the version …

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -753,11 +753,19 @@ protected:
 private:
   void Play()
   {
-    m_item->SetProperty("playlist_type_hint", PLAYLIST::TYPE_VIDEO);
-    const ContentUtils::PlayMode mode{m_item->GetProperty("CheckAutoPlayNextItem").asBoolean()
+    auto item{m_item};
+    if (item->m_bIsFolder && item->HasVideoVersions())
+    {
+      //! @todo get rid of "videos with versions as folder" hack!
+      item = std::make_shared<CFileItem>(*item);
+      item->m_bIsFolder = false;
+    }
+
+    item->SetProperty("playlist_type_hint", PLAYLIST::TYPE_VIDEO);
+    const ContentUtils::PlayMode mode{item->GetProperty("CheckAutoPlayNextItem").asBoolean()
                                           ? ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM
                                           : ContentUtils::PlayMode::PLAY_ONLY_THIS};
-    VIDEO_UTILS::PlayItem(m_item, "", mode);
+    VIDEO_UTILS::PlayItem(item, "", mode);
   }
 };
 } // unnamed namespace


### PR DESCRIPTION
…that info is displayed for, not to queue and play all versions of the movie when 'show videos with multiple versions as folder' is ON.

From an internal discussion (due to lack of time just copied over instead of rephrasing it here):

CrystalP
Another info dialog glitch: after opening Info from a movie with multiple versions, the Play button plays the first version of the list of versions, not the default. Weird because the version name and media info are from the default version.


ksooo
Only happens when "show movies with multiple versions as folder" is ON, right?


ksooo
What actually happens here is that all versions of the movie are queued in the video play list, because the item to play is a folder, and then playback starts with the first queued movie. Not intended behaviour, ofc. Just explaining what I found out what happens. Reason is one more time Kodi not being really prepared to handle items which represent a movie and a folder at the same time. And I'm convinced we will find more of those code paths. 

Runtime-tested on macOS, latest Kodi master.

@CrystalP please review (and runtime-test if you like).