### PR TITLE
CFile: Handle std::bad_alloc in LoadFile

### DIFF
--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -994,6 +994,7 @@ ssize_t CFile::LoadFile(const std::string& filename, std::vector<uint8_t>& outpu
 }
 
 ssize_t CFile::LoadFile(const CURL& file, std::vector<uint8_t>& outputBuffer)
+try
 {
   static const size_t max_file_size = 0x7FFFFFFF;
   static const size_t min_chunk_size = 64 * 1024U;
@@ -1057,6 +1058,12 @@ ssize_t CFile::LoadFile(const CURL& file, std::vector<uint8_t>& outputBuffer)
   outputBuffer.resize(total_read);
 
   return total_read;
+}
+catch (const std::bad_alloc&)
+{
+  outputBuffer.clear();
+  CLog::LogF(LOGERROR, "Failed to load {}: out of memory", file.GetFileName());
+  return -1;
 }
 
 double CFile::GetDownloadSpeed()


### PR DESCRIPTION
## Description

In #25288 it looks like a device tries to handle a video as a picture and runs out of memory when trying to loading that file. A `std::bad_alloc` gets thrown, isn't handled and so Kodi dies. We should try to handle this in the `CFile::LoadFile` method.

But it should be said that this won't work for most Linux systems due to memory overcommitment. On such systems `new`/`malloc` basically never fails and instead the process gets killed by the OOM killer at some point. But as can be seen in #25288 this doesn't seem to be the case on every system.

## Motivation and context

Try our best to not let Kodi die. Fixes #25288.

## How has this been tested?

I tried to test this by placing large files with .png extensions into my picture folder but every time Kodi gets OOM killed before a memory allocation fails.

## What is the effect on users?

Maybe Kodi doesn't die, maybe it still dies.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
