### PR TITLE
[Android] Fix Zip Path Traversal vulnerability

### DIFF
--- a/tools/android/packaging/xbmc/src/Splash.java.in
+++ b/tools/android/packaging/xbmc/src/Splash.java.in
@@ -300,6 +300,10 @@ public class Splash extends Activity
 
         mState = Caching;
         publishProgress(mProgressStatus);
+
+        String cXbmcHome = fXbmcHome.getCanonicalPath();
+        Log.d(TAG, "output: " + cXbmcHome);
+
         while (entries.hasMoreElements())
         {
           // Update the progress bar
@@ -313,6 +317,14 @@ public class Splash extends Activity
 
           String sFullPath = sXbmcHome + "/" + sName;
           File fFullPath = new File(sFullPath);
+
+          // Zip Path Traversal vulnerability
+          String cFullPath = fFullPath.getCanonicalPath();
+          if (!cFullPath.startsWith(cXbmcHome)) {
+            Log.w(TAG, "Unsafe unzipping pattern: " + cFullPath);
+            continue;
+          }
+
           if (e.isDirectory())
           {
             fFullPath.mkdirs();


### PR DESCRIPTION
## Description
The following security warning is raised when the app is submitted to the Google Play Store:
```
Your app contains an unsafe unzipping pattern that may lead to a path traversal vulnerability.

org.xbmc.kodi.Splash$FillCache.doInBackground
```
This PR fixes it by checking if canonical paths to unzipped files are underneath the expected directory.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
