### PR TITLE
Query GL extensions by enum instead of strings

### DIFF
--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferOpenGLES.cpp
@@ -71,7 +71,7 @@ bool CRenderBufferOpenGLES::UploadTexture()
       glTexSubImage2D(m_textureTarget, 0, 0, y, m_width, 1, m_pixelformat, m_pixeltype, pixels);
     }
   }
-  else if (m_context.IsExtSupported("GL_EXT_unpack_subimage"))
+  else if (m_context.IsExtSupported(GLEXTENSIONS::EXT_unpack_subimage))
   {
 #ifdef GL_UNPACK_ROW_LENGTH_EXT
     glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, stride / m_bpp);

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolOpenGLES.cpp
@@ -38,13 +38,13 @@ bool CRenderBufferPoolOpenGLES::ConfigureInternal()
     case AV_PIX_FMT_0RGB32:
     {
       m_pixeltype = GL_UNSIGNED_BYTE;
-      if (m_context.IsExtSupported("GL_EXT_texture_format_BGRA8888") ||
-          m_context.IsExtSupported("GL_IMG_texture_format_BGRA8888"))
+      if (m_context.IsExtSupported(GLEXTENSIONS::EXT_texture_format_BGRA8888) ||
+          m_context.IsExtSupported(GLEXTENSIONS::IMG_texture_format_BGRA8888))
       {
         m_internalformat = GL_BGRA_EXT;
         m_pixelformat = GL_BGRA_EXT;
       }
-      else if (m_context.IsExtSupported("GL_APPLE_texture_format_BGRA8888"))
+      else if (m_context.IsExtSupported(GLEXTENSIONS::APPLE_texture_format_BGRA8888))
       {
         // Apple's implementation does not conform to spec. Instead, they require
         // differing format/internalformat, more like GL.

--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.cpp
@@ -71,6 +71,11 @@ bool CRenderContext::IsExtSupported(const char* extension)
   return m_rendering->IsExtSupported(extension);
 }
 
+bool CRenderContext::IsExtSupported(const GLEXTENSIONS::EXTENSION extension)
+{
+  return m_rendering->IsExtSupported(extension);
+}
+
 #if defined(HAS_GL) || defined(HAS_GLES)
 namespace
 {

--- a/xbmc/cores/RetroPlayer/rendering/RenderContext.h
+++ b/xbmc/cores/RetroPlayer/rendering/RenderContext.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "games/GameTypes.h"
+#include "rendering/Extensions.h"
 #include "utils/ColorUtils.h"
 #include "utils/Geometry.h"
 #include "windowing/Resolution.h"
@@ -62,6 +63,7 @@ public:
   void SetScissors(const CRect& rect);
   void ApplyStateBlock();
   bool IsExtSupported(const char* extension);
+  bool IsExtSupported(const GLEXTENSIONS::EXTENSION extension);
 
   // OpenGL(ES) rendering functions
   void EnableGUIShader(GL_SHADER_METHOD method);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.cpp
@@ -535,7 +535,7 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum A
     }
   }
 
-  if (!CServiceBroker::GetRenderSystem()->IsExtSupported("GL_NV_vdpau_interop"))
+  if (!CServiceBroker::GetRenderSystem()->IsExtSupported(GLEXTENSIONS::NV_vdpau_interop))
   {
     CLog::Log(LOGINFO, "VDPAU::Open: required extension GL_NV_vdpau_interop not found");
     return false;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/FrameBufferObject.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/FrameBufferObject.cpp
@@ -26,7 +26,7 @@ CFrameBufferObject::CFrameBufferObject()
 
 bool CFrameBufferObject::IsSupported()
 {
-  if(CServiceBroker::GetRenderSystem()->IsExtSupported("GL_EXT_framebuffer_object"))
+  if (CServiceBroker::GetRenderSystem()->IsExtSupported(GLEXTENSIONS::EXT_framebuffer_object))
     m_supported = true;
   else
     m_supported = false;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -233,7 +233,8 @@ bool CLinuxRendererGL::Configure(const VideoPicture &picture, float fps, unsigne
   m_nonLinStretchGui = false;
   m_pixelRatio = 1.0;
 
-  m_pboSupported = CServiceBroker::GetRenderSystem()->IsExtSupported("GL_ARB_pixel_buffer_object");
+  m_pboSupported =
+      CServiceBroker::GetRenderSystem()->IsExtSupported(GLEXTENSIONS::ARB_pixel_buffer_object);
 
   // setup the background colour
   m_clearColour = CServiceBroker::GetWinSystem()->UseLimitedColor() ? (16.0f / 0xff) : 0.0f;
@@ -2562,7 +2563,7 @@ bool CLinuxRendererGL::Supports(ERENDERFEATURE feature) const
 
 bool CLinuxRendererGL::SupportsMultiPassRendering()
 {
-  return m_renderSystem->IsExtSupported("GL_EXT_framebuffer_object");
+  return m_renderSystem->IsExtSupported(GLEXTENSIONS::EXT_framebuffer_object);
 }
 
 bool CLinuxRendererGL::Supports(ESCALINGMETHOD method) const
@@ -2601,7 +2602,7 @@ bool CLinuxRendererGL::Supports(ESCALINGMETHOD method) const
     if (major > 3 ||
         (major == 3 && minor >= 2))
       hasFramebuffer = true;
-    if (m_renderSystem->IsExtSupported("GL_EXT_framebuffer_object"))
+    if (m_renderSystem->IsExtSupported(GLEXTENSIONS::EXT_framebuffer_object))
       hasFramebuffer = true;
     if (hasFramebuffer  && (m_renderMethod & RENDER_GLSL))
       return true;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -17,6 +17,7 @@
 #include "application/Application.h"
 #include "cores/IPlayer.h"
 #include "guilib/Texture.h"
+#include "rendering/Extensions.h"
 #include "rendering/MatrixGL.h"
 #include "rendering/gles/RenderSystemGLES.h"
 #include "settings/AdvancedSettings.h"
@@ -43,7 +44,7 @@ CLinuxRendererGLES::CLinuxRendererGLES()
   m_renderSystem = dynamic_cast<CRenderSystemGLES*>(CServiceBroker::GetRenderSystem());
 
 #if defined (GL_UNPACK_ROW_LENGTH_EXT)
-  if (m_renderSystem->IsExtSupported("GL_EXT_unpack_subimage"))
+  if (m_renderSystem->IsExtSupported(GLEXTENSIONS::EXT_unpack_subimage))
   {
     m_pixelStoreKey = GL_UNPACK_ROW_LENGTH_EXT;
   }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
@@ -17,6 +17,7 @@
 #include "cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayImage.h"
 #include "cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlaySSA.h"
 #include "cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlaySpu.h"
+#include "rendering/Extensions.h"
 #include "rendering/MatrixGL.h"
 #include "rendering/gles/RenderSystemGLES.h"
 #include "utils/GLUtils.h"
@@ -58,13 +59,13 @@ static void LoadTexture(GLenum target,
 
   if (!alpha)
   {
-    if (renderSystem->IsExtSupported("GL_EXT_texture_format_BGRA8888") ||
-        renderSystem->IsExtSupported("GL_IMG_texture_format_BGRA8888"))
+    if (renderSystem->IsExtSupported(GLEXTENSIONS::EXT_texture_format_BGRA8888) ||
+        renderSystem->IsExtSupported(GLEXTENSIONS::IMG_texture_format_BGRA8888))
     {
       bgraSupported = true;
       internalFormat = externalFormat = GL_BGRA_EXT;
     }
-    else if (renderSystem->IsExtSupported("GL_APPLE_texture_format_BGRA8888"))
+    else if (renderSystem->IsExtSupported(GLEXTENSIONS::APPLE_texture_format_BGRA8888))
     {
       // Apple's implementation does not conform to spec. Instead, they require
       // differing format/internalformat, more like GL.

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderCaptureGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderCaptureGL.cpp
@@ -58,7 +58,7 @@ void CRenderCaptureGL::BeginRender()
       if (!m_occlusionQuerySupported)
         CLog::Log(LOGWARNING,
                   "CRenderCaptureGL: Occlusion_query not supported, performance might suffer");
-      if (!CServiceBroker::GetRenderSystem()->IsExtSupported("GL_ARB_pixel_buffer_object"))
+      if (!CServiceBroker::GetRenderSystem()->IsExtSupported(GLEXTENSIONS::ARB_pixel_buffer_object))
         CLog::Log(
             LOGWARNING,
             "CRenderCaptureGL: GL_ARB_pixel_buffer_object not supported, performance might suffer");

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGL.cpp
@@ -55,7 +55,7 @@ ConvolutionFilterShader::ConvolutionFilterShader(ESCALINGMETHOD method, bool str
   std::string shadername;
   std::string defines;
 
-  m_floattex = CServiceBroker::GetRenderSystem()->IsExtSupported("GL_ARB_texture_float");
+  m_floattex = CServiceBroker::GetRenderSystem()->IsExtSupported(GLEXTENSIONS::ARB_texture_float);
 
   if (m_method == VS_SCALINGMETHOD_CUBIC_B_SPLINE ||
       m_method == VS_SCALINGMETHOD_CUBIC_MITCHELL ||

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGLES.cpp
@@ -63,7 +63,7 @@ ConvolutionFilterShader::ConvolutionFilterShader(ESCALINGMETHOD method)
   std::string shadername;
   std::string defines;
 
-  if (CServiceBroker::GetRenderSystem()->IsExtSupported("GL_EXT_color_buffer_float"))
+  if (CServiceBroker::GetRenderSystem()->IsExtSupported(GLEXTENSIONS::EXT_color_buffer_float))
   {
     m_floattex = true;
   }

--- a/xbmc/guilib/TextureGL.cpp
+++ b/xbmc/guilib/TextureGL.cpp
@@ -10,6 +10,7 @@
 
 #include "ServiceBroker.h"
 #include "guilib/TextureManager.h"
+#include "rendering/Extensions.h"
 #include "rendering/RenderSystem.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/GLUtils.h"
@@ -179,12 +180,15 @@ void CGLTexture::LoadToGPU()
       internalformat = pixelformat = GL_RGB;
       break;
     case XB_FMT_A8R8G8B8:
-      if (CServiceBroker::GetRenderSystem()->IsExtSupported("GL_EXT_texture_format_BGRA8888") ||
-          CServiceBroker::GetRenderSystem()->IsExtSupported("GL_IMG_texture_format_BGRA8888"))
+      if (CServiceBroker::GetRenderSystem()->IsExtSupported(
+              GLEXTENSIONS::EXT_texture_format_BGRA8888) ||
+          CServiceBroker::GetRenderSystem()->IsExtSupported(
+              GLEXTENSIONS::IMG_texture_format_BGRA8888))
       {
         internalformat = pixelformat = GL_BGRA_EXT;
       }
-      else if (CServiceBroker::GetRenderSystem()->IsExtSupported("GL_APPLE_texture_format_BGRA8888"))
+      else if (CServiceBroker::GetRenderSystem()->IsExtSupported(
+                   GLEXTENSIONS::APPLE_texture_format_BGRA8888))
       {
         // Apple's implementation does not conform to spec. Instead, they require
         // differing format/internalformat, more like GL.

--- a/xbmc/rendering/CMakeLists.txt
+++ b/xbmc/rendering/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES RenderSystem.cpp)
 
-set(HEADERS RenderSystem.h
+set(HEADERS Extensions.h
+            RenderSystem.h
             RenderSystemTypes.h)
 
 if(TARGET OpenGL::GL OR TARGET OpenGL::GLES)

--- a/xbmc/rendering/Extensions.h
+++ b/xbmc/rendering/Extensions.h
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (C) 2017-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "utils/Map.h"
+
+#include <string_view>
+
+struct GLEXTENSIONS
+{
+  enum EXTENSION
+  {
+    APPLE_texture_format_BGRA8888,
+    ARB_multitexture,
+    ARB_pixel_buffer_object,
+    ARB_texture_float,
+    EXT_color_buffer_float,
+    EXT_framebuffer_object,
+    EXT_texture_format_BGRA8888,
+    EXT_unpack_subimage,
+    IMG_texture_format_BGRA8888,
+    KHR_debug,
+    NV_vdpau_interop,
+    NVX_gpu_memory_info,
+    OES_EGL_image_external,
+    EXTENSION_MAX
+  };
+
+  static constexpr auto stringMap = make_map<EXTENSION, std::string_view>({
+      {APPLE_texture_format_BGRA8888, "GL_APPLE_texture_format_BGRA8888"},
+      {ARB_multitexture, "GL_ARB_multitexture"},
+      {ARB_pixel_buffer_object, "GL_ARB_pixel_buffer_object"},
+      {ARB_texture_float, "GL_ARB_texture_float"},
+      {EXT_color_buffer_float, "GL_EXT_color_buffer_float"},
+      {EXT_framebuffer_object, "GL_EXT_framebuffer_object"},
+      {EXT_texture_format_BGRA8888, "GL_EXT_texture_format_BGRA8888"},
+      {EXT_unpack_subimage, "GL_EXT_unpack_subimage"},
+      {IMG_texture_format_BGRA8888, "GL_IMG_texture_format_BGRA8888"},
+      {KHR_debug, "GL_KHR_debug"},
+      {NV_vdpau_interop, "GL_NV_vdpau_interop"},
+      {NVX_gpu_memory_info, "GL_NVX_gpu_memory_info"},
+      {OES_EGL_image_external, "GL_OES_EGL_image_external"},
+  });
+
+  static_assert(static_cast<size_t>(EXTENSION_MAX) == stringMap.size(),
+                "Mismatch between enum and stringmap!");
+};

--- a/xbmc/rendering/RenderSystem.h
+++ b/xbmc/rendering/RenderSystem.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "RenderSystemTypes.h"
+#include "rendering/Extensions.h"
 #include "utils/ColorUtils.h"
 #include "utils/Geometry.h"
 
@@ -39,6 +40,7 @@ public:
   virtual void PresentRender(bool rendered, bool videoLayer) = 0;
   virtual bool ClearBuffers(UTILS::COLOR::Color color) = 0;
   virtual bool IsExtSupported(const char* extension) const = 0;
+  virtual bool IsExtSupported(const GLEXTENSIONS::EXTENSION extension) { return false; }
 
   virtual void SetViewPort(const CRect& viewPort) = 0;
   virtual void GetViewPort(CRect& viewPort) = 0;

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -11,6 +11,7 @@
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "guilib/GUITextureGL.h"
+#include "rendering/Extensions.h"
 #include "rendering/MatrixGL.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
@@ -89,10 +90,12 @@ bool CRenderSystemGL::InitRenderSystem()
     m_glslMinor = 0;
   }
 
+  QueryExtensions();
+
 #if defined(GL_KHR_debug) && defined(TARGET_LINUX)
   if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_openGlDebugging)
   {
-    if (IsExtSupported("GL_KHR_debug"))
+    if (IsExtSupported(GLEXTENSIONS::KHR_debug))
     {
       auto glDebugMessageCallback =
           CEGLUtils::GetRequiredProcAddress<PFNGLDEBUGMESSAGECALLBACKPROC>(
@@ -188,7 +191,7 @@ bool CRenderSystemGL::ResetRenderSystem(int width, int height)
   glMatrixTexture->LoadIdentity();
   glMatrixTexture.Load();
 
-  if (IsExtSupported("GL_ARB_multitexture"))
+  if (IsExtSupported(GLEXTENSIONS::ARB_multitexture))
   {
     //clear error flags
     ResetGLErrors();
@@ -314,6 +317,13 @@ bool CRenderSystemGL::IsExtSupported(const char* extension) const
 bool CRenderSystemGL::SupportsNPOT(bool dxt) const
 {
   return true;
+}
+
+void CRenderSystemGL::QueryExtensions()
+{
+  for (auto extension = GLEXTENSIONS::stringMap.cbegin();
+       extension != GLEXTENSIONS::stringMap.cend(); ++extension)
+    m_extensionMap[extension->first] = IsExtSupported(std::string(extension->second).c_str());
 }
 
 void CRenderSystemGL::PresentRender(bool rendered, bool videoLayer)

--- a/xbmc/rendering/gl/RenderSystemGL.h
+++ b/xbmc/rendering/gl/RenderSystemGL.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "GLShader.h"
+#include "rendering/Extensions.h"
 #include "rendering/RenderSystem.h"
 #include "utils/ColorUtils.h"
 #include "utils/Map.h"
@@ -75,6 +76,11 @@ public:
   void PresentRender(bool rendered, bool videoLayer) override;
   bool ClearBuffers(UTILS::COLOR::Color color) override;
   bool IsExtSupported(const char* extension) const override;
+  void QueryExtensions();
+  bool IsExtSupported(GLEXTENSIONS::EXTENSION extension) override
+  {
+    return m_extensionMap[extension];
+  }
 
   void SetVSync(bool vsync);
   void ResetVSync() { m_bVsyncInit = false; }
@@ -136,4 +142,5 @@ protected:
   std::map<ShaderMethodGL, std::unique_ptr<CGLShader>> m_pShader;
   ShaderMethodGL m_method = ShaderMethodGL::SM_DEFAULT;
   GLuint m_vertexArray = GL_NONE;
+  std::map<GLEXTENSIONS::EXTENSION, bool> m_extensionMap{};
 };

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -10,6 +10,7 @@
 
 #include "guilib/DirtyRegion.h"
 #include "guilib/GUITextureGLES.h"
+#include "rendering/Extensions.h"
 #include "rendering/MatrixGL.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
@@ -74,10 +75,12 @@ bool CRenderSystemGLES::InitRenderSystem()
 
   m_RenderExtensions += " ";
 
+  QueryExtensions();
+
 #if defined(GL_KHR_debug) && defined(TARGET_LINUX)
   if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_openGlDebugging)
   {
-    if (IsExtSupported("GL_KHR_debug"))
+    if (IsExtSupported(GLEXTENSIONS::KHR_debug))
     {
       auto glDebugMessageCallback = CEGLUtils::GetRequiredProcAddress<PFNGLDEBUGMESSAGECALLBACKKHRPROC>("glDebugMessageCallbackKHR");
       auto glDebugMessageControl = CEGLUtils::GetRequiredProcAddress<PFNGLDEBUGMESSAGECONTROLKHRPROC>("glDebugMessageControlKHR");
@@ -218,6 +221,13 @@ bool CRenderSystemGLES::IsExtSupported(const char* extension) const
 
     return m_RenderExtensions.find(name) != std::string::npos;
   }
+}
+
+void CRenderSystemGLES::QueryExtensions()
+{
+  for (auto extension = GLEXTENSIONS::stringMap.cbegin();
+       extension != GLEXTENSIONS::stringMap.cend(); ++extension)
+    m_extensionMap[extension->first] = IsExtSupported(std::string(extension->second).c_str());
 }
 
 void CRenderSystemGLES::PresentRender(bool rendered, bool videoLayer)
@@ -470,7 +480,7 @@ void CRenderSystemGLES::InitialiseShaders()
     CLog::Log(LOGERROR, "GUI Shader gles_shader_rgba_bob.frag - compile and link failed");
   }
 
-  if (IsExtSupported("GL_OES_EGL_image_external"))
+  if (IsExtSupported(GLEXTENSIONS::OES_EGL_image_external))
   {
     m_pShader[ShaderMethodGLES::SM_TEXTURE_RGBA_OES] =
         std::make_unique<CGLESShader>("gles_shader_rgba_oes.frag", defines);

--- a/xbmc/rendering/gles/RenderSystemGLES.h
+++ b/xbmc/rendering/gles/RenderSystemGLES.h
@@ -85,6 +85,11 @@ public:
   void PresentRender(bool rendered, bool videoLayer) override;
   bool ClearBuffers(UTILS::COLOR::Color color) override;
   bool IsExtSupported(const char* extension) const override;
+  void QueryExtensions();
+  bool IsExtSupported(const GLEXTENSIONS::EXTENSION extension) override
+  {
+    return m_extensionMap.at(extension);
+  }
 
   void SetVSync(bool vsync);
   void ResetVSync() { m_bVsyncInit = false; }
@@ -140,4 +145,5 @@ protected:
   ShaderMethodGLES m_method = ShaderMethodGLES::SM_DEFAULT;
 
   GLint      m_viewPort[4];
+  std::map<GLEXTENSIONS::EXTENSION, bool> m_extensionMap{};
 };

--- a/xbmc/utils/GLUtils.cpp
+++ b/xbmc/utils/GLUtils.cpp
@@ -207,7 +207,7 @@ void LogGraphicsInfo()
 #define GL_GPU_MEMORY_INFO_EVICTION_COUNT_NVX            0x904A
 #define GL_GPU_MEMORY_INFO_EVICTED_MEMORY_NVX            0x904B
 
-  if (CServiceBroker::GetRenderSystem()->IsExtSupported("GL_NVX_gpu_memory_info"))
+  if (CServiceBroker::GetRenderSystem()->IsExtSupported(GLEXTENSIONS::NVX_gpu_memory_info))
   {
     GLint mem = 0;
 


### PR DESCRIPTION
## Description
The PR changes the way to query for GL/GLES extensions. We can now query for an enum, instead of doing string compares.

Maybe there is a better way to implement it, but this approach looks reasonable to me. I'd like to hear if someone has some input.

## Motivation and context
String compares are somewhat expensive. Some might be queried pretty often, so keeping track of what is supported might be better in terms of performance.

## How has this been tested?
Compiles fine for GL/GLES. Runs fine.

## What is the effect on users?
Almost none; except a tiny, tiny performance increase.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
