### PR TITLE
DXVA: Use at least 8 surfaces for H.264 decoding

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp
@@ -29,6 +29,7 @@
 #include "utils/SystemInfo.h"
 #include "utils/log.h"
 
+#include <algorithm>
 #include <mutex>
 
 #include <Windows.h>
@@ -1376,7 +1377,8 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, enum AVPixel
     break;
   case AV_CODEC_ID_H264:
     // by specification h264 decoder can hold up to 16 unique refs
-    m_refs += avctx->refs ? avctx->refs : 16;
+    // but use 8 at least to avoid potential issues in some rare streams
+    m_refs += std::max(8, avctx->refs ? avctx->refs : 16);
     break;
   case AV_CODEC_ID_VP9:
     m_refs += 8;


### PR DESCRIPTION
## Description
DXVA: Use at least 8 surfaces for H.264 decoding

## Motivation and context
Issue reported on Slack #Windows: some rare dash encrypted streams (H.264) are decoded corrupted using DXVA2 due insufficient surfaces. Works fine with DXVA2 acceleration disabled.

H.264 reports in headers / container number of surfaces needed for decoding based on number of refs used for encode (video encoding parameters used to create the stream). But some times this info may be wrong/inaccurate or decoder implementation of vendor (NVIDIA, AMD, etc.) may require additional surfaces due multi-threading / slices or some other parameter / feature used in one particular stream.

Currently for H.264 we using only the minimum required surfaces e.g. 4 if video itself has 4 references:

```
Video
ID                                       : 5
Format                                   : AVC
Format/Info                              : Advanced Video Codec
Format profile                           : High@L3.1
Format settings                          : CABAC / 4 Ref Frames
Format settings, CABAC                   : Yes
Format settings, Reference frames        : 4 frames
Codec ID                                 : encv / avc1
Codec ID/Info                            : Advanced Video Coding
Duration                                 : 11 min 34 s
Width                                    : 1 280 pixels
Height                                   : 720 pixels
Display aspect ratio                     : 16:9
Frame rate                               : 25.000 FPS
Color space                              : YUV
Chroma subsampling                       : 4:2:0
Bit depth                                : 8 bits
Scan type                                : Progressive
Encoded date                             : 2023-11-30 18:18:06 UTC
Tagged date                              : 2023-11-30 18:18:06 UTC
Encryption                               : Encrypted
mdhd_Duration                            : 694320
Codec configuration box                  : avcC
```

Proposed improvement is use always a minimum of 8 as is enough to handle 99% of cases (H.264 technically supports up to 16 refs but very rarely are used such quantity and anyway if is corrected signaled would be used).

8 is a sane number also always used for AV1, VP9 and usually in H265. As Kodi needs other 8 surfaces for rendering in total is 16 surfaces that is fine for use also in 4K resolution on Xbox:

https://github.com/xbmc/xbmc/blob/18a5d7b662377b2ef40a5dcc9637bda4a9fc1aac/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.cpp#L1405-L1412


This also may fix others corruption issues reported sporadically, especially on Xbox using live TV streams like:
https://forum.kodi.tv/showthread.php?tid=365273



## How has this been tested?
Runtime in Windows x64 
However the encrypted test stream seems is not available anymore. 
Tested with regular H.264 stream (not encrypted) and checked that works fine using in total 16 surfaces (8 decoding + 8 rendering).


## What is the effect on users?
Fixes video corruption decoding some rare H.264 / AVC streams  

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
