### PR TITLE
[video] Preserve special characters in default names of extras

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
@@ -276,9 +276,6 @@ std::string CGUIDialogVideoManagerExtras::GenerateVideoExtra(const std::string& 
   // remove file extension
   URIUtils::RemoveExtension(extrasVersion);
 
-  // remove special characters
-  extrasVersion = StringUtils::ReplaceSpecialCharactersWithSpace(extrasVersion);
-
   // trim the string
   return StringUtils::Trim(extrasVersion);
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Use filenames as is as default name of extras added to movies.

Removed the StringUtils::ReplaceSpecialCharactersWithSpace() call.

The database storage/retrieval has proper escaping of the characters and works fine without.

Maybe worth a backport as this is very self-contained change, though technically it's not a bug fix.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Noticed by forum user https://forum.kodi.tv/showthread.php?tid=337992&pid=3195791#pid3195791

The default name generated when adding an extra to a movie (through library scan or manual addition) has the special characters replaced with spaces;

special characters: .-_+,!'"/\*?#$%&@()[]{} and tab

That's not intuitive and I didn't find a good reason for that filter.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

sqlite and mariadb.

Since some of those characters cannot be naturally found in filenames (ex /), I changed the CGUIDialogVideoManagerExtras::GenerateVideoExtra() function to set a filename containing some normal text + all the special characters.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

with filename "test .- _ +, !'\"\t/\\*?#$%&@()[]{} test" injected directly in GenerateVideoExtra

Before PR:
![image](https://github.com/xbmc/xbmc/assets/489377/e4338038-a70f-4086-aaa6-2fd097bfc4aa)


After PR:
![image](https://github.com/xbmc/xbmc/assets/489377/68725958-153a-485d-8e5e-bbb83c1aae7e)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
