### PR TITLE
MacOS: Avoid rendering refresh while liveresizing

### DIFF
--- a/xbmc/windowing/osx/OpenGL/OSXGLView.h
+++ b/xbmc/windowing/osx/OpenGL/OSXGLView.h
@@ -16,12 +16,6 @@
 - (CGLContextObj)getGLContextObj;
 
 /**
- * @brief Application renders out of the NSOpenGLView drawRect (on a different thread). Hence the current
- *  NSOpenGLContext needs to be make current so that the view on the context is valid for rendering.
- *  This should be done whenever gl calls are about to be done.
- */
-- (void)NotifyContext;
-/**
  * @brief Update the current OpenGL context (view is set before updating)
  */
 - (void)Update;
@@ -29,10 +23,5 @@
  * @brief Copies the back buffer to the front buffer of the OpenGL context.
  */
 - (void)FlushBuffer;
-
-/**
- * @brief Specifies if the glContext is currently owned by the view
- */
-@property(atomic, assign) BOOL glContextOwned;
 
 @end

--- a/xbmc/windowing/osx/OpenGL/OSXGLView.mm
+++ b/xbmc/windowing/osx/OpenGL/OSXGLView.mm
@@ -20,8 +20,6 @@
   NSTrackingArea* m_trackingArea;
 }
 
-@synthesize glContextOwned;
-
 - (void)SendInputEvent:(NSEvent*)nsEvent
 {
   CWinSystemOSX* winSystem = dynamic_cast<CWinSystemOSX*>(CServiceBroker::GetWinSystem());
@@ -88,14 +86,6 @@
 
 - (void)drawRect:(NSRect)rect
 {
-  // whenever the view/window is resized the glContext is made current to the main (rendering) thread.
-  // Since kodi does its rendering on the application main thread (not the macOS rendering thread), we
-  // need to store this so that on a subsquent frame render we get the ownership of the gl context again.
-  // doing this blindly without any sort of control may stall the main thread and lead to low GUI fps
-  // since the glContext ownership needs to be obtained from the rendering thread (diverged from the actual
-  // thread doing the rendering calls).
-  [self setGlContextOwned:TRUE];
-
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     [self setOpenGLContext:m_glcontext];
@@ -215,17 +205,8 @@
 - (void)Update
 {
   assert(m_glcontext);
-  [self NotifyContext];
-  [m_glcontext update];
-}
-
-- (void)NotifyContext
-{
-  assert(m_glcontext);
-  // signals/notifies the context that this view is current (required if we render out of DrawRect)
-  // ownership of the context is transferred to the callee thread
   [m_glcontext makeCurrentContext];
-  [self setGlContextOwned:FALSE];
+  [m_glcontext update];
 }
 
 - (void)FlushBuffer

--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -71,7 +71,6 @@ public:
   void MoveToScreen(unsigned int screenIdx) override;
   void OnMove(int x, int y) override;
   void OnChangeScreen(unsigned int screenIdx) override;
-  CGraphicContext& GetGfxContext() const override;
   bool HasValidResolution() const;
 
   std::string GetClipboardText() override;

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -1304,18 +1304,6 @@ CGLContextObj CWinSystemOSX::GetCGLContextObj()
   return cglcontex;
 }
 
-CGraphicContext& CWinSystemOSX::GetGfxContext() const
-{
-  if (m_glView && [m_glView glContextOwned])
-  {
-    dispatch_sync(dispatch_get_main_queue(), ^{
-      [m_glView NotifyContext];
-    });
-  }
-
-  return CWinSystemBase::GetGfxContext();
-}
-
 bool CWinSystemOSX::FlushBuffer()
 {
   if (m_appWindow)


### PR DESCRIPTION
## Description
To render while resizing Kodi would need to render in NSView drawrect, in the main thread. Since we currently render in the application thread there's no other way to solve this without simply avoid refreshing while doing live resizes. Resizing the window steals the gl context and we could simply be performing render operations. Also, locking or similar approaches have detrimental effect on the render performance because the context belongs to the view and we'd have to execute operations on the main thread.
So for now, let's just block refreshes while doing live resizes, the view gets refreshed at the end of the operation.
This was the approach the old sdl implementation used to follow.

For the future we should consider splitting the app rendering to an application component and later to another thread (so that platforms could decide which thread to use for rendering)

## Motivation and context
Fixes https://github.com/xbmc/xbmc/issues/24954

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Runtime tested on Macos, doing live resize

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
App should not crash anymore on live resize. Solution isn't perfect (the previous rendered texture keeps on screen - scaled - until you stop resizing) but it's the possible solution

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
