### PR TITLE
[PVR] Timer settings dialog: When creating new timer rules without an…

### DIFF
--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -120,7 +120,7 @@ void CGUIDialogPVRTimerSettings::SetTimer(const std::shared_ptr<CPVRTimerInfoTag
   m_firstDayLocalTime = m_timerInfoTag->FirstDayAsLocalTime();
 
   m_strEpgSearchString = m_timerInfoTag->m_strEpgSearchString;
-  if ((m_bIsNewTimer || !m_timerType->SupportsEpgTitleMatch()) && m_strEpgSearchString.empty())
+  if (!m_bIsNewTimer && m_strEpgSearchString.empty())
     m_strEpgSearchString = m_strTitle;
 
   m_bFullTextEpgSearch = m_timerInfoTag->m_bFullTextEpgSearch;

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -989,7 +989,7 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTag::CreateFromEpg(
     if (timerType)
     {
       if (timerType->SupportsEpgTitleMatch())
-        newTag->m_strEpgSearchString = newTag->m_strTitle;
+        newTag->m_strEpgSearchString = tag->Title();
 
       if (timerType->SupportsWeekdays())
         newTag->m_iWeekdays = PVR_WEEKDAY_ALLDAYS;


### PR DESCRIPTION
… epg tag, leave epg search string empty. When created from an epg tag, title of the tag will be taken over as epg search string like before this PR.

Fixes #25090 

Before:
![screenshot00003](https://github.com/xbmc/xbmc/assets/3226626/d5a1987a-e52c-4d70-a71d-968d4b4a08cd)

After:
![screenshot00008](https://github.com/xbmc/xbmc/assets/3226626/32cb62ca-5cb6-4e6e-bbac-fb48e2622d1c)

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish when you find time for a review.