### PR TITLE
[VideoSettings] Change default tone map method to Hable

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.h
@@ -82,7 +82,7 @@ protected:
   bool m_hasLightMetadata = false;
   AVContentLightMetadata m_lightMetadata;
   bool m_toneMapping = false;
-  ETONEMAPMETHOD m_toneMappingMethod = VS_TONEMAPMETHOD_REINHARD;
+  ETONEMAPMETHOD m_toneMappingMethod = VS_TONEMAPMETHOD_OFF;
   float m_toneMappingParam = 1.0;
 
   bool m_colorConversion{false};

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.h
@@ -69,7 +69,7 @@ class BaseYUV2RGBGLSLShader : public CGLSLShaderProgram
     bool m_hasLightMetadata{false};
     AVContentLightMetadata m_lightMetadata;
     bool m_toneMapping{false};
-    ETONEMAPMETHOD m_toneMappingMethod{VS_TONEMAPMETHOD_REINHARD};
+    ETONEMAPMETHOD m_toneMappingMethod{VS_TONEMAPMETHOD_OFF};
     float m_toneMappingParam{1.0};
 
     bool m_colorConversion{false};

--- a/xbmc/cores/VideoSettings.cpp
+++ b/xbmc/cores/VideoSettings.cpp
@@ -39,7 +39,7 @@ CVideoSettings::CVideoSettings()
   m_StereoMode = 0;
   m_StereoInvert = false;
   m_VideoStream = -1;
-  m_ToneMapMethod = VS_TONEMAPMETHOD_REINHARD;
+  m_ToneMapMethod = VS_TONEMAPMETHOD_OFF;
   m_ToneMapParam = 1.0f;
   m_Orientation = 0;
   m_CenterMixLevel = 0;

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -119,7 +119,7 @@ bool CMediaSettings::Load(const TiXmlNode *settings)
     int toneMapMethod;
     if (!XMLUtils::GetInt(pElement, "tonemapmethod", toneMapMethod, VS_TONEMAPMETHOD_OFF,
                           VS_TONEMAPMETHOD_MAX))
-      toneMapMethod = VS_TONEMAPMETHOD_REINHARD;
+      toneMapMethod = VS_TONEMAPMETHOD_HABLE;
     m_defaultVideoSettings.m_ToneMapMethod = static_cast<ETONEMAPMETHOD>(toneMapMethod);
 
     if (!XMLUtils::GetFloat(pElement, "tonemapparam", m_defaultVideoSettings.m_ToneMapParam, 0.1f, 5.0f))


### PR DESCRIPTION
## Description
[VideoSettings] Change default tone map method to Hable

## Motivation and context
With Reinhard colors are "washed out" and on all Windows / Xbox and desktop GL systems others better methods should work perfectly fine. Hable is the most elaborate method that offers good results for almost any range of source nits.

90% of people don't know how to find this setting so they never use it....

e.g:
https://www.reddit.com/r/kodi/comments/1ba71z5/kodi_has_very_washed_out_colors_compared_to_plex/

Reinhard default was previously kept because Hable was not implemented on all platforms but this is no longer a valid reason.

There may be other arguments: Hable cannot be used on underpowered systems e.g. Android, but Reinhard cannot be used on these systems either because it requires disable MediaCodecSurface. 

Shield and Fire TV's can do hardware based HDR to SDR tone mapping ...when firmware works: https://github.com/xbmc/xbmc/issues/20695#issuecomment-1763355058



## How has this been tested?
Runtime Windows x64

## What is the effect on users?
Better HDR to SDR tone mapping by default

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
