### PR TITLE
[cmake] Allow addons to set alternate CXX_STANDARD

### DIFF
--- a/cmake/scripts/common/CompilerSettings.cmake
+++ b/cmake/scripts/common/CompilerSettings.cmake
@@ -1,5 +1,5 @@
 # Languages and global compiler settings
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 20 CACHE STRING "CXX_STANDARD")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_ASM_FLAGS "${CMAKE_C_FLAGS} -x assembler-with-cpp")


### PR DESCRIPTION
## Description
Allow to set CMAKE_CXX_STANDARD via command line and addons to default to c++17 still.

## Motivation and context
This is pretty nasty imo, but the way addons reuse core cmake files doesnt really give much of a choice.

Without this, platforms that do not utilise toolchains (ie linux generally) are having CMAKE_CXX_STANDARD set by the inclusion of CompilerSettings.cmake at https://github.com/xbmc/xbmc/blob/008c70a2fad8650d7553151280e4fe128cfb29e9/cmake/addons/CMakeLists.txt#L83
Theres no way to override this currently. Changing it to a CACHE variable allows a user to set -DCMAKE_CXX_STANDARD=xx at configure time to use an alternate standard. We wouldnt generally want to use this for core, but whilst addons arent all guaranteed to be c++20 compatible, users may need a way to set this at the command line.

~~The nasty part is the duplication of the CompilerSettings.cmake file into an addon specific variant that automatically sets to 17 for CMAKE_CXX_STANDARD. Currently there is potentially too many addons to bring up to c++20 compatible dependencies, so this at least makes addons default to standard prior to c++20 bump in core.~~

Anyone has any better solutions, im all ears.

## How has this been tested?
Only checking --trace-expand output and utilising -DCMAKE_CXX_STANDARD to test it is alterable from building an addon directly.

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
