### PR TITLE
Store streamed video subtitle on custom subtitles path if defined by user

### DIFF
--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -548,14 +548,15 @@ void CGUIDialogSubtitles::OnDownloadComplete(const CFileItemList *items, const s
   std::vector<std::string> vecFiles;
 
   std::string strCurrentFilePath;
-  if (URIUtils::IsHTTP(strCurrentFile))
+  const std::string subPath = CSpecialProtocol::TranslatePath("special://subtitles");
+
+  if (subPath.empty() && URIUtils::IsHTTP(strCurrentFile))
   {
     strCurrentFile = "TempSubtitle";
     vecFiles.push_back(strCurrentFile);
   }
   else
   {
-    std::string subPath = CSpecialProtocol::TranslatePath("special://subtitles");
     if (!subPath.empty())
       strDownloadPath = subPath;
 


### PR DESCRIPTION
## Description

The fix is by checking if a custom subtitle path is defined, if so, do store the downloaded subtitle on the custom path.
This way the user is allowed to keep the old kodi behavior if indeed needed. 

## Motivation and context

fixes the "regression" described on https://github.com/xbmc/xbmc/issues/24742 which was introduced on https://github.com/xbmc/xbmc/pull/24252

## How has this been tested?
Tested locally on a windows machine on my setup.

When no custom subtitles path is defined , the new behavior is kept.
When setting a custom subtitle path the old behavior is back , and the file is stored as stream.lang.srt on the custom subtitle path.

## What is the effect on users?
Users like me which utilized the old behavior can keep it.
Users which did not set custom subtitles path should not be affected at all.


## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
