### PR TITLE
[GUITextLayout] Fix text wrap and justify alignment

### DIFF
--- a/xbmc/guilib/GUILabelControl.dox
+++ b/xbmc/guilib/GUILabelControl.dox
@@ -68,9 +68,7 @@ want to be able to give it more content than will fit on one line, then setting:
    <wrapmultiline>true</wrapmultiline>
 ~~~~~~~~~~~~~
 
-will cause the text to be cut up (at the spaces in the text) onto multiple lines.
-Note that if a single word is larger than <b>`<width>`</b> then it will not be cut, and
-will still overflow.
+Will cause the text to be cut up onto multiple lines.
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Reworked code that wrap text

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
since the old Kodi versions, the text wrap has always been broken, and cause of side effects on justify alignment
this can be shown clearly on Kodi GUI tiles when an tile has a too long text without spaces (such as filenames)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
with custom addon having a textbox control e.g.
```xml
<control type="textbox" id="10000">
      <align>left</align> // or justify
// label with spaces ...
      <label>[I]Sailor moon[/I], [B]Sailor mars[/B], Sailor mercury, Sailor Venus, Sailor Jupiter.[CR]They fight in the name of the moon.</label>
// ... or label with one space and too long text without spaces
      <label>[I]Sailor moon[/I],[B]Sailormars[/B],Sailormercury,SailorVenus,SailorJupiter.[CR]Theyfightinthenameofthemoon.</label>
      <textcolor>FFFFFFFF</textcolor>
      <scroll>false</scroll>
      <haspath>false</haspath>
      <font>font12</font>
</control>
```

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Display text on screen correctly

## Screenshots (if appropriate):
**Case 1: Too long text without enough spaces (only one after first "Sailor"), note the text that go outside the GUI control**
BEFORE:
![case0](https://github.com/xbmc/xbmc/assets/3257156/d7c35631-020b-4739-b9d0-061d8516274c)
AFTER:
![immagine](https://github.com/xbmc/xbmc/assets/3257156/f6354dcd-7fd1-47e7-9493-d3a5fcfce0c3)

**Case 2: Justify alignment is broken, after a paragraph (CR) text must not be justified**
BEFORE:
![case1](https://github.com/xbmc/xbmc/assets/3257156/5d06181b-4b12-4e29-8e00-4ea3a42e6fa3)
AFTER:
![case1-after](https://github.com/xbmc/xbmc/assets/3257156/2d1ed519-9817-4ceb-8beb-e8852f86ed0e)

**Example of broken text on Kodi GUI tiles, see the major differences on yellow boxes**
BEFORE:
![immagine](https://github.com/xbmc/xbmc/assets/3257156/7d87735f-7f2d-4131-8ab9-e4125558ce2f)
AFTER:
![immagine](https://github.com/xbmc/xbmc/assets/3257156/462dc871-50b9-4104-8611-3e25dec8d020)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
