### PR TITLE
GL/GLES: split off GLES from GLTexture

### DIFF
--- a/xbmc/guilib/CMakeLists.txt
+++ b/xbmc/guilib/CMakeLists.txt
@@ -160,23 +160,25 @@ set(HEADERS DDSImage.h
             XBTFReader.h)
 
 if(TARGET OpenGL::GL OR TARGET OpenGL::GLES)
-  list(APPEND SOURCES Shader.cpp
-                      TextureGL.cpp)
-  list(APPEND HEADERS Shader.h
-                      TextureGL.h)
+  list(APPEND SOURCES Shader.cpp)
+  list(APPEND HEADERS Shader.h)
 
   if(TARGET OpenGL::GL)
     list(APPEND SOURCES GUIFontTTFGL.cpp
-                        GUITextureGL.cpp)
+                        GUITextureGL.cpp
+                        TextureGL.cpp)
     list(APPEND HEADERS GUIFontTTFGL.h
-                        GUITextureGL.h)
+                        GUITextureGL.h
+                        TextureGL.h)
   endif()
 
   if(TARGET OpenGL::GLES)
     list(APPEND SOURCES GUIFontTTFGLES.cpp
-                        GUITextureGLES.cpp)
+                        GUITextureGLES.cpp
+                        TextureGLES.cpp)
     list(APPEND HEADERS GUIFontTTFGLES.h
-                        GUITextureGLES.h)
+                        GUITextureGLES.h
+                        TextureGLES.h)
   endif()
 
 endif()

--- a/xbmc/guilib/TextureGLES.cpp
+++ b/xbmc/guilib/TextureGLES.cpp
@@ -6,7 +6,7 @@
  *  See LICENSES/README.md for more information.
  */
 
-#include "TextureGL.h"
+#include "TextureGLES.h"
 
 #include "ServiceBroker.h"
 #include "guilib/TextureManager.h"
@@ -23,35 +23,31 @@ std::unique_ptr<CTexture> CTexture::CreateTexture(unsigned int width,
                                                   unsigned int height,
                                                   XB_FMT format)
 {
-  return std::make_unique<CGLTexture>(width, height, format);
+  return std::make_unique<CGLESTexture>(width, height, format);
 }
 
-CGLTexture::CGLTexture(unsigned int width, unsigned int height, XB_FMT format)
+CGLESTexture::CGLESTexture(unsigned int width, unsigned int height, XB_FMT format)
   : CTexture(width, height, format)
 {
-  unsigned int major, minor;
-  CServiceBroker::GetRenderSystem()->GetRenderVersion(major, minor);
-  if (major >= 3)
-    m_isOglVersion3orNewer = true;
 }
 
-CGLTexture::~CGLTexture()
+CGLESTexture::~CGLESTexture()
 {
   DestroyTextureObject();
 }
 
-void CGLTexture::CreateTextureObject()
+void CGLESTexture::CreateTextureObject()
 {
-  glGenTextures(1, (GLuint*) &m_texture);
+  glGenTextures(1, (GLuint*)&m_texture);
 }
 
-void CGLTexture::DestroyTextureObject()
+void CGLESTexture::DestroyTextureObject()
 {
   if (m_texture)
     CServiceBroker::GetGUI()->GetTextureManager().ReleaseHwTexture(m_texture);
 }
 
-void CGLTexture::LoadToGPU()
+void CGLESTexture::LoadToGPU()
 {
   if (!m_pixels)
   {
@@ -73,13 +69,9 @@ void CGLTexture::LoadToGPU()
   // Set the texture's stretching properties
   if (IsMipmapped())
   {
-    GLenum mipmapFilter = (m_scalingMethod == TEXTURE_SCALING::NEAREST ? GL_LINEAR_MIPMAP_NEAREST : GL_LINEAR_MIPMAP_LINEAR);
+    GLenum mipmapFilter = (m_scalingMethod == TEXTURE_SCALING::NEAREST ? GL_LINEAR_MIPMAP_NEAREST
+                                                                       : GL_LINEAR_MIPMAP_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, mipmapFilter);
-
-    // Lower LOD bias equals more sharpness, but less smooth animation
-    glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_LOD_BIAS, -0.5f);
-    if (!m_isOglVersion3orNewer)
-      glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE);
   }
   else
   {
@@ -114,54 +106,58 @@ void CGLTexture::LoadToGPU()
               "GL: Image width {} too big to fit into single texture unit, truncating to {}",
               m_textureWidth, maxSize);
 
-    glPixelStorei(GL_UNPACK_ROW_LENGTH, m_textureWidth);
-
     m_textureWidth = maxSize;
   }
 
-  GLenum format = GL_BGRA;
-  GLint numcomponents = GL_RGBA;
+  // All incoming textures are BGRA, which GLES does not necessarily support.
+  // Some (most?) hardware supports BGRA textures via an extension.
+  // If not, we convert to RGBA first to avoid having to swizzle in shaders.
+  // Explicitly define GL_BGRA_EXT here in the case that it's not defined by
+  // system headers, and trust the extension list instead.
+#ifndef GL_BGRA_EXT
+#define GL_BGRA_EXT 0x80E1
+#endif
+
+  GLint internalformat;
+  GLenum pixelformat;
 
   switch (m_format)
   {
-  case XB_FMT_DXT1:
-    format = GL_COMPRESSED_RGBA_S3TC_DXT1_EXT;
-    break;
-  case XB_FMT_DXT3:
-    format = GL_COMPRESSED_RGBA_S3TC_DXT3_EXT;
-    break;
-  case XB_FMT_DXT5:
-  case XB_FMT_DXT5_YCoCg:
-    format = GL_COMPRESSED_RGBA_S3TC_DXT5_EXT;
-    break;
-  case XB_FMT_RGB8:
-    format = GL_RGB;
-    numcomponents = GL_RGB;
-    break;
-  case XB_FMT_A8R8G8B8:
-  default:
-    break;
+    default:
+    case XB_FMT_RGBA8:
+      internalformat = pixelformat = GL_RGBA;
+      break;
+    case XB_FMT_RGB8:
+      internalformat = pixelformat = GL_RGB;
+      break;
+    case XB_FMT_A8R8G8B8:
+      if (CServiceBroker::GetRenderSystem()->IsExtSupported("GL_EXT_texture_format_BGRA8888") ||
+          CServiceBroker::GetRenderSystem()->IsExtSupported("GL_IMG_texture_format_BGRA8888"))
+      {
+        internalformat = pixelformat = GL_BGRA_EXT;
+      }
+      else if (CServiceBroker::GetRenderSystem()->IsExtSupported(
+                   "GL_APPLE_texture_format_BGRA8888"))
+      {
+        // Apple's implementation does not conform to spec. Instead, they require
+        // differing format/internalformat, more like GL.
+        internalformat = GL_RGBA;
+        pixelformat = GL_BGRA_EXT;
+      }
+      else
+      {
+        SwapBlueRed(m_pixels, m_textureHeight, GetPitch());
+        internalformat = pixelformat = GL_RGBA;
+      }
+      break;
   }
+  glTexImage2D(GL_TEXTURE_2D, 0, internalformat, m_textureWidth, m_textureHeight, 0, pixelformat,
+               GL_UNSIGNED_BYTE, m_pixels);
 
-  if ((m_format & XB_FMT_DXT_MASK) == 0)
-  {
-    glTexImage2D(GL_TEXTURE_2D, 0, numcomponents,
-                 m_textureWidth, m_textureHeight, 0,
-                 format, GL_UNSIGNED_BYTE, m_pixels);
-  }
-  else
-  {
-    glCompressedTexImage2D(GL_TEXTURE_2D, 0, format,
-                           m_textureWidth, m_textureHeight, 0,
-                           GetPitch() * GetRows(), m_pixels);
-  }
-
-  if (IsMipmapped() && m_isOglVersion3orNewer)
+  if (IsMipmapped())
   {
     glGenerateMipmap(GL_TEXTURE_2D);
   }
-
-  glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
 
   VerifyGLState();
 
@@ -174,9 +170,8 @@ void CGLTexture::LoadToGPU()
   m_loadedToGPU = true;
 }
 
-void CGLTexture::BindToUnit(unsigned int unit)
+void CGLESTexture::BindToUnit(unsigned int unit)
 {
   glActiveTexture(GL_TEXTURE0 + unit);
   glBindTexture(GL_TEXTURE_2D, m_texture);
 }
-

--- a/xbmc/guilib/TextureGLES.h
+++ b/xbmc/guilib/TextureGLES.h
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "Texture.h"
+
+#include "system_gl.h"
+
+/************************************************************************/
+/*    CGLESTexture                                                       */
+/************************************************************************/
+class CGLESTexture : public CTexture
+{
+public:
+  CGLESTexture(unsigned int width = 0, unsigned int height = 0, XB_FMT format = XB_FMT_A8R8G8B8);
+  ~CGLESTexture() override;
+
+  void CreateTextureObject() override;
+  void DestroyTextureObject() override;
+  void LoadToGPU() override;
+  void BindToUnit(unsigned int unit) override;
+
+protected:
+  GLuint m_texture = 0;
+};

--- a/xbmc/guilib/TextureGLES.h
+++ b/xbmc/guilib/TextureGLES.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2024 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -12,9 +12,6 @@
 
 #include "system_gl.h"
 
-/************************************************************************/
-/*    CGLESTexture                                                       */
-/************************************************************************/
 class CGLESTexture : public CTexture
 {
 public:
@@ -28,4 +25,5 @@ public:
 
 protected:
   GLuint m_texture = 0;
+  bool m_isGLESVersion30orNewer{false};
 };


### PR DESCRIPTION
## Description
This PR splits off the GLES part of GLTexture.

## Motivation and context
No more ifdeffery (https://github.com/xbmc/xbmc/pull/25205).

## How has this been tested?
GL and GLES compile and run fine.

## What is the effect on users?
None.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
