### PR TITLE
[Estuary] Fix watched icons for episodes & sets

### DIFF
--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -475,6 +475,7 @@
 		<value condition="!ListItem.IsParentFolder">OverlayUnwatched.png</value>
 	</variable>
 	<variable name="ItemStatusIconVar">
+		<value condition="[String.IsEqual(Listitem.DBType,tvshow) | String.IsEqual(Listitem.DBType,season)] + String.IsEqual(ListItem.Property(WatchedEpisodes),ListItem.Property(TotalEpisodes)) | String.IsEqual(ListItem.DBtype,set) + String.IsEqual(ListItem.Property(Watched),ListItem.Property(Total))">OverlayWatched.png</value>
 		<value condition="String.IsEqual(ListItem.DBtype,tvshow) | String.IsEqual(ListItem.DBtype,set) | String.IsEqual(ListItem.DBType,season)">lists/played-total.png</value>
 		<value condition="ListItem.IsRecording">windows/pvr/record.png</value>
 		<value condition="ListItem.HasReminder">icons/pvr/timers/bell.png</value>

--- a/addons/skin.estuary/xml/View_54_InfoWall.xml
+++ b/addons/skin.estuary/xml/View_54_InfoWall.xml
@@ -163,19 +163,20 @@
 				<visible>!ListItem.IsParentFolder</visible>
 			</control>
 			<control type="label">
-				<left>31</left>
+				<left>30</left>
 				<top>178</top>
-				<width>260</width>
+				<width>220</width>
 				<label>$PARAM[thumb_label]</label>
 				<font>font20_title</font>
 				<shadowcolor>text_shadow</shadowcolor>
-				<align>right</align>
+				<align>left</align>
 			</control>
-			<control type="image">
-				<left>20</left>
+			<control type="image">		
+				<left>260</left>
 				<top>175</top>
 				<width>32</width>
 				<height>32</height>
+				<align>right</align>
 				<texture>$VAR[ItemStatusIconVar]</texture>
 			</control>
 			<control type="textbox">


### PR DESCRIPTION
## Description
In v21 the watched tick was removed when tv shows or seasons were fully watched during the reshuffle of the poster/icon overlays. This restores the Watched tick icon in these circumstances. The Watched tick icon was also added for Movie Sets which have the same style of overlay.

## Motivation and context
User on forum https://forum.kodi.tv/showthread.php?tid=377441 requested restoration of the tick. This was done and an inconsistancy with placement of the watched icon between season and episode wall views was also corrected.

As Movie Sets also use a **unwatched count/total count - icon** style overlay on the poster, this will now also show the watched tick when when all movies within set are watched for consistancy of style.

## How has this been tested?
Tested locally with watched & unwatched seasons & sets.

## What is the effect on users?
Restore the watched tick that was present in v20 but had been removed for some circumstances in v21.

## Screenshots (if appropriate):

**Seasons - v21 & Master**

No tick when all episodes watched

![image](https://github.com/xbmc/xbmc/assets/5781142/d8ef54a2-4a78-439e-9edd-b6cfd293b829)

**Seasons - after PR**

Tick present when all episodes watched

![image](https://github.com/xbmc/xbmc/assets/5781142/ac46ff76-7922-4d08-b9ca-8f42b267a336)

**Episode Wall - v21 & Master**

Watched tick is bottom left which is inconsistent with the season view and movies.

![image](https://github.com/xbmc/xbmc/assets/5781142/9fdf9059-311c-41d0-abf0-0ab94bf423f5)

**Episode Wall - after PR**

Watched tick is bottom right to align with season view and movie poster views so tick is always consistently in the same place.

![image](https://github.com/xbmc/xbmc/assets/5781142/6ecaf204-549d-4462-8623-e82cc5622150)

**Movie Sets - v21 & Master**

No tick when all movies in set are watched.

![image](https://github.com/xbmc/xbmc/assets/5781142/3264b3b3-e2da-414a-acfa-cf2cd6ea3db3)

**Movie Sets - after PR**

Tick present when all movies in set are watched.

![image](https://github.com/xbmc/xbmc/assets/5781142/648ac26e-d89f-4717-b896-5e38f1731e0e)

**Movies - no change**

For comparison only showing that the watched tick is always bottom right on Poster views, so the Episode Wall change aligns with this.

![image](https://github.com/xbmc/xbmc/assets/5781142/73b3e8cd-e22e-49c6-ab32-e073ac1d8726)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
