### PR TITLE
[video] Improve Performance of the "Choose version" dialog

### DIFF
--- a/xbmc/video/guilib/VideoVersionHelper.cpp
+++ b/xbmc/video/guilib/VideoVersionHelper.cpp
@@ -46,7 +46,7 @@ private:
   std::shared_ptr<const CFileItem> ChooseVideo(CGUIDialogSelect& dialog,
                                                int headingId,
                                                int buttonId,
-                                               const CFileItemList& itemsToDisplay,
+                                               CFileItemList& itemsToDisplay,
                                                const CFileItemList& itemsToSwitchTo);
 
   const std::shared_ptr<const CFileItem> m_item;
@@ -151,15 +151,13 @@ std::shared_ptr<const CFileItem> CVideoChooser::ChooseVideoExtra()
 std::shared_ptr<const CFileItem> CVideoChooser::ChooseVideo(CGUIDialogSelect& dialog,
                                                             int headingId,
                                                             int buttonId,
-                                                            const CFileItemList& itemsToDisplay,
+                                                            CFileItemList& itemsToDisplay,
                                                             const CFileItemList& itemsToSwitchTo)
 {
   CVideoThumbLoader thumbLoader;
+  thumbLoader.Load(itemsToDisplay);
   for (auto& item : itemsToDisplay)
-  {
-    thumbLoader.LoadItem(item.get());
     item->SetLabel2(item->GetVideoInfoTag()->m_strFileNameAndPath);
-  }
 
   dialog.Reset();
 
@@ -173,6 +171,9 @@ std::shared_ptr<const CFileItem> CVideoChooser::ChooseVideo(CGUIDialogSelect& di
   dialog.SetItems(itemsToDisplay);
 
   dialog.Open();
+
+  if (thumbLoader.IsLoading())
+    thumbLoader.StopThread();
 
   m_switchType = dialog.IsButtonPressed();
   if (dialog.IsConfirmed())


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Simplified the structure of the query that retrieves art to avoid a table scan for MariaDB engine.
This improved performance of sqlite as well, though not as drastically.

Made art loading async for the "Choose version" dialog, although it doesn't make much difference with the relatively low number of rows of versions or extras.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

1-2 second delay noticed before the choose version dialog appears after selecting a movie.

It turned out that MariaDB query optimizer failed to use an index of the art table with the subquery structure of the SQL query.
Sqlite didn't have that issue (not to the same degree at least).

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Sqlite and MariaDB 10 & 11.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

No delay for version/extra selection with remote database.

## Screenshots (if appropriate):

MariaDB, 64k rows in art table.

Before, 1.5s:
![image](https://github.com/xbmc/xbmc/assets/489377/0b05ac61-8f83-4b27-b6f7-c04b73908fd0)

After, 3ms:
![image](https://github.com/xbmc/xbmc/assets/489377/3841859a-8afd-45c7-afac-6b5aabeb4023)

The difference is less drastic with sqlite (20-30% improvement of a considerably lower baseline).

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
