### PR TITLE
[FileSystem] deprecate use of READ_CHUNKED flag

### DIFF
--- a/xbmc/addons/interfaces/Filesystem.cpp
+++ b/xbmc/addons/interfaces/Filesystem.cpp
@@ -138,7 +138,9 @@ unsigned int Interface_Filesystem::TranslateFileReadBitsToKodi(unsigned int addo
   if (addonFlags & ADDON_READ_TRUNCATED)
     kodiFlags |= READ_TRUNCATED;
   if (addonFlags & ADDON_READ_CHUNKED)
-    kodiFlags |= READ_CHUNKED;
+    CLog::Log(LOGWARNING,
+              "Interface_Filesystem::{} - detected use of deprecated 'ADDON_READ_CHUNKED' flag",
+              __FUNCTION__);
   if (addonFlags & ADDON_READ_CACHED)
     kodiFlags |= READ_CACHED;
   if (addonFlags & ADDON_READ_NO_CACHE)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESound.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESound.cpp
@@ -110,7 +110,7 @@ CSoundPacket *CActiveAESound::GetSound(bool orig)
 
 bool CActiveAESound::Prepare()
 {
-  unsigned int flags = READ_TRUNCATED | READ_CHUNKED;
+  unsigned int flags = READ_TRUNCATED;
   m_pFile = new CFile();
 
   if (!m_pFile->Open(m_filename, flags))

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp
@@ -182,8 +182,8 @@ std::shared_ptr<CDVDInputStream> CDVDFactoryInputStream::CreateInputStream(IVide
   }
 
   // our file interface handles all these types of streams
-  return std::make_shared<CDVDInputStreamFile>(
-      finalFileitem, XFILE::READ_TRUNCATED | XFILE::READ_BITRATE | XFILE::READ_CHUNKED);
+  return std::make_shared<CDVDInputStreamFile>(finalFileitem,
+                                               XFILE::READ_TRUNCATED | XFILE::READ_BITRATE);
 }
 
 std::shared_ptr<CDVDInputStream> CDVDFactoryInputStream::CreateInputStream(IVideoPlayer* pPlayer, const CFileItem &fileitem, const std::vector<std::string>& filenames)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -1244,8 +1244,8 @@ void CDVDInputStreamBluray::SetupPlayerSettings()
 
 bool CDVDInputStreamBluray::OpenStream(CFileItem &item)
 {
-  m_pstream = std::make_unique<CDVDInputStreamFile>(item, READ_TRUNCATED | READ_BITRATE |
-                                                              READ_CHUNKED | READ_NO_CACHE);
+  m_pstream =
+      std::make_unique<CDVDInputStreamFile>(item, READ_TRUNCATED | READ_BITRATE | READ_NO_CACHE);
 
   if (!m_pstream->Open())
   {

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -48,8 +48,6 @@ bool CDVDInputStreamFile::Open()
   // If this file is audio and/or video (= not a subtitle) flag to caller
   if (!VIDEO::IsSubtitle(m_item))
     flags |= READ_AUDIO_VIDEO;
-  else
-    flags |= READ_NO_BUFFER; // disable CFileStreamBuffer for subtitles
 
   std::string content = m_item.GetMimeType();
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -150,8 +150,8 @@ bool CDVDInputStreamNavigator::Open()
   if (m_item.IsDiscImage())
   {
     // if dvd image file (ISO or alike) open using libdvdnav stream callback functions
-    m_pstream = std::make_unique<CDVDInputStreamFile>(
-        m_item, XFILE::READ_TRUNCATED | XFILE::READ_BITRATE | XFILE::READ_CHUNKED);
+    m_pstream =
+        std::make_unique<CDVDInputStreamFile>(m_item, XFILE::READ_TRUNCATED | XFILE::READ_BITRATE);
 #if DVDNAV_VERSION >= 60100
     if (!m_pstream->Open() || m_dll.dvdnav_open_stream2(&m_dvdnav, m_pstream.get(), &loggerCallback,
                                                         &m_dvdnav_stream_cb) != DVDNAV_STATUS_OK)

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -66,7 +66,7 @@ bool CFile::Copy(const CURL& url2, const CURL& dest, XFILE::IFileCallback* pCall
   CURL url(url2);
   if (StringUtils::StartsWith(url.Get(), "zip://") || URIUtils::IsInAPK(url.Get()))
     url.SetOptions("?cache=no");
-  if (file.Open(url.Get(), READ_TRUNCATED | READ_CHUNKED))
+  if (file.Open(url.Get(), READ_TRUNCATED | READ_NO_BUFFER))
   {
 
     CFile newFile;
@@ -389,7 +389,7 @@ bool CFile::ShouldUseStreamBuffer(const CURL& url)
   if (m_flags & READ_NO_BUFFER)
     return false;
 
-  if (m_flags & READ_CHUNKED || m_pFile->GetChunkSize() > 0)
+  if (m_flags & READ_AUDIO_VIDEO)
     return true;
 
   // file size > 200 MB but not in optical disk

--- a/xbmc/filesystem/IFileTypes.h
+++ b/xbmc/filesystem/IFileTypes.h
@@ -16,9 +16,6 @@ namespace XFILE
 /* indicate that caller can handle truncated reads, where function returns before entire buffer has been filled */
 static const unsigned int READ_TRUNCATED = 0x01;
 
-/* indicate that that caller support read in the minimum defined chunk size, this disables internal cache then */
-static const unsigned int READ_CHUNKED = 0x02;
-
 /* use cache to access this file */
 static const unsigned int READ_CACHED = 0x04;
 


### PR DESCRIPTION
## Description
[FileSystem] deprecate use of READ_CHUNKED flag

This is a follow up of https://github.com/xbmc/xbmc/pull/25128 or better alternative as fixes the same in more elaborated way. Also fixes other potential issues or "unwanted behavior changes" due the main refactor in StreamBuffer logic.

## Motivation and context
As commented in the other PR, `READ_AUDIO_VIDEO` flag fits better into `CFile::ShouldUseStreamBuffer` method because same as FileCache, StreamBuffer only should be used in audio/video files.

Once replaced here results that `READ_CHUNKED` flag is a dead code because only is set but never read/used. Then can be deprecated.

The others changes are only small adjustments to maintain the same functionality and some potential fix.


## How has this been tested?
Runtime Windows x64 and Shield

Tested that use of FileCache and StreamBuffer is maintained same as before for most habitual scenarios: tested MKV's local/network SMB, NFS. Tested Blu-Ray BDMV folders and ISOs SMB and NFS. Adequate chunk size is used same as before: 128K on network and 6144 bytes locally. Tested DVD, DVD ISOs. 

Fix for external SRT is preserved without needing to use the `READ_NO_BUFFER` flag since when opening subtitles it does not have the `READ_AUDIO_VIDEO` flag and the file size >200 MB condition is not met either.


## What is the effect on users?
Nothing directly but prevents other potentially cases of StreamBuffer used on file contents that are not suitable (non audio/video files).



## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
