### PR TITLE
[GUIFontTTF] Fix regressions on centered GUI text

### DIFF
--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -512,11 +512,11 @@ void CGUIFontTTF::DrawTextInternal(CGraphicContext& context,
         if (!c)
           continue;
 
-        float nextWidth;
+        float nextWidth = textWidth;
         if ((ch & 0xffff) == static_cast<character_t>('\t'))
-          nextWidth = GetTabSpaceLength();
+          nextWidth += GetTabSpaceLength();
         else
-          nextWidth = textWidth + c->m_advance;
+          nextWidth += c->m_advance;
 
         if (maxPixelWidth > 0 && nextWidth > maxPixelWidth)
         {
@@ -540,11 +540,11 @@ void CGUIFontTTF::DrawTextInternal(CGraphicContext& context,
         if (!c)
           continue;
 
-        float nextWidth;
+        float nextWidth = textWidth;
         if ((ch & 0xffff) == static_cast<character_t>('\t'))
-          nextWidth = GetTabSpaceLength();
+          nextWidth += GetTabSpaceLength();
         else
-          nextWidth = textWidth + c->m_advance;
+          nextWidth += c->m_advance;
 
         if (maxPixelWidth > 0 && nextWidth > maxPixelWidth)
           break;

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -518,7 +518,7 @@ void CGUIFontTTF::DrawTextInternal(CGraphicContext& context,
         else
           nextWidth = textWidth + c->m_advance;
 
-        if (nextWidth > maxPixelWidth)
+        if (maxPixelWidth > 0 && nextWidth > maxPixelWidth)
         {
           // Start rendering from the glyph that does not exceed the maximum width
           startPosGlyph = std::distance(itRGlyph, glyphs.crend());
@@ -546,7 +546,7 @@ void CGUIFontTTF::DrawTextInternal(CGraphicContext& context,
         else
           nextWidth = textWidth + c->m_advance;
 
-        if (nextWidth > maxPixelWidth)
+        if (maxPixelWidth > 0 && nextWidth > maxPixelWidth)
           break;
 
         textWidth = nextWidth;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
fixes a couple of regressions caused by #24799
this is noticeable on kodi splash screen

1 problem was on maxPixelWidth where was missing a condition to avoid consider 0 value (disabled)
2 problem tab chars was resetting the textWidth calculation

BEFORE:
![Pr1_Before](https://github.com/xbmc/xbmc/assets/3257156/13778536-4f32-4832-9bb4-fef0ace9fc75)
AFTER:
![Pr1_After](https://github.com/xbmc/xbmc/assets/3257156/9dc44ff2-e05c-4563-b19a-8e64dade616b)

BEFORE WITH TAB:
![Pr2_Before](https://github.com/xbmc/xbmc/assets/3257156/a15423a6-5c3f-4c6d-900d-17b0484fba25)
AFTER WITH TAB:
![Pr2_After](https://github.com/xbmc/xbmc/assets/3257156/4751aaaf-9113-452e-8470-63ee90b178de)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #25155
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
