### PR TITLE
[videoplayer] Add hdrtype filter to player selection rules

### DIFF
--- a/xbmc/cores/playercorefactory/PlayerSelectionRule.cpp
+++ b/xbmc/cores/playercorefactory/PlayerSelectionRule.cpp
@@ -63,9 +63,11 @@ void CPlayerSelectionRule::Initialize(TiXmlElement* pRule)
   m_videoCodec = XMLUtils::GetAttribute(pRule, "videocodec");
   m_videoResolution = XMLUtils::GetAttribute(pRule, "videoresolution");
   m_videoAspect = XMLUtils::GetAttribute(pRule, "videoaspect");
+  m_hdrType = XMLUtils::GetAttribute(pRule, "hdrtype");
 
   m_bStreamDetails = m_audioCodec.length() > 0 || m_audioChannels.length() > 0 ||
-    m_videoCodec.length() > 0 || m_videoResolution.length() > 0 || m_videoAspect.length() > 0;
+                     m_videoCodec.length() > 0 || m_videoResolution.length() > 0 ||
+                     m_videoAspect.length() > 0 || m_hdrType.length() > 0;
 
   if (m_bStreamDetails && !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_MYVIDEOS_EXTRACTFLAGS))
   {
@@ -165,6 +167,13 @@ void CPlayerSelectionRule::GetPlayers(const CFileItem& item, std::vector<std::st
 
     if (CompileRegExp(m_videoAspect, regExp) &&
         !MatchesRegExp(CStreamDetails::VideoAspectToAspectDescription(streamDetails.GetVideoAspect()),  regExp))
+      return;
+
+    std::string hdrType{streamDetails.GetVideoHdrType()};
+    if (hdrType.length() == 0)
+      hdrType = "none";
+
+    if (CompileRegExp(m_hdrType, regExp) && !MatchesRegExp(hdrType, regExp))
       return;
   }
 

--- a/xbmc/cores/playercorefactory/PlayerSelectionRule.h
+++ b/xbmc/cores/playercorefactory/PlayerSelectionRule.h
@@ -55,6 +55,7 @@ private:
   std::string m_videoCodec;
   std::string m_videoResolution;
   std::string m_videoAspect;
+  std::string m_hdrType;
 
   std::string m_playerName;
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Expose the hdrType stream details as a filter that can be used in player selection rules and allow regexp. similar to audiocodec, videocodec, ...

attribute name: hdrtype

Possible values at this time:
dolbyvision
hdr10
hlg
none

none does not exist in stream details (values NULL and blank).
Artificially created because:
- the XML reading code cannot tell the difference between empty and non-existent attribute, so hdrtype="" in a rule is not possible
- changing the conversion of StreamHdrType::HDR_TYPE_NONE to text seemed like it could have far-ranging effects...

example:
```
  <rules action="prepend">  
    <rule hdrtype="dolbyvision" player="MPV"/>
  </rules>
```
## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

More reliable automatic selection of players (filters had to be based on filename so far).

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

playercorefactory.xml with 4 external players defined and rules defined for each type of hdr (and lack of hdr)
tried videos with dolby vision, hdr10, hlg and no hdr.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

More reliable automatic selection of player for hdr streams.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
