### PR TITLE
VideoPlayer: Fix error window for tempo/fractional play speeds

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2157,9 +2157,9 @@ void CVideoPlayer::HandlePlaySpeed()
         // the the bigger is the error we allow
         if (m_playSpeed > DVD_PLAYSPEED_NORMAL)
         {
-          int errorwin = m_playSpeed / DVD_PLAYSPEED_NORMAL;
-          if (errorwin > 8)
-            errorwin = 8;
+          double errorwin = static_cast<double>(m_playSpeed) / DVD_PLAYSPEED_NORMAL;
+          if (errorwin > 8.0)
+            errorwin = 8.0;
           error /= errorwin;
         }
 


### PR DESCRIPTION
## Description
When playing files with tempo enabled, `m_playSpeed` is not a multiple of `DVD_PLAYSPEED_NORMAL` hence the error window should account for the fractional value. E.g. with tempo of 1.5 the previous calculation would return 1 for the `errorwin` instead of 1.5. The `error` variable is already a double anyway. This makes the allowed error in such conditions a bit higher, enough to avoid the consecutive seeks when we seek into a given position with tempo enabled.

@FernetMenta I think this one is a no-brainer but your feedback is appreciated regardless

## Motivation and context
Fix picture freeze for a couple of seconds when seeking with tempo enabled
Should make https://github.com/xbmc/xbmc/issues/24324 a bit better (but won't close)

## How has this been tested?
Tempo enabled, seeking into different parts of the file. Seeking now happens pretty quick and doesn't lead to picture freeze.

## What is the effect on users?
Better seeks (with no picture freeze) when playing with tempo enabled

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

