### PR TITLE
[AdvandedSettings] Additional latency setting for HDR

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -304,7 +304,7 @@ void CRenderManager::FrameMove()
       lock.unlock();
       if (!Configure())
         return;
-
+      UpdateLatencyTweak();
       firstFrame = true;
       FrameWait(50ms);
     }
@@ -890,11 +890,14 @@ void CRenderManager::PresentBlend(bool clear, DWORD flags, DWORD alpha)
 void CRenderManager::UpdateLatencyTweak()
 {
   float fps = CServiceBroker::GetWinSystem()->GetGfxContext().GetFPS();
+  const bool isHDREnabled = CServiceBroker::GetWinSystem()->GetOSHDRStatus() == HDR_STATUS::HDR_ON;
+
   float refresh = fps;
   if (CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution() == RES_WINDOW)
     refresh = 0; // No idea about refresh rate when windowed, just get the default latency
   m_latencyTweak = static_cast<double>(
-      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->GetLatencyTweak(refresh));
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->GetLatencyTweak(refresh,
+                                                                                     isHDREnabled));
 }
 
 void CRenderManager::UpdateResolution()

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -94,6 +94,7 @@ struct RefreshVideoLatency
   float refreshmax;
 
   float delay;
+  float hdrextradelay;
 };
 
 typedef std::vector<TVShowRegexp> SETTINGS_TVSHOWLIST;
@@ -163,6 +164,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     std::vector<RefreshOverride> m_videoAdjustRefreshOverrides;
     std::vector<RefreshVideoLatency> m_videoRefreshLatency;
     float m_videoDefaultLatency;
+    float m_videoDefaultHdrExtraLatency;
     int  m_videoCaptureUseOcclusionQuery;
     bool m_DXVACheckCompatibility;
     bool m_DXVACheckCompatibilityPresent;
@@ -340,7 +342,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     std::vector<std::string> m_settingsFiles;
     void ParseSettingsFile(const std::string &file);
 
-    float GetLatencyTweak(float refreshrate);
+    float GetLatencyTweak(float refreshrate, bool isHDREnabled);
     bool m_initialized;
 
     void SetDebugMode(bool debug);


### PR DESCRIPTION
## Description
Provides an additional setting 'hdrextradelay' under 'latency' tag (default setting) and under a 'refresh' node in AdvancedSettings.xml

This value (in ms) will be added to the existing display's 'delay' value to calculate total delay, only when HDR mode is active. Can be applied to the selected range of refresh rates.

## Motivation and context
I hate lip-sync issues with a passion, and while trying to adjust it for my setup I noticed everytime I set it right for SDR content it derails the previous setting I orignally had made with HDR and vice-versa. 

After a little bit of research I found out there is significant latency added on my TV (OLED LG G3) when HDR is enabled at 23-25hz range. About 100 ms or so. I suppose it is the case with most modern HDR TVs aswell.
I'm on HCPC on Windows myself but I'm pretty sure this delay comes from the TV and not anything else. If I'm wrong, well, it still solves a problem for some. 
 
So it's an unresolved issue for a lot of people who watch mixxed content. 
Therefore it ought to be taken into account and adjustable in the most user-friendly media player out there. 

## How has this been tested?
Yes, it's been tested. During dev/debug (Windows x64 build) based on the Master branch. Hardware used : HDR monitor + AMD 6950xt GPU. 

Then I built a patched Nexus 20.5 build for my everyday use (Windows 10 + Nvidia 1070ti GPU + LG G3) and it works flawlessly so far. 

## Types of change

- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)


## Checklist:

- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
