### PR TITLE
[CharArrayParser] Skip malformed EOL

### DIFF
--- a/xbmc/utils/CharArrayParser.cpp
+++ b/xbmc/utils/CharArrayParser.cpp
@@ -156,11 +156,19 @@ bool CCharArrayParser::ReadNextLine(std::string& line)
   line.assign(m_data + m_position, lineLimit - m_position);
   m_position = lineLimit;
 
+  // Skip EOL chars
   if (m_data[m_position] == '\r')
   {
     m_position++;
+
+    if (m_data[m_position] == '\n')
+      m_position++;
+    // Malformed EOL as \r\r\n
+    else if (m_position + 1 <= m_limit && m_data[m_position] == '\r' &&
+             m_data[m_position + 1] == '\n')
+      m_position += 2;
   }
-  if (m_data[m_position] == '\n')
+  else if (m_data[m_position] == '\n')
   {
     m_position++;
   }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Some subtitles may have a malformed line breaks as follow: CR+CR+LF
that is a mixed line breaks between macintosh + windows format
on other media players like VLC or MPV somewhat are able skip malformed chars to allow to try read the file in a better way

subtitles like this use case was working on Kodi <= 19 because to read text lines was using `std::stringstream` `getline`
that by default identify the new line by checking for `\n` and somewhat other EOL chars was ignored
but from Kodi 20 has been introduced CharArrayParser to get the text lines
this to allow read Macintosh format subtitles (usually webvtt) but dont handle this situation

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #25299

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
sample video + srt
[Video test+srt.zip](https://github.com/user-attachments/files/15800707/Video.test%2Bsrt.zip)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Subs working despite malformed EOL chars

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
