### PR TITLE
[PVR][guilib][Estuary] Guide window improvement

### DIFF
--- a/addons/skin.estuary/xml/Includes_PVR.xml
+++ b/addons/skin.estuary/xml/Includes_PVR.xml
@@ -526,6 +526,53 @@
 			<visible>!String.IsEmpty(PVR.ChannelNumberInput)</visible>
 		</control>
 	</include>
+	<include name="EpgEventDetails">
+		<definition>
+			<control type="group">
+				<top>0</top>
+				<left>350</left>
+				<right>$PARAM[right]</right>
+				<control type="label">
+					<width>100%</width>
+					<height>30</height>
+					<label>[B]$INFO[ListItem.EpgEventTitle][/B] $INFO[ListItem.Year,([COLOR grey],[/COLOR])]</label>
+				</control>
+				<control type="label">
+					<top>35</top>
+					<width>100%</width>
+					<height>30</height>
+					<label>$VAR[FlagDashLabel][I][COLOR grey]$VAR[SeasonEpisodeLabel][/COLOR]$INFO[ListItem.EpisodeName,[COLOR white],[/COLOR]][/I]</label>
+				</control>
+			</control>
+			<control type="textbox">
+				<left>350</left>
+				<top>85</top>
+				<right>$PARAM[right]</right>
+				<height>130</height>
+				<align>justify</align>
+				<label>$INFO[ListItem.Plot]</label>
+				<autoscroll delay="10000" time="3000" repeat="10000">Skin.HasSetting(AutoScroll)</autoscroll>
+			</control>
+			<control type="group">
+				<top>220</top>
+				<left>350</left>
+				<control type="label">
+					<top>0</top>
+					<width>25%</width>
+					<height>30</height>
+					<label>$INFO[ListItem.StartTime,[COLOR button_focus]$LOCALIZE[555]:[/COLOR] ]$INFO[ListItem.EndTime, - ]</label>
+				</control>
+				<control type="label">
+					<top>0</top>
+					<right>$PARAM[right]</right>
+					<width>75%</width>
+					<height>30</height>
+					<align>right</align>
+					<label>$INFO[ListItem.Genre,[COLOR button_focus]$LOCALIZE[515]:[/COLOR] ]</label>
+				</control>
+			</control>
+		</definition>
+	</include>
 	<include name="EpgGrid">
 		<definition>
 			<control type="epggrid" id="$PARAM[control_id]">

--- a/addons/skin.estuary/xml/MyPVRGuide.xml
+++ b/addons/skin.estuary/xml/MyPVRGuide.xml
@@ -178,47 +178,29 @@
 						<height>250</height>
 						<aspectratio align="center" aligny="center">keep</aspectratio>
 						<fadetime>400</fadetime>
-						<texture>$INFO[ListItem.Icon]</texture>
+						<texture>$INFO[ListItem.ChannelLogo]</texture>
 					</control>
 					<control type="group">
-						<top>0</top>
-						<left>350</left>
-						<control type="label">
-							<width>70%</width>
-							<height>30</height>
-							<label>[B]$INFO[ListItem.EpgEventTitle][/B] $INFO[ListItem.Year,([COLOR grey],[/COLOR])]</label>
-						</control>
-						<control type="label">
-							<top>0</top>
-							<right>30</right>
-							<width>30%</width>
-							<height>30</height>
-							<align>right</align>
-							<label>[COLOR button_focus]$INFO[ListItem.StartTime,[COLOR grey]$LOCALIZE[555]:[/COLOR] ][/COLOR]$INFO[ListItem.EndTime,[COLOR button_focus] - ,[/COLOR]]</label>
-						</control>
-						<control type="label">
-							<top>35</top>
-							<width>60%</width>
-							<height>30</height>
-							<label>$VAR[FlagDashLabel][I][COLOR grey]$VAR[SeasonEpisodeLabel][/COLOR]$INFO[ListItem.EpisodeName,[COLOR white],[/COLOR]][/I]</label>
-						</control>
-						<control type="label">
-							<top>35</top>
-							<right>30</right>
-							<width>40%</width>
-							<height>30</height>
-							<align>right</align>
-							<label>$INFO[ListItem.Genre,[COLOR grey]$LOCALIZE[515]:[/COLOR] ]</label>
-						</control>
+						<visible>String.IsEmpty(ListItem.EpgEventIcon)</visible>
+						<include content="EpgEventDetails">
+							<param name="right" value="30"/>
+						</include>
 					</control>
-					<control type="textbox">
-						<left>350</left>
-						<top>85</top>
+					<control type="group">
+						<visible>!String.IsEmpty(ListItem.EpgEventIcon)</visible>
+						<include content="EpgEventDetails">
+							<param name="right" value="350"/>
+						</include>
+					</control>
+					<control type="image">
+						<top>10</top>
 						<right>30</right>
-						<height>170</height>
-						<align>justify</align>
-						<label>$INFO[ListItem.Plot]</label>
-						<autoscroll delay="10000" time="3000" repeat="10000">Skin.HasSetting(AutoScroll)</autoscroll>
+						<width>290</width>
+						<height>250</height>
+						<aspectratio align="center" aligny="center">keep</aspectratio>
+						<fadetime>400</fadetime>
+						<texture>$INFO[ListItem.EpgEventIcon]</texture>
+						<visible>!String.IsEmpty(ListItem.EpgEventIcon)</visible>
 					</control>
 				</control>
 			</control>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -2788,6 +2788,14 @@ const infomap musicpartymode[] = {{ "enabled",           MUSICPM_ENABLED },
 ///     @return The channel name of the radio programme that's currently playing (PVR).
 ///     <p>
 ///   }
+///   \table_row3{   <b>`MusicPlayer.ChannelLogo`</b>,
+///                  \anchor MusicPlayer_ChannelLogo
+///                  _string_,
+///     @return The path for the logo of the currently playing radio channel\, if available (PVR).
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link MusicPlayer_ChannelLogo `MusicPlayer.ChannelLogo`\endlink
+///     <p>
+///   }
 ///   \table_row3{   <b>`MusicPlayer.ChannelNumberLabel`</b>,
 ///                  \anchor MusicPlayer_ChannelNumberLabel
 ///                  _string_,
@@ -2877,6 +2885,7 @@ const infomap musicpartymode[] = {{ "enabled",           MUSICPM_ENABLED },
 /// \table_end
 ///
 /// -----------------------------------------------------------------------------
+// clang-format off
 const infomap musicplayer[] =    {{ "title",            MUSICPLAYER_TITLE },
                                   { "album",            MUSICPLAYER_ALBUM },
                                   { "artist",           MUSICPLAYER_ARTIST },
@@ -2911,6 +2920,7 @@ const infomap musicplayer[] =    {{ "title",            MUSICPLAYER_TITLE },
                                   { "playcount",        MUSICPLAYER_PLAYCOUNT },
                                   { "lastplayed",       MUSICPLAYER_LASTPLAYED },
                                   { "channelname",      MUSICPLAYER_CHANNEL_NAME },
+                                  { "channellogo",      MUSICPLAYER_CHANNEL_LOGO },
                                   { "channelnumberlabel", MUSICPLAYER_CHANNEL_NUMBER },
                                   { "channelgroup",     MUSICPLAYER_CHANNEL_GROUP },
                                   { "dbid",             MUSICPLAYER_DBID },
@@ -2922,6 +2932,7 @@ const infomap musicplayer[] =    {{ "title",            MUSICPLAYER_TITLE },
                                   { "totaldiscs",       MUSICPLAYER_TOTALDISCS },
                                   { "station",          MUSICPLAYER_STATIONNAME }
 };
+// clang-format on
 
 /// \page modules__infolabels_boolean_conditions
 /// \subsection modules__infolabels_boolean_conditions_Videoplayer Video player
@@ -3850,6 +3861,14 @@ const infomap musicplayer[] =    {{ "title",            MUSICPLAYER_TITLE },
 ///     @return The name of the currently tuned channel (PVR).
 ///     <p>
 ///   }
+///   \table_row3{   <b>`VideoPlayer.ChannelLogo`</b>,
+///                  \anchor VideoPlayer_ChannelLogo
+///                  _string_,
+///     @return The path for the logo of the currently playing TV channel\, if available (PVR).
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link VideoPlayer_ChannelLogo `VideoPlayer.ChannelLogo`\endlink
+///     <p>
+///   }
 ///   \table_row3{   <b>`VideoPlayer.ChannelNumberLabel`</b>,
 ///                  \anchor VideoPlayer_ChannelNumberLabel
 ///                  _string_,
@@ -3996,6 +4015,7 @@ const infomap videoplayer[] =    {{ "title",            VIDEOPLAYER_TITLE },
                                   { "nextendtime",      VIDEOPLAYER_NEXT_ENDTIME },
                                   { "nextduration",     VIDEOPLAYER_NEXT_DURATION },
                                   { "channelname",      VIDEOPLAYER_CHANNEL_NAME },
+                                  { "channellogo",      VIDEOPLAYER_CHANNEL_LOGO },
                                   { "channelnumberlabel", VIDEOPLAYER_CHANNEL_NUMBER },
                                   { "channelgroup",     VIDEOPLAYER_CHANNEL_GROUP },
                                   { "hasepg",           VIDEOPLAYER_HAS_EPG },
@@ -5974,6 +5994,14 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     @return The name of current selected TV channel in a container.
 ///     <p>
 ///   }
+///   \table_row3{   <b>`ListItem.ChannelLogo`</b>,
+///                  \anchor ListItem_ChannelLogo
+///                  _string_,
+///     @return The path for the logo of the currently selected radio or TV channel\, if available (PVR).
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link ListItem_ChannelLogo `ListItem.ChannelLogo`\endlink
+///     <p>
+///   }
 ///   \table_row3{   <b>`ListItem.VideoCodec`</b>,
 ///                  \anchor ListItem_VideoCodec
 ///                  _string_,
@@ -7127,6 +7155,7 @@ const infomap listitem_labels[]= {{ "thumb",            LISTITEM_THUMB },
                                   { "nextenddate",      LISTITEM_NEXT_ENDDATE },
                                   { "nextduration",     LISTITEM_NEXT_DURATION },
                                   { "channelname",      LISTITEM_CHANNEL_NAME },
+                                  { "channellogo",      LISTITEM_CHANNEL_LOGO },
                                   { "channelnumberlabel", LISTITEM_CHANNEL_NUMBER },
                                   { "channelgroup",     LISTITEM_CHANNEL_GROUP },
                                   { "hasepg",           LISTITEM_HAS_EPG },

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -224,6 +224,9 @@
 #define MUSICPLAYER_CONTENT         246
 #define MUSICPLAYER_ISMULTIDISC     247
 
+// More Musicplayer infolabels
+#define MUSICPLAYER_CHANNEL_LOGO 248
+
 // Videoplayer infolabels
 #define VIDEOPLAYER_HDR_TYPE          249
 // Keep videoplayer infolabels that work with offset and position together
@@ -317,6 +320,9 @@
 #define RETROPLAYER_VIDEO_FILTER      330
 #define RETROPLAYER_STRETCH_MODE      331
 #define RETROPLAYER_VIDEO_ROTATION    332
+
+// More PVR infolabels
+#define VIDEOPLAYER_CHANNEL_LOGO 333
 
 #define CONTAINER_HAS_PARENT_ITEM    341
 #define CONTAINER_CAN_FILTER         342
@@ -981,6 +987,7 @@ static constexpr unsigned int SYSTEM_LOCALE = 1012;
 #define LISTITEM_HASVIDEOEXTRAS     (LISTITEM_START + 216)
 #define LISTITEM_PVR_CLIENT_NAME    (LISTITEM_START + 217)
 #define LISTITEM_PVR_INSTANCE_NAME  (LISTITEM_START + 218)
+#define LISTITEM_CHANNEL_LOGO       (LISTITEM_START + 219)
 
 #define LISTITEM_END                (LISTITEM_START + 2500)
 

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -425,6 +425,9 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
       case LISTITEM_CHANNEL_NAME:
         strValue = timer->ChannelName();
         return true;
+      case LISTITEM_CHANNEL_LOGO:
+        strValue = timer->ChannelIcon();
+        return true;
       case LISTITEM_PVR_CLIENT_NAME:
         strValue = CServiceBroker::GetPVRManager().GetClient(timer->ClientID())->GetClientName();
         return true;
@@ -485,7 +488,6 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
         if (recording->HasExpirationTime())
         {
           strValue = GetAsLocalizedTimeString(recording->ExpirationTimeAsLocalTime());
-          ;
           return true;
         }
         break;
@@ -519,6 +521,18 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
         if (groupMember)
         {
           strValue = groupMember->ChannelNumber().FormattedChannelNumber();
+          return true;
+        }
+        break;
+      }
+      case VIDEOPLAYER_CHANNEL_LOGO:
+      case LISTITEM_CHANNEL_LOGO:
+      {
+        const std::shared_ptr<const CPVRChannelGroupMember> groupMember =
+            CServiceBroker::GetPVRManager().Get<PVR::GUI::Channels>().GetChannelGroupMember(*item);
+        if (groupMember)
+        {
+          strValue = groupMember->Channel()->IconPath();
           return true;
         }
         break;
@@ -815,12 +829,16 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
           if (!strValue.empty())
             return true;
         }
-        // fall-thru is intended
         [[fallthrough]];
       }
       case VIDEOPLAYER_CHANNEL_NAME:
       case LISTITEM_CHANNEL_NAME:
         strValue = channel->ChannelName();
+        return true;
+      case MUSICPLAYER_CHANNEL_LOGO:
+      case VIDEOPLAYER_CHANNEL_LOGO:
+      case LISTITEM_CHANNEL_LOGO:
+        strValue = channel->IconPath();
         return true;
       case MUSICPLAYER_CHANNEL_NUMBER:
       case VIDEOPLAYER_CHANNEL_NUMBER:


### PR DESCRIPTION
Motivation: Currently, the Guide window can either display the channel logo or a thumbnail of the programme. If both graphics are available, thumbnail will be preferred. In the fullscreen live TV OSD however, we can show both graphics already:

![screenshot00004](https://github.com/xbmc/xbmc/assets/3226626/f3950089-f1d0-4bae-8d89-ed74431f03f2)

This PR aligns the guide window content with the OSD contain by adding support for channel logo and programme thumbnail, similar to the OSD.

**Before:**
![screenshot00003](https://github.com/xbmc/xbmc/assets/3226626/3cbe9ffb-0cfa-4fb9-9bed-c17ef2be88e8)

**After:**
![screenshot00005](https://github.com/xbmc/xbmc/assets/3226626/0221c7b6-b783-4533-8a11-50575d876688)

In case only channel logo is available, guide window will look like before, channel logo on the left, text area spans to right border of screen.

For this, **new GUI info labels** were needed:

**ListItem.ChannelLogo, VideoPlayer.ChannelLogo, MusicPlayer.ChannelLogo**, completing the other channel related labels, (like ListItem.ChannelName and ListItem.ChannelNumberLabel). These labels contain the path of the channel logo of the selected or playing pvr channel.

Runtime-tested on macOS and Android, latest xbmc master.

@jjd-uk  could you please have a look at the skin changes?
@phunkyfish please review the code changes.