### PR TITLE
Introduce media type to recordings to allow filtering between recordings and VOD

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Recordings.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Recordings.h
@@ -57,6 +57,7 @@ public:
     m_cStructure->iEpgEventId = 0;
     m_cStructure->iChannelUid = PVR_RECORDING_VALUE_NOT_AVAILABLE;
     m_cStructure->channelType = PVR_RECORDING_CHANNEL_TYPE_UNKNOWN;
+    m_cStructure->mediaType = PVR_RECORDING_MEDIA_TYPE_RECORDING;
     m_cStructure->iFlags = 0;
     m_cStructure->sizeInBytes = PVR_RECORDING_VALUE_NOT_AVAILABLE;
   }
@@ -95,6 +96,7 @@ public:
   /// | **EPG event id** | `unsigned int` | @ref PVRRecording::SetEPGEventId "SetEPGEventId" | @ref PVRRecording::GetEPGEventId "GetEPGEventId" | *optional*
   /// | **Channel unique id** | `int` | @ref PVRRecording::SetChannelUid "SetChannelUid" | @ref PVRRecording::GetChannelUid "GetChannelUid" | *optional*
   /// | **Channel type** | @ref PVR_RECORDING_CHANNEL_TYPE | @ref PVRRecording::SetChannelType "SetChannelType" | @ref PVRRecording::GetChannelType "GetChannelType" | *optional*
+  /// | **Media type** | @ref PVR_RECORDING_MEDIA_TYPE | @ref PVRRecording::SetMediaType "SetMediaType" | @ref PVRRecording::GetMediaType "GetMediaType" | *optional*
   /// | **First aired** | `std::string` | @ref PVRRecording::SetFirstAired "SetFirstAired" | @ref PVRRecording::GetFirstAired "GetFirstAired" | *optional*
   /// | **Flags** | `std::string` | @ref PVRRecording::SetFlags "SetFlags" | @ref PVRRecording::GetFlags "GetFlags" | *optional*
   /// | **Size in bytes** | `std::string` | @ref PVRRecording::SetSizeInBytes "SetSizeInBytes" | @ref PVRRecording::GetSizeInBytes "GetSizeInBytes" | *optional*
@@ -423,6 +425,28 @@ public:
 
   /// @brief To get with @ref SetChannelType changed values
   PVR_RECORDING_CHANNEL_TYPE GetChannelType() const { return m_cStructure->channelType; }
+
+  /// @brief **optional**\n
+  /// Media type.
+  ///
+  /// By default set to @ref PVR_RECORDING_MEDIA_TYPE_RECORDING.
+  /// See @ref cpp_kodi_addon_pvr_Defs_Recording_PVR_RECORDING_MEDIA_TYPE for
+  /// all availble values. Media Type should always be known to the client.
+  ///
+  /// --------------------------------------------------------------------------
+  ///
+  /// @copydetails cpp_kodi_addon_pvr_Defs_Recording_PVR_RECORDING_MEDIA_TYPE
+  ///
+  /// Example:
+  /// ~~~~~~~~~~~~~{.cpp}
+  /// kodi::addon::PVRRecording tag;
+  /// tag.SetMediaType(PVR_RECORDING_MEDIA_TYPE_RECORDING);
+  /// ~~~~~~~~~~~~~
+  ///
+  void SetMediaType(PVR_RECORDING_MEDIA_TYPE mediaType) { m_cStructure->mediaType = mediaType; }
+
+  /// @brief To get with @ref SetMediaType changed values
+  PVR_RECORDING_MEDIA_TYPE GetMediaType() const { return m_cStructure->mediaType; }
 
   /// @brief **optional**\n
   /// First aired date of this recording.

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_recordings.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_recordings.h
@@ -99,6 +99,26 @@ extern "C"
   ///@}
   //----------------------------------------------------------------------------
 
+  //============================================================================
+  /// @defgroup cpp_kodi_addon_pvr_Defs_Recording_PVR_RECORDING_MEDIA_TYPE enum PVR_RECORDING_MEDIA_TYPE
+  /// @ingroup cpp_kodi_addon_pvr_Defs_Recording
+  /// @brief **PVR recording media types**\n
+  /// Used on @ref kodi::addon::PVRRecording::SetMediaType() value to set related
+  /// type.
+  ///
+  ///@{
+  typedef enum PVR_RECORDING_MEDIA_TYPE
+  {
+    /// @brief __0__ : Recording media.
+    PVR_RECORDING_MEDIA_TYPE_RECORDING = 0,
+
+    /// @brief __1__ : VOD media.
+    PVR_RECORDING_MEDIA_TYPE_VOD = 1,
+
+  } PVR_RECORDING_MEDIA_TYPE;
+  ///@}
+  //----------------------------------------------------------------------------
+
   /*!
    * @brief "C" PVR add-on recording.
    *
@@ -134,6 +154,7 @@ extern "C"
     unsigned int iEpgEventId;
     int iChannelUid;
     enum PVR_RECORDING_CHANNEL_TYPE channelType;
+    enum PVR_RECORDING_MEDIA_TYPE mediaType;
     char strFirstAired[PVR_ADDON_DATE_STRING_LENGTH];
     unsigned int iFlags;
     int64_t sizeInBytes;

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -130,8 +130,8 @@
 #define ADDON_INSTANCE_VERSION_PERIPHERAL_DEPENDS     "addon-instance/Peripheral.h" \
                                                       "addon-instance/PeripheralUtils.h"
 
-#define ADDON_INSTANCE_VERSION_PVR                    "8.3.0"
-#define ADDON_INSTANCE_VERSION_PVR_MIN                "8.2.0"
+#define ADDON_INSTANCE_VERSION_PVR                    "9.0.0"
+#define ADDON_INSTANCE_VERSION_PVR_MIN                "9.0.0"
 #define ADDON_INSTANCE_VERSION_PVR_XML_ID             "kodi.binary.instance.pvr"
 #define ADDON_INSTANCE_VERSION_PVR_DEPENDS            "c-api/addon-instance/pvr.h" \
                                                       "c-api/addon-instance/pvr/pvr_providers.h" \

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -540,9 +540,9 @@ void CPVRRecording::Update(const CPVRRecording& tag, const CPVRClient& client)
 
 void CPVRRecording::UpdatePath()
 {
-  m_strFileNameAndPath = CPVRRecordingsPath(m_bIsDeleted, m_bRadio, m_strDirectory, m_strTitle,
-                                            m_iSeason, m_iEpisode, GetYear(), m_strShowTitle,
-                                            m_strChannelName, m_recordingTime, m_strRecordingId);
+  m_strFileNameAndPath = CPVRRecordingsPath(
+      m_bIsDeleted, m_bRadio, m_mediaType, m_strDirectory, m_strTitle, m_iSeason, m_iEpisode,
+      GetYear(), m_strShowTitle, m_strChannelName, m_recordingTime, m_strRecordingId);
 }
 
 const CDateTime& CPVRRecording::RecordingTimeAsLocalTime() const

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -145,6 +145,15 @@ CPVRRecording::CPVRRecording(const PVR_RECORDING& recording, unsigned int iClien
       }
     }
   }
+  if (recording.mediaType == PVR_RECORDING_MEDIA_TYPE_RECORDING)
+    m_mediaType = RecordingMediaType::PVR_RECORDING_MEDIA_TYPE_RECORDING;
+  else if (recording.mediaType == PVR_RECORDING_MEDIA_TYPE_VOD)
+    m_mediaType = RecordingMediaType::PVR_RECORDING_MEDIA_TYPE_VOD;
+  else
+  {
+    CLog::Log(LOGWARNING, "Unhandled enum value, defaulting to PVR_RECORDING_MEDIA_TYPE_RECORDING");
+    m_mediaType = RecordingMediaType::PVR_RECORDING_MEDIA_TYPE_RECORDING;
+  }
 
   UpdatePath();
 }
@@ -169,7 +178,8 @@ bool CPVRRecording::operator==(const CPVRRecording& right) const
           m_iGenreSubType == right.m_iGenreSubType && m_firstAired == right.m_firstAired &&
           m_iFlags == right.m_iFlags && m_sizeInBytes == right.m_sizeInBytes &&
           m_strProviderName == right.m_strProviderName &&
-          m_iClientProviderUniqueId == right.m_iClientProviderUniqueId);
+          m_iClientProviderUniqueId == right.m_iClientProviderUniqueId &&
+          m_mediaType == right.m_mediaType);
 }
 
 bool CPVRRecording::operator!=(const CPVRRecording& right) const
@@ -214,6 +224,15 @@ void CPVRRecording::FillAddonData(PVR_RECORDING& recording) const
   recording.iChannelUid = ChannelUid();
   recording.channelType =
       IsRadio() ? PVR_RECORDING_CHANNEL_TYPE_RADIO : PVR_RECORDING_CHANNEL_TYPE_TV;
+  if (MediaType() == RecordingMediaType::PVR_RECORDING_MEDIA_TYPE_RECORDING)
+    recording.mediaType = PVR_RECORDING_MEDIA_TYPE_RECORDING;
+  else if (MediaType() == RecordingMediaType::PVR_RECORDING_MEDIA_TYPE_VOD)
+    recording.mediaType = PVR_RECORDING_MEDIA_TYPE_VOD;
+  else
+  {
+    CLog::Log(LOGWARNING, "Unhandled enum value, defaulting to PVR_RECORDING_MEDIA_TYPE_RECORDING");
+    recording.mediaType = PVR_RECORDING_MEDIA_TYPE_RECORDING;
+  }
   if (FirstAired().IsValid())
     strncpy(recording.strFirstAired, FirstAired().GetAsW3CDate().c_str(),
             sizeof(recording.strFirstAired) - 1);
@@ -286,6 +305,7 @@ void CPVRRecording::Reset()
   }
   m_strProviderName.clear();
   m_iClientProviderUniqueId = PVR_PROVIDER_INVALID_UID;
+  m_mediaType = RecordingMediaType::PVR_RECORDING_MEDIA_TYPE_RECORDING;
 
   m_recordingTime.Reset();
   CVideoInfoTag::Reset();
@@ -474,6 +494,7 @@ void CPVRRecording::Update(const CPVRRecording& tag, const CPVRClient& client)
     m_sizeInBytes = tag.m_sizeInBytes;
     m_strProviderName = tag.m_strProviderName;
     m_iClientProviderUniqueId = tag.m_iClientProviderUniqueId;
+    m_mediaType = tag.m_mediaType;
   }
 
   if (client.GetClientCapabilities().SupportsRecordingsPlayCount())

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -32,6 +32,12 @@ class CPVRClient;
 class CPVRProvider;
 class CPVRTimerInfoTag;
 
+enum class RecordingMediaType : int
+{
+  PVR_RECORDING_MEDIA_TYPE_RECORDING,
+  PVR_RECORDING_MEDIA_TYPE_VOD
+};
+
 /*!
    * @brief Representation of a CPVRRecording unique ID.
    */
@@ -238,6 +244,12 @@ public:
    * @return true if this is a radio recording, false if this is a tv recording
    */
   bool IsRadio() const { return m_bRadio; }
+
+  /*!
+   * @brief Retrieve the type of media this recording is
+   * @return PVR_RECORDING_MEDIA_TYPE_RECORDING if this is a pvr recording, PVR_RECORDING_MEDIA_TYPE_VOD if this is a VOD
+   */
+  RecordingMediaType MediaType() const { return m_mediaType; }
 
   /*!
    * @return Broadcast id of the EPG event associated with this recording or EPG_TAG_INVALID_UID
@@ -535,6 +547,8 @@ private:
   std::string m_strProviderName; /*!< name of the provider this recording is from */
   int m_iClientProviderUniqueId =
       PVR_PROVIDER_INVALID_UID; /*!< provider uid associated with this recording on the client */
+  RecordingMediaType m_mediaType = RecordingMediaType::
+      PVR_RECORDING_MEDIA_TYPE_RECORDING; /*!< The type of media this recording is */
 
   mutable CCriticalSection m_critSection;
 };

--- a/xbmc/pvr/recordings/PVRRecordings.h
+++ b/xbmc/pvr/recordings/PVRRecordings.h
@@ -24,6 +24,7 @@ class CPVREpgInfoTag;
 class CPVRRecording;
 class CPVRRecordingUid;
 class CPVRRecordingsPath;
+enum class RecordingMediaType;
 
 class CPVRRecordings
 {
@@ -63,9 +64,13 @@ public:
   void UpdateInProgressSize();
 
   int GetNumTVRecordings() const;
+  int GetNumTVRecordings(RecordingMediaType mediaType) const;
   bool HasDeletedTVRecordings() const;
+  bool HasDeletedTVRecordings(RecordingMediaType mediaType) const;
   int GetNumRadioRecordings() const;
+  int GetNumRadioRecordings(RecordingMediaType mediaType) const;
   bool HasDeletedRadioRecordings() const;
+  bool HasDeletedRadioRecordings(RecordingMediaType mediaType) const;
 
   /*!
    * @brief Set a recording's watched state
@@ -83,10 +88,16 @@ public:
   bool ResetResumePoint(const std::shared_ptr<CPVRRecording>& recording);
 
   /*!
-   * @brief Get a list of all recordings
-   * @return the list of all recordings
+   * @brief Get a list of all recordings for the media type PVR_RECORDING_MEDIA_TYPE_RECORDING
+   * @return the list of all recordings for the media type PVR_RECORDING_MEDIA_TYPE_RECORDING
    */
   std::vector<std::shared_ptr<CPVRRecording>> GetAll() const;
+
+  /*!
+   * @brief Get a list of all recordings filtered by media type
+   * @return the list of all recordings filtered by media type
+   */
+  std::vector<std::shared_ptr<CPVRRecording>> GetAll(RecordingMediaType mediaType) const;
 
   std::shared_ptr<CPVRRecording> GetByPath(const std::string& path) const;
   std::shared_ptr<CPVRRecording> GetById(int iClientId, const std::string& strRecordingId) const;
@@ -148,7 +159,11 @@ private:
   std::unique_ptr<CVideoDatabase> m_database;
   bool m_bDeletedTVRecordings = false;
   bool m_bDeletedRadioRecordings = false;
+  std::map<RecordingMediaType, bool> m_hasDeletedTVRecordingsMap;
+  std::map<RecordingMediaType, bool> m_hasDeletedRadioRecordingsMap;
   unsigned int m_iTVRecordings = 0;
   unsigned int m_iRadioRecordings = 0;
+  std::map<RecordingMediaType, unsigned int> m_numTVRecordingsMap;
+  std::map<RecordingMediaType, unsigned int> m_numRadioRecordingsMap;
 };
 } // namespace PVR

--- a/xbmc/pvr/recordings/PVRRecordingsPath.h
+++ b/xbmc/pvr/recordings/PVRRecordingsPath.h
@@ -14,6 +14,8 @@ class CDateTime;
 
 namespace PVR
 {
+enum class RecordingMediaType;
+
 class CPVRRecordingsPath
 {
 public:
@@ -24,9 +26,10 @@ public:
   static const std::string PATH_DELETED_RADIO_RECORDINGS;
 
   explicit CPVRRecordingsPath(const std::string& strPath);
-  CPVRRecordingsPath(bool bDeleted, bool bRadio);
+  CPVRRecordingsPath(bool bDeleted, bool bRadio, RecordingMediaType mediaType);
   CPVRRecordingsPath(bool bDeleted,
                      bool bRadio,
+                     PVR::RecordingMediaType mediaType,
                      const std::string& strDirectory,
                      const std::string& strTitle,
                      int iSeason,

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -58,7 +58,10 @@ void CGUIWindowPVRRecordingsBase::OnWindowLoaded()
 
 std::string CGUIWindowPVRRecordingsBase::GetDirectoryPath()
 {
-  const std::string basePath = CPVRRecordingsPath(m_bShowDeletedRecordings, m_bRadio);
+  const std::string basePath = CPVRRecordingsPath(
+      m_bShowDeletedRecordings, m_bRadio,
+      RecordingMediaType::
+          PVR_RECORDING_MEDIA_TYPE_RECORDING); //TODO Need to decide how to handle Recordings vs VOD here in the UI
   return URIUtils::PathHasParent(m_vecItems->GetPath(), basePath) ? m_vecItems->GetPath()
                                                                   : basePath;
 }
@@ -512,10 +515,16 @@ bool CGUIWindowPVRRecordingsBase::GetFilteredItems(const std::string& filter, CF
 
 std::string CGUIWindowPVRTVRecordings::GetRootPath() const
 {
-  return CPVRRecordingsPath(m_bShowDeletedRecordings, false);
+  return CPVRRecordingsPath(
+      m_bShowDeletedRecordings, false,
+      RecordingMediaType::
+          PVR_RECORDING_MEDIA_TYPE_RECORDING); //TODO Need to decide how to handle Recordings vs VOD here in the UI
 }
 
 std::string CGUIWindowPVRRadioRecordings::GetRootPath() const
 {
-  return CPVRRecordingsPath(m_bShowDeletedRecordings, true);
+  return CPVRRecordingsPath(
+      m_bShowDeletedRecordings, true,
+      RecordingMediaType::
+          PVR_RECORDING_MEDIA_TYPE_RECORDING); //TODO Need to decide how to handle Recordings vs VOD here in the UI
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Introduce a media type enum to PVR recordings to be able to distinguish PVR Recordings. The PR introduce VOD in addition to standard PVR recordings.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

If a user add-on has VOD in their PVR add-on to be able to filter these in the UI. This PR is just the API change required to implement filtering.

Filtering could be done in the current recordings UI, or even as a separate tile, I'm open to suggestions here.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Using iptvsimple on mac.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

None yet.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
