### PR TITLE
[VideoPlayer] Fix initial interlaced stream refresh rate switch

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3753,10 +3753,9 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
   {
     if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE) != ADJUST_REFRESHRATE_OFF)
     {
-      const double framerate =
-          DVD_TIME_BASE /
-          CDVDCodecUtils::NormalizeFrameduration(
-              (double)DVD_TIME_BASE * ((hint.interlaced ? 2 : 1) * hint.fpsscale) / hint.fpsrate);
+      const double framerate = DVD_TIME_BASE / CDVDCodecUtils::NormalizeFrameduration(
+                                                   (double)DVD_TIME_BASE * hint.fpsscale /
+                                                   (hint.fpsrate * (hint.interlaced ? 2 : 1)));
 
       RESOLUTION res = CResolutionUtils::ChooseBestResolution(static_cast<float>(framerate), hint.width, hint.height, !hint.stereo_mode.empty());
       CServiceBroker::GetWinSystem()->GetGfxContext().SetVideoResolution(res, false);

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -173,8 +173,7 @@ void CVideoPlayerVideo::OpenStream(CDVDStreamInfo& hint, std::unique_ptr<CDVDVid
   if (hint.fpsrate && hint.fpsscale)
   {
     m_fFrameRate = DVD_TIME_BASE / CDVDCodecUtils::NormalizeFrameduration(
-                                       (double)DVD_TIME_BASE *
-                                       ((hint.interlaced ? 2 : 1) * hint.fpsscale) / hint.fpsrate);
+                                       (double)DVD_TIME_BASE * hint.fpsscale / hint.fpsrate);
 
     m_bFpsInvalid = false;
     m_processInfo.SetVideoFps(static_cast<float>(m_fFrameRate));


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Address issues with previous PR #24121to avoid two consecutive refresh rate switches when starting the playback of an interlaced video.

- Restore original logic of `CVideoPlayerVideo::OpenStream()`. Videoplayer handled that case correctly already and the change actually caused an internal switch after timing was extracted from the timestamps (no user visible effect, but couldn't be good)

- Fix the initial framerate calculation of `CVideoPlayer::OpenVideoStream()`, which was halving instead of doubling.

Same as before, .ts are excluded because of possible impact on PVR fast channel switching close to release

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#24121 sort of avoided two consecutive refresh rate switches when starting the playback of an interlaced video but did it incorrectly with side effects, noticed in some user debug logs for other issues.

The mistake was sometimes covered up by the available resolutions of the screen and the reverted logic of VideoPlayerVideo.

Interlaced material is not as common nowadays, maybe that's the reason the issue wasn't reported since 21b2.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows, screen with normal, double and quadruple refresh rates available and screen with fixed rr.
mkv with interlaced stream (intial doubling happens), ts with interlaced stream (no initial doubling, no behavior change on purpose)
mkv / .ts with progressive stream

Watched the OS screen refresh rate and debug log

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
More reliable direct switch to correct frame rate for interlaced videos (except .ts on purpose).

## Screenshots (if appropriate):
Before, broken case:
```
info <general>: [WHITELIST] Searching the whitelist for: width: 720, height: 576, fps: 12.500, 3D: false
...
debug <general>: [WHITELIST] Matched a desktop resolution with an exact refresh rate LG TV #1: 1920x1080 @ 25.00Hz (90)
...
debug <general>: CRenderManager::Configure - change configuration. 720x576. display: 720x405. framerate: 12.50.
...
debug <general>: CVideoPlayerVideo::CalcFrameRate framerate was:12.500000 calculated:25.000000
debug <general>: CRenderManager::Configure - change configuration. 720x576. display: 720x405. framerate: 50.00.
...
info <general>: [WHITELIST] Searching the whitelist for: width: 720, height: 576, fps: 50.000, 3D: false
...
debug <general>: [WHITELIST] Matched a desktop resolution with an exact refresh rate LG TV #1: 1920x1080 @ 50.00Hz (93)
info <general>: Display resolution ADJUST : LG TV #1: 1920x1080 @ 50.00Hz (93) (weight: 0.000)
```

After, same video and situation:
```
info <general>: [WHITELIST] Searching the whitelist for: width: 720, height: 576, fps: 50.000, 3D: false
...
debug <general>: [WHITELIST] Matched a desktop resolution with an exact refresh rate LG TV #1: 1920x1080 @ 50.00Hz (93)
...
debug <general>: CRenderManager::Configure - change configuration. 720x576. display: 720x405. framerate: 50.00.
```


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
