### PR TITLE
VideoPlayerAudio: limit max allowed Out-Of-Sync for "self-learning" to 80 ms

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -558,8 +558,8 @@ bool CVideoPlayerAudio::ProcessDecoderOutput(DVDAudioFrame &audioframe)
       {
         m_disconLearning = false;
         m_disconAdjustTimeMs = (static_cast<double>(m_disconAdjustTimeMs) * 1.15) + 5.0;
-        if (m_disconAdjustTimeMs > 100) // sanity check
-          m_disconAdjustTimeMs = 100;
+        if (m_disconAdjustTimeMs > 80) // sanity check
+          m_disconAdjustTimeMs = 80;
 
         CLog::LogF(LOGINFO, "Changed max allowed Out-Of-Sync value to {} ms due self-learning",
                    m_disconAdjustTimeMs);


### PR DESCRIPTION
## Description
VideoPlayerAudio: limit max allowed Out-Of-Sync for "self-learning" to 80 ms

## Motivation and context
As commented in https://github.com/xbmc/xbmc/pull/25229 recently found that use high values for `maxpassthroughoffsyncduration` e.g. 96 ms breaks a/v sync corrections because AE cannot correct error bigger that 2 * frame time. And since current "self-learning" algo calculates this value based in first seconds of stream is very influenced by bad a/v sync at start (and not yet corrected) and noise in error calculations (system clock irregularities, etc.).

With all this is possible too large values (even max. 100 ms) that cause error is accumulated and never corrected or too small values (25/30 ms) that may cause accidental corrections if error is bigger later (or noise in error only). 

~Then is better replace self-learning with a frame time based value, obtaining much more predictable operation.~

~`1.5 * frame_time` seems good value and has been well tested. Higher values could be used and up to 1.95 * frame_time has been tested to work well (a/v corrections occur when necessary) but not has much sense use high values now because the main use case is TrueHD (due error oscillation) but now this is mitigated in https://github.com/xbmc/xbmc/pull/25229 and no visible frame skips/repeats with 62 ms.~

In general high values produces worse a/v sync because allows bigger stationary error (never corrected).

Users still may use high values via advancedsettings ~but a log warning is printed if value is > 1.95 * frame_time.~

If any cases are discovered where accidental corrections continue to occur, instead of raising the threshold, the root cause should be investigated and reduce the error or noise in error, etc.

## How has this been tested?
Runtime Shield

## What is the effect on users?
For users who did not use advancedsettings it's a significant improvement because it prevents random problems because the value used could be too large ~or too low~ in specific (random) cases.

For users who use advancedsettings nothing changes ~but it is encouraged to use "better" values.~

## Screenshots (if appropriate):
Two very different cases in which the value of 1.5 * frame time works well:

![FreeGuy-62](https://github.com/xbmc/xbmc/assets/58434170/b2d34aa2-9095-4025-b9a4-b1933f45d9b3)

![Cars-62](https://github.com/xbmc/xbmc/assets/58434170/dcc4010e-8ac3-41f3-8ca1-ff43a1dd845d)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
