### PR TITLE
[video] Fix Movie Information Refresh

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -443,6 +443,12 @@ bool CGUIWindowVideoBase::ShowInfo(const CFileItemPtr& item2, const ScraperPtr& 
 
       if (item->IsVideoDb() && item->HasVideoInfoTag())
         item->SetPath(item->GetVideoInfoTag()->GetPath());
+      else if (!item->IsVideoDb() && item->m_bIsFolder)
+      {
+        // Info on folder containing a movie needs dyn path as path for refresh with correct name
+        //! @todo get rid of "videos with versions as folder" hack to be able to fix in CFileItem::GetBaseMoviePath()
+        item->SetPath(item->GetVideoInfoTag()->GetPath());
+      }
     }
   }
 


### PR DESCRIPTION

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Address path/dynpath issue when refreshing movie info from the movie folder in Videos node.
Detailed scenario in "Motivation and context".
In the process of refreshing the movie info, CFileItem::GetBaseMoviePath() needs to see the movie itself (the dyn path) as the path instead of the directory (the "natural" path).

The regression was partially created by commit https://github.com/xbmc/xbmc/commit/167f53ff9390381627e2432081d255fcf7a6c2d4 of PR https://github.com/xbmc/xbmc/pull/23674 and later changes.

A better fix may be to modify CFileItem::GetBaseMoviePath() but I didn't see how to do it in a way that doesn't break the videos with versions represented as folders.

Style of the patch is a bit weird, I didn't find a nice way to combine the two tests and at the same time attach a comment that clearly applies to only one of them.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #24994 / forum https://forum.kodi.tv/showthread.php?tid=377102, regression in v21 versus v20.

With a movie folder structure like this, scanned into library:
Action Movies
  -> The Scorpion King
    -> The Scorpion King.mkv

Refresh movie info in Videos from the folder "The Scorpion King". The movie suggestions of the scraper are based on the parent folder name ("Action Movies" here) instead of the movie name.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with Info/Refresh on folder containing movie, on the movie itself, on tv show, on season and on episode.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Fix movie refresh from movie folder

## Screenshots (if appropriate):
Before, Info then Refresh on the "The Scorpion King" folder, suggestions are for parent directory name "Action Movies":
![image](https://github.com/xbmc/xbmc/assets/489377/712725e5-8f27-482d-ba23-19cf7b55335b)

After, suggestions based on the movie name:
![image](https://github.com/xbmc/xbmc/assets/489377/1710ebf7-2ea3-455d-a389-cad251bdd96e)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
