### PR TITLE
[imagecache] Add a process to clean old images from cache

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -1508,6 +1508,7 @@ msgid "(0=auto)"
 msgstr ""
 
 #. generic "cleaning database" label used in different places
+#: xbmc/TextureCache.cpp
 #: xbmc/music/MusicDatabase.cpp
 #: xbmc/pvr/guilib/PVRGUIActionsDatabase.cpp
 #: xbmc/settings/MediaSettings.cpp
@@ -8772,7 +8773,25 @@ msgctxt "#14277"
 msgid "Allow remote control from applications on other systems"
 msgstr ""
 
-#empty strings from id 14278 to 14300
+#empty strings from id 14278 to 14279
+
+#: system/settings/settings.xml
+msgctxt "#14280"
+msgid "Maintenance"
+msgstr ""
+
+#: system/settings/settings.xml
+#: xbmc/TextureCache.cpp
+msgctxt "#14281"
+msgid "Clean image cache"
+msgstr ""
+
+#: system/settings/settings.xml
+msgctxt "#14282"
+msgid "Immediately remove unused images from the cache - images not associated with an item in the media library nor viewed recently. Kodi does this over time in the background."
+msgstr ""
+
+#empty strings from id 14283 to 14300
 
 #. pvr "channels" settings group label
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1018,6 +1018,12 @@
           <control type="button" format="action" />
         </setting>
       </group>
+      <group id="4" label="14280">
+        <setting id="maintenance.cleanimagecache" type="action" label="14281" help="14282">
+          <level>3</level>
+          <control type="button" format="action" />
+        </setting>
+      </group>
     </category>
     <category id="filelists" label="16000" help="36121">
       <group id="1" label="593">

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -15,12 +15,14 @@
 #include "threads/Timer.h"
 #include "utils/JobManager.h"
 
+#include <atomic>
 #include <chrono>
 #include <memory>
 #include <set>
 #include <string>
 #include <vector>
 
+class CGUIDialogProgress;
 class CJob;
 class CURL;
 class CTexture;
@@ -155,6 +157,8 @@ public:
   bool Export(const std::string &image, const std::string &destination, bool overwrite);
   bool Export(const std::string &image, const std::string &destination); //! @todo BACKWARD COMPATIBILITY FOR MUSIC THUMBS
 
+  bool CleanAllUnusedImages();
+
 private:
   // private construction, and no assignments; use the provided singleton methods
   CTextureCache(const CTextureCache&) = delete;
@@ -218,7 +222,9 @@ private:
 
   void CleanTimer();
   std::chrono::milliseconds ScanOldestCache();
+  bool CleanAllUnusedImagesJob(CGUIDialogProgress* progress);
 
+  std::atomic_flag m_cleaningInProgress;
   CTimer m_cleanTimer;
   CCriticalSection m_databaseSection;
   CTextureDatabase m_database;

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -12,8 +12,10 @@
 #include "TextureDatabase.h"
 #include "threads/CriticalSection.h"
 #include "threads/Event.h"
+#include "threads/Timer.h"
 #include "utils/JobManager.h"
 
+#include <chrono>
 #include <memory>
 #include <set>
 #include <string>
@@ -152,6 +154,7 @@ public:
    */
   bool Export(const std::string &image, const std::string &destination, bool overwrite);
   bool Export(const std::string &image, const std::string &destination); //! @todo BACKWARD COMPATIBILITY FOR MUSIC THUMBS
+
 private:
   // private construction, and no assignments; use the provided singleton methods
   CTextureCache(const CTextureCache&) = delete;
@@ -213,6 +216,10 @@ private:
    */
   void OnCachingComplete(bool success, CTextureCacheJob *job);
 
+  void CleanTimer();
+  std::chrono::milliseconds ScanOldestCache();
+
+  CTimer m_cleanTimer;
   CCriticalSection m_databaseSection;
   CTextureDatabase m_database;
   std::set<std::string> m_processinglist; ///< currently processing list to avoid 2 jobs being processed at once

--- a/xbmc/TextureDatabase.h
+++ b/xbmc/TextureDatabase.h
@@ -86,6 +86,20 @@ public:
 
   bool GetTextures(CVariant &items, const Filter &filter);
 
+  /*!
+   * @brief Get a list of the oldest cached images eligible for cleaning.
+   * @param maxImages the maximum number of images to return
+   * @return
+   */
+  std::vector<std::string> GetOldestCachedImages(unsigned int maxImages) const;
+
+  /*!
+   * @brief Set a list of images to be kept. Used to clean the image cache.
+   * @param imagesToKeep
+   * @return
+   */
+  bool SetKeepCachedImages(const std::vector<std::string>& imagesToKeep);
+
   // rule creation
   CDatabaseQueryRule *CreateRule() const override;
   CDatabaseQueryRuleCombination *CreateCombination() const override;
@@ -100,6 +114,6 @@ protected:
   void CreateTables() override;
   void CreateAnalytics() override;
   void UpdateTables(int version) override;
-  int GetSchemaVersion() const override { return 13; }
+  int GetSchemaVersion() const override { return 14; }
   const char* GetBaseDBName() const override { return "Textures"; }
 };

--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -1252,3 +1252,45 @@ bool CAddonDatabase::AddInstalledAddon(const std::shared_ptr<CAddonInfo>& addon,
 
   return true;
 }
+
+namespace
+{
+bool IsAddonImageChecked(const std::string& addonImage,
+                         const std::vector<std::string>& imagesToCheck)
+{
+  if (addonImage.empty())
+    return false;
+
+  auto found = std::find(imagesToCheck.begin(), imagesToCheck.end(), addonImage);
+  return found != imagesToCheck.end();
+}
+} // namespace
+
+std::vector<std::string> CAddonDatabase::GetUsedImages(
+    const std::vector<std::string>& imagesToCheck) const
+{
+  if (!imagesToCheck.size())
+    return {};
+
+  VECADDONS allAddons;
+  if (!GetRepositoryContent(allAddons))
+    return imagesToCheck;
+
+  std::vector<std::string> result;
+  for (const auto& addon : allAddons)
+  {
+    if (IsAddonImageChecked(addon->Icon(), imagesToCheck))
+      result.push_back(addon->Icon());
+    for (const auto& screenshot : addon->Screenshots())
+    {
+      if (IsAddonImageChecked(screenshot, imagesToCheck))
+        result.push_back(screenshot);
+    }
+    for (const auto& artPair : addon->Art())
+    {
+      if (IsAddonImageChecked(artPair.second, imagesToCheck))
+        result.push_back(artPair.second);
+    }
+  }
+  return result;
+}

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -230,6 +230,13 @@ public:
    */
   bool AddInstalledAddon(const std::shared_ptr<CAddonInfo>& addon, const std::string& origin);
 
+  /*!
+   * @brief Check the passed in list of images if used in this database. Used to clean the image cache.
+   * @param imagesToCheck
+   * @return a list of the passed in images used by this database.
+   */
+  std::vector<std::string> GetUsedImages(const std::vector<std::string>& imagesToCheck) const;
+
 protected:
   void CreateTables() override;
   void CreateAnalytics() override;

--- a/xbmc/imagefiles/CMakeLists.txt
+++ b/xbmc/imagefiles/CMakeLists.txt
@@ -1,7 +1,9 @@
-set(SOURCES ImageFileURL.cpp
+set(SOURCES ImageCacheCleaner.cpp
+            ImageFileURL.cpp
             SpecialImageLoaderFactory.cpp)
 
-set(HEADERS ImageFileURL.h
+set(HEADERS ImageCacheCleaner.h
+            ImageFileURL.h
             SpecialImageFileLoader.h
             SpecialImageLoaderFactory.h)
 

--- a/xbmc/imagefiles/ImageCacheCleaner.cpp
+++ b/xbmc/imagefiles/ImageCacheCleaner.cpp
@@ -1,0 +1,112 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ImageCacheCleaner.h"
+
+#include "ServiceBroker.h"
+#include "TextureCache.h"
+#include "TextureDatabase.h"
+#include "addons/AddonDatabase.h"
+#include "music/MusicDatabase.h"
+#include "utils/log.h"
+#include "video/VideoDatabase.h"
+
+namespace IMAGE_FILES
+{
+std::optional<IMAGE_FILES::CImageCacheCleaner> CImageCacheCleaner::Create()
+{
+  auto result = CImageCacheCleaner();
+  if (result.m_valid)
+    return std::move(result);
+  return {};
+}
+
+CImageCacheCleaner::CImageCacheCleaner()
+{
+  bool valid = true;
+  m_textureDB = std::make_unique<CTextureDatabase>();
+  if (!m_textureDB->Open())
+  {
+    valid = false;
+    CLog::LogF(LOGWARNING, "failed to initialize image cache cleaner: failed to open texture DB");
+  }
+
+  m_videoDB = std::make_unique<CVideoDatabase>();
+  if (!m_videoDB->Open())
+  {
+    valid = false;
+    CLog::LogF(LOGWARNING, "failed to initialize image cache cleaner: failed to open video DB");
+  }
+
+  m_musicDB = std::make_unique<CMusicDatabase>();
+  if (!m_musicDB->Open())
+  {
+    valid = false;
+    CLog::LogF(LOGWARNING, "failed to initialize image cache cleaner: failed to open music DB");
+  }
+
+  m_addonDB = std::make_unique<ADDON::CAddonDatabase>();
+  if (!m_addonDB->Open())
+  {
+    valid = false;
+    CLog::LogF(LOGWARNING, "failed to initialize image cache cleaner: failed to open add-on DB");
+  }
+  m_valid = valid;
+}
+
+CImageCacheCleaner::~CImageCacheCleaner()
+{
+  if (m_addonDB)
+    m_addonDB->Close();
+  if (m_musicDB)
+    m_musicDB->Close();
+  if (m_videoDB)
+    m_videoDB->Close();
+  if (m_textureDB)
+    m_textureDB->Close();
+}
+
+CleanerResult CImageCacheCleaner::ScanOldestCache(unsigned int imageLimit)
+{
+  CLog::LogF(LOGDEBUG, "begin process to clean image cache");
+
+  auto images = m_textureDB->GetOldestCachedImages(imageLimit);
+  if (images.empty())
+  {
+    CLog::LogF(LOGDEBUG, "found no old cached images to process");
+    return CleanerResult{0, {}, {}};
+  }
+  unsigned int processedCount = images.size();
+  CLog::LogF(LOGDEBUG, "found {} old cached images to process", processedCount);
+
+  auto usedImages = m_videoDB->GetUsedImages(images);
+
+  auto nextUsedImages = m_musicDB->GetUsedImages(images);
+  usedImages.insert(usedImages.end(), std::make_move_iterator(nextUsedImages.begin()),
+                    std::make_move_iterator(nextUsedImages.end()));
+
+  nextUsedImages = m_addonDB->GetUsedImages(images);
+  usedImages.insert(usedImages.end(), std::make_move_iterator(nextUsedImages.begin()),
+                    std::make_move_iterator(nextUsedImages.end()));
+
+  images.erase(std::remove_if(images.begin(), images.end(),
+                              [&usedImages](const std::string& image) {
+                                return std::find(usedImages.cbegin(), usedImages.cend(), image) !=
+                                       usedImages.cend();
+                              }),
+               images.end());
+
+  m_textureDB->SetKeepCachedImages(usedImages);
+
+  unsigned int keptCount = usedImages.size();
+  CLog::LogF(LOGDEBUG, "cleaning {} unused images from cache, keeping {}", images.size(),
+             keptCount);
+
+  return CleanerResult{processedCount, keptCount, std::move(images)};
+}
+} // namespace IMAGE_FILES

--- a/xbmc/imagefiles/ImageCacheCleaner.h
+++ b/xbmc/imagefiles/ImageCacheCleaner.h
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+class CTextureDatabase;
+class CVideoDatabase;
+class CMusicDatabase;
+namespace ADDON
+{
+class CAddonDatabase;
+}
+
+namespace IMAGE_FILES
+{
+struct CleanerResult
+{
+  unsigned int processedCount;
+  unsigned int keptCount;
+  std::vector<std::string> imagesToClean;
+};
+
+/*!
+ * @brief Clean old unused images from the image cache.
+ */
+class CImageCacheCleaner
+{
+public:
+  static std::optional<IMAGE_FILES::CImageCacheCleaner> Create();
+  ~CImageCacheCleaner();
+  CImageCacheCleaner(const CImageCacheCleaner&) = delete;
+  CImageCacheCleaner& operator=(const CImageCacheCleaner&) = delete;
+  CImageCacheCleaner(CImageCacheCleaner&&) = default;
+  CImageCacheCleaner& operator=(CImageCacheCleaner&&) = default;
+
+  CleanerResult ScanOldestCache(unsigned int imageLimit);
+
+private:
+  CImageCacheCleaner();
+  bool m_valid;
+
+  std::unique_ptr<CTextureDatabase> m_textureDB;
+  std::unique_ptr<CVideoDatabase> m_videoDB;
+  std::unique_ptr<CMusicDatabase> m_musicDB;
+  std::unique_ptr<ADDON::CAddonDatabase> m_addonDB;
+};
+} // namespace IMAGE_FILES

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -882,6 +882,12 @@ public:
   std::string GetAlbumsLastModified();
   std::string GetArtistsLastModified();
 
+  /*!
+   * @brief Check the passed in list of images if used in this database. Used to clean the image cache.
+   * @param imagesToCheck
+   * @return a list of the passed in images used by this database.
+   */
+  std::vector<std::string> GetUsedImages(const std::vector<std::string>& imagesToCheck) const;
 
 protected:
   std::map<std::string, int> m_genreCache;

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -10,6 +10,7 @@
 
 #include "PlayListPlayer.h"
 #include "ServiceBroker.h"
+#include "TextureCache.h"
 #include "cores/RetroPlayer/RetroPlayerUtils.h"
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "guilib/LocalizeStrings.h"
@@ -366,6 +367,10 @@ void CMediaSettings::OnSettingAction(const std::shared_ptr<const CSetting>& sett
       videodatabase.ImportFromXML(path);
       videodatabase.Close();
     }
+  }
+  else if (settingId == CSettings::SETTING_MAINTENANCE_CLEANIMAGECACHE)
+  {
+    CServiceBroker::GetTextureCache()->CleanAllUnusedImages();
   }
 }
 

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -560,6 +560,7 @@ void CSettings::InitializeISettingCallbacks()
   settingSet.insert(CSettings::SETTING_VIDEOLIBRARY_IMPORT);
   settingSet.insert(CSettings::SETTING_VIDEOLIBRARY_EXPORT);
   settingSet.insert(CSettings::SETTING_VIDEOLIBRARY_SHOWUNWATCHEDPLOTS);
+  settingSet.insert(CSettings::SETTING_MAINTENANCE_CLEANIMAGECACHE);
   GetSettingsManager()->RegisterCallback(&CMediaSettings::GetInstance(), settingSet);
 
   settingSet.clear();

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -282,6 +282,7 @@ public:
   static constexpr auto SETTING_MUSICLIBRARY_EXPORT_ARTWORK = "musiclibrary.exportartwork";
   static constexpr auto SETTING_MUSICLIBRARY_EXPORT_SKIPNFO = "musiclibrary.exportskipnfo";
   static constexpr auto SETTING_MUSICLIBRARY_IMPORT = "musiclibrary.import";
+  static constexpr auto SETTING_MAINTENANCE_CLEANIMAGECACHE = "maintenance.cleanimagecache";
   static constexpr auto SETTING_MUSICPLAYER_AUTOPLAYNEXTITEM = "musicplayer.autoplaynextitem";
   static constexpr auto SETTING_MUSICPLAYER_QUEUEBYDEFAULT = "musicplayer.queuebydefault";
   static constexpr auto SETTING_MUSICPLAYER_SEEKSTEPS = "musicplayer.seeksteps";

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1113,6 +1113,13 @@ public:
   int GetFileIdByMovie(int idMovie);
   std::string GetFileBasePathById(int idFile);
 
+  /*!
+   * @brief Check the passed in list of images if used in this database. Used to clean the image cache.
+   * @param imagesToCheck
+   * @return a list of the passed in images used by this database.
+   */
+  std::vector<std::string> GetUsedImages(const std::vector<std::string>& imagesToCheck);
+
 protected:
   int AddNewMovie(CVideoInfoTag& details);
   int AddNewMusicVideo(CVideoInfoTag& details);


### PR DESCRIPTION
## Description
Adds a conservative image cache cleaning process. It removes images from the cache if they are not in the video or music library and have not been used in the past month.

Also checks the add-on database for images. Ignores PVR images as those cached images are managed another way. Implemented as a background process checking up to 1000 images up to 4 times per day.

When checking the video library it considers [the "Artwork level" settings](https://kodi.wiki/view/Settings/Media/Videos#Artwork). Same for the [music library](https://kodi.wiki/view/Settings/Media/Music#Artwork) except treats "Custom" like Maximum, since it has a couple of special rules.

PR also adds an action in settings to clear all old images at once.

## Motivation and context
Some devices don't have enough storage space to hold every image Kodi ever displayed, and it shouldn't even if there is enough space.

These days the texture cache is likely to take up a relatively large amount of device storage space, this is one conservative step to limiting that amount.

## How has this been tested?
Manual testing on Windows and Pi3 and dogfooding on Pi5 for a couple weeks.

## What is the effect on users?
Prevent the image cache from growing indefinitely. Solve out-of-space issues when library artwork fits in 50% - 80% of storage space, from CCwGTV and tiny library / just streaming to 16GB storage and large libraries with a lot of artwork.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/86ca7eb1-94fa-4ba6-8c60-3f11e7f932a1)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
