### PR TITLE
[android] gradle use useLegacyPackaging

### DIFF
--- a/tools/android/packaging/xbmc/build.gradle.in
+++ b/tools/android/packaging/xbmc/build.gradle.in
@@ -47,6 +47,9 @@ android {
     }
     packagingOptions{
       doNotStrip '**.setup'
+      jniLibs {
+          useLegacyPackaging = true
+      }
     }
 }
 


### PR DESCRIPTION
## Description
Fix PIL module loading failure after #24938 

## Motivation and context
Nightlies blew out to almost double their size after #24938 and a user reported a failure when android tried to access a PIL library. Extracting the APK's showed no difference in actual packaged size with/without 24938 commits. Turns out sdk 23 (or maybe 24) introduced a change that alters packaging native libs. This is the "current" method to restore the old behaviour. the deprecated option was a change in the androidmanifest file - https://developer.android.com/guide/topics/manifest/application-element#extractNativeLibs

This uses to the old packaging style for native libs, that makes apk's correctly work, however ive no idea if this will have an effect on aab bundles down the line. Guess thats a future us problem.

## How has this been tested?
Forum user tested armv7 and PIL was functional - https://forum.kodi.tv/showthread.php?tid=377041

## What is the effect on users?
Working shared lib usage (PIL, pycryptodome)

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
