### PR TITLE
Screensaver: don't make the dialog black

### DIFF
--- a/xbmc/windows/GUIWindowScreensaver.cpp
+++ b/xbmc/windows/GUIWindowScreensaver.cpp
@@ -17,7 +17,6 @@
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPowerHandling.h"
 #include "guilib/GUIComponent.h"
-#include "guilib/GUITexture.h"
 #include "guilib/GUIWindowManager.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -41,10 +40,6 @@ void CGUIWindowScreensaver::Process(unsigned int currentTime, CDirtyRegionList& 
 
 void CGUIWindowScreensaver::Render()
 {
-  // FIXME/TODO: Screensaver addons should make the screen black instead
-  // keeping this just for compatibility reasons since it's now a dialog.
-  CGUITexture::DrawQuad(m_renderRegion, UTILS::COLOR::BLACK);
-
   if (m_addon)
   {
     auto& context = CServiceBroker::GetWinSystem()->GetGfxContext();


### PR DESCRIPTION
## Description
Added in https://github.com/xbmc/xbmc/pull/24664 as an hack since the change from a window to a dialog in screensavers. Screensaver.asteroids does not clear the screen on windows leading to a change of behaviour. Such "issues" should be fixed by the addons and not Kodi. Furthermore, if a screensaver doesn't want to have a black background but see through the kodi gui it should be free to do so.

Screensavers in need to changes (clear color on windows):

- [x] screensaver.asteriods (https://github.com/xbmc/screensaver.asteroids/pull/78)
- [x] screensaver.pingpong (https://github.com/xbmc/screensaver.pingpong/pull/77)
- [x] screensavers.rsxs (https://github.com/xbmc/screensavers.rsxs/commit/4577c810bc123948af19787cb14d0dc75b2db8b6)
- [x] biogenesis (https://github.com/xbmc/screensaver.biogenesis/pull/73)
- [x] stars (https://github.com/xbmc/screensaver.stars/pull/71)
- [x] greynetic (https://github.com/xbmc/screensaver.greynetic/pull/64)
- [x] pyro (https://github.com/xbmc/screensaver.pyro/pull/66)

## Motivation and context
Remove hack

## How has this been tested?
Untested for now, v22 material (PRing to get an artifact)

## What is the effect on users?
Hopefully none

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)