### PR TITLE
[cmake][modules] FindBluray correctly append rather than set compile definition

### DIFF
--- a/cmake/modules/FindBluray.cmake
+++ b/cmake/modules/FindBluray.cmake
@@ -69,8 +69,8 @@ if(NOT TARGET Bluray::Bluray)
     endif()
 
     if(NOT CORE_PLATFORM_NAME_LC STREQUAL windowsstore)
-      set_target_properties(Bluray::Bluray PROPERTIES
-                                           INTERFACE_COMPILE_DEFINITIONS "HAVE_LIBBLURAY_BDJ=1")
+      set_property(TARGET Bluray::Bluray APPEND PROPERTY
+                                                INTERFACE_COMPILE_DEFINITIONS "HAVE_LIBBLURAY_BDJ")
     endif()
 
     set_property(GLOBAL APPEND PROPERTY INTERNAL_DEPS_PROP Bluray::Bluray)


### PR DESCRIPTION
## Description
Fixes #25184 

## Motivation and context
Fix #25184. @78andyp if you wouldnt mind confirming.

## How has this been tested?
Windows/macos correctly set HAVE_LIBBLURAY

## What is the effect on users?
Fixes bluray support

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
