### PR TITLE
[Windows] fix DirectSound buffer underrun with some Bluetooth audio devices

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
@@ -218,10 +218,10 @@ bool CAESinkDirectSound::Initialize(AEAudioFormat &format, std::string &device)
 
   m_AvgBytesPerSec = wfxex.Format.nAvgBytesPerSec;
 
-  unsigned int uiFrameCount = (int)(format.m_sampleRate * 0.015); //default to 15ms chunks
+  const unsigned int uiFrameCount = static_cast<int>(format.m_sampleRate * 0.050); // 50ms chunks
   m_dwFrameSize = wfxex.Format.nBlockAlign;
   m_dwChunkSize = m_dwFrameSize * uiFrameCount;
-  m_dwBufferLen = m_dwChunkSize * 12; //180ms total buffer
+  m_dwBufferLen = m_dwChunkSize * 8; // 400ms total buffer
 
   // fill in the secondary sound buffer descriptor
   DSBUFFERDESC dsbdesc = {};


### PR DESCRIPTION
## Description
Fix DirectSound buffer underrun with some Bluetooth audio devices

Fixes https://github.com/xbmc/xbmc/issues/20567

## Motivation and context
Windows 11 has changed a bit the way DirectSound is handled and in combination with some Bluetooth audio devices / drivers causes buffer underruns. 

There was some confusion with this because at the beginning of Windows 11 there were widespread problems with BT audio devices. After some Microsoft patches the situation improved significantly but even today some devices still have problems apparently only with Kodi (even that these same devices works in Kodi with Windows 10).

In any case DirectSound buffers seems very small: only 15ms chunks and 180 ms sink buffer. On forum one of affected users has confirmed issue is fixed increasing buffer size in various combinations:

15 ms * 20 chunks = 300 ms OK
15 ms * 30 chunks = 450 ms OK
50 ms * 8 chunks = 400 ms  OK
50 ms * 5 chunks = 250 ms is not enough 

https://forum.kodi.tv/showthread.php?tid=376406&pid=3193663#pid3193663

15 ms seems have some issues because 44100 sample rate * 0.015  is not exact number, then no exact number of samples for chunk duration. Good candidates are 20 ms 30 ms or 50 ms but stressing thins --> scrolling very fast in a list of files with GUI sounds I have gotten occasional buffer underruns with 20 ms and even 30 ms and 10 chunks (300 ms buffer). Same is happens with current 15 ms and 12 chunks. Seems 15 ms chunk is too small regardless of buffer size.

50 ms seems best number to obtain stability and works fine in my system with 5 chunks but not enough on these BT devices. 

8 chunks seems totally stable and is one of options tested with success on affected BT devices.

NOTE: this problem only happens in DirectSound, WASAPI is not affected because works in other way and system/driver returns optimal buffer duration that is already bigger: 500 ms or 1s. 


## What is the effect on users?
Fixes DirectSound buffer underruns in Windows 11 in combination with some Bluetooth audio devices.



## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
