### PR TITLE
VideoPlayer: Fix stalls when seeking with tempo enabled

### DIFF
--- a/xbmc/cores/VideoPlayer/AudioSinkAE.cpp
+++ b/xbmc/cores/VideoPlayer/AudioSinkAE.cpp
@@ -112,11 +112,12 @@ unsigned int CAudioSinkAE::AddPackets(const DVDAudioFrame &audioframe)
     m_syncError = 0.0;
   }
 
-  //Calculate a timeout when this definitely should be done
+  // Calculate a timeout when this definitely should be done
   double timeout;
   timeout  = DVD_SEC_TO_TIME(m_pAudioStream->GetDelay()) + audioframe.duration;
   timeout += DVD_SEC_TO_TIME(1.0);
   timeout += m_pClock->GetAbsoluteClock();
+  timeout *= m_pClock->GetClockSpeed();
 
   unsigned int total = audioframe.nb_frames - audioframe.framesOut;
   unsigned int frames = total;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3989,8 +3989,9 @@ void CVideoPlayer::FlushBuffers(double pts, bool accurate, bool sync)
   m_VideoPlayerRadioRDS->Flush();
   m_VideoPlayerAudioID3->Flush();
 
-  if (m_playSpeed == DVD_PLAYSPEED_NORMAL ||
-      m_playSpeed == DVD_PLAYSPEED_PAUSE)
+  if (m_playSpeed == DVD_PLAYSPEED_NORMAL || m_playSpeed == DVD_PLAYSPEED_PAUSE ||
+      (m_playSpeed >= DVD_PLAYSPEED_NORMAL * m_processInfo->MinTempoPlatform() &&
+       m_playSpeed <= DVD_PLAYSPEED_NORMAL * m_processInfo->MaxTempoPlatform()))
   {
     // make sure players are properly flushed, should put them in stalled state
     auto msg = std::make_shared<CDVDMsgGeneralSynchronize>(1s, SYNCSOURCE_AUDIO | SYNCSOURCE_VIDEO);


### PR DESCRIPTION
## Description
This should fix player "stalls" when doing seeks with tempo enabled. https://github.com/xbmc/xbmc/pull/24692 helped but there were still two issues:
- With tempo  audio and video are active and sync needs to exist for both. On `FlushBuffers` sync was being ignored and was only considered for `DVD_PLAYSPEED_NORMAL`. While for ff/rw sync should not be done (audio is muted) for tempo it must be taken into account.
- The timeout calculation in the audiosink was not considering the clock speed, returning values higher (in case the tempo was < 1) than it should, leading the player to wait for longer times than it should.

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/24324

## How has this been tested?
Runtime tested on Linux. Seeks while speed is normal, tempo enabled (> and < 1) and with ff/rw. 

## What is the effect on users?
Seeks now happen pretty much instantaneously if playback has tempo enabled.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
