### PR TITLE
[Windows] Fix Discovery of MAC Address

### DIFF
--- a/xbmc/platform/win32/network/NetworkWin32.cpp
+++ b/xbmc/platform/win32/network/NetworkWin32.cpp
@@ -248,7 +248,7 @@ bool CNetworkWin32::PingHost(const struct sockaddr& host, unsigned int timeout_m
 
 bool CNetworkInterfaceWin32::GetHostMacAddress(unsigned long host, std::string& mac) const
 {
-  struct sockaddr sockHost;
+  sockaddr sockHost{};
   sockHost.sa_family = AF_INET;
   reinterpret_cast<struct sockaddr_in&>(sockHost).sin_addr.S_un.S_addr = host;
   return GetHostMacAddress(&sockHost, mac);
@@ -260,21 +260,19 @@ bool CNetworkInterfaceWin32::GetHostMacAddress(struct sockaddr* host, std::strin
   if (GetBestInterfaceEx(host, &InterfaceIndex) != NO_ERROR)
     return false;
 
-  NET_LUID luid = {};
+  NET_LUID luid{};
   if (ConvertInterfaceIndexToLuid(InterfaceIndex, &luid) != NO_ERROR)
     return false;
 
-  MIB_IPNET_ROW2 neighborIp = {};
+  MIB_IPNET_ROW2 neighborIp{};
   neighborIp.InterfaceLuid = luid;
-  neighborIp.InterfaceIndex;
-  neighborIp.Address.si_family = host->sa_family;
   switch (host->sa_family)
   {
     case AF_INET:
-      neighborIp.Address.Ipv4 = reinterpret_cast<const struct sockaddr_in&>(host);
+      memcpy(&neighborIp.Address.Ipv4, host, sizeof(sockaddr_in));
       break;
     case AF_INET6:
-      neighborIp.Address.Ipv6 = reinterpret_cast<const struct sockaddr_in6&>(host);
+      memcpy(&neighborIp.Address.Ipv6, host, sizeof(sockaddr_in6));
       break;
     default:
       return false;

--- a/xbmc/platform/win32/network/NetworkWin32.cpp
+++ b/xbmc/platform/win32/network/NetworkWin32.cpp
@@ -278,13 +278,20 @@ bool CNetworkInterfaceWin32::GetHostMacAddress(struct sockaddr* host, std::strin
       return false;
   }
 
-  DWORD dwRetVal = ResolveIpNetEntry2(&neighborIp, nullptr);
+  DWORD dwRetVal = GetIpNetEntry2(&neighborIp);
+
+  if (dwRetVal != NO_ERROR)
+  {
+    CLog::LogF(LOGDEBUG, "Host not found in the cache (error {}), resolve the address.", dwRetVal);
+    dwRetVal = ResolveIpNetEntry2(&neighborIp, nullptr);
+  }
 
   if (dwRetVal != NO_ERROR)
   {
     CLog::LogF(LOGERROR, "ResolveIpNetEntry2 failed with error ({})", dwRetVal);
     return false;
   }
+
   if (neighborIp.PhysicalAddressLength < MAC_LENGTH)
   {
     CLog::LogF(LOGERROR,


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Fix the CNetworkInterfaceWin32::GetHostMacAddress() function on Windows. It seems to have stopped working with PR #14369 which added support for IPv6.
A pointer dereference was missing and the wrong data was passed to the Windows API ResolveIpNetEntry2() for host discovery. It always failed with error 87 (ERROR_INVALID_PARAMETER).

For style, I could have gone the way below instead for the same result, but is it a safe way to copy structs of various sizes?
```
neighborIp.Address.Ipv4 = *reinterpret_cast<const struct sockaddr_in*>(host);
...
neighborIp.Address.Ipv6 = *reinterpret_cast<const struct sockaddr_in6*>(host);
```

Also added a small optimization to look for the host in the OS cache before hitting the wire with a resolution request.

I think this can be backported.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Should fix the broken WOL issue reported in forum https://forum.kodi.tv/showthread.php?tid=377218 and #25058.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Windows 10, IPv4.
The hosts are resolved when activating the WOL setting of Kodi, toast messages appear and a wakeonlan.xml file with valid addresses is generated.

IPv6 support is not in a shape that allows testing of MAC resolution.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Working WOL function on Windows.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
