### PR TITLE
[PVR] Recently added channels

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -2706,6 +2706,7 @@ msgstr ""
 
 #: xbmc/dialogs/GUIDialogMediaFilter.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
+#: xbmc/pvr/windows/GUIViewStatePVR.cpp
 msgctxt "#570"
 msgid "Date added"
 msgstr ""

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -3929,7 +3929,13 @@ msgctxt "#854"
 msgid "Any channel from any client"
 msgstr ""
 
-#empty strings from id 855 to 996
+#. Label for Estuary 'Recently added channels' 'home screen widget
+#: addons/skin.estuary/xml/Home.xml
+msgctxt "#855"
+msgid "Recently added channels"
+msgstr ""
+
+#empty strings from id 856 to 996
 
 #: xbmc/windows/GUIMediaWindow.cpp
 msgctxt "#997"

--- a/addons/skin.estuary/xml/Home.xml
+++ b/addons/skin.estuary/xml/Home.xml
@@ -443,6 +443,17 @@
 							<param name="widget_target" value="tvsearch"/>
 							<param name="list_id" value="12600"/>
 						</include>
+						<include content="WidgetListPVR" condition="System.HasPVRAddon">
+							<param name="content_path" value="pvr://channels/tv/*?view=dateadded"/>
+							<param name="sortby" value="dateadded"/>
+							<param name="sortorder" value="descending"/>
+							<param name="widget_header" value="$LOCALIZE[855]"/>
+							<param name="widget_target" value="tvchannels"/>
+							<param name="item_limit" value="15"/>
+							<param name="list_id" value="12700"/>
+							<param name="info_update" value="5000"/>
+							<param name="label2" value="$INFO[ListItem.DateAdded]"/>
+						</include>
 					</control>
 					<include content="ImageWidget" condition="!System.HasPVRAddon">
 						<param name="text_label" value="$LOCALIZE[31143]" />
@@ -514,6 +525,17 @@
 							<param name="widget_header" value="$LOCALIZE[19337]"/>
 							<param name="widget_target" value="radiosearch"/>
 							<param name="list_id" value="13600"/>
+						</include>
+						<include content="WidgetListPVR" condition="System.HasPVRAddon">
+							<param name="content_path" value="pvr://channels/radio/*?view=dateadded"/>
+							<param name="sortby" value="dateadded"/>
+							<param name="sortorder" value="descending"/>
+							<param name="widget_header" value="$LOCALIZE[855]"/>
+							<param name="widget_target" value="radiochannels"/>
+							<param name="item_limit" value="15"/>
+							<param name="list_id" value="13700"/>
+							<param name="info_update" value="5000"/>
+							<param name="label2" value="$INFO[ListItem.DateAdded]"/>
 						</include>
 					</control>
 					<include content="ImageWidget" condition="!System.HasPVRAddon">

--- a/xbmc/guilib/listproviders/DirectoryProvider.cpp
+++ b/xbmc/guilib/listproviders/DirectoryProvider.cpp
@@ -311,9 +311,10 @@ void CDirectoryProvider::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
     {
       if (message == "OnPlay" || message == "OnResume" || message == "OnStop")
       {
-        if (m_currentSort.sortBy == SortByNone || // not nice, but many directories that need to be refreshed on start/stop have no special sort order (e.g. in progress movies)
+        if (m_currentSort.sortBy ==
+                SortByNone || // not nice, but many directories that need to be refreshed on start/stop have no special sort order (e.g. in progress movies)
             m_currentSort.sortBy == SortByLastPlayed ||
-            m_currentSort.sortBy == SortByPlaycount ||
+            m_currentSort.sortBy == SortByDateAdded || m_currentSort.sortBy == SortByPlaycount ||
             m_currentSort.sortBy == SortByLastUsed)
           m_updateState = INVALIDATED;
       }

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -64,7 +64,7 @@ namespace PVR
      * @brief Get the minimal database version that is required to operate correctly.
      * @return The minimal database version.
      */
-    int GetSchemaVersion() const override { return 44; }
+    int GetSchemaVersion() const override { return 45; }
 
     /*!
      * @brief Get the default sqlite database filename.

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -111,6 +111,7 @@ void CPVRChannel::Serialize(CVariant& value) const
   value["uniqueid"] = m_iUniqueId;
   CDateTime lastPlayed(m_iLastWatched);
   value["lastplayed"] = lastPlayed.IsValid() ? lastPlayed.GetAsDBDate() : "";
+  value["dateadded"] = m_dateTimeAdded.IsValid() ? m_dateTimeAdded.GetAsDBDate() : "";
 
   std::shared_ptr<CPVREpgInfoTag> epg = GetEPGNow();
   if (epg)
@@ -402,6 +403,20 @@ bool CPVRChannel::SetLastWatched(time_t lastWatched, int groupId)
   const std::shared_ptr<CPVRDatabase> database = CServiceBroker::GetPVRManager().GetTVDatabase();
   if (database)
     return database->UpdateLastWatched(*this, groupId);
+
+  return false;
+}
+
+bool CPVRChannel::SetDateTimeAdded(const CDateTime& dateTimeAdded)
+{
+  std::unique_lock<CCriticalSection> lock(m_critSection);
+
+  if (m_dateTimeAdded != dateTimeAdded)
+  {
+    m_dateTimeAdded = dateTimeAdded;
+    m_bChanged = true;
+    return true;
+  }
 
   return false;
 }
@@ -735,6 +750,12 @@ time_t CPVRChannel::LastWatched() const
 {
   std::unique_lock<CCriticalSection> lock(m_critSection);
   return m_iLastWatched;
+}
+
+CDateTime CPVRChannel::DateTimeAdded() const
+{
+  std::unique_lock<CCriticalSection> lock(m_critSection);
+  return m_dateTimeAdded;
 }
 
 bool CPVRChannel::IsChanged() const

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -676,6 +676,8 @@ void CPVRChannel::ToSortable(SortItem& sortable, Field field) const
     sortable[FieldLastPlayed] =
         lastWatched.IsValid() ? lastWatched.GetAsDBDateTime() : StringUtils::Empty;
   }
+  else if (field == FieldDateAdded)
+    sortable[FieldDateAdded] = m_dateTimeAdded.GetAsDBDateTime();
   else if (field == FieldProvider)
     sortable[FieldProvider] = StringUtils::Format("{} {}", m_iClientId, m_iClientProviderUid);
 }

--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "XBDateTime.h"
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_channels.h"
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_providers.h"
 #include "pvr/PVRCachedImage.h"
@@ -219,6 +220,18 @@ public:
    * @return True if the something changed, false otherwise.
    */
   bool SetLastWatched(time_t lastWatched, int groupId);
+
+  /*!
+   * @return the date and time this channel was added to the TV database.
+   */
+  CDateTime DateTimeAdded() const;
+
+  /*!
+   * @brief Set the date and time the channel was added to the TV database.
+   * @param dateTimeAdded The date and time.
+   * @return True if the something changed, false otherwise.
+   */
+  bool SetDateTimeAdded(const CDateTime& dateTimeAdded);
 
   /*!
    * @brief Check whether this channel has unpersisted data changes.
@@ -551,6 +564,7 @@ private:
       PVR_PROVIDER_INVALID_UID; /*!< the unique id for this provider from the client */
   int m_lastWatchedGroupId{
       -1}; /*!< the id of the channel group the channel was watched from the last time */
+  CDateTime m_dateTimeAdded; /*!< the date and time the channel was added to the TV datebase */
   //@}
 
   mutable CCriticalSection m_critSection;

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -609,6 +609,10 @@ bool CPVRChannelGroup::UpdateFromClient(const std::shared_ptr<CPVRChannelGroupMe
     if (groupMember->GroupID() == INVALID_GROUP_ID)
       groupMember->SetGroupID(GroupID());
 
+    // Seeing this channel for the very first time. Remember when it was added.
+    if (IsChannelsOwner() && !channel->DateTimeAdded().IsValid())
+      channel->SetDateTimeAdded(CDateTime::GetUTCDateTime());
+
     m_sortedMembers.emplace_back(groupMember);
     m_members.emplace(channel->StorageId(), groupMember);
 

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -591,6 +591,7 @@ bool CPVRGUIDirectory::GetChannelsDirectory(CFileItemList& results) const
     else if (path.IsChannelGroup())
     {
       const bool playedOnly{(m_url.HasOption("view") && (m_url.GetOption("view") == "lastplayed"))};
+      const bool dateAdded{(m_url.HasOption("view") && (m_url.GetOption("view") == "dateadded"))};
       const bool showHiddenChannels{path.IsHiddenChannelGroup()};
       const std::vector<std::shared_ptr<CPVRChannelGroupMember>> groupMembers{
           GetChannelGroupMembers(path)};
@@ -600,6 +601,10 @@ bool CPVRGUIDirectory::GetChannelsDirectory(CFileItemList& results) const
           continue;
 
         if (playedOnly && !groupMember->Channel()->LastWatched())
+          continue;
+
+        if (dateAdded && (!groupMember->Channel()->DateTimeAdded().IsValid() ||
+                          groupMember->Channel()->LastWatched()))
           continue;
 
         results.Add(std::make_shared<CFileItem>(groupMember));

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -870,6 +870,13 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
         strValue =
             CServiceBroker::GetPVRManager().GetClient(channel->ClientID())->GetInstanceName();
         return true;
+      case LISTITEM_DATE_ADDED:
+        if (channel->DateTimeAdded().IsValid())
+        {
+          strValue = channel->DateTimeAdded().GetAsLocalizedDate();
+          return true;
+        }
+        break;
     }
   }
 

--- a/xbmc/pvr/windows/GUIViewStatePVR.cpp
+++ b/xbmc/pvr/windows/GUIViewStatePVR.cpp
@@ -34,6 +34,9 @@ CGUIViewStateWindowPVRChannels::CGUIViewStateWindowPVRChannels(const int windowI
   AddSortMethod(
       SortByLastPlayed, 568, // "Last played"
       LABEL_MASKS("%L", "%p", "%L", "%p")); // Filename, LastPlayed | Foldername, LastPlayed
+  AddSortMethod(SortByDateAdded, 570, // "Date added"
+                LABEL_MASKS("%L", "%a", "%L", "%a"), // Filename, DateAdded | Foldername, DateAdded
+                SortAttributeNone, SortOrderDescending);
   AddSortMethod(SortByClientChannelOrder, 19315, // "Backend number"
                 LABEL_MASKS("%L", "", "%L", "")); // Filename, empty | Foldername, empty
   AddSortMethod(SortByProvider, 19348, // "Provider"
@@ -107,6 +110,9 @@ CGUIViewStateWindowPVRGuide::CGUIViewStateWindowPVRGuide(const int windowId,
   AddSortMethod(
       SortByLastPlayed, SortAttributeIgnoreLabel, 568, // "Last played"
       LABEL_MASKS("%L", "%p", "%L", "%p")); // Filename, LastPlayed | Foldername, LastPlayed
+  AddSortMethod(SortByDateAdded, 570, // "Date added"
+                LABEL_MASKS("%L", "%a", "%L", "%a"), // Filename, DateAdded | Foldername, DateAdded
+                SortAttributeNone, SortOrderDescending);
   AddSortMethod(SortByClientChannelOrder, 19315, // "Backend number"
                 LABEL_MASKS("%L", "", "%L", "")); // Filename, empty | Foldername, empty
   AddSortMethod(SortByProvider, 19348, // "Provider"


### PR DESCRIPTION
This PR adds support for recently added TV/Radio channels.

Changes:

* Guide window: Add ability to sort content by "Date added"
* Channels window: Add ability to sort content by "Date added"
* Estuary: TV/Radio Home screen: Add "Recently added channels" widget

GUI Engine:
* Add support for PVR channels to ListItem.DateAdded

Implementation details:
* Whenever a channel is seen the first time by PVR core, the respective date and time will be stored in the TV database along with the channel data. For this a TV database version bump is required.
* Channels will be visible in the "recently added channels"  widget as long as 
a) the channel is available from the PVR client, 
b) the channel was not hidden by the user (using the channel manager)
c) the channel was not watched (same behavior as "Recently added movies" widget)

Screen shots:
![screenshot00003](https://github.com/xbmc/xbmc/assets/3226626/3ec80249-8699-463f-b7e8-0dc32bf2d09b)
![screenshot00005](https://github.com/xbmc/xbmc/assets/3226626/035e9435-c44a-4dce-8384-c998683687c4)
![screenshot00004](https://github.com/xbmc/xbmc/assets/3226626/5170dc60-604c-4d85-bb67-21197ac9e12a)

Runtime-tested on macOS and Android, latest Kodi master.

@phunkyfish can you please review the code changes.
@jjd-uk are the skin changes okay?