### PR TITLE
[wayland] Treat monitor physical width/height of 0 as invalid

### DIFF
--- a/xbmc/windowing/wayland/Output.cpp
+++ b/xbmc/windowing/wayland/Output.cpp
@@ -31,9 +31,9 @@ COutput::COutput(std::uint32_t globalName,
   {
     std::unique_lock<CCriticalSection> lock(m_geometryCriticalSection);
     m_position = {x, y};
-    // Some monitors report invalid (negative) values that would cause an exception
-    // with CSizeInt
-    if (physWidth < 0 || physHeight < 0)
+    // Some monitors report invalid (non-positive) values that would cause an exception
+    // with CSizeInt and/or lead to nonsensical DPI values.
+    if (physWidth <= 0 || physHeight <= 0)
       m_physicalSize = {};
     else
       m_physicalSize = {physWidth, physHeight};


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This change prevents Kodi from using a physical size of the output where one of the dimensions is 0. Otherwise, we risk dividing by 0 e.g. in `COutput::GetPixelRatioForMode()`.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On my laptop, KWin reports the physical size of the built-in display as 790x0 mm. Kodi currently accepts such dimensions (it only checks for negative values) and it must lead to some bogus calculations down the road, as evidenced by corrupted rendering of images (see screenshot). The screenshot comes from my distro's Kodi package -- when I build Kodi myself (debug and release), it immediately crashes on a failed assertion (see below).

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Without this PR, both debug and release builds of both master and Omega branches crash on a failed assertion:
```
kodi.bin: /home/kuba/projects/xbmc/xbmc/utils/MathUtils.h:68: int MathUtils::round_int(double): Assertion `x > static_cast<double>((int) (INT_MIN / 2)) - 1.0' failed.
zsh: IOT instruction (core dumped)  ./kodi.bin
```

With this PR, both debug and release builds of both master and Omega branches no longer crash due to the assertion and don't show the glitches.
 
## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
This change affects users whose Wayland compositor reports a monitor physical size with exactly 1 dimension equal to 0. For those users, this change should reduce rendering artifacts. 

## Screenshots (if appropriate):
![kodi](https://github.com/xbmc/xbmc/assets/17250100/acfe0b7f-a43b-4471-a5ae-a82c615f5d4a)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
