### PR TITLE
[BP][FileSystem] limit SMB chunk size to 64 KB for SMBv1

### DIFF
--- a/xbmc/platform/posix/filesystem/SMBFile.cpp
+++ b/xbmc/platform/posix/filesystem/SMBFile.cpp
@@ -746,5 +746,17 @@ int CSMBFile::GetChunkSize()
 {
   const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
 
-  return settings ? (settings->GetInt(CSettings::SETTING_SMB_CHUNKSIZE) * 1024) : (128 * 1024);
+  if (!settings)
+    return (64 * 1024);
+
+  int chunkSize = settings->GetInt(CSettings::SETTING_SMB_CHUNKSIZE) * 1024;
+
+  if (settings->GetInt(CSettings::SETTING_SMB_MINPROTOCOL) == 1 &&
+      settings->GetInt(CSettings::SETTING_SMB_MAXPROTOCOL) == 1)
+  {
+    if (chunkSize > 64 * 1024)
+      chunkSize = 64 * 1024;
+  }
+
+  return chunkSize;
 }


### PR DESCRIPTION
## Description
Backport of https://github.com/xbmc/xbmc/pull/25291



## What is the effect on users?
None with default settings. Limits SMB chunk size to 64 KB if user sets SMB min protocol and SMB max protocol to 1.



## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
