### PR TITLE
[BP][Xbox] Fix crash when DisplayInformation it's called from other thread

### DIFF
--- a/xbmc/windowing/win10/WinSystemWin10.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10.cpp
@@ -692,7 +692,14 @@ float CWinSystemWin10::GetGuiSdrPeakLuminance() const
 */
 bool CWinSystemWin10::HasSystemSdrPeakLuminance()
 {
-  return CWIN32Util::GetSystemSdrWhiteLevel(std::wstring(), nullptr);
+  if (m_uiThreadId == GetCurrentThreadId())
+  {
+    const bool hasSystemSdrPeakLum = CWIN32Util::GetSystemSdrWhiteLevel(std::wstring(), nullptr);
+    m_cachedHasSystemSdrPeakLum = hasSystemSdrPeakLum;
+    return hasSystemSdrPeakLum;
+  }
+
+  return m_cachedHasSystemSdrPeakLum;
 }
 
 /*!

--- a/xbmc/windowing/win10/WinSystemWin10.h
+++ b/xbmc/windowing/win10/WinSystemWin10.h
@@ -156,6 +156,10 @@ protected:
 
   bool m_validSystemSdrPeakLuminance{false};
   float m_systemSdrPeakLuminance{.0f};
+
+  DWORD m_uiThreadId{0};
+  HDR_STATUS m_cachedHdrStatus{HDR_STATUS::HDR_UNSUPPORTED};
+  bool m_cachedHasSystemSdrPeakLum{false};
 };
 
 #pragma pack(pop)


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/25025



## What is the effect on users?
Fix crash on Xbox when retrieving Settings with JSON commands / remote control apps or web interface.



## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
