### PR TITLE
VideoPlayerAudio: simplifies max Out-Of-Sync (maxpassthroughoffsyncduration) setting

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
@@ -115,9 +115,7 @@ protected:
   SInfo            m_info;
 
   bool m_displayReset = false;
-  unsigned int m_disconAdjustTimeMs = 10; // maximum sync-off before adjusting
+  unsigned int m_disconAdjustTimeMs = 50; // maximum sync-off before adjusting
   int m_disconAdjustCounter = 0;
-  XbmcThreads::EndTime<> m_disconTimer;
-  bool m_disconLearning = false;
 };
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -585,7 +585,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetFloat(pElement, "limiterhold", m_limiterHold, 0.0f, 100.0f);
     XMLUtils::GetFloat(pElement, "limiterrelease", m_limiterRelease, 0.001f, 100.0f);
     XMLUtils::GetUInt(pElement, "maxpassthroughoffsyncduration", m_maxPassthroughOffSyncDuration,
-                      10, 100);
+                      20, 80);
     XMLUtils::GetBoolean(pElement, "allowmultichannelfloat", m_AllowMultiChannelFloat);
     XMLUtils::GetBoolean(pElement, "superviseaudiodelay", m_superviseAudioDelay);
   }

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -154,7 +154,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int m_videoIgnoreSecondsAtStart;
     float m_videoIgnorePercentAtEnd;
     float m_audioApplyDrc;
-    unsigned int m_maxPassthroughOffSyncDuration = 10; // when 10 ms off adjust
+    unsigned int m_maxPassthroughOffSyncDuration = 50; // when 50 ms off adjust
     bool m_AllowMultiChannelFloat = false; // Android only switch to be removed in v22
     bool m_superviseAudioDelay = false; // Android only to correct broken audio firmwares
 


### PR DESCRIPTION
## Description
VideoPlayerAudio: simplifies max Out-Of-Sync (maxpassthroughoffsyncduration) setting

## Motivation and context
As commented in https://github.com/xbmc/xbmc/pull/25233 "self-learning" not always provide an adequate value and can end up causing sporadic random issues if a very low value such as 20 ms is obtained. It has already been limited above 80 ms which is fine.

With the latest improvements in TrueHD it is less and less necessary to use very high values (*) and values below 41 ms (frame time) do not make sense either.

(*)
> I expected to see video stutters on my Shield with only maxpassthroughoffsyncduration 50, but it seems like your MAT Rework somehow also fixed the video stutter problem that I had!
> Now Kodi plays everything completely perfectly for me, awesome work!
> 
> I also tried maxpassthroughoffsyncduration 96 and it was perfect as well, so I think I will personally keep it at 96 just to be extra safe. But maxpassthroughoffsyncduration 50 with this MAT Rework seems perfect so far!

https://forum.kodi.tv/showthread.php?tid=377117&pid=3199254#pid3199254

With all this, the reasonable values are:

minimum: 20 ms
Maximum: 80 ms
Default: 50 ms

The default value is the most debatable but seems adequate between 41 ms (1 frame time) and 62 ms (1.5 frame time). 

Additionally, 50 is the half of the maximum AudioEngine threshold (100 ms) and is the center of the chosen maximum and minimum [20 - 80].

NOTE: 50 ms may seem like a high value if that were the final a/v off-sync but this does not actually happen since during playback there are continuous small peaks and noise in the error that will cause it to correct when 50 ms is reached, then the stationary error will tend to center around +-50 ms. Even if it is not centered on zero, the offset will most of the time be 25 ms at most.

## How has this been tested?
Runtime Windows x64

## What is the effect on users?
- For users that not use previously advancedsetting is an improvement as avoids random sporadic low values that may cause excessive video sync corrections (perceived as micro-stuttering or frame skips).
- For users that use previously very high advancedsetting values [81 - 100] is an improvement as limits to 80 and assures a/v sync corrections works as designed (e.g no audio dropouts due 100 ms threshold reached every x minutes).

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
