### PR TITLE
Start moving video fileitem classifiers to separate file

### DIFF
--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -31,6 +31,7 @@
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingDefinitions.h"
+#include "video/VideoFileItemClassify.h"
 
 #include <stdlib.h>
 #ifndef TARGET_WINDOWS
@@ -51,6 +52,7 @@
 using namespace XFILE;
 using namespace MEDIA_DETECT;
 using namespace KODI::MESSAGING;
+using namespace KODI::VIDEO;
 using namespace std::chrono_literals;
 
 using KODI::MESSAGING::HELPERS::DialogResponse;
@@ -399,7 +401,7 @@ bool CAutorun::RunDisc(IDirectory* pDir, const std::string& strDrive, int& nAdde
     for (int i = 0; i < tempItems.Size(); i++)
     {
       CFileItemPtr pItem = tempItems[i];
-      if (!pItem->m_bIsFolder && pItem->IsVideo())
+      if (!pItem->m_bIsFolder && IsVideo(*pItem))
       {
         bPlaying = true;
         if (pItem->IsStack())

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -156,13 +156,6 @@ public:
 
   bool Exists(bool bUseCache = true) const;
 
-  /*!
-   \brief Check whether an item is a video item. Note that this returns true for
-    anything with a video info tag, so that may include eg. folders.
-   \return true if item is video, false otherwise.
-   */
-  bool IsVideo() const;
-
   bool IsDiscStub() const;
 
   /*!

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -37,9 +37,11 @@
 #include "utils/Variant.h"
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
+#include "video/VideoFileItemClassify.h"
 
 using namespace PLAYLIST;
 using namespace KODI::MESSAGING;
+using namespace KODI::VIDEO;
 
 CPlayListPlayer::CPlayListPlayer(void)
 {
@@ -266,7 +268,7 @@ bool CPlayListPlayer::PlayItemIdx(int itemIdx)
 bool CPlayListPlayer::Play(const CFileItemPtr& pItem, const std::string& player)
 {
   Id playlistId;
-  bool isVideo{pItem->IsVideo()};
+  bool isVideo{IsVideo(*pItem)};
   bool isAudio{pItem->IsAudio()};
 
   if (isAudio && !isVideo)
@@ -949,7 +951,7 @@ void PLAYLIST::CPlayListPlayer::OnApplicationMessage(KODI::MESSAGING::ThreadMess
         Id playlistId = TYPE_MUSIC;
         for (int i = 0; i < list->Size(); i++)
         {
-          if ((*list)[i]->IsVideo())
+          if (IsVideo(*list->Get(i)))
           {
             playlistId = TYPE_VIDEO;
             break;
@@ -967,7 +969,7 @@ void PLAYLIST::CPlayListPlayer::OnApplicationMessage(KODI::MESSAGING::ThreadMess
           {
             return;
           }
-          if (item->IsAudio() || item->IsVideo())
+          if (item->IsAudio() || IsVideo(*item))
             Play(item, pMsg->strParam);
           else
             g_application.PlayMedia(*item, pMsg->strParam, playlistId);

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "network/Network.h"
+#include "video/VideoFileItemClassify.h"
 #if defined(TARGET_DARWIN)
 #include <sys/param.h>
 #include <mach-o/dyld.h>
@@ -92,6 +93,7 @@ using namespace MEDIA_DETECT;
 using namespace XFILE;
 using namespace PLAYLIST;
 using KODI::UTILITY::CDigest;
+using namespace KODI::VIDEO;
 
 #if !defined(TARGET_WINDOWS)
 unsigned int CUtil::s_randomSeed = time(NULL);
@@ -2054,10 +2056,8 @@ void CUtil::ScanForExternalSubtitles(const std::string& strMovie, std::vector<st
   auto start = std::chrono::steady_clock::now();
 
   CFileItem item(strMovie, false);
-  if ((item.IsInternetStream() && !URIUtils::IsOnLAN(item.GetDynPath()))
-    || item.IsPlayList()
-    || item.IsLiveTV()
-    || !item.IsVideo())
+  if ((item.IsInternetStream() && !URIUtils::IsOnLAN(item.GetDynPath())) || item.IsPlayList() ||
+      item.IsLiveTV() || !IsVideo(item))
     return;
 
   CLog::Log(LOGDEBUG, "{}: Searching for subtitles...", __FUNCTION__);
@@ -2346,11 +2346,8 @@ std::string CUtil::GetVobSubIdxFromSub(const std::string& vobSub)
 void CUtil::ScanForExternalAudio(const std::string& videoPath, std::vector<std::string>& vecAudio)
 {
   CFileItem item(videoPath, false);
-  if ( item.IsInternetStream()
-   ||  item.IsPlayList()
-   ||  item.IsLiveTV()
-   ||  item.IsPVR()
-   || !item.IsVideo())
+  if (item.IsInternetStream() || item.IsPlayList() || item.IsLiveTV() || item.IsPVR() ||
+      !IsVideo(item))
     return;
 
   std::string strBasePath;

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -60,6 +60,7 @@
 #include "filesystem/DirectoryFactory.h"
 #include "filesystem/DllLibCurl.h"
 #include "filesystem/File.h"
+#include "video/VideoFileItemClassify.h"
 #ifdef HAS_FILESYSTEM_NFS
 #include "filesystem/NFSFile.h"
 #endif
@@ -198,6 +199,7 @@ using namespace PVR;
 using namespace PERIPHERALS;
 using namespace KODI;
 using namespace KODI::MESSAGING;
+using namespace KODI::VIDEO;
 using namespace ActiveAE;
 
 using namespace XbmcThreads;
@@ -2301,7 +2303,7 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
     m_nextPlaylistItem = -1;
     stackHelper->Clear();
 
-    if (item.IsVideo())
+    if (IsVideo(item))
       CUtil::ClearSubtitles();
   }
 
@@ -2346,7 +2348,7 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
   {
     // the following code block is only applicable when bRestart is false OR to ISO stacks
 
-    if (item.IsVideo())
+    if (IsVideo(item))
     {
       // open the d/b and retrieve the bookmarks for the current movie
       CVideoDatabase dbs;
@@ -2458,7 +2460,7 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
         CSettings::SETTING_MUSICFILES_SELECTACTION) &&
         !CMediaSettings::GetInstance().DoesMediaStartWindowed();
   }
-  else if (item.IsVideo() && playlistId == PLAYLIST::TYPE_VIDEO &&
+  else if (IsVideo(item) && playlistId == PLAYLIST::TYPE_VIDEO &&
            CServiceBroker::GetPlaylistPlayer().GetPlaylist(playlistId).size() > 1)
   { // playing from a playlist by the looks
     // don't switch to fullscreen if we are not playing the first item...
@@ -2783,9 +2785,9 @@ bool CApplication::OnMessage(CGUIMessage& message)
       bool bNothingToQueue = false;
 
       const auto appPlayer = GetComponent<CApplicationPlayer>();
-      if (!file.IsVideo() && appPlayer->IsPlayingVideo())
+      if (!IsVideo(file) && appPlayer->IsPlayingVideo())
         bNothingToQueue = true;
-      else if ((!file.IsAudio() || file.IsVideo()) && appPlayer->IsPlayingAudio())
+      else if ((!file.IsAudio() || IsVideo(file)) && appPlayer->IsPlayingAudio())
         bNothingToQueue = true;
 
       if (bNothingToQueue)
@@ -3053,7 +3055,7 @@ bool CApplication::ExecuteXBMCAction(std::string actionStr,
     }
     else
 #endif
-    if (item.IsAudio() || item.IsVideo() || item.IsGame())
+        if (item.IsAudio() || IsVideo(item) || item.IsGame())
     { // an audio or video file
       PlayFile(item, "");
     }
@@ -3174,10 +3176,8 @@ void CApplication::ProcessSlow()
 
   // Temporarily pause pausable jobs when viewing video/picture
   int currentWindow = CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow();
-  if (CurrentFileItem().IsVideo() ||
-      CurrentFileItem().IsPicture() ||
-      currentWindow == WINDOW_FULLSCREEN_VIDEO ||
-      currentWindow == WINDOW_FULLSCREEN_GAME ||
+  if (IsVideo(CurrentFileItem()) || CurrentFileItem().IsPicture() ||
+      currentWindow == WINDOW_FULLSCREEN_VIDEO || currentWindow == WINDOW_FULLSCREEN_GAME ||
       currentWindow == WINDOW_SLIDESHOW)
   {
     CServiceBroker::GetJobManager()->PauseJobs();

--- a/xbmc/application/ApplicationPlayerCallback.cpp
+++ b/xbmc/application/ApplicationPlayerCallback.cpp
@@ -32,9 +32,12 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
+#include "video/VideoFileItemClassify.h"
 #include "video/VideoInfoTag.h"
 
 #include <memory>
+
+using namespace KODI::VIDEO;
 
 CApplicationPlayerCallback::CApplicationPlayerCallback()
 {
@@ -80,7 +83,7 @@ void CApplicationPlayerCallback::OnPlayBackStarted(const CFileItem& file)
    * This should speed up player startup for files on internet filesystems (eg. webdav) and
    * increase performance on low powered systems (Atom/ARM).
    */
-  if (file.IsVideo() || file.IsGame())
+  if (IsVideo(file) || file.IsGame())
   {
     CServiceBroker::GetJobManager()->PauseJobs();
   }
@@ -128,7 +131,7 @@ void CApplicationPlayerCallback::OnPlayerCloseFile(const CFileItem& file,
 
   if ((fileItem.IsAudio() && advancedSettings->m_audioPlayCountMinimumPercent > 0 &&
        percent >= advancedSettings->m_audioPlayCountMinimumPercent) ||
-      (fileItem.IsVideo() && advancedSettings->m_videoPlayCountMinimumPercent > 0 &&
+      (IsVideo(fileItem) && advancedSettings->m_videoPlayCountMinimumPercent > 0 &&
        percent >= advancedSettings->m_videoPlayCountMinimumPercent))
   {
     playCountUpdate = true;

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
@@ -25,11 +25,14 @@
 #include "utils/StringUtils.h"
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
+#include "video/VideoFileItemClassify.h"
 
 #include <mutex>
 #include <sstream>
 
 #define PLAYERCOREFACTORY_XML "playercorefactory.xml"
+
+using namespace KODI;
 
 CPlayerCoreFactory::CPlayerCoreFactory(const CProfileManager& profileManager)
   : m_settings(CServiceBroker::GetSettingsComponent()->GetSettings()),
@@ -141,7 +144,7 @@ void CPlayerCoreFactory::GetPlayers(const CFileItem& item, std::vector<std::stri
   // "videodefaultplayer"
   if (defaultInputstreamPlayerOverride == ForcedPlayer::VIDEO_DEFAULT ||
       (defaultInputstreamPlayerOverride == ForcedPlayer::NONE &&
-       (item.IsVideo() || (!item.IsAudio() && !item.IsGame()))))
+       (VIDEO::IsVideo(item) || (!item.IsAudio() && !item.IsGame()))))
   {
     int idx = GetPlayerIndex("videodefaultplayer");
     if (idx > -1)

--- a/xbmc/cores/playercorefactory/PlayerSelectionRule.cpp
+++ b/xbmc/cores/playercorefactory/PlayerSelectionRule.cpp
@@ -19,9 +19,12 @@
 #include "utils/XBMCTinyXML.h"
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
+#include "video/VideoFileItemClassify.h"
 #include "video/VideoInfoTag.h"
 
 #include <algorithm>
+
+using namespace KODI;
 
 CPlayerSelectionRule::CPlayerSelectionRule(TiXmlElement* pRule)
 {
@@ -116,7 +119,7 @@ void CPlayerSelectionRule::GetPlayers(const CFileItem& item, std::vector<std::st
     return;
   if (m_tAudio >= 0 && (m_tAudio > 0) != item.IsAudio())
     return;
-  if (m_tVideo >= 0 && (m_tVideo > 0) != item.IsVideo())
+  if (m_tVideo >= 0 && (m_tVideo > 0) != VIDEO::IsVideo(item))
     return;
   if (m_tGame >= 0 && (m_tGame > 0) != item.IsGame())
     return;

--- a/xbmc/favourites/FavouritesService.cpp
+++ b/xbmc/favourites/FavouritesService.cpp
@@ -21,8 +21,11 @@
 #include "utils/URIUtils.h"
 #include "utils/XBMCTinyXML2.h"
 #include "utils/log.h"
+#include "video/VideoFileItemClassify.h"
 
 #include <mutex>
+
+using namespace KODI;
 
 namespace
 {
@@ -71,7 +74,7 @@ bool IsMediasourceOfFavItemUnlocked(const std::shared_ptr<CFileItem>& item)
 
   if (action == CFavouritesURL::Action::PLAY_MEDIA)
   {
-    if (itemToCheck.IsVideo())
+    if (VIDEO::IsVideo(itemToCheck))
     {
       if (!profileManager->GetCurrentProfile().videoLocked())
         return g_passwordManager.IsMediaFileUnlocked("video", itemToCheck.GetPath());

--- a/xbmc/guilib/guiinfo/PicturesGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PicturesGUIInfo.cpp
@@ -20,11 +20,13 @@
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
+#include "video/VideoFileItemClassify.h"
 
 #include <map>
 #include <memory>
 
 using namespace KODI::GUILIB::GUIINFO;
+using namespace KODI;
 
 static const std::map<int, int> listitem2slideshow_map =
 {
@@ -251,7 +253,7 @@ bool CPicturesGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int conte
     case SLIDESHOW_ISVIDEO:
     {
       CSlideShowDelegator& slideShow = CServiceBroker::GetSlideShowDelegator();
-      value = slideShow.GetCurrentSlide() && slideShow.GetCurrentSlide()->IsVideo();
+      value = slideShow.GetCurrentSlide() && VIDEO::IsVideo(*slideShow.GetCurrentSlide());
       return true;
     }
   }

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -35,6 +35,7 @@
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
+#include "video/VideoFileItemClassify.h"
 #include "video/VideoInfoTag.h"
 #include "video/VideoManagerTypes.h"
 #include "video/VideoThumbLoader.h"
@@ -43,6 +44,7 @@
 
 using namespace KODI::GUILIB;
 using namespace KODI::GUILIB::GUIINFO;
+using namespace KODI;
 
 CVideoGUIInfo::CVideoGUIInfo()
   : m_appPlayer(CServiceBroker::GetAppComponents().GetComponent<CApplicationPlayer>())
@@ -61,7 +63,7 @@ int CVideoGUIInfo::GetPercentPlayed(const CVideoInfoTag* tag) const
 
 bool CVideoGUIInfo::InitCurrentItem(CFileItem *item)
 {
-  if (item && item->IsVideo())
+  if (item && VIDEO::IsVideo(*item))
   {
     // special case where .strm is used to start an audio stream
     if (item->IsInternetStream() && m_appPlayer->IsPlayingAudio())

--- a/xbmc/guilib/listproviders/DirectoryProvider.cpp
+++ b/xbmc/guilib/listproviders/DirectoryProvider.cpp
@@ -34,6 +34,7 @@
 #include "utils/XMLUtils.h"
 #include "utils/guilib/GUIContentUtils.h"
 #include "utils/log.h"
+#include "video/VideoFileItemClassify.h"
 #include "video/VideoInfoTag.h"
 #include "video/VideoThumbLoader.h"
 #include "video/VideoUtils.h"
@@ -47,6 +48,7 @@
 
 using namespace XFILE;
 using namespace KODI::MESSAGING;
+using namespace KODI::VIDEO;
 using namespace PVR;
 
 class CDirectoryJob : public CJob
@@ -133,7 +135,7 @@ public:
 
   std::shared_ptr<CThumbLoader> getThumbLoader(const CGUIStaticItemPtr& item)
   {
-    if (item->IsVideo())
+    if (IsVideo(*item))
     {
       initThumbLoader<CVideoThumbLoader>(InfoTagType::VIDEO);
       return m_thumbloaders[InfoTagType::VIDEO];

--- a/xbmc/interfaces/AnnouncementManager.cpp
+++ b/xbmc/interfaces/AnnouncementManager.cpp
@@ -18,6 +18,7 @@
 #include "utils/Variant.h"
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
+#include "video/VideoFileItemClassify.h"
 
 #include <memory>
 #include <mutex>
@@ -26,6 +27,7 @@
 #define LOOKUP_PROPERTY "database-lookup"
 
 using namespace ANNOUNCEMENT;
+using namespace KODI::VIDEO;
 
 const std::string CAnnouncementManager::ANNOUNCEMENT_SENDER = "xbmc";
 
@@ -296,7 +298,7 @@ void CAnnouncementManager::DoAnnounce(AnnouncementFlag flag,
         object["item"]["artist"] = item->GetMusicInfoTag()->GetArtist();
     }
   }
-  else if (item->IsVideo())
+  else if (IsVideo(*item))
   {
     // video item but has no video info tag.
     type = "movie";

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -38,6 +38,7 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 #include "video/PlayerController.h"
+#include "video/VideoFileItemClassify.h"
 #include "video/VideoUtils.h"
 #include "video/guilib/VideoGUIUtils.h"
 #include "video/guilib/VideoSelectActionProcessor.h"
@@ -47,6 +48,8 @@
 #ifdef HAS_OPTICAL_DRIVE
 #include "Autorun.h"
 #endif
+
+using namespace KODI::VIDEO;
 
 /*! \brief Clear current playlist
  *  \param params (ignored)
@@ -434,7 +437,7 @@ void GetItemsForPlayList(const std::shared_ptr<CFileItem>& item, CFileItemList& 
 PLAYLIST::Id GetPlayListId(const CFileItem& item)
 {
   PLAYLIST::Id playlistId{PLAYLIST::TYPE_NONE};
-  if (item.IsVideo())
+  if (IsVideo(item))
     playlistId = PLAYLIST::TYPE_VIDEO;
   else if (item.IsAudio())
     playlistId = PLAYLIST::TYPE_MUSIC;
@@ -538,7 +541,7 @@ int PlayOrQueueMedia(const std::vector<std::string>& params, bool forcePlay)
       bool containsVideo = false;
       for (const auto& i : items)
       {
-        const bool isVideo = i->IsVideo();
+        const bool isVideo = IsVideo(*i);
         containsMusic |= !isVideo;
         containsVideo |= isVideo;
 
@@ -556,7 +559,7 @@ int PlayOrQueueMedia(const std::vector<std::string>& params, bool forcePlay)
         {
           for (int i = items.Size() - 1; i >= 0; i--) //remove music entries
           {
-            if (!items[i]->IsVideo())
+            if (!IsVideo(*items[i]))
               items.Remove(i);
           }
         }
@@ -615,7 +618,7 @@ int PlayOrQueueMedia(const std::vector<std::string>& params, bool forcePlay)
 
   if (forcePlay)
   {
-    if ((item.IsAudio() || item.IsVideo()) && !item.IsSmartPlayList() && !item.IsPVR())
+    if ((item.IsAudio() || IsVideo(item)) && !item.IsSmartPlayList() && !item.IsPVR())
     {
       if (!item.HasProperty("playlist_type_hint"))
         item.SetProperty("playlist_type_hint", GetPlayListId(item));

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -40,10 +40,12 @@
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
+#include "video/VideoFileItemClassify.h"
 #include "view/GUIViewState.h"
 
 #include <memory>
 
+using namespace KODI::VIDEO;
 using namespace MUSIC_INFO;
 using namespace XFILE;
 using namespace std::chrono_literals;
@@ -606,7 +608,7 @@ void CAsyncGetItemsForPlaylist::GetItemsForPlaylist(const std::shared_ptr<CFileI
       // python files can be played
       m_queuedItems.Add(item);
     }
-    else if (!item->IsNFO() && (item->IsAudio() || item->IsVideo()))
+    else if (!item->IsNFO() && (item->IsAudio() || IsVideo(*item)))
     {
       const auto itemCheck = m_queuedItems.Get(item->GetPath());
       if (!itemCheck || itemCheck->GetStartOffset() != item->GetStartOffset())

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -22,6 +22,7 @@
 #include "application/Application.h"
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPlayer.h"
+#include "video/VideoFileItemClassify.h"
 #ifdef HAS_CDDA_RIPPER
 #include "cdrip/CDDARipper.h"
 #endif
@@ -73,6 +74,7 @@ using namespace MUSIC_GRABBER;
 using namespace MUSIC_INFO;
 using namespace KODI::MESSAGING;
 using KODI::MESSAGING::HELPERS::DialogResponse;
+using namespace KODI::VIDEO;
 
 using namespace std::chrono_literals;
 
@@ -305,7 +307,7 @@ void CGUIWindowMusicBase::OnItemInfo(int iItem)
     return;
   }
 
-  if (item->IsVideo() && item->HasVideoInfoTag() &&
+  if (IsVideo(*item) && item->HasVideoInfoTag() &&
       item->GetVideoInfoTag()->m_type == MediaTypeMusicVideo)
   { // Music video on a mixed current playlist or navigation by music > music video > artist > video
     CGUIDialogVideoInfo::ShowFor(*item);
@@ -348,7 +350,8 @@ void CGUIWindowMusicBase::RetrieveMusicInfo()
   for (int i = 0; i < m_vecItems->Size(); ++i)
   {
     CFileItemPtr pItem = (*m_vecItems)[i];
-    if (pItem->m_bIsFolder || pItem->IsPlayList() || pItem->IsPicture() || pItem->IsLyrics() || pItem->IsVideo())
+    if (pItem->m_bIsFolder || pItem->IsPlayList() || pItem->IsPicture() || pItem->IsLyrics() ||
+        IsVideo(*pItem))
       continue;
 
     CMusicInfoTag& tag = *pItem->GetMusicInfoTag();

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -28,6 +28,7 @@
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
+#include "video/VideoFileItemClassify.h"
 #include "video/VideoInfoTag.h"
 
 #include <algorithm>
@@ -38,6 +39,7 @@
 
 #include <Platinum/Source/Platinum/Platinum.h>
 
+using namespace KODI;
 using namespace MUSIC_INFO;
 using namespace XFILE;
 
@@ -203,7 +205,7 @@ NPT_String GetMimeType(const CFileItem& item, const PLT_HttpRequestContext* cont
   /* fallback to generic mime type if not found */
   if (mime.IsEmpty())
   {
-    if (item.IsVideo() || item.IsVideoDb())
+    if (VIDEO::IsVideo(item) || item.IsVideoDb())
       mime = "video/" + ext;
     else if (item.IsAudio() || item.IsMusicDb())
       mime = "audio/" + ext;
@@ -528,7 +530,7 @@ PLT_MediaObject* BuildObject(CFileItem& item,
         PopulateObjectFromTag(*tag, *object, &file_path, &resource, quirks, upnp_service);
       }
     }
-    else if (item.IsVideoDb() || item.IsVideo())
+    else if (item.IsVideoDb() || VIDEO::IsVideo(item))
     {
       object->m_ObjectClass.type = "object.item.videoItem";
 
@@ -818,7 +820,7 @@ PLT_MediaObject* BuildObject(CFileItem& item,
   // look for and add external subtitle if we are processing a video file and
   // we are being called by a UPnP player or renderer or the user has chosen
   // to look for external subtitles
-  if (upnp_server != NULL && item.IsVideo() &&
+  if (upnp_server != nullptr && VIDEO::IsVideo(item) &&
       (upnp_service == UPnPPlayer || upnp_service == UPnPRenderer ||
        settings->GetBool(CSettings::SETTING_SERVICES_UPNPLOOKFOREXTERNALSUBTITLES)))
   {

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -24,6 +24,7 @@
 #include "utils/StringUtils.h"
 #include "utils/TimeUtils.h"
 #include "utils/log.h"
+#include "video/VideoFileItemClassify.h"
 #include "video/VideoThumbLoader.h"
 
 #include <mutex>
@@ -33,6 +34,7 @@
 #include <Platinum/Source/Platinum/Platinum.h>
 
 using namespace KODI::MESSAGING;
+using namespace KODI;
 
 using KODI::MESSAGING::HELPERS::DialogResponse;
 using namespace std::chrono_literals;
@@ -383,7 +385,7 @@ bool CUPnPPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options)
   m_stopremote = true;
   m_started = true;
 
-  if (file.IsVideo())
+  if (VIDEO::IsVideo(file))
   {
     m_hasVideo = true;
   }

--- a/xbmc/network/upnp/UPnPRenderer.cpp
+++ b/xbmc/network/upnp/UPnPRenderer.cpp
@@ -30,11 +30,14 @@
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
+#include "video/VideoFileItemClassify.h"
 
 #include <inttypes.h>
 #include <mutex>
 
 #include <Platinum/Source/Platinum/Platinum.h>
+
+using namespace KODI::VIDEO;
 
 NPT_SET_LOCAL_LOGGER("xbmc.upnp.renderer")
 
@@ -628,7 +631,7 @@ NPT_Result CUPnPRenderer::OnSetNextAVTransportURI(PLT_ActionReference& action)
   {
 
     PLAYLIST::Id playlistId = PLAYLIST::TYPE_MUSIC;
-    if (item->IsVideo())
+    if (IsVideo(*item))
       playlistId = PLAYLIST::TYPE_VIDEO;
 
     // note: auto-deleted when the message is consumed

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -40,6 +40,7 @@
 #include "utils/Variant.h"
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
+#include "video/VideoFileItemClassify.h"
 #include "view/GUIViewState.h"
 
 #define CONTROL_BTNSORTASC          4
@@ -47,6 +48,7 @@
 
 using namespace XFILE;
 using namespace KODI::MESSAGING;
+using namespace KODI::VIDEO;
 
 using namespace std::chrono_literals;
 
@@ -294,7 +296,7 @@ bool CGUIWindowPictures::GetDirectory(const std::string &strDirectory, CFileItem
 
 bool CGUIWindowPictures::OnPlayMedia(int iItem, const std::string &player)
 {
-  if (m_vecItems->Get(iItem)->IsVideo())
+  if (IsVideo(*m_vecItems->Get(iItem)))
     return CGUIMediaWindow::OnPlayMedia(iItem);
 
   return ShowPicture(iItem, false);
@@ -327,7 +329,7 @@ bool CGUIWindowPictures::ShowPicture(int iItem, bool startSlideShow)
   {
     if (!pItem->m_bIsFolder &&
         !(URIUtils::IsRAR(pItem->GetPath()) || URIUtils::IsZIP(pItem->GetPath())) &&
-        (pItem->IsPicture() || (bShowVideos && pItem->IsVideo())))
+        (pItem->IsPicture() || (bShowVideos && IsVideo(*pItem))))
     {
       slideShow.Add(pItem.get());
     }

--- a/xbmc/pictures/PictureInfoLoader.cpp
+++ b/xbmc/pictures/PictureInfoLoader.cpp
@@ -13,6 +13,9 @@
 #include "ServiceBroker.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "video/VideoFileItemClassify.h"
+
+using namespace KODI;
 
 CPictureInfoLoader::CPictureInfoLoader()
 {
@@ -50,7 +53,8 @@ bool CPictureInfoLoader::LoadItem(CFileItem* pItem)
 
 bool CPictureInfoLoader::LoadItemCached(CFileItem* pItem)
 {
-  if (!pItem->IsPicture() || pItem->IsZIP() || pItem->IsRAR() || pItem->IsCBR() || pItem->IsCBZ() || pItem->IsInternetStream() || pItem->IsVideo())
+  if (!pItem->IsPicture() || pItem->IsZIP() || pItem->IsRAR() || pItem->IsCBR() || pItem->IsCBZ() ||
+      pItem->IsInternetStream() || VIDEO::IsVideo(*pItem))
     return false;
 
   if (pItem->HasPictureInfoTag())
@@ -73,7 +77,8 @@ bool CPictureInfoLoader::LoadItemLookup(CFileItem* pItem)
   if (m_pProgressCallback && !pItem->m_bIsFolder)
     m_pProgressCallback->SetProgressAdvance();
 
-  if (!pItem->IsPicture() || pItem->IsZIP() || pItem->IsRAR() || pItem->IsCBR() || pItem->IsCBZ() || pItem->IsInternetStream() || pItem->IsVideo())
+  if (!pItem->IsPicture() || pItem->IsZIP() || pItem->IsRAR() || pItem->IsCBR() || pItem->IsCBZ() ||
+      pItem->IsInternetStream() || VIDEO::IsVideo(*pItem))
     return false;
 
   if (pItem->HasPictureInfoTag())

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -23,8 +23,10 @@
 #include "utils/FileExtensionProvider.h"
 #include "utils/FileUtils.h"
 #include "utils/URIUtils.h"
+#include "video/VideoFileItemClassify.h"
 #include "video/VideoThumbLoader.h"
 
+using namespace KODI::VIDEO;
 using namespace XFILE;
 
 CPictureThumbLoader::CPictureThumbLoader() : CThumbLoader()
@@ -78,7 +80,8 @@ bool CPictureThumbLoader::LoadItemCached(CFileItem* pItem)
   { // load the thumb from the image file
     thumb = pItem->HasArt("thumb") ? pItem->GetArt("thumb") : CTextureUtils::GetWrappedThumbURL(pItem->GetPath());
   }
-  else if (pItem->IsVideo() && !pItem->IsZIP() && !pItem->IsRAR() && !pItem->IsCBZ() && !pItem->IsCBR() && !pItem->IsPlayList())
+  else if (IsVideo(*pItem) && !pItem->IsZIP() && !pItem->IsRAR() && !pItem->IsCBZ() &&
+           !pItem->IsCBR() && !pItem->IsPlayList())
   { // video
     CVideoThumbLoader loader;
     loader.LoadItemCached(pItem);

--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -16,10 +16,12 @@
 #include "utils/CharsetConverter.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
+#include "video/VideoFileItemClassify.h"
 #include "video/VideoInfoTag.h"
 
 #include <inttypes.h>
 
+using namespace KODI;
 using namespace PLAYLIST;
 using namespace XFILE;
 
@@ -183,7 +185,8 @@ bool CPlayListM3U::Load(const std::string& strFileName)
           if (iEndOffset)
             lDuration = static_cast<int>(CUtil::ConvertMilliSecsToSecsIntRounded(iEndOffset - iStartOffset));
         }
-        if (newItem->IsVideo() && !newItem->HasVideoInfoTag()) // File is a video and needs a VideoInfoTag
+        if (VIDEO::IsVideo(*newItem) &&
+            !newItem->HasVideoInfoTag()) // File is a video and needs a VideoInfoTag
           newItem->GetVideoInfoTag()->Reset(); // Force VideoInfoTag creation
         if (lDuration && newItem->IsAudio())
           newItem->GetMusicInfoTag()->SetDuration(lDuration);

--- a/xbmc/playlists/PlayListPLS.cpp
+++ b/xbmc/playlists/PlayListPLS.cpp
@@ -19,6 +19,7 @@
 #include "utils/XBMCTinyXML.h"
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
+#include "video/VideoFileItemClassify.h"
 #include "video/VideoInfoTag.h"
 
 #include <iostream>
@@ -26,6 +27,7 @@
 #include <string>
 #include <vector>
 
+using namespace KODI;
 using namespace XFILE;
 using namespace PLAYLIST;
 
@@ -272,7 +274,8 @@ bool CPlayListASX::LoadAsxIniInfo(std::istream &stream)
     CLog::Log(LOGINFO, "Adding element {}={}", name, value);
     CFileItemPtr newItem(new CFileItem(value));
     newItem->SetPath(value);
-    if (newItem->IsVideo() && !newItem->HasVideoInfoTag()) // File is a video and needs a VideoInfoTag
+    if (VIDEO::IsVideo(*newItem) &&
+        !newItem->HasVideoInfoTag()) // File is a video and needs a VideoInfoTag
       newItem->GetVideoInfoTag()->Reset(); // Force VideoInfoTag creation
     Add(newItem);
   }

--- a/xbmc/utils/GroupUtils.cpp
+++ b/xbmc/utils/GroupUtils.cpp
@@ -13,10 +13,13 @@
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "video/VideoDbUrl.h"
+#include "video/VideoFileItemClassify.h"
 #include "video/VideoInfoTag.h"
 
 #include <map>
 #include <set>
+
+using namespace KODI;
 
 using SetMap = std::map<int, std::set<CFileItemPtr> >;
 
@@ -127,7 +130,7 @@ bool GroupUtils::Group(GroupBy groupBy, const std::string &baseDir, const CFileI
 
         //accumulate the path for a multipath construction
         CFileItem video(movieInfo->m_basePath, false);
-        if (video.IsVideo())
+        if (VIDEO::IsVideo(video))
           pathSet.insert(URIUtils::GetParentPath(movieInfo->m_basePath));
         else
           pathSet.insert(movieInfo->m_basePath);

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -28,6 +28,9 @@
 #include "utils/Variant.h"
 #include "video/Bookmark.h"
 #include "video/VideoDatabase.h"
+#include "video/VideoFileItemClassify.h"
+
+using namespace KODI::VIDEO;
 
 void CSaveFileState::DoWork(CFileItem& item,
                             CBookmark& bookmark,
@@ -57,7 +60,7 @@ void CSaveFileState::DoWork(CFileItem& item,
       return;
     }
 #endif
-    if (item.IsVideo())
+    if (IsVideo(item))
     {
       std::string redactPath = CURL::GetRedacted(progressTrackingFile);
       CLog::Log(LOGDEBUG, "{} - Saving file state for video item {}", __FUNCTION__, redactPath);

--- a/xbmc/video/CMakeLists.txt
+++ b/xbmc/video/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES Bookmark.cpp
             VideoDatabase.cpp
             VideoDbUrl.cpp
             VideoEmbeddedImageFileLoader.cpp
+            VideoFileItemClassify.cpp
             VideoGeneratedImageFileLoader.cpp
             VideoInfoDownloader.cpp
             VideoInfoScanner.cpp
@@ -28,6 +29,7 @@ set(HEADERS Bookmark.h
             VideoDatabase.h
             VideoDbUrl.h
             VideoEmbeddedImageFileLoader.h
+            VideoFileItemClassify.h
             VideoGeneratedImageFileLoader.h
             VideoInfoDownloader.h
             VideoInfoScanner.h

--- a/xbmc/video/VideoFileItemClassify.cpp
+++ b/xbmc/video/VideoFileItemClassify.cpp
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "video/VideoFileItemClassify.h"
+
+#include "FileItem.h"
+#include "ServiceBroker.h"
+#include "utils/FileExtensionProvider.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
+
+namespace KODI::VIDEO
+{
+
+bool IsVideo(const CFileItem& item)
+{
+  /* check preset mime type */
+  if (StringUtils::StartsWithNoCase(item.GetMimeType(), "video/"))
+    return true;
+
+  if (item.HasVideoInfoTag())
+    return true;
+
+  if (item.HasGameInfoTag())
+    return false;
+
+  if (item.HasMusicInfoTag())
+    return false;
+
+  if (item.HasPictureInfoTag())
+    return false;
+
+  // TV recordings are videos...
+  if (!item.m_bIsFolder && URIUtils::IsPVRTVRecordingFileOrFolder(item.GetPath()))
+    return true;
+
+  // ... all other PVR items are not.
+  if (item.IsPVR())
+    return false;
+
+  if (URIUtils::IsDVD(item.GetPath()))
+    return true;
+
+  std::string extension;
+  if (StringUtils::StartsWithNoCase(item.GetMimeType(), "application/"))
+  { /* check for some standard types */
+    extension = item.GetMimeType().substr(12);
+    if (StringUtils::EqualsNoCase(extension, "ogg") ||
+        StringUtils::EqualsNoCase(extension, "mp4") || StringUtils::EqualsNoCase(extension, "mxf"))
+      return true;
+  }
+
+  //! @todo If the file is a zip file, ask the game clients if any support this
+  // file before assuming it is video.
+
+  return URIUtils::HasExtension(item.GetPath(),
+                                CServiceBroker::GetFileExtensionProvider().GetVideoExtensions());
+}
+
+} // namespace KODI::VIDEO

--- a/xbmc/video/VideoFileItemClassify.h
+++ b/xbmc/video/VideoFileItemClassify.h
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+class CFileItem;
+
+namespace KODI::VIDEO
+{
+
+//! \brief Check whether an item is a video item.
+//! \details Note that this returns true for anything with a video info tag,
+//!          so that may include eg. folders.
+bool IsVideo(const CFileItem& item);
+
+} // namespace KODI::VIDEO

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -42,6 +42,7 @@
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
+#include "video/VideoFileItemClassify.h"
 #include "video/VideoManagerTypes.h"
 #include "video/VideoThumbLoader.h"
 #include "video/dialogs/GUIDialogVideoManagerExtras.h"
@@ -54,6 +55,7 @@
 using namespace XFILE;
 using namespace ADDON;
 using namespace KODI::MESSAGING;
+using namespace KODI::VIDEO;
 
 using KODI::MESSAGING::HELPERS::DialogResponse;
 using KODI::UTILITY::CDigest;
@@ -721,8 +723,8 @@ namespace VIDEO
                                           CScraperUrl* pURL,
                                           CGUIDialogProgress* pDlgProgress)
   {
-    if (pItem->m_bIsFolder || !pItem->IsVideo() || pItem->IsNFO() ||
-       (pItem->IsPlayList() && !URIUtils::HasExtension(pItem->GetPath(), ".strm")))
+    if (pItem->m_bIsFolder || !IsVideo(*pItem) || pItem->IsNFO() ||
+        (pItem->IsPlayList() && !URIUtils::HasExtension(pItem->GetPath(), ".strm")))
       return INFO_NOT_NEEDED;
 
     if (ProgressCancelled(pDlgProgress, 198, pItem->GetLabel()))
@@ -826,8 +828,8 @@ namespace VIDEO
                                                CScraperUrl* pURL,
                                                CGUIDialogProgress* pDlgProgress)
   {
-    if (pItem->m_bIsFolder || !pItem->IsVideo() || pItem->IsNFO() ||
-       (pItem->IsPlayList() && !URIUtils::HasExtension(pItem->GetPath(), ".strm")))
+    if (pItem->m_bIsFolder || !IsVideo(*pItem) || pItem->IsNFO() ||
+        (pItem->IsPlayList() && !URIUtils::HasExtension(pItem->GetPath(), ".strm")))
       return INFO_NOT_NEEDED;
 
     if (ProgressCancelled(pDlgProgress, 20394, pItem->GetLabel()))
@@ -2204,7 +2206,7 @@ namespace VIDEO
         KODI::TIME::FileTime time = pItem->m_dateTime;
         digest.Update(&time, sizeof(KODI::TIME::FileTime));
       }
-      if (pItem->IsVideo() && !pItem->IsPlayList() && !pItem->IsNFO())
+      if (IsVideo(*pItem) && !pItem->IsPlayList() && !pItem->IsNFO())
         count++;
     }
     hash = digest.Finalize();

--- a/xbmc/video/VideoItemArtworkHandler.cpp
+++ b/xbmc/video/VideoItemArtworkHandler.cpp
@@ -23,11 +23,13 @@
 #include "utils/Variant.h"
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
+#include "video/VideoFileItemClassify.h"
 #include "video/VideoInfoScanner.h"
 #include "video/VideoInfoTag.h"
 #include "video/VideoThumbLoader.h"
 #include "video/tags/VideoTagExtractionHelper.h"
 
+using namespace KODI::VIDEO;
 using namespace VIDEO;
 using namespace XFILE;
 
@@ -118,7 +120,7 @@ void CVideoItemArtworkHandler::AddItemPathToFileBrowserSources(std::vector<CMedi
     itemDir = m_item->GetVideoInfoTag()->GetPath();
 
   const CFileItem itemTmp(itemDir, false);
-  if (itemTmp.IsVideo())
+  if (IsVideo(itemTmp))
     itemDir = URIUtils::GetParentPath(itemDir);
 
   AddItemPathStringToFileBrowserSources(sources, itemDir,

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -29,6 +29,7 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
+#include "video/VideoFileItemClassify.h"
 #include "video/VideoInfoTag.h"
 #include "video/VideoManagerTypes.h"
 #include "video/guilib/VideoVersionHelper.h"
@@ -37,6 +38,7 @@
 #include <cstdlib>
 #include <utility>
 
+using namespace KODI::VIDEO;
 using namespace XFILE;
 using namespace VIDEO;
 
@@ -180,8 +182,11 @@ bool CVideoThumbLoader::LoadItemCached(CFileItem* pItem)
 
   if (!pItem->HasVideoInfoTag() || !pItem->GetVideoInfoTag()->HasStreamDetails()) // no stream details
   {
-    if ((pItem->HasVideoInfoTag() && pItem->GetVideoInfoTag()->m_iFileId >= 0) // file (or maybe folder) is in the database
-    || (!pItem->m_bIsFolder && pItem->IsVideo())) // Some other video file for which we haven't yet got any database details
+    if ((pItem->HasVideoInfoTag() &&
+         pItem->GetVideoInfoTag()->m_iFileId >= 0) // file (or maybe folder) is in the database
+        || (!pItem->m_bIsFolder &&
+            IsVideo(
+                *pItem))) // Some other video file for which we haven't yet got any database details
     {
       if (m_videoDatabase->GetStreamDetails(*pItem))
         pItem->SetInvalid();
@@ -286,7 +291,7 @@ bool CVideoThumbLoader::LoadItemLookup(CFileItem* pItem)
   }
 
   // We can only extract flags/thumbs for file-like items
-  if (!pItem->m_bIsFolder && pItem->IsVideo())
+  if (!pItem->m_bIsFolder && IsVideo(*pItem))
   {
     const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
     if (!pItem->HasArt("thumb"))

--- a/xbmc/video/VideoUtils.cpp
+++ b/xbmc/video/VideoUtils.cpp
@@ -21,6 +21,7 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
+#include "video/VideoFileItemClassify.h"
 #include "video/VideoInfoTag.h"
 
 #include <algorithm>

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -35,6 +35,7 @@
 #include "utils/Variant.h"
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
+#include "video/VideoFileItemClassify.h"
 #include "view/ViewState.h"
 
 #include <algorithm>
@@ -47,6 +48,8 @@
 #define CONTROL_ADD_EPISODE_BOOKMARK   4
 
 #define CONTROL_THUMBS                11
+
+using namespace KODI::VIDEO;
 
 CGUIDialogVideoBookmarks::CGUIDialogVideoBookmarks()
   : CGUIDialog(WINDOW_DIALOG_VIDEO_BOOKMARKS, "VideoOSDBookmarks.xml")
@@ -531,7 +534,7 @@ bool CGUIDialogVideoBookmarks::AddEpisodeBookmark()
 
 bool CGUIDialogVideoBookmarks::OnAddBookmark()
 {
-  if (!g_application.CurrentFileItem().IsVideo())
+  if (!IsVideo(g_application.CurrentFileItem()))
     return false;
 
   if (CGUIDialogVideoBookmarks::AddBookmark())

--- a/xbmc/video/guilib/VideoGUIUtils.cpp
+++ b/xbmc/video/guilib/VideoGUIUtils.cpp
@@ -35,9 +35,12 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
+#include "video/VideoFileItemClassify.h"
 #include "video/VideoInfoTag.h"
 #include "video/VideoUtils.h"
 #include "view/GUIViewState.h"
+
+using namespace KODI::VIDEO;
 
 namespace
 {
@@ -307,7 +310,7 @@ void CAsyncGetItemsForPlaylist::GetItemsForPlaylist(const std::shared_ptr<CFileI
     itemCopy->SetStartOffset(item->GetStartOffset());
     m_queuedItems.Add(itemCopy);
   }
-  else if (!item->IsNFO() && item->IsVideo())
+  else if (!item->IsNFO() && IsVideo(*item))
   {
     m_queuedItems.Add(item);
   }
@@ -571,7 +574,7 @@ bool IsItemPlayable(const CFileItem& item)
   {
     return true;
   }
-  else if ((!item.m_bIsFolder && item.IsVideo()) || item.IsDVD() || item.IsCDDA())
+  else if ((!item.m_bIsFolder && IsVideo(item)) || item.IsDVD() || item.IsCDDA())
   {
     return true;
   }

--- a/xbmc/video/test/CMakeLists.txt
+++ b/xbmc/video/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES TestStacks.cpp
+            TestVideoFileItemClassify.cpp
             TestVideoInfoScanner.cpp
             TestVideoUtils.cpp)
 

--- a/xbmc/video/test/TestVideoFileItemClassify.cpp
+++ b/xbmc/video/test/TestVideoFileItemClassify.cpp
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "FileItem.h"
+#include "ServiceBroker.h"
+#include "games/tags/GameInfoTag.h"
+#include "music/tags/MusicInfoTag.h"
+#include "pictures/PictureInfoTag.h"
+#include "utils/FileExtensionProvider.h"
+#include "video/VideoFileItemClassify.h"
+#include "video/VideoInfoTag.h"
+
+#include <array>
+
+#include <gtest/gtest.h>
+
+using namespace KODI;
+
+struct VideoClassifyTest
+{
+  VideoClassifyTest(const std::string& path,
+                    bool res = true,
+                    const std::string& mime = "",
+                    int tag_type = 0)
+    : item(path, false), result(res)
+  {
+    if (!mime.empty())
+      item.SetMimeType(mime);
+    switch (tag_type)
+    {
+      case 1:
+        item.GetVideoInfoTag()->m_strFileNameAndPath = path;
+        break;
+      case 2:
+        item.GetGameInfoTag()->SetGameClient("some_client");
+        break;
+      case 3:
+        item.GetMusicInfoTag()->SetPlayCount(1);
+        break;
+      case 4:
+        item.GetPictureInfoTag()->SetInfo("foo", "bar");
+        ;
+        break;
+      default:
+        break;
+    }
+  }
+
+  CFileItem item;
+  bool result;
+};
+
+class VideoTest : public testing::WithParamInterface<VideoClassifyTest>, public testing::Test
+{
+};
+
+TEST_P(VideoTest, IsVideo)
+{
+  EXPECT_EQ(VIDEO::IsVideo(GetParam().item), GetParam().result);
+}
+
+const auto video_tests = std::array{
+    VideoClassifyTest{"/home/user/video.avi", true, "video/avi"},
+    VideoClassifyTest{"/home/user/video.avi", true, "", 1},
+    VideoClassifyTest{"/home/user/video.avi", false, "", 2},
+    VideoClassifyTest{"/home/user/video.avi", false, "", 3},
+    VideoClassifyTest{"/home/user/video.avi", false, "", 4},
+    VideoClassifyTest{"pvr://recordings/tv/1", true},
+    VideoClassifyTest{"pvr://123", false},
+    VideoClassifyTest{"dvd://VIDEO_TS/video_ts.ifo", true},
+    VideoClassifyTest{"dvd://1", true},
+    VideoClassifyTest{"/home/user/video.not", true, "application/ogg"},
+    VideoClassifyTest{"/home/user/video.not", true, "application/mp4"},
+    VideoClassifyTest{"/home/user/video.not", true, "application/mxf"},
+};
+
+INSTANTIATE_TEST_SUITE_P(TestVideoFileItemClassify, VideoTest, testing::ValuesIn(video_tests));
+
+TEST(TestVideoFileItemClassify, VideoExtensions)
+{
+  const auto& exts = CServiceBroker::GetFileExtensionProvider().GetVideoExtensions();
+  for (const auto& ext : StringUtils::Split(exts, "|"))
+  {
+    if (!ext.empty())
+      EXPECT_TRUE(VIDEO::IsVideo(CFileItem(ext, false)));
+  }
+}

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -53,6 +53,7 @@
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
 #include "video/VideoDbUrl.h"
+#include "video/VideoFileItemClassify.h"
 #include "video/VideoInfoScanner.h"
 #include "video/VideoLibraryQueue.h"
 #include "video/VideoManagerTypes.h"
@@ -73,6 +74,7 @@ using namespace VIDEO::GUILIB;
 using namespace ADDON;
 using namespace PVR;
 using namespace KODI::MESSAGING;
+using namespace KODI::VIDEO;
 
 #define CONTROL_BTNVIEWASICONS     2
 #define CONTROL_BTNSORTBY          3
@@ -303,7 +305,7 @@ bool CGUIWindowVideoBase::OnItemInfo(const CFileItem& fileItem)
                                                             ->m_moviesExcludeFromScanRegExps;
       for (const auto& i : items)
       {
-        if (i->IsVideo() && !i->IsPlayList() &&
+        if (IsVideo(*i) && !i->IsPlayList() &&
             !CUtil::ExcludeFileOrFolder(i->GetPath(), excludeFromScan))
         {
           item.SetPath(i->GetPath());
@@ -733,7 +735,7 @@ void CGUIWindowVideoBase::LoadVideoInfo(CFileItemList& items,
       }
 
       // set the watched overlay
-      if (pItem->IsVideo())
+      if (IsVideo(*pItem))
         pItem->SetOverlayImage(pItem->HasVideoInfoTag() &&
                                        pItem->GetVideoInfoTag()->GetPlayCount() > 0
                                    ? CGUIListItem::ICON_OVERLAY_WATCHED

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -56,9 +56,11 @@
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
+#include "video/VideoFileItemClassify.h"
 
 using namespace XFILE;
 using namespace KODI::MESSAGING;
+using namespace KODI::VIDEO;
 
 #define CONTROL_BTNSELECTALL            1
 #define CONTROL_BTNFAVOURITES           2
@@ -655,7 +657,7 @@ void CGUIWindowFileManager::OnStart(CFileItem *pItem, const std::string &player)
     g_application.ProcessAndStartPlaylist(strPlayList, *pPlayList, PLAYLIST::TYPE_MUSIC);
     return;
   }
-  if (pItem->IsAudio() || pItem->IsVideo())
+  if (pItem->IsAudio() || IsVideo(*pItem))
   {
     CServiceBroker::GetPlaylistPlayer().Play(std::make_shared<CFileItem>(*pItem), player);
     return;


### PR DESCRIPTION
## Description
Separate out CFileItem::IsVideo() member into a static predicate; instead of item.IsxXX() we instead have a predicate IsVideo(item). 

## Motivation and context
Currently the API of CFileItem is kinda enormous. This makes the CFileItem class implementation a mish-mash of all sorts of components, which again makes refactoring it into something resembling a separable component rather painful. A contributor to this is a lot of CFileItem::IsXXX methods which do not in reality need access to much of the internals, but which are only thinly coupled through public accessors such as CFileItem::GetPath(). We can do better, these methods can instead be static predicates.

This is a meek start of such an effort. In the process I have added a test for the new predicate.

## How has this been tested?
It compiles.

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
