### PR TITLE
[backport] fix gcc-14 compile issues for Omega

### DIFF
--- a/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.cpp
+++ b/xbmc/platform/posix/filesystem/SMBWSDiscoveryListener.cpp
@@ -17,6 +17,7 @@
 
 #include "platform/posix/filesystem/SMBWSDiscovery.h"
 
+#include <algorithm>
 #include <array>
 #include <chrono>
 #include <mutex>

--- a/xbmc/utils/Geometry.h
+++ b/xbmc/utils/Geometry.h
@@ -177,7 +177,7 @@ public:
     return {m_w, m_h};
   }
 
-  template<class U> explicit CSizeGen<T>(const CSizeGen<U>& rhs)
+  template<class U> explicit CSizeGen(const CSizeGen<U>& rhs)
   {
     CheckSet(static_cast<T> (rhs.m_w), static_cast<T> (rhs.m_h));
   }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
- Backport of #25106 

fix gcc-14 compile issues:
Add missing header which are no longer indirectly included by other headers, fixes build with gcc-14.
Fix an incorrect template-id as not allowed for constructor in C++20

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Gcc 14 porting background
- https://gcc.gnu.org/gcc-14/porting_to.html

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Build of Omega on LE12/13 with gcc-14.1rc

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
