### PR TITLE
[PVR] Channel groups: Fix duplicate database entries caused by temporarily unavailable groups/members.

### DIFF
--- a/xbmc/pvr/channels/PVRChannel.h
+++ b/xbmc/pvr/channels/PVRChannel.h
@@ -93,7 +93,7 @@ public:
   /*!
    * @brief Set the identifier for this channel.
    * @param iDatabaseId The new channel ID
-   * @return True if the something changed, false otherwise.
+   * @return True if something changed, false otherwise.
    */
   bool SetChannelID(int iDatabaseId);
 
@@ -114,7 +114,7 @@ public:
    * The EPG of hidden channels won't be updated.
    * @param bIsHidden The new setting.
    * @param bIsUserSetIcon true if user changed the hidden flag via GUI, false otherwise.
-   * @return True if the something changed, false otherwise.
+   * @return True if something changed, false otherwise.
    */
   bool SetHidden(bool bIsHidden, bool bIsUserSetHidden = false);
 
@@ -129,7 +129,7 @@ public:
    * Set to true to lock this channel. Set to false to unlock it.
    * Locked channels need can only be viewed if parental PIN entered.
    * @param bIsLocked The new setting.
-   * @return True if the something changed, false otherwise.
+   * @return True if something changed, false otherwise.
    */
   bool SetLocked(bool bIsLocked);
 
@@ -191,7 +191,7 @@ public:
    * @brief Set the path to the icon for this channel.
    * @param strIconPath The new path.
    * @param bIsUserSetIcon true if user changed the icon via GUI, false otherwise.
-   * @return True if the something changed, false otherwise.
+   * @return True if something changed, false otherwise.
    */
   bool SetIconPath(const std::string& strIconPath, bool bIsUserSetIcon = false);
 
@@ -204,7 +204,7 @@ public:
    * @brief Set the name for this channel used by XBMC.
    * @param strChannelName The new channel name.
    * @param bIsUserSetName whether the change was triggered by the user directly
-   * @return True if the something changed, false otherwise.
+   * @return True if something changed, false otherwise.
    */
   bool SetChannelName(const std::string& strChannelName, bool bIsUserSetName = false);
 
@@ -217,7 +217,7 @@ public:
    * @brief Set the last time the channel has been watched and the channel group used to watch.
    * @param lastWatched The new last watched time value.
    * @param groupId the id of the group used to watch the channel.
-   * @return True if the something changed, false otherwise.
+   * @return True if something changed, false otherwise.
    */
   bool SetLastWatched(time_t lastWatched, int groupId);
 
@@ -229,7 +229,7 @@ public:
   /*!
    * @brief Set the date and time the channel was added to the TV database.
    * @param dateTimeAdded The date and time.
-   * @return True if the something changed, false otherwise.
+   * @return True if something changed, false otherwise.
    */
   bool SetDateTimeAdded(const CDateTime& dateTimeAdded);
 
@@ -267,7 +267,7 @@ public:
   /*!
    * @brief Set the identifier of the client that serves this channel.
    * @param iClientId The new ID.
-   * @return True if the something changed, false otherwise.
+   * @return True if something changed, false otherwise.
    */
   bool SetClientID(int iClientId);
 
@@ -415,7 +415,7 @@ public:
   /*!
    * @brief Set to true if an EPG should be used for this channel. Set to false otherwise.
    * @param bEPGEnabled The new value.
-   * @return True if the something changed, false otherwise.
+   * @return True if something changed, false otherwise.
    */
   bool SetEPGEnabled(bool bEPGEnabled);
 
@@ -436,7 +436,7 @@ public:
    * Set to "client" to load the EPG from the backend
    *
    * @param strScraper The new scraper name.
-   * @return True if the something changed, false otherwise.
+   * @return True if something changed, false otherwise.
    */
   bool SetEPGScraper(const std::string& strScraper);
 
@@ -512,7 +512,7 @@ private:
   /*!
    * @brief Set the client provider Uid for this channel
    * @param iClientProviderUid The provider Uid for this channel
-   * @return True if the something changed, false otherwise.
+   * @return True if something changed, false otherwise.
    */
   bool SetClientProviderUid(int iClientProviderUid);
 

--- a/xbmc/pvr/channels/PVRChannelGroup.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroup.cpp
@@ -245,6 +245,15 @@ void CPVRChannelGroup::UpdateClientPriorities()
     SortAndRenumber();
 }
 
+bool CPVRChannelGroup::ShouldBeIgnored(
+    const std::vector<std::shared_ptr<CPVRChannelGroup>>& allChannelGroups) const
+{
+  std::unique_lock<CCriticalSection> lock(m_critSection);
+
+  // Empty group should be ignored.
+  return m_members.empty();
+}
+
 bool CPVRChannelGroup::UpdateMembersClientPriority()
 {
   const std::shared_ptr<const CPVRClients> clients = CServiceBroker::GetPVRManager().Clients();

--- a/xbmc/pvr/channels/PVRChannelGroup.h
+++ b/xbmc/pvr/channels/PVRChannelGroup.h
@@ -499,6 +499,15 @@ public:
    */
   virtual bool IsChannelsOwner() const = 0;
 
+  /*!
+   * @brief Check whether this group should be ignored, e.g. not presented to the user and API.
+   * @param allChannelGroups All available channel groups. This information might be needed by
+   * implementations to calculate the ignore state.
+   * @return True if to be ignored, false otherwise.
+   */
+  virtual bool ShouldBeIgnored(
+      const std::vector<std::shared_ptr<CPVRChannelGroup>>& allChannelGroups) const;
+
 protected:
   /*!
    * @brief Remove deleted group members from this group.

--- a/xbmc/pvr/channels/PVRChannelGroupAllChannels.h
+++ b/xbmc/pvr/channels/PVRChannelGroupAllChannels.h
@@ -88,6 +88,18 @@ public:
    */
   bool IsChannelsOwner() const override { return true; }
 
+  /*!
+   * @brief Check whether this group should be ignored, e.g. not presented to the user and API.
+   * @param allChannelGroups All available channel groups.
+   * @return True if to be ignored, false otherwise.
+   */
+  bool ShouldBeIgnored(
+      const std::vector<std::shared_ptr<CPVRChannelGroup>>& allChannelGroups) const override
+  {
+    // "All channels" groups must always be present.
+    return false;
+  }
+
 protected:
   /*!
    * @brief Remove deleted group members from this group. Delete stale channels.

--- a/xbmc/pvr/channels/PVRChannelGroupFromUser.h
+++ b/xbmc/pvr/channels/PVRChannelGroupFromUser.h
@@ -63,6 +63,18 @@ public:
   bool IsChannelsOwner() const override { return false; }
 
   /*!
+   * @brief Check whether this group should be ignored, e.g. not presented to the user and API.
+   * @param allChannelGroups All available channel groups.
+   * @return True if to be ignored, false otherwise.
+   */
+  bool ShouldBeIgnored(
+      const std::vector<std::shared_ptr<CPVRChannelGroup>>& allChannelGroups) const override
+  {
+    // User-created groups shall always be present.
+    return false;
+  }
+
+  /*!
    * @brief Update data with channel group members from the given clients, sync with local data.
    * @param clients The clients to fetch data from. Leave empty to fetch data from all created clients.
    * @return True on success, false otherwise.

--- a/xbmc/pvr/channels/PVRChannelGroups.h
+++ b/xbmc/pvr/channels/PVRChannelGroups.h
@@ -244,6 +244,16 @@ private:
 
   int GetGroupClientPriority(const std::shared_ptr<const CPVRChannelGroup>& group) const;
 
+  enum class Exclude
+  {
+    NONE,
+    IGNORED,
+  };
+  std::shared_ptr<CPVRChannelGroup> GetGroupByName(const std::string& name,
+                                                   int clientID,
+                                                   Exclude exclude) const;
+  std::shared_ptr<CPVRChannelGroup> GetGroupById(int groupId, Exclude exclude) const;
+
   bool m_bRadio{false};
   std::vector<std::shared_ptr<CPVRChannelGroup>> m_groups;
   mutable CCriticalSection m_critSection;


### PR DESCRIPTION
The problem fixed here is a bit hard to explain, but I will try. Whenever we encounter an empty channel group after updating from clients, due to some temporary error (on client side), we remove the group from `CPVRChannelGroups::m_groups` to "hide" it from the user (to avoid confusion). To decrease number of database look ups we never reload this group once the problem (on client side) was fixed, which leads to the now non-empty group being treated as new and a second database entry will we written instead of updating the existing one.

This PR changes that in above mentioned temporary error condition the group will no longer be removed from memory, but marked as "to be ignored" as long as the error persists (on client side).

For this, some lookup methods of `CPVRChannelGroups` needed to be adjusted and a mechanism for groups to report that they should be ignored was introduced.

Second commit just fixes some typos in `CPVRChannel`'s doxy I spotted while working on this fix.

Runtime-tested on Android and macOS, latest Kodi master.

@phunkyfish I hope my explanation was somehow clear so that you are able to review the code change.