### PR TITLE
[video] Fix 'Play using...' context menu item not visible for version…

### DIFF
--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -426,8 +426,11 @@ bool CVideoPlay::Execute(const std::shared_ptr<CFileItem>& itemIn) const
 
 bool CVideoPlayUsing::IsVisible(const CFileItem& item) const
 {
-  if (item.HasVideoVersions())
-    return false; // display "Play version using..." if multiple versions are available.
+  if (item.HasVideoVersions() &&
+      !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+          CSettings::SETTING_VIDEOLIBRARY_SHOWVIDEOVERSIONSASFOLDER) &&
+      !VIDEO::IsVideoAssetFile(item))
+    return false;
 
   if (item.IsLiveTV())
     return false;


### PR DESCRIPTION
…s displayed in versions folder mode.

Fixes a problem mentioned here: https://github.com/xbmc/xbmc/pull/24670#issuecomment-1935448852

Runtime-tested on macOS, latest Kodi master.

@CrystalP can you review and test?