### PR TITLE
Simplify network FileItem classifiers

### DIFF
--- a/xbmc/network/NetworkFileItemClassify.cpp
+++ b/xbmc/network/NetworkFileItemClassify.cpp
@@ -19,10 +19,7 @@ bool IsInternetStream(const CFileItem& item)
   if (item.HasProperty("IsHTTPDirectory"))
     return false;
 
-  if (!item.GetDynPath().empty())
-    return URIUtils::IsInternetStream(item.GetDynPath());
-
-  return URIUtils::IsInternetStream(item.GetPath());
+  return URIUtils::IsInternetStream(item.GetDynPath());
 }
 
 bool IsRemote(const CFileItem& item)
@@ -32,10 +29,7 @@ bool IsRemote(const CFileItem& item)
 
 bool IsStreamedFilesystem(const CFileItem& item)
 {
-  if (!item.GetDynPath().empty())
-    return URIUtils::IsStreamedFilesystem(item.GetDynPath());
-
-  return URIUtils::IsStreamedFilesystem(item.GetPath());
+  return URIUtils::IsStreamedFilesystem(item.GetDynPath());
 }
 
 } // namespace KODI::NETWORK

--- a/xbmc/network/NetworkFileItemClassify.cpp
+++ b/xbmc/network/NetworkFileItemClassify.cpp
@@ -14,15 +14,15 @@
 namespace KODI::NETWORK
 {
 
-bool IsInternetStream(const CFileItem& item, const bool bStrictCheck /* = false */)
+bool IsInternetStream(const CFileItem& item)
 {
   if (item.HasProperty("IsHTTPDirectory"))
-    return bStrictCheck;
+    return false;
 
   if (!item.GetDynPath().empty())
-    return URIUtils::IsInternetStream(item.GetDynPath(), bStrictCheck);
+    return URIUtils::IsInternetStream(item.GetDynPath());
 
-  return URIUtils::IsInternetStream(item.GetPath(), bStrictCheck);
+  return URIUtils::IsInternetStream(item.GetPath());
 }
 
 bool IsRemote(const CFileItem& item)

--- a/xbmc/network/NetworkFileItemClassify.h
+++ b/xbmc/network/NetworkFileItemClassify.h
@@ -14,7 +14,7 @@ namespace KODI::NETWORK
 {
 
 //! \brief Check whether an item is a an internet stream.
-bool IsInternetStream(const CFileItem& item, const bool bStrictCheck = false);
+bool IsInternetStream(const CFileItem& item);
 
 //! \brief Check whether an item is on a remote location.
 bool IsRemote(const CFileItem& item);

--- a/xbmc/network/test/TestNetworkFileItemClassify.cpp
+++ b/xbmc/network/test/TestNetworkFileItemClassify.cpp
@@ -33,120 +33,58 @@ struct SimpleDefinition
 
 } // namespace
 
-struct InternetStreamDefinition
-{
-  InternetStreamDefinition(const std::string& path, bool folder, bool strict, bool res)
-    : item(path, folder), strictCheck(strict), result(res)
-  {
-  }
-
-  CFileItem item;
-  bool strictCheck;
-  bool result;
-};
-
-class InternetStreamTest : public testing::WithParamInterface<InternetStreamDefinition>,
+class InternetStreamTest : public testing::WithParamInterface<SimpleDefinition>,
                            public testing::Test
 {
 };
 
 TEST_P(InternetStreamTest, IsInternetStream)
 {
-  EXPECT_EQ(NETWORK::IsInternetStream(GetParam().item, GetParam().strictCheck), GetParam().result);
+  EXPECT_EQ(NETWORK::IsInternetStream(GetParam().item), GetParam().result);
 }
 
 const auto inetstream_tests = std::array{
-    InternetStreamDefinition{"/home/user/test.disc", false, false, false},
-    InternetStreamDefinition{"/home/user/test.disc", true, true, false},
-    InternetStreamDefinition{"http://some.where/foo", false, false, true},
-    InternetStreamDefinition{"http://some.where/foo", false, true, true},
-    InternetStreamDefinition{"http://some.where/foo", true, false, true},
-    InternetStreamDefinition{"http://some.where/foo", true, true, true},
-    InternetStreamDefinition{"https://some.where/foo", false, false, true},
-    InternetStreamDefinition{"https://some.where/foo", false, true, true},
-    InternetStreamDefinition{"https://some.where/foo", true, false, true},
-    InternetStreamDefinition{"https://some.where/foo", true, true, true},
-    InternetStreamDefinition{"tcp://some.where/foo", false, false, true},
-    InternetStreamDefinition{"tcp://some.where/foo", false, true, true},
-    InternetStreamDefinition{"tcp://some.where/foo", true, false, true},
-    InternetStreamDefinition{"tcp://some.where/foo", true, true, true},
-    InternetStreamDefinition{"udp://some.where/foo", false, false, true},
-    InternetStreamDefinition{"udp://some.where/foo", false, true, true},
-    InternetStreamDefinition{"udp://some.where/foo", true, false, true},
-    InternetStreamDefinition{"udp://some.where/foo", true, true, true},
-    InternetStreamDefinition{"rtp://some.where/foo", false, false, true},
-    InternetStreamDefinition{"rtp://some.where/foo", false, false, true},
-    InternetStreamDefinition{"rtp://some.where/foo", true, false, true},
-    InternetStreamDefinition{"rtp://some.where/foo", true, true, true},
-    InternetStreamDefinition{"sdp://some.where/foo", false, false, true},
-    InternetStreamDefinition{"sdp://some.where/foo", false, true, true},
-    InternetStreamDefinition{"sdp://some.where/foo", true, false, true},
-    InternetStreamDefinition{"sdp://some.where/foo", true, true, true},
-    InternetStreamDefinition{"mms://some.where/foo", false, false, true},
-    InternetStreamDefinition{"mms://some.where/foo", false, true, true},
-    InternetStreamDefinition{"mms://some.where/foo", true, false, true},
-    InternetStreamDefinition{"mms://some.where/foo", true, true, true},
-    InternetStreamDefinition{"mmst://some.where/foo", false, false, true},
-    InternetStreamDefinition{"mmst://some.where/foo", false, true, true},
-    InternetStreamDefinition{"mmst://some.where/foo", true, false, true},
-    InternetStreamDefinition{"mmst://some.where/foo", true, true, true},
-    InternetStreamDefinition{"mmsh://some.where/foo", false, false, true},
-    InternetStreamDefinition{"mmsh://some.where/foo", false, true, true},
-    InternetStreamDefinition{"mmsh://some.where/foo", true, false, true},
-    InternetStreamDefinition{"mmsh://some.where/foo", true, true, true},
-    InternetStreamDefinition{"rtsp://some.where/foo", false, false, true},
-    InternetStreamDefinition{"rtsp://some.where/foo", false, true, true},
-    InternetStreamDefinition{"rtsp://some.where/foo", true, false, true},
-    InternetStreamDefinition{"rtsp://some.where/foo", true, true, true},
-    InternetStreamDefinition{"rtmp://some.where/foo", false, false, true},
-    InternetStreamDefinition{"rtmp://some.where/foo", false, true, true},
-    InternetStreamDefinition{"rtmp://some.where/foo", true, false, true},
-    InternetStreamDefinition{"rtmp://some.where/foo", true, true, true},
-    InternetStreamDefinition{"rtmpt://some.where/foo", false, false, true},
-    InternetStreamDefinition{"rtmpt://some.where/foo", false, true, true},
-    InternetStreamDefinition{"rtmpt://some.where/foo", true, false, true},
-    InternetStreamDefinition{"rtmpt://some.where/foo", true, true, true},
-    InternetStreamDefinition{"rtmpe://some.where/foo", false, false, true},
-    InternetStreamDefinition{"rtmpe://some.where/foo", false, true, true},
-    InternetStreamDefinition{"rtmpe://some.where/foo", true, false, true},
-    InternetStreamDefinition{"rtmpe://some.where/foo", true, true, true},
-    InternetStreamDefinition{"rtmpte://some.where/foo", false, false, true},
-    InternetStreamDefinition{"rtmpte://some.where/foo", false, true, true},
-    InternetStreamDefinition{"rtmpte://some.where/foo", true, false, true},
-    InternetStreamDefinition{"rtmpte://some.where/foo", true, true, true},
-    InternetStreamDefinition{"rtmps://some.where/foo", false, false, true},
-    InternetStreamDefinition{"rtmps://some.where/foo", false, true, true},
-    InternetStreamDefinition{"rtmps://some.where/foo", true, false, true},
-    InternetStreamDefinition{"rtmps://some.where/foo", true, true, true},
-    InternetStreamDefinition{"shout://some.where/foo", false, false, true},
-    InternetStreamDefinition{"shout://some.where/foo", false, true, true},
-    InternetStreamDefinition{"shout://some.where/foo", true, false, true},
-    InternetStreamDefinition{"shout://some.where/foo", true, true, true},
-    InternetStreamDefinition{"rss://some.where/foo", false, false, true},
-    InternetStreamDefinition{"rss://some.where/foo", false, true, true},
-    InternetStreamDefinition{"rss://some.where/foo", true, false, true},
-    InternetStreamDefinition{"rss://some.where/foo", true, true, true},
-    InternetStreamDefinition{"rsss://some.where/foo", false, false, true},
-    InternetStreamDefinition{"rsss://some.where/foo", false, true, true},
-    InternetStreamDefinition{"rsss://some.where/foo", true, false, true},
-    InternetStreamDefinition{"rsss://some.where/foo", true, true, true},
-    InternetStreamDefinition{"upnp://some.where/foo", false, false, false},
-    InternetStreamDefinition{"upnp://some.where/foo", true, false, false},
-    InternetStreamDefinition{"upnp://some.where/foo", false, true, true},
-    InternetStreamDefinition{"upnp://some.where/foo", true, true, true},
-    InternetStreamDefinition{"ftp://some.where/foo", false, false, false},
-    InternetStreamDefinition{"ftp://some.where/foo", true, false, false},
-    InternetStreamDefinition{"ftp://some.where/foo", false, true, true},
-    InternetStreamDefinition{"ftp://some.where/foo", true, true, true},
-    InternetStreamDefinition{"sftp://some.where/foo", false, false, false},
-    InternetStreamDefinition{"sftp://some.where/foo", true, false, false},
-    InternetStreamDefinition{"sftp://some.where/foo", false, true, true},
-    InternetStreamDefinition{"sftp://some.where/foo", true, true, true},
-    InternetStreamDefinition{"ssh://some.where/foo", false, false, false},
-    InternetStreamDefinition{"ssh://some.where/foo", true, false, false},
-    InternetStreamDefinition{"ssh://some.where/foo", false, true, true},
-    InternetStreamDefinition{"ssh://some.where/foo", true, true, true},
-    InternetStreamDefinition{"ssh://some.where/foo", true, true, true},
+    SimpleDefinition{"/home/user/test.disc", false, false},
+    SimpleDefinition{"http://some.where/foo", false, true},
+    SimpleDefinition{"http://some.where/foo", true, true},
+    SimpleDefinition{"https://some.where/foo", false, true},
+    SimpleDefinition{"https://some.where/foo", true, true},
+    SimpleDefinition{"tcp://some.where/foo", false, true},
+    SimpleDefinition{"tcp://some.where/foo", true, true},
+    SimpleDefinition{"udp://some.where/foo", false, true},
+    SimpleDefinition{"udp://some.where/foo", true, true},
+    SimpleDefinition{"rtp://some.where/foo", false, true},
+    SimpleDefinition{"rtp://some.where/foo", true, true},
+    SimpleDefinition{"sdp://some.where/foo", false, true},
+    SimpleDefinition{"sdp://some.where/foo", true, true},
+    SimpleDefinition{"mms://some.where/foo", false, true},
+    SimpleDefinition{"mms://some.where/foo", true, true},
+    SimpleDefinition{"mmst://some.where/foo", false, true},
+    SimpleDefinition{"mmst://some.where/foo", true, true},
+    SimpleDefinition{"mmsh://some.where/foo", false, true},
+    SimpleDefinition{"mmsh://some.where/foo", true, true},
+    SimpleDefinition{"rtsp://some.where/foo", false, true},
+    SimpleDefinition{"rtsp://some.where/foo", true, true},
+    SimpleDefinition{"rtmp://some.where/foo", false, true},
+    SimpleDefinition{"rtmp://some.where/foo", true, true},
+    SimpleDefinition{"rtmpt://some.where/foo", false, true},
+    SimpleDefinition{"rtmpt://some.where/foo", true, true},
+    SimpleDefinition{"rtmpe://some.where/foo", false, true},
+    SimpleDefinition{"rtmpe://some.where/foo", true, true},
+    SimpleDefinition{"rtmpte://some.where/foo", false, true},
+    SimpleDefinition{"rtmpte://some.where/foo", true, true},
+    SimpleDefinition{"rtmps://some.where/foo", false, true},
+    SimpleDefinition{"rtmps://some.where/foo", true, true},
+    SimpleDefinition{"shout://some.where/foo", false, true},
+    SimpleDefinition{"shout://some.where/foo", true, true},
+    SimpleDefinition{"rss://some.where/foo", false, true},
+    SimpleDefinition{"rss://some.where/foo", true, true},
+    SimpleDefinition{"rsss://some.where/foo", false, true},
+    SimpleDefinition{"rsss://some.where/foo", true, true},
+    SimpleDefinition{"upnp://some.where/foo", false, false},
+    SimpleDefinition{"ftp://some.where/foo", false, false},
+    SimpleDefinition{"sftp://some.where/foo", false, false},
+    SimpleDefinition{"ssh://some.where/foo", false, false},
 };
 
 INSTANTIATE_TEST_SUITE_P(TestNetworkFileItemClassify,
@@ -158,38 +96,27 @@ TEST(TestNetworkWorkFileItemClassify, InternetStreamStacks)
   std::string stackPath;
   EXPECT_TRUE(XFILE::CStackDirectory::ConstructStackPath(
       {"/home/foo/somthing.avi", "/home/bar/else.mkv"}, stackPath));
-  EXPECT_FALSE(NETWORK::IsInternetStream(CFileItem(stackPath, false), false));
-  EXPECT_FALSE(NETWORK::IsInternetStream(CFileItem(stackPath, true), false));
-  EXPECT_FALSE(NETWORK::IsInternetStream(CFileItem(stackPath, false), true));
-  EXPECT_FALSE(NETWORK::IsInternetStream(CFileItem(stackPath, true), true));
+  EXPECT_FALSE(NETWORK::IsInternetStream(CFileItem(stackPath, false)));
+  EXPECT_FALSE(NETWORK::IsInternetStream(CFileItem(stackPath, true)));
 
   EXPECT_TRUE(XFILE::CStackDirectory::ConstructStackPath(
       {"https://home/foo/somthing.avi", "https://home/bar/else.mkv"}, stackPath));
-  EXPECT_TRUE(NETWORK::IsInternetStream(CFileItem(stackPath, false), false));
-  EXPECT_TRUE(NETWORK::IsInternetStream(CFileItem(stackPath, true), false));
-  EXPECT_TRUE(NETWORK::IsInternetStream(CFileItem(stackPath, false), true));
-  EXPECT_TRUE(NETWORK::IsInternetStream(CFileItem(stackPath, true), true));
+  EXPECT_TRUE(NETWORK::IsInternetStream(CFileItem(stackPath, false)));
+  EXPECT_TRUE(NETWORK::IsInternetStream(CFileItem(stackPath, true)));
 
   EXPECT_TRUE(XFILE::CStackDirectory::ConstructStackPath(
       {"ftp://home/foo/somthing.avi", "ftp://home/bar/else.mkv"}, stackPath));
-  EXPECT_FALSE(NETWORK::IsInternetStream(CFileItem(stackPath, false), false));
-  EXPECT_FALSE(NETWORK::IsInternetStream(CFileItem(stackPath, true), false));
-  EXPECT_TRUE(NETWORK::IsInternetStream(CFileItem(stackPath, false), true));
-  EXPECT_TRUE(NETWORK::IsInternetStream(CFileItem(stackPath, true), true));
-
-  EXPECT_TRUE(XFILE::CStackDirectory::ConstructStackPath(
-      {"ftp://home/foo/somthing.avi", "/home/bar/else.mkv"}, stackPath));
-  EXPECT_FALSE(NETWORK::IsInternetStream(CFileItem(stackPath, false), false));
-  EXPECT_FALSE(NETWORK::IsInternetStream(CFileItem(stackPath, true), false));
-  EXPECT_TRUE(NETWORK::IsInternetStream(CFileItem(stackPath, false), true));
-  EXPECT_TRUE(NETWORK::IsInternetStream(CFileItem(stackPath, true), true));
+  EXPECT_FALSE(NETWORK::IsInternetStream(CFileItem(stackPath, false)));
+  EXPECT_FALSE(NETWORK::IsInternetStream(CFileItem(stackPath, true)));
 
   EXPECT_TRUE(XFILE::CStackDirectory::ConstructStackPath(
       {"/home/foo/somthing.avi", "ftp://home/bar/else.mkv"}, stackPath));
-  EXPECT_FALSE(NETWORK::IsInternetStream(CFileItem(stackPath, false), false));
-  EXPECT_FALSE(NETWORK::IsInternetStream(CFileItem(stackPath, true), false));
-  EXPECT_FALSE(NETWORK::IsInternetStream(CFileItem(stackPath, false), true));
-  EXPECT_FALSE(NETWORK::IsInternetStream(CFileItem(stackPath, true), true));
+  EXPECT_FALSE(NETWORK::IsInternetStream(CFileItem(stackPath, false)));
+  EXPECT_FALSE(NETWORK::IsInternetStream(CFileItem(stackPath, true)));
+
+  CFileItem item("https://some.where/", true);
+  item.SetProperty("IsHTTPDirectory", true);
+  EXPECT_FALSE(NETWORK::IsInternetStream(item));
 }
 
 class RemoteTest : public testing::WithParamInterface<SimpleDefinition>, public testing::Test


### PR DESCRIPTION
## Description
Drop unused parameter and use the fact that DynPath() returns Path() if no dynpath is available.

## Motivation and context
Simpler code is better code

## How has this been tested?
It builds and (modified) tests pass

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
