### PR TITLE
[BP][tools/depends] LLVM15 support - reduce errors to warnings

### DIFF
--- a/tools/depends/native/pkg-config/Makefile
+++ b/tools/depends/native/pkg-config/Makefile
@@ -17,6 +17,10 @@ ifeq ($(CROSS_COMPILING),no)
 PC_PATH:=$(PC_PATH):/usr/lib/pkgconfig:/usr/lib/$(HOST)/pkgconfig:/usr/share/pkgconfig
 endif
 
+# LLVM 15 has raised this to error by default. drop back to warning
+CFLAGS=$(NATIVE_CFLAGS) -Wno-error=int-conversion
+export CFLAGS
+
 # configuration settings
 CONFIGURE=./configure --prefix=$(PREFIX) --enable-indirect-deps --with-pc-path=$(PC_PATH) --with-internal-glib
 LIBDYLIB=$(PLATFORM)/pkg-config

--- a/tools/depends/target/gnutls/Makefile
+++ b/tools/depends/target/gnutls/Makefile
@@ -34,6 +34,10 @@ CONFIGURE=./configure --prefix=$(PREFIX) \
                       --without-idn \
                       $(CONFIGURE_OPTIONS)
 
+# LLVM 15 has raised this to error by default. drop back to warning
+CFLAGS+= -Wno-error=implicit-int
+export CFLAGS
+
 LIBDYLIB=$(PLATFORM)/lib/.libs/lib$(LIBNAME).a
 
 all: .installed-$(PLATFORM)

--- a/tools/depends/target/openssl/Makefile
+++ b/tools/depends/target/openssl/Makefile
@@ -21,6 +21,8 @@ else
     endif
   endif
   ifeq ($(OS), darwin_embedded)
+    # LLVM 15 has raised this to error by default. drop back to warning
+    CFLAGS+= -Wno-error=implicit-int
     export SDKROOT CFLAGS
     OPENSSLPLATFORM=kodi-$(TARGET_PLATFORM)-$(CPU)
     ifeq ($(TARGET_PLATFORM),appletvos)

--- a/tools/depends/target/samba-gplv3/Makefile
+++ b/tools/depends/target/samba-gplv3/Makefile
@@ -52,6 +52,9 @@ else
   endif
 endif
 
+# LLVM 15 has raised this to error by default. drop back to warning
+CFLAGS+= -Wno-error=int-conversion
+
 export PERL5LIB:=$(PERLMODULE):$(PERL5LIB)
 
 export CC CXX CPP AR RANLIB LD AS NM STRIP TOOLCHAIN


### PR DESCRIPTION
## Description
Backport of #24824
LLVM 15 raised some warning types to errors. For our purposes, just lower back to warnings.

## Motivation and context
Make 21 easily buildable on latest xcode for the foreseeable future

## How has this been tested?


## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
