### PR TITLE
[Backport]Rendering: drop markwindow dirty after setrendergui change

### DIFF
--- a/xbmc/application/ApplicationPowerHandling.cpp
+++ b/xbmc/application/ApplicationPowerHandling.cpp
@@ -67,12 +67,6 @@ void CApplicationPowerHandling::ResetNavigationTimer()
 
 void CApplicationPowerHandling::SetRenderGUI(bool renderGUI)
 {
-  if (renderGUI && !m_renderGUI)
-  {
-    CGUIComponent* gui = CServiceBroker::GetGUI();
-    if (gui)
-      CServiceBroker::GetGUI()->GetWindowManager().MarkDirty();
-  }
   m_renderGUI = renderGUI;
 }
 

--- a/xbmc/windowing/osx/OpenGL/WindowControllerMacOS.mm
+++ b/xbmc/windowing/osx/OpenGL/WindowControllerMacOS.mm
@@ -22,8 +22,6 @@
 
 @implementation XBMCWindowControllerMacOS
 
-bool m_inFullscreenTransition = false;
-
 - (nullable instancetype)initWithTitle:(NSString*)title defaultSize:(NSSize)size
 {
   auto frame = NSMakeRect(0, 0, size.width, size.height);
@@ -81,9 +79,6 @@ bool m_inFullscreenTransition = false;
 
 - (void)windowWillStartLiveResize:(NSNotification*)notification
 {
-  if (m_inFullscreenTransition)
-    return;
-
   std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
   if (appPort)
   {
@@ -93,9 +88,6 @@ bool m_inFullscreenTransition = false;
 
 - (void)windowDidEndLiveResize:(NSNotification*)notification
 {
-  if (m_inFullscreenTransition)
-    return;
-
   std::shared_ptr<CAppInboundProtocol> appPort = CServiceBroker::GetAppPort();
   if (appPort)
   {
@@ -196,14 +188,8 @@ bool m_inFullscreenTransition = false;
   return frameSize;
 }
 
-- (void)windowWillExitFullScreen:(NSNotification*)notification
-{
-  m_inFullscreenTransition = true;
-}
-
 - (void)windowWillEnterFullScreen:(NSNotification*)pNotification
 {
-  m_inFullscreenTransition = true;
   CWinSystemOSX* winSystem = dynamic_cast<CWinSystemOSX*>(CServiceBroker::GetWinSystem());
   if (!winSystem)
     return;
@@ -241,7 +227,6 @@ bool m_inFullscreenTransition = false;
 
 - (void)windowDidExitFullScreen:(NSNotification*)pNotification
 {
-  m_inFullscreenTransition = false;
   auto winSystem = dynamic_cast<CWinSystemOSX*>(CServiceBroker::GetWinSystem());
   if (!winSystem)
     return;
@@ -268,7 +253,6 @@ bool m_inFullscreenTransition = false;
 
 - (void)windowDidEnterFullScreen:(NSNotification*)notification
 {
-  m_inFullscreenTransition = false;
   auto winSystem = dynamic_cast<CWinSystemOSX*>(CServiceBroker::GetWinSystem());
   if (!winSystem)
     return;


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/25164 for Omega. Please only merge if confirmed no regressions are caused by the original PR for master.