### PR TITLE
VideoPlayer: MediaCodec - Fix PAL videos not rendering in fullscreen

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -1731,6 +1731,8 @@ void CDVDVideoCodecAndroidMediaCodec::ConfigureOutputFormat(CJNIMediaFormat& med
   int crop_top    = 0;
   int crop_right  = 0;
   int crop_bottom = 0;
+  int disp_width = 0;
+  int disp_height = 0;
 
   if (mediaformat.containsKey(CJNIMediaFormat::KEY_WIDTH))
     width = mediaformat.getInteger(CJNIMediaFormat::KEY_WIDTH);
@@ -1758,6 +1760,14 @@ void CDVDVideoCodecAndroidMediaCodec::ConfigureOutputFormat(CJNIMediaFormat& med
     if (mediaformat.containsKey(CJNIMediaFormat::KEY_CROP_BOTTOM))
       crop_bottom = mediaformat.getInteger(CJNIMediaFormat::KEY_CROP_BOTTOM);
   }
+
+  // Note: These properties are not documented in the Android SDK but
+  // are available in the MediaFormat object.
+  // This is how it's done in ffmpeg too.
+  if (mediaformat.containsKey("display-width"))
+    disp_width = mediaformat.getInteger("display-width");
+  if (mediaformat.containsKey("display-height"))
+    disp_height = mediaformat.getInteger("display-height");
 
   if (!crop_right)
     crop_right = width-1;
@@ -1792,6 +1802,11 @@ void CDVDVideoCodecAndroidMediaCodec::ConfigureOutputFormat(CJNIMediaFormat& med
 
   m_videobuffer.iDisplayWidth  = m_videobuffer.iWidth  = width;
   m_videobuffer.iDisplayHeight = m_videobuffer.iHeight = height;
+
+  if (disp_width > 0 && disp_height > 0 && !m_hints.forced_aspect)
+  {
+    m_hints.aspect = static_cast<double>(disp_width) / static_cast<double>(disp_height);
+  }
 
   if (m_hints.aspect > 1.0 && !m_hints.forced_aspect)
   {


### PR DESCRIPTION
## Description
PAL formatted streams that have 720x576 pixel a SAR of 65/45 and DAR of 16:9 are rendered with black sidebars when using MediaCodec.
It renders fullscreen when disabling MediaCodec or rendering using VAAPI on Linux.

I tried to understand what the issue is, by viewing the code of mpv and ffmpeg and this is what i came up with.
The idea is taken from ffmepgs MediaCodec implementation.

## Motivation and context
Fix Android rendering differently compared to other platforms.

## How has this been tested?
Not yet, due to lack of dev env, need outcome of this PR to test.

## What is the effect on users?
Android renders PAL videos like mpv, vlc or other render methods in Kodi without using the video stretch setting.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
