### PR TITLE
Bump androidx.tvprovider:tvprovider

### DIFF
--- a/tools/android/packaging/xbmc/build.gradle.in
+++ b/tools/android/packaging/xbmc/build.gradle.in
@@ -56,6 +56,6 @@ project.afterEvaluate {
 
 dependencies {
     // New support library to for channels/programs development.
-    implementation 'androidx.tvprovider:tvprovider:1.0.0'
+    implementation 'androidx.tvprovider:tvprovider:1.1.0-alpha01'
     implementation 'com.google.code.gson:gson:2.10.1'
 }


### PR DESCRIPTION
## Description
Update the support library for TV provider to the latest version.

Also fixes the following Play Store warning:

```
androidx.annotation:annotation:1.0.0
This SDK version has been reported as outdated. Consider upgrading to a newer version (1.0.1 - 1.0.2, 1.1.0-alpha02+).
```

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
