### PR TITLE
Fix rx6400 detection

### DIFF
--- a/xbmc/platform/win32/WIN32Util.cpp
+++ b/xbmc/platform/win32/WIN32Util.cpp
@@ -32,6 +32,7 @@
 #endif
 #include <array>
 #include <locale.h>
+#include <sstream>
 
 #include <shellapi.h>
 #include <shlobj.h>
@@ -59,6 +60,21 @@ using namespace winrt::Windows::Graphics::Display;
 using namespace winrt::Windows::Graphics::Display::Core;
 using namespace winrt::Windows::Storage;
 #endif
+
+void VideoDriverInfo::Log()
+{
+  if (!valid)
+  {
+    CLog::LogF(LOGERROR, "video driver version information is not valid");
+    return;
+  }
+
+  if (vendorId == PCIV_NVIDIA)
+    CLog::LogF(LOGINFO, "video driver version is {} {}.{} ({})", DX::GetGFXProviderName(vendorId),
+               majorVersion, minorVersion, version);
+  else
+    CLog::LogF(LOGINFO, "video driver version is {} {}", DX::GetGFXProviderName(vendorId), version);
+}
 
 CWIN32Util::CWIN32Util(void)
 {
@@ -1601,7 +1617,6 @@ VideoDriverInfo CWIN32Util::GetVideoDriverInfo(const UINT vendorId, const std::w
     subkey.append(L"\\");
     subkey.append(L"0000");
     DWORD lg;
-
     wchar_t desc[128] = {};
     lg = sizeof(desc);
     if (ERROR_SUCCESS != RegGetValueW(HKEY_LOCAL_MACHINE, subkey.c_str(), L"DriverDesc",
@@ -1613,33 +1628,110 @@ VideoDriverInfo CWIN32Util::GetVideoDriverInfo(const UINT vendorId, const std::w
       continue;
 
     // driver of interest found, we read version
-    wchar_t version[64] = {};
-    lg = sizeof(version);
+    wchar_t wversion[64] = {};
+    lg = sizeof(wversion);
     if (ERROR_SUCCESS != RegGetValueW(HKEY_LOCAL_MACHINE, subkey.c_str(), L"DriverVersion",
-                                      RRF_RT_REG_SZ, nullptr, version, &lg))
+                                      RRF_RT_REG_SZ, nullptr, wversion, &lg))
       continue;
 
-    info.valid = true;
-    info.version = FromW(std::wstring(version));
+    const std::string version = FromW(std::wstring(wversion));
 
-    // convert driver store version to Nvidia version
-    if (vendorId == PCIV_NVIDIA)
-    {
-      std::string ver(info.version);
-      StringUtils::Replace(ver, ".", "");
-      info.majorVersion = std::stoi(ver.substr(ver.length() - 5, 3));
-      info.minorVersion = std::stoi(ver.substr(ver.length() - 2, 2));
-    }
-    else // for Intel/AMD fill major version only. Single-digit for WDDM < 1.3.
-    {
-      info.majorVersion = std::stoi(info.version.substr(0, info.version.find('.')));
-    }
+    info = FormatVideoDriverInfo(vendorId, version);
 
   } while (sta == ERROR_SUCCESS && !info.valid);
 
   RegCloseKey(hKey);
 #endif
 
+  return info;
+}
+
+VideoDriverInfo CWIN32Util::GetVideoDriverInfoDX(const UINT vendorId, LUID adapterLuid)
+{
+  VideoDriverInfo info = {};
+
+#ifdef TARGET_WINDOWS_DESKTOP
+  HKEY hKey = nullptr;
+  const wchar_t* SUBKEY = L"SOFTWARE\\Microsoft\\DirectX";
+
+  if (ERROR_SUCCESS != RegOpenKeyExW(HKEY_LOCAL_MACHINE, SUBKEY, 0, KEY_ENUMERATE_SUB_KEYS, &hKey))
+    return {};
+
+  LSTATUS sta = ERROR_SUCCESS;
+  wchar_t keyName[128] = {};
+  DWORD index = 0;
+  DWORD len;
+
+  using KODI::PLATFORM::WINDOWS::FromW;
+
+  do
+  {
+    len = sizeof(keyName) / sizeof(wchar_t);
+    sta = RegEnumKeyExW(hKey, index, keyName, &len, nullptr, nullptr, nullptr, nullptr);
+    index++;
+
+    if (sta != ERROR_SUCCESS)
+      continue;
+
+    LUID luid = {};
+    DWORD qwordSize = sizeof(luid);
+
+    if (ERROR_SUCCESS !=
+        RegGetValueW(hKey, keyName, L"AdapterLuid", RRF_RT_QWORD, nullptr, &luid, &qwordSize))
+      continue;
+
+    if (luid.HighPart != adapterLuid.HighPart || luid.LowPart != adapterLuid.LowPart)
+      continue;
+
+    // driver of interest found, read the version
+    uint64_t rawDriverVersion{};
+    if (ERROR_SUCCESS != RegGetValueW(hKey, keyName, L"DriverVersion", RRF_RT_QWORD, nullptr,
+                                      &rawDriverVersion, &qwordSize))
+      continue;
+
+    info = FormatVideoDriverInfo(vendorId, rawDriverVersion);
+
+  } while (sta == ERROR_SUCCESS && !info.valid);
+
+  RegCloseKey(hKey);
+#endif
+
+  return info;
+}
+
+VideoDriverInfo CWIN32Util::FormatVideoDriverInfo(const UINT vendorId, uint64_t rawVersion)
+{
+  const unsigned int part1 = static_cast<unsigned int>(rawVersion >> 48);
+  const unsigned int part2 = static_cast<unsigned int>((rawVersion >> 32) & 0xFFFF);
+  const unsigned int part3 = static_cast<unsigned int>((rawVersion >> 16) & 0xFFFF);
+  const unsigned int part4 = static_cast<unsigned int>(rawVersion & 0xFFFF);
+
+  std::ostringstream ss;
+  ss << part1 << '.' << part2 << '.' << part3 << '.' << part4;
+
+  return FormatVideoDriverInfo(vendorId, ss.str());
+}
+
+VideoDriverInfo CWIN32Util::FormatVideoDriverInfo(const UINT vendorId, const std::string version)
+{
+  VideoDriverInfo info = {};
+
+  info.valid = true;
+  info.vendorId = vendorId;
+  info.version = version;
+
+  // convert driver store version to Nvidia version
+  if (vendorId == PCIV_NVIDIA)
+  {
+    std::string ver(version);
+    StringUtils::Replace(ver, ".", "");
+    info.majorVersion = std::stoi(ver.substr(ver.length() - 5, 3));
+    info.minorVersion = std::stoi(ver.substr(ver.length() - 2, 2));
+  }
+  else // for Intel/AMD fill major version only
+  {
+    info.majorVersion = std::stoi(version.substr(0, version.find('.')));
+  }
   return info;
 }
 

--- a/xbmc/platform/win32/WIN32Util.cpp
+++ b/xbmc/platform/win32/WIN32Util.cpp
@@ -1603,7 +1603,7 @@ VideoDriverInfo CWIN32Util::GetVideoDriverInfo(const UINT vendorId, const std::w
     DWORD lg;
 
     wchar_t desc[128] = {};
-    lg = sizeof(desc) / sizeof(wchar_t);
+    lg = sizeof(desc);
     if (ERROR_SUCCESS != RegGetValueW(HKEY_LOCAL_MACHINE, subkey.c_str(), L"DriverDesc",
                                       RRF_RT_REG_SZ, nullptr, desc, &lg))
       continue;
@@ -1614,7 +1614,7 @@ VideoDriverInfo CWIN32Util::GetVideoDriverInfo(const UINT vendorId, const std::w
 
     // driver of interest found, we read version
     wchar_t version[64] = {};
-    lg = sizeof(version) / sizeof(wchar_t);
+    lg = sizeof(version);
     if (ERROR_SUCCESS != RegGetValueW(HKEY_LOCAL_MACHINE, subkey.c_str(), L"DriverVersion",
                                       RRF_RT_REG_SZ, nullptr, version, &lg))
       continue;

--- a/xbmc/platform/win32/WIN32Util.h
+++ b/xbmc/platform/win32/WIN32Util.h
@@ -22,10 +22,13 @@
 
 struct VideoDriverInfo
 {
+  UINT vendorId;
   int majorVersion;
   int minorVersion;
   bool valid;
   std::string version;
+
+  void Log();
 };
 
 class CURL; // forward declaration
@@ -83,6 +86,9 @@ public:
   static void PlatformSyslog();
 
   static VideoDriverInfo GetVideoDriverInfo(const UINT vendorId, const std::wstring& driverDesc);
+  static VideoDriverInfo GetVideoDriverInfoDX(const UINT vendorId, LUID adapterLuid);
+  static VideoDriverInfo FormatVideoDriverInfo(const UINT vendorId, uint64_t rawVersion);
+  static VideoDriverInfo FormatVideoDriverInfo(const UINT vendorId, const std::string version);
   static std::wstring GetDisplayFriendlyName(const std::wstring& GdiDeviceName);
   /*!
    * \brief Set the thread name using SetThreadDescription when available

--- a/xbmc/rendering/dx/DeviceResources.h
+++ b/xbmc/rendering/dx/DeviceResources.h
@@ -150,7 +150,7 @@ namespace DX
     void HandleOutputChange(const std::function<bool(DXGI_OUTPUT_DESC)>& cmpFunc);
     bool CreateFactory();
     void CheckNV12SharedTexturesSupport();
-    VideoDriverInfo GetVideoDriverVersion();
+    VideoDriverInfo GetVideoDriverVersion() const;
     void CheckDXVA2SharedDecoderSurfaces();
 
     HWND m_window{ nullptr };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Modified the retrieval of the video driver version to work with AMD RX 6400 and Windows 10 (change probably required for all RDNA generations under Windows 10, but no hw to confirm)

- For recent-ish drivers (WDDM2.3 and above, ie Windows 10 Falls Creator around October 2017), the driver version can be queried using DXGI only.
- For older drivers, different driver components may return different version numbers, making the dxgi method unreliable. Maybe it's still ok but without examples it's best to fallback to the former registry method.
- Buffer size correction for the traditional version detection using the registry
- A different registry tree works for detection of old and new gpu, as well as the RX 6400 that is causing trouble with the traditional registry method. Added as secondary registry detection if there is no match with the traditional method.

Instead of adding a third detection method we could add a note in the existing registry method about the alternative, in case we need it in the future. I don't mind cutting that code.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Driver version of RX6400 is not identified in Windows 10 because of different spelling of the name through dxgi (adapter description) and in the HKLM\SYSTEM\CurrentControlSet\Control\Video registry sub-tree.
dxgi: AMD Radeon RX 6400
registry: AMD Radeon (TM) RX 6400

In turn this disables some features in Kodi such as shared decoding surfaces and their synchronization, resulting in green flashes when skipping in the video.

Two methods found to list correctly the driver version:
1. Searching HKLM\SOFTWARE\Microsoft\DirectX in the registry provides information very similar to the attributes of dxgi adapters, including the unique luid.
However neither the original nor this subtrees are documented officially (or I don't know where documentation is located) and both have some risk, so these registry keys could be used when the traditional method fails.

2. New dxgi-only method for newer gpus (WDDM 2.3). Uses IDXGIAdapter->CheckInterfaceSupport()

edit: found the same issue in a Windows 11 log with a RX 5700 XT, expecting the fix to apply as well.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Windows 10 with RX 6400, 5600G, nVidia GT1030, Intel 13th gen

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):
before
```
DX:DeviceResources::GetVideoDriverVersion: video driver version is AMD
```

after
```
DX:DeviceResources::GetVideoDriverVersion: video driver version is AMD 31.0.24033.1003
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
