### PR TITLE
[Android][libass] Unneeded link to libc++

### DIFF
--- a/tools/depends/target/libass/Makefile
+++ b/tools/depends/target/libass/Makefile
@@ -1,12 +1,6 @@
 include ../../Makefile.include LIBASS-VERSION ../../download-files.include
 DEPS = ../../Makefile.include Makefile LIBASS-VERSION ../../download-files.include
 
-ifeq ($(OS),android)
-  # Android API Level 21/22 requires explicit link.
-  # This doesnt appear to be required for API Level 23+ (Android 6+)
-  export LDFLAGS+= -lstdc++
-endif
-
 # configuration settings
 CONFIGURE=cp -f $(CONFIG_SUB) $(CONFIG_GUESS) .; \
           ./configure --prefix=$(PREFIX) \


### PR DESCRIPTION
## Description
As the minimum API level is set to 24 there is no need for this explicit link to libc++.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
