### PR TITLE
[settings] Change default for setting 'Show videos with multiple versions as folder' to ON.

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1124,7 +1124,7 @@
         </setting>
         <setting id="videolibrary.showvideoversionsasfolder" type="boolean" label="40206" help="40207">
           <level>1</level>
-          <default>false</default>
+          <default>true</default>
           <control type="toggle" />
         </setting>
         <setting id="myvideos.flatten" type="boolean" label="20456" help="36183">


### PR DESCRIPTION
As discussed internally, we want to change the default value of the setting. With this, the default UX for navigation of versions would already be close to the "set like" UX we are aiming for at the end.

Runtime-tested on macOS, latest Kodi master.

@CrystalP could you please review?