### PR TITLE
RenderSystemGL/GLES: Handle `glGetString(GL_VERSION)` returning a null pointer

### DIFF
--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -21,6 +21,8 @@
 #include "utils/log.h"
 #include "windowing/WinSystem.h"
 
+#include <exception>
+
 #if defined(TARGET_LINUX)
 #include "utils/EGLUtils.h"
 #endif
@@ -47,6 +49,12 @@ bool CRenderSystemGL::InitRenderSystem()
   {
     sscanf(ver, "%d.%d", &m_RenderVersionMajor, &m_RenderVersionMinor);
     m_RenderVersion = ver;
+  }
+  else
+  {
+    CLog::Log(LOGFATAL, "CRenderSystemGL::{} - glGetString(GL_VERSION) returned NULL, exiting",
+              __FUNCTION__);
+    std::terminate();
   }
 
   CLog::Log(LOGINFO, "CRenderSystemGL::{} - Version: {}, Major: {}, Minor: {}", __FUNCTION__, ver,

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -21,6 +21,8 @@
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
 
+#include <exception>
+
 #if defined(TARGET_LINUX)
 #include "utils/EGLUtils.h"
 #endif
@@ -51,6 +53,12 @@ bool CRenderSystemGLES::InitRenderSystem()
     if (!m_RenderVersionMajor)
       sscanf(ver, "%*s %*s %d.%d", &m_RenderVersionMajor, &m_RenderVersionMinor);
     m_RenderVersion = ver;
+  }
+  else
+  {
+    CLog::Log(LOGFATAL, "CRenderSystemGLES::{} - glGetString(GL_VERSION) returned NULL, exiting",
+              __FUNCTION__);
+    std::terminate();
   }
 
   // Get our driver vendor and renderer


### PR DESCRIPTION
## Description

There seem to be situations where  `glGetString(GL_VERSION)` returns a null pointer. To prevent a crash when logging the  version the returned value needs to checked and in case of `nullptr` an alternative string can be logged.

## Motivation and context

Fixes #25243.

## How has this been tested?

Not tested.

## What is the effect on users?

Kodi doesn't crash on this location though it's unclear what will happen afterwards.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
