### PR TITLE
[MUSIC] Get correct duration of stream from FFMPEG for audiobook chap…

### DIFF
--- a/xbmc/filesystem/AudioBookFileDirectory.cpp
+++ b/xbmc/filesystem/AudioBookFileDirectory.cpp
@@ -106,7 +106,7 @@ bool CAudioBookFileDirectory::GetDirectory(const CURL& url,
     item->SetStartOffset(CUtil::ConvertSecsToMilliSecs(m_fctx->chapters[i]->start *
                                                        av_q2d(m_fctx->chapters[i]->time_base)));
     item->SetEndOffset(m_fctx->chapters[i]->end * av_q2d(m_fctx->chapters[i]->time_base));
-    int compare = m_fctx->duration / (AV_TIME_BASE);
+    int compare = m_fctx->streams[0]->duration * av_q2d(m_fctx->streams[0]->time_base);
     if (item->GetEndOffset() < 0 || item->GetEndOffset() > compare)
     {
       if (i < m_fctx->nb_chapters-1)


### PR DESCRIPTION
…ters

## Description
Due to the ffmpeg bump, the duration for the last chapter of an .m4b audiobook is no longer calculated.  This PR fixes that.
## Motivation and context
Rebased some other stuff to do with audiobooks in general that I am looking at, and noticed this issue.

## How has this been tested?
Tested locally.  

## What is the effect on users?
Last chapter of an audiobook will have the correct duration.

## Screenshots (if appropriate):
Before fix.
![screenshot00115](https://github.com/xbmc/xbmc/assets/18698554/cab6f05b-285b-499c-b996-9524049ffa18)
![screenshot00116](https://github.com/xbmc/xbmc/assets/18698554/db199856-f17b-4754-9bf2-1e7cc29c2004)

After fix.
![screenshot00117](https://github.com/xbmc/xbmc/assets/18698554/08b99f2d-e71f-45de-b440-e9a587172e5f)
![screenshot00118](https://github.com/xbmc/xbmc/assets/18698554/aa035047-7390-45cd-8d13-408c7899e5a8)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
