### PR TITLE
Fix Python xbmc.getLanguage() return when UI language has regional variant

### DIFF
--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -183,6 +183,7 @@ namespace XBMCAddon
     String getLanguage(int format /* = CLangCodeExpander::ENGLISH_NAME */, bool region /*= false*/)
     {
       XBMC_TRACE;
+      const std::string LANGNAME_DELIM{" ("}; //Delimiter for ENGLISH_NAME (region)
       std::string lang = g_langInfo.GetEnglishLanguageName();
 
       switch (format)
@@ -199,6 +200,7 @@ namespace XBMCAddon
       case CLangCodeExpander::ISO_639_1:
         {
           std::string langCode;
+          lang = StringUtils::Split(lang, LANGNAME_DELIM)[0];
           g_LangCodeExpander.ConvertToISO6391(lang, langCode);
           if (region)
           {
@@ -213,6 +215,7 @@ namespace XBMCAddon
       case CLangCodeExpander::ISO_639_2:
         {
           std::string langCode;
+          lang = StringUtils::Split(lang, LANGNAME_DELIM)[0];
           g_LangCodeExpander.ConvertToISO6392B(lang, langCode);
           if (region)
           {


### PR DESCRIPTION

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
ModuleXbmc.cpp function getLanguage
The UI language was failing to return correct ISO 639-1 and ISO 639-2 language and optional region codes when UI language is set to a language with a regional variant -- for example, English (New Zealand).   This fix splits the language English Name at " (" so only the language name is used when retrieving the language codes.
## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix for https://github.com/xbmc/xbmc/issues/24990

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Windows 10 x64 with OS locale en-us.  Python addon created to call xbmc.getLanguage([format], [region]) for all 6 possible cases, including region=True and region=False.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Addons using xbmc.getLanguage() will work properly.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
