### PR TITLE
[Android] Allow setting the VideoLayout view to transparent color

### DIFF
--- a/xbmc/platform/android/PlatformAndroid.cpp
+++ b/xbmc/platform/android/PlatformAndroid.cpp
@@ -8,7 +8,10 @@
 
 #include "PlatformAndroid.h"
 
+#include "ServiceBroker.h"
 #include "filesystem/SpecialProtocol.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/log.h"
 #include "windowing/android/WinSystemAndroidGLESContext.h"
 
@@ -36,6 +39,20 @@ bool CPlatformAndroid::InitStageOne()
   CWinSystemAndroidGLESContext::Register();
 
   CAndroidPowerSyscall::Register();
+
+  return true;
+}
+
+bool CPlatformAndroid::InitStageThree()
+{
+  if (!CPlatformPosix::InitStageThree())
+    return false;
+
+  if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiVideoLayoutTransparent)
+  {
+    CLog::Log(LOGINFO, "XBMCApp: VideoLayout view was set to transparent.");
+    CXBMCApp::Get().SetVideoLayoutBackgroundColor(0);
+  }
 
   return true;
 }

--- a/xbmc/platform/android/PlatformAndroid.h
+++ b/xbmc/platform/android/PlatformAndroid.h
@@ -20,5 +20,6 @@ class CPlatformAndroid : public CPlatformPosix
     ~CPlatformAndroid() override = default;
 
     bool InitStageOne() override;
+    bool InitStageThree() override;
     void PlatformSyslog() override;
 };

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -91,6 +91,7 @@
 #include <androidjni/MediaStore.h>
 #include <androidjni/NetworkInfo.h>
 #include <androidjni/PackageManager.h>
+#include <androidjni/Resources.h>
 #include <androidjni/StatFs.h>
 #include <androidjni/System.h>
 #include <androidjni/SystemClock.h>
@@ -1667,6 +1668,40 @@ std::shared_ptr<CNativeWindow> CXBMCApp::GetNativeWindow(int timeout) const
     m_mainView->waitForSurface(timeout);
 
   return m_window;
+}
+
+// The map must contain keys "id" and "color", both are integers
+void CXBMCApp::SetViewBackgroundColorCallback(void* mapVariant)
+{
+  CVariant* mapV = static_cast<CVariant*>(mapVariant);
+  int viewId = (*mapV)["id"].asInteger();
+  int color = (*mapV)["color"].asInteger();
+
+  delete mapV;
+
+  CJNIView view = findViewById(viewId);
+  if (view)
+  {
+    view.setBackgroundColor(color);
+  }
+}
+
+void CXBMCApp::SetVideoLayoutBackgroundColor(const int color)
+{
+  CJNIResources resources = CJNIContext::getResources();
+  if (resources)
+  {
+    int id = resources.getIdentifier("VideoLayout", "id", CJNIContext::getPackageName());
+    if (id > 0)
+    {
+      // this object is deallocated in the callback
+      CVariant* msg = new CVariant(CVariant::VariantTypeObject);
+      (*msg)["id"] = id;
+      (*msg)["color"] = color;
+
+      runNativeOnUiThread(SetViewBackgroundColorCallback, msg);
+    }
+  }
 }
 
 void CXBMCApp::RegisterInputDeviceCallbacks(IInputDeviceCallbacks* handler)

--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -181,6 +181,7 @@ public:
 
   void SetDisplayMode(int mode, float rate);
   int GetDPI() const;
+  void SetVideoLayoutBackgroundColor(const int color);
 
   CRect MapRenderToDroid(const CRect& srcRect);
 
@@ -243,6 +244,7 @@ private:
   void SetupEnv();
   static void SetDisplayModeCallback(void* modeVariant);
   static void KeepScreenOnCallback(void* onVariant);
+  static void SetViewBackgroundColorCallback(void* mapVariant);
 
   static void RegisterDisplayListenerCallback(void*);
   void UnregisterDisplayListener();

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -1227,6 +1227,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetBoolean(pElement, "fronttobackrendering", m_guiFrontToBackRendering);
     XMLUtils::GetBoolean(pElement, "geometryclear", m_guiGeometryClear);
     XMLUtils::GetBoolean(pElement, "asynctextureupload", m_guiAsyncTextureUpload);
+    XMLUtils::GetBoolean(pElement, "transparentvideolayout", m_guiVideoLayoutTransparent);
   }
 
   std::string seekSteps;

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -337,6 +337,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_guiFrontToBackRendering{false};
     bool m_guiGeometryClear{true};
     bool m_guiAsyncTextureUpload{false};
+    bool m_guiVideoLayoutTransparent{false};
 
     unsigned int m_addonPackageFolderSize;
 


### PR DESCRIPTION
## Description
Add advanced setting to set the `VideoLayout` view background color on launch, for Android devices only.
Replaces PR https://github.com/xbmc/xbmc/pull/25171

Usage:
```
<advancedsettings version="1.0">
  <gui>
   <transparentvideolayout>true</transparentvideolayout>
 </gui>
</advancedsettings>
```

## Motivation and context
Sony TVs have a long standing firmware bug. Allow a user to configure the video layout background color to workaround this.
Fixes #25166 

## How has this been tested?
Runtime tested on FireTV Stick 4K Max which has the same issue but with transparent background color instead of black.
Needs testing by Sony TV users.

## What is the effect on users?
None by default. Requires advanced setting.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
