### PR TITLE
[picture] Make picture viewer work with enabled smart redraw

### DIFF
--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -408,9 +408,12 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
 
   // if we haven't processed yet, we should mark the whole screen
   if (!HasProcessed())
+  {
     regions.emplace_back(CRect(
         0.0f, 0.0f, static_cast<float>(CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth()),
         static_cast<float>(CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight())));
+    MarkDirtyRegion();
+  }
 
   if (m_iCurrentSlide < 0 || m_iCurrentSlide >= static_cast<int>(m_slides.size()))
     m_iCurrentSlide = 0;
@@ -496,6 +499,7 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
     regions.emplace_back(CRect(
         0.0f, 0.0f, static_cast<float>(CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth()),
         static_cast<float>(CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight())));
+    MarkDirtyRegion();
     return;
   }
 
@@ -558,6 +562,9 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
   // render the current image
   if (m_Image[m_iCurrentPic]->IsLoaded())
   {
+    if (m_Image[m_iCurrentPic]->IsAnimating())
+      MarkDirtyRegion();
+
     m_Image[m_iCurrentPic]->SetInSlideshow(bSlideShow);
     m_Image[m_iCurrentPic]->Pause(!bSlideShow);
     m_Image[m_iCurrentPic]->Process(currentTime, regions);
@@ -572,6 +579,7 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
     {
       m_Image[m_iCurrentPic]->SetTransitionTime(1, IMMEDIATE_TRANSITION_TIME);
       m_bLoadNextPic = false;
+      MarkDirtyRegion();
     }
   }
 
@@ -598,6 +606,10 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
         if (m_Image[1 - m_iCurrentPic]->DisplayEffectNeedChange(effect))
           m_Image[1 - m_iCurrentPic]->Reset(effect);
       }
+
+      if (m_Image[1 - m_iCurrentPic]->IsAnimating())
+        MarkDirtyRegion();
+
       // set the appropriate transition time
       m_Image[1 - m_iCurrentPic]->SetTransitionTime(0,
                                                     m_Image[m_iCurrentPic]->GetTransitionTime(1));
@@ -980,6 +992,7 @@ bool CGUIWindowSlideShow::OnAction(const CAction &action)
   default:
     return CGUIDialog::OnAction(action);
   }
+  MarkDirtyRegion();
   return true;
 }
 

--- a/xbmc/pictures/SlideShowPicture.cpp
+++ b/xbmc/pictures/SlideShowPicture.cpp
@@ -85,6 +85,16 @@ bool CSlideShowPic::IsFinished() const
   return IsLoaded() && m_iCounter >= m_transitionEnd.start + m_transitionEnd.length;
 }
 
+bool CSlideShowPic::IsAnimating() const
+{
+  return !IsFinished() &&
+         (m_displayEffect != EFFECT_NO_TIMEOUT || // Special snowflake, doesn't work without this
+          m_iCounter < m_transitionStart.length || // Inside start transition
+          m_iCounter >= m_transitionEnd.start || // Inside end transition
+          (m_iCounter >= m_transitionTemp.start &&
+           m_iCounter < m_transitionTemp.start + m_transitionTemp.length)); // Inside display effect
+}
+
 void CSlideShowPic::SetTexture(int iSlideNumber,
                                std::unique_ptr<CTexture> pTexture,
                                DISPLAY_EFFECT dispEffect,
@@ -368,7 +378,7 @@ void CSlideShowPic::Process(unsigned int currentTime, CDirtyRegionList &dirtyreg
   }
   if (m_iCounter >= m_transitionEnd.start)
     m_bDrawNextImage = true;
-  if (m_displayEffect != EFFECT_NO_TIMEOUT || m_iCounter < m_transitionStart.length || m_iCounter >= m_transitionEnd.start || (m_iCounter >= m_transitionTemp.start && m_iCounter < m_transitionTemp.start + m_transitionTemp.length))
+  if (IsAnimating())
   {
     /* this really annoying.  there's non-stop logging when viewing a pic outside of the slideshow
     if (m_displayEffect == EFFECT_NO_TIMEOUT)

--- a/xbmc/pictures/SlideShowPicture.cpp
+++ b/xbmc/pictures/SlideShowPicture.cpp
@@ -411,7 +411,7 @@ void CSlideShowPic::Process(unsigned int currentTime, CDirtyRegionList &dirtyreg
     */
     m_iCounter++;
   }
-  if (m_iCounter > m_transitionEnd.start + m_transitionEnd.length)
+  if (m_iCounter >= m_transitionEnd.start + m_transitionEnd.length)
     m_bIsFinished = true;
 
   RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo();

--- a/xbmc/pictures/SlideShowPicture.h
+++ b/xbmc/pictures/SlideShowPicture.h
@@ -65,6 +65,7 @@ public:
 
   void Zoom(float fZoomAmount, bool immediate = false);
   void Rotate(float fRotateAngle, bool immediate = false);
+  void UpdateAlpha();
   void Pause(bool bPause);
   void SetInSlideshow(bool slideshow);
   void SetOriginalSize(int iOriginalWidth, int iOriginalHeight, bool bFullSize);

--- a/xbmc/pictures/SlideShowPicture.h
+++ b/xbmc/pictures/SlideShowPicture.h
@@ -51,6 +51,7 @@ public:
   bool DisplayEffectNeedChange(DISPLAY_EFFECT newDispEffect) const;
   bool IsStarted() const { return m_iCounter > 0; }
   bool IsFinished() const;
+  bool IsAnimating() const;
   bool DrawNextImage() const { return m_bDrawNextImage; }
 
   int GetWidth() const { return (int)m_fWidth; }

--- a/xbmc/pictures/SlideShowPicture.h
+++ b/xbmc/pictures/SlideShowPicture.h
@@ -50,7 +50,7 @@ public:
   DISPLAY_EFFECT DisplayEffect() const { return m_displayEffect; }
   bool DisplayEffectNeedChange(DISPLAY_EFFECT newDispEffect) const;
   bool IsStarted() const { return m_iCounter > 0; }
-  bool IsFinished() const { return m_bIsFinished; }
+  bool IsFinished() const;
   bool DrawNextImage() const { return m_bDrawNextImage; }
 
   int GetWidth() const { return (int)m_fWidth; }
@@ -95,7 +95,6 @@ private:
   int m_iOriginalHeight;
   int m_iSlideNumber;
   bool m_bIsLoaded;
-  bool m_bIsFinished;
   bool m_bDrawNextImage;
   bool m_bIsDirty;
   std::string m_strFileName;


### PR DESCRIPTION
## Description
Fixes the problem with the picture viewer and enabled smart redraw that has been reported in https://github.com/xbmc/xbmc/issues/25100. This PR also contains additional refactorings that I did to help me understanding the code better.

Fixes #25100.

## Motivation and context
See above.

## How has this been tested?
Browsing pictures and viewing slide shows. There are problems if videos are part of the slide show but that has already been the case before this PR and fixing those are not in scope.

## What is the effect on users?
Being able to watch pictures and picture slide shows.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
