### PR TITLE
Rendering: Set window dirty only on app thread

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -809,7 +809,16 @@ void CApplication::Render()
     return;
 
   // render gui layer
-  if (appPower->GetRenderGUI() && !m_skipGuiRender)
+  const bool renderGUI = appPower->GetRenderGUI();
+  if (m_guiRenderLastState != std::nullopt && renderGUI && m_guiRenderLastState != renderGUI)
+  {
+    CGUIComponent* gui = CServiceBroker::GetGUI();
+    if (gui)
+      CServiceBroker::GetGUI()->GetWindowManager().MarkDirty();
+  }
+  m_guiRenderLastState = renderGUI;
+
+  if (renderGUI && !m_skipGuiRender)
   {
     if (CServiceBroker::GetWinSystem()->GetGfxContext().GetStereoMode())
     {

--- a/xbmc/application/Application.h
+++ b/xbmc/application/Application.h
@@ -24,6 +24,7 @@
 #include <atomic>
 #include <chrono>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -218,6 +219,7 @@ protected:
 
   std::chrono::time_point<std::chrono::steady_clock> m_lastRenderTime;
   bool m_skipGuiRender = false;
+  std::optional<bool> m_guiRenderLastState;
 
   std::unique_ptr<MUSIC_INFO::CMusicInfoScanner> m_musicInfoScanner;
 

--- a/xbmc/application/ApplicationPowerHandling.cpp
+++ b/xbmc/application/ApplicationPowerHandling.cpp
@@ -67,12 +67,6 @@ void CApplicationPowerHandling::ResetNavigationTimer()
 
 void CApplicationPowerHandling::SetRenderGUI(bool renderGUI)
 {
-  if (renderGUI && !m_renderGUI)
-  {
-    CGUIComponent* gui = CServiceBroker::GetGUI();
-    if (gui)
-      CServiceBroker::GetGUI()->GetWindowManager().MarkDirty();
-  }
   m_renderGUI = renderGUI;
 }
 

--- a/xbmc/windowing/osx/OpenGL/WindowControllerMacOS.mm
+++ b/xbmc/windowing/osx/OpenGL/WindowControllerMacOS.mm
@@ -22,8 +22,6 @@
 
 @implementation XBMCWindowControllerMacOS
 
-bool m_inFullscreenTransition = false;
-
 - (nullable instancetype)initWithTitle:(NSString*)title defaultSize:(NSSize)size
 {
   auto frame = NSMakeRect(0, 0, size.width, size.height);
@@ -81,9 +79,6 @@ bool m_inFullscreenTransition = false;
 
 - (void)windowWillStartLiveResize:(NSNotification*)notification
 {
-  if (m_inFullscreenTransition)
-    return;
-
   std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
   if (appPort)
   {
@@ -93,9 +88,6 @@ bool m_inFullscreenTransition = false;
 
 - (void)windowDidEndLiveResize:(NSNotification*)notification
 {
-  if (m_inFullscreenTransition)
-    return;
-
   std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
   if (appPort)
   {
@@ -196,14 +188,8 @@ bool m_inFullscreenTransition = false;
   return frameSize;
 }
 
-- (void)windowWillExitFullScreen:(NSNotification*)notification
-{
-  m_inFullscreenTransition = true;
-}
-
 - (void)windowWillEnterFullScreen:(NSNotification*)pNotification
 {
-  m_inFullscreenTransition = true;
   CWinSystemOSX* winSystem = dynamic_cast<CWinSystemOSX*>(CServiceBroker::GetWinSystem());
   if (!winSystem)
     return;
@@ -241,7 +227,6 @@ bool m_inFullscreenTransition = false;
 
 - (void)windowDidExitFullScreen:(NSNotification*)pNotification
 {
-  m_inFullscreenTransition = false;
   auto winSystem = dynamic_cast<CWinSystemOSX*>(CServiceBroker::GetWinSystem());
   if (!winSystem)
     return;
@@ -268,7 +253,6 @@ bool m_inFullscreenTransition = false;
 
 - (void)windowDidEnterFullScreen:(NSNotification*)notification
 {
-  m_inFullscreenTransition = false;
   auto winSystem = dynamic_cast<CWinSystemOSX*>(CServiceBroker::GetWinSystem());
   if (!winSystem)
     return;


### PR DESCRIPTION
## Description
Makes sure the window is marked as dirty only on the rendering thread and not somewhere else (e.g. after calling setrendergui). This caused a regression for resolution change in macOS after https://github.com/xbmc/xbmc/pull/25026 since the graphical context is locked on the macos main thread (thread 1).

## Motivation and context
Fix resolution change on macOS

## How has this been tested?
Runtime tested on macOS

## What is the effect on users?
Should fix refresh rate switch on macOS without causing a deadlock. Also, drops an hack for fullscreen toggle which was caused by the same root cause.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

