### PR TITLE
Joysticks: Fix mapping PS4 trigger analog semiaxes

### DIFF
--- a/xbmc/input/joysticks/generic/ButtonMapping.cpp
+++ b/xbmc/input/joysticks/generic/ButtonMapping.cpp
@@ -451,31 +451,34 @@ bool CButtonMapping::MapPrimitive(const CDriverPrimitive& primitive)
 {
   bool bHandled = false;
 
-  auto now = std::chrono::steady_clock::now();
-
-  bool bTimeoutElapsed = true;
-
-  if (m_buttonMapper->NeedsCooldown())
-    bTimeoutElapsed = (now >= m_lastAction + std::chrono::milliseconds(MAPPING_COOLDOWN_MS));
-
-  if (bTimeoutElapsed)
-  {
-    bHandled = m_buttonMapper->MapPrimitive(m_buttonMap, m_keymap, primitive);
-
-    if (bHandled)
-      m_lastAction = std::chrono::steady_clock::now();
-  }
-  else if (m_buttonMap->IsIgnored(primitive))
+  if (m_buttonMap->IsIgnored(primitive))
   {
     bHandled = true;
   }
   else
   {
-    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_lastAction);
+    auto now = std::chrono::steady_clock::now();
 
-    CLog::Log(LOGDEBUG, "Button mapping: rapid input after {}ms dropped for profile \"{}\"",
-              duration.count(), m_buttonMapper->ControllerID());
-    bHandled = true;
+    bool bTimeoutElapsed = true;
+
+    if (m_buttonMapper->NeedsCooldown())
+      bTimeoutElapsed = (now >= m_lastAction + std::chrono::milliseconds(MAPPING_COOLDOWN_MS));
+
+    if (bTimeoutElapsed)
+    {
+      bHandled = m_buttonMapper->MapPrimitive(m_buttonMap, m_keymap, primitive);
+
+      if (bHandled)
+        m_lastAction = std::chrono::steady_clock::now();
+    }
+    else
+    {
+      auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_lastAction);
+
+      CLog::Log(LOGDEBUG, "Button mapping: rapid input after {}ms dropped for profile \"{}\"",
+                duration.count(), m_buttonMapper->ControllerID());
+      bHandled = true;
+    }
   }
 
   return bHandled;


### PR DESCRIPTION
## Description

Background: Rapid input is dropped when buttonmapping, because some controllers send multiple events per button press with different button IDs.

For example, on many PlayStation controllers, the triggers send an analog event, and a digital event when the trigger crosses about halfway. The 0.5 analog event arrives shortly before or shortly after the digital  event.

_The bug:_ If the digital button is ignored, the analog event may be detected as rapid input and dropped.

_The fix:_ Prioritizing the "IsIngored" check.

## Motivation and context

Fix is broken out from https://github.com/xbmc/xbmc/pull/24604, as it doesn't touch Android.

## How has this been tested?

Tested as part of my RetroPlayer builds since January: https://github.com/garbear/xbmc/releases

## What is the effect on users?

* Improved trigger detection in controller button mapper

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
