### PR TITLE
fixed: infinite loop parsing an invalid moving speed config

### DIFF
--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -764,6 +764,7 @@ bool CGUIControlFactory::GetMovingSpeedConfig(const TiXmlNode* pRootNode,
     if (!eventType)
     {
       CLog::LogF(LOGERROR, "Failed to parse XML \"eventconfig\" tag missing \"type\" attribute");
+      configElement = configElement->NextSiblingElement("eventconfig");
       continue;
     }
 

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -757,14 +757,13 @@ bool CGUIControlFactory::GetMovingSpeedConfig(const TiXmlNode* pRootNode,
       StringUtils::ToUint32(XMLUtils::GetAttribute(msNode, "resettimeout"))};
   float globalDelta{StringUtils::ToFloat(XMLUtils::GetAttribute(msNode, "delta"))};
 
-  const TiXmlElement* configElement{msNode->FirstChildElement("eventconfig")};
-  while (configElement)
+  for (const TiXmlElement* configElement{msNode->FirstChildElement("eventconfig")}; configElement;
+       configElement = configElement->NextSiblingElement("eventconfig"))
   {
     const char* eventType = configElement->Attribute("type");
     if (!eventType)
     {
       CLog::LogF(LOGERROR, "Failed to parse XML \"eventconfig\" tag missing \"type\" attribute");
-      configElement = configElement->NextSiblingElement("eventconfig");
       continue;
     }
 
@@ -783,8 +782,6 @@ bool CGUIControlFactory::GetMovingSpeedConfig(const TiXmlNode* pRootNode,
 
     UTILS::MOVING_SPEED::EventCfg eventCfg{acceleration, maxVelocity, resetTimeout, delta};
     movingSpeedCfg.emplace(UTILS::MOVING_SPEED::ParseEventType(eventType), eventCfg);
-
-    configElement = configElement->NextSiblingElement("eventconfig");
   }
   return true;
 }


### PR DESCRIPTION
## Description
if type was missing we logged the fact infinitely as we did not advance to the sibling element

## Motivation and context
I don't like finite loops.

## How has this been tested?
Noticed while writing a test.

## What is the effect on users?
Poor sobs would sit there waiting while their disc filled up with log messages, and then they would get sad.
Now happy.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
