### PR TITLE
[MUSIC] Only set libraryartfilled property if we actually found art

### DIFF
--- a/xbmc/music/MusicThumbLoader.cpp
+++ b/xbmc/music/MusicThumbLoader.cpp
@@ -366,8 +366,8 @@ bool CMusicThumbLoader::FillLibraryArt(CFileItem &item)
     }
 
     item.AppendArt(artmap);
+    item.SetProperty("libraryartfilled", true);
   }
 
-  item.SetProperty("libraryartfilled", true);
   return artfound;
 }


### PR DESCRIPTION
## Description
Current code sets the property `libraryartfilled` to true, regardless of whether or not any art was actually found.  This PR moves the setting to inside the `if (artfound)` condition so that it's only set on an item if we actually did add some art to it.

## Motivation and context
With PR https://github.com/xbmc/xbmc/pull/21940 , playlists now accurately load the duration of a track from the m3u file.  This results in the creation of a `CMusicInfoTag()` which contains just the duration. Before that PR, no infotag would have been created. 

The end result is that art is only looked up for the first item in the playlist (previously, items had no infotag and so were always looked up) and the rest of the items in the playlist end up with the `libraryartfilled` property being set.  This prevents the thumbloader from loading any art when called by guiinfo.  

Fixes https://github.com/xbmc/xbmc/issues/24665

Moving the setting inside the if condition restores the correct behaviour.

## How has this been tested?
Tested locally with the same playlist before and after the change.

## What is the effect on users?
All items in an m3u(8) playlist will show all art items.

## Screenshots (if appropriate):

## Before change
### Track 1 of playlist - shows fanart, album cover etc
![screenshot00091](https://github.com/xbmc/xbmc/assets/18698554/f8c63468-627b-4f6b-af38-96da1e217315)

### Track 2 - just album cover, no fanart
![screenshot00092](https://github.com/xbmc/xbmc/assets/18698554/37f897fb-6b4a-4096-8fe8-cbd0d84ec8b8)

### Track 3 - no art at all
![screenshot00093](https://github.com/xbmc/xbmc/assets/18698554/1441950e-6e8f-4356-a61a-b9c849984ee9)

## After change

### Track 2 - all art
![screenshot00095](https://github.com/xbmc/xbmc/assets/18698554/ceed4348-111b-42a6-bc4c-43cca3d48861)

### track 3 - all art
![screenshot00096](https://github.com/xbmc/xbmc/assets/18698554/bb7dd122-c11c-4edb-a8b6-2b0ef9c45c9b)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
