### PR TITLE
GL/GLES: Add anisotropic filtering support

### DIFF
--- a/xbmc/guilib/GUIFontTTFGL.cpp
+++ b/xbmc/guilib/GUIFontTTFGL.cpp
@@ -16,6 +16,8 @@
 #include "gui3d.h"
 #include "rendering/MatrixGL.h"
 #include "rendering/gl/RenderSystemGL.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/GLUtils.h"
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
@@ -87,6 +89,16 @@ bool CGUIFontTTFGL::FirstBegin()
     // Set the texture image -- THIS WORKS, so the pixels must be wrong.
     glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, m_texture->GetWidth(), m_texture->GetHeight(), 0,
                  pixformat, GL_UNSIGNED_BYTE, 0);
+
+#ifdef GL_TEXTURE_MAX_ANISOTROPY_EXT
+    if (CServiceBroker::GetRenderSystem()->IsExtSupported("GL_EXT_texture_filter_anisotropic"))
+    {
+      int32_t aniso =
+          CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiAnisotropicFiltering;
+      if (aniso > 1)
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, aniso);
+    }
+#endif
 
     VerifyGLState();
     m_textureStatus = TEXTURE_UPDATED;

--- a/xbmc/guilib/GUIFontTTFGLES.cpp
+++ b/xbmc/guilib/GUIFontTTFGLES.cpp
@@ -16,6 +16,8 @@
 #include "gui3d.h"
 #include "rendering/MatrixGL.h"
 #include "rendering/gles/RenderSystemGLES.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/GLUtils.h"
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
@@ -82,6 +84,16 @@ bool CGUIFontTTFGLES::FirstBegin()
     // Set the texture image -- THIS WORKS, so the pixels must be wrong.
     glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, m_texture->GetWidth(), m_texture->GetHeight(), 0,
                  pixformat, GL_UNSIGNED_BYTE, 0);
+
+#ifdef GL_TEXTURE_MAX_ANISOTROPY_EXT
+    if (CServiceBroker::GetRenderSystem()->IsExtSupported("GL_EXT_texture_filter_anisotropic"))
+    {
+      int32_t aniso =
+          CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiAnisotropicFiltering;
+      if (aniso > 1)
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, aniso);
+    }
+#endif
 
     VerifyGLState();
     m_textureStatus = TEXTURE_UPDATED;

--- a/xbmc/guilib/TextureGL.cpp
+++ b/xbmc/guilib/TextureGL.cpp
@@ -12,6 +12,7 @@
 #include "guilib/TextureManager.h"
 #include "rendering/RenderSystem.h"
 #include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/GLUtils.h"
 #include "utils/MemUtils.h"
 #include "utils/log.h"
@@ -90,6 +91,16 @@ void CGLTexture::LoadToGPU()
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+#ifdef GL_TEXTURE_MAX_ANISOTROPY_EXT
+  if (CServiceBroker::GetRenderSystem()->IsExtSupported("GL_EXT_texture_filter_anisotropic"))
+  {
+    int32_t aniso =
+        CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiAnisotropicFiltering;
+    if (aniso > 1)
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, aniso);
+  }
+#endif
 
   unsigned int maxSize = CServiceBroker::GetRenderSystem()->GetMaxTextureSize();
   if (m_textureHeight > maxSize)

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -1219,6 +1219,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetBoolean(pElement, "visualizedirtyregions", m_guiVisualizeDirtyRegions);
     XMLUtils::GetInt(pElement, "algorithmdirtyregions",     m_guiAlgorithmDirtyRegions);
     XMLUtils::GetBoolean(pElement, "smartredraw", m_guiSmartRedraw);
+    XMLUtils::GetInt(pElement, "anisotropicfiltering", m_guiAnisotropicFiltering);
   }
 
   std::string seekSteps;

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -331,6 +331,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_guiVisualizeDirtyRegions;
     int  m_guiAlgorithmDirtyRegions;
     bool m_guiSmartRedraw;
+    int32_t m_guiAnisotropicFiltering{0};
     unsigned int m_addonPackageFolderSize;
 
     bool m_jsonOutputCompact;


### PR DESCRIPTION
## Description
The PR adds support for anisotropic filtering to GL/GLES. 

It is an advanced setting for the time being:
```
<advancedsettings>
  <gui>
    <anisotropicfiltering>16</anisotropicfiltering>
  </gui>
</advancedsettings>
```

## Motivation and context
Texture surfaces at glancing angles are a bit blurry (if sampled with mipmapping enabled) or display shimmering artifacts (without mm). 

With Anisotropic filtering, the GPU might sample from multiple locations, giving a nicer looking result. The actual implementation is highly GPU dependent.

## How has this been tested?
On my RX570, it has no effect with our current texture pipeline. Forcing mipmaps, there is some visible change on rotated surfaces.

## What is the effect on users?
Higher image quality for X/Y rotated surfaces, with possible performance decrease.

## Screenshots (if appropriate):

Forced mipmap:
![mipmap](https://github.com/xbmc/xbmc/assets/30039775/7c240ccf-e800-43c6-9644-37a629b28443)

Forced mipmap + anisotropic filtering:
![mipmap_aniso](https://github.com/xbmc/xbmc/assets/30039775/f64e34a8-40d6-45e1-a633-c1a06be92925)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
