### PR TITLE
joystick.xml: Fix Back/Select button going home instead of back one window

### DIFF
--- a/system/keymaps/joystick.xml
+++ b/system/keymaps/joystick.xml
@@ -49,7 +49,7 @@
       <x>ContextMenu</x>
       <y>FullScreen</y>
       <start>ActivateWindow(PlayerControls)</start>
-      <back>ActivateWindow(Home)</back>
+      <back>Back</back>
       <guide>ActivateWindow(Home)</guide>
       <up>Up</up>
       <down>Down</down>
@@ -97,7 +97,7 @@
       <x>OSD</x>
       <y>FullScreen</y>
       <start>Info</start>
-      <back>FullScreen</back>
+      <back>Stop</back>
       <guide>OSD</guide>
       <up>ChapterOrBigStepForward</up>
       <down>ChapterOrBigStepBack</down>
@@ -174,7 +174,7 @@
       <b>Stop</b>
       <b holdtime="500">FullScreen</b>
       <x>OSD</x>
-      <back>OSD</back>
+      <back>Stop</back>
       <guide>OSD</guide>
       <start>Info</start>
       <up>ChannelUp</up>
@@ -194,7 +194,7 @@
       <b>Stop</b>
       <b holdtime="500">FullScreen</b>
       <x>OSD</x>
-      <back>OSD</back>
+      <back>Stop</back>
       <guide>OSD</guide>
       <start>Info</start>
       <up>ChannelUp</up>


### PR DESCRIPTION
## Description

This PR updates joystick.xml to change the behavior of the Back/Select button to have the same behavior as the rest of Android. This matches the behavior of Android outside of Kodi, and IMO is more intuitive.

@bjsvedin, you've touched joystick.xml recently, what do you think?

## Motivation and context

The problem on Android was pointed out by a tester (didn't save the link).

## How has this been tested?

Tested as part of my RetroPlayer builds since January: https://github.com/garbear/xbmc/releases

## What is the effect on users?

* Fixes behavior of the Back/Select button on Android

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
