### PR TITLE
[Android] Fix wake-up when sleeping with active hdmi

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -1332,22 +1332,21 @@ void CXBMCApp::onReceive(CJNIIntent intent)
   }
   else if (action == CJNIAudioManager::ACTION_HDMI_AUDIO_PLUG)
   {
-    m_supportsHdmiAudioPlug = true;
-    const bool hdmiPlugged = (intent.getIntExtra(CJNIAudioManager::EXTRA_AUDIO_PLUG_STATE, 0) != 0);
-    android_printf("-- HDMI is plugged in: %s", hdmiPlugged ? "yes" : "no");
+    m_hdmiPlugged = (intent.getIntExtra(CJNIAudioManager::EXTRA_AUDIO_PLUG_STATE, 0) != 0);
+    android_printf("-- HDMI is plugged in: %s", m_hdmiPlugged ? "yes" : "no");
     if (g_application.IsInitialized())
     {
       CWinSystemBase* winSystem = CServiceBroker::GetWinSystem();
       if (winSystem && dynamic_cast<CWinSystemAndroid*>(winSystem))
-        dynamic_cast<CWinSystemAndroid*>(winSystem)->SetHdmiState(hdmiPlugged);
+        dynamic_cast<CWinSystemAndroid*>(winSystem)->SetHdmiState(m_hdmiPlugged);
     }
-    if (hdmiPlugged && m_aeReset)
+    if (m_hdmiPlugged && m_aeReset)
     {
       android_printf("CXBMCApp::onReceive: Reset audio engine");
       CServiceBroker::GetActiveAE()->DeviceChange();
       m_aeReset = false;
     }
-    if (hdmiPlugged && m_wakeUp)
+    if (m_hdmiPlugged && m_wakeUp)
     {
       OnWakeup();
       m_wakeUp = false;
@@ -1361,11 +1360,11 @@ void CXBMCApp::onReceive(CJNIIntent intent)
     // screen but it is actually sent in response to changes in the overall interactive state of
     // the device.
     CLog::Log(LOGINFO, "Got device wakeup intent");
-    if (m_supportsHdmiAudioPlug)
+    if (m_hdmiPlugged)
+      OnWakeup();
+    else
       // wake-up sequence continues in ACTION_HDMI_AUDIO_PLUG intent
       m_wakeUp = true;
-    else
-      OnWakeup();
   }
   else if (action == CJNIIntent::ACTION_SCREEN_OFF)
   {

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -257,7 +257,7 @@ private:
   bool m_hdmiSource{false};
   bool m_wakeUp{false};
   bool m_aeReset{false};
-  bool m_supportsHdmiAudioPlug{false};
+  bool m_hdmiPlugged{true};
   IInputDeviceCallbacks* m_inputDeviceCallbacks{nullptr};
   IInputDeviceEventHandler* m_inputDeviceEventHandler{nullptr};
   bool m_hasReqVisible{false};


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Improved logic for wake-up handling. If hdmi-unplugged-event was received after screen-off-event, we wait for hdmi-plugged-event before calling of wake-up routine. If hdmi remained active during sleep, the wake-up routine is executed directly after receiving of screen-on event (do not wait for hdmi event, which never comes in that case).

Fixes #24950.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In #24632 the call to wake-up routine was moved from event ACTION_SCREEN_ON to ACTION_HDMI_AUDIO_PLUG. That solved issue with sleep/wake-up on Fire TV.

An extra pre-caution was made for systems not supporting ACTION_HDMI_AUDIO_PLUG: on these systems the wake-up routine is executed in ACTION_SCREEN_ON as it was in older versions.

Despite of the pre-caution the change has introduced an issue on Chromecast 4k (#24950). The analysis pointed out to a behavior which we didn't take into account. The device does support ACTION_HDMI_AUDIO_PLUG and sends this event on app start but doesn't send the event when going into sleep or on wake-up. That confuses our code and prevents the wake-up routine from being executed.

### Improvement
Instead of using first incoming event ACTION_HDMI_AUDIO_PLUG as a criteria for decision when to call wake-up routine, we now doing it in a more smarter way:
- if after event ACTION_SCREEN_OFF we received event ACTION_HDMI_AUDIO_PLUG (with status "unplugged"), then during wake-up we wait for ACTION_HDMI_AUDIO_PLUG (with status "plugged").
- if event ACTION_SCREEN_OFF wasn't followed by ACTION_HDMI_AUDIO_PLUG (with status "unplugged"), then the wake-up routine is executed immediately after receiving ACTION_SCREEN_ON.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
### Test 1: Fire TV
Test case to ensure the sleep/wake-up still work without issues on Fire TV (test steps copied from #24632):

Fire TV Stick 4K Max 2nd gen, connected to AVR Denon AVC-X4800H, connected to TV LG C1. Fire TV is configured to stop outputting signal on sleep. Fire TV and Kodi are configured to output all audio formats as passthrough, using Kodi IEC packer. HDMI-passthrough and HDMI-Control (CEC) are disabled on AVR.

1. Start Kodi.
2. Make sure audio passthrough is configured in Kodi settings, using Kodi IEC packer.
3. Playback a video with multichannel audio such as Dolby Digital or DTS, check on 4. AVR that the incoming signal is correct.
5. Stop video playback.
6. Switch off all devices using on/off button on Fire TV remote. If Fire TV is properly configured the AVR and TV will both switch off.
7. Wait a few seconds for sleep mode to activate.
8. Press on/off button on Fire TV remote to wake up Fire TV and switch on AVR and TV.
9. Kodi should be active.
10. Try to playback the same video.
11. Check incoming signal on AVR.
12. Go to Audio settings in Kodi. Check that Kodi IEC packer is still selected as audio passthrough device.
#### Test results
On step 10 AVR shows the same input signal as on step 3. On step 11 "Kodi IEC packer" is in the list of audio devices and it is selected as output device. Audio passthrough works correctly.

### Test 2: Chromecast 4K
@diogosena, who has reported the problem, confirmed the PR has fixed the issue for him: https://github.com/xbmc/xbmc/issues/24950#issuecomment-2046138560. 

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Sleep/wake-up should now work correctly on Chromecast 4K.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
