### PR TITLE
[Android] Adjust GUI SRD peak luminance when display is in HDR PQ mode

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2998,7 +2998,12 @@
         <control type="toggle" />
       </setting>
       <setting id="videoscreen.guipeakluminance" type="integer" label="36097" help="36547">
-        <requirement>HAS_DX</requirement>
+        <requirement>
+          <or>
+            <condition>HAS_DX</condition>
+            <condition>HAS_MEDIACODEC</condition>
+          </or>
+        </requirement>
         <dependencies>
           <dependency type="visible" on="property" name="ishdrdisplay"/>
           <dependency type="enable">

--- a/system/shaders/GLES/2.0/gles_shader_default.frag
+++ b/system/shaders/GLES/2.0/gles_shader_default.frag
@@ -22,6 +22,7 @@
 
 precision mediump float;
 uniform lowp vec4 m_unicol;
+uniform float m_sdrPeak;
 
 void main ()
 {
@@ -32,6 +33,10 @@ void main ()
 #if defined(KODI_LIMITED_RANGE)
   rgb.rgb *= (235.0 - 16.0) / 255.0;
   rgb.rgb += 16.0 / 255.0;
+#endif
+
+#if defined(KODI_TRANSFER_PQ)
+  rgb.rgb *= m_sdrPeak;
 #endif
 
   gl_FragColor = rgb;

--- a/system/shaders/GLES/2.0/gles_shader_fonts.frag
+++ b/system/shaders/GLES/2.0/gles_shader_fonts.frag
@@ -24,6 +24,7 @@ precision mediump float;
 uniform sampler2D m_samp0;
 varying vec4 m_cord0;
 varying lowp vec4 m_colour;
+uniform float m_sdrPeak;
 
 void main ()
 {
@@ -35,6 +36,10 @@ void main ()
 #if defined(KODI_LIMITED_RANGE)
   rgb.rgb *= (235.0 - 16.0) / 255.0;
   rgb.rgb += 16.0 / 255.0;
+#endif
+
+#if defined(KODI_TRANSFER_PQ)
+  rgb.rgb *= m_sdrPeak;
 #endif
 
   gl_FragColor = rgb;

--- a/system/shaders/GLES/2.0/gles_shader_multi.frag
+++ b/system/shaders/GLES/2.0/gles_shader_multi.frag
@@ -25,6 +25,7 @@ uniform sampler2D m_samp0;
 uniform sampler2D m_samp1;
 varying vec4 m_cord0;
 varying vec4 m_cord1;
+uniform float m_sdrPeak;
 
 void main ()
 {
@@ -35,6 +36,10 @@ void main ()
 #if defined(KODI_LIMITED_RANGE)
   rgb.rgb *= (235.0 - 16.0) / 255.0;
   rgb.rgb += 16.0 / 255.0;
+#endif
+
+#if defined(KODI_TRANSFER_PQ)
+  rgb.rgb *= m_sdrPeak;
 #endif
 
   gl_FragColor = rgb;

--- a/system/shaders/GLES/2.0/gles_shader_multi_blendcolor.frag
+++ b/system/shaders/GLES/2.0/gles_shader_multi_blendcolor.frag
@@ -26,6 +26,7 @@ uniform sampler2D m_samp1;
 varying vec4 m_cord0;
 varying vec4 m_cord1;
 uniform lowp vec4 m_unicol;
+uniform float m_sdrPeak;
 
 void main ()
 {
@@ -36,6 +37,10 @@ void main ()
 #if defined(KODI_LIMITED_RANGE)
   rgb.rgb *= (235.0 - 16.0) / 255.0;
   rgb.rgb += 16.0 / 255.0;
+#endif
+
+#if defined(KODI_TRANSFER_PQ)
+  rgb.rgb *= m_sdrPeak;
 #endif
 
   gl_FragColor = rgb;

--- a/system/shaders/GLES/2.0/gles_shader_texture.frag
+++ b/system/shaders/GLES/2.0/gles_shader_texture.frag
@@ -24,6 +24,7 @@ precision mediump float;
 uniform sampler2D m_samp0;
 uniform lowp vec4 m_unicol;
 varying vec4 m_cord0;
+uniform float m_sdrPeak;
 
 void main ()
 {
@@ -34,6 +35,10 @@ void main ()
 #if defined(KODI_LIMITED_RANGE)
   rgb.rgb *= (235.0 - 16.0) / 255.0;
   rgb.rgb += 16.0 / 255.0;
+#endif
+
+#if defined(KODI_TRANSFER_PQ)
+  rgb.rgb *= m_sdrPeak;
 #endif
 
   gl_FragColor = rgb;

--- a/system/shaders/GLES/2.0/gles_shader_texture_noalpha.frag
+++ b/system/shaders/GLES/2.0/gles_shader_texture_noalpha.frag
@@ -11,6 +11,7 @@
 precision mediump float;
 uniform sampler2D m_samp0;
 varying vec4 m_cord0;
+uniform float m_sdrPeak;
 
 void main ()
 {
@@ -19,6 +20,10 @@ void main ()
 #if defined(KODI_LIMITED_RANGE)
   rgb *= (235.0 - 16.0) / 255.0;
   rgb += 16.0 / 255.0;
+#endif
+
+#if defined(KODI_TRANSFER_PQ)
+  rgb.rgb *= m_sdrPeak;
 #endif
 
   gl_FragColor = vec4(rgb, 1.0);

--- a/system/shaders/GLES/2.0/gles_shader_texture_noblend.frag
+++ b/system/shaders/GLES/2.0/gles_shader_texture_noblend.frag
@@ -23,6 +23,7 @@
 precision mediump float;
 uniform sampler2D m_samp0;
 varying vec4 m_cord0;
+uniform float m_sdrPeak;
 
 void main ()
 {
@@ -33,6 +34,10 @@ void main ()
 #if defined(KODI_LIMITED_RANGE)
   rgb.rgb *= (235.0 - 16.0) / 255.0;
   rgb.rgb += 16.0 / 255.0;
+#endif
+
+#if defined(KODI_TRANSFER_PQ)
+  rgb.rgb *= m_sdrPeak;
 #endif
 
   gl_FragColor = rgb;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.cpp
@@ -51,6 +51,8 @@ void VideoPicture::Reset()
   qscale_type = 0;
   pict_type = 0;
 
+  hdrType = StreamHdrType::HDR_TYPE_NONE;
+
   hasDisplayMetadata = false;
   hasLightMetadata = false;
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -64,6 +64,8 @@ public:
   int qscale_type;
   int pict_type;
 
+  StreamHdrType hdrType;
+
   bool hasDisplayMetadata = false;
   AVMasteringDisplayMetadata displayMetadata;
   bool hasLightMetadata = false;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -1802,6 +1802,11 @@ void CDVDVideoCodecAndroidMediaCodec::ConfigureOutputFormat(CJNIMediaFormat& med
       m_videobuffer.iDisplayHeight = ((int)lrint(m_videobuffer.iWidth / m_hints.aspect)) & ~3;
     }
   }
+
+  m_videobuffer.hdrType = m_hints.hdrType;
+  m_videobuffer.color_space = m_hints.colorSpace;
+  m_videobuffer.color_primaries = m_hints.colorPrimaries;
+  m_videobuffer.color_transfer = m_hints.colorTransferCharacteristic;
 }
 
 void CDVDVideoCodecAndroidMediaCodec::CallbackInitSurfaceTexture(void *userdata)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -1063,6 +1063,8 @@ bool CDVDVideoCodecFFmpeg::GetPictureCommon(VideoPicture* pVideoPicture)
   pVideoPicture->qstride = 0;
   pVideoPicture->qscale_type = 0;
 
+  pVideoPicture->hdrType = m_hints.hdrType;
+
   AVFrameSideData* sd;
 
   // https://github.com/FFmpeg/FFmpeg/blob/991d417692/doc/APIchanges#L18-L20

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererMediaCodecSurface.cpp
@@ -63,6 +63,18 @@ bool CRendererMediaCodecSurface::Configure(const VideoPicture &picture, float fp
   CalculateFrameAspectRatio(picture.iDisplayWidth, picture.iDisplayHeight);
   SetViewMode(m_videoSettings.m_ViewMode);
 
+  // Configure GUI/OSD for HDR PQ when display is in HDR PQ mode
+  if (picture.color_transfer == AVCOL_TRC_SMPTE2084)
+  {
+    if (CServiceBroker::GetWinSystem()->IsHDRDisplay())
+      CServiceBroker::GetWinSystem()->GetGfxContext().SetTransferPQ(true);
+  }
+  else if (picture.hdrType == StreamHdrType::HDR_TYPE_DOLBYVISION)
+  {
+    if (CServiceBroker::GetWinSystem()->GetDisplayHDRCapabilities().SupportsDolbyVision())
+      CServiceBroker::GetWinSystem()->GetGfxContext().SetTransferPQ(true);
+  }
+
   return true;
 }
 
@@ -130,6 +142,8 @@ void CRendererMediaCodecSurface::Reset()
   for (int i = 0 ; i < 4 ; ++i)
     ReleaseVideoBuffer(i, false);
   m_lastIndex = -1;
+
+  CServiceBroker::GetWinSystem()->GetGfxContext().SetTransferPQ(false);
 }
 
 void CRendererMediaCodecSurface::RenderUpdate(int index, int index2, bool clear, unsigned int flags, unsigned int alpha)

--- a/xbmc/rendering/RenderSystem.h
+++ b/xbmc/rendering/RenderSystem.h
@@ -91,6 +91,7 @@ protected:
   RENDER_STEREO_VIEW m_stereoView = RENDER_STEREO_VIEW_OFF;
   RENDER_STEREO_MODE m_stereoMode = RENDER_STEREO_MODE_OFF;
   bool m_limitedColorRange = false;
+  bool m_transferPQ{false};
 
   std::unique_ptr<CGUIImage> m_splashImage;
   std::unique_ptr<CGUITextLayout> m_splashMessageLayout;

--- a/xbmc/rendering/gles/GLESShader.cpp
+++ b/xbmc/rendering/gles/GLESShader.cpp
@@ -48,6 +48,7 @@ void CGLESShader::OnCompiledAndLinked()
   m_hStep   = glGetUniformLocation(ProgramHandle(), "m_step");
   m_hContrast   = glGetUniformLocation(ProgramHandle(), "m_contrast");
   m_hBrightness = glGetUniformLocation(ProgramHandle(), "m_brightness");
+  m_sdrPeak = glGetUniformLocation(ProgramHandle(), "m_sdrPeak");
 
   // Variables passed directly to the Vertex shader
   m_hProj  = glGetUniformLocation(ProgramHandle(), "m_proj");
@@ -166,6 +167,9 @@ bool CGLESShader::OnEnabled()
 
   glUniform1f(m_hBrightness, 0.0f);
   glUniform1f(m_hContrast, 1.0f);
+
+  const float sdrPeak = CServiceBroker::GetWinSystem()->GetGuiSdrPeakLuminance();
+  glUniform1f(m_sdrPeak, sdrPeak);
 
   return true;
 }

--- a/xbmc/rendering/gles/GLESShader.h
+++ b/xbmc/rendering/gles/GLESShader.h
@@ -62,4 +62,6 @@ protected:
   GLfloat m_clipXOffset;
   GLfloat m_clipYFactor;
   GLfloat m_clipYOffset;
+
+  GLfloat m_sdrPeak;
 };

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -163,15 +163,18 @@ bool CRenderSystemGLES::BeginRender()
   if (!m_bRenderCreated)
     return false;
 
-  bool useLimited = CServiceBroker::GetWinSystem()->UseLimitedColor();
+  const bool useLimited = CServiceBroker::GetWinSystem()->UseLimitedColor();
+  const bool usePQ = CServiceBroker::GetWinSystem()->GetGfxContext().IsTransferPQ();
 
-  if (m_limitedColorRange != useLimited)
+  if (m_limitedColorRange != useLimited || m_transferPQ != usePQ)
   {
     ReleaseShaders();
+
+    m_limitedColorRange = useLimited;
+    m_transferPQ = usePQ;
+
     InitialiseShaders();
   }
-
-  m_limitedColorRange = useLimited;
 
   return true;
 }
@@ -387,6 +390,11 @@ void CRenderSystemGLES::InitialiseShaders()
   if (m_limitedColorRange)
   {
     defines += "#define KODI_LIMITED_RANGE 1\n";
+  }
+
+  if (m_transferPQ)
+  {
+    defines += "#define KODI_TRANSFER_PQ 1\n";
   }
 
   m_pShader[ShaderMethodGLES::SM_DEFAULT] =

--- a/xbmc/windowing/GraphicContext.h
+++ b/xbmc/windowing/GraphicContext.h
@@ -179,6 +179,9 @@ public:
   const std::string& GetMediaDir() const;
   void SetMediaDir(const std::string& strMediaDir);
 
+  void SetTransferPQ(bool PQ) { m_isTransferPQ = PQ; }
+  bool IsTransferPQ() const { return m_isTransferPQ; }
+
 protected:
 
   void UpdateCameraPosition(const CPoint &camera, const float &factor);
@@ -229,4 +232,6 @@ protected:
   RENDER_STEREO_VIEW m_stereoView = RENDER_STEREO_VIEW_OFF;
   RENDER_STEREO_MODE m_stereoMode = RENDER_STEREO_MODE_OFF;
   RENDER_STEREO_MODE m_nextStereoMode = RENDER_STEREO_MODE_OFF;
+
+  bool m_isTransferPQ{false};
 };

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -217,6 +217,7 @@ public:
   virtual HDR_STATUS GetOSHDRStatus() { return HDR_STATUS::HDR_UNSUPPORTED; }
   virtual CHDRCapabilities GetDisplayHDRCapabilities() const { return {}; }
   static const char* SETTING_WINSYSTEM_IS_HDR_DISPLAY;
+  virtual float GetGuiSdrPeakLuminance() const { return .0f; }
   virtual bool HasSystemSdrPeakLuminance() { return false; }
 
   /*!

--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -320,3 +320,11 @@ CHDRCapabilities CWinSystemAndroid::GetDisplayHDRCapabilities() const
 {
   return CAndroidUtils::GetDisplayHDRCapabilities();
 }
+
+float CWinSystemAndroid::GetGuiSdrPeakLuminance() const
+{
+  const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+  const int guiSdrPeak = settings->GetInt(CSettings::SETTING_VIDEOSCREEN_GUISDRPEAKLUMINANCE);
+
+  return ((0.7f * guiSdrPeak + 30.0f) / 100.0f);
+}

--- a/xbmc/windowing/android/WinSystemAndroid.h
+++ b/xbmc/windowing/android/WinSystemAndroid.h
@@ -59,6 +59,7 @@ public:
   bool IsHDRDisplay() override;
 
   CHDRCapabilities GetDisplayHDRCapabilities() const override;
+  float GetGuiSdrPeakLuminance() const override;
 
 protected:
   std::unique_ptr<KODI::WINDOWING::IOSScreenSaver> GetOSScreenSaverImpl() override;

--- a/xbmc/windowing/win10/WinSystemWin10.h
+++ b/xbmc/windowing/win10/WinSystemWin10.h
@@ -82,6 +82,7 @@ public:
   bool Show(bool raise = true) override;
   std::string GetClipboardText() override;
   bool UseLimitedColor() override;
+  float GetGuiSdrPeakLuminance() const override;
   bool HasSystemSdrPeakLuminance() override;
 
   // videosync
@@ -98,7 +99,6 @@ public:
   virtual bool DPIChanged(WORD dpi, RECT windowRect) const;
   bool IsMinimized() const { return m_bMinimized; }
   void SetMinimized(bool minimized) { m_bMinimized = minimized; }
-  float GetGuiSdrPeakLuminance() const;
   void CacheSystemSdrPeakLuminance();
 
   bool CanDoWindowed() override;

--- a/xbmc/windowing/windows/WinSystemWin32.h
+++ b/xbmc/windowing/windows/WinSystemWin32.h
@@ -96,6 +96,7 @@ public:
   bool Show(bool raise = true) override;
   std::string GetClipboardText() override;
   bool UseLimitedColor() override;
+  float GetGuiSdrPeakLuminance() const override;
   bool HasSystemSdrPeakLuminance() override;
 
   // videosync
@@ -114,7 +115,6 @@ public:
   virtual bool DPIChanged(WORD dpi, RECT windowRect) const;
   bool IsMinimized() const { return m_bMinimized; }
   void SetMinimized(bool minimized);
-  float GetGuiSdrPeakLuminance() const;
   void CacheSystemSdrPeakLuminance();
 
   void SetSizeMoveMode(bool mode) { m_bSizeMoveEnabled = mode; }


### PR DESCRIPTION
## Description
[Android] Adjust GUI SRD peak luminance when display is in HDR PQ mode

This the equivalent functionality of https://github.com/xbmc/xbmc/pull/18984 and https://github.com/xbmc/xbmc/pull/21973 for Android.

## Motivation and context
This is requested a lot on the forums....

https://forum.kodi.tv/showthread.php?tid=376360
https://forum.kodi.tv/showthread.php?tid=357205
https://www.reddit.com/r/kodi/comments/1awb6h3/osd_hdr_too_bright_during_playback/

With this is not necessary set subtitles color dark grey or different color for SDR / HDR and also is adjusted OSD and all GUI elements.

Android already does basic tone mapping - there is no need for full tone mapping from BT.709 to BT.2020 or gamma to PQ transfer. Only is need to set the SDR peak to 100 or 200 nits because by default it seems to be set to 1000 nits (at least in Shiled) and this is why it looks much brighter than normal SDR.

When SDR peak is set to 100 - 200 nits then GUI has same appearance than in SDR and GUI white is regular SDR white.

The default setting is 40% and matches what we already have in Windows. That is, the result is consistent with Windows using the same setting value. Adjusting GUI setting to 100% gives you the maximum brightness (~1000 nits), which is the same as before this PR.


## How has this been tested?
Runtime Shield Pro 2019

Forum users:
- Fire TV Stick 4K Max 2nd gen (https://forum.kodi.tv/showthread.php?tid=376360&pid=3186614#pid3186614)
- Fire TV Stick 4K Max 1st gen (https://forum.kodi.tv/showthread.php?tid=376360&pid=3186768#pid3186768)

## What is the effect on users?
No more tricks to adjust brightness of subtitles / OSD / GUI when playing HDR10 or Dolby Vision contents.

## Screenshots (if appropriate):

![screenshot00001](https://github.com/xbmc/xbmc/assets/58434170/a54bfe70-f129-49b1-82fa-17f282367ec0)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
