### PR TITLE
[GUI] [Skins] Update ListItem.BackendInstanceName to include single-server PVR clients.

### DIFF
--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -429,7 +429,7 @@ std::string CPVRClient::GetInstanceName() const
     Addon()->GetSettingString(ADDON_SETTING_INSTANCE_NAME_VALUE, instanceName, InstanceId());
     return instanceName;
   }
-  return "";
+  return Name();
 }
 
 PVR_ERROR CPVRClient::GetDriveSpace(uint64_t& iTotal, uint64_t& iUsed) const


### PR DESCRIPTION
## Description
Update `CPVRClient::GetInstanceName()` / `ListItem.BackendInstanceName` to return the PVR name if the PVR does not support multiple instances.

## Motivation and context
When a PVR client does not support multiple instances (single-server), the solution implemented in [PR#24182](https://github.com/xbmc/xbmc/pull/24182) returns a null string.

When a mixture of multi-instance and single-server PVRs coexist, single-server PVR clients are not correctly identified via ListItem.BackendInstanceName.

## How has this been tested?
- A mix of multi-instance and single-server PVR clients were installed and enabled.
- The string returned by ListItem.BackendInstanceName was evaluated for multi-instance and single-server PVR clients. 

## What is the effect on users?
Users connecting to multiple PVR backends, including via single-server PVR clients, will more easily be able to determine EPG entries, channels, recordings, timers and timer rules originating from their various PVRs.

## Screenshots (if appropriate):
Not applicable.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
