### PR TITLE
[Windows] a few CMake updates

### DIFF
--- a/cmake/scripts/windows/ArchSetup.cmake
+++ b/cmake/scripts/windows/ArchSetup.cmake
@@ -1,5 +1,5 @@
 # Minimum SDK version we support
-set(VS_MINIMUM_SDK_VERSION 10.0.14393.0)
+set(VS_MINIMUM_SDK_VERSION 10.0.18362.0)
 
 if(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION VERSION_LESS VS_MINIMUM_SDK_VERSION)
   message(FATAL_ERROR "Detected Windows SDK version is ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}.\n"
@@ -90,8 +90,7 @@ link_directories(${DEPENDS_PATH}/lib)
 
 # Additional libraries
 list(APPEND DEPLIBS bcrypt.lib d3d11.lib DInput8.lib DSound.lib winmm.lib Mpr.lib Iphlpapi.lib WS2_32.lib
-                    PowrProf.lib setupapi.lib Shlwapi.lib dwmapi.lib dxguid.lib DelayImp.lib version.lib
-                    crypt32.lib)
+                    PowrProf.lib setupapi.lib Shlwapi.lib dwmapi.lib dxguid.lib DelayImp.lib)
 
 # NODEFAULTLIB option
 set(_nodefaultlibs_RELEASE libcmt)
@@ -104,8 +103,7 @@ foreach(_lib ${_nodefaultlibs_DEBUG})
 endforeach()
 
 # DELAYLOAD option
-set(_delayloadlibs zlib.dll libmariadb.dll libxslt.dll dnssd.dll dwmapi.dll sqlite3.dll
-                   d3dcompiler_47.dll)
+set(_delayloadlibs libmariadb.dll libxslt.dll dnssd.dll dwmapi.dll sqlite3.dll d3dcompiler_47.dll)
 foreach(_lib ${_delayloadlibs})
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DELAYLOAD:\"${_lib}\"")
 endforeach()
@@ -120,12 +118,4 @@ set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /DEBUG /OP
 
 if(CMAKE_GENERATOR MATCHES "Visual Studio")
   set_property(GLOBAL PROPERTY USE_FOLDERS ON)
-
-  # Generate a batch file that opens Visual Studio with the necessary env variables set.
-  file(WRITE ${CMAKE_BINARY_DIR}/kodi-sln.bat
-             "@echo off\n"
-             "set KODI_HOME=%~dp0\n"
-             "set PATH=%~dp0\\system\n"
-             "set PreferredToolArchitecture=x64\n"
-             "start %~dp0\\${PROJECT_NAME}.sln")
 endif()


### PR DESCRIPTION
## Description
[Windows] a few CMake updates

## Motivation and context

- Bumps minimal Windows SDK to `10.0.18362.0` (for consistency with same version required in UWP) because current `10.0.14393.0` is totally obsolete.
- Removes linking to some libs that only needed on Windows 7:  `version.lib` and `crypt32.lib`
- Removes link warning:

```
LINK : warning LNK4199: /DELAYLOAD:zlib.dll ignored; no imports found from zlib.dll [C:\jenkins-workspace\workspace\WIN-64\kodi-build.x64\kodi.vcxproj]
```
- Removes generate `kodi-sln.bat` file to launch Visual Studio solution: Obsolete and this breaks compatibility to execute custom commands in CMake (e.g. execute Powershell scrips) like those needed in https://github.com/xbmc/xbmc/pull/24882 . VS solution can be opened directly from generated `kodi.sln`.


## How has this been tested?
Build Windows x64 and Runtime tested in Windows 8.1 (VM), Windows 10 (VM) and Windows 11.

## What is the effect on users?
Nothing

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
