### PR TITLE
Use unique service names in Zeroconf registration

### DIFF
--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -627,7 +627,8 @@ bool CAirTunesServer::StartServer(int port, bool nonlocal, bool usePassword, con
     txt.emplace_back("am", "Kodi,1");
     txt.emplace_back("vs", "130.14");
 
-    CZeroconf::GetInstance()->PublishService("servers.airtunes", "_raop._tcp", appName, port, txt);
+    CZeroconf::GetInstance()->PublishService("servers.airtunes", "_raop._tcp",
+                                             CSysInfo::GetDeviceName() + " airtunes", port, txt);
   }
 
   return success;

--- a/xbmc/network/EventServer.cpp
+++ b/xbmc/network/EventServer.cpp
@@ -149,12 +149,10 @@ void CEventServer::Run()
   }
 
   // publish service
-  std::vector<std::pair<std::string, std::string> > txt;
-  CZeroconf::GetInstance()->PublishService("servers.eventserver",
-                               "_xbmc-events._udp",
-                               CSysInfo::GetDeviceName(),
-                               m_iPort,
-                               txt);
+  std::vector<std::pair<std::string, std::string>> txt;
+  CZeroconf::GetInstance()->PublishService("servers.eventserver", "_xbmc-events._udp",
+                                           CSysInfo::GetDeviceName() + " eventserver", m_iPort,
+                                           txt);
 
   // add our socket to the 'select' listener
   listener.AddSocket(m_pSocket.get());

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -711,9 +711,12 @@ bool CNetworkServices::StartWebserver()
 
   // publish web frontend and API services
 #ifdef HAS_WEB_INTERFACE
-  CZeroconf::GetInstance()->PublishService("servers.webserver", "_http._tcp", CSysInfo::GetDeviceName(), webPort, txt);
+  CZeroconf::GetInstance()->PublishService("servers.webserver", "_http._tcp",
+                                           CSysInfo::GetDeviceName() + " webserver", webPort, txt);
 #endif // HAS_WEB_INTERFACE
-  CZeroconf::GetInstance()->PublishService("servers.jsonrpc-http", "_xbmc-jsonrpc-h._tcp", CSysInfo::GetDeviceName(), webPort, txt);
+  CZeroconf::GetInstance()->PublishService("servers.jsonrpc-http", "_xbmc-jsonrpc-h._tcp",
+                                           CSysInfo::GetDeviceName() + " jsonrpc-http", webPort,
+                                           txt);
 #endif // HAS_ZEROCONF
 
   return true;
@@ -785,7 +788,9 @@ bool CNetworkServices::StartAirPlayServer()
   // we have implemented it anyways).
   txt.emplace_back("features", "0x20F7");
 
-  CZeroconf::GetInstance()->PublishService("servers.airplay", "_airplay._tcp", CSysInfo::GetDeviceName(), CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_airPlayPort, txt);
+  CZeroconf::GetInstance()->PublishService(
+      "servers.airplay", "_airplay._tcp", CSysInfo::GetDeviceName() + " airplay",
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_airPlayPort, txt);
 #endif // HAS_ZEROCONF
 
   return true;
@@ -878,7 +883,7 @@ bool CNetworkServices::StartJSONRPCServer()
                              CSettings::SETTING_SERVICES_DEVICEUUID));
 
   CZeroconf::GetInstance()->PublishService(
-      "servers.jsonrpc-tcp", "_xbmc-jsonrpc._tcp", CSysInfo::GetDeviceName(),
+      "servers.jsonrpc-tcp", "_xbmc-jsonrpc._tcp", CSysInfo::GetDeviceName() + " jsonrpc-tcp",
       CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_jsonTcpPort, txt);
 #endif // HAS_ZEROCONF
 


### PR DESCRIPTION
## Description
Currently network services are using the same name, in my device: `Kodi (192.168.1.3)`. These services should have unique names.

Exception that occurs when registering services in Android:
```
E MdnsAdvertiser: Name conflict adding services that should have unique names
E MdnsAdvertiser: android.net.connectivity.com.android.server.connectivity.mdns.NameConflictException
E MdnsAdvertiser:    at android.net.connectivity.com.android.server.connectivity.mdns.MdnsRecordRepository.addService(MdnsRecordRepository.java:314)
...
```

This PR adds a suffix to the name that clearly identifies the service. 

log now:
```
info <general>: ZeroconfAndroid: Kodi (192.168.1.3) jsonrpc-tcp. now registered and active
info <general>: ZeroconfAndroid: Kodi (192.168.1.3) eventserver. now registered and active
info <general>: ZeroconfAndroid: Kodi (192.168.1.3) webserver. now registered and active
info <general>: ZeroconfAndroid: Kodi (192.168.1.3) jsonrpc-http. now registered and active
```

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
