### PR TITLE
[webOS][wayland] Fix long presses on webOS 7+

### DIFF
--- a/xbmc/windowing/wayland/CMakeLists.txt
+++ b/xbmc/windowing/wayland/CMakeLists.txt
@@ -68,10 +68,12 @@ if(TARGET_WEBOS)
                               PROPERTIES GENERATED TRUE)
 
   list(APPEND SOURCES OSScreenSaverWebOS.cpp
+                      SeatWebOS.cpp
                       ShellSurfaceWebOSShell.cpp
                       WinSystemWaylandWebOS.cpp
                       ${WAYLAND_EXTRA_PROTOCOL_GENERATED_DIR}/wayland-webos-protocols.cpp)
   list(APPEND HEADERS OSScreenSaverWebOS.h
+                      SeatWebOS.h
                       ShellSurfaceWebOSShell.h
                       WinSystemWaylandWebOS.h
                       ${WAYLAND_EXTRA_PROTOCOL_GENERATED_DIR}/wayland-webos-protocols.hpp)

--- a/xbmc/windowing/wayland/Seat.cpp
+++ b/xbmc/windowing/wayland/Seat.cpp
@@ -179,6 +179,11 @@ void CSeat::HandleKeyboardCapability()
       handler->OnKeyboardModifiers(this, serial, modsDepressed, modsLatched, modsLocked, group);
     }
   };
+  InstallKeyboardRepeatInfo();
+}
+
+void CSeat::InstallKeyboardRepeatInfo()
+{
   m_keyboard.on_repeat_info() = [this](std::int32_t rate, std::int32_t delay)
   {
     for (auto handler : m_rawKeyboardHandlers)
@@ -187,7 +192,6 @@ void CSeat::HandleKeyboardCapability()
     }
   };
 }
-
 
 void CSeat::HandlePointerCapability()
 {

--- a/xbmc/windowing/wayland/Seat.cpp
+++ b/xbmc/windowing/wayland/Seat.cpp
@@ -136,10 +136,7 @@ void CSeat::SetCursor(std::uint32_t serial, wayland::surface_t const &surface, s
 {
   if (m_pointer)
   {
-    // set_cursor on webOS completely breaks pointer input
-#ifndef TARGET_WEBOS
     m_pointer.set_cursor(serial, surface, hotspotX, hotspotY);
-#endif
   }
 }
 

--- a/xbmc/windowing/wayland/Seat.h
+++ b/xbmc/windowing/wayland/Seat.h
@@ -121,7 +121,7 @@ public:
    * \param connection connection for retrieving additional globals
    */
   CSeat(std::uint32_t globalName, wayland::seat_t const& seat, CConnection& connection);
-  ~CSeat() noexcept;
+  virtual ~CSeat() noexcept;
 
   void AddRawInputHandlerKeyboard(IRawInputHandlerKeyboard* rawKeyboardHandler);
   void RemoveRawInputHandlerKeyboard(IRawInputHandlerKeyboard* rawKeyboardHandler);
@@ -172,7 +172,10 @@ public:
    * Parameters are identical wo wl_pointer.set_cursor().
    * If the seat does not currently have the pointer capability, this is a no-op.
    */
-  void SetCursor(std::uint32_t serial, wayland::surface_t const& surface, std::int32_t hotspotX, std::int32_t hotspotY);
+  virtual void SetCursor(std::uint32_t serial,
+                         wayland::surface_t const& surface,
+                         std::int32_t hotspotX,
+                         std::int32_t hotspotY);
 
 private:
   CSeat(CSeat const& other) = delete;

--- a/xbmc/windowing/wayland/Seat.h
+++ b/xbmc/windowing/wayland/Seat.h
@@ -177,6 +177,9 @@ public:
                          std::int32_t hotspotX,
                          std::int32_t hotspotY);
 
+protected:
+  virtual void InstallKeyboardRepeatInfo();
+
 private:
   CSeat(CSeat const& other) = delete;
   CSeat& operator=(CSeat const& other) = delete;

--- a/xbmc/windowing/wayland/SeatWebOS.cpp
+++ b/xbmc/windowing/wayland/SeatWebOS.cpp
@@ -1,0 +1,22 @@
+/*
+*  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "SeatWebOS.h"
+
+namespace KODI::WINDOWING::WAYLAND
+{
+
+void CSeatWebOS::SetCursor(std::uint32_t serial,
+                           wayland::surface_t const& surface,
+                           std::int32_t hotspotX,
+                           std::int32_t hotspotY)
+{
+  // set_cursor on webOS completely breaks pointer input
+}
+
+} // namespace KODI::WINDOWING::WAYLAND

--- a/xbmc/windowing/wayland/SeatWebOS.cpp
+++ b/xbmc/windowing/wayland/SeatWebOS.cpp
@@ -19,4 +19,11 @@ void CSeatWebOS::SetCursor(std::uint32_t serial,
   // set_cursor on webOS completely breaks pointer input
 }
 
+void CSeatWebOS::InstallKeyboardRepeatInfo()
+{
+  // Since webOS 7 the compositor sends the following key repeat info:
+  // Key repeat rate: 40 cps, delay 400 ms
+  // Which is too fast for the long press detection
+}
+
 } // namespace KODI::WINDOWING::WAYLAND

--- a/xbmc/windowing/wayland/SeatWebOS.h
+++ b/xbmc/windowing/wayland/SeatWebOS.h
@@ -1,0 +1,30 @@
+/*
+*  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "Seat.h"
+
+namespace KODI::WINDOWING::WAYLAND
+{
+
+class CSeatWebOS final : public CSeat
+{
+public:
+  CSeatWebOS(std::uint32_t globalName, wayland::seat_t const& seat, CConnection& connection)
+    : CSeat(globalName, seat, connection)
+  {
+  }
+
+  void SetCursor(std::uint32_t serial,
+                 wayland::surface_t const& surface,
+                 std::int32_t hotspotX,
+                 std::int32_t hotspotY) override;
+};
+
+} // namespace KODI::WINDOWING::WAYLAND

--- a/xbmc/windowing/wayland/SeatWebOS.h
+++ b/xbmc/windowing/wayland/SeatWebOS.h
@@ -25,6 +25,9 @@ public:
                  wayland::surface_t const& surface,
                  std::int32_t hotspotX,
                  std::int32_t hotspotY) override;
+
+protected:
+  void InstallKeyboardRepeatInfo() override;
 };
 
 } // namespace KODI::WINDOWING::WAYLAND

--- a/xbmc/windowing/wayland/WinSystemWayland.h
+++ b/xbmc/windowing/wayland/WinSystemWayland.h
@@ -122,6 +122,8 @@ protected:
   void OnConfigure(std::uint32_t serial, CSizeInt size, IShellSurface::StateBitset state) override;
   void OnClose() override;
 
+  virtual std::unique_ptr<CSeat> CreateSeat(std::uint32_t name, wayland::seat_t& seat);
+
 private:
   // IInputHandler
   void OnEnter(InputType type) override;
@@ -208,7 +210,7 @@ private:
 
   // Seat handling
   // -------------
-  std::map<std::uint32_t, CSeat> m_seats;
+  std::map<std::uint32_t, std::unique_ptr<CSeat>> m_seats;
   CCriticalSection m_seatsMutex;
   std::unique_ptr<CSeatInputProcessing> m_seatInputProcessing;
   std::map<std::uint32_t, std::shared_ptr<COutput>> m_outputs;

--- a/xbmc/windowing/wayland/WinSystemWaylandWebOS.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandWebOS.cpp
@@ -11,6 +11,7 @@
 #include "Connection.h"
 #include "OSScreenSaverWebOS.h"
 #include "Registry.h"
+#include "SeatWebOS.h"
 #include "ShellSurfaceWebOSShell.h"
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPlayer.h"
@@ -146,6 +147,11 @@ IShellSurface* CWinSystemWaylandWebOS::CreateShellSurface(const std::string& nam
 std::unique_ptr<KODI::WINDOWING::IOSScreenSaver> CWinSystemWaylandWebOS::GetOSScreenSaverImpl()
 {
   return std::make_unique<COSScreenSaverWebOS>();
+}
+
+std::unique_ptr<CSeat> CWinSystemWaylandWebOS::CreateSeat(std::uint32_t name, wayland::seat_t& seat)
+{
+  return std::make_unique<CSeatWebOS>(name, seat, *GetConnection());
 }
 
 bool CWinSystemWaylandWebOS::OnAppLifecycleEventWrapper(LSHandle* sh, LSMessage* reply, void* ctx)

--- a/xbmc/windowing/wayland/WinSystemWaylandWebOS.h
+++ b/xbmc/windowing/wayland/WinSystemWaylandWebOS.h
@@ -50,6 +50,7 @@ public:
 
 protected:
   std::unique_ptr<KODI::WINDOWING::IOSScreenSaver> GetOSScreenSaverImpl() override;
+  std::unique_ptr<CSeat> CreateSeat(std::uint32_t name, wayland::seat_t& seat) override;
 
 private:
   static bool OnAppLifecycleEventWrapper(LSHandle* sh, LSMessage* reply, void* ctx);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Long presses were not always registered correctly on webOS 7 and later. On webOS 7+ the compositor sends a keyboard repeat info like this `Key repeat rate: 40 cps, delay 400 ms`. On webOS 6 and below this was not send at all so these values were set at the default. The new values on webOS 7+ are too fast for the long press detection to work.

I did introduce a new `CSeatWebOS` class to avoid ifdeffing and and also remove the current `ifdef` inside `CSeat`.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #24962 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
webOS 7

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
