### PR TITLE
[DllLoader] Remove fstatvfs64 wrapper

### DIFF
--- a/xbmc/cores/DllLoader/exports/wrapper.c
+++ b/xbmc/cores/DllLoader/exports/wrapper.c
@@ -36,7 +36,6 @@ typedef fpos_t    fpos64_t;
 #endif
 
 struct mntent;
-struct statvfs64;
 
 void* dllmalloc(size_t );
 void* dllcalloc( size_t , size_t );
@@ -92,7 +91,6 @@ int dll_ftrylockfile(FILE *file);
 void dll_funlockfile(FILE *file);
 int dll_fstat64(int fd, struct stat64 *buf);
 int dll_fstat(int fd, struct _stat *buf);
-int dll_fstatvfs64(int fildes, struct statvfs64 *buf);
 FILE* dll_popen(const char *command, const char *mode);
 void* dll_dlopen(const char *filename, int flag);
 int dll_setvbuf(FILE *stream, char *buf, int type, size_t size);
@@ -443,11 +441,6 @@ int __wrap_fstat(int fd, struct _stat *buf)
 int __wrap_fstat64(int fd, struct stat64* buf)
 {
   return dll_fstat64(fd, buf);
-}
-
-int __wrap_fstatvfs64(int fd, struct statvfs64* buf)
-{
-  return dll_fstatvfs64(fd, buf);
 }
 
 int __wrap_setvbuf(FILE *stream, char *buf, int type, size_t size)

--- a/xbmc/cores/DllLoader/exports/wrapper_mach_alias
+++ b/xbmc/cores/DllLoader/exports/wrapper_mach_alias
@@ -20,7 +20,6 @@ ___wrap_fread _fread
 ___wrap_freopen _freopen
 ___wrap_fseek _fseek
 ___wrap_fsetpos _fsetpos
-___wrap_fstatvfs64 _fstatvfs64
 ___wrap_ftell _ftell
 ___wrap_ftrylockfile _ftrylockfile
 ___wrap_funlockfile _funlockfile


### PR DESCRIPTION
## Description
Fix issue #24955

```
Unable to load /data/app/~~21tKzYJHPqm5dSVt4v_75w==/org.xbmc.kodi--RnuPO4K2pQyUUtbeV22LQ==/lib/arm64/libdvdnav-aarch64.so, reason: dlopen failed: cannot locate symbol "dll_fstatvfs64"
```

Reported to occur on Android and Linux.

Related to #24893

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
