### PR TITLE
changed: make AppInboundProtocol more self-contained

### DIFF
--- a/xbmc/application/AppInboundProtocol.cpp
+++ b/xbmc/application/AppInboundProtocol.cpp
@@ -12,15 +12,35 @@
 #include "application/Application.h"
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPowerHandling.h"
+#include "guilib/GUIComponent.h"
+#include "guilib/GUIWindowManager.h"
+#include "input/InputManager.h"
+#include "input/actions/Action.h"
+#include "input/actions/ActionIDs.h"
+#include "messaging/ApplicationMessenger.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/DisplaySettings.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
+#include "threads/SingleLock.h"
 
 CAppInboundProtocol::CAppInboundProtocol(CApplication &app) : m_pApp(app)
 {
-
 }
 
-bool CAppInboundProtocol::OnEvent(XBMC_Event &event)
+bool CAppInboundProtocol::OnEvent(const XBMC_Event& newEvent)
 {
-  return m_pApp.OnEvent(event);
+  std::unique_lock<CCriticalSection> lock(m_portSection);
+  if (m_closed)
+    return false;
+  m_portEvents.push_back(newEvent);
+  return true;
+}
+
+void CAppInboundProtocol::Close()
+{
+  std::unique_lock<CCriticalSection> lock(m_portSection);
+  m_closed = true;
 }
 
 void CAppInboundProtocol::SetRenderGUI(bool renderGUI)
@@ -28,4 +48,69 @@ void CAppInboundProtocol::SetRenderGUI(bool renderGUI)
   auto& components = CServiceBroker::GetAppComponents();
   const auto appPower = components.GetComponent<CApplicationPowerHandling>();
   appPower->SetRenderGUI(renderGUI);
+}
+
+void CAppInboundProtocol::HandleEvents()
+{
+  std::unique_lock<CCriticalSection> lock(m_portSection);
+  while (!m_portEvents.empty())
+  {
+    auto newEvent = m_portEvents.front();
+    m_portEvents.pop_front();
+    CSingleExit lock(m_portSection);
+    switch (newEvent.type)
+    {
+      case XBMC_QUIT:
+        if (!m_pApp.m_bStop)
+          CServiceBroker::GetAppMessenger()->PostMsg(TMSG_QUIT);
+        break;
+      case XBMC_VIDEORESIZE:
+        if (CServiceBroker::GetGUI()->GetWindowManager().Initialized())
+        {
+          if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_fullScreen)
+          {
+            CServiceBroker::GetWinSystem()->GetGfxContext().ApplyWindowResize(newEvent.resize.w,
+                                                                              newEvent.resize.h);
+
+            const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+            settings->SetInt(CSettings::SETTING_WINDOW_WIDTH, newEvent.resize.w);
+            settings->SetInt(CSettings::SETTING_WINDOW_HEIGHT, newEvent.resize.h);
+            settings->Save();
+          }
+          else
+          {
+            const auto& res_info = CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP);
+            CServiceBroker::GetWinSystem()->ForceFullScreen(res_info);
+          }
+        }
+        break;
+      case XBMC_VIDEOMOVE:
+      {
+        CServiceBroker::GetWinSystem()->OnMove(newEvent.move.x, newEvent.move.y);
+      }
+      break;
+      case XBMC_MODECHANGE:
+        CServiceBroker::GetWinSystem()->GetGfxContext().ApplyModeChange(newEvent.mode.res);
+        break;
+      case XBMC_SCREENCHANGE:
+        CServiceBroker::GetWinSystem()->OnChangeScreen(newEvent.screen.screenIdx);
+        break;
+      case XBMC_USEREVENT:
+        CServiceBroker::GetAppMessenger()->PostMsg(static_cast<uint32_t>(newEvent.user.code));
+        break;
+      case XBMC_SETFOCUS:
+      {
+        // Reset the screensaver
+        const auto appPower = m_pApp.GetComponent<CApplicationPowerHandling>();
+        appPower->ResetScreenSaver();
+        appPower->WakeUpScreenSaverAndDPMS();
+        // Send a mouse motion event with no dx,dy for getting the current guiitem selected
+        m_pApp.OnAction(CAction(ACTION_MOUSE_MOVE, 0, static_cast<float>(newEvent.focus.x),
+                                static_cast<float>(newEvent.focus.y), 0, 0));
+        break;
+      }
+      default:
+        CServiceBroker::GetInputManager().OnEvent(newEvent);
+    }
+  }
 }

--- a/xbmc/application/AppInboundProtocol.h
+++ b/xbmc/application/AppInboundProtocol.h
@@ -8,17 +8,28 @@
 
 #pragma once
 
+#include "threads/CriticalSection.h"
 #include "windowing/XBMC_events.h"
+
+#include <deque>
 
 class CApplication;
 
 class CAppInboundProtocol
 {
+  friend class CApplication;
+
 public:
-  CAppInboundProtocol(CApplication &app);
-  bool OnEvent(XBMC_Event &event);
+  CAppInboundProtocol(CApplication& app);
+  bool OnEvent(const XBMC_Event& newEvent);
   void SetRenderGUI(bool renderGUI);
+  void Close();
 
 protected:
+  void HandleEvents();
+
+  bool m_closed = false;
   CApplication &m_pApp;
+  std::deque<XBMC_Event> m_portEvents;
+  CCriticalSection m_portSection;
 };

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -244,76 +244,6 @@ CApplication::~CApplication(void)
   DeregisterComponent(typeid(CApplicationActionListeners));
 }
 
-bool CApplication::OnEvent(XBMC_Event& newEvent)
-{
-  std::unique_lock<CCriticalSection> lock(m_portSection);
-  m_portEvents.push_back(newEvent);
-  return true;
-}
-
-void CApplication::HandlePortEvents()
-{
-  std::unique_lock<CCriticalSection> lock(m_portSection);
-  while (!m_portEvents.empty())
-  {
-    auto newEvent = m_portEvents.front();
-    m_portEvents.pop_front();
-    CSingleExit lock(m_portSection);
-    switch(newEvent.type)
-    {
-      case XBMC_QUIT:
-        if (!m_bStop)
-          CServiceBroker::GetAppMessenger()->PostMsg(TMSG_QUIT);
-        break;
-      case XBMC_VIDEORESIZE:
-        if (CServiceBroker::GetGUI()->GetWindowManager().Initialized())
-        {
-          if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_fullScreen)
-          {
-            CServiceBroker::GetWinSystem()->GetGfxContext().ApplyWindowResize(newEvent.resize.w, newEvent.resize.h);
-
-            const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-            settings->SetInt(CSettings::SETTING_WINDOW_WIDTH, newEvent.resize.w);
-            settings->SetInt(CSettings::SETTING_WINDOW_HEIGHT, newEvent.resize.h);
-            settings->Save();
-          }
-          else
-          {
-            const auto& res_info = CDisplaySettings::GetInstance().GetResolutionInfo(RES_DESKTOP);
-            CServiceBroker::GetWinSystem()->ForceFullScreen(res_info);
-          }
-        }
-        break;
-      case XBMC_VIDEOMOVE:
-      {
-        CServiceBroker::GetWinSystem()->OnMove(newEvent.move.x, newEvent.move.y);
-      }
-        break;
-      case XBMC_MODECHANGE:
-        CServiceBroker::GetWinSystem()->GetGfxContext().ApplyModeChange(newEvent.mode.res);
-        break;
-      case XBMC_SCREENCHANGE:
-        CServiceBroker::GetWinSystem()->OnChangeScreen(newEvent.screen.screenIdx);
-        break;
-      case XBMC_USEREVENT:
-        CServiceBroker::GetAppMessenger()->PostMsg(static_cast<uint32_t>(newEvent.user.code));
-        break;
-      case XBMC_SETFOCUS:
-      {
-        // Reset the screensaver
-        const auto appPower = GetComponent<CApplicationPowerHandling>();
-        appPower->ResetScreenSaver();
-        appPower->WakeUpScreenSaverAndDPMS();
-        // Send a mouse motion event with no dx,dy for getting the current guiitem selected
-        OnAction(CAction(ACTION_MOUSE_MOVE, 0, static_cast<float>(newEvent.focus.x), static_cast<float>(newEvent.focus.y), 0, 0));
-        break;
-      }
-      default:
-        CServiceBroker::GetInputManager().OnEvent(newEvent);
-    }
-  }
-}
-
 extern "C" void __stdcall init_emu_environ();
 extern "C" void __stdcall update_emu_environ();
 extern "C" void __stdcall cleanup_emu_environ();
@@ -1585,7 +1515,7 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
     newEvent.type = XBMC_VIDEORESIZE;
     newEvent.resize.w = pMsg->param1;
     newEvent.resize.h = pMsg->param2;
-    OnEvent(newEvent);
+    m_pAppPort->OnEvent(newEvent);
     CServiceBroker::GetGUI()->GetWindowManager().MarkDirty();
   }
     break;
@@ -1744,7 +1674,7 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
     if (pMsg->lpVoid)
     {
       XBMC_Event* event = static_cast<XBMC_Event*>(pMsg->lpVoid);
-      OnEvent(*event);
+      m_pAppPort->OnEvent(*event);
       delete event;
     }
   }
@@ -1822,7 +1752,7 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
       }
     }
 
-    HandlePortEvents();
+    m_pAppPort->HandleEvents();
     CServiceBroker::GetInputManager().Process(CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindowOrDialog(), frameTime);
 
     if (processGUI && renderGUI)
@@ -2092,7 +2022,7 @@ bool CApplication::Stop(int exitCode)
         break;
       }
     }
-    m_pAppPort.reset();
+    m_pAppPort->Close();
   }
 
   try

--- a/xbmc/application/Application.h
+++ b/xbmc/application/Application.h
@@ -20,11 +20,9 @@
 #include "utils/GlobalsHandling.h"
 #include "utils/Stopwatch.h"
 #include "windowing/Resolution.h"
-#include "windowing/XBMC_events.h"
 
 #include <atomic>
 #include <chrono>
-#include <deque>
 #include <memory>
 #include <string>
 #include <vector>
@@ -88,8 +86,6 @@ class CApplication : public IWindowManagerCallback,
                      public CApplicationPlayerCallback,
                      public CApplicationSettingsHandling
 {
-friend class CAppInboundProtocol;
-
 public:
 
   // If playback time of current item is greater than this value, ACTION_PREV_ITEM will seek to start
@@ -200,16 +196,11 @@ protected:
   bool OnSettingsSaving() const override;
   void PlaybackCleanup();
 
-  // inbound protocol
-  bool OnEvent(XBMC_Event& newEvent);
-
   std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> m_pAnnouncementManager;
   std::unique_ptr<CGUIComponent> m_pGUI;
   std::unique_ptr<CWinSystemBase> m_pWinSystem;
   std::unique_ptr<ActiveAE::CActiveAE> m_pActiveAE;
   std::shared_ptr<CAppInboundProtocol> m_pAppPort;
-  std::deque<XBMC_Event> m_portEvents;
-  CCriticalSection m_portSection;
 
   // timer information
   CStopWatch m_restartPlayerTimer;
@@ -228,8 +219,6 @@ protected:
   std::unique_ptr<MUSIC_INFO::CMusicInfoScanner> m_musicInfoScanner;
 
   bool PlayStack(CFileItem& item, bool bRestart);
-
-  void HandlePortEvents();
 
   std::unique_ptr<CInertialScrollingHandler> m_pInertialScrollingHandler;
 


### PR DESCRIPTION
## Description
move the parts that was still CApplication (deque, lock, queue and handle events) into the AppInboundProtocol class.

add a method to close the port

## Motivation and context
More separation

## How has this been tested?
Builds, runs

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
