### PR TITLE
ActiveAE: remove special latency case for TrueHD

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -153,13 +153,6 @@ void CEngineStats::GetDelay(AEDelayStatus& status, CActiveAEStream *stream)
     status.delay +=
         static_cast<double>(m_bufferedSamples) * m_sinkFormat.m_streamInfo.GetDuration() / 1000;
 
-  if (!m_pcmOutput && m_sinkNeedIecPack &&
-      m_sinkFormat.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD)
-  {
-    // take into account MAT packer latency (half duration of MAT frame)
-    status.delay += m_sinkFormat.m_streamInfo.GetDuration() / 1000 / 2;
-  }
-
   for (auto &str : m_streamStats)
   {
     if (str.m_streamId == stream->m_id)
@@ -185,13 +178,6 @@ void CEngineStats::GetSyncInfo(CAESyncInfo& info, CActiveAEStream *stream)
         static_cast<double>(m_bufferedSamples) * m_sinkFormat.m_streamInfo.GetDuration() / 1000;
 
   status.delay += static_cast<double>(m_sinkLatency);
-
-  if (!m_pcmOutput && m_sinkNeedIecPack &&
-      m_sinkFormat.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD)
-  {
-    // take into account MAT packer latency (half duration of MAT frame)
-    status.delay += m_sinkFormat.m_streamInfo.GetDuration() / 1000 / 2;
-  }
 
   for (auto &str : m_streamStats)
   {


### PR DESCRIPTION
## Description
ActiveAE: remove special latency case for TrueHD

## Motivation and context
After https://github.com/xbmc/xbmc/pull/25256 since MAT packing is moved to early stages (before AE a/v sync code), MAT packing latency (if any) is not need take into account in AE stages.

This removes more TrueHD special handling code.

## How has this been tested?
Is hard to tell the difference because is only 10 ms but tested several TrueHD samples and for me the a/v sync is perfect now without this.

## What is the effect on users?
nothing / 10 ms more precise TrueHD a/v sync

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
