### PR TITLE
Update kodi.sh.in to make usage of ENV_ARGS safe when both, KODI_AE_SINK and KODI_GL_INTERFACE, are used in parallel.

### DIFF
--- a/tools/Linux/kodi.sh.in
+++ b/tools/Linux/kodi.sh.in
@@ -171,6 +171,7 @@ if command_exists gdb; then
   fi
 fi
 
+ENV_ARGS=
 if [ -n "${KODI_AE_SINK}" ]; then
 
   echo "KODI_AE_SINK env variable is deprecated and will be removed in the future."
@@ -197,11 +198,11 @@ if [ -n "${KODI_GL_INTERFACE}" ]; then
   echo "Use the --gl-interface command line switch instead."
 
   if [ "${KODI_GL_INTERFACE}" = "GLX" ]; then
-    ENV_ARGS="--gl-interface=glx"
+    ENV_ARGS="${ENV_ARGS} --gl-interface=glx"
   elif [ "${KODI_GL_INTERFACE}" = "EGL" ]; then
-    ENV_ARGS="--gl-interface=egl"
+    ENV_ARGS="${ENV_ARGS} --gl-interface=egl"
   elif [ "${KODI_GL_INTERFACE}" = "EGL_PB" ]; then
-    ENV_ARGS="--gl-interface=egl-pb"
+    ENV_ARGS="${ENV_ARGS} --gl-interface=egl-pb"
   fi
 fi
 


### PR DESCRIPTION
Make usage of ENV_ARGS safe when both, KODI_AE_SINK and KODI_GL_INTERFACE, are used in parallel.

Please note, this request replaces https://github.com/xbmc/xbmc/pull/25047, because I failed to update the commit message in there. Hopefully I got it right this time...

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The current version uses ENV_ARGS only to add one potential argument to be added to the kodi invocation line. When a user uses both variables, KODI_AE_SINK and KODI_GL_INTERFACE, only "--gl-interface=..." gets passed, "--audio-backend=..." gets lost.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is a bug, and it is fixed by applying this patch.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built packages locally for openSUSE_Leap_15.5 and openSUSE_Tumbleweed. Kodi works and uses the values passed in via the deprecated environment variables.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
None.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
