### PR TITLE
[video] Allow changing the type of a movie asset between version and extra

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
@@ -131,9 +131,9 @@ bool CGUIDialogVideoManagerExtras::AddVideoExtra()
 
     if (newAsset.m_idFile != -1 && newAsset.m_assetTypeId != -1)
     {
-      // The video already is an asset of the movie
-      if (newAsset.m_idMedia == dbId &&
-          newAsset.m_mediaType == m_videoAsset->GetVideoInfoTag()->m_type)
+      // The video already is an extra of the movie
+      if (newAsset.m_idMedia == dbId && newAsset.m_mediaType == mediaType &&
+          newAsset.m_assetType == VideoAssetType::EXTRA)
       {
         unsigned int msgid{};
 
@@ -153,9 +153,9 @@ bool CGUIDialogVideoManagerExtras::AddVideoExtra()
         return false;
       }
 
-      // The video is an asset of another movie
+      // The video is an asset of another movie or different asset type of same movie
 
-      // The video is a version, ask for confirmation
+      // The video is a version, ask for confirmation of the asset type change
       if (newAsset.m_assetType == VideoAssetType::VERSION &&
           !CGUIDialogYesNo::ShowAndGetInput(CVariant{40015},
                                             StringUtils::Format(g_localizeStrings.Get(40036))))
@@ -171,6 +171,7 @@ bool CGUIDialogVideoManagerExtras::AddVideoExtra()
       else
         return false;
 
+      if (newAsset.m_idMedia != dbId && newAsset.m_mediaType == mediaType)
       {
         unsigned int msgid{};
 

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -498,9 +498,9 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
     // @todo look only for a version identified by idFile instead of retrieving all versions
     if (newAsset.m_idFile != -1 && newAsset.m_assetTypeId != -1)
     {
-      // The video already is an asset of the movie
-      if (newAsset.m_idMedia == dbId &&
-          newAsset.m_mediaType == m_videoAsset->GetVideoInfoTag()->m_type)
+      // The video already is a version of the movie
+      if (newAsset.m_idMedia == dbId && newAsset.m_mediaType == mediaType &&
+          newAsset.m_assetType == VideoAssetType::VERSION)
       {
         unsigned int msgid{};
 
@@ -520,9 +520,9 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
         return false;
       }
 
-      // The video is an asset of another movie
+      // The video is an asset of another movie or different asset type of same movie
 
-      // The video is an extra, ask for confirmation
+      // The video is an extra, ask for confirmation of the asset type change
       if (newAsset.m_assetType == VideoAssetType::EXTRA &&
           !CGUIDialogYesNo::ShowAndGetInput(CVariant{40014},
                                             StringUtils::Format(g_localizeStrings.Get(40035))))
@@ -538,6 +538,7 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
       else
         return false;
 
+      if (newAsset.m_idMedia != dbId && newAsset.m_mediaType == mediaType)
       {
         unsigned int msgid{};
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

There was no reason to prevent the change of a movie version into an extra of the same movie (or vice versa).

That type of change is done through the "Add" button of the Versions/Extras Manger dialog and was already allowed and working when turning a movie version into an extra of a different movie for example.

The PR fine-tunes a couple conditions when adding a file as version or extra to a movie:
- Same movie and same asset type (adding a version and asset was a version): rejected - should use the rename function instead
- Same movie and different asset type (adding a version and the asset was an extra, or adding an extra and the asset was a version): allowed

- The confirmation popup about moving an asset to a different movie only shows when actually moving an asset to a different movie. Was showing in other cases as well before PR.


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Reported by patk in Slack.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Changed movie version into extra of same movie, changed movie extra into version of same movie.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Remove surprising behavior of versions/extras manager add buttons.

## Screenshots (if appropriate):
Before:
![image](https://github.com/xbmc/xbmc/assets/489377/d5ef725e-8d79-4649-adc2-7e6c92d0184c)

![image](https://github.com/xbmc/xbmc/assets/489377/a9065bc0-dc4d-4994-8c3e-b5a29ed02bc8)


After:
![image](https://github.com/xbmc/xbmc/assets/489377/29dee7e4-2057-4d68-90c6-7bec343294e0)

![image](https://github.com/xbmc/xbmc/assets/489377/aa8841c0-d92c-46a9-88d3-19b7ef419ffb)

![image](https://github.com/xbmc/xbmc/assets/489377/4efee582-9865-4b9c-aa19-8da062f262d9)

![image](https://github.com/xbmc/xbmc/assets/489377/690ffcdc-0e40-4e77-904d-12e04668d34a)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
