### PR TITLE
Enforce minimum interval between add-on repository updates

### DIFF
--- a/xbmc/addons/RepositoryUpdater.h
+++ b/xbmc/addons/RepositoryUpdater.h
@@ -54,12 +54,20 @@ public:
    */
   void Await();
 
+  enum class UpdateScheduleType
+  {
+    /*! Update should be scheduled as the first update after application start or setting change. */
+    First,
+    /*! Update should be scheduled as a regular update during application runtime. */
+    Regular
+  };
+
   /**
    * Schedule an automatic update to run based on settings and previous update
    * times. May be called when there are external changes this updater must know
    * about. Any previously scheduled update will be cancelled.
    */
-  void ScheduleUpdate();
+  void ScheduleUpdate(UpdateScheduleType scheduleType);
 
   /**
    * Returns the time of the last check (oldest). Invalid time if never checked.


### PR DESCRIPTION
## Description
Repository update can fail in a way that would lead to an immediate reschedule of the update. A common reason would be a failure to update the `nextcheck` column of the `repo` table. This leads to mirror and repository servers getting constantly hammered.

Since there is no reason to have a smaller update interval than an hour anyway, we just enforce this as the minimum in all regular updates. This should catch all possible errors leading to a continuous series of requests.

## Motivation and context
#24829 

## How has this been tested?
Manual test stepping through common cases with the debugger on my machine.

## What is the effect on users?
Their broken RPi will not saturate their internet connection any more...

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
