### PR TITLE
[settings] Fix empty heading of input dialogs (keyboard, number, ...)…

### DIFF
--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -1300,7 +1300,7 @@ CGUIControlEditSetting::CGUIControlEditSetting(CGUIEditControl* pEdit,
   else if (controlFormat == "md5")
     inputType = CGUIEditControl::INPUT_TYPE_PASSWORD_MD5;
 
-  m_pEdit->SetInputType(inputType, heading);
+  m_pEdit->SetInputType(inputType, localizer ? CVariant{localizer->Localize(heading)} : heading);
 
   // this will automatically trigger validation so it must be executed after
   // having set the value of the control based on the value of the setting


### PR DESCRIPTION
… for addon settings edit controls.

Fixes #25216 

Before:
![screenshot00009](https://github.com/xbmc/xbmc/assets/3226626/2407f42b-bfae-413a-a9b7-bdabcc7e4b4f)
![screenshot00008](https://github.com/xbmc/xbmc/assets/3226626/87e7931c-f390-4b5c-bed7-423d161bd8fc)

After:
![screenshot00011](https://github.com/xbmc/xbmc/assets/3226626/d8c5e993-bc6d-42dc-854c-ae8bfea2bec0)
![screenshot00010](https://github.com/xbmc/xbmc/assets/3226626/1f0eb568-fc2e-4506-8c17-500ef9036434)

Problem was that `CGUIEditControl::SetInputType`does not know anything about special handling required for resolving addon-defined string ids, thus it fails, ending with an empty string. Addon-supplied string ids must be resolved by `resolver` before handed over to the edit control.

Runtime-tested on macOS and Android, latest Kodi master.

@enen92 @neo1973 when you find some time, please review.