### PR TITLE
[Subtitles][WebVTT] Implements signature verification through regex pattern.

### DIFF
--- a/cmake/installdata/test-reference-data.txt
+++ b/cmake/installdata/test-reference-data.txt
@@ -8,6 +8,13 @@ xbmc/cores/VideoPlayer/test/edl/testdata/mplayertimebasedinterleavedcuts.edl
 xbmc/cores/VideoPlayer/test/edl/testdata/mplayertimebasedmixed.edl
 xbmc/cores/VideoPlayer/test/edl/testdata/snapstream.mkv.chapters.xml
 xbmc/cores/VideoPlayer/test/edl/testdata/videoredo.Vprj
+xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/testdata/sample1_minimal.vtt
+xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/testdata/sample2_text_space_lf.vtt
+xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/testdata/sample3_text_tab_lf.vtt
+xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/testdata/sample4_text_space_crlf.vtt
+xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/testdata/sample5_text_tab_crlf.vtt
+xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/testdata/sample6_text_space_crcr.vtt
+xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/testdata/sample7_minimal_BOM.vtt
 xbmc/filesystem/test/data/httpdirectory/apache-default.html
 xbmc/filesystem/test/data/httpdirectory/apache-fancy.html
 xbmc/filesystem/test/data/httpdirectory/apache-html.html

--- a/cmake/treedata/common/tests.txt
+++ b/cmake/treedata/common/tests.txt
@@ -3,6 +3,7 @@ xbmc/addons/gui/skin/test         test/skin
 xbmc/cores/AudioEngine/Sinks/test test/audioengine_sinks
 xbmc/cores/VideoPlayer/test/edl   test/edl
 xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/test test/videoshaders
+xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt   test/webvtt
 xbmc/filesystem/test              test/filesystem
 xbmc/games/addons/input/test      test/games/addons/input
 xbmc/games/controllers/input/test test/games/controllers/input

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleStream.cpp
@@ -16,7 +16,6 @@
 #include "utils/Utf8Utils.h"
 #include "utils/log.h"
 
-#include <cstdio>
 #include <cstring>
 #include <memory>
 
@@ -28,7 +27,7 @@ bool CDVDSubtitleStream::Open(const std::string& strFile)
 {
   CFileItem item(strFile, false);
   item.SetContentLookup(false);
-  std::shared_ptr<CDVDInputStream> pInputStream(CDVDFactoryInputStream::CreateInputStream(NULL, item));
+  std::shared_ptr<CDVDInputStream> pInputStream(CDVDFactoryInputStream::CreateInputStream(nullptr, item));
   if (pInputStream && pInputStream->Open())
   {
     // prepare buffer
@@ -86,7 +85,7 @@ bool CDVDSubtitleStream::Open(const std::string& strFile)
       m_subtitleData = converted;
     }
 
-    m_arrayParser.Reset(m_subtitleData.c_str(), m_subtitleData.size());
+    m_arrayParser.Reset(m_subtitleData.c_str(), static_cast<int>(m_subtitleData.size()));
     return true;
   }
 

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleStream.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/DVDSubtitleStream.h
@@ -30,7 +30,7 @@ public:
    *         is known to be incompatible, e.g., vob sub files.
    *  \param[in] pInputStream The input stream for the subtitle to check.
    */
-  bool IsIncompatible(CDVDInputStream* pInputStream, std::vector<uint8_t>& buf, size_t* bytesRead);
+  static bool IsIncompatible(CDVDInputStream* pInputStream, std::vector<uint8_t>& buf, size_t* bytesRead);
 
   /*!
    *  \brief Read some data of specified length, from the current position

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitleParserWebVTT.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitleParserWebVTT.cpp
@@ -37,14 +37,16 @@ bool CSubtitleParserWebVTT::Open(CDVDStreamInfo& hints)
   if (!m_webvttHandler.Initialize())
     return false;
 
-  // Get the first chars to check WebVTT signature
-  if (!m_webvttHandler.CheckSignature(m_pStream->Read(10)))
+  std::string line;
+
+  // WebVTT signature is according to spec length-variable and stops
+  // with two consecutive line terminators.
+  // Get the first line to check WebVTT signature.
+  if(!(m_pStream->ReadLine(line) && m_webvttHandler.CheckSignature(line)))
     return false;
-  m_pStream->Seek(0);
 
   // Start decoding all lines
   std::vector<subtitleData> subtitleList;
-  std::string line;
 
   while (m_pStream->ReadLine(line))
   {

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitleParserWebVTT.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitleParserWebVTT.cpp
@@ -12,7 +12,6 @@
 #include "SubtitlesStyle.h"
 #include "cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.h"
 #include "utils/CharArrayParser.h"
-#include "utils/StringUtils.h"
 
 #include <vector>
 

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitleParserWebVTT.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitleParserWebVTT.h
@@ -17,7 +17,7 @@ class CSubtitleParserWebVTT : public CDVDSubtitleParserText, public CSubtitlesAd
 {
 public:
   CSubtitleParserWebVTT(std::unique_ptr<CDVDSubtitleStream>&& pStream, const std::string& strFile);
-  ~CSubtitleParserWebVTT() = default;
+  ~CSubtitleParserWebVTT() override = default;
 
   bool Open(CDVDStreamInfo& hints) override;
 };

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(SOURCES TestWebVTTSignatures.cpp)
+
+core_add_test_library(webvtt_test)

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/TestWebVTTSignatures.cpp
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/TestWebVTTSignatures.cpp
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (C) 2005-2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include <cmath>
+#include <gtest/gtest.h>
+#include "test/TestUtils.h"
+#include "cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.h"
+#include "cores/VideoPlayer/DVDSubtitles/SubtitleParserWebVTT.h"
+#include "cores/VideoPlayer/DVDStreamInfo.h"
+
+
+/*
+ * CSubtitleParserWebVTT will build up a subtitle stream.
+ * If CMAKE has ENABLE_OPTICAL it may blow up on MediaManager
+ * attempting to compare CDDrive paths.
+ * Disable ENABLE_OPTICAL to build CSubtitleParserWebVTT
+ * standalone without starting up entire ServiceManager
+ * architechture.
+ */
+
+TEST(TestWebVTT, TestWebVTTSignature_Minimal) {
+  std::string path = XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/testdata/sample1_minimal.vtt");
+  CSubtitleParserWebVTT parserWebVtt = CSubtitleParserWebVTT(nullptr, path);
+  CDVDStreamInfo hints = CDVDStreamInfo();
+  EXPECT_EQ(true, parserWebVtt.Open(hints));
+}
+
+TEST(TestWebVTT, TestWebVTTSignature_Text_Space_LF) {
+  std::string path = XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/testdata/sample2_text_space_lf.vtt");
+  CSubtitleParserWebVTT parserWebVtt = CSubtitleParserWebVTT(nullptr, path);
+  CDVDStreamInfo hints = CDVDStreamInfo();
+  EXPECT_EQ(true, parserWebVtt.Open(hints));
+}
+
+TEST(TestWebVTT, TestWebVTTSignature_Text_Tab_LF) {
+  std::string path = XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/testdata/sample3_text_tab_lf.vtt");
+  CSubtitleParserWebVTT parserWebVtt = CSubtitleParserWebVTT(nullptr, path);
+  CDVDStreamInfo hints = CDVDStreamInfo();
+  EXPECT_EQ(true, parserWebVtt.Open(hints));
+}
+
+TEST(TestWebVTT, TestWebVTTSignature_Text_Space_CRLF) {
+  std::string path = XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/testdata/sample4_text_space_crlf.vtt");
+  CSubtitleParserWebVTT parserWebVtt = CSubtitleParserWebVTT(nullptr, path);
+  CDVDStreamInfo hints = CDVDStreamInfo();
+  EXPECT_EQ(true, parserWebVtt.Open(hints));
+}
+
+TEST(TestWebVTT, TestWebVTTSignature_Text_Tab_CRLF) {
+  std::string path = XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/testdata/sample5_text_tab_crlf.vtt");
+  CSubtitleParserWebVTT parserWebVtt = CSubtitleParserWebVTT(nullptr, path);
+  CDVDStreamInfo hints = CDVDStreamInfo();
+  EXPECT_EQ(true, parserWebVtt.Open(hints));
+}
+
+TEST(TestWebVTT, TestWebVTTSignature_Text_Space_CR_No_LF) {
+  std::string path = XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/testdata/sample6_text_space_crcr.vtt");
+  CSubtitleParserWebVTT parserWebVtt = CSubtitleParserWebVTT(nullptr, path);
+  CDVDStreamInfo hints = CDVDStreamInfo();
+  EXPECT_EQ(true, parserWebVtt.Open(hints));
+}
+
+TEST(TestWebVTT, TestWebVTTSignature_BOM) {
+  std::string path = XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/testdata/sample7_minimal_BOM.vtt");
+  CSubtitleParserWebVTT parserWebVtt = CSubtitleParserWebVTT(nullptr, path);
+  CDVDStreamInfo hints = CDVDStreamInfo();
+  EXPECT_EQ(true, parserWebVtt.Open(hints));
+}

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/testdata/sample1_minimal.vtt
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/testdata/sample1_minimal.vtt
@@ -1,0 +1,26 @@
+WEBVTT
+
+00:10.851 --> 00:14.938
+[narrator] <i>This is some sample text
+of simple tags and line breaks,</i>
+
+00:15.022 --> 00:16.690
+<i>This is more text</i>
+
+00:17.441 --> 00:19.526
+<i>Another cue</i>
+
+00:19.609 --> 00:24.156
+<i>and more cues.</i>
+
+00:33.331 --> 00:35.333
+[bracketed cue]
+
+
+02:06.049 --> 02:09.177
+ALL CAPS TEXT
+WITH NO STYLING
+
+02:40.041 --> 02:43.170
+- Some standard dialogue
+- [Steve] Hi.

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/testdata/sample2_text_space_lf.vtt
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/testdata/sample2_text_space_lf.vtt
@@ -1,0 +1,26 @@
+WEBVTT arbitraryTextAfterSpaceHere
+
+00:10.851 --> 00:14.938
+[narrator] <i>This is some sample text
+of simple tags and line breaks,</i>
+
+00:15.022 --> 00:16.690
+<i>This is more text</i>
+
+00:17.441 --> 00:19.526
+<i>Another cue</i>
+
+00:19.609 --> 00:24.156
+<i>and more cues.</i>
+
+00:33.331 --> 00:35.333
+[bracketed cue]
+
+
+02:06.049 --> 02:09.177
+ALL CAPS TEXT
+WITH NO STYLING
+
+02:40.041 --> 02:43.170
+- Some standard dialogue
+- [Steve] Hi.

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/testdata/sample3_text_tab_lf.vtt
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/testdata/sample3_text_tab_lf.vtt
@@ -1,0 +1,26 @@
+WEBVTT	arbitraryTextAfterTabHere
+
+00:10.851 --> 00:14.938
+[narrator] <i>This is some sample text
+of simple tags and line breaks,</i>
+
+00:15.022 --> 00:16.690
+<i>This is more text</i>
+
+00:17.441 --> 00:19.526
+<i>Another cue</i>
+
+00:19.609 --> 00:24.156
+<i>and more cues.</i>
+
+00:33.331 --> 00:35.333
+[bracketed cue]
+
+
+02:06.049 --> 02:09.177
+ALL CAPS TEXT
+WITH NO STYLING
+
+02:40.041 --> 02:43.170
+- Some standard dialogue
+- [Steve] Hi.

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/testdata/sample4_text_space_crlf.vtt
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/testdata/sample4_text_space_crlf.vtt
@@ -1,0 +1,26 @@
+WEBVTT	arbitraryTextAfterTabHere
+
+00:10.851 --> 00:14.938
+[narrator] <i>This is some sample text
+of simple tags and line breaks,</i>
+
+00:15.022 --> 00:16.690
+<i>This is more text</i>
+
+00:17.441 --> 00:19.526
+<i>Another cue</i>
+
+00:19.609 --> 00:24.156
+<i>and more cues.</i>
+
+00:33.331 --> 00:35.333
+[bracketed cue]
+
+
+02:06.049 --> 02:09.177
+ALL CAPS TEXT
+WITH NO STYLING
+
+02:40.041 --> 02:43.170
+- Some standard dialogue
+- [Steve] Hi.

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/testdata/sample5_text_tab_crlf.vtt
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/testdata/sample5_text_tab_crlf.vtt
@@ -1,0 +1,26 @@
+WEBVTT	arbitraryTextAfterTabHere
+
+00:10.851 --> 00:14.938
+[narrator] <i>This is some sample text
+of simple tags and line breaks,</i>
+
+00:15.022 --> 00:16.690
+<i>This is more text</i>
+
+00:17.441 --> 00:19.526
+<i>Another cue</i>
+
+00:19.609 --> 00:24.156
+<i>and more cues.</i>
+
+00:33.331 --> 00:35.333
+[bracketed cue]
+
+
+02:06.049 --> 02:09.177
+ALL CAPS TEXT
+WITH NO STYLING
+
+02:40.041 --> 02:43.170
+- Some standard dialogue
+- [Steve] Hi.

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/testdata/sample6_text_space_crcr.vtt
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/testdata/sample6_text_space_crcr.vtt
@@ -1,0 +1,24 @@
+WEBVTT arbitraryTextAfterSpaceHere00:10.851 --> 00:14.938
+[narrator] <i>This is some sample text
+of simple tags and line breaks,</i>
+
+00:15.022 --> 00:16.690
+<i>This is more text</i>
+
+00:17.441 --> 00:19.526
+<i>Another cue</i>
+
+00:19.609 --> 00:24.156
+<i>and more cues.</i>
+
+00:33.331 --> 00:35.333
+[bracketed cue]
+
+
+02:06.049 --> 02:09.177
+ALL CAPS TEXT
+WITH NO STYLING
+
+02:40.041 --> 02:43.170
+- Some standard dialogue
+- [Steve] Hi.

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/testdata/sample7_minimal_BOM.vtt
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/test/webvtt/testdata/sample7_minimal_BOM.vtt
@@ -1,0 +1,4 @@
+﻿WEBVTT arbitraryTextAfterSpaceHere
+
+00:10.851 --> 00:14.938
+[narrator] <i>This is some sample textof simple tags and line breaks,</i>00:15.022 --> 00:16.690<i>This is more text</i>00:17.441 --> 00:19.526<i>Another cue</i>00:19.609 --> 00:24.156<i>and more cues.</i>00:33.331 --> 00:35.333[bracketed cue]02:06.049 --> 02:09.177ALL CAPS TEXTWITH NO STYLING02:40.041 --> 02:43.170- Some standard dialogue- [Steve] Hi.

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.h
@@ -219,6 +219,7 @@ private:
   bool m_overrideStyle{false};
   bool m_overridePositions{false};
   WebvttSection m_currentSection{WebvttSection::UNDEFINED};
+  CRegExp m_signatureRegex;
   CRegExp m_cueTimeRegex;
   CRegExp m_timeRegex;
   std::map<std::string, CRegExp> m_cuePropsMapRegex;

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/webvtt/WebVTTHandler.h
@@ -15,7 +15,7 @@
 #include <deque>
 #include <map>
 #include <memory>
-#include <stdio.h>
+#include <cstdio>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -115,12 +115,12 @@ enum class WebvttSelector
 
 struct webvttCssStyle
 {
-  webvttCssStyle() {}
+  webvttCssStyle() = default;
   webvttCssStyle(WebvttSelector selectorType,
-                 const std::string& selectorName,
+                 std::string  selectorName,
                  const std::string& colorHexRGB)
     : m_selectorType{selectorType},
-      m_selectorName{selectorName},
+      m_selectorName{std::move(selectorName)},
       // Color hex values need to be in BGR format
       m_color(colorHexRGB.substr(4, 2) + colorHexRGB.substr(2, 2) + colorHexRGB.substr(0, 2))
   {
@@ -147,8 +147,8 @@ struct tagToken
 class CWebVTTHandler
 {
 public:
-  CWebVTTHandler(){};
-  ~CWebVTTHandler(){};
+  CWebVTTHandler()= default;
+  ~CWebVTTHandler()= default;
 
   /*!
   * \brief Prepare the handler to the decoding
@@ -175,7 +175,7 @@ public:
   /*
    * \brief Return true if the margins are handled by the parser.
    */
-  bool IsForcedMargins() const { return !m_overridePositions; }
+  [[nodiscard]] bool IsForcedMargins() const { return !m_overridePositions; }
 
   /*
    * \brief Set the period start pts to sync subtitles
@@ -201,7 +201,7 @@ private:
                               int& pos,
                               int flagTags[],
                               std::deque<std::pair<std::string, webvttCssStyle*>>& cssTagsOpened);
-  void InsertCssStyleCloseTag(const tagToken& tag,
+  static void InsertCssStyleCloseTag(const tagToken& tag,
                               std::string& text,
                               int& pos,
                               int flagTags[],
@@ -210,7 +210,7 @@ private:
   bool GetBaseStyle(webvttCssStyle& style);
   void ConvertAddSubtitle(std::vector<subtitleData>* subList);
   void LoadColors();
-  double GetTimeFromRegexTS(CRegExp& regex, int indexStart = 1);
+  static double GetTimeFromRegexTS(CRegExp& regex, int indexStart = 1);
 
   // Last subtitle data added, must persist and be updated between all demuxer packages
   std::unique_ptr<subtitleData> m_lastSubtitleData;


### PR DESCRIPTION
## Description

Discards the old magic character fixed-length implementation of signature verification for a simple regex match.

## Motivation and context

Current signature verification for webvtt is not spec-compliant.

According to [the spec](https://www.w3.org/TR/webvtt1/#file-structure), the signature can be variable-length, and has some weird and specific interactions with whitespace characters.

Since the regular line decode in the parser properly consumes the BOM and carriage returns, one more simple regex pattern can deal with unusually formatted signatures as regex is already being used extensively in the VTT handler.


## How has this been tested?
Added a couple of minimal valid .vtt files into the testdata with various permutations of whitespace and extra text in the signature.

Set up and ran a few GTests tests using these vtt files.

Tests and builds were ran in an Ubuntu 23.10 machine with gcc 11.4.0 with default CMake config except ENABLE_OPTICAL disabled for tests, as the new tests build an instance of the parser directly, which can trigger `CMediaManager::TranslateDevicePath` which failed immediately when attempting to lock `m_muAutoSource`. Without ENABLE_OPTICAL, that path is never triggered as it's only used to check for optical drive paths.

Other then that testing quirk, all source changes are fairly minimal and locally limited. Should not affect any of the API surface beyond the actual parser and handler.

## What is the effect on users?

This should allow .webm video files which use WebVTT exclusively to be properly decoded (had a few .webm files trip up on signature verification with valid signatures).

<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
