### PR TITLE
[addons] Migrate AddonInfoBuilder to tinyxml2 usage

### DIFF
--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -32,6 +32,7 @@
 #include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
+#include "utils/XBMCTinyXML2.h"
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 
@@ -1359,14 +1360,15 @@ bool CAddonMgr::AddonsFromRepoXML(const RepositoryDirInfo& repo,
                                   const std::string& xml,
                                   std::vector<AddonInfoPtr>& addons)
 {
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   if (!doc.Parse(xml))
   {
     CLog::Log(LOGERROR, "CAddonMgr::{}: Failed to parse addons.xml", __func__);
     return false;
   }
 
-  if (doc.RootElement() == nullptr || doc.RootElement()->ValueStr() != "addons")
+  if (doc.RootElement() == nullptr ||
+      !StringUtils::EqualsNoCase(doc.RootElement()->Value(), "addons"))
   {
     CLog::Log(LOGERROR, "CAddonMgr::{}: Failed to parse addons.xml. Malformed", __func__);
     return false;

--- a/xbmc/addons/addoninfo/AddonInfoBuilder.h
+++ b/xbmc/addons/addoninfo/AddonInfoBuilder.h
@@ -17,7 +17,11 @@
 #include <vector>
 
 class CDateTime;
-class TiXmlElement;
+
+namespace tinyxml2
+{
+class XMLElement;
+} // namespace tinyxml2
 
 namespace ADDON
 {
@@ -38,7 +42,7 @@ class CAddonInfoBuilder
 public:
   static AddonInfoPtr Generate(const std::string& id, AddonType type);
   static AddonInfoPtr Generate(const std::string& addonPath, bool platformCheck = true);
-  static AddonInfoPtr Generate(const TiXmlElement* baseElement,
+  static AddonInfoPtr Generate(const tinyxml2::XMLElement* baseElement,
                                const RepositoryDirInfo& repo,
                                bool platformCheck = true);
 
@@ -52,18 +56,20 @@ public:
 
 private:
   static bool ParseXML(const AddonInfoPtr& addon,
-                       const TiXmlElement* element,
+                       const tinyxml2::XMLElement* element,
                        const std::string& addonPath);
   static bool ParseXML(const AddonInfoPtr& addon,
-                       const TiXmlElement* element,
+                       const tinyxml2::XMLElement* element,
                        const std::string& addonPath,
                        const RepositoryDirInfo& repo);
   static bool ParseXMLTypes(CAddonType& addonType,
                             const AddonInfoPtr& info,
-                            const TiXmlElement* child);
-  static bool ParseXMLExtension(CAddonExtensions& addonExt, const TiXmlElement* element);
-  static bool GetTextList(const TiXmlElement* element, const std::string& tag, std::unordered_map<std::string, std::string>& translatedValues);
-  static const char* GetPlatformLibraryName(const TiXmlElement* element);
+                            const tinyxml2::XMLElement* child);
+  static bool ParseXMLExtension(CAddonExtensions& addonExt, const tinyxml2::XMLElement* element);
+  static bool GetTextList(const tinyxml2::XMLElement* element,
+                          const std::string& tag,
+                          std::unordered_map<std::string, std::string>& translatedValues);
+  static const char* GetPlatformLibraryName(const tinyxml2::XMLElement* element);
   static bool PlatformSupportsAddon(const AddonInfoPtr& addon);
 };
 

--- a/xbmc/addons/test/TestAddonInfoBuilder.cpp
+++ b/xbmc/addons/test/TestAddonInfoBuilder.cpp
@@ -10,7 +10,7 @@
 #include "addons/addoninfo/AddonInfo.h"
 #include "addons/addoninfo/AddonInfoBuilder.h"
 #include "addons/addoninfo/AddonType.h"
-#include "utils/XBMCTinyXML.h"
+#include "utils/XBMCTinyXML2.h"
 
 #include <set>
 
@@ -73,7 +73,7 @@ TEST_F(TestAddonInfoBuilder, TestGenerate_Id_Type)
 
 TEST_F(TestAddonInfoBuilder, TestGenerate_Repo)
 {
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   EXPECT_TRUE(doc.Parse(addonXML));
   ASSERT_NE(nullptr, doc.RootElement());
 


### PR DESCRIPTION
## Description
Migrate AddonInfoBuilder to tinyxml2 usage

## Motivation and context
Less tinyxml, moar tinyxml2.

AddonInfoBuilder was well contained, and low hanging fruit. Bonus it already had tests to validate changes.

## How has this been tested?
```
[----------] Global test environment tear-down
[==========] 961 tests from 124 test suites ran. (6101 ms total)
[  PASSED  ] 961 tests.

  YOU HAVE 7 DISABLED TESTS

Clean shutdown of TestGlobalPattern1
```

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
