### PR TITLE
[video][favourites][listproviders] Refactor play/select action processor choose video version control code

### DIFF
--- a/xbmc/favourites/GUIWindowFavourites.cpp
+++ b/xbmc/favourites/GUIWindowFavourites.cpp
@@ -138,9 +138,6 @@ bool CGUIWindowFavourites::OnSelect(int itemIdx)
   // video select action setting is for files only, except exec func is playmedia...
   if (targetItem.HasVideoInfoTag() && (!targetItem.m_bIsFolder || isPlayMedia))
   {
-    // play the given/default video version, even if multiple versions are available
-    targetItem.SetProperty("has_resolved_video_asset", true);
-
     CVideoSelectActionProcessor proc{std::make_shared<CFileItem>(targetItem)};
     if (proc.ProcessDefaultAction())
       return true;

--- a/xbmc/guilib/listproviders/DirectoryProvider.cpp
+++ b/xbmc/guilib/listproviders/DirectoryProvider.cpp
@@ -563,9 +563,6 @@ bool CDirectoryProvider::OnClick(const CGUIListItemPtr& item)
   // video select action setting is for files only, except exec func is playmedia...
   if (targetItem.HasVideoInfoTag() && (!targetItem.m_bIsFolder || isPlayMedia))
   {
-    // play the given/default video version, even if multiple versions are available
-    targetItem.SetProperty("has_resolved_video_asset", true);
-
     CVideoSelectActionProcessor proc{*this, std::make_shared<CFileItem>(targetItem)};
     if (proc.ProcessDefaultAction())
       return true;

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -235,12 +235,11 @@ bool CVideoChooseVersion::IsVisible(const CFileItem& item) const
 
 bool CVideoChooseVersion::Execute(const std::shared_ptr<CFileItem>& item) const
 {
-  // force selection dialog, regardless of any settings like 'Select default video version'
-  item->SetProperty("needs_resolved_video_asset", true);
   item->SetProperty("video_asset_type", static_cast<int>(VideoAssetType::VERSION));
   CVideoSelectActionProcessor proc{item};
+  // force selection dialog, regardless of any settings like 'Select default video version'
+  proc.EnforceVideoAssetSelect();
   const bool ret = proc.ProcessDefaultAction();
-  item->ClearProperty("needs_resolved_video_asset");
   item->ClearProperty("video_asset_type");
   return ret;
 }
@@ -358,19 +357,14 @@ void SetPathAndPlay(const std::shared_ptr<CFileItem>& item, PlayMode mode)
       }
     }
 
-    if (mode == PlayMode::PLAY_VERSION_USING)
-    {
-      // force video version selection dialog
-      itemCopy->SetProperty("needs_resolved_video_asset", true);
-    }
-    else
-    {
-      // play the given/default video version, if multiple versions are available
-      itemCopy->SetProperty("has_resolved_video_asset", true);
-    }
-
     const bool choosePlayer{mode == PlayMode::PLAY_USING || mode == PlayMode::PLAY_VERSION_USING};
     CVideoPlayActionProcessor proc{itemCopy, choosePlayer};
+    if (mode == PlayMode::PLAY_VERSION_USING)
+    {
+      // force selection dialog, regardless of any settings like 'Select default video version'
+      proc.EnforceVideoAssetSelect();
+    }
+
     if (mode == PlayMode::RESUME && (itemCopy->GetStartOffset() == STARTOFFSET_RESUME ||
                                      VIDEO_UTILS::GetItemResumeInformation(*item).isResumable))
       proc.ProcessAction(VIDEO::GUILIB::ACTION_RESUME);

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -25,9 +25,9 @@
 #include "video/VideoManagerTypes.h"
 #include "video/VideoUtils.h"
 #include "video/dialogs/GUIDialogVideoInfo.h"
+#include "video/guilib/VideoAssetHelper.h"
 #include "video/guilib/VideoPlayActionProcessor.h"
 #include "video/guilib/VideoSelectActionProcessor.h"
-#include "video/guilib/VideoVersionHelper.h"
 
 #include <utility>
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -8181,7 +8181,7 @@ bool CVideoDatabase::GetMoviesByWhere(const std::string& strBaseDir, const Filte
             path = RewriteVideoVersionURL(strBaseDir, movie);
           }
           // this is a certain version, no need to resolve (e.g. no version chooser on select)
-          pItem->SetProperty("has_resolved_video_asset", true);
+          pItem->SetProperty("has_resolved_video_version", true);
         }
 
         if (path.empty())

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -31,7 +31,7 @@
 #include "video/VideoDatabase.h"
 #include "video/VideoInfoTag.h"
 #include "video/VideoManagerTypes.h"
-#include "video/guilib/VideoVersionHelper.h"
+#include "video/guilib/VideoAssetHelper.h"
 
 #include <algorithm>
 #include <cstdlib>

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -58,8 +58,8 @@
 #include "video/VideoUtils.h"
 #include "video/dialogs/GUIDialogVideoManagerExtras.h"
 #include "video/dialogs/GUIDialogVideoManagerVersions.h"
+#include "video/guilib/VideoAssetHelper.h"
 #include "video/guilib/VideoPlayActionProcessor.h"
-#include "video/guilib/VideoVersionHelper.h"
 #include "video/windows/GUIWindowVideoNav.h"
 
 #include <algorithm>

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -812,9 +812,6 @@ void CGUIDialogVideoInfo::Play(bool resume)
   // close our dialog
   Close(true);
 
-  // play the current video version, even if multiple versions are available
-  m_movieItem->SetProperty("has_resolved_video_asset", true);
-
   if (resume)
   {
     CVideoPlayActionProcessor proc{m_movieItem};
@@ -841,8 +838,6 @@ void CGUIDialogVideoInfo::Play(bool resume)
       }
     }
   }
-
-  m_movieItem->ClearProperty("has_resolved_video_asset");
 }
 
 namespace

--- a/xbmc/video/guilib/CMakeLists.txt
+++ b/xbmc/video/guilib/CMakeLists.txt
@@ -1,10 +1,10 @@
 set(SOURCES VideoPlayActionProcessor.cpp
             VideoSelectActionProcessor.cpp
-            VideoVersionHelper.cpp)
+            VideoAssetHelper.cpp)
 
 set(HEADERS VideoAction.h
             VideoPlayActionProcessor.h
             VideoSelectActionProcessor.h
-            VideoVersionHelper.h)
+            VideoAssetHelper.h)
 
 core_add_library(video_guilib)

--- a/xbmc/video/guilib/VideoAssetHelper.cpp
+++ b/xbmc/video/guilib/VideoAssetHelper.cpp
@@ -6,7 +6,7 @@
  *  See LICENSES/README.md for more information.
  */
 
-#include "VideoVersionHelper.h"
+#include "VideoAssetHelper.h"
 
 #include "FileItem.h"
 #include "ServiceBroker.h"
@@ -182,7 +182,7 @@ std::shared_ptr<const CFileItem> CVideoChooser::ChooseVideo(CGUIDialogSelect& di
 }
 } // unnamed namespace
 
-std::shared_ptr<CFileItem> CVideoVersionHelper::ChooseVideoFromAssets(
+std::shared_ptr<CFileItem> CVideoAssetHelper::ChooseVideoFromAssets(
     const std::shared_ptr<CFileItem>& item)
 {
   std::shared_ptr<const CFileItem> video;

--- a/xbmc/video/guilib/VideoAssetHelper.cpp
+++ b/xbmc/video/guilib/VideoAssetHelper.cpp
@@ -183,7 +183,7 @@ std::shared_ptr<const CFileItem> CVideoChooser::ChooseVideo(CGUIDialogSelect& di
 } // unnamed namespace
 
 std::shared_ptr<CFileItem> CVideoAssetHelper::ChooseVideoFromAssets(
-    const std::shared_ptr<CFileItem>& item)
+    const std::shared_ptr<CFileItem>& item, VideoAssetSelectMode mode)
 {
   std::shared_ptr<const CFileItem> video;
 
@@ -218,7 +218,7 @@ std::shared_ptr<CFileItem> CVideoAssetHelper::ChooseVideoFromAssets(
 
   if (hasMultipleChoices)
   {
-    if (!item->GetProperty("needs_resolved_video_asset").asBoolean(false))
+    if (mode == VideoAssetSelectMode::ENABLE_AUTO_SELECT)
     {
       // auto select the default video version
       const auto settings{CServiceBroker::GetSettingsComponent()->GetSettings()};
@@ -248,8 +248,8 @@ std::shared_ptr<CFileItem> CVideoAssetHelper::ChooseVideoFromAssets(
       }
     }
 
-    if (!video && (item->GetProperty("needs_resolved_video_asset").asBoolean(false) ||
-                   !item->GetProperty("has_resolved_video_asset").asBoolean(false)))
+    if (!video && (mode == VideoAssetSelectMode::ENABLE_AUTO_SELECT ||
+                   mode == VideoAssetSelectMode::ENFORCE_SELECT))
     {
       CVideoChooser chooser{item};
 

--- a/xbmc/video/guilib/VideoAssetHelper.h
+++ b/xbmc/video/guilib/VideoAssetHelper.h
@@ -16,7 +16,7 @@ namespace VIDEO
 {
 namespace GUILIB
 {
-class CVideoVersionHelper
+class CVideoAssetHelper
 {
 public:
   static std::shared_ptr<CFileItem> ChooseVideoFromAssets(const std::shared_ptr<CFileItem>& item);

--- a/xbmc/video/guilib/VideoAssetHelper.h
+++ b/xbmc/video/guilib/VideoAssetHelper.h
@@ -16,10 +16,18 @@ namespace VIDEO
 {
 namespace GUILIB
 {
+enum class VideoAssetSelectMode
+{
+  NO_SELECT,
+  ENABLE_AUTO_SELECT,
+  ENFORCE_SELECT,
+};
+
 class CVideoAssetHelper
 {
 public:
-  static std::shared_ptr<CFileItem> ChooseVideoFromAssets(const std::shared_ptr<CFileItem>& item);
+  static std::shared_ptr<CFileItem> ChooseVideoFromAssets(const std::shared_ptr<CFileItem>& item,
+                                                          VideoAssetSelectMode mode);
 };
 } // namespace GUILIB
 

--- a/xbmc/video/guilib/VideoPlayActionProcessor.cpp
+++ b/xbmc/video/guilib/VideoPlayActionProcessor.cpp
@@ -33,15 +33,21 @@ bool CVideoPlayActionProcessorBase::ProcessDefaultAction()
 
 bool CVideoPlayActionProcessorBase::ProcessAction(Action action)
 {
-  m_userCancelled = false;
-
-  const auto movie{CVideoAssetHelper::ChooseVideoFromAssets(m_item)};
-  if (movie)
-    m_item = movie;
-  else
+  if (m_enforceVideoAssetSelect || m_enableVideoAssetAutoSelect)
   {
-    m_userCancelled = true;
-    return true; // User cancelled the select menu. We're done.
+    m_userCancelled = false;
+
+    const VideoAssetSelectMode mode{m_enforceVideoAssetSelect
+                                        ? VideoAssetSelectMode::ENFORCE_SELECT
+                                        : VideoAssetSelectMode::ENABLE_AUTO_SELECT};
+    const auto movie{CVideoAssetHelper::ChooseVideoFromAssets(m_item, mode)};
+    if (movie)
+      m_item = movie;
+    else
+    {
+      m_userCancelled = true;
+      return true; // User cancelled the select menu. We're done.
+    }
   }
 
   return Process(action);

--- a/xbmc/video/guilib/VideoPlayActionProcessor.cpp
+++ b/xbmc/video/guilib/VideoPlayActionProcessor.cpp
@@ -16,7 +16,7 @@
 #include "settings/SettingsComponent.h"
 #include "utils/Variant.h"
 #include "video/VideoUtils.h"
-#include "video/guilib/VideoVersionHelper.h"
+#include "video/guilib/VideoAssetHelper.h"
 
 using namespace VIDEO::GUILIB;
 
@@ -35,7 +35,7 @@ bool CVideoPlayActionProcessorBase::ProcessAction(Action action)
 {
   m_userCancelled = false;
 
-  const auto movie{CVideoVersionHelper::ChooseVideoFromAssets(m_item)};
+  const auto movie{CVideoAssetHelper::ChooseVideoFromAssets(m_item)};
   if (movie)
     m_item = movie;
   else

--- a/xbmc/video/guilib/VideoPlayActionProcessor.h
+++ b/xbmc/video/guilib/VideoPlayActionProcessor.h
@@ -27,6 +27,9 @@ public:
   bool ProcessDefaultAction();
   bool ProcessAction(Action action);
 
+  void EnableVideoAssetAutoSelect() { m_enableVideoAssetAutoSelect = true; }
+  void EnforceVideoAssetSelect() { m_enforceVideoAssetSelect = true; }
+
   bool UserCancelled() const { return m_userCancelled; }
 
   static Action ChoosePlayOrResume(const CFileItem& item);
@@ -39,6 +42,8 @@ protected:
   virtual bool OnPlaySelected() = 0;
 
   std::shared_ptr<CFileItem> m_item;
+  bool m_enableVideoAssetAutoSelect{false};
+  bool m_enforceVideoAssetSelect{false};
   bool m_userCancelled{false};
 
 private:

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -59,9 +59,9 @@
 #include "video/VideoManagerTypes.h"
 #include "video/VideoUtils.h"
 #include "video/dialogs/GUIDialogVideoInfo.h"
+#include "video/guilib/VideoAssetHelper.h"
 #include "video/guilib/VideoPlayActionProcessor.h"
 #include "video/guilib/VideoSelectActionProcessor.h"
-#include "video/guilib/VideoVersionHelper.h"
 #include "view/GUIViewState.h"
 
 #include <memory>

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -616,6 +616,12 @@ bool CGUIWindowVideoBase::OnFileAction(int iItem, Action action, const std::stri
     return false;
 
   CVideoSelectActionProcessor proc(*this, item, iItem, player);
+  if (item->HasVideoVersions() && !item->GetProperty("has_resolved_video_version").asBoolean(false))
+  {
+    // For movies with multiple versions, enable auto selection of default versions (setting)
+    // or selection dialog
+    proc.EnableVideoAssetAutoSelect();
+  }
   return proc.ProcessAction(action);
 }
 
@@ -1474,7 +1480,7 @@ void CGUIWindowVideoBase::UpdateVideoVersionItems()
       int videoVersionId{-1};
       if (item->IsVideoDb() && item->GetVideoInfoTag()->HasVideoVersions())
       {
-        if (item->GetProperty("has_resolved_video_asset").asBoolean(false))
+        if (item->GetProperty("has_resolved_video_version").asBoolean(false))
         {
           // certain version of the movie
           videoVersionId = item->GetVideoInfoTag()->GetAssetInfo().GetId();

--- a/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
+++ b/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
@@ -427,11 +427,8 @@ bool CGUIWindowVideoPlaylist::OnPlayMedia(int iItem, const std::string& player)
   else
   {
     const auto item{m_vecItems->Get(iItem)};
-    // play the current video version, even if multiple versions are available
-    item->SetProperty("has_resolved_video_asset", true);
     CVideoPlayActionProcessor proc{item, iItem, player};
     proc.ProcessDefaultAction();
-    item->ClearProperty("has_resolved_video_asset");
   }
   return true;
 }


### PR DESCRIPTION
Some (final) cleanup before beta 3 release:

1. Rename CVideoVersionHelper to CVideoAssetHelper, incl. file names.
2. Refactor play/select action processor choose video version control code, changing default behaviour from 'choose' to 'not choose', because not choosing is majority of use cases. Cleans up the code for better readability and maintainability.

No intend functional change in this Pr.

Runtime-tested on macOS, latest Kodi master.

@CrystalP could you please review, ideally runtime-test?