### PR TITLE
[Estuary] Fix player controls

### DIFF
--- a/addons/skin.estuary/xml/MusicOSD.xml
+++ b/addons/skin.estuary/xml/MusicOSD.xml
@@ -46,14 +46,14 @@
 						<param name="texture" value="osd/fullscreen/buttons/previous.png"/>
 					</include>
 					<onclick>PlayerControl(Previous)</onclick>
-					<visible>Player.ChapterCount | MusicPlayer.HasPrevious | [Player.SeekEnabled + MusicPlayer.Content(livetv)]</visible>
+					<enable>Player.ChapterCount | MusicPlayer.HasPrevious | [Player.SeekEnabled + MusicPlayer.Content(livetv)]</enable>
 				</control>
 				<control type="radiobutton" id="601">
 					<include content="OSDButton">
 						<param name="texture" value="osd/fullscreen/buttons/rewind.png"/>
 					</include>
 					<onclick>PlayerControl(Rewind)</onclick>
-					<visible>[Player.SeekEnabled + !MusicPlayer.Content(livetv)] + !Player.Paused</visible>
+					<enable>[Player.SeekEnabled + !MusicPlayer.Content(livetv)] + !Player.Paused</enable>
 				</control>
 				<control type="group" id="698">
 					<width>76</width>
@@ -94,14 +94,14 @@
 						<param name="texture" value="osd/fullscreen/buttons/forward.png"/>
 					</include>
 					<onclick>PlayerControl(Forward)</onclick>
-					<visible>[Player.SeekEnabled + !MusicPlayer.Content(livetv)] + !Player.Paused</visible>
+					<enable>[Player.SeekEnabled + !MusicPlayer.Content(livetv)] + !Player.Paused</enable>
 				</control>
 				<control type="radiobutton" id="607">
 					<include content="OSDButton">
 						<param name="texture" value="osd/fullscreen/buttons/next.png"/>
 					</include>
 					<onclick>PlayerControl(Next)</onclick>
-					<visible>Player.ChapterCount | MusicPlayer.HasNext | PVR.IsTimeShift</visible>
+					<enable>Player.ChapterCount | MusicPlayer.HasNext | PVR.IsTimeShift</enable>
 				</control>
 				<control type="radiobutton" id="608">
 					<textureradioonfocus colordiffuse="white">osd/fullscreen/buttons/record-white.png</textureradioonfocus>

--- a/addons/skin.estuary/xml/MusicOSD.xml
+++ b/addons/skin.estuary/xml/MusicOSD.xml
@@ -46,14 +46,15 @@
 						<param name="texture" value="osd/fullscreen/buttons/previous.png"/>
 					</include>
 					<onclick>PlayerControl(Previous)</onclick>
-					<enable>Player.ChapterCount | MusicPlayer.HasPrevious | [Player.SeekEnabled + MusicPlayer.Content(livetv)]</enable>
+					<visible>Player.ChapterCount | MusicPlayer.HasPrevious | [Player.SeekEnabled + MusicPlayer.Content(livetv)]</visible>
 				</control>
 				<control type="radiobutton" id="601">
 					<include content="OSDButton">
 						<param name="texture" value="osd/fullscreen/buttons/rewind.png"/>
 					</include>
-					<onclick>PlayerControl(Rewind)</onclick>
-					<enable>[Player.SeekEnabled + !MusicPlayer.Content(livetv)] + !Player.Paused</enable>
+					<onclick condition="Player.Paused">PlayerControl(Play)</onclick>
+					<onclick condition="!Player.Paused">PlayerControl(Rewind)</onclick>
+					<visible>Player.SeekEnabled + !MusicPlayer.Content(livetv)</visible>
 				</control>
 				<control type="group" id="698">
 					<width>76</width>
@@ -93,15 +94,16 @@
 					<include content="OSDButton">
 						<param name="texture" value="osd/fullscreen/buttons/forward.png"/>
 					</include>
-					<onclick>PlayerControl(Forward)</onclick>
-					<enable>[Player.SeekEnabled + !MusicPlayer.Content(livetv)] + !Player.Paused</enable>
+					<onclick condition="Player.Paused">PlayerControl(Play)</onclick>
+					<onclick condition="!Player.Paused">PlayerControl(Forward)</onclick>
+					<visible>Player.SeekEnabled + !MusicPlayer.Content(livetv)</visible>
 				</control>
 				<control type="radiobutton" id="607">
 					<include content="OSDButton">
 						<param name="texture" value="osd/fullscreen/buttons/next.png"/>
 					</include>
 					<onclick>PlayerControl(Next)</onclick>
-					<enable>Player.ChapterCount | MusicPlayer.HasNext | PVR.IsTimeShift</enable>
+					<visible>Player.ChapterCount | MusicPlayer.HasNext | PVR.IsTimeShift</visible>
 				</control>
 				<control type="radiobutton" id="608">
 					<textureradioonfocus colordiffuse="white">osd/fullscreen/buttons/record-white.png</textureradioonfocus>

--- a/addons/skin.estuary/xml/VideoOSD.xml
+++ b/addons/skin.estuary/xml/VideoOSD.xml
@@ -58,7 +58,7 @@
 							<param name="texture" value="osd/fullscreen/buttons/rewind.png"/>
 						</include>
 						<onclick>PlayerControl(Rewind)</onclick>
-						<visible>[Player.SeekEnabled + !VideoPlayer.Content(livetv)] + !Player.Paused</visible>
+						<enable>[Player.SeekEnabled + !VideoPlayer.Content(livetv)] + !Player.Paused</enable>
 					</control>
 					<control type="group" id="698">
 						<width>76</width>
@@ -99,7 +99,7 @@
 							<param name="texture" value="osd/fullscreen/buttons/forward.png"/>
 						</include>
 						<onclick>PlayerControl(Forward)</onclick>
-						<visible>[Player.SeekEnabled + !VideoPlayer.Content(livetv)] + !Player.Paused</visible>
+						<enable>[Player.SeekEnabled + !VideoPlayer.Content(livetv)] + !Player.Paused</enable>
 					</control>
 					<control type="radiobutton" id="607">
 						<include content="OSDButton">

--- a/addons/skin.estuary/xml/VideoOSD.xml
+++ b/addons/skin.estuary/xml/VideoOSD.xml
@@ -57,8 +57,9 @@
 						<include content="OSDButton">
 							<param name="texture" value="osd/fullscreen/buttons/rewind.png"/>
 						</include>
-						<onclick>PlayerControl(Rewind)</onclick>
-						<enable>[Player.SeekEnabled + !VideoPlayer.Content(livetv)] + !Player.Paused</enable>
+						<onclick condition="Player.Paused">PlayerControl(Play)</onclick>
+						<onclick condition="!Player.Paused">PlayerControl(Rewind)</onclick>
+						<visible>Player.SeekEnabled + !VideoPlayer.Content(livetv)</visible>
 					</control>
 					<control type="group" id="698">
 						<width>76</width>
@@ -98,8 +99,9 @@
 						<include content="OSDButton">
 							<param name="texture" value="osd/fullscreen/buttons/forward.png"/>
 						</include>
-						<onclick>PlayerControl(Forward)</onclick>
-						<enable>[Player.SeekEnabled + !VideoPlayer.Content(livetv)] + !Player.Paused</enable>
+						<onclick condition="Player.Paused">PlayerControl(Play)</onclick>
+						<onclick condition="!Player.Paused">PlayerControl(Forward)</onclick>
+						<visible>Player.SeekEnabled + !VideoPlayer.Content(livetv)</visible>
 					</control>
 					<control type="radiobutton" id="607">
 						<include content="OSDButton">


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Changes the `visible` conditions to `enable` conditions so as to keep all the buttons in the same positions to ease the use of mouse and touch controls.
## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently when pausing video or music the button positions in the OSD change making mouse/touch controls awkward.
Fixes issue https://github.com/xbmc/xbmc/issues/24514
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.
## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
OSD buttons keep their positions and unusable buttons simply get disabled instead of hidden.
## Screenshots (if appropriate):

Video OSD - playing
![screenshot00000](https://github.com/xbmc/xbmc/assets/133808/cf04f834-9e9e-48ee-84a8-50471376f4aa)

Video OSD - paused
![screenshot00001](https://github.com/xbmc/xbmc/assets/133808/a24dc993-a67a-4a70-99ed-bffb3af4d5ac)

Video OSD - paused with fix
![screenshot00002](https://github.com/xbmc/xbmc/assets/133808/f1a5e131-c477-44c7-a430-423a52a55993)

Music OSD - playing
![screenshot00003](https://github.com/xbmc/xbmc/assets/133808/b844a151-bf77-4083-bae0-558c61b5dc19)

Music OSD - paused
![screenshot00004](https://github.com/xbmc/xbmc/assets/133808/f7b64710-1375-48aa-8447-64c666e586d8)

Music OSD - paused with fix
![screenshot00005](https://github.com/xbmc/xbmc/assets/133808/7a6772e7-a25b-4f79-a2d1-f788dea54e18)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
