### PR TITLE
[Android] Set minimum API level to 24

### DIFF
--- a/cmake/platform/android/android.cmake
+++ b/cmake/platform/android/android.cmake
@@ -6,6 +6,6 @@ list(APPEND PLATFORM_OPTIONAL_DEPS LibDovi)
 # Store SDK compile version
 set(TARGET_SDK 34)
 # Minimum supported SDK version
-set(TARGET_MINSDK 21)
+set(TARGET_MINSDK 24)
 
 set(${CORE_PLATFORM_NAME_LC}_SEARCH_CONFIG NO_DEFAULT_PATH CACHE STRING "")

--- a/docs/README.Android.md
+++ b/docs/README.Android.md
@@ -238,7 +238,7 @@ make -j$(getconf _NPROCESSORS_ONLN)
 ```
 --with-ndk-api=<ndk number>
 ```
-  specify ndk level (optional for android), default is 21.]
+  specify ndk level (optional for android), default is 24.]
 
 ```
 --with-ndk-path=<path>

--- a/tools/android/packaging/xbmc/src/Splash.java.in
+++ b/tools/android/packaging/xbmc/src/Splash.java.in
@@ -397,11 +397,7 @@ public class Splash extends Activity
     AlertDialog.Builder builder = new AlertDialog.Builder(act);
     builder.setTitle(title);
     builder.setIcon(android.R.drawable.ic_dialog_alert);
-    if (Build.VERSION.SDK_INT >= 24) {
-      builder.setMessage(Html.fromHtml(message, Html.FROM_HTML_MODE_LEGACY));
-    } else {
-      builder.setMessage(Html.fromHtml(message));
-    }
+    builder.setMessage(Html.fromHtml(message, Html.FROM_HTML_MODE_LEGACY));
     builder.setPositiveButton("Exit", (dialog, arg1) -> {
       dialog.dismiss();
       act.finish();
@@ -514,16 +510,13 @@ public class Splash extends Activity
         retVal = true;
       }
     }
-    else if (Build.VERSION.SDK_INT > 22)
+    else
     {
       int permissionCheck;
       permissionCheck = checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE);
       if (permissionCheck == PERMISSION_GRANTED)
         retVal = true;
     }
-    else
-      retVal=  true;
-
     return retVal;
   }
 

--- a/tools/buildsteps/defaultenv
+++ b/tools/buildsteps/defaultenv
@@ -57,7 +57,7 @@ case $XBMC_PLATFORM_DIR in
 
   android)
     DEFAULT_NDK_VERSION="21e" # NDK package version (newer API can be inside)
-    DEFAULT_NDK_API="21" # Lollipop API level (21) defined in package ./sysroot/usr/include/android/api-level.h
+    DEFAULT_NDK_API="24" # Nougat API level (24) defined in package ./sysroot/usr/include/android/api-level.h
     DEFAULT_XBMC_DEPENDS_ROOT=$WORKSPACE/tools/depends/xbmc-depends
     DEFAULT_CONFIGURATION="RelWithDebInfo"
     ;;

--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -87,9 +87,9 @@ AC_ARG_WITH([sdk],
 
 AC_ARG_WITH([ndk-api],
   [AS_HELP_STRING([--with-ndk-api],
-  [specify ndk level (optional for android), default is 21.])],
+  [specify ndk level (optional for android), default is 24.])],
   [use_ndk_api=$withval],
-  [use_ndk_api=21])
+  [use_ndk_api=24])
 
 AC_ARG_ENABLE([gplv3],
   [AS_HELP_STRING([--enable-gplv3],

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -162,7 +162,8 @@ int CAESinkAUDIOTRACK::AudioTrackWrite(char* audioData, int offsetInBytes, int s
     if (m_floatbuf.size() != (sizeInBytes - offsetInBytes) / sizeof(float))
       m_floatbuf.resize((sizeInBytes - offsetInBytes) / sizeof(float));
     memcpy(m_floatbuf.data(), audioData + offsetInBytes, sizeInBytes - offsetInBytes);
-    written = m_at_jni->write(m_floatbuf, 0, (sizeInBytes - offsetInBytes) / sizeof(float), CJNIAudioTrack::WRITE_BLOCKING);
+    written = m_at_jni->write(m_floatbuf, 0, (sizeInBytes - offsetInBytes) / sizeof(float),
+                              CJNIAudioTrack::WRITE_BLOCKING);
     written *= sizeof(float);
   }
   else if (m_jniAudioFormat == CJNIAudioFormat::ENCODING_IEC61937)
@@ -170,10 +171,8 @@ int CAESinkAUDIOTRACK::AudioTrackWrite(char* audioData, int offsetInBytes, int s
     if (m_shortbuf.size() != (sizeInBytes - offsetInBytes) / sizeof(int16_t))
       m_shortbuf.resize((sizeInBytes - offsetInBytes) / sizeof(int16_t));
     memcpy(m_shortbuf.data(), audioData + offsetInBytes, sizeInBytes - offsetInBytes);
-    if (CJNIBase::GetSDKVersion() >= 23)
-      written = m_at_jni->write(m_shortbuf, 0, (sizeInBytes - offsetInBytes) / sizeof(int16_t), CJNIAudioTrack::WRITE_BLOCKING);
-    else
-      written = m_at_jni->write(m_shortbuf, 0, (sizeInBytes - offsetInBytes) / sizeof(int16_t));
+    written = m_at_jni->write(m_shortbuf, 0, (sizeInBytes - offsetInBytes) / sizeof(int16_t),
+                              CJNIAudioTrack::WRITE_BLOCKING);
     written *= sizeof(uint16_t);
   }
   else
@@ -181,10 +180,8 @@ int CAESinkAUDIOTRACK::AudioTrackWrite(char* audioData, int offsetInBytes, int s
     if (static_cast<int>(m_charbuf.size()) != (sizeInBytes - offsetInBytes))
       m_charbuf.resize(sizeInBytes - offsetInBytes);
     memcpy(m_charbuf.data(), audioData + offsetInBytes, sizeInBytes - offsetInBytes);
-    if (CJNIBase::GetSDKVersion() >= 23)
-      written = m_at_jni->write(m_charbuf, 0, sizeInBytes - offsetInBytes, CJNIAudioTrack::WRITE_BLOCKING);
-    else
-      written = m_at_jni->write(m_charbuf, 0, sizeInBytes - offsetInBytes);
+    written =
+        m_at_jni->write(m_charbuf, 0, sizeInBytes - offsetInBytes, CJNIAudioTrack::WRITE_BLOCKING);
   }
 
   return written;
@@ -1119,26 +1116,23 @@ void CAESinkAUDIOTRACK::UpdateAvailablePassthroughCapabilities(bool isRaw)
       }
     }
 
-    if (CJNIAudioManager::GetSDKVersion() >= 23)
+    if (CJNIAudioFormat::ENCODING_DTS_HD != -1)
     {
-      if (CJNIAudioFormat::ENCODING_DTS_HD != -1)
+      if (VerifySinkConfiguration(48000, AEChannelMapToAUDIOTRACKChannelMask(AE_CH_LAYOUT_7_1),
+                                  CJNIAudioFormat::ENCODING_DTS_HD, true))
       {
-        if (VerifySinkConfiguration(48000, AEChannelMapToAUDIOTRACKChannelMask(AE_CH_LAYOUT_7_1),
-                                    CJNIAudioFormat::ENCODING_DTS_HD, true))
-        {
-          CLog::Log(LOGDEBUG, "Firmware implements DTS-HD RAW");
-          m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD);
-          m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD_MA);
-        }
+        CLog::Log(LOGDEBUG, "Firmware implements DTS-HD RAW");
+        m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD);
+        m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD_MA);
       }
-      if (CJNIAudioFormat::ENCODING_DOLBY_TRUEHD != -1)
+    }
+    if (CJNIAudioFormat::ENCODING_DOLBY_TRUEHD != -1)
+    {
+      if (VerifySinkConfiguration(48000, AEChannelMapToAUDIOTRACKChannelMask(AE_CH_LAYOUT_7_1),
+                                  CJNIAudioFormat::ENCODING_DOLBY_TRUEHD, true))
       {
-        if (VerifySinkConfiguration(48000, AEChannelMapToAUDIOTRACKChannelMask(AE_CH_LAYOUT_7_1),
-                                    CJNIAudioFormat::ENCODING_DOLBY_TRUEHD, true))
-        {
-          CLog::Log(LOGDEBUG, "Firmware implements TrueHD RAW");
-          m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_TRUEHD);
-        }
+        CLog::Log(LOGDEBUG, "Firmware implements TrueHD RAW");
+        m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_TRUEHD);
       }
     }
   }
@@ -1200,10 +1194,9 @@ void CAESinkAUDIOTRACK::UpdateAvailablePCMCapabilities()
   int encoding = CJNIAudioFormat::ENCODING_PCM_16BIT;
   m_sinkSupportsFloat = VerifySinkConfiguration(native_sampleRate, CJNIAudioFormat::CHANNEL_OUT_STEREO, CJNIAudioFormat::ENCODING_PCM_FLOAT);
 
-  if (CJNIAudioManager::GetSDKVersion() >= 21)
-    m_sinkSupportsMultiChannelFloat =
-        VerifySinkConfiguration(native_sampleRate, CJNIAudioFormat::CHANNEL_OUT_7POINT1_SURROUND,
-                                CJNIAudioFormat::ENCODING_PCM_FLOAT);
+  m_sinkSupportsMultiChannelFloat =
+      VerifySinkConfiguration(native_sampleRate, CJNIAudioFormat::CHANNEL_OUT_7POINT1_SURROUND,
+                              CJNIAudioFormat::ENCODING_PCM_FLOAT);
 
   if (m_sinkSupportsFloat)
   {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -353,14 +353,10 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
     CLog::Log(LOGERROR, "CDVDVideoCodecAndroidMediaCodec::Open - {}", "null size, cannot handle");
     goto FAIL;
   }
-  else if (hints.orientation && m_render_surface && CJNIBase::GetSDKVersion() < 23)
-  {
-    CLog::Log(LOGERROR, "CDVDVideoCodecAndroidMediaCodec::Open - {}",
-              "Surface does not support orientation before API 23");
-    goto FAIL;
-  }
-  else if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_VIDEOPLAYER_USEMEDIACODEC) &&
-           !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_VIDEOPLAYER_USEMEDIACODECSURFACE))
+  else if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+               CSettings::SETTING_VIDEOPLAYER_USEMEDIACODEC) &&
+           !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+               CSettings::SETTING_VIDEOPLAYER_USEMEDIACODECSURFACE))
     goto FAIL;
 
   CLog::Log(
@@ -553,44 +549,41 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
           m_formatname = isDvhe ? "amc-dvhe" : "amc-dvh1";
           profile = 0; // not an HEVC profile
 
-          if (CJNIBase::GetSDKVersion() >= 24)
+          switch (m_hints.dovi.dv_profile)
           {
-            switch (m_hints.dovi.dv_profile)
-            {
-              case 0:
-              case 1:
-              case 2:
-              case 3:
-              case 6:
-                // obsolete profiles that are not supported in current applications.
-                // 0 is ignored in case the AVDOVIDecoderConfigurationRecord hint is unset.
-                break;
-              case 4:
-                profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheDtr;
-                break;
-              case 5:
-                profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheStn;
-                break;
-              case 7:
-                // set profile 8 when converting
-                if (convertDovi && CJNIBase::GetSDKVersion() >= 27)
-                  profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheSt;
+            case 0:
+            case 1:
+            case 2:
+            case 3:
+            case 6:
+              // obsolete profiles that are not supported in current applications.
+              // 0 is ignored in case the AVDOVIDecoderConfigurationRecord hint is unset.
+              break;
+            case 4:
+              profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheDtr;
+              break;
+            case 5:
+              profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheStn;
+              break;
+            case 7:
+              // set profile 8 when converting
+              if (convertDovi && CJNIBase::GetSDKVersion() >= 27)
+                profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheSt;
 
-                // Profile 7 is not commonly supported. Not setting the profile here
-                // allows to pick the first available Dolby Vision codec.
-                // profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheDtb;
-                break;
-              case 8:
-                if (CJNIBase::GetSDKVersion() >= 27)
-                  profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheSt;
-                break;
-              case 9:
-                if (CJNIBase::GetSDKVersion() >= 27)
-                  profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvavSe;
-                break;
-              default:
-                break;
-            }
+              // Profile 7 is not commonly supported. Not setting the profile here
+              // allows to pick the first available Dolby Vision codec.
+              // profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheDtb;
+              break;
+            case 8:
+              if (CJNIBase::GetSDKVersion() >= 27)
+                profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvheSt;
+              break;
+            case 9:
+              if (CJNIBase::GetSDKVersion() >= 27)
+                profile = CJNIMediaCodecInfoCodecProfileLevel::DolbyVisionProfileDvavSe;
+              break;
+            default:
+              break;
           }
         }
       }
@@ -1476,7 +1469,7 @@ bool CDVDVideoCodecAndroidMediaCodec::ConfigureMediaCodec(void)
       CJNIMediaFormat::createVideoFormat(m_mime, m_hints.width, m_hints.height);
   mediaformat.setInteger(CJNIMediaFormat::KEY_MAX_INPUT_SIZE, 0);
 
-  if (CJNIBase::GetSDKVersion() >= 23 && m_render_surface)
+  if (m_render_surface)
   {
     // Handle rotation
     mediaformat.setInteger(CJNIMediaFormat::KEY_ROTATION, m_hints.orientation);
@@ -1487,89 +1480,86 @@ bool CDVDVideoCodecAndroidMediaCodec::ConfigureMediaCodec(void)
                                     true);
   }
 
-  if (CJNIBase::GetSDKVersion() >= 24)
+  switch (m_hints.colorRange)
   {
-    switch (m_hints.colorRange)
-    {
-      case AVCOL_RANGE_UNSPECIFIED:
-        CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::ConfigureMediaCodec Color range: "
-                            "AVCOL_RANGE_UNSPECIFIED");
-        break;
-      case AVCOL_RANGE_MPEG:
-        mediaformat.setInteger(CJNIMediaFormat::KEY_COLOR_RANGE,
-                               CJNIMediaFormat::COLOR_RANGE_LIMITED);
-        break;
-      case AVCOL_RANGE_JPEG:
-        mediaformat.setInteger(CJNIMediaFormat::KEY_COLOR_RANGE, CJNIMediaFormat::COLOR_RANGE_FULL);
-        break;
-      default:
-        CLog::Log(LOGWARNING,
-                  "CDVDVideoCodecAndroidMediaCodec::ConfigureMediaCodec Unhandled Color range: {}",
-                  m_hints.colorRange);
-        break;
-    }
+    case AVCOL_RANGE_UNSPECIFIED:
+      CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::ConfigureMediaCodec Color range: "
+                          "AVCOL_RANGE_UNSPECIFIED");
+      break;
+    case AVCOL_RANGE_MPEG:
+      mediaformat.setInteger(CJNIMediaFormat::KEY_COLOR_RANGE,
+                             CJNIMediaFormat::COLOR_RANGE_LIMITED);
+      break;
+    case AVCOL_RANGE_JPEG:
+      mediaformat.setInteger(CJNIMediaFormat::KEY_COLOR_RANGE, CJNIMediaFormat::COLOR_RANGE_FULL);
+      break;
+    default:
+      CLog::Log(LOGWARNING,
+                "CDVDVideoCodecAndroidMediaCodec::ConfigureMediaCodec Unhandled Color range: {}",
+                m_hints.colorRange);
+      break;
+  }
 
-    switch (m_hints.colorPrimaries)
-    {
-      case AVCOL_PRI_UNSPECIFIED:
-        CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::ConfigureMediaCodec Color primaries: "
-                            "AVCOL_PRI_UNSPECIFIED");
-        break;
-      case AVCOL_PRI_BT709:
-        mediaformat.setInteger(CJNIMediaFormat::KEY_COLOR_STANDARD,
-                               CJNIMediaFormat::COLOR_STANDARD_BT709);
-        break;
-      case AVCOL_PRI_BT2020:
-        mediaformat.setInteger(CJNIMediaFormat::KEY_COLOR_STANDARD,
-                               CJNIMediaFormat::COLOR_STANDARD_BT2020);
-        break;
-      default:
-        CLog::Log(
-            LOGWARNING,
-            "CDVDVideoCodecAndroidMediaCodec::ConfigureMediaCodec Unhandled Color primaries: {}",
-            m_hints.colorPrimaries);
-        break;
-    }
+  switch (m_hints.colorPrimaries)
+  {
+    case AVCOL_PRI_UNSPECIFIED:
+      CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::ConfigureMediaCodec Color primaries: "
+                          "AVCOL_PRI_UNSPECIFIED");
+      break;
+    case AVCOL_PRI_BT709:
+      mediaformat.setInteger(CJNIMediaFormat::KEY_COLOR_STANDARD,
+                             CJNIMediaFormat::COLOR_STANDARD_BT709);
+      break;
+    case AVCOL_PRI_BT2020:
+      mediaformat.setInteger(CJNIMediaFormat::KEY_COLOR_STANDARD,
+                             CJNIMediaFormat::COLOR_STANDARD_BT2020);
+      break;
+    default:
+      CLog::Log(
+          LOGWARNING,
+          "CDVDVideoCodecAndroidMediaCodec::ConfigureMediaCodec Unhandled Color primaries: {}",
+          m_hints.colorPrimaries);
+      break;
+  }
 
-    switch (m_hints.colorTransferCharacteristic)
-    {
-      case AVCOL_TRC_UNSPECIFIED:
-        CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::ConfigureMediaCodec Transfer "
-                            "characteristic: AVCOL_TRC_UNSPECIFIED");
-        break;
-      case AVCOL_TRC_LINEAR:
-        mediaformat.setInteger(CJNIMediaFormat::KEY_COLOR_TRANSFER,
-                               CJNIMediaFormat::COLOR_TRANSFER_LINEAR);
-        break;
-      case AVCOL_TRC_BT709:
-      case AVCOL_TRC_SMPTE170M:
-        mediaformat.setInteger(CJNIMediaFormat::KEY_COLOR_TRANSFER,
-                               CJNIMediaFormat::COLOR_TRANSFER_SDR_VIDEO);
-        break;
-      case AVCOL_TRC_SMPTE2084:
-        mediaformat.setInteger(CJNIMediaFormat::KEY_COLOR_TRANSFER,
-                               CJNIMediaFormat::COLOR_TRANSFER_ST2084);
-        break;
-      case AVCOL_TRC_ARIB_STD_B67:
-        mediaformat.setInteger(CJNIMediaFormat::KEY_COLOR_TRANSFER,
-                               CJNIMediaFormat::COLOR_TRANSFER_HLG);
-        break;
-      default:
-        CLog::Log(LOGWARNING,
-                  "CDVDVideoCodecAndroidMediaCodec::ConfigureMediaCodec Unhandled Transfer "
-                  "characteristic: {}",
-                  m_hints.colorTransferCharacteristic);
-        break;
-    }
+  switch (m_hints.colorTransferCharacteristic)
+  {
+    case AVCOL_TRC_UNSPECIFIED:
+      CLog::Log(LOGDEBUG, "CDVDVideoCodecAndroidMediaCodec::ConfigureMediaCodec Transfer "
+                          "characteristic: AVCOL_TRC_UNSPECIFIED");
+      break;
+    case AVCOL_TRC_LINEAR:
+      mediaformat.setInteger(CJNIMediaFormat::KEY_COLOR_TRANSFER,
+                             CJNIMediaFormat::COLOR_TRANSFER_LINEAR);
+      break;
+    case AVCOL_TRC_BT709:
+    case AVCOL_TRC_SMPTE170M:
+      mediaformat.setInteger(CJNIMediaFormat::KEY_COLOR_TRANSFER,
+                             CJNIMediaFormat::COLOR_TRANSFER_SDR_VIDEO);
+      break;
+    case AVCOL_TRC_SMPTE2084:
+      mediaformat.setInteger(CJNIMediaFormat::KEY_COLOR_TRANSFER,
+                             CJNIMediaFormat::COLOR_TRANSFER_ST2084);
+      break;
+    case AVCOL_TRC_ARIB_STD_B67:
+      mediaformat.setInteger(CJNIMediaFormat::KEY_COLOR_TRANSFER,
+                             CJNIMediaFormat::COLOR_TRANSFER_HLG);
+      break;
+    default:
+      CLog::Log(LOGWARNING,
+                "CDVDVideoCodecAndroidMediaCodec::ConfigureMediaCodec Unhandled Transfer "
+                "characteristic: {}",
+                m_hints.colorTransferCharacteristic);
+      break;
+  }
 
-    std::vector<uint8_t> hdr_static_data = GetHDRStaticMetadata();
-    if (!hdr_static_data.empty())
-    {
-      CJNIByteBuffer bytebuffer = CJNIByteBuffer::allocateDirect(hdr_static_data.size());
-      void* dts_ptr = xbmc_jnienv()->GetDirectBufferAddress(bytebuffer.get_raw());
-      memcpy(dts_ptr, hdr_static_data.data(), hdr_static_data.size());
-      mediaformat.setByteBuffer(CJNIMediaFormat::KEY_HDR_STATIC_INFO, bytebuffer);
-    }
+  std::vector<uint8_t> hdr_static_data = GetHDRStaticMetadata();
+  if (!hdr_static_data.empty())
+  {
+    CJNIByteBuffer bytebuffer = CJNIByteBuffer::allocateDirect(hdr_static_data.size());
+    void* dts_ptr = xbmc_jnienv()->GetDirectBufferAddress(bytebuffer.get_raw());
+    memcpy(dts_ptr, hdr_static_data.data(), hdr_static_data.size());
+    mediaformat.setByteBuffer(CJNIMediaFormat::KEY_HDR_STATIC_INFO, bytebuffer);
   }
 
   // handle codec extradata
@@ -1740,14 +1730,10 @@ void CDVDVideoCodecAndroidMediaCodec::ConfigureOutputFormat(CJNIMediaFormat& med
     height = mediaformat.getInteger(CJNIMediaFormat::KEY_HEIGHT);
   if (mediaformat.containsKey(CJNIMediaFormat::KEY_COLOR_FORMAT))
     color_format = mediaformat.getInteger(CJNIMediaFormat::KEY_COLOR_FORMAT);
-
-  if (CJNIBase::GetSDKVersion() >= 23)
-  {
-    if (mediaformat.containsKey(CJNIMediaFormat::KEY_STRIDE))
-      stride = mediaformat.getInteger(CJNIMediaFormat::KEY_STRIDE);
-    if (mediaformat.containsKey(CJNIMediaFormat::KEY_SLICE_HEIGHT))
-      slice_height = mediaformat.getInteger(CJNIMediaFormat::KEY_SLICE_HEIGHT);
-  }
+  if (mediaformat.containsKey(CJNIMediaFormat::KEY_STRIDE))
+    stride = mediaformat.getInteger(CJNIMediaFormat::KEY_STRIDE);
+  if (mediaformat.containsKey(CJNIMediaFormat::KEY_SLICE_HEIGHT))
+    slice_height = mediaformat.getInteger(CJNIMediaFormat::KEY_SLICE_HEIGHT);
 
   if (CJNIBase::GetSDKVersion() >= 33)
   {

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -55,7 +55,6 @@
 
 #include "platform/android/activity/IInputDeviceCallbacks.h"
 #include "platform/android/activity/IInputDeviceEventHandler.h"
-#include "platform/android/network/NetworkAndroid.h"
 #include "platform/android/powermanagement/AndroidPowerSyscall.h"
 
 #include <memory>
@@ -1411,18 +1410,6 @@ void CXBMCApp::onReceive(CJNIIntent intent)
       CAndroidKey::XBMC_Key(keycode, XBMCK_MEDIA_REWIND, 0, 0, up);
     else if (keycode == CJNIKeyEvent::KEYCODE_MEDIA_STOP)
       CAndroidKey::XBMC_Key(keycode, XBMCK_MEDIA_STOP, 0, 0, up);
-  }
-  else if (action == CJNIConnectivityManager::CONNECTIVITY_ACTION)
-  {
-    if (g_application.IsInitialized())
-    {
-      if (CJNIBase::GetSDKVersion() < 24)
-      {
-        CNetworkBase& net = CServiceBroker::GetNetwork();
-        CNetworkAndroid* netdroid = static_cast<CNetworkAndroid*>(&net);
-        netdroid->RetrieveInterfaces();
-      }
-    }
   }
 }
 

--- a/xbmc/platform/android/network/NetworkAndroid.cpp
+++ b/xbmc/platform/android/network/NetworkAndroid.cpp
@@ -237,11 +237,8 @@ CNetworkAndroid::CNetworkAndroid() : CNetworkBase(), CJNIXBMCConnectivityManager
 {
   RetrieveInterfaces();
 
-  if (CJNIBase::GetSDKVersion() >= 24)
-  {
-    CJNIConnectivityManager connman{CXBMCApp::getSystemService(CJNIContext::CONNECTIVITY_SERVICE)};
-    connman.registerDefaultNetworkCallback(this->get_raw());
-  }
+  CJNIConnectivityManager connman{CXBMCApp::getSystemService(CJNIContext::CONNECTIVITY_SERVICE)};
+  connman.registerDefaultNetworkCallback(this->get_raw());
 }
 
 CNetworkAndroid::~CNetworkAndroid()
@@ -251,11 +248,8 @@ CNetworkAndroid::~CNetworkAndroid()
   for (auto intf : m_oldInterfaces)
     delete intf;
 
-  if (CJNIBase::GetSDKVersion() >= 24)
-  {
-    CJNIConnectivityManager connman{CXBMCApp::getSystemService(CJNIContext::CONNECTIVITY_SERVICE)};
-    connman.unregisterNetworkCallback(this->get_raw());
-  }
+  CJNIConnectivityManager connman{CXBMCApp::getSystemService(CJNIContext::CONNECTIVITY_SERVICE)};
+  connman.unregisterNetworkCallback(this->get_raw());
 }
 
 bool CNetworkAndroid::GetHostName(std::string& hostname)

--- a/xbmc/windowing/android/AndroidUtils.cpp
+++ b/xbmc/windowing/android/AndroidUtils.cpp
@@ -145,16 +145,13 @@ CAndroidUtils::CAndroidUtils()
   std::string displaySize;
   m_width = m_height = 0;
 
-  if (CJNIBase::GetSDKVersion() >= 23)
+  fetchDisplayModes();
+  for (const RESOLUTION_INFO& res : s_res_displayModes)
   {
-    fetchDisplayModes();
-    for (const RESOLUTION_INFO& res : s_res_displayModes)
+    if (res.iWidth > m_width || res.iHeight > m_height)
     {
-      if (res.iWidth > m_width || res.iHeight > m_height)
-      {
-        m_width = res.iWidth;
-        m_height = res.iHeight;
-      }
+      m_width = res.iWidth;
+      m_height = res.iHeight;
     }
   }
 
@@ -333,8 +330,7 @@ bool CAndroidUtils::ProbeResolutions(std::vector<RESOLUTION_INFO>& resolutions)
 
 bool CAndroidUtils::UpdateDisplayModes()
 {
-  if (CJNIBase::GetSDKVersion() >= 23)
-    fetchDisplayModes();
+  fetchDisplayModes();
   return true;
 }
 


### PR DESCRIPTION
## Description
The minimum API level required for the app to run will be 24 (Android 7.0).

Also remove the related backward compatibility code.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
