### PR TITLE
[bp] fix typo: [cleanup] convert defines to functions

### DIFF
--- a/xbmc/utils/BitstreamReader.h
+++ b/xbmc/utils/BitstreamReader.h
@@ -47,6 +47,6 @@ constexpr uint32_t BS_RB24(const uint8_t* x)
 
 constexpr uint32_t BS_RB32(const uint8_t* x)
 {
-  return (x[1] << 24) | (x[1] << 16) | (x[2] << 8) | x[3];
+  return (x[0] << 24) | (x[1] << 16) | (x[2] << 8) | x[3];
 }
 


### PR DESCRIPTION
## Description
backport of https://github.com/xbmc/xbmc/pull/25172 by @Portisch

fix typo: [[cleanup] convert defines to functions](https://github.com/xbmc/xbmc/commit/9009de080165912ddccc44c713cefcb7de007447#diff-18b12d9597c765b7a8e7db9bff3f81b0f4c3e36c7c3625d26232fb6d642b46c9R55)
