### PR TITLE
[Android] zipAlignEnabled has been deprecated for a while

### DIFF
--- a/tools/android/packaging/xbmc/build.gradle.in
+++ b/tools/android/packaging/xbmc/build.gradle.in
@@ -21,26 +21,21 @@ android {
             enableV2Signing true
             enableV3Signing true
         }
-
     }
     buildTypes {
         debug {
-            zipAlignEnabled true
             signingConfig signingConfigs.release
         }
         relwithdebinfo {
-            zipAlignEnabled true
             signingConfig signingConfigs.release
         }
         release {
-            zipAlignEnabled true
             signingConfig signingConfigs.release
         }
     }
     aaptOptions {
         ignoreAssetsPattern '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'
     }
-
     sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'


### PR DESCRIPTION
## Description
APK is zip aligned by default. Remove from `build.gradle` as it has no effect.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
