### PR TITLE
Draft: RFC: Low latency streaming

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
@@ -16,6 +16,7 @@ CDVDInputStream::CDVDInputStream(DVDStreamType streamType, const CFileItem& file
   m_streamType = streamType;
   m_contentLookup = true;
   m_realtime = fileitem.GetProperty(STREAM_PROPERTY_ISREALTIMESTREAM).asBoolean(false);
+  m_lowLatency = false;
   m_item = fileitem;
 }
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -196,6 +196,9 @@ public:
 
   void SetRealtime(bool realtime) { m_realtime = realtime; }
 
+  virtual bool IsLowLatency() { return m_lowLatency; }
+  void SetLowLatency(bool lowLatency) { m_lowLatency = lowLatency; }
+
   // interfaces
   virtual IDemux* GetIDemux() { return nullptr; }
   virtual IPosTime* GetIPosTime() { return nullptr; }
@@ -212,4 +215,5 @@ protected:
   CFileItem m_item;
   bool m_contentLookup;
   bool m_realtime;
+  bool m_lowLatency;
 };

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFFmpeg.cpp
@@ -44,6 +44,11 @@ bool CDVDInputStreamFFmpeg::Open()
       StringUtils::CompareNoCase(m_item.GetDynPath(), "rtp://", 6) == 0)
   {
     m_realtime = true;
+
+    CURL url = GetURL();
+    std::string lowlatency;
+    if (url.GetOption("lowlatency", lowlatency))
+      m_lowLatency = lowlatency == "true";
   }
 
   return true;

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
@@ -676,6 +676,20 @@ int64_t CProcessInfo::GetMaxTime()
   return m_timeMax;
 }
 
+void CProcessInfo::SetStateLowLatency(bool state)
+{
+  CSingleLock lock(m_renderSection);
+
+  m_lowLatencyStream = state;
+}
+
+bool CProcessInfo::IsLowLatencyStream()
+{
+  CSingleLock lock(m_stateSection);
+
+  return m_lowLatencyStream;
+}
+
 //******************************************************************************
 // settings
 //******************************************************************************

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
@@ -119,6 +119,9 @@ public:
   void SetVideoSettings(CVideoSettings &settings);
   CVideoSettingsLocked& GetVideoSettingsLocked();
 
+  void SetStateLowLatency(bool state);
+  bool IsLowLatencyStream();
+
 protected:
   CProcessInfo();
   static std::map<std::string, CreateProcessControl> m_processControls;
@@ -177,4 +180,6 @@ protected:
   CCriticalSection m_settingsSection;
   CVideoSettings m_videoSettings;
   std::unique_ptr<CVideoSettingsLocked> m_videoSettingsLocked;
+
+  bool m_lowLatencyStream;
 };

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2014,6 +2014,9 @@ void CVideoPlayer::HandlePlaySpeed()
     if (m_pInputStream->IsRealtime())
       threshold = 40;
 
+    if (m_pInputStream->IsLowLatency())
+      threshold = 2;
+
     bool video = m_CurrentVideo.id < 0 || (m_CurrentVideo.syncState == IDVDStreamPlayer::SYNC_WAITSYNC) ||
                  (m_CurrentVideo.packets == 0 && m_CurrentAudio.packets > threshold) ||
                  (!m_VideoPlayerAudio->AcceptsData() && m_processInfo->GetLevelVQ() < 10);

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5012,7 +5012,7 @@ void CVideoPlayer::UpdatePlayState(double timeout)
   }
   else
   {
-    state.cache_level = std::min(1.0, queueTime / 8000.0);
+    state.cache_level = std::min(1.0, queueTime / m_messageQueueTimeSize);
     state.cache_offset = queueTime / state.timeMax;
     state.cache_time = queueTime / 1000.0;
   }

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1910,7 +1910,11 @@ void CVideoPlayer::HandlePlaySpeed()
     if (m_pInputStream->IsRealtime() &&
         (m_CurrentAudio.id < 0 || m_VideoPlayerAudio->GetLevel() >= levelTreshold))
     {
-      SetCaching(CACHESTATE_INIT);
+      // immediately set cache to done if we have audio data
+      if (m_pInputStream->IsLowLatency())
+        SetCaching(CACHESTATE_DONE);
+      else
+        SetCaching(CACHESTATE_INIT);
     }
   }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2104,7 +2104,12 @@ void CVideoPlayer::HandlePlaySpeed()
       }
       else if (m_CurrentAudio.starttime != DVD_NOPTS_VALUE && m_CurrentAudio.packets > 0)
       {
-        if (m_pInputStream->IsRealtime())
+        if (m_pInputStream->IsRealtime() && m_pInputStream->IsLowLatency())
+        {
+          // Do not add 400ms extradelay, but use cachetotal instead of cachetime to have more buffer
+          clock = m_CurrentAudio.starttime - m_CurrentAudio.cachetotal;
+        }
+        if (m_pInputStream->IsRealtime() && !m_pInputStream->IsLowLatency())
           clock = m_CurrentAudio.starttime - m_CurrentAudio.cachetotal - DVD_MSEC_TO_TIME(400);
         else
           clock = m_CurrentAudio.starttime - m_CurrentAudio.cachetime;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1906,7 +1906,7 @@ void CVideoPlayer::HandlePlaySpeed()
     if (m_pInputStream->IsRealtime() &&
         (m_CurrentAudio.id < 0 || m_VideoPlayerAudio->GetLevel() > 10))
     {
-      SetCaching(CACHESTATE_INIT);
+      SetCaching(CACHESTATE_DONE);
     }
   }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -603,6 +603,12 @@ void CVideoPlayer::DestroyPlayers()
   delete m_VideoPlayerRadioRDS;
   m_VideoPlayerAudioID3.reset();
 
+  m_VideoPlayerVideo = nullptr;
+  m_VideoPlayerAudio = nullptr;
+  m_VideoPlayerSubtitle = nullptr;
+  m_VideoPlayerTeletext = nullptr;
+  m_VideoPlayerRadioRDS = nullptr;
+
   m_players_created = false;
 }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1902,11 +1902,15 @@ void CVideoPlayer::HandlePlaySpeed()
         SetCaching(CACHESTATE_INIT);
     }
 
-    // if audio stream stalled, wait until demux queue filled 10%
+    int levelTreshold = 10;
+    if (m_pInputStream->IsLowLatency())
+      levelTreshold = 2;
+
+    // if audio stream stalled, wait until demux queue filled levelTreshold percent
     if (m_pInputStream->IsRealtime() &&
-        (m_CurrentAudio.id < 0 || m_VideoPlayerAudio->GetLevel() > 10))
+        (m_CurrentAudio.id < 0 || m_VideoPlayerAudio->GetLevel() >= levelTreshold))
     {
-      SetCaching(CACHESTATE_DONE);
+      SetCaching(CACHESTATE_INIT);
     }
   }
 
@@ -1922,7 +1926,7 @@ void CVideoPlayer::HandlePlaySpeed()
     if (m_CurrentAudio.id >= 0 && m_CurrentVideo.id >= 0)
     {
       if ((!m_VideoPlayerAudio->AcceptsData() || !m_VideoPlayerVideo->AcceptsData()) &&
-          m_cachingTimer.IsTimePast())
+          (m_cachingTimer.IsTimePast() || m_pInputStream->IsRealtime() || m_pInputStream->IsLowLatency()))
       {
         SetCaching(CACHESTATE_DONE);
       }

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3426,7 +3426,7 @@ bool CVideoPlayer::GetSubtitleVisible() const
     return pStream->IsSubtitleStreamEnabled();
   }
 
-  return m_VideoPlayerVideo->IsSubtitleEnabled();
+  return m_VideoPlayerVideo && m_VideoPlayerVideo->IsSubtitleEnabled();
 }
 
 void CVideoPlayer::SetSubtitleVisible(bool bVisible)
@@ -5075,8 +5075,8 @@ void CVideoPlayer::SetVideoSettings(CVideoSettings& settings)
   m_renderManager.SetDelay(static_cast<int>(settings.m_AudioDelay * 1000.0f));
   m_renderManager.SetSubtitleVerticalPosition(settings.m_subtitleVerticalPosition,
                                               settings.m_subtitleVerticalPositionSave);
-  m_VideoPlayerVideo->EnableSubtitle(settings.m_SubtitleOn);
-  m_VideoPlayerVideo->SetSubtitleDelay(static_cast<int>(-settings.m_SubtitleDelay * DVD_TIME_BASE));
+  m_VideoPlayerVideo && m_VideoPlayerVideo->EnableSubtitle(settings.m_SubtitleOn);
+  m_VideoPlayerVideo && m_VideoPlayerVideo->SetSubtitleDelay(static_cast<int>(-settings.m_SubtitleDelay * DVD_TIME_BASE));
 }
 
 void CVideoPlayer::FrameMove()

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1945,7 +1945,7 @@ void CVideoPlayer::HandlePlaySpeed()
       SetCaching(CACHESTATE_DONE);
   }
 
-  if (m_caching == CACHESTATE_DONE)
+  if (m_caching == CACHESTATE_DONE && !m_pInputStream->IsLowLatency())
   {
     if (m_playSpeed == DVD_PLAYSPEED_NORMAL && !tolerateStall)
     {

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -32,6 +32,8 @@
 #include <utility>
 #include <vector>
 
+constexpr auto VP_MESSAGE_QUEUE_SIZE_STANDARD = 8.0;
+constexpr auto VP_MESSAGE_QUEUE_SIZE_LL = 1.0; // goal is to get it down to 0.2 or lower
 struct SPlayerState
 {
   SPlayerState() { Clear(); }
@@ -591,4 +593,6 @@ protected:
   bool m_UpdateStreamDetails;
 
   std::atomic<bool> m_displayLost;
+
+  double m_messageQueueTimeSize = VP_MESSAGE_QUEUE_SIZE_STANDARD;
 };

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
@@ -30,7 +30,7 @@ class CDVDAudioCodec;
 class CVideoPlayerAudio : public CThread, public IDVDStreamPlayerAudio
 {
 public:
-  CVideoPlayerAudio(CDVDClock* pClock, CDVDMessageQueue& parent, CProcessInfo &processInfo);
+  CVideoPlayerAudio(CDVDClock* pClock, CDVDMessageQueue& parent, CProcessInfo &processInfo, const double messageQueueTimeSize);
   ~CVideoPlayerAudio() override;
 
   bool OpenStream(CDVDStreamInfo hints) override;
@@ -117,5 +117,6 @@ protected:
   bool m_displayReset = false;
   unsigned int m_disconAdjustTimeMs = 50; // maximum sync-off before adjusting
   int m_disconAdjustCounter = 0;
+  const double m_messageQueueTimeSize;
 };
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -48,12 +48,14 @@ CVideoPlayerVideo::CVideoPlayerVideo(CDVDClock* pClock
                                 ,CDVDOverlayContainer* pOverlayContainer
                                 ,CDVDMessageQueue& parent
                                 ,CRenderManager& renderManager
-                                ,CProcessInfo &processInfo)
+                                ,CProcessInfo &processInfo
+                                ,double messageQueueTimeSize)
 : CThread("VideoPlayerVideo")
 , IDVDStreamPlayerVideo(processInfo)
 , m_messageQueue("video")
 , m_messageParent(parent)
 , m_renderManager(renderManager)
+, m_messageQueueTimeSize(messageQueueTimeSize)
 {
   m_pClock = pClock;
   m_pOverlayContainer = pOverlayContainer;
@@ -67,9 +69,9 @@ CVideoPlayerVideo::CVideoPlayerVideo(CDVDClock* pClock
   m_iDroppedRequest = 0;
   m_fForcedAspectRatio = 0;
 
-  // 128 MB allows max bitrate of 128 Mbit/s (e.g. UHD Blu-Ray) during 8 seconds
+  // 128 MB allows max bitrate of 128 Mbit/s (e.g. UHD Blu-Ray) during m_messageQueueTimeSize seconds
   m_messageQueue.SetMaxDataSize(128 * 1024 * 1024);
-  m_messageQueue.SetMaxTimeSize(8.0);
+  m_messageQueue.SetMaxTimeSize(m_messageQueueTimeSize);
 
   m_iDroppedFrames = 0;
   m_fFrameRate = 25;
@@ -953,7 +955,7 @@ CVideoPlayerVideo::EOutputState CVideoPlayerVideo::OutputPicture(const VideoPict
 std::string CVideoPlayerVideo::GetPlayerInfo()
 {
   std::ostringstream s;
-  s << "vq:"   << std::setw(2) << std::min(99, m_processInfo.GetLevelVQ()) << "%";
+  s << "vq:"   << std::setw(2) << std::min(99, m_processInfo.GetLevelVQ()) << "%" << StringUtils::Format(" {:6.3f}s", m_processInfo.GetLevelVQ() * (m_messageQueueTimeSize * 1000) / 100 / 1000);
   s << ", Mb/s:" << std::fixed << std::setprecision(2) << (double)GetVideoBitrate() / (1024.0*1024.0);
   s << ", fr:"     << std::fixed << std::setprecision(3) << m_fFrameRate;
   s << ", drop:" << m_iDroppedFrames;

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.h
@@ -49,7 +49,8 @@ public:
                  ,CDVDOverlayContainer* pOverlayContainer
                  ,CDVDMessageQueue& parent
                  ,CRenderManager& renderManager,
-                 CProcessInfo &processInfo);
+                 CProcessInfo &processInfo,
+                 const double messageQueueTimeSize);
   ~CVideoPlayerVideo() override;
 
   bool OpenStream(CDVDStreamInfo hint) override;
@@ -141,4 +142,6 @@ protected:
   VideoPicture m_picture;
 
   EOutputState m_outputSate;
+
+  const double m_messageQueueTimeSize;
 };


### PR DESCRIPTION
## Description
Remove video playback latency as much as possible.

## Motivation and context
If you set VLC's network caching to 200ms or a little less, it can pretty much flawlessly stream
local multicasts with very little delay.
In comparison Kodi does not have such a setting and the default latency for a UDP multicast, starts at around 400ms and slowly grows to around 1.2s (around 10% of vq/aq).
I'd like to have Kodi be able to play video with as little delay as feasibly possible.

## How has this been tested?
I ran this code as part of my fork (which is based on an older Kodi version) on Android, this particular PR is not tested as I don't have a working buildmachine for current master atm).
I've used an HDMI encoder that multicasts a UDP stream.

For playback I added the new lowlatency=true parameter like so: ´udp://239.1.1.10:1234?lowlatency=true´
Additionally I used the keep audio device alive feature set to always and modified the code to match the "idle" sink configuration to match my streams audio config, so AE is already preconfigured when I start the stream.
In this scenario the code works pretty well.

## What is the effect on users?
Very fast video/audio playback with little delay.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)


## Notes
* This is a draft, so take it as such
* I'm well aware this touches the very core of playback and I don't understand all of the code, so I'm looking for more insights, maybe @FernetMenta is able to shed some light on the MessageQueue implementation and A/V sync details
* I turned off resample for low latency, because I could clearly hear pitch changes for my test stream even though it would only correct speed to like 0,98 (thus not applying the 5% slowdown or speedup cause I removed that handling for LL altogether)

## Open issues
- [ ] switching from normal playback to low latency doesn't clear buffers, so delay is super big when doing that
- [ ] the latency slowly gets bigger which I'd like to fix
- [ ] I'm still thinking about another more generic way to preload AE, so I can still get the same speed to start sync
- [ ] Sometimes the queue is very empty and player starts to skip frames (happens rarely though)
- [ ] Fix more potential crashes due to recreation of VPV when switching to LL