### PR TITLE
[Video] Improve user experience when playing movies/episodes from Bluray ISO/BDMV.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7289,7 +7289,9 @@ msgctxt "#13423"
 msgid "Remember for this path"
 msgstr ""
 
-#empty string with id 13424
+msgctxt "#13424"
+msgid "Choose playlist"
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#13425"

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1559,6 +1559,9 @@ bool CFileItem::IsSamePath(const CFileItem *item) const
   {
     if (item->HasProperty("item_start") || HasProperty("item_start"))
       return (item->GetProperty("item_start") == GetProperty("item_start"));
+    // See if we have associated a bluray playlist
+    if (IsBlurayPlaylist(*this) || IsBlurayPlaylist(*item))
+      return (GetDynPath() == item->GetDynPath());
     return true;
   }
   if (HasMusicInfoTag() && item->HasMusicInfoTag())
@@ -1956,6 +1959,22 @@ const std::string &CFileItem::GetDynPath() const
 void CFileItem::SetDynPath(const std::string &path)
 {
   m_strDynPath = path;
+}
+
+std::string CFileItem::GetBlurayPath() const
+{
+  if (IsBlurayPlaylist(*this))
+  {
+    CURL url(GetDynPath());
+    CURL url2(url.GetHostName()); // strip bluray://
+    if (url2.IsProtocol("udf"))
+      // ISO
+      return url2.GetHostName(); // strip udf://
+    else if (url.IsProtocol("bluray"))
+      // BDMV
+      return url2.Get() + "BDMV/index.bdmv";
+  }
+  return GetDynPath();
 }
 
 void CFileItem::SetCueDocument(const CCueDocumentPtr& cuePtr)
@@ -2472,7 +2491,11 @@ std::string CFileItem::GetLocalMetadataPath() const
   if (m_bIsFolder && !IsFileFolder())
     return m_strPath;
 
-  std::string parent(URIUtils::GetParentPath(m_strPath));
+  std::string parent{};
+  if (IsBlurayPlaylist(*this))
+    parent = URIUtils::GetParentPath(GetBlurayPath());
+  else
+    parent = URIUtils::GetParentPath(m_strPath);
   std::string parentFolder(parent);
   URIUtils::RemoveSlashAtEnd(parentFolder);
   parentFolder = URIUtils::GetFileName(parentFolder);

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -142,6 +142,8 @@ public:
   const std::string &GetDynPath() const;
   void SetDynPath(const std::string &path);
 
+  std::string GetBlurayPath() const;
+
   /*! \brief reset class to it's default values as per construction.
    Free's all allocated memory.
    \sa Initialize

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -266,7 +266,9 @@ bool CPlayListPlayer::PlayItemIdx(int itemIdx)
   return Play();
 }
 
-bool CPlayListPlayer::Play(const CFileItemPtr& pItem, const std::string& player)
+bool CPlayListPlayer::Play(const CFileItemPtr& pItem,
+                           const std::string& player,
+                           bool forceSelection /* = false */)
 {
   Id playlistId;
   bool isVideo{IsVideo(*pItem)};
@@ -304,13 +306,14 @@ bool CPlayListPlayer::Play(const CFileItemPtr& pItem, const std::string& player)
   SetCurrentPlaylist(playlistId);
   Add(playlistId, pItem);
 
-  return Play(0, player);
+  return Play(0, player, false, false, forceSelection);
 }
 
 bool CPlayListPlayer::Play(int iSong,
                            const std::string& player,
                            bool bAutoPlay /* = false */,
-                           bool bPlayPrevious /* = false */)
+                           bool bPlayPrevious /* = false */,
+                           bool forceSelection /* = false */)
 {
   if (m_iCurrentPlayList == TYPE_NONE)
     return false;
@@ -342,7 +345,7 @@ bool CPlayListPlayer::Play(int iSong,
   m_bPlaybackStarted = false;
 
   const auto playAttempt = std::chrono::steady_clock::now();
-  bool ret = g_application.PlayFile(*item, player, bAutoPlay);
+  bool ret = g_application.PlayFile(*item, player, bAutoPlay, forceSelection);
   if (!ret)
   {
     CLog::Log(LOGERROR, "Playlist Player: skipping unplayable item: {}, path [{}]", m_iCurrentSong,

--- a/xbmc/PlayListPlayer.h
+++ b/xbmc/PlayListPlayer.h
@@ -55,19 +55,22 @@ public:
    * \brief Creates a new playlist for an item and starts playing it
    * \param pItem The item to play.
    * \param player The player name.
+   * \param forceSelection for Blurays, force simple menu to change playlist (default to false)
    * \return True if has success, otherwise false.
    */
-  bool Play(const CFileItemPtr& pItem, const std::string& player);
+  bool Play(const CFileItemPtr& pItem, const std::string& player, bool forceSelection = false);
 
   /*! \brief Start playing a particular entry in the current playlist
    \param index the index of the item to play. This value is modified to ensure it lies within the current playlist.
    \param replace whether this item should replace the currently playing item. See CApplication::PlayFile (defaults to false).
    \param playPreviousOnFail whether to go back to the previous item if playback fails (default to false)
+   \param forceSelection for Blurays, force simple menu to change playlist (default to false)
    */
   bool Play(int index,
             const std::string& player,
             bool replace = false,
-            bool playPreviousOnFail = false);
+            bool playPreviousOnFail = false,
+            bool forceSelection = false);
 
   /*! \brief Returns the index of the current item in active playlist.
    \return Current item in the active playlist.

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -2286,7 +2286,10 @@ bool CApplication::PlayStack(CFileItem& item, bool bRestart)
   return PlayFile(selectedStackPart, "", true);
 }
 
-bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRestart)
+bool CApplication::PlayFile(CFileItem item,
+                            const std::string& player,
+                            bool bRestart /* = false */,
+                            bool forceSelection /* = false */)
 {
   // Ensure the MIME type has been retrieved for http:// and shout:// streams
   if (item.GetMimeType().empty())
@@ -2426,7 +2429,7 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
 
   // a disc image might be Blu-Ray disc
   if (!(options.startpercent > 0.0 || options.starttime > 0.0) &&
-      (IsBDFile(item) || item.IsDiscImage()))
+      (IsBDFile(item) || item.IsDiscImage() || (IsBlurayPlaylist(item) && forceSelection)))
   {
     // No video selection when using external or remote players (they handle it if supported)
     const bool isSimpleMenuAllowed = [&]()
@@ -2444,7 +2447,7 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
     if (isSimpleMenuAllowed)
     {
       // Check if we must show the simplified bd menu.
-      if (!CGUIDialogSimpleMenu::ShowPlaySelection(item))
+      if (!CGUIDialogSimpleMenu::ShowPlaySelection(item, forceSelection))
         return true;
     }
   }

--- a/xbmc/application/Application.h
+++ b/xbmc/application/Application.h
@@ -125,7 +125,10 @@ public:
                                PLAYLIST::CPlayList& playlist,
                                PLAYLIST::Id playlistId,
                                int track = 0);
-  bool PlayFile(CFileItem item, const std::string& player, bool bRestart = false);
+  bool PlayFile(CFileItem item,
+                const std::string& player,
+                bool bRestart = false,
+                bool forceSelection = false);
   void StopPlaying();
   void Restart(bool bSamePosition = true);
   void DelayedPlayerRestart();

--- a/xbmc/dialogs/GUIDialogContextMenu.h
+++ b/xbmc/dialogs/GUIDialogContextMenu.h
@@ -88,6 +88,7 @@ enum CONTEXT_BUTTON
   CONTEXT_BUTTON_PLAY_NEXT,
   CONTEXT_BUTTON_NAVIGATE,
   CONTEXT_BUTTON_MANAGE_VIDEOVERSIONS,
+  CONTEXT_BUTTON_CHOOSE_PLAYLIST,
 };
 
 class CContextButtons : public std::vector< std::pair<size_t, std::string> >

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -29,6 +29,8 @@
 #include "video/VideoFileItemClassify.h"
 #include "video/VideoInfoTag.h"
 
+std::string m_savePath;
+
 using namespace KODI;
 
 namespace
@@ -52,11 +54,17 @@ protected:
 };
 }
 
-
-bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item)
+bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item, bool forceSelection /* = false */)
 {
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_DISC_PLAYBACK) != BD_PLAYBACK_SIMPLE_MENU)
     return true;
+
+  m_savePath = "";
+  if (VIDEO::IsBlurayPlaylist(item) && forceSelection)
+  {
+    m_savePath = item.GetDynPath(); // save for screen refresh later
+    item.SetDynPath(item.GetBlurayPath());
+  }
 
   if (VIDEO::IsBDFile(item))
   {
@@ -127,10 +135,11 @@ bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item, const std::string&
 
     if (item_new->m_bIsFolder == false)
     {
-      std::string original_path = item.GetDynPath();
+      if (m_savePath.empty()) // If not set above (choose playlist selected)
+        m_savePath = item.GetDynPath();
       item.SetDynPath(item_new->GetDynPath());
       item.SetProperty("get_stream_details_from_player", true);
-      item.SetProperty("original_listitem_url", original_path);
+      item.SetProperty("original_listitem_url", m_savePath);
       return true;
     }
 

--- a/xbmc/dialogs/GUIDialogSimpleMenu.h
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.h
@@ -20,7 +20,7 @@ class CGUIDialogSimpleMenu
 public:
 
   /*! \brief Show dialog allowing selection of wanted playback item */
-  static bool ShowPlaySelection(CFileItem& item);
+  static bool ShowPlaySelection(CFileItem& item, bool forceSelection = false);
   static bool ShowPlaySelection(CFileItem& item, const std::string& directory);
 
 protected:

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -584,10 +584,12 @@ public:
                            const std::map<std::string, std::string>& artwork,
                            int idShow,
                            int idEpisode = -1);
+  bool SetFileForEpisode(const std::string& fileAndPath, int idEpisode, int idFile);
+  bool SetFileForMovie(const std::string& fileAndPath, int idMovie, int idFile);
   int SetDetailsForMusicVideo(CVideoInfoTag& details,
                               const std::map<std::string, std::string>& artwork,
                               int idMVideo = -1);
-  void SetStreamDetailsForFile(const CStreamDetails& details, const std::string &strFileNameAndPath);
+  int SetStreamDetailsForFile(const CStreamDetails& details, const std::string& strFileNameAndPath);
   void SetStreamDetailsForFileId(const CStreamDetails& details, int idFile);
 
   bool SetSingleValue(VideoDbContentType type, int dbId, int dbField, const std::string& strValue);
@@ -686,7 +688,7 @@ public:
   void DeleteBookMarkForEpisode(const CVideoInfoTag& tag);
   bool GetResumePoint(CVideoInfoTag& tag);
   bool GetStreamDetails(CFileItem& item);
-  bool GetStreamDetails(CVideoInfoTag& tag) const;
+  bool GetStreamDetails(CVideoInfoTag& tag);
   bool GetDetailsByTypeAndId(CFileItem& item, VideoDbContentType type, int id);
   CVideoInfoTag GetDetailsByTypeAndId(VideoDbContentType type, int id);
 

--- a/xbmc/video/VideoFileItemClassify.cpp
+++ b/xbmc/video/VideoFileItemClassify.cpp
@@ -72,6 +72,11 @@ bool IsProtectedBlurayDisc(const CFileItem& item)
   return CFileUtils::Exists(path);
 }
 
+bool IsBlurayPlaylist(const CFileItem& item)
+{
+  return StringUtils::EqualsNoCase(URIUtils::GetExtension(item.GetDynPath()), ".mpls");
+}
+
 bool IsSubtitle(const CFileItem& item)
 {
   return URIUtils::HasExtension(item.GetPath(),

--- a/xbmc/video/VideoFileItemClassify.h
+++ b/xbmc/video/VideoFileItemClassify.h
@@ -25,6 +25,9 @@ bool IsDVDFile(const CFileItem& item, bool bVobs = true, bool bIfos = true);
 //! \brief Checks whether item points to a protected blu-ray disc.
 bool IsProtectedBlurayDisc(const CFileItem& item);
 
+//! \brief Checks whether item points to a blu-ray playlist (.mpls)
+bool IsBlurayPlaylist(const CFileItem& item);
+
 //! \brief Check whether an item is a subtitle file.
 bool IsSubtitle(const CFileItem& item);
 

--- a/xbmc/video/windows/GUIWindowVideoBase.h
+++ b/xbmc/video/windows/GUIWindowVideoBase.h
@@ -143,4 +143,6 @@ private:
    \return true: the information of the item was modified. false: no change.
    */
   bool ShowInfo(const CFileItemPtr& item, const ADDON::ScraperPtr& content);
+
+  bool m_forceSelection;
 };


### PR DESCRIPTION
This is another attempt at #24277 using @rmrector's advice about the VFS.

Complements #24304.

When a movie/episode is played from an ISO/BDMV an additional file is added `files` table and this is linked to the `movies` or `episodes` entry.

I've also fixed the way Play from Here works (or didn't work) for ISOs/BDMVs - by properly removing duplicates.

It doesn't require any database changes (unlike the first attempt).

## Description

## Motivation and context

## How has this been tested?

Locally

## What is the effect on users?

Base
Having just refreshed from scraper - no details shown and duration from scraper.
<img width="1280" alt="image" src="https://github.com/xbmc/xbmc/assets/99039295/b77285f0-bf07-4ec5-a409-261d88032c2f">
<img width="1280" alt="image" src="https://github.com/xbmc/xbmc/assets/99039295/afb990be-1361-499f-9091-22e3b2884d50">

Before
Having just watched episode 1 - the details for both Episodes 1 and 2 (both on first ISO) have changed.
<img width="1280" alt="image" src="https://github.com/xbmc/xbmc/assets/99039295/f86b7744-ad27-4e7e-9e2a-36146781fc42">
<img width="1280" alt="image" src="https://github.com/xbmc/xbmc/assets/99039295/c44e0416-dd72-4da5-a588-91e721234b97">

After
Having just watched episode 1 - only episode 1 has changed
<img width="1280" alt="image" src="https://github.com/xbmc/xbmc/assets/99039295/741fa02e-287d-4199-bbd3-96a24fdb0a48">
<img width="1280" alt="image" src="https://github.com/xbmc/xbmc/assets/99039295/e73ec7f0-f194-4e10-8fc6-838e19481bd8">

Then watching episode 2 - only 2 has changed and 1 is preserved.
<img width="1280" alt="image" src="https://github.com/xbmc/xbmc/assets/99039295/2e4d31d6-4b4b-4924-b207-b3a48a439048">
<img width="1280" alt="image" src="https://github.com/xbmc/xbmc/assets/99039295/33419df3-ebe6-4372-b9c0-29f1c643a334">

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
