### PR TITLE
[bookmarks] Fix large and rotated thumbnail creation 

### DIFF
--- a/xbmc/application/ApplicationPlayer.cpp
+++ b/xbmc/application/ApplicationPlayer.cpp
@@ -865,6 +865,18 @@ float CApplicationPlayer::GetRenderAspectRatio() const
     return 1.0;
 }
 
+bool CApplicationPlayer::GetRects(CRect& source, CRect& dest, CRect& view) const
+{
+  const std::shared_ptr<const IPlayer> player{GetInternal()};
+  if (player)
+  {
+    player->GetRects(source, dest, view);
+    return true;
+  }
+  else
+    return false;
+}
+
 void CApplicationPlayer::TriggerUpdateResolution()
 {
   std::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/application/ApplicationPlayer.cpp
+++ b/xbmc/application/ApplicationPlayer.cpp
@@ -877,6 +877,15 @@ bool CApplicationPlayer::GetRects(CRect& source, CRect& dest, CRect& view) const
     return false;
 }
 
+unsigned int CApplicationPlayer::GetOrientation() const
+{
+  const std::shared_ptr<const IPlayer> player{GetInternal()};
+  if (player)
+    return player->GetOrientation();
+  else
+    return 0;
+}
+
 void CApplicationPlayer::TriggerUpdateResolution()
 {
   std::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/application/ApplicationPlayer.h
+++ b/xbmc/application/ApplicationPlayer.h
@@ -56,6 +56,7 @@ public:
   void SetRenderViewMode(int mode, float zoom, float par, float shift, bool stretch);
   float GetRenderAspectRatio() const;
   bool GetRects(CRect& source, CRect& dest, CRect& view) const;
+  unsigned int GetOrientation() const;
   void TriggerUpdateResolution();
   bool IsRenderingVideo() const;
   bool IsRenderingGuiLayer() const;

--- a/xbmc/application/ApplicationPlayer.h
+++ b/xbmc/application/ApplicationPlayer.h
@@ -55,6 +55,7 @@ public:
   void FlushRenderer();
   void SetRenderViewMode(int mode, float zoom, float par, float shift, bool stretch);
   float GetRenderAspectRatio() const;
+  bool GetRects(CRect& source, CRect& dest, CRect& view) const;
   void TriggerUpdateResolution();
   bool IsRenderingVideo() const;
   bool IsRenderingGuiLayer() const;

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -231,7 +231,12 @@ public:
   virtual float GetRenderAspectRatio() const { return 1.0; }
   virtual void TriggerUpdateResolution() {}
   virtual bool IsRenderingVideo() const { return false; }
-
+  virtual void GetRects(CRect& source, CRect& dest, CRect& view) const
+  {
+    source = {};
+    dest = {};
+    view = {};
+  }
   virtual bool Supports(EINTERLACEMETHOD method) const { return false; }
   virtual EINTERLACEMETHOD GetDeinterlacingMethodDefault() const
   {

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -237,6 +237,7 @@ public:
     dest = {};
     view = {};
   }
+  virtual unsigned int GetOrientation() const { return 0; }
   virtual bool Supports(EINTERLACEMETHOD method) const { return false; }
   virtual EINTERLACEMETHOD GetDeinterlacingMethodDefault() const
   {

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5034,6 +5034,11 @@ float CVideoPlayer::GetRenderAspectRatio() const
   return m_renderManager.GetAspectRatio();
 }
 
+void CVideoPlayer::GetRects(CRect& source, CRect& dest, CRect& view) const
+{
+  m_renderManager.GetVideoRect(source, dest, view);
+}
+
 void CVideoPlayer::TriggerUpdateResolution()
 {
   std::string stereomode;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5039,6 +5039,11 @@ void CVideoPlayer::GetRects(CRect& source, CRect& dest, CRect& view) const
   m_renderManager.GetVideoRect(source, dest, view);
 }
 
+unsigned int CVideoPlayer::GetOrientation() const
+{
+  return m_renderManager.GetOrientation();
+}
+
 void CVideoPlayer::TriggerUpdateResolution()
 {
   std::string stereomode;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -341,6 +341,7 @@ public:
   void SetRenderViewMode(int mode, float zoom, float par, float shift, bool stretch) override;
   float GetRenderAspectRatio() const override;
   void GetRects(CRect& source, CRect& dest, CRect& view) const override;
+  unsigned int GetOrientation() const override;
   void TriggerUpdateResolution() override;
   bool IsRenderingVideo() const override;
   bool Supports(EINTERLACEMETHOD method) const override;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -340,6 +340,7 @@ public:
   void FlushRenderer() override;
   void SetRenderViewMode(int mode, float zoom, float par, float shift, bool stretch) override;
   float GetRenderAspectRatio() const override;
+  void GetRects(CRect& source, CRect& dest, CRect& view) const override;
   void TriggerUpdateResolution() override;
   bool IsRenderingVideo() const override;
   bool Supports(EINTERLACEMETHOD method) const override;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
@@ -85,6 +85,7 @@ public:
   */
   void GetVideoRect(CRect& source, CRect& dest, CRect& view) const;
   float GetAspectRatio() const;
+  unsigned int GetOrientation() const { return m_renderOrientation; }
 
   static void SettingOptionsRenderMethodsFiller(const std::shared_ptr<const CSetting>& setting,
                                                 std::vector<IntegerSettingOption>& list,

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -70,6 +70,15 @@ float CRenderManager::GetAspectRatio() const
     return 1.0f;
 }
 
+unsigned int CRenderManager::GetOrientation() const
+{
+  std::unique_lock<CCriticalSection> lock(m_statelock);
+  if (m_pRenderer)
+    return m_pRenderer->GetOrientation();
+  else
+    return 0;
+}
+
 void CRenderManager::SetVideoSettings(const CVideoSettings& settings)
 {
   std::unique_lock<CCriticalSection> lock(m_statelock);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -60,6 +60,7 @@ public:
   // Functions called from render thread
   void GetVideoRect(CRect& source, CRect& dest, CRect& view) const;
   float GetAspectRatio() const;
+  unsigned int GetOrientation() const;
   void FrameMove();
   void FrameWait(std::chrono::milliseconds duration);
   void Render(bool clear, DWORD flags = 0, DWORD alpha = 255, bool gui = true);

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -41,8 +41,6 @@
 #include <string>
 #include <vector>
 
-#define BOOKMARK_THUMB_WIDTH CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_imageRes
-
 #define CONTROL_ADD_BOOKMARK           2
 #define CONTROL_CLEAR_BOOKMARKS        3
 #define CONTROL_ADD_EPISODE_BOOKMARK   4
@@ -380,15 +378,37 @@ bool CGUIDialogVideoBookmarks::AddBookmark(CVideoInfoTag* tag)
   bookmark.player = g_application.GetCurrentPlayer();
 
   // create the thumbnail image
-  float aspectRatio = appPlayer->GetRenderAspectRatio();
-  int width = BOOKMARK_THUMB_WIDTH;
-  int height = (int)(BOOKMARK_THUMB_WIDTH / aspectRatio);
-  if (height > (int)BOOKMARK_THUMB_WIDTH)
-  {
-    height = BOOKMARK_THUMB_WIDTH;
-    width = (int)(BOOKMARK_THUMB_WIDTH * aspectRatio);
-  }
+  const float aspectRatio{appPlayer->GetRenderAspectRatio()};
+  CRect srcRect{}, renderRect{}, viewRect{};
+  appPlayer->GetRects(srcRect, renderRect, viewRect);
+  const unsigned int srcWidth{static_cast<unsigned int>(srcRect.Width())};
+  const unsigned int srcHeight{static_cast<unsigned int>(srcRect.Height())};
+  const unsigned int renderWidth{static_cast<unsigned int>(renderRect.Width())};
+  const unsigned int renderHeight{static_cast<unsigned int>(renderRect.Height())};
+  const unsigned int viewWidth{static_cast<unsigned int>(viewRect.Width())};
+  const unsigned int viewHeight{static_cast<unsigned int>(viewRect.Height())};
 
+  if (!srcWidth || !srcHeight || !renderWidth || !renderHeight || !viewWidth || !viewHeight)
+    return false;
+
+  // FIXME: the renderer sets the scissors to the size of the screen (provided by graphiccontext),
+  // limiting the max size of thumbs (for example 4k video played on 1024x768 screen)
+
+  // The advanced setting defines the max size of the largest dimension (depends on orientation)
+  const unsigned int maxThumbDim{
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_imageRes};
+  unsigned int width{}, height{};
+
+  if (aspectRatio >= 1.0f)
+  {
+    width = std::min({maxThumbDim, viewWidth, renderWidth, srcWidth});
+    height = static_cast<unsigned int>(width / aspectRatio);
+  }
+  else
+  {
+    height = std::min({maxThumbDim, viewHeight, renderHeight, srcHeight});
+    width = static_cast<unsigned int>(height * aspectRatio);
+  }
 
   uint8_t *pixels = (uint8_t*)malloc(height * width * 4);
   unsigned int captureId = appPlayer->RenderCaptureAlloc();


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

There were a few bugs in the bookmark thumbnail creation, all addressed in this PR:
1/ thumbnail clipped for size > screen size (original problem reported in #24818 - imageres=9999 is the extreme case, but happens at lower values too (ex. 2000 for 1080p screen)
2/ thumbnail of rotated videos distorted
3/ needlessly large thumbnails

The code could have been made a bit more compact at the expense of readability. I can change if requested (the two blocks of if(rotated) {} else {} could be compacted into one).

In more details:
1/Bookmark thumbnails are created by video rendering, unlike movie/episode thumbnails, created directly the source video.
It brings a constraint: rendering is clipped to screen size by scissors set by GraphicContext. Decoupling would be good in the future.
-> PR fix: thumbnail dimensions calculated to fit in screen size

2/ The video container rotation metadata flag was not taken into account, resulting wrong aspect ratio and distorted thumbnail image. The dimensions of the source are pre-rotation, rotation is applied when rendering
-> PR fix: switch width/height as appropriate when comparing source dimensions against screen size, rendering area, ...

3/ With the points above taken care of, the thumbnail of a DVD played at 4k resolution would create a 4k-sized thumbnail. This is inefficient. The thumbnail will be limited to the source size instead (taking into account non-square pixels - so not always source widthxsource height dimension)
-> PR fix: make sure thumbnail dimensions do not exceed source dimensions

To avoid making the code overly complex, picture adjustments applied during rendering (zoom, a/r adjustment, crop) are not taken into account.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #24818 (set advanced settings "imageres" to 9999 for thumbs at source size)

Also noticed thumbs of rotated video were distorted.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Bookmark thumbs work for all sizes and orientation.

## Screenshots (if appropriate):
Before PR - imageres 9999 4k video 1080p screen > thumbnail 9999x5624
![image](https://github.com/xbmc/xbmc/assets/489377/0ba4d7b8-dc26-4c2d-b5a1-28008b0893c1)

Before PR - imageres 1080 rotated DVD source 720x480 - thumbnail is 1080x810 (wrong ar)
![image](https://github.com/xbmc/xbmc/assets/489377/b305d323-91e6-4840-93ee-6fd00dfd5a88)

Before PR - imageres 9999 rotated DVD source 720x480 - thumbnail is 9999x7499 (cumulates both issues)
![image](https://github.com/xbmc/xbmc/assets/489377/6ded8de9-4481-43c4-9f3f-56c5a646671b)

With PR - imageres 9999 4k video 1080p screen
![image](https://github.com/xbmc/xbmc/assets/489377/26a7f276-ca37-4c17-b8f0-242075730d93)

With PR - imageres 9999 rotated DVD source 720x480 - thumbnail is 540x720 (due to non-square pixels of source)
![image](https://github.com/xbmc/xbmc/assets/489377/abb65715-6b99-4480-b524-3ce9c072113a)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
