### PR TITLE
[video] fix selected item after removing version/extra

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoManager.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -305,6 +305,7 @@ void CGUIDialogVideoManager::Remove()
 
   // refresh data and controls
   Refresh();
+  RefreshSelectedVideoAsset();
   UpdateControls();
 }
 
@@ -464,4 +465,22 @@ void CGUIDialogVideoManager::AppendItemFolderToFileBrowserSources(
     itemSource.strPath = itemDir;
     sources.emplace_back(itemSource);
   }
+}
+
+void CGUIDialogVideoManager::RefreshSelectedVideoAsset()
+{
+  if (!m_selectedVideoAsset || !m_selectedVideoAsset->HasVideoInfoTag() ||
+      !m_videoAssetsList->Size())
+  {
+    m_selectedVideoAsset = std::make_shared<CFileItem>();
+    return;
+  }
+
+  const int dbId{m_selectedVideoAsset->GetVideoInfoTag()->m_iDbId};
+  const auto it{std::find_if(m_videoAssetsList->cbegin(), m_videoAssetsList->cend(),
+                             [dbId](const auto& entry)
+                             { return entry->GetVideoInfoTag()->m_iDbId == dbId; })};
+
+  if (it == m_videoAssetsList->cend())
+    m_selectedVideoAsset = m_videoAssetsList->Get(0);
 }

--- a/xbmc/video/dialogs/GUIDialogVideoManager.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.h
@@ -56,6 +56,7 @@ protected:
                               VideoAssetType assetType,
                               const std::string& defaultName);
   void AppendItemFolderToFileBrowserSources(std::vector<CMediaSource>& sources);
+  void RefreshSelectedVideoAsset();
 
   CVideoDatabase m_database;
   std::shared_ptr<CFileItem> m_videoAsset;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

The selected item member was not updated after removing a version or extra

This PR selects the first item of the list when the previously selected item doesn't exist in the list anymore after Refresh() - for example after removal of an item.

The first checks are overkill for the current needs in the context of the Remove button but make the function bulletproof for the future.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #24485, which affects both versions and extras.

After removal of a version or extra, the top item of the list is highlighted and appears selected, but going to the remove button again attempts to remove again the already removed item, instead of removing the new selection.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Versions/Extras Manager still opens with correct default item selected (default version or 1st extra of the list)
Back to back removals work as expected on the new selected item (top of the list).

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Remove version/extra works as expected without side effects.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
