### PR TITLE
[Backport][AudioEngine] Make a smarter choice between PulseAudio and PipeWire

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkPULSE.h
@@ -31,7 +31,7 @@ public:
   CAESinkPULSE();
   ~CAESinkPULSE() override;
 
-  static bool Register();
+  static bool Register(bool allowPipeWireCompatServer);
   static std::unique_ptr<IAESink> Create(std::string& device, AEAudioFormat& desiredFormat);
   static void EnumerateDevicesEx(AEDeviceInfoList &list, bool force = false);
   static void Cleanup();

--- a/xbmc/platform/freebsd/PlatformFreebsd.cpp
+++ b/xbmc/platform/freebsd/PlatformFreebsd.cpp
@@ -89,7 +89,7 @@ bool CPlatformFreebsd::InitStageOne()
   }
   else if (sink == "pulseaudio")
   {
-    OPTIONALS::PulseAudioRegister();
+    OPTIONALS::PulseAudioRegister(true);
   }
   else if (sink == "oss")
   {
@@ -102,11 +102,11 @@ bool CPlatformFreebsd::InitStageOne()
   else if (sink == "alsa+pulseaudio")
   {
     OPTIONALS::ALSARegister();
-    OPTIONALS::PulseAudioRegister();
+    OPTIONALS::PulseAudioRegister(true);
   }
   else
   {
-    if (!OPTIONALS::PulseAudioRegister())
+    if (!OPTIONALS::PulseAudioRegister(false))
     {
       if (!OPTIONALS::ALSARegister())
       {

--- a/xbmc/platform/linux/OptionalsReg.cpp
+++ b/xbmc/platform/linux/OptionalsReg.cpp
@@ -33,13 +33,13 @@ bool OPTIONALS::ALSARegister()
 
 #ifdef HAS_PULSEAUDIO
 #include "cores/AudioEngine/Sinks/AESinkPULSE.h"
-bool OPTIONALS::PulseAudioRegister()
+bool OPTIONALS::PulseAudioRegister(bool allowPipeWireCompatServer)
 {
-  bool ret = CAESinkPULSE::Register();
+  bool ret = CAESinkPULSE::Register(allowPipeWireCompatServer);
   return ret;
 }
 #else
-bool OPTIONALS::PulseAudioRegister()
+bool OPTIONALS::PulseAudioRegister(bool)
 {
   return false;
 }

--- a/xbmc/platform/linux/OptionalsReg.h
+++ b/xbmc/platform/linux/OptionalsReg.h
@@ -23,7 +23,7 @@ bool ALSARegister();
 
 namespace OPTIONALS
 {
-bool PulseAudioRegister();
+bool PulseAudioRegister(bool allowPipeWireCompatServer);
 }
 
 //-----------------------------------------------------------------------------

--- a/xbmc/platform/linux/PlatformLinux.cpp
+++ b/xbmc/platform/linux/PlatformLinux.cpp
@@ -101,7 +101,7 @@ bool CPlatformLinux::InitStageOne()
   }
   else if (sink == "pulseaudio")
   {
-    OPTIONALS::PulseAudioRegister();
+    OPTIONALS::PulseAudioRegister(true);
   }
   else if (sink == "pipewire")
   {
@@ -114,11 +114,11 @@ bool CPlatformLinux::InitStageOne()
   else if (sink == "alsa+pulseaudio")
   {
     OPTIONALS::ALSARegister();
-    OPTIONALS::PulseAudioRegister();
+    OPTIONALS::PulseAudioRegister(true);
   }
   else
   {
-    if (!OPTIONALS::PulseAudioRegister())
+    if (!OPTIONALS::PulseAudioRegister(false))
     {
       if (!OPTIONALS::PipewireRegister())
       {


### PR DESCRIPTION
## Description

Backport of #25043.

## Motivation and context

#25043 has been in master for ~1 month without complaints. I think it will be a better default experience for native PipeWire users then defaulting to PulseAudio again (see #25019). Especially since @lrusak fixed some problems in PipeWire itself :wink: 

## How has this been tested?

On Arch with a full PipeWire setup PipeWire is used by default. By passing `--audio-backend=pulseaudio` PulseAudio is used instead.

## What is the effect on users?

Better default choice of the used audio API.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
