### PR TITLE
[Windows] enable XAudio2 sink in Windows desktop and code improvements

### DIFF
--- a/xbmc/cores/AudioEngine/CMakeLists.txt
+++ b/xbmc/cores/AudioEngine/CMakeLists.txt
@@ -105,17 +105,18 @@ endif()
 
 if(CORE_SYSTEM_NAME MATCHES windows)
   list(APPEND SOURCES Sinks/AESinkWASAPI.cpp
+                      Sinks/AESinkXAudio.cpp
                       Sinks/windows/AESinkFactoryWin.cpp)
   list(APPEND HEADERS Sinks/AESinkWASAPI.h
+                      Sinks/AESinkXAudio.h
                       Sinks/windows/AESinkFactoryWin.h)
+
   if(CORE_SYSTEM_NAME STREQUAL windowsstore)
-    list(APPEND SOURCES Sinks/AESinkXAudio.cpp
-                        Sinks/windows/AESinkFactoryWin10.cpp)
-    list(APPEND SOURCES Sinks/AESinkXAudio.h)
-  elseif(CORE_SYSTEM_NAME STREQUAL windows)
+    list(APPEND SOURCES Sinks/windows/AESinkFactoryWin10.cpp)
+  else()
     list(APPEND SOURCES Sinks/AESinkDirectSound.cpp
                         Sinks/windows/AESinkFactoryWin32.cpp)
-    list(APPEND SOURCES Sinks/AESinkDirectSound.h)
+    list(APPEND HEADERS Sinks/AESinkDirectSound.h)
   endif()
 endif()
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
@@ -797,6 +797,22 @@ initialize:
 
   m_sourceVoice->Stop();
 
+  CLog::LogF(LOGDEBUG, "Initializing XAudio with the following parameters:");
+  CLog::Log(LOGDEBUG, "  Audio Device    : {}", KODI::PLATFORM::WINDOWS::FromW(device));
+  CLog::Log(LOGDEBUG, "  Sample Rate     : {}", wfxex.Format.nSamplesPerSec);
+  CLog::Log(LOGDEBUG, "  Sample Format   : {}", CAEUtil::DataFormatToStr(format.m_dataFormat));
+  CLog::Log(LOGDEBUG, "  Bits Per Sample : {}", wfxex.Format.wBitsPerSample);
+  CLog::Log(LOGDEBUG, "  Valid Bits/Samp : {}", wfxex.Samples.wValidBitsPerSample);
+  CLog::Log(LOGDEBUG, "  Channel Count   : {}", wfxex.Format.nChannels);
+  CLog::Log(LOGDEBUG, "  Block Align     : {}", wfxex.Format.nBlockAlign);
+  CLog::Log(LOGDEBUG, "  Avg. Bytes Sec  : {}", wfxex.Format.nAvgBytesPerSec);
+  CLog::Log(LOGDEBUG, "  Samples/Block   : {}", wfxex.Samples.wSamplesPerBlock);
+  CLog::Log(LOGDEBUG, "  Format cBSize   : {}", wfxex.Format.cbSize);
+  CLog::Log(LOGDEBUG, "  Channel Layout  : {}", ((std::string)format.m_channelLayout));
+  CLog::Log(LOGDEBUG, "  Channel Mask    : {}", wfxex.dwChannelMask);
+  CLog::Log(LOGDEBUG, "  Frames          : {}", format.m_frames);
+  CLog::Log(LOGDEBUG, "  Frame Size      : {}", format.m_frameSize);
+
   return true;
 }
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
@@ -619,13 +619,8 @@ initialize:
     return false;
   }
 
-  const unsigned int bufferLen = static_cast<int>(format.m_sampleRate * 0.02); // 20 ms chunks
-  m_dwFrameSize = wfxex.Format.nBlockAlign;
-  m_dwChunkSize = m_dwFrameSize * bufferLen;
-  m_dwBufferLen = m_dwChunkSize * 4; // 80 ms buffer
-  m_AvgBytesPerSec = wfxex.Format.nAvgBytesPerSec;
+  format.m_frames = static_cast<int>(format.m_sampleRate * 0.02); // 20 ms chunks
 
-  format.m_frames = bufferLen;
   m_format = format;
 
   CLog::LogF(LOGINFO, "XAudio Sink Initialized using: {}, {}, {}",

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
@@ -897,29 +897,6 @@ void CAESinkXAudio::Drain()
   m_running = false;
 }
 
-bool CAESinkXAudio::IsUSBDevice()
-{
-#if 0 // TODO
-  IPropertyStore *pProperty = nullptr;
-  PROPVARIANT varName;
-  PropVariantInit(&varName);
-  bool ret = false;
-
-  HRESULT hr = m_pDevice->OpenPropertyStore(STGM_READ, &pProperty);
-  if (!SUCCEEDED(hr))
-    return ret;
-  hr = pProperty->GetValue(PKEY_Device_EnumeratorName, &varName);
-
-  std::string str = localWideToUtf(varName.pwszVal);
-  StringUtils::ToUpper(str);
-  ret = (str == "USB");
-  PropVariantClear(&varName);
-  if (pProperty)
-    pProperty->Release();
-#endif
-  return false;
-}
-
 bool CAESinkXAudio::AddEndOfStreamPacket()
 {
   constexpr unsigned int frames{1};

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
@@ -244,11 +244,9 @@ unsigned int CAESinkXAudio::AddPackets(uint8_t **data, unsigned int frames, unsi
   HRESULT hr = S_OK;
   DWORD flags = 0;
 
-#ifndef _DEBUG
   LARGE_INTEGER timerStart;
   LARGE_INTEGER timerStop;
   LARGE_INTEGER timerFreq;
-#endif
 
   XAUDIO2_BUFFER xbuffer = BuildXAudio2Buffer(data, frames, offset);
 
@@ -276,11 +274,9 @@ unsigned int CAESinkXAudio::AddPackets(uint8_t **data, unsigned int frames, unsi
     return frames;
   }
 
-#ifndef _DEBUG
   /* Get clock time for latency checks */
   QueryPerformanceFrequency(&timerFreq);
   QueryPerformanceCounter(&timerStart);
-#endif
 
   /* Wait for Audio Driver to tell us it's got a buffer available */
   //XAUDIO2_VOICE_STATE state;
@@ -300,7 +296,6 @@ unsigned int CAESinkXAudio::AddPackets(uint8_t **data, unsigned int frames, unsi
   if (!m_running)
     return 0;
 
-#ifndef _DEBUG
   QueryPerformanceCounter(&timerStop);
   LONGLONG timerDiff = timerStop.QuadPart - timerStart.QuadPart;
   double timerElapsed = (double) timerDiff * 1000.0 / (double) timerFreq.QuadPart;
@@ -311,14 +306,11 @@ unsigned int CAESinkXAudio::AddPackets(uint8_t **data, unsigned int frames, unsi
     CLog::LogF(LOGDEBUG, "Possible AQ Loss: Avg. Time Waiting for Audio Driver callback : {}msec",
                (int)m_avgTimeWaiting);
   }
-#endif
 
   hr = m_sourceVoice->SubmitSourceBuffer(&xbuffer);
   if (FAILED(hr))
   {
-    #ifdef _DEBUG
     CLog::LogF(LOGERROR, "submiting buffer failed due to {}", WASAPIErrToStr(hr));
-#endif
     delete xbuffer.pContext;
     return INT_MAX;
   }

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
@@ -52,8 +52,6 @@ inline void SafeDestroyVoice(TVoice **ppVoice)
 
 CAESinkXAudio::CAESinkXAudio()
 {
-  m_channelLayout.Reset();
-
   HRESULT hr = XAudio2Create(m_xAudio2.ReleaseAndGetAddressOf(), 0);
   if (FAILED(hr))
   {
@@ -729,13 +727,9 @@ bool CAESinkXAudio::InitializeInternal(std::string deviceId, AEAudioFormat &form
 
 initialize:
 
-  CAESinkFactoryWin::AEChannelsFromSpeakerMask(m_channelLayout, wfxex.dwChannelMask);
-  format.m_channelLayout = m_channelLayout;
-
-  /* When the stream is raw, the values in the format structure are set to the link    */
-  /* parameters, so store the encoded stream values here for the IsCompatible function */
-  m_encodedChannels   = wfxex.Format.nChannels;
-  m_encodedSampleRate = (format.m_dataFormat == AE_FMT_RAW) ? format.m_streamInfo.m_sampleRate : format.m_sampleRate;
+  CAEChannelInfo channelLayout;
+  CAESinkFactoryWin::AEChannelsFromSpeakerMask(channelLayout, wfxex.dwChannelMask);
+  format.m_channelLayout = channelLayout;
 
   /* Set up returned sink format for engine */
   if (format.m_dataFormat != AE_FMT_RAW)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
@@ -36,12 +36,6 @@ using namespace Microsoft::WRL;
 
 extern const char *WASAPIErrToStr(HRESULT err);
 
-#define EXIT_ON_FAILURE(hr, reason, ...) \
-  if (FAILED(hr)) \
-  { \
-    CLog::Log(LOGERROR, reason " - {}", __VA_ARGS__, WASAPIErrToStr(hr)); \
-    goto failed; \
-  }
 #define XAUDIO_BUFFERS_IN_QUEUE 2
 
 template <class TVoice>
@@ -136,7 +130,7 @@ bool CAESinkXAudio::Initialize(AEAudioFormat &format, std::string &device)
 
   if (!InitializeInternal(device, format))
   {
-    CLog::Log(LOGINFO, __FUNCTION__": Could not Initialize voices with that format");
+    CLog::LogF(LOGINFO, "could not Initialize voices with that format");
     goto failed;
   }
 
@@ -150,7 +144,7 @@ bool CAESinkXAudio::Initialize(AEAudioFormat &format, std::string &device)
   return true;
 
 failed:
-  CLog::Log(LOGERROR, __FUNCTION__": XAudio initialization failed.");
+  CLog::LogF(LOGERROR, "XAudio initialization failed");
   return true;
 }
 
@@ -184,7 +178,7 @@ void CAESinkXAudio::Deinitialize()
     }
     catch (...)
     {
-      CLog::Log(LOGERROR, "{}: Invalidated source voice - Releasing", __FUNCTION__);
+      CLog::LogF(LOGERROR, "invalidated source voice - Releasing");
     }
   }
   m_running = false;
@@ -351,7 +345,7 @@ void CAESinkXAudio::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
   hr = XAudio2Create(xaudio2.ReleaseAndGetAddressOf(), eflags);
   if (FAILED(hr))
   {
-    CLog::Log(LOGDEBUG, __FUNCTION__": Failed to activate XAudio for capability testing.");
+    CLog::LogF(LOGDEBUG, "failed to activate XAudio for capability testing");
     goto failed;
   }
 
@@ -381,9 +375,9 @@ void CAESinkXAudio::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
 
     if (FAILED(hr))
     {
-      CLog::Log(
-          LOGINFO, __FUNCTION__ ": stream type \"{}\" on device \"{}\" seems to be not supported.",
-          CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_DTSHD_MA), details.strDescription);
+      CLog::LogF(LOGINFO, "stream type \"{}\" on device \"{}\" seems to be not supported.",
+                 CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_DTSHD_MA),
+                 details.strDescription);
     }
     else
     {
@@ -410,9 +404,9 @@ void CAESinkXAudio::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
 
     if (FAILED(hr))
     {
-      CLog::Log(LOGINFO,
-                __FUNCTION__ ": stream type \"{}\" on device \"{}\" seems to be not supported.",
-                CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_DTSHD), details.strDescription);
+      CLog::LogF(LOGINFO, "stream type \"{}\" on device \"{}\" seems to be not supported.",
+                 CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_DTSHD),
+                 details.strDescription);
     }
     else
     {
@@ -429,9 +423,9 @@ void CAESinkXAudio::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
     hr = xaudio2->CreateSourceVoice(&mSourceVoice, &wfxex.Format);
     if (FAILED(hr))
     {
-      CLog::Log(
-          LOGINFO, __FUNCTION__ ": stream type \"{}\" on device \"{}\" seems to be not supported.",
-          CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_TRUEHD), details.strDescription);
+      CLog::LogF(LOGINFO, "stream type \"{}\" on device \"{}\" seems to be not supported.",
+                 CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_TRUEHD),
+                 details.strDescription);
     }
     else
     {
@@ -453,9 +447,8 @@ void CAESinkXAudio::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
 
     if (FAILED(hr))
     {
-      CLog::Log(LOGINFO,
-                __FUNCTION__ ": stream type \"{}\" on device \"{}\" seems to be not supported.",
-                CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_EAC3), details.strDescription);
+      CLog::LogF(LOGINFO, "stream type \"{}\" on device \"{}\" seems to be not supported.",
+                 CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_EAC3), details.strDescription);
     }
     else
     {
@@ -477,9 +470,8 @@ void CAESinkXAudio::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
     hr = xaudio2->CreateSourceVoice(&mSourceVoice, &wfxex.Format);
     if (FAILED(hr))
     {
-      CLog::Log(LOGINFO,
-                __FUNCTION__ ": stream type \"{}\" on device \"{}\" seems to be not supported.",
-                "STREAM_TYPE_DTS", details.strDescription);
+      CLog::LogF(LOGINFO, "stream type \"{}\" on device \"{}\" seems to be not supported.",
+                 "STREAM_TYPE_DTS", details.strDescription);
     }
     else
     {
@@ -496,9 +488,8 @@ void CAESinkXAudio::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
     hr = xaudio2->CreateSourceVoice(&mSourceVoice, &wfxex.Format);
     if (FAILED(hr))
     {
-      CLog::Log(LOGINFO,
-                __FUNCTION__ ": stream type \"{}\" on device \"{}\" seems to be not supported.",
-                CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_AC3), details.strDescription);
+      CLog::LogF(LOGINFO, "stream type \"{}\" on device \"{}\" seems to be not supported.",
+                 CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_AC3), details.strDescription);
     }
     else
     {
@@ -566,9 +557,8 @@ void CAESinkXAudio::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
       else if (wfxex.Format.nSamplesPerSec == 192000 && add192)
       {
         deviceInfo.m_sampleRates.push_back(WASAPISampleRates[j]);
-        CLog::Log(LOGINFO,
-                  __FUNCTION__ ": sample rate 192khz on device \"{}\" seems to be not supported.",
-                  details.strDescription);
+        CLog::LogF(LOGINFO, "sample rate 192khz on device \"{}\" seems to be not supported.",
+                   details.strDescription);
       }
     }
     SafeDestroyVoice(&mSourceVoice);
@@ -603,8 +593,7 @@ void CAESinkXAudio::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
 failed:
 
   if (FAILED(hr))
-    CLog::Log(LOGERROR, __FUNCTION__ ": Failed to enumerate XAudio endpoint devices ({}).",
-              WASAPIErrToStr(hr));
+    CLog::LogF(LOGERROR, "failed to enumerate XAudio endpoint devices ({})", WASAPIErrToStr(hr));
 }
 
 /// ------------------- Private utility functions -----------------------------------
@@ -658,10 +647,10 @@ bool CAESinkXAudio::InitializeInternal(std::string deviceId, AEAudioFormat &form
   {
     if (!bdefault)
     {
-      CLog::Log(LOGINFO,
-                __FUNCTION__ ": Could not locate the device named \"{}\" in the list of Xaudio "
-                             "endpoint devices. Trying the default device...",
-                KODI::PLATFORM::WINDOWS::FromW(device));
+      CLog::LogF(LOGINFO,
+                 "could not locate the device named \"{}\" in the list of Xaudio endpoint devices. "
+                 "Trying the default device...",
+                 KODI::PLATFORM::WINDOWS::FromW(device));
     }
 
     // smartphone issue: providing device ID (even default ID) causes E_NOINTERFACE result
@@ -670,9 +659,8 @@ bool CAESinkXAudio::InitializeInternal(std::string deviceId, AEAudioFormat &form
                                           0, 0, nullptr, AudioCategory_Media);
     if (FAILED(hr) || !pMasterVoice)
     {
-      CLog::Log(LOGINFO,
-                __FUNCTION__ ": Could not retrieve the default XAudio audio endpoint ({}).",
-                WASAPIErrToStr(hr));
+      CLog::LogF(LOGINFO, "Could not retrieve the default XAudio audio endpoint ({}).",
+                 WASAPIErrToStr(hr));
       return false;
     }
   }
@@ -686,7 +674,7 @@ bool CAESinkXAudio::InitializeInternal(std::string deviceId, AEAudioFormat &form
   hr = m_xAudio2->CreateSourceVoice(&m_sourceVoice, &wfxex.Format, 0, XAUDIO2_DEFAULT_FREQ_RATIO, &m_voiceCallback);
   if (SUCCEEDED(hr))
   {
-    CLog::Log(LOGINFO, __FUNCTION__": Format is Supported - will attempt to Initialize");
+    CLog::LogF(LOGINFO, "Format is Supported - will attempt to Initialize");
     goto initialize;
   }
 
@@ -694,9 +682,9 @@ bool CAESinkXAudio::InitializeInternal(std::string deviceId, AEAudioFormat &form
     return false;
 
   if (CServiceBroker::GetLogging().CanLogComponent(LOGAUDIO))
-    CLog::Log(LOGDEBUG,
-              __FUNCTION__ ": CreateSourceVoice failed ({}) - trying to find a compatible format",
-              WASAPIErrToStr(hr));
+    CLog::LogFC(LOGDEBUG, LOGAUDIO,
+                "CreateSourceVoice failed ({}) - trying to find a compatible format",
+                WASAPIErrToStr(hr));
 
   requestedChannels = wfxex.Format.nChannels;
 
@@ -751,7 +739,7 @@ bool CAESinkXAudio::InitializeInternal(std::string deviceId, AEAudioFormat &form
         }
 
         if (FAILED(hr))
-          CLog::Log(LOGERROR, __FUNCTION__ ": creating voices failed ({})", WASAPIErrToStr(hr));
+          CLog::LogF(LOGERROR, "creating voices failed ({})", WASAPIErrToStr(hr));
       }
 
       if (closestMatch >= 0)
@@ -763,7 +751,8 @@ bool CAESinkXAudio::InitializeInternal(std::string deviceId, AEAudioFormat &form
     }
   }
 
-  CLog::Log(LOGERROR, __FUNCTION__": Unable to locate a supported output format for the device.  Check the speaker settings in the control panel.");
+  CLog::LogF(LOGERROR, "unable to locate a supported output format for the device. Check the "
+                       "speaker settings in the control panel.");
 
   /* We couldn't find anything supported. This should never happen      */
   /* unless the user set the wrong speaker setting in the control panel */
@@ -806,7 +795,7 @@ initialize:
   hr = m_sourceVoice->Start(0, XAUDIO2_COMMIT_NOW);
   if (FAILED(hr))
   {
-    CLog::Log(LOGERROR, __FUNCTION__ ": Voice start failed : {}", WASAPIErrToStr(hr));
+    CLog::LogF(LOGERROR, "Voice start failed : {}", WASAPIErrToStr(hr));
     CLog::Log(LOGDEBUG, "  Sample Rate     : {}", wfxex.Format.nSamplesPerSec);
     CLog::Log(LOGDEBUG, "  Sample Format   : {}", CAEUtil::DataFormatToStr(format.m_dataFormat));
     CLog::Log(LOGDEBUG, "  Bits Per Sample : {}", wfxex.Format.wBitsPerSample);
@@ -825,7 +814,7 @@ initialize:
   m_xAudio2->GetPerformanceData(&perfData);
   if (!perfData.TotalSourceVoiceCount)
   {
-    CLog::Log(LOGERROR, __FUNCTION__ ": GetPerformanceData Failed : {}", WASAPIErrToStr(hr));
+    CLog::LogF(LOGERROR, "GetPerformanceData Failed : {}", WASAPIErrToStr(hr));
     return false;
   }
 
@@ -835,9 +824,9 @@ initialize:
   m_dwBufferLen = m_dwChunkSize * 4;
   m_AvgBytesPerSec = wfxex.Format.nAvgBytesPerSec;
 
-  CLog::Log(LOGINFO, __FUNCTION__ ": XAudio Sink Initialized using: {}, {}, {}",
-            CAEUtil::DataFormatToStr(format.m_dataFormat), wfxex.Format.nSamplesPerSec,
-            wfxex.Format.nChannels);
+  CLog::LogF(LOGINFO, "XAudio Sink Initialized using: {}, {}, {}",
+             CAEUtil::DataFormatToStr(format.m_dataFormat), wfxex.Format.nSamplesPerSec,
+             wfxex.Format.nChannels);
 
   m_sourceVoice->Stop();
 
@@ -891,7 +880,7 @@ void CAESinkXAudio::Drain()
     }
     catch (...)
     {
-      CLog::Log(LOGERROR, "{}: Invalidated source voice - Releasing", __FUNCTION__);
+      CLog::LogF(LOGERROR, "invalidated source voice - Releasing");
     }
   }
   m_running = false;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
@@ -157,14 +157,6 @@ void CAESinkXAudio::Deinitialize()
   m_initialized = false;
 }
 
-/**
- * @brief rescale uint64_t without overflowing on large values
- */
-static uint64_t rescale_u64(uint64_t val, uint64_t num, uint64_t den)
-{
-  return ((val / den) * num) + (((val % den) * num) / den);
-}
-
 void CAESinkXAudio::GetDelay(AEDelayStatus& status)
 {
   HRESULT hr = S_OK;

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
@@ -50,25 +50,7 @@ inline void SafeDestroyVoice(TVoice **ppVoice)
 
 ///  ----------------- CAESinkXAudio ------------------------
 
-CAESinkXAudio::CAESinkXAudio() :
-  m_masterVoice(nullptr),
-  m_sourceVoice(nullptr),
-  m_encodedChannels(0),
-  m_encodedSampleRate(0),
-  sinkReqFormat(AE_FMT_INVALID),
-  sinkRetFormat(AE_FMT_INVALID),
-  m_AvgBytesPerSec(0),
-  m_dwChunkSize(0),
-  m_dwFrameSize(0),
-  m_dwBufferLen(0),
-  m_sinkFrames(0),
-  m_framesInBuffers(0),
-  m_running(false),
-  m_initialized(false),
-  m_isSuspended(false),
-  m_isDirty(false),
-  m_uiBufferLen(0),
-  m_avgTimeWaiting(50)
+CAESinkXAudio::CAESinkXAudio()
 {
   m_channelLayout.Reset();
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
@@ -316,150 +316,17 @@ void CAESinkXAudio::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool fo
 
     std::wstring deviceId = KODI::PLATFORM::WINDOWS::ToW(details.strDevicePath);
 
-    /* Test format DTS-HD-MA */
-    wfxex.Format.cbSize = sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX);
-    wfxex.Format.nSamplesPerSec = 192000;
-    wfxex.dwChannelMask = KSAUDIO_SPEAKER_7POINT1_SURROUND;
-    wfxex.Format.wFormatTag = WAVE_FORMAT_EXTENSIBLE;
-    wfxex.SubFormat = KSDATAFORMAT_SUBTYPE_IEC61937_DTS_HD;
-    wfxex.Format.wBitsPerSample = 16;
-    wfxex.Samples.wValidBitsPerSample = 16;
-    wfxex.Format.nChannels = 8;
-    wfxex.Format.nBlockAlign = wfxex.Format.nChannels * (wfxex.Format.wBitsPerSample >> 3);
-    wfxex.Format.nAvgBytesPerSec = wfxex.Format.nSamplesPerSec * wfxex.Format.nBlockAlign;
-
-    hr2 = xaudio2->CreateMasteringVoice(&mMasterVoice, wfxex.Format.nChannels, wfxex.Format.nSamplesPerSec,
-                                        0, deviceId.c_str(), nullptr, AudioCategory_Media);
-    hr = xaudio2->CreateSourceVoice(&mSourceVoice, &wfxex.Format);
-
-    if (FAILED(hr))
-    {
-      CLog::LogF(LOGINFO, "stream type \"{}\" on device \"{}\" seems to be not supported.",
-                 CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_DTSHD_MA),
-                 details.strDescription);
-    }
-    else
-    {
-      deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD_MA);
-      add192 = true;
-    }
-    SafeDestroyVoice(&mSourceVoice);
-
-    /* Test format DTS-HD-HR */
-    wfxex.Format.cbSize = sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX);
-    wfxex.Format.nSamplesPerSec = 192000;
-    wfxex.dwChannelMask = KSAUDIO_SPEAKER_5POINT1;
-    wfxex.Format.wFormatTag = WAVE_FORMAT_EXTENSIBLE;
-    wfxex.SubFormat = KSDATAFORMAT_SUBTYPE_IEC61937_DTS_HD;
-    wfxex.Format.wBitsPerSample = 16;
-    wfxex.Samples.wValidBitsPerSample = 16;
-    wfxex.Format.nChannels = 2;
-    wfxex.Format.nBlockAlign = wfxex.Format.nChannels * (wfxex.Format.wBitsPerSample >> 3);
-    wfxex.Format.nAvgBytesPerSec = wfxex.Format.nSamplesPerSec * wfxex.Format.nBlockAlign;
-
-    hr2 = xaudio2->CreateMasteringVoice(&mMasterVoice, wfxex.Format.nChannels, wfxex.Format.nSamplesPerSec,
-                                        0, deviceId.c_str(), nullptr, AudioCategory_Media);
-    hr = xaudio2->CreateSourceVoice(&mSourceVoice, &wfxex.Format);
-
-    if (FAILED(hr))
-    {
-      CLog::LogF(LOGINFO, "stream type \"{}\" on device \"{}\" seems to be not supported.",
-                 CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_DTSHD),
-                 details.strDescription);
-    }
-    else
-    {
-      deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD);
-      add192 = true;
-    }
-    SafeDestroyVoice(&mSourceVoice);
-
-    /* Test format Dolby TrueHD */
-    wfxex.SubFormat = KSDATAFORMAT_SUBTYPE_IEC61937_DOLBY_MLP;
-    wfxex.Format.nChannels = 8;
-    wfxex.dwChannelMask = KSAUDIO_SPEAKER_7POINT1_SURROUND;
-
-    hr = xaudio2->CreateSourceVoice(&mSourceVoice, &wfxex.Format);
-    if (FAILED(hr))
-    {
-      CLog::LogF(LOGINFO, "stream type \"{}\" on device \"{}\" seems to be not supported.",
-                 CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_TRUEHD),
-                 details.strDescription);
-    }
-    else
-    {
-      deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_TRUEHD);
-      add192 = true;
-    }
-
-    /* Test format Dolby EAC3 */
-    wfxex.SubFormat = KSDATAFORMAT_SUBTYPE_IEC61937_DOLBY_DIGITAL_PLUS;
-    wfxex.Format.nChannels = 2;
-    wfxex.Format.nBlockAlign = wfxex.Format.nChannels * (wfxex.Format.wBitsPerSample >> 3);
-    wfxex.Format.nAvgBytesPerSec = wfxex.Format.nSamplesPerSec * wfxex.Format.nBlockAlign;
-
-    SafeDestroyVoice(&mSourceVoice);
-    SafeDestroyVoice(&mMasterVoice);
-    hr2 = xaudio2->CreateMasteringVoice(&mMasterVoice, wfxex.Format.nChannels, wfxex.Format.nSamplesPerSec,
-                                        0, deviceId.c_str(), nullptr, AudioCategory_Media);
-    hr = xaudio2->CreateSourceVoice(&mSourceVoice, &wfxex.Format);
-
-    if (FAILED(hr))
-    {
-      CLog::LogF(LOGINFO, "stream type \"{}\" on device \"{}\" seems to be not supported.",
-                 CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_EAC3), details.strDescription);
-    }
-    else
-    {
-      deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_EAC3);
-      add192 = true;
-    }
-
-    /* Test format DTS */
-    wfxex.Format.nSamplesPerSec = 48000;
-    wfxex.dwChannelMask = KSAUDIO_SPEAKER_5POINT1;
-    wfxex.SubFormat = KSDATAFORMAT_SUBTYPE_IEC61937_DTS;
-    wfxex.Format.nBlockAlign = wfxex.Format.nChannels * (wfxex.Format.wBitsPerSample >> 3);
-    wfxex.Format.nAvgBytesPerSec = wfxex.Format.nSamplesPerSec * wfxex.Format.nBlockAlign;
-
-    SafeDestroyVoice(&mSourceVoice);
-    SafeDestroyVoice(&mMasterVoice);
-    hr2 = xaudio2->CreateMasteringVoice(&mMasterVoice, wfxex.Format.nChannels, wfxex.Format.nSamplesPerSec,
-                                        0, deviceId.c_str(), nullptr, AudioCategory_Media);
-    hr = xaudio2->CreateSourceVoice(&mSourceVoice, &wfxex.Format);
-    if (FAILED(hr))
-    {
-      CLog::LogF(LOGINFO, "stream type \"{}\" on device \"{}\" seems to be not supported.",
-                 "STREAM_TYPE_DTS", details.strDescription);
-    }
-    else
-    {
-      deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD_CORE);
-      deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_2048);
-      deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_1024);
-      deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTS_512);
-    }
-    SafeDestroyVoice(&mSourceVoice);
-
-    /* Test format Dolby AC3 */
-    wfxex.SubFormat = KSDATAFORMAT_SUBTYPE_IEC61937_DOLBY_DIGITAL;
-
-    hr = xaudio2->CreateSourceVoice(&mSourceVoice, &wfxex.Format);
-    if (FAILED(hr))
-    {
-      CLog::LogF(LOGINFO, "stream type \"{}\" on device \"{}\" seems to be not supported.",
-                 CAEUtil::StreamTypeToStr(CAEStreamInfo::STREAM_TYPE_AC3), details.strDescription);
-    }
-    else
-    {
-      deviceInfo.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_AC3);
-    }
-
     /* Test format for PCM format iteration */
     wfxex.Format.cbSize = sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX);
+    wfxex.Format.nSamplesPerSec = 48000;
+    wfxex.Format.nChannels = 2;
     wfxex.dwChannelMask = KSAUDIO_SPEAKER_STEREO;
     wfxex.Format.wFormatTag = WAVE_FORMAT_EXTENSIBLE;
     wfxex.SubFormat = KSDATAFORMAT_SUBTYPE_IEEE_FLOAT;
+
+    xaudio2->CreateMasteringVoice(&mMasterVoice, wfxex.Format.nChannels,
+                                  wfxex.Format.nSamplesPerSec, 0, deviceId.c_str(), nullptr,
+                                  AudioCategory_Media);
 
     for (int p = AE_FMT_FLOAT; p > AE_FMT_INVALID; p--)
     {

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
@@ -159,10 +159,6 @@ void CAESinkXAudio::Deinitialize()
 
 void CAESinkXAudio::GetDelay(AEDelayStatus& status)
 {
-  HRESULT hr = S_OK;
-  uint64_t pos = 0, tick = 0;
-  int retries = 0;
-
   if (!m_initialized)
   {
     status.SetDelay(0.0);
@@ -172,8 +168,7 @@ void CAESinkXAudio::GetDelay(AEDelayStatus& status)
   XAUDIO2_VOICE_STATE state;
   m_sourceVoice->GetState(&state, 0);
 
-  double delay = (double)(m_sinkFrames - state.SamplesPlayed) / m_format.m_sampleRate;
-  status.SetDelay(delay);
+  status.SetDelay(static_cast<double>(m_sinkFrames - state.SamplesPlayed) / m_format.m_sampleRate);
   return;
 }
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp
@@ -18,7 +18,9 @@
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
 
+#ifdef TARGET_WINDOWS_STORE
 #include "platform/win10/AsyncHelpers.h"
+#endif
 #include "platform/win32/CharsetConverter.h"
 
 #include <algorithm>

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.h
@@ -139,10 +139,6 @@ private:
     CAEChannelInfo m_channelLayout;
     std::string m_device;
 
-    AEDataFormat sinkReqFormat{AE_FMT_INVALID};
-    AEDataFormat sinkRetFormat{AE_FMT_INVALID};
-
-    unsigned int m_uiBufferLen{0}; // xaudio endpoint buffer size, in frames
     unsigned int m_AvgBytesPerSec{0};
     unsigned int m_dwChunkSize{0};
     unsigned int m_dwFrameSize{0};

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.h
@@ -137,7 +137,6 @@ private:
     unsigned int m_encodedChannels{0};
     unsigned int m_encodedSampleRate{0};
     CAEChannelInfo m_channelLayout;
-    std::string m_device;
 
     unsigned int m_AvgBytesPerSec{0};
     unsigned int m_dwChunkSize{0};

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.h
@@ -135,10 +135,6 @@ private:
 
     AEAudioFormat m_format;
 
-    unsigned int m_AvgBytesPerSec{0};
-    unsigned int m_dwChunkSize{0};
-    unsigned int m_dwFrameSize{0};
-    unsigned int m_dwBufferLen{0};
     uint64_t m_sinkFrames{0};
     std::atomic<uint16_t> m_framesInBuffers{0};
 

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.h
@@ -145,4 +145,6 @@ private:
     bool m_initialized{false};
     bool m_isSuspended{false}; // sink is in a suspended state - release audio device
     bool m_isDirty{false}; // sink output failed - needs re-init or new device
+
+    LARGE_INTEGER m_timerFreq{}; // performance counter frequency for latency calculations
 };

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.h
@@ -111,8 +111,8 @@ private:
       HANDLE m_StreamEndEvent{0};
     };
 
-    bool InitializeInternal(std::string deviceId, AEAudioFormat &format);
-    bool IsUSBDevice();
+    bool InitializeInternal(std::string deviceId, AEAudioFormat& format);
+
     /*!
      * \brief Add a 1 frame long buffer with the end of stream flag to the voice.
      * \return true for success, false for failure

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.h
@@ -134,9 +134,6 @@ private:
     VoiceCallback m_voiceCallback;
 
     AEAudioFormat m_format;
-    unsigned int m_encodedChannels{0};
-    unsigned int m_encodedSampleRate{0};
-    CAEChannelInfo m_channelLayout;
 
     unsigned int m_AvgBytesPerSec{0};
     unsigned int m_dwChunkSize{0};

--- a/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.h
@@ -129,31 +129,32 @@ private:
     XAUDIO2_BUFFER BuildXAudio2Buffer(uint8_t** data, unsigned int frames, unsigned int offset);
 
     Microsoft::WRL::ComPtr<IXAudio2> m_xAudio2;
-    IXAudio2MasteringVoice* m_masterVoice;
-    IXAudio2SourceVoice* m_sourceVoice;
+    IXAudio2MasteringVoice* m_masterVoice{nullptr};
+    IXAudio2SourceVoice* m_sourceVoice{nullptr};
     VoiceCallback m_voiceCallback;
 
     AEAudioFormat m_format;
-    unsigned int m_encodedChannels;
-    unsigned int m_encodedSampleRate;
+    unsigned int m_encodedChannels{0};
+    unsigned int m_encodedSampleRate{0};
     CAEChannelInfo m_channelLayout;
     std::string m_device;
 
-    enum AEDataFormat sinkReqFormat;
-    enum AEDataFormat sinkRetFormat;
+    AEDataFormat sinkReqFormat{AE_FMT_INVALID};
+    AEDataFormat sinkRetFormat{AE_FMT_INVALID};
 
-    unsigned int m_uiBufferLen;    /* xaudio endpoint buffer size, in frames */
-    unsigned int m_AvgBytesPerSec;
-    unsigned int m_dwChunkSize;
-    unsigned int m_dwFrameSize;
-    unsigned int m_dwBufferLen;
-    uint64_t m_sinkFrames;
-    std::atomic<uint16_t> m_framesInBuffers;
+    unsigned int m_uiBufferLen{0}; // xaudio endpoint buffer size, in frames
+    unsigned int m_AvgBytesPerSec{0};
+    unsigned int m_dwChunkSize{0};
+    unsigned int m_dwFrameSize{0};
+    unsigned int m_dwBufferLen{0};
+    uint64_t m_sinkFrames{0};
+    std::atomic<uint16_t> m_framesInBuffers{0};
 
-    double m_avgTimeWaiting;       /* time between next buffer of data from SoftAE and driver call for data */
+    // time between next buffer of data from SoftAE and driver call for data
+    double m_avgTimeWaiting{50.0};
 
-    bool m_running;
-    bool m_initialized;
-    bool m_isSuspended;            /* sink is in a suspended state - release audio device */
-    bool m_isDirty;                /* sink output failed - needs re-init or new device */
+    bool m_running{false};
+    bool m_initialized{false};
+    bool m_isSuspended{false}; // sink is in a suspended state - release audio device
+    bool m_isDirty{false}; // sink output failed - needs re-init or new device
 };

--- a/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin.h
+++ b/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin.h
@@ -175,6 +175,7 @@ static const sampleFormat testFormats[] = { {KSDATAFORMAT_SUBTYPE_IEEE_FLOAT, 32
 
 struct RendererDetail
 {
+  std::string strDevicePath;
   std::string strDeviceId;
   std::string strDescription;
   std::string strWinDevType;

--- a/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin10.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin10.cpp
@@ -101,6 +101,9 @@ std::vector<RendererDetail> CAESinkFactoryWin::GetRendererDetails()
       details.strDescription = KODI::PLATFORM::WINDOWS::FromW(devInfo.Name().c_str());
       details.strDeviceId = KODI::PLATFORM::WINDOWS::FromW(devInfo.Id().c_str());
 
+      // on Windows UWP device Id is same as Path
+      details.strDevicePath = details.strDeviceId;
+
       details.bDefault = (devInfo.Id() == defaultId);
 
       list.push_back(details);

--- a/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin32.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/windows/AESinkFactoryWin32.cpp
@@ -147,6 +147,7 @@ std::vector<RendererDetail> CAESinkFactoryWin::GetRendererDetails()
       if (wstrDDID.compare(pwszID) == 0)
         details.bDefault = true;
 
+      details.strDevicePath = KODI::PLATFORM::WINDOWS::FromW(pwszID);
       CoTaskMemFree(pwszID);
     }
 

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -16,6 +16,7 @@
 #include "cores/AudioEngine/AESinkFactory.h"
 #include "cores/AudioEngine/Sinks/AESinkDirectSound.h"
 #include "cores/AudioEngine/Sinks/AESinkWASAPI.h"
+#include "cores/AudioEngine/Sinks/AESinkXaudio.h"
 #include "filesystem/File.h"
 #include "filesystem/SpecialProtocol.h"
 #include "messaging/ApplicationMessenger.h"
@@ -75,6 +76,7 @@ CWinSystemWin32::CWinSystemWin32()
   AE::CAESinkFactory::ClearSinks();
   CAESinkDirectSound::Register();
   CAESinkWASAPI::Register();
+  CAESinkXAudio::Register();
   CScreenshotSurfaceWindows::Register();
 
   if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bScanIRServer)


### PR DESCRIPTION
## Description
[Windows] enable XAudio2 sink in Windows desktop + code improvements

Now that Windows minimum version is Windows 8.1 is possible enable this sink also for Windows desktop as it's supported on Windows 8, 10 and 11.

## Motivation and context
See: https://github.com/xbmc/xbmc/pull/25046#issuecomment-2075497248

Initially it was just a quick test to see what "would happen" when enabled XAudio on Windows desktop. It has turned out to work quite well but a multitude of things to improve have also been detected and hidden bugs have appeared in the enumeration of devices that were hidden since Xbox only uses one device.

It is not yet intended to be an alternative to DirectSound and does not replace it, it only adds XAudio as an additional option. I think that with these changes it is in a usable state although more issues will probably appear when tested on a large scale. The code improvements and general improvements are also valid for Xbox as the code is common.

Many of the changes are just code improvements with no changes in functionality. The only notable change is in the device enumeration in commit https://github.com/xbmc/xbmc/pull/25068/commits/4c4016017a9204ae81ed420a05f1c2465fc4ba36. Also fixed issues on channels layout enumeration.

XAudio wants device Id in the from: `{0.0.0.00000000}.{4f5f9f01-868c-4a8b-b96c-d1e12e05cc92}` while the form `{4F5F9F01-868C-4A8B-B96C-D1E12E05CC92}` was being used. This causes code always fallback to default device here:

https://github.com/xbmc/xbmc/blob/4876e9da44b37fd14bd52e24772a7516dbf0c7f7/xbmc/cores/AudioEngine/Sinks/AESinkXAudio.cpp#L645-L671

That was a known issue but not very important on Xbox since there is only one device anyway. For Windows Desktop this would not be acceptable because the user expects to open the device selected in settings and not always the default one i.e: `HDMI - DENON-AVR (NVIDIA High Definition Audio)`.


## How has this been tested?
Runtime Windows 11 x64 and Xbox Series S

All devices are enumerated correctly, channels layouts, sample rates, formats, etc. 
Sound plays...

```
2024-04-28 11:10:45.632 T:4928     info <general>: Found 3 Lists of Devices
2024-04-28 11:10:45.632 T:4928     info <general>: Enumerated DIRECTSOUND devices:
2024-04-28 11:10:45.632 T:4928     info <general>:     Device 1
2024-04-28 11:10:45.632 T:4928     info <general>:         m_deviceName      : {4F5F9F01-868C-4A8B-B96C-D1E12E05CC92}
2024-04-28 11:10:45.632 T:4928     info <general>:         m_displayName     : SPDIF - SPDIF Interface (Realtek USB2.0 Audio)
2024-04-28 11:10:45.632 T:4928     info <general>:         m_displayNameExtra: DIRECTSOUND: SPDIF Interface (Realtek USB2.0 Audio)
2024-04-28 11:10:45.632 T:4928     info <general>:         m_deviceType      : AE_DEVTYPE_IEC958
2024-04-28 11:10:45.632 T:4928     info <general>:         m_channels        : FL, FR
2024-04-28 11:10:45.632 T:4928     info <general>:         m_sampleRates     : 48000
2024-04-28 11:10:45.632 T:4928     info <general>:         m_dataFormats     : AE_FMT_FLOAT,AE_FMT_RAW
2024-04-28 11:10:45.633 T:4928     info <general>:         m_streamTypes     : STREAM_TYPE_AC3,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_512
2024-04-28 11:10:45.633 T:4928     info <general>:     Device 2
2024-04-28 11:10:45.633 T:4928     info <general>:         m_deviceName      : {6A8744BE-9C7F-4E4E-AB1D-BC40FEFEE1E5}
2024-04-28 11:10:45.633 T:4928     info <general>:         m_displayName     : Speakers - Altavoces (Realtek USB2.0 Audio)
2024-04-28 11:10:45.633 T:4928     info <general>:         m_displayNameExtra: DIRECTSOUND: Altavoces (Realtek USB2.0 Audio)
2024-04-28 11:10:45.633 T:4928     info <general>:         m_deviceType      : AE_DEVTYPE_PCM
2024-04-28 11:10:45.633 T:4928     info <general>:         m_channels        : FL, FR
2024-04-28 11:10:45.633 T:4928     info <general>:         m_sampleRates     : 48000
2024-04-28 11:10:45.633 T:4928     info <general>:         m_dataFormats     : AE_FMT_FLOAT
2024-04-28 11:10:45.633 T:4928     info <general>:         m_streamTypes     : STREAM_TYPE_AC3,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_512
2024-04-28 11:10:45.633 T:4928     info <general>:     Device 3
2024-04-28 11:10:45.633 T:4928     info <general>:         m_deviceName      : default
2024-04-28 11:10:45.633 T:4928     info <general>:         m_displayName     : default
2024-04-28 11:10:45.633 T:4928     info <general>:         m_displayNameExtra: 
2024-04-28 11:10:45.633 T:4928     info <general>:         m_deviceType      : AE_DEVTYPE_PCM
2024-04-28 11:10:45.633 T:4928     info <general>:         m_channels        : FL, FR
2024-04-28 11:10:45.633 T:4928     info <general>:         m_sampleRates     : 48000
2024-04-28 11:10:45.634 T:4928     info <general>:         m_dataFormats     : AE_FMT_FLOAT
2024-04-28 11:10:45.634 T:4928     info <general>:         m_streamTypes     : STREAM_TYPE_AC3,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_512
2024-04-28 11:10:45.634 T:4928     info <general>:     Device 4
2024-04-28 11:10:45.634 T:4928     info <general>:         m_deviceName      : {B2BF28FD-954F-4BE6-931C-F58821B5F236}
2024-04-28 11:10:45.634 T:4928     info <general>:         m_displayName     : HDMI - DENON-AVR (NVIDIA High Definition Audio)
2024-04-28 11:10:45.634 T:4928     info <general>:         m_displayNameExtra: DIRECTSOUND: DENON-AVR (NVIDIA High Definition Audio)
2024-04-28 11:10:45.634 T:4928     info <general>:         m_deviceType      : AE_DEVTYPE_HDMI
2024-04-28 11:10:45.634 T:4928     info <general>:         m_channels        : FL, FR
2024-04-28 11:10:45.634 T:4928     info <general>:         m_sampleRates     : 48000
2024-04-28 11:10:45.634 T:4928     info <general>:         m_dataFormats     : AE_FMT_FLOAT,AE_FMT_RAW
2024-04-28 11:10:45.634 T:4928     info <general>:         m_streamTypes     : STREAM_TYPE_AC3,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_512,STREAM_TYPE_AC3,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_512
2024-04-28 11:10:45.634 T:4928     info <general>:     Device 5
2024-04-28 11:10:45.634 T:4928     info <general>:         m_deviceName      : {DC8229C7-9334-4344-8AC9-37D81DF4D15C}
2024-04-28 11:10:45.634 T:4928     info <general>:         m_displayName     : HDMI - PA249 (NVIDIA High Definition Audio)
2024-04-28 11:10:45.634 T:4928     info <general>:         m_displayNameExtra: DIRECTSOUND: PA249 (NVIDIA High Definition Audio)
2024-04-28 11:10:45.634 T:4928     info <general>:         m_deviceType      : AE_DEVTYPE_HDMI
2024-04-28 11:10:45.634 T:4928     info <general>:         m_channels        : FL, FR
2024-04-28 11:10:45.634 T:4928     info <general>:         m_sampleRates     : 48000
2024-04-28 11:10:45.635 T:4928     info <general>:         m_dataFormats     : AE_FMT_FLOAT,AE_FMT_RAW
2024-04-28 11:10:45.635 T:4928     info <general>:         m_streamTypes     : STREAM_TYPE_AC3,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_512,STREAM_TYPE_AC3,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_512,STREAM_TYPE_AC3,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_512
2024-04-28 11:10:45.635 T:4928     info <general>: Enumerated WASAPI devices:
2024-04-28 11:10:45.635 T:4928     info <general>:     Device 1
2024-04-28 11:10:45.635 T:4928     info <general>:         m_deviceName      : {4F5F9F01-868C-4A8B-B96C-D1E12E05CC92}
2024-04-28 11:10:45.635 T:4928     info <general>:         m_displayName     : SPDIF - SPDIF Interface (Realtek USB2.0 Audio)
2024-04-28 11:10:45.635 T:4928     info <general>:         m_displayNameExtra: WASAPI: SPDIF Interface (Realtek USB2.0 Audio)
2024-04-28 11:10:45.635 T:4928     info <general>:         m_deviceType      : AE_DEVTYPE_IEC958
2024-04-28 11:10:45.635 T:4928     info <general>:         m_channels        : FL, FR
2024-04-28 11:10:45.635 T:4928     info <general>:         m_sampleRates     : 192000,96000,88200,48000,44100
2024-04-28 11:10:45.635 T:4928     info <general>:         m_dataFormats     : AE_FMT_S24NE3,AE_FMT_S24LE3,AE_FMT_S24BE3,AE_FMT_S16NE,AE_FMT_S16LE,AE_FMT_S16BE,AE_FMT_RAW
2024-04-28 11:10:45.635 T:4928     info <general>:         m_streamTypes     : STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_512,STREAM_TYPE_AC3
2024-04-28 11:10:45.635 T:4928     info <general>:     Device 2
2024-04-28 11:10:45.635 T:4928     info <general>:         m_deviceName      : {6A8744BE-9C7F-4E4E-AB1D-BC40FEFEE1E5}
2024-04-28 11:10:45.635 T:4928     info <general>:         m_displayName     : Speakers - Altavoces (Realtek USB2.0 Audio)
2024-04-28 11:10:45.635 T:4928     info <general>:         m_displayNameExtra: WASAPI: Altavoces (Realtek USB2.0 Audio)
2024-04-28 11:10:45.635 T:4928     info <general>:         m_deviceType      : AE_DEVTYPE_PCM
2024-04-28 11:10:45.636 T:4928     info <general>:         m_channels        : FL, FR
2024-04-28 11:10:45.636 T:4928     info <general>:         m_sampleRates     : 192000,176400,96000,88200,48000,44100
2024-04-28 11:10:45.636 T:4928     info <general>:         m_dataFormats     : AE_FMT_S24NE3,AE_FMT_S24LE3,AE_FMT_S24BE3,AE_FMT_S32NE,AE_FMT_S32LE,AE_FMT_S32BE,AE_FMT_S16NE,AE_FMT_S16LE,AE_FMT_S16BE,AE_FMT_RAW
2024-04-28 11:10:45.636 T:4928     info <general>:         m_streamTypes     : STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_512,STREAM_TYPE_AC3
2024-04-28 11:10:45.636 T:4928     info <general>:     Device 3
2024-04-28 11:10:45.636 T:4928     info <general>:         m_deviceName      : default
2024-04-28 11:10:45.636 T:4928     info <general>:         m_displayName     : default
2024-04-28 11:10:45.636 T:4928     info <general>:         m_displayNameExtra: 
2024-04-28 11:10:45.636 T:4928     info <general>:         m_deviceType      : AE_DEVTYPE_PCM
2024-04-28 11:10:45.636 T:4928     info <general>:         m_channels        : FL, FR
2024-04-28 11:10:45.636 T:4928     info <general>:         m_sampleRates     : 192000,176400,96000,88200,48000,44100
2024-04-28 11:10:45.636 T:4928     info <general>:         m_dataFormats     : AE_FMT_S24NE3,AE_FMT_S24LE3,AE_FMT_S24BE3,AE_FMT_S32NE,AE_FMT_S32LE,AE_FMT_S32BE,AE_FMT_S16NE,AE_FMT_S16LE,AE_FMT_S16BE,AE_FMT_RAW
2024-04-28 11:10:45.636 T:4928     info <general>:         m_streamTypes     : STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_512,STREAM_TYPE_AC3
2024-04-28 11:10:45.636 T:4928     info <general>:     Device 4
2024-04-28 11:10:45.636 T:4928     info <general>:         m_deviceName      : {B2BF28FD-954F-4BE6-931C-F58821B5F236}
2024-04-28 11:10:45.636 T:4928     info <general>:         m_displayName     : HDMI - DENON-AVR (NVIDIA High Definition Audio)
2024-04-28 11:10:45.636 T:4928     info <general>:         m_displayNameExtra: WASAPI: DENON-AVR (NVIDIA High Definition Audio)
2024-04-28 11:10:45.636 T:4928     info <general>:         m_deviceType      : AE_DEVTYPE_HDMI
2024-04-28 11:10:45.637 T:4928     info <general>:         m_channels        : FL, FR
2024-04-28 11:10:45.637 T:4928     info <general>:         m_sampleRates     : 192000,176400,96000,88200,48000,44100,32000
2024-04-28 11:10:45.637 T:4928     info <general>:         m_dataFormats     : AE_FMT_S24NE4MSB,AE_FMT_S16NE,AE_FMT_S16LE,AE_FMT_S16BE,AE_FMT_RAW
2024-04-28 11:10:45.637 T:4928     info <general>:         m_streamTypes     : STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_512,STREAM_TYPE_AC3,STREAM_TYPE_DTSHD,STREAM_TYPE_DTSHD_MA,STREAM_TYPE_TRUEHD,STREAM_TYPE_EAC3,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_512,STREAM_TYPE_AC3
2024-04-28 11:10:45.637 T:4928     info <general>:     Device 5
2024-04-28 11:10:45.637 T:4928     info <general>:         m_deviceName      : {DC8229C7-9334-4344-8AC9-37D81DF4D15C}
2024-04-28 11:10:45.637 T:4928     info <general>:         m_displayName     : HDMI - PA249 (NVIDIA High Definition Audio)
2024-04-28 11:10:45.637 T:4928     info <general>:         m_displayNameExtra: WASAPI: PA249 (NVIDIA High Definition Audio)
2024-04-28 11:10:45.637 T:4928     info <general>:         m_deviceType      : AE_DEVTYPE_HDMI
2024-04-28 11:10:45.637 T:4928     info <general>:         m_channels        : FL, FR
2024-04-28 11:10:45.637 T:4928     info <general>:         m_sampleRates     : 192000,48000
2024-04-28 11:10:45.637 T:4928     info <general>:         m_dataFormats     : AE_FMT_S24NE4MSB,AE_FMT_S16NE,AE_FMT_S16LE,AE_FMT_S16BE,AE_FMT_RAW
2024-04-28 11:10:45.637 T:4928     info <general>:         m_streamTypes     : STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_512,STREAM_TYPE_AC3,STREAM_TYPE_DTSHD,STREAM_TYPE_DTSHD_MA,STREAM_TYPE_TRUEHD,STREAM_TYPE_EAC3,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_512,STREAM_TYPE_AC3,STREAM_TYPE_DTSHD,STREAM_TYPE_DTSHD_MA,STREAM_TYPE_TRUEHD,STREAM_TYPE_EAC3,STREAM_TYPE_DTSHD_CORE,STREAM_TYPE_DTS_2048,STREAM_TYPE_DTS_1024,STREAM_TYPE_DTS_512,STREAM_TYPE_AC3
2024-04-28 11:10:45.637 T:4928     info <general>: Enumerated XAUDIO devices:
2024-04-28 11:10:45.637 T:4928     info <general>:     Device 1
2024-04-28 11:10:45.637 T:4928     info <general>:         m_deviceName      : {0.0.0.00000000}.{4f5f9f01-868c-4a8b-b96c-d1e12e05cc92}
2024-04-28 11:10:45.637 T:4928     info <general>:         m_displayName     : SPDIF - SPDIF Interface (Realtek USB2.0 Audio)
2024-04-28 11:10:45.637 T:4928     info <general>:         m_displayNameExtra: XAudio: SPDIF Interface (Realtek USB2.0 Audio)
2024-04-28 11:10:45.637 T:4928     info <general>:         m_deviceType      : AE_DEVTYPE_IEC958
2024-04-28 11:10:45.638 T:4928     info <general>:         m_channels        : FL, FR
2024-04-28 11:10:45.638 T:4928     info <general>:         m_sampleRates     : 192000,176400,96000,88200,48000,44100,32000,22050,11025
2024-04-28 11:10:45.638 T:4928     info <general>:         m_dataFormats     : AE_FMT_FLOAT,AE_FMT_S24NE3,AE_FMT_S24LE3,AE_FMT_S24BE3,AE_FMT_S24NE4MSB,AE_FMT_S32NE,AE_FMT_S32LE,AE_FMT_S32BE,AE_FMT_S16NE,AE_FMT_S16LE,AE_FMT_S16BE,AE_FMT_U8
2024-04-28 11:10:45.638 T:4928     info <general>:         m_streamTypes     : No passthrough capabilities
2024-04-28 11:10:45.638 T:4928     info <general>:     Device 2
2024-04-28 11:10:45.638 T:4928     info <general>:         m_deviceName      : {0.0.0.00000000}.{6a8744be-9c7f-4e4e-ab1d-bc40fefee1e5}
2024-04-28 11:10:45.638 T:4928     info <general>:         m_displayName     : Speakers - Altavoces (Realtek USB2.0 Audio)
2024-04-28 11:10:45.638 T:4928     info <general>:         m_displayNameExtra: XAudio: Altavoces (Realtek USB2.0 Audio)
2024-04-28 11:10:45.638 T:4928     info <general>:         m_deviceType      : AE_DEVTYPE_PCM
2024-04-28 11:10:45.638 T:4928     info <general>:         m_channels        : FL, FR
2024-04-28 11:10:45.638 T:4928     info <general>:         m_sampleRates     : 192000,176400,96000,88200,48000,44100,32000,22050,11025
2024-04-28 11:10:45.638 T:4928     info <general>:         m_dataFormats     : AE_FMT_FLOAT,AE_FMT_S24NE3,AE_FMT_S24LE3,AE_FMT_S24BE3,AE_FMT_S24NE4MSB,AE_FMT_S32NE,AE_FMT_S32LE,AE_FMT_S32BE,AE_FMT_S16NE,AE_FMT_S16LE,AE_FMT_S16BE,AE_FMT_U8
2024-04-28 11:10:45.638 T:4928     info <general>:         m_streamTypes     : No passthrough capabilities
2024-04-28 11:10:45.638 T:4928     info <general>:     Device 3
2024-04-28 11:10:45.638 T:4928     info <general>:         m_deviceName      : default
2024-04-28 11:10:45.638 T:4928     info <general>:         m_displayName     : default
2024-04-28 11:10:45.638 T:4928     info <general>:         m_displayNameExtra: 
2024-04-28 11:10:45.638 T:4928     info <general>:         m_deviceType      : AE_DEVTYPE_PCM
2024-04-28 11:10:45.639 T:4928     info <general>:         m_channels        : FL, FR
2024-04-28 11:10:45.639 T:4928     info <general>:         m_sampleRates     : 192000,176400,96000,88200,48000,44100,32000,22050,11025
2024-04-28 11:10:45.639 T:4928     info <general>:         m_dataFormats     : AE_FMT_FLOAT,AE_FMT_S24NE3,AE_FMT_S24LE3,AE_FMT_S24BE3,AE_FMT_S24NE4MSB,AE_FMT_S32NE,AE_FMT_S32LE,AE_FMT_S32BE,AE_FMT_S16NE,AE_FMT_S16LE,AE_FMT_S16BE,AE_FMT_U8
2024-04-28 11:10:45.639 T:4928     info <general>:         m_streamTypes     : No passthrough capabilities
2024-04-28 11:10:45.639 T:4928     info <general>:     Device 4
2024-04-28 11:10:45.639 T:4928     info <general>:         m_deviceName      : {0.0.0.00000000}.{b2bf28fd-954f-4be6-931c-f58821b5f236}
2024-04-28 11:10:45.639 T:4928     info <general>:         m_displayName     : HDMI - DENON-AVR (NVIDIA High Definition Audio)
2024-04-28 11:10:45.639 T:4928     info <general>:         m_displayNameExtra: XAudio: DENON-AVR (NVIDIA High Definition Audio)
2024-04-28 11:10:45.639 T:4928     info <general>:         m_deviceType      : AE_DEVTYPE_HDMI
2024-04-28 11:10:45.639 T:4928     info <general>:         m_channels        : FL, FR
2024-04-28 11:10:45.639 T:4928     info <general>:         m_sampleRates     : 192000,176400,96000,88200,48000,44100,32000,22050,11025
2024-04-28 11:10:45.639 T:4928     info <general>:         m_dataFormats     : AE_FMT_FLOAT,AE_FMT_S24NE3,AE_FMT_S24LE3,AE_FMT_S24BE3,AE_FMT_S24NE4MSB,AE_FMT_S32NE,AE_FMT_S32LE,AE_FMT_S32BE,AE_FMT_S16NE,AE_FMT_S16LE,AE_FMT_S16BE,AE_FMT_U8
2024-04-28 11:10:45.639 T:4928     info <general>:         m_streamTypes     : No passthrough capabilities
2024-04-28 11:10:45.639 T:4928     info <general>:     Device 5
2024-04-28 11:10:45.639 T:4928     info <general>:         m_deviceName      : {0.0.0.00000000}.{dc8229c7-9334-4344-8ac9-37d81df4d15c}
2024-04-28 11:10:45.639 T:4928     info <general>:         m_displayName     : HDMI - PA249 (NVIDIA High Definition Audio)
2024-04-28 11:10:45.639 T:4928     info <general>:         m_displayNameExtra: XAudio: PA249 (NVIDIA High Definition Audio)
2024-04-28 11:10:45.639 T:4928     info <general>:         m_deviceType      : AE_DEVTYPE_HDMI
2024-04-28 11:10:45.639 T:4928     info <general>:         m_channels        : FL, FR
2024-04-28 11:10:45.640 T:4928     info <general>:         m_sampleRates     : 192000,176400,96000,88200,48000,44100,32000,22050,11025
2024-04-28 11:10:45.640 T:4928     info <general>:         m_dataFormats     : AE_FMT_FLOAT,AE_FMT_S24NE3,AE_FMT_S24LE3,AE_FMT_S24BE3,AE_FMT_S24NE4MSB,AE_FMT_S32NE,AE_FMT_S32LE,AE_FMT_S32BE,AE_FMT_S16NE,AE_FMT_S16LE,AE_FMT_S16BE,AE_FMT_U8
2024-04-28 11:10:45.640 T:4928     info <general>:         m_streamTypes     : No passthrough capabilities
2024-04-28 11:10:45.640 T:16920    info <general>: CActiveAESink::OpenSink - initialize sink
2024-04-28 11:10:45.972 T:16920    info <general>: CAESinkXAudio::InitializeInternal: Format is Supported - will attempt to Initialize
2024-04-28 11:10:45.972 T:16920    info <general>: CAESinkXAudio::InitializeInternal: XAudio Sink Initialized using: AE_FMT_FLOAT, 44100, 2
```

## What is the effect on users?
Users have another type of sink to choose from besides DirectSound and WASAPI. 

Pros:
 - Very low latency.
 - No possibility of buffer underruns since it's not a circular buffer but a queue based.
 - Modern API.
 - Like DirectSound does not take devices for exclusive use. Other applications can play audio at the same time.

Cons:
 - No passthrough support.


## Screenshots (if appropriate):

![XAudio](https://github.com/xbmc/xbmc/assets/58434170/b65975d3-4827-4748-887f-1c673c43043c)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
