### PR TITLE
[guilib] Decouple left/right text truncate from alignment

### DIFF
--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -85,7 +85,6 @@ void CGUIEditControl::DefaultConstructor()
   m_smsLastKey = 0;
   m_smsKeyIndex = 0;
   m_label2.GetLabelInfo().offsetX = 0;
-  m_label2.SetReversedTruncate(true); // Truncate the text by default on the left
   m_isMD5 = false;
   m_invalidInput = false;
   m_inputValidator = NULL;
@@ -538,7 +537,7 @@ void CGUIEditControl::ProcessText(unsigned int currentTime)
     if (HasFocus() || leftTextWidth == 0)
       changed |= m_label2.SetOverflow(CGUILabel::OVER_FLOW_CLIP);
     else
-      changed |= m_label2.SetOverflow(CGUILabel::OVER_FLOW_TRUNCATE);
+      changed |= m_label2.SetOverflow(CGUILabel::OVER_FLOW_TRUNCATE_LEFT);
 
     changed |= m_label2.Process(currentTime);
     CServiceBroker::GetWinSystem()->GetGfxContext().RestoreClipRegion();

--- a/xbmc/guilib/GUIFadeLabelControl.cpp
+++ b/xbmc/guilib/GUIFadeLabelControl.cpp
@@ -184,8 +184,7 @@ void CGUIFadeLabelControl::Render()
     float posX = m_posX + m_label.offsetX;
     if (m_label.align & XBFONT_CENTER_X)
       posX = m_posX + m_width * 0.5f;
-    else if (m_label.align & XBFONT_RIGHT)
-      posX = m_posX + m_width - m_textLayout.GetTextWidth();
+
     m_textLayout.Render(posX, posY, m_label.angle, m_label.textColor, m_label.shadowColor, m_label.align, m_width - m_label.offsetX);
     CGUIControl::Render();
     return;
@@ -198,8 +197,7 @@ void CGUIFadeLabelControl::Render()
     float posX = m_posX + m_label.offsetX;
     if (m_label.align & XBFONT_CENTER_X)
       posX = m_posX + m_width * 0.5f;
-    else if (m_label.align & XBFONT_RIGHT)
-      posX = m_posX + m_width - m_textLayout.GetTextWidth();
+
     m_textLayout.Render(posX, posY, 0, m_label.textColor, m_label.shadowColor, m_label.align, m_width);
   }
   else

--- a/xbmc/guilib/GUIFont.h
+++ b/xbmc/guilib/GUIFont.h
@@ -35,12 +35,15 @@ class CGraphicContext;
 ///
 /// Flags are used as bits to have several together, e.g. `XBFONT_LEFT | XBFONT_CENTER_Y`
 ///
+// clang-format off
 constexpr int XBFONT_LEFT = 0; ///< Align X left
 constexpr int XBFONT_RIGHT = (1 << 0); ///< Align X right
 constexpr int XBFONT_CENTER_X = (1 << 1); ///< Align X center
 constexpr int XBFONT_CENTER_Y = (1 << 2); ///< Align Y center
-constexpr int XBFONT_TRUNCATED = (1 << 3); ///< Truncated text
+constexpr int XBFONT_TRUNCATED = (1 << 3); ///< Truncated text from right (text end with ellipses)
 constexpr int XBFONT_JUSTIFIED = (1 << 4); ///< Justify text
+constexpr int XBFONT_TRUNCATED_LEFT = (1 << 5); ///< Truncated text from left (text start with ellipses)
+// clang-format on
 /// @}
 
 // flags for font style. lower 16 bits are the unicode code

--- a/xbmc/guilib/GUILabel.cpp
+++ b/xbmc/guilib/GUILabel.cpp
@@ -130,9 +130,12 @@ void CGUILabel::Render()
     }
     else
     {
-      align |= XBFONT_TRUNCATED;
-      // Allow to text truncate (and relative ellipsis "...") on the left for use cases like edit controls (CGUIEditControl)
-      if (m_isReversedTruncate && (m_label.align & XBFONT_RIGHT))
+      if (m_overflowType == OVER_FLOW_TRUNCATE_LEFT)
+        align |= XBFONT_TRUNCATED_LEFT;
+      else
+        align |= XBFONT_TRUNCATED;
+
+      if (m_label.align & XBFONT_RIGHT)
         align |= XBFONT_RIGHT;
     }
     m_textLayout.Render(posX, posY, m_label.angle, color, m_label.shadowColor, align, m_overflowType == OVER_FLOW_CLIP ? m_textLayout.GetTextWidth() : m_renderRect.Width(), renderSolid);

--- a/xbmc/guilib/GUILabel.cpp
+++ b/xbmc/guilib/GUILabel.cpp
@@ -137,6 +137,12 @@ void CGUILabel::Render()
 
       if (m_label.align & XBFONT_RIGHT)
         align |= XBFONT_RIGHT;
+
+      if (m_label.align & XBFONT_CENTER_X)
+      {
+        posX += m_renderRect.Width() * 0.5f; // hack for centered multiline text, same of above
+        align |= XBFONT_CENTER_X;
+      }
     }
     m_textLayout.Render(posX, posY, m_label.angle, color, m_label.shadowColor, align, m_overflowType == OVER_FLOW_CLIP ? m_textLayout.GetTextWidth() : m_renderRect.Width(), renderSolid);
   }

--- a/xbmc/guilib/GUILabel.h
+++ b/xbmc/guilib/GUILabel.h
@@ -79,10 +79,14 @@ public:
 
   /*! \brief allowed overflow handling techniques for labels, as defined by the skin
    */
-  enum OVER_FLOW { OVER_FLOW_TRUNCATE = 0,
-                   OVER_FLOW_SCROLL,
-                   OVER_FLOW_WRAP,
-                   OVER_FLOW_CLIP };
+  enum OVER_FLOW
+  {
+    OVER_FLOW_TRUNCATE = 0, // Truncated text from right (text end with ellipses)
+    OVER_FLOW_SCROLL,
+    OVER_FLOW_WRAP,
+    OVER_FLOW_CLIP,
+    OVER_FLOW_TRUNCATE_LEFT // Truncated text from left (text start with ellipses)
+  };
 
   CGUILabel(float posX, float posY, float width, float height, const CLabelInfo& labelInfo, OVER_FLOW overflow = OVER_FLOW_TRUNCATE);
   CGUILabel(const CGUILabel& label);
@@ -155,12 +159,6 @@ public:
    \sa OVER_FLOW
    */
   bool SetOverflow(OVER_FLOW overflow);
-
-  /*!
-   * \brief Set if the text truncate (and ellipsis "...") must be done in reverse (on LTR text by default on the left).
-   * \param isReversed Set true to reversed behaviour
-   */
-  void SetReversedTruncate(bool isReversed) { m_isReversedTruncate = isReversed; }
 
   /*! \brief Set this label invalid.  Forces an update of the control
    */
@@ -236,8 +234,7 @@ private:
   CGUITextLayout m_textLayout;
 
   bool           m_scrolling;
-  OVER_FLOW      m_overflowType;
-  bool m_isReversedTruncate{false};
+  OVER_FLOW m_overflowType;
   CScrollInfo    m_scrollInfo;
   CRect          m_renderRect;   ///< actual sizing of text
   CRect          m_maxRect;      ///< maximum sizing of text

--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -227,8 +227,6 @@ void CGUITextBox::Render()
     // alignment correction
     if (alignment & XBFONT_CENTER_X)
       posX += m_width * 0.5f;
-    if (alignment & XBFONT_RIGHT)
-      posX += m_width;
 
     if (m_font)
     {
@@ -242,20 +240,12 @@ void CGUITextBox::Render()
       while (posY < m_posY + m_renderHeight && current < (int)m_lines.size())
       {
         const CGUIString& lineString = m_lines[current];
-        float linePosX = posX;
         uint32_t align = alignment;
 
         if (lineString.m_text.size() && lineString.m_carriageReturn)
           align &= ~XBFONT_JUSTIFIED; // last line of a paragraph shouldn't be justified
 
-        if (align & XBFONT_RIGHT)
-        {
-          // We need to adjust the posX in similar way the CGUILabel recalculate the render rect
-          // see CGUILabel::UpdateRenderRect()
-          linePosX -= GetTextWidth(lineString.m_text);
-        }
-
-        m_font->DrawText(linePosX, posY, m_colors, m_label.shadowColor, lineString.m_text, align,
+        m_font->DrawText(posX, posY, m_colors, m_label.shadowColor, lineString.m_text, align,
                          m_width);
         posY += m_itemHeight;
         current++;

--- a/xbmc/interfaces/legacy/Control.h
+++ b/xbmc/interfaces/legacy/Control.h
@@ -746,6 +746,7 @@ namespace XBMCAddon
     /// | XBFONT_CENTER_Y   | 0x00000004 | Align Y center
     /// | XBFONT_TRUNCATED  | 0x00000008 | Truncated text
     /// | XBFONT_JUSTIFIED  | 0x00000010 | Justify text
+    /// | XBFONT_TRUNCATED_LEFT | 0x00000020 | Truncated text from left
     /// @param hasPath              [opt] bool - True=stores a
     ///                                 path / False=no path
     /// @param angle                [opt] integer - angle of control.
@@ -887,6 +888,7 @@ namespace XBMCAddon
     /// | XBFONT_CENTER_Y   | 0x00000004 | Align Y center
     /// | XBFONT_TRUNCATED  | 0x00000008 | Truncated text
     /// | XBFONT_JUSTIFIED  | 0x00000010 | Justify text
+    /// | XBFONT_TRUNCATED_LEFT | 0x00000020 | Truncated text from left
     /// @param focusTexture         [opt] string - filename for focus texture.
     /// @param noFocusTexture       [opt] string - filename for no focus texture.
     ///
@@ -1126,6 +1128,7 @@ namespace XBMCAddon
     /// | XBFONT_CENTER_Y   | 0x00000004 | Align Y center
     /// | XBFONT_TRUNCATED  | 0x00000008 | Truncated text
     /// | XBFONT_JUSTIFIED  | 0x00000010 | Justify text
+    /// | XBFONT_TRUNCATED_LEFT | 0x00000020 | Truncated text from left
     /// @param shadowColor              [opt] hexstring - color of items
     ///                                     label's shadow. (e.g. '0xFF000000')
     ///
@@ -1660,6 +1663,7 @@ namespace XBMCAddon
     /// | XBFONT_CENTER_Y   | 0x00000004 | Align Y center
     /// | XBFONT_TRUNCATED  | 0x00000008 | Truncated text
     /// | XBFONT_JUSTIFIED  | 0x00000010 | Justify text
+    /// | XBFONT_TRUNCATED_LEFT | 0x00000020 | Truncated text from left
     ///
     /// @note You can use the above as keywords for arguments and skip certain
     ///       optional arguments.\n
@@ -2264,6 +2268,7 @@ namespace XBMCAddon
     /// | XBFONT_CENTER_Y   | 0x00000004 | Align Y center
     /// | XBFONT_TRUNCATED  | 0x00000008 | Truncated text
     /// | XBFONT_JUSTIFIED  | 0x00000010 | Justify text
+    /// | XBFONT_TRUNCATED_LEFT | 0x00000020 | Truncated text from left
     /// @param font                 [opt] string - font used for label text.
     ///                                 (e.g. 'font13')
     /// @param textColor            [opt] hexstring - color of enabled
@@ -2545,6 +2550,7 @@ namespace XBMCAddon
     /// | XBFONT_CENTER_Y   | 0x00000004 | Align Y center
     /// | XBFONT_TRUNCATED  | 0x00000008 | Truncated text
     /// | XBFONT_JUSTIFIED  | 0x00000010 | Justify text
+    /// | XBFONT_TRUNCATED_LEFT | 0x00000020 | Truncated text from left
     /// @param font                 [opt] string - font used for label text.
     ///                             (e.g. 'font13')
     /// @param textColor            [opt] hexstring - color of label when control


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This PR introduce the left text truncate setting.

The problem is started with the GUI control improvements PR #22691 where in the past i tried to introduce the left truncate, but has caused some issues with the right text alignment. After that i had tried to fix with PR #24624, but was not so perfect solution (this PR also revert that changes).

The right solution is decouple left/right truncate so that can be configured without strictly depends from alignment.

`XBFONT_TRUNCATED_LEFT` was inevitably added and should extend the "alignment" settings for python addons without particular impact

Having improved the code, I took the opportunity to include an additional fix for the use case having `<align>center</align>` and `OVER_FLOW` to TRUNCATE, was already broken from oldest kodi versions (screenshots for center case below)

These changes keep same behaviours for GUI settings improvements as shown on screenshots of PR #22691

In case of rebranch the backport to Kodi 21 is mandatory for the final release.

**Note 1 for `<align>justify</align>` / `XBFONT_JUSTIFIED`:**
This alignment was already broken, and will not be addressed with this PR

Note 2: the new left truncate can have an additional use for RTL text but requires other improvements

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #24725

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
user confirmed no regressions:
https://github.com/xbmc/xbmc/issues/24725#issuecomment-1985410259
https://github.com/xbmc/xbmc/issues/24610#issuecomment-1985000375

Used custom python addon with a xml window and with:
- label control `<control type="label" id="10000">` 
- fadelabel `<control type="fadelabel" id="10000">` (note this control perform truncate without ellipses)
- textbox `<control type="textbox" id="10000">`

**CURRENT MASTER BRANCH (BEFORE):**
_Here i show only broken use cases_

Multilines both lines are short, dont exceed the container width, and then text **"truncate" is not applied**
`<align>right</align>`
![immagine](https://github.com/xbmc/xbmc/assets/3257156/8ca1e8d0-c3d7-4d76-bbb9-150c7a558ad0)

Multilines both lines are too long, exceed the container width, and text **"truncate to RIGHT" is applied**
`<align>center</align>` (broken already before Kodi 20)
![309718003-62be8951-adca-44ee-a235-d09478f3e74b](https://github.com/xbmc/xbmc/assets/3257156/31687d47-c3b0-40a5-b7fa-1b3149e82602)
`<align>right</align>`
![309718003-62be8951-adca-44ee-a235-d09478f3e74b](https://github.com/xbmc/xbmc/assets/3257156/31687d47-c3b0-40a5-b7fa-1b3149e82602)

**WITH PR (NOW):**

Multilines both lines are short, dont exceed the container width, and then text **"truncate" is not applied**
`<align>left</align>`
![immagine](https://github.com/xbmc/xbmc/assets/3257156/bccb43d2-a07d-43df-b87c-250a3d3e417d)
`<align>center</align>`
![immagine](https://github.com/xbmc/xbmc/assets/3257156/9e96bfa0-7176-4516-ab0a-2999147b9db1)
`<align>right</align>`
![immagine](https://github.com/xbmc/xbmc/assets/3257156/5bfed6fb-a8b1-4f16-9639-bdcac057d8a1)

Multilines both lines are too long, exceed the container width, and text **"truncate to RIGHT" is applied**
`<align>left</align>`
![immagine](https://github.com/xbmc/xbmc/assets/3257156/62be8951-adca-44ee-a235-d09478f3e74b)
`<align>center</align>`
![immagine](https://github.com/xbmc/xbmc/assets/3257156/280d267f-0836-4bdd-a7b4-6503ea953342)
`<align>right</align>`
![immagine](https://github.com/xbmc/xbmc/assets/3257156/45553e25-9ae8-4426-805a-9792fdbafef1)

Only for sake of completness, example of truncate from LEFT, on right aligned text:
![immagine](https://github.com/xbmc/xbmc/assets/3257156/9a766196-1252-4f28-8b7f-43ff87284259)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Various type of GUI controls used on skins should display text as expected
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
