### PR TITLE
[PVR] Add support for 'any channel from any client' to epg-based reminder rules

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -3922,7 +3922,13 @@ msgctxt "#853"
 msgid "Any channel from client \"{0:s}\""
 msgstr ""
 
-#empty strings from id 854 to 996
+#. Label for denoting any channel from any available client in timer settings dialog
+#: xbmc/pvr/dialogs/GUIDislogPVRTimerSettings.cpp
+msgctxt "#854"
+msgid "Any channel from any client"
+msgstr ""
+
+#empty strings from id 855 to 996
 
 #: xbmc/windows/GUIMediaWindow.cpp
 msgctxt "#997"

--- a/xbmc/pvr/PVRDatabase.cpp
+++ b/xbmc/pvr/PVRDatabase.cpp
@@ -1114,7 +1114,7 @@ std::vector<std::shared_ptr<CPVRTimerInfoTag>> CPVRDatabase::GetTimers(
   std::string strQuery = "SELECT * FROM timers ";
   const std::string clientIds = GetClientIdsSQL(clients);
   if (!clientIds.empty())
-    strQuery += "WHERE " + clientIds;
+    strQuery += "WHERE " + clientIds + " OR (iClientId = -1)"; // always load client agnostic timers
 
   std::unique_lock<CCriticalSection> lock(m_critSection);
   strQuery = PrepareSQL(strQuery);

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -42,7 +42,8 @@ class CPVRTimerInfoTag;
 class CPVRTimerType;
 class CPVRTimersContainer;
 
-#define PVR_INVALID_CLIENT_ID (-2)
+static constexpr int PVR_ANY_CLIENT_ID = -1;
+static constexpr int PVR_INVALID_CLIENT_ID = -2;
 
 /*!
  * Interface from Kodi to a PVR add-on.

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -15,6 +15,7 @@
 #include "guilib/WindowIDs.h"
 #include "input/WindowTranslator.h"
 #include "pvr/PVRManager.h"
+#include "pvr/addons/PVRClient.h" // PVR_ANY_CLIENT_ID
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRChannelGroupMember.h"
@@ -648,7 +649,8 @@ bool GetTimersSubDirectory(const CPVRTimersPath& path,
 
   for (const auto& timer : timers)
   {
-    if ((timer->IsRadio() == bRadio) && timer->HasParent() && (timer->ClientID() == iClientId) &&
+    if ((timer->IsRadio() == bRadio) && timer->HasParent() &&
+        (iClientId == PVR_ANY_CLIENT_ID || timer->ClientID() == iClientId) &&
         (timer->ParentClientIndex() == iParentId) && (!bHideDisabled || !timer->IsDisabled()))
     {
       item = std::make_shared<CFileItem>(timer);

--- a/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
@@ -583,7 +583,8 @@ bool CPVRGUIActionsTimers::EditTimer(const CFileItem& item) const
   if (ShowTimerSettings(newTimer) &&
       (!timer->GetTimerType()->IsReadOnly() || timer->GetTimerType()->SupportsEnableDisable()))
   {
-    if (newTimer->GetTimerType() == timer->GetTimerType())
+    if (newTimer->GetTimerType() == timer->GetTimerType() &&
+        newTimer->ClientID() == timer->ClientID())
     {
       if (CServiceBroker::GetPVRManager().Timers()->UpdateTimer(newTimer))
         return true;
@@ -596,12 +597,15 @@ bool CPVRGUIActionsTimers::EditTimer(const CFileItem& item) const
     }
     else
     {
-      // timer type changed. delete the original timer, then create the new timer. this order is
-      // important. for instance, the new timer might be a rule which schedules the original timer.
-      // deleting the original timer after creating the rule would do literally this and we would
-      // end up with one timer missing wrt to the rule defined by the new timer.
+      // Timer type or client changed. delete the original timer, then create the new timer. This
+      // order is important. for instance, the new timer might be a rule which schedules the
+      // original timer. Deleting the original timer after creating the rule would do literally this
+      // and we would end up with one timer missing wrt to the rule defined by the new timer.
       if (DeleteTimer(timer, timer->IsRecording(), false))
       {
+        if (newTimer->IsTimerRule())
+          newTimer->ResetChildState();
+
         if (AddTimer(newTimer))
           return true;
 

--- a/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
@@ -10,6 +10,7 @@
 
 #include "FileItem.h"
 #include "ServiceBroker.h"
+#include "dialogs/GUIDialogBusy.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "dialogs/GUIDialogYesNo.h"
@@ -35,6 +36,7 @@
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "pvr/timers/PVRTimers.h"
 #include "settings/Settings.h"
+#include "threads/IRunnable.h"
 #include "utils/StringUtils.h"
 #include "utils/SystemInfo.h"
 #include "utils/Variant.h"
@@ -49,6 +51,71 @@
 
 using namespace PVR;
 using namespace KODI::MESSAGING;
+
+namespace
+{
+class AsyncUpdateTimer : private IRunnable
+{
+public:
+  AsyncUpdateTimer(const CPVRGUIActionsTimers& guiActions,
+                   const std::shared_ptr<CPVRTimerInfoTag>& oldTimer,
+                   const std::shared_ptr<CPVRTimerInfoTag>& newTimer)
+    : m_guiActions(guiActions), m_oldTimer(oldTimer), m_newTimer(newTimer)
+  {
+  }
+
+  bool Execute()
+  {
+    CGUIDialogBusy::Wait(this, 100, false);
+    return m_success;
+  }
+
+private:
+  // IRunnable implementation
+  void Run() override
+  {
+    m_success = true;
+
+    if (m_newTimer->GetTimerType() == m_oldTimer->GetTimerType() &&
+        m_newTimer->ClientID() == m_oldTimer->ClientID())
+    {
+      if (CServiceBroker::GetPVRManager().Timers()->UpdateTimer(m_newTimer))
+        return;
+
+      HELPERS::ShowOKDialogText(
+          CVariant{257},
+          CVariant{
+              19263}); // "Error", "Could not update the timer. Check the log for more information about this message."
+      m_success = false;
+      return;
+    }
+    else
+    {
+      // Timer type or client changed. Delete the original timer, then create the new timer. This
+      // order is important. for instance, the new timer might be a rule which schedules the
+      // original timer. Deleting the original timer after creating the rule would do literally this
+      // and we would end up with one timer missing wrt to the rule defined by the new timer.
+      if (m_guiActions.DeleteTimer(m_oldTimer, m_oldTimer->IsRecording(), false))
+      {
+        if (m_newTimer->IsTimerRule())
+          m_newTimer->ResetChildState();
+
+        m_success = m_guiActions.AddTimer(m_newTimer);
+        if (!m_success)
+        {
+          // rollback.
+          m_success = m_guiActions.AddTimer(m_oldTimer);
+        }
+      }
+    }
+  }
+
+  const CPVRGUIActionsTimers& m_guiActions;
+  std::shared_ptr<CPVRTimerInfoTag> m_oldTimer;
+  std::shared_ptr<CPVRTimerInfoTag> m_newTimer;
+  bool m_success{false};
+};
+} // unnamed namespace
 
 CPVRGUIActionsTimers::CPVRGUIActionsTimers()
   : m_settings({CSettings::SETTING_PVRRECORD_INSTANTRECORDTIME,
@@ -583,36 +650,8 @@ bool CPVRGUIActionsTimers::EditTimer(const CFileItem& item) const
   if (ShowTimerSettings(newTimer) &&
       (!timer->GetTimerType()->IsReadOnly() || timer->GetTimerType()->SupportsEnableDisable()))
   {
-    if (newTimer->GetTimerType() == timer->GetTimerType() &&
-        newTimer->ClientID() == timer->ClientID())
-    {
-      if (CServiceBroker::GetPVRManager().Timers()->UpdateTimer(newTimer))
-        return true;
-
-      HELPERS::ShowOKDialogText(
-          CVariant{257},
-          CVariant{
-              19263}); // "Error", "Could not update the timer. Check the log for more information about this message."
-      return false;
-    }
-    else
-    {
-      // Timer type or client changed. delete the original timer, then create the new timer. This
-      // order is important. for instance, the new timer might be a rule which schedules the
-      // original timer. Deleting the original timer after creating the rule would do literally this
-      // and we would end up with one timer missing wrt to the rule defined by the new timer.
-      if (DeleteTimer(timer, timer->IsRecording(), false))
-      {
-        if (newTimer->IsTimerRule())
-          newTimer->ResetChildState();
-
-        if (AddTimer(newTimer))
-          return true;
-
-        // rollback.
-        return AddTimer(timer);
-      }
-    }
+    AsyncUpdateTimer asyncUpdate(*this, timer, newTimer);
+    return asyncUpdate.Execute();
   }
   return false;
 }

--- a/xbmc/pvr/guilib/PVRGUIActionsTimers.h
+++ b/xbmc/pvr/guilib/PVRGUIActionsTimers.h
@@ -106,6 +106,20 @@ public:
   bool DeleteTimer(const CFileItem& item) const;
 
   /*!
+   * @brief Delete a timer or timer rule, showing a confirmation dialog in case a timer currently
+   * recording shall be deleted.
+   * @param timer containing a timer or timer rule to delete.
+   * @param bIsRecording denotes whether the timer is currently recording (controls correct
+   * confirmation dialog).
+   * @param bDeleteRule denotes to delete a timer rule. For convenience, one can pass a timer
+   * created by a rule.
+   * @return true, if the timer or timer rule was deleted successfully, false otherwise.
+   */
+  bool DeleteTimer(const std::shared_ptr<CPVRTimerInfoTag>& timer,
+                   bool bIsRecording,
+                   bool bDeleteRule) const;
+
+  /*!
    * @brief Delete a timer rule, always showing a confirmation dialog.
    * @param item containing a timer rule to delete. item must be a timer, an epg tag or a channel.
    * @return true, if the timer rule was deleted successfully, false otherwise.
@@ -183,20 +197,6 @@ private:
    * @return true, if the timer or timer rule was deleted successfully, false otherwise.
   */
   bool DeleteTimer(const CFileItem& item, bool bIsRecording, bool bDeleteRule) const;
-
-  /*!
-   * @brief Delete a timer or timer rule, showing a confirmation dialog in case a timer currently
-   * recording shall be deleted.
-   * @param timer containing a timer or timer rule to delete.
-   * @param bIsRecording denotes whether the timer is currently recording (controls correct
-   * confirmation dialog).
-   * @param bDeleteRule denotes to delete a timer rule. For convenience, one can pass a timer
-   * created by a rule.
-   * @return true, if the timer or timer rule was deleted successfully, false otherwise.
-   */
-  bool DeleteTimer(const std::shared_ptr<CPVRTimerInfoTag>& timer,
-                   bool bIsRecording,
-                   bool bDeleteRule) const;
 
   /*!
    * @brief Open a dialog to confirm timer delete.

--- a/xbmc/pvr/timers/PVRTimerRuleMatcher.cpp
+++ b/xbmc/pvr/timers/PVRTimerRuleMatcher.cpp
@@ -10,6 +10,7 @@
 
 #include "XBDateTime.h"
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_channels.h" // PVR_CHANNEL_INVALID_UID
+#include "pvr/addons/PVRClient.h" // PVR_ANY_CLIENT_ID
 #include "pvr/epg/EpgInfoTag.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "utils/RegExp.h"
@@ -90,8 +91,10 @@ bool CPVRTimerRuleMatcher::MatchSeriesLink(
 bool CPVRTimerRuleMatcher::MatchChannel(const std::shared_ptr<const CPVREpgInfoTag>& epgTag) const
 {
   if (m_timerRule->GetTimerType()->SupportsAnyChannel() &&
-      m_timerRule->ClientChannelUID() == PVR_CHANNEL_INVALID_UID)
-    return true; // matches any channel
+      m_timerRule->ClientChannelUID() == PVR_CHANNEL_INVALID_UID &&
+      (m_timerRule->ClientID() == PVR_ANY_CLIENT_ID ||
+       m_timerRule->ClientID() == epgTag->ClientID()))
+    return true; // matches any channel from any client / any channel from a certain client
 
   if (m_timerRule->GetTimerType()->SupportsChannels())
     return m_timerRule->ClientChannelUID() != PVR_CHANNEL_INVALID_UID &&

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -1218,8 +1218,10 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::GetTimerRule(
       for (const auto& tagsEntry : m_tags)
       {
         const auto it = std::find_if(tagsEntry.second.cbegin(), tagsEntry.second.cend(),
-                                     [iClientId, iParentClientIndex](const auto& timersEntry) {
-                                       return timersEntry->ClientID() == iClientId &&
+                                     [iClientId, iParentClientIndex](const auto& timersEntry)
+                                     {
+                                       return (timersEntry->ClientID() == PVR_ANY_CLIENT_ID ||
+                                               timersEntry->ClientID() == iClientId) &&
                                               timersEntry->ClientIndex() == iParentClientIndex;
                                      });
         if (it != tagsEntry.second.cend())


### PR DESCRIPTION
The screenshot should explain it all. This PR adds the possibility to create epg-based reminder rules, which match any channel provided by any available PVR client.

![screenshot00003](https://github.com/xbmc/xbmc/assets/3226626/436cb17e-2c64-4af4-a245-1a2df59eddd1)

Second introduces a busy dialog when updating timers, as this can take some time for certain timer types, esp. complex reminder rules.
 
Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish something best to be reviewed by you I guess.