### PR TITLE
[Docs] ListItem InfoLabels Documentation Incomplete/Malformed

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -6492,7 +6492,6 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///     replaces `ListItem.AddonBroken`.
 ///     <p>
 ///   }
-
 ///   \table_row3{   <b>`ListItem.AddonType`</b>,
 ///                  \anchor ListItem_AddonType
 ///                  _string_,


### PR DESCRIPTION
## Description
The current online documentation for ‘ListItem’ InfoLabels ends at ‘ListItem.AddonLifecycleDesc’, however, more labels are documented in the source file.  There is also some malformed documentation in the ‘listitem_labels’ section of ‘GUIInfoManager.cpp’

A single empty line appears to interrupt the documentation creation process.  Removing this empty line produces documentation up to ‘ListItem.HasVideoExtras’ (the last item documented in the source file) and removes the malformed documentation from ‘GUIInfoManager.cpp’.

## Motivation and context
Provide accurate documentation.

## How has this been tested?

- Build the documentation locally and observe the issues.
- Remove the blank line,
- Rebuild the documentation locally and observe the results. 

## What is the effect on users?
None.  For developers only.

## Screenshots (if appropriate):
**Before**
![dUdVhTA](https://github.com/xbmc/xbmc/assets/127641886/bf8225e8-aea3-425e-8fdc-2d8413f29592)
**After**
![oc6W1xU](https://github.com/xbmc/xbmc/assets/127641886/4858f64c-d0e4-4739-9da9-9ac4cc5cf04d)


## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
