### PR TITLE
Android-Gui: Allow setting the DecorView to transparent color

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -666,6 +666,13 @@ bool CApplication::Initialize()
       }
     }
 
+#if defined(TARGET_ANDROID)
+    if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiLayoutTransparent)
+    {
+      CLog::Log(LOGINFO, "XBMCApp: Decorview Color was set to transparent.");
+      CXBMCApp::Get().SetDecorViewBackgroundColor(0);
+    }
+#endif
     // Start splashscreen and load skin
     CServiceBroker::GetRenderSystem()->ShowSplash("");
     skinHandling->m_confirmSkinChange = true;

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -1669,6 +1669,30 @@ std::shared_ptr<CNativeWindow> CXBMCApp::GetNativeWindow(int timeout) const
   return m_window;
 }
 
+void CXBMCApp::SetDecorViewBackgroundColorCallback(void* colorVariant)
+{
+  CVariant* colorV = static_cast<CVariant*>(colorVariant);
+  const int color = colorV->asInteger();
+  delete colorV;
+
+  CJNIWindow window = getWindow();
+  if (window)
+  {
+    CJNIView view = window.getDecorView();
+    if (view)
+    {
+      view.setBackgroundColor(color);
+    }
+  }
+}
+
+void CXBMCApp::SetDecorViewBackgroundColor(const int color)
+{
+  // this object is deallocated in the callback
+  CVariant* variant = new CVariant(color);
+  runNativeOnUiThread(SetDecorViewBackgroundColorCallback, variant);
+}
+
 void CXBMCApp::RegisterInputDeviceCallbacks(IInputDeviceCallbacks* handler)
 {
   if (handler != nullptr)

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -181,6 +181,7 @@ public:
 
   void SetDisplayMode(int mode, float rate);
   int GetDPI() const;
+  void SetDecorViewBackgroundColor(const int color);
 
   CRect MapRenderToDroid(const CRect& srcRect);
 
@@ -243,6 +244,7 @@ private:
   void SetupEnv();
   static void SetDisplayModeCallback(void* modeVariant);
   static void KeepScreenOnCallback(void* onVariant);
+  static void SetDecorViewBackgroundColorCallback(void* onVariant);
 
   static void RegisterDisplayListenerCallback(void*);
   void UnregisterDisplayListener();

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -1226,6 +1226,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetInt(pElement, "anisotropicfiltering", m_guiAnisotropicFiltering);
     XMLUtils::GetBoolean(pElement, "fronttobackrendering", m_guiFrontToBackRendering);
     XMLUtils::GetBoolean(pElement, "geometryclear", m_guiGeometryClear);
+    XMLUtils::GetBoolean(pElement, "transparentguilayout", m_guiLayoutTransparent);
   }
 
   std::string seekSteps;

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -336,6 +336,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int32_t m_guiAnisotropicFiltering{0};
     bool m_guiFrontToBackRendering{false};
     bool m_guiGeometryClear{true};
+    bool m_guiLayoutTransparent = false;
     unsigned int m_addonPackageFolderSize;
 
     bool m_jsonOutputCompact;


### PR DESCRIPTION
Sony TVs have a long standing firmware bug. Allow a user to configure the background color to workaround this.

Usage:
```
<advancedsettings>
  <gui>
   <transparentguilayout>true</transparentguilayout>
 </gui>
</advancedsettings>
```