### PR TITLE
[Subtitles] Set undefined if language could not be detected

### DIFF
--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -481,7 +481,7 @@ std::string CStreamDetails::GetSubtitleLanguage(int idx) const
   if (item)
     return item->m_strLanguage;
   else
-    return "";
+    return "und";
 }
 
 void CStreamDetails::Archive(CArchive& ar)

--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -479,9 +479,9 @@ std::string CStreamDetails::GetSubtitleLanguage(int idx) const
   const CStreamDetailSubtitle* item =
       dynamic_cast<const CStreamDetailSubtitle*>(GetNthStream(CStreamDetail::SUBTITLE, idx));
   if (item)
-    return item->m_strLanguage;
+    return item->m_strLanguage.empty() ? "und" : item->m_strLanguage;
   else
-    return "und";
+    return "";
 }
 
 void CStreamDetails::Archive(CArchive& ar)

--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -282,7 +282,7 @@ std::string CStreamDetails::GetVideoLanguage(int idx) const
   const CStreamDetailVideo* item =
       dynamic_cast<const CStreamDetailVideo*>(GetNthStream(CStreamDetail::VIDEO, idx));
   if (item)
-    return item->m_strLanguage;
+    return item->m_strLanguage.empty() ? "und" : item->m_strLanguage;
   else
     return "";
 }
@@ -459,7 +459,7 @@ std::string CStreamDetails::GetAudioLanguage(int idx) const
   const CStreamDetailAudio* item =
       dynamic_cast<const CStreamDetailAudio*>(GetNthStream(CStreamDetail::AUDIO, idx));
   if (item)
-    return item->m_strLanguage;
+    return item->m_strLanguage.empty() ? "und" : item->m_strLanguage;
   else
     return "";
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Set "und" for undefined (empty) subtitle language into the library database.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This would allow to show into the skin the video has a subtitle despite we don't have its language.
Currently, when a video has an undefined language for a subtitle, the skin shows information like there is no subtitle (if only one subtitle stream - or if all subtitle streams are without any language defined). Skin can only display there is a subtitle while playing the video.
This skin data would show something (currently, not) :
`<visible>!ListItem.IsFolder + Window.IsActive(videos) + !String.IsEmpty(ListItem.Property(SubtitleLanguage.1))</visible>`

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
