### PR TITLE
Fix skin element "toggle button"

### DIFF
--- a/xbmc/guilib/GUIToggleButtonControl.cpp
+++ b/xbmc/guilib/GUIToggleButtonControl.cpp
@@ -38,6 +38,7 @@ void CGUIToggleButtonControl::Process(unsigned int currentTime, CDirtyRegionList
     m_selectButton.SetPulseOnSelect(m_pulseOnSelect);
     ProcessToggle(currentTime);
     m_selectButton.DoProcess(currentTime, dirtyregions);
+    CGUIControl::Process(currentTime, dirtyregions);
   }
   else
     CGUIButtonControl::Process(currentTime, dirtyregions);


### PR DESCRIPTION
## Description
The PR (hopefully) fixes issue https://github.com/xbmc/xbmc/issues/25279 where alt label/textures of toggle buttons would not render.

## Motivation and context
The scissor cull PR (https://github.com/xbmc/xbmc/pull/23022) seems to uncover some hidden bugs. I'm pretty sure we have had issues with dirty region rendering for this element, which now crops up as them not rendering at all. There might be more.

## How has this been tested?
Barely. I do have a makeshift debug skin where I can kinda reproduce the issue and the fix.

## What is the effect on users?
Correct rendering of toggle buttons.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
