### PR TITLE
Teletext: Fix crash due to invalid FTC_Node

### DIFF
--- a/xbmc/video/Teletext.h
+++ b/xbmc/video/Teletext.h
@@ -193,7 +193,7 @@ private:
   FTC_SBit            m_sBit;             /*  "       "   "  */
   FT_Face             m_Face;             /*  "       "   "  */
   /*! An opaque handle to a cache node object. Each cache node is reference-counted. */
-  FTC_Node m_anode;
+  FTC_Node m_anode{nullptr};
   FTC_ImageTypeRec    m_TypeTTF;          /*  "       "   "  */
   int                 m_Ascender;         /*  "       "   "  */
 


### PR DESCRIPTION
## Description
Found this in one of my tv channels. The channel has teletext but doesn't really have any data which means the `m_anode` is not ever initialized (it happens here: https://github.com/xbmc/xbmc/blob/7a7420fcd6153bfebc21ac4d2f6764ee9ef7364e/xbmc/video/Teletext.cpp#L2394 - this block of code is never reached). As a result when we close the window and try to unreference the cache node from the manager (https://github.com/xbmc/xbmc/blob/7a7420fcd6153bfebc21ac4d2f6764ee9ef7364e/xbmc/video/Teletext.cpp#L733) Kodi crashes. This happens because, as `m_anode` is not initialized to NULL, the value of the pointer is indeterminate - not null but also not referenced by the manager.
Initializing it to nullptr fixes the issue. 

Review should be a no-brainer.