### PR TITLE
PeripheralBusUSBLibUdev: fix assert issue with systemd udev

### DIFF
--- a/xbmc/platform/linux/peripherals/PeripheralBusUSBLibUdev.cpp
+++ b/xbmc/platform/linux/peripherals/PeripheralBusUSBLibUdev.cpp
@@ -108,7 +108,9 @@ bool CPeripheralBusUSB::PerformDeviceScan(PeripheralScanResults &results)
 
     if (bContinue)
     {
-      dev = udev_device_get_parent(udev_device_get_parent(parent));
+      dev = udev_device_get_parent(parent);
+      if (dev)
+        dev = udev_device_get_parent(dev);
       if (!dev || !udev_device_get_sysattr_value(dev,"idVendor") || !udev_device_get_sysattr_value(dev, "idProduct"))
         bContinue = false;
     }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

do not call udev_device_get_parent(udev_device_get_parent(dev)) directly as a null return on the parent will cause an assert in udev_device_get_parent

ref:
- https://github.com/Pulse-Eight/libcec/issues/658
- https://github.com/Pulse-Eight/libcec/pull/659
- https://github.com/systemd/systemd/issues/33292

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

correct call to the libudev library

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

run tested on LibreELEC 13 (master)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
