### PR TITLE
[Video][Stacks] Fix file stacks only play first part of stack from home screen.

### DIFF
--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -527,17 +527,7 @@ int PlayOrQueueMedia(const std::vector<std::string>& params, bool forcePlay)
   }
   item.SetProperty("check_resume", false);
 
-  if (item.IsStack())
-  {
-    const VIDEO_UTILS::ResumeInformation resumeInfo =
-        VIDEO_UTILS::GetStackPartResumeInformation(item, playOffset + 1);
-
-    if (item.GetStartOffset() == STARTOFFSET_RESUME)
-      item.SetStartOffset(resumeInfo.startOffset);
-
-    item.m_lStartPartNumber = resumeInfo.partNumber;
-  }
-  else if (!forcePlay /* queue */ || item.m_bIsFolder || item.IsPlayList())
+  if (!forcePlay /* queue */ || item.m_bIsFolder || item.IsPlayList())
   {
     CFileItemList items;
     GetItemsForPlayList(std::make_shared<CFileItem>(item), items);

--- a/xbmc/utils/ExecString.cpp
+++ b/xbmc/utils/ExecString.cpp
@@ -38,9 +38,12 @@ CExecString::CExecString(const std::string& function,
                          const std::string& param)
   : m_function(function)
 {
-  m_valid = !m_function.empty() && !target.GetPath().empty();
+  const std::string path{target.GetVideoInfoTag()->HasVideoVersions() ? target.GetPath()
+                                                                      : target.GetDynPath()};
 
-  m_params.emplace_back(StringUtils::Paramify(target.GetPath()));
+  m_valid = !m_function.empty() && !path.empty();
+
+  m_params.emplace_back(StringUtils::Paramify(path));
 
   if (target.m_bIsFolder)
     m_params.emplace_back("isdir");


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

File stacks only play first part of stack from home screen.
In v20 the whole stack is played correctly.

Debugging the code in v20 compared with v21 it seems that, whilst the `FileItem` associated with the entries on the home screen in correct (with a `VideoDB` url in Path and the actual path to play in DynPath) when it goes through `ExecString` only the `VideoDB` url is passed to `PlayOrQueueMedia` and DynPath is blank so all the subsequent `IsStack()` routines fail to trigger (so it doesn't seem possible to change things later in play routines).

@ksooo - I'm sure you'll have a better way to do this.

Also removed some code in `PlayerBuiltins.cpp` as it was forcing resume to be from the beginning of an item in the stack - whereas the correct resume info was set earlier - so it seems unnecessary.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #24812 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally on win 11 x64.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Entire stack plays.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
