### PR TITLE
[Video][Stacks] Fix folder stacks.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16621,7 +16621,27 @@ msgctxt "#25014"
 msgid "Manual"
 msgstr ""
 
-#empty strings from id 25015 to 29800
+#: application/ApplicationPlayerCallback.cpp
+msgctxt "#25015"
+msgid "Stacks"
+msgstr ""
+
+#: application/ApplicationPlayerCallback.cpp
+msgctxt "#25016"
+msgid "Continue to play next item in stack?"
+msgstr ""
+
+#: application/ApplicationPlayerCallback.cpp
+msgctxt "#25017"
+msgid "Continue"
+msgstr ""
+
+#: application/ApplicationPlayerCallback.cpp
+msgctxt "#25018"
+msgid "Stop"
+msgstr ""
+
+#empty strings from id 25019 to 29800
 
 #: unused
 msgctxt "#29801"

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -142,8 +142,6 @@ public:
   const std::string &GetDynPath() const;
   void SetDynPath(const std::string &path);
 
-  std::string GetBlurayPath() const;
-
   /*! \brief reset class to it's default values as per construction.
    Free's all allocated memory.
    \sa Initialize

--- a/xbmc/FileItemList.h
+++ b/xbmc/FileItemList.h
@@ -80,7 +80,7 @@ public:
    \param stackFiles whether to stack all items or just collapse folders (defaults to true)
    \sa StackFiles,StackFolders
    */
-  void Stack(bool stackFiles = true);
+  void Stack();
 
   SortOrder GetSortOrder() const { return m_sortDescription.sortOrder; }
   SortBy GetSortMethod() const { return m_sortDescription.sortBy; }
@@ -178,17 +178,8 @@ private:
   void FillSortFields(FILEITEMFILLFUNC func);
   std::string GetDiscFileCache(int windowID) const;
 
-  /*!
-   \brief stack files in a CFileItemList
-   \sa Stack
-   */
-  void StackFiles();
-
-  /*!
-   \brief stack folders in a CFileItemList
-   \sa Stack
-   */
-  void StackFolders();
+  void ConvertDiscFoldersToFiles();
+  void ConvertDiscFolderToFile(const std::shared_ptr<CFileItem>& item, const std::string& playPath);
 
   VECFILEITEMS m_items;
   MAPFILEITEMS m_map;

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -18,6 +18,7 @@
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPlayer.h"
 #include "application/ApplicationPowerHandling.h"
+#include "application/ApplicationStackHelper.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "filesystem/PluginDirectory.h"
 #include "filesystem/VideoDatabaseFile.h"
@@ -945,7 +946,11 @@ void PLAYLIST::CPlayListPlayer::OnApplicationMessage(KODI::MESSAGING::ThreadMess
     {
       // Discard the current playlist, if TMSG_MEDIA_PLAY gets posted with just a single item.
       // Otherwise items may fail to play, when started while a playlist is playing.
-      Reset();
+      // But a single item in a stack is allowed.
+      CPlayList& playlist = GetPlaylist(m_iCurrentPlayList);
+      CFileItemPtr pitem = playlist[m_iCurrentSong];
+      if (!URIUtils::IsStack(pitem->GetDynPath()))
+        Reset();
 
       CFileItem *item = static_cast<CFileItem*>(pMsg->lpVoid);
       g_application.PlayFile(*item, "", pMsg->param1 != 0);

--- a/xbmc/application/Application.h
+++ b/xbmc/application/Application.h
@@ -216,6 +216,8 @@ protected:
 
   int m_nextPlaylistItem = -1;
 
+  bool m_CancelPlayback{false};
+
   std::chrono::time_point<std::chrono::steady_clock> m_lastRenderTime;
   bool m_skipGuiRender = false;
 

--- a/xbmc/application/ApplicationStackHelper.cpp
+++ b/xbmc/application/ApplicationStackHelper.cpp
@@ -77,7 +77,6 @@ bool CApplicationStackHelper::InitializeStack(const CFileItem & item)
     SetRegisteredStack(GetStackPartFileItem(i), stack);
     SetRegisteredStackPartNumber(GetStackPartFileItem(i), i);
   }
-  m_currentStackIsDiscImageStack = URIUtils::IsDiscImageStack(item.GetDynPath());
 
   return true;
 }
@@ -85,141 +84,120 @@ bool CApplicationStackHelper::InitializeStack(const CFileItem & item)
 std::optional<int64_t> CApplicationStackHelper::InitializeStackStartPartAndOffset(
     const CFileItem& item)
 {
+  // see if we have the info in the database
+  //! @todo If user changes the time speed (FPS via framerate conversion stuff)
+  //!       then these times will be wrong.
+  //!       Also, this is really just a hack for the slow load up times we have
+  //!       A much better solution is a fast reader of FPS and fileLength
+  //!       that we can use on a file to get it's time.
   CVideoDatabase dbs;
-  int64_t startoffset = 0;
 
-  // case 1: stacked ISOs
-  if (m_currentStackIsDiscImageStack)
+  std::vector<uint64_t> times;
+  uint64_t totalTimeMs{0};
+  bool haveTimes{false};
+
+  if (dbs.Open())
+    haveTimes = dbs.GetStackTimes(item.GetDynPath(), times);
+
+  // If not times and is a regular (file) stack then get times from files
+  // Not possible for BD/DVD (folder) stacks due to playlist/title not known
+  if (!haveTimes && !IsPlayingDiscStack())
   {
-    // first assume values passed to the stack
-    int selectedFile = item.m_lStartPartNumber;
-    startoffset = item.GetStartOffset();
-
-    // check if we instructed the stack to resume from default
-    if (startoffset == STARTOFFSET_RESUME) // selected file is not specified, pick the 'last' resume point
+    for (int i = 0; i < m_currentStack->Size(); ++i)
     {
-      if (dbs.Open())
+      int duration;
+      if (!CDVDFileInfo::GetFileDuration(GetStackPartFileItem(i).GetDynPath(), duration))
       {
-        CBookmark bookmark;
-        std::string path = item.GetDynPath();
-        if (item.HasProperty("original_listitem_url") && URIUtils::IsPlugin(item.GetProperty("original_listitem_url").asString()))
-          path = item.GetProperty("original_listitem_url").asString();
-        if (dbs.GetResumeBookMark(path, bookmark))
-        {
-          startoffset = CUtil::ConvertSecsToMilliSecs(bookmark.timeInSeconds);
-          selectedFile = bookmark.partNumber;
-        }
-        dbs.Close();
+        m_currentStack->Clear();
+        return std::nullopt;
       }
-      else
-        CLog::LogF(LOGERROR, "Cannot open VideoDatabase");
+      totalTimeMs += duration;
+      times.emplace_back(totalTimeMs);
     }
-
-    // make sure that the selected part is within the boundaries
-    if (selectedFile <= 0)
-    {
-      CLog::LogF(LOGWARNING, "Selected part {} out of range, playing part 1", selectedFile);
-      selectedFile = 1;
-    }
-    else if (selectedFile > m_currentStack->Size())
-    {
-      CLog::LogF(LOGWARNING, "Selected part {} out of range, playing part {}", selectedFile,
-                 m_currentStack->Size());
-      selectedFile = m_currentStack->Size();
-    }
-
-    // set startoffset in selected item, track stack item for updating purposes, and finally play disc part
-    m_currentStackPosition = selectedFile - 1;
-    startoffset = startoffset > 0 ? STARTOFFSET_RESUME : 0;
+    dbs.SetStackTimes(item.GetDynPath(), times);
+    haveTimes = true;
   }
-  // case 2: all other stacks
-  else
+
+  // If have times (saved or found above) then update stack
+  if (haveTimes)
   {
-    // see if we have the info in the database
-    //! @todo If user changes the time speed (FPS via framerate conversion stuff)
-    //!       then these times will be wrong.
-    //!       Also, this is really just a hack for the slow load up times we have
-    //!       A much better solution is a fast reader of FPS and fileLength
-    //!       that we can use on a file to get it's time.
-    std::vector<uint64_t> times;
-    bool haveTimes(false);
-
-    if (dbs.Open())
+    totalTimeMs = times.back();
+    int i;
+    for (i = 0; i < static_cast<int>(times.size()); ++i)
     {
-      haveTimes = dbs.GetStackTimes(item.GetDynPath(), times);
-      dbs.Close();
+      CFileItem& part{GetStackPartFileItem(i)};
+      // set end time in known parts
+      part.SetEndOffset(times[i]);
+      // set start time in known parts
+      SetRegisteredStackPartStartTimeMs(part, i == 0 ? 0 : times[i - 1]);
+      // set total time in known parts
+      SetRegisteredStackTotalTimeMs(part, totalTimeMs);
     }
-
-    // calculate the total time of the stack
-    uint64_t totalTimeMs = 0;
-    for (int i = 0; i < m_currentStack->Size(); i++)
-    {
-      if (haveTimes)
-      {
-        // set end time in every part
-        GetStackPartFileItem(i).SetEndOffset(times[i]);
-      }
-      else
-      {
-        int duration;
-        if (!CDVDFileInfo::GetFileDuration(GetStackPartFileItem(i).GetDynPath(), duration))
-        {
-          m_currentStack->Clear();
-          return std::nullopt;
-        }
-        totalTimeMs += duration;
-        // set end time in every part
-        GetStackPartFileItem(i).SetEndOffset(totalTimeMs);
-        times.push_back(totalTimeMs);
-      }
-      // set start time in every part
-      SetRegisteredStackPartStartTimeMs(GetStackPartFileItem(i), GetStackPartStartTimeMs(i));
-    }
-    // set total time in every part
-    totalTimeMs = GetStackTotalTimeMs();
-    for (int i = 0; i < m_currentStack->Size(); i++)
-      SetRegisteredStackTotalTimeMs(GetStackPartFileItem(i), totalTimeMs);
-
-    uint64_t msecs = item.GetStartOffset();
-
-    if (!haveTimes || item.GetStartOffset() == STARTOFFSET_RESUME)
-    {
-      if (dbs.Open())
-      {
-        // have our times now, so update the dB
-        if (!haveTimes && !times.empty())
-          dbs.SetStackTimes(item.GetDynPath(), times);
-
-        if (item.GetStartOffset() == STARTOFFSET_RESUME)
-        {
-          // can only resume seek here, not dvdstate
-          CBookmark bookmark;
-          std::string path = item.GetDynPath();
-          if (item.HasProperty("original_listitem_url") && URIUtils::IsPlugin(item.GetProperty("original_listitem_url").asString()))
-            path = item.GetProperty("original_listitem_url").asString();
-          if (dbs.GetResumeBookMark(path, bookmark))
-            msecs = static_cast<uint64_t>(bookmark.timeInSeconds * 1000);
-          else
-            msecs = 0;
-        }
-        dbs.Close();
-      }
-    }
-
-    m_currentStackPosition = GetStackPartNumberAtTimeMs(msecs);
-    startoffset = msecs - GetStackPartStartTimeMs(m_currentStackPosition);
+    m_knownStackParts = times.size();
   }
-  return startoffset;
+
+  int64_t msecs = item.GetStartOffset();
+
+  if (msecs == STARTOFFSET_RESUME)
+  {
+    CBookmark bookmark;
+    std::string path = item.GetDynPath();
+    if (item.HasProperty("original_listitem_url") &&
+        URIUtils::IsPlugin(item.GetProperty("original_listitem_url").asString()))
+      path = item.GetProperty("original_listitem_url").asString();
+    if (dbs.GetResumeBookMark(path, bookmark))
+      msecs = static_cast<int64_t>(bookmark.timeInSeconds * 1000);
+    else
+      msecs = 0;
+  }
+
+  dbs.Close();
+
+  // Adjust absolute position to stack
+  m_currentStackPosition = GetStackPartNumberAtTimeMs(msecs);
+
+  // Remember if this was a disc stack
+  m_wasDiscStack = HasDiscParts();
+
+  return msecs - static_cast<int64_t>(GetStackPartStartTimeMs(m_currentStackPosition));
 }
 
-bool CApplicationStackHelper::IsPlayingISOStack() const
+// IsPlayingDiscStack - means we can't move back and forth between items
+
+bool CApplicationStackHelper::IsPlayingDiscStack() const
 {
-  return m_currentStack->Size() > 0 && m_currentStackIsDiscImageStack;
+  return m_currentStack->Size() > 0 && !IsPlayingRegularStack();
 }
+
+// Is PlayingRegularStack - means we can move back and forth between items
 
 bool CApplicationStackHelper::IsPlayingRegularStack() const
 {
-  return m_currentStack->Size() > 0 && !m_currentStackIsDiscImageStack;
+  if (m_currentStack->Size() > 0)
+  {
+    const int currentPart = GetCurrentPartNumber() < 1 ? 1 : GetCurrentPartNumber();
+    for (int i = 0; i < currentPart; ++i)
+    {
+      const std::string path = GetStackPartFileItem(i).GetDynPath();
+      if (URIUtils::IsDiscImage(path) || URIUtils::IsDVDFile(path) || URIUtils::IsBDFile(path))
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
+bool CApplicationStackHelper::HasDiscParts() const
+{
+  for (int i = 0; i < m_currentStack->Size(); ++i)
+  {
+    const std::string path = GetStackPartFileItem(i).GetDynPath();
+    if (URIUtils::IsDiscImage(path) || URIUtils::IsDVDFile(path) || URIUtils::IsBDFile(path))
+      return true;
+  }
+  return false;
 }
 
 bool CApplicationStackHelper::HasNextStackPartFileItem() const
@@ -234,10 +212,16 @@ uint64_t CApplicationStackHelper::GetStackPartEndTimeMs(int partNumber) const
 
 uint64_t CApplicationStackHelper::GetStackTotalTimeMs() const
 {
-  return GetStackPartEndTimeMs(m_currentStack->Size() - 1);
+  for (int i = m_currentStack->Size() - 1; i >= 0; --i)
+  {
+    const uint64_t endTime = GetStackPartEndTimeMs(i);
+    if (endTime > 0)
+      return endTime;
+  }
+  return 0;
 }
 
-int CApplicationStackHelper::GetStackPartNumberAtTimeMs(uint64_t msecs)
+int CApplicationStackHelper::GetStackPartNumberAtTimeMs(uint64_t msecs) const
 {
   if (msecs > 0)
   {
@@ -259,12 +243,12 @@ void CApplicationStackHelper::ClearAllRegisteredStackInformation()
 std::shared_ptr<const CFileItem> CApplicationStackHelper::GetRegisteredStack(
     const CFileItem& item) const
 {
-  return GetStackPartInformation(item.GetDynPath())->m_pStack;
+  return GetStackPartInformation(item.GetPath())->m_pStack;
 }
 
 bool CApplicationStackHelper::HasRegisteredStack(const CFileItem& item) const
 {
-  const auto it = m_stackmap.find(item.GetDynPath());
+  const auto it = m_stackmap.find(item.GetPath());
   return it != m_stackmap.end() && it->second != nullptr;
 }
 
@@ -286,32 +270,60 @@ const CFileItem& CApplicationStackHelper::GetStackPartFileItem(int partNumber) c
 
 int CApplicationStackHelper::GetRegisteredStackPartNumber(const CFileItem& item)
 {
-  return GetStackPartInformation(item.GetDynPath())->m_lStackPartNumber;
+  return GetStackPartInformation(item.GetPath())->m_lStackPartNumber;
 }
 
 void CApplicationStackHelper::SetRegisteredStackPartNumber(const CFileItem& item, int partNumber)
 {
-  GetStackPartInformation(item.GetDynPath())->m_lStackPartNumber = partNumber;
+  GetStackPartInformation(item.GetPath())->m_lStackPartNumber = partNumber;
 }
 
 uint64_t CApplicationStackHelper::GetRegisteredStackPartStartTimeMs(const CFileItem& item) const
 {
-  return GetStackPartInformation(item.GetDynPath())->m_lStackPartStartTimeMs;
+  return GetStackPartInformation(item.GetPath())->m_lStackPartStartTimeMs;
 }
 
 void CApplicationStackHelper::SetRegisteredStackPartStartTimeMs(const CFileItem& item, uint64_t startTime)
 {
-  GetStackPartInformation(item.GetDynPath())->m_lStackPartStartTimeMs = startTime;
+  GetStackPartInformation(item.GetPath())->m_lStackPartStartTimeMs = startTime;
 }
 
 uint64_t CApplicationStackHelper::GetRegisteredStackTotalTimeMs(const CFileItem& item) const
 {
-  return GetStackPartInformation(item.GetDynPath())->m_lStackTotalTimeMs;
+  return GetStackPartInformation(item.GetPath())->m_lStackTotalTimeMs;
 }
 
 void CApplicationStackHelper::SetRegisteredStackTotalTimeMs(const CFileItem& item, uint64_t totalTime)
 {
-  GetStackPartInformation(item.GetDynPath())->m_lStackTotalTimeMs = totalTime;
+  GetStackPartInformation(item.GetPath())->m_lStackTotalTimeMs = totalTime;
+}
+
+void CApplicationStackHelper::SetRegisteredStackDynPaths(const std::string& newPath) const
+{
+  for (const auto& stackmapitem : m_stackmap)
+    stackmapitem.second->m_pStack->SetDynPath(newPath);
+}
+
+void CApplicationStackHelper::SetRegisteredStackPartDynPath(const CFileItem& item,
+                                                            const std::string& newPath)
+{
+  CFileItem& stackItem(GetStackPartFileItem(GetRegisteredStackPartNumber(item)));
+  stackItem.SetDynPath(newPath);
+}
+
+void CApplicationStackHelper::SetStackEndTimeMs(const uint64_t totalTimeMs)
+{
+  for (int i = 0; i < m_currentStack->Size(); i++)
+    SetRegisteredStackTotalTimeMs(GetStackPartFileItem(i), totalTimeMs);
+}
+
+void CApplicationStackHelper::SetStackPartOffsets(const CFileItem& item,
+                                                  const int64_t startOffset,
+                                                  const int64_t endOffset)
+{
+  CFileItem& stackItem(GetStackPartFileItem(GetRegisteredStackPartNumber(item)));
+  stackItem.SetStartOffset(startOffset);
+  stackItem.SetEndOffset(endOffset);
 }
 
 CApplicationStackHelper::StackPartInformationPtr CApplicationStackHelper::GetStackPartInformation(

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -166,6 +166,7 @@ public:
   virtual int Read(uint8_t* buf, int buf_size) = 0;
   virtual int64_t Seek(int64_t offset, int whence) = 0;
   virtual int64_t GetLength() = 0;
+  virtual int64_t GetDuration() = 0;
   virtual std::string& GetContent() { return m_content; }
   virtual std::string GetFileName();
   virtual CURL GetURL();

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -324,12 +324,7 @@ bool CDVDInputStreamBluray::Open()
 
   int mode = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_DISC_PLAYBACK);
 
-  if (URIUtils::HasExtension(filename, ".mpls"))
-  {
-    m_navmode = false;
-    m_titleInfo = GetTitleFile(filename);
-  }
-  else if (mode == BD_PLAYBACK_MAIN_TITLE)
+  if (mode == BD_PLAYBACK_MAIN_TITLE)
   {
     m_navmode = false;
     m_titleInfo = GetTitleLongest();
@@ -339,6 +334,11 @@ bool CDVDInputStreamBluray::Open()
     // resuming a bluray for which we have a saved state - the playlist will be open later on SetState
     m_navmode = false;
     return true;
+  }
+  else if (URIUtils::HasExtension(filename, ".mpls"))
+  {
+    m_navmode = false;
+    m_titleInfo = GetTitleFile(filename);
   }
   else
   {
@@ -1012,6 +1012,13 @@ int64_t CDVDInputStreamBluray::Seek(int64_t offset, int whence)
 int64_t CDVDInputStreamBluray::GetLength()
 {
   return static_cast<int64_t>(bd_get_title_size(m_bd));
+}
+
+int64_t CDVDInputStreamBluray::GetDuration()
+{
+  if (m_titleInfo)
+    return static_cast<int64_t>(m_titleInfo->duration / 90);
+  return 0;
 }
 
 static bool find_stream(int pid, BLURAY_STREAM_INFO *info, int count, std::string &language)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -61,6 +61,7 @@ public:
   void Abort() override;
   bool IsEOF() override;
   int64_t GetLength() override;
+  int64_t GetDuration() override;
   int GetBlockSize() override { return 6144; }
   ENextStream NextStream() override;
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.h
@@ -22,6 +22,7 @@ public:
   int64_t Seek(int64_t offset, int whence) override;
   bool IsEOF() override;
   int64_t GetLength() override;
+  int64_t GetDuration() override { return 0; }
   std::string GetFileName() override;
 
   void  Abort() override { m_aborted = true;  }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.h
@@ -21,6 +21,7 @@ public:
   int64_t Seek(int64_t offset, int whence) override;
   bool IsEOF() override;
   int64_t GetLength() override;
+  int64_t GetDuration() override { return 0; }
   BitstreamStats GetBitstreamStats() const override ;
   int GetBlockSize() override;
   void SetReadRate(uint32_t rate) override;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
@@ -56,6 +56,7 @@ public:
   int GetBlockSize() override { return DVDSTREAM_BLOCK_SIZE_DVD; }
   bool IsEOF() override { return m_bEOF; }
   int64_t GetLength() override { return 0; }
+  int64_t GetDuration() override { return 0; }
   ENextStream NextStream() override ;
 
   void ActivateButton() override;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamStack.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamStack.h
@@ -25,6 +25,7 @@ public:
   int64_t Seek(int64_t offset, int whence) override;
   bool IsEOF() override;
   int64_t GetLength() override;
+  int64_t GetDuration() override { return 0; }
 
 protected:
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
@@ -57,6 +57,7 @@ public:
   int Read(uint8_t* buf, int buf_size) override;
   int64_t Seek(int64_t offset, int whence) override;
   int64_t GetLength() override;
+  int64_t GetDuration() override { return 0; }
   int GetBlockSize() override;
   bool IsEOF() override;
   bool CanSeek() override; //! @todo drop this

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamMultiSource.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamMultiSource.h
@@ -29,6 +29,7 @@ public:
   int GetBlockSize() override;
   bool GetCacheStatus(XFILE::SCacheStatus *status) override;
   int64_t GetLength() override;
+  int64_t GetDuration() override { return 0; }
   bool IsEOF() override;
   CDVDInputStream::ENextStream NextStream() override;
   bool Open() override;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamPVRBase.h
@@ -38,6 +38,7 @@ public:
   int64_t Seek(int64_t offset, int whence) override;
   bool IsEOF() override;
   int64_t GetLength() override;
+  int64_t GetDuration() override { return 0; }
   int GetBlockSize() override;
 
   ENextStream NextStream() override;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -24,6 +24,7 @@
 #include "guilib/DispResource.h"
 #include "threads/SystemClock.h"
 #include "threads/Thread.h"
+#include "utils/StreamDetails.h"
 
 #include <atomic>
 #include <chrono>
@@ -475,7 +476,7 @@ protected:
   void UpdateContent();
   void UpdateContentState();
 
-  void UpdateFileItemStreamDetails(CFileItem& item);
+  void UpdateFileItemStreamDetails(CFileItem& item, const bool alwaysUpdate = false);
   int GetPreviousChapter();
 
   bool m_players_created;
@@ -490,6 +491,7 @@ protected:
   XbmcThreads::EndTime<> m_cachingTimer;
 
   std::unique_ptr<CProcessInfo> m_processInfo;
+  uint64_t m_longestTime{0};
 
   CCurrentStream m_CurrentAudio;
   CCurrentStream m_CurrentVideo;

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -60,7 +60,7 @@ bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item, bool forceSelectio
   if (forceSelection && VIDEO::IsBlurayPlaylist(item))
   {
     item.SetProperty("save_dyn_path", item.GetDynPath()); // save for screen refresh later
-    item.SetDynPath(item.GetBlurayPath());
+    item.SetDynPath(URIUtils::GetBlurayPath(item.GetDynPath()));
   }
 
   if (VIDEO::IsBDFile(item))

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -31,7 +31,6 @@
 
 #include <libbluray/bluray-version.h>
 #include <libbluray/bluray.h>
-#include <libbluray/filesystem.h>
 #include <libbluray/log_control.h>
 
 namespace XFILE

--- a/xbmc/filesystem/StackDirectory.h
+++ b/xbmc/filesystem/StackDirectory.h
@@ -23,11 +23,12 @@ namespace XFILE
     ~CStackDirectory() override;
     bool GetDirectory(const CURL& url, CFileItemList& items) override;
     bool AllowAll() const override { return true; }
-    static std::string GetStackedTitlePath(const std::string &strPath);
-    static std::string GetStackedTitlePath(const std::string &strPath, VECCREGEXP& RegExps);
+    static std::string GetStackedTitlePath(const std::string& strPath);
     static std::string GetFirstStackedFile(const std::string &strPath);
     static bool GetPaths(const std::string& strPath, std::vector<std::string>& vecPaths);
     static std::string ConstructStackPath(const CFileItemList& items, const std::vector<int> &stack);
     static bool ConstructStackPath(const std::vector<std::string> &paths, std::string &stackedPath);
+    static std::string GetParentPath(const std::string& path);
+    static void LoadRegExps(VECCREGEXP& fileRegExps, VECCREGEXP& folderRegExps);
   };
 }

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -269,7 +269,7 @@ void CPowerManager::StorePlayerState()
                                            stackHelper->GetCurrentStackPartStartTimeMs());
     // in case of iso stack, keep track of part number
     m_lastPlayedFileItem->m_lStartPartNumber =
-        stackHelper->IsPlayingISOStack() ? stackHelper->GetCurrentPartNumber() + 1 : 1;
+        stackHelper->IsPlayingDiscStack() ? stackHelper->GetCurrentPartNumber() + 1 : 1;
     // for iso and iso stacks, keep track of playerstate
     m_lastPlayedFileItem->SetProperty("savedplayerstate", appPlayer->GetPlayerState());
     CLog::Log(LOGDEBUG,

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -244,12 +244,15 @@ void CAdvancedSettings::Initialize()
                                         m_allExcludeFromScanRegExps.end());
 
   m_folderStackRegExps.clear();
-  m_folderStackRegExps.emplace_back("((cd|dvd|dis[ck])[0-9]+)$");
+  //m_folderStackRegExps.emplace_back("((cd|dvd|dis[ck])[0-9]+)$");
+  m_folderStackRegExps.emplace_back(
+      "(.*?)(?:[^\\/])((?:cd|dvd|p(?:(?:ar)?t)|dis[ck])[ _.-]*[0-9])$");
 
   m_videoStackRegExps.clear();
   m_videoStackRegExps.emplace_back("(.*?)([ _.-]*(?:cd|dvd|p(?:(?:ar)?t)|dis[ck])[ _.-]*[0-9]+)(.*?)(\\.[^.]+)$");
-  m_videoStackRegExps.emplace_back("(.*?)([ _.-]*(?:cd|dvd|p(?:(?:ar)?t)|dis[ck])[ _.-]*[a-d])(.*?)(\\.[^.]+)$");
-  m_videoStackRegExps.emplace_back("(.*?)([ ._-]*[a-d])(.*?)(\\.[^.]+)$");
+  m_videoStackRegExps.emplace_back(
+      "(.*?)([ _.-]*(?:cd|dvd|p(?:(?:ar)?t)|dis[ck])[ _.-]*[a-z])(.*?)(\\.[^.]+)$");
+  m_videoStackRegExps.emplace_back("^(.+)((?:[ ._-]|(?<=\\)))[a-z])()(\\.[^.]+)$");
   // This one is a bit too greedy to enable by default.  It will stack sequels
   // in a flat dir structure, but is perfectly safe in a dir-per-vid one.
   //m_videoStackRegExps.push_back("(.*?)([ ._-]*[0-9])(.*?)(\\.[^.]+)$");
@@ -430,6 +433,7 @@ void CAdvancedSettings::Initialize()
   m_subtitlesExtensions = ".utf|.utf8|.utf-8|.sub|.srt|.smi|.rt|.txt|.ssa|.text|.ssa|.aqt|.jss|"
                           ".ass|.vtt|.idx|.ifo|.zip|.sup";
   m_discStubExtensions = ".disc";
+  m_discImageExtensions = ".img|.iso|.nrg|.udf";
   // internal music extensions
   m_musicExtensions += "|.cdda";
   // internal video extensions

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -362,6 +362,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     // runtime settings which cannot be set from advancedsettings.xml
     std::string m_videoExtensions;
     std::string m_discStubExtensions;
+    std::string m_discImageExtensions;
     std::string m_subtitlesExtensions;
     std::string m_musicExtensions;
     std::string m_pictureExtensions;

--- a/xbmc/test/TestFileItem.cpp
+++ b/xbmc/test/TestFileItem.cpp
@@ -57,23 +57,29 @@ TEST_P(TestFileItemSpecifiedArtJpg, GetLocalArt)
   EXPECT_EQ(compare, path);
 }
 
-const TestFileData MovieFiles[] = {{ "c:\\dir\\filename.avi", false, "c:\\dir\\filename-art.jpg" },
-                                   { "c:\\dir\\filename.avi", true,  "c:\\dir\\art.jpg" },
-                                   { "/dir/filename.avi", false, "/dir/filename-art.jpg" },
-                                   { "/dir/filename.avi", true,  "/dir/art.jpg" },
-                                   { "smb://somepath/file.avi", false, "smb://somepath/file-art.jpg" },
-                                   { "smb://somepath/file.avi", true, "smb://somepath/art.jpg" },
-                                   { "stack:///path/to/movie-cd1.avi , /path/to/movie-cd2.avi", false,  "/path/to/movie-art.jpg" },
-                                   { "stack:///path/to/movie-cd1.avi , /path/to/movie-cd2.avi", true,  "/path/to/art.jpg" },
-                                   { "stack:///path/to/movie_name/cd1/some_file1.avi , /path/to/movie_name/cd2/some_file2.avi", true,  "/path/to/movie_name/art.jpg" },
-                                   { "/home/user/TV Shows/Dexter/S1/1x01.avi", false, "/home/user/TV Shows/Dexter/S1/1x01-art.jpg" },
-                                   { "/home/user/TV Shows/Dexter/S1/1x01.avi", true, "/home/user/TV Shows/Dexter/S1/art.jpg" },
-                                   { "zip://g%3a%5cmultimedia%5cmovies%5cSphere%2ezip/Sphere.avi", false, "g:\\multimedia\\movies\\Sphere-art.jpg" },
-                                   { "zip://g%3a%5cmultimedia%5cmovies%5cSphere%2ezip/Sphere.avi", true, "g:\\multimedia\\movies\\art.jpg" },
-                                   { "/home/user/movies/movie_name/video_ts/VIDEO_TS.IFO", false, "/home/user/movies/movie_name/art.jpg" },
-                                   { "/home/user/movies/movie_name/video_ts/VIDEO_TS.IFO", true, "/home/user/movies/movie_name/art.jpg" },
-                                   { "/home/user/movies/movie_name/BDMV/index.bdmv", false, "/home/user/movies/movie_name/art.jpg" },
-                                   { "/home/user/movies/movie_name/BDMV/index.bdmv", true, "/home/user/movies/movie_name/art.jpg" }};
+const TestFileData MovieFiles[] = {
+    {"c:\\dir\\filename.avi", false, "c:\\dir\\filename-art.jpg"},
+    {"c:\\dir\\filename.avi", true, "c:\\dir\\art.jpg"},
+    {"/dir/filename.avi", false, "/dir/filename-art.jpg"},
+    {"/dir/filename.avi", true, "/dir/art.jpg"},
+    {"smb://somepath/file.avi", false, "smb://somepath/file-art.jpg"},
+    {"smb://somepath/file.avi", true, "smb://somepath/art.jpg"},
+    {"stack:///path/to/movie-cd1.avi , /path/to/movie-cd2.avi", false, "/path/to/movie-art.jpg"},
+    {"stack:///path/to/movie-cd1.avi , /path/to/movie-cd2.avi", true, "/path/to/art.jpg"},
+    {"stack:///path/to/movie_name cd1/some_file1.avi , /path/to/movie_name cd2/some_file2.avi",
+     true, "/path/to/movie_name/art.jpg"},
+    {"/home/user/TV Shows/Dexter/S1/1x01.avi", false, "/home/user/TV Shows/Dexter/S1/1x01-art.jpg"},
+    {"/home/user/TV Shows/Dexter/S1/1x01.avi", true, "/home/user/TV Shows/Dexter/S1/art.jpg"},
+    {"zip://g%3a%5cmultimedia%5cmovies%5cSphere%2ezip/Sphere.avi", false,
+     "g:\\multimedia\\movies\\Sphere-art.jpg"},
+    {"zip://g%3a%5cmultimedia%5cmovies%5cSphere%2ezip/Sphere.avi", true,
+     "g:\\multimedia\\movies\\art.jpg"},
+    {"/home/user/movies/movie_name/video_ts/VIDEO_TS.IFO", false,
+     "/home/user/movies/movie_name/art.jpg"},
+    {"/home/user/movies/movie_name/video_ts/VIDEO_TS.IFO", true,
+     "/home/user/movies/movie_name/art.jpg"},
+    {"/home/user/movies/movie_name/BDMV/index.bdmv", false, "/home/user/movies/movie_name/art.jpg"},
+    {"/home/user/movies/movie_name/BDMV/index.bdmv", true, "/home/user/movies/movie_name/art.jpg"}};
 
 INSTANTIATE_TEST_SUITE_P(MovieFiles, TestFileItemSpecifiedArtJpg, ValuesIn(MovieFiles));
 

--- a/xbmc/utils/FileExtensionProvider.cpp
+++ b/xbmc/utils/FileExtensionProvider.cpp
@@ -51,6 +51,11 @@ std::string CFileExtensionProvider::GetDiscStubExtensions() const
   return m_advancedSettings->m_discStubExtensions;
 }
 
+std::string CFileExtensionProvider::GetDiscImageExtensions() const
+{
+  return m_advancedSettings->m_discImageExtensions;
+}
+
 std::string CFileExtensionProvider::GetMusicExtensions() const
 {
   std::string extensions(m_advancedSettings->m_musicExtensions);

--- a/xbmc/utils/FileExtensionProvider.h
+++ b/xbmc/utils/FileExtensionProvider.h
@@ -54,6 +54,11 @@ public:
   std::string GetDiscStubExtensions() const;
 
   /*!
+   * @brief Returns a list of disc image extensions
+   */
+  std::string GetDiscImageExtensions() const;
+
+  /*!
    * @brief Returns a file folder extensions
    */
   std::string GetFileFolderExtensions() const;

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -9,7 +9,6 @@
 #include "URIUtils.h"
 
 #include "FileItem.h"
-#include "FileItemList.h"
 #include "ServiceBroker.h"
 #include "StringUtils.h"
 #include "URL.h"
@@ -325,32 +324,14 @@ bool URIUtils::GetParentPath(const std::string& strPath, std::string& strParent)
 
   CURL url(strPath);
   std::string strFile = url.GetFileName();
-  if ( URIUtils::HasParentInHostname(url) && strFile.empty())
+  if (HasParentInHostname(url) && strFile.empty())
   {
     strFile = url.GetHostName();
     return GetParentPath(strFile, strParent);
   }
   else if (url.IsProtocol("stack"))
   {
-    CStackDirectory dir;
-    CFileItemList items;
-    if (!dir.GetDirectory(url, items))
-      return false;
-    CURL url2(GetDirectory(items[0]->GetPath()));
-    if (HasParentInHostname(url2))
-      GetParentPath(url2.Get(), strParent);
-    else
-      strParent = url2.Get();
-    for( int i=1;i<items.Size();++i)
-    {
-      items[i]->m_strDVDLabel = GetDirectory(items[i]->GetPath());
-      if (HasParentInHostname(url2))
-        items[i]->SetPath(GetParentPath(items[i]->m_strDVDLabel));
-      else
-        items[i]->SetPath(items[i]->m_strDVDLabel);
-
-      GetCommonPath(strParent,items[i]->GetPath());
-    }
+    strParent = CStackDirectory::GetParentPath(url.Get());
     return true;
   }
   else if (url.IsProtocol("multipath"))
@@ -453,6 +434,57 @@ std::string URIUtils::GetBasePath(const std::string& strPath)
       strDirectory = GetDirectory(strCheck);
   }
   return strDirectory;
+}
+
+std::string URIUtils::GetBaseMoviePath(const std::string& path)
+{
+  std::string root{path};
+
+  // Deal with dvd:// or bluray:// and any embedded udf://
+  CURL url{root};
+  while (HasParentInHostname(url))
+  {
+    root = url.GetHostName();
+    url.Parse(root);
+  }
+
+  // Deal with any BD/DVD directories
+  if (IsBDFile(root))
+  {
+    root = GetParentPath(root);
+    RemoveSlashAtEnd(root);
+    if (GetFileName(root) == "BDMV")
+      root = GetParentPath(root);
+  }
+  else if (IsDVDFile(root))
+  {
+    root = GetParentPath(root);
+    RemoveSlashAtEnd(root);
+    if (GetFileName(root) == "VIDEO_TS")
+      root = GetParentPath(root);
+  }
+
+  // If simply file then get path
+  if (!GetFileName(root).empty())
+    root = GetDirectory(root);
+
+  return root;
+}
+
+std::string URIUtils::GetBlurayPath(const std::string& path)
+{
+  if (IsBlurayPlaylist(path))
+  {
+    CURL url(path);
+    CURL url2(url.GetHostName()); // strip bluray://
+    if (url2.IsProtocol("udf"))
+      // ISO
+      return url2.GetHostName(); // strip udf://
+    if (url.IsProtocol("bluray"))
+      // BDMV
+      return url2.Get() + "BDMV/index.bdmv";
+  }
+  return path;
 }
 
 std::string URLEncodePath(const std::string& strPath)
@@ -779,6 +811,22 @@ bool URIUtils::IsDVD(const std::string& strFile)
   return false;
 }
 
+bool URIUtils::IsDVDFile(const std::string& file)
+{
+  return StringUtils::EndsWith(StringUtils::ToLower(file), "video_ts.ifo");
+}
+
+bool URIUtils::IsBDFile(const std::string& file)
+{
+  return StringUtils::EndsWith(StringUtils::ToLower(file), "index.bdmv");
+}
+
+bool URIUtils::IsBlurayPlaylist(const std::string& file)
+{
+  return IsProtocol(file, "bluray") &&
+         StringUtils::EqualsNoCase(GetExtension(StringUtils::ToLower(file)), ".mpls");
+}
+
 bool URIUtils::IsStack(const std::string& strFile)
 {
   return IsProtocol(strFile, "stack");
@@ -866,9 +914,19 @@ bool URIUtils::IsDiscImage(const std::string& file)
   return HasExtension(file, ".img|.iso|.nrg|.udf");
 }
 
+// Consider a disc image stack if ANY of the items is a disc image
+
 bool URIUtils::IsDiscImageStack(const std::string& file)
 {
-  return IsStack(file) && IsDiscImage(CStackDirectory::GetFirstStackedFile(file));
+  if (IsStack(file))
+  {
+    std::vector<std::string> paths;
+    CStackDirectory::GetPaths(file, paths);
+    for (const std::string& path : paths)
+      if (IsDiscImage(path) || IsDVDFile(path) || IsBDFile(path))
+        return true;
+  }
+  return false;
 }
 
 bool URIUtils::IsSpecial(const std::string& strFile)

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -87,6 +87,9 @@ public:
    */
   static std::string GetBasePath(const std::string& strPath);
 
+  static std::string GetBaseMoviePath(const std::string& path);
+  static std::string GetBlurayPath(const std::string& path);
+
   /* \brief Change the base path of a URL: fromPath/fromFile -> toPath/toFile
     Handles changes in path separator and filename URL encoding if necessary to derive toFile.
     \param fromPath the base path of the original URL
@@ -135,6 +138,9 @@ public:
   static bool IsDAV(const std::string& strFile);
   static bool IsDOSPath(const std::string &path);
   static bool IsDVD(const std::string& strFile);
+  static bool IsDVDFile(const std::string& file);
+  static bool IsBDFile(const std::string& file);
+  static bool IsBlurayPlaylist(const std::string& file);
   static bool IsFTP(const std::string& strFile);
   static bool IsHTTP(const std::string& strFile, bool bTranslate = false);
   static bool IsUDP(const std::string& strFile);
@@ -178,6 +184,7 @@ public:
   static bool IsArchive(const std::string& strFile);
   static bool IsDiscImage(const std::string& file);
   static bool IsDiscImageStack(const std::string& file);
+  static bool IsDiscStack(const std::string& file);
   static bool IsBluray(const std::string& strFile);
   static bool IsAndroidApp(const std::string& strFile);
   static bool IsLibraryFolder(const std::string& strFile);

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1319,6 +1319,31 @@ int CVideoDatabase::GetMovieId(const std::string& strFilenameAndPath)
   return -1;
 }
 
+int CVideoDatabase::GetMovieId(const int fileId) const
+{
+  try
+  {
+    if (nullptr == m_pDB)
+      return -1;
+    if (nullptr == m_pDS)
+      return -1;
+    if (fileId == -1)
+      return -1;
+
+    const std::string strSQL = PrepareSQL("SELECT idMovie FROM movie WHERE idFile=%i", fileId);
+    m_pDS->query(strSQL);
+
+    if (m_pDS->num_rows() > 0)
+      return m_pDS->fv(0).get_asInt();
+    return -1;
+  }
+  catch (...)
+  {
+    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, fileId);
+  }
+  return -1;
+}
+
 int CVideoDatabase::GetTvShowId(const std::string& strPath)
 {
   try
@@ -1995,8 +2020,15 @@ bool CVideoDatabase::HasMovieInfo(const std::string& strFilenameAndPath)
       return false;
     if (nullptr == m_pDS)
       return false;
+
     int idMovie = GetMovieId(strFilenameAndPath);
-    return (idMovie > 0); // index of zero is also invalid
+    if (idMovie > 0) // index of zero is also invalid
+      return true;
+
+    // Check to see if filename has been updated with bluray:// or dvd://
+    const int idFile = GetFileId(strFilenameAndPath);
+    idMovie = GetMovieId(idFile);
+    return (idMovie > 0);
   }
   catch (...)
   {
@@ -3024,14 +3056,21 @@ int CVideoDatabase::SetDetailsForSeason(const CVideoInfoTag& details, const std:
   return -1;
 }
 
-bool CVideoDatabase::SetFileForEpisode(const std::string& fileAndPath, int idEpisode, int idFile)
+bool CVideoDatabase::SetFileForEpisode(const std::string& fileAndPath,
+                                       const int idEpisode,
+                                       const int oldIdFile)
 {
+  const int idFile = AddFile(fileAndPath);
+  if (idFile < 0)
+    return false;
+
   try
   {
     BeginTransaction();
-    std::string sql = PrepareSQL("UPDATE episode SET c18='%s', idFile=%i WHERE idEpisode=%i",
-                                 fileAndPath.c_str(), idFile, idEpisode);
+    std::string sql =
+        PrepareSQL("UPDATE episode SET idFile=%i WHERE idEpisode=%i", idFile, idEpisode);
     m_pDS->exec(sql);
+    DeleteFile(oldIdFile);
     CommitTransaction();
 
     return true;
@@ -3044,27 +3083,79 @@ bool CVideoDatabase::SetFileForEpisode(const std::string& fileAndPath, int idEpi
   return false;
 }
 
-bool CVideoDatabase::SetFileForMovie(const std::string& fileAndPath, int idMovie, int idFile)
+bool CVideoDatabase::SetFileForMovie(const std::string& fileAndPath, const int oldIdFile)
 {
+  const int idFile = AddFile(fileAndPath);
+  if (idFile < 0)
+    return false;
+
   try
   {
     BeginTransaction();
-    std::string sql = PrepareSQL("UPDATE movie SET c22='%s', idFile=%i WHERE idMovie=%i",
-                                 fileAndPath.c_str(), idFile, idMovie);
+    std::string sql = PrepareSQL("UPDATE movie SET idFile=%i WHERE idFile=%i", idFile, oldIdFile);
     m_pDS->exec(sql);
-    sql = PrepareSQL("UPDATE videoversion SET idFile=%i WHERE idMedia=%i AND media_type='movie'",
-                     idFile, idMovie);
+
+    sql = PrepareSQL("UPDATE videoversion SET idFile=%i WHERE idFile=%i AND media_type='movie'",
+                     idFile, oldIdFile);
     m_pDS->exec(sql);
+
+    sql = PrepareSQL("UPDATE art SET media_id=%i WHERE media_id=%i AND media_type='videoversion'",
+                     idFile, oldIdFile);
+    m_pDS->exec(sql);
+    DeleteFile(oldIdFile);
     CommitTransaction();
 
     return true;
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, idMovie);
+    CLog::Log(LOGERROR, "{} ({}) failed", __FUNCTION__, idFile);
   }
   RollbackTransaction();
   return false;
+}
+
+void CVideoDatabase::DeleteFile(int idFile)
+{
+  // First check not multiple references to file (eg. episodes)
+  std::string sql{PrepareSQL("SELECT idFile FROM movie WHERE idFile = %i UNION SELECT idFile FROM "
+                             "episode WHERE idFile = %i",
+                             idFile, idFile)};
+  m_pDS->query(sql);
+  if (m_pDS->eof())
+  {
+    // Get idPath
+    sql = PrepareSQL(
+        "SELECT path.idPath FROM path JOIN files ON path.idPath = files.idPath WHERE idFile = %i",
+        idFile);
+    m_pDS->query(sql);
+    int path{-1};
+    if (!m_pDS->eof())
+    {
+      path = m_pDS->fv("idPath").get_asInt();
+    }
+
+    // Remove file and any associated bookmarks and streamdetails
+    sql = PrepareSQL("DELETE FROM files WHERE idFile = %i", idFile);
+    m_pDS->exec(sql);
+    sql = PrepareSQL("DELETE FROM bookmark WHERE idFile = %i", idFile);
+    m_pDS->exec(sql);
+    DeleteStreamDetails(idFile);
+
+    // Delete path if orphan
+    if (path >= 0)
+    {
+      sql = PrepareSQL("SELECT idFile FROM files JOIN path ON files.idPath = path.idPath WHERE "
+                       "files.idPath = %i",
+                       path);
+      m_pDS->query(sql);
+      if (m_pDS->eof())
+      {
+        sql = PrepareSQL("DELETE FROM path WHERE idPath = %i", path);
+        m_pDS->exec(sql);
+      }
+    }
+  }
 }
 
 int CVideoDatabase::SetDetailsForEpisode(CVideoInfoTag& details,
@@ -3256,15 +3347,14 @@ int CVideoDatabase::SetDetailsForMusicVideo(CVideoInfoTag& details,
   return -1;
 }
 
-int CVideoDatabase::SetStreamDetailsForFile(const CStreamDetails& details,
-                                            const std::string& strFileNameAndPath)
+void CVideoDatabase::SetStreamDetailsForFile(const CStreamDetails& details,
+                                             const std::string& strFileNameAndPath)
 {
   // AddFile checks to make sure the file isn't already in the DB first
   int idFile = AddFile(strFileNameAndPath);
   if (idFile < 0)
-    return -1;
+    return;
   SetStreamDetailsForFileId(details, idFile);
-  return idFile;
 }
 
 void CVideoDatabase::SetStreamDetailsForFileId(const CStreamDetails& details, int idFile)
@@ -3375,54 +3465,47 @@ void CVideoDatabase::GetBookMarksForFile(const std::string& strFilenameAndPath, 
 {
   try
   {
-    if (URIUtils::IsDiscImageStack(strFilenameAndPath))
-    {
-      CStackDirectory dir;
-      CFileItemList fileList;
-      const CURL pathToUrl(strFilenameAndPath);
-      dir.GetDirectory(pathToUrl, fileList);
-      if (!bAppend)
-        bookmarks.clear();
-      for (int i = fileList.Size() - 1; i >= 0; i--) // put the bookmarks of the highest part first in the list
-        GetBookMarksForFile(fileList[i]->GetPath(), bookmarks, type, true, (i+1));
-    }
-    else
-    {
-      int idFile = GetFileId(strFilenameAndPath);
-      if (idFile < 0) return ;
-      if (!bAppend)
-        bookmarks.erase(bookmarks.begin(), bookmarks.end());
-      if (nullptr == m_pDB)
-        return;
-      if (nullptr == m_pDS)
-        return;
+    int idFile = GetFileId(strFilenameAndPath);
+    if (idFile < 0)
+      return;
+    if (!bAppend)
+      bookmarks.erase(bookmarks.begin(), bookmarks.end());
+    if (nullptr == m_pDB)
+      return;
+    if (nullptr == m_pDS)
+      return;
 
-      std::string strSQL=PrepareSQL("select * from bookmark where idFile=%i and type=%i order by timeInSeconds", idFile, (int)type);
-      m_pDS->query( strSQL );
-      while (!m_pDS->eof())
+    std::string strSQL =
+        PrepareSQL("select * from bookmark where idFile=%i and type=%i order by timeInSeconds",
+                   idFile, (int)type);
+    m_pDS->query(strSQL);
+    while (!m_pDS->eof())
+    {
+      CBookmark bookmark;
+      bookmark.timeInSeconds = m_pDS->fv("timeInSeconds").get_asDouble();
+      bookmark.partNumber = partNumber;
+      bookmark.totalTimeInSeconds = m_pDS->fv("totalTimeInSeconds").get_asDouble();
+      bookmark.thumbNailImage = m_pDS->fv("thumbNailImage").get_asString();
+      bookmark.playerState = m_pDS->fv("playerState").get_asString();
+      bookmark.player = m_pDS->fv("player").get_asString();
+      bookmark.type = type;
+      if (type == CBookmark::EPISODE)
       {
-        CBookmark bookmark;
-        bookmark.timeInSeconds = m_pDS->fv("timeInSeconds").get_asDouble();
-        bookmark.partNumber = partNumber;
-        bookmark.totalTimeInSeconds = m_pDS->fv("totalTimeInSeconds").get_asDouble();
-        bookmark.thumbNailImage = m_pDS->fv("thumbNailImage").get_asString();
-        bookmark.playerState = m_pDS->fv("playerState").get_asString();
-        bookmark.player = m_pDS->fv("player").get_asString();
-        bookmark.type = type;
-        if (type == CBookmark::EPISODE)
-        {
-          std::string strSQL2=PrepareSQL("select c%02d, c%02d from episode where c%02d=%i order by c%02d, c%02d", VIDEODB_ID_EPISODE_EPISODE, VIDEODB_ID_EPISODE_SEASON, VIDEODB_ID_EPISODE_BOOKMARK, m_pDS->fv("idBookmark").get_asInt(), VIDEODB_ID_EPISODE_SORTSEASON, VIDEODB_ID_EPISODE_SORTEPISODE);
-          m_pDS2->query(strSQL2);
-          bookmark.episodeNumber = m_pDS2->fv(0).get_asInt();
-          bookmark.seasonNumber = m_pDS2->fv(1).get_asInt();
-          m_pDS2->close();
-        }
-        bookmarks.push_back(bookmark);
-        m_pDS->next();
+        std::string strSQL2 =
+            PrepareSQL("select c%02d, c%02d from episode where c%02d=%i order by c%02d, c%02d",
+                       VIDEODB_ID_EPISODE_EPISODE, VIDEODB_ID_EPISODE_SEASON,
+                       VIDEODB_ID_EPISODE_BOOKMARK, m_pDS->fv("idBookmark").get_asInt(),
+                       VIDEODB_ID_EPISODE_SORTSEASON, VIDEODB_ID_EPISODE_SORTEPISODE);
+        m_pDS2->query(strSQL2);
+        bookmark.episodeNumber = m_pDS2->fv(0).get_asInt();
+        bookmark.seasonNumber = m_pDS2->fv(1).get_asInt();
+        m_pDS2->close();
       }
-      //sort(bookmarks.begin(), bookmarks.end(), SortBookmarks);
-      m_pDS->close();
+      bookmarks.push_back(bookmark);
+      m_pDS->next();
     }
+    //sort(bookmarks.begin(), bookmarks.end(), SortBookmarks);
+    m_pDS->close();
   }
   catch (...)
   {
@@ -4028,7 +4111,7 @@ std::string CVideoDatabase::GetFileBasePathById(int idFile)
   return "";
 }
 
-int CVideoDatabase::GetFileIdByMovie(int idMovie)
+int CVideoDatabase::GetFileIdByMovie(int idMovie) const
 {
   if (!m_pDB || !m_pDS)
     return -1;
@@ -4049,6 +4132,32 @@ int CVideoDatabase::GetFileIdByMovie(int idMovie)
   catch (...)
   {
     CLog::Log(LOGERROR, "{} failed for movie {}", __FUNCTION__, idMovie);
+  }
+
+  return idFile;
+}
+
+int CVideoDatabase::GetFileIdByEpisode(int idEpisode) const
+{
+  if (!m_pDB || !m_pDS)
+    return -1;
+
+  int idFile = -1;
+
+  try
+  {
+    m_pDS->query(PrepareSQL("SELECT idFile FROM episode WHERE idEpisode = %i", idEpisode));
+
+    if (!m_pDS->eof())
+    {
+      idFile = m_pDS->fv("idFile").get_asInt();
+    }
+
+    m_pDS->close();
+  }
+  catch (...)
+  {
+    CLog::Log(LOGERROR, "{} failed for episode {}", __FUNCTION__, idEpisode);
   }
 
   return idFile;
@@ -6679,7 +6788,9 @@ void CVideoDatabase::UpdateFanart(const CFileItem& item, VideoDbContentType type
 CDateTime CVideoDatabase::SetPlayCount(const CFileItem& item, int count, const CDateTime& date)
 {
   int id{-1};
-  if (IsBlurayPlaylist(item))
+  if (item.HasProperty("new_stack_path"))
+    id = AddFile(item.GetProperty("new_stack_path").asString());
+  else if (IsBlurayPlaylist(item))
     id = AddFile(item.GetDynPath());
   else if (item.HasProperty("original_listitem_url") &&
            URIUtils::IsPlugin(item.GetProperty("original_listitem_url").asString()))
@@ -10084,6 +10195,10 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle,
         if (URIUtils::IsInArchive(fullPath))
           fullPath = CURL(fullPath).GetHostName();
 
+        // if bluray:// get actual path
+        if (URIUtils::IsProtocol(fullPath, "bluray"))
+          fullPath = URIUtils::GetBlurayPath(fullPath);
+
         bool del = true;
         if (URIUtils::IsPlugin(fullPath))
         {
@@ -11401,10 +11516,12 @@ bool CVideoDatabase::ImportArtFromXML(const TiXmlNode *node, std::map<std::strin
   return !artwork.empty();
 }
 
-void CVideoDatabase::ConstructPath(std::string& strDest, const std::string& strPath, const std::string& strFileName)
+void CVideoDatabase::ConstructPath(std::string& strDest,
+                                   const std::string& strPath,
+                                   const std::string& strFileName)
 {
-  if (URIUtils::IsStack(strFileName) ||
-      URIUtils::IsInArchive(strFileName) || URIUtils::IsPlugin(strPath))
+  if (URIUtils::IsStack(strFileName) || URIUtils::IsInArchive(strFileName) ||
+      URIUtils::IsPlugin(strPath) || URIUtils::IsProtocol(strFileName, "bluray"))
     strDest = strFileName;
   else
     strDest = URIUtils::AddFileToFolder(strPath, strFileName);
@@ -11416,6 +11533,19 @@ void CVideoDatabase::SplitPath(const std::string& strFileNameAndPath, std::strin
   {
     URIUtils::GetParentPath(strFileNameAndPath,strPath);
     strFileName = strFileNameAndPath;
+  }
+  else if (URIUtils::IsProtocol(strFileNameAndPath, "bluray"))
+  {
+    CURL url(strFileNameAndPath);
+    std::string root = url.GetHostName();
+    if (URIUtils::IsProtocol(root, "udf"))
+    {
+      CURL url(root);
+      root = url.GetHostName();
+    }
+    strFileName = strFileNameAndPath;
+    std::string temp;
+    URIUtils::Split(root, strPath, temp);
   }
   else if (URIUtils::IsPlugin(strFileNameAndPath))
   {

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -585,12 +585,13 @@ public:
                            const std::map<std::string, std::string>& artwork,
                            int idShow,
                            int idEpisode = -1);
-  bool SetFileForEpisode(const std::string& fileAndPath, int idEpisode, int idFile);
-  bool SetFileForMovie(const std::string& fileAndPath, int idMovie, int idFile);
+  bool SetFileForEpisode(const std::string& fileAndPath, const int idEpisode, const int oldIdFile);
+  bool SetFileForMovie(const std::string& fileAndPath, const int oldIdFile);
   int SetDetailsForMusicVideo(CVideoInfoTag& details,
                               const std::map<std::string, std::string>& artwork,
                               int idMVideo = -1);
-  int SetStreamDetailsForFile(const CStreamDetails& details, const std::string& strFileNameAndPath);
+  void SetStreamDetailsForFile(const CStreamDetails& details,
+                               const std::string& strFileNameAndPath);
   void SetStreamDetailsForFileId(const CStreamDetails& details, int idFile);
 
   bool SetSingleValue(VideoDbContentType type, int dbId, int dbField, const std::string& strValue);
@@ -603,6 +604,7 @@ public:
 
   int UpdateDetailsForMovie(int idMovie, CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, const std::set<std::string> &updatedDetails);
 
+  void DeleteFile(int idFile);
   void DeleteMovie(int idMovie,
                    bool bKeepId = false,
                    DeleteMovieCascadeAction action = DeleteMovieCascadeAction::ALL_ASSETS);
@@ -1097,9 +1099,11 @@ public:
   bool UpdateAssetsOwner(const std::string& mediaType, int dbIdSource, int dbIdTarget);
 
   int GetMovieId(const std::string& strFilenameAndPath);
+  int GetMovieId(const int fileId) const;
   std::string GetMovieTitle(int idMovie);
   void GetSameVideoItems(const CFileItem& item, CFileItemList& items);
-  int GetFileIdByMovie(int idMovie);
+  int GetFileIdByMovie(int idMovie) const;
+  int GetFileIdByEpisode(int idEpisode) const;
   std::string GetFileBasePathById(int idFile);
 
 protected:

--- a/xbmc/video/VideoFileItemClassify.cpp
+++ b/xbmc/video/VideoFileItemClassify.cpp
@@ -66,6 +66,19 @@ bool IsDVDFile(const CFileItem& item, bool bVobs /*= true*/, bool bIfos /*= true
   return false;
 }
 
+bool IsDVDImageFile(const CFileItem& item)
+{
+  if (URIUtils::IsDiscImage(item.GetDynPath()))
+  {
+    CURL url;
+    url.SetProtocol("udf");
+    url.SetHostName(item.GetPath());
+    url.SetFileName("VIDEO_TS/VIDEO_TS.IFO");
+    return CFileUtils::Exists(url.Get());
+  }
+  return false;
+}
+
 bool IsProtectedBlurayDisc(const CFileItem& item)
 {
   const std::string path = URIUtils::AddFileToFolder(item.GetPath(), "AACS", "Unit_Key_RO.inf");

--- a/xbmc/video/VideoFileItemClassify.h
+++ b/xbmc/video/VideoFileItemClassify.h
@@ -22,6 +22,9 @@ bool IsDiscStub(const CFileItem& item);
 //! \brief Check whether an item is a DVD file.
 bool IsDVDFile(const CFileItem& item, bool bVobs = true, bool bIfos = true);
 
+//! \brief Check whether an item is a DVD image file.
+bool IsDVDImageFile(const CFileItem& item);
+
 //! \brief Checks whether item points to a protected blu-ray disc.
 bool IsProtectedBlurayDisc(const CFileItem& item);
 

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1483,7 +1483,8 @@ namespace KODI::VIDEO
 
     CVideoInfoTag &movieDetails = *pItem->GetVideoInfoTag();
     if (movieDetails.m_basePath.empty())
-      movieDetails.m_basePath = pItem->GetBaseMoviePath(videoFolder);
+      movieDetails.m_basePath =
+          pItem->GetBaseMoviePath(videoFolder || URIUtils::IsStack(pItem->GetDynPath()));
     movieDetails.m_parentPathID = m_database.AddPath(URIUtils::GetParentPath(movieDetails.m_basePath));
 
     movieDetails.m_strFileNameAndPath = pItem->GetPath();


### PR DESCRIPTION
## Description

Folder stacks are useful for those who have ISOs or DVD/Bluray folders.
They are currently broken.

There were several issues:
- the code to generate folder stacks (`stack://`) was incomplete.
- folder stacks were then not recognised at various points in the play pathway (initially, transitioning from one item to another etc..)
- playing a stack from the main menu (not movie menu) was also broken (fixed in #24820)
- correct length of combined folder stack and streamdetails not saved correctly and not shown in bottom right
- routine to determine potential NFO/art path was broken

Also fixes:
- if you stop a DVD/Bluray on a menu after watching the film the menu length and not the film length is recoded (and shown in bottom right).
- one of the regexs for file stacks was to relaxed (see discussion in comments)

There a few differences now between file and folder stacks.
- For DVDs - each item is played in isolation, sequentially - you cannot move back and forth like you can with a file stack.
- For Blurays, now #24720 is in, bluray stacks will be built dynamically the first time they are played - and you will be able to move backwards. Once every item is played (and converted to bluray://) then a stack will behave exactly like a file stack.

## Motivation and context

Fixes #16109.

## How has this been tested?

Only locally currently.
With DVD/ISO/Bluray folders.
Also checked file stacks and individual DVD/Bluray/ISOs still play.

## What is the effect on users?

As above.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
