### PR TITLE
GLES: disable attribute array when rendering from FBO

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -1293,6 +1293,9 @@ void CLinuxRendererGLES::RenderFromFBO()
 
   glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, idx);
 
+  glDisableVertexAttribArray(loc);
+  glDisableVertexAttribArray(vertLoc);
+
   VerifyGLState();
 
   if (m_pVideoFilterShader)


### PR DESCRIPTION
## Description
Disables attribute arrays after rendering from an FBO when a high quality video scaler is active.

The arrays `vert` and `tex` go out of scope at the end of the function, but both array pointers still point to them. This might cause issues in the next drawcall. 

## Motivation and context
Might fix https://github.com/xbmc/xbmc/issues/25040.

## How has this been tested?
Still renders fine on my desktop.

## What is the effect on users?
Might prevent a crash.

## Screenshots (if appropriate):
Before: unnecessary pointer (Buffer 1):
![image](https://github.com/xbmc/xbmc/assets/30039775/9a7aafb4-cc5e-4393-853b-556c4b3739b6)

After (Buffer 1 is not bound): 
![image](https://github.com/xbmc/xbmc/assets/30039775/29ac2e0f-32f0-4600-8347-db6c17b896fc)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
