### PR TITLE
Backport: MediaSession: Update only when something changes

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -258,6 +258,7 @@ private:
   bool m_wakeUp{false};
   bool m_aeReset{false};
   bool m_hdmiPlugged{true};
+  bool m_mediaSessionUpdated{false};
   IInputDeviceCallbacks* m_inputDeviceCallbacks{nullptr};
   IInputDeviceEventHandler* m_inputDeviceEventHandler{nullptr};
   bool m_hasReqVisible{false};


### PR DESCRIPTION
Reason: With speed and buffer position the Receiver exactly knows where we currently are. On Pause, Stop or Play the information is updated.

Backport of:  #24986

Fixes stuttering introduced by asking for tvrecommendations twice per second.