### PR TITLE
[plugins] Ignore fileaction (play) if item is not playable...

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -544,7 +544,9 @@ bool CGUIWindowVideoBase::OnSelect(int iItem)
   if (!item->m_bIsFolder && path != "add" &&
       !StringUtils::StartsWith(path, "newsmartplaylist://") &&
       !StringUtils::StartsWith(path, "newplaylist://") &&
-      !StringUtils::StartsWith(path, "newtag://") && !StringUtils::StartsWith(path, "script://"))
+      !StringUtils::StartsWith(path, "newtag://") && !StringUtils::StartsWith(path, "script://") &&
+      !StringUtils::StartsWith(path, "plugin://") && !item->HasProperty("IsPlayable") &&
+      !item->GetProperty("IsPlayable").asBoolean())
     return OnFileAction(iItem, CVideoSelectActionProcessorBase::GetDefaultSelectAction(), "");
 
   return CGUIMediaWindow::OnSelect(iItem);


### PR DESCRIPTION
## Description
@ksooo likely a regression caused by the video versions and/or the refactor of context menus. If a plugin item is not a folder but it is not playable (signalled via the respective property) fileactions (play, playpart, etc) should be ignored and select be triggered instead. This will run the script instead, otherwise it'll get waiting forever for a playable item. 

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/24736

## How has this been tested?
Runtime tested with the plugin of the issue report and other plugins that include playable items

## What is the effect on users?
Fix regression

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
