### PR TITLE
[Backport] new TrueHD MAT packer code + move TrueHD packing to CDVDAudioCodecPassthrough

### DIFF
--- a/xbmc/cores/AudioEngine/CMakeLists.txt
+++ b/xbmc/cores/AudioEngine/CMakeLists.txt
@@ -14,7 +14,8 @@ set(SOURCES AEResampleFactory.cpp
             Utils/AELimiter.cpp
             Utils/AEPackIEC61937.cpp
             Utils/AEStreamInfo.cpp
-            Utils/AEUtil.cpp)
+            Utils/AEUtil.cpp
+            Utils/PackerMAT.cpp)
 
 set(HEADERS AEResampleFactory.h
             AESinkFactory.h
@@ -44,7 +45,8 @@ set(HEADERS AEResampleFactory.h
             Utils/AERingBuffer.h
             Utils/AEStreamData.h
             Utils/AEStreamInfo.h
-            Utils/AEUtil.h)
+            Utils/AEUtil.h
+            Utils/PackerMAT.h)
 
 if(TARGET ALSA::ALSA)
   list(APPEND SOURCES Sinks/AESinkALSA.cpp

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -153,13 +153,6 @@ void CEngineStats::GetDelay(AEDelayStatus& status, CActiveAEStream *stream)
     status.delay +=
         static_cast<double>(m_bufferedSamples) * m_sinkFormat.m_streamInfo.GetDuration() / 1000;
 
-  if (!m_pcmOutput && m_sinkNeedIecPack &&
-      m_sinkFormat.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD)
-  {
-    // take into account MAT packer latency (half duration of MAT frame)
-    status.delay += m_sinkFormat.m_streamInfo.GetDuration() / 1000 / 2;
-  }
-
   for (auto &str : m_streamStats)
   {
     if (str.m_streamId == stream->m_id)
@@ -185,13 +178,6 @@ void CEngineStats::GetSyncInfo(CAESyncInfo& info, CActiveAEStream *stream)
         static_cast<double>(m_bufferedSamples) * m_sinkFormat.m_streamInfo.GetDuration() / 1000;
 
   status.delay += static_cast<double>(m_sinkLatency);
-
-  if (!m_pcmOutput && m_sinkNeedIecPack &&
-      m_sinkFormat.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD)
-  {
-    // take into account MAT packer latency (half duration of MAT frame)
-    status.delay += m_sinkFormat.m_streamInfo.GetDuration() / 1000 / 2;
-  }
 
   for (auto &str : m_streamStats)
   {

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
@@ -144,8 +144,6 @@ protected:
     SKIP_SWAP,
   } m_swapState;
 
-  std::vector<uint8_t> m_mergeBuffer;
-
   std::string m_deviceFriendlyName;
   std::string m_device;
   std::vector<AE::AESinkInfo> m_sinkInfoList;

--- a/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.h
+++ b/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.h
@@ -32,24 +32,8 @@ public:
   static CAEChannelInfo GetOutputChannelMap(const CAEStreamInfo& info);
 
 private:
-  void PackTrueHD(CAEStreamInfo &info, uint8_t* data, int size);
   void PackDTSHD(CAEStreamInfo &info, uint8_t* data, int size);
   void PackEAC3(CAEStreamInfo &info, uint8_t* data, int size);
-
-  /* we keep the trueHD and dtsHD buffers separate so that we can handle a fast stream switch */
-  std::vector<uint8_t> m_trueHD[2];
-
-  struct TrueHD
-  {
-    int prevFrameSize;
-    int samplesPerFrame;
-    int bufferFilled;
-    int bufferIndex;
-    uint16_t prevFrameTime;
-    uint8_t* outputBuffer;
-  };
-
-  TrueHD m_thd{};
 
   std::vector<uint8_t> m_dtsHD;
   unsigned int m_dtsHDSize = 0;

--- a/xbmc/cores/AudioEngine/Utils/AEPackIEC61937.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEPackIEC61937.cpp
@@ -86,7 +86,7 @@ int CAEPackIEC61937::PackDTS_2048(uint8_t *data, unsigned int size, uint8_t *des
   return PackDTS(data, size, dest, littleEndian, OUT_FRAMESTOBYTES(DTS3_FRAME_SIZE), IEC61937_TYPE_DTS3);
 }
 
-int CAEPackIEC61937::PackTrueHD(uint8_t *data, unsigned int size, uint8_t *dest)
+int CAEPackIEC61937::PackTrueHD(const uint8_t* data, unsigned int size, uint8_t* dest)
 {
   if (size == 0)
     return OUT_FRAMESTOBYTES(TRUEHD_FRAME_SIZE);
@@ -95,8 +95,8 @@ int CAEPackIEC61937::PackTrueHD(uint8_t *data, unsigned int size, uint8_t *dest)
   struct IEC61937Packet *packet = (struct IEC61937Packet*)dest;
   packet->m_preamble1 = IEC61937_PREAMBLE1;
   packet->m_preamble2 = IEC61937_PREAMBLE2;
-  packet->m_type      = IEC61937_TYPE_TRUEHD;
-  packet->m_length    = size;
+  packet->m_type = IEC61937_TYPE_TRUEHD;
+  packet->m_length = 61424;
 
   if (data == NULL)
     data = packet->m_data;

--- a/xbmc/cores/AudioEngine/Utils/AEPackIEC61937.h
+++ b/xbmc/cores/AudioEngine/Utils/AEPackIEC61937.h
@@ -36,8 +36,8 @@ public:
   static int PackDTS_512 (uint8_t *data, unsigned int size, uint8_t *dest, bool littleEndian);
   static int PackDTS_1024(uint8_t *data, unsigned int size, uint8_t *dest, bool littleEndian);
   static int PackDTS_2048(uint8_t *data, unsigned int size, uint8_t *dest, bool littleEndian);
-  static int PackTrueHD  (uint8_t *data, unsigned int size, uint8_t *dest);
-  static int PackDTSHD   (uint8_t *data, unsigned int size, uint8_t *dest, unsigned int period);
+  static int PackTrueHD(const uint8_t* data, unsigned int size, uint8_t* dest);
+  static int PackDTSHD(uint8_t* data, unsigned int size, uint8_t* dest, unsigned int period);
   static int PackPause(uint8_t *dest, unsigned int millis, unsigned int framesize, unsigned int samplerate, unsigned int rep_period, unsigned int encodedRate);
 private:
 

--- a/xbmc/cores/AudioEngine/Utils/PackerMAT.cpp
+++ b/xbmc/cores/AudioEngine/Utils/PackerMAT.cpp
@@ -1,0 +1,429 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PackerMAT.h"
+
+#include "utils/log.h"
+
+#include <array>
+#include <assert.h>
+#include <utility>
+
+extern "C"
+{
+#include <libavutil/common.h>
+#include <libavutil/intreadwrite.h>
+}
+
+namespace
+{
+constexpr uint32_t FORMAT_MAJOR_SYNC = 0xf8726fba;
+
+constexpr auto BURST_HEADER_SIZE = 8;
+constexpr auto MAT_BUFFER_SIZE = 61440;
+constexpr auto MAT_BUFFER_LIMIT = MAT_BUFFER_SIZE - 24; // MAT end code size
+constexpr auto MAT_POS_MIDDLE = 30708 + BURST_HEADER_SIZE; // middle point + IEC header in front
+
+// magic MAT format values, meaning is unknown at this point
+constexpr std::array<uint8_t, 20> mat_start_code = {0x07, 0x9E, 0x00, 0x03, 0x84, 0x01, 0x01,
+                                                    0x01, 0x80, 0x00, 0x56, 0xA5, 0x3B, 0xF4,
+                                                    0x81, 0x83, 0x49, 0x80, 0x77, 0xE0};
+
+constexpr std::array<uint8_t, 12> mat_middle_code = {0xC3, 0xC1, 0x42, 0x49, 0x3B, 0xFA,
+                                                     0x82, 0x83, 0x49, 0x80, 0x77, 0xE0};
+
+constexpr std::array<uint8_t, 24> mat_end_code = {0xC3, 0xC2, 0xC0, 0xC4, 0x00, 0x00, 0x00, 0x00,
+                                                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x97, 0x11,
+                                                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+} // namespace
+
+CPackerMAT::CPackerMAT()
+{
+  m_buffer.reserve(MAT_BUFFER_SIZE);
+}
+
+// On a high level, a MAT frame consists of a sequence of padded TrueHD frames
+// The size of the padded frame can be determined from the frame time/sequence code in the frame header,
+// since it varies to accommodate spikes in bitrate.
+// In average all frames are always padded to 2560 bytes, so that 24 frames fit in one MAT frame, however
+// due to bitrate spikes single sync frames have been observed to use up to twice that size, in which
+// case they'll be preceded by smaller frames to keep the average bitrate constant.
+// A constant padding to 2560 bytes can work (this is how the ffmpeg spdifenc module works), however
+// high-bitrate streams can overshoot this size and therefor require proper handling of dynamic padding.
+bool CPackerMAT::PackTrueHD(const uint8_t* data, int size)
+{
+  TrueHDMajorSyncInfo info;
+
+  // get the ratebits and output timing from the sync frame
+  if (AV_RB32(data + 4) == FORMAT_MAJOR_SYNC)
+  {
+    info = ParseTrueHDMajorSyncHeaders(data, size);
+
+    if (!info.valid)
+      return false;
+
+    m_state.ratebits = info.ratebits;
+  }
+  else if (m_state.prevFrametimeValid == false)
+  {
+    // only start streaming on a major sync frame
+    m_state.numberOfSamplesOffset = 0;
+    return false;
+  }
+
+  const uint16_t frameTime = AV_RB16(data + 2);
+  uint32_t spaceSize = 0;
+  const uint16_t frameSamples = 40 << (m_state.ratebits & 7);
+  m_state.outputTiming += frameSamples;
+
+  if (info.outputTimingPresent)
+  {
+    if (m_state.outputTimingValid && (info.outputTiming != m_state.outputTiming))
+    {
+      CLog::Log(LOGWARNING,
+                "CPackerMAT::PackTrueHD: detected a stream discontinuity -> output timing "
+                "expected: {}, found: {}",
+                m_state.outputTiming, info.outputTiming);
+    }
+    m_state.outputTiming = info.outputTiming;
+    m_state.outputTimingValid = true;
+  }
+
+  // compute final padded size for the previous frame, if any
+  if (m_state.prevFrametimeValid)
+    spaceSize = uint16_t(frameTime - m_state.prevFrametime) * (64 >> (m_state.ratebits & 7));
+
+  // compute padding (ie. difference to the size of the previous frame)
+  assert(!m_state.prevFrametimeValid || spaceSize >= m_state.prevMatFramesize);
+
+  // if for some reason the spaceSize fails, align the actual frame size
+  if (spaceSize < m_state.prevMatFramesize)
+    spaceSize = FFALIGN(m_state.prevMatFramesize, (64 >> (m_state.ratebits & 7)));
+
+  m_state.padding += (spaceSize - m_state.prevMatFramesize);
+
+  // detect seeks and re-initialize internal state i.e. skip stream
+  // until the next major sync frame
+  if (m_state.padding > MAT_BUFFER_SIZE * 5)
+  {
+    CLog::Log(LOGINFO, "CPackerMAT::PackTrueHD: seek detected, re-initializing MAT packer state");
+    m_state = {};
+    m_state.init = true;
+    m_buffer.clear();
+    m_bufferCount = 0;
+    return false;
+  }
+
+  // store frame time of the previous frame
+  m_state.prevFrametime = frameTime;
+  m_state.prevFrametimeValid = true;
+
+  // Write the MAT header into the fresh buffer
+  if (GetCount() == 0)
+  {
+    WriteHeader();
+
+    // initial header, don't count it for the frame size
+    if (m_state.init == false)
+    {
+      m_state.init = true;
+      m_state.matFramesize = 0;
+    }
+  }
+
+  // write padding of the previous frame (if any)
+  while (m_state.padding > 0)
+  {
+    WritePadding();
+
+    assert(m_state.padding == 0 || GetCount() == MAT_BUFFER_SIZE);
+
+    // Buffer is full, submit it
+    if (GetCount() == MAT_BUFFER_SIZE)
+    {
+      FlushPacket();
+
+      // and setup a new buffer
+      WriteHeader();
+    }
+  }
+
+  // count the number of samples in this frame
+  m_state.samples += frameSamples;
+
+  // write actual audio data to the buffer
+  int remaining = FillDataBuffer(data, size, Type::DATA);
+
+  // not all data could be written, or the buffer is full
+  if (remaining || GetCount() == MAT_BUFFER_SIZE)
+  {
+    // flush out old data
+    FlushPacket();
+
+    if (remaining)
+    {
+      // setup a new buffer
+      WriteHeader();
+
+      // and write the remaining data
+      remaining = FillDataBuffer(data + (size - remaining), remaining, Type::DATA);
+
+      assert(remaining == 0);
+    }
+  }
+
+  // store the size of the current MAT frame, so we can add padding later
+  m_state.prevMatFramesize = m_state.matFramesize;
+  m_state.matFramesize = 0;
+
+  // return true if have MAT packet
+  return !m_outputQueue.empty();
+}
+
+std::vector<uint8_t> CPackerMAT::GetOutputFrame()
+{
+  std::vector<uint8_t> buffer;
+
+  if (m_outputQueue.empty())
+    return {};
+
+  buffer = std::move(m_outputQueue.front());
+
+  m_outputQueue.pop_front();
+
+  return buffer;
+}
+
+void CPackerMAT::WriteHeader()
+{
+  m_buffer.resize(MAT_BUFFER_SIZE);
+
+  // reserve size for the IEC header and the MAT start code
+  const size_t size = BURST_HEADER_SIZE + mat_start_code.size();
+
+  // write MAT start code. IEC header written later, skip space only
+  memcpy(m_buffer.data() + BURST_HEADER_SIZE, mat_start_code.data(), mat_start_code.size());
+  m_bufferCount = size;
+
+  // unless the start code falls into the padding, it's considered part of the current MAT frame
+  // Note that audio frames are not always aligned with MAT frames, so we might already have a partial
+  // frame at this point
+  m_state.matFramesize += size;
+
+  // The MAT metadata counts as padding, if we're scheduled to write any, which mean the start bytes
+  // should reduce any further padding.
+  if (m_state.padding > 0)
+  {
+    // if the header fits into the padding of the last frame, just reduce the amount of needed padding
+    if (m_state.padding > size)
+    {
+      m_state.padding -= size;
+      m_state.matFramesize = 0;
+    }
+    else
+    {
+      // otherwise, consume all padding and set the size of the next MAT frame to the remaining data
+      m_state.matFramesize = (size - m_state.padding);
+      m_state.padding = 0;
+    }
+  }
+}
+
+void CPackerMAT::WritePadding()
+{
+  if (m_state.padding == 0)
+    return;
+
+  // for padding not writes any data (nullptr) as buffer is already zeroed
+  // only counts/skip bytes
+  const int remaining = FillDataBuffer(nullptr, m_state.padding, Type::PADDING);
+
+  // not all padding could be written to the buffer, write it later
+  if (remaining >= 0)
+  {
+    m_state.padding = remaining;
+    m_state.matFramesize = 0;
+  }
+  else
+  {
+    // more padding then requested was written, eg. there was a MAT middle/end marker
+    // that needed to be written
+    m_state.padding = 0;
+    m_state.matFramesize = -remaining;
+  }
+}
+
+void CPackerMAT::AppendData(const uint8_t* data, int size, Type type)
+{
+  // for padding not write anything, only skip bytes
+  if (type == Type::DATA)
+    memcpy(m_buffer.data() + m_bufferCount, data, size);
+
+  m_state.matFramesize += size;
+  m_bufferCount += size;
+}
+
+int CPackerMAT::FillDataBuffer(const uint8_t* data, int size, Type type)
+{
+  if (GetCount() >= MAT_BUFFER_LIMIT)
+    return size;
+
+  int remaining = size;
+
+  // Write MAT middle marker, if needed
+  // The MAT middle marker always needs to be in the exact same spot, any audio data will be split.
+  // If we're currently writing padding, then the marker will be considered as padding data and
+  // reduce the amount of padding still required.
+  if (GetCount() <= MAT_POS_MIDDLE && GetCount() + size > MAT_POS_MIDDLE)
+  {
+    // write as much data before the middle code as we can
+    int nBytesBefore = MAT_POS_MIDDLE - GetCount();
+    AppendData(data, nBytesBefore, type);
+    remaining -= nBytesBefore;
+
+    // write the MAT middle code
+    AppendData(mat_middle_code.data(), mat_middle_code.size(), Type::DATA);
+
+    // if we're writing padding, deduct the size of the code from it
+    if (type == Type::PADDING)
+      remaining -= mat_middle_code.size();
+
+    // write remaining data after the MAT marker
+    if (remaining > 0)
+      remaining = FillDataBuffer(data + nBytesBefore, remaining, type);
+
+    return remaining;
+  }
+
+  // not enough room in the buffer to write all the data,
+  // write as much as we can and add the MAT footer
+  if (GetCount() + size >= MAT_BUFFER_LIMIT)
+  {
+    // write as much data before the middle code as we can
+    int nBytesBefore = MAT_BUFFER_LIMIT - GetCount();
+    AppendData(data, nBytesBefore, type);
+    remaining -= nBytesBefore;
+
+    // write the MAT end code
+    AppendData(mat_end_code.data(), mat_end_code.size(), Type::DATA);
+
+    assert(GetCount() == MAT_BUFFER_SIZE);
+
+    // MAT markers don't displace padding, so reduce the amount of padding
+    if (type == Type::PADDING)
+      remaining -= mat_end_code.size();
+
+    // any remaining data will be written in future calls
+    return remaining;
+  }
+
+  AppendData(data, size, type);
+
+  return 0;
+}
+
+void CPackerMAT::FlushPacket()
+{
+  if (GetCount() == 0)
+    return;
+
+  assert(GetCount() == MAT_BUFFER_SIZE);
+
+  // normal number of samples per frame
+  const uint16_t frameSamples = 40 << (m_state.ratebits & 7);
+  const uint32_t MATSamples = (frameSamples * 24);
+
+  // push MAT packet to output queue
+  m_outputQueue.emplace_back(std::move(m_buffer));
+
+  // we expect 24 frames per MAT frame, so calculate an offset from that
+  // this is done after delivery, because it modifies the duration of the frame,
+  //  eg. the start of the next frame
+  if (MATSamples != m_state.samples)
+    m_state.numberOfSamplesOffset += m_state.samples - MATSamples;
+
+  m_state.samples = 0;
+
+  m_buffer.clear();
+  m_bufferCount = 0;
+}
+
+TrueHDMajorSyncInfo CPackerMAT::ParseTrueHDMajorSyncHeaders(const uint8_t* p, int buffsize) const
+{
+  TrueHDMajorSyncInfo info;
+
+  if (buffsize < 32)
+    return {};
+
+  // parse major sync and look for a restart header
+  int majorSyncSize = 28;
+  if (p[29] & 1) // restart header exists
+  {
+    int extensionSize = p[30] >> 4; // calculate headers size
+    majorSyncSize += 2 + extensionSize * 2;
+  }
+
+  CBitStream bs(p + 4, buffsize - 4);
+
+  bs.SkipBits(32); // format_sync
+
+  info.ratebits = bs.ReadBits(4); // ratebits
+  info.valid = true;
+
+  //  (1) 6ch_multichannel_type
+  //  (1) 8ch_multichannel_type
+  //  (2) reserved
+  //  (2) 2ch_presentation_channel_modifier
+  //  (2) 6ch_presentation_channel_modifier
+  //  (5) 6ch_presentation_channel_assignment
+  //  (2) 8ch_presentation_channel_modifier
+  // (13) 8ch_presentation_channel_assignment
+  // (16) signature
+  // (16) flags
+  // (16) reserved
+  //  (1) variable_rate
+  // (15) peak_data_rate
+  bs.SkipBits(1 + 1 + 2 + 2 + 2 + 5 + 2 + 13 + 16 + 16 + 16 + 1 + 15);
+
+  const int numSubstreams = bs.ReadBits(4);
+
+  bs.SkipBits(4 + (majorSyncSize - 17) * 8);
+
+  // substream directory
+  for (int i = 0; i < numSubstreams; i++)
+  {
+    int extraSubstreamWord = bs.ReadBits(1);
+    //  (1) restart_nonexistent
+    //  (1) crc_present
+    //  (1) reserved
+    // (12) substream_end_ptr
+    bs.SkipBits(15);
+    if (extraSubstreamWord)
+      bs.SkipBits(16); // drc_gain_update, drc_time_update, reserved
+  }
+
+  // substream segments
+  for (int i = 0; i < numSubstreams; i++)
+  {
+    if (bs.ReadBits(1))
+    { // block_header_exists
+      if (bs.ReadBits(1))
+      { // restart_header_exists
+        bs.SkipBits(14); // restart_sync_word
+        info.outputTiming = bs.ReadBits(16);
+        info.outputTimingPresent = true;
+        // XXX: restart header
+      }
+      // XXX: Block header
+    }
+    // XXX: All blocks, all substreams?
+    break;
+  }
+
+  return info;
+}

--- a/xbmc/cores/AudioEngine/Utils/PackerMAT.h
+++ b/xbmc/cores/AudioEngine/Utils/PackerMAT.h
@@ -1,0 +1,116 @@
+/*
+ *  Copyright (C) 2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <deque>
+#include <stdint.h>
+#include <vector>
+
+struct TrueHDMajorSyncInfo
+{
+  int ratebits{0};
+  uint16_t outputTiming{0};
+  bool outputTimingPresent{false};
+  bool valid{false};
+};
+
+enum class Type
+{
+  PADDING,
+  DATA,
+};
+
+class CPackerMAT
+{
+public:
+  CPackerMAT();
+  ~CPackerMAT() = default;
+
+  bool PackTrueHD(const uint8_t* data, int size);
+  std::vector<uint8_t> GetOutputFrame();
+
+private:
+  struct MATState
+  {
+    bool init; // differentiates the first header
+
+    // audio_sampling_frequency:
+    //  0 -> 48 kHz
+    //  1 -> 96 kHz
+    //  2 -> 192 kHz
+    //  8 -> 44.1 kHz
+    //  9 -> 88.2 kHz
+    // 10 -> 176.4 kHz
+    int ratebits;
+
+    // Output timing obtained parsing TrueHD major sync headers (when available) or
+    // inferred increasing a counter the rest of the time.
+    uint16_t outputTiming;
+    bool outputTimingValid;
+
+    // Input timing of audio unit (obtained of each audio unit) and used to calculate padding
+    // bytes. On the contrary of outputTiming, frametime is present in all audio units.
+    uint16_t prevFrametime;
+    bool prevFrametimeValid;
+
+    uint32_t matFramesize; // size in bytes of current MAT frame
+    uint32_t prevMatFramesize; // size in bytes of previous MAT frame
+
+    uint32_t padding; // padding bytes pending to write
+    uint32_t samples; // number of samples accumulated in current MAT frame
+    int numberOfSamplesOffset; // offset respect number of samples in a standard MAT frame (40 * 24)
+  };
+
+  void WriteHeader();
+  void WritePadding();
+  void AppendData(const uint8_t* data, int size, Type type);
+  uint32_t GetCount() const { return m_bufferCount; }
+  int FillDataBuffer(const uint8_t* data, int size, Type type);
+  void FlushPacket();
+  TrueHDMajorSyncInfo ParseTrueHDMajorSyncHeaders(const uint8_t* p, int buffsize) const;
+
+  MATState m_state{};
+
+  uint32_t m_bufferCount{0};
+  std::vector<uint8_t> m_buffer;
+  std::deque<std::vector<uint8_t>> m_outputQueue;
+};
+
+class CBitStream
+{
+public:
+  // opens an existing byte array as bitstream
+  CBitStream(const uint8_t* bytes, int _size)
+  {
+    data = bytes;
+    size = _size;
+  }
+
+  // reads bits from bitstream
+  int ReadBits(int bits)
+  {
+    int dat = 0;
+    for (int i = index; i < index + bits; i++)
+    {
+      dat = dat * 2 + getbit(data[i / 8], i % 8);
+    }
+    index += bits;
+    return dat;
+  }
+
+  // skip bits from bitstream
+  void SkipBits(int bits) { index += bits; }
+
+private:
+  uint8_t getbit(uint8_t x, int y) { return (x >> (7 - y)) & 1; }
+
+  const uint8_t* data{nullptr};
+  int size{0};
+  int index{0};
+};

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.h
@@ -14,9 +14,11 @@
 #include "cores/AudioEngine/Utils/AEStreamInfo.h"
 
 #include <list>
+#include <memory>
 #include <vector>
 
 class CProcessInfo;
+class CPackerMAT;
 
 class CDVDAudioCodecPassthrough : public CDVDAudioCodec
 {
@@ -36,6 +38,7 @@ public:
 
 private:
   int GetData(uint8_t** dst);
+  unsigned int PackTrueHD();
   CAEStreamParser m_parser;
   uint8_t* m_buffer = nullptr;
   unsigned int m_bufferSize = 0;
@@ -49,6 +52,7 @@ private:
   std::string m_codecName;
 
   // TrueHD specifics
+  std::unique_ptr<CPackerMAT> m_packerMAT;
   std::vector<uint8_t> m_trueHDBuffer;
   unsigned int m_trueHDoffset = 0;
   unsigned int m_trueHDframes = 0;

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
@@ -115,9 +115,7 @@ protected:
   SInfo            m_info;
 
   bool m_displayReset = false;
-  unsigned int m_disconAdjustTimeMs = 10; // maximum sync-off before adjusting
+  unsigned int m_disconAdjustTimeMs = 50; // maximum sync-off before adjusting
   int m_disconAdjustCounter = 0;
-  XbmcThreads::EndTime<> m_disconTimer;
-  bool m_disconLearning = false;
 };
 

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -847,17 +847,8 @@ inline bool PAPlayer::ProcessStream(StreamInfo *si, double &freeBufferTime)
         free_space = (double)(si->m_stream->GetSpace() / si->m_bytesPerSample) / si->m_audioFormat.m_sampleRate;
       else
       {
-        if (si->m_audioFormat.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD &&
-            !m_processInfo->WantsRawPassthrough())
-        {
-          free_space = static_cast<double>(si->m_stream->GetSpace()) *
-                       si->m_audioFormat.m_streamInfo.GetDuration() / 1000 / 2;
-        }
-        else
-        {
-          free_space = static_cast<double>(si->m_stream->GetSpace()) *
-                       si->m_audioFormat.m_streamInfo.GetDuration() / 1000;
-        }
+        free_space = static_cast<double>(si->m_stream->GetSpace()) *
+                     si->m_audioFormat.m_streamInfo.GetDuration() / 1000;
       }
 
       freeBufferTime = std::max(freeBufferTime , free_space);
@@ -906,17 +897,9 @@ bool PAPlayer::QueueData(StreamInfo *si)
         CLog::Log(LOGERROR, "PAPlayer::QueueData - unknown error");
         return false;
       }
-      if (si->m_audioFormat.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD &&
-          !m_processInfo->WantsRawPassthrough())
-      {
-        si->m_framesSent += si->m_audioFormat.m_streamInfo.GetDuration() / 1000 / 2 *
-                            si->m_audioFormat.m_streamInfo.m_sampleRate;
-      }
-      else
-      {
-        si->m_framesSent += si->m_audioFormat.m_streamInfo.GetDuration() / 1000 *
-                            si->m_audioFormat.m_streamInfo.m_sampleRate;
-      }
+
+      si->m_framesSent += si->m_audioFormat.m_streamInfo.GetDuration() / 1000 *
+                          si->m_audioFormat.m_streamInfo.m_sampleRate;
     }
   }
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -584,7 +584,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetFloat(pElement, "limiterhold", m_limiterHold, 0.0f, 100.0f);
     XMLUtils::GetFloat(pElement, "limiterrelease", m_limiterRelease, 0.001f, 100.0f);
     XMLUtils::GetUInt(pElement, "maxpassthroughoffsyncduration", m_maxPassthroughOffSyncDuration,
-                      10, 100);
+                      20, 80);
     XMLUtils::GetBoolean(pElement, "allowmultichannelfloat", m_AllowMultiChannelFloat);
     XMLUtils::GetBoolean(pElement, "superviseaudiodelay", m_superviseAudioDelay);
   }

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -153,7 +153,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int m_videoIgnoreSecondsAtStart;
     float m_videoIgnorePercentAtEnd;
     float m_audioApplyDrc;
-    unsigned int m_maxPassthroughOffSyncDuration = 10; // when 10 ms off adjust
+    unsigned int m_maxPassthroughOffSyncDuration = 50; // when 50 ms off adjust
     bool m_AllowMultiChannelFloat = false; // Android only switch to be removed in v22
     bool m_superviseAudioDelay = false; // Android only to correct broken audio firmwares
 


### PR DESCRIPTION
## Description
This PR is the backport of: 
https://github.com/xbmc/xbmc/pull/24984 and https://github.com/xbmc/xbmc/pull/25256

Also other minor PR's that depend on the main ones:
https://github.com/xbmc/xbmc/pull/25149, https://github.com/xbmc/xbmc/pull/25208, https://github.com/xbmc/xbmc/pull/25282, https://github.com/xbmc/xbmc/pull/25306, https://github.com/xbmc/xbmc/pull/25264

They have been squashed because the changes are cleaner and there are less lines changed than with separate commits (some intermediate commits partial reverts some changes).


## Motivation and context
The reason the new MAT code was implemented was audio dropouts on some TrueHD sources e.g. Cars (2006) although it was later seen that there were also random dropouts but that they did not affect all setups the same. This has already been fixed in master and Omega but there are still dropouts with these sources.

More research has been done to determine exactly what role the new MAT code plays in this: That is, the old MAT code moved to CDVDAudioCodecPassthrough has also been tested along with the rest of the improvements. 

See: https://github.com/thexai/xbmc/commit/7426e69b0d8d34839cb0d1474c9d2e993d10707c

The result is that it improves a lot but does not completely eliminate all dropouts in Cars. So, the conclusion is that the old MAT code has limitations and is not capable of handling all TrueHD sources (although it works fine in 99.9% of the cases). This would affect all setups and all platforms since it does not depend on timings or performance things but on the MAT code itself.

Then the new MAT code is necessary to fix this completely.


## How has this been tested?
Tested several weeks in forum thread: https://forum.kodi.tv/showthread.php?tid=377117


## What is the effect on users?
Eliminates completely all (known) TrueHD related audio dropouts: even in the most problematic sources and in the most problematic setups (users who have reported dropouts only present in their setup and not reproducible in others).



## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
