### PR TITLE
Android: One fix on the joystick codepath

### DIFF
--- a/xbmc/platform/android/peripherals/AndroidJoystickState.cpp
+++ b/xbmc/platform/android/peripherals/AndroidJoystickState.cpp
@@ -221,6 +221,25 @@ bool CAndroidJoystickState::ProcessEvent(const AInputEvent* event)
 
       bool result = SetButtonValue(keycode, buttonState);
 
+      if (!result)
+      {
+        // Try shoehorning keys into buttons
+        switch (keycode)
+        {
+          case AKEYCODE_MENU:
+            result = SetButtonValue(AKEYCODE_BUTTON_START, buttonState);
+            break;
+          case AKEYCODE_BACK:
+            result = SetButtonValue(AKEYCODE_BUTTON_SELECT, buttonState);
+            break;
+          case AKEYCODE_HOME:
+            result = SetButtonValue(AKEYCODE_BUTTON_MODE, buttonState);
+            break;
+          default:
+            break;
+        }
+      }
+
       return result;
     }
 

--- a/xbmc/platform/android/peripherals/PeripheralBusAndroid.cpp
+++ b/xbmc/platform/android/peripherals/PeripheralBusAndroid.cpp
@@ -382,8 +382,59 @@ bool CPeripheralBusAndroid::ConvertToPeripheralScanResult(
   if (!inputDevice.supportsSource(CJNIViewInputDevice::SOURCE_JOYSTICK) &&
       !inputDevice.supportsSource(CJNIViewInputDevice::SOURCE_GAMEPAD))
   {
-    CLog::Log(LOGDEBUG, "CPeripheralBusAndroid: ignoring non-joystick device");
-    return false;
+    // Observed an anomylous PS4 controller with only SOURCE_MOUSE
+    if (!inputDevice.supportsSource(CJNIViewInputDevice::SOURCE_MOUSE))
+    {
+      CLog::Log(LOGDEBUG, "CPeripheralBusAndroid: ignoring non-joystick device");
+      return false;
+    }
+
+    // Make sure the anomylous controller has buttons
+    // clang-format off
+    std::vector<int> buttons{
+        AKEYCODE_BUTTON_A,
+        AKEYCODE_BUTTON_B,
+        AKEYCODE_BUTTON_C,
+        AKEYCODE_BUTTON_X,
+        AKEYCODE_BUTTON_Y,
+        AKEYCODE_BUTTON_Z,
+        AKEYCODE_BUTTON_L1,
+        AKEYCODE_BUTTON_R1,
+        AKEYCODE_BUTTON_L2,
+        AKEYCODE_BUTTON_R2,
+        AKEYCODE_BUTTON_THUMBL,
+        AKEYCODE_BUTTON_THUMBR,
+        AKEYCODE_BUTTON_START,
+        AKEYCODE_BUTTON_SELECT,
+        AKEYCODE_BUTTON_MODE,
+        AKEYCODE_BUTTON_1,
+        AKEYCODE_BUTTON_2,
+        AKEYCODE_BUTTON_3,
+        AKEYCODE_BUTTON_4,
+        AKEYCODE_BUTTON_5,
+        AKEYCODE_BUTTON_6,
+        AKEYCODE_BUTTON_7,
+        AKEYCODE_BUTTON_8,
+        AKEYCODE_BUTTON_9,
+        AKEYCODE_BUTTON_10,
+        AKEYCODE_BUTTON_11,
+        AKEYCODE_BUTTON_12,
+        AKEYCODE_BUTTON_13,
+        AKEYCODE_BUTTON_14,
+        AKEYCODE_BUTTON_15,
+        AKEYCODE_BUTTON_16,
+    };
+    // clang-format on
+
+    auto result = inputDevice.hasKeys(buttons);
+
+    if (std::find(result.begin(), result.end(), true) == result.end())
+    {
+      CLog::Log(LOGDEBUG, "CPeripheralBusAndroid: ignoring non-joystick device with mouse source");
+      return false;
+    }
+
+    CLog::Log(LOGDEBUG, "CPeripheralBusAndroid: adding non-joystick device with mouse source");
   }
 
   peripheralScanResult.m_type = PERIPHERAL_JOYSTICK;

--- a/xbmc/platform/android/peripherals/PeripheralBusAndroid.cpp
+++ b/xbmc/platform/android/peripherals/PeripheralBusAndroid.cpp
@@ -450,8 +450,59 @@ bool CPeripheralBusAndroid::ConvertToPeripheralScanResult(
   if (!inputDevice.supportsSource(CJNIViewInputDevice::SOURCE_JOYSTICK) &&
       !inputDevice.supportsSource(CJNIViewInputDevice::SOURCE_GAMEPAD))
   {
-    CLog::Log(LOGDEBUG, "CPeripheralBusAndroid: ignoring non-joystick device");
-    return false;
+    // Observed an anomylous PS4 controller with only SOURCE_MOUSE
+    if (!inputDevice.supportsSource(CJNIViewInputDevice::SOURCE_MOUSE))
+    {
+      CLog::Log(LOGDEBUG, "CPeripheralBusAndroid: ignoring non-joystick device");
+      return false;
+    }
+
+    // Make sure the anomylous controller has buttons
+    // clang-format off
+    std::vector<int> buttons{
+        AKEYCODE_BUTTON_A,
+        AKEYCODE_BUTTON_B,
+        AKEYCODE_BUTTON_C,
+        AKEYCODE_BUTTON_X,
+        AKEYCODE_BUTTON_Y,
+        AKEYCODE_BUTTON_Z,
+        AKEYCODE_BUTTON_L1,
+        AKEYCODE_BUTTON_R1,
+        AKEYCODE_BUTTON_L2,
+        AKEYCODE_BUTTON_R2,
+        AKEYCODE_BUTTON_THUMBL,
+        AKEYCODE_BUTTON_THUMBR,
+        AKEYCODE_BUTTON_START,
+        AKEYCODE_BUTTON_SELECT,
+        AKEYCODE_BUTTON_MODE,
+        AKEYCODE_BUTTON_1,
+        AKEYCODE_BUTTON_2,
+        AKEYCODE_BUTTON_3,
+        AKEYCODE_BUTTON_4,
+        AKEYCODE_BUTTON_5,
+        AKEYCODE_BUTTON_6,
+        AKEYCODE_BUTTON_7,
+        AKEYCODE_BUTTON_8,
+        AKEYCODE_BUTTON_9,
+        AKEYCODE_BUTTON_10,
+        AKEYCODE_BUTTON_11,
+        AKEYCODE_BUTTON_12,
+        AKEYCODE_BUTTON_13,
+        AKEYCODE_BUTTON_14,
+        AKEYCODE_BUTTON_15,
+        AKEYCODE_BUTTON_16,
+    };
+    // clang-format on
+
+    auto result = inputDevice.hasKeys(buttons);
+
+    if (std::find(result.begin(), result.end(), true) == result.end())
+    {
+      CLog::Log(LOGDEBUG, "CPeripheralBusAndroid: ignoring non-joystick device with mouse source");
+      return false;
+    }
+
+    CLog::Log(LOGDEBUG, "CPeripheralBusAndroid: adding non-joystick device with mouse source");
   }
 
   peripheralScanResult.m_type = PERIPHERAL_JOYSTICK;


### PR DESCRIPTION
## Description

This PR contains two fixes for Android quirks on the joystick codepath:

* Commit 2: Fixes PS4 controllers that identify as a mouse due to their touchpad
* Commit 1: Fixes the middle buttons on my PS4 controller

Because only code on the joystick codepath is touched, this PR should have no effect on anything other than joysticks.

## Motivation and context

Both fixes are hacks around Android quirks, but with both fixes my PS4 controller works in Kodi.

Because it only affects joysticks, it therefore separates out the remaining "safer" Android fixes from https://github.com/xbmc/xbmc/pull/24604.

I just bought a shiny new PS5 controller, so I'll test that with these fixes too.

## How has this been tested?

Tested as part of my RetroPlayer builds since January: https://github.com/garbear/xbmc/releases

Due to the hacky nature of the fixes, more testing is needed. I plan to continue working on joysticks as the other PRs get merged:

* https://github.com/xbmc/xbmc/pull/25174
* https://github.com/xbmc/xbmc/pull/25175
* https://github.com/xbmc/xbmc/pull/25176
* https://github.com/xbmc/xbmc/pull/25177
* https://github.com/xbmc/xbmc/pull/25178

## What is the effect on users?

* Fixes PS4 controllers on Android

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
