### PR TITLE
[webOS] Implement DTS support

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1313,7 +1313,7 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
         format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_AC3;
         format.m_streamInfo.m_channels = 2;
         format.m_streamInfo.m_sampleRate = 48000;
-        format.m_streamInfo.m_ac3FrameSize = m_encoderFormat.m_frames;
+        format.m_streamInfo.m_frameSize = m_encoderFormat.m_frames;
         //! @todo implement
         if (m_encoderBuffers && initSink)
         {

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -458,15 +458,15 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
           rawlength_in_seconds = 8 * m_format.m_streamInfo.GetDuration() / 1000;
           break;
         case CAEStreamInfo::STREAM_TYPE_AC3:
-           ac3FrameSize = m_format.m_streamInfo.m_ac3FrameSize;
-           if (ac3FrameSize == 0)
-             ac3FrameSize = 1536; // fallback if not set, e.g. Transcoding
-           m_min_buffer_size = std::max(m_min_buffer_size * 3, ac3FrameSize * 8);
-           m_format.m_frames = m_min_buffer_size;
-           multiplier = m_min_buffer_size / ac3FrameSize; // int division is wanted
-           rawlength_in_seconds = multiplier * m_format.m_streamInfo.GetDuration() / 1000;
+          ac3FrameSize = m_format.m_streamInfo.m_frameSize;
+          if (ac3FrameSize == 0)
+            ac3FrameSize = 1536; // fallback if not set, e.g. Transcoding
+          m_min_buffer_size = std::max(m_min_buffer_size * 3, ac3FrameSize * 8);
+          m_format.m_frames = m_min_buffer_size;
+          multiplier = m_min_buffer_size / ac3FrameSize; // int division is wanted
+          rawlength_in_seconds = multiplier * m_format.m_streamInfo.GetDuration() / 1000;
           break;
-          // EAC3 is currently not supported
+        // EAC3 is currently not supported
         case CAEStreamInfo::STREAM_TYPE_EAC3:
           m_min_buffer_size = 2 * 10752; // least common multiple of 1792 and 1536
           m_format.m_frames = m_min_buffer_size; // needs testing

--- a/xbmc/cores/AudioEngine/Sinks/AESinkDARWINTVOS.mm
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDARWINTVOS.mm
@@ -784,15 +784,15 @@ bool CAESinkDARWINTVOS::Initialize(AEAudioFormat& format, std::string& device)
   switch (format.m_streamInfo.m_type)
   {
     case CAEStreamInfo::STREAM_TYPE_AC3:
-      if (!format.m_streamInfo.m_ac3FrameSize)
-        format.m_streamInfo.m_ac3FrameSize = 1536;
-      format.m_frames = format.m_streamInfo.m_ac3FrameSize;
+      if (!format.m_streamInfo.m_frameSize)
+        format.m_streamInfo.m_frameSize = 1536;
+      format.m_frames = format.m_streamInfo.m_frameSize;
       buffer_size = format.m_frames * 8;
       break;
     case CAEStreamInfo::STREAM_TYPE_EAC3:
-      if (!format.m_streamInfo.m_ac3FrameSize)
-        format.m_streamInfo.m_ac3FrameSize = 1536;
-      format.m_frames = format.m_streamInfo.m_ac3FrameSize;
+      if (!format.m_streamInfo.m_frameSize)
+        format.m_streamInfo.m_frameSize = 1536;
+      format.m_frames = format.m_streamInfo.m_frameSize;
       buffer_size = format.m_frames * 8;
       break;
     case CAEStreamInfo::STREAM_TYPE_DTS_512:

--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
@@ -369,7 +369,7 @@ bool CAEStreamParser::TrySyncAC3(uint8_t* data,
       // no need to resync => return true
       return true;
     }
-    m_info.m_ac3FrameSize = fsizeMain;
+    m_info.m_frameSize = fsizeMain;
     if (TrySyncAC3(data + fsizeMain, size - fsizeMain, resyncing, true))
     {
       // concatenate the main and dependent frames
@@ -393,7 +393,7 @@ bool CAEStreamParser::TrySyncAC3(uint8_t* data,
     m_info.m_channels = AC3Channels[acmod] + lfeon;
     m_syncFunc = &CAEStreamParser::SyncAC3;
     m_info.m_type = CAEStreamInfo::STREAM_TYPE_AC3;
-    m_info.m_ac3FrameSize += m_fsize;
+    m_info.m_frameSize += m_fsize;
     m_info.m_repeat = 1;
 
     CLog::Log(LOGINFO, "CAEStreamParser::TrySyncAC3 - AC3 stream detected ({} channels, {}Hz)",
@@ -452,7 +452,7 @@ bool CAEStreamParser::TrySyncAC3(uint8_t* data,
         // no need to resync => return true
         return true;
       }
-      m_info.m_ac3FrameSize = fsizeMain;
+      m_info.m_frameSize = fsizeMain;
       if (TrySyncAC3(data + fsizeMain, size - fsizeMain, resyncing, true))
       {
         // concatenate the main and dependent frames
@@ -469,7 +469,7 @@ bool CAEStreamParser::TrySyncAC3(uint8_t* data,
     m_info.m_channels = AC3Channels[acmod] + lfeon;
     m_syncFunc = &CAEStreamParser::SyncAC3;
     m_info.m_type = CAEStreamInfo::STREAM_TYPE_EAC3;
-    m_info.m_ac3FrameSize += m_fsize;
+    m_info.m_frameSize += m_fsize;
 
     CLog::Log(LOGINFO, "CAEStreamParser::TrySyncAC3 - E-AC3 stream detected ({} channels, {}Hz)",
               m_info.m_channels, m_info.m_sampleRate);
@@ -673,6 +673,7 @@ unsigned int CAEStreamParser::SyncDTS(uint8_t* data, unsigned int size)
       m_dtsBlocks = dtsBlocks;
       m_info.m_channels = DTSChannels[amode] + (lfe ? 1 : 0);
       m_syncFunc = &CAEStreamParser::SyncDTS;
+      m_info.m_frameSize = m_fsize;
       m_info.m_repeat = 1;
 
       if (dataType == CAEStreamInfo::STREAM_TYPE_DTSHD_MA)
@@ -812,6 +813,7 @@ unsigned int CAEStreamParser::SyncTrueHD(uint8_t* data, unsigned int size)
       m_fsize = length;
       m_info.m_type = CAEStreamInfo::STREAM_TYPE_TRUEHD;
       m_syncFunc = &CAEStreamParser::SyncTrueHD;
+      m_info.m_frameSize = length;
       m_info.m_repeat = 1;
       return skip;
     }

--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.h
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.h
@@ -45,7 +45,7 @@ public:
   bool m_dataIsLE = true;
   unsigned int m_dtsPeriod = 0;
   unsigned int m_repeat = 0;
-  unsigned int m_ac3FrameSize = 0;
+  unsigned int m_frameSize = 0;
 };
 
 class CAEStreamParser


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Implement DTS support for webOS.

The dts packet frame size was not available from `AEStreamInfo` so I renamed `m_ac3FrameSize` to `m_frameSize` and added the necessary changes to the `AEStreamParser` to expose that information. All the other sinks that use this field only use it in case of (e)AC3 audio so the change has no effect on them.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
webOS 8, tried several different DTS format files

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
