### PR TITLE
changed: consistently use KODI::VIDEO namespace

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1160,7 +1160,7 @@ bool CFileItem::IsBluray() const
   if (URIUtils::IsBluray(m_strPath))
     return true;
 
-  CFileItem item = CFileItem(VIDEO_UTILS::GetOpticalMediaPath(*this), false);
+  CFileItem item = CFileItem(VIDEO::UTILS::GetOpticalMediaPath(*this), false);
 
   return IsBDFile(item);
 }

--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -802,7 +802,7 @@ void CFileItemList::StackFolders()
         // check for dvd folders
         if (!bMatch)
         {
-          std::string dvdPath = VIDEO_UTILS::GetOpticalMediaPath(*item);
+          std::string dvdPath = VIDEO::UTILS::GetOpticalMediaPath(*item);
 
           if (!dvdPath.empty())
           {

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -46,8 +46,8 @@
 #include <fstrcmp.h>
 
 using namespace XFILE;
+using namespace KODI;
 using namespace MUSIC_GRABBER;
-using namespace VIDEO;
 
 namespace ADDON
 {
@@ -1251,9 +1251,9 @@ std::vector<CMusicArtistInfo> CScraper::FindArtist(CCurlFile &fcurl, const std::
 }
 
 // fetch list of episodes from URL (from video database)
-EPISODELIST CScraper::GetEpisodeList(XFILE::CCurlFile &fcurl, const CScraperUrl &scurl)
+VIDEO::EPISODELIST CScraper::GetEpisodeList(XFILE::CCurlFile& fcurl, const CScraperUrl& scurl)
 {
-  EPISODELIST vcep;
+  VIDEO::EPISODELIST vcep;
   if (!scurl.HasUrls())
     return vcep;
 
@@ -1276,7 +1276,7 @@ EPISODELIST CScraper::GetEpisodeList(XFILE::CCurlFile &fcurl, const CScraperUrl 
 
     for (int i = 0; i < items.Size(); ++i)
     {
-      EPISODE ep;
+      VIDEO::EPISODE ep;
       const auto& tag = *items[i]->GetVideoInfoTag();
       ep.strTitle = tag.m_strTitle;
       ep.iSeason = tag.m_iSeason;
@@ -1312,7 +1312,7 @@ EPISODELIST CScraper::GetEpisodeList(XFILE::CCurlFile &fcurl, const CScraperUrl 
     for (TiXmlElement *pxeMovie = xhDoc.FirstChild("episodeguide").FirstChild("episode").Element();
          pxeMovie; pxeMovie = pxeMovie->NextSiblingElement())
     {
-      EPISODE ep;
+      VIDEO::EPISODE ep;
       TiXmlElement *pxeLink = pxeMovie->FirstChildElement("url");
       std::string strEpNum;
       if (pxeLink && XMLUtils::GetInt(pxeMovie, "season", ep.iSeason) &&

--- a/xbmc/addons/Scraper.h
+++ b/xbmc/addons/Scraper.h
@@ -129,7 +129,7 @@ public:
     const std::string &sAlbum, const std::string &sArtist = "");
   std::vector<MUSIC_GRABBER::CMusicArtistInfo> FindArtist(
     XFILE::CCurlFile &fcurl, const std::string &sArtist);
-  VIDEO::EPISODELIST GetEpisodeList(XFILE::CCurlFile &fcurl, const CScraperUrl &scurl);
+  KODI::VIDEO::EPISODELIST GetEpisodeList(XFILE::CCurlFile& fcurl, const CScraperUrl& scurl);
 
   bool GetVideoDetails(XFILE::CCurlFile& fcurl,
                        const std::unordered_map<std::string, std::string>& uniqueIDs,

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -192,7 +192,6 @@ using namespace XFILE;
 #ifdef HAS_OPTICAL_DRIVE
 using namespace MEDIA_DETECT;
 #endif
-using namespace VIDEO;
 using namespace MUSIC_INFO;
 using namespace EVENTSERVER;
 using namespace JSONRPC;
@@ -200,7 +199,6 @@ using namespace PVR;
 using namespace PERIPHERALS;
 using namespace KODI;
 using namespace KODI::MESSAGING;
-using namespace KODI::VIDEO;
 using namespace ActiveAE;
 
 using namespace XbmcThreads;
@@ -2307,11 +2305,11 @@ bool CApplication::PlayFile(CFileItem item,
     m_nextPlaylistItem = -1;
     stackHelper->Clear();
 
-    if (IsVideo(item))
+    if (VIDEO::IsVideo(item))
       CUtil::ClearSubtitles();
   }
 
-  if (IsDiscStub(item))
+  if (VIDEO::IsDiscStub(item))
   {
     return CServiceBroker::GetMediaManager().playStubFile(item);
   }
@@ -2352,7 +2350,7 @@ bool CApplication::PlayFile(CFileItem item,
   {
     // the following code block is only applicable when bRestart is false OR to ISO stacks
 
-    if (IsVideo(item))
+    if (VIDEO::IsVideo(item))
     {
       // open the d/b and retrieve the bookmarks for the current movie
       CVideoDatabase dbs;
@@ -2360,7 +2358,7 @@ bool CApplication::PlayFile(CFileItem item,
 
       std::string path = item.GetPath();
       std::string videoInfoTagPath(item.GetVideoInfoTag()->m_strFileNameAndPath);
-      if (videoInfoTagPath.find("removable://") == 0 || IsVideoDb(item))
+      if (videoInfoTagPath.find("removable://") == 0 || VIDEO::IsVideoDb(item))
         path = videoInfoTagPath;
 
       // Note that we need to load the tag from database also if the item already has a tag,
@@ -2430,7 +2428,8 @@ bool CApplication::PlayFile(CFileItem item,
 
   // a disc image might be Blu-Ray disc
   if (!(options.startpercent > 0.0 || options.starttime > 0.0) &&
-      (IsBDFile(item) || item.IsDiscImage() || (IsBlurayPlaylist(item) && forceSelection)))
+      (VIDEO::IsBDFile(item) || item.IsDiscImage() ||
+       (VIDEO::IsBlurayPlaylist(item) && forceSelection)))
   {
     // No video selection when using external or remote players (they handle it if supported)
     const bool isSimpleMenuAllowed = [&]()
@@ -2464,7 +2463,7 @@ bool CApplication::PlayFile(CFileItem item,
         CSettings::SETTING_MUSICFILES_SELECTACTION) &&
         !CMediaSettings::GetInstance().DoesMediaStartWindowed();
   }
-  else if (IsVideo(item) && playlistId == PLAYLIST::TYPE_VIDEO &&
+  else if (VIDEO::IsVideo(item) && playlistId == PLAYLIST::TYPE_VIDEO &&
            CServiceBroker::GetPlaylistPlayer().GetPlaylist(playlistId).size() > 1)
   { // playing from a playlist by the looks
     // don't switch to fullscreen if we are not playing the first item...
@@ -2789,9 +2788,9 @@ bool CApplication::OnMessage(CGUIMessage& message)
       bool bNothingToQueue = false;
 
       const auto appPlayer = GetComponent<CApplicationPlayer>();
-      if (!IsVideo(file) && appPlayer->IsPlayingVideo())
+      if (!VIDEO::IsVideo(file) && appPlayer->IsPlayingVideo())
         bNothingToQueue = true;
-      else if ((!MUSIC::IsAudio(file) || IsVideo(file)) && appPlayer->IsPlayingAudio())
+      else if ((!MUSIC::IsAudio(file) || VIDEO::IsVideo(file)) && appPlayer->IsPlayingAudio())
         bNothingToQueue = true;
 
       if (bNothingToQueue)
@@ -3059,7 +3058,7 @@ bool CApplication::ExecuteXBMCAction(std::string actionStr,
     }
     else
 #endif
-        if (MUSIC::IsAudio(item) || IsVideo(item) || item.IsGame())
+        if (MUSIC::IsAudio(item) || VIDEO::IsVideo(item) || item.IsGame())
     { // an audio or video file
       PlayFile(item, "");
     }
@@ -3180,7 +3179,7 @@ void CApplication::ProcessSlow()
 
   // Temporarily pause pausable jobs when viewing video/picture
   int currentWindow = CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow();
-  if (IsVideo(CurrentFileItem()) || CurrentFileItem().IsPicture() ||
+  if (VIDEO::IsVideo(CurrentFileItem()) || CurrentFileItem().IsPicture() ||
       currentWindow == WINDOW_FULLSCREEN_VIDEO || currentWindow == WINDOW_FULLSCREEN_GAME ||
       currentWindow == WINDOW_SLIDESHOW)
   {

--- a/xbmc/application/Application.h
+++ b/xbmc/application/Application.h
@@ -69,7 +69,7 @@ namespace ActiveAE
   class CActiveAE;
 }
 
-namespace VIDEO
+namespace KODI::VIDEO
 {
   class CVideoInfoScanner;
 }

--- a/xbmc/favourites/ContextMenus.cpp
+++ b/xbmc/favourites/ContextMenus.cpp
@@ -22,6 +22,7 @@
 #include "video/guilib/VideoGUIUtils.h"
 
 using namespace CONTEXTMENU;
+using namespace KODI;
 
 bool CFavouriteContextMenuAction::IsVisible(const CFileItem& item) const
 {
@@ -129,7 +130,7 @@ std::string CFavouritesTargetResume::GetLabel(const CFileItem& item) const
 {
   const std::shared_ptr<CFileItem> targetItem{ResolveFavouriteItem(item)};
   if (targetItem)
-    return VIDEO_UTILS::GetResumeString(*targetItem);
+    return VIDEO::UTILS::GetResumeString(*targetItem);
 
   return {};
 }
@@ -140,7 +141,7 @@ bool CFavouritesTargetResume::IsVisible(const CFileItem& item) const
   {
     const std::shared_ptr<CFileItem> targetItem{ResolveFavouriteItem(item)};
     if (targetItem)
-      return VIDEO_UTILS::GetItemResumeInformation(*targetItem).isResumable;
+      return VIDEO::UTILS::GetItemResumeInformation(*targetItem).isResumable;
   }
   return false;
 }
@@ -157,7 +158,7 @@ bool CFavouritesTargetResume::Execute(const std::shared_ptr<CFileItem>& item) co
 std::string CFavouritesTargetPlay::GetLabel(const CFileItem& item) const
 {
   const std::shared_ptr<CFileItem> targetItem{ResolveFavouriteItem(item)};
-  if (targetItem && VIDEO_UTILS::GetItemResumeInformation(*targetItem).isResumable)
+  if (targetItem && VIDEO::UTILS::GetItemResumeInformation(*targetItem).isResumable)
     return g_localizeStrings.Get(12021); // Play from beginning
 
   return g_localizeStrings.Get(208); // Play

--- a/xbmc/favourites/GUIWindowFavourites.cpp
+++ b/xbmc/favourites/GUIWindowFavourites.cpp
@@ -27,6 +27,8 @@
 #include "video/guilib/VideoPlayActionProcessor.h"
 #include "video/guilib/VideoSelectActionProcessor.h"
 
+using namespace KODI;
+
 CGUIWindowFavourites::CGUIWindowFavourites()
   : CGUIMediaWindow(WINDOW_FAVOURITES, "MyFavourites.xml")
 {
@@ -167,7 +169,7 @@ bool CGUIWindowFavourites::OnAction(const CAction& action)
     const auto item{std::make_shared<CFileItem>(*target)};
 
     // video play action setting is for files and folders...
-    if (item->HasVideoInfoTag() || (item->m_bIsFolder && VIDEO_UTILS::IsItemPlayable(*item)))
+    if (item->HasVideoInfoTag() || (item->m_bIsFolder && VIDEO::UTILS::IsItemPlayable(*item)))
     {
       CVideoPlayActionProcessor proc{item};
       if (proc.ProcessDefaultAction())

--- a/xbmc/guilib/listproviders/DirectoryProvider.cpp
+++ b/xbmc/guilib/listproviders/DirectoryProvider.cpp
@@ -48,9 +48,8 @@
 #include <utility>
 
 using namespace XFILE;
+using namespace KODI;
 using namespace KODI::MESSAGING;
-using namespace KODI::MUSIC;
-using namespace KODI::VIDEO;
 using namespace PVR;
 
 class CDirectoryJob : public CJob
@@ -137,12 +136,12 @@ public:
 
   std::shared_ptr<CThumbLoader> getThumbLoader(const CGUIStaticItemPtr& item)
   {
-    if (IsVideo(*item))
+    if (VIDEO::IsVideo(*item))
     {
       initThumbLoader<CVideoThumbLoader>(InfoTagType::VIDEO);
       return m_thumbloaders[InfoTagType::VIDEO];
     }
-    if (IsAudio(*item))
+    if (MUSIC::IsAudio(*item))
     {
       initThumbLoader<CMusicThumbLoader>(InfoTagType::AUDIO);
       return m_thumbloaders[InfoTagType::AUDIO];
@@ -600,7 +599,7 @@ bool CDirectoryProvider::OnPlay(const std::shared_ptr<CGUIListItem>& item)
 
   // video play action setting is for files and folders...
   if (targetItem.HasVideoInfoTag() ||
-      (targetItem.m_bIsFolder && VIDEO_UTILS::IsItemPlayable(targetItem)))
+      (targetItem.m_bIsFolder && VIDEO::UTILS::IsItemPlayable(targetItem)))
   {
     CVideoPlayActionProcessor proc{std::make_shared<CFileItem>(targetItem)};
     if (proc.ProcessDefaultAction())

--- a/xbmc/imagefiles/SpecialImageLoaderFactory.cpp
+++ b/xbmc/imagefiles/SpecialImageLoaderFactory.cpp
@@ -17,6 +17,7 @@
 #include "video/VideoGeneratedImageFileLoader.h"
 
 using namespace IMAGE_FILES;
+using namespace KODI;
 
 CSpecialImageLoaderFactory::CSpecialImageLoaderFactory()
 {

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -51,8 +51,7 @@
 #include "Autorun.h"
 #endif
 
-using namespace KODI::MUSIC;
-using namespace KODI::VIDEO;
+using namespace KODI;
 
 /*! \brief Clear current playlist
  *  \param params (ignored)
@@ -431,8 +430,8 @@ namespace
 {
 void GetItemsForPlayList(const std::shared_ptr<CFileItem>& item, CFileItemList& queuedItems)
 {
-  if (VIDEO_UTILS::IsItemPlayable(*item))
-    VIDEO_UTILS::GetItemsForPlayList(item, queuedItems);
+  if (VIDEO::UTILS::IsItemPlayable(*item))
+    VIDEO::UTILS::GetItemsForPlayList(item, queuedItems);
   else if (MUSIC_UTILS::IsItemPlayable(*item))
     MUSIC_UTILS::GetItemsForPlayList(item, queuedItems);
 }
@@ -440,9 +439,9 @@ void GetItemsForPlayList(const std::shared_ptr<CFileItem>& item, CFileItemList& 
 PLAYLIST::Id GetPlayListId(const CFileItem& item)
 {
   PLAYLIST::Id playlistId{PLAYLIST::TYPE_NONE};
-  if (IsVideo(item))
+  if (VIDEO::IsVideo(item))
     playlistId = PLAYLIST::TYPE_VIDEO;
-  else if (IsAudio(item))
+  else if (MUSIC::IsAudio(item))
     playlistId = PLAYLIST::TYPE_MUSIC;
 
   return playlistId;
@@ -483,7 +482,7 @@ int PlayOrQueueMedia(const std::vector<std::string>& params, bool forcePlay)
     else if (StringUtils::EqualsNoCase(params[i], "resume"))
     {
       // force the item to resume (if applicable)
-      if (VIDEO_UTILS::GetItemResumeInformation(item).isResumable)
+      if (VIDEO::UTILS::GetItemResumeInformation(item).isResumable)
         item.SetStartOffset(STARTOFFSET_RESUME);
       else
         item.SetStartOffset(0);
@@ -544,7 +543,7 @@ int PlayOrQueueMedia(const std::vector<std::string>& params, bool forcePlay)
       bool containsVideo = false;
       for (const auto& i : items)
       {
-        const bool isVideo = IsVideo(*i);
+        const bool isVideo = VIDEO::IsVideo(*i);
         containsMusic |= !isVideo;
         containsVideo |= isVideo;
 
@@ -562,7 +561,7 @@ int PlayOrQueueMedia(const std::vector<std::string>& params, bool forcePlay)
         {
           for (int i = items.Size() - 1; i >= 0; i--) //remove music entries
           {
-            if (!IsVideo(*items[i]))
+            if (!VIDEO::IsVideo(*items[i]))
               items.Remove(i);
           }
         }
@@ -621,7 +620,7 @@ int PlayOrQueueMedia(const std::vector<std::string>& params, bool forcePlay)
 
   if (forcePlay)
   {
-    if ((IsAudio(item) || IsVideo(item)) && !item.IsSmartPlayList() && !item.IsPVR())
+    if ((MUSIC::IsAudio(item) || VIDEO::IsVideo(item)) && !item.IsSmartPlayList() && !item.IsPVR())
     {
       if (!item.HasProperty("playlist_type_hint"))
         item.SetProperty("playlist_type_hint", GetPlayListId(item));

--- a/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
@@ -49,6 +49,7 @@
 #include <string>
 #include <vector>
 
+using namespace KODI;
 using namespace PVR;
 using namespace KODI::MESSAGING;
 
@@ -83,7 +84,7 @@ bool CPVRGUIActionsPlayback::CheckResumeRecording(const CFileItem& item) const
 
 bool CPVRGUIActionsPlayback::ResumePlayRecording(const CFileItem& item, bool bFallbackToPlay) const
 {
-  if (VIDEO_UTILS::GetItemResumeInformation(item).isResumable)
+  if (VIDEO::UTILS::GetItemResumeInformation(item).isResumable)
   {
     const_cast<CFileItem*>(&item)->SetStartOffset(STARTOFFSET_RESUME);
   }
@@ -126,7 +127,7 @@ bool CPVRGUIActionsPlayback::PlayRecording(const CFileItem& item, bool bCheckRes
 
   if (!bCheckResume || CheckResumeRecording(item))
   {
-    if (!item.m_bIsFolder && VIDEO_UTILS::IsAutoPlayNextItem(item))
+    if (!item.m_bIsFolder && VIDEO::UTILS::IsAutoPlayNextItem(item))
     {
       // recursively add items located in the same folder as item to play list, starting with item
       std::string parentPath = item.GetProperty("ParentPath").asString();
@@ -144,7 +145,7 @@ bool CPVRGUIActionsPlayback::PlayRecording(const CFileItem& item, bool bCheckRes
         parentItem->SetStartOffset(STARTOFFSET_RESUME);
 
       auto queuedItems = std::make_unique<CFileItemList>();
-      VIDEO_UTILS::GetItemsForPlayList(parentItem, *queuedItems);
+      VIDEO::UTILS::GetItemsForPlayList(parentItem, *queuedItems);
 
       // figure out where to start playback
       int pos = 0;
@@ -180,7 +181,7 @@ bool CPVRGUIActionsPlayback::PlayRecordingFolder(const CFileItem& item, bool bCh
     // recursively add items to list
     const auto itemToQueue = std::make_shared<CFileItem>(item);
     auto queuedItems = std::make_unique<CFileItemList>();
-    VIDEO_UTILS::GetItemsForPlayList(itemToQueue, *queuedItems);
+    VIDEO::UTILS::GetItemsForPlayList(itemToQueue, *queuedItems);
 
     CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_PLAY, 0, -1,
                                                static_cast<void*>(queuedItems.release()));

--- a/xbmc/pvr/guilib/PVRGUIRecordingsPlayActionProcessor.h
+++ b/xbmc/pvr/guilib/PVRGUIRecordingsPlayActionProcessor.h
@@ -16,7 +16,8 @@
 
 namespace PVR
 {
-class CGUIPVRRecordingsPlayActionProcessor : public VIDEO::GUILIB::CVideoPlayActionProcessorBase
+class CGUIPVRRecordingsPlayActionProcessor
+  : public KODI::VIDEO::GUILIB::CVideoPlayActionProcessorBase
 {
 public:
   explicit CGUIPVRRecordingsPlayActionProcessor(const std::shared_ptr<CFileItem>& item)

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -38,8 +38,8 @@
 #include <mutex>
 #include <string>
 
+using namespace KODI;
 using namespace PVR;
-using namespace VIDEO::GUILIB;
 
 CGUIWindowPVRRecordingsBase::CGUIWindowPVRRecordingsBase(bool bRadio,
                                                          int id,
@@ -258,7 +258,7 @@ protected:
 
   bool OnQueueSelected() override
   {
-    VIDEO_UTILS::QueueItem(m_item, VIDEO_UTILS::QueuePosition::POSITION_END);
+    VIDEO::UTILS::QueueItem(m_item, VIDEO::UTILS::QueuePosition::POSITION_END);
     return true;
   }
 
@@ -279,7 +279,7 @@ private:
   const int m_itemIndex{-1};
 };
 
-class CVideoPlayActionProcessor : public CVideoPlayActionProcessorBase
+class CVideoPlayActionProcessor : public VIDEO::GUILIB::CVideoPlayActionProcessorBase
 {
 public:
   explicit CVideoPlayActionProcessor(const std::shared_ptr<CFileItem>& item)

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
@@ -43,7 +43,7 @@
 #define SETTING_ALL_EXTERNAL_AUDIO "allexternalaudio"
 
 using namespace ADDON;
-
+using namespace KODI;
 
 CGUIDialogContentSettings::CGUIDialogContentSettings()
   : CGUIDialogSettingsManualBase(WINDOW_DIALOG_CONTENT_SETTINGS, "DialogSettings.xml")

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.h
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.h
@@ -14,7 +14,7 @@
 #include <map>
 #include <utility>
 
-namespace VIDEO
+namespace KODI::VIDEO
 {
   struct SScanSettings;
 }
@@ -35,7 +35,7 @@ public:
   const ADDON::ScraperPtr& GetScraper() const { return m_scraper; }
   void SetScraper(ADDON::ScraperPtr scraper) { m_scraper = std::move(scraper); }
 
-  void SetScanSettings(const VIDEO::SScanSettings &scanSettings);
+  void SetScanSettings(const KODI::VIDEO::SScanSettings& scanSettings);
   bool GetScanRecursive() const { return m_scanRecursive; }
   bool GetUseDirectoryNames() const { return m_useDirectoryNames; }
   bool GetContainsSingleItem() const { return m_containsSingleItem; }
@@ -44,7 +44,9 @@ public:
   bool GetUseAllExternalAudio() const { return m_allExternalAudio; }
 
   static bool Show(ADDON::ScraperPtr& scraper, CONTENT_TYPE content = CONTENT_NONE);
-  static bool Show(ADDON::ScraperPtr& scraper, VIDEO::SScanSettings& settings, CONTENT_TYPE content = CONTENT_NONE);
+  static bool Show(ADDON::ScraperPtr& scraper,
+                   KODI::VIDEO::SScanSettings& settings,
+                   CONTENT_TYPE content = CONTENT_NONE);
 
 protected:
   // specializations of CGUIWindow

--- a/xbmc/utils/PlayerUtils.cpp
+++ b/xbmc/utils/PlayerUtils.cpp
@@ -14,6 +14,8 @@
 #include "utils/Variant.h"
 #include "video/guilib/VideoGUIUtils.h"
 
+using namespace KODI;
+
 bool CPlayerUtils::IsItemPlayable(const CFileItem& itemIn)
 {
   const CFileItem item(itemIn.GetItemToPlay());
@@ -31,7 +33,7 @@ bool CPlayerUtils::IsItemPlayable(const CFileItem& itemIn)
     return true;
 
   // Movies / TV Shows / Music Videos
-  if (VIDEO_UTILS::IsItemPlayable(item))
+  if (VIDEO::UTILS::IsItemPlayable(item))
     return true;
 
   //! @todo add more types on demand.

--- a/xbmc/video/Episode.h
+++ b/xbmc/video/Episode.h
@@ -18,7 +18,7 @@
 class CFileItem;
 
 // single episode information
-namespace VIDEO
+namespace KODI::VIDEO
 {
   struct EPISODE
   {

--- a/xbmc/video/VideoChapterImageFileLoader.cpp
+++ b/xbmc/video/VideoChapterImageFileLoader.cpp
@@ -16,16 +16,18 @@
 #include "settings/SettingsComponent.h"
 #include "utils/log.h"
 
+namespace KODI::VIDEO
+{
+
 bool VIDEO::CVideoChapterImageFileLoader::CanLoad(const std::string& specialType) const
 {
   return specialType == "videochapter";
 }
 
-std::unique_ptr<CTexture> VIDEO::CVideoChapterImageFileLoader::Load(
-    const std::string& specialType,
-    const std::string& goofyChapterPath,
-    unsigned int,
-    unsigned int) const
+std::unique_ptr<CTexture> CVideoChapterImageFileLoader::Load(const std::string& specialType,
+                                                             const std::string& goofyChapterPath,
+                                                             unsigned int,
+                                                             unsigned int) const
 {
   // "goofy" chapter path because these paths don't yet conform to 'image://' path standard
 
@@ -52,3 +54,5 @@ std::unique_ptr<CTexture> VIDEO::CVideoChapterImageFileLoader::Load(
   CFileItem item{cleanname, false};
   return CDVDFileInfo::ExtractThumbToTexture(item, chapterNum);
 }
+
+} // namespace KODI::VIDEO

--- a/xbmc/video/VideoChapterImageFileLoader.h
+++ b/xbmc/video/VideoChapterImageFileLoader.h
@@ -10,7 +10,7 @@
 
 #include "imagefiles/SpecialImageFileLoader.h"
 
-namespace VIDEO
+namespace KODI::VIDEO
 {
 /*!
  * @brief Generates a texture for a thumbnail of a video chapter.
@@ -28,4 +28,4 @@ public:
                                  unsigned int preferredHeight) const override;
 };
 
-} // namespace VIDEO
+} // namespace KODI::VIDEO

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -68,8 +68,8 @@
 
 using namespace dbiplus;
 using namespace XFILE;
-using namespace VIDEO;
 using namespace ADDON;
+using namespace KODI;
 using namespace KODI::MESSAGING;
 using namespace KODI::GUILIB;
 using namespace KODI::VIDEO;

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -56,7 +56,7 @@ namespace dbiplus
 
 typedef std::vector<CVideoInfoTag> VECMOVIES;
 
-namespace VIDEO
+namespace KODI::VIDEO
 {
   class IVideoInfoScannerObserver;
   struct SScanSettings;
@@ -693,9 +693,12 @@ public:
   CVideoInfoTag GetDetailsByTypeAndId(VideoDbContentType type, int id);
 
   // scraper settings
-  void SetScraperForPath(const std::string& filePath, const ADDON::ScraperPtr& info, const VIDEO::SScanSettings& settings);
+  void SetScraperForPath(const std::string& filePath,
+                         const ADDON::ScraperPtr& info,
+                         const KODI::VIDEO::SScanSettings& settings);
   ADDON::ScraperPtr GetScraperForPath(const std::string& strPath);
-  ADDON::ScraperPtr GetScraperForPath(const std::string& strPath, VIDEO::SScanSettings& settings);
+  ADDON::ScraperPtr GetScraperForPath(const std::string& strPath,
+                                      KODI::VIDEO::SScanSettings& settings);
 
   /*! \brief Retrieve the scraper and settings we should use for the specified path
    If the scraper is not set on this particular path, we'll recursively check parent folders.
@@ -705,7 +708,9 @@ public:
    \return A ScraperPtr containing the scraper information. Returns NULL if a trivial (Content == CONTENT_NONE)
            scraper or no scraper is found.
    */
-  ADDON::ScraperPtr GetScraperForPath(const std::string& strPath, VIDEO::SScanSettings& settings, bool& foundDirectly);
+  ADDON::ScraperPtr GetScraperForPath(const std::string& strPath,
+                                      KODI::VIDEO::SScanSettings& settings,
+                                      bool& foundDirectly);
 
   /*! \brief Retrieve the content type of videos in the given path
    If content is set on the folder, we return the given content type, except in the case of tvshows,
@@ -752,7 +757,9 @@ public:
   bool GetSubPaths(const std::string& basepath, std::vector< std::pair<int, std::string> >& subpaths);
 
   bool GetSourcePath(const std::string &path, std::string &sourcePath);
-  bool GetSourcePath(const std::string &path, std::string &sourcePath, VIDEO::SScanSettings& settings);
+  bool GetSourcePath(const std::string& path,
+                     std::string& sourcePath,
+                     KODI::VIDEO::SScanSettings& settings);
 
   // for music + musicvideo linkups - if no album and title given it will return the artist id, else the id of the matching video
   int GetMatchingMusicVideo(const std::string& strArtist, const std::string& strAlbum = "", const std::string& strTitle = "");

--- a/xbmc/video/VideoEmbeddedImageFileLoader.cpp
+++ b/xbmc/video/VideoEmbeddedImageFileLoader.cpp
@@ -16,7 +16,8 @@
 #include "video/tags/IVideoInfoTagLoader.h"
 #include "video/tags/VideoInfoTagLoaderFactory.h"
 
-using namespace VIDEO;
+namespace KODI::VIDEO
+{
 
 bool CVideoEmbeddedImageFileLoader::CanLoad(const std::string& specialType) const
 {
@@ -47,10 +48,11 @@ bool GetEmbeddedThumb(const std::string& path, const std::string& type, Embedded
 }
 } // namespace
 
-std::unique_ptr<CTexture> CVideoEmbeddedImageFileLoader::Load(const std::string& specialType,
-                                                              const std::string& filePath,
-                                                              unsigned int preferredWidth,
-                                                              unsigned int preferredHeight) const
+std::unique_ptr<CTexture> VIDEO::CVideoEmbeddedImageFileLoader::Load(
+    const std::string& specialType,
+    const std::string& filePath,
+    unsigned int preferredWidth,
+    unsigned int preferredHeight) const
 {
   EmbeddedArt art;
   if (GetEmbeddedThumb(filePath, specialType.substr(6), art))
@@ -58,3 +60,5 @@ std::unique_ptr<CTexture> CVideoEmbeddedImageFileLoader::Load(const std::string&
                                           preferredHeight);
   return {};
 }
+
+} // namespace KODI::VIDEO

--- a/xbmc/video/VideoEmbeddedImageFileLoader.h
+++ b/xbmc/video/VideoEmbeddedImageFileLoader.h
@@ -10,7 +10,7 @@
 
 #include "imagefiles/SpecialImageFileLoader.h"
 
-namespace VIDEO
+namespace KODI::VIDEO
 {
 /*!
  * @brief Generates a texture for an image embedded in a video file.
@@ -28,4 +28,4 @@ public:
                                  unsigned int preferredHeight) const override;
 };
 
-} // namespace VIDEO
+} // namespace KODI::VIDEO

--- a/xbmc/video/VideoGeneratedImageFileLoader.cpp
+++ b/xbmc/video/VideoGeneratedImageFileLoader.cpp
@@ -20,9 +20,10 @@
 #include "video/VideoFileItemClassify.h"
 #include "video/VideoInfoTag.h"
 
-using namespace KODI::VIDEO;
+namespace KODI::VIDEO
+{
 
-bool VIDEO::CVideoGeneratedImageFileLoader::CanLoad(const std::string& specialType) const
+bool CVideoGeneratedImageFileLoader::CanLoad(const std::string& specialType) const
 {
   return specialType == "video";
 }
@@ -67,3 +68,5 @@ std::unique_ptr<CTexture> VIDEO::CVideoGeneratedImageFileLoader::Load(
 
   return CDVDFileInfo::ExtractThumbToTexture(item);
 }
+
+} // namespace KODI::VIDEO

--- a/xbmc/video/VideoGeneratedImageFileLoader.h
+++ b/xbmc/video/VideoGeneratedImageFileLoader.h
@@ -10,7 +10,7 @@
 
 #include "imagefiles/SpecialImageFileLoader.h"
 
-namespace VIDEO
+namespace KODI::VIDEO
 {
 /*!
  * @brief Generates a texture for a thumbnail of a video file, from a frame approx 1/3 into the video.
@@ -25,4 +25,4 @@ public:
                                  unsigned int preferredHeight) const override;
 };
 
-} // namespace VIDEO
+} // namespace KODI::VIDEO

--- a/xbmc/video/VideoInfoDownloader.cpp
+++ b/xbmc/video/VideoInfoDownloader.cpp
@@ -14,7 +14,7 @@
 #include "utils/Variant.h"
 #include "utils/log.h"
 
-using namespace VIDEO;
+using namespace KODI;
 using namespace KODI::MESSAGING;
 using namespace std::chrono_literals;
 
@@ -220,8 +220,8 @@ bool CVideoInfoDownloader::GetEpisodeDetails(const CScraperUrl &url,
 }
 
 bool CVideoInfoDownloader::GetEpisodeList(const CScraperUrl& url,
-                                          EPISODELIST& movieDetails,
-                                          CGUIDialogProgress *pProgress /* = NULL */)
+                                          VIDEO::EPISODELIST& movieDetails,
+                                          CGUIDialogProgress* pProgress /* = NULL */)
 {
   //CLog::Log(LOGDEBUG,"CVideoInfoDownloader::GetDetails({})", url.m_strURL);
   m_url = url;

--- a/xbmc/video/VideoInfoDownloader.h
+++ b/xbmc/video/VideoInfoDownloader.h
@@ -59,7 +59,9 @@ public:
                   CVideoInfoTag& movieDetails,
                   CGUIDialogProgress* pProgress = NULL);
   bool GetEpisodeDetails(const CScraperUrl& url, CVideoInfoTag &movieDetails, CGUIDialogProgress *pProgress = NULL);
-  bool GetEpisodeList(const CScraperUrl& url, VIDEO::EPISODELIST& details, CGUIDialogProgress *pProgress = NULL);
+  bool GetEpisodeList(const CScraperUrl& url,
+                      KODI::VIDEO::EPISODELIST& details,
+                      CGUIDialogProgress* pProgress = NULL);
 
   static void ShowErrorDialog(const ADDON::CScraperError &sce);
 
@@ -77,7 +79,7 @@ protected:
   MOVIELIST           m_movieList;
   CVideoInfoTag       m_movieDetails;
   CScraperUrl         m_url;
-  VIDEO::EPISODELIST  m_episode;
+  KODI::VIDEO::EPISODELIST m_episode;
   LOOKUP_STATE m_state = DO_NOTHING;
   int m_found = 0;
   ADDON::ScraperPtr   m_info;

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -61,7 +61,7 @@ using namespace KODI::VIDEO;
 using KODI::MESSAGING::HELPERS::DialogResponse;
 using KODI::UTILITY::CDigest;
 
-namespace VIDEO
+namespace KODI::VIDEO
 {
 
   CVideoInfoScanner::CVideoInfoScanner()

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -21,7 +21,7 @@ class CRegExp;
 class CFileItem;
 class CFileItemList;
 
-namespace VIDEO
+namespace KODI::VIDEO
 {
   class IVideoInfoTagLoader;
 
@@ -264,5 +264,4 @@ namespace VIDEO
      */
     static std::string GetArtTypeFromSize(unsigned int width, unsigned int height);
   };
-}
-
+  } // namespace KODI::VIDEO

--- a/xbmc/video/VideoItemArtworkHandler.cpp
+++ b/xbmc/video/VideoItemArtworkHandler.cpp
@@ -30,9 +30,10 @@
 #include "video/VideoThumbLoader.h"
 #include "video/tags/VideoTagExtractionHelper.h"
 
-using namespace KODI::VIDEO;
-using namespace VIDEO;
 using namespace XFILE;
+
+namespace KODI::VIDEO
+{
 
 namespace
 {
@@ -555,3 +556,5 @@ std::unique_ptr<IVideoItemArtworkHandler> IVideoItemArtworkHandlerFactory::Creat
 
   return artHandler;
 }
+
+} // namespace KODI::VIDEO

--- a/xbmc/video/VideoItemArtworkHandler.h
+++ b/xbmc/video/VideoItemArtworkHandler.h
@@ -15,7 +15,7 @@
 class CFileItem;
 class CMediaSource;
 
-namespace VIDEO
+namespace KODI::VIDEO
 {
 class IVideoItemArtworkHandler
 {
@@ -50,4 +50,4 @@ public:
                                                           const std::string& artType);
 };
 
-} // namespace VIDEO
+} // namespace KODI::VIDEO

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -39,9 +39,8 @@
 #include <cstdlib>
 #include <utility>
 
-using namespace KODI::VIDEO;
+using namespace KODI;
 using namespace XFILE;
-using namespace VIDEO;
 
 CVideoThumbLoader::CVideoThumbLoader() : CThumbLoader()
 {
@@ -186,7 +185,7 @@ bool CVideoThumbLoader::LoadItemCached(CFileItem* pItem)
     if ((pItem->HasVideoInfoTag() &&
          pItem->GetVideoInfoTag()->m_iFileId >= 0) // file (or maybe folder) is in the database
         || (!pItem->m_bIsFolder &&
-            IsVideo(
+            VIDEO::IsVideo(
                 *pItem))) // Some other video file for which we haven't yet got any database details
     {
       if (m_videoDatabase->GetStreamDetails(*pItem))
@@ -292,7 +291,7 @@ bool CVideoThumbLoader::LoadItemLookup(CFileItem* pItem)
   }
 
   // We can only extract flags/thumbs for file-like items
-  if (!pItem->m_bIsFolder && IsVideo(*pItem))
+  if (!pItem->m_bIsFolder && VIDEO::IsVideo(*pItem))
   {
     const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
     if (!pItem->HasArt("thumb"))
@@ -414,7 +413,7 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
     m_videoDatabase->Open();
 
     // @todo unify asset path for other items path
-    if (IsVideoAssetFile(item))
+    if (VIDEO::IsVideoAssetFile(item))
     {
       if (m_videoDatabase->GetArtForAsset(
               tag.m_iFileId,
@@ -555,7 +554,7 @@ std::string CVideoThumbLoader::GetLocalArt(const CFileItem &item, const std::str
 std::string CVideoThumbLoader::GetEmbeddedThumbURL(const CFileItem &item)
 {
   std::string path(item.GetPath());
-  if (IsVideoDb(item) && item.HasVideoInfoTag())
+  if (VIDEO::IsVideoDb(item) && item.HasVideoInfoTag())
     path = item.GetVideoInfoTag()->m_strFileNameAndPath;
   if (URIUtils::IsStack(path))
     path = CStackDirectory::GetFirstStackedFile(path);
@@ -601,7 +600,7 @@ void CVideoThumbLoader::DetectAndAddMissingItemData(CFileItem &item)
   if (stereoMode.empty())
   {
     std::string path = item.GetPath();
-    if (IsVideoDb(item) && item.HasVideoInfoTag())
+    if (VIDEO::IsVideoDb(item) && item.HasVideoInfoTag())
       path = item.GetVideoInfoTag()->GetPath();
 
     // check for custom stereomode setting in video settings

--- a/xbmc/video/VideoUtils.cpp
+++ b/xbmc/video/VideoUtils.cpp
@@ -34,7 +34,7 @@ using namespace KODI::VIDEO;
 
 namespace
 {
-VIDEO_UTILS::ResumeInformation GetFolderItemResumeInformation(const CFileItem& item)
+KODI::VIDEO::UTILS::ResumeInformation GetFolderItemResumeInformation(const CFileItem& item)
 {
   if (!item.m_bIsFolder)
     return {};
@@ -84,7 +84,7 @@ VIDEO_UTILS::ResumeInformation GetFolderItemResumeInformation(const CFileItem& i
 
   if (folderItem.IsResumable())
   {
-    VIDEO_UTILS::ResumeInformation resumeInfo;
+    KODI::VIDEO::UTILS::ResumeInformation resumeInfo;
     resumeInfo.isResumable = true;
     return resumeInfo;
   }
@@ -92,7 +92,7 @@ VIDEO_UTILS::ResumeInformation GetFolderItemResumeInformation(const CFileItem& i
   return {};
 }
 
-VIDEO_UTILS::ResumeInformation GetNonFolderItemResumeInformation(const CFileItem& item)
+KODI::VIDEO::UTILS::ResumeInformation GetNonFolderItemResumeInformation(const CFileItem& item)
 {
   // do not resume nfo files
   if (item.IsNFO())
@@ -106,7 +106,7 @@ VIDEO_UTILS::ResumeInformation GetNonFolderItemResumeInformation(const CFileItem
   if (item.IsLiveTV() || item.IsDeleted())
     return {};
 
-  VIDEO_UTILS::ResumeInformation resumeInfo;
+  KODI::VIDEO::UTILS::ResumeInformation resumeInfo;
 
   if (item.GetCurrentResumeTimeAndPartNumber(resumeInfo.startOffset, resumeInfo.partNumber))
   {
@@ -182,7 +182,7 @@ VIDEO_UTILS::ResumeInformation GetNonFolderItemResumeInformation(const CFileItem
 
 } // unnamed namespace
 
-namespace VIDEO_UTILS
+namespace KODI::VIDEO::UTILS
 {
 std::string GetOpticalMediaPath(const CFileItem& item)
 {
@@ -281,4 +281,4 @@ ResumeInformation GetStackPartResumeInformation(const CFileItem& item, unsigned 
   return resumeInfo;
 }
 
-} // namespace VIDEO_UTILS
+} // namespace KODI::VIDEO::UTILS

--- a/xbmc/video/VideoUtils.h
+++ b/xbmc/video/VideoUtils.h
@@ -12,7 +12,7 @@
 
 class CFileItem;
 
-namespace VIDEO_UTILS
+namespace KODI::VIDEO::UTILS
 {
 /*!
  \brief Check whether an item is an optical media folder or its parent.
@@ -57,4 +57,4 @@ ResumeInformation GetItemResumeInformation(const CFileItem& item);
  */
 ResumeInformation GetStackPartResumeInformation(const CFileItem& item, unsigned int partNumber);
 
-} // namespace VIDEO_UTILS
+} // namespace KODI::VIDEO::UTILS

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -72,8 +72,8 @@
 
 using namespace XFILE::VIDEODATABASEDIRECTORY;
 using namespace XFILE;
+using namespace KODI;
 using namespace KODI::MESSAGING;
-using namespace KODI::VIDEO;
 
 #define CONTROL_IMAGE                3
 #define CONTROL_TEXTAREA             4
@@ -282,7 +282,7 @@ void CGUIDialogVideoInfo::OnInitWindow()
     CONTROL_DISABLE(CONTROL_BTN_REFRESH);
 
   // @todo add support to edit video asset art. Until then edit art through Versions Manager.
-  if (!IsVideoAssetFile(*m_movieItem))
+  if (!VIDEO::IsVideoAssetFile(*m_movieItem))
     CONTROL_ENABLE_ON_CONDITION(
         CONTROL_BTN_GET_THUMB,
         (profileManager->GetCurrentProfile().canWriteDatabases() ||
@@ -769,7 +769,7 @@ private:
     const ContentUtils::PlayMode mode{item->GetProperty("CheckAutoPlayNextItem").asBoolean()
                                           ? ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM
                                           : ContentUtils::PlayMode::PLAY_ONLY_THIS};
-    VIDEO_UTILS::PlayItem(item, "", mode);
+    VIDEO::UTILS::PlayItem(item, "", mode);
   }
 };
 } // unnamed namespace
@@ -1070,7 +1070,7 @@ std::string CGUIDialogVideoInfo::GetThumbnail() const
 
 int CGUIDialogVideoInfo::ManageVideoItem(const std::shared_ptr<CFileItem>& item)
 {
-  if (item == nullptr || !IsVideoDb(*item) || !item->HasVideoInfoTag() ||
+  if (item == nullptr || !VIDEO::IsVideoDb(*item) || !item->HasVideoInfoTag() ||
       item->GetVideoInfoTag()->m_iDbId < 0)
     return -1;
 
@@ -1082,18 +1082,18 @@ int CGUIDialogVideoInfo::ManageVideoItem(const std::shared_ptr<CFileItem>& item)
   int dbId = item->GetVideoInfoTag()->m_iDbId;
 
   CContextButtons buttons;
-  if ((type == MediaTypeMovie && !IsVideoAssetFile(*item)) || type == MediaTypeVideoCollection ||
-      type == MediaTypeTvShow || type == MediaTypeEpisode ||
+  if ((type == MediaTypeMovie && !VIDEO::IsVideoAssetFile(*item)) ||
+      type == MediaTypeVideoCollection || type == MediaTypeTvShow || type == MediaTypeEpisode ||
       (type == MediaTypeSeason &&
        item->GetVideoInfoTag()->m_iSeason > 0) || // seasons without "all seasons" and "specials"
       type == MediaTypeMusicVideo)
     buttons.Add(CONTEXT_BUTTON_EDIT, 16105);
 
-  if ((type == MediaTypeMovie && !IsVideoAssetFile(*item)) || type == MediaTypeTvShow ||
+  if ((type == MediaTypeMovie && !VIDEO::IsVideoAssetFile(*item)) || type == MediaTypeTvShow ||
       type == MediaTypeSeason)
     buttons.Add(CONTEXT_BUTTON_EDIT_SORTTITLE, 16107);
 
-  if (type == MediaTypeMovie && !IsVideoAssetFile(*item))
+  if (type == MediaTypeMovie && !VIDEO::IsVideoAssetFile(*item))
   {
     // only show link/unlink if there are tvshows available
     if (database.HasContent(VideoDbContentType::TVSHOWS))
@@ -1117,8 +1117,9 @@ int CGUIDialogVideoInfo::ManageVideoItem(const std::shared_ptr<CFileItem>& item)
       item->GetVideoInfoTag()->m_iBookmarkId > 0)
     buttons.Add(CONTEXT_BUTTON_UNLINK_BOOKMARK, 20405);
 
-  if (type == MediaTypeVideoCollection || (type == MediaTypeMovie && !IsVideoAssetFile(*item)) ||
-      type == MediaTypeTvShow || type == MediaTypeSeason || type == MediaTypeEpisode)
+  if (type == MediaTypeVideoCollection ||
+      (type == MediaTypeMovie && !VIDEO::IsVideoAssetFile(*item)) || type == MediaTypeTvShow ||
+      type == MediaTypeSeason || type == MediaTypeEpisode)
     buttons.Add(CONTEXT_BUTTON_SET_ART, 13511);
 
   // movie sets
@@ -1142,7 +1143,7 @@ int CGUIDialogVideoInfo::ManageVideoItem(const std::shared_ptr<CFileItem>& item)
     }
   }
 
-  if (type != MediaTypeSeason && !IsVideoAssetFile(*item))
+  if (type != MediaTypeSeason && !VIDEO::IsVideoAssetFile(*item))
   {
     // Remove from library
     buttons.Add(CONTEXT_BUTTON_DELETE, 646);

--- a/xbmc/video/dialogs/GUIDialogVideoManager.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -37,6 +37,8 @@
 #include <algorithm>
 #include <string>
 
+using namespace KODI;
+
 static constexpr unsigned int CONTROL_LABEL_TITLE = 2;
 
 static constexpr unsigned int CONTROL_BUTTON_PLAY = 21;
@@ -287,7 +289,7 @@ private:
     const ContentUtils::PlayMode mode{m_item->GetProperty("CheckAutoPlayNextItem").asBoolean()
                                           ? ContentUtils::PlayMode::CHECK_AUTO_PLAY_NEXT_ITEM
                                           : ContentUtils::PlayMode::PLAY_ONLY_THIS};
-    VIDEO_UTILS::PlayItem(m_item, "", mode);
+    VIDEO::UTILS::PlayItem(m_item, "", mode);
   }
 };
 } // unnamed namespace

--- a/xbmc/video/guilib/VideoAction.h
+++ b/xbmc/video/guilib/VideoAction.h
@@ -8,9 +8,7 @@
 
 #pragma once
 
-namespace VIDEO
-{
-namespace GUILIB
+namespace KODI::VIDEO::GUILIB
 {
 // Note: Do not change the numerical values of the elements. Some of them are used as values for
 //       the integer settings SETTING_MYVIDEOS_SELECTACTION and SETTING_MYVIDEOS_PLAYACTION.
@@ -25,5 +23,4 @@ enum Action
   ACTION_PLAYPART = 6,
   ACTION_QUEUE = 7,
 };
-} // namespace GUILIB
-} // namespace VIDEO
+} // namespace KODI::VIDEO::GUILIB

--- a/xbmc/video/guilib/VideoGUIUtils.cpp
+++ b/xbmc/video/guilib/VideoGUIUtils.cpp
@@ -42,8 +42,8 @@
 #include "video/VideoUtils.h"
 #include "view/GUIViewState.h"
 
-using namespace KODI;
-using namespace KODI::VIDEO;
+namespace KODI
+{
 
 namespace
 {
@@ -53,7 +53,7 @@ public:
   CAsyncGetItemsForPlaylist(const std::shared_ptr<CFileItem>& item, CFileItemList& queuedItems)
     : m_item(item),
       m_resume((item->GetStartOffset() == STARTOFFSET_RESUME) &&
-               VIDEO_UTILS::GetItemResumeInformation(*item).isResumable),
+               VIDEO::UTILS::GetItemResumeInformation(*item).isResumable),
       m_queuedItems(queuedItems)
   {
   }
@@ -140,7 +140,7 @@ void CAsyncGetItemsForPlaylist::GetItemsForPlaylist(const std::shared_ptr<CFileI
   if (item->m_bIsFolder)
   {
     // check if it's a folder with dvd or bluray files, then just add the relevant file
-    const std::string mediapath = VIDEO_UTILS::GetOpticalMediaPath(*item);
+    const std::string mediapath = VIDEO::UTILS::GetOpticalMediaPath(*item);
     if (!mediapath.empty())
     {
       m_queuedItems.Add(std::make_shared<CFileItem>(mediapath, false));
@@ -203,7 +203,7 @@ void CAsyncGetItemsForPlaylist::GetItemsForPlaylist(const std::shared_ptr<CFileI
       items.Sort(sortDesc);
     }
 
-    if (items.GetContent().empty() && !IsVideoDb(items) && !items.IsVirtualDirectoryRoot() &&
+    if (items.GetContent().empty() && !VIDEO::IsVideoDb(items) && !items.IsVirtualDirectoryRoot() &&
         !items.IsSourcesPath() && !items.IsLibraryFolder())
     {
       CVideoDatabase db;
@@ -305,7 +305,7 @@ void CAsyncGetItemsForPlaylist::GetItemsForPlaylist(const std::shared_ptr<CFileI
     // a playable python files
     m_queuedItems.Add(item);
   }
-  else if (IsVideoDb(*item))
+  else if (VIDEO::IsVideoDb(*item))
   {
     // this case is needed unless we allow IsVideo() to return true for videodb items,
     // but then we have issues with playlists of videodb items
@@ -313,7 +313,7 @@ void CAsyncGetItemsForPlaylist::GetItemsForPlaylist(const std::shared_ptr<CFileI
     itemCopy->SetStartOffset(item->GetStartOffset());
     m_queuedItems.Add(itemCopy);
   }
-  else if (!item->IsNFO() && IsVideo(*item))
+  else if (!item->IsNFO() && VIDEO::IsVideo(*item))
   {
     m_queuedItems.Add(item);
   }
@@ -337,7 +337,7 @@ void AddItemToPlayListAndPlay(const std::shared_ptr<CFileItem>& itemToQueue,
 {
   // recursively add items to list
   CFileItemList queuedItems;
-  VIDEO_UTILS::GetItemsForPlayList(itemToQueue, queuedItems);
+  VIDEO::UTILS::GetItemsForPlayList(itemToQueue, queuedItems);
 
   auto& playlistPlayer = CServiceBroker::GetPlaylistPlayer();
   playlistPlayer.ClearPlaylist(PLAYLIST::TYPE_VIDEO);
@@ -370,7 +370,9 @@ void AddItemToPlayListAndPlay(const std::shared_ptr<CFileItem>& itemToQueue,
 
 } // unnamed namespace
 
-namespace VIDEO_UTILS
+} // namespace KODI
+
+namespace KODI::VIDEO::UTILS
 {
 void PlayItem(
     const std::shared_ptr<CFileItem>& itemIn,
@@ -620,4 +622,4 @@ std::string GetResumeString(const CFileItem& item)
   return {};
 }
 
-} // namespace VIDEO_UTILS
+} // namespace KODI::VIDEO::UTILS

--- a/xbmc/video/guilib/VideoGUIUtils.h
+++ b/xbmc/video/guilib/VideoGUIUtils.h
@@ -15,7 +15,7 @@
 class CFileItem;
 class CFileItemList;
 
-namespace VIDEO_UTILS
+namespace KODI::VIDEO::UTILS
 {
 /*! \brief Start playback of the given item. If the item is a folder, build a playlist with
   all items contained in the folder and start playback of the playlist. If item is a single video
@@ -65,4 +65,4 @@ bool IsItemPlayable(const CFileItem& item);
  */
 std::string GetResumeString(const CFileItem& item);
 
-} // namespace VIDEO_UTILS
+} // namespace KODI::VIDEO::UTILS

--- a/xbmc/video/guilib/VideoPlayActionProcessor.cpp
+++ b/xbmc/video/guilib/VideoPlayActionProcessor.cpp
@@ -16,7 +16,8 @@
 #include "video/guilib/VideoGUIUtils.h"
 #include "video/guilib/VideoVersionHelper.h"
 
-using namespace VIDEO::GUILIB;
+namespace KODI::VIDEO::GUILIB
+{
 
 Action CVideoPlayActionProcessorBase::GetDefaultAction()
 {
@@ -77,7 +78,7 @@ Action CVideoPlayActionProcessorBase::ChoosePlayOrResume(const CFileItem& item)
 {
   Action action = ACTION_PLAY_FROM_BEGINNING;
 
-  const std::string resumeString = VIDEO_UTILS::GetResumeString(item);
+  const std::string resumeString = VIDEO::UTILS::GetResumeString(item);
   if (!resumeString.empty())
   {
     CContextButtons choices;
@@ -90,3 +91,5 @@ Action CVideoPlayActionProcessorBase::ChoosePlayOrResume(const CFileItem& item)
 
   return action;
 }
+
+} // namespace KODI::VIDEO::GUILIB

--- a/xbmc/video/guilib/VideoPlayActionProcessor.h
+++ b/xbmc/video/guilib/VideoPlayActionProcessor.h
@@ -14,9 +14,7 @@
 
 class CFileItem;
 
-namespace VIDEO
-{
-namespace GUILIB
+namespace KODI::VIDEO::GUILIB
 {
 class CVideoPlayActionProcessorBase
 {
@@ -44,5 +42,4 @@ protected:
 private:
   CVideoPlayActionProcessorBase() = delete;
 };
-} // namespace GUILIB
-} // namespace VIDEO
+} // namespace KODI::VIDEO::GUILIB

--- a/xbmc/video/guilib/VideoSelectActionProcessor.cpp
+++ b/xbmc/video/guilib/VideoSelectActionProcessor.cpp
@@ -24,7 +24,8 @@
 #include "video/VideoInfoTag.h"
 #include "video/guilib/VideoGUIUtils.h"
 
-using namespace VIDEO::GUILIB;
+namespace KODI::VIDEO::GUILIB
+{
 
 Action CVideoSelectActionProcessorBase::GetDefaultSelectAction()
 {
@@ -107,7 +108,7 @@ Action CVideoSelectActionProcessorBase::ChooseVideoItemSelectAction() const
 {
   CContextButtons choices;
 
-  const std::string resumeString = VIDEO_UTILS::GetResumeString(*m_item);
+  const std::string resumeString = UTILS::GetResumeString(*m_item);
   if (!resumeString.empty())
   {
     choices.Add(ACTION_RESUME, resumeString);
@@ -124,3 +125,5 @@ Action CVideoSelectActionProcessorBase::ChooseVideoItemSelectAction() const
 
   return static_cast<Action>(CGUIDialogContextMenu::ShowAndGetChoice(choices));
 }
+
+} // namespace KODI::VIDEO::GUILIB

--- a/xbmc/video/guilib/VideoSelectActionProcessor.h
+++ b/xbmc/video/guilib/VideoSelectActionProcessor.h
@@ -14,9 +14,7 @@
 
 class CFileItem;
 
-namespace VIDEO
-{
-namespace GUILIB
+namespace KODI::VIDEO::GUILIB
 {
 class CVideoSelectActionProcessorBase : public CVideoPlayActionProcessorBase
 {
@@ -44,5 +42,4 @@ private:
   Action ChooseVideoItemSelectAction() const;
   unsigned int ChooseStackItemPartNumber() const;
 };
-} // namespace GUILIB
-} // namespace VIDEO
+} // namespace KODI::VIDEO::GUILIB

--- a/xbmc/video/guilib/VideoVersionHelper.cpp
+++ b/xbmc/video/guilib/VideoVersionHelper.cpp
@@ -26,8 +26,8 @@
 #include "video/VideoManagerTypes.h"
 #include "video/VideoThumbLoader.h"
 
-using namespace KODI::VIDEO;
-using namespace VIDEO::GUILIB;
+namespace KODI::VIDEO::GUILIB
+{
 
 namespace
 {
@@ -281,3 +281,5 @@ std::shared_ptr<CFileItem> CVideoVersionHelper::ChooseVideoFromAssets(
 
   return item;
 }
+
+} // namespace KODI::VIDEO::GUILIB

--- a/xbmc/video/guilib/VideoVersionHelper.h
+++ b/xbmc/video/guilib/VideoVersionHelper.h
@@ -12,15 +12,13 @@
 
 class CFileItem;
 
-namespace VIDEO
+namespace KODI::VIDEO::GUILIB
 {
-namespace GUILIB
-{
+
 class CVideoVersionHelper
 {
 public:
   static std::shared_ptr<CFileItem> ChooseVideoFromAssets(const std::shared_ptr<CFileItem>& item);
 };
-} // namespace GUILIB
 
-} // namespace VIDEO
+} // namespace KODI::VIDEO::GUILIB

--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
@@ -37,8 +37,8 @@
 #include <memory>
 #include <utility>
 
+using namespace KODI;
 using namespace KODI::MESSAGING;
-using namespace VIDEO;
 
 CVideoLibraryRefreshingJob::CVideoLibraryRefreshingJob(std::shared_ptr<CFileItem> item,
                                                        bool forceRefresh,
@@ -109,9 +109,9 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
 
     if (!ignoreNfo)
     {
-      std::unique_ptr<IVideoInfoTagLoader> loader;
-      loader.reset(CVideoInfoTagLoaderFactory::CreateLoader(*m_item, scraper,
-                                                            scanSettings.parent_name_root, m_forceRefresh));
+      std::unique_ptr<VIDEO::IVideoInfoTagLoader> loader;
+      loader.reset(VIDEO::CVideoInfoTagLoaderFactory::CreateLoader(
+          *m_item, scraper, scanSettings.parent_name_root, m_forceRefresh));
       // check if there's an NFO for the item
       CInfoScanner::INFO_TYPE nfoResult = CInfoScanner::NO_NFO;
       if (loader)
@@ -182,7 +182,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
       {
         CFileItemList items;
         items.Add(m_item);
-        CVideoInfoScanner scanner;
+        VIDEO::CVideoInfoScanner scanner;
         if (scanner.RetrieveVideoInfo(items, scanSettings.parent_name, scraper->Content(),
                                       !ignoreNfo, nullptr, m_refreshAll, GetProgressDialog()))
         {
@@ -360,7 +360,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
     }
 
     // finally download the information for the item
-    CVideoInfoScanner scanner;
+    VIDEO::CVideoInfoScanner scanner;
     if (!scanner.RetrieveVideoInfo(items, scanSettings.parent_name,
                                    scraper->Content(), !ignoreNfo,
                                    scraperUrl.HasUrls() ? &scraperUrl : nullptr,

--- a/xbmc/video/jobs/VideoLibraryScanningJob.h
+++ b/xbmc/video/jobs/VideoLibraryScanningJob.h
@@ -45,7 +45,7 @@ protected:
   bool Work(CVideoDatabase &db) override;
 
 private:
-  VIDEO::CVideoInfoScanner m_scanner;
+  KODI::VIDEO::CVideoInfoScanner m_scanner;
   std::string m_directory;
   bool m_showProgress;
   bool m_scanAll;

--- a/xbmc/video/tags/IVideoInfoTagLoader.h
+++ b/xbmc/video/tags/IVideoInfoTagLoader.h
@@ -18,7 +18,7 @@ class CFileItem;
 class CVideoInfoTag;
 class EmbeddedArt;
 
-namespace VIDEO
+namespace KODI::VIDEO
 {
 
 //! \brief Base class for video tag loaders.

--- a/xbmc/video/tags/VideoInfoTagLoaderFactory.cpp
+++ b/xbmc/video/tags/VideoInfoTagLoaderFactory.cpp
@@ -14,7 +14,8 @@
 #include "VideoTagLoaderPlugin.h"
 #include "video/tags/VideoTagExtractionHelper.h"
 
-using namespace VIDEO;
+namespace KODI::VIDEO
+{
 
 IVideoInfoTagLoader* CVideoInfoTagLoaderFactory::CreateLoader(const CFileItem& item,
                                                               const ADDON::ScraperPtr& info,
@@ -45,3 +46,5 @@ IVideoInfoTagLoader* CVideoInfoTagLoaderFactory::CreateLoader(const CFileItem& i
 
   return nullptr;
 }
+
+} // namespace KODI::VIDEO

--- a/xbmc/video/tags/VideoInfoTagLoaderFactory.h
+++ b/xbmc/video/tags/VideoInfoTagLoaderFactory.h
@@ -13,7 +13,7 @@
 
 class CFileItem;  // forward
 
-namespace VIDEO
+namespace KODI::VIDEO
 {
   class CVideoInfoTagLoaderFactory
   {
@@ -31,4 +31,4 @@ namespace VIDEO
     CVideoInfoTagLoaderFactory(void) = delete;
     virtual ~CVideoInfoTagLoaderFactory() = delete;
   };
-}
+  } // namespace KODI::VIDEO

--- a/xbmc/video/tags/VideoTagExtractionHelper.cpp
+++ b/xbmc/video/tags/VideoTagExtractionHelper.cpp
@@ -17,7 +17,8 @@
 #include "video/VideoInfoTag.h"
 #include "video/tags/VideoTagLoaderFFmpeg.h"
 
-using namespace VIDEO::TAGS;
+namespace KODI::VIDEO::TAGS
+{
 
 bool CVideoTagExtractionHelper::IsExtractionSupportedFor(const CFileItem& item)
 {
@@ -39,3 +40,5 @@ std::string CVideoTagExtractionHelper::ExtractEmbeddedArtFor(const CFileItem& it
   }
   return {};
 }
+
+} // namespace KODI::VIDEO::TAGS

--- a/xbmc/video/tags/VideoTagExtractionHelper.h
+++ b/xbmc/video/tags/VideoTagExtractionHelper.h
@@ -12,9 +12,7 @@
 
 class CFileItem;
 
-namespace VIDEO
-{
-namespace TAGS
+namespace KODI::VIDEO::TAGS
 {
 class CVideoTagExtractionHelper
 {
@@ -37,5 +35,4 @@ public:
    */
   static std::string ExtractEmbeddedArtFor(const CFileItem& item, const std::string& artType);
 };
-} // namespace TAGS
-} // namespace VIDEO
+} // namespace KODI::VIDEO::TAGS

--- a/xbmc/video/tags/VideoTagLoaderFFmpeg.h
+++ b/xbmc/video/tags/VideoTagLoaderFFmpeg.h
@@ -21,7 +21,7 @@ namespace XFILE
 }
 
 //! \brief Video tag loader using FFMPEG.
-class CVideoTagLoaderFFmpeg : public VIDEO::IVideoInfoTagLoader
+class CVideoTagLoaderFFmpeg : public KODI::VIDEO::IVideoInfoTagLoader
 {
 public:
   //! \brief Constructor.

--- a/xbmc/video/tags/VideoTagLoaderNFO.h
+++ b/xbmc/video/tags/VideoTagLoaderNFO.h
@@ -14,7 +14,7 @@
 #include <vector>
 
 //! \brief Video tag loader using nfo files.
-class CVideoTagLoaderNFO : public VIDEO::IVideoInfoTagLoader
+class CVideoTagLoaderNFO : public KODI::VIDEO::IVideoInfoTagLoader
 {
 public:
   CVideoTagLoaderNFO(const CFileItem& item,

--- a/xbmc/video/tags/VideoTagLoaderPlugin.h
+++ b/xbmc/video/tags/VideoTagLoaderPlugin.h
@@ -17,7 +17,7 @@
 #include <vector>
 
 //! \brief Video tag loader from plugin source.
-class CVideoTagLoaderPlugin : public VIDEO::IVideoInfoTagLoader
+class CVideoTagLoaderPlugin : public KODI::VIDEO::IVideoInfoTagLoader
 {
 public:
   CVideoTagLoaderPlugin(const CFileItem& item, bool forceRefresh);

--- a/xbmc/video/test/TestVideoInfoScanner.cpp
+++ b/xbmc/video/test/TestVideoInfoScanner.cpp
@@ -11,7 +11,7 @@
 
 #include <gtest/gtest.h>
 
-using namespace VIDEO;
+using namespace KODI;
 using ::testing::Test;
 using ::testing::WithParamInterface;
 using ::testing::ValuesIn;
@@ -48,13 +48,13 @@ class TestVideoInfoScanner : public Test,
 TEST_P(TestVideoInfoScanner, EnumerateEpisodeItem)
 {
   const TestEntry& entry = GetParam();
-  CVideoInfoScanner scanner;
+  VIDEO::CVideoInfoScanner scanner;
   CFileItem item(entry.path, false);
-  EPISODELIST expected;
+  VIDEO::EPISODELIST expected;
   for (int i = 0; i < 3 && entry.episode[i]; i++)
     expected.emplace_back(entry.season, entry.episode[i], 0, false);
 
-  EPISODELIST result;
+  VIDEO::EPISODELIST result;
   ASSERT_TRUE(scanner.EnumerateEpisodeItem(&item, result));
   EXPECT_EQ(expected.size(), result.size());
   for (size_t i = 0; i < expected.size(); i++)
@@ -65,9 +65,9 @@ INSTANTIATE_TEST_SUITE_P(VideoInfoScanner, TestVideoInfoScanner, ValuesIn(TestDa
 
 TEST(TestVideoInfoScanner, EnumerateEpisodeItemByTitle)
 {
-  CVideoInfoScanner scanner;
+  VIDEO::CVideoInfoScanner scanner;
   CFileItem item("/foo.special.mp4", false);
-  EPISODELIST result;
+  VIDEO::EPISODELIST result;
   ASSERT_TRUE(scanner.EnumerateEpisodeItem(&item, result));
   ASSERT_EQ(result.size(), 1);
   ASSERT_EQ(result[0].strTitle, "foo");

--- a/xbmc/video/test/TestVideoUtils.cpp
+++ b/xbmc/video/test/TestVideoUtils.cpp
@@ -19,6 +19,7 @@
 
 #include <gtest/gtest.h>
 
+using namespace KODI;
 namespace fs = KODI::PLATFORM::FILESYSTEM;
 
 using OptDef = std::pair<std::string, bool>;
@@ -39,9 +40,9 @@ TEST_P(OpticalMediaPathTest, GetOpticalMediaPath)
   }
   CFileItem item(temp_path, true);
   if (GetParam().second)
-    EXPECT_EQ(VIDEO_UTILS::GetOpticalMediaPath(item), file_path);
+    EXPECT_EQ(VIDEO::UTILS::GetOpticalMediaPath(item), file_path);
   else
-    EXPECT_EQ(VIDEO_UTILS::GetOpticalMediaPath(item), "");
+    EXPECT_EQ(VIDEO::UTILS::GetOpticalMediaPath(item), "");
 
   XFILE::CDirectory::RemoveRecursive(temp_path);
 }

--- a/xbmc/video/windows/GUIWindowVideoBase.h
+++ b/xbmc/video/windows/GUIWindowVideoBase.h
@@ -96,7 +96,7 @@ protected:
    \param action the action to perform
    \return true if the action is performed, false otherwise
    */
-  bool OnFileAction(int item, VIDEO::GUILIB::Action action, const std::string& player);
+  bool OnFileAction(int item, KODI::VIDEO::GUILIB::Action action, const std::string& player);
 
   void OnRestartItem(int iItem, const std::string &player = "");
   bool OnPlayOrResumeItem(int iItem, const std::string& player = "");
@@ -118,7 +118,9 @@ protected:
 
   void OnSearch();
   void OnSearchItemFound(const CFileItem* pSelItem);
-  int GetScraperForItem(CFileItem *item, ADDON::ScraperPtr &info, VIDEO::SScanSettings& settings);
+  int GetScraperForItem(CFileItem* item,
+                        ADDON::ScraperPtr& info,
+                        KODI::VIDEO::SScanSettings& settings);
 
   static bool OnUnAssignContent(const std::string &path, int header, int text);
 

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -50,8 +50,8 @@
 
 using namespace XFILE;
 using namespace VIDEODATABASEDIRECTORY;
+using namespace KODI;
 using namespace KODI::MESSAGING;
-using namespace KODI::VIDEO;
 
 #define CONTROL_BTNVIEWASICONS     2
 #define CONTROL_BTNSORTBY          3
@@ -155,7 +155,7 @@ bool CGUIWindowVideoNav::OnMessage(CGUIMessage& message)
             // We are here if the item is filtered out in the nav window
             const std::string& path = message.GetStringParam(0);
             CFileItem item(path, URIUtils::HasSlashAtEnd(path));
-            if (IsVideoDb(item))
+            if (VIDEO::IsVideoDb(item))
             {
               *(item.GetVideoInfoTag()) = XFILE::CVideoDatabaseFile::GetVideoTag(CURL(item.GetPath()));
               if (!item.GetVideoInfoTag()->IsEmpty())
@@ -245,7 +245,7 @@ bool CGUIWindowVideoNav::OnMessage(CGUIMessage& message)
 
 SelectFirstUnwatchedItem CGUIWindowVideoNav::GetSettingSelectFirstUnwatchedItem()
 {
-  if (IsVideoDb(*m_vecItems))
+  if (VIDEO::IsVideoDb(*m_vecItems))
   {
     NODE_TYPE nodeType = CVideoDatabaseDirectory::GetDirectoryChildType(m_vecItems->GetPath());
 
@@ -361,7 +361,7 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
   bool bResult = CGUIWindowVideoBase::GetDirectory(strDirectory, items);
   if (bResult)
   {
-    if (IsVideoDb(items))
+    if (VIDEO::IsVideoDb(items))
     {
       XFILE::CVideoDatabaseDirectory dir;
       CQueryParams params;
@@ -549,7 +549,7 @@ void CGUIWindowVideoNav::UpdateButtons()
   else if (m_vecItems->IsPath("sources://video/"))
     strLabel = g_localizeStrings.Get(744);
   // everything else is from a videodb:// path
-  else if (IsVideoDb(*m_vecItems))
+  else if (VIDEO::IsVideoDb(*m_vecItems))
   {
     CVideoDatabaseDirectory dir;
     dir.GetLabel(m_vecItems->GetPath(), strLabel);
@@ -674,7 +674,7 @@ void CGUIWindowVideoNav::OnDeleteItem(const CFileItemPtr& pItem)
   if (m_vecItems->IsParentFolder())
     return;
 
-  if (!IsVideoDb(*m_vecItems) && !IsVideoDb(*pItem))
+  if (!VIDEO::IsVideoDb(*m_vecItems) && !VIDEO::IsVideoDb(*pItem))
   {
     if (!pItem->IsPath("newsmartplaylist://video") && !pItem->IsPath("special://videoplaylists/") &&
         !pItem->IsPath("sources://video/") && !URIUtils::IsProtocol(pItem->GetPath(), "newtag"))
@@ -801,7 +801,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
       // can we update the database?
       if (profileManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser)
       {
-        if (!CVideoLibraryQueue::GetInstance().IsScanningLibrary() && IsVideoDb(*item) &&
+        if (!CVideoLibraryQueue::GetInstance().IsScanningLibrary() && VIDEO::IsVideoDb(*item) &&
             item->HasVideoInfoTag() &&
             (item->GetVideoInfoTag()->m_type == MediaTypeMovie || // movies
              item->GetVideoInfoTag()->m_type == MediaTypeTvShow || // tvshows
@@ -827,7 +827,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
         }
       }
 
-      if (!IsVideoDb(*m_vecItems) && !m_vecItems->IsVirtualDirectoryRoot())
+      if (!VIDEO::IsVideoDb(*m_vecItems) && !m_vecItems->IsVirtualDirectoryRoot())
       { // non-video db items, file operations are allowed
         if ((CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_ALLOWFILEDELETION) &&
             CUtil::SupportsWriteFileOperations(item->GetPath())) ||
@@ -838,7 +838,7 @@ void CGUIWindowVideoNav::GetContextButtons(int itemNumber, CContextButtons &butt
           buttons.Add(CONTEXT_BUTTON_RENAME, 118);
         }
         // add "Set/Change content" to folders
-        if (item->m_bIsFolder && !IsVideoDb(*item) && !item->IsPlayList() &&
+        if (item->m_bIsFolder && !VIDEO::IsVideoDb(*item) && !item->IsPlayList() &&
             !item->IsSmartPlayList() && !item->IsLibraryFolder() && !item->IsLiveTV() &&
             !item->IsPlugin() && !item->IsAddonsPath() && !URIUtils::IsUPnP(item->GetPath()))
         {
@@ -1084,7 +1084,7 @@ bool CGUIWindowVideoNav::ApplyWatchedFilter(CFileItemList &items)
   ||  node == NODE_TYPE_RECENTLY_ADDED_MOVIES
   ||  node == NODE_TYPE_RECENTLY_ADDED_MUSICVIDEOS)
     filterWatched = true;
-  if (!IsVideoDb(items))
+  if (!VIDEO::IsVideoDb(items))
     filterWatched = true;
   if (items.GetContent() == "tvshows" &&
      (items.IsSmartPlayList() || items.IsLibraryFolder()))

--- a/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
+++ b/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
@@ -48,8 +48,7 @@
 #define CONTROL_BTNPREVIOUS 25
 #define CONTROL_BTNREPEAT 26
 
-using namespace KODI::VIDEO;
-using namespace VIDEO::GUILIB;
+using namespace KODI;
 
 CGUIWindowVideoPlaylist::CGUIWindowVideoPlaylist()
   : CGUIWindowVideoBase(WINDOW_VIDEO_PLAYLIST, "MyPlaylist.xml")
@@ -66,7 +65,7 @@ void CGUIWindowVideoPlaylist::OnPrepareFileItems(CFileItemList& items)
   if (items.IsEmpty())
     return;
 
-  if (!IsVideoDb(items) && !items.IsVirtualDirectoryRoot())
+  if (!VIDEO::IsVideoDb(items) && !items.IsVirtualDirectoryRoot())
   { // load info from the database
     std::string label;
     if (items.GetLabel().empty() &&
@@ -379,7 +378,7 @@ void CGUIWindowVideoPlaylist::UpdateButtons()
 
 namespace
 {
-class CVideoPlayActionProcessor : public CVideoPlayActionProcessorBase
+class CVideoPlayActionProcessor : public VIDEO::GUILIB::CVideoPlayActionProcessorBase
 {
 public:
   CVideoPlayActionProcessor(const std::shared_ptr<CFileItem>& item,

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -495,7 +495,7 @@ bool CGUIViewState::AutoPlayNextVideoItem() const
   if (GetPlaylist() != PLAYLIST::TYPE_VIDEO)
     return false;
 
-  return VIDEO_UTILS::IsAutoPlayNextItem(m_items.GetContent());
+  return VIDEO::UTILS::IsAutoPlayNextItem(m_items.GetContent());
 }
 
 void CGUIViewState::LoadViewState(const std::string &path, int windowID)


### PR DESCRIPTION
- drop VIDEO namespace
- make VIDEO_UTILS a nested namespace KODI::VIDEO::UTILS

## Description
In PR https://github.com/xbmc/xbmc/pull/24940 I was told to put the functions in a KODI::VIDEO namespace.
This is rather conflicty with the existing VIDEO namespace. This PR unifies everything under KODI::VIDEO

## Motivation and context
Fix up namespace clashes

## How has this been tested?
It builds

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
