### PR TITLE
[Settings] Fix Read Factor displayed as 0.0x in logs when setting value is "Adaptive"

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -22290,7 +22290,7 @@ msgstr ""
 #. Description of setting #37107 "Read Factor"
 #: system/settings/settings.xml
 msgctxt "#37108"
-msgid "Determines cache fill rate in terms of avg. bitrate of stream x Read Factor. Increasing this multiple, cache fills faster. Large multiples may cause CPU spikes on some devices, saturate the connection and worsen performance.[CR][Adaptative] Uses dynamically calculated Read Factor based on cache level."
+msgid "Determines cache fill rate in terms of avg. bitrate of stream x Read Factor. Increasing this multiple, cache fills faster. Large multiples may cause CPU spikes on some devices, saturate the connection and worsen performance.[CR][Adaptive] Uses dynamically calculated Read Factor based on cache level."
 msgstr ""
 
 #. Description of setting "Chunk Size"
@@ -22338,7 +22338,7 @@ msgstr ""
 #. Value of setting #37107 "Read Factor"
 #: xbmc/settings/SevicesSettings.cpp
 msgctxt "#37116"
-msgid "Adaptative"
+msgid "Adaptive"
 msgstr ""
 
 #empty strings from id 37117 to 37119

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -387,13 +387,14 @@ bool CApplication::Create()
 
   // Log Cache GUI settings (replacement of cache in advancedsettings.xml)
   const auto settings = settingsComponent->GetSettings();
+  const float readFactor = settings->GetInt(CSettings::SETTING_FILECACHE_READFACTOR) / 100.0f;
   CLog::Log(LOGINFO,
-            "New Cache GUI Settings (replacement of cache in advancedsettings.xml) are:\n - Buffer "
-            "Mode: {}\n - Memory Size: {} MB\n - Read "
-            "Factor: {:.2f} x\n - Chunk Size : {} bytes",
+            "New Cache GUI Settings (replacement of cache in advancedsettings.xml) are:\n  Buffer "
+            "Mode: {}\n  Memory Size: {} MB\n  Read "
+            "Factor: {:.2f} x {}\n  Chunk Size : {} bytes",
             settings->GetInt(CSettings::SETTING_FILECACHE_BUFFERMODE),
-            settings->GetInt(CSettings::SETTING_FILECACHE_MEMORYSIZE),
-            settings->GetInt(CSettings::SETTING_FILECACHE_READFACTOR) / 100.0f,
+            settings->GetInt(CSettings::SETTING_FILECACHE_MEMORYSIZE), readFactor,
+            (readFactor < 1.0f) ? "(adaptive)" : "",
             settings->GetInt(CSettings::SETTING_FILECACHE_CHUNKSIZE));
 
   CLog::Log(LOGINFO, "creating subdirectories");


### PR DESCRIPTION
## Description
- Fix Read Factor displayed as 0.0x in logs when setting value is "Adaptive".
- Fix "adaptive" spelling.

## Motivation and context
It can be confusing to see a read factor of 0 only.

**Before**
```
2024-02-16 17:57:52.174 T:21924    info <general>: New Cache GUI Settings (replacement of cache in advancedsettings.xml) are:
                                                    - Buffer Mode: 4
                                                    - Memory Size: 128 MB
                                                    - Read Factor: 0.00 x
                                                    - Chunk Size : 131072 bytes
```

**After**
```
2024-02-16 17:56:45.587 T:6860     info <general>: New Cache GUI Settings (replacement of cache in advancedsettings.xml) are:
                                                     Buffer Mode: 4
                                                     Memory Size: 128 MB
                                                     Read Factor: 0.00 x (adaptive)
                                                     Chunk Size : 131072 bytes
```

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
