### PR TITLE
GBM/X11/Wayland: Implement asynchronous texture uploads

### DIFF
--- a/xbmc/GUILargeTextureManager.cpp
+++ b/xbmc/GUILargeTextureManager.cpp
@@ -13,6 +13,8 @@
 #include "commons/ilog.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/Texture.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/JobManager.h"
 #include "utils/TimeUtils.h"
 #include "utils/log.h"
@@ -65,6 +67,9 @@ bool CImageLoader::DoWork()
       if (needsChecking)
         CServiceBroker::GetTextureCache()->BackgroundCacheImage(texturePath);
 
+      if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiAsyncTextureUpload)
+        m_texture->LoadToGPUAsync();
+
       return true;
     }
 
@@ -77,7 +82,14 @@ bool CImageLoader::DoWork()
 
   // not in our texture cache or it failed to load from it, so try and load directly and then cache the result
   CServiceBroker::GetTextureCache()->CacheImage(texturePath, &m_texture);
-  return (m_texture != NULL);
+
+  if (!m_texture)
+    return false;
+
+  if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiAsyncTextureUpload)
+    m_texture->LoadToGPUAsync();
+
+  return true;
 }
 
 CGUILargeTextureManager::CLargeTexture::CLargeTexture(const std::string &path):

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -18,8 +18,6 @@
 #include "guilib/TextureBase.h"
 #include "guilib/iimage.h"
 #include "guilib/imagefactory.h"
-#include "settings/AdvancedSettings.h"
-#include "settings/SettingsComponent.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 #include "windowing/WinSystem.h"
@@ -267,22 +265,14 @@ bool CTexture::LoadIImage(IImage* pImage,
 
   ClampToEdge();
 
-  LoadToGPUAsync();
-
   return true;
 }
 
 void CTexture::LoadToGPUAsync()
 {
-  if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiAsyncTextureUpload)
-    return;
-
   // Already in main context?
   if (CServiceBroker::GetWinSystem()->HasContext())
-  {
-    LoadToGPU();
     return;
-  }
 
   if (!CServiceBroker::GetWinSystem()->BindTextureUploadContext())
     return;

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -18,8 +18,11 @@
 #include "guilib/TextureBase.h"
 #include "guilib/iimage.h"
 #include "guilib/imagefactory.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
+#include "windowing/WinSystem.h"
 #if defined(TARGET_DARWIN_EMBEDDED)
 #include <ImageIO/ImageIO.h>
 #include "filesystem/File.h"
@@ -236,26 +239,59 @@ bool CTexture::LoadIImage(IImage* pImage,
                           unsigned int width,
                           unsigned int height)
 {
-  if(pImage != NULL && pImage->LoadImageFromMemory(buffer, bufSize, width, height))
+  if (pImage == nullptr)
+    return false;
+
+  if (!pImage->LoadImageFromMemory(buffer, bufSize, width, height))
+    return false;
+
+  if (pImage->Width() == 0 || pImage->Height() == 0)
+    return false;
+
+  Allocate(pImage->Width(), pImage->Height(), XB_FMT_A8R8G8B8);
+
+  if (m_pixels == nullptr)
+    return false;
+
+  if (!pImage->Decode(m_pixels, GetTextureWidth(), GetRows(), GetPitch(), XB_FMT_A8R8G8B8))
+    return false;
+
+  if (pImage->Orientation())
+    m_orientation = pImage->Orientation() - 1;
+
+  m_hasAlpha = pImage->hasAlpha();
+  m_originalWidth = pImage->originalWidth();
+  m_originalHeight = pImage->originalHeight();
+  m_imageWidth = pImage->Width();
+  m_imageHeight = pImage->Height();
+
+  ClampToEdge();
+
+  LoadToGPUAsync();
+
+  return true;
+}
+
+void CTexture::LoadToGPUAsync()
+{
+  if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiAsyncTextureUpload)
+    return;
+
+  // Already in main context?
+  if (CServiceBroker::GetWinSystem()->HasContext())
   {
-    if (pImage->Width() > 0 && pImage->Height() > 0)
-    {
-      Allocate(pImage->Width(), pImage->Height(), XB_FMT_A8R8G8B8);
-      if (m_pixels != nullptr && pImage->Decode(m_pixels, GetTextureWidth(), GetRows(), GetPitch(), XB_FMT_A8R8G8B8))
-      {
-        if (pImage->Orientation())
-          m_orientation = pImage->Orientation() - 1;
-        m_hasAlpha = pImage->hasAlpha();
-        m_originalWidth = pImage->originalWidth();
-        m_originalHeight = pImage->originalHeight();
-        m_imageWidth = pImage->Width();
-        m_imageHeight = pImage->Height();
-        ClampToEdge();
-        return true;
-      }
-    }
+    LoadToGPU();
+    return;
   }
-  return false;
+
+  if (!CServiceBroker::GetWinSystem()->BindTextureUploadContext())
+    return;
+
+  LoadToGPU();
+
+  SyncGPU();
+
+  CServiceBroker::GetWinSystem()->UnbindTextureUploadContext();
 }
 
 bool CTexture::LoadFromMemory(unsigned int width,

--- a/xbmc/guilib/Texture.h
+++ b/xbmc/guilib/Texture.h
@@ -88,6 +88,11 @@ public:
               const unsigned char* pixels,
               bool loadToGPU);
 
+  /*! 
+   * \brief Uploads the texture to the GPU. 
+   */
+  void LoadToGPUAsync();
+
   virtual void CreateTextureObject() = 0;
   virtual void DestroyTextureObject() = 0;
   virtual void LoadToGPU() = 0;
@@ -110,8 +115,4 @@ protected:
                   unsigned int bufSize,
                   unsigned int width,
                   unsigned int height);
-  /*! 
-   * \brief Uploads the texture to the GPU. 
-   */
-  void LoadToGPUAsync();
 };

--- a/xbmc/guilib/Texture.h
+++ b/xbmc/guilib/Texture.h
@@ -91,6 +91,10 @@ public:
   virtual void CreateTextureObject() = 0;
   virtual void DestroyTextureObject() = 0;
   virtual void LoadToGPU() = 0;
+  /*! 
+   * \brief Blocks execution until the previous GFX commands have been processed.
+   */
+  virtual void SyncGPU(){};
   virtual void BindToUnit(unsigned int unit) = 0;
 
 private:
@@ -106,4 +110,8 @@ protected:
                   unsigned int bufSize,
                   unsigned int width,
                   unsigned int height);
+  /*! 
+   * \brief Uploads the texture to the GPU. 
+   */
+  void LoadToGPUAsync();
 };

--- a/xbmc/guilib/TextureGL.cpp
+++ b/xbmc/guilib/TextureGL.cpp
@@ -229,6 +229,11 @@ void CGLTexture::LoadToGPU()
   m_loadedToGPU = true;
 }
 
+void CGLTexture::SyncGPU()
+{
+  glFinish();
+}
+
 void CGLTexture::BindToUnit(unsigned int unit)
 {
   glActiveTexture(GL_TEXTURE0 + unit);

--- a/xbmc/guilib/TextureGL.h
+++ b/xbmc/guilib/TextureGL.h
@@ -24,6 +24,7 @@ public:
   void CreateTextureObject() override;
   void DestroyTextureObject() override;
   void LoadToGPU() override;
+  void SyncGPU() override;
   void BindToUnit(unsigned int unit) override;
 
 protected:

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -1226,6 +1226,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetInt(pElement, "anisotropicfiltering", m_guiAnisotropicFiltering);
     XMLUtils::GetBoolean(pElement, "fronttobackrendering", m_guiFrontToBackRendering);
     XMLUtils::GetBoolean(pElement, "geometryclear", m_guiGeometryClear);
+    XMLUtils::GetBoolean(pElement, "asynctextureupload", m_guiAsyncTextureUpload);
   }
 
   std::string seekSteps;

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -336,6 +336,8 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int32_t m_guiAnisotropicFiltering{0};
     bool m_guiFrontToBackRendering{false};
     bool m_guiGeometryClear{true};
+    bool m_guiAsyncTextureUpload{false};
+
     unsigned int m_addonPackageFolderSize;
 
     bool m_jsonOutputCompact;

--- a/xbmc/utils/EGLUtils.cpp
+++ b/xbmc/utils/EGLUtils.cpp
@@ -620,16 +620,14 @@ bool CEGLContextUtils::BindTextureUploadContext()
 
   m_textureUploadLock.lock();
 
-  if (eglMakeCurrent(m_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, m_eglUploadContext))
-  {
-    return true;
-  }
-  else
+  if (!eglMakeCurrent(m_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, m_eglUploadContext))
   {
     m_textureUploadLock.unlock();
     CLog::LogF(LOGERROR, "Couldn't bind texture upload context.");
     return false;
   }
+
+  return true;
 }
 
 bool CEGLContextUtils::UnbindTextureUploadContext()
@@ -641,14 +639,16 @@ bool CEGLContextUtils::UnbindTextureUploadContext()
     return false;
   }
 
-  bool success = eglMakeCurrent(m_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
-
-  if (!success)
-    CLog::Log(LOGERROR, "Couldn't release texture upload context");
+  if (!eglMakeCurrent(m_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT))
+  {
+    CLog::LogF(LOGERROR, "Couldn't release texture upload context");
+    m_textureUploadLock.unlock();
+    return false;
+  }
 
   m_textureUploadLock.unlock();
 
-  return success;
+  return true;
 }
 
 bool CEGLContextUtils::HasContext()

--- a/xbmc/utils/EGLUtils.cpp
+++ b/xbmc/utils/EGLUtils.cpp
@@ -428,6 +428,12 @@ bool CEGLContextUtils::CreateContext(CEGLAttributesVec contextAttribs)
     return false;
   }
 
+  m_eglUploadContext =
+      eglCreateContext(m_eglDisplay, m_eglConfig, m_eglContext, contextAttribs.Get());
+
+  if (m_eglUploadContext == EGL_NO_CONTEXT)
+    CLog::Log(LOGWARNING, "Failed to create EGL upload context");
+
   return true;
 }
 
@@ -565,6 +571,12 @@ void CEGLContextUtils::DestroyContext()
     eglDestroyContext(m_eglDisplay, m_eglContext);
     m_eglContext = EGL_NO_CONTEXT;
   }
+
+  if (m_eglUploadContext)
+  {
+    eglDestroyContext(m_eglDisplay, m_eglUploadContext);
+    m_eglUploadContext = EGL_NO_CONTEXT;
+  }
 }
 
 void CEGLContextUtils::DestroySurface()
@@ -596,4 +608,50 @@ bool CEGLContextUtils::TrySwapBuffers()
   }
 
   return (eglSwapBuffers(m_eglDisplay, m_eglSurface) == EGL_TRUE);
+}
+
+bool CEGLContextUtils::BindTextureUploadContext()
+{
+  if (m_eglDisplay == EGL_NO_DISPLAY || m_eglUploadContext == EGL_NO_CONTEXT)
+  {
+    CLog::LogF(LOGERROR, "No texture upload context found.");
+    return false;
+  }
+
+  m_textureUploadLock.lock();
+
+  if (eglMakeCurrent(m_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, m_eglUploadContext))
+  {
+    return true;
+  }
+  else
+  {
+    m_textureUploadLock.unlock();
+    CLog::LogF(LOGERROR, "Couldn't bind texture upload context.");
+    return false;
+  }
+}
+
+bool CEGLContextUtils::UnbindTextureUploadContext()
+{
+  if (m_eglDisplay == EGL_NO_DISPLAY || m_eglUploadContext == EGL_NO_CONTEXT)
+  {
+    CLog::LogF(LOGERROR, "No texture upload context found.");
+    m_textureUploadLock.unlock();
+    return false;
+  }
+
+  bool success = eglMakeCurrent(m_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+
+  if (!success)
+    CLog::Log(LOGERROR, "Couldn't release texture upload context");
+
+  m_textureUploadLock.unlock();
+
+  return success;
+}
+
+bool CEGLContextUtils::HasContext()
+{
+  return eglGetCurrentContext() != EGL_NO_CONTEXT;
 }

--- a/xbmc/utils/EGLUtils.h
+++ b/xbmc/utils/EGLUtils.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "threads/CriticalSection.h"
+
 #include <array>
 #include <set>
 #include <stdexcept>
@@ -219,6 +221,10 @@ public:
     return m_eglConfig;
   }
 
+  bool BindTextureUploadContext();
+  bool UnbindTextureUploadContext();
+  bool HasContext();
+
 private:
   void SurfaceAttrib();
 
@@ -229,4 +235,6 @@ private:
   EGLSurface m_eglSurface{EGL_NO_SURFACE};
   EGLContext m_eglContext{EGL_NO_CONTEXT};
   EGLConfig m_eglConfig{}, m_eglHDRConfig{};
+  EGLContext m_eglUploadContext{EGL_NO_CONTEXT};
+  mutable CCriticalSection m_textureUploadLock;
 };

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -260,6 +260,24 @@ public:
    */
   std::pair<bool, int> GetDitherSettings();
 
+  /*!
+   * \brief Binds a shared context to the current thread, in order to upload textures asynchronously.
+   * \return Return true if a texture upload context exists and the binding succeeds.
+   */
+  virtual bool BindTextureUploadContext() { return false; }
+
+  /*!
+   * \brief Unbinds the shared context.
+   * \return Return true if the texture upload context has been unbound.
+   */
+  virtual bool UnbindTextureUploadContext() { return false; }
+
+  /*!
+   * \brief Checks if a graphics context is already bound to the current thread.
+   * \return Return true if so.
+   */
+  virtual bool HasContext() { return false; }
+
 protected:
   void UpdateDesktopResolution(RESOLUTION_INFO& newRes, const std::string &output, int width, int height, float refreshRate, uint32_t dwFlags);
   void UpdateDesktopResolution(RESOLUTION_INFO& newRes,

--- a/xbmc/windowing/X11/GLContextEGL.cpp
+++ b/xbmc/windowing/X11/GLContextEGL.cpp
@@ -564,16 +564,14 @@ bool CGLContextEGL::BindTextureUploadContext()
 
   m_textureUploadLock.lock();
 
-  if (eglMakeCurrent(m_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, m_eglUploadContext))
-  {
-    return true;
-  }
-  else
+  if (!eglMakeCurrent(m_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, m_eglUploadContext))
   {
     m_textureUploadLock.unlock();
     CLog::LogF(LOGERROR, "Couldn't bind texture upload context.");
     return false;
   }
+
+  return true;
 }
 
 bool CGLContextEGL::UnbindTextureUploadContext()
@@ -584,11 +582,17 @@ bool CGLContextEGL::UnbindTextureUploadContext()
     m_textureUploadLock.unlock();
     return false;
   }
-  bool success = eglMakeCurrent(m_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
-  if (!success)
-    CLog::LogF(LOGERROR, "Couldn't release texture upload context.");
+
+  if (!eglMakeCurrent(m_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT))
+  {
+    CLog::LogF(LOGERROR, "Couldn't release texture upload context");
+    m_textureUploadLock.unlock();
+    return false;
+  }
+
   m_textureUploadLock.unlock();
-  return success;
+
+  return true;
 }
 
 bool CGLContextEGL::HasContext()

--- a/xbmc/windowing/X11/GLContextEGL.cpp
+++ b/xbmc/windowing/X11/GLContextEGL.cpp
@@ -14,6 +14,7 @@
 #include "GLContextEGL.h"
 
 #include "ServiceBroker.h"
+#include "commons/ilog.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/log.h"
@@ -21,11 +22,12 @@
 #include <clocale>
 #include <mutex>
 
-#include <EGL/eglext.h>
 #include <unistd.h>
 
 #include "PlatformDefs.h"
 #include "system_gl.h"
+
+#include <EGL/eglext.h>
 
 #define EGL_NO_CONFIG (EGLConfig)0
 
@@ -160,6 +162,8 @@ bool CGLContextEGL::Refresh(bool force, int screen, Window glWindow, bool &newCo
       EGL_NONE
   };
   m_eglContext = eglCreateContext(m_eglDisplay, m_eglConfig, EGL_NO_CONTEXT, contextAttributes);
+  m_eglUploadContext = eglCreateContext(m_eglDisplay, m_eglConfig, m_eglContext, contextAttributes);
+
   if (m_eglContext == EGL_NO_CONTEXT)
   {
     EGLint contextAttributes[] =
@@ -168,6 +172,8 @@ bool CGLContextEGL::Refresh(bool force, int screen, Window glWindow, bool &newCo
       EGL_NONE
     };
     m_eglContext = eglCreateContext(m_eglDisplay, m_eglConfig, EGL_NO_CONTEXT, contextAttributes);
+    m_eglUploadContext =
+        eglCreateContext(m_eglDisplay, m_eglConfig, m_eglContext, contextAttributes);
 
     if (m_eglContext == EGL_NO_CONTEXT)
     {
@@ -189,6 +195,9 @@ bool CGLContextEGL::Refresh(bool force, int screen, Window glWindow, bool &newCo
   }
 
   m_eglGetSyncValuesCHROMIUM = (PFNEGLGETSYNCVALUESCHROMIUMPROC)eglGetProcAddress("eglGetSyncValuesCHROMIUM");
+
+  if (m_eglUploadContext == EGL_NO_CONTEXT)
+    CLog::Log(LOGWARNING, "failed to create EGL upload context");
 
   m_usePB = false;
   return true;
@@ -286,6 +295,11 @@ bool CGLContextEGL::CreatePB()
     return false;
   }
 
+  m_eglUploadContext = eglCreateContext(m_eglDisplay, m_eglConfig, m_eglContext, contextAttributes);
+
+  if (m_eglUploadContext == EGL_NO_CONTEXT)
+    CLog::Log(LOGWARNING, "Failed to create EGL upload context");
+
   m_usePB = true;
   return true;
 }
@@ -298,6 +312,12 @@ void CGLContextEGL::Destroy()
     eglMakeCurrent(m_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
     eglDestroyContext(m_eglDisplay, m_eglContext);
     m_eglContext = EGL_NO_CONTEXT;
+  }
+
+  if (m_eglUploadContext)
+  {
+    eglDestroyContext(m_eglDisplay, m_eglUploadContext);
+    m_eglUploadContext = EGL_NO_CONTEXT;
   }
 
   if (m_eglSurface)
@@ -532,6 +552,48 @@ uint64_t CGLContextEGL::GetVblankTiming(uint64_t &msc, uint64_t &interval)
   }
 
   return ret;
+}
+
+bool CGLContextEGL::BindTextureUploadContext()
+{
+  if (m_eglDisplay == EGL_NO_DISPLAY || m_eglUploadContext == EGL_NO_CONTEXT)
+  {
+    CLog::LogF(LOGERROR, "No texture upload context found.");
+    return false;
+  }
+
+  m_textureUploadLock.lock();
+
+  if (eglMakeCurrent(m_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, m_eglUploadContext))
+  {
+    return true;
+  }
+  else
+  {
+    m_textureUploadLock.unlock();
+    CLog::LogF(LOGERROR, "Couldn't bind texture upload context.");
+    return false;
+  }
+}
+
+bool CGLContextEGL::UnbindTextureUploadContext()
+{
+  if (m_eglDisplay == EGL_NO_DISPLAY || m_eglUploadContext == EGL_NO_CONTEXT)
+  {
+    CLog::LogF(LOGERROR, "No texture upload context found.");
+    m_textureUploadLock.unlock();
+    return false;
+  }
+  bool success = eglMakeCurrent(m_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+  if (!success)
+    CLog::LogF(LOGERROR, "Couldn't release texture upload context.");
+  m_textureUploadLock.unlock();
+  return success;
+}
+
+bool CGLContextEGL::HasContext()
+{
+  return eglGetCurrentContext() != EGL_NO_CONTEXT;
 }
 
 void CGLContextEGL::QueryExtensions()

--- a/xbmc/windowing/X11/GLContextEGL.h
+++ b/xbmc/windowing/X11/GLContextEGL.h
@@ -9,10 +9,12 @@
 #pragma once
 
 #include "GLContext.h"
-#include "system_egl.h"
 #include "threads/CriticalSection.h"
 
 #include <cstdint>
+#include <mutex>
+
+#include "system_egl.h"
 
 #include <EGL/eglext.h>
 #ifdef HAVE_EGLEXTANGLE
@@ -35,6 +37,10 @@ public:
   void SwapBuffers() override;
   void QueryExtensions() override;
   uint64_t GetVblankTiming(uint64_t &msc, uint64_t &interval) override;
+
+  bool BindTextureUploadContext();
+  bool UnbindTextureUploadContext();
+  bool HasContext();
 
   EGLint m_renderingApi;
   EGLDisplay m_eglDisplay = EGL_NO_DISPLAY;
@@ -60,4 +66,7 @@ protected:
   CCriticalSection m_syncLock;
 
   bool m_usePB = false;
+
+  EGLContext m_eglUploadContext = EGL_NO_CONTEXT;
+  mutable CCriticalSection m_textureUploadLock;
 };

--- a/xbmc/windowing/X11/GLContextEGL.h
+++ b/xbmc/windowing/X11/GLContextEGL.h
@@ -12,7 +12,6 @@
 #include "threads/CriticalSection.h"
 
 #include <cstdint>
-#include <mutex>
 
 #include "system_egl.h"
 

--- a/xbmc/windowing/X11/WinSystemX11GLContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
@@ -112,6 +112,30 @@ EGLConfig CWinSystemX11GLContext::GetEGLConfig() const
   return static_cast<CGLContextEGL*>(m_pGLContext)->m_eglConfig;
 }
 
+bool CWinSystemX11GLContext::BindTextureUploadContext()
+{
+  if (m_pGLContext)
+    return static_cast<CGLContextEGL*>(m_pGLContext)->BindTextureUploadContext();
+  else
+    return false;
+}
+
+bool CWinSystemX11GLContext::UnbindTextureUploadContext()
+{
+  if (m_pGLContext)
+    return static_cast<CGLContextEGL*>(m_pGLContext)->UnbindTextureUploadContext();
+  else
+    return false;
+}
+
+bool CWinSystemX11GLContext::HasContext()
+{
+  if (m_pGLContext)
+    return static_cast<CGLContextEGL*>(m_pGLContext)->HasContext();
+  else
+    return false;
+}
+
 bool CWinSystemX11GLContext::SetWindow(int width, int height, bool fullscreen, const std::string &output, int *winstate)
 {
   int newwin = 0;

--- a/xbmc/windowing/X11/WinSystemX11GLContext.h
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.h
@@ -58,6 +58,10 @@ public:
   EGLContext GetEGLContext() const;
   EGLConfig GetEGLConfig() const;
 
+  bool BindTextureUploadContext() override;
+  bool UnbindTextureUploadContext() override;
+  bool HasContext() override;
+
 protected:
   bool SetWindow(int width, int height, bool fullscreen, const std::string &output, int *winstate = NULL) override;
   void PresentRenderImpl(bool rendered) override;

--- a/xbmc/windowing/X11/WinSystemX11GLESContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLESContext.cpp
@@ -92,6 +92,30 @@ EGLConfig CWinSystemX11GLESContext::GetEGLConfig() const
   return m_pGLContext->m_eglConfig;
 }
 
+bool CWinSystemX11GLESContext::BindTextureUploadContext()
+{
+  if (m_pGLContext)
+    return static_cast<CGLContextEGL*>(m_pGLContext)->BindTextureUploadContext();
+  else
+    return false;
+}
+
+bool CWinSystemX11GLESContext::UnbindTextureUploadContext()
+{
+  if (m_pGLContext)
+    return static_cast<CGLContextEGL*>(m_pGLContext)->UnbindTextureUploadContext();
+  else
+    return false;
+}
+
+bool CWinSystemX11GLESContext::HasContext()
+{
+  if (m_pGLContext)
+    return static_cast<CGLContextEGL*>(m_pGLContext)->HasContext();
+  else
+    return false;
+}
+
 bool CWinSystemX11GLESContext::SetWindow(int width, int height, bool fullscreen, const std::string& output, int* winstate)
 {
   int newwin = 0;

--- a/xbmc/windowing/X11/WinSystemX11GLESContext.h
+++ b/xbmc/windowing/X11/WinSystemX11GLESContext.h
@@ -46,6 +46,10 @@ public:
   EGLContext GetEGLContext() const;
   EGLConfig GetEGLConfig() const;
 
+  bool BindTextureUploadContext() override;
+  bool UnbindTextureUploadContext() override;
+  bool HasContext() override;
+
 protected:
   bool SetWindow(int width, int height, bool fullscreen, const std::string& output, int* winstate = nullptr) override;
   void PresentRenderImpl(bool rendered) override;

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -150,3 +150,18 @@ void CWinSystemGbmEGLContext::delete_CVaapiProxy::operator()(CVaapiProxy *p) con
 {
   VaapiProxyDelete(p);
 }
+
+bool CWinSystemGbmEGLContext::BindTextureUploadContext()
+{
+  return m_eglContext.BindTextureUploadContext();
+}
+
+bool CWinSystemGbmEGLContext::UnbindTextureUploadContext()
+{
+  return m_eglContext.UnbindTextureUploadContext();
+}
+
+bool CWinSystemGbmEGLContext::HasContext()
+{
+  return m_eglContext.HasContext();
+}

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
@@ -35,6 +35,10 @@ public:
                        RESOLUTION_INFO& res) override;
   bool DestroyWindow() override;
 
+  bool BindTextureUploadContext() override;
+  bool UnbindTextureUploadContext() override;
+  bool HasContext() override;
+
 protected:
   CWinSystemGbmEGLContext(EGLenum platform, std::string const& platformExtension)
     : CWinSystemEGL{platform, platformExtension}

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContext.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContext.cpp
@@ -102,6 +102,21 @@ bool CWinSystemWaylandEGLContext::DestroyWindowSystem()
   return CWinSystemWaylandImpl::DestroyWindowSystem();
 }
 
+bool CWinSystemWaylandEGLContext::BindTextureUploadContext()
+{
+  return m_eglContext.BindTextureUploadContext();
+}
+
+bool CWinSystemWaylandEGLContext::UnbindTextureUploadContext()
+{
+  return m_eglContext.UnbindTextureUploadContext();
+}
+
+bool CWinSystemWaylandEGLContext::HasContext()
+{
+  return m_eglContext.HasContext();
+}
+
 CSizeInt CWinSystemWaylandEGLContext::GetNativeWindowAttachedSize()
 {
   int width, height;

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContext.h
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContext.h
@@ -43,6 +43,10 @@ public:
   bool DestroyWindow() override;
   bool DestroyWindowSystem() override;
 
+  bool BindTextureUploadContext() override;
+  bool UnbindTextureUploadContext() override;
+  bool HasContext() override;
+
 protected:
   /**
    * Inheriting classes should override InitWindowSystem() without parameters


### PR DESCRIPTION
## Description
This PR implements asynchronous texture uploads, by having a helper EGL context.

## Motivation and context
Previously, the texture uploads of assets (fanart, thumbs, etc.) were synchronous with the UI rendering, despite most of the texture pipeline (reading, decoding, converting, scaling) being asynchronous. 

This meant that the main thread would need to wait for the upload to complete, which would block execution. While I don't have concrete numbers, the workload of processing a typical 1920x1080 texture (memcopy + driver stuff) could tax a low-end device for quite some time, which normally lead to dropped frames.

While there is no guarantee that async uploads will behave better, there is much more room for the driver to perform well. I expect Mesa to perform better.

The feature is currently gated behind an advanced setting:
```
<advancedsettings>
  <gui>
    <asynctextureupload>true</asynctextureupload>
  </gui>
</advancedsettings>
```

The async upload could be further refined by uploading the texture in chunks, with pauses in between. In testing, pauses between texture processing steps reduced dips in framerate, presumably by relieving stress on the memory bus. 

## How has this been tested?
Runs fine on X11 with GL and GLES.
A prototype ran fine on GBM on my Ordroid C2, but needs retesting.
Wayland is fully untested.

## What is the effect on users?
Less jank, better system performance. 

## Screenshots (if appropriate):
Estuary with synchronous (UI texture) upload disabled, only asynchronously uploaded textures are being shown (text is still synchronous):
![image](https://github.com/xbmc/xbmc/assets/30039775/6916422b-74fd-46bd-bb9a-34f411505e08)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
