### PR TITLE
[guilib] Fix font loading after skin switch

### DIFF
--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -507,10 +507,7 @@ void GUIFontManager::LoadFonts(const TiXmlNode* fontNode)
 
     if (!fontName.empty() && URIUtils::HasExtension(fileName, ".ttf"))
     {
-      //! @todo Why do we tolower() this shit?
-      std::string strFontFileName = fileName;
-      StringUtils::ToLower(strFontFileName);
-      LoadTTF(fontName, strFontFileName, textColor, shadowColor, iSize, iStyle, false, lineSpacing,
+      LoadTTF(fontName, fileName, textColor, shadowColor, iSize, iStyle, false, lineSpacing,
               aspect);
     }
     fontNode = fontNode->NextSibling("font");


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Keep the original font filename case in the OrigFontInfo structure, so that when Kodi's window is resized, GUIFontManage::ReloadTTFFonts() is able to locate the font files and generate fonts in the newly required sizes.

The font reload was broken by the commit https://github.com/xbmc/xbmc/commit/640fce7356a90dd1ad5936acff51bbbced141736 and the addition of ToLower() to GUIFontManager::LoadFonts() for unclear reasons. A PR is not available with additional details and the dev didn't remember after 12 years.
Maybe it was for the extension comparison or maybe it was to account for the case-insensitivity of older filesystems like FAT
The other changes of the commit can stay, they're still useful or significantly rewritten already.

The extension comparison is still case insensitive after the PR so a font like ARIAL.TTF is still recognized.
Maybe case-sensitive filesystems would have trouble if case in fonts.xml and on filesystem is not exactly the same but that's par for the course?

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Problem reported in the forum https://forum.kodi.tv/showthread.php?tid=376481

After some digging, the problem was that the font names for the Estuary and Aeon Nox Silvo skins have mixed case and are cached by Kodi with the original mixed case names.

When switching Kodi between fullscreen and windowed, or when resizing the window in windowed mode, GUIFontManage::ReloadTTFFonts() was using a lower case file font name, which was causing the cache lookup to fail, and the font was not created in the requested size.

The problem is hidden before changing skin because the skin font directories are not in the cache (yet).

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Normal appearance of Kodi GUI after switching skin and resizing the window. This is most useful for skinners.

## Screenshots (if appropriate):

Start Kodi fullscreen in Estuary
Change skin to Aeon Nox Silvo
Press \ to go to Windowed mode

before PR, wrong font sizes:
![image](https://github.com/xbmc/xbmc/assets/489377/bdb3cea1-42b0-40b5-8af2-844675da1e19)

with PR, normal appearance:
![image](https://github.com/xbmc/xbmc/assets/489377/1a84c45c-a857-495e-a24b-9bc88428b90d)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
