### PR TITLE
PackerMAT: adjust log messages

### DIFF
--- a/xbmc/cores/AudioEngine/Utils/PackerMAT.cpp
+++ b/xbmc/cores/AudioEngine/Utils/PackerMAT.cpp
@@ -86,9 +86,10 @@ bool CPackerMAT::PackTrueHD(const uint8_t* data, int size)
   {
     if (m_state.outputTimingValid && (info.outputTiming != m_state.outputTiming))
     {
-      CLog::LogF(LOGWARNING,
-                 "detected a stream discontinuity -> output timing expected: {}, found: {}",
-                 m_state.outputTiming, info.outputTiming);
+      CLog::Log(LOGWARNING,
+                "CPackerMAT::PackTrueHD: detected a stream discontinuity -> output timing "
+                "expected: {}, found: {}",
+                m_state.outputTiming, info.outputTiming);
     }
     m_state.outputTiming = info.outputTiming;
     m_state.outputTimingValid = true;
@@ -241,9 +242,10 @@ void CPackerMAT::WritePadding()
   if (!m_logPadding && m_state.padding > MAT_BUFFER_SIZE / 2)
   {
     m_logPadding = true;
-    CLog::LogF(LOGWARNING,
-               "a large padding block of {} bytes is required due to unusual timestamps",
-               m_state.padding);
+    CLog::Log(LOGWARNING,
+              "CPackerMAT::WritePadding: a large padding block of {} bytes is required due to "
+              "unusual timestamps",
+              m_state.padding);
   }
   else if (m_logPadding && m_state.padding < MAT_BUFFER_SIZE / 2)
     m_logPadding = false;
@@ -349,11 +351,6 @@ void CPackerMAT::FlushPacket()
 
   // push MAT packet to output queue
   m_outputQueue.emplace_back(std::move(m_buffer));
-
-  if (m_outputQueue.size() > 1)
-    CLog::LogF(LOGDEBUG,
-               "several MAT packets generated in a row, the size of the output queue is {}",
-               m_outputQueue.size());
 
   // we expect 24 frames per MAT frame, so calculate an offset from that
   // this is done after delivery, because it modifies the duration of the frame,


### PR DESCRIPTION
## Description
PackerMAT: adjust log messages


## Motivation and context
 - Removed a log line that not provides much useful info (it was mostly for development).
- Adjusted others two lines using `Log` instead of `LogF` due different behavior in others platforms compared Windows: only in Windows shows class name.


## How has this been tested?
Build Windows x64


## What is the effect on users?
Consistent log messages in all platforms.


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
