### PR TITLE
[video] VideoSelectActionProcessor: On ACTION_INFO, if the item has …

### DIFF
--- a/xbmc/video/guilib/VideoGUIUtils.cpp
+++ b/xbmc/video/guilib/VideoGUIUtils.cpp
@@ -595,6 +595,20 @@ bool IsItemPlayable(const CFileItem& item)
   return false;
 }
 
+bool HasItemVideoDbInformation(const CFileItem& item)
+{
+  CVideoDatabase db;
+  if (!db.Open())
+  {
+    CLog::LogF(LOGERROR, "Cannot open VideoDatabase");
+    return false;
+  }
+
+  return db.HasMovieInfo(item.GetDynPath()) ||
+         db.HasTvShowInfo(URIUtils::GetDirectory(item.GetPath())) ||
+         db.HasEpisodeInfo(item.GetDynPath()) || db.HasMusicVideoInfo(item.GetDynPath());
+}
+
 std::string GetResumeString(const CFileItem& item)
 {
   const ResumeInformation resumeInfo = GetItemResumeInformation(item);

--- a/xbmc/video/guilib/VideoGUIUtils.h
+++ b/xbmc/video/guilib/VideoGUIUtils.h
@@ -59,6 +59,13 @@ bool GetItemsForPlayList(const std::shared_ptr<CFileItem>& item, CFileItemList& 
 bool IsItemPlayable(const CFileItem& item);
 
 /*!
+ \brief Check whether for the given item information is stored in the video database.
+ \param item The item to check
+ \return True if info is available, false otherwise.
+ */
+bool HasItemVideoDbInformation(const CFileItem& item);
+
+/*!
  \brief Get a localized resume string for the given item, if it is resumable.
  \param item The item to retrieve the resume string for
  \return The resume string or empty string in case the item is not resumable.

--- a/xbmc/video/guilib/VideoSelectActionProcessor.cpp
+++ b/xbmc/video/guilib/VideoSelectActionProcessor.cpp
@@ -21,6 +21,7 @@
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
+#include "video/VideoFileItemClassify.h"
 #include "video/VideoInfoTag.h"
 #include "video/guilib/VideoGUIUtils.h"
 
@@ -70,7 +71,17 @@ bool CVideoSelectActionProcessorBase::Process(Action action)
       return OnQueueSelected();
 
     case ACTION_INFO:
+    {
+      if (GetDefaultAction() == ACTION_INFO && !KODI::VIDEO::IsVideoDb(*m_item) &&
+          !m_item->IsPlugin() && !m_item->IsScript() &&
+          !KODI::VIDEO::UTILS::HasItemVideoDbInformation(*m_item))
+      {
+        // for items without info fall back to default play action
+        return Process(CVideoPlayActionProcessorBase::GetDefaultAction());
+      }
+
       return OnInfoSelected();
+    }
 
     case ACTION_MORE:
       return OnMoreSelected();

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -252,9 +252,7 @@ bool CGUIWindowVideoBase::OnItemInfo(const CFileItem& fileItem)
   const ADDON::ScraperPtr scraper = m_database.GetScraperForPath(strDir, settings, foundDirectly);
 
   if (!fileItem.HasVideoInfoTag() && !scraper && !(fileItem.IsPlugin() || fileItem.IsScript()) &&
-      !(m_database.HasMovieInfo(fileItem.GetDynPath()) || m_database.HasTvShowInfo(strDir) ||
-        m_database.HasEpisodeInfo(fileItem.GetDynPath()) ||
-        m_database.HasMusicVideoInfo(fileItem.GetDynPath())))
+      !KODI::VIDEO::UTILS::HasItemVideoDbInformation(fileItem))
   {
     // We have no chance to fill a video info tag, neither scraper nor db data available.
     HELPERS::ShowOKDialogText(CVariant{20176}, // Show video information


### PR DESCRIPTION
…no video db info data, fall back to resume/play.

Fixes #25217 and complaints on the Forum regarding changed behavior.

Runtime-tesed on macOS and Android, latest Kodi master.

@enen92 maybe you can have a look at the code change?