### PR TITLE
[PVR] Timer settings dialog: Add client name to 'Any channel' value s…

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -3916,7 +3916,13 @@ msgctxt "#852"
 msgid "Valid port range is 1024-65535"
 msgstr ""
 
-#empty strings from id 853 to 996
+#. Label for denoting any channel for a certain client in timer settings dialog
+#: xbmc/pvr/dialogs/GUIDislogPVRTimerSettings.cpp
+msgctxt "#853"
+msgid "Any channel from client \"{0:s}\""
+msgstr ""
+
+#empty strings from id 854 to 996
 
 #: xbmc/windows/GUIMediaWindow.cpp
 msgctxt "#997"

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -890,7 +890,12 @@ void CGUIDialogPVRTimerSettings::InitializeChannelsList()
   {
     m_channelEntries.insert(
         {index, ChannelDescriptor(PVR_CHANNEL_INVALID_UID, client.second->GetID(),
-                                  g_localizeStrings.Get(809))}); // "Any channel"
+                                  clients.size() == 1
+                                      // Any channel
+                                      ? g_localizeStrings.Get(809)
+                                      // Any channel from client "X"
+                                      : StringUtils::Format(g_localizeStrings.Get(853),
+                                                            client.second->GetFullClientName()))});
     ++index;
   }
 


### PR DESCRIPTION
…o the values can be distinguished by the user.

When creating an epg-based reminder rule in a multi-client setup, the 'any channel' labels in timer settings dialog had all the same label, making it impossible to safely pick an entry for the intended client.

Thus, I consider this a fix not just an improvement.

This PR adds the full client name to the 'any channel' labels, if multiple clients are active.

Before:
![screenshot00003](https://github.com/xbmc/xbmc/assets/3226626/0faf2ee3-991b-4c3c-a4b6-58b86dadd6bd)

After: 
![screenshot00004](https://github.com/xbmc/xbmc/assets/3226626/bba2badc-78ca-4b63-9414-cb891614387b)

Runtime-tested on macOS and android, latest Kodi master.

@phunkyfish should be an easy one for a review.