### PR TITLE
Enhance bitrate detection for MKVs

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1623,7 +1623,17 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
         st->iChannelLayout = codecparChannelLayout;
         st->iSampleRate = pStream->codecpar->sample_rate;
         st->iBlockAlign = pStream->codecpar->block_align;
-        st->iBitRate = static_cast<int>(pStream->codecpar->bit_rate);
+
+        // Read bitrate from BPS tag for MKVs missing bitrate info in stream header
+        if (pStream->codecpar->bit_rate == 0 && av_dict_get(pStream->metadata, "BPS", NULL, 0))
+        {
+          st->iBitRate = static_cast<int>(
+              strtol(av_dict_get(pStream->metadata, "BPS", NULL, 0)->value, NULL, 10));
+        }
+        else
+        {
+          st->iBitRate = static_cast<int>(pStream->codecpar->bit_rate);
+        }
         st->iBitsPerSample = pStream->codecpar->bits_per_raw_sample;
         char buf[32] = {};
         // https://github.com/FFmpeg/FFmpeg/blob/6ccc3989d15/doc/APIchanges#L50-L53
@@ -1684,7 +1694,17 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
           st->fAspect *= (double)pStream->codecpar->width / pStream->codecpar->height;
         st->iOrientation = 0;
         st->iBitsPerPixel = pStream->codecpar->bits_per_coded_sample;
-        st->iBitRate = static_cast<int>(pStream->codecpar->bit_rate);
+
+        // Read bitrate from BPS tag for MKVs missing bitrate info in stream header
+        if (pStream->codecpar->bit_rate == 0 && av_dict_get(pStream->metadata, "BPS", NULL, 0))
+        {
+          st->iBitRate = static_cast<int>(
+              strtol(av_dict_get(pStream->metadata, "BPS", NULL, 0)->value, NULL, 10));
+        }
+        else
+        {
+          st->iBitRate = static_cast<int>(pStream->codecpar->bit_rate);
+        }
         st->bitDepth = 8;
         const AVPixFmtDescriptor* desc =
             av_pix_fmt_desc_get(static_cast<AVPixelFormat>(pStream->codecpar->format));


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Adds additional logic to the ffmpeg based file opening logic to read video and audio stream bitrate information from the "BPS" metadata tag present in MKV files.

## Motivation and context
Some MKV files  do not have the video stream bitrate information in their headers  but have it stored as a metadata tag named "BPS". Some references [1](https://video.stackexchange.com/questions/29115/why-i-cant-check-the-bit-rate-on-some-videos), [2](https://superuser.com/questions/1752328/why-is-ffprobe-showing-n-a-for-bitrate)

Look at the ffprobe output on a "bad" file below
```
 Stream #0:0(eng): Video: hevc, none, 3840x2160, SAR 1:1 DAR 16:9, 24 fps, 24 tbr, 1k tbn (default) (original)
    Metadata:
      BPS             : 14957593
      DURATION        : 00:42:12.209000000
      NUMBER_OF_FRAMES: 60773
      NUMBER_OF_BYTES : 4734468984
      _STATISTICS_WRITING_APP: mkvmerge v80.0 ('Roundabout') 64-bit
      _STATISTICS_TAGS: BPS DURATION NUMBER_OF_FRAMES NUMBER_OF_BYTES
    Side data:
      DOVI configuration record: version: 1.0, profile: 8, level: 6, rpu flag: 1, el flag: 0, bl flag: 1, compatibility id: 1
  Stream #0:1(eng): Audio: eac3, 48000 Hz, 5.1(side), 768 kb/s (default) (original)
    Metadata:
      BPS             : 768000
      DURATION        : 00:42:12.192000000
      NUMBER_OF_FRAMES: 79131
      NUMBER_OF_BYTES : 243090432
      _STATISTICS_WRITING_APP: mkvmerge v80.0 ('Roundabout') 64-bit
      _STATISTICS_TAGS: BPS DURATION NUMBER_OF_FRAMES NUMBER_OF_BYTES
```
The audio track gets it's bitrate picked up in the first line describing each stream,  while the video track doesn't.  A "good" file that doesn't have this issue looks like this (not an mkv)
```
  Stream #0:0[0x1](eng): Video: h264 (Main) (avc1 / 0x31637661), yuv420p(tv, progressive), 1920x1080 [SAR 1:1 DAR 16:9], 2992 kb/s, 25 fps, 25 tbr, 25k tbn (default)
    Metadata:
      creation_time   : 2013-10-11T05:45:06.000000Z
      handler_name    : ?Mainconcept Video Media Handler
      vendor_id       : [0][0][0][0]
      encoder         : AVC Coding
  Stream #0:1[0x2](eng): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 189 kb/s (default)
    Metadata:
      creation_time   : 2013-10-11T05:45:06.000000Z
      handler_name    : #Mainconcept MP4 Sound Media Handler
      vendor_id       : [0][0][0][0]

```

This results in some very minor but annoying things.
1. The video bitrate doesn't appear in the "Select video stream panel"
"good" file: ![image](https://github.com/xbmc/xbmc/assets/15867363/beedee7b-2f84-4919-928f-6a3ba44f4f06)
"bad" file:![image](https://github.com/xbmc/xbmc/assets/15867363/6ba9d3da-9117-4568-9df2-e2526e511d3c)
2. [More Important] The video bitrate doesn't appear in the PlayerProcessInfo screen
"good" file: ![image](https://github.com/xbmc/xbmc/assets/15867363/bee51ccf-2c75-4f95-a6fd-d1435d755539)
"bad" file: ![image](https://github.com/xbmc/xbmc/assets/15867363/5ee1155d-81e5-4a01-beaf-ed3d06f8f31a)

This PR aims to make the video bitrate info appear properly in these above 2 scenarios

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
3 video files were used for testing.
1. One had the bitrate info in the headers already (existing code should detect it fine). This file loaded fine an the bitrate appeared
4. One was an MKV that was missing bitrate info in the headers, but had a "BPS" metadata tag for the video stream. This stream's bitrate is now picked up
5. The MKV from step 2, but will all metadata tags stripped out. This file loaded fine without crashing, but the bitrate info was missing in kodi (as expected)

Since I found it a bit difficult to get a build environment working as per the README here, I used the ubuntu package's build steps (download source using apt and build with debuild) and tested everything on top of the latest version of kodi that's present in ubuntu 22.04 (kodi 19)
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
Should have no impact.
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):
Already mentioned above

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
