### PR TITLE
[BP] Fix rare random audio dropouts in some TrueHD sources (passthrough)

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -558,8 +558,8 @@ bool CVideoPlayerAudio::ProcessDecoderOutput(DVDAudioFrame &audioframe)
       {
         m_disconLearning = false;
         m_disconAdjustTimeMs = (static_cast<double>(m_disconAdjustTimeMs) * 1.15) + 5.0;
-        if (m_disconAdjustTimeMs > 100) // sanity check
-          m_disconAdjustTimeMs = 100;
+        if (m_disconAdjustTimeMs > 80) // sanity check
+          m_disconAdjustTimeMs = 80;
 
         CLog::LogF(LOGINFO, "Changed max allowed Out-Of-Sync value to {} ms due self-learning",
                    m_disconAdjustTimeMs);


### PR DESCRIPTION
## Description
This is the backport of two small fixes (merged in master):

- https://github.com/xbmc/xbmc/pull/25229
- https://github.com/xbmc/xbmc/pull/25233

Recently found that high values of max allowed Out-Of-Sync (81 to 100ms) may cause random TrueHD dropouts due error oscillations are too close to the 100 ms threshold and a/v sync correction not to work the way it was designed (i.e instead of only video adjust, triggers AE major a/v sync mechanism).



## What is the effect on users?
Fix rare random audio dropouts in some TrueHD sources (only relevant for passthrough).




## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
