### PR TITLE
[PVR] Timer settings dialog: Fix selection of current channel, …

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -983,6 +983,31 @@ void CGUIDialogPVRTimerSettings::ChannelsFiller(const SettingConstPtr& setting,
         foundCurrent = true;
       }
     }
+
+    if (foundCurrent)
+    {
+      // Verify m_channel is still valid. Update if not.
+      if (std::find_if(list.cbegin(), list.cend(),
+                       [&current](const auto& channel)
+                       { return channel.value == current; }) == list.cend())
+      {
+        // Set m_channel and current to first valid channel in list
+        const int first{list.front().value};
+        const auto it =
+            std::find_if(pThis->m_channelEntries.cbegin(), pThis->m_channelEntries.cend(),
+                         [first](const auto& channel) { return channel.first == first; });
+
+        if (it != pThis->m_channelEntries.cend())
+        {
+          current = (*it).first;
+          pThis->m_channel = (*it).second;
+        }
+        else
+        {
+          CLog::LogF(LOGERROR, "Unable to find channel to select");
+        }
+      }
+    }
   }
   else
     CLog::LogF(LOGERROR, "No dialog");


### PR DESCRIPTION
…for example on change of client due to selection of another timer type.

If you run a multi-PVR-client setup, and change the timer type from a type from client A to a type provided by client B, then the 'Channel' field of the timer settings dialog was empty afterwards. With this PR, the first valid channel from client B will be selected on timer type change from client A to client B.

Runtime-tested on macOS and Android.

@phunkyfish please review, thanks.