### PR TITLE
[Android][libgcrypt] Enable neon support for all arm archs

### DIFF
--- a/tools/depends/target/libgcrypt/Makefile
+++ b/tools/depends/target/libgcrypt/Makefile
@@ -1,13 +1,6 @@
 include ../../Makefile.include LIBGCRYPT-VERSION ../../download-files.include
 DEPS = ../../Makefile.include Makefile LIBGCRYPT-VERSION ../../download-files.include
 
-ifeq ($(OS),android)
-  # Just blanket disable neon support for non arm64 arch
-  ifneq ($(findstring arm64, $(CPU)), arm64)
-    CONFIGURE_FLAGS+= --disable-neon-support
-  endif
-endif
-
 ifeq ($(findstring apple-darwin, $(HOST)), apple-darwin)
   # required to fix asm link failure due C_SYMBOL_NAME macro not prepending _ to exported symbol
   # exported symbols only have s single _ instead of double __


### PR DESCRIPTION
## Description
Remove the flag  `--disable-neon-support`

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
