### PR TITLE
[videodb] Movie Deletion/Conversion to Version Refactor and Optimization

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2624,7 +2624,10 @@ int CVideoDatabase::SetDetailsForMovie(CVideoInfoTag& details,
       idMovie = GetMovieId(filePath);
 
     if (idMovie > -1)
-      DeleteMovie(idMovie, true); // true to keep the table entry
+    {
+      const int idFile{GetDbId(PrepareSQL("SELECT idFile FROM movie WHERE idMovie=%i", idMovie))};
+      DeleteStreamDetails(idFile);
+    }
     else
     {
       // only add a new movie if we don't already have a valid idMovie
@@ -3701,9 +3704,7 @@ void CVideoDatabase::DeleteBookMarkForEpisode(const CVideoInfoTag& tag)
 }
 
 //********************************************************************************************************************************
-void CVideoDatabase::DeleteMovie(int idMovie,
-                                 bool bKeepId /* = false */,
-                                 DeleteMovieCascadeAction ca /* = ALL_ASSETS */)
+void CVideoDatabase::DeleteMovie(int idMovie, DeleteMovieCascadeAction ca /* = ALL_ASSETS */)
 {
   if (idMovie < 0)
     return;
@@ -3717,55 +3718,46 @@ void CVideoDatabase::DeleteMovie(int idMovie,
 
     BeginTransaction();
 
-    int idFile = GetDbId(PrepareSQL("SELECT idFile FROM movie WHERE idMovie=%i", idMovie));
+    const int idFile{GetDbId(PrepareSQL("SELECT idFile FROM movie WHERE idMovie=%i", idMovie))};
     DeleteStreamDetails(idFile);
 
-    // keep the movie table entry, linking to tv shows, and bookmarks
-    // so we can update the data in place
-    // the ancillary tables are still purged
-    if (!bKeepId)
+    const std::string path = GetSingleValue(PrepareSQL(
+        "SELECT strPath FROM path JOIN files ON files.idPath=path.idPath WHERE files.idFile=%i",
+        idFile));
+    if (!path.empty())
+      InvalidatePathHash(path);
+
+    const std::string strSQL{PrepareSQL("DELETE FROM movie WHERE idMovie=%i", idMovie)};
+    m_pDS->exec(strSQL);
+
+    if (ca == DeleteMovieCascadeAction::ALL_ASSETS)
     {
-      const std::string path = GetSingleValue(PrepareSQL(
-          "SELECT strPath FROM path JOIN files ON files.idPath=path.idPath WHERE files.idFile=%i",
-          idFile));
-      if (!path.empty())
-        InvalidatePathHash(path);
+      // The default version of the movie was removed by a delete trigger.
+      // Clean up the other assets attached to the movie, if any.
 
-      const std::string strSQL = PrepareSQL("delete from movie where idMovie=%i", idMovie);
-      m_pDS->exec(strSQL);
+      // need local dataset due to nested DeleteVideoAsset query
+      const std::unique_ptr<Dataset> pDS{m_pDB->CreateDataset()};
 
-      if (ca == DeleteMovieCascadeAction::ALL_ASSETS)
+      pDS->query(PrepareSQL("SELECT idFile FROM videoversion WHERE idMedia=%i AND media_type='%s'",
+                            idMovie, MediaTypeMovie));
+
+      while (!pDS->eof())
       {
-        // The default version of the movie was removed by a delete trigger.
-        // Clean up the other assets attached to the movie, if any.
-
-        // need local dataset due to nested DeleteVideoAsset query
-        std::unique_ptr<Dataset> pDS{m_pDB->CreateDataset()};
-
-        pDS->query(
-            PrepareSQL("SELECT idFile FROM videoversion WHERE idMedia=%i AND media_type='%s'",
-                       idMovie, MediaTypeMovie));
-
-        while (!pDS->eof())
+        if (!DeleteVideoAsset(pDS->fv(0).get_asInt()))
         {
-          if (!DeleteVideoAsset(pDS->fv(0).get_asInt()))
-          {
-            RollbackTransaction();
-            pDS->close();
-            return;
-          }
-          pDS->next();
+          RollbackTransaction();
+          pDS->close();
+          return;
         }
-        pDS->close();
+        pDS->next();
       }
+      pDS->close();
     }
 
     //! @todo move this below CommitTransaction() once UPnP doesn't rely on this anymore
-    if (!bKeepId)
-      AnnounceRemove(MediaTypeMovie, idMovie);
+    AnnounceRemove(MediaTypeMovie, idMovie);
 
     CommitTransaction();
-
   }
   catch (...)
   {

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2623,16 +2623,9 @@ int CVideoDatabase::SetDetailsForMovie(CVideoInfoTag& details,
     if (idMovie < 0)
       idMovie = GetMovieId(filePath);
 
-    if (idMovie > -1)
-    {
-      const int idFile{GetDbId(PrepareSQL("SELECT idFile FROM movie WHERE idMovie=%i", idMovie))};
-      DeleteStreamDetails(idFile);
-    }
-    else
+    if (idMovie == -1)
     {
       // only add a new movie if we don't already have a valid idMovie
-      // (DeleteMovie is called with bKeepId == true so the movie won't
-      // be removed from the movie table)
       idMovie = AddNewMovie(details);
       if (idMovie < 0)
       {

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -604,7 +604,6 @@ public:
   int UpdateDetailsForMovie(int idMovie, CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, const std::set<std::string> &updatedDetails);
 
   void DeleteMovie(int idMovie,
-                   bool bKeepId = false,
                    DeleteMovieCascadeAction action = DeleteMovieCascadeAction::ALL_ASSETS);
   void DeleteTvShow(int idTvShow, bool bKeepId = false);
   void DeleteTvShow(const std::string& strPath);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -414,6 +414,12 @@ enum class DeleteMovieCascadeAction
   ALL_ASSETS
 };
 
+enum class DeleteMovieHashAction
+{
+  HASH_DELETE,
+  HASH_PRESERVE
+};
+
 #define COMPARE_PERCENTAGE     0.90f // 90%
 #define COMPARE_PERCENTAGE_MIN 0.50f // 50%
 
@@ -609,7 +615,8 @@ public:
   int UpdateDetailsForMovie(int idMovie, CVideoInfoTag& details, const std::map<std::string, std::string> &artwork, const std::set<std::string> &updatedDetails);
 
   void DeleteMovie(int idMovie,
-                   DeleteMovieCascadeAction action = DeleteMovieCascadeAction::ALL_ASSETS);
+                   DeleteMovieCascadeAction action = DeleteMovieCascadeAction::ALL_ASSETS,
+                   DeleteMovieHashAction hashAction = DeleteMovieHashAction::HASH_DELETE);
   void DeleteTvShow(int idTvShow, bool bKeepId = false);
   void DeleteTvShow(const std::string& strPath);
   void DeleteSeason(int idSeason, bool bKeepId = false);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -591,6 +591,11 @@ public:
                               const std::map<std::string, std::string>& artwork,
                               int idMVideo = -1);
   int SetStreamDetailsForFile(const CStreamDetails& details, const std::string& strFileNameAndPath);
+  /*!
+   * \brief Clear any existing stream details and add the new provided details to a file.
+   * \param[in] details New stream details
+   * \param[in] idFile Identifier of the file
+   */
   void SetStreamDetailsForFileId(const CStreamDetails& details, int idFile);
 
   bool SetSingleValue(VideoDbContentType type, int dbId, int dbField, const std::string& strValue);

--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
@@ -333,7 +333,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
     if (origDbId > 0)
     {
       if (scraper->Content() == CONTENT_MOVIES)
-        db.DeleteMovie(origDbId, false, DeleteMovieCascadeAction::DEFAULT_VERSION);
+        db.DeleteMovie(origDbId, DeleteMovieCascadeAction::DEFAULT_VERSION);
       else if (scraper->Content() == CONTENT_MUSICVIDEOS)
         db.DeleteMusicVideo(origDbId);
       else if (scraper->Content() == CONTENT_TVSHOWS)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Minor refactor and optimization in movie deletion and conversion of a movie into a version.

See motivation and context for the "why".

One commit per logical step, as follows:

[refactors]
- Removed the KeepId parameter of DeleteMovie. It was complicating the flow and reducing the function to a stream deletion. Have the only caller delete the streams directly instead.
- The stream deletion by the caller is redundant because of an unconditional call a bit later of "SetStreamDetailsForFileId" which unconditionally deletes all streams first, before adding the new ones (if any) > removed the duplicate stream deletion
- Added doxygen to SetStreamDetailsForFileId

[small optimization]
- Added parameter to DeleteMovie to skip the hash deletion for the case of movie conversion into a version. That doesn't disrupt the flow of the function and is OK I think

No backport to v21, there is nothing broken to fix.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prompted by an investigation of what happens after a movie is turned into a version, and the user refreshes the library or adds the movie to library again from Videos node.

There is no crash and things work fine, but a small optimization can be made to the hash: it's deleted when converting a movie into a version, but recreated (even though there is no file/folder change) in the next library scan / explicit scan of the movie.

Instead, the hash could be preserved and the next scan will be a little faster (detect the folder as "no change" instead of "new")

Then noticed that the parameters of the DeleteMovie are a bit strange and could use a bit of refactoring.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deleted movies, converted movies to versions
Tried different scraper settings (single movie in folder named after the movie or not, recurse or not)
"Library Update" function, "Scan to library", "Scan source"

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Barely noticeable - slightly faster library scan after converting movies to versions

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
