### PR TITLE
Move some music fileitem classifiers to separate file

### DIFF
--- a/cmake/treedata/common/tests.txt
+++ b/cmake/treedata/common/tests.txt
@@ -8,6 +8,7 @@ xbmc/games/addons/input/test      test/games/addons/input
 xbmc/games/controllers/input/test test/games/controllers/input
 xbmc/input/keyboard/test          test/input/keyboard
 xbmc/interfaces/python/test       test/python
+xbmc/music/test                   test/music
 xbmc/music/tags/test              test/music_tags
 xbmc/network/test                 test/network
 xbmc/playlists/test               test/playlists

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -26,6 +26,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "messaging/helpers/DialogHelper.h"
+#include "music/MusicFileItemClassify.h"
 #include "playlists/PlayList.h"
 #include "profiles/ProfileManager.h"
 #include "settings/Settings.h"
@@ -52,6 +53,7 @@
 
 using namespace XFILE;
 using namespace MEDIA_DETECT;
+using namespace KODI;
 using namespace KODI::MESSAGING;
 using namespace KODI::VIDEO;
 using namespace std::chrono_literals;
@@ -439,7 +441,7 @@ bool CAutorun::RunDisc(IDirectory* pDir, const std::string& strDrive, int& nAdde
     for (int i = 0; i < vecItems.Size(); i++)
     {
       CFileItemPtr pItem = vecItems[i];
-      if (!pItem->m_bIsFolder && pItem->IsAudio())
+      if (!pItem->m_bIsFolder && MUSIC::IsAudio(*pItem))
       {
         nAddedToPlaylist++;
         CServiceBroker::GetPlaylistPlayer().Add(PLAYLIST::TYPE_MUSIC, pItem);

--- a/xbmc/ContextMenus.cpp
+++ b/xbmc/ContextMenus.cpp
@@ -14,10 +14,13 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "input/WindowTranslator.h"
+#include "music/MusicFileItemClassify.h"
 #include "storage/MediaManager.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
+
+using namespace KODI;
 
 namespace CONTEXTMENU
 {
@@ -25,7 +28,7 @@ namespace CONTEXTMENU
   bool CEjectDisk::IsVisible(const CFileItem& item) const
   {
 #ifdef HAS_OPTICAL_DRIVE
-    return item.IsRemovable() && (item.IsDVD() || item.IsCDDA());
+    return item.IsRemovable() && (item.IsDVD() || MUSIC::IsCDDA(item));
 #else
     return false;
 #endif
@@ -43,7 +46,7 @@ namespace CONTEXTMENU
   bool CEjectDrive::IsVisible(const CFileItem& item) const
   {
     // Must be HDD
-    return item.IsRemovable() && !item.IsDVD() && !item.IsCDDA();
+    return item.IsRemovable() && !item.IsDVD() && !MUSIC::IsCDDA(item);
   }
 
   bool CEjectDrive::Execute(const std::shared_ptr<CFileItem>& item) const

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1165,11 +1165,6 @@ bool CFileItem::IsBluray() const
   return IsBDFile(item);
 }
 
-bool CFileItem::IsCDDA() const
-{
-  return URIUtils::IsCDDA(m_strPath);
-}
-
 bool CFileItem::IsDVD() const
 {
   return URIUtils::IsDVD(m_strPath) || m_iDriveType == CMediaSource::SOURCE_TYPE_DVD;
@@ -1237,7 +1232,7 @@ bool CFileItem::IsVirtualDirectoryRoot() const
 
 bool CFileItem::IsRemovable() const
 {
-  return IsOnDVD() || IsCDDA() || m_iDriveType == CMediaSource::SOURCE_TYPE_REMOVABLE;
+  return IsOnDVD() || MUSIC::IsCDDA(*this) || m_iDriveType == CMediaSource::SOURCE_TYPE_REMOVABLE;
 }
 
 bool CFileItem::IsReadOnly() const
@@ -2460,7 +2455,7 @@ bool CFileItem::LoadMusicTag()
       return true;
   }
   // no tag - try some other things
-  if (IsCDDA())
+  if (MUSIC::IsCDDA(*this))
   {
     // we have the tracknumber...
     int iTrack = GetMusicInfoTag()->GetTrackNumber();

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1012,11 +1012,6 @@ bool CFileItem::IsPicture() const
   return false;
 }
 
-bool CFileItem::IsLyrics() const
-{
-  return URIUtils::HasExtension(m_strPath, ".cdg|.lrc");
-}
-
 bool CFileItem::IsInternetStream(const bool bStrictCheck /* = false */) const
 {
   if (HasProperty("IsHTTPDirectory"))

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1220,11 +1220,6 @@ bool CFileItem::IsHD() const
   return URIUtils::IsHD(m_strPath);
 }
 
-bool CFileItem::IsMusicDb() const
-{
-  return URIUtils::IsMusicDb(m_strPath);
-}
-
 bool CFileItem::IsVirtualDirectoryRoot() const
 {
   return (m_bIsFolder && m_strPath.empty());
@@ -1525,7 +1520,7 @@ bool CFileItem::IsSamePath(const CFileItem *item) const
       }
     }
   }
-  if (IsMusicDb() && HasMusicInfoTag())
+  if (MUSIC::IsMusicDb(*this) && HasMusicInfoTag())
   {
     CFileItem dbItem(m_musicInfoTag->GetURL(), false);
     if (HasProperty("item_start"))
@@ -1539,7 +1534,7 @@ bool CFileItem::IsSamePath(const CFileItem *item) const
       dbItem.SetProperty("item_start", GetProperty("item_start"));
     return dbItem.IsSamePath(item);
   }
-  if (item->IsMusicDb() && item->HasMusicInfoTag())
+  if (MUSIC::IsMusicDb(*item) && item->HasMusicInfoTag())
   {
     CFileItem dbItem(item->m_musicInfoTag->GetURL(), false);
     if (item->HasProperty("item_start"))
@@ -1998,18 +1993,13 @@ bool CFileItem::LoadTracksFromCueDocument(CFileItemList& scannedItems)
 
 std::string CFileItem::GetUserMusicThumb(bool alwaysCheckRemote /* = false */, bool fallbackToFolder /* = false */) const
 {
-  if (m_strPath.empty()
-   || StringUtils::StartsWithNoCase(m_strPath, "newsmartplaylist://")
-   || StringUtils::StartsWithNoCase(m_strPath, "newplaylist://")
-   || m_bIsShareOrDrive
-   || IsInternetStream()
-   || URIUtils::IsUPnP(m_strPath)
-   || (URIUtils::IsFTP(m_strPath) && !CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bFTPThumbs)
-   || IsPlugin()
-   || IsAddonsPath()
-   || IsLibraryFolder()
-   || IsParentFolder()
-   || IsMusicDb())
+  if (m_strPath.empty() || StringUtils::StartsWithNoCase(m_strPath, "newsmartplaylist://") ||
+      StringUtils::StartsWithNoCase(m_strPath, "newplaylist://") || m_bIsShareOrDrive ||
+      IsInternetStream() || URIUtils::IsUPnP(m_strPath) ||
+      (URIUtils::IsFTP(m_strPath) &&
+       !CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bFTPThumbs) ||
+      IsPlugin() || IsAddonsPath() || IsLibraryFolder() || IsParentFolder() ||
+      MUSIC::IsMusicDb(*this))
     return "";
 
   // we first check for <filename>.tbn or <foldername>.tbn
@@ -2631,7 +2621,7 @@ bool CFileItem::LoadDetails()
     return LoadMusicTag();
   }
 
-  if (IsMusicDb())
+  if (MUSIC::IsMusicDb(*this))
   {
     if (HasMusicInfoTag())
       return true;

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -913,42 +913,6 @@ bool CFileItem::IsPVRTimer() const
   return HasPVRTimerInfoTag();
 }
 
-bool CFileItem::IsAudio() const
-{
-  /* check preset mime type */
-  if(StringUtils::StartsWithNoCase(m_mimetype, "audio/"))
-    return true;
-
-  if (HasMusicInfoTag())
-    return true;
-
-  if (HasVideoInfoTag())
-    return false;
-
-  if (HasPictureInfoTag())
-    return false;
-
-  if (HasGameInfoTag())
-    return false;
-
-  if (IsCDDA())
-    return true;
-
-  if(StringUtils::StartsWithNoCase(m_mimetype, "application/"))
-  { /* check for some standard types */
-    std::string extension = m_mimetype.substr(12);
-    if( StringUtils::EqualsNoCase(extension, "ogg")
-     || StringUtils::EqualsNoCase(extension, "mp4")
-     || StringUtils::EqualsNoCase(extension, "mxf") )
-     return true;
-  }
-
-  //! @todo If the file is a zip file, ask the game clients if any support this
-  // file before assuming it is audio
-
-  return URIUtils::HasExtension(m_strPath, CServiceBroker::GetFileExtensionProvider().GetMusicExtensions());
-}
-
 bool CFileItem::IsDeleted() const
 {
   if (HasPVRRecordingInfoTag())
@@ -1344,7 +1308,7 @@ void CFileItem::FillInDefaultIcon()
         // PVR deleted recording
         SetArt("icon", "DefaultVideoDeleted.png");
       }
-      else if ( IsAudio() )
+      else if (MUSIC::IsAudio(*this))
       {
         // audio
         SetArt("icon", "DefaultAudio.png");
@@ -2469,7 +2433,7 @@ std::string CFileItem::GetLocalMetadataPath() const
 bool CFileItem::LoadMusicTag()
 {
   // not audio
-  if (!IsAudio())
+  if (!MUSIC::IsAudio(*this))
     return false;
   // already loaded?
   if (HasMusicInfoTag() && m_musicInfoTag->Loaded())
@@ -2653,7 +2617,7 @@ bool CFileItem::LoadDetails()
             return true;
           }
         }
-        else if (item->IsAudio())
+        else if (MUSIC::IsAudio(*item))
         {
           if (item->LoadMusicTag())
           {
@@ -2667,7 +2631,7 @@ bool CFileItem::LoadDetails()
     return false;
   }
 
-  if (IsAudio())
+  if (MUSIC::IsAudio(*this))
   {
     return LoadMusicTag();
   }

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -29,6 +29,7 @@
 #include "music/Album.h"
 #include "music/Artist.h"
 #include "music/MusicDatabase.h"
+#include "music/MusicFileItemClassify.h"
 #include "music/tags/MusicInfoTag.h"
 #include "music/tags/MusicInfoTagLoaderFactory.h"
 #include "pictures/PictureInfoTag.h"
@@ -1014,11 +1015,6 @@ bool CFileItem::IsPicture() const
 bool CFileItem::IsLyrics() const
 {
   return URIUtils::HasExtension(m_strPath, ".cdg|.lrc");
-}
-
-bool CFileItem::IsCUESheet() const
-{
-  return URIUtils::HasExtension(m_strPath, ".cue");
 }
 
 bool CFileItem::IsInternetStream(const bool bStrictCheck /* = false */) const

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -957,11 +957,6 @@ bool CFileItem::IsDeleted() const
   return false;
 }
 
-bool CFileItem::IsAudioBook() const
-{
-  return IsType(".m4b") || IsType(".mka");
-}
-
 bool CFileItem::IsGame() const
 {
   if (HasGameInfoTag())
@@ -1045,16 +1040,13 @@ bool CFileItem::IsFileFolder(EFileFolderType types) const
 
   if(types & always_type)
   {
-    if(IsSmartPlayList()
-    || (IsPlayList() && CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_playlistAsFolders)
-    || IsAPK()
-    || IsZIP()
-    || IsRAR()
-    || IsRSS()
-    || IsAudioBook()
-    || IsType(".ogg|.oga|.xbt")
+    if (IsSmartPlayList() ||
+        (IsPlayList() &&
+         CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_playlistAsFolders) ||
+        IsAPK() || IsZIP() || IsRAR() || IsRSS() || MUSIC::IsAudioBook(*this) ||
+        IsType(".ogg|.oga|.xbt")
 #if defined(TARGET_ANDROID)
-    || IsType(".apk")
+        || IsType(".apk")
 #endif
     )
     return true;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -162,7 +162,6 @@ public:
    \return true if item is picture, false otherwise.
    */
   bool IsPicture() const;
-  bool IsLyrics() const;
 
   /*!
    \brief Check whether an item is an audio item. Note that this returns true for

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -164,13 +164,6 @@ public:
   bool IsPicture() const;
 
   /*!
-   \brief Check whether an item is an audio item. Note that this returns true for
-    anything with a music info tag, so that may include eg. folders.
-   \return true if item is audio, false otherwise.
-   */
-  bool IsAudio() const;
-
-  /*!
    \brief Check whether an item is 'deleted' (for example, a trashed pvr recording).
    \return true if item is 'deleted', false otherwise.
    */

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -190,7 +190,6 @@ public:
   bool IsCBZ() const;
   bool IsCBR() const;
   bool IsISO9660() const;
-  bool IsCDDA() const;
   bool IsDVD() const;
   bool IsOnDVD() const;
   bool IsOnLAN() const;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -176,12 +176,6 @@ public:
    */
   bool IsDeleted() const;
 
-  /*!
-   \brief Check whether an item is an audio book item.
-   \return true if item is audiobook, false otherwise.
-   */
-  bool IsAudioBook() const;
-
   bool IsGame() const;
   bool IsInternetStream(const bool bStrictCheck = false) const;
   bool IsStreamedFilesystem() const;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -201,7 +201,6 @@ public:
   bool IsStack() const;
   bool IsFavourite() const;
   bool IsMultiPath() const;
-  bool IsMusicDb() const;
   bool IsEPG() const;
   bool IsPVRChannel() const;
   bool IsPVRChannelGroup() const;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -184,7 +184,6 @@ public:
   bool IsAudioBook() const;
 
   bool IsGame() const;
-  bool IsCUESheet() const;
   bool IsInternetStream(const bool bStrictCheck = false) const;
   bool IsStreamedFilesystem() const;
   bool IsPlayList() const;

--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -1076,7 +1076,7 @@ std::string CFileItemList::GetDiscFileCache(int windowID) const
 
   uint32_t crc = Crc32::ComputeFromLowerCase(strPath);
 
-  if (IsCDDA() || IsOnDVD())
+  if (MUSIC::IsCDDA(*this) || IsOnDVD())
     return StringUtils::Format("special://temp/archive_cache/r-{:08x}.fi", crc);
 
   if (IsMusicDb())

--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -16,6 +16,7 @@
 #include "filesystem/MusicDatabaseDirectory.h"
 #include "filesystem/StackDirectory.h"
 #include "filesystem/VideoDatabaseDirectory.h"
+#include "music/MusicFileItemClassify.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -609,7 +610,7 @@ void CFileItemList::FilterCueItems()
     CFileItemPtr pItem = m_items[i];
     if (!pItem->m_bIsFolder)
     { // see if it's a .CUE sheet
-      if (pItem->IsCUESheet())
+      if (MUSIC::IsCUESheet(*pItem))
       {
         CCueDocumentPtr cuesheet(new CCueDocument);
         if (cuesheet->ParseFile(pItem->GetPath()))
@@ -652,7 +653,7 @@ void CFileItemList::FilterCueItems()
                   {
                     strMediaFile = URIUtils::ReplaceExtension(pItem->GetPath(), *i);
                     CFileItem item(strMediaFile, false);
-                    if (!item.IsCUESheet() && !item.IsPlayList() && Contains(strMediaFile))
+                    if (!MUSIC::IsCUESheet(item) && !item.IsPlayList() && Contains(strMediaFile))
                     {
                       bFoundMediaFile = true;
                       break;

--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -640,7 +640,7 @@ void CFileItemList::FilterCueItems()
                 strMediaFile = pItem->GetPath();
                 URIUtils::RemoveExtension(strMediaFile);
                 CFileItem item(strMediaFile, false);
-                if (item.IsAudio() && Contains(strMediaFile))
+                if (MUSIC::IsAudio(item) && Contains(strMediaFile))
                 {
                   bFoundMediaFile = true;
                 }

--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -1079,7 +1079,7 @@ std::string CFileItemList::GetDiscFileCache(int windowID) const
   if (MUSIC::IsCDDA(*this) || IsOnDVD())
     return StringUtils::Format("special://temp/archive_cache/r-{:08x}.fi", crc);
 
-  if (IsMusicDb())
+  if (MUSIC::IsMusicDb(*this))
     return StringUtils::Format("special://temp/archive_cache/mdb-{:08x}.fi", crc);
 
   if (VIDEO::IsVideoDb(*this))
@@ -1097,7 +1097,7 @@ std::string CFileItemList::GetDiscFileCache(int windowID) const
 bool CFileItemList::AlwaysCache() const
 {
   // some database folders are always cached
-  if (IsMusicDb())
+  if (MUSIC::IsMusicDb(*this))
     return CMusicDatabaseDirectory::CanCache(GetPath());
   if (VIDEO::IsVideoDb(*this))
     return CVideoDatabaseDirectory::CanCache(GetPath());

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -29,6 +29,7 @@
 #include "interfaces/AnnouncementManager.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "music/MusicFileItemClassify.h"
 #include "music/tags/MusicInfoTag.h"
 #include "playlists/PlayList.h"
 #include "settings/AdvancedSettings.h"
@@ -41,6 +42,7 @@
 #include "video/VideoFileItemClassify.h"
 
 using namespace PLAYLIST;
+using namespace KODI;
 using namespace KODI::MESSAGING;
 using namespace KODI::VIDEO;
 
@@ -270,7 +272,7 @@ bool CPlayListPlayer::Play(const CFileItemPtr& pItem, const std::string& player)
 {
   Id playlistId;
   bool isVideo{IsVideo(*pItem)};
-  bool isAudio{pItem->IsAudio()};
+  bool isAudio{MUSIC::IsAudio(*pItem)};
 
   if (isAudio && !isVideo)
     playlistId = TYPE_MUSIC;
@@ -970,7 +972,7 @@ void PLAYLIST::CPlayListPlayer::OnApplicationMessage(KODI::MESSAGING::ThreadMess
           {
             return;
           }
-          if (item->IsAudio() || IsVideo(*item))
+          if (MUSIC::IsAudio(*item) || IsVideo(*item))
             Play(item, pMsg->strParam);
           else
             g_application.PlayMedia(*item, pMsg->strParam, playlistId);

--- a/xbmc/SeekHandler.cpp
+++ b/xbmc/SeekHandler.cpp
@@ -19,6 +19,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
+#include "music/MusicFileItemClassify.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -33,6 +34,8 @@
 #include <cmath>
 #include <mutex>
 #include <stdlib.h>
+
+using namespace KODI;
 
 CSeekHandler::~CSeekHandler()
 {
@@ -275,7 +278,8 @@ bool CSeekHandler::OnAction(const CAction &action)
   if (!appPlayer->IsPlaying() || !appPlayer->CanSeek())
     return false;
 
-  SeekType type = g_application.CurrentFileItem().IsAudio() ? SEEK_TYPE_MUSIC : SEEK_TYPE_VIDEO;
+  SeekType type =
+      MUSIC::IsAudio(g_application.CurrentFileItem()) ? SEEK_TYPE_MUSIC : SEEK_TYPE_VIDEO;
 
   if (SeekTimeCode(action))
     return true;

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -2571,7 +2571,7 @@ void CApplication::PlaybackCleanup()
 
   // DVD ejected while playing in vis ?
   if (!appPlayer->IsPlayingAudio() &&
-      (m_itemCurrentFile->IsCDDA() || m_itemCurrentFile->IsOnDVD()) &&
+      (MUSIC::IsCDDA(*m_itemCurrentFile) || m_itemCurrentFile->IsOnDVD()) &&
       !CServiceBroker::GetMediaManager().IsDiscInDrive() &&
       CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() == WINDOW_VISUALISATION)
   {

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -60,6 +60,7 @@
 #include "filesystem/DirectoryFactory.h"
 #include "filesystem/DllLibCurl.h"
 #include "filesystem/File.h"
+#include "music/MusicFileItemClassify.h"
 #include "video/VideoFileItemClassify.h"
 #ifdef HAS_FILESYSTEM_NFS
 #include "filesystem/NFSFile.h"
@@ -2452,7 +2453,7 @@ bool CApplication::PlayFile(CFileItem item, const std::string& player, bool bRes
   // this really aught to be inside !bRestart, but since PlayStack
   // uses that to init playback, we have to keep it outside
   const PLAYLIST::Id playlistId = CServiceBroker::GetPlaylistPlayer().GetCurrentPlaylist();
-  if (item.IsAudio() && playlistId == PLAYLIST::TYPE_MUSIC)
+  if (MUSIC::IsAudio(item) && playlistId == PLAYLIST::TYPE_MUSIC)
   { // playing from a playlist by the looks
     // don't switch to fullscreen if we are not playing the first item...
     options.fullscreen = !CServiceBroker::GetPlaylistPlayer().HasPlayedFirstFile() &&
@@ -2787,7 +2788,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
       const auto appPlayer = GetComponent<CApplicationPlayer>();
       if (!IsVideo(file) && appPlayer->IsPlayingVideo())
         bNothingToQueue = true;
-      else if ((!file.IsAudio() || IsVideo(file)) && appPlayer->IsPlayingAudio())
+      else if ((!MUSIC::IsAudio(file) || IsVideo(file)) && appPlayer->IsPlayingAudio())
         bNothingToQueue = true;
 
       if (bNothingToQueue)
@@ -3055,7 +3056,7 @@ bool CApplication::ExecuteXBMCAction(std::string actionStr,
     }
     else
 #endif
-        if (item.IsAudio() || IsVideo(item) || item.IsGame())
+        if (MUSIC::IsAudio(item) || IsVideo(item) || item.IsGame())
     { // an audio or video file
       PlayFile(item, "");
     }

--- a/xbmc/application/ApplicationPlayerCallback.cpp
+++ b/xbmc/application/ApplicationPlayerCallback.cpp
@@ -23,6 +23,7 @@
 #include "interfaces/AnnouncementManager.h"
 #include "interfaces/json-rpc/JSONUtils.h"
 #include "interfaces/python/XBPython.h"
+#include "music/MusicFileItemClassify.h"
 #include "profiles/ProfileManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSettings.h"
@@ -37,6 +38,7 @@
 
 #include <memory>
 
+using namespace KODI;
 using namespace KODI::VIDEO;
 
 CApplicationPlayerCallback::CApplicationPlayerCallback()
@@ -129,7 +131,7 @@ void CApplicationPlayerCallback::OnPlayerCloseFile(const CFileItem& file,
   const std::shared_ptr<CAdvancedSettings> advancedSettings =
       CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
 
-  if ((fileItem.IsAudio() && advancedSettings->m_audioPlayCountMinimumPercent > 0 &&
+  if ((MUSIC::IsAudio(fileItem) && advancedSettings->m_audioPlayCountMinimumPercent > 0 &&
        percent >= advancedSettings->m_audioPlayCountMinimumPercent) ||
       (IsVideo(fileItem) && advancedSettings->m_videoPlayCountMinimumPercent > 0 &&
        percent >= advancedSettings->m_videoPlayCountMinimumPercent))

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -20,6 +20,7 @@
 #include "cores/DataCacheCore.h"
 #include "cores/VideoPlayer/Process/ProcessInfo.h"
 #include "messaging/ApplicationMessenger.h"
+#include "music/MusicFileItemClassify.h"
 #include "music/tags/MusicInfoTag.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
@@ -32,6 +33,7 @@
 #include <memory>
 #include <mutex>
 
+using namespace KODI;
 using namespace std::chrono_literals;
 
 #define TIME_TO_CACHE_NEXT_FILE 5000 /* 5 seconds before end of song, start caching the next song */
@@ -248,8 +250,8 @@ bool PAPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options)
 void PAPlayer::UpdateCrossfadeTime(const CFileItem& file)
 {
   // we explicitly disable crossfading for audio cds
-  if (file.IsCDDA())
-   m_upcomingCrossfadeMS = 0;
+  if (MUSIC::IsCDDA(file))
+    m_upcomingCrossfadeMS = 0;
   else
     m_upcomingCrossfadeMS = m_defaultCrossfadeMS = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_MUSICPLAYER_CROSSFADE) * 1000;
 
@@ -400,7 +402,7 @@ bool PAPlayer::QueueNextFileEx(const CFileItem &file, bool fadeIn)
 
   si->m_prepareNextAtFrame = 0;
   // cd drives don't really like it to be crossfaded or prepared
-  if (!file.IsCDDA())
+  if (!MUSIC::IsCDDA(file))
   {
     if (streamTotalTime >= TIME_TO_CACHE_NEXT_FILE + m_defaultCrossfadeMS)
       si->m_prepareNextAtFrame = (int)((streamTotalTime - TIME_TO_CACHE_NEXT_FILE - m_defaultCrossfadeMS) * si->m_audioFormat.m_sampleRate / 1000.0f);

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
@@ -16,6 +16,7 @@
 #include "cores/VideoPlayer/Interface/InputStreamConstants.h"
 #include "dialogs/GUIDialogContextMenu.h"
 #include "guilib/LocalizeStrings.h"
+#include "music/MusicFileItemClassify.h"
 #include "profiles/ProfileManager.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
@@ -144,7 +145,7 @@ void CPlayerCoreFactory::GetPlayers(const CFileItem& item, std::vector<std::stri
   // "videodefaultplayer"
   if (defaultInputstreamPlayerOverride == ForcedPlayer::VIDEO_DEFAULT ||
       (defaultInputstreamPlayerOverride == ForcedPlayer::NONE &&
-       (VIDEO::IsVideo(item) || (!item.IsAudio() && !item.IsGame()))))
+       (VIDEO::IsVideo(item) || (!MUSIC::IsAudio(item) && !item.IsGame()))))
   {
     int idx = GetPlayerIndex("videodefaultplayer");
     if (idx > -1)
@@ -164,7 +165,7 @@ void CPlayerCoreFactory::GetPlayers(const CFileItem& item, std::vector<std::stri
   // Set audio default player
   // Pushback all audio players in case we don't know the type
   if (defaultInputstreamPlayerOverride == ForcedPlayer::AUDIO_DEFAULT ||
-      (defaultInputstreamPlayerOverride == ForcedPlayer::NONE && item.IsAudio()))
+      (defaultInputstreamPlayerOverride == ForcedPlayer::NONE && MUSIC::IsAudio(item)))
   {
     int idx = GetPlayerIndex("audiodefaultplayer");
     if (idx > -1)

--- a/xbmc/cores/playercorefactory/PlayerSelectionRule.cpp
+++ b/xbmc/cores/playercorefactory/PlayerSelectionRule.cpp
@@ -11,6 +11,7 @@
 #include "FileItem.h"
 #include "ServiceBroker.h"
 #include "URL.h"
+#include "music/MusicFileItemClassify.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/RegExp.h"
@@ -117,7 +118,7 @@ void CPlayerSelectionRule::GetPlayers(const CFileItem& item, std::vector<std::st
 
   if (m_bStreamDetails && !item.HasVideoInfoTag())
     return;
-  if (m_tAudio >= 0 && (m_tAudio > 0) != item.IsAudio())
+  if (m_tAudio >= 0 && (m_tAudio > 0) != MUSIC::IsAudio(item))
     return;
   if (m_tVideo >= 0 && (m_tVideo > 0) != VIDEO::IsVideo(item))
     return;

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -28,6 +28,7 @@
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "media/MediaLockState.h"
+#include "music/MusicFileItemClassify.h"
 #include "profiles/ProfileManager.h"
 #include "profiles/dialogs/GUIDialogLockSettings.h"
 #include "settings/MediaSourceSettings.h"
@@ -38,6 +39,8 @@
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
+
+using namespace KODI;
 
 #define BACKGROUND_IMAGE       999
 #define GROUP_LIST             996
@@ -221,7 +224,7 @@ void CGUIDialogContextMenu::GetContextButtons(const std::string &type, const CFi
   // Add buttons to the ContextMenu that should be visible for both sources and autosourced items
   // Optical removable drives automatically have the static Eject button added (see CEjectDisk).
   // Here we only add the eject button to HDD drives
-  if (item && item->IsRemovable() && !item->IsDVD() && !item->IsCDDA())
+  if (item && item->IsRemovable() && !item->IsDVD() && !MUSIC::IsCDDA(*item))
   {
     buttons.Add(CONTEXT_BUTTON_EJECT_DRIVE, 13420); // Remove safely
   }

--- a/xbmc/favourites/FavouritesService.cpp
+++ b/xbmc/favourites/FavouritesService.cpp
@@ -14,6 +14,7 @@
 #include "Util.h"
 #include "favourites/FavouritesURL.h"
 #include "input/WindowTranslator.h"
+#include "music/MusicFileItemClassify.h"
 #include "profiles/ProfileManager.h"
 #include "settings/SettingsComponent.h"
 #include "utils/ContentUtils.h"
@@ -81,7 +82,7 @@ bool IsMediasourceOfFavItemUnlocked(const std::shared_ptr<CFileItem>& item)
 
       return false;
     }
-    else if (itemToCheck.IsAudio())
+    else if (MUSIC::IsAudio(itemToCheck))
     {
       if (!profileManager->GetCurrentProfile().musicLocked())
         return g_passwordManager.IsMediaFileUnlocked("music", itemToCheck.GetPath());

--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -20,6 +20,7 @@
 #include "dialogs/GUIDialogBusy.h"
 #include "guilib/GUIWindowManager.h"
 #include "messaging/ApplicationMessenger.h"
+#include "music/MusicFileItemClassify.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/Job.h"
@@ -285,8 +286,8 @@ bool CDirectory::GetDirectory(const CURL& url,
 
     //  Should any of the files we read be treated as a directory?
     //  Disable for database folders, as they already contain the extracted items
-    if (!(hints.flags & DIR_FLAG_NO_FILE_DIRS) && !items.IsMusicDb() && !VIDEO::IsVideoDb(items) &&
-        !items.IsSmartPlayList())
+    if (!(hints.flags & DIR_FLAG_NO_FILE_DIRS) && !MUSIC::IsMusicDb(items) &&
+        !VIDEO::IsVideoDb(items) && !items.IsSmartPlayList())
       FilterFileDirectories(items, hints.mask);
 
     // Correct items for path substitution

--- a/xbmc/filesystem/FileDirectoryFactory.cpp
+++ b/xbmc/filesystem/FileDirectoryFactory.cpp
@@ -8,6 +8,8 @@
 
 #include "FileDirectoryFactory.h"
 
+#include "music/MusicFileItemClassify.h"
+
 #if defined(HAS_ISO9660PP)
 #include "ISO9660Directory.h"
 #endif
@@ -39,6 +41,7 @@
 #include "utils/log.h"
 
 using namespace ADDON;
+using namespace KODI;
 using namespace KODI::ADDONS;
 using namespace XFILE;
 using namespace PLAYLIST;
@@ -235,11 +238,11 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
     return NULL;
   }
 
-  if (pItem->IsAudioBook())
+  if (MUSIC::IsAudioBook(*pItem))
   {
     if (!pItem->HasMusicInfoTag() || pItem->GetEndOffset() <= 0)
     {
-      std::unique_ptr<CAudioBookFileDirectory> pDir(new CAudioBookFileDirectory);
+      auto pDir = std::make_unique<CAudioBookFileDirectory>();
       if (pDir->ContainsFiles(url))
         return pDir.release();
     }

--- a/xbmc/filesystem/SourcesDirectory.cpp
+++ b/xbmc/filesystem/SourcesDirectory.cpp
@@ -72,7 +72,7 @@ bool CSourcesDirectory::GetDirectory(const VECSOURCES &sources, CFileItemList &i
     else if (   pItem->IsPath("special://musicplaylists/")
              || pItem->IsPath("special://videoplaylists/"))
       strIcon = "DefaultPlaylist.png";
-    else if (VIDEO::IsVideoDb(*pItem) || pItem->IsMusicDb() || pItem->IsPlugin() ||
+    else if (VIDEO::IsVideoDb(*pItem) || MUSIC::IsMusicDb(*pItem) || pItem->IsPlugin() ||
              pItem->IsPath("musicsearch://"))
       strIcon = "DefaultFolder.png";
     else if (pItem->IsRemote())

--- a/xbmc/filesystem/SourcesDirectory.cpp
+++ b/xbmc/filesystem/SourcesDirectory.cpp
@@ -15,6 +15,7 @@
 #include "Util.h"
 #include "guilib/TextureManager.h"
 #include "media/MediaLockState.h"
+#include "music/MusicFileItemClassify.h"
 #include "profiles/ProfileManager.h"
 #include "settings/MediaSourceSettings.h"
 #include "storage/MediaManager.h"
@@ -82,7 +83,7 @@ bool CSourcesDirectory::GetDirectory(const VECSOURCES &sources, CFileItemList &i
       strIcon = "DefaultDVDFull.png";
     else if (pItem->IsBluray())
       strIcon = "DefaultBluray.png";
-    else if (pItem->IsCDDA())
+    else if (MUSIC::IsCDDA(*pItem))
       strIcon = "DefaultCDDA.png";
     else if (pItem->IsRemovable() && CServiceBroker::GetGUI()->GetTextureManager().HasTexture("DefaultRemovableDisk.png"))
       strIcon = "DefaultRemovableDisk.png";

--- a/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
@@ -50,7 +50,7 @@ bool CMusicGUIInfo::InitCurrentItem(CFileItem *item)
     tag->SetLoaded(true);
 
     // find a thumb for this file.
-    if (item->IsInternetStream() && !item->IsMusicDb())
+    if (item->IsInternetStream() && !MUSIC::IsMusicDb(*item))
     {
       if (!g_application.m_strPlayListFile.empty())
       {
@@ -358,7 +358,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         return true;
       case LISTITEM_FILENAME:
       case LISTITEM_FILE_EXTENSION:
-        if (item->IsMusicDb())
+        if (MUSIC::IsMusicDb(*item))
           value = URIUtils::GetFileName(tag->GetURL());
         else if (item->HasVideoInfoTag()) // special handling for music videos, which have both a videotag and a musictag
           break;
@@ -373,7 +373,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         return true;
       case LISTITEM_FOLDERNAME:
       case LISTITEM_PATH:
-        if (item->IsMusicDb())
+        if (MUSIC::IsMusicDb(*item))
           value = URIUtils::GetDirectory(tag->GetURL());
         else if (item->HasVideoInfoTag()) // special handling for music videos, which have both a videotag and a musictag
           break;
@@ -389,7 +389,7 @@ bool CMusicGUIInfo::GetLabel(std::string& value, const CFileItem *item, int cont
         }
         return true;
       case LISTITEM_FILENAME_AND_PATH:
-        if (item->IsMusicDb())
+        if (MUSIC::IsMusicDb(*item))
           value = tag->GetURL();
         else if (item->HasVideoInfoTag()) // special handling for music videos, which have both a videotag and a musictag
           break;

--- a/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
@@ -21,6 +21,7 @@
 #include "guilib/guiinfo/GUIInfo.h"
 #include "guilib/guiinfo/GUIInfoHelper.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
+#include "music/MusicFileItemClassify.h"
 #include "music/MusicInfoLoader.h"
 #include "music/MusicThumbLoader.h"
 #include "music/tags/MusicInfoTag.h"
@@ -30,6 +31,7 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
+using namespace KODI;
 using namespace KODI::GUILIB;
 using namespace KODI::GUILIB::GUIINFO;
 using namespace MUSIC_INFO;
@@ -38,7 +40,7 @@ bool CMusicGUIInfo::InitCurrentItem(CFileItem *item)
 {
   const auto& components = CServiceBroker::GetAppComponents();
   const auto appPlayer = components.GetComponent<CApplicationPlayer>();
-  if (item && (item->IsAudio() || (item->IsInternetStream() && appPlayer->IsPlayingAudio())))
+  if (item && (MUSIC::IsAudio(*item) || (item->IsInternetStream() && appPlayer->IsPlayingAudio())))
   {
     CLog::Log(LOGDEBUG, "CMusicGUIInfo::InitCurrentItem({})", item->GetPath());
 

--- a/xbmc/guilib/listproviders/DirectoryProvider.cpp
+++ b/xbmc/guilib/listproviders/DirectoryProvider.cpp
@@ -18,6 +18,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "interfaces/AnnouncementManager.h"
+#include "music/MusicFileItemClassify.h"
 #include "music/MusicThumbLoader.h"
 #include "pictures/PictureThumbLoader.h"
 #include "pvr/PVRManager.h"
@@ -48,6 +49,7 @@
 
 using namespace XFILE;
 using namespace KODI::MESSAGING;
+using namespace KODI::MUSIC;
 using namespace KODI::VIDEO;
 using namespace PVR;
 
@@ -140,7 +142,7 @@ public:
       initThumbLoader<CVideoThumbLoader>(InfoTagType::VIDEO);
       return m_thumbloaders[InfoTagType::VIDEO];
     }
-    if (item->IsAudio())
+    if (IsAudio(*item))
     {
       initThumbLoader<CMusicThumbLoader>(InfoTagType::AUDIO);
       return m_thumbloaders[InfoTagType::AUDIO];

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -24,6 +24,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
+#include "music/MusicFileItemClassify.h"
 #include "music/MusicUtils.h"
 #include "playlists/PlayList.h"
 #include "pvr/PVRManager.h"
@@ -50,6 +51,7 @@
 #include "Autorun.h"
 #endif
 
+using namespace KODI::MUSIC;
 using namespace KODI::VIDEO;
 
 /*! \brief Clear current playlist
@@ -440,7 +442,7 @@ PLAYLIST::Id GetPlayListId(const CFileItem& item)
   PLAYLIST::Id playlistId{PLAYLIST::TYPE_NONE};
   if (IsVideo(item))
     playlistId = PLAYLIST::TYPE_VIDEO;
-  else if (item.IsAudio())
+  else if (IsAudio(item))
     playlistId = PLAYLIST::TYPE_MUSIC;
 
   return playlistId;
@@ -619,7 +621,7 @@ int PlayOrQueueMedia(const std::vector<std::string>& params, bool forcePlay)
 
   if (forcePlay)
   {
-    if ((item.IsAudio() || IsVideo(item)) && !item.IsSmartPlayList() && !item.IsPVR())
+    if ((IsAudio(item) || IsVideo(item)) && !item.IsSmartPlayList() && !item.IsPVR())
     {
       if (!item.HasProperty("playlist_type_hint"))
         item.SetProperty("playlist_type_hint", GetPlayListId(item));

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -31,6 +31,7 @@
 #include "interfaces/builtins/Builtins.h"
 #include "messaging/ApplicationMessenger.h"
 #include "music/MusicDatabase.h"
+#include "music/MusicFileItemClassify.h"
 #include "pictures/SlideShowDelegator.h"
 #include "pvr/PVRManager.h"
 #include "pvr/PVRPlaybackState.h"
@@ -56,6 +57,7 @@
 #include <map>
 #include <tuple>
 
+using namespace KODI;
 using namespace JSONRPC;
 using namespace PVR;
 
@@ -269,7 +271,7 @@ JSONRPC_STATUS CPlayerOperations::GetItem(const std::string &method, ITransportL
           }
         }
 
-        if (fileItem->IsMusicDb())
+        if (MUSIC::IsMusicDb(*fileItem))
         {
           CMusicDatabase musicdb;
           CFileItemList items;

--- a/xbmc/music/CMakeLists.txt
+++ b/xbmc/music/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES Album.cpp
             MusicDatabase.cpp
             MusicDbUrl.cpp
             MusicEmbeddedImageFileLoader.cpp
+            MusicFileItemClassify.cpp
             MusicInfoLoader.cpp
             MusicLibraryQueue.cpp
             MusicThumbLoader.cpp
@@ -18,6 +19,7 @@ set(HEADERS Album.h
             MusicDatabase.h
             MusicDbUrl.h
             MusicEmbeddedImageFileLoader.h
+            MusicFileItemClassify.h
             MusicInfoLoader.h
             MusicLibraryQueue.h
             MusicThumbLoader.h

--- a/xbmc/music/MusicFileItemClassify.cpp
+++ b/xbmc/music/MusicFileItemClassify.cpp
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "music/MusicFileItemClassify.h"
+
+#include "FileItem.h"
+#include "utils/URIUtils.h"
+
+namespace KODI::MUSIC
+{
+
+bool IsCUESheet(const CFileItem& item)
+{
+  return URIUtils::HasExtension(item.GetPath(), ".cue");
+}
+
+} // namespace KODI::MUSIC

--- a/xbmc/music/MusicFileItemClassify.cpp
+++ b/xbmc/music/MusicFileItemClassify.cpp
@@ -19,4 +19,9 @@ bool IsCUESheet(const CFileItem& item)
   return URIUtils::HasExtension(item.GetPath(), ".cue");
 }
 
+bool IsLyrics(const CFileItem& item)
+{
+  return URIUtils::HasExtension(item.GetPath(), ".cdg|.lrc");
+}
+
 } // namespace KODI::MUSIC

--- a/xbmc/music/MusicFileItemClassify.cpp
+++ b/xbmc/music/MusicFileItemClassify.cpp
@@ -35,7 +35,7 @@ bool IsAudio(const CFileItem& item)
   if (item.HasGameInfoTag())
     return false;
 
-  if (item.IsCDDA())
+  if (IsCDDA(item))
     return true;
 
   if (StringUtils::StartsWithNoCase(item.GetMimeType(), "application/"))
@@ -56,6 +56,11 @@ bool IsAudio(const CFileItem& item)
 bool IsAudioBook(const CFileItem& item)
 {
   return item.IsType(".m4b") || item.IsType(".mka");
+}
+
+bool IsCDDA(const CFileItem& item)
+{
+  return URIUtils::IsCDDA(item.GetPath());
 }
 
 bool IsCUESheet(const CFileItem& item)

--- a/xbmc/music/MusicFileItemClassify.cpp
+++ b/xbmc/music/MusicFileItemClassify.cpp
@@ -14,6 +14,11 @@
 namespace KODI::MUSIC
 {
 
+bool IsAudioBook(const CFileItem& item)
+{
+  return item.IsType(".m4b") || item.IsType(".mka");
+}
+
 bool IsCUESheet(const CFileItem& item)
 {
   return URIUtils::HasExtension(item.GetPath(), ".cue");

--- a/xbmc/music/MusicFileItemClassify.cpp
+++ b/xbmc/music/MusicFileItemClassify.cpp
@@ -73,4 +73,9 @@ bool IsLyrics(const CFileItem& item)
   return URIUtils::HasExtension(item.GetPath(), ".cdg|.lrc");
 }
 
+bool IsMusicDb(const CFileItem& item)
+{
+  return URIUtils::IsMusicDb(item.GetPath());
+}
+
 } // namespace KODI::MUSIC

--- a/xbmc/music/MusicFileItemClassify.cpp
+++ b/xbmc/music/MusicFileItemClassify.cpp
@@ -9,10 +9,49 @@
 #include "music/MusicFileItemClassify.h"
 
 #include "FileItem.h"
+#include "ServiceBroker.h"
+#include "utils/FileExtensionProvider.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 
 namespace KODI::MUSIC
 {
+
+bool IsAudio(const CFileItem& item)
+{
+  /* check preset mime type */
+  if (StringUtils::StartsWithNoCase(item.GetMimeType(), "audio/"))
+    return true;
+
+  if (item.HasMusicInfoTag())
+    return true;
+
+  if (item.HasVideoInfoTag())
+    return false;
+
+  if (item.HasPictureInfoTag())
+    return false;
+
+  if (item.HasGameInfoTag())
+    return false;
+
+  if (item.IsCDDA())
+    return true;
+
+  if (StringUtils::StartsWithNoCase(item.GetMimeType(), "application/"))
+  { /* check for some standard types */
+    std::string extension = item.GetMimeType().substr(12);
+    if (StringUtils::EqualsNoCase(extension, "ogg") ||
+        StringUtils::EqualsNoCase(extension, "mp4") || StringUtils::EqualsNoCase(extension, "mxf"))
+      return true;
+  }
+
+  //! @todo If the file is a zip file, ask the game clients if any support this
+  // file before assuming it is audio
+
+  return URIUtils::HasExtension(item.GetPath(),
+                                CServiceBroker::GetFileExtensionProvider().GetMusicExtensions());
+}
 
 bool IsAudioBook(const CFileItem& item)
 {

--- a/xbmc/music/MusicFileItemClassify.h
+++ b/xbmc/music/MusicFileItemClassify.h
@@ -21,6 +21,9 @@ bool IsAudio(const CFileItem& item);
 //! \brief Check whether an item is an audio book item.
 bool IsAudioBook(const CFileItem& item);
 
+//! \brief Check whether an item is an audio cd item.
+bool IsCDDA(const CFileItem& item);
+
 //! \brief Check whether an item is a cue sheet.
 bool IsCUESheet(const CFileItem& item);
 

--- a/xbmc/music/MusicFileItemClassify.h
+++ b/xbmc/music/MusicFileItemClassify.h
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+class CFileItem;
+
+namespace KODI::MUSIC
+{
+
+//! \brief Check whether an item is a cue sheet.
+bool IsCUESheet(const CFileItem& item);
+
+} // namespace KODI::MUSIC

--- a/xbmc/music/MusicFileItemClassify.h
+++ b/xbmc/music/MusicFileItemClassify.h
@@ -13,6 +13,9 @@ class CFileItem;
 namespace KODI::MUSIC
 {
 
+//! \brief Check whether an item is an audio book item.
+bool IsAudioBook(const CFileItem& item);
+
 //! \brief Check whether an item is a cue sheet.
 bool IsCUESheet(const CFileItem& item);
 

--- a/xbmc/music/MusicFileItemClassify.h
+++ b/xbmc/music/MusicFileItemClassify.h
@@ -13,6 +13,11 @@ class CFileItem;
 namespace KODI::MUSIC
 {
 
+//! \brief Check whether an item is an audio item.
+//! \details Note that this returns true for anything with a music info tag,
+//!          so that may include eg. folders.
+bool IsAudio(const CFileItem& item);
+
 //! \brief Check whether an item is an audio book item.
 bool IsAudioBook(const CFileItem& item);
 

--- a/xbmc/music/MusicFileItemClassify.h
+++ b/xbmc/music/MusicFileItemClassify.h
@@ -30,5 +30,7 @@ bool IsCUESheet(const CFileItem& item);
 //! \brief Check whether an item is a lyrics file.
 bool IsLyrics(const CFileItem& item);
 
+//! \brief Check whether an item is a music database item.
+bool IsMusicDb(const CFileItem& item);
+
 } // namespace KODI::MUSIC
-}

--- a/xbmc/music/MusicFileItemClassify.h
+++ b/xbmc/music/MusicFileItemClassify.h
@@ -16,4 +16,8 @@ namespace KODI::MUSIC
 //! \brief Check whether an item is a cue sheet.
 bool IsCUESheet(const CFileItem& item);
 
+//! \brief Check whether an item is a lyrics file.
+bool IsLyrics(const CFileItem& item);
+
 } // namespace KODI::MUSIC
+}

--- a/xbmc/music/MusicInfoLoader.cpp
+++ b/xbmc/music/MusicInfoLoader.cpp
@@ -152,7 +152,7 @@ bool CMusicInfoLoader::LoadItemCached(CFileItem* pItem)
       pItem->IsSmartPlayList() ||
       StringUtils::StartsWithNoCase(pItem->GetPath(), "newplaylist://") ||
       StringUtils::StartsWithNoCase(pItem->GetPath(), "newsmartplaylist://") || pItem->IsNFO() ||
-      (pItem->IsInternetStream() && !pItem->IsMusicDb()))
+      (pItem->IsInternetStream() && !MUSIC::IsMusicDb(*pItem)))
     return false;
 
   // Get thumb for item
@@ -170,7 +170,7 @@ bool CMusicInfoLoader::LoadItemLookup(CFileItem* pItem)
       pItem->IsPlayList() || pItem->IsSmartPlayList() || //
       StringUtils::StartsWithNoCase(pItem->GetPath(), "newplaylist://") || //
       StringUtils::StartsWithNoCase(pItem->GetPath(), "newsmartplaylist://") || //
-      pItem->IsNFO() || (pItem->IsInternetStream() && !pItem->IsMusicDb()))
+      pItem->IsNFO() || (pItem->IsInternetStream() && !MUSIC::IsMusicDb(*pItem)))
     return false;
 
   if ((!pItem->HasMusicInfoTag() || !pItem->GetMusicInfoTag()->Loaded()) && MUSIC::IsAudio(*pItem))
@@ -213,7 +213,7 @@ bool CMusicInfoLoader::LoadItemLookup(CFileItem* pItem)
         if (!it->second[0].strThumb.empty())
           pItem->SetArt("thumb", it->second[0].strThumb);
       }
-      else if (pItem->IsMusicDb())
+      else if (MUSIC::IsMusicDb(*pItem))
       { // a music db item that doesn't have tag loaded - grab details from the database
         XFILE::MUSICDATABASEDIRECTORY::CQueryParams param;
         XFILE::MUSICDATABASEDIRECTORY::CDirectoryNode::GetDatabaseInfo(pItem->GetPath(),param);

--- a/xbmc/music/MusicInfoLoader.cpp
+++ b/xbmc/music/MusicInfoLoader.cpp
@@ -18,6 +18,7 @@
 #include "filesystem/File.h"
 #include "filesystem/MusicDatabaseDirectory/DirectoryNode.h"
 #include "filesystem/MusicDatabaseDirectory/QueryParams.h"
+#include "music/MusicFileItemClassify.h"
 #include "music/tags/MusicInfoTag.h"
 #include "music/tags/MusicInfoTagLoaderFactory.h"
 #include "settings/Settings.h"
@@ -27,8 +28,9 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
-using namespace XFILE;
+using namespace KODI;
 using namespace MUSIC_INFO;
+using namespace XFILE;
 
 // HACK until we make this threadable - specify 1 thread only for now
 CMusicInfoLoader::CMusicInfoLoader() : CBackgroundInfoLoader()
@@ -72,8 +74,8 @@ void CMusicInfoLoader::OnLoaderStart()
 
 bool CMusicInfoLoader::LoadAdditionalTagInfo(CFileItem* pItem)
 {
-  if (!pItem || (pItem->m_bIsFolder && !pItem->IsAudio()) ||
-      pItem->IsPlayList() || pItem->IsNFO() || pItem->IsInternetStream())
+  if (!pItem || (pItem->m_bIsFolder && !MUSIC::IsAudio(*pItem)) || pItem->IsPlayList() ||
+      pItem->IsNFO() || pItem->IsInternetStream())
     return false;
 
   if (pItem->GetProperty("hasfullmusictag") == "true")
@@ -146,11 +148,11 @@ bool CMusicInfoLoader::LoadItem(CFileItem* pItem)
 
 bool CMusicInfoLoader::LoadItemCached(CFileItem* pItem)
 {
-  if ((pItem->m_bIsFolder && !pItem->IsAudio()) ||
-      pItem->IsPlayList() || pItem->IsSmartPlayList() ||
+  if ((pItem->m_bIsFolder && !MUSIC::IsAudio(*pItem)) || pItem->IsPlayList() ||
+      pItem->IsSmartPlayList() ||
       StringUtils::StartsWithNoCase(pItem->GetPath(), "newplaylist://") ||
-      StringUtils::StartsWithNoCase(pItem->GetPath(), "newsmartplaylist://") ||
-      pItem->IsNFO() || (pItem->IsInternetStream() && !pItem->IsMusicDb()))
+      StringUtils::StartsWithNoCase(pItem->GetPath(), "newsmartplaylist://") || pItem->IsNFO() ||
+      (pItem->IsInternetStream() && !pItem->IsMusicDb()))
     return false;
 
   // Get thumb for item
@@ -164,14 +166,14 @@ bool CMusicInfoLoader::LoadItemLookup(CFileItem* pItem)
   if (m_pProgressCallback && !pItem->m_bIsFolder)
     m_pProgressCallback->SetProgressAdvance();
 
-  if ((pItem->m_bIsFolder && !pItem->IsAudio()) || //
+  if ((pItem->m_bIsFolder && !MUSIC::IsAudio(*pItem)) || //
       pItem->IsPlayList() || pItem->IsSmartPlayList() || //
       StringUtils::StartsWithNoCase(pItem->GetPath(), "newplaylist://") || //
       StringUtils::StartsWithNoCase(pItem->GetPath(), "newsmartplaylist://") || //
       pItem->IsNFO() || (pItem->IsInternetStream() && !pItem->IsMusicDb()))
     return false;
 
-  if ((!pItem->HasMusicInfoTag() || !pItem->GetMusicInfoTag()->Loaded()) && pItem->IsAudio())
+  if ((!pItem->HasMusicInfoTag() || !pItem->GetMusicInfoTag()->Loaded()) && MUSIC::IsAudio(*pItem))
   {
     // first check the cached item
     CFileItemPtr mapItem = (*m_mapFileItems)[pItem->GetPath()];

--- a/xbmc/music/MusicInfoLoader.cpp
+++ b/xbmc/music/MusicInfoLoader.cpp
@@ -225,7 +225,9 @@ bool CMusicInfoLoader::LoadItemLookup(CFileItem* pItem)
             pItem->SetArt("thumb", song.strThumb);
         }
       }
-      else if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_MUSICFILES_USETAGS) || pItem->IsCDDA())
+      else if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                   CSettings::SETTING_MUSICFILES_USETAGS) ||
+               MUSIC::IsCDDA(*pItem))
       { // Nothing found, load tag from file,
         // always try to load cddb info
         // get correct tag parser

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -505,7 +505,7 @@ void CAsyncGetItemsForPlaylist::GetItemsForPlaylist(const std::shared_ptr<CFileI
   if (item->IsParentFolder() || !item->CanQueue() || item->IsRAR() || item->IsZIP())
     return;
 
-  if (item->IsMusicDb() && item->m_bIsFolder && !item->IsParentFolder())
+  if (MUSIC::IsMusicDb(*item) && item->m_bIsFolder && !item->IsParentFolder())
   {
     // we have a music database folder, just grab the "all" item underneath it
     XFILE::CMusicDatabaseDirectory dir;
@@ -601,7 +601,7 @@ void CAsyncGetItemsForPlaylist::GetItemsForPlaylist(const std::shared_ptr<CFileI
         GetItemsForPlaylist((*playList)[i]);
       }
     }
-    else if (item->IsInternetStream() && !item->IsMusicDb())
+    else if (item->IsInternetStream() && !MUSIC::IsMusicDb(*item))
     {
       // just queue the internet stream, it will be expanded on play
       m_queuedItems.Add(item);
@@ -918,7 +918,7 @@ bool IsItemPlayable(const CFileItem& item)
     return false;
 
   if (item.m_bIsFolder &&
-      (item.IsMusicDb() || StringUtils::StartsWithNoCase(item.GetPath(), "library://music/")))
+      (MUSIC::IsMusicDb(item) || StringUtils::StartsWithNoCase(item.GetPath(), "library://music/")))
   {
     // Exclude top level nodes - eg can't play 'genres' just a specific genre etc
     const XFILE::MUSICDATABASEDIRECTORY::NODE_TYPE node =

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -29,6 +29,7 @@
 #include "media/MediaType.h"
 #include "music/MusicDatabase.h"
 #include "music/MusicDbUrl.h"
+#include "music/MusicFileItemClassify.h"
 #include "music/tags/MusicInfoTag.h"
 #include "playlists/PlayList.h"
 #include "playlists/PlayListFactory.h"
@@ -46,6 +47,7 @@
 
 #include <memory>
 
+using namespace KODI;
 using namespace KODI::VIDEO;
 using namespace MUSIC_INFO;
 using namespace XFILE;
@@ -609,7 +611,7 @@ void CAsyncGetItemsForPlaylist::GetItemsForPlaylist(const std::shared_ptr<CFileI
       // python files can be played
       m_queuedItems.Add(item);
     }
-    else if (!item->IsNFO() && (item->IsAudio() || IsVideo(*item)))
+    else if (!item->IsNFO() && (MUSIC::IsAudio(*item) || IsVideo(*item)))
     {
       const auto itemCheck = m_queuedItems.Get(item->GetPath());
       if (!itemCheck || itemCheck->GetStartOffset() != item->GetStartOffset())
@@ -929,7 +931,7 @@ bool IsItemPlayable(const CFileItem& item)
 
   if (item.HasMusicInfoTag() && item.CanQueue())
     return true;
-  else if (!item.m_bIsFolder && item.IsAudio())
+  else if (!item.m_bIsFolder && MUSIC::IsAudio(item))
     return true;
   else if (item.m_bIsFolder)
   {

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -27,6 +27,7 @@
 #include "input/actions/ActionIDs.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "music/MusicDatabase.h"
+#include "music/MusicFileItemClassify.h"
 #include "music/MusicLibraryQueue.h"
 #include "music/MusicThumbLoader.h"
 #include "music/MusicUtils.h"
@@ -48,6 +49,7 @@
 using namespace XFILE;
 using namespace MUSIC_INFO;
 using namespace MUSICDATABASEDIRECTORY;
+using namespace KODI;
 using namespace KODI::MESSAGING;
 
 #define CONTROL_BTN_REFRESH      6
@@ -990,7 +992,7 @@ void CGUIDialogMusicInfo::ShowFor(CFileItem* pItem)
 
   // We have a folder album/artist info dialog only shown for db items
   // or for music video with artist/album in music library
-  if (pItem->IsMusicDb())
+  if (MUSIC::IsMusicDb(*pItem))
   {
     if (!pItem->HasMusicInfoTag() || pItem->GetMusicInfoTag()->GetDatabaseId() < 1)
     {

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -22,6 +22,7 @@
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "music/MusicDatabase.h"
+#include "music/MusicFileItemClassify.h"
 #include "music/MusicUtils.h"
 #include "music/tags/MusicInfoTag.h"
 #include "music/windows/GUIWindowMusicBase.h"
@@ -30,6 +31,8 @@
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
 #include "utils/FileUtils.h"
+
+using namespace KODI;
 
 #define CONTROL_BTN_REFRESH       6
 #define CONTROL_USERRATING        7
@@ -40,8 +43,6 @@
 #define CONTROL_LIST              50
 
 #define TIME_TO_BUSY_DIALOG 500
-
-
 
 class CGetSongInfoJob : public CJob
 {
@@ -375,7 +376,7 @@ void CGUIDialogSongInfo::OnGetArt()
   if (type == "thumb")
   { // Local thumb type art held in <filename>.tbn (for non-library items)
     localThumb = m_song->GetUserMusicThumb(true);
-    if (m_song->IsMusicDb())
+    if (MUSIC::IsMusicDb(*m_song))
     {
       CFileItem item(m_song->GetMusicInfoTag()->GetURL(), false);
       localThumb = item.GetUserMusicThumb(true);
@@ -495,7 +496,7 @@ void CGUIDialogSongInfo::ShowFor(CFileItem* pItem)
 {
   if (pItem->m_bIsFolder)
     return;
-  if (!pItem->IsMusicDb())
+  if (!MUSIC::IsMusicDb(*pItem))
     pItem->LoadMusicTag();
   if (!pItem->HasMusicInfoTag())
     return;

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -37,6 +37,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "interfaces/AnnouncementManager.h"
+#include "music/MusicFileItemClassify.h"
 #include "music/MusicLibraryQueue.h"
 #include "music/MusicThumbLoader.h"
 #include "music/MusicUtils.h"
@@ -56,6 +57,7 @@
 #include <algorithm>
 #include <utility>
 
+using namespace KODI;
 using namespace MUSIC_INFO;
 using namespace XFILE;
 using namespace MUSICDATABASEDIRECTORY;
@@ -578,7 +580,7 @@ CInfoScanner::INFO_RET CMusicInfoScanner::ScanTags(const CFileItemList& items,
     if (CUtil::ExcludeFileOrFolder(pItem->GetPath(), regexps))
       continue;
 
-    if (pItem->m_bIsFolder || pItem->IsPlayList() || pItem->IsPicture() || pItem->IsLyrics())
+    if (pItem->m_bIsFolder || pItem->IsPlayList() || pItem->IsPicture() || MUSIC::IsLyrics(*pItem))
       continue;
 
     m_currentItem++;

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1274,7 +1274,7 @@ int CMusicInfoScanner::GetPathHash(const CFileItemList &items, std::string &hash
     digest.Update((unsigned char *)&pItem->m_dwSize, sizeof(pItem->m_dwSize));
     KODI::TIME::FileTime time = pItem->m_dateTime;
     digest.Update((unsigned char*)&time, sizeof(KODI::TIME::FileTime));
-    if (pItem->IsAudio() && !pItem->IsPlayList() && !pItem->IsNFO())
+    if (MUSIC::IsAudio(*pItem) && !pItem->IsPlayList() && !pItem->IsNFO())
       count++;
   }
   hash = digest.Finalize();
@@ -2334,7 +2334,7 @@ int CMusicInfoScanner::CountFiles(const CFileItemList &items, bool recursive)
 
     if (recursive && pItem->m_bIsFolder)
       count+=CountFilesRecursively(pItem->GetPath());
-    else if (pItem->IsAudio() && !pItem->IsPlayList() && !pItem->IsNFO())
+    else if (MUSIC::IsAudio(*pItem) && !pItem->IsPlayList() && !pItem->IsNFO())
       count++;
   }
   return count;

--- a/xbmc/music/tags/MusicInfoTagLoaderFactory.cpp
+++ b/xbmc/music/tags/MusicInfoTagLoaderFactory.cpp
@@ -18,9 +18,11 @@
 #include "addons/AudioDecoder.h"
 #include "addons/ExtsMimeSupportList.h"
 #include "addons/addoninfo/AddonType.h"
+#include "music/MusicFileItemClassify.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 
+using namespace KODI;
 using namespace KODI::ADDONS;
 using namespace MUSIC_INFO;
 
@@ -34,7 +36,7 @@ IMusicInfoTagLoader* CMusicInfoTagLoaderFactory::CreateLoader(const CFileItem& i
   if (item.IsInternetStream())
     return NULL;
 
-  if (item.IsMusicDb())
+  if (MUSIC::IsMusicDb(item))
     return new CMusicInfoTagLoaderDatabase();
 
   std::string strExtension = URIUtils::GetExtension(item.GetPath());

--- a/xbmc/music/test/CMakeLists.txt
+++ b/xbmc/music/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(SOURCES TestMusicFileItemClassify.cpp)
+
+core_add_test_library(music_test)

--- a/xbmc/music/test/TestMusicFileItemClassify.cpp
+++ b/xbmc/music/test/TestMusicFileItemClassify.cpp
@@ -22,6 +22,27 @@ struct SimpleDefinition
   bool result;
 };
 
+class AudioBookTest : public testing::WithParamInterface<SimpleDefinition>, public testing::Test
+{
+};
+
+TEST_P(AudioBookTest, IsAudioBook)
+{
+  EXPECT_EQ(MUSIC::IsAudioBook(CFileItem(GetParam().path, GetParam().folder)), GetParam().result);
+}
+
+const auto audiobook_tests = std::array{
+    SimpleDefinition{"/home/user/test.m4b", false, true},
+    SimpleDefinition{"/home/user/test.m4b", true, true},
+    SimpleDefinition{"/home/user/test.mka", false, true},
+    SimpleDefinition{"/home/user/test.mka", true, true},
+    SimpleDefinition{"/home/user/test.not", false, false},
+};
+
+INSTANTIATE_TEST_SUITE_P(TestMusicFileItemClassify,
+                         AudioBookTest,
+                         testing::ValuesIn(audiobook_tests));
+
 class CuesheetTest : public testing::WithParamInterface<SimpleDefinition>, public testing::Test
 {
 };
@@ -58,4 +79,3 @@ const auto lyrics_tests = std::array{
 };
 
 INSTANTIATE_TEST_SUITE_P(TestMusicFileItemClassify, LyricsTest, testing::ValuesIn(lyrics_tests));
->>>>>>> e56c3cc3f8 (move CFileItem::IsLyrics to MusicFileItemClassify)

--- a/xbmc/music/test/TestMusicFileItemClassify.cpp
+++ b/xbmc/music/test/TestMusicFileItemClassify.cpp
@@ -171,3 +171,20 @@ const auto cdda_tests = std::array{
 };
 
 INSTANTIATE_TEST_SUITE_P(TestMusicFileItemClassify, CDDATest, testing::ValuesIn(cdda_tests));
+
+class MusicDbTest : public testing::WithParamInterface<SimpleDefinition>, public testing::Test
+{
+};
+
+TEST_P(MusicDbTest, IsMusicDb)
+{
+  EXPECT_EQ(MUSIC::IsMusicDb(CFileItem(GetParam().path, GetParam().folder)), GetParam().result);
+}
+
+const auto musicdb_tests = std::array{
+    SimpleDefinition{"musicdb://1", false, true},
+    SimpleDefinition{"musicdb://1/", true, true},
+    SimpleDefinition{"/home/foo/musicdb/yo.mp3", false, false},
+};
+
+INSTANTIATE_TEST_SUITE_P(TestMusicFileItemClassify, MusicDbTest, testing::ValuesIn(musicdb_tests));

--- a/xbmc/music/test/TestMusicFileItemClassify.cpp
+++ b/xbmc/music/test/TestMusicFileItemClassify.cpp
@@ -153,3 +153,21 @@ const auto lyrics_tests = std::array{
 };
 
 INSTANTIATE_TEST_SUITE_P(TestMusicFileItemClassify, LyricsTest, testing::ValuesIn(lyrics_tests));
+
+class CDDATest : public testing::WithParamInterface<SimpleDefinition>, public testing::Test
+{
+};
+
+TEST_P(CDDATest, IsCDDA)
+{
+  EXPECT_EQ(MUSIC::IsCDDA(CFileItem(GetParam().path, GetParam().folder)), GetParam().result);
+}
+
+const auto cdda_tests = std::array{
+    SimpleDefinition{"cdda://1", false, true},
+    SimpleDefinition{"cdda://1/", true, true},
+    SimpleDefinition{"cdda://1/", true, true},
+    SimpleDefinition{"/home/foo/yo.cdda", false, false},
+};
+
+INSTANTIATE_TEST_SUITE_P(TestMusicFileItemClassify, CDDATest, testing::ValuesIn(cdda_tests));

--- a/xbmc/music/test/TestMusicFileItemClassify.cpp
+++ b/xbmc/music/test/TestMusicFileItemClassify.cpp
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "FileItem.h"
+#include "music/MusicFileItemClassify.h"
+
+#include <array>
+
+#include <gtest/gtest.h>
+
+using namespace KODI;
+
+struct SimpleDefinition
+{
+  std::string path;
+  bool folder;
+  bool result;
+};
+
+class CuesheetTest : public testing::WithParamInterface<SimpleDefinition>, public testing::Test
+{
+};
+
+TEST_P(CuesheetTest, IsCUESheet)
+{
+  EXPECT_EQ(MUSIC::IsCUESheet(CFileItem(GetParam().path, GetParam().folder)), GetParam().result);
+}
+
+const auto cuesheet_tests = std::array{
+    SimpleDefinition{"/home/user/test.cue", false, true},
+    SimpleDefinition{"/home/user/test.cue/", true, false},
+    SimpleDefinition{"/home/user/test.foo", false, false},
+};
+
+INSTANTIATE_TEST_SUITE_P(TestMusicFileItemClassify,
+                         CuesheetTest,
+                         testing::ValuesIn(cuesheet_tests));

--- a/xbmc/music/test/TestMusicFileItemClassify.cpp
+++ b/xbmc/music/test/TestMusicFileItemClassify.cpp
@@ -40,3 +40,22 @@ const auto cuesheet_tests = std::array{
 INSTANTIATE_TEST_SUITE_P(TestMusicFileItemClassify,
                          CuesheetTest,
                          testing::ValuesIn(cuesheet_tests));
+
+class LyricsTest : public testing::WithParamInterface<SimpleDefinition>, public testing::Test
+{
+};
+
+TEST_P(LyricsTest, IsLyrics)
+{
+  EXPECT_EQ(MUSIC::IsLyrics(CFileItem(GetParam().path, GetParam().folder)), GetParam().result);
+}
+
+const auto lyrics_tests = std::array{
+    SimpleDefinition{"/home/user/test.lrc", false, true},
+    SimpleDefinition{"/home/user/test.cdg", false, true},
+    SimpleDefinition{"/home/user/test.not", false, false},
+    SimpleDefinition{"/home/user/test.lrc/", true, false},
+};
+
+INSTANTIATE_TEST_SUITE_P(TestMusicFileItemClassify, LyricsTest, testing::ValuesIn(lyrics_tests));
+>>>>>>> e56c3cc3f8 (move CFileItem::IsLyrics to MusicFileItemClassify)

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -23,6 +23,7 @@
 #include "application/Application.h"
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPlayer.h"
+#include "music/MusicFileItemClassify.h"
 #include "video/VideoFileItemClassify.h"
 #ifdef HAS_CDDA_RIPPER
 #include "cdrip/CDDARipper.h"
@@ -73,6 +74,7 @@ using namespace XFILE;
 using namespace MUSICDATABASEDIRECTORY;
 using namespace MUSIC_GRABBER;
 using namespace MUSIC_INFO;
+using namespace KODI;
 using namespace KODI::MESSAGING;
 using KODI::MESSAGING::HELPERS::DialogResponse;
 using namespace KODI::VIDEO;
@@ -351,8 +353,8 @@ void CGUIWindowMusicBase::RetrieveMusicInfo()
   for (int i = 0; i < m_vecItems->Size(); ++i)
   {
     CFileItemPtr pItem = (*m_vecItems)[i];
-    if (pItem->m_bIsFolder || pItem->IsPlayList() || pItem->IsPicture() || pItem->IsLyrics() ||
-        IsVideo(*pItem))
+    if (pItem->m_bIsFolder || pItem->IsPlayList() || pItem->IsPicture() ||
+        MUSIC::IsLyrics(*pItem) || IsVideo(*pItem))
       continue;
 
     CMusicInfoTag& tag = *pItem->GetMusicInfoTag();

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -411,9 +411,8 @@ void CGUIWindowMusicBase::UpdateButtons()
 {
   CONTROL_ENABLE_ON_CONDITION(CONTROL_BTNRIP, CServiceBroker::GetMediaManager().IsAudio());
 
-  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTNSCAN,
-                              !(m_vecItems->IsVirtualDirectoryRoot() ||
-                                m_vecItems->IsMusicDb()));
+  CONTROL_ENABLE_ON_CONDITION(
+      CONTROL_BTNSCAN, !(m_vecItems->IsVirtualDirectoryRoot() || MUSIC::IsMusicDb(*m_vecItems)));
 
   if (CMusicLibraryQueue::GetInstance().IsScanningLibrary())
     SET_CONTROL_LABEL(CONTROL_BTNSCAN, 14056); // Stop Scan
@@ -736,7 +735,7 @@ void CGUIWindowMusicBase::OnRetrieveMusicInfo(CFileItemList& items)
   // No need to attempt to read music file tags for music videos
   if (IsVideoDb(items))
     return;
-  if (items.GetFolderCount() == items.Size() || items.IsMusicDb() ||
+  if (items.GetFolderCount() == items.Size() || MUSIC::IsMusicDb(items) ||
       (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
            CSettings::SETTING_MUSICFILES_USETAGS) &&
        !MUSIC::IsCDDA(items)))
@@ -882,10 +881,9 @@ bool CGUIWindowMusicBase::GetDirectory(const std::string &strDirectory, CFileIte
 bool CGUIWindowMusicBase::CheckFilterAdvanced(CFileItemList &items) const
 {
   const std::string& content = items.GetContent();
-  if ((items.IsMusicDb() || CanContainFilter(m_strFilterPath)) &&
+  if ((MUSIC::IsMusicDb(items) || CanContainFilter(m_strFilterPath)) &&
       (StringUtils::EqualsNoCase(content, "artists") ||
-       StringUtils::EqualsNoCase(content, "albums")  ||
-       StringUtils::EqualsNoCase(content, "songs")))
+       StringUtils::EqualsNoCase(content, "albums") || StringUtils::EqualsNoCase(content, "songs")))
     return true;
 
   return false;
@@ -1047,7 +1045,7 @@ void CGUIWindowMusicBase::OnPrepareFileItems(CFileItemList &items)
 {
   CGUIMediaWindow::OnPrepareFileItems(items);
 
-  if (!items.IsMusicDb() && !items.IsSmartPlayList())
+  if (!MUSIC::IsMusicDb(items) && !items.IsSmartPlayList())
     RetrieveMusicInfo();
 }
 

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -897,7 +897,7 @@ bool CGUIWindowMusicBase::CanContainFilter(const std::string &strDirectory) cons
 bool CGUIWindowMusicBase::OnSelect(int iItem)
 {
   auto item = m_vecItems->Get(iItem);
-  if (item->IsAudioBook())
+  if (MUSIC::IsAudioBook(*item))
   {
     int bookmark;
     if (m_musicdatabase.GetResumeBookmarkForAudioBook(*item, bookmark) && bookmark > 0)

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -458,7 +458,7 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
       }
 #ifdef HAS_OPTICAL_DRIVE
       // enable Rip CD Audio or Track button if we have an audio disc
-      if (CServiceBroker::GetMediaManager().IsDiscInDrive() && m_vecItems->IsCDDA())
+      if (CServiceBroker::GetMediaManager().IsDiscInDrive() && MUSIC::IsCDDA(*m_vecItems))
       {
         // those cds can also include Audio Tracks: CDExtra and MixedMode!
         MEDIA_DETECT::CCdInfo* pCdInfo = CServiceBroker::GetMediaManager().GetCdInfo();
@@ -469,7 +469,7 @@ void CGUIWindowMusicBase::GetContextButtons(int itemNumber, CContextButtons &but
     }
 
     // enable CDDB lookup if the current dir is CDDA
-    if (CServiceBroker::GetMediaManager().IsDiscInDrive() && m_vecItems->IsCDDA() &&
+    if (CServiceBroker::GetMediaManager().IsDiscInDrive() && MUSIC::IsCDDA(*m_vecItems) &&
         (profileManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser))
     {
       buttons.Add(CONTEXT_BUTTON_CDDB, 16002);
@@ -567,7 +567,7 @@ void CGUIWindowMusicBase::OnRipCD()
 {
   if (CServiceBroker::GetMediaManager().IsAudio())
   {
-    if (!g_application.CurrentFileItem().IsCDDA())
+    if (!MUSIC::IsCDDA(g_application.CurrentFileItem()))
     {
 #ifdef HAS_CDDA_RIPPER
       KODI::CDRIP::CCDDARipper::GetInstance().RipCD();
@@ -582,7 +582,7 @@ void CGUIWindowMusicBase::OnRipTrack(int iItem)
 {
   if (CServiceBroker::GetMediaManager().IsAudio())
   {
-    if (!g_application.CurrentFileItem().IsCDDA())
+    if (!MUSIC::IsCDDA(g_application.CurrentFileItem()))
     {
 #ifdef HAS_CDDA_RIPPER
       CFileItemPtr item = m_vecItems->Get(iItem);
@@ -736,8 +736,10 @@ void CGUIWindowMusicBase::OnRetrieveMusicInfo(CFileItemList& items)
   // No need to attempt to read music file tags for music videos
   if (IsVideoDb(items))
     return;
-  if (items.GetFolderCount()==items.Size() || items.IsMusicDb() ||
-     (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_MUSICFILES_USETAGS) && !items.IsCDDA()))
+  if (items.GetFolderCount() == items.Size() || items.IsMusicDb() ||
+      (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+           CSettings::SETTING_MUSICFILES_USETAGS) &&
+       !MUSIC::IsCDDA(items)))
   {
     return;
   }

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -352,7 +352,7 @@ bool CGUIWindowMusicNav::OnClick(int iItem, const std::string &player /* = "" */
     }
     return true;
   }
-  if (item->IsMusicDb() && !item->m_bIsFolder)
+  if (MUSIC::IsMusicDb(*item) && !item->m_bIsFolder)
     m_musicdatabase.SetPropertiesForFileItem(*item);
 
   if (item->IsPlayList() &&
@@ -430,7 +430,7 @@ bool CGUIWindowMusicNav::GetDirectory(const std::string &strDirectory, CFileItem
         break;
     }
   }
-  else if (StringUtils::StartsWithNoCase(strDirectory, "musicdb://") || items.IsMusicDb())
+  else if (StringUtils::StartsWithNoCase(strDirectory, "musicdb://") || MUSIC::IsMusicDb(items))
   {
     CMusicDatabaseDirectory dir;
     NODE_TYPE node = dir.GetDirectoryChildType(items.GetPath());

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -29,6 +29,7 @@
 #include "input/actions/ActionIDs.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "music/MusicFileItemClassify.h"
 #include "music/MusicLibraryQueue.h"
 #include "music/dialogs/GUIDialogInfoProviderSettings.h"
 #include "music/tags/MusicInfoTag.h"
@@ -54,6 +55,7 @@
 using namespace XFILE;
 using namespace PLAYLIST;
 using namespace MUSICDATABASEDIRECTORY;
+using namespace KODI;
 using namespace KODI::MESSAGING;
 using namespace KODI::VIDEO;
 
@@ -582,7 +584,7 @@ void CGUIWindowMusicNav::GetContextButtons(int itemNumber, CContextButtons &butt
       CGUIDialogContextMenu::GetContextButtons("music", item, buttons);
 #ifdef HAS_OPTICAL_DRIVE
       // enable Rip CD an audio disc
-      if (CServiceBroker::GetMediaManager().IsDiscInDrive() && item->IsCDDA())
+      if (CServiceBroker::GetMediaManager().IsDiscInDrive() && MUSIC::IsCDDA(*item))
       {
         // those cds can also include Audio Tracks: CDExtra and MixedMode!
         MEDIA_DETECT::CCdInfo* pCdInfo = CServiceBroker::GetMediaManager().GetCdInfo();

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -25,6 +25,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
+#include "music/MusicFileItemClassify.h"
 #include "music/tags/MusicInfoTag.h"
 #include "playlists/PlayListM3U.h"
 #include "profiles/ProfileManager.h"
@@ -37,6 +38,8 @@
 #include "utils/Variant.h"
 #include "utils/log.h"
 #include "view/GUIViewState.h"
+
+using namespace KODI;
 
 #define CONTROL_BTNVIEWASICONS 2
 #define CONTROL_BTNSORTBY 3
@@ -336,7 +339,7 @@ void CGUIWindowMusicPlayList::SavePlayList()
 
       //  Musicdatabase items should contain the real path instead of a musicdb url
       //  otherwise the user can't save and reuse the playlist when the musicdb gets deleted
-      if (pItem->IsMusicDb())
+      if (MUSIC::IsMusicDb(*pItem))
         pItem->SetPath(pItem->GetMusicInfoTag()->GetURL());
 
       playlist.Add(pItem);

--- a/xbmc/music/windows/MusicFileItemListModifier.cpp
+++ b/xbmc/music/windows/MusicFileItemListModifier.cpp
@@ -14,17 +14,19 @@
 #include "filesystem/MusicDatabaseDirectory/DirectoryNode.h"
 #include "guilib/LocalizeStrings.h"
 #include "music/MusicDbUrl.h"
+#include "music/MusicFileItemClassify.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 
 #include <memory>
 
+using namespace KODI;
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
 bool CMusicFileItemListModifier::CanModify(const CFileItemList &items) const
 {
-  if (items.IsMusicDb())
+  if (MUSIC::IsMusicDb(items))
     return true;
 
   return false;
@@ -40,7 +42,7 @@ bool CMusicFileItemListModifier::Modify(CFileItemList &items) const
 //  depending on the child node
 void CMusicFileItemListModifier::AddQueuingFolder(CFileItemList& items)
 {
-  if (!items.IsMusicDb())
+  if (!MUSIC::IsMusicDb(items))
     return;
 
   auto directoryNode = CDirectoryNode::ParseURL(items.GetPath());

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -17,6 +17,7 @@
 #include "filesystem/MusicDatabaseDirectory.h"
 #include "filesystem/StackDirectory.h"
 #include "filesystem/VideoDatabaseDirectory.h"
+#include "music/MusicFileItemClassify.h"
 #include "music/tags/MusicInfoTag.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
@@ -207,7 +208,7 @@ NPT_String GetMimeType(const CFileItem& item, const PLT_HttpRequestContext* cont
   {
     if (VIDEO::IsVideo(item) || VIDEO::IsVideoDb(item))
       mime = "video/" + ext;
-    else if (item.IsAudio() || item.IsMusicDb())
+    else if (MUSIC::IsAudio(item) || item.IsMusicDb())
       mime = "audio/" + ext;
     else if (item.IsPicture())
       mime = "image/" + ext;
@@ -520,7 +521,7 @@ PLT_MediaObject* BuildObject(CFileItem& item,
     object->m_ObjectID = EncodeObjectId(item.GetPath());
 
     /* Setup object type */
-    if (item.IsMusicDb() || item.IsAudio())
+    if (item.IsMusicDb() || MUSIC::IsAudio(item))
     {
       object->m_ObjectClass.type = "object.item.audioItem.musicTrack";
 

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -208,7 +208,7 @@ NPT_String GetMimeType(const CFileItem& item, const PLT_HttpRequestContext* cont
   {
     if (VIDEO::IsVideo(item) || VIDEO::IsVideoDb(item))
       mime = "video/" + ext;
-    else if (MUSIC::IsAudio(item) || item.IsMusicDb())
+    else if (MUSIC::IsAudio(item) || MUSIC::IsMusicDb(item))
       mime = "audio/" + ext;
     else if (item.IsPicture())
       mime = "image/" + ext;
@@ -521,7 +521,7 @@ PLT_MediaObject* BuildObject(CFileItem& item,
     object->m_ObjectID = EncodeObjectId(item.GetPath());
 
     /* Setup object type */
-    if (item.IsMusicDb() || MUSIC::IsAudio(item))
+    if (MUSIC::IsMusicDb(item) || MUSIC::IsAudio(item))
     {
       object->m_ObjectClass.type = "object.item.audioItem.musicTrack";
 
@@ -617,7 +617,7 @@ PLT_MediaObject* BuildObject(CFileItem& item,
     container->m_ChildrenCount = -1;
 
     /* this might be overkill, but hey */
-    if (item.IsMusicDb())
+    if (MUSIC::IsMusicDb(item))
     {
       MUSICDATABASEDIRECTORY::NODE_TYPE node =
           CMusicDatabaseDirectory::GetDirectoryType(item.GetPath());

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -17,6 +17,7 @@
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "messaging/helpers/DialogHelper.h"
+#include "music/MusicFileItemClassify.h"
 #include "music/MusicThumbLoader.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -389,7 +390,7 @@ bool CUPnPPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options)
   {
     m_hasVideo = true;
   }
-  else if (file.IsAudio())
+  else if (MUSIC::IsAudio(file))
   {
     m_hasAudio = true;
   }

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -228,7 +228,7 @@ int CUPnPPlayer::PlayFile(const CFileItem& file,
 
   if (VIDEO::IsVideoDb(file))
     thumb_loader = NPT_Reference<CThumbLoader>(new CVideoThumbLoader());
-  else if (item.IsMusicDb())
+  else if (MUSIC::IsMusicDb(item))
     thumb_loader = NPT_Reference<CThumbLoader>(new CMusicThumbLoader());
 
   obj = BuildObject(item, path, false, thumb_loader, NULL, CUPnP::GetServer(), UPnPPlayer);
@@ -422,7 +422,7 @@ bool CUPnPPlayer::QueueNextFile(const CFileItem& file)
 
   if (VIDEO::IsVideoDb(file))
     thumb_loader = NPT_Reference<CThumbLoader>(new CVideoThumbLoader());
-  else if (item.IsMusicDb())
+  else if (MUSIC::IsMusicDb(item))
     thumb_loader = NPT_Reference<CThumbLoader>(new CMusicThumbLoader());
 
   obj = BuildObject(item, path, false, thumb_loader, NULL, CUPnP::GetServer(), UPnPPlayer);

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -722,7 +722,7 @@ NPT_Result CUPnPServer::OnBrowseMetadata(PLT_ActionReference& action,
     {
       thumb_loader = NPT_Reference<CThumbLoader>(new CVideoThumbLoader());
     }
-    else if (item->IsMusicDb())
+    else if (MUSIC::IsMusicDb(*item))
     {
       thumb_loader = NPT_Reference<CThumbLoader>(new CMusicThumbLoader());
     }
@@ -1399,7 +1399,7 @@ NPT_Result CUPnPServer::OnUpdateObject(PLT_ActionReference& action,
       CVideoThumbLoader().FillLibraryArt(updated);
     }
   }
-  else if (updated.IsMusicDb())
+  else if (MUSIC::IsMusicDb(updated))
   {
     //! @todo implement this
   }
@@ -1415,7 +1415,7 @@ NPT_Result CUPnPServer::OnUpdateObject(PLT_ActionReference& action,
     updated.SetPath(path);
     if (IsVideoDb(updated))
       CUtil::DeleteVideoDatabaseDirectoryCache();
-    else if (updated.IsMusicDb())
+    else if (MUSIC::IsMusicDb(updated))
       CUtil::DeleteMusicDatabaseDirectoryCache();
 
     CFileItemPtr msgItem(new CFileItem(updated));

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -25,6 +25,7 @@
 #include "interfaces/AnnouncementManager.h"
 #include "music/Artist.h"
 #include "music/MusicDatabase.h"
+#include "music/MusicFileItemClassify.h"
 #include "music/MusicLibraryQueue.h"
 #include "music/MusicThumbLoader.h"
 #include "music/tags/MusicInfoTag.h"
@@ -51,6 +52,7 @@
 NPT_SET_LOCAL_LOGGER("xbmc.upnp.server")
 
 using namespace ANNOUNCEMENT;
+using namespace KODI;
 using namespace KODI::VIDEO;
 using namespace XFILE;
 using KODI::UTILITY::CDigest;
@@ -451,7 +453,7 @@ PLT_MediaObject* CUPnPServer::Build(const std::shared_ptr<CFileItem>& item,
       item->m_bIsFolder = true;
     }
     // audio and not a playlist -> song, so it's not a folder
-    else if (item->IsAudio())
+    else if (MUSIC::IsAudio(*item))
     {
       item->m_bIsFolder = false;
     }

--- a/xbmc/playlists/PlayList.cpp
+++ b/xbmc/playlists/PlayList.cpp
@@ -14,6 +14,7 @@
 #include "ServiceBroker.h"
 #include "filesystem/File.h"
 #include "interfaces/AnnouncementManager.h"
+#include "music/MusicFileItemClassify.h"
 #include "music/tags/MusicInfoTag.h"
 #include "utils/Random.h"
 #include "utils/StringUtils.h"
@@ -29,7 +30,7 @@
 #include <utility>
 #include <vector>
 
-
+using namespace KODI;
 using namespace MUSIC_INFO;
 using namespace XFILE;
 using namespace PLAYLIST;
@@ -351,7 +352,7 @@ int CPlayList::RemoveDVDItems()
   while (it != m_vecItems.end() )
   {
     CFileItemPtr item = *it;
-    if ( item->IsCDDA() || item->IsOnDVD() )
+    if (MUSIC::IsCDDA(*item) || item->IsOnDVD())
     {
       vecFilenames.push_back( item->GetPath() );
     }

--- a/xbmc/playlists/PlayList.cpp
+++ b/xbmc/playlists/PlayList.cpp
@@ -508,7 +508,7 @@ void CPlayList::UpdateItem(const CFileItem *item)
 
 const std::string& CPlayList::ResolveURL(const std::shared_ptr<CFileItem>& item) const
 {
-  if (item->IsMusicDb() && item->HasMusicInfoTag())
+  if (MUSIC::IsMusicDb(*item) && item->HasMusicInfoTag())
     return item->GetMusicInfoTag()->GetURL();
   else
     return item->GetDynPath();

--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -12,6 +12,7 @@
 #include "URL.h"
 #include "Util.h"
 #include "filesystem/File.h"
+#include "music/MusicFileItemClassify.h"
 #include "music/tags/MusicInfoTag.h"
 #include "utils/CharsetConverter.h"
 #include "utils/URIUtils.h"
@@ -188,7 +189,7 @@ bool CPlayListM3U::Load(const std::string& strFileName)
         if (VIDEO::IsVideo(*newItem) &&
             !newItem->HasVideoInfoTag()) // File is a video and needs a VideoInfoTag
           newItem->GetVideoInfoTag()->Reset(); // Force VideoInfoTag creation
-        if (lDuration && newItem->IsAudio())
+        if (lDuration && MUSIC::IsAudio(*newItem))
           newItem->GetMusicInfoTag()->SetDuration(lDuration);
         for (auto &prop : properties)
         {

--- a/xbmc/playlists/PlayListPLS.cpp
+++ b/xbmc/playlists/PlayListPLS.cpp
@@ -12,6 +12,7 @@
 #include "PlayListFactory.h"
 #include "Util.h"
 #include "filesystem/File.h"
+#include "music/MusicFileItemClassify.h"
 #include "music/tags/MusicInfoTag.h"
 #include "utils/CharsetConverter.h"
 #include "utils/StringUtils.h"
@@ -139,7 +140,7 @@ bool CPlayListPLS::Load(const std::string &strFile)
         if (m_vecItems[idx - 1]->GetLabel().empty())
           m_vecItems[idx - 1]->SetLabel(URIUtils::GetFileName(strValue));
         CFileItem item(strValue, false);
-        if (bShoutCast && !item.IsAudio())
+        if (bShoutCast && !MUSIC::IsAudio(item))
           strValue.replace(0, 7, "shout://");
 
         strValue = URIUtils::SubstitutePath(strValue);

--- a/xbmc/utils/ExecString.cpp
+++ b/xbmc/utils/ExecString.cpp
@@ -12,6 +12,7 @@
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "Util.h"
+#include "music/MusicFileItemClassify.h"
 #include "music/tags/MusicInfoTag.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
@@ -128,7 +129,7 @@ bool CExecString::Parse(const CFileItem& item, const std::string& contextWindow)
   {
     if (VIDEO::IsVideoDb(item) && item.HasVideoInfoTag())
       BuildPlayMedia(item, StringUtils::Paramify(item.GetVideoInfoTag()->m_strFileNameAndPath));
-    else if (item.IsMusicDb() && item.HasMusicInfoTag())
+    else if (MUSIC::IsMusicDb(item) && item.HasMusicInfoTag())
       BuildPlayMedia(item, StringUtils::Paramify(item.GetMusicInfoTag()->GetURL()));
     else if (item.IsPicture())
       Build("ShowPicture", {StringUtils::Paramify(item.GetPath())});

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -194,7 +194,7 @@ void CSaveFileState::DoWork(CFileItem& item,
       }
     }
 
-    if (item.IsAudio())
+    if (MUSIC::IsAudio(item))
     {
       std::string redactPath = CURL::GetRedacted(progressTrackingFile);
       CLog::Log(LOGDEBUG, "{} - Saving file state for audio item {}", __FUNCTION__, redactPath);

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -217,7 +217,7 @@ void CSaveFileState::DoWork(CFileItem& item,
 
           // UPnP announce resume point changes to clients
           // however not if playcount is modified as that already announces
-          if (item.IsMusicDb())
+          if (MUSIC::IsMusicDb(item))
           {
             CVariant data;
             data["id"] = item.GetMusicInfoTag()->GetDatabaseId();

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -23,6 +23,7 @@
 #include "interfaces/AnnouncementManager.h"
 #include "log.h"
 #include "music/MusicDatabase.h"
+#include "music/MusicFileItemClassify.h"
 #include "music/tags/MusicInfoTag.h"
 #include "network/upnp/UPnP.h"
 #include "utils/Variant.h"
@@ -30,6 +31,7 @@
 #include "video/VideoDatabase.h"
 #include "video/VideoFileItemClassify.h"
 
+using namespace KODI;
 using namespace KODI::VIDEO;
 
 void CSaveFileState::DoWork(CFileItem& item,
@@ -226,7 +228,7 @@ void CSaveFileState::DoWork(CFileItem& item,
         }
       }
 
-      if (item.IsAudioBook())
+      if (MUSIC::IsAudioBook(item))
       {
         musicdatabase.Open();
         musicdatabase.SetResumeBookmarkForAudioBook(

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -18,6 +18,7 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
+#include "music/MusicFileItemClassify.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/ContentUtils.h"
@@ -36,6 +37,7 @@
 
 #include <utility>
 
+using namespace KODI::MUSIC;
 using namespace KODI::VIDEO;
 
 namespace CONTEXTMENU
@@ -394,7 +396,7 @@ bool CVideoResume::Execute(const std::shared_ptr<CFileItem>& itemIn) const
 {
   const auto item{std::make_shared<CFileItem>(itemIn->GetItemToPlay())};
 #ifdef HAS_OPTICAL_DRIVE
-  if (item->IsDVD() || item->IsCDDA())
+  if (item->IsDVD() || IsCDDA(*item))
     return MEDIA_DETECT::CAutorun::PlayDisc(item->GetPath(), true, false);
 #endif
 
@@ -422,7 +424,7 @@ bool CVideoPlay::Execute(const std::shared_ptr<CFileItem>& itemIn) const
 {
   const auto item{std::make_shared<CFileItem>(itemIn->GetItemToPlay())};
 #ifdef HAS_OPTICAL_DRIVE
-  if (item->IsDVD() || item->IsCDDA())
+  if (item->IsDVD() || IsCDDA(*item))
     return MEDIA_DETECT::CAutorun::PlayDisc(item->GetPath(), true, true);
 #endif
   SetPathAndPlay(item, PlayMode::PLAY);

--- a/xbmc/video/guilib/VideoGUIUtils.cpp
+++ b/xbmc/video/guilib/VideoGUIUtils.cpp
@@ -516,7 +516,7 @@ bool IsItemPlayable(const CFileItem& item)
     return true;
 
   // Exclude all music library items
-  if (item.IsMusicDb() || StringUtils::StartsWithNoCase(item.GetPath(), "library://music/"))
+  if (MUSIC::IsMusicDb(item) || StringUtils::StartsWithNoCase(item.GetPath(), "library://music/"))
     return false;
 
   // Exclude other components

--- a/xbmc/video/guilib/VideoGUIUtils.cpp
+++ b/xbmc/video/guilib/VideoGUIUtils.cpp
@@ -23,6 +23,7 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
+#include "music/MusicFileItemClassify.h"
 #include "playlists/PlayList.h"
 #include "playlists/PlayListFactory.h"
 #include "profiles/ProfileManager.h"
@@ -41,6 +42,7 @@
 #include "video/VideoUtils.h"
 #include "view/GUIViewState.h"
 
+using namespace KODI;
 using namespace KODI::VIDEO;
 
 namespace
@@ -575,7 +577,7 @@ bool IsItemPlayable(const CFileItem& item)
   {
     return true;
   }
-  else if ((!item.m_bIsFolder && IsVideo(item)) || item.IsDVD() || item.IsCDDA())
+  else if ((!item.m_bIsFolder && IsVideo(item)) || item.IsDVD() || MUSIC::IsCDDA(item))
   {
     return true;
   }

--- a/xbmc/video/test/TestVideoFileItemClassify.cpp
+++ b/xbmc/video/test/TestVideoFileItemClassify.cpp
@@ -133,7 +133,9 @@ TEST(TestVideoFileItemClassify, VideoExtensions)
   for (const auto& ext : StringUtils::Split(exts, "|"))
   {
     if (!ext.empty())
+    {
       EXPECT_TRUE(VIDEO::IsVideo(CFileItem(ext, false)));
+    }
   }
 }
 
@@ -190,7 +192,9 @@ TEST(TestVideoFileItemClassify, IsSubtitle)
   for (const auto& ext : StringUtils::Split(exts, "|"))
   {
     if (!ext.empty())
+    {
       EXPECT_TRUE(VIDEO::IsSubtitle(CFileItem("random" + ext, false)));
+    }
   }
 
   EXPECT_FALSE(VIDEO::IsSubtitle(CFileItem("random.notasub", false)));

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -39,6 +39,7 @@
 #include "interfaces/generic/ScriptInvocationManager.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "music/MusicFileItemClassify.h"
 #include "network/Network.h"
 #include "pictures/SlideShowDelegator.h"
 #include "platform/Filesystem.h"
@@ -59,6 +60,7 @@
 #include "video/VideoFileItemClassify.h"
 
 using namespace XFILE;
+using namespace KODI;
 using namespace KODI::MESSAGING;
 using namespace KODI::VIDEO;
 
@@ -657,7 +659,7 @@ void CGUIWindowFileManager::OnStart(CFileItem *pItem, const std::string &player)
     g_application.ProcessAndStartPlaylist(strPlayList, *pPlayList, PLAYLIST::TYPE_MUSIC);
     return;
   }
-  if (pItem->IsAudio() || IsVideo(*pItem))
+  if (MUSIC::IsAudio(*pItem) || IsVideo(*pItem))
   {
     CServiceBroker::GetPlaylistPlayer().Play(std::make_shared<CFileItem>(*pItem), player);
     return;


### PR DESCRIPTION
## Description
Continuing moving file item classifiers, this time some music ones.

## Motivation and context
Reduce CFileItem API

## How has this been tested?
It builds + I have added tests.

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
