### PR TITLE
[video] Hide 'Choose version' and 'Play version using' context menu i…

### DIFF
--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -18,6 +18,8 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/ExecString.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -230,7 +232,10 @@ protected:
 
 bool CVideoChooseVersion::IsVisible(const CFileItem& item) const
 {
-  return item.HasVideoVersions() && !VIDEO::IsVideoAssetFile(item);
+  return item.HasVideoVersions() &&
+         !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+             CSettings::SETTING_VIDEOLIBRARY_SHOWVIDEOVERSIONSASFOLDER) &&
+         !VIDEO::IsVideoAssetFile(item);
 }
 
 bool CVideoChooseVersion::Execute(const std::shared_ptr<CFileItem>& item) const
@@ -440,7 +445,10 @@ bool CVideoPlayUsing::Execute(const std::shared_ptr<CFileItem>& itemIn) const
 
 bool CVideoPlayVersionUsing::IsVisible(const CFileItem& item) const
 {
-  return item.HasVideoVersions() && !VIDEO::IsVideoAssetFile(item);
+  return item.HasVideoVersions() &&
+         !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+             CSettings::SETTING_VIDEOLIBRARY_SHOWVIDEOVERSIONSASFOLDER) &&
+         !VIDEO::IsVideoAssetFile(item);
 }
 
 bool CVideoPlayVersionUsing::Execute(const std::shared_ptr<CFileItem>& itemIn) const


### PR DESCRIPTION
…tems if setting 'Show videos with multiple versions as folder' is ON.

In this navigation mode, versions can easily be selected directly from the folder listing the versions. No need for extra context menu items.

Runtime-tested on macOS, latest Kodi master.

@CrystalP could you please review?