### PR TITLE
Bump version to 21.0.1 to allow Android install on top of Play Store version

### DIFF
--- a/version.txt
+++ b/version.txt
@@ -9,8 +9,8 @@ WEBSITE http://kodi.tv
 VERSION_MAJOR 21
 VERSION_MINOR 0
 VERSION_TAG
-VERSION_CODE 21.0.0
-ADDON_API 21.0.0
+VERSION_CODE 21.0.1
+ADDON_API 21.0.1
 ADDON_REPOS repository.xbmc.org|https://mirrors.kodi.tv
 APP_PACKAGE org.xbmc.kodi
 PACKAGE_IDENTITY XBMCFoundation.Kodi


### PR DESCRIPTION
## Motivation and context

Android users has trouble installing nightly builds because Play Store version is `21.0.1` and nightly `21.0.0`

Is even worse because install may fail silently (without error) and user thinks app is updated but not.

This change is only relevant for Android.


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
