### PR TITLE
[Android] Use compileSdk, minSdk and targetSdk

### DIFF
--- a/tools/android/packaging/xbmc/build.gradle.in
+++ b/tools/android/packaging/xbmc/build.gradle.in
@@ -2,12 +2,12 @@ apply plugin: 'com.android.application'
 
 android {
     namespace '@APP_PACKAGE@'
-    compileSdkVersion @TARGET_SDK@
+    compileSdk @TARGET_SDK@
     ndkPath "@NDKROOT@"
     defaultConfig {
         applicationId "@APP_PACKAGE@"
-        minSdkVersion @TARGET_MINSDK@
-        targetSdkVersion @TARGET_SDK@
+        minSdk @TARGET_MINSDK@
+        targetSdk @TARGET_SDK@
         versionCode @APP_VERSION_CODE_ANDROID@
         versionName "@APP_VERSION@"
     }


### PR DESCRIPTION
## Description
`compileSdkVersion` has been deprecated and should be replaced by `compileSdk`.

Use also `minSdk` and `targetSdk` instead of `minSdkVersion` and `targetSdkVersion`.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
