### PR TITLE
[guiinfo] Fix LISTITEM_LABEL for movies with multiple versions only …

### DIFF
--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -533,6 +533,9 @@ bool CVideoGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
 
         // special casing for "show videos with multiple versions as folders", where the label
         // should be the video version, not the movie title.
+        if (!item->HasVideoVersions())
+          break;
+
         CGUIWindow* videoNav{
             CServiceBroker::GetGUI()->GetWindowManager().GetWindow(WINDOW_VIDEO_NAV)};
         if (videoNav && videoNav->GetProperty("VideoVersionsFolderView").asBoolean() &&


### PR DESCRIPTION
…to overwrite with video version name if there is one.

Fixes #24713 - fyi @jurialmunkey 

Runtime-tested on macOS, latest Kodi master.

@CrystalP please review. And yes, I know this is not clean, but another workaround for the half-baked "view movies with multiple versions as folder" feature.