### PR TITLE
stacks: make InitializeStackStartPartAndOffset return optional and ha…

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -2264,10 +2264,16 @@ bool CApplication::PlayStack(CFileItem& item, bool bRestart)
   if (!stackHelper->InitializeStack(item))
     return false;
 
-  int startoffset = stackHelper->InitializeStackStartPartAndOffset(item);
+  std::optional<int> startoffset = stackHelper->InitializeStackStartPartAndOffset(item);
+  if (!startoffset)
+  {
+    CLog::LogF(LOGERROR, "Failed to obtain start offset for stack {}. Aborting playback.",
+               item.GetDynPath());
+    return false;
+  }
 
   CFileItem selectedStackPart = stackHelper->GetCurrentStackPartFileItem();
-  selectedStackPart.SetStartOffset(startoffset);
+  selectedStackPart.SetStartOffset(startoffset.value());
 
   if (item.HasProperty("savedplayerstate"))
   {

--- a/xbmc/application/ApplicationStackHelper.cpp
+++ b/xbmc/application/ApplicationStackHelper.cpp
@@ -81,7 +81,7 @@ bool CApplicationStackHelper::InitializeStack(const CFileItem & item)
   return true;
 }
 
-int CApplicationStackHelper::InitializeStackStartPartAndOffset(const CFileItem& item)
+std::optional<int> CApplicationStackHelper::InitializeStackStartPartAndOffset(const CFileItem& item)
 {
   CVideoDatabase dbs;
   int64_t startoffset = 0;
@@ -163,7 +163,7 @@ int CApplicationStackHelper::InitializeStackStartPartAndOffset(const CFileItem& 
         if (!CDVDFileInfo::GetFileDuration(GetStackPartFileItem(i).GetDynPath(), duration))
         {
           m_currentStack->Clear();
-          return false;
+          return std::nullopt;
         }
         totalTimeMs += duration;
         // set end time in every part

--- a/xbmc/application/ApplicationStackHelper.h
+++ b/xbmc/application/ApplicationStackHelper.h
@@ -13,6 +13,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 
 class CFileItem;
@@ -36,8 +37,9 @@ public:
   /*!
   \brief Initialize stack times for each part, start & end, total time, and current part number if resume offset is specified.
   \param item the FileItem object that is the stack
+  \returns the part offset if available, nullopt in case of errors
   */
-  int InitializeStackStartPartAndOffset(const CFileItem& item);
+  std::optional<int> InitializeStackStartPartAndOffset(const CFileItem& item);
 
   /*!
   \brief returns the current part number


### PR DESCRIPTION
…ndle errors

## Description
This fixes a crash when playing stack files if for some reason you've deleted one of the files from the disk. `InitializeStackStartPartAndOffset` returns an integer (the current playing part). If the file does not exist on the HDD it can't find the duration of the file and it simply return `false` for error after pruning/cleaning the stackfile (`m_currentStack->Clear();`). This is implicitly converted to part 0 as if no error had occurred but the stackfile no longer has any items so we try to dereference a nullpointer later...

This simply makes the method return optional and, in case of errors, it doesn't fill the part number. This lets the client code handling any possible errors avoid it going further.


## Motivation and context
I still spent quite a bit of time understanding whatever was going on since Kodi was crashing on playback. I've deleted one of the files before while doing some tests.
Kodi should handle errors graciously.

## How has this been tested?
Runtime tested

## What is the effect on users?
No crash in the explained condition above.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
