### PR TITLE
[Video] Fix for #25097 and requested updates from #24720

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7289,6 +7289,9 @@ msgctxt "#13423"
 msgid "Remember for this path"
 msgstr ""
 
+#. Shown on context menu when a bluray:// or dvd:// playlist has already been saved
+#. Giving the user a chance to select a new one via the simple menu dialog
+#: xbmc/video/windows/GUIWindowVideoBase.cpp
 msgctxt "#13424"
 msgid "Choose playlist"
 msgstr ""

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -2429,7 +2429,7 @@ bool CApplication::PlayFile(CFileItem item,
   // a disc image might be Blu-Ray disc
   if (!(options.startpercent > 0.0 || options.starttime > 0.0) &&
       (VIDEO::IsBDFile(item) || item.IsDiscImage() ||
-       (VIDEO::IsBlurayPlaylist(item) && forceSelection)))
+       (forceSelection && VIDEO::IsBlurayPlaylist(item))))
   {
     // No video selection when using external or remote players (they handle it if supported)
     const bool isSimpleMenuAllowed = [&]()

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -29,8 +29,6 @@
 #include "video/VideoFileItemClassify.h"
 #include "video/VideoInfoTag.h"
 
-std::string m_savePath;
-
 using namespace KODI;
 
 namespace
@@ -59,10 +57,9 @@ bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item, bool forceSelectio
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_DISC_PLAYBACK) != BD_PLAYBACK_SIMPLE_MENU)
     return true;
 
-  m_savePath = "";
-  if (VIDEO::IsBlurayPlaylist(item) && forceSelection)
+  if (forceSelection && VIDEO::IsBlurayPlaylist(item))
   {
-    m_savePath = item.GetDynPath(); // save for screen refresh later
+    item.SetProperty("save_dyn_path", item.GetDynPath()); // save for screen refresh later
     item.SetDynPath(item.GetBlurayPath());
   }
 
@@ -135,11 +132,14 @@ bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item, const std::string&
 
     if (item_new->m_bIsFolder == false)
     {
-      if (m_savePath.empty()) // If not set above (choose playlist selected)
-        m_savePath = item.GetDynPath();
+      std::string path;
+      if (item.HasProperty("save_dyn_path"))
+        path = item.GetProperty("save_dyn_path").asString();
+      else
+        path = item.GetDynPath(); // If not set above (choose playlist selected)
       item.SetDynPath(item_new->GetDynPath());
       item.SetProperty("get_stream_details_from_player", true);
-      item.SetProperty("original_listitem_url", m_savePath);
+      item.SetProperty("original_listitem_url", path);
       return true;
     }
 

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -60,11 +60,7 @@
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
-#include "video/VideoFileItemClassify.h"
-#include "video/VideoInfoTag.h"
 #include "view/GUIViewState.h"
-
-#include <inttypes.h>
 
 #define CONTROL_BTNVIEWASICONS       2
 #define CONTROL_BTNSORTBY            3
@@ -1537,21 +1533,11 @@ bool CGUIMediaWindow::OnPlayAndQueueMedia(const CFileItemPtr& item, const std::s
                                   { return i->IsZIP() || i->IsRAR() || i->m_bIsFolder; }),
                    playlist.end());
 
-    // Remove duplicates (eg. ISO/VIDEO_TS)
-    playlist.erase(
-        std::unique(playlist.begin(), playlist.end(),
-                    [](const std::shared_ptr<CFileItem>& i, const std::shared_ptr<CFileItem>& j) {
-                      return i->GetVideoInfoTag()->m_basePath == j->GetVideoInfoTag()->m_basePath;
-                    }),
-        playlist.end());
-
     // Chosen item
     int mediaToPlay =
         std::distance(playlist.begin(), std::find_if(playlist.begin(), playlist.end(),
-                                                     [&item](const std::shared_ptr<CFileItem>& i) {
-                                                       return i->GetVideoInfoTag()->m_basePath ==
-                                                              item->GetVideoInfoTag()->m_basePath;
-                                                     }));
+                                                     [&item](const std::shared_ptr<CFileItem>& i)
+                                                     { return i->GetPath() == item->GetPath(); }));
 
     // Add to playlist
     CServiceBroker::GetPlaylistPlayer().ClearPlaylist(playlistId);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

This PR is twofold:

1) It fixes the issue reported in #25097.

When play from here or automatically play next item are selected then a playlsit is generated.
If this was done through Video -> Files, on items that weren't yet scanned into the database then there was no `VideoInfoTag` and therefore `p->GetVideoInfoTag()->m_basePath` was actually empty.

This corrects that.

2) Requested updates from devs

As detailed in https://github.com/xbmc/xbmc/commit/54a63d02f1e63ebad0cd99dc06ca070c91ceb93c

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?

Part 1 by @smp79 who kindly reported the original issue.

## What is the effect on users?

Fix and code optimisation/clarity.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
