### PR TITLE
AESinkPipewire: Properly identify HDMI devices

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -348,10 +348,17 @@ void CAESinkPipewire::EnumerateDevicesEx(AEDeviceInfoList& list, bool force)
                                   streamTypes.end());
     }
 
-    if (device.m_channels.Count() == 2 && !device.m_streamTypes.empty())
+    if (!device.m_streamTypes.empty())
     {
-      device.m_deviceType = AE_DEVTYPE_IEC958;
       device.m_dataFormats.emplace_back(AE_FMT_RAW);
+      if (device.m_channels.Count() == 2)
+      {
+        device.m_deviceType = AE_DEVTYPE_IEC958;
+      }
+      else
+      {
+        device.m_deviceType = AE_DEVTYPE_HDMI;
+      }
     }
 
     list.emplace_back(device);

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -348,10 +348,18 @@ void CAESinkPipewire::EnumerateDevicesEx(AEDeviceInfoList& list, bool force)
                                   streamTypes.end());
     }
 
+    // If DTS-HD-MA or TrueHD are configured 8 channels are needed
+    bool hasHBRFormat = std::any_of(device.m_streamTypes.cbegin(), device.m_streamTypes.cend(),
+                                    [](const auto& streamType)
+                                    {
+                                      return streamType == CAEStreamInfo::STREAM_TYPE_TRUEHD ||
+                                             streamType == CAEStreamInfo::STREAM_TYPE_DTSHD_MA;
+                                    });
+
     if (!device.m_streamTypes.empty())
     {
       device.m_dataFormats.emplace_back(AE_FMT_RAW);
-      if (device.m_channels.Count() == 2)
+      if (!hasHBRFormat && device.m_channels.Count() == 2)
       {
         device.m_deviceType = AE_DEVTYPE_IEC958;
       }


### PR DESCRIPTION
Without this AE would only allow passthrough on SPDIF devices as it checks for the device not being PCM when allowing Passthrough.