### PR TITLE
[BP] AEStreamInfo: remove spammy EAC3 log line

### DIFF
--- a/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEStreamInfo.cpp
@@ -408,12 +408,7 @@ bool CAEStreamParser::TrySyncAC3(uint8_t* data,
       return false;
 
     if (strmtyp != 1 && wantEAC3dependent)
-    {
-      CLog::Log(LOGDEBUG,
-                "CAEStreamParser::TrySyncAC3 - Unexpected stream type: {} (wantEAC3dependent: {})",
-                strmtyp, wantEAC3dependent);
       return false;
-    }
 
     unsigned int framesize = (((data[2] & 0x7) << 8) | data[3]) + 1;
     uint8_t fscod = (data[4] >> 6) & 0x3;


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/25103



## What is the effect on users?
Fixes possible issues due high CPU usage on Android devices, especially when played Dolby Vision + E-AC3 / Atmos streams.



## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
