### PR TITLE
[PVR] Fix crash on creation of epg-based reminder rule with 'any channel'…

### DIFF
--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -511,7 +511,7 @@ bool CPVRTimers::UpdateEntries(int iMaxNotificationDelay)
       bool bDeleteTimer = false;
       if (!timer->IsOwnedByClient())
       {
-        if (timer->IsEpgBased())
+        if (timer->IsEpgBased() && timer->Channel())
         {
           // update epg tag
           const std::shared_ptr<const CPVREpg> epg =


### PR DESCRIPTION
… set instead of a certain channel.

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish a no-brainer to review I guess.