### PR TITLE
AESinkAudioTrack: Help broken firmwares to make kodi ignore broken delay

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -11,7 +11,9 @@
 #include "ServiceBroker.h"
 #include "cores/AudioEngine/AESinkFactory.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
+#include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/TimeUtils.h"
 #include "utils/log.h"
@@ -420,6 +422,9 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
       m_format.m_dataFormat     = AE_FMT_S16LE;
     }
   }
+
+  m_superviseAudioDelay =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_superviseAudioDelay;
 
   int atChannelMask = AEChannelMapToAUDIOTRACKChannelMask(m_format.m_channelLayout);
   m_format.m_channelLayout  = AUDIOTRACKChannelMaskToAEChannelMap(atChannelMask);
@@ -848,7 +853,7 @@ unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t **data, unsigned int frames, 
     const double max_stuck_delay_ms = m_audiotrackbuffer_sec_orig * 2000.0;
     const double stime_ms = 1000.0 * frames / m_format.m_sampleRate;
 
-    if (m_stuckCounter * stime_ms > max_stuck_delay_ms)
+    if (m_superviseAudioDelay && (m_stuckCounter * stime_ms > max_stuck_delay_ms))
     {
       CLog::Log(LOGERROR, "Sink got stuck with {:f} ms - ask AE for reopening", max_stuck_delay_ms);
       usleep(max_stuck_delay_ms * 1000);

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -96,6 +96,7 @@ private:
   double m_hw_delay = 0.0;
   CJNIAudioTimestamp m_timestamp;
   XbmcThreads::EndTime<> m_stampTimer;
+  bool m_superviseAudioDelay = false;
 
   std::vector<float> m_floatbuf;
   std::vector<int16_t> m_shortbuf;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -594,6 +594,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetFloat(pElement, "limiterrelease", m_limiterRelease, 0.001f, 100.0f);
     XMLUtils::GetUInt(pElement, "maxpassthroughoffsyncduration", m_maxPassthroughOffSyncDuration,
                       10, 100);
+    XMLUtils::GetBoolean(pElement, "superviseaudiodelay", m_superviseAudioDelay);
   }
 
   pElement = pRootElement->FirstChildElement("x11");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -160,6 +160,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     float m_videoIgnorePercentAtEnd;
     float m_audioApplyDrc;
     unsigned int m_maxPassthroughOffSyncDuration = 10; // when 10 ms off adjust
+    bool m_superviseAudioDelay = false; // Android only to correct broken audio firmwares
 
     int   m_videoVDPAUScaling;
     float m_videoNonLinStretchRatio;


### PR DESCRIPTION
Backport of https://github.com/xbmc/xbmc/pull/24597

Kodi can supervise the sink for being stuck, which means: if you open a sink with 160 ms buffer and it does not move while eating more than twice of the buffer's audio data, it is considered a bug. Sadly - there is a whole lot of broken firmwares out there, one of the leards: Ugoos. Which is the reason I make disabled by default. That means that FireTV Cube 3rd Gen and others would need to enable this - once again - via an advanced settings.

``` 
<advancedsettings>
<audio>
<superviseaudiodelay>true</superviseaudiodelay>
<audio>
</advancedsettings>
```

This is a backport towards Nexus as thie "good meant" supervising by default caused regresions, on you guessed it, broken firmware or semi-broken firmware (if you consider 300 ms off-sync semi-broken ;-)). Use the same "opt-in" as in master / v21.