### PR TITLE
[FileSystem] Fix: not use CFileStreamBuffer in all network files

### DIFF
--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -393,9 +393,6 @@ bool CFile::ShouldUseStreamBuffer(const CURL& url)
   if (m_pFile->GetLength() > 200 * 1024 * 1024 && !URIUtils::IsDVD(url.GetShareName()))
     return true;
 
-  if (URIUtils::IsNetworkFilesystem(url.Get()))
-    return true;
-
   return false;
 }
 


### PR DESCRIPTION
## Description
[FileSystem] Fix: not use CFileStreamBuffer in all network files

Fixes https://github.com/xbmc/xbmc/issues/24629

## Motivation and context
Seems https://github.com/xbmc/xbmc/pull/24504 is causing issues on some binary add-ons. 

It may be that some add-ons use file methods intended for binary data to read text files. But in any case this is a workaround.

Anyway `IsNetworkFilesystem` is quite redundant because if is a "big file" and is not a optical disk this also includes network files but only "big network files" now.

Seems the side effects was all related to read xml/text files over network.....


## How has this been tested?
Untested. Someone with proper setup/hw should confirm that this fixes the issues in `pvr.vuplus`


## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
