### PR TITLE
[PlayLists] PlayListASX migrate to tinyxml2

### DIFF
--- a/xbmc/playlists/PlayListASX.h
+++ b/xbmc/playlists/PlayListASX.h
@@ -12,6 +12,12 @@
 
 #include <iostream>
 
+namespace tinyxml2
+{
+class XMLDocument;
+class XMLNode;
+} // namespace tinyxml2
+
 namespace KODI::PLAYLIST
 {
 class CPlayListASX : public CPlayList
@@ -21,5 +27,12 @@ public:
 
 private:
   bool LoadAsxIniInfo(std::istream& stream);
+
+  /*  recurseLowercaseNames
+   *  Function allows recursive iteration of a source element to lowercase all
+   *  element and attrib Names, and save to a targetNode.
+   *  targetNode must be a separate XMLDocument to sourceNode XMLDocument
+   */
+  void recurseLowercaseNames(tinyxml2::XMLNode& targetNode, tinyxml2::XMLNode* sourceNode);
 };
 } // namespace KODI::PLAYLIST

--- a/xbmc/playlists/test/test.asx
+++ b/xbmc/playlists/test/test.asx
@@ -1,8 +1,11 @@
-<asx version="3.0">
+<ASX version="3.0">
   <title>Example.com Live Stream</title>
  
   <entry>
     <title>Short Announcement to Play Before Main Stream</title>
+    <test>
+      <something>something test</something>
+    </test>
     <ref href="http://example.com/announcement.wma" />
     <param name="aParameterName" value="aParameterValue" />
   </entry>
@@ -14,10 +17,10 @@
     <copyright>Copyright © 2005 Example.com</copyright>
   </entry>
 
-  <Entry>
+  <ENTRY>
     <TITLE>Capital Title</TITLE>
-    <ref href="http://example3.com:8080" />
+    <REF HREF="http://example3.com:8080" />
     <AUTHOR>Capital Author</AUTHOR>
-    <copyright>Copyright © 2005 Example.com</copyright>
-  </Entry>
-</asx>
+    <COPYRIGHT>Copyright © 2005 Example.com</COPYRIGHT>
+  </ENTRY>
+</ASX>


### PR DESCRIPTION
## Description
Migrate last playlist type to tinyxml2 usage

## Motivation and context
the asx format is case insensitive, whereas xml (and and tinyxml2) are. To deal with this, the original tinyxml usage did a lowercase conversion for all elements before parsing. Tinyxml2's memory management doesnt really make this easy, and even less so not having IterateChildren available in tinyxml2. We have to manually parse the original xml source, creating a copy of all elements, and lowercasing where appropriate.

## How has this been tested?
Included tests pass

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
