### PR TITLE
Kill CGUIListItemPtr typedef

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -10798,7 +10798,7 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
   }
   else if (info >= LISTITEM_START && info <= LISTITEM_END)
   {
-    const CGUIListItemPtr item = GUIINFO::GetCurrentListItem(contextWindow);
+    const std::shared_ptr<CGUIListItem> item = GUIINFO::GetCurrentListItem(contextWindow);
     if (item && item->IsFileItem())
       return GetItemLabel(static_cast<CFileItem*>(item.get()), contextWindow, info, fallback);
   }
@@ -10816,7 +10816,7 @@ bool CGUIInfoManager::GetInt(int &value, int info, int contextWindow, const CGUI
   }
   else if (info >= LISTITEM_START && info <= LISTITEM_END)
   {
-    CGUIListItemPtr itemPtr;
+    std::shared_ptr<CGUIListItem> itemPtr;
     if (!item)
     {
       itemPtr = GUIINFO::GetCurrentListItem(contextWindow);
@@ -10857,7 +10857,9 @@ void CGUIInfoManager::UnRegister(const INFO::InfoPtr& expression)
   m_bools.erase(expression);
 }
 
-bool CGUIInfoManager::EvaluateBool(const std::string &expression, int contextWindow /* = 0 */, const CGUIListItemPtr &item /* = nullptr */)
+bool CGUIInfoManager::EvaluateBool(const std::string& expression,
+                                   int contextWindow /* = 0 */,
+                                   const std::shared_ptr<CGUIListItem>& item /* = nullptr */)
 {
   INFO::InfoPtr info = Register(expression, contextWindow);
   if (info)
@@ -10872,7 +10874,7 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
 
   if (condition >= LISTITEM_START && condition < LISTITEM_END)
   {
-    CGUIListItemPtr itemPtr;
+    std::shared_ptr<CGUIListItem> itemPtr;
     if (!item)
     {
       itemPtr = GUIINFO::GetCurrentListItem(contextWindow);
@@ -10901,7 +10903,7 @@ bool CGUIInfoManager::GetMultiInfoBool(const CGUIInfo &info, int contextWindow, 
 
   if (condition >= LISTITEM_START && condition <= LISTITEM_END)
   {
-    CGUIListItemPtr itemPtr;
+    std::shared_ptr<CGUIListItem> itemPtr;
     if (!item)
     {
       itemPtr = GUIINFO::GetCurrentListItem(contextWindow, info.GetData1(), info.GetData2(), info.GetInfoFlag());
@@ -10942,7 +10944,7 @@ bool CGUIInfoManager::GetMultiInfoBool(const CGUIInfo &info, int contextWindow, 
           if (info.GetData2() < 0) // info labels are stored with negative numbers
           {
             int info2 = -info.GetData2();
-            CGUIListItemPtr item2;
+            std::shared_ptr<CGUIListItem> item2;
 
             if (IsListItemInfo(info2))
             {
@@ -11047,7 +11049,7 @@ bool CGUIInfoManager::GetMultiInfoInt(int &value, const CGUIInfo &info, int cont
   }
   else if (info.m_info >= LISTITEM_START && info.m_info <= LISTITEM_END)
   {
-    CGUIListItemPtr itemPtr;
+    std::shared_ptr<CGUIListItem> itemPtr;
     if (!item)
     {
       itemPtr = GUIINFO::GetCurrentListItem(contextWindow, info.GetData1(), info.GetData2(), info.GetInfoFlag());
@@ -11082,7 +11084,8 @@ std::string CGUIInfoManager::GetMultiInfoLabel(const CGUIInfo &constinfo, int co
 
   if (info.m_info >= LISTITEM_START && info.m_info <= LISTITEM_END)
   {
-    const CGUIListItemPtr item = GUIINFO::GetCurrentListItem(contextWindow, info.GetData1(), info.GetData2(), info.GetInfoFlag());
+    const std::shared_ptr<CGUIListItem> item = GUIINFO::GetCurrentListItem(
+        contextWindow, info.GetData1(), info.GetData2(), info.GetInfoFlag());
     if (item)
     {
       // Image prioritizes images over labels (in the case of music item ratings for instance)
@@ -11127,7 +11130,7 @@ std::string CGUIInfoManager::GetImage(int info, int contextWindow, std::string *
            info == LISTITEM_OVERLAY ||
            info == LISTITEM_ART)
   {
-    const CGUIListItemPtr item = GUIINFO::GetCurrentListItem(contextWindow);
+    const std::shared_ptr<CGUIListItem> item = GUIINFO::GetCurrentListItem(contextWindow);
     if (item && item->IsFileItem())
       return GetItemImage(item.get(), contextWindow, info, fallback);
   }

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -24,7 +24,6 @@ class CFileItem;
 class CVideoInfoTag;
 
 class CGUIListItem;
-typedef std::shared_ptr<CGUIListItem> CGUIListItemPtr;
 
 namespace KODI
 {
@@ -99,7 +98,7 @@ public:
    */
   bool EvaluateBool(const std::string& expression,
                     int context,
-                    const CGUIListItemPtr& item = nullptr);
+                    const std::shared_ptr<CGUIListItem>& item = nullptr);
 
   int TranslateString(const std::string &strCondition);
   int TranslateSingleString(const std::string &strCondition, bool &listItemDependent);

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -3068,7 +3068,8 @@ bool CApplication::OnMessage(CGUIMessage& message)
   return false;
 }
 
-bool CApplication::ExecuteXBMCAction(std::string actionStr, const CGUIListItemPtr &item /* = NULL */)
+bool CApplication::ExecuteXBMCAction(std::string actionStr,
+                                     const std::shared_ptr<CGUIListItem>& item /* = NULL */)
 {
   // see if it is a user set string
 

--- a/xbmc/application/Application.h
+++ b/xbmc/application/Application.h
@@ -167,7 +167,7 @@ public:
 
   void UpdateCurrentPlayArt();
 
-  bool ExecuteXBMCAction(std::string action, const CGUIListItemPtr &item = NULL);
+  bool ExecuteXBMCAction(std::string action, const std::shared_ptr<CGUIListItem>& item = NULL);
 
 #ifdef HAS_OPTICAL_DRIVE
   std::unique_ptr<MEDIA_DETECT::CAutorun> m_Autorun;

--- a/xbmc/games/controllers/listproviders/GUIGameControllerProvider.cpp
+++ b/xbmc/games/controllers/listproviders/GUIGameControllerProvider.cpp
@@ -65,7 +65,7 @@ bool CGUIGameControllerProvider::Update(bool forceRefresh)
   return bDirty;
 }
 
-void CGUIGameControllerProvider::Fetch(std::vector<CGUIListItemPtr>& items)
+void CGUIGameControllerProvider::Fetch(std::vector<std::shared_ptr<CGUIListItem>>& items)
 {
   items = m_items;
 }
@@ -125,7 +125,7 @@ void CGUIGameControllerProvider::UpdateItems()
   int portIndex = -1;
   for (unsigned int i = 0; i < static_cast<unsigned int>(m_items.size()); ++i)
   {
-    CGUIListItemPtr& guiItem = m_items.at(i);
+    std::shared_ptr<CGUIListItem>& guiItem = m_items.at(i);
 
     // Pad list if aligning to the right
     if (m_alignment == XBFONT_RIGHT && i + m_portCount < MAX_PORT_COUNT)

--- a/xbmc/games/controllers/listproviders/GUIGameControllerProvider.h
+++ b/xbmc/games/controllers/listproviders/GUIGameControllerProvider.h
@@ -64,10 +64,10 @@ public:
   // Implementation of IListProvider
   std::unique_ptr<IListProvider> Clone() override;
   bool Update(bool forceRefresh) override;
-  void Fetch(std::vector<CGUIListItemPtr>& items) override;
-  bool OnClick(const CGUIListItemPtr& item) override { return false; }
-  bool OnInfo(const CGUIListItemPtr& item) override { return false; }
-  bool OnContextMenu(const CGUIListItemPtr& item) override { return false; }
+  void Fetch(std::vector<std::shared_ptr<CGUIListItem>>& items) override;
+  bool OnClick(const std::shared_ptr<CGUIListItem>& item) override { return false; }
+  bool OnInfo(const std::shared_ptr<CGUIListItem>& item) override { return false; }
+  bool OnContextMenu(const std::shared_ptr<CGUIListItem>& item) override { return false; }
   void SetDefaultItem(int item, bool always) override {}
   int GetDefaultItem() const override { return -1; }
   bool AlwaysFocusDefaultItem() const override { return false; }

--- a/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
+++ b/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
@@ -63,7 +63,7 @@ bool CDialogInGameSaves::OnMessage(CGUIMessage& message)
       if (message.GetControlId() == GetID())
       {
         const std::string& itemPath = message.GetStringParam();
-        CGUIListItemPtr itemInfo = message.GetItem();
+        std::shared_ptr<CGUIListItem> itemInfo = message.GetItem();
 
         if (!itemPath.empty())
         {
@@ -127,7 +127,8 @@ unsigned int CDialogInGameSaves::GetFocusedItem() const
   return m_focusedControl;
 }
 
-void CDialogInGameSaves::OnItemRefresh(const std::string& itemPath, const CGUIListItemPtr& itemInfo)
+void CDialogInGameSaves::OnItemRefresh(const std::string& itemPath,
+                                       const std::shared_ptr<CGUIListItem>& itemInfo)
 {
   // Turn the message params into a savestate item
   CFileItemPtr item = TranslateMessageItem(itemPath, itemInfo);
@@ -400,8 +401,8 @@ void CDialogInGameSaves::OnDelete(CFileItem& focusedItem)
   }
 }
 
-CFileItemPtr CDialogInGameSaves::TranslateMessageItem(const std::string& messagePath,
-                                                      const CGUIListItemPtr& messageItem)
+CFileItemPtr CDialogInGameSaves::TranslateMessageItem(
+    const std::string& messagePath, const std::shared_ptr<CGUIListItem>& messageItem)
 {
   CFileItemPtr item;
 

--- a/xbmc/games/dialogs/osd/DialogInGameSaves.h
+++ b/xbmc/games/dialogs/osd/DialogInGameSaves.h
@@ -52,7 +52,7 @@ protected:
 
 private:
   void InitSavedGames();
-  void OnItemRefresh(const std::string& itemPath, const CGUIListItemPtr& itemInfo);
+  void OnItemRefresh(const std::string& itemPath, const std::shared_ptr<CGUIListItem>& itemInfo);
 
   /*!
    * \brief Translates the GUI list item received in a GUI message into a
@@ -72,7 +72,7 @@ private:
    *         can be obtained
    */
   static CFileItemPtr TranslateMessageItem(const std::string& messagePath,
-                                           const CGUIListItemPtr& messageItem);
+                                           const std::shared_ptr<CGUIListItem>& messageItem);
 
   CFileItemList m_savestateItems;
   const CFileItemPtr m_newSaveItem;

--- a/xbmc/guilib/GUIAction.cpp
+++ b/xbmc/guilib/GUIAction.cpp
@@ -59,7 +59,9 @@ bool CGUIAction::ExecuteActions() const
   return ExecuteActions(DEFAULT_CONTROL_ID, DEFAULT_CONTROL_ID);
 }
 
-bool CGUIAction::ExecuteActions(int controlID, int parentID, const CGUIListItemPtr &item /* = NULL */) const
+bool CGUIAction::ExecuteActions(int controlID,
+                                int parentID,
+                                const std::shared_ptr<CGUIListItem>& item /* = NULL */) const
 {
   if (m_actions.empty())
     return false;

--- a/xbmc/guilib/GUIAction.h
+++ b/xbmc/guilib/GUIAction.h
@@ -13,7 +13,7 @@
 #include <vector>
 
 class CGUIControl;
-class CGUIListItem; typedef std::shared_ptr<CGUIListItem> CGUIListItemPtr;
+class CGUIListItem;
 
 /**
  * Class containing vector of condition->(action/navigation route) and handling its execution.
@@ -83,7 +83,9 @@ public:
   /**
    * Execute actions (no navigation paths); if action is paired with condition - evaluate condition first
    */
-  bool ExecuteActions(int controlID, int parentID, const CGUIListItemPtr& item = nullptr) const;
+  bool ExecuteActions(int controlID,
+                      int parentID,
+                      const std::shared_ptr<CGUIListItem>& item = nullptr) const;
   /**
    * Check if there are any conditional actions
   */

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -179,7 +179,7 @@ void CGUIBaseContainer::Process(unsigned int currentTime, CDirtyRegionList &dirt
     bool focused = (current == GetOffset() + GetCursor());
     if (itemNo >= 0)
     {
-      CGUIListItemPtr item = m_items[itemNo];
+      std::shared_ptr<CGUIListItem> item = m_items[itemNo];
       item->SetCurrentItem(itemNo + 1);
 
       // render our item
@@ -202,7 +202,12 @@ void CGUIBaseContainer::Process(unsigned int currentTime, CDirtyRegionList &dirt
   CGUIControl::Process(currentTime, dirtyregions);
 }
 
-void CGUIBaseContainer::ProcessItem(float posX, float posY, CGUIListItemPtr& item, bool focused, unsigned int currentTime, CDirtyRegionList &dirtyregions)
+void CGUIBaseContainer::ProcessItem(float posX,
+                                    float posY,
+                                    std::shared_ptr<CGUIListItem>& item,
+                                    bool focused,
+                                    unsigned int currentTime,
+                                    CDirtyRegionList& dirtyregions)
 {
   if (!m_focusedLayout || !m_layout) return;
 
@@ -277,7 +282,7 @@ void CGUIBaseContainer::Render()
     end += cacheAfter * m_layout->Size(m_orientation);
 
     float focusedPos = 0;
-    CGUIListItemPtr focusedItem;
+    std::shared_ptr<CGUIListItem> focusedItem;
     int current = offset - cacheBefore;
     while (pos < end && m_items.size())
     {
@@ -287,7 +292,7 @@ void CGUIBaseContainer::Render()
       bool focused = (current == GetOffset() + GetCursor());
       if (itemNo >= 0)
       {
-        CGUIListItemPtr item = m_items[itemNo];
+        std::shared_ptr<CGUIListItem> item = m_items[itemNo];
         // render our item
         if (focused)
         {
@@ -649,7 +654,7 @@ void CGUIBaseContainer::OnJumpLetter(const std::string& letter, bool skip /*=fal
   unsigned int i      = (offset + ((skip) ? 1 : 0)) % m_items.size();
   do
   {
-    CGUIListItemPtr item = m_items[i];
+    std::shared_ptr<CGUIListItem> item = m_items[i];
     std::string label = item->GetLabel();
     if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING))
       label = SortUtils::RemoveArticles(label);
@@ -730,10 +735,10 @@ int CGUIBaseContainer::GetSelectedItem() const
   return CorrectOffset(GetOffset(), GetCursor());
 }
 
-CGUIListItemPtr CGUIBaseContainer::GetListItem(int offset, unsigned int flag) const
+std::shared_ptr<CGUIListItem> CGUIBaseContainer::GetListItem(int offset, unsigned int flag) const
 {
   if (!m_items.size() || !m_layout)
-    return CGUIListItemPtr();
+    return std::shared_ptr<CGUIListItem>();
   int item = GetSelectedItem() + offset;
   if (flag & INFOFLAG_LISTITEM_POSITION) // use offset from the first item displayed, taking into account scrolling
     item = CorrectOffset((int)(m_scroller.GetValue() / m_layout->Size(m_orientation)), offset);
@@ -752,12 +757,12 @@ CGUIListItemPtr CGUIBaseContainer::GetListItem(int offset, unsigned int flag) co
     if (item >= 0 && item < (int)m_items.size())
       return m_items[item];
   }
-  return CGUIListItemPtr();
+  return std::shared_ptr<CGUIListItem>();
 }
 
 CGUIListItemLayout *CGUIBaseContainer::GetFocusedLayout() const
 {
-  CGUIListItemPtr item = GetListItem(0);
+  std::shared_ptr<CGUIListItem> item = GetListItem(0);
   if (item.get()) return item->GetFocusedLayout();
   return NULL;
 }
@@ -912,7 +917,7 @@ std::string CGUIBaseContainer::GetDescription() const
   int item = GetSelectedItem();
   if (item >= 0 && item < (int)m_items.size())
   {
-    CGUIListItemPtr pItem = m_items[item];
+    std::shared_ptr<CGUIListItem> pItem = m_items[item];
     if (pItem->m_bIsFolder)
       strLabel = StringUtils::Format("[{}]", pItem->GetLabel());
     else
@@ -1067,7 +1072,7 @@ void CGUIBaseContainer::UpdateListProvider(bool forceRefresh /* = false */)
         // as fallback, try to re-identify selected item by comparing item paths.
         for (int i = 0; i < static_cast<int>(m_items.size()); i++)
         {
-          const CGUIListItemPtr c(m_items[i]);
+          const std::shared_ptr<CGUIListItem> c(m_items[i]);
           if (c->IsFileItem())
           {
             const std::string &selectedPath = static_cast<CFileItem *>(c.get())->GetPath();
@@ -1120,7 +1125,7 @@ void CGUIBaseContainer::UpdateScrollByLetter()
   std::string currentMatch;
   for (unsigned int i = 0; i < m_items.size(); i++)
   {
-    CGUIListItemPtr item = m_items[i];
+    std::shared_ptr<CGUIListItem> item = m_items[i];
     // The letter offset jumping is only for ASCII characters at present, and
     // our checks are all done in uppercase
     std::string nextLetter;
@@ -1321,7 +1326,7 @@ void CGUIBaseContainer::DumpTextureUse()
   CLog::Log(LOGDEBUG, "{} for container {}", __FUNCTION__, GetID());
   for (unsigned int i = 0; i < m_items.size(); ++i)
   {
-    CGUIListItemPtr item = m_items[i];
+    std::shared_ptr<CGUIListItem> item = m_items[i];
     if (item->GetFocusedLayout()) item->GetFocusedLayout()->DumpTextureUse();
     if (item->GetLayout()) item->GetLayout()->DumpTextureUse();
   }

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -68,7 +68,7 @@ public:
   void LoadLayout(TiXmlElement *layout);
   void LoadListProvider(TiXmlElement *content, int defaultItem, bool defaultAlways);
 
-  CGUIListItemPtr GetListItem(int offset, unsigned int flag = 0) const override;
+  std::shared_ptr<CGUIListItem> GetListItem(int offset, unsigned int flag = 0) const override;
 
   bool GetCondition(int condition, int data) const override;
   std::string GetLabel(int info) const override;
@@ -100,7 +100,12 @@ protected:
   EVENT_RESULT OnMouseEvent(const CPoint& point, const KODI::MOUSE::CMouseEvent& event) override;
   bool OnClick(int actionID);
 
-  virtual void ProcessItem(float posX, float posY, CGUIListItemPtr& item, bool focused, unsigned int currentTime, CDirtyRegionList &dirtyregions);
+  virtual void ProcessItem(float posX,
+                           float posY,
+                           std::shared_ptr<CGUIListItem>& item,
+                           bool focused,
+                           unsigned int currentTime,
+                           CDirtyRegionList& dirtyregions);
 
   void Render() override;
   virtual void RenderItem(float posX, float posY, CGUIListItem *item, bool focused);
@@ -139,9 +144,9 @@ protected:
   ORIENTATION m_orientation;
   int m_itemsPerPage;
 
-  std::vector< CGUIListItemPtr > m_items;
-  typedef std::vector<CGUIListItemPtr> ::iterator iItems;
-  CGUIListItemPtr m_lastItem;
+  std::vector<std::shared_ptr<CGUIListItem>> m_items;
+  typedef std::vector<std::shared_ptr<CGUIListItem>>::iterator iItems;
+  std::shared_ptr<CGUIListItem> m_lastItem;
 
   int m_pageControl;
 

--- a/xbmc/guilib/GUIMessage.cpp
+++ b/xbmc/guilib/GUIMessage.cpp
@@ -38,7 +38,7 @@ CGUIMessage::CGUIMessage(int msg,
                          int controlID,
                          int64_t param1,
                          int64_t param2,
-                         const CGUIListItemPtr& item)
+                         const std::shared_ptr<CGUIListItem>& item)
   : m_item(item)
 {
   m_message = msg;
@@ -69,7 +69,7 @@ void* CGUIMessage::GetPointer() const
   return m_pointer;
 }
 
-CGUIListItemPtr CGUIMessage::GetItem() const
+std::shared_ptr<CGUIListItem> CGUIMessage::GetItem() const
 {
   return m_item;
 }
@@ -155,7 +155,7 @@ size_t CGUIMessage::GetNumStringParams() const
   return m_params.size();
 }
 
-void CGUIMessage::SetItem(CGUIListItemPtr item)
+void CGUIMessage::SetItem(std::shared_ptr<CGUIListItem> item)
 {
   m_item = std::move(item);
 }

--- a/xbmc/guilib/GUIMessage.h
+++ b/xbmc/guilib/GUIMessage.h
@@ -355,7 +355,7 @@ constexpr const int GUI_MSG_CODINGTABLE_LOOKUP_COMPLETED = 65000;
 #include <memory>
 
 // forwards
-class CGUIListItem; typedef std::shared_ptr<CGUIListItem> CGUIListItemPtr;
+class CGUIListItem;
 class CFileItemList;
 
 /*!
@@ -373,7 +373,7 @@ public:
               int controlID,
               int64_t param1,
               int64_t param2,
-              const CGUIListItemPtr& item);
+              const std::shared_ptr<CGUIListItem>& item);
   CGUIMessage(const CGUIMessage& msg);
   ~CGUIMessage(void);
   CGUIMessage& operator = (const CGUIMessage& msg);
@@ -381,7 +381,7 @@ public:
   int GetControlId() const ;
   int GetMessage() const;
   void* GetPointer() const;
-  CGUIListItemPtr GetItem() const;
+  std::shared_ptr<CGUIListItem> GetItem() const;
   int GetParam1() const;
   int64_t GetParam1AsI64() const;
   int GetParam2() const;
@@ -397,7 +397,7 @@ public:
   void SetStringParams(const std::vector<std::string> &params);
   const std::string& GetStringParam(size_t param = 0) const;
   size_t GetNumStringParams() const;
-  void SetItem(CGUIListItemPtr item);
+  void SetItem(std::shared_ptr<CGUIListItem> item);
 
 private:
   std::string m_strLabel;
@@ -408,7 +408,7 @@ private:
   void* m_pointer;
   int64_t m_param1;
   int64_t m_param2;
-  CGUIListItemPtr m_item;
+  std::shared_ptr<CGUIListItem> m_item;
 
   static std::string empty_string;
 };

--- a/xbmc/guilib/GUIPanelContainer.cpp
+++ b/xbmc/guilib/GUIPanelContainer.cpp
@@ -63,7 +63,7 @@ void CGUIPanelContainer::Process(unsigned int currentTime, CDirtyRegionList &dir
       break;
     if (current >= 0)
     {
-      CGUIListItemPtr item = m_items[current];
+      std::shared_ptr<CGUIListItem> item = m_items[current];
       item->SetCurrentItem(current + 1);
       bool focused = (current == GetOffset() * m_itemsPerRow + GetCursor()) && m_bHasFocus;
 
@@ -111,7 +111,7 @@ void CGUIPanelContainer::Render()
 
     float focusedPos = 0;
     int focusedCol = 0;
-    CGUIListItemPtr focusedItem;
+    std::shared_ptr<CGUIListItem> focusedItem;
     int current = (offset - cacheBefore) * m_itemsPerRow;
     int col = 0;
     while (pos < end && m_items.size())
@@ -120,7 +120,7 @@ void CGUIPanelContainer::Render()
         break;
       if (current >= 0)
       {
-        CGUIListItemPtr item = m_items[current];
+        std::shared_ptr<CGUIListItem> item = m_items[current];
         bool focused = (current == GetOffset() * m_itemsPerRow + GetCursor()) && m_bHasFocus;
         // render our item
         if (focused)

--- a/xbmc/guilib/GUIWrappingListContainer.cpp
+++ b/xbmc/guilib/GUIWrappingListContainer.cpp
@@ -131,7 +131,7 @@ void CGUIWrappingListContainer::ValidateOffset()
       // add additional copies of items, as we require extras at render time
       for (unsigned int i = 0; i < numItems; i++)
       {
-        m_items.push_back(CGUIListItemPtr(m_items[i]->Clone()));
+        m_items.push_back(std::shared_ptr<CGUIListItem>(m_items[i]->Clone()));
         m_extraItems++;
       }
     }

--- a/xbmc/guilib/IGUIContainer.h
+++ b/xbmc/guilib/IGUIContainer.h
@@ -12,8 +12,6 @@
 
 #include <memory>
 
-typedef std::shared_ptr<CGUIListItem> CGUIListItemPtr;
-
 /*!
  \ingroup controls
  \brief
@@ -40,6 +38,6 @@ public:
     m_label = label;
   }
 
-  virtual CGUIListItemPtr GetListItem(int offset, unsigned int flag = 0) const = 0;
+  virtual std::shared_ptr<CGUIListItem> GetListItem(int offset, unsigned int flag = 0) const = 0;
   virtual std::string GetLabel(int info) const                                 = 0;
 };

--- a/xbmc/guilib/guiinfo/GUIInfoHelper.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoHelper.cpp
@@ -159,9 +159,12 @@ CGUIControl* GetActiveContainer(int containerId, int contextWindow)
   return nullptr;
 }
 
-CGUIListItemPtr GetCurrentListItem(int contextWindow, int containerId /* = 0 */, int itemOffset /* = 0 */, unsigned int itemFlags /* = 0 */)
+std::shared_ptr<CGUIListItem> GetCurrentListItem(int contextWindow,
+                                                 int containerId /* = 0 */,
+                                                 int itemOffset /* = 0 */,
+                                                 unsigned int itemFlags /* = 0 */)
 {
-  CGUIListItemPtr item;
+  std::shared_ptr<CGUIListItem> item;
 
   if (containerId == 0  &&
       itemOffset == 0 &&

--- a/xbmc/guilib/guiinfo/GUIInfoHelper.h
+++ b/xbmc/guilib/guiinfo/GUIInfoHelper.h
@@ -16,7 +16,6 @@
 class CFileItem;
 
 class CGUIListItem;
-typedef std::shared_ptr<CGUIListItem> CGUIListItemPtr;
 
 class CGUIControl;
 class CGUIMediaWindow;
@@ -34,7 +33,10 @@ std::string GetPlaylistLabel(int item, PLAYLIST::Id playlistid = PLAYLIST::TYPE_
 CGUIWindow* GetWindow(int contextWindow);
 CGUIControl* GetActiveContainer(int containerId, int contextWindow);
 CGUIMediaWindow* GetMediaWindow(int contextWindow);
-CGUIListItemPtr GetCurrentListItem(int contextWindow, int containerId = 0, int itemOffset = 0, unsigned int itemFlags = 0);
+std::shared_ptr<CGUIListItem> GetCurrentListItem(int contextWindow,
+                                                 int containerId = 0,
+                                                 int itemOffset = 0,
+                                                 unsigned int itemFlags = 0);
 
 std::string GetFileInfoLabelValueFromPath(int info, const std::string& filenameAndPath);
 

--- a/xbmc/guilib/listproviders/DirectoryProvider.cpp
+++ b/xbmc/guilib/listproviders/DirectoryProvider.cpp
@@ -329,7 +329,7 @@ void CDirectoryProvider::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
   }
 }
 
-void CDirectoryProvider::Fetch(std::vector<CGUIListItemPtr> &items)
+void CDirectoryProvider::Fetch(std::vector<std::shared_ptr<CGUIListItem>>& items)
 {
   std::unique_lock<CCriticalSection> lock(m_section);
   items.clear();
@@ -544,7 +544,7 @@ protected:
 };
 } // namespace
 
-bool CDirectoryProvider::OnClick(const CGUIListItemPtr& item)
+bool CDirectoryProvider::OnClick(const std::shared_ptr<CGUIListItem>& item)
 {
   CFileItem targetItem{*std::static_pointer_cast<CFileItem>(item)};
 
@@ -580,7 +580,7 @@ bool CDirectoryProvider::OnClick(const CGUIListItemPtr& item)
   return ExecuteAction({fileItem, GetTarget(fileItem)});
 }
 
-bool CDirectoryProvider::OnPlay(const CGUIListItemPtr& item)
+bool CDirectoryProvider::OnPlay(const std::shared_ptr<CGUIListItem>& item)
 {
   CFileItem targetItem{*std::static_pointer_cast<CFileItem>(item)};
 
@@ -628,7 +628,7 @@ bool CDirectoryProvider::OnInfo(const std::shared_ptr<CFileItem>& fileItem)
   return UTILS::GUILIB::CGUIContentUtils::ShowInfoForItem(*targetItem);
 }
 
-bool CDirectoryProvider::OnInfo(const CGUIListItemPtr& item)
+bool CDirectoryProvider::OnInfo(const std::shared_ptr<CGUIListItem>& item)
 {
   auto fileItem = std::static_pointer_cast<CFileItem>(item);
   return OnInfo(fileItem);
@@ -643,7 +643,7 @@ bool CDirectoryProvider::OnContextMenu(const std::shared_ptr<CFileItem>& fileIte
   return CONTEXTMENU::ShowFor(fileItem, CContextMenuManager::MAIN);
 }
 
-bool CDirectoryProvider::OnContextMenu(const CGUIListItemPtr& item)
+bool CDirectoryProvider::OnContextMenu(const std::shared_ptr<CGUIListItem>& item)
 {
   auto fileItem = std::static_pointer_cast<CFileItem>(item);
   return OnContextMenu(fileItem);

--- a/xbmc/guilib/listproviders/DirectoryProvider.h
+++ b/xbmc/guilib/listproviders/DirectoryProvider.h
@@ -69,14 +69,14 @@ public:
                 const std::string& sender,
                 const std::string& message,
                 const CVariant& data) override;
-  void Fetch(std::vector<CGUIListItemPtr> &items) override;
+  void Fetch(std::vector<std::shared_ptr<CGUIListItem>>& items) override;
   void Reset() override;
-  bool OnClick(const CGUIListItemPtr &item) override;
-  bool OnPlay(const CGUIListItemPtr& item) override;
+  bool OnClick(const std::shared_ptr<CGUIListItem>& item) override;
+  bool OnPlay(const std::shared_ptr<CGUIListItem>& item) override;
   bool OnInfo(const std::shared_ptr<CFileItem>& item);
   bool OnContextMenu(const std::shared_ptr<CFileItem>& item);
-  bool OnInfo(const CGUIListItemPtr &item) override;
-  bool OnContextMenu(const CGUIListItemPtr &item) override;
+  bool OnInfo(const std::shared_ptr<CGUIListItem>& item) override;
+  bool OnContextMenu(const std::shared_ptr<CGUIListItem>& item) override;
   bool IsUpdating() const override;
   void FreeResources(bool immediately) override;
 

--- a/xbmc/guilib/listproviders/IListProvider.h
+++ b/xbmc/guilib/listproviders/IListProvider.h
@@ -13,7 +13,6 @@
 
 class TiXmlNode;
 class CGUIListItem;
-typedef std::shared_ptr<CGUIListItem> CGUIListItemPtr;
 
 /*!
  \ingroup listproviders
@@ -52,7 +51,7 @@ public:
   /*! \brief Fetch the current list of items.
    \param items [out] the list to be filled.
    */
-  virtual void Fetch(std::vector<CGUIListItemPtr> &items)=0;
+  virtual void Fetch(std::vector<std::shared_ptr<CGUIListItem>>& items) = 0;
 
   /*! \brief Check whether the list provider is updating content.
    \return true if in the processing of updating, false otherwise.
@@ -73,25 +72,25 @@ public:
    \param item the item that was clicked.
    \return true if the click was handled, false otherwise.
    */
-  virtual bool OnClick(const CGUIListItemPtr &item)=0;
+  virtual bool OnClick(const std::shared_ptr<CGUIListItem>& item) = 0;
 
   /*! \brief Play event on an item.
    \param item the item to play.
    \return true if the event was handled, false otherwise.
    */
-  virtual bool OnPlay(const CGUIListItemPtr& item) { return false; }
+  virtual bool OnPlay(const std::shared_ptr<CGUIListItem>& item) { return false; }
 
   /*! \brief Open the info dialog for an item provided by this IListProvider.
    \param item the item that was clicked.
    \return true if the dialog was shown, false otherwise.
    */
-  virtual bool OnInfo(const CGUIListItemPtr &item)=0;
+  virtual bool OnInfo(const std::shared_ptr<CGUIListItem>& item) = 0;
 
   /*! \brief Open the context menu for an item provided by this IListProvider.
    \param item the item that was clicked.
    \return true if the click was handled, false otherwise.
    */
-  virtual bool OnContextMenu(const CGUIListItemPtr &item)=0;
+  virtual bool OnContextMenu(const std::shared_ptr<CGUIListItem>& item) = 0;
 
   /*! \brief Set the default item to focus. For backwards compatibility.
    \param item the item to focus.

--- a/xbmc/guilib/listproviders/MultiProvider.cpp
+++ b/xbmc/guilib/listproviders/MultiProvider.cpp
@@ -46,10 +46,10 @@ bool CMultiProvider::Update(bool forceRefresh)
   return result;
 }
 
-void CMultiProvider::Fetch(std::vector<CGUIListItemPtr> &items)
+void CMultiProvider::Fetch(std::vector<std::shared_ptr<CGUIListItem>>& items)
 {
   std::unique_lock<CCriticalSection> lock(m_section);
-  std::vector<CGUIListItemPtr> subItems;
+  std::vector<std::shared_ptr<CGUIListItem>> subItems;
   items.clear();
   m_itemMap.clear();
   for (auto const& provider : m_providers)
@@ -84,7 +84,7 @@ void CMultiProvider::Reset()
     provider->Reset();
 }
 
-bool CMultiProvider::OnClick(const CGUIListItemPtr &item)
+bool CMultiProvider::OnClick(const std::shared_ptr<CGUIListItem>& item)
 {
   std::unique_lock<CCriticalSection> lock(m_section);
   auto key = GetItemKey(item);
@@ -95,7 +95,7 @@ bool CMultiProvider::OnClick(const CGUIListItemPtr &item)
     return false;
 }
 
-bool CMultiProvider::OnInfo(const CGUIListItemPtr &item)
+bool CMultiProvider::OnInfo(const std::shared_ptr<CGUIListItem>& item)
 {
   std::unique_lock<CCriticalSection> lock(m_section);
   auto key = GetItemKey(item);
@@ -106,7 +106,7 @@ bool CMultiProvider::OnInfo(const CGUIListItemPtr &item)
     return false;
 }
 
-bool CMultiProvider::OnContextMenu(const CGUIListItemPtr &item)
+bool CMultiProvider::OnContextMenu(const std::shared_ptr<CGUIListItem>& item)
 {
   std::unique_lock<CCriticalSection> lock(m_section);
   auto key = GetItemKey(item);
@@ -117,7 +117,7 @@ bool CMultiProvider::OnContextMenu(const CGUIListItemPtr &item)
     return false;
 }
 
-CMultiProvider::item_key_type CMultiProvider::GetItemKey(CGUIListItemPtr const &item)
+CMultiProvider::item_key_type CMultiProvider::GetItemKey(std::shared_ptr<CGUIListItem> const& item)
 {
   return reinterpret_cast<item_key_type>(item.get());
 }

--- a/xbmc/guilib/listproviders/MultiProvider.h
+++ b/xbmc/guilib/listproviders/MultiProvider.h
@@ -29,16 +29,16 @@ public:
   // Implementation of IListProvider
   std::unique_ptr<IListProvider> Clone() override;
   bool Update(bool forceRefresh) override;
-  void Fetch(std::vector<CGUIListItemPtr> &items) override;
+  void Fetch(std::vector<std::shared_ptr<CGUIListItem>>& items) override;
   bool IsUpdating() const override;
   void Reset() override;
-  bool OnClick(const CGUIListItemPtr &item) override;
-  bool OnInfo(const CGUIListItemPtr &item) override;
-  bool OnContextMenu(const CGUIListItemPtr &item) override;
+  bool OnClick(const std::shared_ptr<CGUIListItem>& item) override;
+  bool OnInfo(const std::shared_ptr<CGUIListItem>& item) override;
+  bool OnContextMenu(const std::shared_ptr<CGUIListItem>& item) override;
 
 protected:
   typedef size_t item_key_type;
-  static item_key_type GetItemKey(CGUIListItemPtr const &item);
+  static item_key_type GetItemKey(std::shared_ptr<CGUIListItem> const& item);
   std::vector<IListProviderPtr> m_providers;
   std::map<item_key_type, IListProvider*> m_itemMap;
   CCriticalSection m_section; // protects m_itemMap

--- a/xbmc/guilib/listproviders/StaticProvider.cpp
+++ b/xbmc/guilib/listproviders/StaticProvider.cpp
@@ -91,7 +91,7 @@ bool CStaticListProvider::Update(bool forceRefresh)
   return changed; //! @todo Also returned changed if properties are changed (if so, need to update scroll to letter).
 }
 
-void CStaticListProvider::Fetch(std::vector<CGUIListItemPtr> &items)
+void CStaticListProvider::Fetch(std::vector<std::shared_ptr<CGUIListItem>>& items)
 {
   items.clear();
   for (const auto& i : m_items)
@@ -130,7 +130,7 @@ bool CStaticListProvider::AlwaysFocusDefaultItem() const
   return m_defaultAlways;
 }
 
-bool CStaticListProvider::OnClick(const CGUIListItemPtr &item)
+bool CStaticListProvider::OnClick(const std::shared_ptr<CGUIListItem>& item)
 {
   CGUIStaticItem *staticItem = static_cast<CGUIStaticItem*>(item.get());
   return staticItem->GetClickActions().ExecuteActions(0, m_parentID);

--- a/xbmc/guilib/listproviders/StaticProvider.h
+++ b/xbmc/guilib/listproviders/StaticProvider.h
@@ -24,10 +24,10 @@ public:
   // Implementation of IListProvider
   std::unique_ptr<IListProvider> Clone() override;
   bool Update(bool forceRefresh) override;
-  void Fetch(std::vector<CGUIListItemPtr> &items) override;
-  bool OnClick(const CGUIListItemPtr &item) override;
-  bool OnInfo(const CGUIListItemPtr &item) override { return false; }
-  bool OnContextMenu(const CGUIListItemPtr &item) override { return false; }
+  void Fetch(std::vector<std::shared_ptr<CGUIListItem>>& items) override;
+  bool OnClick(const std::shared_ptr<CGUIListItem>& item) override;
+  bool OnInfo(const std::shared_ptr<CGUIListItem>& item) override { return false; }
+  bool OnContextMenu(const std::shared_ptr<CGUIListItem>& item) override { return false; }
   void SetDefaultItem(int item, bool always) override;
   int GetDefaultItem() const override;
   bool AlwaysFocusDefaultItem() const override;

--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -1266,7 +1266,7 @@ namespace XBMCAddon
     void ControlList::sendLabelBind(int tail)
     {
       // construct a CFileItemList to pass 'em on to the list
-      CGUIListItemPtr items(new CFileItemList());
+      std::shared_ptr<CGUIListItem> items(new CFileItemList());
       for (unsigned int i = vecItems.size() - tail; i < vecItems.size(); i++)
         static_cast<CFileItemList*>(items.get())->Add(vecItems[i]->item);
 

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.cpp
@@ -1157,7 +1157,7 @@ void CGUIEPGGridContainer::UpdateBlock(bool bUpdateBlockTravelAxis /* = true */)
 
 CGUIListItemLayout* CGUIEPGGridContainer::GetFocusedLayout() const
 {
-  CGUIListItemPtr item = GetListItem(0);
+  std::shared_ptr<CGUIListItem> item = GetListItem(0);
 
   if (item)
     return item->GetFocusedLayout();
@@ -1363,11 +1363,10 @@ CFileItemPtr CGUIEPGGridContainer::GetSelectedGridItem(int offset /*= 0*/) const
   return item;
 }
 
-
-CGUIListItemPtr CGUIEPGGridContainer::GetListItem(int offset, unsigned int flag) const
+std::shared_ptr<CGUIListItem> CGUIEPGGridContainer::GetListItem(int offset, unsigned int flag) const
 {
   if (!m_gridModel->HasChannelItems())
-    return CGUIListItemPtr();
+    return std::shared_ptr<CGUIListItem>();
 
   int item = m_channelCursor + m_channelOffset + offset;
   if (flag & INFOFLAG_LISTITEM_POSITION)
@@ -1386,7 +1385,7 @@ CGUIListItemPtr CGUIEPGGridContainer::GetListItem(int offset, unsigned int flag)
     if (item >= 0 && item < m_gridModel->ChannelItemsSize())
       return m_gridModel->GetChannelItem(item);
   }
-  return CGUIListItemPtr();
+  return std::shared_ptr<CGUIListItem>();
 }
 
 std::string CGUIEPGGridContainer::GetLabel(int info) const
@@ -2141,7 +2140,7 @@ void CGUIEPGGridContainer::HandleChannels(bool bRender, unsigned int currentTime
   end += cacheAfterChannel * m_channelLayout->Size(m_orientation);
 
   float focusedPos = 0;
-  CGUIListItemPtr focusedItem;
+  std::shared_ptr<CGUIListItem> focusedItem;
 
   CFileItemPtr item;
   int current = chanOffset - cacheBeforeChannel;

--- a/xbmc/pvr/guilib/GUIEPGGridContainer.h
+++ b/xbmc/pvr/guilib/GUIEPGGridContainer.h
@@ -68,7 +68,7 @@ namespace PVR
     void Process(unsigned int currentTime, CDirtyRegionList& dirtyregions) override;
     void Render() override;
 
-    CGUIListItemPtr GetListItem(int offset, unsigned int flag = 0) const override;
+    std::shared_ptr<CGUIListItem> GetListItem(int offset, unsigned int flag = 0) const override;
     std::string GetLabel(int info) const override;
 
     std::shared_ptr<CFileItem> GetSelectedGridItem(int offset = 0) const;


### PR DESCRIPTION
## Description
I am trying to decouple CFileitem from GUI. The main idea is to introduce something in the lines of MVVM with a "viewmodel" that is useful for any type of view (GUI being one of them) but that would store intermediate objects. CGUIFileItem meets the requirements almost entirely for a direct move there except for the GUILayout dependency and similar stuff. So the idea is that instead of CFileItem extending CGUIFileitem it would extend a new object (CViewModelListitem) that would be generic enough to be present with or without GUI.
These typedefs make the work a bit harder and are getting in the way so lets just kill them in bulk.

## Motivation and context
We've been killing the usages of the typedef as we go, so just nuke them all to make our lifes easier. 

## How has this been tested?
Compiling is sufficient.

## What is the effect on users?
None

