### PR TITLE
[Audio] TrueHD rework - moves MAT packing to DVDAudioCodecPassthrough

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
@@ -144,8 +144,6 @@ protected:
     SKIP_SWAP,
   } m_swapState;
 
-  std::vector<uint8_t> m_mergeBuffer;
-
   std::string m_deviceFriendlyName;
   std::string m_device;
   std::vector<AE::AESinkInfo> m_sinkInfoList;

--- a/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.h
+++ b/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.h
@@ -12,12 +12,10 @@
 #include "AEPackIEC61937.h"
 
 #include <list>
-#include <memory>
 #include <stdint.h>
 #include <vector>
 
 class CAEStreamInfo;
-class CPackerMAT;
 
 class CAEBitstreamPacker
 {
@@ -34,13 +32,8 @@ public:
   static CAEChannelInfo GetOutputChannelMap(const CAEStreamInfo& info);
 
 private:
-  void GetDataTrueHD();
   void PackDTSHD(CAEStreamInfo &info, uint8_t* data, int size);
   void PackEAC3(CAEStreamInfo &info, uint8_t* data, int size);
-
-  std::unique_ptr<CPackerMAT> m_packerMAT;
-
-  unsigned int m_dataCountTrueHD{0};
 
   std::vector<uint8_t> m_dtsHD;
   unsigned int m_dtsHDSize = 0;

--- a/xbmc/cores/AudioEngine/Utils/PackerMAT.cpp
+++ b/xbmc/cores/AudioEngine/Utils/PackerMAT.cpp
@@ -181,7 +181,8 @@ bool CPackerMAT::PackTrueHD(const uint8_t* data, int size)
   m_state.prevMatFramesize = m_state.matFramesize;
   m_state.matFramesize = 0;
 
-  return true;
+  // return true if have MAT packet
+  return !m_outputQueue.empty();
 }
 
 std::vector<uint8_t> CPackerMAT::GetOutputFrame()
@@ -237,17 +238,6 @@ void CPackerMAT::WritePadding()
 {
   if (m_state.padding == 0)
     return;
-
-  if (!m_logPadding && m_state.padding > MAT_BUFFER_SIZE / 2)
-  {
-    m_logPadding = true;
-    CLog::Log(LOGWARNING,
-              "CPackerMAT::WritePadding: a large padding block of {} bytes is required due to "
-              "unusual timestamps",
-              m_state.padding);
-  }
-  else if (m_logPadding && m_state.padding < MAT_BUFFER_SIZE / 2)
-    m_logPadding = false;
 
   // for padding not writes any data (nullptr) as buffer is already zeroed
   // only counts/skip bytes

--- a/xbmc/cores/AudioEngine/Utils/PackerMAT.h
+++ b/xbmc/cores/AudioEngine/Utils/PackerMAT.h
@@ -33,7 +33,6 @@ public:
   ~CPackerMAT() = default;
 
   bool PackTrueHD(const uint8_t* data, int size);
-  bool HaveOutput() const { return !m_outputQueue.empty(); }
   std::vector<uint8_t> GetOutputFrame();
 
 private:
@@ -77,8 +76,6 @@ private:
   TrueHDMajorSyncInfo ParseTrueHDMajorSyncHeaders(const uint8_t* p, int buffsize) const;
 
   MATState m_state{};
-
-  bool m_logPadding{false};
 
   uint32_t m_bufferCount{0};
   std::vector<uint8_t> m_buffer;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.h
@@ -14,9 +14,11 @@
 #include "cores/AudioEngine/Utils/AEStreamInfo.h"
 
 #include <list>
+#include <memory>
 #include <vector>
 
 class CProcessInfo;
+class CPackerMAT;
 
 class CDVDAudioCodecPassthrough : public CDVDAudioCodec
 {
@@ -36,6 +38,7 @@ public:
 
 private:
   int GetData(uint8_t** dst);
+  unsigned int PackTrueHD();
   CAEStreamParser m_parser;
   uint8_t* m_buffer = nullptr;
   unsigned int m_bufferSize = 0;
@@ -49,6 +52,7 @@ private:
   std::string m_codecName;
 
   // TrueHD specifics
+  std::unique_ptr<CPackerMAT> m_packerMAT;
   std::vector<uint8_t> m_trueHDBuffer;
   unsigned int m_trueHDoffset = 0;
   unsigned int m_trueHDframes = 0;

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -849,17 +849,8 @@ inline bool PAPlayer::ProcessStream(StreamInfo *si, double &freeBufferTime)
         free_space = (double)(si->m_stream->GetSpace() / si->m_bytesPerSample) / si->m_audioFormat.m_sampleRate;
       else
       {
-        if (si->m_audioFormat.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD &&
-            !m_processInfo->WantsRawPassthrough())
-        {
-          free_space = static_cast<double>(si->m_stream->GetSpace()) *
-                       si->m_audioFormat.m_streamInfo.GetDuration() / 1000 / 2;
-        }
-        else
-        {
-          free_space = static_cast<double>(si->m_stream->GetSpace()) *
-                       si->m_audioFormat.m_streamInfo.GetDuration() / 1000;
-        }
+        free_space = static_cast<double>(si->m_stream->GetSpace()) *
+                     si->m_audioFormat.m_streamInfo.GetDuration() / 1000;
       }
 
       freeBufferTime = std::max(freeBufferTime , free_space);
@@ -908,17 +899,9 @@ bool PAPlayer::QueueData(StreamInfo *si)
         CLog::Log(LOGERROR, "PAPlayer::QueueData - unknown error");
         return false;
       }
-      if (si->m_audioFormat.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD &&
-          !m_processInfo->WantsRawPassthrough())
-      {
-        si->m_framesSent += si->m_audioFormat.m_streamInfo.GetDuration() / 1000 / 2 *
-                            si->m_audioFormat.m_streamInfo.m_sampleRate;
-      }
-      else
-      {
-        si->m_framesSent += si->m_audioFormat.m_streamInfo.GetDuration() / 1000 *
-                            si->m_audioFormat.m_streamInfo.m_sampleRate;
-      }
+
+      si->m_framesSent += si->m_audioFormat.m_streamInfo.GetDuration() / 1000 *
+                          si->m_audioFormat.m_streamInfo.m_sampleRate;
     }
   }
 


### PR DESCRIPTION
## Description
- This allows remove intermediate 12 audio units packing and handle TrueHD same as all others codecs in ActiveAESink.
- Also improves performance: removed parsing of raw bitstream to obtain units length. This is for both IEC and RAW.
- Allows remove PAPlayer hack for TrueHD.
- Simplifies PackerMAT: removes HaveOutput() and padding in logs.

## Motivation and context
The best ideas come to mind when you are thinking about anything else...

## How has this been tested?
- Passed Cars 20 minutes playback time, no dropouts and no a/v sync corrections.
- Tested several TrueHD samples IEC & RAW.
- Tested PAPlayer both IEC & RAW.
- Checked a/v sync error values --> have decreased!

## What is the effect on users?
Improves TrueHD stability and performance...

## Screenshots (if appropriate):
**Before**
![Cars-62](https://github.com/xbmc/xbmc/assets/58434170/4e7e7394-750e-4294-bd78-9449d4ac9340)
The error increases rapidly and several corrections are made to keep it at 62 ms

**After**
![Cars-50-rework](https://github.com/xbmc/xbmc/assets/58434170/dbbe6ebe-44a7-4d4e-befa-6f2b5949f67c)
The error always remains below +-20 ms and does not reach the 50 ms threshold in this case. No correction occurs.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
