### PR TITLE
GBM: fix setting no HDR mode (on SDR display)

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -718,6 +718,7 @@ void CLinuxRendererGLES::UnInit()
   m_bConfigured = false;
 
   CServiceBroker::GetWinSystem()->SetHDR(nullptr);
+  m_passthroughHDR = false;
 }
 
 bool CLinuxRendererGLES::CreateTexture(int index)

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -401,7 +401,7 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
       m_hdr_blob_id = 0;
     }
 
-    return true;
+    return false;
   }
 
   KODI::UTILS::Colorimetry colorimetry = DRMPRIME::GetColorimetry(*videoPicture);
@@ -501,7 +501,7 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
     drm->SetActive(true);
   }
 
-  return true;
+  return m_hdr_blob_id != 0;
 }
 
 bool CWinSystemGbm::IsHDRDisplay()


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
SetHDR() has to return false if HDR cannot be enabled.

m_passthroughHDR has to be cleared in CLinuxRendererGLES::UnInit()

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #24585

As shown in the issue SDR displays are detected as HDR capable.  Therefore e.g. allow tone mapping cannot be used.

In CLinuxRendererGLES::Configure() m_passthroughHDR is set to the result of the SetHDR() call and later used to selecting color primaries and to enable tone mapping. 

Backport ~is required~ done.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Building Generic image of recent LE master with this PR. Tone mapping is working on my SDR displays.

~Due to lack of supporting hardware HDR display functionality has to be tested by volunteers.~ HDR display succesful tested by @smp79 

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

GBM HDR tone mapping working. 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
