### PR TITLE
[Video] Various fixes for bluray:// (and archive://) paths.

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1779,7 +1779,7 @@ void CFileItem::SetDynPath(const std::string &path)
 
 std::string CFileItem::GetBlurayPath() const
 {
-  if (VIDEO::IsBlurayPlaylist(*this))
+  if (URIUtils::IsBluray(GetDynPath()))
   {
     CURL url(GetDynPath());
     CURL url2(url.GetHostName()); // strip bluray://

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2000,7 +2000,8 @@ std::string CFileItem::GetBaseMoviePath(bool bUseFolderNames) const
     return GetLocalMetadataPath();
 
   if (bUseFolderNames &&
-     (!m_bIsFolder || URIUtils::IsInArchive(m_strPath) ||
+      (!m_bIsFolder || URIUtils::IsInArchive(m_strPath) ||
+       URIUtils::IsBluray(m_strPath) ||
      (HasVideoInfoTag() && GetVideoInfoTag()->m_iDbId > 0 && !CMediaTypes::IsContainer(GetVideoInfoTag()->m_type))))
   {
     std::string name2(strMovieName);

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1363,7 +1363,7 @@ bool CFileItem::IsSamePath(const CFileItem *item) const
     if (item->HasProperty("item_start") || HasProperty("item_start"))
       return (item->GetProperty("item_start") == GetProperty("item_start"));
     // See if we have associated a bluray playlist
-    if (VIDEO::IsBlurayPlaylist(*this) || VIDEO::IsBlurayPlaylist(*item))
+    if (URIUtils::IsBluray(this->GetDynPath()) || URIUtils::IsBluray(item->GetDynPath()))
       return (GetDynPath() == item->GetDynPath());
     return true;
   }
@@ -1783,16 +1783,7 @@ void CFileItem::SetDynPath(const std::string &path)
 std::string CFileItem::GetBlurayPath() const
 {
   if (URIUtils::IsBluray(GetDynPath()))
-  {
-    CURL url(GetDynPath());
-    CURL url2(url.GetHostName()); // strip bluray://
-    if (url2.IsProtocol("udf"))
-      // ISO
-      return url2.GetHostName(); // strip udf://
-    else if (url.IsProtocol("bluray"))
-      // BDMV
-      return url2.Get() + "BDMV/index.bdmv";
-  }
+    return URIUtils::GetBlurayPath(GetDynPath());
   return GetDynPath();
 }
 
@@ -2032,7 +2023,7 @@ std::string CFileItem::GetLocalMetadataPath() const
     return m_strPath;
 
   std::string parent{};
-  if (VIDEO::IsBlurayPlaylist(*this))
+  if (URIUtils::IsBluray(this->GetDynPath()))
     parent = URIUtils::GetParentPath(GetBlurayPath());
   else
     parent = URIUtils::GetParentPath(m_strPath);

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -883,12 +883,15 @@ bool CFileItem::Exists(bool bUseCache /* = true */) const
   if (URIUtils::IsStack(strPath))
     strPath = CStackDirectory::GetFirstStackedFile(strPath);
 
+  if (URIUtils::IsBluray(strPath) && URIUtils::GetFileName(strPath) == "menu")
+  {
+    strPath = CURL(strPath).GetHostName();
+    return CDirectory::Exists(strPath, bUseCache);
+  }
+
   if (m_bIsFolder)
     return CDirectory::Exists(strPath, bUseCache);
-  else
-    return CFile::Exists(strPath, bUseCache);
-
-  return false;
+  return CFile::Exists(strPath, bUseCache);
 }
 
 bool CFileItem::IsEPG() const

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1994,9 +1994,9 @@ std::string CFileItem::GetBaseMoviePath(bool bUseFolderNames) const
     return GetLocalMetadataPath();
 
   if (bUseFolderNames &&
-      (!m_bIsFolder || URIUtils::IsInArchive(m_strPath) ||
-       URIUtils::IsBluray(m_strPath) ||
-     (HasVideoInfoTag() && GetVideoInfoTag()->m_iDbId > 0 && !CMediaTypes::IsContainer(GetVideoInfoTag()->m_type))))
+      (!m_bIsFolder || URIUtils::IsInArchive(m_strPath) || URIUtils::IsBluray(m_strPath) ||
+       (HasVideoInfoTag() && GetVideoInfoTag()->m_iDbId > 0 &&
+        !CMediaTypes::IsContainer(GetVideoInfoTag()->m_type))))
   {
     std::string name2(strMovieName);
     URIUtils::GetParentPath(name2,strMovieName);

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -883,7 +883,7 @@ bool CFileItem::Exists(bool bUseCache /* = true */) const
   if (URIUtils::IsStack(strPath))
     strPath = CStackDirectory::GetFirstStackedFile(strPath);
 
-  if (URIUtils::IsBluray(strPath) && URIUtils::GetFileName(strPath) == "menu")
+  if (URIUtils::IsBlurayPath(strPath) && URIUtils::GetFileName(strPath) == "menu")
   {
     strPath = CURL(strPath).GetHostName();
     return CDirectory::Exists(strPath, bUseCache);
@@ -1153,7 +1153,7 @@ bool CFileItem::IsMultiPath() const
 
 bool CFileItem::IsBluray() const
 {
-  if (URIUtils::IsBluray(m_strPath))
+  if (URIUtils::IsBlurayPath(m_strPath))
     return true;
 
   CFileItem item = CFileItem(VIDEO::UTILS::GetOpticalMediaPath(*this), false);
@@ -1363,7 +1363,7 @@ bool CFileItem::IsSamePath(const CFileItem *item) const
     if (item->HasProperty("item_start") || HasProperty("item_start"))
       return (item->GetProperty("item_start") == GetProperty("item_start"));
     // See if we have associated a bluray playlist
-    if (URIUtils::IsBluray(this->GetDynPath()) || URIUtils::IsBluray(item->GetDynPath()))
+    if (URIUtils::IsBlurayPath(this->GetDynPath()) || URIUtils::IsBlurayPath(item->GetDynPath()))
       return (GetDynPath() == item->GetDynPath());
     return true;
   }
@@ -1782,7 +1782,7 @@ void CFileItem::SetDynPath(const std::string &path)
 
 std::string CFileItem::GetBlurayPath() const
 {
-  if (URIUtils::IsBluray(GetDynPath()))
+  if (URIUtils::IsBlurayPath(GetDynPath()))
     return URIUtils::GetBlurayPath(GetDynPath());
   return GetDynPath();
 }
@@ -1994,7 +1994,7 @@ std::string CFileItem::GetBaseMoviePath(bool bUseFolderNames) const
     return GetLocalMetadataPath();
 
   if (bUseFolderNames &&
-      (!m_bIsFolder || URIUtils::IsInArchive(m_strPath) || URIUtils::IsBluray(m_strPath) ||
+      (!m_bIsFolder || URIUtils::IsInArchive(m_strPath) || URIUtils::IsBlurayPath(m_strPath) ||
        (HasVideoInfoTag() && GetVideoInfoTag()->m_iDbId > 0 &&
         !CMediaTypes::IsContainer(GetVideoInfoTag()->m_type))))
   {
@@ -2023,7 +2023,7 @@ std::string CFileItem::GetLocalMetadataPath() const
     return m_strPath;
 
   std::string parent{};
-  if (URIUtils::IsBluray(this->GetDynPath()))
+  if (URIUtils::IsBlurayPath(this->GetDynPath()))
     parent = URIUtils::GetParentPath(GetBlurayPath());
   else
     parent = URIUtils::GetParentPath(m_strPath);

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1780,13 +1780,6 @@ void CFileItem::SetDynPath(const std::string &path)
   m_strDynPath = path;
 }
 
-std::string CFileItem::GetBlurayPath() const
-{
-  if (URIUtils::IsBlurayPath(GetDynPath()))
-    return URIUtils::GetBlurayPath(GetDynPath());
-  return GetDynPath();
-}
-
 void CFileItem::SetCueDocument(const CCueDocumentPtr& cuePtr)
 {
   m_cueDocument = cuePtr;
@@ -2022,19 +2015,11 @@ std::string CFileItem::GetLocalMetadataPath() const
   if (m_bIsFolder && !IsFileFolder())
     return m_strPath;
 
-  std::string parent{};
-  if (URIUtils::IsBlurayPath(this->GetDynPath()))
-    parent = URIUtils::GetParentPath(GetBlurayPath());
-  else
-    parent = URIUtils::GetParentPath(m_strPath);
-  std::string parentFolder(parent);
-  URIUtils::RemoveSlashAtEnd(parentFolder);
-  parentFolder = URIUtils::GetFileName(parentFolder);
-  if (StringUtils::EqualsNoCase(parentFolder, "VIDEO_TS") || StringUtils::EqualsNoCase(parentFolder, "BDMV"))
-  { // go back up another one
-    parent = URIUtils::GetParentPath(parent);
-  }
-  return parent;
+  if (URIUtils::IsBlurayPath(this->GetDynPath()) || VIDEO::IsDVDFile(*this) ||
+      VIDEO::IsBDFile(*this))
+    return URIUtils::GetDiscBasePath(this->GetDynPath());
+
+  return URIUtils::GetParentPath(m_strPath);
 }
 
 bool CFileItem::LoadMusicTag()

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -142,8 +142,6 @@ public:
   const std::string &GetDynPath() const;
   void SetDynPath(const std::string &path);
 
-  std::string GetBlurayPath() const;
-
   /*! \brief reset class to it's default values as per construction.
    Free's all allocated memory.
    \sa Initialize

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1901,30 +1901,27 @@ std::string CUtil::GetFrameworksPath(bool forPython)
   return strFrameworksPath;
 }
 
-void CUtil::GetVideoBasePathAndFileName(const std::string& videoPath, std::string& basePath, std::string& videoFileName)
+void CUtil::GetVideoBasePathAndFileName(const std::string& videoPath,
+                                        std::string& basePath,
+                                        std::string& videoFileName)
 {
   CFileItem item(videoPath, false);
-  videoFileName = URIUtils::ReplaceExtension(URIUtils::GetFileName(videoPath), "");
 
-  if (item.HasVideoInfoTag())
-    basePath = item.GetVideoInfoTag()->m_basePath;
-
-  if (basePath.empty() && item.IsOpticalMediaFile())
-    basePath = item.GetLocalMetadataPath();
-
-  CURL url(videoPath);
-  if (basePath.empty() && url.IsProtocol("bluray"))
+  if (item.IsOpticalMediaFile() || URIUtils::IsBlurayPath(item.GetDynPath()))
   {
-    basePath = url.GetHostName();
-    videoFileName = URIUtils::ReplaceExtension(GetTitleFromPath(url.GetHostName()), "");
-
-    url = CURL(url.GetHostName());
-    if (url.IsProtocol("udf"))
-      basePath = URIUtils::GetParentPath(url.GetHostName());
+    basePath = item.GetLocalMetadataPath();
+    videoFileName = URIUtils::ReplaceExtension(GetTitleFromPath(basePath), "");
   }
+  else
+  {
+    videoFileName = URIUtils::ReplaceExtension(URIUtils::GetFileName(videoPath), "");
 
-  if (basePath.empty())
-    basePath = URIUtils::GetBasePath(videoPath);
+    if (item.HasVideoInfoTag())
+      basePath = item.GetVideoInfoTag()->m_basePath;
+
+    if (basePath.empty())
+      basePath = URIUtils::GetBasePath(videoPath);
+  }
 }
 
 void CUtil::GetItemsToScan(const std::string& videoPath,

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -2435,7 +2435,7 @@ bool CApplication::PlayFile(CFileItem item,
   // a disc image might be Blu-Ray disc
   if (!(options.startpercent > 0.0 || options.starttime > 0.0) &&
       (VIDEO::IsBDFile(item) || item.IsDiscImage() ||
-       (forceSelection && VIDEO::IsBlurayPlaylist(item))))
+       (forceSelection && URIUtils::IsBluray(item.GetDynPath()))))
   {
     // No video selection when using external or remote players (they handle it if supported)
     const bool isSimpleMenuAllowed = [&]()

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -2435,7 +2435,7 @@ bool CApplication::PlayFile(CFileItem item,
   // a disc image might be Blu-Ray disc
   if (!(options.startpercent > 0.0 || options.starttime > 0.0) &&
       (VIDEO::IsBDFile(item) || item.IsDiscImage() ||
-       (forceSelection && URIUtils::IsBluray(item.GetDynPath()))))
+       (forceSelection && URIUtils::IsBlurayPath(item.GetDynPath()))))
   {
     // No video selection when using external or remote players (they handle it if supported)
     const bool isSimpleMenuAllowed = [&]()

--- a/xbmc/application/ApplicationPlayerCallback.cpp
+++ b/xbmc/application/ApplicationPlayerCallback.cpp
@@ -58,7 +58,7 @@ void CApplicationPlayerCallback::OnPlayBackStarted(const CFileItem& file)
   std::shared_ptr<CFileItem> itemCurrentFile;
 
   // check if VideoPlayer should set file item stream details from its current streams
-  const bool isBlu_dvd_image_or_stream = URIUtils::IsBluray(file.GetPath()) ||
+  const bool isBlu_dvd_image_or_stream = URIUtils::IsBlurayPath(file.GetPath()) ||
                                          VIDEO::IsDVDFile(file) || file.IsDiscImage() ||
                                          NETWORK::IsInternetStream(file);
 

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -267,8 +267,8 @@ bool CDVDFileInfo::CanExtract(const CFileItem& fileItem)
     return false;
 
   // mostly can't extract from discs and files from discs.
-  if (URIUtils::IsBluray(fileItem.GetPath()) || VIDEO::IsBDFile(fileItem) || fileItem.IsDVD() ||
-      fileItem.IsDiscImage() || VIDEO::IsDVDFile(fileItem, false, true))
+  if (fileItem.IsBluray() || fileItem.IsDVD() || fileItem.IsDiscImage() ||
+      VIDEO::IsDVDFile(fileItem, false, true))
     return false;
 
   // For HTTP/FTP we only allow extraction when on a LAN

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -157,7 +157,8 @@ bool CDVDInputStreamBluray::Open()
     openDisc = VIDEO::IsProtectedBlurayDisc(base);
 
     // check for a menu call for an image file
-    if (StringUtils::EqualsNoCase(filename, "menu"))
+    if (StringUtils::EqualsNoCase(filename, "menu") &&
+        !(m_item.GetStartOffset() == STARTOFFSET_RESUME && m_item.IsResumable()))
     {
       //get rid of the udf:// protocol
       CURL url2(root);

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -57,7 +57,7 @@ bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item, bool forceSelectio
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_DISC_PLAYBACK) != BD_PLAYBACK_SIMPLE_MENU)
     return true;
 
-  if (forceSelection && URIUtils::IsBluray(item.GetDynPath()))
+  if (forceSelection && URIUtils::IsBlurayPath(item.GetDynPath()))
   {
     item.SetProperty("save_dyn_path", item.GetDynPath()); // save for screen refresh later
     item.SetDynPath(item.GetBlurayPath());

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -60,7 +60,7 @@ bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item, bool forceSelectio
   if (forceSelection && URIUtils::IsBlurayPath(item.GetDynPath()))
   {
     item.SetProperty("save_dyn_path", item.GetDynPath()); // save for screen refresh later
-    item.SetDynPath(item.GetBlurayPath());
+    item.SetDynPath(URIUtils::GetBlurayFile(item.GetDynPath()));
   }
 
   if (VIDEO::IsBDFile(item))

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -57,7 +57,7 @@ bool CGUIDialogSimpleMenu::ShowPlaySelection(CFileItem& item, bool forceSelectio
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_DISC_PLAYBACK) != BD_PLAYBACK_SIMPLE_MENU)
     return true;
 
-  if (forceSelection && VIDEO::IsBlurayPlaylist(item))
+  if (forceSelection && URIUtils::IsBluray(item.GetDynPath()))
   {
     item.SetProperty("save_dyn_path", item.GetDynPath()); // save for screen refresh later
     item.SetDynPath(item.GetBlurayPath());

--- a/xbmc/filesystem/DirectoryCache.cpp
+++ b/xbmc/filesystem/DirectoryCache.cpp
@@ -164,7 +164,7 @@ void CDirectoryCache::AddFile(const std::string& strFile)
   }
 }
 
-bool CDirectoryCache::FileExists(const std::string& strFile, bool& bInCache)
+bool CDirectoryCache::FileExists(std::string strFile, bool& bInCache)
 {
   std::unique_lock<CCriticalSection> lock(m_cs);
   bInCache = false;
@@ -174,6 +174,13 @@ bool CDirectoryCache::FileExists(const std::string& strFile, bool& bInCache)
   URIUtils::RemoveSlashAtEnd(strPath);
   std::string storedPath = URIUtils::GetDirectory(strPath);
   URIUtils::RemoveSlashAtEnd(storedPath);
+
+  // For bluray:// get the underlying file (udf:// etc..)
+  if (URIUtils::IsBluray(strFile))
+  {
+    CURL url{strFile};
+    strFile = url.GetHostName() + url.GetFileName();
+  }
 
   auto i = m_cache.find(storedPath);
   if (i != m_cache.end())

--- a/xbmc/filesystem/DirectoryCache.cpp
+++ b/xbmc/filesystem/DirectoryCache.cpp
@@ -176,7 +176,7 @@ bool CDirectoryCache::FileExists(std::string strFile, bool& bInCache)
   URIUtils::RemoveSlashAtEnd(storedPath);
 
   // For bluray:// get the underlying file (udf:// etc..)
-  if (URIUtils::IsBluray(strFile))
+  if (URIUtils::IsBlurayPath(strFile))
   {
     CURL url{strFile};
     strFile = url.GetHostName() + url.GetFileName();

--- a/xbmc/filesystem/DirectoryCache.h
+++ b/xbmc/filesystem/DirectoryCache.h
@@ -49,7 +49,7 @@ namespace XFILE
     void ClearSubPaths(const std::string& strPath);
     void Clear();
     void AddFile(const std::string& strFile);
-    bool FileExists(const std::string& strPath, bool& bInCache);
+    bool FileExists(std::string strFile, bool& bInCache);
 #ifdef _DEBUG
     void PrintStats() const;
 #endif

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -284,7 +284,7 @@ bool CFile::Open(const CURL& file, const unsigned int flags)
     if (!(m_flags & READ_NO_CACHE))
     {
       const std::string pathToUrl(url.Get());
-      if (URIUtils::IsDVD(pathToUrl) || URIUtils::IsBluray(pathToUrl) ||
+      if (URIUtils::IsDVD(pathToUrl) || URIUtils::IsBlurayPath(pathToUrl) ||
           (m_flags & READ_AUDIO_VIDEO))
       {
         const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();

--- a/xbmc/utils/ArtUtils.cpp
+++ b/xbmc/utils/ArtUtils.cpp
@@ -226,7 +226,7 @@ std::string GetLocalArtBaseFilename(const CFileItem& item, bool& useFolder)
   if (item.IsMultiPath())
     strFile = CMultiPathDirectory::GetFirstPath(item.GetPath());
 
-  if (item.IsOpticalMediaFile() || URIUtils::IsBluray(file))
+  if (item.IsOpticalMediaFile() || URIUtils::IsBlurayPath(file))
   { // optical media files should be treated like folders
     useFolder = true;
     strFile = item.GetLocalMetadataPath();
@@ -279,7 +279,7 @@ std::string GetLocalFanart(const CFileItem& item)
   }
 
   // no local fanart available for these
-  if (NETWORK::IsInternetStream(item) || URIUtils::IsUPnP(file) || URIUtils::IsBluray(file) ||
+  if (NETWORK::IsInternetStream(item) || URIUtils::IsUPnP(file) || URIUtils::IsBlurayPath(file) ||
       item.IsLiveTV() || item.IsPlugin() || item.IsAddonsPath() || item.IsDVD() ||
       (URIUtils::IsFTP(file) &&
        !CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bFTPThumbs) ||

--- a/xbmc/utils/ArtUtils.cpp
+++ b/xbmc/utils/ArtUtils.cpp
@@ -226,7 +226,7 @@ std::string GetLocalArtBaseFilename(const CFileItem& item, bool& useFolder)
   if (item.IsMultiPath())
     strFile = CMultiPathDirectory::GetFirstPath(item.GetPath());
 
-  if (item.IsOpticalMediaFile())
+  if (item.IsOpticalMediaFile() || URIUtils::IsBluray(file))
   { // optical media files should be treated like folders
     useFolder = true;
     strFile = item.GetLocalMetadataPath();

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -183,29 +183,29 @@ void CSaveFileState::DoWork(CFileItem& item,
           if (!videodatabase.GetStreamDetails(dbItem) ||
               dbItem.GetVideoInfoTag()->m_streamDetails != item.GetVideoInfoTag()->m_streamDetails)
           {
-            if (!videodatabase.SetStreamDetailsForFile(item.GetVideoInfoTag()->m_streamDetails,
-                                                       progressTrackingFile))
-              videoDbSuccess = false;
-            else
-            {
-              if (URIUtils::IsProtocol(item.GetDynPath(), "bluray"))
-              {
-                if (item.GetVideoContentType() == VideoDbContentType::MOVIES)
-                {
-                  const int currentFileId{
-                      videodatabase.GetFileIdByMovie(item.GetVideoInfoTag()->m_iDbId)};
-                  videoDbSuccess = videodatabase.SetFileForMovie(item.GetDynPath(), currentFileId);
-                }
-                else if (item.GetVideoContentType() == VideoDbContentType::EPISODES)
-                {
-                  const int currentFileId{
-                      videodatabase.GetFileIdByEpisode(item.GetVideoInfoTag()->m_iDbId)};
-                  videoDbSuccess = videodatabase.SetFileForEpisode(
-                      item.GetDynPath(), item.GetVideoInfoTag()->m_iDbId, currentFileId);
-                }
-              }
-              updateListing = true;
-            }
+            videoDbSuccess = videodatabase.SetStreamDetailsForFile(
+                item.GetVideoInfoTag()->m_streamDetails, progressTrackingFile);
+            updateListing = !videoDbSuccess;
+          }
+        }
+
+        // See if fileId needs updating
+        if (URIUtils::IsProtocol(item.GetDynPath(), "bluray"))
+        {
+          if (item.GetVideoContentType() == VideoDbContentType::MOVIES)
+          {
+            const auto& tag{item.GetVideoInfoTag()};
+            const int currentFileId{videodatabase.GetFileIdByMovie(tag->m_iDbId)};
+            if (tag->m_strFileNameAndPath != item.GetDynPath())
+              videoDbSuccess = videodatabase.SetFileForMovie(item.GetDynPath(), currentFileId);
+          }
+          else if (item.GetVideoContentType() == VideoDbContentType::EPISODES)
+          {
+            const auto& tag{item.GetVideoInfoTag()};
+            const int currentFileId{videodatabase.GetFileIdByEpisode(tag->m_iDbId)};
+            if (tag->m_strFileNameAndPath != item.GetDynPath())
+              videoDbSuccess = videodatabase.SetFileForEpisode(
+                  item.GetDynPath(), item.GetVideoInfoTag()->m_iDbId, currentFileId);
           }
         }
 

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -46,8 +46,9 @@ void CSaveFileState::DoWork(CFileItem& item,
     progressTrackingFile =
         item.GetVideoInfoTag()
             ->m_strFileNameAndPath; // this variable contains removable:// suffixed by disc label+uniqueid or is empty if label not uniquely identified
-  else if (IsBlurayPlaylist(item) && (item.GetVideoContentType() == VideoDbContentType::MOVIES ||
-                                      item.GetVideoContentType() == VideoDbContentType::EPISODES))
+  else if (URIUtils::IsBluray(item.GetDynPath()) &&
+           (item.GetVideoContentType() == VideoDbContentType::MOVIES ||
+            item.GetVideoContentType() == VideoDbContentType::EPISODES))
     progressTrackingFile = item.GetDynPath();
   else if (item.HasVideoInfoTag() && IsVideoDb(item))
     progressTrackingFile =

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -46,7 +46,7 @@ void CSaveFileState::DoWork(CFileItem& item,
     progressTrackingFile =
         item.GetVideoInfoTag()
             ->m_strFileNameAndPath; // this variable contains removable:// suffixed by disc label+uniqueid or is empty if label not uniquely identified
-  else if (URIUtils::IsBluray(item.GetDynPath()) &&
+  else if (URIUtils::IsBlurayPath(item.GetDynPath()) &&
            (item.GetVideoContentType() == VideoDbContentType::MOVIES ||
             item.GetVideoContentType() == VideoDbContentType::EPISODES))
     progressTrackingFile = item.GetDynPath();
@@ -59,7 +59,7 @@ void CSaveFileState::DoWork(CFileItem& item,
     // only use original_listitem_url for Python, UPnP and Bluray sources
     std::string original = item.GetProperty("original_listitem_url").asString();
     if (URIUtils::IsPlugin(original) || URIUtils::IsUPnP(original) ||
-        URIUtils::IsBluray(item.GetPath()))
+        URIUtils::IsBlurayPath(item.GetPath()))
       progressTrackingFile = original;
   }
 

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -182,14 +182,10 @@ void CSaveFileState::DoWork(CFileItem& item,
           if (!videodatabase.GetStreamDetails(dbItem) ||
               dbItem.GetVideoInfoTag()->m_streamDetails != item.GetVideoInfoTag()->m_streamDetails)
           {
-            const int idFile = videodatabase.SetStreamDetailsForFile(
-                item.GetVideoInfoTag()->m_streamDetails, progressTrackingFile);
-
-            if (idFile == -2)
-            {
+            if (!videodatabase.SetStreamDetailsForFile(item.GetVideoInfoTag()->m_streamDetails,
+                                                       progressTrackingFile))
               videoDbSuccess = false;
-            }
-            else if (idFile > 0)
+            else
             {
               if (URIUtils::IsProtocol(item.GetDynPath(), "bluray"))
               {

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -15,7 +15,6 @@
 #include "URIUtils.h"
 #include "URL.h"
 #include "Util.h"
-#include "application/ApplicationComponents.h"
 #include "application/ApplicationStackHelper.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIMessage.h"
@@ -192,14 +191,23 @@ void CSaveFileState::DoWork(CFileItem& item,
             }
             else if (idFile > 0)
             {
+              if (URIUtils::IsProtocol(item.GetDynPath(), "bluray"))
+              {
+                if (item.GetVideoContentType() == VideoDbContentType::MOVIES)
+                {
+                  const int currentFileId{
+                      videodatabase.GetFileIdByMovie(item.GetVideoInfoTag()->m_iDbId)};
+                  videoDbSuccess = videodatabase.SetFileForMovie(item.GetDynPath(), currentFileId);
+                }
+                else if (item.GetVideoContentType() == VideoDbContentType::EPISODES)
+                {
+                  const int currentFileId{
+                      videodatabase.GetFileIdByEpisode(item.GetVideoInfoTag()->m_iDbId)};
+                  videoDbSuccess = videodatabase.SetFileForEpisode(
+                      item.GetDynPath(), item.GetVideoInfoTag()->m_iDbId, currentFileId);
+                }
+              }
               updateListing = true;
-
-              if (item.GetVideoContentType() == VideoDbContentType::MOVIES)
-                videoDbSuccess = videodatabase.SetFileForMovie(
-                    item.GetDynPath(), item.GetVideoInfoTag()->m_iDbId, idFile);
-              else if (item.GetVideoContentType() == VideoDbContentType::EPISODES)
-                videoDbSuccess = videodatabase.SetFileForEpisode(
-                    item.GetDynPath(), item.GetVideoInfoTag()->m_iDbId, idFile);
             }
           }
         }

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -455,6 +455,22 @@ std::string URIUtils::GetBasePath(const std::string& strPath)
   return strDirectory;
 }
 
+std::string URIUtils::GetBlurayPath(const std::string& path)
+{
+  if (IsBlurayPlaylist(path))
+  {
+    CURL url(path);
+    CURL url2(url.GetHostName()); // strip bluray://
+    if (url2.IsProtocol("udf"))
+      // ISO
+      return url2.GetHostName(); // strip udf://
+    if (url.IsProtocol("bluray"))
+      // BDMV
+      return url2.Get() + "BDMV/index.bdmv";
+  }
+  return path;
+}
+
 std::string URLEncodePath(const std::string& strPath)
 {
   std::vector<std::string> segments = StringUtils::Split(strPath, "/");
@@ -777,6 +793,12 @@ bool URIUtils::IsDVD(const std::string& strFile)
 #endif
 
   return false;
+}
+
+bool URIUtils::IsBlurayPlaylist(const std::string& file)
+{
+  return IsProtocol(file, "bluray") &&
+         StringUtils::EqualsNoCase(GetExtension(StringUtils::ToLower(file)), ".mpls");
 }
 
 bool URIUtils::IsStack(const std::string& strFile)

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -466,7 +466,7 @@ std::string URIUtils::GetBasePath(const std::string& strPath)
   return strDirectory;
 }
 
-std::string URIUtils::GetBlurayPath(const std::string& path)
+std::string URIUtils::GetBlurayFile(const std::string& path)
 {
   if (IsBlurayPath(path))
   {
@@ -480,6 +480,29 @@ std::string URIUtils::GetBlurayPath(const std::string& path)
       return url2.Get() + "BDMV/index.bdmv";
   }
   return path;
+}
+
+std::string URIUtils::GetDiscBase(std::string file)
+{
+  if (IsBlurayPath(file))
+    file = GetBlurayFile(file);
+
+  std::string parent{GetParentPath(file)};
+  std::string parentFolder{parent};
+  RemoveSlashAtEnd(parentFolder);
+  parentFolder = GetFileName(parentFolder);
+  if (StringUtils::EqualsNoCase(parentFolder, "VIDEO_TS") ||
+      StringUtils::EqualsNoCase(parentFolder, "BDMV"))
+    return GetParentPath(parent); // go back up another one
+  return parent;
+}
+
+std::string URIUtils::GetDiscBasePath(const std::string& file)
+{
+  std::string base{GetDiscBase(file)};
+  if (IsDiscImage(base))
+    return GetDirectory(base);
+  return base;
 }
 
 std::string URLEncodePath(const std::string& strPath)

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -330,6 +330,17 @@ bool URIUtils::GetParentPath(const std::string& strPath, std::string& strParent)
     strFile = url.GetHostName();
     return GetParentPath(strFile, strParent);
   }
+  else if (url.IsProtocol("bluray"))
+  {
+    CURL url2(url.GetHostName()); // strip bluray://
+    if (url2.IsProtocol("udf"))
+    {
+      strFile = url2.GetHostName(); // strip udf://
+      return GetParentPath(strFile, strParent);
+    }
+    strParent = url2.Get();
+    return true;
+  }
   else if (url.IsProtocol("stack"))
   {
     CStackDirectory dir;

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -468,7 +468,7 @@ std::string URIUtils::GetBasePath(const std::string& strPath)
 
 std::string URIUtils::GetBlurayPath(const std::string& path)
 {
-  if (IsBluray(path))
+  if (IsBlurayPath(path))
   {
     CURL url(path);
     CURL url2(url.GetHostName()); // strip bluray://
@@ -1210,7 +1210,7 @@ bool URIUtils::IsVideoDb(const std::string& strFile)
   return IsProtocol(strFile, "videodb");
 }
 
-bool URIUtils::IsBluray(const std::string& strFile)
+bool URIUtils::IsBlurayPath(const std::string& strFile)
 {
   return IsProtocol(strFile, "bluray");
 }

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -468,7 +468,7 @@ std::string URIUtils::GetBasePath(const std::string& strPath)
 
 std::string URIUtils::GetBlurayPath(const std::string& path)
 {
-  if (IsBlurayPlaylist(path))
+  if (IsBluray(path))
   {
     CURL url(path);
     CURL url2(url.GetHostName()); // strip bluray://
@@ -804,12 +804,6 @@ bool URIUtils::IsDVD(const std::string& strFile)
 #endif
 
   return false;
-}
-
-bool URIUtils::IsBlurayPlaylist(const std::string& file)
-{
-  return IsProtocol(file, "bluray") &&
-         StringUtils::EqualsNoCase(GetExtension(StringUtils::ToLower(file)), ".mpls");
 }
 
 bool URIUtils::IsStack(const std::string& strFile)

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -87,6 +87,8 @@ public:
    */
   static std::string GetBasePath(const std::string& strPath);
 
+  static std::string GetBlurayPath(const std::string& path);
+
   /* \brief Change the base path of a URL: fromPath/fromFile -> toPath/toFile
     Handles changes in path separator and filename URL encoding if necessary to derive toFile.
     \param fromPath the base path of the original URL
@@ -135,6 +137,7 @@ public:
   static bool IsDAV(const std::string& strFile);
   static bool IsDOSPath(const std::string &path);
   static bool IsDVD(const std::string& strFile);
+  static bool IsBlurayPlaylist(const std::string& file);
   static bool IsFTP(const std::string& strFile);
   static bool IsHTTP(const std::string& strFile, bool bTranslate = false);
   static bool IsUDP(const std::string& strFile);

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -87,7 +87,24 @@ public:
    */
   static std::string GetBasePath(const std::string& strPath);
 
-  static std::string GetBlurayPath(const std::string& path);
+  /*! \brief Given a bluray:// path, return the base .ISO or index.BDMV.
+   \param path bluray:// path.
+   \return the base .ISO or index.BDMV.
+   */
+  static std::string GetBlurayFile(const std::string& path);
+
+  /*! \brief Given a bluray:// path, return the base .ISO or folder containing the bluray file structure.
+   \param path bluray:// path.
+   \return the base .ISO or folder containing the bluray file structure.
+   \note Used to determine file/folder to delete
+   */
+  static std::string GetDiscBase(std::string file);
+
+  /*! \brief Given a bluray:// path, return the folder containing the .ISO or bluray file structure.
+   \param path bluray:// path.
+   \return the folder containing the .ISO or bluray file structure.
+   */
+  static std::string GetDiscBasePath(const std::string& file);
 
   /* \brief Change the base path of a URL: fromPath/fromFile -> toPath/toFile
     Handles changes in path separator and filename URL encoding if necessary to derive toFile.

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -180,7 +180,7 @@ public:
   static bool IsArchive(const std::string& strFile);
   static bool IsDiscImage(const std::string& file);
   static bool IsDiscImageStack(const std::string& file);
-  static bool IsBluray(const std::string& strFile);
+  static bool IsBlurayPath(const std::string& strFile);
   static bool IsAndroidApp(const std::string& strFile);
   static bool IsLibraryFolder(const std::string& strFile);
   static bool IsLibraryContent(const std::string& strFile);

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -137,7 +137,6 @@ public:
   static bool IsDAV(const std::string& strFile);
   static bool IsDOSPath(const std::string &path);
   static bool IsDVD(const std::string& strFile);
-  static bool IsBlurayPlaylist(const std::string& file);
   static bool IsFTP(const std::string& strFile);
   static bool IsHTTP(const std::string& strFile, bool bTranslate = false);
   static bool IsUDP(const std::string& strFile);

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -444,7 +444,7 @@ TEST_F(TestURIUtils, IsZIP)
 
 TEST_F(TestURIUtils, IsBluray)
 {
-  EXPECT_TRUE(URIUtils::IsBluray("bluray://path/to/file"));
+  EXPECT_TRUE(URIUtils::IsBlurayPath("bluray://path/to/file"));
 }
 
 TEST_F(TestURIUtils, AddSlashAtEnd)

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3336,18 +3336,14 @@ int CVideoDatabase::SetDetailsForMusicVideo(CVideoInfoTag& details,
   return -1;
 }
 
-int CVideoDatabase::SetStreamDetailsForFile(const CStreamDetails& details,
-                                            const std::string& strFileNameAndPath)
+bool CVideoDatabase::SetStreamDetailsForFile(const CStreamDetails& details,
+                                             const std::string& strFileNameAndPath)
 {
   // AddFile checks to make sure the file isn't already in the DB first
   int idFile = AddFile(strFileNameAndPath);
   if (idFile < 0)
-    return -1;
-  //! @todo ugly error return mechanism, fixme
-  if (SetStreamDetailsForFileId(details, idFile))
-    return idFile;
-  else
-    return -2;
+    return false;
+  return SetStreamDetailsForFileId(details, idFile);
 }
 
 bool CVideoDatabase::SetStreamDetailsForFileId(const CStreamDetails& details, int idFile) const

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3141,7 +3141,7 @@ void CVideoDatabase::DeleteFile(int idFile)
     DeleteStreamDetails(idFile);
 
     // Delete path if orphan (and not base directory - needs to remain to prevent re-adding on library update)
-    if (path >= 0 && URIUtils::IsBluray(strPath))
+    if (path >= 0 && URIUtils::IsBlurayPath(strPath))
     {
       sql = PrepareSQL("SELECT idFile FROM files JOIN path ON files.idPath = path.idPath WHERE "
                        "files.idPath = %i",
@@ -6761,7 +6761,7 @@ int CVideoDatabase::GetPlayCount(const std::string& strFilenameAndPath)
 
 int CVideoDatabase::GetPlayCount(const CFileItem &item)
 {
-  if (URIUtils::IsBluray(item.GetDynPath()))
+  if (URIUtils::IsBlurayPath(item.GetDynPath()))
     return GetPlayCount(GetFileId(item.GetDynPath()));
   return GetPlayCount(GetFileId(item));
 }
@@ -6834,7 +6834,7 @@ void CVideoDatabase::UpdateFanart(const CFileItem& item, VideoDbContentType type
 CDateTime CVideoDatabase::SetPlayCount(const CFileItem& item, int count, const CDateTime& date)
 {
   int id{-1};
-  if (URIUtils::IsBluray(item.GetDynPath()))
+  if (URIUtils::IsBlurayPath(item.GetDynPath()))
     id = AddFile(item.GetDynPath());
   else if (item.HasProperty("original_listitem_url") &&
            URIUtils::IsPlugin(item.GetProperty("original_listitem_url").asString()))
@@ -10930,7 +10930,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
             nfoFile = URIUtils::AddFileToFolder(
                                     URIUtils::GetParentPath(nfoFile),
                                     URIUtils::GetFileName(nfoFile));
-          else if (URIUtils::IsBluray(item.GetDynPath()))
+          else if (URIUtils::IsBlurayPath(item.GetDynPath()))
             nfoFile =
                 URIUtils::ReplaceExtension(URIUtils::GetBlurayPath(item.GetDynPath()), ".nfo");
 
@@ -11254,7 +11254,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
       while (!pDS->eof())
       {
         std::string file{pDS->fv("strPath").get_asString() + pDS->fv("strFileName").get_asString()};
-        if (URIUtils::IsBluray(file))
+        if (URIUtils::IsBlurayPath(file))
           file = URIUtils::GetBlurayPath(file);
         fileMap.insert({file, index});
         pDS->next();
@@ -11317,7 +11317,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
           {
             std::string nfoFile(URIUtils::ReplaceExtension(ART::GetTBNFile(item), ".nfo"));
 
-            if (URIUtils::IsBluray(item.GetDynPath()))
+            if (URIUtils::IsBlurayPath(item.GetDynPath()))
               nfoFile =
                   URIUtils::ReplaceExtension(URIUtils::GetBlurayPath(item.GetDynPath()), ".nfo");
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -10293,7 +10293,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle,
 
         // if bluray:// get actual path
         if (URIUtils::IsProtocol(fullPath, "bluray"))
-          fullPath = URIUtils::GetBlurayPath(fullPath);
+          fullPath = URIUtils::GetBlurayFile(fullPath);
 
         bool del = true;
         if (URIUtils::IsPlugin(fullPath))
@@ -10932,7 +10932,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
                                     URIUtils::GetFileName(nfoFile));
           else if (URIUtils::IsBlurayPath(item.GetDynPath()))
             nfoFile =
-                URIUtils::ReplaceExtension(URIUtils::GetBlurayPath(item.GetDynPath()), ".nfo");
+                URIUtils::ReplaceExtension(URIUtils::GetBlurayFile(item.GetDynPath()), ".nfo");
 
           if (overwrite || !CFile::Exists(nfoFile, false))
           {
@@ -11255,7 +11255,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
       {
         std::string file{pDS->fv("strPath").get_asString() + pDS->fv("strFileName").get_asString()};
         if (URIUtils::IsBlurayPath(file))
-          file = URIUtils::GetBlurayPath(file);
+          file = URIUtils::GetBlurayFile(file);
         fileMap.insert({file, index});
         pDS->next();
         index++;
@@ -11319,7 +11319,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
 
             if (URIUtils::IsBlurayPath(item.GetDynPath()))
               nfoFile =
-                  URIUtils::ReplaceExtension(URIUtils::GetBlurayPath(item.GetDynPath()), ".nfo");
+                  URIUtils::ReplaceExtension(URIUtils::GetBlurayFile(item.GetDynPath()), ".nfo");
 
             if (overwrite || !CFile::Exists(nfoFile, false))
             {

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3121,9 +3121,9 @@ void CVideoDatabase::DeleteFile(int idFile)
   if (m_pDS->eof())
   {
     // Get idPath
-    sql = PrepareSQL(
-        "SELECT path.idPath, path.strPath FROM path JOIN files ON path.idPath = files.idPath WHERE idFile = %i",
-        idFile);
+    sql = PrepareSQL("SELECT path.idPath, path.strPath FROM path JOIN files ON path.idPath = "
+                     "files.idPath WHERE idFile = %i",
+                     idFile);
     m_pDS->query(sql);
     int path{-1};
     std::string strPath;
@@ -11243,7 +11243,8 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
       }
 
       // now save the episodes from this show
-      sql = PrepareSQL("select * from episode_view where idShow=%i order by idSeason, idEpisode",tvshow.m_iDbId);
+      sql = PrepareSQL("select * from episode_view where idShow=%i order by idSeason, idEpisode",
+                       tvshow.m_iDbId);
       pDS->query(sql);
       std::string showDir(item.GetPath());
 
@@ -11260,12 +11261,13 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
         index++;
       }
 
-      for (auto file = fileMap.begin(); file != fileMap.end(); file = fileMap.upper_bound(file->first))
+      for (auto file = fileMap.begin(); file != fileMap.end();
+           file = fileMap.upper_bound(file->first))
       {
         // multi-episode files need dumping to the same XML
         CVideoInfoTag episode;
         auto episodes{fileMap.equal_range(file->first)};
-        for (auto episode_it = episodes.first; episode_it!=episodes.second; ++episode_it)
+        for (auto episode_it = episodes.first; episode_it != episodes.second; ++episode_it)
         {
           if (episode_it == episodes.first)
           {

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -10440,6 +10440,8 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle,
           if (scraper && CPluginDirectory::CheckExists(TranslateContent(scraper->Content()), path))
             exists = true;
         }
+        else if (URIUtils::IsProtocol(path, "archive"))
+          exists = CDirectory::Exists(URIUtils::GetDirectory(CURL(path).GetHostName()), false);
         else
           exists = CDirectory::Exists(path, false);
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -11357,7 +11357,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
             CServiceBroker::GetTextureCache()->Export(i.second, savedThumb, overwrite);
           }
           if (actorThumbs)
-            ExportActorThumbs(actorsDir, singlePath, episode, !singleFile, overwrite);
+            ExportActorThumbs(actorsDir, singlePath, episode, !singleFile, overwrite, tvshowDir);
         }
       }
       pDS->close();
@@ -11426,12 +11426,14 @@ void CVideoDatabase::ExportActorThumbs(const std::string& path,
                                        const std::string& singlePath,
                                        const CVideoInfoTag& tag,
                                        bool singleFiles,
-                                       bool overwrite /*=false*/) const
+                                       bool overwrite /* =false */,
+                                       const std::string& tvshowDir /* ="" */) const
 {
   std::string strPath(path);
   if (singleFiles)
   {
-    strPath = URIUtils::AddFileToFolder(singlePath, ".actors");
+    strPath = URIUtils::AddFileToFolder(
+        tag.m_type == MediaTypeEpisode && !tvshowDir.empty() ? tvshowDir : singlePath, ".actors");
     if (!CDirectory::Exists(strPath))
     {
       CDirectory::Create(strPath);

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3093,6 +3093,13 @@ bool CVideoDatabase::SetFileForMovie(const std::string& fileAndPath, const int o
     sql = PrepareSQL("UPDATE art SET media_id=%i WHERE media_id=%i AND media_type='videoversion'",
                      idFile, oldIdFile);
     m_pDS->exec(sql);
+    sql = PrepareSQL("SELECT idFile FROM streamdetails WHERE idFile = %i", idFile);
+    m_pDS->query(sql);
+    if (m_pDS->eof())
+    {
+      sql = PrepareSQL("UPDATE streamdetails SET idFile=%i WHERE idFile=%i", idFile, oldIdFile);
+      m_pDS->exec(sql);
+    }
     DeleteFile(oldIdFile);
 
     return true;

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -947,7 +947,8 @@ public:
                          const std::string& singlePath,
                          const CVideoInfoTag& tag,
                          bool singleFiles,
-                         bool overwrite = false) const;
+                         bool overwrite = false,
+                         const std::string& tvshowDir = "") const;
   void ImportFromXML(const std::string &path);
   void DumpToDummyFiles(const std::string &path);
   bool ImportArtFromXML(const TiXmlNode *node, std::map<std::string, std::string> &artwork);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -592,8 +592,8 @@ public:
                            const std::map<std::string, std::string>& artwork,
                            int idShow,
                            int idEpisode = -1);
-  bool SetFileForEpisode(const std::string& fileAndPath, int idEpisode, int idFile);
-  bool SetFileForMovie(const std::string& fileAndPath, int idMovie, int idFile);
+  bool SetFileForEpisode(const std::string& fileAndPath, const int idEpisode, const int oldIdFile);
+  bool SetFileForMovie(const std::string& fileAndPath, const int oldIdFile);
   int SetDetailsForMusicVideo(CVideoInfoTag& details,
                               const std::map<std::string, std::string>& artwork,
                               int idMVideo = -1);
@@ -604,7 +604,7 @@ public:
    * \param[in] idFile Identifier of the file
    * \return operation success. true for success, false for failure
    */
-  bool SetStreamDetailsForFileId(const CStreamDetails& details, int idFile);
+  bool SetStreamDetailsForFileId(const CStreamDetails& details, int idFile) const;
 
   bool SetSingleValue(VideoDbContentType type, int dbId, int dbField, const std::string& strValue);
   bool SetSingleValue(VideoDbContentType type,
@@ -637,6 +637,7 @@ public:
   void UpdateFanart(const CFileItem& item, VideoDbContentType type);
   void DeleteSet(int idSet);
   void DeleteTag(int idTag, VideoDbContentType mediaType);
+  void DeleteFile(int idFile);
 
   /*! \brief Get video settings for the specified file id
    \param idFile file id to get the settings for
@@ -1149,9 +1150,11 @@ public:
   bool UpdateAssetsOwner(const std::string& mediaType, int dbIdSource, int dbIdTarget);
 
   int GetMovieId(const std::string& strFilenameAndPath);
+  int GetMovieId(const int fileId) const;
   std::string GetMovieTitle(int idMovie);
   void GetSameVideoItems(const CFileItem& item, CFileItemList& items);
-  int GetFileIdByMovie(int idMovie);
+  int GetFileIdByMovie(int idMovie) const;
+  int GetFileIdByEpisode(int idEpisode) const;
   std::string GetFileBasePathById(int idFile);
 
   /*!

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -944,10 +944,10 @@ public:
 
   void ExportToXML(const std::string &path, bool singleFile = true, bool images=false, bool actorThumbs=false, bool overwrite=false);
   void ExportActorThumbs(const std::string& path,
+                         const std::string& singlePath,
                          const CVideoInfoTag& tag,
                          bool singleFiles,
-                         bool overwrite = false,
-                         const std::string& tvshowDir = "") const;
+                         bool overwrite = false) const;
   void ImportFromXML(const std::string &path);
   void DumpToDummyFiles(const std::string &path);
   bool ImportArtFromXML(const TiXmlNode *node, std::map<std::string, std::string> &artwork);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -597,7 +597,8 @@ public:
   int SetDetailsForMusicVideo(CVideoInfoTag& details,
                               const std::map<std::string, std::string>& artwork,
                               int idMVideo = -1);
-  int SetStreamDetailsForFile(const CStreamDetails& details, const std::string& strFileNameAndPath);
+  bool SetStreamDetailsForFile(const CStreamDetails& details,
+                               const std::string& strFileNameAndPath);
   /*!
    * \brief Clear any existing stream details and add the new provided details to a file.
    * \param[in] details New stream details

--- a/xbmc/video/VideoFileItemClassify.cpp
+++ b/xbmc/video/VideoFileItemClassify.cpp
@@ -72,11 +72,6 @@ bool IsProtectedBlurayDisc(const CFileItem& item)
   return CFileUtils::Exists(path);
 }
 
-bool IsBlurayPlaylist(const CFileItem& item)
-{
-  return StringUtils::EqualsNoCase(URIUtils::GetExtension(item.GetDynPath()), ".mpls");
-}
-
 bool IsSubtitle(const CFileItem& item)
 {
   return URIUtils::HasExtension(item.GetPath(),

--- a/xbmc/video/VideoFileItemClassify.h
+++ b/xbmc/video/VideoFileItemClassify.h
@@ -25,9 +25,6 @@ bool IsDVDFile(const CFileItem& item, bool bVobs = true, bool bIfos = true);
 //! \brief Checks whether item points to a protected blu-ray disc.
 bool IsProtectedBlurayDisc(const CFileItem& item);
 
-//! \brief Checks whether item points to a blu-ray playlist (.mpls)
-bool IsBlurayPlaylist(const CFileItem& item);
-
 //! \brief Check whether an item is a subtitle file.
 bool IsSubtitle(const CFileItem& item);
 

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -197,7 +197,7 @@ bool CVideoInfoTag::Save(TiXmlNode *node, const std::string &tag, bool savePathI
     XMLUtils::SetString(movie, "filenameandpath", m_strFileNameAndPath);
     XMLUtils::SetString(movie, "basepath", m_basePath);
   }
-  else if (URIUtils::IsBluray(m_strFileNameAndPath))
+  else if (URIUtils::IsBlurayPath(m_strFileNameAndPath))
   {
     CURL url{m_strFileNameAndPath};
     XMLUtils::SetString(movie, "relativefilename", url.GetFileName());

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -9,17 +9,17 @@
 #include "VideoInfoTag.h"
 
 #include "ServiceBroker.h"
+#include "URL.h"
 #include "guilib/LocalizeStrings.h"
 #include "imagefiles/ImageFileURL.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/Archive.h"
 #include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
-#include "utils/URIUtils.h"
-#include "URL.h"
 #include "video/VideoManagerTypes.h"
 
 #include <algorithm>

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -18,6 +18,8 @@
 #include "utils/Variant.h"
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
+#include "utils/URIUtils.h"
+#include "URL.h"
 #include "video/VideoManagerTypes.h"
 
 #include <algorithm>
@@ -194,6 +196,11 @@ bool CVideoInfoTag::Save(TiXmlNode *node, const std::string &tag, bool savePathI
     XMLUtils::SetString(movie, "path", m_strPath);
     XMLUtils::SetString(movie, "filenameandpath", m_strFileNameAndPath);
     XMLUtils::SetString(movie, "basepath", m_basePath);
+  }
+  else if (URIUtils::IsBluray(m_strFileNameAndPath))
+  {
+    CURL url{m_strFileNameAndPath};
+    XMLUtils::SetString(movie, "relativefilename", url.GetFileName());
   }
   if (!m_strEpisodeGuide.empty())
   {
@@ -1138,6 +1145,10 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
 
   if (XMLUtils::GetString(movie, "filenameandpath", value))
     SetFileNameAndPath(value);
+  else if (XMLUtils::GetString(movie, "relativefilename", value))
+  {
+    SetFile(value);
+  }
 
   if (XMLUtils::GetDate(movie, "premiered", m_premiered))
   {

--- a/xbmc/video/VideoUtils.cpp
+++ b/xbmc/video/VideoUtils.cpp
@@ -63,7 +63,7 @@ std::string FindTrailer(const CFileItem& item)
   }
 
   // no local trailer available for these
-  if (NETWORK::IsInternetStream(item) || URIUtils::IsUPnP(strFile) || URIUtils::IsBluray(strFile) ||
+  if (NETWORK::IsInternetStream(item) || URIUtils::IsUPnP(strFile) || URIUtils::IsBlurayPath(strFile) ||
       item.IsLiveTV() || item.IsPlugin() || item.IsDVD())
     return "";
 

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1472,6 +1472,8 @@ bool CGUIDialogVideoInfo::DeleteVideoItem(const std::shared_ptr<CFileItem>& item
         strDeletePath = URIUtils::GetDirectory(strDeletePath);
       }
     }
+    else if (URIUtils::IsBlurayPath(strDeletePath))
+      strDeletePath = URIUtils::GetDiscBase(strDeletePath);
     if (URIUtils::HasSlashAtEnd(strDeletePath))
       item->m_bIsFolder = true;
 

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -64,7 +64,6 @@
 #include "video/dialogs/GUIDialogVideoManagerVersions.h"
 #include "video/guilib/VideoGUIUtils.h"
 #include "video/guilib/VideoPlayActionProcessor.h"
-#include "video/guilib/VideoVersionHelper.h"
 #include "video/windows/GUIWindowVideoNav.h"
 
 #include <algorithm>
@@ -1463,16 +1462,7 @@ bool CGUIDialogVideoInfo::DeleteVideoItem(const std::shared_ptr<CFileItem>& item
   {
     std::string strDeletePath = item->GetVideoInfoTag()->GetPath();
 
-    if (StringUtils::EqualsNoCase(URIUtils::GetFileName(strDeletePath), "VIDEO_TS.IFO"))
-    {
-      strDeletePath = URIUtils::GetDirectory(strDeletePath);
-      if (StringUtils::EndsWithNoCase(strDeletePath, "video_ts/"))
-      {
-        URIUtils::RemoveSlashAtEnd(strDeletePath);
-        strDeletePath = URIUtils::GetDirectory(strDeletePath);
-      }
-    }
-    else if (URIUtils::IsBlurayPath(strDeletePath))
+    if (URIUtils::IsBlurayPath(strDeletePath) || VIDEO::IsDVDFile(*item) || VIDEO::IsBDFile(*item))
       strDeletePath = URIUtils::GetDiscBase(strDeletePath);
     if (URIUtils::HasSlashAtEnd(strDeletePath))
       item->m_bIsFolder = true;

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -838,7 +838,7 @@ void CGUIWindowVideoBase::GetContextButtons(int itemNumber, CContextButtons &but
       }
       if (PLAYLIST::IsSmartPlayList(*item) || PLAYLIST::IsSmartPlayList(*m_vecItems))
         buttons.Add(CONTEXT_BUTTON_EDIT_SMART_PLAYLIST, 586);
-      if (URIUtils::IsBluray(item->GetDynPath()))
+      if (URIUtils::IsBlurayPath(item->GetDynPath()))
         buttons.Add(CONTEXT_BUTTON_CHOOSE_PLAYLIST, 13424);
     }
   }

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -838,7 +838,7 @@ void CGUIWindowVideoBase::GetContextButtons(int itemNumber, CContextButtons &but
       }
       if (PLAYLIST::IsSmartPlayList(*item) || PLAYLIST::IsSmartPlayList(*m_vecItems))
         buttons.Add(CONTEXT_BUTTON_EDIT_SMART_PLAYLIST, 586);
-      if (VIDEO::IsBlurayPlaylist(*item))
+      if (URIUtils::IsBluray(item->GetDynPath()))
         buttons.Add(CONTEXT_BUTTON_CHOOSE_PLAYLIST, 13424);
     }
   }


### PR DESCRIPTION
## Description

Following on from discussion in #24720 (as amended by discussion below).

Fixes:
- bluray:// path not updated if more than one videoversion
- videoversions would be readded after library scan after bluray:// path assigned
- library clean coud remove bluray:// paths (and archive:// paths)
- now removes orphan `file` and `path` entries
- information diaglog refresh used wrong movie name
- choose playlist option missing if stopped in menu
- import/export of bluray:// containing items
- fix resume when played through menu
- fix could not delete bluray:// when removing from library and rename/delete enabled

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
