### PR TITLE
stacks: fix Visual Studio warning

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -2264,7 +2264,7 @@ bool CApplication::PlayStack(CFileItem& item, bool bRestart)
   if (!stackHelper->InitializeStack(item))
     return false;
 
-  std::optional<int> startoffset = stackHelper->InitializeStackStartPartAndOffset(item);
+  std::optional<int64_t> startoffset = stackHelper->InitializeStackStartPartAndOffset(item);
   if (!startoffset)
   {
     CLog::LogF(LOGERROR, "Failed to obtain start offset for stack {}. Aborting playback.",

--- a/xbmc/application/ApplicationStackHelper.cpp
+++ b/xbmc/application/ApplicationStackHelper.cpp
@@ -81,7 +81,8 @@ bool CApplicationStackHelper::InitializeStack(const CFileItem & item)
   return true;
 }
 
-std::optional<int> CApplicationStackHelper::InitializeStackStartPartAndOffset(const CFileItem& item)
+std::optional<int64_t> CApplicationStackHelper::InitializeStackStartPartAndOffset(
+    const CFileItem& item)
 {
   CVideoDatabase dbs;
   int64_t startoffset = 0;

--- a/xbmc/application/ApplicationStackHelper.h
+++ b/xbmc/application/ApplicationStackHelper.h
@@ -39,7 +39,7 @@ public:
   \param item the FileItem object that is the stack
   \returns the part offset if available, nullopt in case of errors
   */
-  std::optional<int> InitializeStackStartPartAndOffset(const CFileItem& item);
+  std::optional<int64_t> InitializeStackStartPartAndOffset(const CFileItem& item);
 
   /*!
   \brief returns the current part number


### PR DESCRIPTION
## Description
Fix Visual Studio warning after https://github.com/xbmc/xbmc/pull/24880

## Motivation and context
```
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\include\optional(83,17): warning C4244: 'initializing': conversion from '_Ty' to 'int', possible loss of data [C:\jenkins-workspace\workspace\WIN-64\kodi-build.x64\libkodi.vcxproj]
          with
          [
              _Ty=int64_t
          ] (compiling source file C:\jenkins-workspace\workspace\WIN-64\xbmc\application\ApplicationStackHelper.cpp)
C:\jenkins-workspace\workspace\WIN-64\xbmc\application\ApplicationStackHelper.cpp(334,1): message : see reference to function template instantiation 'std::_Optional_destruct_base<_Ty,true>::_Optional_destruct_base<__int64>(std::in_place_t,__int64 &&) noexcept' being compiled [C:\jenkins-workspace\workspace\WIN-64\kodi-build.x64\libkodi.vcxproj]
          with
          [
              _Ty=int
          ]
  mysqldataset.cpp
  GUIDialogBoxBase.cpp
  GUIDialogBusy.cpp
C:\jenkins-workspace\workspace\WIN-64\xbmc\application\ApplicationStackHelper.cpp(334,1): message : see reference to function template instantiation 'std::_Optional_destruct_base<_Ty,true>::_Optional_destruct_base<__int64>(std::in_place_t,__int64 &&) noexcept' being compiled [C:\jenkins-workspace\workspace\WIN-64\kodi-build.x64\libkodi.vcxproj]
          with
          [
              _Ty=int
          ]
  GUIDialogBusyNoCancel.cpp
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\include\optional(247,1): message : see reference to function template instantiation 'std::_Optional_construct_base<_Ty>::_Optional_construct_base<__int64>(std::in_place_t,__int64 &&)' being compiled [C:\jenkins-workspace\workspace\WIN-64\kodi-build.x64\libkodi.vcxproj]
          with
          [
              _Ty=int
          ] (compiling source file C:\jenkins-workspace\workspace\WIN-64\xbmc\application\ApplicationStackHelper.cpp)
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\include\optional(247,18): message : see reference to function template instantiation 'std::_Optional_construct_base<_Ty>::_Optional_construct_base<__int64>(std::in_place_t,__int64 &&)' being compiled [C:\jenkins-workspace\workspace\WIN-64\kodi-build.x64\libkodi.vcxproj]
          with
          [
              _Ty=int
          ] (compiling source file C:\jenkins-workspace\workspace\WIN-64\xbmc\application\ApplicationStackHelper.cpp)
C:\jenkins-workspace\workspace\WIN-64\xbmc\application\ApplicationStackHelper.cpp(210,21): message : see reference to function template instantiation 'std::optional<int>::optional<int64_t,0>(_Ty2 &&) noexcept' being compiled [C:\jenkins-workspace\workspace\WIN-64\kodi-build.x64\libkodi.vcxproj]
          with
          [
              _Ty2=int64_t
          ]
C:\jenkins-workspace\workspace\WIN-64\xbmc\application\ApplicationStackHelper.cpp(210,3): message : see reference to function template instantiation 'std::optional<int>::optional<int64_t,0>(_Ty2 &&) noexcept' being compiled [C:\jenkins-workspace\workspace\WIN-64\kodi-build.x64\libkodi.vcxproj]
          with
          [
              _Ty2=int64_t
          ]
```

Use int64_t in all chain as final use wants int64_t in SetStartOffset() anyway:

https://github.com/xbmc/xbmc/blob/4a78706ce16a77b087c6566ba5979262830138fb/xbmc/application/Application.cpp#L2263-L2276

## How has this been tested?
Windows x64

## What is the effect on users?
nothing

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
