### PR TITLE
[Video] Fix Episode NFO parsing error (introduced in #24565)

### DIFF
--- a/xbmc/NfoFile.cpp
+++ b/xbmc/NfoFile.cpp
@@ -11,7 +11,6 @@
 
 #include "NfoFile.h"
 
-#include "FileItem.h"
 #include "FileItemList.h"
 #include "ServiceBroker.h"
 #include "addons/AddonManager.h"
@@ -60,13 +59,12 @@ CInfoScanner::INFO_TYPE CNfoFile::Create(const std::string& strPath,
       int infos=0;
       while (m_headPos != std::string::npos && details.m_iEpisode != episode)
       {
-        m_headPos = m_doc.find("<episodedetails", m_headPos);
+        m_headPos = m_doc.find("<episodedetails", m_headPos + 1);
         if (m_headPos == std::string::npos)
           break;
 
         bNfo  = GetDetails(details);
         infos++;
-        m_headPos++;
       }
       if (details.m_iEpisode != episode)
       {


### PR DESCRIPTION
## Description

As reported in the forum https://forum.kodi.tv/showthread.php?tid=377480.

Error introduced in #24565 (I cannot reproduce the problem I was attempting to fix).

Also removed unneeded #include.

## Motivation and context

Fix episode NFO parsing

## How has this been tested?

Locally

## What is the effect on users?

As above.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
