### PR TITLE
[groovy] don't use wildcards in classpath instead point out exact jar

### DIFF
--- a/xbmc/interfaces/swig/CMakeLists.txt
+++ b/xbmc/interfaces/swig/CMakeLists.txt
@@ -1,7 +1,9 @@
 function(generate_file file)
-  set(classpath ${groovy_SOURCE_DIR}/lib/*
-                ${apache-commons-lang_SOURCE_DIR}/*
-                ${apache-commons-text_SOURCE_DIR}/*
+  set(classpath ${groovy_SOURCE_DIR}/lib/groovy-${GROOVY_VER}.jar
+                ${groovy_SOURCE_DIR}/lib/groovy-xml-${GROOVY_VER}.jar
+                ${groovy_SOURCE_DIR}/lib/groovy-templates-${GROOVY_VER}.jar
+                ${apache-commons-lang_SOURCE_DIR}/commons-lang3-${APACHE_COMMONS_LANG_VER}.jar
+                ${apache-commons-text_SOURCE_DIR}/commons-text-${APACHE_COMMONS_TEXT_VER}.jar
                 ${CMAKE_SOURCE_DIR}/tools/codegenerator
                 ${CMAKE_CURRENT_SOURCE_DIR}/../python)
   if(NOT CORE_SYSTEM_NAME STREQUAL windows AND NOT CORE_SYSTEM_NAME STREQUAL windowsstore)


### PR DESCRIPTION
## Description
The issue is triggered when java is used in containerized environment.
When the container tool mounts/binds ext4 fs directly or with an overlayfs, the wildcard used in CLASSPATH (-cp) of java is not processing all the files pointed. This seems to happen only when host and the contaniner has different architecture (ie: 32 vs 64). So not every containerized env has this issue.

Workarounds:
For overlays fs, giving an option xino=on prevents this happening, for systemd-nspawn, --bind argument does mount with xino=off, therefore i could not find a way to modify this.

For ext4 mounting to container, i could not find a workaround.

General workaround in Kodi Buildsystem is to point directly to jar files instead of using wildcards.


## Motivation and context
It prevents some existing and potential future build errors

## How has this been tested?
in archlinux x86_64 host running aarhc64 and armv7h container.

## What is the effect on users?
fixes https://github.com/xbmc/xbmc/issues/24225

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
