### PR TITLE
[video] Fix 'play version using' version select dialog having 'extras' button.

### DIFF
--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -446,7 +446,7 @@ bool CVideoPlayVersionUsing::IsVisible(const CFileItem& item) const
 bool CVideoPlayVersionUsing::Execute(const std::shared_ptr<CFileItem>& itemIn) const
 {
   const auto item{std::make_shared<CFileItem>(itemIn->GetItemToPlay())};
-  item->SetProperty("video_asset_type", "version");
+  item->SetProperty("video_asset_type", static_cast<int>(VideoAssetType::VERSION));
   SetPathAndPlay(item, PlayMode::PLAY_VERSION_USING);
   return true;
 }


### PR DESCRIPTION
"Extras" button is not wanted in the select dialog that opens for context menu item 'Play version using'.  

Bug most probably slipped in while changing type of item property "video_asset_type" from string to int which happened during review of another PR.

Runtime-tested on macOS, latest Kodi master.

@CrystalP can you please review.