### PR TITLE
[iOS/tvOS] disable VTB for real-time interlaced videos

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VTB.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VTB.cpp
@@ -15,7 +15,6 @@
 #include "cores/VideoPlayer/Process/ProcessInfo.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
-#include "utils/log.h"
 
 #include <mutex>
 
@@ -130,6 +129,13 @@ void CVideoBufferPoolVTB::Return(int id)
 
 IHardwareDecoder* CDecoder::Create(CDVDStreamInfo &hint, CProcessInfo &processInfo, AVPixelFormat fmt)
 {
+#if defined(TARGET_DARWIN_EMBEDDED)
+  // force disable HW acceleration for live streams
+  // to avoid absent image issue on interlaced videos
+  if (processInfo.IsRealtimeStream())
+    return nullptr;
+#endif
+
   if (fmt == AV_PIX_FMT_VIDEOTOOLBOX && CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_VIDEOPLAYER_USEVTB))
     return new VTB::CDecoder(processInfo);
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
No more attempts to use hardware acceleration for real-time streams. Now interlaced video will show image, although frames will be partially dropped.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Interlaced videos don't show any image (just sound and spinning wheel) on iOS/tvOS with VTB on, and disabling VTB globally (via Kodi settings) isn't a good option.

fixes #18287, also see that issue for discussion and potential FFmpeg patch that might've workarounded the issue internally

fixes #18698

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on tvOS:
- various IPTV streams using IPTVSimple (I use udpxy): the workaround works
- .strm files with UDP URL: works
- .strm files with HTTP URL: doesn't work

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
no need to turn off VTB to play interlaced videos

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
