### PR TITLE
KeymapAction Overloading fix

### DIFF
--- a/system/keymaps/joystick.xml
+++ b/system/keymaps/joystick.xml
@@ -28,14 +28,29 @@
 <!--     <a holdtime="500">ContextMenu</a>                                   -->
 <!--   </joystick>                                                           -->
 <!--                                                                         -->
-<!-- Buttons can be also require hotkeys to be pressed:                      -->
+<!-- Buttons can be overloaded with hotkeys:                                 -->
 <!--   <joystick profile="game.controller.default">                          -->
-<!--     <start hotkey="back">Stop</start>                                   -->
+<!--     <a>Select</a>                                                       -->
+<!--     <a hotkey="back">ContextMenu</a>                                    -->
 <!--   </joystick>                                                           -->
 <!--                                                                         -->
-<!-- Due to limitations in the button mapper, buttons can be overloaded with -->
-<!-- different hold durations, but not different hotkeys for the same        -->
-<!-- duration.                                                               -->
+<!-- It is even possible to combine both hotkeys and hold durations:         -->
+<!--   <joystick profile="game.controller.default">                          -->
+<!--     <a>Select</a>                                                       -->
+<!--     <a hotkey="back">ContextMenu</a>                                    -->
+<!--     <a hotkey="back" holdtime="500">Stop</a>                            -->
+<!--   </joystick>                                                           -->
+<!--                                                                         -->
+<!-- Both hold duration and hotkeys can be the only stand alone variant of   -->
+<!-- an action:                                                              -->
+<!--   <joystick profile="game.controller.default">                          -->
+<!--     <a hotkey="back">ContextMenu</a>                                    -->
+<!--     <b holdtime="500">Stop</b>                                          -->
+<!--   </joystick>                                                           -->
+<!--                                                                         -->
+<!-- A limitation is that if a single press is mapped in a section, a        -->
+<!-- global "holdtime" overload will be ignored. The workaround is to        -->
+<!-- duplicate the holdtime overload in the section.                         -->
 <!--                                                                         -->
 <!-- More documentation on keymaps can be found on                           -->
 <!-- http://kodi.wiki/view/keymaps                                           -->

--- a/xbmc/input/keymaps/KeymapTypes.h
+++ b/xbmc/input/keymaps/KeymapTypes.h
@@ -38,7 +38,7 @@ struct KeymapAction
 struct KeymapActionGroup
 {
   int windowId = -1;
-  std::set<KeymapAction> actions;
+  std::multiset<KeymapAction> actions;
 };
 } // namespace KEYMAP
 } // namespace KODI


### PR DESCRIPTION
Modified KeymapActionGroup actions to be a multiset. This allows for hotkey overrides with the same hold durations. Updated joystick.xml comments to showcase new behavior.

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
The KeymapActionGroup action property used a std::set. I modified it to use a std::multiset.

<!--- Describe your change in detail here. -->
The std::set was used for automatic sorting, and that was based on the action's holdTimeMs as provided by the action's < operator. The std::set also enforced uniqueness based on that comparison operator. If you attempted to add another action with the same duration, regardless of the hotkeys, it would be discarded by the set. The std::multiset will still sort by the provided comparison operator, but will not enforce uniqueness in the set. 

This will not cause problems elsewhere because in MapAction.cpp line 28, we are already doing a unique check with the combination of holdTimeMs and hotkeys.


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
I was customizing my joystick.xml file when I learned about overriding, but was disappointed when learning overloading was so limited. With proper overloading I could double the amount of actions available to me with quick access on just the controller, allowing less need for system navigation. I wanted this fix.

<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
I built Kodi with my change, and modified my joystick.xml by adding multiple variations of hotkey and hold duration overloads to a button, along with repeated overloads, and tested that each of them was available/not available to me. All overloads I expected to be available were, I had no overload conflicts, and a when repeated overloads with different actions were declared, the last one declared was the action that was used.

Though i could find no evidence keyboards would be affected, I also tested keyboard actions in FullscreenVideo with existing overloaded keys, and i added more variations to confirm they still work as expected.


<!--- Include details of your testing environment, and the tests you ran to -->
I built and installed on Windows 11 machines. They are vanilla windows environments, no modificaitons. I built on one machine, and installed on a second for my tests. I used an xbox series controller and a standard keyboard in my tests.


<!--- see how your change affects other areas of the code, etc. -->
The folder structure makes it look like this will affect ALL sources of input, because the KeymapAction file is in the keymap folder, not in joysticks, but from my searches ONLY joystick uses the holdDurationMs value and ONLY joysticks uses CWindowKeymap::MapAction. Keyboards use the mod "longpress", which is imported and handled by different classes. I did not dive into remote and touch, but the searches didn't bring up any code from there.


## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
This will not have immediate affects on any users. I didn't modify existing functionality, only allowed for greater functionality through end user customization. Though I would like to see increased default functionality in joystick keymaps in the future.

<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
       I do not know where to add a test. Will accept advice
- [ ] All new and existing tests passed 
       I have not found how to run tests. Will accept advice
