### PR TITLE
[ExecString] combine SplitParameters with identical function of CUtil

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1163,7 +1163,7 @@ void CUtil::SplitParams(const std::string &paramString, std::vector<std::string>
           if (quotaPos > 1 && quotaPos < parameter.length() - 1 && parameter[quotaPos - 1] == '=')
           {
             parameter.erase(parameter.length() - 1);
-            parameter.erase(quotaPos);
+            parameter.erase(quotaPos, 1);
           }
         }
         parameters.push_back(parameter);
@@ -1204,7 +1204,7 @@ void CUtil::SplitParams(const std::string &paramString, std::vector<std::string>
     if (quotaPos > 1 && quotaPos < parameter.length() - 1 && parameter[quotaPos - 1] == '=')
     {
       parameter.erase(parameter.length() - 1);
-      parameter.erase(quotaPos);
+      parameter.erase(quotaPos, 1);
     }
   }
   if (!parameter.empty() || parameters.size())

--- a/xbmc/test/TestUtil.cpp
+++ b/xbmc/test/TestUtil.cpp
@@ -152,3 +152,128 @@ const TestUtilCleanStringData values[] = {
     {"Some (Director Cut).BDRemux.mkv", true, "Some (Director Cut)", "Some (Director Cut)", ""}};
 
 INSTANTIATE_TEST_SUITE_P(URL, TestUtilCleanString, ValuesIn(values));
+
+struct TestUtilSplitParamsData
+{
+  std::string input;
+  std::vector<std::string> expectedResult;
+};
+
+std::ostream& operator<<(std::ostream& os, const TestUtilSplitParamsData& rhs)
+{
+  os << "(input: " << rhs.input << "; expCount: " << rhs.expectedResult.size();
+  for (unsigned int i = 0; i < rhs.expectedResult.size(); ++i)
+    os << "; expParam " << i + 1 << ": " << rhs.expectedResult[i];
+
+  return os;
+}
+
+class TestUtilSplitParams : public Test, public WithParamInterface<TestUtilSplitParamsData>
+{
+};
+
+TEST_P(TestUtilSplitParams, SplitParams)
+{
+  std::vector<std::string> actual;
+  CUtil::SplitParams(GetParam().input, actual);
+  EXPECT_EQ(actual.size(), GetParam().expectedResult.size());
+  EXPECT_EQ(actual, GetParam().expectedResult);
+}
+
+const TestUtilSplitParamsData valuesSplitParams[] = {
+    {"", {}},
+    {"one", {"one"}},
+    {" one", {"one"}},
+    {"one ", {"one"}},
+    {" one ", {"one"}},
+    // quotes " removed only when at beginning and end of param (after trimming)
+    {R"(" one")", {R"( one)"}},
+    {R"("one ")", {R"(one )"}},
+    {R"("on"e )", {R"("on"e)"}},
+    {R"(o"n"e )", {R"(o"n"e)"}},
+    {R"(o" n"e )", {R"(o" n"e)"}},
+    {R"( "one" )", {R"(one)"}},
+    {R"( " one")", {R"( one)"}},
+    {R"( " one " )", {R"( one )"}},
+    {R"(o" n"e )", {R"(o" n"e)"}},
+    {R"(o"ne" )", {R"(o"ne")"}},
+    {R"(o\"ne")", {R"(o"ne")"}},
+    {R"(\" one")", {R"( one)"}},
+    {R"(\" one\")", {R"( one)"}},
+    {R"("one " one)", {R"("one " one)"}},
+    // function 1 parameter
+    {"fun(p1)", {"fun(p1)"}},
+    {" fun(p1)", {"fun(p1)"}},
+    {"fun(p1) ", {"fun(p1)"}},
+    {"fun(p1 p1) ", {"fun(p1 p1)"}},
+    {"fun( p1 ) ", {"fun( p1 )"}}, // no trim: likely omission of the code?
+    // 2 parameters
+    {"one,", {"one", ""}},
+    {"one,two", {"one", "two"}},
+    {"one ,two", {"one", "two"}},
+    {"one,two ", {"one", "two"}},
+    {"one, two", {"one", "two"}},
+    {"one,two two", {"one", "two two"}},
+    {"one, two two", {"one", "two two"}},
+    {"one,two two ", {"one", "two two"}},
+    {R"(\" one\", two)", {R"( one)", "two"}},
+    //{R"(\" one", two)", {R"( one)", "two"}}, // mixing \" & " not supported for multi param
+    {R"(one, \" two\")", {"one", R"( two)"}},
+    //{R"(one, \" two")", {"one", R"( two)"}},  // mixing \" & " not supported for multi param
+
+    // function 2 parameters
+    {"fun(p1,p2)", {"fun(p1,p2)"}},
+    {"fun(p1 ,p2)", {"fun(p1 ,p2)"}}, // no trim: omission in the code?
+    {"fun(p1, p2)", {"fun(p1, p2)"}}, // no trim: omission in the code?
+    {"fun(p1 p1 ,p2)", {"fun(p1 p1 ,p2)"}}, // no trim: omission in the code?
+    {"fun(p1,p2), two", {"fun(p1,p2)", "two"}},
+    {"\"fun(p1,p2)\",two", {"fun(p1,p2)", "two"}},
+    {"\"fun(p1,p2)\",\" two\"", {"fun(p1,p2)", " two"}},
+    {"fun(p1,p2),\" two\"", {"fun(p1,p2)", " two"}},
+    {"\\\"fun(p1,p2)\\\",two", {"fun(p1,p2)", "two"}},
+    {"fun(p1,p2),\\\"two\\\"", {"fun(p1,p2)", "two"}},
+    {"fun(fun2(p1,p2),p3),two", {"fun(fun2(p1,p2),p3)", "two"}},
+    {"fun\"ction(p1,p2\",p3,p4)\"", {"fun\"ction(p1,p2\"", "p3", "p4)\""}},
+    // 3 parameters
+    {"one,two,three", {"one", "two", "three"}},
+    {"one,two two,three", {"one", "two two", "three"}},
+    {"one, two, three", {"one", "two", "three"}},
+    {"one, two two, three", {"one", "two two", "three"}},
+    // \ escaping
+    {R"(D:\foo\bar\baz.m2ts)", {R"(D:\foo\bar\baz.m2ts)"}},
+    {R"(D:\foo\bar\)", {R"(D:\foo\bar\)"}},
+    {R"(D:\\foo\bar\)", {R"(D:\foo\bar\)"}},
+    {R"(D:\foo\\bar\)", {R"(D:\foo\bar\)"}},
+    {R"(D:\foo\bar\\)", {R"(D:\foo\bar\)"}},
+    {R"(D:\\\foo\bar\)", {R"(D:\\foo\bar\)"}},
+    {R"(D:\foo\\\bar\)", {R"(D:\foo\\bar\)"}},
+    {R"(D:\foo\bar\\\)", {R"(D:\foo\bar\\)"}},
+    {R"(D:\\\\foo\bar\)", {R"(D:\\foo\bar\)"}},
+    {R"(D:\foo\\\\bar\)", {R"(D:\foo\\bar\)"}},
+    {R"(D:\foo\bar\\\\)", {R"(D:\foo\bar\\)"}},
+    {R"("D:\foo\\bar\\\baz.m2ts\\\\")", {R"(D:\foo\bar\\baz.m2ts\\)"}},
+    {R"(" D:\foo\\bar\\\baz.m2ts\\\\")", {R"( D:\foo\bar\\baz.m2ts\\)"}},
+    {R"(\"D:\foo\\bar\\\baz.m2ts\\\\\")", {R"(D:\foo\bar\\baz.m2ts\\)"}},
+    {R"(\" D:\foo\\bar\\\baz.m2ts\\\\\")", {R"( D:\foo\bar\\baz.m2ts\\)"}},
+    {R"(123,D:\foo\\bar\\\baz.m2ts\\\\,abc)", {"123", R"(D:\foo\bar\\baz.m2ts\\)", "abc"}},
+    {R"(123,"D:\foo\\bar\\\baz.m2ts\\\\",abc)", {"123", R"(D:\foo\bar\\baz.m2ts\\)", "abc"}},
+    {R"(123," D:\foo\\bar\\\baz.m2ts\\\\",abc)", {"123", R"( D:\foo\bar\\baz.m2ts\\)", "abc"}},
+    {R"(123,\"D:\foo\\bar\\\baz.m2ts\\\\\",abc)", {"123", R"(D:\foo\bar\\baz.m2ts\\)", "abc"}},
+    {R"(123,\" D:\foo\\bar\\\baz.m2ts\\\\\",abc)", {"123", R"( D:\foo\bar\\baz.m2ts\\)", "abc"}},
+    // name="value" parameter form
+    {R"(name="value")", {"name=value"}},
+    {R"(name="value1 value2")", {"name=value1 value2"}},
+    {R"(name="value1,value2")", {"name=value1,value2"}},
+    {R"(name="value1, value2")", {"name=value1, value2"}},
+    {R"(name="value1 "value2 " value3")", {R"(name=value1 "value2 " value3)"}},
+    {R"(name="value1 \"value2 \" value 3")", {R"(name=value1 "value2 " value 3)"}},
+    {R"(name=\"value\")", {R"(name=value)"}},
+    {R"("name=\"value\"")", {R"(name="value")"}},
+    {R"(name=value1,value2)", {"name=value1", "value2"}},
+    {R"(foo=bar=value1,value2)", {"foo=bar=value1", "value2"}},
+    {R"(foo=bar="value1,value2")", {"foo=bar=value1,value2"}},
+    {R"("name=value1 value2")", {"name=value1 value2"}},
+    {R"(abc, name="value", cde)", {"abc", "name=value", "cde"}},
+};
+
+INSTANTIATE_TEST_SUITE_P(SP, TestUtilSplitParams, ValuesIn(valuesSplitParams));


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Fixed in CUtil::SplitParams() the issue corrected in CExecString::SplitParams() by #24821

`parameter.erase(quotaPos);` => `parameter.erase(quotaPos, 1);`

Since both versions of the function were identical, share the code rather than duplicate it.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Issue found in CUtil::SplitParams() while checking the history of the changes that led to the bug and fix in CExecString::SplitParams() by #24821. Then I noticed that the code in both classes was identical.

Not sure why an identical copy was created by #22118. @ksoo it looks like you wrote that PR, any idea?

Before that, #3507 converted a now deleted class CStdString, with a member  `Delete(int nIdx, int nCount=1)` to `std::string::erase()`.
Unfortunately the default value of the second parameter was not copied to all conversions to `erase()`, creating the bug in `CUtil::SplitParams()`, later copied to `CExecString::SplitParams()`.
I checked the other changes of #3507 and that was the only one that required a fix. because the other Delete() calls had an explicit parameter value and were converted correctly, or removed the last character of a string, which doesn't need a count parameter for erase() to do the same thing.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
no runtime change noticed.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
