### PR TITLE
[clang-tidy] fix modernize-* and performance-* warnings

### DIFF
--- a/xbmc/CueDocument.cpp
+++ b/xbmc/CueDocument.cpp
@@ -75,10 +75,7 @@ class FileReader
   : public CueReader
 {
 public:
-  explicit FileReader(const std::string &strFile) : m_szBuffer{}
-  {
-    m_opened = m_file.Open(strFile);
-  }
+  explicit FileReader(const std::string& strFile) { m_opened = m_file.Open(strFile); }
   bool ReadLine(std::string &line) override
   {
     // Read the next line.
@@ -106,7 +103,7 @@ public:
 private:
   CFile m_file;
   bool m_opened;
-  char m_szBuffer[1024];
+  char m_szBuffer[1024]{};
 };
 
 class BufferReader

--- a/xbmc/cores/DataCacheCore.cpp
+++ b/xbmc/cores/DataCacheCore.cpp
@@ -14,12 +14,8 @@
 #include <mutex>
 #include <utility>
 
-CDataCacheCore::CDataCacheCore() :
-  m_playerVideoInfo {},
-  m_playerAudioInfo {},
-  m_contentInfo {},
-  m_renderInfo {},
-  m_stateInfo {}
+CDataCacheCore::CDataCacheCore()
+  : m_playerVideoInfo{}, m_playerAudioInfo{}, m_contentInfo{}, m_stateInfo{}
 {
 }
 

--- a/xbmc/cores/DataCacheCore.h
+++ b/xbmc/cores/DataCacheCore.h
@@ -306,7 +306,7 @@ protected:
   struct SRenderInfo
   {
     bool m_isClockSync;
-  } m_renderInfo;
+  } m_renderInfo{};
 
   mutable CCriticalSection m_stateSection;
   bool m_playerStateChanged = false;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecAndroidMediaCodec.cpp
@@ -27,6 +27,7 @@
 #include "utils/log.h"
 
 #include <cassert>
+#include <memory>
 #include <stdexcept>
 
 #include <androidjni/ByteBuffer.h>
@@ -208,7 +209,7 @@ bool CDVDAudioCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
       mimeTypes = codec_info.getSupportedTypes();
       if (std::find(mimeTypes.begin(), mimeTypes.end(), m_mime) != mimeTypes.end())
       {
-        m_codec = std::shared_ptr<CJNIMediaCodec>(new CJNIMediaCodec(CJNIMediaCodec::createByCodecName(codecName)));
+        m_codec = std::make_shared<CJNIMediaCodec>(CJNIMediaCodec::createByCodecName(codecName));
         if (xbmc_jnienv()->ExceptionCheck())
         {
           xbmc_jnienv()->ExceptionDescribe();
@@ -288,16 +289,15 @@ PROCESSDECODER:
       {
         CLog::Log(LOGDEBUG, "CDVDAudioCodecAndroidMediaCodec::Open Prefer the Google raw decoder "
                             "over the MediaTek one");
-        m_codec = std::shared_ptr<CJNIMediaCodec>(
-            new CJNIMediaCodec(CJNIMediaCodec::createByCodecName("OMX.google.raw.decoder")));
+        m_codec = std::make_shared<CJNIMediaCodec>(
+            CJNIMediaCodec::createByCodecName("OMX.google.raw.decoder"));
       }
       else
       {
         CLog::Log(
             LOGDEBUG,
             "CDVDAudioCodecAndroidMediaCodec::Open Use the raw decoder proposed by the platform");
-        m_codec = std::shared_ptr<CJNIMediaCodec>(
-            new CJNIMediaCodec(CJNIMediaCodec::createDecoderByType(m_mime)));
+        m_codec = std::make_shared<CJNIMediaCodec>(CJNIMediaCodec::createDecoderByType(m_mime));
       }
       if (xbmc_jnienv()->ExceptionCheck())
       {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -840,8 +840,7 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
     {
       if (types[j] == m_mime)
       {
-        m_codec = std::shared_ptr<CJNIMediaCodec>(
-            new CJNIMediaCodec(CJNIMediaCodec::createByCodecName(m_codecname)));
+        m_codec = std::make_shared<CJNIMediaCodec>(CJNIMediaCodec::createByCodecName(m_codecname));
         if (xbmc_jnienv()->ExceptionCheck())
         {
           xbmc_jnienv()->ExceptionDescribe();
@@ -921,7 +920,7 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
   m_processInfo.SetVideoDeintMethod("hardware");
   m_processInfo.SetVideoDAR(m_hints.aspect);
 
-  m_videoBufferPool = std::shared_ptr<CMediaCodecVideoBufferPool>(new CMediaCodecVideoBufferPool(m_codec));
+  m_videoBufferPool = std::make_shared<CMediaCodecVideoBufferPool>(m_codec);
 
   UpdateFpsDuration();
 
@@ -1832,9 +1831,9 @@ void CDVDVideoCodecAndroidMediaCodec::InitSurfaceTexture(void)
     glBindTexture(  GL_TEXTURE_EXTERNAL_OES, 0);
     m_textureId = texture_id;
 
-    m_surfaceTexture = std::shared_ptr<CJNISurfaceTexture>(new CJNISurfaceTexture(m_textureId));
+    m_surfaceTexture = std::make_shared<CJNISurfaceTexture>(m_textureId);
     // hook the surfaceTexture OnFrameAvailable callback
-    m_frameAvailable = std::shared_ptr<CDVDMediaCodecOnFrameAvailable>(new CDVDMediaCodecOnFrameAvailable(m_surfaceTexture));
+    m_frameAvailable = std::make_shared<CDVDMediaCodecOnFrameAvailable>(m_surfaceTexture);
     m_jnivideosurface = CJNISurface(*m_surfaceTexture);
   }
   else

--- a/xbmc/dialogs/GUIDialogNumeric.cpp
+++ b/xbmc/dialogs/GUIDialogNumeric.cpp
@@ -38,8 +38,7 @@
 using namespace KODI::MESSAGING;
 using KODI::UTILITY::CDigest;
 
-CGUIDialogNumeric::CGUIDialogNumeric(void)
-  : CGUIDialog(WINDOW_DIALOG_NUMERIC, "DialogNumeric.xml"), m_block{}, m_lastblock{}
+CGUIDialogNumeric::CGUIDialogNumeric(void) : CGUIDialog(WINDOW_DIALOG_NUMERIC, "DialogNumeric.xml")
 {
   memset(&m_datetime, 0, sizeof(KODI::TIME::SystemTime));
   m_loadType = KEEP_IN_MEMORY;

--- a/xbmc/dialogs/GUIDialogNumeric.h
+++ b/xbmc/dialogs/GUIDialogNumeric.h
@@ -75,8 +75,8 @@ protected:
   INPUT_MODE m_mode = INPUT_PASSWORD; // the current input mode
   KODI::TIME::SystemTime m_datetime; // for time and date modes
   uint8_t m_ip[4];                  // for ip address mode
-  uint32_t m_block;             // for time, date, and IP methods.
-  uint32_t m_lastblock;
+  uint32_t m_block{}; // for time, date, and IP methods.
+  uint32_t m_lastblock{};
   bool m_dirty = false; // true if the current block has been changed.
   std::string m_number;              ///< for number or password input
 };

--- a/xbmc/platform/android/peripherals/AndroidJoystickState.cpp
+++ b/xbmc/platform/android/peripherals/AndroidJoystickState.cpp
@@ -236,6 +236,7 @@ bool CAndroidJoystickState::ProcessEvent(const AInputEvent* event)
         {
           // get all potential values
           std::vector<float> values;
+          values.reserve(axis.ids.size());
           for (const auto& axisId : axis.ids)
             values.push_back(AMotionEvent_getAxisValue(event, axisId, pointer));
 

--- a/xbmc/utils/PlayerUtils.cpp
+++ b/xbmc/utils/PlayerUtils.cpp
@@ -41,7 +41,7 @@ bool CPlayerUtils::IsItemPlayable(const CFileItem& itemIn)
   return false;
 }
 
-void CPlayerUtils::AdvanceTempoStep(std::shared_ptr<CApplicationPlayer> appPlayer,
+void CPlayerUtils::AdvanceTempoStep(const std::shared_ptr<CApplicationPlayer>& appPlayer,
                                     TempoStepChange change)
 {
   const auto step = 0.1f;

--- a/xbmc/utils/PlayerUtils.h
+++ b/xbmc/utils/PlayerUtils.h
@@ -23,6 +23,6 @@ class CPlayerUtils
 {
 public:
   static bool IsItemPlayable(const CFileItem& item);
-  static void AdvanceTempoStep(std::shared_ptr<CApplicationPlayer> appPlayer,
+  static void AdvanceTempoStep(const std::shared_ptr<CApplicationPlayer>& appPlayer,
                                TempoStepChange change);
 };


### PR DESCRIPTION
## Description
[clang-tidy] fix modernize-* and performance-* warnings

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
