### PR TITLE
Platform: Linux: PowerManagement: Logind/Upower: Fix battery info/Upo…

### DIFF
--- a/xbmc/platform/linux/powermanagement/LogindUPowerSyscall.h
+++ b/xbmc/platform/linux/powermanagement/LogindUPowerSyscall.h
@@ -37,13 +37,15 @@ private:
   bool m_canReboot;
   bool m_hasUPower;
   bool m_lowBattery;
+  bool m_chargerState;
+  int m_batteryState;
   int m_batteryLevel;
   int m_delayLockSleepFd = -1; // file descriptor for the logind sleep delay lock
   int m_delayLockShutdownFd = -1; // file descriptor for the logind powerdown delay lock
-  void UpdateBatteryLevel();
+  void UpdatePowerSupplyInfo();
   void InhibitDelayLockSleep();
-  void InhibitDelayLockShutdown();  
-  int InhibitDelayLock(const char *what);
+  void InhibitDelayLockShutdown();
+  int InhibitDelayLock(const char* what);
   void ReleaseDelayLockSleep();
   void ReleaseDelayLockShutdown();
   void ReleaseDelayLock(int lockFd, const char *what);


### PR DESCRIPTION
This an initial fix for proper battery statistics within kodi on linux for not only system batteries, but adding checks against power supplies. I have more stuff to sort/clean up, that breaks more of this information out to userspace properly, mostly for themes, so designers can tell if the battery is charging, or if the charger is connected, and the battery isnt charging, such as when the state is reported as full. I also plan on finding away to get more proper notification when remote batteries, controller batteries, other device batteries are low as well, if the device reports that info.

I am also interested in feedback as to if this should also be ported to this PR, using that api instead of the one existing in kodi currently: https://github.com/xbmc/xbmc/pull/17327

and if @garbear sees this, I would also be interested in finding a way to link this with peripheral.joystick as well for game controllers.

Included in this PR to fix what is already implemented, and not a PR that is waiting to be finished:

Fix: upower stopped reporting device changed.  Now device Change events are handled by dbus property changes, so monitor for that instead.
WAR: WIP: Some workarounds for unknown fuel gage init issues on some devices which cause reporting of wrong state until first time charger is connected.
Fix: The battery info being added together and averaged, for all detected batteries. We only want to monitor system batteries at this stage.
Adds: Initial charger state detection. Only implemented in the sense that we filter out the results of state and save them for use later.
Adds: UX: Dont sound low battery alarm if charger is connected.
Adds: Make a note if multiple batteries/chargers are found in debug log.
Adds: Make a note if any non power supply batteries(Unfiltered Types) are found in debug log.


This PR should close: https://github.com/xbmc/xbmc/issues/16828