### PR TITLE
Remove timezone/timezonecountry infolabels from guilib

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1763,12 +1763,13 @@ const infomap weather[] =        {{ "isfetched",        WEATHER_IS_FETCHED },
 ///                  _string_,
 ///     @return Locale-specific information depending on the requested type.
 ///     @param type - Can be one of the following:
-///       - <b>timezonecountry</b> The country name for the current time zone.
-///       - <b>timezone</b> The full timezone name with country and optional region.
 ///       - <b>region</b> The currently selected region name within the selected language ( \link System_Language `System.Language` \endlink).
 ///       - <b>iso</b> The country code of the currently selected region as specified in <a href="https://kodi.wiki/view/Language_support#What_is_langinfo.xml">langinfo.xml</a>.
 ///     <p><hr>
 ///     @skinning_v21 **[New Infolabel]** \link System_Locale
+///     `System.Locale(type)`\endlink
+///     <p>
+///     @skinning_v22 **[Removed options]** `timezonecountry` and `timezone` from \link System_Locale
 ///     `System.Locale(type)`\endlink
 ///     <p>
 ///   }
@@ -10239,15 +10240,7 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
           return AddMultiInfo(CGUIInfo(SYSTEM_IDLE_TIME, atoi(param.c_str())));
         else if (prop.name == "locale")
         {
-          if (param == "timezonecountry")
-          {
-            return SYSTEM_LOCALE_TIMEZONECOUNTRY;
-          }
-          else if (param == "timezone")
-          {
-            return SYSTEM_LOCALE_TIMEZONE;
-          }
-          else if (param == "region")
+          if (param == "region")
           {
             return SYSTEM_LOCALE_REGION;
           }

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -568,8 +568,6 @@
 #define SYSTEM_BUILD_VERSION_CODE 1007
 #define SYSTEM_BUILD_VERSION_GIT 1008
 
-static constexpr unsigned int SYSTEM_LOCALE_TIMEZONECOUNTRY = 1009;
-static constexpr unsigned int SYSTEM_LOCALE_TIMEZONE = 1010;
 static constexpr unsigned int SYSTEM_LOCALE_REGION = 1011;
 static constexpr unsigned int SYSTEM_LOCALE = 1012;
 


### PR DESCRIPTION
This is a leftover from PR #24899 (removal of timezone setting from Kodi). Removal of the functionality means that the infolabels should also not be advertised.