### PR TITLE
[Android] Adjust copying of resource files to cache folder

### DIFF
--- a/tools/android/packaging/xbmc/src/Splash.java.in
+++ b/tools/android/packaging/xbmc/src/Splash.java.in
@@ -89,7 +89,6 @@ public class Splash extends Activity
   private BroadcastReceiver mExternalStorageReceiver = null;
   private boolean mExternalStorageChecked = false;
   private boolean mCachingDone = false;
-  private boolean mInstallLibs = false;
   private boolean mPermissionOK = false;
 
   private class StateMachine extends Handler
@@ -212,7 +211,7 @@ public class Splash extends Activity
             {
               sendEmptyMessage(InError);
             }
-            if (fXbmcHome.exists() && fXbmcHome.lastModified() >= fPackagePath.lastModified() && !mInstallLibs)
+            if (fXbmcHome.exists() && fXbmcHome.lastModified() >= fPackagePath.lastModified())
             {
               mState = CachingDone;
               mCachingDone = true;
@@ -286,8 +285,8 @@ public class Splash extends Activity
       }
       fXbmcHome.mkdirs();
 
-      // Log.d(TAG, "apk: " + sPackagePath);
-      // Log.d(TAG, "output: " + sXbmcHome);
+      Log.d(TAG, "apk: " + sPackagePath);
+      Log.d(TAG, "output: " + sXbmcHome);
 
       ZipFile zip;
       byte[] buf = new byte[4096];
@@ -309,27 +308,17 @@ public class Splash extends Activity
           ZipEntry e = (ZipEntry) entries.nextElement();
           String sName = e.getName();
 
-          if (!(sName.startsWith("assets/") || (mInstallLibs && sName.startsWith("lib/"))))
+          if (!sName.startsWith("assets/"))
             continue;
 
-          String sFullPath = null;
-          if (sName.startsWith("lib/"))
+          String sFullPath = sXbmcHome + "/" + sName;
+          File fFullPath = new File(sFullPath);
+          if (e.isDirectory())
           {
-            if (e.isDirectory())
-              continue;
-            sFullPath = getApplicationInfo().nativeLibraryDir + "/" + new File(sName).getName();
+            fFullPath.mkdirs();
+            continue;
           }
-          else
-          {
-            sFullPath = sXbmcHome + "/" + sName;
-            File fFullPath = new File(sFullPath);
-            if (e.isDirectory())
-            {
-              fFullPath.mkdirs();
-              continue;
-            }
-            fFullPath.getParentFile().mkdirs();
-          }
+          fFullPath.getParentFile().mkdirs();
 
           try
           {
@@ -724,7 +713,7 @@ public class Splash extends Activity
 
         SetupEnvironment();
 
-        if (mState != InError && fXbmcHome.exists() && fXbmcHome.lastModified() >= fPackagePath.lastModified() && !mInstallLibs)
+        if (mState != InError && fXbmcHome.exists() && fXbmcHome.lastModified() >= fPackagePath.lastModified())
         {
           mState = CachingDone;
           mCachingDone = true;


### PR DESCRIPTION
## Description
When the app is started for the first time, the files in the `assets` folder are unzipped in the cache folder `/data/user/0/org.xbmc.kodi/cache/apk`

In the code that performs this task there is unused code due to the check of the private variable `mInstalledLib` which always has a false value.

Also the related code should be removed, since the native libraries (lib folder) are installed in the app-specific folder on the device and not in the cache folder.

## How has this been tested?
Several installation tests and the app works fine.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
