### PR TITLE
Rendering: drop markwindow dirty after setrendergui change

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -810,16 +810,7 @@ void CApplication::Render()
     return;
 
   // render gui layer
-  const bool renderGUI = appPower->GetRenderGUI();
-  if (m_guiRenderLastState != std::nullopt && renderGUI && m_guiRenderLastState != renderGUI)
-  {
-    CGUIComponent* gui = CServiceBroker::GetGUI();
-    if (gui)
-      CServiceBroker::GetGUI()->GetWindowManager().MarkDirty();
-  }
-  m_guiRenderLastState = renderGUI;
-
-  if (renderGUI && !m_skipGuiRender)
+  if (appPower->GetRenderGUI() && !m_skipGuiRender)
   {
     if (CServiceBroker::GetWinSystem()->GetGfxContext().GetStereoMode())
     {

--- a/xbmc/application/Application.h
+++ b/xbmc/application/Application.h
@@ -24,7 +24,6 @@
 #include <atomic>
 #include <chrono>
 #include <memory>
-#include <optional>
 #include <string>
 #include <vector>
 
@@ -219,7 +218,6 @@ protected:
 
   std::chrono::time_point<std::chrono::steady_clock> m_lastRenderTime;
   bool m_skipGuiRender = false;
-  std::optional<bool> m_guiRenderLastState;
 
   std::unique_ptr<MUSIC_INFO::CMusicInfoScanner> m_musicInfoScanner;
 


### PR DESCRIPTION
## Description
This is an alternative to https://github.com/xbmc/xbmc/pull/25132 which proposes to remove the old logic of setting the window dirty after a change of state in the implementation of SetRenderGUI.

## Motivation and context
The original block of code was added in https://github.com/xbmc/xbmc/commit/bd4c0ae108ac4e2e4840c51f6ad1efd5699f89db as part https://github.com/xbmc/xbmc/pull/1493 with work related to OMXPlayer which is no longer part of Kodi. I suppose this block of code is no longer used and IMHO its done in the wrong place (marking the window dirty should be a reaction to a given event). The removed code was added by me in https://github.com/xbmc/xbmc/pull/25121 as an effort to provide the same logic but it has raised problems with the continuous polling of state on the rendering thread.
 
With recent changes to macOS to fix crashes on window resize we need to disable and enable the gui render before and after the live resize operation (since rendering does not happen on the macOS main thread and it "steals" the GL context). This change caused issues due to concurrent access to the gfx lock by different threads (rendering thread and macOS main thread).

Other proposals like using app messaging instead of the polling (or the removal of the affected code) caused issues on android since it requires the usage of components early in the initialization phase (and they are not yet available).

Since we're on a bit of an impasse and I couldn't really find any requirement for this block of code (which I strongly believe is dead logic by now), I propose to drop it entirely and leave it on master for a while to see if any regression comes in. If any, we should try to implement a solution constrained to the problem and minimize impact on all other platforms. I commit myself to doing it if it happens. Hopefully not :)

## How has this been tested?
Runtime tested on macOS and android, no issues detected

## What is the effect on users?
Hopefully none, let's see

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
