### PR TITLE
[WIP][videoplayer][pvr] implement picture support within VideoPlayer ID3 tag stream

### DIFF
--- a/addons/skin.estuary/xml/MusicVisualisation.xml
+++ b/addons/skin.estuary/xml/MusicVisualisation.xml
@@ -14,22 +14,45 @@
 			<visible>!Skin.HasSetting(hide_background_fanart)</visible>
 			<animation effect="zoom" start="105" end="130" center="auto" time="10000" tween="sine" easing="inout" pulse="true" condition="Skin.HasSetting(animate_background_fanart)">Conditional</animation>
 			<animation effect="slide" start="-30,-30" end="30,30" time="6000" tween="sine" easing="inout" pulse="true" condition="Skin.HasSetting(animate_background_fanart)">Conditional</animation>
-			<control type="image">
-				<aspectratio>scale</aspectratio>
-				<fadetime>400</fadetime>
-				<animation effect="fade" start="0" end="100" time="400">WindowOpen</animation>
-				<animation effect="fade" start="100" end="0" time="300">WindowClose</animation>
-				<animation effect="fade" start="100" end="50" time="0" condition="Visualisation.Enabled">Conditional</animation>
-				<texture background="true">$INFO[Player.Art(fanart)]</texture>
-				<visible>String.IsEmpty(Window(Visualisation).Property(ArtistSlideshow.Image))</visible>
+			<control type="group">
+				<visible>!PVR.IsPlayingRadio</visible>
+				<control type="image">
+					<aspectratio>scale</aspectratio>
+					<fadetime>400</fadetime>
+					<animation effect="fade" start="0" end="100" time="400">WindowOpen</animation>
+					<animation effect="fade" start="100" end="0" time="300">WindowClose</animation>
+					<animation effect="fade" start="100" end="50" time="0" condition="Visualisation.Enabled">Conditional</animation>
+					<texture background="true">$INFO[Player.Art(fanart)]</texture>
+					<visible>String.IsEmpty(Window(Visualisation).Property(ArtistSlideshow.Image))</visible>
+				</control>
+				<control type="image">
+					<aspectratio>scale</aspectratio>
+					<fadetime>400</fadetime>
+					<animation effect="fade" start="0" end="100" time="400">WindowOpen</animation>
+					<animation effect="fade" start="100" end="0" time="300">WindowClose</animation>
+					<animation effect="fade" start="100" end="50" time="0" condition="Visualisation.Enabled">Conditional</animation>
+					<texture background="true">$INFO[Window(Visualisation).Property(ArtistSlideshow.Image)]</texture>
+				</control>
 			</control>
-			<control type="image">
-				<aspectratio>scale</aspectratio>
-				<fadetime>400</fadetime>
-				<animation effect="fade" start="0" end="100" time="400">WindowOpen</animation>
-				<animation effect="fade" start="100" end="0" time="300">WindowClose</animation>
-				<animation effect="fade" start="100" end="50" time="0" condition="Visualisation.Enabled">Conditional</animation>
-				<texture background="true">$INFO[Window(Visualisation).Property(ArtistSlideshow.Image)]</texture>
+			<control type="group">
+				<visible>PVR.IsPlayingRadio</visible>
+				<control type="image">
+					<aspectratio>keep</aspectratio>
+					<fadetime>400</fadetime>
+					<animation effect="fade" start="0" end="100" time="400">WindowOpen</animation>
+					<animation effect="fade" start="100" end="0" time="300">WindowClose</animation>
+					<animation effect="fade" start="100" end="50" time="0" condition="Visualisation.Enabled">Conditional</animation>
+					<texture background="true">$INFO[Player.Art(fanart)]</texture>
+					<visible>String.IsEmpty(Window(Visualisation).Property(ArtistSlideshow.Image))</visible>
+				</control>
+				<control type="image">
+					<aspectratio>keep</aspectratio>
+					<fadetime>400</fadetime>
+					<animation effect="fade" start="0" end="100" time="400">WindowOpen</animation>
+					<animation effect="fade" start="100" end="0" time="300">WindowClose</animation>
+					<animation effect="fade" start="100" end="50" time="0" condition="Visualisation.Enabled">Conditional</animation>
+					<texture background="true">$INFO[Window(Visualisation).Property(ArtistSlideshow.Image)]</texture>
+				</control>
 			</control>
 		</control>
 		<control type="group">

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudioID3.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudioID3.cpp
@@ -10,13 +10,18 @@
 
 #include "DVDStreamInfo.h"
 #include "GUIInfoManager.h"
+#include "GUIUserMessages.h"
 #include "Interface/DemuxPacket.h"
 #include "ServiceBroker.h"
 #include "application/Application.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
+#include "filesystem/SpecialProtocol.h"
 #include "guilib/GUIComponent.h"
+#include "guilib/GUIWindowManager.h"
 #include "music/tags/MusicInfoTag.h"
+#include "pvr/channels/PVRChannel.h"
+#include "pvr/channels/PVRRadioRDSInfoTag.h"
 #include "utils/Digest.h"
 #include "utils/log.h"
 
@@ -29,6 +34,7 @@
 #include <taglib/textidentificationframe.h>
 
 using namespace TagLib;
+using namespace PVR;
 
 using namespace std::chrono_literals;
 
@@ -90,6 +96,10 @@ void CVideoPlayerAudioID3::CloseStream(bool bWaitForBuffers)
   StopThread();
 
   m_messageQueue.End();
+  m_currentRadiotext.reset();
+  if (m_currentPVRChannel)
+    m_currentPVRChannel->SetRadioRDSInfoTag(m_currentRadiotext);
+  m_currentPVRChannel.reset();
 }
 
 void CVideoPlayerAudioID3::SendMessage(std::shared_ptr<CDVDMsg> pMsg, int priority)
@@ -155,6 +165,10 @@ void CVideoPlayerAudioID3::Process()
     else if (pMsg->IsType(CDVDMsg::PLAYER_SETSPEED))
     {
       m_speed = std::static_pointer_cast<CDVDMsgInt>(pMsg)->m_value;
+    }
+    else if (pMsg->IsType(CDVDMsg::GENERAL_FLUSH) || pMsg->IsType(CDVDMsg::GENERAL_RESET))
+    {
+      ResetCache();
     }
   }
 }
@@ -255,28 +269,83 @@ void CVideoPlayerAudioID3::ProcessID3v2(const ID3v2::Tag* tag) const
     MUSIC_INFO::CMusicInfoTag* currentMusic = currentMusicFile.GetMusicInfoTag();
     if (currentMusic)
     {
+      if (m_currentRadiotext)
+        m_currentRadiotext->SetPlayingRadioText(true);
+
       bool changed = false;
 
       const ID3v2::FrameListMap& frameListMap = tag->frameListMap();
       for (const auto& it : frameListMap)
       {
-        if (it.first == "TIT2")
+        if (it.first[0] == 'T')
         {
-          const std::string str = it.second.front()->toString().to8Bit(true);
-          currentMusic->SetTitle(str);
-          changed = true;
-        }
+          std::string str = it.second.front()->toString().to8Bit(true);
+          if (str == "!!!EMPTY!!!")
+            str = "";
 
-        else if (it.first == "TPE1")
-        {
-          currentMusic->SetArtist(GetID3v2StringList(it.second), true);
-          changed = true;
-        }
+          if (it.first == "TKDL")
+          {
+            if (m_currentRadiotext)
+              m_currentRadiotext->SetRadioText(str);
+          }
 
-        else if (it.first == "TALB")
-        {
-          const std::string str = it.second.front()->toString().to8Bit(true);
-          currentMusic->SetAlbum(str);
+          else if (it.first == "TKNO")
+          {
+            if (m_currentRadiotext)
+              m_currentRadiotext->SetProgNow(str);
+          }
+
+          else if (it.first == "TKNE")
+          {
+            if (m_currentRadiotext)
+              m_currentRadiotext->SetProgNext(str);
+          }
+
+          else if (it.first == "TIT2")
+          {
+            if (!str.empty())
+            {
+              currentMusic->SetTitle(str);
+              if (m_currentRadiotext)
+                m_currentRadiotext->SetTitle(str);
+            }
+            else
+            {
+              ClearPlayingTitle(currentMusic);
+            }
+          }
+
+          else if (it.first == "TPE1")
+          {
+            currentMusic->SetArtist(GetID3v2StringList(it.second), true);
+            if (m_currentRadiotext)
+              m_currentRadiotext->SetArtist(str);
+          }
+
+          else if (it.first == "TALB")
+          {
+            currentMusic->SetAlbum(str);
+            if (m_currentRadiotext)
+              m_currentRadiotext->SetAlbum(str);
+          }
+
+          else if (it.first == "TCON")
+          {
+            currentMusic->SetGenre(GetID3v2StringList(it.second));
+          }
+
+          else if (it.first == "TYER")
+          {
+            currentMusic->SetYear(
+                static_cast<int>(strtol(it.second.front()->toString().toCString(true), nullptr, 10)));
+          }
+
+          else if (it.first == "TRCK")
+          {
+            currentMusic->SetTrackNumber(
+                static_cast<int>(strtol(it.second.front()->toString().toCString(true), nullptr, 10)));
+          }
+
           changed = true;
         }
 
@@ -288,31 +357,15 @@ void CVideoPlayerAudioID3::ProcessID3v2(const ID3v2::Tag* tag) const
             auto commentsFrame = dynamic_cast<const ID3v2::CommentsFrame*>(ct);
             if (commentsFrame && commentsFrame->description().isEmpty())
             {
-              currentMusic->SetComment(commentsFrame->text().to8Bit(true));
+              const std::string str = it.second.front()->toString().to8Bit(true);
+              currentMusic->SetComment(str);
+
+              if (m_currentRadiotext)
+                m_currentRadiotext->SetComment(str);
               changed = true;
               break;
             }
           }
-        }
-
-        else if (it.first == "TCON")
-        {
-          currentMusic->SetGenre(GetID3v2StringList(it.second));
-          changed = true;
-        }
-
-        else if (it.first == "TYER")
-        {
-          currentMusic->SetYear(
-              static_cast<int>(strtol(it.second.front()->toString().toCString(true), nullptr, 10)));
-          changed = true;
-        }
-
-        else if (it.first == "TRCK")
-        {
-          currentMusic->SetTrackNumber(
-              static_cast<int>(strtol(it.second.front()->toString().toCString(true), nullptr, 10)));
-          changed = true;
         }
 
         // Support for setting the cover art image via CMusicInfoTag does not currently exist,
@@ -341,7 +394,7 @@ void CVideoPlayerAudioID3::ProcessID3v2(const ID3v2::Tag* tag) const
 
               int picTypeId;
               std::string picTypeName;
-              ;
+
               if (type == ID3v2::AttachedPictureFrame::FrontCover)
               {
                 picTypeId = 0;
@@ -416,4 +469,35 @@ std::vector<std::string> CVideoPlayerAudioID3::StringListToVectorString(
   for (const auto& value : stringList)
     values.emplace_back(value.to8Bit(true));
   return values;
+}
+
+void CVideoPlayerAudioID3::ResetCache()
+{
+  m_currentPVRChannel = g_application.CurrentFileItem().GetPVRChannelInfoTag();
+  if (m_currentPVRChannel)
+  {
+    m_currentRadiotext = std::make_shared<CPVRRadioRDSInfoTag>();
+    m_currentPVRChannel->SetRadioRDSInfoTag(m_currentRadiotext);
+  }
+
+  // send a message to all windows to tell them to update the radiotext
+  CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
+  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
+}
+
+void CVideoPlayerAudioID3::ClearPlayingTitle(MUSIC_INFO::CMusicInfoTag* currentMusic) const
+{
+  currentMusic->SetTitle("");
+  currentMusic->SetArtist("");
+  currentMusic->SetAlbum("");
+  currentMusic->SetGenre("");
+  currentMusic->SetYear(0);
+  currentMusic->SetTrackNumber(0);
+
+  if (m_currentRadiotext)
+  {
+    m_currentRadiotext->SetTitle("");
+    m_currentRadiotext->SetArtist("");
+    m_currentRadiotext->SetAlbum("");
+  }
 }

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudioID3.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudioID3.cpp
@@ -13,8 +13,11 @@
 #include "Interface/DemuxPacket.h"
 #include "ServiceBroker.h"
 #include "application/Application.h"
+#include "filesystem/Directory.h"
+#include "filesystem/File.h"
 #include "guilib/GUIComponent.h"
 #include "music/tags/MusicInfoTag.h"
+#include "utils/Digest.h"
 #include "utils/log.h"
 
 #include <taglib/attachedpictureframe.h>
@@ -33,6 +36,9 @@ CVideoPlayerAudioID3::CVideoPlayerAudioID3(CProcessInfo& processInfo)
   : IDVDStreamPlayer(processInfo), CThread("VideoPlayerAudioID3"), m_messageQueue("id3")
 {
   CLog::Log(LOGDEBUG, "Audio ID3 tag processor - new {}", __FUNCTION__);
+
+  if (!XFILE::CDirectory::Exists(m_cacheDir))
+    XFILE::CDirectory::Create(m_cacheDir);
 }
 
 CVideoPlayerAudioID3::~CVideoPlayerAudioID3()
@@ -245,7 +251,8 @@ void CVideoPlayerAudioID3::ProcessID3v2(const ID3v2::Tag* tag) const
 {
   if (tag != nullptr && !tag->isEmpty())
   {
-    MUSIC_INFO::CMusicInfoTag* currentMusic = g_application.CurrentFileItem().GetMusicInfoTag();
+    CFileItem& currentMusicFile = g_application.CurrentFileItem();
+    MUSIC_INFO::CMusicInfoTag* currentMusic = currentMusicFile.GetMusicInfoTag();
     if (currentMusic)
     {
       bool changed = false;
@@ -253,83 +260,138 @@ void CVideoPlayerAudioID3::ProcessID3v2(const ID3v2::Tag* tag) const
       const ID3v2::FrameListMap& frameListMap = tag->frameListMap();
       for (const auto& it : frameListMap)
       {
-        if (!it.second.isEmpty())
+        if (it.first == "TIT2")
         {
-          if (it.first == "TIT2")
-          {
-            currentMusic->SetTitle(it.second.front()->toString().to8Bit(true));
-            changed = true;
-          }
+          const std::string str = it.second.front()->toString().to8Bit(true);
+          currentMusic->SetTitle(str);
+          changed = true;
+        }
 
-          else if (it.first == "TPE1")
-          {
-            currentMusic->SetArtist(GetID3v2StringList(it.second));
-            changed = true;
-          }
+        else if (it.first == "TPE1")
+        {
+          currentMusic->SetArtist(GetID3v2StringList(it.second), true);
+          changed = true;
+        }
 
-          else if (it.first == "TALB")
-          {
-            currentMusic->SetAlbum(it.second.front()->toString().to8Bit(true));
-            changed = true;
-          }
+        else if (it.first == "TALB")
+        {
+          const std::string str = it.second.front()->toString().to8Bit(true);
+          currentMusic->SetAlbum(str);
+          changed = true;
+        }
 
-          else if (it.first == "COMM")
+        else if (it.first == "COMM")
+        {
+          // Loop through and look for the main (no description) comment
+          for (const auto& ct : it.second)
           {
-            // Loop through and look for the main (no description) comment
-            for (const auto& ct : it.second)
+            auto commentsFrame = dynamic_cast<const ID3v2::CommentsFrame*>(ct);
+            if (commentsFrame && commentsFrame->description().isEmpty())
             {
-              auto commentsFrame = dynamic_cast<const ID3v2::CommentsFrame*>(ct);
-              if (commentsFrame && commentsFrame->description().isEmpty())
+              currentMusic->SetComment(commentsFrame->text().to8Bit(true));
+              changed = true;
+              break;
+            }
+          }
+        }
+
+        else if (it.first == "TCON")
+        {
+          currentMusic->SetGenre(GetID3v2StringList(it.second));
+          changed = true;
+        }
+
+        else if (it.first == "TYER")
+        {
+          currentMusic->SetYear(
+              static_cast<int>(strtol(it.second.front()->toString().toCString(true), nullptr, 10)));
+          changed = true;
+        }
+
+        else if (it.first == "TRCK")
+        {
+          currentMusic->SetTrackNumber(
+              static_cast<int>(strtol(it.second.front()->toString().toCString(true), nullptr, 10)));
+          changed = true;
+        }
+
+        // Support for setting the cover art image via CMusicInfoTag does not currently exist,
+        // the code sample below would check for an ID3v2 "APIC" tag of the proper type and
+        // convert the information into an EmbeddedArt object instance
+        //
+        else if (it.first == "APIC")
+        {
+          using KODI::UTILITY::CDigest;
+
+          // Loop through and look for the FrontCover picture frame
+          for (const auto& pi : it.second)
+          {
+            auto pictureFrame = dynamic_cast<ID3v2::AttachedPictureFrame*>(pi);
+            if (pictureFrame)
+            {
+              std::string ext;
+              if (pictureFrame->mimeType().to8Bit(true) == "image/png")
+                ext = "png";
+              else if (pictureFrame->mimeType().to8Bit(true) == "image/jpeg")
+                ext = "jpg";
+              else
+                continue;
+
+              const ID3v2::AttachedPictureFrame::Type type = pictureFrame->type();
+
+              int picTypeId;
+              std::string picTypeName;
+              ;
+              if (type == ID3v2::AttachedPictureFrame::FrontCover)
               {
-                currentMusic->SetComment(commentsFrame->text().to8Bit(true));
+                picTypeId = 0;
+                picTypeName = "fanart";
+              }
+              else if (type == ID3v2::AttachedPictureFrame::FileIcon)
+              {
+                picTypeId = 1;
+                picTypeName = "thumb";
+              }
+              else
+                continue;
+
+              const uint8_t* data =
+                  reinterpret_cast<const uint8_t*>(pictureFrame->picture().data());
+              const size_t size = pictureFrame->size();
+              const std::string md5 = CDigest::Calculate(CDigest::Type::MD5, data, size);
+
+              if (m_ImageTypeList[picTypeId].lastMD5 == md5)
+                continue;
+
+              std::string cacheDir = StringUtils::Format("{}/{}-{}.{}", m_cacheDir, picTypeName,
+                                                         m_ImageTypeList[picTypeId].toogleId, ext);
+
+              XFILE::CFile file;
+              if (file.OpenForWrite(cacheDir, true))
+              {
+                file.Write(reinterpret_cast<const uint8_t*>(pictureFrame->picture().data()),
+                           pictureFrame->size());
+                file.Close();
+
+                currentMusicFile.SetArt(picTypeName, cacheDir);
+
+                m_ImageTypeList[picTypeId].lastMD5 = md5;
+                m_ImageTypeList[picTypeId].toogleId = m_ImageTypeList[picTypeId].toogleId ? 0 : 1;
+
+                if (!m_ImageTypeList[picTypeId].lastExt.empty())
+                {
+                  cacheDir = StringUtils::Format("{}/{}-{}.{}", m_cacheDir, picTypeName,
+                                                 m_ImageTypeList[picTypeId].toogleId,
+                                                 m_ImageTypeList[picTypeId].lastExt);
+                  XFILE::CFile::Delete(cacheDir);
+                }
+
+                m_ImageTypeList[picTypeId].lastExt = ext;
+
                 changed = true;
-                break;
               }
             }
           }
-
-          else if (it.first == "TCON")
-          {
-            currentMusic->SetGenre(GetID3v2StringList(it.second));
-            changed = true;
-          }
-
-          else if (it.first == "TYER")
-          {
-            currentMusic->SetYear(static_cast<int>(
-                strtol(it.second.front()->toString().toCString(true), nullptr, 10)));
-            changed = true;
-          }
-
-          else if (it.first == "TRCK")
-          {
-            currentMusic->SetTrackNumber(static_cast<int>(
-                strtol(it.second.front()->toString().toCString(true), nullptr, 10)));
-            changed = true;
-          }
-
-          // Support for setting the cover art image via CMusicInfoTag does not currently exist,
-          // the code sample below would check for an ID3v2 "APIC" tag of the proper type and
-          // convert the information into an EmbeddedArt object instance
-          //
-          // else if (it.first == "APIC")
-          // {
-          //  // Loop through and look for the FrontCover picture frame
-          //  for (const auto& pi : it.second)
-          //  {
-          //    auto pictureFrame = dynamic_cast<ID3v2::AttachedPictureFrame*>(pi);
-          //    if (pictureFrame && pictureFrame->type() == ID3v2::AttachedPictureFrame::FrontCover)
-          //    {
-          //      EmbeddedArt coverArt(
-          //          reinterpret_cast<const uint8_t*>(pictureFrame->picture().data()),
-          //          pictureFrame->size(), pictureFrame->mimeType().to8Bit(true));
-
-          //      // Assumes "void CMusicInfoTag::SetCoverArt(const EmbeddedArt& art)" exists
-          //      currentMusic->SetCoverArt(coverArt);
-          //      changed = true;
-          //    }
-          //  }
-          // }
         }
       }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudioID3.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudioID3.h
@@ -55,4 +55,12 @@ private:
   int m_speed = DVD_PLAYSPEED_NORMAL;
   CCriticalSection m_critSection;
   CDVDMessageQueue m_messageQueue;
+
+  const std::string m_cacheDir = "special://temp/audio_id3";
+  mutable struct TOGGLE_DATA
+  {
+    int toogleId = 0;
+    std::string lastExt;
+    std::string lastMD5;
+  } m_ImageTypeList[2];
 };

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudioID3.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudioID3.h
@@ -22,6 +22,12 @@
 #include <taglib/id3v2tag.h>
 #include <taglib/tstringlist.h>
 
+namespace PVR
+{
+class CPVRChannel;
+class CPVRRadioRDSInfoTag;
+} // namespace PVR
+
 class CVideoPlayerAudioID3 : public IDVDStreamPlayer, private CThread
 {
 public:
@@ -45,9 +51,11 @@ protected:
   void Process() override;
 
 private:
+  void ResetCache();
   void ProcessID3(const unsigned char* data, unsigned int length) const;
   void ProcessID3v1(const TagLib::ID3v1::Tag* tag) const;
   void ProcessID3v2(const TagLib::ID3v2::Tag* tag) const;
+  void ClearPlayingTitle(MUSIC_INFO::CMusicInfoTag* currentMusic) const;
 
   static std::vector<std::string> GetID3v2StringList(const TagLib::ID3v2::FrameList& frameList);
   static std::vector<std::string> StringListToVectorString(const TagLib::StringList& stringList);
@@ -55,6 +63,8 @@ private:
   int m_speed = DVD_PLAYSPEED_NORMAL;
   CCriticalSection m_critSection;
   CDVDMessageQueue m_messageQueue;
+  std::shared_ptr<PVR::CPVRRadioRDSInfoTag> m_currentRadiotext;
+  std::shared_ptr<PVR::CPVRChannel> m_currentPVRChannel;
 
   const std::string m_cacheDir = "special://temp/audio_id3";
   mutable struct TOGGLE_DATA


### PR DESCRIPTION
## Description

Is still marked as WIP as not 100% testet for all cases, add-on not finished and maybe I combine with RDS to give https://github.com/xbmc/xbmc/blob/master/xbmc/pvr/channels/PVRRadioRDSInfoTag.cpp data too, as the basic ID3 not support what a radio stream can bring.

---------------------------------------

This adds needed changes to become the image support working within. As note, as ID3 tag is normally not designed for streams with content changes was some special parts needed. To know that the image is changed becomes on every call a MD5 checksum done and to compare to previous image and to know is changed.

Further, as on Radio streams it can also comes that no song track runs, becomes now not checked about empty values on begin and allow to clear a title, as this can happen.

The DAB+ presented the images in 320x240 pixels, but the stream will also gives URL (e.g. https://onair.swr.de/radiovis/swr3/current.jpg) and will look that add-on download the pictures (if user want id within settings)

This relates primary to PVR add-ons (Radio streams), but this M3U type can also be used for inputstream add-ons itself.

>NOTE: The change on skin xml was needed as the presented pictures are in 4/3 and texts on lower area where then was gone partly away.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
https://github.com/kodi-pvr/pvr.rtlradio/pull/19
>NOTE: add-on request currently not sync to test by this!

<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

Here about what comes when add-on brings the infos
![Screenshot 2024-04-11 202358](https://github.com/xbmc/xbmc/assets/6879739/46a5710a-6c15-46f3-84b4-d586a4059d67)
![Screenshot 2024-04-11 202444](https://github.com/xbmc/xbmc/assets/6879739/40dc6bcd-aadd-411c-a879-b175cda4098c)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
