### PR TITLE
[PVR] CPVRClient: Request TV groups and members only if the addon supports TV.

### DIFF
--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -723,31 +723,41 @@ PVR_ERROR CPVRClient::GetChannelGroupsAmount(int& iGroups) const
 
 PVR_ERROR CPVRClient::GetChannelGroups(CPVRChannelGroups* groups) const
 {
-  return DoAddonCall(__func__,
-                     [this, groups](const AddonInstance* addon) {
-                       PVR_HANDLE_STRUCT handle = {};
-                       handle.callerAddress = this;
-                       handle.dataAddress = groups;
-                       return addon->toAddon->GetChannelGroups(addon, &handle, groups->IsRadio());
-                     },
-                     m_clientCapabilities.SupportsChannelGroups());
+  const bool radio{groups->IsRadio()};
+  return DoAddonCall(
+      __func__,
+      [this, groups](const AddonInstance* addon)
+      {
+        PVR_HANDLE_STRUCT handle = {};
+        handle.callerAddress = this;
+        handle.dataAddress = groups;
+        return addon->toAddon->GetChannelGroups(addon, &handle, groups->IsRadio());
+      },
+      m_clientCapabilities.SupportsChannelGroups() &&
+          ((radio && m_clientCapabilities.SupportsRadio()) ||
+           (!radio && m_clientCapabilities.SupportsTV())));
 }
 
 PVR_ERROR CPVRClient::GetChannelGroupMembers(
     CPVRChannelGroup* group,
     std::vector<std::shared_ptr<CPVRChannelGroupMember>>& groupMembers) const
 {
-  return DoAddonCall(__func__,
-                     [this, group, &groupMembers](const AddonInstance* addon) {
-                       PVR_HANDLE_STRUCT handle = {};
-                       handle.callerAddress = this;
-                       handle.dataAddress = &groupMembers;
+  const bool radio{group->IsRadio()};
+  return DoAddonCall(
+      __func__,
+      [this, group, &groupMembers](const AddonInstance* addon)
+      {
+        PVR_HANDLE_STRUCT handle = {};
+        handle.callerAddress = this;
+        handle.dataAddress = &groupMembers;
 
-                       PVR_CHANNEL_GROUP tag;
-                       group->FillAddonData(tag);
-                       return addon->toAddon->GetChannelGroupMembers(addon, &handle, &tag);
-                     },
-                     m_clientCapabilities.SupportsChannelGroups());
+        PVR_CHANNEL_GROUP tag;
+        group->FillAddonData(tag);
+        return addon->toAddon->GetChannelGroupMembers(addon, &handle, &tag);
+      },
+      m_clientCapabilities.SupportsChannelGroups() &&
+          ((radio && m_clientCapabilities.SupportsRadio()) ||
+           (!radio && m_clientCapabilities.SupportsTV())));
 }
 
 PVR_ERROR CPVRClient::GetProvidersAmount(int& iProviders) const


### PR DESCRIPTION
…Same for radio.

Stumbled upon this while working on something else. We must not call an addon function if the respective addon capability is not present. 

 For example, we must not call GetGroups with radio = true if the respective addon only supports TV. Happens for example with pvr.waipu. Behavior in this case is undefined and pvr.waipu GetGroups implementation ignors the radio parameter and returns all TV groups, flagged in the returned groups respectively as TV, which at the end led to a new TV database entry for every TV group on every Kodi restart. 

@flubshi this is not actually a bug in pvr.waipu and the problem is fixed with this PR, but you could maybe enhance your logging (if not already present - did not check) for GetGroups and GetGroupMembers to detect those wrong precondition. You should return an error "wrong parameters" in this case. 

Runtime-tested on macOS, latest Kodi master.

@phunkyfish whenever you find some time for a review.