### PR TITLE
[video][Estuary] Info Dialog Versions and Extras Changes

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -24026,7 +24026,13 @@ msgctxt "#40038"
 msgid "The default version of a movie with multiple versions cannot be added to another movie. Please move or remove the other versions first."
 msgstr ""
 
-#empty strings with id 40039 to 40199
+#. Manage video extras context menu item
+#: xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+msgctxt "#40039"
+msgid "Manage extras"
+msgstr ""
+
+#empty strings with id 40040 to 40199
 
 #. Select default video version setting
 #: system/settings/settings.xml

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -951,7 +951,6 @@ msgstr ""
 
 #. generic "play" (some sort of media) label used in different places
 #: addons/skin.estuary/xml/DialogVideoInfo.xml
-#: addons/skin.estuary/xml/DialogVideoManager.xml
 #: addons/skin.estuary/xml/SkinSettings.xml
 #: addons/skin.estuary/xml/Variables.xml
 #: xbmc/dialogs/GUIDialogPlayEject.cpp

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -24095,7 +24095,6 @@ msgid "Play version using..."
 msgstr ""
 
 #. Button label for video versions
-#: addons/skin.estuary/xml/DialogVideoInfo.xml
 #: xbmc/video/guilib/VideoVersionHelper.cpp
 msgctxt "#40210"
 msgid "Versions"

--- a/addons/skin.estuary/xml/DialogVideoInfo.xml
+++ b/addons/skin.estuary/xml/DialogVideoInfo.xml
@@ -540,12 +540,6 @@
 						<param name="label" value="$VAR[VideoInfoPlayButtonLabelVar]" />
 					</include>
 					<include content="InfoDialogButton">
-						<param name="id" value="14" />
-						<param name="icon" value="icons/infodialogs/versions.png" />
-						<param name="label" value="$LOCALIZE[40210]" />
-						<param name="visible" value="Control.IsEnabled(14)" />
-					</include>
-					<include content="InfoDialogButton">
 						<param name="id" value="15" />
 						<param name="icon" value="icons/infodialogs/extras.png" />
 						<param name="label" value="$LOCALIZE[40211]" />

--- a/addons/skin.estuary/xml/DialogVideoInfo.xml
+++ b/addons/skin.estuary/xml/DialogVideoInfo.xml
@@ -540,6 +540,18 @@
 						<param name="label" value="$VAR[VideoInfoPlayButtonLabelVar]" />
 					</include>
 					<include content="InfoDialogButton">
+						<param name="id" value="14" />
+						<param name="icon" value="icons/infodialogs/versions.png" />
+						<param name="label" value="$LOCALIZE[40210]" />
+						<param name="visible" value="Control.IsEnabled(14)" />
+					</include>
+					<include content="InfoDialogButton">
+						<param name="id" value="15" />
+						<param name="icon" value="icons/infodialogs/extras.png" />
+						<param name="label" value="$LOCALIZE[40211]" />
+						<param name="visible" value="Control.IsEnabled(15)" />
+					</include>
+					<include content="InfoDialogButton">
 						<param name="id" value="11" />
 						<param name="icon" value="icons/infodialogs/trailer.png" />
 						<param name="label" value="$LOCALIZE[20410]" />
@@ -622,18 +634,6 @@
 						<param name="onclick_2" value="ActivateWindow(Music,musicdb://albums/?artist=$INFO[ListItem.Artist]&amp;albumartistonly=true&amp;compilation=false)" />
 						<param name="label" value="$LOCALIZE[132]" />
 						<param name="visible" value="String.IsEqual(ListItem.DBType,musicvideo)" />
-					</include>
-					<include content="InfoDialogButton">
-						<param name="id" value="14" />
-						<param name="icon" value="icons/infodialogs/versions.png" />
-						<param name="label" value="$LOCALIZE[40000]" />
-						<param name="visible" value="Control.IsEnabled(14)" />
-					</include>
-					<include content="InfoDialogButton">
-						<param name="id" value="15" />
-						<param name="icon" value="icons/infodialogs/extras.png" />
-						<param name="label" value="$LOCALIZE[40211]" />
-						<param name="visible" value="Control.IsEnabled(15)" />
 					</include>
 					<include content="InfoDialogButton">
 						<param name="id" value="443" />

--- a/addons/skin.estuary/xml/DialogVideoInfo.xml
+++ b/addons/skin.estuary/xml/DialogVideoInfo.xml
@@ -627,13 +627,13 @@
 						<param name="id" value="14" />
 						<param name="icon" value="icons/infodialogs/versions.png" />
 						<param name="label" value="$LOCALIZE[40000]" />
-						<param name="visible" value="String.IsEqual(ListItem.DBType,movie)" />
+						<param name="visible" value="Control.IsEnabled(14)" />
 					</include>
 					<include content="InfoDialogButton">
 						<param name="id" value="15" />
 						<param name="icon" value="icons/infodialogs/extras.png" />
 						<param name="label" value="$LOCALIZE[40211]" />
-						<param name="visible" value="String.IsEqual(ListItem.DBType,movie)" />
+						<param name="visible" value="Control.IsEnabled(15)" />
 					</include>
 					<include content="InfoDialogButton">
 						<param name="id" value="443" />

--- a/addons/skin.estuary/xml/DialogVideoManager.xml
+++ b/addons/skin.estuary/xml/DialogVideoManager.xml
@@ -87,10 +87,6 @@
 				<align>top</align>
 				<scrolltime tween="quadratic">200</scrolltime>
 				<include content="DefaultDialogButton">
-					<param name="id" value="21" />
-					<param name="label" value="$LOCALIZE[208]" />
-				</include>
-				<include content="DefaultDialogButton">
 					<param name="id" value="22" />
 					<param name="label" value="$LOCALIZE[40014]" />
 					<param name="visible">Window.IsVisible(managevideoversions)</param>

--- a/xbmc/dialogs/GUIDialogContextMenu.h
+++ b/xbmc/dialogs/GUIDialogContextMenu.h
@@ -88,6 +88,7 @@ enum CONTEXT_BUTTON
   CONTEXT_BUTTON_PLAY_NEXT,
   CONTEXT_BUTTON_NAVIGATE,
   CONTEXT_BUTTON_MANAGE_VIDEOVERSIONS,
+  CONTEXT_BUTTON_MANAGE_VIDEOEXTRAS,
 };
 
 class CContextButtons : public std::vector< std::pair<size_t, std::string> >

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -73,6 +73,7 @@ using namespace XFILE;
 using namespace KODI::MESSAGING;
 using namespace VIDEO::GUILIB;
 
+// clang-format off
 #define CONTROL_IMAGE                3
 #define CONTROL_TEXTAREA             4
 #define CONTROL_BTN_TRACKS           5
@@ -84,10 +85,10 @@ using namespace VIDEO::GUILIB;
 #define CONTROL_BTN_PLAY_TRAILER    11
 #define CONTROL_BTN_GET_FANART      12
 #define CONTROL_BTN_DIRECTOR        13
-#define CONTROL_BTN_PLAY_VIDEO_VERSIONS 14
 #define CONTROL_BTN_PLAY_VIDEO_EXTRAS 15
 
 #define CONTROL_LIST                50
+// clang-format on
 
 // predicate used by sorting and set_difference
 bool compFileItemsByDbId(const CFileItemPtr& lhs, const CFileItemPtr& rhs)
@@ -162,17 +163,13 @@ bool CGUIDialogVideoInfo::OnMessage(CGUIMessage& message)
         m_bViewReview = !m_bViewReview;
         Update();
       }
-      else if (iControl == CONTROL_BTN_PLAY_VIDEO_VERSIONS)
-      {
-        OnPlayVideoAsset(VideoAssetType::VERSION);
-      }
       else if (iControl == CONTROL_BTN_PLAY_VIDEO_EXTRAS)
       {
         OnPlayVideoAsset(VideoAssetType::EXTRA);
       }
       else if (iControl == CONTROL_BTN_PLAY)
       {
-        Play(m_movieItem);
+        OnPlay();
       }
       else if (iControl == CONTROL_BTN_USERRATING)
       {
@@ -301,12 +298,6 @@ void CGUIDialogVideoInfo::OnInitWindow()
         GetUniqueID().c_str(), "plugin"));
   else
     CONTROL_DISABLE(CONTROL_BTN_GET_FANART);
-
-  if (type == VideoDbContentType::MOVIES && m_movieItem->HasVideoVersions() &&
-      !VIDEO::IsVideoAssetFile(*m_movieItem))
-    CONTROL_ENABLE(CONTROL_BTN_PLAY_VIDEO_VERSIONS);
-  else
-    CONTROL_DISABLE(CONTROL_BTN_PLAY_VIDEO_VERSIONS);
 
   if (type == VideoDbContentType::MOVIES && m_movieItem->HasVideoExtras())
     CONTROL_ENABLE(CONTROL_BTN_PLAY_VIDEO_EXTRAS);
@@ -2158,4 +2149,13 @@ void CGUIDialogVideoInfo::ManageVideoVersions(const std::shared_ptr<CFileItem>& 
 void CGUIDialogVideoInfo::ManageVideoExtras(const std::shared_ptr<CFileItem>& item)
 {
   CGUIDialogVideoManagerExtras::ManageVideoExtras(item);
+}
+
+void CGUIDialogVideoInfo::OnPlay()
+{
+  if (m_movieItem->GetVideoContentType() == VideoDbContentType::MOVIES &&
+      m_movieItem->HasVideoVersions() && !VIDEO::IsVideoAssetFile(*m_movieItem))
+    OnPlayVideoAsset(VideoAssetType::VERSION);
+  else
+    Play(m_movieItem);
 }

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1120,8 +1120,9 @@ int CGUIDialogVideoInfo::ManageVideoItem(const std::shared_ptr<CFileItem>& item)
 
   if (type == MediaTypeMovie)
   {
-    // manage video versions
+    // manage video versions and extras
     buttons.Add(CONTEXT_BUTTON_MANAGE_VIDEOVERSIONS, 40001); // Manage versions
+    buttons.Add(CONTEXT_BUTTON_MANAGE_VIDEOEXTRAS, 40039); // Manage extras
   }
 
   if (type == MediaTypeEpisode &&
@@ -1199,6 +1200,11 @@ int CGUIDialogVideoInfo::ManageVideoItem(const std::shared_ptr<CFileItem>& item)
 
       case CONTEXT_BUTTON_MANAGE_VIDEOVERSIONS:
         ManageVideoVersions(item);
+        result = true;
+        break;
+
+      case CONTEXT_BUTTON_MANAGE_VIDEOEXTRAS:
+        ManageVideoExtras(item);
         result = true;
         break;
 
@@ -2147,4 +2153,9 @@ void CGUIDialogVideoInfo::OnPlayVideoAsset(VideoAssetType assetType)
 void CGUIDialogVideoInfo::ManageVideoVersions(const std::shared_ptr<CFileItem>& item)
 {
   CGUIDialogVideoManagerVersions::ManageVideoVersions(item);
+}
+
+void CGUIDialogVideoInfo::ManageVideoExtras(const std::shared_ptr<CFileItem>& item)
+{
+  CGUIDialogVideoManagerExtras::ManageVideoExtras(item);
 }

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.h
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.h
@@ -94,6 +94,7 @@ protected:
    */
   void OnSearchItemFound(const CFileItem* pItem);
   void OnPlayVideoAsset(VideoAssetType assetType);
+  void OnPlay();
   void Play(const std::shared_ptr<CFileItem>& item, bool resume = false);
   void OnGetArt();
   void OnGetFanart();

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.h
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.h
@@ -18,6 +18,7 @@ class CFileItem;
 class CFileItemList;
 class CMediaSource;
 class CVideoDatabase;
+enum class VideoAssetType;
 
 class CGUIDialogVideoInfo :
       public CGUIDialog
@@ -91,9 +92,8 @@ protected:
    * \param pItem Search result item
    */
   void OnSearchItemFound(const CFileItem* pItem);
-  bool OnManageVideoVersions();
-  bool OnManageVideoExtras();
-  void Play(bool resume = false);
+  void OnPlayVideoAsset(VideoAssetType assetType);
+  void Play(const std::shared_ptr<CFileItem>& item, bool resume = false);
   void OnGetArt();
   void OnGetFanart();
   void OnSetUserrating() const;

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.h
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.h
@@ -56,6 +56,7 @@ public:
   static bool SetMovieSet(const CFileItem *movieItem, const CFileItem *selectedSet);
 
   static void ManageVideoVersions(const std::shared_ptr<CFileItem>& item);
+  static void ManageVideoExtras(const std::shared_ptr<CFileItem>& item);
 
   static bool GetItemsForTag(const std::string &strHeading, const std::string &type, CFileItemList &items, int idTag = -1, bool showAll = true);
   static bool AddItemsToTag(const std::shared_ptr<CFileItem>& tagItem);

--- a/xbmc/video/dialogs/GUIDialogVideoManager.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -37,7 +37,6 @@
 
 static constexpr unsigned int CONTROL_LABEL_TITLE = 2;
 
-static constexpr unsigned int CONTROL_BUTTON_PLAY = 21;
 static constexpr unsigned int CONTROL_BUTTON_REMOVE = 26;
 static constexpr unsigned int CONTROL_BUTTON_CHOOSE_ART = 27;
 
@@ -72,14 +71,7 @@ bool CGUIDialogVideoManager::OnMessage(CGUIMessage& message)
       {
         const int action{message.GetParam1()};
         if (action == ACTION_SELECT_ITEM || action == ACTION_MOUSE_LEFT_CLICK)
-        {
-          if (UpdateSelectedAsset())
-            SET_CONTROL_FOCUS(CONTROL_BUTTON_PLAY, 0);
-        }
-      }
-      else if (control == CONTROL_BUTTON_PLAY)
-      {
-        Play();
+          UpdateSelectedAsset();
       }
       else if (control == CONTROL_BUTTON_REMOVE)
       {
@@ -138,7 +130,6 @@ void CGUIDialogVideoManager::UpdateButtons()
   {
     CONTROL_ENABLE(CONTROL_BUTTON_CHOOSE_ART);
     CONTROL_ENABLE(CONTROL_BUTTON_REMOVE);
-    CONTROL_ENABLE(CONTROL_BUTTON_PLAY);
 
     SET_CONTROL_FOCUS(CONTROL_LIST_ASSETS, 0);
   }
@@ -146,7 +137,6 @@ void CGUIDialogVideoManager::UpdateButtons()
   {
     CONTROL_DISABLE(CONTROL_BUTTON_CHOOSE_ART);
     CONTROL_DISABLE(CONTROL_BUTTON_REMOVE);
-    CONTROL_DISABLE(CONTROL_BUTTON_PLAY);
   }
 }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Proof of concept of idea proposed in Slack to move versions and extras management exclusively into the context menu and to make the Info dialog read only.

Multiple changes to the Info dialog:
- Modify the Versions and Extras button to call the Choose dialog and play versions and extras. No button id change (14 and 15 respectively)
- The versions and extras buttons are enabled and visible only when the movie has multiple versions or has extras respectively
- Versions and extras buttons moved next to the Play button

Versions / Extras Manager dialogs:
- Removed the Play button

I need help with the following:
- Naming of the versions and extras buttons: keep as is, change to Play version / Play extra, or just "Play" and rely on the icon to clarify?

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The info dialog is for information, not management. The manage context menu exists for that purpose.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Invoked the dialog from the library on movies with different numbers of versions and extras, invoked on versions inside the movie folder.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
 Hopefully a less surprising info dialog.

## Screenshots (if appropriate):
Info screen for movie with multiple versions and extras (without the commit to merge Play and Play versions):
![image](https://github.com/xbmc/xbmc/assets/489377/4ab15b75-0a1a-4f80-9618-4bb4473c7468)

Info dialog on movie with single version and extras (no "Play version" button)
or on a version inside the movie folder
or multiple versions and extras, with the commit to merge Play and Play versions:
![image](https://github.com/xbmc/xbmc/assets/489377/632fd05f-efd7-4224-be86-df8d8c8161ff)

Versions and Extras Manager without Play button:
![image](https://github.com/xbmc/xbmc/assets/489377/b01f19c7-4770-4b58-ac4c-e6361fcece6e)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
