### PR TITLE
Bump Android NDK 26c 

### DIFF
--- a/docs/README.Android.md
+++ b/docs/README.Android.md
@@ -73,8 +73,8 @@ sudo apt install autoconf bison build-essential curl default-jdk flex gawk git g
 **[back to top](#table-of-contents)**
 
 ## 3. Prerequisites
-Building Kodi for Android requires Android NDK revision 20b. For the SDK just use the latest available.
-Kodi CI/CD platforms currently use r21e for build testing and releases, so we recommend using r21e for the most tested build experience
+Building Kodi for Android requires Android NDK revision 26c. For the SDK just use the latest available.
+Kodi CI/CD platforms currently use r26c for build testing and releases, so we recommend using r26c for the most tested build experience
 
 * **[Android SDK](https://developer.android.com/studio/index.html)** (Look for `Get just the command line tools`)
 
@@ -100,7 +100,7 @@ cd $HOME/android-tools/android-sdk-linux/cmdline-tools/bin
 ./sdkmanager --sdk_root=$(pwd)/../.. platform-tools
 ./sdkmanager --sdk_root=$(pwd)/../.. "platforms;android-34"
 ./sdkmanager --sdk_root=$(pwd)/../.. "build-tools;33.0.1"
-./sdkmanager --sdk_root=$(pwd)/../.. "ndk;21.4.7075529"
+./sdkmanager --sdk_root=$(pwd)/../.. "ndk;26.2.11394342"
 ```
 
 ### 3.3. Create a key to sign debug APKs
@@ -135,22 +135,22 @@ cd $HOME/kodi/tools/depends
 
 Configure build for aarch64:
 ```
-./configure --with-tarballs=$HOME/android-tools/xbmc-tarballs --host=aarch64-linux-android --with-sdk-path=$HOME/android-tools/android-sdk-linux --with-ndk-path=$HOME/android-tools/android-sdk-linux/ndk/21.4.7075529 --prefix=$HOME/android-tools/xbmc-depends
+./configure --with-tarballs=$HOME/android-tools/xbmc-tarballs --host=aarch64-linux-android --with-sdk-path=$HOME/android-tools/android-sdk-linux --with-ndk-path=$HOME/android-tools/android-sdk-linux/ndk/26.2.11394342 --prefix=$HOME/android-tools/xbmc-depends
 ```
 
 Or configure build for arm:
 ```
-./configure --with-tarballs=$HOME/android-tools/xbmc-tarballs --host=arm-linux-androideabi --with-sdk-path=$HOME/android-tools/android-sdk-linux --with-ndk-path=$HOME/android-tools/android-sdk-linux/ndk/21.4.7075529 --prefix=$HOME/android-tools/xbmc-depends
+./configure --with-tarballs=$HOME/android-tools/xbmc-tarballs --host=arm-linux-androideabi --with-sdk-path=$HOME/android-tools/android-sdk-linux --with-ndk-path=$HOME/android-tools/android-sdk-linux/ndk/26.2.11394342 --prefix=$HOME/android-tools/xbmc-depends
 ```
 
 Or configure build for x86:
 ```
-./configure --with-tarballs=$HOME/android-tools/xbmc-tarballs --host=i686-linux-android --with-sdk-path=$HOME/android-tools/android-sdk-linux --with-ndk-path=$HOME/android-tools/android-sdk-linux/ndk/21.4.7075529 --prefix=$HOME/android-tools/xbmc-depends
+./configure --with-tarballs=$HOME/android-tools/xbmc-tarballs --host=i686-linux-android --with-sdk-path=$HOME/android-tools/android-sdk-linux --with-ndk-path=$HOME/android-tools/android-sdk-linux/ndk/26.2.11394342 --prefix=$HOME/android-tools/xbmc-depends
 ```
 
 Or configure build for x86_64:
 ```
-./configure --with-tarballs=$HOME/android-tools/xbmc-tarballs --host=x86_64-linux-android --with-sdk-path=$HOME/android-tools/android-sdk-linux --with-ndk-path=$HOME/android-tools/android-sdk-linux/ndk/21.4.7075529 --prefix=$HOME/android-tools/xbmc-depends
+./configure --with-tarballs=$HOME/android-tools/xbmc-tarballs --host=x86_64-linux-android --with-sdk-path=$HOME/android-tools/android-sdk-linux --with-ndk-path=$HOME/android-tools/android-sdk-linux/ndk/26.2.11394342 --prefix=$HOME/android-tools/xbmc-depends
 ```
 
 > [!NOTE]  

--- a/tools/buildsteps/defaultenv
+++ b/tools/buildsteps/defaultenv
@@ -56,7 +56,7 @@ case $XBMC_PLATFORM_DIR in
     ;;
 
   android)
-    DEFAULT_NDK_VERSION="21e" # NDK package version (newer API can be inside)
+    DEFAULT_NDK_VERSION="26c" # NDK package version (newer API can be inside)
     DEFAULT_NDK_API="24" # Nougat API level (24) defined in package ./sysroot/usr/include/android/api-level.h
     DEFAULT_XBMC_DEPENDS_ROOT=$WORKSPACE/tools/depends/xbmc-depends
     DEFAULT_CONFIGURATION="RelWithDebInfo"

--- a/tools/depends/target/samba-gplv3/samba_android.patch
+++ b/tools/depends/target/samba-gplv3/samba_android.patch
@@ -1,36 +1,3 @@
---- a/lib/util/charset/iconv.c
-+++ b/lib/util/charset/iconv.c
-@@ -31,6 +31,10 @@
- #include <unicode/utrans.h>
- #endif
- 
-+#if defined(ANDROID) && (!defined(__ANDROID_API__) || __ANDROID_API__ < 28)
-+#include <byteswap.h>
-+#endif
-+
- #ifdef strcasecmp
- #undef strcasecmp
- #endif
-@@ -755,6 +755,19 @@
- 	return 0;
- }
- 
-+#if defined(ANDROID) && (!defined(__ANDROID_API__) || __ANDROID_API__ < 28)
-+void swab(const void *from, void*to, ssize_t n)
-+{
-+  ssize_t i;
-+
-+  if (n < 0)
-+    return;
-+
-+  for (i = 0; i < (n/2)*2; i += 2)
-+    *((uint16_t*)to+i) = bswap_16(*((uint16_t*)from+i));
-+}
-+#endif
-+
- static size_t iconv_swab(void *cd, const char **inbuf, size_t *inbytesleft,
- 			 char **outbuf, size_t *outbytesleft)
- {
 --- a/nsswitch/libwbclient/wbc_pwd.c
 +++ b/nsswitch/libwbclient/wbc_pwd.c
 @@ -46,7 +46,9 @@
@@ -97,14 +64,3 @@
  
  typedef struct winbindd_gr {
  	fstring gr_name;
---- a/lib/replace/wscript
-+++ b/lib/replace/wscript
-@@ -225,7 +225,7 @@
-                             headers='sys/socket.h netinet/in.h arpa/inet.h netdb.h')
-         conf.DEFINE('REPLACE_REQUIRES_LIBSOCKET_LIBNSL', 1)
- 
--    conf.CHECK_FUNCS('memset_s memset_explicit')
-+    conf.undefine('HAVE_MEMSET_EXPLICIT')
- 
-     conf.CHECK_CODE('''
-                     #include <string.h>

--- a/tools/depends/target/samba/samba_android.patch
+++ b/tools/depends/target/samba/samba_android.patch
@@ -9,40 +9,6 @@
  	/* On Linux we lose the ability to dump core when we change our user
  	 * ID. We know how to dump core safely, so let's make sure we have our
  	 * dumpable flag set.
---- a/source/lib/iconv.c
-+++ b/source/lib/iconv.c
-@@ -20,7 +20,10 @@
- */
- 
- #include "includes.h"
--
-+#if defined(ANDROID)
-+#include <stdint.h>
-+#include <asm/byteorder.h>
-+#endif
- /*
-  * We have to use strcasecmp here as the character conversions
-  * haven't been initialised yet. JRA.
-@@ -489,6 +492,19 @@
- 	return 0;
- }
- 
-+#if defined(ANDROID)
-+void swab(const void *from, void*to, ssize_t n)
-+{
-+  ssize_t i;
-+
-+  if (n < 0)
-+    return;
-+
-+  for (i = 0; i < (n/2)*2; i += 2)
-+    *((uint16_t*)to+i) = __arch__swab16(*((uint16_t*)from+i));
-+}
-+#endif
-+
- static size_t iconv_swab(void *cd, const char **inbuf, size_t *inbytesleft,
- 			 char **outbuf, size_t *outbytesleft)
- {
 --- a/source/lib/replace/system/passwd.h
 +++ b/source/lib/replace/system/passwd.h
 @@ -62,6 +62,8 @@


### PR DESCRIPTION
## Description
Continued from #22116

~~Changes in Thread.cpp to fix ftello() undeclared identifier error if `__USE_FILE_OFFSET64` and `__ANDROID_API__ < 24`~~

Note: need param `NDK_VERSION=26.2.11394342` in jenkins config for the android builders

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
