### PR TITLE
FileCache: fix unnecessary use of StreamBuffer when is used FileCache

### DIFF
--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -101,8 +101,10 @@ bool CFileCache::Open(const CURL& url)
 
   CLog::Log(LOGDEBUG, "CFileCache::{} - <{}> opening", __FUNCTION__, m_sourcePath);
 
-  // opening the source file.
-  if (!m_source.Open(url.Get(), READ_NO_CACHE | READ_TRUNCATED | READ_CHUNKED))
+  // Opening the source file.
+  // The READ_NO_CACHE and READ_NO_BUFFER flags are required to avoid create other intances of
+  // FileCache or StreamBuffer since CFile::Open is called again in loop
+  if (!m_source.Open(url.Get(), READ_NO_CACHE | READ_TRUNCATED | READ_NO_BUFFER))
   {
     CLog::Log(LOGERROR, "CFileCache::{} - <{}> failed to open", __FUNCTION__, m_sourcePath);
     Close();


### PR DESCRIPTION
## Description
FileCache: fix unnecessary use of StreamBuffer when is used FileCache

## Motivation and context
Since the improvements in the StreamBuffer logic and configurable chunk size for SMB / NFS there is a latent bug that does not seem to have caused issues but is an unwanted behavior: StreamBuffer is used at the same time as FileCache when this is not necessary since FileCache it already allows read from the source with the appropriate chunk size on its own.

```
Current:
[ffmpeg/demuxer]  <----- [StreamBuffer] <----- [FileCache] <----- [network/source]


PR:
[ffmpeg/demuxer]  <----- [FileCache] <----- [network/source]
```


This is only when is in use FileCache, with FileCache disabled or not in use due type of source / location nothing changes:

```
Current and PR:
[ffmpeg/demuxer]  <----- [StreamBuffer]  <----- [network/source]
```

**NOTE:** this fix is also included in https://github.com/xbmc/xbmc/pull/25158 but I want split the fix only to backport to Omega.


## How has this been tested?
Tested in Shield (NFS mainly) several weeks.


## What is the effect on users?
No changes are expected, it doesn't even seem like it was penalizing performance. But because add-ons also make direct calls to open files and there are many use cases it is possible that something was broken because of this...

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
