### PR TITLE
GLES: Implement basic post processing pass

### DIFF
--- a/system/shaders/GLES/2.0/gles_shader_passtrough.vert
+++ b/system/shaders/GLES/2.0/gles_shader_passtrough.vert
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#version 100
+
+attribute vec2 m_attrpos;
+varying vec2 m_cord0;
+
+// this shader expects a full-screen triangle with normalized coordinates.
+
+void main()
+{
+  gl_Position.xy = m_attrpos * vec2(2.) - vec2(1.);
+  m_cord0 = m_attrpos;
+}

--- a/system/shaders/GLES/2.0/gles_shader_resolve.frag
+++ b/system/shaders/GLES/2.0/gles_shader_resolve.frag
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#version 100
+
+#if defined(KODI_FETCH_ARM)
+#extension GL_ARM_shader_framebuffer_fetch : enable
+#elif defined(KODI_FETCH_EXT)
+#extension GL_EXT_shader_framebuffer_fetch : enable
+#elif defined(KODI_FETCH_NV)
+#extension GL_NV_shader_framebuffer_fetch : enable
+#endif
+
+precision mediump float;
+uniform sampler2D m_samp0;
+varying vec2 m_cord0;
+
+void main()
+{
+#if defined(KODI_FETCH_ARM)
+  vec4 rgba = gl_LastFragColorARM;
+#elif defined(KODI_FETCH_EXT)
+  vec4 rgba = gl_LastFragColor;
+#elif defined(KODI_FETCH_NV)
+  vec4 rgba = gl_LastFragColor;
+#else
+  vec4 rgba = texture2D(m_samp0, m_cord0);
+#endif
+
+#if defined(KODI_LIMITED_RANGE_PASS)
+  rgba.rgb *= (235.0 - 16.0) / 255.0;
+  rgba.rgb += 16.0 / 255.0;
+#endif
+
+  gl_FragColor = rgba;
+}

--- a/xbmc/rendering/RenderSystemTypes.h
+++ b/xbmc/rendering/RenderSystemTypes.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017-2018 Team Kodi
+ *  Copyright (C) 2017-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -32,4 +32,12 @@ enum RENDER_STEREO_MODE
   // Pseudo modes
   RENDER_STEREO_MODE_AUTO = 100,
   RENDER_STEREO_MODE_UNDEFINED = 999,
+};
+
+enum RENDER_RESOLVE
+{
+  RENDER_RESOLVE_DEFAULT, // default rendering behaviour
+  RENDER_RESOLVE_BLIT, // blit an intermediate buffer to the default FB
+  RENDER_RESOLVE_SHADER_SINGLE_PASS, // use shaders to apply an intermediate buffer to the default FB
+  RENDER_RESOLVE_SHADER_DUAL_PASS, // use shaders to apply an intermediate buffer to the default FB in a extra pass
 };

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -788,7 +788,7 @@ void CRenderSystemGLES::BindIntermediateBuffer()
 
 bool CRenderSystemGLES::PostProcessBlit()
 {
-#if HAS_GLES >= 3
+#if HAS_GLES == 3
   if (m_limitedColorRange)
     return false;
 

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -201,6 +201,7 @@ bool CRenderSystemGLES::EndRender()
     case RENDER_RESOLVE_BLIT:
       if (PostProcessBlit())
         return true;
+      [[fallthrough]];
     case RENDER_RESOLVE_SHADER_DUAL_PASS:
       return PostProcessShaderDualPass();
     case RENDER_RESOLVE_DEFAULT:
@@ -788,7 +789,8 @@ void CRenderSystemGLES::BindIntermediateBuffer()
 
 bool CRenderSystemGLES::PostProcessBlit()
 {
-#if HAS_GLES == 3
+  // jenkins won't build android if enabled
+#if (HAS_GLES == 3 && not defined(TARGET_ANDROID))
   if (m_limitedColorRange)
     return false;
 

--- a/xbmc/rendering/gles/RenderSystemGLES.h
+++ b/xbmc/rendering/gles/RenderSystemGLES.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -33,6 +33,7 @@ enum class ShaderMethodGLES
   SM_TEXTURE_RGBA_BOB,
   SM_TEXTURE_RGBA_BOB_OES,
   SM_TEXTURE_NOALPHA,
+  SM_RESOLVE,
   SM_MAX
 };
 
@@ -63,6 +64,7 @@ private:
       {ShaderMethodGLES::SM_TEXTURE_RGBA_BOB, "texture rgba bob"},
       {ShaderMethodGLES::SM_TEXTURE_RGBA_BOB_OES, "texture rgba bob OES"},
       {ShaderMethodGLES::SM_TEXTURE_NOALPHA, "texture no alpha"},
+      {ShaderMethodGLES::SM_RESOLVE, "resolve shader"},
   });
 
   static_assert(static_cast<size_t>(ShaderMethodGLES::SM_MAX) == ShaderMethodGLESMap.size(),
@@ -125,6 +127,37 @@ public:
   GLint GUIShaderGetBrightness();
   GLint GUIShaderGetModel();
 
+  /**
+   * @brief Binds the intermediate framebuffer, so that it can be rendered to.
+   * Creates one if needed.
+   */
+  void BindIntermediateBuffer();
+  /**
+   * @brief Creates a triangle spanning the whole screen.
+   */
+  void CreateDefaultVertex();
+  /**
+   * @brief Blits the intermediate buffer to the main frame buffer. 
+   * Width/Height can differ, but we can't blend/manipulate the content.
+   *
+   * @return true The blit succeeded
+   */
+  bool PostProcessBlit();
+  /**
+   * @brief Applies the "virtual" intermediate buffer to the main frame buffer.
+   * Width/Height need to be the same, but we can blend/manipulate the content.
+   *
+   * @return true The pass succeeded
+   */
+  bool PostProcessShaderSinglePass();
+  /**
+   * @brief Applies the intermediate buffer to the main frame buffer.
+   * Width/Height can differ, and we can blend and manipulate the content.
+   *
+   * @return true The pass succeeded
+   */
+  bool PostProcessShaderDualPass();
+
 protected:
   virtual void SetVSyncImpl(bool enable) = 0;
   virtual void PresentRenderImpl(bool rendered) = 0;
@@ -140,4 +173,10 @@ protected:
   ShaderMethodGLES m_method = ShaderMethodGLES::SM_DEFAULT;
 
   GLint      m_viewPort[4];
+  GLuint m_framebufferGUI{0};
+  GLuint m_textureGUI{0};
+  GLuint m_defaultVertex{0};
+
+  RENDER_RESOLVE m_renderPassType{RENDER_RESOLVE_DEFAULT};
+  bool m_isRenderingVideoInUI{false};
 };


### PR DESCRIPTION
## Description
With this PR, I'm implementing a post processing pass for GLES. In its current form, the only feature is to remap the full range (0-255) UI to a limited range (16-235) output. 

It comes with three different flavors for applying the UI to the framebuffer: the blitter, single pass- and dual pass shaders.

The blitter just copies the UI from an intermediate buffer to the final frame buffer. While it can't manipulate the color values, it can upscale the UI and converting its color depth. On some systems, a special part of the hardware is used, freeing the GPU for other tasks. It is currently not used, but pretty interesting for future work.

The single pass shader is executed at the last step of the rendering. It can't scale the UI or manipulate the color depth. On most systems with the required GL extensions (GL_EXT_shader_framebuffer_fetch), the intermediate buffer never leaves the on-chip memory, which makes it the fastest method. With GL_EXT_shader_pixel_local_storage, a higher intermediate buffer could be used in the future.

The dual pass shader is executed similarly to the blitter pass, but can manipulate color. It is the most versatile, but also the most expensive.

## Motivation and context
On the surface, it is just moving the color range manipulation to a different shader. But there is so much more than that. It provides a place for:
- Resolving/support of high depth color buffers (reduces banding)
- Dithering
- Brightness reduction of Kodi running on a HDR screens on Android (https://github.com/xbmc/xbmc/pull/24756)
- Color mapping
- Screen (video) independent UI resolution and frame rate
- An interface to split the UI rendering from the rest of the system

## How has this been tested?
The dual pass shader and the blitter appear to work fine. I have yet to test the single pass shader.

## What is the effect on users?
Depends on the system. When enabling color range limiting; rendering time might be slower, but the image quality should be better. 

Banding will be less when implementing dithering.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
