### PR TITLE
Fix regression for play actions

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -538,15 +538,17 @@ bool CGUIWindowVideoBase::OnSelect(int iItem)
   if (iItem < 0 || iItem >= m_vecItems->Size())
     return false;
 
-  CFileItemPtr item = m_vecItems->Get(iItem);
+  const std::shared_ptr<CFileItem> item = m_vecItems->Get(iItem);
 
-  std::string path = item->GetPath();
+  const std::string path = item->GetPath();
   if (!item->m_bIsFolder && path != "add" &&
-      !StringUtils::StartsWith(path, "newsmartplaylist://") &&
-      !StringUtils::StartsWith(path, "newplaylist://") &&
-      !StringUtils::StartsWith(path, "newtag://") && !StringUtils::StartsWith(path, "script://") &&
-      !StringUtils::StartsWith(path, "plugin://") && !item->HasProperty("IsPlayable") &&
-      !item->GetProperty("IsPlayable").asBoolean())
+      ((!StringUtils::StartsWith(path, "newsmartplaylist://") &&
+        !StringUtils::StartsWith(path, "newplaylist://") &&
+        !StringUtils::StartsWith(path, "newtag://") &&
+        !StringUtils::StartsWith(path, "script://") &&
+        !StringUtils::StartsWith(path, "plugin://")) ||
+       (StringUtils::StartsWith(path, "plugin://") &&
+        item->GetProperty("IsPlayable").asBoolean(false))))
     return OnFileAction(iItem, CVideoSelectActionProcessorBase::GetDefaultSelectAction(), "");
 
   return CGUIMediaWindow::OnSelect(iItem);


### PR DESCRIPTION
## Description
This fixes a regression caused by https://github.com/xbmc/xbmc/pull/24743 and mentioned by @CrystalP in https://github.com/xbmc/xbmc/pull/24743#issuecomment-1973670363.
Long story short, the file actions should be available for:
- The same items as before
- For plugin items if they are flagged as playable

Sorry for the small delay, didn't manage to get into the computer last night.

## Motivation and context
Kodi v21 RC

## How has this been tested?
Runtime tested with playable plugins, playable files and non-playable plugin items

## What is the effect on users?
Resume actions should be restored

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
