### PR TITLE
[Addon] Cache commonly parsed XML files

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -27,6 +27,7 @@
 #include <ostream>
 #include <string.h>
 #include <utility>
+#include <unordered_map>
 #include <vector>
 
 #ifdef HAS_PYTHON
@@ -38,7 +39,7 @@ using XFILE::CFile;
 
 namespace
 {
-class FilenameXMLCache
+class CFilenameXMLCache
 {
 public:
   const CXBMCTinyXML* loadXMLFile(const std::string& id, const std::string& xmlFilename)
@@ -46,11 +47,10 @@ public:
     struct __stat64 s;
     if (XFILE::CFile::Stat(xmlFilename, &s) == 0)
     {
-      auto found = m_cache.find(xmlFilename);
+      const auto found = m_cache.find(xmlFilename);
       if (found != m_cache.end() && s.st_mtime <= found->second.modified)
       {
-        auto& cachedItem = found->second;
-        return &cachedItem.xml;
+        return &found->second.xml;
       }
       else
       {
@@ -86,7 +86,7 @@ private:
   std::unordered_map<std::string, CacheItem> m_cache;
 };
 
-FilenameXMLCache cache;
+CFilenameXMLCache cache;
 } // namespace
 
 namespace ADDON

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -386,7 +386,7 @@ public:
   void OnPreInstall() override{};
   void OnPostInstall(bool update, bool modal) override{};
   void OnPreUnInstall() override{};
-  void OnPostUnInstall() override{};
+  void OnPostUnInstall() override;
 
 protected:
   /*!


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
During a scan of libraries (Tested using Movies and TV shows) each directory is queried for 2x settings. If no settings are found for that specific directory being scanned the parent (recursively) directory settings are used; This commonly defaults to the root directory. During the scan of each sub-directory the same XML file is commonly parsed which is now optimized using a cache.

## Motivation and context
Optimization of library scans

## How has this been tested?
Manually tested to ensure library scans still work as expected.
Profiling before and after to ensure reduced calls to CXMLCTinyXML::LoadFile is called less.

## What is the effect on users?
Faster scan times, especially noticeable on low-powered android boxes.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
