### PR TITLE
[Cmake][module] Flatbuffers dont use target name that coincides with lib target

### DIFF
--- a/cmake/modules/FindFlatBuffers.cmake
+++ b/cmake/modules/FindFlatBuffers.cmake
@@ -4,11 +4,11 @@
 #
 # This will define the following target:
 #
-#   flatbuffers::flatbuffers - The flatbuffers headers
+#   flatbuffers::flatheaders - The flatbuffers headers
 
 find_package(FlatC REQUIRED)
 
-if(NOT TARGET flatbuffers::flatbuffers)
+if(NOT TARGET flatbuffers::flatheaders)
 
   include(cmake/scripts/common/ModuleHelpers.cmake)
 
@@ -56,14 +56,14 @@ if(NOT TARGET flatbuffers::flatbuffers)
                                     REQUIRED_VARS FLATBUFFERS_INCLUDE_DIR
                                     VERSION_VAR FLATBUFFERS_VER)
 
-  add_library(flatbuffers::flatbuffers INTERFACE IMPORTED)
-  set_target_properties(flatbuffers::flatbuffers PROPERTIES
+  add_library(flatbuffers::flatheaders INTERFACE IMPORTED)
+  set_target_properties(flatbuffers::flatheaders PROPERTIES
                                                  INTERFACE_INCLUDE_DIRECTORIES "${FLATBUFFERS_INCLUDE_DIR}")
 
-  add_dependencies(flatbuffers::flatbuffers flatbuffers::flatc)
+  add_dependencies(flatbuffers::flatheaders flatbuffers::flatc)
 
   if(TARGET flatbuffers)
-    add_dependencies(flatbuffers::flatbuffers flatbuffers)
+    add_dependencies(flatbuffers::flatheaders flatbuffers)
   endif()
 
   # Add internal build target when a Multi Config Generator is used
@@ -82,5 +82,5 @@ if(NOT TARGET flatbuffers::flatbuffers)
     add_dependencies(build_internal_depends flatbuffers)
   endif()
 
-  set_property(GLOBAL APPEND PROPERTY INTERNAL_DEPS_PROP flatbuffers::flatbuffers)
+  set_property(GLOBAL APPEND PROPERTY INTERNAL_DEPS_PROP flatbuffers::flatheaders)
 endif()

--- a/cmake/modules/FindFlatBuffers.cmake
+++ b/cmake/modules/FindFlatBuffers.cmake
@@ -56,31 +56,38 @@ if(NOT TARGET flatbuffers::flatheaders)
                                     REQUIRED_VARS FLATBUFFERS_INCLUDE_DIR
                                     VERSION_VAR FLATBUFFERS_VER)
 
-  add_library(flatbuffers::flatheaders INTERFACE IMPORTED)
-  set_target_properties(flatbuffers::flatheaders PROPERTIES
-                                                 INTERFACE_INCLUDE_DIRECTORIES "${FLATBUFFERS_INCLUDE_DIR}")
+  if(FlatBuffers_FOUND)
 
-  add_dependencies(flatbuffers::flatheaders flatbuffers::flatc)
+    add_library(flatbuffers::flatheaders INTERFACE IMPORTED)
+    set_target_properties(flatbuffers::flatheaders PROPERTIES
+                                                   INTERFACE_INCLUDE_DIRECTORIES "${FLATBUFFERS_INCLUDE_DIR}")
 
-  if(TARGET flatbuffers)
-    add_dependencies(flatbuffers::flatheaders flatbuffers)
-  endif()
+    add_dependencies(flatbuffers::flatheaders flatbuffers::flatc)
 
-  # Add internal build target when a Multi Config Generator is used
-  # We cant add a dependency based off a generator expression for targeted build types,
-  # https://gitlab.kitware.com/cmake/cmake/-/issues/19467
-  # therefore if the find heuristics only find the library, we add the internal build
-  # target to the project to allow user to manually trigger for any build type they need
-  # in case only a specific build type is actually available (eg Release found, Debug Required)
-  # This is mainly targeted for windows who required different runtime libs for different
-  # types, and they arent compatible
-  if(_multiconfig_generator)
-    if(NOT TARGET flatbuffers)
-      buildflatbuffers()
-      set_target_properties(flatbuffers PROPERTIES EXCLUDE_FROM_ALL TRUE)
+    if(TARGET flatbuffers)
+      add_dependencies(flatbuffers::flatheaders flatbuffers)
     endif()
-    add_dependencies(build_internal_depends flatbuffers)
-  endif()
 
-  set_property(GLOBAL APPEND PROPERTY INTERNAL_DEPS_PROP flatbuffers::flatheaders)
+    # Add internal build target when a Multi Config Generator is used
+    # We cant add a dependency based off a generator expression for targeted build types,
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/19467
+    # therefore if the find heuristics only find the library, we add the internal build
+    # target to the project to allow user to manually trigger for any build type they need
+    # in case only a specific build type is actually available (eg Release found, Debug Required)
+    # This is mainly targeted for windows who required different runtime libs for different
+    # types, and they arent compatible
+    if(_multiconfig_generator)
+      if(NOT TARGET flatbuffers)
+        buildflatbuffers()
+        set_target_properties(flatbuffers PROPERTIES EXCLUDE_FROM_ALL TRUE)
+      endif()
+      add_dependencies(build_internal_depends flatbuffers)
+    endif()
+
+    set_property(GLOBAL APPEND PROPERTY INTERNAL_DEPS_PROP flatbuffers::flatheaders)
+  else()
+    if(FlatBuffers_FIND_REQUIRED)
+      message(FATAL_ERROR "Flatbuffer schema headers were not found. You may want to try -DENABLE_INTERNAL_FLATBUFFERS=ON to build the internal headers package")
+    endif()
+  endif()
 endif()

--- a/xbmc/cores/RetroPlayer/messages/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/messages/CMakeLists.txt
@@ -20,8 +20,8 @@ set_target_properties(retroplayer_messages PROPERTIES FOLDER "Generated Messages
                                                       INCLUDE_DIRECTORIES ${CMAKE_CURRENT_BINARY_DIR}
                                                       SOURCES "${FLATC_OUTPUTS}")
 
-if(TARGET flatbuffers::flatbuffers)
-  set_property(TARGET flatbuffers::flatbuffers APPEND PROPERTY
+if(TARGET flatbuffers::flatheaders)
+  set_property(TARGET flatbuffers::flatheaders APPEND PROPERTY
                                                INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_BINARY_DIR}")
-  add_dependencies(retroplayer_messages flatbuffers::flatbuffers)
+  add_dependencies(retroplayer_messages flatbuffers::flatheaders)
 endif()


### PR DESCRIPTION
## Description
Fixes #25048

## Motivation and context
Fix #25048

Also add failure message for more context for user.

## How has this been tested?


## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
