### PR TITLE
[addons] Fix addonmgr/profilemgr deadlock when switching profiles

### DIFF
--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -249,7 +249,6 @@ std::vector<std::shared_ptr<IAddon>> CAddonMgr::GetOutdatedAddons() const
 std::vector<std::shared_ptr<IAddon>> CAddonMgr::GetAvailableUpdatesOrOutdatedAddons(
     AddonCheckType addonCheckType) const
 {
-  std::unique_lock<CCriticalSection> lock(m_critSection);
   auto start = std::chrono::steady_clock::now();
 
   std::vector<std::shared_ptr<IAddon>> result;


### PR DESCRIPTION
Fixes a deadlock I encountered while switching profiles.

Deadlock thread vs thread 13

Thread 1 has addonmgr mtx and wants profilemgr mtx
Thread 13 is the other around

Idea of the fix: Looking at `CAddonMgr::GetAvailableUpdatesOrOutdatedAddons` implementation it gets quite obvious that the mutex that gets acquired there is actually not needed. So I just removed that line of code.

Runtime tested on macOS, latest Kodi master.

@enen92 maybe you can have a look at the code change?

```
(lldb) thread backtrace all
  thread #1, queue = 'com.apple.main-thread'
    frame #0: 0x00007ff81bdebb92 libsystem_kernel.dylib`__psynch_mutexwait + 10
    frame #1: 0x0000000117c20d33 libsystem_pthread.dylib`_pthread_mutex_firstfit_lock_wait + 94
    frame #2: 0x0000000117c20c7b libsystem_pthread.dylib`_pthread_mutex_firstfit_lock_slow + 208
    frame #3: 0x0000000106592f45 Kodi`XbmcThreads::CRecursiveMutex::lock(this=0x00007fd034214378) at RecursiveMutex.h:39:24
    frame #4: 0x0000000106572299 Kodi`XbmcThreads::CountingLockable<XbmcThreads::CRecursiveMutex>::lock(this=0x00007fd034214378) at Lockables.h:50:32
    frame #5: 0x00000001062ba497 Kodi`std::__1::unique_lock<CCriticalSection>::unique_lock(this=0x00007ff7ba001388, __m=0x00007fd034214378) at __mutex_base:118:61
    frame #6: 0x00000001062aab2d Kodi`std::__1::unique_lock<CCriticalSection>::unique_lock(this=0x00007ff7ba001388, __m=0x00007fd034214378) at __mutex_base:118:54
    frame #7: 0x00000001062ab68a Kodi`ADDON::CAddonMgr::GetAddon(this=0x00007fd034214300, str="resource.images.studios.white", addon=nullptr, type=UNKNOWN, onlyEnabled=CHOICE_YES) const at AddonManager.cpp:636:38
!!!! wants addonmgr mutex
    frame #8: 0x00000001062aff67 Kodi`ADDON::CAddonMgr::GetAddon(this=0x00007fd034214300, str="resource.images.studios.white", addon=nullptr, onlyEnabled=CHOICE_YES) const at AddonManager.cpp:660:10
    frame #9: 0x00000001070820f0 Kodi`KODI::GUILIB::GUIINFO::CAddonsGUIInfo::GetBool(this=0x00007fd0348cc6d0, value=0x00007ff7ba00183f, gitem=0x00007fd0341c9d50, contextWindow=10000, info=0x00007fd039def810) const at AddonsGUIInfo.cpp:251:41
    frame #10: 0x0000000107097dc4 Kodi`KODI::GUILIB::GUIINFO::CGUIInfoProviders::GetBool(this=0x00007fd0348cc6b0, value=0x00007ff7ba00183f, item=0x00007fd0341c9d50, contextWindow=10000, info=0x00007fd039def810) const at GUIInfoProviders.cpp:110:19
    frame #11: 0x0000000106176d3c Kodi`CGUIInfoManager::GetMultiInfoBool(this=0x00007fd0348cc600, info=0x00007fd039def810, contextWindow=10000, item=0x0000000000000000) at GUIInfoManager.cpp:10785:29
    frame #12: 0x00000001061767c2 Kodi`CGUIInfoManager::GetBool(this=0x00007fd0348cc600, condition1=40370, contextWindow=10000, item=0x0000000000000000) at GUIInfoManager.cpp:10745:15
    ...
    frame #43: 0x0000000107010cbe Kodi`CGUIWindowManager::ChangeActiveWindow(this=0x00007fd0341c9be0, newWindow=12999, strPath="") at GUIWindowManager.cpp:757:3
    frame #44: 0x0000000107a18ae3 Kodi`CProfileManager::FinalizeLoadProfile(this=0x000060000327cdc0) at ProfileManager.cpp:436:48
    frame #45: 0x0000000107a18696 Kodi`CProfileManager::LoadProfile(this=0x000060000327cdc0, index=0) at ProfileManager.cpp:370:3
    frame #46: 0x0000000107a195e4 Kodi`CProfileManager::LoadMasterProfileForLogin(this=0x000060000327cdc0) at ProfileManager.cpp:624:5
!!! has profilemgr mtx
    frame #47: 0x0000000107a193f6 Kodi`CProfileManager::LogOff(this=0x000060000327cdc0) at ProfileManager.cpp:460:3
    frame #48: 0x000000010721b87d Kodi`LogOff(params=size=0) at ProfileBuiltins.cpp:53:19
    frame #49: 0x00000001071d2b78 Kodi`CBuiltins::Execute(this=0x000000010c2ebb70, execString="System.LogOff") at Builtins.cpp:158:14
    frame #50: 0x0000000106583808 Kodi`CApplication::ExecuteXBMCAction(this=0x00007fd034104080, actionStr="System.LogOff", item=nullptr) at Application.cpp:2999:32
    frame #51: 0x0000000106582233 Kodi`CApplication::OnMessage(this=0x00007fd034104080, message=0x00007ff7ba006820) at Application.cpp:2976:14
    frame #52: 0x000000010700e8fc Kodi`CGUIWindowManager::SendMessage(this=0x00007fd0341c9be0, message=0x00007ff7ba006820) at GUIWindowManager.cpp:496:23
    frame #53: 0x0000000106e6e3d0 Kodi`CGUIAction::ExecuteActions(this=0x00007fd039ed9d88, controlID=0, parentID=10111, item=nullptr) const at GUIAction.cpp:87:52
    frame #54: 0x00000001074632a6 Kodi`CStaticListProvider::OnClick(this=0x0000600000d22cd0, item=std::__1::shared_ptr<CGUIListItem>::element_type @ 0x00007fd039ed9ad0 strong=3 weak=1) at StaticProvider.cpp:136:40
    ...

* thread #13, name = 'JobWorker'
    frame #0: 0x00007ff81bdebb92 libsystem_kernel.dylib`__psynch_mutexwait + 10
    frame #1: 0x0000000117c20d33 libsystem_pthread.dylib`_pthread_mutex_firstfit_lock_wait + 94
    frame #2: 0x0000000117c20c7b libsystem_pthread.dylib`_pthread_mutex_firstfit_lock_slow + 208
    frame #3: 0x0000000106592f45 Kodi`XbmcThreads::CRecursiveMutex::lock(this=0x000060000327ce10) at RecursiveMutex.h:39:24
    frame #4: 0x0000000106572299 Kodi`XbmcThreads::CountingLockable<XbmcThreads::CRecursiveMutex>::lock(this=0x000060000327ce10) at Lockables.h:50:32
    frame #5: 0x0000000107a1ca47 Kodi`std::__1::unique_lock<CCriticalSection>::unique_lock(this=0x0000700003725200, __m=0x000060000327ce10) at __mutex_base:118:61
    frame #6: 0x0000000107a179dd Kodi`std::__1::unique_lock<CCriticalSection>::unique_lock(this=0x0000700003725200, __m=0x000060000327ce10) at __mutex_base:118:54
  * frame #7: 0x0000000107a19191 Kodi`CProfileManager::GetCurrentProfile(this=0x000060000327cdc0) const at ProfileManager.cpp:552:38
!!! wants profilemgr mtx
    frame #8: 0x0000000107a1a214 Kodi`CProfileManager::GetDatabaseFolder(this=0x000060000327cdc0) const at ProfileManager.cpp:657:7
    frame #9: 0x0000000106a2a177 Kodi`CDatabase::InitSettings(this=0x00007000037257f8, dbSettings=0x00007000037253d0) at Database.cpp:564:74
    frame #10: 0x0000000106a29f3d Kodi`CDatabase::Open(this=0x00007000037257f8, settings=0x0000700003725558) at Database.cpp:533:3
    frame #11: 0x0000000106a29dd0 Kodi`CDatabase::Open(this=0x00007000037257f8) at Database.cpp:517:10
    frame #12: 0x000000010626f0a5 Kodi`ADDON::CAddonDatabase::Open(this=0x00007000037257f8) at AddonDatabase.cpp:197:21
    frame #13: 0x00000001062d1bc6 Kodi`ADDON::CAddonRepos::CAddonRepos(this=0x00007000037257f0) at AddonRepos.cpp:45:23
    frame #14: 0x00000001062d2625 Kodi`ADDON::CAddonRepos::CAddonRepos(this=0x00007000037257f0) at AddonRepos.cpp:44:1
    frame #15: 0x00000001062ac4d1 Kodi`ADDON::CAddonMgr::GetAvailableUpdatesOrOutdatedAddons(this=0x00007fd034214300, addonCheckType=AVAILABLE_UPDATES) const at AddonManager.cpp:257:15
!!!! has addonmgr mutex (but actually does not need it!)
    frame #16: 0x00000001062ac3a1 Kodi`ADDON::CAddonMgr::GetAvailableUpdates(this=0x00007fd034214300) const at AddonManager.cpp:230:7
    frame #17: 0x00000001062acdf9 Kodi`ADDON::CAddonMgr::HasAvailableUpdates(this=0x00007fd034214300) at AddonManager.cpp:316:11
    frame #18: 0x0000000106b52535 Kodi`XFILE::RootDirectory(items=0x0000700003727870) at AddonsDirectory.cpp:622:37
    frame #19: 0x0000000106b51907 Kodi`XFILE::CAddonsDirectory::GetDirectory(this=0x000060000187bac0, url=0x0000700003726bf0, items=0x0000700003727870) at AddonsDirectory.cpp:678:5
    frame #20: 0x0000000106bb7d97 Kodi`XFILE::CDirectory::GetDirectory(url=0x0000700003727130, pDirectory=std::__1::shared_ptr<XFILE::IDirectory>::element_type @ 0x000060000187bac0 strong=1 weak=1, items=0x0000700003727870, hints=0x00007000037272b0) at Directory.cpp:193:30
    frame #21: 0x0000000106bb7918 Kodi`XFILE::CDirectory::GetDirectory(url=0x0000700003727130, items=0x0000700003727870, hints=0x00007000037272b0) at Directory.cpp:155:10
    frame #22: 0x0000000106bb782e Kodi`XFILE::CDirectory::GetDirectory(strPath="addons://", items=0x0000700003727870, strMask="", flags=0) at Directory.cpp:121:10
    frame #23: 0x00000001074428b0 Kodi`CDirectoryJob::DoWork(this=0x0000600003138990) at DirectoryProvider.cpp:147:9
    frame #24: 0x00000001081897b9 Kodi`CJobWorker::Process(this=0x00007fd0341e0940) at JobManager.cpp:55:22
    frame #25: 0x00000001080b3d44 Kodi`CThread::Action(this=0x00007fd0341e0940) at Thread.cpp:267:5
    frame #26: 0x00000001080ba0ec Kodi`CThread::Create(this=0x00006000003cb1e0, pThread=0x00007fd0341e0940, promise=promise<bool> @ 0x0000700003727f20)::$_0::operator()(CThread*, std::__1::promise<bool>) const at Thread.cpp:138:18
    frame #27: 0x00000001080b9df9 Kodi`decltype(__f=0x00006000003cb1e0, __args=0x00006000003cb1e8, __args=0x00006000003cb1f0)::$_0>(fp)(static_cast<CThread*>(fp0), static_cast<std::__1::promise<bool>>(fp0))) std::__1::__invoke<CThread::Create(bool)::$_0, CThread*, std::__1::promise<bool> >(CThread::Create(bool)::$_0&&, CThread*&&, std::__1::promise<bool>&&) at type_traits:3918:1
    frame #28: 0x00000001080b9d67 Kodi`void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, CThread::Create(bool)::$_0, CThread*, std::__1::promise<bool>, 2ul, 3ul>(__t=size=4, (null)=__tuple_indices<2, 3> @ 0x0000700003727f68)::$_0, CThread*, std::__1::promise<bool> >&, std::__1::__tuple_indices<2ul, 3ul>) at thread:287:5
    frame #29: 0x00000001080b9462 Kodi`void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, CThread::Create(bool)::$_0, CThread*, std::__1::promise<bool> > >(__vp=0x00006000003cb1e0) at thread:298:5
    frame #30: 0x0000000117c1bc0d libsystem_pthread.dylib`_pthread_start + 125
    frame #31: 0x0000000117c23ccf libsystem_pthread.dylib`thread_start + 15
 ```

