### PR TITLE
AEStreamInfo: remove spammy EAC3 log line

### DIFF
--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
@@ -408,12 +408,7 @@ bool CAEStreamParser::TrySyncAC3(uint8_t* data,
       return false;
 
     if (strmtyp != 1 && wantEAC3dependent)
-    {
-      CLog::Log(LOGDEBUG,
-                "CAEStreamParser::TrySyncAC3 - Unexpected stream type: {} (wantEAC3dependent: {})",
-                strmtyp, wantEAC3dependent);
       return false;
-    }
 
     unsigned int framesize = (((data[2] & 0x7) << 8) | data[3]) + 1;
     uint8_t fscod = (data[4] >> 6) & 0x3;


### PR DESCRIPTION
## Description
AEStreamInfo: remove spammy EAC3 log line

## Motivation and context
See https://forum.kodi.tv/showthread.php?tid=377350

This log line is repeated hundreds of times every second and this may cause high CPU load (even if debug level is not enabled because text is sent and processed anyway).

```
2024-05-01 15:54:05.466 T:24925   debug <general>: CAEStreamParser::TrySyncAC3 - Unexpected stream type: 0 (wantEAC3dependent: true)
2024-05-01 15:54:08.688 T:22739    info <general>: Skipped 101 duplicate messages..
2024-05-01 15:54:08.688 T:22739   debug <general>: CDVDSubtitlesLibass: [ass] fontselect: (DejaVu Sans, 400, 0) -> DejaVuSans, 0, DejaVuSans
2024-05-01 15:54:08.701 T:24925   debug <general>: CAEStreamParser::TrySyncAC3 - Unexpected stream type: 0 (wantEAC3dependent: true)
2024-05-01 15:54:18.756 T:24925    info <general>: Skipped 312 duplicate messages..
2024-05-01 15:54:18.756 T:24925   debug <general>: CAEStreamParser::TrySyncAC3 - Unexpected stream type: 0 (wantEAC3dependent: true)
2024-05-01 15:54:28.804 T:24925    info <general>: Skipped 313 duplicate messages..
2024-05-01 15:54:28.804 T:24925   debug <general>: CAEStreamParser::TrySyncAC3 - Unexpected stream type: 0 (wantEAC3dependent: true)
2024-05-01 15:54:38.852 T:24925    info <general>: Skipped 313 duplicate messages..
2024-05-01 15:54:38.852 T:24925   debug <general>: CAEStreamParser::TrySyncAC3 - Unexpected stream type: 0 (wantEAC3dependent: true)
2024-05-01 15:54:48.858 T:24925    info <general>: Skipped 312 duplicate messages..
2024-05-01 15:54:48.858 T:24925   debug <general>: CAEStreamParser::TrySyncAC3 - Unexpected stream type: 0 (wantEAC3dependent: true)
2024-05-01 15:54:58.927 T:24925    info <general>: Skipped 314 duplicate messages..
2024-05-01 15:54:58.927 T:24925   debug <general>: CAEStreamParser::TrySyncAC3 - Unexpected stream type: 0 (wantEAC3dependent: true)
2024-05-01 15:55:08.928 T:24925    info <general>: Skipped 312 duplicate messages..
2024-05-01 15:55:08.928 T:24925   debug <general>: CAEStreamParser::TrySyncAC3 - Unexpected stream type: 0 (wantEAC3dependent: true)
2024-05-01 15:55:18.980 T:24925    info <general>: Skipped 313 duplicate messages..
2024-05-01 15:55:18.980 T:24925   debug <general>: CAEStreamParser::TrySyncAC3 - Unexpected stream type: 0 (wantEAC3dependent: true)
2024-05-01 15:55:23.342 T:22739    info <general>: Skipped 136 duplicate messages..
```

## How has this been tested?
Tested on Shield with EAC3 stream and cannot reproduce stutter but probably is not exactly same case, anyway log line is repeated dozens of times (PT audio works fine and Atmos is detected on AVR).

```
2024-05-01 18:19:29.402 T:1843    debug <general>: CAEStreamParser::TrySyncAC3 - Unexpected stream type: 0 (wantEAC3dependent: true)
2024-05-01 18:19:30.055 T:1931     info <general>: Skipped 20 duplicate messages..
```

## What is the effect on users?
Fixes possible issues due high CPU usage on Android devices

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
