### PR TITLE
[Video][Actions] new action: PreviousSubtitle

### DIFF
--- a/xbmc/addons/interfaces/gui/GUITranslator.cpp
+++ b/xbmc/addons/interfaces/gui/GUITranslator.cpp
@@ -328,6 +328,8 @@ ADDON_ACTION CAddonGUITranslator::TranslateActionIdToAddon(int kodiId)
       return ADDON_ACTION_MENU;
     case ACTION_SET_RATING:
       return ADDON_ACTION_SET_RATING;
+    case ACTION_PREV_SUBTITLE:
+      return ADDON_ACTION_PREV_SUBTITLE;
     case ACTION_RECORD:
       return ADDON_ACTION_RECORD;
     case ACTION_PASTE:
@@ -816,6 +818,8 @@ int CAddonGUITranslator::TranslateActionIdToKodi(ADDON_ACTION addonId)
       return ACTION_MENU;
     case ADDON_ACTION_SET_RATING:
       return ACTION_SET_RATING;
+    case ADDON_ACTION_PREV_SUBTITLE:
+      return ACTION_PREV_SUBTITLE;
     case ADDON_ACTION_RECORD:
       return ACTION_RECORD;
     case ADDON_ACTION_PASTE:

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/input/action_ids.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/input/action_ids.h
@@ -512,6 +512,10 @@ enum ADDON_ACTION
   /// @brief <b>`164`</b>: Set rating.
   ADDON_ACTION_SET_RATING = 164,
 
+  /// @brief <b>`165`</b>: Switch to previous subtitle of movie. Can be used in
+  /// the VideoFullScreen.xml window (with ID 2005).
+  ADDON_ACTION_PREV_SUBTITLE = 165,
+
   /// @brief <b>`170`</b>: Record.
   ADDON_ACTION_RECORD = 170,
 

--- a/xbmc/input/actions/ActionIDs.h
+++ b/xbmc/input/actions/ActionIDs.h
@@ -358,6 +358,8 @@ constexpr const int ACTION_MENU = 163;
 
 constexpr const int ACTION_SET_RATING = 164;
 
+constexpr const int ACTION_PREV_SUBTITLE = 165;
+
 constexpr const int ACTION_RECORD = 170;
 
 constexpr const int ACTION_PASTE = 180;

--- a/xbmc/input/actions/ActionTranslator.cpp
+++ b/xbmc/input/actions/ActionTranslator.cpp
@@ -53,6 +53,7 @@ static const std::map<ActionName, ActionID> ActionMappings = {
     {"osd", ACTION_SHOW_OSD},
     {"showsubtitles", ACTION_SHOW_SUBTITLES},
     {"nextsubtitle", ACTION_NEXT_SUBTITLE},
+    {"previoussubtitle", ACTION_PREV_SUBTITLE},
     {"browsesubtitle", ACTION_BROWSE_SUBTITLE},
     {"cyclesubtitle", ACTION_CYCLE_SUBTITLE},
     {"dialogselectvideo", ACTION_DIALOG_SELECT_VIDEO},

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -97,6 +97,7 @@ bool CPlayerController::OnAction(const CAction &action)
       }
 
       case ACTION_NEXT_SUBTITLE:
+      case ACTION_PREV_SUBTITLE:
       case ACTION_CYCLE_SUBTITLE:
       {
         if (appPlayer->GetSubtitleCount() == 0)
@@ -107,10 +108,11 @@ bool CPlayerController::OnAction(const CAction &action)
 
         if (appPlayer->GetSubtitleVisible())
         {
-          if (++currentSub >= appPlayer->GetSubtitleCount())
+          currentSub += (action.GetID() == ACTION_PREV_SUBTITLE) ? -1 : 1;
+          if (currentSub < 0 || currentSub >= appPlayer->GetSubtitleCount())
           {
             currentSub = 0;
-            if (action.GetID() == ACTION_NEXT_SUBTITLE)
+            if (action.GetID() != ACTION_CYCLE_SUBTITLE)
             {
               appPlayer->SetSubtitleVisible(false);
               currentSubVisible = false;
@@ -118,8 +120,13 @@ bool CPlayerController::OnAction(const CAction &action)
           }
           appPlayer->SetSubtitle(currentSub);
         }
-        else if (action.GetID() == ACTION_NEXT_SUBTITLE)
+        else if (action.GetID() != ACTION_CYCLE_SUBTITLE)
         {
+          if (currentSub == 0 && action.GetID() == ACTION_PREV_SUBTITLE)
+          {
+            currentSub = appPlayer->GetSubtitleCount() - 1;
+            appPlayer->SetSubtitle(currentSub);
+          }
           appPlayer->SetSubtitleVisible(true);
         }
 


### PR DESCRIPTION
## Background

When advancing through the available subtitle tracks, it's easy to accidentally overshoot the desired one, and end up having to either navigate menus to go back a step (obscuring the video) or keep advancing through the entire list to wrap around to the beginning and finally reach the desired one again (an annoyingly circuitous approach).

Also, there are times when switching back and forth between two adjacent subtitle tracks makes sense. For example, when watching a bilingual film with a few bits of muddled dialogue, the viewer might want the normal subtitles for most of the film but switch to SDH subtitles for the muddled parts, and then switch back to normal. Again, this is cumbersome when the only options are to navigate menus or advance forward through the subtitle track list.

In both these cases, the problem is especially bad when subtitles for dozens of languages are present.

## What does this change?

This patch adds the PreviousSubtitle action, for symmetry with NextSubtitle, and to handle situations like those described above with a single button press.

## How has this been tested?

Tested on (and originally written for) Leia, on a Raspberry Pi 2 running OpenELEC. (Because that's what I have available for testing.) I mapped a button to the PreviousSubtitle action and verified that it behaves like NextSubtitle, but in the other direction.

I also installed it on my own media player, and have been using it without problems ever since.

Porting to the master branch was straightforward, since the affected code has had no structural changes since Leia.

## What is the effect on users?

No effect on users unless they (or their distribution) map a button to this new action. In that case, they get a quality-of-life improvement.

## Types of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
