### PR TITLE
[Docs] Fix unescaped commas for InfoLabel and Add-on Built-in Functions.

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3941,7 +3941,7 @@ const infomap musicplayer[] =    {{ "title",            MUSICPLAYER_TITLE },
 ///   \table_row3{   <b>`VideoPlayer.VideoVersionName`</b>,
 ///                  \anchor VideoPlayer_VideoVersionName
 ///                  _string_,
-///     @return String containing the version name of the currently playing video (movie) - empty if not a movie, version name is not set or not a version
+///     @return String containing the version name of the currently playing video (movie) - empty if not a movie\, version name is not set or not a version
 ///     <p><hr>
 ///     @skinning_v21 **[New Infolabel]** \link VideoPlayer_VideoVersionName `VideoPlayer.VideoVersionName`\endlink
 ///   }
@@ -6488,7 +6488,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///                  _string_,
 ///     @return From addon defined message text when it is marked as special condition inside repository.
 ///     <p><hr>
-///     @skinning_v19 **[New Infolabel]** \link ListItem_AddonLifecycleDesc `ListItem.AddonLifecycleDesc``\endlink
+///     @skinning_v19 **[New Infolabel]** \link ListItem_AddonLifecycleDesc `ListItem.AddonLifecycleDesc`\endlink
 ///     replaces `ListItem.AddonBroken`.
 ///     <p>
 ///   }
@@ -6910,7 +6910,7 @@ const infomap container_str[]  = {{ "property",         CONTAINER_PROPERTY },
 ///   \table_row3{   <b>`ListItem.AlbumStatus`</b>,
 ///                  \anchor ListItem_AlbumStatus
 ///                  _string_,
-///     @return The Musicbrainz release status of the album (official, bootleg, promotion etc)
+///     @return The Musicbrainz release status of the album (official\, bootleg\, promotion etc)
 ///     <p><hr>
 ///     @skinning_v19 **[New Infolabel]** \link ListItem_AlbumStatus `ListItem.AlbumStatus`\endlink
 ///   }

--- a/xbmc/interfaces/builtins/PlayerBuiltins.cpp
+++ b/xbmc/interfaces/builtins/PlayerBuiltins.cpp
@@ -771,8 +771,8 @@ static int SubtitleShiftDown(const std::vector<std::string>& params)
 ///     | Partymode(path to .xsp) | Partymode for *.xsp-file               | Partymode for *.xsp-file    |             |
 ///     | ShowVideoMenu           | Shows the DVD/BR menu if available     | none                        |             |
 ///     | FrameAdvance(n) ***     | Advance video by _n_ frames            | none                        | Kodi v18    |
-///     | SubtitleShiftUp(save)   | Shift up the subtitle position, add "save" to save the change permanently    | none | Kodi v20 |
-///     | SubtitleShiftDown(save) | Shift down the subtitle position, add "save" to save the change permanently  | none | Kodi v20 |
+///     | SubtitleShiftUp(save)   | Shift up the subtitle position\, add "save" to save the change permanently    | none | Kodi v20 |
+///     | SubtitleShiftDown(save) | Shift down the subtitle position\, add "save" to save the change permanently  | none | Kodi v20 |
 ///     <br>
 ///     '*' = For these controls\, the PlayerControl built-in function can make use of the 'notify'-parameter. For example: PlayerControl(random\, notify)
 ///     <br>
@@ -803,8 +803,8 @@ static int SubtitleShiftDown(const std::vector<std::string>& params)
 ///     <b>`PlayMedia(media[\,isdir][\,1]\,[playoffset=xx])`</b>
 ///     ,
 ///     Plays the given media. This can be a playlist\, music\, or video file\, directory\,
-///     plugin\, disc image stack\, video file stack or an URL. The optional parameter `,isdir` can
-///     be used for playing a directory. `,1` will start the media without switching to fullscreen.
+///     plugin\, disc image stack\, video file stack or an URL. The optional parameter `\,isdir` can
+///     be used for playing a directory. `\,1` will start the media without switching to fullscreen.
 ///     If media is a playlist or a disc image stack or a video file stack\, you can use
 ///     playoffset=xx where xx is the position to start playback from.
 ///     @param[in] media                 URL to media to play (optional).
@@ -831,8 +831,8 @@ static int SubtitleShiftDown(const std::vector<std::string>& params)
 ///     <b>`QueueMedia(media[\,isdir][\,1][\,playnext]\,[playoffset=xx])`</b>
 ///     \anchor Builtin_QueueMedia,
 ///     Queues the given media. This can be a playlist\, music\, or video file\, directory\,
-///     plugin\, disc image stack\, video file stack or an URL. The optional parameter `,isdir` can
-///     be used for playing a directory. `,1` will start the media without switching to fullscreen.
+///     plugin\, disc image stack\, video file stack or an URL. The optional parameter `\,isdir` can
+///     be used for playing a directory. `\,1` will start the media without switching to fullscreen.
 ///     If media is a playlist or a disc image stack or a video file stack\, you can use
 ///     playoffset=xx where xx is the position to start playback from.
 ///     where xx is the position to start playback from.
@@ -842,8 +842,8 @@ static int SubtitleShiftDown(const std::vector<std::string>& params)
 ///     @param[in] resume                Set `resume` to force resuming (optional).
 ///     @param[in] noresume              Set `noresume` to force not resuming (optional).
 ///     @param[in] playoffset            Set `playoffset=<offset>` to start playback from a given position in a playlist or stack (optional).
-///     @param[in] playnext              Set `playnext` to play the media right after the currently playing item, if player is currently
-///     playing. If player is not playing, append media to current playlist (optional).
+///     @param[in] playnext              Set `playnext` to play the media right after the currently playing item\, if player is currently
+///     playing. If player is not playing\, append media to current playlist (optional).
 ///     <p><hr>
 ///     @skinning_v20 **[New builtin]** \link Builtin_QueueMedia `QueueMedia(media[\,isdir][\,1][\,playnext]\,[playoffset=xx])`\endlink
 ///     <p>


### PR DESCRIPTION
## Description
Resolve some documentation syntax error uncovered after PR #25151
InfoLabels and Add-on built-ins.

## Motivation and context
Updated documentation

## How has this been tested?
Rebuilt docs locally.

## What is the effect on users?
None, developers only.

## Screenshots (if appropriate):
N/A

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
