### PR TITLE
[streamdetails] Add SubtitleCodec and SubtitleSourceType

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -37,6 +37,7 @@
 #include "DVDDemuxers/DVDDemuxVobsub.h"
 #include "DVDDemuxers/DVDFactoryDemuxer.h"
 #include "DVDInputStreams/DVDFactoryInputStream.h"
+#include "DVDSubtitles/SubtitleSourceType.h"
 #include "Process/ProcessInfo.h"
 #include "TextureCache.h"
 #include "Util.h"
@@ -411,6 +412,8 @@ bool CDVDFileInfo::DemuxerToStreamDetails(const std::shared_ptr<CDVDInputStream>
     {
       CStreamDetailSubtitle *p = new CStreamDetailSubtitle();
       p->m_strLanguage = stream->language;
+      p->m_codec = pDemux->GetStreamCodecName(stream->demuxerId, stream->uniqueId);
+      p->m_sourceType = SUBTITLES::SubtitleSourceType::MUXED;
       details.AddStream(p);
       retVal = true;
     }
@@ -479,6 +482,8 @@ bool CDVDFileInfo::AddExternalSubtitleToDetails(const std::string &path, CStream
       CStreamDetailSubtitle *dsub = new CStreamDetailSubtitle();
       std::string lang = stream->language;
       dsub->m_strLanguage = g_LangCodeExpander.ConvertToISO6392B(lang);
+      dsub->m_codec = v.GetStreamCodecName(stream->demuxerId, stream->uniqueId);
+      dsub->m_sourceType = SUBTITLES::SubtitleSourceType::EXTERNAL;
       details.AddStream(dsub);
     }
     return true;
@@ -493,6 +498,8 @@ bool CDVDFileInfo::AddExternalSubtitleToDetails(const std::string &path, CStream
   CStreamDetailSubtitle *dsub = new CStreamDetailSubtitle();
   ExternalStreamInfo info = CUtil::GetExternalStreamDetailsFromFilename(path, filename);
   dsub->m_strLanguage = g_LangCodeExpander.ConvertToISO6392B(info.language);
+  dsub->m_sourceType = SUBTITLES::SubtitleSourceType::EXTERNAL;
+  // m_codec is not set - will be empty string
   details.AddStream(dsub);
 
   return true;

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/CMakeLists.txt
@@ -28,6 +28,7 @@ set(HEADERS DVDFactorySubtitle.h
             DVDSubtitlesLibass.h
             SubtitleParserWebVTT.h
             SubtitlesAdapter.h
+            SubtitleSourceType.h
             SubtitlesStyle.h)
 
 core_add_library(dvdsubtitles)

--- a/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitleSourceType.h
+++ b/xbmc/cores/VideoPlayer/DVDSubtitles/SubtitleSourceType.h
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+namespace KODI::SUBTITLES
+{
+
+enum class SubtitleSourceType : int
+{
+  UNKNOWN = -1,
+  MUXED = 0,
+  EXTERNAL = 1
+};
+
+} // namespace KODI::SUBTITLES

--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -150,15 +150,23 @@ void CStreamDetailSubtitle::Archive(CArchive& ar)
   if (ar.IsStoring())
   {
     ar << m_strLanguage;
+    ar << m_codec;
+    ar << static_cast<int>(m_sourceType);
   }
   else
   {
     ar >> m_strLanguage;
+    ar >> m_codec;
+    int tmpSourceType;
+    ar >> tmpSourceType;
+    m_sourceType = static_cast<KODI::SUBTITLES::SubtitleSourceType>(tmpSourceType);
   }
 }
 void CStreamDetailSubtitle::Serialize(CVariant& value) const
 {
   value["language"] = m_strLanguage;
+  value["codec"] = m_codec;
+  value["sourceType"] = static_cast<int>(m_sourceType);
 }
 
 bool CStreamDetailSubtitle::IsWorseThan(const CStreamDetail &that) const
@@ -182,6 +190,8 @@ CStreamDetailSubtitle& CStreamDetailSubtitle::operator=(const CStreamDetailSubti
   {
     this->m_pParent = that.m_pParent;
     this->m_strLanguage = that.m_strLanguage;
+    this->m_codec = that.m_codec;
+    this->m_sourceType = that.m_sourceType;
   }
   return *this;
 }
@@ -242,7 +252,9 @@ bool CStreamDetails::operator ==(const CStreamDetails &right) const
 
   for (int iStream=1; iStream<=GetSubtitleStreamCount(); iStream++)
   {
-    if (GetSubtitleLanguage(iStream) != right.GetSubtitleLanguage(iStream) )
+    if (GetSubtitleLanguage(iStream) != right.GetSubtitleLanguage(iStream) ||
+        GetSubtitleCodec(iStream) != right.GetSubtitleCodec(iStream) ||
+        GetSubtitleSourceType(iStream) != right.GetSubtitleSourceType(iStream))
       return false;
   }
 
@@ -483,6 +495,24 @@ std::string CStreamDetails::GetSubtitleLanguage(int idx) const
     return item->m_strLanguage;
   else
     return "";
+}
+
+std::string CStreamDetails::GetSubtitleCodec(int idx) const
+{
+  const CStreamDetailSubtitle* item =
+      dynamic_cast<const CStreamDetailSubtitle*>(GetNthStream(CStreamDetail::SUBTITLE, idx));
+  if (item)
+    return item->m_codec;
+  return {};
+}
+
+KODI::SUBTITLES::SubtitleSourceType CStreamDetails::GetSubtitleSourceType(int idx) const
+{
+  const CStreamDetailSubtitle* item =
+      dynamic_cast<const CStreamDetailSubtitle*>(GetNthStream(CStreamDetail::SUBTITLE, idx));
+  if (item)
+    return item->m_sourceType;
+  return KODI::SUBTITLES::SubtitleSourceType::UNKNOWN;
 }
 
 void CStreamDetails::Archive(CArchive& ar)

--- a/xbmc/utils/StreamDetails.h
+++ b/xbmc/utils/StreamDetails.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "ISerializable.h"
+#include "cores/VideoPlayer/DVDSubtitles/SubtitleSourceType.h"
 #include "cores/VideoPlayer/Interface/StreamInfo.h"
 #include "utils/IArchivable.h"
 
@@ -86,6 +87,8 @@ public:
   void Serialize(CVariant& value) const override;
   bool IsWorseThan(const CStreamDetail &that) const override;
 
+  std::string m_codec;
+  KODI::SUBTITLES::SubtitleSourceType m_sourceType{KODI::SUBTITLES::SubtitleSourceType::UNKNOWN};
   std::string m_strLanguage;
 };
 
@@ -124,6 +127,8 @@ public:
   int GetAudioChannels(int idx = 0) const;
 
   std::string GetSubtitleLanguage(int idx = 0) const;
+  std::string GetSubtitleCodec(int idx = 0) const;
+  KODI::SUBTITLES::SubtitleSourceType GetSubtitleSourceType(int idx = 0) const;
 
   void AddStream(CStreamDetail *item);
   void Reset(void);

--- a/xbmc/video/VideoDatabaseMigration.cpp
+++ b/xbmc/video/VideoDatabaseMigration.cpp
@@ -1053,9 +1053,15 @@ void CVideoDatabase::UpdateTables(int iVersion)
     }
     m_pDS->close();
   }
+
+  if (iVersion < 142)
+  {
+    m_pDS->exec("ALTER TABLE streamdetails ADD strSubtitleCodec text");
+    m_pDS->exec("ALTER TABLE streamdetails ADD iSubtitleSourceType integer");
+  }
 }
 
 int CVideoDatabase::GetSchemaVersion() const
 {
-  return 141;
+  return 142;
 }

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -618,6 +618,9 @@ void CVideoThumbLoader::DetectAndAddMissingItemData(CFileItem &item)
     {
       std::string index = std::to_string(i);
       item.SetProperty("SubtitleLanguage." + index, details.GetSubtitleLanguage(i).c_str());
+      item.SetProperty("SubtitleSourceType." + index,
+                       static_cast<int>(details.GetSubtitleSourceType(i)));
+      item.SetProperty("SubtitleCodec." + index, details.GetSubtitleCodec(i));
     }
   }
 


### PR DESCRIPTION
## Description
This is yet another alternative to https://github.com/xbmc/xbmc/pull/25000 and adds the codec type (if available) for subtitles as well as their type (muxed/external). This allows skins to rely on properties that should always be defined (i.e. the type) instead of the language as the single source of truth.

## Motivation and context
Currently to check if a file has subtitles skins check for the subtitle language property. However:
If no subtitle:
String.IsEmpty(ListItem.Property(SubtitleLanguage.1) = true

If there is a subtitle but language that isn't defined:
String.IsEmpty(ListItem.Property(SubtitleLanguage.1) = true

With this change we have the information more consistent with audio and have also properties that should always be defined indirectly solving the issue above.

## How has this been tested?
Runtime tested

## What is the effect on users?
Skins can use the subtitle sourceType property to check if a given subtitle exists.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
