### PR TITLE
[videodb][videoversion] Fix Leaks on Movie / Asset Removal

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -12540,30 +12540,16 @@ void CVideoDatabase::SetVideoVersion(int idFile, int idVideoVersion)
   }
 }
 
-void CVideoDatabase::AddPrimaryVideoVersion(VideoDbContentType itemType,
-                                            int dbId,
-                                            int idVideoVersion,
-                                            CFileItem& item)
-{
-  AddVideoVersion(itemType, dbId, idVideoVersion, VideoAssetType::VERSION, item);
-}
-
-void CVideoDatabase::AddExtrasVideoVersion(VideoDbContentType itemType,
-                                           int dbId,
-                                           int idVideoVersion,
-                                           CFileItem& item)
-{
-  AddVideoVersion(itemType, dbId, idVideoVersion, VideoAssetType::EXTRA, item);
-}
-
-void CVideoDatabase::AddVideoVersion(VideoDbContentType itemType,
-                                     int dbId,
-                                     int idVideoVersion,
-                                     VideoAssetType videoAssetType,
-                                     CFileItem& item)
+void CVideoDatabase::AddVideoAsset(VideoDbContentType itemType,
+                                   int dbId,
+                                   int idVideoVersion,
+                                   VideoAssetType videoAssetType,
+                                   CFileItem& item)
 {
   if (!m_pDB || !m_pDS)
     return;
+
+  assert(m_pDB->in_transaction() == false);
 
   MediaType mediaType;
   if (itemType == VideoDbContentType::MOVIES)
@@ -12579,6 +12565,8 @@ void CVideoDatabase::AddVideoVersion(VideoDbContentType itemType,
 
   try
   {
+    BeginTransaction();
+
     m_pDS->query(PrepareSQL("SELECT idFile FROM videoversion WHERE idFile = %i", idFile));
 
     if (m_pDS->num_rows() == 0)
@@ -12594,10 +12582,13 @@ void CVideoDatabase::AddVideoVersion(VideoDbContentType itemType,
 
     if (videoAssetType == VideoAssetType::VERSION)
       SetVideoVersionDefaultArt(idFile, item.GetVideoInfoTag()->m_iDbId, itemType);
+
+    CommitTransaction();
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed for video {}", __FUNCTION__, dbId);
+    CLog::LogF(LOGERROR, "failed for video {}", dbId);
+    RollbackTransaction();
   }
 }
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3720,19 +3720,38 @@ void CVideoDatabase::DeleteMovie(int idMovie,
     // the ancillary tables are still purged
     if (!bKeepId)
     {
-      std::string path = GetSingleValue(PrepareSQL("SELECT strPath FROM path JOIN files ON files.idPath=path.idPath WHERE files.idFile=%i", idFile));
+      const std::string path = GetSingleValue(PrepareSQL(
+          "SELECT strPath FROM path JOIN files ON files.idPath=path.idPath WHERE files.idFile=%i",
+          idFile));
       if (!path.empty())
         InvalidatePathHash(path);
 
-      std::string strSQL = PrepareSQL("delete from movie where idMovie=%i", idMovie);
+      const std::string strSQL = PrepareSQL("delete from movie where idMovie=%i", idMovie);
       m_pDS->exec(strSQL);
 
       if (ca == DeleteMovieCascadeAction::ALL_ASSETS)
       {
-        const std::string strSQL{
-            PrepareSQL("DELETE FROM videoversion WHERE idMedia = %i AND media_type = '%s'", idMovie,
-                       MediaTypeMovie)};
-        m_pDS->exec(strSQL);
+        // The default version of the movie was removed by a delete trigger.
+        // Clean up the other assets attached to the movie, if any.
+
+        // need local dataset due to nested DeleteVideoAsset query
+        std::unique_ptr<Dataset> pDS{m_pDB->CreateDataset()};
+
+        pDS->query(
+            PrepareSQL("SELECT idFile FROM videoversion WHERE idMedia=%i AND media_type='%s'",
+                       idMovie, MediaTypeMovie));
+
+        while (!pDS->eof())
+        {
+          if (!DeleteVideoAsset(pDS->fv(0).get_asInt()))
+          {
+            RollbackTransaction();
+            pDS->close();
+            return;
+          }
+          pDS->next();
+        }
+        pDS->close();
       }
     }
 
@@ -3745,7 +3764,7 @@ void CVideoDatabase::DeleteMovie(int idMovie,
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed", __FUNCTION__);
+    CLog::LogF(LOGERROR, "failed");
     RollbackTransaction();
   }
 }
@@ -12461,31 +12480,48 @@ bool CVideoDatabase::IsDefaultVideoVersion(int idFile)
   return false;
 }
 
-bool CVideoDatabase::RemoveVideoVersion(int dbId)
+bool CVideoDatabase::DeleteVideoAsset(int idFile)
 {
   if (!m_pDB || !m_pDS)
     return false;
 
-  if (IsDefaultVideoVersion(dbId))
+  if (IsDefaultVideoVersion(idFile))
     return false;
+
+  const bool inTransaction{m_pDB->in_transaction()};
 
   try
   {
-    std::string path = GetSingleValue(PrepareSQL(
+    if (!inTransaction)
+      BeginTransaction();
+
+    const std::string path = GetSingleValue(PrepareSQL(
         "SELECT strPath FROM path JOIN files ON files.idPath=path.idPath WHERE files.idFile=%i",
-        dbId));
+        idFile));
     if (!path.empty())
       InvalidatePathHash(path);
 
-    m_pDS->exec(PrepareSQL("DELETE FROM videoversion WHERE idFile = %i", dbId));
+    /*! \todo replace with a delete trigger on videoversion */
+    m_pDS->exec(PrepareSQL("DELETE FROM art WHERE media_id=%i and media_type='%s'", idFile,
+                           MediaTypeVideoVersion));
+
+    /*! \todo replace with a delete trigger on videoversion */
+    DeleteStreamDetails(idFile);
+
+    m_pDS->exec(PrepareSQL("DELETE FROM videoversion WHERE idFile=%i", idFile));
+
+    if (!inTransaction)
+      CommitTransaction();
 
     return true;
   }
   catch (...)
   {
-    CLog::Log(LOGERROR, "{} failed for {}", __FUNCTION__, dbId);
+    CLog::LogF(LOGERROR, "failed for {}", idFile);
+    if (!inTransaction)
+      RollbackTransaction();
+    return false;
   }
-  return false;
 }
 
 void CVideoDatabase::SetVideoVersion(int idFile, int idVideoVersion)

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -369,6 +369,10 @@ void CVideoDatabase::CreateAnalytics()
               "DELETE FROM videoversion WHERE idFile=old.idFile; "
               "DELETE FROM art WHERE media_id=old.idFile AND media_type='videoversion'; "
               "END");
+  m_pDS->exec("CREATE TRIGGER delete_videoversion AFTER DELETE ON videoversion FOR EACH ROW BEGIN "
+              "DELETE FROM art WHERE media_id=old.idFile AND media_type='videoversion'; "
+              "DELETE FROM streamdetails WHERE idFile=old.idFile; "
+              "END");
 
   CreateViews();
 }
@@ -6452,7 +6456,7 @@ void CVideoDatabase::UpdateTables(int iVersion)
 
 int CVideoDatabase::GetSchemaVersion() const
 {
-  return 131;
+  return 132;
 }
 
 bool CVideoDatabase::LookupByFolders(const std::string &path, bool shows)
@@ -12500,13 +12504,6 @@ bool CVideoDatabase::DeleteVideoAsset(int idFile)
         idFile));
     if (!path.empty())
       InvalidatePathHash(path);
-
-    /*! \todo replace with a delete trigger on videoversion */
-    m_pDS->exec(PrepareSQL("DELETE FROM art WHERE media_id=%i and media_type='%s'", idFile,
-                           MediaTypeVideoVersion));
-
-    /*! \todo replace with a delete trigger on videoversion */
-    DeleteStreamDetails(idFile);
 
     m_pDS->exec(PrepareSQL("DELETE FROM videoversion WHERE idFile=%i", idFile));
 

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1063,19 +1063,11 @@ public:
   int AddVideoVersionType(const std::string& typeVideoVersion,
                           VideoAssetTypeOwner owner,
                           VideoAssetType assetType);
-  void AddVideoVersion(VideoDbContentType itemType,
-                       int dbId,
-                       int idVideoVersion,
-                       VideoAssetType videoAssetType,
-                       CFileItem& item);
-  void AddPrimaryVideoVersion(VideoDbContentType itemType,
-                              int dbId,
-                              int idVideoVersion,
-                              CFileItem& item);
-  void AddExtrasVideoVersion(VideoDbContentType itemType,
-                             int dbId,
-                             int idVideoVersion,
-                             CFileItem& item);
+  void AddVideoAsset(VideoDbContentType itemType,
+                     int dbId,
+                     int idVideoVersion,
+                     VideoAssetType videoAssetType,
+                     CFileItem& item);
   bool DeleteVideoAsset(int idFile);
   bool IsDefaultVideoVersion(int idFile);
   bool GetVideoVersionTypes(VideoDbContentType idContent,

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1076,7 +1076,7 @@ public:
                              int dbId,
                              int idVideoVersion,
                              CFileItem& item);
-  bool RemoveVideoVersion(int dbId);
+  bool DeleteVideoAsset(int idFile);
   bool IsDefaultVideoVersion(int idFile);
   bool GetVideoVersionTypes(VideoDbContentType idContent,
                             VideoAssetType asset,

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -2487,8 +2487,9 @@ namespace VIDEO
           const int idVideoVersion = m_database.AddVideoVersionType(
               typeVideoVersion, VideoAssetTypeOwner::AUTO, VideoAssetType::EXTRA);
 
-          m_database.AddExtrasVideoVersion(ContentToVideoDbType(content), dbId, idVideoVersion,
-                                           *item.get());
+          m_database.AddVideoAsset(ContentToVideoDbType(content), dbId, idVideoVersion,
+                                   VideoAssetType::EXTRA, *item.get());
+
           CLog::Log(LOGDEBUG, "VideoInfoScanner: Added video extras {}",
                     CURL::GetRedacted(item->GetPath()));
         },

--- a/xbmc/video/dialogs/GUIDialogVideoManager.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -311,8 +311,7 @@ void CGUIDialogVideoManager::Remove()
     return;
   }
 
-  //! @todo db refactor: should not be version, but asset
-  m_database.RemoveVideoVersion(m_selectedVideoAsset->GetVideoInfoTag()->m_iDbId);
+  m_database.DeleteVideoAsset(m_selectedVideoAsset->GetVideoInfoTag()->m_iDbId);
 
   // refresh data and controls
   Refresh();

--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
@@ -215,12 +215,6 @@ bool CGUIDialogVideoManagerExtras::AddVideoExtra()
         return m_database.ConvertVideoToVersion(itemType, newAsset.m_idMedia, dbId,
                                                 idNewVideoVersion, VideoAssetType::EXTRA);
       }
-      else
-      {
-        // @todo: should be in a database transaction with the addition as a new asset below
-        if (!m_database.DeleteVideoAsset(newAsset.m_idFile))
-          return false;
-      }
     }
 
     CFileItem item{path, false};

--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
@@ -239,7 +239,7 @@ bool CGUIDialogVideoManagerExtras::AddVideoExtra()
     if (idNewVideoVersion == -1)
       return false;
 
-    m_database.AddExtrasVideoVersion(itemType, dbId, idNewVideoVersion, item);
+    m_database.AddVideoAsset(itemType, dbId, idNewVideoVersion, VideoAssetType::EXTRA, item);
 
     return true;
   }

--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
@@ -218,7 +218,7 @@ bool CGUIDialogVideoManagerExtras::AddVideoExtra()
       else
       {
         // @todo: should be in a database transaction with the addition as a new asset below
-        if (!m_database.RemoveVideoVersion(newAsset.m_idFile))
+        if (!m_database.DeleteVideoAsset(newAsset.m_idFile))
           return false;
       }
     }

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -587,7 +587,7 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
       else
       {
         // @todo: should be in a database transaction with the addition as a new asset below
-        if (!m_database.RemoveVideoVersion(newAsset.m_idFile))
+        if (!m_database.DeleteVideoAsset(newAsset.m_idFile))
           return false;
       }
     }

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -584,12 +584,6 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
           return false;
         }
       }
-      else
-      {
-        // @todo: should be in a database transaction with the addition as a new asset below
-        if (!m_database.DeleteVideoAsset(newAsset.m_idFile))
-          return false;
-      }
     }
 
     CFileItem item{path, false};

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -606,7 +606,7 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
     if (idNewVideoVersion == -1)
       return false;
 
-    m_database.AddPrimaryVideoVersion(itemType, dbId, idNewVideoVersion, item);
+    m_database.AddVideoAsset(itemType, dbId, idNewVideoVersion, VideoAssetType::VERSION, item);
 
     return true;
   }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Modify version/extra addition and removal to be symmetrical and to follow the add/delete patterns used elsewhere in Kodi video db. Add is an upsert.
Sub-resources of a video asset that have to be created / removed/invalidated:
- art
- stream details
- path

This code works around a couple problems that would need some significant refactors
- have to be careful not to use the same dataset at multiple levels of the call stack, they are like global variables.
- transaction nesting

The last commit adds a table delete trigger to take care of asset art and stream details removal, to follow the pattern of the other tables.
My understanding is that the db version cannot be bumped for stable releases so that commit is not eligible for backport to v21. The other commits can be backported.

There are conflicts with #25022 in CVideoDatabase::DeleteMovie(). This PR is more important, I will adapt the other PR later.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Noticed inconsistencies in data cleanup after removing movie additional versions or extras, sometimes a library update wouldn't notice the files of the remove versions or extras.
Some data remained in the database after removing versions or extras.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
sqlite and mariadb
Remove movie from library, remove version from movie, remove extra from movie, followed by update libray or scan for new content.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Versions/extras scanned more consistently, remove leaks in the database.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
