### PR TITLE
Apple toolchain fixups

### DIFF
--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -194,6 +194,8 @@ case $build in
     host_sysroot="$native_sdk_path"
     host_includes="${host_includes} -isysroot $native_sdk_path"
 
+    # We only set CC_FOR_BUILD as we require use_build_toolchain to be populated
+    # All other build apps are detected by AC_PATH_PROG further down
     CC_FOR_BUILD=[`$use_xcrun --find clang`]
     use_build_toolchain=[`$CC_FOR_BUILD --version | grep InstalledDir | awk '{ print $2}'`]
 
@@ -263,8 +265,11 @@ case $host in
     esac
   ;;
   *darwin*)
+    # Again we set CC to find toolchain path for use in AC_PATH_TOOL macros further down
     CC=[`$use_xcrun --find clang`]
-    platform_cxx=clang++
+    # May as well just set CXX direct as platform_cxx default is g++. Setting the variable
+    # before AC_PATH_TOOL causes that macro to do nothing and just use the set variable
+    CXX=[`$use_xcrun --find clang++`]
     use_toolchain=[`$CC --version | grep InstalledDir | awk '{ print $2}'`]
 esac
 

--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -190,7 +190,7 @@ case $build in
 
     # acquire build platform (native) sdk sysroot.
     build_platform=macosx
-    native_sdk_path=[`$use_xcrun --show-sdk-path`]
+    native_sdk_path=[`$use_xcrun --sdk macosx --show-sdk-path`]
     host_sysroot="$native_sdk_path"
     host_includes="${host_includes} -isysroot $native_sdk_path"
 

--- a/tools/depends/native/cmake/Makefile
+++ b/tools/depends/native/cmake/Makefile
@@ -7,10 +7,6 @@ DEPS = ../../Makefile.include Makefile CMAKE-VERSION ../../download-files.includ
 SETENV=CC="$(CC_FOR_BUILD)" CXX="$(CXX_FOR_BUILD)" LD=$(LD_FOR_BUILD) CFLAGS="$(NATIVE_CFLAGS)" \
 	CXXFLAGS="$(NATIVE_CXXFLAGS)" LDFLAGS="$(NATIVE_LDFLAGS)"
 
-ifeq ($(NATIVE_OS), osx)
-  SETENV+=SDKROOT=$(shell xcrun --show-sdk-path)
-endif
-
 CONFIGURE=./bootstrap --prefix=$(NATIVEPREFIX) --system-curl
 ifeq ($(USE_CCACHE), yes)
 	CONFIGURE+=--enable-ccache


### PR DESCRIPTION
## Description
Minor configure and native cmake env var cleanups

## Motivation and context
@ksooo is currently experiencing build failures of native tools (cmake in particular) with xcode 15.4. I havent been able to replicate his failures, but saw these whilst trying to replicate.

## How has this been tested?
macosx aarch64 xcode 15.4 and command line build tools (currently 15.3) building native tools completely.

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
