### PR TITLE
GetOpticalMediaPath: move to video utils

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -60,6 +60,7 @@
 #include "video/Bookmark.h"
 #include "video/VideoDatabase.h"
 #include "video/VideoInfoTag.h"
+#include "video/VideoUtils.h"
 
 #include <algorithm>
 #include <cstdlib>
@@ -1308,7 +1309,7 @@ bool CFileItem::IsBluray() const
   if (URIUtils::IsBluray(m_strPath))
     return true;
 
-  CFileItem item = CFileItem(GetOpticalMediaPath(), false);
+  CFileItem item = CFileItem(VIDEO_UTILS::GetOpticalMediaPath(*this), false);
 
   return item.IsBDFile();
 }
@@ -2006,37 +2007,6 @@ void CFileItem::SetFromSong(const CSong &song)
   if (!song.strThumb.empty())
     SetArt("thumb", song.strThumb);
   FillInMimeType(false);
-}
-
-std::string CFileItem::GetOpticalMediaPath() const
-{
-  std::string path;
-  path = URIUtils::AddFileToFolder(GetPath(), "VIDEO_TS.IFO");
-  if (CFile::Exists(path))
-    return path;
-
-  path = URIUtils::AddFileToFolder(GetPath(), "VIDEO_TS", "VIDEO_TS.IFO");
-  if (CFile::Exists(path))
-    return path;
-
-#ifdef HAVE_LIBBLURAY
-  path = URIUtils::AddFileToFolder(GetPath(), "index.bdmv");
-  if (CFile::Exists(path))
-    return path;
-
-  path = URIUtils::AddFileToFolder(GetPath(), "BDMV", "index.bdmv");
-  if (CFile::Exists(path))
-    return path;
-
-  path = URIUtils::AddFileToFolder(GetPath(), "INDEX.BDM");
-  if (CFile::Exists(path))
-    return path;
-
-  path = URIUtils::AddFileToFolder(GetPath(), "BDMV", "INDEX.BDM");
-  if (CFile::Exists(path))
-    return path;
-#endif
-  return std::string();
 }
 
 /**
@@ -2960,7 +2930,7 @@ void CFileItemList::StackFolders()
         // check for dvd folders
         if (!bMatch)
         {
-          std::string dvdPath = item->GetOpticalMediaPath();
+          std::string dvdPath = VIDEO_UTILS::GetOpticalMediaPath(*item);
 
           if (!dvdPath.empty())
           {

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -157,14 +157,6 @@ public:
   bool Exists(bool bUseCache = true) const;
 
   /*!
-   \brief Check whether an item is an optical media folder or its parent.
-    This will return the non-empty path to the playable entry point of the media
-    one or two levels down (VIDEO_TS.IFO for DVDs or index.bdmv for BDs).
-    The returned path will be empty if folder does not meet this criterion.
-   \return non-empty string if item is optical media folder, empty otherwise.
-   */
-  std::string GetOpticalMediaPath() const;
-  /*!
    \brief Check whether an item is a video item. Note that this returns true for
     anything with a video info tag, so that may include eg. folders.
    \return true if item is video, false otherwise.

--- a/xbmc/video/VideoUtils.cpp
+++ b/xbmc/video/VideoUtils.cpp
@@ -182,33 +182,23 @@ namespace VIDEO_UTILS
 {
 std::string GetOpticalMediaPath(const CFileItem& item)
 {
-  std::string path;
-  path = URIUtils::AddFileToFolder(item.GetPath(), "VIDEO_TS.IFO");
-  if (CFileUtils::Exists(path))
-    return path;
+  auto exists = [&item](const std::string& file)
+  {
+    const std::string path = URIUtils::AddFileToFolder(item.GetPath(), file);
+    return CFileUtils::Exists(path);
+  };
 
-  path = URIUtils::AddFileToFolder(item.GetPath(), "VIDEO_TS", "VIDEO_TS.IFO");
-  if (CFileUtils::Exists(path))
-    return path;
-
+  using namespace std::string_literals;
+  const auto files = std::array{
+      "VIDEO_TS.IFO"s,    "VIDEO_TS/VIDEO_TS.IFO"s,
 #ifdef HAVE_LIBBLURAY
-  path = URIUtils::AddFileToFolder(item.GetPath(), "index.bdmv");
-  if (CFileUtils::Exists(path))
-    return path;
-
-  path = URIUtils::AddFileToFolder(item.GetPath(), "BDMV", "index.bdmv");
-  if (CFileUtils::Exists(path))
-    return path;
-
-  path = URIUtils::AddFileToFolder(item.GetPath(), "INDEX.BDM");
-  if (CFileUtils::Exists(path))
-    return path;
-
-  path = URIUtils::AddFileToFolder(item.GetPath(), "BDMV", "INDEX.BDM");
-  if (CFileUtils::Exists(path))
-    return path;
+      "index.bdmv"s,      "INDEX.BDM"s,
+      "BDMV/index.bdmv"s, "BDMV/INDEX.BDM"s,
 #endif
-  return std::string();
+  };
+
+  const auto it = std::find_if(files.begin(), files.end(), exists);
+  return it != files.end() ? URIUtils::AddFileToFolder(item.GetPath(), *it) : std::string{};
 }
 
 bool IsAutoPlayNextItem(const CFileItem& item)

--- a/xbmc/video/VideoUtils.cpp
+++ b/xbmc/video/VideoUtils.cpp
@@ -17,11 +17,14 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
+#include "utils/FileUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
 #include "video/VideoInfoTag.h"
 
+#include <algorithm>
+#include <array>
 #include <cstdint>
 #include <vector>
 
@@ -177,6 +180,37 @@ VIDEO_UTILS::ResumeInformation GetNonFolderItemResumeInformation(const CFileItem
 
 namespace VIDEO_UTILS
 {
+std::string GetOpticalMediaPath(const CFileItem& item)
+{
+  std::string path;
+  path = URIUtils::AddFileToFolder(item.GetPath(), "VIDEO_TS.IFO");
+  if (CFileUtils::Exists(path))
+    return path;
+
+  path = URIUtils::AddFileToFolder(item.GetPath(), "VIDEO_TS", "VIDEO_TS.IFO");
+  if (CFileUtils::Exists(path))
+    return path;
+
+#ifdef HAVE_LIBBLURAY
+  path = URIUtils::AddFileToFolder(item.GetPath(), "index.bdmv");
+  if (CFileUtils::Exists(path))
+    return path;
+
+  path = URIUtils::AddFileToFolder(item.GetPath(), "BDMV", "index.bdmv");
+  if (CFileUtils::Exists(path))
+    return path;
+
+  path = URIUtils::AddFileToFolder(item.GetPath(), "INDEX.BDM");
+  if (CFileUtils::Exists(path))
+    return path;
+
+  path = URIUtils::AddFileToFolder(item.GetPath(), "BDMV", "INDEX.BDM");
+  if (CFileUtils::Exists(path))
+    return path;
+#endif
+  return std::string();
+}
+
 bool IsAutoPlayNextItem(const CFileItem& item)
 {
   if (!item.HasVideoInfoTag())

--- a/xbmc/video/VideoUtils.h
+++ b/xbmc/video/VideoUtils.h
@@ -14,6 +14,15 @@ class CFileItem;
 
 namespace VIDEO_UTILS
 {
+/*!
+ \brief Check whether an item is an optical media folder or its parent.
+  This will return the non-empty path to the playable entry point of the media
+  one or two levels down (VIDEO_TS.IFO for DVDs or index.bdmv for BDs).
+  The returned path will be empty if folder does not meet this criterion.
+ \return non-empty string if item is optical media folder, empty otherwise.
+ */
+std::string GetOpticalMediaPath(const CFileItem& item);
+
 /*! \brief Check whether auto play next item is set for the media type of the given item.
   \param item [in] the item to check
   \return True if auto play next item is active, false otherwise.

--- a/xbmc/video/guilib/VideoGUIUtils.cpp
+++ b/xbmc/video/guilib/VideoGUIUtils.cpp
@@ -134,7 +134,7 @@ void CAsyncGetItemsForPlaylist::GetItemsForPlaylist(const std::shared_ptr<CFileI
   if (item->m_bIsFolder)
   {
     // check if it's a folder with dvd or bluray files, then just add the relevant file
-    const std::string mediapath = item->GetOpticalMediaPath();
+    const std::string mediapath = VIDEO_UTILS::GetOpticalMediaPath(*item);
     if (!mediapath.empty())
     {
       m_queuedItems.Add(std::make_shared<CFileItem>(mediapath, false));

--- a/xbmc/video/test/CMakeLists.txt
+++ b/xbmc/video/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES TestStacks.cpp
-            TestVideoInfoScanner.cpp)
+            TestVideoInfoScanner.cpp
+            TestVideoUtils.cpp)
 
 core_add_test_library(video_test)

--- a/xbmc/video/test/TestVideoUtils.cpp
+++ b/xbmc/video/test/TestVideoUtils.cpp
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "FileItem.h"
+#include "Util.h"
+#include "filesystem/Directory.h"
+#include "platform/Filesystem.h"
+#include "utils/FileUtils.h"
+#include "utils/URIUtils.h"
+#include "video/VideoUtils.h"
+
+#include <array>
+#include <fstream>
+
+#include <gtest/gtest.h>
+
+namespace fs = KODI::PLATFORM::FILESYSTEM;
+
+using OptDef = std::pair<std::string, bool>;
+
+class OpticalMediaPathTest : public testing::WithParamInterface<OptDef>, public testing::Test
+{
+};
+
+TEST_P(OpticalMediaPathTest, GetOpticalMediaPath)
+{
+  std::error_code ec;
+  const std::string temp_path = fs::create_temp_directory(ec);
+  EXPECT_FALSE(ec);
+  const std::string file_path = URIUtils::AddFileToFolder(temp_path, GetParam().first);
+  EXPECT_TRUE(CUtil::CreateDirectoryEx(URIUtils::GetDirectory(file_path)));
+  {
+    std::ofstream of(file_path);
+  }
+  CFileItem item(temp_path, true);
+  if (GetParam().second)
+    EXPECT_EQ(VIDEO_UTILS::GetOpticalMediaPath(item), file_path);
+  else
+    EXPECT_EQ(VIDEO_UTILS::GetOpticalMediaPath(item), "");
+
+  XFILE::CDirectory::RemoveRecursive(temp_path);
+}
+
+const auto mediapath_tests = std::array{
+    OptDef{"VIDEO_TS.IFO", true},    OptDef{"VIDEO_TS/VIDEO_TS.IFO", true},
+    OptDef{"some.file", false},
+#ifdef HAVE_LIBBLURAY
+    OptDef{"index.bdmv", true},      OptDef{"INDEX.BDM", true},
+    OptDef{"BDMV/index.bdmv", true}, OptDef{"BDMV/INDEX.BDM", true},
+#endif
+};
+
+INSTANTIATE_TEST_SUITE_P(TestVideoUtils, OpticalMediaPathTest, testing::ValuesIn(mediapath_tests));

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -286,7 +286,8 @@ bool CGUIWindowVideoBase::OnItemInfo(const CFileItem& fileItem)
       CDirectory::GetDirectory(item.GetPath(), items, fileExts, DIR_FLAG_DEFAULTS);
 
       // Check for cases 1_dir/1_dir/.../file (e.g. by packages where have a extra folder)
-      while (items.Size() == 1 && items[0]->m_bIsFolder && items[0]->GetOpticalMediaPath().empty())
+      while (items.Size() == 1 && items[0]->m_bIsFolder &&
+             VIDEO_UTILS::GetOpticalMediaPath(*items[0]).empty())
       {
         const std::string path = items[0]->GetPath();
         items.Clear();


### PR DESCRIPTION
## Description
Move GetOpticalMediaPath from CFileItem to VideoUtils

## Motivation and context:
This method has very little to do with the item apart from using its path. Let's trim some fat off CFileItem.

## How has this been tested?
It works.

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
