### PR TITLE
Linux: Use pulseaudio by default again

### DIFF
--- a/xbmc/platform/linux/PlatformLinux.cpp
+++ b/xbmc/platform/linux/PlatformLinux.cpp
@@ -118,9 +118,9 @@ bool CPlatformLinux::InitStageOne()
   }
   else
   {
-    if (!OPTIONALS::PipewireRegister())
+    if (!OPTIONALS::PulseAudioRegister())
     {
-      if (!OPTIONALS::PulseAudioRegister())
+      if (!OPTIONALS::PipewireRegister())
       {
         if (!OPTIONALS::ALSARegister())
         {


### PR DESCRIPTION
Due to multiple reports on the forum it seems the certain pipewire installations (ARCH Linux, flatpak users) do not cope very well with the pipewire setup.

Therefore revert to pulseaudio by default in Omega.

https://forum.kodi.tv/showthread.php?tid=377144
https://forum.kodi.tv/showthread.php?tid=377131
https://forum.kodi.tv/showthread.php?tid=376809