### PR TITLE
[videoplayer] Fix Playback Delay for Items from uPnP sources

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -782,7 +782,9 @@ bool CVideoPlayer::OpenInputStream()
   {
     // find any available external subtitles
     std::vector<std::string> filenames;
-    CUtil::ScanForExternalSubtitles(m_item.GetDynPath(), filenames);
+
+    if (!URIUtils::IsUPnP(m_item.GetPath()))
+      CUtil::ScanForExternalSubtitles(m_item.GetDynPath(), filenames);
 
     // load any subtitles from file item
     std::string key("subtitle:1");


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

When opening a file for playback, `ScanForExternalSubtitles` looks for external subtitles in the directory of the played item but the dynpath of uPnP items cannot be manipulated in that way and is supposed to be treated as an opaque string (see context for details)

The PR creates a special case in `OpenInputStream` to skip `ScanForExternalSubtitles` for the upnp protocol.

This was implemented in the caller of `ScanForExternalSubtitles` because the protocol is not available anymore in the strMovie parameter and filtering everything http would have the unwanted side-effect of breaking external sub retrieval for webdav/http.

The Kodi uPnP client + server combination has a way to provide external subtitles through the item properties, which still works after the PR.

Should probably be backported.


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

reported in forum https://forum.kodi.tv/showthread.php?tid=376839

It takes minutes to start the playback of items from uPnP sources with Gerbera as uPnP server. I confirmed the issue with UMS server as well. There was no issue with other uPnP servers, such as minidlna and Kodi.

Example with UMS: playing upnp://8a4304d5-a1c1-45a0-aa39-e4882b5ca24b/29930/ translates to http://192.168.2.103:5001/get/29930/bbb_sunflower_1080p_60fps_normal.mp4

When playing the item, ScanForExternalSubtitles downloads http://192.168.2.103:5001/get/29930/ to enumerate the directory of the item and find possible subtitle files/directories. However UMS returns the video itself instead of a directory listing and Kodi notices only after the complete download of the video to memory that it's not a directory.

There is no uPnP standard to describe external subs, but a few vendor extensions were created and they don't rely on directory enumeration (were added to Kodi as uPnP server by #6184).

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with minidlna, UMS, Gerbera and Kodi as uPnP servers and there was no delay when playing videos.

External subtitles work for Kodi uPnP client + server and don't for Kodi client + other server => no change

Not sure how to test that other clients can still get external subs from Kodi uPnP server (which client? other than Kodi). Breakage is very unlikely as no server code was modified.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

no unexpected delay when playing videos from uPnP sources.


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
