### PR TITLE
[Docs] Fix doxygen references for cutlist deprecation

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -802,7 +802,7 @@ const infomap integer_bools[] =  {{ "isequal",          INTEGER_IS_EQUAL },
 ///     @deprecated \link Player_Cutlist `Player.Cutlist`\endlink is deprecated and will be removed in the next version.
 ///     <p><hr>
 ///     @skinning_v19 **[New Infolabel]** \link Player_Cutlist `Player.Cutlist`\endlink
-///     @skinning_v20 \link Player_Cutlist `Player.Cutlist`\endlink is deprecated\, use \link Player_Editlist `Player.Editlist`\endlink instead
+///     @skinning_v20 \link Player_Cutlist `Player.Cutlist`\endlink is deprecated\, use \link Player_Cuts `Player.Cuts`\endlink instead
 ///     <p>
 ///   }
 ///   \table_row3{   <b>`Player.Editlist`</b>,

--- a/xbmc/guilib/GUIRangesControl.dox
+++ b/xbmc/guilib/GUIRangesControl.dox
@@ -39,7 +39,7 @@ important, as xml tags are case-sensitive.
 | lefttexture   | The texture used in the left hand side of the range
 | midtexture    | The texture used for the mid section of the range
 | righttexture  | The texture used in the right hand side of the range
-| info          | Specifies the information the range control holds. It expects an infolabel that returns a string in CSV format: e.g. `"start1,end1,start2,end2,..."`. Tokens must have values in the range from 0.0 to 100.0. end token must be less or equal than start token. Examples of currently supported infolabels are \link Player_Editlist `Player.Editlist`\endlink, \link Player_Cutlist `Player.Cutlist`\endlink (@deprecated), \link Player_Cuts `Player.Cuts`\endlink, \link Player_SceneMarkers `Player.Cutlist`\endlink and \link Player_Chapters `Player.Chapters`\endlink.
+| info          | Specifies the information the range control holds. It expects an infolabel that returns a string in CSV format: e.g. `"start1,end1,start2,end2,..."`. Tokens must have values in the range from 0.0 to 100.0. end token must be less or equal than start token. Examples of currently supported infolabels are \link Player_Editlist `Player.Editlist`\endlink, \link Player_Cutlist `Player.Cutlist`\endlink, \link Player_Cuts `Player.Cuts`\endlink, \link Player_SceneMarkers `Player.Cutlist`\endlink and \link Player_Chapters `Player.Chapters`\endlink. \n @deprecated \link Player_Cutlist `Player.Cutlist`\endlink is deprecated use \link Player_Cuts `Player.Cuts`\endlink instead.
 
 \section Ranges_Control_sect3 Revision History
 


### PR DESCRIPTION
## Description
Fix some issues in the doxygen page regarding skinning revisions for Player.Cutlist (deprecated in favor or Player.Cuts).

![image](https://github.com/xbmc/xbmc/assets/7375276/740324b0-e799-4856-bfeb-e3478b3295eb)

![image](https://github.com/xbmc/xbmc/assets/7375276/6d3b9e53-fa54-4e5b-bbfa-f70c11169f65)
