### PR TITLE
Screensaver: Do not force dim if another modal is being shown

### DIFF
--- a/xbmc/application/ApplicationPowerHandling.cpp
+++ b/xbmc/application/ApplicationPowerHandling.cpp
@@ -394,10 +394,8 @@ void CApplicationPowerHandling::ActivateScreenSaver(bool forceType /*= false */)
 
     // Enforce Dim for special cases.
     bool bUseDim = false;
-    if (CServiceBroker::GetGUI()->GetWindowManager().HasModalDialog(true))
-      bUseDim = true;
-    else if (appPlayer && appPlayer->IsPlayingVideo() &&
-             settings->GetBool(CSettings::SETTING_SCREENSAVER_USEDIMONPAUSE))
+    if (appPlayer && appPlayer->IsPlayingVideo() &&
+        settings->GetBool(CSettings::SETTING_SCREENSAVER_USEDIMONPAUSE))
       bUseDim = true;
     else if (CServiceBroker::GetPVRManager().Get<PVR::GUI::Channels>().IsRunningChannelScan())
       bUseDim = true;

--- a/xbmc/windows/GUIWindowScreensaver.h
+++ b/xbmc/windows/GUIWindowScreensaver.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "guilib/GUIWindow.h"
+#include "guilib/GUIDialog.h"
 
 #include <memory>
 
@@ -20,7 +20,7 @@ class CScreenSaver;
 } // namespace ADDONS
 } // namespace KODI
 
-class CGUIWindowScreensaver : public CGUIWindow
+class CGUIWindowScreensaver : public CGUIDialog
 {
 public:
   CGUIWindowScreensaver();
@@ -35,8 +35,10 @@ public:
   void Process(unsigned int currentTime, CDirtyRegionList& regions) override;
 
 protected:
-  EVENT_RESULT OnMouseEvent(const CPoint& point, const KODI::MOUSE::CMouseEvent& event) override;
+  void UpdateVisibility() override;
+  void OnInitWindow() override;
 
 private:
   std::unique_ptr<KODI::ADDONS::CScreenSaver> m_addon;
+  bool m_visible{false};
 };


### PR DESCRIPTION
## Description
This block of code still comes from the svn import but I don't think it make sense anymore (since modal dialogs suffered a lot of changes since then). Kodi forces DIM instead of the configured screensaver as long as a modal is shown.

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/24627

## How has this been tested?
Runtime tested by setting kaster as the screensaver and wait a bit having a modal dialog on top

## What is the effect on users?
Configured

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
