### PR TITLE
[CharsetConverter] Fix crash if iconv returns EINVAL

### DIFF
--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -462,7 +462,7 @@ bool CCharsetConverter::CInnerConverter::convert(iconv_t type, int multiplier, c
   const typename OUTPUT::size_type sizeInChars = (typename OUTPUT::size_type) (outBufSize - outBytesAvail) / sizeof(typename OUTPUT::value_type);
   typename OUTPUT::const_pointer strPtr = (typename OUTPUT::const_pointer) outBuf;
   /* Make sure that all buffer is assigned and string is stopped at end of buffer */
-  if (strPtr[sizeInChars-1] == 0 && strSource[strSource.length()-1] != 0)
+  if (sizeInChars > 0 && strPtr[sizeInChars - 1] == 0 && strSource[strSource.length() - 1] != 0)
     strDest.assign(strPtr, sizeInChars-1);
   else
     strDest.assign(strPtr, sizeInChars);


### PR DESCRIPTION
## Description
Found while working on https://github.com/xbmc/xbmc/pull/24109. If for some reason iconv fails to convert the sequence due to EINVAL (Invalid sequence at the end of input buffer) the loop breaks and we reach this condition. If this happens to happen right on the beginning on the string (in my case "\xa9 Copyright 2020 IPTC (Test Images) - www.iptc.org") sizeInChars is zero and strPtr[sizeInChars - 1] points to nirvana...
In those case let the string be empty instead of crashing Kodi.